### PR TITLE
Vulkan Resource Binding Support

### DIFF
--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -282,6 +282,7 @@ struct ezGALResourceViewCreationDescription : public ezHashableStruct<ezGALResou
 
   ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
 
+  // Texture only
   ezUInt32 m_uiMostDetailedMipLevel = 0;
   ezUInt32 m_uiMipLevelsToUse = 0xFFFFFFFFu;
 

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -100,7 +100,7 @@ private:
 
 struct EZ_RENDERERFOUNDATION_DLL ezGALShaderStage
 {
-  enum Enum
+  enum Enum : ezUInt8
   {
     VertexShader,
     HullShader,

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -431,7 +431,7 @@ vk::Pipeline ezResourceCacheVulkan::RequestGraphicsPipeline(const GraphicsPipeli
       stage.pName = "main";
     }
   }
-  
+
   vk::GraphicsPipelineCreateInfo pipe;
   pipe.renderPass = desc.m_renderPass;
   pipe.layout = desc.m_layout;

--- a/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
+++ b/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
@@ -7,6 +7,7 @@
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Resources/RenderTargetViewVulkan.h>
+#include <RendererVulkan/Shader/ShaderVulkan.h>
 
 #include <vulkan/vulkan.hpp>
 
@@ -31,7 +32,7 @@ public:
   struct PipelineLayoutDesc
   {
     EZ_DECLARE_POD_TYPE();
-    int m_TODO = 0;
+    vk::DescriptorSetLayout m_layout;
   };
 
   struct GraphicsPipelineDesc
@@ -52,6 +53,13 @@ public:
 
   static vk::PipelineLayout RequestPipelineLayout(const PipelineLayoutDesc& desc);
   static vk::Pipeline RequestGraphicsPipeline(const GraphicsPipelineDesc& desc);
+
+  struct DescriptorSetLayoutDesc
+  {
+    mutable ezUInt32 m_uiHash = 0;
+    ezHybridArray<vk::DescriptorSetLayoutBinding, 6> m_bindings;
+  };
+  static vk::DescriptorSetLayout RequestDescriptorSetLayout(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc);
 
 private:
   struct FramebufferKey
@@ -109,6 +117,9 @@ private:
 
     static ezUInt32 Hash(const GraphicsPipelineDesc& desc);
     static bool Equal(const GraphicsPipelineDesc& a, const GraphicsPipelineDesc& b);
+
+    static ezUInt32 Hash(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc) { return desc.m_uiHash; }
+    static bool Equal(const ezGALShaderVulkan::DescriptorSetLayoutDesc& a, const ezGALShaderVulkan::DescriptorSetLayoutDesc& b);
   };
 
   struct FrameBufferCache
@@ -134,4 +145,5 @@ private:
 
   static ezHashTable<PipelineLayoutDesc, vk::PipelineLayout, ResourceCacheHash> s_pipelineLayouts;
   static ezHashTable<GraphicsPipelineDesc, vk::Pipeline, ResourceCacheHash> s_graphicsPipelines;
+  static ezHashTable<ezGALShaderVulkan::DescriptorSetLayoutDesc, vk::DescriptorSetLayout, ResourceCacheHash> s_descriptorSetLayouts;
 };

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -143,6 +143,7 @@ private:
   bool m_bRenderPassActive = false;
 
   // Bound objects for deferred state flushes
+  ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
   ezResourceCacheVulkan::GraphicsPipelineDesc m_PipelineDesc;
   vk::Framebuffer m_frameBuffer;
   vk::RenderPassBeginInfo m_renderPass;
@@ -151,23 +152,16 @@ private:
   vk::Viewport m_viewport;
   vk::Rect2D m_scissor;
 
-  const ezGALRenderTargetView* m_pBoundRenderTargets[EZ_GAL_MAX_RENDERTARGET_COUNT];
-  const ezGALRenderTargetView* m_pBoundDepthStencilTarget;
+  const ezGALRenderTargetView* m_pBoundRenderTargets[EZ_GAL_MAX_RENDERTARGET_COUNT] = {};
+  const ezGALRenderTargetView* m_pBoundDepthStencilTarget = nullptr;
   ezUInt32 m_uiBoundRenderTargetCount;
 
   const ezGALBufferVulkan* m_pIndexBuffer = nullptr;
   vk::Buffer m_pBoundVertexBuffers[EZ_GAL_MAX_VERTEX_BUFFER_COUNT];
   vk::DeviceSize m_VertexBufferOffsets[EZ_GAL_MAX_VERTEX_BUFFER_COUNT] = {};
 
-  const ezGALBufferVulkan* m_pBoundConstantBuffers[EZ_GAL_MAX_CONSTANT_BUFFER_COUNT];
-  ezGAL::ModifiedRange m_BoundConstantBuffersRange[ezGALShaderStage::ENUM_COUNT];
-
-  ezHybridArray<const ezGALResourceViewVulkan*, 16> m_pBoundShaderResourceViews[ezGALShaderStage::ENUM_COUNT];
-  ezGAL::ModifiedRange m_BoundShaderResourceViewsRange[ezGALShaderStage::ENUM_COUNT];
-
+  const ezGALBufferVulkan* m_pBoundConstantBuffers[EZ_GAL_MAX_CONSTANT_BUFFER_COUNT] = {};
+  ezHybridArray<const ezGALResourceViewVulkan*, 16> m_pBoundShaderResourceViews[ezGALShaderStage::ENUM_COUNT] = {};
   ezHybridArray<const ezGALUnorderedAccessViewVulkan*, 16> m_pBoundUnoderedAccessViews;
-  ezGAL::ModifiedRange m_pBoundUnoderedAccessViewsRange;
-
-  const ezGALSamplerStateVulkan* m_pBoundSamplerStates[ezGALShaderStage::ENUM_COUNT][EZ_GAL_MAX_SAMPLER_COUNT];
-  ezGAL::ModifiedRange m_BoundSamplerStatesRange[ezGALShaderStage::ENUM_COUNT];
+  const ezGALSamplerStateVulkan* m_pBoundSamplerStates[ezGALShaderStage::ENUM_COUNT][EZ_GAL_MAX_SAMPLER_COUNT] = {};
 };

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -700,12 +700,12 @@ void ezGALCommandEncoderImplVulkan::SetRasterizerStatePlatform(const ezGALRaster
 
 void ezGALCommandEncoderImplVulkan::SetViewportPlatform(const ezRectFloat& rect, float fMinDepth, float fMaxDepth)
 {
-  // We use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a nagative height performs y-inversion of the clip-space to framebuffer-space transform.
+  // We use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a negative height performs y-inversion of the clip-space to framebuffer-space transform.
   // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance1.html
   vk::Viewport viewport = {rect.x, rect.height + rect.y, rect.width, -rect.height, fMinDepth, fMaxDepth};
   if (m_viewport != viewport)
   {
-    // viewport is marked as dynamic in the pipeline layout and thus does not mark m_bPipelineStateDirty.
+    // Viewport is marked as dynamic in the pipeline layout and thus does not mark m_bPipelineStateDirty.
     m_viewport = viewport;
     m_bViewportDirty = true;
   }

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -900,7 +900,7 @@ void ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
     m_bIndexBufferDirty = false;
   }
 
-  if (true/*m_bDescriptorsDirty*/)
+  if (true /*m_bDescriptorsDirty*/)
   {
     //#TODO_VULKAN we always create a new descriptor set as we don't know if a buffer was modified since the last draw call (ezGALBufferVulkan::DiscardBuffer).
     // Need to figure out a fast check if any buffer or buffer of a resource view was discarded.

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -3,6 +3,7 @@
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
 #include <RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/QueryVulkan.h>
 #include <RendererVulkan/Resources/RenderTargetViewVulkan.h>
@@ -31,6 +32,7 @@ void ezGALCommandEncoderImplVulkan::Reset()
   m_bDescriptorsDirty = true;
   m_BoundVertexBuffersRange.Reset();
 
+  m_LayoutDesc = {};
   m_PipelineDesc = {};
   m_frameBuffer = nullptr;
 
@@ -50,6 +52,18 @@ void ezGALCommandEncoderImplVulkan::Reset()
     m_pBoundVertexBuffers[i] = nullptr;
     m_VertexBufferOffsets[i] = 0;
   }
+
+  for (ezUInt32 i = 0; i < EZ_GAL_MAX_CONSTANT_BUFFER_COUNT; i++)
+  {
+    m_pBoundConstantBuffers[i] = nullptr;
+  }
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
+  {
+    m_pBoundShaderResourceViews[i].Clear();
+  }
+  m_pBoundUnoderedAccessViews.Clear();
+
+  ezMemoryUtils::ZeroFill(&m_pBoundSamplerStates[0][0], ezGALShaderStage::ENUM_COUNT * EZ_GAL_MAX_SAMPLER_COUNT);
 
   m_renderPass = vk::RenderPassBeginInfo();
   m_clearValues.Clear();
@@ -86,11 +100,6 @@ void ezGALCommandEncoderImplVulkan::SetConstantBufferPlatform(ezUInt32 uiSlot, c
 {
   // \todo Check if the device supports the slot index?
   m_pBoundConstantBuffers[uiSlot] = pBuffer != nullptr ? static_cast<const ezGALBufferVulkan*>(pBuffer) : nullptr;
-
-  // The GAL doesn't care about stages for constant buffer, but we need to handle this internally.
-  for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
-    m_BoundConstantBuffersRange[stage].SetToIncludeValue(uiSlot);
-
   m_bDescriptorsDirty = true;
 }
 
@@ -98,8 +107,6 @@ void ezGALCommandEncoderImplVulkan::SetSamplerStatePlatform(ezGALShaderStage::En
 {
   // \todo Check if the device supports the stage / the slot index
   m_pBoundSamplerStates[Stage][uiSlot] = pSamplerState != nullptr ? static_cast<const ezGALSamplerStateVulkan*>(pSamplerState) : nullptr;
-  m_BoundSamplerStatesRange[Stage].SetToIncludeValue(uiSlot);
-
   m_bDescriptorsDirty = true;
 }
 
@@ -108,8 +115,6 @@ void ezGALCommandEncoderImplVulkan::SetResourceViewPlatform(ezGALShaderStage::En
   auto& boundShaderResourceViews = m_pBoundShaderResourceViews[Stage];
   boundShaderResourceViews.EnsureCount(uiSlot + 1);
   boundShaderResourceViews[uiSlot] = pResourceView != nullptr ? static_cast<const ezGALResourceViewVulkan*>(pResourceView) : nullptr;
-  m_BoundShaderResourceViewsRange[Stage].SetToIncludeValue(uiSlot);
-
   m_bDescriptorsDirty = true;
 }
 
@@ -117,8 +122,6 @@ void ezGALCommandEncoderImplVulkan::SetUnorderedAccessViewPlatform(ezUInt32 uiSl
 {
   m_pBoundUnoderedAccessViews.EnsureCount(uiSlot + 1);
   m_pBoundUnoderedAccessViews[uiSlot] = pUnorderedAccessView != nullptr ? static_cast<const ezGALUnorderedAccessViewVulkan*>(pUnorderedAccessView) : nullptr;
-  m_pBoundUnoderedAccessViewsRange.SetToIncludeValue(uiSlot);
-
   m_bDescriptorsDirty = true;
 }
 
@@ -200,64 +203,40 @@ void ezGALCommandEncoderImplVulkan::CopyBufferRegionPlatform(const ezGALBuffer* 
   bufferCopy.size = uiByteCount;
 
   m_pCommandBuffer->copyBuffer(source, destination, 1, &bufferCopy);
+  //#TODO_VULKAN memory barrier needed here?
 }
 
 void ezGALCommandEncoderImplVulkan::UpdateBufferPlatform(const ezGALBuffer* pDestination, ezUInt32 uiDestOffset, ezArrayPtr<const ezUInt8> pSourceData,
   ezGALUpdateMode::Enum updateMode)
 {
-  EZ_ASSERT_DEBUG(!m_bRenderPassActive, "Vulkan does not support updating buffers while a render pass is active. TODO: Fix high level render code to make this impossible.");
-
   EZ_CHECK_ALIGNMENT_16(pSourceData.GetPtr());
 
   auto pVulkanDestination = static_cast<const ezGALBufferVulkan*>(pDestination);
 
-  if (pDestination->GetDescription().m_BufferType == ezGALBufferType::ConstantBuffer)
+  switch (updateMode)
   {
-    m_pCommandBuffer->updateBuffer(pVulkanDestination->GetVkBuffer(), uiDestOffset, pSourceData.GetCount(), pSourceData.GetPtr());
-  }
-  else
-  {
-    if (updateMode == ezGALUpdateMode::CopyToTempStorage)
+    case ezGALUpdateMode::Discard:
+      pVulkanDestination->DiscardBuffer();
+      [[fallthrough]];
+    case ezGALUpdateMode::NoOverwrite:
     {
-      if (ezGALBufferVulkan* tmpBuffer = m_GALDeviceVulkan.FindTempBuffer(pSourceData.GetCount()))
-      {
-        EZ_ASSERT_DEV(tmpBuffer->GetAllocationInfo().m_size >= pSourceData.GetCount(), "Source data is too big to copy staged!");
-
-        ezVulkanAllocation alloc = tmpBuffer->GetAllocation();
-        void* pData = nullptr;
-
-        VK_ASSERT_DEV(ezMemoryAllocatorVulkan::MapMemory(alloc, &pData));
-        EZ_ASSERT_DEV(pData, "Implementation error");
-
-        ezMemoryUtils::Copy((ezUInt8*)pData, pSourceData.GetPtr(), pSourceData.GetCount());
-
-        ezMemoryAllocatorVulkan::UnmapMemory(alloc);
-
-        CopyBufferRegionPlatform(pDestination, uiDestOffset, tmpBuffer, 0, pSourceData.GetCount());
-      }
-      else
-      {
-        EZ_REPORT_FAILURE("Could not find a temp buffer for update.");
-      }
-    }
-    else
-    {
-      // TODO need to check if the buffer is mappable
-
-      // TODO is this behavior available on Vulkan?
-      //D3D11_MAP mapType = (updateMode == ezGALUpdateMode::Discard) ? D3D11_MAP_WRITE_DISCARD : D3D11_MAP_WRITE_NO_OVERWRITE;
-
-      EZ_ASSERT_DEV(pVulkanDestination->GetAllocationInfo().m_size >= pSourceData.GetCount(), "Source data is too big to copy staged!");
       ezVulkanAllocation alloc = pVulkanDestination->GetAllocation();
       void* pData = nullptr;
-
       VK_ASSERT_DEV(ezMemoryAllocatorVulkan::MapMemory(alloc, &pData));
       EZ_ASSERT_DEV(pData, "Implementation error");
-
       ezMemoryUtils::Copy((ezUInt8*)pData, pSourceData.GetPtr(), pSourceData.GetCount());
-
       ezMemoryAllocatorVulkan::UnmapMemory(alloc);
     }
+    break;
+    case ezGALUpdateMode::CopyToTempStorage:
+    {
+      EZ_ASSERT_DEBUG(!m_bRenderPassActive, "Vulkan does not support copying buffers while a render pass is active. TODO: Fix high level render code to make this impossible.");
+
+      m_GALDeviceVulkan.UploadBufferStaging(pVulkanDestination, pSourceData, uiDestOffset);
+    }
+    break;
+    default:
+      break;
   }
 }
 
@@ -345,12 +324,13 @@ void ezGALCommandEncoderImplVulkan::CopyTextureRegionPlatform(const ezGALTexture
 void ezGALCommandEncoderImplVulkan::UpdateTexturePlatform(const ezGALTexture* pDestination, const ezGALTextureSubresource& DestinationSubResource,
   const ezBoundingBoxu32& DestinationBox, const ezGALSystemMemoryDescription& pSourceData)
 {
+  //#TODO_VULKAN texture implementation missing.
   ezUInt32 uiWidth = ezMath::Max(DestinationBox.m_vMax.x - DestinationBox.m_vMin.x, 1u);
   ezUInt32 uiHeight = ezMath::Max(DestinationBox.m_vMax.y - DestinationBox.m_vMin.y, 1u);
   ezUInt32 uiDepth = ezMath::Max(DestinationBox.m_vMax.z - DestinationBox.m_vMin.z, 1u);
   ezGALResourceFormat::Enum format = pDestination->GetDescription().m_Format;
 
-  if (ezGALTextureVulkan* pTempTexture = m_GALDeviceVulkan.FindTempTexture(uiWidth, uiHeight, uiDepth, format))
+  if (ezGALTextureVulkan* pTempTexture = nullptr)
   {
     ezVulkanAllocation alloc = pTempTexture->GetAllocation();
     void* pData = nullptr;
@@ -720,7 +700,9 @@ void ezGALCommandEncoderImplVulkan::SetRasterizerStatePlatform(const ezGALRaster
 
 void ezGALCommandEncoderImplVulkan::SetViewportPlatform(const ezRectFloat& rect, float fMinDepth, float fMaxDepth)
 {
-  vk::Viewport viewport = {rect.x, rect.y, rect.width, rect.height, fMinDepth, fMaxDepth};
+  // We use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a nagative height performs y-inversion of the clip-space to framebuffer-space transform.
+  // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance1.html
+  vk::Viewport viewport = {rect.x, rect.height + rect.y, rect.width, -rect.height, fMinDepth, fMaxDepth};
   if (m_viewport != viewport)
   {
     // viewport is marked as dynamic in the pipeline layout and thus does not mark m_bPipelineStateDirty.
@@ -867,13 +849,16 @@ void ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
 
   if (m_bPipelineStateDirty)
   {
-    ezResourceCacheVulkan::PipelineLayoutDesc desc;
-    m_PipelineDesc.m_layout = ezResourceCacheVulkan::RequestPipelineLayout(desc);
+    const ezGALShaderVulkan::DescriptorSetLayoutDesc& descriptorLayoutDesc = m_PipelineDesc.m_pCurrentShader->GetDescriptorSetLayout();
 
+    m_LayoutDesc.m_layout = ezResourceCacheVulkan::RequestDescriptorSetLayout(descriptorLayoutDesc);
+    m_PipelineDesc.m_layout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
     vk::Pipeline pipeline = ezResourceCacheVulkan::RequestGraphicsPipeline(m_PipelineDesc);
 
     m_pCommandBuffer->bindPipeline(vk::PipelineBindPoint::eGraphics, pipeline);
     m_bPipelineStateDirty = false;
+    // Changes to the descriptor layout always require the descriptor set to be re-created.
+    m_bDescriptorsDirty = true;
   }
 
   if (m_bViewportDirty)
@@ -915,58 +900,72 @@ void ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
     m_bIndexBufferDirty = false;
   }
 
-#if 0
-  for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
+  if (true/*m_bDescriptorsDirty*/)
   {
-    if (m_pBoundShaders[stage] != nullptr && m_BoundConstantBuffersRange[stage].IsValid())
+    //#TODO_VULKAN we always create a new descriptor set as we don't know if a buffer was modified since the last draw call (ezGALBufferVulkan::DiscardBuffer).
+    // Need to figure out a fast check if any buffer or buffer of a resource view was discarded.
+    m_bDescriptorsDirty = false;
+
+    ezHybridArray<vk::WriteDescriptorSet, 16> descriptorWrites;
+    vk::DescriptorSet descriptorSet = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_LayoutDesc.m_layout);
+
+    ezArrayPtr<const ezGALShaderVulkan::BindingMapping> bindingMapping = m_PipelineDesc.m_pCurrentShader->GetBindingMapping();
+    const ezUInt32 uiCount = bindingMapping.GetCount();
+    for (ezUInt32 i = 0; i < uiCount; i++)
     {
-      const ezUInt32 uiStartSlot = m_BoundConstantBuffersRange[stage].m_uiMin;
-      const ezUInt32 uiNumSlots = m_BoundConstantBuffersRange[stage].GetCount();
-
-      SetConstantBuffers((ezGALShaderStage::Enum)stage, m_pDXContext, uiStartSlot, uiNumSlots, m_pBoundConstantBuffers + uiStartSlot);
-
-      m_BoundConstantBuffersRange[stage].Reset();
+      const ezGALShaderVulkan::BindingMapping& mapping = bindingMapping[i];
+      vk::WriteDescriptorSet& write = descriptorWrites.ExpandAndGetRef();
+      write.dstArrayElement = 0;
+      write.descriptorType = mapping.m_descriptorType;
+      write.dstBinding = mapping.m_uiTarget;
+      write.dstSet = descriptorSet;
+      write.descriptorCount = 1;
+      switch (mapping.m_type)
+      {
+        case ezGALShaderVulkan::BindingMapping::ConstantBuffer:
+        {
+          const ezGALBufferVulkan* pBuffer = m_pBoundConstantBuffers[mapping.m_uiSource];
+          write.pBufferInfo = &pBuffer->GetBufferInfo();
+        }
+        break;
+        case ezGALShaderVulkan::BindingMapping::ResourceView:
+        {
+          const ezGALResourceViewVulkan* pResourceView = m_pBoundShaderResourceViews[mapping.m_stage][mapping.m_uiSource];
+          if (!pResourceView->GetDescription().m_hTexture.IsInvalidated())
+          {
+            write.pImageInfo = &pResourceView->GetImageInfo();
+          }
+          else
+          {
+            write.pBufferInfo = &pResourceView->GetBufferInfo();
+          }
+        }
+        break;
+        case ezGALShaderVulkan::BindingMapping::UAV:
+        {
+          const ezGALUnorderedAccessViewVulkan* pUAV = m_pBoundUnoderedAccessViews[mapping.m_uiSource];
+          if (!pUAV->GetDescription().m_hTexture.IsInvalidated())
+          {
+            write.pImageInfo = &pUAV->GetImageInfo();
+          }
+          else
+          {
+            write.pBufferInfo = &pUAV->GetBufferInfo();
+          }
+        }
+        break;
+        case ezGALShaderVulkan::BindingMapping::Sampler:
+        {
+          const ezGALSamplerStateVulkan* pSampler = m_pBoundSamplerStates[mapping.m_stage][mapping.m_uiSource];
+          write.pImageInfo = &pSampler->GetImageInfo();
+        }
+        break;
+        default:
+          break;
+      }
     }
+
+    ezDescriptorSetPoolVulkan::UpdateDescriptorSet(descriptorSet, descriptorWrites);
+    m_pCommandBuffer->bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, 1, &descriptorSet, 0, nullptr);
   }
-
-  // Do UAV bindings before SRV since UAV are outputs which need to be unbound before they are potentially rebound as SRV again.
-  if (m_pBoundUnoderedAccessViewsRange.IsValid())
-  {
-    const ezUInt32 uiStartSlot = m_pBoundUnoderedAccessViewsRange.m_uiMin;
-    const ezUInt32 uiNumSlots = m_pBoundUnoderedAccessViewsRange.GetCount();
-    m_pDXContext->CSSetUnorderedAccessViews(uiStartSlot, uiNumSlots, m_pBoundUnoderedAccessViews.GetData() + uiStartSlot,
-      nullptr); // Todo: Count reset.
-
-    m_pBoundUnoderedAccessViewsRange.Reset();
-  }
-
-  for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
-  {
-    // Need to do bindings even on inactive shader stages since we might miss unbindings otherwise!
-    if (m_BoundShaderResourceViewsRange[stage].IsValid())
-    {
-      const ezUInt32 uiStartSlot = m_BoundShaderResourceViewsRange[stage].m_uiMin;
-      const ezUInt32 uiNumSlots = m_BoundShaderResourceViewsRange[stage].GetCount();
-
-      SetShaderResources((ezGALShaderStage::Enum)stage, m_pDXContext, uiStartSlot, uiNumSlots,
-        m_pBoundShaderResourceViews[stage].GetData() + uiStartSlot);
-
-      m_BoundShaderResourceViewsRange[stage].Reset();
-    }
-
-    // Don't need to unset sampler stages for unbound shader stages.
-    if (m_pBoundShaders[stage] == nullptr)
-      continue;
-
-    if (m_BoundSamplerStatesRange[stage].IsValid())
-    {
-      const ezUInt32 uiStartSlot = m_BoundSamplerStatesRange[stage].m_uiMin;
-      const ezUInt32 uiNumSlots = m_BoundSamplerStatesRange[stage].GetCount();
-
-      SetSamplers((ezGALShaderStage::Enum)stage, m_pDXContext, uiStartSlot, uiNumSlots, m_pBoundSamplerStates[stage] + uiStartSlot);
-
-      m_BoundSamplerStatesRange[stage].Reset();
-    }
-  }
-#endif
 }

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -61,7 +61,7 @@ public:
     ezUInt32 m_uiQueueIndex = 0;
   };
 
-  ezUInt64 GetCurrentFrame() const { return m_uiFrameCounter;}
+  ezUInt64 GetCurrentFrame() const { return m_uiFrameCounter; }
   ezUInt64 GetSafeFrame() const { return m_uiSafeFrame; }
 
   vk::Instance GetVulkanInstance() const;
@@ -122,7 +122,7 @@ public:
     {
       vk::DebugUtilsObjectNameInfoEXT nameInfo;
       nameInfo.objectType = object.objectType;
-      nameInfo.objectHandle = (uint64_t)static_cast<T::NativeType>(object);
+      nameInfo.objectHandle = (uint64_t) static_cast<T::NativeType>(object);
       nameInfo.pObjectName = szName;
 
       SetDebugName(nameInfo, allocation);

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -235,7 +235,7 @@ private:
 
   void FillFormatLookupTable();
 
-  ezUInt64 m_uiFrameCounter = 0;
+  ezUInt64 m_uiFrameCounter = 1; ///< We start at 1 so m_uiFrameCounter and m_uiSafeFrame are not equal at the start.
   ezUInt64 m_uiSafeFrame = 0;
   ezUInt8 m_uiCurrentPerFrameData = 0;
   ezUInt8 m_uiNextPerFrameData = 1;

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -105,9 +105,6 @@ EZ_END_SUBSYSTEM_DECLARATION;
 
 ezGALDeviceVulkan::ezGALDeviceVulkan(const ezGALDeviceCreationDescription& Description)
   : ezGALDevice(Description)
-  , m_device(nullptr)
-  //, m_pDebug(nullptr)
-  , m_uiFrameCounter(1)
 {
 }
 
@@ -377,7 +374,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   FillFormatLookupTable();
 
   ezClipSpaceDepthRange::Default = ezClipSpaceDepthRange::ZeroToOne;
-  // We use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a nagative height performs y-inversion of the clip-space to framebuffer-space transform.
+  // We use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a negative height performs y-inversion of the clip-space to framebuffer-space transform.
   // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance1.html
   ezClipSpaceYMode::RenderToTextureDefault = ezClipSpaceYMode::Regular;
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -11,6 +11,7 @@
 #include <RendererVulkan/Device/PassVulkan.h>
 #include <RendererVulkan/Device/SwapChainVulkan.h>
 #include <RendererVulkan/Pools/CommandBufferPoolVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Pools/FencePoolVulkan.h>
 #include <RendererVulkan/Pools/SemaphorePoolVulkan.h>
 #include <RendererVulkan/Pools/StagingBufferPoolVulkan.h>
@@ -106,7 +107,7 @@ ezGALDeviceVulkan::ezGALDeviceVulkan(const ezGALDeviceCreationDescription& Descr
   : ezGALDevice(Description)
   , m_device(nullptr)
   //, m_pDebug(nullptr)
-  , m_uiFrameCounter(0)
+  , m_uiFrameCounter(1)
 {
 }
 
@@ -131,8 +132,10 @@ vk::Result ezGALDeviceVulkan::SelectInstanceExtensions(ezHybridArray<const char*
   }
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result
+  {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop)
+      { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -167,8 +170,10 @@ vk::Result ezGALDeviceVulkan::SelectDeviceExtensions(ezHybridArray<const char*, 
   }
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result
+  {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop)
+      { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -193,8 +198,11 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   const char* layers[] = {"VK_LAYER_KHRONOS_validation"};
   {
     // Create instance
+    // We use Vulkan 1.1 because of two features:
+    // 1. Descriptor set pools return vk::Result::eErrorOutOfPoolMemory if exhaused. Removing the requirement to count usage yourself.
+    // 2. Viewport height can be negative which performs y-inversion of the clip-space to framebuffer-space transform.
     vk::ApplicationInfo applicationInfo = {};
-    applicationInfo.apiVersion = VK_API_VERSION_1_0;
+    applicationInfo.apiVersion = VK_API_VERSION_1_1;
     applicationInfo.applicationVersion = VK_MAKE_VERSION(1, 0, 0); // TODO put ezEngine version here
     applicationInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);      // TODO put ezEngine version here
     applicationInfo.pApplicationName = "ezEngine";
@@ -373,29 +381,9 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   FillFormatLookupTable();
 
   ezClipSpaceDepthRange::Default = ezClipSpaceDepthRange::ZeroToOne;
-  ezClipSpaceYMode::RenderToTextureDefault = ezClipSpaceYMode::Flipped;
-
-  // Per frame data & timer data
-  for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_PerFrameData); ++i)
-  {
-    auto& perFrameData = m_PerFrameData[i];
-
-    //if (FAILED(m_pDevice->CreateQuery(&disjointQueryDesc, &perFrameData.m_pDisjointTimerQuery)))
-    //{
-    //  ezLog::Error("Creation of native DirectX query for disjoint query has failed!");
-    //  return EZ_FAILURE;
-    //}
-  }
-
-  m_Timestamps.SetCountUninitialized(1024);
-  for (ezUInt32 i = 0; i < m_Timestamps.GetCount(); ++i)
-  {
-    //if (FAILED(m_pDevice->CreateQuery(&timerQueryDesc, &m_Timestamps[i])))
-    //{
-    //  ezLog::Error("Creation of native DirectX query for timestamp has failed!");
-    //  return EZ_FAILURE;
-    //}
-  }
+  // We use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a nagative height performs y-inversion of the clip-space to framebuffer-space transform.
+  // https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_KHR_maintenance1.html
+  ezClipSpaceYMode::RenderToTextureDefault = ezClipSpaceYMode::Regular;
 
   m_SyncTimeDiff.SetZero();
 
@@ -406,10 +394,19 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   ezFencePoolVulkan::Initialize(m_device);
   ezResourceCacheVulkan::Initialize(this, m_device);
   ezStagingBufferPoolVulkan::Initialize(m_device);
+  ezDescriptorSetPoolVulkan::Initialize(m_device);
 
-  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([this, &desc](ezAllocatorBase* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainVulkan, desc); }); });
+  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle
+    { return CreateSwapChain([this, &desc](ezAllocatorBase* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainVulkan, desc); }); });
 
   return EZ_SUCCESS;
+}
+
+void ezGALDeviceVulkan::SetDebugName(const vk::DebugUtilsObjectNameInfoEXT& info, ezVulkanAllocation allocation)
+{
+  m_device.setDebugUtilsObjectNameEXT(info);
+  if (allocation)
+    ezMemoryAllocatorVulkan::SetAllocationUserData(allocation, info.pObjectName);
 }
 
 void ezGALDeviceVulkan::ReportLiveGpuObjects()
@@ -417,7 +414,7 @@ void ezGALDeviceVulkan::ReportLiveGpuObjects()
   // This is automatically done in the validation layer and can't be easily done manually.
 }
 
-void ezGALDeviceVulkan::UploadBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> pInitialData)
+void ezGALDeviceVulkan::UploadBufferStaging(const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> pInitialData, vk::DeviceSize dstOffset)
 {
   void* pData = nullptr;
 
@@ -430,9 +427,10 @@ void ezGALDeviceVulkan::UploadBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPt
 
   vk::BufferCopy region;
   region.srcOffset = 0;
-  region.dstOffset = 0;
+  region.dstOffset = dstOffset;
   region.size = pInitialData.GetCount();
 
+  //#TODO_VULKAN atomic min size violation?
   GetCurrentCommandBuffer().copyBuffer(stagingBuffer.m_buffer, pBuffer->GetVkBuffer(), 1, &region);
 
 
@@ -442,7 +440,7 @@ void ezGALDeviceVulkan::UploadBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPt
   buffer_mem_barrier.srcAccessMask = vk::AccessFlagBits::eTransferWrite;
   buffer_mem_barrier.dstAccessMask = pBuffer->GetAccessMask();
   buffer_mem_barrier.buffer = pBuffer->GetVkBuffer();
-  buffer_mem_barrier.offset = 0;
+  buffer_mem_barrier.offset = region.dstOffset;
   buffer_mem_barrier.size = region.size;
 
   GetCurrentCommandBuffer().pipelineBarrier(vk::PipelineStageFlagBits::eTransfer, pBuffer->GetUsedByPipelineStage(), vk::DependencyFlags(), 0, nullptr, 1, &buffer_mem_barrier, 0, nullptr);
@@ -458,6 +456,7 @@ ezResult ezGALDeviceVulkan::ShutdownPlatform()
     ReclaimLater(m_lastCommandBufferFinished);
   auto& pCommandEncoder = m_pDefaultPass->m_pCommandEncoderImpl;
 
+  m_device.waitIdle();
   for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_PerFrameData); ++i)
   {
     // First, we wait for all fences for all submit calls. This is necessary to make sure no resources of the frame are still in use by the GPU.
@@ -477,52 +476,22 @@ ezResult ezGALDeviceVulkan::ShutdownPlatform()
   {
     {
       EZ_LOCK(m_PerFrameData[i].m_pendingDeletionsMutex);
+      DeletePendingResources(m_PerFrameData[i].m_pendingDeletionsPrevious);
       DeletePendingResources(m_PerFrameData[i].m_pendingDeletions);
     }
     {
       EZ_LOCK(m_PerFrameData[i].m_reclaimResourcesMutex);
+      ReclaimResources(m_PerFrameData[i].m_reclaimResourcesPrevious);
       ReclaimResources(m_PerFrameData[i].m_reclaimResources);
     }
   }
 
+  ezDescriptorSetPoolVulkan::DeInitialize();
   ezStagingBufferPoolVulkan::DeInitialize();
   ezResourceCacheVulkan::DeInitialize();
   ezCommandBufferPoolVulkan::DeInitialize();
   ezSemaphorePoolVulkan::DeInitialize();
   ezFencePoolVulkan::DeInitialize();
-
-
-  for (ezUInt32 type = 0; type < TempResourceType::ENUM_COUNT; ++type)
-  {
-    for (auto it = m_FreeTempResources[type].GetIterator(); it.IsValid(); ++it)
-    {
-      ezDynamicArray<VkResource*>& resources = it.Value();
-      for (auto pResource : resources)
-      {
-        EZ_GAL_VULKAN_RELEASE(pResource);
-      }
-    }
-    m_FreeTempResources[type].Clear();
-
-    for (auto& tempResource : m_UsedTempResources[type])
-    {
-      EZ_GAL_VULKAN_RELEASE(tempResource.m_pResource);
-    }
-    m_UsedTempResources[type].Clear();
-  }
-
-  for (auto& timestamp : m_Timestamps)
-  {
-    EZ_GAL_VULKAN_RELEASE(timestamp);
-  }
-  m_Timestamps.Clear();
-
-  for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_PerFrameData); ++i)
-  {
-    auto& perFrameData = m_PerFrameData[i];
-
-    //EZ_GAL_VULKAN_RELEASE(perFrameData.m_pDisjointTimerQuery);
-  }
 
   m_pDefaultPass = nullptr;
 
@@ -910,9 +879,8 @@ void ezGALDeviceVulkan::DestroyVertexDeclarationPlatform(ezGALVertexDeclaration*
 
 ezGALTimestampHandle ezGALDeviceVulkan::GetTimestampPlatform()
 {
-  ezUInt32 uiIndex = m_uiNextTimestamp;
-  m_uiNextTimestamp = (m_uiNextTimestamp + 1) % m_Timestamps.GetCount();
-  return {uiIndex, m_uiFrameCounter};
+  EZ_ASSERT_NOT_IMPLEMENTED;
+  return ezGALTimestampHandle();
 }
 
 ezResult ezGALDeviceVulkan::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& result)
@@ -978,12 +946,13 @@ void ezGALDeviceVulkan::BeginFramePlatform(const ezUInt64 uiRenderFrame)
 
     {
       EZ_LOCK(m_PerFrameData[m_uiCurrentPerFrameData].m_pendingDeletionsMutex);
-      DeletePendingResources(m_PerFrameData[m_uiCurrentPerFrameData].m_pendingDeletions);
+      DeletePendingResources(m_PerFrameData[m_uiCurrentPerFrameData].m_pendingDeletionsPrevious);
     }
     {
       EZ_LOCK(m_PerFrameData[m_uiCurrentPerFrameData].m_reclaimResourcesMutex);
-      ReclaimResources(m_PerFrameData[m_uiCurrentPerFrameData].m_reclaimResources);
+      ReclaimResources(m_PerFrameData[m_uiCurrentPerFrameData].m_reclaimResourcesPrevious);
     }
+    m_uiSafeFrame = m_PerFrameData[m_uiCurrentPerFrameData].m_uiFrame;
   }
   {
     auto& perFrameData = m_PerFrameData[m_uiNextPerFrameData];
@@ -1049,10 +1018,21 @@ void ezGALDeviceVulkan::EndFramePlatform()
     }
   }
 */
+  {
+    // Resources can be added to deletion / reclaim outside of the render frame. These will not be covered by the fences. To handle this, we swap the resources arrays so for any newly added resources we know they are not part of the batch that is deleted / reclaimed with the frame.
+    auto& currentFrameData = m_PerFrameData[m_uiCurrentPerFrameData];
+    {
+      EZ_LOCK(currentFrameData.m_pendingDeletionsMutex);
+      currentFrameData.m_pendingDeletionsPrevious.Swap(currentFrameData.m_pendingDeletions);
+    }
+    {
+      EZ_LOCK(currentFrameData.m_reclaimResourcesMutex);
+      currentFrameData.m_reclaimResourcesPrevious.Swap(currentFrameData.m_reclaimResources);
+    }
+  }
   m_uiCurrentPerFrameData = (m_uiCurrentPerFrameData + 1) % EZ_ARRAY_SIZE(m_PerFrameData);
   m_uiNextPerFrameData = (m_uiCurrentPerFrameData + 1) % EZ_ARRAY_SIZE(m_PerFrameData);
   ++m_uiFrameCounter;
-  m_PerFrameData[m_uiNextPerFrameData].m_uiFrame = m_uiFrameCounter;
 }
 
 void ezGALDeviceVulkan::FillCapabilitiesPlatform()
@@ -1110,120 +1090,6 @@ void ezGALDeviceVulkan::FillCapabilitiesPlatform()
 
   m_Capabilities.m_bConservativeRasterization = false; // need to query for VK_EXT_CONSERVATIVE_RASTERIZATION
 }
-
-#if 0
-
-vk::Buffer ezGALDeviceVulkan::FindTempBuffer(ezUInt32 uiSize)
-{
-  const ezUInt32 uiExpGrowthLimit = 16 * 1024 * 1024;
-
-  uiSize = ezMath::Max(uiSize, 256U);
-  if (uiSize < uiExpGrowthLimit)
-  {
-    uiSize = ezMath::PowerOfTwo_Ceil(uiSize);
-  }
-  else
-  {
-    uiSize = ezMemoryUtils::AlignSize(uiSize, uiExpGrowthLimit);
-  }
-
-  ID3D11Resource* pResource = nullptr;
-  auto it = m_FreeTempResources[TempResourceType::Buffer].Find(uiSize);
-  if (it.IsValid())
-  {
-    ezDynamicArray<ID3D11Resource*>& resources = it.Value();
-    if (!resources.IsEmpty())
-    {
-      pResource = resources[0];
-      resources.RemoveAtAndSwap(0);
-    }
-  }
-
-  if (pResource == nullptr)
-  {
-    D3D11_BUFFER_DESC desc;
-    desc.ByteWidth = uiSize;
-    desc.Usage = D3D11_USAGE_STAGING;
-    desc.BindFlags = 0;
-    desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-    desc.MiscFlags = 0;
-    desc.StructureByteStride = 0;
-
-    ID3D11Buffer* pBuffer = nullptr;
-    if (!SUCCEEDED(m_pDevice->CreateBuffer(&desc, nullptr, &pBuffer)))
-    {
-      return nullptr;
-    }
-
-    pResource = pBuffer;
-  }
-
-  auto& tempResource = m_UsedTempResources[TempResourceType::Buffer].ExpandAndGetRef();
-  tempResource.m_pResource = pResource;
-  tempResource.m_uiFrame = m_uiFrameCounter;
-  tempResource.m_uiHash = uiSize;
-
-  return pResource;
-}
-
-ID3D11Resource* ezGALDeviceVulkan::FindTempTexture(ezUInt32 uiWidth, ezUInt32 uiHeight, ezUInt32 uiDepth, ezGALResourceFormat::Enum format)
-{
-  ezUInt32 data[] = {uiWidth, uiHeight, uiDepth, (ezUInt32)format};
-  ezUInt32 uiHash = ezHashingUtils::xxHash32(data, sizeof(data));
-
-  ID3D11Resource* pResource = nullptr;
-  auto it = m_FreeTempResources[TempResourceType::Texture].Find(uiHash);
-  if (it.IsValid())
-  {
-    ezDynamicArray<ID3D11Resource*>& resources = it.Value();
-    if (!resources.IsEmpty())
-    {
-      pResource = resources[0];
-      resources.RemoveAtAndSwap(0);
-    }
-  }
-
-  if (pResource == nullptr)
-  {
-    if (uiDepth == 1)
-    {
-      D3D11_TEXTURE2D_DESC desc;
-      desc.Width = uiWidth;
-      desc.Height = uiHeight;
-      desc.MipLevels = 1;
-      desc.ArraySize = 1;
-      desc.Format = GetFormatLookupTable().GetFormatInfo(format).m_eStorage;
-      desc.SampleDesc.Count = 1;
-      desc.SampleDesc.Quality = 0;
-      desc.Usage = D3D11_USAGE_STAGING;
-      desc.BindFlags = 0;
-      desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-      desc.MiscFlags = 0;
-
-      ID3D11Texture2D* pTexture = nullptr;
-      if (!SUCCEEDED(m_pDevice->CreateTexture2D(&desc, nullptr, &pTexture)))
-      {
-        return nullptr;
-      }
-
-      pResource = pTexture;
-    }
-    else
-    {
-      EZ_ASSERT_NOT_IMPLEMENTED;
-      return nullptr;
-    }
-  }
-
-  auto& tempResource = m_UsedTempResources[TempResourceType::Texture].ExpandAndGetRef();
-  tempResource.m_pResource = pResource;
-  tempResource.m_uiFrame = m_uiFrameCounter;
-  tempResource.m_uiHash = uiHash;
-
-  return pResource;
-}
-
-#endif
 
 vk::PipelineStageFlags ezGALDeviceVulkan::GetSupportedStages() const
 {
@@ -1314,38 +1180,15 @@ void ezGALDeviceVulkan::ReclaimResources(ezDeque<ReclaimResource>& resources)
       case vk::ObjectType::eCommandBuffer:
         ezCommandBufferPoolVulkan::ReclaimCommandBuffer(reinterpret_cast<vk::CommandBuffer&>(resource.m_pObject));
         break;
+      case vk::ObjectType::eDescriptorPool:
+        ezDescriptorSetPoolVulkan::ReclaimPool(reinterpret_cast<vk::DescriptorPool&>(resource.m_pObject));
+        break;
       default:
         EZ_REPORT_FAILURE("This object type is not implemented");
         break;
     }
   }
   resources.Clear();
-}
-
-void ezGALDeviceVulkan::FreeTempResources(ezUInt64 uiFrame)
-{
-  for (ezUInt32 type = 0; type < TempResourceType::ENUM_COUNT; ++type)
-  {
-    while (!m_UsedTempResources[type].IsEmpty())
-    {
-      auto& usedTempResource = m_UsedTempResources[type].PeekFront();
-      if (usedTempResource.m_uiFrame == uiFrame)
-      {
-        auto it = m_FreeTempResources[type].Find(usedTempResource.m_uiHash);
-        if (!it.IsValid())
-        {
-          it = m_FreeTempResources[type].Insert(usedTempResource.m_uiHash, ezDynamicArray<VkResource*>(&m_Allocator));
-        }
-
-        it.Value().PushBack(usedTempResource.m_pResource);
-        m_UsedTempResources[type].PopFront();
-      }
-      else
-      {
-        break;
-      }
-    }
-  }
 }
 
 void ezGALDeviceVulkan::FillFormatLookupTable()
@@ -1552,7 +1395,8 @@ void ezGALDeviceVulkan::FillFormatLookupTable()
   m_FormatLookupTable.SetFormatInfo(ezGALResourceFormat::AUByteNormalized,
     ezGALFormatLookupEntryVulkan(vk::Format::eR8Unorm).RT(vk::Format::eR8Unorm).VA(vk::Format::eR8Unorm).RV(vk::Format::eR8Unorm));
 
-  auto SelectDepthFormat = [&](const std::vector<vk::Format>& list) -> vk::Format {
+  auto SelectDepthFormat = [&](const std::vector<vk::Format>& list) -> vk::Format
+  {
     for (auto& format : list)
     {
       vk::FormatProperties formatProperties;

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -132,10 +132,8 @@ vk::Result ezGALDeviceVulkan::SelectInstanceExtensions(ezHybridArray<const char*
   }
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result
-  {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop)
-      { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -170,10 +168,8 @@ vk::Result ezGALDeviceVulkan::SelectDeviceExtensions(ezHybridArray<const char*, 
   }
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result
-  {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop)
-      { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -396,8 +392,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   ezStagingBufferPoolVulkan::Initialize(m_device);
   ezDescriptorSetPoolVulkan::Initialize(m_device);
 
-  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle
-    { return CreateSwapChain([this, &desc](ezAllocatorBase* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainVulkan, desc); }); });
+  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([this, &desc](ezAllocatorBase* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainVulkan, desc); }); });
 
   return EZ_SUCCESS;
 }
@@ -1395,8 +1390,7 @@ void ezGALDeviceVulkan::FillFormatLookupTable()
   m_FormatLookupTable.SetFormatInfo(ezGALResourceFormat::AUByteNormalized,
     ezGALFormatLookupEntryVulkan(vk::Format::eR8Unorm).RT(vk::Format::eR8Unorm).VA(vk::Format::eR8Unorm).RV(vk::Format::eR8Unorm));
 
-  auto SelectDepthFormat = [&](const std::vector<vk::Format>& list) -> vk::Format
-  {
+  auto SelectDepthFormat = [&](const std::vector<vk::Format>& list) -> vk::Format {
     for (auto& format : list)
     {
       vk::FormatProperties formatProperties;

--- a/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
@@ -11,7 +11,7 @@ VKAPI_ATTR void VKAPI_CALL vkGetDeviceBufferMemoryRequirements(
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 
-#define VMA_VULKAN_VERSION 1000000
+#define VMA_VULKAN_VERSION 1001000
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
 #define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
 #define VMA_STATS_STRING_ENABLED 1
@@ -66,7 +66,7 @@ vk::Result ezMemoryAllocatorVulkan::Initialize(vk::PhysicalDevice physicalDevice
   vulkanFunctions.vkGetDeviceProcAddr = &vkGetDeviceProcAddr;
 
   VmaAllocatorCreateInfo allocatorCreateInfo = {};
-  allocatorCreateInfo.vulkanApiVersion = VK_API_VERSION_1_0;
+  allocatorCreateInfo.vulkanApiVersion = VK_API_VERSION_1_1;
   allocatorCreateInfo.physicalDevice = physicalDevice;
   allocatorCreateInfo.device = device;
   allocatorCreateInfo.instance = instance;

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <RendererVulkan/RendererVulkanDLL.h>
+
+#include <vulkan/vulkan.hpp>
+
+EZ_DEFINE_AS_POD_TYPE(vk::DescriptorType);
+
+template <>
+struct ezHashHelper<vk::DescriptorType>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(vk::DescriptorType value) { return ezHashHelper<ezUInt32>::Hash(ezUInt32(value)); }
+  EZ_ALWAYS_INLINE static bool Equal(vk::DescriptorType a, vk::DescriptorType b) { return a == b; }
+};
+
+class EZ_RENDERERVULKAN_DLL ezDescriptorSetPoolVulkan
+{
+public:
+  static void Initialize(vk::Device device);
+  static void DeInitialize();
+  static ezHashTable<vk::DescriptorType, float>& AccessDescriptorPoolWeights();
+
+  static vk::DescriptorSet CreateDescriptorSet(vk::DescriptorSetLayout layout);
+  static void UpdateDescriptorSet(vk::DescriptorSet descriptorSet, ezArrayPtr<vk::WriteDescriptorSet> update);
+  static void ReclaimPool(vk::DescriptorPool& descriptorPool);
+
+private:
+  static vk::DescriptorPool GetNewPool();
+
+  static vk::DescriptorPool s_currentPool;
+  static ezHybridArray<vk::DescriptorPool, 4> s_freePools;
+  static vk::Device s_device;
+  static ezHashTable<vk::DescriptorType, float> s_descriptorWeights;
+};

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -25,6 +25,8 @@ public:
   static void ReclaimPool(vk::DescriptorPool& descriptorPool);
 
 private:
+  static constexpr ezUInt32 s_uiPoolBaseSize = 1024;
+
   static vk::DescriptorPool GetNewPool();
 
   static vk::DescriptorPool s_currentPool;

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -118,12 +118,12 @@ vk::DescriptorPool ezDescriptorSetPoolVulkan::GetNewPool()
     ezHybridArray<vk::DescriptorPoolSize, 20> poolSizes;
     for (auto weight : s_descriptorWeights)
     {
-      if (static_cast<ezUInt32>(weight.Value() * 1000) > 0)
-        poolSizes.PushBack(vk::DescriptorPoolSize(weight.Key(), static_cast<ezUInt32>(weight.Value() * 1000)));
+      if (static_cast<ezUInt32>(weight.Value() * s_uiPoolBaseSize) > 0)
+        poolSizes.PushBack(vk::DescriptorPoolSize(weight.Key(), static_cast<ezUInt32>(weight.Value() * s_uiPoolBaseSize)));
     }
     vk::DescriptorPoolCreateInfo poolCreateInfo;
     poolCreateInfo.flags = {};
-    poolCreateInfo.maxSets = 1000;
+    poolCreateInfo.maxSets = s_uiPoolBaseSize;
     poolCreateInfo.poolSizeCount = poolSizes.GetCount();
     poolCreateInfo.pPoolSizes = poolSizes.GetData();
 

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -25,7 +25,7 @@ void ezDescriptorSetPoolVulkan::Initialize(vk::Device device)
   s_descriptorWeights[vk::DescriptorType::eStorageBufferDynamic] = 0.0f; // Same as eStorageBuffer but allows updating the memory offset into the buffer dynamically.
 
   // Not supported by EZ so far.
-  s_descriptorWeights[vk::DescriptorType::eInputAttachment] = 0.0f;      //frame-buffer local read-only image view.
+  s_descriptorWeights[vk::DescriptorType::eInputAttachment] = 0.0f; //frame-buffer local read-only image view.
   s_descriptorWeights[vk::DescriptorType::eCombinedImageSampler] = 0.0f;
   s_descriptorWeights[vk::DescriptorType::eInlineUniformBlock] = 0.0f;
   s_descriptorWeights[vk::DescriptorType::eAccelerationStructureKHR] = 0.0f;

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -1,0 +1,140 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
+
+
+vk::DescriptorPool ezDescriptorSetPoolVulkan::s_currentPool;
+ezHybridArray<vk::DescriptorPool, 4> ezDescriptorSetPoolVulkan::s_freePools;
+vk::Device ezDescriptorSetPoolVulkan::s_device;
+ezHashTable<vk::DescriptorType, float> ezDescriptorSetPoolVulkan::s_descriptorWeights;
+
+void ezDescriptorSetPoolVulkan::Initialize(vk::Device device)
+{
+  s_device = device;
+  s_descriptorWeights[vk::DescriptorType::eSampler] = 0.5f;       // Image sampler.
+  s_descriptorWeights[vk::DescriptorType::eSampledImage] = 2.0f;  // Read-only image view.
+  s_descriptorWeights[vk::DescriptorType::eStorageImage] = 1.0f;  // Read / write image view.
+  s_descriptorWeights[vk::DescriptorType::eUniformBuffer] = 1.0f; // Read-only struct (constant buffer)
+  s_descriptorWeights[vk::DescriptorType::eStorageBuffer] = 1.0f; // Read / write struct (UAV).
+
+  // Not used by EZ so far.
+  s_descriptorWeights[vk::DescriptorType::eUniformTexelBuffer] = 0.0f;   // Read-only linear texel buffer with view.
+  s_descriptorWeights[vk::DescriptorType::eStorageTexelBuffer] = 0.0f;   // Read / write linear texel buffer with view.
+  s_descriptorWeights[vk::DescriptorType::eUniformBufferDynamic] = 0.0f; // Same as eUniformBuffer but allows updating the memory offset into the buffer dynamically.
+  s_descriptorWeights[vk::DescriptorType::eStorageBufferDynamic] = 0.0f; // Same as eStorageBuffer but allows updating the memory offset into the buffer dynamically.
+
+  // Not supported by EZ so far.
+  s_descriptorWeights[vk::DescriptorType::eInputAttachment] = 0.0f;      //frame-buffer local read-only image view.
+  s_descriptorWeights[vk::DescriptorType::eCombinedImageSampler] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eInlineUniformBlock] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eAccelerationStructureKHR] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eAccelerationStructureNV] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eMutableVALVE] = 0.0f;
+}
+
+void ezDescriptorSetPoolVulkan::DeInitialize()
+{
+  s_descriptorWeights.Clear();
+  s_descriptorWeights.Compact();
+
+  for (vk::DescriptorPool& pool : s_freePools)
+  {
+    s_device.destroyDescriptorPool(pool, nullptr);
+  }
+  s_freePools.Clear();
+  s_freePools.Compact();
+  if (s_currentPool)
+  {
+    s_device.resetDescriptorPool(s_currentPool);
+    s_device.destroyDescriptorPool(s_currentPool, nullptr);
+    s_currentPool = nullptr;
+  }
+
+  s_device = nullptr;
+}
+
+ezHashTable<vk::DescriptorType, float>& ezDescriptorSetPoolVulkan::AccessDescriptorPoolWeights()
+{
+  return s_descriptorWeights;
+}
+
+vk::DescriptorSet ezDescriptorSetPoolVulkan::CreateDescriptorSet(vk::DescriptorSetLayout layout)
+{
+  vk::DescriptorSet set;
+  if (!s_currentPool)
+  {
+    s_currentPool = GetNewPool();
+  }
+
+  vk::DescriptorSetAllocateInfo allocateInfo;
+  allocateInfo.pSetLayouts = &layout;
+  allocateInfo.descriptorPool = s_currentPool;
+  allocateInfo.descriptorSetCount = 1;
+
+  vk::Result res = s_device.allocateDescriptorSets(&allocateInfo, &set);
+  bool bPoolExhausted = false;
+
+  switch (res)
+  {
+    case vk::Result::eSuccess:
+      break;
+    case vk::Result::eErrorFragmentedPool:
+    case vk::Result::eErrorOutOfPoolMemory:
+      bPoolExhausted = true;
+      break;
+    default:
+      VK_ASSERT_DEV(res);
+      break;
+  }
+
+  if (bPoolExhausted)
+  {
+    ezGALDeviceVulkan* pDevice = static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice());
+    pDevice->ReclaimLater(s_currentPool);
+    s_currentPool = GetNewPool();
+    allocateInfo.descriptorPool = s_currentPool;
+    VK_ASSERT_DEV(s_device.allocateDescriptorSets(&allocateInfo, &set));
+  }
+
+  return set;
+}
+
+void ezDescriptorSetPoolVulkan::UpdateDescriptorSet(vk::DescriptorSet descriptorSet, ezArrayPtr<vk::WriteDescriptorSet> update)
+{
+  s_device.updateDescriptorSets(update.GetCount(), update.GetPtr(), 0, nullptr);
+}
+
+void ezDescriptorSetPoolVulkan::ReclaimPool(vk::DescriptorPool& descriptorPool)
+{
+  s_device.resetDescriptorPool(descriptorPool);
+  s_freePools.PushBack(descriptorPool);
+}
+
+vk::DescriptorPool ezDescriptorSetPoolVulkan::GetNewPool()
+{
+  if (s_freePools.IsEmpty())
+  {
+    ezHybridArray<vk::DescriptorPoolSize, 20> poolSizes;
+    for (auto weight : s_descriptorWeights)
+    {
+      if (static_cast<ezUInt32>(weight.Value() * 1000) > 0)
+        poolSizes.PushBack(vk::DescriptorPoolSize(weight.Key(), static_cast<ezUInt32>(weight.Value() * 1000)));
+    }
+    vk::DescriptorPoolCreateInfo poolCreateInfo;
+    poolCreateInfo.flags = {};
+    poolCreateInfo.maxSets = 1000;
+    poolCreateInfo.poolSizeCount = poolSizes.GetCount();
+    poolCreateInfo.pPoolSizes = poolSizes.GetData();
+
+    vk::DescriptorPool descriptorPool;
+    VK_ASSERT_DEV(s_device.createDescriptorPool(&poolCreateInfo, nullptr, &descriptorPool));
+    return descriptorPool;
+  }
+  else
+  {
+    vk::DescriptorPool pool = s_freePools.PeekBack();
+    s_freePools.PopBack();
+    return pool;
+  }
+}

--- a/Code/Engine/RendererVulkan/Resources/BufferVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/BufferVulkan.h
@@ -8,7 +8,9 @@
 class EZ_RENDERERVULKAN_DLL ezGALBufferVulkan : public ezGALBuffer
 {
 public:
+  void DiscardBuffer() const;
   EZ_ALWAYS_INLINE vk::Buffer GetVkBuffer() const;
+  const vk::DescriptorBufferInfo& GetBufferInfo() const;
 
   EZ_ALWAYS_INLINE vk::IndexType GetIndexType() const;
   EZ_ALWAYS_INLINE ezVulkanAllocation GetAllocation() const;
@@ -17,6 +19,13 @@ public:
   EZ_ALWAYS_INLINE vk::AccessFlags GetAccessMask() const;
 
 protected:
+  struct BufferVulkan
+  {
+    vk::Buffer m_buffer;
+    ezVulkanAllocation m_alloc;
+    mutable ezUInt64 m_currentFrame = 0;
+  };
+
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
@@ -26,21 +35,26 @@ protected:
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ezUInt8> pInitialData) override;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
-
   virtual void SetDebugNamePlatform(const char* szName) const override;
+  void CreateBuffer() const;
   vk::DeviceSize GetAlignment(const ezGALDeviceVulkan* pDevice, vk::BufferUsageFlags usage) const;
 
-  vk::Buffer m_buffer;
-  ezVulkanAllocation m_alloc;
-  ezVulkanAllocationInfo m_allocInfo;
+  mutable BufferVulkan m_currentBuffer;
+  mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
+  mutable ezDeque<BufferVulkan> m_usedBuffers;
+  mutable ezVulkanAllocationInfo m_allocInfo;
 
   // Data for memory barriers and access
   vk::PipelineStageFlags m_stages = {};
   vk::AccessFlags m_access = {};
-  vk::IndexType m_indexType; // Only applicable for index buffers
+  vk::IndexType m_indexType = vk::IndexType::eUint16; // Only applicable for index buffers
+  vk::BufferUsageFlags m_usage = {};
+  vk::DeviceSize m_size = 0;
 
   ezGALDeviceVulkan* m_pDeviceVulkan = nullptr;
   vk::Device m_device;
+
+  mutable ezString m_sDebugName;
 };
 
 #include <RendererVulkan/Resources/Implementation/BufferVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -7,8 +7,6 @@
 
 ezGALBufferVulkan::ezGALBufferVulkan(const ezGALBufferCreationDescription& Description)
   : ezGALBuffer(Description)
-  , m_buffer(nullptr)
-  , m_indexType(vk::IndexType::eUint16)
 {
 }
 
@@ -17,32 +15,32 @@ ezGALBufferVulkan::~ezGALBufferVulkan() {}
 ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ezUInt8> pInitialData)
 {
   m_pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+  m_device = m_pDeviceVulkan->GetVulkanDevice();
 
   m_stages = vk::PipelineStageFlagBits::eTransfer;
-  vk::BufferCreateInfo bufferCreateInfo = {};
 
   switch (m_Description.m_BufferType)
   {
     case ezGALBufferType::ConstantBuffer:
-      bufferCreateInfo.usage = vk::BufferUsageFlagBits::eUniformBuffer;
+      m_usage = vk::BufferUsageFlagBits::eUniformBuffer;
       m_stages |= m_pDeviceVulkan->GetSupportedStages();
       m_access |= vk::AccessFlagBits::eUniformRead;
       break;
     case ezGALBufferType::IndexBuffer:
-      bufferCreateInfo.usage = vk::BufferUsageFlagBits::eIndexBuffer;
+      m_usage = vk::BufferUsageFlagBits::eIndexBuffer;
       m_stages |= vk::PipelineStageFlagBits::eVertexInput;
       m_access |= vk::AccessFlagBits::eIndexRead;
       m_indexType = m_Description.m_uiStructSize == 2 ? vk::IndexType::eUint16 : vk::IndexType::eUint32;
 
       break;
     case ezGALBufferType::VertexBuffer:
-      bufferCreateInfo.usage = vk::BufferUsageFlagBits::eVertexBuffer;
+      m_usage = vk::BufferUsageFlagBits::eVertexBuffer;
       m_stages |= vk::PipelineStageFlagBits::eVertexInput;
       m_access |= vk::AccessFlagBits::eVertexAttributeRead;
       break;
     case ezGALBufferType::Generic:
       m_stages |= m_pDeviceVulkan->GetSupportedStages();
-      //bufferCreateInfo.usage = 0; //#TODO_VULKAN Is this correct for Vulkan?
+      //#TODO_VULKAN Is this correct for Vulkan?
       break;
     default:
       ezLog::Error("Unknown buffer type supplied to CreateBuffer()!");
@@ -51,21 +49,21 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
 
   if (m_Description.m_bAllowShaderResourceView)
   {
-    bufferCreateInfo.usage |= vk::BufferUsageFlagBits::eStorageBuffer;
+    m_usage |= vk::BufferUsageFlagBits::eStorageBuffer;
     m_stages |= m_pDeviceVulkan->GetSupportedStages();
     m_access |= vk::AccessFlagBits::eShaderRead;
   }
 
   if (m_Description.m_bAllowUAV)
   {
-    bufferCreateInfo.usage |= vk::BufferUsageFlagBits::eStorageBuffer;
+    m_usage |= vk::BufferUsageFlagBits::eStorageBuffer;
     m_stages |= m_pDeviceVulkan->GetSupportedStages();
     m_access |= vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
   }
 
   if (m_Description.m_bStreamOutputTarget)
   {
-    bufferCreateInfo.usage |= vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransformFeedbackBufferEXT;
+    m_usage |= vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eTransformFeedbackBufferEXT;
     //#TODO_VULKAN will need to create a counter buffer.
     m_stages |= vk::PipelineStageFlagBits::eTransformFeedbackEXT;
     m_access |= vk::AccessFlagBits::eTransformFeedbackWriteEXT;
@@ -73,29 +71,23 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
 
   if (m_Description.m_bUseForIndirectArguments)
   {
-    bufferCreateInfo.usage |= vk::BufferUsageFlagBits::eIndirectBuffer;
+    m_usage |= vk::BufferUsageFlagBits::eIndirectBuffer;
     m_stages |= vk::PipelineStageFlagBits::eDrawIndirect;
     m_access |= vk::AccessFlagBits::eIndirectCommandRead;
   }
 
   if (m_Description.m_ResourceAccess.m_bReadBack)
   {
-    bufferCreateInfo.usage |= vk::BufferUsageFlagBits::eTransferSrc;
+    m_usage |= vk::BufferUsageFlagBits::eTransferSrc;
     m_access |= vk::AccessFlagBits::eTransferRead;
   }
 
-  bufferCreateInfo.usage |= vk::BufferUsageFlagBits::eTransferDst;
+  m_usage |= vk::BufferUsageFlagBits::eTransferDst;
   m_access |= vk::AccessFlagBits::eTransferWrite;
 
-  bufferCreateInfo.pQueueFamilyIndices = nullptr;
-  bufferCreateInfo.queueFamilyIndexCount = 0;
-  bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
-
   EZ_ASSERT_DEBUG(pInitialData.GetCount() <= m_Description.m_uiTotalSize, "Initial data is bigger than target buffer.");
-  vk::DeviceSize alignment = GetAlignment(m_pDeviceVulkan, bufferCreateInfo.usage);
-  vk::DeviceSize newSize = ezMemoryUtils::AlignSize((vk::DeviceSize)m_Description.m_uiTotalSize, alignment);
-  bufferCreateInfo.size = newSize;
-
+  vk::DeviceSize alignment = GetAlignment(m_pDeviceVulkan, m_usage);
+  m_size = ezMemoryUtils::AlignSize((vk::DeviceSize)m_Description.m_uiTotalSize, alignment);
 
   if (m_Description.m_bAllowRawViews)
   {
@@ -107,44 +99,95 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
     // TODO Vulkan?
   }
 
-  ezVulkanAllocationCreateInfo allocInfo;
-  allocInfo.m_usage = ezVulkanMemoryUsage::Auto;
-  allocInfo.m_flags = {};
-  VK_SUCCEED_OR_RETURN_EZ_FAILURE(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocInfo, m_buffer, m_alloc, &m_allocInfo));
+  CreateBuffer();
 
-  m_device = m_pDeviceVulkan->GetVulkanDevice(); // TODO remove this
+  m_resourceBufferInfo.offset = 0;
+  m_resourceBufferInfo.range = m_size;
 
   if (!pInitialData.IsEmpty())
-    m_pDeviceVulkan->UploadBuffer(this, pInitialData);
+  {
+    void* pData = nullptr;
+    VK_ASSERT_DEV(ezMemoryAllocatorVulkan::MapMemory(m_currentBuffer.m_alloc, &pData));
+    EZ_ASSERT_DEV(pData, "Implementation error");
+    ezMemoryUtils::Copy((ezUInt8*)pData, pInitialData.GetPtr(), pInitialData.GetCount());
+    ezMemoryAllocatorVulkan::UnmapMemory(m_currentBuffer.m_alloc);
+  }
   return EZ_SUCCESS;
 }
 
 ezResult ezGALBufferVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
-  if (m_buffer)
+  if (m_currentBuffer.m_buffer)
   {
-    ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
-    pVulkanDevice->DeleteLater(m_buffer, m_alloc);
+    m_pDeviceVulkan->DeleteLater(m_currentBuffer.m_buffer, m_currentBuffer.m_alloc);
+    m_allocInfo = {};
   }
+  for (auto& bufferVulkan : m_usedBuffers)
+  {
+    m_pDeviceVulkan->DeleteLater(bufferVulkan.m_buffer, bufferVulkan.m_alloc);
+  }
+  m_usedBuffers.Clear();
+  m_resourceBufferInfo = vk::DescriptorBufferInfo();
+
+  m_stages = {};
+  m_access = {};
+  m_indexType = vk::IndexType::eUint16;
+  m_usage = {};
+  m_size = 0;
+
+  m_pDeviceVulkan = nullptr;
+  m_device = nullptr;
 
   return EZ_SUCCESS;
 }
 
+void ezGALBufferVulkan::DiscardBuffer() const
+{
+  m_usedBuffers.PushBack(m_currentBuffer);
+  m_currentBuffer = {};
+
+  ezUInt64 uiSafeFrame = m_pDeviceVulkan->GetSafeFrame();
+  if (m_usedBuffers.PeekFront().m_currentFrame <= uiSafeFrame)
+  {
+    m_currentBuffer = m_usedBuffers.PeekFront();
+    m_usedBuffers.PopFront();
+    m_allocInfo = ezMemoryAllocatorVulkan::GetAllocationInfo(m_currentBuffer.m_alloc);
+  }
+  else
+  {
+    CreateBuffer();
+    SetDebugNamePlatform(m_sDebugName);
+  }
+}
+
+const vk::DescriptorBufferInfo& ezGALBufferVulkan::GetBufferInfo() const
+{
+  m_currentBuffer.m_currentFrame = m_pDeviceVulkan->GetCurrentFrame();
+  // Vulkan buffers get constantly swapped out for new ones so the vk::Buffer pointer is not persistent.
+  // We need to acquire the latest one on every request for rendering.
+  m_resourceBufferInfo.buffer = m_currentBuffer.m_buffer;
+  return m_resourceBufferInfo;
+}
+
+void ezGALBufferVulkan::CreateBuffer() const
+{
+  vk::BufferCreateInfo bufferCreateInfo;
+  bufferCreateInfo.usage = m_usage;
+  bufferCreateInfo.pQueueFamilyIndices = nullptr;
+  bufferCreateInfo.queueFamilyIndexCount = 0;
+  bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
+  bufferCreateInfo.size = m_size;
+
+  ezVulkanAllocationCreateInfo allocCreateInfo;
+  allocCreateInfo.m_usage = ezVulkanMemoryUsage::Auto;
+  allocCreateInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessSequentialWrite;
+  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_currentBuffer.m_buffer, m_currentBuffer.m_alloc, &m_allocInfo));
+}
+
 void ezGALBufferVulkan::SetDebugNamePlatform(const char* szName) const
 {
-  ezUInt32 uiLength = ezStringUtils::GetStringElementCount(szName);
-
-  if (m_buffer)
-  {
-    vk::DebugUtilsObjectNameInfoEXT nameInfo;
-    nameInfo.objectType = m_buffer.objectType;
-    nameInfo.objectHandle = (uint64_t)(VkBuffer)m_buffer;
-    nameInfo.pObjectName = szName;
-
-    m_device.setDebugUtilsObjectNameEXT(nameInfo);
-    if (m_alloc)
-      ezMemoryAllocatorVulkan::SetAllocationUserData(m_alloc, szName);
-  }
+  m_sDebugName = szName;
+  m_pDeviceVulkan->SetDebugName(szName, m_currentBuffer.m_buffer, m_currentBuffer.m_alloc);
 }
 
 vk::DeviceSize ezGALBufferVulkan::GetAlignment(const ezGALDeviceVulkan* pDevice, vk::BufferUsageFlags usage) const

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan_inl.h
@@ -1,7 +1,8 @@
 
 vk::Buffer ezGALBufferVulkan::GetVkBuffer() const
 {
-  return m_buffer;
+  m_currentBuffer.m_currentFrame = m_pDeviceVulkan->GetCurrentFrame();
+  return m_currentBuffer.m_buffer;
 }
 
 vk::IndexType ezGALBufferVulkan::GetIndexType() const
@@ -11,7 +12,7 @@ vk::IndexType ezGALBufferVulkan::GetIndexType() const
 
 ezVulkanAllocation ezGALBufferVulkan::GetAllocation() const
 {
-  return m_alloc;
+  return m_currentBuffer.m_alloc;
 }
 
 const ezVulkanAllocationInfo& ezGALBufferVulkan::GetAllocationInfo() const

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan_inl.h
@@ -1,10 +1,4 @@
-
-const vk::DescriptorSetLayoutBinding& ezGALResourceViewVulkan::GetResourceBinding() const
+const vk::DescriptorImageInfo& ezGALResourceViewVulkan::GetImageInfo() const
 {
-  return m_resourceBinding;
-}
-
-const vk::WriteDescriptorSet& ezGALResourceViewVulkan::GetResourceBindingData() const
-{
-  return m_resourceBindingData;
+  return m_resourceImageInfo;
 }

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
@@ -185,17 +185,7 @@ ezResult ezGALTextureVulkan::DeInitPlatform(ezGALDevice* pDevice)
 
 void ezGALTextureVulkan::SetDebugNamePlatform(const char* szName) const
 {
-  if (m_image)
-  {
-    vk::DebugUtilsObjectNameInfoEXT nameInfo;
-    nameInfo.objectType = m_image.objectType;
-    nameInfo.objectHandle = (uint64_t)(VkImage)m_image;
-    nameInfo.pObjectName = szName;
-
-    m_device.setDebugUtilsObjectNameEXT(nameInfo);
-    if (m_alloc)
-      ezMemoryAllocatorVulkan::SetAllocationUserData(m_alloc, szName);
-  }
+  static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice())->SetDebugName(szName, m_image, m_alloc);
 }
 
 ezResult ezGALTextureVulkan::CreateStagingBuffer(ezGALDeviceVulkan* pDevice)

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan_inl.h
@@ -3,6 +3,16 @@ vk::Image ezGALTextureVulkan::GetImage() const
   return m_image;
 }
 
+vk::ImageLayout ezGALTextureVulkan::GetCurrentLayout() const
+{
+  return m_currentLayout;
+}
+
+vk::ImageLayout ezGALTextureVulkan::GetPreferredLayout() const
+{
+  return m_preferredLayout;
+}
+
 ezVulkanAllocation ezGALTextureVulkan::GetAllocation() const
 {
   return m_alloc;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h
@@ -1,5 +1,4 @@
-
-ID3D11UnorderedAccessView* ezGALUnorderedAccessViewVulkan::GetDXResourceView() const
+const vk::DescriptorImageInfo& ezGALUnorderedAccessViewVulkan::GetImageInfo() const
 {
-  return m_pDXUnorderedAccessView;
+  return m_resourceImageInfo;
 }

--- a/Code/Engine/RendererVulkan/Resources/ResourceViewVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/ResourceViewVulkan.h
@@ -13,7 +13,7 @@ public:
   EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& GetImageInfo() const;
   const vk::DescriptorBufferInfo& GetBufferInfo() const;
 
-protected :
+protected:
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 

--- a/Code/Engine/RendererVulkan/Resources/ResourceViewVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/ResourceViewVulkan.h
@@ -5,29 +5,27 @@
 
 #include <vulkan/vulkan.hpp>
 
+class ezGALBufferVulkan;
+
 class ezGALResourceViewVulkan : public ezGALResourceView
 {
 public:
-  EZ_ALWAYS_INLINE const vk::DescriptorSetLayoutBinding& GetResourceBinding() const;
-  EZ_ALWAYS_INLINE const vk::WriteDescriptorSet& GetResourceBindingData() const;
+  EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& GetImageInfo() const;
+  const vk::DescriptorBufferInfo& GetBufferInfo() const;
 
-protected:
+protected :
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
   ezGALResourceViewVulkan(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description);
-
   ~ezGALResourceViewVulkan();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
-  vk::ImageView m_imageView;
-  vk::DescriptorSetLayoutBinding m_resourceBinding;
-  vk::WriteDescriptorSet m_resourceBindingData;
-  vk::DescriptorBufferInfo m_resourceBufferInfo;
-  vk::DescriptorImageInfo m_resourceImageInfo;
+  const ezGALBufferVulkan* m_pParentBuffer = nullptr;
+  mutable vk::DescriptorImageInfo m_resourceImageInfo;
+  mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
 };
 
 #include <RendererVulkan/Resources/Implementation/ResourceViewVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/Resources/TextureVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/TextureVulkan.h
@@ -10,6 +10,8 @@ class ezGALTextureVulkan : public ezGALTexture
 {
 public:
   EZ_ALWAYS_INLINE vk::Image GetImage() const;
+  EZ_ALWAYS_INLINE vk::ImageLayout GetCurrentLayout() const;
+  EZ_ALWAYS_INLINE vk::ImageLayout GetPreferredLayout() const;
 
   EZ_ALWAYS_INLINE ezVulkanAllocation GetAllocation() const;
   EZ_ALWAYS_INLINE const ezVulkanAllocationInfo& GetAllocationInfo() const;
@@ -32,6 +34,9 @@ protected:
   ezResult CreateStagingBuffer(ezGALDeviceVulkan* pDevice);
 
   vk::Image m_image;
+  vk::ImageLayout m_currentLayout;
+  vk::ImageLayout m_preferredLayout;
+
   ezVulkanAllocation m_alloc;
   ezVulkanAllocationInfo m_allocInfo;
 

--- a/Code/Engine/RendererVulkan/Resources/UnorderedAccessViewVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/UnorderedAccessViewVulkan.h
@@ -3,26 +3,30 @@
 
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
 
-struct ID3D11UnorderedAccessView;
+#include <vulkan/vulkan.hpp>
+
+class ezGALBufferVulkan;
 
 class ezGALUnorderedAccessViewVulkan : public ezGALUnorderedAccessView
 {
 public:
-  EZ_ALWAYS_INLINE ID3D11UnorderedAccessView* GetDXResourceView() const;
+  EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& GetImageInfo() const;
+  const vk::DescriptorBufferInfo& GetBufferInfo() const;
 
 protected:
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
   ezGALUnorderedAccessViewVulkan(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description);
-
   ~ezGALUnorderedAccessViewVulkan();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
-  ID3D11UnorderedAccessView* m_pDXUnorderedAccessView;
+private:
+  const ezGALBufferVulkan* m_pParentBuffer = nullptr;
+  mutable vk::DescriptorImageInfo m_resourceImageInfo;
+  mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
 };
 
 #include <RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -70,11 +70,11 @@ ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
   struct LayoutBinding
   {
     const ezVulkanDescriptorSetLayoutBinding* m_binding = nullptr; ///< The first binding under which this resource was encountered.
-    vk::ShaderStageFlags m_stages = {}; ///< Bitflags of all stages that share this binding. Matching is done by name.
+    vk::ShaderStageFlags m_stages = {};                            ///< Bitflags of all stages that share this binding. Matching is done by name.
   };
   ezHybridArray<ShaderRemapping, 6> remappings[ezGALShaderStage::ENUM_COUNT]; ///< Remappings for each shader stage.
-  ezHybridArray<LayoutBinding, 6> sourceBindings; ///< Bindings across all stages. Can have gaps. Array index is the binding index.
-  ezMap<ezStringView, ezUInt32> bindingMap; ///< Maps binding name to index in sourceBindings.
+  ezHybridArray<LayoutBinding, 6> sourceBindings;                             ///< Bindings across all stages. Can have gaps. Array index is the binding index.
+  ezMap<ezStringView, ezUInt32> bindingMap;                                   ///< Maps binding name to index in sourceBindings.
 
   for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
   {
@@ -140,8 +140,7 @@ ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
       }
     }
   }
-  m_BindingMapping.Sort([](const BindingMapping& lhs, const BindingMapping& rhs)
-    { return lhs.m_uiTarget < rhs.m_uiTarget; });
+  m_BindingMapping.Sort([](const BindingMapping& lhs, const BindingMapping& rhs) { return lhs.m_uiTarget < rhs.m_uiTarget; });
 
   // Build Vulkan descriptor set layout
   for (ezUInt32 i = 0; i < sourceBindings.GetCount(); i++)
@@ -156,8 +155,7 @@ ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
       binding.stageFlags = sourceBinding.m_stages;
     }
   }
-  m_descriptorSetLayoutDesc.m_bindings.Sort([](const vk::DescriptorSetLayoutBinding& lhs, const vk::DescriptorSetLayoutBinding& rhs)
-    { return lhs.binding < rhs.binding; });
+  m_descriptorSetLayoutDesc.m_bindings.Sort([](const vk::DescriptorSetLayoutBinding& lhs, const vk::DescriptorSetLayoutBinding& rhs) { return lhs.binding < rhs.binding; });
   m_descriptorSetLayoutDesc.ComputeHash();
 
   // Remap and build shaders

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -1,16 +1,34 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
+#include <Foundation/Algorithm/HashStream.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Shader/ShaderVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
+#include <ShaderCompilerDXC/SpirvMetaData.h>
+
+EZ_CHECK_AT_COMPILETIME(ezVulkanDescriptorSetLayoutBinding::ConstantBuffer == ezGALShaderVulkan::BindingMapping::ConstantBuffer);
+EZ_CHECK_AT_COMPILETIME(ezVulkanDescriptorSetLayoutBinding::ResourceView == ezGALShaderVulkan::BindingMapping::ResourceView);
+EZ_CHECK_AT_COMPILETIME(ezVulkanDescriptorSetLayoutBinding::UAV == ezGALShaderVulkan::BindingMapping::UAV);
+EZ_CHECK_AT_COMPILETIME(ezVulkanDescriptorSetLayoutBinding::Sampler == ezGALShaderVulkan::BindingMapping::Sampler);
+
+void ezGALShaderVulkan::DescriptorSetLayoutDesc::ComputeHash()
+{
+  ezHashStreamWriter32 writer;
+  const ezUInt32 uiSize = m_bindings.GetCount();
+  for (ezUInt32 i = 0; i < uiSize; i++)
+  {
+    const auto& binding = m_bindings[i];
+    writer << binding.binding;
+    writer << ezConversionUtilsVulkan::GetUnderlyingValue(binding.descriptorType);
+    writer << binding.descriptorCount;
+    writer << ezConversionUtilsVulkan::GetUnderlyingFlagsValue(binding.stageFlags);
+    writer << binding.pImmutableSamplers;
+  }
+  m_uiHash = writer.GetHashValue();
+}
 
 ezGALShaderVulkan::ezGALShaderVulkan(const ezGALShaderCreationDescription& Description)
   : ezGALShader(Description)
-  , m_pVertexShader(nullptr)
-  , m_pHullShader(nullptr)
-  , m_pDomainShader(nullptr)
-  , m_pGeometryShader(nullptr)
-  , m_pPixelShader(nullptr)
-  , m_pComputeShader(nullptr)
 {
 }
 
@@ -18,93 +36,169 @@ ezGALShaderVulkan::~ezGALShaderVulkan() {}
 
 void ezGALShaderVulkan::SetDebugName(const char* szName) const
 {
-  ezUInt32 uiLength = ezStringUtils::GetStringElementCount(szName);
-
-  // TODO
-#if 0
-  if (m_pVertexShader != nullptr)
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice());
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
   {
-    m_pVertexShader->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
+    pVulkanDevice->SetDebugName(szName, m_Shaders[i]);
   }
-
-  if (m_pHullShader != nullptr)
-  {
-    m_pHullShader->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
-  }
-
-  if (m_pDomainShader != nullptr)
-  {
-    m_pDomainShader->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
-  }
-
-  if (m_pGeometryShader != nullptr)
-  {
-    m_pGeometryShader->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
-  }
-
-  if (m_pPixelShader != nullptr)
-  {
-    m_pPixelShader->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
-  }
-
-  if (m_pComputeShader != nullptr)
-  {
-    m_pComputeShader->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
-  }
-#endif
 }
 
 ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
 {
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  // Extract meta data and shader code.
+  ezArrayPtr<const ezUInt8> shaderCode[ezGALShaderStage::ENUM_COUNT];
+  ezDynamicArray<ezVulkanDescriptorSetLayout> sets[ezGALShaderStage::ENUM_COUNT];
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
+  {
+    if (m_Description.HasByteCodeForStage((ezGALShaderStage::Enum)i))
+    {
+      ezArrayPtr<const ezUInt8> metaData(reinterpret_cast<const ezUInt8*>(m_Description.m_ByteCodes[i]->GetByteCode()), m_Description.m_ByteCodes[i]->GetSize());
+      ezSpirvMetaData::Read(metaData, shaderCode[i], sets[i]);
+    }
+  }
+
+  // Compute remapping.
+  // Each shader stage is compiled individually and has its own binding indices.
+  // In Vulkan we need to map all stages into one descriptor layout which requires us to remap some shader stages so no binding index conflicts appear.
+  struct ShaderRemapping
+  {
+    const ezVulkanDescriptorSetLayoutBinding* pBinding = 0;
+    ezUInt16 m_uiTarget = 0; ///< The new binding target that pBinding needs to be remapped to.
+  };
+  struct LayoutBinding
+  {
+    const ezVulkanDescriptorSetLayoutBinding* m_binding = nullptr; ///< The first binding under which this resource was encountered.
+    vk::ShaderStageFlags m_stages = {}; ///< Bitflags of all stages that share this binding. Matching is done by name.
+  };
+  ezHybridArray<ShaderRemapping, 6> remappings[ezGALShaderStage::ENUM_COUNT]; ///< Remappings for each shader stage.
+  ezHybridArray<LayoutBinding, 6> sourceBindings; ///< Bindings across all stages. Can have gaps. Array index is the binding index.
+  ezMap<ezStringView, ezUInt32> bindingMap; ///< Maps binding name to index in sourceBindings.
+
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
+  {
+    const vk::ShaderStageFlags vulkanStage = ezConversionUtilsVulkan::GetShaderStage((ezGALShaderStage::Enum)i);
+    if (m_Description.HasByteCodeForStage((ezGALShaderStage::Enum)i))
+    {
+      EZ_ASSERT_DEV(sets[i].GetCount() <= 1, "Only a single descriptor set is currently supported.");
+
+      for (ezUInt32 j = 0; j < sets[i].GetCount(); j++)
+      {
+        const ezVulkanDescriptorSetLayout& set = sets[i][j];
+        EZ_ASSERT_DEV(set.m_uiSet == 0, "Only a single descriptor set is currently supported.");
+        for (ezUInt32 k = 0; k < set.bindings.GetCount(); k++)
+        {
+          const ezVulkanDescriptorSetLayoutBinding& binding = set.bindings[k];
+          // Does a binding already exist for the resource with the same name?
+          if (ezUInt32* pBindingIdx = bindingMap.GetValue(binding.m_sName))
+          {
+            LayoutBinding& layoutBinding = sourceBindings[*pBindingIdx];
+            layoutBinding.m_stages |= vulkanStage;
+            const ezVulkanDescriptorSetLayoutBinding* pCurrentBinding = layoutBinding.m_binding;
+            EZ_ASSERT_DEBUG(pCurrentBinding->m_Type == binding.m_Type, "The descriptor {} was found with different resource type {} and {}", binding.m_sName, pCurrentBinding->m_Type, binding.m_Type);
+            EZ_ASSERT_DEBUG(pCurrentBinding->m_uiDescriptorType == binding.m_uiDescriptorType, "The descriptor {} was found with different type {} and {}", binding.m_sName, pCurrentBinding->m_uiDescriptorType, binding.m_uiDescriptorType);
+            EZ_ASSERT_DEBUG(pCurrentBinding->m_uiDescriptorCount == binding.m_uiDescriptorCount, "The descriptor {} was found with different count {} and {}", binding.m_sName, pCurrentBinding->m_uiDescriptorCount, binding.m_uiDescriptorCount);
+            // The binding index differs from the one already in the set, remapping is necessary.
+            if (binding.m_uiBinding != *pBindingIdx)
+            {
+              remappings[i].PushBack({&binding, pCurrentBinding->m_uiBinding});
+            }
+          }
+          else
+          {
+            ezUInt8 uiTargetBinding = binding.m_uiBinding;
+            // Doesn't exist yet, find a good place for it.
+            if (binding.m_uiBinding >= sourceBindings.GetCount())
+              sourceBindings.SetCount(binding.m_uiBinding + 1);
+
+            // If the original binding index doesn't exist yet, use it (No remapping necessary).
+            if (sourceBindings[binding.m_uiBinding].m_binding == nullptr)
+            {
+              sourceBindings[binding.m_uiBinding] = {&binding, vulkanStage};
+              bindingMap[binding.m_sName] = uiTargetBinding;
+            }
+            else
+            {
+              // Binding index already in use, remapping necessary.
+              uiTargetBinding = (ezUInt8)sourceBindings.GetCount();
+              sourceBindings.PushBack({&binding, vulkanStage});
+              bindingMap[binding.m_sName] = uiTargetBinding;
+              remappings[i].PushBack({&binding, uiTargetBinding});
+            }
+
+            // The shader reflection used by the high level renderer is per stage and assumes it can map resources to stages.
+            // We build this remapping table to map our descriptor binding to the original per-stage resource binding model.
+            BindingMapping& bindingMapping = m_BindingMapping.ExpandAndGetRef();
+            bindingMapping.m_descriptorType = (vk::DescriptorType)binding.m_uiDescriptorType;
+            bindingMapping.m_type = (BindingMapping::Type)binding.m_Type;
+            bindingMapping.m_stage = (ezGALShaderStage::Enum)i;
+            bindingMapping.m_uiSource = binding.m_uiBinding;
+            bindingMapping.m_uiTarget = uiTargetBinding;
+          }
+        }
+      }
+    }
+  }
+  m_BindingMapping.Sort([](const BindingMapping& lhs, const BindingMapping& rhs)
+    { return lhs.m_uiTarget < rhs.m_uiTarget; });
+
+  // Build Vulkan descriptor set layout
+  for (ezUInt32 i = 0; i < sourceBindings.GetCount(); i++)
+  {
+    const LayoutBinding& sourceBinding = sourceBindings[i];
+    if (sourceBinding.m_binding != nullptr)
+    {
+      vk::DescriptorSetLayoutBinding& binding = m_descriptorSetLayoutDesc.m_bindings.ExpandAndGetRef();
+      binding.binding = i;
+      binding.descriptorType = (vk::DescriptorType)sourceBinding.m_binding->m_uiDescriptorType;
+      binding.descriptorCount = sourceBinding.m_binding->m_uiDescriptorCount;
+      binding.stageFlags = sourceBinding.m_stages;
+    }
+  }
+  m_descriptorSetLayoutDesc.m_bindings.Sort([](const vk::DescriptorSetLayoutBinding& lhs, const vk::DescriptorSetLayoutBinding& rhs)
+    { return lhs.binding < rhs.binding; });
+  m_descriptorSetLayoutDesc.ComputeHash();
+
+  // Remap and build shaders
+  ezUInt32 uiMaxShaderSize = 0;
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
+  {
+    if (!remappings[i].IsEmpty())
+    {
+      uiMaxShaderSize = ezMath::Max(uiMaxShaderSize, shaderCode[i].GetCount());
+    }
+  }
+
   vk::ShaderModuleCreateInfo createInfo;
-
-  if (m_Description.HasByteCodeForStage(ezGALShaderStage::VertexShader))
+  ezDynamicArray<ezUInt8> tempBuffer;
+  tempBuffer.Reserve(uiMaxShaderSize);
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
   {
-    createInfo.codeSize = m_Description.m_ByteCodes[ezGALShaderStage::VertexShader]->GetSize();
-    EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "");
-    createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[ezGALShaderStage::VertexShader]->GetByteCode());
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_pVertexShader));
-  }
-
-  if (m_Description.HasByteCodeForStage(ezGALShaderStage::HullShader))
-  {
-    createInfo.codeSize = m_Description.m_ByteCodes[ezGALShaderStage::HullShader]->GetSize();
-    EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "");
-    createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[ezGALShaderStage::HullShader]->GetByteCode());
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_pHullShader));
-  }
-
-  if (m_Description.HasByteCodeForStage(ezGALShaderStage::DomainShader))
-  {
-    createInfo.codeSize = m_Description.m_ByteCodes[ezGALShaderStage::DomainShader]->GetSize();
-    EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "");
-    createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[ezGALShaderStage::DomainShader]->GetByteCode());
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_pDomainShader));
-  }
-
-  if (m_Description.HasByteCodeForStage(ezGALShaderStage::GeometryShader))
-  {
-    createInfo.codeSize = m_Description.m_ByteCodes[ezGALShaderStage::GeometryShader]->GetSize();
-    EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "");
-    createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[ezGALShaderStage::GeometryShader]->GetByteCode());
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_pGeometryShader));
-  }
-
-  if (m_Description.HasByteCodeForStage(ezGALShaderStage::PixelShader))
-  {
-    createInfo.codeSize = m_Description.m_ByteCodes[ezGALShaderStage::PixelShader]->GetSize();
-    EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "");
-    createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[ezGALShaderStage::PixelShader]->GetByteCode());
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_pPixelShader));
-  }
-
-  if (m_Description.HasByteCodeForStage(ezGALShaderStage::ComputeShader))
-  {
-    createInfo.codeSize = m_Description.m_ByteCodes[ezGALShaderStage::ComputeShader]->GetSize();
-    EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "");
-    createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[ezGALShaderStage::ComputeShader]->GetByteCode());
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_pComputeShader));
+    if (m_Description.HasByteCodeForStage((ezGALShaderStage::Enum)i))
+    {
+      if (remappings[i].IsEmpty())
+      {
+        createInfo.codeSize = shaderCode[i].GetCount();
+        EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "Spirv shader code should be a multiple of 4.");
+        createInfo.pCode = reinterpret_cast<const ezUInt32*>(shaderCode[i].GetPtr());
+        VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_Shaders[i]));
+      }
+      else
+      {
+        tempBuffer = shaderCode[i];
+        ezUInt32* pData = reinterpret_cast<ezUInt32*>(tempBuffer.GetData());
+        for (const auto& remap : remappings[i])
+        {
+          EZ_ASSERT_DEBUG(pData[remap.pBinding->m_uiWordOffset] == remap.pBinding->m_uiBinding, "Spirv descriptor word offset does not point to descriptor index.");
+          pData[remap.pBinding->m_uiWordOffset] = remap.m_uiTarget;
+        }
+        createInfo.codeSize = tempBuffer.GetCount();
+        EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "Spirv shader code should be a multiple of 4.");
+        createInfo.pCode = pData;
+        VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_Shaders[i]));
+      }
+    }
   }
 
   return EZ_SUCCESS;
@@ -112,13 +206,14 @@ ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
 
 ezResult ezGALShaderVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
+  m_descriptorSetLayoutDesc = {};
+  m_BindingMapping.Clear();
+
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
-  pVulkanDevice->DeleteLater(m_pVertexShader);
-  pVulkanDevice->DeleteLater(m_pHullShader);
-  pVulkanDevice->DeleteLater(m_pDomainShader);
-  pVulkanDevice->DeleteLater(m_pGeometryShader);
-  pVulkanDevice->DeleteLater(m_pPixelShader);
-  pVulkanDevice->DeleteLater(m_pComputeShader);
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
+  {
+    pVulkanDevice->DeleteLater(m_Shaders[i]);
+  }
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h
@@ -1,30 +1,15 @@
 
-vk::ShaderModule ezGALShaderVulkan::GetVertexShader() const
+vk::ShaderModule ezGALShaderVulkan::GetShader(ezGALShaderStage::Enum stage) const
 {
-  return m_pVertexShader;
+  return m_Shaders[stage];
 }
 
-vk::ShaderModule ezGALShaderVulkan::GetHullShader() const
+const ezGALShaderVulkan::DescriptorSetLayoutDesc& ezGALShaderVulkan::GetDescriptorSetLayout() const
 {
-  return m_pHullShader;
+  return m_descriptorSetLayoutDesc;
 }
 
-vk::ShaderModule ezGALShaderVulkan::GetDomainShader() const
+const ezArrayPtr<const ezGALShaderVulkan::BindingMapping> ezGALShaderVulkan::GetBindingMapping() const
 {
-  return m_pDomainShader;
-}
-
-vk::ShaderModule ezGALShaderVulkan::GetGeometryShader() const
-{
-  return m_pGeometryShader;
-}
-
-vk::ShaderModule ezGALShaderVulkan::GetPixelShader() const
-{
-  return m_pPixelShader;
-}
-
-vk::ShaderModule ezGALShaderVulkan::GetComputeShader() const
-{
-  return m_pComputeShader;
+  return m_BindingMapping;
 }

--- a/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
@@ -30,10 +30,10 @@ public:
       Sampler,
     };
     vk::DescriptorType m_descriptorType = vk::DescriptorType::eSampler;
-    Type m_type = Type::ConstantBuffer; ///< Source resource type in the high level binding model.
+    Type m_type = Type::ConstantBuffer;                            ///< Source resource type in the high level binding model.
     ezGALShaderStage::Enum m_stage = ezGALShaderStage::ENUM_COUNT; ///< Source stage in the high level resource binding model.
-    ezUInt8 m_uiSource = 0; ///< Source binding index in the high level resource binding model.
-    ezUInt8 m_uiTarget = 0; ///< Target binding index in the descriptor set layout.
+    ezUInt8 m_uiSource = 0;                                        ///< Source binding index in the high level resource binding model.
+    ezUInt8 m_uiTarget = 0;                                        ///< Target binding index in the descriptor set layout.
   };
 
   void SetDebugName(const char* szName) const override;

--- a/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
@@ -1,23 +1,46 @@
 
 #pragma once
 
+#include <RendererVulkan/RendererVulkanDLL.h>
+
 #include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Shader/Shader.h>
-#include <RendererVulkan/RendererVulkanDLL.h>
 
 #include <vulkan/vulkan.hpp>
 
 class EZ_RENDERERVULKAN_DLL ezGALShaderVulkan : public ezGALShader
 {
 public:
+  /// \brief Used as input to ezResourceCacheVulkan::RequestDescriptorSetLayout to create a vk::DescriptorSetLayout.
+  struct DescriptorSetLayoutDesc
+  {
+    mutable ezUInt32 m_uiHash = 0;
+    ezHybridArray<vk::DescriptorSetLayoutBinding, 6> m_bindings;
+    void ComputeHash();
+  };
+
+  /// \brief Remaps high level resource binding to the descriptor layout used by this shader.
+  struct BindingMapping
+  {
+    enum Type : ezUInt8
+    {
+      ConstantBuffer,
+      ResourceView,
+      UAV,
+      Sampler,
+    };
+    vk::DescriptorType m_descriptorType = vk::DescriptorType::eSampler;
+    Type m_type = Type::ConstantBuffer; ///< Source resource type in the high level binding model.
+    ezGALShaderStage::Enum m_stage = ezGALShaderStage::ENUM_COUNT; ///< Source stage in the high level resource binding model.
+    ezUInt8 m_uiSource = 0; ///< Source binding index in the high level resource binding model.
+    ezUInt8 m_uiTarget = 0; ///< Target binding index in the descriptor set layout.
+  };
+
   void SetDebugName(const char* szName) const override;
 
-  EZ_ALWAYS_INLINE vk::ShaderModule GetVertexShader() const;
-  EZ_ALWAYS_INLINE vk::ShaderModule GetHullShader() const;
-  EZ_ALWAYS_INLINE vk::ShaderModule GetDomainShader() const;
-  EZ_ALWAYS_INLINE vk::ShaderModule GetGeometryShader() const;
-  EZ_ALWAYS_INLINE vk::ShaderModule GetPixelShader() const;
-  EZ_ALWAYS_INLINE vk::ShaderModule GetComputeShader() const;
+  EZ_ALWAYS_INLINE vk::ShaderModule GetShader(ezGALShaderStage::Enum stage) const;
+  EZ_ALWAYS_INLINE const DescriptorSetLayoutDesc& GetDescriptorSetLayout() const;
+  EZ_ALWAYS_INLINE const ezArrayPtr<const BindingMapping> GetBindingMapping() const;
 
 protected:
   friend class ezGALDeviceVulkan;
@@ -30,12 +53,9 @@ protected:
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
 private:
-  vk::ShaderModule m_pVertexShader;
-  vk::ShaderModule m_pHullShader;
-  vk::ShaderModule m_pDomainShader;
-  vk::ShaderModule m_pGeometryShader;
-  vk::ShaderModule m_pPixelShader;
-  vk::ShaderModule m_pComputeShader;
+  DescriptorSetLayoutDesc m_descriptorSetLayoutDesc;
+  ezHybridArray<BindingMapping, 16> m_BindingMapping;
+  vk::ShaderModule m_Shaders[ezGALShaderStage::ENUM_COUNT];
 };
 
 #include <RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
@@ -189,15 +189,10 @@ ezResult ezGALRasterizerStateVulkan::DeInitPlatform(ezGALDevice* pDevice)
 
 ezGALSamplerStateVulkan::ezGALSamplerStateVulkan(const ezGALSamplerStateCreationDescription& Description)
   : ezGALSamplerState(Description)
-  , m_samplerState({})
-  , m_sampler(nullptr)
 {
 }
 
 ezGALSamplerStateVulkan::~ezGALSamplerStateVulkan() {}
-
-/*
- */
 
 ezResult ezGALSamplerStateVulkan::InitPlatform(ezGALDevice* pDevice)
 {
@@ -219,34 +214,17 @@ ezResult ezGALSamplerStateVulkan::InitPlatform(ezGALDevice* pDevice)
   samplerCreateInfo.mipLodBias = m_Description.m_fMipLodBias;
   samplerCreateInfo.mipmapMode = GALFilterToVulkanMipmapMode[m_Description.m_MipFilter];
 
-  m_sampler = pVulkanDevice->GetVulkanDevice().createSampler(samplerCreateInfo);
-
-  if (!m_sampler)
-  {
-    return EZ_FAILURE;
-  }
-  else
-  {
-    return EZ_SUCCESS;
-  }
-
-  m_samplerState.descriptorType = vk::DescriptorType::eSampledImage;
-
-  // TODO sampler binding info
+  m_resourceImageInfo.imageLayout = vk::ImageLayout::eUndefined;
+  VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createSampler(&samplerCreateInfo, nullptr, &m_resourceImageInfo.sampler));
+  return EZ_SUCCESS;
 }
 
 
 ezResult ezGALSamplerStateVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
-  if (m_sampler)
-  {
-    ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
-    pVulkanDevice->DeleteLater(m_sampler);
-  }
-
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+  pVulkanDevice->DeleteLater(m_resourceImageInfo.sampler);
   return EZ_SUCCESS;
 }
-
-
 
 EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_State_Implementation_StateVulkan);

--- a/Code/Engine/RendererVulkan/State/Implementation/StateVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/State/Implementation/StateVulkan_inl.h
@@ -14,7 +14,7 @@ EZ_ALWAYS_INLINE const vk::PipelineRasterizationStateCreateInfo* ezGALRasterizer
   return &m_rasterizerState;
 }
 
-EZ_ALWAYS_INLINE const vk::DescriptorSetLayoutBinding* ezGALSamplerStateVulkan::GetSamplerState() const
+EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& ezGALSamplerStateVulkan::GetImageInfo() const
 {
-  return &m_samplerState;
+  return m_resourceImageInfo;
 }

--- a/Code/Engine/RendererVulkan/State/StateVulkan.h
+++ b/Code/Engine/RendererVulkan/State/StateVulkan.h
@@ -69,22 +69,19 @@ protected:
 class EZ_RENDERERVULKAN_DLL ezGALSamplerStateVulkan : public ezGALSamplerState
 {
 public:
-  EZ_ALWAYS_INLINE const vk::DescriptorSetLayoutBinding* GetSamplerState() const;
+  EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& GetImageInfo() const;
 
 protected:
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
   ezGALSamplerStateVulkan(const ezGALSamplerStateCreationDescription& Description);
-
   ~ezGALSamplerStateVulkan();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
-  vk::Sampler m_sampler = {};
-  vk::DescriptorSetLayoutBinding m_samplerState = {};
+  vk::DescriptorImageInfo m_resourceImageInfo;
 };
 
 

--- a/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
@@ -13,13 +13,31 @@ EZ_DEFINE_AS_POD_TYPE(vk::PresentModeKHR);
 class EZ_RENDERERVULKAN_DLL ezConversionUtilsVulkan
 {
 public:
+  /// \brief Helper function to hash vk enums.
+  template <typename T, typename R = typename std::underlying_type<T>::type>
+  static R GetUnderlyingValue(T value)
+  {
+    return static_cast<std::underlying_type<T>::type>(value);
+  }
+
+  /// \brief Helper function to hash vk flags.
+  template <typename T>
+  static auto GetUnderlyingFlagsValue(T value)
+  {
+    return static_cast<T::MaskType>(value);
+  }
+
   static vk::SampleCountFlagBits GetSamples(ezEnum<ezGALMSAASampleCount> samples);
   static vk::PresentModeKHR GetPresentMode(ezEnum<ezGALPresentMode> presentMode, const ezDynamicArray<vk::PresentModeKHR>& supportedModes);
   static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALRenderTargetViewCreationDescription& desc);
   static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALResourceViewCreationDescription& viewDesc);
+  static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc);
+  static vk::ImageViewType GetImageViewType(ezEnum<ezGALTextureType> texType, bool bIsArray);
+
   static bool IsDepthFormat(vk::Format format);
   static bool IsStencilFormat(vk::Format format);
   static vk::PrimitiveTopology GetPrimitiveTopology(ezEnum<ezGALPrimitiveTopology> topology);
+  static vk::ShaderStageFlagBits GetShaderStage(ezGALShaderStage::Enum stage);
 };
 
 #include <RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h>

--- a/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
+++ b/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
@@ -443,7 +443,7 @@ ezResult ezShaderCompilerDXC::ReflectShaderStage(ezShaderProgramData& inout_Data
       //#TODO_VULKAN Currently hard coded to a single DescriptorSetLayout.
       ezHybridArray<ezVulkanDescriptorSetLayout, 3> sets;
       ezVulkanDescriptorSetLayout& set = sets.ExpandAndGetRef();
-     
+
       for (ezUInt32 i = 0; i < uiCount; ++i)
       {
         auto& info = *vars[i];
@@ -453,19 +453,19 @@ ezResult ezShaderCompilerDXC::ReflectShaderStage(ezShaderProgramData& inout_Data
         binding.m_uiBinding = static_cast<ezUInt8>(info.binding);
         switch (info.resource_type)
         {
-        case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_SAMPLER:
-          binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::Sampler;
+          case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_SAMPLER:
+            binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::Sampler;
             break;
-        case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_CBV:
-          binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::ConstantBuffer;
-          break;
-        case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_SRV:
-          binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::ResourceView;
-          break;
-        default:
-        case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_UAV:
-          binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::UAV;
-          break;
+          case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_CBV:
+            binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::ConstantBuffer;
+            break;
+          case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_SRV:
+            binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::ResourceView;
+            break;
+          default:
+          case SpvReflectResourceType::SPV_REFLECT_RESOURCE_FLAG_UAV:
+            binding.m_Type = ezVulkanDescriptorSetLayoutBinding::ResourceType::UAV;
+            break;
         }
         binding.m_uiDescriptorType = static_cast<ezUInt32>(info.descriptor_type);
         binding.m_uiDescriptorCount = 1;
@@ -475,8 +475,7 @@ ezResult ezShaderCompilerDXC::ReflectShaderStage(ezShaderProgramData& inout_Data
         }
         binding.m_uiWordOffset = info.word_offset.binding;
       }
-      set.bindings.Sort([](const ezVulkanDescriptorSetLayoutBinding& lhs, const ezVulkanDescriptorSetLayoutBinding& rhs)
-        { return lhs.m_uiBinding < rhs.m_uiBinding; });
+      set.bindings.Sort([](const ezVulkanDescriptorSetLayoutBinding& lhs, const ezVulkanDescriptorSetLayoutBinding& rhs) { return lhs.m_uiBinding < rhs.m_uiBinding; });
 
       ezSpirvMetaData::Write(stream, bytecode, sets);
 

--- a/Code/Engine/ShaderCompilerDXC/SpirvMetaData.h
+++ b/Code/Engine/ShaderCompilerDXC/SpirvMetaData.h
@@ -1,0 +1,119 @@
+#pragma once
+#include <Foundation/Basics.h>
+#include <Foundation/Containers/HybridArray.h>
+#include <Foundation/IO/Stream.h>
+#include <Foundation/IO/MemoryStream.h>
+
+struct ezVulkanDescriptorSetLayoutBinding
+{
+  enum ResourceType : ezUInt8
+  {
+    ConstantBuffer,
+    ResourceView,
+    UAV,
+    Sampler,
+  };
+
+  EZ_DECLARE_POD_TYPE();
+  ezStringView m_sName; ///< Used to match the same descriptor use across multiple stages.
+  ezUInt8 m_uiBinding = 0;
+  ResourceType m_Type = ResourceType::ConstantBuffer;
+  ezUInt16 m_uiDescriptorType = 0; ///< Maps to vk::DescriptorType
+  ezUInt32 m_uiDescriptorCount = 1;
+  ezUInt32 m_uiWordOffset = 0; ///< Offset of the location in the spirv code where the binding index is located to allow changing it at runtime.
+};
+
+struct ezVulkanDescriptorSetLayout
+{
+  ezUInt32 m_uiSet = 0;
+  ezHybridArray<ezVulkanDescriptorSetLayoutBinding, 6> bindings;
+};
+
+namespace ezSpirvMetaData
+{
+  constexpr ezUInt32 s_uiSpirvMetaDataMagicNumber = 0x4B565A45; //EZVK
+
+  enum MetaDataVersion
+  {
+    Version1 = 1,
+  };
+
+  void Write(ezStreamWriter& stream, const ezArrayPtr<ezUInt8>& shaderCode, const ezDynamicArray<ezVulkanDescriptorSetLayout>& sets)
+  {
+    stream << s_uiSpirvMetaDataMagicNumber;
+    stream.WriteVersion(MetaDataVersion::Version1);
+    const ezUInt32 uiSize = shaderCode.GetCount();
+    stream << uiSize;
+    stream.WriteBytes(shaderCode.GetPtr(), uiSize).AssertSuccess();
+
+    const ezUInt8 uiSets = sets.GetCount();
+    stream << uiSets;
+    for (ezUInt8 i = 0; i < uiSets; i++)
+    {
+      const ezVulkanDescriptorSetLayout& set = sets[i];
+      stream << set.m_uiSet;
+      const ezUInt8 uiBindings = set.bindings.GetCount();
+      stream << uiBindings;
+      for (ezUInt8 j = 0; j < uiBindings; j++)
+      {
+        const ezVulkanDescriptorSetLayoutBinding& binding = set.bindings[j];
+        stream.WriteString(binding.m_sName).AssertSuccess();
+        stream << binding.m_uiBinding;
+        stream << static_cast<ezUInt8>(binding.m_Type);
+        stream << binding.m_uiDescriptorType;
+        stream << binding.m_uiDescriptorCount;
+        stream << binding.m_uiWordOffset;
+      }
+    }
+  }
+
+  /// \brief Reads Vulkan shader code and meta data from a data buffer. Note that 'data' must be kept alive for the lifetime of the shader as this functions stores views into this memory in its out parameters.
+  /// \param data Raw data buffer to read the shader code and meta data from.
+  /// \param out_shaderCode Will be filled with a view into data that contains the shader byte code.
+  /// \param out_sets Will be filled with shader meta data. Note that this array contains string views into 'data'.
+  void Read(const ezArrayPtr<const ezUInt8> data, ezArrayPtr<const ezUInt8>& out_shaderCode, ezDynamicArray<ezVulkanDescriptorSetLayout>& out_sets)
+  {
+    ezRawMemoryStreamReader stream(data.GetPtr(), data.GetCount());
+
+    ezUInt32 uiMagicNumber;
+    stream >> uiMagicNumber;
+    EZ_ASSERT_DEV(uiMagicNumber == s_uiSpirvMetaDataMagicNumber, "Vulkan shader does not start with s_uiSpirvMetaDataMagicNumber");
+    ezTypeVersion uiVersion = stream.ReadVersion(MetaDataVersion::Version1);
+    EZ_ASSERT_DEV(uiVersion == MetaDataVersion::Version1, "Unknown Vulkan shader version '{}'", uiVersion);
+
+    ezUInt32 uiSize = 0;
+    stream >> uiSize;
+    out_shaderCode = ezArrayPtr<const ezUInt8>(&data[(ezUInt32)stream.GetReadPosition()], uiSize);
+    stream.SkipBytes(uiSize);
+
+    ezUInt8 uiSets = 0;
+    stream >> uiSets;
+    out_sets.Reserve(uiSets);
+
+    for (ezUInt8 i = 0; i < uiSets; i++)
+    {
+      ezVulkanDescriptorSetLayout& set = out_sets.ExpandAndGetRef();
+      stream >> set.m_uiSet;
+      ezUInt8 uiBindings = 0;
+      stream >> uiBindings;
+      set.bindings.Reserve(uiBindings);
+
+      for (ezUInt8 j = 0; j < uiBindings; j++)
+      {
+        ezVulkanDescriptorSetLayoutBinding& binding = set.bindings.ExpandAndGetRef();
+
+        ezUInt32 uiStringElements = 0;
+        stream >> uiStringElements;
+        binding.m_sName = ezStringView(reinterpret_cast<const char*>(&data[(ezUInt32)stream.GetReadPosition()]), uiStringElements);
+        stream.SkipBytes(uiStringElements);
+
+        stream >> binding.m_uiBinding;
+        stream >> reinterpret_cast<ezUInt8&>(binding.m_Type);
+        stream >> binding.m_uiDescriptorType;
+        stream >> binding.m_uiDescriptorCount;
+        stream >> binding.m_uiWordOffset;
+      }
+    }
+
+  }
+} // namespace

--- a/Code/Engine/ShaderCompilerDXC/SpirvMetaData.h
+++ b/Code/Engine/ShaderCompilerDXC/SpirvMetaData.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <Foundation/Basics.h>
 #include <Foundation/Containers/HybridArray.h>
-#include <Foundation/IO/Stream.h>
 #include <Foundation/IO/MemoryStream.h>
+#include <Foundation/IO/Stream.h>
 
 struct ezVulkanDescriptorSetLayoutBinding
 {
@@ -114,6 +114,5 @@ namespace ezSpirvMetaData
         stream >> binding.m_uiWordOffset;
       }
     }
-
   }
-} // namespace
+} // namespace ezSpirvMetaData

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -2,9 +2,10 @@
 
 #include <Core/GameState/GameStateWindow.h>
 #include <Core/Graphics/Camera.h>
+#include <RendererTest/Basics/PipelineStates.h>
+
 #include <RendererTest/../../../Data/UnitTests/RendererTest/Shaders/TestConstants.h>
 #include <RendererTest/../../../Data/UnitTests/RendererTest/Shaders/TestInstancing.h>
-#include <RendererTest/Basics/PipelineStates.h>
 
 ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 {

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -2,9 +2,9 @@
 
 #include <Core/GameState/GameStateWindow.h>
 #include <Core/Graphics/Camera.h>
-#include <RendererTest/Basics/PipelineStates.h>
 #include <RendererTest/../../../Data/UnitTests/RendererTest/Shaders/TestConstants.h>
 #include <RendererTest/../../../Data/UnitTests/RendererTest/Shaders/TestInstancing.h>
+#include <RendererTest/Basics/PipelineStates.h>
 
 ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 {
@@ -133,7 +133,7 @@ void ezRendererTestPipelineStates::RenderBlock(ezMeshBufferResourceHandle mesh, 
   {
     ezGALRenderCommandEncoder* pCommandEncoder = BeginRendering(clearColor, uiRenderTargetClearMask, pViewport, pScissor);
     {
-      
+
       if (mesh.IsValid())
       {
         ezRenderContext::GetDefaultInstance()->BindShader(m_hNDCPositionOnlyShader);
@@ -282,7 +282,6 @@ void ezRendererTestPipelineStates::ConstantBufferTest()
           pContext->DrawMeshBuffer(1).AssertSuccess();
         }
       }
-      
     }
     EndRendering();
   }
@@ -323,7 +322,6 @@ void ezRendererTestPipelineStates::StructuredBufferTest()
       pContext->BindBuffer("instancingData", m_pDevice->GetDefaultResourceView(m_hInstancingData));
 
       pContext->DrawMeshBuffer(1, 0, 8).AssertSuccess();
-
     }
     EndRendering();
   }

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -3,6 +3,8 @@
 #include <Core/GameState/GameStateWindow.h>
 #include <Core/Graphics/Camera.h>
 #include <RendererTest/Basics/PipelineStates.h>
+#include <RendererTest/../../../Data/UnitTests/RendererTest/Shaders/TestConstants.h>
+#include <RendererTest/../../../Data/UnitTests/RendererTest/Shaders/TestInstancing.h>
 
 ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 {
@@ -11,6 +13,9 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
   EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
   m_hMostBasicTriangleShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/MostBasicTriangle.ezShader");
   m_hNDCPositionOnlyShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/NDCPositionOnly.ezShader");
+  m_hConstantBufferShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ConstantBuffer.ezShader");
+  m_hInstancingShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Instancing.ezShader");
+
   {
     ezMeshBufferResourceDescriptor desc;
     desc.AddStream(ezGALVertexAttributeSemantic::Position, ezGALResourceFormat::XYZFloat);
@@ -41,6 +46,20 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 
     m_hSphereMesh = ezResourceManager::CreateResource<ezMeshBufferResource>("UnitTest-SphereMesh", std::move(desc), "SphereMesh");
   }
+  m_hTestColorsConstantBuffer = ezRenderContext::CreateConstantBufferStorage<ezTestColors>();
+  m_hTestPositionsConstantBuffer = ezRenderContext::CreateConstantBufferStorage<ezTestPositions>();
+  {
+    ezGALBufferCreationDescription desc;
+    desc.m_uiStructSize = sizeof(ezTestShaderData);
+    desc.m_uiTotalSize = 8 * desc.m_uiStructSize;
+    desc.m_BufferType = ezGALBufferType::Generic;
+    desc.m_bUseAsStructuredBuffer = true;
+    desc.m_bAllowShaderResourceView = true;
+    desc.m_ResourceAccess.m_bImmutable = false;
+
+    m_hInstancingData = m_pDevice->CreateBuffer(desc);
+  }
+
   return EZ_SUCCESS;
 }
 
@@ -48,8 +67,20 @@ ezResult ezRendererTestPipelineStates::DeInitializeSubTest(ezInt32 iIdentifier)
 {
   m_hTriangleMesh.Invalidate();
   m_hSphereMesh.Invalidate();
+
   m_hMostBasicTriangleShader.Invalidate();
   m_hNDCPositionOnlyShader.Invalidate();
+  m_hConstantBufferShader.Invalidate();
+  m_hInstancingShader.Invalidate();
+
+  m_hTestColorsConstantBuffer.Invalidate();
+  m_hTestPositionsConstantBuffer.Invalidate();
+
+  if (!m_hInstancingData.IsInvalidated())
+  {
+    m_pDevice->DestroyBuffer(m_hInstancingData);
+    m_hInstancingData.Invalidate();
+  }
 
   DestroyWindow();
   ShutdownRenderer();
@@ -76,6 +107,12 @@ ezTestAppRun ezRendererTestPipelineStates::RunSubTest(ezInt32 iIdentifier, ezUIn
     case SubTests::ST_IndexBuffer:
       IndexBufferTest();
       break;
+    case SubTests::ST_ConstantBuffer:
+      ConstantBufferTest();
+      break;
+    case SubTests::ST_StructuredBuffer:
+      StructuredBufferTest();
+      break;
     default:
       EZ_ASSERT_NOT_IMPLEMENTED;
       break;
@@ -94,38 +131,9 @@ void ezRendererTestPipelineStates::RenderBlock(ezMeshBufferResourceHandle mesh, 
 {
   m_pPass = m_pDevice->BeginPass("MostBasicTriangle");
   {
-    const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);
-
-    ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture()));
-    renderingSetup.m_ClearColor = clearColor;
-    renderingSetup.m_uiRenderTargetClearMask = uiRenderTargetClearMask;
-    if (!m_hDepthStencilTexture.IsInvalidated())
+    ezGALRenderCommandEncoder* pCommandEncoder = BeginRendering(clearColor, uiRenderTargetClearMask, pViewport, pScissor);
     {
-      renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture));
-      renderingSetup.m_bClearDepth = true;
-      renderingSetup.m_bClearStencil = true;
-    }
-    ezRectFloat viewport = ezRectFloat(0.0f, 0.0f, (float)m_pWindow->GetClientAreaSize().width, (float)m_pWindow->GetClientAreaSize().height);
-    if (pViewport)
-    {
-      viewport = *pViewport;
-    }
-
-    ezGALRenderCommandEncoder* pCommandEncoder = ezRenderContext::GetDefaultInstance()->BeginRendering(m_pPass, renderingSetup, viewport);
-    {
-      static ezHashedString sClipSpaceFlipped = ezMakeHashedString("CLIP_SPACE_FLIPPED");
-      static ezHashedString sTrue = ezMakeHashedString("TRUE");
-      static ezHashedString sFalse = ezMakeHashedString("FALSE");
-      ezClipSpaceYMode::Enum bla = ezClipSpaceYMode::RenderToTextureDefault;
-      ezRenderContext::GetDefaultInstance()->SetShaderPermutationVariable(sClipSpaceFlipped, bla == ezClipSpaceYMode::Flipped ? sTrue : sFalse);
-
-      ezRectU32 scissor = ezRectU32(0, 0, m_pWindow->GetClientAreaSize().width, m_pWindow->GetClientAreaSize().height);
-      if (pScissor)
-      {
-        scissor = *pScissor;
-      }
-      pCommandEncoder->SetScissorRect(scissor);
+      
       if (mesh.IsValid())
       {
         ezRenderContext::GetDefaultInstance()->BindShader(m_hNDCPositionOnlyShader);
@@ -139,11 +147,52 @@ void ezRendererTestPipelineStates::RenderBlock(ezMeshBufferResourceHandle mesh, 
         ezRenderContext::GetDefaultInstance()->DrawMeshBuffer(1).AssertSuccess();
       }
     }
-    ezRenderContext::GetDefaultInstance()->EndRendering();
-    m_pWindow->ProcessWindowMessages();
+    EndRendering();
   }
   m_pDevice->EndPass(m_pPass);
   m_pPass = nullptr;
+}
+
+ezGALRenderCommandEncoder* ezRendererTestPipelineStates::BeginRendering(ezColor clearColor, ezUInt32 uiRenderTargetClearMask, ezRectFloat* pViewport, ezRectU32* pScissor)
+{
+  const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);
+
+  ezGALRenderingSetup renderingSetup;
+  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture()));
+  renderingSetup.m_ClearColor = clearColor;
+  renderingSetup.m_uiRenderTargetClearMask = uiRenderTargetClearMask;
+  if (!m_hDepthStencilTexture.IsInvalidated())
+  {
+    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture));
+    renderingSetup.m_bClearDepth = true;
+    renderingSetup.m_bClearStencil = true;
+  }
+  ezRectFloat viewport = ezRectFloat(0.0f, 0.0f, (float)m_pWindow->GetClientAreaSize().width, (float)m_pWindow->GetClientAreaSize().height);
+  if (pViewport)
+  {
+    viewport = *pViewport;
+  }
+
+  ezGALRenderCommandEncoder* pCommandEncoder = ezRenderContext::GetDefaultInstance()->BeginRendering(m_pPass, renderingSetup, viewport);
+  ezRectU32 scissor = ezRectU32(0, 0, m_pWindow->GetClientAreaSize().width, m_pWindow->GetClientAreaSize().height);
+  if (pScissor)
+  {
+    scissor = *pScissor;
+  }
+  pCommandEncoder->SetScissorRect(scissor);
+
+  static ezHashedString sClipSpaceFlipped = ezMakeHashedString("CLIP_SPACE_FLIPPED");
+  static ezHashedString sTrue = ezMakeHashedString("TRUE");
+  static ezHashedString sFalse = ezMakeHashedString("FALSE");
+  ezClipSpaceYMode::Enum clipSpace = ezClipSpaceYMode::RenderToTextureDefault;
+  ezRenderContext::GetDefaultInstance()->SetShaderPermutationVariable(sClipSpaceFlipped, clipSpace == ezClipSpaceYMode::Flipped ? sTrue : sFalse);
+  return pCommandEncoder;
+}
+
+void ezRendererTestPipelineStates::EndRendering()
+{
+  ezRenderContext::GetDefaultInstance()->EndRendering();
+  m_pWindow->ProcessWindowMessages();
 }
 
 void ezRendererTestPipelineStates::MostBasicTriangleTest()
@@ -183,6 +232,103 @@ void ezRendererTestPipelineStates::VertexBufferTest()
 void ezRendererTestPipelineStates::IndexBufferTest()
 {
   RenderBlock(m_hSphereMesh, ezColor::Orange);
+}
+
+
+ezTransform CreateTransform(const ezUInt32 uiColumns, const ezUInt32 uiRows, ezUInt32 x, ezUInt32 y)
+{
+  ezTransform t = ezTransform::IdentityTransform();
+  t.m_vScale = ezVec3(1.0f / float(uiColumns), 1.0f / float(uiRows), 1);
+  t.m_vPosition = ezVec3(ezMath::Lerp(-1.f, 1.f, (float(x) + 0.5f) / float(uiColumns)), ezMath::Lerp(1.f, -1.f, (float(y) + 0.5f) / float(uiRows)), 0);
+  if (ezClipSpaceYMode::RenderToTextureDefault == ezClipSpaceYMode::Flipped)
+  {
+    ezTransform flipY = ezTransform::IdentityTransform();
+    flipY.m_vScale.y *= -1.0f;
+    t = flipY * t;
+  }
+  return t;
+}
+
+void ezRendererTestPipelineStates::ConstantBufferTest()
+{
+  const ezUInt32 uiColumns = 4;
+  const ezUInt32 uiRows = 2;
+
+  m_pPass = m_pDevice->BeginPass("ConstantBufferTest");
+  {
+    ezGALRenderCommandEncoder* pCommandEncoder = BeginRendering(ezColor::CornflowerBlue, 0xFFFFFFFF);
+    ezRenderContext* pContext = ezRenderContext::GetDefaultInstance();
+    {
+      pContext->BindConstantBuffer("ezTestColors", m_hTestColorsConstantBuffer);
+      pContext->BindConstantBuffer("ezTestPositions", m_hTestPositionsConstantBuffer);
+      pContext->BindShader(m_hConstantBufferShader);
+      pContext->BindNullMeshBuffer(ezGALPrimitiveTopology::Triangles, 1);
+
+      for (ezUInt32 x = 0; x < uiColumns; ++x)
+      {
+        for (ezUInt32 y = 0; y < uiRows; ++y)
+        {
+          {
+            auto constants = ezRenderContext::GetConstantBufferData<ezTestColors>(m_hTestColorsConstantBuffer);
+            constants->VertexColor = ezColor::GetPaletteColor(x * uiRows + y).GetAsVec4();
+          }
+          {
+            ezTransform t = CreateTransform(uiColumns, uiRows, x, y);
+            auto constants = ezRenderContext::GetConstantBufferData<ezTestPositions>(m_hTestPositionsConstantBuffer);
+            constants->Vertex0 = (t * ezVec3(1.f, -1.f, 0.0f)).GetAsVec4(1.0f);
+            constants->Vertex1 = (t * ezVec3(-1.f, -1.f, 0.0f)).GetAsVec4(1.0f);
+            constants->Vertex2 = (t * ezVec3(-0.f, 1.f, 0.0f)).GetAsVec4(1.0f);
+          }
+          pContext->DrawMeshBuffer(1).AssertSuccess();
+        }
+      }
+      
+    }
+    EndRendering();
+  }
+  m_pDevice->EndPass(m_pPass);
+  m_pPass = nullptr;
+}
+
+EZ_DEFINE_AS_POD_TYPE(ezTestShaderData);
+
+void ezRendererTestPipelineStates::StructuredBufferTest()
+{
+  const ezUInt32 uiColumns = 4;
+  const ezUInt32 uiRows = 2;
+
+  ezHybridArray<ezTestShaderData, 8> instanceData;
+  instanceData.SetCountUninitialized(8);
+  for (ezUInt32 x = 0; x < uiColumns; ++x)
+  {
+    for (ezUInt32 y = 0; y < uiRows; ++y)
+    {
+      ezTestShaderData& instance = instanceData[x * uiRows + y];
+      instance.InstanceColor = ezColor::GetPaletteColor(x * uiRows + y).GetAsVec4();
+      ezTransform t = CreateTransform(uiColumns, uiRows, x, y);
+      instance.InstanceTransform = t;
+    }
+  }
+
+  m_pPass = m_pDevice->BeginPass("InstancingTest");
+  {
+    ezGALRenderCommandEncoder* pCommandEncoder = BeginRendering(ezColor::CornflowerBlue, 0xFFFFFFFF);
+
+    pCommandEncoder->UpdateBuffer(m_hInstancingData, 0, instanceData.GetArrayPtr().ToByteArray());
+
+    ezRenderContext* pContext = ezRenderContext::GetDefaultInstance();
+    {
+      pContext->BindShader(m_hInstancingShader);
+      pContext->BindMeshBuffer(m_hTriangleMesh);
+      pContext->BindBuffer("instancingData", m_pDevice->GetDefaultResourceView(m_hInstancingData));
+
+      pContext->DrawMeshBuffer(1, 0, 8).AssertSuccess();
+
+    }
+    EndRendering();
+  }
+  m_pDevice->EndPass(m_pPass);
+  m_pPass = nullptr;
 }
 
 static ezRendererTestPipelineStates g_PipelineStatesTest;

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.h
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.h
@@ -15,6 +15,8 @@ private:
     ST_ViewportScissor,
     ST_VertexBuffer,
     ST_IndexBuffer,
+    ST_ConstantBuffer,
+    ST_StructuredBuffer,
   };
 
   virtual void SetupSubTests() override
@@ -23,6 +25,8 @@ private:
     AddSubTest("02 - ViewportScissor", SubTests::ST_ViewportScissor);
     AddSubTest("03 - VertexBuffer", SubTests::ST_VertexBuffer);
     AddSubTest("04 - IndexBuffer", SubTests::ST_IndexBuffer);
+    AddSubTest("05 - ConstantBuffer", SubTests::ST_ConstantBuffer);
+    AddSubTest("06 - StructuredBuffer", SubTests::ST_StructuredBuffer);
   }
 
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
@@ -31,14 +35,27 @@ private:
 
   void RenderBlock(ezMeshBufferResourceHandle mesh, ezColor clearColor = ezColor::CornflowerBlue, ezUInt32 uiRenderTargetClearMask = 0xFFFFFFFF, ezRectFloat* pViewport = nullptr, ezRectU32* pScissor = nullptr);
 
+  ezGALRenderCommandEncoder* BeginRendering(ezColor clearColor, ezUInt32 uiRenderTargetClearMask, ezRectFloat* pViewport = nullptr, ezRectU32* pScissor = nullptr);
+  void EndRendering();
+
   void MostBasicTriangleTest();
   void ViewportScissorTest();
   void VertexBufferTest();
   void IndexBufferTest();
+  void ConstantBufferTest();
+  void StructuredBufferTest();
 
 private:
   ezShaderResourceHandle m_hMostBasicTriangleShader;
   ezShaderResourceHandle m_hNDCPositionOnlyShader;
+  ezShaderResourceHandle m_hConstantBufferShader;
+  ezShaderResourceHandle m_hInstancingShader;
+
   ezMeshBufferResourceHandle m_hTriangleMesh;
   ezMeshBufferResourceHandle m_hSphereMesh;
+
+  ezConstantBufferStorageHandle m_hTestColorsConstantBuffer;
+  ezConstantBufferStorageHandle m_hTestPositionsConstantBuffer;
+
+  ezGALBufferHandle m_hInstancingData;
 };

--- a/Data/UnitTests/RendererTest/Shaders/ConstantBuffer.ezShader
+++ b/Data/UnitTests/RendererTest/Shaders/ConstantBuffer.ezShader
@@ -1,0 +1,44 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+
+[RENDERSTATE]
+
+DepthTest = false
+CullMode = CullMode_None
+
+[VERTEXSHADER]
+
+#include "TestConstants.h"
+
+struct VS_OUT
+{
+  float4 Position : SV_Position;
+};
+
+VS_OUT main(uint vertexId : SV_VertexID)
+{
+  VS_OUT RetVal;
+  RetVal.Position = Vertex0;
+  if (vertexId == 1)
+	  RetVal.Position = Vertex1;
+  else if (vertexId == 2)
+	  RetVal.Position = Vertex2;
+  return RetVal;
+}
+
+[PIXELSHADER]
+
+#include "TestConstants.h"
+
+struct VS_OUT
+{
+  float4 Position : SV_Position;
+};
+
+float4 main(VS_OUT a) : SV_Target
+{
+  return VertexColor;
+}
+

--- a/Data/UnitTests/RendererTest/Shaders/Instancing.ezShader
+++ b/Data/UnitTests/RendererTest/Shaders/Instancing.ezShader
@@ -1,0 +1,48 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+
+[RENDERSTATE]
+
+DepthTest = false
+CullMode = CullMode_None
+
+[VERTEXSHADER]
+
+#include "TestInstancing.h"
+
+struct VS_IN
+{
+  float3 Position : POSITION;
+};
+
+struct VS_OUT
+{
+  float4 Position : SV_Position;
+  float4 Color : COLOR0;
+};
+
+VS_OUT main(VS_IN Input, uint InstanceID : SV_InstanceID)
+{
+  ezTestShaderData instanceData = instancingData[InstanceID];
+  float4x4 transformMatrix = TransformToMatrix(instanceData.InstanceTransform);
+  VS_OUT RetVal;
+  RetVal.Position = mul(transformMatrix, float4(Input.Position, 1.0f));
+  RetVal.Color = instanceData.InstanceColor;
+  return RetVal;
+}
+
+[PIXELSHADER]
+
+struct VS_OUT
+{
+  float4 Position : SV_Position;
+  float4 Color : COLOR0;
+};
+
+float4 main(VS_OUT a) : SV_Target
+{
+  return a.Color;
+}
+

--- a/Data/UnitTests/RendererTest/Shaders/TestConstants.h
+++ b/Data/UnitTests/RendererTest/Shaders/TestConstants.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../../Base/Shaders/Common/Platforms.h"
 #include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
+#include "../../../Base/Shaders/Common/Platforms.h"
 
 CONSTANT_BUFFER(ezTestColors, 2)
 {

--- a/Data/UnitTests/RendererTest/Shaders/TestConstants.h
+++ b/Data/UnitTests/RendererTest/Shaders/TestConstants.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../../../Base/Shaders/Common/Platforms.h"
+#include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
+
+CONSTANT_BUFFER(ezTestColors, 2)
+{
+  FLOAT4(VertexColor);
+};
+
+CONSTANT_BUFFER(ezTestPositions, 3)
+{
+  FLOAT4(Vertex0);
+  FLOAT4(Vertex1);
+  FLOAT4(Vertex2);
+};

--- a/Data/UnitTests/RendererTest/Shaders/TestConstants.h
+++ b/Data/UnitTests/RendererTest/Shaders/TestConstants.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
 #include "../../../Base/Shaders/Common/Platforms.h"
+
+#include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
 
 CONSTANT_BUFFER(ezTestColors, 2)
 {

--- a/Data/UnitTests/RendererTest/Shaders/TestInstancing.h
+++ b/Data/UnitTests/RendererTest/Shaders/TestInstancing.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
 #include "../../../Base/Shaders/Common/Platforms.h"
+
+#include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
 
 struct EZ_ALIGN_16(ezTestShaderData)
 {

--- a/Data/UnitTests/RendererTest/Shaders/TestInstancing.h
+++ b/Data/UnitTests/RendererTest/Shaders/TestInstancing.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../../../Base/Shaders/Common/Platforms.h"
+#include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
+
+struct EZ_ALIGN_16(ezTestShaderData)
+{
+  FLOAT4(InstanceColor);
+  TRANSFORM(InstanceTransform);
+};
+
+// this is only defined during shader compilation
+#if EZ_ENABLED(PLATFORM_SHADER)
+
+StructuredBuffer<ezTestShaderData> instancingData;
+
+#else // C++
+
+EZ_CHECK_AT_COMPILETIME(sizeof(ezTestShaderData) == 64);
+
+#endif

--- a/Data/UnitTests/RendererTest/Shaders/TestInstancing.h
+++ b/Data/UnitTests/RendererTest/Shaders/TestInstancing.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../../Base/Shaders/Common/Platforms.h"
 #include "../../../Base/Shaders/Common/ConstantBufferMacros.h"
+#include "../../../Base/Shaders/Common/Platforms.h"
 
 struct EZ_ALIGN_16(ezTestShaderData)
 {


### PR DESCRIPTION
## Resource Binding Support
* ezResourceCacheVulkan::RequestDescriptorSetLayout creates a vk::DescriptorSetLayout backed by a hashtable.
* ezDescriptorSetPoolVulkan::CreateDescriptorSet creates new sets until the current pool is exhaused. Pool will return to the ring buffer once no descriptor sets in it are in use anymore.
* ezGALSamplerStateVulkan / ezGALResourceViewVulkan / ezGALBufferVulkan / ezGALUnorderedAccessViewVulkan now have getters for vk::DescriptorImageInfo / vk::DescriptorBufferInfo used to build the descriptor set.

## Vulkan Shader
* The EZ shader system stores reflection data for each individual shader stage. However, in Vulkan all stages combined share the same descriptor binding slots and any collisions between stages must be resolved to build a valid shader. To do so we store meta data in the shader to remap descriptor binding slots at runtime which allos us to deduplicate shader stage code that is used by mulitple shaders.
* Meta data (ezSpirvMetaData) is written into the shader binary blob. It has all the data necessary to reconstruct the descriptor set layout and remap descriptor bindings.
* No versioning info was present in the old shader stage binary blob so any old Vulkan shader cache needs to be deleted.
* Remapping happens in ezGALShaderVulkan::InitPlatform. As the vertex shader is the first stage it never requires remapping. This will build a remapping table as the shader reflection used by the high level renderer is per stage and assumes it can map resources to stages. A remapping table was added to map our descriptor binding to the original per-stage resource binding model. This happens during ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges.

## Buffer Updates
* Implemented ezGALCommandEncoderImplVulkan::UpdateBufferPlatform.
* Added ezGALBufferVulkan::DiscardBuffer which creates a new buffer and puts the old one in a ring buffer to be reclaimed later once it is no longer in use.

## Vulkan Device
* Upgraded to Vulkan 1.1
  * We now use ezClipSpaceYMode::Regular and rely in the Vulkan 1.1 feature that a nagative height performs y-inversion of the clip-space to framebuffer-space transform.
  * Descriptor set pools return vk::Result::eErrorOutOfPoolMemory if exhaused. Removing the requirement to count usage yourself.
* Added SetDebugName to unify setting Vulkan object debug names.
* Added GetCurrentFrame / GetSafeFrame to allow external code to figure out if a resource is still in use. Anything that was touched <= GetSafeFrame is safe to reuse.
* m_uiFrameCounter starts at 1 now to make sure GetCurrentFrame  / GetSafeFrame are not identical at the start.
* Per frame data m_reclaimResources / m_pendingDeletions is now swapped out at the end of the frame with m_reclaimResourcesPrevious / m_pendingDeletionsPrevious respectively to allow resources to be added to the list outside of the renderframe which would have previously filed the objects under an old fence, reclaiming them too early.
* Some code cleanup.

## Unit Tests
* Added a constant buffer test that updates two constant buffers multiple times per frame.
* Added a structured buffer test that updates a buffer each frame used for an instanced draw call of the same scene generated by the previous test.