### PR TITLE
HLSL EvaluateAttributeAtSample emulation for Vulkan

### DIFF
--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -438,6 +438,10 @@ vk::Pipeline ezResourceCacheVulkan::RequestGraphicsPipeline(const GraphicsPipeli
   // No multisampling.
   vk::PipelineMultisampleStateCreateInfo multisample;
   multisample.rasterizationSamples = ezConversionUtilsVulkan::GetSamples(desc.m_msaa);
+  if (multisample.rasterizationSamples != vk::SampleCountFlagBits::e1 && desc.m_pCurrentBlendState->GetDescription().m_bAlphaToCoverage)
+  {
+    multisample.alphaToCoverageEnable = true;
+  }
 
   // Specify that these states will be dynamic, i.e. not part of pipeline state object.
   ezHybridArray<vk::DynamicState, 2> dynamics;

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -35,24 +35,6 @@ public:
     vk::SampleCountFlagBits targetSamples;
   };
 
-  struct PipelineCacheKey
-  {
-    EZ_DECLARE_POD_TYPE();
-
-    vk::RenderPass m_renderPass;
-    ezEnum<ezGALMSAASampleCount> m_sampelCount;
-    ezShaderUtils::ezBuiltinShaderType m_shaderType;
-  };
-
-  struct PipelineCacheValue
-  {
-    EZ_DECLARE_POD_TYPE();
-
-    ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
-    ezResourceCacheVulkan::GraphicsPipelineDesc m_PipelineDesc;
-    vk::Pipeline m_pipeline;
-  };
-
   struct FramebufferCacheKey
   {
     EZ_DECLARE_POD_TYPE();
@@ -110,7 +92,6 @@ private:
 
     ezHashTable<ezGALShaderHandle, ezGALVertexDeclarationHandle> m_vertexDeclarations;
     ezHashTable<RenderPassCacheKey, vk::RenderPass> m_renderPasses;
-    ezHashTable<PipelineCacheKey, PipelineCacheValue> m_pipelines;
     ezHashTable<ImageViewCacheKey, vk::ImageView> m_sourceImageViews;
     ezHashTable<vk::Image, ImageViewCacheValue> m_imageToSourceImageViewCacheKey;
     ezHashTable<ImageViewCacheKey, vk::ImageView> m_targetImageViews;

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/DocumentNodeManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/DocumentNodeManager.cpp
@@ -531,7 +531,7 @@ bool ezDocumentNodeManager::PasteObjects(const ezArrayPtr<ezDocument::PasteInfo>
       }
     }
 
-    vAvgPos /= nodeCount;
+    vAvgPos /= (float)nodeCount;
     const ezVec2 vMoveNode = -vAvgPos + pickedPosition;
 
     for (const ezDocumentObject* pObject : AddedObjects)

--- a/Data/Base/Shaders/Common/Platforms.h
+++ b/Data/Base/Shaders/Common/Platforms.h
@@ -14,19 +14,19 @@
   #undef PLATFORM_DX11
   #define PLATFORM_DX11 EZ_ON
 
-float ezEvaluateAttributeAtSample(float Attribute, uint SampleIndex)
+float ezEvaluateAttributeAtSample(float Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
   return EvaluateAttributeAtSample(Attribute, SampleIndex);
 }
-float2 ezEvaluateAttributeAtSample(float2 Attribute, uint SampleIndex)
+float2 ezEvaluateAttributeAtSample(float2 Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
   return EvaluateAttributeAtSample(Attribute, SampleIndex);
 }
-float3 ezEvaluateAttributeAtSample(float3 Attribute, uint SampleIndex)
+float3 ezEvaluateAttributeAtSample(float3 Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
   return EvaluateAttributeAtSample(Attribute, SampleIndex);
 }
-float4 ezEvaluateAttributeAtSample(float4 Attribute, uint SampleIndex)
+float4 ezEvaluateAttributeAtSample(float4 Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
   return EvaluateAttributeAtSample(Attribute, SampleIndex);
 }
@@ -40,23 +40,72 @@ float4 ezEvaluateAttributeAtSample(float4 Attribute, uint SampleIndex)
   #undef PLATFORM_VULKAN
   #define PLATFORM_VULKAN EZ_ON
 
+
+// GetRenderTargetSamplePosition does not have an equivalent function in Vulkan so these values are hard-coded.
+// https://learn.microsoft.com/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels
+static const float2 offsets[] =
+{
+  // 1x MSAA
+  float2(0, 0),
+  // 2x MSAA
+  float2(4,4),
+  float2(-4,-4),
+  // 4x MSAA
+  float2(-2, -6),
+  float2(6, -2),
+  float2(-6, 2),
+  float2(2, 6),
+  // 8x MSAA
+  float2(1, -3),
+  float2(-1, 3),
+  float2(-5, 1),
+  float2(-3, -5),
+  float2(-5, 5),
+  float2(-7, -1),
+  float2(3, 7),
+  float2(7, -7),
+  // 16x MSAA
+  float2(1,1),
+  float2(-1,-3),
+  float2(-3,2),
+  float2(4,-1),
+  float2(-5,-2),
+  float2(2,5),
+  float2(5,3),
+  float2(3,-5),
+  float2(-2,6),
+  float2(0,-7),
+  float2(-4,-6),
+  float2(-6,4),
+  float2(-8,0),
+  float2(7,-4),
+  float2(6,7),
+  float2(-7,-8),
+};
+
 // Workaround for error: EvaluateAttributeAtSample intrinsic function unimplemented
 // See https://github.com/microsoft/DirectXShaderCompiler/issues/3649
-float ezEvaluateAttributeAtSample(float Attribute, uint SampleIndex)
+float ezEvaluateAttributeAtSample(float Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
-  return Attribute;
+  float2 sampleOffset = offsets[NumMsaaSamples + SampleIndex - 1] * 0.125f;
+  return Attribute + ddx(Attribute) * sampleOffset.x + ddy(Attribute) * sampleOffset.y;
 }
-float2 ezEvaluateAttributeAtSample(float2 Attribute, uint SampleIndex)
-{
-  return Attribute;
+
+float2 ezEvaluateAttributeAtSample(float2 Attribute, uint SampleIndex, uint NumMsaaSamples)
+{ 
+  float2 sampleOffset = offsets[NumMsaaSamples + SampleIndex - 1] * 0.125f;
+  return Attribute + ddx(Attribute) * sampleOffset.x + ddy(Attribute) * sampleOffset.y;
 }
-float3 ezEvaluateAttributeAtSample(float3 Attribute, uint SampleIndex)
+
+float3 ezEvaluateAttributeAtSample(float3 Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
-  return Attribute;
+  float2 sampleOffset = offsets[NumMsaaSamples + SampleIndex - 1] * 0.125f;
+  return Attribute + ddx(Attribute) * sampleOffset.x + ddy(Attribute) * sampleOffset.y;
 }
-float4 ezEvaluateAttributeAtSample(float4 Attribute, uint SampleIndex)
+float4 ezEvaluateAttributeAtSample(float4 Attribute, uint SampleIndex, uint NumMsaaSamples)
 {
-  return Attribute;
+  float2 sampleOffset = offsets[NumMsaaSamples + SampleIndex - 1] * 0.125f;
+  return Attribute + ddx(Attribute) * sampleOffset.x + ddy(Attribute) * sampleOffset.y;
 }
 
 #endif

--- a/Data/Base/Shaders/Common/Platforms.h
+++ b/Data/Base/Shaders/Common/Platforms.h
@@ -44,43 +44,43 @@ float4 ezEvaluateAttributeAtSample(float4 Attribute, uint SampleIndex, uint NumM
 // GetRenderTargetSamplePosition does not have an equivalent function in Vulkan so these values are hard-coded.
 // https://learn.microsoft.com/windows/win32/api/d3d11/ne-d3d11-d3d11_standard_multisample_quality_levels
 static const float2 offsets[] =
-{
-  // 1x MSAA
-  float2(0, 0),
-  // 2x MSAA
-  float2(4,4),
-  float2(-4,-4),
-  // 4x MSAA
-  float2(-2, -6),
-  float2(6, -2),
-  float2(-6, 2),
-  float2(2, 6),
-  // 8x MSAA
-  float2(1, -3),
-  float2(-1, 3),
-  float2(-5, 1),
-  float2(-3, -5),
-  float2(-5, 5),
-  float2(-7, -1),
-  float2(3, 7),
-  float2(7, -7),
-  // 16x MSAA
-  float2(1,1),
-  float2(-1,-3),
-  float2(-3,2),
-  float2(4,-1),
-  float2(-5,-2),
-  float2(2,5),
-  float2(5,3),
-  float2(3,-5),
-  float2(-2,6),
-  float2(0,-7),
-  float2(-4,-6),
-  float2(-6,4),
-  float2(-8,0),
-  float2(7,-4),
-  float2(6,7),
-  float2(-7,-8),
+  {
+    // 1x MSAA
+    float2(0, 0),
+    // 2x MSAA
+    float2(4, 4),
+    float2(-4, -4),
+    // 4x MSAA
+    float2(-2, -6),
+    float2(6, -2),
+    float2(-6, 2),
+    float2(2, 6),
+    // 8x MSAA
+    float2(1, -3),
+    float2(-1, 3),
+    float2(-5, 1),
+    float2(-3, -5),
+    float2(-5, 5),
+    float2(-7, -1),
+    float2(3, 7),
+    float2(7, -7),
+    // 16x MSAA
+    float2(1, 1),
+    float2(-1, -3),
+    float2(-3, 2),
+    float2(4, -1),
+    float2(-5, -2),
+    float2(2, 5),
+    float2(5, 3),
+    float2(3, -5),
+    float2(-2, 6),
+    float2(0, -7),
+    float2(-4, -6),
+    float2(-6, 4),
+    float2(-8, 0),
+    float2(7, -4),
+    float2(6, 7),
+    float2(-7, -8),
 };
 
 // Workaround for error: EvaluateAttributeAtSample intrinsic function unimplemented
@@ -92,7 +92,7 @@ float ezEvaluateAttributeAtSample(float Attribute, uint SampleIndex, uint NumMsa
 }
 
 float2 ezEvaluateAttributeAtSample(float2 Attribute, uint SampleIndex, uint NumMsaaSamples)
-{ 
+{
   float2 sampleOffset = offsets[NumMsaaSamples + SampleIndex - 1] * 0.125f;
   return Attribute + ddx(Attribute) * sampleOffset.x + ddy(Attribute) * sampleOffset.y;
 }

--- a/Data/Base/Shaders/Materials/MaterialHelper.h
+++ b/Data/Base/Shaders/Materials/MaterialHelper.h
@@ -64,7 +64,7 @@ uint CalculateCoverage()
     
     for (uint i = 0; i < NumMsaaSamples; ++i)
     {
-      G.Input.TexCoord0 = ezEvaluateAttributeAtSample(texCoords, i);
+      G.Input.TexCoord0 = ezEvaluateAttributeAtSample(texCoords, i, NumMsaaSamples);
 
       float opacity = GetOpacity();
       coverage |= (opacity > 0.0) ? (1U << i) : 0;


### PR DESCRIPTION
* **EvaluateAttributeAtSample**: Sample value is computed via ddx / ddy on the input parameter multiplied by a hardcoded sample offset.
* Implemented alpha to coverage.
* Removed **PipelineCacheKey** in **ezImageCopyVulkan**. The key contained raw pointers which would crash on e.g. shader reload. The values are already cached in **ezResourceCacheVulkan** so this just replaced one unsafe hashmap lookup with 3 safe hashmap lookups.
* Compile fix in DocumentNodeManager.