### PR TITLE
Adds a rational type

### DIFF
--- a/Code/Engine/Foundation/Math/Implementation/Rational_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Rational_inl.h
@@ -1,10 +1,10 @@
 
-ezRational::ezRational(ezUInt32 uiNumerator, ezUInt32 uiDenominator)
+EZ_ALWAYS_INLINE ezRational::ezRational(ezUInt32 uiNumerator, ezUInt32 uiDenominator)
   : m_uiNumerator(uiNumerator)
   , m_uiDenominator(uiDenominator)
 {}
 
-bool ezRational::IsIntegral() const
+EZ_ALWAYS_INLINE bool ezRational::IsIntegral() const
 {
   if (m_uiNumerator == 0 && m_uiDenominator == 0)
     return true;
@@ -12,28 +12,27 @@ bool ezRational::IsIntegral() const
   return ((m_uiNumerator / m_uiDenominator) * m_uiDenominator) == m_uiNumerator;
 }
 
-bool ezRational::operator==(const ezRational& other) const
+EZ_ALWAYS_INLINE bool ezRational::operator==(const ezRational& other) const
 {
   return m_uiNumerator == other.m_uiNumerator && m_uiDenominator == other.m_uiDenominator;
 }
 
-bool ezRational::operator!=(const ezRational& other) const
+EZ_ALWAYS_INLINE bool ezRational::operator!=(const ezRational& other) const
 {
   return m_uiNumerator != other.m_uiNumerator || m_uiDenominator != other.m_uiDenominator;
 }
 
-ezUInt32 ezRational::GetNumerator() const
+EZ_ALWAYS_INLINE ezUInt32 ezRational::GetNumerator() const
 {
   return m_uiNumerator;
 }
 
-ezUInt32 ezRational::GetDenominator() const
+EZ_ALWAYS_INLINE ezUInt32 ezRational::GetDenominator() const
 {
   return m_uiDenominator;
 }
 
-/// \brief Returns the result of the division as an integer.
-ezUInt32 ezRational::GetIntegralResult() const
+EZ_ALWAYS_INLINE ezUInt32 ezRational::GetIntegralResult() const
 {
   if (m_uiNumerator == 0 && m_uiDenominator == 0)
     return 0;
@@ -41,7 +40,7 @@ ezUInt32 ezRational::GetIntegralResult() const
   return m_uiNumerator / m_uiDenominator;
 }
 
-double ezRational::GetFloatingPointResult() const
+EZ_ALWAYS_INLINE double ezRational::GetFloatingPointResult() const
 {
   if (m_uiNumerator == 0 && m_uiDenominator == 0)
     return 0.0;
@@ -50,16 +49,12 @@ double ezRational::GetFloatingPointResult() const
 
 }
 
-/// \brief Returns true if the rational is valid (follows the rules stated in the class description)
-bool ezRational::IsValid() const
+EZ_ALWAYS_INLINE bool ezRational::IsValid() const
 {
   return m_uiDenominator != 0 || (m_uiNumerator == 0 && m_uiDenominator == 0);
 }
 
-/// \brief This helper returns a reduced fraction in case of an integral input.
-///
-/// Note that this will assert in DEV builds if this class is not integral.
-ezRational ezRational::ReduceIntegralFraction() const
+EZ_ALWAYS_INLINE ezRational ezRational::ReduceIntegralFraction() const
 {
   EZ_ASSERT_DEV(IsValid() && IsIntegral(), "ReduceIntegralFraction can only be called on valid, integral rational numbers");
 

--- a/Code/Engine/Foundation/Math/Implementation/Rational_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Rational_inl.h
@@ -1,0 +1,67 @@
+
+ezRational::ezRational(ezUInt32 uiNumerator, ezUInt32 uiDenominator)
+  : m_uiNumerator(uiNumerator)
+  , m_uiDenominator(uiDenominator)
+{}
+
+bool ezRational::IsIntegral() const
+{
+  if (m_uiNumerator == 0 && m_uiDenominator == 0)
+    return true;
+
+  return ((m_uiNumerator / m_uiDenominator) * m_uiDenominator) == m_uiNumerator;
+}
+
+bool ezRational::operator==(const ezRational& other) const
+{
+  return m_uiNumerator == other.m_uiNumerator && m_uiDenominator == other.m_uiDenominator;
+}
+
+bool ezRational::operator!=(const ezRational& other) const
+{
+  return m_uiNumerator != other.m_uiNumerator || m_uiDenominator != other.m_uiDenominator;
+}
+
+ezUInt32 ezRational::GetNumerator() const
+{
+  return m_uiNumerator;
+}
+
+ezUInt32 ezRational::GetDenominator() const
+{
+  return m_uiDenominator;
+}
+
+/// \brief Returns the result of the division as an integer.
+ezUInt32 ezRational::GetIntegralResult() const
+{
+  if (m_uiNumerator == 0 && m_uiDenominator == 0)
+    return 0;
+
+  return m_uiNumerator / m_uiDenominator;
+}
+
+double ezRational::GetFloatingPointResult() const
+{
+  if (m_uiNumerator == 0 && m_uiDenominator == 0)
+    return 0.0;
+
+  return static_cast<double>(m_uiNumerator) / static_cast<double>(m_uiDenominator);
+
+}
+
+/// \brief Returns true if the rational is valid (follows the rules stated in the class description)
+bool ezRational::IsValid() const
+{
+  return m_uiDenominator != 0 || (m_uiNumerator == 0 && m_uiDenominator == 0);
+}
+
+/// \brief This helper returns a reduced fraction in case of an integral input.
+///
+/// Note that this will assert in DEV builds if this class is not integral.
+ezRational ezRational::ReduceIntegralFraction() const
+{
+  EZ_ASSERT_DEV(IsValid() && IsIntegral(), "ReduceIntegralFraction can only be called on valid, integral rational numbers");
+
+  return ezRational(m_uiNumerator / m_uiDenominator, 1);
+}

--- a/Code/Engine/Foundation/Math/Rational.h
+++ b/Code/Engine/Foundation/Math/Rational.h
@@ -1,0 +1,56 @@
+
+#pragma once
+
+#include <Foundation/Basics.h>
+
+/// \brief A class which can be used to represent rational numbers by stating their numerator and denominator.
+///
+/// ezRational uses the following rules
+///   0/0 is legal and will be interpreted as 0/1
+///   If you are representing a whole number, the denominator should be 1
+///
+class ezRational
+{
+public:
+
+  EZ_DECLARE_POD_TYPE();
+
+  /// \brief Constructor to initialize a rational
+  ezRational(ezUInt32 uiNumerator, ezUInt32 uiDenominator);
+
+  /// \brief returns true if the division of the numerator by the denominator would result in a full integer
+  bool IsIntegral() const;
+
+  /// \brief Equality operator
+  bool operator == (const ezRational& other) const;
+
+  /// \brief Inequality operator
+  bool operator != (const ezRational& other) const;
+
+  /// \brief Returns the numerator of the rational number
+  ezUInt32 GetNumerator() const;
+
+  /// \brief Returns the denominator
+  ezUInt32 GetDenominator() const;
+
+  /// \brief Returns the result of the division as an integer.
+  ezUInt32 GetIntegralResult() const;
+
+  /// \brief Returns the result of the division as a floating point number (double).
+  double GetFloatingPointResult() const;
+
+  /// \brief Returns true if the rational is valid (follows the rules stated in the class description)
+  bool IsValid() const;
+
+  /// \brief This helper returns a reduced fraction in case of an integral input.
+  ///
+  /// Note that this will assert in DEV builds if this class is not integral.
+  ezRational ReduceIntegralFraction() const;
+
+protected:
+
+  ezUInt32 m_uiNumerator = 0;
+  ezUInt32 m_uiDenominator = 1;
+};
+
+#include <Foundation/Math/Implementation/Rational_inl.h>

--- a/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/Strings/String.h>
 #include <Foundation/Strings/StringBuilder.h>
 #include <Foundation/Types/Variant.h>
+#include <Foundation/Math/Rational.h>
 
 ezFormatString::ezFormatString(const ezStringBuilder& s)
 {
@@ -193,6 +194,24 @@ ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezAngle& arg)
   tmp[writepos + 2] = '\0';
 
   return ezStringView(tmp, tmp + writepos + 2);
+}
+
+ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezRational& arg)
+{
+  ezUInt32 writepos = 0;
+
+  if (arg.IsIntegral())
+  {
+    ezStringUtils::OutputFormattedInt(tmp, uiLength, writepos, arg.GetIntegralResult(), 1, false, 10);
+
+    return ezStringView(tmp, tmp + writepos);
+  }
+  else
+  {
+    ezStringUtils::snprintf(tmp, uiLength, "%i/%i", arg.GetNumerator(), arg.GetDenominator());
+
+    return ezStringView(tmp);
+  }
 }
 
 ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezTime& arg)

--- a/Code/Engine/Foundation/Strings/Implementation/FormatStringArgs.h
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatStringArgs.h
@@ -6,6 +6,7 @@
 class ezStringBuilder;
 class ezVariant;
 class ezAngle;
+class ezRational;
 struct ezTime;
 
 struct ezArgI
@@ -189,6 +190,7 @@ EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const e
 EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, ezResult arg);
 EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezVariant& arg);
 EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezAngle& arg);
+EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezRational& arg);
 EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezArgHumanReadable& arg);
 EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezTime& arg);
 EZ_FOUNDATION_DLL ezStringView BuildString(char* tmp, ezUInt32 uiLength, const ezArgSensitive& arg);

--- a/Code/UnitTests/FoundationTest/Math/RationalTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/RationalTest.cpp
@@ -1,0 +1,57 @@
+#include <FoundationTestPCH.h>
+
+#include <Foundation/Math/Rational.h>
+#include <Foundation/Strings/StringBuilder.h>
+
+EZ_CREATE_SIMPLE_TEST(Math, Rational)
+{
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Rational")
+  {
+    ezRational r1(100, 1);
+
+    EZ_TEST_BOOL(r1.IsValid());
+    EZ_TEST_BOOL(r1.IsIntegral());
+
+    ezRational r2(100, 0);
+    EZ_TEST_BOOL(!r2.IsValid());
+
+    EZ_TEST_BOOL(r1 != r2);
+
+    ezRational r3(100, 1);
+    EZ_TEST_BOOL(r3 == r1);
+
+    ezRational r4(0, 0);
+    EZ_TEST_BOOL(r4.IsValid());
+
+
+    ezRational r5(30, 6);
+    EZ_TEST_BOOL(r5.IsIntegral());
+    EZ_TEST_INT(r5.GetIntegralResult(), 5);
+    EZ_TEST_FLOAT(r5.GetFloatingPointResult(), 5, ezMath::SmallEpsilon<double>());
+
+    ezRational reducedTest(5, 1);
+    EZ_TEST_BOOL(r5.ReduceIntegralFraction() == reducedTest);
+
+    ezRational r6(31, 6);
+    EZ_TEST_BOOL(!r6.IsIntegral());
+    EZ_TEST_FLOAT(r6.GetFloatingPointResult(), 5.16666666666, ezMath::SmallEpsilon<double>());
+
+
+    EZ_TEST_INT(r6.GetDenominator(), 6);
+    EZ_TEST_INT(r6.GetNumerator(), 31);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Rational String Formatting")
+  {
+    ezRational r1(50, 25);
+
+    ezStringBuilder sb;
+    sb.Format("Rational: {}", r1);
+    EZ_TEST_STRING(sb, "Rational: 2");
+
+
+    ezRational r2(233, 76);
+    sb.Format("Rational: {}", r2);
+    EZ_TEST_STRING(sb, "Rational: 233/76");
+  }
+}


### PR DESCRIPTION
Can be used to hold fractional values.
Useful when storing screen refresh rates as they might be integral (e.g. 60Hz or real, like 59.94Hz).
This way UI code can select the best representation without loosing precision due to the use of floats.