### PR TITLE
Fix out of bounds read in ezUnicodeUtils::MoveToNextUtf8

### DIFF
--- a/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
@@ -170,10 +170,11 @@ void ezPathUtils::GetRootedPathParts(ezStringView sPath, ezStringView& root, ezS
     return;
 
   const char* szStart = sPath.GetStartPointer();
+  const char* szPathEnd = sPath.GetEndPointer();
 
   do
   {
-    ezUnicodeUtils::MoveToNextUtf8(szStart);
+    ezUnicodeUtils::MoveToNextUtf8(szStart, szPathEnd);
 
     if (*szStart == '\0')
       return;
@@ -181,10 +182,10 @@ void ezPathUtils::GetRootedPathParts(ezStringView sPath, ezStringView& root, ezS
   } while (IsPathSeparator(*szStart));
 
   const char* szEnd = szStart;
-  ezUnicodeUtils::MoveToNextUtf8(szEnd);
+  ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd);
 
   while (*szEnd != '\0' && !IsPathSeparator(*szEnd))
-    ezUnicodeUtils::MoveToNextUtf8(szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd);
 
   root = ezStringView(szStart, szEnd);
   if (*szEnd == '\0')
@@ -194,8 +195,8 @@ void ezPathUtils::GetRootedPathParts(ezStringView sPath, ezStringView& root, ezS
   else
   {
     // skip path separator for the relative path
-    ezUnicodeUtils::MoveToNextUtf8(szEnd);
-    relPath = ezStringView(szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd);
+    relPath = ezStringView(szEnd, szPathEnd);
   }
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringBase_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBase_inl.h
@@ -177,7 +177,7 @@ template <typename Derived>
 const char* ezStringBase<Derived>::ComputeCharacterPosition(ezUInt32 uiCharacterIndex) const
 {
   const char* pos = InternalGetData();
-  ezUnicodeUtils::MoveToNextUtf8(pos, uiCharacterIndex);
+  ezUnicodeUtils::MoveToNextUtf8(pos, InternalGetDataEnd(), uiCharacterIndex);
   return pos;
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringUtils.cpp
@@ -545,8 +545,8 @@ bool ezStringUtils::StartsWith_NoCase(const char* szString, const char* szStarts
     if (ezStringUtils::CompareChars_NoCase(szStartsWith, szString) != 0)
       return false;
 
-    ezUnicodeUtils::MoveToNextUtf8(szString);
-    ezUnicodeUtils::MoveToNextUtf8(szStartsWith);
+    ezUnicodeUtils::MoveToNextUtf8(szString, pStringEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szStartsWith, szStartsWithEnd);
   }
 
   // if both are equally long, this comparison will return true
@@ -610,12 +610,12 @@ const char* ezStringUtils::FindSubString(const char* szSource, const char* szStr
 
   const char* pCurPos = &szSource[0];
 
-  while ((*pCurPos != '\0') && (pCurPos < pSourceEnd))
+  while ((pCurPos < pSourceEnd) && (*pCurPos != '\0'))
   {
     if (ezStringUtils::StartsWith(pCurPos, szStringToFind, pSourceEnd, szStringToFindEnd))
       return pCurPos;
 
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pSourceEnd);
   }
 
   return nullptr;
@@ -634,7 +634,7 @@ const char* ezStringUtils::FindSubString_NoCase(const char* szSource, const char
     if (ezStringUtils::StartsWith_NoCase(pCurPos, szStringToFind, pSourceEnd, szStringToFindEnd))
       return pCurPos;
 
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pSourceEnd);
   }
 
   return nullptr;
@@ -708,7 +708,7 @@ const char* ezStringUtils::FindWholeWord(const char* szString, const char* szSea
     }
 
     pPrevPos = pCurPos;
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pStringEnd);
   }
 
   return nullptr;
@@ -738,7 +738,7 @@ const char* ezStringUtils::FindWholeWord_NoCase(
     }
 
     pPrevPos = pCurPos;
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pStringEnd);
   }
 
   return nullptr;

--- a/Code/Engine/Foundation/Strings/Implementation/StringView.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView.cpp
@@ -26,7 +26,7 @@ void ezStringView::Shrink(ezUInt32 uiShrinkCharsFront, ezUInt32 uiShrinkCharsBac
 {
   while (IsValid() && (uiShrinkCharsFront > 0))
   {
-    ezUnicodeUtils::MoveToNextUtf8(m_pStart, 1);
+    ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd, 1);
     --uiShrinkCharsFront;
   }
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -57,12 +57,12 @@ inline void ezStringView::operator++()
   if (!IsValid())
     return;
 
-  ezUnicodeUtils::MoveToNextUtf8(m_pStart);
+  ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd);
 }
 
 inline void ezStringView::operator+=(ezUInt32 d)
 {
-  ezUnicodeUtils::MoveToNextUtf8(m_pStart, d);
+  ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd, d);
 }
 
 inline bool ezStringView::IsValid() const

--- a/Code/Engine/Foundation/Strings/Implementation/UnicodeUtils_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/UnicodeUtils_inl.h
@@ -211,6 +211,23 @@ inline void ezUnicodeUtils::MoveToNextUtf8(const char*& szUtf8, ezUInt32 uiNumCh
   }
 }
 
+inline void ezUnicodeUtils::MoveToNextUtf8(const char*& szUtf8, const char* szUtf8End, ezUInt32 uiNumCharacters)
+{
+  EZ_ASSERT_DEBUG(szUtf8 != nullptr, "Bad programmer!");
+
+  while (uiNumCharacters > 0 && szUtf8 < szUtf8End)
+  {
+    EZ_ASSERT_DEV(*szUtf8 != '\0', "The given string must not point to the zero terminator.");
+
+    do
+    {
+      ++szUtf8;
+    } while ((szUtf8 < szUtf8End) && IsUtf8ContinuationByte(*szUtf8));
+
+    --uiNumCharacters;
+  }
+}
+
 inline void ezUnicodeUtils::MoveToPriorUtf8(const char*& szUtf8, ezUInt32 uiNumCharacters)
 {
   EZ_ASSERT_DEBUG(szUtf8 != nullptr, "Bad programmer!");

--- a/Code/Engine/Foundation/Strings/UnicodeUtils.h
+++ b/Code/Engine/Foundation/Strings/UnicodeUtils.h
@@ -44,6 +44,12 @@ public:
   /// It may not point to a zero terminator already.
   static void MoveToNextUtf8(const char*& szUtf8, ezUInt32 uiNumCharacters = 1); // [tested]
 
+  /// \brief Moves the given string pointer ahead to the next Utf8 character sequence.
+  ///
+  /// The string may point to an invalid position (in between a character sequence).
+  /// It may not point to a zero terminator already.
+  static void MoveToNextUtf8(const char*& szUtf8, const char* szUtf8End, ezUInt32 uiNumCharacters = 1); // [tested]
+
   /// \brief Moves the given string pointer backwards to the previous Utf8 character sequence.
   ///
   /// The string may point to an invalid position (in between a character sequence), or even the \0 terminator,

--- a/Code/UnitTests/FoundationTest/Strings/UnicodeUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/UnicodeUtilsTest.cpp
@@ -185,6 +185,31 @@ EZ_CREATE_SIMPLE_TEST(Strings, UnicodeUtils)
 
     ezUnicodeUtils::MoveToNextUtf8(sz);
     EZ_TEST_BOOL(sz == &s.GetData()[12]);
+
+    sz = s.GetData();
+    const char* szEnd = s.GetView().GetEndPointer();
+
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[1]);
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[2]);
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[4]);
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[6]);
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[8]);
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[11]);
+
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    EZ_TEST_BOOL(sz == &s.GetData()[12]);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "MoveToPriorUtf8")


### PR DESCRIPTION
This introduces a new overload of ezUnicodeUtils::MoveToNextUtf8 that respects a given end pointer.

The current version of MoveToNextUtf8 will read beyond the end of valid memory if the string is not zero terminated.

Found with valgrind