### PR TITLE
Adds a 'random seed' value to every game object

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/WorldRttiConverterContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/WorldRttiConverterContext.cpp
@@ -61,6 +61,7 @@ void* ezWorldRttiConverterContext::CreateObject(const ezUuid& guid, const ezRTTI
 
     ezGameObjectDesc d;
     d.m_sName.Assign(ezConversionUtils::ToString(guid, tmp).GetData());
+    d.m_uiStableRandomSeed = ezHashingUtils::xxHash32(tmp.GetData(), tmp.GetElementCount());
 
     ezGameObjectHandle hObject = m_pWorld->CreateObject(d);
     ezGameObject* pObject;

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -263,7 +263,7 @@ void ezPrefabReferenceComponent::InstantiatePrefab()
     {
       ezHybridArray<ezGameObject*, 8> createdRootObjects;
 
-      pResource->InstantiatePrefab(*GetWorld(), id, GetOwner()->GetHandle(), &createdRootObjects, &GetOwner()->GetTeamID(), &m_Parameters, false);
+      pResource->InstantiatePrefab(*GetWorld(), id, GetOwner()->GetHandle(), &createdRootObjects, &GetOwner()->GetTeamID(), &m_Parameters, false, GetOwner()->GetStableRandomSeed());
 
       // while exporting a scene all game objects with this tag are ignored and not exported
       // set this tag on all game objects that were created by instantiating this prefab
@@ -278,7 +278,7 @@ void ezPrefabReferenceComponent::InstantiatePrefab()
     }
     else
     {
-      pResource->InstantiatePrefab(*GetWorld(), id, GetOwner()->GetHandle(), nullptr, &GetOwner()->GetTeamID(), &m_Parameters, false);
+      pResource->InstantiatePrefab(*GetWorld(), id, GetOwner()->GetHandle(), nullptr, &GetOwner()->GetTeamID(), &m_Parameters, false, GetOwner()->GetStableRandomSeed());
     }
   }
 }

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -257,13 +257,19 @@ void ezPrefabReferenceComponent::InstantiatePrefab()
     ezTransform id;
     id.SetIdentity();
 
+    ezPrefabInstantiationOptions options;
+    options.m_hParent = GetOwner()->GetHandle();
+    options.m_pOverrideTeamID = &GetOwner()->GetTeamID();
+
     // if this ID is valid, this prefab is instantiated at editor runtime
     // replicate the same ID across all instantiated sub components to get correct picking behavior
     if (GetUniqueID() != ezInvalidIndex)
     {
       ezHybridArray<ezGameObject*, 8> createdRootObjects;
 
-      pResource->InstantiatePrefab(*GetWorld(), id, GetOwner()->GetHandle(), &createdRootObjects, &GetOwner()->GetTeamID(), &m_Parameters, false, GetOwner()->GetStableRandomSeed());
+      options.m_pCreatedRootObjectsOut = &createdRootObjects;
+
+      pResource->InstantiatePrefab(*GetWorld(), id, options, &m_Parameters);
 
       // while exporting a scene all game objects with this tag are ignored and not exported
       // set this tag on all game objects that were created by instantiating this prefab
@@ -278,7 +284,7 @@ void ezPrefabReferenceComponent::InstantiatePrefab()
     }
     else
     {
-      pResource->InstantiatePrefab(*GetWorld(), id, GetOwner()->GetHandle(), nullptr, &GetOwner()->GetTeamID(), &m_Parameters, false, GetOwner()->GetStableRandomSeed());
+      pResource->InstantiatePrefab(*GetWorld(), id, options, &m_Parameters);
     }
   }
 }

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
@@ -17,10 +17,16 @@ ezPrefabResource::ezPrefabResource()
 {
 }
 
-void ezPrefabResource::InstantiatePrefab(ezWorld& world, const ezTransform& rootTransform, ezGameObjectHandle hParent, ezHybridArray<ezGameObject*, 8>* out_CreatedRootObjects, const ezUInt16* pOverrideTeamID, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, bool bForceDynamic)
+void ezPrefabResource::InstantiatePrefab(
+  ezWorld& world, const ezTransform& rootTransform, ezGameObjectHandle hParent, ezHybridArray<ezGameObject*, 8>* out_CreatedRootObjects, const ezUInt16* pOverrideTeamID, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, bool bForceDynamic, ezUInt32 uiParentRandomSeed)
 {
   if (GetLoadingState() != ezResourceState::Loaded)
     return;
+
+  while (uiParentRandomSeed == 0)
+  {
+    uiParentRandomSeed = world.GetRandomNumberGenerator().UInt();
+  }
 
   if (pExposedParamValues != nullptr && !pExposedParamValues->IsEmpty())
   {
@@ -30,13 +36,13 @@ void ezPrefabResource::InstantiatePrefab(ezWorld& world, const ezTransform& root
     if (out_CreatedRootObjects == nullptr)
       out_CreatedRootObjects = &createdRootObjects;
 
-    m_WorldReader.InstantiatePrefab(world, rootTransform, hParent, out_CreatedRootObjects, &createdChildObjects, pOverrideTeamID, bForceDynamic);
+    m_WorldReader.InstantiatePrefab(world, rootTransform, hParent, out_CreatedRootObjects, &createdChildObjects, pOverrideTeamID, bForceDynamic, uiParentRandomSeed);
 
     ApplyExposedParameterValues(pExposedParamValues, createdChildObjects, *out_CreatedRootObjects);
   }
   else
   {
-    m_WorldReader.InstantiatePrefab(world, rootTransform, hParent, out_CreatedRootObjects, nullptr, pOverrideTeamID, bForceDynamic);
+    m_WorldReader.InstantiatePrefab(world, rootTransform, hParent, out_CreatedRootObjects, nullptr, pOverrideTeamID, bForceDynamic, uiParentRandomSeed);
   }
 }
 

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
@@ -17,32 +17,33 @@ ezPrefabResource::ezPrefabResource()
 {
 }
 
-void ezPrefabResource::InstantiatePrefab(
-  ezWorld& world, const ezTransform& rootTransform, ezGameObjectHandle hParent, ezHybridArray<ezGameObject*, 8>* out_CreatedRootObjects, const ezUInt16* pOverrideTeamID, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, bool bForceDynamic, ezUInt32 uiParentRandomSeed)
+void ezPrefabResource::InstantiatePrefab(ezWorld& world, const ezTransform& rootTransform, ezPrefabInstantiationOptions options, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues)
 {
   if (GetLoadingState() != ezResourceState::Loaded)
     return;
-
-  while (uiParentRandomSeed == 0)
-  {
-    uiParentRandomSeed = world.GetRandomNumberGenerator().UInt();
-  }
 
   if (pExposedParamValues != nullptr && !pExposedParamValues->IsEmpty())
   {
     ezHybridArray<ezGameObject*, 8> createdRootObjects;
     ezHybridArray<ezGameObject*, 8> createdChildObjects;
 
-    if (out_CreatedRootObjects == nullptr)
-      out_CreatedRootObjects = &createdRootObjects;
+    if (options.m_pCreatedRootObjectsOut == nullptr)
+    {
+      options.m_pCreatedRootObjectsOut = &createdRootObjects;
+    }
 
-    m_WorldReader.InstantiatePrefab(world, rootTransform, hParent, out_CreatedRootObjects, &createdChildObjects, pOverrideTeamID, bForceDynamic, uiParentRandomSeed);
+    if (options.m_pCreatedChildObjectsOut == nullptr)
+    {
+      options.m_pCreatedChildObjectsOut = &createdChildObjects;
+    }
 
-    ApplyExposedParameterValues(pExposedParamValues, createdChildObjects, *out_CreatedRootObjects);
+    m_WorldReader.InstantiatePrefab(world, rootTransform, options);
+
+    ApplyExposedParameterValues(pExposedParamValues, *options.m_pCreatedChildObjectsOut, *options.m_pCreatedRootObjectsOut);
   }
   else
   {
-    m_WorldReader.InstantiatePrefab(world, rootTransform, hParent, out_CreatedRootObjects, nullptr, pOverrideTeamID, bForceDynamic, uiParentRandomSeed);
+    m_WorldReader.InstantiatePrefab(world, rootTransform, options);
   }
 }
 

--- a/Code/Engine/Core/Prefabs/PrefabReferenceComponent.h
+++ b/Code/Engine/Core/Prefabs/PrefabReferenceComponent.h
@@ -69,8 +69,6 @@ private:
   void InstantiatePrefab();
   void ClearPreviousInstances();
 
-  void ResourceEventHandler(const ezResourceEvent& e);
-
   ezPrefabResourceHandle m_hPrefab;
   ezArrayMap<ezHashedString, ezVariant> m_Parameters;
   bool m_bInUpdateList = false;

--- a/Code/Engine/Core/Prefabs/PrefabResource.h
+++ b/Code/Engine/Core/Prefabs/PrefabResource.h
@@ -35,7 +35,8 @@ public:
   ezPrefabResource();
 
   /// \brief Creates an instance of this prefab in the given world.
-  void InstantiatePrefab(ezWorld& world, const ezTransform& rootTransform, ezGameObjectHandle hParent, ezHybridArray<ezGameObject*, 8>* out_CreatedRootObjects, const ezUInt16* pOverrideTeamID, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, bool bForceDynamic);
+  void InstantiatePrefab(
+    ezWorld& world, const ezTransform& rootTransform, ezGameObjectHandle hParent, ezHybridArray<ezGameObject*, 8>* out_CreatedRootObjects, const ezUInt16* pOverrideTeamID, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, bool bForceDynamic, ezUInt32 uiParentRandomSeed = 0);
 
   void ApplyExposedParameterValues(const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, const ezHybridArray<ezGameObject*, 8>& createdChildObjects, const ezHybridArray<ezGameObject*, 8>& createdRootObjects) const;
 

--- a/Code/Engine/Core/Prefabs/PrefabResource.h
+++ b/Code/Engine/Core/Prefabs/PrefabResource.h
@@ -35,8 +35,7 @@ public:
   ezPrefabResource();
 
   /// \brief Creates an instance of this prefab in the given world.
-  void InstantiatePrefab(
-    ezWorld& world, const ezTransform& rootTransform, ezGameObjectHandle hParent, ezHybridArray<ezGameObject*, 8>* out_CreatedRootObjects, const ezUInt16* pOverrideTeamID, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, bool bForceDynamic, ezUInt32 uiParentRandomSeed = 0);
+  void InstantiatePrefab(ezWorld& world, const ezTransform& rootTransform, ezPrefabInstantiationOptions options, const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues = nullptr);
 
   void ApplyExposedParameterValues(const ezArrayMap<ezHashedString, ezVariant>* pExposedParamValues, const ezHybridArray<ezGameObject*, 8>& createdChildObjects, const ezHybridArray<ezGameObject*, 8>& createdRootObjects) const;
 

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -443,7 +443,24 @@ public:
   /// \brief Changes the team ID for this object and all children recursively.
   void SetTeamID(ezUInt16 id);
 
+  /// \brief Returns a random value that is chosen once during object creation and remains stable even throughout serialization.
+  ///
+  /// This value is intended to be used for choosing random variations of components. For instance, if a component has two
+  /// different meshes it can use for variation, this seed should be used to decide which one to use.
+  ///
+  /// The stable random seed can also be set from the outside, which is what the editor does, to assign a truly stable seed value.
+  /// Therefore, each object placed in the editor will always have the same seed value, and objects won't change their appearance
+  /// on every run of the game.
+  ///
+  /// The stable seed is also propagated through prefab instances, such that every prefab instance gets a different value, but
+  /// in a deterministic fashion.
   ezUInt32 GetStableRandomSeed() const { return m_pTransformationData->m_uiStableRandomSeed; }
+
+  /// \brief OVerwrites the object's random seed value.
+  ///
+  /// See \a GetStableRandomSeed() for details.
+  ///
+  /// It should not be necessary to manually change this value, unless you want to make the seed deterministic according to a custom rule.
   void SetStableRandomSeed(ezUInt32 seed) { m_pTransformationData->m_uiStableRandomSeed = seed; }
 
 private:

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -174,15 +174,13 @@ public:
   void AddChild(const ezGameObjectHandle& child, ezGameObject::TransformPreservation preserve = TransformPreservation::PreserveGlobal);
 
   /// \brief Adds the given objects as child objects.
-  void AddChildren(
-    const ezArrayPtr<const ezGameObjectHandle>& children, ezGameObject::TransformPreservation preserve = TransformPreservation::PreserveGlobal);
+  void AddChildren(const ezArrayPtr<const ezGameObjectHandle>& children, ezGameObject::TransformPreservation preserve = TransformPreservation::PreserveGlobal);
 
   /// \brief Detaches the given child object from this object and makes it a top-level object.
   void DetachChild(const ezGameObjectHandle& child, ezGameObject::TransformPreservation preserve = TransformPreservation::PreserveGlobal);
 
   /// \brief Detaches the given child objects from this object and makes them top-level objects.
-  void DetachChildren(
-    const ezArrayPtr<const ezGameObjectHandle>& children, ezGameObject::TransformPreservation preserve = TransformPreservation::PreserveGlobal);
+  void DetachChildren(const ezArrayPtr<const ezGameObjectHandle>& children, ezGameObject::TransformPreservation preserve = TransformPreservation::PreserveGlobal);
 
   /// \brief Returns the number of children.
   ezUInt32 GetChildCount() const;
@@ -429,8 +427,7 @@ public:
   ///
   /// \param queueType In which update phase to deliver the message.
   /// \param delay An optional delay before delivering the message.
-  void PostEventMessage(ezEventMessage& msg, const ezComponent* pSenderComponent, ezTime delay,
-    ezObjectMsgQueueType::Enum queueType = ezObjectMsgQueueType::NextFrame) const;
+  void PostEventMessage(ezEventMessage& msg, const ezComponent* pSenderComponent, ezTime delay, ezObjectMsgQueueType::Enum queueType = ezObjectMsgQueueType::NextFrame) const;
 
 
   /// \brief Returns the tag set associated with this object.
@@ -445,6 +442,9 @@ public:
 
   /// \brief Changes the team ID for this object and all children recursively.
   void SetTeamID(ezUInt16 id);
+
+  ezUInt32 GetStableRandomSeed() const { return m_pTransformationData->m_uiStableRandomSeed; }
+  void SetStableRandomSeed(ezUInt32 seed) { m_pTransformationData->m_uiStableRandomSeed = seed; }
 
 private:
   friend class ezComponentManagerBase;
@@ -514,7 +514,9 @@ private:
     ezSpatialDataHandle m_hSpatialData;
     ezUInt32 m_uiSpatialDataCategoryBitmask;
 
-    ezUInt32 m_uiPadding2[2];
+    ezUInt32 m_uiStableRandomSeed = 0;
+
+    ezUInt32 m_uiPadding2[1];
 
     void UpdateLocalTransform();
 

--- a/Code/Engine/Core/World/GameObjectDesc.h
+++ b/Code/Engine/Core/World/GameObjectDesc.h
@@ -23,4 +23,5 @@ struct EZ_CORE_DLL ezGameObjectDesc
   ezVec3 m_LocalScaling = ezVec3(1, 1, 1);               ///< The local scaling relative to the parent (or the world)
   float m_LocalUniformScaling = 1.0f;                    ///< An additional local uniform scaling relative to the parent (or the world)
   ezTagSet m_Tags;                                       ///< See ezGameObject::GetTags()
+  ezUInt32 m_uiStableRandomSeed = 0;                     ///< 0 means the entity gets a random value assigned
 };

--- a/Code/Engine/Core/World/GameObjectDesc.h
+++ b/Code/Engine/Core/World/GameObjectDesc.h
@@ -23,5 +23,5 @@ struct EZ_CORE_DLL ezGameObjectDesc
   ezVec3 m_LocalScaling = ezVec3(1, 1, 1);               ///< The local scaling relative to the parent (or the world)
   float m_LocalUniformScaling = 1.0f;                    ///< An additional local uniform scaling relative to the parent (or the world)
   ezTagSet m_Tags;                                       ///< See ezGameObject::GetTags()
-  ezUInt32 m_uiStableRandomSeed = 0;                     ///< 0 means the entity gets a random value assigned
+  ezUInt32 m_uiStableRandomSeed = 0xFFFFFFFF;            ///< 0 means the entity gets a random value assigned, 0xFFFFFFFF means that if the object has a parent, the value will be derived deterministically from that one's seed, otherwise it gets a random value, any other value will be used directly
 };

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -186,6 +186,13 @@ ezGameObjectHandle ezWorld::CreateObject(const ezGameObjectDesc& desc, ezGameObj
   pTransformationData->m_globalBounds = pTransformationData->m_localBounds;
   pTransformationData->m_hSpatialData.Invalidate();
   pTransformationData->m_uiSpatialDataCategoryBitmask = 0;
+  pTransformationData->m_uiStableRandomSeed = desc.m_uiStableRandomSeed;
+
+  // make sure it's never zero
+  while (pTransformationData->m_uiStableRandomSeed == 0)
+  {
+    pTransformationData->m_uiStableRandomSeed = GetRandomNumberGenerator().UInt();
+  }
 
   if (pParentData != nullptr)
   {
@@ -269,8 +276,7 @@ ezComponentInitBatchHandle ezWorld::CreateComponentInitBatch(const char* szBatch
 void ezWorld::DeleteComponentInitBatch(const ezComponentInitBatchHandle& batch)
 {
   auto& pInitBatch = m_Data.m_InitBatches[batch.GetInternalID()];
-  EZ_ASSERT_DEV(pInitBatch->m_ComponentsToInitialize.IsEmpty() && pInitBatch->m_ComponentsToStartSimulation.IsEmpty(),
-    "Init batch has not been completely processed");
+  EZ_ASSERT_DEV(pInitBatch->m_ComponentsToInitialize.IsEmpty() && pInitBatch->m_ComponentsToStartSimulation.IsEmpty(), "Init batch has not been completely processed");
   m_Data.m_InitBatches.Remove(batch.GetInternalID());
 }
 
@@ -282,8 +288,7 @@ void ezWorld::BeginAddingComponentsToInitBatch(const ezComponentInitBatchHandle&
 
 void ezWorld::EndAddingComponentsToInitBatch(const ezComponentInitBatchHandle& batch)
 {
-  EZ_ASSERT_DEV(m_Data.m_InitBatches[batch.GetInternalID()] == m_Data.m_pCurrentInitBatch, "Init batch with id {} is currently not active",
-    batch.GetInternalID().m_Data);
+  EZ_ASSERT_DEV(m_Data.m_InitBatches[batch.GetInternalID()] == m_Data.m_pCurrentInitBatch, "Init batch with id {} is currently not active", batch.GetInternalID().m_Data);
   m_Data.m_pCurrentInitBatch = m_Data.m_pDefaultInitBatch;
 }
 
@@ -302,16 +307,12 @@ bool ezWorld::IsComponentInitBatchCompleted(const ezComponentInitBatchHandle& ba
   {
     if (pInitBatch->m_ComponentsToInitialize.IsEmpty())
     {
-      double fStartSimCompletion = pInitBatch->m_ComponentsToStartSimulation.IsEmpty()
-                                     ? 1.0
-                                     : (double)pInitBatch->m_uiNextComponentToStartSimulation / pInitBatch->m_ComponentsToStartSimulation.GetCount();
+      double fStartSimCompletion = pInitBatch->m_ComponentsToStartSimulation.IsEmpty() ? 1.0 : (double)pInitBatch->m_uiNextComponentToStartSimulation / pInitBatch->m_ComponentsToStartSimulation.GetCount();
       *pCompletionFactor = fStartSimCompletion * 0.5 + 0.5;
     }
     else
     {
-      double fInitCompletion = pInitBatch->m_ComponentsToInitialize.IsEmpty()
-                                 ? 1.0
-                                 : (double)pInitBatch->m_uiNextComponentToInitialize / pInitBatch->m_ComponentsToInitialize.GetCount();
+      double fInitCompletion = pInitBatch->m_ComponentsToInitialize.IsEmpty() ? 1.0 : (double)pInitBatch->m_uiNextComponentToInitialize / pInitBatch->m_ComponentsToInitialize.GetCount();
       *pCompletionFactor = fInitCompletion * 0.5;
     }
   }
@@ -325,8 +326,7 @@ void ezWorld::CancelComponentInitBatch(const ezComponentInitBatchHandle& batch)
   pInitBatch->m_ComponentsToInitialize.Clear();
   pInitBatch->m_ComponentsToStartSimulation.Clear();
 }
-void ezWorld::PostMessage(
-  const ezGameObjectHandle& receiverObject, const ezMessage& msg, ezObjectMsgQueueType::Enum queueType, ezTime delay, bool bRecursive) const
+void ezWorld::PostMessage(const ezGameObjectHandle& receiverObject, const ezMessage& msg, ezObjectMsgQueueType::Enum queueType, ezTime delay, bool bRecursive) const
 {
   // This method is allowed to be called from multiple threads.
 
@@ -621,8 +621,7 @@ void ezWorld::SetParent(ezGameObject* pObject, ezGameObject* pNewParent, ezGameO
 
 void ezWorld::LinkToParent(ezGameObject* pObject)
 {
-  EZ_ASSERT_DEBUG(
-    pObject->m_NextSiblingIndex == 0 && pObject->m_PrevSiblingIndex == 0, "Object is either still linked to another parent or data was not cleared.");
+  EZ_ASSERT_DEBUG(pObject->m_NextSiblingIndex == 0 && pObject->m_PrevSiblingIndex == 0, "Object is either still linked to another parent or data was not cleared.");
   if (ezGameObject* pParentObject = pObject->GetParent())
   {
     const ezUInt32 uiIndex = pObject->m_InternalId.m_InstanceIndex;
@@ -751,8 +750,7 @@ void ezWorld::ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::En
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
       if (entry.m_pMessage->GetDebugMessageRouting())
       {
-        ezLog::Warning(
-          "ezWorld::ProcessQueuedMessage: Receiver ezComponent for message of type '{0}' does not exist anymore.", entry.m_pMessage->GetId());
+        ezLog::Warning("ezWorld::ProcessQueuedMessage: Receiver ezComponent for message of type '{0}' does not exist anymore.", entry.m_pMessage->GetId());
       }
 #endif
     }
@@ -778,8 +776,7 @@ void ezWorld::ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::En
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
       if (entry.m_pMessage->GetDebugMessageRouting())
       {
-        ezLog::Warning(
-          "ezWorld::ProcessQueuedMessage: Receiver ezGameObject for message of type '{0}' does not exist anymore.", entry.m_pMessage->GetId());
+        ezLog::Warning("ezWorld::ProcessQueuedMessage: Receiver ezGameObject for message of type '{0}' does not exist anymore.", entry.m_pMessage->GetId());
       }
 #endif
     }
@@ -865,10 +862,8 @@ void ezWorld::RegisterUpdateFunction(const ezComponentManagerBase::UpdateFunctio
 {
   CheckForWriteAccess();
 
-  EZ_ASSERT_DEV(desc.m_Phase == ezComponentManagerBase::UpdateFunctionDesc::Phase::Async || desc.m_uiGranularity == 0,
-    "Granularity must be 0 for synchronous update functions");
-  EZ_ASSERT_DEV(desc.m_Phase != ezComponentManagerBase::UpdateFunctionDesc::Phase::Async || desc.m_DependsOn.GetCount() == 0,
-    "Asynchronous update functions must not have dependencies");
+  EZ_ASSERT_DEV(desc.m_Phase == ezComponentManagerBase::UpdateFunctionDesc::Phase::Async || desc.m_uiGranularity == 0, "Granularity must be 0 for synchronous update functions");
+  EZ_ASSERT_DEV(desc.m_Phase != ezComponentManagerBase::UpdateFunctionDesc::Phase::Async || desc.m_DependsOn.GetCount() == 0, "Asynchronous update functions must not have dependencies");
   EZ_ASSERT_DEV(desc.m_Function.IsComparable(), "Delegates with captures are not allowed as ezWorld update functions.");
 
   m_Data.m_UpdateFunctionsToRegister.PushBack(desc);
@@ -941,8 +936,7 @@ void ezWorld::UpdateAsynchronous()
 {
   ezTaskGroupID taskGroupId = ezTaskSystem::CreateTaskGroup(ezTaskPriority::EarlyThisFrame);
 
-  ezDynamicArrayBase<ezInternal::WorldData::RegisteredUpdateFunction>& updateFunctions =
-    m_Data.m_UpdateFunctions[ezComponentManagerBase::UpdateFunctionDesc::Phase::Async];
+  ezDynamicArrayBase<ezInternal::WorldData::RegisteredUpdateFunction>& updateFunctions = m_Data.m_UpdateFunctions[ezComponentManagerBase::UpdateFunctionDesc::Phase::Async];
 
   ezUInt32 uiCurrentTaskIndex = 0;
 
@@ -1136,8 +1130,7 @@ void ezWorld::ProcessUpdateFunctionsToRegister()
       }
     }
 
-    EZ_ASSERT_DEV(m_Data.m_UpdateFunctionsToRegister.GetCount() < uiNumFunctionsToRegister,
-      "No functions have been registered because the dependencies could not be found.");
+    EZ_ASSERT_DEV(m_Data.m_UpdateFunctionsToRegister.GetCount() < uiNumFunctionsToRegister, "No functions have been registered because the dependencies could not be found.");
   }
 }
 

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldWriter.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldWriter.cpp
@@ -66,7 +66,7 @@ void ezWorldWriter::WriteObjects(ezStreamWriter& stream, ezArrayPtr<const ezGame
 
 ezResult ezWorldWriter::WriteToStream()
 {
-  const ezUInt8 uiVersion = 9;
+  const ezUInt8 uiVersion = 10;
   *m_pStream << uiVersion;
 
   // version 8: use string dedup instead of handle writer
@@ -277,6 +277,7 @@ void ezWorldWriter::WriteGameObject(const ezGameObject* pObject)
   s << pObject->IsDynamic();
   pObject->GetTags().Save(s);
   s << pObject->GetTeamID();
+  s << pObject->GetStableRandomSeed();
 }
 
 void ezWorldWriter::WriteComponentTypeInfo(const ezRTTI* pRtti)

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -259,7 +259,10 @@ ezResult ezGameState::SpawnPlayer(const ezTransform* pStartPosition)
           startPos.m_vPosition.z += 1.0f; // do not spawn player prefabs on the ground, they may not have their origin there
         }
 
-        pPrefab->InstantiatePrefab(*m_pMainWorld, startPos, ezGameObjectHandle(), nullptr, &uiTeamID, &(it->m_Parameters), false);
+        ezPrefabInstantiationOptions options;
+        options.m_pOverrideTeamID = &uiTeamID;
+
+        pPrefab->InstantiatePrefab(*m_pMainWorld, startPos, options, &(it->m_Parameters));
 
         return EZ_SUCCESS;
       }

--- a/Code/Engine/GameEngine/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/ProjectileComponent.cpp
@@ -361,7 +361,10 @@ void ezProjectileComponent::OnTriggered(ezMsgComponentInternalTrigger& msg)
   {
     ezResourceLock<ezPrefabResource> pPrefab(m_hTimeoutPrefab, ezResourceAcquireMode::AllowLoadingFallback);
 
-    pPrefab->InstantiatePrefab(*GetWorld(), GetOwner()->GetGlobalTransform(), ezGameObjectHandle(), nullptr, &GetOwner()->GetTeamID(), nullptr, false);
+    ezPrefabInstantiationOptions options;
+    options.m_pOverrideTeamID = &GetOwner()->GetTeamID();
+
+    pPrefab->InstantiatePrefab(*GetWorld(), GetOwner()->GetGlobalTransform(), options, nullptr);
   }
 
   GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());

--- a/Code/Engine/GameEngine/Gameplay/Implementation/SpawnComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/SpawnComponent.cpp
@@ -105,16 +105,21 @@ void ezSpawnComponent::DoSpawn(const ezTransform& tLocalSpawn)
 {
   ezResourceLock<ezPrefabResource> pResource(m_hPrefab, ezResourceAcquireMode::AllowLoadingFallback);
 
+  ezPrefabInstantiationOptions options;
+  options.m_pOverrideTeamID = &GetOwner()->GetTeamID();
+
   if (m_SpawnFlags.IsAnySet(ezSpawnComponentFlags::AttachAsChild))
   {
-    pResource->InstantiatePrefab(*GetWorld(), tLocalSpawn, GetOwner()->GetHandle(), nullptr, &GetOwner()->GetTeamID(), &m_Parameters, false);
+    options.m_hParent = GetOwner()->GetHandle();
+
+    pResource->InstantiatePrefab(*GetWorld(), tLocalSpawn, options, &m_Parameters);
   }
   else
   {
     ezTransform tGlobalSpawn;
     tGlobalSpawn.SetGlobalTransform(GetOwner()->GetGlobalTransform(), tLocalSpawn);
 
-    pResource->InstantiatePrefab(*GetWorld(), tGlobalSpawn, ezGameObjectHandle(), nullptr, &GetOwner()->GetTeamID(), &m_Parameters, false);
+    pResource->InstantiatePrefab(*GetWorld(), tGlobalSpawn, options, &m_Parameters);
   }
 }
 

--- a/Code/Engine/GameEngine/Gameplay/Implementation/TimedDeathComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/TimedDeathComponent.cpp
@@ -84,7 +84,10 @@ void ezTimedDeathComponent::OnTriggered(ezMsgComponentInternalTrigger& msg)
   {
     ezResourceLock<ezPrefabResource> pPrefab(m_hTimeoutPrefab, ezResourceAcquireMode::AllowLoadingFallback);
 
-    pPrefab->InstantiatePrefab(*GetWorld(), GetOwner()->GetGlobalTransform(), ezGameObjectHandle(), nullptr, &GetOwner()->GetTeamID(), nullptr, false);
+    ezPrefabInstantiationOptions options;
+    options.m_pOverrideTeamID = &GetOwner()->GetTeamID();
+
+    pPrefab->InstantiatePrefab(*GetWorld(), GetOwner()->GetGlobalTransform(), options);
   }
 
   GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());

--- a/Code/Engine/GameEngine/Physics/Implementation/SurfaceResource.cpp
+++ b/Code/Engine/GameEngine/Physics/Implementation/SurfaceResource.cpp
@@ -288,7 +288,13 @@ bool ezSurfaceResource::InteractWithSurface(ezWorld* pWorld, ezGameObjectHandle 
   }
 
   ezHybridArray<ezGameObject*, 8> rootObjects;
-  pPrefab->InstantiatePrefab(*pWorld, t, hParent, &rootObjects, pOverrideTeamID, &pIA->m_Parameters, false);
+
+  ezPrefabInstantiationOptions options;
+  options.m_hParent = hParent;
+  options.m_pCreatedRootObjectsOut = &rootObjects;
+  options.m_pOverrideTeamID = pOverrideTeamID;
+
+  pPrefab->InstantiatePrefab(*pWorld, t, options, &pIA->m_Parameters);
 
   {
     ezMsgSetFloatParameter msgSetFloat;

--- a/Code/Engine/RendererCore/Decals/DecalComponent.h
+++ b/Code/Engine/RendererCore/Decals/DecalComponent.h
@@ -149,7 +149,7 @@ protected:
   ezUInt32 m_uiApplyOnlyToId = 0;
 
   ezTime m_StartFadeOutTime;
-  ezUInt32 m_uiInternalSortKey;
+  ezUInt32 m_uiInternalSortKey = 0;
   static ezUInt16 s_uiNextSortKey;
 
 private:

--- a/Code/Engine/RendererCore/Decals/DecalComponent.h
+++ b/Code/Engine/RendererCore/Decals/DecalComponent.h
@@ -126,7 +126,6 @@ protected:
   void SetApplyToRef(const char* szReference); // [ property ]
   void UpdateApplyTo();
 
-  void OnObjectCreated(const ezAbstractObjectNode& node);
   void OnTriggered(ezMsgComponentInternalTrigger& msg);
   void OnMsgDeleteGameObject(ezMsgDeleteGameObject& msg);
   void OnMsgOnlyApplyToObject(ezMsgOnlyApplyToObject& msg);
@@ -150,7 +149,6 @@ protected:
 
   ezTime m_StartFadeOutTime;
   ezUInt32 m_uiInternalSortKey = 0;
-  static ezUInt16 s_uiNextSortKey;
 
 private:
   const char* DummyGetter() const { return nullptr; }

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.cpp
@@ -293,5 +293,8 @@ void ezParticleEventReaction_Prefab::ProcessEvent(const ezParticleEvent& e)
   trans.m_qRotation = trans.m_qRotation * qRot;
 
   ezResourceLock<ezPrefabResource> pPrefab(m_hPrefab, ezResourceAcquireMode::BlockTillLoaded);
-  pPrefab->InstantiatePrefab(*m_pOwnerEffect->GetWorld(), trans, ezGameObjectHandle(), nullptr, nullptr, nullptr, false);
+
+  ezPrefabInstantiationOptions options;
+
+  pPrefab->InstantiatePrefab(*m_pOwnerEffect->GetWorld(), trans, options);
 }

--- a/Code/EnginePlugins/PhysXPlugin/WorldModule/Implementation/PhysXWorldModule.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/WorldModule/Implementation/PhysXWorldModule.cpp
@@ -1287,7 +1287,12 @@ void ezPhysXWorldModule::FetchResults(const ezWorldModule::UpdateContext& contex
           if (pPrefab.GetAcquireResult() == ezResourceAcquireResult::Final)
           {
             ezHybridArray<ezGameObject*, 8> created;
-            pPrefab->InstantiatePrefab(*m_pWorld, ezTransform(slideInfo.m_vPosition), ezGameObjectHandle(), &created, nullptr, nullptr, true);
+
+            ezPrefabInstantiationOptions options;
+            options.m_pCreatedRootObjectsOut = &created;
+            options.bForceDynamic = true;
+
+            pPrefab->InstantiatePrefab(*m_pWorld, ezTransform(slideInfo.m_vPosition), options);
             slideInfo.m_hRollPrefab = created[0]->GetHandle();
           }
         }
@@ -1327,7 +1332,12 @@ void ezPhysXWorldModule::FetchResults(const ezWorldModule::UpdateContext& contex
           if (pPrefab.GetAcquireResult() == ezResourceAcquireResult::Final)
           {
             ezHybridArray<ezGameObject*, 8> created;
-            pPrefab->InstantiatePrefab(*m_pWorld, ezTransform(slideInfo.m_vPosition), ezGameObjectHandle(), &created, nullptr, nullptr, true);
+
+            ezPrefabInstantiationOptions options;
+            options.m_pCreatedRootObjectsOut = &created;
+            options.bForceDynamic = true;
+
+            pPrefab->InstantiatePrefab(*m_pWorld, ezTransform(slideInfo.m_vPosition), options);
             slideInfo.m_hSlidePrefab = created[0]->GetHandle();
           }
         }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/PlacementTile.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/PlacementTile.cpp
@@ -131,7 +131,11 @@ ezUInt32 PlacementTile::PlaceObjects(ezWorld& world, ezArrayPtr<const PlacementT
 
     ezTransform transform = ezSimdConversion::ToTransform(objectTransform.m_Transform);
     ezHybridArray<ezGameObject*, 8> rootObjects;
-    pPrefab->InstantiatePrefab(world, transform, ezGameObjectHandle(), &rootObjects, nullptr, nullptr, false);
+
+    ezPrefabInstantiationOptions options;
+    options.m_pCreatedRootObjectsOut = &rootObjects;
+
+    pPrefab->InstantiatePrefab(world, transform, options);
 
     for (auto pRootObject : rootObjects)
     {

--- a/Code/Samples/RtsGamePlugin/Components/UnitComponent.cpp
+++ b/Code/Samples/RtsGamePlugin/Components/UnitComponent.cpp
@@ -131,8 +131,10 @@ void RtsUnitComponent::OnUnitDestroyed()
   {
     ezResourceLock<ezPrefabResource> pPrefab(m_hOnDestroyedPrefab, ezResourceAcquireMode::AllowLoadingFallback);
 
-    pPrefab->InstantiatePrefab(
-      *GetWorld(), GetOwner()->GetGlobalTransform(), ezGameObjectHandle(), nullptr, &GetOwner()->GetTeamID(), nullptr, false);
+    ezPrefabInstantiationOptions options;
+    options.m_pOverrideTeamID = &GetOwner()->GetTeamID();
+
+    pPrefab->InstantiatePrefab(*GetWorld(), GetOwner()->GetGlobalTransform(), options);
   }
 
   GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());
@@ -310,8 +312,7 @@ void RtsUnitComponent::FireAt(ezGameObjectHandle hUnit)
     RtsMsgSetTarget msg;
     msg.m_hObject = hUnit;
 
-    ezGameObject* pSpawned =
-      RtsGameState::GetSingleton()->SpawnNamedObjectAt(GetOwner()->GetGlobalTransform(), "ProtonTorpedo1", GetOwner()->GetTeamID());
+    ezGameObject* pSpawned = RtsGameState::GetSingleton()->SpawnNamedObjectAt(GetOwner()->GetGlobalTransform(), "ProtonTorpedo1", GetOwner()->GetTeamID());
 
     pSpawned->PostMessage(msg, ezTime::Zero(), ezObjectMsgQueueType::AfterInitialized);
   }

--- a/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
+++ b/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
@@ -200,8 +200,7 @@ void RtsGameState::SelectUnits()
 
   if (pSelected != nullptr)
   {
-    if (ezInputManager::GetInputSlotState(ezInputSlot_KeyLeftCtrl) == ezKeyState::Down ||
-        ezInputManager::GetInputSlotState(ezInputSlot_KeyRightCtrl) == ezKeyState::Down)
+    if (ezInputManager::GetInputSlotState(ezInputSlot_KeyLeftCtrl) == ezKeyState::Down || ezInputManager::GetInputSlotState(ezInputSlot_KeyRightCtrl) == ezKeyState::Down)
     {
       m_SelectedUnits.ToggleSelection(pSelected->GetHandle());
     }
@@ -304,9 +303,8 @@ ezResult RtsGameState::ComputePickingRay()
 
   const auto& vp = pView->GetViewport();
 
-  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(pView->GetInverseViewProjectionMatrix(ezCameraEye::Left), (ezUInt32)vp.x, (ezUInt32)vp.y,
-        (ezUInt32)vp.width, (ezUInt32)vp.height, ezVec3((float)m_MouseInputState.m_MousePos.x, (float)m_MouseInputState.m_MousePos.y, 0),
-        m_vCurrentPickingRayStart, &m_vCurrentPickingRayDir)
+  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(
+        pView->GetInverseViewProjectionMatrix(ezCameraEye::Left), (ezUInt32)vp.x, (ezUInt32)vp.y, (ezUInt32)vp.width, (ezUInt32)vp.height, ezVec3((float)m_MouseInputState.m_MousePos.x, (float)m_MouseInputState.m_MousePos.y, 0), m_vCurrentPickingRayStart, &m_vCurrentPickingRayDir)
         .Failed())
     return EZ_FAILURE;
 
@@ -372,7 +370,12 @@ ezGameObject* RtsGameState::SpawnNamedObjectAt(const ezTransform& transform, con
   ezResourceLock<ezPrefabResource> pPrefab(hPrefab, ezResourceAcquireMode::BlockTillLoaded);
 
   ezHybridArray<ezGameObject*, 8> CreatedRootObjects;
-  pPrefab->InstantiatePrefab(*m_pMainWorld, transform, ezGameObjectHandle(), &CreatedRootObjects, &uiTeamID, nullptr, false);
+
+  ezPrefabInstantiationOptions options;
+  options.m_pCreatedRootObjectsOut = &CreatedRootObjects;
+  options.m_pOverrideTeamID = &uiTeamID;
+
+  pPrefab->InstantiatePrefab(*m_pMainWorld, transform, options);
 
   return CreatedRootObjects[0];
 }


### PR DESCRIPTION
This value can be used to initialize things in components with random values, for instance decals use this now to randomly select one of the provided decal assets.

The random seed is either randomly chosen at game object creation time, or it can be fixed (a stable 'random' number). The latter is done by the editor, meaning that all manually placed objects will use a stable seed. Therefore, every decal that was manually placed will use the exact same variation no matter how often the scene is modified or exported.
The former is done for all dynamically created objects, so everything that spawns at runtime will vary truly randomly.

The random seed is propagated through prefabs, so it is now possible that components that are spawned through prefabs vary, but still in a deterministic way, ie. they will be equally stable, if the prefab was instantiated in the editor.