### PR TITLE
Make re-runs of cmake faster

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsQt.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsQt.cmake
@@ -12,6 +12,23 @@ macro(ez_requires_qt)
 	ez_requires(EZ_ENABLE_QT_SUPPORT)
 endmacro()
 
+macro(ez_find_qt)
+	# Global keyword was added in cmake 3.24.0 and significantly speeds up generation of QT targets
+	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
+		if(EZ_QT_DIR)
+			find_package(Qt5 COMPONENTS ${ARGN} REQUIRED PATHS ${EZ_QT_DIR} GLOBAL)
+		else()
+			find_package(Qt5 COMPONENTS ${ARGN} REQUIRED GLOBAL)
+		endif()
+	else()
+		if(EZ_QT_DIR)
+			find_package(Qt5 COMPONENTS ${ARGN} REQUIRED PATHS ${EZ_QT_DIR})
+		else()
+			find_package(Qt5 COMPONENTS ${ARGN} REQUIRED)
+		endif()
+	endif()
+endmacro()
+
 # #####################################
 # ## ez_prepare_find_qt()
 # #####################################
@@ -97,11 +114,7 @@ function(ez_link_target_qt)
 
 	ez_prepare_find_qt()
 
-	if(EZ_QT_DIR)
-		find_package(Qt5 COMPONENTS ${FN_ARG_COMPONENTS} REQUIRED PATHS ${EZ_QT_DIR})
-	else()
-		find_package(Qt5 COMPONENTS ${FN_ARG_COMPONENTS} REQUIRED)
-	endif()
+	ez_find_qt(${FN_ARG_COMPONENTS})
 
 	mark_as_advanced(FORCE Qt5_DIR)
 	mark_as_advanced(FORCE Qt5Core_DIR)
@@ -177,11 +190,7 @@ function(ez_qt_wrap_target_ui_files TARGET_NAME FILES_TO_WRAP)
 
 	ez_prepare_find_qt()
 
-	if(EZ_QT_DIR)
-		find_package(Qt5 COMPONENTS Widgets REQUIRED PATHS ${EZ_QT_DIR})
-	else()
-		find_package(Qt5 COMPONENTS Widgets REQUIRED)
-	endif()
+	ez_find_qt(Widgets)
 
 	if(NOT TARGET Qt5::uic)
 		message(FATAL_ERROR "UIC.exe not found")
@@ -214,11 +223,7 @@ function(ez_qt_wrap_target_moc_files TARGET_NAME FILES_TO_WRAP)
 
 	ez_prepare_find_qt()
 
-	if(EZ_QT_DIR)
-		find_package(Qt5 COMPONENTS Widgets REQUIRED PATHS ${EZ_QT_DIR})
-	else()
-		find_package(Qt5 COMPONENTS Widgets REQUIRED)
-	endif()
+	ez_find_qt(Widgets)
 
 	set(Qt5Core_MOC_EXECUTABLE Qt5::moc)
 	ez_retrieve_target_pch(${TARGET_NAME} PCH_H)
@@ -249,11 +254,7 @@ function(ez_qt_wrap_target_qrc_files TARGET_NAME FILES_TO_WRAP)
 
 	ez_prepare_find_qt()
 
-	if(EZ_QT_DIR)
-		find_package(Qt5 COMPONENTS Widgets REQUIRED PATHS ${EZ_QT_DIR})
-	else()
-		find_package(Qt5 COMPONENTS Widgets REQUIRED)
-	endif()
+	ez_find_qt(Widgets)
 
 	set(Qt5Core_RCC_EXECUTABLE Qt5::rcc)
 	qt5_add_resources(QRC_FILES ${FILES_TO_WRAP})

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsUnityFiles.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsUnityFiles.cmake
@@ -76,7 +76,6 @@ function(ez_generate_folder_unity_file TARGET_NAME PROJECT_DIRECTORY SUB_FOLDER_
 
 	if(EXISTS ${FOLDER_UNITY_FILE})
 		# check if the generated unity file is different from the existing one
-		#file(SHA1 ${FOLDER_UNITY_FILE} UNITY_EXISTING_HASH)
 		file(READ ${FOLDER_UNITY_FILE} OLD_UNITY_FILE_CONTENTS)
 		string(SHA1 UNITY_EXISTING_HASH ${OLD_UNITY_FILE_CONTENTS})
 		string(SHA1 UNITY_NEW_HASH ${UNITY_FILE_CONTENTS})
@@ -88,7 +87,6 @@ function(ez_generate_folder_unity_file TARGET_NAME PROJECT_DIRECTORY SUB_FOLDER_
 
 	if(${UNITY_FILE_NEEDS_UPDATE})
 		file(WRITE ${FOLDER_UNITY_FILE} ${UNITY_FILE_CONTENTS})
-		message("Writing unity file ${FOLDER_UNITY_FILE}")
 	endif()
 
 	# add the file to the target and sort it into the proper sub-tree

--- a/Code/BuildSystem/CMake/ezUtils.cmake
+++ b/Code/BuildSystem/CMake/ezUtils.cmake
@@ -317,18 +317,24 @@ endfunction()
 # ## ez_glob_source_files(<path-to-folder> <out-files>)
 # #####################################
 function(ez_glob_source_files ROOT_DIR RESULT_ALL_SOURCES)
-	file(GLOB_RECURSE CPP_FILES "${ROOT_DIR}/*.cpp" "${ROOT_DIR}/*.cc")
-	file(GLOB_RECURSE H_FILES "${ROOT_DIR}/*.h" "${ROOT_DIR}/*.hpp" "${ROOT_DIR}/*.inl")
-	file(GLOB_RECURSE C_FILES "${ROOT_DIR}/*.c")
-	file(GLOB_RECURSE CS_FILES "${ROOT_DIR}/*.cs")
+	file(GLOB_RECURSE RELEVANT_FILES 
+		"${ROOT_DIR}/*.cpp" 
+		"${ROOT_DIR}/*.cc" 
+		"${ROOT_DIR}/*.h" 
+		"${ROOT_DIR}/*.hpp" 
+		"${ROOT_DIR}/*.inl" 
+		"${ROOT_DIR}/*.c" 
+		"${ROOT_DIR}/*.cs" 
+		"${ROOT_DIR}/*.ui"
+		"${ROOT_DIR}/*.qrc"
+		"${ROOT_DIR}/*.def"
+		"${ROOT_DIR}/*.ico"
+		"${ROOT_DIR}/*.rc"
+		"${ROOT_DIR}/*.cmake"
+		"${ROOT_DIR}/CMakeLists.txt"
+	)
 
-	file(GLOB_RECURSE UI_FILES "${ROOT_DIR}/*.ui")
-	file(GLOB_RECURSE QRC_FILES "${ROOT_DIR}/*.qrc")
-	file(GLOB_RECURSE DEF_FILES "${ROOT_DIR}/*.def")
-	file(GLOB_RECURSE RES_FILES "${ROOT_DIR}/*.ico" "${ROOT_DIR}/*.rc")
-	file(GLOB_RECURSE CMAKE_FILES "${ROOT_DIR}/*.cmake" "${ROOT_DIR}/CMakeLists.txt")
-
-	set(${RESULT_ALL_SOURCES} ${CPP_FILES} ${H_FILES} ${C_FILES} ${CS_FILES} ${UI_FILES} ${QRC_FILES} ${RES_FILES} ${DEF_FILES} ${CMAKE_FILES} PARENT_SCOPE)
+	set(${RESULT_ALL_SOURCES} ${RELEVANT_FILES} PARENT_SCOPE)
 endfunction()
 
 # #####################################
@@ -441,7 +447,7 @@ endfunction()
 # #####################################
 function(ez_init_projects)
 	# find all init.cmake files below this directory
-	file(GLOB_RECURSE INIT_FILES "init.cmake")
+	file(GLOB_RECURSE INIT_FILES "${CMAKE_SOURCE_DIR}/${EZ_SUBMODULE_PREFIX_PATH}/Code/init.cmake")
 
 	foreach(INIT_FILE ${INIT_FILES})
 		message(STATUS "Including '${INIT_FILE}'")
@@ -454,10 +460,10 @@ endfunction()
 # #####################################
 function(ez_finalize_projects)
 	# find all init.cmake files below this directory
-	file(GLOB_RECURSE INIT_FILES "finalize.cmake")
+	file(GLOB_RECURSE FINALIZE_FILES "${CMAKE_SOURCE_DIR}/${EZ_SUBMODULE_PREFIX_PATH}/Code/finalize.cmake")
 
 	# TODO: also finalize external projects
-	foreach(INIT_FILE ${INIT_FILES})
+	foreach(INIT_FILE ${FINALIZE_FILES})
 		message(STATUS "Including '${INIT_FILE}'")
 		include("${INIT_FILE}")
 	endforeach()
@@ -470,7 +476,7 @@ endfunction()
 # The build filter is intended to only build a subset of ezEngine.
 # The build filters are configured through cmake files in the 'BuildFilters' directory.
 function(ez_build_filter_init)
-	file(GLOB_RECURSE FILTER_FILES "${CMAKE_SOURCE_DIR}/*.BuildFilter")
+	file(GLOB_RECURSE FILTER_FILES "${CMAKE_SOURCE_DIR}/${EZ_SUBMODULE_PREFIX_PATH}/Code/BuildSystem/CMake/BuildFilters/*.BuildFilter")
 
 	get_property(EZ_BUILD_FILTER_NAMES GLOBAL PROPERTY EZ_BUILD_FILTER_NAMES)
 


### PR DESCRIPTION
* Once there is a existing cmake cache, reduce the runtime of cmake by 36% (down to 5.3 seconds from 8.3 seconds on my machine)
* This is possible thanks to the discovery of the cmake `--profiling-output=perf.json --profiling-format=google-trace` command line options, which give you a json file that can be opened in `chrome://tracing`