### PR TITLE
Only use PCH when generating a Visual Studio Solution

### DIFF
--- a/Code/BuildSystem/CMake/ezUtilsDetect.cmake
+++ b/Code/BuildSystem/CMake/ezUtilsDetect.cmake
@@ -187,7 +187,7 @@ function(ez_detect_generator)
 
 	if (EZ_CMAKE_PLATFORM_WINDOWS) # Supported windows generators
 	
-	  if (MSVC)
+	  if (CMAKE_GENERATOR MATCHES "Visual Studio")
 	  
 			# Visual Studio (All VS generators define MSVC)
 			message (STATUS "Generator is MSVC (EZ_CMAKE_GENERATOR_MSVC)")
@@ -195,7 +195,7 @@ function(ez_detect_generator)
 			set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_MSVC ON)
 			set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_PREFIX "Vs")
 			set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_CONFIGURATION $<CONFIGURATION>)
-	  elseif(CMAKE_GENERATOR STREQUAL "Ninja") # Ninja makefiles. Only makefile format supported by Visual Studio Open Folder
+	  elseif(CMAKE_GENERATOR MATCHES "Ninja") # Ninja makefiles. Only makefile format supported by Visual Studio Open Folder
 			message (STATUS "Buildsystem is Ninja (EZ_CMAKE_GENERATOR_NINJA)")
 			
 			set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_NINJA ON)

--- a/Code/BuildSystem/CMake/ezUtilsPCH.cmake
+++ b/Code/BuildSystem/CMake/ezUtilsPCH.cmake
@@ -37,7 +37,7 @@ endfunction()
 
 function(ez_pch_use PCH_H TARGET_CPPS)
 
-  if (NOT MSVC)
+  if (NOT EZ_CMAKE_GENERATOR_MSVC)
     return()
   endif()
 
@@ -68,7 +68,7 @@ endfunction()
 
 function(ez_pch_create PCH_H TARGET_CPP)
 
-  if (NOT MSVC)
+  if (NOT EZ_CMAKE_GENERATOR_MSVC)
     return()
   endif()
 


### PR DESCRIPTION
This allows to build on windows using ninja + msvc, which currently doesn't work due to PCH issues.