### PR TITLE
 HeaderChecker utility, removal of windows.h

### DIFF
--- a/Code/BuildSystem/CMake/toolchain-winstore.cmake
+++ b/Code/BuildSystem/CMake/toolchain-winstore.cmake
@@ -1,5 +1,5 @@
 set(CMAKE_SYSTEM_NAME WindowsStore)
 
 # Windows anniversary update version. As of writing the newest hololens emulator does not support Windows Creator's update.
-set(CMAKE_SYSTEM_VERSION 10.0.14393.0)
-set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.14393.0)
+set(CMAKE_SYSTEM_VERSION 10.0.17763.0)
+set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.17763.0)

--- a/Code/Editor/Editor/EditorPCH.h
+++ b/Code/Editor/Editor/EditorPCH.h
@@ -1,4 +1,7 @@
 #include <Foundation/Basics.h>
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <QDockWidget>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -1,5 +1,7 @@
 #include <EditorEngineProcessPCH.h>
 
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <Core/ResourceManager/ResourceManager.h>
 #include <EditorEngineProcess/EngineProcGameApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Communication/IpcChannel.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Strings/StringUtils.h>
@@ -57,7 +58,7 @@ ezResult ezEngineProcessCommunicationChannel::ConnectToHostProcess()
     ezLog::Debug("Host Process ID: {0}", m_iHostPID);
 
     m_pChannel =
-        ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client);
+      ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client);
   }
   else
   {

--- a/Code/Editor/EditorFramework/EditorFrameworkPCH.h
+++ b/Code/Editor/EditorFramework/EditorFrameworkPCH.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <Foundation/Basics.h>
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <Foundation/Strings/TranslationLookup.h>
 #include <Foundation/Utilities/Progress.h>

--- a/Code/Editor/EditorProcessor/EditorProcessorPCH.h
+++ b/Code/Editor/EditorProcessor/EditorProcessorPCH.h
@@ -17,7 +17,6 @@
 #include <Core/Input/InputManager.h>
 #include <Foundation/Containers/Deque.h>
 #include <Foundation/Logging/Log.h>
-#include <Foundation/Application/Application.h>
 #include <QApplication>
 #include <qstylefactory.h>
 #include <QSettings>

--- a/Code/Editor/EditorProcessor/Main.cpp
+++ b/Code/Editor/EditorProcessor/Main.cpp
@@ -1,10 +1,10 @@
 #include <EditorProcessorPCH.h>
 
-#include <Foundation/Application/Application.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <Foundation/Application/Application.h>
 #include <GuiFoundation/UIServices/ImageCache.moc.h>
 #include <QApplication>
 #include <QSettings>
@@ -51,8 +51,8 @@ public:
     {
       ezProcessAssetResponseMsg msg;
       {
-        ezLogEntryDelegate logger([&msg](ezLogEntry& entry) -> void { msg.m_LogEntries.PushBack(std::move(entry)); },
-                                  ezLogMsgType::WarningMsg);
+        ezLogEntryDelegate logger(
+          [&msg](ezLogEntry& entry) -> void { msg.m_LogEntries.PushBack(std::move(entry)); }, ezLogMsgType::WarningMsg);
         ezLogSystemScope logScope(&logger);
 
         const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(pMsg->m_sPlatform);
@@ -68,7 +68,7 @@ public:
           ezAssetCurator::GetSingleton()->SetActiveAssetProfileByIndex(uiPlatform);
 
           const ezStatus res = ezAssetCurator::GetSingleton()->TransformAsset(
-              pMsg->m_AssetGuid, false, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform));
+            pMsg->m_AssetGuid, false, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform));
 
           msg.m_bSuccess = res.m_Result.Succeeded();
 
@@ -104,26 +104,26 @@ public:
       bool bTransform = true;
 
       ezQtEditorApp::GetSingleton()->connect(
-          ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(), [this, &bTransform]() {
-            if (!bTransform)
-              return;
+        ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(), [this, &bTransform]() {
+          if (!bTransform)
+            return;
 
-            bTransform = false;
+          bTransform = false;
 
-            const ezString sPlatform = ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-transform");
-            const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(sPlatform);
+          const ezString sPlatform = ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-transform");
+          const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(sPlatform);
 
-            if (uiPlatform == ezInvalidIndex)
-            {
-              ezLog::Error("Asset platform config '{0}' is unknown", sPlatform);
-            }
-            else
-            {
-              ezAssetCurator::GetSingleton()->TransformAllAssets(ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform));
-            }
+          if (uiPlatform == ezInvalidIndex)
+          {
+            ezLog::Error("Asset platform config '{0}' is unknown", sPlatform);
+          }
+          else
+          {
+            ezAssetCurator::GetSingleton()->TransformAllAssets(ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform));
+          }
 
-            QApplication::quit();
-          });
+          QApplication::quit();
+        });
 
       const ezInt32 iReturnCode = ezQtEditorApp::GetSingleton()->RunEditor();
       SetReturnCode(iReturnCode);
@@ -136,20 +136,20 @@ public:
         m_IPC.m_Events.AddEventHandler(ezMakeDelegate(&ezEditorApplication::EventHandlerIPC, this));
 
         ezQtEditorApp::GetSingleton()->OpenProject(sProject);
-        ezQtEditorApp::GetSingleton()->connect(ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(),
-                                               [this]() {
-                                                 static bool bRecursionBlock = false;
-                                                 if (bRecursionBlock)
-                                                   return;
-                                                 bRecursionBlock = true;
+        ezQtEditorApp::GetSingleton()->connect(
+          ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(), [this]() {
+            static bool bRecursionBlock = false;
+            if (bRecursionBlock)
+              return;
+            bRecursionBlock = true;
 
-                                                 if (!m_IPC.IsHostAlive())
-                                                   QApplication::quit();
+            if (!m_IPC.IsHostAlive())
+              QApplication::quit();
 
-                                                 m_IPC.WaitForMessages();
+            m_IPC.WaitForMessages();
 
-                                                 bRecursionBlock = false;
-                                               });
+            bRecursionBlock = false;
+          });
 
         const ezInt32 iReturnCode = ezQtEditorApp::GetSingleton()->RunEditor();
         SetReturnCode(iReturnCode);

--- a/Code/Editor/EditorProcessor/Main.cpp
+++ b/Code/Editor/EditorProcessor/Main.cpp
@@ -1,5 +1,7 @@
 #include <EditorProcessorPCH.h>
 
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.h>
 #include <EditorFramework/Assets/AssetCurator.h>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssetsPCH.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssetsPCH.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <Foundation/Basics.h>
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <QWidget>
 
 // <StaticLinkUtil::StartHere>

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -8,6 +8,11 @@
 #include <Core/World/ComponentManager.h>
 #include <Core/World/GameObjectDesc.h>
 
+// Avoid conflicts with windows.h
+#ifdef SendMessage
+#undef SendMessage
+#endif
+
 /// \brief This class represents an object inside the world.
 ///
 /// Game objects only consists of hierarchical data like transformation and a list of components.

--- a/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.cpp
@@ -1,0 +1,44 @@
+#include <FoundationPCH.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+#include <Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
+namespace ezApplicationDetails
+{
+  void AttachToConsoleWindow(ezMinWindows::BOOL (EZ_WINDOWS_WINAPI *consoleHandler)(ezMinWindows::DWORD dwCtrlType))
+  {
+    // We're attaching to a potential console parent process
+    // and ignore failure when no such parent is present
+    if (AttachConsole(ATTACH_PARENT_PROCESS) == TRUE)
+    {
+      SetConsoleCtrlHandler(consoleHandler, TRUE);
+
+      // this is necessary to direct the standard
+      // output to the newly attached console
+      freopen("CONOUT$", "w", stdout);
+      freopen("CONOUT$", "w", stderr);
+      freopen("CONIN$", "r", stdin);
+      printf("\n");
+    }
+  }
+
+  void DetachFromConsoleWindow()
+  {
+    if (GetConsoleWindow())
+    {
+      // Since the console already printed a new prompt the input pointer ends up in the blanks after
+      // our output and no new prompt appears. Sending an enter keypress works around that limitation.
+      INPUT ip = {};
+
+      ip.type = INPUT_KEYBOARD;
+      // key code for enter
+      ip.ki.wVk = 0x0D;
+      SendInput(1, &ip, sizeof(INPUT));
+
+      ip.ki.dwFlags = KEYEVENTF_KEYUP; // KEYEVENTF_KEYUP for key release
+      SendInput(1, &ip, sizeof(INPUT));
+    }
+  }
+}
+#endif

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.cpp
@@ -1,0 +1,26 @@
+#include <FoundationPCH.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+#include <Foundation/Application/Implementation/Uwp/ApplicationEntryPoint_uwp.h>
+#include <roapi.h>
+
+namespace ezApplicationDetails
+{
+  ezResult InitializeWinrt()
+  {
+    HRESULT result = RoInitialize(RO_INIT_MULTITHREADED);
+    if (FAILED(result))
+    {
+      printf("Failed to init WinRT: %i", result);
+      return EZ_FAILURE;
+    }
+
+    return EZ_SUCCESS;
+  }
+
+  void UninitializeWinrt()
+  {
+    RoUninitialize();
+  }
+}
+#endif

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
@@ -4,7 +4,6 @@
 /// \file
 
 #include <Foundation/Memory/MemoryTracker.h>
-#include <roapi.h>
 
 // Disable C++/CX adds.
 #pragma warning(disable : 4447)

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
@@ -14,15 +14,17 @@ extern EZ_FOUNDATION_DLL ezResult ezUWPRun(ezApplication* pApp);
 
 namespace ezApplicationDetails
 {
+  EZ_FOUNDATION_DLL ezResult InitializeWinrt();
+  EZ_FOUNDATION_DLL void UninitializeWinrt();
+
   template <typename AppClass, typename... Args>
   int EntryFunc(Args&&... arguments)
   {
     static char appBuffer[sizeof(AppClass)]; // Not on the stack to cope with smaller stacks.
 
-    HRESULT result = RoInitialize(RO_INIT_MULTITHREADED);
-    if (FAILED(result))
+    if (InitializeWinrt().Failed())
     {
-      printf("Failed to init WinRT: %i", result);
+      return 1;
     }
 
     AppClass* pApp = new (appBuffer) AppClass(std::forward<Args>(arguments)...);
@@ -37,7 +39,7 @@ namespace ezApplicationDetails
         printf("Return Code: '%s'\n", text.c_str());
     }
 
-    RoUninitialize();
+    UninitializeWinrt();
 
     return iReturnCode;
   }

--- a/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
@@ -1,6 +1,7 @@
 #include <FoundationPCH.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Application/Application.h>
 #include <Foundation/Application/Implementation/uwp/Application_uwp.h>
 #include <Foundation/IO/OSFile.h>

--- a/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
 
 #include <Foundation/Basics.h>

--- a/Code/Engine/Foundation/Basics.h
+++ b/Code/Engine/Foundation/Basics.h
@@ -8,6 +8,14 @@
 
 #include <Foundation/UserConfig.h>
 
+#ifdef BUILDSYSTEM_BUILDING_FOUNDATION_LIB
+#define EZ_FOUNDATION_INTERNAL_HEADER_ALLOWED 1
+#else
+#define EZ_FOUNDATION_INTERNAL_HEADER_ALLOWED 0
+#endif
+
+#define EZ_FOUNDATION_INTERNAL_HEADER static_assert(EZ_FOUNDATION_INTERNAL_HEADER_ALLOWED, "This is a internal header which may only be used when compiling ezFoundation");
+
 // include the different headers for the supported platforms
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 #include <Foundation/Basics/Platform/Win/Platform_win.h>

--- a/Code/Engine/Foundation/Basics/Assert.cpp
+++ b/Code/Engine/Foundation/Basics/Assert.cpp
@@ -1,5 +1,6 @@
 #include <FoundationPCH.h>
 
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Strings/StringBuilder.h>
 #include <Foundation/Strings/StringUtils.h>
 #include <Foundation/System/SystemInformation.h>

--- a/Code/Engine/Foundation/Basics/Platform/Win/HResultUtils.cpp
+++ b/Code/Engine/Foundation/Basics/Platform/Win/HResultUtils.cpp
@@ -8,7 +8,7 @@
 
 #  include <comdef.h>
 
-EZ_FOUNDATION_DLL ezString ezHRESULTtoString(HRESULT result)
+EZ_FOUNDATION_DLL ezString ezHRESULTtoString(ezMinWindows::HRESULT result)
 {
   _com_error error(result, nullptr);
   const TCHAR* messageW = error.ErrorMessage();

--- a/Code/Engine/Foundation/Basics/Platform/Win/HResultUtils.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/HResultUtils.h
@@ -1,30 +1,31 @@
 #pragma once
 
 #include <Foundation/Basics.h>
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
 #include <Foundation/Strings/String.h>
 
 /// Build string implementation for HRESULT.
-EZ_FOUNDATION_DLL ezString ezHRESULTtoString(HRESULT result);
+EZ_FOUNDATION_DLL ezString ezHRESULTtoString(ezMinWindows::HRESULT result);
 
 /// Conversion of HRESULT to ezResult.
-inline ezResult ezToResult(HRESULT result)
+inline ezResult ezToResult(ezMinWindows::HRESULT result)
 {
-  return SUCCEEDED(result) ? EZ_SUCCESS : EZ_FAILURE;
+  return result >= 0 ? EZ_SUCCESS : EZ_FAILURE;
 }
 
 #define EZ_HRESULT_TO_FAILURE(code)                                                                                                        \
   do                                                                                                                                       \
   {                                                                                                                                        \
-    HRESULT s = (code);                                                                                                                    \
-    if (FAILED(s))                                                                                                                         \
+    ezMinWindows::HRESULT s = (code);                                                                                                      \
+    if (s < 0)                                                                                                                             \
       return EZ_FAILURE;                                                                                                                   \
   } while (false)
 
 #define EZ_HRESULT_TO_FAILURE_LOG(code)                                                                                                    \
   do                                                                                                                                       \
   {                                                                                                                                        \
-    HRESULT s = (code);                                                                                                                    \
-    if (FAILED(s))                                                                                                                         \
+    ezMinWindows::HRESULT s = (code);                                                                                                      \
+    if (s < 0)                                                                                                                             \
     {                                                                                                                                      \
       ezLog::Error("Call '{0}' failed with: {1}", EZ_STRINGIZE(code), ezHRESULTtoString(s));                                               \
       return EZ_FAILURE;                                                                                                                   \
@@ -34,8 +35,8 @@ inline ezResult ezToResult(HRESULT result)
 #define EZ_HRESULT_TO_LOG(code)                                                                                                            \
   do                                                                                                                                       \
   {                                                                                                                                        \
-    HRESULT s = (code);                                                                                                                    \
-    if (FAILED(s))                                                                                                                         \
+    ezMinWindows::HRESULT s = (code);                                                                                                      \
+    if (s < 0)                                                                                                                             \
     {                                                                                                                                      \
       ezLog::Error("Call '{0}' failed with: {1}", EZ_STRINGIZE(code), ezHRESULTtoString(s));                                               \
     }                                                                                                                                      \
@@ -44,8 +45,8 @@ inline ezResult ezToResult(HRESULT result)
 #define EZ_HRESULT_TO_LOG_RET(code)                                                                                                        \
   do                                                                                                                                       \
   {                                                                                                                                        \
-    HRESULT s = (code);                                                                                                                    \
-    if (FAILED(s))                                                                                                                         \
+    ezMinWindows::HRESULT s = (code);                                                                                                      \
+    if (s < 0)                                                                                                                             \
     {                                                                                                                                      \
       ezLog::Error("Call '{0}' failed with: {1}", EZ_STRINGIZE(code), ezHRESULTtoString(s));                                               \
       return;                                                                                                                              \
@@ -55,7 +56,6 @@ inline ezResult ezToResult(HRESULT result)
 #define EZ_HRESULT_TO_ASSERT(code)                                                                                                         \
   do                                                                                                                                       \
   {                                                                                                                                        \
-    HRESULT s = (code);                                                                                                                    \
-    EZ_ASSERT_DEV(SUCCEEDED(s), "Call '{0}' failed with: {1}", EZ_STRINGIZE(code), ezHRESULTtoString(s));                                  \
+    ezMinWindows::HRESULT s = (code);                                                                                                      \
+    EZ_ASSERT_DEV(s >= 0, "Call '{0}' failed with: {1}", EZ_STRINGIZE(code), ezHRESULTtoString(s));                                        \
   } while (false)
-

--- a/Code/Engine/Foundation/Basics/Platform/Win/IncludeWindows.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/IncludeWindows.h
@@ -1,0 +1,70 @@
+#pragma once
+
+// this is important for code that wants to include winsock2.h later on
+#define _WINSOCKAPI_   /* Prevent inclusion of winsock.h in windows.h */
+
+// already includes Windows.h, but defines important other things first
+//#include <winsock2.h>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+
+// unset windows macros
+#undef min
+#undef max
+#undef GetObject
+#undef ERROR
+#undef DeleteFile
+#undef CopyFile
+#undef DispatchMessage
+#undef PostMessage
+#undef SendMessage
+#undef OPAQUE
+#undef SetPort
+
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
+
+namespace ezMinWindows
+{
+  template <>
+  struct ToNativeImpl<HINSTANCE>
+  {
+    typedef ::HINSTANCE type;
+    static EZ_ALWAYS_INLINE ::HINSTANCE ToNative(HINSTANCE hInstance)
+    {
+      return reinterpret_cast<::HINSTANCE>(hInstance);
+    }
+  };
+
+  template <>
+  struct ToNativeImpl<HWND>
+  {
+    typedef ::HWND type;
+    static EZ_ALWAYS_INLINE ::HWND ToNative(HWND hWnd)
+    {
+      return reinterpret_cast<::HWND>(hWnd);
+    }
+  };
+
+  template <>
+  struct FromNativeImpl<::HWND>
+  {
+    typedef HWND type;
+    static EZ_ALWAYS_INLINE HWND FromNative(::HWND hWnd)
+    {
+      return reinterpret_cast<HWND>(hWnd);
+    }
+  };
+
+  template <>
+  struct FromNativeImpl<::HINSTANCE>
+  {
+    typedef HINSTANCE type;
+    static EZ_ALWAYS_INLINE HINSTANCE FromNative(::HINSTANCE hInstance)
+    {
+      return reinterpret_cast<HINSTANCE>(hInstance);
+    }
+  };
+}

--- a/Code/Engine/Foundation/Basics/Platform/Win/IncludeWindows.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/IncludeWindows.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 // this is important for code that wants to include winsock2.h later on
 #define _WINSOCKAPI_   /* Prevent inclusion of winsock.h in windows.h */
 
@@ -68,3 +69,4 @@ namespace ezMinWindows
     }
   };
 }
+#endif

--- a/Code/Engine/Foundation/Basics/Platform/Win/MinWindows.cpp
+++ b/Code/Engine/Foundation/Basics/Platform/Win/MinWindows.cpp
@@ -1,5 +1,6 @@
 #include <FoundationPCH.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Basics/Platform/Win/MinWindows.h>
 #include <type_traits>
@@ -41,3 +42,4 @@ void ezCheckWindowsTypeSizes()
   static_assert(
     EZ_WINDOWS_INVALID_HANDLE_VALUE == INVALID_HANDLE_VALUE, "EZ_WINDOWS_INVALID_HANDLE_VALUE does not match INVALID_HANDLE_VALUE");
 }
+#endif

--- a/Code/Engine/Foundation/Basics/Platform/Win/MinWindows.cpp
+++ b/Code/Engine/Foundation/Basics/Platform/Win/MinWindows.cpp
@@ -1,0 +1,43 @@
+#include <FoundationPCH.h>
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
+#include <type_traits>
+
+template <typename ezType, typename WindowsType, bool mustBeConvertible>
+void ezVerifyWindowsType()
+{
+  static_assert(sizeof(ezType) == sizeof(WindowsType), "ez <=> windows.h size mismatch");
+  static_assert(alignof(ezType) == alignof(WindowsType), "ez <=> windows.h alignment mismatch");
+  static_assert(std::is_pointer<ezType>::value == std::is_pointer<WindowsType>::value, "ez <=> windows.h pointer type mismatch");
+  static_assert(!mustBeConvertible || ezConversionTest<ezType, WindowsType>::exists == 1, "ez <=> windows.h conversion failure");
+  static_assert(!mustBeConvertible || ezConversionTest<WindowsType, ezType>::exists == 1, "windows.h <=> ez conversion failure");
+};
+
+void CALLBACK WindowsCallbackTest1();
+void EZ_WINDOWS_CALLBACK WindowsCallbackTest2();
+void WINAPI WindowsWinapiTest1();
+void EZ_WINDOWS_WINAPI WindowsWinapiTest2();
+
+// Will never be called and thus removed by the linker
+void ezCheckWindowsTypeSizes()
+{
+  ezVerifyWindowsType<ezMinWindows::DWORD, DWORD, true>();
+  ezVerifyWindowsType<ezMinWindows::UINT, UINT, true>();
+  ezVerifyWindowsType<ezMinWindows::BOOL, BOOL, true>();
+  ezVerifyWindowsType<ezMinWindows::LPARAM, LPARAM, true>();
+  ezVerifyWindowsType<ezMinWindows::WPARAM, WPARAM, true>();
+  ezVerifyWindowsType<ezMinWindows::HINSTANCE, HINSTANCE, false>();
+  ezVerifyWindowsType<ezMinWindows::HMODULE, HMODULE, false>();
+  ezVerifyWindowsType<ezMinWindows::LPSTR, LPSTR, true>();
+  ezVerifyWindowsType<ezMinWindows::HWND, HWND, false>();
+  ezVerifyWindowsType<ezMinWindows::HRESULT, HRESULT, true>();
+
+  static_assert(
+    std::is_same<decltype(&WindowsCallbackTest1), decltype(&WindowsCallbackTest2)>::value, "EZ_WINDOWS_CALLBACK does not match CALLBACK");
+  static_assert(
+    std::is_same<decltype(&WindowsWinapiTest1), decltype(&WindowsWinapiTest2)>::value, "EZ_WINDOWS_WINAPI does not match WINAPI");
+
+  static_assert(
+    EZ_WINDOWS_INVALID_HANDLE_VALUE == INVALID_HANDLE_VALUE, "EZ_WINDOWS_INVALID_HANDLE_VALUE does not match INVALID_HANDLE_VALUE");
+}

--- a/Code/Engine/Foundation/Basics/Platform/Win/MinWindows.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/MinWindows.h
@@ -1,0 +1,53 @@
+#pragma once
+
+namespace ezMinWindows
+{
+  typedef int BOOL;
+  typedef unsigned long DWORD;
+  typedef unsigned int UINT;
+  typedef char* LPSTR;
+  struct ezHINSTANCE;
+  typedef ezHINSTANCE* HINSTANCE;
+  typedef HINSTANCE HMODULE;
+  struct ezHWND;
+  typedef ezHWND* HWND;
+  typedef long HRESULT;
+  typedef void* HANDLE;
+
+#if EZ_ENABLED(EZ_PLATFORM_64BIT)
+  typedef ezUInt64 WPARAM;
+  typedef ezUInt64 LPARAM;
+#else
+  typedef ezUInt32 WPARAM;
+  typedef ezUInt32 LPARAM;
+#endif
+
+  template <typename T>
+  struct ToNativeImpl
+  {
+  };
+
+  template <typename T>
+  struct FromNativeImpl
+  {
+  };
+
+  /// Helper function to convert ezMinWindows types into native windows.h types.
+  /// Include IncludeWindows.h before using it.
+  template <typename T>
+  EZ_ALWAYS_INLINE typename ToNativeImpl<T>::type ToNative(T t)
+  {
+    return ToNativeImpl<T>::ToNative(t);
+  }
+
+  /// Helper function to native windows.h types to ezMinWindows types.
+  /// Include IncludeWindows.h before using it.
+  template <typename T>
+  EZ_ALWAYS_INLINE typename FromNativeImpl<T>::type FromNative(T t)
+  {
+    return FromNativeImpl<T>::FromNative(t);
+  }
+}
+#define EZ_WINDOWS_CALLBACK __stdcall
+#define EZ_WINDOWS_WINAPI __stdcall
+#define EZ_WINDOWS_INVALID_HANDLE_VALUE (void*)-1

--- a/Code/Engine/Foundation/Basics/Platform/Win/Platform_win.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/Platform_win.h
@@ -16,6 +16,8 @@
 #  define _CRT_SECURE_NO_WARNINGS
 #endif
 
+//#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <winapifamily.h>
 
 #undef EZ_PLATFORM_WINDOWS_UWP
@@ -30,30 +32,9 @@
 #  define EZ_PLATFORM_WINDOWS_DESKTOP EZ_ON
 #endif
 
-// this is important for code that wants to include winsock2.h later on
-#define _WINSOCKAPI_   /* Prevent inclusion of winsock.h in windows.h */
-
-// already includes Windows.h, but defines important other things first
-//#include <winsock2.h>
-
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
+#ifndef NULL
+#define NULL 0
 #endif
-#include <Windows.h>
-
-#include <malloc.h>
-
-// unset windows macros
-#undef min
-#undef max
-#undef GetObject
-#undef ERROR
-#undef DeleteFile
-#undef CopyFile
-#undef DispatchMessage
-#undef PostMessage
-#undef SendMessage
-#undef OPAQUE
 
 #if defined(_MSC_VER)
 
@@ -73,7 +54,6 @@
 #    define EZ_COMPILE_FOR_DEBUG EZ_ON
 #  endif
 
-#  include <intrin.h>
 
 // Functions marked as EZ_ALWAYS_INLINE will be inlined even in Debug builds, which means you will step over them in a debugger
 #  define EZ_ALWAYS_INLINE __forceinline
@@ -163,10 +143,6 @@
 #    define EZ_LEFT_PARENTHESIS (
 #    define EZ_RIGHT_PARENTHESIS )
 #    define EZ_VA_NUM_ARGS(...) EZ_VA_NUM_ARGS_HELPER EZ_LEFT_PARENTHESIS __VA_ARGS__, EZ_VA_NUM_ARGS_REVERSE_SEQUENCE EZ_RIGHT_PARENTHESIS
-#  endif
-
-#  ifndef va_copy
-#    define va_copy(dest, source) (dest) = (source)
 #  endif
 
 #  if _M_ARM

--- a/Code/Engine/Foundation/Basics/Platform/uwp/UWPUtils.h
+++ b/Code/Engine/Foundation/Basics/Platform/uwp/UWPUtils.h
@@ -8,6 +8,7 @@
 #include <Foundation/Types/Types.h>
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <guiddef.h>
 #include <windows.foundation.h>
 #include <windows.foundation.numerics.h>

--- a/Code/Engine/Foundation/Basics/Platform/uwp/UWPUtils.h
+++ b/Code/Engine/Foundation/Basics/Platform/uwp/UWPUtils.h
@@ -7,6 +7,7 @@
 #include <Foundation/Basics/Platform/Win/HResultUtils.h>
 #include <Foundation/Types/Types.h>
 
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <guiddef.h>
 #include <windows.foundation.h>
 #include <windows.foundation.numerics.h>

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Tokenizer.cpp
@@ -98,8 +98,9 @@ void ezTokenizer::AddToken()
   m_CurMode = ezTokenType::Unknown;
 }
 
-void ezTokenizer::Tokenize(ezArrayPtr<const ezUInt8> Data, ezLogInterface* pLog, ezAllocatorBase* pAllocator)
+void ezTokenizer::Tokenize(ezArrayPtr<const ezUInt8> Data, ezLogInterface* pLog)
 {
+  ezAllocatorBase* pAllocator = m_Data.GetAllocator();
   if (Data.GetCount() >= 3)
   {
     const char* dataStart = reinterpret_cast<const char*>(Data.GetPtr());

--- a/Code/Engine/Foundation/CodeUtils/Tokenizer.h
+++ b/Code/Engine/Foundation/CodeUtils/Tokenizer.h
@@ -76,10 +76,14 @@ class EZ_FOUNDATION_DLL ezTokenizer
 {
 public:
   /// \brief Constructor.
-  ezTokenizer();
+  ///
+  /// Takes an additional optional allocator. If no allocator is given the default allocator will be used.
+  ezTokenizer(ezAllocatorBase* pAllocator = nullptr);
+
+  ~ezTokenizer();
 
   /// \brief Clears any previous result and creates a new token stream for the given array.
-  void Tokenize(ezArrayPtr<const ezUInt8> Data, ezLogInterface* pLog);
+  void Tokenize(ezArrayPtr<const ezUInt8> Data, ezLogInterface* pLog, ezAllocatorBase* pAllocator = nullptr);
 
   /// \brief Gives read access to the token stream.
   const ezDeque<ezToken>& GetTokens() const { return m_Tokens; }

--- a/Code/Engine/Foundation/CodeUtils/Tokenizer.h
+++ b/Code/Engine/Foundation/CodeUtils/Tokenizer.h
@@ -83,7 +83,7 @@ public:
   ~ezTokenizer();
 
   /// \brief Clears any previous result and creates a new token stream for the given array.
-  void Tokenize(ezArrayPtr<const ezUInt8> Data, ezLogInterface* pLog, ezAllocatorBase* pAllocator = nullptr);
+  void Tokenize(ezArrayPtr<const ezUInt8> Data, ezLogInterface* pLog);
 
   /// \brief Gives read access to the token stream.
   const ezDeque<ezToken>& GetTokens() const { return m_Tokens; }

--- a/Code/Engine/Foundation/Communication/Implementation/IpcChannelEnet.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcChannelEnet.cpp
@@ -13,7 +13,7 @@ ezIpcChannelEnet::ezIpcChannelEnet(const char* szAddress, Mode::Enum mode)
     : ezIpcChannel(szAddress, mode)
 {
   m_sAddress = szAddress;
-  m_Network = EZ_DEFAULT_NEW(ezRemoteInterfaceEnet);
+  m_Network = ezRemoteInterfaceEnet::Make();
   m_Network->SetMessageHandler(0, ezMakeDelegate(&ezIpcChannelEnet::NetworkMessageHandler, this));
   m_Network->m_RemoteEvents.AddEventHandler(ezMakeDelegate(&ezIpcChannelEnet::EnetEventHandler, this));
 

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterfaceEnet.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterfaceEnet.cpp
@@ -9,9 +9,37 @@
 #include <Foundation/Types/ScopeExit.h>
 #include <enet/enet.h>
 
-bool ezRemoteInterfaceEnet::s_bEnetInitialized = false;
+class ezRemoteInterfaceEnetImpl : public ezRemoteInterfaceEnet
+{
 
-ezResult ezRemoteInterfaceEnet::InternalCreateConnection(ezRemoteMode mode, const char* szServerAddress)
+protected:
+  virtual void InternalUpdateRemoteInterface() override;
+  virtual ezResult InternalCreateConnection(ezRemoteMode mode, const char* szServerAddress) override;
+  virtual void InternalShutdownConnection() override;
+  virtual ezTime InternalGetPingToServer() override;
+  virtual ezResult InternalTransmit(ezRemoteTransmitMode tm, const ezArrayPtr<const ezUInt8>& data) override;
+
+private:
+  ENetAddress m_EnetServerAddress;
+  ENetHost* m_pEnetHost = nullptr;
+  ENetPeer* m_pEnetConnectionToServer = nullptr;
+  bool m_bAllowNetworkUpdates = true;
+  ezMap<void*, ezUInt32> m_EnetPeerToClientID;
+
+  static bool s_bEnetInitialized;
+};
+
+ezInternal::NewInstance<ezRemoteInterfaceEnet> ezRemoteInterfaceEnet::Make(ezAllocatorBase* allocator /*= ezFoundation::GetDefaultAllocator()*/)
+{
+  return EZ_NEW(allocator, ezRemoteInterfaceEnetImpl);
+}
+
+ezRemoteInterfaceEnet::ezRemoteInterfaceEnet() = default;
+ezRemoteInterfaceEnet::~ezRemoteInterfaceEnet() = default;
+
+bool ezRemoteInterfaceEnetImpl::s_bEnetInitialized = false;
+
+ezResult ezRemoteInterfaceEnetImpl::InternalCreateConnection(ezRemoteMode mode, const char* szServerAddress)
 {
   if (!s_bEnetInitialized)
   {
@@ -82,7 +110,7 @@ ezResult ezRemoteInterfaceEnet::InternalCreateConnection(ezRemoteMode mode, cons
   return EZ_SUCCESS;
 }
 
-void ezRemoteInterfaceEnet::InternalShutdownConnection()
+void ezRemoteInterfaceEnetImpl::InternalShutdownConnection()
 {
   m_uiPort = 0;
 
@@ -108,7 +136,7 @@ void ezRemoteInterfaceEnet::InternalShutdownConnection()
   m_pEnetConnectionToServer = nullptr;
 }
 
-ezTime ezRemoteInterfaceEnet::InternalGetPingToServer()
+ezTime ezRemoteInterfaceEnetImpl::InternalGetPingToServer()
 {
   EZ_ASSERT_DEV(m_pEnetConnectionToServer != nullptr, "Client has not connected to server");
 
@@ -116,7 +144,7 @@ ezTime ezRemoteInterfaceEnet::InternalGetPingToServer()
   return ezTime::Milliseconds(m_pEnetConnectionToServer->lastRoundTripTime);
 }
 
-ezResult ezRemoteInterfaceEnet::InternalTransmit(ezRemoteTransmitMode tm, const ezArrayPtr<const ezUInt8>& data)
+ezResult ezRemoteInterfaceEnetImpl::InternalTransmit(ezRemoteTransmitMode tm, const ezArrayPtr<const ezUInt8>& data)
 {
   if (m_pEnetHost == nullptr)
     return EZ_FAILURE;
@@ -127,7 +155,7 @@ ezResult ezRemoteInterfaceEnet::InternalTransmit(ezRemoteTransmitMode tm, const 
   return EZ_SUCCESS;
 }
 
-void ezRemoteInterfaceEnet::InternalUpdateRemoteInterface()
+void ezRemoteInterfaceEnetImpl::InternalUpdateRemoteInterface()
 {
   if (!m_pEnetHost)
     return;

--- a/Code/Engine/Foundation/Communication/Implementation/Win/MessageLoop_win.h
+++ b/Code/Engine/Foundation/Communication/Implementation/Win/MessageLoop_win.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 
 #include <Foundation/Basics.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Communication/Implementation/MessageLoop.h>
 
 class ezIpcChannel;

--- a/Code/Engine/Foundation/Communication/Implementation/Win/PipeChannel_win.h
+++ b/Code/Engine/Foundation/Communication/Implementation/Win/PipeChannel_win.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 
 #include <Foundation/Basics.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Communication/IpcChannel.h>
 
 struct IOContext

--- a/Code/Engine/Foundation/Communication/RemoteInterfaceEnet.h
+++ b/Code/Engine/Foundation/Communication/RemoteInterfaceEnet.h
@@ -4,31 +4,24 @@
 
 #ifdef BUILDSYSTEM_ENABLE_ENET_SUPPORT
 
-#include <enet/enet.h>
-
 /// \brief An implementation for ezRemoteInterface built on top of Enet
 class EZ_FOUNDATION_DLL ezRemoteInterfaceEnet : public ezRemoteInterface
 {
+public:
+  ~ezRemoteInterfaceEnet();
+
+  /// \brief Allocates a new instance with the given allocator
+  static ezInternal::NewInstance<ezRemoteInterfaceEnet> Make(ezAllocatorBase* allocator = ezFoundation::GetDefaultAllocator());
+
   /// \brief The port through which the connection was started
   ezUInt16 GetPort() const { return m_uiPort; }
 
-protected:
-  virtual void InternalUpdateRemoteInterface() override;
-  virtual ezResult InternalCreateConnection(ezRemoteMode mode, const char* szServerAddress) override;
-  virtual void InternalShutdownConnection() override;
-  virtual ezTime InternalGetPingToServer() override;
-  virtual ezResult InternalTransmit(ezRemoteTransmitMode tm, const ezArrayPtr<const ezUInt8>& data) override;
-
 private:
+  ezRemoteInterfaceEnet();
+  friend class ezRemoteInterfaceEnetImpl;
+
+protected:
   ezUInt16 m_uiPort = 0;
-
-  ENetAddress m_EnetServerAddress;
-  ENetHost* m_pEnetHost = nullptr;
-  ENetPeer* m_pEnetConnectionToServer = nullptr;
-  bool m_bAllowNetworkUpdates = true;
-  ezMap<void*, ezUInt32> m_EnetPeerToClientID;
-
-  static bool s_bEnetInitialized;
 };
 
 #endif

--- a/Code/Engine/Foundation/Configuration/Implementation/Win/Plugin_Win.h
+++ b/Code/Engine/Foundation/Configuration/Implementation/Win/Plugin_Win.h
@@ -1,10 +1,14 @@
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 
 #include <Foundation/Configuration/Plugin.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 typedef HMODULE ezPluginModule;
 

--- a/Code/Engine/Foundation/FoundationInternal.h
+++ b/Code/Engine/Foundation/FoundationInternal.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef BUILDSYSTEM_BUILDING_FOUNDATION_LIB
+#define EZ_FOUNDATION_INTERNAL_HEADER_ALLOWED 1
+#else
+#define EZ_FOUNDATION_INTERNAL_HEADER_ALLOWED 0
+#endif
+
+#define EZ_FOUNDATION_INTERNAL_HEADER static_assert(EZ_FOUNDATION_INTERNAL_HEADER_ALLOWED, "This is a internal header which may only be used when compiling ezFoundation");

--- a/Code/Engine/Foundation/FoundationPCH.h
+++ b/Code/Engine/Foundation/FoundationPCH.h
@@ -2,6 +2,10 @@
 
 #include <Foundation/Basics.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#endif
+
 // <StaticLinkUtil::StartHere>
 // all include's before this will be left alone and not replaced by the StaticLinkUtil
 // all include's AFTER this will be removed by the StaticLinkUtil and updated by what is actually used throughout the library

--- a/Code/Engine/Foundation/IO/Implementation/Posix/OSFile_posix.h
+++ b/Code/Engine/Foundation/IO/Implementation/Posix/OSFile_posix.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Foundation/FoundationPCH.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <Foundation/Logging/Log.h>
 #include <Utilities/CommandLineUtils.h>
 #include <errno.h>

--- a/Code/Engine/Foundation/IO/Implementation/Win/DirectoryWatcher_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/DirectoryWatcher_win.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/IO/DirectoryWatcher.h>
 #include <Foundation/Logging/Log.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 struct ezDirectoryWatcherImpl
 {

--- a/Code/Engine/Foundation/IO/Implementation/Win/MemoryMappedFile_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/MemoryMappedFile_win.h
@@ -45,6 +45,10 @@ ezMemoryMappedFile::~ezMemoryMappedFile()
 
 ezResult ezMemoryMappedFile::Open(const char* szAbsolutePath, Mode mode)
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+  // TODO implement
+  return EZ_FAILURE;
+#else
   EZ_ASSERT_DEV(mode != Mode::None, "Invalid mode to open the memory mapped file");
   EZ_ASSERT_DEV(ezPathUtils::IsAbsolutePath(szAbsolutePath), "ezMemoryMappedFile::Open() can only be used with absolute file paths");
 
@@ -105,6 +109,7 @@ ezResult ezMemoryMappedFile::Open(const char* szAbsolutePath, Mode mode)
   }
 
   return EZ_SUCCESS;
+#endif
 }
 
 ezResult ezMemoryMappedFile::OpenShared(const char* szSharedName, ezUInt64 uiSize, Mode mode)

--- a/Code/Engine/Foundation/IO/Implementation/Win/MemoryMappedFile_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/MemoryMappedFile_win.h
@@ -45,10 +45,6 @@ ezMemoryMappedFile::~ezMemoryMappedFile()
 
 ezResult ezMemoryMappedFile::Open(const char* szAbsolutePath, Mode mode)
 {
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
-  // TODO implement
-  return EZ_FAILURE;
-#else
   EZ_ASSERT_DEV(mode != Mode::None, "Invalid mode to open the memory mapped file");
   EZ_ASSERT_DEV(ezPathUtils::IsAbsolutePath(szAbsolutePath), "ezMemoryMappedFile::Open() can only be used with absolute file paths");
 
@@ -109,7 +105,6 @@ ezResult ezMemoryMappedFile::Open(const char* szAbsolutePath, Mode mode)
   }
 
   return EZ_SUCCESS;
-#endif
 }
 
 ezResult ezMemoryMappedFile::OpenShared(const char* szSharedName, ezUInt64 uiSize, Mode mode)

--- a/Code/Engine/Foundation/IO/Implementation/Win/OSFileDeclarations_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/OSFileDeclarations_win.h
@@ -5,21 +5,32 @@
 // Deactivate Doxygen document generation for the following block.
 /// \cond
 
+// Avoid conflicts with windows.h
+#ifdef DeleteFile
+#undef DeleteFile
+#endif
+
+#ifdef CopyFile
+#undef CopyFile
+#endif
+
 #if EZ_DISABLED(EZ_USE_POSIX_FILE_API)
+
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
 
 struct ezOSFileData
 {
   ezOSFileData()
   {
-    m_pFileHandle = INVALID_HANDLE_VALUE;
+    m_pFileHandle = EZ_WINDOWS_INVALID_HANDLE_VALUE;
   }
 
-  HANDLE m_pFileHandle;
+  ezMinWindows::HANDLE m_pFileHandle;
 };
 
 struct ezFileIterationData
 {
-  ezHybridArray<HANDLE, 16> m_Handles;
+  ezHybridArray<ezMinWindows::HANDLE, 16> m_Handles;
 };
 
 #endif

--- a/Code/Engine/Foundation/IO/Implementation/Win/OSFile_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/OSFile_win.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Strings/StringConversion.h>
 #include <Foundation/Threading/ThreadUtils.h>

--- a/Code/Engine/Foundation/Logging/Implementation/ConsoleWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/ConsoleWriter.cpp
@@ -3,6 +3,8 @@
 #include <Foundation/Logging/ConsoleWriter.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 static void SetConsoleColor(WORD ui)
 {
 #if EZ_DISABLED(EZ_PLATFORM_WINDOWS_UWP)

--- a/Code/Engine/Foundation/Logging/Implementation/VisualStudioWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/VisualStudioWriter.cpp
@@ -4,6 +4,7 @@
 #include <Foundation/Strings/StringConversion.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 void ezLogWriter::VisualStudio::LogMessageHandler(const ezLoggingEventData& eventData)
 {

--- a/Code/Engine/Foundation/Math/Implementation/Math_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Math_inl.h
@@ -69,7 +69,7 @@ namespace ezMath
     EZ_ASSERT_DEBUG(value != 0, "FirstBitLow is undefined for 0");
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-    DWORD uiIndex = 0;
+    unsigned long uiIndex = 0;
     _BitScanForward(&uiIndex, value);
     return uiIndex;
 #elif EZ_ENABLED(EZ_COMPILER_GCC) || EZ_ENABLED(EZ_COMPILER_CLANG)
@@ -85,7 +85,7 @@ namespace ezMath
     EZ_ASSERT_DEBUG(value != 0, "FirstBitHigh is undefined for 0");
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-    DWORD uiIndex = 0;
+    unsigned long uiIndex = 0;
     _BitScanReverse(&uiIndex, value);
     return uiIndex;
 #elif EZ_ENABLED(EZ_COMPILER_GCC) || EZ_ENABLED(EZ_COMPILER_CLANG)

--- a/Code/Engine/Foundation/Memory/Implementation/MemoryTracker.cpp
+++ b/Code/Engine/Foundation/Memory/Implementation/MemoryTracker.cpp
@@ -9,6 +9,10 @@
 #include <Foundation/Threading/Mutex.h>
 #include <Foundation/Utilities/StackTracer.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#endif
+
 namespace
 {
   // no tracking for the tracker data itself

--- a/Code/Engine/Foundation/Memory/Implementation/MemoryUtils.cpp
+++ b/Code/Engine/Foundation/Memory/Implementation/MemoryUtils.cpp
@@ -1,5 +1,9 @@
 #include <FoundationPCH.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#endif
+
 void ezMemoryUtils::ReserveLower4GBAddressSpace()
 {
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS) && EZ_ENABLED(EZ_PLATFORM_64BIT)

--- a/Code/Engine/Foundation/Memory/Implementation/Win/PageAllocator_win.h
+++ b/Code/Engine/Foundation/Memory/Implementation/Win/PageAllocator_win.h
@@ -1,3 +1,7 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
+#include <Foundation/Basics/Platform/Win/Platform_win.h>
 
 // static
 void* ezPageAllocator::AllocatePage(size_t uiSize)

--- a/Code/Engine/Foundation/Memory/Policies/Win/GuardedAllocation_win.h
+++ b/Code/Engine/Foundation/Memory/Policies/Win/GuardedAllocation_win.h
@@ -1,4 +1,9 @@
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 namespace ezMemoryPolicies
 {
   struct AlloctionMetaData

--- a/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
@@ -262,6 +262,8 @@ ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezArgHumanReadable&
 }
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezArgErrorCode& arg)
 {
   LPVOID lpMsgBuf = nullptr;

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
@@ -4,6 +4,8 @@
 #include <Foundation/Strings/FormatString.h>
 #include <Foundation/Strings/StringBuilder.h>
 
+#include <stdarg.h>
+
 ezStringBuilder::ezStringBuilder(const char* pData1, const char* pData2, const char* pData3, const char* pData4, const char* pData5,
                                  const char* pData6)
 {
@@ -1095,6 +1097,15 @@ void ezStringBuilder::PrependFormat(const ezFormatString& string)
   Prepend(tmp);
 }
 
+void ezStringBuilder::Printf(const char* szUtf8Format, ...)
+{
+  va_list args;
+  va_start(args, szUtf8Format);
+
+  PrintfArgs(szUtf8Format, args);
+
+  va_end(args);
+}
 
 EZ_STATICLINK_FILE(Foundation, Foundation_Strings_Implementation_StringBuilder);
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder_inl.h
@@ -198,16 +198,6 @@ inline void ezStringBuilder::ToLower()
   m_Data.SetCountUninitialized(uiNewStringLength + 1);
 }
 
-inline void ezStringBuilder::Printf(const char* szUtf8Format, ...)
-{
-  va_list args;
-  va_start(args, szUtf8Format);
-
-  PrintfArgs(szUtf8Format, args);
-
-  va_end(args);
-}
-
 inline void ezStringBuilder::ChangeCharacter(iterator& it, ezUInt32 uiCharacter)
 {
   EZ_ASSERT_DEV(it.IsValid(), "The given character iterator does not point to a valid character.");

--- a/Code/Engine/Foundation/Strings/StringConversion.h
+++ b/Code/Engine/Foundation/Strings/StringConversion.h
@@ -3,6 +3,8 @@
 #include <Foundation/Containers/HybridArray.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+// Include our windows.h header first to get rid of defines.
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 // For HString, HStringReference and co.
 #include <wrl/wrappers/corewrappers.h>
 #endif

--- a/Code/Engine/Foundation/System/Implementation/OSX/SystemInformation_OSX.h
+++ b/Code/Engine/Foundation/System/Implementation/OSX/SystemInformation_OSX.h
@@ -1,3 +1,6 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/Code/Engine/Foundation/System/Implementation/Posix/UuidGenerator_posix.h
+++ b/Code/Engine/Foundation/System/Implementation/Posix/UuidGenerator_posix.h
@@ -1,4 +1,8 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <uuid/uuid.h>
+
 
 EZ_CHECK_AT_COMPILETIME(sizeof(ezUInt64) * 2 == sizeof(uuid_t));
 

--- a/Code/Engine/Foundation/System/Implementation/Win/ProcessGroup_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/ProcessGroup_win.h
@@ -29,6 +29,9 @@ void ezProcessGroupImpl::Close()
 
 void ezProcessGroupImpl::Initialize()
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+  // TODO implement
+#else
   if (m_hJobObject == INVALID_HANDLE_VALUE)
   {
     m_hJobObject = CreateJobObjectW(nullptr, nullptr);
@@ -58,6 +61,7 @@ void ezProcessGroupImpl::Initialize()
     Port.CompletionPort = m_hCompletionPort;
     SetInformationJobObject(m_hJobObject, JobObjectAssociateCompletionPortInformation, &Port, sizeof(Port));
   }
+#endif
 }
 
 ezProcessGroup::ezProcessGroup(const char* szGroupName /*= nullptr*/)
@@ -73,6 +77,10 @@ ezProcessGroup::~ezProcessGroup()
 
 ezResult ezProcessGroup::Launch(const ezProcessOptions& opt)
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+  // TODO implement
+  return EZ_FAILURE;
+#else
   m_impl->Initialize();
 
   ezProcess& process = m_Processes.ExpandAndGetRef();
@@ -93,6 +101,7 @@ ezResult ezProcessGroup::Launch(const ezProcessOptions& opt)
 
   m_impl->m_bHasNewProcesses = true;
   return EZ_SUCCESS;
+#endif
 }
 
 ezResult ezProcessGroup::WaitToFinish(ezTime timeout /*= ezTime::Zero()*/)
@@ -160,6 +169,10 @@ ezResult ezProcessGroup::WaitToFinish(ezTime timeout /*= ezTime::Zero()*/)
 
 ezResult ezProcessGroup::TerminateAll(ezInt32 iForcedExitCode /*= -2*/)
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+  // TODO implement
+  return EZ_FAILURE;
+#else
   if (m_impl->m_hJobObject == INVALID_HANDLE_VALUE)
     return EZ_SUCCESS;
 
@@ -172,4 +185,5 @@ ezResult ezProcessGroup::TerminateAll(ezInt32 iForcedExitCode /*= -2*/)
   EZ_SUCCEED_OR_RETURN(WaitToFinish());
 
   return EZ_SUCCESS;
+#endif
 }

--- a/Code/Engine/Foundation/System/Implementation/Win/ProcessGroup_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/ProcessGroup_win.h
@@ -29,9 +29,6 @@ void ezProcessGroupImpl::Close()
 
 void ezProcessGroupImpl::Initialize()
 {
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
-  // TODO implement
-#else
   if (m_hJobObject == INVALID_HANDLE_VALUE)
   {
     m_hJobObject = CreateJobObjectW(nullptr, nullptr);
@@ -61,7 +58,6 @@ void ezProcessGroupImpl::Initialize()
     Port.CompletionPort = m_hCompletionPort;
     SetInformationJobObject(m_hJobObject, JobObjectAssociateCompletionPortInformation, &Port, sizeof(Port));
   }
-#endif
 }
 
 ezProcessGroup::ezProcessGroup(const char* szGroupName /*= nullptr*/)
@@ -77,10 +73,6 @@ ezProcessGroup::~ezProcessGroup()
 
 ezResult ezProcessGroup::Launch(const ezProcessOptions& opt)
 {
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
-  // TODO implement
-  return EZ_FAILURE;
-#else
   m_impl->Initialize();
 
   ezProcess& process = m_Processes.ExpandAndGetRef();
@@ -101,7 +93,6 @@ ezResult ezProcessGroup::Launch(const ezProcessOptions& opt)
 
   m_impl->m_bHasNewProcesses = true;
   return EZ_SUCCESS;
-#endif
 }
 
 ezResult ezProcessGroup::WaitToFinish(ezTime timeout /*= ezTime::Zero()*/)
@@ -169,10 +160,6 @@ ezResult ezProcessGroup::WaitToFinish(ezTime timeout /*= ezTime::Zero()*/)
 
 ezResult ezProcessGroup::TerminateAll(ezInt32 iForcedExitCode /*= -2*/)
 {
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
-  // TODO implement
-  return EZ_FAILURE;
-#else
   if (m_impl->m_hJobObject == INVALID_HANDLE_VALUE)
     return EZ_SUCCESS;
 
@@ -185,5 +172,4 @@ ezResult ezProcessGroup::TerminateAll(ezInt32 iForcedExitCode /*= -2*/)
   EZ_SUCCEED_OR_RETURN(WaitToFinish());
 
   return EZ_SUCCESS;
-#endif
 }

--- a/Code/Engine/Foundation/System/Implementation/Win/Process_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/Process_win.h
@@ -21,9 +21,11 @@ struct ezPipeWin
     if (!CreatePipe(&m_pipeRead, &m_pipeWrite, &saAttr, 0))
       ezLog::Error("ezPipeWin: CreatePipe failed");
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
     // Ensure the read handle to the pipe is not inherited.
     if (!SetHandleInformation(m_pipeRead, HANDLE_FLAG_INHERIT, 0))
       ezLog::Error("Stdout SetHandleInformation");
+#endif
   }
 
   void Close()
@@ -122,6 +124,10 @@ ezOsProcessID ezProcess::GetCurrentProcessID()
 
 ezResult ezProcess::Launch(const ezProcessOptions& opt, ezBitflags<ezProcessLaunchFlags> launchFlags /*= ezAsyncProcessFlags::None*/)
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+  // TODO implement
+  return EZ_FAILURE;
+#else
   EZ_ASSERT_DEV(m_impl->m_ProcessHandle == nullptr, "Cannot reuse an instance of ezProcess");
   EZ_ASSERT_DEV(m_impl->m_ProcessID == 0, "Cannot reuse an instance of ezProcess");
 
@@ -208,6 +214,7 @@ ezResult ezProcess::Launch(const ezProcessOptions& opt, ezBitflags<ezProcessLaun
   }
 
   return EZ_SUCCESS;
+#endif
 }
 
 ezResult ezProcess::ResumeSuspended()

--- a/Code/Engine/Foundation/System/Implementation/Win/Process_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/Process_win.h
@@ -21,11 +21,9 @@ struct ezPipeWin
     if (!CreatePipe(&m_pipeRead, &m_pipeWrite, &saAttr, 0))
       ezLog::Error("ezPipeWin: CreatePipe failed");
 
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
     // Ensure the read handle to the pipe is not inherited.
     if (!SetHandleInformation(m_pipeRead, HANDLE_FLAG_INHERIT, 0))
       ezLog::Error("Stdout SetHandleInformation");
-#endif
   }
 
   void Close()
@@ -124,10 +122,6 @@ ezOsProcessID ezProcess::GetCurrentProcessID()
 
 ezResult ezProcess::Launch(const ezProcessOptions& opt, ezBitflags<ezProcessLaunchFlags> launchFlags /*= ezAsyncProcessFlags::None*/)
 {
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
-  // TODO implement
-  return EZ_FAILURE;
-#else
   EZ_ASSERT_DEV(m_impl->m_ProcessHandle == nullptr, "Cannot reuse an instance of ezProcess");
   EZ_ASSERT_DEV(m_impl->m_ProcessID == 0, "Cannot reuse an instance of ezProcess");
 
@@ -214,7 +208,6 @@ ezResult ezProcess::Launch(const ezProcessOptions& opt, ezBitflags<ezProcessLaun
   }
 
   return EZ_SUCCESS;
-#endif
 }
 
 ezResult ezProcess::ResumeSuspended()

--- a/Code/Engine/Foundation/System/Implementation/Win/SystemInformation_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/SystemInformation_win.h
@@ -1,6 +1,11 @@
 // Deactivate Doxygen document generation for the following block.
 /// \cond
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
 #include <Foundation/Basics/Platform/uwp/UWPUtils.h>
 #include <windows.networking.connectivity.h>

--- a/Code/Engine/Foundation/System/Implementation/Win/UuidGenerator_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/UuidGenerator_win.h
@@ -1,3 +1,6 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <rpc.h>
 #include <combaseapi.h>
 

--- a/Code/Engine/Foundation/Threading/Implementation/Win/AtomicUtils_win.h
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/AtomicUtils_win.h
@@ -4,79 +4,139 @@
 
 #define EZ_ATOMICUTLS_WIN_INL_H_INCLUDED
 
+#include <intrin.h>
+
 EZ_ALWAYS_INLINE ezInt32 ezAtomicUtils::Read(volatile const ezInt32& src)
 {
-  return _InterlockedOr((volatile LONG*)(&src), 0);
+  return _InterlockedOr((volatile long*)(&src), 0);
 }
 
 EZ_ALWAYS_INLINE ezInt64 ezAtomicUtils::Read(volatile const ezInt64& src)
 {
-  return InterlockedOr64(const_cast<volatile ezInt64*>(&src), 0);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do 
+  {
+    old = src;
+  } while (_InterlockedCompareExchange64(const_cast<volatile ezInt64*>(&src), old, old) != old);
+  return old;
+#else
+  return _InterlockedOr64(const_cast<volatile ezInt64*>(&src), 0);
+#endif
 }
 
 EZ_ALWAYS_INLINE ezInt32 ezAtomicUtils::Increment(volatile ezInt32& dest)
 {
-  return InterlockedIncrement(reinterpret_cast<volatile LONG*>(&dest));
+  return _InterlockedIncrement(reinterpret_cast<volatile long*>(&dest));
 }
 
 EZ_ALWAYS_INLINE ezInt64 ezAtomicUtils::Increment(volatile ezInt64& dest)
 {
-  return InterlockedIncrement64(&dest);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, old + 1, old) != old);
+  return old;
+#else
+  return _InterlockedIncrement64(&dest);
+#endif
 }
-
 
 EZ_ALWAYS_INLINE ezInt32 ezAtomicUtils::Decrement(volatile ezInt32& dest)
 {
-  return InterlockedDecrement(reinterpret_cast<volatile LONG*>(&dest));
+  return _InterlockedDecrement(reinterpret_cast<volatile long*>(&dest));
 }
 
 EZ_ALWAYS_INLINE ezInt64 ezAtomicUtils::Decrement(volatile ezInt64& dest)
 {
-  return InterlockedDecrement64(&dest);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, old - 1, old) != old);
+  return old;
+#else
+  return _InterlockedDecrement64(&dest);
+#endif
 }
 
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::Add(volatile ezInt32& dest, ezInt32 value)
 {
-  InterlockedExchangeAdd(reinterpret_cast<volatile LONG*>(&dest), value);
+  _InterlockedExchangeAdd(reinterpret_cast<volatile long*>(&dest), value);
 }
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::Add(volatile ezInt64& dest, ezInt64 value)
 {
-  InterlockedExchangeAdd64(&dest, value);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, old + value, old) != old);
+#else
+  _InterlockedExchangeAdd64(&dest, value);
+#endif
 }
 
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::And(volatile ezInt32& dest, ezInt32 value)
 {
-  _InterlockedAnd(reinterpret_cast<volatile LONG*>(&dest), value);
+  _InterlockedAnd(reinterpret_cast<volatile long*>(&dest), value);
 }
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::And(volatile ezInt64& dest, ezInt64 value)
 {
-  InterlockedAnd64(&dest, value);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, old & value, old) != old);
+#else
+  _InterlockedAnd64(&dest, value);
+#endif
 }
 
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::Or(volatile ezInt32& dest, ezInt32 value)
 {
-  _InterlockedOr(reinterpret_cast<volatile LONG*>(&dest), value);
+  _InterlockedOr(reinterpret_cast<volatile long*>(&dest), value);
 }
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::Or(volatile ezInt64& dest, ezInt64 value)
 {
-  InterlockedOr64(&dest, value);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, old | value, old) != old);
+#else
+  _InterlockedOr64(&dest, value);
+#endif
 }
 
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::Xor(volatile ezInt32& dest, ezInt32 value)
 {
-  _InterlockedXor(reinterpret_cast<volatile LONG*>(&dest), value);
+  _InterlockedXor(reinterpret_cast<volatile long*>(&dest), value);
 }
 
 EZ_ALWAYS_INLINE void ezAtomicUtils::Xor(volatile ezInt64& dest, ezInt64 value)
 {
-  InterlockedXor64(&dest, value);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, old ^ value, old) != old);
+#else
+  _InterlockedXor64(&dest, value);
+#endif
 }
 
 
@@ -88,7 +148,7 @@ inline void ezAtomicUtils::Min(volatile ezInt32& dest, ezInt32 value)
     ezInt32 iOldValue = dest;
     ezInt32 iNewValue = value < iOldValue ? value : iOldValue; // do Min manually here, to break #include cycles
 
-    if (InterlockedCompareExchange(reinterpret_cast<volatile LONG*>(&dest), iNewValue, iOldValue) == iOldValue)
+    if (_InterlockedCompareExchange(reinterpret_cast<volatile long*>(&dest), iNewValue, iOldValue) == iOldValue)
       break;
   }
 }
@@ -101,11 +161,10 @@ inline void ezAtomicUtils::Min(volatile ezInt64& dest, ezInt64 value)
     ezInt64 iOldValue = dest;
     ezInt64 iNewValue = value < iOldValue ? value : iOldValue; // do Min manually here, to break #include cycles
 
-    if (InterlockedCompareExchange64(&dest, iNewValue, iOldValue) == iOldValue)
+    if (_InterlockedCompareExchange64(&dest, iNewValue, iOldValue) == iOldValue)
       break;
   }
 }
-
 
 inline void ezAtomicUtils::Max(volatile ezInt32& dest, ezInt32 value)
 {
@@ -115,7 +174,7 @@ inline void ezAtomicUtils::Max(volatile ezInt32& dest, ezInt32 value)
     ezInt32 iOldValue = dest;
     ezInt32 iNewValue = iOldValue < value ? value : iOldValue; // do Max manually here, to break #include cycles
 
-    if (InterlockedCompareExchange(reinterpret_cast<volatile LONG*>(&dest), iNewValue, iOldValue) == iOldValue)
+    if (_InterlockedCompareExchange(reinterpret_cast<volatile long*>(&dest), iNewValue, iOldValue) == iOldValue)
       break;
   }
 }
@@ -128,7 +187,7 @@ inline void ezAtomicUtils::Max(volatile ezInt64& dest, ezInt64 value)
     ezInt64 iOldValue = dest;
     ezInt64 iNewValue = iOldValue < value ? value : iOldValue; // do Max manually here, to break #include cycles
 
-    if (InterlockedCompareExchange64(&dest, iNewValue, iOldValue) == iOldValue)
+    if (_InterlockedCompareExchange64(&dest, iNewValue, iOldValue) == iOldValue)
       break;
   }
 }
@@ -136,27 +195,36 @@ inline void ezAtomicUtils::Max(volatile ezInt64& dest, ezInt64 value)
 
 inline ezInt32 ezAtomicUtils::Set(volatile ezInt32& dest, ezInt32 value)
 {
-  return InterlockedExchange(reinterpret_cast<volatile LONG*>(&dest), value);
+  return _InterlockedExchange(reinterpret_cast<volatile long*>(&dest), value);
 }
 
 EZ_ALWAYS_INLINE ezInt64 ezAtomicUtils::Set(volatile ezInt64& dest, ezInt64 value)
 {
-  return InterlockedExchange64(&dest, value);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+  ezInt64 old;
+  do
+  {
+    old = dest;
+  } while (_InterlockedCompareExchange64(&dest, value, old) != old);
+  return old;
+#else
+  return _InterlockedExchange64(&dest, value);
+#endif
 }
 
 
 EZ_ALWAYS_INLINE bool ezAtomicUtils::TestAndSet(volatile ezInt32& dest, ezInt32 expected, ezInt32 value)
 {
-  return InterlockedCompareExchange(reinterpret_cast<volatile LONG*>(&dest), value, expected) == expected;
+  return _InterlockedCompareExchange(reinterpret_cast<volatile long*>(&dest), value, expected) == expected;
 }
 
 EZ_ALWAYS_INLINE bool ezAtomicUtils::TestAndSet(volatile ezInt64& dest, ezInt64 expected, ezInt64 value)
 {
-  return InterlockedCompareExchange64(&dest, value, expected) == expected;
+  return _InterlockedCompareExchange64(&dest, value, expected) == expected;
 }
 
 EZ_ALWAYS_INLINE bool ezAtomicUtils::TestAndSet(void** volatile dest, void* expected, void* value)
 {
-  return InterlockedCompareExchangePointer(dest, value, expected) == expected;
+  return _InterlockedCompareExchangePointer(dest, value, expected) == expected;
 }
 

--- a/Code/Engine/Foundation/Threading/Implementation/Win/Mutex_win.cpp
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/Mutex_win.cpp
@@ -1,0 +1,30 @@
+#include <FoundationPCH.h>
+
+#include <Foundation/Threading/Mutex.h>
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
+template <ezUInt32 a, ezUInt32 b>
+struct SameSize
+{
+  static_assert(a == b, "Critical section has incorrect size");
+};
+
+template <ezUInt32 a, ezUInt32 b>
+struct SameAlignment
+{
+  static_assert(a == b, "Critical section has incorrect alignment");
+};
+
+
+ezMutex::ezMutex()
+{
+  SameSize<sizeof(ezMutexHandle), sizeof(CRITICAL_SECTION)> check1; (void)check1;
+  SameAlignment<alignof(ezMutexHandle), alignof(CRITICAL_SECTION)> check2; (void)check2;
+  InitializeCriticalSection((CRITICAL_SECTION*)&m_Handle);
+}
+
+ezMutex::~ezMutex()
+{
+  DeleteCriticalSection((CRITICAL_SECTION*)&m_Handle);
+}

--- a/Code/Engine/Foundation/Threading/Implementation/Win/Mutex_win.cpp
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/Mutex_win.cpp
@@ -1,5 +1,6 @@
 #include <FoundationPCH.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 #include <Foundation/Threading/Mutex.h>
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
@@ -28,3 +29,4 @@ ezMutex::~ezMutex()
 {
   DeleteCriticalSection((CRITICAL_SECTION*)&m_Handle);
 }
+#endif

--- a/Code/Engine/Foundation/Threading/Implementation/Win/Mutex_win.h
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/Mutex_win.h
@@ -4,24 +4,52 @@
 
 #define EZ_MUTEX_WIN_INL_H_INCLUDED
 
-inline ezMutex::ezMutex()
-{
-  InitializeCriticalSection(&m_Handle);
-}
+#ifdef _MSC_VER
 
-inline ezMutex::~ezMutex()
+extern "C"
 {
-  DeleteCriticalSection(&m_Handle);
+  // The main purpose of this little hack here is to have Mutex::Acquire and Mutex::Release inline-able without including windows.h
+  // The hack however does only work on the MSVC compiler. See fall back code below.
+
+  // First define two functions which are binary compatible with EnterCriticalSection and LeaveCriticalSection
+  __declspec(dllimport) void __stdcall ezWinEnterCriticalSection(ezMutexHandle* handle);
+  __declspec(dllimport) void __stdcall ezWinLeaveCriticalSection(ezMutexHandle* handle);
+
+  // Now redirect them through linker flags to the correct implementation
+#  if EZ_ENABLED(EZ_PLATFORM_32BIT)
+#    pragma comment(linker, "/alternatename:__imp__ezWinEnterCriticalSection@4=__imp__EnterCriticalSection@4")
+#    pragma comment(linker, "/alternatename:__imp__ezWinLeaveCriticalSection@4=__imp__LeaveCriticalSection@4")
+#  else
+#    pragma comment(linker, "/alternatename:__imp_ezWinEnterCriticalSection=__imp_EnterCriticalSection")
+#    pragma comment(linker, "/alternatename:__imp_ezWinLeaveCriticalSection=__imp_LeaveCriticalSection")
+#  endif
 }
 
 inline void ezMutex::Acquire()
 {
-  EnterCriticalSection(&m_Handle);
+  ezWinEnterCriticalSection(&m_Handle);
   ++m_iLockCount;
 }
 
 inline void ezMutex::Release()
 {
   --m_iLockCount;
-  LeaveCriticalSection(&m_Handle);
+  ezWinLeaveCriticalSection(&m_Handle);
 }
+
+#else
+
+#  include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
+inline void ezMutex::Acquire()
+{
+  EnterCriticalSection((CRITICAL_SECTION*)&m_Handle);
+  ++m_iLockCount;
+}
+
+inline void ezMutex::Release()
+{
+  --m_iLockCount;
+  LeaveCriticalSection((CRITICAL_SECTION*)&m_Handle);
+}
+#endif

--- a/Code/Engine/Foundation/Threading/Implementation/Win/OSThread_win.h
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/OSThread_win.h
@@ -4,6 +4,11 @@
 
 #define EZ_OSTHREAD_WIN_INL_H_INCLUDED
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 ezAtomicInteger32 ezOSThread::s_iThreadCount;
 
 // Deactivate Doxygen document generation for the following block.

--- a/Code/Engine/Foundation/Threading/Implementation/Win/ThreadingDeclarations_win.h
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/ThreadingDeclarations_win.h
@@ -3,16 +3,29 @@
 // Deactivate Doxygen document generation for the following block.
 /// \cond
 
-typedef CRITICAL_SECTION ezMutexHandle;
-typedef HANDLE ezThreadHandle;
-typedef DWORD ezThreadID;
-typedef DWORD(__stdcall* ezOSThreadEntryPoint)(LPVOID lpThreadParameter);
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
 
-#define EZ_THREAD_CLASS_ENTRY_POINT DWORD __stdcall ezThreadClassEntryPoint(LPVOID lpThreadParameter);
+#if EZ_ENABLED(EZ_PLATFORM_32BIT)
+struct EZ_ALIGN(ezMutexHandle, 4)
+{
+  ezUInt8 data[24];
+};
+#else
+struct EZ_ALIGN(ezMutexHandle, 8)
+{
+  ezUInt8 data[40];
+};
+#endif
+
+typedef ezMinWindows::HANDLE ezThreadHandle;
+typedef ezMinWindows::DWORD ezThreadID;
+typedef ezMinWindows::DWORD(__stdcall* ezOSThreadEntryPoint)(void* lpThreadParameter);
+
+#define EZ_THREAD_CLASS_ENTRY_POINT ezMinWindows::DWORD __stdcall ezThreadClassEntryPoint(void* lpThreadParameter);
 
 struct ezThreadSignalData
 {
-  HANDLE m_hEvent; // Nobody knows what happened during THE EVENT
+  ezMinWindows::HANDLE m_hEvent; // Nobody knows what happened during THE EVENT
 };
 
 /// \endcond

--- a/Code/Engine/Foundation/Time/Implementation/OSX/Time_osx.h
+++ b/Code/Engine/Foundation/Time/Implementation/OSX/Time_osx.h
@@ -1,3 +1,6 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <CoreServices/CoreServices.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>

--- a/Code/Engine/Foundation/Time/Implementation/OSX/Timestamp_osx.h
+++ b/Code/Engine/Foundation/Time/Implementation/OSX/Timestamp_osx.h
@@ -1,3 +1,6 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <CoreFoundation/CoreFoundation.h>
 
 const ezTimestamp ezTimestamp::CurrentTimestamp()

--- a/Code/Engine/Foundation/Time/Implementation/Win/Time_win.h
+++ b/Code/Engine/Foundation/Time/Implementation/Win/Time_win.h
@@ -1,3 +1,8 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 static double g_fInvQpcFrequency;
 
 void ezTime::Initialize()

--- a/Code/Engine/Foundation/Utilities/ExceptionHandler.h
+++ b/Code/Engine/Foundation/Utilities/ExceptionHandler.h
@@ -1,13 +1,15 @@
 #pragma once
 
-#include <Foundation/FoundationInternal.h>
-EZ_FOUNDATION_INTERNAL_HEADER
-
 #include <Foundation/Basics.h>
 #include <Foundation/Strings/String.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-typedef LONG(WINAPI* EZ_TOP_LEVEL_EXCEPTION_HANDLER)(struct _EXCEPTION_POINTERS* pExceptionInfo);
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
+extern "C"
+{
+  struct _EXCEPTION_POINTERS;
+}
+typedef long(EZ_WINDOWS_WINAPI* EZ_TOP_LEVEL_EXCEPTION_HANDLER)(struct _EXCEPTION_POINTERS* pExceptionInfo);
 #elif EZ_ENABLED(EZ_PLATFORM_OSX) || EZ_ENABLED(EZ_PLATFORM_LINUX)
 typedef void(* EZ_TOP_LEVEL_EXCEPTION_HANDLER)();
 #else
@@ -30,8 +32,8 @@ public:
   static void SetExceptionHandler(EZ_TOP_LEVEL_EXCEPTION_HANDLER handler, const char* appName, const char* absDumpPath);
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-  static LONG WINAPI DefaultExceptionHandler(struct _EXCEPTION_POINTERS* pExceptionInfo);
-  static ezResult WriteDump(EXCEPTION_POINTERS* exceptionInfo = nullptr);
+  static long EZ_WINDOWS_WINAPI DefaultExceptionHandler(struct _EXCEPTION_POINTERS* pExceptionInfo);
+  static ezResult WriteDump(struct _EXCEPTION_POINTERS* exceptionInfo = nullptr);
 #elif EZ_ENABLED(EZ_PLATFORM_OSX) || EZ_ENABLED(EZ_PLATFORM_LINUX)
   static void DefaultExceptionHandler() noexcept;
   static ezResult WriteDump();

--- a/Code/Engine/Foundation/Utilities/ExceptionHandler.h
+++ b/Code/Engine/Foundation/Utilities/ExceptionHandler.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #include <Foundation/Basics.h>
 #include <Foundation/Strings/String.h>
 

--- a/Code/Engine/Foundation/Utilities/Implementation/CommandLineUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/CommandLineUtils.cpp
@@ -4,6 +4,7 @@
 #include <Foundation/Utilities/ConversionUtils.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #  include <shellapi.h>
 #endif
 

--- a/Code/Engine/Foundation/Utilities/Implementation/Posix/ExceptionHandler_posix.h
+++ b/Code/Engine/Foundation/Utilities/Implementation/Posix/ExceptionHandler_posix.h
@@ -1,3 +1,5 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
 
 #include <csignal>
 #include <cxxabi.h>

--- a/Code/Engine/Foundation/Utilities/Implementation/Posix/StackTracer_posix.h
+++ b/Code/Engine/Foundation/Utilities/Implementation/Posix/StackTracer_posix.h
@@ -4,6 +4,8 @@
 
 #define EZ_STACKTRACER_POSIX_INL_H_INCLUDED
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
 
 #include <Foundation/Math/Math.h>
 #include <execinfo.h>

--- a/Code/Engine/Foundation/Utilities/Implementation/Win/ExceptionHandler_win.h
+++ b/Code/Engine/Foundation/Utilities/Implementation/Win/ExceptionHandler_win.h
@@ -1,4 +1,7 @@
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 #  include <Dbghelp.h>
 #  include <Shlwapi.h>
 #  include <tchar.h>
@@ -89,3 +92,20 @@ ezResult ezExceptionHandler::WriteDump(EXCEPTION_POINTERS* exceptionInfo)
 #endif
   return EZ_FAILURE;
 }
+#else
+LONG WINAPI ezExceptionHandler::DefaultExceptionHandler(struct _EXCEPTION_POINTERS* pExceptionInfo)
+{
+  return EXCEPTION_CONTINUE_SEARCH;
+}
+
+void ezExceptionHandler::SetExceptionHandler(EZ_TOP_LEVEL_EXCEPTION_HANDLER handler, const char* appName, const char* absDumpPath)
+{
+  s_appName = appName;
+  s_absDumpPath = absDumpPath;
+}
+
+ezResult ezExceptionHandler::WriteDump(EXCEPTION_POINTERS* exceptionInfo)
+{  
+  return EZ_FAILURE;
+}
+#endif

--- a/Code/Engine/Foundation/Utilities/Implementation/Win/ExceptionHandler_win.h
+++ b/Code/Engine/Foundation/Utilities/Implementation/Win/ExceptionHandler_win.h
@@ -38,7 +38,7 @@ void ezExceptionHandler::SetExceptionHandler(EZ_TOP_LEVEL_EXCEPTION_HANDLER hand
   SetUnhandledExceptionFilter(handler);
 }
 
-ezResult ezExceptionHandler::WriteDump(EXCEPTION_POINTERS* exceptionInfo)
+ezResult ezExceptionHandler::WriteDump(struct _EXCEPTION_POINTERS* exceptionInfo)
 {
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   ezStringBuilder path;

--- a/Code/Engine/Foundation/Utilities/Implementation/Win/StackTracer_uwp.h
+++ b/Code/Engine/Foundation/Utilities/Implementation/Win/StackTracer_uwp.h
@@ -4,6 +4,9 @@
 
 #define EZ_STACKTRACER_UWP_INL_H_INCLUDED
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 void ezStackTracer::OnPluginEvent(const ezPlugin::PluginEvent& e) {}
 
 // static

--- a/Code/Engine/Foundation/Utilities/Implementation/Win/StackTracer_win.h
+++ b/Code/Engine/Foundation/Utilities/Implementation/Win/StackTracer_win.h
@@ -4,6 +4,9 @@
 
 #define EZ_STACKTRACER_WIN_INL_H_INCLUDED
 
+#include <Foundation/FoundationInternal.h>
+EZ_FOUNDATION_INTERNAL_HEADER
+
 #define EZ_MSVC_WARNING_NUMBER 4091
 #include <Foundation/Basics/Compiler/DisableWarning.h>
 

--- a/Code/Engine/Foundation/headerCheckerIgnore.json
+++ b/Code/Engine/Foundation/headerCheckerIgnore.json
@@ -1,0 +1,48 @@
+{
+	"includeTarget" :
+	{
+		"byName" : [
+			"cmath",
+			"cstdio",
+			"cstdlib",
+			"cstring",
+			"cwchar",
+			"cwctype",
+			"new",
+			"type_traits",
+			"TargetConditionals.h",
+			"winapifamily.h",
+			"typeinfo",
+			"algorithm",
+			"utility",
+			"stdint.h",
+			"emmintrin.h",
+			"pmmintrin.h",
+			"tmmintrin.h",
+			"smmintrin.h",
+			"nmmintrin.h",
+			"immintrin.h",
+			"array",
+			"tuple",
+			"corewrappers.h",
+			"future",
+			"stdexcept",
+			"iterator",
+			"stddef.h",
+			"intrin.h",
+			"malloc.h",
+			"pthread.h",
+			"stdarg.h",
+			"time.h",
+			"unistd.h"
+		]
+	},
+	"includeSource" : 
+	{
+		"byName" : [
+			"IncludeWindows.h",
+			"UWPUtils.h",
+			"ThreadingDeclarations_posix.h"
+		]
+	}
+}

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -14,6 +14,7 @@
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
 #include <RendererDX11/State/StateDX11.h>
 #include <System/Window/Window.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 #include <d3d11.h>
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
@@ -751,7 +752,7 @@ void ezGALDeviceDX11::SetPrimarySwapChainPlatform(ezGALSwapChain* pSwapChain)
 {
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   // Make window association
-  m_pDXGIFactory->MakeWindowAssociation(pSwapChain->GetDescription().m_pWindow->GetNativeWindowHandle(), 0);
+  m_pDXGIFactory->MakeWindowAssociation(ezMinWindows::ToNative(pSwapChain->GetDescription().m_pWindow->GetNativeWindowHandle()), 0);
 #endif
 }
 

--- a/Code/Engine/RendererDX11/Device/Implementation/SwapChainDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/SwapChainDX11.cpp
@@ -3,6 +3,7 @@
 #include <RendererDX11/Device/DeviceDX11.h>
 #include <RendererDX11/Device/SwapChainDX11.h>
 #include <System/Window/Window.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 #include <Foundation/Basics/Platform/Win/HResultUtils.h>
 #include <d3d11.h>
@@ -70,7 +71,7 @@ ezResult ezGALSwapChainDX11::InitPlatform(ezGALDevice* pDevice)
       DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH; /// \todo The mode switch needs to be handled (ResizeBuffers + communication with engine)
   SwapChainDesc.SampleDesc.Count = m_Description.m_SampleCount;
   SwapChainDesc.SampleDesc.Quality = 0; /// \todo Get from MSAA value of the m_Description
-  SwapChainDesc.OutputWindow = m_Description.m_pWindow->GetNativeWindowHandle();
+  SwapChainDesc.OutputWindow = ezMinWindows::ToNative(m_Description.m_pWindow->GetNativeWindowHandle());
   SwapChainDesc.SwapEffect =
       DXGI_SWAP_EFFECT_DISCARD; // The FLIP models are more efficient but only supported in Win8+. See
                                 // https://msdn.microsoft.com/en-us/library/windows/desktop/bb173077(v=vs.85).aspx#DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL

--- a/Code/Engine/System/Screen/Implementation/Win32/Screen_win32.inl
+++ b/Code/Engine/System/Screen/Implementation/Win32/Screen_win32.inl
@@ -1,4 +1,5 @@
 #include <SystemPCH.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 BOOL CALLBACK ezMonitorEnumProc(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData)
 {

--- a/Code/Engine/System/Window/Implementation/Win32/InputDevice_win32.h
+++ b/Code/Engine/System/Window/Implementation/Win32/InputDevice_win32.h
@@ -2,6 +2,7 @@
 
 #include <Core/Input/DeviceTypes/MouseKeyboard.h>
 #include <System/SystemDLL.h>
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
 
 class EZ_SYSTEM_DLL ezStandardInputDevice : public ezInputDeviceMouseKeyboard
 {
@@ -12,7 +13,7 @@ public:
   ~ezStandardInputDevice();
 
   /// \brief This function needs to be called by all Windows functions, to pass the input information through to this input device.
-  void WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
+  void WindowMessage(ezMinWindows::HWND hWnd, ezMinWindows::UINT Msg, ezMinWindows::WPARAM wParam, ezMinWindows::LPARAM lParam);
 
   /// \brief Calling this function will 'translate' most key names from English to the OS language, by querying that information
   /// from the OS.
@@ -34,7 +35,7 @@ private:
   virtual void RegisterInputSlots() override;
   virtual void ResetInputSlotValues() override;
 
-  void ApplyClipRect(ezMouseCursorClipMode::Enum mode, HWND hWnd);
+  void ApplyClipRect(ezMouseCursorClipMode::Enum mode, ezMinWindows::HWND hWnd);
 
   static bool s_bMainWindowUsed;
   ezUInt32 m_uiWindowNumber = 0;

--- a/Code/Engine/System/Window/Implementation/Win32/InputDevice_win32.inl
+++ b/Code/Engine/System/Window/Implementation/Win32/InputDevice_win32.inl
@@ -1,10 +1,12 @@
 #include <SystemPCH.h>
 
+#include <System/Window/Implementation/Win32/InputDevice_win32.h>
+
 #include <Core/Input/InputManager.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Strings/StringConversion.h>
-#include <System/Window/Implementation/Win32/InputDevice_win32.h>
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStandardInputDevice, 1, ezRTTINoAllocator)
   ;
@@ -269,7 +271,7 @@ void ezStandardInputDevice::ResetInputSlotValues()
   m_InputSlotValues[ezInputSlot_MouseDblClick2] = 0;
 }
 
-void ezStandardInputDevice::ApplyClipRect(ezMouseCursorClipMode::Enum mode, HWND hWnd)
+void ezStandardInputDevice::ApplyClipRect(ezMouseCursorClipMode::Enum mode, ezMinWindows::HWND hWnd)
 {
   if (!m_bApplyClipRect)
     return;
@@ -285,15 +287,15 @@ void ezStandardInputDevice::ApplyClipRect(ezMouseCursorClipMode::Enum mode, HWND
   RECT r;
   {
     RECT area;
-    GetClientRect(hWnd, &area);
+    GetClientRect(ezMinWindows::ToNative(hWnd), &area);
     POINT p0, p1;
     p0.x = 0;
     p0.y = 0;
     p1.x = area.right;
     p1.y = area.bottom;
 
-    ClientToScreen(hWnd, &p0);
-    ClientToScreen(hWnd, &p1);
+    ClientToScreen(ezMinWindows::ToNative(hWnd), &p0);
+    ClientToScreen(ezMinWindows::ToNative(hWnd), &p1);
 
     r.top = p0.y;
     r.left = p0.x;
@@ -336,7 +338,8 @@ void ezStandardInputDevice::SetClipMouseCursor(ezMouseCursorClipMode::Enum mode)
 // When this is enabled, mouse clicks are retrieved via standard WM_LBUTTONDOWN.
 #define EZ_MOUSEBUTTON_COMPATIBILTY_MODE EZ_ON
 
-void ezStandardInputDevice::WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
+void ezStandardInputDevice::WindowMessage(
+  ezMinWindows::HWND hWnd, ezMinWindows::UINT Msg, ezMinWindows::WPARAM wParam, ezMinWindows::LPARAM lParam)
 {
 #if EZ_ENABLED(EZ_MOUSEBUTTON_COMPATIBILTY_MODE)
   static ezInt32 s_iMouseCaptureCount = 0;
@@ -362,7 +365,7 @@ void ezStandardInputDevice::WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LP
     case WM_MOUSEMOVE:
     {
       RECT area;
-      GetClientRect(hWnd, &area);
+      GetClientRect(ezMinWindows::ToNative(hWnd), &area);
 
       const ezUInt32 uiResX = area.right - area.left;
       const ezUInt32 uiResY = area.bottom - area.top;
@@ -424,7 +427,7 @@ void ezStandardInputDevice::WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LP
       m_InputSlotValues[ezInputSlot_MouseButton0] = 1.0f;
 
       if (s_iMouseCaptureCount == 0)
-        SetCapture(hWnd);
+        SetCapture(ezMinWindows::ToNative(hWnd));
       ++s_iMouseCaptureCount;
 
       return;
@@ -443,7 +446,7 @@ void ezStandardInputDevice::WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LP
       m_InputSlotValues[ezInputSlot_MouseButton1] = 1.0f;
 
       if (s_iMouseCaptureCount == 0)
-        SetCapture(hWnd);
+        SetCapture(ezMinWindows::ToNative(hWnd));
       ++s_iMouseCaptureCount;
 
       return;
@@ -462,7 +465,7 @@ void ezStandardInputDevice::WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LP
       m_InputSlotValues[ezInputSlot_MouseButton2] = 1.0f;
 
       if (s_iMouseCaptureCount == 0)
-        SetCapture(hWnd);
+        SetCapture(ezMinWindows::ToNative(hWnd));
       ++s_iMouseCaptureCount;
       return;
 
@@ -482,7 +485,7 @@ void ezStandardInputDevice::WindowMessage(HWND hWnd, UINT Msg, WPARAM wParam, LP
         m_InputSlotValues[ezInputSlot_MouseButton4] = 1.0f;
 
       if (s_iMouseCaptureCount == 0)
-        SetCapture(hWnd);
+        SetCapture(ezMinWindows::ToNative(hWnd));
       ++s_iMouseCaptureCount;
 
       return;

--- a/Code/Engine/System/Window/Implementation/Window.cpp
+++ b/Code/Engine/System/Window/Implementation/Window.cpp
@@ -206,5 +206,11 @@ ezWindow::~ezWindow()
     Destroy();
 }
 
+
+void ezWindow::OnWindowMessage(ezMinWindows::HWND hWnd, ezMinWindows::UINT Msg, ezMinWindows::WPARAM WParam, ezMinWindows::LPARAM LParam)
+{
+
+}
+
 EZ_STATICLINK_FILE(System, System_Window_Implementation_Window);
 

--- a/Code/Engine/System/Window/Window.h
+++ b/Code/Engine/System/Window/Window.h
@@ -29,7 +29,8 @@ typedef sf::Window* ezWindowHandle;
 
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 
-typedef HWND ezWindowHandle;
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
+typedef ezMinWindows::HWND ezWindowHandle;
 #define INVALID_WINDOW_HANDLE_VALUE (ezWindowHandle)(0)
 
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
@@ -234,7 +235,7 @@ public:
   ///   Will be called <i>after</i> the On[...] callbacks!
   ///
   /// \see OnResizeMessage
-  virtual void OnWindowMessage(HWND hWnd, UINT Msg, WPARAM WParam, LPARAM LParam) {}
+  virtual void OnWindowMessage(ezMinWindows::HWND hWnd, ezMinWindows::UINT Msg, ezMinWindows::WPARAM WParam, ezMinWindows::LPARAM LParam);
 
 #elif EZ_ENABLED(EZ_PLATFORM_OSX)
 

--- a/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
@@ -3,6 +3,7 @@
 #include <Foundation/IO/Stream.h>
 #include <Texture/Image/Formats/BmpFileFormat.h>
 #include <Texture/Image/ImageConversion.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 ezBmpFileFormat g_bmpFormat;
 

--- a/Code/EnginePlugins/FmodPlugin/FmodSingleton.cpp
+++ b/Code/EnginePlugins/FmodPlugin/FmodSingleton.cpp
@@ -12,6 +12,7 @@ EZ_IMPLEMENT_SINGLETON(ezFmod);
 static ezFmod g_FmodSingleton;
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 HANDLE g_hLiveUpdateMutex = NULL;
 #endif
 

--- a/Code/EnginePlugins/RenderDocPlugin/RenderDocSingleton.cpp
+++ b/Code/EnginePlugins/RenderDocPlugin/RenderDocSingleton.cpp
@@ -4,6 +4,7 @@
 #include <Foundation/Utilities/CommandLineUtils.h>
 #include <RenderDocPlugin/RenderDocSingleton.h>
 #include <RenderDocPlugin/ThirdParty/renderdoc_app.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 EZ_IMPLEMENT_SINGLETON(ezRenderDoc);
 
@@ -23,7 +24,7 @@ ezRenderDoc::ezRenderDoc()
   if (!dllHandle)
   {
     dllHandle = LoadLibraryW(L"renderdoc.dll");
-    m_HandleToFree = dllHandle;
+    m_HandleToFree = ezMinWindows::FromNative(dllHandle);
   }
 
   if (!dllHandle)
@@ -59,7 +60,7 @@ ezRenderDoc::~ezRenderDoc()
 
   if (m_HandleToFree)
   {
-    FreeLibrary(m_HandleToFree);
+    FreeLibrary(ezMinWindows::ToNative(m_HandleToFree));
     m_HandleToFree = nullptr;
   }
 }

--- a/Code/EnginePlugins/RenderDocPlugin/RenderDocSingleton.h
+++ b/Code/EnginePlugins/RenderDocPlugin/RenderDocSingleton.h
@@ -35,5 +35,5 @@ public:
 
 private:
   RENDERDOC_API_1_4_0* m_pRenderDocAPI = nullptr;
-  HMODULE m_HandleToFree = nullptr;
+  ezMinWindows::HMODULE m_HandleToFree = nullptr;
 };

--- a/Code/EnginePlugins/XBoxControllerPlugin/InputDeviceXBox.cpp
+++ b/Code/EnginePlugins/XBoxControllerPlugin/InputDeviceXBox.cpp
@@ -1,6 +1,7 @@
 #include <Core/Input/InputManager.h>
 #include <Foundation/Logging/Log.h>
 #include <XBoxControllerPlugin/InputDeviceXBox.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
 #include <Xinput.h>
 

--- a/Code/Tools/Fileserve/Main.cpp
+++ b/Code/Tools/Fileserve/Main.cpp
@@ -8,7 +8,7 @@
 #ifdef EZ_USE_QT
 #include <Gui.moc.h>
 #include <QApplication>
-#include <Windows.h>
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #endif
 
 #ifdef EZ_USE_QT

--- a/Code/Tools/HeaderCheck/CMakeLists.txt
+++ b/Code/Tools/HeaderCheck/CMakeLists.txt
@@ -1,0 +1,13 @@
+ez_cmake_init()
+
+ez_requires(EZ_CMAKE_PLATFORM_WINDOWS_DESKTOP)
+
+# Get the name of this folder as the project name
+get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
+
+ez_create_target(APPLICATION ${PROJECT_NAME})
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+  Core
+)

--- a/Code/Tools/HeaderCheck/Main.cpp
+++ b/Code/Tools/HeaderCheck/Main.cpp
@@ -427,7 +427,7 @@ public:
     ezTokenizer tokenizer(m_stackAllocator.Borrow());
     auto dataView = fileContents.GetView();
     tokenizer.Tokenize(ezArrayPtr<const ezUInt8>(reinterpret_cast<const ezUInt8*>(dataView.GetStartPointer()), dataView.GetElementCount()),
-      ezLog::GetThreadLocalLogSystem(), m_stackAllocator.Borrow());
+      ezLog::GetThreadLocalLogSystem());
 
     ezStringView hash("#");
     ezStringView include("include");

--- a/Code/Tools/HeaderCheck/Main.cpp
+++ b/Code/Tools/HeaderCheck/Main.cpp
@@ -1,0 +1,559 @@
+#include <Foundation/Application/Application.h>
+#include <Foundation/CodeUtils/Tokenizer.h>
+#include <Foundation/Configuration/Startup.h>
+#include <Foundation/Containers/Map.h>
+#include <Foundation/Containers/Set.h>
+#include <Foundation/IO/FileSystem/DataDirTypeFolder.h>
+#include <Foundation/IO/FileSystem/FileReader.h>
+#include <Foundation/IO/FileSystem/FileSystem.h>
+#include <Foundation/IO/JSONReader.h>
+#include <Foundation/Logging/ConsoleWriter.h>
+#include <Foundation/Logging/HTMLWriter.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Logging/VisualStudioWriter.h>
+#include <Foundation/Memory/StackAllocator.h>
+#include <Foundation/Strings/PathUtils.h>
+#include <Foundation/Strings/String.h>
+#include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Types/UniquePtr.h>
+
+namespace
+{
+  EZ_ALWAYS_INLINE void SkipWhitespace(ezToken& token, ezUInt32& i, const ezDeque<ezToken>& tokens)
+  {
+    while (token.m_iType == ezTokenType::Whitespace)
+    {
+      token = tokens[++i];
+    }
+  }
+
+  EZ_ALWAYS_INLINE void SkipLine(ezToken& token, ezUInt32& i, const ezDeque<ezToken>& tokens)
+  {
+    while (token.m_iType != ezTokenType::Newline && token.m_iType != ezTokenType::EndOfFile)
+    {
+      token = tokens[++i];
+    }
+  }
+} // namespace
+
+class ezHeaderCheckApp : public ezApplication
+{
+private:
+  ezString m_sSearchDir;
+  ezString m_sProjectName;
+  bool m_bHadErrors;
+  bool m_bHadSeriousWarnings;
+  bool m_bHadWarnings;
+  ezUniquePtr<ezStackAllocator<ezMemoryTrackingFlags::None>> m_stackAllocator;
+  ezDynamicArray<ezString> m_includeDirectories;
+
+  struct IgnoreInfo
+  {
+    ezHashSet<ezString> m_byName;
+  };
+
+  IgnoreInfo m_ignoreTarget;
+  IgnoreInfo m_ignoreSource;
+public:
+  typedef ezApplication SUPER;
+
+  ezHeaderCheckApp()
+    : ezApplication("StaticLinkerApp")
+  {
+    m_bHadErrors = false;
+    m_bHadSeriousWarnings = false;
+    m_bHadWarnings = false;
+  }
+
+  /// Makes sure the apps return value reflects whether there were any errors or warnings
+  static void LogInspector(const ezLoggingEventData& eventData)
+  {
+    ezHeaderCheckApp* app = (ezHeaderCheckApp*)ezApplication::GetApplicationInstance();
+
+    switch (eventData.m_EventType)
+    {
+      case ezLogMsgType::ErrorMsg:
+        app->m_bHadErrors = true;
+        break;
+      case ezLogMsgType::SeriousWarningMsg:
+        app->m_bHadSeriousWarnings = true;
+        break;
+      case ezLogMsgType::WarningMsg:
+        app->m_bHadWarnings = true;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  ezResult ParseArray(const ezVariant& value, ezHashSet<ezString>& dst)
+  {
+    if (!value.CanConvertTo<ezVariantArray>())
+    {
+      ezLog::Error("Expected array");
+      return EZ_FAILURE;
+    }
+    auto a = value.Get<ezVariantArray>();
+    const auto arraySize = a.GetCount();
+    for (ezUInt32 i = 0; i < arraySize; i++)
+    {
+      auto& el = a[i];
+      if (!el.CanConvertTo<ezString>())
+      {
+        ezLog::Error("Value {0} at index {1} can not be converted to a string. Expected array of strings.", el, i);
+        return EZ_FAILURE;
+      }
+      ezStringBuilder file = el.Get<ezString>();
+      file.ToLower();
+      dst.Insert(file);
+    }
+    return EZ_SUCCESS;
+  }
+
+  ezResult ParseIgnoreFile(const ezStringView ignoreFilePath)
+  {
+    ezJSONReader jsonReader;
+    jsonReader.SetLogInterface(ezLog::GetThreadLocalLogSystem());
+
+    ezFileReader reader;
+    ezString sIgnoreFilePath = ignoreFilePath;
+    if (reader.Open(sIgnoreFilePath).Failed())
+    {
+      ezLog::Error("Failed to open ignore file {0}", ignoreFilePath);
+      return EZ_FAILURE;
+    }
+
+    if (jsonReader.Parse(reader).Failed())
+      return EZ_FAILURE;
+
+    const ezStringView includeTarget = "includeTarget";
+    const ezStringView includeSource = "includeSource";
+    const ezStringView byName = "byName";
+
+    auto topLevel = jsonReader.GetTopLevelObject();
+    for (auto it = topLevel.GetIterator(); it.IsValid(); it.Next())
+    {
+      if (it.Key() == includeTarget || it.Key() == includeSource)
+      {
+        IgnoreInfo& info = (it.Key() == includeTarget) ? m_ignoreTarget : m_ignoreSource;
+        auto inner = it.Value().Get<ezVariantDictionary>();
+        for (auto it2 = inner.GetIterator(); it2.IsValid(); it2.Next())
+        {
+          if (it2.Key() == byName)
+          {
+            if (ParseArray(it2.Value(), info.m_byName).Failed())
+            {
+              ezLog::Error("Failed to parse value of '{0}.{1}'.", it.Key(), it2.Key());
+              EZ_FAILURE;
+            }
+          }
+          else
+          {
+            ezLog::Error("Unknown field of '{0}.{1}'", it.Key(), it2.Key());
+            return EZ_FAILURE;
+          }
+        }
+      }
+      else
+      {
+        ezLog::Error("Unknown json member in root object '{0}'", it.Key().GetView());
+        return EZ_FAILURE;
+      }
+    }
+    return EZ_SUCCESS;
+  }
+
+  virtual void AfterCoreSystemsStartup() override
+  {
+    ezGlobalLog::AddLogWriter(ezLogWriter::Console::LogMessageHandler);
+    ezGlobalLog::AddLogWriter(ezLogWriter::VisualStudio::LogMessageHandler);
+    ezGlobalLog::AddLogWriter(LogInspector);
+
+    m_stackAllocator = EZ_DEFAULT_NEW(ezStackAllocator<ezMemoryTrackingFlags::None>, "Temp Allocator", ezFoundation::GetAlignedAllocator());
+
+    if (GetArgumentCount() < 2)
+      ezLog::Error("This tool requires at leas one command-line argument: An absolute path to the top-level folder of a library.");
+
+    // Add standard folder factory
+    ezFileSystem::RegisterDataDirectoryFactory(ezDataDirectory::FolderType::Factory);
+
+    // Add the empty data directory to access files via absolute paths
+    ezFileSystem::AddDataDirectory("", "App", ":", ezFileSystem::AllowWrites);
+
+    // pass the absolute path to the directory that should be scanned as the first parameter to this application
+    ezStringBuilder sSearchDir;
+
+    auto numArgs = GetArgumentCount();
+    auto shortInclude = ezStringView("-i");
+    auto longInclude = ezStringView("--includeDir");
+    auto shortIgnoreFile = ezStringView("-f");
+    auto longIgnoreFile = ezStringView("--ignoreFile");
+    for (ezUInt32 argi = 1; argi < numArgs; argi++)
+    {
+      auto arg = ezStringView(GetArgument(argi));
+      if (arg == shortInclude || arg == longInclude)
+      {
+        if (numArgs <= argi + 1)
+        {
+          ezLog::Error("Missing path for {0}", arg);
+          return;
+        }
+        ezStringBuilder includeDir = GetArgument(argi + 1);
+        if (includeDir == shortInclude || includeDir == longInclude || includeDir == shortIgnoreFile || includeDir == longIgnoreFile)
+        {
+          ezLog::Error("Missing path for {0} found {1} instead", arg, includeDir.GetView());
+          return;
+        }
+        argi++;
+        includeDir.MakeCleanPath();
+        m_includeDirectories.PushBack(includeDir);
+      }
+      else if (arg == shortIgnoreFile || arg == longIgnoreFile)
+      {
+        if (numArgs <= argi + 1)
+        {
+          ezLog::Error("Missing path for {0}", arg);
+          return;
+        }
+        ezStringBuilder ignoreFile = GetArgument(argi + 1);
+        if (ignoreFile == shortInclude || ignoreFile == longInclude || ignoreFile == shortIgnoreFile || ignoreFile == longIgnoreFile)
+        {
+          ezLog::Error("Missing path for {0} found {1} instead", arg, ignoreFile.GetView());
+          return;
+        }
+        argi++;
+        ignoreFile.MakeCleanPath();
+        if (ParseIgnoreFile(ignoreFile.GetView()).Failed())
+          return;
+      }
+      else
+      {
+        if (sSearchDir.IsEmpty())
+        {
+          sSearchDir = arg;
+          sSearchDir.MakeCleanPath();
+        }
+        else
+        {
+          ezLog::Error("Currently only one directory is supported for searching. Did you forget -i|--includeDir?");
+        }
+      }
+    }
+
+    if (!ezPathUtils::IsAbsolutePath(sSearchDir.GetData()))
+      ezLog::Error("The given path is not absolute: '{0}'", sSearchDir);
+
+    m_sSearchDir = sSearchDir;
+
+    auto projectStart = m_sSearchDir.GetView().FindLastSubString("/");
+    if (projectStart == nullptr)
+    {
+      ezLog::Error("Failed to parse project name from search path {0}", sSearchDir);
+      return;
+    }
+    ezStringBuilder projectName = ezStringView(projectStart + 1, m_sSearchDir.GetView().GetEndPointer());
+    projectName.ToUpper();
+    m_sProjectName = projectName;
+
+    // use such a path to write to an absolute file
+    // ':abs/C:/some/file.txt"
+  }
+
+  virtual void BeforeCoreSystemsShutdown() override
+  {
+    if (m_bHadWarnings || m_bHadSeriousWarnings || m_bHadErrors)
+    {
+      ezLog::Warning("There have been errors or warnings, see log for details.");
+    }
+
+    if (m_bHadErrors || m_bHadSeriousWarnings)
+      SetReturnCode(2); // Errors or Serious Warnings, yet files modified, this is unusual, requires reverting the source from outside.
+    else if (m_bHadWarnings)
+      SetReturnCode(1); // Warnings, files still modified. (normal operation)
+    else
+      SetReturnCode(0); // No issues, files modified. (normal operation)
+
+    m_stackAllocator = nullptr;
+
+    ezGlobalLog::RemoveLogWriter(LogInspector);
+    ezGlobalLog::RemoveLogWriter(ezLogWriter::Console::LogMessageHandler);
+    ezGlobalLog::RemoveLogWriter(ezLogWriter::VisualStudio::LogMessageHandler);
+  }
+
+  ezResult ReadEntireFile(const char* szFile, ezStringBuilder& sOut)
+  {
+    sOut.Clear();
+
+    ezFileReader File;
+    if (File.Open(szFile) == EZ_FAILURE)
+    {
+      ezLog::Error("Could not open for reading: '{0}'", szFile);
+      return EZ_FAILURE;
+    }
+
+    ezDynamicArray<ezUInt8> FileContent;
+
+    ezUInt8 Temp[4024];
+    ezUInt64 uiRead = File.ReadBytes(Temp, EZ_ARRAY_SIZE(Temp));
+
+    while (uiRead > 0)
+    {
+      FileContent.PushBackRange(ezArrayPtr<ezUInt8>(Temp, (ezUInt32)uiRead));
+
+      uiRead = File.ReadBytes(Temp, EZ_ARRAY_SIZE(Temp));
+    }
+
+    FileContent.PushBack(0);
+
+    if (!ezUnicodeUtils::IsValidUtf8((const char*)&FileContent[0]))
+    {
+      ezLog::Error("The file \"{0}\" contains characters that are not valid Utf8. This often happens when you type special characters in "
+                   "an editor that does not save the file in Utf8 encoding.",
+        szFile);
+      return EZ_FAILURE;
+    }
+
+    sOut = (const char*)&FileContent[0];
+
+    return EZ_SUCCESS;
+  }
+
+  void IterateOverFiles()
+  {
+    if (m_bHadSeriousWarnings || m_bHadErrors)
+      return;
+
+    const ezUInt32 uiSearchDirLength = m_sSearchDir.GetElementCount() + 1;
+
+    // get a directory iterator for the search directory
+    ezFileSystemIterator it;
+    if (it.StartSearch(m_sSearchDir.GetData(), true, false) == EZ_SUCCESS)
+    {
+      ezStringBuilder currentFile, sExt;
+
+      // while there are additional files / folders
+      do
+      {
+        // build the absolute path to the current file
+        currentFile = it.GetCurrentPath();
+        currentFile.AppendPath(it.GetStats().m_sName.GetData());
+
+        // file extensions are always converted to lower-case actually
+        sExt = currentFile.GetFileExtension();
+
+        if (sExt.IsEqual_NoCase("h") || sExt.IsEqual_NoCase("inl"))
+        {
+          EZ_LOG_BLOCK("Header", &currentFile.GetData()[uiSearchDirLength]);
+          CheckHeaderFile(currentFile);
+          m_stackAllocator->Reset();
+          continue;
+        }
+      } while (it.Next() == EZ_SUCCESS);
+    }
+    else
+      ezLog::Error("Could not search the directory '{0}'", m_sSearchDir);
+  }
+
+  void CheckInclude(const ezStringBuilder& currentFile, const ezStringBuilder& includePath, ezUInt32 line)
+  {
+    ezStringBuilder absIncludePath(m_stackAllocator.Borrow());
+    bool includeOutside = true;
+    if (includePath.IsAbsolutePath())
+    {
+      for (auto& includeDir : m_includeDirectories)
+      {
+        if (includePath.StartsWith(includeDir))
+        {
+          includeOutside = false;
+          break;
+        }
+      }
+    }
+    else
+    {
+      bool includeFound = false;
+      if (includePath.StartsWith("ThirdParty"))
+      {
+        includeOutside = true;
+      }
+      else
+      {
+        for (auto& includeDir : m_includeDirectories)
+        {
+          absIncludePath = includeDir;
+          absIncludePath.AppendPath(includePath);
+          if (ezOSFile::ExistsFile(absIncludePath))
+          {
+            includeOutside = false;
+            break;
+          }
+        }
+      }
+    }
+
+    if (includeOutside)
+    {
+      ezStringBuilder includeFileLower = includePath.GetFileNameAndExtension();
+      includeFileLower.ToLower();
+      ezStringBuilder currentFileLower = currentFile.GetFileNameAndExtension();
+      currentFileLower.ToLower();
+
+      bool ignore = m_ignoreTarget.m_byName.Contains(includeFileLower)
+        || m_ignoreSource.m_byName.Contains(currentFileLower);
+
+      if (!ignore)
+      {
+        ezLog::Error(
+          "Including '{0}' in {1}:{2} leaks underlying implementation detail. Including system or thirdparty headers in public easy header "
+          "files is not allowed. Please use an interface, factory or pimpl to hide the implementation and avoid the include.",
+          includePath.GetView(), currentFile.GetView(), line);
+      }
+    }
+  }
+
+  void CheckHeaderFile(const ezStringBuilder& currentFile)
+  {
+    ezStringBuilder fileContents(m_stackAllocator.Borrow());
+    ReadEntireFile(currentFile.GetData(), fileContents);
+
+
+    auto fileDir = currentFile.GetFileDirectory();
+
+    ezStringBuilder internalMacroToken(m_stackAllocator.Borrow());
+    internalMacroToken.Append("EZ_", m_sProjectName, "_INTERNAL_HEADER");
+    auto internalMacroTokenView = internalMacroToken.GetView();
+
+    ezTokenizer tokenizer(m_stackAllocator.Borrow());
+    auto dataView = fileContents.GetView();
+    tokenizer.Tokenize(ezArrayPtr<const ezUInt8>(reinterpret_cast<const ezUInt8*>(dataView.GetStartPointer()), dataView.GetElementCount()),
+      ezLog::GetThreadLocalLogSystem(), m_stackAllocator.Borrow());
+
+    ezStringView hash("#");
+    ezStringView include("include");
+    ezStringView openAngleBracket("<");
+    ezStringView closeAngleBracket(">");
+
+    bool isInternalHeader = false;
+    auto tokens = tokenizer.GetTokens();
+    const auto numTokens = tokens.GetCount();
+    for (ezUInt32 i = 0; i < numTokens; i++)
+    {
+      auto curToken = tokens[i];
+      while (curToken.m_iType == ezTokenType::Whitespace)
+      {
+        curToken = tokens[++i];
+      }
+      if (curToken.m_iType == ezTokenType::NonIdentifier && curToken.m_DataView == hash)
+      {
+        do
+        {
+          curToken = tokens[++i];
+        } while (curToken.m_iType == ezTokenType::Whitespace);
+
+        if (curToken.m_iType == ezTokenType::Identifier && curToken.m_DataView == include)
+        {
+          auto includeToken = curToken;
+          do
+          {
+            curToken = tokens[++i];
+          } while (curToken.m_iType == ezTokenType::Whitespace);
+
+          if (curToken.m_iType == ezTokenType::String1)
+          {
+            // #include "bla"
+            ezStringBuilder absIncludePath(m_stackAllocator.Borrow());
+            ezStringBuilder relativePath(m_stackAllocator.Borrow());
+            relativePath = curToken.m_DataView;
+            relativePath.Trim("\"");
+            relativePath.MakeCleanPath();
+            absIncludePath = fileDir;
+            absIncludePath.AppendPath(relativePath);
+
+            if (!ezOSFile::ExistsFile(absIncludePath))
+            {
+              ezLog::Error("The file '{0}' does not exist. Includes relative to the global include directories should use the #include "
+                           "<path/to/file.h> syntax.",
+                absIncludePath);
+            }
+            else if (!isInternalHeader)
+            {
+              CheckInclude(currentFile, absIncludePath, includeToken.m_uiLine);
+            }
+          }
+          else if (curToken.m_iType == ezTokenType::NonIdentifier && curToken.m_DataView == openAngleBracket)
+          {
+            // #include <bla>
+            bool error = false;
+            auto startToken = curToken;
+            do
+            {
+              curToken = tokens[++i];
+              if (curToken.m_iType == ezTokenType::Newline)
+              {
+                ezLog::Error("Non-terminated '<' in #include {0} line {1}", currentFile.GetView(), includeToken.m_uiLine);
+                error = true;
+                break;
+              }
+            } while (curToken.m_iType != ezTokenType::NonIdentifier || curToken.m_DataView != closeAngleBracket);
+
+            if (error)
+            {
+              // in case of error skip the malformed line in hopes that we can recover from the error.
+              do
+              {
+                curToken = tokens[++i];
+              } while (curToken.m_iType != ezTokenType::Newline);
+            }
+            else if (!isInternalHeader)
+            {
+              ezStringBuilder includePath(m_stackAllocator.Borrow());
+              includePath = ezStringView(startToken.m_DataView.GetEndPointer(), curToken.m_DataView.GetStartPointer());
+              includePath.MakeCleanPath();
+              CheckInclude(currentFile, includePath, startToken.m_uiLine);
+            }
+          }
+          else
+          {
+            // error
+            ezLog::Error("Can not parse #include statement in {0} line {1}", currentFile.GetView(), includeToken.m_uiLine);
+          }
+        }
+        else
+        {
+          while (curToken.m_iType != ezTokenType::Newline && curToken.m_iType != ezTokenType::EndOfFile)
+          {
+            curToken = tokens[++i];
+          }
+        }
+      }
+      else
+      {
+        if (curToken.m_iType == ezTokenType::Identifier && curToken.m_DataView == internalMacroTokenView)
+        {
+          isInternalHeader = true;
+        }
+        else
+        {
+          while (curToken.m_iType != ezTokenType::Newline && curToken.m_iType != ezTokenType::EndOfFile)
+          {
+            curToken = tokens[++i];
+          }
+        }
+      }
+    }
+  }
+
+  virtual ezApplication::ApplicationExecution Run() override
+  {
+    // something basic has gone wrong
+    if (m_bHadSeriousWarnings || m_bHadErrors)
+      return ezApplication::Quit;
+
+    IterateOverFiles();
+
+    return ezApplication::Quit;
+  }
+};
+
+EZ_CONSOLEAPP_ENTRY_POINT(ezHeaderCheckApp);

--- a/Code/Tools/Libs/GuiFoundation/GuiFoundationPCH.h
+++ b/Code/Tools/Libs/GuiFoundation/GuiFoundationPCH.h
@@ -1,5 +1,7 @@
 #include <GuiFoundation/GuiFoundationDLL.h>
 
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Logging/Log.h>
 

--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Node.h
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Node.h
@@ -5,6 +5,11 @@
 #include <Foundation/Containers/HybridArray.h>
 #include <QGraphicsWidget>
 
+// Avoid conflicts with windows.
+#ifdef GetObject
+#undef GetObject
+#endif
+
 class ezQtPin;
 class ezDocumentNodeManager;
 class QLabel;

--- a/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectManager.h
@@ -8,6 +8,11 @@
 class ezDocumentObjectManager;
 class ezDocument;
 
+// Prevent conflicts with windows.h
+#ifdef GetObject
+#undef GetObject
+#endif
+
 class EZ_TOOLSFOUNDATION_DLL ezDocumentRoot : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezDocumentRoot, ezReflectedClass);

--- a/Code/Tools/StaticLinkUtil/Main.cpp
+++ b/Code/Tools/StaticLinkUtil/Main.cpp
@@ -45,7 +45,7 @@ The parameters and function body will be automatically generated and later updat
 See the Return Codes at the end of the BeforeCoreSystemsShutdown function.
 */
 
-class ezHeaderCheckApp : public ezApplication
+class ezStaticLinkerApp : public ezApplication
 {
 private:
   ezString m_sSearchDir;
@@ -77,7 +77,7 @@ private:
 public:
   typedef ezApplication SUPER;
 
-  ezHeaderCheckApp()
+  ezStaticLinkerApp()
     : ezApplication("StaticLinkerApp")
   {
     m_bHadErrors = false;
@@ -90,7 +90,7 @@ public:
   /// Makes sure the apps return value reflects whether there were any errors or warnings
   static void LogInspector(const ezLoggingEventData& eventData)
   {
-    ezHeaderCheckApp* app = (ezHeaderCheckApp*) ezApplication::GetApplicationInstance();
+    ezStaticLinkerApp* app = (ezStaticLinkerApp*) ezApplication::GetApplicationInstance();
 
     switch (eventData.m_EventType)
     {
@@ -764,4 +764,4 @@ public:
   }
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezHeaderCheckApp);
+EZ_CONSOLEAPP_ENTRY_POINT(ezStaticLinkerApp);

--- a/Code/Tools/StaticLinkUtil/Main.cpp
+++ b/Code/Tools/StaticLinkUtil/Main.cpp
@@ -45,7 +45,7 @@ The parameters and function body will be automatically generated and later updat
 See the Return Codes at the end of the BeforeCoreSystemsShutdown function.
 */
 
-class ezStaticLinkerApp : public ezApplication
+class ezHeaderCheckApp : public ezApplication
 {
 private:
   ezString m_sSearchDir;
@@ -77,7 +77,7 @@ private:
 public:
   typedef ezApplication SUPER;
 
-  ezStaticLinkerApp()
+  ezHeaderCheckApp()
     : ezApplication("StaticLinkerApp")
   {
     m_bHadErrors = false;
@@ -90,7 +90,7 @@ public:
   /// Makes sure the apps return value reflects whether there were any errors or warnings
   static void LogInspector(const ezLoggingEventData& eventData)
   {
-    ezStaticLinkerApp* app = (ezStaticLinkerApp*) ezApplication::GetApplicationInstance();
+    ezHeaderCheckApp* app = (ezHeaderCheckApp*) ezApplication::GetApplicationInstance();
 
     switch (eventData.m_EventType)
     {
@@ -764,4 +764,4 @@ public:
   }
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezStaticLinkerApp);
+EZ_CONSOLEAPP_ENTRY_POINT(ezHeaderCheckApp);

--- a/Code/UnitTests/FoundationTest/Strings/FormatStringTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/FormatStringTest.cpp
@@ -7,6 +7,8 @@
 #include <Foundation/Time/Time.h>
 #include <Foundation/Time/Timestamp.h>
 
+#include <stdarg.h>
+
 void TestFormat(const ezFormatString& str, const char* szExpected)
 {
   ezStringBuilder sb;

--- a/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
+++ b/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
@@ -1,6 +1,7 @@
 #include <GameEngineTestPCH.h>
 
 #include "Basics.h"
+#include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Strings/StringConversion.h>
 #include <Foundation/System/Process.h>

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.h
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.h
@@ -194,10 +194,11 @@ protected:
 #endif
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#include <Foundation/Basics/Platform/Win/MinWindows.h>
 #  define EZ_NV_OPTIMUS                                                                                                                    \
     extern "C"                                                                                                                             \
     {                                                                                                                                      \
-      _declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;                                                                         \
+      _declspec(dllexport) ezMinWindows::DWORD NvOptimusEnablement = 0x00000001;                                                           \
     }
 #else
 #  define EZ_NV_OPTIMUS

--- a/Data/UnitTests/FoundationTest/Preprocessor/ErrorBadQuotes - Expected.txt
+++ b/Data/UnitTests/FoundationTest/Preprocessor/ErrorBadQuotes - Expected.txt
@@ -1,4 +1,4 @@
 Processing failed
-Log: 'Unescaped Newline in string'
+Log: 'Unescaped Newline in string line 4 column 0'
 Preprocessor/ErrorBadQuotes.txt: Line 3 [2]: Error: #error 'Before bad quote ' After bad quote'
 Log: 'File 'Preprocessor/ErrorBadQuotes.txt', Line 3 (2): #error 'Before bad quote ' After bad quote''

--- a/Data/UnitTests/FoundationTest/Preprocessor/ErrorBadQuotes2 - Expected.txt
+++ b/Data/UnitTests/FoundationTest/Preprocessor/ErrorBadQuotes2 - Expected.txt
@@ -1,4 +1,4 @@
 Processing failed
-Log: 'Unescaped Newline in string'
+Log: 'Unescaped Newline in string line 4 column 0'
 Preprocessor/ErrorBadQuotes2.txt: Line 3 [2]: Error: #error '"String not closed here'
 Log: 'File 'Preprocessor/ErrorBadQuotes2.txt', Line 3 (2): #error '"String not closed here''


### PR DESCRIPTION
* Added HeaderChecker utility.
* removal of windows.h from ezFoundation public includes. 
* Differentiate between public and internal headers in ezFoundation.