### PR TITLE
Fixed crashes in PhysX integration

### DIFF
--- a/Code/Engine/GameEngine/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/GameEngine/Interfaces/PhysicsWorldModule.h
@@ -56,12 +56,6 @@ struct ezPhysicsQueryParameters
   {
   }
 
-  ezPhysicsQueryParameters(ezUInt32 uiCollisionLayer, ezUInt32 uiIgnoreShapeId)
-    : m_uiCollisionLayer(uiCollisionLayer)
-    , m_uiIgnoreShapeId(uiIgnoreShapeId)
-  {
-  }
-
   ezUInt32 m_uiCollisionLayer = 0;
   ezBitflags<ezPhysicsShapeType> m_ShapeTypes = ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic;
   ezUInt32 m_uiIgnoreShapeId = ezInvalidIndex;

--- a/Code/EnginePlugins/PhysXPlugin/Components/BreakableSheet.h
+++ b/Code/EnginePlugins/PhysXPlugin/Components/BreakableSheet.h
@@ -160,10 +160,10 @@ protected:
   // PhysX Objects
   physx::PxRigidStatic* m_pUnbrokenActor = nullptr;
   ezUInt32 m_uiUnbrokenShapeId = ezInvalidIndex;
-  ezPxUserData m_UnbrokenUserData;
+  ezUInt32 m_uiUnbrokenUserDataIndex = ezInvalidIndex;
 
   ezDynamicArray<physx::PxRigidDynamic*> m_PieceActors;
   ezDynamicArray<ezUInt32> m_PieceShapeIds;
-  ezDynamicArray<ezPxUserData> m_PieceUserDatas;
+  ezDynamicArray<ezUInt32> m_PieceUserDataIndices;
   ezMap<ezUInt32, physx::PxRigidDynamic*> m_ShapeIDsToActors;
 };

--- a/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxCharacterControllerComponent.cpp
@@ -266,7 +266,8 @@ void ezPxCharacterControllerComponent::Update()
     t.m_vPosition = posAfter;
 
     ezPhysicsCastResult castResult;
-    if (pModule->SweepTestCapsule(castResult, pProxy->m_fCapsuleRadius, pProxy->GetCurrentCapsuleHeight(), t, ezVec3(0, 0, -1), pProxy->m_fMaxStepHeight, ezPhysicsQueryParameters(pProxy->m_uiCollisionLayer, pProxy->GetShapeId())))
+    if (pModule->SweepTestCapsule(castResult, pProxy->m_fCapsuleRadius, pProxy->GetCurrentCapsuleHeight(), t, ezVec3(0, 0, -1), pProxy->m_fMaxStepHeight,
+          ezPhysicsQueryParameters(pProxy->m_uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, pProxy->GetShapeId())))
     {
       RawMove(ezVec3(0, 0, -castResult.m_fDistance));
 

--- a/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxCharacterProxyComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxCharacterProxyComponent.cpp
@@ -341,7 +341,8 @@ ezBitflags<ezPxCharacterCollisionFlags> ezPxCharacterProxyComponent::Move(const 
 
         // make sure the character controller does not overlap with anything when standing up
         ezPhysXWorldModule* pModule = GetWorld()->GetOrCreateModule<ezPhysXWorldModule>();
-        if (!pModule->OverlapTestCapsule(m_fCapsuleRadius, m_fCapsuleHeight, t, ezPhysicsQueryParameters(m_uiCollisionLayer, GetShapeId())))
+        if (!pModule->OverlapTestCapsule(m_fCapsuleRadius, m_fCapsuleHeight, t,
+              ezPhysicsQueryParameters(m_uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, GetShapeId())))
         {
           m_bIsCrouching = false;
           m_pController->resize(m_fCapsuleHeight);

--- a/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxRaycastInteractComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxRaycastInteractComponent.cpp
@@ -80,7 +80,8 @@ void ezPxRaycastInteractComponent::ExecuteInteraction()
   }
 
   ezPhysicsCastResult res;
-  if (!pModule->Raycast(res, GetOwner()->GetGlobalPosition(), vDirection, m_fMaxDistance, ezPhysicsQueryParameters(m_uiCollisionLayer, uiIgnoreShapeID)))
+  if (!pModule->Raycast(res, GetOwner()->GetGlobalPosition(), vDirection, m_fMaxDistance,
+        ezPhysicsQueryParameters(m_uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, uiIgnoreShapeID)))
   {
     return;
   }

--- a/Code/EnginePlugins/PhysXPlugin/Components/PxCharacterProxyComponent.h
+++ b/Code/EnginePlugins/PhysXPlugin/Components/PxCharacterProxyComponent.h
@@ -81,11 +81,10 @@ protected:
   void OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg) const; // [ msg handler ]
 
   ezUInt32 m_uiShapeId = ezInvalidIndex;
+  ezUInt32 m_uiUserDataIndex = ezInvalidIndex;
   bool m_bIsCrouching = false;
 
   physx::PxCapsuleController* m_pController = nullptr;
 
   ezUniquePtr<ezPxCharacterProxyData> m_Data;
-
-  ezPxUserData m_UserData;
 };

--- a/Code/EnginePlugins/PhysXPlugin/Components/PxDynamicActorComponent.h
+++ b/Code/EnginePlugins/PhysXPlugin/Components/PxDynamicActorComponent.h
@@ -91,5 +91,5 @@ private:
   bool m_bKinematic = false;
   bool m_bCCD = false;
 
-  ezPxUserData m_UserData;
+  ezUInt32 m_uiUserDataIndex = ezInvalidIndex;
 };

--- a/Code/EnginePlugins/PhysXPlugin/Components/PxStaticActorComponent.h
+++ b/Code/EnginePlugins/PhysXPlugin/Components/PxStaticActorComponent.h
@@ -43,9 +43,8 @@ protected:
   void OnMsgExtractGeometry(ezMsgExtractGeometry& msg) const;
 
   ezUInt32 m_uiShapeId = ezInvalidIndex;
+  ezUInt32 m_uiUserDataIndex = ezInvalidIndex;
   ezPxMeshResourceHandle m_hCollisionMesh;
 
   physx::PxRigidStatic* m_pActor = nullptr;
-
-  ezPxUserData m_UserData;
 };

--- a/Code/EnginePlugins/PhysXPlugin/Components/PxTriggerComponent.h
+++ b/Code/EnginePlugins/PhysXPlugin/Components/PxTriggerComponent.h
@@ -66,5 +66,6 @@ protected:
 
   ezHashedString m_sTriggerMessage;
   ezEventMessageSender<ezMsgTriggerTriggered> m_TriggerEventSender; // [ event ]
-  ezPxUserData m_UserData;
+
+  ezUInt32 m_uiUserDataIndex = ezInvalidIndex;
 };

--- a/Code/EnginePlugins/PhysXPlugin/Shapes/PxShapeComponent.h
+++ b/Code/EnginePlugins/PhysXPlugin/Shapes/PxShapeComponent.h
@@ -45,10 +45,9 @@ protected:
   virtual physx::PxShape* CreateShape(physx::PxRigidActor* pActor, physx::PxTransform& out_ShapeTransform) = 0;
 
   ezUInt32 m_uiShapeId = ezInvalidIndex;
+  ezUInt32 m_uiUserDataIndex = ezInvalidIndex;
 
-  ezSurfaceResourceHandle m_hSurface;
-
-  ezPxUserData m_UserData;
+  ezSurfaceResourceHandle m_hSurface;  
 
   friend class ezPxActorComponent;
   void AddToActor(physx::PxRigidActor* pActor, const ezSimdTransform& parentTransform);

--- a/Code/EnginePlugins/PhysXPlugin/Utilities/PxUserData.h
+++ b/Code/EnginePlugins/PhysXPlugin/Utilities/PxUserData.h
@@ -14,68 +14,58 @@ class ezBreakableSheetComponent;
 class ezPxUserData
 {
 public:
+  EZ_DECLARE_POD_TYPE();
 
-  EZ_ALWAYS_INLINE ezPxUserData()
-    : m_Type(Invalid)
-    , m_pObject(nullptr)
-    , m_pAdditionalUserData(nullptr)
+  ezPxUserData() = default;
+  ~ezPxUserData() { Invalidate(); }
+
+  EZ_ALWAYS_INLINE void Init(ezPxDynamicActorComponent* pObject)
   {
+    m_Type = DynamicActorComponent;
+    m_pObject = pObject;
   }
 
-  EZ_ALWAYS_INLINE ezPxUserData(nullptr_t)
-    : m_Type(Invalid)
-    , m_pObject(nullptr)
-    , m_pAdditionalUserData(nullptr)
+  EZ_ALWAYS_INLINE void Init(ezPxStaticActorComponent* pObject)
   {
+    m_Type = StaticActorComponent;
+    m_pObject = pObject;
   }
 
-  EZ_ALWAYS_INLINE ezPxUserData(ezPxDynamicActorComponent* pObject)
-    : m_Type(DynamicActorComponent)
-    , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
+  EZ_ALWAYS_INLINE void Init(ezPxTriggerComponent* pObject)
   {
+    m_Type = TriggerComponent;
+    m_pObject = pObject;
   }
 
-  EZ_ALWAYS_INLINE ezPxUserData(ezPxStaticActorComponent* pObject)
-    : m_Type(StaticActorComponent)
-    , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
+  EZ_ALWAYS_INLINE void Init(ezPxCharacterProxyComponent* pObject)
   {
+    m_Type = CharacterProxyComponent;
+    m_pObject = pObject;
   }
 
-  EZ_ALWAYS_INLINE ezPxUserData(ezPxTriggerComponent* pObject)
-    : m_Type(TriggerComponent)
-    , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
+  EZ_ALWAYS_INLINE void Init(ezPxShapeComponent* pObject)
   {
+    m_Type = ShapeComponent;
+    m_pObject = pObject;
   }
 
-  EZ_ALWAYS_INLINE ezPxUserData(ezPxCharacterProxyComponent* pObject)
-    : m_Type(CharacterProxyComponent)
-    , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
+  EZ_ALWAYS_INLINE void Init(ezBreakableSheetComponent* pObject)
   {
-  }
-
-  EZ_ALWAYS_INLINE ezPxUserData(ezPxShapeComponent* pObject)
-    : m_Type(ShapeComponent)
-    , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
-  {
+    m_Type = BreakableSheetComponent;
+    m_pObject = pObject;
   }
 
   EZ_ALWAYS_INLINE ezPxUserData(ezSurfaceResource* pObject)
     : m_Type(SurfaceResource)
     , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
   {
   }
 
-  EZ_ALWAYS_INLINE ezPxUserData(ezBreakableSheetComponent* pObject)
-    : m_Type(BreakableSheet)
-    , m_pObject(pObject)
-    , m_pAdditionalUserData(nullptr)
+  EZ_FORCE_INLINE void Invalidate()
   {
+    m_Type = Invalid;
+    m_pObject = nullptr;
+    m_pAdditionalUserData = nullptr;
   }
 
   EZ_FORCE_INLINE static ezPxDynamicActorComponent* GetDynamicActorComponent(void* pUserData)
@@ -136,7 +126,7 @@ public:
   EZ_FORCE_INLINE static ezBreakableSheetComponent* GetBreakableSheetComponent(void* pUserData)
   {
     ezPxUserData* pPxUserData = static_cast<ezPxUserData*>(pUserData);
-    if (pPxUserData != nullptr && pPxUserData->m_Type == BreakableSheet)
+    if (pPxUserData != nullptr && pPxUserData->m_Type == BreakableSheetComponent)
     {
       return static_cast<ezBreakableSheetComponent*>(pPxUserData->m_pObject);
     }
@@ -149,13 +139,11 @@ public:
     ezPxUserData* pPxUserData = static_cast<ezPxUserData*>(pUserData);
     if (pPxUserData != nullptr &&
         (pPxUserData->m_Type == DynamicActorComponent ||
-         pPxUserData->m_Type == StaticActorComponent ||
-         pPxUserData->m_Type == TriggerComponent ||
-         pPxUserData->m_Type == CharacterProxyComponent ||
-         pPxUserData->m_Type == ShapeComponent ||
-         pPxUserData->m_Type == BreakableSheet
-        )
-      )
+          pPxUserData->m_Type == StaticActorComponent ||
+          pPxUserData->m_Type == TriggerComponent ||
+          pPxUserData->m_Type == CharacterProxyComponent ||
+          pPxUserData->m_Type == ShapeComponent ||
+          pPxUserData->m_Type == BreakableSheetComponent))
     {
       return static_cast<ezComponent*>(pPxUserData->m_pObject);
     }
@@ -195,11 +183,11 @@ private:
     TriggerComponent,
     CharacterProxyComponent,
     ShapeComponent,
-    SurfaceResource,
-    BreakableSheet
+    BreakableSheetComponent,
+    SurfaceResource
   };
 
-  Type m_Type;
-  void* m_pObject;
-  void* m_pAdditionalUserData;
+  Type m_Type = Invalid;
+  void* m_pObject = nullptr;
+  void* m_pAdditionalUserData = nullptr;
 };

--- a/Code/EnginePlugins/PhysXPlugin/WorldModule/Implementation/PhysXWorldModule.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/WorldModule/Implementation/PhysXWorldModule.cpp
@@ -190,16 +190,14 @@ namespace
     EZ_ASSERT_DEBUG(!out_Result.m_vPosition.IsNaN(), "Raycast hit Position is NaN");
     EZ_ASSERT_DEBUG(!out_Result.m_vNormal.IsNaN(), "Raycast hit Normal is NaN");
 
+    if (ezComponent* pShapeComponent = ezPxUserData::GetComponent(pHitShape->userData))
     {
-      ezComponent* pShapeComponent = ezPxUserData::GetComponent(pHitShape->userData);
-      EZ_ASSERT_DEBUG(pShapeComponent != nullptr, "Shape should have set a component as user data");
       out_Result.m_hShapeObject = pShapeComponent->GetOwner()->GetHandle();
       out_Result.m_uiShapeId = pHitShape->getQueryFilterData().word2;
     }
 
+    if (ezComponent* pActorComponent = ezPxUserData::GetComponent(pHitShape->getActor()->userData))
     {
-      ezComponent* pActorComponent = ezPxUserData::GetComponent(pHitShape->getActor()->userData);
-      EZ_ASSERT_DEBUG(pActorComponent != nullptr, "Actor should have set a component as user data");
       out_Result.m_hActorObject = pActorComponent->GetOwner()->GetHandle();
     }
 
@@ -538,8 +536,7 @@ public:
 
       if (pTriggerComponent != nullptr && pOtherComponent != nullptr)
       {
-        ezTriggerState::Enum triggerState =
-          pair.status == PxPairFlag::eNOTIFY_TOUCH_FOUND ? ezTriggerState::Activated : ezTriggerState::Deactivated;
+        ezTriggerState::Enum triggerState = (pair.status == PxPairFlag::eNOTIFY_TOUCH_FOUND) ? ezTriggerState::Activated : ezTriggerState::Deactivated;
         pTriggerComponent->PostTriggerMessage(pOtherComponent, triggerState);
       }
     }
@@ -1127,14 +1124,14 @@ void ezPhysXWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_Re
   out_Results.m_Results.SetCountUninitialized(allOverlaps.nbTouches);
   for (ezUInt32 i = 0; i < allOverlaps.nbTouches; ++i)
   {
+    if (ezComponent* pShapeComponent = ezPxUserData::GetComponent(g_OverlapHits[i].shape->userData))
     {
-      ezComponent* pShapeComponent = ezPxUserData::GetComponent(g_OverlapHits[i].shape->userData);
       out_Results.m_Results[i].m_hShapeObject = pShapeComponent->GetOwner()->GetHandle();
       out_Results.m_Results[i].m_uiShapeId = g_OverlapHits[i].shape->getQueryFilterData().word2;
     }
 
+    if (ezComponent* pActorComponent = ezPxUserData::GetComponent(g_OverlapHits[i].actor->userData))
     {
-      ezComponent* pActorComponent = ezPxUserData::GetComponent(g_OverlapHits[i].actor->userData);
       out_Results.m_Results[i].m_hActorObject = pActorComponent->GetOwner()->GetHandle();
     }
   }

--- a/Code/EnginePlugins/PhysXPlugin/WorldModule/PhysXWorldModule.h
+++ b/Code/EnginePlugins/PhysXPlugin/WorldModule/PhysXWorldModule.h
@@ -6,6 +6,7 @@
 #include <PhysXPlugin/PhysXInterface.h>
 
 class ezPxSimulationEventCallback;
+class ezPxUserData;
 
 class EZ_PHYSXPLUGIN_DLL ezPhysXWorldModule : public ezPhysicsWorldModuleInterface
 {
@@ -26,7 +27,10 @@ public:
   const physx::PxControllerManager* GetCharacterManager() const { return m_pCharacterManager; }
 
   ezUInt32 CreateShapeId();
-  void DeleteShapeId(ezUInt32 uiShapeId);
+  void DeleteShapeId(ezUInt32& uiShapeId);
+
+  ezUInt32 AllocateUserData(ezPxUserData*& out_pUserData);
+  void DeallocateUserData(ezUInt32& uiUserDataIndex);
 
   void SetGravity(const ezVec3& objectGravity, const ezVec3& characterGravity);
   virtual ezVec3 GetGravity() const override { return m_Settings.m_vObjectGravity; }
@@ -60,6 +64,8 @@ private:
   bool SweepTest(ezPhysicsCastResult& out_Result, const physx::PxGeometry& geometry, const physx::PxTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
   bool OverlapTest(const physx::PxGeometry& geometry, const physx::PxTransform& transform, const ezPhysicsQueryParameters& params) const;
 
+  void FreeUserDataAfterSimulationStep();
+
   void StartSimulation(const ezWorldModule::UpdateContext& context);
   void FetchResults(const ezWorldModule::UpdateContext& context);
 
@@ -73,6 +79,10 @@ private:
   ezUInt32 m_uiNextShapeId;
   ezDynamicArray<ezUInt32> m_FreeShapeIds;
 
+  ezDeque<ezPxUserData> m_AllocatedUserData;
+  ezDynamicArray<ezUInt32> m_FreeUserData;
+  ezDynamicArray<ezUInt32> m_FreeUserDataAfterSimulationStep;
+
   ezDynamicArray<ezUInt8, ezAlignedAllocatorWrapper> m_ScratchMemory;
 
   ezTime m_AccumulatedTimeSinceUpdate;
@@ -81,6 +91,7 @@ private:
 
   ezDelegateTask<void> m_SimulateTask;
   ezTaskGroupID m_SimulateTaskGroupId;
+  bool m_bSimulationStepExecuted = false;
 
   EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(PhysX, PhysXPlugin);
 };

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsPhysics.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsPhysics.cpp
@@ -105,7 +105,7 @@ static int __CPP_Physics_SweepTestSphere(duk_context* pDuk)
   const ezUInt32 uiIgnoreShapeID = duk.GetIntValue(5);
 
   ezPhysicsCastResult res;
-  if (!pModule->SweepTestSphere(res, fRadius, vStart, vDir, fDistance, ezPhysicsQueryParameters(uiCollisionLayer, uiIgnoreShapeID)))
+  if (!pModule->SweepTestSphere(res, fRadius, vStart, vDir, fDistance, ezPhysicsQueryParameters(uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, uiIgnoreShapeID)))
   {
     return duk.ReturnNull();
   }
@@ -130,7 +130,7 @@ static int __CPP_Physics_SweepTestBox(duk_context* pDuk)
   const ezUInt32 uiIgnoreShapeID = duk.GetIntValue(5);
 
   ezPhysicsCastResult res;
-  if (!pModule->SweepTestBox(res, vExtents, transform, vDir, fDistance, ezPhysicsQueryParameters(uiCollisionLayer, uiIgnoreShapeID)))
+  if (!pModule->SweepTestBox(res, vExtents, transform, vDir, fDistance, ezPhysicsQueryParameters(uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, uiIgnoreShapeID)))
   {
     return duk.ReturnNull();
   }
@@ -156,7 +156,7 @@ static int __CPP_Physics_SweepTestCapsule(duk_context* pDuk)
   const ezUInt32 uiIgnoreShapeID = duk.GetIntValue(6);
 
   ezPhysicsCastResult res;
-  if (!pModule->SweepTestCapsule(res, fCapsuleRadius, fCapsuleHeight, transform, vDir, fDistance, ezPhysicsQueryParameters(uiCollisionLayer, uiIgnoreShapeID)))
+  if (!pModule->SweepTestCapsule(res, fCapsuleRadius, fCapsuleHeight, transform, vDir, fDistance, ezPhysicsQueryParameters(uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, uiIgnoreShapeID)))
   {
     return duk.ReturnNull();
   }
@@ -178,7 +178,7 @@ static int __CPP_Physics_OverlapTestSphere(duk_context* pDuk)
   const ezUInt32 uiCollisionLayer = duk.GetUIntValue(2);
   const ezUInt32 uiIgnoreShapeID = duk.GetIntValue(3);
 
-  return duk.ReturnBool(pModule->OverlapTestSphere(fRadius, vPos, ezPhysicsQueryParameters(uiCollisionLayer, uiIgnoreShapeID)));
+  return duk.ReturnBool(pModule->OverlapTestSphere(fRadius, vPos, ezPhysicsQueryParameters(uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, uiIgnoreShapeID)));
 }
 
 static int __CPP_Physics_OverlapTestCapsule(duk_context* pDuk)
@@ -194,7 +194,7 @@ static int __CPP_Physics_OverlapTestCapsule(duk_context* pDuk)
   const ezUInt32 uiCollisionLayer = duk.GetUIntValue(3);
   const ezUInt32 uiIgnoreShapeID = duk.GetIntValue(4);
 
-  return duk.ReturnBool(pModule->OverlapTestCapsule(fCapsuleRadius, fCapsuleHeight, transform, ezPhysicsQueryParameters(uiCollisionLayer, uiIgnoreShapeID)));
+  return duk.ReturnBool(pModule->OverlapTestCapsule(fCapsuleRadius, fCapsuleHeight, transform, ezPhysicsQueryParameters(uiCollisionLayer, ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic, uiIgnoreShapeID)));
 }
 
 static int __CPP_Physics_GetGravity(duk_context* pDuk)


### PR DESCRIPTION
* Fixed crash when accessing deleted actors in fetchresults when no simulation step was executed due to high framerate
* Fixed crash in raycasts or other queries when a shape was hit whose component was just deleted and the owner was already invalid. 
* Also made sure that user data is valid until the next simulation step is done when a component was deleted.