### PR TITLE
Added a component to render custom geometry

### DIFF
--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -95,7 +95,7 @@ protected:
 
   ezDynamicMeshBufferResourceHandle m_hDynamicMesh;
 
-  //virtual void OnActivated() override;
+  virtual void OnActivated() override;
 };
 
 /// \brief Temporary data used to feed the ezCustomMeshRenderer.

--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -39,7 +39,7 @@ public:
   /// \brief Creates a new dynamic mesh buffer.
   ///
   /// The new buffer can hold the given number of vertices and indices (either 16 bit or 32 bit).
-  ezDynamicMeshBufferResourceHandle CreateMeshResource(ezUInt32 uiNumVertices, ezUInt32 uiNumPrimitives, ezUInt32 uiNumIndices, bool b32BitIndices = true);
+  ezDynamicMeshBufferResourceHandle CreateMeshResource(ezGALPrimitiveTopology::Enum topology, ezUInt32 uiMaxVertices, ezUInt32 uiMaxPrimitives, ezGALIndexType::Enum indexType);
 
   /// \brief Returns the currently set mesh resource.
   ezDynamicMeshBufferResourceHandle GetMeshResource() const { return m_hDynamicMesh; }

--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <RendererCore/Meshes/MeshComponentBase.h>
+#include <RendererCore/Pipeline/Renderer.h>
+
+using ezDynamicMeshBufferResourceHandle = ezTypedResourceHandle<class ezDynamicMeshBufferResource>;
+using ezCustomMeshComponentManager = ezComponentManager<class ezCustomMeshComponent, ezBlockStorageType::Compact>;
+
+/// \brief This component is used to render custom geometry.
+///
+/// Sometimes game code needs to build geometry on the fly to visualize dynamic things.
+/// The ezDynamicMeshBufferResource is an easy to use resource to build geometry and change it frequently.
+/// This component takes such a resource and takes care of rendering it.
+/// The same resource can be set on multiple components to instantiate it in different locations.
+class EZ_RENDERERCORE_DLL ezCustomMeshComponent : public ezRenderComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezCustomMeshComponent, ezRenderComponent, ezCustomMeshComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& stream) override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezRenderComponent
+
+public:
+  virtual ezResult GetLocalBounds(ezBoundingBoxSphere& bounds, bool& bAlwaysVisible) override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezCustomMeshComponent
+
+public:
+  ezCustomMeshComponent();
+  ~ezCustomMeshComponent();
+
+  /// \brief Creates a new dynamic mesh buffer.
+  ///
+  /// The new buffer can hold the given number of vertices and indices (either 16 bit or 32 bit).
+  ezDynamicMeshBufferResourceHandle CreateMeshResource(ezUInt32 uiNumVertices, ezUInt32 uiNumPrimitives, ezUInt32 uiNumIndices, bool b32BitIndices = true);
+
+  /// \brief Returns the currently set mesh resource.
+  ezDynamicMeshBufferResourceHandle GetMeshResource() const { return m_hDynamicMesh; }
+
+  /// \brief Sets which mesh buffer to use.
+  ///
+  /// This can be used to have multiple ezCustomMeshComponent's reference the same mesh buffer,
+  /// such that the object gets instanced in different locations.
+  void SetMeshResource(const ezDynamicMeshBufferResourceHandle& hMesh);
+
+  /// \brief Configures the component to render only a subset of the primitives in the mesh buffer.
+  void SetUsePrimitiveRange(ezUInt32 uiFirstPrimitive = 0, ezUInt32 uiNumPrimitives = ezMath::MaxValue<ezUInt32>());
+
+  /// \brief Sets the bounds that are used for culling.
+  ///
+  /// Note: It is very important that this is called whenever the mesh buffer is modified and the size of
+  /// the mesh has changed, otherwise the object might not appear or be culled incorrectly.
+  void SetBounds(const ezBoundingBoxSphere& bounds);
+
+  /// \brief Sets the material for rendering.
+  void SetMaterial(const ezMaterialResourceHandle& hMaterial);
+
+  /// \brief Returns the material that is used for rendering.
+  ezMaterialResourceHandle GetMaterial() const;
+
+  void SetMaterialFile(const char* szMaterial); // [ property ]
+  const char* GetMaterialFile() const;          // [ property ]
+
+  /// \brief Sets a specific render data category used for rendering.
+  ///
+  /// Typically it is not necessary to change this, but it can be used to render the object in a
+  /// certain render pass.
+  EZ_ALWAYS_INLINE void SetRenderDataCategory(ezRenderData::Category category) { m_RenderDataCategory = category; }
+
+  /// \brief Sets the mesh instance color.
+  void SetColor(const ezColor& color); // [ property ]
+
+  /// \brief Returns the mesh instance color.
+  const ezColor& GetColor() const; // [ property ]
+
+  void OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& msg); // [ msg handler ]
+  void OnMsgSetColor(ezMsgSetColor& msg);               // [ msg handler ]
+
+protected:
+  void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
+
+  ezRenderData::Category m_RenderDataCategory = ezInvalidRenderDataCategory;
+  ezMaterialResourceHandle m_hMaterial;
+  ezColor m_Color = ezColor::White;
+  ezUInt32 m_uiFirstPrimitive = 0;
+  ezUInt32 m_uiNumPrimitives = 0xFFFFFFFF;
+  ezBoundingBoxSphere m_Bounds;
+
+  ezDynamicMeshBufferResourceHandle m_hDynamicMesh;
+
+  //virtual void OnActivated() override;
+};
+
+/// \brief Temporary data used to feed the ezCustomMeshRenderer.
+class EZ_RENDERERCORE_DLL ezCustomMeshRenderData : public ezRenderData
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezCustomMeshRenderData, ezRenderData);
+
+public:
+  virtual void FillBatchIdAndSortingKey();
+
+  ezDynamicMeshBufferResourceHandle m_hMesh;
+  ezMaterialResourceHandle m_hMaterial;
+  ezColor m_Color = ezColor::White;
+
+  ezUInt32 m_uiFlipWinding : 1;
+  ezUInt32 m_uiUniformScale : 1;
+
+  ezUInt32 m_uiFirstPrimitive = 0;
+  ezUInt32 m_uiNumPrimitives = 0xFFFFFFFF;
+
+  ezUInt32 m_uiUniqueID = 0;
+};
+
+/// \brief A renderer that handles all ezCustomMeshRenderData.
+class EZ_RENDERERCORE_DLL ezCustomMeshRenderer : public ezRenderer
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezCustomMeshRenderer, ezRenderer);
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezCustomMeshRenderer);
+
+public:
+  ezCustomMeshRenderer();
+  ~ezCustomMeshRenderer();
+
+  virtual void GetSupportedRenderDataCategories(ezHybridArray<ezRenderData::Category, 8>& categories) const override;
+  virtual void GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& types) const override;
+  virtual void RenderBatch(const ezRenderViewContext& renderContext, const ezRenderPipelinePass* pPass, const ezRenderDataBatch& batch) const override;
+};

--- a/Code/Engine/RendererCore/Meshes/DynamicMeshBufferResource.h
+++ b/Code/Engine/RendererCore/Meshes/DynamicMeshBufferResource.h
@@ -13,6 +13,7 @@ struct ezDynamicMeshBufferResourceDescriptor
   ezGALIndexType::Enum m_IndexType = ezGALIndexType::UInt;
   ezUInt32 m_uiMaxPrimitives = 0;
   ezUInt32 m_uiMaxVertices = 0;
+  bool m_bColorStream = false;
 };
 
 struct EZ_RENDERERCORE_DLL ezDynamicMeshVertex
@@ -60,6 +61,7 @@ public:
   EZ_ALWAYS_INLINE const ezDynamicMeshBufferResourceDescriptor& GetDescriptor() const { return m_Descriptor; }
   EZ_ALWAYS_INLINE ezGALBufferHandle GetVertexBuffer() const { return m_hVertexBuffer; }
   EZ_ALWAYS_INLINE ezGALBufferHandle GetIndexBuffer() const { return m_hIndexBuffer; }
+  EZ_ALWAYS_INLINE ezGALBufferHandle GetColorBuffer() const { return m_hColorBuffer; }
 
   /// \brief Grants write access to the vertex data, and flags the data as 'dirty'.
   ezArrayPtr<ezDynamicMeshVertex> AccessVertexData()
@@ -86,6 +88,15 @@ public:
     return m_Index32Data;
   }
 
+  /// \brief Grants write access to the color data, and flags the data as 'dirty'.
+  ///
+  /// Accessing this data is only valid, if creation of the color buffer was enabled.
+  ezArrayPtr<ezColorLinearUB> AccessColorData()
+  {
+    m_bAccessedCB = true;
+    return m_ColorData;
+  }
+
   const ezVertexDeclarationInfo& GetVertexDeclaration() const { return m_VertexDeclaration; }
 
   /// \brief Uploads the current vertex and index data to the GPU.
@@ -107,13 +118,16 @@ private:
 
   bool m_bAccessedVB = false;
   bool m_bAccessedIB = false;
+  bool m_bAccessedCB = false;
 
   ezGALBufferHandle m_hVertexBuffer;
   ezGALBufferHandle m_hIndexBuffer;
+  ezGALBufferHandle m_hColorBuffer;
   ezDynamicMeshBufferResourceDescriptor m_Descriptor;
 
   ezVertexDeclarationInfo m_VertexDeclaration;
   ezDynamicArray<ezDynamicMeshVertex, ezAlignedAllocatorWrapper> m_VertexData;
   ezDynamicArray<ezUInt16, ezAlignedAllocatorWrapper> m_Index16Data;
   ezDynamicArray<ezUInt32, ezAlignedAllocatorWrapper> m_Index32Data;
+  ezDynamicArray<ezColorLinearUB, ezAlignedAllocatorWrapper> m_ColorData;
 };

--- a/Code/Engine/RendererCore/Meshes/DynamicMeshBufferResource.h
+++ b/Code/Engine/RendererCore/Meshes/DynamicMeshBufferResource.h
@@ -62,9 +62,23 @@ public:
   EZ_ALWAYS_INLINE ezGALBufferHandle GetVertexBuffer() const { return m_hVertexBuffer; }
   EZ_ALWAYS_INLINE ezGALBufferHandle GetIndexBuffer() const { return m_hIndexBuffer; }
 
-  ezArrayPtr<ezDynamicMeshVertex> AccessVertexData() { return m_VertexData; }
-  ezArrayPtr<ezUInt16> AccessIndex16Data() { return m_Index16Data; }
-  ezArrayPtr<ezUInt32> AccessIndex32Data() { return m_Index32Data; }
+  ezArrayPtr<ezDynamicMeshVertex> AccessVertexData()
+  {
+    m_bAccessedVB = true;
+    return m_VertexData;
+  }
+
+  ezArrayPtr<ezUInt16> AccessIndex16Data()
+  {
+    m_bAccessedIB = true;
+    return m_Index16Data;
+  }
+
+  ezArrayPtr<ezUInt32> AccessIndex32Data()
+  {
+    m_bAccessedIB = true;
+    return m_Index32Data;
+  }
 
   void SetTopology(ezGALPrimitiveTopology::Enum topology) { m_Descriptor.m_Topology = topology; }
   ezGALPrimitiveTopology::Enum GetTopology() const { return m_Descriptor.m_Topology; }
@@ -80,6 +94,9 @@ private:
   virtual ezResourceLoadDesc UnloadData(Unload WhatToUnload) override;
   virtual ezResourceLoadDesc UpdateContent(ezStreamReader* Stream) override;
   virtual void UpdateMemoryUsage(MemoryUsage& out_NewMemoryUsage) override;
+
+  bool m_bAccessedVB = false;
+  bool m_bAccessedIB = false;
 
   ezGALBufferHandle m_hVertexBuffer;
   ezGALBufferHandle m_hIndexBuffer;

--- a/Code/Engine/RendererCore/Meshes/DynamicMeshBufferResource.h
+++ b/Code/Engine/RendererCore/Meshes/DynamicMeshBufferResource.h
@@ -10,10 +10,9 @@ using ezDynamicMeshBufferResourceHandle = ezTypedResourceHandle<class ezDynamicM
 struct ezDynamicMeshBufferResourceDescriptor
 {
   ezGALPrimitiveTopology::Enum m_Topology = ezGALPrimitiveTopology::Triangles;
-  ezUInt32 m_uiNumPrimitives = 0;
-  ezUInt32 m_uiNumVertices = 0;
-  ezUInt32 m_uiNumIndices16 = 0;
-  ezUInt32 m_uiNumIndices32 = 0;
+  ezGALIndexType::Enum m_IndexType = ezGALIndexType::UInt;
+  ezUInt32 m_uiMaxPrimitives = 0;
+  ezUInt32 m_uiMaxVertices = 0;
 };
 
 struct EZ_RENDERERCORE_DLL ezDynamicMeshVertex
@@ -62,33 +61,44 @@ public:
   EZ_ALWAYS_INLINE ezGALBufferHandle GetVertexBuffer() const { return m_hVertexBuffer; }
   EZ_ALWAYS_INLINE ezGALBufferHandle GetIndexBuffer() const { return m_hIndexBuffer; }
 
+  /// \brief Grants write access to the vertex data, and flags the data as 'dirty'.
   ezArrayPtr<ezDynamicMeshVertex> AccessVertexData()
   {
     m_bAccessedVB = true;
     return m_VertexData;
   }
 
+  /// \brief Grants write access to the 16 bit index data, and flags the data as 'dirty'.
+  ///
+  /// Accessing this data is only valid, if the buffer was created with 16 bit indices.
   ezArrayPtr<ezUInt16> AccessIndex16Data()
   {
     m_bAccessedIB = true;
     return m_Index16Data;
   }
 
+  /// \brief Grants write access to the 32 bit index data, and flags the data as 'dirty'.
+  ///
+  /// Accessing this data is only valid, if the buffer was created with 32 bit indices.
   ezArrayPtr<ezUInt32> AccessIndex32Data()
   {
     m_bAccessedIB = true;
     return m_Index32Data;
   }
 
-  void SetTopology(ezGALPrimitiveTopology::Enum topology) { m_Descriptor.m_Topology = topology; }
-  ezGALPrimitiveTopology::Enum GetTopology() const { return m_Descriptor.m_Topology; }
-
-  void SetPrimitiveCount(ezUInt32 numPrimitives) { m_Descriptor.m_uiNumPrimitives = numPrimitives; }
-  ezUInt32 GetPrimitiveCount() const { return m_Descriptor.m_uiNumPrimitives; }
-
   const ezVertexDeclarationInfo& GetVertexDeclaration() const { return m_VertexDeclaration; }
 
-  void UpdateGpuBuffer(ezGALCommandEncoder* pGALCommandEncoder, ezUInt32 uiFirstVertex, ezUInt32 uiNumVertices, ezUInt32 uiFirstIndex, ezUInt32 uiNumIndices, ezGALUpdateMode::Enum mode = ezGALUpdateMode::Discard);
+  /// \brief Uploads the current vertex and index data to the GPU.
+  ///
+  /// If all values are set to default, the entire data is uploaded.
+  /// If \a uiNumVertices or \a uiNumIndices is set to the max value, all vertices or indices (after their start offset) are uploaded.
+  ///
+  /// In all other cases, the number of elements to upload must be within valid bounds.
+  ///
+  /// This function can be used to only upload a subset of the modified data.
+  ///
+  /// Note that this function doesn't do anything, if the vertex or index data wasn't recently accessed through AccessVertexData(), AccessIndex16Data() or AccessIndex32Data(). So if you want to upload multiple pieces of the data to the GPU, you have to call these functions in between to flag the uploaded data as out-of-date.
+  void UpdateGpuBuffer(ezGALCommandEncoder* pGALCommandEncoder, ezUInt32 uiFirstVertex = 0, ezUInt32 uiNumVertices = ezMath::MaxValue<ezUInt32>(), ezUInt32 uiFirstIndex = 0, ezUInt32 uiNumIndices = ezMath::MaxValue<ezUInt32>(), ezGALUpdateMode::Enum mode = ezGALUpdateMode::Discard);
 
 private:
   virtual ezResourceLoadDesc UnloadData(Unload WhatToUnload) override;

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -93,6 +93,7 @@ ezDynamicMeshBufferResourceHandle ezCustomMeshComponent::CreateMeshResource(ezGA
   desc.m_uiMaxVertices = uiMaxVertices;
   desc.m_uiMaxPrimitives = uiMaxPrimitives;
   desc.m_IndexType = indexType;
+  desc.m_bColorStream = true;
 
   ezStringBuilder sGuid;
   sGuid.Format("CustomMesh_{}", s_iCustomMeshResources.Increment());
@@ -227,38 +228,44 @@ void ezCustomMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   msg.AddRenderData(pRenderData, category, bDontCacheYet ? ezRenderData::Caching::Never : ezRenderData::Caching::IfStatic);
 }
 
-//void ezCustomMeshComponent::OnActivated()
-//{
-//  ezGeometry geo;
-//  geo.AddTorus(1.0f, 1.5f, 32, 16, ezColor::White);
-//  geo.TriangulatePolygons();
-//  geo.ComputeTangents();
-//
-//  auto hMesh = CreateMeshResource(ezGALPrimitiveTopology::Triangles, geo.GetVertices().GetCount(), geo.GetPolygons().GetCount(), ezGALIndexType::UInt);
-//
-//  ezResourceLock<ezDynamicMeshBufferResource> pMesh(hMesh, ezResourceAcquireMode::BlockTillLoaded);
-//
-//  auto verts = pMesh->AccessVertexData();
-//
-//  for (ezUInt32 v = 0; v < verts.GetCount(); ++v)
-//  {
-//    verts[v].m_vPosition = geo.GetVertices()[v].m_vPosition;
-//    verts[v].m_vTexCoord.SetZero();
-//    verts[v].EncodeNormal(geo.GetVertices()[v].m_vNormal);
-//    verts[v].EncodeTangent(geo.GetVertices()[v].m_vTangent, 1.0f);
-//  }
-//
-//  auto ind = pMesh->AccessIndex32Data();
-//
-//  for (ezUInt32 i = 0; i < geo.GetPolygons().GetCount(); ++i)
-//  {
-//    ind[i * 3 + 0] = geo.GetPolygons()[i].m_Vertices[0];
-//    ind[i * 3 + 1] = geo.GetPolygons()[i].m_Vertices[1];
-//    ind[i * 3 + 2] = geo.GetPolygons()[i].m_Vertices[2];
-//  }
-//
-//  SetBounds(ezBoundingSphere(ezVec3::ZeroVector(), 1.5f));
-//}
+void ezCustomMeshComponent::OnActivated()
+{
+  if (false)
+  {
+    ezGeometry geo;
+    geo.AddTorus(1.0f, 1.5f, 32, 16, ezColor::White);
+    geo.TriangulatePolygons();
+    geo.ComputeTangents();
+
+    auto hMesh = CreateMeshResource(ezGALPrimitiveTopology::Triangles, geo.GetVertices().GetCount(), geo.GetPolygons().GetCount(), ezGALIndexType::UInt);
+
+    ezResourceLock<ezDynamicMeshBufferResource> pMesh(hMesh, ezResourceAcquireMode::BlockTillLoaded);
+
+    auto verts = pMesh->AccessVertexData();
+    auto cols = pMesh->AccessColorData();
+
+    for (ezUInt32 v = 0; v < verts.GetCount(); ++v)
+    {
+      verts[v].m_vPosition = geo.GetVertices()[v].m_vPosition;
+      verts[v].m_vTexCoord.SetZero();
+      verts[v].EncodeNormal(geo.GetVertices()[v].m_vNormal);
+      verts[v].EncodeTangent(geo.GetVertices()[v].m_vTangent, 1.0f);
+
+      cols[v] = ezColor::CornflowerBlue;
+    }
+
+    auto ind = pMesh->AccessIndex32Data();
+
+    for (ezUInt32 i = 0; i < geo.GetPolygons().GetCount(); ++i)
+    {
+      ind[i * 3 + 0] = geo.GetPolygons()[i].m_Vertices[0];
+      ind[i * 3 + 1] = geo.GetPolygons()[i].m_Vertices[1];
+      ind[i * 3 + 2] = geo.GetPolygons()[i].m_Vertices[2];
+    }
+
+    SetBounds(ezBoundingSphere(ezVec3::ZeroVector(), 1.5f));
+  }
+}
 
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -1,0 +1,379 @@
+#include <RendererCore/RendererCorePCH.h>
+
+#include <../../Data/Base/Shaders/Common/ObjectConstants.h>
+#include <Core/Graphics/Geometry.h>
+#include <Core/Messages/SetColorMessage.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <Foundation/Utilities/GraphicsUtils.h>
+#include <RendererCore/Meshes/CustomMeshComponent.h>
+#include <RendererCore/Meshes/DynamicMeshBufferResource.h>
+#include <RendererCore/Pipeline/InstanceDataProvider.h>
+#include <RendererCore/Pipeline/RenderDataBatch.h>
+#include <RendererCore/Pipeline/RenderPipeline.h>
+#include <RendererCore/Pipeline/RenderPipelinePass.h>
+#include <RendererCore/RenderContext/RenderContext.h>
+#include <RendererFoundation/Device/Device.h>
+
+// clang-format off
+EZ_BEGIN_COMPONENT_TYPE(ezCustomMeshComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("Rendering"),
+  }
+  EZ_END_ATTRIBUTES;
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
+    EZ_ACCESSOR_PROPERTY("Material", GetMaterialFile, SetMaterialFile)->AddAttributes(new ezAssetBrowserAttribute("Material")),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+    EZ_MESSAGE_HANDLER(ezMsgSetMeshMaterial, OnMsgSetMeshMaterial),
+    EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+  } EZ_END_MESSAGEHANDLERS;
+}
+EZ_END_COMPONENT_TYPE
+// clang-format on
+
+ezAtomicInteger32 s_iCustomMeshResources;
+
+ezCustomMeshComponent::ezCustomMeshComponent()
+{
+  m_Bounds.SetInvalid();
+}
+
+ezCustomMeshComponent::~ezCustomMeshComponent() = default;
+
+void ezCustomMeshComponent::SerializeComponent(ezWorldWriter& stream) const
+{
+  SUPER::SerializeComponent(stream);
+  ezStreamWriter& s = stream.GetStream();
+
+  s << m_Color;
+  s << m_hMaterial;
+
+  ezUInt32 uiCategory = m_RenderDataCategory.m_uiValue;
+  s << uiCategory;
+}
+
+void ezCustomMeshComponent::DeserializeComponent(ezWorldReader& stream)
+{
+  SUPER::DeserializeComponent(stream);
+  const ezUInt32 uiVersion = stream.GetComponentTypeVersion(GetStaticRTTI());
+
+  ezStreamReader& s = stream.GetStream();
+
+  s >> m_Color;
+  s >> m_hMaterial;
+
+  ezUInt32 uiCategory = 0;
+  s >> uiCategory;
+  m_RenderDataCategory.m_uiValue = uiCategory;
+}
+
+ezResult ezCustomMeshComponent::GetLocalBounds(ezBoundingBoxSphere& bounds, bool& bAlwaysVisible)
+{
+  if (m_Bounds.IsValid())
+  {
+    bounds = m_Bounds;
+    return EZ_SUCCESS;
+  }
+
+  return EZ_FAILURE;
+}
+
+ezDynamicMeshBufferResourceHandle ezCustomMeshComponent::CreateMeshResource(ezUInt32 uiNumVertices, ezUInt32 uiNumPrimitives, ezUInt32 uiNumIndices, bool b32BitIndices /*= true*/)
+{
+  ezDynamicMeshBufferResourceDescriptor desc;
+  desc.m_Topology = ezGALPrimitiveTopology::Triangles;
+  desc.m_uiNumVertices = uiNumVertices;
+  desc.m_uiNumPrimitives = uiNumPrimitives;
+  desc.m_uiNumIndices16 = b32BitIndices ? 0 : uiNumIndices;
+  desc.m_uiNumIndices32 = b32BitIndices ? uiNumIndices : 0;
+
+  ezStringBuilder sGuid;
+  sGuid.Format("CustomMesh_{}", s_iCustomMeshResources.Increment());
+
+  m_hDynamicMesh = ezResourceManager::CreateResource<ezDynamicMeshBufferResource>(sGuid, std::move(desc));
+
+  InvalidateCachedRenderData();
+
+  return m_hDynamicMesh;
+}
+
+void ezCustomMeshComponent::SetMeshResource(const ezDynamicMeshBufferResourceHandle& hMesh)
+{
+  m_hDynamicMesh = hMesh;
+  InvalidateCachedRenderData();
+}
+
+void ezCustomMeshComponent::SetBounds(const ezBoundingBoxSphere& bounds)
+{
+  m_Bounds = bounds;
+  TriggerLocalBoundsUpdate();
+}
+
+void ezCustomMeshComponent::SetMaterial(const ezMaterialResourceHandle& hMaterial)
+{
+  m_hMaterial = hMaterial;
+  InvalidateCachedRenderData();
+}
+
+ezMaterialResourceHandle ezCustomMeshComponent::GetMaterial() const
+{
+  return m_hMaterial;
+}
+
+void ezCustomMeshComponent::SetMaterialFile(const char* szMaterial)
+{
+  ezMaterialResourceHandle hResource;
+
+  if (!ezStringUtils::IsNullOrEmpty(szMaterial))
+  {
+    hResource = ezResourceManager::LoadResource<ezMaterialResource>(szMaterial);
+  }
+
+  m_hMaterial = hResource;
+}
+
+const char* ezCustomMeshComponent::GetMaterialFile() const
+{
+  if (!m_hMaterial.IsValid())
+    return "";
+
+  return m_hMaterial.GetResourceID();
+}
+
+void ezCustomMeshComponent::SetColor(const ezColor& color)
+{
+  m_Color = color;
+
+  InvalidateCachedRenderData();
+}
+
+const ezColor& ezCustomMeshComponent::GetColor() const
+{
+  return m_Color;
+}
+
+void ezCustomMeshComponent::OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& msg)
+{
+  SetMaterial(msg.m_hMaterial);
+}
+
+void ezCustomMeshComponent::OnMsgSetColor(ezMsgSetColor& msg)
+{
+  msg.ModifyColor(m_Color);
+
+  InvalidateCachedRenderData();
+}
+
+void ezCustomMeshComponent::SetUsePrimitiveRange(ezUInt32 uiFirstPrimitive /*= 0*/, ezUInt32 uiNumPrimitives /*= ezMath::MaxValue<ezUInt32>()*/)
+{
+  m_uiFirstPrimitive = uiFirstPrimitive;
+  m_uiNumPrimitives = uiNumPrimitives;
+}
+
+void ezCustomMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
+{
+  if (!m_hDynamicMesh.IsValid() || !m_hMaterial.IsValid())
+    return;
+
+  ezResourceLock<ezDynamicMeshBufferResource> pMesh(m_hDynamicMesh, ezResourceAcquireMode::BlockTillLoaded);
+
+  ezCustomMeshRenderData* pRenderData = ezCreateRenderDataForThisFrame<ezCustomMeshRenderData>(GetOwner());
+  {
+    pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform() * pRenderData->m_GlobalTransform;
+    pRenderData->m_GlobalBounds = GetOwner()->GetGlobalBounds();
+    pRenderData->m_hMesh = m_hDynamicMesh;
+    pRenderData->m_hMaterial = m_hMaterial;
+    pRenderData->m_Color = m_Color;
+    pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
+    pRenderData->m_uiFirstPrimitive = ezMath::Min(m_uiFirstPrimitive, pMesh->GetPrimitiveCount());
+    pRenderData->m_uiNumPrimitives = ezMath::Min(m_uiNumPrimitives, pMesh->GetPrimitiveCount() - pRenderData->m_uiFirstPrimitive);
+
+    pRenderData->FillBatchIdAndSortingKey();
+  }
+
+  bool bDontCacheYet = false;
+
+  // Determine render data category.
+  ezRenderData::Category category = m_RenderDataCategory;
+  if (category == ezInvalidRenderDataCategory)
+  {
+    ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+
+    if (pMaterial.GetAcquireResult() == ezResourceAcquireResult::LoadingFallback)
+      bDontCacheYet = true;
+
+    ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
+    if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
+    {
+      category = ezDefaultRenderDataCategories::LitOpaque;
+    }
+    else if (blendModeValue == "BLEND_MODE_MASKED")
+    {
+      category = ezDefaultRenderDataCategories::LitMasked;
+    }
+    else
+    {
+      category = ezDefaultRenderDataCategories::LitTransparent;
+    }
+  }
+
+  msg.AddRenderData(pRenderData, category, bDontCacheYet ? ezRenderData::Caching::Never : ezRenderData::Caching::IfStatic);
+}
+//
+//void ezCustomMeshComponent::OnActivated()
+//{
+//  ezGeometry geo;
+//  geo.AddTorus(1.0f, 1.5f, 32, 16, ezColor::White);
+//  geo.TriangulatePolygons();
+//  geo.ComputeTangents();
+//
+//  auto hMesh = CreateMeshResource(geo.GetVertices().GetCount(), geo.GetPolygons().GetCount(), geo.GetPolygons().GetCount() * 3);
+//
+//  ezResourceLock<ezDynamicMeshBufferResource> pMesh(hMesh, ezResourceAcquireMode::BlockTillLoaded);
+//
+//  auto verts = pMesh->AccessVertexData();
+//
+//  for (ezUInt32 v = 0; v < verts.GetCount(); ++v)
+//  {
+//    verts[v].m_vPosition = geo.GetVertices()[v].m_vPosition;
+//    verts[v].m_vTexCoord.SetZero();
+//    verts[v].EncodeNormal(geo.GetVertices()[v].m_vNormal);
+//    verts[v].EncodeTangent(geo.GetVertices()[v].m_vTangent, 1.0f);
+//  }
+//
+//  auto ind = pMesh->AccessIndex32Data();
+//
+//  for (ezUInt32 i = 0; i < geo.GetPolygons().GetCount(); ++i)
+//  {
+//    ind[i * 3 + 0] = geo.GetPolygons()[i].m_Vertices[0];
+//    ind[i * 3 + 1] = geo.GetPolygons()[i].m_Vertices[1];
+//    ind[i * 3 + 2] = geo.GetPolygons()[i].m_Vertices[2];
+//  }
+//
+//  SetBounds(ezBoundingSphere(ezVec3::ZeroVector(), 1.5f));
+//}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCustomMeshRenderData, 1, ezRTTIDefaultAllocator<ezCustomMeshRenderData>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+
+void ezCustomMeshRenderData::FillBatchIdAndSortingKey()
+{
+  const ezUInt32 uiAdditionalBatchData = 0;
+
+  m_uiFlipWinding = m_GlobalTransform.ContainsNegativeScale() ? 1 : 0;
+  m_uiUniformScale = m_GlobalTransform.ContainsUniformScale() ? 1 : 0;
+
+  const ezUInt32 uiMeshIDHash = ezHashingUtils::StringHashTo32(m_hMesh.GetResourceIDHash());
+  const ezUInt32 uiMaterialIDHash = m_hMaterial.IsValid() ? ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash()) : 0;
+
+  // Generate batch id from mesh, material and part index.
+  ezUInt32 data[] = {uiMeshIDHash, uiMaterialIDHash, 0 /*m_uiSubMeshIndex*/, m_uiFlipWinding, uiAdditionalBatchData};
+  m_uiBatchId = ezHashingUtils::xxHash32(data, sizeof(data));
+
+  // Sort by material and then by mesh
+  m_uiSortingKey = (uiMaterialIDHash << 16) | ((uiMeshIDHash + 0 /*m_uiSubMeshIndex*/) & 0xFFFE) | m_uiFlipWinding;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCustomMeshRenderer, 1, ezRTTIDefaultAllocator<ezCustomMeshRenderer>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezCustomMeshRenderer::ezCustomMeshRenderer() = default;
+ezCustomMeshRenderer::~ezCustomMeshRenderer() = default;
+
+void ezCustomMeshRenderer::GetSupportedRenderDataCategories(ezHybridArray<ezRenderData::Category, 8>& categories) const
+{
+  categories.PushBack(ezDefaultRenderDataCategories::LitOpaque);
+  categories.PushBack(ezDefaultRenderDataCategories::LitMasked);
+  categories.PushBack(ezDefaultRenderDataCategories::LitTransparent);
+  categories.PushBack(ezDefaultRenderDataCategories::Selection);
+}
+
+void ezCustomMeshRenderer::GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& types) const
+{
+  types.PushBack(ezGetStaticRTTI<ezCustomMeshRenderData>());
+}
+
+void ezCustomMeshRenderer::RenderBatch(const ezRenderViewContext& renderViewContext, const ezRenderPipelinePass* pPass, const ezRenderDataBatch& batch) const
+{
+  ezRenderContext* pRenderContext = renderViewContext.m_pRenderContext;
+  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
+  ezGALCommandEncoder* pGALCommandEncoder = pRenderContext->GetCommandEncoder();
+
+  ezInstanceData* pInstanceData = pPass->GetPipeline()->GetFrameDataProvider<ezInstanceDataProvider>()->GetData(renderViewContext);
+  pInstanceData->BindResources(pRenderContext);
+
+  const ezCustomMeshRenderData* pRenderData1st = batch.GetFirstData<ezCustomMeshRenderData>();
+
+  if (pRenderData1st->m_uiFlipWinding)
+  {
+    pRenderContext->SetShaderPermutationVariable("FLIP_WINDING", "TRUE");
+  }
+  else
+  {
+    pRenderContext->SetShaderPermutationVariable("FLIP_WINDING", "FALSE");
+  }
+
+  pRenderContext->SetShaderPermutationVariable("VERTEX_SKINNING", "FALSE");
+
+  for (auto it = batch.GetIterator<ezCustomMeshRenderData>(0, batch.GetCount()); it.IsValid(); ++it)
+  {
+    const ezCustomMeshRenderData* pRenderData = it;
+
+    ezResourceLock<ezDynamicMeshBufferResource> pBuffer(pRenderData->m_hMesh, ezResourceAcquireMode::BlockTillLoaded);
+
+    pRenderContext->BindMaterial(pRenderData->m_hMaterial);
+
+    ezUInt32 uiInstanceDataOffset = 0;
+    ezArrayPtr<ezPerInstanceData> instanceData = pInstanceData->GetInstanceData(1, uiInstanceDataOffset);
+
+    instanceData[0].GameObjectID = pRenderData->m_uiUniqueID;
+    instanceData[0].Color = pRenderData->m_Color;
+    instanceData[0].ObjectToWorld = pRenderData->m_GlobalTransform;
+
+    if (pRenderData->m_uiUniformScale)
+    {
+      instanceData[0].ObjectToWorldNormal = instanceData[0].ObjectToWorld;
+    }
+    else
+    {
+      ezMat4 objectToWorld = pRenderData->m_GlobalTransform.GetAsMat4();
+
+      ezMat3 mInverse = objectToWorld.GetRotationalPart();
+      mInverse.Invert(0.0f).IgnoreResult();
+      // we explicitly ignore the return value here (success / failure)
+      // because when we have a scale of 0 (which happens temporarily during editing) that would be annoying
+      instanceData[0].ObjectToWorldNormal = mInverse.GetTranspose();
+    }
+
+    pInstanceData->UpdateInstanceData(pRenderContext, 1);
+
+    const auto& desc = pBuffer->GetDescriptor();
+    pBuffer->UpdateGpuBuffer(pGALCommandEncoder, 0, desc.m_uiNumVertices, 0, desc.m_uiNumIndices32);
+
+    // redo this after the primitive count has changed
+    pRenderContext->BindMeshBuffer(pRenderData->m_hMesh);
+
+    renderViewContext.m_pRenderContext->DrawMeshBuffer(pRenderData->m_uiNumPrimitives, pRenderData->m_uiFirstPrimitive).IgnoreResult();
+  }
+}

--- a/Code/Engine/RendererCore/Meshes/Implementation/DynamicMeshBufferResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/DynamicMeshBufferResource.cpp
@@ -142,16 +142,19 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezDynamicMeshBufferResource, ezDynamicMeshBuffe
 
 void ezDynamicMeshBufferResource::UpdateGpuBuffer(ezGALCommandEncoder* pGALCommandEncoder, ezUInt32 uiFirstVertex, ezUInt32 uiNumVertices, ezUInt32 uiFirstIndex, ezUInt32 uiNumIndices, ezGALUpdateMode::Enum mode /*= ezGALUpdateMode::Discard*/)
 {
-  if (uiNumVertices > 0)
+  if (m_bAccessedVB && uiNumVertices > 0)
   {
     EZ_ASSERT_DEV(uiNumVertices <= m_VertexData.GetCount(), "Can't upload {} vertices, the buffer was allocated to hold a maximum of {} vertices.", uiNumVertices, m_VertexData.GetCount());
 
+    m_bAccessedVB = false;
 
     pGALCommandEncoder->UpdateBuffer(m_hVertexBuffer, sizeof(ezDynamicMeshVertex) * uiFirstVertex, m_VertexData.GetArrayPtr().GetSubArray(uiFirstVertex, uiNumVertices).ToByteArray(), mode);
   }
 
-  if (uiNumIndices > 0 && !m_hIndexBuffer.IsInvalidated())
+  if (m_bAccessedIB && uiNumIndices > 0 && !m_hIndexBuffer.IsInvalidated())
   {
+    m_bAccessedIB = false;
+
     if (!m_Index16Data.IsEmpty())
     {
       EZ_ASSERT_DEV(uiFirstIndex < m_Index16Data.GetCount(), "Invalid first index value {}", uiFirstIndex);

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
@@ -81,19 +81,19 @@ void ezMeshRenderData::FillBatchIdAndSortingKey()
 
 // clang-format off
 EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezMeshComponentBase, 1)
+{
+  EZ_BEGIN_ATTRIBUTES
   {
-    EZ_BEGIN_ATTRIBUTES
-    {
-      new ezCategoryAttribute("Rendering"),
-    }
-    EZ_END_ATTRIBUTES;
-    EZ_BEGIN_MESSAGEHANDLERS
-    {
-      EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
-      EZ_MESSAGE_HANDLER(ezMsgSetMeshMaterial, OnMsgSetMeshMaterial),
-      EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
-    } EZ_END_MESSAGEHANDLERS;
+    new ezCategoryAttribute("Rendering"),
   }
+  EZ_END_ATTRIBUTES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+    EZ_MESSAGE_HANDLER(ezMsgSetMeshMaterial, OnMsgSetMeshMaterial),
+    EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+  } EZ_END_MESSAGEHANDLERS;
+}
 EZ_END_ABSTRACT_COMPONENT_TYPE;
 // clang-format on
 

--- a/Code/Engine/RendererCore/Meshes/MeshBufferResource.h
+++ b/Code/Engine/RendererCore/Meshes/MeshBufferResource.h
@@ -14,6 +14,7 @@ struct EZ_RENDERERCORE_DLL ezVertexStreamInfo : public ezHashableStruct<ezVertex
   EZ_DECLARE_POD_TYPE();
 
   ezGALVertexAttributeSemantic::Enum m_Semantic;
+  ezUInt8 m_uiVertexBufferSlot = 0;
   ezGALResourceFormat::Enum m_Format;
   ezUInt16 m_uiOffset;      ///< at which byte offset the first element starts
   ezUInt16 m_uiElementSize; ///< the number of bytes for this element type (depends on the format); this is not the stride between elements!

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -486,8 +486,7 @@ void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBuffe
 void ezRenderContext::BindMeshBuffer(const ezDynamicMeshBufferResourceHandle& hDynamicMeshBuffer)
 {
   ezResourceLock<ezDynamicMeshBufferResource> pMeshBuffer(hDynamicMeshBuffer, ezResourceAcquireMode::AllowLoadingFallback);
-  BindMeshBuffer(pMeshBuffer->GetVertexBuffer(), pMeshBuffer->GetIndexBuffer(), &(pMeshBuffer->GetVertexDeclaration()), pMeshBuffer->GetTopology(),
-    pMeshBuffer->GetPrimitiveCount());
+  BindMeshBuffer(pMeshBuffer->GetVertexBuffer(), pMeshBuffer->GetIndexBuffer(), &(pMeshBuffer->GetVertexDeclaration()), pMeshBuffer->GetDescriptor().m_Topology, pMeshBuffer->GetDescriptor().m_uiMaxPrimitives);
 }
 
 ezResult ezRenderContext::DrawMeshBuffer(ezUInt32 uiPrimitiveCount, ezUInt32 uiFirstPrimitive, ezUInt32 uiInstanceCount)

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -440,10 +440,9 @@ void ezRenderContext::BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuff
 }
 
 void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBufferHandle hIndexBuffer,
-  const ezVertexDeclarationInfo* pVertexDeclarationInfo, ezGALPrimitiveTopology::Enum topology, ezUInt32 uiPrimitiveCount)
+  const ezVertexDeclarationInfo* pVertexDeclarationInfo, ezGALPrimitiveTopology::Enum topology, ezUInt32 uiPrimitiveCount, ezGALBufferHandle hVertexBuffer2, ezGALBufferHandle hVertexBuffer3, ezGALBufferHandle hVertexBuffer4)
 {
-  if (m_hVertexBuffer == hVertexBuffer && m_hIndexBuffer == hIndexBuffer && m_pVertexDeclarationInfo == pVertexDeclarationInfo &&
-      m_Topology == topology && m_uiMeshBufferPrimitiveCount == uiPrimitiveCount)
+  if (m_hVertexBuffers[0] == hVertexBuffer && m_hVertexBuffers[1] == hVertexBuffer2 && m_hVertexBuffers[2] == hVertexBuffer3 && m_hVertexBuffers[3] == hVertexBuffer4 && m_hIndexBuffer == hIndexBuffer && m_pVertexDeclarationInfo == pVertexDeclarationInfo && m_Topology == topology && m_uiMeshBufferPrimitiveCount == uiPrimitiveCount)
   {
     return;
   }
@@ -475,7 +474,10 @@ void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBuffe
     SetShaderPermutationVariable("TOPOLOGY", sTopologies[m_Topology]);
   }
 
-  m_hVertexBuffer = hVertexBuffer;
+  m_hVertexBuffers[0] = hVertexBuffer;
+  m_hVertexBuffers[1] = hVertexBuffer2;
+  m_hVertexBuffers[2] = hVertexBuffer3;
+  m_hVertexBuffers[3] = hVertexBuffer4;
   m_hIndexBuffer = hIndexBuffer;
   m_pVertexDeclarationInfo = pVertexDeclarationInfo;
   m_uiMeshBufferPrimitiveCount = uiPrimitiveCount;
@@ -486,7 +488,7 @@ void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBuffe
 void ezRenderContext::BindMeshBuffer(const ezDynamicMeshBufferResourceHandle& hDynamicMeshBuffer)
 {
   ezResourceLock<ezDynamicMeshBufferResource> pMeshBuffer(hDynamicMeshBuffer, ezResourceAcquireMode::AllowLoadingFallback);
-  BindMeshBuffer(pMeshBuffer->GetVertexBuffer(), pMeshBuffer->GetIndexBuffer(), &(pMeshBuffer->GetVertexDeclaration()), pMeshBuffer->GetDescriptor().m_Topology, pMeshBuffer->GetDescriptor().m_uiMaxPrimitives);
+  BindMeshBuffer(pMeshBuffer->GetVertexBuffer(), pMeshBuffer->GetIndexBuffer(), &(pMeshBuffer->GetVertexDeclaration()), pMeshBuffer->GetDescriptor().m_Topology, pMeshBuffer->GetDescriptor().m_uiMaxPrimitives, pMeshBuffer->GetColorBuffer());
 }
 
 ezResult ezRenderContext::DrawMeshBuffer(ezUInt32 uiPrimitiveCount, ezUInt32 uiFirstPrimitive, ezUInt32 uiInstanceCount)
@@ -678,7 +680,11 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::MeshBufferBindingChanged))
     {
       pCommandEncoder->SetPrimitiveTopology(m_Topology);
-      pCommandEncoder->SetVertexBuffer(0, m_hVertexBuffer);
+
+      for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hVertexBuffers); ++i)
+      {
+        pCommandEncoder->SetVertexBuffer(i, m_hVertexBuffers[i]);
+      }
 
       if (!m_hIndexBuffer.IsInvalidated())
         pCommandEncoder->SetIndexBuffer(m_hIndexBuffer);
@@ -689,7 +695,7 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
       return EZ_FAILURE;
 
     // If there is a vertex buffer we need a valid vertex declaration as well.
-    if (!m_hVertexBuffer.IsInvalidated() && hVertexDeclaration.IsInvalidated())
+    if ((!m_hVertexBuffers[0].IsInvalidated() || !m_hVertexBuffers[1].IsInvalidated() || !m_hVertexBuffers[2].IsInvalidated() || !m_hVertexBuffers[3].IsInvalidated()) && hVertexDeclaration.IsInvalidated())
       return EZ_FAILURE;
 
     pCommandEncoder->SetVertexDeclaration(hVertexDeclaration);
@@ -713,7 +719,11 @@ void ezRenderContext::ResetContextState()
 
   m_hActiveShaderPermutation.Invalidate();
 
-  m_hVertexBuffer.Invalidate();
+  for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hVertexBuffers); ++i)
+  {
+    m_hVertexBuffers[i].Invalidate();
+  }
+
   m_hIndexBuffer.Invalidate();
   m_pVertexDeclarationInfo = nullptr;
   m_Topology = ezGALPrimitiveTopology::ENUM_COUNT; // Set to something invalid
@@ -915,7 +925,7 @@ ezResult ezRenderContext::BuildVertexDeclaration(ezGALShaderHandle hShader, cons
       gal.m_eFormat = stream.m_Format;
       gal.m_eSemantic = stream.m_Semantic;
       gal.m_uiOffset = stream.m_uiOffset;
-      gal.m_uiVertexBufferSlot = 0;
+      gal.m_uiVertexBufferSlot = stream.m_uiVertexBufferSlot;
       vd.m_VertexAttributes.PushBack(gal);
     }
 

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -77,7 +77,7 @@ public:
     }
 
     EZ_ALWAYS_INLINE T* operator->() { return m_pGALCommandEncoder; }
-    EZ_ALWAYS_INLINE operator const T *() { return m_pGALCommandEncoder; }
+    EZ_ALWAYS_INLINE operator const T*() { return m_pGALCommandEncoder; }
 
   private:
     friend class ezRenderContext;

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -77,7 +77,7 @@ public:
     }
 
     EZ_ALWAYS_INLINE T* operator->() { return m_pGALCommandEncoder; }
-    EZ_ALWAYS_INLINE operator const T*() { return m_pGALCommandEncoder; }
+    EZ_ALWAYS_INLINE operator const T *() { return m_pGALCommandEncoder; }
 
   private:
     friend class ezRenderContext;
@@ -170,7 +170,7 @@ public:
 
   void BindMeshBuffer(const ezDynamicMeshBufferResourceHandle& hDynamicMeshBuffer);
   void BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuffer);
-  void BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBufferHandle hIndexBuffer, const ezVertexDeclarationInfo* pVertexDeclarationInfo, ezGALPrimitiveTopology::Enum topology, ezUInt32 uiPrimitiveCount);
+  void BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBufferHandle hIndexBuffer, const ezVertexDeclarationInfo* pVertexDeclarationInfo, ezGALPrimitiveTopology::Enum topology, ezUInt32 uiPrimitiveCount, ezGALBufferHandle hVertexBuffer2 = {}, ezGALBufferHandle hVertexBuffer3 = {}, ezGALBufferHandle hVertexBuffer4 = {});
   EZ_ALWAYS_INLINE void BindNullMeshBuffer(ezGALPrimitiveTopology::Enum topology, ezUInt32 uiPrimitiveCount)
   {
     BindMeshBuffer(ezGALBufferHandle(), ezGALBufferHandle(), nullptr, topology, uiPrimitiveCount);
@@ -282,7 +282,7 @@ private:
 
   ezBitflags<ezShaderBindFlags> m_ShaderBindFlags;
 
-  ezGALBufferHandle m_hVertexBuffer;
+  ezGALBufferHandle m_hVertexBuffers[4];
   ezGALBufferHandle m_hIndexBuffer;
   const ezVertexDeclarationInfo* m_pVertexDeclarationInfo;
   ezGALPrimitiveTopology::Enum m_Topology;

--- a/Code/Engine/RendererFoundation/Basics.cpp
+++ b/Code/Engine/RendererFoundation/Basics.cpp
@@ -3,6 +3,7 @@
 #include <RendererFoundation/RendererFoundationDLL.h>
 
 const ezUInt8 ezGALIndexType::Size[ezGALIndexType::ENUM_COUNT] = {
+  0,               // None
   sizeof(ezInt16), // UShort
   sizeof(ezInt32)  // UInt
 };

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -130,7 +130,7 @@ struct ezGALSamplerStateCreationDescription : public ezHashableStruct<ezGALSampl
 
 struct ezGALVertexAttributeSemantic
 {
-  enum Enum
+  enum Enum : ezUInt8
   {
     Position,
     Normal,

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -81,8 +81,9 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALIndexType
 {
   enum Enum
   {
-    UShort,
-    UInt,
+    None,   // indices are not used, vertices are just used in order to form primitives
+    UShort, // 16 bit indices are used to select which vertices shall form a primitive, thus meshes can only use up to 65535 vertices
+    UInt,   // 32 bit indices are used to select which vertices shall form a primitive
 
     ENUM_COUNT
   };

--- a/Code/Engine/RendererFoundation/Resources/ResourceFormats.h
+++ b/Code/Engine/RendererFoundation/Resources/ResourceFormats.h
@@ -6,7 +6,7 @@
 
 struct EZ_RENDERERFOUNDATION_DLL ezGALResourceFormat
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Data/Base/Shaders/Materials/DefaultMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/DefaultMaterial.ezShader
@@ -133,6 +133,11 @@ float3 GetBaseColor()
 {
   float3 baseColor = BaseColor.rgb * GetInstanceData().Color.rgb;
 
+  // note that the default material actually doesn't support per-vertex colors
+#if defined(USE_COLOR0)  
+  baseColor *= G.Input.Color0;
+#endif
+
   [branch]
   if (UseBaseTexture)
   {

--- a/Data/Tools/ezEditor/Localization/en/ScenePlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ScenePlugin.txt
@@ -405,3 +405,4 @@ ezClothSheetFlags::FixedEdgeRight;Edge: Right
 ezClothSheetFlags::FixedEdgeBottom;Edge: Bottom
 ezClothSheetFlags::FixedEdgeLeft;Edge: Left
 ezClothSheetFlags::FixedEdgeLeft;Edge: Left
+ezCustomMeshComponent;Custom Mesh Component


### PR DESCRIPTION
This component makes it easier to render custom meshes. The ezDynamicMeshBufferResource is already meant for building geometry that works with standard materials, but you need a custom renderer to use it. This component provides exactly that.

It only uses a single material, but you can let it render only a subset of the mesh, so you could have multiple submeshes in a single resource and use multiple components to render them.