### PR TITLE
Character improvements

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -105,6 +105,7 @@ void ezJoltCharacterControllerComponent::OnSimulationStarted()
 
   JPH::CharacterVirtualSettings opt;
   opt.mUp = JPH::Vec3::sAxisZ();
+  opt.mSupportingVolume = JPH::Plane(opt.mUp, -GetShapeRadius());
   opt.mShape = MakeNextCharacterShape();
   opt.mMaxSlopeAngle = m_MaxClimbingSlope.GetRadian();
   opt.mMass = m_fMass;
@@ -218,7 +219,7 @@ bool ezJoltCharacterControllerComponent::RawMoveWithVelocity(const ezVec3& vVelo
 
         // ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugRenderer::ScreenPlacement::TopLeft, "Stair", "Walk Stairs", ezColor::OrangeRed);
 
-        bStepped = m_pCharacter->WalkStairs(GetUpdateTimeDelta(), JPH::Vec3(0, 0, -10) /*gravity*/, stepUp, step_forward, step_forward_test, JPH::Vec3::sZero(), broadphaseFilter, objectFilter, m_BodyFilter, *pModule->GetTempAllocator());
+        bStepped = m_pCharacter->WalkStairs(GetUpdateTimeDelta(), stepUp, step_forward, step_forward_test, JPH::Vec3::sZero(), broadphaseFilter, objectFilter, m_BodyFilter, *pModule->GetTempAllocator());
       }
     }
   }
@@ -325,9 +326,10 @@ void ezJoltCharacterControllerComponent::TeleportToPosition(const ezVec3& vGloba
 
 bool ezJoltCharacterControllerComponent::StickToGround(float fMaxDist)
 {
-  if (m_pCharacter->GetGroundState() != JPH::CharacterBase::EGroundState::InAir)
+  if (m_pCharacter->GetGroundState() != JPH::CharacterBase::EGroundState::InAir 
+    || m_pCharacter->GetGroundState() != JPH::CharacterBase::EGroundState::NotSupported) 
     return false;
-
+  
   ezJoltBroadPhaseLayerFilter broadphaseFilter(ezPhysicsShapeType::Static | ezPhysicsShapeType::Dynamic);
   ezJoltObjectLayerFilter objectFilter(m_uiCollisionLayer);
 

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -398,6 +398,9 @@ void ezJoltDefaultCharacterComponent::DebugVisualizations()
       case JPH::CharacterBase::EGroundState::InAir:
         ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugRenderer::ScreenPlacement::TopLeft, "JCC", "Jolt: In Air", ezColor::CornflowerBlue);
         break;
+      case JPH::CharacterBase::EGroundState::NotSupported:
+        ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugRenderer::ScreenPlacement::TopLeft, "JCC", "Jolt: Not Supported", ezColor::Yellow);
+        break;
       case JPH::CharacterBase::EGroundState::OnSteepGround:
         ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugRenderer::ScreenPlacement::TopLeft, "JCC", "Jolt: Steep", ezColor::OrangeRed);
         break;
@@ -573,6 +576,7 @@ void ezJoltDefaultCharacterComponent::UpdateCharacter()
   switch (GetJoltCharacter()->GetGroundState())
   {
     case JPH::CharacterBase::EGroundState::InAir:
+    case JPH::CharacterBase::EGroundState::NotSupported:
       m_LastGroundState = GroundState::InAir;
       // TODO: filter out 'sliding' when touching a ceiling (should be 'in air')
       break;

--- a/Code/EnginePlugins/JoltPlugin/Character/JoltCharacterControllerComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Character/JoltCharacterControllerComponent.h
@@ -96,7 +96,10 @@ protected:
   /// The shape may not get applied to the character, in case this is used by things like TryResize and the next shape is
   /// determined to not fit.
   virtual JPH::Ref<JPH::Shape> MakeNextCharacterShape() = 0;
-
+  
+  /// \brief Returns the radius of the shape. This never changes at runtime.
+  virtual float GetShapeRadius() const = 0;
+  
   /// \brief Called up to once per frame, but potentially less often, if physics updates were skipped due to high framerates.
   ///
   /// All shape modifications and moves should only be executed during this step.

--- a/Code/EnginePlugins/JoltPlugin/Character/JoltDefaultCharacterComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Character/JoltDefaultCharacterComponent.h
@@ -76,7 +76,7 @@ public:
   float GetCurrentCylinderHeight() const;
 
   /// \brief Returns the radius of the shape. This never changes at runtime.
-  float GetShapeRadius() const;
+  virtual float GetShapeRadius() const override;
 
   GroundState GetGroundState() const { return m_LastGroundState; }
   bool IsStandingOnGround() const { return m_LastGroundState == GroundState::OnGround; } // [ scriptable ]

--- a/Code/ThirdParty/Jolt/Core/Core.h
+++ b/Code/ThirdParty/Jolt/Core/Core.h
@@ -115,14 +115,14 @@
 #define JPH_SUPPRESS_WARNING_PUSH		JPH_PRAGMA(clang diagnostic push)
 #define JPH_SUPPRESS_WARNING_POP		JPH_PRAGMA(clang diagnostic pop)
 #define JPH_CLANG_SUPPRESS_WARNING(w)	JPH_PRAGMA(clang diagnostic ignored w)
-	#if __clang_major__ >= 16
-		#define JPH_CLANG16_SUPPRESS_WARNING(w)	JPH_PRAGMA(clang diagnostic ignored w)
+	#if __clang_major__ >= 15
+		#define JPH_CLANG15_SUPPRESS_WARNING(w)	JPH_PRAGMA(clang diagnostic ignored w)
 	#else
-		#define JPH_CLANG16_SUPPRESS_WARNING(w)
+		#define JPH_CLANG15_SUPPRESS_WARNING(w)
 	#endif
 #else
 #define JPH_CLANG_SUPPRESS_WARNING(w)
-#define JPH_CLANG16_SUPPRESS_WARNING(w)
+#define JPH_CLANG15_SUPPRESS_WARNING(w)
 #endif
 #ifdef JPH_COMPILER_GCC
 #define JPH_PRAGMA(x)					_Pragma(#x)
@@ -162,7 +162,8 @@
 	JPH_CLANG_SUPPRESS_WARNING("-Wgnu-zero-variadic-macro-arguments")							\
 	JPH_CLANG_SUPPRESS_WARNING("-Wdocumentation-unknown-command")								\
 	JPH_CLANG_SUPPRESS_WARNING("-Wctad-maybe-unsupported")										\
-	JPH_CLANG16_SUPPRESS_WARNING("-Wunqualified-std-cast-call")									\
+	JPH_CLANG_SUPPRESS_WARNING("-Wdeprecated-copy")												\
+	JPH_CLANG15_SUPPRESS_WARNING("-Wunqualified-std-cast-call")									\
 	JPH_IF_NOT_ANDROID(JPH_CLANG_SUPPRESS_WARNING("-Wimplicit-int-float-conversion"))			\
 																								\
 	JPH_GCC_SUPPRESS_WARNING("-Wcomment")														\

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyInterface.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyInterface.cpp
@@ -17,7 +17,39 @@ JPH_NAMESPACE_BEGIN
 
 Body *BodyInterface::CreateBody(const BodyCreationSettings &inSettings)
 {
-	return mBodyManager->CreateBody(inSettings);
+	Body *body = mBodyManager->AllocateBody(inSettings);
+	if (!mBodyManager->AddBody(body))
+	{
+		mBodyManager->FreeBody(body);
+		return nullptr;
+	}
+	return body;
+}
+
+Body *BodyInterface::CreateBodyWithID(const BodyID &inBodyID, const BodyCreationSettings &inSettings)
+{
+	Body *body = mBodyManager->AllocateBody(inSettings);
+	if (!mBodyManager->AddBodyWithCustomID(body, inBodyID))
+	{
+		mBodyManager->FreeBody(body);
+		return nullptr;
+	}
+	return body;
+}
+
+Body *BodyInterface::CreateBodyWithoutID(const BodyCreationSettings &inSettings) const
+{
+	return mBodyManager->AllocateBody(inSettings);
+}
+
+void BodyInterface::DestroyBodyWithoutID(Body *inBody) const
+{
+	mBodyManager->FreeBody(inBody);
+}
+
+bool BodyInterface::AssignBodyID(Body *ioBody, const BodyID &inBodyID)
+{
+	return mBodyManager->AddBodyWithCustomID(ioBody, inBodyID);
 }
 
 void BodyInterface::DestroyBody(const BodyID &inBodyID)

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyInterface.h
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyInterface.h
@@ -35,6 +35,22 @@ public:
 	/// @return Created body or null when out of bodies
 	Body *						CreateBody(const BodyCreationSettings &inSettings);
 	
+	/// Create a body with specified ID. This function can be used if a simulation is to run in sync between clients or if a simulation needs to be restored exactly.
+	/// The ID created on the server can be replicated to the client and used to create a deterministic simulation.
+	/// @return Created body or null when the body ID is invalid or a body of the same ID already exists.
+	Body *						CreateBodyWithID(const BodyID &inBodyID, const BodyCreationSettings &inSettings);
+
+	/// Advanced use only. Creates a body without specifying an ID. This body cannot be added to the world until it has gotten a body ID. A call to CreateBodyWithoutID followed by AssignBodyID is equivalent to calling CreateBodyWithID.
+	/// @return Created body
+	Body *						CreateBodyWithoutID(const BodyCreationSettings &inSettings) const;
+
+	/// Advanced use only. Destroy a body previously created with CreateBodyWithoutID that hasn't gotten an ID yet through the AssignBodyID function. Bodies that did get an ID should be destroyed through DestroyBody.
+	void						DestroyBodyWithoutID(Body *inBody) const;
+
+	/// Advanced use only. Assigns a body ID to a body that was created using CreateBodyWithoutID. After this call, the body can be added to the world like any other body.
+	/// @return false if the body already has an ID or if the ID is not valid.
+	bool						AssignBodyID(Body *ioBody, const BodyID &inBodyID);
+
 	/// Destroy a body
 	void						DestroyBody(const BodyID &inBodyID);
 	

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyManager.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyManager.cpp
@@ -120,43 +120,8 @@ BodyManager::BodyStats BodyManager::GetBodyStats() const
 	return stats;
 }
 
-Body *BodyManager::CreateBody(const BodyCreationSettings &inBodyCreationSettings)
+Body *BodyManager::AllocateBody(const BodyCreationSettings &inBodyCreationSettings) const
 {
-	// Determine next free index
-	uint32 idx;
-	{
-		UniqueLock lock(mBodiesMutex, EPhysicsLockTypes::BodiesList);
-
-		if (mBodyIDFreeListStart != cBodyIDFreeListEnd)
-		{
-			// Pop an item from the freelist
-			JPH_ASSERT(mBodyIDFreeListStart & cIsFreedBody);
-			idx = uint32(mBodyIDFreeListStart >> cFreedBodyIndexShift);
-			JPH_ASSERT(!sIsValidBodyPointer(mBodies[idx]));
-			mBodyIDFreeListStart = uintptr_t(mBodies[idx]);
-		}
-		else
-		{
-			if (mBodies.size() < mBodies.capacity())
-			{
-				// Allocate a new entry, note that the array should not actually resize since we've reserved it at init time
-				idx = uint32(mBodies.size());
-				mBodies.push_back((Body *)cBodyIDFreeListEnd);
-			}
-			else
-			{
-				// Out of bodies
-				return nullptr;
-			}
-		}
-
-		// Update cached number of bodies
-		mNumBodies++;
-	}
-
-	// Get next sequence number
-	uint8 seq_no = GetNextSequenceNumber(idx);
-
 	// Fill in basic properties
 	Body *body;
 	if (inBodyCreationSettings.HasMassProperties())
@@ -169,7 +134,6 @@ Body *BodyManager::CreateBody(const BodyCreationSettings &inBodyCreationSettings
 	{
 	 	body = new Body;
 	}
-	body->mID = BodyID(idx, seq_no);
 	body->mShape = inBodyCreationSettings.GetShape();
 	body->mUserData = inBodyCreationSettings.mUserData;
 	body->SetFriction(inBodyCreationSettings.mFriction);
@@ -202,9 +166,129 @@ Body *BodyManager::CreateBody(const BodyCreationSettings &inBodyCreationSettings
 	// Position body
 	body->SetPositionAndRotationInternal(inBodyCreationSettings.mPosition, inBodyCreationSettings.mRotation);
 
-	// Add body
-	mBodies[idx] = body;
 	return body;
+}
+
+void BodyManager::FreeBody(Body *inBody) const
+{
+	JPH_ASSERT(inBody->GetID().IsInvalid(), "This function should only be called on a body that doesn't have an ID yet, use DestroyBody otherwise");
+
+	sDeleteBody(inBody);
+}
+
+bool BodyManager::AddBody(Body *ioBody)
+{
+	// Return error when body was already added
+	if (!ioBody->GetID().IsInvalid())
+		return false;
+
+	// Determine next free index
+	uint32 idx;
+	{
+		UniqueLock lock(mBodiesMutex, EPhysicsLockTypes::BodiesList);
+
+		if (mBodyIDFreeListStart != cBodyIDFreeListEnd)
+		{
+			// Pop an item from the freelist
+			JPH_ASSERT(mBodyIDFreeListStart & cIsFreedBody);
+			idx = uint32(mBodyIDFreeListStart >> cFreedBodyIndexShift);
+			JPH_ASSERT(!sIsValidBodyPointer(mBodies[idx]));
+			mBodyIDFreeListStart = uintptr_t(mBodies[idx]);
+			mBodies[idx] = ioBody;
+		}
+		else
+		{
+			if (mBodies.size() < mBodies.capacity())
+			{
+				// Allocate a new entry, note that the array should not actually resize since we've reserved it at init time
+				idx = uint32(mBodies.size());
+				mBodies.push_back(ioBody);
+			}
+			else
+			{
+				// Out of bodies
+				return false;
+			}
+		}
+
+		// Update cached number of bodies
+		mNumBodies++;
+	}
+
+	// Get next sequence number and assign the ID
+	uint8 seq_no = GetNextSequenceNumber(idx);
+	ioBody->mID = BodyID(idx, seq_no);
+	return true;
+}
+
+bool BodyManager::AddBodyWithCustomID(Body *ioBody, const BodyID &inBodyID)
+{
+	// Return error when body was already added
+	if (!ioBody->GetID().IsInvalid())
+		return false;
+
+	{
+		UniqueLock lock(mBodiesMutex, EPhysicsLockTypes::BodiesList);
+
+		// Check if index is beyond the max body ID
+		uint32 idx = inBodyID.GetIndex();
+		if (idx >= mBodies.capacity())
+			return false; // Return error
+
+		if (idx < mBodies.size())
+		{
+			// Body array entry has already been allocated, check if there's a free body here
+			if (sIsValidBodyPointer(mBodies[idx]))
+				return false; // Return error
+
+			// Remove the entry from the freelist
+			uintptr_t idx_start = mBodyIDFreeListStart >> cFreedBodyIndexShift;
+			if (idx == idx_start)
+			{
+				// First entry, easy to remove, the start of the list is our next
+				mBodyIDFreeListStart = uintptr_t(mBodies[idx]);
+			}
+			else
+			{
+				// Loop over the freelist and find the entry in the freelist pointing to our index
+				// TODO: This is O(N), see if this becomes a performance problem (don't want to put the freed bodies in a double linked list)
+				uintptr_t cur, next;
+				for (cur = idx_start; cur != cBodyIDFreeListEnd >> cFreedBodyIndexShift; cur = next)
+				{
+					next = uintptr_t(mBodies[cur]) >> cFreedBodyIndexShift;
+					if (next == idx)
+					{
+						mBodies[cur] = mBodies[idx];
+						break;
+					}
+				}
+				JPH_ASSERT(cur != cBodyIDFreeListEnd >> cFreedBodyIndexShift);
+			}
+
+			// Put the body in the slot
+			mBodies[idx] = ioBody;
+		}
+		else
+		{
+			// Ensure that all body IDs up to this body ID have been allocated and added to the free list
+			while (idx > mBodies.size())
+			{
+				// Push the id onto the freelist
+				mBodies.push_back((Body *)mBodyIDFreeListStart);
+				mBodyIDFreeListStart = (uintptr_t(mBodies.size() - 1) << cFreedBodyIndexShift) | cIsFreedBody;
+			}
+
+			// Add the element to the list
+			mBodies.push_back(ioBody);
+		}
+
+		// Update cached number of bodies
+		mNumBodies++;
+	}
+
+	// Assign the ID
+	ioBody->mID = inBodyID;
+	return true;
 }
 
 void BodyManager::DestroyBodies(const BodyID *inBodyIDs, int inNumber)

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyManager.h
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyManager.h
@@ -60,12 +60,19 @@ public:
 	/// Get stats about the bodies in the body manager (slow, iterates through all bodies)
 	BodyStats						GetBodyStats() const;
 
-	/// Create a body.
-	/// This is a thread safe function. Can return null if there are no more bodies available.
-	Body *							CreateBody(const BodyCreationSettings &inBodyCreationSettings);
+	/// Create a body using creation settings. The returned body will not be part of the body manager yet.
+	Body *							AllocateBody(const BodyCreationSettings &inBodyCreationSettings) const;
 
-	/// Mark a list of bodies for destruction and remove it from this manager.
-	/// This is a thread safe function since the body is not deleted until the next PhysicsSystem::Update() (which will take all locks)
+	/// Free a body that has not been added to the body manager yet (if it has, use DestroyBodies).
+	void							FreeBody(Body *inBody) const;
+
+	/// Add a body to the body manager, assigning it the next available ID. Returns false if no more IDs are available.
+	bool							AddBody(Body *ioBody);
+
+	/// Add a body to the body manager, assigning it a custom ID. Returns false if the ID is not valid.
+	bool							AddBodyWithCustomID(Body *ioBody, const BodyID &inBodyID);
+
+	/// Remove a set of bodies from the body manager and destroy them.
 	void							DestroyBodies(const BodyID *inBodyIDs, int inNumber);
 
 	/// Activate a list of bodies.

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterBase.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterBase.cpp
@@ -11,7 +11,8 @@ JPH_NAMESPACE_BEGIN
 CharacterBase::CharacterBase(const CharacterBaseSettings *inSettings, PhysicsSystem *inSystem) :
 	mSystem(inSystem),
 	mShape(inSettings->mShape),
-	mUp(inSettings->mUp)
+	mUp(inSettings->mUp),
+	mSupportingVolume(inSettings->mSupportingVolume)
 {
 	// Initialize max slope angle
 	SetMaxSlopeAngle(inSettings->mMaxSlopeAngle);

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterBase.h
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterBase.h
@@ -27,6 +27,11 @@ public:
 	/// Vector indicating the up direction of the character
 	Vec3								mUp = Vec3::sAxisY();
 
+	/// Plane, defined in local space relative to the character. Every contact behind this plane can support the
+	/// character, every contact in front of this plane is treated as only colliding with the player.
+	/// Default: Accept any contact.
+	Plane								mSupportingVolume { Vec3::sAxisY(), -1.0e10f };
+
 	/// Maximum angle of slope that character can still walk on (radians).
 	float								mMaxSlopeAngle = DegreesToRadians(50.0f);
 
@@ -70,13 +75,17 @@ public:
 	{
 		OnGround,						///< Character is on the ground and can move freely.
 		OnSteepGround,					///< Character is on a slope that is too steep and can't climb up any further. The caller should start applying downward velocity if sliding from the slope is desired.
-		InAir,							///< Character is in the air.
+		NotSupported,					///< Character is touching an object, but is not supported by it and should fall. The GetGroundXXX functions will return information about the touched object.
+		InAir,							///< Character is in the air and is not touching anything.
 	};
 
 	///@name Properties of the ground this character is standing on
 
 	/// Current ground state
 	EGroundState						GetGroundState() const									{ return mGroundState; }
+
+	/// Returns true if the player is supported by normal or steep ground
+	bool								IsSupported() const										{ return mGroundState == EGroundState::OnGround || mGroundState == EGroundState::OnSteepGround; }
 
 	/// Get the contact point with the ground
 	Vec3 								GetGroundPosition() const								{ return mGroundPosition; }
@@ -112,6 +121,9 @@ protected:
 
 	// The character's world space up axis
 	Vec3								mUp;
+
+	// Every contact behind this plane can support the character
+	Plane								mSupportingVolume;
 
 	// Beyond this value there is no max slope
 	static constexpr float				cNoMaxSlopeAngle = 0.9999f;

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.h
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.h
@@ -147,7 +147,6 @@ public:
 
 	/// When stair walking is needed, you can call the WalkStairs function to cast up, forward and down again to try to find a valid position
 	/// @param inDeltaTime Time step to simulate.
-	/// @param inGravity Gravity vector (m/s^2). This gravity vector is only used when the character is standing on top of another object to apply downward force.
 	/// @param inStepUp The direction and distance to step up (this corresponds to the max step height)
 	/// @param inStepForward The direction and distance to step forward after the step up
 	/// @param inStepForwardTest When running at a high frequency, inStepForward can be very small and it's likely that you hit the side of the stairs on the way down. This could produce a normal that violates the max slope angle. If this happens, we test again using this distance from the up position to see if we find a valid slope.
@@ -157,7 +156,7 @@ public:
 	/// @param inBodyFilter Filter that is used to check if a character collides with a body.
 	/// @param inAllocator An allocator for temporary allocations. All memory will be freed by the time this function returns.
 	/// @return true if the stair walk was successful
-	bool								WalkStairs(float inDeltaTime, Vec3Arg inGravity, Vec3Arg inStepUp, Vec3Arg inStepForward, Vec3Arg inStepForwardTest, Vec3Arg inStepDownExtra, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, TempAllocator &inAllocator);
+	bool								WalkStairs(float inDeltaTime, Vec3Arg inStepUp, Vec3Arg inStepForward, Vec3Arg inStepForwardTest, Vec3Arg inStepDownExtra, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, TempAllocator &inAllocator);
 
 	/// This function can be used to artificially keep the character to the floor. Normally when a character is on a small step and starts moving horizontally, the character will
 	/// lose contact with the floor because the initial vertical velocity is zero while the horizontal velocity is quite high. To prevent the character from losing contact with the floor,
@@ -287,7 +286,7 @@ private:
 	inline static void					sFillContactProperties(Contact &outContact, const Body &inBody, Vec3Arg inUp, const taCollector &inCollector, const CollideShapeResult &inResult);
 
 	// Move the shape from ioPosition and try to displace it by inVelocity * inDeltaTime, this will try to slide the shape along the world geometry
-	void								MoveShape(Vec3 &ioPosition, Vec3Arg inVelocity, Vec3Arg inGravity, float inDeltaTime, ContactList *outActiveContacts, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, TempAllocator &inAllocator
+	void								MoveShape(Vec3 &ioPosition, Vec3Arg inVelocity, float inDeltaTime, ContactList *outActiveContacts, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, TempAllocator &inAllocator
 	#ifdef JPH_DEBUG_RENDERER
 		, bool inDrawConstraints = false
 	#endif // JPH_DEBUG_RENDERER
@@ -306,14 +305,14 @@ private:
 	void								DetermineConstraints(TempContactList &inContacts, ConstraintList &outConstraints) const;
 
 	// Use the constraints to solve the displacement of the character. This will slide the character on the planes around the origin for as far as possible.
-	void								SolveConstraints(Vec3Arg inVelocity, Vec3Arg inGravity, float inDeltaTime, float inTimeRemaining, ConstraintList &ioConstraints, IgnoredContactList &ioIgnoredContacts, float &outTimeSimulated, Vec3 &outDisplacement, TempAllocator &inAllocator
+	void								SolveConstraints(Vec3Arg inVelocity, float inDeltaTime, float inTimeRemaining, ConstraintList &ioConstraints, IgnoredContactList &ioIgnoredContacts, float &outTimeSimulated, Vec3 &outDisplacement, TempAllocator &inAllocator
 	#ifdef JPH_DEBUG_RENDERER
 		, bool inDrawConstraints = false
 	#endif // JPH_DEBUG_RENDERER
 		) const;
 
 	// Handle contact with physics object that we're colliding against
-	bool								HandleContact(Vec3Arg inVelocity, Constraint &ioConstraint, Vec3Arg inGravity, float inDeltaTime) const;
+	bool								HandleContact(Vec3Arg inVelocity, Constraint &ioConstraint, float inDeltaTime) const;
 
 	// Does a swept test of the shape from inPosition with displacement inDisplacement, returns true if there was a collision
 	bool								GetFirstContactForSweep(Vec3Arg inPosition, Vec3Arg inDisplacement, Contact &outContact, const IgnoredContactList &inIgnoredContacts, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, TempAllocator &inAllocator) const;

--- a/Code/ThirdParty/Jolt/Physics/Collision/CastConvexVsTriangles.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/CastConvexVsTriangles.cpp
@@ -91,12 +91,7 @@ void CastConvexVsTriangles::Cast(Vec3Arg inV0, Vec3Arg inV1, Vec3Arg inV2, uint8
 			// Get supporting face of shape 1
 			Mat44 transform_1_to_2 = mShapeCast.mCenterOfMassStart;
 			transform_1_to_2.SetTranslation(transform_1_to_2.GetTranslation() + fraction * mShapeCast.mDirection);
-			static_cast<const ConvexShape *>(mShapeCast.mShape)->GetSupportingFace(transform_1_to_2.Multiply3x3Transposed(-contact_normal), mShapeCast.mScale, result.mShape1Face);
-
-			// Convert to world space
-			Mat44 transform_1_to_world = mCenterOfMassTransform2 * transform_1_to_2;
-			for (Vec3 &p : result.mShape1Face)
-				p = transform_1_to_world * p;
+			static_cast<const ConvexShape *>(mShapeCast.mShape)->GetSupportingFace(SubShapeID(), transform_1_to_2.Multiply3x3Transposed(-contact_normal), mShapeCast.mScale, mCenterOfMassTransform2 * transform_1_to_2, result.mShape1Face);
 
 			// Get face of the triangle
 			triangle.GetSupportingFace(contact_normal, result.mShape2Face);

--- a/Code/ThirdParty/Jolt/Physics/Collision/CollideConvexVsTriangles.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/CollideConvexVsTriangles.cpp
@@ -132,11 +132,7 @@ void CollideConvexVsTriangles::Collide(Vec3Arg inV0, Vec3Arg inV1, Vec3Arg inV2,
 	if (mCollideShapeSettings.mCollectFacesMode == ECollectFacesMode::CollectFaces)
 	{
 		// Get supporting face of shape 1
-		mShape1->GetSupportingFace(-penetration_axis, mScale1, result.mShape1Face);
-
-		// Convert to world space
-		for (Vec3 &p : result.mShape1Face)
-			p = mTransform1 * p;
+		mShape1->GetSupportingFace(SubShapeID(), -penetration_axis, mScale1, mTransform1, result.mShape1Face);
 
 		// Get face of the triangle
 		triangle.GetSupportingFace(penetration_axis, result.mShape2Face);

--- a/Code/ThirdParty/Jolt/Physics/Collision/GroupFilter.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/GroupFilter.cpp
@@ -48,6 +48,11 @@ GroupFilter::GroupFilterResult GroupFilter::sRestoreFromBinaryState(StreamIn &in
 
 	// Construct and read the data of the group filter
 	Ref<GroupFilter> group_filter = reinterpret_cast<GroupFilter *>(rtti->CreateObject());
+	if (group_filter == nullptr)
+	{
+		result.SetError("Failed to create instance of group filter");
+		return result;
+	}
 	group_filter->RestoreBinaryState(inStream);
 	if (inStream.IsEOF() || inStream.IsFailed())
 	{

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/BoxShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/BoxShape.cpp
@@ -124,11 +124,17 @@ const ConvexShape::Support *BoxShape::GetSupportFunction(ESupportMode inMode, Su
 	return nullptr;
 }
 
-void BoxShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const 
+void BoxShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const 
 { 
+	JPH_ASSERT(inSubShapeID.IsEmpty(), "Invalid subshape ID");
+
 	Vec3 scaled_half_extent = inScale.Abs() * mHalfExtent;
 	AABox box(-scaled_half_extent, scaled_half_extent);
 	box.GetSupportingFace(inDirection, outVertices); 
+
+	// Transform to world space
+	for (Vec3 &v : outVertices)
+		v = inCenterOfMassTransform * v;
 }
 
 MassProperties BoxShape::GetMassProperties() const

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/BoxShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/BoxShape.h
@@ -57,11 +57,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override;
 
 #ifdef JPH_DEBUG_RENDERER
 	// See Shape::Draw
@@ -89,6 +89,9 @@ public:
 
 	// See Shape::GetVolume
 	virtual float			GetVolume() const override									{ return GetLocalBounds().GetVolume(); }
+
+	/// Get the convex radius of this box
+	float					GetConvexRadius() const										{ return mConvexRadius; }
 
 	// Register shape functions with the registry
 	static void				sRegister();

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/CapsuleShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/CapsuleShape.cpp
@@ -170,8 +170,9 @@ const ConvexShape::Support *CapsuleShape::GetSupportFunction(ESupportMode inMode
 	return nullptr;
 }
 
-void CapsuleShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const
+void CapsuleShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
 {	
+	JPH_ASSERT(inSubShapeID.IsEmpty(), "Invalid subshape ID");
 	JPH_ASSERT(IsValidScale(inScale));
 
 	// Get direction in horizontal plane
@@ -203,8 +204,8 @@ void CapsuleShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, Suppo
 	// If projection is roughly equal then return line, otherwise we return nothing as there's only 1 point
 	if (abs(proj_top - proj_bottom) < cCapsuleProjectionSlop * inDirection.Length())
 	{
-		outVertices.push_back(support_top);
-		outVertices.push_back(support_bottom);
+		outVertices.push_back(inCenterOfMassTransform * support_top);
+		outVertices.push_back(inCenterOfMassTransform * support_bottom);
 	}
 }
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/CapsuleShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/CapsuleShape.h
@@ -65,11 +65,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override;
 
 #ifdef JPH_DEBUG_RENDERER
 	// See Shape::Draw

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/CompoundShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/CompoundShape.cpp
@@ -170,6 +170,18 @@ Vec3 CompoundShape::GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inL
 	return transform.Multiply3x3Transposed(normal);
 }
 
+void CompoundShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
+{
+	// Decode sub shape index
+	SubShapeID remainder;
+	uint32 index = GetSubShapeIndexFromID(inSubShapeID, remainder);
+
+	// Apply transform and pass on to sub shape
+	const SubShape &shape = mSubShapes[index];
+	Mat44 transform = shape.GetLocalTransformNoScale(inScale);
+	shape.mShape->GetSupportingFace(remainder, transform.Multiply3x3Transposed(inDirection), shape.TransformScale(inScale), inCenterOfMassTransform * transform, outVertices);
+}
+
 void CompoundShape::GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const
 {
 	outTotalVolume = 0.0f;

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/CompoundShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/CompoundShape.h
@@ -86,6 +86,9 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See Shape::GetSubmergedVolume
 	virtual void					GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/ConvexHullShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/ConvexHullShape.h
@@ -64,11 +64,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override;
 
 	// See Shape::GetSubmergedVolume
 	virtual void			GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;
@@ -108,6 +108,12 @@ public:
 
 	/// Get the planes of this convex hull
 	const Array<Plane> &	GetPlanes() const													{ return mPlanes; }
+
+	/// Get the number of vertices in this convex hull
+	inline uint				GetNumPoints() const												{ return (uint)mPoints.size(); }
+
+	/// Get a vertex of this convex hull relative to the center of mass
+	inline Vec3				GetPoint(uint inIndex) const										{ return mPoints[inIndex].mPosition; }
 
 	// Register shape functions with the registry
 	static void				sRegister();

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/ConvexShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/ConvexShape.cpp
@@ -144,18 +144,10 @@ void ConvexShape::sCollideConvexVsConvex(const Shape *inShape1, const Shape *inS
 	if (inCollideShapeSettings.mCollectFacesMode == ECollectFacesMode::CollectFaces)
 	{
 		// Get supporting face of shape 1
-		shape1->GetSupportingFace(-penetration_axis, inScale1, result.mShape1Face);
-
-		// Convert to world space
-		for (Vec3 &p : result.mShape1Face)
-			p = inCenterOfMassTransform1 * p;
+		shape1->GetSupportingFace(SubShapeID(), -penetration_axis, inScale1, inCenterOfMassTransform1, result.mShape1Face);
 
 		// Get supporting face of shape 2 
-		shape2->GetSupportingFace(transform_2_to_1.Multiply3x3Transposed(penetration_axis), inScale2, result.mShape2Face);
-
-		// Convert to world space
-		for (Vec3 &p : result.mShape2Face)
-			p = inCenterOfMassTransform2 * p;
+		shape2->GetSupportingFace(SubShapeID(), transform_2_to_1.Multiply3x3Transposed(penetration_axis), inScale2, inCenterOfMassTransform2, result.mShape2Face);
 	}
 
 	// Notify the collector
@@ -297,19 +289,10 @@ void ConvexShape::sCastConvexVsConvex(const ShapeCast &inShapeCast, const ShapeC
 			// Get supporting face of shape 1
 			Mat44 transform_1_to_2 = inShapeCast.mCenterOfMassStart;
 			transform_1_to_2.SetTranslation(transform_1_to_2.GetTranslation() + fraction * inShapeCast.mDirection);
-			cast_shape->GetSupportingFace(transform_1_to_2.Multiply3x3Transposed(-contact_normal), inShapeCast.mScale, result.mShape1Face);
-
-			// Convert to world space
-			Mat44 transform_1_to_world = inCenterOfMassTransform2 * transform_1_to_2;
-			for (Vec3 &p : result.mShape1Face)
-				p = transform_1_to_world * p;
+			cast_shape->GetSupportingFace(SubShapeID(), transform_1_to_2.Multiply3x3Transposed(-contact_normal), inShapeCast.mScale, inCenterOfMassTransform2 * transform_1_to_2, result.mShape1Face);
 
 			// Get supporting face of shape 2
-			shape->GetSupportingFace(contact_normal, inScale, result.mShape2Face);
-
-			// Convert to world space
-			for (Vec3 &p : result.mShape2Face)
-				p = inCenterOfMassTransform2 * p;
+			shape->GetSupportingFace(SubShapeID(), contact_normal, inScale, inCenterOfMassTransform2, result.mShape2Face);
 		}
 
 		JPH_IF_TRACK_NARROWPHASE_STATS(TrackNarrowPhaseCollector track;)
@@ -491,7 +474,7 @@ void ConvexShape::DrawGetSupportingFace(DebugRenderer *inRenderer, Mat44Arg inCe
 		Vec3 direction = 0.05f * v;
 			
 		SupportingFace face;
-		GetSupportingFace(direction, inScale, face);
+		GetSupportingFace(SubShapeID(), direction, inScale, Mat44::sIdentity(), face);
 			
 		if (!face.empty())
 		{

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/ConvexShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/ConvexShape.h
@@ -99,13 +99,6 @@ public:
 	/// inScale scales this shape in local space.
 	virtual const Support *			GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const = 0;
 
-	/// Type definition for a supporting face
-	using SupportingFace = StaticArray<Vec3, 32>;
-
-	/// Get the vertices of the face that faces inDirection the most (includes convex radius).
-	/// Face is relative to the center of mass of the shape.
-	virtual void					GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const = 0;
-
 	/// Material of the shape
 	void							SetMaterial(const PhysicsMaterial *inMaterial)				{ mMaterial = inMaterial; }
 	const PhysicsMaterial *			GetMaterial() const											{ return mMaterial != nullptr? mMaterial : PhysicsMaterial::sDefault; }

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/CylinderShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/CylinderShape.cpp
@@ -185,8 +185,9 @@ const ConvexShape::Support *CylinderShape::GetSupportFunction(ESupportMode inMod
 	return nullptr;
 }
 
-void CylinderShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const
+void CylinderShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
 {	
+	JPH_ASSERT(inSubShapeID.IsEmpty(), "Invalid subshape ID");
 	JPH_ASSERT(IsValidScale(inScale));
 
 	// Get scaled cylinder
@@ -206,15 +207,16 @@ void CylinderShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, Supp
 		float f = -scaled_radius / o;
 		float vx = x * f;
 		float vz = z * f;
-		outVertices.push_back(Vec3(vx, scaled_half_height, vz));
-		outVertices.push_back(Vec3(vx, -scaled_half_height, vz));
+		outVertices.push_back(inCenterOfMassTransform * Vec3(vx, scaled_half_height, vz));
+		outVertices.push_back(inCenterOfMassTransform * Vec3(vx, -scaled_half_height, vz));
 	}
 	else
 	{
 		// Hitting top or bottom
 		Vec3 multiplier = y < 0.0f? Vec3(scaled_radius, scaled_half_height, scaled_radius) : Vec3(-scaled_radius, -scaled_half_height, scaled_radius);
+		Mat44 transform = inCenterOfMassTransform.PreScaled(multiplier);
 		for (const Vec3 &v : cTopFace)
-			outVertices.push_back(multiplier * v);
+			outVertices.push_back(transform * v);
 	}
 }
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/CylinderShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/CylinderShape.h
@@ -61,11 +61,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override;
 
 #ifdef JPH_DEBUG_RENDERER
 	// See Shape::Draw
@@ -96,6 +96,9 @@ public:
 
 	// See Shape::GetVolume
 	virtual float			GetVolume() const override												{ return 2.0f * JPH_PI * mHalfHeight * Square(mRadius); }
+
+	/// Get the convex radius of this cylinder
+	float					GetConvexRadius() const													{ return mConvexRadius; }
 
 	// See Shape::IsValidScale
 	virtual bool			IsValidScale(Vec3Arg inScale) const override;

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/DecoratedShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/DecoratedShape.cpp
@@ -48,6 +48,11 @@ const PhysicsMaterial *DecoratedShape::GetMaterial(const SubShapeID &inSubShapeI
 	return mInnerShape->GetMaterial(inSubShapeID);
 }
 
+void DecoratedShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
+{
+	mInnerShape->GetSupportingFace(inSubShapeID, inDirection, inScale, inCenterOfMassTransform, outVertices);
+}
+
 uint64 DecoratedShape::GetSubShapeUserData(const SubShapeID &inSubShapeID) const
 {
 	return mInnerShape->GetSubShapeUserData(inSubShapeID);

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/DecoratedShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/DecoratedShape.h
@@ -49,6 +49,9 @@ public:
 	// See Shape::GetMaterial
 	virtual const PhysicsMaterial *	GetMaterial(const SubShapeID &inSubShapeID) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See Shape::GetSubShapeUserData
 	virtual uint64					GetSubShapeUserData(const SubShapeID &inSubShapeID) const override;
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/HeightFieldShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/HeightFieldShape.h
@@ -121,6 +121,9 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See Shape::GetSubmergedVolume
 	virtual void					GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override { JPH_ASSERT(false, "Not supported"); }
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/MeshShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/MeshShape.h
@@ -86,6 +86,9 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 #ifdef JPH_DEBUG_RENDERER
 	// See Shape::Draw
 	virtual void					Draw(DebugRenderer *inRenderer, Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, ColorArg inColor, bool inUseMaterialColors, bool inDrawWireframe) const override;

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.cpp
@@ -67,6 +67,11 @@ Vec3 OffsetCenterOfMassShape::GetSurfaceNormal(const SubShapeID &inSubShapeID, V
 	return mInnerShape->GetSurfaceNormal(inSubShapeID, inLocalSurfacePosition + mOffset);
 }
 
+void OffsetCenterOfMassShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
+{
+	mInnerShape->GetSupportingFace(inSubShapeID, inDirection, inScale, inCenterOfMassTransform.PreTranslated(-mOffset), outVertices);
+}
+
 void OffsetCenterOfMassShape::GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const
 {
 	mInnerShape->GetSubmergedVolume(inCenterOfMassTransform.PreTranslated(-mOffset), inScale, inSurface, outTotalVolume, outSubmergedVolume, outCenterOfBuoyancy);

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/OffsetCenterOfMassShape.h
@@ -64,6 +64,9 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See Shape::GetSubmergedVolume
 	virtual void					GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/RotatedTranslatedShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/RotatedTranslatedShape.cpp
@@ -95,6 +95,12 @@ Vec3 RotatedTranslatedShape::GetSurfaceNormal(const SubShapeID &inSubShapeID, Ve
 	return transform.Multiply3x3Transposed(normal);
 }
 
+void RotatedTranslatedShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
+{
+	Mat44 transform = Mat44::sRotation(mRotation);
+	mInnerShape->GetSupportingFace(inSubShapeID, transform.Multiply3x3Transposed(inDirection), TransformScale(inScale), inCenterOfMassTransform * transform, outVertices);
+}
+
 void RotatedTranslatedShape::GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const
 {
 	// Get center of mass transform of child

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h
@@ -71,6 +71,9 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See Shape::GetSubmergedVolume
 	virtual void					GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/ScaledShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/ScaledShape.cpp
@@ -76,6 +76,11 @@ Vec3 ScaledShape::GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLoc
 	return (normal / mScale).Normalized();
 }
 
+void ScaledShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
+{
+	mInnerShape->GetSupportingFace(inSubShapeID, inDirection, inScale * mScale, inCenterOfMassTransform, outVertices);
+}
+
 void ScaledShape::GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const
 {
 	mInnerShape->GetSubmergedVolume(inCenterOfMassTransform, inScale * mScale, inSurface, outTotalVolume, outSubmergedVolume, outCenterOfBuoyancy);

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/ScaledShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/ScaledShape.h
@@ -64,6 +64,9 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See Shape::GetSubmergedVolume
 	virtual void					GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/Shape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/Shape.h
@@ -208,6 +208,18 @@ public:
 	/// Note: When you have a CollideShapeResult or ShapeCastResult you should use -mPenetrationAxis.Normalized() as contact normal as GetSurfaceNormal will only return face normals (and not vertex or edge normals).
 	virtual Vec3					GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const = 0;
 
+	/// Type definition for a supporting face
+	using SupportingFace = StaticArray<Vec3, 32>;
+
+	/// Get the vertices of the face that faces inDirection the most (includes any convex radius). Note that this function can only return faces of
+	/// convex shapes or triangles, which is why a sub shape ID to get to that leaf must be provided. 
+	/// @param inSubShapeID Sub shape ID of target shape
+	/// @param inDirection Direction that the face should be facing (in local space to this shape)
+	/// @param inCenterOfMassTransform Transform to transform outVertices with
+	/// @param inScale Scale of this shape
+	/// @param outVertices Resulting face. The returned face can be empty if the shape doesn't have polygons to return (e.g. because it's a sphere). The face will be returned in world space.
+	virtual void					GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const { /* Nothing */ }
+
 	/// Get the user data of a particular sub shape ID
 	virtual uint64					GetSubShapeUserData(const SubShapeID &inSubShapeID) const			{ return mUserData; }
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/SphereShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/SphereShape.h
@@ -57,11 +57,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override { /* Hit is always a single point, no point in returning anything */ }
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override	{ /* Hit is always a single point, no point in returning anything */ }
 
 	// See Shape::GetSubmergedVolume
 	virtual void			GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/TaperedCapsuleShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/TaperedCapsuleShape.cpp
@@ -208,8 +208,9 @@ const ConvexShape::Support *TaperedCapsuleShape::GetSupportFunction(ESupportMode
 	return nullptr;
 }
 
-void TaperedCapsuleShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const
+void TaperedCapsuleShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
 {	
+	JPH_ASSERT(inSubShapeID.IsEmpty(), "Invalid subshape ID");
 	JPH_ASSERT(IsValidScale(inScale));
 
 	// Check zero vector
@@ -237,8 +238,8 @@ void TaperedCapsuleShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale
 	// If projection is roughly equal then return line, otherwise we return nothing as there's only 1 point
 	if (abs(proj_top - proj_bottom) < cCapsuleProjectionSlop * len)
 	{
-		outVertices.push_back(support_top);
-		outVertices.push_back(support_bottom);
+		outVertices.push_back(inCenterOfMassTransform * support_top);
+		outVertices.push_back(inCenterOfMassTransform * support_bottom);
 	}
 }
 

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/TaperedCapsuleShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/TaperedCapsuleShape.h
@@ -63,11 +63,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override;
 
 #ifdef JPH_DEBUG_RENDERER
 	// See Shape::Draw

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/TriangleShape.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/TriangleShape.cpp
@@ -155,11 +155,26 @@ const ConvexShape::Support *TriangleShape::GetSupportFunction(ESupportMode inMod
 	return nullptr;
 }
 
-void TriangleShape::GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const
+void TriangleShape::GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const
 {
-	outVertices.push_back(inScale * mV1);
-	outVertices.push_back(inScale * mV2);
-	outVertices.push_back(inScale * mV3);
+	JPH_ASSERT(inSubShapeID.IsEmpty(), "Invalid subshape ID");
+
+	// Calculate transform with scale
+	Mat44 transform = inCenterOfMassTransform.PreScaled(inScale);
+
+	// Flip triangle if scaled inside out
+	if (ScaleHelpers::IsInsideOut(inScale))
+	{
+		outVertices.push_back(transform * mV1);
+		outVertices.push_back(transform * mV3);
+		outVertices.push_back(transform * mV2);
+	}
+	else
+	{
+		outVertices.push_back(transform * mV1);
+		outVertices.push_back(transform * mV2);
+		outVertices.push_back(transform * mV3);
+	}
 }
 
 MassProperties TriangleShape::GetMassProperties() const

--- a/Code/ThirdParty/Jolt/Physics/Collision/Shape/TriangleShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/Shape/TriangleShape.h
@@ -61,11 +61,11 @@ public:
 	// See Shape::GetSurfaceNormal
 	virtual Vec3			GetSurfaceNormal(const SubShapeID &inSubShapeID, Vec3Arg inLocalSurfacePosition) const override;
 
+	// See Shape::GetSupportingFace
+	virtual void			GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Vec3Arg inScale, Mat44Arg inCenterOfMassTransform, SupportingFace &outVertices) const override;
+
 	// See ConvexShape::GetSupportFunction
 	virtual const Support *	GetSupportFunction(ESupportMode inMode, SupportBuffer &inBuffer, Vec3Arg inScale) const override;
-
-	// See ConvexShape::GetSupportingFace
-	virtual void			GetSupportingFace(Vec3Arg inDirection, Vec3Arg inScale, SupportingFace &outVertices) const override;
 
 	// See Shape::GetSubmergedVolume
 	virtual void			GetSubmergedVolume(Mat44Arg inCenterOfMassTransform, Vec3Arg inScale, const Plane &inSurface, float &outTotalVolume, float &outSubmergedVolume, Vec3 &outCenterOfBuoyancy) const override;

--- a/Code/ThirdParty/Jolt/Physics/Collision/TransformedShape.h
+++ b/Code/ThirdParty/Jolt/Physics/Collision/TransformedShape.h
@@ -127,6 +127,17 @@ public:
 		return inv_com.Multiply3x3Transposed(mShape->GetSurfaceNormal(MakeSubShapeIDRelativeToShape(inSubShapeID), (inv_com * inPosition) / scale) / scale).Normalized();
 	}
 
+	/// Get the vertices of the face that faces inDirection the most (includes any convex radius). Note that this function can only return faces of
+	/// convex shapes or triangles, which is why a sub shape ID to get to that leaf must be provided. 
+	/// @param inSubShapeID Sub shape ID of target shape
+	/// @param inDirection Direction that the face should be facing (in world space)
+	/// @param outVertices Resulting face. Note the returned face can have a single point if the shape doesn't have polygons to return (e.g. because it's a sphere). The face will be returned in world space.
+	void						GetSupportingFace(const SubShapeID &inSubShapeID, Vec3Arg inDirection, Shape::SupportingFace &outVertices) const
+	{
+		Mat44 com = GetCenterOfMassTransform();
+		mShape->GetSupportingFace(MakeSubShapeIDRelativeToShape(inSubShapeID), com.Multiply3x3Transposed(inDirection), GetShapeScale(), com, outVertices);
+	}
+
 	/// Get material of a particular sub shape
 	inline const PhysicsMaterial *GetMaterial(const SubShapeID &inSubShapeID) const
 	{

--- a/Code/ThirdParty/Jolt/Physics/Constraints/PointConstraint.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Constraints/PointConstraint.cpp
@@ -59,6 +59,22 @@ PointConstraint::PointConstraint(Body &inBody1, Body &inBody2, const PointConstr
 	}
 }
 
+void PointConstraint::SetPoint1(EConstraintSpace inSpace, Vec3Arg inPoint1)
+{
+	mLocalSpacePosition1 = inPoint1;
+
+	if (inSpace == EConstraintSpace::WorldSpace)
+		mLocalSpacePosition1 = mBody1->GetInverseCenterOfMassTransform() * mLocalSpacePosition1;
+}
+
+void PointConstraint::SetPoint2(EConstraintSpace inSpace, Vec3Arg inPoint2)
+{
+	mLocalSpacePosition2 = inPoint2;
+
+	if (inSpace == EConstraintSpace::WorldSpace)
+		mLocalSpacePosition2 = mBody2->GetInverseCenterOfMassTransform() * mLocalSpacePosition2;
+}
+
 void PointConstraint::CalculateConstraintProperties()
 {	
 	mPointConstraintPart.CalculateConstraintProperties(*mBody1, Mat44::sRotation(mBody1->GetRotation()), mLocalSpacePosition1, *mBody2, Mat44::sRotation(mBody2->GetRotation()), mLocalSpacePosition2);

--- a/Code/ThirdParty/Jolt/Physics/Constraints/PointConstraint.h
+++ b/Code/ThirdParty/Jolt/Physics/Constraints/PointConstraint.h
@@ -57,6 +57,18 @@ public:
 	virtual void				RestoreState(StateRecorder &inStream) override;
 	virtual Ref<ConstraintSettings> GetConstraintSettings() const override;
 
+	/// Update the attachment point for body 1
+	void						SetPoint1(EConstraintSpace inSpace, Vec3Arg inPoint1);
+
+	/// Update the attachment point for body 2
+	void						SetPoint2(EConstraintSpace inSpace, Vec3Arg inPoint2);
+
+	/// Get the attachment point for body 1 relative to body 1 COM
+	inline Vec3					GetLocalSpacePoint1() const									{ return mLocalSpacePosition1; }
+
+	/// Get the attachment point for body 2 relative to body 2 COM
+	inline Vec3					GetLocalSpacePoint2() const									{ return mLocalSpacePosition2; }
+
 	// See: TwoBodyConstraint
 	virtual Mat44				GetConstraintToBody1Matrix() const override					{ return Mat44::sTranslation(mLocalSpacePosition1); }
 	virtual Mat44				GetConstraintToBody2Matrix() const override					{ return Mat44::sTranslation(mLocalSpacePosition2); } // Note: Incorrect rotation as we don't track the original rotation difference, should not matter though as the constraint is not limiting rotation.

--- a/Code/ThirdParty/Jolt/Physics/Constraints/SixDOFConstraint.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Constraints/SixDOFConstraint.cpp
@@ -77,7 +77,7 @@ void SixDOFConstraint::UpdateRotationLimits()
 {
 	// Make values sensible
 	for (int i = 3; i < 6; ++i)
-		if (IsAxisFixed((EAxis)i))
+		if (IsFixedAxis((EAxis)i))
 			mLimitMin[i] = mLimitMax[i] = 0.0f;
 		else
 		{
@@ -307,12 +307,12 @@ void SixDOFConstraint::SetupVelocityConstraint(float inDeltaTime)
 
 			// Setup limit constraint
 			bool constraint_active = false;
-			if (IsAxisFixed(axis))
+			if (IsFixedAxis(axis))
 			{
 				// When constraint is fixed it is always active
 				constraint_active = true;
 			}
-			else if (!IsAxisFree(axis))
+			else if (!IsFreeAxis(axis))
 			{
 				// When constraint is limited, it is only active when outside of the allowed range
 				float d = translation_axis.Dot(u);
@@ -567,9 +567,9 @@ bool SixDOFConstraint::SolveVelocityConstraint(float inDeltaTime)
 				// If the axis is not fixed it must be limited (or else the constraint would not be active)
 				// Calculate the min and max constraint force based on on which side we're limited
 				float limit_min = -FLT_MAX, limit_max = FLT_MAX;
-				if (!IsAxisFixed(EAxis(EAxis::TranslationX + i)))
+				if (!IsFixedAxis(EAxis(EAxis::TranslationX + i)))
 				{
-					JPH_ASSERT(!IsAxisFree(EAxis(EAxis::TranslationX + i)));
+					JPH_ASSERT(!IsFreeAxis(EAxis(EAxis::TranslationX + i)));
 					if (mDisplacement[i] <= mLimitMin[i])
 						limit_min = 0;
 					else if (mDisplacement[i] >= mLimitMax[i])
@@ -640,9 +640,9 @@ bool SixDOFConstraint::SolvePositionConstraint(float inDeltaTime, float inBaumga
 			// Determine position error
 			float error = 0.0f;
 			EAxis axis(EAxis(EAxis::TranslationX + i));
-			if (IsAxisFixed(axis))
+			if (IsFixedAxis(axis))
 				error = u.Dot(translation_axis);
-			else if (!IsAxisFree(axis))
+			else if (!IsFreeAxis(axis))
 			{
 				float displacement = u.Dot(translation_axis);
 				if (displacement <= mLimitMin[axis])

--- a/Code/ThirdParty/Jolt/Physics/Constraints/SixDOFConstraint.h
+++ b/Code/ThirdParty/Jolt/Physics/Constraints/SixDOFConstraint.h
@@ -122,6 +122,13 @@ public:
 	/// Update the rotational limits for this constraint, note that this won't change if axis are free or not.
 	void						SetRotationLimits(Vec3Arg inLimitMin, Vec3Arg inLimitMax);
 
+	/// Get constraint Limits
+	float						GetLimitsMin(EAxis inAxis) const							{ return mLimitMin[inAxis]; }
+	float						GetLimitsMax(EAxis inAxis) const							{ return mLimitMax[inAxis]; }
+
+	inline bool					IsFixedAxis(EAxis inAxis) const								{ return (mFixedAxis & (1 << inAxis)) != 0; }
+	inline bool					IsFreeAxis(EAxis inAxis) const								{ return (mFreeAxis & (1 << inAxis)) != 0; }
+
 	/// Set the max friction for each axis
 	void						SetMaxFriction(EAxis inAxis, float inFriction);
 	float						GetMaxFriction(EAxis inAxis) const							{ return mMaxFriction[inAxis]; }
@@ -179,13 +186,11 @@ private:
 	void						CacheRotationMotorActive();
 
 	// Constraint settings helper functions
-	inline bool					IsAxisFixed(EAxis inAxis) const								{ return (mFixedAxis & (1 << inAxis)) != 0; }
-	inline bool					IsAxisFree(EAxis inAxis) const								{ return (mFreeAxis & (1 << inAxis)) != 0; }
 	inline bool					IsTranslationConstrained() const							{ return (mFreeAxis & 0b111) != 0b111; }
 	inline bool					IsTranslationFullyConstrained() const						{ return (mFixedAxis & 0b111) == 0b111; }
 	inline bool					IsRotationConstrained() const								{ return (mFreeAxis & 0b111000) != 0b111000; }
 	inline bool					IsRotationFullyConstrained() const							{ return (mFixedAxis & 0b111000) == 0b111000; }
-	inline bool					HasFriction(EAxis inAxis) const								{ return !IsAxisFixed(inAxis) && mMaxFriction[inAxis] > 0.0f; }
+	inline bool					HasFriction(EAxis inAxis) const								{ return !IsFixedAxis(inAxis) && mMaxFriction[inAxis] > 0.0f; }
 
 	// CONFIGURATION PROPERTIES FOLLOW
 

--- a/Code/ThirdParty/Jolt/Physics/Vehicle/VehicleConstraint.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Vehicle/VehicleConstraint.cpp
@@ -279,7 +279,7 @@ void VehicleConstraint::CalculateWheelContactPoint(Mat44Arg inBodyTransform, con
 {
 	Vec3 contact_pos = inBodyTransform * (inWheel.mSettings->mPosition + inWheel.mSettings->mDirection * inWheel.mContactLength);
 	outR1PlusU = contact_pos - mBody->GetCenterOfMassPosition();
-	outR2 = contact_pos - mBody->GetCenterOfMassPosition();
+	outR2 = contact_pos - inWheel.mContactBody->GetCenterOfMassPosition();
 }
 
 void VehicleConstraint::CalculatePitchRollConstraintProperties(float inDeltaTime, Mat44Arg inBodyTransform)

--- a/Code/ThirdParty/Jolt/Physics/Vehicle/VehicleConstraint.h
+++ b/Code/ThirdParty/Jolt/Physics/Vehicle/VehicleConstraint.h
@@ -42,6 +42,26 @@ protected:
 
 /// Constraint that simulates a vehicle
 /// Note: Don't forget to register the constraint as a StepListener with the PhysicsSystem!
+///
+/// When the vehicle drives over very light objects (rubble) you may see the car body dip down. This is a known issue and is an artifact of the iterative solver that Jolt is using.
+/// Basically if a light object is sandwiched between two heavy objects (the static floor and the car body), the light object is not able to transfer enough force from the ground to
+/// the car body to keep the car body up. You can see this effect in the HeavyOnLightTest sample, the boxes on the right have a lot of penetration because they're on top of light objects.
+/// 
+/// There are a couple of ways to improve this:
+/// 
+/// 1. You can increase the number of velocity steps (global settings PhysicsSettings::mNumVelocitySteps or if you only want to increase it on
+/// the vehicle you can use VehicleConstraintSettings::mNumVelocityStepsOverride). E.g. going from 10 to 30 steps in the HeavyOnLightTest sample makes the penetration a lot less.
+/// The number of position steps can also be increased (the first prevents the body from going down, the second corrects it if the problem did
+/// occur which inevitably happens due to numerical drift). This solution costs CPU cycles.
+/// 
+/// 2. You can reduce the mass difference between the vehicle body and the rubble on the floor (by making the rubble heavier or the car lighter).
+///
+/// 3. You could filter out collisions between the vehicle collision test and the rubble completely. This would make the wheels ignore the rubble but would cause the vehicle to drive
+/// through it as if nothing happened. You could create fake wheels (keyframed bodies) that move along with the vehicle and that only collide with rubble (and not the vehicle or the ground).
+/// This would cause the vehicle to push away the rubble without the rubble being able to affect the vehicle (unless it hits the main body of course).
+///
+/// Note that when driving over rubble, you may see the wheel jump up and down quite quickly because one frame a collision is found and the next frame not.
+/// To alleviate this, it may be needed to smooth the motion of the visual mesh for the wheel.
 class VehicleConstraint : public Constraint, public PhysicsStepListener
 {
 public:


### PR DESCRIPTION
* Update to Jolt version f59dbeb9917103a0cca7c4935b7e9a65537f8632
* Added supporting volume for character, contacts that fall outside will return the state NotSupported and will no longer prevent the character from falling
* Improved fraction correction in GetFirstContactForSweep so that it uses the actual face of the contact instead of estimating it with an infinite plane. Before the character would jump up a lot during stair walk with a frequency of 300Hz.
* Allow walk stairs to slide during horizontal movement. This fixes a bug where a wall next to a stairs would prevent the player from doing stair walking
* Ensure that we prefer returning a supporting contact even if the normal of a non-supporting contact is pointing up more