### PR TITLE
Added a component for propagating 'power flow' through cables

### DIFF
--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.cpp
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.cpp
@@ -52,6 +52,29 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgPhysicsJointBroke, 1, ezRTTIDefaultAllocato
 //}
 EZ_END_DYNAMIC_REFLECTED_TYPE
 
+EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgObjectGrabbed);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgObjectGrabbed, 1, ezRTTIDefaultAllocator<ezMsgObjectGrabbed>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("GrabbedBy", m_hGrabbedBy),
+    EZ_MEMBER_PROPERTY("GotGrabbed", m_bGotGrabbed),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgReleaseObjectGrab);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgReleaseObjectGrab, 1, ezRTTIDefaultAllocator<ezMsgReleaseObjectGrab>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("GrabbedObjectToRelease", m_hGrabbedObjectToRelease),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 //////////////////////////////////////////////////////////////////////////
 
 EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgBuildStaticMesh);

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -186,7 +186,7 @@ struct EZ_CORE_DLL ezMsgPhysicsJointBroke : public ezEventMessage
 };
 
 /// \brief Sent by components such as ezJoltGrabObjectComponent to indicate that the object has been grabbed or released.
-class EZ_CORE_DLL ezMsgObjectGrabbed : public ezMessage
+struct EZ_CORE_DLL ezMsgObjectGrabbed : public ezMessage
 {
   EZ_DECLARE_MESSAGE_TYPE(ezMsgObjectGrabbed, ezMessage);
 
@@ -195,7 +195,7 @@ class EZ_CORE_DLL ezMsgObjectGrabbed : public ezMessage
 };
 
 /// \brief Send this to components such as ezJoltGrabObjectComponent to demand that m_hGrabbedObjectToRelease should no longer be grabbed.
-class EZ_CORE_DLL ezMsgReleaseObjectGrab : public ezMessage
+struct EZ_CORE_DLL ezMsgReleaseObjectGrab : public ezMessage
 {
   EZ_DECLARE_MESSAGE_TYPE(ezMsgReleaseObjectGrab, ezMessage);
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/PowerConnectorComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/PowerConnectorComponent.cpp
@@ -2,6 +2,8 @@
 
 #include <Core/Interfaces/PhysicsWorldModule.h>
 #include <Core/Messages/SetColorMessage.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
 #include <GameComponentsPlugin/Gameplay/PowerConnectorComponent.h>
 
 // clang-format off

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/PowerConnectorComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/PowerConnectorComponent.cpp
@@ -1,5 +1,6 @@
 #include <GameComponentsPlugin/GameComponentsPCH.h>
 
+#include <Core/Interfaces/PhysicsWorldModule.h>
 #include <Core/Messages/SetColorMessage.h>
 #include <GameComponentsPlugin/Gameplay/PowerConnectorComponent.h>
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/PowerConnectorComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/PowerConnectorComponent.cpp
@@ -1,0 +1,385 @@
+#include <GameComponentsPlugin/GameComponentsPCH.h>
+
+#include <Core/Messages/SetColorMessage.h>
+#include <GameComponentsPlugin/Gameplay/PowerConnectorComponent.h>
+
+// clang-format off
+EZ_IMPLEMENT_MESSAGE_TYPE(ezEventMsgSetPowerInput);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEventMsgSetPowerInput, 1, ezRTTIDefaultAllocator<ezEventMsgSetPowerInput>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("PrevValue", m_uiPrevValue),
+    EZ_MEMBER_PROPERTY("NewValue", m_uiNewValue),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+      new ezAutoGenVisScriptMsgHandler()
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_COMPONENT_TYPE(ezPowerConnectorComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Output", GetOutput, SetOutput),
+    EZ_ACCESSOR_PROPERTY("Buddy", DummyGetter, SetBuddyReference)->AddAttributes(new ezGameObjectReferenceAttribute()),
+    EZ_ACCESSOR_PROPERTY("ConnectedTo", DummyGetter, SetConnectedToReference)->AddAttributes(new ezGameObjectReferenceAttribute()),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgSensorDetectedObjectsChanged, OnMsgSensorDetectedObjectsChanged),
+    EZ_MESSAGE_HANDLER(ezMsgObjectGrabbed, OnMsgObjectGrabbed),
+  }
+  EZ_END_MESSAGEHANDLERS;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("Gameplay"),
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_COMPONENT_TYPE;
+// clang-format on
+
+void ezPowerConnectorComponent::SerializeComponent(ezWorldWriter& stream) const
+{
+  SUPER::SerializeComponent(stream);
+
+  auto& s = stream.GetStream();
+
+  stream.WriteGameObjectHandle(m_hBuddy);
+  stream.WriteGameObjectHandle(m_hConnectedTo);
+
+  s << m_uiOutput;
+}
+
+void ezPowerConnectorComponent::DeserializeComponent(ezWorldReader& stream)
+{
+  SUPER::DeserializeComponent(stream);
+
+  auto& s = stream.GetStream();
+
+  m_hBuddy = stream.ReadGameObjectHandle();
+  m_hConnectedTo = stream.ReadGameObjectHandle();
+
+  s >> m_uiOutput;
+}
+
+void ezPowerConnectorComponent::ConnectToSocket(ezGameObjectHandle hSocket)
+{
+  if (IsConnected())
+    return;
+
+  if (GetOwner()->GetWorld()->GetClock().GetAccumulatedTime() - m_DetachTime < ezTime::Seconds(1))
+  {
+    // recently detached -> wait a bit before allowing to attach again
+    return;
+  }
+
+  Attach(hSocket);
+}
+
+void ezPowerConnectorComponent::SetOutput(ezUInt16 value)
+{
+  if (m_uiOutput == value)
+    return;
+
+  m_uiOutput = value;
+
+  OutputChanged(m_uiOutput);
+}
+
+void ezPowerConnectorComponent::SetInput(ezUInt16 value)
+{
+  if (m_uiInput == value)
+    return;
+
+  InputChanged(m_uiInput, value);
+  m_uiInput = value;
+}
+
+void ezPowerConnectorComponent::SetBuddyReference(const char* szReference)
+{
+  auto resolver = GetWorld()->GetGameObjectReferenceResolver();
+
+  if (!resolver.IsValid())
+    return;
+
+  SetBuddy(resolver(szReference, GetHandle(), "Buddy"));
+}
+
+void ezPowerConnectorComponent::SetBuddy(ezGameObjectHandle hNewBuddy)
+{
+  if (m_hBuddy == hNewBuddy)
+    return;
+
+  if (!IsActiveAndInitialized())
+  {
+    m_hBuddy = hNewBuddy;
+    return;
+  }
+
+  ezGameObjectHandle hPrevBuddy = m_hBuddy;
+  m_hBuddy = {};
+
+  ezGameObject* pBuddy;
+  if (GetOwner()->GetWorld()->TryGetObject(hPrevBuddy, pBuddy))
+  {
+    ezPowerConnectorComponent* pConnector;
+    if (pBuddy->TryGetComponentOfBaseType(pConnector))
+    {
+      pConnector->SetOutput(0);
+      pConnector->SetBuddy({});
+    }
+  }
+
+  m_hBuddy = hNewBuddy;
+
+  if (GetOwner()->GetWorld()->TryGetObject(hNewBuddy, pBuddy))
+  {
+    ezPowerConnectorComponent* pConnector;
+    if (pBuddy->TryGetComponentOfBaseType(pConnector))
+    {
+      pConnector->SetBuddy(GetOwner()->GetHandle());
+      pConnector->SetOutput(m_uiInput);
+    }
+  }
+}
+
+void ezPowerConnectorComponent::SetConnectedToReference(const char* szReference)
+{
+  auto resolver = GetWorld()->GetGameObjectReferenceResolver();
+
+  if (!resolver.IsValid())
+    return;
+
+  SetConnectedTo(resolver(szReference, GetHandle(), "ConnectedTo"));
+}
+
+void ezPowerConnectorComponent::SetConnectedTo(ezGameObjectHandle hNewConnectedTo)
+{
+  if (m_hConnectedTo == hNewConnectedTo)
+    return;
+
+  if (!IsActiveAndInitialized())
+  {
+    m_hConnectedTo = hNewConnectedTo;
+    return;
+  }
+
+  ezGameObjectHandle hPrevConnectedTo = m_hConnectedTo;
+  m_hConnectedTo = {};
+
+  ezGameObject* pConnectedTo;
+  if (GetOwner()->GetWorld()->TryGetObject(hPrevConnectedTo, pConnectedTo))
+  {
+    ezPowerConnectorComponent* pConnector;
+    if (pConnectedTo->TryGetComponentOfBaseType(pConnector))
+    {
+      pConnector->SetInput(0);
+      pConnector->SetConnectedTo({});
+    }
+  }
+
+  m_hConnectedTo = hNewConnectedTo;
+
+  if (GetOwner()->GetWorld()->TryGetObject(hNewConnectedTo, pConnectedTo))
+  {
+    ezPowerConnectorComponent* pConnector;
+    if (pConnectedTo->TryGetComponentOfBaseType(pConnector))
+    {
+      pConnector->SetConnectedTo(GetOwner()->GetHandle());
+      pConnector->SetInput(m_uiOutput);
+    }
+  }
+
+  if (hNewConnectedTo.IsInvalidated() && IsAttached())
+  {
+    // make sure that if we get disconnected, we also clean up our detachment state
+    Detach();
+  }
+}
+
+bool ezPowerConnectorComponent::IsConnected() const
+{
+  // since connectors automatically disconnect themselves from their peers upon destruction, this should be sufficient (no need to check object for existence)
+  return !m_hConnectedTo.IsInvalidated();
+}
+
+bool ezPowerConnectorComponent::IsAttached() const
+{
+  return !m_hAttachPoint.IsInvalidated();
+}
+
+void ezPowerConnectorComponent::OnDeactivated()
+{
+  Detach();
+  SetBuddy({});
+
+  SUPER::OnDeactivated();
+}
+
+void ezPowerConnectorComponent::OnSimulationStarted()
+{
+  SUPER::OnSimulationStarted();
+
+  ezGameObjectHandle hAlreadyConnectedTo = m_hConnectedTo;
+  m_hConnectedTo.Invalidate();
+
+  if (!hAlreadyConnectedTo.IsInvalidated())
+  {
+    Attach(hAlreadyConnectedTo);
+  }
+
+  if (m_uiInput != 0)
+  {
+    InputChanged(0, m_uiInput);
+  }
+
+  if (m_uiOutput != 0)
+  {
+    OutputChanged(m_uiOutput);
+  }
+}
+
+void ezPowerConnectorComponent::OnMsgSensorDetectedObjectsChanged(ezMsgSensorDetectedObjectsChanged& msg)
+{
+  if (!msg.m_DetectedObjects.IsEmpty())
+  {
+    ConnectToSocket(msg.m_DetectedObjects[0]);
+  }
+}
+
+void ezPowerConnectorComponent::OnMsgObjectGrabbed(ezMsgObjectGrabbed& msg)
+{
+  if (msg.m_bGotGrabbed)
+  {
+    Detach();
+
+    m_hGrabbedBy = msg.m_hGrabbedBy;
+
+    if (ezGameObject* pSensor = GetOwner()->FindChildByName("ActiveWhenGrabbed"))
+    {
+      pSensor->SetActiveFlag(true);
+    }
+  }
+  else
+  {
+    m_hGrabbedBy.Invalidate();
+
+    if (ezGameObject* pSensor = GetOwner()->FindChildByName("ActiveWhenGrabbed"))
+    {
+      pSensor->SetActiveFlag(false);
+    }
+  }
+}
+
+void ezPowerConnectorComponent::Attach(ezGameObjectHandle hSocket)
+{
+  ezWorld* pWorld = GetOwner()->GetWorld();
+
+  ezGameObject* pSocket;
+  if (!pWorld->TryGetObject(hSocket, pSocket))
+    return;
+
+  ezPowerConnectorComponent* pConnector;
+  if (pSocket->TryGetComponentOfBaseType(pConnector))
+  {
+    // don't connect to an already connected object
+    if (pConnector->IsConnected())
+      return;
+  }
+
+  const ezTransform tSocket = pSocket->GetGlobalTransform();
+
+  ezGameObjectDesc go;
+  go.m_hParent = hSocket;
+
+  ezGameObject* pAttach;
+  m_hAttachPoint = pWorld->CreateObject(go, pAttach);
+
+  ezPhysicsWorldModuleInterface* pPhysicsWorldModule = GetWorld()->GetOrCreateModule<ezPhysicsWorldModuleInterface>();
+
+  ezPhysicsWorldModuleInterface::FixedJointConfig cfg;
+  cfg.m_hActorA = {};
+  cfg.m_hActorB = GetOwner()->GetHandle();
+  cfg.m_LocalFrameA = tSocket;
+  pPhysicsWorldModule->AddFixedJointComponent(pAttach, cfg);
+
+  SetConnectedTo(hSocket);
+
+  if (!m_hGrabbedBy.IsInvalidated())
+  {
+    ezGameObject* pGrab;
+    if (pWorld->TryGetObject(m_hGrabbedBy, pGrab))
+    {
+      ezMsgReleaseObjectGrab msg;
+      msg.m_hGrabbedObjectToRelease = GetOwner()->GetHandle();
+      pGrab->SendMessage(msg);
+    }
+  }
+}
+
+void ezPowerConnectorComponent::Detach()
+{
+  if (IsConnected())
+  {
+    m_DetachTime = GetOwner()->GetWorld()->GetClock().GetAccumulatedTime();
+
+    SetConnectedTo({});
+  }
+
+  if (!m_hAttachPoint.IsInvalidated())
+  {
+    GetOwner()->GetWorld()->DeleteObjectDelayed(m_hAttachPoint, false);
+    m_hAttachPoint.Invalidate();
+  }
+}
+
+void ezPowerConnectorComponent::InputChanged(ezUInt16 uiPrevInput, ezUInt16 uiInput)
+{
+  if (!IsActiveAndSimulating())
+    return;
+
+  ezEventMsgSetPowerInput msg;
+  msg.m_uiPrevValue = uiPrevInput;
+  msg.m_uiNewValue = uiInput;
+
+  GetOwner()->PostEventMessage(msg, this, ezTime());
+
+  if (m_hBuddy.IsInvalidated())
+    return;
+
+  ezGameObject* pBuddy;
+  if (GetOwner()->GetWorld()->TryGetObject(m_hBuddy, pBuddy))
+  {
+    ezPowerConnectorComponent* pConnector;
+    if (pBuddy->TryGetComponentOfBaseType(pConnector))
+    {
+      pConnector->SetOutput(uiInput);
+    }
+  }
+}
+
+void ezPowerConnectorComponent::OutputChanged(ezUInt16 uiOutput)
+{
+  if (!IsActiveAndSimulating())
+    return;
+
+  if (m_hConnectedTo.IsInvalidated())
+    return;
+
+  ezGameObject* pConnectedTo;
+  if (GetOwner()->GetWorld()->TryGetObject(m_hConnectedTo, pConnectedTo))
+  {
+    ezPowerConnectorComponent* pConnector;
+    if (pConnectedTo->TryGetComponentOfBaseType(pConnector))
+    {
+      pConnector->SetInput(uiOutput);
+    }
+  }
+}

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/PowerConnectorComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/PowerConnectorComponent.h
@@ -2,6 +2,9 @@
 #include <GameComponentsPlugin/GameComponentsDLL.h>
 #include <GameEngine/AI/SensorComponent.h>
 
+struct ezMsgObjectGrabbed;
+struct ezMsgSensorDetectedObjectsChanged;
+
 /// \brief This event is posted by ezPowerConnectorComponent whenever the power input on a connector changes.
 ///
 /// When a connector gets input through it's connection to another connector, this message is sent.

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/PowerConnectorComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/PowerConnectorComponent.h
@@ -1,0 +1,122 @@
+#include <Core/World/Component.h>
+#include <GameComponentsPlugin/GameComponentsDLL.h>
+#include <GameEngine/AI/SensorComponent.h>
+
+/// \brief This event is posted by ezPowerConnectorComponent whenever the power input on a connector changes.
+///
+/// When a connector gets input through it's connection to another connector, this message is sent.
+/// This can then be used by scripts on parent nodes to switch other functionality on or off.
+/// Both the previous and new value are sent, so that the difference can be calculated.
+/// This is useful in case a script has multiple connectors and needs to keep track of the total amount of power available.
+class EZ_GAMECOMPONENTS_DLL ezEventMsgSetPowerInput : public ezEventMessage
+{
+  EZ_DECLARE_MESSAGE_TYPE(ezEventMsgSetPowerInput, ezEventMessage);
+
+  ezUInt16 m_uiPrevValue = 0;
+  ezUInt16 m_uiNewValue = 0;
+};
+
+using ezPowerConnectorComponentManager = ezComponentManager<class ezPowerConnectorComponent, ezBlockStorageType::Compact>;
+
+/// \brief This component is for propagating the flow of power in cables or fluid in pipes and determine whether it arrives at a receiver.
+///
+/// This component is meant for building puzzles where you have to connect the right objects to power something.
+/// It uses physics constraints to physically connect two pieces and have them snap together.
+/// It also reacts to being grabbed (ezMsgObjectGrabbed) to disconnect.
+///
+/// On its own this component doesn't do anything.
+/// However, it can be set to be 'connected' to another object with an ezPowerConnectorComponent, in which case it would propagate its own
+/// 'output' as the 'input' on that component.
+/// If its output is non-zero and thus the input on the connected component is also non-zero, the other component will post ezEventMsgSetPowerInput,
+/// to which a script can react and for example switch a light on.
+///
+/// Connectors are bi-directional ("full duplex"), so they can have both an input and an output and the two values are independent of each other.
+/// That means power can flow in both or just one direction and therefore it is not important with which end a cable gets connected to something.
+///
+/// To enable building things like cables, each ezPowerConnectorComponent can also have a 'buddy', which is an object on which another
+/// ezPowerConnectorComponent exists.
+/// If a connector gets input, that input value is propagated to the buddy as its output value. Thus when a cable gets input on one end,
+/// the other end (if it is properly set as the buddy) will output that value. So if that end is also 'connected' to something, the output will
+/// be further propagated as the 'input' on that object. This can go through many hops until the value reaches the final connector (if you build a
+/// circular chain it will stop when it reaches the starting point).
+///
+/// The component automatically connects to another object when it receives a ezMsgSensorDetectedObjectsChanged, so it should have a child
+/// object with a sensor. The sensor should use a dedicated spatial category to search for markers where it can connect.
+///
+/// To have a sensor (or other effects) only active when the connector is grabbed, put them in a child object with the name "ActiveWhenGrabbed"
+/// and disable the object by default. The parent ezPowerConnectorComponent will toggle the active flag of that object when it gets grabbed or let go.
+///
+/// To build a cable, don't forget to set each end as the 'buddy' of the other end.
+class EZ_GAMECOMPONENTS_DLL ezPowerConnectorComponent : public ezComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezPowerConnectorComponent, ezComponent, ezPowerConnectorComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& stream) override;
+
+protected:
+  virtual void OnDeactivated() override;
+  virtual void OnSimulationStarted() override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezPowerConnectorComponent
+
+public:
+  /// \brief Sets how much output (of whatever kind) this connector produces.
+  ///
+  /// If this is zero, it is either a receiver, or a pass-through connector, e.g. a cable, or just currently inactive.
+  /// If this is non-zero, it acts like a source, and when another connector gets connected to it, that output will be propagated
+  /// through the connection/buddy chain.
+  void SetOutput(ezUInt16 value);                   // [ property ]
+  ezUInt16 GetOutput() const { return m_uiOutput; } // [ property ]
+
+  void SetBuddy(ezGameObjectHandle hObject);
+  void SetConnectedTo(ezGameObjectHandle hObject);
+
+  /// \brief Whether the connector is currently connected to another connector.
+  bool IsConnected() const;
+
+  /// \brief Whether the connector is physically attached to another connector.
+  bool IsAttached() const;
+
+  void Detach();
+  void Attach(ezGameObjectHandle hObject);
+
+protected:
+  void SetBuddyReference(const char* szReference);       // [ property ]
+  void SetConnectedToReference(const char* szReference); // [ property ]
+
+  void ConnectToSocket(ezGameObjectHandle hSocket);
+
+  void SetInput(ezUInt16 value);
+
+  /// \brief Whenever a ezMsgSensorDetectedObjectsChanged arrives, the connector attempts to connect to the reported object.
+  void OnMsgSensorDetectedObjectsChanged(ezMsgSensorDetectedObjectsChanged& msg); // [ message handler ]
+
+  /// \brief Whenever the connector gets grabbed, it detaches from its current connection.
+  ///
+  /// It also toggles the active flag of the child object with the name "ActiveWhenGrabbed".
+  /// So to only have it connect to other connectors when grabbed, put the sensor component into such a child object.
+  void OnMsgObjectGrabbed(ezMsgObjectGrabbed& msg); // [ message handler ]
+
+
+  ezTime m_DetachTime;
+  ezGameObjectHandle m_hAttachPoint;
+  ezGameObjectHandle m_hGrabbedBy;
+
+  ezUInt16 m_uiOutput = 0;
+  ezUInt16 m_uiInput = 0;
+
+  ezGameObjectHandle m_hBuddy;
+  ezGameObjectHandle m_hConnectedTo;
+
+  void InputChanged(ezUInt16 uiPrevInput, ezUInt16 uiInput);
+  void OutputChanged(ezUInt16 uiOutput);
+
+private:
+  const char* DummyGetter() const { return nullptr; }
+};

--- a/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltGrabObjectComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltGrabObjectComponent.cpp
@@ -12,29 +12,6 @@
 #include <RendererCore/Debug/DebugRenderer.h>
 
 // clang-format off
-EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgObjectGrabbed);
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgObjectGrabbed, 1, ezRTTIDefaultAllocator<ezMsgObjectGrabbed>)
-{
-  EZ_BEGIN_PROPERTIES
-  {
-    EZ_MEMBER_PROPERTY("GrabbedBy", m_hGrabbedBy),
-    EZ_MEMBER_PROPERTY("GotGrabbed", m_bGotGrabbed),
-  }
-  EZ_END_PROPERTIES;
-}
-EZ_END_DYNAMIC_REFLECTED_TYPE;
-
-EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgReleaseObjectGrab);
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgReleaseObjectGrab, 1, ezRTTIDefaultAllocator<ezMsgReleaseObjectGrab>)
-{
-  EZ_BEGIN_PROPERTIES
-  {
-    EZ_MEMBER_PROPERTY("GrabbedObjectToRelease", m_hGrabbedObjectToRelease),
-  }
-  EZ_END_PROPERTIES;
-}
-EZ_END_DYNAMIC_REFLECTED_TYPE;
-
 EZ_BEGIN_COMPONENT_TYPE(ezJoltGrabObjectComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/EnginePlugins/JoltPlugin/Constraints/JoltGrabObjectComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Constraints/JoltGrabObjectComponent.h
@@ -8,23 +8,6 @@ namespace JPH
   class SixDOFConstraint;
 }
 
-/// \brief Sent by components such as ezJoltGrabObjectComponent to indicate that the object has been grabbed or released.
-class EZ_JOLTPLUGIN_DLL ezMsgObjectGrabbed : public ezMessage
-{
-  EZ_DECLARE_MESSAGE_TYPE(ezMsgObjectGrabbed, ezMessage);
-
-  ezGameObjectHandle m_hGrabbedBy;
-  bool m_bGotGrabbed = true;
-};
-
-/// \brief Send this to components such as ezJoltGrabObjectComponent to demand that m_hGrabbedObjectToRelease should no longer be grabbed.
-class EZ_JOLTPLUGIN_DLL ezMsgReleaseObjectGrab : public ezMessage
-{
-  EZ_DECLARE_MESSAGE_TYPE(ezMsgReleaseObjectGrab, ezMessage);
-
-  ezGameObjectHandle m_hGrabbedObjectToRelease;
-};
-
 using ezJoltGrabObjectComponentManager = ezComponentManagerSimple<class ezJoltGrabObjectComponent, ezComponentUpdateType::WhenSimulating, ezBlockStorageType::Compact>;
 
 /// \brief Used to 'grab' physical objects and attach them to an object. For player objects to pick up objects.

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -7,6 +7,7 @@
 #include <JoltPlugin/Character/JoltCharacterControllerComponent.h>
 #include <JoltPlugin/Components/JoltSettingsComponent.h>
 #include <JoltPlugin/Constraints/JoltConstraintComponent.h>
+#include <JoltPlugin/Constraints/JoltFixedConstraintComponent.h>
 #include <JoltPlugin/Shapes/JoltShapeBoxComponent.h>
 #include <JoltPlugin/System/JoltContacts.h>
 #include <JoltPlugin/System/JoltCore.h>
@@ -351,6 +352,13 @@ void ezJoltWorldModule::AddStaticCollisionBox(ezGameObject* pObject, ezVec3 boxS
   ezJoltShapeBoxComponent* pBox;
   ezJoltShapeBoxComponent::CreateComponent(pObject, pBox);
   pBox->SetHalfExtents(boxSize * 0.5f);
+}
+
+void ezJoltWorldModule::AddFixedJointComponent(ezGameObject* pOwner, const ezPhysicsWorldModuleInterface::FixedJointConfig& cfg)
+{
+  ezJoltFixedConstraintComponent* pConstraint = nullptr;
+  m_pWorld->GetOrCreateComponentManager<ezJoltFixedConstraintComponentManager>()->CreateComponent(pOwner, pConstraint);
+  pConstraint->SetActors(cfg.m_hActorA, cfg.m_LocalFrameA, cfg.m_hActorB, cfg.m_LocalFrameB);
 }
 
 void ezJoltWorldModule::QueueBodyToAdd(JPH::Body* pBody, bool bAwake)

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -68,6 +68,8 @@ public:
 
   virtual void AddStaticCollisionBox(ezGameObject* pObject, ezVec3 boxSize) override;
 
+  virtual void AddFixedJointComponent(ezGameObject* pOwner, const ezPhysicsWorldModuleInterface::FixedJointConfig& cfg) override;
+
   ezDeque<ezComponentHandle> m_RequireUpdate;
 
   const ezMap<ezJoltActorComponent*, ezUInt32>& GetActiveActors() const { return m_ActiveActors; }


### PR DESCRIPTION
This is a component for creating game play puzzles, e.g. to determine whether a machine is properly connected to a power source and thus powered on.