### PR TITLE
Support for additive animation clips

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -20,6 +20,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 3, ezRTTIDefault
   {
     EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Animation", "*.fbx;*.gltf;*.glb")),
     EZ_MEMBER_PROPERTY("UseAnimationClip", m_sAnimationClipToExtract),
+    EZ_MEMBER_PROPERTY("Additive", m_bAdditive),
     EZ_ARRAY_MEMBER_PROPERTY("AvailableClips", m_AvailableClips)->AddAttributes(new ezReadOnlyAttribute, new ezContainerAttribute(false, false, false)),
     EZ_MEMBER_PROPERTY("FirstFrame", m_uiFirstFrame),
     EZ_MEMBER_PROPERTY("NumFrames", m_uiNumFrames),
@@ -114,6 +115,7 @@ ezStatus ezAnimationClipAssetDocument::InternalTransformAsset(ezStreamWriter& st
   ezModelImporter2::ImportOptions opt;
   opt.m_sSourceFile = sAbsFilename;
   opt.m_pAnimationOutput = &desc;
+  opt.m_bAdditiveAnimation = pProp->m_bAdditive;
   opt.m_sAnimationToImport = pProp->m_sAnimationClipToExtract;
   opt.m_uiFirstAnimKeyframe = pProp->m_uiFirstFrame;
   opt.m_uiNumAnimKeyframes = pProp->m_uiNumFrames;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -35,6 +35,7 @@ public:
   ezString m_sSourceFile;
   ezString m_sAnimationClipToExtract;
   ezDynamicArray<ezString> m_AvailableClips;
+  bool m_bAdditive = false;
   ezUInt32 m_uiFirstFrame = 0;
   ezUInt32 m_uiNumFrames = 0;
   ezString m_sPreviewMesh;

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
@@ -150,8 +150,20 @@ void ezSimpleAnimationComponent::Update()
   cmdSample.m_EventSampling = mode;
 
   auto& cmdL2M = poseGen.AllocCommandLocalToModelPose();
-  cmdL2M.m_Inputs.PushBack(cmdSample.GetCommandID());
   cmdL2M.m_pSendLocalPoseMsgTo = GetOwner();
+
+  if (animDesc.m_bAdditive)
+  {
+    auto& cmdComb = poseGen.AllocCommandCombinePoses();
+    cmdComb.m_Inputs.PushBack(cmdSample.GetCommandID());
+    cmdComb.m_InputWeights.PushBack(1.0f);
+
+    cmdL2M.m_Inputs.PushBack(cmdComb.GetCommandID());
+  }
+  else
+  {
+    cmdL2M.m_Inputs.PushBack(cmdSample.GetCommandID());
+  }
 
   auto& cmdOut = poseGen.AllocCommandModelPoseToOutput();
   cmdOut.m_Inputs.PushBack(cmdL2M.GetCommandID());

--- a/Code/Engine/RendererCore/AnimationSystem/AnimPoseGenerator.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimPoseGenerator.h
@@ -86,6 +86,7 @@ struct EZ_RENDERERCORE_DLL ezAnimPoseGeneratorCommandSampleTrack final : public 
 private:
   friend class ezAnimPoseGenerator;
 
+  bool m_bAdditive = false;
   ezUInt32 m_uiUniqueID = 0;
   ezAnimPoseGeneratorLocalPoseID m_LocalPoseOutput = ezInvalidIndex;
 };

--- a/Code/Engine/RendererCore/AnimationSystem/AnimationClipResource.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimationClipResource.h
@@ -72,6 +72,8 @@ public:
 
   ezEventTrack m_EventTrack;
 
+  bool m_bAdditive = false;
+
 private:
   ezArrayMap<ezHashedString, JointInfo> m_JointInfos;
   ezDataBuffer m_Transforms;

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimPoseGenerator.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimPoseGenerator.cpp
@@ -158,7 +158,6 @@ void ezAnimPoseGenerator::Validate() const
   for (auto& cmd : m_CommandsSampleEventTrack)
   {
     EZ_ASSERT_DEV(cmd.m_hAnimationClip.IsValid(), "Invalid animation clips are not allowed.");
-    
   }
 }
 
@@ -258,6 +257,8 @@ void ezAnimPoseGenerator::ExecuteCmd(ezAnimPoseGeneratorCommandSampleTrack& cmd,
 
   const ozz::animation::Animation& ozzAnim = pResource->GetDescriptor().GetMappedOzzAnimation(*m_pSkeleton);
 
+  cmd.m_bAdditive = pResource->GetDescriptor().m_bAdditive;
+
   auto transforms = AcquireLocalPoseTransforms(cmd.m_LocalPoseOutput);
 
   auto& pSampler = m_SamplingCaches[cmd.m_uiUniqueID];
@@ -292,6 +293,7 @@ void ezAnimPoseGenerator::ExecuteCmd(ezAnimPoseGeneratorCommandCombinePoses& cmd
   auto transforms = AcquireLocalPoseTransforms(cmd.m_LocalPoseOutput);
 
   ezHybridArray<ozz::animation::BlendingJob::Layer, 8> bl;
+  ezHybridArray<ozz::animation::BlendingJob::Layer, 8> blAdd;
 
   for (ezUInt32 i = 0; i < cmd.m_Inputs.GetCount(); ++i)
   {
@@ -300,37 +302,50 @@ void ezAnimPoseGenerator::ExecuteCmd(ezAnimPoseGeneratorCommandCombinePoses& cmd
     if (cmdIn.GetType() == ezAnimPoseGeneratorCommandType::SampleEventTrack)
       continue;
 
-    ozz::animation::BlendingJob::Layer& layer = bl.ExpandAndGetRef();
-    layer.weight = cmd.m_InputWeights[i];
-
-    if (cmd.m_InputBoneWeights.GetCount() > i && !cmd.m_InputBoneWeights[i].IsEmpty())
-    {
-      layer.joint_weights = ozz::span(cmd.m_InputBoneWeights[i].GetPtr(), cmd.m_InputBoneWeights[i].GetEndPtr());
-    }
+    ozz::animation::BlendingJob::Layer* layer = nullptr;
 
     switch (cmdIn.GetType())
     {
       case ezAnimPoseGeneratorCommandType::SampleTrack:
       {
+        if (static_cast<const ezAnimPoseGeneratorCommandSampleTrack&>(cmdIn).m_bAdditive)
+        {
+          layer = &blAdd.ExpandAndGetRef();
+        }
+        else
+        {
+          layer = &bl.ExpandAndGetRef();
+        }
+
         auto transform = AcquireLocalPoseTransforms(static_cast<const ezAnimPoseGeneratorCommandSampleTrack&>(cmdIn).m_LocalPoseOutput);
-        layer.transform = ozz::span<const ozz::math::SoaTransform>(transform.GetPtr(), transform.GetCount());
+        layer->transform = ozz::span<const ozz::math::SoaTransform>(transform.GetPtr(), transform.GetCount());
       }
       break;
 
       case ezAnimPoseGeneratorCommandType::CombinePoses:
       {
+        layer = &bl.ExpandAndGetRef();
+
         auto transform = AcquireLocalPoseTransforms(static_cast<const ezAnimPoseGeneratorCommandCombinePoses&>(cmdIn).m_LocalPoseOutput);
-        layer.transform = ozz::span<const ozz::math::SoaTransform>(transform.GetPtr(), transform.GetCount());
+        layer->transform = ozz::span<const ozz::math::SoaTransform>(transform.GetPtr(), transform.GetCount());
       }
       break;
 
         EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
+    }
+
+    layer->weight = cmd.m_InputWeights[i];
+
+    if (cmd.m_InputBoneWeights.GetCount() > i && !cmd.m_InputBoneWeights[i].IsEmpty())
+    {
+      layer->joint_weights = ozz::span(cmd.m_InputBoneWeights[i].GetPtr(), cmd.m_InputBoneWeights[i].GetEndPtr());
     }
   }
 
   ozz::animation::BlendingJob job;
   job.threshold = 1.0f;
   job.layers = ozz::span<const ozz::animation::BlendingJob::Layer>(begin(bl), end(bl));
+  job.additive_layers = ozz::span<const ozz::animation::BlendingJob::Layer>(begin(blAdd), end(blAdd));
   job.bind_pose = m_pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton().joint_bind_poses();
   job.output = ozz::span<ozz::math::SoaTransform>(transforms.GetPtr(), transforms.GetCount());
   EZ_ASSERT_DEBUG(job.Validate(), "");

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
@@ -132,7 +132,7 @@ void ezAnimationClipResourceDescriptor::operator=(ezAnimationClipResourceDescrip
 
 ezResult ezAnimationClipResourceDescriptor::Serialize(ezStreamWriter& stream) const
 {
-  stream.WriteVersion(8);
+  stream.WriteVersion(9);
 
   const ezUInt16 uiNumJoints = m_JointInfos.GetCount();
   stream << uiNumJoints;
@@ -160,12 +160,14 @@ ezResult ezAnimationClipResourceDescriptor::Serialize(ezStreamWriter& stream) co
 
   m_EventTrack.Save(stream);
 
+  stream << m_bAdditive;
+
   return EZ_SUCCESS;
 }
 
 ezResult ezAnimationClipResourceDescriptor::Deserialize(ezStreamReader& stream)
 {
-  const ezTypeVersion uiVersion = stream.ReadVersion(8);
+  const ezTypeVersion uiVersion = stream.ReadVersion(9);
 
   if (uiVersion < 6)
     return EZ_FAILURE;
@@ -209,6 +211,11 @@ ezResult ezAnimationClipResourceDescriptor::Deserialize(ezStreamReader& stream)
   if (uiVersion >= 8)
   {
     m_EventTrack.Load(stream);
+  }
+
+  if (uiVersion >= 9)
+  {
+    stream >> m_bAdditive;
   }
 
   return EZ_SUCCESS;

--- a/Code/Tools/Libs/ModelImporter2/Importer/Importer.h
+++ b/Code/Tools/Libs/ModelImporter2/Importer/Importer.h
@@ -27,6 +27,7 @@ namespace ezModelImporter2
 
     ezEditableSkeleton* m_pSkeletonOutput = nullptr;
 
+    bool m_bAdditiveAnimation = false;
     ezString m_sAnimationToImport; // empty = first in file; "name" = only anim with that name
     ezAnimationClipResourceDescriptor* m_pAnimationOutput = nullptr;
     ezUInt32 m_uiFirstAnimKeyframe = 0;


### PR DESCRIPTION
* Animation clip assets now have the flag "Additive" with which the clip is imported as an additive animation.
* When played back, additive animations are "added" on top of other animations (or the rest pose) instead of blending between them. This can be used for "ambient" animations, such as breathing, hit reactions and idle twitches.

Fixes #417 