### PR TITLE
Allow using an 'ezSdkRoot.txt' redirection file to point to the SDK dir

### DIFF
--- a/Code/BuildSystem/CMake/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/ezUtilsCppFlags.cmake
@@ -99,7 +99,7 @@ function(ez_set_build_flags_msvc TARGET_NAME)
 	# Remove unreferenced data (does not work together with incremental build)
 	set (LINKER_FLAGS_RELEASE "${LINKER_FLAGS_RELEASE} /OPT:REF")
 		
-	# Enable comdat folding. Reduces the number of redudant template functions and thus reduces binary size. Makes debugging harder though.
+	# Enable comdat folding. Reduces the number of redundant template functions and thus reduces binary size. Makes debugging harder though.
 	set (LINKER_FLAGS_RELEASE "${LINKER_FLAGS_RELEASE} /OPT:ICF")	
 
   	set_target_properties (${TARGET_NAME} PROPERTIES LINK_FLAGS_RELEASE        ${LINKER_FLAGS_RELEASE})
@@ -109,18 +109,26 @@ function(ez_set_build_flags_msvc TARGET_NAME)
 		target_compile_options(${TARGET_NAME} PRIVATE "/analyze")
 	endif()
 	
-	# Ignore various warnings we are not interrested in
+	# Ignore various warnings we are not interested in
 	# 4251 = class 'type' needs to have dll-interface to be used by clients of class 'type2' -> dll export / import issues (mostly with templates)
+	target_compile_options(${TARGET_NAME} PUBLIC /wd4251)
+
 	# 4345 = behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized
+	target_compile_options(${TARGET_NAME} PUBLIC /wd4345)
+
 	# 4201 = nonstandard extension used: nameless struct/union
+	target_compile_options(${TARGET_NAME} PUBLIC /wd4201)
+
 	# 4324 = structure was padded due to alignment specifier
+	target_compile_options(${TARGET_NAME} PUBLIC /wd4324)
+
 	# 4100 = unreferenced formal parameter
 	# 4189 = local variable is initialized but not referenced
 	# 4127 = conditional expression is constant
 	# 4245 = signed/unsigned mismatch
 	# 4389 = signed/unsigned mismatch
 	# 4310 = cast truncates constant value
-	target_compile_options(${TARGET_NAME} PRIVATE /wd4251 /wd4345 /wd4201 /wd4324 /wd4100 /wd4189 /wd4127 /wd4245 /wd4389 /wd4310)
+	target_compile_options(${TARGET_NAME} PRIVATE /wd4100 /wd4189 /wd4127 /wd4245 /wd4389 /wd4310)
 	
 	# Set Warnings as Errors: Too few/many parameters given for Macro
 	target_compile_options(${TARGET_NAME} PRIVATE /we4002 /we4003)

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -213,6 +213,8 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
 
   {
     EZ_PROFILE_SCOPE("Filesystem");
+    ezFileSystem::DetectSdkRootDirectory();
+
     const ezString sAppDir = ezApplicationServices::GetSingleton()->GetApplicationDataFolder();
     ezString sUserData = ezApplicationServices::GetSingleton()->GetApplicationUserDataFolder();
     if (!ezStringUtils::IsNullOrEmpty(szUserDataFolder))

--- a/Code/Engine/Foundation/IO/FileSystem/FileSystem.h
+++ b/Code/Engine/Foundation/IO/FileSystem/FileSystem.h
@@ -129,14 +129,20 @@ public:
 
   /// \brief Searches for a directory to use as the "Sdk" special directory
   ///
-  /// It does so by starting at the directory where the application binary is located and then going up until it finds
-  /// a folder that contains the given sub-folder.
-  /// The sub-folder is usually where the engine loads the most basic data from, so it should exist.
+  /// It does so by starting at the directory where the application binary is located and then goes up
+  /// until it finds a folder that contains the given sub-folder. The sub-folder is usually where the
+  /// engine loads the most basic data from, so it should exist.
+  ///
+  /// Additionally the 'redirection file' feature of ezFileSystem::FindFolderWithSubPath() is used
+  /// to allow finding a relocated SDK folder. To do that, place a file called 'ezSdkRoot.txt'
+  /// in your top level folder. It should contain the relative path pointing to the SDK folder.
   ///
   /// Upon success SetSdkRootDirectory() is called with the resulting path.
   ///
   /// \note If the Sdk root directory has been set before, this function does nothing!
   /// It will not override a previously set value. If that is desired, call SetSdkRootDirectory("") first.
+  ///
+  /// \sa ezFileSystem::FindFolderWithSubPath()
   static ezResult DetectSdkRootDirectory(const char* szExpectedSubFolder = "Data/Base");
 
   /// \brief the special directory ">Sdk" is the root folder of the SDK data, it is often used as the main reference
@@ -224,8 +230,14 @@ public:
     ezDataDirectoryType** out_ppDataDir = nullptr); // [tested]
 
   /// \brief Starts at szStartDirectory and goes up until it finds a folder that contains the given sub folder structure.
+  ///
   /// Returns EZ_FAILURE if nothing is found. Otherwise \a result is the absolute path to the existing folder that has a given sub-folder.
-  static ezResult FindFolderWithSubPath(const char* szStartDirectory, const char* szSubPath, ezStringBuilder& result); // [tested]
+  ///
+  /// \param result If successful, this contains the folder path in which szSubPath exists.
+  /// \param szStartDirectory The directory in which to start the search and iterate upwards.
+  /// \param szSubPath the relative path to look for in each visited directory. The function succeeds if such a file or folder is found.
+  /// \param szRedirectionFileName An optional file name for a redirection file. If in any visited folder a file with this name is found, it will be opened, read entirely, and appended to the current search path, and it is checked whether \a szSubPath can be found there. This step is not recursive and can't result in an endless loop. It allows to relocate the SDK folder and still have it found, by placing such a redirection file. A common use case, is when ezEngine is used as a Git submodule and therefore the overall file structure is slightly different.
+  static ezResult FindFolderWithSubPath(ezStringBuilder& result, const char* szStartDirectory, const char* szSubPath, const char* szRedirectionFileName = nullptr); // [tested]
 
   /// \brief Returns true, if any data directory knows how to redirect the given path. Otherwise the original string is returned in out_sRedirection.
   static bool ResolveAssetRedirection(const char* szPathOrAssetGuid, ezStringBuilder& out_sRedirection);
@@ -320,9 +332,9 @@ struct ezFileSystem::FileEventType
     CloseFile,                 ///< A file was closed.
     AddDataDirectorySucceeded, ///< A data directory was successfully added.
     AddDataDirectoryFailed,    ///< Adding a data directory failed. No factory could handle it (or there were none).
-    RemoveDataDirectory, ///< A data directory was removed. IMPORTANT: This is where ResourceManagers should check if some loaded resources need to be
-                         ///< purged.
-    DeleteFile           ///< A file is about to be deleted.
+    RemoveDataDirectory,       ///< A data directory was removed. IMPORTANT: This is where ResourceManagers should check if some loaded resources need to be
+                               ///< purged.
+    DeleteFile                 ///< A file is about to be deleted.
   };
 };
 

--- a/Code/Engine/Foundation/IO/FileSystem/Implementation/FileSystem.cpp
+++ b/Code/Engine/Foundation/IO/FileSystem/Implementation/FileSystem.cpp
@@ -676,8 +676,7 @@ ezResult ezFileSystem::ResolvePath(const char* szPath, ezStringBuilder* out_sAbs
   return EZ_SUCCESS;
 }
 
-
-ezResult ezFileSystem::FindFolderWithSubPath(const char* szStartDirectory, const char* szSubPath, ezStringBuilder& result)
+ezResult ezFileSystem::FindFolderWithSubPath(ezStringBuilder& result, const char* szStartDirectory, const char* szSubPath, const char* szRedirectionFileName /*= nullptr*/)
 {
   ezStringBuilder sStartDirAbs = szStartDirectory;
   sStartDirAbs.MakeCleanPath();
@@ -698,7 +697,6 @@ ezResult ezFileSystem::FindFolderWithSubPath(const char* szStartDirectory, const
     sStartDirAbs = abs;
   }
 
-
   result = szStartDirectory;
   result.MakeCleanPath();
 
@@ -706,30 +704,46 @@ ezResult ezFileSystem::FindFolderWithSubPath(const char* szStartDirectory, const
 
   while (!result.IsEmpty())
   {
-    FullPath = sStartDirAbs;
-    FullPath.AppendPath("ezSdkRoot.txt");
+    sRedirection.Clear();
 
-    ezOSFile f;
-    if (f.Open(FullPath, ezFileOpenMode::Read).Succeeded())
+    if (!ezStringUtils::IsNullOrEmpty(szRedirectionFileName))
     {
-      ezDataBuffer db;
-      f.ReadAll(db);
-      db.PushBack('\0');
-      sRedirection.Set((const char*)db.GetData());
-    }
-    else
-    {
-      sRedirection.Clear();
+      FullPath = sStartDirAbs;
+      FullPath.AppendPath(szRedirectionFileName);
+
+      ezOSFile f;
+      if (f.Open(FullPath, ezFileOpenMode::Read).Succeeded())
+      {
+        ezDataBuffer db;
+        f.ReadAll(db);
+        db.PushBack('\0');
+        sRedirection.Set((const char*)db.GetData());
+      }
     }
 
+    // first try with the redirection
+    if (!sRedirection.IsEmpty())
+    {
+      FullPath = sStartDirAbs;
+      FullPath.AppendPath(sRedirection);
+      FullPath.AppendPath(szSubPath);
+      FullPath.MakeCleanPath();
+
+      if (ezOSFile::ExistsDirectory(FullPath) || ezOSFile::ExistsFile(FullPath))
+      {
+        result.AppendPath(sRedirection);
+        result.MakeCleanPath();
+        return EZ_SUCCESS;
+      }
+    }
+
+    // then try without the redirection
     FullPath = sStartDirAbs;
-    FullPath.AppendPath(sRedirection);
     FullPath.AppendPath(szSubPath);
     FullPath.MakeCleanPath();
 
     if (ezOSFile::ExistsDirectory(FullPath) || ezOSFile::ExistsFile(FullPath))
     {
-      result.AppendPath(sRedirection);
       return EZ_SUCCESS;
     }
 
@@ -797,9 +811,9 @@ ezResult ezFileSystem::DetectSdkRootDirectory(const char* szExpectedSubFolder /*
 #elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
   sdkRoot = ezOSFile::GetApplicationDirectory();
 #else
-  if (ezFileSystem::FindFolderWithSubPath(ezOSFile::GetApplicationDirectory(), szExpectedSubFolder, sdkRoot).Failed())
+  if (ezFileSystem::FindFolderWithSubPath(sdkRoot, ezOSFile::GetApplicationDirectory(), szExpectedSubFolder, "ezSdkRoot.txt").Failed())
   {
-    ezLog::Error("Could not find SDK root. Application dir is '{0}'. Searched for parent with 'Data\\Base' sub-folder.", ezOSFile::GetApplicationDirectory());
+    ezLog::Error("Could not find SDK root. Application dir is '{0}'. Searched for parent with '{1}' sub-folder.", ezOSFile::GetApplicationDirectory(), szExpectedSubFolder);
     return EZ_FAILURE;
   }
 #endif

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -98,7 +98,7 @@ ezString ezGameApplication::FindProjectDirectory() const
   }
 
   ezStringBuilder result;
-  if (ezFileSystem::FindFolderWithSubPath(ezOSFile::GetApplicationDirectory(), m_sAppProjectPath, result).Failed())
+  if (ezFileSystem::FindFolderWithSubPath(result, ezOSFile::GetApplicationDirectory(), m_sAppProjectPath).Failed())
   {
     ezLog::Error("Could not find the project directory.");
   }

--- a/Code/Tools/Libs/ToolsFoundation/Application/Implementation/ApplicationServices.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Application/Implementation/ApplicationServices.cpp
@@ -4,6 +4,7 @@
 #include <ToolsFoundation/Application/ApplicationServices.h>
 #include <ToolsFoundation/Document/Document.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
+#include <Foundation/IO/FileSystem/FileSystem.h>
 
 EZ_IMPLEMENT_SINGLETON(ezApplicationServices);
 
@@ -36,11 +37,13 @@ ezString ezApplicationServices::GetApplicationUserDataFolder() const
 
 ezString ezApplicationServices::GetApplicationDataFolder() const
 {
-  ezStringBuilder sAppDir = ezOSFile::GetApplicationDirectory();
-  sAppDir.AppendPath("../../../Data/Tools", m_sApplicationName);
-  sAppDir.MakeCleanPath();
+  ezStringBuilder sAppDir(">sdk/Data/Tools/", m_sApplicationName);
 
-  return sAppDir;
+  ezStringBuilder result;
+  ezFileSystem::ResolveSpecialDirectory(sAppDir, result);
+  result.MakeCleanPath();
+
+  return result;
 }
 
 ezString ezApplicationServices::GetApplicationPreferencesFolder() const

--- a/Code/Tools/Libs/ToolsFoundation/Application/Implementation/ApplicationServices.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Application/Implementation/ApplicationServices.cpp
@@ -1,10 +1,10 @@
 #include <ToolsFoundationPCH.h>
 
+#include <Foundation/IO/FileSystem/FileSystem.h>
 #include <Foundation/IO/OSFile.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 #include <ToolsFoundation/Document/Document.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
-#include <Foundation/IO/FileSystem/FileSystem.h>
 
 EZ_IMPLEMENT_SINGLETON(ezApplicationServices);
 

--- a/Code/Tools/Player/Main.cpp
+++ b/Code/Tools/Player/Main.cpp
@@ -38,12 +38,11 @@ ezResult ezPlayerApplication::BeforeCoreSystemsStartup()
   else
 #else
   m_sSceneFile = ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-scene", 0, "");
-  EZ_ASSERT_ALWAYS(
-    !m_sSceneFile.IsEmpty(), "Scene file has not been specified. Use the -scene command followed by a full path to the ezBinaryScene file");
+  EZ_ASSERT_ALWAYS(!m_sSceneFile.IsEmpty(), "Scene file has not been specified. Use the -scene command followed by a full path to the ezBinaryScene file");
 #endif
   {
     ezStringBuilder projectPath;
-    if (ezFileSystem::FindFolderWithSubPath(m_sSceneFile, "ezProject", projectPath).Succeeded())
+    if (ezFileSystem::FindFolderWithSubPath(projectPath, m_sSceneFile, "ezProject").Succeeded())
     {
       m_sAppProjectPath = projectPath;
     }

--- a/Code/UnitTests/FoundationTest/IO/FileSystemTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/FileSystemTest.cpp
@@ -310,7 +310,7 @@ Only concrete and clocks.\n\
       StartPath.Set(sOutputFolder1Resolved, "/SubSub", "/Irrelevant");
       SubPath.Set("DoesNotExist");
 
-      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(StartPath, SubPath, result).Failed());
+      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(result, StartPath, SubPath).Failed());
     }
 
     {
@@ -318,7 +318,7 @@ Only concrete and clocks.\n\
       SubPath.Set("SubFolder2");
       expected.Set(sOutputFolderResolved, "/IO/");
 
-      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(StartPath, SubPath, result).Succeeded());
+      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(result, StartPath, SubPath).Succeeded());
       EZ_TEST_STRING(result, expected);
     }
 
@@ -327,7 +327,7 @@ Only concrete and clocks.\n\
       SubPath.Set("IO/SubFolder2");
       expected.Set(sOutputFolderResolved, "/");
 
-      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(StartPath, SubPath, result).Succeeded());
+      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(result, StartPath, SubPath).Succeeded());
       EZ_TEST_STRING(result, expected);
     }
 
@@ -336,7 +336,7 @@ Only concrete and clocks.\n\
       SubPath.Set("IO/SubFolder2");
       expected.Set(sOutputFolderResolved, "/");
 
-      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(StartPath, SubPath, result).Succeeded());
+      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(result, StartPath, SubPath).Succeeded());
       EZ_TEST_STRING(result, expected);
     }
 
@@ -345,7 +345,7 @@ Only concrete and clocks.\n\
       SubPath.Set("SubFolder2/FileSystemTest2.txt");
       expected.Set(sOutputFolderResolved, "/IO/");
 
-      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(StartPath, SubPath, result).Succeeded());
+      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(result, StartPath, SubPath).Succeeded());
       EZ_TEST_STRING(result, expected);
     }
 
@@ -354,7 +354,7 @@ Only concrete and clocks.\n\
       SubPath.Set("IO/SubFolder2");
       expected.Set(":toplevel/");
 
-      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(StartPath, SubPath, result).Succeeded());
+      EZ_TEST_BOOL(ezFileSystem::FindFolderWithSubPath(result, StartPath, SubPath).Succeeded());
       EZ_TEST_STRING(result, expected);
     }
 


### PR DESCRIPTION
If ezEngine is hooked up as a submodule, ez apps can't find the proper folder where the SDK root is located.

With this change you can put a file 'ezSdkRoot.txt' into the top most folder of your repository. It has to contain the relative path from this directory, to the ez SDK directory.

So if your repository is in "C:\MyRepo" and ez is a submodule located in "C:\MyRepo\ezSubmodule", you would put the file into "C:\MyRepo" and it should only contain the string "ezSubmodule".

Then all tools (ezEditor etc) and all ez(Game)Applications will automatically find the correct root.