### PR TITLE
Convex mesh assets only use a single surface (#743)

### DIFF
--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -195,6 +195,21 @@ ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltCookingMesh&
   }
 
   // Extract Material Information
+  if (m_bIsConvexMesh)
+  {
+    meshDesc.CollapseSubMeshes();
+    pProp->m_Slots.SetCount(1);
+    pProp->m_Slots[0].m_sLabel = "Convex";
+    pProp->m_Slots[0].m_sResource = pProp->m_sConvexMeshSurface;
+
+    const auto subMeshInfo = meshDesc.GetSubMeshes()[0];
+
+    for (ezUInt32 tri = 0; tri < subMeshInfo.m_uiPrimitiveCount; ++tri)
+    {
+      outMesh.m_PolygonSurfaceID[subMeshInfo.m_uiFirstPrimitive + tri] = 0;
+    }
+  }
+  else
   {
     pProp->m_Slots.SetCount(meshDesc.GetSubMeshes().GetCount());
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -44,6 +44,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 1, ezRTTIDef
     EZ_MEMBER_PROPERTY("Detail", m_uiDetail)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(0, 32)),
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", "*.obj;*.fbx;*.gltf;*.glb")),
     EZ_ARRAY_MEMBER_PROPERTY("Surfaces", m_Slots)->AddAttributes(new ezContainerAttribute(false, false, true)),
+    EZ_MEMBER_PROPERTY("Surface", m_sConvexMeshSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
   }
   EZ_END_PROPERTIES;
 }
@@ -70,6 +71,8 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
   props["MeshFile"].m_Visibility = ezPropertyUiState::Invisible;
   props["ConvexMeshType"].m_Visibility = ezPropertyUiState::Invisible;
   props["MaxConvexPieces"].m_Visibility = ezPropertyUiState::Invisible;
+  props["Surfaces"].m_Visibility = isConvex ? ezPropertyUiState::Invisible : ezPropertyUiState::Default;
+  props["Surface"].m_Visibility = isConvex ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
 
   if (!isConvex)
   {

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
@@ -57,6 +57,7 @@ public:
 
   ezString m_sMeshFile;
   float m_fUniformScaling = 1.0f;
+  ezString m_sConvexMeshSurface;
 
   ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::PositiveX;
   ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveY;

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshResourceDescriptor.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshResourceDescriptor.cpp
@@ -54,6 +54,25 @@ ezArrayPtr<const ezMeshResourceDescriptor::SubMesh> ezMeshResourceDescriptor::Ge
   return m_SubMeshes;
 }
 
+void ezMeshResourceDescriptor::CollapseSubMeshes()
+{
+  for (ezUInt32 idx = 1; idx < m_SubMeshes.GetCount(); ++idx)
+  {
+    m_SubMeshes[0].m_uiFirstPrimitive = ezMath::Min(m_SubMeshes[0].m_uiFirstPrimitive, m_SubMeshes[idx].m_uiFirstPrimitive);
+    m_SubMeshes[0].m_uiPrimitiveCount += m_SubMeshes[idx].m_uiPrimitiveCount;
+
+    if (m_SubMeshes[0].m_Bounds.IsValid() && m_SubMeshes[idx].m_Bounds.IsValid())
+    {
+      m_SubMeshes[0].m_Bounds.ExpandToInclude(m_SubMeshes[idx].m_Bounds);
+    }
+  }
+
+  m_SubMeshes.SetCount(1);
+  m_SubMeshes[0].m_uiMaterialIndex = 0;
+
+  m_Materials.SetCount(1);
+}
+
 const ezBoundingBoxSphere& ezMeshResourceDescriptor::GetBounds() const
 {
   return m_Bounds;

--- a/Code/Engine/RendererCore/Meshes/MeshResourceDescriptor.h
+++ b/Code/Engine/RendererCore/Meshes/MeshResourceDescriptor.h
@@ -50,6 +50,9 @@ public:
 
   ezArrayPtr<const SubMesh> GetSubMeshes() const;
 
+  /// \brief Merges all submeshes into just one.
+  void CollapseSubMeshes();
+
   void ComputeBounds();
   const ezBoundingBoxSphere& GetBounds() const;
   void SetBounds(const ezBoundingBoxSphere& bounds) { m_Bounds = bounds; }


### PR DESCRIPTION
Fixes #743.

Convex meshes by design only have a single surface. So far, the convex mesh asset would still extract all the material information from a source mesh and present that to users. This was a problem, because the physics engine asserted that convex meshes only have a single surface.

Now the material list is hidden and instead just a single surface property is displayed.