### PR TITLE
ezImage 64bit data support

### DIFF
--- a/Code/Engine/Core/Graphics/Implementation/Geometry.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Geometry.cpp
@@ -439,7 +439,7 @@ void ezGeometry::AddTesselatedRectXY(const ezVec2& size, const ezColor& color, e
   const ezVec2 halfSize = size * 0.5f;
   bool bFlipWinding = mTransform.GetRotationalPart().GetDeterminant() < 0;
 
-  const ezVec2 sizeFraction = size.CompDiv(ezVec2(uiTesselationX, uiTesselationY));
+  const ezVec2 sizeFraction = size.CompDiv(ezVec2(static_cast<float>(uiTesselationX), static_cast<float>(uiTesselationY)));
 
   for (ezUInt32 vy = 0; vy < uiTesselationY + 1; ++vy)
   {

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceTypeLoader.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceTypeLoader.cpp
@@ -5,6 +5,7 @@
 #include <Core/ResourceManager/ResourceTypeLoader.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/OSFile.h>
+#include <Foundation/Profiling/Profiling.h>
 
 struct FileResourceLoadData
 {

--- a/Code/Engine/Foundation/Basics/Platform/Win/Platform_win.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/Platform_win.h
@@ -134,17 +134,11 @@
 // conditional expression is constant
 #  pragma warning(disable : 4127)
 
-// conversion from 'int 32' to 'int 16', possible loss of data
-#  pragma warning(disable : 4244)
-
 // signed/unsigned mismatch
 #  pragma warning(disable : 4245)
 
 // signed/unsigned mismatch
 #  pragma warning(disable : 4389)
-
-// declaration of 'X' hides previous local declaration
-#  pragma warning(disable : 4456)
 
 // cast truncates constant value
 #  pragma warning(disable : 4310)

--- a/Code/Engine/Foundation/Configuration/Implementation/CVar.cpp
+++ b/Code/Engine/Foundation/Configuration/Implementation/CVar.cpp
@@ -399,7 +399,7 @@ void ezCVar::LoadCVarsFromFile(bool bOnlyNewOnes, bool bSetAsCurrentValue)
                 {
                   ezCVarFloat* pTyped = (ezCVarFloat*)pCVar;
                   pTyped->m_Values[ezCVarValue::Stored] = static_cast<float>(Value);
-                  *pTyped = Value;
+                  *pTyped = static_cast<float>(Value);
                 }
               }
               break;
@@ -474,7 +474,7 @@ void ezCVar::LoadCVarsFromCommandLine(bool bOnlyNewOnes /*= true*/, bool bSetAsC
           Value = ezCommandLineUtils::GetGlobalInstance()->GetFloatOption(sTemp, Value);
 
           pTyped->m_Values[ezCVarValue::Stored] = static_cast<float>(Value);
-          *pTyped = Value;
+          *pTyped = static_cast<float>(Value);
         }
         break;
         case ezCVarType::String:

--- a/Code/Engine/Foundation/Containers/Blob.h
+++ b/Code/Engine/Foundation/Containers/Blob.h
@@ -1,0 +1,340 @@
+
+#pragma once
+
+#include <Foundation/Types/ArrayPtr.h>
+
+/// \brief This class encapsulates a blob's storage and it's size. It is recommended to use this class instead of plain C arrays.
+///
+/// No data is deallocated at destruction, the ezBlobPtr only allows for easier access.
+template <typename T>
+class ezBlobPtr
+{
+public:
+  EZ_DECLARE_POD_TYPE();
+
+  typedef T ElementType;
+  typedef typename ezTypeTraits<T>::NonConstType MutableElementType;
+
+public:
+  typedef typename ezArrayPtrDetail::ByteTypeHelper<T>::type ByteType;
+  typedef typename ezArrayPtrDetail::VoidTypeHelper<T>::valueType ValueType;
+  typedef typename ezArrayPtrDetail::VoidTypeHelper<T>::pointerType PointerType;
+
+  /// \brief Initializes the ezBlobPtr to be empty.
+  EZ_ALWAYS_INLINE ezBlobPtr() // [tested]
+    : m_ptr(nullptr)
+    , m_uiCount(0u)
+  {
+  }
+
+  /// \brief Initializes the ezBlobPtr with the given pointer and number of elements. No memory is allocated or copied.
+  /// \note For ezBlobPtr<void> and ezBlobPtr<const void>, this constructor is only available if ptr is of
+  ///    type void*, const void*, or any T* with sizeof(T) == 1
+  template <typename U, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value ||
+                                                    sizeof(typename ezArrayPtrDetail::VoidTypeHelper<U>::valueType) == 1>>
+  inline ezBlobPtr(U* ptr, ezUInt64 uiCount) // [tested]
+    : m_ptr(ptr)
+    , m_uiCount(uiCount)
+  {
+    // If any of the arguments is invalid, we invalidate ourself.
+    if (m_ptr == nullptr || m_uiCount == 0)
+    {
+      m_ptr = nullptr;
+      m_uiCount = 0;
+    }
+  }
+
+  /// \brief Initializes the ezBlobPtr to encapsulate the given array.
+  template <size_t N>
+  EZ_ALWAYS_INLINE ezBlobPtr(ValueType (&staticArray)[N]) // [tested]
+    : m_ptr(staticArray)
+    , m_uiCount(static_cast<ezUInt64>(N))
+  {
+  }
+
+  /// \brief Initializes the ezBlobPtr to be a copy of \a other. No memory is allocated or copied.
+  EZ_ALWAYS_INLINE ezBlobPtr(const ezBlobPtr<T>& other) // [tested]
+    : m_ptr(other.m_ptr)
+    , m_uiCount(other.m_uiCount)
+  {
+  }
+
+  /// \brief Convert to const version.
+  operator ezBlobPtr<const T>() const { return ezBlobPtr<const T>(static_cast<const T*>(GetPtr()), GetCount()); } // [tested]
+
+  /// \brief Copies the pointer and size of /a other. Does not allocate any data.
+  EZ_ALWAYS_INLINE void operator=(const ezBlobPtr<T>& other) // [tested]
+  {
+    m_ptr = other.m_ptr;
+    m_uiCount = other.m_uiCount;
+  }
+
+  /// \brief Clears the array
+  EZ_ALWAYS_INLINE void Clear()
+  {
+    m_ptr = nullptr;
+    m_uiCount = 0;
+  }
+
+  EZ_ALWAYS_INLINE void operator=(std::nullptr_t) // [tested]
+  {
+    m_ptr = nullptr;
+    m_uiCount = 0;
+  }
+
+  /// \brief Returns the pointer to the array.
+  EZ_ALWAYS_INLINE const PointerType GetPtr() const // [tested]
+  {
+    return m_ptr;
+  }
+
+  /// \brief Returns the pointer to the array.
+  EZ_ALWAYS_INLINE PointerType GetPtr() // [tested]
+  {
+    return m_ptr;
+  }
+
+  /// \brief Returns the pointer behind the last element of the array
+  EZ_ALWAYS_INLINE PointerType GetEndPtr() { return m_ptr + m_uiCount; }
+
+  /// \brief Returns the pointer behind the last element of the array
+  EZ_ALWAYS_INLINE const PointerType GetEndPtr() const { return m_ptr + m_uiCount; }
+
+  /// \brief Returns whether the array is empty.
+  EZ_ALWAYS_INLINE bool IsEmpty() const // [tested]
+  {
+    return GetCount() == 0;
+  }
+
+  /// \brief Returns the number of elements in the array.
+  EZ_ALWAYS_INLINE ezUInt64 GetCount() const // [tested]
+  {
+    return m_uiCount;
+  }
+
+  /// \brief Creates a sub-array from this array.
+  EZ_FORCE_INLINE ezBlobPtr<const T> GetSubArray(ezUInt64 uiStart, ezUInt64 uiCount) const // [tested]
+  {
+    EZ_ASSERT_DEV(uiStart + uiCount <= GetCount(), "uiStart+uiCount ({0}) has to be smaller or equal than the count ({1}).",
+      uiStart + uiCount, GetCount());
+    return ezBlobPtr<const T>(GetPtr() + uiStart, uiCount);
+  }
+
+  /// \brief Creates a sub-array from this array.
+  EZ_FORCE_INLINE ezBlobPtr<T> GetSubArray(ezUInt64 uiStart, ezUInt64 uiCount) // [tested]
+  {
+    EZ_ASSERT_DEV(uiStart + uiCount <= GetCount(), "uiStart+uiCount ({0}) has to be smaller or equal than the count ({1}).",
+      uiStart + uiCount, GetCount());
+    return ezBlobPtr<T>(GetPtr() + uiStart, uiCount);
+  }
+
+  /// \brief Creates a sub-array from this array.
+  /// \note \code ap.GetSubArray(i) \endcode is equivalent to \code ap.GetSubArray(i, ap.GetCount() - i) \endcode.
+  EZ_FORCE_INLINE ezBlobPtr<const T> GetSubArray(ezUInt64 uiStart) const // [tested]
+  {
+    EZ_ASSERT_DEV(uiStart <= GetCount(), "uiStart ({0}) has to be smaller or equal than the count ({1}).", uiStart, GetCount());
+    return ezBlobPtr<const T>(GetPtr() + uiStart, GetCount() - uiStart);
+  }
+
+  /// \brief Creates a sub-array from this array.
+  /// \note \code ap.GetSubArray(i) \endcode is equivalent to \code ap.GetSubArray(i, ap.GetCount() - i) \endcode.
+  EZ_FORCE_INLINE ezBlobPtr<T> GetSubArray(ezUInt64 uiStart) // [tested]
+  {
+    EZ_ASSERT_DEV(uiStart <= GetCount(), "uiStart ({0}) has to be smaller or equal than the count ({1}).", uiStart, GetCount());
+    return ezBlobPtr<T>(GetPtr() + uiStart, GetCount() - uiStart);
+  }
+
+  /// \brief Reinterprets this array as a byte array.
+  EZ_ALWAYS_INLINE ezBlobPtr<const ByteType> ToByteArray() const
+  {
+    return ezBlobPtr<const ByteType>(reinterpret_cast<const ByteType*>(GetPtr()), GetCount() * sizeof(T));
+  }
+
+  /// \brief Reinterprets this array as a byte array.
+  EZ_ALWAYS_INLINE ezBlobPtr<ByteType> ToByteArray()
+  {
+    return ezBlobPtr<ByteType>(reinterpret_cast<ByteType*>(GetPtr()), GetCount() * sizeof(T));
+  }
+
+  /// \brief Cast an ArrayPtr to an ArrayPtr to a different, but same size, type
+  template <typename U>
+  EZ_ALWAYS_INLINE ezBlobPtr<U> Cast()
+  {
+    static_assert(sizeof(ezArrayPtrDetail::VoidTypeHelper<T>::valueType) == sizeof(ezArrayPtrDetail::VoidTypeHelper<U>::valueType),
+      "Can only cast with equivalent element size.");
+    return ezBlobPtr<U>(reinterpret_cast<U*>(GetPtr()), GetCount());
+  }
+
+  /// \brief Cast an ArrayPtr to an ArrayPtr to a different, but same size, type
+  template <typename U>
+  EZ_ALWAYS_INLINE ezBlobPtr<const U> Cast() const
+  {
+    static_assert(sizeof(ezArrayPtrDetail::VoidTypeHelper<T>::valueType) == sizeof(ezArrayPtrDetail::VoidTypeHelper<U>::valueType),
+      "Can only cast with equivalent element size.");
+    return ezBlobPtr<const U>(reinterpret_cast<const U*>(GetPtr()), GetCount());
+  }
+
+  /// \brief Index access.
+  EZ_FORCE_INLINE const ValueType& operator[](ezUInt64 uiIndex) const // [tested]
+  {
+    EZ_ASSERT_DEV(uiIndex < GetCount(), "Cannot access element {0}, the array only holds {1} elements.", uiIndex, GetCount());
+    return *static_cast<const ValueType*>(GetPtr() + uiIndex);
+  }
+
+  /// \brief Index access.
+  EZ_FORCE_INLINE ValueType& operator[](ezUInt64 uiIndex) // [tested]
+  {
+    EZ_ASSERT_DEV(uiIndex < GetCount(), "Cannot access element {0}, the array only holds {1} elements.", uiIndex, GetCount());
+    return *static_cast<ValueType*>(GetPtr() + uiIndex);
+  }
+
+  /// \brief Compares the two arrays for equality.
+  inline bool operator==(const ezBlobPtr<const T>& other) const // [tested]
+  {
+    if (GetCount() != other.GetCount())
+      return false;
+
+    if (GetPtr() == other.GetPtr())
+      return true;
+
+    return ezMemoryUtils::IsEqual(static_cast<const ValueType*>(GetPtr()), static_cast<const ValueType*>(other.GetPtr()), GetCount());
+  }
+
+  /// \brief Compares the two arrays for inequality.
+  EZ_ALWAYS_INLINE bool operator!=(const ezBlobPtr<const T>& other) const // [tested]
+  {
+    return !(*this == other);
+  }
+
+  /// \brief Copies the data from \a other into this array. The arrays must have the exact same size.
+  inline void CopyFrom(const ezBlobPtr<const T>& other) // [tested]
+  {
+    EZ_ASSERT_DEV(GetCount() == other.GetCount(), "Count for copy does not match. Target has {0} elements, source {1} elements", GetCount(),
+      other.GetCount());
+
+    ezMemoryUtils::Copy(static_cast<ValueType*>(GetPtr()), static_cast<const ValueType*>(other.GetPtr()), GetCount());
+  }
+
+  EZ_ALWAYS_INLINE void Swap(ezBlobPtr<T>& other)
+  {
+    ezMath::Swap(m_ptr, other.m_ptr);
+    ezMath::Swap(m_uiCount, other.m_uiCount);
+  }
+
+  typedef const T* const_iterator;
+  typedef const_reverse_pointer_iterator<T> const_reverse_iterator;
+  typedef T* iterator;
+  typedef reverse_pointer_iterator<T> reverse_iterator;
+
+private:
+  PointerType m_ptr;
+  ezUInt64 m_uiCount;
+};
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::iterator begin(ezBlobPtr<T>& container)
+{
+  return container.GetPtr();
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_iterator begin(const ezBlobPtr<T>& container)
+{
+  return container.GetPtr();
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_iterator cbegin(const ezBlobPtr<T>& container)
+{
+  return container.GetPtr();
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::reverse_iterator rbegin(ezBlobPtr<T>& container)
+{
+  return typename ezBlobPtr<T>::reverse_iterator(container.GetPtr() + container.GetCount() - 1);
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_reverse_iterator rbegin(const ezBlobPtr<T>& container)
+{
+  return typename ezBlobPtr<T>::const_reverse_iterator(container.GetPtr() + container.GetCount() - 1);
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_reverse_iterator crbegin(const ezBlobPtr<T>& container)
+{
+  return typename ezBlobPtr<T>::const_reverse_iterator(container.GetPtr() + container.GetCount() - 1);
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::iterator end(ezBlobPtr<T>& container)
+{
+  return container.GetPtr() + container.GetCount();
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_iterator end(const ezBlobPtr<T>& container)
+{
+  return container.GetPtr() + container.GetCount();
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_iterator cend(const ezBlobPtr<T>& container)
+{
+  return container.GetPtr() + container.GetCount();
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::reverse_iterator rend(ezBlobPtr<T>& container)
+{
+  return typename ezBlobPtr<T>::reverse_iterator(container.GetPtr() - 1);
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_reverse_iterator rend(const ezBlobPtr<T>& container)
+{
+  return typename ezBlobPtr<T>::const_reverse_iterator(container.GetPtr() - 1);
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_same<std::remove_cv_t<T>, void>::value>>
+typename ezBlobPtr<T>::const_reverse_iterator crend(const ezBlobPtr<T>& container)
+{
+  return typename ezBlobPtr<T>::const_reverse_iterator(container.GetPtr() - 1);
+}
+
+
+class EZ_FOUNDATION_DLL ezBlob
+{
+public:
+
+  EZ_DECLARE_MEM_RELOCATABLE_TYPE();
+
+  ezBlob();
+  ezBlob(ezBlob&& other);
+  void operator=(ezBlob&& rhs);
+  ~ezBlob();
+
+  void CopyFrom(void* pSource, ezUInt64 uiSize);
+  void Clear();
+  void SetCountUninitialized(ezUInt64 uiCount);
+
+  /// \brief Returns a blob pointer to the blob data, or an empty blob pointer if the blob is empty.
+  template<typename T>
+  ezBlobPtr<T> GetBlobPtr()
+  {
+    return ezBlobPtr<T>(static_cast<T*>(m_pStorage), m_uiSize);
+  }
+
+  /// \brief Returns a blob pointer to the blob data, or an empty blob pointer if the blob is empty.
+  template<typename T>
+  ezBlobPtr<const T> GetBlobPtr() const
+  {
+    return ezBlobPtr<const T>(static_cast<T*>(m_pStorage), m_uiSize);
+  }
+
+private:
+
+  void* m_pStorage = nullptr;
+  ezUInt64 m_uiSize = 0;
+};

--- a/Code/Engine/Foundation/Containers/Implementation/Blob.cpp
+++ b/Code/Engine/Foundation/Containers/Implementation/Blob.cpp
@@ -1,0 +1,58 @@
+
+#include <FoundationPCH.h>
+#include <Foundation/Containers/Blob.h>
+#include <Foundation/Memory/Allocator.h>
+
+ezBlob::ezBlob() = default;
+
+ezBlob::ezBlob(ezBlob&& other)
+{
+  m_pStorage = other.m_pStorage;
+  m_uiSize = other.m_uiSize;
+
+  other.m_pStorage = nullptr;
+  other.m_uiSize = 0;
+}
+
+void ezBlob::operator=(ezBlob&& rhs)
+{
+  Clear();
+
+  m_pStorage = rhs.m_pStorage;
+  m_uiSize = rhs.m_uiSize;
+
+  rhs.m_pStorage = nullptr;
+  rhs.m_uiSize = 0;
+}
+
+ezBlob::~ezBlob()
+{
+  Clear();
+}
+
+void ezBlob::CopyFrom(void* pSource, ezUInt64 uiSize)
+{
+  SetCountUninitialized(uiSize);
+  ezMemoryUtils::Copy(static_cast<ezUInt8*>(m_pStorage), static_cast<ezUInt8*>(pSource), uiSize);
+}
+
+void ezBlob::Clear()
+{
+  if(m_pStorage)
+  {
+    ezFoundation::GetAlignedAllocator()->Deallocate(m_pStorage);
+    m_pStorage = nullptr;
+    m_uiSize = 0;
+  }
+}
+
+void ezBlob::SetCountUninitialized(ezUInt64 uiCount)
+{
+  if(m_uiSize != uiCount)
+  {
+    Clear();
+
+    m_pStorage = ezFoundation::GetAlignedAllocator()->Allocate(uiCount, 64);
+    m_uiSize = uiCount;
+  }
+}

--- a/Code/Engine/Foundation/Containers/Implementation/Blob.cpp
+++ b/Code/Engine/Foundation/Containers/Implementation/Blob.cpp
@@ -30,7 +30,7 @@ ezBlob::~ezBlob()
   Clear();
 }
 
-void ezBlob::CopyFrom(void* pSource, ezUInt64 uiSize)
+void ezBlob::SetFrom(void* pSource, ezUInt64 uiSize)
 {
   SetCountUninitialized(uiSize);
   ezMemoryUtils::Copy(static_cast<ezUInt8*>(m_pStorage), static_cast<ezUInt8*>(pSource), uiSize);
@@ -54,5 +54,13 @@ void ezBlob::SetCountUninitialized(ezUInt64 uiCount)
 
     m_pStorage = ezFoundation::GetAlignedAllocator()->Allocate(uiCount, 64);
     m_uiSize = uiCount;
+  }
+}
+
+void ezBlob::ZeroFill()
+{
+  if(m_pStorage)
+  {
+    ezMemoryUtils::ZeroFill(static_cast<ezUInt8*>(m_pStorage), static_cast<size_t>(m_uiSize));
   }
 }

--- a/Code/Engine/Foundation/IO/Implementation/DeduplicationReadContext_inl.h
+++ b/Code/Engine/Foundation/IO/Implementation/DeduplicationReadContext_inl.h
@@ -95,7 +95,7 @@ ezResult ezDeduplicationReadContext::ReadArray(
 
   if (uiCount > 0)
   {
-    static_cast<ArrayType&>(Array).Reserve(uiCount);
+    static_cast<ArrayType&>(Array).Reserve(static_cast<ezUInt32>(uiCount));
 
     for (ezUInt32 i = 0; i < static_cast<ezUInt32>(uiCount); ++i)
     {

--- a/Code/Engine/Foundation/IO/Implementation/Stream_inl.h
+++ b/Code/Engine/Foundation/IO/Implementation/Stream_inl.h
@@ -299,7 +299,7 @@ ezResult ezStreamReader::ReadArray(ezArrayBase<ValueType, ArrayType>& Array)
 
   if (uiCount > 0)
   {
-    static_cast<ArrayType&>(Array).Reserve(uiCount);
+    static_cast<ArrayType&>(Array).Reserve(static_cast<ezUInt32>(uiCount));
 
     for (ezUInt32 i = 0; i < static_cast<ezUInt32>(uiCount); ++i)
     {

--- a/Code/Engine/GameEngine/DearImgui/DearImgui.cpp
+++ b/Code/Engine/GameEngine/DearImgui/DearImgui.cpp
@@ -174,7 +174,7 @@ void ezImgui::BeginFrame(const ezViewHandle& hView)
   }
 
   auto viewport = pView->GetViewport();
-  m_CurrentWindowResolution = ezSizeU32(viewport.width, viewport.height);
+  m_CurrentWindowResolution = ezSizeU32(static_cast<ezUInt32>(viewport.width), static_cast<ezUInt32>(viewport.height));
 
   ImGuiIO& cfg = ImGui::GetIO();
 

--- a/Code/Engine/ModelImporter/Importers/AssimpImporter.cpp
+++ b/Code/Engine/ModelImporter/Importers/AssimpImporter.cpp
@@ -591,9 +591,9 @@ namespace ezModelImporter
         {
           // Only fbx files have this unit scale factor and the default unit for fbx is cm. We want meters.
           fUnitScale = fUnitScale / 100.0f;
-          node->mTransformation.a1 *= fUnitScale;
-          node->mTransformation.b2 *= fUnitScale;
-          node->mTransformation.c3 *= fUnitScale;
+          node->mTransformation.a1 *= static_cast<float>(fUnitScale);
+          node->mTransformation.b2 *= static_cast<float>(fUnitScale);
+          node->mTransformation.c3 *= static_cast<float>(fUnitScale);
         }
       }
     }

--- a/Code/Engine/RendererCore/Components/Implementation/CameraComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/CameraComponent.cpp
@@ -491,7 +491,7 @@ float ezCameraComponent::GetEV100() const
   // EV_100 + log2 (S /100) = log2 (N^2 / t)
   // EV_100 = log2 (N^2 / t) - log2 (S /100)
   // EV_100 = log2 (N^2 / t . 100 / S)
-  return ezMath::Log2((m_fAperture * m_fAperture) / m_ShutterTime.GetSeconds() * 100.0f / m_fISO) - m_fExposureCompensation;
+  return ezMath::Log2((m_fAperture * m_fAperture) / m_ShutterTime.AsFloatInSeconds() * 100.0f / m_fISO) - m_fExposureCompensation;
 }
 
 float ezCameraComponent::GetExposure() const

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -1072,8 +1072,8 @@ void ezDebugRenderer::OnEngineStartup()
 
     ezGALSystemMemoryDescription memoryDesc;
     memoryDesc.m_pData = debugFontImage.GetPixelPointer<ezUInt8>();
-    memoryDesc.m_uiRowPitch = debugFontImage.GetRowPitch();
-    memoryDesc.m_uiSlicePitch = debugFontImage.GetDepthPitch();
+    memoryDesc.m_uiRowPitch = static_cast<ezUInt32>(debugFontImage.GetRowPitch());
+    memoryDesc.m_uiSlicePitch = static_cast<ezUInt32>(debugFontImage.GetDepthPitch());
 
     ezTexture2DResourceDescriptor desc;
     desc.m_DescGAL.m_uiWidth = debugFontImage.GetWidth();

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -6,12 +6,14 @@
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/Math/Color16f.h>
 #include <Foundation/Profiling/Profiling.h>
+#include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/GPUResourcePool/GPUResourcePool.h>
 #include <RendererCore/Lights/Implementation/ReflectionPool.h>
 #include <RendererCore/Lights/Implementation/ReflectionProbeData.h>
 #include <RendererCore/Meshes/MeshComponentBase.h>
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererFoundation/Context/Context.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Texture.h>
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -215,7 +215,7 @@ namespace
         renderView.m_hView = ezRenderWorld::CreateView(sName, pView);
 
         pView->SetCameraUsageHint(ezCameraUsageHint::Reflection);
-        pView->SetViewport(ezRectFloat(0.0f, 0.0f, s_uiReflectionCubeMapSize, s_uiReflectionCubeMapSize));
+        pView->SetViewport(ezRectFloat(0.0f, 0.0f, static_cast<float>(s_uiReflectionCubeMapSize), static_cast<float>(s_uiReflectionCubeMapSize)));
 
         pView->SetRenderPipelineResource(ezResourceManager::LoadResource<ezRenderPipelineResource>(szRenderPipelineResource));
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.h
@@ -6,6 +6,8 @@
 class ezGALTextureHandle;
 class ezGALBufferHandle;
 class ezView;
+class ezWorld;
+class ezComponent;
 struct ezMsgExtractRenderData;
 struct ezReflectionProbeData;
 

--- a/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
@@ -34,7 +34,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSkyLightComponent, 1, ezComponentMode::Dynamic)
 EZ_END_COMPONENT_TYPE
 // clang-format on
 
-static ezUInt32 s_uiSkyLightPriority = 10;
+static float s_fSkyLightPriority = 10.0f;
 
 ezSkyLightComponent::ezSkyLightComponent()
 {
@@ -44,7 +44,7 @@ ezSkyLightComponent::~ezSkyLightComponent() = default;
 
 void ezSkyLightComponent::OnActivated()
 {
-  ezReflectionPool::RegisterReflectionProbe(m_ReflectionProbeData, GetWorld(), s_uiSkyLightPriority);
+  ezReflectionPool::RegisterReflectionProbe(m_ReflectionProbeData, GetWorld(), s_fSkyLightPriority);
 
   GetOwner()->UpdateLocalBounds();
 }
@@ -91,7 +91,7 @@ void ezSkyLightComponent::OnExtractRenderData(ezMsgExtractRenderData& msg) const
   if (m_ReflectionProbeData.m_fIntensity <= 0.0f)
     return;
 
-  ezReflectionPool::ExtractReflectionProbe(msg, m_ReflectionProbeData, this, s_uiSkyLightPriority);
+  ezReflectionPool::ExtractReflectionProbe(msg, m_ReflectionProbeData, this, s_fSkyLightPriority);
 }
 
 void ezSkyLightComponent::SerializeComponent(ezWorldWriter& stream) const

--- a/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
@@ -6,6 +6,8 @@
 #include <RendererCore/Lights/Implementation/ReflectionPool.h>
 #include <RendererCore/Lights/SkyLightComponent.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererCore/Pipeline/RenderData.h>
+#include <RendererCore/Pipeline/View.h>
 
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ezSkyLightComponent, 1, ezComponentMode::Dynamic)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
@@ -5,6 +5,7 @@
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererFoundation/Profiling/Profiling.h>
+#include <RendererFoundation/Resources/Texture.h>
 
 #include <RendererCore/../../../Data/Base/Shaders/Pipeline/ReflectionIrradianceConstants.h>
 

--- a/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
@@ -113,10 +113,11 @@ void ezTexture2DResource::FillOutDescriptor(ezTexture2DResourceDescriptor& td, c
         }
         else
         {
-          id.m_uiRowPitch = pImage->GetRowPitch(mip);
+          id.m_uiRowPitch = static_cast<ezUInt32>(pImage->GetRowPitch(mip));
         }
 
-        id.m_uiSlicePitch = pImage->GetDepthPitch(mip);
+        EZ_ASSERT_DEV(pImage->GetDepthPitch(mip) < ezMath::BasicType<ezUInt32>::MaxValue(), "Depth pitch exceeds ezGAL limits.");
+        id.m_uiSlicePitch = static_cast<ezUInt32>(pImage->GetDepthPitch(mip));
 
         out_MemoryUsed += id.m_uiSlicePitch;
       }

--- a/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
@@ -137,6 +137,8 @@ ezResourceLoadDesc ezTextureCubeResource::UpdateContent(ezStreamReader* Stream)
 
         id.m_pData = pImage->GetPixelPointer<ezUInt8>(mip, face, array_index);
 
+        EZ_ASSERT_DEV(pImage->GetDepthPitch(mip) < ezMath::BasicType<ezUInt32>::MaxValue(), "Depth pitch exceeds ezGAL limits.");
+
         if (ezImageFormat::GetType(pImage->GetImageFormat()) == ezImageFormatType::BLOCK_COMPRESSED)
         {
           const ezUInt32 uiMemPitchFactor = ezGALResourceFormat::GetBitsPerElement(m_Format) * 4 / 8;
@@ -145,10 +147,10 @@ ezResourceLoadDesc ezTextureCubeResource::UpdateContent(ezStreamReader* Stream)
         }
         else
         {
-          id.m_uiRowPitch = pImage->GetRowPitch(mip);
+          id.m_uiRowPitch = static_cast<ezUInt32>(pImage->GetRowPitch(mip));
         }
 
-        id.m_uiSlicePitch = pImage->GetDepthPitch(mip);
+        id.m_uiSlicePitch = static_cast<ezUInt32>(pImage->GetDepthPitch(mip));
 
         m_uiMemoryGPU[m_uiLoadedTextures] += id.m_uiSlicePitch;
       }

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11_inl.h
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11_inl.h
@@ -1,4 +1,4 @@
-﻿
+
 EZ_ALWAYS_INLINE ID3D11Device* ezGALDeviceDX11::GetDXDevice() const
 {
   return m_pDevice;
@@ -18,7 +18,7 @@ inline ID3D11Query* ezGALDeviceDX11::GetTimestamp(ezGALTimestampHandle hTimestam
 {
   if (hTimestamp.m_uiIndex < m_Timestamps.GetCount())
   {
-    return m_Timestamps[hTimestamp.m_uiIndex];
+    return m_Timestamps[static_cast<ezUInt32>(hTimestamp.m_uiIndex)];
   }
 
   return nullptr;

--- a/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
@@ -2000,7 +2000,7 @@ class ezImageConversion_CompressBC4 : public ezImageConversionStepCompressBlocks
                                   ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 stride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
-    ezUInt32 rowPitch = ezImageFormat::GetRowPitch(sourceFormat, 4 * numBlocksX);
+    ezUInt64 rowPitch = ezImageFormat::GetRowPitch(sourceFormat, 4 * numBlocksX);
 
     // Bias to shift signed data into unsigned range so we can treat it the same as unsigned
     ezUInt8 bias = 0;
@@ -2057,7 +2057,7 @@ class ezImageConversion_CompressBC5 : public ezImageConversionStepCompressBlocks
                                   ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 stride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
-    ezUInt32 rowPitch = ezImageFormat::GetRowPitch(sourceFormat, 4 * numBlocksX);
+    ezUInt64 rowPitch = ezImageFormat::GetRowPitch(sourceFormat, 4 * numBlocksX);
 
     // Bias to shift signed data into unsigned range so we can treat it the same as unsigned
     ezUInt8 bias = 0;

--- a/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
@@ -1701,7 +1701,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 elementsPerBlock = 16;
@@ -1736,7 +1736,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 elementsPerBlock = 16;
@@ -1784,7 +1784,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 elementsPerBlock = 16;
@@ -1825,7 +1825,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 elementsPerBlock = 16;
@@ -1872,7 +1872,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 elementsPerBlock = 16;
@@ -1921,7 +1921,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 targetFormatByteSize = ezImageFormat::GetBitsPerPixel(targetFormat) / 8;
@@ -1959,7 +1959,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 sourceStride = s_bc67NumPixelsPerBlock * ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -1996,7 +1996,7 @@ class ezImageConversion_CompressBC4 : public ezImageConversionStepCompressBlocks
     return supportedConversions;
   }
 
-  virtual ezResult CompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
+  virtual ezResult CompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
                                   ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 stride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -2053,7 +2053,7 @@ class ezImageConversion_CompressBC5 : public ezImageConversionStepCompressBlocks
     return supportedConversions;
   }
 
-  virtual ezResult CompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
+  virtual ezResult CompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
                                   ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 stride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;

--- a/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
@@ -183,7 +183,7 @@ class ezImageConversion_CompressDxTex : public ezImageConversionStepCompressBloc
     return supportedConversions;
   }
 
-  virtual ezResult CompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
+  virtual ezResult CompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     const ezUInt32 targetWidth = numBlocksX * ezImageFormat::GetBlockWidth(targetFormat);
@@ -242,7 +242,7 @@ class ezImageConversion_CompressDxTex : public ezImageConversionStepCompressBloc
     if (!bCompressionDone)
       return EZ_FAILURE;
 
-    target.CopyFrom(ezArrayPtr<const void>(dxDstImage.GetPixels(), static_cast<ezUInt32>(dxDstImage.GetPixelsSize())));
+    target.CopyFrom(ezBlobPtr<const void>(dxDstImage.GetPixels(), static_cast<ezUInt32>(dxDstImage.GetPixelsSize())));
 
     return EZ_SUCCESS;
   }

--- a/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
@@ -184,7 +184,7 @@ class ezImageConversionStep_Decompress16bpp : ezImageConversionStepLinear
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = 2;
@@ -223,7 +223,7 @@ class ezImageConversionStep_Compress16bpp : ezImageConversionStepLinear
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = 4;
@@ -267,7 +267,7 @@ struct ezImageSwizzleConversion32_2103 : public ezImageConversionStepLinear
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = 4;
@@ -352,7 +352,7 @@ struct ezImageConversion_BGRX_BGRA : public ezImageConversionStepLinear
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = 4;
@@ -417,7 +417,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -510,7 +510,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = 16;
@@ -546,7 +546,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -585,7 +585,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -625,7 +625,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -665,7 +665,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -701,7 +701,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = 4;
@@ -737,7 +737,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -775,7 +775,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -813,7 +813,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     // Work with single channels instead of pixels
@@ -854,7 +854,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -928,7 +928,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -1026,7 +1026,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -1078,7 +1078,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -1215,7 +1215,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
@@ -1358,7 +1358,7 @@ public:
     return supportedConversions;
   }
 
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const override
   {
     ezUInt32 sourceStride = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;

--- a/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
@@ -52,7 +52,7 @@ ezUInt16 ezCompressA4B4G4R4(ezColorBaseUB color)
   ezUInt32 g = (color.g * 15 + 135) >> 8;
   ezUInt32 b = (color.b * 15 + 135) >> 8;
   ezUInt32 a = (color.a * 15 + 135) >> 8;
-  return (r << 12) | (g << 8) | (b << 4) | a;
+  return static_cast<ezUInt16>((r << 12) | (g << 8) | (b << 4) | a);
 }
 
 ezColorBaseUB ezDecompressB4G4R4A4(ezUInt16 uiColor)
@@ -71,15 +71,15 @@ ezUInt16 ezCompressB4G4R4A4(ezColorBaseUB color)
   ezUInt32 g = (color.g * 15 + 135) >> 8;
   ezUInt32 b = (color.b * 15 + 135) >> 8;
   ezUInt32 a = (color.a * 15 + 135) >> 8;
-  return (a << 12) | (r << 8) | (g << 4) | b;
+  return static_cast<ezUInt16>((a << 12) | (r << 8) | (g << 4) | b);
 }
 
 ezColorBaseUB ezDecompressB5G6R5(ezUInt16 uiColor)
 {
   ezColorBaseUB result;
-  result.r = ((uiColor & 0xF800u) * 527 + 47104) >> 17;
-  result.g = ((uiColor & 0x07E0u) * 259 + 1056) >> 11;
-  result.b = ((uiColor & 0x001Fu) * 527 + 23) >> 6;
+  result.r = static_cast<ezUInt8>(((uiColor & 0xF800u) * 527 + 47104) >> 17);
+  result.g = static_cast<ezUInt8>(((uiColor & 0x07E0u) * 259 + 1056) >> 11);
+  result.b = static_cast<ezUInt8>(((uiColor & 0x001Fu) * 527 + 23) >> 6);
   result.a = 0xFF;
 
   return result;
@@ -90,15 +90,15 @@ ezUInt16 ezCompressB5G6R5(ezColorBaseUB color)
   ezUInt32 r = (color.r * 249 + 1024) >> 11;
   ezUInt32 g = (color.g * 253 + 512) >> 10;
   ezUInt32 b = (color.b * 249 + 1024) >> 11;
-  return (r << 11) | (g << 5) | b;
+  return static_cast<ezUInt16>((r << 11) | (g << 5) | b);
 }
 
 ezColorBaseUB ezDecompressB5G5R5X1(ezUInt16 uiColor)
 {
   ezColorBaseUB result;
-  result.r = ((uiColor & 0x7C00u) * 527 + 23552) >> 16;
-  result.g = ((uiColor & 0x03E0u) * 527 + 736) >> 11;
-  result.b = ((uiColor & 0x001Fu) * 527 + 23) >> 6;
+  result.r = static_cast<ezUInt8>(((uiColor & 0x7C00u) * 527 + 23552) >> 16);
+  result.g = static_cast<ezUInt8>(((uiColor & 0x03E0u) * 527 + 736) >> 11);
+  result.b = static_cast<ezUInt8>(((uiColor & 0x001Fu) * 527 + 23) >> 6);
   result.a = 0xFF;
   return result;
 }
@@ -108,16 +108,16 @@ ezUInt16 ezCompressB5G5R5X1(ezColorBaseUB color)
   ezUInt32 r = (color.r * 249 + 1024) >> 11;
   ezUInt32 g = (color.g * 249 + 1024) >> 11;
   ezUInt32 b = (color.b * 249 + 1024) >> 11;
-  return (1 << 15) | (r << 10) | (g << 5) | b;
+  return static_cast<ezUInt16>((1 << 15) | (r << 10) | (g << 5) | b);
 }
 
 ezColorBaseUB ezDecompressB5G5R5A1(ezUInt16 uiColor)
 {
   ezColorBaseUB result;
-  result.r = ((uiColor & 0x7C00u) * 527 + 23552) >> 16;
-  result.g = ((uiColor & 0x03E0u) * 527 + 736) >> 11;
-  result.b = ((uiColor & 0x001Fu) * 527 + 23) >> 6;
-  result.a = ((uiColor & 0x8000u) * 255) >> 15;
+  result.r = static_cast<ezUInt8>(((uiColor & 0x7C00u) * 527 + 23552) >> 16);
+  result.g = static_cast<ezUInt8>(((uiColor & 0x03E0u) * 527 + 736) >> 11);
+  result.b = static_cast<ezUInt8>(((uiColor & 0x001Fu) * 527 + 23) >> 6);
+  result.a = static_cast<ezUInt8>(((uiColor & 0x8000u) * 255) >> 15);
   return result;
 }
 
@@ -127,15 +127,15 @@ ezUInt16 ezCompressB5G5R5A1(ezColorBaseUB color)
   ezUInt32 g = (color.g * 249 + 1024) >> 11;
   ezUInt32 b = (color.b * 249 + 1024) >> 11;
   ezUInt32 a = (color.a) >> 7;
-  return (a << 15) | (r << 10) | (g << 5) | b;
+  return static_cast<ezUInt16>((a << 15) | (r << 10) | (g << 5) | b);
 }
 
 ezColorBaseUB ezDecompressX1B5G5R5(ezUInt16 uiColor)
 {
   ezColorBaseUB result;
-  result.r = ((uiColor & 0xF800u) * 527 + 23552) >> 17;
-  result.g = ((uiColor & 0x07C0u) * 527 + 736) >> 12;
-  result.b = ((uiColor & 0x003Eu) * 527 + 23) >> 7;
+  result.r = static_cast<ezUInt8>(((uiColor & 0xF800u) * 527 + 23552) >> 17);
+  result.g = static_cast<ezUInt8>(((uiColor & 0x07C0u) * 527 + 736) >> 12);
+  result.b = static_cast<ezUInt8>(((uiColor & 0x003Eu) * 527 + 23) >> 7);
   result.a = 0xFF;
   return result;
 }
@@ -145,16 +145,16 @@ ezUInt16 ezCompressX1B5G5R5(ezColorBaseUB color)
   ezUInt32 r = (color.r * 249 + 1024) >> 11;
   ezUInt32 g = (color.g * 249 + 1024) >> 11;
   ezUInt32 b = (color.b * 249 + 1024) >> 11;
-  return (r << 11) | (g << 6) | (b << 1) | 1;
+  return static_cast<ezUInt16>((r << 11) | (g << 6) | (b << 1) | 1);
 }
 
 ezColorBaseUB ezDecompressA1B5G5R5(ezUInt16 uiColor)
 {
   ezColorBaseUB result;
-  result.r = ((uiColor & 0xF800u) * 527 + 23552) >> 17;
-  result.g = ((uiColor & 0x07C0u) * 527 + 736) >> 12;
-  result.b = ((uiColor & 0x003Eu) * 527 + 23) >> 7;
-  result.a = (uiColor & 0x0001u) * 255;
+  result.r = static_cast<ezUInt8>(((uiColor & 0xF800u) * 527 + 23552) >> 17);
+  result.g = static_cast<ezUInt8>(((uiColor & 0x07C0u) * 527 + 736) >> 12);
+  result.b = static_cast<ezUInt8>(((uiColor & 0x003Eu) * 527 + 23) >> 7);
+  result.a = static_cast<ezUInt8>((uiColor & 0x0001u) * 255);
   return result;
 }
 
@@ -164,7 +164,7 @@ ezUInt16 ezCompressA1B5G5R5(ezColorBaseUB color)
   ezUInt32 g = (color.g * 249 + 1024) >> 11;
   ezUInt32 b = (color.b * 249 + 1024) >> 11;
   ezUInt32 a = color.a >> 7;
-  return (r << 11) | (g << 6) | (b << 1) | a;
+  return static_cast<ezUInt16>((r << 11) | (g << 6) | (b << 1) | a);
 }
 
 template <ezColorBaseUB (*decompressFunc)(ezUInt16), ezImageFormat::Enum templateSourceFormat>

--- a/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
@@ -347,7 +347,7 @@ ezResult ezDdsFileFormat::WriteImage(ezStreamWriter& stream, const ezImageView& 
   {
     case ezImageFormatType::LINEAR:
       fileHeader.m_uiFlags |= ezDdsdFlags::PITCH;
-      fileHeader.m_uiPitchOrLinearSize = image.GetRowPitch(0);
+      fileHeader.m_uiPitchOrLinearSize = static_cast<ezUInt32>(image.GetRowPitch(0));
       break;
 
     case ezImageFormatType::BLOCK_COMPRESSED:

--- a/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
@@ -279,9 +279,9 @@ ezResult ezDdsFileFormat::ReadImage(ezStreamReader& stream, ezImage& image, ezLo
     return EZ_FAILURE;
   }
 
-  ezUInt32 uiDataSize = image.GetArrayPtr<void>().GetCount();
+  ezUInt64 uiDataSize = image.GetBlobPtr<void>().GetCount();
 
-  if (stream.ReadBytes(image.GetArrayPtr<void>().GetPtr(), uiDataSize) != uiDataSize)
+  if (stream.ReadBytes(image.GetBlobPtr<void>().GetPtr(), uiDataSize) != uiDataSize)
   {
     ezLog::Error(pLog, "Failed to read image data.");
     return EZ_FAILURE;
@@ -493,7 +493,7 @@ ezResult ezDdsFileFormat::WriteImage(ezStreamWriter& stream, const ezImageView& 
     }
   }
 
-  if (stream.WriteBytes(image.GetArrayPtr<void>().GetPtr(), image.GetArrayPtr<void>().GetCount()) != EZ_SUCCESS)
+  if (stream.WriteBytes(image.GetBlobPtr<void>().GetPtr(), image.GetBlobPtr<void>().GetCount()) != EZ_SUCCESS)
   {
     ezLog::Error(pLog, "Failed to write image data.");
     return EZ_FAILURE;

--- a/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
+++ b/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
@@ -111,16 +111,18 @@ ezResult ezStbImageFileFormats::ReadImage(ezStreamReader& stream, ezImage& image
 
   image.ResetAndAlloc(imageHeader);
 
+  const size_t elementsToCopy = static_cast<size_t>(width) * static_cast<size_t>(height) * static_cast<size_t>(numComp);
+
   // Set pixels. Different strategies depending on component count.
   if (isHDR)
   {
-    float* targetImageData = image.GetArrayPtr<float>().GetPtr();
-    ezMemoryUtils::Copy(targetImageData, (const float*)sourceImageData, width * height * numComp);
+    float* targetImageData = image.GetBlobPtr<float>().GetPtr();
+    ezMemoryUtils::Copy(targetImageData, (const float*)sourceImageData, elementsToCopy);
   }
   else
   {
-    ezUInt8* targetImageData = image.GetArrayPtr<ezUInt8>().GetPtr();
-    ezMemoryUtils::Copy(targetImageData, (const ezUInt8*)sourceImageData, width * height * numComp);
+    ezUInt8* targetImageData = image.GetBlobPtr<ezUInt8>().GetPtr();
+    ezMemoryUtils::Copy(targetImageData, (const ezUInt8*)sourceImageData, elementsToCopy);
   }
 
   stbi_image_free((void*)sourceImageData);
@@ -161,7 +163,7 @@ ezResult ezStbImageFileFormats::WriteImage(
   if (ezStringUtils::IsEqual_NoCase(szFileExtension, "png"))
   {
     if (stbi_write_png_to_func(write_func, &stream, image.GetWidth(), image.GetHeight(),
-          ezImageFormat::GetNumChannels(image.GetImageFormat()), image.GetArrayPtr<void>().GetPtr(), 0))
+          ezImageFormat::GetNumChannels(image.GetImageFormat()), image.GetBlobPtr<void>().GetPtr(), 0))
     {
       return EZ_SUCCESS;
     }
@@ -170,7 +172,7 @@ ezResult ezStbImageFileFormats::WriteImage(
   if (ezStringUtils::IsEqual_NoCase(szFileExtension, "jpg") || ezStringUtils::IsEqual_NoCase(szFileExtension, "jpeg"))
   {
     if (stbi_write_jpg_to_func(write_func, &stream, image.GetWidth(), image.GetHeight(),
-          ezImageFormat::GetNumChannels(image.GetImageFormat()), image.GetArrayPtr<void>().GetPtr(), 95))
+          ezImageFormat::GetNumChannels(image.GetImageFormat()), image.GetBlobPtr<void>().GetPtr(), 95))
     {
       return EZ_SUCCESS;
     }

--- a/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
@@ -109,11 +109,11 @@ ezResult ezTgaFileFormat::WriteImage(ezStreamWriter& stream, const ezImageView& 
       uiHeader[2] = 10;
     }
 
-    uiHeader[13] = image.GetWidth(0) / 256;
-    uiHeader[15] = image.GetHeight(0) / 256;
-    uiHeader[12] = image.GetWidth(0) % 256;
-    uiHeader[14] = image.GetHeight(0) % 256;
-    uiHeader[16] = ezImageFormat::GetBitsPerPixel(image.GetImageFormat());
+    uiHeader[13] = static_cast<ezUInt8>(image.GetWidth(0) / 256);
+    uiHeader[15] = static_cast<ezUInt8>(image.GetHeight(0) / 256);
+    uiHeader[12] = static_cast<ezUInt8>(image.GetWidth(0) % 256);
+    uiHeader[14] = static_cast<ezUInt8>(image.GetHeight(0) % 256);
+    uiHeader[16] = static_cast<ezUInt8>(ezImageFormat::GetBitsPerPixel(image.GetImageFormat()));
 
     stream.WriteBytes(uiHeader, 18);
   }
@@ -184,7 +184,7 @@ ezResult ezTgaFileFormat::WriteImage(ezStreamWriter& stream, const ezImageView& 
             ++iEqual;
           else
           {
-            ezUInt8 uiRepeat = iEqual + 127;
+            ezUInt8 uiRepeat = static_cast<ezUInt8>(iEqual + 127);
 
             stream << uiRepeat;
             stream << pc.b;
@@ -246,7 +246,7 @@ ezResult ezTgaFileFormat::WriteImage(ezStreamWriter& stream, const ezImageView& 
     }
     else if (iRLE == 2) // equal values
     {
-      ezUInt8 uiRepeat = iEqual + 127;
+      ezUInt8 uiRepeat = static_cast<ezUInt8>(iEqual + 127);
 
       stream << uiRepeat;
       stream << pc.b;

--- a/Code/Engine/Texture/Image/Image.h
+++ b/Code/Engine/Texture/Image/Image.h
@@ -2,6 +2,7 @@
 
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Containers/Blob.h>
 #include <Foundation/Logging/Log.h>
 
 #include <Texture/Image/ImageHeader.h>
@@ -14,7 +15,7 @@ public:
   ezImageView();
 
   /// \brief Constructs an image view with the given header and image data.
-  ezImageView(const ezImageHeader& header, ezArrayPtr<const void> imageData);
+  ezImageView(const ezImageHeader& header, ezBlobPtr<const void> imageData);
 
   /// \brief Constructs an empty image view.
   void Clear();
@@ -23,7 +24,7 @@ public:
   bool IsValid() const;
 
   /// \brief Constructs an image view with the given header and image data.
-  void ResetAndViewExternalStorage(const ezImageHeader& header, ezArrayPtr<const void> imageData);
+  void ResetAndViewExternalStorage(const ezImageHeader& header, ezBlobPtr<const void> imageData);
 
   /// \brief Convenience function to save the image to the given file.
   ezResult SaveTo(const char* szFileName, ezLogInterface* pLog = ezLog::GetThreadLocalLogSystem()) const;
@@ -33,7 +34,7 @@ public:
 
   /// \brief Returns a view to the entire data contained in this image.
   template <typename T>
-  ezArrayPtr<const T> GetArrayPtr() const;
+  ezBlobPtr<const T> GetBlobPtr() const;
 
   /// \brief Returns a view to the given sub-image.
   ezImageView GetSubImageView(ezUInt32 uiMipLevel = 0, ezUInt32 uiFace = 0, ezUInt32 uiArrayIndex = 0) const;
@@ -71,16 +72,16 @@ public:
   using ezImageHeader::GetRowPitch;
 
 protected:
-  ezUInt32 ComputeLayout();
+  ezUInt64 ComputeLayout();
 
   void ValidateSubImageIndices(ezUInt32 uiMipLevel, ezUInt32 uiFace, ezUInt32 uiArrayIndex) const;
   template <typename T>
   void ValidateDataTypeAccessor() const;
 
-  const ezUInt32& GetSubImageOffset(ezUInt32 uiMipLevel, ezUInt32 uiFace, ezUInt32 uiArrayIndex) const;
+  const ezUInt64& GetSubImageOffset(ezUInt32 uiMipLevel, ezUInt32 uiFace, ezUInt32 uiArrayIndex) const;
 
-  ezHybridArray<ezUInt32, 16> m_subImageOffsets;
-  ezArrayPtr<ezUInt8> m_dataPtr;
+  ezHybridArray<ezUInt64, 16> m_subImageOffsets;
+  ezBlobPtr<ezUInt8> m_dataPtr;
 };
 
 /// \brief A class containing image data and associated meta data.
@@ -103,7 +104,7 @@ class EZ_TEXTURE_DLL ezImage : public ezImageView
   explicit ezImage(const ezImageHeader& header);
 
   /// \brief Constructs an image with the given header backed by user-supplied external storage.
-  explicit ezImage(const ezImageHeader& header, ezArrayPtr<void> externalData);
+  explicit ezImage(const ezImageHeader& header, ezBlobPtr<void> externalData);
   
   /// \brief Constructor from image view (copies the image data to internal storage)
   explicit ezImage(const ezImageView& other);
@@ -131,7 +132,7 @@ public:
   /// \brief Constructs an image with the given header and attaches to the user-supplied external storage.
   ///
   /// The user is responsible to keep the external storage alive as long as this ezImage is alive.
-  void ResetAndUseExternalStorage(const ezImageHeader& header, ezArrayPtr<void> externalData);
+  void ResetAndUseExternalStorage(const ezImageHeader& header, ezBlobPtr<void> externalData);
 
   /// \brief Moves the given data into this object.
   ///
@@ -152,9 +153,9 @@ public:
 
   /// \brief Returns a view to the entire data contained in this image.
   template <typename T>
-  ezArrayPtr<T> GetArrayPtr();
+  ezBlobPtr<T> GetBlobPtr();
 
-  using ezImageView::GetArrayPtr;
+  using ezImageView::GetBlobPtr;
 
   /// \brief Returns a view to the given sub-image.
   ezImage GetSubImageView(ezUInt32 uiMipLevel = 0, ezUInt32 uiFace = 0, ezUInt32 uiArrayIndex = 0);
@@ -181,7 +182,7 @@ public:
 private:
   bool UsesExternalStorage() const;
 
-  ezDynamicArray<ezUInt8> m_internalStorage;
+  ezBlob m_internalStorage;
 };
 
 #include <Texture/Image/Implementation/Image_inl.h>

--- a/Code/Engine/Texture/Image/ImageConversion.h
+++ b/Code/Engine/Texture/Image/ImageConversion.h
@@ -49,7 +49,7 @@ class EZ_TEXTURE_DLL ezImageConversionStepLinear : public ezImageConversionStep
 {
 public:
   /// \brief Converts a batch of pixels.
-  virtual ezResult ConvertPixels(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  virtual ezResult ConvertPixels(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt64 numElements,
                                  ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const = 0;
 };
 
@@ -58,7 +58,7 @@ class EZ_TEXTURE_DLL ezImageConversionStepDecompressBlocks : public ezImageConve
 {
 public:
   /// \brief Decompresses the given number of blocks.
-  virtual ezResult DecompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocks,
+  virtual ezResult DecompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocks,
                                     ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const = 0;
 };
 
@@ -67,7 +67,7 @@ class EZ_TEXTURE_DLL ezImageConversionStepCompressBlocks : public ezImageConvers
 {
 public:
   /// \brief Compresses the given number of blocks.
-  virtual ezResult CompressBlocks(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
+  virtual ezResult CompressBlocks(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numBlocksX, ezUInt32 numBlocksY,
                                   ezImageFormat::Enum sourceFormat, ezImageFormat::Enum targetFormat) const = 0;
 };
 
@@ -121,11 +121,11 @@ public:
   static ezResult Convert(const ezImageView& source, ezImage& target, ezArrayPtr<ConversionPathNode> path, ezUInt32 numScratchBuffers);
 
   /// \brief Converts the raw source data into a target data buffer with the given format. Source and target may be the same.
-  static ezResult ConvertRaw(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements, ezImageFormat::Enum sourceFormat,
+  static ezResult ConvertRaw(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numElements, ezImageFormat::Enum sourceFormat,
                              ezImageFormat::Enum targetFormat);
 
   /// \brief Converts the raw source data into a target data buffer using a precomputed conversion path.
-  static ezResult ConvertRaw(ezArrayPtr<const void> source, ezArrayPtr<void> target, ezUInt32 numElements,
+  static ezResult ConvertRaw(ezBlobPtr<const void> source, ezBlobPtr<void> target, ezUInt32 numElements,
                              ezArrayPtr<ConversionPathNode> path, ezUInt32 numScratchBuffers);
 
 private:

--- a/Code/Engine/Texture/Image/ImageFormat.h
+++ b/Code/Engine/Texture/Image/ImageFormat.h
@@ -293,7 +293,7 @@ struct EZ_TEXTURE_DLL ezImageFormat
   static ezUInt32 GetRowPitch(Enum format, ezUInt32 width);
 
   /// \brief Computes the size in bytes of a 2D slice of blocks (compressed) or pixels (if uncompressed) of the given width and height.
-  static ezUInt32 GetDepthPitch(Enum format, ezUInt32 width, ezUInt32 height);
+  static ezUInt64 GetDepthPitch(Enum format, ezUInt32 width, ezUInt32 height);
 
   /// \brief Returns the type of the image format.
   static ezImageFormatType::Enum GetType(Enum format);

--- a/Code/Engine/Texture/Image/ImageFormat.h
+++ b/Code/Engine/Texture/Image/ImageFormat.h
@@ -53,7 +53,7 @@ struct EZ_TEXTURE_DLL ezImageFormatChannel
 struct EZ_TEXTURE_DLL ezImageFormat
 {
   /// \brief Enum describing the encoding format of the pixels of an image.
-  enum Enum
+  enum Enum : ezUInt16
   {
     UNKNOWN,
 
@@ -290,7 +290,7 @@ struct EZ_TEXTURE_DLL ezImageFormat
   static ezUInt32 GetNumBlocksZ(Enum format, ezUInt32 depth);
 
   /// \brief Computes the size in bytes of a row of blocks (compressed) or pixels (if uncompressed) of the given width.
-  static ezUInt32 GetRowPitch(Enum format, ezUInt32 width);
+  static ezUInt64 GetRowPitch(Enum format, ezUInt32 width);
 
   /// \brief Computes the size in bytes of a 2D slice of blocks (compressed) or pixels (if uncompressed) of the given width and height.
   static ezUInt64 GetDepthPitch(Enum format, ezUInt32 width, ezUInt32 height);

--- a/Code/Engine/Texture/Image/ImageHeader.h
+++ b/Code/Engine/Texture/Image/ImageHeader.h
@@ -99,7 +99,7 @@ public:
   ezUInt32 GetNumBlocksZ(ezUInt32 uiMipLevel = 0) const { return ezImageFormat::GetNumBlocksZ(m_format, GetDepth(uiMipLevel)); }
 
   /// \brief Returns the offset in bytes between two subsequent rows of the given mip level.
-  ezUInt32 GetRowPitch(ezUInt32 uiMipLevel = 0) const { return ezImageFormat::GetRowPitch(GetImageFormat(), GetWidth(uiMipLevel)); }
+  ezUInt64 GetRowPitch(ezUInt32 uiMipLevel = 0) const { return ezImageFormat::GetRowPitch(GetImageFormat(), GetWidth(uiMipLevel)); }
 
   /// \brief Returns the offset in bytes between two subsequent depth slices of the given mip level.
   ezUInt64 GetDepthPitch(ezUInt32 uiMipLevel = 0) const

--- a/Code/Engine/Texture/Image/ImageHeader.h
+++ b/Code/Engine/Texture/Image/ImageHeader.h
@@ -102,19 +102,19 @@ public:
   ezUInt32 GetRowPitch(ezUInt32 uiMipLevel = 0) const { return ezImageFormat::GetRowPitch(GetImageFormat(), GetWidth(uiMipLevel)); }
 
   /// \brief Returns the offset in bytes between two subsequent depth slices of the given mip level.
-  ezUInt32 GetDepthPitch(ezUInt32 uiMipLevel = 0) const
+  ezUInt64 GetDepthPitch(ezUInt32 uiMipLevel = 0) const
   {
     return ezImageFormat::GetDepthPitch(GetImageFormat(), GetWidth(uiMipLevel), GetHeight(uiMipLevel));
   }
 
   /// \brief Computes the data size required for an image with the header's format and dimensions.
-  ezUInt32 ComputeDataSize() const
+  ezUInt64 ComputeDataSize() const
   {
-    ezUInt32 uiDataSize = 0;
+    ezUInt64 uiDataSize = 0;
 
     for (ezUInt32 uiMipLevel = 0; uiMipLevel < GetNumMipLevels(); uiMipLevel++)
     {
-      uiDataSize += GetDepthPitch(uiMipLevel) * GetDepth(uiMipLevel);
+      uiDataSize += GetDepthPitch(uiMipLevel) * static_cast<ezUInt64>(GetDepth(uiMipLevel));
     }
 
     return uiDataSize * GetNumArrayIndices() * GetNumFaces();

--- a/Code/Engine/Texture/Image/Implementation/Image.cpp
+++ b/Code/Engine/Texture/Image/Implementation/Image.cpp
@@ -289,8 +289,8 @@ ezImageView ezImageView::GetSubImageView(ezUInt32 uiMipLevel /*= 0*/, ezUInt32 u
   header.SetDepth(GetDepth(uiMipLevel));
   header.SetImageFormat(m_format);
 
-  const ezUInt32& offset = GetSubImageOffset(uiMipLevel, uiFace, uiArrayIndex);
-  ezUInt32 size = *(&offset + 1) - offset;
+  const ezUInt64& offset = GetSubImageOffset(uiMipLevel, uiFace, uiArrayIndex);
+  ezUInt64 size = *(&offset + 1) - offset;
 
   ezBlobPtr<const ezUInt8> subView = m_dataPtr.GetSubArray(offset, size);
 
@@ -327,8 +327,8 @@ ezImageView ezImageView::GetSliceView(ezUInt32 uiMipLevel /*= 0*/, ezUInt32 uiFa
   header.SetDepth(1);
   header.SetImageFormat(m_format);
 
-  ezUInt32 offset = GetSubImageOffset(uiMipLevel, uiFace, uiArrayIndex) + z * GetDepthPitch(uiMipLevel);
-  ezUInt32 size = GetDepthPitch(uiMipLevel);
+  ezUInt64 offset = GetSubImageOffset(uiMipLevel, uiFace, uiArrayIndex) + z * GetDepthPitch(uiMipLevel);
+  ezUInt64 size = GetDepthPitch(uiMipLevel);
 
   ezBlobPtr<const ezUInt8> subView = m_dataPtr.GetSubArray(offset, size);
 

--- a/Code/Engine/Texture/Image/Implementation/ImageConversion.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageConversion.cpp
@@ -539,7 +539,7 @@ ezResult ezImageConversion::ConvertSingleStepDecompress(const ezImageView& sourc
         const ezUInt32 numBlocksX = source.GetNumBlocksX(mipLevel);
         const ezUInt32 numBlocksY = source.GetNumBlocksY(mipLevel);
 
-        const ezUInt32 targetRowPitch = target.GetRowPitch(mipLevel);
+        const ezUInt64 targetRowPitch = target.GetRowPitch(mipLevel);
         const ezUInt32 targetBytesPerPixel = ezImageFormat::GetBitsPerPixel(targetFormat) / 8;
 
         const ezUInt32 blockSizeInBytes = ezImageFormat::GetBitsPerBlock(sourceFormat) / 8;
@@ -605,7 +605,7 @@ ezResult ezImageConversion::ConvertSingleStepCompress(const ezImageView& source,
         const ezUInt32 targetWidth = numBlocksX * ezImageFormat::GetBlockWidth(targetFormat);
         const ezUInt32 targetHeight = numBlocksY * ezImageFormat::GetBlockHeight(targetFormat);
 
-        const ezUInt32 sourceRowPitch = source.GetRowPitch(mipLevel);
+        const ezUInt64 sourceRowPitch = source.GetRowPitch(mipLevel);
         const ezUInt32 sourceBytesPerPixel = ezImageFormat::GetBitsPerPixel(sourceFormat) / 8;
 
         const ezUInt32 blockSizeInBytes = ezImageFormat::GetBitsPerBlock(targetFormat) / 8;
@@ -626,7 +626,7 @@ ezResult ezImageConversion::ConvertSingleStepCompress(const ezImageView& source,
             ezUInt32 sourceY = ezMath::Min(y, sourceHeight - 1);
 
             memcpy(paddedSlice.GetPixelPointer<void>(0, 0, 0, 0, y),
-                   source.GetPixelPointer<void>(mipLevel, face, arrayIndex, 0, sourceY, slice), sourceRowPitch);
+                   source.GetPixelPointer<void>(mipLevel, face, arrayIndex, 0, sourceY, slice), static_cast<size_t>(sourceRowPitch));
 
             for (ezUInt32 x = sourceWidth; x < targetWidth; ++x)
             {

--- a/Code/Engine/Texture/Image/Implementation/ImageFormat.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageFormat.cpp
@@ -707,9 +707,9 @@ ezUInt32 ezImageFormat::GetRowPitch(Enum format, ezUInt32 width)
   return GetNumBlocksX(format, width) * GetBitsPerBlock(format) / 8;
 }
 
-ezUInt32 ezImageFormat::GetDepthPitch(Enum format, ezUInt32 width, ezUInt32 height)
+ezUInt64 ezImageFormat::GetDepthPitch(Enum format, ezUInt32 width, ezUInt32 height)
 {
-  return GetNumBlocksY(format, height) * GetRowPitch(format, width);
+  return static_cast<ezUInt64>(GetNumBlocksY(format, height)) * static_cast<ezUInt64>(GetRowPitch(format, width));
 }
 
 ezImageFormatType::Enum ezImageFormat::GetType(Enum format)

--- a/Code/Engine/Texture/Image/Implementation/ImageFormat.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageFormat.cpp
@@ -702,9 +702,9 @@ ezUInt32 ezImageFormat::GetNumBlocksZ(Enum format, ezUInt32 depth)
   return (depth - 1) / GetBlockDepth(format) + 1;
 }
 
-ezUInt32 ezImageFormat::GetRowPitch(Enum format, ezUInt32 width)
+ezUInt64 ezImageFormat::GetRowPitch(Enum format, ezUInt32 width)
 {
-  return GetNumBlocksX(format, width) * GetBitsPerBlock(format) / 8;
+  return static_cast<ezUInt64>(GetNumBlocksX(format, width)) * GetBitsPerBlock(format) / 8;
 }
 
 ezUInt64 ezImageFormat::GetDepthPitch(Enum format, ezUInt32 width, ezUInt32 height)

--- a/Code/Engine/Texture/Image/Implementation/Image_inl.h
+++ b/Code/Engine/Texture/Image/Implementation/Image_inl.h
@@ -41,7 +41,7 @@ const T* ezImageView::GetPixelPointer(ezUInt32 uiMipLevel /*= 0*/, ezUInt32 uiFa
   EZ_ASSERT_DEV(y < GetNumBlocksY(uiMipLevel), "Invalid y coordinate");
   EZ_ASSERT_DEV(z < GetNumBlocksZ(uiMipLevel), "Invalid z coordinate");
 
-  ezUInt32 offset = GetSubImageOffset(uiMipLevel, uiFace, uiArrayIndex) + z * GetDepthPitch(uiMipLevel) + y * GetRowPitch(uiMipLevel) + x * ezImageFormat::GetBitsPerBlock(m_format) / 8;
+  ezUInt64 offset = GetSubImageOffset(uiMipLevel, uiFace, uiArrayIndex) + z * GetDepthPitch(uiMipLevel) + y * GetRowPitch(uiMipLevel) + x * ezImageFormat::GetBitsPerBlock(m_format) / 8;
   return reinterpret_cast<const T*>(&m_dataPtr[offset]);
 }
 

--- a/Code/Engine/Texture/Image/Implementation/Image_inl.h
+++ b/Code/Engine/Texture/Image/Implementation/Image_inl.h
@@ -18,18 +18,18 @@ struct ezImageSizeofHelper<const void>
 };
 
 template <typename T>
-ezArrayPtr<const T> ezImageView::GetArrayPtr() const
+ezBlobPtr<const T> ezImageView::GetBlobPtr() const
 {
   ValidateDataTypeAccessor<T>();
-  return ezArrayPtr<const T>(reinterpret_cast<T*>(static_cast<ezUInt8*>(m_dataPtr.GetPtr())), m_dataPtr.GetCount() / ezImageSizeofHelper<T>::Size);
+  return ezBlobPtr<const T>(reinterpret_cast<T*>(static_cast<ezUInt8*>(m_dataPtr.GetPtr())), m_dataPtr.GetCount() / ezImageSizeofHelper<T>::Size);
 }
 
 template <typename T>
-ezArrayPtr<T> ezImage::GetArrayPtr()
+ezBlobPtr<T> ezImage::GetBlobPtr()
 {
-  ezArrayPtr<const T> constPtr = ezImageView::GetArrayPtr<T>();
+  ezBlobPtr<const T> constPtr = ezImageView::GetBlobPtr<T>();
   
-  return ezArrayPtr<T>(const_cast<T*>(static_cast<const T*>(constPtr.GetPtr())), constPtr.GetCount());
+  return ezBlobPtr<T>(const_cast<T*>(static_cast<const T*>(constPtr.GetPtr())), constPtr.GetCount());
 }
 
 template <typename T>

--- a/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
@@ -192,7 +192,7 @@ ezResult ezTexConvProcessor::GenerateThumbnailOutput(const ezImage& srcImg, ezIm
     const float fTileSize = 16.0f;
 
     ezColorLinearUB* pPixels = dstImg.GetPixelPointer<ezColorLinearUB>();
-    const ezUInt32 rowPitch = dstImg.GetRowPitch();
+    const ezUInt64 rowPitch = dstImg.GetRowPitch();
 
     ezInt32 checkCounter = 0;
     ezColor tiles[2]{ezColor::LightGray, ezColor::DarkGray};
@@ -215,7 +215,7 @@ ezResult ezTexConvProcessor::GenerateThumbnailOutput(const ezImage& srcImg, ezIm
         }
       }
 
-      pPixels = ezMemoryUtils::AddByteOffset(pPixels, rowPitch);
+      pPixels = ezMemoryUtils::AddByteOffset(pPixels, static_cast<ptrdiff_t>(rowPitch));
     }
   }
 

--- a/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
@@ -191,7 +191,7 @@ ezResult ezTexConvProcessor::CreateAtlasTexture(
 
   // make sure the target texture is filled with all black
   {
-    auto pixelData = atlas.GetArrayPtr<ezUInt8>();
+    auto pixelData = atlas.GetBlobPtr<ezUInt8>();
     ezMemoryUtils::ZeroFill(pixelData.GetPtr(), pixelData.GetCount());
   }
 

--- a/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
@@ -74,7 +74,8 @@ ezResult ezTexConvProcessor::LoadAtlasInputs(const ezTextureAtlasCreationDesc& a
         }
 
         ezUInt32 uiResX = 0, uiResY = 0;
-        EZ_SUCCEED_OR_RETURN(DetermineTargetResolution(item.m_InputImage[layer], ezImageFormat::UNKNOWN, uiResX, uiResY));
+        ezEnum<ezImageFormat> format = ezImageFormat::UNKNOWN;
+        EZ_SUCCEED_OR_RETURN(DetermineTargetResolution(item.m_InputImage[layer], format, uiResX, uiResY));
 
         EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[layer], item.m_InputImage[layer], uiResX, uiResY));
       }

--- a/Code/Engine/Texture/TexConv/Implementation/TextureModifications.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TextureModifications.cpp
@@ -76,7 +76,7 @@ ezResult ezTexConvProcessor::PremultiplyAlpha(ezImage& image) const
   if (!m_Descriptor.m_bPremultiplyAlpha)
     return EZ_SUCCESS;
 
-  for (ezColor& col : image.GetArrayPtr<ezColor>())
+  for (ezColor& col : image.GetBlobPtr<ezColor>())
   {
     col.r *= col.a;
     col.g *= col.a;

--- a/Code/Engine/Texture/Utils/Implementation/TextureAtlasDesc.cpp
+++ b/Code/Engine/Texture/Utils/Implementation/TextureAtlasDesc.cpp
@@ -8,7 +8,10 @@ ezResult ezTextureAtlasCreationDesc::Serialize(ezStreamWriter& stream) const
 {
   stream.WriteVersion(1);
 
-  const ezUInt8 uiNumLayers = m_Layers.GetCount();
+  if(m_Layers.GetCount() > 255u)
+    return EZ_FAILURE;
+
+  const ezUInt8 uiNumLayers = static_cast<ezUInt8>(m_Layers.GetCount());
   stream << uiNumLayers;
 
   for (ezUInt32 l = 0; l < uiNumLayers; ++l)

--- a/Code/Tools/TexConv2/ParseUtils.cpp
+++ b/Code/Tools/TexConv2/ParseUtils.cpp
@@ -50,7 +50,7 @@ ezResult ezTexConv2::ParseFloatOption(const char* szOption, float fMinValue, flo
   const auto pCmd = ezCommandLineUtils::GetGlobalInstance();
   float fDefault = fResult;
 
-  const float val = pCmd->GetFloatOption(szOption, fResult);
+  const float val = static_cast<float>(pCmd->GetFloatOption(szOption, fResult));
 
   if (!ezMath::IsInRange(val, fMinValue, fMaxValue))
   {

--- a/Code/UnitTests/CoreTest/Scripting/LuaWrapperTest.cpp
+++ b/Code/UnitTests/CoreTest/Scripting/LuaWrapperTest.cpp
@@ -251,24 +251,24 @@ EZ_CREATE_SIMPLE_TEST(Scripting, LuaWrapper)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetFloatVariable (Global)")
   {
-    EZ_TEST_INT(sMain.GetFloatVariable("nonexisting1", 13), 13);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 4.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar2", 13), 7.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("nonexisting2", 14), 14);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 4.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar2", 13), 7.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("nonexisting1", 13), 13, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 4.3f, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar2", 13), 7.3f, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("nonexisting2", 14), 14, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 4.3f, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar2", 13), 7.3f, ezMath::BasicType<float>::DefaultEpsilon());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetFloatVariable (Table)")
   {
     EZ_TEST_BOOL(sMain.OpenTable("MyTable") == EZ_SUCCESS);
 
-    EZ_TEST_INT(sMain.GetFloatVariable("nonexisting1", 13), 13);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 14.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar2", 13), 17.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("nonexisting2", 14), 14);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 14.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar2", 13), 17.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("nonexisting1", 13), 13, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 14.3f, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar2", 13), 17.3f, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("nonexisting2", 14), 14, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 14.3f, ezMath::BasicType<float>::DefaultEpsilon());
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar2", 13), 17.3f, ezMath::BasicType<float>::DefaultEpsilon());
 
     sMain.CloseTable();
   }
@@ -345,22 +345,22 @@ EZ_CREATE_SIMPLE_TEST(Scripting, LuaWrapper)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetVariable (float, Global)")
   {
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 4.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 4.3f, ezMath::BasicType<float>::DefaultEpsilon());
     sMain.SetVariable("floatvar1", 27.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 27.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 27.3f, ezMath::BasicType<float>::DefaultEpsilon());
     sMain.SetVariable("floatvar1", 4.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 4.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 4.3f, ezMath::BasicType<float>::DefaultEpsilon());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetVariable (float, Table)")
   {
     EZ_TEST_BOOL(sMain.OpenTable("MyTable") == EZ_SUCCESS);
 
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 14.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 14.3f, ezMath::BasicType<float>::DefaultEpsilon());
     sMain.SetVariable("floatvar1", 127.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 127.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 127.3f, ezMath::BasicType<float>::DefaultEpsilon());
     sMain.SetVariable("floatvar1", 14.3f);
-    EZ_TEST_INT(sMain.GetFloatVariable("floatvar1", 13), 14.3f);
+    EZ_TEST_FLOAT(sMain.GetFloatVariable("floatvar1", 13), 14.3f, ezMath::BasicType<float>::DefaultEpsilon());
 
     sMain.CloseTable();
   }

--- a/Code/UnitTests/FoundationTest/IO/CompressedStreamZstdTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/CompressedStreamZstdTest.cpp
@@ -74,8 +74,8 @@ EZ_CREATE_SIMPLE_TEST(IO, CompressedStreamZstd)
     // flush all data
     CompressedWriter.FinishCompressedStream();
 
-    const ezUInt32 uiCompressed = CompressedWriter.GetCompressedSize();
-    const ezUInt32 uiUncompressed = CompressedWriter.GetUncompressedSize();
+    const ezUInt64 uiCompressed = CompressedWriter.GetCompressedSize();
+    const ezUInt64 uiUncompressed = CompressedWriter.GetUncompressedSize();
 
     EZ_TEST_INT(uiUncompressed, TestData.GetCount() * sizeof(ezUInt32));
 

--- a/Code/UnitTests/FoundationTest/IO/DeduplicationContextTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/DeduplicationContextTest.cpp
@@ -110,9 +110,9 @@ EZ_CREATE_SIMPLE_TEST(IO, DeduplicationContext)
     ComplexObject obj;
     for (ezUInt32 i = 0; i < 20; ++i)
     {
-      obj.m_Transforms.ExpandAndGetRef() = EZ_DEFAULT_NEW(ezTransform, ezVec3(i, 0, 0));
-      obj.m_Positions.ExpandAndGetRef() = ezVec3(1, 2, i);
-      obj.m_Scales.ExpandAndGetRef() = EZ_DEFAULT_NEW(RefCountedVec3, ezVec3(0, i, 0));
+      obj.m_Transforms.ExpandAndGetRef() = EZ_DEFAULT_NEW(ezTransform, ezVec3(static_cast<float>(i), 0, 0));
+      obj.m_Positions.ExpandAndGetRef() = ezVec3(1, 2, static_cast<float>(i));
+      obj.m_Scales.ExpandAndGetRef() = EZ_DEFAULT_NEW(RefCountedVec3, ezVec3(0, static_cast<float>(i), 0));
     }
 
     for (ezUInt32 i = 0; i < 10; ++i)
@@ -156,9 +156,9 @@ EZ_CREATE_SIMPLE_TEST(IO, DeduplicationContext)
       EZ_TEST_BOOL(component.m_pPosition == &obj.m_Positions[component.m_uiIndex]);
       EZ_TEST_BOOL(component.m_pScale == obj.m_Scales[component.m_uiIndex]);
 
-      EZ_TEST_BOOL(component.m_pTransform->m_vPosition == ezVec3(i * 2, 0, 0));
-      EZ_TEST_BOOL(*component.m_pPosition == ezVec3(1, 2, i * 2));
-      EZ_TEST_BOOL(component.m_pScale->m_v == ezVec3(0, i * 2, 0));
+      EZ_TEST_BOOL(component.m_pTransform->m_vPosition == ezVec3(static_cast<float>(i) * 2, 0, 0));
+      EZ_TEST_BOOL(*component.m_pPosition == ezVec3(1, 2, static_cast<float>(i) * 2));
+      EZ_TEST_BOOL(component.m_pScale->m_v == ezVec3(0, static_cast<float>(i) * 2, 0));
     }
 
     for (ezUInt32 i = 0; i < 10; ++i)

--- a/Code/UnitTests/FoundationTest/Math/RandomTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/RandomTest.cpp
@@ -218,14 +218,14 @@ EZ_CREATE_SIMPLE_TEST(Math, Random)
 
     for (ezInt32 i = 2; i < 10000; ++i)
     {
-      const float val = r.FloatInRange(i, i);
+      const float val = r.FloatInRange(static_cast<float>(i), static_cast<float>(i));
       EZ_TEST_BOOL(val >= i);
       EZ_TEST_BOOL(val < i + i);
     }
 
     for (ezInt32 i = 2; i < 10000; ++i)
     {
-      const float val = r.FloatInRange(-i, 2 * i);
+      const float val = r.FloatInRange(static_cast<float>(-i), 2 * static_cast<float>(i));
       EZ_TEST_BOOL(val >= -i);
       EZ_TEST_BOOL(val < -i + 2 * i);
     }
@@ -241,14 +241,14 @@ EZ_CREATE_SIMPLE_TEST(Math, Random)
 
     for (ezInt32 i = 2; i < 10000; ++i)
     {
-      const float val = r.FloatMinMax(i, 2 * i);
+      const float val = r.FloatMinMax(static_cast<float>(i), static_cast<float>(2 * i));
       EZ_TEST_BOOL(val >= i);
       EZ_TEST_BOOL(val <= i + i);
     }
 
     for (ezInt32 i = 2; i < 10000; ++i)
     {
-      const float val = r.FloatMinMax(-i, i);
+      const float val = r.FloatMinMax(static_cast<float>(-i), static_cast<float>(i));
       EZ_TEST_BOOL(val >= -i);
       EZ_TEST_BOOL(val <= i);
     }

--- a/Code/UnitTests/FoundationTest/Reflection/FunctionReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/FunctionReflectionTest.cpp
@@ -369,14 +369,14 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Functions)
 
     ezVariant ret(&retS);
     funccall.Execute(&test, test.m_values, ret);
-    EZ_TEST_INT(retS.m_fFloat1, 42);
-    EZ_TEST_FLOAT(retS.m_UInt8, 42, 0);
+    EZ_TEST_FLOAT(retS.m_fFloat1, 42, 0);
+    EZ_TEST_INT(retS.m_UInt8, 42);
 
-    EZ_TEST_INT(rs.m_fFloat1, 999);
-    EZ_TEST_FLOAT(rs.m_UInt8, 666, 0);
+    EZ_TEST_FLOAT(rs.m_fFloat1, 999, 0);
+    EZ_TEST_INT(rs.m_UInt8, 666);
 
-    EZ_TEST_INT(ps.m_fFloat1, 666);
-    EZ_TEST_FLOAT(ps.m_UInt8, 999, 0);
+    EZ_TEST_DOUBLE(ps.m_fFloat1, 666, 0);
+    EZ_TEST_INT(ps.m_UInt8, 999);
 
     test.m_bPtrAreNull = true;
     test.m_values[4] = ezVariant();

--- a/Data/Base/Plugins.ddl
+++ b/Data/Base/Plugins.ddl
@@ -18,12 +18,6 @@ Plugin
 }
 Plugin
 {
-	string %Path{"ezEnginePluginPhysX"}
-	bool %LoadCopy{false}
-	string %DependencyOf{"EditorPluginPhysX"}
-}
-Plugin
-{
 	string %Path{"ezEnginePluginScene"}
 	bool %LoadCopy{false}
 	string %DependencyOf{"EditorPluginScene"}
@@ -45,12 +39,6 @@ Plugin
 	string %Path{"ezParticlePlugin"}
 	bool %LoadCopy{false}
 	string %DependencyOf{"EditorPluginParticle"}
-}
-Plugin
-{
-	string %Path{"ezPhysXPlugin"}
-	bool %LoadCopy{false}
-	string %DependencyOf{"EditorPluginPhysX"}
 }
 Plugin
 {


### PR DESCRIPTION
Adds ezBlob as a container to store large data amounts.
Switched ezImage to use ezBlob & ezBlobPtr. Large textures now can be loaded in ezImage.
To fix all potential problems with the switch of GetDepthPitch and GetRowPitch to 64 bit I removed the pragma warning disable for size truncation and fixed all issues that appeared because of that. This might expose some problems in custom code which is not checked in.
Unit tests run.