### PR TITLE
RenderData caching fixes

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -177,7 +177,7 @@ void ezEngineProcessDocumentContext::HandleMessage(const ezEditorEngineDocumentM
       ezGameObject* pObject = static_cast<ezGameObject*>(target.m_pObject);
       if (pObject != nullptr && pObject->IsStatic())
       {
-        ezRenderWorld::DeleteCachedRenderDataRecursive(pObject);
+        ezRenderWorld::DeleteCachedRenderDataForObjectRecursive(pObject);
       }
     }
     else if (target.m_pType->IsDerivedFrom<ezComponent>())

--- a/Code/Engine/Core/World/ComponentManager.h
+++ b/Code/Engine/Core/World/ComponentManager.h
@@ -88,6 +88,7 @@ class ezComponentManager : public ezComponentManagerBase
 {
 public:
   typedef T ComponentType;
+  typedef ezComponentManagerBase SUPER;
 
   /// \brief Although the constructor is public always use ezWorld::CreateComponentManager to create an instance.
   ezComponentManager(ezWorld* pWorld);

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -369,6 +369,10 @@ public:
   /// \brief Returns a list of all components attached to this object.
   ezArrayPtr<const ezComponent* const> GetComponents() const;
 
+  /// \brief Returns the current version of components attached to this object.
+  /// This version is increased whenever components are added or removed and can be used for cache validation.
+  ezUInt16 GetComponentVersion() const { return m_uiComponentVersion; }
+
 
   /// \brief Sends a message to all components of this object.
   bool SendMessage(ezMessage& msg);

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -371,7 +371,7 @@ public:
 
   /// \brief Returns the current version of components attached to this object.
   /// This version is increased whenever components are added or removed and can be used for cache validation.
-  ezUInt16 GetComponentVersion() const { return m_uiComponentVersion; }
+  ezUInt16 GetComponentVersion() const;
 
 
   /// \brief Sends a message to all components of this object.
@@ -556,6 +556,12 @@ private:
 #endif
 
   ezSmallArrayBase<ezComponent*, NUM_INPLACE_COMPONENTS> m_Components;
+
+  struct ComponentUserData
+  {
+    ezUInt16 m_uiVersion;
+    ezUInt16 m_uiUnused;
+  };
 
   ezTagSet m_Tags;
 };

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -727,7 +727,7 @@ void ezGameObject::AddComponent(ezComponent* pComponent)
 
   pComponent->m_pOwner = this;
   m_Components.PushBack(pComponent, GetWorld()->GetAllocator());
-  m_Components.GetUserData()++;
+  m_Components.GetUserData<ComponentUserData>().m_uiVersion++;
 
   pComponent->UpdateActiveState(IsActive());
 
@@ -749,7 +749,7 @@ void ezGameObject::RemoveComponent(ezComponent* pComponent)
 
   pComponent->m_pOwner = nullptr;
   m_Components.RemoveAtAndSwap(uiIndex);
-  ++m_uiComponentVersion;
+  m_Components.GetUserData<ComponentUserData>().m_uiVersion++;
 
   if (m_Flags.IsSet(ezObjectFlags::ComponentChangesNotifications))
   {

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -727,6 +727,7 @@ void ezGameObject::AddComponent(ezComponent* pComponent)
 
   pComponent->m_pOwner = this;
   m_Components.PushBack(pComponent, GetWorld()->GetAllocator());
+  m_Components.GetUserData()++;
 
   pComponent->UpdateActiveState(IsActive());
 
@@ -748,6 +749,7 @@ void ezGameObject::RemoveComponent(ezComponent* pComponent)
 
   pComponent->m_pOwner = nullptr;
   m_Components.RemoveAtAndSwap(uiIndex);
+  ++m_uiComponentVersion;
 
   if (m_Flags.IsSet(ezObjectFlags::ComponentChangesNotifications))
   {

--- a/Code/Engine/Core/World/Implementation/GameObject_inl.h
+++ b/Code/Engine/Core/World/Implementation/GameObject_inl.h
@@ -499,6 +499,11 @@ EZ_ALWAYS_INLINE ezArrayPtr<const ezComponent* const> ezGameObject::GetComponent
   return ezMakeArrayPtr(const_cast<const ezComponent* const*>(m_Components.GetData()), m_Components.GetCount());
 }
 
+EZ_ALWAYS_INLINE ezUInt16 ezGameObject::GetComponentVersion() const
+{
+  return m_Components.GetUserData<ComponentUserData>().m_uiVersion;
+}
+
 EZ_ALWAYS_INLINE ezTagSet& ezGameObject::GetTags()
 {
   return m_Tags;

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -247,6 +247,9 @@ void ezWorld::DeleteObjectNow(const ezGameObjectHandle& hObject)
   if (!m_Data.m_Objects.TryGetValue(hObject, pObject))
     return;
 
+  // inform external systems that we are about to delete this object
+  m_Data.m_ObjectDeletionEvent.Broadcast(pObject);
+
   // set object to inactive so components and children know that they shouldn't access the object anymore.
   pObject->m_Flags.Remove(ezObjectFlags::ActiveFlag | ezObjectFlags::ActiveState);
 

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -40,6 +40,7 @@ namespace ezInternal
     ObjectStorage m_ObjectStorage;
 
     ezSet<ezGameObject*, ezCompareHelper<ezGameObject*>, ezLocalAllocatorWrapper> m_DeadObjects;
+    ezEvent<const ezGameObject*> m_ObjectDeletionEvent;
 
   public:
     class EZ_CORE_DLL ConstObjectIterator

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -15,6 +15,11 @@ EZ_FORCE_INLINE ezGameObjectHandle ezWorld::CreateObject(const ezGameObjectDesc&
   return CreateObject(desc, pNewObject);
 }
 
+EZ_ALWAYS_INLINE const ezEvent<const ezGameObject*>& ezWorld::GetObjectDeletionEvent() const
+{
+  return m_Data.m_ObjectDeletionEvent;
+}
+
 EZ_FORCE_INLINE bool ezWorld::IsValidObject(const ezGameObjectHandle& object) const
 {
   CheckForReadAccess();

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -53,6 +53,10 @@ public:
   /// valid until then.
   void DeleteObjectDelayed(const ezGameObjectHandle& object);
 
+  /// \brief Returns the event that is triggered before an object is deleted. This can be used for external systems to cleanup data
+  /// which is associated with the deleted object.
+  const ezEvent<const ezGameObject*>& GetObjectDeletionEvent() const;
+
   /// \brief Returns whether the given handle corresponds to a valid object.
   bool IsValidObject(const ezGameObjectHandle& object) const;
 
@@ -351,8 +355,7 @@ private:
   void SetObjectGlobalKey(ezGameObject* pObject, const ezHashedString& sGlobalKey);
   const char* GetObjectGlobalKey(const ezGameObject* pObject) const;
 
-  void PostMessage(
-    const ezGameObjectHandle& receiverObject, const ezMessage& msg, ezObjectMsgQueueType::Enum queueType, ezTime delay, bool bRecursive) const;
+  void PostMessage(const ezGameObjectHandle& receiverObject, const ezMessage& msg, ezObjectMsgQueueType::Enum queueType, ezTime delay, bool bRecursive) const;
   void ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::Entry& entry);
   void ProcessQueuedMessages(ezObjectMsgQueueType::Enum queueType);
 

--- a/Code/Engine/RendererCore/Pipeline/Declarations.h
+++ b/Code/Engine/RendererCore/Pipeline/Declarations.h
@@ -30,11 +30,25 @@ namespace ezInternal
   {
     EZ_DECLARE_POD_TYPE();
 
-    const ezRenderData* m_pRenderData;
-    ezUInt32 m_uiSortingKey;
-    ezUInt16 m_uiCategory;
-    ezUInt16 m_uiComponentIndex : 15;
-    ezUInt16 m_uiCacheIfStatic : 1;
+    const ezRenderData* m_pRenderData = nullptr;
+    ezUInt16 m_uiCategory = 0;
+    ezUInt16 m_uiComponentIndex = 0;
+    ezUInt16 m_uiPartIndex = 0;
+
+    EZ_ALWAYS_INLINE bool operator==(const RenderDataCacheEntry& other) const
+    {
+      return m_pRenderData == other.m_pRenderData && m_uiCategory == other.m_uiCategory &&
+             m_uiComponentIndex == other.m_uiComponentIndex && m_uiPartIndex == other.m_uiPartIndex;
+    }
+
+    // Cache entries need to be sorted by component index and then by part index
+    EZ_ALWAYS_INLINE bool operator<(const RenderDataCacheEntry& other) const
+    {
+      if (m_uiComponentIndex == other.m_uiComponentIndex)
+        return m_uiPartIndex < other.m_uiPartIndex;
+
+      return m_uiComponentIndex < other.m_uiComponentIndex;
+    }
   };
 } // namespace ezInternal
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -238,7 +238,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
 
         AddRenderDataFromMessage(msg);
       }
-      else // component does not handle extract message at all
+      else if (pComponent->IsActiveAndInitialized()) // component does not handle extract message at all
       {
         EZ_ASSERT_DEV(pComponent->GetDynamicRTTI()->CanHandleMessage<ezMsgExtractRenderData>() == false, "");
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -154,30 +154,18 @@ void ezRenderData::ClearRendererInstances()
 
 //////////////////////////////////////////////////////////////////////////
 
-ezRenderData::Category ezDefaultRenderDataCategories::Light =
-  ezRenderData::RegisterCategory("Light", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::Decal =
-  ezRenderData::RegisterCategory("Decal", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::Sky =
-  ezRenderData::RegisterCategory("Sky", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::LitOpaque =
-  ezRenderData::RegisterCategory("LitOpaque", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::LitMasked =
-  ezRenderData::RegisterCategory("LitMasked", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::LitTransparent =
-  ezRenderData::RegisterCategory("LitTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
-ezRenderData::Category ezDefaultRenderDataCategories::LitForeground =
-  ezRenderData::RegisterCategory("LitForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::SimpleOpaque =
-  ezRenderData::RegisterCategory("SimpleOpaque", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::SimpleTransparent =
-  ezRenderData::RegisterCategory("SimpleTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
-ezRenderData::Category ezDefaultRenderDataCategories::SimpleForeground =
-  ezRenderData::RegisterCategory("SimpleForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::Selection =
-  ezRenderData::RegisterCategory("Selection", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::GUI =
-  ezRenderData::RegisterCategory("GUI", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
+ezRenderData::Category ezDefaultRenderDataCategories::Light = ezRenderData::RegisterCategory("Light", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::Decal = ezRenderData::RegisterCategory("Decal", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::Sky = ezRenderData::RegisterCategory("Sky", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitOpaque = ezRenderData::RegisterCategory("LitOpaque", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitMasked = ezRenderData::RegisterCategory("LitMasked", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitTransparent = ezRenderData::RegisterCategory("LitTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
+ezRenderData::Category ezDefaultRenderDataCategories::LitForeground = ezRenderData::RegisterCategory("LitForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::SimpleOpaque = ezRenderData::RegisterCategory("SimpleOpaque", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::SimpleTransparent = ezRenderData::RegisterCategory("SimpleTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
+ezRenderData::Category ezDefaultRenderDataCategories::SimpleForeground = ezRenderData::RegisterCategory("SimpleForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::Selection = ezRenderData::RegisterCategory("Selection", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::GUI = ezRenderData::RegisterCategory("GUI", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -187,8 +175,7 @@ void ezMsgExtractRenderData::AddRenderData(
   auto& cached = m_ExtractedRenderData.ExpandAndGetRef();
   cached.m_pRenderData = pRenderData;
   cached.m_uiCategory = category.m_uiValue;
-  cached.m_uiComponentIndex = 0x7FFF;
-  cached.m_uiCacheIfStatic = (cachingBehavior == ezRenderData::Caching::IfStatic);
+  cached.m_bCacheIfStatic = (cachingBehavior == ezRenderData::Caching::IfStatic);
 }
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Pipeline_Implementation_RenderData);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -175,7 +175,11 @@ void ezMsgExtractRenderData::AddRenderData(
   auto& cached = m_ExtractedRenderData.ExpandAndGetRef();
   cached.m_pRenderData = pRenderData;
   cached.m_uiCategory = category.m_uiValue;
-  cached.m_bCacheIfStatic = (cachingBehavior == ezRenderData::Caching::IfStatic);
+
+  if (cachingBehavior == ezRenderData::Caching::IfStatic)
+  {
+    ++m_uiNumCacheIfStatic;
+  }
 }
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Pipeline_Implementation_RenderData);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/View.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/View.cpp
@@ -66,7 +66,7 @@ void ezView::SetWorld(ezWorld* pWorld)
     m_pWorld = pWorld;
 
     ezRenderWorld::ResetRenderDataCache(*this);
-  }  
+  }
 }
 
 void ezView::SetRenderTargetSetup(ezGALRenderTargetSetup& renderTargetSetup)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/View.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/View.cpp
@@ -63,10 +63,10 @@ void ezView::SetWorld(ezWorld* pWorld)
 {
   if (m_pWorld != pWorld)
   {
-    ezRenderWorld::DeleteCachedRenderData(*this);
-  }
+    m_pWorld = pWorld;
 
-  m_pWorld = pWorld;
+    ezRenderWorld::ResetRenderDataCache(*this);
+  }  
 }
 
 void ezView::SetRenderTargetSetup(ezGALRenderTargetSetup& renderTargetSetup)

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -118,7 +118,14 @@ struct EZ_RENDERERCORE_DLL ezMsgExtractRenderData : public ezMessage
 private:
   friend class ezExtractor;
 
-  ezHybridArray<ezInternal::RenderDataCacheEntry, 16> m_ExtractedRenderData;
+  struct Data
+  {
+    const ezRenderData* m_pRenderData = nullptr;
+    ezUInt16 m_uiCategory = 0;
+    bool m_bCacheIfStatic = false;
+  };
+
+  ezHybridArray<Data, 16> m_ExtractedRenderData;
 };
 
 #include <RendererCore/Pipeline/Implementation/RenderData_inl.h>

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -122,10 +122,10 @@ private:
   {
     const ezRenderData* m_pRenderData = nullptr;
     ezUInt16 m_uiCategory = 0;
-    bool m_bCacheIfStatic = false;
   };
 
   ezHybridArray<Data, 16> m_ExtractedRenderData;
+  ezUInt32 m_uiNumCacheIfStatic = 0;
 };
 
 #include <RendererCore/Pipeline/Implementation/RenderData_inl.h>

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -683,6 +683,17 @@ void ezRenderWorld::OnEngineStartup()
 
 void ezRenderWorld::OnEngineShutdown()
 {
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+  for (auto it : s_CachedRenderData)
+  {
+    auto& cachedRenderDataPerComponent = it.Value();
+    if (cachedRenderDataPerComponent.IsEmpty() == false)
+    {
+      EZ_REPORT_FAILURE("Leaked cached render data of type '{}'", cachedRenderDataPerComponent[0]->GetDynamicRTTI()->GetTypeName());
+    }
+  }
+#endif
+
   ClearRenderDataCache();
 
   EZ_DEFAULT_DELETE(s_pCacheAllocator);

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -648,17 +648,16 @@ void ezRenderWorld::UpdateRenderDataCache()
       auto& perObjectCache = perObjectCaches[uiCacheIndex];
       if (perObjectCache.m_uiVersion != newEntries.m_Cache.m_uiVersion)
       {
-        EZ_ASSERT_DEV(perObjectCache.m_Entries.IsEmpty(), "");
-
         perObjectCache.m_Entries.Clear();
         perObjectCache.m_uiVersion = newEntries.m_Cache.m_uiVersion;
       }
 
       for (auto& newEntry : newEntries.m_Cache.m_Entries)
       {
-        EZ_ASSERT_DEBUG(!perObjectCache.m_Entries.Contains(newEntry), "");
-
-        perObjectCache.m_Entries.PushBack(newEntry);
+        if (!perObjectCache.m_Entries.Contains(newEntry))
+        {
+          perObjectCache.m_Entries.PushBack(newEntry);
+        }
       }
 
       // keep entries sorted, otherwise the logic ezExtractor::ExtractRenderData doesn't work

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -43,22 +43,20 @@ public:
   static void DeleteView(const ezViewHandle& hView);
 
   static bool TryGetView(const ezViewHandle& hView, ezView*& out_pView);
-  static ezView* GetViewByUsageHint(
-    ezCameraUsageHint::Enum usageHint, ezCameraUsageHint::Enum alternativeUsageHint = ezCameraUsageHint::None, const ezWorld* pWorld = nullptr);
+  static ezView* GetViewByUsageHint(ezCameraUsageHint::Enum usageHint, ezCameraUsageHint::Enum alternativeUsageHint = ezCameraUsageHint::None, const ezWorld* pWorld = nullptr);
 
   static void AddMainView(const ezViewHandle& hView);
   static void RemoveMainView(const ezViewHandle& hView);
   static void ClearMainViews();
   static ezArrayPtr<ezViewHandle> GetMainViews();
 
-  static void CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent,
-    ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries);
+  static void CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries);
 
   static void DeleteAllCachedRenderData();
   static void DeleteCachedRenderData(const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent);
   static void DeleteCachedRenderDataRecursive(const ezGameObject* pOwnerObject);
   static void DeleteCachedRenderData(ezView& view);
-  static ezArrayPtr<ezInternal::RenderDataCacheEntry> GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner);
+  static ezArrayPtr<const ezInternal::RenderDataCacheEntry> GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion);
 
   static void AddViewToRender(const ezViewHandle& hView);
 

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -54,8 +54,9 @@ public:
 
   static void DeleteAllCachedRenderData();
   static void DeleteCachedRenderData(const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent);
-  static void DeleteCachedRenderDataRecursive(const ezGameObject* pOwnerObject);
-  static void DeleteCachedRenderData(ezView& view);
+  static void DeleteCachedRenderDataForObject(const ezGameObject* pOwnerObject);
+  static void DeleteCachedRenderDataForObjectRecursive(const ezGameObject* pOwnerObject);
+  static void ResetRenderDataCache(ezView& view);
   static ezArrayPtr<const ezInternal::RenderDataCacheEntry> GetCachedRenderData(const ezView& view, const ezGameObjectHandle& hOwner, ezUInt16 uiComponentVersion);
 
   static void AddViewToRender(const ezViewHandle& hView);
@@ -110,6 +111,7 @@ private:
   friend class ezView;
   friend class ezRenderPipeline;
 
+  static void DeleteCachedRenderDataInternal(const ezGameObjectHandle& hOwnerObject);
   static void ClearRenderDataCache();
   static void UpdateRenderDataCache();
 

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -88,6 +88,8 @@ ezFmodEventComponentManager::ezFmodEventComponentManager(ezWorld* pWorld)
 
 void ezFmodEventComponentManager::Initialize()
 {
+  SUPER::Initialize();
+
   {
     auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezFmodEventComponentManager::UpdateOcclusion, this);
     desc.m_Phase = ezWorldModule::UpdateFunctionDesc::Phase::Async;
@@ -110,6 +112,8 @@ void ezFmodEventComponentManager::Initialize()
 void ezFmodEventComponentManager::Deinitialize()
 {
   ezResourceManager::GetResourceEvents().RemoveEventHandler(ezMakeDelegate(&ezFmodEventComponentManager::ResourceEventHandler, this));
+
+  SUPER::Deinitialize();
 }
 
 ezUInt32 ezFmodEventComponentManager::AddOcclusionState(ezFmodEventComponent* pComponent, ezFmodParameterId occlusionParamId, float fRadius)

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -32,6 +32,8 @@ ezProcPlacementComponentManager::~ezProcPlacementComponentManager() {}
 
 void ezProcPlacementComponentManager::Initialize()
 {
+  SUPER::Initialize();
+
   {
     auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezProcPlacementComponentManager::FindTiles, this);
     desc.m_Phase = ezWorldModule::UpdateFunctionDesc::Phase::PreAsync;
@@ -66,6 +68,8 @@ void ezProcPlacementComponentManager::Deinitialize()
     activeTile.Deinitialize(*GetWorld());
   }
   m_ActiveTiles.Clear();
+
+  SUPER::Deinitialize();
 }
 
 void ezProcPlacementComponentManager::FindTiles(const ezWorldModule::UpdateContext& context)

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -43,6 +43,8 @@ ezProcVertexColorComponentManager::~ezProcVertexColorComponentManager() = defaul
 
 void ezProcVertexColorComponentManager::Initialize()
 {
+  SUPER::Initialize();
+
   {
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezUInt32);
@@ -82,6 +84,8 @@ void ezProcVertexColorComponentManager::Deinitialize()
   ezResourceManager::GetResourceEvents().RemoveEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnResourceEvent, this));
 
   ezProcVolumeComponent::GetAreaInvalidatedEvent().RemoveEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnAreaInvalidated, this));
+
+  SUPER::Deinitialize();
 }
 
 void ezProcVertexColorComponentManager::UpdateVertexColors(const ezWorldModule::UpdateContext& context)

--- a/Data/Samples/Testing Chambers/Weapons/Plasma/Plasma_SI_Default.ezPrefab
+++ b/Data/Samples/Testing Chambers/Weapons/Plasma/Plasma_SI_Default.ezPrefab
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{4503936315766485946,5467247986140777545}}
-		u4 %Hash{13541855931827474398}
+		u4 %Hash{16237774556327049893}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{4954456250233479308,17760596100351715494}}
@@ -75,7 +75,7 @@ o
 		b %Active{1}
 		u1 %OcclusionCollisionLayer{0}
 		f %OcclusionThreshold{0x0000003F}
-		s %OnFinishedAction{"ezOnComponentFinishedAction::None"}
+		s %OnFinishedAction{"ezOnComponentFinishedAction::DeleteGameObject"}
 		b %Paused{0}
 		f %Pitch{0x0000803F}
 		b %ShowDebugInfo{0}
@@ -295,7 +295,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezGameObject"}
-		u3 %TypeSize{168}
+		u3 %TypeSize{128}
 		u3 %TypeVersion{1}
 	}
 }
@@ -367,7 +367,7 @@ o
 		s %PluginName{"ezEditorPluginParticle"}
 		VarArray %Properties{}
 		s %TypeName{"ezParticleComponent"}
-		u3 %TypeSize{336}
+		u3 %TypeSize{328}
 		u3 %TypeVersion{5}
 	}
 }


### PR DESCRIPTION
Ensure that render data caches are invalidated when non-render components are added or removed. Also made sure that caches are deleted when objects are deleted that only had non-render components attached.