### PR TITLE
Various linux fixes

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsDetect.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsDetect.cmake
@@ -337,6 +337,8 @@ function(ez_detect_compiler_and_architecture)
 			else()
 				message(FATAL_ERROR "The compile test did not output the MSC_VER. Compiler broken? Compiler output: ${COMPILE_OUTPUT}")
 			endif()
+		else()
+			set(EZ_DETECTED_MSVC_VER "<NOT USING MSVC>" CACHE INTERNAL "")
 		endif()
 	endif()
 

--- a/Code/Engine/Foundation/CMakeLists.txt
+++ b/Code/Engine/Foundation/CMakeLists.txt
@@ -27,7 +27,7 @@ if (EZ_CMAKE_PLATFORM_LINUX)
     PRIVATE
 
     uuid
-	dl # dlopen, dlclose, etc
+    dl # dlopen, dlclose, etc
   )
 endif()
 

--- a/Code/Engine/Foundation/Communication/Implementation/Linux/PipeChannel_linux.h
+++ b/Code/Engine/Foundation/Communication/Implementation/Linux/PipeChannel_linux.h
@@ -43,5 +43,7 @@ private:
 
   ezUInt8 m_InputBuffer[4096];
   ezAtomicBool m_Connecting = false;
+
+  ezUInt64 m_previousSendOffset = 0;
 };
 #endif

--- a/Code/Engine/Foundation/Threading/Implementation/TaskWorkerThread.cpp
+++ b/Code/Engine/Foundation/Threading/Implementation/TaskWorkerThread.cpp
@@ -14,8 +14,8 @@ static const char* GenerateThreadName(ezWorkerThreadType::Enum ThreadType, ezUIn
 }
 
 ezTaskWorkerThread::ezTaskWorkerThread(ezWorkerThreadType::Enum ThreadType, ezUInt32 uiThreadNumber)
-  // We need at least 128 kb of stack size, otherwise the shader compilation tasks will run out of stack space.
-  : ezThread(GenerateThreadName(ThreadType, uiThreadNumber), 128 * 1024)
+  // We need at least 256 kb of stack size, otherwise the shader compilation tasks will run out of stack space.
+  : ezThread(GenerateThreadName(ThreadType, uiThreadNumber), 256 * 1024)
 {
   m_WorkerType = ThreadType;
   m_uiWorkerThreadNumber = uiThreadNumber & 0xFFFF;


### PR DESCRIPTION
* Fix issue with sending large packets over PipeChannel_linux
* Increase stack size for worker threads, as 128kb is not sufficient for the Shader compiler on linux.
* Fix issue with caching detected architecture values on linux.