### PR TITLE
PhysX binaries are now automatically downloaded from GitHub

### DIFF
--- a/Code/BuildSystem/CMake/FindEzPhysX.cmake
+++ b/Code/BuildSystem/CMake/FindEzPhysX.cmake
@@ -7,6 +7,35 @@ if (TARGET ezPhysX::Foundation)
 endif()
 
 set (EZ_PHYSX_DIR "EZ_PHYSX_DIR-NOTFOUND" CACHE PATH "Directory of PhysX installation")
+mark_as_advanced(FORCE EZ_PHYSX_DIR)
+
+ez_pull_architecture_vars()
+
+if ((EZ_PHYSX_DIR STREQUAL "EZ_PHYSX_DIR-NOTFOUND") OR (EZ_PHYSX_DIR STREQUAL ""))
+
+  if (EZ_CMAKE_ARCHITECTURE_32BIT)
+    set (EZ_PHYSX_VER "physx-3.4.2-vc142-win32")
+    set (EZ_PHYSX_SRC "https://github.com/ezEngine/thirdparty/releases/download/PhysX-3.4.2-win32-win64/physx-3.4.2-vc142-win32.zip")
+  endif()
+
+  if (EZ_CMAKE_ARCHITECTURE_64BIT)
+    set (EZ_PHYSX_VER "physx-3.4.2-vc142-win64")
+    set (EZ_PHYSX_SRC "https://github.com/ezEngine/thirdparty/releases/download/PhysX-3.4.2-win32-win64/physx-3.4.2-vc142-win64.zip")
+  endif()
+
+  set (EZ_PHYSX_ZIP "${CMAKE_BINARY_DIR}/${EZ_PHYSX_VER}.zip")
+
+  if (NOT EXISTS(${EZ_PHYSX_ZIP}))
+    message(STATUS "Downloading '${EZ_PHYSX_ZIP}'...")
+    file(DOWNLOAD ${EZ_PHYSX_SRC} ${EZ_PHYSX_ZIP} SHOW_PROGRESS)
+
+    message(STATUS "Extracting '${EZ_PHYSX_ZIP}'...")  
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf ${EZ_PHYSX_ZIP} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  endif()
+  
+  set (EZ_PHYSX_DIR "${CMAKE_BINARY_DIR}/${EZ_PHYSX_VER}" CACHE PATH "Directory of PhysX installation" FORCE)
+  
+endif()
 
 find_path(EZ_PHYSX_DIR PhysX_3.4/Include/PxActor.h
   PATHS

--- a/Code/BuildSystem/CMake/FindEzPhysX.cmake
+++ b/Code/BuildSystem/CMake/FindEzPhysX.cmake
@@ -6,12 +6,12 @@ if (TARGET ezPhysX::Foundation)
 	return()
 endif()
 
-set (EZ_PHYSX_DIR "EZ_PHYSX_DIR-NOTFOUND" CACHE PATH "Directory of PhysX installation")
-mark_as_advanced(FORCE EZ_PHYSX_DIR)
+set (EZ_PHYSX_SDK "EZ_PHYSX_SDK-NOTFOUND" CACHE PATH "Directory of PhysX installation")
+mark_as_advanced(FORCE EZ_PHYSX_SDK)
 
 ez_pull_architecture_vars()
 
-if ((EZ_PHYSX_DIR STREQUAL "EZ_PHYSX_DIR-NOTFOUND") OR (EZ_PHYSX_DIR STREQUAL ""))
+if ((EZ_PHYSX_SDK STREQUAL "EZ_PHYSX_SDK-NOTFOUND") OR (EZ_PHYSX_SDK STREQUAL ""))
 
   if (EZ_CMAKE_ARCHITECTURE_32BIT)
     set (EZ_PHYSX_VER "physx-3.4.2-vc142-win32")
@@ -25,7 +25,7 @@ if ((EZ_PHYSX_DIR STREQUAL "EZ_PHYSX_DIR-NOTFOUND") OR (EZ_PHYSX_DIR STREQUAL ""
 
   set (EZ_PHYSX_ZIP "${CMAKE_BINARY_DIR}/${EZ_PHYSX_VER}.zip")
 
-  if (NOT EXISTS(${EZ_PHYSX_ZIP}))
+  if (NOT EXISTS ${EZ_PHYSX_ZIP})
     message(STATUS "Downloading '${EZ_PHYSX_ZIP}'...")
     file(DOWNLOAD ${EZ_PHYSX_SRC} ${EZ_PHYSX_ZIP} SHOW_PROGRESS)
 
@@ -33,11 +33,11 @@ if ((EZ_PHYSX_DIR STREQUAL "EZ_PHYSX_DIR-NOTFOUND") OR (EZ_PHYSX_DIR STREQUAL ""
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar -xf ${EZ_PHYSX_ZIP} WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
   endif()
   
-  set (EZ_PHYSX_DIR "${CMAKE_BINARY_DIR}/${EZ_PHYSX_VER}" CACHE PATH "Directory of PhysX installation" FORCE)
+  set (EZ_PHYSX_SDK "${CMAKE_BINARY_DIR}/${EZ_PHYSX_VER}" CACHE PATH "Directory of PhysX installation" FORCE)
   
 endif()
 
-find_path(EZ_PHYSX_DIR PhysX_3.4/Include/PxActor.h
+find_path(EZ_PHYSX_SDK PhysX_3.4/Include/PxActor.h
   PATHS
   ${CMAKE_SOURCE_DIR}/Code/ThirdParty/PhysX
 )
@@ -55,18 +55,18 @@ else()
 endif()
 
 
-set (PHYSX_LIB_DIR "${EZ_PHYSX_DIR}/PhysX_3.4/Lib/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
-set (PHYSX_BIN_DIR "${EZ_PHYSX_DIR}/PhysX_3.4/Bin/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
-set (PHYSX_INC_DIR "${EZ_PHYSX_DIR}/PhysX_3.4/Include")
+set (PHYSX_LIB_DIR "${EZ_PHYSX_SDK}/PhysX_3.4/Lib/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
+set (PHYSX_BIN_DIR "${EZ_PHYSX_SDK}/PhysX_3.4/Bin/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
+set (PHYSX_INC_DIR "${EZ_PHYSX_SDK}/PhysX_3.4/Include")
 
-set (PXSHARED_LIB_DIR "${EZ_PHYSX_DIR}/PxShared/Lib/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
-set (PXSHARED_BIN_DIR "${EZ_PHYSX_DIR}/PxShared/Bin/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
-set (PXSHARED_INC_DIR "${EZ_PHYSX_DIR}/PxShared/Include")
+set (PXSHARED_LIB_DIR "${EZ_PHYSX_SDK}/PxShared/Lib/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
+set (PXSHARED_BIN_DIR "${EZ_PHYSX_SDK}/PxShared/Bin/${PX_COMPILER_SUFFIX}${PX_FOLDER_SUFFIX}")
+set (PXSHARED_INC_DIR "${EZ_PHYSX_SDK}/PxShared/Include")
 
 
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ezPhysX DEFAULT_MSG EZ_PHYSX_DIR)
+find_package_handle_standard_args(ezPhysX DEFAULT_MSG EZ_PHYSX_SDK)
 
 if (ezPhysX_FOUND)
 


### PR DESCRIPTION
Prebuilt binaries are stored as 'Releases' in https://github.com/ezEngine/thirdparty.

CMake now checks whether a PhysX binary is needed, selects which one, downloads the zip, extracts it and points the EZ_PHYSX_DIR variable there.
Because that variable is not important for the user anymore, it is marked as 'advanced', so it does not show up in the GUI anymore.

If you want to switch to the automatic distribution, just clear the EZ_PHYSX_DIR variable and rerun "Configure" in CMake.