### PR TITLE
Refactored ezPlayer and ezFallbackbackGameState for scene switching

### DIFF
--- a/Code/Engine/Core/WorldSerializer/WorldReader.h
+++ b/Code/Engine/Core/WorldSerializer/WorldReader.h
@@ -45,7 +45,7 @@ class EZ_CORE_DLL ezWorldReader
 public:
   /// \brief A context object is returned from InstantiateWorld or InstantiatePrefab if a maxStepTime greater than zero is specified.
   ///
-  /// Call the Step function periodically until it returns true to complete the instantiation.
+  /// Call the Step() function periodically to complete the instantiation.
   /// Each step will try to spend not more than the given maxStepTime.
   /// E.g. this is useful if the instantiation cost of large prefabs needs to be distributed over multiple frames.
   class InstantiationContextBase
@@ -53,9 +53,9 @@ public:
   public:
     enum class StepResult
     {
-      Continue,
-      ContinueNextFrame,
-      Finished,
+      Continue,          ///< The available time slice is used up. Call Step() again to continue the process.
+      ContinueNextFrame, ///< The process has reached a point where you need to call ezWorld::Update(). Otherwise no further progress can be made.
+      Finished,          ///< The instantiation is finished and you can delete the context. Don't call 'Step()' on it again.
     };
 
     virtual ~InstantiationContextBase() {}

--- a/Code/Engine/GameEngine/GameApplication/GameApplication.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplication.h
@@ -67,6 +67,9 @@ public:
   /// \brief Used at runtime (by the editor) to reload input maps. Forwards to Init_ConfigureInput()
   void ReinitializeInputConfig();
 
+  /// \brief Returns the project path that was given to the constructor (or modified by an overridden implementation).
+  ezStringView GetAppProjectPath() const { return m_sAppProjectPath; }
+
 protected:
   virtual void Init_ConfigureInput() override;
   virtual void Init_ConfigureAssetManagement() override;

--- a/Code/Engine/GameEngine/Utils/Implementation/SceneLoadUtil.cpp
+++ b/Code/Engine/GameEngine/Utils/Implementation/SceneLoadUtil.cpp
@@ -1,0 +1,200 @@
+#include <GameEngine/GameEnginePCH.h>
+
+#include <Core/Assets/AssetFileHeader.h>
+#include <Core/Collection/CollectionResource.h>
+#include <GameEngine/GameApplication/GameApplication.h>
+#include <GameEngine/Utils/SceneLoadUtil.h>
+
+// preloading assets is considered to be the vast majority of scene loading
+constexpr float fCollectionPreloadPiece = 0.9f;
+
+ezSceneLoadUtility::ezSceneLoadUtility() = default;
+ezSceneLoadUtility::~ezSceneLoadUtility() = default;
+
+void ezSceneLoadUtility::StartSceneLoading(ezStringView sSceneFile, ezStringView sPreloadCollectionFile)
+{
+  EZ_ASSERT_DEV(m_LoadingState == LoadingState::NotStarted, "Can't reuse an ezSceneLoadUtility.");
+
+  EZ_LOG_BLOCK("StartSceneLoading");
+
+  m_LoadingState = LoadingState::Ongoing;
+
+  ezStringBuilder sFinalSceneFile = sSceneFile;
+
+  if (sFinalSceneFile.IsEmpty())
+  {
+    LoadingFailed("No scene file specified.");
+    return;
+  }
+
+  ezLog::Info("Loading scene '{}'.", sSceneFile);
+
+  if (sFinalSceneFile.IsAbsolutePath())
+  {
+    // this can fail if the scene is in a different data directory than the project directory
+    // shouldn't stop us from loading it anyway
+    sFinalSceneFile.MakeRelativeTo(ezGameApplication::GetGameApplicationInstance()->GetAppProjectPath()).IgnoreResult();
+  }
+
+  if (sFinalSceneFile.HasExtension("ezScene") || sFinalSceneFile.HasExtension("ezPrefab"))
+  {
+    if (sFinalSceneFile.IsAbsolutePath())
+    {
+      if (ezFileSystem::ResolvePath(sFinalSceneFile, nullptr, &sFinalSceneFile).Failed())
+      {
+        LoadingFailed(ezFmt("Scene path is not located in any data directory: '{}'", sFinalSceneFile));
+        return;
+      }
+    }
+
+    // if this is a path to the non-transformed source file, redirect it to the transformed file in the asset cache
+    sFinalSceneFile.Prepend("AssetCache/Common/");
+    sFinalSceneFile.ChangeFileExtension("ezObjectGraph");
+  }
+
+  if (sFinalSceneFile != sSceneFile)
+  {
+    ezLog::Dev("Redirecting scene file from '{}' to '{}'", sSceneFile, sFinalSceneFile);
+  }
+
+  m_sFile = sFinalSceneFile;
+
+  if (!sPreloadCollectionFile.IsEmpty())
+  {
+    m_hPreloadCollection = ezResourceManager::LoadResource<ezCollectionResource>(ezString(sPreloadCollectionFile));
+  }
+}
+
+ezUniquePtr<ezWorld> ezSceneLoadUtility::RetrieveLoadedScene()
+{
+  EZ_ASSERT_DEV(m_LoadingState == LoadingState::FinishedSuccessfully, "Can't retrieve a scene when loading hasn't finished successfully.");
+
+  return std::move(m_pWorld);
+}
+
+void ezSceneLoadUtility::LoadingFailed(const ezFormatString& reason)
+{
+  EZ_ASSERT_DEV(m_LoadingState == LoadingState::Ongoing, "Invalid loading state");
+  m_LoadingState = LoadingState::Failed;
+
+  ezStringBuilder tmp;
+  m_sFailureReason = reason.GetText(tmp);
+}
+
+void ezSceneLoadUtility::TickSceneLoading()
+{
+  switch (m_LoadingState)
+  {
+    case LoadingState::FinishedSuccessfully:
+    case LoadingState::Failed:
+      return;
+
+    default:
+      break;
+  }
+
+  // update our current loading progress
+  {
+    m_fLoadingProgress = fCollectionPreloadPiece;
+
+    // if we have a collection, preload that first
+    if (m_hPreloadCollection.IsValid())
+    {
+      m_fLoadingProgress = 0.0f;
+
+      ezResourceLock<ezCollectionResource> pCollection(m_hPreloadCollection, ezResourceAcquireMode::AllowLoadingFallback_NeverFail);
+
+      if (pCollection.GetAcquireResult() == ezResourceAcquireResult::Final)
+      {
+        pCollection->PreloadResources();
+
+        float progress = 0.0f;
+        if (pCollection->IsLoadingFinished(&progress))
+        {
+          m_fLoadingProgress = fCollectionPreloadPiece;
+        }
+        else
+        {
+          m_fLoadingProgress = progress * fCollectionPreloadPiece;
+        }
+      }
+    }
+
+    // if preloading the collection is finished (or we just don't have one) add the world instantiation progress
+    if (m_fLoadingProgress == fCollectionPreloadPiece)
+    {
+      m_fLoadingProgress += m_InstantiationProgress.GetCompletion() * (1.0f - fCollectionPreloadPiece);
+    }
+  }
+
+  // as long as we are still pre-loading assets from the collection, don't do anything else
+  if (m_fLoadingProgress < fCollectionPreloadPiece)
+    return;
+
+  // if we haven't created a world yet, do so now, and set up an instantiation context
+  if (m_pWorld == nullptr)
+  {
+    EZ_LOG_BLOCK("LoadObjectGraph", m_sFile);
+
+    ezWorldDesc desc(m_sFile);
+    m_pWorld = EZ_DEFAULT_NEW(ezWorld, desc);
+
+    EZ_LOCK(m_pWorld->GetWriteMarker());
+
+    if (m_FileReader.Open(m_sFile).Failed())
+    {
+      LoadingFailed("Failed to open the file.");
+      return;
+    }
+    else
+    {
+      // Read and skip the asset file header
+      ezAssetFileHeader header;
+      header.Read(m_FileReader).AssertSuccess();
+
+      char szSceneTag[16];
+      m_FileReader.ReadBytes(szSceneTag, sizeof(char) * 16);
+
+      if (!ezStringUtils::IsEqualN(szSceneTag, "[ezBinaryScene]", 16))
+      {
+        LoadingFailed("The given file isn't an object-graph file.");
+        return;
+      }
+
+      if (m_WorldReader.ReadWorldDescription(m_FileReader).Failed())
+      {
+        LoadingFailed("Error reading world description.");
+        return;
+      }
+
+      m_pInstantiationContext = m_WorldReader.InstantiateWorld(*m_pWorld, nullptr, ezTime::Milliseconds(1), &m_InstantiationProgress);
+    }
+  }
+  else if (m_pInstantiationContext)
+  {
+    ezWorldReader::InstantiationContextBase::StepResult res = m_pInstantiationContext->Step();
+
+    if (res == ezWorldReader::InstantiationContextBase::StepResult::ContinueNextFrame)
+    {
+      // TODO: can we finish the world instantiation without updating the entire world?
+      // E.g. only finish component instantiation?
+      // also we may want to step the world only with a very small (and fixed!) time-step
+
+      EZ_LOCK(m_pWorld->GetWriteMarker());
+      m_pWorld->Update();
+    }
+    else if (res == ezWorldReader::InstantiationContextBase::StepResult::Finished)
+    {
+      // TODO: ticking twice seems to fix some Jolt physics issues
+      EZ_LOCK(m_pWorld->GetWriteMarker());
+      m_pWorld->Update();
+
+      m_pInstantiationContext = nullptr;
+      m_LoadingState = LoadingState::FinishedSuccessfully;
+    }
+  }
+  else
+  {
+    EZ_REPORT_FAILURE("Invalid code path.");
+  }
+}

--- a/Code/Engine/GameEngine/Utils/SceneLoadUtil.h
+++ b/Code/Engine/GameEngine/Utils/SceneLoadUtil.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <Core/ResourceManager/ResourceHandle.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Foundation/IO/FileSystem/FileReader.h>
+#include <Foundation/Types/UniquePtr.h>
+#include <Foundation/Utilities/Progress.h>
+#include <GameEngine/GameEngineDLL.h>
+
+using ezCollectionResourceHandle = ezTypedResourceHandle<class ezCollectionResource>;
+
+/// \brief This class allows to load a scene in the background and switch to it, once loading has finished.
+class EZ_GAMEENGINE_DLL ezSceneLoadUtility
+{
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezSceneLoadUtility);
+
+public:
+  ezSceneLoadUtility();
+  ~ezSceneLoadUtility();
+
+  enum class LoadingState
+  {
+    NotStarted,
+    Ongoing,
+    FinishedSuccessfully,
+    Failed,
+  };
+
+  /// \brief Returns whether loading is still ongoing or finished.
+  LoadingState GetLoadingState() const { return m_LoadingState; }
+
+  /// \brief Returns a loading progress value in 0 to 1 range.
+  float GetLoadingProgress() const { return m_fLoadingProgress; }
+
+  /// \brief In case loading failed, this returns what went wrong.
+  ezStringView GetLoadingFailureReason() const { return m_sFailureReason; }
+
+  /// \brief Starts loading a scene. If provided, the assets in the collection are loaded first and then the scene is instantiated.
+  ///
+  /// Using a collection will make loading in the background much smoother. Without it, most assets will be loaded once the scene gets updated
+  /// for the first time, resulting in very long delays.
+  void StartSceneLoading(ezStringView sSceneFile, ezStringView sPreloadCollectionFile);
+
+  /// \brief This has to be called periodically (usually once per frame) to progress the scene loading.
+  ///
+  /// Call GetLoadingState() afterwards to check whether loading has finished or failed.
+  void TickSceneLoading();
+
+  /// \brief Once loading is finished successfully, call this to take ownership of the loaded scene.
+  ///
+  /// Afterwards there is no point in keeping the ezSceneLoadUtility around anymore and it should be deleted.
+  ezUniquePtr<ezWorld> RetrieveLoadedScene();
+
+private:
+  void LoadingFailed(const ezFormatString& reason);
+
+  LoadingState m_LoadingState = LoadingState::NotStarted;
+  float m_fLoadingProgress = 0.0f;
+  ezString m_sFailureReason;
+
+  ezString m_sFile;
+  ezCollectionResourceHandle m_hPreloadCollection;
+  ezFileReader m_FileReader;
+  ezWorldReader m_WorldReader;
+  ezUniquePtr<ezWorld> m_pWorld;
+  ezUniquePtr<ezWorldReader::InstantiationContextBase> m_pInstantiationContext;
+  ezProgress m_InstantiationProgress;
+};

--- a/Code/Samples/Asteroids/GameState.cpp
+++ b/Code/Samples/Asteroids/GameState.cpp
@@ -120,13 +120,9 @@ void AsteroidGameState::DestroyLevel()
   m_pLevel = nullptr;
 }
 
-
-
 ezGameStatePriority AsteroidGameState::DeterminePriority(ezWorld* pWorld) const
 {
-  return
-
-    ezGameStatePriority::Default;
+  return ezGameStatePriority::Default;
 }
 
 void AsteroidGameState::ProcessInput()

--- a/Code/Samples/RtsGamePlugin/GameState/RtsGameState.h
+++ b/Code/Samples/RtsGamePlugin/GameState/RtsGameState.h
@@ -30,10 +30,7 @@ public:
   //////////////////////////////////////////////////////////////////////////
   // Initialization & Setup
 public:
-  virtual
-
-    ezGameStatePriority
-    DeterminePriority(ezWorld* pWorld) const override;
+  virtual ezGameStatePriority DeterminePriority(ezWorld* pWorld) const override;
 
 private:
   virtual void OnActivation(ezWorld* pWorld, const ezTransform* pStartPosition) override;

--- a/Code/Samples/SampleGamePlugin/GameState/SampleGameState.cpp
+++ b/Code/Samples/SampleGamePlugin/GameState/SampleGameState.cpp
@@ -120,8 +120,6 @@ void SampleGameState::BeforeWorldUpdate()
 #endif
 }
 
-
-
 ezGameStatePriority SampleGameState::DeterminePriority(ezWorld* pWorld) const
 {
   return ezGameStatePriority::Default;

--- a/Code/Tools/Player/Player.cpp
+++ b/Code/Tools/Player/Player.cpp
@@ -22,6 +22,7 @@
 // this injects the main function
 EZ_APPLICATION_ENTRY_POINT(ezPlayerApplication);
 
+// these command line options may not all be directly used in ezPlayer, but the ezFallbackGameState reads those options to determine which scene to load
 ezCommandLineOptionString opt_Project("_Player", "-project", "Path to the project folder.\nUsually an absolute path, though relative paths will work for projects that are located inside the EZ SDK directory.", "");
 ezCommandLineOptionString opt_Scene("_Player", "-scene", "Path to a scene file.\nUsually given relative to the corresponding project data directory where it resides, but can also be given as an absolute path.", "");
 
@@ -32,6 +33,7 @@ ezPlayerApplication::ezPlayerApplication()
 
 ezResult ezPlayerApplication::BeforeCoreSystemsStartup()
 {
+  // show the command line options, if help is requested
   {
     // since this is a GUI application (not a console app), printf has no effect
     // therefore we have to show the command line options with a message box
@@ -49,16 +51,7 @@ ezResult ezPlayerApplication::BeforeCoreSystemsStartup()
 
   EZ_SUCCEED_OR_RETURN(SUPER::BeforeCoreSystemsStartup());
 
-  m_State = State::Ok;
-
-  if (DetermineProjectPath().Succeeded())
-  {
-    if (DetermineScenePath().Failed())
-    {
-      m_State = State::NoScene;
-      m_Menu = Menu::SceneSelection;
-    }
-  }
+  DetermineProjectPath();
 
   return EZ_SUCCESS;
 }
@@ -70,33 +63,11 @@ void ezPlayerApplication::AfterCoreSystemsStartup()
 
   ezStartup::StartupHighLevelSystems();
 
-  // create the ezWorld into which we load all levels
-  ezWorldDesc desc("MainWorld");
-  m_pWorld = EZ_DEFAULT_NEW(ezWorld, desc);
-
-  if (m_State == State::Ok)
-  {
-    if (LoadScene(m_sSceneFile).Failed())
-    {
-      m_State = State::BadScene;
-      m_Menu = Menu::None;
-      SetReturnCode(2);
-    }
-  }
-
-  if (GetActiveGameState() == nullptr)
-  {
-    // if no scene was loaded (yet), still create a game-state, because that one creates the app's window
-    // otherwise we won't see anything and can't interact with the menu
-    ActivateGameState(m_pWorld.Borrow()).IgnoreResult();
-  }
-}
-
-void ezPlayerApplication::BeforeHighLevelSystemsShutdown()
-{
-  SUPER::BeforeHighLevelSystemsShutdown();
-
-  m_pWorld.Clear();
+  // we need a game state to do anything
+  // if no custom game state is available, ezFallbackGameState will be used
+  // the game state is also responsible for either creating a world, or loading it
+  // the ezFallbackGameState inspects the command line to figure out which scene to load
+  ActivateGameState(nullptr).AssertSuccess();
 }
 
 void ezPlayerApplication::Run_InputUpdate()
@@ -107,24 +78,9 @@ void ezPlayerApplication::Run_InputUpdate()
   {
     RequestQuit();
   }
-
-  if (ezStringUtils::IsNullOrEmpty(ezInputManager::GetExclusiveInputSet()) ||
-      ezStringUtils::IsEqual(ezInputManager::GetExclusiveInputSet(), "ezPlayer"))
-  {
-    if (DisplayMenu())
-    {
-      // prevents the currently active scene from getting any input
-      ezInputManager::SetExclusiveInputSet("ezPlayer");
-    }
-    else
-    {
-      // allows the active scene to retrieve input again
-      ezInputManager::SetExclusiveInputSet("");
-    }
-  }
 }
 
-ezResult ezPlayerApplication::DetermineProjectPath()
+void ezPlayerApplication::DetermineProjectPath()
 {
   ezStringBuilder sProjectPath = opt_Project.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
 
@@ -136,7 +92,7 @@ ezResult ezPlayerApplication::DetermineProjectPath()
   if (sProjectPath.IsEmpty())
   {
     m_sAppProjectPath = ">project";
-    return EZ_SUCCESS;
+    return;
   }
 #endif
 
@@ -149,19 +105,17 @@ ezResult ezPlayerApplication::DetermineProjectPath()
     if (!sScenePath.IsAbsolutePath())
     {
       // scene path is not absolute -> can't extract project path
-      m_State = State::NoProject;
       m_sAppProjectPath = ezFileSystem::GetSdkRootDirectory();
       SetReturnCode(1);
-      return EZ_FAILURE;
+      return;
     }
 
     if (ezFileSystem::FindFolderWithSubPath(sProjectPath, sScenePath, "ezProject", "ezSdkRoot.txt").Failed())
     {
       // couldn't find the 'ezProject' file in any parent folder of the scene
-      m_State = State::NoProject;
       m_sAppProjectPath = ezFileSystem::GetSdkRootDirectory();
       SetReturnCode(1);
-      return EZ_FAILURE;
+      return;
     }
   }
   else if (!ezPathUtils::IsAbsolutePath(sProjectPath))
@@ -175,10 +129,9 @@ ezResult ezPlayerApplication::DetermineProjectPath()
 
   if (sProjectPath.IsEmpty())
   {
-    m_State = State::NoProject;
     m_sAppProjectPath = ezFileSystem::GetSdkRootDirectory();
     SetReturnCode(1);
-    return EZ_FAILURE;
+    return;
   }
 
   // store it now, even if it fails, for error reporting
@@ -186,265 +139,7 @@ ezResult ezPlayerApplication::DetermineProjectPath()
 
   if (!ezOSFile::ExistsDirectory(sProjectPath))
   {
-    m_State = State::BadProject;
     SetReturnCode(1);
-    return EZ_FAILURE;
-  }
-
-  return EZ_SUCCESS;
-}
-
-ezResult ezPlayerApplication::DetermineScenePath()
-{
-  ezStringBuilder sScenePath = opt_Scene.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
-
-#if EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)
-  // TODO: We can't specify command line arguments on many platforms so the scene file is currently hardcoded
-  if (sScenePath.IsEmpty())
-  {
-    m_sSceneFile = "Scenes/Empty.ezScene";
-    return EZ_SUCCESS;
-  }
-#endif
-
-  sScenePath.MakeCleanPath();
-
-  if (sScenePath.IsEmpty())
-    return EZ_FAILURE;
-
-  if (sScenePath.IsAbsolutePath())
-  {
-    // this is just to make the path shorter, when possible
-    // but can fail if the scene is in another data directory
-    sScenePath.MakeRelativeTo(m_sAppProjectPath).IgnoreResult();
-  }
-
-  m_sSceneFile = sScenePath;
-  return EZ_SUCCESS;
-}
-
-ezResult ezPlayerApplication::LoadScene(const char* szFile)
-{
-  EZ_LOG_BLOCK("LoadScene", szFile);
-
-  ezStringBuilder sSceneFile = szFile;
-
-  if (sSceneFile.IsEmpty())
-  {
-    ezLog::Error("No scene file specified.");
-    return EZ_FAILURE;
-  }
-
-  ezLog::Info("Loading scene '{}'.", szFile);
-
-  if (sSceneFile.IsAbsolutePath())
-  {
-    // this can fail if the scene is in a different data directory than the project directory
-    // shouldn't stop us from loading it anyway
-    sSceneFile.MakeRelativeTo(m_sAppProjectPath).IgnoreResult();
-  }
-
-  if (sSceneFile.HasExtension("ezScene") || sSceneFile.HasExtension("ezPrefab"))
-  {
-    if (sSceneFile.IsRelativePath())
-    {
-      // if this is a path to the non-transformed source file, redirect it to the transformed file in the asset cache
-      sSceneFile.Prepend("AssetCache/Common/");
-      sSceneFile.ChangeFileExtension("ezObjectGraph");
-    }
-  }
-
-  if (sSceneFile != szFile)
-  {
-    ezLog::Info("Redirecting scene file from '{}' to '{}'", szFile, sSceneFile);
-  }
-
-  EZ_SUCCEED_OR_RETURN(LoadObjectGraph(sSceneFile));
-
-  // (re-)create the game-state
-  // this is either custom game code, or the ezFallbackGameState
-  // it is responsible for creating the main window, setting up the input devices
-  // and adding high-level game logic
-  {
-    DeactivateGameState();
-    ActivateGameState(m_pWorld.Borrow()).IgnoreResult();
-  }
-
-  ezLog::Success("Successfully loaded scene.");
-  return EZ_SUCCESS;
-}
-
-ezResult ezPlayerApplication::LoadObjectGraph(const char* szFile)
-{
-  EZ_LOG_BLOCK("LoadObjectGraph", szFile);
-
-  EZ_ASSERT_DEV(m_pWorld != nullptr, "ezWorld must be created before loading anything into it.");
-  EZ_LOCK(m_pWorld->GetWriteMarker());
-
-  // make sure the world is empty
-  m_pWorld->Clear();
-
-  ezFileReader file;
-
-  if (file.Open(szFile).Failed())
-  {
-    ezLog::Error("Failed to open the file.");
-    return EZ_FAILURE;
-  }
-
-  // Read and skip the asset file header
-  {
-    ezAssetFileHeader header;
-    header.Read(file).AssertSuccess();
-
-    char szSceneTag[16];
-    file.ReadBytes(szSceneTag, sizeof(char) * 16);
-
-    if (!ezStringUtils::IsEqualN(szSceneTag, "[ezBinaryScene]", 16))
-    {
-      ezLog::Error("The given file isn't an object-graph file.");
-      return EZ_FAILURE;
-    }
-  }
-
-  ezWorldReader reader;
-  if (reader.ReadWorldDescription(file).Failed())
-  {
-    ezLog::Error("Error reading world description.");
-    return EZ_FAILURE;
-  }
-
-  reader.InstantiateWorld(*m_pWorld, nullptr);
-  return EZ_SUCCESS;
-}
-
-void ezPlayerApplication::FindAvailableScenes()
-{
-  if (m_bCheckedForScenes)
     return;
-
-  m_bCheckedForScenes = true;
-
-#if EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS)
-  ezFileSystemIterator fsit;
-  ezStringBuilder sScenePath;
-
-  for (ezFileSystem::StartSearch(fsit, "", ezFileSystemIteratorFlags::ReportFilesRecursive);
-       fsit.IsValid(); fsit.Next())
-  {
-    fsit.GetStats().GetFullPath(sScenePath);
-
-    if (!sScenePath.HasExtension(".ezScene"))
-      continue;
-
-    sScenePath.MakeRelativeTo(fsit.GetCurrentSearchTerm()).AssertSuccess();
-
-    m_AvailableScenes.PushBack(sScenePath);
   }
-#endif
-}
-
-bool ezPlayerApplication::DisplayMenu()
-{
-  if (m_State == State::NoProject)
-  {
-    ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", "No project path provided.\n\nUse the command-line argument\n-project \"Path/To/ezProject\"\nto tell ezPlayer which project to load.\n\nWith the argument\n-scene \"Path/To/Scene.ezScene\"\nyou can also directly load a specific scene.\n\nPress ESC to quit.", ezColor::Red);
-
-    return false;
-  }
-
-  if (m_State == State::BadProject)
-  {
-    ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", ezFmt("Invalid project path provided.\nThe given project directory does not exist:\n\n{}\n\nPress ESC to quit.", m_sAppProjectPath), ezColor::Red);
-
-    return false;
-  }
-
-  if (ezInputManager::GetInputSlotState(ezInputSlot_KeyLeftWin) == ezKeyState::Pressed || ezInputManager::GetInputSlotState(ezInputSlot_KeyRightWin) == ezKeyState::Pressed)
-  {
-    if (m_Menu == Menu::SceneSelection)
-      m_Menu = Menu::None;
-    else
-      m_Menu = Menu::SceneSelection;
-  }
-
-  if (m_State == State::Ok && m_Menu == Menu::None)
-    return false;
-
-  ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", ezFmt("Project: '{}'", m_sAppProjectPath), ezColor::White);
-
-  if (m_State == State::BadScene)
-  {
-    ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", ezFmt("Failed to load scene: '{}'", m_sSceneFile), ezColor::Red);
-  }
-  else
-  {
-    ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", ezFmt("Scene: '{}'", m_sSceneFile), ezColor::White);
-  }
-
-  if (m_Menu == Menu::SceneSelection)
-  {
-    FindAvailableScenes();
-
-    ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", "\nSelect scene:\n", ezColor::White);
-
-    for (ezUInt32 i = 0; i < m_AvailableScenes.GetCount(); ++i)
-    {
-      const auto& file = m_AvailableScenes[i];
-
-      if (i == m_uiSelectedScene)
-      {
-        ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", ezFmt("> {} <", file), ezColor::Gold);
-      }
-      else
-      {
-        ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", ezFmt("  {}  ", file), ezColor::GhostWhite);
-      }
-    }
-
-    ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugRenderer::ScreenPlacement::TopCenter, "_Player", "\nPress 'Return' to load scene.\nPress the 'Windows' key to toggle this menu.", ezColor::White);
-
-    if (ezInputManager::GetInputSlotState(ezInputSlot_KeyEscape) == ezKeyState::Pressed)
-    {
-      m_Menu = Menu::None;
-    }
-    else if (!m_AvailableScenes.IsEmpty())
-    {
-      if (ezInputManager::GetInputSlotState(ezInputSlot_KeyUp) == ezKeyState::Pressed)
-      {
-        if (m_uiSelectedScene == 0)
-          m_uiSelectedScene = m_AvailableScenes.GetCount() - 1;
-        else
-          --m_uiSelectedScene;
-      }
-
-      if (ezInputManager::GetInputSlotState(ezInputSlot_KeyDown) == ezKeyState::Pressed)
-      {
-        if (m_uiSelectedScene == m_AvailableScenes.GetCount() - 1)
-          m_uiSelectedScene = 0;
-        else
-          ++m_uiSelectedScene;
-      }
-
-      if (ezInputManager::GetInputSlotState(ezInputSlot_KeyReturn) == ezKeyState::Pressed || ezInputManager::GetInputSlotState(ezInputSlot_KeyNumpadEnter) == ezKeyState::Pressed)
-      {
-        m_sSceneFile = m_AvailableScenes[m_uiSelectedScene];
-
-        if (LoadScene(m_AvailableScenes[m_uiSelectedScene]).Succeeded())
-        {
-          m_State = State::Ok;
-          m_Menu = Menu::None;
-        }
-        else
-        {
-          m_State = State::BadScene;
-          m_Menu = Menu::SceneSelection;
-        }
-      }
-
-      return true;
-    }
-  }
-
-  return false;
 }

--- a/Code/Tools/Player/Player.h
+++ b/Code/Tools/Player/Player.h
@@ -13,46 +13,7 @@ protected:
   virtual void Run_InputUpdate() override;
   virtual ezResult BeforeCoreSystemsStartup() override;
   virtual void AfterCoreSystemsStartup() override;
-  virtual void BeforeHighLevelSystemsShutdown() override;
 
 private:
-  ezResult DetermineProjectPath();
-  ezResult DetermineScenePath();
-
-  /// \brief Attempts to load an '.ezScene' or '.ezPrefab' file into the main world.
-  ezResult LoadScene(const char* szSceneFile);
-
-  /// \brief Attempts to load an '.ezObjectGraph' file into the main world.
-  ezResult LoadObjectGraph(const char* szFile);
-
-  /// \brief Finds all available '.ezScene' files in this project.
-  ///
-  /// Note that only files that are properly 'transformed', ie have corresponding '.ezObjectGraph' files, will be loadable.
-  void FindAvailableScenes();
-
-  bool DisplayMenu();
-
-  enum class State
-  {
-    Ok,
-    NoProject,
-    BadProject,
-    NoScene,
-    BadScene,
-  };
-
-  enum class Menu
-  {
-    None,
-    SceneSelection,
-  };
-
-  State m_State = State::Ok;
-  Menu m_Menu = Menu::None;
-
-  ezString m_sSceneFile;
-  ezUniquePtr<ezWorld> m_pWorld;
-  bool m_bCheckedForScenes = false;
-  ezDynamicArray<ezString> m_AvailableScenes;
-  ezUInt32 m_uiSelectedScene = 0;
+  void DetermineProjectPath();
 };


### PR DESCRIPTION
ezPlayer now does nearly nothing. Nearly all functionality is now the responsibility of the game state. Therefore, the convenience functionality of selecting a scene, and also determining which scene to start with, is left to the ezFallbackGameState. If users derive their game state from that, they also get this convenience functionality, but if it is unwanted, they can derive from another base class.

This gives way more control to custom game states running inside ezPlayer.

Additionally, a scene loading utility was added, which makes it easy to load a scene from file in the background. ezFallbackGameState has a bit of infrastructure to load one scene in the background and switch to it when ready. This functionality is subject to further refinement in the (near) future.