### PR TITLE
Fail prefab export when C++ types are missing

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
@@ -97,7 +97,7 @@ protected:
   virtual void UpdateDocumentContext();
 
   /// \brief Exports to current document resource to file. Make sure to write ezAssetFileHeader at the start of it.
-  virtual bool ExportDocument(const ezExportDocumentMsgToEngine* pMsg);
+  virtual ezStatus ExportDocument(const ezExportDocumentMsgToEngine* pMsg);
   void UpdateSyncObjects();
 
   /// \brief Creates the thumbnail view context. It uses 'CreateViewContext' in combination with an off-screen render target.

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -314,12 +314,8 @@ class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezExportDocumentMsgToEditor : public e
   EZ_ADD_DYNAMIC_REFLECTION(ezExportDocumentMsgToEditor, ezEditorEngineDocumentMsg);
 
 public:
-  ezExportDocumentMsgToEditor()
-    : m_bOutputSuccess(false)
-  {
-  }
-
-  bool m_bOutputSuccess;
+  bool m_bOutputSuccess = false;
+  ezString m_sFailureMsg;
 };
 
 class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezCreateThumbnailMsgToEngine : public ezEditorEngineDocumentMsg

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -203,7 +203,11 @@ void ezEngineProcessDocumentContext::HandleMessage(const ezEditorEngineDocumentM
     const ezExportDocumentMsgToEngine* pMsg2 = static_cast<const ezExportDocumentMsgToEngine*>(pMsg);
     ezExportDocumentMsgToEditor ret;
     ret.m_DocumentGuid = pMsg->m_DocumentGuid;
-    ret.m_bOutputSuccess = ExportDocument(pMsg2);
+
+    ezStatus res = ExportDocument(pMsg2);
+    ret.m_bOutputSuccess = res.Succeeded();
+    ret.m_sFailureMsg = res.m_sMessage;
+
     if (!ret.m_bOutputSuccess)
     {
       ezLog::Error("Could not export to file '{0}'.", pMsg2->m_sOutputFile);
@@ -290,7 +294,8 @@ void ezEngineProcessDocumentContext::HandleMessage(const ezEditorEngineDocumentM
 
 void ezEngineProcessDocumentContext::AddSyncObject(ezEditorEngineSyncObject* pSync)
 {
-  pSync->Configure(m_DocumentGuid, [this](ezEditorEngineSyncObject* pSync) { RemoveSyncObject(pSync); });
+  pSync->Configure(m_DocumentGuid, [this](ezEditorEngineSyncObject* pSync)
+    { RemoveSyncObject(pSync); });
 
   m_SyncObjects[pSync->GetGuid()] = pSync;
 }
@@ -496,10 +501,9 @@ void ezEngineProcessDocumentContext::UpdateDocumentContext()
   }
 }
 
-bool ezEngineProcessDocumentContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
+ezStatus ezEngineProcessDocumentContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
 {
-  ezLog::Error("Export document not implemented for '{0}'", GetDynamicRTTI()->GetTypeName());
-  return false;
+  return ezStatus(ezFmt("Export document not implemented for '{0}'", GetDynamicRTTI()->GetTypeName()));
 }
 
 

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -294,8 +294,7 @@ void ezEngineProcessDocumentContext::HandleMessage(const ezEditorEngineDocumentM
 
 void ezEngineProcessDocumentContext::AddSyncObject(ezEditorEngineSyncObject* pSync)
 {
-  pSync->Configure(m_DocumentGuid, [this](ezEditorEngineSyncObject* pSync)
-    { RemoveSyncObject(pSync); });
+  pSync->Configure(m_DocumentGuid, [this](ezEditorEngineSyncObject* pSync) { RemoveSyncObject(pSync); });
 
   m_SyncObjects[pSync->GetGuid()] = pSync;
 }

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -333,6 +333,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezExportDocumentMsgToEditor, 1, ezRTTIDefaultAll
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("OutputSuccess", m_bOutputSuccess),
+    EZ_MEMBER_PROPERTY("FailureMsg", m_sFailureMsg),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/WorldRttiConverterContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/WorldRttiConverterContext.cpp
@@ -12,13 +12,16 @@ void ezWorldRttiConverterContext::Clear()
 
   m_OtherPickingMap.Clear();
   m_ComponentPickingMap.Clear();
-}
 
+  m_UnknownTypes.Clear();
+}
 
 void ezWorldRttiConverterContext::DeleteExistingObjects()
 {
   if (m_pWorld == nullptr)
     return;
+
+  m_UnknownTypes.Clear();
 
   EZ_LOCK(m_pWorld->GetWriteMarker());
 
@@ -266,4 +269,11 @@ ezUuid ezWorldRttiConverterContext::GetObjectGUID(const ezRTTI* pRtti, const voi
     return m_ComponentMap.GetGuid(pComponent->GetHandle());
   }
   return ezRttiConverterContext::GetObjectGUID(pRtti, pObject);
+}
+
+void ezWorldRttiConverterContext::OnUnknownTypeError(ezStringView sTypeName)
+{
+  ezRttiConverterContext::OnUnknownTypeError(sTypeName);
+
+  m_UnknownTypes.Insert(sTypeName);
 }

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h
@@ -32,6 +32,8 @@ public:
   virtual ezRttiConverterObject GetObjectByGUID(const ezUuid& guid) const override;
   virtual ezUuid GetObjectGUID(const ezRTTI* pRtti, const void* pObject) const override;
 
+  virtual void OnUnknownTypeError(ezStringView sTypeName) override;
+
   ezWorld* m_pWorld;
   ezEditorGuidEngineHandleMap<ezGameObjectHandle> m_GameObjectMap;
   ezEditorGuidEngineHandleMap<ezComponentHandle> m_ComponentMap;
@@ -54,4 +56,6 @@ public:
   };
 
   ezEvent<const Event&> m_Events;
+
+  ezSet<ezString> m_UnknownTypes;
 };

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -318,6 +318,7 @@ public:
 
   ///@}
 
+  void InvalidateAssetsWithTransformState(ezAssetInfo::TransformState state);
 
 public:
   ezEvent<const ezAssetCuratorEvent&> m_Events;
@@ -360,8 +361,7 @@ private:
   /// \name Asset Hashing and Status Updates (AssetUpdates.cpp)
   ///@{
 
-  ezAssetInfo::TransformState HashAsset(
-    ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDependencies, const ezHybridArray<ezString, 16>& runtimeDependencies, ezSet<ezString>& missingDependencies, ezSet<ezString>& missingReferences, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
+  ezAssetInfo::TransformState HashAsset(ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDependencies, const ezHybridArray<ezString, 16>& runtimeDependencies, ezSet<ezString>& missingDependencies, ezSet<ezString>& missingReferences, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
   bool AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
 
   ezResult EnsureAssetInfoUpdated(const ezUuid& assetGuid);
@@ -377,6 +377,7 @@ private:
 
   void RemoveAssetTransformState(const ezUuid& assetGuid);
   void InvalidateAssetTransformState(const ezUuid& assetGuid);
+
   ezAssetInfo::TransformState UpdateAssetTransformState(ezUuid assetGuid, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
   void UpdateAssetTransformState(const ezUuid& assetGuid, ezAssetInfo::TransformState state);
   void UpdateAssetTransformLog(const ezUuid& assetGuid, ezDynamicArray<ezLogEntry>& logEntries);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -79,7 +79,7 @@ inline ezStreamReader& operator>>(ezStreamReader& inout_stream, ezFileStatus& re
 void ezAssetInfo::Update(ezUniquePtr<ezAssetInfo>& rhs)
 {
   // Don't update the existance state, it is handled via ezAssetCurator::SetAssetExistanceState
-  //m_ExistanceState = rhs->m_ExistanceState;
+  // m_ExistanceState = rhs->m_ExistanceState;
   m_TransformState = rhs->m_TransformState;
   m_pDocumentTypeDescriptor = rhs->m_pDocumentTypeDescriptor;
   m_sAbsolutePath = std::move(rhs->m_sAbsolutePath);
@@ -152,7 +152,8 @@ void ezAssetCurator::StartInitialize(const ezApplicationFileSystemConfig& cfg)
   m_pWatcher = EZ_DEFAULT_NEW(ezAssetWatcher, m_FileSystemConfig);
   m_pAssetTableWriter = EZ_DEFAULT_NEW(ezAssetTableWriter, m_FileSystemConfig);
 
-  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]() {
+  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]()
+    {
     EZ_LOCK(m_CuratorMutex);
     LoadCaches();
 
@@ -638,7 +639,8 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
   // TODO: This is the old slow code path that will find the longest substring match.
   // Should be removed or folded into FindBestMatchForFile once it's surely not needed anymore.
 
-  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo* {
+  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo*
+  {
     // try to find the 'exact' relative path
     // otherwise find the shortest possible path
     ezUInt32 uiMinLength = 0xFFFFFFFF;
@@ -803,6 +805,18 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
 ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile*, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, bool bForce)
 {
   return ezAssetCurator::UpdateAssetTransformState(assetGuid, out_uiAssetHash, out_uiThumbHash, bForce);
+}
+
+void ezAssetCurator::InvalidateAssetsWithTransformState(ezAssetInfo::TransformState state)
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  ezHashSet<ezUuid> allWithState = m_TransformState[state];
+
+  for (const auto& asset : allWithState)
+  {
+    InvalidateAssetTransformState(asset);
+  }
 }
 
 ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid assetGuid, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce)
@@ -1006,7 +1020,8 @@ ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArra
   {
     EZ_LOCK(m_CuratorMutex);
 
-    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool {
+    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool
+    {
       for (auto it = m_ReferencedFiles.GetIterator(); it.IsValid(); ++it)
       {
         if (it.Value().m_Status != ezFileStatus::Status::Valid)
@@ -1057,7 +1072,8 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   ezSet<ezUuid> todoList;
   todoList.Insert(assetGuid);
 
-  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset) {
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset)
+  {
     auto it = inverseTracker.Find(sAsset);
     if (it.IsValid())
     {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -152,8 +152,7 @@ void ezAssetCurator::StartInitialize(const ezApplicationFileSystemConfig& cfg)
   m_pWatcher = EZ_DEFAULT_NEW(ezAssetWatcher, m_FileSystemConfig);
   m_pAssetTableWriter = EZ_DEFAULT_NEW(ezAssetTableWriter, m_FileSystemConfig);
 
-  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]()
-    {
+  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]() {
     EZ_LOCK(m_CuratorMutex);
     LoadCaches();
 
@@ -639,8 +638,7 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
   // TODO: This is the old slow code path that will find the longest substring match.
   // Should be removed or folded into FindBestMatchForFile once it's surely not needed anymore.
 
-  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo*
-  {
+  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo* {
     // try to find the 'exact' relative path
     // otherwise find the shortest possible path
     ezUInt32 uiMinLength = 0xFFFFFFFF;
@@ -1020,8 +1018,7 @@ ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArra
   {
     EZ_LOCK(m_CuratorMutex);
 
-    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool
-    {
+    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool {
       for (auto it = m_ReferencedFiles.GetIterator(); it.IsValid(); ++it)
       {
         if (it.Value().m_Status != ezFileStatus::Status::Valid)
@@ -1072,8 +1069,7 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   ezSet<ezUuid> todoList;
   todoList.Insert(assetGuid);
 
-  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset)
-  {
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset) {
     auto it = inverseTracker.Find(sAsset);
     if (it.IsValid())
     {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -362,8 +362,7 @@ ezUInt64 ezAssetDocument::GetDocumentHash() const
   {
     typesSorted.PushBack(pType);
   }
-  typesSorted.Sort([](const ezRTTI* a, const ezRTTI* b)
-    { return ezStringUtils::Compare(a->GetTypeName(), b->GetTypeName()) < 0; });
+  typesSorted.Sort([](const ezRTTI* a, const ezRTTI* b) { return ezStringUtils::Compare(a->GetTypeName(), b->GetTypeName()) < 0; });
   for (const ezRTTI* pType : typesSorted)
   {
     uiHash = ezHashingUtils::xxHash64(pType->GetTypeName(), std::strlen(pType->GetTypeName()), uiHash);
@@ -407,8 +406,7 @@ ezTransformStatus ezAssetDocument::DoTransformAsset(const ezPlatformProfile* pAs
     AssetHeader.SetFileHashAndVersion(uiHash, GetAssetTypeVersion());
     const auto& outputs = GetAssetDocumentInfo()->m_Outputs;
 
-    auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus
-    {
+    auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus {
       const ezString sTargetFile = GetAssetDocumentManager()->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), szOutputTag, pAssetProfile);
       ezTransformStatus ret = InternalTransformAsset(sTargetFile, szOutputTag, pAssetProfile, AssetHeader, transformFlags);
 
@@ -660,8 +658,7 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
   GetEditorEngineConnection()->SendMessage(&msg);
 
   ezStatus status(EZ_FAILURE);
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&status](ezProcessMessage* pMsg) -> bool
-  {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&status](ezProcessMessage* pMsg) -> bool {
     ezExportDocumentMsgToEditor* pMsg2 = ezDynamicCast<ezExportDocumentMsgToEditor*>(pMsg);
     status = ezStatus(pMsg2->m_bOutputSuccess ? EZ_SUCCESS : EZ_FAILURE, pMsg2->m_sFailureMsg);
     return true;
@@ -722,8 +719,7 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
   GetEditorEngineConnection()->SendMessage(&msg);
 
   ezDataBuffer data;
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
-  {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
     ezCreateThumbnailMsgToEditor* pThumbnailMsg = ezDynamicCast<ezCreateThumbnailMsgToEditor*>(pMsg);
     data = pThumbnailMsg->m_ThumbnailData;
     return true;
@@ -795,8 +791,7 @@ void ezAssetDocument::HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg)
 
 void ezAssetDocument::AddSyncObject(ezEditorEngineSyncObject* pSync) const
 {
-  pSync->Configure(GetGuid(), [this](ezEditorEngineSyncObject* pSync)
-    { RemoveSyncObject(pSync); });
+  pSync->Configure(GetGuid(), [this](ezEditorEngineSyncObject* pSync) { RemoveSyncObject(pSync); });
 
   m_SyncObjects.PushBack(pSync);
   m_AllSyncObjects[pSync->GetGuid()] = pSync;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -271,7 +271,7 @@ void ezAssetDocument::AddReferences(const ezDocumentObject* pObject, ezAssetDocu
         }
         break;
         case ezPropertyCategory::Map:
-          //#TODO Search for exposed params that reference assets.
+          // #TODO Search for exposed params that reference assets.
           if (pProp->GetFlags().IsSet(ezPropertyFlags::StandardType) && pProp->GetSpecificType()->GetVariantType() == ezVariantType::String)
           {
             ezVariant value = pObject->GetTypeAccessor().GetValue(pProp->GetPropertyName());
@@ -362,7 +362,8 @@ ezUInt64 ezAssetDocument::GetDocumentHash() const
   {
     typesSorted.PushBack(pType);
   }
-  typesSorted.Sort([](const ezRTTI* a, const ezRTTI* b) { return ezStringUtils::Compare(a->GetTypeName(), b->GetTypeName()) < 0; });
+  typesSorted.Sort([](const ezRTTI* a, const ezRTTI* b)
+    { return ezStringUtils::Compare(a->GetTypeName(), b->GetTypeName()) < 0; });
   for (const ezRTTI* pType : typesSorted)
   {
     uiHash = ezHashingUtils::xxHash64(pType->GetTypeName(), std::strlen(pType->GetTypeName()), uiHash);
@@ -406,7 +407,8 @@ ezTransformStatus ezAssetDocument::DoTransformAsset(const ezPlatformProfile* pAs
     AssetHeader.SetFileHashAndVersion(uiHash, GetAssetTypeVersion());
     const auto& outputs = GetAssetDocumentInfo()->m_Outputs;
 
-    auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus {
+    auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus
+    {
       const ezString sTargetFile = GetAssetDocumentManager()->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), szOutputTag, pAssetProfile);
       ezTransformStatus ret = InternalTransformAsset(sTargetFile, szOutputTag, pAssetProfile, AssetHeader, transformFlags);
 
@@ -657,10 +659,11 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
 
   GetEditorEngineConnection()->SendMessage(&msg);
 
-  bool bSuccess = false;
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&bSuccess](ezProcessMessage* pMsg) -> bool {
+  ezStatus status(EZ_FAILURE);
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&status](ezProcessMessage* pMsg) -> bool
+  {
     ezExportDocumentMsgToEditor* pMsg2 = ezDynamicCast<ezExportDocumentMsgToEditor*>(pMsg);
-    bSuccess = pMsg2->m_bOutputSuccess;
+    status = ezStatus(pMsg2->m_bOutputSuccess ? EZ_SUCCESS : EZ_FAILURE, pMsg2->m_sFailureMsg);
     return true;
   };
 
@@ -670,9 +673,9 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
   }
   else
   {
-    if (!bSuccess)
+    if (status.Failed())
     {
-      return ezStatus(ezFmt("Remote exporting {0} to \"{1}\" failed.", GetDocumentTypeName(), msg.m_sOutputFile));
+      return status;
     }
 
     ezLog::Success("{0} \"{1}\" has been exported.", GetDocumentTypeName(), msg.m_sOutputFile);
@@ -719,7 +722,8 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
   GetEditorEngineConnection()->SendMessage(&msg);
 
   ezDataBuffer data;
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
+  {
     ezCreateThumbnailMsgToEditor* pThumbnailMsg = ezDynamicCast<ezCreateThumbnailMsgToEditor*>(pMsg);
     data = pThumbnailMsg->m_ThumbnailData;
     return true;
@@ -791,7 +795,8 @@ void ezAssetDocument::HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg)
 
 void ezAssetDocument::AddSyncObject(ezEditorEngineSyncObject* pSync) const
 {
-  pSync->Configure(GetGuid(), [this](ezEditorEngineSyncObject* pSync) { RemoveSyncObject(pSync); });
+  pSync->Configure(GetGuid(), [this](ezEditorEngineSyncObject* pSync)
+    { RemoveSyncObject(pSync); });
 
   m_SyncObjects.PushBack(pSync);
   m_AllSyncObjects[pSync->GetGuid()] = pSync;

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -214,6 +214,8 @@ public:
   /// \brief Instructs the engine to reload its resources
   void ReloadEngineResources();
 
+  void RestartEngineProcessIfPluginsChanged();
+
 Q_SIGNALS:
   void IdleEvent();
 
@@ -251,7 +253,6 @@ private:
   void LoadProjectPreferences();
   void StoreEnginePluginModificationTimes();
   bool CheckForEnginePluginModifications();
-  void RestartEngineProcessIfPluginsChanged();
   void SaveAllOpenDocuments();
 
   void ReadTagRegistry();

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -233,7 +233,8 @@ bool ezEditorEngineProcessConnection::ConnectToRemoteProcess()
   m_pRemoteProcess->ConnectToServer(dlg.GetResultingAddress().toUtf8().data()).IgnoreResult();
 
   ezQtWaitForOperationDlg waitDialog(QApplication::activeWindow());
-  waitDialog.m_OnIdle = [this]() -> bool {
+  waitDialog.m_OnIdle = [this]() -> bool
+  {
     if (m_pRemoteProcess->IsConnected())
       return false;
 
@@ -325,7 +326,8 @@ ezResult ezEditorEngineProcessConnection::WaitForDocumentMessage(const ezUuid& a
   data.m_AssetGuid = assetGuid;
   data.m_pCallback = pCallback;
 
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
+  {
     ezEditorEngineDocumentMsg* pMsg2 = ezDynamicCast<ezEditorEngineDocumentMsg*>(pMsg);
     if (pMsg2 && data.m_AssetGuid == pMsg2->m_DocumentGuid)
     {
@@ -398,16 +400,18 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
   {
     docs.PushBack(it.Value());
   }
-  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b) {
+  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b)
+    {
     if (a->IsMainDocument() != b->IsMainDocument())
       return a->IsMainDocument();
-    return a < b;
-  });
+    return a < b; });
 
   for (ezAssetDocument* pDoc : docs)
   {
     SendDocumentOpenMessage(pDoc, true);
   }
+
+  ezAssetCurator::GetSingleton()->InvalidateAssetsWithTransformState(ezAssetInfo::TransformState::TransformError);
 
   ezLog::Success("Engine Process is running");
 

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -233,8 +233,7 @@ bool ezEditorEngineProcessConnection::ConnectToRemoteProcess()
   m_pRemoteProcess->ConnectToServer(dlg.GetResultingAddress().toUtf8().data()).IgnoreResult();
 
   ezQtWaitForOperationDlg waitDialog(QApplication::activeWindow());
-  waitDialog.m_OnIdle = [this]() -> bool
-  {
+  waitDialog.m_OnIdle = [this]() -> bool {
     if (m_pRemoteProcess->IsConnected())
       return false;
 
@@ -326,8 +325,7 @@ ezResult ezEditorEngineProcessConnection::WaitForDocumentMessage(const ezUuid& a
   data.m_AssetGuid = assetGuid;
   data.m_pCallback = pCallback;
 
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
-  {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
     ezEditorEngineDocumentMsg* pMsg2 = ezDynamicCast<ezEditorEngineDocumentMsg*>(pMsg);
     if (pMsg2 && data.m_AssetGuid == pMsg2->m_DocumentGuid)
     {
@@ -400,8 +398,7 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
   {
     docs.PushBack(it.Value());
   }
-  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b)
-    {
+  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b) {
     if (a->IsMainDocument() != b->IsMainDocument())
       return a->IsMainDocument();
     return a < b; });

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -61,6 +61,8 @@ public:
   {
     if (const ezProcessAssetMsg* pMsg = ezDynamicCast<const ezProcessAssetMsg*>(e.m_pMessage))
     {
+      ezQtEditorApp::GetSingleton()->RestartEngineProcessIfPluginsChanged();
+
       ezProcessAssetResponseMsg msg;
       {
         ezLogEntryDelegate logger([&msg](ezLogEntry& ref_entry) -> void { msg.m_LogEntries.PushBack(std::move(ref_entry)); },

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -1436,6 +1436,11 @@ void ezSceneDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
 
 ezTransformStatus ezSceneDocument::ExportScene(bool bCreateThumbnail)
 {
+  if (GetUnknownObjectTypeInstances() > 0)
+  {
+    return ezTransformStatus("Can't export scene/prefab when it contains unknown object types.");
+  }
+
   // #TODO export layers
   auto saveres = SaveDocument();
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/LayerContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/LayerContext.cpp
@@ -113,10 +113,10 @@ void ezLayerContext::DestroyViewContext(ezEngineProcessViewContext* pContext)
   EZ_REPORT_FAILURE("Layers should not create views.");
 }
 
-bool ezLayerContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
+ezStatus ezLayerContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
 {
   EZ_REPORT_FAILURE("Layers do not support export yet. THe layer content is baked into the main scene instead.");
-  return false;
+  return ezStatus("Nope");
 }
 
 void ezLayerContext::UpdateDocumentContext()

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/LayerContext.h
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/LayerContext.h
@@ -27,7 +27,7 @@ protected:
 
   virtual ezEngineProcessViewContext* CreateViewContext() override;
   virtual void DestroyViewContext(ezEngineProcessViewContext* pContext) override;
-  virtual bool ExportDocument(const ezExportDocumentMsgToEngine* pMsg) override;
+  virtual ezStatus ExportDocument(const ezExportDocumentMsgToEngine* pMsg) override;
 
   virtual void UpdateDocumentContext() override;
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -939,8 +939,7 @@ void ezSceneContext::ExportExposedParameters(const ezWorldWriter& ww, ezDeferred
     paramdesc.m_sProperty.Assign(esp.m_sPropertyPath.GetData());
   }
 
-  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool
-    { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
+  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
 
   file << exposedParams.GetCount();
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -797,8 +797,22 @@ void ezSceneContext::InsertSelectedChildren(const ezGameObject* pObject)
   }
 }
 
-bool ezSceneContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
+ezStatus ezSceneContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
 {
+  if (!m_Context.m_UnknownTypes.IsEmpty())
+  {
+    ezStringBuilder s;
+
+    s.Append("Scene / prefab export failed: ");
+
+    for (const ezString& sType : m_Context.m_UnknownTypes)
+    {
+      s.AppendFormat("'{}' is unknown. ", sType);
+    }
+
+    return ezStatus(s.GetView());
+  }
+
   // make sure the world has been updated at least once, otherwise components aren't initialized
   // and messages for geometry extraction won't be delivered
   // this is necessary for the scene export modifiers to work
@@ -842,7 +856,10 @@ bool ezSceneContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
   }
 
   // do the actual file writing
-  return file.Close().Succeeded();
+  if (file.Close().Failed())
+    return ezStatus(ezFmt("Writing to '{}' failed.", pMsg->m_sOutputFile));
+
+  return ezStatus(EZ_SUCCESS);
 }
 
 void ezSceneContext::ExportExposedParameters(const ezWorldWriter& ww, ezDeferredFileWriter& file) const
@@ -922,7 +939,8 @@ void ezSceneContext::ExportExposedParameters(const ezWorldWriter& ww, ezDeferred
     paramdesc.m_sProperty.Assign(esp.m_sPropertyPath.GetData());
   }
 
-  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
+  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool
+    { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
 
   file << exposedParams.GetCount();
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.h
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.h
@@ -62,7 +62,7 @@ protected:
 
   virtual ezEngineProcessViewContext* CreateViewContext() override;
   virtual void DestroyViewContext(ezEngineProcessViewContext* pContext) override;
-  virtual bool ExportDocument(const ezExportDocumentMsgToEngine* pMsg) override;
+  virtual ezStatus ExportDocument(const ezExportDocumentMsgToEngine* pMsg) override;
   void ExportExposedParameters(const ezWorldWriter& ww, ezDeferredFileWriter& file) const;
 
   virtual bool UpdateThumbnailViewContext(ezEngineProcessViewContext* pThumbnailViewContext) override;

--- a/Code/Engine/Foundation/Serialization/Implementation/RttiConverterReader.cpp
+++ b/Code/Engine/Foundation/Serialization/Implementation/RttiConverterReader.cpp
@@ -16,7 +16,7 @@ ezInternal::NewInstance<void> ezRttiConverterReader::CreateObjectFromNode(const 
   const ezRTTI* pRtti = ezRTTI::FindTypeByName(pNode->GetType());
   if (pRtti == nullptr)
   {
-    ezLog::Error("RTTI type '{0}' is unknown, CreateObjectFromNode failed.", pNode->GetType());
+    m_pContext->OnUnknownTypeError(pNode->GetType());
     return nullptr;
   }
 

--- a/Code/Engine/Foundation/Serialization/Implementation/RttiConverterWriter.cpp
+++ b/Code/Engine/Foundation/Serialization/Implementation/RttiConverterWriter.cpp
@@ -1,5 +1,6 @@
 #include <Foundation/FoundationPCH.h>
 
+#include <Foundation/Logging/Log.h>
 #include <Foundation/Reflection/ReflectionUtils.h>
 #include <Foundation/Serialization/RttiConverter.h>
 #include <Foundation/Types/ScopeExit.h>

--- a/Code/Engine/Foundation/Serialization/Implementation/RttiConverterWriter.cpp
+++ b/Code/Engine/Foundation/Serialization/Implementation/RttiConverterWriter.cpp
@@ -12,6 +12,11 @@ void ezRttiConverterContext::Clear()
   m_QueuedObjects.Clear();
 }
 
+void ezRttiConverterContext::OnUnknownTypeError(ezStringView sTypeName)
+{
+  ezLog::Error("RTTI type '{0}' is unknown, CreateObjectFromNode failed.", sTypeName);
+}
+
 ezUuid ezRttiConverterContext::GenerateObjectGuid(const ezUuid& parentGuid, const ezAbstractProperty* pProp, ezVariant index, void* pObject) const
 {
   ezUuid guid = parentGuid;
@@ -146,7 +151,8 @@ ezRttiConverterWriter::ezRttiConverterWriter(ezAbstractObjectGraph* pGraph, ezRt
   m_pGraph = pGraph;
   m_pContext = pContext;
 
-  m_Filter = [bSerializeReadOnly, bSerializeOwnerPtrs](const void* pObject, const ezAbstractProperty* pProp) {
+  m_Filter = [bSerializeReadOnly, bSerializeOwnerPtrs](const void* pObject, const ezAbstractProperty* pProp)
+  {
     if (pProp->GetFlags().IsSet(ezPropertyFlags::ReadOnly) && !bSerializeReadOnly)
       return false;
 

--- a/Code/Engine/Foundation/Serialization/Implementation/RttiConverterWriter.cpp
+++ b/Code/Engine/Foundation/Serialization/Implementation/RttiConverterWriter.cpp
@@ -151,8 +151,7 @@ ezRttiConverterWriter::ezRttiConverterWriter(ezAbstractObjectGraph* pGraph, ezRt
   m_pGraph = pGraph;
   m_pContext = pContext;
 
-  m_Filter = [bSerializeReadOnly, bSerializeOwnerPtrs](const void* pObject, const ezAbstractProperty* pProp)
-  {
+  m_Filter = [bSerializeReadOnly, bSerializeOwnerPtrs](const void* pObject, const ezAbstractProperty* pProp) {
     if (pProp->GetFlags().IsSet(ezPropertyFlags::ReadOnly) && !bSerializeReadOnly)
       return false;
 

--- a/Code/Engine/Foundation/Serialization/RttiConverter.h
+++ b/Code/Engine/Foundation/Serialization/RttiConverter.h
@@ -50,6 +50,8 @@ public:
   virtual ezUuid EnqueObject(const ezUuid& guid, const ezRTTI* pRtti, void* pObject);
   virtual ezRttiConverterObject DequeueObject();
 
+  virtual void OnUnknownTypeError(ezStringView sTypeName);
+
 protected:
   ezHashTable<ezUuid, ezRttiConverterObject> m_GuidToObject;
   mutable ezHashTable<const void*, ezUuid> m_ObjectToGuid;
@@ -77,11 +79,11 @@ public:
   ezAbstractObjectNode* AddSubObjectToGraph(const ezRTTI* pRtti, const void* pObject, const ezUuid& guid, const char* szNodeName);
 
 private:
-  ezRttiConverterContext* m_pContext;
-  ezAbstractObjectGraph* m_pGraph;
+  ezRttiConverterContext* m_pContext = nullptr;
+  ezAbstractObjectGraph* m_pGraph = nullptr;
   FilterFunction m_Filter;
-  bool m_bSerializeReadOnly;
-  bool m_bSerializeOwnerPtrs;
+  bool m_bSerializeReadOnly = false;
+  bool m_bSerializeOwnerPtrs = false;
 };
 
 class EZ_FOUNDATION_DLL ezRttiConverterReader
@@ -96,6 +98,6 @@ private:
   void ApplyProperty(void* pObject, ezAbstractProperty* pProperty, const ezAbstractObjectNode::Property* pSource);
   void CallOnObjectCreated(const ezAbstractObjectNode* pNode, const ezRTTI* pRtti, void* pObject);
 
-  ezRttiConverterContext* m_pContext;
-  const ezAbstractObjectGraph* m_pGraph;
+  ezRttiConverterContext* m_pContext = nullptr;
+  const ezAbstractObjectGraph* m_pGraph = nullptr;
 };


### PR DESCRIPTION
Currently when a prefab is exported, it will just skip unknown component types and the export succeeds.

So for example, if a game plugin is currently not compiled, and vital components are missing, the export doesn't care and just removes those components from the exported scene.

This is obviously problematic, because then those prefabs don't work as intended. It is also a problem, because the background asset processor will make sure that all assets get exported, so if you open a project that uses a C++ game plugin, it is unlikely that you manage to compile that, before all prefabs are exported in a broken state.

The solution is to detect this case, and fail the export step, so that you are forced to compile the necessary code first. Additionally, whenever the engine process is reloaded, all previously failed assets are re-evaluated, so that they automatically export successfully, once this is possible.
