### PR TITLE
Rewrote shader parser

### DIFF
--- a/Code/Engine/Foundation/CodeUtils/Implementation/Conditions.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Conditions.cpp
@@ -134,7 +134,7 @@ ezResult ezPreprocessor::ParseFactor(const TokenStream& Tokens, ezUInt32& uiCurT
   }
 
   ezUInt32 uiValueToken = uiCurToken;
-  if (Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiValueToken))
+  if (Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiValueToken) || Accept(Tokens, uiCurToken, ezTokenType::Integer, &uiValueToken))
   {
     const ezString sVal = Tokens[uiValueToken]->m_DataView;
 

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Expand.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Expand.cpp
@@ -190,7 +190,7 @@ ezResult ezPreprocessor::ExpandObjectMacro(MacroDefinition& Macro, TokenStream& 
     sLine.Format("{0}", m_sCurrentFileStack.PeekBack().m_iCurrentLine);
 
     ezToken* pNewToken = AddCustomToken(pMacroToken, sLine);
-    pNewToken->m_iType = ezTokenType::Identifier;
+    pNewToken->m_iType = ezTokenType::Integer;
 
     Output.PushBack(pNewToken);
 
@@ -408,8 +408,8 @@ void ezPreprocessor::MergeTokens(const ezToken* pFirst, const ezToken* pSecond, 
   }
 
   if (pFirst == nullptr || pSecond == nullptr ||
-      pFirst->m_iType != ezTokenType::Identifier ||
-      pSecond->m_iType != ezTokenType::Identifier)
+      (pFirst->m_iType != ezTokenType::Identifier && pFirst->m_iType != ezTokenType::Integer) ||
+      (pSecond->m_iType != ezTokenType::Identifier && pSecond->m_iType != ezTokenType::Integer))
   {
     if (pFirst != nullptr)
       Output.PushBack(pFirst);

--- a/Code/Engine/Foundation/CodeUtils/Implementation/FileHandling.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/FileHandling.cpp
@@ -75,7 +75,7 @@ const ezTokenizer* ezTokenizedFileCache::Tokenize(const ezString& sFileName, ezA
         SkipWhitespace(Tokens, uiNext);
 
         if (uiNext < Tokens.GetCount() &&
-            Tokens[uiNext].m_iType == ezTokenType::Identifier)
+            Tokens[uiNext].m_iType == ezTokenType::Integer)
         {
           ezInt32 iNextLine = 0;
 

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Preprocessor.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Preprocessor.cpp
@@ -324,7 +324,7 @@ ezResult ezPreprocessor::HandleLine(const TokenStream& Tokens, ezUInt32 uiCurTok
     CopyRelevantTokens(Tokens, uiHashToken, TokenOutput, true);
 
   ezUInt32 uiNumberToken = 0;
-  if (Expect(Tokens, uiCurToken, ezTokenType::Identifier, &uiNumberToken).Failed())
+  if (Expect(Tokens, uiCurToken, ezTokenType::Integer, &uiNumberToken).Failed())
     return EZ_FAILURE;
 
   ezInt32 iNextLine = 0;

--- a/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
@@ -156,7 +156,6 @@ namespace ezTokenParseUtils
     }
   }
 
-
   void CreateCleanTokenStream(const TokenStream& Tokens, ezUInt32 uiCurToken, TokenStream& Destination, bool bKeepComments)
   {
     SkipWhitespace(Tokens, uiCurToken);
@@ -178,7 +177,8 @@ namespace ezTokenParseUtils
     }
   }
 
-  void CombineTokensToString(const TokenStream& Tokens0, ezUInt32 uiCurToken, ezStringBuilder& sResult, bool bKeepComments, bool bRemoveRedundantWhitespace, bool bInsertLine)
+  void CombineTokensToString(const TokenStream& Tokens0, ezUInt32 uiCurToken, ezStringBuilder& sResult, bool bKeepComments,
+    bool bRemoveRedundantWhitespace, bool bInsertLine)
   {
     TokenStream Tokens;
 
@@ -236,6 +236,39 @@ namespace ezTokenParseUtils
       sTemp = Tokens[t]->m_DataView;
       sResult.Append(sTemp.GetView());
     }
+  }
+
+  ezResult ParseNumber(const TokenStream& Tokens, ezUInt32& uiCurToken, double& out_fResult)
+  {
+    SkipWhitespace(Tokens, uiCurToken);
+    ezUInt32 uiOldToken = uiCurToken;
+
+    ezStringBuilder sNumber;
+
+    ezUInt32 uiIntegerPart = uiCurToken;
+    if (Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiIntegerPart))
+    {
+      sNumber = Tokens[uiIntegerPart]->m_DataView;
+    }
+    
+    if (Accept(Tokens, uiCurToken, "."))
+    {
+      sNumber.Append(".");
+    }
+
+    ezUInt32 uiFractionalPart = uiCurToken;
+    if (Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiFractionalPart))
+    {
+      sNumber.Append(Tokens[uiFractionalPart]->m_DataView);
+    }
+
+    if (ezConversionUtils::StringToFloat(sNumber, out_fResult).Failed())
+    {
+      uiCurToken = uiOldToken;
+      return EZ_FAILURE;
+    }
+
+    return EZ_SUCCESS;
   }
 }
 

--- a/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
@@ -237,39 +237,6 @@ namespace ezTokenParseUtils
       sResult.Append(sTemp.GetView());
     }
   }
-
-  ezResult ParseNumber(const TokenStream& Tokens, ezUInt32& uiCurToken, double& out_fResult)
-  {
-    SkipWhitespace(Tokens, uiCurToken);
-    ezUInt32 uiOldToken = uiCurToken;
-
-    ezStringBuilder sNumber;
-
-    ezUInt32 uiIntegerPart = uiCurToken;
-    if (Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiIntegerPart))
-    {
-      sNumber = Tokens[uiIntegerPart]->m_DataView;
-    }
-    
-    if (Accept(Tokens, uiCurToken, "."))
-    {
-      sNumber.Append(".");
-    }
-
-    ezUInt32 uiFractionalPart = uiCurToken;
-    if (Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiFractionalPart))
-    {
-      sNumber.Append(Tokens[uiFractionalPart]->m_DataView);
-    }
-
-    if (ezConversionUtils::StringToFloat(sNumber, out_fResult).Failed())
-    {
-      uiCurToken = uiOldToken;
-      return EZ_FAILURE;
-    }
-
-    return EZ_SUCCESS;
-  }
 }
 
 EZ_STATICLINK_FILE(Foundation, Foundation_CodeUtils_Implementation_TokenParseUtils);

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
@@ -402,6 +402,20 @@ void ezTokenizer::HandleNonIdentifier()
   AddToken();
 }
 
+void ezTokenizer::GetAllLines(ezHybridArray<const ezToken*, 32>& Tokens) const
+{
+  Tokens.Clear();
+  Tokens.Reserve(m_Tokens.GetCount());
+
+  for (const ezToken& curToken : m_Tokens)
+  {
+    if (curToken.m_iType != ezTokenType::Newline)
+    {
+      Tokens.PushBack(&curToken);
+    }
+  }
+}
+
 ezResult ezTokenizer::GetNextLine(ezUInt32& uiFirstToken, ezHybridArray<ezToken*, 32>& Tokens)
 {
   Tokens.Clear();

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
@@ -342,7 +342,7 @@ void ezTokenizer::HandleString(char terminator)
 
 void ezTokenizer::HandleNumber()
 {
-  if (m_uiCurChar == '0' && m_uiNextChar == 'x' || m_uiNextChar == 'X')
+  if (m_uiCurChar == '0' && (m_uiNextChar == 'x' || m_uiNextChar == 'X'))
   {
     NextChar();
     NextChar();
@@ -550,7 +550,7 @@ ezResult ezTokenizer::GetNextLine(ezUInt32& uiFirstToken, ezHybridArray<const ez
         {
           ezStringBuilder s1 = m_Tokens[uiFirstToken - 1].m_DataView;
           ezStringBuilder s2 = m_Tokens[uiFirstToken + 2].m_DataView;
-          ezLog::Warning("Line {0}: The \\ at the line end is in the middle of an identifier name ('{1}' and '{2}'). However, merging identifier names is m_uiCurCharly not supported.", m_Tokens[uiFirstToken].m_uiLine, s1, s2);
+          ezLog::Warning("Line {0}: The \\ at the line end is in the middle of an identifier name ('{1}' and '{2}'). However, merging identifier names is currently not supported.", m_Tokens[uiFirstToken].m_uiLine, s1, s2);
         }
 
         // ignore this

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
@@ -239,10 +239,10 @@ void ezTokenizer::HandleUnknown()
     return;
   }
 
-  if (ezStringUtils::IsDecimalDigit(m_uiCurChar) || m_uiCurChar == '.')
+  if (ezStringUtils::IsDecimalDigit(m_uiCurChar) || (m_uiCurChar == '.' && ezStringUtils::IsDecimalDigit(m_uiNextChar)))
   {
     m_CurMode = m_uiCurChar == '.' ? ezTokenType::Float : ezTokenType::Integer;
-    NextChar();
+    // Do not advance to next char here since we need the first character in HandleNumber
     return;
   }
 
@@ -342,8 +342,9 @@ void ezTokenizer::HandleString(char terminator)
 
 void ezTokenizer::HandleNumber()
 {
-  if (m_uiCurChar == 'x' || m_uiCurChar == 'X')
+  if (m_uiCurChar == '0' && m_uiNextChar == 'x' || m_uiNextChar == 'X')
   {
+    NextChar();
     NextChar();
 
     ezUInt32 uiDigitsRead = 0;
@@ -360,6 +361,8 @@ void ezTokenizer::HandleNumber()
   }
   else
   {
+    NextChar();
+
     while (ezStringUtils::IsDecimalDigit(m_uiCurChar))
     {
       NextChar();
@@ -403,6 +406,11 @@ void ezTokenizer::HandleNumber()
         {
           ezLog::Error(m_pLog, "Invalid float literal");
         }
+      }
+
+      if (m_uiCurChar == 'f') // skip float suffix
+      {
+        NextChar();
       }
     }
   }

--- a/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
+++ b/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
@@ -20,7 +20,5 @@ namespace ezTokenParseUtils
   EZ_FOUNDATION_DLL void CombineTokensToString(const TokenStream& Tokens, ezUInt32 uiCurToken, ezStringBuilder& sResult, bool bKeepComments = true, bool bRemoveRedundantWhitespace = false, bool bInsertLine = false);
   EZ_FOUNDATION_DLL void CombineRelevantTokensToString(const TokenStream& Tokens, ezUInt32 uiCurToken, ezStringBuilder& sResult);
   EZ_FOUNDATION_DLL void CreateCleanTokenStream(const TokenStream& Tokens, ezUInt32 uiCurToken, TokenStream& Destination, bool bKeepComments);
-
-  EZ_FOUNDATION_DLL ezResult ParseNumber(const TokenStream& Tokens, ezUInt32& uiCurToken, double& out_fResult);
 }
 

--- a/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
+++ b/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
@@ -7,18 +7,20 @@ namespace ezTokenParseUtils
 {
   typedef ezHybridArray<const ezToken*, 32> TokenStream;
 
-  void SkipWhitespace(const TokenStream& Tokens, ezUInt32& uiCurToken);
-  void SkipWhitespaceAndNewline(const TokenStream& Tokens, ezUInt32& uiCurToken);
-  bool IsEndOfLine(const TokenStream& Tokens, ezUInt32 uiCurToken, bool bIgnoreWhitespace);
-  void CopyRelevantTokens(const TokenStream& Source, ezUInt32 uiFirstSourceToken, TokenStream& Destination, bool bPreserveNewLines);
+  EZ_FOUNDATION_DLL void SkipWhitespace(const TokenStream& Tokens, ezUInt32& uiCurToken);
+  EZ_FOUNDATION_DLL void SkipWhitespaceAndNewline(const TokenStream& Tokens, ezUInt32& uiCurToken);
+  EZ_FOUNDATION_DLL bool IsEndOfLine(const TokenStream& Tokens, ezUInt32 uiCurToken, bool bIgnoreWhitespace);
+  EZ_FOUNDATION_DLL void CopyRelevantTokens(const TokenStream& Source, ezUInt32 uiFirstSourceToken, TokenStream& Destination, bool bPreserveNewLines);
 
-  bool Accept(const TokenStream& Tokens, ezUInt32& uiCurToken, const char* szToken, ezUInt32* pAccepted = nullptr);
-  bool Accept(const TokenStream& Tokens, ezUInt32& uiCurToken, ezTokenType::Enum Type, ezUInt32* pAccepted = nullptr);
-  bool Accept(const TokenStream& Tokens, ezUInt32& uiCurToken, const char* szToken1, const char* szToken2, ezUInt32* pAccepted = nullptr);
-  bool AcceptUnless(const TokenStream& Tokens, ezUInt32& uiCurToken, const char* szToken1, const char* szToken2, ezUInt32* pAccepted = nullptr);
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& Tokens, ezUInt32& uiCurToken, const char* szToken, ezUInt32* pAccepted = nullptr);
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& Tokens, ezUInt32& uiCurToken, ezTokenType::Enum Type, ezUInt32* pAccepted = nullptr);
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& Tokens, ezUInt32& uiCurToken, const char* szToken1, const char* szToken2, ezUInt32* pAccepted = nullptr);
+  EZ_FOUNDATION_DLL bool AcceptUnless(const TokenStream& Tokens, ezUInt32& uiCurToken, const char* szToken1, const char* szToken2, ezUInt32* pAccepted = nullptr);
 
-  void CombineTokensToString(const TokenStream& Tokens, ezUInt32 uiCurToken, ezStringBuilder& sResult, bool bKeepComments = true, bool bRemoveRedundantWhitespace = false, bool bInsertLine = false);
-  void CombineRelevantTokensToString(const TokenStream& Tokens, ezUInt32 uiCurToken, ezStringBuilder& sResult);
-  void CreateCleanTokenStream(const TokenStream& Tokens, ezUInt32 uiCurToken, TokenStream& Destination, bool bKeepComments);
+  EZ_FOUNDATION_DLL void CombineTokensToString(const TokenStream& Tokens, ezUInt32 uiCurToken, ezStringBuilder& sResult, bool bKeepComments = true, bool bRemoveRedundantWhitespace = false, bool bInsertLine = false);
+  EZ_FOUNDATION_DLL void CombineRelevantTokensToString(const TokenStream& Tokens, ezUInt32 uiCurToken, ezStringBuilder& sResult);
+  EZ_FOUNDATION_DLL void CreateCleanTokenStream(const TokenStream& Tokens, ezUInt32 uiCurToken, TokenStream& Destination, bool bKeepComments);
+
+  EZ_FOUNDATION_DLL ezResult ParseNumber(const TokenStream& Tokens, ezUInt32& uiCurToken, double& out_fResult);
 }
 

--- a/Code/Engine/Foundation/CodeUtils/Tokenizer.h
+++ b/Code/Engine/Foundation/CodeUtils/Tokenizer.h
@@ -20,6 +20,8 @@ struct EZ_FOUNDATION_DLL ezTokenType
     BlockComment,  ///< A comment that starts with a slash and a star, and ends at the next star/slash combination (or end of file)
     String1,       ///< A string enclosed in "
     String2,       ///< A string enclosed in '
+    Integer,       ///< An integer number
+    Float,         ///< A floating point number
     EndOfFile,     ///< End-of-file marker
     ENUM_COUNT,
   };
@@ -111,6 +113,7 @@ private:
 
   void HandleUnknown();
   void HandleString(char terminator);
+  void HandleNumber();
   void HandleLineComment();
   void HandleBlockComment();
   void HandleWhitespace();

--- a/Code/Engine/Foundation/CodeUtils/Tokenizer.h
+++ b/Code/Engine/Foundation/CodeUtils/Tokenizer.h
@@ -85,6 +85,9 @@ public:
   /// \brief Gives read and write access to the token stream.
   ezDeque<ezToken>& GetTokens() { return m_Tokens; }
 
+  /// \brief Returns an array of all tokens. New line tokens are ignored.
+  void GetAllLines(ezHybridArray<const ezToken*, 32>& Tokens) const;
+
   /// \brief Returns an array of tokens that represent the next line in the file.
   ///
   /// Returns EZ_SUCCESS when there was more data to return, EZ_FAILURE if the end of the file was reached already.

--- a/Code/Engine/Foundation/Strings/Implementation/StringUtils_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringUtils_inl.h
@@ -125,3 +125,13 @@ EZ_ALWAYS_INLINE bool ezStringUtils::IsEqualN_NoCase(const char* pString1, const
   return ezStringUtils::CompareN_NoCase(pString1, pString2, uiCharsToCompare, pString1End, pString2End) == 0;
 }
 
+EZ_ALWAYS_INLINE bool ezStringUtils::IsDecimalDigit(ezUInt32 uiChar)
+{
+  return (uiChar >= '0' && uiChar <= '9');
+}
+
+EZ_ALWAYS_INLINE bool ezStringUtils::IsHexDigit(ezUInt32 uiChar)
+{
+  return IsDecimalDigit(uiChar) || (uiChar >= 'A' && uiChar <= 'F') || (uiChar >= 'a' && uiChar <= 'f');
+}
+

--- a/Code/Engine/Foundation/Strings/StringUtils.h
+++ b/Code/Engine/Foundation/Strings/StringUtils.h
@@ -243,6 +243,12 @@ public:
   /// '\v' (vertical tab)
   static bool IsWhiteSpace(ezUInt32 uiChar); // [tested]
 
+  /// \brief A decimal digit from 0..9
+  static bool IsDecimalDigit(ezUInt32 uiChar); // [tested]
+
+  /// \brief A hexadecimal digit from 0..F
+  static bool IsHexDigit(ezUInt32 uiChar); // [tested]
+
   /// \brief A default word delimiter function for English text.
   static bool IsWordDelimiter_English(ezUInt32 uiChar); // [tested]
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
@@ -141,9 +141,9 @@ void ezShaderManager::ReloadPermutationVarConfig(const char* szName, const ezTem
   }
 
   ezVariant defaultValue;
-  ezHybridArray<ezHashedString, 16> enumValues;
+  ezShaderParser::EnumDefinition enumDef;
 
-  ezShaderParser::ParsePermutationVarConfig(szName, sTemp, defaultValue, enumValues);
+  ezShaderParser::ParsePermutationVarConfig(sTemp, defaultValue, enumDef);
   if (defaultValue.IsValid())
   {
     ezHashedString sName;
@@ -152,7 +152,7 @@ void ezShaderManager::ReloadPermutationVarConfig(const char* szName, const ezTem
     auto& config = s_PermutationVarConfigs[sName];
     config.m_sName = sName;
     config.m_DefaultValue = defaultValue;
-    config.m_EnumValues = enumValues;
+    config.m_EnumValues = enumDef.m_Values;
   }
 }
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -60,6 +60,33 @@ namespace
       return ezVariant(sValue.GetData());
     }
 
+    if (Accept(Tokens, uiCurToken, ezTokenType::Integer, &uiValueToken))
+    {
+      ezString sValue = Tokens[uiValueToken]->m_DataView;
+
+      ezInt64 iValue = 0;
+      if (sValue.StartsWith_NoCase("0x"))
+      {
+        iValue = ezConversionUtils::ConvertHexStringToUInt32(sValue);
+      }
+      else
+      {
+        ezConversionUtils::StringToInt64(sValue, iValue);
+      }
+
+      return ezVariant(iValue);
+    }
+
+    if (Accept(Tokens, uiCurToken, ezTokenType::Float, &uiValueToken))
+    {
+      ezString sValue = Tokens[uiValueToken]->m_DataView;
+
+      double fValue = 0;
+      ezConversionUtils::StringToFloat(sValue, fValue);
+
+      return ezVariant(fValue);
+    }
+
     if (Accept(Tokens, uiCurToken, "true", "false", &uiValueToken))
     {
       bool bValue = Tokens[uiValueToken]->m_DataView == "true";
@@ -132,12 +159,6 @@ namespace
           }
         }
       }
-    }
-
-    double fValue = 0;
-    if (ParseNumber(Tokens, uiCurToken, fValue).Succeeded())
-    {
-      return ezVariant(fValue);
     }
 
     return ezVariant();
@@ -248,7 +269,7 @@ namespace
       if (Accept(Tokens, uiCurToken, "="))
       {
         ezUInt32 uiValueToken = uiCurToken;
-        Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiValueToken);
+        Accept(Tokens, uiCurToken, ezTokenType::Integer, &uiValueToken);
 
         ezInt32 iValue = 0;
         if (ezConversionUtils::StringToInt(Tokens[uiValueToken]->m_DataView.GetData(), iValue).Succeeded() && iValue >= 0)

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -314,7 +314,7 @@ namespace
       }
     }
 
-    out_EnumDefinition.m_DefaultValue = uiDefaultValue;
+    out_EnumDefinition.m_uiDefaultValue = uiDefaultValue;
 
     if (!Accept(Tokens, uiCurToken, "}"))
     {
@@ -505,7 +505,7 @@ void ezShaderParser::ParsePermutationVarConfig(ezStringView s, ezVariant& out_De
     ezUInt32 uiCurToken = 0;
     ParseEnum(tokens, uiCurToken, out_EnumDefinition);
 
-    out_DefaultValue = out_EnumDefinition.m_DefaultValue;
+    out_DefaultValue = out_EnumDefinition.m_uiDefaultValue;
   }
   else
   {

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -87,7 +87,7 @@ namespace
       return ezVariant(fValue);
     }
 
-    if (Accept(Tokens, uiCurToken, "true", "false", &uiValueToken))
+    if (Accept(Tokens, uiCurToken, "true", &uiValueToken) || Accept(Tokens, uiCurToken, "false", &uiValueToken))
     {
       bool bValue = Tokens[uiValueToken]->m_DataView == "true";
       return ezVariant(bValue);

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -1,5 +1,6 @@
 #include <RendererCorePCH.h>
 
+#include <Foundation/CodeUtils/TokenParseUtils.h>
 #include <Foundation/CodeUtils/Tokenizer.h>
 #include <Foundation/Types/Variant.h>
 #include <Foundation/Utilities/ConversionUtils.h>
@@ -7,9 +8,303 @@
 #include <RendererCore/ShaderCompiler/ShaderManager.h>
 #include <RendererCore/ShaderCompiler/ShaderParser.h>
 
+using namespace ezTokenParseUtils;
+
 namespace
 {
-  bool IsIdentifier(ezUInt32 c) { return !ezStringUtils::IsIdentifierDelimiter_C_Code(c); }
+  static ezHashTable<ezStringView, const ezRTTI*> s_NameToTypeTable;
+
+  void InitializeTables()
+  {
+    if (!s_NameToTypeTable.IsEmpty())
+      return;
+
+    s_NameToTypeTable.Insert("float", ezGetStaticRTTI<float>());
+    s_NameToTypeTable.Insert("float2", ezGetStaticRTTI<ezVec2>());
+    s_NameToTypeTable.Insert("float3", ezGetStaticRTTI<ezVec3>());
+    s_NameToTypeTable.Insert("float4", ezGetStaticRTTI<ezVec4>());
+    s_NameToTypeTable.Insert("int", ezGetStaticRTTI<int>());
+    s_NameToTypeTable.Insert("int2", ezGetStaticRTTI<ezVec2I32>());
+    s_NameToTypeTable.Insert("int3", ezGetStaticRTTI<ezVec3I32>());
+    s_NameToTypeTable.Insert("int4", ezGetStaticRTTI<ezVec4I32>());
+    s_NameToTypeTable.Insert("uint", ezGetStaticRTTI<ezUInt32>());
+    s_NameToTypeTable.Insert("uint2", ezGetStaticRTTI<ezVec2U32>());
+    s_NameToTypeTable.Insert("uint3", ezGetStaticRTTI<ezVec3U32>());
+    s_NameToTypeTable.Insert("uint4", ezGetStaticRTTI<ezVec4U32>());
+    s_NameToTypeTable.Insert("bool", ezGetStaticRTTI<bool>());
+    s_NameToTypeTable.Insert("Color", ezGetStaticRTTI<ezColor>());
+    /// \todo Are we going to support linear UB colors ?
+    s_NameToTypeTable.Insert("Texture2D", ezGetStaticRTTI<ezString>());
+    s_NameToTypeTable.Insert("Texture3D", ezGetStaticRTTI<ezString>());
+    s_NameToTypeTable.Insert("TextureCube", ezGetStaticRTTI<ezString>());
+  }
+
+  const ezRTTI* GetType(ezStringView sType)
+  {
+    InitializeTables();
+
+    const ezRTTI* pType = nullptr;
+    s_NameToTypeTable.TryGetValue(sType, pType);
+    return pType;
+  }
+
+  ezVariant ParseValue(const TokenStream& Tokens, ezUInt32& uiCurToken)
+  {
+    ezUInt32 uiValueToken = uiCurToken;
+
+    if (Accept(Tokens, uiCurToken, ezTokenType::String1, &uiValueToken) || Accept(Tokens, uiCurToken, ezTokenType::String2, &uiValueToken))
+    {
+      ezStringBuilder sValue = Tokens[uiValueToken]->m_DataView;
+      sValue.Trim("\"'");
+
+      return ezVariant(sValue.GetData());
+    }
+
+    if (Accept(Tokens, uiCurToken, "true", "false", &uiValueToken))
+    {
+      bool bValue = Tokens[uiValueToken]->m_DataView == "true";
+      return ezVariant(bValue);
+    }
+
+    auto& dataView = Tokens[uiCurToken]->m_DataView;
+    if (Tokens[uiCurToken]->m_iType == ezTokenType::Identifier &&
+        ezStringUtils::IsValidIdentifierName(dataView.GetStartPosition(), dataView.GetEndPosition()))
+    {
+      // complex type constructor
+      const ezRTTI* pType = nullptr;
+      if (!s_NameToTypeTable.TryGetValue(dataView, pType))
+      {
+        ezLog::Error("Invalid type name '{}'", dataView);
+        return ezVariant();
+      }
+
+      ++uiCurToken;
+      Accept(Tokens, uiCurToken, "(");
+
+      ezHybridArray<ezVariant, 8> constructorArgs;
+
+      while (!Accept(Tokens, uiCurToken, ")"))
+      {
+        ezVariant value = ParseValue(Tokens, uiCurToken);
+        if (value.IsValid())
+        {
+          constructorArgs.PushBack(value);
+        }
+        else
+        {
+          ezLog::Error("Invalid arguments for constructor '{}'", pType->GetTypeName());
+          return EZ_FAILURE;
+        }
+
+        Accept(Tokens, uiCurToken, ",");
+      }
+
+      // find matching constructor
+      auto& functions = pType->GetFunctions();
+      for (auto pFunc : functions)
+      {
+        if (pFunc->GetFunctionType() == ezFunctionType::Constructor && pFunc->GetArgumentCount() == constructorArgs.GetCount())
+        {
+          ezHybridArray<ezVariant, 8> convertedArgs;
+          bool bAllArgsValid = true;
+
+          for (ezUInt32 uiArg = 0; uiArg < pFunc->GetArgumentCount(); ++uiArg)
+          {
+            const ezRTTI* pArgType = pFunc->GetArgumentType(uiArg);
+            ezResult conversionResult = EZ_FAILURE;
+            convertedArgs.PushBack(constructorArgs[uiArg].ConvertTo(pArgType->GetVariantType(), &conversionResult));
+            if (conversionResult.Failed())
+            {
+              bAllArgsValid = false;
+              break;
+            }
+          }
+
+          if (bAllArgsValid)
+          {
+            ezVariant result;
+            pFunc->Execute(nullptr, convertedArgs, result);
+
+            if (result.IsValid())
+            {
+              return result;
+            }
+          }
+        }
+      }
+    }
+
+    double fValue = 0;
+    if (ParseNumber(Tokens, uiCurToken, fValue).Succeeded())
+    {
+      return ezVariant(fValue);
+    }
+
+    return ezVariant();
+  }
+
+  ezResult ParseAttribute(const TokenStream& Tokens, ezUInt32& uiCurToken, ezShaderParser::ParameterDefinition& out_ParameterDefinition)
+  {
+    if (!Accept(Tokens, uiCurToken, "@"))
+    {
+      return EZ_FAILURE;
+    }
+
+    ezUInt32 uiTypeToken = uiCurToken;
+    if (!Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiTypeToken))
+    {
+      return EZ_FAILURE;
+    }
+
+    ezShaderParser::AttributeDefinition& attributeDef = out_ParameterDefinition.m_Attributes.ExpandAndGetRef();
+    attributeDef.m_sType = Tokens[uiTypeToken]->m_DataView;
+
+    Accept(Tokens, uiCurToken, "(");
+
+    while (!Accept(Tokens, uiCurToken, ")"))
+    {
+      ezVariant value = ParseValue(Tokens, uiCurToken);
+      if (value.IsValid())
+      {
+        attributeDef.m_Values.PushBack(value);
+      }
+      else
+      {
+        ezLog::Error("Invalid arguments for attribute '{}'", attributeDef.m_sType);
+        return EZ_FAILURE;
+      }
+
+      Accept(Tokens, uiCurToken, ",");
+    }
+
+    return EZ_SUCCESS;
+  }
+
+  ezResult ParseParameter(const TokenStream& Tokens, ezUInt32& uiCurToken, ezShaderParser::ParameterDefinition& out_ParameterDefinition)
+  {
+    ezUInt32 uiTypeToken = uiCurToken;
+    if (!Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiTypeToken))
+    {
+      return EZ_FAILURE;
+    }
+
+    out_ParameterDefinition.m_sType = Tokens[uiTypeToken]->m_DataView;
+    out_ParameterDefinition.m_pType = GetType(out_ParameterDefinition.m_sType);
+
+    ezUInt32 uiNameToken = uiCurToken;
+    if (!Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiNameToken))
+    {
+      return EZ_FAILURE;
+    }
+
+    out_ParameterDefinition.m_sName = Tokens[uiNameToken]->m_DataView;
+
+    while (!Accept(Tokens, uiCurToken, ";"))
+    {
+      if (ParseAttribute(Tokens, uiCurToken, out_ParameterDefinition).Failed())
+      {
+        return EZ_FAILURE;
+      }
+    }
+
+    return EZ_SUCCESS;
+  }
+
+  ezResult ParseEnum(const TokenStream& Tokens, ezUInt32& uiCurToken, ezShaderParser::EnumDefinition& out_EnumDefinition)
+  {
+    if (!Accept(Tokens, uiCurToken, "enum"))
+    {
+      return EZ_FAILURE;
+    }
+
+    ezUInt32 uiNameToken = uiCurToken;
+    if (!Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiNameToken))
+    {
+      return EZ_FAILURE;
+    }
+
+    out_EnumDefinition.m_sName = Tokens[uiNameToken]->m_DataView;
+    ezStringBuilder sEnumPrefix(out_EnumDefinition.m_sName, "_");
+
+    if (!Accept(Tokens, uiCurToken, "{"))
+    {
+      ezLog::Error("Opening bracket expected for enum definition.");
+      return EZ_FAILURE;
+    }
+
+    ezUInt32 uiDefaultValue = 0;
+    ezUInt32 uiCurrentValue = 0;
+
+    while (true)
+    {
+      ezUInt32 uiValueNameToken = uiCurToken;
+      if (!Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiValueNameToken))
+      {
+        return EZ_FAILURE;
+      }
+
+      ezStringView sValueName = Tokens[uiValueNameToken]->m_DataView;
+
+      if (Accept(Tokens, uiCurToken, "="))
+      {
+        ezUInt32 uiValueToken = uiCurToken;
+        Accept(Tokens, uiCurToken, ezTokenType::Identifier, &uiValueToken);
+
+        ezInt32 iValue = 0;
+        if (ezConversionUtils::StringToInt(Tokens[uiValueToken]->m_DataView.GetData(), iValue).Succeeded() && iValue >= 0)
+        {
+          uiCurrentValue = iValue;
+        }
+        else
+        {
+          ezLog::Error("Invalid enum value '{0}'. Only positive numbers are allowed.", Tokens[uiValueToken]->m_DataView);
+        }
+      }
+
+      if (sValueName.IsEqual_NoCase("default"))
+      {
+        uiDefaultValue = uiCurrentValue;
+      }
+
+      if (!sValueName.StartsWith(sEnumPrefix))
+      {
+        ezLog::Error("Enum value does not start with the expected enum name as prefix: '{0}'", sEnumPrefix);
+      }
+
+      out_EnumDefinition.m_Values.EnsureCount(uiCurrentValue + 1);
+
+      if (ezStringUtils::IsNullOrEmpty(out_EnumDefinition.m_Values[uiCurrentValue].GetData()))
+      {
+        const ezStringBuilder sFinalName = sValueName;
+        out_EnumDefinition.m_Values[uiCurrentValue].Assign(sFinalName.GetData());
+      }
+      else
+      {
+        ezLog::Error("A enum value with '{0}' already exists: '{1}'", uiCurrentValue, out_EnumDefinition.m_Values[uiCurrentValue]);
+      }
+
+      if (Accept(Tokens, uiCurToken, ","))
+      {
+        ++uiCurrentValue;
+      }
+      else
+      {
+        break;
+      }
+    }
+
+    out_EnumDefinition.m_DefaultValue = uiDefaultValue;
+
+    if (!Accept(Tokens, uiCurToken, "}"))
+    {
+      ezLog::Error("Closing bracket expected for enum definition.");
+      return EZ_FAILURE;
+    }
+
+    Accept(Tokens, uiCurToken, ";");
+
+    return EZ_SUCCESS;
+  }
 
   void SkipWhitespace(ezStringView& s)
   {
@@ -18,78 +313,11 @@ namespace
       ++s;
     }
   }
-
-  void ParseAttribute(ezStringView& s, ezShaderParser::ParameterDefinition& def)
-  {
-    SkipWhitespace(s);
-
-    if (!s.IsValid() || s.GetCharacter() != '@')
-      return;
-
-    ++s; // skip @
-
-    const char* szNameStart = s.GetData();
-    while (s.IsValid() && IsIdentifier(s.GetCharacter()))
-    {
-      ++s;
-    }
-
-    ezShaderParser::AttributeDefinition attributeDef;
-    attributeDef.m_sName = ezStringView(szNameStart, s.GetData());
-
-    SkipWhitespace(s);
-
-    if (!s.IsValid() || s.GetCharacter() != '(')
-      return;
-
-    ++s; // skip (
-    int braces = 0;
-
-    const char* szValueStart = s.GetData();
-    while (s.IsValid())
-    {
-      if (s.GetCharacter() == '(')
-      {
-        braces++;
-
-        ++s; // skip (
-        szValueStart = s.GetData();
-      }
-      else
-      {
-        if (s.GetCharacter() == ')')
-        {
-          if (braces == 0)
-            break;
-          braces--;
-        }
-        ++s;
-      }
-    }
-
-    if (!s.IsValid() || s.GetCharacter() != ')')
-      return;
-
-    ezStringView view = ezStringView(szValueStart, s.GetData());
-
-    ++s; // skip )
-
-    // remove " at the start and end of the string, if given
-    if (view.StartsWith("\""))
-      view.Shrink(1, 0);
-    if (view.EndsWith("\""))
-      view.Shrink(0, 1);
-
-    attributeDef.m_sValue = view;
-    if (!def.m_sName.IsEmpty())
-    {
-      def.m_Attributes.PushBack(attributeDef);
-    }
-  }
 } // namespace
 
 // static
-void ezShaderParser::ParseMaterialParameterSection(ezStreamReader& stream, ezHybridArray<ParameterDefinition, 16>& out_Parameter)
+void ezShaderParser::ParseMaterialParameterSection(
+  ezStreamReader& stream, ezHybridArray<ParameterDefinition, 16>& out_Parameter, ezHybridArray<EnumDefinition, 4>& out_EnumDefinitions)
 {
   ezString sContent;
   sContent.ReadAll(stream);
@@ -100,64 +328,38 @@ void ezShaderParser::ParseMaterialParameterSection(ezStreamReader& stream, ezHyb
   ezUInt32 uiFirstLine = 0;
   ezStringView s = Sections.GetSectionContent(ezShaderHelper::ezShaderSections::MATERIALPARAMETER, uiFirstLine);
 
-  SkipWhitespace(s);
+  ezTokenizer tokenizer;
+  tokenizer.Tokenize(ezArrayPtr<const ezUInt8>((const ezUInt8*)s.GetData(), s.GetElementCount()), ezLog::GetThreadLocalLogSystem());
 
-  while (s.IsValid())
+  TokenStream tokens;
+  tokenizer.GetAllLines(tokens);
+
+  ezUInt32 uiCurToken = 0;
+
+  while (!Accept(tokens, uiCurToken, ezTokenType::EndOfFile))
   {
-    const char* szCurrentStart = s.GetData();
-
-    const char* szTypeStart = s.GetData();
-    while (s.IsValid() && IsIdentifier(s.GetCharacter()))
+    EnumDefinition enumDef;
+    if (ParseEnum(tokens, uiCurToken, enumDef).Succeeded())
     {
-      ++s;
+      out_EnumDefinitions.PushBack(std::move(enumDef));
+      continue;
     }
 
-    ParameterDefinition def;
-    def.m_sType = ezStringView(szTypeStart, s.GetData());
-
-    SkipWhitespace(s);
-
-    const char* szNameStart = s.GetData();
-    while (s.IsValid() && IsIdentifier(s.GetCharacter()))
+    ParameterDefinition paramDef;
+    if (ParseParameter(tokens, uiCurToken, paramDef).Succeeded())
     {
-      ++s;
+      out_Parameter.PushBack(std::move(paramDef));
+      continue;
     }
 
-    def.m_sName = ezStringView(szNameStart, s.GetData());
-
-    SkipWhitespace(s);
-
-    while (s.IsValid() && s.GetCharacter() == '@')
-    {
-      ParseAttribute(s, def);
-
-      SkipWhitespace(s);
-    }
-
-    if (!s.IsValid())
-      break;
-
-    if (s.GetCharacter() == ';')
-      ++s; // skip ;
-
-    if (!def.m_sType.IsEmpty() && !def.m_sName.IsEmpty())
-    {
-      out_Parameter.PushBack(def);
-    }
-
-    SkipWhitespace(s);
-
-    if (szCurrentStart == s.GetData()) // no change -> parsing error
-    {
-      ezLog::Error("Error parsing material parameter section of shader");
-      break;
-    }
+    ezLog::Error("Invalid token in material parameter section '{}'", tokens[uiCurToken]->m_DataView);
+    break;
   }
 }
 
 // static
-void ezShaderParser::ParsePermutationSection(ezStreamReader& stream, ezHybridArray<ezHashedString, 16>& out_PermVars,
-                                             ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars)
+void ezShaderParser::ParsePermutationSection(
+  ezStreamReader& stream, ezHybridArray<ezHashedString, 16>& out_PermVars, ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars)
 {
   ezString sContent;
   sContent.ReadAll(stream);
@@ -171,8 +373,8 @@ void ezShaderParser::ParsePermutationSection(ezStreamReader& stream, ezHybridArr
 }
 
 // static
-void ezShaderParser::ParsePermutationSection(ezStringView s, ezHybridArray<ezHashedString, 16>& out_PermVars,
-                                             ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars)
+void ezShaderParser::ParsePermutationSection(
+  ezStringView s, ezHybridArray<ezHashedString, 16>& out_PermVars, ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars)
 {
   out_PermVars.Clear();
   out_FixedPermVars.Clear();
@@ -254,8 +456,7 @@ void ezShaderParser::ParsePermutationSection(ezStringView s, ezHybridArray<ezHas
 }
 
 // static
-void ezShaderParser::ParsePermutationVarConfig(const char* szPermVarName, ezStringView s, ezVariant& out_DefaultValue,
-                                               ezHybridArray<ezHashedString, 16>& out_EnumValues)
+void ezShaderParser::ParsePermutationVarConfig(ezStringView s, ezVariant& out_DefaultValue, EnumDefinition& out_EnumDefinition)
 {
   SkipWhitespace(s);
 
@@ -274,78 +475,16 @@ void ezShaderParser::ParsePermutationVarConfig(const char* szPermVarName, ezStri
   }
   else if (s.StartsWith("enum"))
   {
-    const ezStringBuilder sEnumPrefix(szPermVarName, "_");
+    ezTokenizer tokenizer;
+    tokenizer.Tokenize(ezArrayPtr<const ezUInt8>((const ezUInt8*)s.GetData(), s.GetElementCount()), ezLog::GetThreadLocalLogSystem());
 
-    const char* szOpenBracket = s.FindSubString("{");
-    const char* szCloseBracket = s.FindLastSubString("}");
+    TokenStream tokens;
+    tokenizer.GetAllLines(tokens);
 
-    if (ezStringUtils::IsNullOrEmpty(szOpenBracket) || ezStringUtils::IsNullOrEmpty(szCloseBracket))
-    {
-      ezLog::Error("No brackets found for enum definition.");
-    }
+    ezUInt32 uiCurToken = 0;
+    ParseEnum(tokens, uiCurToken, out_EnumDefinition);
 
-    ezStringBuilder sEnumValues = ezStringView(szOpenBracket + 1, szCloseBracket);
-
-    ezHybridArray<ezStringView, 32> enumValues;
-    sEnumValues.Split(false, enumValues, ",");
-
-    ezUInt32 uiDefaultValue = 0;
-    ezUInt32 uiCurrentValue = 0;
-    for (ezStringView& sName : enumValues)
-    {
-      sName.Trim(" \r\n\t");
-
-      if (sName.IsEmpty())
-        continue;
-
-      const char* szValue = sName.FindSubString("=");
-      if (!ezStringUtils::IsNullOrEmpty(szValue))
-      {
-        // this feature seems to be unused at the moment
-
-        sName = ezStringView(sName.GetStartPosition(), szValue);
-        sName.Trim(" \r\n\t");
-
-        ++szValue;
-
-        ezInt32 iValue = 0;
-        if (ezConversionUtils::StringToInt(szValue, iValue).Succeeded() && iValue >= 0)
-        {
-          uiCurrentValue = iValue;
-        }
-        else
-        {
-          ezLog::Error("Invalid enum value '{0}'. Only positive numbers are allowed.", szValue);
-        }
-      }
-
-      // this feature seems to be unused at the moment
-      if (sName.IsEqual_NoCase("default"))
-      {
-        uiDefaultValue = uiCurrentValue;
-      }
-
-      if (!sName.StartsWith(sEnumPrefix))
-      {
-        ezLog::Error("Enum value does not start with the expected enum name as prefix: '{0}'", sEnumPrefix);
-      }
-
-      out_EnumValues.EnsureCount(uiCurrentValue + 1);
-
-      if (ezStringUtils::IsNullOrEmpty(out_EnumValues[uiCurrentValue].GetData()))
-      {
-        const ezStringBuilder sFinalName = sName;
-        out_EnumValues[uiCurrentValue].Assign(sFinalName.GetData());
-      }
-      else
-      {
-        ezLog::Error("A enum value with '{0}' already exists: '{1}'", uiCurrentValue, out_EnumValues[uiCurrentValue]);
-      }
-
-      ++uiCurrentValue;
-    }
-
-    out_DefaultValue = uiDefaultValue;
+    out_DefaultValue = out_EnumDefinition.m_DefaultValue;
   }
   else
   {
@@ -356,4 +495,3 @@ void ezShaderParser::ParsePermutationVarConfig(const char* szPermVarName, ezStri
 
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_ShaderCompiler_Implementation_ShaderParser);
-

--- a/Code/Engine/RendererCore/ShaderCompiler/ShaderParser.h
+++ b/Code/Engine/RendererCore/ShaderCompiler/ShaderParser.h
@@ -26,7 +26,7 @@ public:
   struct EnumDefinition
   {
     ezString m_sName;
-    ezVariant m_DefaultValue;
+    ezUInt32 m_uiDefaultValue;
     ezHybridArray<ezHashedString, 16> m_Values;
   };
 

--- a/Code/Engine/RendererCore/ShaderCompiler/ShaderParser.h
+++ b/Code/Engine/RendererCore/ShaderCompiler/ShaderParser.h
@@ -1,33 +1,43 @@
 #pragma once
 
-#include <RendererCore/Declarations.h>
 #include <Foundation/Strings/String.h>
+#include <RendererCore/Declarations.h>
 
 class ezPropertyAttribute;
 
 class EZ_RENDERERCORE_DLL ezShaderParser
 {
 public:
-
   struct AttributeDefinition
   {
-    ezString m_sName;
-    ezString m_sValue;
+    ezString m_sType;
+    ezHybridArray<ezVariant, 8> m_Values;
   };
 
   struct ParameterDefinition
   {
+    const ezRTTI* m_pType = nullptr;
     ezString m_sType;
     ezString m_sName;
 
     ezHybridArray<AttributeDefinition, 4> m_Attributes;
   };
 
-  static void ParseMaterialParameterSection(ezStreamReader& stream, ezHybridArray<ParameterDefinition, 16>& out_Parameter);
+  struct EnumDefinition
+  {
+    ezString m_sName;
+    ezVariant m_DefaultValue;
+    ezHybridArray<ezHashedString, 16> m_Values;
+  };
 
-  static void ParsePermutationSection(ezStreamReader& stream, ezHybridArray<ezHashedString, 16>& out_PermVars, ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars);
-  static void ParsePermutationSection(ezStringView sPermutationSection, ezHybridArray<ezHashedString, 16>& out_PermVars, ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars);
+  static void ParseMaterialParameterSection(
+    ezStreamReader& stream, ezHybridArray<ParameterDefinition, 16>& out_Parameter, ezHybridArray<EnumDefinition, 4>& out_EnumDefinitions);
 
-  static void ParsePermutationVarConfig(const char* szPermVarName, ezStringView sPermutationVarConfig, ezVariant& out_DefaultValue, ezHybridArray<ezHashedString, 16>& out_EnumValues);
+  static void ParsePermutationSection(
+    ezStreamReader& stream, ezHybridArray<ezHashedString, 16>& out_PermVars, ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars);
+  static void ParsePermutationSection(ezStringView sPermutationSection, ezHybridArray<ezHashedString, 16>& out_PermVars,
+    ezHybridArray<ezPermutationVar, 16>& out_FixedPermVars);
+
+  static void ParsePermutationVarConfig(
+    ezStringView sPermutationVarConfig, ezVariant& out_DefaultValue, EnumDefinition& out_EnumDefinition);
 };
-

--- a/Code/Tools/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/Tools/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -45,36 +45,9 @@ namespace
     const ezRTTI* m_pType;
   };
 
-  static ezHashTable<const char*, const ezRTTI*> s_NameToTypeTable;
-
-  void InitializeTables()
-  {
-    if (!s_NameToTypeTable.IsEmpty())
-      return;
-
-    s_NameToTypeTable.Insert("float", ezGetStaticRTTI<float>());
-    s_NameToTypeTable.Insert("float2", ezGetStaticRTTI<ezVec2>());
-    s_NameToTypeTable.Insert("float3", ezGetStaticRTTI<ezVec3>());
-    s_NameToTypeTable.Insert("float4", ezGetStaticRTTI<ezVec4>());
-    s_NameToTypeTable.Insert("int", ezGetStaticRTTI<int>());
-    s_NameToTypeTable.Insert("int2", ezGetStaticRTTI<ezVec2I32>());
-    s_NameToTypeTable.Insert("int3", ezGetStaticRTTI<ezVec3I32>());
-    s_NameToTypeTable.Insert("int4", ezGetStaticRTTI<ezVec4I32>());
-    s_NameToTypeTable.Insert("uint", ezGetStaticRTTI<ezUInt32>());
-    s_NameToTypeTable.Insert("uint2", ezGetStaticRTTI<ezVec2U32>());
-    s_NameToTypeTable.Insert("uint3", ezGetStaticRTTI<ezVec3U32>());
-    s_NameToTypeTable.Insert("uint4", ezGetStaticRTTI<ezVec4U32>());
-    s_NameToTypeTable.Insert("bool", ezGetStaticRTTI<bool>());
-    s_NameToTypeTable.Insert("Color", ezGetStaticRTTI<ezColor>());
-    /// \todo Are we going to support linear UB colors ?
-    s_NameToTypeTable.Insert("Texture2D", ezGetStaticRTTI<ezString>());
-    s_NameToTypeTable.Insert("Texture3D", ezGetStaticRTTI<ezString>());
-    s_NameToTypeTable.Insert("TextureCube", ezGetStaticRTTI<ezString>());
-  }
-
   static ezHashTable<ezString, PermutationVarConfig> s_PermutationVarConfigs;
 
-  const ezRTTI* GetPermutationType(ezShaderParser::ParameterDefinition& def)
+  const ezRTTI* GetPermutationType(const ezShaderParser::ParameterDefinition& def)
   {
     EZ_ASSERT_DEV(def.m_sType.IsEqual("Permutation"), "");
 
@@ -99,9 +72,9 @@ namespace
     sTemp.ReadAll(file);
 
     ezVariant defaultValue;
-    ezHybridArray<ezHashedString, 16> enumValues;
+    ezShaderParser::EnumDefinition enumDefinition;
 
-    ezShaderParser::ParsePermutationVarConfig(def.m_sName, sTemp, defaultValue, enumValues);
+    ezShaderParser::ParsePermutationVarConfig(sTemp, defaultValue, enumDefinition);
     if (defaultValue.IsValid())
     {
       pConfig = &(s_PermutationVarConfigs[def.m_sName]);
@@ -128,13 +101,13 @@ namespace
 
         descEnum.m_Properties.PushBack(ezReflectedPropertyDescriptor(sEnumName, defaultValue.Get<ezUInt32>(), noAttributes));
 
-        for (ezUInt32 i = 0; i < enumValues.GetCount(); ++i)
+        for (ezUInt32 i = 0; i < enumDefinition.m_Values.GetCount(); ++i)
         {
-          if (enumValues[i].IsEmpty())
+          if (enumDefinition.m_Values[i].IsEmpty())
             continue;
 
           ezStringBuilder sEnumName;
-          sEnumName.Format("{0}::{1}", def.m_sName, enumValues[i]);
+          sEnumName.Format("{0}::{1}", def.m_sName, enumDefinition.m_Values[i]);
 
           descEnum.m_Properties.PushBack(ezReflectedPropertyDescriptor(sEnumName, (ezUInt32)i, noAttributes));
         }
@@ -148,24 +121,40 @@ namespace
     return nullptr;
   }
 
-  const ezRTTI* GetType(ezShaderParser::ParameterDefinition& def)
+  const ezRTTI* GetType(const ezShaderParser::ParameterDefinition& def)
   {
-    InitializeTables();
+    if (def.m_pType != nullptr)
+    {
+      return def.m_pType;
+    }
 
     if (def.m_sType.IsEqual("Permutation"))
     {
       return GetPermutationType(def);
     }
 
-    const ezRTTI* pType = nullptr;
-    s_NameToTypeTable.TryGetValue(def.m_sType.GetData(), pType);
-    return pType;
+    return nullptr;
   }
 
   void AddAttributes(ezShaderParser::ParameterDefinition& def, const ezRTTI* pType, ezHybridArray<ezPropertyAttribute*, 2>& attributes)
   {
     if (def.m_sType.StartsWith_NoCase("texture"))
     {
+      if (def.m_sType.IsEqual("Texture2D"))
+      {
+        attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 2D"));
+        attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "Texture 2D;Render Target"));
+      }
+      else if (def.m_sType.IsEqual("Texture3D"))
+      {
+        attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 3D"));
+        attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "Texture 3D"));
+      }
+      else if (def.m_sType.IsEqual("TextureCube"))
+      {
+        attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture Cube"));
+        attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "Texture Cube"));
+      }
     }
     else if (def.m_sType.StartsWith_NoCase("permutation"))
     {
@@ -176,88 +165,28 @@ namespace
       attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Constant"));
     }
 
-    if (def.m_sType.IsEqual("Texture2D"))
-    {
-      attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 2D"));
-      attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "Texture 2D;Render Target"));
-    }
-    else if (def.m_sType.IsEqual("Texture3D"))
-    {
-      attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 3D"));
-      attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "Texture 3D"));
-    }
-    else if (def.m_sType.IsEqual("TextureCube"))
-    {
-      attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture Cube"));
-      attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "Texture Cube"));
-    }
-
     for (auto& attributeDef : def.m_Attributes)
     {
-      float fValues[4] = {};
-      ezUInt32 uiNumFloats = ezConversionUtils::ExtractFloatsFromString(attributeDef.m_sValue, 4, fValues);
-
-      if (attributeDef.m_sName.IsEqual("Default"))
+      if (attributeDef.m_sType.IsEqual("Default") && attributeDef.m_Values.GetCount() >= 1)
       {
-        ///\todo: this needs a proper implementation for types other than float
-        if (pType == ezGetStaticRTTI<float>())
+        if (pType == ezGetStaticRTTI<ezColor>())
         {
-          if (uiNumFloats >= 1)
-          {
-            attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, fValues[0]));
-          }
-        }
-        if (pType == ezGetStaticRTTI<ezVec2>())
-        {
-          if (uiNumFloats >= 2)
-          {
-            attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, ezVec2(fValues[0], fValues[1])));
-          }
-        }
-        if (pType == ezGetStaticRTTI<ezVec3>())
-        {
-          if (uiNumFloats >= 3)
-          {
-            attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, ezVec3(fValues[0], fValues[1], fValues[2])));
-          }
-        }
-        if (pType == ezGetStaticRTTI<ezVec4>())
-        {
-          if (uiNumFloats == 4)
-          {
-            attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, ezVec4(fValues[0], fValues[1], fValues[2], fValues[3])));
-          }
-        }
-        else if (pType == ezGetStaticRTTI<ezColor>())
-        {
-          if (uiNumFloats >= 3)
-          {
-            ezColor color(fValues[0], fValues[1], fValues[2]);
-            if (uiNumFloats == 4)
-            {
-              color.a = fValues[3];
-            }
+          // always expose the alpha channel for color properties
+          attributes.PushBack(EZ_DEFAULT_NEW(ezExposeColorAlphaAttribute));
 
-            attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, color));
-
-            // always expose the alpha channel for color properties
-            attributes.PushBack(EZ_DEFAULT_NEW(ezExposeColorAlphaAttribute));
+          // patch default type, VSE writes float4 instead of color
+          if (attributeDef.m_Values[0].GetType() == ezVariantType::Vector4)
+          {
+            ezVec4 v = attributeDef.m_Values[0].Get<ezVec4>();
+            attributeDef.m_Values[0] = ezColor(v.x, v.y, v.z, v.w);
           }
         }
-        else if (pType == ezGetStaticRTTI<ezString>())
-        {
-          attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, ezVariant(attributeDef.m_sValue)));
-        }
+
+        attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, attributeDef.m_Values[0]));        
       }
-      else if (attributeDef.m_sName.IsEqual("Clamp"))
+      else if (attributeDef.m_sType.IsEqual("Clamp") && attributeDef.m_Values.GetCount() >= 2)
       {
-        if (pType == ezGetStaticRTTI<float>())
-        {
-          if (uiNumFloats >= 2)
-          {
-            attributes.PushBack(EZ_DEFAULT_NEW(ezClampValueAttribute, fValues[0], fValues[1]));
-          }
-        }
+        attributes.PushBack(EZ_DEFAULT_NEW(ezClampValueAttribute, attributeDef.m_Values[0], attributeDef.m_Values[1]));
       }
     }
   }
@@ -337,6 +266,7 @@ void ezShaderTypeRegistry::UpdateShaderType(ShaderData& data)
   EZ_LOG_BLOCK("Updating Shader Parameters", data.m_sShaderPath.GetData());
 
   ezHybridArray<ezShaderParser::ParameterDefinition, 16> parameters;
+  ezHybridArray<ezShaderParser::EnumDefinition, 4> enumDefinitions;
 
   {
     ezFileStats Stats;
@@ -349,7 +279,7 @@ void ezShaderTypeRegistry::UpdateShaderType(ShaderData& data)
       return;
     }
 
-    ezShaderParser::ParseMaterialParameterSection(file, parameters);
+    ezShaderParser::ParseMaterialParameterSection(file, parameters, enumDefinitions);
     data.m_fileModifiedTime = Stats.m_LastModificationTime;
   }
 

--- a/Code/UnitTests/FoundationTest/CodeUtils/MathExpressionTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/MathExpressionTest.cpp
@@ -27,9 +27,9 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, MathExpression)
       EZ_TEST_BOOL(!expr.IsValid());
     }
     {
-      ezMathExpression expr("1 + 2");
+      ezMathExpression expr("1.5 + 2.5");
       EZ_TEST_BOOL(expr.IsValid());
-      EZ_TEST_DOUBLE(expr.Evaluate(), 3.0, 0.0);
+      EZ_TEST_DOUBLE(expr.Evaluate(), 4.0, 0.0);
     }
     {
       ezMathExpression expr("1- 2");

--- a/Code/UnitTests/FoundationTest/Strings/StringUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringUtilsTest.cpp
@@ -823,6 +823,25 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringUtils)
     }
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsDecimalDigit / IsHexDigit")
+  {
+    EZ_TEST_BOOL(ezStringUtils::IsDecimalDigit('0'));
+    EZ_TEST_BOOL(ezStringUtils::IsDecimalDigit('4'));
+    EZ_TEST_BOOL(ezStringUtils::IsDecimalDigit('9'));
+    EZ_TEST_BOOL(!ezStringUtils::IsDecimalDigit('/'));
+    EZ_TEST_BOOL(!ezStringUtils::IsDecimalDigit('A'));
+
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('0'));
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('4'));
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('9'));
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('A'));
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('E'));
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('a'));
+    EZ_TEST_BOOL(ezStringUtils::IsHexDigit('f'));
+    EZ_TEST_BOOL(!ezStringUtils::IsHexDigit('g'));
+    EZ_TEST_BOOL(!ezStringUtils::IsHexDigit('/'));    
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsWordDelimiter_English / IsIdentifierDelimiter_C_Code")
   {
     for (ezUInt32 i = 0; i < 256; ++i)

--- a/Data/Base/Materials/BaseMaterials/Sky.ezMaterialAsset
+++ b/Data/Base/Materials/BaseMaterials/Sky.ezMaterialAsset
@@ -124,7 +124,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x0000803E}
+		d %Value{0x000000000000D03F}
 	}
 }
 o
@@ -269,10 +269,23 @@ o
 }
 o
 {
-	Uuid %id{u4{8841353700765633788,6300541515330189163}}
-	s %t{"ezExposeColorAlphaAttribute"}
+	Uuid %id{u4{15627491270869756527,6243390200236019521}}
+	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
-	p{}
+	p
+	{
+		b %Value{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8841353700765633788,6300541515330189163}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Color %Value{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+	}
 }
 o
 {
@@ -405,6 +418,7 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{17719889580936951450,17425918634288647917}}
+			Uuid{u4{15627491270869756527,6243390200236019521}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
@@ -460,12 +474,9 @@ o
 o
 {
 	Uuid %id{u4{13754454282246037307,13323104836659046162}}
-	s %t{"ezDefaultValueAttribute"}
+	s %t{"ezExposeColorAlphaAttribute"}
 	u3 %v{1}
-	p
-	{
-		Color %Value{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
-	}
+	p{}
 }
 o
 {
@@ -573,7 +584,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x00007A44}
+		d %Value{0x0000000000408F40}
 	}
 }
 o

--- a/Data/Base/Shaders/Materials/DefaultMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/DefaultMaterial.ezShader
@@ -24,7 +24,7 @@ float MaskThreshold @Default(0.25);
 
 bool UseBaseTexture;
 Texture2D BaseTexture;
-Color BaseColor @Default(1.0, 1.0, 1.0);
+Color BaseColor @Default(Color(1.0, 1.0, 1.0));
 
 bool UseNormalAndRoughnessTexture;
 Texture2D NormalTexture;
@@ -37,7 +37,7 @@ float MetallicValue @Default(0.0) @Clamp(0.0, 1.0);
 
 bool UseEmissiveTexture;
 Texture2D EmissiveTexture;
-Color EmissiveColor @Default(0.0, 0.0, 0.0);
+Color EmissiveColor @Default(Color(0.0, 0.0, 0.0));
 
 bool UseOcclusionTexture;
 Texture2D OcclusionTexture;

--- a/Data/Base/Shaders/Materials/SkyMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/SkyMaterial.ezShader
@@ -21,7 +21,7 @@ bool UseFog @Default(true);
 float VirtualDistance @Default(1000.0f);
 
 TextureCube CubeMap;
-Color BaseColor @Default(1.0, 1.0, 1.0);
+Color BaseColor @Default(Color(1.0, 1.0, 1.0));
 
 [RENDERSTATE]
 


### PR DESCRIPTION
- Rewrote shader parser using ezTokenizer instead of operating on strings directly.
- Added support for integer and float parsing to ezTokenizer.
- Added support for enum types in material parameters.
- Also use constructor reflection for attribute parameters to construct complex types like vec3, color etc.
