### PR TITLE
Single channel (R8) texture conversion fix

### DIFF
--- a/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
@@ -58,7 +58,7 @@ ezResult ezTexConvProcessor::Process()
 
     ezLog::Info("Target resolution is '{} x {}'", uiTargetResolutionX, uiTargetResolutionY);
 
-    EZ_SUCCEED_OR_RETURN(ConvertAndScaleInputImages(uiTargetResolutionX, uiTargetResolutionY));
+    EZ_SUCCEED_OR_RETURN(ConvertAndScaleInputImages(uiTargetResolutionX, uiTargetResolutionY, m_Descriptor.m_Usage));
 
     EZ_SUCCEED_OR_RETURN(ClampInputValues(m_Descriptor.m_InputImages, m_Descriptor.m_fMaxValue));
 

--- a/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
@@ -96,7 +96,7 @@ ezResult ezTexConvProcessor::LoadAtlasInputs(const ezTextureAtlasCreationDesc& a
         ezUInt32 uiResX = 0, uiResY = 0;
         EZ_SUCCEED_OR_RETURN(DetermineTargetResolution(item.m_InputImage[layer], ezImageFormat::UNKNOWN, uiResX, uiResY));
 
-        EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[layer], item.m_InputImage[layer], uiResX, uiResY));
+        EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[layer], item.m_InputImage[layer], uiResX, uiResY, atlasDesc.m_Layers[layer].m_Usage));
       }
     }
 
@@ -114,11 +114,11 @@ ezResult ezTexConvProcessor::LoadAtlasInputs(const ezTextureAtlasCreationDesc& a
       ezUInt32 uiResX = 0, uiResY = 0;
       EZ_SUCCEED_OR_RETURN(DetermineTargetResolution(alphaImg, ezImageFormat::UNKNOWN, uiResX, uiResY));
 
-      EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sAlphaInput, alphaImg, uiResX, uiResY));
+      EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sAlphaInput, alphaImg, uiResX, uiResY, ezTexConvUsage::Linear));
 
 
       // layer 0 must have the exact same size as the alpha texture
-      EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[0], item.m_InputImage[0], uiResX, uiResY));
+      EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[0], item.m_InputImage[0], uiResX, uiResY, ezTexConvUsage::Linear));
 
       // copy alpha channel into layer 0
       EZ_SUCCEED_OR_RETURN(ezImageUtils::CopyChannel(item.m_InputImage[0], 3, alphaImg, 0));
@@ -129,7 +129,7 @@ ezResult ezTexConvProcessor::LoadAtlasInputs(const ezTextureAtlasCreationDesc& a
         if (item.m_InputImage[layer].GetWidth() <= uiResX && item.m_InputImage[layer].GetHeight() <= uiResY)
           continue;
 
-        EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[layer], item.m_InputImage[layer], uiResX, uiResY));
+        EZ_SUCCEED_OR_RETURN(ConvertAndScaleImage(srcItem.m_sLayerInput[layer], item.m_InputImage[layer], uiResX, uiResY, ezTexConvUsage::Linear));
       }
     }
   }

--- a/Code/Engine/Texture/TexConv/TexConvProcessor.h
+++ b/Code/Engine/Texture/TexConv/TexConvProcessor.h
@@ -28,7 +28,7 @@ private:
 
   ezResult LoadInputImages();
   ezResult ForceSRGBFormats();
-  ezResult ConvertAndScaleInputImages(ezUInt32 uiResolutionX, ezUInt32 uiResolutionY);
+  ezResult ConvertAndScaleInputImages(ezUInt32 uiResolutionX, ezUInt32 uiResolutionY, ezEnum<ezTexConvUsage> usage);
   ezResult ConvertToNormalMap(ezImage& bumpMap) const;
   ezResult ConvertToNormalMap(ezArrayPtr<ezImage> bumpMap) const;
   ezResult ClampInputValues(ezArrayPtr<ezImage> images, float maxValue) const;
@@ -59,7 +59,7 @@ private:
   //////////////////////////////////////////////////////////////////////////
   // Purely functional
   static ezResult AdjustUsage(const char* szFilename, const ezImage& srcImg, ezEnum<ezTexConvUsage>& inout_Usage);
-  static ezResult ConvertAndScaleImage(const char* szImageName, ezImage& inout_Image, ezUInt32 uiResolutionX, ezUInt32 uiResolutionY);
+  static ezResult ConvertAndScaleImage(const char* szImageName, ezImage& inout_Image, ezUInt32 uiResolutionX, ezUInt32 uiResolutionY, ezEnum<ezTexConvUsage> usage);
 
   //////////////////////////////////////////////////////////////////////////
   // Output Generation


### PR DESCRIPTION
Textures with a single channel (R8, not RGB or RGBA) that are imported with usage 'Color' need to copy the single channel data over into the other channels, otherwise they appear red instead of greyscale.

Fixes #484 