### PR TITLE
yaml-based Azure Pipelines CI

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Android-x86.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x86.yml
@@ -1,0 +1,85 @@
+# Variable 'task.MSBuild.status' was defined in the Variables tab
+trigger:
+  branches:
+    include:
+    - dev
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: dev
+jobs:
+- job: Job_2
+  displayName: StartVM
+  pool:
+    name: Hosted VS2017
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureFunctionCode
+  - task: PowerShell@2
+    displayName: StartVM
+    continueOnError: true
+    inputs:
+      targetType: inline
+      script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartWindowsVM?code=$(AzureFunctionCode)&vmname=Windows10-1809"
+- job: Job_1
+  displayName: Android-x86
+  timeoutInMinutes: 180
+  pool:
+    name: Default
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureBlobPW
+  - task: CMake@1
+    displayName: CMake x64
+    enabled: False
+    inputs:
+      cwd: build\x64
+      cmakeArgs: -DCMAKE_PREFIX_PATH=$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64 -DEZ_QT_DIR="$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64" -DEZ_BUILD_PHYSX=0 -DEZ_BUILD_FMOD=0 -DEZ_BUILD_GAMES=0 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -G "Visual Studio 16 2019 Win64" ../../
+  - task: CMake@1
+    displayName: CMake build RemoteTestHarness
+    enabled: False
+    inputs:
+      cwd: build\x64
+      cmakeArgs: --build . --target RemoteTestHarness --config Debug
+  - task: CMake@1
+    displayName: CMake Android Ninja
+    inputs:
+      cwd: build\Android-x86-RelWithDebInfo
+      cmakeArgs: -G "Ninja" -DCMAKE_INSTALL_PREFIX:PATH="$(System.DefaultWorkingDirectory)\install\Android-x86-RelWithDebInfo"  -DCMAKE_TOOLCHAIN_FILE="$(ANDROID_NDK)\build\cmake\android.toolchain.cmake"  -DANDROID_ABI="x86"  -DANDROID_PLATFORM="23"  -DEZ_ENABLE_QT_SUPPORT="0"  -DEZ_BUILD_SAMPLES="0"  -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DCMAKE_MAKE_PROGRAM="C:\Program Files\CMake\bin\ninja.exe" ../../
+  - task: CmdLine@2
+    displayName: Build
+    inputs:
+      script: >-
+        cd $(System.DefaultWorkingDirectory)\build\Android-x86-RelWithDebInfo
+
+        ninja libFoundationTest.so
+  - task: PowerShell@2
+    displayName: PowerShell Script
+    inputs:
+      targetType: inline
+      filePath: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+      script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+  - task: CmdLine@2
+    displayName: List files
+    condition: always()
+    inputs:
+      script: >
+        dir /s /o $(System.DefaultWorkingDirectory)\Output
+...

--- a/Code/BuildSystem/AzurePipelines/Linux-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Linux-x64.yml
@@ -1,0 +1,93 @@
+# Variable 'unityfiles' was defined in the Variables tab
+trigger:
+  branches:
+    include:
+    - dev
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: dev
+jobs:
+- job: Job_1
+  displayName: Linux-x64
+  pool:
+    name: Hosted Ubuntu 1604
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+  - task: Bash@3
+    displayName: QT
+    inputs:
+      targetType: inline
+      filePath: sudo apt-get update
+      script: >-
+        sudo add-apt-repository ppa:beineri/opt-qt-5.11.1-xenial
+
+        sudo apt update
+
+        sudo apt install qt511-meta-full
+  - task: Bash@3
+    displayName: SFML
+    inputs:
+      targetType: inline
+      script: >-
+        wget https://www.sfml-dev.org/files/SFML-2.5.1-linux-gcc-64-bit.tar.gz
+
+        sudo mkdir /usr/SFML
+
+        sudo tar xf SFML-2.5.1-linux-gcc-64-bit.tar.gz -C /usr/SFML/
+  - task: Bash@3
+    displayName: Apt-Get
+    inputs:
+      targetType: inline
+      script: sudo apt-get install -y cmake uuid-dev libx11-dev qt5-default build-essential
+  - task: Bash@3
+    displayName: Info
+    inputs:
+      targetType: inline
+      script: >-
+        lscpu | grep -E '^Thread|^Core|^Socket|^CPU\('
+
+        # dpkg -L libsfml-dev
+
+        git config --list
+
+        dpkg --list | grep compiler
+  - task: CMake@1
+    displayName: CMake
+    inputs:
+      cmakeArgs: -DCMAKE_PREFIX_PATH=/opt/qt511/;/usr/SFML/SFML-2.5.1;/usr/SFML/SFML-2.5.1/lib/cmake/SFML -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=g++-9 -DCMAKE_C_COMPILER=gcc-9 -DEZ_ENABLE_FOLDER_UNITY_FILES=$(unityfiles) -G "Unix Makefiles" ../
+  - task: Bash@3
+    displayName: Make
+    inputs:
+      targetType: inline
+      script: make -C ./build -j2
+  - task: PowerShell@2
+    displayName: PowerShell Script
+    inputs:
+      targetType: inline
+      script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+  - task: Bash@3
+    displayName: FoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: ./Output/Bin/LinuxMakeGccRelDeb64/FoundationTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/FoundationTest
+  - task: Bash@3
+    displayName: CoreTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: ./Output/Bin/LinuxMakeGccRelDeb64/CoreTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/CoreTest
+  - task: Bash@3
+    displayName: ToolsFoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: ./Output/Bin/LinuxMakeGccRelDeb64/ToolsFoundationTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/ToolsFoundationTest
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    condition: succeededOrFailed()
+...

--- a/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
@@ -1,0 +1,150 @@
+# Variable 'Configuration' was defined in the Variables tab
+# Variable 'P12password' was defined in the Variables tab
+# Variable 'SDK' was defined in the Variables tab
+# Variable 'TestConfiguration' was defined in the Variables tab
+# Variable 'TestSDK' was defined in the Variables tab
+# Variable 'unityfiles' was defined in the Variables tab
+variables:
+- name: BuildParameters.xcWorkspacePath
+  value: '**/*.xcodeproj/project.xcworkspace'
+- name: BuildParameters.scheme
+  value: ''
+- name: BuildParameters.xcodeVersion
+  value: default
+- name: BuildParameters.xcodeDeveloperDir
+  value: ''
+trigger:
+  branches:
+    include:
+    - dev
+name: $(date:yyyyMMdd)$(rev:.r)
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: dev
+jobs:
+- job: Job_1
+  displayName: MacOS-x64
+  pool:
+    name: Hosted macOS
+  steps:
+  - checkout: self
+  - task: InstallAppleCertificate@2
+    displayName: Install an Apple certificate
+    enabled: False
+    inputs:
+      certPwd: $(P12password)
+      deleteCert: false
+      deleteCustomKeychain: false
+  - task: InstallAppleProvisioningProfile@1
+    displayName: Install an Apple provisioning profile
+    enabled: False
+  - task: Xcode@5
+    displayName: Xcode test
+    enabled: False
+    inputs:
+      actions: test
+      configuration: $(TestConfiguration)
+      sdk: $(TestSDK)
+      xcWorkspacePath: $(BuildParameters.xcWorkspacePath)
+      scheme: $(BuildParameters.scheme)
+      xcodeVersion: $(BuildParameters.xcodeVersion)
+      xcodeDeveloperDir: $(BuildParameters.xcodeDeveloperDir)
+      signingOption: default
+      destinationPlatformOption: iOS
+      destinationSimulators: iPhone 7
+      publishJUnitResults: true
+  - task: Bash@3
+    displayName: Bash Script
+    inputs:
+      targetType: inline
+      filePath: brew install Caskroom/cask/xquartz
+      script: >-
+        brew update
+
+        brew pull https://github.com/Homebrew/homebrew-core/pull/49913
+
+        brew install Caskroom/cask/xquartz
+
+        brew install qt5
+
+        brew install sfml
+  - task: CMake@1
+    displayName: CMake
+    inputs:
+      cmakeArgs: -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt@5/5.15.2/;/usr/local/Cellar/sfml/2.5.1/ -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DEZ_ENABLE_FOLDER_UNITY_FILES=$(unityfiles) -G "Xcode" ../
+  - task: Xcode@5
+    displayName: Xcode build
+    inputs:
+      xcWorkspacePath: $(BuildParameters.xcWorkspacePath)
+      scheme: $(BuildParameters.scheme)
+      xcodeVersion: $(BuildParameters.xcodeVersion)
+      xcodeDeveloperDir: $(BuildParameters.xcodeDeveloperDir)
+      destinationPlatformOption: macOS
+      destinationSimulators: iPhone 7
+      args: -scheme ALL_BUILD
+  - task: PowerShell@2
+    displayName: PowerShell Script
+    inputs:
+      targetType: inline
+      script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+  - task: Bash@3
+    displayName: FoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: ./Output/Bin//OsxXcodeClangRelDeb64/FoundationTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/FoundationTest
+  - task: Bash@3
+    displayName: CoreTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: ./Output/Bin//OsxXcodeClangRelDeb64/CoreTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/CoreTest
+  - task: Bash@3
+    displayName: ToolsFoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: ./Output/Bin//OsxXcodeClangRelDeb64/ToolsFoundationTest -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)/ToolsFoundationTest
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    condition: succeededOrFailed()
+  - task: Bash@3
+    displayName: List output
+    condition: succeededOrFailed()
+    enabled: False
+    inputs:
+      targetType: inline
+      script: >
+        find ./Output/Bin/ -type f
+
+        find /usr/local/Cellar/sfml/2.5.1 -type f
+  - task: CopyFiles@2
+    displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+    condition: succeededOrFailed()
+    enabled: False
+    inputs:
+      SourceFolder: $(system.defaultworkingdirectory)
+      Contents: '**/*.ipa'
+      TargetFolder: $(build.artifactstagingdirectory)
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    condition: succeededOrFailed()
+    enabled: False
+    inputs:
+      PathtoPublish: $(build.artifactstagingdirectory)
+  - task: AppCenterTest@1
+    displayName: Test with Visual Studio App Center
+    condition: succeededOrFailed()
+    enabled: False
+    inputs:
+      app: '**/*.ipa'
+  - task: AppCenterDistribute@2
+    displayName: Deploy **/*.ipa to Visual Studio App Center
+    condition: succeededOrFailed()
+    enabled: False
+    inputs:
+      app: '**/*.ipa'
+      packParentFolder: false
+...

--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -1,0 +1,204 @@
+# Variable 'task.MSBuild.status' was defined in the Variables tab
+trigger:
+  branches:
+    include:
+    - dev
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: dev
+jobs:
+- job: Job_3
+  displayName: StartVM
+  pool:
+    name: Hosted VS2017
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureFunctionCode
+  - task: PowerShell@2
+    displayName: StartVM
+    continueOnError: true
+    inputs:
+      targetType: inline
+      script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartWindowsVM?code=$(AzureFunctionCode)&vmname=Windows10-1809"
+- job: Job_1
+  displayName: Windows-x64
+  timeoutInMinutes: 180
+  pool:
+    name: Default
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureBlobPW,ThirdPartyWinx64
+  - task: PowerShell@2
+    displayName: Download ThirdParty
+    inputs:
+      targetType: inline
+      script: >-
+        if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyWinx64))
+        {
+          if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyWinx64))
+          {
+            & mkdir $(System.DefaultWorkingDirectory)\ThirdPartyWinx64
+          }
+          if (!(Test-Path $(System.DefaultWorkingDirectory)\build))
+          {
+            & mkdir $(System.DefaultWorkingDirectory)\build
+          }
+          & compact /c /s /i /f $(System.DefaultWorkingDirectory)\ThirdPartyWinx64\
+          & compact /c /s /i /f $(System.DefaultWorkingDirectory)\build\
+          & compact /c /s /i /f $(Build.ArtifactStagingDirectory)\
+          $url7zip = "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip"
+          $output7zip = "./7zip.zip"
+          $urlThirdParty = "$(ThirdPartyWinx64)"
+          $outputThirdParty = "$(System.DefaultWorkingDirectory)\ThirdParty.7z"
+          $output = "$(System.DefaultWorkingDirectory)"
+          wget $url7zip -OutFile $output7zip
+          Expand-Archive -Path $output7zip -DestinationPath $output -Force
+          # Start-BitsTransfer -Source $urlThirdParty -Destination $outputThirdParty
+          wget $urlThirdParty -OutFile $outputThirdParty
+          & "$output/7zip/7z.exe" x -p$(AzureBlobPW) $outputThirdParty
+          & del $outputThirdParty
+        }
+  - task: PowerShell@2
+    displayName: Delete old crash dumps
+    inputs:
+      targetType: inline
+      script: >-
+        if ((Test-Path $(System.DefaultWorkingDirectory)\Output\Bin\WinVs2019RelDeb64))
+        {
+            Get-ChildItem $(System.DefaultWorkingDirectory)\Output\Bin\WinVs2019RelDeb64\*.dmp | foreach { Remove-Item -Force -Path $_.FullName }
+        }
+  - task: CMake@1
+    displayName: CMake Step
+    inputs:
+      cmakeArgs: -DCMAKE_PREFIX_PATH=$(System.DefaultWorkingDirectory)\ThirdPartyWinx64\Qtvs141x64;"$(System.DefaultWorkingDirectory)\ThirdPartyWinx64\FMOD Studio API Windows" -DEZ_QT_DIR="$(System.DefaultWorkingDirectory)\ThirdPartyWinx64\Qtvs141x64" -DEZ_ENABLE_FOLDER_UNITY_FILES=0 -DEZ_BUILD_OPENXR=1 -DEZ_BUILD_PHYSX=1 -DEZ_BUILD_FMOD=1 -DEZ_BUILD_GAMES=1 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -A "x64" -G "Visual Studio 16 2019" ../
+  - task: MSBuild@1
+    displayName: Build solution build/ezVs2019.sln
+    inputs:
+      solution: build/ezVs2019.sln
+      msbuildArchitecture: x64
+      platform: x64
+      configuration: RelWithDebInfo
+  - task: PowerShell@2
+    displayName: PowerShell Script
+    inputs:
+      targetType: inline
+      filePath: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+      script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+  - task: CmdLine@2
+    displayName: HeaderCheck
+    condition: succeededOrFailed()
+    inputs:
+      script: Output\Bin\WinVs2019RelDeb64\HeaderCheck.exe $(System.DefaultWorkingDirectory)\Code\Engine\Foundation -i $(System.DefaultWorkingDirectory)\Code\Engine -f $(System.DefaultWorkingDirectory)\Code\Engine\Foundation\headerCheckerIgnore.json
+  - task: CmdLine@2
+    displayName: FoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019RelDeb64\FoundationTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\FoundationTest
+  - task: CmdLine@2
+    displayName: CoreTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019RelDeb64\CoreTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\CoreTest
+  - task: CmdLine@2
+    displayName: ToolsFoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019RelDeb64\ToolsFoundationTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\ToolsFoundationTest
+  - task: CmdLine@2
+    displayName: RendererTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019RelDeb64\RendererTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTest
+  - task: CmdLine@2
+    displayName: EditorTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: >-
+        set QT_PLUGIN_PATH=Output\Bin\WinVs2019RelDeb64
+
+        Output\Bin\WinVs2019RelDeb64\EditorTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\EditorTest
+  - task: CmdLine@2
+    displayName: GameEngineTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019RelDeb64\GameEngineTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\GameEngineTest
+  - task: CmdLine@2
+    displayName: List files
+    condition: always()
+    inputs:
+      script: dir /s /o $(System.DefaultWorkingDirectory)\Output
+  - task: CmdLine@2
+    displayName: Copy Bin
+    condition: failed()
+    inputs:
+      script: >-
+        REM rmdir /S /Q $(System.DefaultWorkingDirectory)\build
+
+        xcopy Output\Bin\WinVs2019RelDeb64\*.dll $(Build.ArtifactStagingDirectory)\Bin\WinVs2019RelDeb64\ /C/D/Y
+
+        xcopy Output\Bin\WinVs2019RelDeb64\*.pdb $(Build.ArtifactStagingDirectory)\Bin\WinVs2019RelDeb64\ /C/D/Y
+
+        xcopy Output\Bin\WinVs2019RelDeb64\*.exe $(Build.ArtifactStagingDirectory)\Bin\WinVs2019RelDeb64\ /C/D/Y
+  - task: PowerShell@2
+    displayName: Copy AssetCaches
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      targetType: inline
+      script: >-
+        $RootDir = "$(System.DefaultWorkingDirectory)"
+
+        $TargetDir = "$(Build.ArtifactStagingDirectory)\AssetCache"
+
+
+        Set-Location $RootDir
+
+        $AssetCaches = (Get-ChildItem $RootDir -Directory -include AssetCache -recurse)
+
+
+        foreach($Dir in $AssetCaches)
+
+        {
+            Write-Host "Dir: $Dir"
+            $relativePath = Get-Item $Dir | Resolve-Path -Relative
+            $targetPath = Join-Path -Path $TargetDir -ChildPath $relativePath
+            Write-Host "targetPath: $targetPath"
+            New-Item -ItemType Directory -Force -Path $targetPath
+            Copy-Item $Dir\* -Filter * -Destination $targetPath -Recurse -Force
+        }
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: TestResults'
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\Test
+      ArtifactName: TestResults
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: Bin'
+    condition: failed()
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\Bin
+      ArtifactName: Bin
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: AssetCache'
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\AssetCache
+      ArtifactName: AssetCache
+...

--- a/Code/BuildSystem/AzurePipelines/WindowsUWP-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/WindowsUWP-x64.yml
@@ -1,0 +1,195 @@
+# Variable 'task.MSBuild.status' was defined in the Variables tab
+trigger:
+  branches:
+    include:
+    - dev
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: dev
+jobs:
+- job: Job_2
+  displayName: StartVM
+  pool:
+    name: Hosted VS2017
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureFunctionCode
+  - task: PowerShell@2
+    displayName: StartVM
+    continueOnError: true
+    inputs:
+      targetType: inline
+      script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartWindowsVM?code=$(AzureFunctionCode)&vmname=Windows10-1809"
+- job: Job_1
+  displayName: WindowsUWP-x64
+  timeoutInMinutes: 180
+  pool:
+    name: Default
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+  - task: AzureKeyVault@1
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureBlobPW,ThirdPartyUWPx86
+  - task: PowerShell@2
+    displayName: Download ThirdParty
+    inputs:
+      targetType: inline
+      script: |
+        if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86))
+        {
+          if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86))
+          {
+            & mkdir $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86
+          }
+          if (!(Test-Path $(System.DefaultWorkingDirectory)\buildUWP))
+          {
+            & mkdir $(System.DefaultWorkingDirectory)\buildUWP
+          }
+          & compact /c /s /i /f $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\
+          & compact /c /s /i /f $(System.DefaultWorkingDirectory)\buildUWP\
+          & compact /c /s /i /f $(Build.ArtifactStagingDirectory)\
+          $url7zip = "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip"
+          $output7zip = "./7zip.zip"
+          $urlThirdParty = "$(ThirdPartyUWPx86)"
+          $outputThirdParty = "$(System.DefaultWorkingDirectory)\ThirdParty.7z"
+          $output = "$(System.DefaultWorkingDirectory)"
+          wget $url7zip -OutFile $output7zip
+          Expand-Archive -Path $output7zip -DestinationPath $output -Force
+          # Start-BitsTransfer -Source $urlThirdParty -Destination $outputThirdParty
+          wget $urlThirdParty -OutFile $outputThirdParty
+          & "$output/7zip/7z.exe" x -p$(AzureBlobPW) $outputThirdParty
+          & del $outputThirdParty
+        }
+  - task: PowerShell@2
+    displayName: Delete old crash dumps
+    inputs:
+      targetType: inline
+      script: |
+        if ((Test-Path $(System.DefaultWorkingDirectory)\Output\Bin\WinVs2019Debug64))
+        {
+          Get-ChildItem $(System.DefaultWorkingDirectory)\Output\Bin\WinVs2019Debug64\*.dmp | foreach { Remove-Item -Force -Path $_.FullName }
+        }
+  - task: CMake@1
+    displayName: CMake x64
+    inputs:
+      cmakeArgs: -DCMAKE_PREFIX_PATH=$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64 -DEZ_QT_DIR="$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64" -DEZ_BUILD_PHYSX=0 -DEZ_BUILD_FMOD=0 -DEZ_BUILD_GAMES=0 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -A "x64" -G "Visual Studio 16 2019" ../
+  - task: CMake@1
+    displayName: CMake build RemoteTestHarness
+    inputs:
+      cmakeArgs: --build . --target RemoteTestHarness --config Debug
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      buildType: specific
+      project: '3be75850-43b5-4a0a-a9b3-9b1693a5beed'
+      pipeline: 10
+      buildVersionToDownload: latest
+      allowPartiallySucceededBuilds: true
+      specificBuildWithTriggering: true
+      artifactName: AssetCache
+      downloadPath: '$(System.DefaultWorkingDirectory)'
+      extractTars: false
+  - task: PowerShell@2
+    displayName: Move x64 build artifacts / download procdump
+    inputs:
+      targetType: inline
+      script: |
+        $RootDir = "$(System.DefaultWorkingDirectory)"
+        $CacheDir = "$(System.DefaultWorkingDirectory)\AssetCache"
+        $BinPath = ".\Output\Bin\WinVs2019Debug64\"
+        ### x64 binaries
+        if (Test-Path $BinPath)
+        {
+          # Remove-Item $BinPath* -Force -Recurse
+        }
+        else
+        {
+          New-Item -ItemType directory -Path $BinPath -Force
+        }
+        #Move-Item -Path .\drop\Bin\WinVs2019Debug64\* -Destination $BinPath
+        #Remove-Item .\drop\ -Force -Recurse
+        ### Asset Cache
+        Copy-Item $CacheDir\* -Filter * -Destination $RootDir -Recurse -Force
+        Remove-Item $CacheDir\ -Force -Recurse
+        ### Procdump
+        wget https://download.sysinternals.com/files/Procdump.zip -OutFile $BinPath\Procdump.zip
+        Expand-Archive -Path $BinPath\Procdump.zip -DestinationPath $BinPath -Force
+  - task: CMake@1
+    displayName: CMake UWP
+    inputs:
+      cwd: buildUWP
+      cmakeArgs: -DCMAKE_PREFIX_PATH="$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\FMOD Studio API UWP" -DEZ_BUILD_OPENXR=1 -DEZ_BUILD_PHYSX=1 -DEZ_BUILD_FMOD=1 -DEZ_BUILD_GAMES=1 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=0 -DCMAKE_TOOLCHAIN_FILE="../Code/BuildSystem/CMake/toolchain-winstore.cmake" -A "x64" -G "Visual Studio 16 2019" ../
+  - task: MSBuild@1
+    displayName: Build solution buildUWP/ezVs2019.sln
+    inputs:
+      solution: buildUWP/ezVs2019.sln
+      msbuildArchitecture: x64
+      platform: x64
+      configuration: RelWithDebInfo
+      maximumCpuCount: true
+  - task: PowerShell@2
+    displayName: PowerShell Script
+    inputs:
+      targetType: inline
+      filePath: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+      script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+  - task: CmdLine@2
+    displayName: FoundationTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\FoundationTest -p FoundationTest
+  - task: CmdLine@2
+    displayName: CoreTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\CoreTest -p CoreTest
+  - task: CmdLine@2
+    displayName: RendererTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\RendererTest -p RendererTest
+  - task: CmdLine@2
+    displayName: GameEngineTest
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\GameEngineTest -p GameEngineTest
+  - task: CmdLine@2
+    displayName: List files
+    condition: always()
+    inputs:
+      script: |
+        dir /s /o $(System.DefaultWorkingDirectory)\Output
+  - task: CmdLine@2
+    displayName: Copy Bin
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      script: |
+        REM rmdir /S /Q $(System.DefaultWorkingDirectory)\build
+        REM rmdir /S /Q $(System.DefaultWorkingDirectory)\buildUWP
+        xcopy Output\Bin\WinVs2019Debug64\*.dll $(Build.ArtifactStagingDirectory)\Bin\WinVs2019Debug64\ /C/D/Y
+        xcopy Output\Bin\WinVs2019Debug64\*.pdb $(Build.ArtifactStagingDirectory)\Bin\WinVs2019Debug64\ /C/D/Y
+        xcopy Output\Bin\WinVs2019Debug64\*.exe $(Build.ArtifactStagingDirectory)\Bin\WinVs2019Debug64\ /C/D/Y
+        xcopy Output\Bin\WinVs2019Debug64\*.dmp $(Build.ArtifactStagingDirectory)\Bin\WinVs2019Debug64\ /C/D/Y
+        xcopy Output\Bin\WinUWPVs2019RelDeb64\*.dll $(Build.ArtifactStagingDirectory)\Bin\ /C/D/Y
+        xcopy Output\Bin\WinUWPVs2019RelDeb64\*.pdb $(Build.ArtifactStagingDirectory)\Bin\ /C/D/Y
+        xcopy Output\Bin\WinUWPVs2019RelDeb64\*.exe $(Build.ArtifactStagingDirectory)\Bin\ /C/D/Y
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: drop'
+    condition: succeededOrFailed()
+...

--- a/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/Application_uwp.cpp
@@ -7,13 +7,14 @@
 #  include <Foundation/IO/OSFile.h>
 #  include <Foundation/Strings/StringConversion.h>
 
+// Disable warning produced by CppWinRT
+#  pragma warning(disable : 5205)
 #  include <winrt/Windows.ApplicationModel.Activation.h>
 #  include <winrt/Windows.ApplicationModel.Core.h>
 #  include <winrt/Windows.Foundation.Collections.h>
 #  include <winrt/Windows.Foundation.h>
 #  include <winrt/Windows.UI.Core.h>
 
-using namespace std::placeholders;
 using namespace winrt::Windows::ApplicationModel::Core;
 
 ezUwpApplication::ezUwpApplication(ezApplication* application)

--- a/Code/ThirdParty/Lua/CMakeLists.txt
+++ b/Code/ThirdParty/Lua/CMakeLists.txt
@@ -15,3 +15,8 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC BUILDSYSTEM_ENABLE_LUA_SUPPORT
 if(EZ_CMAKE_PLATFORM_POSIX)
   target_compile_definitions(${PROJECT_NAME} PRIVATE LUA_USE_POSIX)
 endif()
+
+# Disable warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+if(EZ_CMAKE_PLATFORM_WINDOWS_UWP)
+  target_compile_options(${PROJECT_NAME} PRIVATE /wd4334)
+endif()

--- a/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
@@ -995,8 +995,9 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezTypedObject inline")
   {
-    ezVarianceTypeAngle value = {0.1f, ezAngle::Degree(90.0f)};
-    ezVarianceTypeAngle value2 = {0.2f, ezAngle::Degree(90.0f)};
+    // ezAngle::Degree(90.0f) was replaced with radian as release builds generate a different float then debug.
+    ezVarianceTypeAngle value = {0.1f, ezAngle::Radian(1.57079637f)};
+    ezVarianceTypeAngle value2 = {0.2f, ezAngle::Radian(1.57079637f)};
 
     ezVariant v(value);
     TestVariant<ezVarianceTypeAngle>(v, ezVariantType::TypedObject);
@@ -1019,7 +1020,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
     ezUInt64 uiHash = v.ComputeHash(0);
     EZ_TEST_INT(uiHash, 13667342936068485827ul);
 
-    ezVarianceTypeAngle* pTypedAngle = EZ_DEFAULT_NEW(ezVarianceTypeAngle, {0.1f, ezAngle::Degree(90.0f)});
+    ezVarianceTypeAngle* pTypedAngle = EZ_DEFAULT_NEW(ezVarianceTypeAngle, {0.1f, ezAngle::Radian(1.57079637f)});
     ezVariant copy;
     copy.CopyTypedObject(pTypedAngle, ezGetStaticRTTI<ezVarianceTypeAngle>());
     ezVariant move;

--- a/Code/UnitTests/FoundationTest/Math/MathTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/MathTest.cpp
@@ -739,7 +739,7 @@ EZ_CREATE_SIMPLE_TEST(Math, General)
     for (int i = 0; i < EZ_ARRAY_SIZE(res); ++i)
     {
       const ezVec2 r = ezMath::EvaluateBezierCurve<ezVec2>(step * i, ezVec2(1, 5), ezVec2(0, 3), ezVec2(6, 3), ezVec2(3, 1));
-      EZ_TEST_VEC2(r, res[i], 0.001f);
+      EZ_TEST_VEC2(r, res[i], 0.0011f);
     }
   }
 

--- a/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
+++ b/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Logging/ConsoleWriter.h>
 #include <Foundation/Strings/StringConversion.h>
+#include <Foundation/System/MiniDumpUtils.h>
 #include <Foundation/System/Process.h>
 #include <RendererCore/Components/SkyBoxComponent.h>
 #include <RendererCore/RenderContext/RenderContext.h>
@@ -112,6 +113,11 @@ ezResult TranformProject(const char* szProjectPath, ezUInt32 uiCleanVersion)
   res = proc.WaitToFinish(timeout);
   if (res.Failed())
   {
+#  if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+    ezStringBuilder sDumpFile = sOutputPath;
+    sDumpFile.AppendPath("Timeout.dmp");
+    ezMiniDumpUtils::WriteExternalProcessMiniDump(sDumpFile, proc.GetProcessID()).LogFailure();
+#  endif
     proc.Terminate().IgnoreResult();
     ezLog::Error("Process timeout ({1}): '{0}'", sBinPath, timeout);
     return EZ_FAILURE;

--- a/Code/UnitTests/GameEngineTest/GameEngineTest.cpp
+++ b/Code/UnitTests/GameEngineTest/GameEngineTest.cpp
@@ -7,7 +7,7 @@
 EZ_TESTFRAMEWORK_ENTRY_POINT_BEGIN("GameEngineTest", "GameEngine Tests")
 {
   ezTextureUtils::s_bForceFullQualityAlways = true; // never allow to use low-res textures
-  ezTestFramework::GetInstance()->SetTestTimeout(1000 * 60 * 10);
+  ezTestFramework::GetInstance()->SetTestTimeout(1000 * 60 * 20);
   ezTestFramework::s_bCallstackOnAssert = true;
 }
 EZ_TESTFRAMEWORK_ENTRY_POINT_END()

--- a/Code/UnitTests/RemoteTestHarness/Program.cs
+++ b/Code/UnitTests/RemoteTestHarness/Program.cs
@@ -18,7 +18,7 @@ namespace ezUwpTestHarness
 
       [Option('c', "configuration", Required = false, Default = "RelWithDebInfo", HelpText = "")]
       public string configuration { get; set; }
-      [Option("platform", Required = false, Default = "Win32", HelpText = "")]
+      [Option("platform", Required = false, Default = "x64", HelpText = "")]
       public string platform { get; set; }
     }
 

--- a/Code/UnitTests/RemoteTestHarness/TestUwp.cs
+++ b/Code/UnitTests/RemoteTestHarness/TestUwp.cs
@@ -112,7 +112,7 @@ namespace ezUwpTestHarness
 
       fullPackageName = "";
 
-      string absSlnPath = Path.Combine(_ezWorkspace, "ezVs2017.sln");
+      string absSlnPath = Path.Combine(_ezWorkspace, "ezVs2019.sln");
 
       if (!File.Exists(absSlnPath))
       {
@@ -122,9 +122,9 @@ namespace ezUwpTestHarness
 
       // Just hard-code the string as any other solution will break with the next VS version anyway.
       // Use ".com" version which writes into stdout
-      string[] devEnvPathOptions = new string[] { @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\devenv.com",
-        @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\devenv.com",
-        @"C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\devenv.com"};
+      string[] devEnvPathOptions = new string[] { @"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\devenv.com",
+        @"C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\devenv.com",
+        @"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\devenv.com"};
 
       string devEnvPath = null;
       foreach (string location in devEnvPathOptions)


### PR DESCRIPTION
- Switched UWP 86 to UWP 64 as 86 has too many compiler bugs.
- Switched VS2017 to VS2019 on CI machine.
- GameEngineTest asset transform will dump the process when a timeout is reached.
- Minor test fixes all over the place for latest VS2019.