### PR TITLE
Fix GameEngineTest UWP

### DIFF
--- a/Code/BuildSystem/CMake/toolchain-winstore.cmake
+++ b/Code/BuildSystem/CMake/toolchain-winstore.cmake
@@ -1,5 +1,5 @@
 set(CMAKE_SYSTEM_NAME WindowsStore)
 
 # Windows anniversary update version. As of writing the newest hololens emulator does not support Windows Creator's update.
-set(CMAKE_SYSTEM_VERSION 10.0.17763.0)
-set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.17763.0)
+set(CMAKE_SYSTEM_VERSION 10.0.14393.0)
+set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.14393.0)

--- a/Code/Engine/GameEngine/GameApplication/GameApplication.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplication.h
@@ -49,14 +49,13 @@ public:
   /// function allows to override that by setting a custom function that creates a graphics device.
   static void SetOverrideDefaultDeviceCreator(ezDelegate<ezGALDevice*(const ezGALDeviceCreationDescription&)> creator);
 
-  /// \todo Fix this comment
-  /// \brief virtual function that is called by DoProjectSetup(). The result is passed to ezFileSystem::SetProjectDirectory
+  /// \brief Implementation of ezGameApplicationBase::FindProjectDirectory to define the 'project' special data directory.
   ///
-  /// The default implementation relies on a valid path in m_sAppProjectPath.
-  /// It passes that to SearchProjectDirectory() together with the path to the application binary,
-  /// to search for a project somewhere relative to where the application is installed.
+  /// The default implementation will try to resolve m_sAppProjectPath to an absolute path. m_sAppProjectPath can be absolute itself,
+  /// relative to ">sdk/" or relative to ezOSFile::GetApplicationDirectory().
+  /// m_sAppProjectPath must be set either via the ezGameApplication constructor or manually set before project.
   ///
-  /// Override this, if your application uses a different folder structure or way to specify the project directory.
+  /// Alternatively, ezGameApplication::FindProjectDirectory() must be overwritten.
   virtual ezString FindProjectDirectory() const override;
 
   /// \brief Used at runtime (by the editor) to reload input maps. Forwards to Init_ConfigureInput()

--- a/Code/Engine/GameEngine/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplicationBase.h
@@ -191,8 +191,24 @@ protected:
   virtual ezResult BeforeCoreSystemsStartup() override;
   virtual void AfterCoreSystemsStartup() override;
 
+  /// \brief Returns the target of the 'project' special data directory.
+  ///
+  /// The return value of this function will be passed into ezFileSystem::SetSpecialDirectory.
+  /// Afterwards, any path starting with the special directory marker (">project/") will point
+  /// into this directory.
   virtual ezString FindProjectDirectory() const = 0;
+
+  /// \brief Returns the target of the 'base' data directory.
+  ///
+  /// Path needs to start with a special directory marker (">marker/").
+  /// This is passed into the target of the 'base' data directory. Target defaults to ">sdk/Data/Base".
   virtual ezString GetBaseDataDirectoryPath() const;
+
+  /// \brief Returns the target of the 'project' data directory.
+  ///
+  /// Path needs to start with a special directory marker (">marker/").
+  /// This is passed into the target of the 'project' data directory. Target defaults to ">project/".
+  virtual ezString GetProjectDataDirectoryPath() const;
 
   /// \brief Executes all 'BaseInit_' functions. Typically done very early, before core system startup
   virtual void ExecuteBaseInitFunctions();

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationBaseInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationBaseInit.cpp
@@ -20,6 +20,11 @@ ezString ezGameApplicationBase::GetBaseDataDirectoryPath() const
   return ">sdk/Data/Base";
 }
 
+ezString ezGameApplicationBase::GetProjectDataDirectoryPath() const
+{
+  return ">project/";
+}
+
 void ezGameApplicationBase::ExecuteInitFunctions()
 {
   Init_PlatformProfile_SetPreferred();
@@ -116,7 +121,7 @@ void ezGameApplicationBase::Init_FileSystem_ConfigureDataDirs()
   ezFileSystem::AddDataDirectory(GetBaseDataDirectoryPath(), "GameApplicationBase", "base", ezFileSystem::DataDirUsage::ReadOnly);
 
   // ":project/" for reading the project specific files
-  ezFileSystem::AddDataDirectory(">project/", "GameApplicationBase", "project", ezFileSystem::DataDirUsage::ReadOnly);
+  ezFileSystem::AddDataDirectory(GetProjectDataDirectoryPath(), "GameApplicationBase", "project", ezFileSystem::DataDirUsage::ReadOnly);
 
   {
     ezApplicationFileSystemConfig appFileSystemConfig;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -253,7 +253,9 @@ void ezGameApplication::Init_LoadRequiredPlugins()
 
 #  if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
   ezPlugin::LoadPlugin("ezShaderCompilerHLSL");
+#    if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   ezPlugin::LoadPlugin("ezRenderDocPlugin");
+#    endif
 #  endif
 
   // on sandboxed platforms, we can only load data through fileserve, so enforce use of this plugin

--- a/Code/UnitTests/GameEngineTest/CMakeLists.txt
+++ b/Code/UnitTests/GameEngineTest/CMakeLists.txt
@@ -14,6 +14,18 @@ target_link_libraries(${PROJECT_NAME}
   RendererDX11
 )
 
+if (EZ_CMAKE_PLATFORM_WINDOWS_UWP)
+  # Due to app sandboxing we need to explcitly name required plugins for UWP.
+  target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+    FmodPlugin
+    KrautPlugin
+    ParticlePlugin
+    InspectorPlugin
+  )
+endif()
+
+
 ez_link_target_dx11(${PROJECT_NAME})
 
 ez_ci_add_test(${PROJECT_NAME} NEEDS_HW_ACCESS)

--- a/Code/UnitTests/GameEngineTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/GameEngineTest/TestClass/TestClass.cpp
@@ -81,6 +81,12 @@ ezString ezGameEngineTestApplication::FindProjectDirectory() const
   return m_sAppProjectPath;
 }
 
+ezString ezGameEngineTestApplication::GetProjectDataDirectoryPath() const
+{
+  ezStringBuilder sProjectPath(">sdk/", ezTestFramework::GetInstance()->GetRelTestDataPath(), "/", m_sProjectDirName);
+  return sProjectPath;
+}
+
 ezResult ezGameEngineTestApplication::LoadScene(const char* szSceneFile)
 {
   EZ_LOCK(m_pWorld->GetWriteMarker());
@@ -118,10 +124,8 @@ ezResult ezGameEngineTestApplication::BeforeCoreSystemsStartup()
 {
   EZ_SUCCEED_OR_RETURN(SUPER::BeforeCoreSystemsStartup());
 
-  ezStringBuilder sProjectPath(">sdk/", ezTestFramework::GetInstance()->GetRelTestDataPath(), "/", m_sProjectDirName);
-
   ezStringBuilder sProject;
-  ezFileSystem::ResolveSpecialDirectory(sProjectPath, sProject);
+  ezFileSystem::ResolveSpecialDirectory(GetProjectDataDirectoryPath(), sProject);
   m_sAppProjectPath = sProject;
 
   return EZ_SUCCESS;

--- a/Code/UnitTests/GameEngineTest/TestClass/TestClass.h
+++ b/Code/UnitTests/GameEngineTest/TestClass/TestClass.h
@@ -23,6 +23,7 @@ public:
   ezGameEngineTestApplication(const char* szProjectDirName);
 
   virtual ezString FindProjectDirectory() const final override;
+  virtual ezString GetProjectDataDirectoryPath() const final override;
   const ezImage& GetLastScreenshot() { return m_LastScreenshot; }
 
   ezResult LoadScene(const char* szSceneFile);

--- a/Code/UnitTests/RemoteTestHarness/CMakeLists.txt
+++ b/Code/UnitTests/RemoteTestHarness/CMakeLists.txt
@@ -9,6 +9,10 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target_cs(APPLICATION ${PROJECT_NAME})
 
+add_dependencies(${PROJECT_NAME}
+  Fileserve
+)
+
 set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DOTNET_REFERENCES
   "System"
   "System.Core"

--- a/Code/UnitTests/RemoteTestHarness/ProcessHelper.cs
+++ b/Code/UnitTests/RemoteTestHarness/ProcessHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -7,132 +7,137 @@ using System.Threading.Tasks;
 
 namespace ezUwpTestHarness
 {
+  /// <summary>
+  /// This class contains static helper methods for running external processes.
+  /// </summary>
+  public static class ezProcessHelper
+  {
     /// <summary>
-    /// This class contains static helper methods for running external processes.
+    /// Returned by RunExternalExe. Contains the result of the external process execution.
+    /// If the application could not be started for whatever reason the ExitCode is set to -1.
+    /// Additional information is available to the BuildStepResults errorHandler passed to RunExternalExe.
     /// </summary>
-    public static class ezProcessHelper
+    public class ProcessResult
     {
-        /// <summary>
-        /// Returned by RunExternalExe. Contains the result of the external process execution.
-        /// If the application could not be started for whatever reason the ExitCode is set to -1.
-        /// Additional information is available to the BuildStepResults errorHandler passed to RunExternalExe.
-        /// </summary>
-        public class ProcessResult
-        {
-            public int ExitCode { get; set; }
-            public string StdOut { get; set; }
-            public string ErrorOut { get; set; }
-            public double Duration { get; set; }
+      public int ExitCode { get; set; }
+      public string StdOut { get; set; }
+      public string ErrorOut { get; set; }
+      public double Duration { get; set; }
 
-            public string Errors { get; set; }
-            public void Error(string format, params object[] arg)
-            {
-                string sError = String.Format(format, arg);
-                Console.WriteLine(sError);
-                Errors = Errors + ("\n" + sError);
-            }
-        }
+      public string Errors { get; set; }
+      public void Error(string format, params object[] arg)
+      {
+        string sError = String.Format(format, arg);
+        Console.WriteLine(sError);
+        Errors = Errors + ("\n" + sError);
+      }
 
-        /// <summary>
-        /// Starts an external process and returns a ProcessResult with the generated output and error code.
-        /// </summary>
-        /// <param name="sFilename">Absolute or relative path to the executable. Must be executable from sWorkingDirectory.</param>
-        /// <param name="sArguments">Arguments passed to the executable.</param>
-        /// <param name="sWorkingDirectory">Working dir from which the executable is run.</param>
-        /// <param name="errorHandler">Any error (except normal ErrorOut) that comes up during process execution is passed to this error handler.</param>
-        /// <param name="iTimeoutMS">Timeout in milliseconds until the process is forcibly terminated.</param>
-        /// <returns>Return value is never null.</returns>
-        public static ProcessResult RunExternalExe(string sFilename, string sArguments, string sWorkingDirectory, int iTimeoutMS = 10 * 60 * 1000)
-        {
-            OperatingSystem os = Environment.OSVersion;
-            PlatformID pid = os.Platform;
-
-            if (pid == PlatformID.Win32Windows || pid == PlatformID.Win32NT)
-            {
-                using (var setter = new ezWindowsErrorModeSetter())
-                {
-                    return RunExternalExe_private(sFilename, sArguments, sWorkingDirectory, iTimeoutMS);
-                }
-            }
-            else
-            {
-                return RunExternalExe_private(sFilename, sArguments, sWorkingDirectory, iTimeoutMS);
-            }
-        }
-
-        private static ProcessResult RunExternalExe_private(string sFilename, string sArguments, string sWorkingDirectory, int iTimeoutMS = 10 * 60 * 1000)
-        {
-            // TODO: test if file exists, or interpret thrown Win32Exception
-            Stopwatch sw = new Stopwatch();
-            sw.Start();
-
-            ProcessResult res = new ProcessResult();
-
-            Process process = new Process();
-
-            process.StartInfo.FileName = sFilename;
-            process.StartInfo.Arguments = sArguments;
-            process.StartInfo.CreateNoWindow = true;
-            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardError = true;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.RedirectStandardInput = false;
-            process.StartInfo.WorkingDirectory = sWorkingDirectory;
-
-            try
-            {
-                process.Start();
-
-                using (Task<bool> processWaiter = Task.Factory.StartNew(() => process.WaitForExit(iTimeoutMS)))
-                using (Task<string> outputReader = Task.Factory.StartNew((Func<object, string>)ReadStream, process.StandardOutput))
-                using (Task<string> errorReader = Task.Factory.StartNew((Func<object, string>)ReadStream, process.StandardError))
-                {
-                    bool waitResult = processWaiter.Result;
-
-                    if (!waitResult)
-                    {
-                        process.Kill();
-                    }
-
-                    Task.WaitAll(outputReader, errorReader);
-
-                    if (!waitResult)
-                    {
-                        res.StdOut = outputReader.Result;
-                        res.ErrorOut = errorReader.Result;
-                        res.Error("Error running: {0}, {1}. The process reached its time-limit of {2} minutes!\n", sFilename, sArguments, (float)iTimeoutMS / 60000.0);
-                        res.ExitCode = -1;
-                    }
-                    else
-                    {
-                        res.StdOut = outputReader.Result;
-                        res.ErrorOut = errorReader.Result;
-                        res.ExitCode = process.ExitCode;
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                res.Error("Error running: {0}, {1}. Exception: {2})", sFilename, sArguments, e.Message);
-                Console.WriteLine(e);
-                res.ExitCode = -1;
-            }
-
-            sw.Stop();
-
-            res.Duration = sw.Elapsed.TotalSeconds;
-            res.StdOut = (res.StdOut == null) ? "" : res.StdOut.Replace("\r", "");
-            res.ErrorOut = (res.ErrorOut == null) ? "" : res.ErrorOut.Replace("\r", "");
-            return res;
-        }
-
-        // Safe reading of process output from:
-        // http://alabaxblog.info/2013/06/redirectstandardoutput-beginoutputreadline-pattern-broken/
-        private static string ReadStream(object streamReader)
-        {
-            string result = ((System.IO.StreamReader)streamReader).ReadToEnd();
-            return result;
-        }
+      public override string ToString()
+      {
+        return $"ExitCode: {ExitCode}, Duration: {Duration}\nStdOut: {StdOut}\nErrorOut: {ErrorOut}\nErrors: {Errors}";
+      }
     }
+
+    /// <summary>
+    /// Starts an external process and returns a ProcessResult with the generated output and error code.
+    /// </summary>
+    /// <param name="sFilename">Absolute or relative path to the executable. Must be executable from sWorkingDirectory.</param>
+    /// <param name="sArguments">Arguments passed to the executable.</param>
+    /// <param name="sWorkingDirectory">Working dir from which the executable is run.</param>
+    /// <param name="errorHandler">Any error (except normal ErrorOut) that comes up during process execution is passed to this error handler.</param>
+    /// <param name="iTimeoutMS">Timeout in milliseconds until the process is forcibly terminated.</param>
+    /// <returns>Return value is never null.</returns>
+    public static ProcessResult RunExternalExe(string sFilename, string sArguments, string sWorkingDirectory, int iTimeoutMS = 10 * 60 * 1000)
+    {
+      OperatingSystem os = Environment.OSVersion;
+      PlatformID pid = os.Platform;
+
+      if (pid == PlatformID.Win32Windows || pid == PlatformID.Win32NT)
+      {
+        using (var setter = new ezWindowsErrorModeSetter())
+        {
+          return RunExternalExe_private(sFilename, sArguments, sWorkingDirectory, iTimeoutMS);
+        }
+      }
+      else
+      {
+        return RunExternalExe_private(sFilename, sArguments, sWorkingDirectory, iTimeoutMS);
+      }
+    }
+
+    private static ProcessResult RunExternalExe_private(string sFilename, string sArguments, string sWorkingDirectory, int iTimeoutMS = 10 * 60 * 1000)
+    {
+      // TODO: test if file exists, or interpret thrown Win32Exception
+      Stopwatch sw = new Stopwatch();
+      sw.Start();
+
+      ProcessResult res = new ProcessResult();
+
+      Process process = new Process();
+
+      process.StartInfo.FileName = sFilename;
+      process.StartInfo.Arguments = sArguments;
+      process.StartInfo.CreateNoWindow = true;
+      process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+      process.StartInfo.UseShellExecute = false;
+      process.StartInfo.RedirectStandardError = true;
+      process.StartInfo.RedirectStandardOutput = true;
+      process.StartInfo.RedirectStandardInput = false;
+      process.StartInfo.WorkingDirectory = sWorkingDirectory;
+
+      try
+      {
+        process.Start();
+
+        using (Task<bool> processWaiter = Task.Factory.StartNew(() => process.WaitForExit(iTimeoutMS)))
+        using (Task<string> outputReader = Task.Factory.StartNew((Func<object, string>)ReadStream, process.StandardOutput))
+        using (Task<string> errorReader = Task.Factory.StartNew((Func<object, string>)ReadStream, process.StandardError))
+        {
+          bool waitResult = processWaiter.Result;
+
+          if (!waitResult)
+          {
+            process.Kill();
+          }
+
+          Task.WaitAll(outputReader, errorReader);
+
+          if (!waitResult)
+          {
+            res.StdOut = outputReader.Result;
+            res.ErrorOut = errorReader.Result;
+            res.Error("Error running: {0}, {1}. The process reached its time-limit of {2} minutes!\n", sFilename, sArguments, (float)iTimeoutMS / 60000.0);
+            res.ExitCode = -1;
+          }
+          else
+          {
+            res.StdOut = outputReader.Result;
+            res.ErrorOut = errorReader.Result;
+            res.ExitCode = process.ExitCode;
+          }
+        }
+      }
+      catch (Exception e)
+      {
+        res.Error("Error running: {0}, {1}. Exception: {2})", sFilename, sArguments, e.Message);
+        Console.WriteLine(e);
+        res.ExitCode = -1;
+      }
+
+      sw.Stop();
+
+      res.Duration = sw.Elapsed.TotalSeconds;
+      res.StdOut = (res.StdOut == null) ? "" : res.StdOut.Replace("\r", "");
+      res.ErrorOut = (res.ErrorOut == null) ? "" : res.ErrorOut.Replace("\r", "");
+      return res;
+    }
+
+    // Safe reading of process output from:
+    // http://alabaxblog.info/2013/06/redirectstandardoutput-beginoutputreadline-pattern-broken/
+    private static string ReadStream(object streamReader)
+    {
+      string result = ((System.IO.StreamReader)streamReader).ReadToEnd();
+      return result;
+    }
+  }
 }

--- a/Code/UnitTests/RemoteTestHarness/Program.cs
+++ b/Code/UnitTests/RemoteTestHarness/Program.cs
@@ -1,43 +1,53 @@
 using System;
+using System.Diagnostics;
 using CommandLine;
 
 namespace ezUwpTestHarness
 {
 
-    class Program
+  class Program
+  {
+    public class Options
     {
-        public class Options
-        {
-            [Option('w', "workspace", Required = true, Default = "", HelpText = "")]
-            public string ezWorkspace { get; set; }
-            [Option('o', "output", Required = true, Default = "", HelpText = "")]
-            public string testOutputPath { get; set; }
-            [Option('p', "project", Required = false, Default = "FoundationTest", HelpText = "")]
-            public string project { get; set; }
+      [Option('w', "workspace", Required = true, Default = "", HelpText = "")]
+      public string ezWorkspace { get; set; }
+      [Option('o', "output", Required = true, Default = "", HelpText = "")]
+      public string testOutputPath { get; set; }
+      [Option('p', "project", Required = false, Default = "FoundationTest", HelpText = "")]
+      public string project { get; set; }
 
-            [Option('c', "configuration", Required = false, Default = "RelWithDebInfo", HelpText = "")]
-            public string configuration { get; set; }
-            [Option("platform", Required = false, Default = "Win32", HelpText = "")]
-            public string platform { get; set; }
-        }
-
-        static void Main(string[] args)
-        {
-            Parser.Default.ParseArguments<Options>(args)
-                   .WithParsed<Options>(o =>
-                   {
-                       try
-                       {
-                           ezTestUWP test = new ezTestUWP(o.ezWorkspace, o.testOutputPath, o.configuration, o.platform, o.project);
-                           test.ExecuteTest();
-                       }
-                       catch (Exception e)
-                       {
-                           Environment.ExitCode = 1;
-                           Console.WriteLine(string.Format("Failed to run test. Exception: '{0}'", e.ToString()));
-                       }
-                       Console.Out.Flush();
-                   });
-        }
+      [Option('c', "configuration", Required = false, Default = "RelWithDebInfo", HelpText = "")]
+      public string configuration { get; set; }
+      [Option("platform", Required = false, Default = "Win32", HelpText = "")]
+      public string platform { get; set; }
     }
+
+    static void Main(string[] args)
+    {
+      AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs eventArgs) =>
+      {
+        Environment.ExitCode = 1;
+        Console.WriteLine(string.Format("Failed to run test. Exception: '{0}'", eventArgs.ExceptionObject.ToString()));
+        Console.Out.Flush();
+        try
+        {
+          string args2 = string.Format("-accepteula -ma {0}", Process.GetCurrentProcess().Id);
+          string absBinDir = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
+          var bla = ezProcessHelper.RunExternalExe("procdump", args2, absBinDir);
+        }
+        catch (Exception e)
+        {
+          Console.WriteLine(string.Format("Failed to run procdump: '{0}'", e.ToString()));
+        }
+      };
+
+      Parser.Default.ParseArguments<Options>(args)
+        .WithParsed<Options>(o =>
+        {
+          ezTestUWP test = new ezTestUWP(o.ezWorkspace, o.testOutputPath, o.configuration, o.platform, o.project);
+          test.ExecuteTest();
+        });
+    }
+
+  }
 }


### PR DESCRIPTION
-Support devenv 2017 enterprise and professional builds in RemoteTestHarness.
-Reduce win version to azure VM version.
-Fixes to project data directory handling.
 Separate special directory ">project" target from the data directory "project" target. While the later one normally points to ">project" this is not always the case but was kind of hardcoded which broke fileserve.
-Add build dependency to FileServe to RemoteTestHarness.