### PR TITLE
Include PCH headers in non pch builds

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsDX11.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsDX11.cmake
@@ -9,7 +9,7 @@ function(ez_link_target_dx11 TARGET_NAME)
 
 	# only execute find_package once
 	if(NOT EZ_DX11_LIBRARY)
-		find_package(DirectX11)
+		find_package(DirectX11 REQUIRED)
 
 		if(DirectX11_FOUND)
 			set_property(GLOBAL PROPERTY EZ_DX11_LIBRARY ${DirectX11_LIBRARY})


### PR DESCRIPTION
This is done to remove the difference in behavior between pch and non-pch builds.
Also make it a cmake error if we don't find the DX11 headers.