### PR TITLE
Added macros to easily expose member functions to the scripting system

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraphQt.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraphQt.cpp
@@ -266,7 +266,7 @@ void ezQtVisualScriptNode::InitNode(const ezDocumentNodeManager* pManager, const
 {
   ezQtNode::InitNode(pManager, pObject);
 
-  const auto* pDesc = ezVisualScriptTypeRegistry::GetSingleton()->GetDescriptorForType(pObject->GetType());
+  const ezVisualScriptNodeDescriptor* pDesc = ezVisualScriptTypeRegistry::GetSingleton()->GetDescriptorForType(pObject->GetType());
 
   if (pDesc != nullptr)
   {
@@ -283,7 +283,7 @@ void ezQtVisualScriptNode::UpdateState()
 {
   ezStringBuilder sTitle;
 
-  const auto* pDesc = ezVisualScriptTypeRegistry::GetSingleton()->GetDescriptorForType(GetObject()->GetType());
+  const ezVisualScriptNodeDescriptor* pDesc = ezVisualScriptTypeRegistry::GetSingleton()->GetDescriptorForType(GetObject()->GetType());
 
   if (pDesc == nullptr)
     return;

--- a/Code/Engine/Foundation/Basics/Platform/BlackMagic.h
+++ b/Code/Engine/Foundation/Basics/Platform/BlackMagic.h
@@ -1,11 +1,15 @@
 #pragma once
 
-/// Gets the number of arguments of a variadic preprocessor macro
-#ifndef EZ_VA_NUM_ARGS
-#define EZ_VA_NUM_ARGS(...) \
-  EZ_VA_NUM_ARGS_HELPER(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+/// \file
 
-#define EZ_VA_NUM_ARGS_HELPER(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
+/// Gets the number of arguments of a variadic preprocessor macro.
+/// If an empty __VA_ARGS__ is passed in, this will still return 1.
+/// There is no perfect way to detect parameter lists with zero elements.
+#ifndef EZ_VA_NUM_ARGS
+#  define EZ_VA_NUM_ARGS(...) \
+    EZ_VA_NUM_ARGS_HELPER(__VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+#  define EZ_VA_NUM_ARGS_HELPER(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
 #endif
 
 
@@ -22,7 +26,15 @@
 #define EZ_EXPAND_ARGS_8(op, a0, a1, a2, a3, a4, a5, a6, a7) op(a0) op(a1) op(a2) op(a3) op(a4) op(a5) op(a6) op(a7)
 #define EZ_EXPAND_ARGS_9(op, a0, a1, a2, a3, a4, a5, a6, a7, a8) op(a0) op(a1) op(a2) op(a3) op(a4) op(a5) op(a6) op(a7) op(a8)
 #define EZ_EXPAND_ARGS_10(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) op(a0) op(a1) op(a2) op(a3) op(a4) op(a5) op(a6) op(a7) op(a8) op(a9)
+#define EZ_EXPAND_ARGS_11(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) op(a0) op(a1) op(a2) op(a3) op(a4) op(a5) op(a6) op(a7) op(a8) op(a9) op(a10)
+#define EZ_EXPAND_ARGS_12(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) op(a0) op(a1) op(a2) op(a3) op(a4) op(a5) op(a6) op(a7) op(a8) op(a9) op(a10) op(a11)
 
+/// Variadic macro "dispatching" the arguments to the correct macro.
+/// The number of arguments is found by using EZ_VA_NUM_ARGS(__VA_ARGS__)
+#define EZ_EXPAND_ARGS(op, ...) \
+  EZ_CALL_MACRO(EZ_CONCAT(EZ_EXPAND_ARGS_, EZ_VA_NUM_ARGS(__VA_ARGS__)), (op, __VA_ARGS__))
+
+//////////////////////////////////////////////////////////////////////////
 
 #define EZ_EXPAND_ARGS_WITH_INDEX_1(op, a0) op(a0, 0)
 #define EZ_EXPAND_ARGS_WITH_INDEX_2(op, a0, a1) op(a0, 0) op(a1, 1)
@@ -35,15 +47,46 @@
 #define EZ_EXPAND_ARGS_WITH_INDEX_9(op, a0, a1, a2, a3, a4, a5, a6, a7, a8) op(a0, 0) op(a1, 1) op(a2, 2) op(a3, 3) op(a4, 4) op(a5, 5) op(a6, 6) op(a7, 7) op(a8, 8)
 #define EZ_EXPAND_ARGS_WITH_INDEX_10(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) op(a0, 0) op(a1, 1) op(a2, 2) op(a3, 3) op(a4, 4) op(a5, 5) op(a6, 6) op(a7, 7) op(a8, 8) op(a9, 9)
 
-
-/// Variadic macro "dispatching" the arguments to the correct macro.
-/// The number of arguments is found by using EZ_VA_NUM_ARGS(__VA_ARGS__)
-#define EZ_EXPAND_ARGS(op, ...) \
-  EZ_CALL_MACRO(EZ_CONCAT(EZ_EXPAND_ARGS_, EZ_VA_NUM_ARGS(__VA_ARGS__)), (op, __VA_ARGS__))
-
 #define EZ_EXPAND_ARGS_WITH_INDEX(op, ...) \
   EZ_CALL_MACRO(EZ_CONCAT(EZ_EXPAND_ARGS_WITH_INDEX_, EZ_VA_NUM_ARGS(__VA_ARGS__)), (op, __VA_ARGS__))
 
+//////////////////////////////////////////////////////////////////////////
+
+#define EZ_EXPAND_ARGS_PAIR_1(...)
+#define EZ_EXPAND_ARGS_PAIR_2(op, a0, a1) op(a0, a1)
+#define EZ_EXPAND_ARGS_PAIR_3(op, a0, a1, ...) op(a0, a1)
+#define EZ_EXPAND_ARGS_PAIR_4(op, a0, a1, a2, a3) op(a0, a1) op(a2, a3)
+#define EZ_EXPAND_ARGS_PAIR_6(op, a0, a1, a2, a3, a4, a5) op(a0, a1) op(a2, a3) op(a4, a5)
+#define EZ_EXPAND_ARGS_PAIR_8(op, a0, a1, a2, a3, a4, a5, a6, a7) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7)
+#define EZ_EXPAND_ARGS_PAIR_10(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7) op(a8, a9)
+#define EZ_EXPAND_ARGS_PAIR_12(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7) op(a8, a9) op(a10, a11)
+#define EZ_EXPAND_ARGS_PAIR_14(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7) op(a8, a9) op(a10, a11) op(a12, a13)
+#define EZ_EXPAND_ARGS_PAIR_16(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7) op(a8, a9) op(a10, a11) op(a12, a13) op(a14, a15)
+#define EZ_EXPAND_ARGS_PAIR_18(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7) op(a8, a9) op(a10, a11) op(a12, a13) op(a14, a15) op(a16, a17)
+#define EZ_EXPAND_ARGS_PAIR_20(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) op(a0, a1) op(a2, a3) op(a4, a5) op(a6, a7) op(a8, a9) op(a10, a11) op(a12, a13) op(a14, a15) op(a16, a17) op(a18, a19)
+
+#define EZ_EXPAND_ARGS_PAIR(op, ...) \
+  EZ_CALL_MACRO(EZ_CONCAT(EZ_EXPAND_ARGS_PAIR_, EZ_VA_NUM_ARGS(__VA_ARGS__)), (op, __VA_ARGS__))
+
+//////////////////////////////////////////////////////////////////////////
+
+#define EZ_EXPAND_ARGS_PAIR_COMMA_1(...) /* handles the case of zero parameters (e.g. an empty __VA_ARGS__) */
+#define EZ_EXPAND_ARGS_PAIR_COMMA_2(op, a0, a1) op(a0, a1)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_3(op, a0, a1, ...) op(a0, a1)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_4(op, a0, a1, a2, a3) op(a0, a1), op(a2, a3)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_6(op, a0, a1, a2, a3, a4, a5) op(a0, a1), op(a2, a3), op(a4, a5)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_8(op, a0, a1, a2, a3, a4, a5, a6, a7) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_10(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7), op(a8, a9)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_12(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7), op(a8, a9), op(a10, a11)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_14(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7), op(a8, a9), op(a10, a11), op(a12, a13)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_16(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7), op(a8, a9), op(a10, a11), op(a12, a13), op(a14, a15)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_18(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7), op(a8, a9), op(a10, a11), op(a12, a13), op(a14, a15), op(a16, a17)
+#define EZ_EXPAND_ARGS_PAIR_COMMA_20(op, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19) op(a0, a1), op(a2, a3), op(a4, a5), op(a6, a7), op(a8, a9), op(a10, a11), op(a12, a13), op(a14, a15), op(a16, a17), op(a18, a19)
+
+#define EZ_EXPAND_ARGS_PAIR_COMMA(op, ...) \
+  EZ_CALL_MACRO(EZ_CONCAT(EZ_EXPAND_ARGS_PAIR_COMMA_, EZ_VA_NUM_ARGS(__VA_ARGS__)), (op, __VA_ARGS__))
+
+//////////////////////////////////////////////////////////////////////////
 
 #define EZ_TO_BOOL_0 0
 #define EZ_TO_BOOL_1 1
@@ -58,22 +101,27 @@
 
 #define EZ_TO_BOOL(x) EZ_CONCAT(EZ_TO_BOOL_, x)
 
+//////////////////////////////////////////////////////////////////////////
 
 #define EZ_IF_0(x)
 #define EZ_IF_1(x) x
-#define EZ_IF(cond, x) EZ_CONCAT(EZ_IF_, EZ_TO_BOOL(cond)) \
-(x)
+#define EZ_IF(cond, x)                \
+  EZ_CONCAT(EZ_IF_, EZ_TO_BOOL(cond)) \
+  (x)
 
 #define EZ_IF_ELSE_0(x, y) y
 #define EZ_IF_ELSE_1(x, y) x
-#define EZ_IF_ELSE(cond, x, y) EZ_CONCAT(EZ_IF_ELSE_, EZ_TO_BOOL(cond)) \
-(x, y)
+#define EZ_IF_ELSE(cond, x, y)             \
+  EZ_CONCAT(EZ_IF_ELSE_, EZ_TO_BOOL(cond)) \
+  (x, y)
 
+//////////////////////////////////////////////////////////////////////////
 
 #define EZ_COMMA_MARK_0
 #define EZ_COMMA_MARK_1 ,
 #define EZ_COMMA_IF(cond) EZ_CONCAT(EZ_COMMA_MARK_, EZ_TO_BOOL(cond))
 
+//////////////////////////////////////////////////////////////////////////
 
 #define EZ_LIST_0(x)
 #define EZ_LIST_1(x) EZ_CONCAT(x, 0)
@@ -87,13 +135,16 @@
 #define EZ_LIST_9(x) EZ_LIST_8(x), EZ_CONCAT(x, 8)
 #define EZ_LIST_10(x) EZ_LIST_9(x), EZ_CONCAT(x, 9)
 
-#define EZ_LIST(x, count) EZ_CONCAT(EZ_LIST_, count) \
-(x)
+#define EZ_LIST(x, count)    \
+  EZ_CONCAT(EZ_LIST_, count) \
+  (x)
 
+//////////////////////////////////////////////////////////////////////////
 
 #define EZ_PAIR_LIST_0(x, y)
-#define EZ_PAIR_LIST_1(x, y) EZ_CONCAT(x, 0) \
-EZ_CONCAT(y, 0)
+#define EZ_PAIR_LIST_1(x, y) \
+  EZ_CONCAT(x, 0)            \
+  EZ_CONCAT(y, 0)
 #define EZ_PAIR_LIST_2(x, y) EZ_PAIR_LIST_1(x, y), EZ_CONCAT(x, 1) EZ_CONCAT(y, 1)
 #define EZ_PAIR_LIST_3(x, y) EZ_PAIR_LIST_2(x, y), EZ_CONCAT(x, 2) EZ_CONCAT(y, 2)
 #define EZ_PAIR_LIST_4(x, y) EZ_PAIR_LIST_3(x, y), EZ_CONCAT(x, 3) EZ_CONCAT(y, 3)
@@ -104,6 +155,7 @@ EZ_CONCAT(y, 0)
 #define EZ_PAIR_LIST_9(x, y) EZ_PAIR_LIST_8(x, y), EZ_CONCAT(x, 8) EZ_CONCAT(y, 8)
 #define EZ_PAIR_LIST_10(x, y) EZ_PAIR_LIST_9(x, y), EZ_CONCAT(x, 9) EZ_CONCAT(y, 9)
 
-#define EZ_PAIR_LIST(x, y, count) EZ_CONCAT(EZ_PAIR_LIST_, count) \
-(x, y)
+#define EZ_PAIR_LIST(x, y, count) \
+  EZ_CONCAT(EZ_PAIR_LIST_, count) \
+  (x, y)
 

--- a/Code/Engine/Foundation/Basics/Platform/Win/Platform_win.h
+++ b/Code/Engine/Foundation/Basics/Platform/Win/Platform_win.h
@@ -138,8 +138,8 @@
 // unfortunately, VS 2010 still has this compiler bug which treats a __VA_ARGS__ argument as being one single parameter:
 // https://connect.microsoft.com/VisualStudio/feedback/details/521844/variadic-macro-treating-va-args-as-a-single-parameter-for-other-macros#details
 #  if _MSC_VER >= 1400 && EZ_DISABLED(EZ_COMPILER_MSVC_CLANG)
-#    define EZ_VA_NUM_ARGS_HELPER(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
-#    define EZ_VA_NUM_ARGS_REVERSE_SEQUENCE 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
+#    define EZ_VA_NUM_ARGS_HELPER(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, N, ...) N
+#    define EZ_VA_NUM_ARGS_REVERSE_SEQUENCE 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1
 #    define EZ_LEFT_PARENTHESIS (
 #    define EZ_RIGHT_PARENTHESIS )
 #    define EZ_VA_NUM_ARGS(...) EZ_VA_NUM_ARGS_HELPER EZ_LEFT_PARENTHESIS __VA_ARGS__, EZ_VA_NUM_ARGS_REVERSE_SEQUENCE EZ_RIGHT_PARENTHESIS

--- a/Code/Engine/Foundation/Communication/Implementation/Message.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/Message.cpp
@@ -1,9 +1,16 @@
 #include <FoundationPCH.h>
 
 #include <Foundation/Communication/Message.h>
+#include <Foundation/Communication/ScriptableFunctionBinding.h>
 
+// clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMessage, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_IMPLEMENT_MESSAGE_TYPE(ezScriptFunctionMessage);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezScriptFunctionMessage, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
 
 ezMessageId ezMessage::s_uiNextMsgId = 0;
 
@@ -52,4 +59,3 @@ ezUniquePtr<ezMessage> ezMessage::ReplicatePackedMessage(ezStreamReader& stream)
 }
 
 EZ_STATICLINK_FILE(Foundation, Foundation_Communication_Implementation_Message);
-

--- a/Code/Engine/Foundation/Communication/Implementation/Telemetry.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/Telemetry.cpp
@@ -2,7 +2,10 @@
 
 #include <Foundation/Communication/Telemetry.h>
 #include <Foundation/Threading/ThreadUtils.h>
+
+#ifdef BUILDSYSTEM_ENABLE_ENET_SUPPORT
 #include <enet/enet.h>
+#endif
 
 class ezTelemetryThread;
 

--- a/Code/Engine/Foundation/Communication/Message.h
+++ b/Code/Engine/Foundation/Communication/Message.h
@@ -122,25 +122,25 @@ public:
   static ezUniquePtr<ezMessage> ReplicatePackedMessage(ezStreamReader& stream);
 
 private:
-
 };
 
 /// \brief Add this macro to the declaration of your custom message type.
 #define EZ_DECLARE_MESSAGE_TYPE(messageType, baseType) \
-  private: \
-    EZ_ADD_DYNAMIC_REFLECTION(messageType, baseType); \
-    static ezMessageId MSG_ID; \
-  public: \
-    static ezMessageId GetTypeMsgId() \
-    { \
-      static ezMessageId id = ezMessage::GetNextMsgId(); \
-      return id; \
-    } \
-    EZ_ALWAYS_INLINE messageType() \
-    { \
-      m_Id = messageType::MSG_ID; \
-      m_uiSize = sizeof(messageType); \
-    }
+private:                                               \
+  EZ_ADD_DYNAMIC_REFLECTION(messageType, baseType);    \
+  static ezMessageId MSG_ID;                           \
+                                                       \
+public:                                                \
+  static ezMessageId GetTypeMsgId()                    \
+  {                                                    \
+    static ezMessageId id = ezMessage::GetNextMsgId(); \
+    return id;                                         \
+  }                                                    \
+  EZ_ALWAYS_INLINE messageType()                       \
+  {                                                    \
+    m_Id = messageType::MSG_ID;                        \
+    m_uiSize = sizeof(messageType);                    \
+  }
 
 /// \brief Implements the given message type. Add this macro to a cpp outside of the type declaration.
 #define EZ_IMPLEMENT_MESSAGE_TYPE(messageType) \
@@ -153,4 +153,3 @@ struct ezMessageSenderBase
 {
   typedef T MessageType;
 };
-

--- a/Code/Engine/Foundation/Communication/ScriptableFunctionBinding.h
+++ b/Code/Engine/Foundation/Communication/ScriptableFunctionBinding.h
@@ -1,0 +1,588 @@
+#pragma once
+
+/// \file
+
+#include <Foundation/Communication/Message.h>
+#include <Foundation/Strings/String.h>
+
+/// \brief Macro to declare a member function that should be callable from scripts.
+///
+/// Pass the return type as the first parameter, and the function name as the second.
+/// Then optionally pass in parameters as Type COMMA Name pairs.
+///
+/// Examples:
+///   EZ_SCRIPTABLE_FUNCTION_DECL_VOID(void, DoStuff);
+///   EZ_SCRIPTABLE_FUNCTION_DECL(float, GetStuff, ezInt32, param1);
+///   EZ_SCRIPTABLE_FUNCTION_DECL(ezUInt8, GetMoreStuff, double, param1, const char*, param2);
+///   EZ_SCRIPTABLE_FUNCTION_DECL_VOID(void, WithOutParams, double&, out_param1, int&, inout_param2);
+///
+/// You can use return values and non-const reference parameters to return values from the function.
+/// For reference parameters to work, the parameter name must start with either "out_" or "inout_"
+/// depending on whether it should be only an out value or also an in value.
+///
+/// Use EZ_SCRIPTABLE_FUNCTION_IMPL in the CPP file to implement the declared functionality.
+///
+/// Use EZ_SCRIPTABLE_FUNCTION_DECL_VOID to declare functions that do not return a value.
+///
+/// Details:
+/// The macro will declare a message (derived from ezScriptFunctionMessage), a function to handle that message,
+/// and a function with a regular signature "ReturnType FunctionName(Parameters)"
+/// The message will be used as the glue to communicate from the script with the C++ function.
+/// The message handler will be automatically registered. It unpacks incoming parameter values, forwards the call
+/// to the regular function, and then packs inout and out parameter results back into the message.
+///
+/// \sa EZ_SCRIPTABLE_FUNCTION_DECL_VOID, EZ_SCRIPTABLE_FUNCTION_IMPL, EZ_SCRIPTABLE_FUNCTION_MSG_TYPE
+#define EZ_SCRIPTABLE_FUNCTION_DECL(ReturnType, FuncName, ...) _EZ_SF_DECL(ReturnType, FuncName, __VA_ARGS__)
+
+/// \brief Same as EZ_SCRIPTABLE_FUNCTION_DECL() but for functions that should return 'void'
+#define EZ_SCRIPTABLE_FUNCTION_DECL_VOID(FuncName, ...) _EZ_SF_DECL_VOID(FuncName, __VA_ARGS__)
+
+/// \brief Counter-part macro to EZ_SCRIPTABLE_FUNCTION_DECL() to insert in CPP files to implement the declared functionality
+///
+/// \sa EZ_SCRIPTABLE_FUNCTION_IMPL_VOID, EZ_SCRIPTABLE_FUNCTION_DECL, EZ_SCRIPTABLE_FUNCTION_MSG_TYPE
+#define EZ_SCRIPTABLE_FUNCTION_IMPL(ReturnType, ClassName, FuncName, ...) _EZ_SF_IMPL(ReturnType, ClassName, FuncName, __VA_ARGS__)
+
+/// \brief Same as EZ_SCRIPTABLE_FUNCTION_IMPL() but for functions that should return 'void'
+#define EZ_SCRIPTABLE_FUNCTION_IMPL_VOID(ClassName, FuncName, ...) _EZ_SF_IMPL_VOID(ClassName, FuncName, __VA_ARGS__)
+
+/// \brief Generates the full message class name for the given class's script function
+///
+/// Use this if you ever need to generate an instance of this message yourself, e.g. if you want to do a delayed function call.
+///
+/// \sa EZ_SCRIPTABLE_FUNCTION_DECL, EZ_SCRIPTABLE_FUNCTION_IMPL
+#define EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName) ClassName::_EZ_SF_MSG_NAME(FuncName)
+
+/// \brief Base class for all messages that were auto-generated for script function bindings
+struct EZ_FOUNDATION_DLL ezScriptFunctionMessage : public ezMessage
+{
+  EZ_DECLARE_MESSAGE_TYPE(ezScriptFunctionMessage, ezMessage);
+};
+
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+////////////////// DANGER! HERE BE DRAGONS!!!
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//// SERIOUSLY, DON'T SCROLL FURTHER IF YOU WANT TO KEEP YOUR SANITY
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//// OK, WE START WITH SOME LIGHT READING
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+
+namespace ezInternal
+{
+  /// \internal Used to strip away "out_" and "inout_" from parameter names
+  ///
+  /// These name prefixes are used to detect whether a parameter should be exposed as an output or as both input and output to the function.
+  /// If it has no prefix, it is only input.
+  ///
+  /// Additionally, for "reasons" (preprocessor parsing rules), we cannot just flag return values as reference parameters, so the function return
+  /// value gets a special name, to flag it as such. To make it nicer, we remap it here as well.
+  inline const char* SfRemoveParamPrefix(bool isNonConstReference, const char* szParamName)
+  {
+    if (ezStringUtils::IsEqual(szParamName, "_SfResult"))
+      return "Result";
+
+    // early out, we assert in SfGetParamFlags() that the user didn't use wrong combinations
+    if (!isNonConstReference)
+      return szParamName;
+
+    if (ezStringUtils::StartsWith(szParamName, "out_"))
+      return szParamName + 4;
+    if (ezStringUtils::StartsWith(szParamName, "inout_"))
+      return szParamName + 6;
+
+    return szParamName;
+  }
+
+  /// \internal Used to detect ezPropertyFlags for the message properties, to tag out and inout parameters
+  ///
+  /// Again, the return value of the scriptable function gets special treatment, to tag it as an 'out' parameter even though it is not a reference.
+  inline ezPropertyFlags::Enum SfGetParamFlags(bool isNonConstReference, const char* szParamName)
+  {
+    // the return value is always handled like an 'out' variable
+    if (ezStringUtils::IsEqual(szParamName, "_SfResult"))
+      return ezPropertyFlags::VarOut;
+
+    if (ezStringUtils::StartsWith(szParamName, "out_"))
+    {
+      EZ_ASSERT_DEBUG(isNonConstReference, "Parameter '{}' has an 'out_' prefix, but is not a non-const reference type", szParamName);
+      return ezPropertyFlags::VarOut;
+    }
+
+    if (ezStringUtils::StartsWith(szParamName, "inout_"))
+    {
+      EZ_ASSERT_DEBUG(isNonConstReference, "Parameter '{}' has an 'inout_' prefix, but is not a non-const reference type", szParamName);
+      return ezPropertyFlags::VarInOut;
+    }
+
+    EZ_ASSERT_DEBUG(!isNonConstReference, "Parameter '{}' is a non-const reference type, but does not use an 'out_' or 'inout_' name prefix", szParamName);
+    return ezPropertyFlags::Void;
+  }
+
+  /// \internal Template struct used to remap function parameter types to and from types that are actually supported by the script runtime
+  ///
+  /// The (Visual) Script runtime only supports a very limited set of types. E.g. all numbers are just doubles. Lua and JavaScript do the same.
+  /// Thus, if we want to have a function exposed to the scripting system, but also want to use integers and maybe const char* for strings etc.
+  /// we need to remap those types to a supported type.
+  ///
+  /// Template specializations of SfType declare the 'MappedType' typedef, which specifies which type to use in the script (or rather in the
+  /// message that is exposed to the scripts).
+  /// For instance, all int specializations map the int type to double.
+  ///
+  /// The struct then also defines to functions to cast back and forth between the original type and the mapped type.
+  template <typename VarType>
+  struct SfType
+  {
+  };
+
+  // float -> double
+  template <>
+  struct SfType<float>
+  {
+    typedef float Type;
+    typedef double MappedType;
+    static float CastFromMapped(MappedType in) { return in; }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // double -> double
+  template <>
+  struct SfType<double>
+  {
+    typedef double Type;
+    typedef double MappedType;
+    static double CastFromMapped(MappedType in) { return in; }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // bool -> bool
+  template <>
+  struct SfType<bool>
+  {
+    typedef bool Type;
+    typedef bool MappedType;
+    static bool CastFromMapped(MappedType in) { return in; }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezInt32 -> double (+ rounding when casting back)
+  template <>
+  struct SfType<ezInt32>
+  {
+    typedef ezInt32 Type;
+    typedef double MappedType;
+    static ezInt32 CastFromMapped(MappedType in) { return static_cast<ezInt32>(ezMath::Round(in)); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezInt16 -> double (+ rounding when casting back)
+  template <>
+  struct SfType<ezInt16>
+  {
+    typedef ezInt16 Type;
+    typedef double MappedType;
+    static ezInt16 CastFromMapped(MappedType in) { return static_cast<ezInt16>(ezMath::Round(in)); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezInt8 -> double (+ rounding when casting back)
+  template <>
+  struct SfType<ezInt8>
+  {
+    typedef ezInt8 Type;
+    typedef double MappedType;
+    static ezInt8 CastFromMapped(MappedType in) { return static_cast<ezInt8>(ezMath::Round(in)); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezUInt32 -> double (+ rounding when casting back)
+  template <>
+  struct SfType<ezUInt32>
+  {
+    typedef ezUInt32 Type;
+    typedef double MappedType;
+    static ezUInt32 CastFromMapped(MappedType in) { return static_cast<ezUInt32>(ezMath::Round(in)); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezUInt16 -> double (+ rounding when casting back)
+  template <>
+  struct SfType<ezUInt16>
+  {
+    typedef ezUInt16 Type;
+    typedef double MappedType;
+    static ezUInt16 CastFromMapped(MappedType in) { return static_cast<ezUInt16>(ezMath::Round(in)); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezUInt8 -> double (+ rounding when casting back)
+  template <>
+  struct SfType<ezUInt8>
+  {
+    typedef ezUInt8 Type;
+    typedef double MappedType;
+    static ezUInt8 CastFromMapped(MappedType in) { return static_cast<ezUInt8>(ezMath::Round(in)); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // const char* -> ezString
+  template <>
+  struct SfType<const char*>
+  {
+    typedef const char* Type;
+    typedef ezString MappedType;
+    static const char* CastFromMapped(const MappedType& in) { return in.GetData(); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+
+  // ezStringView\ -> ezString
+  template <>
+  struct SfType<ezStringView>
+  {
+    typedef ezStringView Type;
+    typedef ezString MappedType;
+    static ezStringView CastFromMapped(const MappedType& in) { return in.GetView(); }
+    static MappedType CastToMapped(Type in) { return static_cast<MappedType>(in); }
+  };
+}; // namespace ezInternal
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//// SOME HELPER MACROS TO MAKE LIFE LESS MISERABLE
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+/// \internal Builds the name of the ezMessage that is used to bind a script function
+#define _EZ_SF_MSG_NAME(FuncName) EZ_CONCAT(SfMsg_, FuncName)
+
+/// \internal Builds the name of the message handler function, e.g. generates "OnMyFunc"
+#define _EZ_SF_MSG_HANDLER_NAME(FuncName) EZ_CONCAT(On, FuncName)
+
+/// \internal Builds the full name of the message handler function, e.g. generates "MyClass::OnMyFunc"
+#define _EZ_SF_MSG_HANDLER_NAME_FULL(ClassName, FuncName) ClassName::_EZ_SF_MSG_HANDLER_NAME(FuncName)
+
+/// \internal Builds the name of a temp variable, takes two parameters and ignores the first, because the macro is called with pairs of Type/Name
+#define _EZ_SF_TMP_PARAM_NAME(Type, Name) EZ_CONCAT(Tmp, Name)
+
+/// \internal When this macro is called, it simply outputs the values of the two parameters after each other
+/// the only reason for this to exist is because it is called by another macro for all pairs of variadic parameters
+#define _EZ_SF_DECL_FUNC_PARAM(Type, Name) Type Name
+
+/// \internal Generates C++ code that detects whether a type is a reference type and not const
+///
+/// For this to work as expected, one needs to peel away the reference type and THEN check for const-ness,
+/// otherwise a "const int&" will be reported as non-const, because technically the variable is not const, only the pointed to variable is,
+/// but that is what we are more interested in
+#define _EZ_SF_IS_NON_CONST_REF(Type) (std::is_reference<Type>::value) && (std::is_const<std::remove_reference<Type>::type>::value == false)
+
+/// \internal Creates an instance of ezScriptFunctionRegistrar to auto-register the auto-generated message handler function
+///
+/// This is basically a copy of EZ_MESSAGE_HANDLER, just with minor adjustments to register our function
+#define _EZ_SF_REGISTER(ClassName, FuncName)                                              \
+  static ezInternal::ezScriptFunctionRegistrar<ClassName> EZ_CONCAT(ClassName, FuncName)( \
+    new ezInternal::MessageHandler<EZ_IS_CONST_MESSAGE_HANDLER(                           \
+      ClassName,                                                                          \
+      EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName),                               \
+      &_EZ_SF_MSG_HANDLER_NAME_FULL(ClassName, FuncName))>::Impl<ClassName, EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName), &_EZ_SF_MSG_HANDLER_NAME_FULL(ClassName, FuncName)>())
+
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//// AND NOW THE TRULY HORRIFIC PART
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+/// \internal Implementation of EZ_SCRIPTABLE_FUNCTION_DECL
+///
+/// This macro first declares a message type for binding the function call.
+/// It then declares a function to handle that message type, and finally another
+/// function for the regular function call (what should be used from C++ directly).
+///
+/// This macro uses EZ_EXPAND_ARGS_PAIR and EZ_EXPAND_ARGS_PAIR_COMMA to expand all vararg parameters as pairs of (Type, Name).
+/// It does so once inside the message body to declare all message members, and a second time in the declaration of the
+/// regular function, to declare the function parameters.
+///
+/// The latter case is easy, we just use _EZ_SF_DECL_FUNC_PARAM to simply pass through all vararg parameter pairs into
+/// the function declaration. The EZ_EXPAND_ARGS_PAIR_COMMA automatically inserts commas between each parameter type/name pair.
+///
+/// The former case is way more tricky, because we also want to insert the function return type as a message member, so that we
+/// have a place where the return value can be written to (and then be picked up by the scripting system again and just handled
+/// like an out parameter).
+/// HOWEVER, the ReturnType may be 'void' and we cannot declare a void member!
+/// The current work-around is to use a separate macro for this case, ie. _EZ_SF_DECL_VOID()
+#define _EZ_SF_DECL(ReturnType, FuncName, ...)                                      \
+  struct _EZ_SF_MSG_NAME(FuncName)                                                  \
+    : public ezScriptFunctionMessage                                                \
+  {                                                                                 \
+    EZ_DECLARE_MESSAGE_TYPE(_EZ_SF_MSG_NAME(FuncName), ezScriptFunctionMessage);    \
+    EZ_EXPAND_ARGS_PAIR(_EZ_SF_DECL_MSG_MEMBER, ReturnType, _SfResult, __VA_ARGS__) \
+  };                                                                                \
+  void _EZ_SF_MSG_HANDLER_NAME(FuncName)(_EZ_SF_MSG_NAME(FuncName) & msg);          \
+  ReturnType FuncName(EZ_EXPAND_ARGS_PAIR_COMMA(_EZ_SF_DECL_FUNC_PARAM, __VA_ARGS__))
+
+/// \internal Same as _EZ_SF_DECL() but with adjustments for the ReturnType being 'void'
+#define _EZ_SF_DECL_VOID(FuncName, ...)                                          \
+  struct _EZ_SF_MSG_NAME(FuncName)                                               \
+    : public ezScriptFunctionMessage                                             \
+  {                                                                              \
+    EZ_DECLARE_MESSAGE_TYPE(_EZ_SF_MSG_NAME(FuncName), ezScriptFunctionMessage); \
+    EZ_EXPAND_ARGS_PAIR(_EZ_SF_DECL_MSG_MEMBER, __VA_ARGS__)                     \
+  };                                                                             \
+  void _EZ_SF_MSG_HANDLER_NAME(FuncName)(_EZ_SF_MSG_NAME(FuncName) & msg);       \
+  void FuncName(EZ_EXPAND_ARGS_PAIR_COMMA(_EZ_SF_DECL_FUNC_PARAM, __VA_ARGS__))
+
+
+/// \internal Used to insert a member into the declaration of the message
+///
+/// This macro expands to "SfType<Type>::MappedType Name", which simply declares a member of the supported type, ie. for int/float types the
+/// member is mapped to use 'double' as the type, etc. We also remove const-ness and reference-ness as those would not work in the message.
+#define _EZ_SF_DECL_MSG_MEMBER(Type, Name) ezInternal::SfType<ezTypeTraits<Type>::NonConstReferenceType>::MappedType Name;
+
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//// IT GETS WORSE, I WARNED YOU !
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+
+/// \internal Implementation of EZ_SCRIPTABLE_FUNCTION_IMPL
+///
+/// This macro first builds the RTTI block for the message.
+/// For that it needs to generate an EZ_MEMBER_PROPERTY call for every function parameter and the function return type.
+/// _EZ_SF_IMPL_VOID() is a separate variant to handle 'void' as the function return type.
+///
+/// Additionally it has to handle zero to nine function parameters.
+/// That is why the _EZ_SF_MSG_PROP_LIST_XY macros below exist. Unfortunately, on 'standard-compliant' preprocessor implementations
+/// our macros to auto-expand lists start to fail at this macro nesting depth (working theory...). So instead the _EZ_SF_MSG_PROP_LIST_ macros implement all the different
+/// cases manually.
+///
+/// After the message type is defined, we call _EZ_SF_REGISTER to auto-register the message handling function with the RTTI info of 'ClassName'.
+///
+/// After that we define the message handler function itself. It uses _EZ_SF_FUNC_PUSH_TMP_PARAMS to first copy all message members into local temp variables of
+/// the correct type.
+/// Then it does the actual function call (yay! finally!)
+/// And afterwards it uses _EZ_SF_FUNC_PULL_TMP_PARAMS to copy the values of all 'out' and 'inout' parameters from the temp variables back into the message members
+/// (with correct casting) such that the values are available to the scripting system.
+/// It has to do the same thing for the return value of the function.
+///
+/// After all this, the signature of the regular member function is inserted and finally the user can write his curly braces and the script function body.
+/// So for the user everything is shiny and awesome and all the parameters are just like he expected and he can return a value and he doesn't have to think about
+/// all the horrors that power his maddest ideas. Oh god what have I done! I've created a monster!! It's alive!!!!
+#define _EZ_SF_IMPL(ReturnType, ClassName, FuncName, ...)                                                                                                                \
+  EZ_IMPLEMENT_MESSAGE_TYPE(EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName));                                                                                       \
+  EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName), 1, ezRTTIDefaultAllocator<EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName)>) \
+    {                                                                                                                                                                    \
+      EZ_BEGIN_ATTRIBUTES                                                                                                                                                \
+      {                                                                                                                                                                  \
+        new ezAutoGenVisScriptMsgSender(),                                                                                                                               \
+      } EZ_END_ATTRIBUTES;                                                                                                                                               \
+      EZ_CALL_MACRO(EZ_CONCAT(_EZ_SF_MSG_PROP_LIST_, EZ_VA_NUM_ARGS(ReturnType, _SfResult, __VA_ARGS__)), (ReturnType, _SfResult, __VA_ARGS__))                          \
+    }                                                                                                                                                                    \
+  EZ_END_DYNAMIC_REFLECTED_TYPE;                                                                                                                                         \
+  _EZ_SF_REGISTER(ClassName, FuncName);                                                                                                                                  \
+  void _EZ_SF_MSG_HANDLER_NAME_FULL(ClassName, FuncName)(EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName) & msg)                                                     \
+  {                                                                                                                                                                      \
+    EZ_EXPAND_ARGS_PAIR(_EZ_SF_FUNC_PUSH_TMP_PARAMS, __VA_ARGS__);                                                                                                       \
+    msg._SfResult = ezInternal::SfType<ReturnType>::CastToMapped(FuncName(EZ_EXPAND_ARGS_PAIR_COMMA(_EZ_SF_TMP_PARAM_NAME, __VA_ARGS__)));                               \
+    EZ_EXPAND_ARGS_PAIR(_EZ_SF_FUNC_PULL_TMP_PARAMS, __VA_ARGS__);                                                                                                       \
+  }                                                                                                                                                                      \
+  ReturnType ClassName::FuncName(EZ_EXPAND_ARGS_PAIR_COMMA(_EZ_SF_DECL_FUNC_PARAM, __VA_ARGS__))
+
+
+/// \internal Same as _EZ_SF_IMPL() but with adjustments for the ReturnType being 'void'
+#define _EZ_SF_IMPL_VOID(ClassName, FuncName, ...)                                                                                                                       \
+  EZ_IMPLEMENT_MESSAGE_TYPE(EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName));                                                                                       \
+  EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName), 1, ezRTTIDefaultAllocator<EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName)>) \
+    {                                                                                                                                                                    \
+      EZ_BEGIN_ATTRIBUTES                                                                                                                                                \
+      {                                                                                                                                                                  \
+        new ezAutoGenVisScriptMsgSender(),                                                                                                                               \
+      } EZ_END_ATTRIBUTES;                                                                                                                                               \
+      EZ_CALL_MACRO(EZ_CONCAT(_EZ_SF_MSG_PROP_LIST_, EZ_VA_NUM_ARGS(__VA_ARGS__)), (__VA_ARGS__))                                                                        \
+    }                                                                                                                                                                    \
+  EZ_END_DYNAMIC_REFLECTED_TYPE;                                                                                                                                         \
+  _EZ_SF_REGISTER(ClassName, FuncName);                                                                                                                                  \
+  void _EZ_SF_MSG_HANDLER_NAME_FULL(ClassName, FuncName)(EZ_SCRIPTABLE_FUNCTION_MSG_TYPE(ClassName, FuncName) & msg)                                                     \
+  {                                                                                                                                                                      \
+    EZ_EXPAND_ARGS_PAIR(_EZ_SF_FUNC_PUSH_TMP_PARAMS, __VA_ARGS__);                                                                                                       \
+    FuncName(EZ_EXPAND_ARGS_PAIR_COMMA(_EZ_SF_TMP_PARAM_NAME, __VA_ARGS__));                                                                                             \
+    EZ_EXPAND_ARGS_PAIR(_EZ_SF_FUNC_PULL_TMP_PARAMS, __VA_ARGS__);                                                                                                       \
+  }                                                                                                                                                                      \
+  void ClassName::FuncName(EZ_EXPAND_ARGS_PAIR_COMMA(_EZ_SF_DECL_FUNC_PARAM, __VA_ARGS__))
+
+
+//////////////////////////////////////////////////////////////////////////
+
+/// \internal Macro used to create the reflection information for a message member
+///
+/// This macro boils down to inserting an EZ_MEMBER_PROPERTY call for the given member variable.
+/// It uses SfRemoveParamPrefix to trim 'out_' and 'inout_' from the exposed name and
+/// it calls SfGetParamFlags to tag the property with the necessary ezPropertyFlag's such that the scripting system knows whether
+/// this property should be handled as an in, out or inout parameter.
+#define _EZ_SF_IMPL_MSG_MEMBER(Type, Name) EZ_MEMBER_PROPERTY(ezInternal::SfRemoveParamPrefix(_EZ_SF_IS_NON_CONST_REF(Type), EZ_STRINGIZE(Name)), Name)->AddFlags(ezInternal::SfGetParamFlags(_EZ_SF_IS_NON_CONST_REF(Type), EZ_STRINGIZE(Name)))
+
+//////////////////////////////////////////////////////////////////////////
+
+/// \internal Handles the case of no return type and no parameters, ie. an empty __VA_ARGS__ list (which will still be reported as having one element)
+#define _EZ_SF_MSG_PROP_LIST_1(...)
+
+/// \internal Handles the case of having a return type but no parameters, ie. an empty __VA_ARGS__ list (which will still be reported as having one element)
+#define _EZ_SF_MSG_PROP_LIST_3(t1, v1, ...) _EZ_SF_MSG_PROP_LIST_2(t1, v1)
+
+/// \internal Handles the case of 1 parameter type/name pair
+#define _EZ_SF_MSG_PROP_LIST_2(t1, v1) \
+  EZ_BEGIN_PROPERTIES                  \
+  {                                    \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),    \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 2 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_4(t1, v1, t2, v2) \
+  EZ_BEGIN_PROPERTIES                          \
+  {                                            \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),            \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),            \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 3 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_6(t1, v1, t2, v2, t3, v3) \
+  EZ_BEGIN_PROPERTIES                                  \
+  {                                                    \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                    \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                    \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                    \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 4 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_8(t1, v1, t2, v2, t3, v3, t4, v4) \
+  EZ_BEGIN_PROPERTIES                                          \
+  {                                                            \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                            \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                            \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                            \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                            \
+  } EZ_END_PROPERTIES;
+
+
+/// \internal Handles the case of 5 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_10(t1, v1, t2, v2, t3, v3, t4, v4, t5, v5) \
+  EZ_BEGIN_PROPERTIES                                                   \
+  {                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t5, v5),                                     \
+  } EZ_END_PROPERTIES;
+
+
+/// \internal Handles the case of 6 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_12(t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6) \
+  EZ_BEGIN_PROPERTIES                                                           \
+  {                                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t5, v5),                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t6, v6),                                             \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 7 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_14(t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7) \
+  EZ_BEGIN_PROPERTIES                                                                   \
+  {                                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t5, v5),                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t6, v6),                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t7, v7),                                                     \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 8 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_16(t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7, t8, v8) \
+  EZ_BEGIN_PROPERTIES                                                                           \
+  {                                                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t5, v5),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t6, v6),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t7, v7),                                                             \
+    _EZ_SF_IMPL_MSG_MEMBER(t8, v8),                                                             \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 9 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_18(t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7, t8, v8, t9, v9) \
+  EZ_BEGIN_PROPERTIES                                                                                   \
+  {                                                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t5, v5),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t6, v6),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t7, v7),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t8, v8),                                                                     \
+    _EZ_SF_IMPL_MSG_MEMBER(t9, v9),                                                                     \
+  } EZ_END_PROPERTIES;
+
+/// \internal Handles the case of 10 parameter type/name pairs
+#define _EZ_SF_MSG_PROP_LIST_20(t1, v1, t2, v2, t3, v3, t4, v4, t5, v5, t6, v6, t7, v7, t8, v8, t9, v9, t10, v10) \
+  EZ_BEGIN_PROPERTIES                                                                                             \
+  {                                                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t1, v1),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t2, v2),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t3, v3),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t4, v4),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t5, v5),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t6, v6),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t7, v7),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t8, v8),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t9, v9),                                                                               \
+    _EZ_SF_IMPL_MSG_MEMBER(t10, v10),                                                                             \
+  } EZ_END_PROPERTIES;
+
+//////////////////////////////////////////////////////////////////////////
+
+/// \internal Used BEFORE the regular function is called to define temp variables within the message handler function to store/copy all the message members
+///
+/// At this point we cast the member variables to the actual type, such that they can be passed easily into the regular function.
+/// Although this could be done in-place in the function call, the temp variables are needed to enable _EZ_SF_FUNC_PULL_TMP_PARAMS to
+/// cast any out and inout parameters to the MappedType and move the output into the message members again.
+#define _EZ_SF_FUNC_PUSH_TMP_PARAMS(Type, Name) ezTypeTraits<Type>::NonConstReferenceType _EZ_SF_TMP_PARAM_NAME(Type, Name) = ezInternal::SfType<ezTypeTraits<Type>::NonConstReferenceType>::CastFromMapped(msg.Name);
+
+/// \internal Used AFTER the regular function was called, to take the 'out' and 'inout' parameters and store them back into the message members.
+///
+/// At this point we also need to cast the values from the actual parameter type to the MappedType again.
+///
+/// To prevent unnecessary copies, only non-const reference parameters get pulled back. Although this is wrapped in an if statement,
+/// the if boils down to a compile-time constant and should be optimized away. Ideally this will then also enable the compiler to optimize away the entire temporary.
+#define _EZ_SF_FUNC_PULL_TMP_PARAMS(Type, Name)                                                                                \
+  if (_EZ_SF_IS_NON_CONST_REF(Type))                                                                                           \
+  {                                                                                                                            \
+    msg.Name = ezInternal::SfType<ezTypeTraits<Type>::NonConstReferenceType>::CastToMapped(_EZ_SF_TMP_PARAM_NAME(Type, Name)); \
+  }

--- a/Code/Engine/Foundation/IO/Archive/Implementation/DataDirTypeArchive.cpp
+++ b/Code/Engine/Foundation/IO/Archive/Implementation/DataDirTypeArchive.cpp
@@ -208,6 +208,8 @@ void ezDataDirectory::ArchiveReaderUncompressed::InternalClose()
 
 //////////////////////////////////////////////////////////////////////////
 
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+
 ezDataDirectory::ArchiveReaderZstd::ArchiveReaderZstd(ezInt32 iDataDirUserData)
   : ArchiveReaderUncompressed(iDataDirUserData)
 {
@@ -226,6 +228,7 @@ ezResult ezDataDirectory::ArchiveReaderZstd::InternalOpen()
   return EZ_SUCCESS;
 }
 
+#endif
 
 EZ_STATICLINK_FILE(Foundation, Foundation_IO_Archive_Implementation_DataDirTypeArchive);
 

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -195,7 +195,7 @@ public:
   static const ezColor Yellow;               ///< #FFFF00
   static const ezColor YellowGreen;          ///< #9ACD32
 
-  // A simple color table with 4 batchs of 8 colors from light to dark. I.e., each
+  // A simple color table with 4 batches of 8 colors from light to dark. I.e., each
   // batch contains the same 8 colors but of increasingly darker shade. E.g., the
   // first batch (from index 0) contains lighter versions of the colors in the
   // second batch (from index 8).

--- a/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.h
@@ -4,11 +4,11 @@
 
 #include <Foundation/Basics.h>
 
-#include <Foundation/Reflection/Implementation/RTTI.h>
 #include <Foundation/Containers/HashSet.h>
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Containers/Set.h>
+#include <Foundation/Reflection/Implementation/RTTI.h>
 #include <Foundation/Types/Bitflags.h>
 #include <Foundation/Types/Enum.h>
 
@@ -46,7 +46,7 @@ struct ezPropertyFlags
 {
   typedef ezUInt16 StorageType;
 
-  enum Enum
+  enum Enum : ezUInt16
   {
     StandardType = EZ_BIT(0), ///< Anything that can be stored inside an ezVariant except for pointers and containers.
     IsEnum = EZ_BIT(1),       ///< enum property, cast to ezAbstractEnumerationProperty.
@@ -60,8 +60,11 @@ struct ezPropertyFlags
     PointerOwner = EZ_BIT(7), ///< This pointer property takes ownership of the passed pointer.
     ReadOnly = EZ_BIT(8),     ///< Can only be read but not modified.
     Hidden = EZ_BIT(9),       ///< This property should not appear in the UI.
-    Phantom = EZ_BIT(10), ///< Phantom types are mirrored types on the editor side. Ie. they do not exist as actual classes in the process.
-                          ///< Also used for data driven types, e.g. by the Visual Shader asset.
+    Phantom = EZ_BIT(10),     ///< Phantom types are mirrored types on the editor side. Ie. they do not exist as actual classes in the process. Also used for data driven types, e.g. by the Visual Shader asset.
+
+    VarOut = EZ_BIT(11),   ///< Tag for non-const-ref function parameters to indicate usage 'out'
+    VarInOut = EZ_BIT(12), ///< Tag for non-const-ref function parameters to indicate usage 'inout'
+
     Default = 0,
     Void = 0
   };
@@ -174,8 +177,8 @@ public:
   /// \brief Adds attributes to the property. Returns itself to allow to be called during initialization. Allocate an attribute using
   /// standard 'new'.
   ezAbstractProperty* AddAttributes(ezPropertyAttribute* pAttrib1, ezPropertyAttribute* pAttrib2 = nullptr,
-                                    ezPropertyAttribute* pAttrib3 = nullptr, ezPropertyAttribute* pAttrib4 = nullptr,
-                                    ezPropertyAttribute* pAttrib5 = nullptr, ezPropertyAttribute* pAttrib6 = nullptr)
+    ezPropertyAttribute* pAttrib3 = nullptr, ezPropertyAttribute* pAttrib4 = nullptr,
+    ezPropertyAttribute* pAttrib5 = nullptr, ezPropertyAttribute* pAttrib6 = nullptr)
   {
     EZ_ASSERT_DEV(pAttrib1 != nullptr, "invalid attribute");
 
@@ -212,7 +215,7 @@ class EZ_FOUNDATION_DLL ezAbstractConstantProperty : public ezAbstractProperty
 public:
   /// \brief Passes the property name through to ezAbstractProperty.
   ezAbstractConstantProperty(const char* szPropertyName)
-      : ezAbstractProperty(szPropertyName)
+    : ezAbstractProperty(szPropertyName)
   {
   }
 
@@ -236,7 +239,7 @@ class EZ_FOUNDATION_DLL ezAbstractMemberProperty : public ezAbstractProperty
 public:
   /// \brief Passes the property name through to ezAbstractProperty.
   ezAbstractMemberProperty(const char* szPropertyName)
-      : ezAbstractProperty(szPropertyName)
+    : ezAbstractProperty(szPropertyName)
   {
   }
 
@@ -272,7 +275,7 @@ class EZ_FOUNDATION_DLL ezAbstractArrayProperty : public ezAbstractProperty
 public:
   /// \brief Passes the property name through to ezAbstractProperty.
   ezAbstractArrayProperty(const char* szPropertyName)
-      : ezAbstractProperty(szPropertyName)
+    : ezAbstractProperty(szPropertyName)
   {
   }
 
@@ -310,7 +313,7 @@ class EZ_FOUNDATION_DLL ezAbstractSetProperty : public ezAbstractProperty
 public:
   /// \brief Passes the property name through to ezAbstractProperty.
   ezAbstractSetProperty(const char* szPropertyName)
-      : ezAbstractProperty(szPropertyName)
+    : ezAbstractProperty(szPropertyName)
   {
   }
 
@@ -345,7 +348,7 @@ class EZ_FOUNDATION_DLL ezAbstractMapProperty : public ezAbstractProperty
 public:
   /// \brief Passes the property name through to ezAbstractProperty.
   ezAbstractMapProperty(const char* szPropertyName)
-      : ezAbstractProperty(szPropertyName)
+    : ezAbstractProperty(szPropertyName)
   {
   }
 
@@ -520,7 +523,7 @@ class ezAbstractFunctionProperty : public ezAbstractProperty
 public:
   /// \brief Passes the property name through to ezAbstractProperty.
   ezAbstractFunctionProperty(const char* szPropertyName)
-      : ezAbstractProperty(szPropertyName)
+    : ezAbstractProperty(szPropertyName)
   {
   }
 
@@ -553,4 +556,3 @@ public:
 
   virtual const ezRTTI* GetSpecificType() const override { return GetReturnType(); }
 };
-

--- a/Code/Engine/Foundation/Reflection/Implementation/MessageHandler.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/MessageHandler.h
@@ -23,6 +23,10 @@ public:
 
   EZ_ALWAYS_INLINE bool IsConst() const { return m_bIsConst; }
 
+  // needed for a linked list of 'additional' message handlers in ezRTTI
+  // see _ezScriptFunctionRegistrar
+  ezAbstractMessageHandler* m_pLinkedMsgHandler = nullptr;
+
 protected:
   typedef void (*DispatchFunc)(void*, ezMessage&);
   typedef void (*ConstDispatchFunc)(const void*, ezMessage&);
@@ -43,6 +47,20 @@ struct ezMessageSenderInfo
 
 namespace ezInternal
 {
+  /// \internal Used to add elements to ezRTTI::m_pAdditionalMessageHandlers
+  template <typename ClassName>
+  struct ezScriptFunctionRegistrar
+  {
+    inline ezScriptFunctionRegistrar(ezAbstractMessageHandler* pHandler)
+    {
+      const ezRTTI* pRtti = ClassName::GetStaticRTTI();
+
+      // extend the linked list
+      pHandler->m_pLinkedMsgHandler = pRtti->m_pAdditionalMessageHandlers;
+      pRtti->m_pAdditionalMessageHandlers = pHandler;
+    }
+  };
+
   template <typename Class, typename MessageType>
   struct MessageHandlerTraits
   {

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
@@ -20,6 +20,12 @@ class ezPropertyAttribute;
 class ezMessage;
 typedef ezUInt16 ezMessageId;
 
+namespace ezInternal
+{
+  template <typename ClassName>
+  struct ezScriptFunctionRegistrar;
+}
+
 /// \brief This enumerable class holds information about reflected types. Each instance represents one type that is known to the reflection
 /// system.
 ///
@@ -34,10 +40,10 @@ class EZ_FOUNDATION_DLL ezRTTI : public ezEnumerable<ezRTTI>
 public:
   /// \brief The constructor requires all the information about the type that this object represents.
   ezRTTI(const char* szName, const ezRTTI* pParentType, ezUInt32 uiTypeSize, ezUInt32 uiTypeVersion, ezUInt32 uiVariantType,
-         ezBitflags<ezTypeFlags> flags, ezRTTIAllocator* pAllocator, ezArrayPtr<ezAbstractProperty*> properties,
-         ezArrayPtr<ezAbstractFunctionProperty*> functions, ezArrayPtr<ezPropertyAttribute*> attributes,
-         ezArrayPtr<ezAbstractMessageHandler*> messageHandlers, ezArrayPtr<ezMessageSenderInfo> messageSenders,
-         const ezRTTI* (*fnVerifyParent)());
+    ezBitflags<ezTypeFlags> flags, ezRTTIAllocator* pAllocator, ezArrayPtr<ezAbstractProperty*> properties,
+    ezArrayPtr<ezAbstractFunctionProperty*> functions, ezArrayPtr<ezPropertyAttribute*> attributes,
+    ezArrayPtr<ezAbstractMessageHandler*> messageHandlers, ezArrayPtr<ezMessageSenderInfo> messageSenders,
+    const ezRTTI* (*fnVerifyParent)());
 
 
   ~ezRTTI();
@@ -65,15 +71,15 @@ public:
 
   /// \brief Returns true if this type is derived from or identical to the given type.
   template <typename BASE>
-  EZ_ALWAYS_INLINE bool IsDerivedFrom() const
+  EZ_ALWAYS_INLINE bool IsDerivedFrom() const // [tested]
   {
     return IsDerivedFrom(ezGetStaticRTTI<BASE>());
-  } // [tested]
+  }
 
   /// \brief Returns the object through which instances of this type can be allocated.
   EZ_ALWAYS_INLINE ezRTTIAllocator* GetAllocator() const { return m_pAllocator; } // [tested]
 
-  /// \brief Returns the array of properties that this type has. Does NOT include properties from base classes.
+  /// \brief Returns the array of properties that this type has. Does NOT include properties from base classes. MAY include nullptr properties!
   EZ_ALWAYS_INLINE const ezArrayPtr<ezAbstractProperty*>& GetProperties() const { return m_Properties; } // [tested]
 
   EZ_ALWAYS_INLINE const ezArrayPtr<ezAbstractFunctionProperty*>& GetFunctions() const { return m_Functions; }
@@ -147,7 +153,7 @@ protected:
   ezArrayPtr<ezAbstractFunctionProperty*> m_Functions;
   ezArrayPtr<ezPropertyAttribute*> m_Attributes;
   void UpdateType(const ezRTTI* pParentType, ezUInt32 uiTypeSize, ezUInt32 uiTypeVersion, ezUInt32 uiVariantType,
-                  ezBitflags<ezTypeFlags> flags);
+    ezBitflags<ezTypeFlags> flags);
   void RegisterType(ezRTTI* pType);
   void UnregisterType(ezRTTI* pType);
 
@@ -172,9 +178,17 @@ protected:
 
   ezArrayPtr<ezAbstractMessageHandler*> m_MessageHandlers;
   ezDynamicArray<ezAbstractMessageHandler*, ezStaticAllocatorWrapper>
-      m_DynamicMessageHandlers; // do not track this data, it won't be deallocated before shutdown
+    m_DynamicMessageHandlers; // do not track this data, it won't be deallocated before shutdown
 
   ezArrayPtr<ezMessageSenderInfo> m_MessageSenders;
+
+  // singly linked list of message handlers that may be added after initial setup of the RTTI type
+  // used for script function registration, to require minimal effort from the user
+  // appended to by ezScriptFunctionRegistrar
+  mutable ezAbstractMessageHandler* m_pAdditionalMessageHandlers = nullptr;
+
+  template <typename ClassName>
+  friend struct ezInternal::ezScriptFunctionRegistrar;
 
 private:
   EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(Foundation, Reflection);
@@ -295,4 +309,3 @@ private:
     return EZ_NEW(pAllocator, CLASS, *static_cast<const CLASS*>(pObject));
   }
 };
-

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -980,6 +980,8 @@ void ezReflectionUtils::GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ez
   for (ezUInt32 i = 0; i < uiCount; ++i)
   {
     ezAbstractProperty* prop = rttiProps[i];
+    if (prop == nullptr)
+      continue;
     if (prop->GetFlags().IsSet(ezPropertyFlags::StandardType))
       continue;
     if (prop->GetAttributeByType<ezTemporaryAttribute>() != nullptr)

--- a/Code/Engine/GameEngine/Animation/Implementation/TransformComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Implementation/TransformComponent.cpp
@@ -19,7 +19,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTransformComponent, 2, ezRTTINoAllocator)
     EZ_ACCESSOR_PROPERTY("AutoToggleDirection", GetAutoToggleDirection, SetAutoToggleDirection), // If true, the animation might stop at start/end points, but set toggle its direction state. Triggering the animation again, means it will run in the reverse direction.
   }
   EZ_END_PROPERTIES;
-    EZ_BEGIN_ATTRIBUTES
+  EZ_BEGIN_ATTRIBUTES
   {
     new ezCategoryAttribute("Transform"),
   }
@@ -57,33 +57,33 @@ ezTransformComponent::ezTransformComponent()
   m_AnimationTime.SetZero();
 }
 
-void ezTransformComponent::ResumeAnimation()
+EZ_SCRIPTABLE_FUNCTION_IMPL_VOID(ezTransformComponent, ResumeAnimation)
 {
   m_Flags.Add(ezTransformComponentFlags::Autorun);
   m_Flags.Remove(ezTransformComponentFlags::Paused);
 }
 
-void ezTransformComponent::SetAnimationPaused(bool bPaused)
+EZ_SCRIPTABLE_FUNCTION_IMPL_VOID(ezTransformComponent, SetAnimationPaused, bool, bPaused)
 {
   m_Flags.AddOrRemove(ezTransformComponentFlags::Paused, bPaused);
 }
 
-void ezTransformComponent::SetDirectionForwards(bool bForwards)
+EZ_SCRIPTABLE_FUNCTION_IMPL_VOID(ezTransformComponent, SetDirectionForwards, bool, bForwards)
 {
   m_Flags.AddOrRemove(ezTransformComponentFlags::AnimationReversed, !bForwards);
 }
 
-void ezTransformComponent::ReverseDirection()
+EZ_SCRIPTABLE_FUNCTION_IMPL_VOID(ezTransformComponent, ReverseDirection)
 {
   m_Flags.AddOrRemove(ezTransformComponentFlags::AnimationReversed, !m_Flags.IsAnySet(ezTransformComponentFlags::AnimationReversed));
 }
 
-bool ezTransformComponent::IsDirectionForwards() const
+EZ_SCRIPTABLE_FUNCTION_IMPL(bool, ezTransformComponent, IsDirectionForwards) const
 {
   return !m_Flags.IsAnySet(ezTransformComponentFlags::AnimationReversed);
 }
 
-bool ezTransformComponent::IsAnimationRunning() const
+EZ_SCRIPTABLE_FUNCTION_IMPL(bool, ezTransformComponent, IsAnimationRunning) const
 {
   return m_Flags.IsAnySet(ezTransformComponentFlags::Autorun);
 }
@@ -171,71 +171,6 @@ float CalculateAcceleratedMovement(
 
   // return the distance with the decelerated movement
   return fDistanceInMeters - 0.5f * fDeceleration * ezMath::Square(fDecTime - fDecTime2);
-}
-
-//////////////////////////////////////////////////////////////////////////
-
-// clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptNode_TransformComponent, 1, ezRTTIDefaultAllocator<ezVisualScriptNode_TransformComponent>)
-{
-  EZ_BEGIN_ATTRIBUTES
-  {
-    new ezCategoryAttribute("Components/Transform")
-  }
-  EZ_END_ATTRIBUTES;
-  EZ_BEGIN_PROPERTIES
-  {
-    EZ_INPUT_EXECUTION_PIN("Play", 0),
-    EZ_INPUT_EXECUTION_PIN("Pause", 1),
-    EZ_INPUT_EXECUTION_PIN("Reverse", 2),
-    EZ_INPUT_DATA_PIN("Component", 0, ezVisualScriptDataPinType::ComponentHandle),
-  }
-  EZ_END_PROPERTIES;
-}
-EZ_END_DYNAMIC_REFLECTED_TYPE;
-// clang-format on
-
-ezVisualScriptNode_TransformComponent::ezVisualScriptNode_TransformComponent() {}
-
-void ezVisualScriptNode_TransformComponent::Execute(ezVisualScriptInstance* pInstance, ezUInt8 uiExecPin)
-{
-  if (m_hComponent.IsInvalidated())
-    return;
-
-  ezComponent* pComponent = nullptr;
-  if (!pInstance->GetWorld()->TryGetComponent(m_hComponent, pComponent))
-    return;
-
-  if (!pComponent->GetDynamicRTTI()->IsDerivedFrom<ezTransformComponent>())
-    return;
-
-  ezTransformComponent* pTransform = static_cast<ezTransformComponent*>(pComponent);
-
-  switch (uiExecPin)
-  {
-    case 0:
-      pTransform->ResumeAnimation();
-      return;
-
-    case 1:
-      pTransform->SetAnimationPaused(true);
-      return;
-
-    case 2:
-      pTransform->ReverseDirection();
-      return;
-  }
-}
-
-void* ezVisualScriptNode_TransformComponent::GetInputPinDataPointer(ezUInt8 uiPin)
-{
-  switch (uiPin)
-  {
-    case 0:
-      return &m_hComponent;
-  }
-
-  return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/GameEngine/Animation/TransformComponent.h
+++ b/Code/Engine/GameEngine/Animation/TransformComponent.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <GameEngine/GameEngineDLL.h>
-#include <Core/World/World.h>
 #include <Core/World/Component.h>
+#include <Core/World/World.h>
+#include <Foundation/Communication/ScriptableFunctionBinding.h>
 #include <Foundation/Time/Time.h>
+#include <GameEngine/GameEngineDLL.h>
 #include <GameEngine/VisualScript/VisualScriptNode.h>
 
 struct ezTransformComponentFlags
@@ -12,14 +13,14 @@ struct ezTransformComponentFlags
 
   enum Enum
   {
-    None                = 0,
-    Autorun             = EZ_BIT(0),
-    AutoReturnStart     = EZ_BIT(1),
-    AutoReturnEnd       = EZ_BIT(2),
+    None = 0,
+    Autorun = EZ_BIT(0),
+    AutoReturnStart = EZ_BIT(1),
+    AutoReturnEnd = EZ_BIT(2),
     AutoToggleDirection = EZ_BIT(3),
-    Paused              = EZ_BIT(4),
-    AnimationReversed   = EZ_BIT(5),
-    Default             = Autorun | AutoReturnStart | AutoReturnEnd | AutoToggleDirection
+    Paused = EZ_BIT(4),
+    AnimationReversed = EZ_BIT(5),
+    Default = Autorun | AutoReturnStart | AutoReturnEnd | AutoToggleDirection
   };
 
   struct Bits
@@ -68,27 +69,10 @@ protected:
   // ************************************* FUNCTIONS *****************************
 
 public:
-  void ResumeAnimation();
-  void SetAnimationPaused(bool bPaused);
-  void SetDirectionForwards(bool bForwards);
-  void ReverseDirection();
-  bool IsDirectionForwards() const;
-  bool IsAnimationRunning() const;
+  EZ_SCRIPTABLE_FUNCTION_DECL_VOID(ResumeAnimation);
+  EZ_SCRIPTABLE_FUNCTION_DECL_VOID(SetAnimationPaused, bool, bPaused);
+  EZ_SCRIPTABLE_FUNCTION_DECL_VOID(SetDirectionForwards, bool, bForwards);
+  EZ_SCRIPTABLE_FUNCTION_DECL_VOID(ReverseDirection);
+  EZ_SCRIPTABLE_FUNCTION_DECL(bool, IsDirectionForwards) const;
+  EZ_SCRIPTABLE_FUNCTION_DECL(bool, IsAnimationRunning) const;
 };
-
-
-//////////////////////////////////////////////////////////////////////////
-
-class EZ_GAMEENGINE_DLL ezVisualScriptNode_TransformComponent : public ezVisualScriptNode
-{
-  EZ_ADD_DYNAMIC_REFLECTION(ezVisualScriptNode_TransformComponent, ezVisualScriptNode);
-public:
-  ezVisualScriptNode_TransformComponent();
-
-  virtual void Execute(ezVisualScriptInstance* pInstance, ezUInt8 uiExecPin) override;
-  virtual void* GetInputPinDataPointer(ezUInt8 uiPin) override;
-
-  ezComponentHandle m_hComponent;
-};
-
-

--- a/Code/Engine/GameEngine/VisualScript/VisualScriptNode.h
+++ b/Code/Engine/GameEngine/VisualScript/VisualScriptNode.h
@@ -28,7 +28,10 @@ public:
   virtual void HandleMessage(ezMessage* pMsg);
 
   /// \brief Whether the node has an execution pin (input or output) and thus must be stepped manually. Otherwise it will be implicitly executed on demand.
-  bool IsManuallyStepped() const;
+  ///
+  /// By default this is determined by checking the properties of the ezVisualScriptNode for attributes of type ezVisScriptExecPinOutAttribute
+  /// and ezVisScriptExecPinInAttribute. If those exist, it is a manually stepped node. However, derived types can override this to use other criteria.
+  virtual bool IsManuallyStepped() const;
 
 protected:
 
@@ -61,6 +64,7 @@ public:
 
   virtual void Execute(ezVisualScriptInstance* pInstance, ezUInt8 uiExecPin) override;
   virtual void* GetInputPinDataPointer(ezUInt8 uiPin) override;
+  virtual bool IsManuallyStepped() const override { return true; }
 
   ezGameObjectHandle m_hObject;
   ezComponentHandle m_hComponent;

--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
@@ -673,7 +673,7 @@ void ezQtNodeScene::OpenSearchMenu(QPoint screenPos)
   connect(pSearchMenu, &ezQtSearchableMenu::MenuItemTriggered, this, &ezQtNodeScene::OnMenuItemTriggered);
   connect(pSearchMenu, &ezQtSearchableMenu::MenuItemTriggered, this, [&menu]() { menu.close(); });
 
-  ezStringBuilder sFullName;
+  ezStringBuilder sFullName, sCleanName;
 
   ezHybridArray<const ezRTTI*, 32> types;
   m_pManager->GetCreateableTypes(types);
@@ -690,8 +690,14 @@ void ezQtNodeScene::OpenSearchMenu(QPoint screenPos)
     if (szUnderscore != nullptr)
       szCleanName = szUnderscore + 1;
 
+    sCleanName = szCleanName;
+    if (const char* szBracket = sCleanName.FindLastSubString("<"))
+    {
+      sCleanName.SetSubString_FromTo(sCleanName.GetData(), szBracket);
+    }
+
     sFullName = m_pManager->GetTypeCategory(pRtti);
-    sFullName.AppendPath(szCleanName);
+    sFullName.AppendPath(sCleanName);
 
     pSearchMenu->AddItem(sFullName, qVariantFromValue((void*)pRtti));
   }

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ToolsReflectionUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ToolsReflectionUtils.cpp
@@ -168,6 +168,9 @@ void ezToolsReflectionUtils::GetReflectedTypeDescriptorFromRtti(const ezRTTI* pR
   {
     ezAbstractProperty* prop = rttiProps[i];
 
+    if (prop == nullptr)
+      continue;
+
     switch (prop->GetCategory())
     {
       case ezPropertyCategory::Constant:

--- a/Data/Samples/Testing Chambers/Meshes/Light Sphere.ezMeshAsset
+++ b/Data/Samples/Testing Chambers/Meshes/Light Sphere.ezMeshAsset
@@ -1,0 +1,213 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{7723535002489422739,5263681251314332144}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Mesh"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{7723535002489422739,5263681251314332144}}
+		u4 %Hash{12136702097426444381}
+		VarArray %MetaInfo{}
+		VarArray %Outputs{}
+		VarArray %References
+		{
+			s{"{ 4795f5c4-4a78-4c13-937e-cf3e6bdecb7c }"}
+		}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{9554845373131879077,4839533822638976188}}
+	s %t{"ezMeshAssetProperties"}
+	u3 %v{3}
+	p
+	{
+		Angle %Angle{f{0xDB0FC940}}
+		b %Cap{1}
+		b %Cap2{1}
+		u2 %Detail{2}
+		u2 %Detail2{1}
+		s %ForwardDir{"ezBasisAxis::NegativeZ"}
+		f %Height{0x0000A040}
+		b %ImportMaterials{1}
+		b %InvertNormals{0}
+		VarArray %Materials
+		{
+			Uuid{u4{8796304639344586903,5492146054807263649}}
+		}
+		s %MeshFile{""}
+		Vec3 %NonUniformScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		s %PrimitiveType{"ezMeshPrimitive::GeodesicSphere"}
+		f %Radius{0x00000040}
+		f %Radius2{0x0000003F}
+		b %RecalculateNormals{0}
+		s %RightDir{"ezBasisAxis::PositiveX"}
+		s %SubmeshName{""}
+		f %UniformScaling{0x0000803F}
+		s %UpDir{"ezBasisAxis::PositiveY"}
+		b %UseSubfolderForMaterialImport{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8796304639344586903,5492146054807263649}}
+	s %t{"ezMaterialResourceSlot"}
+	u3 %v{1}
+	p
+	{
+		s %Label{"Default"}
+		s %Resource{"{ 4795f5c4-4a78-4c13-937e-cf3e6bdecb7c }"}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{9554845373131879077,4839533822638976188}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{3975990526721687754,926589309994965004}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshPrimitive"}
+		u3 %TypeSize{1}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5578311699685810862,3953450409323753049}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshAssetProperties"}
+		u3 %TypeSize{1248}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeSize{72}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7523378465055293707,11345788873737253128}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialResourceSlot"}
+		u3 %TypeSize{128}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeSize{1}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14469700887475489738,16951777026318265606}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBasisAxis"}
+		u3 %TypeSize{1}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeSize{8}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Scenes/Corridor.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Corridor.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{13806862923700048634}
+		u4 %Hash{13950850507231259697}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %References
@@ -20,6 +20,7 @@ o
 			s{"{ 0bbfbc3c-b5e2-4194-af38-84e13516bbc2 }"}
 			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
 			s{"{ 21e7efd6-6d5e-4f03-a4d1-7a430ceb0f8a }"}
+			s{"{ 2cd20eb7-c453-436f-9912-13dc7c1c8867 }"}
 			s{"{ 2d50dee8-5549-4755-bbce-4cc39624919c }"}
 			s{"{ 3bf60313-2bce-45cf-8836-68e3b9ef5323 }"}
 			s{"{ 3eed317b-10cd-4752-8e7d-6fc6460beba0 }"}
@@ -36,8 +37,11 @@ o
 			s{"{ a14fde66-a586-4ab3-96fa-18612f2d744d }"}
 			s{"{ ad417552-5eb2-4bec-81d8-3960872cd7db }"}
 			s{"{ afb2a2a5-e863-4c47-a2f7-002d7dea6162 }"}
+			s{"{ b394c1d7-4e3c-bda8-fee7-e493291f135a }"}
 			s{"{ b579c3bb-6d40-485d-a91d-ae15b15337a9 }"}
 			s{"{ baf34fd7-9f42-4d8d-a95e-e94afd972d1d }"}
+			s{"{ bb7971f0-5a35-490c-9383-ade929822f6b }"}
+			s{"{ c75fd9fb-43d7-4023-a5c0-ccb045a9fd76 }"}
 			s{"{ cb3fcb70-258b-4b4e-a79e-0537ace7d7e3 }"}
 			s{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
 			s{"{ e12eff21-6f53-4b0e-8dc4-4e9f9852d224 }"}
@@ -3914,6 +3918,35 @@ o
 }
 o
 {
+	Uuid %id{u4{17715179716130732451,4865467952141208973}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{7296678144393699734,5147981458818267477}}
+		}
+		VarArray %Components
+		{
+			Uuid{u4{13139697473042292409,5090908748948016218}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0xFEFF7F3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{16999124176144903056,4868634521426597142}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -4064,6 +4097,19 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{13309309453598365102,4886154491682857586}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		VarArray %Materials{}
+		s %Mesh{"{ c75fd9fb-43d7-4023-a5c0-ccb045a9fd76 }"}
 	}
 }
 o
@@ -4462,6 +4508,72 @@ o
 }
 o
 {
+	Uuid %id{u4{14669402842152521866,4959568733202638028}}
+	s %t{"ezSpotLightComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		b %CastShadows{0}
+		f %ConstantBias{0xCDCCCC3D}
+		Angle %InnerSpotAngle{f{0x920A863E}}
+		f %Intensity{0x0000C842}
+		ColorGamma %LightColor{u1{75,144,255,255}}
+		Angle %OuterSpotAngle{f{0x920A063F}}
+		f %PenumbraSize{0xCDCCCC3D}
+		f %Range{0}
+		f %SlopeBias{0x0000803E}
+	}
+}
+o
+{
+	Uuid %id{u4{9127397338303761042,4961329220355244242}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{866706135352698770,5724140116981524480}}
+			Uuid{u4{12648223579933950122,5003351818784289604}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15977599724903618709,4969007581712737443}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		b %AutoToggleDirection{0}
+		s %Axis{"ezBasisAxis::NegativeZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{0}
+		b %ReverseAtStart{0}
+		b %RunAtStartup{0}
+		f %Speed{0x0000A041}
+	}
+}
+o
+{
 	Uuid %id{u4{8100488291317450661,4973837629483089080}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -4664,6 +4776,20 @@ o
 		b %Active{1}
 		VarDict %Parameters{}
 		s %Prefab{"{ 40197e82-5fa5-4045-99d5-f24a2475497a }"}
+	}
+}
+o
+{
+	Uuid %id{u4{12648223579933950122,5003351818784289604}}
+	s %t{"ezPxShapeSphereComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		u1 %CollisionLayer{9}
+		s %OnContact{""}
+		f %Radius{0x00002040}
+		s %Surface{""}
 	}
 }
 o
@@ -4959,13 +5085,14 @@ o
 {
 	Uuid %id{u4{12310385124625322932,5041087509723627308}}
 	s %t{"ezRotorComponent"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		f %Acceleration{0}
 		b %Active{1}
 		b %AutoToggleDirection{0}
 		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
 		f %Deceleration{0}
 		i3 %DegreesToRotate{0}
 		b %ReverseAtEnd{0}
@@ -5153,6 +5280,32 @@ o
 		Quat %LocalRotation{f{0xF20435BF,0,0xF3043533,0xF304353F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4421026007385005984,5063528390582528297}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7691752133548455845,5313795979682572059}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x8F62ED3F,0x8F62EDB3,0x0000C034}}
+		Quat %LocalRotation{f{0,0,0,0xFEFF7F3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000C03F}
 		s %Mode{"ezObjectMode::Automatic"}
 		s %Name{""}
 		VarArray %Tags
@@ -5455,6 +5608,26 @@ o
 }
 o
 {
+	Uuid %id{u4{13139697473042292409,5090908748948016218}}
+	s %t{"ezSliderComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0xCDCCCC3D}
+		b %Active{1}
+		b %AutoToggleDirection{0}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		f %Deceleration{0xCDCCCC3D}
+		f %Distance{0xCDCCCC3D}
+		Time %RandomStart{d{0}}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %RunAtStartup{0}
+		f %Speed{0xCDCC4C3D}
+	}
+}
+o
+{
 	Uuid %id{u4{16757054039035357318,5101372467938238828}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{3}
@@ -5731,6 +5904,32 @@ o
 }
 o
 {
+	Uuid %id{u4{7296678144393699734,5147981458818267477}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13309309453598365102,4886154491682857586}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0x935F8A3D,0x1534A63D,0xE5AFB4BB,0x8C907E3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x8FC2753C}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{3708193764072832985,5159712897391056403}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -5952,6 +6151,19 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{17431479384853566637,5204058001119520889}}
+	s %t{"ezVisualScriptComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		b %HandleGlobalEvents{0}
+		VarDict %Parameters{}
+		s %Script{"{ 2cd20eb7-c453-436f-9912-13dc7c1c8867 }"}
 	}
 }
 o
@@ -6326,6 +6538,22 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{7691752133548455845,5313795979682572059}}
+	s %t{"ezMeshComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x8FFFA03E,0xB68A9F3F,0x45038F40,0x0000803F}}
+		VarArray %Materials
+		{
+			s{"{ b394c1d7-4e3c-bda8-fee7-e493291f135a }"}
+		}
+		s %Mesh{"{ bb7971f0-5a35-490c-9383-ade929822f6b }"}
 	}
 }
 o
@@ -6800,6 +7028,37 @@ o
 		s %GlobalKey{""}
 		Vec3 %LocalPosition{f{0x0000CA41,0x000030C1,0x0000A840}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3350852949908309662,5413563985040122476}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{17715179716130732451,4865467952141208973}}
+			Uuid{u4{9127397338303761042,4961329220355244242}}
+		}
+		VarArray %Components
+		{
+			Uuid{u4{15977599724903618709,4969007581712737443}}
+			Uuid{u4{17431479384853566637,5204058001119520889}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0000B841,0x00009AC1,0x4AC19C3F}}
+		Quat %LocalRotation{f{0x68B9D83C,0xD4929EBC,0xB67D4EBF,0x0A1617BF}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
@@ -7877,13 +8136,14 @@ o
 {
 	Uuid %id{u4{7828322122120970141,5591476348319667789}}
 	s %t{"ezRotorComponent"}
-	u3 %v{2}
+	u3 %v{3}
 	p
 	{
 		f %Acceleration{0}
 		b %Active{1}
 		b %AutoToggleDirection{0}
 		s %Axis{"ezBasisAxis::NegativeZ"}
+		Angle %AxisDeviation{f{0}}
 		f %Deceleration{0}
 		i3 %DegreesToRotate{0}
 		b %ReverseAtEnd{0}
@@ -8031,6 +8291,35 @@ o
 		s %GlobalKey{""}
 		Vec3 %LocalPosition{f{0x00009841,0x00000042,0x0000003F}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15581388527419472022,5634626069867545837}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{4421026007385005984,5063528390582528297}}
+		}
+		VarArray %Components
+		{
+			Uuid{u4{14669402842152521866,4959568733202638028}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xD0F7B741,0xA48699C1,0x1F3E20BF}}
+		Quat %LocalRotation{f{0,0xF20435BF,0xF3043533,0xF304353F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
@@ -8529,6 +8818,18 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{866706135352698770,5724140116981524480}}
+	s %t{"ezPxTriggerComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		b %Kinematic{1}
+		s %TriggerMessage{"PlayerEnter"}
 	}
 }
 o
@@ -9194,6 +9495,8 @@ o
 			Uuid{u4{16228860849447176602,4743277362354764447}}
 			Uuid{u4{8513419777624122695,10331591190739018613}}
 			Uuid{u4{10641499544101636567,14946260972103181663}}
+			Uuid{u4{3350852949908309662,5413563985040122476}}
+			Uuid{u4{15581388527419472022,5634626069867545837}}
 		}
 		Uuid %Settings{u4{11204937990389899402,5417500911553874876}}
 	}
@@ -20855,6 +21158,24 @@ o
 }
 o
 {
+	Uuid %id{u4{14446680793112045351,3506137973542664143}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"ezPhysXPlugin"}
+		VarArray %Properties{}
+		s %TypeName{"ezOnPhysXContact"}
+		u3 %TypeSize{1}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{12988416931910697783,3614107907594852236}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -20880,6 +21201,42 @@ o
 }
 o
 {
+	Uuid %id{u4{13146435625671389871,5145262613012234345}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPxComponent"}
+		s %PluginName{"ezPhysXPlugin"}
+		VarArray %Properties{}
+		s %TypeName{"ezPxShapeComponent"}
+		u3 %TypeSize{96}
+		u3 %TypeVersion{5}
+	}
+}
+o
+{
+	Uuid %id{u4{5109955776826617296,6026817826851389185}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEventMessageHandlerComponent"}
+		u3 %TypeSize{56}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{14006718927935415587,6034394683520582586}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -20893,6 +21250,24 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezVarianceTypeTime"}
 		u3 %TypeSize{16}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10276195715960149106,6149987909253238229}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPxComponent"}
+		s %PluginName{"ezPhysXPlugin"}
+		VarArray %Properties{}
+		s %TypeName{"ezPxActorComponent"}
+		u3 %TypeSize{48}
 		u3 %TypeVersion{1}
 	}
 }
@@ -20983,6 +21358,24 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezSceneDocumentSettings"}
 		u3 %TypeSize{32}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11005437603101136476,7368533338987833088}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBitflagsBase"}
+		u3 %TypeSize{1}
 		u3 %TypeVersion{1}
 	}
 }
@@ -21261,6 +21654,42 @@ o
 }
 o
 {
+	Uuid %id{u4{16906105696366347135,12383969493308773263}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEventMessageHandlerComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualScriptComponent"}
+		u3 %TypeSize{224}
+		u3 %TypeVersion{3}
+	}
+}
+o
+{
+	Uuid %id{u4{14063591547429035251,13671873621033464427}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPxShapeComponent"}
+		s %PluginName{"ezPhysXPlugin"}
+		VarArray %Properties{}
+		s %TypeName{"ezPxShapeSphereComponent"}
+		u3 %TypeSize{104}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{3106992448854867606,14177809816119438754}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -21333,6 +21762,24 @@ o
 }
 o
 {
+	Uuid %id{u4{17070673550512221710,14982893279506273667}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezPhysXPlugin"}
+		VarArray %Properties{}
+		s %TypeName{"ezPxComponent"}
+		u3 %TypeSize{48}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{2947336711354777548,15013008608905564043}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -21399,8 +21846,8 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezRotorComponent"}
-		u3 %TypeSize{96}
-		u3 %TypeVersion{2}
+		u3 %TypeSize{112}
+		u3 %TypeVersion{3}
 	}
 }
 o
@@ -21418,6 +21865,24 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezBasisAxis"}
 		u3 %TypeSize{1}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7428566862802479531,16953577013819886111}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPxActorComponent"}
+		s %PluginName{"ezPhysXPlugin"}
+		VarArray %Properties{}
+		s %TypeName{"ezPxTriggerComponent"}
+		u3 %TypeSize{104}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Samples/Testing Chambers/Scripts/AnimateOnProximity.ezVisualScriptAsset
+++ b/Data/Samples/Testing Chambers/Scripts/AnimateOnProximity.ezVisualScriptAsset
@@ -1,0 +1,531 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{7460244105332986521,4859318384469348023}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Visual Script"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{7460244105332986521,4859318384469348023}}
+		u4 %Hash{13907918596152158996}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{10572254156659245277,18195614921195685160}}
+		}
+		VarArray %Outputs{}
+		VarArray %References{}
+	}
+}
+o
+{
+	Uuid %id{u4{10572254156659245277,18195614921195685160}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters{}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{8155493025362365084,4950459321041252568}}
+	s %t{"VisualScriptNode::ezTransformComponent::SfMsg_SetAnimationPaused<send>"}
+	u3 %v{1}
+	p
+	{
+		Time %Delay{d{0}}
+		VarArray %Node::Connections{}
+		Vec2 %Node::Pos{f{0x8A7D7343,0xC116ED42}}
+		b %Recursive{1}
+		b %bPaused{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3907054453063297935,5180271619085939971}}
+	s %t{"VisualScriptNode::ezVisualScriptNode_PxTriggerEvent"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Node::Connections
+		{
+			Uuid{u4{16960178813939915912,17972781880154427044}}
+			Uuid{u4{17020491390488272460,15929890272681875594}}
+		}
+		Vec2 %Node::Pos{f{0x4D6FD9C2,0x50787ABF}}
+		s %TriggerMessage{"PlayerEnter"}
+	}
+}
+o
+{
+	Uuid %id{u4{5858084899434622124,5180592193588397606}}
+	s %t{"VisualScriptNode::ezTransformComponent::SfMsg_ResumeAnimation<send>"}
+	u3 %v{1}
+	p
+	{
+		Time %Delay{d{0}}
+		VarArray %Node::Connections{}
+		Vec2 %Node::Pos{f{0x56766F43,0x2BDC0EC3}}
+		b %Recursive{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12866748715931612095,5426257630234690300}}
+	s %t{"ezVisualScriptAssetProperties"}
+	u3 %v{1}
+	p
+	{
+		VarArray %BoolParameters{}
+		VarArray %NumberParameters{}
+	}
+}
+o
+{
+	Uuid %id{u4{6478017434873641136,5731391821732679332}}
+	s %t{"VisualScriptNode::ezVisualScriptNode_Log"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Node::Connections{}
+		Vec2 %Node::Pos{f{0xD9EB8344,0x2C3D4D42}}
+		s %Text{"Value1: {0}, Value2: {1}"}
+		d %Value1{0}
+		d %Value2{0}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{12866748715931612095,5426257630234690300}}
+			Uuid{u4{3907054453063297935,5180271619085939971}}
+			Uuid{u4{5858084899434622124,5180592193588397606}}
+			Uuid{u4{8155493025362365084,4950459321041252568}}
+			Uuid{u4{6478017434873641136,5731391821732679332}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{17020491390488272460,15929890272681875594}}
+	s %t{"ConnectionInternal"}
+	u3 %v{1}
+	p
+	{
+		s %SourcePin{"OnDeactivated"}
+		Uuid %Target{u4{8155493025362365084,4950459321041252568}}
+		s %TargetPin{"send"}
+	}
+}
+o
+{
+	Uuid %id{u4{16960178813939915912,17972781880154427044}}
+	s %t{"ConnectionInternal"}
+	u3 %v{1}
+	p
+	{
+		s %SourcePin{"OnActivated"}
+		Uuid %Target{u4{5858084899434622124,5180592193588397606}}
+		s %TargetPin{"send"}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{8732113240502240301,2303958826576729654}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"VisualScriptTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualScriptNodeBase"}
+		u3 %TypeSize{0}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15599825638682874598,2547824520073209735}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Delay"}
+		s %Type{"ezTime"}
+	}
+}
+o
+{
+	Uuid %id{u4{296587147098992468,6141132898438826526}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1579810874233461928,17382669837082181069}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Text"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{11614183841319027127,6205267641758029710}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Const|ezPropertyFlags::Phantom"}
+		s %Name{"TriggerMessage"}
+		s %Type{"ezConstCharPtr"}
+	}
+}
+o
+{
+	Uuid %id{u4{4962765665992557290,6715280353832693008}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualScriptParameter"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualScriptParameterNumber"}
+		u3 %TypeSize{88}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13582417198852453653,7057711126524026311}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualScriptNodeBase"}
+		s %PluginName{"VisualScriptTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{899531686623358321,14717749049036374412}}
+			Uuid{u4{9374903751979799114,10068626647179496000}}
+			Uuid{u4{13716875682524189068,15560471677227423802}}
+		}
+		s %TypeName{"VisualScriptNode::ezTransformComponent::SfMsg_SetAnimationPaused<send>"}
+		u3 %TypeSize{0}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeSize{72}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7040439425406295685,9619530258016208065}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualScriptParameter"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualScriptParameterBool"}
+		u3 %TypeSize{88}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9374903751979799114,10068626647179496000}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"bPaused"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{11227181633145111447,10395068219098614514}}
+	s %t{"ezVisScriptDataPinInAttribute"}
+	u3 %v{1}
+	p
+	{
+		u1 %Slot{0}
+		s %Type{"ezVisualScriptDataPinType::Number"}
+	}
+}
+o
+{
+	Uuid %id{u4{6368621965718573012,11415384275822513235}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualScriptNodeBase"}
+		s %PluginName{"VisualScriptTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{3882968070639578136,16886441184683278188}}
+			Uuid{u4{15599825638682874598,2547824520073209735}}
+		}
+		s %TypeName{"VisualScriptNode::ezTransformComponent::SfMsg_ResumeAnimation<send>"}
+		u3 %TypeSize{0}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11993692835939176881,12150851147140003901}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11227181633145111447,10395068219098614514}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Value1"}
+		s %Type{"double"}
+	}
+}
+o
+{
+	Uuid %id{u4{17135533151767459456,12837951384599239636}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualScriptNodeBase"}
+		s %PluginName{"VisualScriptTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{11993692835939176881,12150851147140003901}}
+			Uuid{u4{12489072460943302532,15175033572131949960}}
+			Uuid{u4{296587147098992468,6141132898438826526}}
+		}
+		s %TypeName{"VisualScriptNode::ezVisualScriptNode_Log"}
+		u3 %TypeSize{0}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1348049192536958413,14323407194349966683}}
+	s %t{"ezVisScriptDataPinInAttribute"}
+	u3 %v{1}
+	p
+	{
+		u1 %Slot{1}
+		s %Type{"ezVisualScriptDataPinType::Number"}
+	}
+}
+o
+{
+	Uuid %id{u4{899531686623358321,14717749049036374412}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Recursive"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{12489072460943302532,15175033572131949960}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1348049192536958413,14323407194349966683}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Value2"}
+		s %Type{"double"}
+	}
+}
+o
+{
+	Uuid %id{u4{13716875682524189068,15560471677227423802}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Delay"}
+		s %Type{"ezTime"}
+	}
+}
+o
+{
+	Uuid %id{u4{852726492910316603,15628122369720123585}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualScriptAssetProperties"}
+		u3 %TypeSize{56}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4184066678543859733,16060427696528311314}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualScriptNodeBase"}
+		s %PluginName{"VisualScriptTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{11614183841319027127,6205267641758029710}}
+		}
+		s %TypeName{"VisualScriptNode::ezVisualScriptNode_PxTriggerEvent"}
+		u3 %TypeSize{0}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3882968070639578136,16886441184683278188}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Member"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Recursive"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{1579810874233461928,17382669837082181069}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Value{"Value1: {0}, Value2: {1}"}
+	}
+}
+o
+{
+	Uuid %id{u4{10970259519099246767,17429395129455586907}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualScriptParameter"}
+		u3 %TypeSize{80}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeSize{8}
+		u3 %TypeVersion{1}
+	}
+}
+}


### PR DESCRIPTION
For an example how to use the macros see TransformComponent.h/.cpp.

The feature aims to make it dead simple to make a function callable from (visual) script.
A couple of smaller additions had to be made in ezRTTI to auto-register message handlers and to ignore null-properties.
Also the visual script system got a little polish to make use of inout / out values properly.

Other than that all the "magic" is simply that the macros generate a dummy message type and message handler behind your back and hook everything up perfectly.

Review at your own risk though.