### PR TITLE
ezImageCopyVulkan Cache

### DIFF
--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -160,6 +160,13 @@ public:
   static void UploadBufferStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> pInitialData, vk::DeviceSize dstOffset = 0);
   static void UploadTextureStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALTextureVulkan* pTexture, const vk::ImageSubresourceLayers& subResource, const ezGALSystemMemoryDescription& data);
 
+  struct OnBeforeImageDestroyedData
+  {
+    vk::Image image;
+    ezGALDeviceVulkan& GALDeviceVulkan;
+  };
+  ezEvent<OnBeforeImageDestroyedData> OnBeforeImageDestroyed;
+
 
   // These functions need to be implemented by a render API abstraction
 protected:

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -34,6 +34,7 @@
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
+#include <RendererVulkan/Utils/ImageCopyVulkan.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>
@@ -499,6 +500,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   ezResourceCacheVulkan::Initialize(this, m_device);
   ezDescriptorSetPoolVulkan::Initialize(m_device);
   ezFallbackResourcesVulkan::Initialize(this);
+  ezImageCopyVulkan::Initialize(*this);
 
   m_pDefaultPass = EZ_NEW(&m_Allocator, ezGALPassVulkan, *this);
 
@@ -607,6 +609,7 @@ void ezGALDeviceVulkan::UploadTextureStaging(ezStagingBufferPoolVulkan* pStaging
 
 ezResult ezGALDeviceVulkan::ShutdownPlatform()
 {
+  ezImageCopyVulkan::DeInitialize(*this);
   ezFallbackResourcesVulkan::DeInitialize();
 
   ezGALWindowSwapChain::SetFactoryMethod({});

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -610,6 +610,8 @@ void ezGALDeviceVulkan::UploadTextureStaging(ezStagingBufferPoolVulkan* pStaging
 ezResult ezGALDeviceVulkan::ShutdownPlatform()
 {
   ezImageCopyVulkan::DeInitialize(*this);
+  DestroyDeadObjects(); // ezImageCopyVulkan might add dead objects, so make sure the list is cleared again
+
   ezFallbackResourcesVulkan::DeInitialize();
 
   ezGALWindowSwapChain::SetFactoryMethod({});

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -33,8 +33,8 @@
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
-#include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
+#include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>
@@ -1325,11 +1325,11 @@ void ezGALDeviceVulkan::DeletePendingResources(ezDeque<PendingDeletion>& pending
         m_device.destroyImageView(reinterpret_cast<vk::ImageView&>(deletion.m_pObject));
         break;
       case vk::ObjectType::eImage:
-        {
-          auto& image = reinterpret_cast<vk::Image&>(deletion.m_pObject);
-          OnBeforeImageDestroyed.Broadcast(OnBeforeImageDestroyedData{image, *this});
-          ezMemoryAllocatorVulkan::DestroyImage(image, deletion.m_allocation);
-        }
+      {
+        auto& image = reinterpret_cast<vk::Image&>(deletion.m_pObject);
+        OnBeforeImageDestroyed.Broadcast(OnBeforeImageDestroyedData{image, *this});
+        ezMemoryAllocatorVulkan::DestroyImage(image, deletion.m_allocation);
+      }
         break;
       case vk::ObjectType::eBuffer:
         ezMemoryAllocatorVulkan::DestroyBuffer(reinterpret_cast<vk::Buffer&>(deletion.m_pObject), deletion.m_allocation);

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1323,7 +1323,11 @@ void ezGALDeviceVulkan::DeletePendingResources(ezDeque<PendingDeletion>& pending
         m_device.destroyImageView(reinterpret_cast<vk::ImageView&>(deletion.m_pObject));
         break;
       case vk::ObjectType::eImage:
-        ezMemoryAllocatorVulkan::DestroyImage(reinterpret_cast<vk::Image&>(deletion.m_pObject), deletion.m_allocation);
+        {
+          auto& image = reinterpret_cast<vk::Image&>(deletion.m_pObject);
+          OnBeforeImageDestroyed.Broadcast(OnBeforeImageDestroyedData{image, *this});
+          ezMemoryAllocatorVulkan::DestroyImage(image, deletion.m_allocation);
+        }
         break;
       case vk::ObjectType::eBuffer:
         ezMemoryAllocatorVulkan::DestroyBuffer(reinterpret_cast<vk::Buffer&>(deletion.m_pObject), deletion.m_allocation);

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -46,6 +46,8 @@ public:
 
   struct PipelineCacheValue
   {
+    EZ_DECLARE_POD_TYPE();
+
     ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
     ezResourceCacheVulkan::GraphicsPipelineDesc m_PipelineDesc;
     vk::Pipeline m_pipeline;
@@ -53,10 +55,28 @@ public:
 
   struct FramebufferCacheKey
   {
+    EZ_DECLARE_POD_TYPE();
+
     vk::RenderPass m_renderpass;
     vk::ImageView m_targetView;
     ezVec3U32 m_extends;
     uint32_t m_layerCount;
+  };
+
+  struct ImageViewCacheKey
+  {
+    EZ_DECLARE_POD_TYPE();
+
+    vk::Image m_image;
+    vk::ImageSubresourceLayers m_subresourceLayers;
+  };
+
+  struct ImageViewCacheValue
+  {
+    EZ_DECLARE_POD_TYPE();
+
+    vk::ImageSubresourceLayers m_subresourceLayers;
+    vk::ImageView m_imageView;
   };
 
 private:
@@ -91,13 +111,13 @@ private:
     ezHashTable<ezGALShaderHandle, ezGALVertexDeclarationHandle> m_vertexDeclarations;
     ezHashTable<RenderPassCacheKey, vk::RenderPass> m_renderPasses;
     ezHashTable<PipelineCacheKey, PipelineCacheValue> m_pipelines;
-    ezHashTable<vk::Image, vk::ImageView> m_SourceImageViews;
-    ezHashTable<vk::Image, vk::ImageView> m_TargetImageViews;
-    ezHashTable<FramebufferCacheKey, vk::Framebuffer> m_Framebuffers;
+    ezHashTable<ImageViewCacheKey, vk::ImageView> m_sourceImageViews;
+    ezHashTable<vk::Image, ImageViewCacheValue> m_imageToSourceImageViewCacheKey;
+    ezHashTable<ImageViewCacheKey, vk::ImageView> m_targetImageViews;
+    ezHashTable<vk::Image, ImageViewCacheValue> m_imageToTargetImageViewCacheKey;
+    ezHashTable<FramebufferCacheKey, vk::Framebuffer> m_framebuffers;
 
     ezEventSubscriptionID m_onBeforeImageDeletedSubscription;
-
-    //TODO add mutex to make thread safe
   };
 
   static ezUniquePtr<Cache> s_cache;

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -16,20 +16,86 @@
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
 
-namespace
+template <>
+struct ezHashHelper<ezGALShaderHandle>
 {
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(ezGALShaderHandle value)
+  {
+    return ezHashHelper<ezGALShaderHandle::IdType::StorageType>::Hash(value.GetInternalID().m_Data);
+  }
 
-} // namespace
+  EZ_ALWAYS_INLINE static bool Equal(ezGALShaderHandle a, ezGALShaderHandle b)
+  {
+    return ezHashHelper<ezGALShaderHandle::IdType::StorageType>::Equal(a.GetInternalID().m_Data, b.GetInternalID().m_Data);
+  }
+};
+
+template <>
+struct ezHashHelper<ezImageCopyVulkan::RenderPassCacheEntry>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(const ezImageCopyVulkan::RenderPassCacheEntry& value)
+  {
+    return ezHashingUtils::CombineHashValues32(static_cast<uint32_t>(value.targetFormat), static_cast<uint32_t>(value.targetSamples));
+  }
+
+  EZ_ALWAYS_INLINE static bool Equal(const ezImageCopyVulkan::RenderPassCacheEntry& a, const ezImageCopyVulkan::RenderPassCacheEntry& b)
+  {
+    return a.targetFormat == b.targetFormat && a.targetSamples == b.targetSamples;
+  }
+};
+
+template <>
+struct ezHashHelper<ezImageCopyVulkan::PipelineCacheKey>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(const ezImageCopyVulkan::PipelineCacheKey& value)
+  {
+    ezHashStreamWriter32 writer;
+    writer << (VkRenderPass)value.m_renderPass;
+    writer << value.m_sampelCount.GetValue();
+    writer << static_cast<ezUInt32>(value.m_shaderType);
+    return writer.GetHashValue();
+  }
+
+  EZ_ALWAYS_INLINE static bool Equal(const ezImageCopyVulkan::PipelineCacheKey& a, const ezImageCopyVulkan::PipelineCacheKey& b)
+  {
+    return a.m_renderPass == b.m_renderPass && a.m_sampelCount == b.m_sampelCount && a.m_shaderType == b.m_shaderType;
+  }
+};
+
+ezUniquePtr<ezImageCopyVulkan::Cache> ezImageCopyVulkan::s_cache;
+
+ezImageCopyVulkan::Cache::Cache(ezAllocatorBase* pAllocator)
+  : m_vertexDeclarations(pAllocator)
+  , m_renderPasses(pAllocator)
+  , m_pipelines(pAllocator)
+{
+}
+
+ezImageCopyVulkan::Cache::~Cache() = default;
 
 ezImageCopyVulkan::ezImageCopyVulkan(ezGALDeviceVulkan& GALDeviceVulkan)
   : m_GALDeviceVulkan(GALDeviceVulkan)
 {
 }
 
-ezImageCopyVulkan::~ezImageCopyVulkan()
+ezImageCopyVulkan::~ezImageCopyVulkan() = default;
+
+void ezImageCopyVulkan::Initialize(ezGALDeviceVulkan& GALDeviceVulkan)
 {
-  m_GALDeviceVulkan.DeleteLater(m_renderPass);
-  m_GALDeviceVulkan.DestroyVertexDeclaration(m_hVertexDecl);
+  s_cache = EZ_NEW(&GALDeviceVulkan.GetAllocator(), ezImageCopyVulkan::Cache, &GALDeviceVulkan.GetAllocator());
+}
+
+void ezImageCopyVulkan::DeInitialize(ezGALDeviceVulkan& GALDeviceVulkan)
+{
+  for (auto& kv : (s_cache->m_vertexDeclarations))
+  {
+    GALDeviceVulkan.DestroyVertexDeclaration(kv.Value());
+  }
+  for (auto& kv : (s_cache->m_renderPasses))
+  {
+    GALDeviceVulkan.GetVulkanDevice().destroyRenderPass(kv.Value());
+  }
+  s_cache = nullptr;
 }
 
 void ezImageCopyVulkan::Init(const ezGALTextureVulkan* pSource, const ezGALTextureVulkan* pTarget, ezShaderUtils::ezBuiltinShaderType type)
@@ -48,71 +114,110 @@ void ezImageCopyVulkan::Init(const ezGALTextureVulkan* pSource, const ezGALTextu
 
   // Render pass
   {
-    ezHybridArray<vk::AttachmentDescription, 4> attachments;
-    ezHybridArray<vk::AttachmentReference, 4> colorAttachmentRefs;
-    vk::AttachmentDescription& vkAttachment = attachments.ExpandAndGetRef();
-    vkAttachment.format = targetFormat;
-    vkAttachment.samples = ezConversionUtilsVulkan::GetSamples(targetDesc.m_SampleCount);
-    vkAttachment.loadOp = vk::AttachmentLoadOp::eLoad; //#TODO_VULKAN we could replace this with don't care if we knew that all copy commands render to the entire sub-resource.
-    vkAttachment.storeOp = vk::AttachmentStoreOp::eStore;
-    vkAttachment.initialLayout = vk::ImageLayout::eColorAttachmentOptimal;
-    vkAttachment.finalLayout = vk::ImageLayout::eColorAttachmentOptimal;
+    RenderPassCacheEntry cacheEntry = {};
+    cacheEntry.targetFormat = targetFormat;
+    cacheEntry.targetSamples = ezConversionUtilsVulkan::GetSamples(targetDesc.m_SampleCount);
 
-    vk::AttachmentReference& colorAttachment = colorAttachmentRefs.ExpandAndGetRef();
-    colorAttachment.attachment = 0;
-    colorAttachment.layout = vk::ImageLayout::eColorAttachmentOptimal;
+    if (auto it = s_cache->m_renderPasses.Find(cacheEntry); it.IsValid())
+    {
+      m_renderPass = it.Value();
+    }
+    else
+    {
+      ezHybridArray<vk::AttachmentDescription, 4> attachments;
+      ezHybridArray<vk::AttachmentReference, 4> colorAttachmentRefs;
+      vk::AttachmentDescription& vkAttachment = attachments.ExpandAndGetRef();
+      vkAttachment.format = cacheEntry.targetFormat;
+      vkAttachment.samples = cacheEntry.targetSamples;
+      vkAttachment.loadOp = vk::AttachmentLoadOp::eLoad; //#TODO_VULKAN we could replace this with don't care if we knew that all copy commands render to the entire sub-resource.
+      vkAttachment.storeOp = vk::AttachmentStoreOp::eStore;
+      vkAttachment.initialLayout = vk::ImageLayout::eColorAttachmentOptimal;
+      vkAttachment.finalLayout = vk::ImageLayout::eColorAttachmentOptimal;
 
-    vk::SubpassDescription subpass;
-    subpass.pipelineBindPoint = vk::PipelineBindPoint::eGraphics;
-    subpass.colorAttachmentCount = colorAttachmentRefs.GetCount();
-    subpass.pColorAttachments = colorAttachmentRefs.GetData();
-    subpass.pDepthStencilAttachment = nullptr;
+      vk::AttachmentReference& colorAttachment = colorAttachmentRefs.ExpandAndGetRef();
+      colorAttachment.attachment = 0;
+      colorAttachment.layout = vk::ImageLayout::eColorAttachmentOptimal;
 
-    vk::SubpassDependency dependency;
-    dependency.dstSubpass = 0;
-    dependency.dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
+      vk::SubpassDescription subpass;
+      subpass.pipelineBindPoint = vk::PipelineBindPoint::eGraphics;
+      subpass.colorAttachmentCount = colorAttachmentRefs.GetCount();
+      subpass.pColorAttachments = colorAttachmentRefs.GetData();
+      subpass.pDepthStencilAttachment = nullptr;
 
-    dependency.dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests;
-    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependency.srcAccessMask = {};
-    dependency.srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests;
+      vk::SubpassDependency dependency;
+      dependency.dstSubpass = 0;
+      dependency.dstAccessMask |= vk::AccessFlagBits::eColorAttachmentWrite;
 
-    vk::RenderPassCreateInfo renderPassCreateInfo;
-    renderPassCreateInfo.attachmentCount = attachments.GetCount();
-    renderPassCreateInfo.pAttachments = attachments.GetData();
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpass;
-    renderPassCreateInfo.dependencyCount = 1;
-    renderPassCreateInfo.pDependencies = &dependency;
+      dependency.dstStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests;
+      dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+      dependency.srcAccessMask = {};
+      dependency.srcStageMask = vk::PipelineStageFlagBits::eColorAttachmentOutput | vk::PipelineStageFlagBits::eEarlyFragmentTests;
 
-    VK_ASSERT_DEV(m_GALDeviceVulkan.GetVulkanDevice().createRenderPass(&renderPassCreateInfo, nullptr, &m_renderPass));
+      vk::RenderPassCreateInfo renderPassCreateInfo;
+      renderPassCreateInfo.attachmentCount = attachments.GetCount();
+      renderPassCreateInfo.pAttachments = attachments.GetData();
+      renderPassCreateInfo.subpassCount = 1;
+      renderPassCreateInfo.pSubpasses = &subpass;
+      renderPassCreateInfo.dependencyCount = 1;
+      renderPassCreateInfo.pDependencies = &dependency;
+
+      VK_ASSERT_DEV(m_GALDeviceVulkan.GetVulkanDevice().createRenderPass(&renderPassCreateInfo, nullptr, &m_renderPass));
+      s_cache->m_renderPasses.Insert(cacheEntry, m_renderPass);
+    }
+  }
+
+  // Vertex declaration
+  {
+    ezShaderUtils::RequestBuiltinShader(type, m_shader);
+    {
+      if (auto it = s_cache->m_vertexDeclarations.Find(m_shader.m_hActiveGALShader); it.IsValid())
+      {
+        m_hVertexDecl = it.Value();
+      }
+      else
+      {
+        ezGALVertexDeclarationCreationDescription desc;
+        desc.m_hShader = m_shader.m_hActiveGALShader;
+        m_hVertexDecl = m_GALDeviceVulkan.CreateVertexDeclaration(desc);
+        s_cache->m_vertexDeclarations.Insert(m_shader.m_hActiveGALShader, m_hVertexDecl);
+      }
+      m_PipelineDesc.m_pCurrentVertexDecl = static_cast<const ezGALVertexDeclarationVulkan*>(m_GALDeviceVulkan.GetVertexDeclaration(m_hVertexDecl));
+    }
   }
 
   // Pipeline
   {
-    m_PipelineDesc.m_renderPass = m_renderPass;
-    m_PipelineDesc.m_topology = ezGALPrimitiveTopology::Triangles;
-    m_PipelineDesc.m_msaa = targetDesc.m_SampleCount;
-    m_PipelineDesc.m_uiAttachmentCount = 1;
 
+    PipelineCacheKey cacheEntry = {};
+    cacheEntry.m_renderPass = m_renderPass;
+    cacheEntry.m_sampelCount = targetDesc.m_SampleCount;
+    cacheEntry.m_shaderType = type;
 
-    ezShaderUtils::RequestBuiltinShader(type, m_shader);
-    m_PipelineDesc.m_pCurrentRasterizerState = static_cast<const ezGALRasterizerStateVulkan*>(m_GALDeviceVulkan.GetRasterizerState(m_shader.m_hRasterizerState));
-    m_PipelineDesc.m_pCurrentBlendState = static_cast<const ezGALBlendStateVulkan*>(m_GALDeviceVulkan.GetBlendState(m_shader.m_hBlendState));
-    m_PipelineDesc.m_pCurrentDepthStencilState = static_cast<const ezGALDepthStencilStateVulkan*>(m_GALDeviceVulkan.GetDepthStencilState(m_shader.m_hDepthStencilState));
-    m_PipelineDesc.m_pCurrentShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_shader.m_hActiveGALShader));
-
+    if (auto it = s_cache->m_pipelines.Find(cacheEntry); it.IsValid())
     {
-      ezGALVertexDeclarationCreationDescription desc;
-      desc.m_hShader = m_shader.m_hActiveGALShader;
-      m_hVertexDecl = m_GALDeviceVulkan.CreateVertexDeclaration(desc);
-      m_PipelineDesc.m_pCurrentVertexDecl = static_cast<const ezGALVertexDeclarationVulkan*>(m_GALDeviceVulkan.GetVertexDeclaration(m_hVertexDecl));
+      m_LayoutDesc = it.Value().m_LayoutDesc;
+      m_PipelineDesc = it.Value().m_PipelineDesc;
+      m_pipeline = it.Value().m_pipeline;
     }
+    else
+    {
+      m_PipelineDesc.m_renderPass = m_renderPass;
+      m_PipelineDesc.m_topology = ezGALPrimitiveTopology::Triangles;
+      m_PipelineDesc.m_msaa = targetDesc.m_SampleCount;
+      m_PipelineDesc.m_uiAttachmentCount = 1;
 
-    const ezGALShaderVulkan::DescriptorSetLayoutDesc& descriptorLayoutDesc = m_PipelineDesc.m_pCurrentShader->GetDescriptorSetLayout();
-    m_LayoutDesc.m_layout = ezResourceCacheVulkan::RequestDescriptorSetLayout(descriptorLayoutDesc);
-    m_PipelineDesc.m_layout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
-    m_pipeline = ezResourceCacheVulkan::RequestGraphicsPipeline(m_PipelineDesc);
+
+      m_PipelineDesc.m_pCurrentRasterizerState = static_cast<const ezGALRasterizerStateVulkan*>(m_GALDeviceVulkan.GetRasterizerState(m_shader.m_hRasterizerState));
+      m_PipelineDesc.m_pCurrentBlendState = static_cast<const ezGALBlendStateVulkan*>(m_GALDeviceVulkan.GetBlendState(m_shader.m_hBlendState));
+      m_PipelineDesc.m_pCurrentDepthStencilState = static_cast<const ezGALDepthStencilStateVulkan*>(m_GALDeviceVulkan.GetDepthStencilState(m_shader.m_hDepthStencilState));
+      m_PipelineDesc.m_pCurrentShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_shader.m_hActiveGALShader));
+
+
+      const ezGALShaderVulkan::DescriptorSetLayoutDesc& descriptorLayoutDesc = m_PipelineDesc.m_pCurrentShader->GetDescriptorSetLayout();
+      m_LayoutDesc.m_layout = ezResourceCacheVulkan::RequestDescriptorSetLayout(descriptorLayoutDesc);
+      m_PipelineDesc.m_layout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
+      m_pipeline = ezResourceCacheVulkan::RequestGraphicsPipeline(m_PipelineDesc);
+    }
   }
 }
 

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -389,7 +389,6 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
       {
         viewCreateInfo.viewType = vk::ImageViewType::e2DArray;
       }
-      ezLog::Info("CreateImageView");
       VK_ASSERT_DEV(m_GALDeviceVulkan.GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &sourceView));
       m_GALDeviceVulkan.SetDebugName("ImageCopy-SRV", sourceView);
       s_cache->m_sourceImageViews.Insert(cacheKey, sourceView);
@@ -417,7 +416,6 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
       {
         viewCreateInfo.viewType = vk::ImageViewType::e2DArray;
       }
-      ezLog::Info("CreateImageView");
       VK_ASSERT_DEV(m_GALDeviceVulkan.GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &targetView));
       m_GALDeviceVulkan.SetDebugName("ImageCopy-RTV", targetView);
       s_cache->m_targetImageViews.Insert(cacheKey, targetView);
@@ -446,7 +444,6 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
       framebufferInfo.width = extends.x;
       framebufferInfo.height = extends.y;
       framebufferInfo.layers = targetLayers.layerCount;
-      ezLog::Info("Create FrameBuffer");
       VK_ASSERT_DEV(m_GALDeviceVulkan.GetVulkanDevice().createFramebuffer(&framebufferInfo, nullptr, &frameBuffer));
 
       s_cache->m_framebuffers.Insert(cacheEntry, frameBuffer);


### PR DESCRIPTION
The current implementation of ezImageCopyVulkan recreates all resources every frame. This is expensive and spams the editor engine process log. Avoid recreating the resources every frame by caching them.