### PR TITLE
Added option to modulate fog with sky color

### DIFF
--- a/Code/Engine/RendererCore/Components/FogComponent.h
+++ b/Code/Engine/RendererCore/Components/FogComponent.h
@@ -17,6 +17,7 @@ public:
   ezColor m_Color;
   float m_fDensity;
   float m_fHeightFalloff;
+  float m_fInvSkyDistance;
 };
 
 class EZ_RENDERERCORE_DLL ezFogComponent : public ezSettingsComponent
@@ -52,6 +53,12 @@ public:
   void SetHeightFalloff(float fHeightFalloff); // [ property ]
   float GetHeightFalloff() const;              // [ property ]
 
+  void SetModulateWithSkyColor(bool bModulate); // [ property ]
+  bool GetModulateWithSkyColor() const;         // [ property ]
+
+  void SetSkyDistance(float fDistance); // [ property ]
+  float GetSkyDistance() const;         // [ property ]
+
 protected:
   void OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg);
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
@@ -59,4 +66,6 @@ protected:
   ezColor m_Color = ezColor(0.2f, 0.2f, 0.3f);
   float m_fDensity = 1.0f;
   float m_fHeightFalloff = 10.0f;
+  float m_fSkyDistance = 1000.0f;
+  bool m_bModulateWithSkyColor = false;
 };

--- a/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
+++ b/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
@@ -33,6 +33,7 @@ public:
   float m_fFogHeightFalloff = 0.0f;
   float m_fFogDensityAtCameraPos = 0.0f;
   float m_fFogDensity = 0.0f;
+  float m_fFogInvSkyDistance = 0.0f;
   ezColor m_FogColor = ezColor::Black;
 };
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -251,6 +251,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(
           pData->m_fFogHeightFalloff = fogHeightFalloff;
           pData->m_fFogDensityAtCameraPos = ezMath::Exp(ezMath::Clamp(fogAtCameraPos, -80.0f, 80.0f)); // Prevent infs
           pData->m_fFogDensity = pFogRenderData->m_fDensity;
+          pData->m_fFogInvSkyDistance = pFogRenderData->m_fInvSkyDistance;
 
           pData->m_FogColor = pFogRenderData->m_Color;
         }

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
@@ -184,6 +184,7 @@ void* ezClusteredDataProvider::UpdateData(const ezRenderViewContext& renderViewC
     pConstants->FogDensityAtCameraPos = pData->m_fFogDensityAtCameraPos;
     pConstants->FogDensity = pData->m_fFogDensity;
     pConstants->FogColor = pData->m_FogColor;
+    pConstants->FogInvSkyDistance = pData->m_fFogInvSkyDistance;
   }
 
   return &m_Data;

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
@@ -19,6 +19,8 @@ void ezSkinnedMeshRenderer::GetSupportedRenderDataTypes(ezHybridArray<const ezRT
 
 void ezSkinnedMeshRenderer::SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const
 {
+  // Don't call base class implementation here since the state will be overwritten in this method anyways.
+
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   ezRenderContext* pContext = renderViewContext.m_pRenderContext;
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorRenderer.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorRenderer.cpp
@@ -21,6 +21,8 @@ void ezProcVertexColorRenderer::GetSupportedRenderDataTypes(ezHybridArray<const 
 
 void ezProcVertexColorRenderer::SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const
 {
+  SUPER::SetAdditionalData(renderViewContext, pRenderData);
+
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   ezRenderContext* pContext = renderViewContext.m_pRenderContext;
 

--- a/Data/Base/Shaders/Common/LightData.h
+++ b/Data/Base/Shaders/Common/LightData.h
@@ -121,6 +121,7 @@ CONSTANT_BUFFER(ezClusteredDataConstants, 3)
   FLOAT1(FogDensityAtCameraPos);
   FLOAT1(FogDensity);
   COLOR4F(FogColor);
+  FLOAT1(FogInvSkyDistance);
 };
 
 #define NUM_CLUSTERS_X 16

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -21,6 +21,7 @@ SamplerState DecalAtlasSampler;
 
 TextureCubeArray ReflectionSpecularTexture;
 Texture2D SkyIrradianceTexture;
+#define NUM_REFLECTION_MIPS 6
 
 Texture2D SceneDepth;
 Texture2D SceneColor;
@@ -394,7 +395,7 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
   // indirect specular
   float3 reflectionDir = CubeMapDirection(reflect(-viewVector, matData.worldNormal));
   float4 coord = float4(reflectionDir, 0);
-  float mipLevel = MipLevelFromRoughness(matData.roughness, 6);
+  float mipLevel = MipLevelFromRoughness(matData.roughness, NUM_REFLECTION_MIPS);
   float3 indirectLight = ReflectionSpecularTexture.SampleLevel(LinearSampler, coord, mipLevel).rgb;
   totalLight.specularLight += matData.specularColor * indirectLight * occlusion;
 
@@ -588,16 +589,26 @@ float GetFogAmount(float3 worldPosition)
   return saturate(exp(-fogDensity * length(cameraToWorldPos)));
 }
 
-float3 ApplyFog(float3 color, float fogAmount)
+float3 ApplyFog(float3 color, float3 worldPosition, float fogAmount)
 {
-  return lerp(FogColor.xyz, color, fogAmount);
+  float3 fogColor = FogColor.rgb;
+  if (FogInvSkyDistance > 0.0)
+  {
+    float distance = 0;
+    float3 viewVector = NormalizeAndGetLength(worldPosition - GetCameraPosition(), distance);
+    float4 coord = float4(CubeMapDirection(viewVector), 0);
+    float mipLevel = saturate(1.0 - distance * FogInvSkyDistance) * NUM_REFLECTION_MIPS;
+    fogColor *= ReflectionSpecularTexture.SampleLevel(LinearSampler, coord, mipLevel).rgb * 2.0;
+  }
+  
+  return lerp(fogColor, color, fogAmount);
 }
 
 float3 ApplyFog(float3 color, float3 worldPosition)
 {
   if (FogDensity > 0.0)
   {
-    return ApplyFog(color, GetFogAmount(worldPosition));
+    return ApplyFog(color, worldPosition, GetFogAmount(worldPosition));
   }
 
   return color;


### PR DESCRIPTION
Uses the filtered sky reflection cubemap to modulate the fog color. Sharper mipmaps are used at sky distance and blurrier mipmaps are used towards the camera. This is a very cheap method to emulate scattering and also ensures that fogged geometry blends nicely into the skybox.