### PR TITLE
Added new small array container class

### DIFF
--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -3,6 +3,7 @@
 /// \file
 
 #include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Containers/SmallArray.h>
 #include <Foundation/SimdMath/SimdConversion.h>
 #include <Foundation/Time/Time.h>
 #include <Foundation/Types/TagSet.h>
@@ -36,7 +37,7 @@ private:
   enum
   {
 #if EZ_ENABLED(EZ_PLATFORM_32BIT)
-    NUM_INPLACE_COMPONENTS = 14
+    NUM_INPLACE_COMPONENTS = 12
 #else
     NUM_INPLACE_COMPONENTS = 6
 #endif
@@ -60,7 +61,7 @@ public:
     const ezGameObject& operator*() const;
     const ezGameObject* operator->() const;
 
-    operator const ezGameObject *() const;
+    operator const ezGameObject*() const;
 
     /// \brief Advances the iterator to the next child object. The iterator will not be valid anymore, if the last child is reached.
     void Next();
@@ -455,7 +456,7 @@ private:
   ezHybridArray<ezGameObject*, 8> Reflection_GetChildren() const;
   void Reflection_AddComponent(ezComponent* pComponent);
   void Reflection_RemoveComponent(ezComponent* pComponent);
-  const ezHybridArray<ezComponent*, NUM_INPLACE_COMPONENTS>& Reflection_GetComponents() const;
+  ezHybridArray<ezComponent*, NUM_INPLACE_COMPONENTS> Reflection_GetComponents() const;
 
   ezObjectMode::Enum Reflection_GetMode() const;
   void Reflection_SetMode(ezObjectMode::Enum mode);
@@ -550,14 +551,8 @@ private:
   ezUInt32 m_uiPadding = 0;
 #endif
 
-  /// \todo small array class to reduce memory overhead
-  ezHybridArray<ezComponent*, NUM_INPLACE_COMPONENTS> m_Components;
+  ezSmallArrayBase<ezComponent*, NUM_INPLACE_COMPONENTS> m_Components;
 
-#if EZ_ENABLED(EZ_PLATFORM_32BIT)
-  ezUInt64 m_uiPadding2 = 0;
-#endif
-
-  /// \todo somehow make this more compact
   ezTagSet m_Tags;
 };
 

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -61,7 +61,7 @@ public:
     const ezGameObject& operator*() const;
     const ezGameObject* operator->() const;
 
-    operator const ezGameObject*() const;
+    operator const ezGameObject *() const;
 
     /// \brief Advances the iterator to the next child object. The iterator will not be valid anymore, if the last child is reached.
     void Next();

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -246,6 +246,7 @@ void ezGameObject::ConstChildIterator::Next()
 
 ezGameObject::~ezGameObject()
 {
+  // Since we are using the small array base class for components we have to cleanup ourself with the correct allocator.
   m_Components.Clear();
   m_Components.Compact(GetWorld()->GetAllocator());
 }

--- a/Code/Engine/Core/World/Implementation/GameObject_inl.h
+++ b/Code/Engine/Core/World/Implementation/GameObject_inl.h
@@ -61,8 +61,6 @@ EZ_ALWAYS_INLINE ezGameObject::ezGameObject(const ezGameObject& other)
   *this = other;
 }
 
-EZ_ALWAYS_INLINE ezGameObject::~ezGameObject() {}
-
 EZ_ALWAYS_INLINE ezGameObjectHandle ezGameObject::GetHandle() const
 {
   return ezGameObjectHandle(m_InternalId);

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -73,7 +73,7 @@ namespace ezInternal
     EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject::TransformationData) == 192);
 #endif
 
-    EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject) == 144); /// \todo get game object size back to 128
+    EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject) == 128);
     EZ_CHECK_AT_COMPILETIME(sizeof(QueuedMsgMetaData) == 16);
 
     EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObjectId::m_WorldIndex) == sizeof(ezComponentId::m_WorldIndex));

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -73,7 +73,7 @@ namespace ezInternal
     EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject::TransformationData) == 192);
 #endif
 
-    EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject) == 168); /// \todo get game object size back to 128
+    EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject) == 144); /// \todo get game object size back to 128
     EZ_CHECK_AT_COMPILETIME(sizeof(QueuedMsgMetaData) == 16);
 
     EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObjectId::m_WorldIndex) == sizeof(ezComponentId::m_WorldIndex));

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -637,6 +637,7 @@ template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllo
 EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::operator=(const ezSmallArray<T, Size, AllocatorWrapper>& rhs)
 {
   *this = ((ezArrayPtr<const T>)rhs); // redirect this to the ezArrayPtr version
+  this->m_uiUserData = rhs.m_uiUserData;
 }
 
 template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -336,7 +336,7 @@ ezUInt32 ezSmallArrayBase<T, Size>::LastIndexOf(const T& value, ezUInt32 uiStart
 {
   const T* pElements = GetElementsPtr();
 
-  for (ezUInt32 i = ezMath::Min(uiStartIndex, m_uiCount); i-- > 0;)
+  for (ezUInt32 i = ezMath::Min<ezUInt32>(uiStartIndex, m_uiCount); i-- > 0;)
   {
     if (ezMemoryUtils::IsEqual(pElements + i, &value))
       return i;

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -6,6 +6,7 @@ template <typename T, ezUInt16 Size>
 EZ_ALWAYS_INLINE ezSmallArrayBase<T, Size>::ezSmallArrayBase(const ezSmallArrayBase<T, Size>& other, ezAllocatorBase* pAllocator)
 {
   CopyFrom((ezArrayPtr<const T>)other, pAllocator);
+  m_uiUserData = other.m_uiUserData;
 }
 
 template <typename T, ezUInt16 Size>
@@ -86,6 +87,7 @@ void ezSmallArrayBase<T, Size>::MoveFrom(ezSmallArrayBase<T, Size>&& other, ezAl
   }
 
   m_uiCount = other.m_uiCount;
+  m_uiUserData = other.m_uiUserData;
 
   // reset the other array to not reference the data anymore
   other.m_pElements = nullptr;

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -106,7 +106,7 @@ EZ_ALWAYS_INLINE ezSmallArrayBase<T, Size>::operator ezArrayPtr<T>()
 template <typename T, ezUInt16 Size>
 EZ_ALWAYS_INLINE bool ezSmallArrayBase<T, Size>::operator==(const ezSmallArrayBase<T, Size>& rhs) const
 {
-  *this == rhs.GetArrayPtr();
+  return *this == rhs.GetArrayPtr();
 }
 
 template <typename T, ezUInt16 Size>
@@ -600,8 +600,8 @@ EZ_ALWAYS_INLINE ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray(const ezA
 
 template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray(ezSmallArray<T, Size, AllocatorWrapper>&& other)
+  : SUPER(static_cast<SUPER&&>(other), AllocatorWrapper::GetAllocator())
 {
-  SUPER::MoveFrom(std::move(other), AllocatorWrapper::GetAllocator());
 }
 
 template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -1,0 +1,519 @@
+
+template <typename T, ezUInt16 Size>
+ezSmallArrayBase<T, Size>::ezSmallArrayBase() = default;
+
+template <typename T, ezUInt16 Size>
+ezSmallArrayBase<T, Size>::~ezSmallArrayBase() = default;
+
+#if 0
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::operator=(const ezArrayPtr<const T>& rhs)
+{
+  if (this->GetData() == rhs.GetPtr())
+  {
+    if (m_uiCount == rhs.GetCount())
+      return;
+
+    EZ_ASSERT_DEV(m_uiCount > rhs.GetCount(), "Dangling array pointer. The given array pointer points to invalid memory.");
+    T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+    ezMemoryUtils::Destruct(pElements + rhs.GetCount(), m_uiCount - rhs.GetCount());
+    m_uiCount = rhs.GetCount();
+    return;
+  }
+
+  const ezUInt32 uiOldCount = m_uiCount;
+  const ezUInt32 uiNewCount = rhs.GetCount();
+
+  if (uiNewCount > uiOldCount)
+  {
+    static_cast<Derived*>(this)->Reserve(uiNewCount);
+    T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+    ezMemoryUtils::Copy(pElements, rhs.GetPtr(), uiOldCount);
+    ezMemoryUtils::CopyConstructArray(pElements + uiOldCount, rhs.GetPtr() + uiOldCount, uiNewCount - uiOldCount);
+  }
+  else
+  {
+    T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+    ezMemoryUtils::Copy(pElements, rhs.GetPtr(), uiNewCount);
+    ezMemoryUtils::Destruct(pElements + uiNewCount, uiOldCount - uiNewCount);
+  }
+
+  m_uiCount = uiNewCount;
+}
+
+#endif
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezSmallArrayBase<T, Size>::operator ezArrayPtr<const T>() const
+{
+  return ezArrayPtr<const T>(GetElementsPtr(), m_uiCount);
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezSmallArrayBase<T, Size>::operator ezArrayPtr<T>()
+{
+  return ezArrayPtr<T>(GetElementsPtr(), m_uiCount);
+}
+
+template <typename T, ezUInt16 Size>
+bool ezSmallArrayBase<T, Size>::operator==(const ezArrayPtr<const T>& rhs) const
+{
+  if (m_uiCount != rhs.GetCount())
+    return false;
+
+  return ezMemoryUtils::IsEqual(GetElementsPtr(), rhs.GetPtr(), m_uiCount);
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE bool ezSmallArrayBase<T, Size>::operator!=(const ezArrayPtr<const T>& rhs) const
+{
+  return !(*this == rhs);
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE const T& ezSmallArrayBase<T, Size>::operator[](const ezUInt16 uiIndex) const
+{
+  EZ_ASSERT_DEV(uiIndex < m_uiCount, "Out of bounds access. Array has {0} elements, trying to access element at index {1}.", m_uiCount, uiIndex);
+  return GetElementsPtr()[uiIndex];
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE T& ezSmallArrayBase<T, Size>::operator[](const ezUInt16 uiIndex)
+{
+  EZ_ASSERT_DEV(uiIndex < m_uiCount, "Out of bounds access. Array has {0} elements, trying to access element at index {1}.", m_uiCount, uiIndex);
+  return GetElementsPtr()[uiIndex];
+}
+
+#if 0
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::SetCount(ezUInt32 uiCount)
+{
+  const ezUInt32 uiOldCount = m_uiCount;
+  const ezUInt32 uiNewCount = uiCount;
+
+  if (uiNewCount > uiOldCount)
+  {
+    static_cast<Derived*>(this)->Reserve(uiNewCount);
+    ezMemoryUtils::DefaultConstruct(static_cast<Derived*>(this)->GetElementsPtr() + uiOldCount, uiNewCount - uiOldCount);
+  }
+  else if (uiNewCount < uiOldCount)
+  {
+    ezMemoryUtils::Destruct(static_cast<Derived*>(this)->GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
+  }
+
+  m_uiCount = uiCount;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::SetCount(ezUInt32 uiCount, const T& FillValue)
+{
+  const ezUInt32 uiOldCount = m_uiCount;
+  const ezUInt32 uiNewCount = uiCount;
+
+  if (uiNewCount > uiOldCount)
+  {
+    static_cast<Derived*>(this)->Reserve(uiNewCount);
+    ezMemoryUtils::CopyConstruct(static_cast<Derived*>(this)->GetElementsPtr() + uiOldCount, FillValue, uiNewCount - uiOldCount);
+  }
+  else if (uiNewCount < uiOldCount)
+  {
+    ezMemoryUtils::Destruct(static_cast<Derived*>(this)->GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
+  }
+
+  m_uiCount = uiCount;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::EnsureCount(ezUInt32 uiCount)
+{
+  if (uiCount > m_uiCount)
+  {
+    SetCount(uiCount);
+  }
+}
+
+template <typename T, ezUInt16 Size>
+template <typename> // Second template needed so that the compiler does only instantiate it when called. Otherwise the static_assert would trigger
+                    // early.
+                    void ezSmallArrayBase<T, Size>::SetCountUninitialized(ezUInt32 uiCount)
+{
+  static_assert(ezIsPodType<T>::value == ezTypeIsPod::value, "SetCountUninitialized is only supported for POD types.");
+  const ezUInt32 uiOldCount = m_uiCount;
+  const ezUInt32 uiNewCount = uiCount;
+
+  if (uiNewCount > uiOldCount)
+  {
+    static_cast<Derived*>(this)->Reserve(uiNewCount);
+    ezMemoryUtils::Construct(static_cast<Derived*>(this)->GetElementsPtr() + uiOldCount, uiNewCount - uiOldCount);
+  }
+  else if (uiNewCount < uiOldCount)
+  {
+    ezMemoryUtils::Destruct(static_cast<Derived*>(this)->GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
+  }
+
+  m_uiCount = uiCount;
+}
+
+#endif
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezUInt32 ezSmallArrayBase<T, Size>::GetCount() const
+{
+  return m_uiCount;
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE bool ezSmallArrayBase<T, Size>::IsEmpty() const
+{
+  return m_uiCount == 0;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::Clear()
+{
+  ezMemoryUtils::Destruct(GetElementsPtr(), m_uiCount);
+  m_uiCount = 0;
+}
+
+template <typename T, ezUInt16 Size>
+bool ezSmallArrayBase<T, Size>::Contains(const T& value) const
+{
+  return IndexOf(value) != ezInvalidIndex;
+}
+
+#if 0
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::Insert(const T& value, ezUInt32 uiIndex)
+{
+  EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
+
+  static_cast<Derived*>(this)->Reserve(m_uiCount + 1);
+
+  ezMemoryUtils::Prepend(static_cast<Derived*>(this)->GetElementsPtr() + uiIndex, value, m_uiCount - uiIndex);
+  m_uiCount++;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::Insert(T&& value, ezUInt32 uiIndex)
+{
+  EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
+
+  static_cast<Derived*>(this)->Reserve(m_uiCount + 1);
+
+  ezMemoryUtils::Prepend(static_cast<Derived*>(this)->GetElementsPtr() + uiIndex, std::move(value), m_uiCount - uiIndex);
+  m_uiCount++;
+}
+
+template <typename T, ezUInt16 Size>
+bool ezSmallArrayBase<T, Size>::RemoveAndCopy(const T& value)
+{
+  ezUInt32 uiIndex = IndexOf(value);
+
+  if (uiIndex == ezInvalidIndex)
+    return false;
+
+  RemoveAtAndCopy(uiIndex);
+  return true;
+}
+
+template <typename T, ezUInt16 Size>
+bool ezSmallArrayBase<T, Size>::RemoveAndSwap(const T& value)
+{
+  ezUInt32 uiIndex = IndexOf(value);
+
+  if (uiIndex == ezInvalidIndex)
+    return false;
+
+  RemoveAtAndSwap(uiIndex);
+  return true;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::RemoveAtAndCopy(ezUInt32 uiIndex, ezUInt32 uiNumElements /*= 1*/)
+{
+  EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.",
+    m_uiCount, uiIndex + uiNumElements - 1);
+
+  T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+
+  m_uiCount -= uiNumElements;
+  ezMemoryUtils::RelocateOverlapped(pElements + uiIndex, pElements + uiIndex + uiNumElements, m_uiCount - uiIndex);
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt32 uiIndex, ezUInt32 uiNumElements /*= 1*/)
+{
+  EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.",
+    m_uiCount, uiIndex + uiNumElements - 1);
+
+  T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+
+  for (ezUInt32 i = 0; i < uiNumElements; ++i)
+  {
+    m_uiCount--;
+
+    if (m_uiCount != uiIndex)
+    {
+      pElements[uiIndex] = std::move(pElements[m_uiCount]);
+    }
+    ezMemoryUtils::Destruct(pElements + m_uiCount, 1);
+    ++uiIndex;
+  }
+}
+
+#endif
+
+template <typename T, ezUInt16 Size>
+ezUInt32 ezSmallArrayBase<T, Size>::IndexOf(const T& value, ezUInt16 uiStartIndex) const
+{
+  const T* pElements = GetElementsPtr();
+
+  for (ezUInt32 i = uiStartIndex; i < m_uiCount; i++)
+  {
+    if (ezMemoryUtils::IsEqual(pElements + i, &value))
+      return i;
+  }
+  return ezInvalidIndex;
+}
+
+template <typename T, ezUInt16 Size>
+ezUInt32 ezSmallArrayBase<T, Size>::LastIndexOf(const T& value, ezUInt16 uiStartIndex) const
+{
+  const T* pElements = GetElementsPtr();
+
+  for (ezUInt32 i = ezMath::Min(uiStartIndex, m_uiCount); i-- > 0;)
+  {
+    if (ezMemoryUtils::IsEqual(pElements + i, &value))
+      return i;
+  }
+  return ezInvalidIndex;
+}
+
+template <typename T, ezUInt16 Size>
+T& ezSmallArrayBase<T, Size>::ExpandAndGetRef()
+{
+  Reserve(m_uiCount + 1);
+
+  T* pElements = GetElementsPtr();
+
+  ezMemoryUtils::Construct(pElements + m_uiCount, 1);
+
+  T& ReturnRef = *(pElements + m_uiCount);
+
+  m_uiCount++;
+
+  return ReturnRef;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::PushBack(const T& value)
+{
+  Reserve(m_uiCount + 1);
+
+  ezMemoryUtils::CopyConstruct(GetElementsPtr() + m_uiCount, value, 1);
+  m_uiCount++;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::PushBack(T&& value)
+{
+  Reserve(m_uiCount + 1);
+
+  ezMemoryUtils::MoveConstruct<T>(GetElementsPtr() + m_uiCount, std::move(value));
+  m_uiCount++;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::PushBackUnchecked(const T& value)
+{
+  EZ_ASSERT_DEV(m_uiCount < m_uiCapacity, "Appending unchecked to array with insufficient capacity.");
+
+  ezMemoryUtils::CopyConstruct(GetElementsPtr() + m_uiCount, value, 1);
+  m_uiCount++;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::PushBackUnchecked(T&& value)
+{
+  EZ_ASSERT_DEV(m_uiCount < m_uiCapacity, "Appending unchecked to array with insufficient capacity.");
+
+  ezMemoryUtils::MoveConstruct<T>(GetElementsPtr() + m_uiCount, std::move(value));
+  m_uiCount++;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::PushBackRange(const ezArrayPtr<const T>& range)
+{
+  const ezUInt32 uiRangeCount = range.GetCount();
+  Reserve(m_uiCount + uiRangeCount);
+
+  ezMemoryUtils::CopyConstructArray(GetElementsPtr() + m_uiCount, range.GetPtr(), uiRangeCount);
+  m_uiCount += uiRangeCount;
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::PopBack(ezUInt32 uiCountToRemove /* = 1 */)
+{
+  EZ_ASSERT_DEV(m_uiCount >= uiCountToRemove, "Out of bounds access. Array has {0} elements, trying to pop {1} elements.", m_uiCount, uiCountToRemove);
+
+  m_uiCount -= uiCountToRemove;
+  ezMemoryUtils::Destruct(GetElementsPtr() + m_uiCount, uiCountToRemove);
+}
+
+template <typename T, ezUInt16 Size>
+EZ_FORCE_INLINE T& ezSmallArrayBase<T, Size>::PeekBack()
+{
+  EZ_ASSERT_DEV(m_uiCount > 0, "Out of bounds access. Trying to peek into an empty array.");
+  return GetElementsPtr()[m_uiCount - 1];
+}
+
+template <typename T, ezUInt16 Size>
+EZ_FORCE_INLINE const T& ezSmallArrayBase<T, Size>::PeekBack() const
+{
+  EZ_ASSERT_DEV(m_uiCount > 0, "Out of bounds access. Trying to peek into an empty array.");
+  return GetElementsPtr()[m_uiCount - 1];
+}
+
+template <typename T, ezUInt16 Size>
+template <typename Comparer>
+void ezSmallArrayBase<T, Size>::Sort(const Comparer& comparer)
+{
+  if (m_uiCount > 1)
+  {
+    ezArrayPtr<T> ar = *this;
+    ezSorting::QuickSort(ar, comparer);
+  }
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::Sort()
+{
+  if (m_uiCount > 1)
+  {
+    ezArrayPtr<T> ar = *this;
+    ezSorting::QuickSort(ar, ezCompareHelper<T>());
+  }
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE T* ezSmallArrayBase<T, Size>::GetData()
+{
+  if (IsEmpty())
+    return nullptr;
+
+  return GetElementsPtr();
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE const T* ezSmallArrayBase<T, Size>::GetData() const
+{
+  if (IsEmpty())
+    return nullptr;
+
+  return GetElementsPtr();
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezArrayPtr<T> ezSmallArrayBase<T, Size>::GetArrayPtr()
+{
+  return ezArrayPtr<T>(GetData(), GetCount());
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezArrayPtr<const T> ezSmallArrayBase<T, Size>::GetArrayPtr() const
+{
+  return ezArrayPtr<const T>(GetData(), GetCount());
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezArrayPtr<typename ezArrayPtr<T>::ByteType> ezSmallArrayBase<T, Size>::GetByteArrayPtr()
+{
+  return GetArrayPtr().ToByteArray();
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezArrayPtr<typename ezArrayPtr<const T>::ByteType> ezSmallArrayBase<T, Size>::GetByteArrayPtr() const
+{
+  return GetArrayPtr().ToByteArray();
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE T* ezSmallArrayBase<T, Size>::GetElementsPtr()
+{
+  return m_uiCapacity <= Size ? reinterpret_cast<T*>(m_StaticData) : m_pElements;
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE const T* ezSmallArrayBase<T, Size>::GetElementsPtr() const
+{
+  return m_uiCapacity <= Size ? reinterpret_cast<const T*>(m_StaticData) : m_pElements;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray() = default;
+
+#if 0
+template <typename T, typename A>
+ezDynamicArray<T, A>::ezDynamicArray(const ezDynamicArray<T, A>& other)
+  : ezDynamicArrayBase<T>(other, A::GetAllocator())
+{
+}
+
+template <typename T, typename A>
+ezDynamicArray<T, A>::ezDynamicArray(const ezDynamicArrayBase<T>& other)
+  : ezDynamicArrayBase<T>(other, A::GetAllocator())
+{
+}
+
+template <typename T, typename A>
+ezDynamicArray<T, A>::ezDynamicArray(const ezArrayPtr<const T>& other)
+  : ezDynamicArrayBase<T>(other, A::GetAllocator())
+{
+}
+
+template <typename T, typename A>
+ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArray<T, A>&& other)
+  : ezDynamicArrayBase<T>(std::move(other), other.GetAllocator())
+{
+}
+
+template <typename T, typename A>
+ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArrayBase<T>&& other)
+  : ezDynamicArrayBase<T>(std::move(other), other.GetAllocator())
+{
+}
+
+template <typename T, typename A>
+void ezDynamicArray<T, A>::operator=(const ezDynamicArray<T, A>& rhs)
+{
+  ezDynamicArrayBase<T>::operator=(rhs);
+}
+
+template <typename T, typename A>
+void ezDynamicArray<T, A>::operator=(const ezDynamicArrayBase<T>& rhs)
+{
+  ezDynamicArrayBase<T>::operator=(rhs);
+}
+
+template <typename T, typename A>
+void ezDynamicArray<T, A>::operator=(const ezArrayPtr<const T>& rhs)
+{
+  ezArrayBase<T, ezDynamicArrayBase<T>>::operator=(rhs);
+}
+
+template <typename T, typename A>
+void ezDynamicArray<T, A>::operator=(ezDynamicArray<T, A>&& rhs) noexcept
+{
+  ezDynamicArrayBase<T>::operator=(std::move(rhs));
+}
+
+template <typename T, typename A>
+void ezDynamicArray<T, A>::operator=(ezDynamicArrayBase<T>&& rhs) noexcept
+{
+  ezDynamicArrayBase<T>::operator=(std::move(rhs));
+}
+#endif

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -135,14 +135,14 @@ EZ_ALWAYS_INLINE bool ezSmallArrayBase<T, Size>::operator!=(const ezArrayPtr<con
 }
 
 template <typename T, ezUInt16 Size>
-EZ_ALWAYS_INLINE const T& ezSmallArrayBase<T, Size>::operator[](const ezUInt16 uiIndex) const
+EZ_ALWAYS_INLINE const T& ezSmallArrayBase<T, Size>::operator[](const ezUInt32 uiIndex) const
 {
   EZ_ASSERT_DEV(uiIndex < m_uiCount, "Out of bounds access. Array has {0} elements, trying to access element at index {1}.", m_uiCount, uiIndex);
   return GetElementsPtr()[uiIndex];
 }
 
 template <typename T, ezUInt16 Size>
-EZ_ALWAYS_INLINE T& ezSmallArrayBase<T, Size>::operator[](const ezUInt16 uiIndex)
+EZ_ALWAYS_INLINE T& ezSmallArrayBase<T, Size>::operator[](const ezUInt32 uiIndex)
 {
   EZ_ASSERT_DEV(uiIndex < m_uiCount, "Out of bounds access. Array has {0} elements, trying to access element at index {1}.", m_uiCount, uiIndex);
   return GetElementsPtr()[uiIndex];
@@ -242,7 +242,7 @@ bool ezSmallArrayBase<T, Size>::Contains(const T& value) const
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::Insert(const T& value, ezUInt16 uiIndex, ezAllocatorBase* pAllocator)
+void ezSmallArrayBase<T, Size>::Insert(const T& value, ezUInt32 uiIndex, ezAllocatorBase* pAllocator)
 {
   EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
 
@@ -253,7 +253,7 @@ void ezSmallArrayBase<T, Size>::Insert(const T& value, ezUInt16 uiIndex, ezAlloc
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::Insert(T&& value, ezUInt16 uiIndex, ezAllocatorBase* pAllocator)
+void ezSmallArrayBase<T, Size>::Insert(T&& value, ezUInt32 uiIndex, ezAllocatorBase* pAllocator)
 {
   EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
 
@@ -288,7 +288,7 @@ bool ezSmallArrayBase<T, Size>::RemoveAndSwap(const T& value)
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::RemoveAtAndCopy(ezUInt16 uiIndex, ezUInt16 uiNumElements /*= 1*/)
+void ezSmallArrayBase<T, Size>::RemoveAtAndCopy(ezUInt32 uiIndex, ezUInt32 uiNumElements /*= 1*/)
 {
   EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.", m_uiCount, uiIndex + uiNumElements - 1);
 
@@ -299,7 +299,7 @@ void ezSmallArrayBase<T, Size>::RemoveAtAndCopy(ezUInt16 uiIndex, ezUInt16 uiNum
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt16 uiIndex, ezUInt16 uiNumElements /*= 1*/)
+void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt32 uiIndex, ezUInt32 uiNumElements /*= 1*/)
 {
   EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.", m_uiCount, uiIndex + uiNumElements - 1);
 
@@ -319,7 +319,7 @@ void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt16 uiIndex, ezUInt16 uiNum
 }
 
 template <typename T, ezUInt16 Size>
-ezUInt32 ezSmallArrayBase<T, Size>::IndexOf(const T& value, ezUInt16 uiStartIndex) const
+ezUInt32 ezSmallArrayBase<T, Size>::IndexOf(const T& value, ezUInt32 uiStartIndex) const
 {
   const T* pElements = GetElementsPtr();
 
@@ -332,7 +332,7 @@ ezUInt32 ezSmallArrayBase<T, Size>::IndexOf(const T& value, ezUInt16 uiStartInde
 }
 
 template <typename T, ezUInt16 Size>
-ezUInt32 ezSmallArrayBase<T, Size>::LastIndexOf(const T& value, ezUInt16 uiStartIndex) const
+ezUInt32 ezSmallArrayBase<T, Size>::LastIndexOf(const T& value, ezUInt32 uiStartIndex) const
 {
   const T* pElements = GetElementsPtr();
 

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -3,44 +3,92 @@ template <typename T, ezUInt16 Size>
 ezSmallArrayBase<T, Size>::ezSmallArrayBase() = default;
 
 template <typename T, ezUInt16 Size>
-ezSmallArrayBase<T, Size>::~ezSmallArrayBase() = default;
-
-#if 0
-template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::operator=(const ezArrayPtr<const T>& rhs)
+EZ_ALWAYS_INLINE ezSmallArrayBase<T, Size>::ezSmallArrayBase(const ezSmallArrayBase<T, Size>& other, ezAllocatorBase* pAllocator)
+  : ezSmallArrayBase<T, Size>((ezArrayPtr<const T>)other, pAllocator) // redirect this to the ezArrayPtr version
 {
-  if (this->GetData() == rhs.GetPtr())
+}
+
+template <typename T, ezUInt16 Size>
+ezSmallArrayBase<T, Size>::ezSmallArrayBase(const ezArrayPtr<const T>& other, ezAllocatorBase* pAllocator)
+{
+  Reserve(other.GetCount(), pAllocator);
+
+  T* pElements = GetElementsPtr();
+  ezMemoryUtils::CopyConstructArray(pElements, other.GetPtr(), other.GetCount());
+
+  m_uiCount = other.GetCount();
+}
+
+template <typename T, ezUInt16 Size>
+ezSmallArrayBase<T, Size>::ezSmallArrayBase(ezSmallArrayBase<T, Size>&& other, ezAllocatorBase* pAllocator)
+{
+  if (other.m_uiCapacity > Size)
   {
-    if (m_uiCount == rhs.GetCount())
-      return;
-
-    EZ_ASSERT_DEV(m_uiCount > rhs.GetCount(), "Dangling array pointer. The given array pointer points to invalid memory.");
-    T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
-    ezMemoryUtils::Destruct(pElements + rhs.GetCount(), m_uiCount - rhs.GetCount());
-    m_uiCount = rhs.GetCount();
-    return;
-  }
-
-  const ezUInt32 uiOldCount = m_uiCount;
-  const ezUInt32 uiNewCount = rhs.GetCount();
-
-  if (uiNewCount > uiOldCount)
-  {
-    static_cast<Derived*>(this)->Reserve(uiNewCount);
-    T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
-    ezMemoryUtils::Copy(pElements, rhs.GetPtr(), uiOldCount);
-    ezMemoryUtils::CopyConstructArray(pElements + uiOldCount, rhs.GetPtr() + uiOldCount, uiNewCount - uiOldCount);
+    m_uiCapacity = other.m_uiCapacity;
+    m_pElements = other.m_pElements;
   }
   else
   {
-    T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
-    ezMemoryUtils::Copy(pElements, rhs.GetPtr(), uiNewCount);
-    ezMemoryUtils::Destruct(pElements + uiNewCount, uiOldCount - uiNewCount);
+    ezMemoryUtils::RelocateConstruct(GetElementsPtr(), other.GetElementsPtr(), other.m_uiCount);
   }
 
-  m_uiCount = uiNewCount;
+  m_uiCount = other.m_uiCount;
+
+  // reset the other array to not reference the data anymore
+  other.m_pElements = nullptr;
+  other.m_uiCount = 0;
+  other.m_uiCapacity = 0;
 }
 
+template <typename T, ezUInt16 Size>
+EZ_FORCE_INLINE ezSmallArrayBase<T, Size>::~ezSmallArrayBase()
+{
+  EZ_ASSERT_DEBUG(m_uiCount == 0, "The derived class did not destruct all objects. Count is {0}.", m_uiCount);
+  EZ_ASSERT_DEBUG(m_pElements == nullptr, "The derived class did not free its memory.");
+}
+
+#if 0
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::operator=(ezSmallArrayBase<T, Size>&& rhs)
+{
+  // Clear any existing data (calls destructors if necessary)
+  Clear();
+
+  EZ_ASSERT_NOT_IMPLEMENTED;
+
+  if (this->m_pAllocator == rhs.m_pAllocator && rhs.m_pAllocator.GetFlags() == Storage::Owned) // only move the storage of rhs, if it owns it
+  {
+    if (this->m_pAllocator.GetFlags() == Storage::Owned)
+    {
+      // only delete our storage, if we own it
+      EZ_DELETE_RAW_BUFFER(this->m_pAllocator, this->m_pElements);
+    }
+
+    // we now own this storage
+    this->m_pAllocator.SetFlags(Storage::Owned);
+
+    // move the data over from the other array
+    this->m_uiCount = rhs.m_uiCount;
+    this->m_uiCapacity = rhs.m_uiCapacity;
+    this->m_pElements = rhs.m_pElements;
+
+    // reset the other array to not reference the data anymore
+    rhs.m_pElements = nullptr;
+    rhs.m_uiCount = 0;
+    rhs.m_uiCapacity = 0;
+  }
+  else
+  {
+    // Ensure we have enough data.
+    this->Reserve(rhs.m_uiCount);
+    this->m_uiCount = rhs.m_uiCount;
+
+    ezMemoryUtils::RelocateConstruct(
+      this->GetElementsPtr(), rhs.GetElementsPtr() /* vital to remap rhs.m_pElements to absolute ptr */, rhs.m_uiCount);
+
+    rhs.m_uiCount = 0;
+  }
+}
 #endif
 
 template <typename T, ezUInt16 Size>
@@ -84,59 +132,56 @@ EZ_ALWAYS_INLINE T& ezSmallArrayBase<T, Size>::operator[](const ezUInt16 uiIndex
   return GetElementsPtr()[uiIndex];
 }
 
-#if 0
-
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::SetCount(ezUInt32 uiCount)
+void ezSmallArrayBase<T, Size>::SetCount(ezUInt16 uiCount, ezAllocatorBase* pAllocator)
 {
   const ezUInt32 uiOldCount = m_uiCount;
   const ezUInt32 uiNewCount = uiCount;
 
   if (uiNewCount > uiOldCount)
   {
-    static_cast<Derived*>(this)->Reserve(uiNewCount);
-    ezMemoryUtils::DefaultConstruct(static_cast<Derived*>(this)->GetElementsPtr() + uiOldCount, uiNewCount - uiOldCount);
+    Reserve(uiNewCount, pAllocator);
+    ezMemoryUtils::DefaultConstruct(GetElementsPtr() + uiOldCount, uiNewCount - uiOldCount);
   }
   else if (uiNewCount < uiOldCount)
   {
-    ezMemoryUtils::Destruct(static_cast<Derived*>(this)->GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
+    ezMemoryUtils::Destruct(GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
   }
 
   m_uiCount = uiCount;
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::SetCount(ezUInt32 uiCount, const T& FillValue)
+void ezSmallArrayBase<T, Size>::SetCount(ezUInt16 uiCount, const T& FillValue, ezAllocatorBase* pAllocator)
 {
   const ezUInt32 uiOldCount = m_uiCount;
   const ezUInt32 uiNewCount = uiCount;
 
   if (uiNewCount > uiOldCount)
   {
-    static_cast<Derived*>(this)->Reserve(uiNewCount);
-    ezMemoryUtils::CopyConstruct(static_cast<Derived*>(this)->GetElementsPtr() + uiOldCount, FillValue, uiNewCount - uiOldCount);
+    Reserve(uiCount, pAllocator);
+    ezMemoryUtils::CopyConstruct(GetElementsPtr() + uiOldCount, FillValue, uiNewCount - uiOldCount);
   }
   else if (uiNewCount < uiOldCount)
   {
-    ezMemoryUtils::Destruct(static_cast<Derived*>(this)->GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
+    ezMemoryUtils::Destruct(GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
   }
 
   m_uiCount = uiCount;
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::EnsureCount(ezUInt32 uiCount)
+void ezSmallArrayBase<T, Size>::EnsureCount(ezUInt16 uiCount, ezAllocatorBase* pAllocator)
 {
   if (uiCount > m_uiCount)
   {
-    SetCount(uiCount);
+    SetCount(uiCount, pAllocator);
   }
 }
 
 template <typename T, ezUInt16 Size>
-template <typename> // Second template needed so that the compiler does only instantiate it when called. Otherwise the static_assert would trigger
-                    // early.
-                    void ezSmallArrayBase<T, Size>::SetCountUninitialized(ezUInt32 uiCount)
+template <typename> // Second template needed so that the compiler does only instantiate it when called. Otherwise the static_assert would trigger early.
+void ezSmallArrayBase<T, Size>::SetCountUninitialized(ezUInt16 uiCount, ezAllocatorBase* pAllocator)
 {
   static_assert(ezIsPodType<T>::value == ezTypeIsPod::value, "SetCountUninitialized is only supported for POD types.");
   const ezUInt32 uiOldCount = m_uiCount;
@@ -144,18 +189,16 @@ template <typename> // Second template needed so that the compiler does only ins
 
   if (uiNewCount > uiOldCount)
   {
-    static_cast<Derived*>(this)->Reserve(uiNewCount);
-    ezMemoryUtils::Construct(static_cast<Derived*>(this)->GetElementsPtr() + uiOldCount, uiNewCount - uiOldCount);
+    Reserve(uiNewCount, pAllocator);
+    ezMemoryUtils::Construct(GetElementsPtr() + uiOldCount, uiNewCount - uiOldCount);
   }
   else if (uiNewCount < uiOldCount)
   {
-    ezMemoryUtils::Destruct(static_cast<Derived*>(this)->GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
+    ezMemoryUtils::Destruct(GetElementsPtr() + uiNewCount, uiOldCount - uiNewCount);
   }
 
   m_uiCount = uiCount;
 }
-
-#endif
 
 template <typename T, ezUInt16 Size>
 EZ_ALWAYS_INLINE ezUInt32 ezSmallArrayBase<T, Size>::GetCount() const
@@ -182,27 +225,25 @@ bool ezSmallArrayBase<T, Size>::Contains(const T& value) const
   return IndexOf(value) != ezInvalidIndex;
 }
 
-#if 0
-
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::Insert(const T& value, ezUInt32 uiIndex)
+void ezSmallArrayBase<T, Size>::Insert(const T& value, ezUInt16 uiIndex, ezAllocatorBase* pAllocator)
 {
   EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
 
-  static_cast<Derived*>(this)->Reserve(m_uiCount + 1);
+  Reserve(m_uiCount + 1, pAllocator);
 
-  ezMemoryUtils::Prepend(static_cast<Derived*>(this)->GetElementsPtr() + uiIndex, value, m_uiCount - uiIndex);
+  ezMemoryUtils::Prepend(GetElementsPtr() + uiIndex, value, m_uiCount - uiIndex);
   m_uiCount++;
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::Insert(T&& value, ezUInt32 uiIndex)
+void ezSmallArrayBase<T, Size>::Insert(T&& value, ezUInt16 uiIndex, ezAllocatorBase* pAllocator)
 {
   EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
 
-  static_cast<Derived*>(this)->Reserve(m_uiCount + 1);
+  Reserve(m_uiCount + 1, pAllocator);
 
-  ezMemoryUtils::Prepend(static_cast<Derived*>(this)->GetElementsPtr() + uiIndex, std::move(value), m_uiCount - uiIndex);
+  ezMemoryUtils::Prepend(GetElementsPtr() + uiIndex, std::move(value), m_uiCount - uiIndex);
   m_uiCount++;
 }
 
@@ -231,24 +272,22 @@ bool ezSmallArrayBase<T, Size>::RemoveAndSwap(const T& value)
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::RemoveAtAndCopy(ezUInt32 uiIndex, ezUInt32 uiNumElements /*= 1*/)
+void ezSmallArrayBase<T, Size>::RemoveAtAndCopy(ezUInt16 uiIndex, ezUInt16 uiNumElements /*= 1*/)
 {
-  EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.",
-    m_uiCount, uiIndex + uiNumElements - 1);
+  EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.", m_uiCount, uiIndex + uiNumElements - 1);
 
-  T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+  T* pElements = GetElementsPtr();
 
   m_uiCount -= uiNumElements;
   ezMemoryUtils::RelocateOverlapped(pElements + uiIndex, pElements + uiIndex + uiNumElements, m_uiCount - uiIndex);
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt32 uiIndex, ezUInt32 uiNumElements /*= 1*/)
+void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt16 uiIndex, ezUInt16 uiNumElements /*= 1*/)
 {
-  EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.",
-    m_uiCount, uiIndex + uiNumElements - 1);
+  EZ_ASSERT_DEV(uiIndex + uiNumElements <= m_uiCount, "Out of bounds access. Array has {0} elements, trying to remove element at index {1}.", m_uiCount, uiIndex + uiNumElements - 1);
 
-  T* pElements = static_cast<Derived*>(this)->GetElementsPtr();
+  T* pElements = GetElementsPtr();
 
   for (ezUInt32 i = 0; i < uiNumElements; ++i)
   {
@@ -262,8 +301,6 @@ void ezSmallArrayBase<T, Size>::RemoveAtAndSwap(ezUInt32 uiIndex, ezUInt32 uiNum
     ++uiIndex;
   }
 }
-
-#endif
 
 template <typename T, ezUInt16 Size>
 ezUInt32 ezSmallArrayBase<T, Size>::IndexOf(const T& value, ezUInt16 uiStartIndex) const
@@ -292,9 +329,9 @@ ezUInt32 ezSmallArrayBase<T, Size>::LastIndexOf(const T& value, ezUInt16 uiStart
 }
 
 template <typename T, ezUInt16 Size>
-T& ezSmallArrayBase<T, Size>::ExpandAndGetRef()
+T& ezSmallArrayBase<T, Size>::ExpandAndGetRef(ezAllocatorBase* pAllocator)
 {
-  Reserve(m_uiCount + 1);
+  Reserve(m_uiCount + 1, pAllocator);
 
   T* pElements = GetElementsPtr();
 
@@ -308,18 +345,18 @@ T& ezSmallArrayBase<T, Size>::ExpandAndGetRef()
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::PushBack(const T& value)
+void ezSmallArrayBase<T, Size>::PushBack(const T& value, ezAllocatorBase* pAllocator)
 {
-  Reserve(m_uiCount + 1);
+  Reserve(m_uiCount + 1, pAllocator);
 
   ezMemoryUtils::CopyConstruct(GetElementsPtr() + m_uiCount, value, 1);
   m_uiCount++;
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::PushBack(T&& value)
+void ezSmallArrayBase<T, Size>::PushBack(T&& value, ezAllocatorBase* pAllocator)
 {
-  Reserve(m_uiCount + 1);
+  Reserve(m_uiCount + 1, pAllocator);
 
   ezMemoryUtils::MoveConstruct<T>(GetElementsPtr() + m_uiCount, std::move(value));
   m_uiCount++;
@@ -344,10 +381,10 @@ void ezSmallArrayBase<T, Size>::PushBackUnchecked(T&& value)
 }
 
 template <typename T, ezUInt16 Size>
-void ezSmallArrayBase<T, Size>::PushBackRange(const ezArrayPtr<const T>& range)
+void ezSmallArrayBase<T, Size>::PushBackRange(const ezArrayPtr<const T>& range, ezAllocatorBase* pAllocator)
 {
   const ezUInt32 uiRangeCount = range.GetCount();
-  Reserve(m_uiCount + uiRangeCount);
+  Reserve(m_uiCount + uiRangeCount, pAllocator);
 
   ezMemoryUtils::CopyConstructArray(GetElementsPtr() + m_uiCount, range.GetPtr(), uiRangeCount);
   m_uiCount += uiRangeCount;
@@ -440,6 +477,67 @@ EZ_ALWAYS_INLINE ezArrayPtr<typename ezArrayPtr<const T>::ByteType> ezSmallArray
 }
 
 template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::Reserve(ezUInt16 uiCapacity, ezAllocatorBase* pAllocator)
+{
+  if (m_uiCapacity >= uiCapacity)
+    return;
+
+  const ezUInt32 uiCurCap = static_cast<ezUInt32>(m_uiCapacity);
+  ezUInt32 uiNewCapacity = ezMemoryUtils::AlignSize<ezUInt32>(uiCurCap + (uiCurCap / 2), CAPACITY_ALIGNMENT);
+
+  uiNewCapacity = ezMath::Clamp<ezUInt32>(uiNewCapacity, uiCapacity, 0xFFFF);
+
+  SetCapacity(static_cast<ezUInt16>(uiNewCapacity), pAllocator);
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::Compact(ezAllocatorBase* pAllocator)
+{
+  if (IsEmpty())
+  {
+    if (m_uiCapacity > Size)
+    {
+      // completely deallocate all data, if the array is empty.
+      EZ_DELETE_RAW_BUFFER(pAllocator, m_pElements);
+    }
+
+    m_uiCapacity = Size;
+    m_pElements = nullptr;
+  }
+  else if (m_uiCapacity > Size)
+  {
+    const ezUInt32 uiNewCapacity = ezMemoryUtils::AlignSize<ezUInt32>(m_uiCount, CAPACITY_ALIGNMENT);
+    if (m_uiCapacity != uiNewCapacity)
+      SetCapacity(uiNewCapacity, pAllocator);
+  }
+}
+
+template <typename T, ezUInt16 Size>
+EZ_ALWAYS_INLINE ezUInt64 ezSmallArrayBase<T, Size>::GetHeapMemoryUsage() const
+{
+  return m_uiCapacity <= Size ? 0 : m_uiCapacity * sizeof(T);
+}
+
+template <typename T, ezUInt16 Size>
+void ezSmallArrayBase<T, Size>::SetCapacity(ezUInt16 uiCapacity, ezAllocatorBase* pAllocator)
+{
+  if (m_uiCapacity <= Size)
+  {
+    // special case when migrating from in-place to external storage
+    T* pNewElements = EZ_NEW_RAW_BUFFER(pAllocator, T, uiCapacity);
+
+    ezMemoryUtils::RelocateConstruct(pNewElements, GetElementsPtr(), m_uiCount);
+    m_pElements = pNewElements;
+  }
+  else
+  {
+    m_pElements = EZ_EXTEND_RAW_BUFFER(pAllocator, m_pElements, m_uiCount, uiCapacity);
+  }
+
+  m_uiCapacity = uiCapacity;
+}
+
+template <typename T, ezUInt16 Size>
 EZ_ALWAYS_INLINE T* ezSmallArrayBase<T, Size>::GetElementsPtr()
 {
   return m_uiCapacity <= Size ? reinterpret_cast<T*>(m_StaticData) : m_pElements;
@@ -456,64 +554,193 @@ EZ_ALWAYS_INLINE const T* ezSmallArrayBase<T, Size>::GetElementsPtr() const
 template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
 ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray() = default;
 
-#if 0
-template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(const ezDynamicArray<T, A>& other)
-  : ezDynamicArrayBase<T>(other, A::GetAllocator())
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray(const ezSmallArray<T, Size, AllocatorWrapper>& other)
+  : SUPER(other, AllocatorWrapper::GetAllocator())
 {
 }
 
-template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(const ezDynamicArrayBase<T>& other)
-  : ezDynamicArrayBase<T>(other, A::GetAllocator())
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray(const ezArrayPtr<const T>& other)
+  : SUPER(other, AllocatorWrapper::GetAllocator())
 {
 }
 
-template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(const ezArrayPtr<const T>& other)
-  : ezDynamicArrayBase<T>(other, A::GetAllocator())
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+ezSmallArray<T, Size, AllocatorWrapper>::ezSmallArray(ezSmallArray<T, Size, AllocatorWrapper>&& other)
+  : SUPER(std::move(other), AllocatorWrapper::GetAllocator())
 {
 }
 
-template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArray<T, A>&& other)
-  : ezDynamicArrayBase<T>(std::move(other), other.GetAllocator())
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+ezSmallArray<T, Size, AllocatorWrapper>::~ezSmallArray()
 {
+  SUPER::Clear();
+  SUPER::Compact(AllocatorWrapper::GetAllocator());
 }
 
-template <typename T, typename A>
-ezDynamicArray<T, A>::ezDynamicArray(ezDynamicArrayBase<T>&& other)
-  : ezDynamicArrayBase<T>(std::move(other), other.GetAllocator())
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+void ezSmallArray<T, Size, AllocatorWrapper>::operator=(const ezSmallArray<T, Size, AllocatorWrapper>& rhs)
 {
+  *this = ((ezArrayPtr<const T>)rhs); // redirect this to the ezArrayPtr version
 }
 
-template <typename T, typename A>
-void ezDynamicArray<T, A>::operator=(const ezDynamicArray<T, A>& rhs)
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+void ezSmallArray<T, Size, AllocatorWrapper>::operator=(const ezArrayPtr<const T>& rhs)
 {
-  ezDynamicArrayBase<T>::operator=(rhs);
+  EZ_ASSERT_NOT_IMPLEMENTED;
 }
 
-template <typename T, typename A>
-void ezDynamicArray<T, A>::operator=(const ezDynamicArrayBase<T>& rhs)
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+void ezSmallArray<T, Size, AllocatorWrapper>::operator=(ezSmallArray<T, Size, AllocatorWrapper>&& rhs) noexcept
 {
-  ezDynamicArrayBase<T>::operator=(rhs);
+  //SUPER::operator=(std::move(rhs));
+  EZ_ASSERT_NOT_IMPLEMENTED;
 }
 
-template <typename T, typename A>
-void ezDynamicArray<T, A>::operator=(const ezArrayPtr<const T>& rhs)
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::SetCount(ezUInt16 uiCount)
 {
-  ezArrayBase<T, ezDynamicArrayBase<T>>::operator=(rhs);
+  SUPER::SetCount(uiCount, AllocatorWrapper::GetAllocator());
 }
 
-template <typename T, typename A>
-void ezDynamicArray<T, A>::operator=(ezDynamicArray<T, A>&& rhs) noexcept
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::SetCount(ezUInt16 uiCount, const T& FillValue)
 {
-  ezDynamicArrayBase<T>::operator=(std::move(rhs));
+  SUPER::SetCount(uiCount, FillValue, AllocatorWrapper::GetAllocator());
 }
 
-template <typename T, typename A>
-void ezDynamicArray<T, A>::operator=(ezDynamicArrayBase<T>&& rhs) noexcept
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::EnsureCount(ezUInt16 uiCount)
 {
-  ezDynamicArrayBase<T>::operator=(std::move(rhs));
+  SUPER::EnsureCount(uiCount, AllocatorWrapper::GetAllocator());
 }
-#endif
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+template <typename> // Second template needed so that the compiler does only instantiate it when called. Otherwise the static_assert would trigger early.
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::SetCountUninitialized(ezUInt16 uiCount)
+{
+  SUPER::SetCountUninitialized(uiCount, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::Insert(const T& value, ezUInt32 uiIndex)
+{
+  SUPER::Insert(value, uiIndex, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::Insert(T&& value, ezUInt32 uiIndex)
+{
+  SUPER::Insert(value, uiIndex, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE T& ezSmallArray<T, Size, AllocatorWrapper>::ExpandAndGetRef()
+{
+  return SUPER::ExpandAndGetRef(AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::PushBack(const T& value)
+{
+  SUPER::PushBack(value, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::PushBack(T&& value)
+{
+  SUPER::PushBack(value, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::PushBackRange(const ezArrayPtr<const T>& range)
+{
+  SUPER::PushBackRange(range, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::Reserve(ezUInt16 uiCapacity)
+{
+  SUPER::Reserve(uiCapacity, AllocatorWrapper::GetAllocator());
+}
+
+template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::Compact()
+{
+  SUPER::Compact(AllocatorWrapper::GetAllocator());
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::iterator begin(ezSmallArrayBase<T, Size>& container)
+{
+  return container.GetData();
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_iterator begin(const ezSmallArrayBase<T, Size>& container)
+{
+  return container.GetData();
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_iterator cbegin(const ezSmallArrayBase<T, Size>& container)
+{
+  return container.GetData();
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::reverse_iterator rbegin(ezSmallArrayBase<T, Size>& container)
+{
+  return typename ezSmallArrayBase<T, Size>::reverse_iterator(container.GetData() + container.GetCount() - 1);
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_reverse_iterator rbegin(const ezSmallArrayBase<T, Size>& container)
+{
+  return typename ezSmallArrayBase<T, Size>::const_reverse_iterator(container.GetData() + container.GetCount() - 1);
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_reverse_iterator crbegin(const ezSmallArrayBase<T, Size>& container)
+{
+  return typename ezSmallArrayBase<T, Size>::const_reverse_iterator(container.GetData() + container.GetCount() - 1);
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::iterator end(ezSmallArrayBase<T, Size>& container)
+{
+  return container.GetData() + container.GetCount();
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_iterator end(const ezSmallArrayBase<T, Size>& container)
+{
+  return container.GetData() + container.GetCount();
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_iterator cend(const ezSmallArrayBase<T, Size>& container)
+{
+  return container.GetData() + container.GetCount();
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::reverse_iterator rend(ezSmallArrayBase<T, Size>& container)
+{
+  return typename ezSmallArrayBase<T, Size>::reverse_iterator(container.GetData() - 1);
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_reverse_iterator rend(const ezSmallArrayBase<T, Size>& container)
+{
+  return typename ezSmallArrayBase<T, Size>::const_reverse_iterator(container.GetData() - 1);
+}
+
+template <typename T, ezUInt16 Size>
+typename ezSmallArrayBase<T, Size>::const_reverse_iterator crend(const ezSmallArrayBase<T, Size>& container)
+{
+  return typename ezSmallArrayBase<T, Size>::const_reverse_iterator(container.GetData() - 1);
+}

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -22,10 +22,17 @@ public:
   ezSmallArrayBase(const ezArrayPtr<const T>& other, ezAllocatorBase* pAllocator);       // [tested]
   ezSmallArrayBase(ezSmallArrayBase<T, Size>&& other, ezAllocatorBase* pAllocator);      // [tested]
 
+  ~ezSmallArrayBase(); // [tested]
+
+  // Can't use regular assignment operators since we need to pass an allocator. Use CopyFrom or MoveFrom methods instead.
   void operator=(const ezSmallArrayBase<T, Size>& rhs) = delete;
   void operator=(ezSmallArrayBase<T, Size>&& rhs) = delete;
 
-  ~ezSmallArrayBase(); // [tested]
+  /// \brief Copies the data from some other array into this one.
+  void CopyFrom(const ezArrayPtr<const T>& other, ezAllocatorBase* pAllocator); // [tested]
+
+  /// \brief Moves the data from some other array into this one.
+  void MoveFrom(ezSmallArrayBase<T, Size>&& other, ezAllocatorBase* pAllocator); // [tested]
 
   /// \brief Conversion to const ezArrayPtr.
   operator ezArrayPtr<const T>() const; // [tested]
@@ -34,9 +41,11 @@ public:
   operator ezArrayPtr<T>(); // [tested]
 
   /// \brief Compares this array to another contiguous array type.
+  bool operator==(const ezSmallArrayBase<T, Size>& rhs) const; // [tested]
   bool operator==(const ezArrayPtr<const T>& rhs) const; // [tested]
 
   /// \brief Compares this array to another contiguous array type.
+  bool operator!=(const ezSmallArrayBase<T, Size>& rhs) const; // [tested]
   bool operator!=(const ezArrayPtr<const T>& rhs) const; // [tested]
 
   /// \brief Returns the element at the given index. Does bounds checks in debug builds.

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -9,7 +9,11 @@
 #  define ezSmallInvalidIndex 0xFFFF
 #endif
 
-/// \brief TODO
+/// \brief Implementation a dynamically growing array with in place storage and small memory overhead.
+///
+/// Best-case performance for the PushBack operation is in O(1) if the ezHybridArray does not need to be expanded.
+/// In the worst case, PushBack is in O(n).
+/// Look-up is guaranteed to always be in O(1).
 template <typename T, ezUInt16 Size>
 class ezSmallArrayBase
 {
@@ -49,10 +53,10 @@ public:
   bool operator!=(const ezArrayPtr<const T>& rhs) const;       // [tested]
 
   /// \brief Returns the element at the given index. Does bounds checks in debug builds.
-  const T& operator[](ezUInt16 uiIndex) const; // [tested]
+  const T& operator[](ezUInt32 uiIndex) const; // [tested]
 
   /// \brief Returns the element at the given index. Does bounds checks in debug builds.
-  T& operator[](ezUInt16 uiIndex); // [tested]
+  T& operator[](ezUInt32 uiIndex); // [tested]
 
   /// \brief Resizes the array to have exactly uiCount elements. Default constructs extra elements if the array is grown.
   void SetCount(ezUInt16 uiCount, ezAllocatorBase* pAllocator); // [tested]
@@ -81,10 +85,10 @@ public:
   bool Contains(const T& value) const; // [tested]
 
   /// \brief Inserts value at index by shifting all following elements.
-  void Insert(const T& value, ezUInt16 uiIndex, ezAllocatorBase* pAllocator); // [tested]
+  void Insert(const T& value, ezUInt32 uiIndex, ezAllocatorBase* pAllocator); // [tested]
 
   /// \brief Inserts value at index by shifting all following elements.
-  void Insert(T&& value, ezUInt16 uiIndex, ezAllocatorBase* pAllocator); // [tested]
+  void Insert(T&& value, ezUInt32 uiIndex, ezAllocatorBase* pAllocator); // [tested]
 
   /// \brief Removes the first occurrence of value and fills the gap by shifting all following elements
   bool RemoveAndCopy(const T& value); // [tested]
@@ -93,16 +97,16 @@ public:
   bool RemoveAndSwap(const T& value); // [tested]
 
   /// \brief Removes the element at index and fills the gap by shifting all following elements
-  void RemoveAtAndCopy(ezUInt16 uiIndex, ezUInt16 uiNumElements = 1); // [tested]
+  void RemoveAtAndCopy(ezUInt32 uiIndex, ezUInt32 uiNumElements = 1); // [tested]
 
   /// \brief Removes the element at index and fills the gap by swapping in the last element
-  void RemoveAtAndSwap(ezUInt16 uiIndex, ezUInt16 uiNumElements = 1); // [tested]
+  void RemoveAtAndSwap(ezUInt32 uiIndex, ezUInt32 uiNumElements = 1); // [tested]
 
   /// \brief Searches for the first occurrence of the given value and returns its index or ezInvalidIndex if not found.
-  ezUInt32 IndexOf(const T& value, ezUInt16 uiStartIndex = 0) const; // [tested]
+  ezUInt32 IndexOf(const T& value, ezUInt32 uiStartIndex = 0) const; // [tested]
 
   /// \brief Searches for the last occurrence of the given value and returns its index or ezInvalidIndex if not found.
-  ezUInt32 LastIndexOf(const T& value, ezUInt16 uiStartIndex = ezSmallInvalidIndex) const; // [tested]
+  ezUInt32 LastIndexOf(const T& value, ezUInt32 uiStartIndex = ezSmallInvalidIndex) const; // [tested]
 
   /// \brief Grows the array by one element and returns a reference to the newly created element.
   T& ExpandAndGetRef(ezAllocatorBase* pAllocator); // [tested]

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -216,14 +216,12 @@ public:
 
   ezSmallArray(const ezSmallArray<T, Size, AllocatorWrapper>& other);
   ezSmallArray(const ezArrayPtr<const T>& other);
-
   ezSmallArray(ezSmallArray<T, Size, AllocatorWrapper>&& other);
 
   ~ezSmallArray();
 
   void operator=(const ezSmallArray<T, Size, AllocatorWrapper>& rhs);
   void operator=(const ezArrayPtr<const T>& rhs);
-
   void operator=(ezSmallArray<T, Size, AllocatorWrapper>&& rhs) noexcept;
 
   void SetCount(ezUInt16 uiCount);                     // [tested]

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -1,0 +1,275 @@
+#pragma once
+
+#include <Foundation/Algorithm/Sorting.h>
+#include <Foundation/Math/Math.h>
+#include <Foundation/Memory/AllocatorWrapper.h>
+#include <Foundation/Types/ArrayPtr.h>
+
+#ifndef ezSmallInvalidIndex
+#  define ezSmallInvalidIndex 0xFFFF
+#endif
+
+/// \brief TODO
+template <typename T, ezUInt16 Size>
+class ezSmallArrayBase
+{
+public:
+  // Only if the stored type is either POD or relocatable the hybrid array itself is also relocatable.
+  EZ_DECLARE_MEM_RELOCATABLE_TYPE_CONDITIONAL(T);
+
+  ezSmallArrayBase();  // [tested]
+  ~ezSmallArrayBase(); // [tested]
+
+  /// \brief Copies the data from some other contiguous array into this one.
+  void operator=(const ezArrayPtr<const T>& rhs); // [tested]
+
+  /// \brief Conversion to const ezArrayPtr.
+  operator ezArrayPtr<const T>() const; // [tested]
+
+  /// \brief Conversion to ezArrayPtr.
+  operator ezArrayPtr<T>(); // [tested]
+
+  /// \brief Compares this array to another contiguous array type.
+  bool operator==(const ezArrayPtr<const T>& rhs) const; // [tested]
+
+  /// \brief Compares this array to another contiguous array type.
+  bool operator!=(const ezArrayPtr<const T>& rhs) const; // [tested]
+
+  /// \brief Returns the element at the given index. Does bounds checks in debug builds.
+  const T& operator[](ezUInt16 uiIndex) const; // [tested]
+
+  /// \brief Returns the element at the given index. Does bounds checks in debug builds.
+  T& operator[](ezUInt16 uiIndex); // [tested]
+
+  /// \brief Resizes the array to have exactly uiCount elements. Default constructs extra elements if the array is grown.
+  void SetCount(ezUInt16 uiCount); // [tested]
+
+  /// \brief Resizes the array to have exactly uiCount elements. Constructs all new elements by copying the FillValue.
+  void SetCount(ezUInt16 uiCount, const T& FillValue); // [tested]
+
+  /// \brief Resizes the array to have exactly uiCount elements. Extra elements might be uninitialized.
+  template <typename = void>                    // Template is used to only conditionally compile this function in when it is actually used.
+  void SetCountUninitialized(ezUInt32 uiCount); // [tested]
+
+  /// \brief Ensures the container has at least \a uiCount elements. Ie. calls SetCount() if the container has fewer elements, does nothing
+  /// otherwise.
+  void EnsureCount(ezUInt32 uiCount); // [tested]
+
+  /// \brief Returns the number of active elements in the array.
+  ezUInt32 GetCount() const; // [tested]
+
+  /// \brief Returns true, if the array does not contain any elements.
+  bool IsEmpty() const; // [tested]
+
+  /// \brief Clears the array.
+  void Clear(); // [tested]
+
+  /// \brief Checks whether the given value can be found in the array. O(n) complexity.
+  bool Contains(const T& value) const; // [tested]
+
+  /// \brief Inserts value at index by shifting all following elements.
+  void Insert(const T& value, ezUInt32 uiIndex); // [tested]
+
+  /// \brief Inserts value at index by shifting all following elements.
+  void Insert(T&& value, ezUInt32 uiIndex); // [tested]
+
+  /// \brief Removes the first occurrence of value and fills the gap by shifting all following elements
+  bool RemoveAndCopy(const T& value); // [tested]
+
+  /// \brief Removes the first occurrence of value and fills the gap by swapping in the last element
+  bool RemoveAndSwap(const T& value); // [tested]
+
+  /// \brief Removes the element at index and fills the gap by shifting all following elements
+  void RemoveAtAndCopy(ezUInt32 uiIndex, ezUInt32 uiNumElements = 1); // [tested]
+
+  /// \brief Removes the element at index and fills the gap by swapping in the last element
+  void RemoveAtAndSwap(ezUInt32 uiIndex, ezUInt32 uiNumElements = 1); // [tested]
+
+  /// \brief Searches for the first occurrence of the given value and returns its index or ezInvalidIndex if not found.
+  ezUInt32 IndexOf(const T& value, ezUInt16 uiStartIndex = 0) const; // [tested]
+
+  /// \brief Searches for the last occurrence of the given value and returns its index or ezInvalidIndex if not found.
+  ezUInt32 LastIndexOf(const T& value, ezUInt16 uiStartIndex = ezSmallInvalidIndex) const; // [tested]
+
+  /// \brief Grows the array by one element and returns a reference to the newly created element.
+  T& ExpandAndGetRef(); // [tested]
+
+  /// \brief Pushes value at the end of the array.
+  void PushBack(const T& value); // [tested]
+
+  /// \brief Pushes value at the end of the array.
+  void PushBack(T&& value); // [tested]
+
+  /// \brief Pushes value at the end of the array. Does NOT ensure capacity.
+  void PushBackUnchecked(const T& value); // [tested]
+
+  /// \brief Pushes value at the end of the array. Does NOT ensure capacity.
+  void PushBackUnchecked(T&& value); // [tested]
+
+  /// \brief Pushes all elements in range at the end of the array. Increases the capacity if necessary.
+  void PushBackRange(const ezArrayPtr<const T>& range); // [tested]
+
+  /// \brief Removes count elements from the end of the array.
+  void PopBack(ezUInt32 uiCountToRemove = 1); // [tested]
+
+  /// \brief Returns the last element of the array.
+  T& PeekBack(); // [tested]
+
+  /// \brief Returns the last element of the array.
+  const T& PeekBack() const; // [tested]
+
+  /// \brief Sort with explicit comparer
+  template <typename Comparer>
+  void Sort(const Comparer& comparer); // [tested]
+
+  /// \brief Sort with default comparer
+  void Sort(); // [tested]
+
+  /// \brief Returns a pointer to the array data, or nullptr if the array is empty.
+  T* GetData();
+
+  /// \brief Returns a pointer to the array data, or nullptr if the array is empty.
+  const T* GetData() const;
+
+  /// \brief Returns an array pointer to the array data, or an empty array pointer if the array is empty.
+  ezArrayPtr<T> GetArrayPtr(); // [tested]
+
+  /// \brief Returns an array pointer to the array data, or an empty array pointer if the array is empty.
+  ezArrayPtr<const T> GetArrayPtr() const; // [tested]
+
+  /// \brief Returns a byte array pointer to the array data, or an empty array pointer if the array is empty.
+  ezArrayPtr<typename ezArrayPtr<T>::ByteType> GetByteArrayPtr(); // [tested]
+
+  /// \brief Returns a byte array pointer to the array data, or an empty array pointer if the array is empty.
+  ezArrayPtr<typename ezArrayPtr<const T>::ByteType> GetByteArrayPtr() const; // [tested]
+
+  /// \brief Expands the array so it can at least store the given capacity.
+  void Reserve(ezUInt16 uiCapacity); // [tested]
+
+  /// \brief Returns the reserved number of elements that the array can hold without reallocating.
+  ezUInt32 GetCapacity() const { return m_uiCapacity; }
+
+  using const_iterator = const T*;
+  using const_reverse_iterator = const_reverse_pointer_iterator<T>;
+  using iterator = T*;
+  using reverse_iterator = reverse_pointer_iterator<T>;
+
+protected:
+  T* GetElementsPtr();
+  const T* GetElementsPtr() const;
+
+  ezUInt32 m_uiUserData = 0;
+
+  ezUInt16 m_uiCount = 0;
+  ezUInt16 m_uiCapacity = Size;
+
+  union
+  {
+    struct : ezAligned<EZ_ALIGNMENT_OF(T)>
+    {
+      ezUInt8 m_StaticData[Size * sizeof(T)];
+    };
+
+    T* m_pElements = nullptr;
+  };
+};
+
+/*
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::iterator begin(ezArrayBase<T, Derived>& container)
+{
+  return container.GetData();
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_iterator begin(const ezArrayBase<T, Derived>& container)
+{
+  return container.GetData();
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_iterator cbegin(const ezArrayBase<T, Derived>& container)
+{
+  return container.GetData();
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::reverse_iterator rbegin(ezArrayBase<T, Derived>& container)
+{
+  return typename ezArrayBase<T, Derived>::reverse_iterator(container.GetData() + container.GetCount() - 1);
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_reverse_iterator rbegin(const ezArrayBase<T, Derived>& container)
+{
+  return typename ezArrayBase<T, Derived>::const_reverse_iterator(container.GetData() + container.GetCount() - 1);
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_reverse_iterator crbegin(const ezArrayBase<T, Derived>& container)
+{
+  return typename ezArrayBase<T, Derived>::const_reverse_iterator(container.GetData() + container.GetCount() - 1);
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::iterator end(ezArrayBase<T, Derived>& container)
+{
+  return container.GetData() + container.GetCount();
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_iterator end(const ezArrayBase<T, Derived>& container)
+{
+  return container.GetData() + container.GetCount();
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_iterator cend(const ezArrayBase<T, Derived>& container)
+{
+  return container.GetData() + container.GetCount();
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::reverse_iterator rend(ezArrayBase<T, Derived>& container)
+{
+  return typename ezArrayBase<T, Derived>::reverse_iterator(container.GetData() - 1);
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_reverse_iterator rend(const ezArrayBase<T, Derived>& container)
+{
+  return typename ezArrayBase<T, Derived>::const_reverse_iterator(container.GetData() - 1);
+}
+
+template <typename T, typename Derived>
+typename ezArrayBase<T, Derived>::const_reverse_iterator crend(const ezArrayBase<T, Derived>& container)
+{
+  return typename ezArrayBase<T, Derived>::const_reverse_iterator(container.GetData() - 1);
+}*/
+
+/// \brief \see ezSmallArrayBase
+template <typename T, ezUInt16 Size, typename AllocatorWrapper = ezDefaultAllocatorWrapper>
+class ezSmallArray : public ezSmallArrayBase<T, Size>
+{
+public:
+  // Only if the stored type is either POD or relocatable the hybrid array itself is also relocatable.
+  EZ_DECLARE_MEM_RELOCATABLE_TYPE_CONDITIONAL(T);
+
+  ezSmallArray();
+
+  ezSmallArray(const ezSmallArray<T, Size, AllocatorWrapper>& other);
+  ezSmallArray(const ezSmallArrayBase<T, Size>& other);
+  ezSmallArray(const ezArrayPtr<const T>& other);
+
+  ezSmallArray(ezSmallArray<T, Size, AllocatorWrapper>&& other);
+  ezSmallArray(ezSmallArrayBase<T, Size>&& other);
+
+  void operator=(const ezSmallArray<T, Size, AllocatorWrapper>& rhs);
+  void operator=(const ezSmallArrayBase<T, Size>& rhs);
+  void operator=(const ezArrayPtr<const T>& rhs);
+
+  void operator=(ezSmallArray<T, Size, AllocatorWrapper>&& rhs) noexcept;
+  void operator=(ezSmallArrayBase<T, Size>&& rhs) noexcept;
+};
+
+#include <Foundation/Containers/Implementation/SmallArray_inl.h>

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -198,7 +198,8 @@ protected:
 
   ezUInt32 m_uiUserData = 0;
 
-  union {
+  union
+  {
     struct : ezAligned<EZ_ALIGNMENT_OF(T)>
     {
       ezUInt8 m_StaticData[Size * sizeof(T)];

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -174,6 +174,12 @@ public:
   using iterator = T*;
   using reverse_iterator = reverse_pointer_iterator<T>;
 
+  template <typename U>
+  const U& GetUserData() const;
+
+  template <typename U>
+  U& GetUserData();
+
 protected:
   enum
   {

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -42,11 +42,11 @@ public:
 
   /// \brief Compares this array to another contiguous array type.
   bool operator==(const ezSmallArrayBase<T, Size>& rhs) const; // [tested]
-  bool operator==(const ezArrayPtr<const T>& rhs) const; // [tested]
+  bool operator==(const ezArrayPtr<const T>& rhs) const;       // [tested]
 
   /// \brief Compares this array to another contiguous array type.
   bool operator!=(const ezSmallArrayBase<T, Size>& rhs) const; // [tested]
-  bool operator!=(const ezArrayPtr<const T>& rhs) const; // [tested]
+  bool operator!=(const ezArrayPtr<const T>& rhs) const;       // [tested]
 
   /// \brief Returns the element at the given index. Does bounds checks in debug builds.
   const T& operator[](ezUInt16 uiIndex) const; // [tested]
@@ -175,10 +175,10 @@ public:
   using reverse_iterator = reverse_pointer_iterator<T>;
 
   template <typename U>
-  const U& GetUserData() const;
+  const U& GetUserData() const; // [tested]
 
   template <typename U>
-  U& GetUserData();
+  U& GetUserData(); // [tested]
 
 protected:
   enum
@@ -191,10 +191,10 @@ protected:
   T* GetElementsPtr();
   const T* GetElementsPtr() const;
 
-  ezUInt32 m_uiUserData = 0;
-
   ezUInt16 m_uiCount = 0;
   ezUInt16 m_uiCapacity = Size;
+
+  ezUInt32 m_uiUserData = 0;
 
   union {
     struct : ezAligned<EZ_ALIGNMENT_OF(T)>

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -5,11 +5,9 @@
 #include <Foundation/Memory/AllocatorWrapper.h>
 #include <Foundation/Types/ArrayPtr.h>
 
-#ifndef ezSmallInvalidIndex
-#  define ezSmallInvalidIndex 0xFFFF
-#endif
+constexpr ezUInt32 ezSmallInvalidIndex = 0xFFFF;
 
-/// \brief Implementation a dynamically growing array with in place storage and small memory overhead.
+/// \brief Implementation of a dynamically growing array with in-place storage and small memory overhead.
 ///
 /// Best-case performance for the PushBack operation is in O(1) if the ezHybridArray does not need to be expanded.
 /// In the worst case, PushBack is in O(n).

--- a/Code/Engine/Foundation/Types/Implementation/TagRegistry.cpp
+++ b/Code/Engine/Foundation/Types/Implementation/TagRegistry.cpp
@@ -37,7 +37,6 @@ const ezTag& ezTagRegistry::RegisterTag(const ezHashedString& TagString)
   ezTag TempTag;
   TempTag.m_uiBlockIndex = uiNextTagIndex / (sizeof(ezTagSetBlockStorage) * 8);
   TempTag.m_uiBitIndex = uiNextTagIndex - (TempTag.m_uiBlockIndex * sizeof(ezTagSetBlockStorage) * 8);
-  TempTag.m_uiPreshiftedBit = (static_cast<ezTagSetBlockStorage>(1) << static_cast<ezTagSetBlockStorage>(TempTag.m_uiBitIndex));
   TempTag.m_TagString = TagString;
 
   // Store the tag

--- a/Code/Engine/Foundation/Types/Implementation/TagSet_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/TagSet_inl.h
@@ -168,7 +168,7 @@ void ezTagSetTemplate<BlockStorageAllocator>::Set(const ezTag& Tag)
     Reallocate(uiNewBlockStart, uiNewBlockIndex);
   }
 
-  ezUInt64& tagBlock = m_TagBlocks[static_cast<ezUInt16>(Tag.m_uiBlockIndex - GetTagBlockStart())];
+  ezUInt64& tagBlock = m_TagBlocks[Tag.m_uiBlockIndex - GetTagBlockStart()];
 
   const ezUInt64 bitMask = EZ_BIT(Tag.m_uiBitIndex);  
   const bool bBitWasSet = ((tagBlock & bitMask) != 0);
@@ -188,7 +188,7 @@ void ezTagSetTemplate<BlockStorageAllocator>::Remove(const ezTag& Tag)
 
   if (IsTagInAllocatedRange(Tag))
   {
-    ezUInt64& tagBlock = m_TagBlocks[static_cast<ezUInt16>(Tag.m_uiBlockIndex - GetTagBlockStart())];
+    ezUInt64& tagBlock = m_TagBlocks[Tag.m_uiBlockIndex - GetTagBlockStart()];
 
     const ezUInt64 bitMask = EZ_BIT(Tag.m_uiBitIndex);
     const bool bBitWasSet = ((tagBlock & bitMask) != 0);
@@ -209,7 +209,7 @@ bool ezTagSetTemplate<BlockStorageAllocator>::IsSet(const ezTag& Tag) const
 
   if (IsTagInAllocatedRange(Tag))
   {
-    return (m_TagBlocks[static_cast<ezUInt16>(Tag.m_uiBlockIndex - GetTagBlockStart())] & EZ_BIT(Tag.m_uiBitIndex)) != 0;
+    return (m_TagBlocks[Tag.m_uiBlockIndex - GetTagBlockStart()] & EZ_BIT(Tag.m_uiBitIndex)) != 0;
   }
   else
   {
@@ -233,8 +233,8 @@ bool ezTagSetTemplate<BlockStorageAllocator>::IsAnySet(const ezTagSetTemplate& O
 
   for (ezUInt32 i = uiMaxBlockStart; i < uiMinBlockEnd; ++i)
   {
-    const ezUInt16 uiThisBlockStorageIndex = static_cast<ezUInt16>(i - GetTagBlockStart());
-    const ezUInt16 uiOtherBlockStorageIndex = static_cast<ezUInt16>(i - OtherSet.GetTagBlockStart());
+    const ezUInt32 uiThisBlockStorageIndex = i - GetTagBlockStart();
+    const ezUInt32 uiOtherBlockStorageIndex = i - OtherSet.GetTagBlockStart();
 
     if ((m_TagBlocks[uiThisBlockStorageIndex] & OtherSet.m_TagBlocks[uiOtherBlockStorageIndex]) != 0)
     {

--- a/Code/Engine/Foundation/Types/Implementation/TagSet_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/TagSet_inl.h
@@ -170,7 +170,7 @@ void ezTagSetTemplate<BlockStorageAllocator>::Set(const ezTag& Tag)
 
   ezUInt64& tagBlock = m_TagBlocks[Tag.m_uiBlockIndex - GetTagBlockStart()];
 
-  const ezUInt64 bitMask = EZ_BIT(Tag.m_uiBitIndex);  
+  const ezUInt64 bitMask = EZ_BIT(Tag.m_uiBitIndex);
   const bool bBitWasSet = ((tagBlock & bitMask) != 0);
 
   tagBlock |= bitMask;
@@ -348,7 +348,7 @@ EZ_ALWAYS_INLINE void ezTagSetTemplate<BlockStorageAllocator>::SetTagBlockStart(
 
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE ezUInt16 ezTagSetTemplate<BlockStorageAllocator>::GetTagCount() const
-      {
+{
   return m_TagBlocks.GetUserData<UserData>().m_uiTagCount;
 }
 

--- a/Code/Engine/Foundation/Types/Implementation/TagSet_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/TagSet_inl.h
@@ -145,7 +145,7 @@ ezTagSetTemplate<BlockStorageAllocator>::ezTagSetTemplate()
 template <typename BlockStorageAllocator>
 bool ezTagSetTemplate<BlockStorageAllocator>::operator==(const ezTagSetTemplate& other) const
 {
-  return m_TagBlocks == other.m_TagBlocks && m_TagBlocks.GetUserData<ezUInt32>() == other.m_TagBlocks.GetUserData<ezUInt32>();
+  return m_TagBlocks == other.m_TagBlocks && m_TagBlocks.template GetUserData<ezUInt32>() == other.m_TagBlocks.template GetUserData<ezUInt32>();
 }
 
 template <typename BlockStorageAllocator>
@@ -331,7 +331,7 @@ void ezTagSetTemplate<BlockStorageAllocator>::Reallocate(ezUInt32 uiNewTagBlockS
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE ezUInt16 ezTagSetTemplate<BlockStorageAllocator>::GetTagBlockStart() const
 {
-  return m_TagBlocks.GetUserData<UserData>().m_uiTagBlockStart;
+  return m_TagBlocks.template GetUserData<UserData>().m_uiTagBlockStart;
 }
 
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
@@ -343,31 +343,31 @@ EZ_ALWAYS_INLINE ezUInt16 ezTagSetTemplate<BlockStorageAllocator>::GetTagBlockEn
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE void ezTagSetTemplate<BlockStorageAllocator>::SetTagBlockStart(ezUInt16 uiTagBlockStart)
 {
-  m_TagBlocks.GetUserData<UserData>().m_uiTagBlockStart = uiTagBlockStart;
+  m_TagBlocks.template GetUserData<UserData>().m_uiTagBlockStart = uiTagBlockStart;
 }
 
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE ezUInt16 ezTagSetTemplate<BlockStorageAllocator>::GetTagCount() const
 {
-  return m_TagBlocks.GetUserData<UserData>().m_uiTagCount;
+  return m_TagBlocks.template GetUserData<UserData>().m_uiTagCount;
 }
 
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE void ezTagSetTemplate<BlockStorageAllocator>::SetTagCount(ezUInt16 uiTagCount)
 {
-  m_TagBlocks.GetUserData<UserData>().m_uiTagCount = uiTagCount;
+  m_TagBlocks.template GetUserData<UserData>().m_uiTagCount = uiTagCount;
 }
 
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE void ezTagSetTemplate<BlockStorageAllocator>::IncreaseTagCount()
 {
-  m_TagBlocks.GetUserData<UserData>().m_uiTagCount++;
+  m_TagBlocks.template GetUserData<UserData>().m_uiTagCount++;
 }
 
 template <typename BlockStorageAllocator /*= ezDefaultAllocatorWrapper*/>
 EZ_ALWAYS_INLINE void ezTagSetTemplate<BlockStorageAllocator>::DecreaseTagCount()
 {
-  m_TagBlocks.GetUserData<UserData>().m_uiTagCount--;
+  m_TagBlocks.template GetUserData<UserData>().m_uiTagCount--;
 }
 
 static ezTypeVersion s_TagSetVersion = 1;

--- a/Code/Engine/Foundation/Types/Tag.h
+++ b/Code/Engine/Foundation/Types/Tag.h
@@ -38,9 +38,6 @@ private:
 
   ezUInt32 m_uiBitIndex;
   ezUInt32 m_uiBlockIndex;
-
-  /// Stores a pre-shifted version of 1u << uiBitIndex
-  ezTagSetBlockStorage m_uiPreshiftedBit;
 };
 
 #include <Foundation/Types/TagSet.h>

--- a/Code/Engine/Foundation/Types/TagSet.h
+++ b/Code/Engine/Foundation/Types/TagSet.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Containers/SmallArray.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/TagRegistry.h>
 
@@ -96,14 +96,26 @@ public:
 private:
   friend class Iterator;
 
-  EZ_ALWAYS_INLINE bool IsTagInAllocatedRange(const ezTag& Tag) const;
+  bool IsTagInAllocatedRange(const ezTag& Tag) const;
 
   void Reallocate(ezUInt32 uiNewTagBlockStart, ezUInt32 uiNewMaxBlockIndex);
 
-  ezHybridArray<ezTagSetBlockStorage, 1, BlockStorageAllocator> m_TagBlocks;
+  ezSmallArray<ezTagSetBlockStorage, 1, BlockStorageAllocator> m_TagBlocks;
 
-  // mutable so IsEmpty and GetNumTagsSet can reset it to 'empty' to prevent reevaluation next time
-  mutable ezUInt32 m_uiTagBlockStart;
+  struct UserData
+  {
+    ezUInt16 m_uiTagBlockStart;
+    ezUInt16 m_uiTagCount;
+  };
+
+  ezUInt16 GetTagBlockStart() const;
+  ezUInt16 GetTagBlockEnd() const;
+  void SetTagBlockStart(ezUInt16 uiTagBlockStart);
+
+  ezUInt16 GetTagCount() const;
+  void SetTagCount(ezUInt16 uiTagCount);
+  void IncreaseTagCount();
+  void DecreaseTagCount();
 };
 
 /// Default tag set, uses ezDefaultAllocatorWrapper for allocations.

--- a/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
@@ -70,25 +70,33 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
 
     EZ_TEST_BOOL(TestTag2.IsValid());
 
-    ezTagSet TagSet;
+    ezTagSet tagSet;
 
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
 
-    TagSet.Set(TestTag2);
+    tagSet.Set(TestTag2);
 
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == true);
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
+    EZ_TEST_INT(tagSet.GetNumTagsSet(), 1);
 
-    TagSet.Set(*TestTag1);
+    tagSet.Set(*TestTag1);
 
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == true);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == true);
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == true);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
+    EZ_TEST_INT(tagSet.GetNumTagsSet(), 2);
 
-    TagSet.Remove(*TestTag1);
+    tagSet.Remove(*TestTag1);
 
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == true);
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
+    EZ_TEST_INT(tagSet.GetNumTagsSet(), 1);
+
+    ezTagSet tagSet2 = tagSet;
+    EZ_TEST_BOOL(tagSet2.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet2.IsSet(TestTag2) == true);
+    EZ_TEST_INT(tagSet2.GetNumTagsSet(), 1);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Many Tags")
@@ -159,6 +167,10 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
     EZ_TEST_BOOL(Non0BlockStartSet.IsSet(RegisteredTags[100]));
     EZ_TEST_BOOL(!Non0BlockStartSet.IsSet(RegisteredTags[0]));
 
+    ezTagSet Non0BlockStartSet2 = Non0BlockStartSet;
+    EZ_TEST_BOOL(Non0BlockStartSet2.IsSet(RegisteredTags[100]));
+    EZ_TEST_INT(Non0BlockStartSet2.GetNumTagsSet(), Non0BlockStartSet.GetNumTagsSet());
+
     // Also test allocating a tag in an earlier block than the first tag allocated in the set
     Non0BlockStartSet.Set(RegisteredTags[0]);
     EZ_TEST_BOOL(Non0BlockStartSet.IsSet(RegisteredTags[100]));
@@ -176,6 +188,8 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
     {
       EZ_TEST_BOOL(!SecondTagSet.IsSet(RegisteredTags[i]));
     }
+
+    EZ_TEST_INT(SecondTagSet.GetNumTagsSet(), BigTagSet.GetNumTagsSet());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsAnySet")
@@ -261,55 +275,55 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
 
     EZ_TEST_BOOL(TestTag2.IsValid());
 
-    ezTagSet TagSet;
+    ezTagSet tagSet;
 
-    EZ_TEST_BOOL(TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == false);
+    EZ_TEST_BOOL(tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
 
-    TagSet.Clear();
+    tagSet.Clear();
 
-    EZ_TEST_BOOL(TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == false);
+    EZ_TEST_BOOL(tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
 
-    TagSet.Set(TestTag2);
+    tagSet.Set(TestTag2);
 
-    EZ_TEST_BOOL(!TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == true);
+    EZ_TEST_BOOL(!tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
 
-    TagSet.Remove(TestTag2);
+    tagSet.Remove(TestTag2);
 
-    EZ_TEST_BOOL(TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == false);
+    EZ_TEST_BOOL(tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
 
-    TagSet.Set(*TestTag1);
-    TagSet.Set(TestTag2);
+    tagSet.Set(*TestTag1);
+    tagSet.Set(TestTag2);
 
-    EZ_TEST_BOOL(!TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == true);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == true);
+    EZ_TEST_BOOL(!tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == true);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
 
-    TagSet.Remove(*TestTag1);
-    TagSet.Remove(TestTag2);
+    tagSet.Remove(*TestTag1);
+    tagSet.Remove(TestTag2);
 
-    EZ_TEST_BOOL(TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == false);
+    EZ_TEST_BOOL(tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
 
-    TagSet.Set(*TestTag1);
-    TagSet.Set(TestTag2);
+    tagSet.Set(*TestTag1);
+    tagSet.Set(TestTag2);
 
-    EZ_TEST_BOOL(!TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == true);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == true);
+    EZ_TEST_BOOL(!tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == true);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
 
-    TagSet.Clear();
+    tagSet.Clear();
 
-    EZ_TEST_BOOL(TagSet.IsEmpty());
-    EZ_TEST_BOOL(TagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(TagSet.IsSet(TestTag2) == false);
+    EZ_TEST_BOOL(tagSet.IsEmpty());
+    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
   }
 }

--- a/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
@@ -5,11 +5,11 @@
 #include <Foundation/Types/TagRegistry.h>
 #include <Foundation/Types/TagSet.h>
 
-#if EZ_ENABLED(EZ_PLATFORM_64BIT)
 static_assert(sizeof(ezTagSet) == 16);
+
+#if EZ_ENABLED(EZ_PLATFORM_64BIT)
 static_assert(sizeof(ezTag) == 16);
 #else
-static_assert(sizeof(ezTagSet) == 12);
 static_assert(sizeof(ezTag) == 12);
 #endif
 

--- a/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
@@ -5,6 +5,14 @@
 #include <Foundation/Types/TagRegistry.h>
 #include <Foundation/Types/TagSet.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_64BIT)
+static_assert(sizeof(ezTagSet) == 16);
+static_assert(sizeof(ezTag) == 16);
+#else
+static_assert(sizeof(ezTagSet) == 12);
+static_assert(sizeof(ezTag) == 12);
+#endif
+
 EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
 {
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Basic Tag Tests")

--- a/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
@@ -768,7 +768,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
       list.PushBack(DynamicArrayTestDetail::Dummy(rand()));
     }
     list.SetCount(32);
-    list.SetCount(4);
+    list.SetCount(16);
 
     list.Compact();
   }

--- a/Code/UnitTests/FoundationTest/Containers/HybridArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HybridArrayTest.cpp
@@ -654,7 +654,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
   {
     ezHybridArray<ezInt32, 16> a;
 
-    for (ezInt32 i = 0; i < 1000; ++i)
+    for (ezInt32 i = 0; i < 1008; ++i)
     {
       a.PushBack(i);
       EZ_TEST_INT(a.GetCount(), i + 1);
@@ -664,7 +664,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
     a.Compact();
     EZ_TEST_BOOL(a.GetHeapMemoryUsage() > 0);
 
-    for (ezInt32 i = 0; i < 1000; ++i)
+    for (ezInt32 i = 0; i < 1008; ++i)
       EZ_TEST_INT(a[i], i);
 
     // this tests whether the static array is reused properly (not the case anymore with new implementation that derives from ezDynamicArray)

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -1,0 +1,1157 @@
+#include <FoundationTestPCH.h>
+
+#include <Foundation/Containers/SmallArray.h>
+#include <Foundation/Memory/CommonAllocators.h>
+#include <Foundation/Strings/String.h>
+
+namespace SmallArrayTestDetail
+{
+
+  class Dummy
+  {
+  public:
+    int a;
+    std::string s;
+
+    Dummy()
+      : a(0)
+      , s("Test")
+    {
+    }
+    Dummy(int a)
+      : a(a)
+      , s("Test")
+    {
+    }
+    Dummy(const Dummy& other)
+      : a(other.a)
+      , s(other.s)
+    {
+    }
+    ~Dummy() {}
+
+    Dummy& operator=(const Dummy& other)
+    {
+      a = other.a;
+      s = other.s;
+      return *this;
+    }
+
+    bool operator<=(const Dummy& dummy) const { return a <= dummy.a; }
+    bool operator>=(const Dummy& dummy) const { return a >= dummy.a; }
+    bool operator>(const Dummy& dummy) const { return a > dummy.a; }
+    bool operator<(const Dummy& dummy) const { return a < dummy.a; }
+    bool operator==(const Dummy& dummy) const { return a == dummy.a; }
+  };
+
+  class NonMovableClass
+  {
+  public:
+    NonMovableClass(int val)
+    {
+      m_val = val;
+      m_pVal = &m_val;
+    }
+
+    NonMovableClass(const NonMovableClass& other)
+    {
+      m_val = other.m_val;
+      m_pVal = &m_val;
+    }
+
+    void operator=(const NonMovableClass& other) { m_val = other.m_val; }
+
+    int m_val = 0;
+    int* m_pVal = nullptr;
+  };
+
+  template <typename T>
+  static ezHybridArray<T, 16> CreateArray(ezUInt32 uiSize, ezUInt32 uiOffset)
+  {
+    ezHybridArray<T, 16> a;
+    a.SetCount(uiSize);
+
+    for (ezUInt32 i = 0; i < uiSize; ++i)
+      a[i] = T(uiOffset + i);
+
+    return a;
+  }
+
+  struct ExternalCounter
+  {
+    EZ_DECLARE_MEM_RELOCATABLE_TYPE();
+
+    ExternalCounter() = default;
+
+    ExternalCounter(int& counter)
+      : m_counter{&counter}
+    {
+    }
+
+    ~ExternalCounter()
+    {
+      if (m_counter)
+        (*m_counter)++;
+    }
+
+    int* m_counter{};
+  };
+} // namespace HybridArrayTestDetail
+
+static void TakesDynamicArray(ezDynamicArray<int>& ar, int num, int start);
+
+#if EZ_ENABLED(EZ_PLATFORM_64BIT)
+static_assert(sizeof(ezSmallArray<ezInt32, 1>) == 16);
+#else
+static_assert(sizeof(ezSmallArray<ezInt32, 1>) == 12);
+#endif
+
+static_assert(ezGetTypeClass<ezSmallArray<ezInt32, 1>>::value == ezTypeIsMemRelocatable::value);
+static_assert(ezGetTypeClass<ezSmallArray<SmallArrayTestDetail::NonMovableClass, 1>>::value == ezTypeIsClass::value);
+
+EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
+{
+  ezConstructionCounter::Reset();
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor")
+  {
+    ezSmallArray<ezInt32, 16> a1;
+    ezSmallArray<ezConstructionCounter, 16> a2;
+
+    EZ_TEST_BOOL(a1.GetCount() == 0);
+    EZ_TEST_BOOL(a2.GetCount() == 0);
+    EZ_TEST_BOOL(a1.IsEmpty());
+    EZ_TEST_BOOL(a2.IsEmpty());
+  }
+
+  #if 0
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Copy Constructor")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    EZ_TEST_BOOL(a1.GetHeapMemoryUsage() == 0);
+
+    for (ezInt32 i = 0; i < 32; ++i)
+    {
+      a1.PushBack(rand() % 100000);
+
+      if (i < 16)
+      {
+        EZ_TEST_BOOL(a1.GetHeapMemoryUsage() == 0);
+      }
+      else
+      {
+        EZ_TEST_BOOL(a1.GetHeapMemoryUsage() >= i * sizeof(ezInt32));
+      }
+    }
+
+    ezHybridArray<ezInt32, 16> a2 = a1;
+    ezHybridArray<ezInt32, 16> a3(a1);
+
+    EZ_TEST_BOOL(a1 == a2);
+    EZ_TEST_BOOL(a1 == a3);
+    EZ_TEST_BOOL(a2 == a3);
+
+    ezInt32 test[] = {1, 2, 3, 4};
+    ezArrayPtr<ezInt32> aptr(test);
+
+    ezHybridArray<ezInt32, 16> a4(aptr);
+
+    EZ_TEST_BOOL(a4 == aptr);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Move Constructor / Operator")
+  {
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+    {
+      // move constructor external storage
+      ezHybridArray<ezConstructionCounter, 16> a1(HybridArrayTestDetail::CreateArray<ezConstructionCounter>(100, 20));
+
+      EZ_TEST_INT(a1.GetCount(), 100);
+      for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+        EZ_TEST_INT(a1[i].m_iData, 20 + i);
+
+      // move operator external storage
+      a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounter>(200, 50);
+
+      EZ_TEST_INT(a1.GetCount(), 200);
+      for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+        EZ_TEST_INT(a1[i].m_iData, 50 + i);
+    }
+
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+    ezConstructionCounter::Reset();
+
+    {
+      // move constructor internal storage
+      ezHybridArray<ezConstructionCounter, 16> a2(HybridArrayTestDetail::CreateArray<ezConstructionCounter>(10, 30));
+
+      EZ_TEST_INT(a2.GetCount(), 10);
+      for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
+        EZ_TEST_INT(a2[i].m_iData, 30 + i);
+
+      // move operator internal storage
+      a2 = HybridArrayTestDetail::CreateArray<ezConstructionCounter>(8, 70);
+
+      EZ_TEST_INT(a2.GetCount(), 8);
+      for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
+        EZ_TEST_INT(a2[i].m_iData, 70 + i);
+    }
+
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+    ezConstructionCounter::Reset();
+
+    ezConstructionCounterRelocatable::Reset();
+    {
+      // move constructor external storage relocatable
+      ezHybridArray<ezConstructionCounterRelocatable, 16> a1(HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(100, 20));
+
+      EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(100, 0));
+
+      EZ_TEST_INT(a1.GetCount(), 100);
+      for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+        EZ_TEST_INT(a1[i].m_iData, 20 + i);
+
+      // move operator external storage
+      a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(200, 50);
+      EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(200, 100));
+
+      EZ_TEST_INT(a1.GetCount(), 200);
+      for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+        EZ_TEST_INT(a1[i].m_iData, 50 + i);
+    }
+
+    EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
+    ezConstructionCounterRelocatable::Reset();
+
+    {
+      // move constructor internal storage relocatable
+      ezHybridArray<ezConstructionCounterRelocatable, 16> a2(HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(10, 30));
+      EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(10, 0));
+
+      EZ_TEST_INT(a2.GetCount(), 10);
+      for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
+        EZ_TEST_INT(a2[i].m_iData, 30 + i);
+
+      // move operator internal storage
+      a2 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
+      EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(8, 10));
+
+      EZ_TEST_INT(a2.GetCount(), 8);
+      for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
+        EZ_TEST_INT(a2[i].m_iData, 70 + i);
+    }
+
+    EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
+    ezConstructionCounterRelocatable::Reset();
+
+    {
+      // move constructor with different allocators
+      ezProxyAllocator proxyAllocator("test allocator", ezFoundation::GetDefaultAllocator());
+      {
+        ezHybridArray<ezConstructionCounterRelocatable, 16> a1(&proxyAllocator);
+
+        a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
+        EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(8, 0));
+        EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
+
+        EZ_TEST_INT(a1.GetCount(), 8);
+        for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+          EZ_TEST_INT(a1[i].m_iData, 70 + i);
+
+        a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(32, 100);
+        EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(32, 8));
+        EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
+
+        EZ_TEST_INT(a1.GetCount(), 32);
+        for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+          EZ_TEST_INT(a1[i].m_iData, 100 + i);
+      }
+
+      EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
+      ezConstructionCounterRelocatable::Reset();
+
+      auto allocatorStats = proxyAllocator.GetStats();
+      EZ_TEST_BOOL(allocatorStats.m_uiNumAllocations == allocatorStats.m_uiNumDeallocations); // check for memory leak?
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Convert to ArrayPtr")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 100; ++i)
+    {
+      ezInt32 r = rand() % 100000;
+      a1.PushBack(r);
+    }
+
+    ezArrayPtr<ezInt32> ap = a1;
+
+    EZ_TEST_BOOL(ap.GetCount() == a1.GetCount());
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator =")
+  {
+    ezHybridArray<ezInt32, 16> a1, a2;
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      a1.PushBack(i);
+
+    a2 = a1;
+
+    EZ_TEST_BOOL(a1 == a2);
+
+    ezArrayPtr<ezInt32> arrayPtr(a1);
+
+    a2 = arrayPtr;
+
+    EZ_TEST_BOOL(a2 == arrayPtr);
+  }
+
+  #endif
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator == / !=")
+  {
+    ezSmallArray<ezInt32, 16> a1, a2;
+
+    EZ_TEST_BOOL(a1 == a1);
+    EZ_TEST_BOOL(a2 == a2);
+    EZ_TEST_BOOL(a1 == a2);
+
+    EZ_TEST_BOOL((a1 != a1) == false);
+    EZ_TEST_BOOL((a2 != a2) == false);
+    EZ_TEST_BOOL((a1 != a2) == false);
+
+    for (ezInt32 i = 0; i < 100; ++i)
+    {
+      ezInt32 r = rand() % 100000;
+      a1.PushBack(r);
+      a2.PushBack(r);
+    }
+
+    EZ_TEST_BOOL(a1 == a1);
+    EZ_TEST_BOOL(a2 == a2);
+    EZ_TEST_BOOL(a1 == a2);
+
+    EZ_TEST_BOOL((a1 != a2) == false);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Index operator")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+    a1.SetCountUninitialized(100);
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      a1[i] = i;
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      EZ_TEST_INT(a1[i], i);
+
+    const ezHybridArray<ezInt32, 16> ca1 = a1;
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      EZ_TEST_INT(ca1[i], i);
+  }
+
+  #if 0
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetCount / GetCount / IsEmpty")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    EZ_TEST_BOOL(a1.IsEmpty());
+
+    for (ezInt32 i = 0; i < 128; ++i)
+    {
+      a1.SetCount(i + 1);
+      EZ_TEST_INT(a1[i], 0);
+      a1[i] = i;
+
+      EZ_TEST_INT(a1.GetCount(), i + 1);
+      EZ_TEST_BOOL(!a1.IsEmpty());
+    }
+
+    for (ezInt32 i = 0; i < 128; ++i)
+      EZ_TEST_INT(a1[i], i);
+
+    for (ezInt32 i = 128; i >= 0; --i)
+    {
+      a1.SetCount(i);
+
+      EZ_TEST_INT(a1.GetCount(), i);
+
+      for (ezInt32 i2 = 0; i2 < i; ++i2)
+        EZ_TEST_INT(a1[i2], i2);
+    }
+
+    EZ_TEST_BOOL(a1.IsEmpty());
+
+    a1.SetCountUninitialized(32);
+    EZ_TEST_INT(a1.GetCount(), 32);
+    a1[31] = 45;
+    EZ_TEST_INT(a1[31], 45);
+
+    // Test SetCount with fill value
+    {
+      ezHybridArray<ezInt32, 2> a2;
+      a2.PushBack(5);
+      a2.PushBack(3);
+      a2.SetCount(10, 42);
+
+      if (EZ_TEST_INT(a2.GetCount(), 10).Succeeded())
+      {
+        EZ_TEST_INT(a2[0], 5);
+        EZ_TEST_INT(a2[1], 3);
+        EZ_TEST_INT(a2[4], 42);
+        EZ_TEST_INT(a2[9], 42);
+      }
+
+      a2.Clear();
+      a2.PushBack(1);
+      a2.PushBack(2);
+      a2.PushBack(3);
+
+      a2.SetCount(2, 10);
+      if (EZ_TEST_INT(a2.GetCount(), 2).Succeeded())
+      {
+        EZ_TEST_INT(a2[0], 1);
+        EZ_TEST_INT(a2[1], 2);
+      }
+    }
+  }
+
+  // Test SetCount with fill value
+  {
+    ezHybridArray<ezInt32, 2> a2;
+    a2.PushBack(5);
+    a2.PushBack(3);
+    a2.SetCount(10, 42);
+
+    if (EZ_TEST_INT(a2.GetCount(), 10).Succeeded())
+    {
+      EZ_TEST_INT(a2[0], 5);
+      EZ_TEST_INT(a2[1], 3);
+      EZ_TEST_INT(a2[4], 42);
+      EZ_TEST_INT(a2[9], 42);
+    }
+
+    a2.Clear();
+    a2.PushBack(1);
+    a2.PushBack(2);
+    a2.PushBack(3);
+
+    a2.SetCount(2, 10);
+    if (EZ_TEST_INT(a2.GetCount(), 2).Succeeded())
+    {
+      EZ_TEST_INT(a2[0], 1);
+      EZ_TEST_INT(a2[1], 2);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Clear")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+    a1.Clear();
+
+    a1.PushBack(3);
+    a1.Clear();
+
+    EZ_TEST_BOOL(a1.IsEmpty());
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Contains / IndexOf / LastIndexOf")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = -100; i < 100; ++i)
+      EZ_TEST_BOOL(!a1.Contains(i));
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      a1.PushBack(i);
+
+    for (ezInt32 i = 0; i < 100; ++i)
+    {
+      EZ_TEST_BOOL(a1.Contains(i));
+      EZ_TEST_INT(a1.IndexOf(i), i);
+      EZ_TEST_INT(a1.LastIndexOf(i), i);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Insert")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    // always inserts at the front
+    for (ezInt32 i = 0; i < 100; ++i)
+      a1.Insert(i, 0);
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      EZ_TEST_INT(a1[i], 99 - i);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAndCopy")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 100; ++i)
+      a1.PushBack(i % 2);
+
+    while (a1.RemoveAndCopy(1))
+    {
+    }
+
+    EZ_TEST_BOOL(a1.GetCount() == 50);
+
+    for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
+      EZ_TEST_INT(a1[i], 0);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAndSwap")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 10; ++i)
+      a1.Insert(i, i); // inserts at the end
+
+    a1.RemoveAndSwap(9);
+    a1.RemoveAndSwap(7);
+    a1.RemoveAndSwap(5);
+    a1.RemoveAndSwap(3);
+    a1.RemoveAndSwap(1);
+
+    EZ_TEST_INT(a1.GetCount(), 5);
+
+    for (ezInt32 i = 0; i < 5; ++i)
+      EZ_TEST_BOOL(ezMath::IsEven(a1[i]));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAtAndCopy")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 10; ++i)
+      a1.Insert(i, i); // inserts at the end
+
+    a1.RemoveAtAndCopy(9);
+    a1.RemoveAtAndCopy(7);
+    a1.RemoveAtAndCopy(5);
+    a1.RemoveAtAndCopy(3);
+    a1.RemoveAtAndCopy(1);
+
+    EZ_TEST_INT(a1.GetCount(), 5);
+
+    for (ezInt32 i = 0; i < 5; ++i)
+      EZ_TEST_INT(a1[i], i * 2);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAtAndSwap")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 10; ++i)
+      a1.Insert(i, i); // inserts at the end
+
+    a1.RemoveAtAndSwap(9);
+    a1.RemoveAtAndSwap(7);
+    a1.RemoveAtAndSwap(5);
+    a1.RemoveAtAndSwap(3);
+    a1.RemoveAtAndSwap(1);
+
+    EZ_TEST_INT(a1.GetCount(), 5);
+
+    for (ezInt32 i = 0; i < 5; ++i)
+      EZ_TEST_BOOL(ezMath::IsEven(a1[i]));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "PushBack / PopBack / PeekBack")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 10; ++i)
+    {
+      a1.PushBack(i);
+      EZ_TEST_INT(a1.PeekBack(), i);
+    }
+
+    for (ezInt32 i = 9; i >= 0; --i)
+    {
+      EZ_TEST_INT(a1.PeekBack(), i);
+      a1.PopBack();
+    }
+
+    a1.PushBack(23);
+    a1.PushBack(2);
+    a1.PushBack(3);
+
+    a1.PopBack(2);
+    EZ_TEST_INT(a1.PeekBack(), 23);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ExpandAndGetRef")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 20; ++i)
+    {
+      ezInt32& intRef = a1.ExpandAndGetRef();
+      intRef = i * 5;
+    }
+
+
+    EZ_TEST_BOOL(a1.GetCount() == 20);
+
+    for (ezInt32 i = 0; i < 20; ++i)
+    {
+      EZ_TEST_INT(a1[i], i * 5);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Construction / Destruction")
+  {
+    {
+      EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+      ezHybridArray<ezConstructionCounter, 16> a1;
+      ezHybridArray<ezConstructionCounter, 16> a2;
+
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
+      EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+      a1.PushBack(ezConstructionCounter(1));
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
+
+      a1.Insert(ezConstructionCounter(2), 0);
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
+
+      a2 = a1;
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 0)); // two copies
+
+      a1.Clear();
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 2));
+
+      a1.PushBack(ezConstructionCounter(3));
+      a1.PushBack(ezConstructionCounter(4));
+      a1.PushBack(ezConstructionCounter(5));
+      a1.PushBack(ezConstructionCounter(6));
+
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(8, 4)); // four temporaries
+
+      a1.RemoveAndCopy(ezConstructionCounter(3));
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(1, 2)); // one temporary, one destroyed
+
+      a1.RemoveAndCopy(ezConstructionCounter(3));
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(1, 1)); // one temporary, none destroyed
+
+      a1.RemoveAtAndCopy(0);
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 1)); // one destroyed
+
+      a1.RemoveAtAndSwap(0);
+      EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 1)); // one destroyed
+    }
+
+    // tests the destructor of a2 and a1
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Compact")
+  {
+    ezHybridArray<ezInt32, 16> a;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+    {
+      a.PushBack(i);
+      EZ_TEST_INT(a.GetCount(), i + 1);
+    }
+
+    EZ_TEST_BOOL(a.GetHeapMemoryUsage() > 0);
+    a.Compact();
+    EZ_TEST_BOOL(a.GetHeapMemoryUsage() > 0);
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      EZ_TEST_INT(a[i], i);
+
+    // this tests whether the static array is reused properly (not the case anymore with new implementation that derives from ezDynamicArray)
+    a.SetCount(15);
+    a.Compact();
+    // EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
+    EZ_TEST_BOOL(a.GetHeapMemoryUsage() > 0);
+
+    for (ezInt32 i = 0; i < 15; ++i)
+      EZ_TEST_INT(a[i], i);
+
+    a.Clear();
+    a.Compact();
+    EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SortingPrimitives")
+  {
+    ezHybridArray<ezUInt32, 16> list;
+
+    list.Sort();
+
+    for (ezUInt32 i = 0; i < 45; i++)
+    {
+      list.PushBack(std::rand());
+    }
+    list.Sort();
+
+    ezUInt32 last = 0;
+    for (ezUInt32 i = 0; i < list.GetCount(); i++)
+    {
+      EZ_TEST_BOOL(last <= list[i]);
+      last = list[i];
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SortingObjects")
+  {
+    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    list.Reserve(128);
+
+    for (ezUInt32 i = 0; i < 100; i++)
+    {
+      list.PushBack(HybridArrayTestDetail::Dummy(rand()));
+    }
+    list.Sort();
+
+    HybridArrayTestDetail::Dummy last = 0;
+    for (ezUInt32 i = 0; i < list.GetCount(); i++)
+    {
+      EZ_TEST_BOOL(last <= list[i]);
+      last = list[i];
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Various")
+  {
+    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    list.PushBack(1);
+    list.PushBack(2);
+    list.PushBack(3);
+    list.Insert(4, 3);
+    list.Insert(0, 1);
+    list.Insert(0, 5);
+
+    EZ_TEST_BOOL(list[0].a == 1);
+    EZ_TEST_BOOL(list[1].a == 0);
+    EZ_TEST_BOOL(list[2].a == 2);
+    EZ_TEST_BOOL(list[3].a == 3);
+    EZ_TEST_BOOL(list[4].a == 4);
+    EZ_TEST_BOOL(list[5].a == 0);
+    EZ_TEST_BOOL(list.GetCount() == 6);
+
+    list.RemoveAtAndCopy(3);
+    list.RemoveAtAndSwap(2);
+
+    EZ_TEST_BOOL(list[0].a == 1);
+    EZ_TEST_BOOL(list[1].a == 0);
+    EZ_TEST_BOOL(list[2].a == 0);
+    EZ_TEST_BOOL(list[3].a == 4);
+    EZ_TEST_BOOL(list.GetCount() == 4);
+    EZ_TEST_BOOL(list.IndexOf(0) == 1);
+    EZ_TEST_BOOL(list.LastIndexOf(0) == 2);
+
+    list.PushBack(5);
+    EZ_TEST_BOOL(list[4].a == 5);
+    HybridArrayTestDetail::Dummy d = list.PeekBack();
+    list.PopBack();
+    EZ_TEST_BOOL(d.a == 5);
+    EZ_TEST_BOOL(list.GetCount() == 4);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Assignment")
+  {
+    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    for (int i = 0; i < 16; i++)
+    {
+      list.PushBack(HybridArrayTestDetail::Dummy(rand()));
+    }
+
+    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list2;
+    for (int i = 0; i < 8; i++)
+    {
+      list2.PushBack(HybridArrayTestDetail::Dummy(rand()));
+    }
+
+    list = list2;
+    EZ_TEST_BOOL(list.GetCount() == list2.GetCount());
+
+    list2.Clear();
+    EZ_TEST_BOOL(list2.GetCount() == 0);
+
+    list2 = list;
+    EZ_TEST_BOOL(list.PeekBack() == list2.PeekBack());
+    EZ_TEST_BOOL(list == list2);
+
+    for (int i = 0; i < 16; i++)
+    {
+      list2.PushBack(HybridArrayTestDetail::Dummy(rand()));
+    }
+
+    list = list2;
+    EZ_TEST_BOOL(list.PeekBack() == list2.PeekBack());
+    EZ_TEST_BOOL(list == list2);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Count")
+  {
+    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    for (int i = 0; i < 16; i++)
+    {
+      list.PushBack(HybridArrayTestDetail::Dummy(rand()));
+    }
+    list.SetCount(32);
+    list.SetCount(4);
+
+    list.Compact();
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Reserve")
+  {
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+    ezHybridArray<ezConstructionCounter, 16> a;
+
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+    a.Reserve(100);
+
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+    a.SetCount(10);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(10, 0));
+
+    a.Reserve(100);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0));
+
+    a.SetCount(100);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(90, 0));
+
+    a.Reserve(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 100)); // had to copy some elements over
+
+    a.SetCount(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 0));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Compact")
+  {
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+    ezHybridArray<ezConstructionCounter, 16> a;
+
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
+    EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
+
+    a.SetCount(100);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 0));
+
+    a.SetCount(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(200, 100));
+
+    a.SetCount(10);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 190));
+
+    // no reallocations and copying, if the memory is already available
+    a.SetCount(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(190, 0));
+
+    a.SetCount(10);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 190));
+
+    // now we remove the spare memory
+    a.Compact();
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(10, 10));
+
+    // this time the array needs to be relocated, and thus the already present elements need to be copied
+    a.SetCount(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(200, 10));
+
+    // this does not deallocate memory
+    a.Clear();
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 200));
+
+    a.SetCount(100);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 0));
+
+    // therefore no object relocation
+    a.SetCount(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 0));
+
+    a.Clear();
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 200));
+
+    // this will deallocate ALL memory
+    a.Compact();
+
+    a.SetCount(100);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 0));
+
+    // this time objects need to be relocated
+    a.SetCount(200);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(200, 100));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "STL Iterator")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      a1.PushBack(1000 - i - 1);
+
+    // STL sort
+    std::sort(begin(a1), end(a1));
+
+    for (ezInt32 i = 1; i < 1000; ++i)
+    {
+      EZ_TEST_BOOL(a1[i - 1] <= a1[i]);
+    }
+
+    // foreach
+    ezUInt32 prev = 0;
+    for (ezUInt32 val : a1)
+    {
+      EZ_TEST_BOOL(prev <= val);
+      prev = val;
+    }
+
+    // const array
+    const ezHybridArray<ezInt32, 16>& a2 = a1;
+
+    // STL lower bound
+    auto lb = std::lower_bound(begin(a2), end(a2), 400);
+    EZ_TEST_BOOL(*lb == a2[400]);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "STL Reverse Iterator")
+  {
+    ezHybridArray<ezInt32, 16> a1;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      a1.PushBack(1000 - i - 1);
+
+    // STL sort
+    std::sort(rbegin(a1), rend(a1));
+
+    for (ezInt32 i = 1; i < 1000; ++i)
+    {
+      EZ_TEST_BOOL(a1[i - 1] >= a1[i]);
+    }
+
+    // foreach
+    ezUInt32 prev = 1000;
+    for (ezUInt32 val : a1)
+    {
+      EZ_TEST_BOOL(prev >= val);
+      prev = val;
+    }
+
+    // const array
+    const ezHybridArray<ezInt32, 16>& a2 = a1;
+
+    // STL lower bound
+    auto lb = std::lower_bound(rbegin(a2), rend(a2), 400);
+    EZ_TEST_BOOL(*lb == a2[1000 - 400 - 1]);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Swap")
+  {
+
+    ezInt32 content1[] = {1, 2, 3, 4};
+    ezInt32 content2[] = {5, 6, 7, 8, 9};
+    ezInt32 contentHeap1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
+    ezInt32 contentHeap2[] = {11, 12, 13, 14, 15, 16, 17, 18, 19, 110, 111, 112, 113};
+
+    {
+      // local <-> local
+      ezHybridArray<ezInt32, 8> a1;
+      ezHybridArray<ezInt32, 16> a2;
+      a1 = ezMakeArrayPtr(content1);
+      a2 = ezMakeArrayPtr(content2);
+
+      ezInt32* a1Ptr = a1.GetData();
+      ezInt32* a2Ptr = a2.GetData();
+
+      a1.Swap(a2);
+
+      // Because the data points to the internal storage the pointers shouldn't change when swapping
+      EZ_TEST_BOOL(a1Ptr == a1.GetData());
+      EZ_TEST_BOOL(a2Ptr == a2.GetData());
+
+      // The data however should be swapped
+      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(content2));
+      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(content1));
+
+      EZ_TEST_INT(a1.GetCapacity(), 8);
+      EZ_TEST_INT(a2.GetCapacity(), 16);
+    }
+
+    {
+      // local <-> heap
+      ezHybridArray<ezInt32, 8> a1;
+      ezDynamicArray<ezInt32> a2;
+      a1 = ezMakeArrayPtr(content1);
+      a2 = ezMakeArrayPtr(contentHeap1);
+      ezInt32* a1Ptr = a1.GetData();
+      ezInt32* a2Ptr = a2.GetData();
+      a1.Swap(a2);
+      EZ_TEST_BOOL(a1Ptr != a1.GetData());
+      EZ_TEST_BOOL(a2Ptr != a2.GetData());
+      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(contentHeap1));
+      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(content1));
+
+      EZ_TEST_INT(a1.GetCapacity(), 16);
+      EZ_TEST_INT(a2.GetCapacity(), 16);
+    }
+
+    {
+      // heap <-> local
+      ezHybridArray<ezInt32, 8> a1;
+      ezHybridArray<ezInt32, 7> a2;
+      a1 = ezMakeArrayPtr(content1);
+      a2 = ezMakeArrayPtr(contentHeap1);
+      ezInt32* a1Ptr = a1.GetData();
+      ezInt32* a2Ptr = a2.GetData();
+      a2.Swap(a1); // Swap is opposite direction as before
+      EZ_TEST_BOOL(a1Ptr != a1.GetData());
+      EZ_TEST_BOOL(a2Ptr != a2.GetData());
+      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(contentHeap1));
+      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(content1));
+
+      EZ_TEST_INT(a1.GetCapacity(), 16);
+      EZ_TEST_INT(a2.GetCapacity(), 16);
+    }
+
+    {
+      // heap <-> heap
+      ezDynamicArray<ezInt32> a1;
+      ezHybridArray<ezInt32, 8> a2;
+      a1 = ezMakeArrayPtr(contentHeap1);
+      a2 = ezMakeArrayPtr(contentHeap2);
+      ezInt32* a1Ptr = a1.GetData();
+      ezInt32* a2Ptr = a2.GetData();
+      a2.Swap(a1);
+      EZ_TEST_BOOL(a1Ptr != a1.GetData());
+      EZ_TEST_BOOL(a2Ptr != a2.GetData());
+      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(contentHeap2));
+      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(contentHeap1));
+
+      EZ_TEST_INT(a1.GetCapacity(), 16);
+      EZ_TEST_INT(a2.GetCapacity(), 16);
+    }
+
+    {
+      // empty <-> local
+      ezHybridArray<ezInt32, 8> a1, a2;
+      a2 = ezMakeArrayPtr(content2);
+      a1.Swap(a2);
+      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(content2));
+      EZ_TEST_BOOL(a2.IsEmpty());
+
+      EZ_TEST_INT(a1.GetCapacity(), 8);
+      EZ_TEST_INT(a2.GetCapacity(), 8);
+    }
+
+    {
+      // empty <-> empty
+      ezHybridArray<ezInt32, 8> a1, a2;
+      a1.Swap(a2);
+      EZ_TEST_BOOL(a1.IsEmpty());
+      EZ_TEST_BOOL(a2.IsEmpty());
+
+      EZ_TEST_INT(a1.GetCapacity(), 8);
+      EZ_TEST_INT(a2.GetCapacity(), 8);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Move")
+  {
+    int counter = 0;
+    {
+      ezHybridArray<HybridArrayTestDetail::ExternalCounter, 2> a, b;
+      EZ_TEST_BOOL(counter == 0);
+
+      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      EZ_TEST_BOOL(counter == 1);
+
+      b = std::move(a);
+      EZ_TEST_BOOL(counter == 1);
+    }
+    EZ_TEST_BOOL(counter == 2);
+
+    counter = 0;
+    {
+      ezHybridArray<HybridArrayTestDetail::ExternalCounter, 2> a, b;
+      EZ_TEST_BOOL(counter == 0);
+
+      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      EZ_TEST_BOOL(counter == 4);
+
+      b = std::move(a);
+      EZ_TEST_BOOL(counter == 4);
+    }
+    EZ_TEST_BOOL(counter == 8);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Use ezHybridArray with ezDynamicArray")
+  {
+    ezHybridArray<int, 16> a;
+
+    TakesDynamicArray(a, 4, a.GetCount());
+    EZ_TEST_INT(a.GetCount(), 4);
+    EZ_TEST_INT(a.GetCapacity(), 16);
+
+    for (int i = 0; i < (int)a.GetCount(); ++i)
+    {
+      EZ_TEST_INT(a[i], i);
+    }
+
+    TakesDynamicArray(a, 12, a.GetCount());
+    EZ_TEST_INT(a.GetCount(), 16);
+    EZ_TEST_INT(a.GetCapacity(), 16);
+
+    for (int i = 0; i < (int)a.GetCount(); ++i)
+    {
+      EZ_TEST_INT(a[i], i);
+    }
+
+    TakesDynamicArray(a, 8, a.GetCount());
+    EZ_TEST_INT(a.GetCount(), 24);
+    EZ_TEST_INT(a.GetCapacity(), 32);
+
+    for (int i = 0; i < (int)a.GetCount(); ++i)
+    {
+      EZ_TEST_INT(a[i], i);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Nested arrays")
+  {
+    ezDynamicArray<ezHybridArray<HybridArrayTestDetail::NonMovableClass, 4>> a;
+
+    for (int i = 0; i < 100; ++i)
+    {
+      ezHybridArray<HybridArrayTestDetail::NonMovableClass, 4> b;
+      b.PushBack(HybridArrayTestDetail::NonMovableClass(i));
+
+      a.PushBack(std::move(b));
+    }
+
+    for (int i = 0; i < 100; ++i)
+    {
+      auto& nonMoveable = a[i][0];
+
+      EZ_TEST_INT(nonMoveable.m_val, i);
+      EZ_TEST_BOOL(nonMoveable.m_pVal == &nonMoveable.m_val);
+    }
+  }
+#endif
+}

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -76,7 +76,7 @@ namespace SmallArrayTestDetail
       a[i] = T(uiOffset + i);
     }
 
-    a.GetUserData<ezUInt32>() = uiUserData;
+    a.template GetUserData<ezUInt32>() = uiUserData;
 
     return a;
   }

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -66,13 +66,17 @@ namespace SmallArrayTestDetail
   };
 
   template <typename T>
-  static ezSmallArray<T, 16> CreateArray(ezUInt32 uiSize, ezUInt32 uiOffset)
+  static ezSmallArray<T, 16> CreateArray(ezUInt32 uiSize, ezUInt32 uiOffset, ezUInt32 uiUserData)
   {
     ezSmallArray<T, 16> a;
     a.SetCount(uiSize);
 
     for (ezUInt32 i = 0; i < uiSize; ++i)
+    {
       a[i] = T(uiOffset + i);
+    }
+
+    a.GetUserData<ezUInt32>() = uiUserData;
 
     return a;
   }
@@ -144,12 +148,17 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
       }
     }
 
+    a1.GetUserData<ezUInt32>() = 11;
+
     ezSmallArray<ezInt32, 16> a2 = a1;
     ezSmallArray<ezInt32, 16> a3(a1);
 
     EZ_TEST_BOOL(a1 == a2);
     EZ_TEST_BOOL(a1 == a3);
     EZ_TEST_BOOL(a2 == a3);
+
+    EZ_TEST_INT(a2.GetUserData<ezUInt32>(), 11);
+    EZ_TEST_INT(a3.GetUserData<ezUInt32>(), 11);
 
     ezInt32 test[] = {1, 2, 3, 4};
     ezArrayPtr<ezInt32> aptr(test);
@@ -165,18 +174,22 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor external storage
-      ezSmallArray<ezConstructionCounter, 16> a1(SmallArrayTestDetail::CreateArray<ezConstructionCounter>(100, 20));
+      ezSmallArray<ezConstructionCounter, 16> a1(SmallArrayTestDetail::CreateArray<ezConstructionCounter>(100, 20, 11));
 
       EZ_TEST_INT(a1.GetCount(), 100);
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
         EZ_TEST_INT(a1[i].m_iData, 20 + i);
 
+      EZ_TEST_INT(a1.GetUserData<ezUInt32>(), 11);
+
       // move operator external storage
-      a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounter>(200, 50);
+      a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounter>(200, 50, 22);
 
       EZ_TEST_INT(a1.GetCount(), 200);
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
         EZ_TEST_INT(a1[i].m_iData, 50 + i);
+
+      EZ_TEST_INT(a1.GetUserData<ezUInt32>(), 22);
     }
 
     EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
@@ -184,18 +197,22 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor internal storage
-      ezSmallArray<ezConstructionCounter, 16> a2(SmallArrayTestDetail::CreateArray<ezConstructionCounter>(10, 30));
+      ezSmallArray<ezConstructionCounter, 16> a2(SmallArrayTestDetail::CreateArray<ezConstructionCounter>(10, 30, 11));
 
       EZ_TEST_INT(a2.GetCount(), 10);
       for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
         EZ_TEST_INT(a2[i].m_iData, 30 + i);
 
+      EZ_TEST_INT(a2.GetUserData<ezUInt32>(), 11);
+
       // move operator internal storage
-      a2 = SmallArrayTestDetail::CreateArray<ezConstructionCounter>(8, 70);
+      a2 = SmallArrayTestDetail::CreateArray<ezConstructionCounter>(8, 70, 22);
 
       EZ_TEST_INT(a2.GetCount(), 8);
       for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
         EZ_TEST_INT(a2[i].m_iData, 70 + i);
+
+      EZ_TEST_INT(a2.GetUserData<ezUInt32>(), 22);
     }
 
     EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
@@ -204,7 +221,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     ezConstructionCounterRelocatable::Reset();
     {
       // move constructor external storage relocatable
-      ezSmallArray<ezConstructionCounterRelocatable, 16> a1(SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(100, 20));
+      ezSmallArray<ezConstructionCounterRelocatable, 16> a1(SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(100, 20, 11));
 
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(100, 0));
 
@@ -212,13 +229,17 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
         EZ_TEST_INT(a1[i].m_iData, 20 + i);
 
+      EZ_TEST_INT(a1.GetUserData<ezUInt32>(), 11);
+
       // move operator external storage
-      a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(200, 50);
+      a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(200, 50, 22);
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(200, 100));
 
       EZ_TEST_INT(a1.GetCount(), 200);
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
         EZ_TEST_INT(a1[i].m_iData, 50 + i);
+
+      EZ_TEST_INT(a1.GetUserData<ezUInt32>(), 22);
     }
 
     EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
@@ -226,20 +247,24 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor internal storage relocatable
-      ezSmallArray<ezConstructionCounterRelocatable, 16> a2(SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(10, 30));
+      ezSmallArray<ezConstructionCounterRelocatable, 16> a2(SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(10, 30, 11));
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(10, 0));
 
       EZ_TEST_INT(a2.GetCount(), 10);
       for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
         EZ_TEST_INT(a2[i].m_iData, 30 + i);
 
+      EZ_TEST_INT(a2.GetUserData<ezUInt32>(), 11);
+
       // move operator internal storage
-      a2 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
+      a2 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70, 22);
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(8, 10));
 
       EZ_TEST_INT(a2.GetCount(), 8);
       for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
         EZ_TEST_INT(a2[i].m_iData, 70 + i);
+
+      EZ_TEST_INT(a2.GetUserData<ezUInt32>(), 22);
     }
 
     EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -758,15 +758,18 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     {
       list.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
+    list.GetUserData<ezUInt32>() = 11;
 
     ezSmallArray<SmallArrayTestDetail::Dummy, 16> list2;
     for (int i = 0; i < 8; i++)
     {
       list2.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
+    list2.GetUserData<ezUInt32>() = 22;
 
     list = list2;
-    EZ_TEST_BOOL(list.GetCount() == list2.GetCount());
+    EZ_TEST_INT(list.GetCount(), list2.GetCount());
+    EZ_TEST_INT(list.GetUserData<ezUInt32>(), list2.GetUserData<ezUInt32>());
 
     list2.Clear();
     EZ_TEST_BOOL(list2.GetCount() == 0);

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -66,9 +66,9 @@ namespace SmallArrayTestDetail
   };
 
   template <typename T>
-  static ezHybridArray<T, 16> CreateArray(ezUInt32 uiSize, ezUInt32 uiOffset)
+  static ezSmallArray<T, 16> CreateArray(ezUInt32 uiSize, ezUInt32 uiOffset)
   {
-    ezHybridArray<T, 16> a;
+    ezSmallArray<T, 16> a;
     a.SetCount(uiSize);
 
     for (ezUInt32 i = 0; i < uiSize; ++i)
@@ -96,7 +96,7 @@ namespace SmallArrayTestDetail
 
     int* m_counter{};
   };
-} // namespace HybridArrayTestDetail
+} // namespace SmallArrayTestDetail
 
 static void TakesDynamicArray(ezDynamicArray<int>& ar, int num, int start);
 
@@ -124,10 +124,9 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     EZ_TEST_BOOL(a2.IsEmpty());
   }
 
-  #if 0
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Copy Constructor")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     EZ_TEST_BOOL(a1.GetHeapMemoryUsage() == 0);
 
@@ -145,8 +144,8 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
       }
     }
 
-    ezHybridArray<ezInt32, 16> a2 = a1;
-    ezHybridArray<ezInt32, 16> a3(a1);
+    ezSmallArray<ezInt32, 16> a2 = a1;
+    ezSmallArray<ezInt32, 16> a3(a1);
 
     EZ_TEST_BOOL(a1 == a2);
     EZ_TEST_BOOL(a1 == a3);
@@ -155,7 +154,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     ezInt32 test[] = {1, 2, 3, 4};
     ezArrayPtr<ezInt32> aptr(test);
 
-    ezHybridArray<ezInt32, 16> a4(aptr);
+    ezSmallArray<ezInt32, 16> a4(aptr);
 
     EZ_TEST_BOOL(a4 == aptr);
   }
@@ -166,14 +165,14 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor external storage
-      ezHybridArray<ezConstructionCounter, 16> a1(HybridArrayTestDetail::CreateArray<ezConstructionCounter>(100, 20));
+      ezSmallArray<ezConstructionCounter, 16> a1(SmallArrayTestDetail::CreateArray<ezConstructionCounter>(100, 20));
 
       EZ_TEST_INT(a1.GetCount(), 100);
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
         EZ_TEST_INT(a1[i].m_iData, 20 + i);
 
       // move operator external storage
-      a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounter>(200, 50);
+      a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounter>(200, 50);
 
       EZ_TEST_INT(a1.GetCount(), 200);
       for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
@@ -185,14 +184,14 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor internal storage
-      ezHybridArray<ezConstructionCounter, 16> a2(HybridArrayTestDetail::CreateArray<ezConstructionCounter>(10, 30));
+      ezSmallArray<ezConstructionCounter, 16> a2(SmallArrayTestDetail::CreateArray<ezConstructionCounter>(10, 30));
 
       EZ_TEST_INT(a2.GetCount(), 10);
       for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
         EZ_TEST_INT(a2[i].m_iData, 30 + i);
 
       // move operator internal storage
-      a2 = HybridArrayTestDetail::CreateArray<ezConstructionCounter>(8, 70);
+      a2 = SmallArrayTestDetail::CreateArray<ezConstructionCounter>(8, 70);
 
       EZ_TEST_INT(a2.GetCount(), 8);
       for (ezUInt32 i = 0; i < a2.GetCount(); ++i)
@@ -205,7 +204,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     ezConstructionCounterRelocatable::Reset();
     {
       // move constructor external storage relocatable
-      ezHybridArray<ezConstructionCounterRelocatable, 16> a1(HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(100, 20));
+      ezSmallArray<ezConstructionCounterRelocatable, 16> a1(SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(100, 20));
 
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(100, 0));
 
@@ -214,7 +213,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
         EZ_TEST_INT(a1[i].m_iData, 20 + i);
 
       // move operator external storage
-      a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(200, 50);
+      a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(200, 50);
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(200, 100));
 
       EZ_TEST_INT(a1.GetCount(), 200);
@@ -227,7 +226,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor internal storage relocatable
-      ezHybridArray<ezConstructionCounterRelocatable, 16> a2(HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(10, 30));
+      ezSmallArray<ezConstructionCounterRelocatable, 16> a2(SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(10, 30));
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(10, 0));
 
       EZ_TEST_INT(a2.GetCount(), 10);
@@ -235,7 +234,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
         EZ_TEST_INT(a2[i].m_iData, 30 + i);
 
       // move operator internal storage
-      a2 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
+      a2 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(8, 10));
 
       EZ_TEST_INT(a2.GetCount(), 8);
@@ -248,21 +247,20 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     {
       // move constructor with different allocators
-      ezProxyAllocator proxyAllocator("test allocator", ezFoundation::GetDefaultAllocator());
       {
-        ezHybridArray<ezConstructionCounterRelocatable, 16> a1(&proxyAllocator);
+        ezSmallArray<ezConstructionCounterRelocatable, 16, ezAlignedAllocatorWrapper> a1;
 
-        a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
+        a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
         EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(8, 0));
-        EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
+        //EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
 
         EZ_TEST_INT(a1.GetCount(), 8);
         for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
           EZ_TEST_INT(a1[i].m_iData, 70 + i);
 
-        a1 = HybridArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(32, 100);
+        a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(32, 100);
         EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(32, 8));
-        EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
+        //EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
 
         EZ_TEST_INT(a1.GetCount(), 32);
         for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
@@ -271,15 +269,12 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
       EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
       ezConstructionCounterRelocatable::Reset();
-
-      auto allocatorStats = proxyAllocator.GetStats();
-      EZ_TEST_BOOL(allocatorStats.m_uiNumAllocations == allocatorStats.m_uiNumDeallocations); // check for memory leak?
     }
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Convert to ArrayPtr")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 100; ++i)
     {
@@ -294,7 +289,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator =")
   {
-    ezHybridArray<ezInt32, 16> a1, a2;
+    ezSmallArray<ezInt32, 16> a1, a2;
 
     for (ezInt32 i = 0; i < 100; ++i)
       a1.PushBack(i);
@@ -309,8 +304,6 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     EZ_TEST_BOOL(a2 == arrayPtr);
   }
-
-  #endif
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator == / !=")
   {
@@ -340,7 +333,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Index operator")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
     a1.SetCountUninitialized(100);
 
     for (ezInt32 i = 0; i < 100; ++i)
@@ -349,17 +342,15 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(a1[i], i);
 
-    const ezHybridArray<ezInt32, 16> ca1 = a1;
+    const ezSmallArray<ezInt32, 16> ca1 = a1;
 
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(ca1[i], i);
   }
 
-  #if 0
-
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetCount / GetCount / IsEmpty")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     EZ_TEST_BOOL(a1.IsEmpty());
 
@@ -395,7 +386,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     // Test SetCount with fill value
     {
-      ezHybridArray<ezInt32, 2> a2;
+      ezSmallArray<ezInt32, 2> a2;
       a2.PushBack(5);
       a2.PushBack(3);
       a2.SetCount(10, 42);
@@ -424,7 +415,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   // Test SetCount with fill value
   {
-    ezHybridArray<ezInt32, 2> a2;
+    ezSmallArray<ezInt32, 2> a2;
     a2.PushBack(5);
     a2.PushBack(3);
     a2.SetCount(10, 42);
@@ -452,7 +443,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Clear")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
     a1.Clear();
 
     a1.PushBack(3);
@@ -463,7 +454,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Contains / IndexOf / LastIndexOf")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = -100; i < 100; ++i)
       EZ_TEST_BOOL(!a1.Contains(i));
@@ -481,7 +472,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Insert")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     // always inserts at the front
     for (ezInt32 i = 0; i < 100; ++i)
@@ -493,7 +484,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAndCopy")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 100; ++i)
       a1.PushBack(i % 2);
@@ -510,7 +501,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAndSwap")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
       a1.Insert(i, i); // inserts at the end
@@ -529,7 +520,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAtAndCopy")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
       a1.Insert(i, i); // inserts at the end
@@ -548,7 +539,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "RemoveAtAndSwap")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
       a1.Insert(i, i); // inserts at the end
@@ -567,7 +558,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "PushBack / PopBack / PeekBack")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
     {
@@ -591,7 +582,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ExpandAndGetRef")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 20; ++i)
     {
@@ -613,8 +604,8 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     {
       EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
 
-      ezHybridArray<ezConstructionCounter, 16> a1;
-      ezHybridArray<ezConstructionCounter, 16> a2;
+      ezSmallArray<ezConstructionCounter, 16> a1;
+      ezSmallArray<ezConstructionCounter, 16> a2;
 
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
       EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
@@ -657,7 +648,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Compact")
   {
-    ezHybridArray<ezInt32, 16> a;
+    ezSmallArray<ezInt32, 16> a;
 
     for (ezInt32 i = 0; i < 1000; ++i)
     {
@@ -672,15 +663,6 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     for (ezInt32 i = 0; i < 1000; ++i)
       EZ_TEST_INT(a[i], i);
 
-    // this tests whether the static array is reused properly (not the case anymore with new implementation that derives from ezDynamicArray)
-    a.SetCount(15);
-    a.Compact();
-    // EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
-    EZ_TEST_BOOL(a.GetHeapMemoryUsage() > 0);
-
-    for (ezInt32 i = 0; i < 15; ++i)
-      EZ_TEST_INT(a[i], i);
-
     a.Clear();
     a.Compact();
     EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
@@ -688,7 +670,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SortingPrimitives")
   {
-    ezHybridArray<ezUInt32, 16> list;
+    ezSmallArray<ezUInt32, 16> list;
 
     list.Sort();
 
@@ -708,16 +690,16 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SortingObjects")
   {
-    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    ezSmallArray<SmallArrayTestDetail::Dummy, 16> list;
     list.Reserve(128);
 
     for (ezUInt32 i = 0; i < 100; i++)
     {
-      list.PushBack(HybridArrayTestDetail::Dummy(rand()));
+      list.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
     list.Sort();
 
-    HybridArrayTestDetail::Dummy last = 0;
+    SmallArrayTestDetail::Dummy last = 0;
     for (ezUInt32 i = 0; i < list.GetCount(); i++)
     {
       EZ_TEST_BOOL(last <= list[i]);
@@ -727,7 +709,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Various")
   {
-    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    ezSmallArray<SmallArrayTestDetail::Dummy, 16> list;
     list.PushBack(1);
     list.PushBack(2);
     list.PushBack(3);
@@ -756,7 +738,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     list.PushBack(5);
     EZ_TEST_BOOL(list[4].a == 5);
-    HybridArrayTestDetail::Dummy d = list.PeekBack();
+    SmallArrayTestDetail::Dummy d = list.PeekBack();
     list.PopBack();
     EZ_TEST_BOOL(d.a == 5);
     EZ_TEST_BOOL(list.GetCount() == 4);
@@ -764,16 +746,16 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Assignment")
   {
-    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    ezSmallArray<SmallArrayTestDetail::Dummy, 16> list;
     for (int i = 0; i < 16; i++)
     {
-      list.PushBack(HybridArrayTestDetail::Dummy(rand()));
+      list.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
 
-    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list2;
+    ezSmallArray<SmallArrayTestDetail::Dummy, 16> list2;
     for (int i = 0; i < 8; i++)
     {
-      list2.PushBack(HybridArrayTestDetail::Dummy(rand()));
+      list2.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
 
     list = list2;
@@ -788,7 +770,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     for (int i = 0; i < 16; i++)
     {
-      list2.PushBack(HybridArrayTestDetail::Dummy(rand()));
+      list2.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
 
     list = list2;
@@ -798,10 +780,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Count")
   {
-    ezHybridArray<HybridArrayTestDetail::Dummy, 16> list;
+    ezSmallArray<SmallArrayTestDetail::Dummy, 16> list;
     for (int i = 0; i < 16; i++)
     {
-      list.PushBack(HybridArrayTestDetail::Dummy(rand()));
+      list.PushBack(SmallArrayTestDetail::Dummy(rand()));
     }
     list.SetCount(32);
     list.SetCount(4);
@@ -813,7 +795,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
   {
     EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
 
-    ezHybridArray<ezConstructionCounter, 16> a;
+    ezSmallArray<ezConstructionCounter, 16> a;
 
     EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
     EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
@@ -843,7 +825,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
   {
     EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
 
-    ezHybridArray<ezConstructionCounter, 16> a;
+    ezSmallArray<ezConstructionCounter, 16> a;
 
     EZ_TEST_BOOL(ezConstructionCounter::HasDone(0, 0)); // nothing has been constructed / destructed in between
     EZ_TEST_BOOL(ezConstructionCounter::HasAllDestructed());
@@ -889,17 +871,17 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     // this will deallocate ALL memory
     a.Compact();
 
-    a.SetCount(100);
-    EZ_TEST_BOOL(ezConstructionCounter::HasDone(100, 0));
+    a.SetCount(10);
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(10, 0));
 
     // this time objects need to be relocated
     a.SetCount(200);
-    EZ_TEST_BOOL(ezConstructionCounter::HasDone(200, 100));
+    EZ_TEST_BOOL(ezConstructionCounter::HasDone(200, 10));
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "STL Iterator")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 1000; ++i)
       a1.PushBack(1000 - i - 1);
@@ -921,7 +903,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     }
 
     // const array
-    const ezHybridArray<ezInt32, 16>& a2 = a1;
+    const ezSmallArray<ezInt32, 16>& a2 = a1;
 
     // STL lower bound
     auto lb = std::lower_bound(begin(a2), end(a2), 400);
@@ -930,7 +912,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "STL Reverse Iterator")
   {
-    ezHybridArray<ezInt32, 16> a1;
+    ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 1000; ++i)
       a1.PushBack(1000 - i - 1);
@@ -952,131 +934,21 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     }
 
     // const array
-    const ezHybridArray<ezInt32, 16>& a2 = a1;
+    const ezSmallArray<ezInt32, 16>& a2 = a1;
 
     // STL lower bound
     auto lb = std::lower_bound(rbegin(a2), rend(a2), 400);
     EZ_TEST_BOOL(*lb == a2[1000 - 400 - 1]);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Swap")
-  {
-
-    ezInt32 content1[] = {1, 2, 3, 4};
-    ezInt32 content2[] = {5, 6, 7, 8, 9};
-    ezInt32 contentHeap1[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13};
-    ezInt32 contentHeap2[] = {11, 12, 13, 14, 15, 16, 17, 18, 19, 110, 111, 112, 113};
-
-    {
-      // local <-> local
-      ezHybridArray<ezInt32, 8> a1;
-      ezHybridArray<ezInt32, 16> a2;
-      a1 = ezMakeArrayPtr(content1);
-      a2 = ezMakeArrayPtr(content2);
-
-      ezInt32* a1Ptr = a1.GetData();
-      ezInt32* a2Ptr = a2.GetData();
-
-      a1.Swap(a2);
-
-      // Because the data points to the internal storage the pointers shouldn't change when swapping
-      EZ_TEST_BOOL(a1Ptr == a1.GetData());
-      EZ_TEST_BOOL(a2Ptr == a2.GetData());
-
-      // The data however should be swapped
-      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(content2));
-      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(content1));
-
-      EZ_TEST_INT(a1.GetCapacity(), 8);
-      EZ_TEST_INT(a2.GetCapacity(), 16);
-    }
-
-    {
-      // local <-> heap
-      ezHybridArray<ezInt32, 8> a1;
-      ezDynamicArray<ezInt32> a2;
-      a1 = ezMakeArrayPtr(content1);
-      a2 = ezMakeArrayPtr(contentHeap1);
-      ezInt32* a1Ptr = a1.GetData();
-      ezInt32* a2Ptr = a2.GetData();
-      a1.Swap(a2);
-      EZ_TEST_BOOL(a1Ptr != a1.GetData());
-      EZ_TEST_BOOL(a2Ptr != a2.GetData());
-      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(contentHeap1));
-      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(content1));
-
-      EZ_TEST_INT(a1.GetCapacity(), 16);
-      EZ_TEST_INT(a2.GetCapacity(), 16);
-    }
-
-    {
-      // heap <-> local
-      ezHybridArray<ezInt32, 8> a1;
-      ezHybridArray<ezInt32, 7> a2;
-      a1 = ezMakeArrayPtr(content1);
-      a2 = ezMakeArrayPtr(contentHeap1);
-      ezInt32* a1Ptr = a1.GetData();
-      ezInt32* a2Ptr = a2.GetData();
-      a2.Swap(a1); // Swap is opposite direction as before
-      EZ_TEST_BOOL(a1Ptr != a1.GetData());
-      EZ_TEST_BOOL(a2Ptr != a2.GetData());
-      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(contentHeap1));
-      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(content1));
-
-      EZ_TEST_INT(a1.GetCapacity(), 16);
-      EZ_TEST_INT(a2.GetCapacity(), 16);
-    }
-
-    {
-      // heap <-> heap
-      ezDynamicArray<ezInt32> a1;
-      ezHybridArray<ezInt32, 8> a2;
-      a1 = ezMakeArrayPtr(contentHeap1);
-      a2 = ezMakeArrayPtr(contentHeap2);
-      ezInt32* a1Ptr = a1.GetData();
-      ezInt32* a2Ptr = a2.GetData();
-      a2.Swap(a1);
-      EZ_TEST_BOOL(a1Ptr != a1.GetData());
-      EZ_TEST_BOOL(a2Ptr != a2.GetData());
-      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(contentHeap2));
-      EZ_TEST_BOOL(a2.GetArrayPtr() == ezMakeArrayPtr(contentHeap1));
-
-      EZ_TEST_INT(a1.GetCapacity(), 16);
-      EZ_TEST_INT(a2.GetCapacity(), 16);
-    }
-
-    {
-      // empty <-> local
-      ezHybridArray<ezInt32, 8> a1, a2;
-      a2 = ezMakeArrayPtr(content2);
-      a1.Swap(a2);
-      EZ_TEST_BOOL(a1.GetArrayPtr() == ezMakeArrayPtr(content2));
-      EZ_TEST_BOOL(a2.IsEmpty());
-
-      EZ_TEST_INT(a1.GetCapacity(), 8);
-      EZ_TEST_INT(a2.GetCapacity(), 8);
-    }
-
-    {
-      // empty <-> empty
-      ezHybridArray<ezInt32, 8> a1, a2;
-      a1.Swap(a2);
-      EZ_TEST_BOOL(a1.IsEmpty());
-      EZ_TEST_BOOL(a2.IsEmpty());
-
-      EZ_TEST_INT(a1.GetCapacity(), 8);
-      EZ_TEST_INT(a2.GetCapacity(), 8);
-    }
-  }
-
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Move")
   {
     int counter = 0;
     {
-      ezHybridArray<HybridArrayTestDetail::ExternalCounter, 2> a, b;
+      ezSmallArray<SmallArrayTestDetail::ExternalCounter, 2> a, b;
       EZ_TEST_BOOL(counter == 0);
 
-      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(SmallArrayTestDetail::ExternalCounter(counter));
       EZ_TEST_BOOL(counter == 1);
 
       b = std::move(a);
@@ -1086,13 +958,13 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     counter = 0;
     {
-      ezHybridArray<HybridArrayTestDetail::ExternalCounter, 2> a, b;
+      ezSmallArray<SmallArrayTestDetail::ExternalCounter, 2> a, b;
       EZ_TEST_BOOL(counter == 0);
 
-      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
-      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
-      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
-      a.PushBack(HybridArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(SmallArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(SmallArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(SmallArrayTestDetail::ExternalCounter(counter));
+      a.PushBack(SmallArrayTestDetail::ExternalCounter(counter));
       EZ_TEST_BOOL(counter == 4);
 
       b = std::move(a);
@@ -1100,58 +972,4 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     }
     EZ_TEST_BOOL(counter == 8);
   }
-
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Use ezHybridArray with ezDynamicArray")
-  {
-    ezHybridArray<int, 16> a;
-
-    TakesDynamicArray(a, 4, a.GetCount());
-    EZ_TEST_INT(a.GetCount(), 4);
-    EZ_TEST_INT(a.GetCapacity(), 16);
-
-    for (int i = 0; i < (int)a.GetCount(); ++i)
-    {
-      EZ_TEST_INT(a[i], i);
-    }
-
-    TakesDynamicArray(a, 12, a.GetCount());
-    EZ_TEST_INT(a.GetCount(), 16);
-    EZ_TEST_INT(a.GetCapacity(), 16);
-
-    for (int i = 0; i < (int)a.GetCount(); ++i)
-    {
-      EZ_TEST_INT(a[i], i);
-    }
-
-    TakesDynamicArray(a, 8, a.GetCount());
-    EZ_TEST_INT(a.GetCount(), 24);
-    EZ_TEST_INT(a.GetCapacity(), 32);
-
-    for (int i = 0; i < (int)a.GetCount(); ++i)
-    {
-      EZ_TEST_INT(a[i], i);
-    }
-  }
-
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Nested arrays")
-  {
-    ezDynamicArray<ezHybridArray<HybridArrayTestDetail::NonMovableClass, 4>> a;
-
-    for (int i = 0; i < 100; ++i)
-    {
-      ezHybridArray<HybridArrayTestDetail::NonMovableClass, 4> b;
-      b.PushBack(HybridArrayTestDetail::NonMovableClass(i));
-
-      a.PushBack(std::move(b));
-    }
-
-    for (int i = 0; i < 100; ++i)
-    {
-      auto& nonMoveable = a[i][0];
-
-      EZ_TEST_INT(nonMoveable.m_val, i);
-      EZ_TEST_BOOL(nonMoveable.m_pVal == &nonMoveable.m_val);
-    }
-  }
-#endif
 }

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -650,7 +650,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
   {
     ezSmallArray<ezInt32, 16> a;
 
-    for (ezInt32 i = 0; i < 1000; ++i)
+    for (ezInt32 i = 0; i < 1008; ++i)
     {
       a.PushBack(i);
       EZ_TEST_INT(a.GetCount(), i + 1);
@@ -660,7 +660,15 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     a.Compact();
     EZ_TEST_BOOL(a.GetHeapMemoryUsage() > 0);
 
-    for (ezInt32 i = 0; i < 1000; ++i)
+    for (ezInt32 i = 0; i < 1008; ++i)
+      EZ_TEST_INT(a[i], i);
+
+    // this tests whether the static array is reused properly
+    a.SetCount(15);
+    a.Compact();
+    EZ_TEST_BOOL(a.GetHeapMemoryUsage() == 0);
+
+    for (ezInt32 i = 0; i < 15; ++i)
       EZ_TEST_INT(a[i], i);
 
     a.Clear();

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -244,32 +244,6 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
     ezConstructionCounterRelocatable::Reset();
-
-    {
-      // move constructor with different allocators
-      {
-        ezSmallArray<ezConstructionCounterRelocatable, 16, ezAlignedAllocatorWrapper> a1;
-
-        a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(8, 70);
-        EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(8, 0));
-        //EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
-
-        EZ_TEST_INT(a1.GetCount(), 8);
-        for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
-          EZ_TEST_INT(a1[i].m_iData, 70 + i);
-
-        a1 = SmallArrayTestDetail::CreateArray<ezConstructionCounterRelocatable>(32, 100);
-        EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasDone(32, 8));
-        //EZ_TEST_BOOL(a1.GetAllocator() == &proxyAllocator); // allocator must not change
-
-        EZ_TEST_INT(a1.GetCount(), 32);
-        for (ezUInt32 i = 0; i < a1.GetCount(); ++i)
-          EZ_TEST_INT(a1[i].m_iData, 100 + i);
-      }
-
-      EZ_TEST_BOOL(ezConstructionCounterRelocatable::HasAllDestructed());
-      ezConstructionCounterRelocatable::Reset();
-    }
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Convert to ArrayPtr")


### PR DESCRIPTION
which is a hybrid array with minimal memory overhead, but can only store up to 65535 elements.

ezTagSet uses this small array as storage and now has a memory footprint of 16 bytes instead of 40 bytes.
ezGameObject uses a small array for components and is now down to 128 bytes :)