### PR TITLE
Added an in-place curve property

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetWindow.cpp
@@ -121,7 +121,6 @@ void ezQtCurve1DAssetDocumentWindow::onInsertCpAt(ezUInt32 uiCurveIdx, ezInt64 t
   ezCurve1DAssetDocument* pDoc = static_cast<ezCurve1DAssetDocument*>(GetDocument());
 
   ezCommandHistory* history = pDoc->GetCommandHistory();
-  history->StartTransaction("Insert Control Point");
 
   if (pDoc->GetPropertyObject()->GetTypeAccessor().GetCount("Curves") == 0)
   {
@@ -166,8 +165,6 @@ void ezQtCurve1DAssetDocumentWindow::onInsertCpAt(ezUInt32 uiCurveIdx, ezInt64 t
   cmdSet.m_sProperty = "RightTangent";
   cmdSet.m_NewValue = ezVec2(+0.1f, 0.0f);
   history->AddCommand(cmdSet);
-
-  history->FinishTransaction();
 }
 
 void ezQtCurve1DAssetDocumentWindow::onCurveCpMoved(ezUInt32 curveIdx, ezUInt32 cpIdx, ezInt64 iTickX, double newPosY)

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.cpp
@@ -1,0 +1,303 @@
+#include <GuiFoundation/GuiFoundationPCH.h>
+
+#include <GuiFoundation/Dialogs/CurveEditDlg.moc.h>
+#include <GuiFoundation/Widgets/Curve1DEditorWidget.moc.h>
+#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <ToolsFoundation/Document/Document.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+QByteArray ezQtCurveEditDlg::s_LastDialogGeometry;
+
+ezQtCurveEditDlg::ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, ezColorGammaUB curveColor, double fMinCurveLength, bool bCurveLengthIsFixed, QWidget* parent)
+  : QDialog(parent)
+{
+  m_fMinCurveLength = fMinCurveLength;
+  m_bCurveLengthIsFixed = bCurveLengthIsFixed;
+  m_pObjectAccessor = pObjectAccessor;
+  m_pCurveObject = pCurveObject;
+
+  setupUi(this);
+
+  ezQtCurve1DEditorWidget* pEdit = CurveEditor;
+
+  connect(pEdit, &ezQtCurve1DEditorWidget::CpMovedEvent, this, &ezQtCurveEditDlg::OnCpMovedEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::CpDeletedEvent, this, &ezQtCurveEditDlg::OnCpDeletedEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::TangentMovedEvent, this, &ezQtCurveEditDlg::OnTangentMovedEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::InsertCpEvent, this, &ezQtCurveEditDlg::OnInsertCpEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::TangentLinkEvent, this, &ezQtCurveEditDlg::OnTangentLinkEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::CpTangentModeEvent, this, &ezQtCurveEditDlg::OnCpTangentModeEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::BeginCpChangesEvent, this, &ezQtCurveEditDlg::OnBeginCpChangesEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::EndCpChangesEvent, this, &ezQtCurveEditDlg::OnEndCpChangesEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::BeginOperationEvent, this, &ezQtCurveEditDlg::OnBeginOperationEvent);
+  connect(pEdit, &ezQtCurve1DEditorWidget::EndOperationEvent, this, &ezQtCurveEditDlg::OnEndOperationEvent);
+
+  m_shortcutUndo = new QShortcut(QKeySequence("Ctrl+Z"), this);
+  m_shortcutRedo = new QShortcut(QKeySequence("Ctrl+Y"), this);
+
+  connect(m_shortcutUndo, &QShortcut::activated, this, &ezQtCurveEditDlg::on_actionUndo_triggered);
+  connect(m_shortcutRedo, &QShortcut::activated, this, &ezQtCurveEditDlg::on_actionRedo_triggered);
+
+  m_Curves.m_Curves.PushBack(EZ_DEFAULT_NEW(ezSingleCurveData));
+  m_Curves.m_Curves.PeekBack()->m_CurveColor = curveColor;
+
+  RetrieveCurveState();
+  UpdatePreview();
+
+  m_uiActionsUndoBaseline = m_pObjectAccessor->GetObjectManager()->GetDocument()->GetCommandHistory()->GetUndoStackSize();
+}
+
+void ezQtCurveEditDlg::RetrieveCurveState()
+{
+  auto& curve = m_Curves.m_Curves.PeekBack();
+
+  ezInt32 iNumPoints = 0;
+  m_pObjectAccessor->GetCount(m_pCurveObject, "ControlPoints", iNumPoints);
+  curve->m_ControlPoints.SetCount(iNumPoints);
+
+  ezVariant v;
+
+  // get a local representation of the curve once, so that we can update the preview more efficiently
+  for (ezInt32 i = 0; i < iNumPoints; ++i)
+  {
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetChildObject(m_pCurveObject, "ControlPoints", i);
+
+    m_pObjectAccessor->GetValue(pPoint, "Tick", v);
+    curve->m_ControlPoints[i].m_iTick = v.ConvertTo<ezInt32>();
+
+    m_pObjectAccessor->GetValue(pPoint, "Value", v);
+    curve->m_ControlPoints[i].m_fValue = v.ConvertTo<double>();
+
+    m_pObjectAccessor->GetValue(pPoint, "LeftTangent", v);
+    curve->m_ControlPoints[i].m_LeftTangent = v.ConvertTo<ezVec2>();
+
+    m_pObjectAccessor->GetValue(pPoint, "RightTangent", v);
+    curve->m_ControlPoints[i].m_RightTangent = v.ConvertTo<ezVec2>();
+
+    m_pObjectAccessor->GetValue(pPoint, "Linked", v);
+    curve->m_ControlPoints[i].m_bTangentsLinked = v.ConvertTo<bool>();
+
+    m_pObjectAccessor->GetValue(pPoint, "LeftTangentMode", v);
+    curve->m_ControlPoints[i].m_LeftTangentMode = (ezCurveTangentMode::Enum)v.ConvertTo<ezInt32>();
+
+    m_pObjectAccessor->GetValue(pPoint, "RightTangentMode", v);
+    curve->m_ControlPoints[i].m_RightTangentMode = (ezCurveTangentMode::Enum)v.ConvertTo<ezInt32>();
+  }
+}
+
+ezQtCurveEditDlg::~ezQtCurveEditDlg()
+{
+  s_LastDialogGeometry = saveGeometry();
+}
+
+void ezQtCurveEditDlg::reject()
+{
+  // ignore
+}
+
+void ezQtCurveEditDlg::accept()
+{
+  // ignore
+}
+
+void ezQtCurveEditDlg::cancel()
+{
+  auto& cmd = *m_pObjectAccessor->GetObjectManager()->GetDocument()->GetCommandHistory();
+  cmd.Undo(cmd.GetUndoStackSize() - m_uiActionsUndoBaseline);
+
+  QDialog::reject();
+}
+
+void ezQtCurveEditDlg::UpdatePreview()
+{
+  ezQtCurve1DEditorWidget* pEdit = CurveEditor;
+  pEdit->SetCurves(m_Curves, m_fMinCurveLength, m_bCurveLengthIsFixed);
+}
+
+void ezQtCurveEditDlg::closeEvent(QCloseEvent*)
+{
+  cancel();
+}
+
+void ezQtCurveEditDlg::OnCpMovedEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, ezInt64 iTickX, double newPosY)
+{
+  // update the local representation
+  {
+    auto& cp = m_Curves.m_Curves[curveIdx]->m_ControlPoints[cpIdx];
+
+    if (cp.m_iTick != iTickX || cp.m_fValue != newPosY)
+    {
+      cp.m_iTick = iTickX;
+      cp.m_fValue = newPosY;
+    }
+  }
+
+  // update the actual object
+  {
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetChildObject(m_pCurveObject, "ControlPoints", cpIdx);
+
+    m_pObjectAccessor->SetValue(pPoint, "Tick", iTickX);
+    m_pObjectAccessor->SetValue(pPoint, "Value", newPosY);
+  }
+}
+
+void ezQtCurveEditDlg::OnCpDeletedEvent(ezUInt32 curveIdx, ezUInt32 cpIdx)
+{
+  // update the local representation
+  {
+    m_Curves.m_Curves[curveIdx]->m_ControlPoints.RemoveAtAndCopy(cpIdx);
+  }
+
+  // update the actual object
+  {
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetChildObject(m_pCurveObject, "ControlPoints", cpIdx);
+    m_pObjectAccessor->RemoveObject(pPoint);
+  }
+}
+
+void ezQtCurveEditDlg::OnTangentMovedEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, float newPosX, float newPosY, bool rightTangent)
+{
+  // update the local representation
+  {
+    auto& cp = m_Curves.m_Curves[curveIdx]->m_ControlPoints[cpIdx];
+
+    if (rightTangent)
+      cp.m_RightTangent.Set(newPosX, newPosY);
+    else
+      cp.m_LeftTangent.Set(newPosX, newPosY);
+  }
+
+  // update the actual object
+  {
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetChildObject(m_pCurveObject, "ControlPoints", cpIdx);
+
+    if (rightTangent)
+      m_pObjectAccessor->SetValue(pPoint, "RightTangent", ezVec2(newPosX, newPosY));
+    else
+      m_pObjectAccessor->SetValue(pPoint, "LeftTangent", ezVec2(newPosX, newPosY));
+  }
+}
+
+void ezQtCurveEditDlg::OnInsertCpEvent(ezUInt32 curveIdx, ezInt64 tickX, double value)
+{
+  // update the local representation
+  {
+    ezCurveControlPointData cp;
+    cp.m_iTick = tickX;
+    cp.m_fValue = value;
+
+    m_Curves.m_Curves[curveIdx]->m_ControlPoints.PushBack(cp);
+  }
+
+  // update the actual object
+  {
+    ezUuid guid;
+    m_pObjectAccessor->AddObject(m_pCurveObject, "ControlPoints", -1, ezGetStaticRTTI<ezCurveControlPointData>(), guid);
+
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetObject(guid);
+
+    m_pObjectAccessor->SetValue(pPoint, "Tick", tickX);
+    m_pObjectAccessor->SetValue(pPoint, "Value", value);
+  }
+}
+
+void ezQtCurveEditDlg::OnTangentLinkEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, bool bLink)
+{
+  // update the local representation
+  {
+    auto& cp = m_Curves.m_Curves[curveIdx]->m_ControlPoints[cpIdx];
+    cp.m_bTangentsLinked = bLink;
+  }
+
+  // update the actual object
+  {
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetChildObject(m_pCurveObject, "ControlPoints", cpIdx);
+
+    m_pObjectAccessor->SetValue(pPoint, "Linked", bLink);
+  }
+}
+
+void ezQtCurveEditDlg::OnCpTangentModeEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, bool rightTangent, int mode)
+{
+  // update the local representation
+  {
+    auto& cp = m_Curves.m_Curves[curveIdx]->m_ControlPoints[cpIdx];
+
+    if (rightTangent)
+      cp.m_RightTangentMode = (ezCurveTangentMode::Enum)mode;
+    else
+      cp.m_LeftTangentMode = (ezCurveTangentMode::Enum)mode;
+  }
+
+  // update the actual object
+  {
+    const ezDocumentObject* pPoint = m_pObjectAccessor->GetChildObject(m_pCurveObject, "ControlPoints", cpIdx);
+
+    if (rightTangent)
+      m_pObjectAccessor->SetValue(pPoint, "RightTangentMode", mode);
+    else
+      m_pObjectAccessor->SetValue(pPoint, "LeftTangentMode", mode);
+  }
+}
+
+void ezQtCurveEditDlg::OnBeginCpChangesEvent(QString name)
+{
+  m_pObjectAccessor->StartTransaction(name.toUtf8().data());
+}
+
+void ezQtCurveEditDlg::OnEndCpChangesEvent()
+{
+  m_pObjectAccessor->FinishTransaction();
+
+  UpdatePreview();
+}
+
+void ezQtCurveEditDlg::OnBeginOperationEvent(QString name)
+{
+  m_pObjectAccessor->BeginTemporaryCommands(name.toUtf8().data());
+}
+
+void ezQtCurveEditDlg::OnEndOperationEvent(bool commit)
+{
+  if (commit)
+    m_pObjectAccessor->FinishTemporaryCommands();
+  else
+    m_pObjectAccessor->CancelTemporaryCommands();
+
+  UpdatePreview();
+}
+
+void ezQtCurveEditDlg::on_actionUndo_triggered()
+{
+  auto& cmd = *m_pObjectAccessor->GetObjectManager()->GetDocument()->GetCommandHistory();
+
+  if (cmd.CanUndo() && cmd.GetUndoStackSize() > m_uiActionsUndoBaseline)
+  {
+    cmd.Undo();
+
+    RetrieveCurveState();
+    UpdatePreview();
+  }
+}
+
+void ezQtCurveEditDlg::on_actionRedo_triggered()
+{
+  auto& cmd = *m_pObjectAccessor->GetObjectManager()->GetDocument()->GetCommandHistory();
+
+  if (cmd.CanRedo())
+  {
+    cmd.Redo();
+
+    RetrieveCurveState();
+    UpdatePreview();
+  }
+}
+
+void ezQtCurveEditDlg::on_ButtonOk_clicked()
+{
+  QDialog::accept();
+}
+
+void ezQtCurveEditDlg::on_ButtonCancel_clicked()
+{
+  cancel();
+}

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <GuiFoundation/ui_CurveEditDlg.h>
+#include <QDialog>
+
+class ezCurveGroupData;
+class ezObjectAccessorBase;
+class ezDocumentObject;
+
+class EZ_GUIFOUNDATION_DLL ezQtCurveEditDlg : public QDialog, Ui_CurveEditDlg
+{
+  Q_OBJECT
+public:
+  ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, ezColorGammaUB curveColor, double fMinCurveLength, bool bCurveLengthIsFixed, QWidget* parent);
+  ~ezQtCurveEditDlg();
+
+  static QByteArray GetLastDialogGeometry() { return s_LastDialogGeometry; }
+
+  virtual void reject() override;
+  virtual void accept() override;
+
+  void cancel();
+
+Q_SIGNALS:
+
+private Q_SLOTS:
+  void OnCpMovedEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, ezInt64 iTickX, double newPosY);
+  void OnCpDeletedEvent(ezUInt32 curveIdx, ezUInt32 cpIdx);
+  void OnTangentMovedEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, float newPosX, float newPosY, bool rightTangent);
+  void OnInsertCpEvent(ezUInt32 uiCurveIdx, ezInt64 tickX, double value);
+  void OnTangentLinkEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, bool bLink);
+  void OnCpTangentModeEvent(ezUInt32 curveIdx, ezUInt32 cpIdx, bool rightTangent, int mode); // ezCurveTangentMode
+
+  void OnBeginCpChangesEvent(QString name);
+  void OnEndCpChangesEvent();
+
+  void OnBeginOperationEvent(QString name);
+  void OnEndOperationEvent(bool commit);
+
+  void on_actionUndo_triggered();
+  void on_actionRedo_triggered();
+  void on_ButtonOk_clicked();
+  void on_ButtonCancel_clicked();
+
+private:
+  static QByteArray s_LastDialogGeometry;
+
+  void RetrieveCurveState();
+  void UpdatePreview();
+
+  double m_fMinCurveLength = 1.0;
+  bool m_bCurveLengthIsFixed = false;
+  ezCurveGroupData m_Curves;
+  ezUInt32 m_uiActionsUndoBaseline = 0;
+
+  QShortcut* m_shortcutUndo = nullptr;
+  QShortcut* m_shortcutRedo = nullptr;
+
+  ezObjectAccessorBase* m_pObjectAccessor = nullptr;
+  const ezDocumentObject* m_pCurveObject = nullptr;
+
+protected:
+  virtual void closeEvent(QCloseEvent*) override;
+};

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.ui
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.ui
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CurveEditDlg</class>
+ <widget class="QDialog" name="CurveEditDlg">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>489</width>
+    <height>415</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Curve Editor</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../QtResources/resources.qrc">
+    <normaloff>:/GuiFoundation/EZ-logo.svg</normaloff>:/GuiFoundation/EZ-logo.svg</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="ezQtCurve1DEditorWidget" name="CurveEditor" native="true"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ButtonOk">
+       <property name="text">
+        <string>OK</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="ButtonCancel">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ezQtCurve1DEditorWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">GuiFoundation/Widgets/Curve1DEditorWidget.moc.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../QtResources/resources.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
@@ -13,6 +13,7 @@
 #include <ToolsFoundation/Document/Document.h>
 
 #include <Foundation/Profiling/Profiling.h>
+#include <GuiFoundation/Widgets/CurveEditData.h>
 #include <QLayout>
 #include <QScrollArea>
 
@@ -126,6 +127,11 @@ static ezQtPropertyWidget* VarianceTypeCreator(const ezRTTI* pRtti)
   return new ezQtVarianceTypeWidget();
 }
 
+static ezQtPropertyWidget* Curve1DTypeCreator(const ezRTTI* pRtti)
+{
+  return new ezQtPropertyEditorCurve1DWidget();
+}
+
 // clang-format off
 EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, PropertyGrid)
 
@@ -170,6 +176,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, PropertyGrid)
 
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezTagSetWidgetAttribute>(), TagSetCreator);
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezVarianceTypeBase>(), VarianceTypeCreator);
+    ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezSingleCurveData>(), Curve1DTypeCreator);
 
 
   }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -1298,8 +1298,7 @@ void ezQtCurve1DButtonWidget::UpdatePreview(ezObjectAccessorBase* pObjectAccesso
     maxY = ezMath::Max(maxY, p.y);
   }
 
-  points.Sort([](const ezVec2d& lhs, const ezVec2d& rhs) -> bool
-    { return lhs.x < rhs.x; });
+  points.Sort([](const ezVec2d& lhs, const ezVec2d& rhs) -> bool { return lhs.x < rhs.x; });
 
   const double pW = ezMath::Max(10, size().width());
   const double pH = ezMath::Clamp(size().height(), 5, 24);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
@@ -280,3 +280,43 @@ protected:
   QMenu* m_pMenu;
   ezInt64 m_iCurrentBitflags;
 };
+
+
+/// *** CURVE1D ***
+
+class EZ_GUIFOUNDATION_DLL ezQtCurve1DButtonWidget : public QLabel
+{
+  Q_OBJECT
+
+public:
+  explicit ezQtCurve1DButtonWidget(QWidget* parent);
+
+  void UpdatePreview(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, QColor color, float minLength, bool fixedLength);
+
+Q_SIGNALS:
+  void clicked();
+
+protected:
+  virtual void mouseReleaseEvent(QMouseEvent* event) override;
+};
+
+class EZ_GUIFOUNDATION_DLL ezQtPropertyEditorCurve1DWidget : public ezQtPropertyWidget
+{
+  Q_OBJECT
+
+public:
+  ezQtPropertyEditorCurve1DWidget();
+
+private Q_SLOTS:
+  void on_Button_triggered();
+
+protected:
+  virtual void SetSelection(const ezHybridArray<ezPropertySelection, 8>& items) override;
+  virtual void OnInit() override;
+  virtual void DoPrepareToDie() override;
+  void UpdatePreview();
+
+protected:
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtCurve1DButtonWidget* m_pWidget = nullptr;
+};

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Curve1DEditorWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Curve1DEditorWidget.moc.h
@@ -15,11 +15,12 @@ public:
   explicit ezQtCurve1DEditorWidget(QWidget* pParent);
   ~ezQtCurve1DEditorWidget();
 
-  void SetCurves(ezCurveGroupData& curveData, double fMinCurveLength, bool bCurveLengthIsFixed);
+  void SetCurves(const ezCurveGroupData& curveData, double fMinCurveLength, bool bCurveLengthIsFixed);
   void SetScrubberPosition(ezUInt64 uiTick);
   void ClearSelection();
 
   void FrameCurve();
+  void FrameSelection();
   void MakeRepeatable(bool bAdjustLastPoint);
   void NormalizeCurveX(ezUInt32 uiActiveCurve);
   void NormalizeCurveY(ezUInt32 uiActiveCurve);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditData.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditData.h
@@ -90,6 +90,20 @@ public:
   double Evaluate(ezInt64 uiTick) const;
 };
 
+class EZ_GUIFOUNDATION_DLL ezSingleCurveDataAttribute : public ezPropertyAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSingleCurveDataAttribute, ezPropertyAttribute);
+
+public:
+  ezSingleCurveDataAttribute() = default;
+  ezSingleCurveDataAttribute(ezColorGammaUB color, float minLength, bool fixedLength);
+
+  float m_fMinLength = 0.0f;
+  bool m_bFixedLength = false;
+  ezColorGammaUB m_DisplayColor;
+};
+
+
 class EZ_GUIFOUNDATION_DLL ezCurveGroupData : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezCurveGroupData, ezReflectedClass);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditWidget.moc.h
@@ -27,6 +27,8 @@ public:
   double GetMaxCurveExtent() const { return m_fMaxCurveExtent; }
 
   void FrameCurve();
+  void FrameSelection();
+  void Frame(double offsetX, double offsetY, double width, double height);
 
   QPoint MapFromScene(const QPointF& pos) const;
   QPoint MapFromScene(const ezVec2d& pos) const { return MapFromScene(QPointF(pos.x, pos.y)); }
@@ -34,6 +36,7 @@ public:
   ezVec2 MapDirFromScene(const ezVec2& pos) const;
 
   void ClearSelection();
+  void SelectAll();
   const ezDynamicArray<ezSelectedCurveCP>& GetSelection() const { return m_SelectedCPs; }
   bool IsSelected(const ezSelectedCurveCP& cp) const;
   void SetSelection(const ezSelectedCurveCP& cp);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
@@ -415,17 +415,14 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
   const auto& selection = CurveEdit->GetSelection();
 
   QMenu* cmSel = m.addMenu("Selection");
-  cmSel->addAction("Select All\tCtrl+A", this, [this]()
-    { CurveEdit->SelectAll(); });
+  cmSel->addAction("Select All\tCtrl+A", this, [this]() { CurveEdit->SelectAll(); });
 
   if (!selection.IsEmpty())
   {
-    cmSel->addAction("Clear Selection\tESC", this, [this]()
-      { CurveEdit->ClearSelection(); });
+    cmSel->addAction("Clear Selection\tESC", this, [this]() { CurveEdit->ClearSelection(); });
 
     cmSel->addAction(
-      "Frame Selection\tShift+F", this, [this]()
-      { FrameSelection(); });
+      "Frame Selection\tShift+F", this, [this]() { FrameSelection(); });
 
     cmSel->addSeparator();
 
@@ -481,8 +478,7 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
     { ClearAllPoints(); });
 
   cm->addAction(
-    "Frame Curve\tCtrl+F", this, [this]()
-    { FrameCurve(); });
+    "Frame Curve\tCtrl+F", this, [this]() { FrameCurve(); });
 
   QMenu* gm = m.addMenu("Generate Curve");
   QMenu* lm = gm->addMenu("Linear");

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
@@ -34,14 +34,14 @@ ezQtCurve1DEditorWidget::ezQtCurve1DEditorWidget(QWidget* pParent)
 
 ezQtCurve1DEditorWidget::~ezQtCurve1DEditorWidget() {}
 
-void ezQtCurve1DEditorWidget::SetCurves(ezCurveGroupData& curves, double fMinCurveLength, bool bCurveLengthIsFixed)
+void ezQtCurve1DEditorWidget::SetCurves(const ezCurveGroupData& curves, double fMinCurveLength, bool bCurveLengthIsFixed)
 {
   ezQtScopedUpdatesDisabled ud(this);
   ezQtScopedBlockSignals bs(this);
 
   m_Curves.CloneFrom(curves);
 
-  CurveEdit->SetCurves(&curves, fMinCurveLength, bCurveLengthIsFixed);
+  CurveEdit->SetCurves(&m_Curves, fMinCurveLength, bCurveLengthIsFixed);
   m_fCurveDuration = CurveEdit->GetMaxCurveExtent();
 
   UpdateSpinBoxes();
@@ -62,6 +62,11 @@ void ezQtCurve1DEditorWidget::ClearSelection()
 void ezQtCurve1DEditorWidget::FrameCurve()
 {
   CurveEdit->FrameCurve();
+}
+
+void ezQtCurve1DEditorWidget::FrameSelection()
+{
+  CurveEdit->FrameSelection();
 }
 
 void ezQtCurve1DEditorWidget::MakeRepeatable(bool bAdjustLastPoint)
@@ -292,7 +297,11 @@ void ezQtCurve1DEditorWidget::onDeleteControlPoints()
 
 void ezQtCurve1DEditorWidget::onDoubleClick(const QPointF& scenePos, const QPointF& epsilon)
 {
+  Q_EMIT BeginCpChangesEvent("Add Control Point");
+
   InsertCpAt(scenePos.x(), scenePos.y(), ezVec2d(ezMath::Abs(epsilon.x()), ezMath::Abs(epsilon.y())));
+
+  Q_EMIT EndCpChangesEvent();
 }
 
 void ezQtCurve1DEditorWidget::onMoveControlPoints(double x, double y)
@@ -401,21 +410,34 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
   m_contextMenuScenePos = scenePos;
 
   QMenu m(this);
-  m.setDefaultAction(m.addAction("Add Point", this, SLOT(onAddPoint())));
+  m.setDefaultAction(m.addAction("Add Point\tDbl Click", this, SLOT(onAddPoint())));
 
   const auto& selection = CurveEdit->GetSelection();
 
+  QMenu* cmSel = m.addMenu("Selection");
+  cmSel->addAction("Select All\tCtrl+A", this, [this]()
+    { CurveEdit->SelectAll(); });
+
   if (!selection.IsEmpty())
   {
-    m.addAction("Delete Points", this, SLOT(onDeleteControlPoints()), QKeySequence(Qt::Key_Delete));
-    m.addSeparator();
-    m.addAction("Link Tangents", this, SLOT(onLinkTangents()));
-    m.addAction("Break Tangents", this, SLOT(onBreakTangents()));
-    m.addAction("Flatten Tangents", this, SLOT(onFlattenTangents()));
+    cmSel->addAction("Clear Selection\tESC", this, [this]()
+      { CurveEdit->ClearSelection(); });
 
-    QMenu* cmLT = m.addMenu("Left Tangents");
-    QMenu* cmRT = m.addMenu("Right Tangents");
-    QMenu* cmBT = m.addMenu("Both Tangents");
+    cmSel->addAction(
+      "Frame Selection\tShift+F", this, [this]()
+      { FrameSelection(); });
+
+    cmSel->addSeparator();
+
+    cmSel->addAction("Delete Points\tDel", this, SLOT(onDeleteControlPoints()));
+    cmSel->addSeparator();
+    cmSel->addAction("Link Tangents", this, SLOT(onLinkTangents()));
+    cmSel->addAction("Break Tangents", this, SLOT(onBreakTangents()));
+    cmSel->addAction("Flatten Tangents", this, SLOT(onFlattenTangents()));
+
+    QMenu* cmLT = cmSel->addMenu("Left Tangents");
+    QMenu* cmRT = cmSel->addMenu("Right Tangents");
+    QMenu* cmBT = cmSel->addMenu("Both Tangents");
 
     cmLT->addAction("Auto", this, [this]()
       { SetTangentMode(ezCurveTangentMode::Auto, true, false); });
@@ -445,7 +467,6 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
       { SetTangentMode(ezCurveTangentMode::Linear, true, true); });
   }
 
-  m.addSeparator();
   QMenu* cm = m.addMenu("Curve");
   cm->addSeparator();
   cm->addAction("Normalize X", this, [this]()
@@ -459,10 +480,9 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
   cm->addAction("Clear Curve", this, [this]()
     { ClearAllPoints(); });
 
-  m.addAction(
-    "Frame", this, [this]()
-    { FrameCurve(); },
-    QKeySequence(Qt::ControlModifier | Qt::Key_F));
+  cm->addAction(
+    "Frame Curve\tCtrl+F", this, [this]()
+    { FrameCurve(); });
 
   QMenu* gm = m.addMenu("Generate Curve");
   QMenu* lm = gm->addMenu("Linear");
@@ -548,7 +568,11 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
 
 void ezQtCurve1DEditorWidget::onAddPoint()
 {
+  Q_EMIT BeginCpChangesEvent("Add Control Point");
+
   InsertCpAt(m_contextMenuScenePos.x(), m_contextMenuScenePos.y(), ezVec2d::ZeroVector());
+
+  Q_EMIT EndCpChangesEvent();
 }
 
 void ezQtCurve1DEditorWidget::onLinkTangents()
@@ -708,6 +732,8 @@ void ezQtCurve1DEditorWidget::onMoveCurve(ezInt32 iCurve, double moveY)
 
 void ezQtCurve1DEditorWidget::onGenerateCurve(ezMath::ezEasingFunctions easingFunction)
 {
+  Q_EMIT BeginCpChangesEvent("Generate Curve");
+
   // Delete all existing control points
   ClearAllPoints();
 
@@ -718,6 +744,8 @@ void ezQtCurve1DEditorWidget::onGenerateCurve(ezMath::ezEasingFunctions easingFu
     const double x = i / fps;
     InsertCpAt(x, GetEasingValue(easingFunction, x), ezVec2d::ZeroVector());
   }
+
+  Q_EMIT EndCpChangesEvent();
 }
 
 void ezQtCurve1DEditorWidget::UpdateSpinBoxes()

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditData.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditData.cpp
@@ -46,7 +46,31 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCurveGroupData, 2, ezRTTIDefaultAllocator<ezCu
   EZ_END_PROPERTIES;
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSingleCurveDataAttribute, 1, ezRTTIDefaultAllocator<ezSingleCurveDataAttribute>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Color", m_DisplayColor),
+    EZ_MEMBER_PROPERTY("MinLength", m_fMinLength),
+    EZ_MEMBER_PROPERTY("FixedLength", m_bFixedLength),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_CONSTRUCTOR_PROPERTY(ezColorGammaUB, float, bool),
+  }
+  EZ_END_FUNCTIONS;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
+
+ezSingleCurveDataAttribute::ezSingleCurveDataAttribute(ezColorGammaUB color, float minLength, bool fixedLength)
+{
+  m_DisplayColor = color;
+  m_fMinLength = minLength;
+  m_bFixedLength = fixedLength;
+}
 
 void ezCurveControlPointData::SetTickFromTime(ezTime time, ezInt64 fps)
 {

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditWidget.cpp
@@ -322,8 +322,7 @@ void ezQtCurveEditWidget::paintEvent(QPaintEvent* e)
 
   if (m_pGridBar)
   {
-    m_pGridBar->SetConfig(viewportSceneRect, fRoughGridDensity, fFineGridDensity, [this](const QPointF& pt) -> QPoint
-      { return MapFromScene(pt); });
+    m_pGridBar->SetConfig(viewportSceneRect, fRoughGridDensity, fFineGridDensity, [this](const QPointF& pt) -> QPoint { return MapFromScene(pt); });
   }
 
   RenderSideLinesAndText(&painter, viewportSceneRect);


### PR DESCRIPTION
This allows to embed curves directly into an object and removes the need to reference a curve asset.
For many use cases this is more convenient than to always create a new curve asset.
The curve is still stored in the same representation, so usually it should be converted to a more suitable runtime representation.