### PR TITLE
Fix potential nullptr access in ezDirectoryWatcher::Enumerate on Windows.

### DIFF
--- a/Code/Engine/Foundation/IO/Implementation/Win/DirectoryWatcher_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/DirectoryWatcher_win.h
@@ -144,6 +144,11 @@ void ezDirectoryWatcher::EnumerateChanges(EnumerateChangesFunction func, ezTime 
     // Reissue the read request
     m_pImpl->DoRead();
 
+    if(numberOfBytes == 0)
+    {
+      return;
+    }
+
     const ezBitflags<ezDirectoryWatcher::Watch> whatToWatch = m_pImpl->m_whatToWatch;
 
     ezFileSystemMirrorType* mirror = m_pImpl->m_mirror.Borrow();

--- a/Code/Engine/Foundation/IO/Implementation/Win/DirectoryWatcher_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/DirectoryWatcher_win.h
@@ -144,7 +144,7 @@ void ezDirectoryWatcher::EnumerateChanges(EnumerateChangesFunction func, ezTime 
     // Reissue the read request
     m_pImpl->DoRead();
 
-    if(numberOfBytes == 0)
+    if (numberOfBytes == 0)
     {
       return;
     }


### PR DESCRIPTION
Safeguard against GetOverlappedResult failing and zero length result in the ezDirectoryWatcher Windows implementation.