### PR TITLE
Makes live updating resource data in the editor less verbose

### DIFF
--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -495,6 +495,36 @@ ezString ezResourceManager::GenerateUniqueResourceID(const char* prefix)
   return resourceID;
 }
 
+ezTypelessResourceHandle ezResourceManager::GetExistingResourceByType(const ezRTTI* pResourceType, const char* szResourceID)
+{
+  ezResource* pResource = nullptr;
+
+  const ezTempHashedString sResourceHash(szResourceID);
+
+  EZ_LOCK(s_ResourceMutex);
+
+  const ezRTTI* pRtti = FindResourceTypeOverride(pResourceType, szResourceID);
+
+  if (s_LoadedResources[pRtti].m_Resources.TryGetValue(sResourceHash, pResource))
+    return ezTypelessResourceHandle(pResource);
+
+  return ezTypelessResourceHandle();
+}
+
+void ezResourceManager::ForceLoadResourceNow(const ezTypelessResourceHandle& hResource)
+{
+  EZ_ASSERT_DEV(hResource.IsValid(), "Cannot access an invalid resource");
+
+  ezResource* pResource = hResource.m_pResource;
+
+  if (pResource->GetLoadingState() != ezResourceState::LoadedResourceMissing && pResource->GetLoadingState() != ezResourceState::Loaded)
+  {
+    InternalPreloadResource(pResource, true);
+
+    EnsureResourceLoadingState(hResource.m_pResource, ezResourceState::Loaded);
+  }
+}
+
 void ezResourceManager::RegisterNamedResource(const char* szLookupName, const char* szRedirectionResource)
 {
   EZ_LOCK(s_ResourceMutex);
@@ -570,4 +600,13 @@ void ezResourceManager::EnableExportMode(bool enable)
   s_bExportMode = enable;
 }
 
+void ezResourceManager::RestoreResource(const ezTypelessResourceHandle& hResource)
+{
+  EZ_ASSERT_DEV(hResource.IsValid(), "Cannot access an invalid resource");
+
+  ezResource* pResource = hResource.m_pResource;
+  pResource->m_Flags.Remove(ezResourceFlags::PreventFileReload);
+
+  ReloadResource(pResource, true);
+}
 EZ_STATICLINK_FILE(Core, Core_ResourceManager_Implementation_ResourceManager);

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager_inl.h
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager_inl.h
@@ -240,17 +240,6 @@ static ezLockedObject<ezMutex, ezDynamicArray<ezResource*>> ezResourceManager::G
 }
 
 template <typename ResourceType>
-void ezResourceManager::RestoreResource(const ezTypedResourceHandle<ResourceType>& hResource)
-{
-  ResourceType* pResource = BeginAcquireResource(hResource, ezResourceAcquireMode::PointerOnly);
-  pResource->m_Flags.Remove(ezResourceFlags::PreventFileReload);
-
-  ReloadResource(pResource, true);
-
-  EndAcquireResource(pResource);
-}
-
-template <typename ResourceType>
 bool ezResourceManager::ReloadResource(const ezTypedResourceHandle<ResourceType>& hResource, bool bForce)
 {
   ResourceType* pResource = BeginAcquireResource(hResource, ezResourceAcquireMode::PointerOnly);

--- a/Code/Engine/Core/ResourceManager/ResourceManager.h
+++ b/Code/Engine/Core/ResourceManager/ResourceManager.h
@@ -79,10 +79,17 @@ public:
   template <typename ResourceType>
   static ezTypedResourceHandle<ResourceType> GetExistingResource(const char* szResourceID);
 
+  /// \brief Same as GetExistingResourceByType() but allows to specify the resource type as an ezRTTI.
+  static ezTypelessResourceHandle GetExistingResourceByType(const ezRTTI* pResourceType, const char* szResourceID);
+
   /// \brief Triggers loading of the given resource. tShouldBeAvailableIn specifies how long the resource is not yet needed, thus allowing
   /// other resources to be loaded first. This is only a hint and there are no guarantees when the resource is available.
   static void PreloadResource(const ezTypelessResourceHandle& hResource);
 
+  /// \brief Similar to locking a resource with 'NoFallback' acquire mode, but can be done with a typeless handle and does not return a result.
+  static void ForceLoadResourceNow(const ezTypelessResourceHandle& hResource);
+
+  /// \brief Returns the current loading state of the given resource.
   static ezResourceState GetLoadingState(const ezTypelessResourceHandle& hResource);
 
   ///@}
@@ -118,8 +125,7 @@ public:
   /// \brief Removes the 'PreventFileReload' flag and forces a reload on the resource.
   ///
   /// \sa UpdateResourceWithCustomLoader()
-  template <typename ResourceType>
-  static void RestoreResource(const ezTypedResourceHandle<ResourceType>& hResource);
+  static void RestoreResource(const ezTypelessResourceHandle& hResource);
 
   ///@}
   /// \name Acquiring resources

--- a/Code/Tools/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Tools/EditorEngineProcess/EngineProcGameApp.cpp
@@ -557,9 +557,13 @@ void ezEngineProcessGameApplication::HandleResourceUpdateMsg(const ezResourceUpd
 
   if (hResource.IsValid())
   {
+    ezStringBuilder sResourceDesc;
+    sResourceDesc.Set(msg.m_sResourceType, "LiveUpdate");
+
     ezUniquePtr<ezResourceLoaderFromMemory> loader(EZ_DEFAULT_NEW(ezResourceLoaderFromMemory));
     loader->m_ModificationTimestamp = ezTimestamp::CurrentTimestamp();
-    loader->m_sResourceDescription = "MaterialImmediateEditorUpdate";
+    loader->m_sResourceDescription = sResourceDesc;
+
     ezMemoryStreamWriter memoryWriter(&loader->m_CustomData);
     memoryWriter.WriteBytes(msg.m_Data.GetData(), msg.m_Data.GetCount());
 

--- a/Code/Tools/EditorEngineProcess/EngineProcGameApp.h
+++ b/Code/Tools/EditorEngineProcess/EngineProcGameApp.h
@@ -9,6 +9,8 @@
 class ezEditorEngineProcessApp;
 class ezDocumentOpenMsgToEngine;
 class ezEngineProcessDocumentContext;
+class ezResourceUpdateMsgToEngine;
+class ezRestoreResourceMsgToEngine;
 
 class ezEngineProcessGameApplication : public ezGameApplication
 {
@@ -48,6 +50,9 @@ private:
   void EventHandlerCVar(const ezCVar::CVarEvent& e);
   void EventHandlerCVarPlugin(const ezPlugin::PluginEvent& e);
   void TransmitCVar(const ezCVar* pCVar);
+
+  void HandleResourceUpdateMsg(const ezResourceUpdateMsgToEngine& msg);
+  void HandleResourceRestoreMsg(const ezRestoreResourceMsgToEngine& msg);
 
   ezEngineProcessDocumentContext* CreateDocumentContext(const ezDocumentOpenMsgToEngine* pMsg);
 

--- a/Code/Tools/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Tools/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -93,6 +93,26 @@ public:
   ezString m_sPayload;
 };
 
+class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezResourceUpdateMsgToEngine : public ezEditorEngineMsg
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezResourceUpdateMsgToEngine, ezEditorEngineMsg);
+
+public:
+  ezString m_sResourceType;
+  ezString m_sResourceID;
+  ezDataBuffer m_Data;
+};
+
+class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezRestoreResourceMsgToEngine : public ezEditorEngineMsg
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezRestoreResourceMsgToEngine, ezEditorEngineMsg);
+public:
+
+  ezString m_sResourceType;
+  ezString m_sResourceID;
+
+};
+
 class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezChangeCVarMsgToEngine : public ezEditorEngineMsg
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezChangeCVarMsgToEngine, ezEditorEngineMsg);

--- a/Code/Tools/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Tools/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -96,6 +96,29 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSimpleConfigMsgToEngine, 1, ezRTTIDefaultAlloc
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezResourceUpdateMsgToEngine, 1, ezRTTIDefaultAllocator<ezResourceUpdateMsgToEngine>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Type", m_sResourceType),
+    EZ_MEMBER_PROPERTY("ID", m_sResourceID),
+    EZ_MEMBER_PROPERTY("Data", m_Data),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRestoreResourceMsgToEngine, 1, ezRTTIDefaultAllocator<ezRestoreResourceMsgToEngine>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Type", m_sResourceType),
+    EZ_MEMBER_PROPERTY("ID", m_sResourceID),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezChangeCVarMsgToEngine, 1, ezRTTIDefaultAllocator<ezChangeCVarMsgToEngine>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/Tools/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/Tools/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -239,8 +239,11 @@ void ezQtMaterialAssetDocumentWindow::UpdatePreview()
   if (ezEditorEngineProcessConnection::GetSingleton()->IsProcessCrashed())
     return;
 
-  ezEditorEngineResourceUpdateMsg msg;
+  ezResourceUpdateMsgToEngine msg;
   msg.m_sResourceType = "Material";
+
+  ezStringBuilder tmp;
+  msg.m_sResourceID = ezConversionUtils::ToString(GetDocument()->GetGuid(), tmp);
 
   ezMemoryStreamStorage streamStorage;
   ezMemoryStreamWriter memoryWriter(&streamStorage);
@@ -258,7 +261,7 @@ void ezQtMaterialAssetDocumentWindow::UpdatePreview()
   GetMaterialDocument()->WriteMaterialAsset(memoryWriter, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), false);
   msg.m_Data = ezArrayPtr<const ezUInt8>(streamStorage.GetData(), streamStorage.GetStorageSize());
 
-  GetEditorEngineConnection()->SendMessage(&msg);
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 }
 
 void ezQtMaterialAssetDocumentWindow::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
@@ -297,8 +300,13 @@ void ezQtMaterialAssetDocumentWindow::SendRedrawMsg()
 
 void ezQtMaterialAssetDocumentWindow::RestoreResource()
 {
-  ezEditorEngineRestoreResourceMsg msg;
-  GetEditorEngineConnection()->SendMessage(&msg);
+  ezRestoreResourceMsgToEngine msg;
+  msg.m_sResourceType = "Material";
+
+  ezStringBuilder tmp;
+  msg.m_sResourceID = ezConversionUtils::ToString(GetDocument()->GetGuid(), tmp);
+
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 }
 
 void ezQtMaterialAssetDocumentWindow::UpdateNodeEditorVisibility()

--- a/Code/Tools/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
+++ b/Code/Tools/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
@@ -624,8 +624,11 @@ void ezQtParticleEffectAssetDocumentWindow::UpdatePreview()
   if (ezEditorEngineProcessConnection::GetSingleton()->IsProcessCrashed())
     return;
 
-  ezEditorEngineResourceUpdateMsg msg;
-  msg.m_sResourceType = "Particle";
+  ezResourceUpdateMsgToEngine msg;
+  msg.m_sResourceType = "Particle Effect";
+
+  ezStringBuilder tmp;
+  msg.m_sResourceID = ezConversionUtils::ToString(GetDocument()->GetGuid(), tmp);
 
   ezMemoryStreamStorage streamStorage;
   ezMemoryStreamWriter memoryWriter(&streamStorage);
@@ -643,7 +646,7 @@ void ezQtParticleEffectAssetDocumentWindow::UpdatePreview()
   GetParticleDocument()->WriteParticleEffectAsset(memoryWriter, ezAssetCurator::GetSingleton()->GetActiveAssetProfile());
   msg.m_Data = ezArrayPtr<const ezUInt8>(streamStorage.GetData(), streamStorage.GetStorageSize());
 
-  GetEditorEngineConnection()->SendMessage(&msg);
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 }
 
 void ezQtParticleEffectAssetDocumentWindow::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
@@ -775,6 +778,11 @@ void ezQtParticleEffectAssetDocumentWindow::SendRedrawMsg()
 
 void ezQtParticleEffectAssetDocumentWindow::RestoreResource()
 {
-  ezEditorEngineRestoreResourceMsg msg;
-  GetEditorEngineConnection()->SendMessage(&msg);
+  ezRestoreResourceMsgToEngine msg;
+  msg.m_sResourceType = "Particle Effect";
+
+  ezStringBuilder tmp;
+  msg.m_sResourceID = ezConversionUtils::ToString(GetDocument()->GetGuid(), tmp);
+
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 }

--- a/Code/Tools/EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementAssetWindow.cpp
+++ b/Code/Tools/EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementAssetWindow.cpp
@@ -83,8 +83,11 @@ void ezProceduralPlacementAssetDocumentWindow::UpdatePreview()
   if (ezEditorEngineProcessConnection::GetSingleton()->IsProcessCrashed())
     return;
 
-  ezEditorEngineResourceUpdateMsg msg;
-  msg.m_sResourceType = "ProceduralPlacement";
+  ezResourceUpdateMsgToEngine msg;
+  msg.m_sResourceType = "Procedural Placement";
+
+  ezStringBuilder tmp;
+  msg.m_sResourceID = ezConversionUtils::ToString(GetDocument()->GetGuid(), tmp);
 
   ezMemoryStreamStorage streamStorage;
   ezMemoryStreamWriter memoryWriter(&streamStorage);
@@ -103,14 +106,19 @@ void ezProceduralPlacementAssetDocumentWindow::UpdatePreview()
   {
     msg.m_Data = ezArrayPtr<const ezUInt8>(streamStorage.GetData(), streamStorage.GetStorageSize());
 
-    GetEditorEngineConnection()->SendMessage(&msg);
+    ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
   }
 }
 
 void ezProceduralPlacementAssetDocumentWindow::RestoreResource()
 {
-  ezEditorEngineRestoreResourceMsg msg;
-  GetEditorEngineConnection()->SendMessage(&msg);
+  ezRestoreResourceMsgToEngine msg;
+  msg.m_sResourceType = "Procedural Placement";
+
+  ezStringBuilder tmp;
+  msg.m_sResourceID = ezConversionUtils::ToString(GetDocument()->GetGuid(), tmp);
+
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 }
 
 void ezProceduralPlacementAssetDocumentWindow::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)

--- a/Code/Tools/EnginePluginAssets/MaterialAsset/MaterialContext.cpp
+++ b/Code/Tools/EnginePluginAssets/MaterialAsset/MaterialContext.cpp
@@ -38,27 +38,7 @@ ezMaterialContext::ezMaterialContext() {}
 
 void ezMaterialContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
 {
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineResourceUpdateMsg>())
-  {
-    const ezEditorEngineResourceUpdateMsg* pMsg2 = static_cast<const ezEditorEngineResourceUpdateMsg*>(pMsg);
-
-    if (pMsg2->m_sResourceType == "Material")
-    {
-      ezUniquePtr<ezResourceLoaderFromMemory> loader(EZ_DEFAULT_NEW(ezResourceLoaderFromMemory));
-      loader->m_ModificationTimestamp = ezTimestamp::CurrentTimestamp();
-      loader->m_sResourceDescription = "MaterialImmediateEditorUpdate";
-      ezMemoryStreamWriter memoryWriter(&loader->m_CustomData);
-      memoryWriter.WriteBytes(pMsg2->m_Data.GetData(), pMsg2->m_Data.GetCount());
-
-      ezResourceManager::UpdateResourceWithCustomLoader(m_hMaterial, std::move(loader));
-
-      // force loading of the resource
-      ezResourceLock<ezMaterialResource> pResource(m_hMaterial, ezResourceAcquireMode::NoFallback);
-    }
-  }
-
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineRestoreResourceMsg>() ||
-      pMsg->GetDynamicRTTI()->IsDerivedFrom<ezCreateThumbnailMsgToEngine>())
+  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezCreateThumbnailMsgToEngine>())
   {
     ezResourceManager::RestoreResource(m_hMaterial);
   }

--- a/Code/Tools/EnginePluginParticle/ParticleAsset/ParticleContext.cpp
+++ b/Code/Tools/EnginePluginParticle/ParticleAsset/ParticleContext.cpp
@@ -51,30 +51,6 @@ void ezParticleContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
     return;
   }
 
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineResourceUpdateMsg>())
-  {
-    const ezEditorEngineResourceUpdateMsg* pMsg2 = static_cast<const ezEditorEngineResourceUpdateMsg*>(pMsg);
-
-    if (pMsg2->m_sResourceType == "Particle")
-    {
-      ezUniquePtr<ezResourceLoaderFromMemory> loader(EZ_DEFAULT_NEW(ezResourceLoaderFromMemory));
-      loader->m_ModificationTimestamp = ezTimestamp::CurrentTimestamp();
-      loader->m_sResourceDescription = "ParticleImmediateEditorUpdate";
-      ezMemoryStreamWriter memoryWriter(&loader->m_CustomData);
-      memoryWriter.WriteBytes(pMsg2->m_Data.GetData(), pMsg2->m_Data.GetCount());
-
-      ezResourceManager::UpdateResourceWithCustomLoader(m_hParticle, std::move(loader));
-
-      // force loading of the resource (not needed here, works well without it)
-      // ezResourceLock<ezParticleEffectResource> pResource(m_hParticle, ezResourceAcquireMode::NoFallback);
-    }
-  }
-
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineRestoreResourceMsg>())
-  {
-    ezResourceManager::RestoreResource(m_hParticle);
-  }
-
   if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineRestartSimulationMsg>())
   {
     RestartEffect();

--- a/Code/Tools/EnginePluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementContext.cpp
+++ b/Code/Tools/EnginePluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementContext.cpp
@@ -21,27 +21,7 @@ ezProceduralPlacementContext::ezProceduralPlacementContext() {}
 
 void ezProceduralPlacementContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
 {
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineResourceUpdateMsg>())
-  {
-    const ezEditorEngineResourceUpdateMsg* pMsg2 = static_cast<const ezEditorEngineResourceUpdateMsg*>(pMsg);
-
-    if (pMsg2->m_sResourceType == "ProceduralPlacement")
-    {
-      ezUniquePtr<ezResourceLoaderFromMemory> loader(EZ_DEFAULT_NEW(ezResourceLoaderFromMemory));
-      loader->m_ModificationTimestamp = ezTimestamp::CurrentTimestamp();
-      loader->m_sResourceDescription = "ProcGenImmediateEditorUpdate";
-      ezMemoryStreamWriter memoryWriter(&loader->m_CustomData);
-      memoryWriter.WriteBytes(pMsg2->m_Data.GetData(), pMsg2->m_Data.GetCount());
-
-      ezResourceManager::UpdateResourceWithCustomLoader(m_hProcGen, std::move(loader));
-
-      // force loading of the resource
-      ezResourceLock<ezProceduralPlacementResource> pResource(m_hProcGen, ezResourceAcquireMode::NoFallback);
-    }
-  }
-
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineRestoreResourceMsg>() ||
-      pMsg->GetDynamicRTTI()->IsDerivedFrom<ezCreateThumbnailMsgToEngine>())
+  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezCreateThumbnailMsgToEngine>())
   {
     ezResourceManager::RestoreResource(m_hProcGen);
   }

--- a/Code/Tools/SharedPluginAssets/Common/Messages.cpp
+++ b/Code/Tools/SharedPluginAssets/Common/Messages.cpp
@@ -3,20 +3,6 @@
 #include <SharedPluginAssets/Common/Messages.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorEngineRestoreResourceMsg, 1, ezRTTIDefaultAllocator<ezEditorEngineRestoreResourceMsg>)
-EZ_END_DYNAMIC_REFLECTED_TYPE;
-
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorEngineResourceUpdateMsg, 1, ezRTTIDefaultAllocator<ezEditorEngineResourceUpdateMsg>)
-{
-  EZ_BEGIN_PROPERTIES
-  {
-    EZ_MEMBER_PROPERTY("Type", m_sResourceType),
-    EZ_MEMBER_PROPERTY("Data", m_Data),
-  }
-  EZ_END_PROPERTIES;
-}
-EZ_END_DYNAMIC_REFLECTED_TYPE;
-
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorEngineRestartSimulationMsg, 1, ezRTTIDefaultAllocator<ezEditorEngineRestartSimulationMsg>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 

--- a/Code/Tools/SharedPluginAssets/Common/Messages.h
+++ b/Code/Tools/SharedPluginAssets/Common/Messages.h
@@ -3,32 +3,9 @@
 #include <SharedPluginAssets/SharedPluginAssetsDLL.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h>
 
-
-class EZ_SHAREDPLUGINASSETS_DLL ezEditorEngineRestoreResourceMsg : public ezEditorEngineDocumentMsg
-{
-  EZ_ADD_DYNAMIC_REFLECTION(ezEditorEngineRestoreResourceMsg, ezEditorEngineDocumentMsg);
-
-public:
-
-};
-
-class EZ_SHAREDPLUGINASSETS_DLL ezEditorEngineResourceUpdateMsg : public ezEditorEngineDocumentMsg
-{
-  EZ_ADD_DYNAMIC_REFLECTION(ezEditorEngineResourceUpdateMsg, ezEditorEngineDocumentMsg);
-
-public:
-  ezEditorEngineResourceUpdateMsg()
-  {
-  }
-
-  ezString m_sResourceType;
-  ezDataBuffer m_Data;
-};
-
 class EZ_SHAREDPLUGINASSETS_DLL ezEditorEngineRestartSimulationMsg : public ezEditorEngineDocumentMsg
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezEditorEngineRestartSimulationMsg, ezEditorEngineDocumentMsg);
-
 public:
 
 };
@@ -36,8 +13,8 @@ public:
 class EZ_SHAREDPLUGINASSETS_DLL ezEditorEngineLoopAnimationMsg : public ezEditorEngineDocumentMsg
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezEditorEngineLoopAnimationMsg, ezEditorEngineDocumentMsg);
-
 public:
+
   bool m_bLoop;
 
 };


### PR DESCRIPTION
Messages for live updating resources are now independent of an engine side document context.

The Procedural Placement engine plugin could be removed now, unless there are other uses for it.