### PR TITLE
Send main docs before sub-docs

### DIFF
--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -400,7 +400,7 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
   }
   docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b) {
     if (a->IsMainDocument() != b->IsMainDocument())
-      return a->IsMainDocument() > b->IsMainDocument();
+      return a->IsMainDocument();
     return a < b;
   });
 


### PR DESCRIPTION
#fixes 754. Main documents must be sent to the engine process before their sub-documents or the engine will crash.