### PR TITLE
Improvements for Game Object Reference editing experience

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <EditorEngineProcessFramework/EditorEngineProcessFrameworkDLL.h>
+#include <EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h>
 #include <Foundation/Types/Uuid.h>
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
-#include <EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h>
 
 class ezEditorEngineSyncObjectMsg;
 class ezEditorEngineSyncObject;
@@ -111,7 +111,7 @@ protected:
 protected:
   const ezEngineProcessViewContext* GetViewContext(ezUInt32 uiView) const { return uiView >= m_ViewContexts.GetCount() ? nullptr : m_ViewContexts[uiView]; }
 
-  ezGameObjectHandle ResolveStringToGameObjectHandle(const void* pString) const;
+  ezGameObjectHandle ResolveStringToGameObjectHandle(const void* pString, ezComponentHandle hThis, const char* szProperty) const;
 
 private:
   friend class ezEditorEngineSyncObject;
@@ -140,7 +140,7 @@ private:
 private:
   enum Constants
   {
-    ThumbnailSuperscaleFactor = 2, ///< Thumbnail render target size is multiplied by this and then the final image is downscaled again. Needs to be power-of-two.
+    ThumbnailSuperscaleFactor = 2,       ///< Thumbnail render target size is multiplied by this and then the final image is downscaled again. Needs to be power-of-two.
     ThumbnailConvergenceFramesTarget = 4 ///< Due to multi-threaded rendering, this must be at least 2
   };
 
@@ -152,5 +152,25 @@ private:
   ezGALTextureHandle m_hThumbnailColorRT;
   ezGALTextureHandle m_hThumbnailDepthRT;
   bool m_bWorldSimStateBeforeThumbnail = false;
-};
 
+  //////////////////////////////////////////////////////////////////////////
+  // GameObject reference resolution
+private:
+  struct GoReferenceTo
+  {
+    const char* m_szComponentProperty = nullptr;
+    ezUuid m_ReferenceToGameObject;
+  };
+
+  struct GoReferencedBy
+  {
+    const char* m_szComponentProperty = nullptr;
+    ezUuid m_ReferencedByComponent;
+  };
+
+  // Components reference GameObjects
+  mutable ezMap<ezUuid, ezHybridArray<GoReferenceTo, 4>> m_GoRef_ReferencesTo;
+
+  // GameObjects referenced by Components
+  mutable ezMap<ezUuid, ezHybridArray<GoReferencedBy, 4>> m_GoRef_ReferencedBy;
+};

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
@@ -173,4 +173,6 @@ private:
 
   // GameObjects referenced by Components
   mutable ezMap<ezUuid, ezHybridArray<GoReferencedBy, 4>> m_GoRef_ReferencedBy;
+
+  void WorldRttiConverterContextEventHandler(const ezWorldRttiConverterContext::Event& e);
 };

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/WorldRttiConverterContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/WorldRttiConverterContext.cpp
@@ -67,6 +67,12 @@ void* ezWorldRttiConverterContext::CreateObject(const ezUuid& guid, const ezRTTI
     if (m_pWorld->TryGetObject(hObject, pObject))
     {
       RegisterObject(guid, pRtti, pObject);
+
+      Event e;
+      e.m_Type = Event::Type::GameObjectCreated;
+      e.m_ObjectGuid = guid;
+      m_Events.Broadcast(e);
+
       return pObject;
     }
     else
@@ -121,6 +127,11 @@ void ezWorldRttiConverterContext::DeleteObject(const ezUuid& guid)
     auto hObject = m_GameObjectMap.GetHandle(guid);
     UnregisterObject(guid);
     m_pWorld->DeleteObjectNow(hObject);
+
+    Event e;
+    e.m_Type = Event::Type::GameObjectDeleted;
+    e.m_ObjectGuid = guid;
+    m_Events.Broadcast(e);
   }
   else if (pRtti->IsDerivedFrom<ezComponent>())
   {

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h
@@ -35,4 +35,18 @@ public:
   ezEditorGuidEngineHandleMap<ezUInt32> m_ComponentPickingMap;
   ezUInt32 m_uiNextComponentPickingID;
   ezUInt32 m_uiHighlightID;
+
+  struct Event
+  {
+    enum class Type
+    {
+      GameObjectCreated,
+      GameObjectDeleted,
+    };
+
+    Type m_Type;
+    ezUuid m_ObjectGuid;
+  };
+
+  ezEvent<const Event&> m_Events;
 };

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -12,7 +12,7 @@ ezStaticArray<ezWorld*, 64> ezWorld::s_Worlds;
 
 const ezUInt16 c_InvalidWorldIndex = 0xFFFFu;
 
-static ezGameObjectHandle DefaultGameObjectReferenceResolver(const void* pData)
+static ezGameObjectHandle DefaultGameObjectReferenceResolver(const void* pData, ezComponentHandle hThis, const char* szProperty)
 {
   const char* szRef = reinterpret_cast<const char*>(pData);
 

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -164,7 +164,7 @@ namespace ezInternal
     bool m_bReportErrorWhenStaticObjectMoves;
 
     /// \brief Maps some data (given as void*) to an ezGameObjectHandle. Only available in special situations (e.g. editor use cases).
-    ezDelegate<ezGameObjectHandle(const void*)> m_GameObjectReferenceResolver;
+    ezDelegate<ezGameObjectHandle(const void*, ezComponentHandle, const char*)> m_GameObjectReferenceResolver;
 
   public:
     class ReadMarker

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -250,7 +250,7 @@ public:
   /// \brief Returns the associated user data.
   void* GetUserData() const;
 
-  using ReferenceResolver = ezDelegate<ezGameObjectHandle(const void*)>;
+  using ReferenceResolver = ezDelegate<ezGameObjectHandle(const void*, ezComponentHandle hThis, const char* szProperty)>;
 
   /// \brief If set, this delegate can be used to map some data (GUID or string) to an ezGameObjectHandle.
   ///

--- a/Code/Engine/GameEngine/Debugging/Implementation/LineToComponent.cpp
+++ b/Code/Engine/GameEngine/Debugging/Implementation/LineToComponent.cpp
@@ -79,7 +79,7 @@ void ezLineToComponent::SetLineToTargetGuid(const char* szTargetGuid)
   if (!resolver.IsValid())
     return;
 
-  m_hTargetObject = resolver(szTargetGuid);
+  m_hTargetObject = resolver(szTargetGuid, GetHandle(), "Target");
 }
 
 const char* ezLineToComponent::GetLineToTargetGuid() const

--- a/Code/Engine/GameEngine/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/GameEngine/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -79,7 +79,7 @@ void ezPrefabReferenceComponent::SerializeComponent(ezWorldWriter& stream) const
         if (var.IsA<ezString>())
         {
           // and the resolver CAN map this string to a game object handle
-          ezGameObjectHandle hObject = resolver(var.Get<ezString>().GetData());
+          ezGameObjectHandle hObject = resolver(var.Get<ezString>().GetData(), ezComponentHandle(), nullptr);
           if (!hObject.IsInvalidated())
           {
             // write the handle properly to file (this enables correct remapping during deserialization)

--- a/Code/EnginePlugins/PhysXPlugin/Joints/Implementation/PxJointComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Joints/Implementation/PxJointComponent.cpp
@@ -133,7 +133,7 @@ void ezPxJointComponent::SetParentActor(const char* szReference)
     return;
 
   SetUserFlag(0, false);
-  m_hActorA = resolver(szReference);
+  m_hActorA = resolver(szReference, GetHandle(), "ParentActor");
 }
 
 void ezPxJointComponent::SetChildActor(const char* szReference)
@@ -144,7 +144,7 @@ void ezPxJointComponent::SetChildActor(const char* szReference)
     return;
 
   SetUserFlag(1, false);
-  m_hActorB = resolver(szReference);
+  m_hActorB = resolver(szReference, GetHandle(), "ChildActor");
 }
 
 void ezPxJointComponent::SetActors(ezGameObjectHandle hActorA, const ezTransform& localFrameA, ezGameObjectHandle hActorB,


### PR DESCRIPTION
* References now work throughout the full document. They do not depend on the order in which they are created anymore.
* Undo/Redo now works correctly.
* References within Prefabs, passed into prefabs, and passed through prefabs into other prefabs now seem to be working fine, including Undo/Redo.