### PR TITLE
View additions

### DIFF
--- a/Code/EditorPlugins/Assets/EnginePluginAssets/MaterialAsset/MaterialView.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/MaterialAsset/MaterialView.cpp
@@ -35,6 +35,7 @@ ezViewHandle ezMaterialViewContext::CreateView()
   ezRenderWorld::CreateView("Material Editor - View", pView);
 
   pView->SetRenderPipelineResource(CreateDefaultRenderPipeline());
+  pView->SetShaderPermutationVariable("MATERIAL_PREVIEW", "TRUE");
 
   ezEngineProcessDocumentContext* pDocumentContext = GetDocumentContext();
   pView->SetWorld(pDocumentContext->GetWorld());

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -893,7 +893,7 @@ void ezGameObject::SendEventMessage(ezEventMessage& msg, const ezComponent* pSen
 
 void ezGameObject::SendEventMessage(ezEventMessage& msg, const ezComponent* pSenderComponent) const
 {
-  if (const ezComponent* pReceiver = GetWorld()->FindEventMsgHandler(msg, const_cast<ezGameObject*>(this)))
+  if (const ezComponent* pReceiver = GetWorld()->FindEventMsgHandler(msg, this))
   {
     if (pSenderComponent)
     {
@@ -908,7 +908,7 @@ void ezGameObject::SendEventMessage(ezEventMessage& msg, const ezComponent* pSen
 void ezGameObject::PostEventMessage(
   ezEventMessage& msg, const ezComponent* pSenderComponent, ezTime delay, ezObjectMsgQueueType::Enum queueType) const
 {
-  if (const ezComponent* pReceiver = GetWorld()->FindEventMsgHandler(msg, const_cast<ezGameObject*>(this)))
+  if (const ezComponent* pReceiver = GetWorld()->FindEventMsgHandler(msg, this))
   {
     if (pSenderComponent)
     {

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -447,6 +447,7 @@ ezUInt32 ezShadowPool::AddDirectionalLight(const ezDirectionalLightComponent* pD
     {
       pView->SetName(viewNames[i]);
       pView->SetWorld(const_cast<ezWorld*>(pDirLight->GetWorld()));
+      pView->SetLodCamera(pReferenceCamera);
     }
 
     // Setup camera

--- a/Code/Engine/RendererCore/Pipeline/ExtractedRenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/ExtractedRenderData.h
@@ -12,23 +12,21 @@ public:
   ezExtractedRenderData();
 
   EZ_ALWAYS_INLINE void SetCamera(const ezCamera& camera) { m_Camera = camera; }
-
   EZ_ALWAYS_INLINE const ezCamera& GetCamera() const { return m_Camera; }
 
-  EZ_ALWAYS_INLINE void SetViewData(const ezViewData& viewData) { m_ViewData = viewData; }
+  EZ_ALWAYS_INLINE void SetLodCamera(const ezCamera& camera) { m_LodCamera = camera; }
+  EZ_ALWAYS_INLINE const ezCamera& GetLodCamera() const { return m_LodCamera; }
 
+  EZ_ALWAYS_INLINE void SetViewData(const ezViewData& viewData) { m_ViewData = viewData; }
   EZ_ALWAYS_INLINE const ezViewData& GetViewData() const { return m_ViewData; }
 
   EZ_ALWAYS_INLINE void SetWorldTime(ezTime time) { m_WorldTime = time; }
-
   EZ_ALWAYS_INLINE ezTime GetWorldTime() const { return m_WorldTime; }
 
   EZ_ALWAYS_INLINE void SetWorldDebugContext(const ezDebugRendererContext& debugContext) { m_WorldDebugContext = debugContext; }
-
   EZ_ALWAYS_INLINE const ezDebugRendererContext& GetWorldDebugContext() const { return m_WorldDebugContext; }
 
   EZ_ALWAYS_INLINE void SetViewDebugContext(const ezDebugRendererContext& debugContext) { m_ViewDebugContext = debugContext; }
-
   EZ_ALWAYS_INLINE const ezDebugRendererContext& GetViewDebugContext() const { return m_ViewDebugContext; }
 
   void AddRenderData(const ezRenderData* pRenderData, ezRenderData::Category category);
@@ -57,6 +55,7 @@ private:
   };
 
   ezCamera m_Camera;
+  ezCamera m_LodCamera; // Temporary until we have a real LOD system
   ezViewData m_ViewData;
   ezTime m_WorldTime;
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -868,6 +868,7 @@ void ezRenderPipeline::ExtractData(const ezView& view)
 
   // Store camera and viewdata
   data.SetCamera(*view.GetCamera());
+  data.SetLodCamera(*view.GetLodCamera());
   data.SetViewData(view.GetData());
   data.SetWorldTime(view.GetWorld()->GetClock().GetAccumulatedTime());
   data.SetWorldDebugContext(view.GetWorld());
@@ -1022,6 +1023,12 @@ void ezRenderPipeline::Render(ezRenderContext* pRenderContext)
   else
     pRenderContext->SetShaderPermutationVariable(sCameraMode, sPerspective);
 
+  // Also set pipeline specific permutation vars
+  for (auto& var : m_PermutationVars)
+  {
+    pRenderContext->SetShaderPermutationVariable(var.m_sName, var.m_sValue);
+  }
+
   ezRenderWorldRenderEvent renderEvent;
   renderEvent.m_Type = ezRenderWorldRenderEvent::Type::BeforePipelineExecution;
   renderEvent.m_pPipeline = this;
@@ -1102,6 +1109,8 @@ void ezRenderPipeline::Render(ezRenderContext* pRenderContext)
 
   renderEvent.m_Type = ezRenderWorldRenderEvent::Type::AfterPipelineExecution;
   ezRenderWorld::s_RenderEvent.Broadcast(renderEvent);
+
+  pRenderContext->ResetContextState();
 
   data.Clear();
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/View_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/View_inl.h
@@ -39,19 +39,24 @@ EZ_ALWAYS_INLINE const ezCamera* ezView::GetCamera() const
   return m_pCamera;
 }
 
-EZ_ALWAYS_INLINE void ezView::SetCullingCamera(ezCamera* pCamera)
+EZ_ALWAYS_INLINE void ezView::SetCullingCamera(const ezCamera* pCamera)
 {
   m_pCullingCamera = pCamera;
-}
-
-EZ_ALWAYS_INLINE ezCamera* ezView::GetCullingCamera()
-{
-  return m_pCullingCamera != nullptr ? m_pCullingCamera : m_pCamera;
 }
 
 EZ_ALWAYS_INLINE const ezCamera* ezView::GetCullingCamera() const
 {
   return m_pCullingCamera != nullptr ? m_pCullingCamera : m_pCamera;
+}
+
+EZ_ALWAYS_INLINE void ezView::SetLodCamera(const ezCamera* pCamera)
+{
+  m_pLodCamera = pCamera;
+}
+
+EZ_ALWAYS_INLINE const ezCamera* ezView::GetLodCamera() const
+{
+  return m_pLodCamera != nullptr ? m_pLodCamera : m_pCamera;
 }
 
 EZ_ALWAYS_INLINE ezEnum<ezCameraUsageHint> ezView::GetCameraUsageHint() const

--- a/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
@@ -11,6 +11,7 @@ class ezProfilingId;
 class ezView;
 class ezRenderPipelinePass;
 class ezFrameDataProviderBase;
+struct ezPermutationVar;
 
 class EZ_RENDERERCORE_DLL ezRenderPipeline : public ezRefCounted
 {
@@ -136,4 +137,6 @@ private: // Member data
   // Data Providers
   mutable ezDynamicArray<ezUniquePtr<ezFrameDataProviderBase>> m_DataProviders;
   mutable ezHashTable<const ezRTTI*, ezUInt32> m_TypeToDataProviderIndex;
+
+  ezDynamicArray<ezPermutationVar> m_PermutationVars;
 };

--- a/Code/Engine/RendererCore/Pipeline/View.h
+++ b/Code/Engine/RendererCore/Pipeline/View.h
@@ -46,9 +46,11 @@ public:
   ezCamera* GetCamera();
   const ezCamera* GetCamera() const;
 
-  void SetCullingCamera(ezCamera* pCamera);
-  ezCamera* GetCullingCamera();
+  void SetCullingCamera(const ezCamera* pCamera);
   const ezCamera* GetCullingCamera() const;
+
+  void SetLodCamera(const ezCamera* pCamera);
+  const ezCamera* GetLodCamera() const;
 
   /// \brief Returns the camera usage hint for the view.
   ezEnum<ezCameraUsageHint> GetCameraUsageHint() const;
@@ -102,6 +104,8 @@ public:
   /// \brief Returns the frustum that should be used for determine visible objects for this view.
   void ComputeCullingFrustum(ezFrustum& out_Frustum) const;
 
+  void SetShaderPermutationVariable(const char* szName, const char* szValue);
+
   void SetRenderPassProperty(const char* szPassName, const char* szPropertyName, const ezVariant& value);
   void SetExtractorProperty(const char* szPassName, const char* szPropertyName, const ezVariant& value);
 
@@ -127,14 +131,15 @@ private:
 
   ezSharedPtr<ezTask> m_pExtractTask;
 
-  ezWorld* m_pWorld;
+  ezWorld* m_pWorld = nullptr;
 
   ezGALRenderTargetSetup m_RenderTargetSetup;
   ezRenderPipelineResourceHandle m_hRenderPipeline;
-  ezUInt32 m_uiRenderPipelineResourceDescriptionCounter;
+  ezUInt32 m_uiRenderPipelineResourceDescriptionCounter = 0;
   ezSharedPtr<ezRenderPipeline> m_pRenderPipeline;
-  ezCamera* m_pCamera;
-  ezCamera* m_pCullingCamera;
+  ezCamera* m_pCamera = nullptr;
+  const ezCamera* m_pCullingCamera = nullptr;
+  const ezCamera* m_pLodCamera = nullptr;
 
 private:
   ezRenderPipelineNodeInputPin m_PinRenderTarget0;
@@ -149,13 +154,18 @@ private:
   /// \brief Rebuilds pipeline if necessary and pushes double-buffered settings into the pipeline.
   void EnsureUpToDate();
 
-  mutable ezUInt32 m_uiLastCameraSettingsModification;
-  mutable ezUInt32 m_uiLastCameraOrientationModification;
-  mutable float m_fLastViewportAspectRatio;
+  mutable ezUInt32 m_uiLastCameraSettingsModification = 0;
+  mutable ezUInt32 m_uiLastCameraOrientationModification = 0;
+  mutable float m_fLastViewportAspectRatio = 1.0f;
 
   mutable ezViewData m_Data;
 
-  ezInternal::RenderDataCache* m_pRenderDataCache;
+  ezInternal::RenderDataCache* m_pRenderDataCache = nullptr;
+
+  ezDynamicArray<ezPermutationVar> m_PermutationVars;
+  bool m_bPermutationVarsDirty = false;
+
+  void ApplyPermutationVars();
 
   struct PropertyValue
   {

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -103,15 +103,11 @@ ezRenderContext::ezRenderContext()
 
   m_hGlobalConstantBufferStorage = CreateConstantBufferStorage<ezGlobalConstants>();
 
-  ezRenderWorld::GetRenderEvent().AddEventHandler(ezMakeDelegate(&ezRenderContext::OnRenderEvent, this));
-
   ResetContextState();
 }
 
 ezRenderContext::~ezRenderContext()
 {
-  ezRenderWorld::GetRenderEvent().RemoveEventHandler(ezMakeDelegate(&ezRenderContext::OnRenderEvent, this));
-
   DeleteConstantBufferStorage(m_hGlobalConstantBufferStorage);
 
   if (s_DefaultInstance == this)
@@ -704,6 +700,7 @@ void ezRenderContext::ResetContextState()
   m_hActiveShader.Invalidate();
   m_hActiveGALShader.Invalidate();
 
+  m_PermutationVariables.Clear();
   m_hNewMaterial.Invalidate();
   m_hMaterial.Invalidate();
 
@@ -879,14 +876,6 @@ void ezRenderContext::OnEngineShutdown()
     }
 
     s_FreeConstantBufferStorage.Clear();
-  }
-}
-
-void ezRenderContext::OnRenderEvent(const ezRenderWorldRenderEvent& e)
-{
-  if (e.m_Type == ezRenderWorldRenderEvent::Type::EndRender)
-  {
-    ResetContextState();
   }
 }
 

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -263,8 +263,6 @@ private:
 
   static void OnEngineShutdown();
 
-  void OnRenderEvent(const ezRenderWorldRenderEvent& e);
-
 private:
   Statistics m_Statistics;
   ezBitflags<ezRenderContextFlags> m_StateFlags;

--- a/Data/Base/Shaders/PermutationVars/MATERIAL_PREVIEW.ezPermVar
+++ b/Data/Base/Shaders/PermutationVars/MATERIAL_PREVIEW.ezPermVar
@@ -1,0 +1,1 @@
+bool MATERIAL_PREVIEW


### PR DESCRIPTION
Added lod camera to view
Also added additional permutation vars that can be set on the view. This is used to set a permutation var for the material preview in the editor that can be used by shaders to deactivate parts that need additional data which is not set in the material preview.