### PR TITLE
Allow preserve coverage option for single channel textures

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
@@ -144,10 +144,14 @@ void ezTextureAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaState
           break;
       }
 
-      if (mapping == ezTexture2DChannelMappingEnum::RGBA1 || mapping == ezTexture2DChannelMappingEnum::R1_G2_B3_A4 ||
+      if (mapping == ezTexture2DChannelMappingEnum::R1 ||
+          mapping == ezTexture2DChannelMappingEnum::RGBA1 || mapping == ezTexture2DChannelMappingEnum::R1_G2_B3_A4 ||
           mapping == ezTexture2DChannelMappingEnum::RGB1_A2 || mapping == ezTexture2DChannelMappingEnum::R1_G2_B3_A4)
       {
-        props["PremultipliedAlpha"].m_Visibility = ezPropertyUiState::Default;
+        if (mapping != ezTexture2DChannelMappingEnum::R1)
+        {
+          props["PremultipliedAlpha"].m_Visibility = ezPropertyUiState::Default;
+        }
 
         if (hasMips)
         {

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -1089,7 +1089,7 @@ void ezImageUtils::GenerateMipMaps(const ezImageView& source, ezImage& target, c
       currentMipMapHeader.SetNumArrayIndices(1);
 
       auto sourceView = source.GetSubImageView(0, face, arrayIndex).GetByteBlobPtr();
-      auto targetView = target.GetSubImageView(0, face, arrayIndex).GetBlobPtr<ezUInt8>();
+      auto targetView = target.GetSubImageView(0, face, arrayIndex).GetByteBlobPtr();
 
       memcpy(targetView.GetPtr(), sourceView.GetPtr(), targetView.GetCount());
 

--- a/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
@@ -87,7 +87,7 @@ ezResult ezTexConvProcessor::Process()
 
     EZ_SUCCEED_OR_RETURN(AdjustHdrExposure(assembledImg));
 
-    EZ_SUCCEED_OR_RETURN(GenerateMipmaps(assembledImg));
+    EZ_SUCCEED_OR_RETURN(GenerateMipmaps(assembledImg, uiNumChannelsUsed));
 
     EZ_SUCCEED_OR_RETURN(PremultiplyAlpha(assembledImg));
 

--- a/Code/Engine/Texture/TexConv/TexConvProcessor.h
+++ b/Code/Engine/Texture/TexConv/TexConvProcessor.h
@@ -47,7 +47,7 @@ private:
   ezResult PremultiplyAlpha(ezImage& image) const;
   ezResult DilateColor2D(ezImage& img) const;
   ezResult Assemble2DSlice(const ezTexConvSliceChannelMapping& mapping, ezUInt32 uiResolutionX, ezUInt32 uiResolutionY, ezColor* pPixelOut) const;
-  ezResult GenerateMipmaps(ezImage& img, ezUInt32 uiNumMips = 0) const;
+  ezResult GenerateMipmaps(ezImage& img, ezUInt32 uiNumChannels, ezUInt32 uiNumMips = 0) const;
 
   //////////////////////////////////////////////////////////////////////////
   // Purely functional


### PR DESCRIPTION
This is useful if you want to have alpha in a separate single channel texture.