### PR TITLE
Fix debug build when using qt6

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsQt.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsQt.cmake
@@ -137,11 +137,11 @@ function(ez_link_target_qt)
 	target_include_directories(${FN_ARG_TARGET} PUBLIC ${CMAKE_BINARY_DIR}/${SUB_FOLDER})
 
 	target_compile_definitions(${FN_ARG_TARGET} PUBLIC EZ_USE_QT)
-    
-    if(EZ_CMAKE_COMPILER_MSVC)
-        # Qt6 requires runtime type information (RTTI) in debug builds.
-        target_compile_options(${FN_ARG_TARGET} PRIVATE "$<$<CONFIG:Debug>:/GR>")
-    endif()
+
+	if(EZ_CMAKE_COMPILER_MSVC)
+		# Qt6 requires runtime type information (RTTI) in debug builds.
+		target_compile_options(${FN_ARG_TARGET} PRIVATE "$<$<CONFIG:Debug>:/GR>")
+	endif()
 
 	foreach(module ${FN_ARG_COMPONENTS})
 		target_link_libraries(${FN_ARG_TARGET} PUBLIC "Qt6::${module}")

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsQt.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsQt.cmake
@@ -137,6 +137,11 @@ function(ez_link_target_qt)
 	target_include_directories(${FN_ARG_TARGET} PUBLIC ${CMAKE_BINARY_DIR}/${SUB_FOLDER})
 
 	target_compile_definitions(${FN_ARG_TARGET} PUBLIC EZ_USE_QT)
+    
+    if(EZ_CMAKE_COMPILER_MSVC)
+        # Qt6 requires runtime type information (RTTI) in debug builds.
+        target_compile_options(${FN_ARG_TARGET} PRIVATE "$<$<CONFIG:Debug>:/GR>")
+    endif()
 
 	foreach(module ${FN_ARG_COMPONENTS})
 		target_link_libraries(${FN_ARG_TARGET} PUBLIC "Qt6::${module}")


### PR DESCRIPTION
* I updated the precompiled qt6 binary package to contain both debug and release binaries.
* A small change cmake is required to make debug builds work with qt6