### PR TITLE
Editor profiling now merges editor and engine process profiling data

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -93,6 +93,14 @@ public:
   double m_fPayload;
 };
 
+class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezSaveProfilingResponseToEditor : public ezEditorEngineMsg
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSaveProfilingResponseToEditor, ezEditorEngineMsg);
+
+public:
+  ezString m_sProfilingFile;
+};
+
 class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezResourceUpdateMsgToEngine : public ezEditorEngineMsg
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezResourceUpdateMsgToEngine, ezEditorEngineMsg);

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -99,6 +99,16 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSimpleConfigMsgToEngine, 1, ezRTTIDefaultAlloc
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSaveProfilingResponseToEditor, 1, ezRTTIDefaultAllocator<ezSaveProfilingResponseToEditor>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("ProfilingFile", m_sProfilingFile),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezResourceUpdateMsgToEngine, 1, ezRTTIDefaultAllocator<ezResourceUpdateMsgToEngine>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -96,6 +96,8 @@ ezResult ezProcessCommunicationChannel::WaitForMessage(const ezRTTI* pMessageTyp
     m_WaitForMessageCallback = WaitForMessageCallback();
   }
 
+  EZ_SCOPE_EXIT(m_WaitForMessageCallback = WaitForMessageCallback(););
+
   const ezTime tStart = ezTime::Now();
 
   while (m_pWaitForMessageType != nullptr)

--- a/Code/Engine/Foundation/Profiling/Implementation/Profiling.cpp
+++ b/Code/Engine/Foundation/Profiling/Implementation/Profiling.cpp
@@ -263,7 +263,7 @@ ezResult ezProfilingSystem::ProfilingData::Write(ezStreamWriter& outputStream) c
         writer.AddVariableString("ph", "M");
 
         writer.BeginObject("args");
-        writer.AddVariableString("name", ezApplication::GetApplicationInstance()->GetApplicationName());
+        writer.AddVariableString("name", ezApplication::GetApplicationInstance() ? ezApplication::GetApplicationInstance()->GetApplicationName().GetData() : "ezEngine");
         writer.EndObject();
       }
       writer.EndObject();

--- a/Code/Engine/Foundation/Profiling/Implementation/Profiling.cpp
+++ b/Code/Engine/Foundation/Profiling/Implementation/Profiling.cpp
@@ -285,29 +285,31 @@ ezResult ezProfilingSystem::ProfilingData::Write(ezStreamWriter& outputStream) c
     // Frames thread metadata
     {
       writer.BeginObject();
-      writer.AddVariableString("name", "thread_name");
-      writer.AddVariableString("cat", "__metadata");
-      writer.AddVariableUInt32("pid", m_uiProcessID);
-      writer.AddVariableUInt64("tid", m_uiFramesThreadID);
-      writer.AddVariableString("ph", "M");
+      {
+        writer.AddVariableString("name", "thread_name");
+        writer.AddVariableString("cat", "__metadata");
+        writer.AddVariableUInt32("pid", m_uiProcessID);
+        writer.AddVariableUInt64("tid", m_uiFramesThreadID);
+        writer.AddVariableString("ph", "M");
 
-      writer.BeginObject("args");
-      writer.AddVariableString("name", "Frames");
-      writer.EndObject();
-
+        writer.BeginObject("args");
+        writer.AddVariableString("name", "Frames");
+        writer.EndObject();
+      }
       writer.EndObject();
 
       writer.BeginObject();
-      writer.AddVariableString("name", "thread_sort_index");
-      writer.AddVariableString("cat", "__metadata");
-      writer.AddVariableUInt32("pid", m_uiProcessID);
-      writer.AddVariableUInt64("tid", m_uiFramesThreadID);
-      writer.AddVariableString("ph", "M");
+      {
+        writer.AddVariableString("name", "thread_sort_index");
+        writer.AddVariableString("cat", "__metadata");
+        writer.AddVariableUInt32("pid", m_uiProcessID);
+        writer.AddVariableUInt64("tid", m_uiFramesThreadID);
+        writer.AddVariableString("ph", "M");
 
-      writer.BeginObject("args");
-      writer.AddVariableInt32("sort_index", -1);
-      writer.EndObject();
-
+        writer.BeginObject("args");
+        writer.AddVariableInt32("sort_index", -1);
+        writer.EndObject();
+      }
       writer.EndObject();
 
       if (writer.HadWriteError())
@@ -316,37 +318,40 @@ ezResult ezProfilingSystem::ProfilingData::Write(ezStreamWriter& outputStream) c
       }
     }
 
+    const ezUInt32 uiGpuCount = m_GPUScopes.GetCount();
     // GPU thread metadata
-    // Since there are no actual threads, we assign 1..gpuCount as the respective threadID
-    for (ezUInt32 gpuIndex = 1; gpuIndex <= m_GPUScopes.GetCount(); ++gpuIndex)
+    // Since there are no actual threads, we assign 1..uiGpuCount as the respective threadID
+    for (ezUInt32 gpuIndex = 1; gpuIndex <= uiGpuCount; ++gpuIndex)
     {
       writer.BeginObject();
-      writer.AddVariableString("name", "thread_name");
-      writer.AddVariableString("cat", "__metadata");
-      writer.AddVariableUInt32("pid", m_uiProcessID);
-      writer.AddVariableUInt64("tid", gpuIndex);
-      writer.AddVariableString("ph", "M");
+      {
+        writer.AddVariableString("name", "thread_name");
+        writer.AddVariableString("cat", "__metadata");
+        writer.AddVariableUInt32("pid", m_uiProcessID);
+        writer.AddVariableUInt64("tid", gpuIndex);
+        writer.AddVariableString("ph", "M");
 
-      ezStringBuilder gpuNameBuilder;
-      gpuNameBuilder.AppendFormat("GPU {}", gpuIndex - 1);
+        ezStringBuilder gpuNameBuilder;
+        gpuNameBuilder.AppendFormat("GPU {}", gpuIndex - 1);
 
-      writer.BeginObject("args");
-      writer.AddVariableString("name", gpuNameBuilder);
-      writer.EndObject();
-
+        writer.BeginObject("args");
+        writer.AddVariableString("name", gpuNameBuilder);
+        writer.EndObject();
+      }
       writer.EndObject();
 
       writer.BeginObject();
-      writer.AddVariableString("name", "thread_sort_index");
-      writer.AddVariableString("cat", "__metadata");
-      writer.AddVariableUInt32("pid", m_uiProcessID);
-      writer.AddVariableUInt64("tid", gpuIndex);
-      writer.AddVariableString("ph", "M");
+      {
+        writer.AddVariableString("name", "thread_sort_index");
+        writer.AddVariableString("cat", "__metadata");
+        writer.AddVariableUInt32("pid", m_uiProcessID);
+        writer.AddVariableUInt64("tid", gpuIndex);
+        writer.AddVariableString("ph", "M");
 
-      writer.BeginObject("args");
-      writer.AddVariableInt32("sort_index", -2);
-      writer.EndObject();
-
+        writer.BeginObject("args");
+        writer.AddVariableInt32("sort_index", -2);
+        writer.EndObject();
+      }
       writer.EndObject();
       if (writer.HadWriteError())
       {
@@ -356,19 +361,35 @@ ezResult ezProfilingSystem::ProfilingData::Write(ezStreamWriter& outputStream) c
 
     // thread metadata
     {
-      for (const ThreadInfo& info : m_ThreadInfos)
+      for (ezUInt32 threadIndex = 0; threadIndex < m_ThreadInfos.GetCount(); ++threadIndex)
       {
+        const ThreadInfo& info = m_ThreadInfos[threadIndex];
         writer.BeginObject();
-        writer.AddVariableString("name", "thread_name");
-        writer.AddVariableString("cat", "__metadata");
-        writer.AddVariableUInt32("pid", m_uiProcessID);
-        writer.AddVariableUInt64("tid", info.m_uiThreadId + 2);
-        writer.AddVariableString("ph", "M");
+        {
+          writer.AddVariableString("name", "thread_name");
+          writer.AddVariableString("cat", "__metadata");
+          writer.AddVariableUInt32("pid", m_uiProcessID);
+          writer.AddVariableUInt64("tid", info.m_uiThreadId + uiGpuCount + 1);
+          writer.AddVariableString("ph", "M");
 
-        writer.BeginObject("args");
-        writer.AddVariableString("name", info.m_sName);
+          writer.BeginObject("args");
+          writer.AddVariableString("name", info.m_sName);
+          writer.EndObject();
+        }
         writer.EndObject();
 
+        writer.BeginObject();
+        {
+          writer.AddVariableString("name", "thread_sort_index");
+          writer.AddVariableString("cat", "__metadata");
+          writer.AddVariableUInt32("pid", m_uiProcessID);
+          writer.AddVariableUInt64("tid", info.m_uiThreadId + uiGpuCount + 1);
+          writer.AddVariableString("ph", "M");
+
+          writer.BeginObject("args");
+          writer.AddVariableInt32("sort_index", threadIndex);
+          writer.EndObject();
+        }
         writer.EndObject();
 
         if (writer.HadWriteError())
@@ -382,7 +403,8 @@ ezResult ezProfilingSystem::ProfilingData::Write(ezStreamWriter& outputStream) c
     ezDynamicArray<CPUScope> sortedScopes;
     for (const auto& eventBuffer : m_AllEventBuffers)
     {
-      const ezUInt64 uiThreadId = eventBuffer.m_uiThreadId + 2;
+      // Since we introduced fake thread IDs via the GPUs, we simply shift all real thread IDs to be in a different range to avoid collisions.
+      const ezUInt64 uiThreadId = eventBuffer.m_uiThreadId + uiGpuCount + 1;
 
       // It seems that chrome does a stable sort by scope begin time. Now that we write complete scopes at the end of a scope
       // we actually write nested scopes before their corresponding parent scope to the file. If both start at the same quantized time stamp

--- a/Code/Engine/Foundation/Profiling/Profiling.h
+++ b/Code/Engine/Foundation/Profiling/Profiling.h
@@ -98,6 +98,7 @@ public:
   struct EZ_FOUNDATION_DLL ProfilingData
   {
     ezUInt32 m_uiFramesThreadID = 0;
+    ezUInt32 m_uiProcessSortIndex = 0;
     ezOsProcessID m_uiProcessID = 0;
 
     ezHybridArray<ThreadInfo, 16> m_ThreadInfos;

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -224,7 +224,8 @@ retry:
       }
   }
 
-  m_Timestamps.SetCountUninitialized(1024);
+  //#TODO_DX11 Replace ring buffer with proper pool like in Vulkan to prevent buffer overrun.
+  m_Timestamps.SetCountUninitialized(2048);
   for (ezUInt32 i = 0; i < m_Timestamps.GetCount(); ++i)
   {
     if (FAILED(m_pDevice->CreateQuery(&timerQueryDesc, &m_Timestamps[i])))

--- a/Code/Engine/RendererFoundation/Profiling/Implementation/Profiling.cpp
+++ b/Code/Engine/RendererFoundation/Profiling/Implementation/Profiling.cpp
@@ -1,6 +1,7 @@
 #include <RendererFoundation/RendererFoundationPCH.h>
 
 #include <Foundation/Configuration/Startup.h>
+#include <Foundation/Logging/Log.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
@@ -38,6 +39,14 @@ public:
 
         if (!beginTime.IsZero() && !endTime.IsZero())
         {
+#  if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+          static bool warnOnRingBufferOverun = true;
+          if (warnOnRingBufferOverun && endTime < beginTime)
+          {
+            warnOnRingBufferOverun = false;
+            ezLog::Error("Profiling end is before start, the DX11 timestamp ring buffer was probably overrun.");
+          }
+#  endif
           ezProfilingSystem::AddGPUScope(timingScope.m_szName, beginTime, endTime);
         }
 

--- a/Code/Engine/RendererVulkan/Pools/Implementation/FencePoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/FencePoolVulkan.cpp
@@ -43,6 +43,13 @@ vk::Fence ezFencePoolVulkan::RequestFence()
 void ezFencePoolVulkan::ReclaimFence(vk::Fence& fence)
 {
   vk::Result fenceStatus = s_device.getFenceStatus(fence);
+  if (fenceStatus == vk::Result::eNotReady)
+  {
+    //#TODO_VULKAN Workaround for fences that were waited for (and thus signaled) returning VK_NOT_READY if AMDs profiler is active.
+    //The fence will simply take another round through the reclaim process and will eventually turn signaled.
+    static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice())->ReclaimLater(fence);
+    return;
+  }
   VK_ASSERT_DEV(fenceStatus);
   s_device.resetFences(1, &fence);
   EZ_ASSERT_DEBUG(s_device, "ezFencePoolVulkan::Initialize not called");

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -498,7 +498,7 @@ void ezJoltDefaultCharacterComponent::CheckFeet()
 
   if (m_DebugFlags.IsAnySet(ezJoltCharacterDebugFlags::VisFootCheck))
   {
-    ezDebugRenderer::DrawLineCapsuleZ(GetWorld(), halfHeight * 2.0, radius, ezColor::YellowGreen, ezTransform(shapeTrans.m_vPosition));
+    ezDebugRenderer::DrawLineCapsuleZ(GetWorld(), halfHeight * 2.0f, radius, ezColor::YellowGreen, ezTransform(shapeTrans.m_vPosition));
   }
 }
 


### PR DESCRIPTION
* Added **ezSaveProfilingResponseToEditor** for the editor to wait for the engine profiling data to be written and to retrieve the absolute path to it.
* **ezProcessCommunicationChannel::WaitForMessage** now clears the **m_WaitForMessageCallback** on exiting the function to not leak it.
* The chrome tracing format is very simple so merging the profiling data is as simple as glueing the two json arrays togther.
* Added process sort index and name to the data so that editor and engine are always sorted and named.
* Increased timestamp ring buffer size in DX11 and added error in debug builds if it is overrun as the trace is completely garbled if that happens.
* Added workaround for AMD profiler claiming fences are **VK_NOT_READY** after we waited for them.
* Jolt compile fix.