### PR TITLE
Added a resource for config files

### DIFF
--- a/Code/Engine/RendererCore/Decals/Implementation/DecalAtlasResource.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalAtlasResource.cpp
@@ -32,7 +32,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(RendererCore, DecalAtlasResource)
   ON_CORESYSTEMS_SHUTDOWN
   {
     ezResourceManager::SetResourceTypeLoadingFallback<ezDecalAtlasResource>(ezDecalAtlasResourceHandle());
-  ezResourceManager::SetResourceTypeMissingFallback<ezDecalAtlasResource>(ezDecalAtlasResourceHandle());
+    ezResourceManager::SetResourceTypeMissingFallback<ezDecalAtlasResource>(ezDecalAtlasResourceHandle());
   }
 
   ON_HIGHLEVELSYSTEMS_STARTUP

--- a/Code/Engine/Utilities/Resources/ConfigFileResource.cpp
+++ b/Code/Engine/Utilities/Resources/ConfigFileResource.cpp
@@ -25,8 +25,9 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(Utilties, ConfigFileResource)
 
   ON_CORESYSTEMS_SHUTDOWN
   {
-    ezResourceManager::SetResourceTypeLoader<ezConfigFileResource>(nullptr);
     ezResourceManager::SetResourceTypeMissingFallback<ezConfigFileResource>(ezConfigFileResourceHandle());
+    ezResourceManager::SetResourceTypeLoader<ezConfigFileResource>(nullptr);
+    ezConfigFileResource::CleanupDynamicPluginReferences();
   }
 
   EZ_END_SUBSYSTEM_DECLARATION;

--- a/Code/Engine/Utilities/Resources/ConfigFileResource.cpp
+++ b/Code/Engine/Utilities/Resources/ConfigFileResource.cpp
@@ -1,0 +1,367 @@
+#include <Utilities/UtilitiesPCH.h>
+
+#include <Foundation/CodeUtils/Preprocessor.h>
+#include <Foundation/Configuration/Startup.h>
+#include <Foundation/IO/FileSystem/FileSystem.h>
+#include <Foundation/IO/OSFile.h>
+#include <Utilities/Resources/ConfigFileResource.h>
+
+static ezConfigFileResourceLoader s_ConfigFileResourceLoader;
+
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(Utilties, ConfigFileResource)
+
+  BEGIN_SUBSYSTEM_DEPENDENCIES
+    "Core"
+  END_SUBSYSTEM_DEPENDENCIES
+
+  ON_CORESYSTEMS_STARTUP
+  {
+    ezResourceManager::SetResourceTypeLoader<ezConfigFileResource>(&s_ConfigFileResourceLoader);
+
+    auto hFallback = ezResourceManager::LoadResource<ezConfigFileResource>("Empty.ezConfig");
+    ezResourceManager::SetResourceTypeMissingFallback<ezConfigFileResource>(hFallback);
+  }
+
+  ON_CORESYSTEMS_SHUTDOWN
+  {
+    ezResourceManager::SetResourceTypeLoader<ezConfigFileResource>(nullptr);
+    ezResourceManager::SetResourceTypeMissingFallback<ezConfigFileResource>(ezConfigFileResourceHandle());
+  }
+
+  EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezConfigFileResource, 1, ezRTTIDefaultAllocator<ezConfigFileResource>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+EZ_RESOURCE_IMPLEMENT_COMMON_CODE(ezConfigFileResource);
+
+ezConfigFileResource::ezConfigFileResource()
+  : ezResource(ezResource::DoUpdate::OnAnyThread, 0)
+{
+}
+
+ezConfigFileResource::~ezConfigFileResource() = default;
+
+ezInt32 ezConfigFileResource::GetInt(ezTempHashedString szName, ezInt32 fallback) const
+{
+  auto it = m_IntData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  return fallback;
+}
+
+ezInt32 ezConfigFileResource::GetInt(ezTempHashedString szName) const
+{
+  auto it = m_IntData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  ezLog::Error("{}: 'int' config variable (name hash = {}) doesn't exist.", this->GetResourceDescription(), szName.GetHash());
+  return 0;
+}
+
+float ezConfigFileResource::GetFloat(ezTempHashedString szName, float fallback) const
+{
+  auto it = m_FloatData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  return fallback;
+}
+
+float ezConfigFileResource::GetFloat(ezTempHashedString szName) const
+{
+  auto it = m_FloatData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  ezLog::Error("{}: 'float' config variable (name hash = {}) doesn't exist.", this->GetResourceDescription(), szName.GetHash());
+  return 0;
+}
+
+bool ezConfigFileResource::GetBool(ezTempHashedString szName, bool fallback) const
+{
+  auto it = m_BoolData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  return fallback;
+}
+
+bool ezConfigFileResource::GetBool(ezTempHashedString szName) const
+{
+  auto it = m_BoolData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  ezLog::Error("{}: 'float' config variable (name hash = {}) doesn't exist.", this->GetResourceDescription(), szName.GetHash());
+  return false;
+}
+
+const char* ezConfigFileResource::GetString(ezTempHashedString szName, const char* fallback) const
+{
+  auto it = m_StringData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  return fallback;
+}
+
+const char* ezConfigFileResource::GetString(ezTempHashedString szName) const
+{
+  auto it = m_StringData.Find(szName);
+  if (it.IsValid())
+    return it.Value();
+
+  ezLog::Error("{}: 'string' config variable '(name hash = {}) doesn't exist.", this->GetResourceDescription(), szName.GetHash());
+  return "";
+}
+
+ezResourceLoadDesc ezConfigFileResource::UnloadData(Unload WhatToUnload)
+{
+  m_IntData.Clear();
+  m_FloatData.Clear();
+  m_StringData.Clear();
+  m_BoolData.Clear();
+
+  ezResourceLoadDesc d;
+  d.m_State = ezResourceState::Unloaded;
+  d.m_uiQualityLevelsDiscardable = 0;
+  d.m_uiQualityLevelsLoadable = 0;
+  return d;
+}
+
+ezResourceLoadDesc ezConfigFileResource::UpdateContent(ezStreamReader* Stream)
+{
+  ezResourceLoadDesc d;
+  d.m_uiQualityLevelsDiscardable = 0;
+  d.m_uiQualityLevelsLoadable = 0;
+  d.m_State = ezResourceState::Loaded;
+
+  if (Stream == nullptr)
+  {
+    d.m_State = ezResourceState::LoadedResourceMissing;
+    return d;
+  }
+
+  m_RequiredFiles.ReadDependencyFile(*Stream).IgnoreResult();
+  Stream->ReadHashTable(m_IntData).IgnoreResult();
+  Stream->ReadHashTable(m_FloatData).IgnoreResult();
+  Stream->ReadHashTable(m_StringData).IgnoreResult();
+  Stream->ReadHashTable(m_BoolData).IgnoreResult();
+
+  return d;
+}
+
+void ezConfigFileResource::UpdateMemoryUsage(MemoryUsage& out_NewMemoryUsage)
+{
+  out_NewMemoryUsage.m_uiMemoryCPU = m_IntData.GetHeapMemoryUsage() + m_FloatData.GetHeapMemoryUsage() + m_StringData.GetHeapMemoryUsage() + m_BoolData.GetHeapMemoryUsage();
+  out_NewMemoryUsage.m_uiMemoryGPU = 0;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+ezResult ezConfigFileResourceLoader::LoadedData::PrePropFileLocator(const char* szCurAbsoluteFile, const char* szIncludeFile, ezPreprocessor::IncludeType IncType, ezStringBuilder& out_sAbsoluteFilePath)
+{
+  ezResult res = ezPreprocessor::DefaultFileLocator(szCurAbsoluteFile, szIncludeFile, IncType, out_sAbsoluteFilePath);
+
+  m_RequiredFiles.AddFileDependency(out_sAbsoluteFilePath);
+
+  return res;
+}
+
+ezResourceLoadData ezConfigFileResourceLoader::OpenDataStream(const ezResource* pResource)
+{
+  EZ_PROFILE_SCOPE("ReadResourceFile");
+  EZ_LOG_BLOCK("Load Config Resource", pResource->GetResourceID());
+
+  ezStringBuilder sConfig;
+
+  ezMap<ezString, ezInt32> intData;
+  ezMap<ezString, float> floatData;
+  ezMap<ezString, ezString> stringData;
+  ezMap<ezString, bool> boolData;
+
+  LoadedData* pData = EZ_DEFAULT_NEW(LoadedData);
+  pData->m_Reader.SetStorage(&pData->m_Storage);
+
+  ezPreprocessor preprop;
+
+  // used to gather all the transitive file dependencies
+  preprop.SetFileLocatorFunction(ezMakeDelegate(&ezConfigFileResourceLoader::LoadedData::PrePropFileLocator, pData));
+
+  if (ezStringUtils::IsEqual(pResource->GetResourceID(), "Empty.ezConfig"))
+  {
+    // do nothing
+  }
+  else if (preprop.Process(pResource->GetResourceID(), sConfig, false, true, false).Succeeded())
+  {
+    sConfig.ReplaceAll("\r", "");
+    sConfig.ReplaceAll("\n", ";");
+
+    ezHybridArray<ezStringView, 32> lines;
+    sConfig.Split(false, lines, ";");
+
+    ezStringBuilder key, value, line;
+
+    for (ezStringView tmp : lines)
+    {
+      line = tmp;
+      line.Trim(" \t");
+
+      if (line.IsEmpty())
+        continue;
+
+      const char* szAssign = line.FindSubString("=");
+
+      if (szAssign == nullptr)
+      {
+        ezLog::Error("Invalid line in config file: '{}'", tmp);
+      }
+      else
+      {
+        value = szAssign + 1;
+        value.Trim(" ");
+
+        line.SetSubString_FromTo(line.GetData(), szAssign);
+        line.ReplaceAll("\t", " ");
+        line.ReplaceAll("  ", " ");
+        line.Trim(" ");
+
+        const bool bOverride = line.TrimWordStart("override ");
+        line.Trim(" ");
+
+        if (line.StartsWith("int "))
+        {
+          key.SetSubString_FromTo(line.GetData() + 4, szAssign);
+          key.Trim(" ");
+
+          if (bOverride && !intData.Contains(key))
+            ezLog::Error("Config 'int' key '{}' is marked override, but doesn't exist yet. Remove 'override' keyword.", key);
+          if (!bOverride && intData.Contains(key))
+            ezLog::Error("Config 'int' key '{}' is not marked override, but exist already. Use 'override int' instead.", key);
+
+          ezInt32 val;
+          if (ezConversionUtils::StringToInt(value, val).Succeeded())
+          {
+            intData[key] = val;
+          }
+          else
+          {
+            ezLog::Error("Failed to parse 'int' in config file: '{}'", tmp);
+          }
+        }
+        else if (line.StartsWith("float "))
+        {
+          key.SetSubString_FromTo(line.GetData() + 6, szAssign);
+          key.Trim(" ");
+
+          if (bOverride && !floatData.Contains(key))
+            ezLog::Error("Config 'float' key '{}' is marked override, but doesn't exist yet. Remove 'override' keyword.", key);
+          if (!bOverride && floatData.Contains(key))
+            ezLog::Error("Config 'float' key '{}' is not marked override, but exist already. Use 'override float' instead.", key);
+
+          double val;
+          if (ezConversionUtils::StringToFloat(value, val).Succeeded())
+          {
+            floatData[key] = (float)val;
+          }
+          else
+          {
+            ezLog::Error("Failed to parse 'float' in config file: '{}'", tmp);
+          }
+        }
+        else if (line.StartsWith("bool "))
+        {
+          key.SetSubString_FromTo(line.GetData() + 5, szAssign);
+          key.Trim(" ");
+
+          if (bOverride && !boolData.Contains(key))
+            ezLog::Error("Config 'bool' key '{}' is marked override, but doesn't exist yet. Remove 'override' keyword.", key);
+          if (!bOverride && boolData.Contains(key))
+            ezLog::Error("Config 'bool' key '{}' is not marked override, but exist already. Use 'override bool' instead.", key);
+
+          bool val;
+          if (ezConversionUtils::StringToBool(value, val).Succeeded())
+          {
+            boolData[key] = val;
+          }
+          else
+          {
+            ezLog::Error("Failed to parse 'bool' in config file: '{}'", tmp);
+          }
+        }
+        else if (line.StartsWith("string "))
+        {
+          key.SetSubString_FromTo(line.GetData() + 7, szAssign);
+          key.Trim(" ");
+
+          if (bOverride && !stringData.Contains(key))
+            ezLog::Error("Config 'string' key '{}' is marked override, but doesn't exist yet. Remove 'override' keyword.", key);
+          if (!bOverride && stringData.Contains(key))
+            ezLog::Error("Config 'string' key '{}' is not marked override, but exist already. Use 'override string' instead.", key);
+
+          if (!value.StartsWith("\"") || !value.EndsWith("\""))
+          {
+            ezLog::Error("Failed to parse 'string' in config file: '{}'", tmp);
+          }
+          else
+          {
+            value.Shrink(1, 1);
+            stringData[key] = value;
+          }
+        }
+        else
+        {
+          ezLog::Error("Invalid line in config file: '{}'", tmp);
+        }
+      }
+    }
+  }
+  else
+  {
+    // empty stream
+    return {};
+  }
+
+  ezResourceLoadData res;
+  res.m_pDataStream = &pData->m_Reader;
+  res.m_pCustomLoaderData = pData;
+
+#if EZ_ENABLED(EZ_SUPPORTS_FILE_STATS)
+  ezFileStats stat;
+  if (ezFileSystem::GetFileStats(pResource->GetResourceID(), stat).Succeeded())
+  {
+    res.m_sResourceDescription = stat.m_sName;
+    res.m_LoadedFileModificationDate = stat.m_LastModificationTime;
+  }
+#endif
+
+  ezMemoryStreamWriter writer(&pData->m_Storage);
+
+  pData->m_RequiredFiles.StoreCurrentTimeStamp();
+  pData->m_RequiredFiles.WriteDependencyFile(writer).IgnoreResult();
+  writer.WriteMap(intData).IgnoreResult();
+  writer.WriteMap(floatData).IgnoreResult();
+  writer.WriteMap(stringData).IgnoreResult();
+  writer.WriteMap(boolData).IgnoreResult();
+
+  return res;
+}
+
+void ezConfigFileResourceLoader::CloseDataStream(const ezResource* pResource, const ezResourceLoadData& LoaderData)
+{
+  LoadedData* pData = static_cast<LoadedData*>(LoaderData.m_pCustomLoaderData);
+
+  EZ_DEFAULT_DELETE(pData);
+}
+
+bool ezConfigFileResourceLoader::IsResourceOutdated(const ezResource* pResource) const
+{
+  return static_cast<const ezConfigFileResource*>(pResource)->m_RequiredFiles.HasAnyFileChanged();
+}

--- a/Code/Engine/Utilities/Resources/ConfigFileResource.h
+++ b/Code/Engine/Utilities/Resources/ConfigFileResource.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <Core/ResourceManager/Resource.h>
+#include <Core/ResourceManager/ResourceTypeLoader.h>
+#include <Foundation/CodeUtils/Preprocessor.h>
+#include <Foundation/Containers/HashTable.h>
+#include <Foundation/IO/DependencyFile.h>
+#include <Foundation/Strings/HashedString.h>
+#include <Utilities/UtilitiesDLL.h>
+
+using ezConfigFileResourceHandle = ezTypedResourceHandle<class ezConfigFileResource>;
+
+/// \brief This resource loads config files containing key/value pairs
+///
+/// The config files usually use the file extension '.ezConfig'.
+///
+/// The file format looks like this:
+///
+/// To declare a key/value pair for the first time, write its type, name and value:
+///   int i = 1
+///   float f = 2.3
+///   bool b = false
+///   string s = "hello"
+///
+/// To set a variable to a different value than before, it has to be marked with 'override':
+///
+///   override i = 4
+///
+/// The format supports C preprocessor features like #include, #define, #ifdef, etc.
+/// This can be used to build hierarchical config files:
+///
+///   #include "BaseConfig.ezConfig"
+///   override int SomeValue = 7
+///
+/// It can also be used to define 'enum types':
+///
+///   #define SmallValue 3
+///   #define BigValue 5
+///   int MyValue = BigValue
+///
+/// Since resources can be reloaded at runtime, config resources are a convenient way to define game parameters
+/// that you may want to tweak at any time.
+/// Using C preprocessor logic (#define, #if, #else, etc) you can quickly select between different configuration sets.
+///
+/// Once loaded, accessing the data is very efficient.
+class EZ_UTILITIES_DLL ezConfigFileResource : public ezResource
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezConfigFileResource, ezResource);
+
+  EZ_RESOURCE_DECLARE_COMMON_CODE(ezConfigFileResource);
+
+public:
+  ezConfigFileResource();
+  ~ezConfigFileResource();
+
+  /// \brief Returns the 'int' variable with the given name. Logs an error, if the variable doesn't exist in the config file.
+  ezInt32 GetInt(ezTempHashedString szName) const;
+
+  /// \brief Returns the 'float' variable with the given name. Logs an error, if the variable doesn't exist in the config file.
+  float GetFloat(ezTempHashedString szName) const;
+
+  /// \brief Returns the 'bool' variable with the given name. Logs an error, if the variable doesn't exist in the config file.
+  bool GetBool(ezTempHashedString szName) const;
+
+  /// \brief Returns the 'string' variable with the given name. Logs an error, if the variable doesn't exist in the config file.
+  const char* GetString(ezTempHashedString szName) const;
+
+  /// \brief Returns the 'int' variable with the given name. Returns the 'fallback' value, if the variable doesn't exist in the config file.
+  ezInt32 GetInt(ezTempHashedString szName, ezInt32 fallback) const;
+
+  /// \brief Returns the 'float' variable with the given name. Returns the 'fallback' value, if the variable doesn't exist in the config file.
+  float GetFloat(ezTempHashedString szName, float fallback) const;
+
+  /// \brief Returns the 'bool' variable with the given name. Returns the 'fallback' value, if the variable doesn't exist in the config file.
+  bool GetBool(ezTempHashedString szName, bool fallback) const;
+
+  /// \brief Returns the 'string' variable with the given name. Returns the 'fallback' value, if the variable doesn't exist in the config file.
+  const char* GetString(ezTempHashedString szName, const char* fallback) const;
+
+protected:
+  virtual ezResourceLoadDesc UnloadData(Unload WhatToUnload) override;
+  virtual ezResourceLoadDesc UpdateContent(ezStreamReader* Stream) override;
+  virtual void UpdateMemoryUsage(MemoryUsage& out_NewMemoryUsage) override;
+
+private:
+  friend class ezConfigFileResourceLoader;
+
+  ezHashTable<ezHashedString, ezInt32> m_IntData;
+  ezHashTable<ezHashedString, float> m_FloatData;
+  ezHashTable<ezHashedString, ezString> m_StringData;
+  ezHashTable<ezHashedString, bool> m_BoolData;
+
+  ezDependencyFile m_RequiredFiles;
+};
+
+
+class EZ_UTILITIES_DLL ezConfigFileResourceLoader : public ezResourceTypeLoader
+{
+public:
+  struct LoadedData
+  {
+    LoadedData()
+      : m_Reader(&m_Storage)
+    {
+    }
+
+    ezMemoryStreamStorage m_Storage;
+    ezMemoryStreamReader m_Reader;
+    ezDependencyFile m_RequiredFiles;
+
+    ezResult PrePropFileLocator(const char* szCurAbsoluteFile, const char* szIncludeFile, ezPreprocessor::IncludeType IncType, ezStringBuilder& out_sAbsoluteFilePath);
+  };
+
+  virtual ezResourceLoadData OpenDataStream(const ezResource* pResource) override;
+  virtual void CloseDataStream(const ezResource* pResource, const ezResourceLoadData& LoaderData) override;
+  virtual bool IsResourceOutdated(const ezResource* pResource) const override;
+};

--- a/Code/Tools/Libs/GuiFoundation/UIServices/QtProgressbar.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/QtProgressbar.h
@@ -49,4 +49,5 @@ private:
   QMetaObject::Connection m_OnButtonDestroyed;
   QMetaObject::Connection m_OnProgressDestroyed;
 #endif
+  QMetaObject::Connection m_OnDialogDestroyed;
 };


### PR DESCRIPTION
Files can #include other config files for hierarchical structures.
Variables are typed (int, float, bool, string).
Enum values can be #defined.
C preprocessor logic can be used.