### PR TITLE
Fix crash in Editor that sometimes occures when showing splash screen.

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -34,7 +34,7 @@ ezQtEditorApp::~ezQtEditorApp()
 
 ezInt32 ezQtEditorApp::RunEditor()
 {
-  ezInt32 ret = s_pQtApplication->exec();
+  ezInt32 ret = m_pQtApplication->exec();
   return ret;
 }
 

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -274,6 +274,7 @@ private:
   ezRecentFilesList s_RecentProjects;
   ezRecentFilesList s_RecentDocuments;
 
+  int s_iArgc = 0;
   QApplication* s_pQtApplication = nullptr;
   ezLongOpControllerManager m_LongOpControllerManager;
   ezEditorEngineProcessConnection* s_pEngineViewProcess;

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -274,8 +274,8 @@ private:
   ezRecentFilesList s_RecentProjects;
   ezRecentFilesList s_RecentDocuments;
 
-  int s_iArgc = 0;
-  QApplication* s_pQtApplication = nullptr;
+  int m_iArgc = 0;
+  QApplication* m_pQtApplication = nullptr;
   ezLongOpControllerManager m_LongOpControllerManager;
   ezEditorEngineProcessConnection* s_pEngineViewProcess;
   QTimer* m_pTimer = nullptr;

--- a/Code/Editor/EditorFramework/EditorApp/Qt.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Qt.cpp
@@ -88,7 +88,8 @@ void ezQtEditorApp::InitQt(int argc, char** argv)
   }
   else
   {
-    s_pQtApplication = new QApplication(argc, argv);
+    s_iArgc = argc;
+    s_pQtApplication = new QApplication(s_iArgc, argv);
     s_pQtApplication->setProperty("Shared", QVariant::fromValue((int)1));
     QFont font = s_pQtApplication->font();
     int ps = font.pixelSize();

--- a/Code/Editor/EditorFramework/EditorApp/Qt.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Qt.cpp
@@ -80,33 +80,33 @@ void ezQtEditorApp::InitQt(int argc, char** argv)
 
   if (qApp != nullptr)
   {
-    s_pQtApplication = qApp;
+    m_pQtApplication = qApp;
     bool ok = false;
-    const int iCount = s_pQtApplication->property("Shared").toInt(&ok);
+    const int iCount = m_pQtApplication->property("Shared").toInt(&ok);
     EZ_ASSERT_DEV(ok, "Existing QApplication was not constructed by EZ!");
-    s_pQtApplication->setProperty("Shared", QVariant::fromValue(iCount + 1));
+    m_pQtApplication->setProperty("Shared", QVariant::fromValue(iCount + 1));
   }
   else
   {
-    s_iArgc = argc;
-    s_pQtApplication = new QApplication(s_iArgc, argv);
-    s_pQtApplication->setProperty("Shared", QVariant::fromValue((int)1));
-    QFont font = s_pQtApplication->font();
+    m_iArgc = argc;
+    m_pQtApplication = new QApplication(m_iArgc, argv);
+    m_pQtApplication->setProperty("Shared", QVariant::fromValue((int)1));
+    QFont font = m_pQtApplication->font();
     int ps = font.pixelSize();
     // font.setPixelSize(11);
-    s_pQtApplication->setFont(font);
+    m_pQtApplication->setFont(font);
   }
 }
 
 void ezQtEditorApp::DeInitQt()
 {
-  const int iCount = s_pQtApplication->property("Shared").toInt();
+  const int iCount = m_pQtApplication->property("Shared").toInt();
   if (iCount == 1)
   {
-    delete s_pQtApplication;
+    delete m_pQtApplication;
   }
   else
   {
-    s_pQtApplication->setProperty("Shared", QVariant::fromValue(iCount - 1));
+    m_pQtApplication->setProperty("Shared", QVariant::fromValue(iCount - 1));
   }
 }


### PR DESCRIPTION
Sometimes when starting the editor, the editor will crash when trying to display the splash screen. This crash happens deep inside QT code.

The issue is that QApplication takes the `argc` argument as reference, not as copy. The Qt Documentation states, that the passed in reference to `argc` must outlive `QApplication`. The current code does not adhere to this requirement.