### PR TITLE
Fix ezDelegate copying a uninitialized byte of memory

### DIFF
--- a/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
@@ -125,7 +125,17 @@ public:
     using signature = R(Args...);
     if constexpr (functionSize <= DataSize && std::is_assignable<signature*&, Function>::value)
     {
-      CopyFunctionToInplaceStorage(function);
+      // Lambdas with no capture have a size of 1.
+      // Lambdas with no capture actually have no data. Do not copy the 1 uninitialized byte.
+      // Propper function pointers have a size of > 4 or 8 (depending on pointer size)
+      if constexpr(functionSize > 1)
+      {
+        CopyFunctionToInplaceStorage(function);
+      }
+      else
+      {
+        memset(m_Data, 0, DataSize);
+      }
 
       m_pInstance.m_ConstPtr = nullptr;
       m_pDispatchFunction = &DispatchToFunction<Function>;

--- a/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/DelegateHelper_inl.h
@@ -128,7 +128,7 @@ public:
       // Lambdas with no capture have a size of 1.
       // Lambdas with no capture actually have no data. Do not copy the 1 uninitialized byte.
       // Propper function pointers have a size of > 4 or 8 (depending on pointer size)
-      if constexpr(functionSize > 1)
+      if constexpr (functionSize > 1)
       {
         CopyFunctionToInplaceStorage(function);
       }


### PR DESCRIPTION
C++ has the rule that no type can have a size of 0 bytes. A lambda with no capture does not have any size though. Due to this rule sizeof reports 1 however. When storing a lambda with no capture in a ezDelegate we copy 1 uninitialized byte into the m_Data buffer and then later use this m_Data buffer to compare the ezDelegate against another ezDelegate. At this point we compare two uninitialized bytes of memory against each other. This commit fixes this issue by not copying the 1 byte in case of a lambda without capture.

Found using Valgrind while looking for a different issue.