### PR TITLE
Fix ez random access iterators to have required [] operator

### DIFF
--- a/Code/Engine/Foundation/Containers/Implementation/ArrayIterator.h
+++ b/Code/Engine/Foundation/Containers/Implementation/ArrayIterator.h
@@ -72,6 +72,14 @@ public:
   EZ_ALWAYS_INLINE bool operator<=(const const_iterator_base& rhs) const { return m_iIndex <= rhs.m_iIndex; }
   EZ_ALWAYS_INLINE bool operator>=(const const_iterator_base& rhs) const { return m_iIndex >= rhs.m_iIndex; }
 
+  EZ_ALWAYS_INLINE const T& operator[](size_t index) const
+  {
+    if (reverse)
+      return (*m_Array)[m_Array->GetCount() - static_cast<ezUInt32>(m_iIndex + index) - 1];
+    else
+      return (*m_Array)[static_cast<ezUInt32>(m_iIndex + index)];
+  }
+
 protected:
   ARRAY* m_Array;
   size_t m_iIndex;
@@ -86,7 +94,10 @@ public:
   typedef T& reference;
 
   iterator_base() {}
-  iterator_base(ARRAY& deque, size_t index) : const_iterator_base<ARRAY, T, reverse>(deque, index) {}
+  iterator_base(ARRAY& deque, size_t index)
+    : const_iterator_base<ARRAY, T, reverse>(deque, index)
+  {
+  }
 
   EZ_ALWAYS_INLINE iterator_base& operator++()
   {
@@ -126,6 +137,15 @@ public:
   }
   using const_iterator_base<ARRAY, T, reverse>::operator->;
   EZ_ALWAYS_INLINE T* operator->() { return &(**this); }
+
+  using const_iterator_base<ARRAY, T, reverse>::operator[];
+  EZ_ALWAYS_INLINE T& operator[](size_t index)
+  {
+    if (reverse)
+      return (*this->m_Array)[this->m_Array->GetCount() - static_cast<ezUInt32>(this->m_iIndex + index) - 1];
+    else
+      return (*this->m_Array)[static_cast<ezUInt32>(this->m_iIndex + index)];
+  }
 };
 
 /// \brief Base class for Pointer like reverse iterators
@@ -140,7 +160,10 @@ public:
   typedef T& reference;
 
   const_reverse_pointer_iterator() { m_ptr = nullptr; }
-  const_reverse_pointer_iterator(T const* ptr) : m_ptr(const_cast<T*>(ptr)) {}
+  const_reverse_pointer_iterator(T const* ptr)
+    : m_ptr(const_cast<T*>(ptr))
+  {
+  }
 
   EZ_ALWAYS_INLINE const_reverse_pointer_iterator& operator++()
   {
@@ -183,6 +206,11 @@ public:
   EZ_ALWAYS_INLINE bool operator<=(const const_reverse_pointer_iterator& rhs) const { return m_ptr >= rhs.m_ptr; }
   EZ_ALWAYS_INLINE bool operator>=(const const_reverse_pointer_iterator& rhs) const { return m_ptr <= rhs.m_ptr; }
 
+  EZ_ALWAYS_INLINE const T& operator[](ptrdiff_t index) const
+  {
+    return *(m_ptr - index);
+  }
+
 protected:
   T* m_ptr;
 };
@@ -196,7 +224,10 @@ public:
   typedef T& reference;
 
   reverse_pointer_iterator() {}
-  reverse_pointer_iterator(T* ptr) : const_reverse_pointer_iterator<T>(ptr) {}
+  reverse_pointer_iterator(T* ptr)
+    : const_reverse_pointer_iterator<T>(ptr)
+  {
+  }
 
   EZ_ALWAYS_INLINE reverse_pointer_iterator& operator++()
   {
@@ -230,5 +261,10 @@ public:
   EZ_ALWAYS_INLINE T& operator*() { return *(this->m_ptr); }
   using const_reverse_pointer_iterator<T>::operator->;
   EZ_ALWAYS_INLINE T* operator->() { return this->m_ptr; }
-};
 
+  using const_reverse_pointer_iterator<T>::operator[];
+  EZ_ALWAYS_INLINE T& operator[](ptrdiff_t index)
+  {
+    return *(this->m_ptr - index);
+  }
+};

--- a/Code/UnitTests/FoundationTest/Basics/Types/ArrayPtrTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/ArrayPtrTest.cpp
@@ -298,6 +298,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, ArrayPtr)
     EZ_TEST_BOOL(*lb == ptr2[400]);
   }
 
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "STL Reverse Iterator")
   {
     ezDynamicArray<ezInt32> a1;
@@ -342,7 +343,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, ArrayPtr)
   //  }
   //  {
   //    ezHybridArray<int*, 4> data;
-  //    //TakeConstArrayPtr2(data, data); // does not compile 
+  //    //TakeConstArrayPtr2(data, data); // does not compile
   //    TakeConstArrayPtr2(data.GetArrayPtr(), data.GetArrayPtr());
   //  }
   //}

--- a/Code/UnitTests/FoundationTest/Containers/DequeTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DequeTest.cpp
@@ -17,7 +17,7 @@ namespace DequeTestDetail
 
     return a;
   }
-}
+} // namespace DequeTestDetail
 
 EZ_CREATE_SIMPLE_TEST(Containers, Deque)
 {

--- a/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
@@ -18,15 +18,15 @@ namespace DynamicArrayTestDetail
     std::string s;
 
     Dummy()
-        : a(0)
-        , b(g_iDummyCounter++)
-        , s("Test")
+      : a(0)
+      , b(g_iDummyCounter++)
+      , s("Test")
     {
     }
     Dummy(int a)
-        : a(a)
-        , b(g_iDummyCounter++)
-        , s("Test")
+      : a(a)
+      , b(g_iDummyCounter++)
+      , s("Test")
     {
     }
 
@@ -114,7 +114,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     {
       // move constructor
       ezDynamicArray<DynamicArrayTestDetail::st, DynamicArrayTestDetail::ezTestAllocatorWrapper> a1(
-          DynamicArrayTestDetail::CreateArray(100, 20));
+        DynamicArrayTestDetail::CreateArray(100, 20));
 
       EZ_TEST_INT(a1.GetCount(), 100);
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)

--- a/Code/UnitTests/FoundationTest/Containers/StaticArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/StaticArrayTest.cpp
@@ -11,18 +11,18 @@ namespace StaticArrayTestDetail
     std::string s;
 
     Dummy()
-        : a(0)
-        , s("Test")
+      : a(0)
+      , s("Test")
     {
     }
     Dummy(int a)
-        : a(a)
-        , s("Test")
+      : a(a)
+      , s("Test")
     {
     }
     Dummy(const Dummy& other)
-        : a(other.a)
-        , s(other.s)
+      : a(other.a)
+      , s(other.s)
     {
     }
     ~Dummy() {}
@@ -40,7 +40,7 @@ namespace StaticArrayTestDetail
     bool operator<(const Dummy& dummy) const { return a < dummy.a; }
     bool operator==(const Dummy& dummy) const { return a == dummy.a; }
   };
-}
+} // namespace StaticArrayTestDetail
 
 #if EZ_ENABLED(EZ_PLATFORM_64BIT)
 static_assert(sizeof(ezStaticArray<ezInt32, 1>) == 24);


### PR DESCRIPTION
This fixes compile errors when using Visual Studio 2019 version 16.5 or newer.