### PR TITLE
const-fix for user-defined conversion of ezSharedPtr

### DIFF
--- a/Code/Engine/Foundation/Types/Implementation/SharedPtr_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/SharedPtr_inl.h
@@ -177,13 +177,7 @@ EZ_ALWAYS_INLINE T* ezSharedPtr<T>::operator->() const
 }
 
 template <typename T>
-EZ_ALWAYS_INLINE ezSharedPtr<T>::operator const T*() const
-{
-  return m_pInstance;
-}
-
-template <typename T>
-EZ_ALWAYS_INLINE ezSharedPtr<T>::operator T*()
+EZ_ALWAYS_INLINE ezSharedPtr<T>::operator T*() const
 {
   return m_pInstance;
 }
@@ -290,4 +284,3 @@ EZ_ALWAYS_INLINE void ezSharedPtr<T>::ReleaseReferenceIfValid()
     m_pAllocator = nullptr;
   }
 }
-

--- a/Code/Engine/Foundation/Types/SharedPtr.h
+++ b/Code/Engine/Foundation/Types/SharedPtr.h
@@ -79,10 +79,7 @@ public:
   T* operator->() const;
 
   /// \brief Provides access to the managed object.
-  operator const T*() const;
-
-  /// \brief Provides access to the managed object.
-  operator T*();
+  operator T*() const;
 
   /// \brief Returns true if there is managed object and false if the shared ptr is empty.
   operator bool() const;


### PR DESCRIPTION
- Allow user-defined conversion of const ezSharedPtr to provide non-const access to managed object