### PR TITLE
Reduce support for Universal Windows Platform (UWP)

### DIFF
--- a/Code/BuildSystem/AzurePipelines/WindowsUWP-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/WindowsUWP-x64.yml
@@ -46,42 +46,42 @@ jobs:
       ConnectedServiceName: a416236e-0672-4024-bca3-853beb235e5e
       KeyVaultName: ezKeys
       SecretsFilter: AzureBlobPW,ThirdPartyUWPx86
-  - task: PowerShell@2
-    displayName: Download ThirdParty
-    inputs:
-      targetType: inline
-      script: |
-        if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86))
-        {
-          if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86))
-          {
-            & mkdir $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86
-          }
-          if (!(Test-Path $(System.DefaultWorkingDirectory)\buildUWP))
-          {
-            & mkdir $(System.DefaultWorkingDirectory)\buildUWP
-          }
-          & compact /c /s /i /f $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\
-          & compact /c /s /i /f $(System.DefaultWorkingDirectory)\buildUWP\
-          & compact /c /s /i /f $(Build.ArtifactStagingDirectory)\
-          $url7zip = "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip"
-          $output7zip = "./7zip.zip"
-          $urlThirdParty = "$(ThirdPartyUWPx86)"
-          $outputThirdParty = "$(System.DefaultWorkingDirectory)\ThirdParty.7z"
-          $output = "$(System.DefaultWorkingDirectory)"
-          wget $url7zip -OutFile $output7zip
-          Expand-Archive -Path $output7zip -DestinationPath $output -Force
-          # Start-BitsTransfer -Source $urlThirdParty -Destination $outputThirdParty
-          wget $urlThirdParty -OutFile $outputThirdParty
-          & "$output/7zip/7z.exe" x -p$(AzureBlobPW) $outputThirdParty
-          & del $outputThirdParty
-        }
-  - task: PowerShell@2
-    displayName: Delete FMOD from ThirdParty
-    inputs:
-      targetType: inline
-      script: |
-        Remove-Item "$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\FMOD Studio API UWP" -Force  -Recurse -ErrorAction SilentlyContinue
+  # - task: PowerShell@2
+  #   displayName: Download ThirdParty
+  #   inputs:
+  #     targetType: inline
+  #     script: |
+  #       if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86))
+  #       {
+  #         if (!(Test-Path $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86))
+  #         {
+  #           & mkdir $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86
+  #         }
+  #         if (!(Test-Path $(System.DefaultWorkingDirectory)\buildUWP))
+  #         {
+  #           & mkdir $(System.DefaultWorkingDirectory)\buildUWP
+  #         }
+  #         & compact /c /s /i /f $(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\
+  #         & compact /c /s /i /f $(System.DefaultWorkingDirectory)\buildUWP\
+  #         & compact /c /s /i /f $(Build.ArtifactStagingDirectory)\
+  #         $url7zip = "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip"
+  #         $output7zip = "./7zip.zip"
+  #         $urlThirdParty = "$(ThirdPartyUWPx86)"
+  #         $outputThirdParty = "$(System.DefaultWorkingDirectory)\ThirdParty.7z"
+  #         $output = "$(System.DefaultWorkingDirectory)"
+  #         wget $url7zip -OutFile $output7zip
+  #         Expand-Archive -Path $output7zip -DestinationPath $output -Force
+  #         # Start-BitsTransfer -Source $urlThirdParty -Destination $outputThirdParty
+  #         wget $urlThirdParty -OutFile $outputThirdParty
+  #         & "$output/7zip/7z.exe" x -p$(AzureBlobPW) $outputThirdParty
+  #         & del $outputThirdParty
+  #       }
+  # - task: PowerShell@2
+  #   displayName: Delete FMOD from ThirdParty
+  #   inputs:
+  #     targetType: inline
+  #     script: |
+  #       Remove-Item "$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\FMOD Studio API UWP" -Force  -Recurse -ErrorAction SilentlyContinue
   - task: PowerShell@2
     displayName: Delete old crash dumps
     inputs:
@@ -91,56 +91,56 @@ jobs:
         {
           Get-ChildItem $(System.DefaultWorkingDirectory)\Output\Bin\WinVs2019Debug64\*.dmp | foreach { Remove-Item -Force -Path $_.FullName }
         }
-  - task: CMake@1
-    displayName: CMake x64
-    inputs:
-      cmakeArgs: -DCMAKE_PREFIX_PATH=$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64 -DEZ_QT_DIR="$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64" -DEZ_BUILD_PHYSX=0 -DEZ_BUILD_FMOD=0 -DEZ_BUILD_GAMES=0 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -A "x64" -G "Visual Studio 16 2019" ../
-  - task: CMake@1
-    displayName: CMake build RemoteTestHarness
-    inputs:
-      cmakeArgs: --build . --target RemoteTestHarness --config Debug
-  - task: DownloadBuildArtifacts@0
-    displayName: 'Download Build Artifacts'
-    inputs:
-      buildType: specific
-      project: '3be75850-43b5-4a0a-a9b3-9b1693a5beed'
-      pipeline: 10
-      buildVersionToDownload: latest
-      allowPartiallySucceededBuilds: true
-      specificBuildWithTriggering: true
-      artifactName: AssetCache
-      downloadPath: '$(System.DefaultWorkingDirectory)'
-      extractTars: false
-  - task: PowerShell@2
-    displayName: Move x64 build artifacts / download procdump
-    inputs:
-      targetType: inline
-      script: |
-        $RootDir = "$(System.DefaultWorkingDirectory)"
-        $CacheDir = "$(System.DefaultWorkingDirectory)\AssetCache"
-        $BinPath = ".\Output\Bin\WinVs2019Debug64\"
-        ### x64 binaries
-        if (Test-Path $BinPath)
-        {
-          # Remove-Item $BinPath* -Force -Recurse
-        }
-        else
-        {
-          New-Item -ItemType directory -Path $BinPath -Force
-        }
-        #Move-Item -Path .\drop\Bin\WinVs2019Debug64\* -Destination $BinPath
-        #Remove-Item .\drop\ -Force -Recurse
-        ### Asset Cache
-        Copy-Item $CacheDir\* -Filter * -Destination $RootDir -Recurse -Force
-        Remove-Item $CacheDir\ -Force -Recurse
-        ### Procdump
-        wget https://download.sysinternals.com/files/Procdump.zip -OutFile $BinPath\Procdump.zip
-        Expand-Archive -Path $BinPath\Procdump.zip -DestinationPath $BinPath -Force
+  # - task: CMake@1
+  #   displayName: CMake x64
+  #   inputs:
+  #     cmakeArgs: -DCMAKE_PREFIX_PATH=$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64 -DEZ_QT_DIR="$(System.DefaultWorkingDirectory)\ThirdPartyUWPx86\vs141x64" -DEZ_BUILD_PHYSX=0 -DEZ_BUILD_FMOD=0 -DEZ_BUILD_GAMES=0 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=1 -DCMAKE_SYSTEM_VERSION=10.0.18362.0 -DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=10.0.18362.0 -A "x64" -G "Visual Studio 16 2019" ../
+  # - task: CMake@1
+  #   displayName: CMake build RemoteTestHarness
+  #   inputs:
+  #     cmakeArgs: --build . --target RemoteTestHarness --config Debug
+  # - task: DownloadBuildArtifacts@0
+  #   displayName: 'Download Build Artifacts'
+  #   inputs:
+  #     buildType: specific
+  #     project: '3be75850-43b5-4a0a-a9b3-9b1693a5beed'
+  #     pipeline: 10
+  #     buildVersionToDownload: latest
+  #     allowPartiallySucceededBuilds: true
+  #     specificBuildWithTriggering: true
+  #     artifactName: AssetCache
+  #     downloadPath: '$(System.DefaultWorkingDirectory)'
+  #     extractTars: false
+  # - task: PowerShell@2
+  #   displayName: Move x64 build artifacts / download procdump
+  #   inputs:
+  #     targetType: inline
+  #     script: |
+  #       $RootDir = "$(System.DefaultWorkingDirectory)"
+  #       $CacheDir = "$(System.DefaultWorkingDirectory)\AssetCache"
+  #       $BinPath = ".\Output\Bin\WinVs2019Debug64\"
+  #       ### x64 binaries
+  #       if (Test-Path $BinPath)
+  #       {
+  #         # Remove-Item $BinPath* -Force -Recurse
+  #       }
+  #       else
+  #       {
+  #         New-Item -ItemType directory -Path $BinPath -Force
+  #       }
+  #       #Move-Item -Path .\drop\Bin\WinVs2019Debug64\* -Destination $BinPath
+  #       #Remove-Item .\drop\ -Force -Recurse
+  #       ### Asset Cache
+  #       Copy-Item $CacheDir\* -Filter * -Destination $RootDir -Recurse -Force
+  #       Remove-Item $CacheDir\ -Force -Recurse
+  #       ### Procdump
+  #       wget https://download.sysinternals.com/files/Procdump.zip -OutFile $BinPath\Procdump.zip
+  #       Expand-Archive -Path $BinPath\Procdump.zip -DestinationPath $BinPath -Force
   - task: CMake@1
     displayName: CMake UWP
     inputs:
       cwd: buildUWP
-      cmakeArgs: -DEZ_BUILD_OPENXR=0 -DEZ_BUILD_PHYSX=1 -DEZ_BUILD_FMOD=1 -DEZ_BUILD_GAMES=1 -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=0 -DCMAKE_TOOLCHAIN_FILE="../Code/BuildSystem/CMake/toolchain-winstore.cmake" -A "x64" -G "Visual Studio 16 2019" ../
+      cmakeArgs: -DEZ_BUILD_FILTER="UwpProjects" -DEZ_COMPILE_ENGINE_AS_DLL=1 -DEZ_ENABLE_QT_SUPPORT=0 -DCMAKE_TOOLCHAIN_FILE="../Code/BuildSystem/CMake/toolchain-winstore.cmake" -A "x64" -G "Visual Studio 16 2019" ../
   - task: MSBuild@1
     displayName: Build solution buildUWP/ezVs2019.sln
     inputs:
@@ -155,26 +155,27 @@ jobs:
       targetType: inline
       filePath: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
       script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
-  - task: CmdLine@2
-    displayName: FoundationTest
-    condition: eq(variables['task.MSBuild.status'], 'success')
-    inputs:
-      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\FoundationTest -p FoundationTest
-  - task: CmdLine@2
-    displayName: CoreTest
-    condition: eq(variables['task.MSBuild.status'], 'success')
-    inputs:
-      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\CoreTest -p CoreTest
-  - task: CmdLine@2
-    displayName: RendererTest
-    condition: eq(variables['task.MSBuild.status'], 'success')
-    inputs:
-      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\RendererTest -p RendererTest
-  - task: CmdLine@2
-    displayName: GameEngineTest
-    condition: eq(variables['task.MSBuild.status'], 'success')
-    inputs:
-      script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\GameEngineTest -p GameEngineTest
+  # Unit tests are now deactivated on UWP
+  # - task: CmdLine@2
+  #   displayName: FoundationTest
+  #   condition: eq(variables['task.MSBuild.status'], 'success')
+  #   inputs:
+  #     script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\FoundationTest -p FoundationTest
+  # - task: CmdLine@2
+  #   displayName: CoreTest
+  #   condition: eq(variables['task.MSBuild.status'], 'success')
+  #   inputs:
+  #     script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\CoreTest -p CoreTest
+  # - task: CmdLine@2
+  #   displayName: RendererTest
+  #   condition: eq(variables['task.MSBuild.status'], 'success')
+  #   inputs:
+  #     script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\RendererTest -p RendererTest
+  # - task: CmdLine@2
+  #   displayName: GameEngineTest
+  #   condition: eq(variables['task.MSBuild.status'], 'success')
+  #   inputs:
+  #     script: Output\Bin\WinVs2019Debug64\RemoteTestHarness.exe -w $(System.DefaultWorkingDirectory)\buildUWP -o $(Build.ArtifactStagingDirectory)\GameEngineTest -p GameEngineTest
   - task: CmdLine@2
     displayName: List files
     condition: always()

--- a/Code/BuildSystem/CMake/BuildFilters/UwpProjects.BuildFilter
+++ b/Code/BuildSystem/CMake/BuildFilters/UwpProjects.BuildFilter
@@ -1,0 +1,13 @@
+set_property(GLOBAL PROPERTY EZ_BUILD_FILTER_UwpProjects
+	Texture
+	Core
+    Foundation
+	FileservePlugin
+	InspectorPlugin
+    enet
+    zstd
+	stb_image
+	mikktspace
+	Lua
+	Duktape
+)


### PR DESCRIPTION
We don't want to fully support UWP anymore, but we still need the base libraries to compile. This PR disables builds for everything but the Foundation, Core and Texture libraries (plus dependencies). And it doesn't run the unit tests anymore, which is a constant source of build failures.

If needed, it can be enabled again.