### PR TITLE
Adds support for per-project translation files

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -25,6 +25,7 @@ class ezProgress;
 class ezQtProgressbar;
 class ezQtEditorApp;
 class QStringList;
+class ezTranslatorFromFiles;
 
 struct EZ_EDITORFRAMEWORK_DLL ezEditorAppEvent
 {
@@ -277,6 +278,10 @@ private:
   // *** Progress Bar ***
   ezProgress* m_pProgressbar;
   ezQtProgressbar* m_pQtProgressbar;
+
+  // *** Localization ***
+  ezTranslatorFromFiles* m_pTranslatorFromFiles = nullptr;
+
 
   ezWhatsNewText m_WhatsNew;
 };

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -100,6 +100,12 @@ void ezQtEditorApp::ProjectEventHandler(const ezToolsProjectEvent& r)
       ReadTagRegistry();
       UpdateInputDynamicEnumValues();
 
+      // add project specific translations
+      // (these are currently never removed)
+      {
+        m_pTranslatorFromFiles->AddTranslationFilesFromFolder(":project/Editor/Localization/en");
+      }
+
       // tell the engine process which file system and plugin configuration to use
       ezEditorEngineProcessConnection::GetSingleton()->SetFileSystemConfig(m_FileSystemConfig);
       ezEditorEngineProcessConnection::GetSingleton()->SetPluginConfig(m_EnginePluginConfig);

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -239,9 +239,11 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> flags, const char* sz
     ezGlobalLog::AddLogWriter(ezLoggingEvent::Handler(&ezLogWriter::HTML::LogMessageHandler, &m_LogHTML));
   }
   ezUniquePtr<ezTranslatorFromFiles> pTranslatorEn = EZ_DEFAULT_NEW(ezTranslatorFromFiles);
+  m_pTranslatorFromFiles = pTranslatorEn.Borrow();
+
   // ezUniquePtr<ezTranslatorFromFiles> pTranslatorDe = EZ_DEFAULT_NEW(ezTranslatorFromFiles);
 
-  pTranslatorEn->LoadTranslationFilesFromFolder(":app/Localization/en");
+  pTranslatorEn->AddTranslationFilesFromFolder(":app/Localization/en");
   // pTranslatorDe->LoadTranslationFilesFromFolder(":app/Localization/de");
 
   ezTranslationLookup::AddTranslator(EZ_DEFAULT_NEW(ezTranslatorLogMissing));

--- a/Code/Engine/Foundation/Strings/Implementation/TranslationLookup.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/TranslationLookup.cpp
@@ -63,14 +63,13 @@ void ezTranslationLookup::Clear()
 
 //////////////////////////////////////////////////////////////////////////
 
-void ezTranslatorFromFiles::LoadTranslationFilesFromFolder(const char* szFolder)
+void ezTranslatorFromFiles::AddTranslationFilesFromFolder(const char* szFolder)
 {
-  EZ_LOG_BLOCK("LoadTranslationFilesFromFolder", szFolder);
+  EZ_LOG_BLOCK("AddTranslationFilesFromFolder", szFolder);
 
-  if (m_sFolder != szFolder)
+  if (!m_Folders.Contains(szFolder))
   {
-    // prevent assigning to itself during Reload()
-    m_sFolder = szFolder;
+    m_Folders.PushBack(szFolder);
   }
 
 #if EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS)
@@ -98,9 +97,9 @@ void ezTranslatorFromFiles::Reload()
 {
   ezTranslatorStorage::Reload();
 
-  if (!m_sFolder.IsEmpty())
+  for (const auto& sFolder : m_Folders)
   {
-    LoadTranslationFilesFromFolder(m_sFolder);
+    AddTranslationFilesFromFolder(sFolder);
   }
 }
 

--- a/Code/Engine/Foundation/Strings/TranslationLookup.h
+++ b/Code/Engine/Foundation/Strings/TranslationLookup.h
@@ -87,14 +87,14 @@ public:
   /// The given path must be absolute or resolvable to an absolute path.
   /// On failure, the function does nothing.
   /// This function depends on ezFileSystemIterator to be available.
-  void LoadTranslationFilesFromFolder(const char* szFolder);
+  void AddTranslationFilesFromFolder(const char* szFolder);
 
   virtual void Reload() override;
 
 private:
   void LoadTranslationFile(const char* szFullPath);
 
-  ezString m_sFolder;
+  ezHybridArray<ezString, 4> m_Folders;
 };
 
 /// \brief Handles looking up translations for strings.


### PR DESCRIPTION
The files must be located in the project under "Editor/Localization/en".
Currently only one language is supported.