### PR TITLE
Fix use of uninitialized memory in reflection tests.

### DIFF
--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -1018,7 +1018,7 @@ void TestSetProperty(const char* szPropName, void* pObject, const ezRTTI* pRtti,
     // Insert default init value
     if (!ezIsPointer<T>::value)
     {
-      T temp;
+      T temp = T{};
       pSetProp->Insert(pObject, &temp);
       EZ_TEST_BOOL(!pSetProp->IsEmpty(pObject));
       EZ_TEST_BOOL(pSetProp->Contains(pObject, &value1));


### PR DESCRIPTION
Found with valgrind.