### PR TITLE
Fixes for world cleanup

### DIFF
--- a/Code/Engine/Core/World/EventMessageHandlerComponent.h
+++ b/Code/Engine/Core/World/EventMessageHandlerComponent.h
@@ -57,6 +57,8 @@ public:
   /// \brief Returns all global event handler for the given world.
   static ezArrayPtr<ezComponentHandle> GetAllGlobalEventHandler(const ezWorld* pWorld);
 
+  static void ClearGlobalEventHandlersForWorld(const ezWorld* pWorld);
+
 private:
   bool m_bDebugOutput = false;
   bool m_bIsGlobalEventHandler = false;

--- a/Code/Engine/Core/World/Implementation/EventMessageHandlerComponent.cpp
+++ b/Code/Engine/Core/World/Implementation/EventMessageHandlerComponent.cpp
@@ -146,5 +146,14 @@ ezArrayPtr<ezComponentHandle> ezEventMessageHandlerComponent::GetAllGlobalEventH
 }
 
 
+void ezEventMessageHandlerComponent::ClearGlobalEventHandlersForWorld(const ezWorld* pWorld)
+{
+  ezUInt32 uiWorldIndex = pWorld->GetIndex();
+
+  if (uiWorldIndex < s_GlobalEventHandlerPerWorld.GetCount())
+  {
+    s_GlobalEventHandlerPerWorld[uiWorldIndex]->Clear();
+  }
+}
 
 EZ_STATICLINK_FILE(Core, Core_World_Implementation_EventMessageHandlerComponent);

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -108,6 +108,8 @@ void ezWorld::Clear()
   // make sure all dead objects and components are cleared right now
   DeleteDeadObjects();
   DeleteDeadComponents();
+
+  ezEventMessageHandlerComponent::ClearGlobalEventHandlersForWorld(this);
 }
 
 void ezWorld::SetCoordinateSystemProvider(const ezSharedPtr<ezCoordinateSystemProvider>& pProvider)

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltTriggerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltTriggerComponent.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <JoltPlugin/Actors/JoltTriggerComponent.h>
 #include <JoltPlugin/Shapes/JoltShapeComponent.h>
+#include <JoltPlugin/System/JoltContacts.h>
 #include <JoltPlugin/System/JoltWorldModule.h>
 #include <JoltPlugin/Utilities/JoltConversionUtils.h>
 
@@ -118,6 +119,11 @@ void ezJoltTriggerComponent::OnSimulationStarted()
 
 void ezJoltTriggerComponent::OnDeactivated()
 {
+  ezJoltWorldModule* pModule = GetWorld()->GetOrCreateModule<ezJoltWorldModule>();
+
+  ezJoltContactListener* pContactListener = pModule->GetContactListener();
+  pContactListener->RemoveTrigger(this);
+
   if (GetOwner()->IsDynamic())
   {
     ezJoltTriggerComponentManager* pManager = static_cast<ezJoltTriggerComponentManager*>(GetOwningManager());

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
@@ -17,6 +17,23 @@ ezCVarBool cvar_PhysicsReactionsVisDiscardedImpacts("Jolt.Reactions.VisDiscarded
 ezCVarBool cvar_PhysicsReactionsVisSlides("Jolt.Reactions.VisSlides", false, ezCVarFlags::Default, "Visualize active slide reactions.");
 ezCVarBool cvar_PhysicsReactionsVisRolls("Jolt.Reactions.VisRolls", false, ezCVarFlags::Default, "Visualize active roll reactions.");
 
+void ezJoltContactListener::RemoveTrigger(const ezJoltTriggerComponent* pTrigger)
+{
+  EZ_LOCK(m_TriggerMutex);
+
+  for (auto it = m_Trigs.GetIterator(); it.IsValid();)
+  {
+    if (it.Value().m_pTrigger == pTrigger)
+    {
+      it = m_Trigs.Remove(it);
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
 void ezJoltContactListener::OnContactAdded(const JPH::Body& inBody0, const JPH::Body& inBody1, const JPH::ContactManifold& inManifold, JPH::ContactSettings& ioSettings)
 {
   const ezUInt64 uiBody0id = inBody0.GetID().GetIndexAndSequenceNumber();

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
@@ -77,6 +77,8 @@ public:
   ezMutex m_TriggerMutex;
   ezMap<ezUInt64, TriggerObj> m_Trigs;
 
+  void RemoveTrigger(const ezJoltTriggerComponent* pTrigger);
+
   virtual void OnContactAdded(const JPH::Body& inBody1, const JPH::Body& inBody2, const JPH::ContactManifold& inManifold, JPH::ContactSettings& ioSettings) override;
   virtual void OnContactPersisted(const JPH::Body& inBody1, const JPH::Body& inBody2, const JPH::ContactManifold& inManifold, JPH::ContactSettings& ioSettings) override;
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -10,6 +10,7 @@
 #include <JoltPlugin/Utilities/JoltUserData.h>
 
 class ezJoltCharacterControllerComponent;
+class ezJoltContactListener;
 
 namespace JPH
 {
@@ -81,6 +82,11 @@ public:
   JPH::TempAllocator* GetTempAllocator() const { return m_pTempAllocator.get(); }
 
   void ActivateCharacterController(ezJoltCharacterControllerComponent* pCharacter, bool bActivate);
+
+  ezJoltContactListener* GetContactListener()
+  {
+    return reinterpret_cast<ezJoltContactListener*>(m_pContactListener);
+  }
 
 private:
   bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;


### PR DESCRIPTION
When a world gets cleared, global message handler state remains. This is fixed now, though not very elegantly.
Similarly, when a Jolt trigger was active while a world gets cleared, it could crash. Now triggers properly clean up after themselves to prevent this issue. Again not very elegant, but I might revisit how triggers are integrated, at a later point.