### PR TITLE
Mesh render data cleanup

### DIFF
--- a/Code/Engine/GameEngine/Animation/AnimatedMeshComponent.h
+++ b/Code/Engine/GameEngine/Animation/AnimatedMeshComponent.h
@@ -3,7 +3,7 @@
 #include <GameEngine/GameEngineDLL.h>
 #include <RendererCore/AnimationSystem/AnimationGraph/AnimationClipSampler.h>
 #include <RendererCore/AnimationSystem/AnimationPose.h>
-#include <RendererCore/Meshes/MeshComponentBase.h>
+#include <RendererCore/Meshes/SkinnedMeshComponent.h>
 
 struct ezSkeletonResourceDescriptor;
 typedef ezTypedResourceHandle<class ezAnimationClipResource> ezAnimationClipResourceHandle;
@@ -11,9 +11,9 @@ typedef ezTypedResourceHandle<class ezSkeletonResource> ezSkeletonResourceHandle
 
 typedef ezComponentManagerSimple<class ezAnimatedMeshComponent, ezComponentUpdateType::WhenSimulating> ezAnimatedMeshComponentManager;
 
-class EZ_GAMEENGINE_DLL ezAnimatedMeshComponent : public ezMeshComponentBase
+class EZ_GAMEENGINE_DLL ezAnimatedMeshComponent : public ezSkinnedMeshComponent
 {
-  EZ_DECLARE_COMPONENT_TYPE(ezAnimatedMeshComponent, ezMeshComponentBase, ezAnimatedMeshComponentManager);
+  EZ_DECLARE_COMPONENT_TYPE(ezAnimatedMeshComponent, ezSkinnedMeshComponent, ezAnimatedMeshComponentManager);
 
 public:
   ezAnimatedMeshComponent();
@@ -57,4 +57,3 @@ protected:
   ezSkeletonResourceHandle m_hSkeleton;
   ezAnimationClipSampler m_AnimationClipSampler;
 };
-

--- a/Code/Engine/GameEngine/Animation/MotionMatchingComponent.h
+++ b/Code/Engine/GameEngine/Animation/MotionMatchingComponent.h
@@ -3,16 +3,16 @@
 #include <GameEngine/GameEngineDLL.h>
 #include <RendererCore/AnimationSystem/AnimationGraph/AnimationClipSampler.h>
 #include <RendererCore/AnimationSystem/AnimationPose.h>
-#include <RendererCore/Meshes/MeshComponentBase.h>
+#include <RendererCore/Meshes/SkinnedMeshComponent.h>
 
 typedef ezTypedResourceHandle<class ezAnimationClipResource> ezAnimationClipResourceHandle;
 typedef ezTypedResourceHandle<class ezSkeletonResource> ezSkeletonResourceHandle;
 
 typedef ezComponentManagerSimple<class ezMotionMatchingComponent, ezComponentUpdateType::WhenSimulating> ezMotionMatchingComponentManager;
 
-class EZ_GAMEENGINE_DLL ezMotionMatchingComponent : public ezMeshComponentBase
+class EZ_GAMEENGINE_DLL ezMotionMatchingComponent : public ezSkinnedMeshComponent
 {
-  EZ_DECLARE_COMPONENT_TYPE(ezMotionMatchingComponent, ezMeshComponentBase, ezMotionMatchingComponentManager);
+  EZ_DECLARE_COMPONENT_TYPE(ezMotionMatchingComponent, ezSkinnedMeshComponent, ezMotionMatchingComponentManager);
 
 public:
   ezMotionMatchingComponent();
@@ -83,9 +83,7 @@ protected:
   ezDynamicArray<MotionData> m_MotionData;
 
   static void PrecomputeMotion(ezDynamicArray<MotionData>& motionData, ezTempHashedString jointName1, ezTempHashedString jointName2,
-                               const ezAnimationClipResourceDescriptor& animClip, ezUInt16 uiAnimClipIndex, const ezSkeleton& skeleton);
+    const ezAnimationClipResourceDescriptor& animClip, ezUInt16 uiAnimClipIndex, const ezSkeleton& skeleton);
 
-  ezUInt32 FindBestKeyframe(const TargetKeyframe& current, ezVec3 vLeftFootPosition, ezVec3 vRightFootPosition,
-                            ezVec3 vTargetDir) const;
+  ezUInt32 FindBestKeyframe(const TargetKeyframe& current, ezVec3 vLeftFootPosition, ezVec3 vRightFootPosition, ezVec3 vTargetDir) const;
 };
-

--- a/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
@@ -11,8 +11,6 @@
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
 
-
-
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_TYPE(ezMeshInstanceData, ezNoBase, 1, ezRTTIDefaultAllocator<ezMeshInstanceData>)
 {
@@ -85,6 +83,18 @@ ezResult ezMeshInstanceData::Deserialize(ezStreamReader& reader)
   return EZ_SUCCESS;
 }
 
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezInstancedMeshRenderData, 1, ezRTTIDefaultAllocator<ezInstancedMeshRenderData>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezInstancedMeshRenderData::FillBatchIdAndSortingKey()
+{
+  FillBatchIdAndSortingKeyInternal(m_uiUniqueID);
+}
+
 //////////////////////////////////////////////////////////////////////////////////////
 
 ezInstancedMeshComponentManager::ezInstancedMeshComponentManager(ezWorld* pWorld)
@@ -106,7 +116,7 @@ void ezInstancedMeshComponentManager::EnqueueUpdate(const ezInstancedMeshCompone
   if (instanceData.IsEmpty())
     return;
 
-  m_RequireUpdate.PushBack({ pComponent->GetHandle(), instanceData });
+  m_RequireUpdate.PushBack({pComponent->GetHandle(), instanceData});
   pComponent->m_uiEnqueuedFrame = uiCurrentFrame;
 }
 
@@ -243,7 +253,7 @@ void ezInstancedMeshComponent::OnExtractRenderData(ezMsgExtractRenderData& msg) 
 
 ezMeshRenderData* ezInstancedMeshComponent::CreateRenderData() const
 {
-  auto pRenderData = ezCreateRenderDataForThisFrame<ezMeshRenderData>(GetOwner());
+  auto pRenderData = ezCreateRenderDataForThisFrame<ezInstancedMeshRenderData>(GetOwner());
 
   if (m_pExplicitInstanceData)
   {

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshRenderer.cpp
@@ -2,7 +2,7 @@
 
 #include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/GPUResourcePool/GPUResourcePool.h>
-#include <RendererCore/Meshes/MeshComponent.h>
+#include <RendererCore/Meshes/InstancedMeshComponent.h>
 #include <RendererCore/Meshes/MeshRenderer.h>
 #include <RendererCore/Pipeline/InstanceDataProvider.h>
 #include <RendererCore/Pipeline/RenderPipeline.h>
@@ -19,9 +19,10 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezMeshRenderer::ezMeshRenderer() = default;
 ezMeshRenderer::~ezMeshRenderer() = default;
 
-void ezMeshRenderer::GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& types)const
+void ezMeshRenderer::GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& types) const
 {
   types.PushBack(ezGetStaticRTTI<ezMeshRenderData>());
+  types.PushBack(ezGetStaticRTTI<ezInstancedMeshRenderData>());
 }
 
 void ezMeshRenderer::GetSupportedRenderDataCategories(ezHybridArray<ezRenderData::Category, 8>& categories) const
@@ -50,7 +51,7 @@ void ezMeshRenderer::RenderBatch(
   const ezMeshResourceHandle& hMesh = pRenderData->m_hMesh;
   const ezMaterialResourceHandle& hMaterial = pRenderData->m_hMaterial;
   const ezUInt32 uiPartIndex = pRenderData->m_uiSubMeshIndex;
-  const bool bHasExplicitInstanceData = pRenderData->m_pExplicitInstanceData != nullptr;
+  const bool bHasExplicitInstanceData = pRenderData->IsInstanceOf<ezInstancedMeshRenderData>();
 
   ezResourceLock<ezMeshResource> pMesh(hMesh, ezResourceAcquireMode::AllowFallback);
 
@@ -62,7 +63,7 @@ void ezMeshRenderer::RenderBatch(
   }
 
   ezInstanceData* pInstanceData = bHasExplicitInstanceData
-                                    ? pRenderData->m_pExplicitInstanceData
+                                    ? static_cast<const ezInstancedMeshRenderData*>(pRenderData)->m_pExplicitInstanceData
                                     : pPass->GetPipeline()->GetFrameDataProvider<ezInstanceDataProvider>()->GetData(renderViewContext);
 
   pInstanceData->BindResources(pContext);
@@ -76,25 +77,10 @@ void ezMeshRenderer::RenderBatch(
     pContext->SetShaderPermutationVariable("FLIP_WINDING", "FALSE");
   }
 
-  // Bind skinning matrices if supplied and set the appropriate permutation variable
-  if (pRenderData->m_hSkinningMatrices.IsInvalidated())
-  {
-    pContext->SetShaderPermutationVariable("VERTEX_SKINNING", "FALSE");
-  }
-  else
-  {
-    pContext->SetShaderPermutationVariable("VERTEX_SKINNING", "TRUE");
-
-    if (!pRenderData->m_pNewSkinningMatricesData.IsEmpty())
-    {
-      pContext->GetGALContext()->UpdateBuffer(pRenderData->m_hSkinningMatrices, 0, pRenderData->m_pNewSkinningMatricesData);
-    }
-
-    pContext->BindBuffer("skinningMatrices", pDevice->GetDefaultResourceView(pRenderData->m_hSkinningMatrices));
-  }
-
   pContext->BindMaterial(hMaterial);
   pContext->BindMeshBuffer(pMesh->GetMeshBuffer());
+
+  SetAdditionalData(renderViewContext, pRenderData);
 
   if (!bHasExplicitInstanceData)
   {
@@ -139,7 +125,7 @@ void ezMeshRenderer::RenderBatch(
   }
   else
   {
-    ezUInt32 uiInstanceCount = pRenderData->m_uiExplicitInstanceCount;
+    ezUInt32 uiInstanceCount = static_cast<const ezInstancedMeshRenderData*>(pRenderData)->m_uiExplicitInstanceCount;
 
     if (renderViewContext.m_pCamera->IsStereoscopic())
       uiInstanceCount *= 2;
@@ -192,6 +178,9 @@ void ezMeshRenderer::FillPerInstanceData(
   out_uiFilteredCount = uiCurrentIndex;
 }
 
-
+void ezMeshRenderer::SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const
+{
+  renderViewContext.m_pRenderContext->SetShaderPermutationVariable("VERTEX_SKINNING", "FALSE");
+}
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Meshes_Implementation_MeshRenderer);

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -1,0 +1,95 @@
+#include <RendererCorePCH.h>
+
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <RendererCore/Meshes/SkinnedMeshComponent.h>
+#include <RendererFoundation/Device/Device.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkinnedMeshRenderData, 1, ezRTTIDefaultAllocator<ezSkinnedMeshRenderData>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezSkinnedMeshRenderData::FillBatchIdAndSortingKey()
+{
+  FillBatchIdAndSortingKeyInternal(m_uiUniqueID);
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezSkinnedMeshComponent, 1);
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Mesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("Animated Mesh")),
+    EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
+    EZ_ARRAY_ACCESSOR_PROPERTY("Materials", Materials_GetCount, Materials_GetValue, Materials_SetValue, Materials_Insert, Materials_Remove)->AddAttributes(new ezAssetBrowserAttribute("Material")),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_COMPONENT_TYPE
+// clang-format on
+
+ezSkinnedMeshComponent::ezSkinnedMeshComponent() = default;
+ezSkinnedMeshComponent::~ezSkinnedMeshComponent() = default;
+
+void ezSkinnedMeshComponent::SerializeComponent(ezWorldWriter& stream) const
+{
+  SUPER::SerializeComponent(stream);
+  auto& s = stream.GetStream();
+}
+
+void ezSkinnedMeshComponent::DeserializeComponent(ezWorldReader& stream)
+{
+  SUPER::DeserializeComponent(stream);
+  const ezUInt32 uiVersion = stream.GetComponentTypeVersion(GetStaticRTTI());
+  auto& s = stream.GetStream();
+}
+
+void ezSkinnedMeshComponent::OnDeactivated()
+{
+  if (!m_hSkinningTransformsBuffer.IsInvalidated())
+  {
+    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hSkinningTransformsBuffer);
+    m_hSkinningTransformsBuffer.Invalidate();
+  }
+
+  SUPER::OnDeactivated();
+}
+
+ezMeshRenderData* ezSkinnedMeshComponent::CreateRenderData() const
+{
+  auto pRenderData = ezCreateRenderDataForThisFrame<ezSkinnedMeshRenderData>(GetOwner());
+
+  if (!m_SkinningMatrices.IsEmpty())
+  {
+    pRenderData->m_hSkinningMatrices = m_hSkinningTransformsBuffer;
+    pRenderData->m_pNewSkinningMatricesData = ezArrayPtr<const ezUInt8>(
+      reinterpret_cast<const ezUInt8*>(m_SkinningMatrices.GetPtr()), m_SkinningMatrices.GetCount() * sizeof(ezMat4));
+  }
+
+  return pRenderData;
+}
+
+void ezSkinnedMeshComponent::CreateSkinningTransformBuffer(ezArrayPtr<const ezMat4> skinningMatrices)
+{
+  EZ_ASSERT_DEBUG(m_hSkinningTransformsBuffer.IsInvalidated(), "The skinning buffer should not exist at this time");
+
+  ezGALBufferCreationDescription BufferDesc;
+  BufferDesc.m_uiStructSize = sizeof(ezMat4);
+  BufferDesc.m_uiTotalSize = BufferDesc.m_uiStructSize * skinningMatrices.GetCount();
+  BufferDesc.m_bUseAsStructuredBuffer = true;
+  BufferDesc.m_bAllowShaderResourceView = true;
+  BufferDesc.m_ResourceAccess.m_bImmutable = false;
+
+  m_hSkinningTransformsBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(BufferDesc, skinningMatrices.ToByteArray());
+}
+
+void ezSkinnedMeshComponent::UpdateSkinningTransformBuffer(ezArrayPtr<const ezMat4> skinningMatrices)
+{
+  ezArrayPtr<ezMat4> pRenderMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezMat4, skinningMatrices.GetCount());
+  pRenderMatrices.CopyFrom(skinningMatrices);
+
+  m_SkinningMatrices = pRenderMatrices;
+}

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
@@ -1,0 +1,42 @@
+#include <RendererCorePCH.h>
+
+#include <RendererCore/Meshes/SkinnedMeshComponent.h>
+#include <RendererCore/Meshes/SkinnedMeshRenderer.h>
+#include <RendererCore/RenderContext/RenderContext.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkinnedMeshRenderer, 1, ezRTTIDefaultAllocator<ezSkinnedMeshRenderer>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezSkinnedMeshRenderer::ezSkinnedMeshRenderer() = default;
+ezSkinnedMeshRenderer::~ezSkinnedMeshRenderer() = default;
+
+void ezSkinnedMeshRenderer::GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& types) const
+{
+  types.PushBack(ezGetStaticRTTI<ezSkinnedMeshRenderData>());
+}
+
+void ezSkinnedMeshRenderer::SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const
+{
+  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
+  ezRenderContext* pContext = renderViewContext.m_pRenderContext;
+
+  auto pSkinnedRenderData = static_cast<const ezSkinnedMeshRenderData*>(pRenderData);
+
+  if (pSkinnedRenderData->m_hSkinningMatrices.IsInvalidated())
+  {
+    pContext->SetShaderPermutationVariable("VERTEX_SKINNING", "FALSE");
+  }
+  else
+  {
+    pContext->SetShaderPermutationVariable("VERTEX_SKINNING", "TRUE");
+
+    if (!pSkinnedRenderData->m_pNewSkinningMatricesData.IsEmpty())
+    {
+      pContext->GetGALContext()->UpdateBuffer(pSkinnedRenderData->m_hSkinningMatrices, 0, pSkinnedRenderData->m_pNewSkinningMatricesData);
+    }
+
+    pContext->BindBuffer("skinningMatrices", pDevice->GetDefaultResourceView(pSkinnedRenderData->m_hSkinningMatrices));
+  }
+}

--- a/Code/Engine/RendererCore/Meshes/InstancedMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/InstancedMeshComponent.h
@@ -32,6 +32,19 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_RENDERERCORE_DLL, ezMeshInstanceData);
 
 //////////////////////////////////////////////////////////////////////////
 
+class EZ_RENDERERCORE_DLL ezInstancedMeshRenderData : public ezMeshRenderData
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezInstancedMeshRenderData, ezMeshRenderData);
+
+public:
+  virtual void FillBatchIdAndSortingKey() override;
+
+  ezInstanceData* m_pExplicitInstanceData = nullptr;
+  ezUInt32 m_uiExplicitInstanceCount = 0;
+};
+
+//////////////////////////////////////////////////////////////////////////
+
 class EZ_RENDERERCORE_DLL ezInstancedMeshComponentManager
   : public ezComponentManager<class ezInstancedMeshComponent, ezBlockStorageType::Compact>
 {

--- a/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
+++ b/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
@@ -14,23 +14,34 @@ class EZ_RENDERERCORE_DLL ezMeshRenderData : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezMeshRenderData, ezRenderData);
 
 public:
-  void FillBatchIdAndSortingKey();
-
+  virtual void FillBatchIdAndSortingKey();
+  
   ezMeshResourceHandle m_hMesh;
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
-  ezGALBufferHandle m_hSkinningMatrices;
-  ezArrayPtr<const ezUInt8>
-      m_pNewSkinningMatricesData; // Optional - if set the buffer specified in m_hSkinningMatrices will be updated with this data
-
-  ezInstanceData* m_pExplicitInstanceData = nullptr; // Optional - can be used to do explicit instanced rendering
-  ezUInt32 m_uiExplicitInstanceCount = 0;
 
   ezUInt32 m_uiSubMeshIndex : 30;
   ezUInt32 m_uiFlipWinding : 1;
   ezUInt32 m_uiUniformScale : 1;
 
   ezUInt32 m_uiUniqueID = 0;
+
+protected:
+  EZ_FORCE_INLINE void FillBatchIdAndSortingKeyInternal(ezUInt32 uiAdditionalBatchData)
+  {
+    m_uiFlipWinding = m_GlobalTransform.ContainsNegativeScale() ? 1 : 0;
+    m_uiUniformScale = m_GlobalTransform.ContainsUniformScale() ? 1 : 0;
+
+    const ezUInt32 uiMeshIDHash = m_hMesh.GetResourceIDHash();
+    const ezUInt32 uiMaterialIDHash = m_hMaterial.IsValid() ? m_hMaterial.GetResourceIDHash() : 0;
+
+    // Generate batch id from mesh, material and part index.
+    ezUInt32 data[] = {uiMeshIDHash, uiMaterialIDHash, m_uiSubMeshIndex, m_uiFlipWinding, uiAdditionalBatchData};
+    m_uiBatchId = ezHashingUtils::xxHash32(data, sizeof(data));
+
+    // Sort by material and then by mesh
+    m_uiSortingKey = (uiMaterialIDHash << 16) | (uiMeshIDHash & 0xFFFE) | m_uiFlipWinding;
+  }
 };
 
 struct EZ_RENDERERCORE_DLL ezMsgSetMeshMaterial : public ezMessage
@@ -60,8 +71,6 @@ public:
 public:
   virtual void SerializeComponent(ezWorldWriter& stream) const override;
   virtual void DeserializeComponent(ezWorldReader& stream) override;
-  virtual void OnDeactivated() override;
-
 
   //////////////////////////////////////////////////////////////////////////
   // ezRenderComponent Interface
@@ -93,9 +102,6 @@ public:
 
 protected:
   virtual ezMeshRenderData* CreateRenderData() const;
-
-  ezGALBufferHandle m_hSkinningTransformsBuffer;
-  ezArrayPtr<const ezMat4> m_SkinningMatrices;
 
   ezUInt32 Materials_GetCount() const;
   const char* Materials_GetValue(ezUInt32 uiIndex) const;

--- a/Code/Engine/RendererCore/Meshes/MeshRenderer.h
+++ b/Code/Engine/RendererCore/Meshes/MeshRenderer.h
@@ -2,6 +2,7 @@
 
 #include <RendererCore/Pipeline/Renderer.h>
 
+class ezMeshRenderData;
 struct ezPerInstanceData;
 
 /// \brief Implements rendering of static meshes
@@ -23,4 +24,6 @@ public:
 protected:
   virtual void FillPerInstanceData(
     ezArrayPtr<ezPerInstanceData> instanceData, const ezRenderDataBatch& batch, ezUInt32 uiStartIndex, ezUInt32& out_uiFilteredCount) const;
+
+  virtual void SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const;
 };

--- a/Code/Engine/RendererCore/Meshes/SkinnedMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/SkinnedMeshComponent.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <RendererCore/Meshes/MeshComponentBase.h>
+
+class EZ_RENDERERCORE_DLL ezSkinnedMeshRenderData : public ezMeshRenderData
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSkinnedMeshRenderData, ezMeshRenderData);
+
+public:
+  virtual void FillBatchIdAndSortingKey();
+
+  ezGALBufferHandle m_hSkinningMatrices;
+  ezArrayPtr<const ezUInt8> m_pNewSkinningMatricesData;
+};
+
+//////////////////////////////////////////////////////////////////////////
+
+class EZ_RENDERERCORE_DLL ezSkinnedMeshComponent : public ezMeshComponentBase
+{
+  EZ_DECLARE_ABSTRACT_COMPONENT_TYPE(ezSkinnedMeshComponent, ezMeshComponentBase);
+
+public:
+  ezSkinnedMeshComponent();
+  ~ezSkinnedMeshComponent();
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent Interface
+  //
+  virtual void SerializeComponent(ezWorldWriter& stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& stream) override;
+
+  virtual void OnDeactivated() override;
+
+protected:
+  virtual ezMeshRenderData* CreateRenderData() const;
+
+  void CreateSkinningTransformBuffer(ezArrayPtr<const ezMat4> skinningMatrices);
+  void UpdateSkinningTransformBuffer(ezArrayPtr<const ezMat4> skinningMatrices);
+
+private:
+  ezGALBufferHandle m_hSkinningTransformsBuffer;
+  ezArrayPtr<const ezMat4> m_SkinningMatrices;
+};

--- a/Code/Engine/RendererCore/Meshes/SkinnedMeshRenderer.h
+++ b/Code/Engine/RendererCore/Meshes/SkinnedMeshRenderer.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <RendererCore/Meshes/MeshRenderer.h>
+
+/// \brief Implements rendering of skinned meshes
+class EZ_RENDERERCORE_DLL ezSkinnedMeshRenderer : public ezMeshRenderer
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSkinnedMeshRenderer, ezMeshRenderer);
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezSkinnedMeshRenderer);
+
+public:
+  ezSkinnedMeshRenderer();
+  ~ezSkinnedMeshRenderer();
+
+  // ezRenderer implementation
+  virtual void GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& types) const override;
+
+protected:
+  virtual void SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const override;
+};


### PR DESCRIPTION
Moved all optional members into derived render data types.

Also removed skinning related members from mesh component base and created a new skinned mesh component base class.