### PR TITLE
Restored old mesh importer behavior

### DIFF
--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/AssimpMeshImport.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/AssimpMeshImport.cpp
@@ -203,18 +203,18 @@ namespace ezModelImporter2
       streams.uiBoneWgt = mb.AddStream(ezGALVertexAttributeSemantic::BoneWeights0, ezGALResourceFormat::RGBAHalf);
     }
 
-    bool bTexCoords1 = true;
-    bool bVertexColors0 = true;
-    bool bVertexColors1 = true;
+    bool bTexCoords1 = false;
+    bool bVertexColors0 = false;
+    bool bVertexColors1 = false;
 
     for (auto pMesh : referenceMeshes)
     {
-      if (!pMesh->HasTextureCoords(1))
-        bTexCoords1 = false;
-      if (!pMesh->HasVertexColors(0))
-        bVertexColors0 = false;
-      if (!pMesh->HasVertexColors(1))
-        bVertexColors1 = false;
+      if (pMesh->HasTextureCoords(1))
+        bTexCoords1 = true;
+      if (pMesh->HasVertexColors(0))
+        bVertexColors0 = true;
+      if (pMesh->HasVertexColors(1))
+        bVertexColors1 = true;
     }
 
     if (bTexCoords1)


### PR DESCRIPTION
Import vertex colors or UV1 once one mesh in the source file has it, instead of only importing it when all meshes have the streams.
Note that all vertex data is already pre-initialized with 0 so if a mesh doesn't have a stream its data will be automatically zero.