### PR TITLE
User/cm/delegate

### DIFF
--- a/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
@@ -21,13 +21,25 @@ struct ezLambdaDelegateStorage : public ezLambdaDelegateStorageBase
   }
 
 private:
+  template < typename = typename std::enable_if< std::is_copy_constructible<Function>::value >::type>
   ezLambdaDelegateStorage(const Function& func)
     : m_func(func)
   {
   }
 
 public:
-  virtual ezLambdaDelegateStorageBase* Clone() const override { return EZ_DEFAULT_NEW(ezLambdaDelegateStorage<Function>, m_func); }
+  virtual ezLambdaDelegateStorageBase* Clone() const override
+  {
+    if constexpr (std::is_copy_constructible<Function>::value)
+    {
+      return EZ_DEFAULT_NEW(ezLambdaDelegateStorage<Function>, m_func);
+    }
+    else
+    {
+      EZ_REPORT_FAILURE("The ezDelegate stores a lambda that is not copyable. Copying this ezDelegate is not supported.");
+      return nullptr;
+    }
+  }
   Function m_func;
 };
 

--- a/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
@@ -1,25 +1,63 @@
 
+/// \brief [Internal] Storage for lambdas with captures in ezDelegate.
+struct EZ_FOUNDATION_DLL ezLambdaDelegateStorageBase
+{
+  ezLambdaDelegateStorageBase() = default;
+  virtual ~ezLambdaDelegateStorageBase() = default;
+  virtual ezLambdaDelegateStorageBase* Clone() const = 0;
+private:
+  ezLambdaDelegateStorageBase(const ezLambdaDelegateStorageBase&) = delete;
+  ezLambdaDelegateStorageBase& operator=(const ezLambdaDelegateStorageBase&) = delete;
+  ezLambdaDelegateStorageBase(ezLambdaDelegateStorageBase&&) = delete;
+  ezLambdaDelegateStorageBase& operator=(ezLambdaDelegateStorageBase&&) = delete;
+};
+
+template <typename Function>
+struct ezLambdaDelegateStorage : public ezLambdaDelegateStorageBase
+{
+  ezLambdaDelegateStorage(Function&& func)
+    : m_func(std::move(func))
+  {
+  }
+
+private:
+  ezLambdaDelegateStorage(const Function& func)
+    : m_func(func)
+  {
+  }
+
+public:
+  virtual ezLambdaDelegateStorageBase* Clone() const override { return EZ_DEFAULT_NEW(ezLambdaDelegateStorage<Function>, m_func); }
+  Function m_func;
+};
+
+
 template <typename R, class... Args>
 struct ezDelegate<R(Args...)> : public ezDelegateBase
 {
 private:
   typedef ezDelegate<R(Args...)> SelfType;
+  constexpr const void* HeapAllocated() const { return reinterpret_cast<const void*>((size_t)-1); }
 
 public:
-  EZ_DECLARE_POD_TYPE();
+  EZ_DECLARE_MEM_RELOCATABLE_TYPE();
 
   EZ_ALWAYS_INLINE ezDelegate()
-      : m_pDispatchFunction(nullptr)
+    : m_pDispatchFunction(nullptr)
   {
   }
+
+  EZ_ALWAYS_INLINE ezDelegate(const SelfType& other) { *this = other; }
+
+  EZ_ALWAYS_INLINE ezDelegate(SelfType&& other) { *this = std::move(other); }
 
   /// \brief Constructs the delegate from a member function type and takes the class instance on which to call the function later.
   template <typename Method, typename Class>
   EZ_FORCE_INLINE ezDelegate(Method method, Class* pInstance)
   {
     EZ_CHECK_AT_COMPILETIME_MSG(sizeof(Method) <= DATA_SIZE, "Member function pointer must not be bigger than 16 bytes");
-    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(&m_Data, EZ_ALIGNMENT_OF(Method)), "Wrong alignment. Expected {0} bytes alignment",
-                    EZ_ALIGNMENT_OF(Method));
+    EZ_ASSERT_DEBUG(
+      ezMemoryUtils::IsAligned(&m_Data, EZ_ALIGNMENT_OF(Method)), "Wrong alignment. Expected {0} bytes alignment", EZ_ALIGNMENT_OF(Method));
 
     memcpy(m_Data, &method, sizeof(Method));
     memset(m_Data + sizeof(Method), 0, DATA_SIZE - sizeof(Method));
@@ -41,8 +79,8 @@ public:
   EZ_FORCE_INLINE ezDelegate(Method method, const Class* pInstance)
   {
     EZ_CHECK_AT_COMPILETIME_MSG(sizeof(Method) <= DATA_SIZE, "Member function pointer must not be bigger than 16 bytes");
-    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(&m_Data, EZ_ALIGNMENT_OF(Method)), "Wrong alignment. Expected {0} bytes alignment",
-                    EZ_ALIGNMENT_OF(Method));
+    EZ_ASSERT_DEBUG(
+      ezMemoryUtils::IsAligned(&m_Data, EZ_ALIGNMENT_OF(Method)), "Wrong alignment. Expected {0} bytes alignment", EZ_ALIGNMENT_OF(Method));
 
     memcpy(m_Data, &method, sizeof(Method));
     memset(m_Data + sizeof(Method), 0, DATA_SIZE - sizeof(Method));
@@ -63,29 +101,67 @@ public:
   template <typename Function>
   EZ_FORCE_INLINE ezDelegate(Function function)
   {
-    EZ_CHECK_AT_COMPILETIME_MSG(sizeof(Function) <= DATA_SIZE, "Function object must not be bigger than 16 bytes");
     EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(&m_Data, EZ_ALIGNMENT_OF(Function)), "Wrong alignment. Expected {0} bytes alignment",
-                    EZ_ALIGNMENT_OF(Function));
+      EZ_ALIGNMENT_OF(Function));
 
-    memcpy(m_Data, &function, sizeof(Function));
-    memset(m_Data + sizeof(Function), 0, DATA_SIZE - sizeof(Function));
-    m_pDispatchFunction = &DispatchToFunction<Function>;
+    // Only memcpy pure function pointers or lambdas that can be cast into pure functions.
+    // Not lambdas with captures, as they can capture non-pod, non-memmoveable data.
+    using signature = R(Args...);
+    if constexpr (sizeof(Function) <= DATA_SIZE && std::is_assignable<signature*&, Function>::value)
+    {
+      m_pInstance.m_ConstPtr = nullptr;
+      memcpy(m_Data, &function, sizeof(Function));
+      memset(m_Data + sizeof(Function), 0, DATA_SIZE - sizeof(Function));
+      m_pDispatchFunction = &DispatchToFunction<Function>;
+    }
+    else
+    {
+      m_pInstance.m_ConstPtr = HeapAllocated();
+      ezLambdaDelegateStorageBase* storage = EZ_DEFAULT_NEW(ezLambdaDelegateStorage<Function>, std::move(function));
+      memcpy(m_Data, &storage, sizeof(storage));
+      memset(m_Data + sizeof(storage), 0, DATA_SIZE - sizeof(storage));
+      m_pDispatchFunction = &DispatchToLambdaStorageFunction<Function>;
+    }
   }
 
-#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
-  EZ_ALWAYS_INLINE ~ezDelegate() { m_pDispatchFunction = nullptr; }
-#endif
+  EZ_ALWAYS_INLINE ~ezDelegate()
+  {
+    Invalidate();
+  }
 
   /// \brief Copies the data from another delegate.
   EZ_FORCE_INLINE void operator=(const SelfType& other)
   {
+    Invalidate();
     m_pInstance = other.m_pInstance;
     m_pDispatchFunction = other.m_pDispatchFunction;
     memcpy(m_Data, other.m_Data, DATA_SIZE);
+    if (other.IsHeapAllocated())
+    {
+      ezLambdaDelegateStorageBase* otherStorage = *reinterpret_cast<ezLambdaDelegateStorageBase**>(other.m_Data);
+      ezLambdaDelegateStorageBase* storage = otherStorage->Clone();
+      memcpy(m_Data, &storage, sizeof(storage));
+    }
+  }
+
+  /// \brief Moves the data from another delegate.
+  EZ_FORCE_INLINE void operator=(SelfType&& other)
+  {
+    Invalidate();
+    m_pInstance = other.m_pInstance;
+    m_pDispatchFunction = other.m_pDispatchFunction;
+    memcpy(m_Data, other.m_Data, DATA_SIZE);
+
+    other.m_pInstance.m_Ptr = nullptr;
+    other.m_pDispatchFunction = nullptr;
+    memset(other.m_Data, 0, DATA_SIZE);
   }
 
   /// \brief Resets a delegate to an invalid state.
-  EZ_FORCE_INLINE void operator=(std::nullptr_t) { m_pDispatchFunction = nullptr; }
+  EZ_FORCE_INLINE void operator=(std::nullptr_t)
+  {
+    Invalidate();
+  }
 
   /// \brief Function call operator. This will call the function that is bound to the delegate, or assert if nothing was bound.
   EZ_FORCE_INLINE R operator()(Args... params) const
@@ -108,12 +184,29 @@ public:
   EZ_ALWAYS_INLINE bool IsValid() const { return m_pDispatchFunction != nullptr; }
 
   /// \brief Resets a delegate to an invalid state.
-  EZ_ALWAYS_INLINE void Invalidate() { m_pDispatchFunction = nullptr; }
+  EZ_ALWAYS_INLINE void Invalidate()
+  {
+    m_pDispatchFunction = nullptr;
+    if (IsHeapAllocated())
+    {
+      FreeHeapData();
+    }
+  }
 
   /// \brief Returns the class instance that is used to call a member function pointer on.
-  EZ_ALWAYS_INLINE void* GetClassInstance() const { return m_pInstance.m_Ptr; }
+  EZ_ALWAYS_INLINE void* GetClassInstance() const { return IsHeapAllocated() ? nullptr : m_pInstance.m_Ptr; }
+
+  /// \brief Returns whether the target function is stored on the heap, i.e. a lambda with captures.
+  EZ_ALWAYS_INLINE bool IsHeapAllocated() const { return m_pInstance.m_ConstPtr == HeapAllocated(); } // [tested]
 
 private:
+  void FreeHeapData()
+  {
+    ezLambdaDelegateStorageBase* data = *reinterpret_cast<ezLambdaDelegateStorageBase**>(m_Data);
+    EZ_DEFAULT_DELETE(data);
+    m_pInstance.m_ConstPtr = 0;
+  }
+
   template <typename Method, typename Class>
   static EZ_FORCE_INLINE R DispatchToMethod(const SelfType& self, Args... params)
   {
@@ -136,6 +229,11 @@ private:
     return (*reinterpret_cast<Function*>(&self.m_Data))(params...);
   }
 
+  template <typename Function>
+  static EZ_ALWAYS_INLINE R DispatchToLambdaStorageFunction(const SelfType& self, Args... params)
+  {
+    return (*reinterpret_cast<ezLambdaDelegateStorage<Function>**>(self.m_Data))->m_func(params...);
+  }
 
   typedef R (*DispatchFunction)(const SelfType& self, Args...);
   DispatchFunction m_pDispatchFunction;
@@ -163,4 +261,3 @@ struct ezMakeDelegateHelper<R (Class::*)(Args...) const>
 {
   typedef ezDelegate<R(Args...)> DelegateType;
 };
-

--- a/Code/Engine/Foundation/Types/Implementation/Delegate_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/Delegate_inl.h
@@ -1,36 +1,5 @@
 
-template <typename T>
-struct ezMakeDelegateHelper
-{
-};
-
-#define ARG_COUNT 0
 #include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
-
-#define ARG_COUNT 1
-#include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
-
-#define ARG_COUNT 2
-#include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
-
-#define ARG_COUNT 3
-#include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
-
-#define ARG_COUNT 4
-#include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
-
-#define ARG_COUNT 5
-#include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
-
-#define ARG_COUNT 6
-#include <Foundation/Types/Implementation/DelegateHelper_inl.h>
-#undef ARG_COUNT
 
 template <typename Function>
 ezDelegate<Function> ezMakeDelegate(Function* function)

--- a/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
@@ -8,6 +8,8 @@ namespace
   {
     TestType() {}
 
+    ezInt32 MethodWithManyParams(ezInt32 a, ezInt32 b, ezInt32 c, ezInt32 d, ezInt32 e, ezInt32 f) { return m_iA + a + b + c + d + e + f; }
+
     ezInt32 Method(ezInt32 b) { return b + m_iA; }
 
     ezInt32 ConstMethod(ezInt32 b) const { return b + m_iA + 4; }
@@ -67,7 +69,7 @@ namespace
   };
 
   static ezInt32 Function(ezInt32 b) { return b + 2; }
-}
+} // namespace
 
 EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
 {
@@ -84,10 +86,27 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
     test.m_iA = 42;
 
     d = TestDelegate(&TestType::Method, &test);
+    EZ_TEST_BOOL(d == TestDelegate(&TestType::Method, &test));
     EZ_TEST_INT(d(4), 46);
 
     d = TestDelegate(&TestTypeDerived::Method, &test);
+    EZ_TEST_BOOL(d == TestDelegate(&TestTypeDerived::Method, &test));
     EZ_TEST_INT(d(4), 8);
+
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Method With Many Params")
+  {
+    typedef ezDelegate<ezInt32(ezInt32, ezInt32, ezInt32, ezInt32, ezInt32, ezInt32)> TestDelegateMany;
+    TestDelegateMany many;
+
+    TestType test;
+    test.m_iA = 1000000;
+
+    many = TestDelegateMany(&TestType::MethodWithManyParams, &test);
+    EZ_TEST_BOOL(many == TestDelegateMany(&TestType::MethodWithManyParams, &test));
+    EZ_TEST_INT(many(1,10,100,1000,10000,100000), 1111111);
+
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Complex Class")
@@ -102,6 +121,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
     constTest.m_iA = 35;
 
     d = TestDelegate(&TestType::ConstMethod, &constTest);
+    EZ_TEST_BOOL(d == TestDelegate(&TestType::ConstMethod, &constTest));
     EZ_TEST_INT(d(4), 43);
   }
 
@@ -110,15 +130,18 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
     TestTypeDerived test;
 
     d = TestDelegate(&TestType::VirtualMethod, &test);
+    EZ_TEST_BOOL(d == TestDelegate(&TestType::VirtualMethod, &test));
     EZ_TEST_INT(d(4), 47);
 
     d = TestDelegate(&TestTypeDerived::VirtualMethod, &test);
+    EZ_TEST_BOOL(d == TestDelegate(&TestTypeDerived::VirtualMethod, &test));
     EZ_TEST_INT(d(4), 47);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Function")
   {
     d = &Function;
+    EZ_TEST_BOOL(d == &Function);
     EZ_TEST_INT(d(4), 6);
   }
 
@@ -168,11 +191,15 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezMakeDelegate")
   {
     auto d1 = ezMakeDelegate(&Function);
+    EZ_TEST_BOOL(d1 == ezMakeDelegate(&Function));
 
     TestType instance;
     auto d2 = ezMakeDelegate(&TestType::Method, &instance);
+    EZ_TEST_BOOL(d2 == ezMakeDelegate(&TestType::Method, &instance));
     auto d3 = ezMakeDelegate(&TestType::ConstMethod, &instance);
+    EZ_TEST_BOOL(d3 == ezMakeDelegate(&TestType::ConstMethod, &instance));
     auto d4 = ezMakeDelegate(&TestType::VirtualMethod, &instance);
+    EZ_TEST_BOOL(d4 == ezMakeDelegate(&TestType::VirtualMethod, &instance));
 
     EZ_IGNORE_UNUSED(d1);
     EZ_IGNORE_UNUSED(d2);

--- a/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
@@ -1,6 +1,8 @@
 #include <FoundationTestPCH.h>
 
 #include <Foundation/Types/Delegate.h>
+#include <Foundation/Types/RefCounted.h>
+#include <Foundation/Types/SharedPtr.h>
 
 namespace
 {
@@ -87,10 +89,12 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
 
     d = TestDelegate(&TestType::Method, &test);
     EZ_TEST_BOOL(d == TestDelegate(&TestType::Method, &test));
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(4), 46);
 
     d = TestDelegate(&TestTypeDerived::Method, &test);
     EZ_TEST_BOOL(d == TestDelegate(&TestTypeDerived::Method, &test));
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(4), 8);
 
   }
@@ -105,6 +109,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
 
     many = TestDelegateMany(&TestType::MethodWithManyParams, &test);
     EZ_TEST_BOOL(many == TestDelegateMany(&TestType::MethodWithManyParams, &test));
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(many(1,10,100,1000,10000,100000), 1111111);
 
   }
@@ -122,6 +127,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
 
     d = TestDelegate(&TestType::ConstMethod, &constTest);
     EZ_TEST_BOOL(d == TestDelegate(&TestType::ConstMethod, &constTest));
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(4), 43);
   }
 
@@ -131,10 +137,12 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
 
     d = TestDelegate(&TestType::VirtualMethod, &test);
     EZ_TEST_BOOL(d == TestDelegate(&TestType::VirtualMethod, &test));
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(4), 47);
 
     d = TestDelegate(&TestTypeDerived::VirtualMethod, &test);
     EZ_TEST_BOOL(d == TestDelegate(&TestTypeDerived::VirtualMethod, &test));
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(4), 47);
   }
 
@@ -142,19 +150,28 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
   {
     d = &Function;
     EZ_TEST_BOOL(d == &Function);
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(4), 6);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - no capture")
   {
     d = [](ezInt32 i) { return i * 4; };
+    EZ_TEST_BOOL(!d.IsHeapAllocated());
     EZ_TEST_INT(d(2), 8);
+
+    TestDelegate d2 = d;
+    EZ_TEST_BOOL(d2 == d);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - capture by value")
   {
     ezInt32 c = 20;
-    d = [c](ezInt32) { return c; };
+    d = [c](ezInt32)
+    {
+      return c;
+    };
+    EZ_TEST_BOOL(d.IsHeapAllocated());
     EZ_TEST_INT(d(3), 20);
     c = 10;
     EZ_TEST_INT(d(3), 20);
@@ -164,6 +181,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
   {
     ezInt32 c = 20;
     d = [c](ezInt32) mutable { return c; };
+    EZ_TEST_BOOL(d.IsHeapAllocated());
     EZ_TEST_INT(d(3), 20);
     c = 10;
     EZ_TEST_INT(d(3), 20);
@@ -173,6 +191,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
       c = 1;
       return result;
     };
+    EZ_TEST_BOOL(d.IsHeapAllocated());
     EZ_TEST_INT(d(3), 13);
     EZ_TEST_INT(d(3), 4);
   }
@@ -184,8 +203,110 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
       c = 5;
       return i;
     };
+    EZ_TEST_BOOL(d.IsHeapAllocated());
     EZ_TEST_INT(d(3), 3);
     EZ_TEST_INT(c, 5);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - capture by value of non-pod")
+  {
+    struct RefCountedInt : public ezRefCounted
+    {
+      RefCountedInt() = default;
+      RefCountedInt(int i)
+        : m_value(i)
+      {
+      }
+      int m_value;
+    };
+
+    ezSharedPtr<RefCountedInt> shared = EZ_DEFAULT_NEW(RefCountedInt, 1);
+    EZ_TEST_INT(shared->GetRefCount(), 1);
+    {
+      TestDelegate deleteMe = [shared](ezInt32 i) -> decltype(i) { return 0; };
+      EZ_TEST_BOOL(deleteMe.IsHeapAllocated());
+      EZ_TEST_INT(shared->GetRefCount(), 2);
+    }
+    EZ_TEST_INT(shared->GetRefCount(), 1);
+
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - capture lots of things")
+  {
+
+    ezInt64 a = 10;
+    ezInt64 b = 20;
+    ezInt64 c = 30;
+    d = [a, b, c](ezInt32 i) -> ezInt32 { return static_cast<ezInt32>(a + b + c + i); };
+    EZ_TEST_INT(d(6), 66);
+    EZ_TEST_BOOL(d.IsHeapAllocated());
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Move semantics")
+  {
+    // Move pure function
+    {
+      d.Invalidate();
+      TestDelegate d2 = &Function;
+      d = std::move(d2);
+      EZ_TEST_BOOL(d.IsValid());
+      EZ_TEST_BOOL(!d2.IsValid());
+      EZ_TEST_BOOL(!d.IsHeapAllocated());
+      EZ_TEST_INT(d(4), 6);
+    }
+
+    // Move delegate
+    ezConstructionCounter::Reset();    
+    d.Invalidate();
+    {
+      ezConstructionCounter value;
+      value.m_iData = 666;
+      EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 1);
+      EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 0);
+      TestDelegate d2 = [value](ezInt32 i) -> ezInt32 { return value.m_iData; };
+      EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 3); // Capture plus moving the lambda.
+      EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 1); // Move of lambda
+      d = std::move(d2);
+      // Moving should not affect anything.
+      EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 3);
+      EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 1);
+      EZ_TEST_BOOL(d.IsValid());
+      EZ_TEST_BOOL(!d2.IsValid());
+      EZ_TEST_BOOL(d.IsHeapAllocated());
+      EZ_TEST_INT(d(0), 666);
+    }
+    EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 2); // value out of scope
+    EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 3);
+    d.Invalidate();
+    EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 3); // lambda destroyed.
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - Copy")
+  {
+    d.Invalidate();
+    ezConstructionCounter::Reset();
+    {
+      ezConstructionCounter value;
+      value.m_iData = 666;
+      EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 1);
+      EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 0);
+      TestDelegate d2 = [value](ezInt32 i) -> ezInt32 { return value.m_iData; };
+      EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 3); // Capture plus moving the lambda.
+      EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 1);  // Move of lambda
+      d = d2;
+      EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 4); // Lambda Copy
+      EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 1);
+      EZ_TEST_BOOL(d.IsValid());
+      EZ_TEST_BOOL(d2.IsValid());
+      EZ_TEST_BOOL(d.IsHeapAllocated());
+      EZ_TEST_BOOL(d2.IsHeapAllocated());
+      EZ_TEST_INT(d(0), 666);
+      EZ_TEST_INT(d2(0), 666);
+    }
+    EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 3); // value and lambda out of scope
+    EZ_TEST_INT(ezConstructionCounter::s_iConstructions, 4);
+    d.Invalidate();
+    EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 4); // lambda destroyed.
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezMakeDelegate")

--- a/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
@@ -309,6 +309,18 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
     EZ_TEST_INT(ezConstructionCounter::s_iDestructions, 4); // lambda destroyed.
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Lambda - capture non-copyable type")
+  {
+    ezUniquePtr<ezConstructionCounter> data(EZ_DEFAULT_NEW(ezConstructionCounter));
+    data->m_iData = 666;
+    TestDelegate d2 = [data = std::move(data)](ezInt32 i) -> ezInt32 { return data->m_iData; };
+    EZ_TEST_INT(d2(0), 666);
+    d = std::move(d2);
+    EZ_TEST_BOOL(d.IsValid());
+    EZ_TEST_BOOL(!d2.IsValid());
+    EZ_TEST_INT(d(0), 666);
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezMakeDelegate")
   {
     auto d1 = ezMakeDelegate(&Function);


### PR DESCRIPTION
ezDelegate now supports lambdas of any size.
    -Any lambda that has captures will be stored in a heap-allocated storage.
    -Correctly handles captures of non-pod data now.
    -Added move semantics.
    -Any lambda that has captures will cause delegate compare to always return false.
    -Changed ezDelegate to use variadic templates.
