### PR TITLE
Use the "new" thread name setting functionality

### DIFF
--- a/Code/Engine/Foundation/Threading/Implementation/Win/OSThread_win.h
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/OSThread_win.h
@@ -2,6 +2,7 @@
 EZ_FOUNDATION_INTERNAL_HEADER
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#include <Foundation/Strings/StringConversion.h>
 
 ezAtomicInteger32 ezOSThread::s_iThreadCount;
 
@@ -26,12 +27,50 @@ typedef struct tagTHREADNAME_INFO
 #define EZ_MSVC_WARNING_NUMBER 6312
 #include <Foundation/Basics/Compiler/DisableWarning.h>
 
-void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
+// See https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
+// this is the new way to set thread names which are also stored with crash dumps and work in more tools (like Pix etc.)
+// however it needs to be loaded dynamically from the kernel DLL.
+typedef HRESULT(WINAPI* pfnSetThreadDescription)(HANDLE, PCWSTR);
+
+
+// According to the docs the thread description function lives in kernel32.dll,
+// however on StackOverflow you can find that it seems to be in KernelBase.dll
+// (https://stackoverflow.com/questions/62243162/how-to-access-setthreaddescription-in-windows-2016-server-version-1607)
+// Thus we try to load it from both places just in case things change
+pfnSetThreadDescription GetSetThreadDescriptionProcAddr()
+{
+  pfnSetThreadDescription retVal = nullptr;
+
+  {
+    HMODULE kernel32 = GetModuleHandleA("Kernel32.dll");
+    if (kernel32 != nullptr)
+    {
+      retVal = reinterpret_cast<pfnSetThreadDescription>(GetProcAddress(kernel32, "SetThreadDescription"));
+    }
+
+    if (retVal != nullptr)
+    {
+      return retVal;
+    }
+  }
+
+  {
+    HMODULE kernelBase = GetModuleHandleA("KernelBase.dll");
+    if (kernelBase != nullptr)
+    {
+      retVal = reinterpret_cast<pfnSetThreadDescription>(GetProcAddress(kernelBase, "SetThreadDescription"));
+    }
+  }
+
+  return retVal;
+}
+
+void SetThreadNameViaException(HANDLE hThread, LPCSTR szThreadName)
 {
   THREADNAME_INFO info;
   info.dwType = 0x1000;
   info.szName = szThreadName;
-  info.dwThreadID = dwThreadID;
+  info.dwThreadID = GetThreadId(hThread);
   info.dwFlags = 0;
 
   __try
@@ -41,6 +80,21 @@ void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
   __except (EXCEPTION_CONTINUE_EXECUTION)
   {
     return; // makes the static code analysis happy
+  }
+}
+
+void SetThreadName(HANDLE hThread, LPCSTR szThreadName)
+{
+  static pfnSetThreadDescription s_pSetThreadDescriptionFnPtr = GetSetThreadDescriptionProcAddr();
+
+  if (s_pSetThreadDescriptionFnPtr)
+  {
+    ezStringWChar threadName(szThreadName);
+    s_pSetThreadDescriptionFnPtr(hThread, threadName.GetData());
+  }
+  else
+  {
+    SetThreadNameViaException(hThread, szThreadName);
   }
 }
 
@@ -72,7 +126,7 @@ ezOSThread::ezOSThread(
   // If a name is given, assign it here
   if (szName != nullptr)
   {
-    SetThreadName(GetThreadId(m_Handle), szName);
+    SetThreadName(m_Handle, szName);
   }
 }
 

--- a/Code/Engine/Foundation/Threading/Implementation/Win/OSThread_win.h
+++ b/Code/Engine/Foundation/Threading/Implementation/Win/OSThread_win.h
@@ -27,6 +27,8 @@ typedef struct tagTHREADNAME_INFO
 #define EZ_MSVC_WARNING_NUMBER 6312
 #include <Foundation/Basics/Compiler/DisableWarning.h>
 
+#if EZ_DISABLED(EZ_PLATFORM_WINDOWS_UWP)
+
 // See https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
 // this is the new way to set thread names which are also stored with crash dumps and work in more tools (like Pix etc.)
 // however it needs to be loaded dynamically from the kernel DLL.
@@ -65,6 +67,8 @@ pfnSetThreadDescription GetSetThreadDescriptionProcAddr()
   return retVal;
 }
 
+#endif
+
 void SetThreadNameViaException(HANDLE hThread, LPCSTR szThreadName)
 {
   THREADNAME_INFO info;
@@ -85,6 +89,7 @@ void SetThreadNameViaException(HANDLE hThread, LPCSTR szThreadName)
 
 void SetThreadName(HANDLE hThread, LPCSTR szThreadName)
 {
+#if EZ_DISABLED(EZ_PLATFORM_WINDOWS_UWP)
   static pfnSetThreadDescription s_pSetThreadDescriptionFnPtr = GetSetThreadDescriptionProcAddr();
 
   if (s_pSetThreadDescriptionFnPtr)
@@ -96,6 +101,9 @@ void SetThreadName(HANDLE hThread, LPCSTR szThreadName)
   {
     SetThreadNameViaException(hThread, szThreadName);
   }
+#else
+  SetThreadNameViaException(hThread, szThreadName);
+#endif
 }
 
 #include <Foundation/Basics/Compiler/RestoreWarning.h>


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
this is the new way to set thread names which are also stored with crash dumps and work in more tools (like Pix etc.)