### PR TITLE
OpenXR upgrade

### DIFF
--- a/Code/BuildSystem/CMake/FindEzOpenXR.cmake
+++ b/Code/BuildSystem/CMake/FindEzOpenXR.cmake
@@ -54,7 +54,8 @@ elseif (EZ_CMAKE_PLATFORM_WINDOWS_DESKTOP)
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ezOpenXR DEFAULT_MSG EZ_OPENXR_DIR)
+find_package_handle_standard_args(ezOpenXR DEFAULT_MSG EZ_OPENXR_LOADER_DIR)
+find_package_handle_standard_args(ezOpenXR DEFAULT_MSG EZ_OPENXR_HEADERS_DIR)
 
 if (EZOPENXR_FOUND)
 

--- a/Code/BuildSystem/CMake/FindEzOpenXR.cmake
+++ b/Code/BuildSystem/CMake/FindEzOpenXR.cmake
@@ -6,23 +6,26 @@ if (TARGET ezOpenXR::Loader)
 	return()
 endif()
 
-set (EZ_OPENXR_DIR "EZ_OPENXR_DIR-NOTFOUND" CACHE PATH "Directory of OpenXR runtime installation")
+set (EZ_OPENXR_LOADER_DIR "EZ_OPENXR_LOADER_DIR-NOTFOUND" CACHE PATH "Directory of OpenXR loader installation")
+set (EZ_OPENXR_HEADERS_DIR "EZ_OPENXR_HEADERS_DIR-NOTFOUND" CACHE PATH "Directory of OpenXR headers installation")
 set (EZ_OPENXR_PREVIEW_DIR "" CACHE PATH "Directory of OpenXR preview include root")
-mark_as_advanced(FORCE EZ_OPENXR_DIR)
+mark_as_advanced(FORCE EZ_OPENXR_LOADER_DIR)
+mark_as_advanced(FORCE EZ_OPENXR_HEADERS_DIR)
 mark_as_advanced(FORCE EZ_OPENXR_PREVIEW_DIR)
 
 ez_pull_compiler_and_architecture_vars()
 
-if ((EZ_OPENXR_DIR STREQUAL "EZ_OPENXR_DIR-NOTFOUND") OR (EZ_OPENXR_DIR STREQUAL ""))
+if ((EZ_OPENXR_LOADER_DIR STREQUAL "EZ_OPENXR_LOADER_DIR-NOTFOUND") OR (EZ_OPENXR_LOADER_DIR STREQUAL "") OR (EZ_OPENXR_HEADERS_DIR STREQUAL "EZ_OPENXR_HEADERS_DIR-NOTFOUND") OR (EZ_OPENXR_HEADERS_DIR STREQUAL ""))
 	ez_nuget_init()
 	execute_process(COMMAND ${NUGET} restore ${CMAKE_SOURCE_DIR}/Code/EnginePlugins/OpenXRPlugin/packages.config -PackagesDirectory ${CMAKE_BINARY_DIR}/packages
 	WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-	set (EZ_OPENXR_DIR "${CMAKE_BINARY_DIR}/packages/OpenXR.Loader.1.0.6.2" CACHE PATH "Directory of OpenXR runtime installation" FORCE)
+	set (EZ_OPENXR_LOADER_DIR "${CMAKE_BINARY_DIR}/packages/OpenXR.Loader.1.0.10.2" CACHE PATH "Directory of OpenXR loader installation" FORCE)
+	set (EZ_OPENXR_HEADERS_DIR "${CMAKE_BINARY_DIR}/packages/OpenXR.Headers.1.0.10.2" CACHE PATH "Directory of OpenXR headers installation" FORCE)
 endif()
 
 if (EZ_CMAKE_PLATFORM_WINDOWS_UWP)
 	set (OPENXR_DYNAMIC ON)
-	find_path(EZ_OPENXR_DIR include/openxr/openxr.h)
+	find_path(EZ_OPENXR_HEADERS_DIR include/openxr/openxr.h)
 
 	if (EZ_CMAKE_ARCHITECTURE_ARM)
 		if (EZ_CMAKE_ARCHITECTURE_64BIT)
@@ -40,7 +43,7 @@ if (EZ_CMAKE_PLATFORM_WINDOWS_UWP)
 
 elseif (EZ_CMAKE_PLATFORM_WINDOWS_DESKTOP)
 	set (OPENXR_DYNAMIC ON)
-	find_path(EZ_OPENXR_DIR include/openxr/openxr.h)
+	find_path(EZ_OPENXR_HEADERS_DIR include/openxr/openxr.h)
 
 	if (EZ_CMAKE_ARCHITECTURE_64BIT)
 		set(OPENXR_BIN_PREFIX "x64")
@@ -50,8 +53,6 @@ elseif (EZ_CMAKE_PLATFORM_WINDOWS_DESKTOP)
 
 endif()
 
-set (OPENXR_DIR_LOADER "${EZ_OPENXR_DIR}")
-
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ezOpenXR DEFAULT_MSG EZ_OPENXR_DIR)
 
@@ -59,15 +60,15 @@ if (EZOPENXR_FOUND)
 
 	add_library(ezOpenXR::Loader SHARED IMPORTED)
 	if (OPENXR_DYNAMIC)
-		set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_LOCATION "${OPENXR_DIR_LOADER}/native/${OPENXR_BIN_PREFIX}/release/bin/openxr_loader.dll")
-		set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_LOCATION_DEBUG "${OPENXR_DIR_LOADER}/native/${OPENXR_BIN_PREFIX}/release/bin/openxr_loader.dll")
+		set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_LOCATION "${EZ_OPENXR_LOADER_DIR}/native/${OPENXR_BIN_PREFIX}/release/bin/openxr_loader.dll")
+		set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_LOCATION_DEBUG "${EZ_OPENXR_LOADER_DIR}/native/${OPENXR_BIN_PREFIX}/release/bin/openxr_loader.dll")
 	endif()
-	set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_IMPLIB "${OPENXR_DIR_LOADER}/native/${OPENXR_BIN_PREFIX}/release/lib/openxr_loader.lib")
-	set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_IMPLIB_DEBUG "${OPENXR_DIR_LOADER}/native/${OPENXR_BIN_PREFIX}/release/lib/openxr_loader.lib")
+	set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_IMPLIB "${EZ_OPENXR_LOADER_DIR}/native/${OPENXR_BIN_PREFIX}/release/lib/openxr_loader.lib")
+	set_target_properties(ezOpenXR::Loader PROPERTIES IMPORTED_IMPLIB_DEBUG "${EZ_OPENXR_LOADER_DIR}/native/${OPENXR_BIN_PREFIX}/release/lib/openxr_loader.lib")
 	
-	set_target_properties(ezOpenXR::Loader PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${OPENXR_DIR_LOADER}/include")
+	set_target_properties(ezOpenXR::Loader PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${EZ_OPENXR_HEADERS_DIR}/include")
 	if (NOT EZ_OPENXR_PREVIEW_DIR STREQUAL "")
-		set_target_properties(ezOpenXR::Loader PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${EZ_OPENXR_PREVIEW_DIR}/include")		
+		set_target_properties(ezOpenXR::Loader PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${EZ_OPENXR_HEADERS_DIR}/include")		
 	endif()
 
 	ez_uwp_mark_import_as_content(ezOpenXR::Loader)
@@ -75,7 +76,6 @@ if (EZOPENXR_FOUND)
 endif()
 
 unset (OPENXR_DYNAMIC)
-unset (OPENXR_DIR_LOADER)
 unset (OPENXR_BIN_PREFIX)
 
 

--- a/Code/BuildSystem/CMake/toolchain-winstore.cmake
+++ b/Code/BuildSystem/CMake/toolchain-winstore.cmake
@@ -1,5 +1,4 @@
 set(CMAKE_SYSTEM_NAME WindowsStore)
 
-# Windows anniversary update version. As of writing the newest hololens emulator does not support Windows Creator's update.
-set(CMAKE_SYSTEM_VERSION 10.0.14393.0)
-set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.14393.0)
+set(CMAKE_SYSTEM_VERSION 10.0.18362.0)
+set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION 10.0.18362.0)

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
@@ -29,14 +29,7 @@ namespace ezApplicationDetails
 
     AppClass* pApp = new (appBuffer) AppClass(std::forward<Args>(arguments)...);
 
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_SUPPORT
-    // TODO: Using OpenXR will crash if we create a core window, will have to use standard run method
-    // and let OpenXR runtime create the window instead. We can't check at this stage whether OpenXR
-    // will be used dynamically as nothing has been initialized yet.
-    ezRun(pApp);
-#else
     ezUWPRun(pApp).IgnoreResult();
-#endif // BUILDSYSTEM_ENABLE_OPENXR_SUPPORT
 
     const int iReturnCode = pApp->GetReturnCode();
     if (iReturnCode != 0)

--- a/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
@@ -43,12 +43,13 @@ void ezUwpApplication::Load(winrt::hstring const& entryPoint)
 
 void ezUwpApplication::Run()
 {
-  ezRun_Startup(m_application);
+  if (ezRun_Startup(m_application).Succeeded())
+  {
+    auto window = winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread();
+    window.Activate();
 
-  auto window = winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread();
-  window.Activate();
-
-  ezRun_MainLoop(m_application);
+    ezRun_MainLoop(m_application);
+  }
   ezRun_Shutdown(m_application);
 }
 

--- a/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.h
@@ -8,38 +8,38 @@ EZ_FOUNDATION_INTERNAL_HEADER
 #  include <Foundation/Basics.h>
 #  include <Foundation/Strings/String.h>
 
-#  include <Windows.ApplicationModel.core.h>
-#  include <Windows.Applicationmodel.h>
-
 #  include <Foundation/Basics/Platform/uwp/UWPUtils.h>
+#  include <winrt/base.h>
 
-using namespace ABI::Windows::ApplicationModel::Core;
-using namespace ABI::Windows::ApplicationModel::Activation;
+#  include <winrt/Windows.ApplicationModel.Activation.h>
+#  include <winrt/Windows.ApplicationModel.Core.h>
 
 class ezApplication;
 
 /// Minimal implementation of a uwp application.
-class ezUwpApplication : public RuntimeClass<IFrameworkViewSource, IFrameworkView>
+class ezUwpApplication : public winrt::implements<ezUwpApplication, winrt::Windows::ApplicationModel::Core::IFrameworkView, winrt::Windows::ApplicationModel::Core::IFrameworkViewSource>
 {
 public:
   ezUwpApplication(ezApplication* application);
   virtual ~ezUwpApplication();
 
   // Inherited via IFrameworkViewSource
-  virtual HRESULT __stdcall CreateView(IFrameworkView** viewProvider) override;
+  winrt::Windows::ApplicationModel::Core::IFrameworkView CreateView();
 
   // Inherited via IFrameworkView
-  virtual HRESULT __stdcall Initialize(ICoreApplicationView* applicationView) override;
-  virtual HRESULT __stdcall SetWindow(ABI::Windows::UI::Core::ICoreWindow* window) override;
-  virtual HRESULT __stdcall Load(HSTRING entryPoint) override;
-  virtual HRESULT __stdcall Run() override;
-  virtual HRESULT __stdcall Uninitialize() override;
+  void Initialize(winrt::Windows::ApplicationModel::Core::CoreApplicationView const& applicationView);
+  void SetWindow(winrt::Windows::UI::Core::CoreWindow const& window);
+  void Load(winrt::hstring const& entryPoint);
+  void Run();
+  void Uninitialize();
 
 private:
-  HRESULT OnActivated(ICoreApplicationView*, IActivatedEventArgs* args);
+  // Application lifecycle event handlers.
+  void OnViewActivated(winrt::Windows::ApplicationModel::Core::CoreApplicationView const& sender, winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs const& args);
+
+  winrt::event_token m_activateRegistrationToken;
 
   ezApplication* m_application;
-  EventRegistrationToken m_activateRegistrationToken;
   ezDynamicArray<ezString> m_commandLineArgs;
 };
 

--- a/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/Win/ETWProvider_win.cpp
@@ -12,6 +12,10 @@
 #  undef _TlgPragmaUtf8End
 #  define _TlgPragmaUtf8Begin
 #  define _TlgPragmaUtf8End
+#  undef _tlgPragmaUtf8Begin
+#  undef _tlgPragmaUtf8End
+#  define _tlgPragmaUtf8Begin
+#  define _tlgPragmaUtf8End
 
 TRACELOGGING_DECLARE_PROVIDER(g_ezETWLogProvider);
 

--- a/Code/Engine/GameEngine/Animation/PropertyAnimComponent.h
+++ b/Code/Engine/GameEngine/Animation/PropertyAnimComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <Core/Messages/EventMessage.h>
 #include <Core/Messages/CommonMessages.h>
+#include <Core/Messages/EventMessage.h>
 #include <Core/World/Component.h>
 #include <Core/World/World.h>
 #include <Foundation/Types/SharedPtr.h>

--- a/Code/Engine/GameEngine/Animation/PropertyAnimComponent.h
+++ b/Code/Engine/GameEngine/Animation/PropertyAnimComponent.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <Core/Messages/EventMessage.h>
+#include <Core/Messages/CommonMessages.h>
 #include <Core/World/Component.h>
 #include <Core/World/World.h>
 #include <Foundation/Types/SharedPtr.h>
 #include <GameEngine/Animation/PropertyAnimResource.h>
 #include <GameEngine/GameEngineDLL.h>
-
 struct ezMsgSetPlaying;
 
 typedef ezComponentManagerSimple<class ezPropertyAnimComponent, ezComponentUpdateType::WhenSimulating> ezPropertyAnimComponentManager;

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -115,9 +115,22 @@ void ezGameState::CreateActors()
       ezView* pView = nullptr;
       EZ_VERIFY(ezRenderWorld::TryGetView(m_hMainView, pView), "");
       ezUniquePtr<ezActor> pXRActor = pXRInterface->CreateActor(pView, ezGALMSAASampleCount::Default, std::move(pMainWindow), std::move(pOutput));
-      ezActorManager::GetSingleton()->AddActor(std::move(pXRActor));
+
+      if (pXRActor)
+      {
+        ezActorManager::GetSingleton()->AddActor(std::move(pXRActor));
+        return;
+      }
+      else
+      {
+        ezUniquePtr<ezWindow> pMainWindow = CreateMainWindow();
+        EZ_ASSERT_DEV(pMainWindow != nullptr, "To change the main window creation behavior, override ezGameState::CreateActors().");
+        ezUniquePtr<ezWindowOutputTargetBase> pOutput = CreateMainOutputTarget(pMainWindow.Borrow());
+        ConfigureMainWindowInputDevices(pMainWindow.Borrow());
+        SetupMainView(pOutput.Borrow(), pMainWindow->GetClientAreaSize());
+      }
     }
-    else
+    
     {
       // Default flat window
       ezUniquePtr<ezActorPluginWindowOwner> pWindowPlugin = EZ_DEFAULT_NEW(ezActorPluginWindowOwner);

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -130,7 +130,7 @@ void ezGameState::CreateActors()
         SetupMainView(pOutput.Borrow(), pMainWindow->GetClientAreaSize());
       }
     }
-    
+
     {
       // Default flat window
       ezUniquePtr<ezActorPluginWindowOwner> pWindowPlugin = EZ_DEFAULT_NEW(ezActorPluginWindowOwner);

--- a/Code/Engine/GameEngine/XR/DeviceTrackingComponent.h
+++ b/Code/Engine/GameEngine/XR/DeviceTrackingComponent.h
@@ -59,4 +59,3 @@ protected:
   bool m_bRotation = true;
   bool m_bScale = true;
 };
-

--- a/Code/Engine/GameEngine/XR/DeviceTrackingComponent.h
+++ b/Code/Engine/GameEngine/XR/DeviceTrackingComponent.h
@@ -56,4 +56,7 @@ protected:
   ezEnum<ezXRDeviceType> m_deviceType;
   ezEnum<ezXRPoseLocation> m_poseLocation;
   ezEnum<ezXRTransformSpace> m_space;
+  bool m_bRotation = true;
+  bool m_bScale = true;
 };
+

--- a/Code/EnginePlugins/OpenXRPlugin/CMakeLists.txt
+++ b/Code/EnginePlugins/OpenXRPlugin/CMakeLists.txt
@@ -13,7 +13,6 @@ target_link_libraries(${PROJECT_NAME}
   GameEngine
 )
 
-target_compile_definitions(${PROJECT_NAME} PUBLIC BUILDSYSTEM_ENABLE_OPENXR_SUPPORT)
 if (NOT EZ_OPENXR_PREVIEW_DIR STREQUAL "")
 	target_compile_definitions(${PROJECT_NAME} PUBLIC BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT)
 endif()

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.cpp
@@ -11,7 +11,7 @@ EZ_IMPLEMENT_SINGLETON(ezOpenXRHandTracking);
 
 bool ezOpenXRHandTracking::IsHandTrackingSupported(ezOpenXR* pOpenXR)
 {
-  XrSystemHandTrackingPropertiesEXT handTrackingSystemProperties{ XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT };
+  XrSystemHandTrackingPropertiesEXT handTrackingSystemProperties{XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT};
   XrSystemProperties systemProperties{XR_TYPE_SYSTEM_PROPERTIES, &handTrackingSystemProperties};
   XrResult res = xrGetSystemProperties(pOpenXR->m_instance, pOpenXR->m_systemId, &systemProperties);
   if (res == XrResult::XR_SUCCESS)
@@ -28,7 +28,7 @@ ezOpenXRHandTracking::ezOpenXRHandTracking(ezOpenXR* pOpenXR)
   for (ezUInt32 uiSide : {0, 1})
   {
     const XrHandEXT uiHand = uiSide == 0 ? XR_HAND_LEFT_EXT : XR_HAND_RIGHT_EXT;
-    XrHandTrackerCreateInfoEXT createInfo{ XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT };
+    XrHandTrackerCreateInfoEXT createInfo{XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT};
     createInfo.hand = uiHand;
     XR_LOG_ERROR(m_pOpenXR->m_extensions.pfn_xrCreateHandTrackerEXT(pOpenXR->m_session, &createInfo, &m_HandTracker[uiSide]));
 
@@ -135,7 +135,7 @@ void ezOpenXRHandTracking::UpdateJointTransforms()
 {
   EZ_PROFILE_SCOPE("UpdateJointTransforms");
   const XrTime time = m_pOpenXR->m_frameState.predictedDisplayTime;
-  XrHandJointsLocateInfoEXT locateInfo{ XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT };
+  XrHandJointsLocateInfoEXT locateInfo{XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT};
   locateInfo.baseSpace = m_pOpenXR->GetBaseSpace();
   locateInfo.time = time;
 
@@ -150,7 +150,7 @@ void ezOpenXRHandTracking::UpdateJointTransforms()
       {
         const XrHandJointLocationEXT& spaceLocation = m_JointLocations[uiSide][i];
         if ((spaceLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0 &&
-          (spaceLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0)
+            (spaceLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0)
         {
           m_JointData[uiSide][i].m_bValid = true;
           m_JointData[uiSide][i].m_Bone.m_fRadius = spaceLocation.radius;

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.cpp
@@ -11,15 +11,13 @@ EZ_IMPLEMENT_SINGLETON(ezOpenXRHandTracking);
 
 bool ezOpenXRHandTracking::IsHandTrackingSupported(ezOpenXR* pOpenXR)
 {
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
-  XrSystemHandTrackingPropertiesMSFT handTrackingSystemProperties{XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_MSFT};
+  XrSystemHandTrackingPropertiesEXT handTrackingSystemProperties{ XR_TYPE_SYSTEM_HAND_TRACKING_PROPERTIES_EXT };
   XrSystemProperties systemProperties{XR_TYPE_SYSTEM_PROPERTIES, &handTrackingSystemProperties};
   XrResult res = xrGetSystemProperties(pOpenXR->m_instance, pOpenXR->m_systemId, &systemProperties);
   if (res == XrResult::XR_SUCCESS)
   {
     return handTrackingSystemProperties.supportsHandTracking;
   }
-#endif
   return false;
 }
 
@@ -27,88 +25,81 @@ ezOpenXRHandTracking::ezOpenXRHandTracking(ezOpenXR* pOpenXR)
   : m_SingletonRegistrar(this)
   , m_pOpenXR(pOpenXR)
 {
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
-  EZ_ASSERT_DEV(m_pOpenXR->m_extensions.m_bHandTracking, "Hand tracking not supported");
   for (ezUInt32 uiSide : {0, 1})
   {
-    const XrHandMSFT uiHand = uiSide == 0 ? XR_HAND_LEFT_MSFT : XR_HAND_RIGHT_MSFT;
-    XrHandTrackerCreateInfoMSFT createInfo{XR_TYPE_HAND_TRACKER_CREATE_INFO_MSFT};
+    const XrHandEXT uiHand = uiSide == 0 ? XR_HAND_LEFT_EXT : XR_HAND_RIGHT_EXT;
+    XrHandTrackerCreateInfoEXT createInfo{ XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT };
     createInfo.hand = uiHand;
-    XR_LOG_ERROR(m_pOpenXR->m_extensions.pfn_xrCreateHandTrackerMSFT(pOpenXR->m_session, &createInfo, &m_HandTracker[uiSide]));
+    XR_LOG_ERROR(m_pOpenXR->m_extensions.pfn_xrCreateHandTrackerEXT(pOpenXR->m_session, &createInfo, &m_HandTracker[uiSide]));
 
-    XrHandJointSpaceCreateInfoMSFT jointCreateInfo{XR_TYPE_HAND_JOINT_SPACE_CREATE_INFO_MSFT};
-    jointCreateInfo.handTracker = m_HandTracker[uiSide];
-    jointCreateInfo.poseInJointSpace = {{0, 0, 0, 1}, {0, 0, 0}};
+    m_Locations[uiSide].type = XR_TYPE_HAND_JOINT_LOCATIONS_EXT;
+    m_Locations[uiSide].next = &m_Velocities;
+    m_Locations[uiSide].jointCount = XR_HAND_JOINT_COUNT_EXT;
+    m_Locations[uiSide].jointLocations = m_JointLocations[uiSide];
 
-    m_JointData[uiSide].SetCount(XR_HAND_JOINT_LITTLE_TIP_MSFT + 1);
-    for (ezUInt32 i = 0; i <= XR_HAND_JOINT_LITTLE_TIP_MSFT; ++i)
+    m_Velocities[uiSide].type = XR_TYPE_HAND_JOINT_VELOCITIES_EXT;
+    m_Velocities[uiSide].jointCount = XR_HAND_JOINT_COUNT_EXT;
+    m_Velocities[uiSide].jointVelocities = m_JointVelocities[uiSide];
+
+    m_JointData[uiSide].SetCount(XR_HAND_JOINT_LITTLE_TIP_EXT + 1);
+    for (ezUInt32 i = 0; i <= XR_HAND_JOINT_LITTLE_TIP_EXT; ++i)
     {
       m_JointData[uiSide][i].m_Bone.m_Transform.SetIdentity();
-      jointCreateInfo.joint = (XrHandJointMSFT)i;
-      XR_LOG_ERROR(m_pOpenXR->m_extensions.pfn_xrCreateHandJointSpaceMSFT(pOpenXR->m_session, &jointCreateInfo, &m_JointData[uiSide][i].m_Space));
     }
   }
 
   // Map hand parts to hand joints
-  m_HandParts[ezXRHandPart::Palm].PushBack(XR_HAND_JOINT_PALM_MSFT);
-  m_HandParts[ezXRHandPart::Palm].PushBack(XR_HAND_JOINT_WRIST_MSFT);
+  m_HandParts[ezXRHandPart::Palm].PushBack(XR_HAND_JOINT_PALM_EXT);
+  m_HandParts[ezXRHandPart::Palm].PushBack(XR_HAND_JOINT_WRIST_EXT);
 
-  m_HandParts[ezXRHandPart::Wrist].PushBack(XR_HAND_JOINT_WRIST_MSFT);
+  m_HandParts[ezXRHandPart::Wrist].PushBack(XR_HAND_JOINT_WRIST_EXT);
 
-  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_TIP_MSFT);
-  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_DISTAL_MSFT);
-  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_PROXIMAL_MSFT);
-  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_METACARPAL_MSFT);
-  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_WRIST_MSFT);
+  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_TIP_EXT);
+  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_DISTAL_EXT);
+  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_PROXIMAL_EXT);
+  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_THUMB_METACARPAL_EXT);
+  m_HandParts[ezXRHandPart::Thumb].PushBack(XR_HAND_JOINT_WRIST_EXT);
 
-  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_TIP_MSFT);
-  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_DISTAL_MSFT);
-  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_INTERMEDIATE_MSFT);
-  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_PROXIMAL_MSFT);
-  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_METACARPAL_MSFT);
-  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_WRIST_MSFT);
+  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_TIP_EXT);
+  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_DISTAL_EXT);
+  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_INTERMEDIATE_EXT);
+  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_PROXIMAL_EXT);
+  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_INDEX_METACARPAL_EXT);
+  m_HandParts[ezXRHandPart::Index].PushBack(XR_HAND_JOINT_WRIST_EXT);
 
-  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_TIP_MSFT);
-  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_DISTAL_MSFT);
-  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_INTERMEDIATE_MSFT);
-  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_PROXIMAL_MSFT);
-  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_METACARPAL_MSFT);
-  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_WRIST_MSFT);
+  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_TIP_EXT);
+  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_DISTAL_EXT);
+  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_INTERMEDIATE_EXT);
+  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT);
+  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_MIDDLE_METACARPAL_EXT);
+  m_HandParts[ezXRHandPart::Middle].PushBack(XR_HAND_JOINT_WRIST_EXT);
 
-  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_TIP_MSFT);
-  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_DISTAL_MSFT);
-  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_INTERMEDIATE_MSFT);
-  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_PROXIMAL_MSFT);
-  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_METACARPAL_MSFT);
-  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_WRIST_MSFT);
+  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_TIP_EXT);
+  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_DISTAL_EXT);
+  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_INTERMEDIATE_EXT);
+  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_PROXIMAL_EXT);
+  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_RING_METACARPAL_EXT);
+  m_HandParts[ezXRHandPart::Ring].PushBack(XR_HAND_JOINT_WRIST_EXT);
 
-  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_TIP_MSFT);
-  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_DISTAL_MSFT);
-  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_INTERMEDIATE_MSFT);
-  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_PROXIMAL_MSFT);
-  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_METACARPAL_MSFT);
-  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_WRIST_MSFT);
-#endif
+  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_TIP_EXT);
+  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_DISTAL_EXT);
+  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_INTERMEDIATE_EXT);
+  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_PROXIMAL_EXT);
+  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_LITTLE_METACARPAL_EXT);
+  m_HandParts[ezXRHandPart::Little].PushBack(XR_HAND_JOINT_WRIST_EXT);
 }
 
 ezOpenXRHandTracking::~ezOpenXRHandTracking()
 {
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
   for (ezUInt32 uiSide : {0, 1})
   {
-    for (ezUInt32 i = 0; i <= XR_HAND_JOINT_LITTLE_TIP_MSFT; ++i)
-    {
-      XR_LOG_ERROR(xrDestroySpace(m_JointData[uiSide][i].m_Space));
-    }
-    XR_LOG_ERROR(m_pOpenXR->m_extensions.pfn_xrDestroyHandTrackerMSFT(m_HandTracker[uiSide]));
+    XR_LOG_ERROR(m_pOpenXR->m_extensions.pfn_xrDestroyHandTrackerEXT(m_HandTracker[uiSide]));
   }
-#endif
 }
 
 ezXRHandTrackingInterface::HandPartTrackingState ezOpenXRHandTracking::TryGetBoneTransforms(
   ezEnum<ezXRHand> hand, ezEnum<ezXRHandPart> handPart, ezEnum<ezXRTransformSpace> space, ezDynamicArray<ezXRHandBone>& out_bones)
 {
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
   EZ_ASSERT_DEV(handPart <= ezXRHandPart::Little, "Invalid hand part.");
   out_bones.Clear();
 
@@ -128,7 +119,7 @@ ezXRHandTrackingInterface::HandPartTrackingState ezOpenXRHandTracking::TryGetBon
     {
       if (const ezStageSpaceComponent* pStage = pStageMan->GetSingletonComponent())
       {
-        ezTransform globalStageTransform = pStage->GetOwner()->GetGlobalTransform();
+        const ezTransform globalStageTransform = pStage->GetOwner()->GetGlobalTransform();
         for (ezXRHandBone& bone : out_bones)
         {
           ezTransform local = bone.m_Transform;
@@ -138,38 +129,48 @@ ezXRHandTrackingInterface::HandPartTrackingState ezOpenXRHandTracking::TryGetBon
     }
   }
   return ezXRHandTrackingInterface::HandPartTrackingState::Tracked;
-#else
-  return ezXRHandTrackingInterface::HandPartTrackingState::NotSupported;
-#endif
 }
 
 void ezOpenXRHandTracking::UpdateJointTransforms()
 {
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
   EZ_PROFILE_SCOPE("UpdateJointTransforms");
   const XrTime time = m_pOpenXR->m_frameState.predictedDisplayTime;
+  XrHandJointsLocateInfoEXT locateInfo{ XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT };
+  locateInfo.baseSpace = m_pOpenXR->GetBaseSpace();
+  locateInfo.time = time;
+
   for (ezUInt32 uiSide : {0, 1})
   {
-    for (ezUInt32 i = 0; i <= XR_HAND_JOINT_LITTLE_TIP_MSFT; ++i)
+    if (m_pOpenXR->m_extensions.pfn_xrLocateHandJointsEXT(m_HandTracker[uiSide], &locateInfo, &m_Locations[uiSide]) != XrResult::XR_SUCCESS)
+      m_Locations[uiSide].isActive = false;
+
+    if (m_Locations[uiSide].isActive)
     {
-      XrHandJointRadiusMSFT jointRadius{XR_TYPE_HAND_JOINT_RADIUS_MSFT};
-      XrSpaceLocation spaceLocation{XR_TYPE_SPACE_LOCATION, &jointRadius};
-      XrResult res = xrLocateSpace(m_JointData[uiSide][i].m_Space, m_pOpenXR->GetBaseSpace(), time, &spaceLocation);
-      if (res == XrResult::XR_SUCCESS && (spaceLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0 &&
-          (spaceLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0)
+      for (ezUInt32 i = 0; i <= XR_HAND_JOINT_LITTLE_TIP_EXT; ++i)
       {
-        m_JointData[uiSide][i].m_bValid = true;
-        m_JointData[uiSide][i].m_Bone.m_fRadius = jointRadius.radius;
-        m_JointData[uiSide][i].m_Bone.m_Transform.m_vPosition = ezOpenXR::ConvertPosition(spaceLocation.pose.position);
-        m_JointData[uiSide][i].m_Bone.m_Transform.m_qRotation = ezOpenXR::ConvertOrientation(spaceLocation.pose.orientation);
+        const XrHandJointLocationEXT& spaceLocation = m_JointLocations[uiSide][i];
+        if ((spaceLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0 &&
+          (spaceLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0)
+        {
+          m_JointData[uiSide][i].m_bValid = true;
+          m_JointData[uiSide][i].m_Bone.m_fRadius = spaceLocation.radius;
+          m_JointData[uiSide][i].m_Bone.m_Transform.m_vPosition = ezOpenXR::ConvertPosition(spaceLocation.pose.position);
+          m_JointData[uiSide][i].m_Bone.m_Transform.m_qRotation = ezOpenXR::ConvertOrientation(spaceLocation.pose.orientation);
+        }
+        else
+        {
+          m_JointData[uiSide][i].m_bValid = false;
+        }
       }
-      else
+    }
+    else
+    {
+      for (ezUInt32 i = 0; i <= XR_HAND_JOINT_LITTLE_TIP_EXT; ++i)
       {
         m_JointData[uiSide][i].m_bValid = false;
       }
     }
   }
-#endif
 }
 
 EZ_STATICLINK_FILE(OpenXRPlugin, OpenXRPlugin_OpenXRHandTracking);

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.h
@@ -29,15 +29,17 @@ private:
   struct JointData
   {
     EZ_DECLARE_POD_TYPE();
-    XrSpace m_Space;
     ezXRHandBone m_Bone;
-    bool m_bValid = false;
+    bool m_bValid;
   };
 
   ezOpenXR* m_pOpenXR = nullptr;
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
-  XrHandTrackerMSFT m_HandTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
-  ezStaticArray<JointData, XR_HAND_JOINT_LITTLE_TIP_MSFT + 1> m_JointData[2];
+  XrHandTrackerEXT m_HandTracker[2] = { XR_NULL_HANDLE, XR_NULL_HANDLE };
+  XrHandJointLocationEXT m_JointLocations[2][XR_HAND_JOINT_COUNT_EXT];
+  XrHandJointVelocityEXT m_JointVelocities[2][XR_HAND_JOINT_COUNT_EXT];
+  XrHandJointLocationsEXT m_Locations[2]{ XR_TYPE_HAND_JOINT_LOCATIONS_EXT };
+  XrHandJointVelocitiesEXT m_Velocities[2]{ XR_TYPE_HAND_JOINT_VELOCITIES_EXT };
+
+  ezStaticArray<JointData, XR_HAND_JOINT_LITTLE_TIP_EXT + 1> m_JointData[2];
   ezStaticArray<ezUInt32, 6> m_HandParts[ezXRHandPart::Little + 1];
-#endif
 };

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.h
@@ -34,11 +34,11 @@ private:
   };
 
   ezOpenXR* m_pOpenXR = nullptr;
-  XrHandTrackerEXT m_HandTracker[2] = { XR_NULL_HANDLE, XR_NULL_HANDLE };
+  XrHandTrackerEXT m_HandTracker[2] = {XR_NULL_HANDLE, XR_NULL_HANDLE};
   XrHandJointLocationEXT m_JointLocations[2][XR_HAND_JOINT_COUNT_EXT];
   XrHandJointVelocityEXT m_JointVelocities[2][XR_HAND_JOINT_COUNT_EXT];
-  XrHandJointLocationsEXT m_Locations[2]{ XR_TYPE_HAND_JOINT_LOCATIONS_EXT };
-  XrHandJointVelocitiesEXT m_Velocities[2]{ XR_TYPE_HAND_JOINT_VELOCITIES_EXT };
+  XrHandJointLocationsEXT m_Locations[2]{XR_TYPE_HAND_JOINT_LOCATIONS_EXT};
+  XrHandJointVelocitiesEXT m_Velocities[2]{XR_TYPE_HAND_JOINT_VELOCITIES_EXT};
 
   ezStaticArray<JointData, XR_HAND_JOINT_LITTLE_TIP_EXT + 1> m_JointData[2];
   ezStaticArray<ezUInt32, 6> m_HandParts[ezXRHandPart::Little + 1];

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRIncludes.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRIncludes.h
@@ -3,6 +3,9 @@
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <d3d11_1.h>
 #define XR_USE_GRAPHICS_API_D3D11
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#  define XR_USE_PLATFORM_WIN32
+#endif
 #include <openxr/openxr.h>
 #include <openxr/openxr_platform.h>
 #include <openxr/openxr_platform_defines.h>

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRInputDevice.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRInputDevice.cpp
@@ -118,8 +118,8 @@ XrResult ezOpenXRInputDevice::CreateActions(XrSession session, XrSpace sceneSpac
   }
 
   XrActionSetCreateInfo actionSetInfo{XR_TYPE_ACTION_SET_CREATE_INFO};
-  strcpy(actionSetInfo.actionSetName, "gameplay");
-  strcpy(actionSetInfo.localizedActionSetName, "Gameplay");
+  ezStringUtils::Copy(actionSetInfo.actionSetName, XR_MAX_ACTION_SET_NAME_SIZE, "gameplay");
+  ezStringUtils::Copy(actionSetInfo.localizedActionSetName, XR_MAX_LOCALIZED_ACTION_SET_NAME_SIZE, "Gameplay");
   actionSetInfo.priority = 0;
   XR_SUCCEED_OR_CLEANUP_LOG(xrCreateActionSet(m_instance, &actionSetInfo, &m_ActionSet), DestroyActions);
 

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRPluginPCH.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRPluginPCH.h
@@ -4,10 +4,10 @@
 #include <Foundation/Logging/Log.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
-  #include <Unknwn.h> // Required to interop with IUnknown. Must be included before C++/WinRT headers.
+#  include <Unknwn.h> // Required to interop with IUnknown. Must be included before C++/WinRT headers.
 
-  #include <winrt/Windows.Foundation.h>
-  #include <winrt/Windows.Foundation.Collections.h>
+#  include <winrt/Windows.Foundation.Collections.h>
+#  include <winrt/Windows.Foundation.h>
 #endif
 
 // <StaticLinkUtil::StartHere>

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRPluginPCH.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRPluginPCH.h
@@ -1,8 +1,16 @@
 #pragma once
 
+#include <Foundation/Basics.h>
+#include <Foundation/Logging/Log.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
+  #include <Unknwn.h> // Required to interop with IUnknown. Must be included before C++/WinRT headers.
+
+  #include <winrt/Windows.Foundation.h>
+  #include <winrt/Windows.Foundation.Collections.h>
+#endif
+
 // <StaticLinkUtil::StartHere>
 // all include's before this will be left alone and not replaced by the StaticLinkUtil
 // all include's AFTER this will be removed by the StaticLinkUtil and updated by what is actually used throughout the library
 
-#include <Foundation/Basics.h>
-#include <Foundation/Logging/Log.h>

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRSingleton.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRSingleton.h
@@ -114,17 +114,15 @@ private:
     bool m_bHandInteraction = false;
 
     bool m_bHandTracking = false;
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
-    PFN_xrCreateHandTrackerMSFT pfn_xrCreateHandTrackerMSFT;
-    PFN_xrDestroyHandTrackerMSFT pfn_xrDestroyHandTrackerMSFT;
-    PFN_xrGetHandTrackerStateMSFT pfn_xrGetHandTrackerStateMSFT;
-    PFN_xrCreateHandJointSpaceMSFT pfn_xrCreateHandJointSpaceMSFT;
-#endif
+    PFN_xrCreateHandTrackerEXT pfn_xrCreateHandTrackerEXT;
+    PFN_xrDestroyHandTrackerEXT pfn_xrDestroyHandTrackerEXT;
+    PFN_xrLocateHandJointsEXT pfn_xrLocateHandJointsEXT;
+
     bool m_bHandTrackingMesh = false;
-#ifdef BUILDSYSTEM_ENABLE_OPENXR_PREVIEW_SUPPORT
     PFN_xrCreateHandMeshSpaceMSFT pfn_xrCreateHandMeshSpaceMSFT;
     PFN_xrUpdateHandMeshMSFT pfn_xrUpdateHandMeshMSFT;
-#endif
+
+    bool m_bHolographicWindowAttachment = false;
   };
 
   // Instance

--- a/Code/EnginePlugins/OpenXRPlugin/packages.config
+++ b/Code/EnginePlugins/OpenXRPlugin/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.6.2" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.10.2" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.2" targetFramework="native" />
 </packages>

--- a/Code/ThirdParty/enet/CMakeLists.txt
+++ b/Code/ThirdParty/enet/CMakeLists.txt
@@ -12,21 +12,14 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC BUILDSYSTEM_ENABLE_ENET_SUPPOR
 if(EZ_CMAKE_PLATFORM_WINDOWS)
   target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32 _WINSOCK_DEPRECATED_NO_WARNINGS)
 
-  if(EZ_CMAKE_PLATFORM_WINDOWS_UWP)
-
-    target_link_libraries(${PROJECT_NAME}
-      PRIVATE
-      OneCore.lib
-    )
-
-  else()
+  if(NOT EZ_CMAKE_PLATFORM_WINDOWS_UWP)
 
     target_link_libraries(${PROJECT_NAME}
       PRIVATE
       ws2_32.lib
       Kernel32.lib
       runtimeobject.lib
-      winmm.lib
+	    winmm.lib
     )
 
   endif()

--- a/Code/ThirdParty/vhacd/src/vhacdVolume.cpp
+++ b/Code/ThirdParty/vhacd/src/vhacdVolume.cpp
@@ -23,6 +23,9 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma warning(push)
+#pragma warning(disable : 4244)
+
 #ifndef _CRT_SECURE_NO_WARNINGS
 #    define _CRT_SECURE_NO_WARNINGS
 #endif
@@ -1185,3 +1188,5 @@ void raycastFill(Volume* volume, RaycastMesh* raycastMesh)
 }
 
 } // namespace VHACD
+
+#pragma warning(pop)

--- a/Code/ThirdParty/zlib/CMakeLists.txt
+++ b/Code/ThirdParty/zlib/CMakeLists.txt
@@ -18,14 +18,7 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC BUILDSYSTEM_ENABLE_ZLIB_SUPPOR
 if(MSVC)
   target_compile_definitions(${PROJECT_NAME} PRIVATE WIN32)
 
-  if(EZ_CMAKE_PLATFORM_WINDOWS_UWP)
-
-    target_link_libraries(${PROJECT_NAME}
-      PRIVATE
-      OneCore.lib
-    )
-
-  elseif(EZ_COMPILE_ENGINE_AS_DLL)
+  if(NOT EZ_CMAKE_PLATFORM_WINDOWS_UWP AND EZ_COMPILE_ENGINE_AS_DLL)
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE ZLIB_DLL_EXPORT=1)
     target_compile_definitions(${PROJECT_NAME} PUBLIC ZLIB_DLL_IMPORT=1)


### PR DESCRIPTION
* Updated OpenXR loader and include NuGet packages to the newest version.
  * Replace preview extensions with final versions.
* Basic implementation of XR_MSFT_HOLOGRAPHIC_WINDOW_ATTACHMENT_EXTENSION_NAME. Resolves #237
* WACK compliance for enent and zlib
* Compiler fix for newest windows SDK which renamed _TlgPragmaUtf8Begin etc.
* Rewrote ezUwpApplication in cppwinrt
* Fallback to flatscreen if XR actor can't be created.
* ezDeviceTrackingComponent extended with option to exclude rotation and scale
* Compile fix for ezPropertyAnimComponent which relies on CommonMessages.h but does not include it itself.