### PR TITLE
Add spatial data categories

### DIFF
--- a/Code/Engine/Core/Messages/UpdateLocalBoundsMessage.h
+++ b/Code/Engine/Core/Messages/UpdateLocalBoundsMessage.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/CoreDLL.h>
+#include <Core/World/SpatialData.h>
 #include <Foundation/Communication/Message.h>
 #include <Foundation/Math/BoundingBoxSphere.h>
 
@@ -8,16 +9,24 @@ struct EZ_CORE_DLL ezMsgUpdateLocalBounds : public ezMessage
 {
   EZ_DECLARE_MESSAGE_TYPE(ezMsgUpdateLocalBounds, ezMessage);
 
-  EZ_ALWAYS_INLINE void AddBounds(const ezBoundingBoxSphere& bounds) { m_ResultingLocalBounds.ExpandToInclude(bounds); }
+  EZ_ALWAYS_INLINE void AddBounds(const ezBoundingBoxSphere& bounds, ezSpatialData::Category category)
+  {
+    m_ResultingLocalBounds.ExpandToInclude(bounds);
+    m_uiSpatialDataCategoryBitmask |= category.GetBitmask();
+  }
 
   ///\brief Enforces the object to be always visible. Note that you can't set this flag to false again,
   ///  because the same message is sent to multiple components and should accumulate the bounds.
-  EZ_ALWAYS_INLINE void SetAlwaysVisible() { m_bAlwaysVisible = true; }
+  EZ_ALWAYS_INLINE void SetAlwaysVisible(ezSpatialData::Category category)
+  {
+    m_bAlwaysVisible = true;
+    m_uiSpatialDataCategoryBitmask |= category.GetBitmask();
+  }
 
 private:
   friend class ezGameObject;
 
   ezBoundingBoxSphere m_ResultingLocalBounds;
+  ezUInt32 m_uiSpatialDataCategoryBitmask = 0;
   bool m_bAlwaysVisible = false;
 };
-

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -421,8 +421,9 @@ private:
     ezSimdBBoxSphere m_globalBounds;
 
     ezSpatialDataHandle m_hSpatialData;
+    ezUInt32 m_uiSpatialDataCategoryBitmask;
 
-    ezUInt32 m_uiPadding2[3];
+    ezUInt32 m_uiPadding2[2];
 
     void UpdateLocalTransform();
 

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -259,7 +259,8 @@ void ezGameObject::operator=(const ezGameObject& other)
 
   if (!m_pTransformationData->m_hSpatialData.IsInvalidated())
   {
-    m_pWorld->GetSpatialSystem().UpdateSpatialData(m_pTransformationData->m_hSpatialData, m_pTransformationData->m_globalBounds, this);
+    m_pWorld->GetSpatialSystem().UpdateSpatialData(m_pTransformationData->m_hSpatialData, m_pTransformationData->m_globalBounds, this,
+      m_pTransformationData->m_uiSpatialDataCategoryBitmask);
   }
 
   m_Components = other.m_Components;
@@ -581,6 +582,7 @@ void ezGameObject::UpdateLocalBounds()
 
   m_pTransformationData->m_localBounds = ezSimdConversion::ToBBoxSphere(msg.m_ResultingLocalBounds);
   m_pTransformationData->m_localBounds.m_BoxHalfExtents.SetW(msg.m_bAlwaysVisible ? 1.0f : 0.0f);
+  m_pTransformationData->m_uiSpatialDataCategoryBitmask = msg.m_uiSpatialDataCategoryBitmask;
 
   if (IsStatic())
   {
@@ -887,7 +889,7 @@ void ezGameObject::TransformationData::UpdateSpatialData(bool bWasAlwaysVisible,
   {
     if (m_hSpatialData.IsInvalidated())
     {
-      m_hSpatialData = spatialSystem.CreateSpatialDataAlwaysVisible(m_pObject);
+      m_hSpatialData = spatialSystem.CreateSpatialDataAlwaysVisible(m_pObject, m_uiSpatialDataCategoryBitmask);
     }
   }
   else
@@ -896,11 +898,11 @@ void ezGameObject::TransformationData::UpdateSpatialData(bool bWasAlwaysVisible,
     {
       if (m_hSpatialData.IsInvalidated())
       {
-        m_hSpatialData = spatialSystem.CreateSpatialData(m_globalBounds, m_pObject);
+        m_hSpatialData = spatialSystem.CreateSpatialData(m_globalBounds, m_pObject, m_uiSpatialDataCategoryBitmask);
       }
       else
       {
-        spatialSystem.UpdateSpatialData(m_hSpatialData, m_globalBounds, m_pObject);
+        spatialSystem.UpdateSpatialData(m_hSpatialData, m_globalBounds, m_pObject, m_uiSpatialDataCategoryBitmask);
       }
     }
     else

--- a/Code/Engine/Core/World/Implementation/SpatialData.cpp
+++ b/Code/Engine/Core/World/Implementation/SpatialData.cpp
@@ -1,0 +1,47 @@
+#include <CorePCH.h>
+
+#include <Core/World/SpatialData.h>
+
+EZ_CHECK_AT_COMPILETIME(sizeof(ezSpatialData) == 64);
+
+ezHybridArray<ezSpatialData::CategoryData, 32> ezSpatialData::s_CategoryData;
+
+// static
+ezSpatialData::Category ezSpatialData::RegisterCategory(const char* szCategoryName)
+{
+  Category oldCategory = FindCategory(szCategoryName);
+  if (oldCategory != ezInvalidSpatialDataCategory)
+    return oldCategory;
+
+  if (s_CategoryData.GetCount() == 32)
+  {
+    EZ_REPORT_FAILURE("Too many spatial data categories");
+    return ezInvalidSpatialDataCategory;
+  }
+
+  Category newCategory = Category(s_CategoryData.GetCount());
+
+  auto& data = s_CategoryData.ExpandAndGetRef();
+  data.m_sName.Assign(szCategoryName);
+
+  return newCategory;
+}
+
+// static
+ezSpatialData::Category ezSpatialData::FindCategory(const char* szCategoryName)
+{
+  ezTempHashedString categoryName(szCategoryName);
+
+  for (ezUInt32 uiCategoryIndex = 0; uiCategoryIndex < s_CategoryData.GetCount(); ++uiCategoryIndex)
+  {
+    if (s_CategoryData[uiCategoryIndex].m_sName == categoryName)
+      return Category(uiCategoryIndex);
+  }
+
+  return ezInvalidSpatialDataCategory;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+ezSpatialData::Category ezDefaultSpatialDataCategories::RenderStatic = ezSpatialData::RegisterCategory("RenderStatic");
+ezSpatialData::Category ezDefaultSpatialDataCategories::RenderDynamic = ezSpatialData::RegisterCategory("RenderDynamic");

--- a/Code/Engine/Core/World/Implementation/SpatialSystem.cpp
+++ b/Code/Engine/Core/World/Implementation/SpatialSystem.cpp
@@ -25,6 +25,7 @@ ezSpatialDataHandle ezSpatialSystem::CreateSpatialData(const ezSimdBBoxSphere& b
   ezSpatialData* pData = m_DataStorage.Create();
 
   pData->m_pObject = pObject;
+  pData->m_uiCategoryBitmask = uiCategoryBitmask;
   pData->m_Bounds = bounds;
 
   SpatialDataAdded(pData);
@@ -37,6 +38,7 @@ ezSpatialDataHandle ezSpatialSystem::CreateSpatialDataAlwaysVisible(ezGameObject
   ezSpatialData* pData = m_DataStorage.Create();
 
   pData->m_pObject = pObject;
+  pData->m_uiCategoryBitmask = uiCategoryBitmask;
   pData->m_Flags.Add(ezSpatialData::Flags::AlwaysVisible);
   pData->m_Bounds.SetInvalid();
 

--- a/Code/Engine/Core/World/Implementation/SpatialSystem.cpp
+++ b/Code/Engine/Core/World/Implementation/SpatialSystem.cpp
@@ -22,6 +22,9 @@ ezSpatialSystem::~ezSpatialSystem() = default;
 
 ezSpatialDataHandle ezSpatialSystem::CreateSpatialData(const ezSimdBBoxSphere& bounds, ezGameObject* pObject, ezUInt32 uiCategoryBitmask)
 {
+  if (uiCategoryBitmask == 0)
+    return ezSpatialDataHandle();
+
   ezSpatialData* pData = m_DataStorage.Create();
 
   pData->m_pObject = pObject;
@@ -35,6 +38,9 @@ ezSpatialDataHandle ezSpatialSystem::CreateSpatialData(const ezSimdBBoxSphere& b
 
 ezSpatialDataHandle ezSpatialSystem::CreateSpatialDataAlwaysVisible(ezGameObject* pObject, ezUInt32 uiCategoryBitmask)
 {
+  if (uiCategoryBitmask == 0)
+    return ezSpatialDataHandle();
+
   ezSpatialData* pData = m_DataStorage.Create();
 
   pData->m_pObject = pObject;

--- a/Code/Engine/Core/World/Implementation/SpatialSystem_RegularGrid.cpp
+++ b/Code/Engine/Core/World/Implementation/SpatialSystem_RegularGrid.cpp
@@ -583,7 +583,10 @@ void ezSpatialSystem_RegularGrid::SpatialDataAdded(ezSpatialData* pData)
 void ezSpatialSystem_RegularGrid::SpatialDataRemoved(ezSpatialData* pData)
 {
   auto pUserData = reinterpret_cast<SpatialUserData*>(&pData->m_uiUserData[0]);
-  pUserData->m_pCell->RemoveData(pData);
+  if (pUserData->m_pCell != nullptr)
+  {
+    pUserData->m_pCell->RemoveData(pData);
+  }
 }
 
 void ezSpatialSystem_RegularGrid::SpatialDataChanged(ezSpatialData* pData, const ezSimdBBoxSphere& oldBounds, ezUInt32 uiOldCategoryBitmask)
@@ -621,7 +624,10 @@ void ezSpatialSystem_RegularGrid::SpatialDataChanged(ezSpatialData* pData, const
 
     pData->m_uiCategoryBitmask = uiNewCategoryBitmask;
 
-    SpatialDataAdded(pData);
+    if (pData->m_uiCategoryBitmask != 0)
+    {
+      SpatialDataAdded(pData);
+    }
   }
 }
 

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -185,6 +185,7 @@ ezGameObjectHandle ezWorld::CreateObject(const ezGameObjectDesc& desc, ezGameObj
   pTransformationData->m_localBounds.m_BoxHalfExtents.SetW(ezSimdFloat::Zero());
   pTransformationData->m_globalBounds = pTransformationData->m_localBounds;
   pTransformationData->m_hSpatialData.Invalidate();
+  pTransformationData->m_uiSpatialDataCategoryBitmask = 0;
 
   if (pParentData != nullptr)
   {

--- a/Code/Engine/Core/World/SpatialData.h
+++ b/Code/Engine/Core/World/SpatialData.h
@@ -23,7 +23,7 @@ struct EZ_ALIGN_16(ezSpatialData)
 
     ezUInt32 m_uiValue;
 
-    EZ_ALWAYS_INLINE ezUInt32 GetBitmask() const { return EZ_BIT(m_uiValue); }
+    EZ_ALWAYS_INLINE ezUInt32 GetBitmask() const { return m_uiValue != ezInvalidIndex ? EZ_BIT(m_uiValue) : 0; }
   };
 
   static EZ_CORE_DLL Category RegisterCategory(const char* szCategoryName);

--- a/Code/Engine/Core/World/SpatialSystem.h
+++ b/Code/Engine/Core/World/SpatialSystem.h
@@ -16,14 +16,14 @@ public:
   /// \name Spatial Data Functions
   ///@{
 
-  ezSpatialDataHandle CreateSpatialData(const ezSimdBBoxSphere& bounds, ezGameObject* pObject = nullptr);
-  ezSpatialDataHandle CreateSpatialDataAlwaysVisible(ezGameObject* pObject = nullptr);
+  ezSpatialDataHandle CreateSpatialData(const ezSimdBBoxSphere& bounds, ezGameObject* pObject, ezUInt32 uiCategoryBitmask);
+  ezSpatialDataHandle CreateSpatialDataAlwaysVisible(ezGameObject* pObject, ezUInt32 uiCategoryBitmask);
 
   void DeleteSpatialData(const ezSpatialDataHandle& hData);
 
   bool TryGetSpatialData(const ezSpatialDataHandle& hData, const ezSpatialData*& out_pData) const;
 
-  void UpdateSpatialData(const ezSpatialDataHandle& hData, const ezSimdBBoxSphere& bounds, ezGameObject* pObject = nullptr);
+  void UpdateSpatialData(const ezSpatialDataHandle& hData, const ezSimdBBoxSphere& bounds, ezGameObject* pObject, ezUInt32 uiCategoryBitmask);
 
   ///@}
   /// \name Simple Queries
@@ -46,29 +46,28 @@ public:
     }
   };
 
-  void FindObjectsInSphere(const ezBoundingSphere& sphere, ezDynamicArray<ezGameObject*>& out_Objects, QueryStats* pStats = nullptr) const;
-  void FindObjectsInSphere(const ezBoundingSphere& sphere, QueryCallback callback, QueryStats* pStats = nullptr) const;
+  void FindObjectsInSphere(const ezBoundingSphere& sphere, ezUInt32 uiCategoryBitmask, ezDynamicArray<ezGameObject*>& out_Objects, QueryStats* pStats = nullptr) const;
+  void FindObjectsInSphere(const ezBoundingSphere& sphere, ezUInt32 uiCategoryBitmask, QueryCallback callback, QueryStats* pStats = nullptr) const;
 
-  void FindObjectsInBox(const ezBoundingBox& box, ezDynamicArray<ezGameObject*>& out_Objects, QueryStats* pStats = nullptr) const;
-  void FindObjectsInBox(const ezBoundingBox& box, QueryCallback callback, QueryStats* pStats = nullptr) const;
+  void FindObjectsInBox(const ezBoundingBox& box, ezUInt32 uiCategoryBitmask, ezDynamicArray<ezGameObject*>& out_Objects, QueryStats* pStats = nullptr) const;
+  void FindObjectsInBox(const ezBoundingBox& box, ezUInt32 uiCategoryBitmask, QueryCallback callback, QueryStats* pStats = nullptr) const;
 
   ///@}
   /// \name Visibility Queries
   ///@{
 
-  void FindVisibleObjects(const ezFrustum& frustum, ezDynamicArray<const ezGameObject*>& out_Objects, QueryStats* pStats = nullptr) const;
+  void FindVisibleObjects(const ezFrustum& frustum, ezUInt32 uiCategoryBitmask, ezDynamicArray<const ezGameObject*>& out_Objects, QueryStats* pStats = nullptr) const;
 
   ///@}
 
 protected:
-  virtual void FindObjectsInSphereInternal(const ezBoundingSphere& sphere, QueryCallback callback, QueryStats* pStats) const = 0;
-  virtual void FindObjectsInBoxInternal(const ezBoundingBox& box, QueryCallback callback, QueryStats* pStats) const = 0;
-  virtual void FindVisibleObjectsInternal(const ezFrustum& frustum, ezDynamicArray<const ezGameObject*>& out_Objects,
-                                          QueryStats* pStats) const = 0;
+  virtual void FindObjectsInSphereInternal(const ezBoundingSphere& sphere, ezUInt32 uiCategoryBitmask, QueryCallback callback, QueryStats* pStats) const = 0;
+  virtual void FindObjectsInBoxInternal(const ezBoundingBox& box, ezUInt32 uiCategoryBitmask, QueryCallback callback, QueryStats* pStats) const = 0;
+  virtual void FindVisibleObjectsInternal(const ezFrustum& frustum, ezUInt32 uiCategoryBitmask, ezDynamicArray<const ezGameObject*>& out_Objects, QueryStats* pStats) const = 0;
 
   virtual void SpatialDataAdded(ezSpatialData* pData) = 0;
   virtual void SpatialDataRemoved(ezSpatialData* pData) = 0;
-  virtual void SpatialDataChanged(ezSpatialData* pData, const ezSimdBBoxSphere& oldBounds) = 0;
+  virtual void SpatialDataChanged(ezSpatialData* pData, const ezSimdBBoxSphere& oldBounds, ezUInt32 uiOldCategoryBitmask) = 0;
   virtual void FixSpatialDataPointer(ezSpatialData* pOldPtr, ezSpatialData* pNewPtr) = 0;
 
   ezProxyAllocator m_Allocator;
@@ -81,4 +80,3 @@ protected:
 
   ezDynamicArray<ezSpatialData*> m_DataAlwaysVisible;
 };
-

--- a/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
+++ b/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
@@ -2,6 +2,7 @@
 
 #include <Core/World/SpatialSystem.h>
 #include <Foundation/SimdMath/SimdVec4i.h>
+#include <Foundation/Types/UniquePtr.h>
 
 class EZ_CORE_DLL ezSpatialSystem_RegularGrid : public ezSpatialSystem
 {

--- a/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
+++ b/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
@@ -39,12 +39,12 @@ private:
   struct SpatialUserData;
   struct Cell;
   struct CellKeyHashHelper;
-  struct CellsPerCategory;
 
-  ezHybridArray<ezUniquePtr<CellsPerCategory>, 2> m_CellsPerCategory;
+  ezHashTable<ezUInt64, ezUniquePtr<Cell>, CellKeyHashHelper, ezLocalAllocatorWrapper> m_Cells;
+  ezUniquePtr<Cell> m_pOverflowCell;
 
   template <typename Functor>
   void ForEachCellInBox(const ezSimdBBox& box, ezUInt32 uiCategoryBitmask, Functor func) const;
 
-  Cell* GetOrCreateCell(const ezSimdBBoxSphere& bounds, ezUInt32 category);
+  Cell* GetOrCreateCell(const ezSimdBBoxSphere& bounds);
 };

--- a/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
+++ b/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
@@ -19,16 +19,16 @@ public:
 
 private:
   // ezSpatialSystem implementation
-  virtual void FindObjectsInSphereInternal(const ezBoundingSphere& sphere, QueryCallback callback,
+  virtual void FindObjectsInSphereInternal(const ezBoundingSphere& sphere, ezUInt32 uiCategoryBitmask, QueryCallback callback,
                                            QueryStats* pStats = nullptr) const override;
-  virtual void FindObjectsInBoxInternal(const ezBoundingBox& box, QueryCallback callback, QueryStats* pStats = nullptr) const override;
+  virtual void FindObjectsInBoxInternal(const ezBoundingBox& box, ezUInt32 uiCategoryBitmask, QueryCallback callback, QueryStats* pStats = nullptr) const override;
 
-  virtual void FindVisibleObjectsInternal(const ezFrustum& frustum, ezDynamicArray<const ezGameObject*>& out_Objects,
+  virtual void FindVisibleObjectsInternal(const ezFrustum& frustum, ezUInt32 uiCategoryBitmask, ezDynamicArray<const ezGameObject*>& out_Objects,
                                           QueryStats* pStats = nullptr) const override;
 
   virtual void SpatialDataAdded(ezSpatialData* pData) override;
   virtual void SpatialDataRemoved(ezSpatialData* pData) override;
-  virtual void SpatialDataChanged(ezSpatialData* pData, const ezSimdBBoxSphere& oldBounds) override;
+  virtual void SpatialDataChanged(ezSpatialData* pData, const ezSimdBBoxSphere& oldBounds, ezUInt32 uiOldCategoryBitmask) override;
   virtual void FixSpatialDataPointer(ezSpatialData* pOldPtr, ezSpatialData* pNewPtr) override;
 
   ezProxyAllocator m_AlignedAllocator;

--- a/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
+++ b/Code/Engine/Core/World/SpatialSystem_RegularGrid.h
@@ -15,16 +15,16 @@ public:
   ezResult GetCellBoxForSpatialData(const ezSpatialDataHandle& hData, ezBoundingBox& out_BoundingBox) const;
 
   /// \brief Returns bounding boxes of all existing cells.
-  void GetAllCellBoxes(ezHybridArray<ezBoundingBox, 16>& out_BoundingBoxes) const;
+  void GetAllCellBoxes(ezHybridArray<ezBoundingBox, 16>& out_BoundingBoxes, ezSpatialData::Category filterCategory = ezInvalidSpatialDataCategory) const;
 
 private:
   // ezSpatialSystem implementation
   virtual void FindObjectsInSphereInternal(const ezBoundingSphere& sphere, ezUInt32 uiCategoryBitmask, QueryCallback callback,
-                                           QueryStats* pStats = nullptr) const override;
+    QueryStats* pStats = nullptr) const override;
   virtual void FindObjectsInBoxInternal(const ezBoundingBox& box, ezUInt32 uiCategoryBitmask, QueryCallback callback, QueryStats* pStats = nullptr) const override;
 
   virtual void FindVisibleObjectsInternal(const ezFrustum& frustum, ezUInt32 uiCategoryBitmask, ezDynamicArray<const ezGameObject*>& out_Objects,
-                                          QueryStats* pStats = nullptr) const override;
+    QueryStats* pStats = nullptr) const override;
 
   virtual void SpatialDataAdded(ezSpatialData* pData) override;
   virtual void SpatialDataRemoved(ezSpatialData* pData) override;
@@ -38,15 +38,13 @@ private:
 
   struct SpatialUserData;
   struct Cell;
-  struct CellKeyHashHelper;  
+  struct CellKeyHashHelper;
+  struct CellsPerCategory;
 
-  ezHashTable<ezUInt64, Cell*, CellKeyHashHelper, ezLocalAllocatorWrapper> m_Cells;
-
-  Cell* m_pOverflowCell;
+  ezHybridArray<ezUniquePtr<CellsPerCategory>, 2> m_CellsPerCategory;
 
   template <typename Functor>
-  void ForEachCellInBox(const ezSimdBBox& box, Functor func) const;
+  void ForEachCellInBox(const ezSimdBBox& box, ezUInt32 uiCategoryBitmask, Functor func) const;
 
-  Cell* GetOrCreateCell(const ezSimdBBoxSphere& bounds);
+  Cell* GetOrCreateCell(const ezSimdBBoxSphere& bounds, ezUInt32 category);
 };
-

--- a/Code/Engine/Foundation/Containers/Implementation/DynamicArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/DynamicArray_inl.h
@@ -165,12 +165,12 @@ ezDynamicArray<T, A>::ezDynamicArray(const ezArrayPtr<const T>& other) : ezDynam
 }
 
 template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArray<T, A>&& other) : ezDynamicArrayBase<T>(std::move(other), A::GetAllocator())
+ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArray<T, A>&& other) : ezDynamicArrayBase<T>(std::move(other), other.GetAllocator())
 {
 }
 
 template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArrayBase<T>&& other) : ezDynamicArrayBase<T>(std::move(other), A::GetAllocator())
+ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArrayBase<T>&& other) : ezDynamicArrayBase<T>(std::move(other), other.GetAllocator())
 {
 }
 

--- a/Code/Engine/Foundation/Containers/Implementation/HashTable_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/HashTable_inl.h
@@ -594,7 +594,7 @@ EZ_FORCE_INLINE ezUInt32 ezHashTableBase<K, V, H>::GetFlagsCapacity() const
 }
 
 template <typename K, typename V, typename H>
-ezUInt32 ezHashTableBase<K, V, H>::GetFlags(ezUInt32* pFlags, ezUInt32 uiEntryIndex) const
+EZ_ALWAYS_INLINE ezUInt32 ezHashTableBase<K, V, H>::GetFlags(ezUInt32* pFlags, ezUInt32 uiEntryIndex) const
 {
 #if EZ_ENABLED(EZ_HASHTABLE_USE_BITFLAGS)
   const ezUInt32 uiIndex = uiEntryIndex / 16;
@@ -611,7 +611,7 @@ void ezHashTableBase<K, V, H>::SetFlags(ezUInt32 uiEntryIndex, ezUInt32 uiFlags)
 #if EZ_ENABLED(EZ_HASHTABLE_USE_BITFLAGS)
   const ezUInt32 uiIndex = uiEntryIndex / 16;
   const ezUInt32 uiSubIndex = (uiEntryIndex & 15) * 2;
-  EZ_ASSERT_DEV(uiIndex < GetFlagsCapacity(), "Out of bounds access");
+  EZ_ASSERT_DEBUG(uiIndex < GetFlagsCapacity(), "Out of bounds access");
   m_pEntryFlags[uiIndex] &= ~(FLAGS_MASK << uiSubIndex);
   m_pEntryFlags[uiIndex] |= (uiFlags << uiSubIndex);
 #else

--- a/Code/Engine/Foundation/Containers/Implementation/HashTable_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/HashTable_inl.h
@@ -683,13 +683,13 @@ ezHashTable<K, V, H, A>::ezHashTable(const ezHashTableBase<K, V, H>& other)
 
 template <typename K, typename V, typename H, typename A>
 ezHashTable<K, V, H, A>::ezHashTable(ezHashTable<K, V, H, A>&& other)
-  : ezHashTableBase<K, V, H>(std::move(other), A::GetAllocator())
+  : ezHashTableBase<K, V, H>(std::move(other), other.GetAllocator())
 {
 }
 
 template <typename K, typename V, typename H, typename A>
 ezHashTable<K, V, H, A>::ezHashTable(ezHashTableBase<K, V, H>&& other)
-  : ezHashTableBase<K, V, H>(std::move(other), A::GetAllocator())
+  : ezHashTableBase<K, V, H>(std::move(other), other.GetAllocator())
 {
 }
 

--- a/Code/Engine/Foundation/Containers/Implementation/HybridArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/HybridArray_inl.h
@@ -247,12 +247,12 @@ ezHybridArray<T, Size, A>::ezHybridArray(const ezHybridArrayBase<T, Size>& other
 }
 
 template <typename T, ezUInt32 Size, typename A>
-ezHybridArray<T, Size, A>::ezHybridArray(ezHybridArray<T, Size, A>&& other) : ezHybridArrayBase<T, Size>(std::move(other), A::GetAllocator())
+ezHybridArray<T, Size, A>::ezHybridArray(ezHybridArray<T, Size, A>&& other) : ezHybridArrayBase<T, Size>(std::move(other), other.GetAllocator())
 {
 }
 
 template <typename T, ezUInt32 Size, typename A>
-ezHybridArray<T, Size, A>::ezHybridArray(ezHybridArrayBase<T, Size>&& other) : ezHybridArrayBase<T, Size>(std::move(other), A::GetAllocator())
+ezHybridArray<T, Size, A>::ezHybridArray(ezHybridArrayBase<T, Size>&& other) : ezHybridArrayBase<T, Size>(std::move(other), other.GetAllocator())
 {
 }
 

--- a/Code/Engine/Foundation/Strings/HashedString.h
+++ b/Code/Engine/Foundation/Strings/HashedString.h
@@ -33,7 +33,7 @@ public:
   };
 
   // Do NOT use a hash-table! The map does not relocate memory when it resizes, which is a vital aspect for the hashed strings to work.
-  typedef ezMap<ezUInt32, HashedData> StringStorage;
+  typedef ezMap<ezUInt32, HashedData, ezCompareHelper<ezUInt32>, ezStaticAllocatorWrapper> StringStorage;
   typedef StringStorage::Iterator HashedType;
 
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)

--- a/Code/Engine/Foundation/Strings/Implementation/HashedString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/HashedString.cpp
@@ -8,10 +8,10 @@ struct HashedStringData
 {
   ezMutex m_Mutex;
   ezHashedString::StringStorage m_Storage;
+  ezHashedString::HashedType m_Empty;
 };
 
 static HashedStringData* s_pHSData;
-static ezHashedString::HashedType s_HSEmpty;
 
 // static
 ezHashedString::HashedType ezHashedString::AddHashedString(const char* szString, ezUInt32 uiHash)
@@ -54,11 +54,11 @@ void ezHashedString::InitHashedString()
   s_pHSData = new (HashedStringDataBuffer) HashedStringData();
 
   // makes sure the empty string exists for the default constructor to use
-  s_HSEmpty = AddHashedString("", ezHashingUtils::MurmurHash32String(""));
+  s_pHSData->m_Empty = AddHashedString("", ezHashingUtils::MurmurHash32String(""));
 
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
   // this one should never get deleted, so make sure its refcount is 2
-  s_HSEmpty.Value().m_iRefCount.Increment();
+  s_pHSData->m_Empty.Value().m_iRefCount.Increment();
 #endif
 }
 
@@ -93,7 +93,7 @@ ezHashedString::ezHashedString()
   if (s_pHSData == nullptr)
     InitHashedString();
 
-  m_Data = s_HSEmpty;
+  m_Data = s_pHSData->m_Empty;
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
   m_Data.Value().m_iRefCount.Increment();
 #endif
@@ -101,23 +101,23 @@ ezHashedString::ezHashedString()
 
 bool ezHashedString::IsEmpty() const
 {
-  return m_Data == s_HSEmpty;
+  return m_Data == s_pHSData->m_Empty;
 }
 
 void ezHashedString::Clear()
 {
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
-  if (m_Data != s_HSEmpty)
+  if (m_Data != s_pHSData->m_Empty)
   {
     HashedType tmp = m_Data;
 
-    m_Data = s_HSEmpty;
+    m_Data = s_pHSData->m_Empty;
     m_Data.Value().m_iRefCount.Increment();
 
     tmp.Value().m_iRefCount.Decrement();
   }
 #else
-  m_Data = s_HSEmpty;
+  m_Data = s_pHSData->m_Empty;
 #endif  
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/HashedString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/HashedString.cpp
@@ -4,19 +4,25 @@
 #include <Foundation/Threading/Lock.h>
 #include <Foundation/Threading/Mutex.h>
 
-static ezHashedString::StringStorage g_HashedStrings;
-static bool g_bHashedStringsInitialized = false;
-static ezHashedString::HashedType g_hsEmpty;
-static ezMutex g_HashedStringMutex;
+struct HashedStringData
+{
+  ezMutex m_Mutex;
+  ezHashedString::StringStorage m_Storage;
+};
+
+static HashedStringData* s_pHSData;
+static ezHashedString::HashedType s_HSEmpty;
 
 // static
 ezHashedString::HashedType ezHashedString::AddHashedString(const char* szString, ezUInt32 uiHash)
 {
-  EZ_LOCK(g_HashedStringMutex);
+  InitHashedString();
+
+  EZ_LOCK(s_pHSData->m_Mutex);
 
   // try to find the existing string
   bool bExisted = false;
-  auto ret = g_HashedStrings.FindOrAdd(uiHash, &bExisted);
+  auto ret = s_pHSData->m_Storage.FindOrAdd(uiHash, &bExisted);
 
   // if it already exists, just increase the refcount
   if (bExisted)
@@ -40,35 +46,33 @@ ezHashedString::HashedType ezHashedString::AddHashedString(const char* szString,
 // static
 void ezHashedString::InitHashedString()
 {
-  // makes sure the empty string exists for the default constructor to use
-
-  EZ_LOCK(g_HashedStringMutex);
-
-  if (g_bHashedStringsInitialized)
+  if (s_pHSData != nullptr)
     return;
 
-  g_bHashedStringsInitialized = true;
+  static ezUInt8 HashedStringDataBuffer[sizeof(HashedStringData)];
+  HashedStringData* pData = new (HashedStringDataBuffer) HashedStringData();
 
-  g_hsEmpty = AddHashedString("", ezHashingUtils::MurmurHash32String(""));
+  // makes sure the empty string exists for the default constructor to use
+  s_HSEmpty = AddHashedString("", ezHashingUtils::MurmurHash32String(""));
 
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
   // this one should never get deleted, so make sure its refcount is 2
-  g_hsEmpty.Value().m_iRefCount.Increment();
+  s_HSEmpty.Value().m_iRefCount.Increment();
 #endif
 }
 
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
 ezUInt32 ezHashedString::ClearUnusedStrings()
 {
-  EZ_LOCK(g_HashedStringMutex);
+  EZ_LOCK(s_pHSData->m_Mutex);
 
   ezUInt32 uiDeleted = 0;
 
-  for (auto it = g_HashedStrings.GetIterator(); it.IsValid();)
+  for (auto it = s_pHSData->m_Storage.GetIterator(); it.IsValid();)
   {
     if (it.Value().m_iRefCount == 0)
     {
-      it = g_HashedStrings.Remove(it);
+      it = s_pHSData->m_Storage.Remove(it);
       ++uiDeleted;
     }
     else
@@ -85,10 +89,10 @@ ezHashedString::ezHashedString()
   EZ_CHECK_AT_COMPILETIME_MSG(sizeof(*this) == sizeof(void*), "The hashed string data should only be as large as one pointer.");
 
   // only insert the empty string once, after that, we can just use it without the need for the mutex
-  if (!g_bHashedStringsInitialized)
+  if (s_pHSData == nullptr)
     InitHashedString();
 
-  m_Data = g_hsEmpty;
+  m_Data = s_HSEmpty;
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
   m_Data.Value().m_iRefCount.Increment();
 #endif
@@ -96,23 +100,23 @@ ezHashedString::ezHashedString()
 
 bool ezHashedString::IsEmpty() const
 {
-  return m_Data == g_hsEmpty;
+  return m_Data == s_HSEmpty;
 }
 
 void ezHashedString::Clear()
 {
 #if EZ_ENABLED(EZ_HASHED_STRING_REF_COUNTING)
-  if (m_Data != g_hsEmpty)
+  if (m_Data != s_HSEmpty)
   {
     HashedType tmp = m_Data;
 
-    m_Data = g_hsEmpty;
+    m_Data = s_HSEmpty;
     m_Data.Value().m_iRefCount.Increment();
 
     tmp.Value().m_iRefCount.Decrement();
   }
 #else
-  m_Data = g_hsEmpty;
+  m_Data = s_HSEmpty;
 #endif  
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/HashedString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/HashedString.cpp
@@ -16,7 +16,8 @@ static ezHashedString::HashedType s_HSEmpty;
 // static
 ezHashedString::HashedType ezHashedString::AddHashedString(const char* szString, ezUInt32 uiHash)
 {
-  InitHashedString();
+  if (s_pHSData == nullptr)
+    InitHashedString();
 
   EZ_LOCK(s_pHSData->m_Mutex);
 
@@ -50,7 +51,7 @@ void ezHashedString::InitHashedString()
     return;
 
   static ezUInt8 HashedStringDataBuffer[sizeof(HashedStringData)];
-  HashedStringData* pData = new (HashedStringDataBuffer) HashedStringData();
+  s_pHSData = new (HashedStringDataBuffer) HashedStringData();
 
   // makes sure the empty string exists for the default constructor to use
   s_HSEmpty = AddHashedString("", ezHashingUtils::MurmurHash32String(""));

--- a/Code/Engine/RendererCore/Components/Implementation/FogComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/FogComponent.cpp
@@ -96,7 +96,7 @@ float ezFogComponent::GetHeightFalloff() const
 
 void ezFogComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
 {
-  msg.SetAlwaysVisible();
+  msg.SetAlwaysVisible(GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
 }
 
 void ezFogComponent::OnExtractRenderData(ezMsgExtractRenderData& msg) const

--- a/Code/Engine/RendererCore/Components/Implementation/RenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RenderComponent.cpp
@@ -46,14 +46,16 @@ void ezRenderComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
 
   if (GetLocalBounds(bounds, bAlwaysVisible).Succeeded())
   {
+    ezSpatialData::Category category = GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic;
+
     if (bounds.IsValid())
     {
-      msg.AddBounds(bounds);
+      msg.AddBounds(bounds, category);
     }
 
     if (bAlwaysVisible)
     {
-      msg.SetAlwaysVisible();
+      msg.SetAlwaysVisible(category);
     }
   }
 }

--- a/Code/Engine/RendererCore/Lights/Implementation/AmbientLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/AmbientLightComponent.cpp
@@ -108,7 +108,7 @@ float ezAmbientLightComponent::GetIntensity() const
 
 void ezAmbientLightComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
 {
-  msg.SetAlwaysVisible();
+  msg.SetAlwaysVisible(GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
 }
 
 void ezAmbientLightComponent::SerializeComponent(ezWorldWriter& stream) const

--- a/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
@@ -78,7 +78,7 @@ float ezSkyLightComponent::GetSaturation() const
 
 void ezSkyLightComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
 {
-  msg.SetAlwaysVisible();
+  msg.SetAlwaysVisible(GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
 }
 
 void ezSkyLightComponent::OnExtractRenderData(ezMsgExtractRenderData& msg) const

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -13,6 +13,7 @@
   ezCVarBool CVarVisBounds("r_VisBounds", false, ezCVarFlags::Default, "Enables debug visualization of object bounds");
   ezCVarBool CVarVisLocalBBox("r_VisLocalBBox", false, ezCVarFlags::Default, "Enables debug visualization of object local bounding box");
   ezCVarBool CVarVisSpatialData("r_VisSpatialData", false, ezCVarFlags::Default, "Enables debug visualization of the spatial data structure");
+  ezCVarString CVarVisSpatialCategory("r_VisSpatialCategory", "", ezCVarFlags::Default, "When set the debug visualization is only shown for the given spatial data category");
   ezCVarBool CVarVisObjectSelection("r_VisObjectSelection", false, ezCVarFlags::Default, "When set the debug visualization is only shown for selected objects");
   ezCVarString CVarVisObjectName("r_VisObjectName", "", ezCVarFlags::Default, "When set the debug visualization is only shown for objects with the given name");
 
@@ -29,8 +30,10 @@ namespace
       const ezSpatialSystem& spatialSystem = view.GetWorld()->GetSpatialSystem();
       if (auto pSpatialSystemGrid = ezDynamicCast<const ezSpatialSystem_RegularGrid*>(&spatialSystem))
       {
+        ezSpatialData::Category filterCategory = ezSpatialData::FindCategory(CVarVisSpatialCategory.GetValue());
+
         ezHybridArray<ezBoundingBox, 16> boxes;
-        pSpatialSystemGrid->GetAllCellBoxes(boxes);
+        pSpatialSystemGrid->GetAllCellBoxes(boxes, filterCategory);
 
         for (auto& box : boxes)
         {

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -67,7 +67,7 @@ namespace
       }
     }
 
-    if (CVarVisSpatialData)
+    if (CVarVisSpatialData && CVarVisSpatialCategory.GetValue().IsEmpty())
     {
       const ezSpatialSystem& spatialSystem = view.GetWorld()->GetSpatialSystem();
       if (auto pSpatialSystemGrid = ezDynamicCast<const ezSpatialSystem_RegularGrid*>(&spatialSystem))

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -15,13 +15,13 @@
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
 ezCVarBool ezRenderPipeline::s_DebugCulling("r_DebugCulling", false, ezCVarFlags::Default,
-                                            "Enables debug visualization of visibility culling");
+  "Enables debug visualization of visibility culling");
 
 ezCVarBool CVarCullingStats("r_CullingStats", false, ezCVarFlags::Default, "Display some stats of the visibility culling");
 #endif
 
 ezRenderPipeline::ezRenderPipeline()
-    : m_PipelineState(PipelineState::Uninitialized)
+  : m_PipelineState(PipelineState::Uninitialized)
 {
   m_CurrentExtractThread = (ezThreadID)0;
   m_CurrentRenderThread = (ezThreadID)0;
@@ -108,7 +108,7 @@ ezRenderPipelinePass* ezRenderPipeline::GetPassByName(const ezStringView& sPassN
 
 
 bool ezRenderPipeline::Connect(ezRenderPipelinePass* pOutputNode, const char* szOutputPinName, ezRenderPipelinePass* pInputNode,
-                               const char* szInputPinName)
+  const char* szInputPinName)
 {
   ezHashedString sOutputPinName;
   sOutputPinName.Assign(szOutputPinName);
@@ -118,7 +118,7 @@ bool ezRenderPipeline::Connect(ezRenderPipelinePass* pOutputNode, const char* sz
 }
 
 bool ezRenderPipeline::Connect(ezRenderPipelinePass* pOutputNode, ezHashedString sOutputPinName, ezRenderPipelinePass* pInputNode,
-                               ezHashedString sInputPinName)
+  ezHashedString sInputPinName)
 {
   ezLogBlock b("ezRenderPipeline::Connect");
 
@@ -149,7 +149,7 @@ bool ezRenderPipeline::Connect(ezRenderPipelinePass* pOutputNode, ezHashedString
   if (itIn.Value().m_Inputs[pPinTarget->m_uiInputIndex] != nullptr)
   {
     ezLog::Error("Pins already connected: '{0}::{1}' -> '{2}::{3}'!", pOutputNode->GetName(), sOutputPinName, pInputNode->GetName(),
-                 sInputPinName);
+      sInputPinName);
     return false;
   }
 
@@ -185,7 +185,7 @@ bool ezRenderPipeline::Connect(ezRenderPipelinePass* pOutputNode, ezHashedString
 }
 
 bool ezRenderPipeline::Disconnect(ezRenderPipelinePass* pOutputNode, ezHashedString sOutputPinName, ezRenderPipelinePass* pInputNode,
-                                  ezHashedString sInputPinName)
+  ezHashedString sInputPinName)
 {
   ezLogBlock b("ezRenderPipeline::Connect");
 
@@ -217,7 +217,7 @@ bool ezRenderPipeline::Disconnect(ezRenderPipelinePass* pOutputNode, ezHashedStr
       itIn.Value().m_Inputs[pPinTarget->m_uiInputIndex] != itOut.Value().m_Outputs[pPinSource->m_uiOutputIndex])
   {
     ezLog::Error("Pins not connected: '{0}::{1}' -> '{2}::{3}'!", pOutputNode->GetName(), sOutputPinName, pInputNode->GetName(),
-                 sInputPinName);
+      sInputPinName);
     return false;
   }
 
@@ -252,7 +252,7 @@ const ezRenderPipelinePassConnection* ezRenderPipeline::GetInputConnection(ezRen
 }
 
 const ezRenderPipelinePassConnection* ezRenderPipeline::GetOutputConnection(ezRenderPipelinePass* pPass,
-                                                                            ezHashedString sOutputPinName) const
+  ezHashedString sOutputPinName) const
 {
   auto it = m_Connections.Find(pPass);
   if (!it.IsValid())
@@ -415,7 +415,7 @@ bool ezRenderPipeline::InitRenderTargetDescriptions(const ezView& view)
     if (view.GetCamera()->IsStereoscopic() && !pPass->IsStereoAware())
     {
       ezLog::Error("View '{0}' uses a stereoscopic camera, but the render pass '{1}' does not support stereo rendering!", view.GetName(),
-                   pPass->GetName());
+        pPass->GetName());
     }
 
     ConnectionData& data = m_Connections[pPass.Borrow()];
@@ -472,7 +472,7 @@ bool ezRenderPipeline::InitRenderTargetDescriptions(const ezView& view)
                    data.m_Inputs[pPin->m_uiInputIndex]->m_Desc.CalculateHash())
           {
             ezLog::Error("The pass has a pass through pin '{0}' that has different descriptors for input and output!",
-                         pPass->GetPinName(pPin));
+              pPass->GetPinName(pPin));
             return false;
           }
         }
@@ -574,7 +574,7 @@ bool ezRenderPipeline::CreateRenderTargetUsage(const ezView& view)
   struct FirstUsageComparer
   {
     FirstUsageComparer(ezDynamicArray<TextureUsageData>& textureUsage)
-        : m_TextureUsage(textureUsage)
+      : m_TextureUsage(textureUsage)
     {
     }
 
@@ -589,7 +589,7 @@ bool ezRenderPipeline::CreateRenderTargetUsage(const ezView& view)
   struct LastUsageComparer
   {
     LastUsageComparer(ezDynamicArray<TextureUsageData>& textureUsage)
-        : m_TextureUsage(textureUsage)
+      : m_TextureUsage(textureUsage)
     {
     }
 
@@ -683,11 +683,11 @@ void ezRenderPipeline::UpdateViewData(const ezView& view, ezUInt32 uiDataIndex)
   if (uiDataIndex == ezRenderWorld::GetDataIndexForExtraction() && m_CurrentExtractThread != (ezThreadID)0)
     return;
 
-  EZ_ASSERT_DEV(uiDataIndex <= 1, "Data index must be 0 or 1");  
+  EZ_ASSERT_DEV(uiDataIndex <= 1, "Data index must be 0 or 1");
   auto& data = m_Data[uiDataIndex];
 
   data.SetCamera(*view.GetCamera());
-  data.SetViewData(view.GetData());  
+  data.SetViewData(view.GetData());
 }
 
 void ezRenderPipeline::AddExtractor(ezUniquePtr<ezExtractor>&& pExtractor)
@@ -800,7 +800,7 @@ void ezRenderPipeline::ClearRenderPassGraphTextures()
 }
 
 bool ezRenderPipeline::AreInputDescriptionsAvailable(const ezRenderPipelinePass* pPass,
-                                                     const ezHybridArray<ezRenderPipelinePass*, 32>& done) const
+  const ezHybridArray<ezRenderPipelinePass*, 32>& done) const
 {
   auto it = m_Connections.Find(pPass);
   const ConnectionData& data = it.Value();
@@ -934,11 +934,12 @@ void ezRenderPipeline::FindVisibleObjects(const ezView& view)
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   const bool bIsMainView =
-      (view.GetCameraUsageHint() == ezCameraUsageHint::MainView || view.GetCameraUsageHint() == ezCameraUsageHint::EditorView);
+    (view.GetCameraUsageHint() == ezCameraUsageHint::MainView || view.GetCameraUsageHint() == ezCameraUsageHint::EditorView);
   const bool bRecordStats = CVarCullingStats && bIsMainView;
   ezSpatialSystem::QueryStats stats;
 
-  view.GetWorld()->GetSpatialSystem().FindVisibleObjects(frustum, m_visibleObjects, bRecordStats ? &stats : nullptr);
+  ezUInt32 uiCategoryBitmask = ezDefaultSpatialDataCategories::RenderStatic.GetBitmask() | ezDefaultSpatialDataCategories::RenderDynamic.GetBitmask();
+  view.GetWorld()->GetSpatialSystem().FindVisibleObjects(frustum, uiCategoryBitmask, m_visibleObjects, bRecordStats ? &stats : nullptr);
 
   ezViewHandle hView = view.GetHandle();
 
@@ -1105,9 +1106,9 @@ void ezRenderPipeline::Render(ezRenderContext* pRenderContext)
     }
   }
   EZ_ASSERT_DEV(uiCurrentFirstUsageIdx == m_TextureUsageIdxSortedByFirstUsage.GetCount(),
-                "Rendering all passes should have moved us through all texture usage blocks!");
+    "Rendering all passes should have moved us through all texture usage blocks!");
   EZ_ASSERT_DEV(uiCurrentLastUsageIdx == m_TextureUsageIdxSortedByLastUsage.GetCount(),
-                "Rendering all passes should have moved us through all texture usage blocks!");
+    "Rendering all passes should have moved us through all texture usage blocks!");
 
   data.Clear();
 
@@ -1120,11 +1121,10 @@ const ezExtractedRenderData& ezRenderPipeline::GetRenderData() const
 }
 
 ezRenderDataBatchList ezRenderPipeline::GetRenderDataBatchesWithCategory(ezRenderData::Category category,
-                                                                         ezRenderDataBatch::Filter filter) const
+  ezRenderDataBatch::Filter filter) const
 {
   auto& data = m_Data[ezRenderWorld::GetDataIndexForRendering()];
   return data.GetRenderDataBatchesWithCategory(category, filter);
 }
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Pipeline_Implementation_RenderPipeline);
-

--- a/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxCharacterProxyComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxCharacterProxyComponent.cpp
@@ -299,8 +299,8 @@ void ezPxCharacterProxyComponent::OnSimulationStarted()
 
 void ezPxCharacterProxyComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const
 {
-  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, -m_fCapsuleHeight * 0.5f), m_fCapsuleRadius));
-  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, m_fCapsuleHeight * 0.5f), m_fCapsuleRadius));
+  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, -m_fCapsuleHeight * 0.5f), m_fCapsuleRadius), ezInvalidSpatialDataCategory);
+  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, m_fCapsuleHeight * 0.5f), m_fCapsuleRadius), ezInvalidSpatialDataCategory);
 }
 
 ezBitflags<ezPxCharacterCollisionFlags> ezPxCharacterProxyComponent::Move(const ezVec3& vMotion, bool bCrouch)

--- a/Code/EnginePlugins/PhysXPlugin/Shapes/Implementation/PxShapeBoxComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Shapes/Implementation/PxShapeBoxComponent.cpp
@@ -57,7 +57,7 @@ void ezPxShapeBoxComponent::DeserializeComponent(ezWorldReader& stream)
 
 void ezPxShapeBoxComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const
 {
-  msg.AddBounds(ezBoundingBox(-m_vExtents * 0.5f, m_vExtents * 0.5f));
+  msg.AddBounds(ezBoundingBox(-m_vExtents * 0.5f, m_vExtents * 0.5f), ezInvalidSpatialDataCategory);
 }
 
 void ezPxShapeBoxComponent::ExtractGeometry(ezMsgExtractGeometry& msg) const

--- a/Code/EnginePlugins/PhysXPlugin/Shapes/Implementation/PxShapeCapsuleComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Shapes/Implementation/PxShapeCapsuleComponent.cpp
@@ -62,8 +62,8 @@ void ezPxShapeCapsuleComponent::DeserializeComponent(ezWorldReader& stream)
 
 void ezPxShapeCapsuleComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const
 {
-  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, -m_fHeight * 0.5f), m_fRadius));
-  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, +m_fHeight * 0.5f), m_fRadius));
+  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, -m_fHeight * 0.5f), m_fRadius), ezInvalidSpatialDataCategory);
+  msg.AddBounds(ezBoundingSphere(ezVec3(0, 0, +m_fHeight * 0.5f), m_fRadius), ezInvalidSpatialDataCategory);
 }
 
 

--- a/Code/EnginePlugins/PhysXPlugin/Shapes/Implementation/PxShapeSphereComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Shapes/Implementation/PxShapeSphereComponent.cpp
@@ -58,7 +58,7 @@ void ezPxShapeSphereComponent::DeserializeComponent(ezWorldReader& stream)
 
 void ezPxShapeSphereComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const
 {
-  msg.AddBounds(ezBoundingSphere(ezVec3::ZeroVector(), m_fRadius));
+  msg.AddBounds(ezBoundingSphere(ezVec3::ZeroVector(), m_fRadius), ezInvalidSpatialDataCategory);
 }
 
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -508,9 +508,9 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProcGenBoxExtents, ezNoBase, 1, ezRTTIDefaultAl
   EZ_END_PROPERTIES;
   EZ_BEGIN_ATTRIBUTES
   {
-      new ezBoxManipulatorAttribute("Extents", "Offset", "Rotation"),
-      new ezBoxVisualizerAttribute("Extents", "Offset", "Rotation", nullptr, ezColor::CornflowerBlue),
-      new ezTransformManipulatorAttribute("Offset", "Rotation"),
+    new ezBoxManipulatorAttribute("Extents", "Offset", "Rotation"),
+    new ezBoxVisualizerAttribute("Extents", "Offset", "Rotation", nullptr, ezColor::CornflowerBlue),
+    new ezTransformManipulatorAttribute("Offset", "Rotation"),
   }
   EZ_END_ATTRIBUTES;
 }
@@ -520,19 +520,19 @@ EZ_BEGIN_COMPONENT_TYPE(ezProcPlacementComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-      EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("ProcGen Graph")),
-      EZ_ARRAY_ACCESSOR_PROPERTY("BoxExtents", BoxExtents_GetCount, BoxExtents_GetValue, BoxExtents_SetValue, BoxExtents_Insert, BoxExtents_Remove),
+    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("ProcGen Graph")),
+    EZ_ARRAY_ACCESSOR_PROPERTY("BoxExtents", BoxExtents_GetCount, BoxExtents_GetValue, BoxExtents_SetValue, BoxExtents_Insert, BoxExtents_Remove),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS
   {
-      EZ_MESSAGE_HANDLER(ezMsgUpdateLocalBounds, OnUpdateLocalBounds),
-      EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnExtractRenderData),
+    EZ_MESSAGE_HANDLER(ezMsgUpdateLocalBounds, OnUpdateLocalBounds),
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnExtractRenderData),
   }
   EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_ATTRIBUTES
   {
-      new ezCategoryAttribute("Procedural Generation"),
+    new ezCategoryAttribute("Procedural Generation"),
   }
   EZ_END_ATTRIBUTES;
 }
@@ -613,7 +613,7 @@ void ezProcPlacementComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
     bounds.ExpandToInclude(localBox);
   }
 
-  msg.AddBounds(bounds);
+  msg.AddBounds(bounds, GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
 }
 
 void ezProcPlacementComponent::OnExtractRenderData(ezMsgExtractRenderData& msg) const

--- a/Code/Samples/RtsGamePlugin/Components/SelectableComponent.cpp
+++ b/Code/Samples/RtsGamePlugin/Components/SelectableComponent.cpp
@@ -25,6 +25,8 @@ EZ_BEGIN_COMPONENT_TYPE(RtsSelectableComponent, 1, ezComponentMode::Static)
 EZ_END_COMPONENT_TYPE
 // clang-format on
 
+ezSpatialData::Category RtsSelectableComponent::s_SelectableCategory = ezSpatialData::RegisterCategory("Selectable");
+
 RtsSelectableComponent::RtsSelectableComponent() = default;
 RtsSelectableComponent::~RtsSelectableComponent() = default;
 
@@ -60,5 +62,5 @@ void RtsSelectableComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
   bounds.m_vCenter.SetZero();
   bounds.m_vBoxHalfExtends.Set(m_fSelectionRadius);
 
-  msg.AddBounds(bounds);
+  msg.AddBounds(bounds, s_SelectableCategory);
 }

--- a/Code/Samples/RtsGamePlugin/Components/SelectableComponent.h
+++ b/Code/Samples/RtsGamePlugin/Components/SelectableComponent.h
@@ -29,6 +29,8 @@ public:
 
   float m_fSelectionRadius = 1.0f;
 
+  static ezSpatialData::Category s_SelectableCategory;
+
 protected:
 
 };

--- a/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
+++ b/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
@@ -357,7 +357,8 @@ ezGameObject* RtsGameState::PickSelectableObject() const
 void RtsGameState::InspectObjectsInArea(const ezVec2& position, float radius, ezSpatialSystem::QueryCallback callback) const
 {
   ezBoundingSphere sphere(position.GetAsVec3(0), radius);
-  m_pMainWorld->GetSpatialSystem().FindObjectsInSphere(sphere, callback, nullptr);
+  ezUInt32 uiCategoryBitmask = RtsSelectableComponent::s_SelectableCategory.GetBitmask();
+  m_pMainWorld->GetSpatialSystem().FindObjectsInSphere(sphere, uiCategoryBitmask, callback, nullptr);
 }
 
 ezGameObject* RtsGameState::SpawnNamedObjectAt(const ezTransform& transform, const char* szObjectName, ezUInt16 uiTeamID)

--- a/Code/UnitTests/CoreTest/World/SpatialSystemTest.cpp
+++ b/Code/UnitTests/CoreTest/World/SpatialSystemTest.cpp
@@ -30,7 +30,7 @@ namespace
       ezBoundingBox bounds;
       bounds.SetCenterAndHalfExtents(ezVec3::ZeroVector(), ezVec3(x, y, z));
 
-      msg.AddBounds(bounds);
+      msg.AddBounds(bounds, GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
     }
   };
 
@@ -65,6 +65,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
     float z = (float)rng.DoubleMinMax(-range, range);
 
     ezGameObjectDesc desc;
+    desc.m_bDynamic = (i >= 500);
     desc.m_LocalPosition = ezVec3(x, y, z);
 
     ezGameObject* pObject = nullptr;
@@ -76,13 +77,15 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
 
   world.Update();
 
+  ezUInt32 uiCategoryBitmask = ezDefaultSpatialDataCategories::RenderStatic.GetBitmask();
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "FindObjectsInSphere")
   {
     ezBoundingSphere testSphere(ezVec3(100.0f, 60.0f, 400.0f), 3000.0f);
 
     ezDynamicArray<ezGameObject*> objectsInSphere;
     ezHashSet<ezGameObject*> uniqueObjects;
-    world.GetSpatialSystem().FindObjectsInSphere(testSphere, objectsInSphere);
+    world.GetSpatialSystem().FindObjectsInSphere(testSphere, uiCategoryBitmask, objectsInSphere);
 
     for (auto pObject : objectsInSphere)
     {
@@ -99,13 +102,14 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       if (testSphere.Overlaps(objSphere))
       {
         EZ_TEST_BOOL(uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsStatic());
       }
     }
 
     objectsInSphere.Clear();
     uniqueObjects.Clear();
 
-    world.GetSpatialSystem().FindObjectsInSphere(testSphere, [&](ezGameObject* pObject) {
+    world.GetSpatialSystem().FindObjectsInSphere(testSphere, uiCategoryBitmask, [&](ezGameObject* pObject) {
       objectsInSphere.PushBack(pObject);
       EZ_TEST_BOOL(!uniqueObjects.Insert(pObject));
 
@@ -126,6 +130,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       if (testSphere.Overlaps(objSphere))
       {
         EZ_TEST_BOOL(uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsStatic());
       }
     }
   }
@@ -137,7 +142,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
 
     ezDynamicArray<ezGameObject*> objectsInBox;
     ezHashSet<ezGameObject*> uniqueObjects;
-    world.GetSpatialSystem().FindObjectsInBox(testBox, objectsInBox);
+    world.GetSpatialSystem().FindObjectsInBox(testBox, uiCategoryBitmask, objectsInBox);
 
     for (auto pObject : objectsInBox)
     {
@@ -154,13 +159,14 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       if (testBox.Overlaps(objBox))
       {
         EZ_TEST_BOOL(uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsStatic());
       }
     }
 
     objectsInBox.Clear();
     uniqueObjects.Clear();
 
-    world.GetSpatialSystem().FindObjectsInBox(testBox, [&](ezGameObject* pObject) {
+    world.GetSpatialSystem().FindObjectsInBox(testBox, uiCategoryBitmask, [&](ezGameObject* pObject) {
       objectsInBox.PushBack(pObject);
       EZ_TEST_BOOL(!uniqueObjects.Insert(pObject));
 
@@ -181,6 +187,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       if (testBox.Overlaps(objBox))
       {
         EZ_TEST_BOOL(uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsStatic());
       }
     }
   }

--- a/Data/Tools/ezEditor/Localization/en/PhysXPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/PhysXPlugin.txt
@@ -32,7 +32,7 @@ ezPxAxis::Z;Z
 ezConvexCollisionMeshType::ConvexHull;Convex Hull
 ezConvexCollisionMeshType::Cylinder;Cylinder
 ezOnPhysXContact::SendReportMsg;Send Contact Reports
-ezOnPhysXContact::ImpactReactions;Impact Reactiongs
+ezOnPhysXContact::ImpactReactions;Impact Reactions
 ezOnPhysXContact::SlideReactions;Slide Reactions
 ezOnPhysXContact::RollXReactions;Roll X Reactions
 ezOnPhysXContact::RollYReactions;Roll Y Reactions


### PR DESCRIPTION
Keep spatial data structures separate for each category. With this spatial data for dynamic and static objects is separated and allows for faster updates of dynamic objects since the static data is not touched.
Also it allows faster queries if your only interested in one category. Could be used for e.g. postprocessing volumes etc.