### PR TITLE
Elaborate logic for ezStringView construction

### DIFF
--- a/Code/Engine/Foundation/Basics/Compiler/Clang/Clang.h
+++ b/Code/Engine/Foundation/Basics/Compiler/Clang/Clang.h
@@ -6,9 +6,12 @@
 #  undef EZ_COMPILER_CLANG
 #  define EZ_COMPILER_CLANG EZ_ON
 
-/// \todo re-investigate: attribute(always inline) does not work for some reason
-#  define EZ_ALWAYS_INLINE inline
-#  define EZ_FORCE_INLINE inline
+#  define EZ_ALWAYS_INLINE __attribute__((always_inline)) inline
+#  if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+#    define EZ_FORCE_INLINE inline
+#  else
+#    define EZ_FORCE_INLINE __attribute__((always_inline)) inline
+#  endif
 
 #  define EZ_ALIGNMENT_OF(type) EZ_COMPILE_TIME_MAX(__alignof(type), EZ_ALIGNMENT_MINIMUM)
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -2,10 +2,24 @@
 
 inline ezStringView::ezStringView() = default;
 
-constexpr inline ezStringView::ezStringView(const char* pStart)
+inline ezStringView::ezStringView(char* pStart)
   : m_pStart(pStart)
   , m_pEnd(pStart + ezStringUtils::GetStringElementCount(pStart))
 {
+}
+
+template <typename T>
+constexpr inline ezStringView::ezStringView(T pStart, typename std::enable_if<std::is_same<T, const char*>::value, int>::type*)
+  : m_pStart(pStart)
+  , m_pEnd(pStart + ezStringUtils::GetStringElementCount(pStart))
+{
+}
+
+template <typename T>
+EZ_ALWAYS_INLINE ezStringView::ezStringView(const T&& str, typename std::enable_if<std::is_same<T, const char*>::value == false && std::is_convertible<T, const char*>::value, int>::type*)
+{
+    m_pStart = str;
+    m_pEnd = m_pStart + ezStringUtils::GetStringElementCount(m_pStart);
 }
 
 inline ezStringView::ezStringView(const char* pStart, const char* pEnd)
@@ -20,6 +34,22 @@ constexpr inline ezStringView::ezStringView(const char* pStart, ezUInt32 uiLengt
   : m_pStart(pStart)
   , m_pEnd(pStart + uiLength)
 {
+}
+
+template <size_t N>
+inline ezStringView::ezStringView(const char(&str)[N])
+: m_pStart(str)
+, m_pEnd(str + N - 1)
+{
+    static_assert(N > 0, "Not a string literal");
+    EZ_ASSERT_DEBUG(str[N-1] == '\0', "Not a string literal. Manually cast to 'const char*' if you are trying to pass a const char fixed size array.");
+}
+
+template <size_t N>
+inline ezStringView::ezStringView(char(&str)[N])
+{
+    m_pStart = str;
+    m_pEnd = m_pStart + ezStringUtils::GetStringElementCount(str, str + N);
 }
 
 inline void ezStringView::operator++()

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -18,8 +18,8 @@ constexpr inline ezStringView::ezStringView(T pStart, typename std::enable_if<st
 template <typename T>
 EZ_ALWAYS_INLINE ezStringView::ezStringView(const T&& str, typename std::enable_if<std::is_same<T, const char*>::value == false && std::is_convertible<T, const char*>::value, int>::type*)
 {
-    m_pStart = str;
-    m_pEnd = m_pStart + ezStringUtils::GetStringElementCount(m_pStart);
+  m_pStart = str;
+  m_pEnd = m_pStart + ezStringUtils::GetStringElementCount(m_pStart);
 }
 
 inline ezStringView::ezStringView(const char* pStart, const char* pEnd)
@@ -37,19 +37,19 @@ constexpr inline ezStringView::ezStringView(const char* pStart, ezUInt32 uiLengt
 }
 
 template <size_t N>
-inline ezStringView::ezStringView(const char(&str)[N])
-: m_pStart(str)
-, m_pEnd(str + N - 1)
+inline ezStringView::ezStringView(const char (&str)[N])
+  : m_pStart(str)
+  , m_pEnd(str + N - 1)
 {
-    static_assert(N > 0, "Not a string literal");
-    EZ_ASSERT_DEBUG(str[N-1] == '\0', "Not a string literal. Manually cast to 'const char*' if you are trying to pass a const char fixed size array.");
+  static_assert(N > 0, "Not a string literal");
+  EZ_ASSERT_DEBUG(str[N - 1] == '\0', "Not a string literal. Manually cast to 'const char*' if you are trying to pass a const char fixed size array.");
 }
 
 template <size_t N>
-inline ezStringView::ezStringView(char(&str)[N])
+inline ezStringView::ezStringView(char (&str)[N])
 {
-    m_pStart = str;
-    m_pEnd = m_pStart + ezStringUtils::GetStringElementCount(str, str + N);
+  m_pStart = str;
+  m_pEnd = m_pStart + ezStringUtils::GetStringElementCount(str, str + N);
 }
 
 inline void ezStringView::operator++()

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -30,7 +30,7 @@ public:
   ezStringView(char* pStart);
 
   /// \brief Creates a string view starting at the given position, ending at the next '\0' terminator.
-  template <typename T> // T is always const char*
+  template <typename T>                                                                                           // T is always const char*
   constexpr ezStringView(T pStart, typename std::enable_if<std::is_same<T, const char*>::value, int>::type* = 0); // [tested]
 
   /// \brief Creates a string view from any class / struct which is implicitly conertible to const char *
@@ -45,11 +45,11 @@ public:
 
   /// \brief Construct a string view from a string literal.
   template <size_t N>
-  ezStringView(const char(&str)[N]);
+  ezStringView(const char (&str)[N]);
 
   /// \brief Construct a string view from a fixed size buffer
   template <size_t N>
-  ezStringView(char(&str)[N]);
+  ezStringView(char (&str)[N]);
 
   /// \brief Advances the start to the next character, unless the end of the range was reached.
   void operator++(); // [tested]

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -6,6 +6,8 @@
 
 #include <Foundation/Strings/Implementation/StringBase.h>
 
+#include <type_traits>
+
 class ezStringBuilder;
 
 /// \brief ezStringView represent a read-only sub-string of a larger string, as it can store a dedicated string end position.
@@ -25,13 +27,29 @@ public:
   ezStringView();
 
   /// \brief Creates a string view starting at the given position, ending at the next '\0' terminator.
-  constexpr ezStringView(const char* pStart); // [tested]
+  ezStringView(char* pStart);
+
+  /// \brief Creates a string view starting at the given position, ending at the next '\0' terminator.
+  template <typename T> // T is always const char*
+  constexpr ezStringView(T pStart, typename std::enable_if<std::is_same<T, const char*>::value, int>::type* = 0); // [tested]
+
+  /// \brief Creates a string view from any class / struct which is implicitly conertible to const char *
+  template <typename T>
+  EZ_ALWAYS_INLINE ezStringView(const T&& str, typename std::enable_if<std::is_same<T, const char*>::value == false && std::is_convertible<T, const char*>::value, int>::type* = 0); // [tested]
 
   /// \brief Creates a string view for the range from pStart to pEnd.
   ezStringView(const char* pStart, const char* pEnd); // [tested]
 
   /// \brief Creates a string view for the range from pStart to pStart + uiLength.
   constexpr ezStringView(const char* pStart, ezUInt32 uiLength);
+
+  /// \brief Construct a string view from a string literal.
+  template <size_t N>
+  ezStringView(const char(&str)[N]);
+
+  /// \brief Construct a string view from a fixed size buffer
+  template <size_t N>
+  ezStringView(char(&str)[N]);
 
   /// \brief Advances the start to the next character, unless the end of the range was reached.
   void operator++(); // [tested]

--- a/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
@@ -42,10 +42,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringView)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor constexpr")
   {
-    constexpr ezStringView a = ezStringView("Hello World");
-    EZ_TEST_INT(a.GetElementCount(), 11);
-    EZ_TEST_STRING(a.GetData(tmp), "Hello World");
-
     constexpr ezStringView b = ezStringView("Hello World", 10);
     EZ_TEST_INT(b.GetElementCount(), 10);
     EZ_TEST_STRING(b.GetData(tmp), "Hello Worl");


### PR DESCRIPTION
Automatically pick the optimal way to construct a ezStringView. String literals are now detected and a string view is constructed optimally from them.

This is the alternative to manually adding the suffix _ezsv to every string literal.