### PR TITLE
Automatically restart engine process, if plugins changed

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EnginePlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EnginePlugins.cpp
@@ -34,6 +34,50 @@ void ezQtEditorApp::DetectAvailableEnginePlugins()
     s_EnginePlugins.m_Plugins[plugin.m_sAppDirRelativePath].m_bToBeLoaded = plugin.m_sDependecyOf.Contains("<manual>");
     s_EnginePlugins.m_Plugins[plugin.m_sAppDirRelativePath].m_bLoadCopy = plugin.m_bLoadCopy;
   }
+
+  StoreEnginePluginModificationTimes();
+}
+
+void ezQtEditorApp::StoreEnginePluginModificationTimes()
+{
+  for (const auto& plugin : m_EnginePluginConfig.m_Plugins)
+  {
+    auto& data = s_EnginePlugins.m_Plugins[plugin.m_sAppDirRelativePath];
+
+    ezStringBuilder sPath, sCopy;
+    ezPlugin::GetPluginPaths(plugin.m_sAppDirRelativePath, sPath, sCopy, 0);
+
+    ezFileStats stats;
+    if (ezOSFile::GetFileStats(sPath, stats).Succeeded())
+    {
+      data.m_LastModification = stats.m_LastModificationTime;
+    }
+  }
+}
+
+bool ezQtEditorApp::CheckForEnginePluginModifications()
+{
+  for (const auto& plugin : m_EnginePluginConfig.m_Plugins)
+  {
+    auto& data = s_EnginePlugins.m_Plugins[plugin.m_sAppDirRelativePath];
+    // only plugins for which a copy was loaded can be modified in parallel
+    if (!plugin.m_bLoadCopy)
+      continue;
+
+    ezStringBuilder sPath, sCopy;
+    ezPlugin::GetPluginPaths(plugin.m_sAppDirRelativePath, sPath, sCopy, 0);
+
+    ezFileStats stats;
+    if (ezOSFile::GetFileStats(sPath, stats).Succeeded())
+    {
+      if (stats.m_LastModificationTime.Compare(data.m_LastModification, ezTimestamp::CompareMode::Newer))
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 void ezQtEditorApp::StoreEnginePluginsToBeLoaded()
@@ -170,4 +214,32 @@ void ezQtEditorApp::ValidateEnginePluginConfig()
 
     ezQtUiServices::MessageBoxWarning(sMsg);
   }
+}
+
+void ezQtEditorApp::RestartEngineProcessIfPluginsChanged()
+{
+  if (m_LastPluginModificationCheck + ezTime::Seconds(2) > ezTime::Now())
+    return;
+
+  m_LastPluginModificationCheck = ezTime::Now();
+
+  for (auto pMan : ezDocumentManager::GetAllDocumentManagers())
+  {
+    for (auto pDoc : pMan->ezDocumentManager::GetAllOpenDocuments())
+    {
+      if (!pDoc->CanEngineProcessBeRestarted())
+      {
+        // not allowed to restart at the moment
+        return;
+      }
+    }
+  }
+
+  if (!CheckForEnginePluginModifications())
+    return;
+
+  ezLog::Info("Engine plugins have changed, restarting engine process.");
+
+  StoreEnginePluginModificationTimes();
+  ezEditorEngineProcessConnection::GetSingleton()->RestartProcess().IgnoreResult();
 }

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
@@ -3,6 +3,7 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>
+#include <Foundation/Time/Timestamp.h>
 
 /// \brief Holds information about a plugin. Used for editor and engine plugins, where the user can configure whether to load them or not.
 struct EZ_EDITORFRAMEWORK_DLL ezPluginInfo
@@ -11,6 +12,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezPluginInfo
   bool m_bActive = false;     // currently loaded into the process
   bool m_bToBeLoaded = false; // supposed to be loaded into the process next restart
   bool m_bLoadCopy = false;
+  ezTimestamp m_LastModification;
 
   bool operator==(const ezPluginInfo& rhs) const
   {

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -50,6 +50,8 @@ void ezQtEditorApp::SlotTimedUpdate()
 
   Q_EMIT IdleEvent();
 
+  RestartEngineProcessIfPluginsChanged();
+
   m_pTimer->start(1);
 }
 
@@ -72,7 +74,7 @@ void ezQtEditorApp::SlotVersionCheckCompleted(bool bNewVersionReleased, bool bFo
     else
     {
       ezStringBuilder tmp("You have the latest version: \n");
-      tmp.Append(m_VersionChecker.GetOwnVersion()); 
+      tmp.Append(m_VersionChecker.GetOwnVersion());
 
       ezQtUiServices::GetSingleton()->MessageBoxInformation(tmp);
     }
@@ -102,6 +104,10 @@ void ezQtEditorApp::EngineProcessMsgHandler(const ezEditorEngineProcessConnectio
       }
     }
     break;
+
+    case ezEditorEngineProcessConnection::Event::Type::ProcessRestarted:
+      StoreEnginePluginModificationTimes();
+      break;
 
     default:
       return;

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -236,6 +236,9 @@ private:
   void LoadProjectPreferences();
   void DetectAvailableEditorPlugins();
   void DetectAvailableEnginePlugins();
+  void StoreEnginePluginModificationTimes();
+  bool CheckForEnginePluginModifications();
+  void RestartEngineProcessIfPluginsChanged();
   void ReadEditorPluginsToBeLoaded();
   void ReadEnginePluginConfig();
   void SaveAllOpenDocuments();
@@ -278,6 +281,7 @@ private:
 
   ezLogWriter::HTML m_LogHTML;
 
+  ezTime m_LastPluginModificationCheck;
   ezApplicationFileSystemConfig m_FileSystemConfig;
   ezApplicationPluginConfig m_EnginePluginConfig;
 
@@ -306,4 +310,3 @@ private:
 };
 
 EZ_DECLARE_FLAGS_OPERATORS(ezQtEditorApp::StartupFlags);
-

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -47,11 +47,9 @@ ezSceneDocument::ezSceneDocument(const char* szDocumentPath, DocumentType Docume
 void ezSceneDocument::InitializeAfterLoading(bool bFirstTimeCreation)
 {
   // (Local mirror only mirrors settings)
-  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
-    { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
+  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
   // (Remote IPC mirror only sends scene)
-  m_Mirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
-    { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
+  m_Mirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
 
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
   EnsureSettingsObjectExist();
@@ -472,20 +470,19 @@ void ezSceneDocument::ShowOrHideSelectedObjects(ShowOrHide action)
     if (!pItem->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
       continue;
 
-    ApplyRecursive(pItem, [this, bHide](const ezDocumentObject* pObj)
-      {
-        // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
-        // return;
+    ApplyRecursive(pItem, [this, bHide](const ezDocumentObject* pObj) {
+      // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
+      // return;
 
-        auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
-        if (pMeta->m_bHidden != bHide)
-        {
-          pMeta->m_bHidden = bHide;
-          m_DocumentObjectMetaData->EndModifyMetaData(ezDocumentObjectMetaData::HiddenFlag);
-        }
-        else
-          m_DocumentObjectMetaData->EndModifyMetaData(0);
-      });
+      auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
+      if (pMeta->m_bHidden != bHide)
+      {
+        pMeta->m_bHidden = bHide;
+        m_DocumentObjectMetaData->EndModifyMetaData(ezDocumentObjectMetaData::HiddenFlag);
+      }
+      else
+        m_DocumentObjectMetaData->EndModifyMetaData(0);
+    });
   }
 }
 
@@ -549,8 +546,7 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(
 
   const ezTransform tReference = QueryLocalTransform(Selection.PeekBack());
 
-  auto centerNodes = [tReference](ezAbstractObjectNode* pGraphNode)
-  {
+  auto centerNodes = [tReference](ezAbstractObjectNode* pGraphNode) {
     if (auto pPosition = pGraphNode->FindProperty("LocalPosition"))
     {
       ezVec3 pos = pPosition->m_Value.ConvertTo<ezVec3>();
@@ -560,8 +556,7 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(
     }
   };
 
-  auto adjustResult = [tReference, this](ezDocumentObject* pObject)
-  {
+  auto adjustResult = [tReference, this](ezDocumentObject* pObject) {
     const ezTransform tOld = QueryLocalTransform(pObject);
 
     ezSetObjectPropertyCommand cmd;
@@ -681,23 +676,22 @@ void ezSceneDocument::ShowOrHideAllObjects(ShowOrHide action)
 {
   const bool bHide = action == ShowOrHide::Hide;
 
-  ApplyRecursive(GetObjectManager()->GetRootObject(), [this, bHide](const ezDocumentObject* pObj)
+  ApplyRecursive(GetObjectManager()->GetRootObject(), [this, bHide](const ezDocumentObject* pObj) {
+    // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
+    // return;
+
+    ezUInt32 uiFlags = 0;
+
+    auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
+
+    if (pMeta->m_bHidden != bHide)
     {
-      // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
-      // return;
+      pMeta->m_bHidden = bHide;
+      uiFlags = ezDocumentObjectMetaData::HiddenFlag;
+    }
 
-      ezUInt32 uiFlags = 0;
-
-      auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
-
-      if (pMeta->m_bHidden != bHide)
-      {
-        pMeta->m_bHidden = bHide;
-        uiFlags = ezDocumentObjectMetaData::HiddenFlag;
-      }
-
-      m_DocumentObjectMetaData->EndModifyMetaData(uiFlags);
-    });
+    m_DocumentObjectMetaData->EndModifyMetaData(uiFlags);
+  });
 }
 void ezSceneDocument::GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const
 {

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -47,9 +47,11 @@ ezSceneDocument::ezSceneDocument(const char* szDocumentPath, DocumentType Docume
 void ezSceneDocument::InitializeAfterLoading(bool bFirstTimeCreation)
 {
   // (Local mirror only mirrors settings)
-  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
+  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
+    { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
   // (Remote IPC mirror only sends scene)
-  m_Mirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
+  m_Mirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
+    { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
 
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
   EnsureSettingsObjectExist();
@@ -470,19 +472,20 @@ void ezSceneDocument::ShowOrHideSelectedObjects(ShowOrHide action)
     if (!pItem->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
       continue;
 
-    ApplyRecursive(pItem, [this, bHide](const ezDocumentObject* pObj) {
-      // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
-      // return;
-
-      auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
-      if (pMeta->m_bHidden != bHide)
+    ApplyRecursive(pItem, [this, bHide](const ezDocumentObject* pObj)
       {
-        pMeta->m_bHidden = bHide;
-        m_DocumentObjectMetaData->EndModifyMetaData(ezDocumentObjectMetaData::HiddenFlag);
-      }
-      else
-        m_DocumentObjectMetaData->EndModifyMetaData(0);
-    });
+        // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
+        // return;
+
+        auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
+        if (pMeta->m_bHidden != bHide)
+        {
+          pMeta->m_bHidden = bHide;
+          m_DocumentObjectMetaData->EndModifyMetaData(ezDocumentObjectMetaData::HiddenFlag);
+        }
+        else
+          m_DocumentObjectMetaData->EndModifyMetaData(0);
+      });
   }
 }
 
@@ -546,7 +549,8 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(
 
   const ezTransform tReference = QueryLocalTransform(Selection.PeekBack());
 
-  auto centerNodes = [tReference](ezAbstractObjectNode* pGraphNode) {
+  auto centerNodes = [tReference](ezAbstractObjectNode* pGraphNode)
+  {
     if (auto pPosition = pGraphNode->FindProperty("LocalPosition"))
     {
       ezVec3 pos = pPosition->m_Value.ConvertTo<ezVec3>();
@@ -556,7 +560,8 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(
     }
   };
 
-  auto adjustResult = [tReference, this](ezDocumentObject* pObject) {
+  auto adjustResult = [tReference, this](ezDocumentObject* pObject)
+  {
     const ezTransform tOld = QueryLocalTransform(pObject);
 
     ezSetObjectPropertyCommand cmd;
@@ -568,6 +573,11 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(
   };
 
   return SUPER::CreatePrefabDocumentFromSelection(szFile, pRootType, centerNodes, adjustResult);
+}
+
+bool ezSceneDocument::CanEngineProcessBeRestarted() const
+{
+  return m_GameMode == GameMode::Off;
 }
 
 void ezSceneDocument::StartSimulateWorld()
@@ -671,22 +681,23 @@ void ezSceneDocument::ShowOrHideAllObjects(ShowOrHide action)
 {
   const bool bHide = action == ShowOrHide::Hide;
 
-  ApplyRecursive(GetObjectManager()->GetRootObject(), [this, bHide](const ezDocumentObject* pObj) {
-    // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
-    // return;
-
-    ezUInt32 uiFlags = 0;
-
-    auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
-
-    if (pMeta->m_bHidden != bHide)
+  ApplyRecursive(GetObjectManager()->GetRootObject(), [this, bHide](const ezDocumentObject* pObj)
     {
-      pMeta->m_bHidden = bHide;
-      uiFlags = ezDocumentObjectMetaData::HiddenFlag;
-    }
+      // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
+      // return;
 
-    m_DocumentObjectMetaData->EndModifyMetaData(uiFlags);
-  });
+      ezUInt32 uiFlags = 0;
+
+      auto pMeta = m_DocumentObjectMetaData->BeginModifyMetaData(pObj->GetGuid());
+
+      if (pMeta->m_bHidden != bHide)
+      {
+        pMeta->m_bHidden = bHide;
+        uiFlags = ezDocumentObjectMetaData::HiddenFlag;
+      }
+
+      m_DocumentObjectMetaData->EndModifyMetaData(uiFlags);
+    });
 }
 void ezSceneDocument::GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const
 {

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -112,6 +112,8 @@ public:
 
   GameMode::Enum GetGameMode() const { return m_GameMode; }
 
+  virtual bool CanEngineProcessBeRestarted() const override;
+
   void StartSimulateWorld();
   void TriggerGameModePlay(bool bUsePickedPositionAsStart);
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -130,6 +130,13 @@ public:
 
   const ezDocumentInfo* GetDocumentInfo() const { return m_pDocumentInfo; }
 
+  /// \brief Asks the document whether a restart of the engine process is allowed at this time.
+  ///
+  /// Documents that are currently interacting with the engine process (active play-the-game mode) should return false.
+  /// All others should return true.
+  /// As long as any document returns false, automatic engine process reload is suppressed.
+  virtual bool CanEngineProcessBeRestarted() const { return true; }
+
   ///@}
   /// \name Clipboard Functions
   ///@{


### PR DESCRIPTION
If a plugin that is tagged as "LoadCopy" is detected to be modified, the editor will automatically restart the engine process, as long as there is currently no simulation going on.
