### PR TITLE
Adds a console to the CVars window (Editor & ezInspector)

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -336,7 +336,7 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
       ezCommandInterpreterState s;
       s.m_sInput = pMsg->m_sCommand;
 
-      m_pConsole->GetCommandInterpreter()->Interpret(s).IgnoreResult();
+      m_pConsole->GetCommandInterpreter()->Interpret(s);
     }
   }
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -336,7 +336,25 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
       ezCommandInterpreterState s;
       s.m_sInput = pMsg->m_sCommand;
 
-      m_pConsole->GetCommandInterpreter()->Interpret(s);
+      ezStringBuilder tmp;
+
+      if (pMsg->m_iType == 1)
+      {
+        m_pConsole->GetCommandInterpreter()->AutoComplete(s);
+        tmp.AppendFormat(";;00||<{}", s.m_sInput);
+      }
+      else
+        m_pConsole->GetCommandInterpreter()->Interpret(s);
+
+      for (auto l : s.m_sOutput)
+      {
+        tmp.AppendFormat(";;{}||{}", ezArgI((int)l.m_Type, 2, true), l.m_sText);
+      }
+
+      ezConsoleCmdResultMsgToEditor r;
+      r.m_sResult = tmp;
+
+      m_IPC.SendMessage(&r);
     }
   }
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -2,6 +2,7 @@
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
+#include <Core/Console/Console.h>
 #include <EditorEngineProcess/EngineProcGameApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h>
@@ -327,6 +328,16 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
     }
     else
       ezLog::Warning("ezChangeCVarMsgToEngine: Unknown CVar '{0}'", pMsg->m_sCVarName);
+  }
+  else if (const auto* pMsg = ezDynamicCast<const ezConsoleCmdMsgToEngine*>(e.m_pMessage))
+  {
+    if (m_pConsole->GetCommandInterpreter())
+    {
+      ezCommandInterpreterState s;
+      s.m_sInput = pMsg->m_sCommand;
+
+      m_pConsole->GetCommandInterpreter()->Interpret(s).IgnoreResult();
+    }
   }
 
   // Document Messages:

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -2,7 +2,7 @@
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
-#include <Core/Console/Console.h>
+#include <Core/Console/QuakeConsole.h>
 #include <EditorEngineProcess/EngineProcGameApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h>

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -126,7 +126,16 @@ class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezConsoleCmdMsgToEngine : public ezEdi
   EZ_ADD_DYNAMIC_REFLECTION(ezConsoleCmdMsgToEngine, ezEditorEngineMsg);
 
 public:
+  ezInt8 m_iType; // 0 = execute, 1 = auto complete
   ezString m_sCommand;
+};
+
+class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezConsoleCmdResultMsgToEditor : public ezEditorEngineMsg
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezConsoleCmdResultMsgToEditor, ezEditorEngineMsg);
+
+public:
+  ezString m_sResult;
 };
 
 ///////////////////////////////////// ezEditorEngineDocumentMsg /////////////////////////////////////

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -121,6 +121,14 @@ public:
   ezVariant m_NewValue;
 };
 
+class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezConsoleCmdMsgToEngine : public ezEditorEngineMsg
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezConsoleCmdMsgToEngine, ezEditorEngineMsg);
+
+public:
+  ezString m_sCommand;
+};
+
 ///////////////////////////////////// ezEditorEngineDocumentMsg /////////////////////////////////////
 
 /// \brief Base class for all messages that are tied to some document.

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -133,6 +133,16 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezChangeCVarMsgToEngine, 1, ezRTTIDefaultAllocat
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezConsoleCmdMsgToEngine, 1, ezRTTIDefaultAllocator<ezConsoleCmdMsgToEngine>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Cmd", m_sCommand),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezLongOpReplicationMsg, 1, ezRTTIDefaultAllocator<ezLongOpReplicationMsg>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -137,7 +137,18 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezConsoleCmdMsgToEngine, 1, ezRTTIDefaultAllocat
 {
   EZ_BEGIN_PROPERTIES
   {
+    EZ_MEMBER_PROPERTY("Type", m_iType),
     EZ_MEMBER_PROPERTY("Cmd", m_sCommand),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezConsoleCmdResultMsgToEditor, 1, ezRTTIDefaultAllocator<ezConsoleCmdResultMsgToEditor>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Result", m_sResult),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
@@ -150,25 +150,7 @@ void ezQtCVarPanel::UpdateUI()
 
   if (m_bUpdateConsole)
   {
-    ezHybridArray<ezStringView, 64> lines;
-    m_sCommandResult.Split(false, lines, ";;");
-
-    ezStringBuilder tmp;
-
-    for (auto l : lines)
-    {
-      l.Shrink(4, 0); // skip the line type number at the front (for now)
-
-      if (l.StartsWith("<"))
-      {
-        l.Shrink(1, 0);
-        m_pCVarWidget->ReplaceConsoleInput(l.GetData(tmp));
-      }
-      else
-      {
-        m_pCVarWidget->GetConsole().AddConsoleString(l);
-      }
-    }
+    m_pCVarWidget->AddConsoleStrings(m_sCommandResult);
   }
 
   m_sCommandResult.Clear();

--- a/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
@@ -3,8 +3,23 @@
 #include <EditorFramework/Panels/CVarPanel/CVarPanel.moc.h>
 #include <Foundation/Configuration/CVar.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
+#include <Core/Console/Console.h>
 
 EZ_IMPLEMENT_SINGLETON(ezQtCVarPanel);
+
+class ezCommandInterpreterFwd : public ezCommandInterpreter
+{
+public:
+  virtual ezResult Interpret(ezCommandInterpreterState& inout_State) override
+  {
+    ezConsoleCmdMsgToEngine msg;
+    msg.m_sCommand = inout_State.m_sInput;
+
+    ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
+
+    return EZ_SUCCESS;
+  }
+};
 
 ezQtCVarPanel::ezQtCVarPanel()
   : ezQtApplicationPanel("Panel.CVar")
@@ -23,6 +38,8 @@ ezQtCVarPanel::ezQtCVarPanel()
   connect(m_pCVarWidget, &ezQtCVarWidget::onFloatChanged, this, &ezQtCVarPanel::FloatChanged);
   connect(m_pCVarWidget, &ezQtCVarWidget::onIntChanged, this, &ezQtCVarPanel::IntChanged);
   connect(m_pCVarWidget, &ezQtCVarWidget::onStringChanged, this, &ezQtCVarPanel::StringChanged);
+
+  m_pCVarWidget->SetConsoleCommandInterpreter(EZ_DEFAULT_NEW(ezCommandInterpreterFwd));
 }
 
 ezQtCVarPanel::~ezQtCVarPanel()

--- a/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
@@ -47,7 +47,7 @@ ezQtCVarPanel::ezQtCVarPanel()
   connect(m_pCVarWidget, &ezQtCVarWidget::onIntChanged, this, &ezQtCVarPanel::IntChanged);
   connect(m_pCVarWidget, &ezQtCVarWidget::onStringChanged, this, &ezQtCVarPanel::StringChanged);
 
-  m_pCVarWidget->SetConsoleCommandInterpreter(EZ_DEFAULT_NEW(ezCommandInterpreterFwd));
+  m_pCVarWidget->GetConsole().SetCommandInterpreter(EZ_DEFAULT_NEW(ezCommandInterpreterFwd));
 }
 
 ezQtCVarPanel::~ezQtCVarPanel()
@@ -153,7 +153,7 @@ void ezQtCVarPanel::UpdateUI()
     ezHybridArray<ezStringView, 64> lines;
     m_sCommandResult.Split(false, lines, ";;");
 
-    ezStringBuilder add, tmp;
+    ezStringBuilder tmp;
 
     for (auto l : lines)
     {
@@ -166,12 +166,9 @@ void ezQtCVarPanel::UpdateUI()
       }
       else
       {
-        add.Append(l);
-        add.Append("\n");
+        m_pCVarWidget->GetConsole().AddConsoleString(l);
       }
     }
-
-    m_pCVarWidget->AddConsoleOutput(add);
   }
 
   m_sCommandResult.Clear();

--- a/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.cpp
@@ -10,14 +10,12 @@ EZ_IMPLEMENT_SINGLETON(ezQtCVarPanel);
 class ezCommandInterpreterFwd : public ezCommandInterpreter
 {
 public:
-  virtual ezResult Interpret(ezCommandInterpreterState& inout_State) override
+  virtual void Interpret(ezCommandInterpreterState& inout_State) override
   {
     ezConsoleCmdMsgToEngine msg;
     msg.m_sCommand = inout_State.m_sInput;
 
     ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
-
-    return EZ_SUCCESS;
   }
 };
 

--- a/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/CVarPanel/CVarPanel.moc.h
@@ -39,5 +39,7 @@ private:
 
   bool m_bUpdateUI = false;
   bool m_bRebuildUI = false;
+  bool m_bUpdateConsole = false;
+  ezStringBuilder m_sCommandResult;
 };
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/Preferences/FmodPreferences.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/Preferences/FmodPreferences.cpp
@@ -40,7 +40,7 @@ void ezFmodProjectPreferences::SyncCVars()
 
   {
     ezChangeCVarMsgToEngine msg;
-    msg.m_sCVarName = "fmod_Mute";
+    msg.m_sCVarName = "Fmod.Mute";
     msg.m_NewValue = m_bMute;
 
     ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
@@ -48,7 +48,7 @@ void ezFmodProjectPreferences::SyncCVars()
 
   {
     ezChangeCVarMsgToEngine msg;
-    msg.m_sCVarName = "fmod_MasterVolume";
+    msg.m_sCVarName = "Fmod.MasterVolume";
     msg.m_NewValue = m_fMasterVolume;
 
     ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);

--- a/Code/Engine/Core/Console/Console.h
+++ b/Code/Engine/Core/Console/Console.h
@@ -123,6 +123,9 @@ public:
   /// Adds additional strings to the console output, if there are further auto-completion suggestions.
   virtual bool AutoComplete(ezStringBuilder& text);
 
+  /// \brief Executes the given input string.
+  ///
+  /// The command is forwarded to the set command interpreter.
   virtual void ExecuteCommand(ezStringView input);
 
 protected:

--- a/Code/Engine/Core/Console/Console.h
+++ b/Code/Engine/Core/Console/Console.h
@@ -38,7 +38,7 @@ struct EZ_CORE_DLL ezCommandInterpreterState
 class EZ_CORE_DLL ezCommandInterpreter : public ezRefCounted
 {
 public:
-  virtual ezResult Interpret(ezCommandInterpreterState& inout_State) = 0;
+  virtual void Interpret(ezCommandInterpreterState& inout_State) = 0;
 };
 
 /// \brief A Quake-style console for in-game configuration of ezCVar and ezConsoleFunction.
@@ -84,11 +84,10 @@ public:
   {
     enum EventType
     {
-      BeforeProcessCommand,  ///< The console is about to process a command
-      ProcessCommandSuccess, ///< A command was successfully processed
-      ProcessCommandFailure, ///< A command failed to be processed
-      StringAdded,           ///< A string was added to the console
-      AutoCompleteRequest,   ///< The user tries to auto-complete the input
+      BeforeProcessCommand, ///< The console is about to process a command
+      ProcessCommand,       ///< A command was processed
+      StringAdded,          ///< A string was added to the console
+      AutoCompleteRequest,  ///< The user tries to auto-complete the input
     };
 
     EventType m_EventType;

--- a/Code/Engine/Core/Console/Console.h
+++ b/Code/Engine/Core/Console/Console.h
@@ -74,11 +74,11 @@ struct ezConsoleEvent
   const ezConsoleString* m_AddedpConsoleString;
 };
 
-class EZ_CORE_DLL ezConsoleBase
+class EZ_CORE_DLL ezConsole
 {
 public:
-  ezConsoleBase();
-  virtual ~ezConsoleBase();
+  ezConsole();
+  virtual ~ezConsole();
 
   /// \name Events
   /// @{
@@ -133,185 +133,32 @@ protected:
   /// \name Console Display
   /// @{
 
+public:
   /// \brief Adds a string to the console.
   ///
   /// The base class only broadcasts an event, but does not store the string anywhere.
   virtual void AddConsoleString(ezStringView text, ezConsoleString::Type type = ezConsoleString::Type::Default);
 
   /// @}
-};
 
-/// \brief A Quake-style console for in-game configuration of ezCVar and ezConsoleFunction.
-///
-/// The console displays the recent log activity and allows to modify cvars and call console functions.
-/// It supports auto-completion of known keywords.
-/// Additionally, 'keys' can be bound to arbitrary commands, such that useful commands can be executed
-/// easily.
-/// The default implementation uses ezConsoleInterpreter::Lua as the interpreter for commands typed into it.
-/// The interpreter can be replaced with custom implementations.
-class EZ_CORE_DLL ezQuakeConsole : public ezConsoleBase
-{
+  /// \name Input History
+  /// @{
+
 public:
-  ezQuakeConsole();
-  virtual ~ezQuakeConsole();
-
-
-
-  /// \name Configuration
-  /// @{
-
-  /// \brief Adjusts how many strings the console will keep in memory at maximum.
-  void SetMaxConsoleStrings(ezUInt32 uiMax) { m_uiMaxConsoleStrings = ezMath::Clamp<ezUInt32>(uiMax, 0, 100000); }
-
-  /// \brief Returns how many strings the console will keep in memory at maximum.
-  ezUInt32 GetMaxConsoleStrings() const { return m_uiMaxConsoleStrings; }
-
-  /// \brief Enables or disables that the output from ezGlobalLog is displayed in the console. Enabled by default.
-  virtual void EnableLogOutput(bool bEnable);
-
-  /// \brief Writes the state of the console (history, bound keys) to the stream.
-  virtual void SaveState(ezStreamWriter& Stream) const;
-
-  /// \brief Reads the state of the console (history, bound keys) from the stream.
-  virtual void LoadState(ezStreamReader& Stream);
-
-  /// @}
-
-  /// \name Command Processing
-  /// @{
-
-
-
-  /// \brief Executes the given command using the current command interpreter.
-  virtual void ExecuteCommand(ezStringView input) override;
-
-  /// \brief Binds \a szCommand to \a szKey. Calling ExecuteBoundKey() with this key will then run that command.
-  ///
-  /// A key can be any arbitrary string. However, it might make sense to either use the standard ASCII characters A-Z and a-z, which allows
-  /// to trigger actions by the press of any of those buttons.
-  /// You can, however, also use names for input buttons, such as 'Key_Left', but then you also need to call ExecuteBoundKey() with those
-  /// names.
-  /// If you use such virtual key names, it makes also sense to listen to the auto-complete event and suggest those key names there.
-  void BindKey(const char* szKey, const char* szCommand);
-
-  /// \brief Removes the key binding.
-  void UnbindKey(const char* szKey);
-
-  /// \brief Executes the command that was bound to this key.
-  void ExecuteBoundKey(const char* szKey);
-
-  /// @}
-
-  /// \name Input Handling
-  /// @{
-
-  /// \brief Inserts one character at the caret position into the console input line.
-  ///
-  /// This function also calls ProcessInputCharacter and FilterInputCharacter. By default this already reacts on Tab, Enter and ESC
-  /// and filters out all non ASCII characters.
-  void AddInputCharacter(ezUInt32 uiChar);
-
-  /// \brief Clears the input line of the console.
-  void ClearInputLine();
-
-  /// \brief Returns the current content of the input line.
-  const char* GetInputLine() const { return m_sInputLine.GetData(); }
-
-  /// \brief Returns the position (in characters) of the caret.
-  ezInt32 GetCaretPosition() const { return m_iCaretPosition; }
-
-  /// \brief Moves the caret in the text. Its position will be clamped to the length of the current input line text.
-  void MoveCaret(ezInt32 iMoveOffset);
-
-  /// \brief Deletes the character following the caret position.
-  void DeleteNextCharacter();
-
-  /// \brief Scrolls the contents of the console up or down. Will be clamped to the available range.
-  void Scroll(ezInt32 iLines);
-
-  /// \brief Returns the current scroll position. This must be used during rendering to start with the proper line.
-  ezUInt32 GetScrollPosition() const { return m_iScrollPosition; }
-
-  /// \brief This function implements input handling (via ezInputManager) for the console.
-  ///
-  /// If the console is 'open' (ie. has full focus), it will handle more input for caret movement etc.
-  /// However, in the 'closed' state, it will still execute bound keys and commands from the history.
-  /// It is not required to call this function, you can implement input handling entirely outside the console.
-  ///
-  /// If this function is used, it should be called once per frame and if the console is considered 'open',
-  /// no further keyboard input should be processed, as that might lead to confusing behavior when the user types
-  /// text into the console.
-  ///
-  /// The state whether the console is considered open has to be managed by the application.
-  virtual void DoDefaultInputHandling(bool bConsoleOpen);
-
-  /// @}
-
-  /// \name Console Content
-  /// @{
-
-  /// \brief Adds a string to the console.
-  ///
-  /// bShowOnScreen is a hint for the renderer to also display this string on screen, even if the console is not visible.
-  virtual void AddConsoleString(ezStringView text, ezConsoleString::Type type = ezConsoleString::Type::Default) override;
-
-  /// \brief Returns all current console strings. Use GetScrollPosition() to know which one should be displayed as the first one.
-  const ezDeque<ezConsoleString>& GetConsoleStrings() const;
-
-  /// \brief Deletes all console strings, making the console empty.
-  void ClearConsoleStrings();
+  /// \brief Adds an item to the input history.
+  void AddToInputHistory(ezStringView text);
 
   /// \brief Returns the current input history.
+  ///
+  /// Make sure to lock the console's mutex while working with the history.
   const ezStaticArray<ezString, 16>& GetInputHistory() const { return m_InputHistory; }
 
   /// \brief Replaces the input line by the next (or previous) history item.
-  void SearchInputHistory(ezInt32 iHistoryUp);
-
-  /// @}
-
-  /// \name Helpers
-  /// @{
-
-
-  /// \brief Returns a nice string containing all the important information about the cvar.
-  static ezString GetFullInfoAsString(ezCVar* pCVar);
-
-  /// \brief Returns the value of the cvar as a string.
-  static const ezString GetValueAsString(ezCVar* pCVar);
-
-  /// @}
-
-  void ReplaceInput(const char* sz);
+  void RetrieveInputHistory(ezInt32 iHistoryUp, ezStringBuilder& result);
 
 protected:
-  /// \brief Deletes the character at the given position in the input line.
-  void RemoveCharacter(ezUInt32 uiInputLinePosition);
-
-  /// \brief Makes sure the caret position is clamped to the input line length.
-  void ClampCaretPosition();
-
-  /// \brief Adds an item to the input history.
-  void AddToInputHistory(const char* szString);
-
-  /// \brief The function that is used to read ezGlobalLog messages.
-  void LogHandler(const ezLoggingEventData& data);
-
-  ezInt32 m_iCaretPosition;
-  ezStringBuilder m_sInputLine;
-
-  virtual bool ProcessInputCharacter(ezUInt32 uiChar);
-  virtual bool FilterInputCharacter(ezUInt32 uiChar);
-  virtual void InputStringChanged();
-
-  ezDeque<ezConsoleString> m_ConsoleStrings;
-  bool m_bUseFilteredStrings = false;
-  ezDeque<ezConsoleString> m_FilteredConsoleStrings;
-  ezUInt32 m_uiMaxConsoleStrings;
-  ezInt32 m_iScrollPosition;
-  ezInt32 m_iCurrentInputHistoryElement;
-  bool m_bLogOutputEnabled;
-  bool m_bDefaultInputHandlingInitialized;
-
+  ezInt32 m_iCurrentInputHistoryElement = -1;
   ezStaticArray<ezString, 16> m_InputHistory;
-  ezMap<ezString, ezString> m_BoundKeys;
+
+  /// @}
 };

--- a/Code/Engine/Core/Console/Console.h
+++ b/Code/Engine/Core/Console/Console.h
@@ -60,6 +60,42 @@ public:
   static const ezString FindCommonString(const ezDeque<ezString>& vStrings);
 };
 
+/// \brief The event data that is broadcast by the console
+struct ezConsoleEvent
+{
+  enum class Type : ezInt32
+  {
+    OutputLineAdded, ///< A string was added to the console
+  };
+
+  Type m_Type;
+
+  /// \brief The console string that was just added.
+  const ezConsoleString* m_AddedpConsoleString;
+};
+
+class EZ_CORE_DLL ezConsoleBase
+{
+public:
+  ezConsoleBase();
+  virtual ~ezConsoleBase();
+
+  /// \name Events
+  /// @{
+
+public:
+  /// \brief Grants access to subscribe and unsubscribe from console events.
+  const ezEvent<const ezConsoleEvent&>& Events() const { return m_Events; }
+
+protected:
+  /// \brief The console event variable, to attach to.
+  ezEvent<const ezConsoleEvent&> m_Events;
+
+  /// @}
+
+protected:
+};
+
 /// \brief A Quake-style console for in-game configuration of ezCVar and ezConsoleFunction.
 ///
 /// The console displays the recent log activity and allows to modify cvars and call console functions.
@@ -68,36 +104,13 @@ public:
 /// easily.
 /// The default implementation uses ezConsoleInterpreter::Lua as the interpreter for commands typed into it.
 /// The interpreter can be replaced with custom implementations.
-class EZ_CORE_DLL ezConsole
+class EZ_CORE_DLL ezConsole : public ezConsoleBase
 {
 public:
   ezConsole();
   virtual ~ezConsole();
 
 
-
-  /// \name Events
-  /// @{
-
-
-  /// \brief The event data that is broadcast by the console
-  struct ConsoleEvent
-  {
-    enum EventType
-    {
-      StringAdded, ///< A string was added to the console
-    };
-
-    EventType m_EventType;
-
-    /// \brief The console string that was just added.
-    const ezConsoleString* m_AddedpConsoleString;
-  };
-
-  /// \brief The console event variable, to attach to.
-  ezEvent<ConsoleEvent&> m_Events;
-
-  /// @}
 
   /// \name Configuration
   /// @{

--- a/Code/Engine/Core/Console/Console.h
+++ b/Code/Engine/Core/Console/Console.h
@@ -100,8 +100,14 @@ public:
   /// \brief Returns the mutex that's used to prevent multi-threaded access
   ezMutex& GetMutex() const { return m_Mutex; }
 
+  static void SetMainConsole(ezConsole* pConsole);
+  static ezConsole* GetMainConsole();
+
 protected:
   mutable ezMutex m_Mutex;
+
+private:
+  static ezConsole* s_pMainConsole;
 
   /// @}
 

--- a/Code/Engine/Core/Console/Console.h
+++ b/Code/Engine/Core/Console/Console.h
@@ -253,6 +253,8 @@ public:
 
   /// @}
 
+  void ReplaceInput(const char* sz);
+
 protected:
   /// \brief Deletes the character at the given position in the input line.
   void RemoveCharacter(ezUInt32 uiInputLinePosition);

--- a/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
+++ b/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
@@ -1,6 +1,7 @@
 #include <Core/CorePCH.h>
 
 #include <Core/Console/Console.h>
+#include <Core/Console/QuakeConsole.h>
 
 void ezCommandInterpreter::FindPossibleCVars(const char* szVariable, ezDeque<ezString>& AutoCompleteOptions, ezDeque<ezConsoleString>& AutoCompleteDescriptions)
 {

--- a/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
+++ b/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
@@ -2,28 +2,6 @@
 
 #include <Core/Console/Console.h>
 
-void ezConsole::AutoCompleteInputLine()
-{
-  if (m_CommandInterpreter)
-  {
-    ezCommandInterpreterState s;
-    s.m_sInput = m_sInputLine;
-
-    m_CommandInterpreter->AutoComplete(s);
-
-    for (auto& l : s.m_sOutput)
-    {
-      AddConsoleString(l.m_sText, l.m_Type);
-    }
-
-    if (m_sInputLine != s.m_sInput)
-    {
-      m_sInputLine = s.m_sInput;
-      MoveCaret(500);
-    }
-  }
-}
-
 void ezCommandInterpreter::FindPossibleCVars(const char* szVariable, ezDeque<ezString>& AutoCompleteOptions, ezDeque<ezConsoleString>& AutoCompleteDescriptions)
 {
   ezStringBuilder sText;
@@ -33,7 +11,7 @@ void ezCommandInterpreter::FindPossibleCVars(const char* szVariable, ezDeque<ezS
   {
     if (ezStringUtils::StartsWith_NoCase(pCVar->GetName(), szVariable))
     {
-      sText.Format("    {0} = {1}", pCVar->GetName(), ezConsole::GetFullInfoAsString(pCVar));
+      sText.Format("    {0} = {1}", pCVar->GetName(), ezQuakeConsole::GetFullInfoAsString(pCVar));
 
       ezConsoleString cs;
       cs.m_sText = sText;
@@ -71,7 +49,7 @@ void ezCommandInterpreter::FindPossibleFunctions(const char* szVariable, ezDeque
 }
 
 
-const ezString ezConsole::GetValueAsString(ezCVar* pCVar)
+const ezString ezQuakeConsole::GetValueAsString(ezCVar* pCVar)
 {
   ezStringBuilder s = "undefined";
 
@@ -115,7 +93,7 @@ const ezString ezConsole::GetValueAsString(ezCVar* pCVar)
   return s.GetData();
 }
 
-ezString ezConsole::GetFullInfoAsString(ezCVar* pCVar)
+ezString ezQuakeConsole::GetFullInfoAsString(ezCVar* pCVar)
 {
   ezStringBuilder s = GetValueAsString(pCVar);
 

--- a/Code/Engine/Core/Console/Implementation/Commands.cpp
+++ b/Code/Engine/Core/Console/Implementation/Commands.cpp
@@ -5,54 +5,38 @@
 
 EZ_ENUMERABLE_CLASS_IMPLEMENTATION(ezConsoleFunctionBase);
 
-void ezConsole::ProcessCommand(const char* szCmd)
+void ezQuakeConsole::ExecuteCommand(ezStringView input)
 {
-  if (ezStringUtils::IsNullOrEmpty(szCmd))
-    return;
-
-  const bool bBind = ezStringUtils::StartsWith_NoCase(szCmd, "bind ");
-  const bool bUnbind = ezStringUtils::StartsWith_NoCase(szCmd, "unbind ");
+  const bool bBind = input.StartsWith_NoCase("bind ");
+  const bool bUnbind = input.StartsWith_NoCase("unbind ");
 
   if (bBind || bUnbind)
   {
-    const char* szAfterCmd = ezStringUtils::FindWordEnd(szCmd, ezStringUtils::IsWhiteSpace); // skip the word 'bind' or 'unbind'
+    ezStringBuilder tmp;
+    const char* szAfterCmd = ezStringUtils::FindWordEnd(input.GetData(tmp), ezStringUtils::IsWhiteSpace); // skip the word 'bind' or 'unbind'
 
     const char* szKeyNameStart = ezStringUtils::SkipCharacters(szAfterCmd, ezStringUtils::IsWhiteSpace);                // go to the next word
     const char* szKeyNameEnd = ezStringUtils::FindWordEnd(szKeyNameStart, ezStringUtils::IsIdentifierDelimiter_C_Code); // find its end
 
     ezStringView sKey(szKeyNameStart, szKeyNameEnd);
-    ezStringBuilder sKeyName = sKey; // copy the word into a zero terminated string
+    tmp = sKey; // copy the word into a zero terminated string
 
     const char* szCommandToBind = ezStringUtils::SkipCharacters(szKeyNameEnd, ezStringUtils::IsWhiteSpace);
 
     if (bUnbind || ezStringUtils::IsNullOrEmpty(szCommandToBind))
     {
-      UnbindKey(sKeyName.GetData());
+      UnbindKey(tmp);
       return;
     }
 
-    BindKey(sKeyName.GetData(), szCommandToBind);
+    BindKey(tmp, szCommandToBind);
     return;
   }
 
-  if (m_CommandInterpreter)
-  {
-    ezCommandInterpreterState s;
-    s.m_sInput = szCmd;
-    m_CommandInterpreter->Interpret(s);
-
-    for (auto& l : s.m_sOutput)
-    {
-      AddConsoleString(l.m_sText, l.m_Type);
-    }
-  }
-  else
-  {
-    AddConsoleString(szCmd);
-  }
+  ezConsoleBase::ExecuteCommand(input);
 }
 
-void ezConsole::BindKey(const char* szKey, const char* szCommand)
+void ezQuakeConsole::BindKey(const char* szKey, const char* szCommand)
 {
   ezStringBuilder s;
   s.Format("Binding key '{0}' to command '{1}'", szKey, szCommand);
@@ -61,7 +45,7 @@ void ezConsole::BindKey(const char* szKey, const char* szCommand)
   m_BoundKeys[szKey] = szCommand;
 }
 
-void ezConsole::UnbindKey(const char* szKey)
+void ezQuakeConsole::UnbindKey(const char* szKey)
 {
   ezStringBuilder s;
   s.Format("Unbinding key '{0}'", szKey);
@@ -70,12 +54,14 @@ void ezConsole::UnbindKey(const char* szKey)
   m_BoundKeys.Remove(szKey);
 }
 
-void ezConsole::ExecuteBoundKey(const char* szKey)
+void ezQuakeConsole::ExecuteBoundKey(const char* szKey)
 {
   auto it = m_BoundKeys.Find(szKey);
 
   if (it.IsValid())
-    ProcessCommand(it.Value().GetData());
+  {
+    ExecuteCommand(it.Value().GetData());
+  }
 }
 
 

--- a/Code/Engine/Core/Console/Implementation/Commands.cpp
+++ b/Code/Engine/Core/Console/Implementation/Commands.cpp
@@ -46,8 +46,39 @@ void ezConsole::ProcessCommand(const char* szCmd)
 
   ezResult res = EZ_FAILURE;
 
-  if (m_CommandProcessor.IsValid())
-    res = m_CommandProcessor(szCmd, this);
+  if (m_CommandInterpreter)
+  {
+    ezCommandInterpreterState s;
+    s.m_sInput = szCmd;
+    res = m_CommandInterpreter->Interpret(s);
+
+    for (auto& l : s.m_sOutput)
+    {
+      switch (l.m_Type)
+      {
+        case ezCommandOutputLine::Type::Default:
+          AddConsoleString(l.m_sText);
+          break;
+        case ezCommandOutputLine::Type::Error:
+          AddConsoleString(l.m_sText, ezColor(1, 0, 0));
+          break;
+        case ezCommandOutputLine::Type::Warning:
+          AddConsoleString(l.m_sText, ezColor(1, 0.8f, 0));
+          break;
+        case ezCommandOutputLine::Type::Note:
+          AddConsoleString(l.m_sText, ezColor(1, 200.0f / 255.0f, 0));
+          break;
+        case ezCommandOutputLine::Type::Success:
+          AddConsoleString(l.m_sText, ezColor(50.0f / 255.0f, 1.0f, 50.0f / 255.0f));
+          break;
+        case ezCommandOutputLine::Type::Executed:
+          AddConsoleString(l.m_sText, ezColor(1.0f, 0.5f, 0.0f));
+          break;
+
+          EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
+      }
+    }
+  }
   else
     AddConsoleString(szCmd, ezColor::White, true);
 

--- a/Code/Engine/Core/Console/Implementation/Commands.cpp
+++ b/Code/Engine/Core/Console/Implementation/Commands.cpp
@@ -1,9 +1,7 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Console/Console.h>
+#include <Core/Console/QuakeConsole.h>
 #include <Foundation/Configuration/CVar.h>
-
-EZ_ENUMERABLE_CLASS_IMPLEMENTATION(ezConsoleFunctionBase);
 
 void ezQuakeConsole::ExecuteCommand(ezStringView input)
 {
@@ -33,7 +31,7 @@ void ezQuakeConsole::ExecuteCommand(ezStringView input)
     return;
   }
 
-  ezConsoleBase::ExecuteCommand(input);
+  ezConsole::ExecuteCommand(input);
 }
 
 void ezQuakeConsole::BindKey(const char* szKey, const char* szCommand)

--- a/Code/Engine/Core/Console/Implementation/Commands.cpp
+++ b/Code/Engine/Core/Console/Implementation/Commands.cpp
@@ -35,15 +35,6 @@ void ezConsole::ProcessCommand(const char* szCmd)
     return;
   }
 
-  // Broadcast that we are about to process some command
-  {
-    ConsoleEvent e;
-    e.m_EventType = ConsoleEvent::BeforeProcessCommand;
-    e.m_szCommand = szCmd;
-
-    m_Events.Broadcast(e);
-  }
-
   if (m_CommandInterpreter)
   {
     ezCommandInterpreterState s;
@@ -52,41 +43,12 @@ void ezConsole::ProcessCommand(const char* szCmd)
 
     for (auto& l : s.m_sOutput)
     {
-      switch (l.m_Type)
-      {
-        case ezCommandOutputLine::Type::Default:
-          AddConsoleString(l.m_sText);
-          break;
-        case ezCommandOutputLine::Type::Error:
-          AddConsoleString(l.m_sText, ezColor(1, 0, 0));
-          break;
-        case ezCommandOutputLine::Type::Warning:
-          AddConsoleString(l.m_sText, ezColor(1, 0.8f, 0));
-          break;
-        case ezCommandOutputLine::Type::Note:
-          AddConsoleString(l.m_sText, ezColor(1, 200.0f / 255.0f, 0));
-          break;
-        case ezCommandOutputLine::Type::Success:
-          AddConsoleString(l.m_sText, ezColor(50.0f / 255.0f, 1.0f, 50.0f / 255.0f));
-          break;
-        case ezCommandOutputLine::Type::Executed:
-          AddConsoleString(l.m_sText, ezColor(1.0f, 0.5f, 0.0f));
-          break;
-
-          EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
-      }
+      AddConsoleString(l.m_sText, l.m_Type);
     }
   }
   else
-    AddConsoleString(szCmd, ezColor::White, true);
-
-  // Broadcast that we have processed a command
   {
-    ConsoleEvent e;
-    e.m_EventType = ConsoleEvent::ProcessCommand;
-    e.m_szCommand = szCmd;
-
-    m_Events.Broadcast(e);
+    AddConsoleString(szCmd);
   }
 }
 
@@ -94,7 +56,7 @@ void ezConsole::BindKey(const char* szKey, const char* szCommand)
 {
   ezStringBuilder s;
   s.Format("Binding key '{0}' to command '{1}'", szKey, szCommand);
-  AddConsoleString(s.GetData(), ezColor(50 / 255.0f, 1, 50 / 255.0f));
+  AddConsoleString(s, ezConsoleString::Type::Success);
 
   m_BoundKeys[szKey] = szCommand;
 }
@@ -103,7 +65,7 @@ void ezConsole::UnbindKey(const char* szKey)
 {
   ezStringBuilder s;
   s.Format("Unbinding key '{0}'", szKey);
-  AddConsoleString(s.GetData(), ezColor(50 / 255.0f, 1, 50 / 255.0f));
+  AddConsoleString(s, ezConsoleString::Type::Success);
 
   m_BoundKeys.Remove(szKey);
 }

--- a/Code/Engine/Core/Console/Implementation/Commands.cpp
+++ b/Code/Engine/Core/Console/Implementation/Commands.cpp
@@ -44,13 +44,11 @@ void ezConsole::ProcessCommand(const char* szCmd)
     m_Events.Broadcast(e);
   }
 
-  ezResult res = EZ_FAILURE;
-
   if (m_CommandInterpreter)
   {
     ezCommandInterpreterState s;
     s.m_sInput = szCmd;
-    res = m_CommandInterpreter->Interpret(s);
+    m_CommandInterpreter->Interpret(s);
 
     for (auto& l : s.m_sOutput)
     {
@@ -85,7 +83,7 @@ void ezConsole::ProcessCommand(const char* szCmd)
   // Broadcast that we have processed a command
   {
     ConsoleEvent e;
-    e.m_EventType = res.Succeeded() ? ConsoleEvent::ProcessCommandSuccess : ConsoleEvent::ProcessCommandFailure;
+    e.m_EventType = ConsoleEvent::ProcessCommand;
     e.m_szCommand = szCmd;
 
     m_Events.Broadcast(e);

--- a/Code/Engine/Core/Console/Implementation/Console.cpp
+++ b/Code/Engine/Core/Console/Implementation/Console.cpp
@@ -36,8 +36,8 @@ void ezConsole::AddConsoleString(const char* szText, ezConsoleString::Type type)
 
   // Broadcast that we have added a string to the console
   {
-    ConsoleEvent e;
-    e.m_EventType = ConsoleEvent::StringAdded;
+    ezConsoleEvent e;
+    e.m_Type = ezConsoleEvent::Type::OutputLineAdded;
     e.m_AddedpConsoleString = &cs;
 
     m_Events.Broadcast(e);
@@ -312,6 +312,19 @@ ezColor ezConsoleString::GetColor() const
   }
 
   return ezColor::White;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+ezConsoleBase::ezConsoleBase()
+{
+}
+
+ezConsoleBase::~ezConsoleBase()
+{
 }
 
 EZ_STATICLINK_FILE(Core, Core_Console_Implementation_Console);

--- a/Code/Engine/Core/Console/Implementation/Console.cpp
+++ b/Code/Engine/Core/Console/Implementation/Console.cpp
@@ -15,7 +15,7 @@ ezConsole::ezConsole()
   // END-DOCS-CODE-SNIPPET
 
 #ifdef BUILDSYSTEM_ENABLE_LUA_SUPPORT
-  SetCommandInterpreter(ezConsoleInterpreter::Lua);
+  SetCommandInterpreter(EZ_DEFAULT_NEW(ezCommandInterpreterLua));
 #endif
 }
 
@@ -256,6 +256,13 @@ void ezConsole::LoadState(ezStreamReader& Stream)
   }
 }
 
+void ezCommandInterpreterState::AddOutputLine(const ezFormatString& text, ezCommandOutputLine::Type type /*= ezCommandOutputLine::Type::Default*/)
+{
+  auto& line = m_sOutput.ExpandAndGetRef();
+  line.m_Type = type;
 
+  ezStringBuilder tmp;
+  line.m_sText = text.GetText(tmp);
+}
 
 EZ_STATICLINK_FILE(Core, Core_Console_Implementation_Console);

--- a/Code/Engine/Core/Console/Implementation/Console.cpp
+++ b/Code/Engine/Core/Console/Implementation/Console.cpp
@@ -264,7 +264,23 @@ ezConsole::ezConsole()
 
 ezConsole::~ezConsole()
 {
+  if (s_pMainConsole == this)
+  {
+    s_pMainConsole = nullptr;
+  }
 }
+
+void ezConsole::SetMainConsole(ezConsole* pConsole)
+{
+  s_pMainConsole = pConsole;
+}
+
+ezConsole* ezConsole::GetMainConsole()
+{
+  return s_pMainConsole;
+}
+
+ezConsole* ezConsole::s_pMainConsole = nullptr;
 
 bool ezConsole::AutoComplete(ezStringBuilder& text)
 {

--- a/Code/Engine/Core/Console/Implementation/Console.cpp
+++ b/Code/Engine/Core/Console/Implementation/Console.cpp
@@ -108,6 +108,11 @@ void ezConsole::SearchInputHistory(ezInt32 iHistoryUp)
 }
 
 
+void ezConsole::ReplaceInput(const char* sz)
+{
+  m_sInputLine = sz;
+  ClampCaretPosition();
+}
 
 void ezConsole::LogHandler(const ezLoggingEventData& data)
 {

--- a/Code/Engine/Core/Console/Implementation/Input.cpp
+++ b/Code/Engine/Core/Console/Implementation/Input.cpp
@@ -1,6 +1,6 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Console/Console.h>
+#include <Core/Console/QuakeConsole.h>
 #include <Core/Input/InputManager.h>
 
 bool ezQuakeConsole::ProcessInputCharacter(ezUInt32 uiChar)
@@ -197,9 +197,15 @@ void ezQuakeConsole::DoDefaultInputHandling(bool bConsoleOpen)
     if (ezInputManager::GetInputActionState("Console", "ScrollDown") == ezKeyState::Pressed)
       Scroll(-10);
     if (ezInputManager::GetInputActionState("Console", "HistoryUp") == ezKeyState::Pressed)
-      SearchInputHistory(1);
+    {
+      RetrieveInputHistory(1, m_sInputLine);
+      m_iCaretPosition = m_sInputLine.GetCharacterCount();
+    }
     if (ezInputManager::GetInputActionState("Console", "HistoryDown") == ezKeyState::Pressed)
-      SearchInputHistory(-1);
+    {
+      RetrieveInputHistory(-1, m_sInputLine);
+      m_iCaretPosition = m_sInputLine.GetCharacterCount();
+    }
 
     const ezUInt32 uiChar = ezInputManager::RetrieveLastCharacter();
 

--- a/Code/Engine/Core/Console/Implementation/Input.cpp
+++ b/Code/Engine/Core/Console/Implementation/Input.cpp
@@ -3,7 +3,7 @@
 #include <Core/Console/Console.h>
 #include <Core/Input/InputManager.h>
 
-bool ezConsole::ProcessInputCharacter(ezUInt32 uiChar)
+bool ezQuakeConsole::ProcessInputCharacter(ezUInt32 uiChar)
 {
   switch (uiChar)
   {
@@ -22,12 +22,15 @@ bool ezConsole::ProcessInputCharacter(ezUInt32 uiChar)
       return false;
 
     case '\t':
-      AutoCompleteInputLine();
+      if (AutoComplete(m_sInputLine))
+      {
+        MoveCaret(500);
+      }
       return false;
 
     case 13: // Enter
-      AddToInputHistory(m_sInputLine.GetData());
-      ProcessCommand(m_sInputLine.GetData());
+      AddToInputHistory(m_sInputLine);
+      ExecuteCommand(m_sInputLine);
       ClearInputLine();
       return false;
   }
@@ -35,7 +38,7 @@ bool ezConsole::ProcessInputCharacter(ezUInt32 uiChar)
   return true;
 }
 
-bool ezConsole::FilterInputCharacter(ezUInt32 uiChar)
+bool ezQuakeConsole::FilterInputCharacter(ezUInt32 uiChar)
 {
   // filter out not only all non-ASCII characters, but also all the non-printable ASCII characters
   // if you want to support full Unicode characters in the console, override this function and change this restriction
@@ -45,19 +48,19 @@ bool ezConsole::FilterInputCharacter(ezUInt32 uiChar)
   return true;
 }
 
-void ezConsole::ClampCaretPosition()
+void ezQuakeConsole::ClampCaretPosition()
 {
   m_iCaretPosition = ezMath::Clamp<ezInt32>(m_iCaretPosition, 0, m_sInputLine.GetCharacterCount());
 }
 
-void ezConsole::MoveCaret(ezInt32 iMoveOffset)
+void ezQuakeConsole::MoveCaret(ezInt32 iMoveOffset)
 {
   m_iCaretPosition += iMoveOffset;
 
   ClampCaretPosition();
 }
 
-void ezConsole::Scroll(ezInt32 iLines)
+void ezQuakeConsole::Scroll(ezInt32 iLines)
 {
   if (m_bUseFilteredStrings)
     m_iScrollPosition = ezMath::Clamp<ezInt32>(m_iScrollPosition + iLines, 0, ezMath::Max<ezInt32>(m_FilteredConsoleStrings.GetCount() - 10, 0));
@@ -65,7 +68,7 @@ void ezConsole::Scroll(ezInt32 iLines)
     m_iScrollPosition = ezMath::Clamp<ezInt32>(m_iScrollPosition + iLines, 0, ezMath::Max<ezInt32>(m_ConsoleStrings.GetCount() - 10, 0));
 }
 
-void ezConsole::ClearInputLine()
+void ezQuakeConsole::ClearInputLine()
 {
   m_sInputLine.Clear();
   m_iCaretPosition = 0;
@@ -78,7 +81,7 @@ void ezConsole::ClearInputLine()
   InputStringChanged();
 }
 
-void ezConsole::ClearConsoleStrings()
+void ezQuakeConsole::ClearConsoleStrings()
 {
   m_ConsoleStrings.Clear();
   m_FilteredConsoleStrings.Clear();
@@ -86,12 +89,12 @@ void ezConsole::ClearConsoleStrings()
   m_iScrollPosition = 0;
 }
 
-void ezConsole::DeleteNextCharacter()
+void ezQuakeConsole::DeleteNextCharacter()
 {
   RemoveCharacter(m_iCaretPosition);
 }
 
-void ezConsole::RemoveCharacter(ezUInt32 uiInputLinePosition)
+void ezQuakeConsole::RemoveCharacter(ezUInt32 uiInputLinePosition)
 {
   if (uiInputLinePosition >= m_sInputLine.GetCharacterCount())
     return;
@@ -107,7 +110,7 @@ void ezConsole::RemoveCharacter(ezUInt32 uiInputLinePosition)
   InputStringChanged();
 }
 
-void ezConsole::AddInputCharacter(ezUInt32 uiChar)
+void ezQuakeConsole::AddInputCharacter(ezUInt32 uiChar)
 {
   if (uiChar == '\0')
     return;
@@ -132,7 +135,7 @@ void ezConsole::AddInputCharacter(ezUInt32 uiChar)
   InputStringChanged();
 }
 
-void ezConsole::DoDefaultInputHandling(bool bConsoleOpen)
+void ezQuakeConsole::DoDefaultInputHandling(bool bConsoleOpen)
 {
   if (!m_bDefaultInputHandlingInitialized)
   {
@@ -217,13 +220,13 @@ void ezConsole::DoDefaultInputHandling(bool bConsoleOpen)
   if (ezInputManager::GetInputActionState("Console", "RepeatLast") == ezKeyState::Pressed)
   {
     if (GetInputHistory().GetCount() >= 1)
-      ProcessCommand(GetInputHistory()[0].GetData());
+      ExecuteCommand(GetInputHistory()[0]);
   }
 
   if (ezInputManager::GetInputActionState("Console", "RepeatSecondLast") == ezKeyState::Pressed)
   {
     if (GetInputHistory().GetCount() >= 2)
-      ProcessCommand(GetInputHistory()[1].GetData());
+      ExecuteCommand(GetInputHistory()[1]);
   }
 }
 

--- a/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
+++ b/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
@@ -105,7 +105,7 @@ static void UnSanitizeCVarName(ezStringBuilder& cvarName)
   }
 }
 
-ezResult ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
+void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
 {
   inout_State.m_sOutput.Clear();
 
@@ -114,7 +114,7 @@ ezResult ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_Sta
   if (sRealCommand.IsEmpty())
   {
     inout_State.AddOutputLine("");
-    return EZ_SUCCESS;
+    return;
   }
 
   sRealCommand.Trim(" \t\n\r");
@@ -176,10 +176,12 @@ ezResult ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_Sta
 
     if (bSetValue && !bValueEmpty)
     {
-      if (Script.ExecuteString(sSanitizedCommand, "console", ezLog::GetThreadLocalLogSystem()).Failed())
+      ezMuteLog muteLog;
+
+      if (Script.ExecuteString(sSanitizedCommand, "console", &muteLog).Failed())
       {
         inout_State.AddOutputLine("  Error Executing Command.", ezCommandOutputLine::Type::Error);
-        return EZ_FAILURE;
+        return;
       }
       else
       {
@@ -206,18 +208,18 @@ ezResult ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_Sta
         inout_State.AddOutputLine("  No Description available.", ezCommandOutputLine::Type::Success);
     }
 
-    return EZ_SUCCESS;
+    return;
   }
   else
   {
-    if (Script.ExecuteString(sSanitizedCommand, "console", ezLog::GetThreadLocalLogSystem()).Failed())
+    ezMuteLog muteLog;
+
+    if (Script.ExecuteString(sSanitizedCommand, "console", &muteLog).Failed())
     {
       inout_State.AddOutputLine("  Error Executing Command.", ezCommandOutputLine::Type::Error);
-      return EZ_FAILURE;
+      return;
     }
   }
-
-  return EZ_SUCCESS;
 }
 
 static int LUAFUNC_ReadCVAR(lua_State* state)

--- a/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
+++ b/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
@@ -1,6 +1,7 @@
 #include <Core/CorePCH.h>
 
 #include <Core/Console/LuaInterpreter.h>
+#include <Core/Console/QuakeConsole.h>
 #include <Core/Scripting/LuaWrapper.h>
 
 #ifdef BUILDSYSTEM_ENABLE_LUA_SUPPORT

--- a/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
+++ b/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
@@ -160,7 +160,7 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
 
   sTemp = "> ";
   sTemp.Append(sRealCommand.GetData());
-  inout_State.AddOutputLine(sTemp, ezCommandOutputLine::Type::Executed);
+  inout_State.AddOutputLine(sTemp, ezConsoleString::Type::Executed);
 
   ezCVar* pCVAR = ezCVar::FindCVarByName(sRealVarName.GetData());
   if (pCVAR != nullptr)
@@ -180,18 +180,18 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
 
       if (Script.ExecuteString(sSanitizedCommand, "console", &muteLog).Failed())
       {
-        inout_State.AddOutputLine("  Error Executing Command.", ezCommandOutputLine::Type::Error);
+        inout_State.AddOutputLine("  Error Executing Command.", ezConsoleString::Type::Error);
         return;
       }
       else
       {
         if (pCVAR->GetFlags().IsAnySet(ezCVarFlags::RequiresRestart))
         {
-          inout_State.AddOutputLine("  This change takes only effect after a restart.", ezCommandOutputLine::Type::Note);
+          inout_State.AddOutputLine("  This change takes only effect after a restart.", ezConsoleString::Type::Note);
         }
 
         sTemp.Format("  {0} = {1}", sRealVarName, ezConsole::GetFullInfoAsString(pCVAR));
-        inout_State.AddOutputLine(sTemp, ezCommandOutputLine::Type::Success);
+        inout_State.AddOutputLine(sTemp, ezConsoleString::Type::Success);
       }
     }
     else
@@ -202,10 +202,10 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
       if (!ezStringUtils::IsNullOrEmpty(pCVAR->GetDescription()))
       {
         sTemp.Format("  Description: {0}", pCVAR->GetDescription());
-        inout_State.AddOutputLine(sTemp, ezCommandOutputLine::Type::Success);
+        inout_State.AddOutputLine(sTemp, ezConsoleString::Type::Success);
       }
       else
-        inout_State.AddOutputLine("  No Description available.", ezCommandOutputLine::Type::Success);
+        inout_State.AddOutputLine("  No Description available.", ezConsoleString::Type::Success);
     }
 
     return;
@@ -216,7 +216,7 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
 
     if (Script.ExecuteString(sSanitizedCommand, "console", &muteLog).Failed())
     {
-      inout_State.AddOutputLine("  Error Executing Command.", ezCommandOutputLine::Type::Error);
+      inout_State.AddOutputLine("  Error Executing Command.", ezConsoleString::Type::Error);
       return;
     }
   }

--- a/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
+++ b/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
@@ -190,13 +190,13 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_State)
           inout_State.AddOutputLine("  This change takes only effect after a restart.", ezConsoleString::Type::Note);
         }
 
-        sTemp.Format("  {0} = {1}", sRealVarName, ezConsole::GetFullInfoAsString(pCVAR));
+        sTemp.Format("  {0} = {1}", sRealVarName, ezQuakeConsole::GetFullInfoAsString(pCVAR));
         inout_State.AddOutputLine(sTemp, ezConsoleString::Type::Success);
       }
     }
     else
     {
-      sTemp.Format("{0} = {1}", sRealVarName, ezConsole::GetFullInfoAsString(pCVAR));
+      sTemp.Format("{0} = {1}", sRealVarName, ezQuakeConsole::GetFullInfoAsString(pCVAR));
       inout_State.AddOutputLine(sTemp);
 
       if (!ezStringUtils::IsNullOrEmpty(pCVAR->GetDescription()))

--- a/Code/Engine/Core/Console/LuaInterpreter.h
+++ b/Code/Engine/Core/Console/LuaInterpreter.h
@@ -4,17 +4,18 @@
 
 #ifdef BUILDSYSTEM_ENABLE_LUA_SUPPORT
 
-namespace ezConsoleInterpreter
+class EZ_CORE_DLL ezCommandInterpreterLua : public ezCommandInterpreter
 {
+public:
   /// \brief The default interpreter used by ezConsole. Uses Lua for parsing and execution.
   ///
-  /// The lua interpreter can modify ezCVar variables and call ezConsoleFunction functions.
+  /// The Lua interpreter can modify ezCVar variables and call ezConsoleFunction functions.
   ///
   /// Typing 'some_bool_cvar =' is a short form for 'some_bool_cvar = not some_bool_cvar'
-  /// which toggles the value of the boolean cvar variable.
+  /// which toggles the value of the boolean CVar variable.
   ///
   /// Mathematical operations are possible, such as 'int_cvar = int_cvar + 1',
-  /// which can be used to modify the cvar gradually.
+  /// which can be used to modify the CVar gradually.
   /// Such a command can be very useful when the console is configured such that it is
   /// easy to re-execute the last commands by hitting just one button.
   /// It can also be used when binding keys to commands.
@@ -26,8 +27,7 @@ namespace ezConsoleInterpreter
   /// SomeConsoleFunc(2, some_cvar)
   ///
   /// If there is any kind of error (e.g. a Lua syntax error), the interpreter will return EZ_FAILURE;
-  EZ_CORE_DLL ezResult Lua(const char* szCommand, ezConsole* pConsole);
-
-} // namespace ezConsoleInterpreter
+  virtual ezResult Interpret(ezCommandInterpreterState& inout_State) override;
+};
 
 #endif // BUILDSYSTEM_ENABLE_LUA_SUPPORT

--- a/Code/Engine/Core/Console/LuaInterpreter.h
+++ b/Code/Engine/Core/Console/LuaInterpreter.h
@@ -27,7 +27,7 @@ public:
   /// SomeConsoleFunc(2, some_cvar)
   ///
   /// If there is any kind of error (e.g. a Lua syntax error), the interpreter will return EZ_FAILURE;
-  virtual ezResult Interpret(ezCommandInterpreterState& inout_State) override;
+  virtual void Interpret(ezCommandInterpreterState& inout_State) override;
 };
 
 #endif // BUILDSYSTEM_ENABLE_LUA_SUPPORT

--- a/Code/Engine/Core/Console/QuakeConsole.h
+++ b/Code/Engine/Core/Console/QuakeConsole.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <Core/Console/Console.h>
+
+struct ezLoggingEventData;
+
+/// \brief A Quake-style console for in-game configuration of ezCVar and ezConsoleFunction.
+///
+/// The console displays the recent log activity and allows to modify cvars and call console functions.
+/// It supports auto-completion of known keywords.
+/// Additionally, 'keys' can be bound to arbitrary commands, such that useful commands can be executed
+/// easily.
+/// The default implementation uses ezConsoleInterpreter::Lua as the interpreter for commands typed into it.
+/// The interpreter can be replaced with custom implementations.
+class EZ_CORE_DLL ezQuakeConsole : public ezConsole
+{
+public:
+  ezQuakeConsole();
+  virtual ~ezQuakeConsole();
+
+
+
+  /// \name Configuration
+  /// @{
+
+  /// \brief Adjusts how many strings the console will keep in memory at maximum.
+  void SetMaxConsoleStrings(ezUInt32 uiMax) { m_uiMaxConsoleStrings = ezMath::Clamp<ezUInt32>(uiMax, 0, 100000); }
+
+  /// \brief Returns how many strings the console will keep in memory at maximum.
+  ezUInt32 GetMaxConsoleStrings() const { return m_uiMaxConsoleStrings; }
+
+  /// \brief Enables or disables that the output from ezGlobalLog is displayed in the console. Enabled by default.
+  virtual void EnableLogOutput(bool bEnable);
+
+  /// \brief Writes the state of the console (history, bound keys) to the stream.
+  virtual void SaveState(ezStreamWriter& Stream) const;
+
+  /// \brief Reads the state of the console (history, bound keys) from the stream.
+  virtual void LoadState(ezStreamReader& Stream);
+
+  /// @}
+
+  /// \name Command Processing
+  /// @{
+
+
+
+  /// \brief Executes the given command using the current command interpreter.
+  virtual void ExecuteCommand(ezStringView input) override;
+
+  /// \brief Binds \a szCommand to \a szKey. Calling ExecuteBoundKey() with this key will then run that command.
+  ///
+  /// A key can be any arbitrary string. However, it might make sense to either use the standard ASCII characters A-Z and a-z, which allows
+  /// to trigger actions by the press of any of those buttons.
+  /// You can, however, also use names for input buttons, such as 'Key_Left', but then you also need to call ExecuteBoundKey() with those
+  /// names.
+  /// If you use such virtual key names, it makes also sense to listen to the auto-complete event and suggest those key names there.
+  void BindKey(const char* szKey, const char* szCommand);
+
+  /// \brief Removes the key binding.
+  void UnbindKey(const char* szKey);
+
+  /// \brief Executes the command that was bound to this key.
+  void ExecuteBoundKey(const char* szKey);
+
+  /// @}
+
+  /// \name Input Handling
+  /// @{
+
+  /// \brief Inserts one character at the caret position into the console input line.
+  ///
+  /// This function also calls ProcessInputCharacter and FilterInputCharacter. By default this already reacts on Tab, Enter and ESC
+  /// and filters out all non ASCII characters.
+  void AddInputCharacter(ezUInt32 uiChar);
+
+  /// \brief Clears the input line of the console.
+  void ClearInputLine();
+
+  /// \brief Returns the current content of the input line.
+  const char* GetInputLine() const { return m_sInputLine.GetData(); }
+
+  /// \brief Returns the position (in characters) of the caret.
+  ezInt32 GetCaretPosition() const { return m_iCaretPosition; }
+
+  /// \brief Moves the caret in the text. Its position will be clamped to the length of the current input line text.
+  void MoveCaret(ezInt32 iMoveOffset);
+
+  /// \brief Deletes the character following the caret position.
+  void DeleteNextCharacter();
+
+  /// \brief Scrolls the contents of the console up or down. Will be clamped to the available range.
+  void Scroll(ezInt32 iLines);
+
+  /// \brief Returns the current scroll position. This must be used during rendering to start with the proper line.
+  ezUInt32 GetScrollPosition() const { return m_iScrollPosition; }
+
+  /// \brief This function implements input handling (via ezInputManager) for the console.
+  ///
+  /// If the console is 'open' (ie. has full focus), it will handle more input for caret movement etc.
+  /// However, in the 'closed' state, it will still execute bound keys and commands from the history.
+  /// It is not required to call this function, you can implement input handling entirely outside the console.
+  ///
+  /// If this function is used, it should be called once per frame and if the console is considered 'open',
+  /// no further keyboard input should be processed, as that might lead to confusing behavior when the user types
+  /// text into the console.
+  ///
+  /// The state whether the console is considered open has to be managed by the application.
+  virtual void DoDefaultInputHandling(bool bConsoleOpen);
+
+  /// @}
+
+  /// \name Console Content
+  /// @{
+
+  /// \brief Adds a string to the console.
+  virtual void AddConsoleString(ezStringView text, ezConsoleString::Type type = ezConsoleString::Type::Default) override;
+
+  /// \brief Returns all current console strings. Use GetScrollPosition() to know which one should be displayed as the first one.
+  const ezDeque<ezConsoleString>& GetConsoleStrings() const;
+
+  /// \brief Deletes all console strings, making the console empty.
+  void ClearConsoleStrings();
+
+
+  /// @}
+
+  /// \name Helpers
+  /// @{
+
+
+  /// \brief Returns a nice string containing all the important information about the cvar.
+  static ezString GetFullInfoAsString(ezCVar* pCVar);
+
+  /// \brief Returns the value of the cvar as a string.
+  static const ezString GetValueAsString(ezCVar* pCVar);
+
+  /// @}
+
+protected:
+  /// \brief Deletes the character at the given position in the input line.
+  void RemoveCharacter(ezUInt32 uiInputLinePosition);
+
+  /// \brief Makes sure the caret position is clamped to the input line length.
+  void ClampCaretPosition();
+
+
+  /// \brief The function that is used to read ezGlobalLog messages.
+  void LogHandler(const ezLoggingEventData& data);
+
+  ezInt32 m_iCaretPosition;
+  ezStringBuilder m_sInputLine;
+
+  virtual bool ProcessInputCharacter(ezUInt32 uiChar);
+  virtual bool FilterInputCharacter(ezUInt32 uiChar);
+  virtual void InputStringChanged();
+
+  ezDeque<ezConsoleString> m_ConsoleStrings;
+  bool m_bUseFilteredStrings = false;
+  ezDeque<ezConsoleString> m_FilteredConsoleStrings;
+  ezUInt32 m_uiMaxConsoleStrings;
+  ezInt32 m_iScrollPosition;
+  bool m_bLogOutputEnabled;
+  bool m_bDefaultInputHandlingInitialized;
+
+
+  ezMap<ezString, ezString> m_BoundKeys;
+};

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -112,7 +112,7 @@ void ezGameApplicationBase::StoreScreenshot(ezImage&& image, const char* szConte
   pWriteTask->ConfigureTask("Write Screenshot", ezTaskNesting::Never);
   pWriteTask->m_Image.ResetAndMove(std::move(image));
 
-  pWriteTask->m_sPath.Format(":appdata/Screenshots/{0} ", ezApplication::GetApplicationInstance()->GetApplicationName());
+  pWriteTask->m_sPath.Format(":appdata/Screenshots/{0}", ezApplication::GetApplicationInstance()->GetApplicationName());
   AppendCurrentTimestamp(pWriteTask->m_sPath);
   pWriteTask->m_sPath.Append(szContext);
   pWriteTask->m_sPath.Append(".png");

--- a/Code/Engine/Core/Scripting/LuaWrapper/Initialize.cpp
+++ b/Code/Engine/Core/Scripting/LuaWrapper/Initialize.cpp
@@ -52,7 +52,7 @@ ezResult ezLuaWrapper::ExecuteString(const char* szString, const char* szDebugCh
     EZ_LOG_BLOCK("ezLuaWrapper::ExecuteString");
 
     ezLog::Error(pLogInterface, "[lua]Lua compile error: {0}", lua_tostring(m_pState, -1));
-    ezLog::Info("[luascript]Script: {0}", szString);
+    ezLog::Info(pLogInterface, "[luascript]Script: {0}", szString);
 
     return EZ_FAILURE;
   }
@@ -64,7 +64,7 @@ ezResult ezLuaWrapper::ExecuteString(const char* szString, const char* szDebugCh
     EZ_LOG_BLOCK("ezLuaWrapper::ExecuteString");
 
     ezLog::Error(pLogInterface, "[lua]Lua error: {0}", lua_tostring(m_pState, -1));
-    ezLog::Info("[luascript]Script: {0}", szString);
+    ezLog::Info(pLogInterface, "[luascript]Script: {0}", szString);
 
     return EZ_FAILURE;
   }

--- a/Code/Engine/Foundation/IO/Implementation/Win/OSFile_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/OSFile_win.h
@@ -95,7 +95,11 @@ ezResult ezOSFile::InternalOpen(const char* szFile, ezFileOpenMode::Enum OpenMod
       if (error == ERROR_INVALID_NAME)
         return res;
 
-      if (error == ERROR_SHARING_VIOLATION)
+      if (error == ERROR_SHARING_VIOLATION
+          // these two situations happen when the ezInspector is connected
+          // for some reason, the networking blocks file reading (when run on the same machine)
+          // retrying fixes the problem, but can introduce very long stalls
+          || error == WSAEWOULDBLOCK || error == ERROR_SUCCESS)
       {
         if (m_bRetryOnSharingViolation)
         {

--- a/Code/Engine/GameEngine/GameApplication/GameApplication.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplication.h
@@ -7,7 +7,7 @@
 #include <Foundation/Threading/DelegateTask.h>
 #include <Foundation/Types/UniquePtr.h>
 
-class ezConsole;
+class ezQuakeConsole;
 
 // TODO: update comments below
 
@@ -90,5 +90,5 @@ protected:
   static ezDelegate<ezGALDevice*(const ezGALDeviceCreationDescription&)> s_DefaultDeviceCreator;
 
   bool m_bShowConsole = false;
-  ezUniquePtr<ezConsole> m_pConsole;
+  ezUniquePtr<ezQuakeConsole> m_pConsole;
 };

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -3,7 +3,7 @@
 #include <Core/ActorSystem/Actor.h>
 #include <Core/ActorSystem/ActorManager.h>
 #include <Core/ActorSystem/ActorPluginWindow.h>
-#include <Core/Console/Console.h>
+#include <Core/Console/QuakeConsole.h>
 #include <Core/Input/InputManager.h>
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Core/World/World.h>

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -45,6 +45,7 @@ ezGameApplication::ezGameApplication(const char* szAppName, const char* szProjec
   m_bWasQuitRequested = false;
 
   m_pConsole = EZ_DEFAULT_NEW(ezQuakeConsole);
+  ezConsole::SetMainConsole(m_pConsole.Borrow());
 }
 
 ezGameApplication::~ezGameApplication()

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -44,7 +44,7 @@ ezGameApplication::ezGameApplication(const char* szAppName, const char* szProjec
   s_pGameApplicationInstance = this;
   m_bWasQuitRequested = false;
 
-  m_pConsole = EZ_DEFAULT_NEW(ezConsole);
+  m_pConsole = EZ_DEFAULT_NEW(ezQuakeConsole);
 }
 
 ezGameApplication::~ezGameApplication()

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -305,7 +305,7 @@ void ezGameApplication::RenderConsole()
     for (ezUInt32 i = uiSkippedLines; i < uiNumConsoleLines; ++i)
     {
       auto& consoleString = consoleStrings[uiFirstLine - i];
-      ezDebugRenderer::Draw2DText(hView, consoleString.m_sText.GetData(), ezVec2I32(iTextLeft, iFirstLinePos + i * iTextHeight), consoleString.m_TextColor);
+      ezDebugRenderer::Draw2DText(hView, consoleString.m_sText.GetData(), ezVec2I32(iTextLeft, iFirstLinePos + i * iTextHeight), consoleString.GetColor());
     }
 
     ezDebugRenderer::Draw2DText(hView, m_pConsole->GetInputLine(), ezVec2I32(iTextLeft, (ezInt32)(fConsoleTextAreaHeight + fBorderWidth)), ezColor::White);

--- a/Code/EnginePlugins/InspectorPlugin/Console.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/Console.cpp
@@ -1,0 +1,54 @@
+#include <InspectorPlugin/InspectorPluginPCH.h>
+
+#include <Core/Console/Console.h>
+#include <Foundation/Communication/Telemetry.h>
+#include <Foundation/Configuration/CVar.h>
+
+static void TelemetryMessage(void* pPassThrough)
+{
+  ezTelemetryMessage Msg;
+  ezStringBuilder input;
+
+  while (ezTelemetry::RetrieveMessage('CMD', Msg) == EZ_SUCCESS)
+  {
+    if (Msg.GetMessageID() == 'EXEC' || Msg.GetMessageID() == 'COMP')
+    {
+      Msg.GetReader() >> input;
+
+      if (ezConsole::GetMainConsole())
+      {
+        if (auto pInt = ezConsole::GetMainConsole()->GetCommandInterpreter())
+        {
+          ezCommandInterpreterState s;
+          s.m_sInput = input;
+
+          if (Msg.GetMessageID() == 'EXEC')
+            pInt->Interpret(s);
+          else
+            pInt->AutoComplete(s);
+
+          ezTelemetryMessage msg;
+          msg.SetMessageID('CMD', 'RES');
+          msg.GetWriter() << s.m_sInput;
+          msg.GetWriter() << (ezUInt16)s.m_sOutput.GetCount();
+          for (const auto& l : s.m_sOutput)
+          {
+            msg.GetWriter() << l.m_sText;
+            msg.GetWriter() << (ezInt16)l.m_Type;
+          }
+          ezTelemetry::Broadcast(ezTelemetry::Reliable, msg);
+        }
+      }
+    }
+  }
+}
+
+void AddConsoleEventHandler()
+{
+  ezTelemetry::AcceptMessagesForSystem('CMD', true, TelemetryMessage, nullptr);
+}
+
+void RemoveConsoleEventHandler()
+{
+  ezTelemetry::AcceptMessagesForSystem('CMD', false);
+}

--- a/Code/EnginePlugins/InspectorPlugin/InspectorPlugin.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/InspectorPlugin.cpp
@@ -17,6 +17,9 @@ void RemoveStartupEventHandler();
 void AddCVarEventHandler();
 void RemoveCVarEventHandler();
 
+void AddConsoleEventHandler();
+void RemoveConsoleEventHandler();
+
 void AddMemoryEventHandler();
 void RemoveMemoryEventHandler();
 
@@ -63,6 +66,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(InspectorPlugin, InspectorPluginMain)
     AddStatsEventHandler();
     AddStartupEventHandler();
     AddCVarEventHandler();
+    AddConsoleEventHandler();
     AddReflectionEventHandler();
     AddMemoryEventHandler();
     AddInputEventHandler();
@@ -88,6 +92,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(InspectorPlugin, InspectorPluginMain)
     RemoveMemoryEventHandler();
     RemoveReflectionEventHandler();
     RemoveCVarEventHandler();
+    RemoveConsoleEventHandler();
     RemoveStartupEventHandler();
     RemoveStatsEventHandler();
     RemoveLogWriter();

--- a/Code/Tools/Inspector/CVarsWidget.cpp
+++ b/Code/Tools/Inspector/CVarsWidget.cpp
@@ -133,6 +133,24 @@ void ezQtCVarsWidget::ProcessTelemetry(void* pUnuseed)
     s_pWidget->CVarWidget->UpdateCVarUI(s_pWidget->m_CVars);
 }
 
+void ezQtCVarsWidget::ProcessTelemetryConsole(void* pUnuseed)
+{
+  if (!s_pWidget)
+    return;
+
+  ezTelemetryMessage msg;
+  ezStringBuilder tmp;
+
+  while (ezTelemetry::RetrieveMessage('CMD', msg) == EZ_SUCCESS)
+  {
+    if (msg.GetMessageID() == 'RES')
+    {
+      msg.GetReader() >> tmp;
+      s_pWidget->CVarWidget->AddConsoleStrings(tmp);
+    }
+  }
+}
+
 void ezQtCVarsWidget::SyncAllCVarsToServer()
 {
   for (auto it = m_CVars.GetIterator(); it.IsValid(); ++it)

--- a/Code/Tools/Inspector/CVarsWidget.cpp
+++ b/Code/Tools/Inspector/CVarsWidget.cpp
@@ -9,6 +9,26 @@
 #include <qlistwidget.h>
 #include <qspinbox.h>
 
+class ezCommandInterpreterInspector : public ezCommandInterpreter
+{
+public:
+  virtual void Interpret(ezCommandInterpreterState& inout_State) override
+  {
+    ezTelemetryMessage Msg;
+    Msg.SetMessageID('CMD', 'EXEC');
+    Msg.GetWriter() << inout_State.m_sInput;
+    ezTelemetry::SendToServer(Msg);
+  }
+
+  virtual void AutoComplete(ezCommandInterpreterState& inout_State) override
+  {
+    ezTelemetryMessage Msg;
+    Msg.SetMessageID('CMD', 'COMP');
+    Msg.GetWriter() << inout_State.m_sInput;
+    ezTelemetry::SendToServer(Msg);
+  }
+};
+
 ezQtCVarsWidget* ezQtCVarsWidget::s_pWidget = nullptr;
 
 ezQtCVarsWidget::ezQtCVarsWidget(QWidget* parent)
@@ -23,6 +43,8 @@ ezQtCVarsWidget::ezQtCVarsWidget(QWidget* parent)
   connect(CVarWidget, &ezQtCVarWidget::onFloatChanged, this, &ezQtCVarsWidget::FloatChanged);
   connect(CVarWidget, &ezQtCVarWidget::onIntChanged, this, &ezQtCVarsWidget::IntChanged);
   connect(CVarWidget, &ezQtCVarWidget::onStringChanged, this, &ezQtCVarsWidget::StringChanged);
+
+  CVarWidget->GetConsole().SetCommandInterpreter(EZ_DEFAULT_NEW(ezCommandInterpreterInspector));
 
   ResetStats();
 }

--- a/Code/Tools/Inspector/CVarsWidget.moc.h
+++ b/Code/Tools/Inspector/CVarsWidget.moc.h
@@ -26,6 +26,7 @@ private Q_SLOTS:
 
 public:
   static void ProcessTelemetry(void* pUnuseed);
+  static void ProcessTelemetryConsole(void* pUnuseed);
 
   void ResetStats();
 

--- a/Code/Tools/Inspector/Inspector.cpp
+++ b/Code/Tools/Inspector/Inspector.cpp
@@ -91,6 +91,7 @@ public:
     ezQtMainWindow MainWindow;
 
     ezTelemetry::AcceptMessagesForSystem('CVAR', true, ezQtCVarsWidget::ProcessTelemetry, nullptr);
+    ezTelemetry::AcceptMessagesForSystem('CMD', true, ezQtCVarsWidget::ProcessTelemetryConsole, nullptr);
     ezTelemetry::AcceptMessagesForSystem(' LOG', true, ezQtLogDockWidget::ProcessTelemetry, nullptr);
     ezTelemetry::AcceptMessagesForSystem(' MEM', true, ezQtMemoryWidget::ProcessTelemetry, nullptr);
     ezTelemetry::AcceptMessagesForSystem('TIME', true, ezQtTimeWidget::ProcessTelemetry, nullptr);

--- a/Code/Tools/Libs/GuiFoundation/CMakeLists.txt
+++ b/Code/Tools/Libs/GuiFoundation/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
   ToolsFoundation
   ads
+  Core
 )
 
 ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets Network WinExtras Svg COPY_DLLS)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Console/Console.h>
 #include <Foundation/Basics.h>
 #include <Foundation/Containers/Deque.h>
 #include <Foundation/Containers/Map.h>
@@ -113,6 +114,8 @@ public:
   /// \brief Updates the existing UI. This is sufficient if values changed only.
   void UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars);
 
+  void SetConsoleCommandInterpreter(const ezSharedPtr<ezCommandInterpreter>& interpreter);
+
 Q_SIGNALS:
   void onBoolChanged(const char* szCVar, bool newValue);
   void onFloatChanged(const char* szCVar, float newValue);
@@ -121,9 +124,16 @@ Q_SIGNALS:
 
 private Q_SLOTS:
   void SearchTextChanged(const QString& text);
+  void ConsoleInputChanged(const QString& text);
+  void ConsoleEnterPressed();
+  void ConsoleSpecialKeyPressed(Qt::Key key);
 
 private:
   QPointer<ezQtCVarModel> m_pItemModel;
   QPointer<QSortFilterProxyModel> m_pFilterModel;
   QPointer<ezQtCVarItemDelegate> m_pItemDelegate;
+
+  void OnConsoleEvent(ezConsole::ConsoleEvent& e);
+
+  ezConsole m_Console;
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -116,6 +116,10 @@ public:
 
   void SetConsoleCommandInterpreter(const ezSharedPtr<ezCommandInterpreter>& interpreter);
 
+  void AddConsoleOutput(const char* text);
+
+  void ReplaceConsoleInput(const char* text);
+
 Q_SIGNALS:
   void onBoolChanged(const char* szCVar, bool newValue);
   void onFloatChanged(const char* szCVar, float newValue);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -138,5 +138,5 @@ private:
 
   void OnConsoleEvent(const ezConsoleEvent& e);
 
-  ezConsoleBase m_Console;
+  ezConsole m_Console;
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -114,11 +114,9 @@ public:
   /// \brief Updates the existing UI. This is sufficient if values changed only.
   void UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars);
 
-  void SetConsoleCommandInterpreter(const ezSharedPtr<ezCommandInterpreter>& interpreter);
-
-  void AddConsoleOutput(const char* text);
-
   void ReplaceConsoleInput(const char* text);
+
+  ezConsole& GetConsole() { return m_Console; }
 
 Q_SIGNALS:
   void onBoolChanged(const char* szCVar, bool newValue);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -114,7 +114,7 @@ public:
   /// \brief Updates the existing UI. This is sufficient if values changed only.
   void UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars);
 
-  void ReplaceConsoleInput(const char* text);
+  void AddConsoleStrings(const ezStringBuilder& encoded);
 
   ezConsole& GetConsole() { return m_Console; }
 

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -128,7 +128,6 @@ Q_SIGNALS:
 
 private Q_SLOTS:
   void SearchTextChanged(const QString& text);
-  void ConsoleInputChanged(const QString& text);
   void ConsoleEnterPressed();
   void ConsoleSpecialKeyPressed(Qt::Key key);
 
@@ -139,5 +138,5 @@ private:
 
   void OnConsoleEvent(const ezConsoleEvent& e);
 
-  ezConsole m_Console;
+  ezConsoleBase m_Console;
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.moc.h
@@ -137,7 +137,7 @@ private:
   QPointer<QSortFilterProxyModel> m_pFilterModel;
   QPointer<ezQtCVarItemDelegate> m_pItemDelegate;
 
-  void OnConsoleEvent(ezConsole::ConsoleEvent& e);
+  void OnConsoleEvent(const ezConsoleEvent& e);
 
   ezConsole m_Console;
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.ui
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.ui
@@ -30,6 +30,22 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QTextEdit" name="ConsoleOutput">
+     <property name="undoRedoEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="lineWrapMode">
+      <enum>QTextEdit::NoWrap</enum>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="ezQtSearchWidget" name="ConsoleInput" native="true"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.ui
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CVarWidget.ui
@@ -13,38 +13,53 @@
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <item>
-    <widget class="ezQtSearchWidget" name="SearchWidget" native="true"/>
-   </item>
-   <item>
-    <widget class="QTreeView" name="CVarsView">
-     <property name="editTriggers">
-      <set>QAbstractItemView::CurrentChanged|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectItems</enum>
-     </property>
-     <property name="uniformRowHeights">
-      <bool>true</bool>
-     </property>
+     <widget class="QWidget" name="">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="ezQtSearchWidget" name="SearchWidget" native="true"/>
+       </item>
+       <item>
+        <widget class="QTreeView" name="CVarsView">
+         <property name="editTriggers">
+          <set>QAbstractItemView::CurrentChanged|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectItems</enum>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QTextEdit" name="ConsoleOutput">
+         <property name="undoRedoEnabled">
+          <bool>false</bool>
+         </property>
+         <property name="lineWrapMode">
+          <enum>QTextEdit::NoWrap</enum>
+         </property>
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="ezQtSearchWidget" name="ConsoleInput" native="true"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <widget class="QTextEdit" name="ConsoleOutput">
-     <property name="undoRedoEnabled">
-      <bool>false</bool>
-     </property>
-     <property name="lineWrapMode">
-      <enum>QTextEdit::NoWrap</enum>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="ezQtSearchWidget" name="ConsoleInput" native="true"/>
    </item>
   </layout>
  </widget>

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -135,6 +135,16 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
     m_Console.AddInputCharacter('\t');
     ConsoleInput->setText(m_Console.GetInputLine());
   }
+  if (key == Qt::Key_Up)
+  {
+    m_Console.SearchInputHistory(1);
+    ConsoleInput->setText(m_Console.GetInputLine());
+  }
+  if (key == Qt::Key_Down)
+  {
+    m_Console.SearchInputHistory(-1);
+    ConsoleInput->setText(m_Console.GetInputLine());
+  }
 }
 
 void ezQtCVarWidget::OnConsoleEvent(ezConsole::ConsoleEvent& e)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -32,11 +32,9 @@ ezQtCVarWidget::ezQtCVarWidget(QWidget* parent)
   CVarsView->setItemDelegateForColumn(1, m_pItemDelegate);
 
   connect(SearchWidget, &ezQtSearchWidget::textChanged, this, &ezQtCVarWidget::SearchTextChanged);
-  connect(ConsoleInput, &ezQtSearchWidget::textChanged, this, &ezQtCVarWidget::ConsoleInputChanged);
   connect(ConsoleInput, &ezQtSearchWidget::enterPressed, this, &ezQtCVarWidget::ConsoleEnterPressed);
   connect(ConsoleInput, &ezQtSearchWidget::specialKeyPressed, this, &ezQtCVarWidget::ConsoleSpecialKeyPressed);
 
-  m_Console.EnableLogOutput(false);
   m_Console.Events().AddEventHandler(ezMakeDelegate(&ezQtCVarWidget::OnConsoleEvent, this));
 
   ConsoleInput->setPlaceholderText("> TAB to auto-complete");
@@ -131,14 +129,9 @@ void ezQtCVarWidget::SearchTextChanged(const QString& text)
   CVarsView->expandAll();
 }
 
-void ezQtCVarWidget::ConsoleInputChanged(const QString& text)
-{
-  m_Console.ReplaceInput(text.toUtf8().data());
-}
-
 void ezQtCVarWidget::ConsoleEnterPressed()
 {
-  m_Console.AddInputCharacter(13);
+  m_Console.ExecuteCommand(ConsoleInput->text().toUtf8().data());
   ConsoleInput->setText("");
 }
 
@@ -146,8 +139,12 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
 {
   if (key == Qt::Key_Tab)
   {
-    m_Console.AddInputCharacter('\t');
-    //ConsoleInput->setText(m_Console.GetInputLine());
+    ezStringBuilder input = ConsoleInput->text().toUtf8().data();
+
+    if (m_Console.AutoComplete(input))
+    {
+      ConsoleInput->setText(input.GetData());
+    }
   }
   if (key == Qt::Key_Up)
   {

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -159,6 +159,20 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
     m_Console.RetrieveInputHistory(-1, input);
     ConsoleInput->setText(input.GetData());
   }
+  if (key == Qt::Key_F2)
+  {
+    if (m_Console.GetInputHistory().GetCount() >= 1)
+    {
+      m_Console.ExecuteCommand(m_Console.GetInputHistory()[0]);
+    }
+  }
+  if (key == Qt::Key_F3)
+  {
+    if (m_Console.GetInputHistory().GetCount() >= 2)
+    {
+      m_Console.ExecuteCommand(m_Console.GetInputHistory()[1]);
+    }
+  }
 }
 
 void ezQtCVarWidget::OnConsoleEvent(const ezConsoleEvent& e)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -93,9 +93,27 @@ void ezQtCVarWidget::UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars
   CVarsView->resizeColumnToContents(1);
 }
 
-void ezQtCVarWidget::ReplaceConsoleInput(const char* text)
+void ezQtCVarWidget::AddConsoleStrings(const ezStringBuilder& encoded)
 {
-  ConsoleInput->setText(text);
+  ezHybridArray<ezStringView, 64> lines;
+  encoded.Split(false, lines, ";;");
+
+  ezStringBuilder tmp;
+
+  for (auto l : lines)
+  {
+    l.Shrink(4, 0); // skip the line type number at the front (for now)
+
+    if (l.StartsWith("<"))
+    {
+      l.Shrink(1, 0);
+      ConsoleInput->setText(l.GetData(tmp));
+    }
+    else
+    {
+      GetConsole().AddConsoleString(l);
+    }
+  }
 }
 
 void ezQtCVarWidget::SearchTextChanged(const QString& text)
@@ -168,6 +186,7 @@ void ezQtCVarWidget::OnConsoleEvent(const ezConsoleEvent& e)
   {
     QString t = ConsoleOutput->toPlainText();
     t += e.m_AddedpConsoleString->m_sText;
+    t += "\n";
     ConsoleOutput->setPlainText(t);
     ConsoleOutput->verticalScrollBar()->setValue(ConsoleOutput->verticalScrollBar()->maximum());
   }

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -53,11 +53,8 @@ void ezQtCVarWidget::Clear()
 
 void ezQtCVarWidget::RebuildCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars)
 {
+  // for now update and rebuild are the same
   UpdateCVarUI(cvars);
-
-  CVarsView->expandAll();
-  CVarsView->resizeColumnToContents(0);
-  CVarsView->resizeColumnToContents(1);
 }
 
 void ezQtCVarWidget::UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars)
@@ -92,11 +89,28 @@ void ezQtCVarWidget::UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars
   }
 
   m_pItemModel->EndResetModel();
+
+  CVarsView->expandAll();
+  CVarsView->resizeColumnToContents(0);
+  CVarsView->resizeColumnToContents(1);
 }
 
 void ezQtCVarWidget::SetConsoleCommandInterpreter(const ezSharedPtr<ezCommandInterpreter>& interpreter)
 {
   m_Console.SetCommandInterpreter(interpreter);
+}
+
+void ezQtCVarWidget::AddConsoleOutput(const char* data)
+{
+  QString t = ConsoleOutput->toPlainText();
+  t += data;
+  ConsoleOutput->setPlainText(t);
+  ConsoleOutput->verticalScrollBar()->setValue(ConsoleOutput->verticalScrollBar()->maximum());
+}
+
+void ezQtCVarWidget::ReplaceConsoleInput(const char* text)
+{
+  ConsoleInput->setText(text);
 }
 
 void ezQtCVarWidget::SearchTextChanged(const QString& text)
@@ -133,7 +147,7 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
   if (key == Qt::Key_Tab)
   {
     m_Console.AddInputCharacter('\t');
-    ConsoleInput->setText(m_Console.GetInputLine());
+    //ConsoleInput->setText(m_Console.GetInputLine());
   }
   if (key == Qt::Key_Up)
   {
@@ -149,13 +163,10 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
 
 void ezQtCVarWidget::OnConsoleEvent(ezConsole::ConsoleEvent& e)
 {
-  if (e.m_EventType == ezConsole::ConsoleEvent::StringAdded)
-  {
-    QString t = ConsoleOutput->toHtml();
-    t += e.m_AddedpConsoleString->m_sText.GetData();
-    ConsoleOutput->setHtml(t);
-    ConsoleOutput->verticalScrollBar()->setValue(ConsoleOutput->verticalScrollBar()->maximum());
-  }
+  //if (e.m_EventType == ezConsole::ConsoleEvent::StringAdded)
+  //{
+  //  AddConsoleOutput(e.m_AddedpConsoleString->m_sText);
+  //}
 }
 
 ezQtCVarModel::ezQtCVarModel(ezQtCVarWidget* owner)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -93,19 +93,6 @@ void ezQtCVarWidget::UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars
   CVarsView->resizeColumnToContents(1);
 }
 
-void ezQtCVarWidget::SetConsoleCommandInterpreter(const ezSharedPtr<ezCommandInterpreter>& interpreter)
-{
-  m_Console.SetCommandInterpreter(interpreter);
-}
-
-void ezQtCVarWidget::AddConsoleOutput(const char* data)
-{
-  QString t = ConsoleOutput->toPlainText();
-  t += data;
-  ConsoleOutput->setPlainText(t);
-  ConsoleOutput->verticalScrollBar()->setValue(ConsoleOutput->verticalScrollBar()->maximum());
-}
-
 void ezQtCVarWidget::ReplaceConsoleInput(const char* text)
 {
   ConsoleInput->setText(text);
@@ -179,7 +166,10 @@ void ezQtCVarWidget::OnConsoleEvent(const ezConsoleEvent& e)
 {
   if (e.m_Type == ezConsoleEvent::Type::OutputLineAdded)
   {
-    AddConsoleOutput(e.m_AddedpConsoleString->m_sText);
+    QString t = ConsoleOutput->toPlainText();
+    t += e.m_AddedpConsoleString->m_sText;
+    ConsoleOutput->setPlainText(t);
+    ConsoleOutput->verticalScrollBar()->setValue(ConsoleOutput->verticalScrollBar()->maximum());
   }
 }
 

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -37,7 +37,7 @@ ezQtCVarWidget::ezQtCVarWidget(QWidget* parent)
   connect(ConsoleInput, &ezQtSearchWidget::specialKeyPressed, this, &ezQtCVarWidget::ConsoleSpecialKeyPressed);
 
   m_Console.EnableLogOutput(false);
-  m_Console.m_Events.AddEventHandler(ezMakeDelegate(&ezQtCVarWidget::OnConsoleEvent, this));
+  m_Console.Events().AddEventHandler(ezMakeDelegate(&ezQtCVarWidget::OnConsoleEvent, this));
 
   ConsoleInput->setPlaceholderText("> TAB to auto-complete");
 }
@@ -161,7 +161,7 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
   }
 }
 
-void ezQtCVarWidget::OnConsoleEvent(ezConsole::ConsoleEvent& e)
+void ezQtCVarWidget::OnConsoleEvent(const ezConsoleEvent& e)
 {
   //if (e.m_EventType == ezConsole::ConsoleEvent::StringAdded)
   //{

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -131,6 +131,7 @@ void ezQtCVarWidget::SearchTextChanged(const QString& text)
 
 void ezQtCVarWidget::ConsoleEnterPressed()
 {
+  m_Console.AddToInputHistory(ConsoleInput->text().toUtf8().data());
   m_Console.ExecuteCommand(ConsoleInput->text().toUtf8().data());
   ConsoleInput->setText("");
 }
@@ -148,22 +149,24 @@ void ezQtCVarWidget::ConsoleSpecialKeyPressed(Qt::Key key)
   }
   if (key == Qt::Key_Up)
   {
-    m_Console.SearchInputHistory(1);
-    ConsoleInput->setText(m_Console.GetInputLine());
+    ezStringBuilder input = ConsoleInput->text().toUtf8().data();
+    m_Console.RetrieveInputHistory(1, input);
+    ConsoleInput->setText(input.GetData());
   }
   if (key == Qt::Key_Down)
   {
-    m_Console.SearchInputHistory(-1);
-    ConsoleInput->setText(m_Console.GetInputLine());
+    ezStringBuilder input = ConsoleInput->text().toUtf8().data();
+    m_Console.RetrieveInputHistory(-1, input);
+    ConsoleInput->setText(input.GetData());
   }
 }
 
 void ezQtCVarWidget::OnConsoleEvent(const ezConsoleEvent& e)
 {
-  //if (e.m_EventType == ezConsole::ConsoleEvent::StringAdded)
-  //{
-  //  AddConsoleOutput(e.m_AddedpConsoleString->m_sText);
-  //}
+  if (e.m_Type == ezConsoleEvent::Type::OutputLineAdded)
+  {
+    AddConsoleOutput(e.m_AddedpConsoleString->m_sText);
+  }
 }
 
 ezQtCVarModel::ezQtCVarModel(ezQtCVarWidget* owner)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchWidget.cpp
@@ -84,7 +84,7 @@ bool ezQtSearchWidget::eventFilter(QObject* obj, QEvent* e)
         return true;
       }
 
-      if (pEvent->key() == Qt::Key_Up || pEvent->key() == Qt::Key_Down || pEvent->key() == Qt::Key_Tab || pEvent->key() == Qt::Key_Backtab)
+      if (pEvent->key() == Qt::Key_Up || pEvent->key() == Qt::Key_Down || pEvent->key() == Qt::Key_Tab || pEvent->key() == Qt::Key_Backtab || pEvent->key() == Qt::Key_F1 || pEvent->key() == Qt::Key_F2 || pEvent->key() == Qt::Key_F3)
       {
         Q_EMIT specialKeyPressed((Qt::Key)pEvent->key());
         return true;

--- a/Code/Tools/Libs/GuiFoundation/Widgets/SearchWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/SearchWidget.moc.h
@@ -33,7 +33,10 @@ Q_SIGNALS:
   void enterPressed();
 
   /// \brief This signal is sent when certain keys are pressed that could be used by external code to implement additional features.
-  /// Currently exposed: Qt::Key_Up, Qt::Key_Down, Qt::Key_Tab, Qt::Key_Backtab (that's SHIFT+Tab)
+  /// Currently exposed:
+  ///   Qt::Key_Up, Qt::Key_Down
+  ///   Qt::Key_Tab, Qt::Key_Backtab (that's SHIFT+Tab)
+  ///   Qt::Key_F1, Qt::Key_F2, Qt::Key_F3
   void specialKeyPressed(Qt::Key key);
 
   void visibleEvent();
@@ -49,4 +52,3 @@ protected:
   QLineEdit* m_pLineEdit;
   QPushButton* m_pClearButton;
 };
-

--- a/Data/Samples/Testing Chambers/Window.ddl
+++ b/Data/Samples/Testing Chambers/Window.ddl
@@ -1,7 +1,7 @@
 WindowDesc
 {
 	string %Title{"Testing Chambers"}
-	string %Mode{"Borderless"}
+	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{1024,768}}
 	bool %ClipMouseCursor{true}
 	bool %ShowMouseCursor{false}


### PR DESCRIPTION
The console can be used the same way as the in-game Quake-style console:

* Hit TAB to auto-complete
* Enter to run a command
* Arrow up/down for input history
* F2, F3 to repeat last and second-to-last command

Commands are sent to the engine process to be executed there. Auto-complete as well. That means all CVars and console functions that are known to the engine process are available, not only the ones known by the local process.

Fixes #224 

![image](https://user-images.githubusercontent.com/6001174/132093357-20a4d970-efd2-4554-a005-91091abd2f11.png)
