### PR TITLE
Hold reference to built-in shaders

### DIFF
--- a/Code/Engine/RendererFoundation/Shader/ShaderUtils.h
+++ b/Code/Engine/RendererFoundation/Shader/ShaderUtils.h
@@ -65,3 +65,4 @@ public:
     g_RequestBuiltinShaderCallback(type, out_shader);
   }
 };
+EZ_DEFINE_AS_POD_TYPE(ezShaderUtils::ezBuiltinShaderType);

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -97,6 +97,7 @@ private:
     ezHashTable<ImageViewCacheKey, vk::ImageView> m_targetImageViews;
     ezHashTable<vk::Image, ImageViewCacheValue> m_imageToTargetImageViewCacheKey;
     ezHashTable<FramebufferCacheKey, vk::Framebuffer> m_framebuffers;
+    ezHashTable<ezShaderUtils::ezBuiltinShaderType, ezShaderUtils::ezBuiltinShader> m_shaders;
 
     ezEventSubscriptionID m_onBeforeImageDeletedSubscription;
   };


### PR DESCRIPTION
* Without this the built-in shaders are freed and reloaded at random intervals.