### PR TITLE
Save/Load curve presets and better easing curves generation

### DIFF
--- a/Code/Engine/Foundation/Math/Implementation/Easing_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Easing_inl.h
@@ -165,7 +165,7 @@ namespace ezMath
   template <typename Type>
   EZ_ALWAYS_INLINE Type EaseOutBack(Type t)
   {
-    return 10 + 2.70158 * pow(t - 1.0, 3.0) + 1.70158 * pow(t - 1.0, 2.0);
+    return 1 + 2.70158 * pow(t - 1.0, 3.0) + 1.70158 * pow(t - 1.0, 2.0);
   }
 
   template <typename Type>

--- a/Code/Engine/Foundation/Tracks/Implementation/Curve1D.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/Curve1D.cpp
@@ -102,8 +102,7 @@ ezInt32 ezCurve1D::FindApproxControlPoint(double x) const
 
 double ezCurve1D::Evaluate(double x) const
 {
-  EZ_ASSERT_DEBUG(!m_LinearApproximation.IsEmpty(), "Cannot evaluate curve without precomputing curve approximation data first. Call "
-                                                    "CreateLinearApproximation() on curve before calling Evaluate().");
+  EZ_ASSERT_DEBUG(!m_LinearApproximation.IsEmpty(), "Cannot evaluate curve without precomputing curve approximation data first. Call CreateLinearApproximation() on curve before calling Evaluate().");
 
   if (m_LinearApproximation.GetCount() >= 2)
   {

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -445,6 +445,7 @@ ezQtPropertyEditorAngleWidget::ezQtPropertyEditorAngleWidget()
     m_pWidget->setMaximum(ezMath::Infinity<double>());
     m_pWidget->setSingleStep(0.1f);
     m_pWidget->setAccelerated(true);
+    m_pWidget->setDecimals(1);
 
     policy.setHorizontalStretch(2);
     m_pWidget->setSizePolicy(policy);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Curve1DEditorWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Curve1DEditorWidget.moc.h
@@ -61,6 +61,8 @@ private Q_SLOTS:
   void onSelectionChanged();
   void onMoveCurve(ezInt32 iCurve, double moveY);
   void onGenerateCurve(ezMath::ezEasingFunctions easingFunction);
+  void onSaveAsPreset();
+  void onLoadPreset();
 
 private:
   void InsertCpAt(double posX, double value, ezVec2d epsilon);
@@ -69,6 +71,9 @@ private:
   void UpdateSpinBoxes();
   void SetTangentMode(ezCurveTangentMode::Enum mode, bool bLeft, bool bRight);
   void ClampPoint(double& x, double& y) const;
+  void SaveCurvePreset(const char* szFile) const;
+  ezResult LoadCurvePreset(const char* szFile);
+  void FindAllPresets();
 
   double m_fCurveDuration;
   ezVec2 m_TangentMove;
@@ -76,4 +81,6 @@ private:
   ezCurveGroupData m_Curves;
   ezCurveGroupData m_CurvesBackup;
   QPointF m_contextMenuScenePos;
+
+  static ezDynamicArray<ezString> s_CurvePresets;
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
@@ -442,17 +442,14 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
   const auto& selection = CurveEdit->GetSelection();
 
   QMenu* cmSel = m.addMenu("Selection");
-  cmSel->addAction("Select All\tCtrl+A", this, [this]()
-    { CurveEdit->SelectAll(); });
+  cmSel->addAction("Select All\tCtrl+A", this, [this]() { CurveEdit->SelectAll(); });
 
   if (!selection.IsEmpty())
   {
-    cmSel->addAction("Clear Selection\tESC", this, [this]()
-      { CurveEdit->ClearSelection(); });
+    cmSel->addAction("Clear Selection\tESC", this, [this]() { CurveEdit->ClearSelection(); });
 
     cmSel->addAction(
-      "Frame Selection\tShift+F", this, [this]()
-      { FrameSelection(); });
+      "Frame Selection\tShift+F", this, [this]() { FrameSelection(); });
 
     cmSel->addSeparator();
 
@@ -508,8 +505,7 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
     { ClearAllPoints(); });
 
   cm->addAction(
-    "Frame Curve\tCtrl+F", this, [this]()
-    { FrameCurve(); });
+    "Frame Curve\tCtrl+F", this, [this]() { FrameCurve(); });
 
   QMenu* presentsMenu = m.addMenu("Presets");
 
@@ -534,70 +530,38 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
     QMenu* qbom = gm->addMenu("Bounce");
 
     gm->addSeparator();
-    lm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InLinear); });
-    lm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutLinear); });
-    sm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InSine); });
-    sm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutSine); });
-    sm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutSine); });
-    qm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InQuad); });
-    qm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutQuad); });
-    qm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutQuad); });
-    qcm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InCubic); });
-    qcm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutCubic); });
-    qcm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutCubic); });
-    qrm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InQuartic); });
-    qrm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutQuartic); });
-    qrm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutQuartic); });
-    qim->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InQuintic); });
-    qim->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutQuintic); });
-    qim->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutQuintic); });
-    qxm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InExpo); });
-    qxm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutExpo); });
-    qxm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutExpo); });
-    qcrm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InCirc); });
-    qcrm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutCirc); });
-    qcrm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutCirc); });
-    qbm->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InBack); });
-    qbm->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutBack); });
-    qbm->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutBack); });
-    qem->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InElastic); });
-    qem->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutElastic); });
-    qem->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutElastic); });
-    qbom->addAction("Ease In", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InBounce); });
-    qbom->addAction("Ease Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::OutBounce); });
-    qbom->addAction("Ease In and Out", this, [this]()
-      { onGenerateCurve(ezMath::ezEasingFunctions::InOutBounce); });
+    lm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InLinear); });
+    lm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutLinear); });
+    sm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InSine); });
+    sm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutSine); });
+    sm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutSine); });
+    qm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InQuad); });
+    qm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutQuad); });
+    qm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutQuad); });
+    qcm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InCubic); });
+    qcm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutCubic); });
+    qcm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutCubic); });
+    qrm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InQuartic); });
+    qrm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutQuartic); });
+    qrm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutQuartic); });
+    qim->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InQuintic); });
+    qim->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutQuintic); });
+    qim->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutQuintic); });
+    qxm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InExpo); });
+    qxm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutExpo); });
+    qxm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutExpo); });
+    qcrm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InCirc); });
+    qcrm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutCirc); });
+    qcrm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutCirc); });
+    qbm->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InBack); });
+    qbm->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutBack); });
+    qbm->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutBack); });
+    qem->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InElastic); });
+    qem->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutElastic); });
+    qem->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutElastic); });
+    qbom->addAction("Ease In", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InBounce); });
+    qbom->addAction("Ease Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::OutBounce); });
+    qbom->addAction("Ease In and Out", this, [this]() { onGenerateCurve(ezMath::ezEasingFunctions::InOutBounce); });
   }
 
   // Show all available presets from disk in a hierarchical menu structure
@@ -605,8 +569,7 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
     ezMap<ezString, QMenu*> subMenus;
     subMenus[""] = presentsMenu;
 
-    auto GetSubMenu = [&](const ezStringBuilder& path, auto GetSubMenu2)
-    {
+    auto GetSubMenu = [&](const ezStringBuilder& path, auto GetSubMenu2) {
       auto it = subMenus.Find(path);
       if (it.IsValid())
         return it.Value();
@@ -630,8 +593,7 @@ void ezQtCurve1DEditorWidget::onContextMenu(QPoint pos, QPointF scenePos)
 
       sPresetPath.Trim("/");
 
-      GetSubMenu(sPresetPath, GetSubMenu)->addAction(sPresetName.GetData(), [this, preset]()
-        { LoadCurvePreset(preset).IgnoreResult(); });
+      GetSubMenu(sPresetPath, GetSubMenu)->addAction(sPresetName.GetData(), [this, preset]() { LoadCurvePreset(preset).IgnoreResult(); });
     }
   }
 
@@ -832,8 +794,7 @@ void ezQtCurve1DEditorWidget::onGenerateCurve(ezMath::ezEasingFunctions easingFu
     samples[i].m_fCorrectValue = GetEasingValue(easingFunction, x);
   }
 
-  auto AddPt = [&](ezUInt32 idx)
-  {
+  auto AddPt = [&](ezUInt32 idx) {
     samples[idx].m_bInserted = true;
     const double x = samples[idx].m_fPos;
     const double y = samples[idx].m_fCorrectValue;

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/Curve1DEditorWidget.cpp
@@ -997,6 +997,8 @@ void ezQtCurve1DEditorWidget::FindAllPresets()
 {
   s_CurvePresets.Clear();
 
+#if EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS)
+
   EZ_LOCK(ezFileSystem::GetMutex());
 
   ezStringBuilder sFilePath;
@@ -1029,6 +1031,8 @@ void ezQtCurve1DEditorWidget::FindAllPresets()
   }
 
   s_CurvePresets.Sort();
+
+#endif
 }
 
 void ezQtCurve1DEditorWidget::UpdateSpinBoxes()


### PR DESCRIPTION
The curve editor now allows to save curves as presets.
All curve presets that are located under "Editor/Presets/Curves" (in any data directory) are automatically available from the context menu. From other places they can be opened manually.
Currently there are no presets shipped, but that may change in the future.

Also the "easing" curves that can be generated from the context menu are now more optimized, containing only the control points that are necessary to decently describe the curve.