### PR TITLE
Procedural Placement internal logic refactor

### DIFF
--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -625,6 +625,8 @@ void ezWorld::ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::En
 
 void ezWorld::ProcessQueuedMessages(ezObjectMsgQueueType::Enum queueType)
 {
+  EZ_PROFILE_SCOPE("Process Queued Messages");
+
   struct MessageComparer
   {
     EZ_FORCE_INLINE bool Less(const ezInternal::WorldData::MessageQueue::Entry& a,

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -275,8 +275,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezManipulatorAttribute::ezManipulatorAttribute(const char* szProperty1, const char* szProperty2 /*= nullptr*/,
-                                               const char* szProperty3 /*= nullptr*/, const char* szProperty4 /*= nullptr*/,
-                                               const char* szProperty5 /*= nullptr*/, const char* szProperty6 /*= nullptr*/)
+  const char* szProperty3 /*= nullptr*/, const char* szProperty4 /*= nullptr*/, const char* szProperty5 /*= nullptr*/,
+  const char* szProperty6 /*= nullptr*/)
 {
   m_sProperty1 = szProperty1;
   m_sProperty2 = szProperty2;
@@ -302,12 +302,12 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezSphereManipulatorAttribute::ezSphereManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
 }
 
 ezSphereManipulatorAttribute::ezSphereManipulatorAttribute(const char* szOuterRadius, const char* szInnerRadius)
-    : ezManipulatorAttribute(szOuterRadius, szInnerRadius)
+  : ezManipulatorAttribute(szOuterRadius, szInnerRadius)
 {
 }
 
@@ -326,12 +326,12 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezCapsuleManipulatorAttribute::ezCapsuleManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
 }
 
 ezCapsuleManipulatorAttribute::ezCapsuleManipulatorAttribute(const char* szLength, const char* szRadius)
-    : ezManipulatorAttribute(szLength, szRadius)
+  : ezManipulatorAttribute(szLength, szRadius)
 {
 }
 
@@ -351,12 +351,13 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezBoxManipulatorAttribute::ezBoxManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
 }
 
-ezBoxManipulatorAttribute::ezBoxManipulatorAttribute(const char* szSize)
-    : ezManipulatorAttribute(szSize)
+ezBoxManipulatorAttribute::ezBoxManipulatorAttribute(
+  const char* szSizeProperty, const char* szOffsetProperty, const char* szRotationProperty)
+  : ezManipulatorAttribute(szSizeProperty, szOffsetProperty, szRotationProperty)
 {
 }
 
@@ -376,19 +377,18 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezNonUniformBoxManipulatorAttribute::ezNonUniformBoxManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
 }
 
 ezNonUniformBoxManipulatorAttribute::ezNonUniformBoxManipulatorAttribute(const char* szNegXProp, const char* szPosXProp,
-                                                                         const char* szNegYProp, const char* szPosYProp,
-                                                                         const char* szNegZProp, const char* szPosZProp)
-    : ezManipulatorAttribute(szNegXProp, szPosXProp, szNegYProp, szPosYProp, szNegZProp, szPosZProp)
+  const char* szNegYProp, const char* szPosYProp, const char* szNegZProp, const char* szPosZProp)
+  : ezManipulatorAttribute(szNegXProp, szPosXProp, szNegYProp, szPosYProp, szNegZProp, szPosZProp)
 {
 }
 
 ezNonUniformBoxManipulatorAttribute::ezNonUniformBoxManipulatorAttribute(const char* szSizeX, const char* szSizeY, const char* szSizeZ)
-    : ezManipulatorAttribute(szSizeX, szSizeY, szSizeZ)
+  : ezManipulatorAttribute(szSizeX, szSizeY, szSizeZ)
 {
 }
 
@@ -407,12 +407,12 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezConeLengthManipulatorAttribute::ezConeLengthManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
 }
 
 ezConeLengthManipulatorAttribute::ezConeLengthManipulatorAttribute(const char* szRadiusProperty)
-    : ezManipulatorAttribute(szRadiusProperty)
+  : ezManipulatorAttribute(szRadiusProperty)
 {
 }
 
@@ -438,13 +438,13 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezConeAngleManipulatorAttribute::ezConeAngleManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
   m_fScale = 1.0f;
 }
 
 ezConeAngleManipulatorAttribute::ezConeAngleManipulatorAttribute(const char* szAngleProperty, float fScale, const char* szRadiusProperty)
-    : ezManipulatorAttribute(szAngleProperty, szRadiusProperty)
+  : ezManipulatorAttribute(szAngleProperty, szRadiusProperty)
 {
   m_fScale = fScale;
 }
@@ -464,13 +464,13 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezTransformManipulatorAttribute::ezTransformManipulatorAttribute()
-    : ezManipulatorAttribute(nullptr)
+  : ezManipulatorAttribute(nullptr)
 {
 }
 
-ezTransformManipulatorAttribute::ezTransformManipulatorAttribute(const char* szTranslateProperty, const char* szRotateProperty,
-                                                                 const char* szScaleProperty)
-    : ezManipulatorAttribute(szTranslateProperty, szRotateProperty, szScaleProperty)
+ezTransformManipulatorAttribute::ezTransformManipulatorAttribute(
+  const char* szTranslateProperty, const char* szRotateProperty, const char* szScaleProperty)
+  : ezManipulatorAttribute(szTranslateProperty, szRotateProperty, szScaleProperty)
 {
 }
 
@@ -492,8 +492,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezVisualizerAttribute::ezVisualizerAttribute(const char* szProperty1, const char* szProperty2 /*= nullptr*/,
-                                             const char* szProperty3 /*= nullptr*/, const char* szProperty4 /*= nullptr*/,
-                                             const char* szProperty5 /*= nullptr*/)
+  const char* szProperty3 /*= nullptr*/, const char* szProperty4 /*= nullptr*/, const char* szProperty5 /*= nullptr*/)
 {
   m_sProperty1 = szProperty1;
   m_sProperty2 = szProperty2;
@@ -526,18 +525,25 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezBoxVisualizerAttribute::ezBoxVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
 }
 
 ezBoxVisualizerAttribute::ezBoxVisualizerAttribute(const char* szSizeProperty, const char* szColorProperty /*= nullptr*/,
-                                                   const ezColor& fixedColor /*= ezColor::MediumVioletRed*/,
-                                                   const char* szOffsetProperty /*= nullptr*/,
-                                                   ezVec3 fixedOffset /*= ezVec3::ZeroVector()*/)
-    : ezVisualizerAttribute(szSizeProperty, szColorProperty, szOffsetProperty)
+  const ezColor& fixedColor /*= ezColor::MediumVioletRed*/, const char* szOffsetProperty /*= nullptr*/,
+  ezVec3 fixedOffset /*= ezVec3::ZeroVector()*/)
+  : ezVisualizerAttribute(szSizeProperty, szColorProperty, szOffsetProperty)
 {
   m_Color = fixedColor;
   m_vOffset = fixedOffset;
+}
+
+ezBoxVisualizerAttribute::ezBoxVisualizerAttribute(const char* szSizeProperty, const char* szOffsetProperty, const char* szRotationProperty,
+  const char* szColorProperty /*= nullptr*/, const ezColor& fixedColor /*= ezColor::MediumVioletRed*/)
+  : ezVisualizerAttribute(szSizeProperty, szColorProperty, szOffsetProperty, szRotationProperty)
+{
+  m_Color = fixedColor;
+  m_vOffset.SetZero();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -564,15 +570,14 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezSphereVisualizerAttribute::ezSphereVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
 }
 
 ezSphereVisualizerAttribute::ezSphereVisualizerAttribute(const char* szRadiusProperty, const char* szColorProperty /*= nullptr*/,
-                                                         const ezColor& fixedColor /*= ezColor::MediumVioletRed*/,
-                                                         const char* szOffsetProperty /*= nullptr*/,
-                                                         ezVec3 fixedOffset /*= ezVec3::ZeroVector()*/)
-    : ezVisualizerAttribute(szRadiusProperty, szColorProperty, szOffsetProperty)
+  const ezColor& fixedColor /*= ezColor::MediumVioletRed*/, const char* szOffsetProperty /*= nullptr*/,
+  ezVec3 fixedOffset /*= ezVec3::ZeroVector()*/)
+  : ezVisualizerAttribute(szRadiusProperty, szColorProperty, szOffsetProperty)
 {
   m_vOffset = fixedOffset;
   m_Color = fixedColor;
@@ -600,20 +605,20 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezCapsuleVisualizerAttribute::ezCapsuleVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
 }
 
-ezCapsuleVisualizerAttribute::ezCapsuleVisualizerAttribute(const char* szHeightProperty, const char* szRadiusProperty,
-                                                           const char* szColorProperty)
-    : ezVisualizerAttribute(szHeightProperty, szRadiusProperty, szColorProperty)
+ezCapsuleVisualizerAttribute::ezCapsuleVisualizerAttribute(
+  const char* szHeightProperty, const char* szRadiusProperty, const char* szColorProperty)
+  : ezVisualizerAttribute(szHeightProperty, szRadiusProperty, szColorProperty)
 {
   m_Color = ezColor::MediumVioletRed;
 }
 
-ezCapsuleVisualizerAttribute::ezCapsuleVisualizerAttribute(const char* szHeightProperty, const char* szRadiusProperty,
-                                                           const ezColor& fixedColor /*= ezColor::MediumVioletRed*/)
-    : ezVisualizerAttribute(szHeightProperty, szRadiusProperty)
+ezCapsuleVisualizerAttribute::ezCapsuleVisualizerAttribute(
+  const char* szHeightProperty, const char* szRadiusProperty, const ezColor& fixedColor /*= ezColor::MediumVioletRed*/)
+  : ezVisualizerAttribute(szHeightProperty, szRadiusProperty)
 {
   m_Color = fixedColor;
 }
@@ -642,16 +647,14 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezCylinderVisualizerAttribute::ezCylinderVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
 }
 
 ezCylinderVisualizerAttribute::ezCylinderVisualizerAttribute(ezEnum<ezBasisAxis> axis, const char* szHeightProperty,
-                                                             const char* szRadiusProperty, const char* szColorProperty /*= nullptr*/,
-                                                             const ezColor& fixedColor /*= ezColor::MediumVioletRed*/,
-                                                             const char* szOffsetProperty /*= nullptr*/,
-                                                             ezVec3 fixedOffset /*= ezVec3::ZeroVector()*/)
-    : ezVisualizerAttribute(szHeightProperty, szRadiusProperty, szColorProperty, szOffsetProperty)
+  const char* szRadiusProperty, const char* szColorProperty /*= nullptr*/, const ezColor& fixedColor /*= ezColor::MediumVioletRed*/,
+  const char* szOffsetProperty /*= nullptr*/, ezVec3 fixedOffset /*= ezVec3::ZeroVector()*/)
+  : ezVisualizerAttribute(szHeightProperty, szRadiusProperty, szColorProperty, szOffsetProperty)
 {
   m_Axis = axis;
   m_Color = fixedColor;
@@ -684,15 +687,15 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezDirectionVisualizerAttribute::ezDirectionVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
   m_Axis = ezBasisAxis::PositiveX;
   m_fScale = 1.0f;
 }
 
-ezDirectionVisualizerAttribute::ezDirectionVisualizerAttribute(ezEnum<ezBasisAxis> axis, float fScale, const char* szColorProperty,
-                                                               const char* szLengthProperty /*= nullptr*/)
-    : ezVisualizerAttribute(szColorProperty, szLengthProperty)
+ezDirectionVisualizerAttribute::ezDirectionVisualizerAttribute(
+  ezEnum<ezBasisAxis> axis, float fScale, const char* szColorProperty, const char* szLengthProperty /*= nullptr*/)
+  : ezVisualizerAttribute(szColorProperty, szLengthProperty)
 {
   m_Axis = axis;
   m_fScale = fScale;
@@ -700,9 +703,8 @@ ezDirectionVisualizerAttribute::ezDirectionVisualizerAttribute(ezEnum<ezBasisAxi
 }
 
 ezDirectionVisualizerAttribute::ezDirectionVisualizerAttribute(ezEnum<ezBasisAxis> axis, float fScale,
-                                                               const ezColor& fixedColor /*= ezColor::MediumVioletRed*/,
-                                                               const char* szLengthProperty /*= nullptr*/)
-    : ezVisualizerAttribute(nullptr, szLengthProperty)
+  const ezColor& fixedColor /*= ezColor::MediumVioletRed*/, const char* szLengthProperty /*= nullptr*/)
+  : ezVisualizerAttribute(nullptr, szLengthProperty)
 {
   m_Axis = axis;
   m_fScale = fScale;
@@ -733,7 +735,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezConeVisualizerAttribute::ezConeVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
   m_Axis = ezBasisAxis::PositiveX;
   m_Color = ezColor::Red;
@@ -741,9 +743,8 @@ ezConeVisualizerAttribute::ezConeVisualizerAttribute()
 }
 
 ezConeVisualizerAttribute::ezConeVisualizerAttribute(ezEnum<ezBasisAxis> axis, const char* szAngleProperty, float fScale,
-                                                     const char* szRadiusProperty, const char* szColorProperty,
-                                                     const ezColor& fixedColor /*= ezColor::MediumVioletRed*/)
-    : ezVisualizerAttribute(szAngleProperty, szRadiusProperty, szColorProperty)
+  const char* szRadiusProperty, const char* szColorProperty, const ezColor& fixedColor /*= ezColor::MediumVioletRed*/)
+  : ezVisualizerAttribute(szAngleProperty, szRadiusProperty, szColorProperty)
 {
   m_Axis = axis;
   m_Color = fixedColor;
@@ -767,14 +768,13 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezCameraVisualizerAttribute::ezCameraVisualizerAttribute()
-    : ezVisualizerAttribute(nullptr)
+  : ezVisualizerAttribute(nullptr)
 {
 }
 
 ezCameraVisualizerAttribute::ezCameraVisualizerAttribute(const char* szModeProperty, const char* szFovProperty,
-                                                         const char* szOrthoDimProperty, const char* szNearPlaneProperty,
-                                                         const char* szFarPlaneProperty)
-    : ezVisualizerAttribute(szModeProperty, szFovProperty, szOrthoDimProperty, szNearPlaneProperty, szFarPlaneProperty)
+  const char* szOrthoDimProperty, const char* szNearPlaneProperty, const char* szFarPlaneProperty)
+  : ezVisualizerAttribute(szModeProperty, szFovProperty, szOrthoDimProperty, szNearPlaneProperty, szFarPlaneProperty)
 {
 }
 
@@ -823,4 +823,3 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 //////////////////////////////////////////////////////////////////////////
 
 EZ_STATICLINK_FILE(Foundation, Foundation_Reflection_Implementation_PropertyAttributes);
-

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -349,7 +349,7 @@ class EZ_FOUNDATION_DLL ezManipulatorAttribute : public ezPropertyAttribute
 
 public:
   ezManipulatorAttribute(const char* szProperty1, const char* szProperty2 = nullptr, const char* szProperty3 = nullptr,
-                         const char* szProperty4 = nullptr, const char* szProperty5 = nullptr, const char* szProperty6 = nullptr);
+    const char* szProperty4 = nullptr, const char* szProperty5 = nullptr, const char* szProperty6 = nullptr);
 
   ezUntrackedString m_sProperty1;
   ezUntrackedString m_sProperty2;
@@ -371,8 +371,6 @@ public:
 
   const ezUntrackedString& GetOuterRadiusProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetInnerRadiusProperty() const { return m_sProperty2; }
-
-protected:
 };
 
 
@@ -399,9 +397,11 @@ class EZ_FOUNDATION_DLL ezBoxManipulatorAttribute : public ezManipulatorAttribut
 
 public:
   ezBoxManipulatorAttribute();
-  ezBoxManipulatorAttribute(const char* szSizeProperty);
+  ezBoxManipulatorAttribute(const char* szSizeProperty, const char* szOffsetProperty = nullptr, const char* szRotationProperty = nullptr);
 
   const ezUntrackedString& GetSizeProperty() const { return m_sProperty1; }
+  const ezUntrackedString& GetOffsetProperty() const { return m_sProperty2; }
+  const ezUntrackedString& GetRotationProperty() const { return m_sProperty3; }
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -413,7 +413,7 @@ class EZ_FOUNDATION_DLL ezNonUniformBoxManipulatorAttribute : public ezManipulat
 public:
   ezNonUniformBoxManipulatorAttribute();
   ezNonUniformBoxManipulatorAttribute(const char* szNegXProp, const char* szPosXProp, const char* szNegYProp, const char* szPosYProp,
-                                      const char* szNegZProp, const char* szPosZProp);
+    const char* szNegZProp, const char* szPosZProp);
   ezNonUniformBoxManipulatorAttribute(const char* szSizeX, const char* szSizeY, const char* szSizeZ);
 
   bool HasSixAxis() const { return !m_sProperty4.IsEmpty(); }
@@ -467,7 +467,8 @@ class EZ_FOUNDATION_DLL ezTransformManipulatorAttribute : public ezManipulatorAt
 
 public:
   ezTransformManipulatorAttribute();
-  ezTransformManipulatorAttribute(const char* szTranslateProperty, const char* szRotateProperty = nullptr, const char* szScaleProperty = nullptr);
+  ezTransformManipulatorAttribute(
+    const char* szTranslateProperty, const char* szRotateProperty = nullptr, const char* szScaleProperty = nullptr);
 
   const ezUntrackedString& GetTranslateProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetRotateProperty() const { return m_sProperty2; }
@@ -482,7 +483,7 @@ class EZ_FOUNDATION_DLL ezVisualizerAttribute : public ezPropertyAttribute
 
 public:
   ezVisualizerAttribute(const char* szProperty1, const char* szProperty2 = nullptr, const char* szProperty3 = nullptr,
-                        const char* szProperty4 = nullptr, const char* szProperty5 = nullptr);
+    const char* szProperty4 = nullptr, const char* szProperty5 = nullptr);
 
   ezUntrackedString m_sProperty1;
   ezUntrackedString m_sProperty2;
@@ -500,12 +501,15 @@ class EZ_FOUNDATION_DLL ezBoxVisualizerAttribute : public ezVisualizerAttribute
 public:
   ezBoxVisualizerAttribute();
   ezBoxVisualizerAttribute(const char* szSizeProperty, const char* szColorProperty = nullptr,
-                           const ezColor& fixedColor = ezColor::MediumVioletRed, const char* szOffsetProperty = nullptr,
-                           ezVec3 fixedOffset = ezVec3::ZeroVector());
+    const ezColor& fixedColor = ezColor::MediumVioletRed, const char* szOffsetProperty = nullptr,
+    ezVec3 fixedOffset = ezVec3::ZeroVector());
+  ezBoxVisualizerAttribute(const char* szSizeProperty, const char* szOffsetProperty, const char* szRotationProperty,
+    const char* szColorProperty = nullptr, const ezColor& fixedColor = ezColor::MediumVioletRed);
 
   const ezUntrackedString& GetSizeProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetColorProperty() const { return m_sProperty2; }
   const ezUntrackedString& GetOffsetProperty() const { return m_sProperty3; }
+  const ezUntrackedString& GetRotationProperty() const { return m_sProperty4; }
 
   ezColor m_Color;
   ezVec3 m_vOffset;
@@ -520,8 +524,8 @@ class EZ_FOUNDATION_DLL ezSphereVisualizerAttribute : public ezVisualizerAttribu
 public:
   ezSphereVisualizerAttribute();
   ezSphereVisualizerAttribute(const char* szRadiusProperty, const char* szColorProperty = nullptr,
-                              const ezColor& fixedColor = ezColor::MediumVioletRed, const char* szOffsetProperty = nullptr,
-                              ezVec3 fixedOffset = ezVec3::ZeroVector());
+    const ezColor& fixedColor = ezColor::MediumVioletRed, const char* szOffsetProperty = nullptr,
+    ezVec3 fixedOffset = ezVec3::ZeroVector());
 
   const ezUntrackedString& GetRadiusProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetColorProperty() const { return m_sProperty2; }
@@ -541,8 +545,8 @@ class EZ_FOUNDATION_DLL ezCapsuleVisualizerAttribute : public ezVisualizerAttrib
 public:
   ezCapsuleVisualizerAttribute();
   ezCapsuleVisualizerAttribute(const char* szHeightProperty, const char* szRadiusProperty, const char* szColorProperty);
-  ezCapsuleVisualizerAttribute(const char* szHeightProperty, const char* szRadiusProperty,
-                               const ezColor& fixedColor = ezColor::MediumVioletRed);
+  ezCapsuleVisualizerAttribute(
+    const char* szHeightProperty, const char* szRadiusProperty, const ezColor& fixedColor = ezColor::MediumVioletRed);
 
   const ezUntrackedString& GetHeightProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetRadiusProperty() const { return m_sProperty2; }
@@ -560,8 +564,8 @@ class EZ_FOUNDATION_DLL ezCylinderVisualizerAttribute : public ezVisualizerAttri
 public:
   ezCylinderVisualizerAttribute();
   ezCylinderVisualizerAttribute(ezEnum<ezBasisAxis> axis, const char* szHeightProperty, const char* szRadiusProperty,
-                                const char* szColorProperty = nullptr, const ezColor& fixedColor = ezColor::MediumVioletRed,
-                                const char* szOffsetProperty = nullptr, ezVec3 fixedOffset = ezVec3::ZeroVector());
+    const char* szColorProperty = nullptr, const ezColor& fixedColor = ezColor::MediumVioletRed, const char* szOffsetProperty = nullptr,
+    ezVec3 fixedOffset = ezVec3::ZeroVector());
 
   const ezUntrackedString& GetHeightProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetRadiusProperty() const { return m_sProperty2; }
@@ -581,10 +585,10 @@ class EZ_FOUNDATION_DLL ezDirectionVisualizerAttribute : public ezVisualizerAttr
 
 public:
   ezDirectionVisualizerAttribute();
-  ezDirectionVisualizerAttribute(ezEnum<ezBasisAxis> axis, float fScale, const char* szColorProperty,
-                                 const char* szLengthProperty = nullptr);
-  ezDirectionVisualizerAttribute(ezEnum<ezBasisAxis> axis, float fScale, const ezColor& fixedColor = ezColor::MediumVioletRed,
-                                 const char* szLengthProperty = nullptr);
+  ezDirectionVisualizerAttribute(
+    ezEnum<ezBasisAxis> axis, float fScale, const char* szColorProperty, const char* szLengthProperty = nullptr);
+  ezDirectionVisualizerAttribute(
+    ezEnum<ezBasisAxis> axis, float fScale, const ezColor& fixedColor = ezColor::MediumVioletRed, const char* szLengthProperty = nullptr);
 
   const ezUntrackedString& GetColorProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetLengthProperty() const { return m_sProperty2; }
@@ -610,7 +614,7 @@ public:
   /// szColorProperty may be nullptr. In this case it is ignored and fixedColor is used instead.
   /// fixedColor is ignored if szColorProperty is valid.
   ezConeVisualizerAttribute(ezEnum<ezBasisAxis> axis, const char* szAngleProperty, float fScale, const char* szRadiusProperty,
-                            const char* szColorProperty = nullptr, const ezColor& fixedColor = ezColor::MediumVioletRed);
+    const char* szColorProperty = nullptr, const ezColor& fixedColor = ezColor::MediumVioletRed);
 
   const ezUntrackedString& GetAngleProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetRadiusProperty() const { return m_sProperty2; }
@@ -632,7 +636,7 @@ public:
 
   /// \brief Attribute to add on an RTTI type to add a camera cone visualizer.
   ezCameraVisualizerAttribute(const char* szModeProperty, const char* szFovProperty, const char* szOrthoDimProperty,
-                              const char* szNearPlaneProperty, const char* szFarPlaneProperty);
+    const char* szNearPlaneProperty, const char* szFarPlaneProperty);
 
   const ezUntrackedString& GetModeProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetFovProperty() const { return m_sProperty2; }
@@ -715,4 +719,3 @@ class EZ_FOUNDATION_DLL ezAutoGenVisScriptMsgHandler : public ezPropertyAttribut
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezAutoGenVisScriptMsgHandler, ezPropertyAttribute);
 };
-

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -467,7 +467,7 @@ class EZ_FOUNDATION_DLL ezTransformManipulatorAttribute : public ezManipulatorAt
 
 public:
   ezTransformManipulatorAttribute();
-  ezTransformManipulatorAttribute(const char* szTranslateProperty, const char* szRotateProperty, const char* szScaleProperty);
+  ezTransformManipulatorAttribute(const char* szTranslateProperty, const char* szRotateProperty = nullptr, const char* szScaleProperty = nullptr);
 
   const ezUntrackedString& GetTranslateProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetRotateProperty() const { return m_sProperty2; }

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -215,7 +215,8 @@ namespace
         renderView.m_hView = ezRenderWorld::CreateView(sName, pView);
 
         pView->SetCameraUsageHint(ezCameraUsageHint::Reflection);
-        pView->SetViewport(ezRectFloat(0.0f, 0.0f, static_cast<float>(s_uiReflectionCubeMapSize), static_cast<float>(s_uiReflectionCubeMapSize)));
+        pView->SetViewport(
+          ezRectFloat(0.0f, 0.0f, static_cast<float>(s_uiReflectionCubeMapSize), static_cast<float>(s_uiReflectionCubeMapSize)));
 
         pView->SetRenderPipelineResource(ezResourceManager::LoadResource<ezRenderPipelineResource>(szRenderPipelineResource));
 
@@ -384,35 +385,41 @@ struct ezReflectionPool::Data
     }
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-    ezGeometry geom;
-    geom.AddSphere(s_fDebugSphereRadius, 32, 16, ezColor::White);
-
-    const char* szBufferResourceName = "ReflectionProbeDebugSphereBuffer";
-    ezMeshBufferResourceHandle hMeshBuffer = ezResourceManager::GetExistingResource<ezMeshBufferResource>(szBufferResourceName);
-    if (!hMeshBuffer.IsValid())
-    {
-      ezMeshBufferResourceDescriptor desc;
-      desc.AddStream(ezGALVertexAttributeSemantic::Position, ezGALResourceFormat::XYZFloat);
-      desc.AddStream(ezGALVertexAttributeSemantic::Normal, ezGALResourceFormat::XYZFloat);
-      desc.AllocateStreamsFromGeometry(geom, ezGALPrimitiveTopology::Triangles);
-
-      hMeshBuffer = ezResourceManager::CreateResource<ezMeshBufferResource>(szBufferResourceName, std::move(desc), szBufferResourceName);
-    }
-
-    const char* szMeshResourceName = "ReflectionProbeDebugSphere";
-    m_hDebugSphere = ezResourceManager::GetExistingResource<ezMeshResource>(szMeshResourceName);
     if (!m_hDebugSphere.IsValid())
     {
-      ezMeshResourceDescriptor desc;
-      desc.UseExistingMeshBuffer(hMeshBuffer);
-      desc.AddSubMesh(geom.CalculateTriangleCount(), 0, 0);
-      desc.ComputeBounds();
+      ezGeometry geom;
+      geom.AddSphere(s_fDebugSphereRadius, 32, 16, ezColor::White);
 
-      m_hDebugSphere = ezResourceManager::CreateResource<ezMeshResource>(szMeshResourceName, std::move(desc), szMeshResourceName);
+      const char* szBufferResourceName = "ReflectionProbeDebugSphereBuffer";
+      ezMeshBufferResourceHandle hMeshBuffer = ezResourceManager::GetExistingResource<ezMeshBufferResource>(szBufferResourceName);
+      if (!hMeshBuffer.IsValid())
+      {
+        ezMeshBufferResourceDescriptor desc;
+        desc.AddStream(ezGALVertexAttributeSemantic::Position, ezGALResourceFormat::XYZFloat);
+        desc.AddStream(ezGALVertexAttributeSemantic::Normal, ezGALResourceFormat::XYZFloat);
+        desc.AllocateStreamsFromGeometry(geom, ezGALPrimitiveTopology::Triangles);
+
+        hMeshBuffer = ezResourceManager::CreateResource<ezMeshBufferResource>(szBufferResourceName, std::move(desc), szBufferResourceName);
+      }
+
+      const char* szMeshResourceName = "ReflectionProbeDebugSphere";
+      m_hDebugSphere = ezResourceManager::GetExistingResource<ezMeshResource>(szMeshResourceName);
+      if (!m_hDebugSphere.IsValid())
+      {
+        ezMeshResourceDescriptor desc;
+        desc.UseExistingMeshBuffer(hMeshBuffer);
+        desc.AddSubMesh(geom.CalculateTriangleCount(), 0, 0);
+        desc.ComputeBounds();
+
+        m_hDebugSphere = ezResourceManager::CreateResource<ezMeshResource>(szMeshResourceName, std::move(desc), szMeshResourceName);
+      }
     }
 
-    m_hDebugMaterial = ezResourceManager::LoadResource<ezMaterialResource>(
-      "{ 6f8067d0-ece8-44e1-af46-79b49266de41 }"); // ReflectionProbeVisualization.ezMaterialAsset
+    if (!m_hDebugMaterial.IsValid())
+    {
+      m_hDebugMaterial = ezResourceManager::LoadResource<ezMaterialResource>(
+        "{ 6f8067d0-ece8-44e1-af46-79b49266de41 }"); // ReflectionProbeVisualization.ezMaterialAsset
+    }
 #endif
   }
 
@@ -721,7 +728,7 @@ void ezReflectionPool::OnBeginRender(ezUInt64 uiFrameCounter)
     {
       ezBoundingBoxu32 destBox;
       destBox.m_vMin.Set(0, i, 0);
-      destBox.m_vMax.Set(6, i+1, 1);
+      destBox.m_vMax.Set(6, i + 1, 1);
 
       ezGALSystemMemoryDescription memDesc;
       memDesc.m_pData = &skyIrradianceStorage[i].m_Values[0];

--- a/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
@@ -72,8 +72,8 @@ private:
 
   void RemoveConnections(ezRenderPipelinePass* pPass);
   void ClearRenderPassGraphTextures();
-  bool AreInputDescriptionsAvailable(const ezRenderPipelinePass* pPass, const ezDynamicArray<ezRenderPipelinePass*>& done) const;
-  bool ArePassThroughInputsDone(const ezRenderPipelinePass* pPass, const ezDynamicArray<ezRenderPipelinePass*>& done) const;
+  bool AreInputDescriptionsAvailable(const ezRenderPipelinePass* pPass, const ezHybridArray<ezRenderPipelinePass*, 32>& done) const;
+  bool ArePassThroughInputsDone(const ezRenderPipelinePass* pPass, const ezHybridArray<ezRenderPipelinePass*, 32>& done) const;
 
   ezFrameDataProviderBase* GetFrameDataProvider(const ezRTTI* pRtti);
 
@@ -123,8 +123,11 @@ private: // Member data
   ezDynamicArray<ezUInt16> m_TextureUsageIdxSortedByFirstUsage; ///< Indices map into m_TextureUsage
   ezDynamicArray<ezUInt16> m_TextureUsageIdxSortedByLastUsage; ///< Indices map into m_TextureUsage
 
+  ezHashTable<ezRenderPipelinePassConnection*, ezUInt32> m_ConnectionToTextureIndex;
+
   // Extractors
   ezDynamicArray<ezUniquePtr<ezExtractor>> m_Extractors;
+  ezDynamicArray<ezUniquePtr<ezExtractor>> m_SortedExtractors;
 
   // Data Providers
   ezDynamicArray<ezUniquePtr<ezFrameDataProviderBase>> m_DataProviders;

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -304,7 +304,7 @@ void ezRenderWorld::DeleteCachedRenderData(const ezGameObjectHandle& hOwnerObjec
       s_DeletedRenderData.PushBack(pCachedRenderData);
     }
 
-    pCachedRenderDataPerComponent->Clear();
+    s_CachedRenderData.Remove(hOwnerComponent);
   }
 }
 
@@ -552,6 +552,8 @@ bool ezRenderWorld::IsRenderingThread()
 
 void ezRenderWorld::ClearRenderDataCache()
 {
+  EZ_PROFILE_SCOPE("Clear Render Data Cache");
+
   for (auto pRenderData : s_DeletedRenderData)
   {
     ezRenderData* ptr = const_cast<ezRenderData*>(pRenderData);
@@ -563,6 +565,8 @@ void ezRenderWorld::ClearRenderDataCache()
 
 void ezRenderWorld::UpdateRenderDataCache()
 {
+  EZ_PROFILE_SCOPE("Update Render Data Cache");
+
   for (auto it = s_Views.GetIterator(); it.IsValid(); ++it)
   {
     ezView* pView = it.Value();

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.cpp
@@ -78,8 +78,9 @@ ezArrayPtr<const ezGameObjectHandle> ActiveTile::GetPlacedObjects() const
 ezBoundingBox ActiveTile::GetBoundingBox() const
 {
   float fTileSize = m_pLayer->GetTileSize();
-  ezVec3 vMin = ezVec3(m_Desc.m_iPosX * fTileSize, m_Desc.m_iPosY * fTileSize, m_Desc.m_fMinZ);
-  ezVec3 vMax = (vMin.GetAsVec2() + ezVec2(fTileSize)).GetAsVec3(m_Desc.m_fMaxZ);
+  ezVec2 vCenter = ezVec2(m_Desc.m_iPosX * fTileSize, m_Desc.m_iPosY * fTileSize);
+  ezVec3 vMin = (vCenter - ezVec2(fTileSize * 0.5f)).GetAsVec3(m_Desc.m_fMinZ);
+  ezVec3 vMax = (vCenter + ezVec2(fTileSize * 0.5f)).GetAsVec3(m_Desc.m_fMaxZ);
 
   return ezBoundingBox(vMin, vMax);
 }

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.cpp
@@ -2,10 +2,7 @@
 
 #include <Core/World/World.h>
 #include <Foundation/SimdMath/SimdConversion.h>
-#include <Foundation/SimdMath/SimdRandom.h>
 #include <GameEngine/Components/PrefabReferenceComponent.h>
-#include <GameEngine/Interfaces/PhysicsWorldModule.h>
-#include <GameEngine/Surfaces/SurfaceResource.h>
 #include <ProceduralPlacementPlugin/Components/Implementation/ActiveTile.h>
 #include <ProceduralPlacementPlugin/Tasks/PlacementTask.h>
 #include <RendererCore/Messages/SetColorMessage.h>
@@ -104,79 +101,16 @@ void ActiveTile::PrepareTask(const ezPhysicsWorldModuleInterface* pPhysicsModule
 {
   EZ_ASSERT_DEV(pPhysicsModule != nullptr, "Physics module must be valid");
 
+  placementTask.m_pPhysicsModule = pPhysicsModule;
   placementTask.m_pLayer = m_pLayer;
   placementTask.m_iTileSeed = (m_Desc.m_iPosX << 11) ^ (m_Desc.m_iPosY * 17);
-
-  ezSimdVec4i seed = ezSimdVec4i(placementTask.m_iTileSeed) + ezSimdVec4i(0, 3, 7, 11);
-
-  ezBoundingBox bbox = GetBoundingBox();
-  float fZRange = bbox.GetExtents().z;
-  ezSimdFloat fZStart = bbox.m_vMax.z;
-  ezSimdVec4f vXY = ezSimdConversion::ToVec3(bbox.m_vMin);
-  ezSimdVec4f vMinOffset = ezSimdConversion::ToVec3(m_pLayer->m_vMinOffset);
-  ezSimdVec4f vMaxOffset = ezSimdConversion::ToVec3(m_pLayer->m_vMaxOffset);
-
-  ezVec3 rayDir = ezVec3(0, 0, -1);
-  ezUInt32 uiCollisionLayer = m_pLayer->m_uiCollisionLayer;
-
-  auto& patternPoints = m_pLayer->m_pPattern->m_Points;
-
-  for (ezUInt32 i = 0; i < patternPoints.GetCount(); ++i)
-  {
-    auto& patternPoint = patternPoints[i];
-    ezSimdVec4f patternCoords = ezSimdConversion::ToVec3(patternPoint.m_Coordinates.GetAsVec3(0.0f));
-
-    ezSimdVec4f rayStart = (vXY + patternCoords * m_pLayer->m_fFootprint);
-    rayStart += ezSimdRandom::FloatMinMax(seed + ezSimdVec4i(i), vMinOffset, vMaxOffset);
-    rayStart.SetZ(fZStart);
-
-    ezPhysicsHitResult hitResult;
-    if (!pPhysicsModule->CastRay(
-          ezSimdConversion::ToVec3(rayStart), rayDir, fZRange, uiCollisionLayer, hitResult, ezPhysicsShapeType::Static))
-      continue;
-
-    if (m_pLayer->m_hSurface.IsValid())
-    {
-      if (!hitResult.m_hSurface.IsValid())
-        continue;
-
-      ezResourceLock<ezSurfaceResource> hitSurface(hitResult.m_hSurface, ezResourceAcquireMode::NoFallbackAllowMissing);
-      if (hitSurface.GetAcquireResult() == ezResourceAcquireResult::MissingFallback)
-        continue;
-
-      if (!hitSurface->IsBasedOn(m_pLayer->m_hSurface))
-        continue;
-    }
-
-    bool bInBoundingBox = false;
-    ezSimdVec4f hitPosition = ezSimdConversion::ToVec3(hitResult.m_vPosition);
-    ezSimdVec4f allOne = ezSimdVec4f(1.0f);
-    for (auto& globalToLocalBox : m_Desc.m_GlobalToLocalBoxTransforms)
-    {
-      ezSimdVec4f localHitPosition = globalToLocalBox.TransformPosition(hitPosition).Abs();
-      if ((localHitPosition <= allOne).AllSet<3>())
-      {
-        bInBoundingBox = true;
-        break;
-      }
-    }
-
-    if (bInBoundingBox)
-    {
-      PlacementPoint& placementPoint = placementTask.m_InputPoints.ExpandAndGetRef();
-      placementPoint.m_vPosition = hitResult.m_vPosition;
-      placementPoint.m_fScale = 1.0f;
-      placementPoint.m_vNormal = hitResult.m_vNormal;
-      placementPoint.m_uiColorIndex = 0;
-      placementPoint.m_uiObjectIndex = 0;
-      placementPoint.m_uiPointIndex = i;
-    }
-  }
+  placementTask.m_TileBoundingBox = GetBoundingBox();
+  placementTask.m_GlobalToLocalBoxTransforms = m_Desc.m_GlobalToLocalBoxTransforms;
 
   m_State = State::Scheduled;
 }
 
-ezUInt32 ActiveTile::PlaceObjects(ezWorld& world, const PlacementTask& placementTask)
+ezUInt32 ActiveTile::PlaceObjects(ezWorld& world, ezArrayPtr<const PlacementTransform> objectTransforms)
 {
   ezGameObjectDesc desc;
   auto& objectsToPlace = m_pLayer->m_ObjectsToPlace;
@@ -184,7 +118,6 @@ ezUInt32 ActiveTile::PlaceObjects(ezWorld& world, const PlacementTask& placement
   ezHybridArray<ezPrefabResource*, 4> prefabs;
   prefabs.SetCount(objectsToPlace.GetCount());
 
-  auto objectTransforms = placementTask.GetOutputTransforms();
   for (auto& objectTransform : objectTransforms)
   {
     const ezUInt32 uiObjectIndex = objectTransform.m_uiObjectIndex;

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.cpp
@@ -50,14 +50,14 @@ void ActiveTile::Deinitialize(ezWorld& world)
   }
   m_PlacedObjects.Clear();
 
-  m_Desc.m_uiResourceIdHash = 0;
+  m_Desc.m_hComponent.Invalidate();
   m_pLayer = nullptr;
   m_State = State::Invalid;
 }
 
 bool ActiveTile::IsValid() const
 {
-  return m_Desc.m_uiResourceIdHash != 0 && m_pLayer != nullptr;
+  return !m_Desc.m_hComponent.IsInvalidated() && m_pLayer != nullptr;
 }
 
 const TileDesc& ActiveTile::GetDesc() const
@@ -150,9 +150,9 @@ void ActiveTile::PrepareTask(const ezPhysicsWorldModuleInterface* pPhysicsModule
     bool bInBoundingBox = false;
     ezSimdVec4f hitPosition = ezSimdConversion::ToVec3(hitResult.m_vPosition);
     ezSimdVec4f allOne = ezSimdVec4f(1.0f);
-    for (auto& boundingBox : m_Desc.m_LocalBoundingBoxes)
+    for (auto& globalToLocalBox : m_Desc.m_GlobalToLocalBoxTransforms)
     {
-      ezSimdVec4f localHitPosition = boundingBox.TransformPosition(hitPosition).Abs();
+      ezSimdVec4f localHitPosition = globalToLocalBox.TransformPosition(hitPosition).Abs();
       if ((localHitPosition <= allOne).AllSet<3>())
       {
         bInBoundingBox = true;

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ActiveTile.h
@@ -28,7 +28,7 @@ namespace ezPPInternal
 
     void PrepareTask(const ezPhysicsWorldModuleInterface* pPhysicsModule, PlacementTask& placementTask);
 
-    ezUInt32 PlaceObjects(ezWorld& world, const PlacementTask& placementTask);
+    ezUInt32 PlaceObjects(ezWorld& world, ezArrayPtr<const PlacementTransform> objectTransforms);
 
   private:
     TileDesc m_Desc;

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ProceduralPlacementComponent.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ProceduralPlacementComponent.cpp
@@ -553,24 +553,52 @@ void ezProceduralPlacementComponentManager::ClearVisibleResources()
 
 //////////////////////////////////////////////////////////////////////////
 
+// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezBoxWithFadeOut, ezNoBase, 1, ezRTTIDefaultAllocator<ezBoxWithFadeOut>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Position", m_vPosition),
+    EZ_MEMBER_PROPERTY("Rotation", m_Rotation),
+    EZ_MEMBER_PROPERTY("Extents", m_vExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
+    EZ_MEMBER_PROPERTY("FadeOutRange", m_vFadeOutRange)->AddAttributes(new ezClampValueAttribute(ezVec3(0), ezVariant())),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+      new ezTransformManipulatorAttribute("Position", "Rotation"),
+      new ezBoxManipulatorAttribute("Extents"),
+      new ezBoxVisualizerAttribute("Extents", nullptr, ezColor::CornflowerBlue, "Position"),
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_STATIC_REFLECTED_TYPE;
+
 EZ_BEGIN_COMPONENT_TYPE(ezProceduralPlacementComponent, 1, ezComponentMode::Static)
 {
-  EZ_BEGIN_PROPERTIES{
-      EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)
-          ->AddAttributes(new ezAssetBrowserAttribute("Procedural Placement")),
-      EZ_ACCESSOR_PROPERTY("Extents", GetExtents, SetExtents)
-          ->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
-  } EZ_END_PROPERTIES;
-  EZ_BEGIN_MESSAGEHANDLERS{
+  EZ_BEGIN_PROPERTIES
+  {
+      EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("Procedural Placement")),
+      EZ_ACCESSOR_PROPERTY("Extents", GetExtents, SetExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
+      EZ_ARRAY_MEMBER_PROPERTY("Boxes", m_Boxes),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
       EZ_MESSAGE_HANDLER(ezMsgUpdateLocalBounds, OnUpdateLocalBounds),
       EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnExtractRenderData),
-  } EZ_END_MESSAGEHANDLERS; EZ_BEGIN_ATTRIBUTES{
+  }
+  EZ_END_MESSAGEHANDLERS;
+  EZ_BEGIN_ATTRIBUTES
+  {
       new ezCategoryAttribute("ProceduralPlacement"),
       new ezBoxManipulatorAttribute("Extents"),
       new ezBoxVisualizerAttribute("Extents"),
-  } EZ_END_ATTRIBUTES;
+  }
+  EZ_END_ATTRIBUTES;
 }
 EZ_END_COMPONENT_TYPE
+// clang-format on
 
 ezProceduralPlacementComponent::ezProceduralPlacementComponent()
 {

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ProceduralPlacementComponent.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ProceduralPlacementComponent.cpp
@@ -554,21 +554,23 @@ void ezProceduralPlacementComponentManager::ClearVisibleResources()
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_STATIC_REFLECTED_TYPE(ezBoxWithFadeOut, ezNoBase, 1, ezRTTIDefaultAllocator<ezBoxWithFadeOut>)
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProcGenBoxExtents, ezNoBase, 1, ezRTTIDefaultAllocator<ezProcGenBoxExtents>)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Position", m_vPosition),
     EZ_MEMBER_PROPERTY("Rotation", m_Rotation),
-    EZ_MEMBER_PROPERTY("Extents", m_vExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
-    EZ_MEMBER_PROPERTY("FadeOutRange", m_vFadeOutRange)->AddAttributes(new ezClampValueAttribute(ezVec3(0), ezVariant())),
+    EZ_MEMBER_PROPERTY("InnerExtents", m_vInnerExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(8.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
+    EZ_MEMBER_PROPERTY("OuterExtents", m_vOuterExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_ATTRIBUTES
   {
+      new ezBoxManipulatorAttribute("InnerExtents", "Position", "Rotation"),
+      new ezBoxVisualizerAttribute("InnerExtents", "Position", "Rotation", nullptr, ezColor::Yellow),
+      new ezBoxManipulatorAttribute("OuterExtents", "Position", "Rotation"),
+      new ezBoxVisualizerAttribute("OuterExtents", "Position", "Rotation", nullptr, ezColor::CornflowerBlue),
       new ezTransformManipulatorAttribute("Position", "Rotation"),
-      new ezBoxManipulatorAttribute("Extents"),
-      new ezBoxVisualizerAttribute("Extents", nullptr, ezColor::CornflowerBlue, "Position"),
   }
   EZ_END_ATTRIBUTES;
 }
@@ -579,8 +581,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProceduralPlacementComponent, 1, ezComponentMode::Stat
   EZ_BEGIN_PROPERTIES
   {
       EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("Procedural Placement")),
-      EZ_ACCESSOR_PROPERTY("Extents", GetExtents, SetExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
-      EZ_ARRAY_MEMBER_PROPERTY("Boxes", m_Boxes),
+      EZ_ARRAY_MEMBER_PROPERTY("Extents2", m_Extents),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS
@@ -592,8 +593,6 @@ EZ_BEGIN_COMPONENT_TYPE(ezProceduralPlacementComponent, 1, ezComponentMode::Stat
   EZ_BEGIN_ATTRIBUTES
   {
       new ezCategoryAttribute("ProceduralPlacement"),
-      new ezBoxManipulatorAttribute("Extents"),
-      new ezBoxVisualizerAttribute("Extents"),
   }
   EZ_END_ATTRIBUTES;
 }

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ProceduralPlacementComponent.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/Implementation/ProceduralPlacementComponent.cpp
@@ -18,8 +18,8 @@
 
 using namespace ezPPInternal;
 
-ezCVarInt CVarMaxProcessingTiles("pp_MaxProcessingTiles", 10, ezCVarFlags::Default, "Maximum number of tiles in process");
-ezCVarInt CVarMaxPlacedObjects("pp_MaxPlacedObjects", 256, ezCVarFlags::Default, "Maximum number of objects placed per frame");
+ezCVarInt CVarMaxProcessingTiles("pp_MaxProcessingTiles", 8, ezCVarFlags::Default, "Maximum number of tiles in process");
+ezCVarInt CVarMaxPlacedObjects("pp_MaxPlacedObjects", 128, ezCVarFlags::Default, "Maximum number of objects placed per frame");
 ezCVarBool CVarVisTiles("pp_VisTiles", false, ezCVarFlags::Default, "Enables debug visualization of procedural placement tiles");
 
 ezProceduralPlacementComponentManager::ezProceduralPlacementComponentManager(ezWorld* pWorld)

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <ProceduralPlacementPlugin/Resources/ProceduralPlacementResource.h>
 #include <Core/World/World.h>
@@ -99,6 +99,16 @@ private:
 
 //////////////////////////////////////////////////////////////////////////
 
+struct ezBoxWithFadeOut
+{
+  ezVec3 m_vPosition;
+  ezQuat m_Rotation;
+  ezVec3 m_vExtents;
+  ezVec3 m_vFadeOutRange;
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_PROCEDURALPLACEMENTPLUGIN_DLL, ezBoxWithFadeOut);
+
 class EZ_PROCEDURALPLACEMENTPLUGIN_DLL ezProceduralPlacementComponent : public ezComponent
 {
   EZ_DECLARE_COMPONENT_TYPE(ezProceduralPlacementComponent, ezComponent, ezProceduralPlacementComponentManager);
@@ -129,4 +139,6 @@ private:
 
   ezProceduralPlacementResourceHandle m_hResource;
   ezVec3 m_vExtents;
+
+  ezDynamicArray<ezBoxWithFadeOut> m_Boxes;
 };

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
@@ -82,10 +82,9 @@ private:
 
 struct ezProcGenBoxExtents
 {
-  ezVec3 m_vPosition = ezVec3::ZeroVector();
+  ezVec3 m_vOffset = ezVec3::ZeroVector();
   ezQuat m_Rotation = ezQuat::IdentityQuaternion();
-  ezVec3 m_vInnerExtents = ezVec3(8);
-  ezVec3 m_vOuterExtents = ezVec3(10);
+  ezVec3 m_vExtents = ezVec3(10);
 
   ezResult Serialize(ezStreamWriter& stream) const;
   ezResult Deserialize(ezStreamReader& stream);
@@ -117,9 +116,17 @@ public:
   virtual void DeserializeComponent(ezWorldReader& stream) override;
 
 private:
+  ezUInt32 BoxExtents_GetCount() const;
+  const ezProcGenBoxExtents& BoxExtents_GetValue(ezUInt32 uiIndex) const;
+  void BoxExtents_SetValue(ezUInt32 uiIndex, const ezProcGenBoxExtents& value);
+  void BoxExtents_Insert(ezUInt32 uiIndex, const ezProcGenBoxExtents& value);
+  void BoxExtents_Remove(ezUInt32 uiIndex);
+
+  void UpdateBoundsAndTiles();
+
   ezProceduralPlacementResourceHandle m_hResource;
 
-  ezDynamicArray<ezProcGenBoxExtents> m_Extents;
+  ezDynamicArray<ezProcGenBoxExtents> m_BoxExtents;
 
   // runtime data
   struct Bounds

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
@@ -33,9 +33,9 @@ private:
   ezUInt32 AllocateTile(const ezPPInternal::TileDesc& desc, ezSharedPtr<const ezPPInternal::Layer>& pLayer);
   void DeallocateTile(ezUInt32 uiTileIndex);
 
-  ezUInt32 AllocatePlacementTask(ezUInt32 uiTileIndex);
-  void DeallocatePlacementTask(ezUInt32 uiPlacementTaskIndex);
-  ezUInt32 GetNumAllocatedPlacementTasks() const;
+  ezUInt32 AllocateProcessingTask(ezUInt32 uiTileIndex);
+  void DeallocateProcessingTask(ezUInt32 uiTaskIndex);
+  ezUInt32 GetNumAllocatedProcessingTasks() const;
 
   void RemoveTilesForComponent(ezProceduralPlacementComponent* pComponent, bool* out_bAnyObjectsRemoved = nullptr);
   void OnResourceEvent(const ezResourceEvent& resourceEvent);
@@ -58,23 +58,24 @@ private:
   ezDynamicArray<ezPPInternal::ActiveTile, ezAlignedAllocatorWrapper> m_ActiveTiles;
   ezDynamicArray<ezUInt32> m_FreeTiles;
 
-  struct PlacementTaskInfo
+  struct ProcessingTask
   {
     EZ_ALWAYS_INLINE bool IsValid() const { return m_uiTileIndex != ezInvalidIndex; }
-    EZ_ALWAYS_INLINE bool IsScheduled() const { return m_taskGroupID.IsValid(); }
+    EZ_ALWAYS_INLINE bool IsScheduled() const { return m_PlacementTaskGroupID.IsValid(); }
     EZ_ALWAYS_INLINE void Invalidate()
     {
-      m_taskGroupID = ezTaskGroupID();
+      m_PlacementTaskGroupID.Invalidate();
       m_uiTileIndex = ezInvalidIndex;
     }
 
-    ezUniquePtr<ezPPInternal::PlacementTask> m_pTask;
-    ezTaskGroupID m_taskGroupID;
+    ezUniquePtr<ezPPInternal::PrepareTask> m_pPrepareTask;
+    ezUniquePtr<ezPPInternal::PlacementTask> m_pPlacementTask;
+    ezTaskGroupID m_PlacementTaskGroupID;
     ezUInt32 m_uiTileIndex;
   };
 
-  ezDynamicArray<PlacementTaskInfo> m_PlacementTaskInfos;
-  ezDynamicArray<ezUInt32> m_FreePlacementTasks;
+  ezDynamicArray<ProcessingTask> m_ProcessingTasks;
+  ezDynamicArray<ezUInt32> m_FreeProcessingTasks;
 
   ezDynamicArray<ezPPInternal::TileDesc, ezAlignedAllocatorWrapper> m_NewTiles;
   ezTaskGroupID m_UpdateTilesTaskGroupID;

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
@@ -23,7 +23,8 @@ public:
 private:
   friend class ezProceduralPlacementComponent;
 
-  void Update(const ezWorldModule::UpdateContext& context);
+  void Prepare(const ezWorldModule::UpdateContext& context);
+  void Raycast(const ezWorldModule::UpdateContext& context);
   void PlaceObjects(const ezWorldModule::UpdateContext& context);
 
   void AddComponent(ezProceduralPlacementComponent* pComponent);
@@ -76,6 +77,7 @@ private:
   ezDynamicArray<ezUInt32> m_FreePlacementTasks;
 
   ezDynamicArray<ezPPInternal::TileDesc, ezAlignedAllocatorWrapper> m_NewTiles;
+  ezTaskGroupID m_UpdateTilesTaskGroupID;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -99,6 +101,8 @@ class EZ_PROCEDURALPLACEMENTPLUGIN_DLL ezProceduralPlacementComponent : public e
 public:
   ezProceduralPlacementComponent();
   ~ezProceduralPlacementComponent();
+
+  ezProceduralPlacementComponent& operator=(ezProceduralPlacementComponent&& other);
 
   virtual void OnActivated() override;
   virtual void OnDeactivated() override;
@@ -129,6 +133,8 @@ private:
   ezDynamicArray<ezProcGenBoxExtents> m_BoxExtents;
 
   // runtime data
+  friend class ezPPInternal::UpdateTilesTask;
+
   struct Bounds
   {
     EZ_DECLARE_POD_TYPE();
@@ -144,6 +150,8 @@ private:
     ezSharedPtr<const ezPPInternal::Layer> m_pLayer;
 
     ezHashTable<ezUInt64, ezUInt32> m_TileIndices;
+
+    ezUniquePtr<ezPPInternal::UpdateTilesTask> m_pUpdateTilesTask;
   };
 
   ezDynamicArray<ActiveLayer> m_Layers;

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
@@ -23,8 +23,8 @@ public:
 private:
   friend class ezProceduralPlacementComponent;
 
-  void Prepare(const ezWorldModule::UpdateContext& context);
-  void Raycast(const ezWorldModule::UpdateContext& context);
+  void UpdateTiles(const ezWorldModule::UpdateContext& context);
+  void PreparePlace(const ezWorldModule::UpdateContext& context);
   void PlaceObjects(const ezWorldModule::UpdateContext& context);
 
   void AddComponent(ezProceduralPlacementComponent* pComponent);
@@ -149,7 +149,15 @@ private:
   {
     ezSharedPtr<const ezPPInternal::Layer> m_pLayer;
 
-    ezHashTable<ezUInt64, ezUInt32> m_TileIndices;
+    struct TileIndexAndAge
+    {
+      EZ_DECLARE_POD_TYPE();
+
+      ezUInt32 m_uiIndex;
+      ezUInt64 m_uiLastSeenFrame;
+    };
+
+    ezHashTable<ezUInt64, TileIndexAndAge> m_TileIndices;
 
     ezUniquePtr<ezPPInternal::UpdateTilesTask> m_pUpdateTilesTask;
   };

--- a/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h
@@ -99,15 +99,15 @@ private:
 
 //////////////////////////////////////////////////////////////////////////
 
-struct ezBoxWithFadeOut
+struct ezProcGenBoxExtents
 {
-  ezVec3 m_vPosition;
-  ezQuat m_Rotation;
-  ezVec3 m_vExtents;
-  ezVec3 m_vFadeOutRange;
+  ezVec3 m_vPosition = ezVec3::ZeroVector();
+  ezQuat m_Rotation = ezQuat::IdentityQuaternion();
+  ezVec3 m_vInnerExtents = ezVec3(8);
+  ezVec3 m_vOuterExtents = ezVec3(10);
 };
 
-EZ_DECLARE_REFLECTABLE_TYPE(EZ_PROCEDURALPLACEMENTPLUGIN_DLL, ezBoxWithFadeOut);
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_PROCEDURALPLACEMENTPLUGIN_DLL, ezProcGenBoxExtents);
 
 class EZ_PROCEDURALPLACEMENTPLUGIN_DLL ezProceduralPlacementComponent : public ezComponent
 {
@@ -140,5 +140,5 @@ private:
   ezProceduralPlacementResourceHandle m_hResource;
   ezVec3 m_vExtents;
 
-  ezDynamicArray<ezBoxWithFadeOut> m_Boxes;
+  ezDynamicArray<ezProcGenBoxExtents> m_Extents;
 };

--- a/Code/Plugins/ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h
@@ -25,6 +25,7 @@ typedef ezTypedResourceHandle<class ezSurfaceResource> ezSurfaceResourceHandle;
 namespace ezPPInternal
 {
   class ActiveTile;
+  class UpdateTilesTask;
   class PlacementTask;
 
   struct Pattern

--- a/Code/Plugins/ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h
@@ -2,19 +2,20 @@
 
 // Configure the DLL Import/Export Define
 #if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)
-  #ifdef BUILDSYSTEM_BUILDING_PROCEDURALPLACEMENTPLUGIN_LIB
-    #define EZ_PROCEDURALPLACEMENTPLUGIN_DLL __declspec(dllexport)
-  #else
-    #define EZ_PROCEDURALPLACEMENTPLUGIN_DLL __declspec(dllimport)
-  #endif
+#  ifdef BUILDSYSTEM_BUILDING_PROCEDURALPLACEMENTPLUGIN_LIB
+#    define EZ_PROCEDURALPLACEMENTPLUGIN_DLL __declspec(dllexport)
+#  else
+#    define EZ_PROCEDURALPLACEMENTPLUGIN_DLL __declspec(dllimport)
+#  endif
 #else
-  #define EZ_PROCEDURALPLACEMENTPLUGIN_DLL
+#  define EZ_PROCEDURALPLACEMENTPLUGIN_DLL
 #endif
 
+#include <Core/ResourceManager/ResourceHandle.h>
+#include <Core/World/Declarations.h>
 #include <Foundation/SimdMath/SimdTransform.h>
 #include <Foundation/Strings/HashedString.h>
 #include <Foundation/Types/SharedPtr.h>
-#include <Core/ResourceManager/ResourceHandle.h>
 
 class ezExpressionByteCode;
 typedef ezTypedResourceHandle<class ezColorGradientResource> ezColorGradientResourceHandle;
@@ -55,18 +56,12 @@ namespace ezPPInternal
       m_pByteCode = nullptr;
     }
 
-    float GetTileSize() const
-    {
-      return m_pPattern->m_fSize * m_fFootprint;
-    }
+    float GetTileSize() const { return m_pPattern->m_fSize * m_fFootprint; }
 
     bool IsValid() const
     {
-      return !m_ObjectsToPlace.IsEmpty() &&
-        m_pPattern != nullptr &&
-        m_fFootprint > 0.0f &&
-        m_fCullDistance > 0.0f &&
-        m_pByteCode != nullptr;
+      return !m_ObjectsToPlace.IsEmpty() && m_pPattern != nullptr && m_fFootprint > 0.0f && m_fCullDistance > 0.0f &&
+             m_pByteCode != nullptr;
     }
 
     ezHashedString m_sName;
@@ -138,7 +133,7 @@ namespace ezPPInternal
 
   struct TileDesc
   {
-    ezUInt32 m_uiResourceIdHash;
+    ezComponentHandle m_hComponent;
     ezUInt32 m_uiLayerIndex;
     ezInt32 m_iPosX;
     ezInt32 m_iPosY;
@@ -147,6 +142,6 @@ namespace ezPPInternal
     float m_fPatternSize;
     float m_fDistanceToCamera;
 
-    ezHybridArray<ezSimdTransform, 8, ezAlignedAllocatorWrapper> m_LocalBoundingBoxes;
+    ezHybridArray<ezSimdTransform, 8, ezAlignedAllocatorWrapper> m_GlobalToLocalBoxTransforms;
   };
-}
+} // namespace ezPPInternal

--- a/Code/Plugins/ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h
@@ -26,6 +26,7 @@ namespace ezPPInternal
 {
   class ActiveTile;
   class UpdateTilesTask;
+  class PrepareTask;
   class PlacementTask;
 
   struct Pattern

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/Implementation/PrepareTask.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/Implementation/PrepareTask.cpp
@@ -1,0 +1,17 @@
+#include <ProceduralPlacementPluginPCH.h>
+
+#include <ProceduralPlacementPlugin/Tasks/PrepareTask.h>
+
+using namespace ezPPInternal;
+
+PrepareTask::PrepareTask(const char* szName)
+  : ezTask(szName)
+{
+}
+
+PrepareTask::~PrepareTask() = default;
+
+void PrepareTask::Execute()
+{
+  // Nothing to do here atm
+}

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/Implementation/UpdateTilesTask.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/Implementation/UpdateTilesTask.cpp
@@ -6,7 +6,7 @@
 
 ezCVarFloat CVarCullDistanceScale(
   "pp_CullDistanceScale", 1.0f, ezCVarFlags::Default, "Global scale to control cull distance for all layers");
-ezCVarInt CVarMaxCullRadius("pp_MaxCullRadius", 10, ezCVarFlags::Default, "Maximum cull radius in number of tiles");
+ezCVarInt CVarMaxCullRadius("pp_MaxCullRadius", 8, ezCVarFlags::Default, "Maximum cull radius in number of tiles");
 
 UpdateTilesTask::UpdateTilesTask(ezProceduralPlacementComponent* pComponent, ezUInt32 uiLayerIndex)
   : m_pComponent(pComponent)

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/Implementation/UpdateTilesTask.cpp
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/Implementation/UpdateTilesTask.cpp
@@ -1,0 +1,110 @@
+#include <ProceduralPlacementPluginPCH.h>
+
+#include <Foundation/Configuration/CVar.h>
+#include <ProceduralPlacementPlugin/Components/ProceduralPlacementComponent.h>
+#include <ProceduralPlacementPlugin/Tasks/UpdateTilesTask.h>
+
+ezCVarFloat CVarCullDistanceScale(
+  "pp_CullDistanceScale", 1.0f, ezCVarFlags::Default, "Global scale to control cull distance for all layers");
+ezCVarInt CVarMaxCullRadius("pp_MaxCullRadius", 10, ezCVarFlags::Default, "Maximum cull radius in number of tiles");
+
+UpdateTilesTask::UpdateTilesTask(ezProceduralPlacementComponent* pComponent, ezUInt32 uiLayerIndex)
+  : m_pComponent(pComponent)
+  , m_uiLayerIndex(uiLayerIndex)
+{
+  ezStringBuilder sName;
+  sName.Format("UpdateTiles {}", m_pComponent->m_Layers[m_uiLayerIndex].m_pLayer->m_sName);
+
+  SetTaskName(sName);
+}
+
+UpdateTilesTask::~UpdateTilesTask() = default;
+
+void ezPPInternal::UpdateTilesTask::Execute()
+{
+  m_NewTiles.Clear();
+
+  ezHybridArray<ezSimdTransform, 8, ezAlignedAllocatorWrapper> globalToLocalBoxTransforms;
+
+  auto& activeLayer = m_pComponent->m_Layers[m_uiLayerIndex];
+
+  const float fTileSize = activeLayer.m_pLayer->GetTileSize();
+  const float fPatternSize = activeLayer.m_pLayer->m_pPattern->m_fSize;
+  const float fCullDistance = activeLayer.m_pLayer->m_fCullDistance * CVarCullDistanceScale;
+  ezSimdVec4f fHalfTileSize = ezSimdVec4f(fTileSize * 0.5f);
+
+  for (ezVec3 vCameraPosition : m_vCameraPositions)
+  {
+    ezVec3 cameraPos = vCameraPosition / fTileSize;
+    float fPosX = ezMath::Round(cameraPos.x);
+    float fPosY = ezMath::Round(cameraPos.y);
+    ezInt32 iPosX = static_cast<ezInt32>(fPosX);
+    ezInt32 iPosY = static_cast<ezInt32>(fPosY);
+    float fRadius = ezMath::Min<float>(ezMath::Ceil(fCullDistance / fTileSize), CVarMaxCullRadius);
+    ezInt32 iRadius = static_cast<ezInt32>(fRadius);
+    ezInt32 iRadiusSqr = iRadius * iRadius;
+
+    float fY = (fPosY - fRadius) * fTileSize;
+    ezInt32 iY = -iRadius;
+
+    while (iY <= iRadius)
+    {
+      float fX = (fPosX - fRadius) * fTileSize;
+      ezInt32 iX = -iRadius;
+
+      while (iX <= iRadius)
+      {
+        if (iX * iX + iY * iY <= iRadiusSqr)
+        {
+          ezUInt64 uiTileKey = GetTileKey(iPosX + iX, iPosY + iY);
+          if (!activeLayer.m_TileIndices.Contains(uiTileKey))
+          {
+            ezSimdVec4f testPos = ezSimdVec4f(fX, fY, 0.0f);
+            ezSimdFloat minZ = 10000.0f;
+            ezSimdFloat maxZ = -10000.0f;
+
+            globalToLocalBoxTransforms.Clear();
+
+            for (auto& bounds : m_pComponent->m_Bounds)
+            {
+              ezSimdBBox extendedBox = bounds.m_GlobalBoundingBox;
+              extendedBox.Grow(fHalfTileSize);
+
+              if (((testPos >= extendedBox.m_Min) && (testPos <= extendedBox.m_Max)).AllSet<2>())
+              {
+                minZ = minZ.Min(bounds.m_GlobalBoundingBox.m_Min.z());
+                maxZ = maxZ.Max(bounds.m_GlobalBoundingBox.m_Max.z());
+
+                globalToLocalBoxTransforms.PushBack(bounds.m_GlobalToLocalBoxTransform);
+              }
+            }
+
+            if (!globalToLocalBoxTransforms.IsEmpty())
+            {
+              activeLayer.m_TileIndices.Insert(uiTileKey, EmptyTileIndex);
+
+              auto& newTile = m_NewTiles.ExpandAndGetRef();
+              newTile.m_hComponent = m_pComponent->GetHandle();
+              newTile.m_uiLayerIndex = m_uiLayerIndex;
+              newTile.m_iPosX = iPosX + iX;
+              newTile.m_iPosY = iPosY + iY;
+              newTile.m_fMinZ = minZ;
+              newTile.m_fMaxZ = maxZ;
+              newTile.m_fPatternSize = fPatternSize;
+              newTile.m_fDistanceToCamera = -1.0f;
+              newTile.m_GlobalToLocalBoxTransforms = globalToLocalBoxTransforms;
+            }
+          }
+        }
+
+        ++iX;
+        fX += fTileSize;
+      }
+
+      ++iY;
+      fY += fTileSize;
+    }
+  }
+
+  m_vCameraPositions.Clear();
+}

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/PlacementTask.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/PlacementTask.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <Foundation/Threading/TaskSystem.h>
 #include <ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h>
 #include <ProceduralPlacementPlugin/VM/ExpressionVM.h>
-#include <Foundation/Threading/TaskSystem.h>
+
+class ezPhysicsWorldModuleInterface;
 
 namespace ezPPInternal
 {
@@ -19,11 +21,20 @@ namespace ezPPInternal
 
   private:
     friend class ActiveTile;
+    friend class PrepareTask;
 
     virtual void Execute() override;
 
+    void FindPlacementPoints();
+    void ExecuteVM();
+
+    const ezPhysicsWorldModuleInterface* m_pPhysicsModule = nullptr;
+
     ezSharedPtr<const Layer> m_pLayer;
-    ezInt32 m_iTileSeed;
+    ezInt32 m_iTileSeed = 0;
+    ezBoundingBox m_TileBoundingBox;
+
+    ezDynamicArray<ezSimdTransform, ezAlignedAllocatorWrapper> m_GlobalToLocalBoxTransforms;
 
     ezDynamicArray<PlacementPoint, ezAlignedAllocatorWrapper> m_InputPoints;
     ezDynamicArray<PlacementTransform, ezAlignedAllocatorWrapper> m_OutputTransforms;
@@ -32,4 +43,4 @@ namespace ezPPInternal
 
     ezExpressionVM m_VM;
   };
-}
+} // namespace ezPPInternal

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/PlacementTask.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/PlacementTask.h
@@ -32,5 +32,4 @@ namespace ezPPInternal
 
     ezExpressionVM m_VM;
   };
-
 }

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/PrepareTask.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/PrepareTask.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h>
+#include <ProceduralPlacementPlugin/VM/ExpressionVM.h>
+#include <Foundation/Threading/TaskSystem.h>
+
+namespace ezPPInternal
+{
+  class EZ_PROCEDURALPLACEMENTPLUGIN_DLL PrepareTask : public ezTask
+  {
+  public:
+    PrepareTask(const char* szName);
+    ~PrepareTask();
+
+  private:
+    virtual void Execute() override;
+  };
+}

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/UpdateTilesTask.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/UpdateTilesTask.h
@@ -20,6 +20,7 @@ namespace ezPPInternal
     void AddCameraPosition(const ezVec3& vCameraPosition) { m_vCameraPositions.PushBack(vCameraPosition); }
 
     ezArrayPtr<const TileDesc> GetNewTiles() const { return m_NewTiles; }
+    ezArrayPtr<const ezUInt64> GetOldTiles() const { return m_OldTileKeys; }
 
   private:
     virtual void Execute() override;
@@ -30,13 +31,24 @@ namespace ezPPInternal
     ezHybridArray<ezVec3, 2> m_vCameraPositions;
 
     ezDynamicArray<TileDesc, ezAlignedAllocatorWrapper> m_NewTiles;
+    ezDynamicArray<ezUInt64> m_OldTileKeys;
+
+    struct TileByAge
+    {
+      EZ_DECLARE_POD_TYPE();
+
+      ezUInt64 m_uiTileKey;
+      ezUInt64 m_uiLastSeenFrame;
+    };
+
+    ezDynamicArray<TileByAge> m_TilesByAge;
   };
 
   EZ_ALWAYS_INLINE ezUInt64 GetTileKey(ezInt32 x, ezInt32 y)
   {
     ezUInt64 sx = (ezUInt32)x;
     ezUInt64 sy = (ezUInt32)y;
-    
+
     return (sx << 32) | sy;
   }
 } // namespace ezPPInternal

--- a/Code/Plugins/ProceduralPlacementPlugin/Tasks/UpdateTilesTask.h
+++ b/Code/Plugins/ProceduralPlacementPlugin/Tasks/UpdateTilesTask.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <Foundation/Threading/TaskSystem.h>
+#include <ProceduralPlacementPlugin/ProceduralPlacementPluginDLL.h>
+
+#ifndef EmptyTileIndex
+#  define EmptyTileIndex ezInvalidIndex
+#endif
+
+class ezProceduralPlacementComponent;
+
+namespace ezPPInternal
+{
+  class UpdateTilesTask : public ezTask
+  {
+  public:
+    UpdateTilesTask(ezProceduralPlacementComponent* pComponent, ezUInt32 uiLayerIndex);
+    ~UpdateTilesTask();
+
+    void AddCameraPosition(const ezVec3& vCameraPosition) { m_vCameraPositions.PushBack(vCameraPosition); }
+
+    ezArrayPtr<const TileDesc> GetNewTiles() const { return m_NewTiles; }
+
+  private:
+    virtual void Execute() override;
+
+    ezProceduralPlacementComponent* m_pComponent = nullptr;
+    ezUInt32 m_uiLayerIndex = 0;
+
+    ezHybridArray<ezVec3, 2> m_vCameraPositions;
+
+    ezDynamicArray<TileDesc, ezAlignedAllocatorWrapper> m_NewTiles;
+  };
+
+  EZ_ALWAYS_INLINE ezUInt64 GetTileKey(ezInt32 x, ezInt32 y)
+  {
+    ezUInt64 sx = (ezUInt32)x;
+    ezUInt64 sy = (ezUInt32)y;
+    
+    return (sx << 32) | sy;
+  }
+} // namespace ezPPInternal

--- a/Code/Tools/EditorFramework/Manipulators/BoxManipulatorAdapter.h
+++ b/Code/Tools/EditorFramework/Manipulators/BoxManipulatorAdapter.h
@@ -19,5 +19,7 @@ protected:
 
   virtual void UpdateGizmoTransform() override;
 
+  ezVec3 m_vPositionOffset;
+  ezQuat m_Rotation;
   ezBoxGizmo m_Gizmo;
 };

--- a/Code/Tools/EditorFramework/Manipulators/Implementation/BoxManipulatorAdapter.cpp
+++ b/Code/Tools/EditorFramework/Manipulators/Implementation/BoxManipulatorAdapter.cpp
@@ -39,7 +39,21 @@ void ezBoxManipulatorAdapter::Update()
     m_Gizmo.SetSize(vSize);
   }
 
-  m_Gizmo.SetTransformation(GetObjectTransform());
+  m_vPositionOffset.SetZero();
+
+  if (!pAttr->GetOffsetProperty().IsEmpty())
+  {
+    m_vPositionOffset = pObjectAccessor->Get<ezVec3>(m_pObject, GetProperty(pAttr->GetOffsetProperty()));
+  }
+
+  m_Rotation.SetIdentity();
+
+  if (!pAttr->GetRotationProperty().IsEmpty())
+  {
+    m_Rotation = pObjectAccessor->Get<ezQuat>(m_pObject, GetProperty(pAttr->GetRotationProperty()));
+  }
+
+  UpdateGizmoTransform();
 }
 
 void ezBoxManipulatorAdapter::GizmoEventHandler(const ezGizmoEvent& e)
@@ -70,5 +84,10 @@ void ezBoxManipulatorAdapter::GizmoEventHandler(const ezGizmoEvent& e)
 
 void ezBoxManipulatorAdapter::UpdateGizmoTransform()
 {
-  m_Gizmo.SetTransformation(GetObjectTransform());
+  ezTransform t;
+  t.m_vScale.Set(1);
+  t.m_vPosition = m_vPositionOffset;
+  t.m_qRotation = m_Rotation;
+
+  m_Gizmo.SetTransformation(GetObjectTransform() * t);
 }

--- a/Code/Tools/EditorFramework/Manipulators/TransformManipulatorAdapter.h
+++ b/Code/Tools/EditorFramework/Manipulators/TransformManipulatorAdapter.h
@@ -21,6 +21,10 @@ protected:
 
   virtual void UpdateGizmoTransform() override;
 
+  ezVec3 GetTranslation();
+  ezQuat GetRotation();
+  ezVec3 GetScale();
+
   ezTranslateGizmo m_TranslateGizmo;
   ezRotateGizmo m_RotateGizmo;
   ezManipulatorScaleGizmo m_ScaleGizmo;

--- a/Code/Tools/EditorFramework/Visualizers/BoxVisualizerAdapter.h
+++ b/Code/Tools/EditorFramework/Visualizers/BoxVisualizerAdapter.h
@@ -20,5 +20,6 @@ protected:
 
   ezVec3 m_Scale;
   ezVec3 m_vPositionOffset;
+  ezQuat m_Rotation;
   ezEngineGizmoHandle m_Gizmo;
 };

--- a/Code/Tools/EditorFramework/Visualizers/Implementation/BoxVisualizerAdapter.cpp
+++ b/Code/Tools/EditorFramework/Visualizers/Implementation/BoxVisualizerAdapter.cpp
@@ -33,7 +33,6 @@ void ezBoxVisualizerAdapter::Update()
 
   if (!pAttr->GetSizeProperty().IsEmpty())
   {
-
     m_Scale = pObjectAccessor->Get<ezVec3>(m_pObject, GetProperty(pAttr->GetSizeProperty()));
   }
 
@@ -55,14 +54,21 @@ void ezBoxVisualizerAdapter::Update()
     EZ_ASSERT_DEBUG(value.IsValid() && value.CanConvertTo<ezVec3>(), "Invalid property bound to ezBoxVisualizerAttribute 'offset'");
     m_vPositionOffset += value.ConvertTo<ezVec3>();
   }
+
+  m_Rotation.SetIdentity();
+
+  if (!pAttr->GetRotationProperty().IsEmpty())
+  {
+    m_Rotation = pObjectAccessor->Get<ezQuat>(m_pObject, GetProperty(pAttr->GetRotationProperty()));
+  }
 }
 
 void ezBoxVisualizerAdapter::UpdateGizmoTransform()
 {
   ezTransform t;
-  t.m_qRotation.SetIdentity();
   t.m_vScale = m_Scale;
   t.m_vPosition = m_vPositionOffset;
+  t.m_qRotation = m_Rotation;
 
   m_Gizmo.SetTransformation(GetObjectTransform() * t);
 }

--- a/Code/Tools/EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementNodes.cpp
+++ b/Code/Tools/EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementNodes.cpp
@@ -1,6 +1,7 @@
 #include <EditorPluginProceduralPlacementPCH.h>
 
 #include <EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementNodes.h>
+#include <Foundation/Math/Random.h>
 
 namespace
 {
@@ -47,7 +48,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProceduralPlacementLayerOutput, 1, ezRTTIDefau
     EZ_MEMBER_PROPERTY("MinScale", m_vMinScale)->AddAttributes(new ezDefaultValueAttribute(ezVec3(1.0f)), new ezClampValueAttribute(ezVec3(0.0f), ezVariant())),
     EZ_MEMBER_PROPERTY("MaxScale", m_vMaxScale)->AddAttributes(new ezDefaultValueAttribute(ezVec3(1.0f)), new ezClampValueAttribute(ezVec3(0.0f), ezVariant())),
     EZ_MEMBER_PROPERTY("ColorGradient", m_sColorGradient)->AddAttributes(new ezAssetBrowserAttribute("ColorGradient")),
-    EZ_MEMBER_PROPERTY("CullDistance", m_fCullDistance)->AddAttributes(new ezDefaultValueAttribute(100.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_MEMBER_PROPERTY("CullDistance", m_fCullDistance)->AddAttributes(new ezDefaultValueAttribute(30.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("Surface")),
 
@@ -164,6 +165,11 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProceduralPlacementRandom, 1, ezRTTIDefaultAll
     EZ_MEMBER_PROPERTY("Value", m_OutputValuePin)
   }
   EZ_END_PROPERTIES;
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_FUNCTION_PROPERTY(OnObjectCreated),
+  }
+  EZ_END_FUNCTIONS;
   EZ_BEGIN_ATTRIBUTES
   {
     new ezTitleAttribute("Random: {Seed}"),
@@ -177,8 +183,16 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezExpressionAST::Node* ezProceduralPlacementRandom::GenerateExpressionASTNode(
   ezArrayPtr<ezExpressionAST::Node*> inputs, ezExpressionAST& out_Ast)
 {
-  auto pRandom = CreateRandom(m_iSeed, out_Ast);
+  ezRandom rnd;
+  rnd.Initialize(m_iSeed < 0 ? m_uiAutoSeed : m_iSeed);
+
+  auto pRandom = CreateRandom(rnd.FloatMinMax(0.0f, 100000.0f), out_Ast);
   return pRandom;
+}
+
+void ezProceduralPlacementRandom::OnObjectCreated(const ezAbstractObjectNode& node)
+{
+  m_uiAutoSeed = ezHashHelper<ezUuid>::Hash(node.GetGuid());
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Tools/EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementNodes.h
+++ b/Code/Tools/EditorPluginProceduralPlacement/ProceduralPlacementAsset/ProceduralPlacementNodes.h
@@ -37,7 +37,7 @@ public:
   ezVec3 m_vMinScale = ezVec3(1);
   ezVec3 m_vMaxScale = ezVec3(1);
 
-  float m_fCullDistance = 100;
+  float m_fCullDistance = 30.0f;
 
   ezUInt32 m_uiCollisionLayer = 0;
 
@@ -65,6 +65,11 @@ public:
   ezInt32 m_iSeed = -1;
 
   ezOutputNodePin m_OutputValuePin;
+
+private:
+  void OnObjectCreated(const ezAbstractObjectNode& node);
+
+  ezUInt32 m_uiAutoSeed;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Data/Samples/Testing Chambers/Plugins.ddl
+++ b/Data/Samples/Testing Chambers/Plugins.ddl
@@ -24,6 +24,12 @@ Plugin
 }
 Plugin
 {
+	string %Path{"ezEnginePluginProceduralPlacement"}
+	bool %LoadCopy{false}
+	string %DependencyOf{"EditorPluginProceduralPlacement"}
+}
+Plugin
+{
 	string %Path{"ezEnginePluginScene"}
 	bool %LoadCopy{false}
 	string %DependencyOf{"EditorPluginScene"}

--- a/Data/Samples/Testing Chambers/Scenes/Corridor.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Corridor.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{1977558759748590222}
+		u4 %Hash{13611242935576824204}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %References
@@ -3979,6 +3979,18 @@ o
 }
 o
 {
+	Uuid %id{u4{11068466961908290238,4903866592875722828}}
+	s %t{"ezProcGenBoxExtents"}
+	u3 %v{1}
+	p
+	{
+		Vec3 %Extents{f{0x00004843,0x00004843,0x00002041}}
+		Vec3 %Offset{f{0,0,0}}
+		Quat %Rotation{f{0,0,0,0x0000803F}}
+	}
+}
+o
+{
 	Uuid %id{u4{8711948141835682434,4913688216909541147}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{3}
@@ -5725,7 +5737,10 @@ o
 	p
 	{
 		b %Active{1}
-		Vec3 %Extents{f{0x00004843,0x00004843,0x00002041}}
+		VarArray %BoxExtents
+		{
+			Uuid{u4{11068466961908290238,4903866592875722828}}
+		}
 		s %Resource{"{ 5f7e8998-fe23-4a33-aa84-d10d4dfcf2a6 }"}
 	}
 }
@@ -19290,7 +19305,7 @@ o
 		s %PluginName{"ezEditorPluginProceduralPlacement"}
 		VarArray %Properties{}
 		s %TypeName{"ezProceduralPlacementComponent"}
-		u3 %TypeSize{72}
+		u3 %TypeSize{128}
 		u3 %TypeVersion{1}
 	}
 }
@@ -20322,6 +20337,24 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"AgentHeight"}
 		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{10743191096997614114,17783734772379841776}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"ezEditorPluginProceduralPlacement"}
+		VarArray %Properties{}
+		s %TypeName{"ezProcGenBoxExtents"}
+		u3 %TypeSize{40}
+		u3 %TypeVersion{1}
 	}
 }
 o

--- a/Data/Tools/ezEditor/Localization/en/ProceduralPlacementPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ProceduralPlacementPlugin.txt
@@ -3,3 +3,5 @@ ProceduralPlacement.DumpDisassembly;Dump Disassembly
 Objects;Objects
 ProceduralPlacement;Procedural Placement
 ezProceduralPlacementComponent;Procedural Placement
+ezProcGenBoxExtents;Box Extents
+BoxExtents;Extents


### PR DESCRIPTION
The procedural placement component now has multiple box extents so internal logic can do placement now per component instead of per resource. 
Placement tiles are now also removed if a certain number of tiles per layer is exceeded. 
Moved all internal placement work into tasks.
Fixed a few per frame allocations and a bug in render data caching that slowed down the engine drastically if objects are continously created and deleted.