### PR TITLE
Close the modified files dialog if all documents have been saved.

### DIFF
--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
@@ -113,6 +113,22 @@ void ezQtModifiedDocumentsDlg::SlotSaveDocument()
   SaveDocument(pDoc).IgnoreResult();
 
   pButtonSave->setEnabled(pDoc->IsModified());
+
+  // Check if now all documents are saved and close the dialog if so
+  bool anyDocumentModified = false;
+  for (ezDocument* pDoc : m_ModifiedDocs)
+  {
+    if (pDoc->IsModified())
+    {
+      anyDocumentModified = true;
+      break;
+    }
+  }
+
+  if (!anyDocumentModified)
+  {
+    accept();
+  }
 }
 
 void ezQtModifiedDocumentsDlg::SlotSelectionChanged(int currentRow, int currentColumn, int previousRow, int previousColumn)


### PR DESCRIPTION
Slight usage improvement - when all documents in the modified files dialog have been saved it closes automatically.