### PR TITLE
Use sharedptr for blackboards

### DIFF
--- a/Code/Engine/Core/Utils/Blackboard.h
+++ b/Code/Engine/Core/Utils/Blackboard.h
@@ -3,6 +3,7 @@
 #include <Core/CoreDLL.h>
 #include <Foundation/Communication/Event.h>
 #include <Foundation/Strings/HashedString.h>
+#include <Foundation/Types/RefCounted.h>
 #include <Foundation/Types/Variant.h>
 
 class ezStreamReader;
@@ -61,7 +62,7 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_CORE_DLL, ezBlackboardEntryFlags);
 ///
 /// For example this is commonly used in game AI, where some system gathers interesting pieces of data about the environment,
 /// and then NPCs might use that information to make decisions.
-class EZ_CORE_DLL ezBlackboard
+class EZ_CORE_DLL ezBlackboard : public ezRefCounted
 {
 public:
   ezBlackboard();

--- a/Code/Engine/GameEngine/Gameplay/BlackboardComponent.h
+++ b/Code/Engine/GameEngine/Gameplay/BlackboardComponent.h
@@ -69,11 +69,11 @@ public:
   ezBlackboardComponent& operator=(ezBlackboardComponent&& other);
 
   /// \brief Try to find a ezBlackboardComponent on pSearchObject or its parents and returns its blackboard
-  static ezBlackboard* FindBlackboard(ezGameObject* pSearchObject);
+  static ezSharedPtr<ezBlackboard> FindBlackboard(ezGameObject* pSearchObject);
 
   /// \brief Returns the blackboard owned by this component
-  ezBlackboard& GetBoard();
-  const ezBlackboard& GetBoard() const;
+  const ezSharedPtr<ezBlackboard>& GetBoard();
+  ezSharedPtr<const ezBlackboard> GetBoard() const;
 
   void SetShowDebugInfo(bool bShow); // [ property ]
   bool GetShowDebugInfo() const;     // [ property ]
@@ -98,7 +98,7 @@ private:
   void OnExtractRenderData(ezMsgExtractRenderData& msg) const;
   void OnEntryChanged(const ezBlackboard::EntryEvent& e);
 
-  ezUniquePtr<ezBlackboard> m_pBoard;
+  ezSharedPtr<ezBlackboard> m_pBoard;
 
   // this array is not held during runtime, it is only needed during editor time until the component is serialized out
   ezDynamicArray<ezBlackboardEntry> m_InitialEntries;

--- a/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
@@ -115,7 +115,7 @@ ezBlackboardComponent::~ezBlackboardComponent() = default;
 ezBlackboardComponent& ezBlackboardComponent::operator=(ezBlackboardComponent&& other) = default;
 
 // static
-ezBlackboard* ezBlackboardComponent::FindBlackboard(ezGameObject* pObject)
+ezSharedPtr<ezBlackboard> ezBlackboardComponent::FindBlackboard(ezGameObject* pObject)
 {
   ezBlackboardComponent* pBlackboardComponent = nullptr;
   while (pObject != nullptr && !pObject->TryGetComponentOfBaseType(pBlackboardComponent))
@@ -125,7 +125,7 @@ ezBlackboard* ezBlackboardComponent::FindBlackboard(ezGameObject* pObject)
 
   if (pBlackboardComponent != nullptr)
   {
-    return &pBlackboardComponent->GetBoard();
+    return pBlackboardComponent->GetBoard();
   }
 
   return nullptr;
@@ -178,14 +178,14 @@ void ezBlackboardComponent::DeserializeComponent(ezWorldReader& stream)
   }
 }
 
-ezBlackboard& ezBlackboardComponent::GetBoard()
+const ezSharedPtr<ezBlackboard>& ezBlackboardComponent::GetBoard()
 {
-  return *m_pBoard.Borrow();
+  return m_pBoard;
 }
 
-const ezBlackboard& ezBlackboardComponent::GetBoard() const
+ezSharedPtr<const ezBlackboard> ezBlackboardComponent::GetBoard() const
 {
-  return *m_pBoard.Borrow();
+  return m_pBoard;
 }
 
 struct BCFlags

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimGraph.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimGraph.h
@@ -54,12 +54,12 @@ public:
   ezAnimGraph();
   ~ezAnimGraph();
 
-  void Configure(const ezSkeletonResourceHandle& hSkeleton, ezAnimPoseGenerator& poseGenerator, ezBlackboard* pBlackboard = nullptr);
+  void Configure(const ezSkeletonResourceHandle& hSkeleton, ezAnimPoseGenerator& poseGenerator, const ezSharedPtr<ezBlackboard>& pBlackboard = nullptr);
 
   void Update(ezTime tDiff, ezGameObject* pTarget);
   void GetRootMotion(ezVec3& translation, ezAngle& rotationX, ezAngle& rotationY, ezAngle& rotationZ) const;
 
-  ezBlackboard* GetBlackboard() { return m_pBlackboard; }
+  const ezSharedPtr<ezBlackboard>& GetBlackboard() { return m_pBlackboard; }
 
   ezResult Serialize(ezStreamWriter& stream) const;
   ezResult Deserialize(ezStreamReader& stream);
@@ -112,7 +112,7 @@ private:
   bool m_bInitialized = false;
 
   ezAnimPoseGenerator* m_pPoseGenerator = nullptr;
-  ezBlackboard* m_pBlackboard = nullptr;
+  ezSharedPtr<ezBlackboard> m_pBlackboard = nullptr;
 
   ezHybridArray<ezAnimGraphPinDataBoneWeights, 4> m_PinDataBoneWeights;
   ezHybridArray<ezAnimGraphPinDataLocalTransforms, 4> m_PinDataLocalTransforms;

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimGraph.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimGraph.cpp
@@ -12,7 +12,7 @@ ezHashTable<ezString, ezSharedPtr<ezAnimGraphSharedBoneWeights>> ezAnimGraph::s_
 ezAnimGraph::ezAnimGraph() = default;
 ezAnimGraph::~ezAnimGraph() = default;
 
-void ezAnimGraph::Configure(const ezSkeletonResourceHandle& hSkeleton, ezAnimPoseGenerator& poseGenerator, ezBlackboard* pBlackboard /*= nullptr*/)
+void ezAnimGraph::Configure(const ezSkeletonResourceHandle& hSkeleton, ezAnimPoseGenerator& poseGenerator, const ezSharedPtr<ezBlackboard>& pBlackboard /*= nullptr*/)
 {
   m_hSkeleton = hSkeleton;
   m_pPoseGenerator = &poseGenerator;

--- a/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
@@ -251,9 +251,9 @@ void ezRmlUiCanvas2DComponent::RemoveDataBinding(ezUInt32 uiDataBindingIndex)
   m_DataBindings[uiDataBindingIndex] = nullptr;
 }
 
-ezUInt32 ezRmlUiCanvas2DComponent::AddBlackboardBinding(ezBlackboard& blackboard)
+ezUInt32 ezRmlUiCanvas2DComponent::AddBlackboardBinding(const ezSharedPtr<ezBlackboard>& pBlackboard)
 {
-  auto pDataBinding = EZ_DEFAULT_NEW(ezRmlUiInternal::BlackboardDataBinding, blackboard);
+  auto pDataBinding = EZ_DEFAULT_NEW(ezRmlUiInternal::BlackboardDataBinding, pBlackboard);
   return AddDataBinding(pDataBinding);
 }
 

--- a/Code/EnginePlugins/RmlUiPlugin/Components/RmlUiCanvas2DComponent.h
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/RmlUiCanvas2DComponent.h
@@ -57,7 +57,7 @@ public:
   void RemoveDataBinding(ezUInt32 uiDataBindingIndex);
 
   /// \brief Adds the given blackboard as data binding. The name of the board is used as model name for the binding.
-  ezUInt32 AddBlackboardBinding(ezBlackboard& blackboard);
+  ezUInt32 AddBlackboardBinding(const ezSharedPtr<ezBlackboard>& pBlackboard);
   void RemoveBlackboardBinding(ezUInt32 uiDataBindingIndex);
 
   ezRmlUiContext* GetOrCreateRmlContext();

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/BlackboardDataBinding.h
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/BlackboardDataBinding.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Foundation/Strings/HashedString.h>
+#include <Foundation/Types/SharedPtr.h>
 #include <RmlUiPlugin/RmlUiDataBinding.h>
 
 class ezBlackboard;
@@ -10,7 +11,7 @@ namespace ezRmlUiInternal
   class BlackboardDataBinding final : public ezRmlUiDataBinding
   {
   public:
-    BlackboardDataBinding(ezBlackboard& blackboard);
+    BlackboardDataBinding(const ezSharedPtr<ezBlackboard>& pBlackboard);
     ~BlackboardDataBinding();
 
     virtual ezResult Initialize(Rml::Context& context) override;
@@ -18,7 +19,7 @@ namespace ezRmlUiInternal
     virtual void Update() override;
 
   private:
-    ezBlackboard& m_Blackboard;
+    ezSharedPtr<ezBlackboard> m_pBlackboard;
 
     Rml::DataModelHandle m_hDataModel;
 

--- a/Code/Samples/RtsGamePlugin/GameMode/EditLevelMode/EditLevelMode.cpp
+++ b/Code/Samples/RtsGamePlugin/GameMode/EditLevelMode/EditLevelMode.cpp
@@ -79,7 +79,7 @@ void RtsEditLevelMode::SetupEditUI()
     if (!pEditUIObject->TryGetComponentOfBaseType(pUiComponent))
       return;
 
-    pUiComponent->AddBlackboardBinding(*m_pBlackboard);
+    pUiComponent->AddBlackboardBinding(m_pBlackboard);
 
     m_hEditUIComponent = pUiComponent->GetHandle();
   }

--- a/Code/Samples/RtsGamePlugin/GameMode/EditLevelMode/EditLevelMode.h
+++ b/Code/Samples/RtsGamePlugin/GameMode/EditLevelMode/EditLevelMode.h
@@ -25,5 +25,5 @@ private:
 
   ezComponentHandle m_hEditUIComponent;
 
-  ezUniquePtr<ezBlackboard> m_pBlackboard;
+  ezSharedPtr<ezBlackboard> m_pBlackboard;
 };


### PR DESCRIPTION
Blackboards are used to share data between multiple subsystems, so their ownership needs to be shared as well to prevent dangling pointer access.