### PR TITLE
Fileserve and UWP unit test fixes

### DIFF
--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
@@ -193,17 +193,20 @@ ezUInt32 ezRemoteInterface::ExecuteAllMessageHandlers()
 
 ezUInt32 ezRemoteInterface::ExecuteMessageHandlersForQueue(ezRemoteMessageQueue& queue)
 {
-  const ezUInt32 ret = queue.m_MessageQueue.GetCount();
+  queue.m_MessageQueueIn.Swap(queue.m_MessageQueueOut);
+  const ezUInt32 ret = queue.m_MessageQueueOut.GetCount();
+
 
   if (queue.m_MessageHandler.IsValid())
   {
-    for (auto& msg : queue.m_MessageQueue)
+    for (auto& msg : queue.m_MessageQueueOut)
     {
       queue.m_MessageHandler(msg);
     }
   }
 
-  queue.m_MessageQueue.Clear();
+  queue.m_MessageQueueOut.Clear();
+
   return ret;
 }
 
@@ -290,7 +293,7 @@ void ezRemoteInterface::ReportMessage(ezUInt32 uiApplicationID, ezUInt32 uiSyste
     return;
 
   // store the data for later
-  auto& msg = queue.m_MessageQueue.ExpandAndGetRef();
+  auto& msg = queue.m_MessageQueueIn.ExpandAndGetRef();
   msg.m_uiApplicationID = uiApplicationID;
   msg.SetMessageID(uiSystemID, uiMsgID);
   msg.GetWriter().WriteBytes(data.GetPtr(), data.GetCount());

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterfaceEnet.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterfaceEnet.cpp
@@ -185,6 +185,9 @@ void ezRemoteInterfaceEnetImpl::InternalUpdateRemoteInterface()
           enet_peer_disconnect(NetworkEvent.peer, 0);
           break;
         }
+        
+        // Uncomment this to allow stepping through enet code without loosing the connection.
+        //enet_peer_timeout(NetworkEvent.peer, 0xFFFFFF, 32000, 0xFFFFFF);
 
 
         if (GetRemoteMode() == ezRemoteMode::Client)

--- a/Code/Engine/Foundation/Communication/RemoteInterface.h
+++ b/Code/Engine/Foundation/Communication/RemoteInterface.h
@@ -47,7 +47,12 @@ typedef ezDelegate<void(ezRemoteMessage&)> ezRemoteMessageHandler;
 struct EZ_FOUNDATION_DLL ezRemoteMessageQueue
 {
   ezRemoteMessageHandler m_MessageHandler;
-  ezDeque<ezRemoteMessage> m_MessageQueue;
+  /// \brief Messages are pushed into this container on arrival.
+  ezDeque<ezRemoteMessage> m_MessageQueueIn;
+  /// \brief To flush the message queue, m_MessageQueueIn and m_MessageQueueOut are swapped.
+  /// Thus new messages can arrive while we execute the event handler for each element
+  /// in this container and then clear it.
+  ezDeque<ezRemoteMessage> m_MessageQueueOut;
 };
 
 class EZ_FOUNDATION_DLL ezRemoteInterface

--- a/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.h
+++ b/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.h
@@ -106,15 +106,15 @@ private:
   ezUInt16 MountDataDirectory(const char* szDataDir, const char* szRootName);
   void UnmountDataDirectory(ezUInt16 uiDataDir);
   static void ComputeDataDirMountPoint(const char* szDataDir, ezStringBuilder& out_sMountPoint);
-  void BuildPathInCache(const char* szFile, const char* szMountPoint, ezStringBuilder& out_sAbsPath,
-                        ezStringBuilder& out_sFullPathMeta) const;
+  void BuildPathInCache(const char* szFile, const char* szMountPoint, ezStringBuilder* out_pAbsPath,
+    ezStringBuilder* out_pFullPathMeta) const;
   void GetFullDataDirCachePath(const char* szDataDir, ezStringBuilder& out_sFullPath, ezStringBuilder& out_sFullPathMeta) const;
   void NetworkMsgHandler(ezRemoteMessage& msg);
   void HandleFileTransferMsg(ezRemoteMessage& msg);
   void HandleFileTransferFinishedMsg(ezRemoteMessage& msg);
   static void WriteMetaFile(ezStringBuilder sCachedMetaFile, ezInt64 iFileTimeStamp, ezUInt64 uiFileHash);
   void WriteDownloadToDisk(ezStringBuilder sCachedFile);
-  ezResult DownloadFile(ezUInt16 uiDataDirID, const char* szFile, bool bForceThisDataDir);
+  ezResult DownloadFile(ezUInt16 uiDataDirID, const char* szFile, bool bForceThisDataDir, ezStringBuilder* out_pFullPath);
   void DetermineCacheStatus(ezUInt16 uiDataDirID, const char* szFile, FileCacheStatus& out_Status) const;
   void UploadFile(ezUInt16 uiDataDirID, const char* szFile, const ezDynamicArray<ezUInt8>& fileContent);
   void InvalidateFileCache(ezUInt16 uiDataDirID, const char* szFile, ezUInt64 uiHash);

--- a/Code/EnginePlugins/FileservePlugin/Client/FileserveDataDir.h
+++ b/Code/EnginePlugins/FileservePlugin/Client/FileserveDataDir.h
@@ -11,11 +11,19 @@
 
 namespace ezDataDirectory
 {
+  class FileserveDataDirectoryReader : public FolderReader
+  {
+  public:
+    FileserveDataDirectoryReader(ezInt32 iDataDirUserData);
+
+  protected:
+    virtual ezResult InternalOpen(ezFileShareMode::Enum FileShareMode) override;
+  };
+
   class FileserveDataDirectoryWriter : public FolderWriter
   {
   protected:
     virtual void InternalClose() override;
-
   };
 
   /// \brief A data directory type to handle access to files that are served from a network host.
@@ -40,6 +48,7 @@ namespace ezDataDirectory
     virtual bool ExistsFile(const char* szFile, bool bOneSpecificDataDir) override;
     /// \brief Limitation: Fileserve does not handle folders, only files. If someone stats a folder, this will fail.
     virtual ezResult GetFileStats(const char* szFileOrFolder, bool bOneSpecificDataDir, ezFileStats& out_Stats) override;
+    virtual FolderReader* CreateFolderReader() const override;
     virtual FolderWriter* CreateFolderWriter() const override;
 
     ezUInt16 m_uiDataDirID = 0xffff;


### PR DESCRIPTION
-Fixed an issue where messages got lost in ezRemoteInterface if ExecuteMessageHandlersForQueue triggered a call to ReportMessage in one of the message handlers. To fix this there are now two queues. One for receiving messages and one for executing message handlers.
-If a data dir can resolve a guid the resulting file should only be loaded from the same data dir. Thus, all functions in ezDataDirectory::FileserveType will lock to the current data dir if they can resolve the guid.
-ezDataDirectory::FileserveType functions will now go directly to ezOSFile after successfully downloading a file.
-ezFileserveClient::BuildPathInCache now uses ptrs to the out strings to allow only selectively building them.
-UWP test harness will now determine the test result by waiting for the final test results log messages and parsing them.