### PR TITLE
MSFT contributions to fix Win32 build

### DIFF
--- a/Code/Engine/Foundation/IO/Implementation/MemoryStream.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/MemoryStream.cpp
@@ -32,9 +32,9 @@ ezUInt64 ezMemoryStreamReader::ReadBytes(void* pReadBuffer, ezUInt64 uiBytesToRe
 
       const ezUInt64 toRead = ezMath::Min<ezUInt64>(data.GetCount(), uiBytesLeft);
 
-      ezMemoryUtils::Copy(static_cast<ezUInt8*>(pReadBuffer), data.GetPtr(), toRead);
+      ezMemoryUtils::Copy(static_cast<ezUInt8*>(pReadBuffer), data.GetPtr(), static_cast<size_t>(toRead)); // Down-cast to size_t for 32-bit.
 
-      pReadBuffer = ezMemoryUtils::AddByteOffset(pReadBuffer, toRead);
+      pReadBuffer = ezMemoryUtils::AddByteOffset(pReadBuffer, static_cast<size_t>(toRead)); // Down-cast to size_t for 32-bit.
 
       m_uiReadPosition += toRead;
       uiBytesLeft -= toRead;
@@ -118,9 +118,9 @@ ezResult ezMemoryStreamWriter::WriteBytes(const void* pWriteBuffer, ezUInt64 uiB
 
       const ezUInt64 toWrite = ezMath::Min<ezUInt64>(data.GetCount(), uiBytesLeft);
 
-      ezMemoryUtils::Copy(data.GetPtr(), static_cast<const ezUInt8*>(pWriteBuffer), toWrite);
+      ezMemoryUtils::Copy(data.GetPtr(), static_cast<const ezUInt8*>(pWriteBuffer), static_cast<size_t>(toWrite)); // Down-cast to size_t for 32-bit.
 
-      pWriteBuffer = ezMemoryUtils::AddByteOffset(pWriteBuffer, toWrite);
+      pWriteBuffer = ezMemoryUtils::AddByteOffset(pWriteBuffer, static_cast<size_t>(toWrite)); // Down-cast to size_t for 32-bit.
 
       m_uiWritePosition += toWrite;
       uiBytesLeft -= toWrite;

--- a/Code/Engine/Foundation/Math/Implementation/Math_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Math_inl.h
@@ -88,7 +88,22 @@ namespace ezMath
     return 0;
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     unsigned long uiIndex = 0;
+#if EZ_ENABLED(EZ_PLATFORM_64BIT)
+
     _BitScanForward64(&uiIndex, value);
+#else
+    uint32_t lower = static_cast<uint32_t>(value);
+    unsigned char returnCode = _BitScanForward(&uiIndex, lower);
+    if (returnCode == 0)
+    {
+      uint32_t upper = static_cast<uint32_t>(value >> 32);
+      returnCode = _BitScanForward(&uiIndex, upper);
+      if (returnCode > 0) // Only can happen in Release build when EZ_ASSERT_DEBUG(value != 0) would fail.
+      {
+        uiIndex += 32; // Add length of lower to index.
+      }
+    }
+#endif
     return uiIndex;
 #elif EZ_ENABLED(EZ_COMPILER_GCC) || EZ_ENABLED(EZ_COMPILER_CLANG)
     return __builtin_ctzll(value);
@@ -122,7 +137,21 @@ namespace ezMath
     return 0;
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     unsigned long uiIndex = 0;
+#if EZ_ENABLED(EZ_PLATFORM_64BIT)
     _BitScanReverse64(&uiIndex, value);
+#else
+    uint32_t upper = static_cast<uint32_t>(value >> 32);
+    unsigned char returnCode = _BitScanReverse(&uiIndex, upper);
+    if (returnCode == 0)
+    {
+      uint32_t lower = static_cast<uint32_t>(value);
+      returnCode = _BitScanReverse(&uiIndex, lower);
+    }
+    else
+    {
+      uiIndex += 32; // Add length of upper to index.
+    }
+#endif
     return uiIndex;
 #elif EZ_ENABLED(EZ_COMPILER_GCC) || EZ_ENABLED(EZ_COMPILER_CLANG)
     return 63 - __builtin_clzll(value);

--- a/Code/Engine/Foundation/Memory/Implementation/AllocatorBase_inl.h
+++ b/Code/Engine/Foundation/Memory/Implementation/AllocatorBase_inl.h
@@ -61,7 +61,7 @@ namespace ezInternal
   EZ_FORCE_INLINE T* CreateRawBuffer(ezAllocatorBase* pAllocator, size_t uiCount)
   {
     ezUInt64 safeAllocationSize = ezMath::SafeMultiply64(uiCount, sizeof(T));
-    return static_cast<T*>(pAllocator->Allocate(safeAllocationSize, EZ_ALIGNMENT_OF(T)));
+    return static_cast<T*>(pAllocator->Allocate(static_cast<size_t>(safeAllocationSize), EZ_ALIGNMENT_OF(T))); // Down-cast to size_t for 32-bit
   }
 
   EZ_FORCE_INLINE void DeleteRawBuffer(ezAllocatorBase* pAllocator, void* ptr)

--- a/Code/UnitTests/FoundationTest/Math/MathTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/MathTest.cpp
@@ -756,6 +756,10 @@ EZ_CREATE_SIMPLE_TEST(Math, General)
     EZ_TEST_INT(ezMath::FirstBitLow(ezUInt64(0xFF000000FF00000C)), 2);
     EZ_TEST_INT(ezMath::FirstBitLow(ezUInt64(0xFF000000FF000008)), 3);
     EZ_TEST_INT(ezMath::FirstBitLow(ezUInt64(0xFFFFFFFFFFFFFFFF)), 0);
+
+    // Edge cases specifically for 32-bit systems where upper and lower 32-bit are handled individually.
+    EZ_TEST_INT(ezMath::FirstBitLow(ezUInt64(0x00000000FFFFFFFF)), 0);
+    EZ_TEST_INT(ezMath::FirstBitLow(ezUInt64(0xFFFFFFFF00000000)), 32);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "FirstBitHigh")
@@ -771,6 +775,10 @@ EZ_CREATE_SIMPLE_TEST(Math, General)
     EZ_TEST_INT(ezMath::FirstBitHigh(ezUInt64(0x003F000000FF000F)), 53);
     EZ_TEST_INT(ezMath::FirstBitHigh(ezUInt64(0x001F000000FF000F)), 52);
     EZ_TEST_INT(ezMath::FirstBitHigh(ezUInt64(0xFFFFFFFFFFFFFFFF)), 63);
+
+    // Edge cases specifically for 32-bit systems where upper and lower 32-bit are handled individually.
+    EZ_TEST_INT(ezMath::FirstBitHigh(ezUInt64(0x00000000FFFFFFFF)), 31);
+    EZ_TEST_INT(ezMath::FirstBitHigh(ezUInt64(0xFFFFFFFF00000000)), 63);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "CountTrailingZeros (32)")


### PR DESCRIPTION
HAR Windows UWP ARM 32-bit build failed due to functions _BitScanReverse64 and _BitScanForward64 not being available in Windows API plus some warnings as errors regarding size_t.