### PR TITLE
Added a help button for components

### DIFF
--- a/Code/Engine/Foundation/Strings/Implementation/TranslationLookup.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/TranslationLookup.cpp
@@ -122,10 +122,10 @@ void ezTranslatorFromFiles::LoadTranslationFile(const char* szFullPath)
   ezStringBuilder sContent;
   sContent.ReadAll(file);
 
-  ezDeque<ezString> Lines;
+  ezDeque<ezStringView> Lines;
   sContent.Split(false, Lines, "\n");
 
-  ezHybridArray<ezString, 4> entries;
+  ezHybridArray<ezStringView, 4> entries;
 
   ezStringBuilder sLine, sKey, sValue, sTooltip, sHelpUrl;
   for (const auto& line : Lines)

--- a/Code/Engine/Foundation/Strings/TranslationLookup.h
+++ b/Code/Engine/Foundation/Strings/TranslationLookup.h
@@ -11,6 +11,7 @@ enum class ezTranslationUsage
 {
   Default,
   Tooltip,
+  HelpURL,
 
   ENUM_COUNT
 };
@@ -123,5 +124,8 @@ private:
 /// \brief Use this macro to query a translation for a string from the ezTranslationLookup system
 #define ezTranslate(string) ezTranslationLookup::Translate(string, ezHashingUtils::StringHash(string), ezTranslationUsage::Default)
 
-/// \brief Use this macro to query a translation for a string from the ezTranslationLookup system
+/// \brief Use this macro to query a translation for a tooltip string from the ezTranslationLookup system
 #define ezTranslateTooltip(string) ezTranslationLookup::Translate(string, ezHashingUtils::StringHash(string), ezTranslationUsage::Tooltip)
+
+/// \brief Use this macro to query a translation for a help URL from the ezTranslationLookup system
+#define ezTranslateHelpURL(string) ezTranslationLookup::Translate(string, ezHashingUtils::StringHash(string), ezTranslationUsage::HelpURL)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ElementGroupButton.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ElementGroupButton.cpp
@@ -21,5 +21,8 @@ ezQtElementGroupButton::ezQtElementGroupButton(QWidget* pParent, ezQtElementGrou
     case ezQtElementGroupButton::ElementAction::DeleteElement:
       setIcon(QIcon(QStringLiteral(":/GuiFoundation/Icons/Delete16.png")));
       break;
+    case ezQtElementGroupButton::ElementAction::Help:
+      setIcon(QIcon(QStringLiteral(":/GuiFoundation/Icons/Log.png")));
+      break;
   }
 }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ElementGroupButton.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ElementGroupButton.cpp
@@ -8,6 +8,8 @@ ezQtElementGroupButton::ezQtElementGroupButton(QWidget* pParent, ezQtElementGrou
   m_Action = action;
   m_pGroupWidget = pGroupWidget;
 
+  setAutoRaise(true);
+
   setIconSize(QSize(16, 16));
 
   switch (action)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ElementGroupButton.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ElementGroupButton.moc.h
@@ -13,6 +13,7 @@ public:
     MoveElementUp,
     MoveElementDown,
     DeleteElement,
+    Help,
   };
 
   explicit ezQtElementGroupButton(QWidget* pParent, ElementAction action, ezQtPropertyWidget* pGroupWidget);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -923,15 +923,6 @@ ezQtPropertyContainerWidget::Element& ezQtPropertyContainerWidget::AddElement(ez
     auto pAttr = m_pProp->GetAttributeByType<ezContainerAttribute>();
     if ((!pAttr || pAttr->CanMove()) && m_pProp->GetCategory() != ezPropertyCategory::Map)
     {
-      // Do we need move buttons at all if we have drag&drop?
-      // ezQtElementGroupButton* pUpButton = new ezQtElementGroupButton(pSubGroup->GetHeader(),
-      // ezQtElementGroupButton::ElementAction::MoveElementUp, pNewWidget);  pSubGroup->GetHeader()->layout()->addWidget(pUpButton);
-      // connect(pUpButton, &QToolButton::clicked, this, &ezQtPropertyContainerWidget::OnElementButtonClicked);
-
-      // ezQtElementGroupButton* pDownButton = new ezQtElementGroupButton(pSubGroup->GetHeader(),
-      // ezQtElementGroupButton::ElementAction::MoveElementDown, pNewWidget);  pSubGroup->GetHeader()->layout()->addWidget(pDownButton);
-      // connect(pDownButton, &QToolButton::clicked, this, &ezQtPropertyContainerWidget::OnElementButtonClicked);
-
       pSubGroup->SetDraggable(true);
       connect(pSubGroup, &ezQtGroupBoxBase::DragStarted, this, &ezQtPropertyContainerWidget::OnDragStarted);
     }
@@ -1253,17 +1244,33 @@ void ezQtPropertyTypeContainerWidget::UpdateElement(ezUInt32 index)
     }
 
     const ezRTTI* pCommonType = ezQtPropertyWidget::GetCommonBaseType(ResolvedObjects);
+
+    // Label
     {
-      // Label
       ezStringBuilder sTitle;
       sTitle.Format("[{0}] - {1}", m_Keys[index].ConvertTo<ezString>(), ezTranslate(pCommonType->GetTypeName()));
       elem.m_pSubGroup->SetTitle(sTitle);
     }
+
+    // Icon
     {
-      // Icon
       ezStringBuilder sIconName;
       sIconName.Set(":/TypeIcons/", pCommonType->GetTypeName());
       elem.m_pSubGroup->SetIcon(ezQtUiServices::GetCachedIconResource(sIconName.GetData()));
+    }
+
+    // help URL
+    {
+      QString url = ezTranslateHelpURL(pCommonType->GetTypeName());
+
+      if (!url.isEmpty())
+      {
+        ezQtElementGroupButton* pHelp = new ezQtElementGroupButton(elem.m_pSubGroup->GetHeader(), ezQtElementGroupButton::ElementAction::Help, this);
+        elem.m_pSubGroup->GetHeader()->layout()->addWidget(pHelp);
+        connect(pHelp, &QToolButton::clicked, this, [=]() {
+          QDesktopServices::openUrl(QUrl(url));
+        });
+      }
     }
   }
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
@@ -207,12 +207,12 @@ protected:
   virtual void DoPrepareToDie() override;
 
 protected:
-  QHBoxLayout* m_pLayout;
-  ezQtGroupBoxBase* m_pGroup;
-  ezQtAddSubElementButton* m_pAddButton;
-  ezQtElementGroupButton* m_pDeleteButton;
-  QHBoxLayout* m_pGroupLayout;
-  ezQtTypeWidget* m_pTypeWidget;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtGroupBoxBase* m_pGroup = nullptr;
+  ezQtAddSubElementButton* m_pAddButton = nullptr;
+  ezQtElementGroupButton* m_pDeleteButton = nullptr;
+  QHBoxLayout* m_pGroupLayout = nullptr;
+  ezQtTypeWidget* m_pTypeWidget = nullptr;
 };
 
 
@@ -237,19 +237,18 @@ public Q_SLOTS:
 protected:
   struct Element
   {
-    Element()
-      : m_pSubGroup(nullptr)
-      , m_pWidget(nullptr)
-    {
-    }
-    Element(ezQtGroupBoxBase* pSubGroup, ezQtPropertyWidget* pWidget)
+    Element() = default;
+
+    Element(ezQtGroupBoxBase* pSubGroup, ezQtPropertyWidget* pWidget, ezQtElementGroupButton* pHelpButton)
       : m_pSubGroup(pSubGroup)
       , m_pWidget(pWidget)
+      , m_pHelpButton(pHelpButton)
     {
     }
 
-    ezQtGroupBoxBase* m_pSubGroup;
-    ezQtPropertyWidget* m_pWidget;
+    ezQtGroupBoxBase* m_pSubGroup = nullptr;
+    ezQtPropertyWidget* m_pWidget = nullptr;
+    ezQtElementGroupButton* m_pHelpButton = nullptr;
   };
 
   virtual ezQtGroupBoxBase* CreateElement(QWidget* pParent);

--- a/Data/Tools/ezEditor/Localization/en/AssetsPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/AssetsPlugin.txt
@@ -36,7 +36,7 @@ Intensity CPs;Intensity Control Points
 ezColorControlPoint;Color
 ezAlphaControlPoint;Alpha
 ezIntensityControlPoint;Intensity
-ezPropertyAnimComponent;Property Animation
+ezPropertyAnimComponent;Property Animation;;http://ezengine.net/pages/docs/animation/property-animation/property-animation-component.html
 Curves;Curves
 ezCurve1DData;Curve Data
 Control Points;Control Points
@@ -154,7 +154,7 @@ ezSkeletonJointGeometryType::None;None
 ezSkeletonJointGeometryType::Capsule;Capsule
 ezSkeletonJointGeometryType::Sphere;Sphere
 ezSkeletonJointGeometryType::Box;Box
-ezSkeletonComponent;Skeleton
+ezSkeletonComponent;Skeleton;;http://ezengine.net/pages/docs/animation/skeletal-animation/skeleton-component.html
 BoolParameters;Bool Variables
 NumberParameters;Number Variables
 StringParameters;String Variables
@@ -191,8 +191,8 @@ ezTexConvUsage::Hdr;HDR
 ezTexConvUsage::NormalMap;Normal Map
 ezTexConvUsage::NormalMap_Inverted; Normal Map (inverted)
 ezTexConvUsage::BumpMap;Bump Map
-ezColorAnimationComponent;Color Animation
-ezJointAttachmentComponent;Joint Attachment
+ezColorAnimationComponent;Color Animation;;http://ezengine.net/pages/docs/animation/property-animation/color-animation-component.html
+ezJointAttachmentComponent;Joint Attachment;;http://ezengine.net/pages/docs/animation/skeletal-animation/joint-attachment-component.html
 AnimatedMeshImport.NoMaterials;Animated Mesh only
 AnimatedMeshImport.WithMaterials;Animated Mesh and Materials
 Length;Length

--- a/Data/Tools/ezEditor/Localization/en/FmodPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/FmodPlugin.txt
@@ -2,5 +2,5 @@ Fmod.Settings.Project;Fmod Project Settings...
 Fmod.Mute;Mute Sounds
 Fmod.MasterVolume;Volume
 Sound;Sound
-ezFmodEventComponent;Fmod Sound Event
-ezFmodListenerComponent;Fmod Listener
+ezFmodEventComponent;Fmod Sound Event;;http://ezengine.net/pages/docs/sound/fmod-event-component.html
+ezFmodListenerComponent;Fmod Listener;;http://ezengine.net/pages/docs/sound/fmod-listener-component.html

--- a/Data/Tools/ezEditor/Localization/en/KrautPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/KrautPlugin.txt
@@ -1,2 +1,2 @@
-ezKrautTreeComponent;Kraut Tree
+ezKrautTreeComponent;Kraut Tree;;http://ezengine.net/pages/docs/terrain/kraut-overview.html
 ezKrautAssetMaterial;Material

--- a/Data/Tools/ezEditor/Localization/en/ParticlePlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ParticlePlugin.txt
@@ -31,7 +31,7 @@ ezParticleEmitterFactory_Burst;Burst
 ezParticleEmitterFactory_Distance;Distance
 ezParticleTypeMeshFactory;Mesh
 ezParticleInitializerFactory_VelocityCone;Velocity Cone
-ezParticleComponent;Particle
+ezParticleComponent;Particle;;http://ezengine.net/pages/docs/effects/particle-effects/particle-effect-component.html
 ezParticleInitializerFactory_BoxPosition;Box Position
 ezParticleInitializerFactory_CylinderPosition;Cylinder Position
 ezParticleInitializerFactory_RandomColor;Random Color

--- a/Data/Tools/ezEditor/Localization/en/PhysXPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/PhysXPlugin.txt
@@ -2,28 +2,28 @@ PhysX.Settings.Project;PhysX Project Settings...
 Physics;Physics
 Joints;Joints
 Shapes;Shapes
-ezPxCenterOfMassComponent;PhysX Center of Mass
-ezPxCharacterControllerComponent;PhysX Character Controller
-ezPxDynamicActorComponent;PhysX Dynamic Actor
-ezPxStaticActorComponent;PhysX Static Actor
-ezPx6DOFJointComponent;PhysX 6DOF Joint
-ezPxDistanceJointComponent;PhysX Distance Joint
-ezPxFixedJointComponent;PhysX Fixed Joint
-ezPxShapeBoxComponent;PhysX Box Shape
-ezPxShapeSphereComponent;PhysX Sphere Shape
-ezPxShapeCapsuleComponent;PhysX Capsule Shape
-ezPxShapeConvexComponent;PhysX Convex Mesh Shape
-ezPxSettingsComponent;PhysX Settings
+ezPxCenterOfMassComponent;PhysX Center of Mass;;http://ezengine.net/pages/docs/physics/collision-shapes/physx-center-of-mass-component.html
+ezPxCharacterControllerComponent;PhysX Character Controller;;http://ezengine.net/pages/docs/physics/special/physx-character-controller.html
+ezPxDynamicActorComponent;PhysX Dynamic Actor;;http://ezengine.net/pages/docs/physics/actors/physx-dynamic-actor-component.html
+ezPxStaticActorComponent;PhysX Static Actor;;http://ezengine.net/pages/docs/physics/actors/physx-static-actor-component.html
+ezPx6DOFJointComponent;PhysX 6DOF Joint;;http://ezengine.net/pages/docs/physics/joints/physx-6dof-joint-component.html
+ezPxDistanceJointComponent;PhysX Distance Joint;;http://ezengine.net/pages/docs/physics/joints/physx-distance-joint-component.html
+ezPxFixedJointComponent;PhysX Fixed Joint;;http://ezengine.net/pages/docs/physics/joints/physx-fixed-joint-component.html
+ezPxShapeBoxComponent;PhysX Box Shape;;http://ezengine.net/pages/docs/physics/collision-shapes/physx-box-shape-component.html
+ezPxShapeSphereComponent;PhysX Sphere Shape;;http://ezengine.net/pages/docs/physics/collision-shapes/physx-sphere-shape-component.html
+ezPxShapeCapsuleComponent;PhysX Capsule Shape;;http://ezengine.net/pages/docs/physics/collision-shapes/physx-capsule-shape-component.html
+ezPxShapeConvexComponent;PhysX Convex Mesh Shape;;http://ezengine.net/pages/docs/physics/collision-shapes/physx-convex-shape-component.html
+ezPxSettingsComponent;PhysX Settings;;http://ezengine.net/pages/docs/physics/physx-settings-component.html
 ezPhysXComponent;PhysX Component
 ezPxActorComponent;PhysX Actor
 ezPxSteppingMode::Variable;Variable
 ezPxSteppingMode::Fixed;Fixed
 ezPxSteppingMode::SemiFixed;SemiFixed
-ezPxTriggerComponent;PhysX Trigger
+ezPxTriggerComponent;PhysX Trigger;;http://ezengine.net/pages/docs/physics/actors/physx-trigger-component.html
 ezPxVisColMeshComponent;PhysX Collision Mesh Visualization
 CollisionMeshImport.TriangleMesh;Triangle Collision Mesh
 CollisionMeshImport.ConvexMesh;Convex Collision Mesh
-ezBreakableSheetComponent;PhysX Breakable Sheet
+ezBreakableSheetComponent;PhysX Breakable Sheet;;http://ezengine.net/pages/docs/physics/actors/physx-breakable-sheet-component.html
 ezPxAxis::X;X
 ezPxAxis::Y;Y
 ezPxAxis::Z;Z
@@ -36,16 +36,16 @@ ezOnPhysXContact::SlideReactions;Slide Reactions
 ezOnPhysXContact::RollXReactions;Roll X Reactions
 ezOnPhysXContact::RollYReactions;Roll Y Reactions
 ezOnPhysXContact::RollZReactions;Roll Z Reactions
-ezPxPrismaticJointComponent;PhysX Prismatic Joint
-ezPxRevoluteJointComponent;PhysX Revolute Joint
-ezPxSphericalJointComponent;PhysX Spherical Joint
+ezPxPrismaticJointComponent;PhysX Prismatic Joint;;http://ezengine.net/pages/docs/physics/joints/physx-prismatic-joint-component.html
+ezPxRevoluteJointComponent;PhysX Revolute Joint;;http://ezengine.net/pages/docs/physics/joints/physx-revolute-joint-component.html
+ezPxSphericalJointComponent;PhysX Spherical Joint;;http://ezengine.net/pages/docs/physics/joints/physx-spherical-joint-component.html
 ezPxJointLimitMode::NoLimit; No Limit
 ezPxJointLimitMode::HardLimit; Hard Limit
 ezPxJointLimitMode::SoftLimit; Soft Limit
 ezPxJointDriveMode::NoDrive;No Drive
 ezPxJointDriveMode::DriveAndSpin; Drive and Spin
 ezPxJointDriveMode::DriveAndBrake; Drive and Brake
-ezPxGrabObjectComponent;PhysX Grab Object
-ezPxCharacterCapsuleShapeComponent;PhysX Character Capsule Shape
+ezPxGrabObjectComponent;PhysX Grab Object;;http://ezengine.net/pages/docs/physics/special/physx-grab-object-component.html
+ezPxCharacterCapsuleShapeComponent;PhysX Character Capsule Shape;;http://ezengine.net/pages/docs/physics/special/physx-character-controller.html
 ezPxBoneColliderComponent;Bone Collider
-ezPxRopeComponent;Rope Simulation
+ezPxRopeComponent;Rope Simulation;;http://ezengine.net/pages/docs/physics/special/physx-rope-component.html

--- a/Data/Tools/ezEditor/Localization/en/RecastPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/RecastPlugin.txt
@@ -1,6 +1,6 @@
 AI;AI
 ezRcAgentComponent;Recast Agent
-ezRcNavMeshComponent;Recast Navmesh
+ezRcNavMeshComponent;Recast Navmesh;;http://ezengine.net/pages/docs/ai/recast-navmesh-component.html
 NavMeshConfig;Navmesh Config
 ezRcMarkPoiVisibleComponent;Recast Mark POI Visible
 ezSoldierComponent;Soldier

--- a/Data/Tools/ezEditor/Localization/en/ScenePlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ScenePlugin.txt
@@ -99,32 +99,32 @@ Rendering;Rendering
 Lighting;Lighting
 Settings;Settings
 Transform;Transform
-ezProjectileComponent;Projectile
-ezDecalComponent;Decal
-ezSpawnComponent;Spawn
-ezTimedDeathComponent;Timed Death
-ezInputComponent;Input
-ezPrefabReferenceComponent;Prefab Reference
-ezCameraComponent;Camera
-ezMeshComponent;Mesh
-ezAmbientLightComponent;Ambient Light
-ezDirectionalLightComponent;Directional Light
-ezSpotLightComponent;Spot Light
-ezPointLightComponent;Point Light
-ezSkyLightComponent;Sky Light
+ezProjectileComponent;Projectile;;http://ezengine.net/pages/docs/gameplay/projectile-component.html
+ezDecalComponent;Decal;;http://ezengine.net/pages/docs/effects/decals.html
+ezSpawnComponent;Spawn;;http://ezengine.net/pages/docs/gameplay/spawn-component.html
+ezTimedDeathComponent;Timed Death;;http://ezengine.net/pages/docs/gameplay/timed-death-component.html
+ezInputComponent;Input;;http://ezengine.net/pages/docs/input/input-component.html
+ezPrefabReferenceComponent;Prefab Reference;;http://ezengine.net/pages/docs/prefabs/prefabs-overview.html
+ezCameraComponent;Camera;;http://ezengine.net/pages/docs/graphics/camera-component.html
+ezMeshComponent;Mesh;;http://ezengine.net/pages/docs/graphics/meshes/mesh-component.html
+ezAmbientLightComponent;Ambient Light;;http://ezengine.net/pages/docs/graphics/lighting/ambient-light-component.html
+ezDirectionalLightComponent;Directional Light;;http://ezengine.net/pages/docs/graphics/lighting/directional-light-component.html
+ezSpotLightComponent;Spot Light;;http://ezengine.net/pages/docs/graphics/lighting/spot-light-component.html
+ezPointLightComponent;Point Light;;http://ezengine.net/pages/docs/graphics/lighting/point-light-component.html
+ezSkyLightComponent;Sky Light;;http://ezengine.net/pages/docs/graphics/lighting/sky-light-component.html
 ezReflectionProbeMode::Static;Static
 ezReflectionProbeMode::Dynamic;Dynamic
-ezSkyBoxComponent;Sky Box
-ezFogComponent;Fog
-ezSpriteComponent;Sprite
-ezRotorComponent;Rotor
+ezSkyBoxComponent;Sky Box;;http://ezengine.net/pages/docs/effects/sky.html
+ezFogComponent;Fog;;http://ezengine.net/pages/docs/effects/fog.html
+ezSpriteComponent;Sprite;;http://ezengine.net/pages/docs/graphics/sprite-component.html
+ezRotorComponent;Rotor;;http://ezengine.net/pages/docs/animation/property-animation/rotor-component.html
 ezHeadBoneComponent;Head Bone
-ezSliderComponent;Slider
-ezCollectionComponent;Collection
-ezLineToComponent;Draw Line To Object
-ezDebugTextComponent;Debug Text
+ezSliderComponent;Slider;;http://ezengine.net/pages/docs/animation/property-animation/slider-component.html
+ezCollectionComponent;Collection;;http://ezengine.net/pages/docs/performance/collection-component.html
+ezLineToComponent;Draw Line To Object;;http://ezengine.net/pages/docs/debugging/components/draw-line-component.html
+ezDebugTextComponent;Debug Text;;http://ezengine.net/pages/docs/debugging/components/debug-text-component.html
 ezRenderTargetActivatorComponent;Render Target Activator
-ezAlwaysVisibleComponent;Always Visible
+ezAlwaysVisibleComponent;Always Visible;;http://ezengine.net/pages/docs/graphics/always-visible-component.html
 Components;Components
 Materials;Materials
 Surfaces;Surfaces
@@ -152,7 +152,7 @@ ezOnComponentFinishedAction2::DeleteComponent;Delete Component
 ezOnComponentFinishedAction2::DeleteGameObject;Delete Object
 ezOnComponentFinishedAction2::Restart;Restart
 ezVisualScriptComponent;Visual Script
-ezAreaDamageComponent;Area Damage
+ezAreaDamageComponent;Area Damage;;http://ezengine.net/pages/docs/gameplay/area-damage-component.html
 ezLogicOperator::Equal;=
 ezLogicOperator::Unequal;<>
 ezLogicOperator::Less;<
@@ -175,7 +175,7 @@ ezGreyBoxShape::StairsY;Stairs Y
 ezGreyBoxShape::ArchX;Arch X
 ezGreyBoxShape::ArchY;Arch Y
 ezGreyBoxShape::SpiralStairs;Spiral Stairs
-ezGreyBoxComponent;Grey Boxing
+ezGreyBoxComponent;Grey Boxing;;http://ezengine.net/pages/docs/scenes/greyboxing.html
 ezSpriteBlendMode::Masked;Masked
 ezSpriteBlendMode::Transparent;Transparent
 ezSpriteBlendMode::Additive;Additive
@@ -185,8 +185,8 @@ ezSrmRenderComponent;Visualize Surface Reconstruction Mesh
 ExposedProperties;Exposed Properties
 ezExposedSceneProperty;Exposed Property
 Parameters;Parameters
-ezSimpleWindComponent;Simple Wind
-ezAnimatedMeshComponent;Animated Mesh
+ezSimpleWindComponent;Simple Wind;;http://ezengine.net/pages/docs/effects/simple-wind-component.html
+ezAnimatedMeshComponent;Animated Mesh;;http://ezengine.net/pages/docs/animation/skeletal-animation/animated-mesh-component.html
 ezMotionMatchingComponent;Motion Matching
 Scene.Utils.Menu;Utilities
 Scene.ExportSceneToOBJ;Export Scene Geometry to OBJ...
@@ -237,12 +237,12 @@ EditorShortcut;Editor Shortcut;Press ALT+Number to jump to this camera.
 Scene.CreateThumbnail;Create Scene Thumbnail
 Scene.GameMode.PlayFromHere;Play From Here
 Scene.GameObject.CreateEmptyHere;Create Empty Object Here
-ezPlayerStartPointComponent;Player Start Point
-ezInstancedMeshComponent;Instanced Mesh
-ezMarkerComponent;Marker
-ezRaycastComponent;Raycast Placement
-ezBeamComponent;Beam
-ezMoveToComponent;Move To
+ezPlayerStartPointComponent;Player Start Point;;http://ezengine.net/pages/docs/gameplay/player-start-point.html
+ezInstancedMeshComponent;Instanced Mesh;;http://ezengine.net/pages/docs/graphics/meshes/instanced-mesh-component.html
+ezMarkerComponent;Marker;;http://ezengine.net/pages/docs/gameplay/marker-component.html
+ezRaycastComponent;Raycast Placement;;http://ezengine.net/pages/docs/gameplay/raycast-placement-component.html
+ezBeamComponent;Beam;;http://ezengine.net/pages/docs/effects/beam-component.html
+ezMoveToComponent;Move To;;http://ezengine.net/pages/docs/animation/property-animation/move-to-component.html
 ezDeviceTrackingComponent;Device Tracking
 ezStageSpaceComponent;Stage Space
 ezXRDeviceType::HMD;HMD
@@ -272,10 +272,10 @@ ezXRStageSpace::Seated;Seated
 ezXRStageSpace::Standing;Standing
 InstanceData;Instance Data
 Scene.Render.PickTransparent;Select Transparent
-ezGrabbableItemComponent;Grabbable Item
+ezGrabbableItemComponent;Grabbable Item;;http://ezengine.net/pages/docs/gameplay/grabbable-item-component.html
 ezVisualizeHandComponent;Visualize Hand
-ezSimpleAnimationComponent;Simple Animation
-ezAnimationControllerComponent;Animation Controller
+ezSimpleAnimationComponent;Simple Animation;;http://ezengine.net/pages/docs/animation/skeletal-animation/simple-animation-component.html
+ezAnimationControllerComponent;Animation Controller;;http://ezengine.net/pages/docs/animation/skeletal-animation/animation-controller/animation-controller-component.html
 ezWindStrength::Calm;Calm
 ezWindStrength::LightBreeze;Light Breeze
 ezWindStrength::GentleBreeze;Gentle Breeze
@@ -286,7 +286,7 @@ ezWindStrength::WeakShockwave;Weak Shockwave
 ezWindStrength::MediumShockwave;Medium Shockwave
 ezWindStrength::StrongShockwave;Strong Shockwave
 ezWindStrength::ExtremeShockwave;Extreme Shockwave
-ezBlackboardComponent;Blackboard
+ezBlackboardComponent;Blackboard;;http://ezengine.net/pages/docs/Miscellaneous/blackboard-component.html
 ezBlackboardEntry;Entry
 ezBlackboardEntryFlags::Save;Save
 ezBlackboardEntryFlags::OnChangeEvent;OnChangeEvent
@@ -301,8 +301,8 @@ ezBlackboardEntryFlags::UserFlag7;UserFlag 7
 ezRootMotionMode::Ignore;Ignore
 ezRootMotionMode::ApplyToOwner;Apply To Owner
 ezRootMotionMode::SendMoveCharacterMsg;Send MoveCharacterMsg
-ezJointOverrideComponent;Joint Override Component
-ezHeightfieldComponent;Heightfield Component
+ezJointOverrideComponent;Joint Override Component;;http://ezengine.net/pages/docs/animation/skeletal-animation/joint-override-component.html
+ezHeightfieldComponent;Heightfield Component;;http://ezengine.net/pages/docs/terrain/heightfield-component.html
 ezRenderComponent;Render Component
 ezReflectionProbeMode::Static;Static
 ezReflectionProbeMode::Dynamic;Dynamic
@@ -380,8 +380,8 @@ DepthFade;Depth Fade
 Fresnel;Fresnel
 Refraction;Refraction
 SetColorMode;Set Color Mode
-ezRopeRenderComponent;Rope Renderer
-ezFakeRopeComponent;Fake Rope Simulation
+ezRopeRenderComponent;Rope Renderer;;http://ezengine.net/pages/docs/effects/rope-render-component.html
+ezFakeRopeComponent;Fake Rope Simulation;;http://ezengine.net/pages/docs/effects/fake-rope-component.html
 ezWindVolumeSphereComponent;Sphere Wind Volume
 ezWindVolumeCylinderComponent;Cylinder Wind Volume
 ezWindVolumeConeComponent;Cone Wind Volume

--- a/Data/Tools/ezEditor/Localization/en/TypeScriptPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/TypeScriptPlugin.txt
@@ -6,4 +6,4 @@ ezTypeScriptParameterColor;Color
 ezTypeScriptParameterNumber;Number
 ezTypeScriptParameterString;String
 ezTypeScriptParameterVec3;Vec3
-ezTypeScriptComponent;TypeScript Component
+ezTypeScriptComponent;TypeScript Component;;http://ezengine.net/pages/docs/custom-code/typescript/ts-component.html


### PR DESCRIPTION
The ezQtPropertyTypeContainerWidget now adds a help button to array entries, when the translation system yields a non-empty URL string for the type. It's using the translation system, so that URLs could theoretically even be language specific (not that we would ever need that, but it kinda makes sense).

@Sanakan8472 I'm not sure the location and placement of the help button is the best solution. I wanted it to be visible, rather than have it in a context menu, because otherwise people wouldn't be aware of it. Still, it takes up a lot of space and might be a bit ugly next to the delete button. Also the code might be a bit hacked, not sure whether there is a better solution.

I'd also like it, if I had similar buttons for each panel (asset browser, logs, etc) and dialogs, but I don't have a good idea how to integrate it there consistently and without too much manual effort.

Fixes #444 