### PR TITLE
Fix assert during RMB in script editor

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -334,7 +334,13 @@ void ezQtMaterialAssetDocumentWindow::SelectionEventHandler(const ezSelectionMan
   if (GetDocument()->GetSelectionManager()->IsSelectionEmpty())
   {
     // delayed execution
-    QTimer::singleShot(1, [this]() { GetDocument()->GetSelectionManager()->SetSelection(GetMaterialDocument()->GetPropertyObject()); });
+    QTimer::singleShot(1, [this]() {
+      // Check again if the selection is empty. This could have changed due to the delayed execution.
+      if (GetDocument()->GetSelectionManager()->IsSelectionEmpty())
+      {
+        GetDocument()->GetSelectionManager()->SetSelection(GetMaterialDocument()->GetPropertyObject());
+      }
+    });
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetWindow.cpp
@@ -169,6 +169,12 @@ void ezQtVisualScriptAssetDocumentWindow::SelectionEventHandler(const ezSelectio
   if (GetDocument()->GetSelectionManager()->IsSelectionEmpty())
   {
     // delayed execution
-    QTimer::singleShot(1, [this]() { GetDocument()->GetSelectionManager()->SetSelection(GetVisualScriptDocument()->GetPropertyObject()); });
+    QTimer::singleShot(1, [this]() {
+      // Check again if the selection is empty. This could have changed due to the delayed execution.
+      if (GetDocument()->GetSelectionManager()->IsSelectionEmpty())
+      {
+        GetDocument()->GetSelectionManager()->SetSelection(GetVisualScriptDocument()->GetPropertyObject());
+      }
+    });
   }
 }

--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
@@ -881,7 +881,10 @@ void ezQtNodeScene::OnSelectionChanged()
     }
   }
 
-  m_bIgnoreSelectionChange = true;
-  m_pManager->GetDocument()->GetSelectionManager()->SetSelection(m_Selection);
-  m_bIgnoreSelectionChange = false;
+  if (!m_bIgnoreSelectionChange)
+  {
+    m_bIgnoreSelectionChange = true;
+    m_pManager->GetDocument()->GetSelectionManager()->SetSelection(m_Selection);
+    m_bIgnoreSelectionChange = false;
+  }
 }


### PR DESCRIPTION
* Fixes #852
* Recursion check was missing in ezQtNodeScene::OnSelectionChanged
* Delayed selection change was messing up the selection as the precondition was checked before the delayed execution but not after. Thus, calling clear() and then select() on a single node would then clear again on idle.