### PR TITLE
Several procecural generation fixes

### DIFF
--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -61,7 +61,7 @@ void ezProcGenGraphAssetDocument::SetDebugPin(const ezPin* pDebugPin)
   GetObjectManager()->m_PropertyEvents.Broadcast(e);
 }
 
-ezStatus ezProcGenGraphAssetDocument::WriteAsset(ezStreamWriter& stream, const ezPlatformProfile* pAssetProfile) const
+ezStatus ezProcGenGraphAssetDocument::WriteAsset(ezStreamWriter& stream, const ezPlatformProfile* pAssetProfile, bool bAllowDebug) const
 {
   const ezDocumentNodeManager* pManager = static_cast<const ezDocumentNodeManager*>(GetObjectManager());
 
@@ -77,7 +77,7 @@ ezStatus ezProcGenGraphAssetDocument::WriteAsset(ezStreamWriter& stream, const e
   ezDynamicArray<const ezDocumentObject*> vertexColorNodes;
   GetAllOutputNodes(placementNodes, vertexColorNodes);
 
-  const bool bDebug = m_pDebugPin != nullptr;
+  const bool bDebug = bAllowDebug && (m_pDebugPin != nullptr);
 
   ezStringDeduplicationWriteContext stringDedupContext(stream);
 
@@ -238,7 +238,7 @@ ezStatus ezProcGenGraphAssetDocument::InternalTransformAsset(ezStreamWriter& str
 {
   EZ_ASSERT_DEV(ezStringUtils::IsNullOrEmpty(szOutputTag), "Additional output '{0}' not implemented!", szOutputTag);
 
-  return WriteAsset(stream, pAssetProfile);
+  return WriteAsset(stream, pAssetProfile, false);
 }
 
 void ezProcGenGraphAssetDocument::GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
@@ -19,7 +19,7 @@ public:
 
   void SetDebugPin(const ezPin* pDebugPin);
 
-  ezStatus WriteAsset(ezStreamWriter& stream, const ezPlatformProfile* pAssetProfile) const;
+  ezStatus WriteAsset(ezStreamWriter& stream, const ezPlatformProfile* pAssetProfile, bool bAllowDebug) const;
 
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.moc.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.moc.h
@@ -28,6 +28,8 @@ private:
   void UpdatePreview();
   void RestoreResource();
 
+  // needed for setting the debug pin
+  void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);
   void TransationEventHandler(const ezCommandHistoryEvent& e);
 
   ezQtNodeScene* m_pScene;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -8,26 +8,27 @@ namespace
   static ezHashedString s_sPerlinNoise = ezMakeHashedString("PerlinNoise");
   static ezHashedString s_sApplyVolumes = ezMakeHashedString("ApplyVolumes");
 
-  ezExpressionAST::NodeType::Enum GetBlendOperator(ezProcGenBlendMode::Enum blendMode)
+  ezExpressionAST::NodeType::Enum GetOperator(ezProcGenBinaryOperator::Enum blendMode)
   {
     switch (blendMode)
     {
-      case ezProcGenBlendMode::Add:
+      case ezProcGenBinaryOperator::Add:
         return ezExpressionAST::NodeType::Add;
-      case ezProcGenBlendMode::Subtract:
+      case ezProcGenBinaryOperator::Subtract:
         return ezExpressionAST::NodeType::Subtract;
-      case ezProcGenBlendMode::Multiply:
+      case ezProcGenBinaryOperator::Multiply:
         return ezExpressionAST::NodeType::Multiply;
-      case ezProcGenBlendMode::Divide:
+      case ezProcGenBinaryOperator::Divide:
         return ezExpressionAST::NodeType::Divide;
-      case ezProcGenBlendMode::Max:
+      case ezProcGenBinaryOperator::Max:
         return ezExpressionAST::NodeType::Max;
-      case ezProcGenBlendMode::Min:
+      case ezProcGenBinaryOperator::Min:
         return ezExpressionAST::NodeType::Min;
-      default:
-        EZ_ASSERT_NOT_IMPLEMENTED;
-        return ezExpressionAST::NodeType::Invalid;
+
+        EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
     }
+
+    return ezExpressionAST::NodeType::Invalid;
   }
 
   ezExpressionAST::Node* CreateRandom(float fSeed, ezExpressionAST& out_Ast)
@@ -136,9 +137,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_PlacementOutput, 1, ezRTTIDefaultAlloc
     EZ_MEMBER_PROPERTY("MaxScale", m_vMaxScale)->AddAttributes(new ezDefaultValueAttribute(ezVec3(1.0f)), new ezClampValueAttribute(ezVec3(0.0f), ezVariant())),
     EZ_MEMBER_PROPERTY("ColorGradient", m_sColorGradient)->AddAttributes(new ezAssetBrowserAttribute("ColorGradient")),
     EZ_MEMBER_PROPERTY("CullDistance", m_fCullDistance)->AddAttributes(new ezDefaultValueAttribute(30.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_ENUM_MEMBER_PROPERTY("PlacementMode", ezProcPlacementMode, m_PlacementMode),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("Surface")),
-    EZ_ENUM_MEMBER_PROPERTY("Mode", ezProcPlacementMode, m_Mode),
 
     EZ_MEMBER_PROPERTY("Density", m_DensityPin)->AddAttributes(new ezColorAttribute(ezColor::White)),
     EZ_MEMBER_PROPERTY("Scale", m_ScalePin)->AddAttributes(new ezColorAttribute(ezColor::LightCoral)),
@@ -238,7 +239,7 @@ void ezProcGen_PlacementOutput::Save(ezStreamWriter& stream)
   stream << m_sSurface;
 
   // chunk version 5
-  stream << m_Mode;
+  stream << m_PlacementMode;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -396,7 +397,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_Blend, 1, ezRTTIDefaultAllocator<ezPro
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ENUM_MEMBER_PROPERTY("Mode", ezProcGenBlendMode, m_BlendMode),
+    EZ_ENUM_MEMBER_PROPERTY("Operator", ezProcGenBinaryOperator, m_Operator),
     EZ_MEMBER_PROPERTY("InputA", m_fInputValueA)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("InputB", m_fInputValueB)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("ClampOutput", m_bClampOutput),
@@ -408,7 +409,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_Blend, 1, ezRTTIDefaultAllocator<ezPro
   EZ_END_PROPERTIES;
   EZ_BEGIN_ATTRIBUTES
   {
-    new ezTitleAttribute("{Mode}({A}, {B})"),
+    new ezTitleAttribute("{Operator}({A}, {B})"),
     new ezCategoryAttribute("Math"),
   }
   EZ_END_ATTRIBUTES;
@@ -432,7 +433,7 @@ ezExpressionAST::Node* ezProcGen_Blend::GenerateExpressionASTNode(ezTempHashedSt
     pInputB = out_Ast.CreateConstant(m_fInputValueB);
   }
 
-  auto pBlend = out_Ast.CreateBinaryOperator(GetBlendOperator(m_BlendMode), pInputA, pInputB);
+  auto pBlend = out_Ast.CreateBinaryOperator(GetOperator(m_Operator), pInputA, pInputB);
 
   if (m_bClampOutput)
   {

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -393,7 +393,7 @@ ezExpressionAST::Node* ezProcGen_PerlinNoise::GenerateExpressionASTNode(ezTempHa
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_Blend, 1, ezRTTIDefaultAllocator<ezProcGen_Blend>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_Blend, 2, ezRTTIDefaultAllocator<ezProcGen_Blend>)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -621,3 +621,28 @@ ezExpressionAST::Node* ezProcGen_ApplyVolumes::GenerateExpressionASTNode(ezTempH
 
   return pFunctionCall;
 }
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+#include <Foundation/Serialization/AbstractObjectGraph.h>
+#include <Foundation/Serialization/GraphPatch.h>
+
+class ezProcGen_Blend_1_2 : public ezGraphPatch
+{
+public:
+  ezProcGen_Blend_1_2()
+    : ezGraphPatch("ezProcGen_Blend", 2)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    // even though not only the name changed, but also the underlying enum type
+    // this seems to be enough, since the enum values are the same
+    pNode->RenameProperty("Mode", "Operator");
+  }
+};
+
+ezProcGen_Blend_1_2 g_ezProcGen_Blend_1_2;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
@@ -67,7 +67,7 @@ public:
 
   ezString m_sColorGradient;
 
-  ezEnum<ezProcPlacementMode> m_Mode;
+  ezEnum<ezProcPlacementMode> m_PlacementMode;
 
   ezRenderPipelineNodeInputPin m_DensityPin;
   ezRenderPipelineNodeInputPin m_ScalePin;
@@ -142,7 +142,7 @@ class ezProcGen_Blend : public ezProcGenNodeBase
 public:
   virtual ezExpressionAST::Node* GenerateExpressionASTNode(ezTempHashedString sOutputName, ezArrayPtr<ezExpressionAST::Node*> inputs, ezExpressionAST& out_Ast, GenerateASTContext& context) override;
 
-  ezEnum<ezProcGenBlendMode> m_BlendMode;
+  ezEnum<ezProcGenBinaryOperator> m_Operator;
   float m_fInputValueA = 1.0f;
   float m_fInputValueB = 1.0f;
   bool m_bClampOutput = false;

--- a/Code/EnginePlugins/ProcGenPlugin/Declarations.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Declarations.cpp
@@ -4,6 +4,11 @@
 #include <ProcGenPlugin/VM/ExpressionByteCode.h>
 
 // clang-format off
+EZ_BEGIN_STATIC_REFLECTED_ENUM(ezProcGenBinaryOperator, 1)
+  EZ_ENUM_CONSTANTS(ezProcGenBinaryOperator::Add, ezProcGenBinaryOperator::Subtract, ezProcGenBinaryOperator::Multiply, ezProcGenBinaryOperator::Divide)
+  EZ_ENUM_CONSTANTS(ezProcGenBinaryOperator::Max, ezProcGenBinaryOperator::Min)
+EZ_END_STATIC_REFLECTED_ENUM;
+
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezProcGenBlendMode, 1)
   EZ_ENUM_CONSTANTS(ezProcGenBlendMode::Add, ezProcGenBlendMode::Subtract, ezProcGenBlendMode::Multiply, ezProcGenBlendMode::Divide)
   EZ_ENUM_CONSTANTS(ezProcGenBlendMode::Max, ezProcGenBlendMode::Min)

--- a/Code/EnginePlugins/ProcGenPlugin/Declarations.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Declarations.h
@@ -12,6 +12,25 @@ using ezColorGradientResourceHandle = ezTypedResourceHandle<class ezColorGradien
 using ezPrefabResourceHandle = ezTypedResourceHandle<class ezPrefabResource>;
 using ezSurfaceResourceHandle = ezTypedResourceHandle<class ezSurfaceResource>;
 
+struct ezProcGenBinaryOperator
+{
+  typedef ezUInt8 StorageType;
+
+  enum Enum
+  {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Max,
+    Min,
+
+    Default = Multiply
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_PROCGENPLUGIN_DLL, ezProcGenBinaryOperator);
+
 struct ezProcGenBlendMode
 {
   typedef ezUInt8 StorageType;

--- a/Data/Tools/ezEditor/Localization/en/ProcGenPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ProcGenPlugin.txt
@@ -2,13 +2,13 @@ ProcGen.DumpAST;Dump AST
 ProcGen.DumpDisassembly;Dump Disassembly
 Objects;Objects
 ProcGen;Procedural Generation
-ezProcPlacementComponent;Procedural Placement
+ezProcPlacementComponent;Procedural Placement;;http://ezengine.net/pages/docs/terrain/procedural/procgen-placement-component.html
 ezProcGenBoxExtents;Box Extents
 BoxExtents;Extents
-ezProcVertexColorComponent;Procedural Vertex Color
-ezProcVolumeSphereComponent;Procedural Volume Sphere
-ezProcVolumeBoxComponent;Procedural Volume Box
-ezProcVolumeImageComponent;Procedural Volume Image
+ezProcVertexColorComponent;Procedural Vertex Color;;http://ezengine.net/pages/docs/terrain/procedural/procgen-vertex-color-component.html
+ezProcVolumeSphereComponent;Procedural Volume Sphere;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-sphere-component.html
+ezProcVolumeBoxComponent;Procedural Volume Box;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-box-component.html
+ezProcVolumeImageComponent;Procedural Volume Image;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-image-component.html
 ezProcGenBlendMode::Add;Add
 ezProcGenBlendMode::Subtract;Subtract
 ezProcGenBlendMode::Multiply;Multiply
@@ -33,3 +33,19 @@ ezProcVolumeImageMode::ChannelG;Green Channel
 ezProcVolumeImageMode::ChannelB;Blue Channel
 ezProcVolumeImageMode::ChannelA;Alpha Channel
 ezProcVolumeImageMode::ReferenceColor;Reference Color
+ezProcGenBinaryOperator::Add;Add
+ezProcGenBinaryOperator::Subtract;Subtract
+ezProcGenBinaryOperator::Multiply;Multiply
+ezProcGenBinaryOperator::Divide;Divide
+ezProcGenBinaryOperator::Max;Max
+ezProcGenBinaryOperator::Min;Min
+PlacementOutput;Placement Output
+VertexColorOutput;Vertex Color Output
+Random;Random
+PerlinNoise;Perlin Noise
+Blend;Blend
+Height;Height
+Slope;Slope
+MeshVertexColor;Mesh Vertex Color
+ApplyVolumes;Apply Volumes
+Operator;Operator


### PR DESCRIPTION
* The 'Debug Pin' state is never saved on disk
* Changing the 'Debug Pin' state updates the preview immediately (again)
* Undo/redo trigger a preview update correctly (again)
* The math blend node doesn't expose the 'set' operator anymore (breaking change)
* Links to component documentation pages