### PR TITLE
Make Collections store asset dependencies transitively

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCollectionAssetEntry, 1, ezRTTIDefaultAllocato
     EZ_MEMBER_PROPERTY("Name", m_sLookupName),
     EZ_MEMBER_PROPERTY("Asset", m_sRedirectionAsset)->AddAttributes(new ezAssetBrowserAttribute(""))
   }
-    EZ_END_PROPERTIES;
+  EZ_END_PROPERTIES;
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
@@ -106,8 +106,7 @@ void ezCollectionAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pIn
   }
 }
 
-ezTransformStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
-  const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const ezCollectionAssetData* pProp = GetProperties();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
@@ -1,6 +1,7 @@
 #include <EditorPluginAssets/EditorPluginAssetsPCH.h>
 
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocumentInfo.h>
 #include <EditorPluginAssets/CollectionAsset/CollectionAsset.h>
 
 // clang-format off
@@ -34,32 +35,97 @@ ezCollectionAssetDocument::ezCollectionAssetDocument(const char* szDocumentPath)
 {
 }
 
-ezTransformStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
-  const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+static void InsertEntry(ezStringView sID, ezStringView sLookupName, ezMap<ezString, ezCollectionEntry>& inout_Found)
 {
+  auto it = inout_Found.Find(sID);
+
+  if (it.IsValid())
+  {
+    if (!sLookupName.IsEmpty())
+    {
+      it.Value().m_sOptionalNiceLookupName = sLookupName;
+    }
+
+    return;
+  }
+
+  ezStringBuilder tmp;
+  ezAssetCurator::ezLockedSubAsset pInfo = ezAssetCurator::GetSingleton()->FindSubAsset(sID.GetData(tmp));
+
+  if (pInfo == nullptr)
+  {
+    ezLog::Warning("Asset in Collection is unknown: '{0}'", sID);
+    return;
+  }
+
+  // insert item itself
+  {
+    ezCollectionEntry& entry = inout_Found[sID];
+    entry.m_sOptionalNiceLookupName = sLookupName;
+    entry.m_sResourceID = sID;
+    entry.m_sAssetTypeName = pInfo->m_Data.m_sSubAssetsDocumentTypeName;
+  }
+
+  // insert dependencies
+  {
+    const ezAssetDocumentInfo* pDocInfo = pInfo->m_pAssetInfo->m_Info.Borrow();
+
+    for (const ezString& doc : pDocInfo->m_AssetTransformDependencies)
+    {
+      InsertEntry(doc, {}, inout_Found);
+    }
+
+    for (const ezString& doc : pDocInfo->m_RuntimeDependencies)
+    {
+      InsertEntry(doc, {}, inout_Found);
+    }
+  }
+}
+
+void ezCollectionAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
+{
+  // TODO: why are collections not marked as needs-transform, out of the box, when a dependency changes ?
+
+  SUPER::UpdateAssetDocumentInfo(pInfo);
+
   const ezCollectionAssetData* pProp = GetProperties();
 
-  ezCollectionResourceDescriptor desc;
-  ezCollectionEntry entry;
+  ezMap<ezString, ezCollectionEntry> entries;
 
   for (const auto& e : pProp->m_Entries)
   {
     if (e.m_sRedirectionAsset.IsEmpty())
       continue;
 
-    ezAssetCurator::ezLockedSubAsset pInfo = ezAssetCurator::GetSingleton()->FindSubAsset(e.m_sRedirectionAsset);
+    InsertEntry(e.m_sRedirectionAsset, e.m_sLookupName, entries);
+  }
 
-    if (pInfo == nullptr)
-    {
-      ezLog::Warning("Asset in Collection is unknown: '{0}'", e.m_sRedirectionAsset);
+  for (auto it : entries)
+  {
+    pInfo->m_AssetTransformDependencies.Insert(it.Value().m_sResourceID);
+  }
+}
+
+ezTransformStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+{
+  const ezCollectionAssetData* pProp = GetProperties();
+
+  ezMap<ezString, ezCollectionEntry> entries;
+
+  for (const auto& e : pProp->m_Entries)
+  {
+    if (e.m_sRedirectionAsset.IsEmpty())
       continue;
-    }
 
-    entry.m_sOptionalNiceLookupName = e.m_sLookupName;
-    entry.m_sResourceID = e.m_sRedirectionAsset;
-    entry.m_sAssetTypeName = pInfo->m_Data.m_sSubAssetsDocumentTypeName;
+    InsertEntry(e.m_sRedirectionAsset, e.m_sLookupName, entries);
+  }
 
-    desc.m_Resources.PushBack(entry);
+  ezCollectionResourceDescriptor desc;
+
+  for (auto it : entries)
+  {
+    desc.m_Resources.PushBack(it.Value());
   }
 
   desc.Save(stream);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
@@ -20,8 +20,6 @@ public:
   ezDynamicArray<ezCollectionAssetEntry> m_Entries;
 };
 
-
-
 class ezCollectionAssetDocument : public ezSimpleAssetDocument<ezCollectionAssetData>
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezCollectionAssetDocument, ezSimpleAssetDocument<ezCollectionAssetData>);
@@ -30,8 +28,7 @@ public:
   ezCollectionAssetDocument(const char* szDocumentPath);
 
 protected:
-  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const;
+  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
-    const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
@@ -30,6 +30,8 @@ public:
   ezCollectionAssetDocument(const char* szDocumentPath);
 
 protected:
+  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const;
+
   virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -150,7 +150,7 @@ public:
   ///
   /// This is mostly for editor use cases, where some documents want to handle the game state, but only
   /// it it was set up for a particular document.
-  ezGameStateBase* GetActiveGameStateLinkedToWorld(ezWorld* pWorld) const;
+  ezGameStateBase* GetActiveGameStateLinkedToWorld(const ezWorld* pWorld) const;
 
 protected:
   /// \brief Creates a game state for the application to use.

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -251,7 +251,7 @@ void ezGameApplicationBase::DeactivateGameState()
   m_pGameState = nullptr;
 }
 
-ezGameStateBase* ezGameApplicationBase::GetActiveGameStateLinkedToWorld(ezWorld* pWorld) const
+ezGameStateBase* ezGameApplicationBase::GetActiveGameStateLinkedToWorld(const ezWorld* pWorld) const
 {
   if (m_pWorldLinkedWithGameState == pWorld)
     return m_pGameState.Borrow();


### PR DESCRIPTION
Collections now store all transitive asset dependencies. That allows to preload all assets that are needed for one asset, without having to add them all manually to a collection.

The collection itself isn't currently properly marked as out-of-date when an indirect asset is modified. See #814, which should fix this in the future. For now a crude method is used to get at least some dependency tracking in there.