### PR TITLE
Provide optimal ways to construct a ezStringView from a literal

### DIFF
--- a/Code/Engine/Foundation/Strings/Implementation/StringUtils_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringUtils_inl.h
@@ -21,7 +21,7 @@ inline ezInt32 ezStringUtils::CompareChars_NoCase(const char* szUtf8Char1, const
 }
 
 template <typename T>
-EZ_ALWAYS_INLINE bool ezStringUtils::IsNullOrEmpty(const T* pString)
+EZ_ALWAYS_INLINE constexpr bool ezStringUtils::IsNullOrEmpty(const T* pString)
 {
   return (pString == nullptr) || (pString[0] == '\0');
 }
@@ -41,6 +41,21 @@ EZ_ALWAYS_INLINE void ezStringUtils::UpdateStringEnd(const T* szStringStart, con
   szStringEnd = szStringStart + GetStringElementCount(szStringStart, ezUnicodeUtils::GetMaxStringEnd<T>());
 }
 
+template <typename T>
+constexpr ezUInt32 ezStringUtils::GetStringElementCount(const T* pString)
+{
+  if (IsNullOrEmpty(pString))
+    return 0;
+
+  ezUInt32 uiCount = 0;
+  while ((*pString != '\0'))
+  {
+    ++pString;
+    ++uiCount;
+  }
+
+  return uiCount;
+}
 
 template <typename T>
 ezUInt32 ezStringUtils::GetStringElementCount(const T* pString, const T* pStringEnd)

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -68,7 +68,7 @@ inline void ezStringView::Trim(const char* szTrimCharsStart, const char* szTrimC
     ezStringUtils::Trim(m_pStart, m_pEnd, szTrimCharsStart, szTrimCharsEnd);
 }
 
-constexpr ezStringView operator "" _ezsv(const char* pString, size_t len)
+constexpr ezStringView operator"" _ezsv(const char* pString, size_t len)
 {
   return ezStringView(pString, static_cast<ezUInt32>(len));
 }

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -68,7 +68,7 @@ inline void ezStringView::Trim(const char* szTrimCharsStart, const char* szTrimC
     ezStringUtils::Trim(m_pStart, m_pEnd, szTrimCharsStart, szTrimCharsEnd);
 }
 
-constexpr ezStringView ezLiterals::operator"" _sv(const char* pString, size_t len)
+constexpr ezStringView operator "" _ezsv(const char* pString, size_t len)
 {
   return ezStringView(pString, static_cast<ezUInt32>(len));
 }

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -3,8 +3,8 @@
 inline ezStringView::ezStringView() = default;
 
 constexpr inline ezStringView::ezStringView(const char* pStart)
-: m_pStart(pStart)
-, m_pEnd(pStart + ezStringUtils::GetStringElementCount(pStart))
+  : m_pStart(pStart)
+  , m_pEnd(pStart + ezStringUtils::GetStringElementCount(pStart))
 {
 }
 
@@ -17,8 +17,8 @@ inline ezStringView::ezStringView(const char* pStart, const char* pEnd)
 }
 
 constexpr inline ezStringView::ezStringView(const char* pStart, ezUInt32 uiLength)
-: m_pStart(pStart)
-, m_pEnd(pStart + uiLength)
+  : m_pStart(pStart)
+  , m_pEnd(pStart + uiLength)
 {
 }
 
@@ -68,7 +68,7 @@ inline void ezStringView::Trim(const char* szTrimCharsStart, const char* szTrimC
     ezStringUtils::Trim(m_pStart, m_pEnd, szTrimCharsStart, szTrimCharsEnd);
 }
 
-constexpr ezStringView ezLiterals::operator "" _sv(const char* pString, size_t len)
+constexpr ezStringView ezLiterals::operator"" _sv(const char* pString, size_t len)
 {
   return ezStringView(pString, static_cast<ezUInt32>(len));
 }

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -2,10 +2,10 @@
 
 inline ezStringView::ezStringView() = default;
 
-inline ezStringView::ezStringView(const char* pStart)
+constexpr inline ezStringView::ezStringView(const char* pStart)
+: m_pStart(pStart)
+, m_pEnd(pStart + ezStringUtils::GetStringElementCount(pStart))
 {
-  m_pStart = pStart;
-  m_pEnd = pStart + ezStringUtils::GetStringElementCount(pStart);
 }
 
 inline ezStringView::ezStringView(const char* pStart, const char* pEnd)
@@ -16,10 +16,10 @@ inline ezStringView::ezStringView(const char* pStart, const char* pEnd)
   m_pEnd = pEnd;
 }
 
-inline ezStringView::ezStringView(const char* pStart, ezUInt32 uiLength)
+constexpr inline ezStringView::ezStringView(const char* pStart, ezUInt32 uiLength)
+: m_pStart(pStart)
+, m_pEnd(pStart + uiLength)
 {
-  m_pStart = pStart;
-  m_pEnd = pStart + uiLength;
 }
 
 inline void ezStringView::operator++()
@@ -66,4 +66,9 @@ inline void ezStringView::Trim(const char* szTrimCharsStart, const char* szTrimC
 {
   if (IsValid())
     ezStringUtils::Trim(m_pStart, m_pEnd, szTrimCharsStart, szTrimCharsEnd);
+}
+
+constexpr ezStringView ezLiterals::operator "" _sv(const char* pString, size_t len)
+{
+  return ezStringView(pString, static_cast<ezUInt32>(len));
 }

--- a/Code/Engine/Foundation/Strings/StringUtils.h
+++ b/Code/Engine/Foundation/Strings/StringUtils.h
@@ -12,7 +12,7 @@ class EZ_FOUNDATION_DLL ezStringUtils
 public:
   /// \brief Returns true, if the given string is a nullptr pointer or a string that immediately terminates with a '\0' character.
   template <typename T>
-  static bool IsNullOrEmpty(const T* pString); // [tested]
+  static constexpr bool IsNullOrEmpty(const T* pString); // [tested]
 
   /// \brief Returns true, if the given string is a nullptr pointer, is equal to its end or a string that immediately terminates with a '\0'
   /// character.
@@ -30,7 +30,17 @@ public:
   /// Equal to the amount of bytes in a string, if used on non-ASCII (i.e. UTF-8) strings.
   /// Equal to the number of characters in a string, if used with UTF-32 strings.
   template <typename T>
-  static ezUInt32 GetStringElementCount(const T* pString, const T* pStringEnd = (const T*)-1); // [tested]
+  static constexpr ezUInt32 GetStringElementCount(const T* pString); // [tested]
+
+  /// \brief Returns the number of elements of type T that the string contains, until it hits an element that is zero OR until it hits the
+  /// end pointer.
+  ///
+  /// Equal to the string length, if used with pure ASCII strings.
+  /// Equal to the amount of bytes in a string, if used on non-ASCII (i.e. UTF-8) strings.
+  /// Equal to the number of characters in a string, if used with UTF-32 strings.
+  template <typename T>
+  static ezUInt32 GetStringElementCount(const T* pString, const T* pStringEnd); // [tested]
+
 
   /// \brief Returns the number of characters (not Bytes!) in a Utf8 string (excluding the zero terminator), until it hits zero or the end
   /// pointer.

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -25,13 +25,13 @@ public:
   ezStringView();
 
   /// \brief Creates a string view starting at the given position, ending at the next '\0' terminator.
-  ezStringView(const char* pStart); // [tested]
+  constexpr ezStringView(const char* pStart); // [tested]
 
   /// \brief Creates a string view for the range from pStart to pEnd.
   ezStringView(const char* pStart, const char* pEnd); // [tested]
 
   /// \brief Creates a string view for the range from pStart to pStart + uiLength.
-  ezStringView(const char* pStart, ezUInt32 uiLength);
+  constexpr ezStringView(const char* pStart, ezUInt32 uiLength);
 
   /// \brief Advances the start to the next character, unless the end of the range was reached.
   void operator++(); // [tested]
@@ -113,5 +113,15 @@ private:
   const char* m_pStart = nullptr;
   const char* m_pEnd = nullptr;
 };
+
+namespace ezLiterals
+{
+  /// \brief String literal suffix to create a ezStringView.
+  ///
+  /// Example:
+  /// using namespace ezLiterals;
+  /// "Hello World"_sv
+  constexpr ezStringView operator "" _sv(const char* pString, size_t len);
+}
 
 #include <Foundation/Strings/Implementation/StringView_inl.h>

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -121,7 +121,7 @@ namespace ezLiterals
   /// Example:
   /// using namespace ezLiterals;
   /// "Hello World"_sv
-  constexpr ezStringView operator "" _sv(const char* pString, size_t len);
-}
+  constexpr ezStringView operator"" _sv(const char* pString, size_t len);
+} // namespace ezLiterals
 
 #include <Foundation/Strings/Implementation/StringView_inl.h>

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -114,14 +114,11 @@ private:
   const char* m_pEnd = nullptr;
 };
 
-namespace ezLiterals
-{
-  /// \brief String literal suffix to create a ezStringView.
-  ///
-  /// Example:
-  /// using namespace ezLiterals;
-  /// "Hello World"_sv
-  constexpr ezStringView operator"" _sv(const char* pString, size_t len);
-} // namespace ezLiterals
+/// \brief String literal suffix to create a ezStringView.
+///
+/// Example:
+/// using namespace ezLiterals;
+/// "Hello World"_ezsv
+constexpr ezStringView operator "" _ezsv(const char* pString, size_t len);
 
 #include <Foundation/Strings/Implementation/StringView_inl.h>

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -119,6 +119,6 @@ private:
 /// Example:
 /// using namespace ezLiterals;
 /// "Hello World"_ezsv
-constexpr ezStringView operator "" _ezsv(const char* pString, size_t len);
+constexpr ezStringView operator"" _ezsv(const char* pString, size_t len);
 
 #include <Foundation/Strings/Implementation/StringView_inl.h>

--- a/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
@@ -4,6 +4,8 @@
 
 #include <Foundation/Strings/String.h>
 
+using namespace ezLiterals;
+
 EZ_CREATE_SIMPLE_TEST(Strings, StringView)
 {
   ezStringBuilder tmp;
@@ -38,6 +40,28 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringView)
     EZ_TEST_STRING(it.GetData(tmp), "fghijklmnopq");
     EZ_TEST_BOOL(it.GetEndPointer() == sz + 17);
     EZ_TEST_INT(it.GetElementCount(), 12);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor constexpr")
+  {
+    constexpr ezStringView a = ezStringView("Hello World");
+    EZ_TEST_INT(a.GetElementCount(), 11);
+    EZ_TEST_STRING(a.GetData(tmp), "Hello World");
+
+    constexpr ezStringView b = ezStringView("Hello World", 10);
+    EZ_TEST_INT(b.GetElementCount(), 10);
+    EZ_TEST_STRING(b.GetData(tmp), "Hello Worl");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "String literal")
+  {
+    constexpr ezStringView a = "Hello World"_sv;
+    EZ_TEST_INT(a.GetElementCount(), 11);
+    EZ_TEST_STRING(a.GetData(tmp), "Hello World");
+
+    ezStringView b = "Hello Worl"_sv;
+    EZ_TEST_INT(b.GetElementCount(), 10);
+    EZ_TEST_STRING(b.GetData(tmp), "Hello Worl");
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator++")

--- a/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
@@ -4,8 +4,6 @@
 
 #include <Foundation/Strings/String.h>
 
-using namespace ezLiterals;
-
 EZ_CREATE_SIMPLE_TEST(Strings, StringView)
 {
   ezStringBuilder tmp;
@@ -55,11 +53,11 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringView)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "String literal")
   {
-    constexpr ezStringView a = "Hello World"_sv;
+    constexpr ezStringView a = "Hello World"_ezsv;
     EZ_TEST_INT(a.GetElementCount(), 11);
     EZ_TEST_STRING(a.GetData(tmp), "Hello World");
 
-    ezStringView b = "Hello Worl"_sv;
+    ezStringView b = "Hello Worl"_ezsv;
     EZ_TEST_INT(b.GetElementCount(), 10);
     EZ_TEST_STRING(b.GetData(tmp), "Hello Worl");
   }


### PR DESCRIPTION
I looked at codegen of msvc,gcc and clang regarding constructing a ezStringView from a string literal. e.g. `ezStringView("Hello World"`
* gcc and clang will generate optimal code with optimizations enabeld
* msvc never generates optimal code, even with optimizations enabled
* gcc and clang generate bad code when optimizations are disabled

The goal is to have a option to get good codegen even in debug builds. For this we now can:

Create constexpr versions of ezStringView. E.g.
`constexpr auto someConstant = ezStringView("bla");`

Or you can use the newly added `_sv` literal suffix:
```
using namespace ezLiterals;

SomeFunctionThatTakesStringView("Hello World"_sv);
```
Going forward we might need to make the `const char*` constructor for ezStringView `explicit`, so that we avoid "bad code" by default.