### PR TITLE
Fix long ops and Mac build

### DIFF
--- a/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
@@ -61,20 +61,20 @@ jobs:
     inputs:
       targetType: inline
       filePath: brew install Caskroom/cask/xquartz
-      script: >-
-        brew update
-
-        brew pull https://github.com/Homebrew/homebrew-core/pull/49913
-
+      script: |
+        # Brew update takes very long. Only enable if below steps start failing.
+        #brew update
+        brew list --versions qt@5
+        brew install qt@5
+        brew info qt@5
         brew install Caskroom/cask/xquartz
-
-        brew install qt5
-
+        brew info Caskroom/cask/xquartz
         brew install sfml
+        brew info sfml
   - task: CMake@1
     displayName: CMake
     inputs:
-      cmakeArgs: -DCMAKE_PREFIX_PATH=/usr/local/Cellar/qt@5/5.15.2/;/usr/local/Cellar/sfml/2.5.1/ -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_BUILD_TYPE=Dev -DEZ_ENABLE_FOLDER_UNITY_FILES=$(unityfiles) -G "Xcode" ../
+      cmakeArgs: -DCMAKE_PREFIX_PATH=/usr/local/opt/qt@5/;/usr/local/Cellar/sfml/2.5.1/ -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_BUILD_TYPE=Dev -DEZ_ENABLE_FOLDER_UNITY_FILES=$(unityfiles) -G "Xcode" ../
   - task: Xcode@5
     displayName: Xcode build
     inputs:

--- a/Code/Editor/EditorFramework/LongOps/Implementation/LongOpsAdapter.cpp
+++ b/Code/Editor/EditorFramework/LongOps/Implementation/LongOpsAdapter.cpp
@@ -48,8 +48,9 @@ void ezLongOpsAdapter::DocumentManagerEventHandler(const ezDocumentManager::Even
 {
   if (e.m_Type == ezDocumentManager::Event::Type::DocumentOpened)
   {
-    const char* szDocType = e.m_pDocument->GetDocumentTypeDescriptor()->m_pDocumentType->GetTypeName();
-    if (ezStringUtils::IsEqual(szDocType, "ezSceneDocument"))
+    const ezRTTI* pRttiScene = ezRTTI::FindTypeByName("ezSceneDocument");
+    const bool bIsScene = e.m_pDocument->GetDocumentTypeDescriptor()->m_pDocumentType->IsDerivedFrom(pRttiScene);
+    if (bIsScene)
     {
       CheckAllTypes();
 
@@ -61,8 +62,9 @@ void ezLongOpsAdapter::DocumentManagerEventHandler(const ezDocumentManager::Even
 
   if (e.m_Type == ezDocumentManager::Event::Type::DocumentClosing)
   {
-    const char* szDocType = e.m_pDocument->GetDocumentTypeDescriptor()->m_pDocumentType->GetTypeName();
-    if (ezStringUtils::IsEqual(szDocType, "ezSceneDocument"))
+    const ezRTTI* pRttiScene = ezRTTI::FindTypeByName("ezSceneDocument");
+    const bool bIsScene = e.m_pDocument->GetDocumentTypeDescriptor()->m_pDocumentType->IsDerivedFrom(pRttiScene);
+    if (bIsScene)
     {
       ezLongOpControllerManager::GetSingleton()->CancelAndRemoveAllOpsForDocument(e.m_pDocument->GetGuid());
 


### PR DESCRIPTION
Mac Qt version is now pinned.
LongOpsAdapter no longer uses string compare to test for an RTTI type.
Fixes #497