### PR TITLE
Unlock shadow view mutex to prevent deadlocks

### DIFF
--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -296,8 +296,13 @@ struct ezShadowPool::Data
     renderTargets.m_hDSTarget = m_hShadowAtlasTexture;
     pView->SetRenderTargets(renderTargets);
 
+    EZ_ASSERT_DEV(m_ShadowViewsMutex.IsLocked(), "m_ShadowViewsMutex must be locked at this point.");
+    m_ShadowViewsMutex.Unlock(); // if the resource gets loaded in the call below, his could lead to a deadlock
+
     // ShadowMapRenderPipeline.ezRenderPipelineAsset
     pView->SetRenderPipelineResource(ezResourceManager::LoadResource<ezRenderPipelineResource>("{ 4f4d9f16-3d47-4c67-b821-a778f11dcaf5 }"));
+
+    m_ShadowViewsMutex.Lock();
 
     // Set viewport size to something valid, this will be changed to the proper location in the atlas texture in OnEndExtraction before
     // rendering.


### PR DESCRIPTION
When many prefabs are opened at editor startup, all views try to create a shadow view. For that they try to enter this mutex on worker threads and will block the worker threads, without the tasksystem being aware of this. One thread enters the mutex and then attempts to load a pipeline, which can't be done on the same thread. However, all workers are blocked by the shadow mutex and thus no worker thread is available and we have a deadlock. The fix is to not be in the mutex while the pipeline gets loaded.

Fixes #634 