### PR TITLE
Document cloning

### DIFF
--- a/Code/Engine/Foundation/Serialization/AbstractObjectGraph.h
+++ b/Code/Engine/Foundation/Serialization/AbstractObjectGraph.h
@@ -162,10 +162,10 @@ public:
 private:
   EZ_DISALLOW_COPY_AND_ASSIGN(ezAbstractObjectGraph);
 
-  void RemapVariant(ezVariant& value, const ezMap<ezUuid, ezUuid>& guidMap);
+  void RemapVariant(ezVariant& value, const ezHashTable<ezUuid, ezUuid>& guidMap);
   void MergeArrays(const ezVariantArray& baseArray, const ezVariantArray& leftArray, const ezVariantArray& rightArray,
                    ezVariantArray& out) const;
-  void ReMapNodeGuidsToMatchGraphRecursive(ezMap<ezUuid, ezUuid>& guidMap, ezAbstractObjectNode* lhs, const ezAbstractObjectGraph& rhsGraph,
+  void ReMapNodeGuidsToMatchGraphRecursive(ezHashTable<ezUuid, ezUuid>& guidMap, ezAbstractObjectNode* lhs, const ezAbstractObjectGraph& rhsGraph,
                                            const ezAbstractObjectNode* rhs);
 
   ezSet<ezString> m_Strings;

--- a/Code/Tools/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/ToolsFoundation/Document/Document.h
@@ -85,6 +85,10 @@ public:
   ezStatus SaveDocument(bool bForce = false);
   typedef ezDelegate<void(ezDocument* doc, ezStatus res)> AfterSaveCallback;
   ezTaskGroupID SaveDocumentAsync(AfterSaveCallback callback, bool bForce = false);
+
+  static ezStatus ReadDocument(const char* sDocumentPath, ezUniquePtr<ezAbstractObjectGraph>& header, ezUniquePtr<ezAbstractObjectGraph>& objects, ezUniquePtr<ezAbstractObjectGraph>& types);
+  static ezStatus ReadAndRegisterTypes(const ezAbstractObjectGraph& types);
+
   ezStatus LoadDocument() { return InternalLoadDocument(); }
 
   /// \brief Brings the corresponding window to the front.

--- a/Code/Tools/ToolsFoundation/Document/DocumentManager.h
+++ b/Code/Tools/ToolsFoundation/Document/DocumentManager.h
@@ -20,6 +20,7 @@ public:
   ezStatus CreateDocument(const char* szDocumentTypeName, const char* szPath, ezDocument*& out_pDocument, ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::None);
   ezStatus OpenDocument(const char* szDocumentTypeName, const char* szPath, ezDocument*& out_pDocument,
     ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::AddToRecentFilesList | ezDocumentFlags::RequestWindow, const ezDocumentObject* pOpenContext = nullptr);
+  virtual ezStatus CloneDocument(const char* szPath, const char* szClonePath, ezUuid& inout_cloneGuid);
   void CloseDocument(ezDocument* pDocument);
   void EnsureWindowRequested(ezDocument* pDocument, const ezDocumentObject* pOpenContext = nullptr);
 

--- a/Code/Tools/ToolsFoundation/Document/DocumentUtils.h
+++ b/Code/Tools/ToolsFoundation/Document/DocumentUtils.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <ToolsFoundation/ToolsFoundationDLL.h>
+#include <ToolsFoundation/Document/Document.h>
+
+class ezDocumentObject;
+struct ezDocumentTypeDescriptor;
+
+class EZ_TOOLSFOUNDATION_DLL ezDocumentUtils
+{
+public:
+  static ezStatus IsValidSaveLocationForDocument(const char* szDocument, const ezDocumentTypeDescriptor** out_pTypeDesc = nullptr);
+};

--- a/Code/Tools/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -5,6 +5,10 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <ToolsFoundation/Document/DocumentManager.h>
 #include <Foundation/IO/OSFile.h>
+#include <Foundation/Serialization/RttiConverter.h>
+#include <Foundation/Serialization/DdlSerializer.h>
+#include <Foundation/IO/FileSystem/DeferredFileWriter.h>
+#include <ToolsFoundation/Document/DocumentUtils.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDocumentManager, 1, ezRTTINoAllocator);
@@ -289,6 +293,70 @@ ezStatus ezDocumentManager::OpenDocument(const char* szDocumentTypeName, const c
   ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext)
 {
   return CreateOrOpenDocument(false, szDocumentTypeName, szPath, out_pDocument, flags, pOpenContext);
+}
+
+
+ezStatus ezDocumentManager::CloneDocument(const char* szPath, const char* szClonePath, ezUuid& inout_cloneGuid)
+{
+  const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+  ezStatus res = ezDocumentUtils::IsValidSaveLocationForDocument(szClonePath, &pTypeDesc);
+  if (res.Failed())
+    return res;
+
+  ezUniquePtr<ezAbstractObjectGraph> header;
+  ezUniquePtr<ezAbstractObjectGraph> objects;
+  ezUniquePtr<ezAbstractObjectGraph> types;
+
+  res = ezDocument::ReadDocument(szPath, header, objects, types);
+  if (res.Failed())
+    return res;
+
+  ezUuid documentId;
+  ezAbstractObjectNode::Property* documentIdProp = nullptr;
+  {
+    ezRttiConverterContext context;
+    ezRttiConverterReader rttiConverter(header.Borrow(), &context);
+    auto* pHeaderNode = header->GetNodeByName("Header");
+    EZ_ASSERT_DEV(pHeaderNode, "No header found, document '{0}' is corrupted.", szPath);
+    documentIdProp = pHeaderNode->FindProperty("DocumentID");
+    EZ_ASSERT_DEV(documentIdProp, "No document ID property found in header, document document '{0}' is corrupted.", szPath);
+    documentId = documentIdProp->m_Value.Get<ezUuid>();
+  }
+
+  ezUuid seedGuid;
+  if (inout_cloneGuid.IsValid())
+  {
+    seedGuid = inout_cloneGuid;
+    seedGuid.RevertCombinationWithSeed(documentId);
+
+    ezUuid test = documentId;
+    test.CombineWithSeed(seedGuid);
+    EZ_ASSERT_DEV(test == inout_cloneGuid, "");
+  }
+  else
+  {
+    seedGuid.CreateNewUuid();
+    inout_cloneGuid = documentId;
+    inout_cloneGuid.CombineWithSeed(seedGuid);
+  }
+
+  {
+    // Remap
+    header->ReMapNodeGuids(seedGuid);
+    objects->ReMapNodeGuids(seedGuid);
+    documentIdProp->m_Value = inout_cloneGuid;
+  }
+
+  {
+    ezDeferredFileWriter file;
+    file.SetOutput(szClonePath);
+    ezAbstractGraphDdlSerializer::WriteDocument(file, header.Borrow(), objects.Borrow(), types.Borrow(), false);
+    if (file.Close() == EZ_FAILURE)
+    {
+      return ezStatus(ezFmt("Unable to open file '{0}' for writing!", szClonePath));
+    }
+  }
+  return ezStatus(EZ_SUCCESS);
 }
 
 void ezDocumentManager::CloseDocument(ezDocument* pDocument)

--- a/Code/Tools/ToolsFoundation/Document/Implementation/DocumentUtils.cpp
+++ b/Code/Tools/ToolsFoundation/Document/Implementation/DocumentUtils.cpp
@@ -1,0 +1,27 @@
+#include <ToolsFoundationPCH.h>
+
+#include <ToolsFoundation/Document/DocumentUtils.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
+
+ezStatus ezDocumentUtils::IsValidSaveLocationForDocument(const char* szDocument, const ezDocumentTypeDescriptor** out_pTypeDesc)
+{
+  const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
+  if (ezDocumentManager::FindDocumentTypeFromPath(szDocument, true, pTypeDesc).Failed())
+  {
+    ezStringBuilder sTemp;
+    sTemp.Format("The selected file extension '{0}' is not registered with any known type.\nCannot create file '{1}'",
+      ezPathUtils::GetFileExtension(szDocument), szDocument);
+    return ezStatus(sTemp.GetData());
+  }
+
+  if (ezDocument* pDocument = pTypeDesc->m_pManager->GetDocumentByPath(szDocument))
+  {
+    return ezStatus("The selected document is already open. You need to close the document before you can re-create it.");
+  }
+
+  if (out_pTypeDesc)
+  {
+    *out_pTypeDesc = pTypeDesc;
+  }
+  return ezStatus(EZ_SUCCESS);
+}


### PR DESCRIPTION
Added ezDocumentManager::CloneDocument
    -Clones the document on disk and shifts all object GUIDs by the delta between old doc GUID and new GUID.
    -Used by Save As action and when encountering duplicates in the curator.
    -Currently has to save the original doc before cloning.
    -Changed AbstractObjectGraph remapping ezMap to ezHashTable for better performance.