### PR TITLE
Scene export now allows to run custom external apps, not just ezPlayer

### DIFF
--- a/Code/Editor/EditorFramework/Preferences/ProjectPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/ProjectPreferences.cpp
@@ -9,7 +9,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProjectPreferencesUser, 1, ezRTTIDefaultAlloca
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("RenderPipelines", m_sRenderPipelines),
+    EZ_ARRAY_MEMBER_PROPERTY("Players", m_PlayerApps)->AddAttributes(new ezHiddenAttribute()),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorFramework/Preferences/ProjectPreferences.h
+++ b/Code/Editor/EditorFramework/Preferences/ProjectPreferences.h
@@ -11,5 +11,6 @@ class EZ_EDITORFRAMEWORK_DLL ezProjectPreferencesUser : public ezPreferences
 public:
   ezProjectPreferencesUser();
 
-  ezString m_sRenderPipelines;
+  // which apps to launch as external 'Players' (other than ezPlayer.exe)
+  ezDynamicArray<ezString> m_PlayerApps;
 };

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -369,7 +369,7 @@ void ezSceneAction::Execute(const ezVariant& value)
 
       if (dlg.m_bRunAfterExport)
       {
-        LaunchPlayer();
+        LaunchPlayer(dlg.m_sApplication);
       }
 
       return;
@@ -505,16 +505,16 @@ void ezSceneAction::Execute(const ezVariant& value)
   }
 }
 
-void ezSceneAction::LaunchPlayer()
+void ezSceneAction::LaunchPlayer(const char* szPlayerApp)
 {
   ezStringBuilder sCmd;
   QStringList arguments = GetPlayerCommandLine(sCmd);
 
-  ezLog::Info("Running: Player.exe {}", sCmd);
-  m_pSceneDocument->ShowDocumentStatus(ezFmt("Running: Player.exe {}", sCmd));
+  ezLog::Info("Running: {} {}", szPlayerApp, sCmd);
+  m_pSceneDocument->ShowDocumentStatus(ezFmt("Running: {} {}", szPlayerApp, sCmd));
 
   QProcess proc;
-  proc.startDetached(QString::fromUtf8("Player.exe"), arguments);
+  proc.startDetached(QString::fromUtf8(szPlayerApp), arguments);
 }
 
 QStringList ezSceneAction::GetPlayerCommandLine(ezStringBuilder& out_SingleLine) const

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.h
@@ -102,7 +102,7 @@ public:
 
   virtual void Execute(const ezVariant& value) override;
 
-  void LaunchPlayer();
+  void LaunchPlayer(const char* szPlayerApp);
   QStringList GetPlayerCommandLine(ezStringBuilder& out_SingleLine) const;
 
 private:

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
@@ -1,20 +1,51 @@
 #include <EditorPluginScene/EditorPluginScenePCH.h>
 
+#include <EditorFramework/Preferences/Preferences.h>
+#include <EditorFramework/Preferences/ProjectPreferences.h>
 #include <EditorPluginScene/Dialogs/ExportAndRunDlg.moc.h>
+#include <Foundation/IO/OSFile.h>
+#include <QFileDialog>
 
 bool ezQtExportAndRunDlg::s_bTransformAll = true;
 bool ezQtExportAndRunDlg::s_bUpdateThumbnail = false;
+
+static int s_iLastPlayerApp = 0;
 
 ezQtExportAndRunDlg::ezQtExportAndRunDlg(QWidget* parent)
   : QDialog(parent)
 {
   setupUi(this);
+
+  ToolCombo->addItem("ezPlayer", "Player.exe");
+
+  ezProjectPreferencesUser* pPref = ezPreferences::QueryPreferences<ezProjectPreferencesUser>();
+
+  for (const auto& app : pPref->m_PlayerApps)
+  {
+    ezStringBuilder name = ezPathUtils::GetFileName(app);
+
+    ToolCombo->addItem(name.GetData(), QString::fromUtf8(app.GetData()));
+  }
+
+  ToolCombo->setCurrentIndex(s_iLastPlayerApp);
 }
 
 void ezQtExportAndRunDlg::PullFromUI()
 {
   s_bTransformAll = TransformAll->isChecked();
   s_bUpdateThumbnail = UpdateThumbnail->isChecked();
+  s_iLastPlayerApp = ToolCombo->currentIndex();
+
+  ezProjectPreferencesUser* pPref = ezPreferences::QueryPreferences<ezProjectPreferencesUser>();
+  pPref->m_PlayerApps.Clear();
+
+  for (int i = 1; i < ToolCombo->count(); ++i)
+  {
+    ezStringBuilder path = ToolCombo->itemData(i).toString().toUtf8().data();
+    path.MakeCleanPath();
+
+    pPref->m_PlayerApps.PushBack(path);
+  }
 }
 
 void ezQtExportAndRunDlg::showEvent(QShowEvent* e)
@@ -38,5 +69,38 @@ void ezQtExportAndRunDlg::on_ExportAndRun_clicked()
 {
   PullFromUI();
   m_bRunAfterExport = true;
+  m_sApplication = ToolCombo->currentData().toString().toUtf8().data();
   accept();
+}
+
+void ezQtExportAndRunDlg::on_AddToolButton_clicked()
+{
+  ezStringBuilder appDir = ezOSFile::GetApplicationDirectory();
+  appDir.MakeCleanPath();
+  static QString sLastPath = appDir.GetData();
+
+  const QString sFile = QFileDialog::getOpenFileName(this, "Select Program", sLastPath, "Applicaation (*.exe)", nullptr, QFileDialog::Option::DontResolveSymlinks);
+
+  if (sFile.isEmpty())
+    return;
+
+  sLastPath = sFile;
+
+  ezStringBuilder path = sFile.toUtf8().data();
+  path.MakeCleanPath();
+  path.TrimWordStart(appDir, "/");
+
+  ezStringBuilder tmp;
+  ToolCombo->addItem(QString::fromUtf8(path.GetFileName().GetData(tmp)), QString::fromUtf8(path.GetData()));
+  ToolCombo->setCurrentIndex(ToolCombo->count() - 1);
+}
+
+void ezQtExportAndRunDlg::on_RemoveToolButton_clicked()
+{
+  ToolCombo->removeItem(ToolCombo->currentIndex());
+}
+
+void ezQtExportAndRunDlg::on_ToolCombo_currentIndexChanged(int idx)
+{
+  RemoveToolButton->setEnabled(idx != 0);
 }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.moc.h
@@ -4,6 +4,8 @@
 #include <EditorPluginScene/ui_ExportAndRunDlg.h>
 #include <QDialog>
 
+class ezSceneDocument;
+
 class ezQtExportAndRunDlg : public QDialog, public Ui_ExportAndRunDlg
 {
   Q_OBJECT
@@ -16,10 +18,14 @@ public:
   bool m_bRunAfterExport = false;
   bool m_bShowThumbnailCheckbox = true;
   ezString m_sCmdLine;
+  ezString m_sApplication;
 
 private Q_SLOTS:
   void on_ExportOnly_clicked();
   void on_ExportAndRun_clicked();
+  void on_AddToolButton_clicked();
+  void on_RemoveToolButton_clicked();
+  void on_ToolCombo_currentIndexChanged(int);
 
 private:
   void PullFromUI();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.ui
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>389</width>
-    <height>193</height>
+    <width>351</width>
+    <height>183</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -58,9 +58,65 @@
     </spacer>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Launch:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QComboBox" name="ToolCombo">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="AddToolButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+         <normaloff>:/GuiFoundation/Icons/Add16.png</normaloff>:/GuiFoundation/Icons/Add16.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="RemoveToolButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+         <normaloff>:/GuiFoundation/Icons/Delete16.png</normaloff>:/GuiFoundation/Icons/Delete16.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Player.exe Command Line:</string>
+      <string>Command Line:</string>
      </property>
     </widget>
    </item>
@@ -94,22 +150,6 @@
       <string/>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
In the scene export dialog you can now add custom apps (like your own game exe).
The path is saved as a per-project preference, so it will be available next time and every project has a different set of player apps.

![image](https://user-images.githubusercontent.com/6001174/147793655-8bfbf4b2-d8ac-44ba-914d-c420dee92de6.png)

All external apps get the same command line (as shown in the dialog). For now there is no way to configure the command line, since this is probably not needed anyway.

Fixes #471