### PR TITLE
Cleans up asset document + manager code

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -75,7 +75,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
   TransformState m_TransformState = TransformState::Unknown;
   ezDynamicArray<ezLogEntry> m_LogEntries;
 
-  const ezDocumentTypeDescriptor* m_pDocumentTypeDescriptor = nullptr;
+  const ezAssetDocumentTypeDescriptor* m_pDocumentTypeDescriptor = nullptr;
   ezString m_sAbsolutePath;
   ezString m_sDataDirRelativePath;
 
@@ -254,8 +254,7 @@ public:
   /// \brief Computes the combined hash for the asset and its references. Returns 0 if anything went wrong.
   ezUInt64 GetAssetReferenceHash(ezUuid assetGuid);
 
-  ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile,
-    const ezDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_AssetHash,
+  ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_AssetHash,
     ezUInt64& out_ThumbHash);
   /// \brief Returns the number of assets in the system and how many are in what transform state
   void GetAssetTransformStats(ezUInt32& out_uiNumAssets, ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT>& out_count);

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <Foundation/Application/Config/FileSystemConfig.h>
 #include <EditorFramework/Assets/AssetDocumentInfo.h>
-#include <GameEngine/Configuration/PlatformProfile.h>
+#include <EditorFramework/Assets/AssetDocumentManager.h>
 #include <EditorFramework/Assets/Declarations.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <Foundation/Algorithm/HashHelperString.h>
+#include <Foundation/Application/Config/FileSystemConfig.h>
 #include <Foundation/Configuration/Singleton.h>
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Logging/LogEntry.h>
@@ -16,6 +16,7 @@
 #include <Foundation/Threading/Mutex.h>
 #include <Foundation/Threading/TaskSystem.h>
 #include <Foundation/Time/Timestamp.h>
+#include <GameEngine/Configuration/PlatformProfile.h>
 #include <ToolsFoundation/Document/DocumentManager.h>
 #include <tuple>
 
@@ -53,6 +54,11 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
   ezAssetInfo() = default;
   void Update(ezUniquePtr<ezAssetInfo>& rhs);
 
+  ezAssetDocumentManager* GetManager()
+  {
+    return static_cast<ezAssetDocumentManager*>(m_pDocumentTypeDescriptor->m_pManager);
+  }
+
   enum TransformState
   {
     Unknown = 0,
@@ -69,7 +75,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
   TransformState m_TransformState = TransformState::Unknown;
   ezDynamicArray<ezLogEntry> m_LogEntries;
 
-  ezAssetDocumentManager* m_pManager = nullptr;
+  const ezDocumentTypeDescriptor* m_pDocumentTypeDescriptor = nullptr;
   ezString m_sAbsolutePath;
   ezString m_sDataDirRelativePath;
 
@@ -214,7 +220,6 @@ private:
   ///@{
 
 public:
-
   /// \brief Transforms all assets and writes the lookup tables. If the given platform is empty, the active platform is used.
   void TransformAllAssets(ezBitflags<ezTransformFlags> transformFlags, const ezPlatformProfile* pAssetProfile = nullptr);
   void ResaveAllAssets();
@@ -250,8 +255,8 @@ public:
   ezUInt64 GetAssetReferenceHash(ezUuid assetGuid);
 
   ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile,
-                                              const ezDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_AssetHash,
-                                              ezUInt64& out_ThumbHash);
+    const ezDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_AssetHash,
+    ezUInt64& out_ThumbHash);
   /// \brief Returns the number of assets in the system and how many are in what transform state
   void GetAssetTransformStats(ezUInt32& out_uiNumAssets, ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT>& out_count);
 
@@ -331,9 +336,9 @@ private:
   void TrackDependencies(ezAssetInfo* pAssetInfo);
   void UntrackDependencies(ezAssetInfo* pAssetInfo);
   void UpdateTrackedFiles(const ezUuid& assetGuid, const ezSet<ezString>& files, ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker,
-                          ezSet<std::tuple<ezUuid, ezUuid>>& unresolved, bool bAdd);
+    ezSet<std::tuple<ezUuid, ezUuid>>& unresolved, bool bAdd);
   void UpdateUnresolvedTrackedFiles(ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker,
-                                    ezSet<std::tuple<ezUuid, ezUuid>>& unresolved);
+    ezSet<std::tuple<ezUuid, ezUuid>>& unresolved);
   ezResult ReadAssetDocumentInfo(const char* szAbsFilePath, ezFileStatus& stat, ezUniquePtr<ezAssetInfo>& assetInfo);
   void UpdateSubAssets(ezAssetInfo& assetInfo);
   /// \brief Computes the hash of the given file. Optionally passes the data stream through into another stream writer.
@@ -364,7 +369,7 @@ private:
   friend class ezAssetProcessor;
 
   ezAtomicInteger32 m_bInitStarted =
-      false; // Used to figure out whether the task system has already started the init task so we don't still its lock.
+    false; // Used to figure out whether the task system has already started the init task so we don't still its lock.
   bool m_bRunUpdateTask;
   bool m_bNeedToReloadResources;
 
@@ -377,7 +382,7 @@ private:
   ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseDependency;
   ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseReferences;
   ezSet<std::tuple<ezUuid, ezUuid>>
-      m_UnresolvedDependencies; ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
+    m_UnresolvedDependencies; ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
   ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedReferences;
 
   // State caches

--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -70,15 +70,6 @@ public:
 
   ezBitflags<ezAssetDocumentFlags> GetAssetFlags() const;
 
-  /// \brief Returns one of the strings that ezAssetDocumentManager::QuerySupportedAssetTypes returned.
-  ///
-  /// This can be different for each instance of the same asset document type.
-  /// E.g. one texture resource may return 'Texture 2D' and another 'Texture 3D'.
-  /// Likewise completely different asset document types may use the same 'asset types'.
-  ///
-  /// This is mostly used for sorting and filtering in the asset browser.
-  virtual const char* QueryAssetType() const = 0;
-
   /// \brief Transforms an asset.
   ///   Typically not called manually but by the curator which takes care of dependencies first.
   ///

--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -134,9 +134,6 @@ public:
 
   ezEvent<const ezEditorEngineDocumentMsg*> m_ProcessMessageEvent;
 
-  /// \brief Uses the asset type name from QueryAssetType and appends "Asset" to it
-  virtual const char* GetDocumentTypeDisplayString() const override;
-
 protected:
   void EngineConnectionEventHandler(const ezEditorEngineProcessConnection::Event& e);
 

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentInfo.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentInfo.h
@@ -20,11 +20,11 @@ public:
   ezSet<ezString> m_AssetTransformDependencies; ///< Files that are required to generate the asset, ie. if one changes, the asset needs to be recreated
   ezSet<ezString> m_RuntimeDependencies;        ///< Other files that are used at runtime together with this asset, e.g. materials for a mesh, needed for thumbnails and packaging.
   ezSet<ezString> m_Outputs;                    ///< Additional output this asset produces besides the default one. These are tags like VISUAL_SHADER that are resolved by the ezAssetDocumentManager into paths.
-  ezHashedString m_sAssetTypeName;
+  ezHashedString m_sAssetsDocumentTypeName;
   ezDynamicArray<ezReflectedClass*> m_MetaInfo; ///< Holds arbitrary objects that store meta-data for the asset document. Mainly used for exposed parameters, but can be any reflected type. This array takes ownership of all objects and deallocates them on shutdown.
 
-  const char* GetAssetTypeName() const;
-  void SetAssetTypeName(const char* sz);
+  const char* GetAssetsDocumentTypeName() const;
+  void SetAssetsDocumentTypeName(const char* sz);
 
   /// \brief Returns an object from m_MetaInfo of the given base type, or nullptr if none exists
   const ezReflectedClass* GetMetaInfo(const ezRTTI* pType) const;

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
@@ -17,8 +17,6 @@ public:
   ezAssetDocumentManager();
   ~ezAssetDocumentManager();
 
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;
-
   /// \brief Opens the asset file and reads the "Header" into the given ezAssetDocumentInfo.
   virtual ezStatus ReadAssetDocumentInfo(ezUniquePtr<ezAssetDocumentInfo>& out_pInfo, ezStreamReader& stream) const;
   virtual void FillOutSubAssetList(const ezAssetDocumentInfo& assetInfo, ezHybridArray<ezSubAssetData, 4>& out_SubAssets) const {}
@@ -61,15 +59,14 @@ public:
   virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const;
 
   /// \brief Calls GetRelativeOutputFileName and prepends [DataDir]/AssetCache/ .
-  ezString GetAbsoluteOutputFileName(const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
+  ezString GetAbsoluteOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
 
   /// \brief Relative to 'AssetCache' folder.
-  virtual ezString GetRelativeOutputFileName(const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const = 0;
+  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
   virtual bool GeneratesProfileSpecificAssets() const = 0;
 
-  bool IsOutputUpToDate(const char* szDocumentPath, const ezSet<ezString>& outputs, ezUInt64 uiHash, ezUInt16 uiTypeVersion);
-  virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, ezUInt16 uiTypeVersion);
+  bool IsOutputUpToDate(const char* szDocumentPath, const ezSet<ezString>& outputs, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
+  virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
 
   ///@}
 
@@ -81,6 +78,5 @@ public:
 
 protected:
   static bool IsResourceUpToDate(const char* szResourceFile, ezUInt64 uiHash, ezUInt16 uiTypeVersion);
-  static void GenerateOutputFilename(ezStringBuilder& inout_sRelativeDocumentPath, const ezPlatformProfile* pAssetProfile,
-                                     const char* szExtension, bool bPlatformSpecific);
+  static void GenerateOutputFilename(ezStringBuilder& inout_sRelativeDocumentPath, const ezPlatformProfile* pAssetProfile, const char* szExtension, bool bPlatformSpecific);
 };

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
@@ -18,7 +18,7 @@ public:
   ~ezAssetDocumentManager();
 
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const = 0;
+
   /// \brief Opens the asset file and reads the "Header" into the given ezAssetDocumentInfo.
   virtual ezStatus ReadAssetDocumentInfo(ezUniquePtr<ezAssetDocumentInfo>& out_pInfo, ezStreamReader& stream) const;
   virtual void FillOutSubAssetList(const ezAssetDocumentInfo& assetInfo, ezHybridArray<ezSubAssetData, 4>& out_SubAssets) const {}

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
@@ -57,17 +57,14 @@ public:
   /// \name Output Functions
   ///@{
 
-  virtual void AddEntriesToAssetTable(const char* szDataDirectory, const ezPlatformProfile* pAssetProfile,
-                                      ezMap<ezString, ezString>& inout_GuidToPath) const;
+  virtual void AddEntriesToAssetTable(const char* szDataDirectory, const ezPlatformProfile* pAssetProfile, ezMap<ezString, ezString>& inout_GuidToPath) const;
   virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const;
 
   /// \brief Calls GetRelativeOutputFileName and prepends [DataDir]/AssetCache/ .
-  ezString GetAbsoluteOutputFileName(const char* szDocumentPath, const char* szOutputTag,
-                                     const ezPlatformProfile* pAssetProfile = nullptr) const;
+  ezString GetAbsoluteOutputFileName(const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
 
   /// \brief Relative to 'AssetCache' folder.
-  virtual ezString GetRelativeOutputFileName(const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag,
-                                             const ezPlatformProfile* pAssetProfile = nullptr) const;
+  virtual ezString GetRelativeOutputFileName(const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const = 0;
   virtual bool GeneratesProfileSpecificAssets() const = 0;
 

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -73,3 +73,12 @@ struct ezSubAssetData
   ezString m_sName;
 };
 
+struct EZ_EDITORFRAMEWORK_DLL ezAssetDocumentTypeDescriptor : public ezDocumentTypeDescriptor
+{
+  ezAssetDocumentTypeDescriptor() = default;
+  ~ezAssetDocumentTypeDescriptor() = default;
+
+  ezString m_sResourceFileExtension;
+  ezBitflags<ezAssetDocumentFlags> m_AssetDocumentFlags;
+};
+

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -69,7 +69,7 @@ EZ_DECLARE_FLAGS_OPERATORS(ezTransformFlags);
 struct ezSubAssetData
 {
   ezUuid m_Guid;
-  ezHashedString m_sAssetTypeName;
+  ezHashedString m_sSubAssetsDocumentTypeName;
   ezString m_sName;
 };
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFilter.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFilter.cpp
@@ -134,7 +134,7 @@ bool ezQtAssetBrowserFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
 
   if (!m_sTypeFilter.IsEmpty())
   {
-    m_sTemp.Set(";", pInfo->m_Data.m_sAssetTypeName, ";");
+    m_sTemp.Set(";", pInfo->m_Data.m_sSubAssetsDocumentTypeName, ";");
 
     if (!m_sTypeFilter.FindSubString(m_sTemp))
       return true;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -325,17 +325,14 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
         ezUInt64 uiUserData1, uiUserData2;
         AssetGuid.GetValues(uiUserData1, uiUserData2);
 
-        const QPixmap* pThumbnailPixmap =
-          ezQtImageCache::GetSingleton()->QueryPixmapForType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName, sThumbnailPath, index,
-            QVariant(uiUserData1), QVariant(uiUserData2), &asset.m_uiThumbnailID);
+        const QPixmap* pThumbnailPixmap = ezQtImageCache::GetSingleton()->QueryPixmapForType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName, sThumbnailPath, index,
+          QVariant(uiUserData1), QVariant(uiUserData2), &asset.m_uiThumbnailID);
 
         return *pThumbnailPixmap;
       }
       else
       {
-        const auto& sIconName = ezDocumentManager::GetDescriptorForDocumentType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName)->m_sIcon;
-
-        return ezQtUiServices::GetCachedPixmapResource(sIconName);
+        return ezQtUiServices::GetCachedPixmapResource(pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor->m_sIcon);
       }
     }
     break;
@@ -355,11 +352,7 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
       return QString::fromUtf8(pSubAsset->m_pAssetInfo->m_sDataDirRelativePath);
 
     case UserRoles::AssetIconPath:
-    {
-      const auto& sIconName = ezDocumentManager::GetDescriptorForDocumentType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName)->m_sIcon;
-
-      return ezQtUiServices::GetCachedPixmapResource(sIconName);
-    }
+      return ezQtUiServices::GetCachedPixmapResource(pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor->m_sIcon);
 
     case UserRoles::TransformState:
       return (int)pSubAsset->m_pAssetInfo->m_TransformState;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -326,7 +326,7 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
         AssetGuid.GetValues(uiUserData1, uiUserData2);
 
         const QPixmap* pThumbnailPixmap =
-            ezQtImageCache::GetSingleton()->QueryPixmapForType(pSubAsset->m_Data.m_sAssetTypeName, sThumbnailPath, index,
+            ezQtImageCache::GetSingleton()->QueryPixmapForType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName, sThumbnailPath, index,
                                                                QVariant(uiUserData1), QVariant(uiUserData2), &asset.m_uiThumbnailID);
 
         return *pThumbnailPixmap;
@@ -334,7 +334,7 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
       else
       {
         ezStringBuilder sIconName;
-        sIconName.Set(":/AssetIcons/", pSubAsset->m_Data.m_sAssetTypeName);
+        sIconName.Set(":/AssetIcons/", pSubAsset->m_Data.m_sSubAssetsDocumentTypeName);
         sIconName.ReplaceAll(" ", "_");
         sIconName.ReplaceAll("(", "");
         sIconName.ReplaceAll(")", "");
@@ -361,7 +361,7 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
     case UserRoles::AssetIconPath:
     {
       ezStringBuilder sIconName;
-      sIconName.Set(":/AssetIcons/", pSubAsset->m_Data.m_sAssetTypeName);
+      sIconName.Set(":/AssetIcons/", pSubAsset->m_Data.m_sSubAssetsDocumentTypeName);
       sIconName.ReplaceAll(" ", "_");
       sIconName.ReplaceAll("(", "");
       sIconName.ReplaceAll(")", "");

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -9,7 +9,7 @@
 #include <QUrl>
 
 ezQtAssetFilter::ezQtAssetFilter(QObject* pParent)
-    : QObject(pParent)
+  : QObject(pParent)
 {
 }
 
@@ -20,8 +20,8 @@ ezQtAssetFilter::ezQtAssetFilter(QObject* pParent)
 struct AssetComparer
 {
   AssetComparer(ezQtAssetBrowserModel* model, const ezMap<ezUuid, ezSubAsset>& allAssets)
-      : m_Model(model)
-      , m_AllAssets(allAssets)
+    : m_Model(model)
+    , m_AllAssets(allAssets)
   {
   }
 
@@ -43,8 +43,8 @@ struct AssetComparer
 };
 
 ezQtAssetBrowserModel::ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* pFilter)
-    : QAbstractItemModel(pParent)
-    , m_pFilter(pFilter)
+  : QAbstractItemModel(pParent)
+  , m_pFilter(pFilter)
 {
   EZ_ASSERT_DEBUG(pFilter != nullptr, "ezQtAssetBrowserModel requires a valid filter.");
   connect(pFilter, &ezQtAssetFilter::FilterChanged, this, [this]() { resetModel(); });
@@ -55,10 +55,10 @@ ezQtAssetBrowserModel::ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* 
   SetIconMode(true);
 
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageLoaded, this, &ezQtAssetBrowserModel::ThumbnailLoaded) != nullptr,
-            "signal/slot connection failed");
+    "signal/slot connection failed");
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageInvalidated, this,
-                    &ezQtAssetBrowserModel::ThumbnailInvalidated) != nullptr,
-            "signal/slot connection failed");
+              &ezQtAssetBrowserModel::ThumbnailInvalidated) != nullptr,
+    "signal/slot connection failed");
 }
 
 ezQtAssetBrowserModel::~ezQtAssetBrowserModel()
@@ -326,20 +326,16 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
         AssetGuid.GetValues(uiUserData1, uiUserData2);
 
         const QPixmap* pThumbnailPixmap =
-            ezQtImageCache::GetSingleton()->QueryPixmapForType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName, sThumbnailPath, index,
-                                                               QVariant(uiUserData1), QVariant(uiUserData2), &asset.m_uiThumbnailID);
+          ezQtImageCache::GetSingleton()->QueryPixmapForType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName, sThumbnailPath, index,
+            QVariant(uiUserData1), QVariant(uiUserData2), &asset.m_uiThumbnailID);
 
         return *pThumbnailPixmap;
       }
       else
       {
-        ezStringBuilder sIconName;
-        sIconName.Set(":/AssetIcons/", pSubAsset->m_Data.m_sSubAssetsDocumentTypeName);
-        sIconName.ReplaceAll(" ", "_");
-        sIconName.ReplaceAll("(", "");
-        sIconName.ReplaceAll(")", "");
+        const auto& sIconName = ezDocumentManager::GetDescriptorForDocumentType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName)->m_sIcon;
 
-        return ezQtUiServices::GetCachedPixmapResource(sIconName.GetData());
+        return ezQtUiServices::GetCachedPixmapResource(sIconName);
       }
     }
     break;
@@ -360,13 +356,9 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int role) const
 
     case UserRoles::AssetIconPath:
     {
-      ezStringBuilder sIconName;
-      sIconName.Set(":/AssetIcons/", pSubAsset->m_Data.m_sSubAssetsDocumentTypeName);
-      sIconName.ReplaceAll(" ", "_");
-      sIconName.ReplaceAll("(", "");
-      sIconName.ReplaceAll(")", "");
+      const auto& sIconName = ezDocumentManager::GetDescriptorForDocumentType(pSubAsset->m_Data.m_sSubAssetsDocumentTypeName)->m_sIcon;
 
-      return ezQtUiServices::GetCachedPixmapResource(sIconName.GetData());
+      return ezQtUiServices::GetCachedPixmapResource(sIconName);
     }
 
     case UserRoles::TransformState:

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -221,12 +221,8 @@ void ezQtAssetBrowserWidget::AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedA
 
   for (const ezDocumentTypeDescriptor* desc : documentTypes)
   {
-    if (!desc->m_bCanCreate)
+    if (!desc->m_bCanCreate || desc->m_sFileExtension.IsEmpty())
       continue;
-    if (desc->m_sFileExtension.IsEmpty())
-      continue;
-    // if (!sTypeFilter.IsEmpty() && !sTypeFilter.FindSubString(desc->m_sDocumentTypeName))
-    // continue;
 
     QAction* pAction = pSubMenu->addAction(desc->m_sDocumentTypeName.GetData());
     pAction->setIcon(ezQtUiServices::GetSingleton()->GetCachedIconResource(desc->m_sIcon));

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -15,7 +15,7 @@
 #include <QTimer>
 
 ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* parent)
-    : QWidget(parent)
+  : QWidget(parent)
 {
   m_uiKnownAssetFolderCount = 0;
   m_bDialogMode = false;
@@ -58,11 +58,11 @@ ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* parent)
   EZ_VERIFY(connect(m_pFilter, SIGNAL(PathFilterChanged()), this, SLOT(OnPathFilterChanged())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pModel, SIGNAL(modelReset()), this, SLOT(OnModelReset())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(ListAssets->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this,
-                    SLOT(OnAssetSelectionChanged(const QItemSelection&, const QItemSelection&))) != nullptr,
-            "signal/slot connection failed");
+              SLOT(OnAssetSelectionChanged(const QItemSelection&, const QItemSelection&))) != nullptr,
+    "signal/slot connection failed");
   EZ_VERIFY(connect(ListAssets->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this,
-                    SLOT(OnAssetSelectionCurrentChanged(const QModelIndex&, const QModelIndex&))) != nullptr,
-            "signal/slot connection failed");
+              SLOT(OnAssetSelectionCurrentChanged(const QModelIndex&, const QModelIndex&))) != nullptr,
+    "signal/slot connection failed");
   connect(SearchWidget, &ezQtSearchWidget::textChanged, this, &ezQtAssetBrowserWidget::OnSearchWidgetTextChanged);
 
   UpdateAssetTypes();
@@ -85,12 +85,16 @@ void ezQtAssetBrowserWidget::UpdateAssetTypes()
 
   for (auto docman : ezDocumentManager::GetAllDocumentManagers())
   {
-    if (!docman->GetDynamicRTTI()->IsDerivedFrom<ezAssetDocumentManager>())
-      continue;
+    if (auto pAssetDocMan = ezDynamicCast<const ezAssetDocumentManager*>(docman))
+    {
+      ezHybridArray<const ezDocumentTypeDescriptor*, 4> documentTypes;
+      pAssetDocMan->GetSupportedDocumentTypes(documentTypes);
 
-    const ezAssetDocumentManager* pAssetDocMan = static_cast<const ezAssetDocumentManager*>(docman);
-
-    pAssetDocMan->QuerySupportedAssetTypes(KnownAssetTypes);
+      for (auto pType : documentTypes)
+      {
+        KnownAssetTypes.Insert(pType->m_sDocumentTypeName);
+      }
+    }
   }
 
   {
@@ -238,15 +242,15 @@ void ezQtAssetBrowserWidget::AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedA
 void ezQtAssetBrowserWidget::on_ListAssets_clicked(const QModelIndex& index)
 {
   Q_EMIT ItemSelected(m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>(),
-                    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
-                    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
+    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
 }
 
 void ezQtAssetBrowserWidget::on_ListAssets_activated(const QModelIndex& index)
 {
   Q_EMIT ItemSelected(m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>(),
-                    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
-                    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
+    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
 }
 
 void ezQtAssetBrowserWidget::on_ListAssets_doubleClicked(const QModelIndex& index)
@@ -259,7 +263,7 @@ void ezQtAssetBrowserWidget::on_ListAssets_doubleClicked(const QModelIndex& inde
   }
 
   Q_EMIT ItemChosen(guid, m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
-                  m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
 }
 
 void ezQtAssetBrowserWidget::on_ButtonListMode_clicked()
@@ -469,7 +473,7 @@ void ezQtAssetBrowserWidget::ClearDirectoryTree()
 }
 
 void ezQtAssetBrowserWidget::BuildDirectoryTree(const char* szCurPath, QTreeWidgetItem* pParent, const char* szCurPathToItem,
-                                                bool bIsHidden)
+  bool bIsHidden)
 {
   if (ezStringUtils::IsNullOrEmpty(szCurPath))
     return;
@@ -543,7 +547,7 @@ void ezQtAssetBrowserWidget::on_TreeFolderFilter_customContextMenuRequested(cons
   if (TreeFolderFilter->currentItem())
   {
     m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder16.png")), QLatin1String("Open in Explorer"), this,
-                SLOT(OnTreeOpenExplorer()));
+      SLOT(OnTreeOpenExplorer()));
   }
 
   {
@@ -579,7 +583,7 @@ void ezQtAssetBrowserWidget::OnTreeOpenExplorer()
     return;
 
   ezStringBuilder sPath =
-      TreeFolderFilter->currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
+    TreeFolderFilter->currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
 
   if (!ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(sPath, true))
     return;
@@ -595,17 +599,17 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
   {
     if (!m_bDialogMode)
       m.setDefaultAction(m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Document16.png")), QLatin1String("Open Document"), this,
-                                     SLOT(OnListOpenAssetDocument())));
+        SLOT(OnListOpenAssetDocument())));
     else
       m.setDefaultAction(m.addAction(QLatin1String("Select"), this, SLOT(OnListOpenAssetDocument())));
 
     m.addAction(QIcon(QLatin1String(":/EditorFramework/Icons/AssetNeedsTransform16.png")), QLatin1String("Transform"), this,
-                SLOT(OnTransform()));
+      SLOT(OnTransform()));
 
     m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder16.png")), QLatin1String("Open in Explorer"), this,
-                SLOT(OnListOpenExplorer()));
+      SLOT(OnListOpenExplorer()));
     m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/DocumentGuid16.png")), QLatin1String("Copy Asset Guid"), this,
-                SLOT(OnListCopyAssetGuid()));
+      SLOT(OnListCopyAssetGuid()));
   }
 
   auto pSortAction = m.addAction(QLatin1String("Sort by Recently Used"), this, SLOT(OnListToggleSortByRecentlyUsed()));
@@ -634,7 +638,7 @@ void ezQtAssetBrowserWidget::OnListOpenAssetDocument()
     }
 
     Q_EMIT ItemChosen(guid, m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
-                    m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+      m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
   }
 }
 
@@ -713,7 +717,7 @@ void ezQtAssetBrowserWidget::OnAssetSelectionChanged(const QItemSelection& selec
 
     ezUuid guid = m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>();
     Q_EMIT ItemSelected(guid, m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
-                      m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+      m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
   }
 }
 
@@ -729,7 +733,7 @@ void ezQtAssetBrowserWidget::OnAssetSelectionCurrentChanged(const QModelIndex& c
 
     ezUuid guid = m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>();
     Q_EMIT ItemSelected(guid, m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(),
-                      m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+      m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
   }
 }
 
@@ -765,7 +769,7 @@ void ezQtAssetBrowserWidget::OnNewAsset()
     if (useSelection && ListAssets->selectionModel()->hasSelection())
     {
       ezString sPath =
-          m_pModel->data(ListAssets->currentIndex(), ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
+        m_pModel->data(ListAssets->currentIndex(), ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
 
       if (!sPath.IsEmpty() && ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sPath))
       {
@@ -783,9 +787,9 @@ void ezQtAssetBrowserWidget::OnNewAsset()
 
   QString sSelectedFilter = sFilter.GetData();
   ezStringBuilder sOutput = QFileDialog::getSaveFileName(QApplication::activeWindow(), title.GetData(), sStartDir, sFilter.GetData(),
-                                                         &sSelectedFilter, QFileDialog::Option::DontResolveSymlinks)
-                                .toUtf8()
-                                .data();
+    &sSelectedFilter, QFileDialog::Option::DontResolveSymlinks)
+                              .toUtf8()
+                              .data();
 
   if (sOutput.IsEmpty())
     return;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1302,7 +1302,7 @@ void ezAssetCurator::ProcessAllCoreAssets()
           {
             if (ezAssetInfo* pInfo = GetAssetInfo(ref))
             {
-              if (name.GetHash() == 0 || pInfo->m_Info->m_sAssetTypeName == name)
+              if (name.GetHash() == 0 || pInfo->m_Info->m_sAssetsDocumentTypeName == name)
               {
                 resReferences = ProcessAsset(pInfo, pAssetProfile, ezTransformFlags::TriggeredManually);
                 if (resReferences.m_Result.Failed())

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1440,8 +1440,10 @@ void ezAssetCurator::BuildFileExtensionSet(ezSet<ezString>& AllExtensions)
 
   const auto& allDesc = ezDocumentManager::GetAllDocumentDescriptors();
 
-  for (const auto& desc : allDesc)
+  for (auto it : allDesc)
   {
+    const auto desc = it.Value();
+
     if (desc->m_pManager->GetDynamicRTTI()->IsDerivedFrom<ezAssetDocumentManager>())
     {
       sTemp = desc->m_sFileExtension;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -82,7 +82,7 @@ void ezAssetInfo::Update(ezUniquePtr<ezAssetInfo>& rhs)
 {
   m_ExistanceState = rhs->m_ExistanceState;
   m_TransformState = rhs->m_TransformState;
-  m_pManager = rhs->m_pManager;
+  m_pDocumentTypeDescriptor = rhs->m_pDocumentTypeDescriptor;
   m_sAbsolutePath = std::move(rhs->m_sAbsolutePath);
   m_sDataDirRelativePath = std::move(rhs->m_sDataDirRelativePath);
   m_Info = std::move(rhs->m_Info);
@@ -1015,7 +1015,7 @@ ezStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ezPlatformP
 ezStatus ezAssetCurator::ResaveAsset(ezAssetInfo* pAssetInfo)
 {
   bool bWasOpen = false;
-  ezDocument* pDoc = pAssetInfo->m_pManager->GetDocumentByPath(pAssetInfo->m_sAbsolutePath);
+  ezDocument* pDoc = pAssetInfo->GetManager()->GetDocumentByPath(pAssetInfo->m_sAbsolutePath);
   if (pDoc)
     bWasOpen = true;
   else
@@ -1218,7 +1218,7 @@ ezResult ezAssetCurator::WriteAssetTable(const char* szDataDirectory, const ezPl
     if (!sTemp.IsPathBelowFolder(sDataDir))
       continue;
 
-    ezAssetDocumentManager* pManager = it.Value()->m_pManager;
+    ezAssetDocumentManager* pManager = it.Value()->GetManager();
 
     auto WriteEntry = [this, &sDataDir, &pAssetProfile, &GuidToPath, pManager, &sTemp, &sTemp2](const ezUuid& guid) {
       ezSubAsset* pSub = GetSubAssetInternal(guid);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -657,8 +657,7 @@ ezUInt64 ezAssetCurator::GetAssetReferenceHash(ezUuid assetGuid)
   return GetAssetHash(assetGuid, true);
 }
 
-ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile,
-  const ezDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash)
+ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash)
 {
   CURATOR_PROFILE("IsAssetUpToDate");
 
@@ -679,7 +678,6 @@ ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetG
     return ezAssetInfo::TransformState::MissingReference;
   }
 
-  auto flags = pManager->GetAssetDocumentTypeFlags(pTypeDescriptor);
   ezString sAssetFile;
   ezSet<ezString> outputs;
   {
@@ -689,9 +687,9 @@ ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetG
     outputs = pAssetInfo->m_Info->m_Outputs;
   }
 
-  if (pManager->IsOutputUpToDate(sAssetFile, outputs, out_AssetHash, pTypeDescriptor->m_pDocumentType->GetTypeVersion()))
+  if (pManager->IsOutputUpToDate(sAssetFile, outputs, out_AssetHash, pTypeDescriptor))
   {
-    if (flags.IsSet(ezAssetDocumentFlags::SupportsThumbnail))
+    if (pTypeDescriptor->m_AssetDocumentFlags.IsSet(ezAssetDocumentFlags::SupportsThumbnail))
     {
       if (!ezAssetDocumentManager::IsThumbnailUpToDate(sAssetFile, out_ThumbHash, pTypeDescriptor->m_pDocumentType->GetTypeVersion()))
       {
@@ -927,11 +925,11 @@ ezStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ezPlatformP
     }
   }
 
-  const ezDocumentTypeDescriptor* pTypeDesc = pAssetInfo->m_pDocumentTypeDescriptor;
+  const ezAssetDocumentTypeDescriptor* pTypeDesc = pAssetInfo->m_pDocumentTypeDescriptor;
 
   EZ_ASSERT_DEV(pTypeDesc->m_pDocumentType->IsDerivedFrom<ezAssetDocument>(), "Asset document does not derive from correct base class ('{0}')", pAssetInfo->m_sDataDirRelativePath);
 
-  auto assetFlags = static_cast<ezAssetDocumentManager*>(pTypeDesc->m_pManager)->GetAssetDocumentTypeFlags(pTypeDesc);
+  auto assetFlags = pTypeDesc->m_AssetDocumentFlags;
 
   // Skip assets that cannot be auto-transformed.
   {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -927,16 +927,9 @@ ezStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ezPlatformP
     }
   }
 
-  // Find the descriptor for the asset.
-  const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
-  if (ezDocumentManager::FindDocumentTypeFromPath(pAssetInfo->m_sAbsolutePath, false, pTypeDesc).Failed())
-  {
-    return ezStatus(ezFmt(
-      "The asset '{0}' could not be queried for its ezDocumentTypeDescriptor, skipping transform!", pAssetInfo->m_sDataDirRelativePath));
-  }
+  const ezDocumentTypeDescriptor* pTypeDesc = pAssetInfo->m_pDocumentTypeDescriptor;
 
-  EZ_ASSERT_DEV(pTypeDesc->m_pDocumentType->IsDerivedFrom<ezAssetDocument>(),
-    "Asset document does not derive from correct base class ('{0}')", pAssetInfo->m_sDataDirRelativePath);
+  EZ_ASSERT_DEV(pTypeDesc->m_pDocumentType->IsDerivedFrom<ezAssetDocument>(), "Asset document does not derive from correct base class ('{0}')", pAssetInfo->m_sDataDirRelativePath);
 
   auto assetFlags = static_cast<ezAssetDocumentManager*>(pTypeDesc->m_pManager)->GetAssetDocumentTypeFlags(pTypeDesc);
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -763,15 +763,6 @@ void ezAssetDocument::SyncObjectsToEngine()
   }
 }
 
-const char* ezAssetDocument::GetDocumentTypeDisplayString() const
-{
-  static ezStringBuilder dummy; // must be static to survive the function call
-  dummy = QueryAssetType();
-  dummy.Append(" Asset");
-
-  return dummy;
-}
-
 namespace
 {
   static const char* szThumbnailInfoTag = "ezThumb";

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -75,7 +75,7 @@ ezTaskGroupID ezAssetDocument::InternalSaveDocument(AfterSaveCallback callback)
   pInfo->m_RuntimeDependencies.Clear();
   pInfo->m_Outputs.Clear();
   pInfo->m_uiSettingsHash = GetDocumentHash();
-  pInfo->m_sAssetTypeName.Assign(GetDocumentTypeName());
+  pInfo->m_sAssetsDocumentTypeName.Assign(GetDocumentTypeName());
   pInfo->ClearMetaData();
   UpdateAssetDocumentInfo(pInfo);
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -75,7 +75,7 @@ ezTaskGroupID ezAssetDocument::InternalSaveDocument(AfterSaveCallback callback)
   pInfo->m_RuntimeDependencies.Clear();
   pInfo->m_Outputs.Clear();
   pInfo->m_uiSettingsHash = GetDocumentHash();
-  pInfo->m_sAssetTypeName.Assign(QueryAssetType());
+  pInfo->m_sAssetTypeName.Assign(GetDocumentTypeName());
   pInfo->ClearMetaData();
   UpdateAssetDocumentInfo(pInfo);
 
@@ -545,11 +545,11 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
 {
   ezProgressRange range("Exporting Asset", 2, false);
 
-  ezLog::Info("Exporting {0} to \"{1}\"", QueryAssetType(), szOutputTarget);
+  ezLog::Info("Exporting {0} to \"{1}\"", GetDocumentTypeName(), szOutputTarget);
 
   if (GetEngineStatus() == ezAssetDocument::EngineStatus::Disconnected)
   {
-    return ezStatus(ezFmt("Exporting {0} to \"{1}\" failed, engine not started or crashed.", QueryAssetType(), szOutputTarget));
+    return ezStatus(ezFmt("Exporting {0} to \"{1}\" failed, engine not started or crashed.", GetDocumentTypeName(), szOutputTarget));
   }
   else if (GetEngineStatus() == ezAssetDocument::EngineStatus::Initializing)
   {
@@ -557,7 +557,7 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
             ->WaitForDocumentMessage(GetGuid(), ezDocumentOpenResponseMsgToEditor::GetStaticRTTI(), ezTime::Seconds(10))
             .Failed())
     {
-      return ezStatus(ezFmt("Exporting {0} to \"{1}\" failed, document initialization timed out.", QueryAssetType(), szOutputTarget));
+      return ezStatus(ezFmt("Exporting {0} to \"{1}\" failed, document initialization timed out.", GetDocumentTypeName(), szOutputTarget));
     }
     EZ_ASSERT_DEV(GetEngineStatus() == ezAssetDocument::EngineStatus::Loaded,
                   "After receiving ezDocumentOpenResponseMsgToEditor, the document should be in loaded state.");
@@ -583,18 +583,18 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
           ->WaitForDocumentMessage(GetGuid(), ezExportDocumentMsgToEditor::GetStaticRTTI(), ezTime::Seconds(60), &callback)
           .Failed())
   {
-    return ezStatus(ezFmt("Remote exporting {0} to \"{1}\" timed out.", QueryAssetType(), msg.m_sOutputFile));
+    return ezStatus(ezFmt("Remote exporting {0} to \"{1}\" timed out.", GetDocumentTypeName(), msg.m_sOutputFile));
   }
   else
   {
     if (!bSuccess)
     {
-      return ezStatus(ezFmt("Remote exporting {0} to \"{1}\" failed.", QueryAssetType(), msg.m_sOutputFile));
+      return ezStatus(ezFmt("Remote exporting {0} to \"{1}\" failed.", GetDocumentTypeName(), msg.m_sOutputFile));
     }
 
-    ezLog::Success("{0} \"{1}\" has been exported.", QueryAssetType(), msg.m_sOutputFile);
+    ezLog::Success("{0} \"{1}\" has been exported.", GetDocumentTypeName(), msg.m_sOutputFile);
 
-    ShowDocumentStatus(ezFmt("{0} exported successfully", QueryAssetType()));
+    ShowDocumentStatus(ezFmt("{0} exported successfully", GetDocumentTypeName()));
 
     return ezStatus(EZ_SUCCESS);
   }
@@ -610,11 +610,11 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
 {
   ezAssetCurator::GetSingleton()->WriteAssetTables();
 
-  ezLog::Info("Create {0} thumbnail for \"{1}\"", QueryAssetType(), GetDocumentPath());
+  ezLog::Info("Create {0} thumbnail for \"{1}\"", GetDocumentTypeName(), GetDocumentPath());
 
   if (GetEngineStatus() == ezAssetDocument::EngineStatus::Disconnected)
   {
-    return ezStatus(ezFmt("Create {0} thumbnail for \"{1}\" failed, engine not started or crashed.", QueryAssetType(), GetDocumentPath()));
+    return ezStatus(ezFmt("Create {0} thumbnail for \"{1}\" failed, engine not started or crashed.", GetDocumentTypeName(), GetDocumentPath()));
   }
   else if (GetEngineStatus() == ezAssetDocument::EngineStatus::Initializing)
   {
@@ -623,7 +623,7 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
             .Failed())
     {
       return ezStatus(
-          ezFmt("Create {0} thumbnail for \"{1}\" failed, document initialization timed out.", QueryAssetType(), GetDocumentPath()));
+          ezFmt("Create {0} thumbnail for \"{1}\" failed, document initialization timed out.", GetDocumentTypeName(), GetDocumentPath()));
     }
     EZ_ASSERT_DEV(GetEngineStatus() == ezAssetDocument::EngineStatus::Loaded,
                   "After receiving ezDocumentOpenResponseMsgToEditor, the document should be in loaded state.");
@@ -643,13 +643,13 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
           ->WaitForDocumentMessage(GetGuid(), ezCreateThumbnailMsgToEditor::GetStaticRTTI(), ezTime::Seconds(60), &callback)
           .Failed())
   {
-    return ezStatus(ezFmt("Create {0} thumbnail for \"{1}\" failed timed out.", QueryAssetType(), GetDocumentPath()));
+    return ezStatus(ezFmt("Create {0} thumbnail for \"{1}\" failed timed out.", GetDocumentTypeName(), GetDocumentPath()));
   }
   else
   {
     if (data.GetCount() != msg.m_uiWidth * msg.m_uiHeight * 4)
     {
-      return ezStatus(ezFmt("Thumbnail generation for {0} failed, thumbnail data is empty.", QueryAssetType()));
+      return ezStatus(ezFmt("Thumbnail generation for {0} failed, thumbnail data is empty.", GetDocumentTypeName()));
     }
 
     ezImageHeader imgHeader;
@@ -663,9 +663,9 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
     ezMemoryUtils::Copy(image.GetPixelPointer<ezUInt8>(), data.GetData(), msg.m_uiWidth * msg.m_uiHeight * 4);
     SaveThumbnail(image, thumbnailInfo);
 
-    ezLog::Success("{0} thumbnail for \"{1}\" has been exported.", QueryAssetType(), GetDocumentPath());
+    ezLog::Success("{0} thumbnail for \"{1}\" has been exported.", GetDocumentTypeName(), GetDocumentPath());
 
-    ShowDocumentStatus(ezFmt("{0} thumbnail created successfully", QueryAssetType()));
+    ShowDocumentStatus(ezFmt("{0} thumbnail created successfully", GetDocumentTypeName()));
 
     return ezStatus(EZ_SUCCESS);
   }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentInfo.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentInfo.cpp
@@ -11,7 +11,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAssetDocumentInfo, 2, ezRTTIDefaultAllocator<e
     EZ_SET_MEMBER_PROPERTY("References", m_RuntimeDependencies),
     EZ_SET_MEMBER_PROPERTY("Outputs", m_Outputs),
     EZ_MEMBER_PROPERTY("Hash", m_uiSettingsHash),
-    EZ_ACCESSOR_PROPERTY("AssetType", GetAssetTypeName, SetAssetTypeName),
+    EZ_ACCESSOR_PROPERTY("AssetType", GetAssetsDocumentTypeName, SetAssetsDocumentTypeName),
     EZ_ARRAY_MEMBER_PROPERTY("MetaInfo", m_MetaInfo)->AddFlags(ezPropertyFlags::PointerOwner),
   }
   EZ_END_PROPERTIES;
@@ -40,7 +40,7 @@ void ezAssetDocumentInfo::operator=(ezAssetDocumentInfo&& rhs)
   m_AssetTransformDependencies = rhs.m_AssetTransformDependencies;
   m_RuntimeDependencies = rhs.m_RuntimeDependencies;
   m_Outputs = rhs.m_Outputs;
-  m_sAssetTypeName = rhs.m_sAssetTypeName;
+  m_sAssetsDocumentTypeName = rhs.m_sAssetsDocumentTypeName;
   m_MetaInfo = std::move(rhs.m_MetaInfo);
 }
 
@@ -50,7 +50,7 @@ void ezAssetDocumentInfo::CreateShallowClone(ezAssetDocumentInfo& rhs) const
   rhs.m_AssetTransformDependencies = m_AssetTransformDependencies;
   rhs.m_RuntimeDependencies = m_RuntimeDependencies;
   rhs.m_Outputs = m_Outputs;
-  rhs.m_sAssetTypeName = m_sAssetTypeName;
+  rhs.m_sAssetsDocumentTypeName = m_sAssetsDocumentTypeName;
   rhs.m_MetaInfo.Clear();
 }
 
@@ -63,14 +63,14 @@ void ezAssetDocumentInfo::ClearMetaData()
   m_MetaInfo.Clear();
 }
 
-const char* ezAssetDocumentInfo::GetAssetTypeName() const
+const char* ezAssetDocumentInfo::GetAssetsDocumentTypeName() const
 {
-  return m_sAssetTypeName.GetData();
+  return m_sAssetsDocumentTypeName.GetData();
 }
 
-void ezAssetDocumentInfo::SetAssetTypeName(const char* sz)
+void ezAssetDocumentInfo::SetAssetsDocumentTypeName(const char* sz)
 {
-  m_sAssetTypeName.Assign(sz);
+  m_sAssetsDocumentTypeName.Assign(sz);
 }
 
 const ezReflectedClass* ezAssetDocumentInfo::GetMetaInfo(const ezRTTI* pType) const

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentManager.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentManager.cpp
@@ -21,8 +21,7 @@ void ezAssetDocumentManager::ComputeAssetProfileHash(const ezPlatformProfile* pA
 
   if (GeneratesProfileSpecificAssets())
   {
-    EZ_ASSERT_DEBUG(m_uiAssetProfileHash != 0,
-                    "Assets that generate a profile-specific output must compute a hash for the profile settings.");
+    EZ_ASSERT_DEBUG(m_uiAssetProfileHash != 0, "Assets that generate a profile-specific output must compute a hash for the profile settings.");
   }
   else
   {
@@ -109,14 +108,12 @@ void ezAssetDocumentManager::AddEntriesToAssetTable(const char* szDataDirectory,
 {
 }
 
-ezString ezAssetDocumentManager::GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory,
-                                                    const ezPlatformProfile* pAssetProfile) const
+ezString ezAssetDocumentManager::GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const
 {
   return GetRelativeOutputFileName(szDataDirectory, pSubAsset->m_pAssetInfo->m_sAbsolutePath, "", pAssetProfile);
 }
 
-ezString ezAssetDocumentManager::GetAbsoluteOutputFileName(const char* szDocumentPath, const char* szOutputTag,
-                                                           const ezPlatformProfile* pAssetProfile) const
+ezString ezAssetDocumentManager::GetAbsoluteOutputFileName(const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const
 {
   ezStringBuilder sProjectDir = ezAssetCurator::GetSingleton()->FindDataDirectoryForAsset(szDocumentPath);
 
@@ -131,8 +128,8 @@ ezString ezAssetDocumentManager::GetRelativeOutputFileName(const char* szDataDir
                                                            const ezPlatformProfile* pAssetProfile) const
 {
   const ezPlatformProfile* sPlatform = ezAssetDocumentManager::DetermineFinalTargetProfile(pAssetProfile);
-  EZ_ASSERT_DEBUG(ezStringUtils::IsNullOrEmpty(szOutputTag),
-                  "The output tag '%s' for '%s' is not supported, override GetRelativeOutputFileName", szOutputTag, szDocumentPath);
+  EZ_ASSERT_DEBUG(ezStringUtils::IsNullOrEmpty(szOutputTag), "The output tag '%s' for '%s' is not supported, override GetRelativeOutputFileName", szOutputTag, szDocumentPath);
+
   ezStringBuilder sRelativePath(szDocumentPath);
   sRelativePath.MakeRelativeTo(szDataDirectory);
   GenerateOutputFilename(sRelativePath, sPlatform, GetResourceTypeExtension(szDocumentPath), GeneratesProfileSpecificAssets());

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -266,7 +266,8 @@ bool ezProcessTask::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, 
   const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
   if (ezDocumentManager::FindDocumentTypeFromPath(pInfo->m_sAbsolutePath, false, pTypeDesc).Succeeded())
   {
-    auto flags = static_cast<ezAssetDocumentManager*>(pTypeDesc->m_pManager)->GetAssetDocumentTypeFlags(pTypeDesc);
+    auto flags = static_cast<const ezAssetDocumentTypeDescriptor*>(pTypeDesc)->m_AssetDocumentFlags;
+
     if (flags.IsAnySet(ezAssetDocumentFlags::OnlyTransformManually | ezAssetDocumentFlags::DisableTransform))
       return false;
   }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -602,7 +602,7 @@ void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
     mainSub.m_ExistanceState = ezAssetExistanceState::FileAdded;
     mainSub.m_pAssetInfo = &assetInfo;
     mainSub.m_Data.m_Guid = assetInfo.m_Info->m_DocumentID;
-    mainSub.m_Data.m_sAssetTypeName.Assign(assetInfo.m_Info->m_sAssetTypeName.GetData());
+    mainSub.m_Data.m_sAssetTypeName = assetInfo.m_Info->m_sAssetTypeName;
   }
 
   if (assetInfo.m_ExistanceState == ezAssetExistanceState::FileModified)

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -602,7 +602,7 @@ void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
     mainSub.m_ExistanceState = ezAssetExistanceState::FileAdded;
     mainSub.m_pAssetInfo = &assetInfo;
     mainSub.m_Data.m_Guid = assetInfo.m_Info->m_DocumentID;
-    mainSub.m_Data.m_sAssetTypeName = assetInfo.m_Info->m_sAssetTypeName;
+    mainSub.m_Data.m_sSubAssetsDocumentTypeName = assetInfo.m_Info->m_sAssetsDocumentTypeName;
   }
 
   if (assetInfo.m_ExistanceState == ezAssetExistanceState::FileModified)

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -253,7 +253,7 @@ ezResult ezAssetCurator::EnsureAssetInfoUpdated(const char* szAbsFilePath)
   {
     // now the GUID must be valid
     EZ_ASSERT_DEV(pNewAssetInfo->m_Info->m_DocumentID.IsValid(),
-                  "Asset header read for '{0}', but its GUID is invalid! Corrupted document?", szAbsFilePath);
+      "Asset header read for '{0}', but its GUID is invalid! Corrupted document?", szAbsFilePath);
     EZ_ASSERT_DEV(RefFile.m_AssetGuid == pNewAssetInfo->m_Info->m_DocumentID, "UpdateAssetInfo broke the GUID!");
 
     // Was the asset already known? Decide whether it was moved (ok) or duplicated (bad)
@@ -284,8 +284,8 @@ ezResult ezAssetCurator::EnsureAssetInfoUpdated(const char* szAbsFilePath)
           TrackDependencies(pOldAssetInfo);
           UpdateAssetTransformState(RefFile.m_AssetGuid, ezAssetInfo::TransformState::Unknown);
           SetAssetExistanceState(
-              *pOldAssetInfo,
-              ezAssetExistanceState::FileModified); // asset was only moved, prevent added event (could have been modified though)
+            *pOldAssetInfo,
+            ezAssetExistanceState::FileModified); // asset was only moved, prevent added event (could have been modified though)
           UpdateSubAssets(*pOldAssetInfo);
           RefFile.m_AssetGuid = pOldAssetInfo->m_Info->m_DocumentID;
           return EZ_SUCCESS;
@@ -362,16 +362,16 @@ ezResult ezAssetCurator::EnsureAssetInfoUpdated(const char* szAbsFilePath)
 void ezAssetCurator::TrackDependencies(ezAssetInfo* pAssetInfo)
 {
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_AssetTransformDependencies, m_InverseDependency,
-                     m_UnresolvedDependencies, true);
+    m_UnresolvedDependencies, true);
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_RuntimeDependencies, m_InverseReferences,
-                     m_UnresolvedReferences, true);
+    m_UnresolvedReferences, true);
 
-  const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_sAbsolutePath, "");
+  const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_pDocumentTypeDescriptor, pAssetInfo->m_sAbsolutePath, "");
   auto it = m_InverseReferences.FindOrAdd(sTargetFile);
   it.Value().PushBack(pAssetInfo->m_Info->m_DocumentID);
   for (auto outputIt = pAssetInfo->m_Info->m_Outputs.GetIterator(); outputIt.IsValid(); ++outputIt)
   {
-    const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_sAbsolutePath, outputIt.Key());
+    const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_pDocumentTypeDescriptor, pAssetInfo->m_sAbsolutePath, outputIt.Key());
     it = m_InverseReferences.FindOrAdd(sTargetFile);
     it.Value().PushBack(pAssetInfo->m_Info->m_DocumentID);
   }
@@ -383,24 +383,24 @@ void ezAssetCurator::TrackDependencies(ezAssetInfo* pAssetInfo)
 void ezAssetCurator::UntrackDependencies(ezAssetInfo* pAssetInfo)
 {
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_AssetTransformDependencies, m_InverseDependency,
-                     m_UnresolvedDependencies, false);
+    m_UnresolvedDependencies, false);
   UpdateTrackedFiles(pAssetInfo->m_Info->m_DocumentID, pAssetInfo->m_Info->m_RuntimeDependencies, m_InverseReferences,
-                     m_UnresolvedReferences, false);
+    m_UnresolvedReferences, false);
 
-  const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_sAbsolutePath, "");
+  const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_pDocumentTypeDescriptor, pAssetInfo->m_sAbsolutePath, "");
   auto it = m_InverseReferences.FindOrAdd(sTargetFile);
   it.Value().RemoveAndCopy(pAssetInfo->m_Info->m_DocumentID);
   for (auto outputIt = pAssetInfo->m_Info->m_Outputs.GetIterator(); outputIt.IsValid(); ++outputIt)
   {
-    const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_sAbsolutePath, outputIt.Key());
+    const ezString sTargetFile = pAssetInfo->GetManager()->GetAbsoluteOutputFileName(pAssetInfo->m_pDocumentTypeDescriptor, pAssetInfo->m_sAbsolutePath, outputIt.Key());
     it = m_InverseReferences.FindOrAdd(sTargetFile);
     it.Value().RemoveAndCopy(pAssetInfo->m_Info->m_DocumentID);
   }
 }
 
 void ezAssetCurator::UpdateTrackedFiles(const ezUuid& assetGuid, const ezSet<ezString>& files,
-                                        ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker,
-                                        ezSet<std::tuple<ezUuid, ezUuid>>& unresolved, bool bAdd)
+  ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker,
+  ezSet<std::tuple<ezUuid, ezUuid>>& unresolved, bool bAdd)
 {
   for (const auto& dep : files)
   {
@@ -449,7 +449,7 @@ void ezAssetCurator::UpdateTrackedFiles(const ezUuid& assetGuid, const ezSet<ezS
 }
 
 void ezAssetCurator::UpdateUnresolvedTrackedFiles(ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker,
-                                                  ezSet<std::tuple<ezUuid, ezUuid>>& unresolved)
+  ezSet<std::tuple<ezUuid, ezUuid>>& unresolved)
 {
   for (auto it = unresolved.GetIterator(); it.IsValid();)
   {
@@ -527,7 +527,7 @@ ezResult ezAssetCurator::ReadAssetDocumentInfo(const char* szAbsFilePath, ezFile
         EZ_REPORT_FAILURE("Invalid asset setup");
       }
 
-      out_assetInfo->m_pDocumentTypeDescriptor = pTypeDesc;
+      out_assetInfo->m_pDocumentTypeDescriptor = static_cast<const ezAssetDocumentTypeDescriptor*>(pTypeDesc);
     }
   }
 
@@ -630,7 +630,7 @@ void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
       bool bExisted = false;
       auto& sub = m_KnownSubAssets.FindOrAdd(data.m_Guid, &bExisted).Value();
       EZ_ASSERT_DEV(bExisted == assetInfo.m_SubAssets.Contains(data.m_Guid),
-                    "Implementation error: m_KnownSubAssets and assetInfo.m_SubAssets are out of sync.");
+        "Implementation error: m_KnownSubAssets and assetInfo.m_SubAssets are out of sync.");
       sub.m_bMainAsset = false;
       sub.m_ExistanceState = bExisted ? ezAssetExistanceState::FileModified : ezAssetExistanceState::FileAdded;
       sub.m_pAssetInfo = &assetInfo;
@@ -837,6 +837,5 @@ void ezUpdateTask::Execute()
 
   ezUInt64 uiAssetHash = 0;
   ezUInt64 uiThumbHash = 0;
-  ezAssetCurator::GetSingleton()->IsAssetUpToDate(assetGuid, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), pTypeDescriptor,
-                                                  uiAssetHash, uiThumbHash);
+  ezAssetCurator::GetSingleton()->IsAssetUpToDate(assetGuid, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), static_cast<const ezAssetDocumentTypeDescriptor*>(pTypeDescriptor), uiAssetHash, uiThumbHash);
 }

--- a/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
@@ -30,8 +30,6 @@ public:
   {
   }
 
-  virtual const char* GetDocumentTypeDisplayString() const override { return "Asset Profile"; }
-
 public:
   virtual ezDocumentInfo* CreateDocumentInfo() override { return EZ_DEFAULT_NEW(ezDocumentInfo); }
 };

--- a/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.cpp
@@ -32,8 +32,6 @@ public:
   {
   }
 
-  virtual const char* GetDocumentTypeDisplayString() const override { return "Preferences"; }
-
 public:
   virtual ezDocumentInfo* CreateDocumentInfo() override { return EZ_DEFAULT_NEW(ezDocumentInfo); }
 };

--- a/Code/Editor/EditorFramework/DragDrop/AssetDragDropHandler.cpp
+++ b/Code/Editor/EditorFramework/DragDrop/AssetDragDropHandler.cpp
@@ -34,9 +34,9 @@ ezString ezAssetDragDropHandler::GetAssetGuidString(const ezDragDropInfo* pInfo)
   return sGuid.toUtf8().data();
 }
 
-ezString ezAssetDragDropHandler::GetAssetTypeName(const ezUuid& assetTypeGuid) const
+ezString ezAssetDragDropHandler::GetAssetsDocumentTypeName(const ezUuid& assetTypeGuid) const
 {
-  return ezAssetCurator::GetSingleton()->GetSubAsset(assetTypeGuid)->m_Data.m_sAssetTypeName.GetData();
+  return ezAssetCurator::GetSingleton()->GetSubAsset(assetTypeGuid)->m_Data.m_sSubAssetsDocumentTypeName.GetData();
 }
 
 bool ezAssetDragDropHandler::IsSpecificAssetType(const ezDragDropInfo* pInfo, const char* szType) const
@@ -46,5 +46,5 @@ bool ezAssetDragDropHandler::IsSpecificAssetType(const ezDragDropInfo* pInfo, co
 
   const ezUuid guid = GetAssetGuid(pInfo);
 
-  return GetAssetTypeName(guid) == szType;
+  return GetAssetsDocumentTypeName(guid) == szType;
 }

--- a/Code/Editor/EditorFramework/DragDrop/AssetDragDropHandler.h
+++ b/Code/Editor/EditorFramework/DragDrop/AssetDragDropHandler.h
@@ -20,7 +20,7 @@ protected:
     return ezConversionUtils::ConvertStringToUuid(GetAssetGuidString(pInfo));
   }
 
-  ezString GetAssetTypeName(const ezUuid& assetTypeGuid) const;
+  ezString GetAssetsDocumentTypeName(const ezUuid& assetTypeGuid) const;
 
   bool IsSpecificAssetType(const ezDragDropInfo* pInfo, const char* szType) const;
 

--- a/Code/Editor/EditorFramework/EditorApp/Documents.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Documents.cpp
@@ -47,8 +47,7 @@ ezDocument* ezQtEditorApp::OpenDocument(const char* szDocument, ezBitflags<ezDoc
       return nullptr;
     }
 
-    EZ_ASSERT_DEV(pDocument != nullptr, "Opening of document type '{0}' succeeded, but returned pointer is nullptr",
-      pTypeDesc->m_sDocumentTypeName);
+    EZ_ASSERT_DEV(pDocument != nullptr, "Opening of document type '{0}' succeeded, but returned pointer is nullptr", pTypeDesc->m_sDocumentTypeName);
 
     if (pDocument->GetUnknownObjectTypeInstances() > 0)
     {
@@ -100,8 +99,7 @@ ezDocument* ezQtEditorApp::CreateDocument(const char* szDocument, ezBitflags<ezD
       return nullptr;
     }
 
-    EZ_ASSERT_DEV(pDocument != nullptr, "Creation of document type '{0}' succeeded, but returned pointer is nullptr",
-      pTypeDesc->m_sDocumentTypeName);
+    EZ_ASSERT_DEV(pDocument != nullptr, "Creation of document type '{0}' succeeded, but returned pointer is nullptr", pTypeDesc->m_sDocumentTypeName);
     EZ_ASSERT_DEV(pDocument->GetUnknownObjectTypeInstances() == 0, "Newly created documents should not contain unknown types.");
   }
 

--- a/Code/Editor/EditorFramework/EditorApp/DocumentsGUI.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/DocumentsGUI.cpp
@@ -70,8 +70,10 @@ ezString ezQtEditorApp::BuildDocumentTypeFileFilter(bool bForCreation)
 
   const auto& allDesc = ezDocumentManager::GetAllDocumentDescriptors();
 
-  for (auto desc : allDesc)
+  for (auto it : allDesc)
   {
+    auto desc = it.Value();
+
     if (bForCreation && !desc->m_bCanCreate)
       continue;
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -89,7 +89,7 @@ bool ezQtAssetPropertyWidget::IsValidAssetType(const char* szAssetReference) con
   if (ezStringUtils::IsEqual(pAssetAttribute->GetTypeFilter(), ";;")) // empty type list -> allows everything
     return true;
 
-  const ezStringBuilder sTypeFilter(";", pAsset->m_Data.m_sAssetTypeName.GetData(), ";");
+  const ezStringBuilder sTypeFilter(";", pAsset->m_Data.m_sSubAssetsDocumentTypeName.GetData(), ";");
   return ezStringUtils::FindSubString_NoCase(pAssetAttribute->GetTypeFilter(), sTypeFilter) != nullptr;
 }
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -364,7 +364,7 @@ void ezQtAssetPropertyWidget::OnCreateNewAsset()
 
 found:
 
-  ezDynamicArray<const ezDocumentTypeDescriptor*> documentTypes;
+  ezHybridArray<const ezDocumentTypeDescriptor*, 4> documentTypes;
   pAssetManToUse->GetSupportedDocumentTypes(documentTypes);
   const ezString sAssetType = documentTypes[0]->m_sDocumentTypeName;
   const ezString sExtension = documentTypes[0]->m_sFileExtension;

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -15,7 +15,7 @@
 #include <ToolsFoundation/Assets/AssetFileExtensionWhitelist.h>
 
 ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
-    : ezQtStandardPropertyWidget()
+  : ezQtStandardPropertyWidget()
 {
   m_uiThumbnailID = 0;
 
@@ -31,9 +31,9 @@ ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
   setFocusProxy(m_pWidget);
 
   EZ_VERIFY(connect(m_pWidget, SIGNAL(editingFinished()), this, SLOT(on_TextFinished_triggered())) != nullptr,
-            "signal/slot connection failed");
+    "signal/slot connection failed");
   EZ_VERIFY(connect(m_pWidget, SIGNAL(textChanged(const QString&)), this, SLOT(on_TextChanged_triggered(const QString&))) != nullptr,
-            "signal/slot connection failed");
+    "signal/slot connection failed");
 
   m_pButton = new QToolButton(this);
   m_pButton->setText(QStringLiteral("..."));
@@ -42,18 +42,18 @@ ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
 
   EZ_VERIFY(connect(m_pButton, SIGNAL(clicked()), this, SLOT(on_BrowseFile_clicked())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pButton, &QWidget::customContextMenuRequested, this, &ezQtAssetPropertyWidget::on_customContextMenuRequested) !=
-                nullptr,
-            "signal/slot connection failed");
+              nullptr,
+    "signal/slot connection failed");
 
   m_pLayout->addWidget(m_pWidget);
   m_pLayout->addWidget(m_pButton);
 
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageLoaded, this, &ezQtAssetPropertyWidget::ThumbnailLoaded) !=
-                nullptr,
-            "signal/slot connection failed");
+              nullptr,
+    "signal/slot connection failed");
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageInvalidated, this,
-                    &ezQtAssetPropertyWidget::ThumbnailInvalidated) != nullptr,
-            "signal/slot connection failed");
+              &ezQtAssetPropertyWidget::ThumbnailInvalidated) != nullptr,
+    "signal/slot connection failed");
 }
 
 
@@ -96,7 +96,7 @@ bool ezQtAssetPropertyWidget::IsValidAssetType(const char* szAssetReference) con
 void ezQtAssetPropertyWidget::OnInit()
 {
   EZ_ASSERT_DEV(m_pProp->GetAttributeByType<ezAssetBrowserAttribute>() != nullptr,
-                "ezQtAssetPropertyWidget was created without a ezAssetBrowserAttribute!");
+    "ezQtAssetPropertyWidget was created without a ezAssetBrowserAttribute!");
 }
 
 void ezQtAssetPropertyWidget::UpdateThumbnail(const ezUuid& guid, const char* szThumbnailPath)
@@ -115,7 +115,7 @@ void ezQtAssetPropertyWidget::UpdateThumbnail(const ezUuid& guid, const char* sz
     sTypeFilter.Trim(" ;");
 
     pThumbnailPixmap = ezQtImageCache::GetSingleton()->QueryPixmapForType(sTypeFilter, szThumbnailPath, QModelIndex(),
-                                                                          QVariant(uiUserData1), QVariant(uiUserData2), &m_uiThumbnailID);
+      QVariant(uiUserData1), QVariant(uiUserData2), &m_uiThumbnailID);
   }
 
   m_pButton->setCursor(Qt::WhatsThisCursor);
@@ -206,13 +206,13 @@ void ezQtAssetPropertyWidget::FillAssetMenu(QMenu& menu)
   const bool bAsset = m_AssetGuid.IsValid();
   menu.setDefaultAction(menu.addAction(QIcon(), QLatin1String("Select Asset"), this, SLOT(on_BrowseFile_clicked())));
   menu.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Document16.png")), QLatin1String("Open Asset"), this,
-                 SLOT(OnOpenAssetDocument()))
-      ->setEnabled(bAsset);
+        SLOT(OnOpenAssetDocument()))
+    ->setEnabled(bAsset);
   menu.addAction(QIcon(), QLatin1String("Select in Asset Browser"), this, SLOT(OnSelectInAssetBrowser()))->setEnabled(bAsset);
   menu.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder16.png")), QLatin1String("Open in Explorer"), this,
-                 SLOT(OnOpenExplorer()));
+    SLOT(OnOpenExplorer()));
   menu.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/DocumentGuid16.png")), QLatin1String("Copy Asset Guid"), this,
-                 SLOT(OnCopyAssetGuid()));
+    SLOT(OnCopyAssetGuid()));
   menu.addAction(QIcon(), QLatin1String("Create New Asset"), this, SLOT(OnCreateNewAsset()));
   menu.addAction(QIcon(":/GuiFoundation/Icons/Delete16.png"), QLatin1String("Clear Asset Reference"), this, SLOT(OnClearReference()));
 }
@@ -269,7 +269,7 @@ void ezQtAssetPropertyWidget::on_customContextMenuRequested(const QPoint& pt)
 void ezQtAssetPropertyWidget::OnOpenAssetDocument()
 {
   ezQtEditorApp::GetSingleton()->OpenDocumentQueued(ezAssetCurator::GetSingleton()->GetSubAsset(m_AssetGuid)->m_pAssetInfo->m_sAbsolutePath,
-                                              GetSelection()[0].m_pObject);
+    GetSelection()[0].m_pObject);
 }
 
 void ezQtAssetPropertyWidget::OnSelectInAssetBrowser()
@@ -341,25 +341,21 @@ void ezQtAssetPropertyWidget::OnCreateNewAsset()
   {
     const ezHybridArray<ezDocumentManager*, 16>& managers = ezDocumentManager::GetAllDocumentManagers();
 
-    ezSet<ezString> documentTypes;
-
     for (ezDocumentManager* pMan : managers)
     {
-      if (!pMan->GetDynamicRTTI()->IsDerivedFrom<ezAssetDocumentManager>())
-        continue;
-
-      ezAssetDocumentManager* pAssetMan = static_cast<ezAssetDocumentManager*>(pMan);
-
-      documentTypes.Clear();
-      pAssetMan->QuerySupportedAssetTypes(documentTypes);
-
-      for (const ezString& assetType : documentTypes)
+      if (auto pAssetMan = ezDynamicCast<ezAssetDocumentManager*>(pMan))
       {
-        if (!sTypeFilter.FindSubString(assetType))
-          continue;
+        ezHybridArray<const ezDocumentTypeDescriptor*, 4> documentTypes;
+        pAssetMan->GetSupportedDocumentTypes(documentTypes);
 
-        pAssetManToUse = pAssetMan;
-        goto found;
+        for (auto pType : documentTypes)
+        {
+          if (!sTypeFilter.FindSubString(pType->m_sDocumentTypeName))
+            continue;
+
+          pAssetManToUse = pAssetMan;
+          goto found;
+        }
       }
     }
   }
@@ -383,9 +379,9 @@ found:
     QString sStartDir = sTemp.GetData();
     QString sSelectedFilter = sExtension.GetData();
     sOutput = QFileDialog::getSaveFileName(QApplication::activeWindow(), title.GetData(), sStartDir, sFilter.GetData(), &sSelectedFilter,
-                                           QFileDialog::Option::DontResolveSymlinks)
-                  .toUtf8()
-                  .data();
+      QFileDialog::Option::DontResolveSymlinks)
+                .toUtf8()
+                .data();
 
     if (sOutput.IsEmpty())
       return;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
@@ -23,8 +23,6 @@ class ezAnimatedMeshAssetDocument : public ezSimpleAssetDocument<ezAnimatedMeshA
 public:
   ezAnimatedMeshAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Animated Mesh"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
                                           const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -20,19 +20,14 @@ ezAnimatedMeshAssetDocumentManager::ezAnimatedMeshAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Animated_Mesh.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimatedMeshAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
+  m_DocTypeDesc.m_sResourceFileExtension = "ezAnimatedMesh";
 }
 
 ezAnimatedMeshAssetDocumentManager::~ezAnimatedMeshAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezAnimatedMeshAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 void ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -15,11 +15,11 @@ ezAnimatedMeshAssetDocumentManager::ezAnimatedMeshAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Animated Mesh";
-  m_AssetDesc.m_sFileExtension = "ezAnimatedMeshAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Animated_Mesh.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimatedMeshAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Animated Mesh";
+  m_DocTypeDesc.m_sFileExtension = "ezAnimatedMeshAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Animated_Mesh.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimatedMeshAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezAnimatedMeshAssetDocumentManager::~ezAnimatedMeshAssetDocumentManager()
@@ -58,5 +58,5 @@ void ezAnimatedMeshAssetDocumentManager::InternalCreateDocument(const char* szDo
 
 void ezAnimatedMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -15,7 +15,6 @@ ezAnimatedMeshAssetDocumentManager::ezAnimatedMeshAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Animated Mesh";
   m_AssetDesc.m_sFileExtension = "ezAnimatedMeshAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Animated_Mesh.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -52,16 +52,12 @@ void ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocument
   }
 }
 
-ezStatus ezAnimatedMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                    bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezAnimatedMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezAnimatedMeshAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezAnimatedMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezAnimatedMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -16,7 +16,7 @@ ezAnimatedMeshAssetDocumentManager::ezAnimatedMeshAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Animated Mesh Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Animated Mesh";
   m_AssetDesc.m_sFileExtension = "ezAnimatedMeshAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Animated_Mesh.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimatedMeshAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
@@ -24,5 +24,5 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezAnimatedMeshAssetDocumentManager();
   ~ezAnimatedMeshAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezAnimatedMesh"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,6 +19,5 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezAnimatedMesh"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Animated Mesh");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -48,8 +48,6 @@ class ezAnimationClipAssetDocument : public ezSimpleAssetDocument<ezAnimationCli
 public:
   ezAnimationClipAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Animation Clip"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
                                           const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
@@ -14,7 +14,6 @@ ezAnimationClipAssetDocumentManager::ezAnimationClipAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Animation Clip";
   m_AssetDesc.m_sFileExtension = "ezAnimationClipAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Animation_Clip.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
@@ -20,20 +20,15 @@ ezAnimationClipAssetDocumentManager::ezAnimationClipAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimationClipAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezAnimationClip";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::None;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Animation Clip", QPixmap(":/AssetIcons/Animation_Clip.png"));
 }
 
 ezAnimationClipAssetDocumentManager::~ezAnimationClipAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezAnimationClipAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::None;
 }
 
 void ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
@@ -53,16 +53,12 @@ void ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent(const ezDocumen
   }
 }
 
-ezStatus ezAnimationClipAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                     bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezAnimationClipAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezAnimationClipAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezAnimationClipAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezAnimationClipAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
@@ -15,7 +15,7 @@ ezAnimationClipAssetDocumentManager::ezAnimationClipAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Animation Clip Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Animation Clip";
   m_AssetDesc.m_sFileExtension = "ezAnimationClipAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Animation_Clip.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimationClipAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
@@ -14,11 +14,11 @@ ezAnimationClipAssetDocumentManager::ezAnimationClipAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Animation Clip";
-  m_AssetDesc.m_sFileExtension = "ezAnimationClipAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Animation_Clip.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimationClipAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Animation Clip";
+  m_DocTypeDesc.m_sFileExtension = "ezAnimationClipAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Animation_Clip.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezAnimationClipAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Animation Clip", QPixmap(":/AssetIcons/Animation_Clip.png"));
 }
@@ -59,5 +59,5 @@ void ezAnimationClipAssetDocumentManager::InternalCreateDocument(const char* szD
 
 void ezAnimationClipAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezAnimationClip"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Animation Clip");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezAnimationClipAssetDocumentManager();
   ~ezAnimationClipAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezAnimationClip"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
@@ -63,7 +63,7 @@ ezStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& strea
 
     entry.m_sOptionalNiceLookupName = e.m_sLookupName;
     entry.m_sResourceID = e.m_sRedirectionAsset;
-    entry.m_sAssetTypeName = pInfo->m_Data.m_sAssetTypeName;
+    entry.m_sAssetTypeName = pInfo->m_Data.m_sSubAssetsDocumentTypeName;
 
     desc.m_Resources.PushBack(entry);
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
@@ -29,8 +29,6 @@ class ezCollectionAssetDocument : public ezSimpleAssetDocument<ezCollectionAsset
 public:
   ezCollectionAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Collection"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -13,11 +13,11 @@ ezCollectionAssetDocumentManager::ezCollectionAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCollectionAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Collection";
-  m_AssetDesc.m_sFileExtension = "ezCollectionAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Collection.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollectionAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Collection";
+  m_DocTypeDesc.m_sFileExtension = "ezCollectionAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Collection.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezCollectionAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Collection", QPixmap(":/AssetIcons/Collection.png"));
 }
@@ -57,5 +57,5 @@ void ezCollectionAssetDocumentManager::InternalCreateDocument(const char* szDocu
 
 void ezCollectionAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -13,7 +13,6 @@ ezCollectionAssetDocumentManager::ezCollectionAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCollectionAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Collection";
   m_AssetDesc.m_sFileExtension = "ezCollectionAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Collection.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -51,16 +51,12 @@ void ezCollectionAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMa
   }
 }
 
-ezStatus ezCollectionAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                  bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezCollectionAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezCollectionAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezCollectionAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezCollectionAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -19,20 +19,15 @@ ezCollectionAssetDocumentManager::ezCollectionAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezCollectionAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezCollection";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Collection", QPixmap(":/AssetIcons/Collection.png"));
 }
 
 ezCollectionAssetDocumentManager::~ezCollectionAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezCollectionAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezCollectionAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 void ezCollectionAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -14,7 +14,7 @@ ezCollectionAssetDocumentManager::ezCollectionAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCollectionAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Collection Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Collection";
   m_AssetDesc.m_sFileExtension = "ezCollectionAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Collection.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollectionAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
@@ -24,8 +24,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezCollectionAssetDocumentManager();
   ~ezCollectionAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezCollection"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
@@ -13,12 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezCollection"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Collection");
-  }
-
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h
@@ -70,8 +70,6 @@ class ezColorGradientAssetDocument : public ezSimpleAssetDocument<ezColorGradien
 public:
   ezColorGradientAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "ColorGradient"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
@@ -12,7 +12,6 @@ ezColorGradientAssetDocumentManager::ezColorGradientAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezColorGradientAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "ColorGradient";
   m_AssetDesc.m_sFileExtension = "ezColorGradientAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/ColorGradient.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
@@ -12,11 +12,11 @@ ezColorGradientAssetDocumentManager::ezColorGradientAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezColorGradientAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "ColorGradient";
-  m_AssetDesc.m_sFileExtension = "ezColorGradientAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/ColorGradient.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezColorGradientAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "ColorGradient";
+  m_DocTypeDesc.m_sFileExtension = "ezColorGradientAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/ColorGradient.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezColorGradientAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezColorGradientAssetDocumentManager::~ezColorGradientAssetDocumentManager()
@@ -54,5 +54,5 @@ void ezColorGradientAssetDocumentManager::InternalCreateDocument(const char* szD
 
 void ezColorGradientAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
@@ -48,16 +48,12 @@ void ezColorGradientAssetDocumentManager::OnDocumentManagerEvent(const ezDocumen
   }
 }
 
-ezStatus ezColorGradientAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                     bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezColorGradientAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezColorGradientAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezColorGradientAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezColorGradientAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
@@ -17,19 +17,14 @@ ezColorGradientAssetDocumentManager::ezColorGradientAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/ColorGradient.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezColorGradientAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezColorGradient";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezColorGradientAssetDocumentManager::~ezColorGradientAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezColorGradientAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezColorGradientAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 void ezColorGradientAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
@@ -13,7 +13,7 @@ ezColorGradientAssetDocumentManager::ezColorGradientAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezColorGradientAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "ColorGradient Asset";
+  m_AssetDesc.m_sDocumentTypeName = "ColorGradient";
   m_AssetDesc.m_sFileExtension = "ezColorGradientAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/ColorGradient.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezColorGradientAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
@@ -13,12 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezColorGradient"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("ColorGradient");
-  }
-
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
@@ -24,8 +24,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezColorGradientAssetDocumentManager();
   ~ezColorGradientAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezColorGradient"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.h
@@ -12,8 +12,6 @@ class ezCurve1DAssetDocument : public ezSimpleAssetDocument<ezCurveGroupData>
 public:
   ezCurve1DAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Curve1D"; }
-
   /// \brief Fills out the ezCurve1D structure with an exact copy of the data in the asset.
   /// Does NOT yet sort the control points, so before evaluating the curve, that must be called manually.
   void FillCurve(ezUInt32 uiCurveIdx, ezCurve1D& out_Result) const;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
@@ -13,7 +13,7 @@ ezCurve1DAssetDocumentManager::ezCurve1DAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCurve1DAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Curve1D Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Curve1D";
   m_AssetDesc.m_sFileExtension = "ezCurve1DAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Curve1D.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCurve1DAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
@@ -17,18 +17,15 @@ ezCurve1DAssetDocumentManager::ezCurve1DAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Curve1D.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezCurve1DAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezCurve1D";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
+
 }
 
 ezCurve1DAssetDocumentManager::~ezCurve1DAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezCurve1DAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags> ezCurve1DAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 void ezCurve1DAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
@@ -12,7 +12,6 @@ ezCurve1DAssetDocumentManager::ezCurve1DAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCurve1DAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Curve1D";
   m_AssetDesc.m_sFileExtension = "ezCurve1DAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Curve1D.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
@@ -47,16 +47,12 @@ void ezCurve1DAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManag
   }
 }
 
-ezStatus ezCurve1DAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                               ezDocument*& out_pDocument)
+void ezCurve1DAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezCurve1DAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezCurve1DAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezCurve1DAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
@@ -12,11 +12,11 @@ ezCurve1DAssetDocumentManager::ezCurve1DAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCurve1DAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Curve1D";
-  m_AssetDesc.m_sFileExtension = "ezCurve1DAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Curve1D.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCurve1DAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Curve1D";
+  m_DocTypeDesc.m_sFileExtension = "ezCurve1DAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Curve1D.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezCurve1DAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezCurve1DAssetDocumentManager::~ezCurve1DAssetDocumentManager()
@@ -53,5 +53,5 @@ void ezCurve1DAssetDocumentManager::InternalCreateDocument(const char* szDocumen
 
 void ezCurve1DAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezCurve1DAssetDocumentManager();
   ~ezCurve1DAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezCurve1D"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezCurve1D"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Curve1D");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -101,11 +101,6 @@ ezDecalAssetDocument::ezDecalAssetDocument(const char* szDocumentPath)
 {
 }
 
-const char* ezDecalAssetDocument::QueryAssetType() const
-{
-  return "Decal";
-}
-
 ezStatus ezDecalAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag,
   const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
@@ -54,8 +54,6 @@ class ezDecalAssetDocument : public ezSimpleAssetDocument<ezDecalAssetProperties
 public:
   ezDecalAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override;
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -25,11 +25,11 @@ ezDecalAssetDocumentManager::ezDecalAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "dds");
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "tga");
 
-  m_AssetDesc.m_sDocumentTypeName = "Decal";
-  m_AssetDesc.m_sFileExtension = "ezDecalAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Decal.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezDecalAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Decal";
+  m_DocTypeDesc.m_sFileExtension = "ezDecalAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Decal.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezDecalAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezDecalAssetDocumentManager::~ezDecalAssetDocumentManager()
@@ -86,7 +86,7 @@ void ezDecalAssetDocumentManager::InternalCreateDocument(const char* szDocumentT
 
 void ezDecalAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
 
 ezUInt64 ezDecalAssetDocumentManager::ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -80,16 +80,12 @@ void ezDecalAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager
   }
 }
 
-ezStatus ezDecalAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezDecalAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezDecalAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezDecalAssetDocumentManager::InternalGetSupportedDocumentTypes(
-  ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezDecalAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -106,7 +106,7 @@ ezStatus ezDecalAssetDocumentManager::GenerateDecalTexture(const ezPlatformProfi
   {
     const auto& asset = it.Value();
 
-    if (asset.m_pAssetInfo->m_pManager != this)
+    if (asset.m_pAssetInfo->GetManager() != this)
       continue;
 
     uiSettingsHash += asset.m_pAssetInfo->m_Info->m_uiSettingsHash;
@@ -135,7 +135,7 @@ ezStatus ezDecalAssetDocumentManager::GenerateDecalTexture(const ezPlatformProfi
     {
       const auto& asset = it.Value();
 
-      if (asset.m_pAssetInfo->m_pManager != this)
+      if (asset.m_pAssetInfo->GetManager() != this)
         continue;
 
       EZ_LOG_BLOCK("Decal", asset.m_pAssetInfo->m_sDataDirRelativePath.GetData());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -30,19 +30,15 @@ ezDecalAssetDocumentManager::ezDecalAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Decal.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezDecalAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezDecalStub";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezDecalAssetDocumentManager::~ezDecalAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezDecalAssetDocumentManager::OnDocumentManagerEvent, this));
 }
-
-
-ezBitflags<ezAssetDocumentFlags> ezDecalAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  return ezAssetDocumentFlags::SupportsThumbnail;
-}
-
 
 void ezDecalAssetDocumentManager::AddEntriesToAssetTable(
   const char* szDataDirectory, const ezPlatformProfile* pAssetProfile, ezMap<ezString, ezString>& inout_GuidToPath) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -25,7 +25,6 @@ ezDecalAssetDocumentManager::ezDecalAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "dds");
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "tga");
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Decal";
   m_AssetDesc.m_sFileExtension = "ezDecalAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Decal.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -26,7 +26,7 @@ ezDecalAssetDocumentManager::ezDecalAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "tga");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Decal Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Decal";
   m_AssetDesc.m_sFileExtension = "ezDecalAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Decal.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezDecalAssetDocument>();
@@ -139,7 +139,7 @@ ezStatus ezDecalAssetDocumentManager::GenerateDecalTexture(const ezPlatformProfi
       if (asset.m_pAssetInfo->m_pManager != this)
         continue;
 
-      EZ_LOG_BLOCK("Decal Asset", asset.m_pAssetInfo->m_sDataDirRelativePath.GetData());
+      EZ_LOG_BLOCK("Decal", asset.m_pAssetInfo->m_sDataDirRelativePath.GetData());
 
       // does the document already exist and is it open ?
       bool bWasOpen = false;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
@@ -33,8 +33,7 @@ private:
   bool IsDecalTextureUpToDate(const char* szDecalFile, ezUInt64 uiSettingsHash) const;
   ezStatus RunTexConv(const char* szTargetFile, const char* szInputFile, const ezAssetFileHeader& AssetHeader);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
@@ -36,6 +36,6 @@ private:
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezDecalAssetDocumentManager();
   ~ezDecalAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezDecalStub"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
   virtual void AddEntriesToAssetTable(const char* szDataDirectory, const ezPlatformProfile* pAssetProfile,
                                       ezMap<ezString, ezString>& inout_GuidToPath) const override;
   virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const override;
@@ -35,7 +31,6 @@ private:
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezDecalStub"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Decal");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
   virtual void AddEntriesToAssetTable(const char* szDataDirectory, const ezPlatformProfile* pAssetProfile,

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -333,11 +333,11 @@ ezString ezMaterialAssetProperties::ResolveRelativeShaderPath() const
     auto pAsset = ezAssetCurator::GetSingleton()->GetSubAsset(guid);
     if (pAsset)
     {
-      EZ_ASSERT_DEV(pAsset->m_pAssetInfo->m_pManager == m_pDocument->GetDocumentManager(),
-                    "Referenced shader via guid by this material is not of type material asset (ezMaterialShaderMode::Custom).");
+      EZ_ASSERT_DEV(pAsset->m_pAssetInfo->GetManager() == m_pDocument->GetDocumentManager(), "Referenced shader via guid by this material is not of type material asset (ezMaterialShaderMode::Custom).");
+
       ezStringBuilder sProjectDir = ezAssetCurator::GetSingleton()->FindDataDirectoryForAsset(pAsset->m_pAssetInfo->m_sAbsolutePath);
-      ezStringBuilder sResult = pAsset->m_pAssetInfo->m_pManager->GetRelativeOutputFileName(
-          sProjectDir, pAsset->m_pAssetInfo->m_sAbsolutePath, ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+      ezStringBuilder sResult = pAsset->m_pAssetInfo->GetManager()->GetRelativeOutputFileName(sProjectDir, pAsset->m_pAssetInfo->m_sAbsolutePath, ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+
       sResult.Prepend("AssetCache/");
       return sResult;
     }
@@ -980,7 +980,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& stream0, co
           if (!asset.isValid())
             continue;
 
-          sValue = asset->m_pAssetInfo->m_pManager->GetAbsoluteOutputFileName(asset->m_pAssetInfo->m_sAbsolutePath, "", pAssetProfile);
+          sValue = asset->m_pAssetInfo->GetManager()->GetAbsoluteOutputFileName(asset->m_pAssetInfo->m_sAbsolutePath, "", pAssetProfile);
 
           sFilename = sValue.GetFileName();
           sFilename.Append("-lowres");

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -298,8 +298,7 @@ void ezMaterialAssetProperties::LoadOldValues()
 ezString ezMaterialAssetProperties::GetAutoGenShaderPathAbs() const
 {
   ezAssetDocumentManager* pManager = ezDynamicCast<ezAssetDocumentManager*>(m_pDocument->GetDocumentManager());
-  ezString sAbsOutputPath =
-      pManager->GetAbsoluteOutputFileName(m_pDocument->GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+  ezString sAbsOutputPath = pManager->GetAbsoluteOutputFileName(m_pDocument->GetAssetDocumentTypeDescriptor(), m_pDocument->GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
   return sAbsOutputPath;
 }
 
@@ -336,7 +335,7 @@ ezString ezMaterialAssetProperties::ResolveRelativeShaderPath() const
       EZ_ASSERT_DEV(pAsset->m_pAssetInfo->GetManager() == m_pDocument->GetDocumentManager(), "Referenced shader via guid by this material is not of type material asset (ezMaterialShaderMode::Custom).");
 
       ezStringBuilder sProjectDir = ezAssetCurator::GetSingleton()->FindDataDirectoryForAsset(pAsset->m_pAssetInfo->m_sAbsolutePath);
-      ezStringBuilder sResult = pAsset->m_pAssetInfo->GetManager()->GetRelativeOutputFileName(sProjectDir, pAsset->m_pAssetInfo->m_sAbsolutePath, ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+      ezStringBuilder sResult = pAsset->m_pAssetInfo->GetManager()->GetRelativeOutputFileName(m_pDocument->GetAssetDocumentTypeDescriptor(), sProjectDir, pAsset->m_pAssetInfo->m_sAbsolutePath, ezMaterialAssetDocumentManager::s_szShaderOutputTag);
 
       sResult.Prepend("AssetCache/");
       return sResult;
@@ -358,7 +357,7 @@ ezString ezMaterialAssetProperties::ResolveRelativeShaderPath() const
 //////////////////////////////////////////////////////////////////////////
 
 ezMaterialAssetDocument::ezMaterialAssetDocument(const char* szDocumentPath)
-    : ezSimpleAssetDocument<ezMaterialAssetProperties>(EZ_DEFAULT_NEW(ezMaterialObjectManager), szDocumentPath, ezAssetDocEngineConnection::Simple)
+  : ezSimpleAssetDocument<ezMaterialAssetProperties>(EZ_DEFAULT_NEW(ezMaterialObjectManager), szDocumentPath, ezAssetDocEngineConnection::Simple)
 {
   ezQtEditorApp::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&ezMaterialAssetDocument::EditorEventHandler, this));
 }
@@ -471,7 +470,7 @@ ezUuid ezMaterialAssetDocument::GetMaterialNodeGuid(const ezAbstractObjectGraph&
 }
 
 void ezMaterialAssetDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed,
-                                                 const char* szBasePrefab)
+  const char* szBasePrefab)
 {
   // Base
   ezAbstractObjectGraph baseGraph;
@@ -599,7 +598,7 @@ public:
   ezResult m_Status;
 
   ezVisualShaderErrorLog()
-      : m_Status(EZ_SUCCESS)
+    : m_Status(EZ_SUCCESS)
   {
   }
 
@@ -624,8 +623,8 @@ public:
 };
 
 ezStatus ezMaterialAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag,
-                                                         const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader,
-                                                         ezBitflags<ezTransformFlags> transformFlags)
+  const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader,
+  ezBitflags<ezTransformFlags> transformFlags)
 {
   if (ezStringUtils::IsEqual(szOutputTag, ezMaterialAssetDocumentManager::s_szShaderOutputTag))
   {
@@ -690,7 +689,7 @@ ezStatus ezMaterialAssetDocument::InternalTransformAsset(const char* szTargetFil
           else
           {
             e.m_Type =
-                log.m_Status.Succeeded() ? ezMaterialVisualShaderEvent::TransformSucceeded : ezMaterialVisualShaderEvent::TransformFailed;
+              log.m_Status.Succeeded() ? ezMaterialVisualShaderEvent::TransformSucceeded : ezMaterialVisualShaderEvent::TransformFailed;
             e.m_sTransformError = log.m_sResult;
             ezLog::Info("Compiled Visual Shader.");
           }
@@ -718,7 +717,7 @@ ezStatus ezMaterialAssetDocument::InternalTransformAsset(const char* szTargetFil
 }
 
 ezStatus ezMaterialAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag,
-                                                         const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader,
+  const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader,
   ezBitflags<ezTransformFlags> transformFlags)
 {
   EZ_ASSERT_DEV(ezStringUtils::IsNullOrEmpty(szOutputTag), "Additional output '{0}' not implemented!", szOutputTag);
@@ -747,9 +746,9 @@ void ezMaterialAssetDocument::InternalGetMetaDataHash(const ezDocumentObject* pO
         inout_uiHash = ezHashingUtils::xxHash64(&pPinSource->GetParent()->GetGuid(), sizeof(ezUuid), inout_uiHash);
         inout_uiHash = ezHashingUtils::xxHash64(&pPinTarget->GetParent()->GetGuid(), sizeof(ezUuid), inout_uiHash);
         inout_uiHash =
-            ezHashingUtils::xxHash64(pPinSource->GetName(), ezStringUtils::GetStringElementCount(pPinSource->GetName()), inout_uiHash);
+          ezHashingUtils::xxHash64(pPinSource->GetName(), ezStringUtils::GetStringElementCount(pPinSource->GetName()), inout_uiHash);
         inout_uiHash =
-            ezHashingUtils::xxHash64(pPinTarget->GetName(), ezStringUtils::GetStringElementCount(pPinTarget->GetName()), inout_uiHash);
+          ezHashingUtils::xxHash64(pPinTarget->GetName(), ezStringUtils::GetStringElementCount(pPinTarget->GetName()), inout_uiHash);
       }
     }
   }
@@ -809,7 +808,7 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
 }
 
 ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& stream0, const ezPlatformProfile* pAssetProfile,
-                                                     bool bEmbedLowResData) const
+  bool bEmbedLowResData) const
 {
   const ezMaterialAssetProperties* pProp = GetProperties();
 
@@ -899,7 +898,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& stream0, co
         {
           ezStringBuilder s;
           ezReflectionUtils::EnumerationToString(Permutation[p]->GetSpecificType(),
-                                                 pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezInt64>(), s);
+            pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezInt64>(), s);
 
           sValue = s.FindLastSubString("::") + 2;
         }
@@ -980,7 +979,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& stream0, co
           if (!asset.isValid())
             continue;
 
-          sValue = asset->m_pAssetInfo->GetManager()->GetAbsoluteOutputFileName(asset->m_pAssetInfo->m_sAbsolutePath, "", pAssetProfile);
+          sValue = asset->m_pAssetInfo->GetManager()->GetAbsoluteOutputFileName(asset->m_pAssetInfo->m_pDocumentTypeDescriptor, asset->m_pAssetInfo->m_sAbsolutePath, "", pAssetProfile);
 
           sFilename = sValue.GetFileName();
           sFilename.Append("-lowres");
@@ -1009,8 +1008,8 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& stream0, co
     stream.FinishCompressedStream();
 
     ezLog::Dev("Compressed material data from {0} KB to {1} KB ({2}%%)", ezArgF((float)stream.GetUncompressedSize() / 1024.0f, 1),
-               ezArgF((float)stream.GetCompressedSize() / 1024.0f, 1),
-               ezArgF(100.0f * stream.GetCompressedSize() / stream.GetUncompressedSize(), 1));
+      ezArgF((float)stream.GetCompressedSize() / 1024.0f, 1),
+      ezArgF(100.0f * stream.GetCompressedSize() / stream.GetUncompressedSize(), 1));
 #endif
   }
 
@@ -1023,7 +1022,7 @@ void ezMaterialAssetDocument::TagVisualShaderFileInvalid(const ezPlatformProfile
     return;
 
   ezAssetDocumentManager* pManager = ezDynamicCast<ezAssetDocumentManager*>(GetDocumentManager());
-  ezString sAutoGenShader = pManager->GetAbsoluteOutputFileName(GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+  ezString sAutoGenShader = pManager->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
 
   ezStringBuilder all;
 
@@ -1056,7 +1055,7 @@ ezStatus ezMaterialAssetDocument::RecreateVisualShaderFile(const ezAssetFileHead
   }
 
   ezAssetDocumentManager* pManager = ezDynamicCast<ezAssetDocumentManager*>(GetDocumentManager());
-  ezString sAutoGenShader = pManager->GetAbsoluteOutputFileName(GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+  ezString sAutoGenShader = pManager->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
 
   ezVisualShaderCodeGenerator codeGen;
 
@@ -1086,7 +1085,7 @@ void ezMaterialAssetDocument::InvalidateCachedShader()
 
   if (GetProperties()->m_ShaderMode == ezMaterialShaderMode::Custom)
   {
-    sShader = pManager->GetAbsoluteOutputFileName(GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+    sShader = pManager->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
   }
   else
   {
@@ -1106,7 +1105,7 @@ void ezMaterialAssetDocument::EditorEventHandler(const ezEditorAppEvent& e)
 }
 
 static void MarkReachableNodes(ezMap<const ezDocumentObject*, bool>& AllNodes, const ezDocumentObject* pRoot,
-                               ezDocumentNodeManager* pNodeManager)
+  ezDocumentNodeManager* pNodeManager)
 {
   if (AllNodes[pRoot])
     return;
@@ -1257,7 +1256,7 @@ bool ezMaterialAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& out_obj
 }
 
 bool ezMaterialAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition,
-                                    const char* szMimeType)
+  const char* szMimeType)
 {
   bool bAddedAll = true;
 
@@ -1323,7 +1322,7 @@ class ezMaterialAssetPropertiesPatch_1_2 : public ezGraphPatch
 {
 public:
   ezMaterialAssetPropertiesPatch_1_2()
-      : ezGraphPatch("ezMaterialAssetProperties", 2)
+    : ezGraphPatch("ezMaterialAssetProperties", 2)
   {
   }
 
@@ -1341,7 +1340,7 @@ class ezMaterialAssetPropertiesPatch_2_3 : public ezGraphPatch
 {
 public:
   ezMaterialAssetPropertiesPatch_2_3()
-      : ezGraphPatch("ezMaterialAssetProperties", 3)
+    : ezGraphPatch("ezMaterialAssetProperties", 3)
   {
   }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.h
@@ -91,8 +91,6 @@ public:
   ezMaterialAssetDocument(const char* szDocumentPath);
   ~ezMaterialAssetDocument();
 
-  virtual const char* QueryAssetType() const override { return "Material"; }
-
   ezDocumentObject* GetShaderPropertyObject();
   const ezDocumentObject* GetShaderPropertyObject() const;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -18,7 +18,6 @@ ezMaterialAssetDocumentManager::ezMaterialAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Material";
   m_AssetDesc.m_sFileExtension = "ezMaterialAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Material.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -100,16 +100,12 @@ void ezMaterialAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMana
   }
 }
 
-ezStatus ezMaterialAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                                ezDocument*& out_pDocument)
+void ezMaterialAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezMaterialAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezMaterialAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezMaterialAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -18,11 +18,11 @@ ezMaterialAssetDocumentManager::ezMaterialAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
 
-  m_AssetDesc.m_sDocumentTypeName = "Material";
-  m_AssetDesc.m_sFileExtension = "ezMaterialAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Material.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezMaterialAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Material";
+  m_DocTypeDesc.m_sFileExtension = "ezMaterialAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Material.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezMaterialAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezMaterialAssetDocumentManager::~ezMaterialAssetDocumentManager()
@@ -106,5 +106,5 @@ void ezMaterialAssetDocumentManager::InternalCreateDocument(const char* szDocume
 
 void ezMaterialAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -19,7 +19,7 @@ ezMaterialAssetDocumentManager::ezMaterialAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Material Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Material";
   m_AssetDesc.m_sFileExtension = "ezMaterialAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Material.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezMaterialAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezMaterialBin"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Material");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
   virtual ezString GetRelativeOutputFileName(const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const override;
   virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, ezUInt16 uiTypeVersion) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
@@ -26,8 +26,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
@@ -11,13 +11,11 @@ public:
   ezMaterialAssetDocumentManager();
   ~ezMaterialAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezMaterialBin"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-  virtual ezString GetRelativeOutputFileName(const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const override;
-  virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, ezUInt16 uiTypeVersion) override;
+  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const override;
+  virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor) override;
 
   static const char* const s_szShaderOutputTag;
+
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -27,6 +25,5 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
-

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
@@ -27,6 +27,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -32,12 +32,12 @@ ezDirectoryWatcher* ezQtMaterialAssetDocumentWindow::s_pNodeConfigWatcher = null
 
 
 ezQtMaterialAssetDocumentWindow::ezQtMaterialAssetDocumentWindow(ezMaterialAssetDocument* pDocument)
-    : ezQtEngineDocumentWindow(pDocument)
+  : ezQtEngineDocumentWindow(pDocument)
 {
   GetDocument()->GetObjectManager()->m_PropertyEvents.AddEventHandler(
-      ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::PropertyEventHandler, this));
+    ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::PropertyEventHandler, this));
   GetDocument()->GetSelectionManager()->m_Events.AddEventHandler(
-      ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::SelectionEventHandler, this));
+    ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::SelectionEventHandler, this));
 
   pDocument->m_VisualShaderEvents.AddEventHandler(ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::VisualShaderEventHandler, this));
 
@@ -151,14 +151,14 @@ ezQtMaterialAssetDocumentWindow::ezQtMaterialAssetDocumentWindow(ezMaterialAsset
 ezQtMaterialAssetDocumentWindow::~ezQtMaterialAssetDocumentWindow()
 {
   GetMaterialDocument()->m_VisualShaderEvents.RemoveEventHandler(
-      ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::VisualShaderEventHandler, this));
+    ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::VisualShaderEventHandler, this));
 
   RestoreResource();
 
   GetDocument()->GetSelectionManager()->m_Events.RemoveEventHandler(
-      ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::SelectionEventHandler, this));
+    ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::SelectionEventHandler, this));
   GetDocument()->GetObjectManager()->m_PropertyEvents.RemoveEventHandler(
-      ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::PropertyEventHandler, this));
+    ezMakeDelegate(&ezQtMaterialAssetDocumentWindow::PropertyEventHandler, this));
 
   const bool bCustom = GetMaterialDocument()->GetPropertyObject()->GetTypeAccessor().GetValue("ShaderMode").ConvertTo<ezInt64>() ==
                        ezMaterialShaderMode::Custom;
@@ -218,8 +218,7 @@ void ezQtMaterialAssetDocumentWindow::OnOpenShaderClicked(bool)
 {
   ezAssetDocumentManager* pManager = (ezAssetDocumentManager*)GetMaterialDocument()->GetDocumentManager();
 
-  ezString sAutoGenShader =
-      pManager->GetAbsoluteOutputFileName(GetMaterialDocument()->GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
+  ezString sAutoGenShader = pManager->GetAbsoluteOutputFileName(GetMaterialDocument()->GetAssetDocumentTypeDescriptor(), GetMaterialDocument()->GetDocumentPath(), ezMaterialAssetDocumentManager::s_szShaderOutputTag);
 
   if (ezOSFile::ExistsFile(sAutoGenShader))
   {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -24,8 +24,6 @@ class ezMeshAssetDocument : public ezSimpleAssetDocument<ezMeshAssetProperties>
 public:
   ezMeshAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Mesh"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -120,16 +120,12 @@ void ezMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager:
   }
 }
 
-ezStatus ezMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                            ezDocument*& out_pDocument)
+void ezMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezMeshAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -18,11 +18,11 @@ ezMeshAssetDocumentManager::ezMeshAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Mesh", "ezMesh");
 
-  m_AssetDesc.m_sDocumentTypeName = "Mesh";
-  m_AssetDesc.m_sFileExtension = "ezMeshAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Mesh.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezMeshAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Mesh";
+  m_DocTypeDesc.m_sFileExtension = "ezMeshAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Mesh.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezMeshAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezMeshAssetDocumentManager::~ezMeshAssetDocumentManager()
@@ -126,5 +126,5 @@ void ezMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTy
 
 void ezMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -18,7 +18,6 @@ ezMeshAssetDocumentManager::ezMeshAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Mesh", "ezMesh");
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Mesh";
   m_AssetDesc.m_sFileExtension = "ezMeshAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Mesh.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -23,18 +23,14 @@ ezMeshAssetDocumentManager::ezMeshAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Mesh.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezMeshAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezMesh";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezMeshAssetDocumentManager::~ezMeshAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezMeshAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags> ezMeshAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezResult ezMeshAssetDocumentManager::OpenPickedDocument(const ezDocumentObject* pPickedComponent, ezUInt32 uiPartIndex)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -19,7 +19,7 @@ ezMeshAssetDocumentManager::ezMeshAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Mesh", "ezMesh");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Mesh Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Mesh";
   m_AssetDesc.m_sFileExtension = "ezMeshAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Mesh.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezMeshAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezMeshAssetDocumentManager();
   ~ezMeshAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezMesh"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
   virtual ezResult OpenPickedDocument(const ezDocumentObject* pPickedComponent, ezUInt32 uiPartIndex) override;
 
 private:
@@ -26,6 +22,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezMesh"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Mesh");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
   virtual ezResult OpenPickedDocument(const ezDocumentObject* pPickedComponent, ezUInt32 uiPartIndex) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
@@ -25,8 +25,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
@@ -26,6 +26,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
@@ -67,7 +67,6 @@ public:
   ezPropertyAnimAssetDocument(const char* szDocumentPath);
   ~ezPropertyAnimAssetDocument();
 
-  virtual const char* QueryAssetType() const override { return "PropertyAnim"; }
   virtual ezObjectAccessorBase* GetObjectAccessor() const override;
 
   void SetAnimationDurationTicks(ezUInt64 uiNumTicks);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
@@ -52,16 +52,12 @@ void ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent(const ezDocument
   }
 }
 
-ezStatus ezPropertyAnimAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                    bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezPropertyAnimAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezPropertyAnimAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezPropertyAnimAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezPropertyAnimAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
@@ -13,7 +13,6 @@ ezPropertyAnimAssetDocumentManager::ezPropertyAnimAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "PropertyAnim";
   m_AssetDesc.m_sFileExtension = "ezPropertyAnimAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/PropertyAnim.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
@@ -14,7 +14,7 @@ ezPropertyAnimAssetDocumentManager::ezPropertyAnimAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "PropertyAnim Asset";
+  m_AssetDesc.m_sDocumentTypeName = "PropertyAnim";
   m_AssetDesc.m_sFileExtension = "ezPropertyAnimAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/PropertyAnim.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezPropertyAnimAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
@@ -19,20 +19,15 @@ ezPropertyAnimAssetDocumentManager::ezPropertyAnimAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezPropertyAnimAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezPropertyAnim";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("PropertyAnim", QPixmap(":/AssetIcons/PropertyAnim.png"));
 }
 
 ezPropertyAnimAssetDocumentManager::~ezPropertyAnimAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezPropertyAnimAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 void ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
@@ -13,11 +13,11 @@ ezPropertyAnimAssetDocumentManager::ezPropertyAnimAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "PropertyAnim";
-  m_AssetDesc.m_sFileExtension = "ezPropertyAnimAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/PropertyAnim.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezPropertyAnimAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "PropertyAnim";
+  m_DocTypeDesc.m_sFileExtension = "ezPropertyAnimAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/PropertyAnim.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezPropertyAnimAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("PropertyAnim", QPixmap(":/AssetIcons/PropertyAnim.png"));
 }
@@ -58,5 +58,5 @@ void ezPropertyAnimAssetDocumentManager::InternalCreateDocument(const char* szDo
 
 void ezPropertyAnimAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
@@ -13,12 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezPropertyAnim"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("PropertyAnim");
-  }
-
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
@@ -24,8 +24,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezPropertyAnimAssetDocumentManager();
   ~ezPropertyAnimAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezPropertyAnim"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.h
@@ -22,8 +22,6 @@ class ezRenderPipelineAssetDocument : public ezAssetDocument
 public:
   ezRenderPipelineAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "RenderPipeline"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
@@ -13,10 +13,6 @@ ezRenderPipelineAssetManager::ezRenderPipelineAssetManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezRenderPipelineAssetManager::OnDocumentManagerEvent, this));
 
-  // additional whitelist for non-asset files where an asset may be selected
-  // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
-
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "RenderPipeline";
   m_AssetDesc.m_sFileExtension = "ezRenderPipelineAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/RenderPipeline.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
@@ -19,19 +19,15 @@ ezRenderPipelineAssetManager::ezRenderPipelineAssetManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezRenderPipelineAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezRenderPipelineBin";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("RenderPipeline", QPixmap(":/AssetIcons/RenderPipeline.png"));
 }
 
 ezRenderPipelineAssetManager::~ezRenderPipelineAssetManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezRenderPipelineAssetManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags> ezRenderPipelineAssetManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 void ezRenderPipelineAssetManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
@@ -13,11 +13,11 @@ ezRenderPipelineAssetManager::ezRenderPipelineAssetManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezRenderPipelineAssetManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "RenderPipeline";
-  m_AssetDesc.m_sFileExtension = "ezRenderPipelineAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/RenderPipeline.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezRenderPipelineAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "RenderPipeline";
+  m_DocTypeDesc.m_sFileExtension = "ezRenderPipelineAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/RenderPipeline.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezRenderPipelineAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("RenderPipeline", QPixmap(":/AssetIcons/RenderPipeline.png"));
 }
@@ -56,5 +56,5 @@ void ezRenderPipelineAssetManager::InternalCreateDocument(const char* szDocument
 
 void ezRenderPipelineAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
@@ -17,7 +17,7 @@ ezRenderPipelineAssetManager::ezRenderPipelineAssetManager()
   // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Render Pipeline Asset";
+  m_AssetDesc.m_sDocumentTypeName = "RenderPipeline";
   m_AssetDesc.m_sFileExtension = "ezRenderPipelineAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/RenderPipeline.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezRenderPipelineAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
@@ -53,16 +53,12 @@ void ezRenderPipelineAssetManager::OnDocumentManagerEvent(const ezDocumentManage
   }
 }
 
-ezStatus ezRenderPipelineAssetManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                              ezDocument*& out_pDocument)
+void ezRenderPipelineAssetManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezRenderPipelineAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezRenderPipelineAssetManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezRenderPipelineAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezRenderPipelineAssetManager();
   ~ezRenderPipelineAssetManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezRenderPipelineBin"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezRenderPipelineBin"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("RenderPipeline");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -16,8 +16,6 @@ public:
   ezSkeletonAssetDocument(const char* szDocumentPath);
   ~ezSkeletonAssetDocument();
 
-  virtual const char* QueryAssetType() const override { return "Skeleton"; }
-
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
 protected:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -14,11 +14,11 @@ ezSkeletonAssetDocumentManager::ezSkeletonAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSkeletonAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Skeleton";
-  m_AssetDesc.m_sFileExtension = "ezSkeletonAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Skeleton.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSkeletonAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Skeleton";
+  m_DocTypeDesc.m_sFileExtension = "ezSkeletonAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Skeleton.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSkeletonAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezSkeletonAssetDocumentManager::~ezSkeletonAssetDocumentManager()
@@ -57,5 +57,5 @@ void ezSkeletonAssetDocumentManager::InternalCreateDocument(const char* szDocume
 
 void ezSkeletonAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -15,7 +15,7 @@ ezSkeletonAssetDocumentManager::ezSkeletonAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSkeletonAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Skeleton Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Skeleton";
   m_AssetDesc.m_sFileExtension = "ezSkeletonAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Skeleton.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSkeletonAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -19,19 +19,14 @@ ezSkeletonAssetDocumentManager::ezSkeletonAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Skeleton.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSkeletonAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezSkeleton";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezSkeletonAssetDocumentManager::~ezSkeletonAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezSkeletonAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezSkeletonAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 void ezSkeletonAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -14,14 +14,11 @@ ezSkeletonAssetDocumentManager::ezSkeletonAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSkeletonAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Skeleton";
   m_AssetDesc.m_sFileExtension = "ezSkeletonAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Skeleton.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSkeletonAssetDocument>();
   m_AssetDesc.m_pManager = this;
-
-  // ezQtImageCache::GetSingleton()->RegisterTypeImage("Skeleton", QPixmap(":/AssetIcons/Skeleton.png"));
 }
 
 ezSkeletonAssetDocumentManager::~ezSkeletonAssetDocumentManager()

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -53,16 +53,12 @@ void ezSkeletonAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMana
   }
 }
 
-ezStatus ezSkeletonAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                                ezDocument*& out_pDocument)
+void ezSkeletonAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezSkeletonAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezSkeletonAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezSkeletonAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezSkeleton"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Skeleton");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezSkeletonAssetDocumentManager();
   ~ezSkeletonAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezSkeleton"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -24,6 +20,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.h
@@ -10,8 +10,6 @@ class ezSurfaceAssetDocument : public ezSimpleAssetDocument<ezSurfaceResourceDes
 public:
   ezSurfaceAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Surface"; }
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
@@ -13,9 +13,6 @@ ezSurfaceAssetDocumentManager::ezSurfaceAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSurfaceAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  // additional whitelist for non-asset files where an asset may be selected
-  // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Surface", "ezSurface");
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Surface";
   m_AssetDesc.m_sFileExtension = "ezSurfaceAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Surface.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
@@ -19,19 +19,15 @@ ezSurfaceAssetDocumentManager::ezSurfaceAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSurfaceAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezSurface";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Surface", QPixmap(":/AssetIcons/Surface.png"));
 }
 
 ezSurfaceAssetDocumentManager::~ezSurfaceAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezSurfaceAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags> ezSurfaceAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 void ezSurfaceAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
@@ -52,16 +52,12 @@ void ezSurfaceAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManag
   }
 }
 
-ezStatus ezSurfaceAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                               ezDocument*& out_pDocument)
+void ezSurfaceAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezSurfaceAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezSurfaceAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezSurfaceAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
@@ -16,7 +16,7 @@ ezSurfaceAssetDocumentManager::ezSurfaceAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Surface", "ezSurface");
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Surface Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Surface";
   m_AssetDesc.m_sFileExtension = "ezSurfaceAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Surface.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSurfaceAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
@@ -13,11 +13,11 @@ ezSurfaceAssetDocumentManager::ezSurfaceAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSurfaceAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Surface";
-  m_AssetDesc.m_sFileExtension = "ezSurfaceAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Surface.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSurfaceAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Surface";
+  m_DocTypeDesc.m_sFileExtension = "ezSurfaceAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Surface.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSurfaceAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Surface", QPixmap(":/AssetIcons/Surface.png"));
 }
@@ -56,5 +56,5 @@ void ezSurfaceAssetDocumentManager::InternalCreateDocument(const char* szDocumen
 
 void ezSurfaceAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
@@ -13,12 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezSurface"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Surface");
-  }
-
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
@@ -24,8 +24,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezSurfaceAssetDocumentManager();
   ~ezSurfaceAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezSurface"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -24,6 +20,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -503,16 +503,6 @@ ezStatus ezTextureAssetDocument::InternalTransformAsset(const char* szTargetFile
   }
 }
 
-const char* ezTextureAssetDocument::QueryAssetType() const
-{
-  if (m_bIsRenderTarget)
-  {
-    return "Render Target";
-  }
-
-  return "Texture 2D";
-}
-
 //////////////////////////////////////////////////////////////////////////
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureAssetDocumentGenerator, 1, ezRTTIDefaultAllocator<ezTextureAssetDocumentGenerator>)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -384,8 +384,7 @@ void ezTextureAssetDocument::InitializeAfterLoading(bool bFirstTimeCreation)
   }
 }
 
-ezStatus ezTextureAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag,
-  const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezStatus ezTextureAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   // EZ_ASSERT_DEV(ezStringUtils::IsEqual(szPlatform, "PC"), "Platform '{0}' is not supported", szPlatform);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
@@ -31,9 +31,6 @@ class ezTextureAssetDocument : public ezSimpleAssetDocument<ezTextureAssetProper
 public:
   ezTextureAssetDocument(const char* szDocumentPath);
 
-  /// \brief Overridden, because QueryAssetType() doesn't return a constant here
-  virtual const char* GetDocumentTypeDisplayString() const override { return "Texture Asset"; }
-
   virtual const char* QueryAssetType() const override;
 
   // for previewing purposes

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
@@ -31,8 +31,6 @@ class ezTextureAssetDocument : public ezSimpleAssetDocument<ezTextureAssetProper
 public:
   ezTextureAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override;
-
   // for previewing purposes
   ezEnum<ezTextureChannelMode> m_ChannelMode;
   ezInt32 m_iTextureLod; // -1 == regular sampling, >= 0 == sample that level

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -36,14 +36,14 @@ ezTextureAssetDocumentManager::ezTextureAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "tga");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Texture Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Texture 2D";
   m_AssetDesc.m_sFileExtension = "ezTextureAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Texture_2D.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
   m_AssetDesc.m_pManager = this;
 
   m_AssetDescRT.m_bCanCreate = true;
-  m_AssetDescRT.m_sDocumentTypeName = "Render Target Asset";
+  m_AssetDescRT.m_sDocumentTypeName = "Render Target";
   m_AssetDescRT.m_sFileExtension = "ezRenderTargetAsset";
   m_AssetDescRT.m_sIcon = ":/AssetIcons/Render_Target.png";
   m_AssetDescRT.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
@@ -74,7 +74,7 @@ ezUInt64 ezTextureAssetDocumentManager::ComputeAssetProfileHashImpl(const ezPlat
 
 ezBitflags<ezAssetDocumentFlags> ezTextureAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
 {
-  if (pDescriptor->m_sDocumentTypeName == "Render Target Asset")
+  if (pDescriptor->m_sDocumentTypeName == "Render Target")
   {
     return ezAssetDocumentFlags::AutoTransformOnSave;
   }
@@ -104,7 +104,7 @@ void ezTextureAssetDocumentManager::InternalCreateDocument(const char* szDocumen
   ezTextureAssetDocument* pDoc = new ezTextureAssetDocument(szPath);
   out_pDocument = pDoc;
 
-  if (ezStringUtils::IsEqual(szDocumentTypeName, "Render Target Asset"))
+  if (ezStringUtils::IsEqual(szDocumentTypeName, "Render Target"))
   {
     pDoc->m_bIsRenderTarget = true;
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -35,14 +35,12 @@ ezTextureAssetDocumentManager::ezTextureAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "dds");
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "tga");
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Texture 2D";
   m_AssetDesc.m_sFileExtension = "ezTextureAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Texture_2D.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
   m_AssetDesc.m_pManager = this;
 
-  m_AssetDescRT.m_bCanCreate = true;
   m_AssetDescRT.m_sDocumentTypeName = "Render Target";
   m_AssetDescRT.m_sFileExtension = "ezRenderTargetAsset";
   m_AssetDescRT.m_sIcon = ":/AssetIcons/Render_Target.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -99,8 +99,7 @@ void ezTextureAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManag
   }
 }
 
-ezStatus ezTextureAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                               ezDocument*& out_pDocument)
+void ezTextureAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   ezTextureAssetDocument* pDoc = new ezTextureAssetDocument(szPath);
   out_pDocument = pDoc;
@@ -109,12 +108,9 @@ ezStatus ezTextureAssetDocumentManager::InternalCreateDocument(const char* szDoc
   {
     pDoc->m_bIsRenderTarget = true;
   }
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezTextureAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezTextureAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
   inout_DocumentTypes.PushBack(&m_AssetDescRT);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -40,12 +40,16 @@ ezTextureAssetDocumentManager::ezTextureAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Texture_2D.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+  m_DocTypeDesc.m_sResourceFileExtension = "ezTexture2D";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoThumbnailOnTransform;
 
   m_DocTypeDesc2.m_sDocumentTypeName = "Render Target";
   m_DocTypeDesc2.m_sFileExtension = "ezRenderTargetAsset";
   m_DocTypeDesc2.m_sIcon = ":/AssetIcons/Render_Target.png";
   m_DocTypeDesc2.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
   m_DocTypeDesc2.m_pManager = this;
+  m_DocTypeDesc2.m_sResourceFileExtension = "ezRenderTarget";
+  m_DocTypeDesc2.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Render Target", QPixmap(":/AssetIcons/Render_Target.png"));
 }
@@ -55,31 +59,9 @@ ezTextureAssetDocumentManager::~ezTextureAssetDocumentManager()
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezTextureAssetDocumentManager::OnDocumentManagerEvent, this));
 }
 
-ezString ezTextureAssetDocumentManager::GetResourceTypeExtension(const char* szDocumentPath) const
-{
-  const ezStringView extension = ezPathUtils::GetFileExtension(szDocumentPath);
-
-  if (extension == "ezRenderTargetAsset")
-    return "ezRenderTarget";
-
-  return "ezTexture2D";
-}
-
 ezUInt64 ezTextureAssetDocumentManager::ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const
 {
   return pAssetProfile->GetTypeConfig<ezTextureAssetProfileConfig>()->m_uiMaxResolution;
-}
-
-ezBitflags<ezAssetDocumentFlags> ezTextureAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  if (pDescriptor->m_sDocumentTypeName == "Render Target")
-  {
-    return ezAssetDocumentFlags::AutoTransformOnSave;
-  }
-  else // Texture 2D
-  {
-    return ezAssetDocumentFlags::AutoThumbnailOnTransform;
-  }
 }
 
 void ezTextureAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -35,17 +35,17 @@ ezTextureAssetDocumentManager::ezTextureAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "dds");
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Image2D", "tga");
 
-  m_AssetDesc.m_sDocumentTypeName = "Texture 2D";
-  m_AssetDesc.m_sFileExtension = "ezTextureAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Texture_2D.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Texture 2D";
+  m_DocTypeDesc.m_sFileExtension = "ezTextureAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Texture_2D.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
-  m_AssetDescRT.m_sDocumentTypeName = "Render Target";
-  m_AssetDescRT.m_sFileExtension = "ezRenderTargetAsset";
-  m_AssetDescRT.m_sIcon = ":/AssetIcons/Render_Target.png";
-  m_AssetDescRT.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
-  m_AssetDescRT.m_pManager = this;
+  m_DocTypeDesc2.m_sDocumentTypeName = "Render Target";
+  m_DocTypeDesc2.m_sFileExtension = "ezRenderTargetAsset";
+  m_DocTypeDesc2.m_sIcon = ":/AssetIcons/Render_Target.png";
+  m_DocTypeDesc2.m_pDocumentType = ezGetStaticRTTI<ezTextureAssetDocument>();
+  m_DocTypeDesc2.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Render Target", QPixmap(":/AssetIcons/Render_Target.png"));
 }
@@ -110,6 +110,6 @@ void ezTextureAssetDocumentManager::InternalCreateDocument(const char* szDocumen
 
 void ezTextureAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
-  inout_DocumentTypes.PushBack(&m_AssetDescRT);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc2);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
@@ -20,11 +20,6 @@ public:
   ezTextureAssetDocumentManager();
   ~ezTextureAssetDocumentManager();
 
-
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override;
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -36,6 +31,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
-  ezDocumentTypeDescriptor m_DocTypeDesc2;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc2;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
@@ -36,6 +36,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
-  ezDocumentTypeDescriptor m_AssetDescRT;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc2;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
@@ -36,8 +36,7 @@ private:
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
@@ -23,12 +23,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override;
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Texture 2D");
-    inout_AssetTypeNames.Insert("Render Target");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetWindow.cpp
@@ -72,9 +72,8 @@ ezActionDescriptorHandle ezTextureAssetActions::s_hLodSlider;
 
 void ezTextureAssetActions::RegisterActions()
 {
-  s_hTextureChannelMode =
-      EZ_REGISTER_DYNAMIC_MENU("TextureAsset.ChannelMode", ezTextureChannelModeAction, ":/EditorFramework/Icons/RenderMode.png");
-  s_hLodSlider = EZ_REGISTER_ACTION_0("TextureAsset.LodSlider", ezActionScope::Document, "Texture Asset", "", ezTextureLodSliderAction);
+  s_hTextureChannelMode = EZ_REGISTER_DYNAMIC_MENU("TextureAsset.ChannelMode", ezTextureChannelModeAction, ":/EditorFramework/Icons/RenderMode.png");
+  s_hLodSlider = EZ_REGISTER_ACTION_0("TextureAsset.LodSlider", ezActionScope::Document, "Texture 2D", "", ezTextureLodSliderAction);
 }
 
 void ezTextureAssetActions::UnregisterActions()

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -231,11 +231,6 @@ ezStatus ezTextureCubeAssetDocument::InternalTransformAsset(const char* szTarget
   return result;
 }
 
-const char* ezTextureCubeAssetDocument::QueryAssetType() const
-{
-  return "Texture Cube";
-}
-
 //////////////////////////////////////////////////////////////////////////
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureCubeAssetDocumentGenerator, 1, ezRTTIDefaultAllocator<ezTextureCubeAssetDocumentGenerator>)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
@@ -28,9 +28,6 @@ class ezTextureCubeAssetDocument : public ezSimpleAssetDocument<ezTextureCubeAss
 public:
   ezTextureCubeAssetDocument(const char* szDocumentPath);
 
-  /// \brief Overridden, because QueryAssetType() doesn't return a constant here
-  virtual const char* GetDocumentTypeDisplayString() const override { return "TextureCube Asset"; }
-
   virtual const char* QueryAssetType() const override;
 
   // for previewing purposes

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
@@ -28,8 +28,6 @@ class ezTextureCubeAssetDocument : public ezSimpleAssetDocument<ezTextureCubeAss
 public:
   ezTextureCubeAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override;
-
   // for previewing purposes
   ezEnum<ezTextureCubeChannelMode> m_ChannelMode;
   ezInt32 m_iTextureLod; // -1 == regular sampling, >= 0 == sample that level

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -15,7 +15,6 @@ ezTextureCubeAssetDocumentManager::ezTextureCubeAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Texture Cube", "dds");
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Texture Cube";
   m_AssetDesc.m_sFileExtension = "ezTextureCubeAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Texture_Cube.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -15,11 +15,11 @@ ezTextureCubeAssetDocumentManager::ezTextureCubeAssetDocumentManager()
   // additional whitelist for non-asset files where an asset may be selected
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Texture Cube", "dds");
 
-  m_AssetDesc.m_sDocumentTypeName = "Texture Cube";
-  m_AssetDesc.m_sFileExtension = "ezTextureCubeAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Texture_Cube.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureCubeAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Texture Cube";
+  m_DocTypeDesc.m_sFileExtension = "ezTextureCubeAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Texture_Cube.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureCubeAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezTextureCubeAssetDocumentManager::~ezTextureCubeAssetDocumentManager()
@@ -57,7 +57,7 @@ void ezTextureCubeAssetDocumentManager::InternalCreateDocument(const char* szDoc
 
 void ezTextureCubeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
 
 ezUInt64 ezTextureCubeAssetDocumentManager::ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -16,7 +16,7 @@ ezTextureCubeAssetDocumentManager::ezTextureCubeAssetDocumentManager()
   ezAssetFileExtensionWhitelist::AddAssetFileExtension("Texture Cube", "dds");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "TextureCube Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Texture Cube";
   m_AssetDesc.m_sFileExtension = "ezTextureCubeAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Texture_Cube.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureCubeAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -20,18 +20,14 @@ ezTextureCubeAssetDocumentManager::ezTextureCubeAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Texture_Cube.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezTextureCubeAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezTextureCube";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoThumbnailOnTransform;
 }
 
 ezTextureCubeAssetDocumentManager::~ezTextureCubeAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezTextureCubeAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezTextureCubeAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  return ezAssetDocumentFlags::AutoThumbnailOnTransform;
 }
 
 void ezTextureCubeAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -51,16 +51,12 @@ void ezTextureCubeAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentM
   }
 }
 
-ezStatus ezTextureCubeAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                   bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezTextureCubeAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezTextureCubeAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezTextureCubeAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezTextureCubeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
@@ -13,12 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezTextureCube"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Texture Cube");
-  }
-
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
@@ -26,6 +26,6 @@ private:
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
@@ -24,8 +24,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezTextureCubeAssetDocumentManager();
   ~ezTextureCubeAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezTextureCube"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -26,6 +22,6 @@ private:
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetWindow.cpp
@@ -72,10 +72,8 @@ ezActionDescriptorHandle ezTextureCubeAssetActions::s_hLodSlider;
 
 void ezTextureCubeAssetActions::RegisterActions()
 {
-  s_hTextureChannelMode =
-      EZ_REGISTER_DYNAMIC_MENU("TextureCubeAsset.ChannelMode", ezTextureCubeChannelModeAction, ":/EditorFramework/Icons/RenderMode.png");
-  s_hLodSlider =
-      EZ_REGISTER_ACTION_0("TextureCubeAsset.LodSlider", ezActionScope::Document, "TextureCube Asset", "", ezTextureCubeLodSliderAction);
+  s_hTextureChannelMode = EZ_REGISTER_DYNAMIC_MENU("TextureCubeAsset.ChannelMode", ezTextureCubeChannelModeAction, ":/EditorFramework/Icons/RenderMode.png");
+  s_hLodSlider = EZ_REGISTER_ACTION_0("TextureCubeAsset.LodSlider", ezActionScope::Document, "Texture Cube", "", ezTextureCubeLodSliderAction);
 }
 
 void ezTextureCubeAssetActions::UnregisterActions()

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAsset.h
@@ -56,8 +56,6 @@ class ezVisualScriptAssetDocument : public ezSimpleAssetDocument<ezVisualScriptA
 public:
   ezVisualScriptAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Visual Script"; }
-
   void HandleVsActivityMsg(const ezVisualScriptActivityMsgToEditor* pActivityMsg);
   void OnInterDocumentMessage(ezReflectedClass* pMessage, ezDocument* pSender) override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
@@ -53,16 +53,12 @@ void ezVisualScriptAssetManager::OnDocumentManagerEvent(const ezDocumentManager:
   }
 }
 
-ezStatus ezVisualScriptAssetManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                            ezDocument*& out_pDocument)
+void ezVisualScriptAssetManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezVisualScriptAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezVisualScriptAssetManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezVisualScriptAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
@@ -13,10 +13,6 @@ ezVisualScriptAssetManager::ezVisualScriptAssetManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezVisualScriptAssetManager::OnDocumentManagerEvent, this));
 
-  // additional whitelist for non-asset files where an asset may be selected
-  // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
-
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Visual Script";
   m_AssetDesc.m_sFileExtension = "ezVisualScriptAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Visual_Script.png";

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
@@ -19,19 +19,15 @@ ezVisualScriptAssetManager::ezVisualScriptAssetManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezVisualScriptAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezVisualScriptBin";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Visual Script", QPixmap(":/AssetIcons/Visual_Script.png"));
 }
 
 ezVisualScriptAssetManager::~ezVisualScriptAssetManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezVisualScriptAssetManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags> ezVisualScriptAssetManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 void ezVisualScriptAssetManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
@@ -17,7 +17,7 @@ ezVisualScriptAssetManager::ezVisualScriptAssetManager()
   // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Material", "ezMaterial");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Visual Script Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Visual Script";
   m_AssetDesc.m_sFileExtension = "ezVisualScriptAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Visual_Script.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezVisualScriptAssetDocument>();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
@@ -13,11 +13,11 @@ ezVisualScriptAssetManager::ezVisualScriptAssetManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezVisualScriptAssetManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Visual Script";
-  m_AssetDesc.m_sFileExtension = "ezVisualScriptAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Visual_Script.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezVisualScriptAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Visual Script";
+  m_DocTypeDesc.m_sFileExtension = "ezVisualScriptAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Visual_Script.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezVisualScriptAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Visual Script", QPixmap(":/AssetIcons/Visual_Script.png"));
 }
@@ -56,5 +56,5 @@ void ezVisualScriptAssetManager::InternalCreateDocument(const char* szDocumentTy
 
 void ezVisualScriptAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezVisualScriptAssetManager();
   ~ezVisualScriptAssetManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezVisualScriptBin"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -24,6 +20,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezVisualScriptBin"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Visual Script");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/AnimationClipAsset/AnimationClipContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/AnimationClipAsset/AnimationClipContext.cpp
@@ -27,7 +27,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipContext, 1, ezRTTIDefaultAllocato
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Animation Clip Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Animation Clip"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/DecalAsset/DecalContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/DecalAsset/DecalContext.cpp
@@ -14,7 +14,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDecalContext, 1, ezRTTIDefaultAllocator<ezDeca
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Decal Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Decal"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/MaterialAsset/MaterialContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/MaterialAsset/MaterialContext.cpp
@@ -27,7 +27,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialContext, 1, ezRTTIDefaultAllocator<ezM
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Material Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Material"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/MeshAsset/MeshContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/MeshAsset/MeshContext.cpp
@@ -28,7 +28,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshContext, 1, ezRTTIDefaultAllocator<ezMeshC
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Mesh Asset;Animated Mesh Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Mesh;Animated Mesh"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/SkeletonAsset/SkeletonContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/SkeletonAsset/SkeletonContext.cpp
@@ -28,7 +28,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkeletonContext, 1, ezRTTIDefaultAllocator<ezS
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Skeleton Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Skeleton"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
@@ -19,7 +19,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureContext, 1, ezRTTIDefaultAllocator<ezTe
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Texture Asset;Render Target Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Texture;Render Target"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
@@ -19,7 +19,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureContext, 1, ezRTTIDefaultAllocator<ezTe
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Texture;Render Target"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Texture 2D;Render Target"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureCubeAsset/TextureCubeContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureCubeAsset/TextureCubeContext.cpp
@@ -19,7 +19,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureCubeContext, 1, ezRTTIDefaultAllocator<
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "TextureCube Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Texture Cube"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
@@ -23,37 +23,32 @@ void OnLoadPlugin(bool bReloading)
 
   ezToolsProject::GetSingleton()->s_Events.AddEventHandler(ToolsProjectEventHandler);
 
-  // Mesh Asset
-  {// Menu Bar
-    {ezActionMapManager::RegisterActionMap("SoundBankAssetMenuBar");
-  ezProjectActions::MapActions("SoundBankAssetMenuBar");
-  ezStandardMenus::MapActions("SoundBankAssetMenuBar",
-    ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
-  ezDocumentActions::MapActions("SoundBankAssetMenuBar", "Menu.File", false);
-  ezCommandHistoryActions::MapActions("SoundBankAssetMenuBar", "Menu.Edit");
-}
-
-// Tool Bar
-{
-  ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar");
-  ezDocumentActions::MapActions("SoundBankAssetToolBar", "", true);
-  ezCommandHistoryActions::MapActions("SoundBankAssetToolBar", "");
-  ezAssetActions::MapActions("SoundBankAssetToolBar", true);
-}
-}
-
-// Scene
-{
-  // Menu Bar
+  // Mesh
   {
-    ezFmodActions::RegisterActions();
-    ezFmodActions::MapMenuActions();
+    // Menu Bar
+    ezActionMapManager::RegisterActionMap("SoundBankAssetMenuBar");
+    ezProjectActions::MapActions("SoundBankAssetMenuBar");
+    ezStandardMenus::MapActions("SoundBankAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
+    ezDocumentActions::MapActions("SoundBankAssetMenuBar", "Menu.File", false);
+    ezCommandHistoryActions::MapActions("SoundBankAssetMenuBar", "Menu.Edit");
+
+    // Tool Bar
+    {
+      ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar");
+      ezDocumentActions::MapActions("SoundBankAssetToolBar", "", true);
+      ezCommandHistoryActions::MapActions("SoundBankAssetToolBar", "");
+      ezAssetActions::MapActions("SoundBankAssetToolBar", true);
+    }
   }
 
-  // Tool Bar
+  // Scene
   {
+    // Menu Bar
+    {
+      ezFmodActions::RegisterActions();
+      ezFmodActions::MapMenuActions();
+    }
   }
-}
 }
 
 void OnUnloadPlugin(bool bReloading)

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <EditorFramework/Assets/SimpleAssetDocument.h>
 
@@ -18,8 +18,6 @@ class ezSoundBankAssetDocument : public ezSimpleAssetDocument<ezSoundBankAssetPr
 
 public:
   ezSoundBankAssetDocument(const char* szDocumentPath);
-
-  virtual const char* GetDocumentTypeDisplayString() const override { return "Sound Bank Asset"; }
 
   virtual const char* QueryAssetType() const override { return "Sound Bank"; }
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.h
@@ -19,8 +19,6 @@ class ezSoundBankAssetDocument : public ezSimpleAssetDocument<ezSoundBankAssetPr
 public:
   ezSoundBankAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Sound Bank"; }
-
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -81,8 +81,8 @@ ezSoundBankAssetDocumentManager::~ezSoundBankAssetDocumentManager()
 void ezSoundBankAssetDocumentManager::FillOutSubAssetList(const ezAssetDocumentInfo& assetInfo,
                                                           ezHybridArray<ezSubAssetData, 4>& out_SubAssets) const
 {
-  ezHashedString sAssetTypeName;
-  sAssetTypeName.Assign("Sound Event");
+  ezHashedString sAssetsDocumentTypeName;
+  sAssetsDocumentTypeName.Assign("Sound Event");
 
   auto* pSystem = m_Fmod->GetSystem();
 
@@ -174,7 +174,7 @@ void ezSoundBankAssetDocumentManager::FillOutSubAssetList(const ezAssetDocumentI
           auto& sub = out_SubAssets.ExpandAndGetRef();
           sub.m_Guid = *ezGuid;
           sub.m_sName = sEventName;
-          sub.m_sAssetTypeName = sAssetTypeName;
+          sub.m_sSubAssetsDocumentTypeName = sAssetsDocumentTypeName;
         }
       }
     }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -59,11 +59,11 @@ ezSoundBankAssetDocumentManager::ezSoundBankAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSoundBankAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Sound Bank";
-  m_AssetDesc.m_sFileExtension = "ezSoundBankAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Sound_Bank.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundBankAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Sound Bank";
+  m_DocTypeDesc.m_sFileExtension = "ezSoundBankAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Sound_Bank.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundBankAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Sound Bank", QPixmap(":/AssetIcons/Sound_Bank.png"));
 
@@ -258,7 +258,7 @@ void ezSoundBankAssetDocumentManager::InternalCreateDocument(const char* szDocum
 
 void ezSoundBankAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
 
 ezUInt64 ezSoundBankAssetDocumentManager::ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -60,7 +60,7 @@ ezSoundBankAssetDocumentManager::ezSoundBankAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSoundBankAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Sound Bank Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Sound Bank";
   m_AssetDesc.m_sFileExtension = "ezSoundBankAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Sound_Bank.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundBankAssetDocument>();

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -65,6 +65,9 @@ ezSoundBankAssetDocumentManager::ezSoundBankAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundBankAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezFmodSoundBank";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::None;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Sound Bank", QPixmap(":/AssetIcons/Sound_Bank.png"));
 
   m_Fmod = EZ_DEFAULT_NEW(ezSimpleFmod);

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -252,16 +252,12 @@ void ezSoundBankAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMan
   }
 }
 
-ezStatus ezSoundBankAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                 bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezSoundBankAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezSoundBankAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezSoundBankAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezSoundBankAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -59,7 +59,6 @@ ezSoundBankAssetDocumentManager::ezSoundBankAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSoundBankAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Sound Bank";
   m_AssetDesc.m_sFileExtension = "ezSoundBankAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Sound_Bank.png";

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
@@ -31,6 +31,6 @@ private:
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
   ezUniquePtr<ezSimpleFmod> m_Fmod;
 };

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
@@ -25,8 +25,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
   ezString GetSoundBankAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const;
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
@@ -13,8 +13,6 @@ public:
   ezSoundBankAssetDocumentManager();
   ~ezSoundBankAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezFmodSoundBank"; }
-
   virtual void FillOutSubAssetList(const ezAssetDocumentInfo& assetInfo, ezHybridArray<ezSubAssetData, 4>& out_SubAssets) const override;
   virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory,
                                       const ezPlatformProfile* pAssetProfile) const override;
@@ -30,7 +28,6 @@ private:
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
   ezUniquePtr<ezSimpleFmod> m_Fmod;
 };

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
@@ -15,8 +15,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezFmodSoundBank"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override { inout_AssetTypeNames.Insert("Sound Bank"); }
-
   virtual void FillOutSubAssetList(const ezAssetDocumentInfo& assetInfo, ezHybridArray<ezSubAssetData, 4>& out_SubAssets) const override;
   virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory,
                                       const ezPlatformProfile* pAssetProfile) const override;

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.h
@@ -20,8 +20,6 @@ class ezSoundEventAssetDocument : public ezSimpleAssetDocument<ezSoundEventAsset
 public:
   ezSoundEventAssetDocument(const char* szDocumentPath);
 
-  virtual const char* GetDocumentTypeDisplayString() const override { return "Sound Event Asset"; }
-
   virtual const char* QueryAssetType() const override { return "Sound Event"; }
 
 protected:

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.h
@@ -20,8 +20,6 @@ class ezSoundEventAssetDocument : public ezSimpleAssetDocument<ezSoundEventAsset
 public:
   ezSoundEventAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "Sound Event"; }
-
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
@@ -20,6 +20,9 @@ ezSoundEventAssetDocumentManager::ezSoundEventAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundEventAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezFmodSoundEvent";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::None;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Sound Event", QPixmap(":/AssetIcons/Sound_Event.png"));
 }
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
@@ -13,12 +13,12 @@ ezSoundEventAssetDocumentManager::ezSoundEventAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSoundEventAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = false;
-  m_AssetDesc.m_sDocumentTypeName = "Sound Event";
-  m_AssetDesc.m_sFileExtension = "ezSoundEventAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Sound_Event.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundEventAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_bCanCreate = false;
+  m_DocTypeDesc.m_sDocumentTypeName = "Sound Event";
+  m_DocTypeDesc.m_sFileExtension = "ezSoundEventAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Sound_Event.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundEventAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Sound Event", QPixmap(":/AssetIcons/Sound_Event.png"));
 }
@@ -50,5 +50,5 @@ void ezSoundEventAssetDocumentManager::InternalCreateDocument(const char* szDocu
 
 void ezSoundEventAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
@@ -14,7 +14,7 @@ ezSoundEventAssetDocumentManager::ezSoundEventAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezSoundEventAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = false;
-  m_AssetDesc.m_sDocumentTypeName = "Sound Event Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Sound Event";
   m_AssetDesc.m_sFileExtension = "ezSoundEventAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Sound_Event.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezSoundEventAssetDocument>();

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
@@ -43,16 +43,12 @@ void ezSoundEventAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMa
   }
 }
 
-ezStatus ezSoundEventAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                  bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezSoundEventAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezSoundEventAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezSoundEventAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezSoundEventAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
@@ -11,8 +11,6 @@ public:
   ezSoundEventAssetDocumentManager();
   ~ezSoundEventAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezFmodSoundEvent"; }
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -21,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezFmodSoundEvent"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Sound Event");
-  }
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
@@ -21,8 +21,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
@@ -22,6 +22,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
@@ -22,7 +22,7 @@ void OnLoadPlugin(bool bReloading)
   ezQtEditorApp::GetSingleton()->AddRuntimePluginDependency("EditorPluginKraut", "ezEnginePluginKraut");
 
 
-  // Kraut Tree Asset
+  // Kraut Tree
   {
     // Menu Bar
     {

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
@@ -20,11 +20,6 @@ ezKrautTreeAssetDocument::ezKrautTreeAssetDocument(const char* szDocumentPath)
 {
 }
 
-const char* ezKrautTreeAssetDocument::QueryAssetType() const
-{
-  return "Kraut Tree";
-}
-
 //////////////////////////////////////////////////////////////////////////
 
 enum ezKrautImportMaterialType : ezUInt8

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
@@ -14,8 +14,6 @@ class ezKrautTreeAssetDocument : public ezSimpleAssetDocument<ezKrautTreeAssetPr
 public:
   ezKrautTreeAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override;
-
 protected:
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
                                           const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
@@ -14,7 +14,7 @@ ezKrautTreeAssetDocumentManager::ezKrautTreeAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezKrautTreeAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Kraut Tree Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Kraut Tree";
   m_AssetDesc.m_sFileExtension = "ezKrautTreeAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Kraut_Tree.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezKrautTreeAssetDocument>();

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
@@ -13,7 +13,6 @@ ezKrautTreeAssetDocumentManager::ezKrautTreeAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezKrautTreeAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Kraut Tree";
   m_AssetDesc.m_sFileExtension = "ezKrautTreeAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Kraut_Tree.png";

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
@@ -13,11 +13,11 @@ ezKrautTreeAssetDocumentManager::ezKrautTreeAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezKrautTreeAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Kraut Tree";
-  m_AssetDesc.m_sFileExtension = "ezKrautTreeAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Kraut_Tree.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezKrautTreeAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Kraut Tree";
+  m_DocTypeDesc.m_sFileExtension = "ezKrautTreeAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Kraut_Tree.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezKrautTreeAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezKrautTreeAssetDocumentManager::~ezKrautTreeAssetDocumentManager()
@@ -48,7 +48,7 @@ void ezKrautTreeAssetDocumentManager::InternalCreateDocument(const char* szDocum
 
 void ezKrautTreeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
 
 ezBitflags<ezAssetDocumentFlags>

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
@@ -42,16 +42,12 @@ void ezKrautTreeAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMan
   }
 }
 
-ezStatus ezKrautTreeAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                     bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezKrautTreeAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezKrautTreeAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezKrautTreeAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezKrautTreeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
@@ -18,6 +18,9 @@ ezKrautTreeAssetDocumentManager::ezKrautTreeAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Kraut_Tree.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezKrautTreeAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezKrautTree";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezKrautTreeAssetDocumentManager::~ezKrautTreeAssetDocumentManager()
@@ -51,10 +54,4 @@ void ezKrautTreeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynami
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
 
-ezBitflags<ezAssetDocumentFlags>
-ezKrautTreeAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::SupportsThumbnail;
-}
 

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
@@ -24,5 +24,5 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
@@ -11,18 +11,14 @@ public:
   ezKrautTreeAssetDocumentManager();
   ~ezKrautTreeAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezKrautTree"; }
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
-  ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;
-
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
@@ -21,8 +21,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezKrautTree"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Kraut Tree");
-  }
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 

--- a/Code/EditorPlugins/Kraut/EnginePluginKraut/KrautTreeAsset/KrautTreeContext.cpp
+++ b/Code/EditorPlugins/Kraut/EnginePluginKraut/KrautTreeAsset/KrautTreeContext.cpp
@@ -30,7 +30,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezKrautTreeContext, 1, ezRTTIDefaultAllocator<ez
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Kraut Tree Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Kraut Tree"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
@@ -23,7 +23,7 @@ void OnLoadPlugin(bool bReloading)
 
   ezParticleActions::RegisterActions();
 
-  // Particle Effect Asset
+  // Particle Effect
   {
     // Menu Bar
     {

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.h
@@ -30,8 +30,6 @@ public:
 
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
-  virtual const char* QueryAssetType() const override { return "Particle Effect"; }
-
   ezStatus WriteParticleEffectAsset(ezStreamWriter& stream, const ezPlatformProfile* pAssetProfile) const;
 
   void TriggerRestartEffect();

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
@@ -51,16 +51,12 @@ void ezParticleEffectAssetDocumentManager::OnDocumentManagerEvent(const ezDocume
   }
 }
 
-ezStatus ezParticleEffectAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                      bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezParticleEffectAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezParticleEffectAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezParticleEffectAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezParticleEffectAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
@@ -16,7 +16,7 @@ ezParticleEffectAssetDocumentManager::ezParticleEffectAssetDocumentManager()
   // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Collision Mesh", "ezPhysXMesh");
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Particle Effect Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Particle Effect";
   m_AssetDesc.m_sFileExtension = "ezParticleEffectAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Particle_Effect.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezParticleEffectAssetDocument>();

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
@@ -17,18 +17,14 @@ ezParticleEffectAssetDocumentManager::ezParticleEffectAssetDocumentManager()
   m_DocTypeDesc.m_sIcon = ":/AssetIcons/Particle_Effect.png";
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezParticleEffectAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
+
+  m_DocTypeDesc.m_sResourceFileExtension = "ezParticleEffect"; 
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezParticleEffectAssetDocumentManager::~ezParticleEffectAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezParticleEffectAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-
-ezBitflags<ezAssetDocumentFlags>
-ezParticleEffectAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  return ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 void ezParticleEffectAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
@@ -12,11 +12,11 @@ ezParticleEffectAssetDocumentManager::ezParticleEffectAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezParticleEffectAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Particle Effect";
-  m_AssetDesc.m_sFileExtension = "ezParticleEffectAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Particle_Effect.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezParticleEffectAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Particle Effect";
+  m_DocTypeDesc.m_sFileExtension = "ezParticleEffectAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Particle_Effect.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezParticleEffectAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 }
 
 ezParticleEffectAssetDocumentManager::~ezParticleEffectAssetDocumentManager()
@@ -54,5 +54,5 @@ void ezParticleEffectAssetDocumentManager::InternalCreateDocument(const char* sz
 
 void ezParticleEffectAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
@@ -12,10 +12,6 @@ ezParticleEffectAssetDocumentManager::ezParticleEffectAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezParticleEffectAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  // additional whitelist for non-asset files where an asset may be selected
-  // ezAssetFileExtensionWhitelist::AddAssetFileExtension("Collision Mesh", "ezPhysXMesh");
-
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Particle Effect";
   m_AssetDesc.m_sFileExtension = "ezParticleEffectAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Particle_Effect.png";

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
@@ -11,9 +11,6 @@ public:
   ezParticleEffectAssetDocumentManager();
   ~ezParticleEffectAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezParticleEffect"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
@@ -23,7 +20,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezParticleEffect"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Particle Effect");
-  }
-
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Particle/EnginePluginParticle/ParticleAsset/ParticleContext.cpp
+++ b/Code/EditorPlugins/Particle/EnginePluginParticle/ParticleAsset/ParticleContext.cpp
@@ -26,7 +26,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleContext, 1, ezRTTIDefaultAllocator<ezP
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Particle Effect Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Particle Effect"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.cpp
@@ -62,15 +62,6 @@ void ezCollisionMeshAssetDocument::InitializeAfterLoading(bool bFirstTimeCreatio
   GetProperties()->m_bIsConvexMesh = m_bIsConvexMesh;
 }
 
-const char* ezCollisionMeshAssetDocument::QueryAssetType() const
-{
-  if (m_bIsConvexMesh)
-    return "Collision Mesh (Convex)";
-
-  return "Collision Mesh";
-}
-
-
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.h
@@ -16,9 +16,6 @@ class ezCollisionMeshAssetDocument : public ezSimpleAssetDocument<ezCollisionMes
 public:
   ezCollisionMeshAssetDocument(const char* szDocumentPath, bool bConvexMesh);
 
-  /// \brief Overridden, because QueryAssetType() doesn't return a constant here
-  virtual const char* GetDocumentTypeDisplayString() const override { return "Collision Mesh Asset"; }
-
   virtual const char* QueryAssetType() const override;
 
   static ezStatus WriteToStream(ezChunkStreamWriter& stream, const ezPhysXCookingMesh& mesh, const ezCollisionMeshAssetProperties* pProp);

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.h
@@ -16,8 +16,6 @@ class ezCollisionMeshAssetDocument : public ezSimpleAssetDocument<ezCollisionMes
 public:
   ezCollisionMeshAssetDocument(const char* szDocumentPath, bool bConvexMesh);
 
-  virtual const char* QueryAssetType() const override;
-
   static ezStatus WriteToStream(ezChunkStreamWriter& stream, const ezPhysXCookingMesh& mesh, const ezCollisionMeshAssetProperties* pProp);
 
 protected:

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
@@ -14,14 +14,14 @@ ezCollisionMeshAssetDocumentManager::ezCollisionMeshAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCollisionMeshAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "Collision Mesh Asset";
+  m_AssetDesc.m_sDocumentTypeName = "Collision Mesh";
   m_AssetDesc.m_sFileExtension = "ezCollisionMeshAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Collision_Mesh.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
   m_AssetDesc.m_pManager = this;
 
   m_ConvexAssetDesc.m_bCanCreate = true;
-  m_ConvexAssetDesc.m_sDocumentTypeName = "Collision Mesh Asset (Convex)";
+  m_ConvexAssetDesc.m_sDocumentTypeName = "Collision Mesh (Convex)";
   m_ConvexAssetDesc.m_sFileExtension = "ezConvexCollisionMeshAsset";
   m_ConvexAssetDesc.m_sIcon = ":/AssetIcons/Collision_Mesh_Convex.png";
   m_ConvexAssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
@@ -51,7 +51,7 @@ void ezCollisionMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocumen
 
 void ezCollisionMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
-  if (ezStringUtils::IsEqual(szDocumentTypeName, "Collision Mesh Asset (Convex)"))
+  if (ezStringUtils::IsEqual(szDocumentTypeName, "Collision Mesh (Convex)"))
   {
     out_pDocument = new ezCollisionMeshAssetDocument(szPath, true);
   }

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
@@ -13,14 +13,12 @@ ezCollisionMeshAssetDocumentManager::ezCollisionMeshAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCollisionMeshAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "Collision Mesh";
   m_AssetDesc.m_sFileExtension = "ezCollisionMeshAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/Collision_Mesh.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
   m_AssetDesc.m_pManager = this;
 
-  m_ConvexAssetDesc.m_bCanCreate = true;
   m_ConvexAssetDesc.m_sDocumentTypeName = "Collision Mesh (Convex)";
   m_ConvexAssetDesc.m_sFileExtension = "ezConvexCollisionMeshAsset";
   m_ConvexAssetDesc.m_sIcon = ":/AssetIcons/Collision_Mesh_Convex.png";

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
@@ -13,17 +13,17 @@ ezCollisionMeshAssetDocumentManager::ezCollisionMeshAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezCollisionMeshAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "Collision Mesh";
-  m_AssetDesc.m_sFileExtension = "ezCollisionMeshAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/Collision_Mesh.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "Collision Mesh";
+  m_DocTypeDesc.m_sFileExtension = "ezCollisionMeshAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/Collision_Mesh.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
-  m_ConvexAssetDesc.m_sDocumentTypeName = "Collision Mesh (Convex)";
-  m_ConvexAssetDesc.m_sFileExtension = "ezConvexCollisionMeshAsset";
-  m_ConvexAssetDesc.m_sIcon = ":/AssetIcons/Collision_Mesh_Convex.png";
-  m_ConvexAssetDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
-  m_ConvexAssetDesc.m_pManager = this;
+  m_DocTypeDesc2.m_sDocumentTypeName = "Collision Mesh (Convex)";
+  m_DocTypeDesc2.m_sFileExtension = "ezConvexCollisionMeshAsset";
+  m_DocTypeDesc2.m_sIcon = ":/AssetIcons/Collision_Mesh_Convex.png";
+  m_DocTypeDesc2.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
+  m_DocTypeDesc2.m_pManager = this;
 }
 
 ezCollisionMeshAssetDocumentManager::~ezCollisionMeshAssetDocumentManager()
@@ -61,8 +61,8 @@ void ezCollisionMeshAssetDocumentManager::InternalCreateDocument(const char* szD
 
 void ezCollisionMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
-  inout_DocumentTypes.PushBack(&m_ConvexAssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc2);
 }
 
 ezBitflags<ezAssetDocumentFlags>

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
@@ -19,11 +19,17 @@ ezCollisionMeshAssetDocumentManager::ezCollisionMeshAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezPhysXMesh";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
+
   m_DocTypeDesc2.m_sDocumentTypeName = "Collision Mesh (Convex)";
   m_DocTypeDesc2.m_sFileExtension = "ezConvexCollisionMeshAsset";
   m_DocTypeDesc2.m_sIcon = ":/AssetIcons/Collision_Mesh_Convex.png";
   m_DocTypeDesc2.m_pDocumentType = ezGetStaticRTTI<ezCollisionMeshAssetDocument>();
   m_DocTypeDesc2.m_pManager = this;
+
+  m_DocTypeDesc2.m_sResourceFileExtension = "ezPhysXMesh";
+  m_DocTypeDesc2.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezCollisionMeshAssetDocumentManager::~ezCollisionMeshAssetDocumentManager()
@@ -63,13 +69,6 @@ void ezCollisionMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDy
 {
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
   inout_DocumentTypes.PushBack(&m_DocTypeDesc2);
-}
-
-ezBitflags<ezAssetDocumentFlags>
-ezCollisionMeshAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::SupportsThumbnail;
 }
 
 ezUInt64 ezCollisionMeshAssetDocumentManager::ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.cpp
@@ -49,8 +49,7 @@ void ezCollisionMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocumen
   }
 }
 
-ezStatus ezCollisionMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath,
-                                                                     bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezCollisionMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   if (ezStringUtils::IsEqual(szDocumentTypeName, "Collision Mesh Asset (Convex)"))
   {
@@ -60,11 +59,9 @@ ezStatus ezCollisionMeshAssetDocumentManager::InternalCreateDocument(const char*
   {
     out_pDocument = new ezCollisionMeshAssetDocument(szPath, false);
   }
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezCollisionMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(
-    ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezCollisionMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
   inout_DocumentTypes.PushBack(&m_ConvexAssetDesc);

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
@@ -18,12 +18,6 @@ public:
     return "ezPhysXMesh";
   }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("Collision Mesh");
-    inout_AssetTypeNames.Insert("Collision Mesh (Convex)");
-  }
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
@@ -31,6 +31,6 @@ private:
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
-  ezDocumentTypeDescriptor m_ConvexAssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc2;
 };

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
@@ -11,26 +11,16 @@ public:
   ezCollisionMeshAssetDocumentManager();
   ~ezCollisionMeshAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override
-  {
-    // TODO: should use a different file extension for concave/convex meshes, otherwise one can create
-    // two meshes with the same name that will overwrite each other every time they are transformed
-    return "ezPhysXMesh";
-  }
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
-  ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;
-
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
-  ezDocumentTypeDescriptor m_DocTypeDesc2;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc2;
 };

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetManager.h
@@ -27,8 +27,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-    ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
@@ -27,10 +27,9 @@ void OnLoadPlugin(bool bReloading)
   ezQtEditorApp::GetSingleton()->AddRuntimePluginDependency("EditorPluginPhysX", "ezPhysXPlugin");
   ezQtEditorApp::GetSingleton()->AddRuntimePluginDependency("EditorPluginPhysX", "ezEnginePluginPhysX");
 
-
   ezToolsProject::GetSingleton()->s_Events.AddEventHandler(ToolsProjectEventHandler);
 
-  // Collision Mesh Asset
+  // Collision Mesh
   {
     ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezCollisionMeshAssetProperties::PropertyMetaStateEventHandler);
 
@@ -38,8 +37,7 @@ void OnLoadPlugin(bool bReloading)
     {
       ezActionMapManager::RegisterActionMap("CollisionMeshAssetMenuBar");
       ezProjectActions::MapActions("CollisionMeshAssetMenuBar");
-      ezStandardMenus::MapActions("CollisionMeshAssetMenuBar",
-        ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
+      ezStandardMenus::MapActions("CollisionMeshAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezDocumentActions::MapActions("CollisionMeshAssetMenuBar", "Menu.File", false);
       ezCommandHistoryActions::MapActions("CollisionMeshAssetMenuBar", "Menu.Edit");
     }

--- a/Code/EditorPlugins/PhysX/EnginePluginPhysX/CollisionMeshAsset/CollisionMeshContext.cpp
+++ b/Code/EditorPlugins/PhysX/EnginePluginPhysX/CollisionMeshAsset/CollisionMeshContext.cpp
@@ -28,7 +28,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCollisionMeshContext, 1, ezRTTIDefaultAllocato
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Collision Mesh Asset;Collision Mesh Asset (Convex)"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Collision Mesh;Collision Mesh (Convex)"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
@@ -17,8 +17,6 @@ class ezProcGenGraphAssetDocument : public ezAssetDocument
 public:
   ezProcGenGraphAssetDocument(const char* szDocumentPath);
 
-  virtual const char* GetDocumentTypeDisplayString() const override { return "ProcGen Graph Asset"; }
-
   virtual const char* QueryAssetType() const override { return "ProcGen Graph"; }
 
   void SetDebugPin(const ezPin* pDebugPin);

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
@@ -17,8 +17,6 @@ class ezProcGenGraphAssetDocument : public ezAssetDocument
 public:
   ezProcGenGraphAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override { return "ProcGen Graph"; }
-
   void SetDebugPin(const ezPin* pDebugPin);
 
   ezStatus WriteAsset(ezStreamWriter& stream, const ezPlatformProfile* pAssetProfile) const;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
@@ -22,17 +22,15 @@ ezProcGenGraphAssetDocumentManager::ezProcGenGraphAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezProcGenGraphAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezProcGenGraph";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("ProcGen Graph", QPixmap(":/AssetIcons/ProcGen_Graph.png"));
 }
 
 ezProcGenGraphAssetDocumentManager::~ezProcGenGraphAssetDocumentManager()
 {
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent, this));
-}
-
-ezBitflags<ezAssetDocumentFlags> ezProcGenGraphAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  return ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 void ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
@@ -16,11 +16,11 @@ ezProcGenGraphAssetDocumentManager::ezProcGenGraphAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "ProcGen Graph";
-  m_AssetDesc.m_sFileExtension = "ezProcGenGraphAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/ProcGen_Graph.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezProcGenGraphAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "ProcGen Graph";
+  m_DocTypeDesc.m_sFileExtension = "ezProcGenGraphAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/ProcGen_Graph.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezProcGenGraphAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("ProcGen Graph", QPixmap(":/AssetIcons/ProcGen_Graph.png"));
 }
@@ -57,5 +57,5 @@ void ezProcGenGraphAssetDocumentManager::InternalCreateDocument(const char* szDo
 
 void ezProcGenGraphAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
@@ -16,7 +16,6 @@ ezProcGenGraphAssetDocumentManager::ezProcGenGraphAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "ProcGen Graph";
   m_AssetDesc.m_sFileExtension = "ezProcGenGraphAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/ProcGen_Graph.png";

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
@@ -31,8 +31,7 @@ ezProcGenGraphAssetDocumentManager::~ezProcGenGraphAssetDocumentManager()
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent, this));
 }
 
-ezBitflags<ezAssetDocumentFlags> ezProcGenGraphAssetDocumentManager::GetAssetDocumentTypeFlags(
-  const ezDocumentTypeDescriptor* pDescriptor) const
+ezBitflags<ezAssetDocumentFlags> ezProcGenGraphAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
 {
   return ezAssetDocumentFlags::AutoTransformOnSave;
 }
@@ -52,16 +51,12 @@ void ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent(const ezDocument
   }
 }
 
-ezStatus ezProcGenGraphAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezProcGenGraphAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezProcGenGraphAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
-void ezProcGenGraphAssetDocumentManager::InternalGetSupportedDocumentTypes(
-  ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
+void ezProcGenGraphAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_AssetDesc);
 }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
@@ -17,7 +17,7 @@ ezProcGenGraphAssetDocumentManager::ezProcGenGraphAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "ProcGen Graph Asset";
+  m_AssetDesc.m_sDocumentTypeName = "ProcGen Graph";
   m_AssetDesc.m_sFileExtension = "ezProcGenGraphAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/ProcGen_Graph.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezProcGenGraphAssetDocument>();

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
@@ -11,10 +11,6 @@ public:
   ezProcGenGraphAssetDocumentManager();
   ~ezProcGenGraphAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezProcGenGraph"; }
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
@@ -23,7 +19,6 @@ private:
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
@@ -24,6 +24,6 @@ private:
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 };
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
@@ -23,8 +23,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                          ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
@@ -13,11 +13,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezProcGenGraph"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("ProcGen Graph");
-  }
-  
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -336,8 +336,7 @@ void ezSceneAction::Execute(const ezVariant& value)
       QStringList arguments;
       arguments << "-scene";
 
-      const ezStringBuilder sPath =
-        m_pSceneDocument->GetAssetDocumentManager()->GetAbsoluteOutputFileName(m_pSceneDocument->GetDocumentPath(), "");
+      const ezStringBuilder sPath = m_pSceneDocument->GetAssetDocumentManager()->GetAbsoluteOutputFileName(m_pSceneDocument->GetAssetDocumentTypeDescriptor(), m_pSceneDocument->GetDocumentPath(), "");
 
       const char* szPath = sPath.GetData();
       arguments << QString::fromUtf8(szPath);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditTools/GreyBoxEditTool.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditTools/GreyBoxEditTool.cpp
@@ -158,7 +158,7 @@ void ezGreyBoxEditTool::GizmoEventHandler(const ezGizmoEvent& e)
       if (lastSelected.IsValid())
       {
         const auto pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(lastSelected);
-        if (pSubAsset && ezStringUtils::IsEqual(pSubAsset->m_pAssetInfo->m_Info->GetAssetTypeName(), "Material"))
+        if (pSubAsset && ezStringUtils::IsEqual(pSubAsset->m_pAssetInfo->m_Info->GetAssetsDocumentTypeName(), "Material"))
         {
           materialGuid = lastSelected;
         }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -1174,14 +1174,6 @@ ezStatus ezSceneDocument::RequestExportScene(const char* szTargetFile, const ezA
   return status;
 }
 
-const char* ezSceneDocument::QueryAssetType() const
-{
-  if (m_bIsPrefab)
-    return "Prefab";
-
-  return "Scene";
-}
-
 void ezSceneDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
 {
   SUPER::UpdateAssetDocumentInfo(pInfo);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -93,15 +93,6 @@ ezSceneDocument::~ezSceneDocument()
   m_ObjectMirror.DeInit();
 }
 
-
-const char* ezSceneDocument::GetDocumentTypeDisplayString() const
-{
-  if (m_bIsPrefab)
-    return "Prefab";
-
-  return "Scene";
-}
-
 void ezSceneDocument::GroupSelection()
 {
   const auto& sel = GetSelectionManager()->GetTopLevelSelection(ezGetStaticRTTI<ezGameObject>());

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -24,9 +24,6 @@ public:
   ezSceneDocument(const char* szDocumentPath, bool bIsPrefab);
   ~ezSceneDocument();
 
-  virtual const char* GetDocumentTypeDisplayString() const override;
-
-
   enum class ShowOrHide
   {
     Show,

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -175,8 +175,6 @@ private:
 
   ezStatus RequestExportScene(const char* szTargetFile, const ezAssetFileHeader& header);
 
-  virtual const char* QueryAssetType() const override;
-
   virtual ezStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   ezStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -17,19 +17,19 @@ ezSceneDocumentManager::ezSceneDocumentManager()
   s_pSingleton = this;
 
   {
-    m_SceneDesc.m_sDocumentTypeName = "Scene";
-    m_SceneDesc.m_sFileExtension = "ezScene";
-    m_SceneDesc.m_sIcon = ":/AssetIcons/Scene.png";
-    m_SceneDesc.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
-    m_SceneDesc.m_pManager = this;
+    m_DocTypeDesc.m_sDocumentTypeName = "Scene";
+    m_DocTypeDesc.m_sFileExtension = "ezScene";
+    m_DocTypeDesc.m_sIcon = ":/AssetIcons/Scene.png";
+    m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
+    m_DocTypeDesc.m_pManager = this;
   }
 
   {
-    m_PrefabDesc.m_sDocumentTypeName = "Prefab";
-    m_PrefabDesc.m_sFileExtension = "ezPrefab";
-    m_PrefabDesc.m_sIcon = ":/AssetIcons/Prefab.png";
-    m_PrefabDesc.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
-    m_PrefabDesc.m_pManager = this;
+    m_DocTypeDesc2.m_sDocumentTypeName = "Prefab";
+    m_DocTypeDesc2.m_sFileExtension = "ezPrefab";
+    m_DocTypeDesc2.m_sIcon = ":/AssetIcons/Prefab.png";
+    m_DocTypeDesc2.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
+    m_DocTypeDesc2.m_pManager = this;
   }
 }
 
@@ -37,7 +37,7 @@ ezSceneDocumentManager::ezSceneDocumentManager()
 ezBitflags<ezAssetDocumentFlags> ezSceneDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
 {
   EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  if (pDescriptor == &m_PrefabDesc)
+  if (pDescriptor == &m_DocTypeDesc2)
   {
     return ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
   }
@@ -67,8 +67,8 @@ void ezSceneDocumentManager::InternalCreateDocument(const char* szDocumentTypeNa
 
 void ezSceneDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_SceneDesc);
-  inout_DocumentTypes.PushBack(&m_PrefabDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc2);
 }
 
 ezString ezSceneDocumentManager::GetResourceTypeExtension(const char* szDocumentPath) const

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -53,11 +53,8 @@ ezBitflags<ezAssetDocumentFlags> ezSceneDocumentManager::GetAssetDocumentTypeFla
   }
 }
 
-ezStatus ezSceneDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-                                                        ezDocument*& out_pDocument)
+void ezSceneDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
-  ezStatus status;
-
   if (ezStringUtils::IsEqual(szDocumentTypeName, "Scene"))
   {
     out_pDocument = new ezSceneDocument(szPath, false);
@@ -71,18 +68,6 @@ ezStatus ezSceneDocumentManager::InternalCreateDocument(const char* szDocumentTy
   {
     out_pDocument = new ezSceneDocument(szPath, true);
   }
-  else
-  {
-    status.m_sMessage = "Unknown Document Type";
-  }
-
-  if (out_pDocument)
-  {
-    status.m_Result = EZ_SUCCESS;
-    // out_pDocument->SetFilePath(szPath);
-  }
-
-  return status;
 }
 
 void ezSceneDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -17,7 +17,6 @@ ezSceneDocumentManager::ezSceneDocumentManager()
   s_pSingleton = this;
 
   {
-    m_SceneDesc.m_bCanCreate = true;
     m_SceneDesc.m_sDocumentTypeName = "Scene";
     m_SceneDesc.m_sFileExtension = "ezScene";
     m_SceneDesc.m_sIcon = ":/AssetIcons/Scene.png";
@@ -26,16 +25,12 @@ ezSceneDocumentManager::ezSceneDocumentManager()
   }
 
   {
-    m_PrefabDesc.m_bCanCreate = true;
     m_PrefabDesc.m_sDocumentTypeName = "Prefab";
     m_PrefabDesc.m_sFileExtension = "ezPrefab";
     m_PrefabDesc.m_sIcon = ":/AssetIcons/Prefab.png";
     m_PrefabDesc.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
     m_PrefabDesc.m_pManager = this;
   }
-
-  // if scene thumbnails are desired, this needs to be removed
-  // ezQtImageCache::GetSingleton()->RegisterTypeImage("Scene", QPixmap(":/AssetIcons/Scene.png"));
 }
 
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -81,12 +81,6 @@ ezString ezSceneDocumentManager::GetResourceTypeExtension(const char* szDocument
   return "ezObjectGraph";
 }
 
-void ezSceneDocumentManager::QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const
-{
-  inout_AssetTypeNames.Insert("Scene");
-  inout_AssetTypeNames.Insert("Prefab");
-}
-
 void ezSceneDocumentManager::SetupDefaultScene(ezDocument* pDocument)
 {
   auto history = pDocument->GetCommandHistory();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -22,6 +22,9 @@ ezSceneDocumentManager::ezSceneDocumentManager()
     m_DocTypeDesc.m_sIcon = ":/AssetIcons/Scene.png";
     m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
     m_DocTypeDesc.m_pManager = this;
+
+    m_DocTypeDesc.m_sResourceFileExtension = "ezObjectGraph";
+    m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::OnlyTransformManually | ezAssetDocumentFlags::SupportsThumbnail;
   }
 
   {
@@ -30,21 +33,9 @@ ezSceneDocumentManager::ezSceneDocumentManager()
     m_DocTypeDesc2.m_sIcon = ":/AssetIcons/Prefab.png";
     m_DocTypeDesc2.m_pDocumentType = ezGetStaticRTTI<ezSceneDocument>();
     m_DocTypeDesc2.m_pManager = this;
-  }
-}
 
-
-ezBitflags<ezAssetDocumentFlags> ezSceneDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  if (pDescriptor == &m_DocTypeDesc2)
-  {
-    return ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
-  }
-  else
-  {
-    // if scene thumbnails are desired, this needs to be added
-    return ezAssetDocumentFlags::OnlyTransformManually | ezAssetDocumentFlags::SupportsThumbnail;
+    m_DocTypeDesc2.m_sResourceFileExtension = "ezObjectGraph";
+    m_DocTypeDesc2.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::SupportsThumbnail;
   }
 }
 
@@ -69,11 +60,6 @@ void ezSceneDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<co
 {
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
   inout_DocumentTypes.PushBack(&m_DocTypeDesc2);
-}
-
-ezString ezSceneDocumentManager::GetResourceTypeExtension(const char* szDocumentPath) const
-{
-  return "ezObjectGraph";
 }
 
 void ezSceneDocumentManager::SetupDefaultScene(ezDocument* pDocument)

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
@@ -28,7 +28,7 @@ private:
 private:
   void SetupDefaultScene(ezDocument* pDocument);
 
-  ezDocumentTypeDescriptor m_SceneDesc;
-  ezDocumentTypeDescriptor m_PrefabDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc2;
 };
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
@@ -18,7 +18,7 @@ public:
   virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
 
 private:
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
@@ -23,8 +23,6 @@ private:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override;
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override;
-
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
 private:

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <ToolsFoundation/Document/DocumentManager.h>
-#include <Foundation/Types/Status.h>
 #include <EditorFramework/Assets/AssetDocumentManager.h>
+#include <Foundation/Types/Status.h>
 #include <GameEngine/Configuration/PlatformProfile.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
 
 class ezSceneDocumentManager : public ezAssetDocumentManager
 {
@@ -14,21 +14,14 @@ public:
 
   static ezSceneDocumentManager* s_pSingleton;
 
-
-  virtual ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const override;
-
 private:
   virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override;
-
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
-private:
   void SetupDefaultScene(ezDocument* pDocument);
 
-  ezDocumentTypeDescriptor m_DocTypeDesc;
-  ezDocumentTypeDescriptor m_DocTypeDesc2;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc2;
 };
-

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -30,7 +30,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneContext, 1, ezRTTIDefaultAllocator<ezScen
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Scene;Prefab;PropertyAnim Asset"),
+    EZ_CONSTANT_PROPERTY("DocumentType", (const char*) "Scene;Prefab;PropertyAnim"),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
@@ -22,7 +22,7 @@ void OnLoadPlugin(bool bReloading)
 
   ezTypeScriptActions::RegisterActions();
 
-  // TypeScript Asset
+  // TypeScript
   {
     // Menu Bar
     {

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.cpp
@@ -24,11 +24,6 @@ ezTypeScriptAssetDocument::ezTypeScriptAssetDocument(const char* szDocumentPath)
 {
 }
 
-const char* ezTypeScriptAssetDocument::QueryAssetType() const
-{
-  return "TypeScript";
-}
-
 void ezTypeScriptAssetDocument::EditScript()
 {
   ezStringBuilder sTsPath(GetProperties()->m_sScriptFile);

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.h
@@ -27,8 +27,6 @@ class ezTypeScriptAssetDocument : public ezSimpleAssetDocument<ezTypeScriptAsset
 public:
   ezTypeScriptAssetDocument(const char* szDocumentPath);
 
-  virtual const char* QueryAssetType() const override;
-
   void EditScript();
 
   const ezEvent<const ezTypeScriptAssetDocumentEvent&>& GetEvent() const { return m_Events; }

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -238,7 +238,7 @@ ezResult ezTypeScriptAssetDocumentManager::GenerateScriptCompendium(ezBitflags<e
   {
     const ezSubAsset* pSub = &it.Value();
 
-    if (pSub->m_pAssetInfo->m_pManager == this)
+    if (pSub->m_pAssetInfo->GetManager() == this)
     {
       allTsAssets.PushBack(pSub->m_pAssetInfo);
     }

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -29,11 +29,11 @@ ezTypeScriptAssetDocumentManager::ezTypeScriptAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezTypeScriptAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_sDocumentTypeName = "TypeScript";
-  m_AssetDesc.m_sFileExtension = "ezTypeScriptAsset";
-  m_AssetDesc.m_sIcon = ":/AssetIcons/TypeScript.png";
-  m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTypeScriptAssetDocument>();
-  m_AssetDesc.m_pManager = this;
+  m_DocTypeDesc.m_sDocumentTypeName = "TypeScript";
+  m_DocTypeDesc.m_sFileExtension = "ezTypeScriptAsset";
+  m_DocTypeDesc.m_sIcon = ":/AssetIcons/TypeScript.png";
+  m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezTypeScriptAssetDocument>();
+  m_DocTypeDesc.m_pManager = this;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("TypeScript", QPixmap(":/AssetIcons/TypeScript.png"));
 
@@ -79,7 +79,7 @@ void ezTypeScriptAssetDocumentManager::InternalCreateDocument(const char* szDocu
 
 void ezTypeScriptAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
-  inout_DocumentTypes.PushBack(&m_AssetDesc);
+  inout_DocumentTypes.PushBack(&m_DocTypeDesc);
 }
 
 ezBitflags<ezAssetDocumentFlags>

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -35,6 +35,9 @@ ezTypeScriptAssetDocumentManager::ezTypeScriptAssetDocumentManager()
   m_DocTypeDesc.m_pDocumentType = ezGetStaticRTTI<ezTypeScriptAssetDocument>();
   m_DocTypeDesc.m_pManager = this;
 
+  m_DocTypeDesc.m_sResourceFileExtension = "ezTypeScriptRes";
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::None;
+
   ezQtImageCache::GetSingleton()->RegisterTypeImage("TypeScript", QPixmap(":/AssetIcons/TypeScript.png"));
 
   ezToolsProject::s_Events.AddEventHandler(ezMakeDelegate(&ezTypeScriptAssetDocumentManager::ToolsProjectEventHandler, this));
@@ -80,13 +83,6 @@ void ezTypeScriptAssetDocumentManager::InternalCreateDocument(const char* szDocu
 void ezTypeScriptAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const
 {
   inout_DocumentTypes.PushBack(&m_DocTypeDesc);
-}
-
-ezBitflags<ezAssetDocumentFlags>
-ezTypeScriptAssetDocumentManager::GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const
-{
-  EZ_ASSERT_DEBUG(pDescriptor->m_pManager == this, "Given type descriptor is not part of this document manager!");
-  return ezAssetDocumentFlags::None;
 }
 
 void ezTypeScriptAssetDocumentManager::ToolsProjectEventHandler(const ezToolsProjectEvent& e)

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -30,7 +30,7 @@ ezTypeScriptAssetDocumentManager::ezTypeScriptAssetDocumentManager()
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezTypeScriptAssetDocumentManager::OnDocumentManagerEvent, this));
 
   m_AssetDesc.m_bCanCreate = true;
-  m_AssetDesc.m_sDocumentTypeName = "TypeScript Asset";
+  m_AssetDesc.m_sDocumentTypeName = "TypeScript";
   m_AssetDesc.m_sFileExtension = "ezTypeScriptAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/TypeScript.png";
   m_AssetDesc.m_pDocumentType = ezGetStaticRTTI<ezTypeScriptAssetDocument>();

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -73,11 +73,9 @@ void ezTypeScriptAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMa
   }
 }
 
-ezStatus ezTypeScriptAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
+void ezTypeScriptAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument)
 {
   out_pDocument = new ezTypeScriptAssetDocument(szPath);
-
-  return ezStatus(EZ_SUCCESS);
 }
 
 void ezTypeScriptAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -29,7 +29,6 @@ ezTypeScriptAssetDocumentManager::ezTypeScriptAssetDocumentManager()
 {
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(&ezTypeScriptAssetDocumentManager::OnDocumentManagerEvent, this));
 
-  m_AssetDesc.m_bCanCreate = true;
   m_AssetDesc.m_sDocumentTypeName = "TypeScript";
   m_AssetDesc.m_sFileExtension = "ezTypeScriptAsset";
   m_AssetDesc.m_sIcon = ":/AssetIcons/TypeScript.png";

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
@@ -16,8 +16,6 @@ public:
   ezTypeScriptAssetDocumentManager();
   ~ezTypeScriptAssetDocumentManager();
 
-  virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezTypeScriptRes"; }
-
   ezTypeScriptTranspiler& GetTranspiler() { return m_Transpiler; }
 
   void SetupProjectForTypeScript(bool bForce);
@@ -28,8 +26,6 @@ private:
 
   virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
-
-  ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 
@@ -46,7 +42,7 @@ private:
   bool m_bProjectSetUp = false;
   ezTypeScriptTranspiler m_Transpiler;
 
-  ezDocumentTypeDescriptor m_DocTypeDesc;
+  ezAssetDocumentTypeDescriptor m_DocTypeDesc;
 
   ezMap<ezString, ezTimestamp> m_CheckedTsFiles;
 };

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
@@ -18,11 +18,6 @@ public:
 
   virtual ezString GetResourceTypeExtension(const char* szDocumentPath) const override { return "ezTypeScriptRes"; }
 
-  virtual void QuerySupportedAssetTypes(ezSet<ezString>& inout_AssetTypeNames) const override
-  {
-    inout_AssetTypeNames.Insert("TypeScript");
-  }
-
   ezTypeScriptTranspiler& GetTranspiler() { return m_Transpiler; }
 
   void SetupProjectForTypeScript(bool bForce);

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
@@ -31,7 +31,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   ezBitflags<ezAssetDocumentFlags> GetAssetDocumentTypeFlags(const ezDocumentTypeDescriptor* pDescriptor) const;

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
@@ -46,7 +46,7 @@ private:
   bool m_bProjectSetUp = false;
   ezTypeScriptTranspiler m_Transpiler;
 
-  ezDocumentTypeDescriptor m_AssetDesc;
+  ezDocumentTypeDescriptor m_DocTypeDesc;
 
   ezMap<ezString, ezTimestamp> m_CheckedTsFiles;
 };

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
@@ -55,7 +55,7 @@ ezQtModifiedDocumentsDlg::ezQtModifiedDocumentsDlg(QWidget* parent, const ezHybr
     TableDocuments->setCellWidget(iRow, 2, pButtonSave);
 
     QTableWidgetItem* pItem0 = new QTableWidgetItem();
-    pItem0->setData(Qt::DisplayRole, QString::fromUtf8(pDoc->GetDocumentTypeDisplayString()));
+    pItem0->setData(Qt::DisplayRole, QString::fromUtf8(pDoc->GetDocumentTypeDescriptor()->m_sDocumentTypeName));
     pItem0->setIcon(ezQtUiServices::GetCachedIconResource(pDoc->GetDocumentTypeDescriptor()->m_sIcon));
     TableDocuments->setItem(iRow, 0, pItem0);
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -62,7 +62,6 @@ public:
   bool IsModified() const { return m_bModified; }
   bool IsReadOnly() const { return m_bReadOnly; }
   const ezUuid& GetGuid() const { return m_pDocumentInfo->m_DocumentID; }
-  virtual const char* GetDocumentTypeDisplayString() const = 0;
 
   const ezDocumentObjectManager* GetObjectManager() const { return m_pObjectManager; }
   ezDocumentObjectManager* GetObjectManager() { return m_pObjectManager; }

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -99,6 +99,9 @@ public:
 
   const ezDocumentTypeDescriptor* GetDocumentTypeDescriptor() const { return m_pTypeDescriptor; }
 
+  /// \brief Returns the document's type name. Same as GetDocumentTypeDescriptor()->m_sDocumentTypeName.
+  const char* GetDocumentTypeName() const { return m_pTypeDescriptor->m_sDocumentTypeName; }
+
   const ezDocumentInfo* GetDocumentInfo() const { return m_pDocumentInfo; }
 
   ///@}

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -226,9 +226,9 @@ protected:
 
   mutable ezSelectionManager m_SelectionManager;
   mutable ezCommandHistory m_CommandHistory;
-  ezDocumentInfo* m_pDocumentInfo;
-  const ezDocumentTypeDescriptor* m_pTypeDescriptor;
-  mutable ezObjectCommandAccessor* m_ObjectAccessor; ///< Default object accessor used by every doc.
+  ezDocumentInfo* m_pDocumentInfo = nullptr;
+  const ezDocumentTypeDescriptor* m_pTypeDescriptor = nullptr;
+  mutable ezObjectCommandAccessor* m_ObjectAccessor = nullptr; ///< Default object accessor used by every doc.
 
 private:
   friend class ezDocumentManager;
@@ -238,8 +238,8 @@ private:
 
   void SetupDocumentInfo(const ezDocumentTypeDescriptor* pTypeDescriptor);
 
-  ezDocumentManager* m_pDocumentManager;
-  ezDocumentObjectManager* m_pObjectManager;
+  ezDocumentManager* m_pDocumentManager = nullptr;
+  ezDocumentObjectManager* m_pObjectManager = nullptr;
 
   ezString m_sDocumentPath;
   bool m_bModified;

--- a/Code/Tools/Libs/ToolsFoundation/Document/DocumentManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/DocumentManager.h
@@ -81,9 +81,7 @@ public:
   void GetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const;
 
 private:
-  virtual ezStatus InternalCanOpenDocument(const char* szDocumentTypeName, const char* szFilePath) const { return ezStatus(EZ_SUCCESS); }
-  virtual ezStatus InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument,
-    ezDocument*& out_pDocument) = 0;
+  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument) = 0;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const = 0;
 
 private:

--- a/Code/Tools/Libs/ToolsFoundation/Document/DocumentManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/DocumentManager.h
@@ -76,7 +76,8 @@ public:
   static ezEvent<const Event&> s_Events;
   static ezEvent<Request&> s_Requests;
 
-  static const ezDynamicArray<const ezDocumentTypeDescriptor*>& GetAllDocumentDescriptors();
+  static const ezDocumentTypeDescriptor* GetDescriptorForDocumentType(const char* szDocumentType);
+  static const ezMap<ezString, const ezDocumentTypeDescriptor*>& GetAllDocumentDescriptors();
 
   void GetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const;
 
@@ -101,5 +102,5 @@ private:
   static ezSet<const ezRTTI*> s_KnownManagers;
   static ezHybridArray<ezDocumentManager*, 16> s_AllDocumentManagers;
 
-  static ezDynamicArray<const ezDocumentTypeDescriptor*> s_AllDocumentDescriptors;
+  static ezMap<ezString, const ezDocumentTypeDescriptor*> s_AllDocumentDescriptors;
 };

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Declarations.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Declarations.h
@@ -33,7 +33,7 @@ struct EZ_TOOLSFOUNDATION_DLL ezDocumentTypeDescriptor
 {
   ezString m_sFileExtension;
   ezString m_sDocumentTypeName;
-  bool m_bCanCreate = false;
+  bool m_bCanCreate = true;
   ezString m_sIcon;
   const ezRTTI* m_pDocumentType = nullptr;
   ezDocumentManager* m_pManager = nullptr;

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -2,12 +2,12 @@
 
 #include <Foundation/Configuration/Plugin.h>
 #include <Foundation/Configuration/SubSystem.h>
-#include <Foundation/Profiling/Profiling.h>
-#include <ToolsFoundation/Document/DocumentManager.h>
-#include <Foundation/IO/OSFile.h>
-#include <Foundation/Serialization/RttiConverter.h>
-#include <Foundation/Serialization/DdlSerializer.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Profiling/Profiling.h>
+#include <Foundation/Serialization/DdlSerializer.h>
+#include <Foundation/Serialization/RttiConverter.h>
+#include <ToolsFoundation/Document/DocumentManager.h>
 #include <ToolsFoundation/Document/DocumentUtils.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
 
@@ -159,7 +159,7 @@ ezStatus ezDocumentManager::CanOpenDocument(const char* szFilePath) const
   {
     if (DocumentTypes[i]->m_sFileExtension.IsEqual_NoCase(sExt))
     {
-      return InternalCanOpenDocument(DocumentTypes[i]->m_sDocumentTypeName, szFilePath);
+      return ezStatus(EZ_SUCCESS);
     }
   }
 
@@ -187,8 +187,8 @@ void ezDocumentManager::EnsureWindowRequested(ezDocument* pDocument, const ezDoc
 }
 
 ezStatus ezDocumentManager::CreateOrOpenDocument(bool bCreate, const char* szDocumentTypeName, const char* szPath,
-                                                 ezDocument*& out_pDocument, ezBitflags<ezDocumentFlags> flags,
-                                                 const ezDocumentObject* pOpenContext /*= nullptr*/)
+  ezDocument*& out_pDocument, ezBitflags<ezDocumentFlags> flags,
+  const ezDocumentObject* pOpenContext /*= nullptr*/)
 {
   ezFileStats fs;
   ezStringBuilder sPath = szPath;
@@ -240,7 +240,7 @@ ezStatus ezDocumentManager::CreateOrOpenDocument(bool bCreate, const char* szDoc
           {
             status = OpenDocument(szDocumentTypeName, sPath, out_pDocument, flags, pOpenContext);
 
-            if(status.Failed())
+            if (status.Failed())
             {
               ezLog::SeriousWarning("Couldn't open cloned template document, proceeding with normal creation behavior.");
             }
@@ -260,9 +260,8 @@ ezStatus ezDocumentManager::CreateOrOpenDocument(bool bCreate, const char* szDoc
 
       {
         EZ_PROFILE_SCOPE(szDocumentTypeName);
-        status = InternalCreateDocument(szDocumentTypeName, sPath, bCreate, out_pDocument);
-        EZ_ASSERT_DEV(status.m_Result == EZ_FAILURE || out_pDocument != nullptr,
-                      "Status was success, but the document manager returned a nullptr document.");
+        status = ezStatus(EZ_SUCCESS);
+        InternalCreateDocument(szDocumentTypeName, sPath, bCreate, out_pDocument);
       }
       out_pDocument->SetAddToResetFilesList(flags.IsSet(ezDocumentFlags::AddToRecentFilesList));
 
@@ -520,7 +519,7 @@ const ezDynamicArray<const ezDocumentTypeDescriptor*>& ezDocumentManager::GetAll
     }
 
     s_AllDocumentDescriptors.Sort(
-        [](const auto& a, const auto& b) -> bool { return a->m_sDocumentTypeName.Compare_NoCase(b->m_sDocumentTypeName) < 0; });
+      [](const auto& a, const auto& b) -> bool { return a->m_sDocumentTypeName.Compare_NoCase(b->m_sDocumentTypeName) < 0; });
   }
 
   return s_AllDocumentDescriptors;

--- a/Code/UnitTests/EditorTest/Project/Project.cpp
+++ b/Code/UnitTests/EditorTest/Project/Project.cpp
@@ -43,8 +43,10 @@ ezResult ezEditorTestProject::DeInitializeTest()
 ezTestAppRun ezEditorTestProject::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
 {
   const auto& allDesc = ezDocumentManager::GetAllDocumentDescriptors();
-  for (auto* pDesc : allDesc)
+  for (auto it : allDesc)
   {
+    auto pDesc = it.Value();
+
     if (pDesc->m_bCanCreate)
     {
       ezStringBuilder sName = m_sProjectPath;

--- a/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.cpp
@@ -76,11 +76,6 @@ void ezTestDocument::ApplyNativePropertyChangesToObjectManager(ezDocumentObject*
   m_ObjectMirror.SendDocument();
 }
 
-const char* ezTestDocument::GetDocumentTypeDisplayString() const
-{
-  return "Test";
-}
-
 ezDocumentInfo* ezTestDocument::CreateDocumentInfo()
 {
   return EZ_DEFAULT_NEW(ezDocumentInfo);

--- a/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.h
+++ b/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.h
@@ -26,7 +26,6 @@ public:
 
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
   void ApplyNativePropertyChangesToObjectManager(ezDocumentObject* pObject);
-  virtual const char* GetDocumentTypeDisplayString() const override;
   virtual ezDocumentInfo* CreateDocumentInfo() override;
 
   ezDocumentObjectMirror m_ObjectMirror;


### PR DESCRIPTION
* No more distinction between "document type" and "asset type"
* Asset icons are now always taken from the document type description (was sometimes auto generated before)
* Removed GetDocumentTypeDisplayString, uses the document type name now
* AssetInfo now knows the exact document type (previously it only new the document manager)
* Moved asset flags + output file extension into document type descriptor