### PR TITLE
Some fixes

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -62,6 +62,9 @@ void ezQtEditorApp::SlotSaveSettings()
 
 void ezQtEditorApp::SlotVersionCheckCompleted(bool bNewVersionReleased, bool bForced)
 {
+  // Close the splash screen so it doesn't become the parent window of our message boxes.
+  CloseSplashScreen();
+
   if (bForced || bNewVersionReleased)
   {
     if (m_VersionChecker.IsLatestNewer())

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -185,7 +185,7 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
 
   m_LongOpControllerManager.Startup(&s_pEngineViewProcess->GetCommunicationChannel());
 
-  QCoreApplication::setOrganizationDomain("www.ezEngine.net");
+  QCoreApplication::setOrganizationDomain("www.ezengine.net");
   QCoreApplication::setOrganizationName("ezEngine Project");
   QCoreApplication::setApplicationName(ezApplicationServices::GetSingleton()->GetApplicationName());
   QCoreApplication::setApplicationVersion("1.0.0");
@@ -273,7 +273,7 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
     connect(&m_VersionChecker, &ezQtVersionChecker::VersionCheckCompleted, this, &ezQtEditorApp::SlotVersionCheckCompleted);
 
     m_VersionChecker.Initialize();
-    m_VersionChecker.Check(false);
+    m_VersionChecker.Check(true);
   }
 
   LoadEditorPlugins();

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -273,7 +273,7 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
     connect(&m_VersionChecker, &ezQtVersionChecker::VersionCheckCompleted, this, &ezQtEditorApp::SlotVersionCheckCompleted);
 
     m_VersionChecker.Initialize();
-    m_VersionChecker.Check(true);
+    m_VersionChecker.Check(false);
   }
 
   LoadEditorPlugins();

--- a/Code/Engine/RendererCore/Material/Implementation/MaterialResource.cpp
+++ b/Code/Engine/RendererCore/Material/Implementation/MaterialResource.cpp
@@ -436,7 +436,12 @@ ezResourceLoadDesc ezMaterialResource::UnloadData(Unload WhatToUnload)
   if (m_Desc.m_hBaseMaterial.IsValid())
   {
     ezResourceLock<ezMaterialResource> pBaseMaterial(m_Desc.m_hBaseMaterial, ezResourceAcquireMode::PointerOnly);
-    pBaseMaterial->m_ModifiedEvent.RemoveEventHandler(ezMakeDelegate(&ezMaterialResource::OnBaseMaterialModified, this));
+
+    auto d = ezMakeDelegate(&ezMaterialResource::OnBaseMaterialModified, this);
+    if (pBaseMaterial->m_ModifiedEvent.HasEventHandler(d))
+    {
+      pBaseMaterial->m_ModifiedEvent.RemoveEventHandler(d);
+    }
   }
 
   m_Desc.Clear();

--- a/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/DelegateTest.cpp
@@ -339,8 +339,13 @@ EZ_CREATE_SIMPLE_TEST(Basics, Delegate)
     auto d4 = ezMakeDelegate(&TestType::VirtualMethod, &instance);
     EZ_TEST_BOOL(d4.IsEqualIfComparable(ezMakeDelegate(&TestType::VirtualMethod, &instance)));
 
+    TestType instance2;
+    auto d2_2 = ezMakeDelegate(&TestType::Method, &instance2);
+    EZ_TEST_BOOL(!d2_2.IsEqualIfComparable(d2));
+
     EZ_IGNORE_UNUSED(d1);
     EZ_IGNORE_UNUSED(d2);
+    EZ_IGNORE_UNUSED(d2_2);
     EZ_IGNORE_UNUSED(d3);
     EZ_IGNORE_UNUSED(d4);
   }


### PR DESCRIPTION
* Workaround for crash in material resource during transform of scene when base asset cache was not present (might need further investigation)
* Close the splash screen before the version check message boxes are opened (otherwise the splash screen becomes the parent of the message boxes which will lead to problems with deletion of objects in event handlers and such)
* Fixed the URL casing of the organization domain of the editor app
* Added a unit test to ensure that ezDelegate::IsEqualIfComparable() doesn't return true when the object instance pointers are different (wasn't a problem, just noticed that this test was missing)