### PR TITLE
Add auto downloading of vulkan SDK on linux.

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Linux-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Linux-x64.yml
@@ -37,7 +37,7 @@ jobs:
   - task: CMake@1
     displayName: CMake
     inputs:
-      cmakeArgs: -DCMAKE_PREFIX_PATH=/opt/qt511/ -DCMAKE_BUILD_TYPE=Dev -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12 -DEZ_ENABLE_FOLDER_UNITY_FILES=$(unityfiles) -G "Unix Makefiles" ../
+      cmakeArgs: -DCMAKE_PREFIX_PATH=/opt/qt511/ -DCMAKE_BUILD_TYPE=Dev -DCMAKE_CXX_COMPILER=g++-12 -DCMAKE_C_COMPILER=gcc-12 -DEZ_ENABLE_FOLDER_UNITY_FILES=$(unityfiles) -DEZ_BUILD_EXPERIMENTAL_VULKAN=ON -G "Unix Makefiles" ../
   - task: Bash@3
     displayName: Make
     inputs:

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -206,7 +206,7 @@ function(ez_set_build_flags_clang TARGET_NAME)
 	endif()
 
 	if(NOT(CMAKE_CURRENT_SOURCE_DIR MATCHES "Code/ThirdParty"))
-		target_compile_options(${TARGET_NAME} PRIVATE -Werror=inconsistent-missing-override -Werror=switch -Werror=uninitialized -Werror=unused-result)
+		target_compile_options(${TARGET_NAME} PRIVATE -Werror=inconsistent-missing-override -Werror=switch -Werror=uninitialized -Werror=unused-result -Werror=return-type)
 	else()
 		# Ignore all warnings in third party code.
 		target_compile_options(${TARGET_NAME} PRIVATE -Wno-everything)
@@ -252,10 +252,10 @@ function(ez_set_build_flags_gcc TARGET_NAME)
 		# Warning / Error settings for ez code
 		# attributes = error if a attribute is placed incorrectly (e.g. EZ_FOUNDATION_DLL)
 		# unused-result = error if [[nodiscard]] return value is not handeled (ezResult)
-		target_compile_options(${TARGET_NAME} PRIVATE -Werror=attributes -Werror=unused-result -Wno-ignored-attributes)
+		target_compile_options(${TARGET_NAME} PRIVATE -Werror=attributes -Werror=unused-result -Wno-ignored-attributes -Werror=return-type)
 	else()
 		# Ignore all warnings in third party code.
-		target_compile_options(${TARGET_NAME} PRIVATE -Wno-everything)
+		target_compile_options(${TARGET_NAME} PRIVATE -w)
 	endif()
 
 	# Look for the super fast ld compatible linker called "mold". If present we want to use it.

--- a/Code/BuildSystem/CMake/FindEzVulkan.cmake
+++ b/Code/BuildSystem/CMake/FindEzVulkan.cmake
@@ -8,6 +8,7 @@ endif()
 set(EZ_VULKAN_DIR $ENV{VULKAN_SDK} CACHE PATH "Directory of the Vulkan SDK")
 
 ez_pull_compiler_and_architecture_vars()
+ez_pull_config_vars()
 
 get_property(EZ_SUBMODULE_PREFIX_PATH GLOBAL PROPERTY EZ_SUBMODULE_PREFIX_PATH)
 
@@ -34,8 +35,24 @@ elseif(EZ_CMAKE_PLATFORM_LINUX AND EZ_CMAKE_ARCHITECTURE_64BIT)
 			PATHS
 			${EZ_VULKAN_DIR}
 			$ENV{VULKAN_SDK}
-			REQUIRED
 		)
+
+		if(EZ_CMAKE_ARCHITECTURE_X86)
+			if((EZ_VULKAN_DIR STREQUAL "EZ_VULKAN_DIR-NOTFOUND") OR (EZ_VULKAN_DIR STREQUAL ""))
+				ez_download_and_extract("${EZ_CONFIG_VULKAN_SDK_LINUXX64_URL}" "${CMAKE_BINARY_DIR}/vulkan-sdk" "vulkan-sdk-${EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION}")
+				set(EZ_VULKAN_DIR "${CMAKE_BINARY_DIR}/vulkan-sdk/${EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION}" CACHE PATH "Directory of the Vulkan SDK" FORCE)
+
+				find_path(EZ_VULKAN_DIR config/vk_layer_settings.txt
+					PATHS
+					${EZ_VULKAN_DIR}
+					$ENV{VULKAN_SDK}
+				)
+			endif()
+		endif()
+
+		if((EZ_VULKAN_DIR STREQUAL "EZ_VULKAN_DIR-NOTFOUND") OR (EZ_VULKAN_DIR STREQUAL ""))
+			message(FATAL_ERROR "Failed to find vulkan SDK. Ez requires the vulkan sdk ${EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION}. Please set the environment variable VULKAN_SDK to the vulkan sdk location.")
+		endif()
 
 		# set(CMAKE_FIND_DEBUG_MODE FALSE)
 	endif()

--- a/Code/BuildSystem/CMake/ezUtils.cmake
+++ b/Code/BuildSystem/CMake/ezUtils.cmake
@@ -27,6 +27,9 @@ macro(ez_pull_config_vars)
 
 	get_property(EZ_CONFIG_QT_WINX64_URL GLOBAL PROPERTY EZ_CONFIG_QT_WINX64_URL)
 	get_property(EZ_CONFIG_QT_WINX64_VERSION GLOBAL PROPERTY EZ_CONFIG_QT_WINX64_VERSION)
+
+	get_property(EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION GLOBAL PROPERTY EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION)
+	get_property(EZ_CONFIG_VULKAN_SDK_LINUXX64_URL GLOBAL PROPERTY EZ_CONFIG_VULKAN_SDK_LINUXX64_URL)
 endmacro()
 
 # #####################################
@@ -591,7 +594,11 @@ endfunction()
 # ## ez_download_and_extract(<url-to-download> <dest-folder-path> <dest-filename-without-extension>)
 # #####################################
 function(ez_download_and_extract URL DEST_FOLDER DEST_FILENAME)
-	get_filename_component(PKG_TYPE ${URL} LAST_EXT)
+	if(${URL} MATCHES ".tar.gz$")
+		set(PKG_TYPE "tar.gz")
+	else()
+		get_filename_component(PKG_TYPE ${URL} LAST_EXT)
+	endif()
 
 	set(FULL_FILENAME "${DEST_FILENAME}.${PKG_TYPE}")
 	set(PKG_FILE "${DEST_FOLDER}/${FULL_FILENAME}")

--- a/Code/Engine/RendererVulkan/Resources/QueryVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/QueryVulkan.h
@@ -6,7 +6,7 @@ class ezGALQueryVulkan : public ezGALQuery
 {
 public:
   EZ_ALWAYS_INLINE ezUInt32 GetID() const;
-  EZ_ALWAYS_INLINE vk::QueryPool GetPool() const {} // TODO
+  EZ_ALWAYS_INLINE vk::QueryPool GetPool() const { return nullptr; } // TODO
 
 protected:
   friend class ezGALDeviceVulkan;

--- a/ezCMakeConfig.cmake
+++ b/ezCMakeConfig.cmake
@@ -16,3 +16,6 @@ set_property(GLOBAL PROPERTY EZ_CONFIG_PATH_7ZA "${CMAKE_SOURCE_DIR}/Data/Tools/
 set_property(GLOBAL PROPERTY EZ_CONFIG_QT_WINX64_VERSION "Qt-5.13.0-vs141-x64")
 set_property(GLOBAL PROPERTY EZ_CONFIG_QT_WINX64_URL "https://github.com/ezEngine/thirdparty/releases/download/Qt-5.13.0-vs141-x64/Qt-5.13.0-vs141-x64.zip")
 
+set_property(GLOBAL PROPERTY EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION "1.3.216.0")
+set_property(GLOBAL PROPERTY EZ_CONFIG_VULKAN_SDK_LINUXX64_URL "https://sdk.lunarg.com/sdk/download/1.3.216.0/linux/vulkansdk-linux-x86_64-1.3.216.0.tar.gz")
+


### PR DESCRIPTION
* If no Vulkan SDK path was specified, cmake will now download the Vulkan SDK on linux.
* Linux CI now builds the Vulkan renderer.
* Make not returning a value from a function an error in gcc & clang