### PR TITLE
Precompiled Header support for non Visual Studio targets.

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsPCH.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsPCH.cmake
@@ -9,6 +9,11 @@ function(ez_set_target_pch TARGET_NAME PCH_NAME)
 
 	# message(STATUS "Setting PCH for '${TARGET_NAME}': ${PCH_NAME}")
 	set_property(TARGET ${TARGET_NAME} PROPERTY "PCH_FILE_NAME" ${PCH_NAME})
+
+	if(NOT EZ_CMAKE_GENERATOR_MSVC)
+		# When not generating a Visual Studio solution we use the cmake build in PCH support
+		target_precompile_headers(${TARGET_NAME} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${PCH_NAME}.h>")
+	endif()
 endfunction()
 
 # #####################################


### PR DESCRIPTION
* Use the cmake precompiled header support when not generating for Visual Studio. This brings PCH support to all platforms.

This change cuts the linux build times on my machine in half.

When generating a visual studio solution, we still want to use our old approach is it is superior
* CMake will generate two PCHs. One für C and one for C++, which is not required when compiling with msvc
* CMake will generate a new PCH file instead of using our already existing pch.h