### PR TITLE
Fixed allocations during compare and hashing

### DIFF
--- a/Code/Engine/Foundation/Algorithm/Comparer.h
+++ b/Code/Engine/Foundation/Algorithm/Comparer.h
@@ -6,10 +6,44 @@ template <typename T>
 struct ezCompareHelper
 {
   /// \brief Returns true if a is less than b
-  EZ_ALWAYS_INLINE bool Less(const T& a, const T& b) const { return a < b; }
+  EZ_ALWAYS_INLINE bool Less(const T& a, const T& b) const
+  {
+    return a < b;
+  }
+
+  /// \brief Returns true if a is less than b
+  template <typename U>
+  EZ_ALWAYS_INLINE bool Less(const T& a, const U& b) const
+  {
+    return a < b;
+  }
+
+  /// \brief Returns true if a is less than b
+  template <typename U>
+  EZ_ALWAYS_INLINE bool Less(const U& a, const T& b) const
+  {
+    return a < b;
+  }
 
   /// \brief Returns true if a is equal to b
-  EZ_ALWAYS_INLINE bool Equal(const T& a, const T& b) const { return a == b; }
+  EZ_ALWAYS_INLINE bool Equal(const T& a, const T& b) const
+  {
+    return a == b;
+  }
+
+  /// \brief Returns true if a is equal to b
+  template <typename U>
+  EZ_ALWAYS_INLINE bool Equal(const T& a, const U& b) const
+  {
+    return a == b;
+  }
+
+  /// \brief Returns true if a is equal to b
+  template <typename U>
+  EZ_ALWAYS_INLINE bool Equal(const U& a, const T& b) const
+  {
+    return a == b;
+  }
 };
 
 // See <Foundation/Strings/String.h> for ezString specialization and case insensitive version.

--- a/Code/Engine/Foundation/Algorithm/HashingUtils.h
+++ b/Code/Engine/Foundation/Algorithm/HashingUtils.h
@@ -69,12 +69,15 @@ public:
 
 /// \brief Helper struct to calculate the Hash of different types.
 ///
-/// This struct can be used to provide a custom hash function for ezHashTable. The default implementation uses the murmur hash function.
+/// This struct can be used to provide a custom hash function for ezHashTable. The default implementation uses the xxHash function.
 template <typename T>
 struct ezHashHelper
 {
-  static ezUInt32 Hash(const T& value);
-  static bool Equal(const T& a, const T& b);
+  template <typename U>
+  static ezUInt32 Hash(const U& value);
+
+  template <typename U>
+  static bool Equal(const T& a, const U& b);
 };
 
 #include <Foundation/Algorithm/Implementation/HashingMurmur_inl.h>

--- a/Code/Engine/Foundation/Algorithm/Implementation/HashingUtils_inl.h
+++ b/Code/Engine/Foundation/Algorithm/Implementation/HashingUtils_inl.h
@@ -16,6 +16,12 @@ namespace ezInternal
     {
       return ezHashingUtils::StringHashTo32(ezHashingUtils::xxHash64((void*)string.InternalGetData(), string.InternalGetElementCount()));
     }
+
+    // extra overload for const char* to prevent unnecessary string allocations on hash lookup
+    EZ_ALWAYS_INLINE static ezUInt32 Hash(const char* szValue)
+    {
+      return ezHashingUtils::StringHashTo32(ezHashingUtils::StringHash(szValue));
+    }
   };
 
   template <typename T, bool isString>
@@ -27,13 +33,15 @@ namespace ezInternal
 } // namespace ezInternal
 
 template <typename T>
-EZ_ALWAYS_INLINE ezUInt32 ezHashHelper<T>::Hash(const T& value)
+template <typename U>
+EZ_ALWAYS_INLINE ezUInt32 ezHashHelper<T>::Hash(const U& value)
 {
   return ezInternal::HashHelperImpl<T, EZ_IS_DERIVED_FROM_STATIC(ezThisIsAString, T)>::Hash(value);
 }
 
 template <typename T>
-EZ_ALWAYS_INLINE bool ezHashHelper<T>::Equal(const T& a, const T& b)
+template <typename U>
+EZ_ALWAYS_INLINE bool ezHashHelper<T>::Equal(const T& a, const U& b)
 {
   return a == b;
 }

--- a/Code/Engine/Foundation/Containers/ArrayBase.h
+++ b/Code/Engine/Foundation/Containers/ArrayBase.h
@@ -35,6 +35,9 @@ public:
   /// \brief Compares this array to another contiguous array type.
   bool operator!=(const ezArrayPtr<const T>& rhs) const; // [tested]
 
+  /// \brief Compares this array to another contiguous array type.
+  bool operator<(const ezArrayPtr<const T>& rhs) const; // [tested]
+
   /// \brief Returns the element at the given index. Does bounds checks in debug builds.
   const T& operator[](ezUInt32 uiIndex) const; // [tested]
 

--- a/Code/Engine/Foundation/Containers/DynamicArray.h
+++ b/Code/Engine/Foundation/Containers/DynamicArray.h
@@ -88,7 +88,7 @@ public:
 
   ezDynamicArray(const ezDynamicArray<T, AllocatorWrapper>& other);
   ezDynamicArray(const ezDynamicArrayBase<T>& other);
-  ezDynamicArray(const ezArrayPtr<const T>& other);
+  explicit ezDynamicArray(const ezArrayPtr<const T>& other);
 
   ezDynamicArray(ezDynamicArray<T, AllocatorWrapper>&& other);
   ezDynamicArray(ezDynamicArrayBase<T>&& other);

--- a/Code/Engine/Foundation/Containers/HashSet.h
+++ b/Code/Engine/Foundation/Containers/HashSet.h
@@ -105,13 +105,15 @@ public:
   bool Insert(CompatibleKeyType&& key); // [tested]
 
   /// \brief Removes the entry with the given key. Returns if an entry was removed.
-  bool Remove(const KeyType& key); // [tested]
+  template <typename CompatibleKeyType>
+  bool Remove(const CompatibleKeyType& key); // [tested]
 
   /// \brief Erases the key at the given Iterator. Returns an iterator to the element after the given iterator.
   ConstIterator Remove(const ConstIterator& pos); // [tested]
 
   /// \brief Returns if an entry with given key exists in the table.
-  bool Contains(const KeyType& key) const; // [tested]
+  template <typename CompatibleKeyType>
+  bool Contains(const CompatibleKeyType& key) const; // [tested]
 
   /// \brief Checks whether all keys of the given set are in the container.
   bool ContainsSet(const ezHashSetBase<KeyType, Hasher>& operand) const; // [tested]
@@ -160,9 +162,14 @@ private:
   };
 
   void SetCapacity(ezUInt32 uiCapacity);
+
   void RemoveInternal(ezUInt32 uiIndex);
-  ezUInt32 FindEntry(const KeyType& key) const;
-  ezUInt32 FindEntry(ezUInt32 uiHash, const KeyType& key) const;
+
+  template <typename CompatibleKeyType>
+  ezUInt32 FindEntry(const CompatibleKeyType& key) const;
+
+  template <typename CompatibleKeyType>
+  ezUInt32 FindEntry(ezUInt32 uiHash, const CompatibleKeyType& key) const;
 
   ezUInt32 GetFlagsCapacity() const;
   ezUInt32 GetFlags(ezUInt32* pFlags, ezUInt32 uiEntryIndex) const;

--- a/Code/Engine/Foundation/Containers/HashTable.h
+++ b/Code/Engine/Foundation/Containers/HashTable.h
@@ -239,6 +239,7 @@ private:
   void SetCapacity(ezUInt32 uiCapacity);
 
   void RemoveInternal(ezUInt32 uiIndex);
+
   template <typename CompatibleKeyType>
   ezUInt32 FindEntry(const CompatibleKeyType& key) const;
 

--- a/Code/Engine/Foundation/Containers/HybridArray.h
+++ b/Code/Engine/Foundation/Containers/HybridArray.h
@@ -24,7 +24,7 @@ public:
   ezHybridArray(const ezHybridArray<T, Size, AllocatorWrapper>& other); // [tested]
 
   /// \brief Creates a copy of the given array.
-  ezHybridArray(const ezArrayPtr<const T>& other); // [tested]
+  explicit ezHybridArray(const ezArrayPtr<const T>& other); // [tested]
 
   /// \brief Moves the given array.
   ezHybridArray(ezHybridArray<T, Size, AllocatorWrapper>&& other); // [tested]

--- a/Code/Engine/Foundation/Containers/Implementation/ArrayBase_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/ArrayBase_inl.h
@@ -72,6 +72,12 @@ EZ_ALWAYS_INLINE bool ezArrayBase<T, Derived>::operator!=(const ezArrayPtr<const
 }
 
 template <typename T, typename Derived>
+EZ_ALWAYS_INLINE bool ezArrayBase<T, Derived>::operator<(const ezArrayPtr<const T>& rhs) const
+{
+  return GetArrayPtr() < rhs;
+}
+
+template <typename T, typename Derived>
 EZ_ALWAYS_INLINE const T& ezArrayBase<T, Derived>::operator[](const ezUInt32 uiIndex) const
 {
   EZ_ASSERT_DEV(uiIndex < m_uiCount, "Out of bounds access. Array has {0} elements, trying to access element at index {1}.", m_uiCount, uiIndex);

--- a/Code/Engine/Foundation/Containers/Implementation/Map_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/Map_inl.h
@@ -628,7 +628,8 @@ EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::Node* ezMapBa
 }
 
 template <typename KeyType, typename ValueType, typename Comparer>
-typename ezMapBase<KeyType, ValueType, Comparer>::Node* ezMapBase<KeyType, ValueType, Comparer>::Remove(Node* root, const KeyType& key, bool& bRemoved)
+template <typename CompatibleKeyType>
+typename ezMapBase<KeyType, ValueType, Comparer>::Node* ezMapBase<KeyType, ValueType, Comparer>::Remove(Node* root, const CompatibleKeyType& key, bool& bRemoved)
 {
   bRemoved = false;
 

--- a/Code/Engine/Foundation/Containers/Map.h
+++ b/Code/Engine/Foundation/Containers/Map.h
@@ -291,7 +291,8 @@ private:
   Node* SkewNode(Node* root);
   Node* SplitNode(Node* root);
   void Insert(const KeyType& key, const ValueType& value, Node*& pInsertedNode);
-  Node* Remove(Node* root, const KeyType& key, bool& bRemoved);
+  template <typename CompatibleKeyType>
+  Node* Remove(Node* root, const CompatibleKeyType& key, bool& bRemoved);
 
   /// \brief Returns the left-most node of the tree(smallest key).
   Node* GetLeftMost() const;

--- a/Code/Engine/Foundation/Memory/Implementation/AllocatorBase_inl.h
+++ b/Code/Engine/Foundation/Memory/Implementation/AllocatorBase_inl.h
@@ -46,6 +46,17 @@ namespace ezInternal
     ezAllocatorBase* m_pAllocator;
   };
 
+  template <typename T>
+  EZ_ALWAYS_INLINE bool operator<(const NewInstance<T>& lhs, T* rhs)
+  {
+    return lhs.m_pInstance < rhs;
+  }
+
+  template <typename T>
+  EZ_ALWAYS_INLINE bool operator<(T* lhs, const NewInstance<T>& rhs)
+  {
+    return lhs < rhs.m_pInstance;
+  }
 
   template <typename T>
   EZ_FORCE_INLINE void Delete(ezAllocatorBase* pAllocator, T* ptr)

--- a/Code/Engine/Foundation/Types/ArrayPtr.h
+++ b/Code/Engine/Foundation/Types/ArrayPtr.h
@@ -219,6 +219,24 @@ public:
     return !(*this == other);
   }
 
+  /// \brief Compares the two arrays for less.
+  inline bool operator<(const ezArrayPtr<const T>& other) const // [tested]
+  {
+    if (GetCount() != other.GetCount())
+      return GetCount() < other.GetCount();
+
+    for (ezUInt32 i = 0; i < GetCount(); ++i)
+    {
+      if (GetPtr()[i] < other.GetPtr()[i])
+        return true;
+
+      if (other.GetPtr()[i] < GetPtr()[i])
+        return false;
+    }
+
+    return false;
+  }
+
   /// \brief Copies the data from \a other into this array. The arrays must have the exact same size.
   inline void CopyFrom(const ezArrayPtr<const T>& other) // [tested]
   {

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -107,15 +107,15 @@ void ezReflectionPool::ExtractReflectionProbe(const ezComponent* pComponent, ezM
   {
     if (msg.m_OverrideCategory == ezInvalidRenderDataCategory)
     {
-      ezStringBuilder sEnum;
-      ezReflectionUtils::BitflagsToString(probeData.m_Flags, sEnum, ezReflectionUtils::EnumConversionMode::ValueNameOnly);
-      ezStringBuilder s;
       ezInt32 activeIndex = 0;
-      if (s_pData->m_ActiveDynamicUpdate.Contains({uiWorldIndex, id}))
+      if (s_pData->m_ActiveDynamicUpdate.Contains(ezReflectionProbeRef{uiWorldIndex, id}))
       {
         activeIndex = 1;
       }
 
+      ezStringBuilder sEnum;
+      ezReflectionUtils::BitflagsToString(probeData.m_Flags, sEnum, ezReflectionUtils::EnumConversionMode::ValueNameOnly);
+      ezStringBuilder s;
       s.Format("\n RefIdx: {}\nUpdating: {}\nFlags: {}\n", iMappedIndex, activeIndex, sEnum);
       ezDebugRenderer::Draw3DText(pWorld, s, pComponent->GetOwner()->GetGlobalPosition(), ezColor::Violet);
     }

--- a/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
@@ -23,7 +23,7 @@ ezResult ezGALVertexDeclarationVulkan::InitPlatform(ezGALDevice* pDevice)
     return EZ_FAILURE;
   }
 
-  ezHybridArray<ezGALShaderVulkan::VertexInputAttribute, 8> vias = pShader->GetVertexInputAttributes();
+  ezHybridArray<ezGALShaderVulkan::VertexInputAttribute, 8> vias(pShader->GetVertexInputAttributes());
   auto FindLocation = [&](ezGALVertexAttributeSemantic::Enum sematic, ezGALResourceFormat::Enum format) -> ezUInt32 {
     for (ezUInt32 i = 0; i < vias.GetCount(); i++)
     {

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Declarations.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Declarations.h
@@ -11,6 +11,13 @@ struct EZ_GUIFOUNDATION_DLL ezPropertySelection
   ezVariant m_Index;
 
   bool operator==(const ezPropertySelection& rhs) const { return m_pObject == rhs.m_pObject && m_Index == rhs.m_Index; }
+
+  bool operator<(const ezPropertySelection& rhs) const
+  {
+    // Qt6 requires the less than operator but never calls it, so we use this dummy for now.
+    EZ_ASSERT_NOT_IMPLEMENTED;
+    return false;
+  }
 };
 
 struct EZ_GUIFOUNDATION_DLL ezPropertyClipboard

--- a/Code/UnitTests/CoreTest/World/SpatialSystemTest.cpp
+++ b/Code/UnitTests/CoreTest/World/SpatialSystemTest.cpp
@@ -120,7 +120,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       ezBoundingSphere objSphere = it->GetGlobalBounds().GetSphere();
       if (testSphere.Overlaps(objSphere))
       {
-        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains((ezGameObject*)it));
       }
     }
 
@@ -149,7 +149,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       ezBoundingSphere objSphere = it->GetGlobalBounds().GetSphere();
       if (testSphere.Overlaps(objSphere))
       {
-        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains((ezGameObject*)it));
       }
     }
   }
@@ -178,7 +178,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       ezBoundingBox objBox = it->GetGlobalBounds().GetBox();
       if (testBox.Overlaps(objBox))
       {
-        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains((ezGameObject*)it));
       }
     }
 
@@ -207,7 +207,7 @@ EZ_CREATE_SIMPLE_TEST(World, SpatialSystem)
       ezBoundingBox objBox = it->GetGlobalBounds().GetBox();
       if (testBox.Overlaps(objBox))
       {
-        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains(it));
+        EZ_TEST_BOOL(it->IsDynamic() || uniqueObjects.Contains((ezGameObject*)it));
       }
     }
   }

--- a/Code/UnitTests/FoundationTest/Basics/Types/ArrayPtrTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/ArrayPtrTest.cpp
@@ -86,7 +86,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, ArrayPtr)
     EZ_TEST_BOOL(ap.GetCount() == 0);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator== / operator!=")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator== / operator!= / operator<")
   {
     ezInt32 pIntData[] = {1, 2, 3, 4, 5};
 
@@ -98,6 +98,11 @@ EZ_CREATE_SIMPLE_TEST(Basics, ArrayPtr)
     EZ_TEST_BOOL(ap1 == ap2);
     EZ_TEST_BOOL(ap1 != ap3);
     EZ_TEST_BOOL(ap1 != ap4);
+
+    EZ_TEST_BOOL(ap1 < ap3);
+    ezInt32 pIntData2[] = {1, 2, 4};
+    ezArrayPtr<ezInt32> ap5(pIntData2, 3);
+    EZ_TEST_BOOL(ap1 < ap5);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator[]")

--- a/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
@@ -196,7 +196,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     EZ_TEST_BOOL(a2 == arrayPtr);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator == / !=")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator == / !=/ <")
   {
     ezDynamicArray<ezInt32> a1, a2;
 
@@ -220,6 +220,12 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     EZ_TEST_BOOL(a1 == a2);
 
     EZ_TEST_BOOL((a1 != a2) == false);
+
+    EZ_TEST_BOOL((a1 < a2) == false);
+    a2.PushBack(100);
+    EZ_TEST_BOOL(a1 < a2);
+    a1.PushBack(99);
+    EZ_TEST_BOOL(a1 < a2);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Index operator")

--- a/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
@@ -589,6 +589,8 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
       EZ_TEST_BOOL(arrayTable.Remove(aPtr));
       EZ_TEST_BOOL(arrayTable.Remove(bPtr));
+
+      EZ_TEST_INT(testAllocator.GetStats().m_uiNumAllocations, oldAllocCount);
     }
   }
 

--- a/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
@@ -16,8 +16,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     // EZ_TEST_INT(std::find(begin(m), end(m), 500).Key(), 499);
 
-    auto itfound = std::find_if(begin(m), end(m), [](ezMap<ezUInt32, ezUInt32>::ConstIterator val)
-      { return val.Value() == 500; });
+    auto itfound = std::find_if(begin(m), end(m), [](ezMap<ezUInt32, ezUInt32>::ConstIterator val) { return val.Value() == 500; });
 
     // EZ_TEST_BOOL(std::find(begin(m), end(m), 500) == itfound);
 

--- a/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
@@ -1,6 +1,7 @@
 #include <FoundationTest/FoundationTestPCH.h>
 
 #include <Foundation/Containers/Map.h>
+#include <Foundation/Memory/CommonAllocators.h>
 #include <Foundation/Strings/String.h>
 #include <algorithm>
 #include <iterator>
@@ -13,11 +14,12 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     for (ezUInt32 i = 0; i < 1000; ++i)
       m[i] = i + 1;
 
-    //EZ_TEST_INT(std::find(begin(m), end(m), 500).Key(), 499);
+    // EZ_TEST_INT(std::find(begin(m), end(m), 500).Key(), 499);
 
-    auto itfound = std::find_if(begin(m), end(m), [](ezMap<ezUInt32, ezUInt32>::ConstIterator val) { return val.Value() == 500; });
+    auto itfound = std::find_if(begin(m), end(m), [](ezMap<ezUInt32, ezUInt32>::ConstIterator val)
+      { return val.Value() == 500; });
 
-    //EZ_TEST_BOOL(std::find(begin(m), end(m), 500) == itfound);
+    // EZ_TEST_BOOL(std::find(begin(m), end(m), 500) == itfound);
 
     ezUInt32 prev = begin(m).Key();
     for (auto it : m)
@@ -166,7 +168,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     {
       EZ_TEST_INT(*m.GetValue(i), i * 10);
 
-      ezUInt32 v = 0;      
+      ezUInt32 v = 0;
       EZ_TEST_BOOL(m.TryGetValue(i, v));
       EZ_TEST_INT(v, i * 10);
 
@@ -657,7 +659,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     // test iterators after swap
     {
-      for (auto it: *map1)
+      for (auto it : *map1)
       {
         EZ_TEST_BOOL(!map2->Contains(it.Key()));
       }
@@ -672,7 +674,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     // seems to be fixed in VS 2019 though
 
     map1->~ezMap<ezString, ezInt32>();
-    //ezMemoryUtils::PatternFill(map1Mem, 0xBA, uiSetSize);
+    // ezMemoryUtils::PatternFill(map1Mem, 0xBA, uiSetSize);
 
     map2->~ezMap<ezString, ezInt32>();
     ezMemoryUtils::PatternFill(map2Mem, 0xBA, uiMapSize);
@@ -719,5 +721,4 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     map2->~ezMap<ezString, ezInt32>();
     ezMemoryUtils::PatternFill(map2Mem, 0xBA, uiMapSize);
   }
-
 }

--- a/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
@@ -577,6 +577,8 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
 
       EZ_TEST_BOOL(arraySet.Remove(aPtr));
       EZ_TEST_BOOL(arraySet.Remove(bPtr));
+
+      EZ_TEST_INT(testAllocator.GetStats().m_uiNumAllocations, oldAllocCount);
     }
   }
 

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -1288,8 +1288,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Pointer)
     containers.m_ArrayPtr.PushBack(EZ_DEFAULT_NEW(ezTestArrays));
     containers.m_ArrayPtr[0]->m_Hybrid.PushBack(5.0);
 
-    ezTestSets* testSets = EZ_DEFAULT_NEW(ezTestSets);
-    containers.m_SetPtr.Insert(testSets);
+    containers.m_SetPtr.Insert(EZ_DEFAULT_NEW(ezTestSets));
     containers.m_SetPtr.GetIterator().Key()->m_Array.PushBack("BLA");
   }
 

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -1288,7 +1288,8 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Pointer)
     containers.m_ArrayPtr.PushBack(EZ_DEFAULT_NEW(ezTestArrays));
     containers.m_ArrayPtr[0]->m_Hybrid.PushBack(5.0);
 
-    containers.m_SetPtr.Insert(EZ_DEFAULT_NEW(ezTestSets));
+    ezTestSets* testSets = EZ_DEFAULT_NEW(ezTestSets);
+    containers.m_SetPtr.Insert(testSets);
     containers.m_SetPtr.GetIterator().Key()->m_Array.PushBack("BLA");
   }
 

--- a/Code/UnitTests/FoundationTest/Serialization/RttiConverterTest.cpp
+++ b/Code/UnitTests/FoundationTest/Serialization/RttiConverterTest.cpp
@@ -315,8 +315,7 @@ EZ_CREATE_SIMPLE_TEST(Serialization, RttiConverter)
     t1.m_pArrays = EZ_DEFAULT_NEW(ezTestArrays);
     t1.m_pArraysDirect = EZ_DEFAULT_NEW(ezTestArrays);
     t1.m_ArrayPtr.PushBack(EZ_DEFAULT_NEW(ezTestArrays));
-    ezTestSets* testSets = EZ_DEFAULT_NEW(ezTestSets);
-    t1.m_SetPtr.Insert(testSets);
+    t1.m_SetPtr.Insert(EZ_DEFAULT_NEW(ezTestSets));
     TestSerialize(&t1);
 
     {

--- a/Code/UnitTests/FoundationTest/Serialization/RttiConverterTest.cpp
+++ b/Code/UnitTests/FoundationTest/Serialization/RttiConverterTest.cpp
@@ -315,7 +315,8 @@ EZ_CREATE_SIMPLE_TEST(Serialization, RttiConverter)
     t1.m_pArrays = EZ_DEFAULT_NEW(ezTestArrays);
     t1.m_pArraysDirect = EZ_DEFAULT_NEW(ezTestArrays);
     t1.m_ArrayPtr.PushBack(EZ_DEFAULT_NEW(ezTestArrays));
-    t1.m_SetPtr.Insert(EZ_DEFAULT_NEW(ezTestSets));
+    ezTestSets* testSets = EZ_DEFAULT_NEW(ezTestSets);
+    t1.m_SetPtr.Insert(testSets);
     TestSerialize(&t1);
 
     {


### PR DESCRIPTION
* When a key that requires allocation (e.g. an dynamic array) was used with ezMap or ezSet a lookup with a compatible type resulted in a temp key allocated because the comparer only allowed the exact key type by default.
* Added operator< for arrays.
* Strings as key in ezHashSet or ezHashTable could also result in a temp string allocated during lookup.
* Ported % optimization from ezHashTable to ezHashSet.