### PR TITLE
Add support for using the fast linux linker 'mold'

### DIFF
--- a/Code/BuildSystem/CMake/ezUtils.cmake
+++ b/Code/BuildSystem/CMake/ezUtils.cmake
@@ -242,8 +242,12 @@ function(ez_set_library_properties TARGET_NAME)
     ez_pull_all_vars()
 
     if (EZ_CMAKE_PLATFORM_LINUX)
-        # Workaround for: https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
-        target_link_libraries (${TARGET_NAME} PRIVATE -lgcc_s -lgcc pthread rt)
+        target_link_libraries (${TARGET_NAME} PRIVATE pthread rt)
+
+        if (EZ_CMAKE_COMPILER_GCC)
+            # Workaround for: https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
+            target_link_libraries (${TARGET_NAME} PRIVATE -lgcc_s -lgcc)
+        endif()
     endif ()
 
     if (EZ_CMAKE_PLATFORM_OSX OR EZ_CMAKE_PLATFORM_LINUX)


### PR DESCRIPTION
* Add support for the new drop-in replacement linker 'mold' (https://github.com/rui314/mold). Mold is significantly faster then all other available linkers on linux. For example when linking FoundationTests build with gcc the link time is reduced by a factor of 10x.