### PR TITLE
Fix bugs in ezStringUtils::StartsWith and ezStringBuilder::MakeRelativeTo

### DIFF
--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
@@ -972,7 +972,10 @@ ezResult ezStringBuilder::MakeRelativeTo(const char* szAbsolutePathToMakeThisRel
     if (sAbsBase.GetData()[iSame] != '/')
       continue;
 
-    if (sAbsBase.IsEqualN_NoCase(sAbsThis.GetData(), iSame + 1))
+    // We need to check here if sAbsThis starts with sAbsBase in the range[0, iSame + 1]. However, we can't compare the first N bytes because those might not be a valid utf8 substring in absBase.
+    // Thus we can't use IsEqualN_NoCase as N would need to be the number of characters, not bytes. Computing the number of characters in absBase would mean iterating the string twice.
+    // As an alternative, as we know [0, iSame + 1] is a valid utf8 string in sAbsBase we can ask whether absThis starts with that substring.
+    if (ezStringUtils::StartsWith_NoCase(sAbsThis.GetData(), sAbsBase.GetData(), sAbsThis.GetData() + sAbsThis.GetElementCount(), sAbsBase.GetData() + iSame + 1))
       break;
   }
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringUtils.cpp
@@ -526,7 +526,7 @@ bool ezStringUtils::StartsWith(const char* szString, const char* szStartsWith, c
   }
 
   // if both are equally long, this comparison will return true
-  return (*szStartsWith == '\0');
+  return (*szStartsWith == '\0' || szStartsWith == szStartsWithEnd);
 }
 
 bool ezStringUtils::StartsWith_NoCase(const char* szString, const char* szStartsWith, const char* pStringEnd, const char* szStartsWithEnd)
@@ -550,7 +550,7 @@ bool ezStringUtils::StartsWith_NoCase(const char* szString, const char* szStarts
   }
 
   // if both are equally long, this comparison will return true
-  return (*szStartsWith == '\0');
+  return (*szStartsWith == '\0' || szStartsWith == szStartsWithEnd);
 }
 
 bool ezStringUtils::EndsWith(const char* szString, const char* szEndsWith, const char* pStringEnd, const char* szEndsWithEnd)

--- a/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
@@ -1327,64 +1327,64 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
   {
     ezStringBuilder p;
 
-    p = "a/b\\c/d\\\\e/f/g";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c").Succeeded());
+    p = u8"ä/b\\c/d\\\\e/f/g";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c").Succeeded());
     EZ_TEST_BOOL(p == "d/e/f/g");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c").Failed());
-    EZ_TEST_BOOL(p == "d/e/f/g");
-
-    p = "a/b\\c//d\\\\e/f/g";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c").Succeeded());
-    EZ_TEST_BOOL(p == "d/e/f/g");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c").Failed());
     EZ_TEST_BOOL(p == "d/e/f/g");
 
-    p = "a/b\\c/d\\\\e/f/g";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c/").Succeeded());
+    p = u8"ä/b\\c//d\\\\e/f/g";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c").Succeeded());
     EZ_TEST_BOOL(p == "d/e/f/g");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c/").Failed());
-    EZ_TEST_BOOL(p == "d/e/f/g");
-
-    p = "a/b\\c//d\\\\e/f/g";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c/").Succeeded());
-    EZ_TEST_BOOL(p == "d/e/f/g");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c/").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c").Failed());
     EZ_TEST_BOOL(p == "d/e/f/g");
 
-    p = "a/b\\c//d\\\\e/f/g";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c\\/d/\\e\\f/g").Succeeded());
+    p = u8"ä/b\\c/d\\\\e/f/g";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c/").Succeeded());
+    EZ_TEST_BOOL(p == "d/e/f/g");
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c/").Failed());
+    EZ_TEST_BOOL(p == "d/e/f/g");
+
+    p = u8"ä/b\\c//d\\\\e/f/g";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c/").Succeeded());
+    EZ_TEST_BOOL(p == "d/e/f/g");
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c/").Failed());
+    EZ_TEST_BOOL(p == "d/e/f/g");
+
+    p = u8"ä/b\\c//d\\\\e/f/g";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c\\/d/\\e\\f/g").Succeeded());
     EZ_TEST_BOOL(p == "");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c\\/d/\\e\\f/g").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c\\/d/\\e\\f/g").Failed());
     EZ_TEST_BOOL(p == "");
 
-    p = "a/b\\c//d\\\\e/f/g/";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c\\/d//e\\f/g\\h/i").Succeeded());
+    p = u8"ä/b\\c//d\\\\e/f/g/";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c\\/d//e\\f/g\\h/i").Succeeded());
     EZ_TEST_BOOL(p == "../../");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c\\/d//e\\f/g\\h/i").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c\\/d//e\\f/g\\h/i").Failed());
     EZ_TEST_BOOL(p == "../../");
 
-    p = "a/b\\c//d\\\\e/f/g/j/k";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c\\/d//e\\f/g\\h/i").Succeeded());
+    p = u8"ä/b\\c//d\\\\e/f/g/j/k";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c\\/d//e\\f/g\\h/i").Succeeded());
     EZ_TEST_BOOL(p == "../../j/k");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c\\/d//e\\f/g\\h/i").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c\\/d//e\\f/g\\h/i").Failed());
     EZ_TEST_BOOL(p == "../../j/k");
 
-    p = "a/b\\c//d\\\\e/f/ge";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c//d/\\e\\f/g\\h/i").Succeeded());
+    p = u8"ä/b\\c//d\\\\e/f/ge";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c//d/\\e\\f/g\\h/i").Succeeded());
     EZ_TEST_BOOL(p == "../../../ge");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c//d/\\e\\f/g\\h/i").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c//d/\\e\\f/g\\h/i").Failed());
     EZ_TEST_BOOL(p == "../../../ge");
 
-    p = "a/b\\c//d\\\\e/f/g.txt";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c//d//e\\f/g\\h/i").Succeeded());
+    p = u8"ä/b\\c//d\\\\e/f/g.txt";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c//d//e\\f/g\\h/i").Succeeded());
     EZ_TEST_BOOL(p == "../../../g.txt");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c//d//e\\f/g\\h/i").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c//d//e\\f/g\\h/i").Failed());
     EZ_TEST_BOOL(p == "../../../g.txt");
 
-    p = "a/b\\c//d\\\\e/f/g";
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c//d//e\\f/g\\h/i").Succeeded());
+    p = u8"ä/b\\c//d\\\\e/f/g";
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c//d//e\\f/g\\h/i").Succeeded());
     EZ_TEST_BOOL(p == "../../");
-    EZ_TEST_BOOL(p.MakeRelativeTo("a\\b/c//d//e\\f/g\\h/i").Failed());
+    EZ_TEST_BOOL(p.MakeRelativeTo(u8"ä\\b/c//d//e\\f/g\\h/i").Failed());
     EZ_TEST_BOOL(p == "../../");
   }
 

--- a/Code/UnitTests/FoundationTest/Strings/StringUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringUtilsTest.cpp
@@ -518,10 +518,15 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringUtils)
     EZ_TEST_BOOL(ezStringUtils::StartsWith("abcdef", "Abc") == false);
 
     // substring test
-    const char* sz = "abc def ghi";
-    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, "abc", sz + 3) == true);
-    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, "abc", sz + 2) == false);
-    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, "abc", sz + 0) == false);
+    const char* sz = u8"äbc def ghi";
+    const ezUInt32 uiByteCount = ezStringUtils::GetStringElementCount(u8"äbc");
+
+    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, u8"äbc", sz + uiByteCount) == true);
+    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, u8"äbc", sz + uiByteCount - 1) == false);
+    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, u8"äbc", sz + 0) == false);
+
+    const char* sz2 = u8"äbc def";
+    EZ_TEST_BOOL(ezStringUtils::StartsWith(sz, sz2, sz + uiByteCount, sz2 + uiByteCount) == true);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "StartsWith_NoCase")
@@ -546,10 +551,14 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringUtils)
     EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sL.GetData(), sU.GetData()) == true);
 
     // substring test
-    const char* sz = "abc def ghi";
-    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, "ABC", sz + 3) == true);
-    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, "ABC", sz + 2) == false);
-    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, "ABC", sz + 0) == false);
+    const char* sz = u8"äbc def ghi";
+    const ezUInt32 uiByteCount = ezStringUtils::GetStringElementCount(u8"äbc");
+    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, u8"ÄBC", sz + uiByteCount) == true);
+    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, u8"ÄBC", sz + uiByteCount - 1) == false);
+    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, u8"ÄBC", sz + 0) == false);
+
+    const char* sz2 = u8"Äbc def";
+    EZ_TEST_BOOL(ezStringUtils::StartsWith_NoCase(sz, sz2, sz + uiByteCount, sz2 + uiByteCount) == true);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "EndsWith")


### PR DESCRIPTION
- Fixed a bug in ezStringUtils::StartsWith that did not account for the szStartsWith string not being null-terminated.
- Fixed a bug in ezStringBuilder::MakeRelativeTo that mistakenly used element count as an input into a function that expects character count. To prevent having to itterate the string twice to compute the character count, the function now uses StartsWith_NoCase to check for equality of the two strings' front.