### PR TITLE
Changes to Generate.sh for documentation

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Linux-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Linux-x64.yml
@@ -23,7 +23,7 @@ jobs:
       targetType: inline
       script: |
         sudo apt-get update
-        sudo apt-get install -y cmake uuid-dev gcc-12 g++-12 libx11-dev build-essential qtbase5-dev qtbase5-dev-tools libqt5svg5-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libqt5x11extras5-dev qtbase5-private-dev xvfb lightdm libassimp-dev
+        sudo apt-get install -y cmake uuid-dev gcc-12 g++-12 libx11-dev build-essential qtbase5-dev qtbase5-dev-tools libqt5svg5-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libqt5x11extras5-dev qtbase5-private-dev xvfb lightdm
   - task: Bash@3
     displayName: Info
     inputs:

--- a/Generate.sh
+++ b/Generate.sh
@@ -11,7 +11,7 @@ opts=$(getopt \
 eval set --$opts
 
 RunCMake=true
-BuildType="Debug"
+BuildType="Dev"
 
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
* Better default build type for Generate.sh (Dev)
* Remove now superfluous package libassimp-dev in linux build.