### PR TITLE
Template document support

### DIFF
--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -9,7 +9,7 @@
 #include <Foundation/Serialization/DdlSerializer.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 #include <ToolsFoundation/Document/DocumentUtils.h>
-#include <Project/ToolsProject.h>
+#include <ToolsFoundation/Project/ToolsProject.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDocumentManager, 1, ezRTTINoAllocator);
@@ -227,17 +227,18 @@ ezStatus ezDocumentManager::CreateOrOpenDocument(bool bCreate, const char* szDoc
         ezString ProjectDirectory = ezToolsProject::GetSingleton()->GetProjectDirectory();
         ezStringBuilder TemplateDocumentPath = ProjectDirectory;
         ezStringBuilder DocumentFileName;
-        TemplateDocumentPath.AppendPath("DocumentTemplates", szDocumentTypeName);
-        TemplateDocumentPath.ChangeFileExtension("ezDocument");
+        TemplateDocumentPath.AppendPath("DocumentTemplates", "Default");
+        ezStringBuilder Temp;
+        TemplateDocumentPath.ChangeFileExtension(sPath.GetFileExtension().GetData(Temp));
 
-        if (ezOSFile::ExistsFile(TemplateDocumentPath.GetData()))
+        if (ezOSFile::ExistsFile(TemplateDocumentPath))
         {
           EZ_PROFILE_SCOPE(szDocumentTypeName);
 
           ezUuid CloneUuid;
-          if (CloneDocument(TemplateDocumentPath.GetData(), sPath.GetData(), CloneUuid).Succeeded())
+          if (CloneDocument(TemplateDocumentPath, sPath, CloneUuid).Succeeded())
           {
-            status = OpenDocument(szDocumentTypeName, sPath.GetData(), out_pDocument, flags, pOpenContext);
+            status = OpenDocument(szDocumentTypeName, sPath, out_pDocument, flags, pOpenContext);
 
             if(status.Failed())
             {

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -9,6 +9,7 @@
 #include <Foundation/Serialization/DdlSerializer.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 #include <ToolsFoundation/Document/DocumentUtils.h>
+#include <Project/ToolsProject.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDocumentManager, 1, ezRTTINoAllocator);
@@ -219,6 +220,41 @@ ezStatus ezDocumentManager::CreateOrOpenDocument(bool bCreate, const char* szDoc
   {
     if (DocumentTypes[i]->m_sDocumentTypeName == szDocumentTypeName)
     {
+      // See if there is a default asset document registered for the type, if so clone
+      // it and use that as the new document instead of creating one from scratch.
+      if (bCreate)
+      {
+        ezString ProjectDirectory = ezToolsProject::GetSingleton()->GetProjectDirectory();
+        ezStringBuilder TemplateDocumentPath = ProjectDirectory;
+        ezStringBuilder DocumentFileName;
+        TemplateDocumentPath.AppendPath("DocumentTemplates", szDocumentTypeName);
+        TemplateDocumentPath.ChangeFileExtension("ezDocument");
+
+        if (ezOSFile::ExistsFile(TemplateDocumentPath.GetData()))
+        {
+          EZ_PROFILE_SCOPE(szDocumentTypeName);
+
+          ezUuid CloneUuid;
+          if (CloneDocument(TemplateDocumentPath.GetData(), sPath.GetData(), CloneUuid).Succeeded())
+          {
+            status = OpenDocument(szDocumentTypeName, sPath.GetData(), out_pDocument, flags, pOpenContext);
+
+            if(status.Failed())
+            {
+              ezLog::SeriousWarning("Couldn't open cloned template document, proceeding with normal creation behavior.");
+            }
+            else
+            {
+              return status;
+            }
+          }
+          else
+          {
+            ezLog::SeriousWarning("Couldn't clone template document, proceeding with normal creation behavior.");
+          }
+        }
+      }
+
       EZ_ASSERT_DEV(DocumentTypes[i]->m_bCanCreate, "This document manager cannot create the document type '{0}'", szDocumentTypeName);
 
       {


### PR DESCRIPTION
The document manager checks now if a template document exists in the "DocumentTemplates" folder in the current project directory. If a document matching the asset type for which a new document is about to be created exists it will clone this document instead of creating one from scratch.