### PR TITLE
Fix two inalid memory access issues in vulkan renderer.

### DIFF
--- a/Code/Engine/RendererCore/Shader/Implementation/ConstantBufferStorage.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ConstantBufferStorage.cpp
@@ -9,6 +9,7 @@ ezConstantBufferStorageBase::ezConstantBufferStorageBase(ezUInt32 uiSizeInBytes)
   , m_uiLastHash(0)
 {
   m_Data = ezMakeArrayPtr(static_cast<ezUInt8*>(ezFoundation::GetAlignedAllocator()->Allocate(uiSizeInBytes, 16)), uiSizeInBytes);
+  memset(m_Data.GetPtr(), 0, m_Data.GetCount());
 
   m_hGALConstantBuffer = ezGALDevice::GetDefaultDevice()->CreateConstantBuffer(uiSizeInBytes);
 }

--- a/Code/Engine/RendererCore/Shader/Implementation/ConstantBufferStorage.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ConstantBufferStorage.cpp
@@ -9,7 +9,7 @@ ezConstantBufferStorageBase::ezConstantBufferStorageBase(ezUInt32 uiSizeInBytes)
   , m_uiLastHash(0)
 {
   m_Data = ezMakeArrayPtr(static_cast<ezUInt8*>(ezFoundation::GetAlignedAllocator()->Allocate(uiSizeInBytes, 16)), uiSizeInBytes);
-  memset(m_Data.GetPtr(), 0, m_Data.GetCount());
+  ezMemoryUtils::ZeroFill(m_Data.GetPtr(), m_Data.GetCount());
 
   m_hGALConstantBuffer = ezGALDevice::GetDefaultDevice()->CreateConstantBuffer(uiSizeInBytes);
 }

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -403,9 +403,10 @@ vk::Pipeline ezResourceCacheVulkan::RequestGraphicsPipeline(const GraphicsPipeli
 #endif // EZ_LOG_VULKAN_RESOURCES
 
   vk::PipelineVertexInputStateCreateInfo vertex_input;
+  ezHybridArray<vk::VertexInputBindingDescription, EZ_GAL_MAX_VERTEX_BUFFER_COUNT> bindings;
   if (desc.m_pCurrentVertexDecl)
   {
-    ezHybridArray<vk::VertexInputBindingDescription, EZ_GAL_MAX_VERTEX_BUFFER_COUNT> bindings = desc.m_pCurrentVertexDecl->GetBindings();
+    bindings = desc.m_pCurrentVertexDecl->GetBindings();
     for (ezUInt32 i = 0; i < bindings.GetCount(); i++)
     {
       bindings[i].stride = desc.m_VertexBufferStrides[bindings[i].binding];


### PR DESCRIPTION
* Issue 1: When computing the hash of constant buffer data, not all data might be written to by the user of the constant buffer. As a result uninitialized bytes are added to the hash.
* Issue 2: Use of the memory held by a HybridArray even though the hybrid array is out of scope.