### PR TITLE
Logging cleanup and ETW support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,4 +349,5 @@ MigrationBackup/
 /Output
 AssetCache
 /build/
+/buildUWP/
 Data/Samples/Testing Chambers/TypeScript/

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -279,7 +279,7 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> flags, const char* sz
       CreateOrOpenProject(false, s_RecentProjects.GetFileList()[0].m_File);
     }
   }
-  else
+  else if (!m_bHeadless)
   {
     if (ezQtContainerWindow::GetContainerWindow())
     {

--- a/Code/Engine/Foundation/Application/Implementation/Posix/ApplicationEntryPoint_posix.h
+++ b/Code/Engine/Foundation/Application/Implementation/Posix/ApplicationEntryPoint_posix.h
@@ -26,7 +26,7 @@
     {                                                                                                                                      \
       const char* szReturnCode = pApp->TranslateReturnCode();                                                                              \
       if (szReturnCode != nullptr && szReturnCode[0] != '\0')                                                                              \
-        printf("Return Code: '%s'\n", szReturnCode);                                                                                       \
+        ezLog::Printf("Return Code: '%s'\n", szReturnCode);                                                                                       \
     }                                                                                                                                      \
     pApp->~AppClass();                                                                                                                     \
     memset(pApp, 0, sizeof(AppClass));                                                                                                     \

--- a/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.cpp
@@ -22,10 +22,10 @@ namespace ezApplicationDetails
 
       if (!fpStdout || !fpStderr || !fpStdin)
       {
-        printf("\nCouldn't reopen console output in AttachToConsoleWindow()\n");
+        ezLog::Print("\nCouldn't reopen console output in AttachToConsoleWindow()\n");
       }
 
-      printf("\n");
+      ezLog::Print("\n");
     }
   }
 

--- a/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
+++ b/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
@@ -7,6 +7,7 @@
 #include <Foundation/Memory/MemoryTracker.h>
 #include <Foundation/Threading/Lock.h>
 #include <Foundation/Threading/Mutex.h>
+#include <Foundation/Logging/Log.h>
 
 namespace ezApplicationDetails
 {
@@ -24,7 +25,7 @@ namespace ezApplicationDetails
     {
       std::string text = pApp->TranslateReturnCode();
       if (!text.empty())
-        printf("Return Code: '%s'\n", text.c_str());
+        ezLog::Printf("Return Code: '%s'\n", text.c_str());
     }
 
     const bool memLeaks = pApp->IsMemoryLeakReportingEnabled();
@@ -70,7 +71,7 @@ namespace ezApplicationDetails
     {
       std::string text = pApp->TranslateReturnCode();
       if (!text.empty())
-        printf("Return Code: '%s'\n", text.c_str());
+        ezLog::Printf("Return Code: '%s'\n", text.c_str());
     }
 
     const bool memLeaks = pApp->IsMemoryLeakReportingEnabled();

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.cpp
@@ -11,7 +11,7 @@ namespace ezApplicationDetails
     HRESULT result = RoInitialize(RO_INIT_MULTITHREADED);
     if (FAILED(result))
     {
-      printf("Failed to init WinRT: %i", result);
+      ezLog::Printf("Failed to init WinRT: %i", result);
       return EZ_FAILURE;
     }
 

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
@@ -4,6 +4,7 @@
 /// \file
 
 #include <Foundation/Memory/MemoryTracker.h>
+#include <Foundation/Logging/Log.h>
 
 // Disable C++/CX adds.
 #pragma warning(disable : 4447)

--- a/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
@@ -98,7 +98,7 @@ EZ_FOUNDATION_DLL ezResult ezUWPRun(ezApplication* pApp)
       HStringReference(RuntimeClass_Windows_ApplicationModel_Core_CoreApplication).Get(), &coreApplication);
   if (FAILED(result))
   {
-    printf("Failed to create core application: %i\n", result);
+    ezLog::Printf("Failed to create core application: %i\n", result);
     return EZ_FAILURE;
   }
 

--- a/Code/Engine/Foundation/Basics/Assert.cpp
+++ b/Code/Engine/Foundation/Basics/Assert.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/Strings/StringUtils.h>
 #include <Foundation/System/SystemInformation.h>
 #include <Foundation/Utilities/ConversionUtils.h>
+#include <Foundation/Logging/Log.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -23,12 +24,8 @@ bool ezDefaultAssertHandler(
     szExpression, szFunction, szSourceFile, uiLine, szAssertMsg);
   szTemp[1024 * 4 - 1] = '\0';
 
-  printf("%s", szTemp);
-
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-  OutputDebugStringW(ezStringWChar(szTemp).GetData());
-#endif
-
+  ezLog::Print(szTemp);
+  
   if (ezSystemInformation::IsDebuggerAttached())
     return true;
 

--- a/Code/Engine/Foundation/FoundationPCH.cpp
+++ b/Code/Engine/Foundation/FoundationPCH.cpp
@@ -86,6 +86,7 @@ EZ_STATICLINK_LIBRARY(Foundation)
   EZ_STATICLINK_REFERENCE(Foundation_IO_Implementation_StreamOperationsOther);
   EZ_STATICLINK_REFERENCE(Foundation_IO_Implementation_StringDeduplicationContext);
   EZ_STATICLINK_REFERENCE(Foundation_Logging_Implementation_ConsoleWriter);
+  EZ_STATICLINK_REFERENCE(Foundation_Logging_Implementation_ETWWriter);
   EZ_STATICLINK_REFERENCE(Foundation_Logging_Implementation_HTMLWriter);
   EZ_STATICLINK_REFERENCE(Foundation_Logging_Implementation_Log);
   EZ_STATICLINK_REFERENCE(Foundation_Logging_Implementation_LogEntry);

--- a/Code/Engine/Foundation/Logging/ETWWriter.h
+++ b/Code/Engine/Foundation/Logging/ETWWriter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Foundation/Logging/Log.h>
+
+namespace ezLogWriter
+{
+
+  /// \brief A simple log writer that outputs all log messages to the ez ETW provider.
+  class EZ_FOUNDATION_DLL ETW
+  {
+  public:
+    /// \brief Register this at ezLog to write all log messages to ETW.
+    static void LogMessageHandler(const ezLoggingEventData& eventData);
+
+    /// \brief Log Message to ETW.
+    static void LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag = "");
+
+  };
+}
+

--- a/Code/Engine/Foundation/Logging/ETWWriter.h
+++ b/Code/Engine/Foundation/Logging/ETWWriter.h
@@ -13,7 +13,7 @@ namespace ezLogWriter
     static void LogMessageHandler(const ezLoggingEventData& eventData);
 
     /// \brief Log Message to ETW.
-    static void LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag = "");
+    static void LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText);
 
   };
 }

--- a/Code/Engine/Foundation/Logging/Implementation/ETWWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/ETWWriter.cpp
@@ -1,0 +1,37 @@
+#include <FoundationPCH.h>
+
+#include <Foundation/Logging/ETWWriter.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#  include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#  include <Foundation/Logging/Implementation/Win/ETWProvider_win.h>
+
+void ezLogWriter::ETW::LogMessageHandler(const ezLoggingEventData& eventData)
+{
+  if (eventData.m_EventType == ezLogMsgType::Flush)
+    return;
+
+  ezETWProvider::GetInstance().LogMessge(eventData.m_EventType, eventData.m_uiIndentation, eventData.m_szText, eventData.m_szTag);
+}
+
+void ezLogWriter::ETW::LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag)
+{
+  if (eventType == ezLogMsgType::Flush)
+    return;
+
+  ezETWProvider::GetInstance().LogMessge(eventType, uiIndentation, szText, szTag);
+}
+
+#else
+
+void ezLogWriter::ETW::LogMessageHandler(const ezLoggingEventData& eventData)
+{
+}
+
+void ezLogWriter::ETW::LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag)
+{
+}
+
+#endif
+
+EZ_STATICLINK_FILE(Foundation, Foundation_Logging_Implementation_ETWWriter);

--- a/Code/Engine/Foundation/Logging/Implementation/ETWWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/ETWWriter.cpp
@@ -11,15 +11,15 @@ void ezLogWriter::ETW::LogMessageHandler(const ezLoggingEventData& eventData)
   if (eventData.m_EventType == ezLogMsgType::Flush)
     return;
 
-  ezETWProvider::GetInstance().LogMessge(eventData.m_EventType, eventData.m_uiIndentation, eventData.m_szText, eventData.m_szTag);
+  ezETWProvider::GetInstance().LogMessge(eventData.m_EventType, eventData.m_uiIndentation, eventData.m_szText);
 }
 
-void ezLogWriter::ETW::LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag)
+void ezLogWriter::ETW::LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText)
 {
   if (eventType == ezLogMsgType::Flush)
     return;
 
-  ezETWProvider::GetInstance().LogMessge(eventType, uiIndentation, szText, szTag);
+  ezETWProvider::GetInstance().LogMessge(eventType, uiIndentation, szText);
 }
 
 #else

--- a/Code/Engine/Foundation/Logging/Implementation/ETWWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/ETWWriter.cpp
@@ -28,7 +28,7 @@ void ezLogWriter::ETW::LogMessageHandler(const ezLoggingEventData& eventData)
 {
 }
 
-void ezLogWriter::ETW::LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag)
+void ezLogWriter::ETW::LogMessage(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText)
 {
 }
 

--- a/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.cpp
@@ -34,14 +34,13 @@ ezETWProvider::~ezETWProvider()
   TraceLoggingUnregister(g_ezETWLogProvider);
 }
 
-void ezETWProvider::LogMessge(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag)
+void ezETWProvider::LogMessge(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText)
 {
   TraceLoggingWrite(g_ezETWLogProvider,
     "LogMessge",
     TraceLoggingValue((int)eventType, "Type"),
     TraceLoggingValue(uiIndentation, "Indentation"),
-    TraceLoggingValue(szText, "Text"),
-    TraceLoggingValue(szTag, "Tag"));
+    TraceLoggingValue(szText, "Text"));
 }
 
 ezETWProvider& ezETWProvider::GetInstance()

--- a/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.cpp
@@ -1,0 +1,52 @@
+#include <FoundationPCH.h>
+
+#include <Foundation/Logging/Implementation/Win/ETWProvider_win.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+
+#    include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#    include <TraceLoggingProvider.h>
+
+// Workaround to support TraceLoggingProvider.h and /utf-8 compiler switch.
+#    undef _TlgPragmaUtf8Begin
+#    undef _TlgPragmaUtf8End
+#    define _TlgPragmaUtf8Begin
+#    define _TlgPragmaUtf8End
+
+TRACELOGGING_DECLARE_PROVIDER(g_ezETWLogProvider);
+
+// Define the GUID to use for the ez ETW Logger
+// {BFD4350A-BA77-463D-B4BE-E30374E42494}
+#    define EZ_LOGGER_GUID (0xbfd4350a, 0xba77, 0x463d, 0xb4, 0xbe, 0xe3, 0x3, 0x74, 0xe4, 0x24, 0x94)
+
+TRACELOGGING_DEFINE_PROVIDER(
+  g_ezETWLogProvider,
+  "ezLogProvider",
+  EZ_LOGGER_GUID);
+
+ezETWProvider::ezETWProvider()
+{
+  TraceLoggingRegister(g_ezETWLogProvider);
+}
+
+ezETWProvider::~ezETWProvider()
+{
+  TraceLoggingUnregister(g_ezETWLogProvider);
+}
+
+void ezETWProvider::LogMessge(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag)
+{
+  TraceLoggingWrite(g_ezETWLogProvider,
+    "LogMessge",
+    TraceLoggingValue((int)eventType, "Type"),
+    TraceLoggingValue(uiIndentation, "Indentation"),
+    TraceLoggingValue(szText, "Text"),
+    TraceLoggingValue(szTag, "Tag"));
+}
+
+ezETWProvider& ezETWProvider::GetInstance()
+{
+  static ezETWProvider instance;
+  return instance;
+}
+#endif

--- a/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.h
+++ b/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.h
@@ -15,7 +15,7 @@ public:
   ezETWProvider();
   ~ezETWProvider();
 
-  void LogMessge(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag = "");
+  void LogMessge(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText);
 
   static ezETWProvider& GetInstance();
 };

--- a/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.h
+++ b/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+
+#  include <Foundation/FoundationInternal.h>
+#  include <Foundation/Logging/Log.h>
+
+EZ_FOUNDATION_INTERNAL_HEADER
+
+class ezETWProvider
+{
+public:
+  ezETWProvider();
+  ~ezETWProvider();
+
+  void LogMessge(ezLogMsgType::Enum eventType, ezUInt8 uiIndentation, const char* szText, const char* szTag = "");
+
+  static ezETWProvider& GetInstance();
+};
+#endif

--- a/Code/Engine/Foundation/Logging/Log.h
+++ b/Code/Engine/Foundation/Logging/Log.h
@@ -309,11 +309,15 @@ public:
 
   /// \brief Calls low-level OS functionality to print a string to the typical outputs, e.g. printf and OutputDebugString.
   ///
+  /// Use this function to log unrecoverable errors like asserts, crash handlers etc.
   /// This function is meant for short term debugging when actual printing to the console is desired. Code using it should be temporary.
   /// This function flushes the output immediately, to ensure output is never lost during a crash. Consequently it has a high performance
   /// overhead.
-  ///
+  static void Print(const char* szText);
+  
+  /// \brief Calls low-level OS functionality to print a string to the typical outputs. Forwards to Print.
   /// \note This function uses actual printf formatting, not ezFormatString syntax.
+  /// \sa ezLog::Print
   static void Printf(const char* szFormat, ...);
 
   /// \brief This enum is used in context of outputting timestamp information to indicate a formatting for said timestamps.

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
@@ -434,7 +434,7 @@ void ezRTTI::SanityCheckType(ezRTTI* pType)
     //  ezStringBuilder s;
     //  s.Format("RTTI: {0}\n", pProp->GetPropertyName());
 
-    //  OutputDebugStringA(s.GetData());
+    //  ezLog::Print(s.GetData());
     //}
 
     if (pProp->GetCategory() != ezPropertyCategory::Function)

--- a/Code/Engine/Foundation/System/Implementation/Win/StackTracer_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/StackTracer_win.h
@@ -174,7 +174,7 @@ void ezStackTracer::OnPluginEvent(const ezPluginEvent& e)
       char errStr[1024];
       sprintf_s(errStr, "StackTracer could not get module info for '%s'. Error-Code %u (\"%s\")\n", e.m_szPluginFile, err,
                 static_cast<char*>(lpMsgBuf));
-      OutputDebugStringA(errStr);
+      ezLog::Print(errStr);
 
       LocalFree(lpMsgBuf);
     }

--- a/Code/UnitTests/RemoteTestHarness/CMakeLists.txt
+++ b/Code/UnitTests/RemoteTestHarness/CMakeLists.txt
@@ -18,6 +18,7 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY VS_DOTNET_REFERENCES
   "System.Data"
   "${CMAKE_CURRENT_BINARY_DIR}/packages/CommandLineParser.2.5.0/lib/net461/CommandLine.dll"
   "${CMAKE_CURRENT_BINARY_DIR}/packages/Newtonsoft.Json.4.5.1/lib/net40/Newtonsoft.Json.dll"
+  "${CMAKE_CURRENT_BINARY_DIR}/packages/Microsoft.Diagnostics.Tracing.TraceEvent.2.0.49/lib/net45/Microsoft.Diagnostics.Tracing.TraceEvent.dll"
 )
 
 add_custom_command(TARGET ${PROJECT_NAME}

--- a/Code/UnitTests/RemoteTestHarness/Program.cs
+++ b/Code/UnitTests/RemoteTestHarness/Program.cs
@@ -24,6 +24,12 @@ namespace ezUwpTestHarness
 
     static void Main(string[] args)
     {
+      if (!(Microsoft.Diagnostics.Tracing.Session.TraceEventSession.IsElevated() ?? false))
+      {
+        Console.Out.WriteLine("To turn on ETW events you need to be Administrator, please run from an Admin process.");
+        Debugger.Break();
+      }
+
       AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs eventArgs) =>
       {
         Environment.ExitCode = 1;

--- a/Code/UnitTests/RemoteTestHarness/TestUwp.cs
+++ b/Code/UnitTests/RemoteTestHarness/TestUwp.cs
@@ -246,7 +246,6 @@ class ezTestUWP
           int Type = (int)data.PayloadByName("Type");
           byte Indentation = (byte)data.PayloadByName("Indentation");
           string Text = (string)data.PayloadByName("Text");
-          string Tag = (string)data.PayloadByName("Tag");
           if (Type != (int)ezLogMsgType.EndGroup)
           {
             Console.Out.WriteLine("".PadLeft(Indentation) + Text);

--- a/Code/UnitTests/RemoteTestHarness/TestUwp.cs
+++ b/Code/UnitTests/RemoteTestHarness/TestUwp.cs
@@ -5,10 +5,30 @@ using System.IO;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Session;
+using System.IO.MemoryMappedFiles;
+using System.Threading;
 
 namespace ezUwpTestHarness
 {
-  class ezTestUWP
+  enum ezLogMsgType
+  {  
+      Flush = -3,
+      BeginGroup = -2,
+      EndGroup = -1,
+      None = 0,
+      ErrorMsg = 1,
+      SeriousWarningMsg = 2,
+      WarningMsg = 3,
+      SuccessMsg = 4,
+      InfoMsg = 5,
+      DevMsg = 6,
+      DebugMsg = 7,
+      All = 8,
+  };
+
+class ezTestUWP
   {
     #region Activation Manager COM definitions
 
@@ -217,67 +237,95 @@ namespace ezUwpTestHarness
         return ezProcessHelper.RunExternalExe(absFilerserveFilename, args, absBinDir, 200000);
       };
 
-      using (Task<ezProcessHelper.ProcessResult> runFileServe = Task.Factory.StartNew(startFileserve, System.Threading.Tasks.TaskCreationOptions.LongRunning))
+      // create a real time user mode session
+      using (var session = new TraceEventSession("ezETWMonitorSession"))
       {
-        runFileServe.Wait(5000);
-
-        // Start AppX
-        uint appXPid;
-        StartAppX(fullPackageName, $"-json {outputFilename} -nogui -rev 0 -all", out appXPid);
-
-        Process appXProcess;
-        appXProcess = Process.GetProcessById((int)appXPid);
-        Console.WriteLine($"AppX pid: {appXPid}.");
-
-        if (!runFileServe.Wait(60000))
+        session.EnableProvider(new Guid("BFD4350A-BA77-463D-B4BE-E30374E42494")); //ezLogProvider
+        session.Source.Dynamic.AddCallbackForProviderEvent("ezLogProvider", "LogMessge", delegate (TraceEvent data)
         {
-          Console.WriteLine(string.Format("Fileserve did not terminate within 10 minutes."));
+          int Type = (int)data.PayloadByName("Type");
+          byte Indentation = (byte)data.PayloadByName("Indentation");
+          string Text = (string)data.PayloadByName("Text");
+          string Tag = (string)data.PayloadByName("Tag");
+          if (Type != (int)ezLogMsgType.EndGroup)
+          {
+            Console.Out.WriteLine("".PadLeft(Indentation) + Text);
+          }
+        });
+
+        //// Set up Ctrl-C to stop the session
+        Console.CancelKeyPress += (object s, ConsoleCancelEventArgs a) => session.Dispose();
+        var thread = new Thread(() =>
+        {
+          session.Source.Process();
+        });
+        thread.Start();
+
+        using (Task<ezProcessHelper.ProcessResult> runFileServe = Task.Factory.StartNew(startFileserve, System.Threading.Tasks.TaskCreationOptions.LongRunning))
+        {
+          runFileServe.Wait(8000);
+
+          // Start AppX
+          uint appXPid;
+          StartAppX(fullPackageName, $"-json {outputFilename} -nogui -rev 0 -all", out appXPid);
+
+          Process appXProcess;
+          appXProcess = Process.GetProcessById((int)appXPid);
+          Console.WriteLine($"AppX pid: {appXPid}.");
+
+          if (!runFileServe.Wait(60000))
+          {
+            Console.WriteLine(string.Format("Fileserve did not terminate within 10 minutes."));
+          }
+          Task.WaitAll(runFileServe);
+
+          // Check whether the AppX is dead by now.
+          if (!appXProcess.WaitForExit(5000))
+          {
+            Console.WriteLine(string.Format("Fileserve is no longer running but the AppX is."));
+            try
+            {
+              string args = string.Format("-accepteula -ma {0}", appXPid);
+              ezProcessHelper.RunExternalExe("procdump", args, absBinDir);
+            }
+            catch (Exception e)
+            {
+              Console.WriteLine(string.Format("Failed to run procdump: '{0}'", e.ToString()));
+            }
+            appXProcess.Kill();
+          }
+          // Can't read exit code: "Process was not started by this object, so requested information cannot be determined"
+          appXProcess.Dispose();
+          appXProcess = null;
         }
-        Task.WaitAll(runFileServe);
 
-        // Check whether the AppX is dead by now.
-        if (!appXProcess.WaitForExit(5000))
+        // Wait for ETW events to trickle through.
+        Thread.Sleep(5000);
+
+        // Read test output.
+        if (File.Exists(absOutputPath))
         {
-          Console.WriteLine(string.Format("Fileserve is no longer running but the AppX is."));
+          string TestResultJSON = File.ReadAllText(absOutputPath, Encoding.UTF8);
+
           try
           {
-            string args = string.Format("-accepteula -ma {0}", appXPid);
-            ezProcessHelper.RunExternalExe("procdump", args, absBinDir);
+            // Parse test output to figure out what the result is as we can't use the exit code.
+            var values = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, dynamic>>(TestResultJSON);
+            var errors = values["errors"] as Newtonsoft.Json.Linq.JArray;
+            Console.WriteLine(string.Format("Errors during test: '{0}'", errors.Count));
+            Environment.ExitCode = errors.Count;
           }
           catch (Exception e)
           {
-            Console.WriteLine(string.Format("Failed to run procdump: '{0}'", e.ToString()));
+            Environment.ExitCode = 1;
+            Console.WriteLine(string.Format("Failed to parse test output: '{0}'", e.ToString()));
           }
-          appXProcess.Kill();
         }
-        // Can't read exit code: "Process was not started by this object, so requested information cannot be determined"
-        appXProcess.Dispose();
-        appXProcess = null;
-      }
-
-      // Read test output.
-      if (File.Exists(absOutputPath))
-      {
-        string TestResultJSON = File.ReadAllText(absOutputPath, Encoding.UTF8);
-
-        try
-        {
-          // Parse test output to figure out what the result is as we can't use the exit code.
-          var values = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, dynamic>>(TestResultJSON);
-          var errors = values["errors"] as Newtonsoft.Json.Linq.JArray;
-          Console.WriteLine(string.Format("Errors during test: '{0}'", errors.Count));
-          Environment.ExitCode = errors.Count;
-        }
-        catch (Exception e)
+        else
         {
           Environment.ExitCode = 1;
-          Console.WriteLine(string.Format("Failed to parse test output: '{0}'", e.ToString()));
+          Console.WriteLine(string.Format("No test output file present!"));
         }
-      }
-      else
-      {
-        Environment.ExitCode = 1;
-        Console.WriteLine(string.Format("No test output file present!"));
       }
     }
   }

--- a/Code/UnitTests/RemoteTestHarness/packages.config
+++ b/Code/UnitTests/RemoteTestHarness/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="CommandLineParser" version="2.5.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="4.5.1" targetFramework="net461" />
+  <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="2.0.49" targetFramework="net461" />
 </packages>

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -9,6 +9,7 @@
 #include <Foundation/System/StackTracer.h>
 #include <Foundation/Threading/ThreadUtils.h>
 #include <Foundation/Types/ScopeExit.h>
+#include <Foundation/Logging/Log.h>
 #include <TestFramework/Utilities/TestOrder.h>
 
 #include <cstdlib>
@@ -32,16 +33,6 @@ ezLog::TimestampMode ezTestFramework::s_LogTimestampMode = ezLog::TimestampMode:
 
 constexpr int s_iMaxErrorMessageLength = 512;
 
-static void PrintCallstack(const char* szText)
-{
-  printf("%s", szText);
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-  OutputDebugStringW(ezStringWChar(szText).GetData());
-#endif
-  fflush(stdout);
-  fflush(stderr);
-};
-
 static bool TestAssertHandler(
   const char* szSourceFile, ezUInt32 uiLine, const char* szFunction, const char* szExpression, const char* szAssertMsg)
 {
@@ -50,7 +41,7 @@ static bool TestAssertHandler(
     void* pBuffer[64];
     ezArrayPtr<void*> tempTrace(pBuffer);
     const ezUInt32 uiNumTraces = ezStackTracer::GetStackTrace(tempTrace, nullptr);
-    ezStackTracer::ResolveStackTrace(tempTrace.GetSubArray(0, uiNumTraces), &PrintCallstack);
+    ezStackTracer::ResolveStackTrace(tempTrace.GetSubArray(0, uiNumTraces), &ezLog::Print);
   }
 
   ezTestFramework::Error(szExpression, szSourceFile, (ezInt32)uiLine, szFunction, szAssertMsg);


### PR DESCRIPTION
-Added ETW provider for UWP testing.
-Move various error handling code to use ezLog::Print instead of platform specific functions.
-Add ETW tracing support to the RemoteTestHarness.