### PR TITLE
Asset Curator Fixes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetWatcher.h
+++ b/Code/Editor/EditorFramework/Assets/AssetWatcher.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <Foundation/Threading/TaskSystem.h>
+#include <Foundation/Threading/AtomicInteger.h>
+#include <Foundation/Configuration/Singleton.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Logging/LogEntry.h>
+#include <EditorFramework/IPC/EditorProcessCommunicationChannel.h>
+#include <Foundation/Application/Config/FileSystemConfig.h>
+
+struct ezAssetCuratorEvent;
+class ezTask;
+struct ezAssetInfo;
+
+/// \brief Creates a file system watcher for the given filesystem config and informs the ezAssetCurator
+/// of any changes.
+class EZ_EDITORFRAMEWORK_DLL ezAssetWatcher
+{
+public:
+  ezAssetWatcher(const ezApplicationFileSystemConfig& fileSystemConfig);
+  ~ezAssetWatcher();
+
+  /// \brief Needs to be called every frame. Handles update delays to allow compacting multiple changes.
+  void MainThreadTick();
+
+private:
+  friend class ezDirectoryUpdateTask;
+  friend class ezAssetCurator;
+  struct WatcherResult
+  {
+    ezString sFile;
+    ezDirectoryWatcherAction action;
+  };
+
+  static constexpr ezUInt32 s_FrameDelay = 5;
+  struct PendingUpdate
+  {
+    ezString sAbsPath;
+    ezUInt32 m_uiFrameDelay = s_FrameDelay;
+  };
+
+
+  void HandleWatcherChange(const WatcherResult& res);
+  void UpdateFile(const char* szAbsPath);
+  void UpdateDirectory(const char* szAbsPath);
+
+private:
+  mutable ezMutex m_WatcherMutex;
+  ezHybridArray<ezDirectoryWatcher*, 6> m_Watchers;
+  ezTask* m_WatcherTask = nullptr;
+  ezTaskGroupID m_WatcherGroup;
+
+  ezHybridArray<ezTaskGroupID, 4> m_DirectoryUpdates;
+  ezHybridArray<PendingUpdate, 4> m_UpdateFile;
+  ezHybridArray<PendingUpdate, 4> m_UpdateDirectory;
+
+  ezApplicationFileSystemConfig m_FileSystemConfig;
+};
+
+/// \brief Task to scan a directory and inform the ezAssetCurator of any changes.
+class ezDirectoryUpdateTask final : public ezTask
+{
+public:
+  ezDirectoryUpdateTask(ezAssetWatcher* pWatcher, const char* szFolder);
+  ~ezDirectoryUpdateTask();
+
+  ezAssetWatcher* m_pWatcher = nullptr;
+  ezString m_sFolder;
+
+private:
+  virtual void Execute() override;
+};

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -19,7 +19,7 @@ ezQtAssetFilter::ezQtAssetFilter(QObject* pParent)
 
 struct AssetComparer
 {
-  AssetComparer(ezQtAssetBrowserModel* model, const ezMap<ezUuid, ezSubAsset>& allAssets)
+  AssetComparer(ezQtAssetBrowserModel* model, const ezHashTable<ezUuid, ezSubAsset>& allAssets)
     : m_Model(model)
     , m_AllAssets(allAssets)
   {
@@ -39,7 +39,7 @@ struct AssetComparer
   }
 
   ezQtAssetBrowserModel* m_Model;
-  const ezMap<ezUuid, ezSubAsset>& m_AllAssets;
+  const ezHashTable<ezUuid, ezSubAsset>& m_AllAssets;
 };
 
 ezQtAssetBrowserModel::ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* pFilter)
@@ -107,7 +107,7 @@ void ezQtAssetBrowserModel::resetModel()
   beginResetModel();
 
   ezAssetCurator::ezLockedSubAssetTable AllAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
-  const ezMap<ezUuid, ezSubAsset>& AllAssets = *(AllAssetsLocked.operator->());
+  const ezHashTable<ezUuid, ezSubAsset>& AllAssets = *(AllAssetsLocked.operator->());
 
   m_AssetsToDisplay.Clear();
   m_AssetsToDisplay.Reserve(AllAssets.GetCount());
@@ -150,7 +150,7 @@ void ezQtAssetBrowserModel::HandleAsset(const ezSubAsset* pInfo, AssetOp op)
   }
 
   ezAssetCurator::ezLockedSubAssetTable AllAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
-  const ezMap<ezUuid, ezSubAsset>& AllAssets = *(AllAssetsLocked.operator->());
+  const ezHashTable<ezUuid, ezSubAsset>& AllAssets = *(AllAssetsLocked.operator->());
 
   AssetEntry ae;
   Init(ae, pInfo);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetWatcher.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetWatcher.cpp
@@ -1,0 +1,301 @@
+#include <EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocumentManager.h>
+#include <EditorFramework/Assets/AssetWatcher.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <Foundation/IO/OSFile.h>
+
+////////////////////////////////////////////////////////////////////////
+// ezAssetWatcher
+////////////////////////////////////////////////////////////////////////
+
+ezAssetWatcher::ezAssetWatcher(const ezApplicationFileSystemConfig& fileSystemConfig)
+{
+  EZ_PROFILE_SCOPE("ezAssetWatcher");
+  m_FileSystemConfig = fileSystemConfig;
+  for (auto& dd : m_FileSystemConfig.m_DataDirs)
+  {
+    ezStringBuilder sTemp;
+    if (ezFileSystem::ResolveSpecialDirectory(dd.m_sDataDirSpecialPath, sTemp).Failed())
+    {
+      ezLog::Error("Failed to init directory watcher for dir '{0}'", dd.m_sDataDirSpecialPath);
+      continue;
+    }
+
+    ezDirectoryWatcher* pWatcher = EZ_DEFAULT_NEW(ezDirectoryWatcher);
+    ezResult res = pWatcher->OpenDirectory(sTemp, ezDirectoryWatcher::Watch::Reads | ezDirectoryWatcher::Watch::Writes |
+      ezDirectoryWatcher::Watch::Creates | ezDirectoryWatcher::Watch::Renames |
+      ezDirectoryWatcher::Watch::Subdirectories);
+
+    if (res.Failed())
+    {
+      EZ_DEFAULT_DELETE(pWatcher);
+      ezLog::Error("Failed to init directory watcher for dir '{0}'", sTemp);
+      continue;
+    }
+
+    m_Watchers.PushBack(pWatcher);
+  }
+  m_WatcherTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "Watcher Update", [this]() {
+    ezHybridArray<WatcherResult, 16> watcherResults;
+    for (ezDirectoryWatcher* pWatcher : m_Watchers)
+    {
+      pWatcher->EnumerateChanges([pWatcher, &watcherResults](const char* szFilename, ezDirectoryWatcherAction action) {
+        ezStringBuilder sTemp = pWatcher->GetDirectory();
+        sTemp.AppendPath(szFilename);
+        sTemp.MakeCleanPath();
+
+        /*if (sTemp.FindSubString("AssetCache/Thumbnails/") != nullptr)
+        {
+          return;
+        }*/
+
+        if (action == ezDirectoryWatcherAction::Modified)
+        {
+          if (ezOSFile::ExistsDirectory(sTemp))
+            return;
+        }
+
+        watcherResults.PushBack({ sTemp, action });
+        });
+    }
+    for (const WatcherResult& res : watcherResults)
+    {
+      HandleWatcherChange(res);
+    }
+    });
+}
+
+
+ezAssetWatcher::~ezAssetWatcher()
+{
+  {
+    EZ_LOCK(m_WatcherMutex);
+
+    ezTaskSystem::WaitForGroup(m_WatcherGroup);
+    EZ_DEFAULT_DELETE(m_WatcherTask);
+
+    for (ezDirectoryWatcher* pWatcher : m_Watchers)
+    {
+      EZ_DEFAULT_DELETE(pWatcher);
+    }
+    m_Watchers.Clear();
+  }
+
+  do 
+  {
+    ezTaskGroupID id;
+    {
+      EZ_LOCK(m_WatcherMutex);
+      if (m_DirectoryUpdates.IsEmpty())
+        break;
+      id = m_DirectoryUpdates.PeekBack();
+    }
+    ezTaskSystem::WaitForGroup(id);
+  } while (true);
+
+  EZ_LOCK(m_WatcherMutex);
+  EZ_ASSERT_DEV(m_DirectoryUpdates.IsEmpty(), "All directory updates should have finished.");
+}
+
+void ezAssetWatcher::MainThreadTick()
+{
+  EZ_PROFILE_SCOPE("ezAssetWatcherTick");
+  EZ_LOCK(m_WatcherMutex);
+  if (m_WatcherTask && ezTaskSystem::IsTaskGroupFinished(m_WatcherGroup))
+  {
+    m_WatcherGroup = ezTaskSystem::StartSingleTask(m_WatcherTask, ezTaskPriority::LongRunningHighPriority);
+  }
+
+  // Files
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+
+  for (ezUInt32 i = m_UpdateFile.GetCount(); i > 0; --i)
+  {
+    PendingUpdate& update = m_UpdateFile[i - 1];
+    --update.m_uiFrameDelay;
+    if (update.m_uiFrameDelay == 0)
+    {
+      pCurator->NotifyOfFileChange(update.sAbsPath);
+      m_UpdateFile.RemoveAtAndSwap(i - 1);
+    }
+  }
+  
+  // Directories
+  for (ezUInt32 i = m_UpdateDirectory.GetCount(); i > 0; --i)
+  {
+    PendingUpdate& update = m_UpdateDirectory[i - 1];
+    --update.m_uiFrameDelay;
+    if (update.m_uiFrameDelay == 0)
+    {
+      ezDirectoryUpdateTask* pTask = EZ_DEFAULT_NEW(ezDirectoryUpdateTask, this, update.sAbsPath);
+      ezTaskGroupID id = ezTaskSystem::StartSingleTask(pTask, ezTaskPriority::LongRunningHighPriority, [this](ezTaskGroupID id)
+        {
+          EZ_LOCK(m_WatcherMutex);
+          m_DirectoryUpdates.RemoveAndSwap(id);
+        });
+      m_DirectoryUpdates.PushBack(id);
+
+      m_UpdateDirectory.RemoveAtAndSwap(i - 1);
+    }
+  }
+}
+
+void ezAssetWatcher::HandleWatcherChange(const WatcherResult& res)
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+  ezFileStats stat;
+  ezResult stats = ezOSFile::GetFileStats(res.sFile, stat);
+  bool isFileKnown = false;
+  {
+    EZ_LOCK(pCurator->m_CuratorMutex);
+    isFileKnown = pCurator->m_ReferencedFiles.Find(res.sFile).IsValid();
+  }
+
+  switch (res.action)
+  {
+    case ezDirectoryWatcherAction::Added:
+    {
+      if (stats == EZ_SUCCESS)
+      {
+        if (stat.m_bIsDirectory)
+        {
+          UpdateDirectory(res.sFile);
+        }
+        else
+        {
+          UpdateFile(res.sFile);
+        }
+      }
+    }
+    break;
+    case ezDirectoryWatcherAction::Removed:
+    {
+      if (isFileKnown)
+      {
+        UpdateFile(res.sFile);
+      }
+      else
+      {
+        UpdateDirectory(res.sFile);
+      }
+    }
+    break;
+    case ezDirectoryWatcherAction::Modified:
+      if (stats == EZ_SUCCESS)
+      {
+        if (stat.m_bIsDirectory)
+        {
+          // TODO: Can directories be modified?
+        }
+        else
+        {
+          UpdateFile(res.sFile);
+        }
+      }
+      break;
+    case ezDirectoryWatcherAction::RenamedOldName:
+      // Ignore, we scan entire parent dir in the following RenamedNewName event.
+      break;
+    case ezDirectoryWatcherAction::RenamedNewName:
+    {
+      // Rescan parent directory.
+      // TODO: Renames on root will rescan the entire data dir.
+      // However, fixing this would require dynamic recursion if we detect that
+      // a folder was actually renamed.
+      ezStringBuilder sParentFolder = res.sFile;
+      sParentFolder.PathParentDirectory();
+      UpdateDirectory(sParentFolder);
+    }
+    break;
+  }
+}
+
+void ezAssetWatcher::UpdateFile(const char* szAbsPath)
+{
+  EZ_LOCK(m_WatcherMutex);
+  for (PendingUpdate& update : m_UpdateFile)
+  {
+    if (update.sAbsPath == szAbsPath)
+    {
+      update.m_uiFrameDelay = s_FrameDelay;
+      return;
+    }
+  }
+  PendingUpdate& update = m_UpdateFile.ExpandAndGetRef();
+  update.m_uiFrameDelay = s_FrameDelay;
+  update.sAbsPath = szAbsPath;
+}
+
+void ezAssetWatcher::UpdateDirectory(const char* szAbsPath)
+{
+  ezStringBuilder sAbsPath = szAbsPath;
+  EZ_LOCK(m_WatcherMutex);
+  for (PendingUpdate& update : m_UpdateDirectory)
+  {
+    // No need to add this directory if itself or a parent directory is already queued.
+    if (sAbsPath.IsPathBelowFolder(update.sAbsPath))
+    {
+      // Reset delay as we are probably doing a bigger operation right now.
+      update.m_uiFrameDelay = s_FrameDelay;
+      return;
+    }
+  }
+  PendingUpdate& update = m_UpdateDirectory.ExpandAndGetRef();
+  update.m_uiFrameDelay = s_FrameDelay;
+  update.sAbsPath = sAbsPath;
+}
+
+////////////////////////////////////////////////////////////////////////
+// ezDirectoryUpdateTask
+////////////////////////////////////////////////////////////////////////
+
+ezDirectoryUpdateTask::ezDirectoryUpdateTask(ezAssetWatcher* pWatcher, const char* szFolder)
+  : m_pWatcher(pWatcher)
+  , m_sFolder(szFolder)
+{
+  ConfigureTask("ezDirectoryUpdateTask", ezTaskNesting::Never, [this](ezTask* pTask)
+    {
+      EZ_DEFAULT_DELETE(pTask);
+    });
+}
+
+ezDirectoryUpdateTask::~ezDirectoryUpdateTask()
+{
+}
+
+void ezDirectoryUpdateTask::Execute()
+{
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+  ezSet<ezString> previouslyKnownFiles;
+  {
+    CURATOR_PROFILE("FindReferencedFiles");
+    // Find all currently known files that are under the given folder.
+    //TODO: is m_InverseDependency / m_InverseReferences covered by this?
+    //TODO: What about asset output files?
+    EZ_LOCK(pCurator->m_CuratorMutex);
+    auto itlowerBound = pCurator->m_ReferencedFiles.LowerBound(m_sFolder);
+    while (itlowerBound.IsValid() && itlowerBound.Key().StartsWith_NoCase(m_sFolder))
+    {
+      previouslyKnownFiles.Insert(itlowerBound.Key());
+      ++itlowerBound;
+    }
+  }
+
+  {
+    CURATOR_PROFILE("IterateDataDirectory");
+    // Iterate folder to find all actually existing files on disk.
+    ezSet<ezString> knownFiles;
+    pCurator->IterateDataDirectory(m_sFolder, &knownFiles);
+
+    // Not encountered files are now removed which the ezAssetCurator must be informed about.
+    previouslyKnownFiles.Difference(knownFiles);
+  }
+
+  CURATOR_PROFILE("HandleRemovedFiles");
+  for (const ezString& sFile : previouslyKnownFiles)
+  {
+    pCurator->HandleSingleFile(sFile);
+  }
+}

--- a/Code/Editor/EditorProcessor/Main.cpp
+++ b/Code/Editor/EditorProcessor/Main.cpp
@@ -78,7 +78,8 @@ public:
           // Check if asset matches the state of the editor
           if ((state != ezAssetInfo::NeedsThumbnail && state != ezAssetInfo::NeedsTransform) || uiAssetHash != pMsg->m_AssetHash || uiThumbHash != pMsg->m_ThumbHash)
           {
-            // Force update the state.
+            // Force update the state. If the asset was created automatically the file might not be known yet.
+            ezAssetCurator::GetSingleton()->NotifyOfFileChange(pMsg->m_sAssetPath);
             state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(pMsg->m_AssetGuid,
               ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, true);
           }

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -228,7 +228,7 @@ ezResult ezTypeScriptAssetDocumentManager::GenerateScriptCompendium(ezBitflags<e
 
   // keep this locked until the end of the function
   ezAssetCurator::ezLockedSubAssetTable AllAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
-  const ezMap<ezUuid, ezSubAsset>& AllAssets = *AllAssetsLocked;
+  const ezHashTable<ezUuid, ezSubAsset>& AllAssets = *AllAssetsLocked;
 
   for (auto it = AllAssets.GetIterator(); it.IsValid(); ++it)
   {

--- a/Code/Engine/Foundation/Containers/HashSet.h
+++ b/Code/Engine/Foundation/Containers/HashSet.h
@@ -108,8 +108,23 @@ public:
   /// \brief Removes the entry with the given key. Returns if an entry was removed.
   bool Remove(const KeyType& key); // [tested]
 
+  /// \brief Erases the key at the given Iterator. Returns an iterator to the element after the given iterator.
+  ConstIterator Remove(const ConstIterator& pos); // [tested]
+
   /// \brief Returns if an entry with given key exists in the table.
   bool Contains(const KeyType& key) const; // [tested]
+
+  /// \brief Checks whether all keys of the given set are in the container.
+  bool ContainsSet(const ezHashSetBase<KeyType, Hasher>& operand) const; // [tested]
+
+  /// \brief Makes this set the union of itself and the operand.
+  void Union(const ezHashSetBase<KeyType, Hasher>& operand); // [tested]
+
+  /// \brief Makes this set the difference of itself and the operand, i.e. subtracts operand.
+  void Difference(const ezHashSetBase<KeyType, Hasher>& operand); // [tested]
+
+  /// \brief Makes this set the intersection of itself and the operand.
+  void Intersection(const ezHashSetBase<KeyType, Hasher>& operand); // [tested]
 
   /// \brief Returns a constant Iterator to the very first element.
   ConstIterator GetIterator() const; // [tested]
@@ -146,6 +161,7 @@ private:
   };
 
   void SetCapacity(ezUInt32 uiCapacity);
+  void RemoveInternal(ezUInt32 uiIndex);
   ezUInt32 FindEntry(const KeyType& key) const;
   ezUInt32 FindEntry(ezUInt32 uiHash, const KeyType& key) const;
 

--- a/Code/Engine/Foundation/Containers/Set.h
+++ b/Code/Engine/Foundation/Containers/Set.h
@@ -132,7 +132,7 @@ public:
   template <typename CompatibleKeyType>
   bool Contains(const CompatibleKeyType& key) const; // [tested]
 
-  /// \brief Checks whether the given key is in the container.
+  /// \brief Checks whether all keys of the given set are in the container.
   bool ContainsSet(const ezSetBase<KeyType, Comparer>& operand) const; // [tested]
 
   /// \brief Returns an Iterator to the element with a key equal or larger than the given key. Returns an invalid iterator, if there is no such element.
@@ -144,13 +144,13 @@ public:
   Iterator UpperBound(const CompatibleKeyType& key) const; // [tested]
 
   /// \brief Makes this set the union of itself and the operand.
-  void Union(const ezSetBase<KeyType, Comparer>& operand);
+  void Union(const ezSetBase<KeyType, Comparer>& operand); // [tested]
 
   /// \brief Makes this set the difference of itself and the operand, i.e. subtracts operand.
-  void Difference(const ezSetBase<KeyType, Comparer>& operand);
+  void Difference(const ezSetBase<KeyType, Comparer>& operand); // [tested]
 
   /// \brief Makes this set the intersection of itself and the operand.
-  void Intersection(const ezSetBase<KeyType, Comparer>& operand);
+  void Intersection(const ezSetBase<KeyType, Comparer>& operand); // [tested]
 
   /// \brief Returns the allocator that is used by this instance.
   ezAllocatorBase* GetAllocator() const { return m_Elements.GetAllocator(); }

--- a/Code/Engine/Foundation/Threading/Implementation/TaskSystemDeclarations.h
+++ b/Code/Engine/Foundation/Threading/Implementation/TaskSystemDeclarations.h
@@ -109,6 +109,14 @@ public:
   /// \brief Resets the GroupID into an invalid state.
   EZ_ALWAYS_INLINE void Invalidate() { m_pTaskGroup = nullptr; }
 
+  EZ_ALWAYS_INLINE bool operator==(const ezTaskGroupID& other) const { return m_pTaskGroup == other.m_pTaskGroup && m_uiGroupCounter == other.m_uiGroupCounter; }
+  EZ_ALWAYS_INLINE bool operator!=(const ezTaskGroupID& other) const { return m_pTaskGroup != other.m_pTaskGroup || m_uiGroupCounter != other.m_uiGroupCounter; }
+  EZ_ALWAYS_INLINE bool operator<(const ezTaskGroupID& other) const
+  {
+    return m_pTaskGroup < other.m_pTaskGroup ||
+      (m_pTaskGroup == other.m_pTaskGroup && m_uiGroupCounter < other.m_uiGroupCounter);
+  }
+
 private:
   friend class ezTaskSystem;
   friend class ezTaskGroup;
@@ -122,7 +130,7 @@ private:
 };
 
 /// \brief Callback type when a task group has been finished (or canceled).
-using ezOnTaskGroupFinishedCallback = ezDelegate<void()>;
+using ezOnTaskGroupFinishedCallback = ezDelegate<void(ezTaskGroupID)>;
 
 /// \brief Callback type when a task has been finished (or canceled).
 using ezOnTaskFinishedCallback = ezDelegate<void(ezTask*)>;

--- a/Code/Engine/Foundation/Threading/TaskSystem.h
+++ b/Code/Engine/Foundation/Threading/TaskSystem.h
@@ -29,11 +29,13 @@ public:
 public:
   /// \brief A helper function to insert a single task into the system and start it right away. Returns ID of the Group into which the task
   /// has been put.
-  static ezTaskGroupID StartSingleTask(ezTask* pTask, ezTaskPriority::Enum Priority); // [tested]
+  /// Once the task and thus the group is finished, an optional \a Callback can be executed.
+  static ezTaskGroupID StartSingleTask(ezTask* pTask, ezTaskPriority::Enum Priority, ezOnTaskGroupFinishedCallback callback = ezOnTaskGroupFinishedCallback()); // [tested]
 
   /// \brief A helper function to insert a single task into the system and start it right away. Returns ID of the Group into which the task
   /// has been put. This overload allows to additionally specify a single dependency.
-  static ezTaskGroupID StartSingleTask(ezTask* pTask, ezTaskPriority::Enum Priority, ezTaskGroupID Dependency); // [tested]
+  /// Once the task and thus the group is finished, an optional \a Callback can be executed.
+  static ezTaskGroupID StartSingleTask(ezTask* pTask, ezTaskPriority::Enum Priority, ezTaskGroupID Dependency, ezOnTaskGroupFinishedCallback callback = ezOnTaskGroupFinishedCallback()); // [tested]
 
   /// \brief Call this function once at the end of a frame. It will ensure that all tasks for 'this frame' get finished properly.
   ///

--- a/Code/UnitTests/FoundationTest/Containers/HashSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HashSetTest.cpp
@@ -303,6 +303,129 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashSet)
     EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Remove (Iterator)")
+  {
+    ezHashSet<ezInt32> a;
+
+    EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
+    for (ezInt32 i = 0; i < 1000; ++i)
+      a.Insert(i);
+
+    ezHashSet<ezInt32>::ConstIterator it = a.GetIterator();
+
+    for (ezInt32 i = 0; i < 1000 - 1; ++i)
+    {
+      ezInt32 value = it.Key();
+      it = a.Remove(it);
+      EZ_TEST_BOOL(!a.Contains(value));
+      EZ_TEST_BOOL(it.IsValid());
+      EZ_TEST_INT(a.GetCount(), 1000 - 1 - i);
+    }
+    it = a.Remove(it);
+    EZ_TEST_BOOL(!it.IsValid());
+    EZ_TEST_BOOL(a.IsEmpty());
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Set Operations")
+  {
+    ezHashSet<ezUInt32> base;
+    base.Insert(1);
+    base.Insert(3);
+    base.Insert(5);
+
+    ezHashSet<ezUInt32> empty;
+
+    ezHashSet<ezUInt32> disjunct;
+    disjunct.Insert(2);
+    disjunct.Insert(4);
+    disjunct.Insert(6);
+
+    ezHashSet<ezUInt32> subSet;
+    subSet.Insert(1);
+    subSet.Insert(5);
+
+    ezHashSet<ezUInt32> superSet;
+    superSet.Insert(1);
+    superSet.Insert(3);
+    superSet.Insert(5);
+    superSet.Insert(7);
+
+    ezHashSet<ezUInt32> nonDisjunctNonEmptySubSet;
+    nonDisjunctNonEmptySubSet.Insert(1);
+    nonDisjunctNonEmptySubSet.Insert(4);
+    nonDisjunctNonEmptySubSet.Insert(5);
+
+    // ContainsSet
+    EZ_TEST_BOOL(base.ContainsSet(base));
+
+    EZ_TEST_BOOL(base.ContainsSet(empty));
+    EZ_TEST_BOOL(!empty.ContainsSet(base));
+
+    EZ_TEST_BOOL(!base.ContainsSet(disjunct));
+    EZ_TEST_BOOL(!disjunct.ContainsSet(base));
+
+    EZ_TEST_BOOL(base.ContainsSet(subSet));
+    EZ_TEST_BOOL(!subSet.ContainsSet(base));
+
+    EZ_TEST_BOOL(!base.ContainsSet(superSet));
+    EZ_TEST_BOOL(superSet.ContainsSet(base));
+
+    EZ_TEST_BOOL(!base.ContainsSet(nonDisjunctNonEmptySubSet));
+    EZ_TEST_BOOL(!nonDisjunctNonEmptySubSet.ContainsSet(base));
+
+    // Union
+    {
+      ezHashSet<ezUInt32> res;
+
+      res.Union(base);
+      EZ_TEST_BOOL(res.ContainsSet(base));
+      EZ_TEST_BOOL(base.ContainsSet(res));
+      res.Union(subSet);
+      EZ_TEST_BOOL(res.ContainsSet(base));
+      EZ_TEST_BOOL(res.ContainsSet(subSet));
+      EZ_TEST_BOOL(base.ContainsSet(res));
+      res.Union(superSet);
+      EZ_TEST_BOOL(res.ContainsSet(base));
+      EZ_TEST_BOOL(res.ContainsSet(subSet));
+      EZ_TEST_BOOL(res.ContainsSet(superSet));
+      EZ_TEST_BOOL(superSet.ContainsSet(res));
+    }
+
+    // Difference
+    {
+      ezHashSet<ezUInt32> res;
+      res.Union(base);
+      res.Difference(empty);
+      EZ_TEST_BOOL(res.ContainsSet(base));
+      EZ_TEST_BOOL(base.ContainsSet(res));
+      res.Difference(disjunct);
+      EZ_TEST_BOOL(res.ContainsSet(base));
+      EZ_TEST_BOOL(base.ContainsSet(res));
+      res.Difference(subSet);
+      EZ_TEST_INT(res.GetCount(), 1);
+      EZ_TEST_BOOL(res.Contains(3));
+    }
+
+    // Intersection
+    {
+      ezHashSet<ezUInt32> res;
+      res.Union(base);
+      res.Intersection(disjunct);
+      EZ_TEST_BOOL(res.IsEmpty());
+      res.Union(base);
+      res.Intersection(subSet);
+      EZ_TEST_BOOL(base.ContainsSet(subSet));
+      EZ_TEST_BOOL(res.ContainsSet(subSet));
+      EZ_TEST_BOOL(subSet.ContainsSet(res));
+      res.Intersection(superSet);
+      EZ_TEST_BOOL(superSet.ContainsSet(res));
+      EZ_TEST_BOOL(res.ContainsSet(subSet));
+      EZ_TEST_BOOL(subSet.ContainsSet(res));
+      res.Intersection(empty);
+      EZ_TEST_BOOL(res.IsEmpty());
+    }
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator==/!=")
   {
     ezStaticArray<ezInt32, 64> keys[2];


### PR DESCRIPTION
Add set operations to ezHashSet
* Allow iterating ezHashSet while removing elements using iterators-based Remove function.

Add ezTaskGroupID parameter in ezOnTaskGroupFinishedCallback
* Made ezTaskGroupID compare and sortable.
* Expose ezOnTaskGroupFinishedCallback in StartSingleTask

Moved asset watcher to its own class
* Removed auto rescan filesystem logic. Everything is done in the background and only for specific folders.
  * Fixes all known updated issues when changing files externally via CC tools.
* Optimized various functions in the ezAssetCurator.
  * FindSubAsset no longer iterates over all assets unless bExhaustiveSearch is set.
  * m_ReferencedFiles is now a ezMap to allows finding all files in a folder efficiently
  * ezUuid keyed containers are now ezHashMap/ezHashSet



