### PR TITLE
Removed TypeSize from ezReflectedTypeDescriptor

### DIFF
--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
@@ -45,7 +45,6 @@ ezExposedParametersTypeRegistry::ezExposedParametersTypeRegistry()
   desc.m_sPluginName = "ExposedParametersTypes";
   desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
   desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
-  desc.m_uiTypeSize = 0;
   desc.m_uiTypeVersion = 0;
 
   m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -102,7 +101,6 @@ void ezExposedParametersTypeRegistry::UpdateExposedParametersType(ParamData& dat
   desc.m_sPluginName = "ExposedParametersTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
   desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
-  desc.m_uiTypeSize = 0;
   desc.m_uiTypeVersion = 2;
 
   for (const auto* parameter : params.m_Parameters)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -89,7 +89,6 @@ namespace
         descEnum.m_sPluginName = "ShaderTypes";
         descEnum.m_sParentTypeName = ezGetStaticRTTI<ezEnumBase>()->GetTypeName();
         descEnum.m_Flags = ezTypeFlags::IsEnum | ezTypeFlags::Phantom;
-        descEnum.m_uiTypeSize = 0;
         descEnum.m_uiTypeVersion = 1;
 
         ezArrayPtr<ezPropertyAttribute* const> noAttributes;
@@ -129,7 +128,6 @@ namespace
     descEnum.m_sPluginName = "ShaderTypes";
     descEnum.m_sParentTypeName = ezGetStaticRTTI<ezEnumBase>()->GetTypeName();
     descEnum.m_Flags = ezTypeFlags::IsEnum | ezTypeFlags::Phantom;
-    descEnum.m_uiTypeSize = 0;
     descEnum.m_uiTypeVersion = 1;
 
     ezArrayPtr<ezPropertyAttribute* const> noAttributes;
@@ -248,7 +246,6 @@ ezShaderTypeRegistry::ezShaderTypeRegistry()
   desc.m_sPluginName = "ShaderTypes";
   desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
   desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
-  desc.m_uiTypeSize = 0;
   desc.m_uiTypeVersion = 2;
 
   m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -336,7 +333,6 @@ void ezShaderTypeRegistry::UpdateShaderType(ShaderData& data)
   desc.m_sPluginName = "ShaderTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
   desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
-  desc.m_uiTypeSize = 0;
   desc.m_uiTypeVersion = 2;
 
   for (auto& enumDef : enumDefinitions)
@@ -438,7 +434,6 @@ public:
       desc.m_sPluginName = "ShaderTypes";
       desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
       desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
-      desc.m_uiTypeSize = 0;
       desc.m_uiTypeVersion = 1;
 
       context.RegisterObject(ezUuid::StableUuidForString(desc.m_sTypeName.GetData()), ezGetStaticRTTI<ezReflectedTypeDescriptor>(), &desc);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptTypeRegistry.cpp
@@ -112,7 +112,6 @@ void ezVisualScriptTypeRegistry::UpdateNodeTypes()
     desc.m_sPluginName = "VisualScriptTypes";
     desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
     desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
-    desc.m_uiTypeSize = 0;
     desc.m_uiTypeVersion = 1;
 
     m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -289,7 +288,6 @@ const ezRTTI* ezVisualScriptTypeRegistry::GenerateTypeFromDesc(const ezVisualScr
   desc.m_sPluginName = "VisualScriptTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
   desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
-  desc.m_uiTypeSize = 0;
   desc.m_uiTypeVersion = 1;
   desc.m_Properties = nd.m_Properties;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
@@ -140,7 +140,6 @@ void ezVisualShaderTypeRegistry::LoadNodeData()
     desc.m_sPluginName = "VisualShaderTypes";
     desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
     desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Abstract | ezTypeFlags::Class;
-    desc.m_uiTypeSize = 0;
     desc.m_uiTypeVersion = 1;
 
     m_pBaseType = ezPhantomRttiManager::RegisterType(desc);
@@ -153,7 +152,6 @@ void ezVisualShaderTypeRegistry::LoadNodeData()
     desc.m_sPluginName = "VisualShaderTypes";
     desc.m_sParentTypeName = ezGetStaticRTTI<ezReflectedClass>()->GetTypeName();
     desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
-    desc.m_uiTypeSize = 0;
     desc.m_uiTypeVersion = 1;
 
     m_pSamplerPinType = ezPhantomRttiManager::RegisterType(desc);
@@ -172,7 +170,6 @@ const ezRTTI* ezVisualShaderTypeRegistry::GenerateTypeFromDesc(const ezVisualSha
   desc.m_sPluginName = "VisualShaderTypes";
   desc.m_sParentTypeName = m_pBaseType->GetTypeName();
   desc.m_Flags = ezTypeFlags::Phantom | ezTypeFlags::Class;
-  desc.m_uiTypeSize = 0;
   desc.m_uiTypeVersion = 1;
   desc.m_Properties = nd.m_Properties;
 

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
@@ -120,7 +120,7 @@ void ezPhantomRTTI::SetAttributes(ezHybridArray<ezPropertyAttribute*, 2>& attrib
 
 void ezPhantomRTTI::UpdateType(ezReflectedTypeDescriptor& desc)
 {
-  ezRTTI::UpdateType(ezRTTI::FindTypeByName(desc.m_sParentTypeName), desc.m_uiTypeSize, desc.m_uiTypeVersion, ezVariantType::Invalid, desc.m_Flags);
+  ezRTTI::UpdateType(ezRTTI::FindTypeByName(desc.m_sParentTypeName), 0, desc.m_uiTypeVersion, ezVariantType::Invalid, desc.m_Flags);
 
   m_sPluginNameStorage = desc.m_sPluginName;
   m_szPluginName = m_sPluginNameStorage.GetData();

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRttiManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRttiManager.cpp
@@ -54,7 +54,7 @@ const ezRTTI* ezPhantomRttiManager::RegisterType(ezReflectedTypeDescriptor& desc
 
   if (pPhantom == nullptr)
   {
-    pPhantom = EZ_DEFAULT_NEW(ezPhantomRTTI, desc.m_sTypeName.GetData(), ezRTTI::FindTypeByName(desc.m_sParentTypeName), desc.m_uiTypeSize,
+    pPhantom = EZ_DEFAULT_NEW(ezPhantomRTTI, desc.m_sTypeName.GetData(), ezRTTI::FindTypeByName(desc.m_sParentTypeName), 0,
       desc.m_uiTypeVersion, ezVariantType::Invalid, desc.m_Flags, desc.m_sPluginName.GetData());
 
     pPhantom->SetProperties(desc.m_Properties);

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedType.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedType.cpp
@@ -284,7 +284,6 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezReflectedTypeDescriptor, ezAttributeHolder, 1, 
     EZ_BITFLAGS_MEMBER_PROPERTY("Flags", ezTypeFlags, m_Flags),
     EZ_ARRAY_MEMBER_PROPERTY("Properties", m_Properties),
     EZ_ARRAY_MEMBER_PROPERTY("Functions", m_Functions),
-    EZ_MEMBER_PROPERTY("TypeSize", m_uiTypeSize),
     EZ_MEMBER_PROPERTY("TypeVersion", m_uiTypeVersion),
   }
   EZ_END_PROPERTIES;

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ToolsReflectionUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ToolsReflectionUtils.cpp
@@ -239,7 +239,6 @@ void ezToolsReflectionUtils::GetMinimalReflectedTypeDescriptorFromRtti(const ezR
   out_desc.m_sTypeName = pRtti->GetTypeName();
   out_desc.m_sPluginName = pRtti->GetPluginName();
   out_desc.m_Flags = pRtti->GetTypeFlags() | ezTypeFlags::Minimal;
-  out_desc.m_uiTypeSize = pRtti->GetTypeSize();
   out_desc.m_uiTypeVersion = pRtti->GetTypeVersion();
   const ezRTTI* pParentRtti = pRtti->GetParentType();
   out_desc.m_sParentTypeName = pParentRtti ? pParentRtti->GetTypeName() : nullptr;

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedType.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedType.h
@@ -104,6 +104,6 @@ struct EZ_TOOLSFOUNDATION_DLL ezReflectedTypeDescriptor : public ezAttributeHold
   ezBitflags<ezTypeFlags> m_Flags;
   ezDynamicArray<ezReflectedPropertyDescriptor> m_Properties;
   ezDynamicArray<ezReflectedFunctionDescriptor> m_Functions;
-  ezUInt32 m_uiTypeVersion;
+  ezUInt32 m_uiTypeVersion = 1;
 };
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_TOOLSFOUNDATION_DLL, ezReflectedTypeDescriptor);

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedType.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedType.h
@@ -104,7 +104,6 @@ struct EZ_TOOLSFOUNDATION_DLL ezReflectedTypeDescriptor : public ezAttributeHold
   ezBitflags<ezTypeFlags> m_Flags;
   ezDynamicArray<ezReflectedPropertyDescriptor> m_Properties;
   ezDynamicArray<ezReflectedFunctionDescriptor> m_Functions;
-  ezUInt32 m_uiTypeSize;
   ezUInt32 m_uiTypeVersion;
 };
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_TOOLSFOUNDATION_DLL, ezReflectedTypeDescriptor);


### PR DESCRIPTION
This value tends to change randomly (debug vs release builds?) and doesn't seem to have any actual use. Since it is serialized to the documents, it introduces pointless document modifications.