### PR TITLE
Only declare USE_TEXCOORD0, USE_NORMAL and USE_TANGENT when used

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
@@ -322,9 +322,20 @@ void ezVisualShaderTypeRegistry::ExtractNodePins(const ezOpenDdlReaderElement* p
       }
 
       // this is optional
-      if (auto pFallback = pElement->FindChildOfType(ezOpenDdlPrimitiveType::String, "DefaultValue"))
+      if (auto pDefaultValue = pElement->FindChildOfType(ezOpenDdlPrimitiveType::String, "DefaultValue"))
       {
-        pin.m_sDefaultValue = pFallback->GetPrimitivesString()[0];
+        pin.m_sDefaultValue = pDefaultValue->GetPrimitivesString()[0];
+      }
+
+      if (auto pDefineWhenUsingDefaultValue = pElement->FindChildOfType(ezOpenDdlPrimitiveType::String, "DefineWhenUsingDefaultValue"))
+      {
+        const ezUInt32 numElements = pDefineWhenUsingDefaultValue->GetNumPrimitives();
+        pin.m_sDefinesWhenUsingDefaultValue.Reserve(numElements);
+
+        for (ezUInt32 i = 0; i < numElements; ++i)
+        {
+          pin.m_sDefinesWhenUsingDefaultValue.PushBack(pDefineWhenUsingDefaultValue->GetPrimitivesString()[i]);
+        }
       }
 
       // this is optional

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <Foundation/Basics.h>
 #include <Foundation/Configuration/Singleton.h>
@@ -16,6 +16,7 @@ struct ezVisualShaderPinDescriptor
   ezColorGammaUB m_Color;
   bool m_bExposeAsProperty = false;
   ezString m_sDefaultValue;
+  ezDynamicArray<ezString> m_sDefinesWhenUsingDefaultValue;
   ezString m_sShaderCodeInline;
   ezString m_sTooltip;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
@@ -48,7 +48,7 @@ private:
   ezStatus InsertPropertyValues(const ezDocumentObject* pNode, const ezVisualShaderNodeDescriptor* pDesc, ezStringBuilder& sString);
   ezStatus GenerateOutputPinCode(const ezDocumentObject* pOwnerNode, const ezPin* pPinSource);
 
-  ezStatus ReplaceInputPinsByCode(const ezDocumentObject* pOwnerNode, const ezVisualShaderNodeDescriptor* pNodeDesc, ezStringBuilder& sInlineCode);
+  ezStatus ReplaceInputPinsByCode(const ezDocumentObject* pOwnerNode, const ezVisualShaderNodeDescriptor* pNodeDesc, ezStringBuilder& sInlineCode, ezStringBuilder& sCodeForPlacingDefines);
   void SetPinDefines(const ezDocumentObject* pOwnerNode, ezStringBuilder& sInlineCode);
   static void AppendStringIfUnique(ezStringBuilder& inout_String, const char* szAppend);
 

--- a/Data/Tools/ezEditor/VisualShader/DefaultMaterial.ddl
+++ b/Data/Tools/ezEditor/VisualShader/DefaultMaterial.ddl
@@ -29,9 +29,6 @@ CAMERA_MODE=CAMERA_MODE_PERSPECTIVE
 
   string %CodeRenderStates { "#include <Shaders/Materials/MaterialState.h>" }
   string %CodeVertexShader { "
-#define USE_NORMAL
-#define USE_TANGENT
-#define USE_TEXCOORD0
 
 #if RENDER_PASS == RENDER_PASS_EDITOR
   #define USE_DEBUG_INTERPOLATOR
@@ -79,10 +76,6 @@ float3 GetWorldPositionOffset(ezPerInstanceData data, float3 worldPosition)
 
   string %CodeGeometryShader { "
 
-#define USE_NORMAL
-#define USE_TANGENT
-#define USE_TEXCOORD0
-
 #include <Shaders/Materials/MaterialStereoGeometryShader.h>
 
 " }
@@ -95,9 +88,6 @@ float MaskThreshold @Default($prop0);
 " }
 
   string %CodePixelDefines { "
-#define USE_NORMAL
-#define USE_TANGENT
-#define USE_TEXCOORD0
 #define USE_SIMPLE_MATERIAL_MODEL
 #define USE_MATERIAL_EMISSIVE
 #define USE_MATERIAL_OCCLUSION
@@ -145,7 +135,11 @@ float3 GetBaseColor()
 
 float3 GetNormal()
 {
+#if defined(USE_TANGENT)
   return TangentToWorldSpace(ToFloat3($in1));
+#else
+  return ToFloat3($in1);
+#endif
 }
 
 float GetMetallic()

--- a/Data/Tools/ezEditor/VisualShader/Inputs.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Inputs.ddl
@@ -25,6 +25,18 @@ Node %UV
   string %Category { "Input" }
   unsigned_int8 %Color { 38, 105, 0 }
 
+  string %CodeVertexShader { "
+#define USE_TEXCOORD0
+" }
+
+  string %CodeGeometryShader { "
+#define USE_TEXCOORD0
+" }
+
+  string %CodePixelDefines { "
+#define USE_TEXCOORD0
+" }
+
   OutputPin %UV
   {
     string %Type { "float2" }
@@ -111,6 +123,18 @@ Node %VertexNormal
   string %Category { "Input" }
   unsigned_int8 %Color { 38, 105, 0 }
 
+  string %CodeVertexShader { "
+#define USE_NORMAL
+" }
+
+  string %CodeGeometryShader { "
+#define USE_NORMAL
+" }
+
+  string %CodePixelDefines { "
+#define USE_NORMAL
+" }
+
   OutputPin %Normal
   {
     string %Type { "float3" }
@@ -124,6 +148,18 @@ Node %VertexTangent
 {
   string %Category { "Input" }
   unsigned_int8 %Color { 38, 105, 0 }
+
+  string %CodeVertexShader { "
+#define USE_TANGENT
+" }
+
+  string %CodeGeometryShader { "
+#define USE_TANGENT
+" }
+
+  string %CodePixelDefines { "
+#define USE_TANGENT
+" }
 
   OutputPin %Tangent
   {

--- a/Data/Tools/ezEditor/VisualShader/Textures.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Textures.ddl
@@ -21,6 +21,7 @@ SamplerState BaseTexture_AutoSampler;
     unsigned_int8 %Color { 50, 50, 128 }
     string %Type { "float2" }
     string %DefaultValue { "G.Input.TexCoord0" }
+    string %DefineWhenUsingDefaultValue { "USE_TEXCOORD0" }
     string %Tooltip { "Optional UV coordinates to sample the texture. Default uses the mesh UV coordinates." }
   }
 
@@ -91,6 +92,7 @@ SamplerState $prop0_AutoSampler;
     string %Type { "float2" }
     unsigned_int8 %Color { 50, 50, 128 }
     string %DefaultValue { "G.Input.TexCoord0" }
+    string %DefineWhenUsingDefaultValue { "USE_TEXCOORD0" }
     string %Tooltip { "Optional UV coordinates to sample the texture. Default uses the mesh UV coordinates." }
   }
 
@@ -126,6 +128,7 @@ SamplerState EmissiveTexture_AutoSampler;
     string %Type { "float2" }
     unsigned_int8 %Color { 50, 50, 128 }
     string %DefaultValue { "G.Input.TexCoord0" }
+    string %DefineWhenUsingDefaultValue { "USE_TEXCOORD0" }
     string %Tooltip { "Optional UV coordinates to sample the texture. Default uses the mesh UV coordinates." }
   }
 
@@ -181,6 +184,7 @@ SamplerState MetallicTexture_AutoSampler;
     string %Type { "float2" }
     unsigned_int8 %Color { 50, 50, 128 }
     string %DefaultValue { "G.Input.TexCoord0" }
+    string %DefineWhenUsingDefaultValue { "USE_TEXCOORD0" }
     string %Tooltip { "Optional UV coordinates to sample the texture. Default uses the mesh UV coordinates." }
   }
 
@@ -216,6 +220,7 @@ SamplerState RoughnessTexture_AutoSampler;
     string %Type { "float2" }
     unsigned_int8 %Color { 50, 50, 128 }
     string %DefaultValue { "G.Input.TexCoord0" }
+    string %DefineWhenUsingDefaultValue { "USE_TEXCOORD0" }
     string %Tooltip { "Optional UV coordinates to sample the texture. Default uses the mesh UV coordinates." }
   }
 
@@ -261,6 +266,7 @@ SamplerState $prop0_AutoSampler;
     string %Type { "float2" }
     unsigned_int8 %Color { 50, 50, 128 }
     string %DefaultValue { "G.Input.TexCoord0" }
+    string %DefineWhenUsingDefaultValue { "USE_TEXCOORD0" }
     string %Tooltip { "Optional UV coordinates to sample the texture. Default uses the mesh UV coordinates." }
   }
 
@@ -345,6 +351,7 @@ SamplerState $prop0_AutoSampler;
     string %Type { "float3" }
     unsigned_int8 %Color { 128, 128, 255 }
     string %DefaultValue { "G.Input.Normal" }
+    string %DefineWhenUsingDefaultValue { "USE_NORMAL" }
   }
 
   OutputPin %RGBA


### PR DESCRIPTION
Only declare USE_TEXCOORD0, USE_NORMAL and USE_TANGENT when the input pins are actually used.

This fixes VSE shaders for minimal models which don't have these vertex streams set.