### PR TITLE
Added easy way to play a one-shot sound

### DIFF
--- a/Code/Engine/Core/Interfaces/SoundInterface.cpp
+++ b/Code/Engine/Core/Interfaces/SoundInterface.cpp
@@ -1,0 +1,14 @@
+#include <Core/CorePCH.h>
+
+#include <Core/Interfaces/SoundInterface.h>
+#include <Foundation/Configuration/Singleton.h>
+
+ezResult ezSoundInterface::PlaySound(ezStringView sResourceID, const ezTransform& globalPosition, float fPitch /*= 1.0f*/, float fVolume /*= 1.0f*/, bool bBlockIfNotLoaded /*= true*/)
+{
+  if (ezSoundInterface* pSoundInterface = ezSingletonRegistry::GetSingletonInstance<ezSoundInterface>())
+  {
+    return pSoundInterface->OneShotSound(sResourceID, globalPosition, fPitch, fVolume, bBlockIfNotLoaded);
+  }
+
+  return EZ_FAILURE;
+}

--- a/Code/Engine/Core/Interfaces/SoundInterface.h
+++ b/Code/Engine/Core/Interfaces/SoundInterface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/CoreDLL.h>
 #include <Foundation/Basics.h>
 
 class ezSoundInterface
@@ -46,4 +47,24 @@ public:
 
   /// \brief Sets the position for listener N. Index -1 is used for the override mode listener.
   virtual void SetListener(ezInt32 iIndex, const ezVec3& vPosition, const ezVec3& vForward, const ezVec3& vUp, const ezVec3& vVelocity) = 0;
+
+  /// \brief Plays a sound once. Callced by ezSoundInterface::PlaySound().
+  virtual ezResult OneShotSound(ezStringView sResourceID, const ezTransform& globalPosition, float fPitch = 1.0f, float fVolume = 1.0f, bool bBlockIfNotLoaded = true) = 0;
+
+  /// \brief Plays a sound once.
+  ///
+  /// Convenience function to call OneShotSound() without having to retrieve the ezSoundInterface first.
+  ///
+  /// Which sound to play is specified through a resource ID ('Asset GUID').
+  /// This is not the most efficient way to load a sound, as there is no way to preload the resource.
+  /// If preloading is desired, you need to access the implementation-specific resource type directly (e.g. ezFmodSoundEventResource).
+  /// Also see ezFmodSoundEventResource::PlayOnce().
+  /// In practice, though, sounds are typically loaded in bulk from sound-banks, and preloading is not necessary.
+  ///
+  /// Be aware that this does not allow to adjust volume, pitch or position after creation. Stopping is also not possible.
+  /// Use a sound component, if that is necessary.
+  ///
+  /// Also by default a pitch of 1 is always used. If the game speed is not 1 (ezWorld clock), a custom pitch would need to be provided,
+  /// if the sound should play at the same speed.
+  EZ_CORE_DLL static ezResult PlaySound(ezStringView sResourceID, const ezTransform& globalPosition, float fPitch = 1.0f, float fVolume = 1.0f, bool bBlockIfNotLoaded = true);
 };

--- a/Code/Engine/Core/ResourceManager/Implementation/Resource.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/Resource.cpp
@@ -105,15 +105,15 @@ void ezResource::PrintHandleStackTraces()
 #endif
 }
 
-void ezResource::SetResourceDescription(const char* szDescription)
+void ezResource::SetResourceDescription(ezStringView sDescription)
 {
-  m_sResourceDescription = szDescription;
+  m_sResourceDescription = sDescription;
 }
 
-void ezResource::SetUniqueID(const char* szUniqueID, bool bIsReloadable)
+void ezResource::SetUniqueID(ezStringView sUniqueID, bool bIsReloadable)
 {
-  m_sUniqueID = szUniqueID;
-  m_uiUniqueIDHash = ezHashingUtils::StringHash(szUniqueID);
+  m_sUniqueID = sUniqueID;
+  m_uiUniqueIDHash = ezHashingUtils::StringHash(sUniqueID);
   SetIsReloadable(bIsReloadable);
 
   ezResourceEvent e;

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -4,11 +4,11 @@
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Foundation/Profiling/Profiling.h>
 
-ezTypelessResourceHandle ezResourceManager::LoadResourceByType(const ezRTTI* pResourceType, const char* szResourceID)
+ezTypelessResourceHandle ezResourceManager::LoadResourceByType(const ezRTTI* pResourceType, ezStringView sResourceID)
 {
   // the mutex here is necessary to prevent a race between resource unloading and storing the pointer in the handle
   EZ_LOCK(s_ResourceMutex);
-  return ezTypelessResourceHandle(GetResource(pResourceType, szResourceID, true));
+  return ezTypelessResourceHandle(GetResource(pResourceType, sResourceID, true));
 }
 
 void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHighestPriority)

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -125,17 +125,17 @@ void ezResourceManager::BroadcastResourceEvent(const ezResourceEvent& e)
   s_pState->m_ResourceEvents.Broadcast(e);
 }
 
-void ezResourceManager::RegisterResourceForAssetType(const char* szAssetTypeName, const ezRTTI* pResourceType)
+void ezResourceManager::RegisterResourceForAssetType(ezStringView sAssetTypeName, const ezRTTI* pResourceType)
 {
-  ezStringBuilder s = szAssetTypeName;
+  ezStringBuilder s = sAssetTypeName;
   s.ToLower();
 
   s_pState->m_AssetToResourceType[s] = pResourceType;
 }
 
-const ezRTTI* ezResourceManager::FindResourceForAssetType(const char* szAssetTypeName)
+const ezRTTI* ezResourceManager::FindResourceForAssetType(ezStringView sAssetTypeName)
 {
-  ezStringBuilder s = szAssetTypeName;
+  ezStringBuilder s = sAssetTypeName;
   s.ToLower();
 
   return s_pState->m_AssetToResourceType.GetValueOrDefault(s, nullptr);
@@ -682,27 +682,27 @@ void ezResourceManager::OnCoreShutdown()
   s_pState.Clear();
 }
 
-ezResource* ezResourceManager::GetResource(const ezRTTI* pRtti, const char* szResourceID, bool bIsReloadable)
+ezResource* ezResourceManager::GetResource(const ezRTTI* pRtti, ezStringView sResourceID, bool bIsReloadable)
 {
-  if (ezStringUtils::IsNullOrEmpty(szResourceID))
+  if (sResourceID.IsEmpty())
     return nullptr;
 
   EZ_ASSERT_DEV(s_ResourceMutex.IsLocked(), "Calling code must lock the mutex until the resource pointer is stored in a handle");
 
   // redirect requested type to override type, if available
-  pRtti = FindResourceTypeOverride(pRtti, szResourceID);
+  pRtti = FindResourceTypeOverride(pRtti, sResourceID);
 
   EZ_ASSERT_DEBUG(pRtti != nullptr, "There is no RTTI information available for the given resource type '{0}'", EZ_STRINGIZE(ResourceType));
   EZ_ASSERT_DEBUG(pRtti->GetAllocator() != nullptr && pRtti->GetAllocator()->CanAllocate(), "There is no RTTI allocator available for the given resource type '{0}'", EZ_STRINGIZE(ResourceType));
 
   ezResource* pResource = nullptr;
-  ezTempHashedString sHashedResourceID(szResourceID);
+  ezTempHashedString sHashedResourceID(sResourceID);
 
   ezHashedString* redirection;
   if (s_pState->m_NamedResources.TryGetValue(sHashedResourceID, redirection))
   {
     sHashedResourceID = *redirection;
-    szResourceID = redirection->GetData();
+    sResourceID = redirection->GetView();
   }
 
   LoadedResources& lr = s_pState->m_LoadedResources[pRtti];
@@ -712,7 +712,7 @@ ezResource* ezResourceManager::GetResource(const ezRTTI* pRtti, const char* szRe
 
   ezResource* pNewResource = pRtti->GetAllocator()->Allocate<ezResource>();
   pNewResource->m_Priority = s_pState->m_ResourceTypePriorities.GetValueOrDefault(pRtti, ezResourcePriority::Medium);
-  pNewResource->SetUniqueID(szResourceID, bIsReloadable);
+  pNewResource->SetUniqueID(sResourceID, bIsReloadable);
   pNewResource->m_Flags.AddOrRemove(ezResourceFlags::ResourceHasTypeFallback, pNewResource->HasResourceTypeLoadingFallback());
 
   lr.m_Resources.Insert(sHashedResourceID, pNewResource);
@@ -754,7 +754,7 @@ void ezResourceManager::UnregisterResourceOverrideType(const ezRTTI* pDerivedTyp
   }
 }
 
-const ezRTTI* ezResourceManager::FindResourceTypeOverride(const ezRTTI* pRtti, const char* szResourceID)
+const ezRTTI* ezResourceManager::FindResourceTypeOverride(const ezRTTI* pRtti, ezStringView sResourceID)
 {
   auto it = s_pState->m_DerivedTypeInfos.Find(pRtti);
 
@@ -762,7 +762,7 @@ const ezRTTI* ezResourceManager::FindResourceTypeOverride(const ezRTTI* pRtti, c
     return pRtti;
 
   ezStringBuilder sRedirectedPath;
-  ezFileSystem::ResolveAssetRedirection(szResourceID, sRedirectedPath);
+  ezFileSystem::ResolveAssetRedirection(sResourceID, sRedirectedPath);
 
   while (it.IsValid())
   {
@@ -782,22 +782,22 @@ const ezRTTI* ezResourceManager::FindResourceTypeOverride(const ezRTTI* pRtti, c
   return pRtti;
 }
 
-ezString ezResourceManager::GenerateUniqueResourceID(const char* prefix)
+ezString ezResourceManager::GenerateUniqueResourceID(ezStringView sResourceIDPrefix)
 {
   ezStringBuilder resourceID;
-  resourceID.Format("{}-{}", prefix, s_pState->m_uiNextResourceID++);
+  resourceID.Format("{}-{}", sResourceIDPrefix, s_pState->m_uiNextResourceID++);
   return resourceID;
 }
 
-ezTypelessResourceHandle ezResourceManager::GetExistingResourceByType(const ezRTTI* pResourceType, const char* szResourceID)
+ezTypelessResourceHandle ezResourceManager::GetExistingResourceByType(const ezRTTI* pResourceType, ezStringView sResourceID)
 {
   ezResource* pResource = nullptr;
 
-  const ezTempHashedString sResourceHash(szResourceID);
+  const ezTempHashedString sResourceHash(sResourceID);
 
   EZ_LOCK(s_ResourceMutex);
 
-  const ezRTTI* pRtti = FindResourceTypeOverride(pResourceType, szResourceID);
+  const ezRTTI* pRtti = FindResourceTypeOverride(pResourceType, sResourceID);
 
   if (s_pState->m_LoadedResources[pRtti].m_Resources.TryGetValue(sResourceHash, pResource))
     return ezTypelessResourceHandle(pResource);
@@ -805,16 +805,16 @@ ezTypelessResourceHandle ezResourceManager::GetExistingResourceByType(const ezRT
   return ezTypelessResourceHandle();
 }
 
-ezTypelessResourceHandle ezResourceManager::GetExistingResourceOrCreateAsync(const ezRTTI* pResourceType, const char* szResourceID, ezUniquePtr<ezResourceTypeLoader>&& loader)
+ezTypelessResourceHandle ezResourceManager::GetExistingResourceOrCreateAsync(const ezRTTI* pResourceType, ezStringView sResourceID, ezUniquePtr<ezResourceTypeLoader>&& loader)
 {
   EZ_LOCK(s_ResourceMutex);
 
-  ezTypelessResourceHandle hResource = GetExistingResourceByType(pResourceType, szResourceID);
+  ezTypelessResourceHandle hResource = GetExistingResourceByType(pResourceType, sResourceID);
 
   if (hResource.IsValid())
     return hResource;
 
-  hResource = GetResource(pResourceType, szResourceID, false);
+  hResource = GetResource(pResourceType, sResourceID, false);
   ezResource* pResource = hResource.m_pResource;
 
   pResource->m_Flags.Add(ezResourceFlags::HasCustomDataLoader | ezResourceFlags::IsCreatedResource);
@@ -837,23 +837,23 @@ void ezResourceManager::ForceLoadResourceNow(const ezTypelessResourceHandle& hRe
   }
 }
 
-void ezResourceManager::RegisterNamedResource(const char* szLookupName, const char* szRedirectionResource)
+void ezResourceManager::RegisterNamedResource(ezStringView sLookupName, ezStringView sRedirectionResource)
 {
   EZ_LOCK(s_ResourceMutex);
 
-  ezTempHashedString lookup(szLookupName);
+  ezTempHashedString lookup(sLookupName);
 
   ezHashedString redirection;
-  redirection.Assign(szRedirectionResource);
+  redirection.Assign(sRedirectionResource);
 
   s_pState->m_NamedResources[lookup] = redirection;
 }
 
-void ezResourceManager::UnregisterNamedResource(const char* szLookupName)
+void ezResourceManager::UnregisterNamedResource(ezStringView sLookupName)
 {
   EZ_LOCK(s_ResourceMutex);
 
-  ezTempHashedString hash(szLookupName);
+  ezTempHashedString hash(sLookupName);
   s_pState->m_NamedResources.Remove(hash);
 }
 

--- a/Code/Engine/Core/ResourceManager/Resource.h
+++ b/Code/Engine/Core/ResourceManager/Resource.h
@@ -51,7 +51,7 @@ public:
 
   /// \brief The resource description allows to store an additional string that might be more descriptive during debugging, than the unique
   /// ID.
-  void SetResourceDescription(const char* szDescription);
+  void SetResourceDescription(ezStringView sDescription);
 
   /// \brief The resource description allows to store an additional string that might be more descriptive during debugging, than the unique
   /// ID.
@@ -137,7 +137,7 @@ private:
   friend class ezResourceManagerWorkerUpdateContent;
 
   /// \brief Called by ezResourceManager shortly after resource creation.
-  void SetUniqueID(const char* szUniqueID, bool bIsReloadable);
+  void SetUniqueID(ezStringView sUniqueID, bool bIsReloadable);
 
   void CallUnloadData(Unload WhatToUnload);
 

--- a/Code/Engine/Core/ResourceManager/ResourceManager.h
+++ b/Code/Engine/Core/ResourceManager/ResourceManager.h
@@ -45,7 +45,7 @@ public:
   /// the resource will be loaded. If it is not possible to load the resource it will change to a 'missing' state. If the code accessing the
   /// resource cannot handle that case, the application will 'terminate' (that means crash).
   template <typename ResourceType>
-  static ezTypedResourceHandle<ResourceType> LoadResource(const char* szResourceID);
+  static ezTypedResourceHandle<ResourceType> LoadResource(ezStringView sResourceID);
 
   /// \brief Same as LoadResource(), but additionally allows to set a priority on the resource and a custom fallback resource for this
   /// instance.
@@ -55,12 +55,12 @@ public:
   /// If a valid fallback resource is specified, the resource will store that as its instance specific fallback resource. This will be used
   /// when trying to acquire the resource later.
   template <typename ResourceType>
-  static ezTypedResourceHandle<ResourceType> LoadResource(const char* szResourceID, ezTypedResourceHandle<ResourceType> hLoadingFallback);
+  static ezTypedResourceHandle<ResourceType> LoadResource(ezStringView sResourceID, ezTypedResourceHandle<ResourceType> hLoadingFallback);
 
 
   /// \brief Same as LoadResource(), but instead of a template argument, the resource type to use is given as ezRTTI info. Returns a
   /// typeless handle due to the missing template argument.
-  static ezTypelessResourceHandle LoadResourceByType(const ezRTTI* pResourceType, const char* szResourceID);
+  static ezTypelessResourceHandle LoadResourceByType(const ezRTTI* pResourceType, ezStringView sResourceID);
 
   /// \brief Checks whether any resource loading is in progress
   static bool IsAnyLoadingInProgress();
@@ -69,7 +69,7 @@ public:
   ///
   /// Provide a prefix that is preferably not used anywhere else (i.e., closely related to your code).
   /// If the prefix is not also used to manually generate resource IDs, this function is guaranteed to return a unique resource ID.
-  static ezString GenerateUniqueResourceID(const char* szResourceIDPrefix);
+  static ezString GenerateUniqueResourceID(ezStringView sResourceIDPrefix);
 
   /// \brief Creates a resource from a descriptor.
   ///
@@ -78,8 +78,7 @@ public:
   /// \param szResourceDescription An optional description that might help during debugging. Often a human readable name or path is stored
   /// here, to make it easier to identify this resource.
   template <typename ResourceType, typename DescriptorType>
-  static ezTypedResourceHandle<ResourceType> CreateResource(
-    const char* szResourceID, DescriptorType&& descriptor, const char* szResourceDescription = nullptr);
+  static ezTypedResourceHandle<ResourceType> CreateResource(ezStringView sResourceID, DescriptorType&& descriptor, ezStringView sResourceDescription = nullptr);
 
   /// \brief Returns a handle to the resource with the given ID if it exists or creates it from a descriptor.
   ///
@@ -87,23 +86,22 @@ public:
   /// \param descriptor A type specific descriptor that holds all the information to create the resource.
   /// \param szResourceDescription An optional description that might help during debugging. Often a human readable name or path is stored here, to make it easier to identify this resource.
   template <typename ResourceType, typename DescriptorType>
-  static ezTypedResourceHandle<ResourceType> GetOrCreateResource(
-    const char* szResourceID, DescriptorType&& descriptor, const char* szResourceDescription = nullptr);
+  static ezTypedResourceHandle<ResourceType> GetOrCreateResource(ezStringView sResourceID, DescriptorType&& descriptor, ezStringView sResourceDescription = nullptr);
 
   /// \brief Returns a handle to the resource with the given ID. If the resource does not exist, the handle is invalid.
   ///
   /// Use this if a resource needs to be created procedurally (with CreateResource()), but might already have been created.
   /// If the returned handle is invalid, then just go through the resource creation step.
   template <typename ResourceType>
-  static ezTypedResourceHandle<ResourceType> GetExistingResource(const char* szResourceID);
+  static ezTypedResourceHandle<ResourceType> GetExistingResource(ezStringView sResourceID);
 
   /// \brief Same as GetExistingResourceByType() but allows to specify the resource type as an ezRTTI.
-  static ezTypelessResourceHandle GetExistingResourceByType(const ezRTTI* pResourceType, const char* szResourceID);
+  static ezTypelessResourceHandle GetExistingResourceByType(const ezRTTI* pResourceType, ezStringView sResourceID);
 
   template <typename ResourceType>
-  static ezTypedResourceHandle<ResourceType> GetExistingResourceOrCreateAsync(const char* szResourceID, ezUniquePtr<ezResourceTypeLoader>&& loader, ezTypedResourceHandle<ResourceType> hLoadingFallback = {})
+  static ezTypedResourceHandle<ResourceType> GetExistingResourceOrCreateAsync(ezStringView sResourceID, ezUniquePtr<ezResourceTypeLoader>&& loader, ezTypedResourceHandle<ResourceType> hLoadingFallback = {})
   {
-    ezTypelessResourceHandle hTypeless = GetExistingResourceOrCreateAsync(ezGetStaticRTTI<ResourceType>(), szResourceID, std::move(loader));
+    ezTypelessResourceHandle hTypeless = GetExistingResourceOrCreateAsync(ezGetStaticRTTI<ResourceType>(), sResourceID, std::move(loader));
 
     auto hTyped = ezTypedResourceHandle<ResourceType>((ResourceType*)hTypeless.m_pResource);
 
@@ -115,7 +113,7 @@ public:
     return hTyped;
   }
 
-  static ezTypelessResourceHandle GetExistingResourceOrCreateAsync(const ezRTTI* pResourceType, const char* szResourceID, ezUniquePtr<ezResourceTypeLoader>&& loader);
+  static ezTypelessResourceHandle GetExistingResourceOrCreateAsync(const ezRTTI* pResourceType, ezStringView sResourceID, ezUniquePtr<ezResourceTypeLoader>&& loader);
 
   /// \brief Triggers loading of the given resource. tShouldBeAvailableIn specifies how long the resource is not yet needed, thus allowing
   /// other resources to be loaded first. This is only a hint and there are no guarantees when the resource is available.
@@ -299,10 +297,10 @@ public:
   ///
   /// This can be used to register a resource under an easier to use name. For example one can register "MenuBackground" as the name for "{
   /// E50DCC85-D375-4999-9CFE-42F1377FAC85 }". If the lookup name already exists, it will be overwritten.
-  static void RegisterNamedResource(const char* szLookupName, const char* szRedirectionResource);
+  static void RegisterNamedResource(ezStringView sLookupName, ezStringView sRedirectionResource);
 
   /// \brief Removes a previously registered name from the redirection table.
-  static void UnregisterNamedResource(const char* szLookupName);
+  static void UnregisterNamedResource(ezStringView sLookupName);
 
 
   ///@}
@@ -311,11 +309,11 @@ public:
 
 public:
   /// \brief Registers which resource type to use to load an asset with the given type name
-  static void RegisterResourceForAssetType(const char* szAssetTypeName, const ezRTTI* pResourceType);
+  static void RegisterResourceForAssetType(ezStringView sAssetTypeName, const ezRTTI* pResourceType);
 
   /// \brief Returns the resource type that was registered to handle the given asset type for loading. nullptr if no resource type was
   /// registered for this asset type.
-  static const ezRTTI* FindResourceForAssetType(const char* szAssetTypeName);
+  static const ezRTTI* FindResourceForAssetType(ezStringView sAssetTypeName);
 
   ///@}
   /// \name Export mode
@@ -333,7 +331,7 @@ public:
   /// Internally it will create a resource but does not load the content. This way it can be ensured that the resource handle is always only
   /// the size of a pointer.
   template <typename ResourceType>
-  static ezTypedResourceHandle<ResourceType> GetResourceHandleForExport(const char* szResourceID);
+  static ezTypedResourceHandle<ResourceType> GetResourceHandleForExport(ezStringView sResourceID);
 
 
   ///@}
@@ -469,8 +467,8 @@ private:
   static void InternalPreloadResource(ezResource* pResource, bool bHighestPriority);
 
   template <typename ResourceType>
-  static ResourceType* GetResource(const char* szResourceID, bool bIsReloadable);
-  static ezResource* GetResource(const ezRTTI* pRtti, const char* szResourceID, bool bIsReloadable);
+  static ResourceType* GetResource(ezStringView sResourceID, bool bIsReloadable);
+  static ezResource* GetResource(const ezRTTI* pRtti, ezStringView sResourceID, bool bIsReloadable);
   static void RunWorkerTask(ezResource* pResource);
   static void UpdateLoadingDeadlines();
   static void ReverseBubbleSortStep(ezDeque<LoadingInfo>& data);
@@ -510,7 +508,7 @@ private:
   };
 
   /// \brief Checks whether there is a type override for pRtti given szResourceID and returns that
-  static const ezRTTI* FindResourceTypeOverride(const ezRTTI* pRtti, const char* szResourceID);
+  static const ezRTTI* FindResourceTypeOverride(const ezRTTI* pRtti, ezStringView sResourceID);
 };
 
 #include <Core/ResourceManager/Implementation/ResourceLock.h>

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -765,8 +765,8 @@ void ezFmodEventComponent::UpdateParameters(FMOD::Studio::EventInstance* pInstan
 {
   const auto pos = GetOwner()->GetGlobalPosition();
   const auto vel = GetOwner()->GetVelocity();
-  const auto fwd = (GetOwner()->GetGlobalRotation() * ezVec3(1, 0, 0)).GetNormalized();
-  const auto up = (GetOwner()->GetGlobalRotation() * ezVec3(0, 0, 1)).GetNormalized();
+  const auto fwd = GetOwner()->GetGlobalRotation() * ezVec3(1, 0, 0);
+  const auto up = GetOwner()->GetGlobalRotation() * ezVec3(0, 0, 1);
 
   FMOD_3D_ATTRIBUTES attr;
   attr.position.x = pos.x;

--- a/Code/EnginePlugins/FmodPlugin/FmodSingleton.cpp
+++ b/Code/EnginePlugins/FmodPlugin/FmodSingleton.cpp
@@ -1,5 +1,6 @@
 #include <FmodPlugin/FmodPluginPCH.h>
 
+#include <Core/ResourceManager/ResourceManager.h>
 #include <FmodPlugin/FmodIncludes.h>
 #include <FmodPlugin/FmodSingleton.h>
 #include <FmodPlugin/Resources/FmodSoundBankResource.h>
@@ -344,6 +345,21 @@ void ezFmod::SetListener(ezInt32 iIndex, const ezVec3& vPosition, const ezVec3& 
   {
     m_pStudioSystem->setListenerAttributes(iIndex, &attr);
   }
+}
+
+ezResult ezFmod::OneShotSound(ezStringView sResourceID, const ezTransform& globalPosition, float fPitch /*= 1.0f*/, float fVolume /*= 1.0f*/, bool bBlockIfNotLoaded /*= true*/)
+{
+  ezFmodSoundEventResourceHandle hSound = ezResourceManager::LoadResource<ezFmodSoundEventResource>(sResourceID);
+
+  if (!hSound.IsValid())
+    return EZ_FAILURE;
+
+  ezResourceLock<ezFmodSoundEventResource> pSound(hSound, bBlockIfNotLoaded ? ezResourceAcquireMode::BlockTillLoaded_NeverFail : ezResourceAcquireMode::AllowLoadingFallback_NeverFail);
+
+  if (pSound.GetAcquireResult() != ezResourceAcquireResult::Final)
+    return EZ_FAILURE;
+
+  return pSound->PlayOnce(globalPosition, fPitch, fVolume);
 }
 
 void ezFmod::DetectPlatform()

--- a/Code/EnginePlugins/FmodPlugin/FmodSingleton.h
+++ b/Code/EnginePlugins/FmodPlugin/FmodSingleton.h
@@ -114,6 +114,8 @@ public:
   virtual void SetListener(ezInt32 iIndex, const ezVec3& vPosition, const ezVec3& vForward, const ezVec3& vUp, const ezVec3& vVelocity) override;
   ezVec3 GetListenerPosition() { return m_vListenerPosition; }
 
+  virtual ezResult OneShotSound(ezStringView sResourceID, const ezTransform& globalPosition, float fPitch = 1.0f, float fVolume = 1.0f, bool bBlockIfNotLoaded = true) override;
+
 private:
   friend class ezFmodSoundBankResource;
   void QueueSoundBankDataForDeletion(ezDataBuffer* pData);

--- a/Code/EnginePlugins/FmodPlugin/Resources/FmodSoundEventResource.h
+++ b/Code/EnginePlugins/FmodPlugin/Resources/FmodSoundEventResource.h
@@ -21,6 +21,11 @@ public:
   ezFmodSoundEventResource();
   ~ezFmodSoundEventResource();
 
+  /// \brief Creates an instance of this sound event and plays it.
+  ///
+  /// This is only allowed for events that are not looped, otherwise EZ_FAILURE is returned.
+  ezResult PlayOnce(const ezTransform& globalPosition, float fPitch = 1.0f, float fVolume = 1.0f) const;
+
   /// \brief Creates a new sound event instance of this fmod sound event. May return nullptr, if the event data could not be loaded.
   FMOD::Studio::EventInstance* CreateInstance() const;
 


### PR DESCRIPTION
A single sound can now be played using ezSoundInterface::PlaySound(). No resource acquiring and no world components or prefabs are necessary. Also migrated ezResourceManager to ezStringView.