### PR TITLE
# Asset Dependency Overhaul

### DIFF
--- a/Code/Editor/EditorFramework/Actions/AssetActions.h
+++ b/Code/Editor/EditorFramework/Actions/AssetActions.h
@@ -10,7 +10,8 @@ public:
   static void RegisterActions();
   static void UnregisterActions();
 
-  static void MapActions(const char* szMapping, bool bDocument);
+  static void MapMenuActions(const char* szMapping, const char* szPath);
+  static void MapToolBarActions(const char* szMapping, bool bDocument);
 
   static ezActionDescriptorHandle s_hAssetCategory;
   static ezActionDescriptorHandle s_hTransformAsset;
@@ -18,6 +19,7 @@ public:
   static ezActionDescriptorHandle s_hResaveAllAssets;
   static ezActionDescriptorHandle s_hCheckFileSystem;
   static ezActionDescriptorHandle s_hWriteLookupTable;
+  static ezActionDescriptorHandle s_hWriteDependencyDGML;
 };
 
 ///
@@ -33,6 +35,7 @@ public:
     ResaveAllAssets,
     CheckFileSystem,
     WriteLookupTable,
+    WriteDependencyDGML,
   };
 
   ezAssetAction(const ezActionContext& context, const char* szName, ButtonType button);

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -67,8 +67,9 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
     NeedsTransform,
     NeedsThumbnail,
     TransformError,
-    MissingDependency,
-    MissingReference,
+    MissingTransformDependency,
+    MissingThumbnailDependency,
+    CircularDependency,
     COUNT,
   };
 
@@ -87,8 +88,9 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
 
   ezUniquePtr<ezAssetDocumentInfo> m_Info;
 
-  ezSet<ezString> m_MissingDependencies;
-  ezSet<ezString> m_MissingReferences;
+  ezSet<ezString> m_MissingTransformDeps;
+  ezSet<ezString> m_MissingThumbnailDeps;
+  ezSet<ezString> m_CircularDependencies;
 
   ezSet<ezUuid> m_SubAssets; ///< Main asset uses the same GUID as this (see m_Info), but is NOT stored in m_SubAssets
 
@@ -270,8 +272,6 @@ public:
   /// \brief Computes the combined hash for the asset and its references. Returns 0 if anything went wrong.
   ezUInt64 GetAssetReferenceHash(ezUuid assetGuid);
 
-  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>* pDependencies, ezSet<ezString>* pReferences);
-
   ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, bool bForce = false);
   /// \brief Returns the number of assets in the system and how many are in what transform state
   void GetAssetTransformStats(ezUInt32& out_uiNumAssets, ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT>& out_count);
@@ -316,9 +316,23 @@ public:
 
   void NeedsReloadResources(const ezUuid& assetGuid);
 
+  void InvalidateAssetsWithTransformState(ezAssetInfo::TransformState state);
+
   ///@}
 
-  void InvalidateAssetsWithTransformState(ezAssetInfo::TransformState state);
+  /// \name Utilities
+  ///@{
+
+  /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
+  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDebs = false, bool bIncludeThumbnailDebs = false, bool bIncludePackageDebs = false) const;
+
+  /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.
+  void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inverseDeps, bool bIncludeTransformDebs = false, bool bIncludeThumbnailDebs = false) const;
+
+  /// \brief Generates a DGML graph of all transform and thumbnail dependencies.
+  void WriteDependencyDGML(const ezUuid& guid, ezStringView sOutputFile) const;
+
+  ///@}
 
 public:
   ezEvent<const ezAssetCuratorEvent&> m_Events;
@@ -361,13 +375,15 @@ private:
   /// \name Asset Hashing and Status Updates (AssetUpdates.cpp)
   ///@{
 
-  ezAssetInfo::TransformState HashAsset(ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDependencies, const ezHybridArray<ezString, 16>& runtimeDependencies, ezSet<ezString>& missingDependencies, ezSet<ezString>& missingReferences, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
+  ezAssetInfo::TransformState HashAsset(
+    ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDeps, const ezHybridArray<ezString, 16>& assetThumbnailDeps, ezSet<ezString>& missingTransformDeps, ezSet<ezString>& missingThumbnailDeps, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
   bool AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
 
   ezResult EnsureAssetInfoUpdated(const ezUuid& assetGuid);
   ezResult EnsureAssetInfoUpdated(const char* szAbsFilePath);
   void TrackDependencies(ezAssetInfo* pAssetInfo);
   void UntrackDependencies(ezAssetInfo* pAssetInfo);
+  ezResult CheckForCircularDependencies(ezAssetInfo* pAssetInfo);
   void UpdateTrackedFiles(const ezUuid& assetGuid, const ezSet<ezString>& files, ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, ezSet<std::tuple<ezUuid, ezUuid>>& unresolved, bool bAdd);
   void UpdateUnresolvedTrackedFiles(ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, ezSet<std::tuple<ezUuid, ezUuid>>& unresolved);
   ezResult ReadAssetDocumentInfo(const char* szAbsFilePath, ezFileStatus& stat, ezUniquePtr<ezAssetInfo>& assetInfo);
@@ -426,10 +442,10 @@ private:
   ezSet<ezString> m_AssetFolders;
 
   // Derived dependency lookup tables
-  ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseDependency;
-  ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseReferences;
-  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedDependencies; ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
-  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedReferences;
+  ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseTransformDeps; // [Absolute path -> asset Guid]
+  ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseThumbnailDeps; // [Absolute path -> asset Guid]
+  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedTransformDeps; ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
+  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedThumbnailDeps;
 
   // State caches
   ezHashSet<ezUuid> m_TransformState[ezAssetInfo::TransformState::COUNT];

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -444,7 +444,7 @@ private:
   // Derived dependency lookup tables
   ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseTransformDeps; // [Absolute path -> asset Guid]
   ezMap<ezString, ezHybridArray<ezUuid, 1>> m_InverseThumbnailDeps; // [Absolute path -> asset Guid]
-  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedTransformDeps; ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
+  ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedTransformDeps;      ///< If a dependency wasn't known yet when an asset info was loaded, it is put in here.
   ezSet<std::tuple<ezUuid, ezUuid>> m_UnresolvedThumbnailDeps;
 
   // State caches

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -324,10 +324,10 @@ public:
   ///@{
 
   /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
-  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDebs = false, bool bIncludeThumbnailDebs = false, bool bIncludePackageDebs = false) const;
+  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false, bool bIncludePackageDeps = false) const;
 
-  /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.
-  void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inverseDeps, bool bIncludeTransformDebs = false, bool bIncludeThumbnailDebs = false) const;
+  /// \brief Generates one inverse transitive hull for all the types dependencies that are enabled. The set will contain inverse dependencies that can reach the given asset (pAssetInfo) via any combination of the enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.
+  void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inverseDeps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false) const;
 
   /// \brief Generates a DGML graph of all transform and thumbnail dependencies.
   void WriteDependencyDGML(const ezUuid& guid, ezStringView sOutputFile) const;

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentInfo.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentInfo.h
@@ -16,12 +16,12 @@ public:
   void CreateShallowClone(ezAssetDocumentInfo& out_docInfo) const;
   void ClearMetaData();
 
-  ezUInt64 m_uiSettingsHash; ///< Current hash over all settings in the document, used to check resulting resource for being up-to-date in combination
-                             ///< with dependency hashes.
-  ezSet<ezString>
-    m_AssetTransformDependencies;        ///< Files that are required to generate the asset, ie. if one changes, the asset needs to be recreated
-  ezSet<ezString> m_RuntimeDependencies; ///< Other files that are used at runtime together with this asset, e.g. materials for a mesh, needed for
-                                         ///< thumbnails and packaging.
+  ezUInt64 m_uiSettingsHash; ///< Current hash over all settings in the document, used to check resulting resource for being up-to-date in combination with dependency hashes.
+
+  ezSet<ezString> m_TransformDependencies; ///< [Data dir relative path or GUID] Files that are required to generate the asset, ie. if one changes, the asset needs to be recreated
+  ezSet<ezString> m_ThumbnailDependencies; ///< [Data dir relative path or GUID] Files that are used to generate the thumbnail.
+  ezSet<ezString> m_PackageDependencies;   ///< [Data dir relative path or GUID] Files that are needed at runtime and should be packaged with the game.
+
   ezSet<ezString> m_Outputs; ///< Additional output this asset produces besides the default one. These are tags like VISUAL_SHADER that are resolved
                              ///< by the ezAssetDocumentManager into paths.
   ezHashedString m_sAssetsDocumentTypeName;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -299,11 +299,14 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int iRole) const
         case ezAssetInfo::TransformError:
           sToolTip.Append("Transform Error");
           break;
-        case ezAssetInfo::MissingDependency:
-          sToolTip.Append("Missing Dependency");
+        case ezAssetInfo::MissingTransformDependency:
+          sToolTip.Append("Missing Transform Dependency");
           break;
-        case ezAssetInfo::MissingReference:
-          sToolTip.Append("Missing Reference");
+        case ezAssetInfo::MissingThumbnailDependency:
+          sToolTip.Append("Missing Thumbnail Dependency");
+          break;
+        case ezAssetInfo::CircularDependency:
+          sToolTip.Append("Circular Dependency");
           break;
         default:
           break;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -226,11 +226,14 @@ void ezQtIconViewDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem&
       case ezAssetInfo::TransformState::UpToDate:
         ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetOk16.png").paint(pPainter, thumbnailRect);
         break;
-      case ezAssetInfo::TransformState::MissingDependency:
+      case ezAssetInfo::TransformState::MissingTransformDependency:
         ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingDependency16.png").paint(pPainter, thumbnailRect);
         break;
-      case ezAssetInfo::TransformState::MissingReference:
+      case ezAssetInfo::TransformState::MissingThumbnailDependency:
         ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingReference16.png").paint(pPainter, thumbnailRect);
+        break;
+      case ezAssetInfo::TransformState::CircularDependency:
+        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetFailedTransform16.png").paint(pPainter, thumbnailRect);
         break;
       case ezAssetInfo::TransformState::TransformError:
         ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetFailedTransform16.png").paint(pPainter, thumbnailRect);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -13,6 +13,7 @@
 #include <Foundation/Serialization/ReflectionSerializer.h>
 #include <Foundation/Time/Stopwatch.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
+#include <Foundation/Utilities/DGMLWriter.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 #define EZ_CURATOR_CACHE_VERSION 2
@@ -86,10 +87,12 @@ void ezAssetInfo::Update(ezUniquePtr<ezAssetInfo>& rhs)
   m_sDataDirParentRelativePath = std::move(rhs->m_sDataDirParentRelativePath);
   m_sDataDirRelativePath = ezStringView(m_sDataDirParentRelativePath.FindSubString("/") + 1); // skip the initial folder
   m_Info = std::move(rhs->m_Info);
+
   m_AssetHash = rhs->m_AssetHash;
   m_ThumbHash = rhs->m_ThumbHash;
-  m_MissingDependencies = rhs->m_MissingDependencies;
-  m_MissingReferences = rhs->m_MissingReferences;
+  m_MissingTransformDeps = std::move(rhs->m_MissingTransformDeps);
+  m_MissingThumbnailDeps = std::move(rhs->m_MissingThumbnailDeps);
+  m_CircularDependencies = std::move(rhs->m_CircularDependencies);
   // Don't copy m_SubAssets, we want to update it independently.
   rhs = nullptr;
 }
@@ -152,7 +155,8 @@ void ezAssetCurator::StartInitialize(const ezApplicationFileSystemConfig& cfg)
   m_pWatcher = EZ_DEFAULT_NEW(ezAssetWatcher, m_FileSystemConfig);
   m_pAssetTableWriter = EZ_DEFAULT_NEW(ezAssetTableWriter, m_FileSystemConfig);
 
-  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]() {
+  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]()
+    {
     EZ_LOCK(m_CuratorMutex);
     LoadCaches();
 
@@ -436,7 +440,7 @@ void ezAssetCurator::ResaveAllAssets()
   for (auto itAsset = m_KnownAssets.GetIterator(); itAsset.IsValid(); ++itAsset)
   {
     auto it2 = dependencies.Insert(itAsset.Key(), ezSet<ezUuid>());
-    for (const ezString& dep : itAsset.Value()->m_Info->m_AssetTransformDependencies)
+    for (const ezString& dep : itAsset.Value()->m_Info->m_TransformDependencies)
     {
       if (ezConversionUtils::IsStringUuid(dep))
       {
@@ -638,7 +642,8 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
   // TODO: This is the old slow code path that will find the longest substring match.
   // Should be removed or folded into FindBestMatchForFile once it's surely not needed anymore.
 
-  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo* {
+  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo*
+  {
     // try to find the 'exact' relative path
     // otherwise find the shortest possible path
     ezUInt32 uiMinLength = 0xFFFFFFFF;
@@ -753,53 +758,6 @@ ezUInt64 ezAssetCurator::GetAssetReferenceHash(ezUuid assetGuid)
   return thumbHash;
 }
 
-void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>* pDependencies, ezSet<ezString>* pReferences)
-{
-  if (ezConversionUtils::IsStringUuid(sAssetOrPath))
-  {
-    auto it = m_KnownSubAssets.Find(ezConversionUtils::ConvertStringToUuid(sAssetOrPath));
-    ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
-    const bool bInsertDep = pDependencies && !pDependencies->Contains(pAssetInfo->m_sAbsolutePath);
-    const bool bInsertRef = pReferences && !pReferences->Contains(pAssetInfo->m_sAbsolutePath);
-
-    if (bInsertDep)
-    {
-      pDependencies->Insert(pAssetInfo->m_sAbsolutePath);
-    }
-    if (bInsertRef)
-    {
-      pReferences->Insert(pAssetInfo->m_sAbsolutePath);
-    }
-
-    if (pDependencies)
-    {
-      for (const ezString& dep : pAssetInfo->m_Info->m_AssetTransformDependencies)
-      {
-        GenerateTransitiveHull(dep, pDependencies, nullptr);
-      }
-    }
-
-    if (pReferences)
-    {
-      for (const ezString& ref : pAssetInfo->m_Info->m_RuntimeDependencies)
-      {
-        GenerateTransitiveHull(ref, nullptr, pReferences);
-      }
-    }
-  }
-  else
-  {
-    if (pDependencies && !pDependencies->Contains(sAssetOrPath))
-    {
-      pDependencies->Insert(sAssetOrPath);
-    }
-    if (pReferences && !pReferences->Contains(sAssetOrPath))
-    {
-      pReferences->Insert(sAssetOrPath);
-    }
-  }
-}
-
 ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile*, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, bool bForce)
 {
   return ezAssetCurator::UpdateAssetTransformState(assetGuid, out_uiAssetHash, out_uiThumbHash, bForce);
@@ -831,6 +789,19 @@ ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid ass
     ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
     assetGuid = pAssetInfo->m_Info->m_DocumentID;
 
+    // Circular dependencies can change if any asset in the circle has changed (and potentially broken the circle). Thus, we need to call CheckForCircularDependencies again for every asset.
+    if (!pAssetInfo->m_CircularDependencies.IsEmpty() && m_TransformStateStale.Contains(assetGuid))
+    {
+      pAssetInfo->m_CircularDependencies.Clear();
+      if (CheckForCircularDependencies(pAssetInfo).Failed())
+      {
+        UpdateAssetTransformState(assetGuid, ezAssetInfo::CircularDependency);
+        out_AssetHash = 0;
+        out_ThumbHash = 0;
+        return ezAssetInfo::CircularDependency;
+      }
+    }
+
     // Setting an asset to unknown actually does not change the m_TransformState but merely adds it to the m_TransformStateStale list.
     // This is to prevent the user facing state to constantly fluctuate if something is tagged as modified but not actually changed (E.g. saving a
     // file without modifying the content). Thus we need to check for m_TransformStateStale as well as for the set state.
@@ -854,8 +825,8 @@ ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid ass
   ezString sAssetFile;
   ezUInt8 uiLastStateUpdate = 0;
   ezUInt64 uiSettingsHash = 0;
-  ezHybridArray<ezString, 16> assetTransformDependencies;
-  ezHybridArray<ezString, 16> runtimeDependencies;
+  ezHybridArray<ezString, 16> transformDeps;
+  ezHybridArray<ezString, 16> thumbnailDeps;
   ezHybridArray<ezString, 16> outputs;
 
   // Lock asset and get all data needed for update computation.
@@ -870,13 +841,13 @@ ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid ass
     uiLastStateUpdate = pAssetInfo->m_LastStateUpdate;
     // The settings has combines both the file settings and the global profile settings.
     uiSettingsHash = pAssetInfo->m_Info->m_uiSettingsHash + pManager->GetAssetProfileHash();
-    for (const ezString& dep : pAssetInfo->m_Info->m_AssetTransformDependencies)
+    for (const ezString& dep : pAssetInfo->m_Info->m_TransformDependencies)
     {
-      assetTransformDependencies.PushBack(dep);
+      transformDeps.PushBack(dep);
     }
-    for (const ezString& ref : pAssetInfo->m_Info->m_RuntimeDependencies)
+    for (const ezString& ref : pAssetInfo->m_Info->m_ThumbnailDependencies)
     {
-      runtimeDependencies.PushBack(ref);
+      thumbnailDeps.PushBack(ref);
     }
     for (const ezString& output : pAssetInfo->m_Info->m_Outputs)
     {
@@ -885,12 +856,12 @@ ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid ass
   }
 
   ezAssetInfo::TransformState state = ezAssetInfo::TransformState::Unknown;
-  ezSet<ezString> missingDependencies;
-  ezSet<ezString> missingReferences;
+  ezSet<ezString> missingTransformDeps;
+  ezSet<ezString> missingThumbnailDeps;
   // Compute final state and hashes.
   {
-    state = HashAsset(uiSettingsHash, assetTransformDependencies, runtimeDependencies, missingDependencies, missingReferences, out_AssetHash, out_ThumbHash, bForce);
-    EZ_ASSERT_DEV(state == ezAssetInfo::Unknown || state == ezAssetInfo::MissingDependency || state == ezAssetInfo::MissingReference, "Unhandled case of HashAsset return value.");
+    state = HashAsset(uiSettingsHash, transformDeps, thumbnailDeps, missingTransformDeps, missingThumbnailDeps, out_AssetHash, out_ThumbHash, bForce);
+    EZ_ASSERT_DEV(state == ezAssetInfo::Unknown || state == ezAssetInfo::MissingTransformDependency || state == ezAssetInfo::MissingThumbnailDependency, "Unhandled case of HashAsset return value.");
 
     if (state == ezAssetInfo::Unknown)
     {
@@ -934,8 +905,8 @@ ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid ass
         UpdateAssetTransformState(assetGuid, state);
         pAssetInfo->m_AssetHash = out_AssetHash;
         pAssetInfo->m_ThumbHash = out_ThumbHash;
-        pAssetInfo->m_MissingDependencies = std::move(missingDependencies);
-        pAssetInfo->m_MissingReferences = std::move(missingReferences);
+        pAssetInfo->m_MissingTransformDeps = std::move(missingTransformDeps);
+        pAssetInfo->m_MissingThumbnailDeps = std::move(missingThumbnailDeps);
         if (state == ezAssetInfo::TransformState::UpToDate)
         {
           UpdateSubAssets(*pAssetInfo);
@@ -1018,7 +989,8 @@ ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArra
   {
     EZ_LOCK(m_CuratorMutex);
 
-    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool {
+    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool
+    {
       for (auto it = m_ReferencedFiles.GetIterator(); it.IsValid(); ++it)
       {
         if (it.Value().m_Status != ezFileStatus::Status::Valid)
@@ -1069,7 +1041,8 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   ezSet<ezUuid> todoList;
   todoList.Insert(assetGuid);
 
-  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset) {
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset)
+  {
     auto it = inverseTracker.Find(sAsset);
     if (it.IsValid())
     {
@@ -1093,8 +1066,8 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
     if (pInfo)
     {
       sCurrentAsset = pInfo->m_sAbsolutePath;
-      GatherReferences(m_InverseReferences, sCurrentAsset);
-      GatherReferences(m_InverseDependency, sCurrentAsset);
+      GatherReferences(m_InverseThumbnailDeps, sCurrentAsset);
+      GatherReferences(m_InverseTransformDeps, sCurrentAsset);
     }
   } while (bTransitive && !todoList.IsEmpty());
 }
@@ -1180,6 +1153,205 @@ void ezAssetCurator::NeedsReloadResources(const ezUuid& assetGuid)
   }
 }
 
+void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDebs, bool bIncludeThumbnailDebs, bool bIncludePackageDebs) const
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  ezHybridArray<ezString, 6> toDoList;
+  deps.Insert(sAssetOrPath);
+  toDoList.PushBack(sAssetOrPath);
+
+  while (!toDoList.IsEmpty())
+  {
+    ezString currentAsset = toDoList.PeekBack();
+    toDoList.PopBack();
+
+    if (ezConversionUtils::IsStringUuid(currentAsset))
+    {
+      auto it = m_KnownSubAssets.Find(ezConversionUtils::ConvertStringToUuid(currentAsset));
+      ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
+
+      if (bIncludeTransformDebs)
+      {
+        for (const ezString& dep : pAssetInfo->m_Info->m_TransformDependencies)
+        {
+          if (!deps.Contains(dep))
+          {
+            deps.Insert(dep);
+            toDoList.PushBack(dep);
+          }
+        }
+      }
+      if (bIncludeThumbnailDebs)
+      {
+        for (const ezString& dep : pAssetInfo->m_Info->m_ThumbnailDependencies)
+        {
+          if (!deps.Contains(dep))
+          {
+            deps.Insert(dep);
+            toDoList.PushBack(dep);
+          }
+        }
+      }
+      if (bIncludePackageDebs)
+      {
+        for (const ezString& dep : pAssetInfo->m_Info->m_PackageDependencies)
+        {
+          if (!deps.Contains(dep))
+          {
+            deps.Insert(dep);
+            toDoList.PushBack(dep);
+          }
+        }
+      }
+    }
+  }
+}
+
+void ezAssetCurator::GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inverseDeps, bool bIncludeTransformDebs, bool bIncludeThumbnailDebs) const
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  ezHybridArray<const ezAssetInfo*, 6> toDoList;
+  toDoList.PushBack(pAssetInfo);
+  inverseDeps.Insert(pAssetInfo->m_Info->m_DocumentID);
+
+  while (!toDoList.IsEmpty())
+  {
+    const ezAssetInfo* currentAsset = toDoList.PeekBack();
+    toDoList.PopBack();
+
+    if (bIncludeTransformDebs)
+    {
+      if (auto it = m_InverseTransformDeps.Find(currentAsset->m_sAbsolutePath); it.IsValid())
+      {
+        for (const ezUuid& asset : it.Value())
+        {
+          if (!inverseDeps.Contains(asset))
+          {
+            ezAssetInfo* pAssetInfo = nullptr;
+            if (m_KnownAssets.TryGetValue(asset, pAssetInfo))
+            {
+              toDoList.PushBack(pAssetInfo);
+              inverseDeps.Insert(asset);
+            }
+          }
+        }
+      }
+    }
+
+    if (bIncludeThumbnailDebs)
+    {
+      if (auto it = m_InverseThumbnailDeps.Find(currentAsset->m_sAbsolutePath); it.IsValid())
+      {
+        for (const ezUuid& asset : it.Value())
+        {
+          if (!inverseDeps.Contains(asset))
+          {
+            ezAssetInfo* pAssetInfo = nullptr;
+            if (m_KnownAssets.TryGetValue(asset, pAssetInfo))
+            {
+              toDoList.PushBack(pAssetInfo);
+              inverseDeps.Insert(asset);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutputFile) const
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  ezDGMLGraph graph;
+
+  ezSet<ezString> deps;
+  ezStringBuilder sTemp;
+  GenerateTransitiveHull(ezConversionUtils::ToString(guid, sTemp), deps, true, true);
+
+  ezHashTable<ezString, ezUInt32> nodeMap;
+  nodeMap.Reserve(deps.GetCount());
+  for (auto& dep : deps)
+  {
+    ezDGMLGraph::NodeDesc nd;
+    if (ezConversionUtils::IsStringUuid(dep))
+    {
+      auto it = m_KnownSubAssets.Find(ezConversionUtils::ConvertStringToUuid(dep));
+      const ezSubAsset& subAsset = it.Value();
+      const ezAssetInfo* pAssetInfo = subAsset.m_pAssetInfo;
+      if (subAsset.m_bMainAsset)
+      {
+        nd.m_Color = ezColor::Blue;
+        sTemp.Format("{}", pAssetInfo->m_sDataDirParentRelativePath);
+      }
+      else
+      {
+        nd.m_Color = ezColor::AliceBlue;
+        sTemp.Format("{} | {}", pAssetInfo->m_sDataDirParentRelativePath, subAsset.GetName());
+      }
+      nd.m_Shape = ezDGMLGraph::NodeShape::Rectangle;
+    }
+    else
+    {
+      sTemp = dep;
+      nd.m_Color = ezColor::Orange;
+      nd.m_Shape = ezDGMLGraph::NodeShape::Rectangle;
+    }
+    ezUInt32 uiGraphNode = graph.AddNode(sTemp, &nd);
+    nodeMap.Insert(dep, uiGraphNode);
+  }
+
+  for (auto& node : deps)
+  {
+    ezDGMLGraph::NodeDesc nd;
+    if (ezConversionUtils::IsStringUuid(node))
+    {
+      ezUInt32 uiInputNode = *nodeMap.GetValue(node);
+
+      auto it = m_KnownSubAssets.Find(ezConversionUtils::ConvertStringToUuid(node));
+      ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
+
+      ezMap<ezUInt32, ezString> connection;
+
+      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel)
+      {
+        ezUInt32 uiOutputNode = *nodeMap.GetValue(ref);
+        sTemp = connection[uiOutputNode];
+        if (sTemp.IsEmpty())
+          sTemp = sLabel;
+        else
+          sTemp.AppendFormat(" | {}", sLabel);
+        connection[uiOutputNode] = sTemp;
+      };
+
+      for (const ezString& ref : pAssetInfo->m_Info->m_TransformDependencies)
+      {
+        ExtendConnection(ref, "Transform");
+      }
+
+      for (const ezString& ref : pAssetInfo->m_Info->m_ThumbnailDependencies)
+      {
+        ExtendConnection(ref, "Thumbnail");
+      }
+
+      // This will make the graph very big, not recommended.
+      /* for (const ezString& ref : pAssetInfo->m_Info->m_PackageDependencies)
+       {
+         ExtendConnection(ref, "Package");
+       }*/
+
+      for (auto it : connection)
+      {
+        graph.AddConnection(uiInputNode, it.Key(), it.Value());
+      }
+    }
+  }
+
+  ezDGMLGraphWriter::WriteGraphToFile(sOutputFile, graph).IgnoreResult();
+}
+
 ////////////////////////////////////////////////////////////////////////
 // ezAssetCurator Processing
 ////////////////////////////////////////////////////////////////////////
@@ -1196,7 +1368,12 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
   ezUInt64 uiThumbHash = 0;
   ezAssetInfo::TransformState state = IsAssetUpToDate(pAssetInfo->m_Info->m_DocumentID, pAssetProfile, pTypeDesc, uiHash, uiThumbHash);
 
-  for (const auto& dep : pAssetInfo->m_Info->m_AssetTransformDependencies)
+  if (state == ezAssetInfo::TransformState::CircularDependency)
+  {
+    return ezTransformStatus(ezFmt("Circular dependency for asset '{0}', can't transform.", pAssetInfo->m_sAbsolutePath));
+  }
+
+  for (const auto& dep : pAssetInfo->m_Info->m_TransformDependencies)
   {
     ezBitflags<ezTransformFlags> transformFlagsDeps = transformFlags;
     transformFlagsDeps.Remove(ezTransformFlags::ForceTransform);
@@ -1207,7 +1384,7 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
   }
 
   ezTransformStatus resReferences;
-  for (const auto& ref : pAssetInfo->m_Info->m_RuntimeDependencies)
+  for (const auto& ref : pAssetInfo->m_Info->m_ThumbnailDependencies)
   {
     ezBitflags<ezTransformFlags> transformFlagsRefs = transformFlags;
     transformFlagsRefs.Remove(ezTransformFlags::ForceTransform);
@@ -1265,7 +1442,7 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
   if (state == ezAssetInfo::TransformState::UpToDate)
     return ezStatus(EZ_SUCCESS);
 
-  if (state == ezAssetInfo::TransformState::MissingDependency)
+  if (state == ezAssetInfo::TransformState::MissingTransformDependency)
   {
     return ezTransformStatus(ezFmt("Missing dependency for asset '{0}', can't transform.", pAssetInfo->m_sAbsolutePath));
   }
@@ -1294,7 +1471,7 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
     }
   }
 
-  if (state == ezAssetInfo::TransformState::MissingReference)
+  if (state == ezAssetInfo::TransformState::MissingThumbnailDependency)
   {
     return ezTransformStatus(ezFmt("Missing reference for asset '{0}', can't create thumbnail.", pAssetInfo->m_sAbsolutePath));
   }
@@ -1413,7 +1590,7 @@ void ezAssetCurator::HandleSingleFile(const ezString& sAbsolutePath)
         pFileStatus->m_AssetGuid = ezUuid();
       }
 
-      auto it = m_InverseDependency.Find(sAbsolutePath);
+      auto it = m_InverseTransformDeps.Find(sAbsolutePath);
       if (it.IsValid())
       {
         for (const ezUuid& guid : it.Value())
@@ -1422,7 +1599,7 @@ void ezAssetCurator::HandleSingleFile(const ezString& sAbsolutePath)
         }
       }
 
-      auto it2 = m_InverseReferences.Find(sAbsolutePath);
+      auto it2 = m_InverseThumbnailDeps.Find(sAbsolutePath);
       if (it2.IsValid())
       {
         for (const ezUuid& guid : it2.Value())
@@ -1465,7 +1642,7 @@ void ezAssetCurator::HandleSingleFile(const ezString& sAbsolutePath, const ezFil
     if (RefFile.m_AssetGuid.IsValid())
       InvalidateAssetTransformState(RefFile.m_AssetGuid);
 
-    auto it = m_InverseDependency.Find(sAbsolutePath);
+    auto it = m_InverseTransformDeps.Find(sAbsolutePath);
     if (it.IsValid())
     {
       for (const ezUuid& guid : it.Value())
@@ -1474,7 +1651,7 @@ void ezAssetCurator::HandleSingleFile(const ezString& sAbsolutePath, const ezFil
       }
     }
 
-    auto it2 = m_InverseReferences.Find(sAbsolutePath);
+    auto it2 = m_InverseThumbnailDeps.Find(sAbsolutePath);
     if (it2.IsValid())
     {
       for (const ezUuid& guid : it2.Value())
@@ -1550,7 +1727,7 @@ void ezAssetCurator::ProcessAllCoreAssets()
 
         for (const ezTempHashedString& name : transformOrder)
         {
-          for (const auto& ref : pSubAsset->m_pAssetInfo->m_Info->m_RuntimeDependencies)
+          for (const auto& ref : pSubAsset->m_pAssetInfo->m_Info->m_PackageDependencies)
           {
             if (ezAssetInfo* pInfo = GetAssetInfo(ref))
             {
@@ -1648,7 +1825,6 @@ void ezAssetCurator::RunNextUpdateTask()
     m_UpdateTaskGroup = ezTaskSystem::StartSingleTask(m_pUpdateTask, ezTaskPriority::FileAccess);
   }
 }
-
 
 ////////////////////////////////////////////////////////////////////////
 // ezAssetCurator Check File System Helper

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -155,8 +155,7 @@ void ezAssetCurator::StartInitialize(const ezApplicationFileSystemConfig& cfg)
   m_pWatcher = EZ_DEFAULT_NEW(ezAssetWatcher, m_FileSystemConfig);
   m_pAssetTableWriter = EZ_DEFAULT_NEW(ezAssetTableWriter, m_FileSystemConfig);
 
-  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]()
-    {
+  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]() {
     EZ_LOCK(m_CuratorMutex);
     LoadCaches();
 
@@ -642,8 +641,7 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
   // TODO: This is the old slow code path that will find the longest substring match.
   // Should be removed or folded into FindBestMatchForFile once it's surely not needed anymore.
 
-  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo*
-  {
+  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo* {
     // try to find the 'exact' relative path
     // otherwise find the shortest possible path
     ezUInt32 uiMinLength = 0xFFFFFFFF;
@@ -989,8 +987,7 @@ ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArra
   {
     EZ_LOCK(m_CuratorMutex);
 
-    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool
-    {
+    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool {
       for (auto it = m_ReferencedFiles.GetIterator(); it.IsValid(); ++it)
       {
         if (it.Value().m_Status != ezFileStatus::Status::Valid)
@@ -1041,8 +1038,7 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   ezSet<ezUuid> todoList;
   todoList.Insert(assetGuid);
 
-  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset)
-  {
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset) {
     auto it = inverseTracker.Find(sAsset);
     if (it.IsValid())
     {
@@ -1315,8 +1311,7 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
 
       ezMap<ezUInt32, ezString> connection;
 
-      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel)
-      {
+      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel) {
         ezUInt32 uiOutputNode = *nodeMap.GetValue(ref);
         sTemp = connection[uiOutputNode];
         if (sTemp.IsEmpty())

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1153,7 +1153,7 @@ void ezAssetCurator::NeedsReloadResources(const ezUuid& assetGuid)
   }
 }
 
-void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDebs, bool bIncludeThumbnailDebs, bool bIncludePackageDebs) const
+void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDeps, bool bIncludeThumbnailDeps, bool bIncludePackageDeps) const
 {
   EZ_LOCK(m_CuratorMutex);
 
@@ -1171,7 +1171,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
       auto it = m_KnownSubAssets.Find(ezConversionUtils::ConvertStringToUuid(currentAsset));
       ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
 
-      if (bIncludeTransformDebs)
+      if (bIncludeTransformDeps)
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_TransformDependencies)
         {
@@ -1182,7 +1182,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
           }
         }
       }
-      if (bIncludeThumbnailDebs)
+      if (bIncludeThumbnailDeps)
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_ThumbnailDependencies)
         {
@@ -1193,7 +1193,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
           }
         }
       }
-      if (bIncludePackageDebs)
+      if (bIncludePackageDeps)
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_PackageDependencies)
         {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -400,8 +400,7 @@ ezUInt64 ezAssetDocument::GetDocumentHash() const
   {
     typesSorted.PushBack(pType);
   }
-  typesSorted.Sort([](const ezRTTI* a, const ezRTTI* b)
-    { return ezStringUtils::Compare(a->GetTypeName(), b->GetTypeName()) < 0; });
+  typesSorted.Sort([](const ezRTTI* a, const ezRTTI* b) { return ezStringUtils::Compare(a->GetTypeName(), b->GetTypeName()) < 0; });
   for (const ezRTTI* pType : typesSorted)
   {
     uiHash = ezHashingUtils::xxHash64(pType->GetTypeName(), std::strlen(pType->GetTypeName()), uiHash);
@@ -445,8 +444,7 @@ ezTransformStatus ezAssetDocument::DoTransformAsset(const ezPlatformProfile* pAs
     AssetHeader.SetFileHashAndVersion(uiHash, GetAssetTypeVersion());
     const auto& outputs = GetAssetDocumentInfo()->m_Outputs;
 
-    auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus
-    {
+    auto GenerateOutput = [this, pAssetProfile, &AssetHeader, transformFlags](const char* szOutputTag) -> ezTransformStatus {
       const ezString sTargetFile = GetAssetDocumentManager()->GetAbsoluteOutputFileName(GetAssetDocumentTypeDescriptor(), GetDocumentPath(), szOutputTag, pAssetProfile);
       ezTransformStatus ret = InternalTransformAsset(sTargetFile, szOutputTag, pAssetProfile, AssetHeader, transformFlags);
 
@@ -759,8 +757,7 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
   GetEditorEngineConnection()->SendMessage(&msg);
 
   ezDataBuffer data;
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
-  {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
     ezCreateThumbnailMsgToEditor* pThumbnailMsg = ezDynamicCast<ezCreateThumbnailMsgToEditor*>(pMsg);
     data = pThumbnailMsg->m_ThumbnailData;
     return true;
@@ -832,8 +829,7 @@ void ezAssetDocument::HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg)
 
 void ezAssetDocument::AddSyncObject(ezEditorEngineSyncObject* pSync) const
 {
-  pSync->Configure(GetGuid(), [this](ezEditorEngineSyncObject* pSync)
-    { RemoveSyncObject(pSync); });
+  pSync->Configure(GetGuid(), [this](ezEditorEngineSyncObject* pSync) { RemoveSyncObject(pSync); });
 
   m_SyncObjects.PushBack(pSync);
   m_AllSyncObjects[pSync->GetGuid()] = pSync;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentInfo.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentInfo.cpp
@@ -7,8 +7,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAssetDocumentInfo, 2, ezRTTIDefaultAllocator<e
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_SET_MEMBER_PROPERTY("Dependencies", m_AssetTransformDependencies),
-    EZ_SET_MEMBER_PROPERTY("References", m_RuntimeDependencies),
+    EZ_SET_MEMBER_PROPERTY("Dependencies", m_TransformDependencies),
+    EZ_SET_MEMBER_PROPERTY("References", m_ThumbnailDependencies),
+    EZ_SET_MEMBER_PROPERTY("PackageDeps", m_PackageDependencies),
     EZ_SET_MEMBER_PROPERTY("Outputs", m_Outputs),
     EZ_MEMBER_PROPERTY("Hash", m_uiSettingsHash),
     EZ_ACCESSOR_PROPERTY("AssetType", GetAssetsDocumentTypeName, SetAssetsDocumentTypeName),
@@ -37,8 +38,9 @@ ezAssetDocumentInfo::ezAssetDocumentInfo(ezAssetDocumentInfo&& rhs)
 void ezAssetDocumentInfo::operator=(ezAssetDocumentInfo&& rhs)
 {
   m_uiSettingsHash = rhs.m_uiSettingsHash;
-  m_AssetTransformDependencies = rhs.m_AssetTransformDependencies;
-  m_RuntimeDependencies = rhs.m_RuntimeDependencies;
+  m_TransformDependencies = rhs.m_TransformDependencies;
+  m_ThumbnailDependencies = rhs.m_ThumbnailDependencies;
+  m_PackageDependencies = rhs.m_PackageDependencies;
   m_Outputs = rhs.m_Outputs;
   m_sAssetsDocumentTypeName = rhs.m_sAssetsDocumentTypeName;
   m_MetaInfo = std::move(rhs.m_MetaInfo);
@@ -47,8 +49,9 @@ void ezAssetDocumentInfo::operator=(ezAssetDocumentInfo&& rhs)
 void ezAssetDocumentInfo::CreateShallowClone(ezAssetDocumentInfo& rhs) const
 {
   rhs.m_uiSettingsHash = m_uiSettingsHash;
-  rhs.m_AssetTransformDependencies = m_AssetTransformDependencies;
-  rhs.m_RuntimeDependencies = m_RuntimeDependencies;
+  rhs.m_TransformDependencies = m_TransformDependencies;
+  rhs.m_ThumbnailDependencies = m_ThumbnailDependencies;
+  rhs.m_PackageDependencies = m_PackageDependencies;
   rhs.m_Outputs = m_Outputs;
   rhs.m_sAssetsDocumentTypeName = m_sAssetsDocumentTypeName;
   rhs.m_MetaInfo.Clear();

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -296,8 +296,7 @@ bool ezProcessTask::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, 
       return false;
   }
 
-  auto TestFunc = [this, &bComplete](const ezSet<ezString>& files) -> ezAssetInfo*
-  {
+  auto TestFunc = [this, &bComplete](const ezSet<ezString>& files) -> ezAssetInfo* {
     for (const auto& sFile : files)
     {
       if (ezAssetInfo* pFileInfo = ezAssetCurator::GetSingleton()->GetAssetInfo(sFile))
@@ -391,8 +390,7 @@ bool ezProcessTask::GetNextAssetToProcess(ezUuid& out_guid, ezStringBuilder& out
 void ezProcessTask::OnProcessCrashed()
 {
   m_Status = ezStatus("Asset processor crashed");
-  ezLogEntryDelegate logger([this](ezLogEntry& ref_entry)
-    { m_LogEntries.PushBack(std::move(ref_entry)); });
+  ezLogEntryDelegate logger([this](ezLogEntry& ref_entry) { m_LogEntries.PushBack(std::move(ref_entry)); });
   ezLog::Error(&logger, "AssetProcessor crashed!");
   ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "AssetProcessor crashed!");
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetWatcher.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetWatcher.cpp
@@ -258,7 +258,7 @@ void ezDirectoryUpdateTask::Execute()
   {
     CURATOR_PROFILE("FindReferencedFiles");
     // Find all currently known files that are under the given folder.
-    // TODO: is m_InverseDependency / m_InverseReferences covered by this?
+    // TODO: is m_InverseTransformDeps / m_InverseThumbnailDeps covered by this?
     // TODO: What about asset output files?
     EZ_LOCK(pCurator->m_CuratorMutex);
     auto itlowerBound = pCurator->m_ReferencedFiles.LowerBound(m_sFolder);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetWatcher.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetWatcher.cpp
@@ -258,8 +258,6 @@ void ezDirectoryUpdateTask::Execute()
   {
     CURATOR_PROFILE("FindReferencedFiles");
     // Find all currently known files that are under the given folder.
-    // TODO: is m_InverseTransformDeps / m_InverseThumbnailDeps covered by this?
-    // TODO: What about asset output files?
     EZ_LOCK(pCurator->m_CuratorMutex);
     auto itlowerBound = pCurator->m_ReferencedFiles.LowerBound(m_sFolder);
     while (itlowerBound.IsValid() && itlowerBound.Key().StartsWith_NoCase(m_sFolder))

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -92,7 +92,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezProjectActions::MapActions("SettingsTabMenuBar");
 
     ezActionMapManager::RegisterActionMap("AssetBrowserToolBar").IgnoreResult();
-    ezAssetActions::MapActions("AssetBrowserToolBar", false);
+    ezAssetActions::MapToolBarActions("AssetBrowserToolBar", false);
 
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezFileBrowserAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtFilePropertyWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezAssetBrowserAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtAssetPropertyWidget(); });

--- a/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
@@ -49,8 +49,9 @@ void ezQtCuratorControl::paintEvent(QPaintEvent* e)
   colors[ezAssetInfo::TransformState::NeedsTransform] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Blue));
   colors[ezAssetInfo::TransformState::NeedsThumbnail] = ezToQtColor(ezColorScheme::DarkUI(float(ezColorScheme::Blue + ezColorScheme::Green) * 0.5f * ezColorScheme::s_fIndexNormalizer));
   colors[ezAssetInfo::TransformState::UpToDate] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Green));
-  colors[ezAssetInfo::TransformState::MissingDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
-  colors[ezAssetInfo::TransformState::MissingReference] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Orange));
+  colors[ezAssetInfo::TransformState::MissingTransformDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
+  colors[ezAssetInfo::TransformState::MissingThumbnailDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Orange));
+  colors[ezAssetInfo::TransformState::CircularDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
   colors[ezAssetInfo::TransformState::TransformError] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
 
   const float fTotalCount = uiNumAssets;
@@ -75,8 +76,8 @@ void ezQtCuratorControl::paintEvent(QPaintEvent* e)
   ezStringBuilder s;
   s.Format("[Un: {0}, Imp: {4}, Tr: {1}, Th: {2}, Err: {3}]", sections[ezAssetInfo::TransformState::Unknown],
     sections[ezAssetInfo::TransformState::NeedsTransform], sections[ezAssetInfo::TransformState::NeedsThumbnail],
-    sections[ezAssetInfo::TransformState::MissingDependency] + sections[ezAssetInfo::TransformState::MissingReference] +
-      sections[ezAssetInfo::TransformState::TransformError],
+    sections[ezAssetInfo::TransformState::MissingTransformDependency] + sections[ezAssetInfo::TransformState::MissingThumbnailDependency] +
+      sections[ezAssetInfo::TransformState::TransformError] + sections[ezAssetInfo::TransformState::CircularDependency],
     sections[ezAssetInfo::TransformState::NeedsImport]);
 
   painter.setPen(QPen(Qt::white));
@@ -136,11 +137,16 @@ void ezQtCuratorControl::SlotUpdateTransformStats()
 
   if (uiNumAssets > 0)
   {
-    s.Format("Unknown: {0}\nImport Needed: {6}\nTransform Needed: {1}\nThumbnail Needed: {2}\nMissing Dependency: {3}\nMissing Reference: {4}\nFailed "
-             "Transform: {5}",
-      sections[ezAssetInfo::TransformState::Unknown], sections[ezAssetInfo::TransformState::NeedsTransform],
-      sections[ezAssetInfo::TransformState::NeedsThumbnail], sections[ezAssetInfo::TransformState::MissingDependency],
-      sections[ezAssetInfo::TransformState::MissingReference], sections[ezAssetInfo::TransformState::TransformError], sections[ezAssetInfo::TransformState::NeedsImport]);
+    s.Format("Unknown: {0}\nImport Needed: {1}\nTransform Needed: {2}\nThumbnail Needed: {3}\nMissing Dependency: {4}\nMissing Reference: {5}\nCircular Dependency: {6}\nFailed Transform: {7}",
+      sections[ezAssetInfo::TransformState::Unknown],
+      sections[ezAssetInfo::TransformState::NeedsImport],
+      sections[ezAssetInfo::TransformState::NeedsTransform],
+      sections[ezAssetInfo::TransformState::NeedsThumbnail],
+      sections[ezAssetInfo::TransformState::MissingTransformDependency],
+      sections[ezAssetInfo::TransformState::MissingThumbnailDependency],
+      sections[ezAssetInfo::TransformState::CircularDependency],
+      sections[ezAssetInfo::TransformState::TransformError]
+      );
     setToolTip(s.GetData());
   }
   else

--- a/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
@@ -145,8 +145,7 @@ void ezQtCuratorControl::SlotUpdateTransformStats()
       sections[ezAssetInfo::TransformState::MissingTransformDependency],
       sections[ezAssetInfo::TransformState::MissingThumbnailDependency],
       sections[ezAssetInfo::TransformState::CircularDependency],
-      sections[ezAssetInfo::TransformState::TransformError]
-      );
+      sections[ezAssetInfo::TransformState::TransformError]);
     setToolTip(s.GetData());
   }
   else

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -21,17 +21,17 @@ bool ezQtAssetCuratorFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
   if (!pInfo->m_bMainAsset)
     return true;
 
-  if (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingDependency &&
-      pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingReference && pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::TransformError)
+  if (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingTransformDependency && pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::CircularDependency &&
+      pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingThumbnailDependency && pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::TransformError)
   {
     return true;
   }
 
   if (m_bFilterTransitive)
   {
-    if (pInfo->m_pAssetInfo->m_TransformState == ezAssetInfo::MissingReference)
+    if (pInfo->m_pAssetInfo->m_TransformState == ezAssetInfo::MissingThumbnailDependency)
     {
-      for (auto& ref : pInfo->m_pAssetInfo->m_MissingReferences)
+      for (auto& ref : pInfo->m_pAssetInfo->m_MissingThumbnailDeps)
       {
         if (!ezAssetCurator::GetSingleton()->FindSubAsset(ref).isValid())
         {
@@ -192,19 +192,28 @@ void ezQtAssetCuratorPanel::UpdateIssueInfo()
 
   ezLogEntryDelegate logger(([this](ezLogEntry& ref_entry) -> void { TransformLog->GetLog()->AddLogMsg(std::move(ref_entry)); }));
   ezStringBuilder text;
-  if (pAssetInfo->m_TransformState == ezAssetInfo::MissingDependency)
+  if (pAssetInfo->m_TransformState == ezAssetInfo::MissingTransformDependency)
   {
-    ezLog::Error(&logger, "Missing Dependency:");
-    for (const ezString& dep : pAssetInfo->m_MissingDependencies)
+    ezLog::Error(&logger, "Missing Transform Dependency:");
+    for (const ezString& dep : pAssetInfo->m_MissingTransformDeps)
     {
       ezStringBuilder sNiceName = getNiceName(dep);
       ezLog::Error(&logger, "{0}", sNiceName);
     }
   }
-  else if (pAssetInfo->m_TransformState == ezAssetInfo::MissingReference)
+  else if (pAssetInfo->m_TransformState == ezAssetInfo::CircularDependency)
   {
-    ezLog::Error(&logger, "Missing Reference:");
-    for (const ezString& ref : pAssetInfo->m_MissingReferences)
+    ezLog::Error(&logger, "Circular Dependency:");
+    for (const ezString& ref : pAssetInfo->m_CircularDependencies)
+    {
+      ezStringBuilder sNiceName = getNiceName(ref);
+      ezLog::Error(&logger, "{0}", sNiceName);
+    }
+  }
+  else if (pAssetInfo->m_TransformState == ezAssetInfo::MissingThumbnailDependency)
+  {
+    ezLog::Error(&logger, "Missing Thumbnail Dependency:");
+    for (const ezString& ref : pAssetInfo->m_MissingThumbnailDeps)
     {
       ezStringBuilder sNiceName = getNiceName(ref);
       ezLog::Error(&logger, "{0}", sNiceName);

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -7,6 +7,7 @@
 #include <EditorFramework/PropertyGrid/AssetBrowserPropertyWidget.moc.h>
 #include <GuiFoundation/UIServices/ImageCache.moc.h>
 #include <ToolsFoundation/Assets/AssetFileExtensionWhitelist.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
 ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
   : ezQtStandardPropertyWidget()
@@ -168,8 +169,27 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
         return;
       }
 
-      m_AssetGuid = ezConversionUtils::ConvertStringToUuid(sText);
+      ezUuid newAssetGuid = ezConversionUtils::ConvertStringToUuid(sText);
 
+      // If this is a thumbnail or transform dependency, make sure the target is not in our inverse hull, i.e. we don't create a circular dependency.
+      const ezAssetBrowserAttribute* pAssetAttribute = m_pProp->GetAttributeByType<ezAssetBrowserAttribute>();
+      if (pAssetAttribute->GetDependencyFlags().IsAnySet(ezDependencyFlags::Thumbnail | ezDependencyFlags::Transform))
+      {
+        ezUuid documentGuid = m_pObjectAccessor->GetObjectManager()->GetDocument()->GetGuid();
+        ezAssetCurator::ezLockedSubAsset asset = ezAssetCurator::GetSingleton()->GetSubAsset(documentGuid);
+        if (asset.isValid())
+        {
+          ezSet<ezUuid> inverseHull;
+          ezAssetCurator::GetSingleton()->GenerateInverseTransitiveHull(asset->m_pAssetInfo, inverseHull, true, true);
+          if (inverseHull.Contains(newAssetGuid))
+          {
+            ezQtUiServices::GetSingleton()->MessageBoxWarning("The asset can't be selected as it would create a circular dependency");
+            return;
+          }
+        }
+      }
+
+      m_AssetGuid = newAssetGuid;
       auto pAsset = ezAssetCurator::GetSingleton()->GetSubAsset(m_AssetGuid);
 
       if (pAsset)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -24,7 +24,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 3, ezRTTIDefault
     EZ_ARRAY_MEMBER_PROPERTY("AvailableClips", m_AvailableClips)->AddAttributes(new ezReadOnlyAttribute, new ezContainerAttribute(false, false, false)),
     EZ_MEMBER_PROPERTY("FirstFrame", m_uiFirstFrame),
     EZ_MEMBER_PROPERTY("NumFrames", m_uiNumFrames),
-    EZ_MEMBER_PROPERTY("PreviewMesh", m_sPreviewMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned")), // TODO: need an attribute that something is 'UI only' (doesn't change the transform state, but is also not 'temporary'
+    EZ_MEMBER_PROPERTY("PreviewMesh", m_sPreviewMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned", ezDependencyFlags::None)),
     EZ_ENUM_MEMBER_PROPERTY("RootMotion", ezRootMotionSource, m_RootMotionMode),
     EZ_MEMBER_PROPERTY("ConstantRootMotion", m_vConstantRootMotion),
     //EZ_MEMBER_PROPERTY("Joint1", m_sJoint1),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
@@ -10,7 +10,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCollectionAssetEntry, 1, ezRTTIDefaultAllocato
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Name", m_sLookupName),
-    EZ_MEMBER_PROPERTY("Asset", m_sRedirectionAsset)->AddAttributes(new ezAssetBrowserAttribute(""))
+    EZ_MEMBER_PROPERTY("Asset", m_sRedirectionAsset)->AddAttributes(new ezAssetBrowserAttribute("", ezDependencyFlags::Package))
   }
   EZ_END_PROPERTIES;
 }
@@ -70,39 +70,10 @@ static void InsertEntry(ezStringView sID, ezStringView sLookupName, ezMap<ezStri
   {
     const ezAssetDocumentInfo* pDocInfo = pInfo->m_pAssetInfo->m_Info.Borrow();
 
-    for (const ezString& doc : pDocInfo->m_AssetTransformDependencies)
+    for (const ezString& doc : pDocInfo->m_PackageDependencies)
     {
       InsertEntry(doc, {}, inout_found);
     }
-
-    for (const ezString& doc : pDocInfo->m_RuntimeDependencies)
-    {
-      InsertEntry(doc, {}, inout_found);
-    }
-  }
-}
-
-void ezCollectionAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
-{
-  // TODO: why are collections not marked as needs-transform, out of the box, when a dependency changes ?
-
-  SUPER::UpdateAssetDocumentInfo(pInfo);
-
-  const ezCollectionAssetData* pProp = GetProperties();
-
-  ezMap<ezString, ezCollectionEntry> entries;
-
-  for (const auto& e : pProp->m_Entries)
-  {
-    if (e.m_sRedirectionAsset.IsEmpty())
-      continue;
-
-    InsertEntry(e.m_sRedirectionAsset, e.m_sLookupName, entries);
-  }
-
-  for (auto it : entries)
-  {
-    pInfo->m_AssetTransformDependencies.Insert(it.Value().m_sResourceID);
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
@@ -28,7 +28,5 @@ public:
   ezCollectionAssetDocument(const char* szDocumentPath);
 
 protected:
-  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
-
   virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -19,7 +19,7 @@ ezCollectionAssetDocumentManager::ezCollectionAssetDocumentManager()
   m_DocTypeDesc.m_CompatibleTypes.PushBack("CompatibleAsset_AssetCollection");
 
   m_DocTypeDesc.m_sResourceFileExtension = "ezCollection";
-  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::OnlyTransformManually;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Collection", QPixmap(":/AssetIcons/Collection.png"));
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -41,6 +41,7 @@ static void ConfigureAnimationControllerAsset()
     ezStandardMenus::MapActions("AnimationControllerAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("AnimationControllerAssetMenuBar");
     ezDocumentActions::MapActions("AnimationControllerAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("AnimationControllerAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("AnimationControllerAssetMenuBar", "Menu.Edit");
     ezEditActions::MapActions("AnimationControllerAssetMenuBar", "Menu.Edit", false, false);
   }
@@ -50,7 +51,7 @@ static void ConfigureAnimationControllerAsset()
     ezActionMapManager::RegisterActionMap("AnimationControllerAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("AnimationControllerAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("AnimationControllerAssetToolBar", "");
-    ezAssetActions::MapActions("AnimationControllerAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("AnimationControllerAssetToolBar", true);
   }
 }
 
@@ -66,6 +67,7 @@ static void ConfigureTexture2DAsset()
     ezStandardMenus::MapActions("TextureAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("TextureAssetMenuBar");
     ezDocumentActions::MapActions("TextureAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("TextureAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("TextureAssetMenuBar", "Menu.Edit");
   }
 
@@ -74,7 +76,7 @@ static void ConfigureTexture2DAsset()
     ezActionMapManager::RegisterActionMap("TextureAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("TextureAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("TextureAssetToolBar", "");
-    ezAssetActions::MapActions("TextureAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("TextureAssetToolBar", true);
     ezTextureAssetActions::MapActions("TextureAssetToolBar", "");
   }
 }
@@ -91,6 +93,7 @@ static void ConfigureTextureCubeAsset()
     ezStandardMenus::MapActions("TextureCubeAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("TextureCubeAssetMenuBar");
     ezDocumentActions::MapActions("TextureCubeAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("TextureCubeAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("TextureCubeAssetMenuBar", "Menu.Edit");
   }
 
@@ -99,7 +102,7 @@ static void ConfigureTextureCubeAsset()
     ezActionMapManager::RegisterActionMap("TextureCubeAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("TextureCubeAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("TextureCubeAssetToolBar", "");
-    ezAssetActions::MapActions("TextureCubeAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("TextureCubeAssetToolBar", true);
     ezTextureAssetActions::MapActions("TextureCubeAssetToolBar", "");
   }
 }
@@ -116,6 +119,7 @@ static void ConfigureLUTAsset()
     ezStandardMenus::MapActions("LUTAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("LUTAssetMenuBar");
     ezDocumentActions::MapActions("LUTAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("LUTAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("LUTAssetMenuBar", "Menu.Edit");
   }
 
@@ -124,7 +128,7 @@ static void ConfigureLUTAsset()
     ezActionMapManager::RegisterActionMap("LUTAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("LUTAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("LUTAssetToolBar", "");
-    ezAssetActions::MapActions("LUTAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("LUTAssetToolBar", true);
   }
 }
 
@@ -139,6 +143,7 @@ static void ConfigureMaterialAsset()
     ezProjectActions::MapActions("MaterialAssetMenuBar");
     ezDocumentActions::MapActions("MaterialAssetMenuBar", "Menu.File", false);
     ezDocumentActions::MapToolsActions("MaterialAssetMenuBar", "Menu.Tools");
+    ezAssetActions::MapMenuActions("MaterialAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("MaterialAssetMenuBar", "Menu.Edit");
     ezEditActions::MapActions("MaterialAssetMenuBar", "Menu.Edit", false, false);
   }
@@ -148,7 +153,7 @@ static void ConfigureMaterialAsset()
     ezActionMapManager::RegisterActionMap("MaterialAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("MaterialAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("MaterialAssetToolBar", "");
-    ezAssetActions::MapActions("MaterialAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("MaterialAssetToolBar", true);
 
     ezMaterialAssetActions::RegisterActions();
     ezMaterialAssetActions::MapActions("MaterialAssetToolBar", "");
@@ -174,6 +179,7 @@ static void ConfigureRenderPipelineAsset()
     ezStandardMenus::MapActions("RenderPipelineAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("RenderPipelineAssetMenuBar");
     ezDocumentActions::MapActions("RenderPipelineAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("RenderPipelineAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("RenderPipelineAssetMenuBar", "Menu.Edit");
     ezEditActions::MapActions("RenderPipelineAssetMenuBar", "Menu.Edit", false, false);
   }
@@ -183,7 +189,7 @@ static void ConfigureRenderPipelineAsset()
     ezActionMapManager::RegisterActionMap("RenderPipelineAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("RenderPipelineAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("RenderPipelineAssetToolBar", "");
-    ezAssetActions::MapActions("RenderPipelineAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("RenderPipelineAssetToolBar", true);
   }
 }
 
@@ -197,6 +203,7 @@ static void ConfigureMeshAsset()
     ezStandardMenus::MapActions("MeshAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("MeshAssetMenuBar");
     ezDocumentActions::MapActions("MeshAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("MeshAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("MeshAssetMenuBar", "Menu.Edit");
   }
 
@@ -205,7 +212,7 @@ static void ConfigureMeshAsset()
     ezActionMapManager::RegisterActionMap("MeshAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("MeshAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("MeshAssetToolBar", "");
-    ezAssetActions::MapActions("MeshAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("MeshAssetToolBar", true);
     ezCommonAssetActions::MapActions("MeshAssetToolBar", "", ezCommonAssetUiState::Grid);
   }
 
@@ -225,6 +232,7 @@ static void ConfigureSurfaceAsset()
     ezStandardMenus::MapActions("SurfaceAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("SurfaceAssetMenuBar");
     ezDocumentActions::MapActions("SurfaceAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("SurfaceAssetMenuBar", "Menu.File");
     ezDocumentActions::MapToolsActions("SurfaceAssetMenuBar", "Menu.Tools");
     ezCommandHistoryActions::MapActions("SurfaceAssetMenuBar", "Menu.Edit");
   }
@@ -234,7 +242,7 @@ static void ConfigureSurfaceAsset()
     ezActionMapManager::RegisterActionMap("SurfaceAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("SurfaceAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("SurfaceAssetToolBar", "");
-    ezAssetActions::MapActions("SurfaceAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("SurfaceAssetToolBar", true);
   }
 }
 
@@ -246,6 +254,7 @@ static void ConfigureCollectionAsset()
     ezStandardMenus::MapActions("CollectionAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("CollectionAssetMenuBar");
     ezDocumentActions::MapActions("CollectionAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("CollectionAssetMenuBar", "Menu.File");
     ezDocumentActions::MapToolsActions("CollectionAssetMenuBar", "Menu.Tools");
     ezCommandHistoryActions::MapActions("CollectionAssetMenuBar", "Menu.Edit");
   }
@@ -255,7 +264,7 @@ static void ConfigureCollectionAsset()
     ezActionMapManager::RegisterActionMap("CollectionAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("CollectionAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("CollectionAssetToolBar", "");
-    ezAssetActions::MapActions("CollectionAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("CollectionAssetToolBar", true);
   }
 }
 
@@ -267,6 +276,7 @@ static void ConfigureColorGradientAsset()
     ezStandardMenus::MapActions("ColorGradientAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("ColorGradientAssetMenuBar");
     ezDocumentActions::MapActions("ColorGradientAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("ColorGradientAssetMenuBar", "Menu.File");
     ezDocumentActions::MapToolsActions("ColorGradientAssetMenuBar", "Menu.Tools");
     ezCommandHistoryActions::MapActions("ColorGradientAssetMenuBar", "Menu.Edit");
   }
@@ -276,7 +286,7 @@ static void ConfigureColorGradientAsset()
     ezActionMapManager::RegisterActionMap("ColorGradientAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("ColorGradientAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("ColorGradientAssetToolBar", "");
-    ezAssetActions::MapActions("ColorGradientAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("ColorGradientAssetToolBar", true);
   }
 }
 
@@ -288,6 +298,7 @@ static void ConfigureCurve1DAsset()
     ezStandardMenus::MapActions("Curve1DAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("Curve1DAssetMenuBar");
     ezDocumentActions::MapActions("Curve1DAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("Curve1DAssetMenuBar", "Menu.File");
     ezDocumentActions::MapToolsActions("Curve1DAssetMenuBar", "Menu.Tools");
     ezCommandHistoryActions::MapActions("Curve1DAssetMenuBar", "Menu.Edit");
   }
@@ -297,7 +308,7 @@ static void ConfigureCurve1DAsset()
     ezActionMapManager::RegisterActionMap("Curve1DAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("Curve1DAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("Curve1DAssetToolBar", "");
-    ezAssetActions::MapActions("Curve1DAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("Curve1DAssetToolBar", true);
   }
 }
 
@@ -309,6 +320,7 @@ static void ConfigurePropertyAnimAsset()
     ezStandardMenus::MapActions("PropertyAnimAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Scene | ezStandardMenuTypes::View | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("PropertyAnimAssetMenuBar");
     ezDocumentActions::MapActions("PropertyAnimAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("PropertyAnimAssetMenuBar", "Menu.File");
     ezDocumentActions::MapToolsActions("PropertyAnimAssetMenuBar", "Menu.Tools");
     ezCommandHistoryActions::MapActions("PropertyAnimAssetMenuBar", "Menu.Edit");
     ezGameObjectSelectionActions::MapActions("PropertyAnimAssetMenuBar", "Menu.Edit");
@@ -323,7 +335,7 @@ static void ConfigurePropertyAnimAsset()
     ezActionMapManager::RegisterActionMap("PropertyAnimAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("PropertyAnimAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("PropertyAnimAssetToolBar", "");
-    ezAssetActions::MapActions("PropertyAnimAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("PropertyAnimAssetToolBar", true);
     ezGameObjectContextActions::MapToolbarActions("PropertyAnimAssetToolBar", "");
     ezGameObjectDocumentActions::MapToolbarActions("PropertyAnimAssetToolBar", "");
     ezTransformGizmoActions::MapToolbarActions("PropertyAnimAssetToolBar", "");
@@ -354,6 +366,7 @@ static void ConfigureVisualScriptAsset()
     ezStandardMenus::MapActions("VisualScriptAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("VisualScriptAssetMenuBar");
     ezDocumentActions::MapActions("VisualScriptAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("VisualScriptAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("VisualScriptAssetMenuBar", "Menu.Edit");
     ezEditActions::MapActions("VisualScriptAssetMenuBar", "Menu.Edit", false, false);
   }
@@ -363,7 +376,7 @@ static void ConfigureVisualScriptAsset()
     ezActionMapManager::RegisterActionMap("VisualScriptAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("VisualScriptAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("VisualScriptAssetToolBar", "");
-    ezAssetActions::MapActions("VisualScriptAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("VisualScriptAssetToolBar", true);
     ezVisualScriptActions::MapActions("VisualScriptAssetToolBar", "");
   }
 }
@@ -378,6 +391,7 @@ static void ConfigureDecalAsset()
     ezStandardMenus::MapActions("DecalAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("DecalAssetMenuBar");
     ezDocumentActions::MapActions("DecalAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("DecalAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("DecalAssetMenuBar", "Menu.Edit");
   }
 
@@ -386,7 +400,7 @@ static void ConfigureDecalAsset()
     ezActionMapManager::RegisterActionMap("DecalAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("DecalAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("DecalAssetToolBar", "");
-    ezAssetActions::MapActions("DecalAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("DecalAssetToolBar", true);
   }
 
   // View Tool Bar
@@ -407,6 +421,7 @@ static void ConfigureAnimationClipAsset()
     ezStandardMenus::MapActions("AnimationClipAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("AnimationClipAssetMenuBar");
     ezDocumentActions::MapActions("AnimationClipAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("AnimationClipAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("AnimationClipAssetMenuBar", "Menu.Edit");
   }
 
@@ -415,7 +430,7 @@ static void ConfigureAnimationClipAsset()
     ezActionMapManager::RegisterActionMap("AnimationClipAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("AnimationClipAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("AnimationClipAssetToolBar", "");
-    ezAssetActions::MapActions("AnimationClipAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("AnimationClipAssetToolBar", true);
     ezCommonAssetActions::MapActions("AnimationClipAssetToolBar", "", ezCommonAssetUiState::Loop | ezCommonAssetUiState::Pause | ezCommonAssetUiState::Restart | ezCommonAssetUiState::SimulationSpeed | ezCommonAssetUiState::Grid);
   }
 
@@ -439,6 +454,7 @@ static void ConfigureSkeletonAsset()
     ezStandardMenus::MapActions("SkeletonAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("SkeletonAssetMenuBar");
     ezDocumentActions::MapActions("SkeletonAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("SkeletonAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("SkeletonAssetMenuBar", "Menu.Edit");
   }
 
@@ -447,7 +463,7 @@ static void ConfigureSkeletonAsset()
     ezActionMapManager::RegisterActionMap("SkeletonAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("SkeletonAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("SkeletonAssetToolBar", "");
-    ezAssetActions::MapActions("SkeletonAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("SkeletonAssetToolBar", true);
     ezCommonAssetActions::MapActions("SkeletonAssetToolBar", "", ezCommonAssetUiState::Grid);
     ezSkeletonActions::MapActions("SkeletonAssetToolBar", "");
   }
@@ -468,6 +484,7 @@ static void ConfigureAnimatedMeshAsset()
     ezStandardMenus::MapActions("AnimatedMeshAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("AnimatedMeshAssetMenuBar");
     ezDocumentActions::MapActions("AnimatedMeshAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("AnimatedMeshAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("AnimatedMeshAssetMenuBar", "Menu.Edit");
   }
 
@@ -476,7 +493,7 @@ static void ConfigureAnimatedMeshAsset()
     ezActionMapManager::RegisterActionMap("AnimatedMeshAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("AnimatedMeshAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("AnimatedMeshAssetToolBar", "");
-    ezAssetActions::MapActions("AnimatedMeshAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("AnimatedMeshAssetToolBar", true);
     ezCommonAssetActions::MapActions("AnimatedMeshAssetToolBar", "", ezCommonAssetUiState::Grid);
   }
 
@@ -496,6 +513,7 @@ static void ConfigureImageDataAsset()
     ezStandardMenus::MapActions("ImageDataAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("ImageDataAssetMenuBar");
     ezDocumentActions::MapActions("ImageDataAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("ImageDataAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("ImageDataAssetMenuBar", "Menu.Edit");
   }
 
@@ -504,7 +522,7 @@ static void ConfigureImageDataAsset()
     ezActionMapManager::RegisterActionMap("ImageDataAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("ImageDataAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("ImageDataAssetToolBar", "");
-    ezAssetActions::MapActions("ImageDataAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("ImageDataAssetToolBar", true);
   }
 
   // View Tool Bar
@@ -524,6 +542,7 @@ static void ConfigureStateMachineAsset()
     ezStandardMenus::MapActions("StateMachineAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("StateMachineAssetMenuBar");
     ezDocumentActions::MapActions("StateMachineAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("StateMachineAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("StateMachineAssetMenuBar", "Menu.Edit");
     ezEditActions::MapActions("StateMachineAssetMenuBar", "Menu.Edit", false, false);
   }
@@ -533,7 +552,7 @@ static void ConfigureStateMachineAsset()
     ezActionMapManager::RegisterActionMap("StateMachineAssetToolBar").IgnoreResult();
     ezDocumentActions::MapActions("StateMachineAssetToolBar", "", true);
     ezCommandHistoryActions::MapActions("StateMachineAssetToolBar", "");
-    ezAssetActions::MapActions("StateMachineAssetToolBar", true);
+    ezAssetActions::MapToolBarActions("StateMachineAssetToolBar", true);
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -35,7 +35,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetProperties, 4, ezRTTIDefaultAlloc
   {
     EZ_ENUM_ACCESSOR_PROPERTY("ShaderMode", ezMaterialShaderMode, GetShaderMode, SetShaderMode),
     EZ_ACCESSOR_PROPERTY("BaseMaterial", GetBaseMaterial, SetBaseMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material")),
-    EZ_ACCESSOR_PROPERTY("Surface", GetSurface, SetSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("Surface", GetSurface, SetSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("Shader", GetShader, SetShader)->AddAttributes(new ezFileBrowserAttribute("Select Shader", "*.ezShader", "CustomAction_CreateShaderFromTemplate")),
     // This property holds the phantom shader properties type so it is only used in the object graph but not actually in the instance of this object.
     EZ_ACCESSOR_PROPERTY("ShaderProperties", GetShaderProperties, SetShaderProperties)->AddFlags(ezPropertyFlags::PointerOwner)->AddAttributes(new ezContainerAttribute(false, false, false)),
@@ -755,13 +755,15 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
   if (GetProperties()->m_ShaderMode != ezMaterialShaderMode::BaseMaterial)
   {
     // remove base material dependency, if it isn't used
-    pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetBaseMaterial());
+    pInfo->m_TransformDependencies.Remove(GetProperties()->GetBaseMaterial());
+    pInfo->m_ThumbnailDependencies.Remove(GetProperties()->GetBaseMaterial());
   }
 
   if (GetProperties()->m_ShaderMode != ezMaterialShaderMode::File)
   {
     // remove shader file dependency, if it isn't used
-    pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetShader());
+    pInfo->m_TransformDependencies.Remove(GetProperties()->GetShader());
+    pInfo->m_ThumbnailDependencies.Remove(GetProperties()->GetShader());
   }
 
   if (GetProperties()->m_ShaderMode == ezMaterialShaderMode::Custom)
@@ -769,7 +771,8 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
     // We write our own guid into the shader field so BaseMaterial materials can find the shader file.
     // This would cause us to have a dependency to ourselves so we need to remove it.
     ezStringBuilder tmp;
-    pInfo->m_AssetTransformDependencies.Remove(ezConversionUtils::ToString(GetGuid(), tmp));
+    pInfo->m_TransformDependencies.Remove(ezConversionUtils::ToString(GetGuid(), tmp));
+    pInfo->m_ThumbnailDependencies.Remove(ezConversionUtils::ToString(GetGuid(), tmp));
 
     ezVisualShaderCodeGenerator codeGen;
 
@@ -778,7 +781,7 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
 
     for (const auto& sCfgFile : cfgFiles)
     {
-      pInfo->m_AssetTransformDependencies.Insert(sCfgFile);
+      pInfo->m_TransformDependencies.Insert(sCfgFile);
     }
 
     pInfo->m_Outputs.Insert(ezMaterialAssetDocumentManager::s_szShaderOutputTag);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -265,7 +265,7 @@ void ezMeshAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) co
   {
     // remove the mesh file dependency, if it is not actually used
     const auto& sMeshFile = GetProperties()->m_sMeshFile;
-    pInfo->m_AssetTransformDependencies.Remove(sMeshFile);
+    pInfo->m_TransformDependencies.Remove(sMeshFile);
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -360,7 +360,7 @@ void ezTextureAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo)
   for (ezUInt32 i = GetProperties()->GetNumInputFiles(); i < 4; ++i)
   {
     // remove unused dependencies
-    pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetInputFile(i));
+    pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile(i));
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -176,11 +176,11 @@ void ezTextureCubeAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pI
     case ezTextureCubeChannelMappingEnum::RGBA1:
     {
       // remove file dependencies, that aren't used
-      pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetInputFile1());
-      pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetInputFile2());
-      pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetInputFile3());
-      pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetInputFile4());
-      pInfo->m_AssetTransformDependencies.Remove(GetProperties()->GetInputFile5());
+      pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile1());
+      pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile2());
+      pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile3());
+      pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile4());
+      pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile5());
       break;
     }
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
@@ -22,6 +22,7 @@ void OnLoadPlugin()
     ezStandardMenus::MapActions("SoundBankAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions("SoundBankAssetMenuBar");
     ezDocumentActions::MapActions("SoundBankAssetMenuBar", "Menu.File", false);
+    ezAssetActions::MapMenuActions("SoundBankAssetMenuBar", "Menu.File");
     ezCommandHistoryActions::MapActions("SoundBankAssetMenuBar", "Menu.Edit");
 
     // Tool Bar
@@ -29,7 +30,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("SoundBankAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("SoundBankAssetToolBar", "");
-      ezAssetActions::MapActions("SoundBankAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("SoundBankAssetToolBar", true);
     }
   }
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.cpp
@@ -29,7 +29,7 @@ void ezSoundBankAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInf
 
   const ezSoundBankAssetProperties* pProp = GetProperties();
 
-  pInfo->m_AssetTransformDependencies.Insert(pProp->m_sSoundBank);
+  pInfo->m_TransformDependencies.Insert(pProp->m_sSoundBank);
 }
 
 ezTransformStatus ezSoundBankAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -87,7 +87,7 @@ void ezSoundBankAssetDocumentManager::FillOutSubAssetList(const ezAssetDocumentI
 
   ezHybridArray<FMOD::Studio::Bank*, 16> loadedBanks;
 
-  for (const ezString& dep : assetInfo.m_AssetTransformDependencies)
+  for (const ezString& dep : assetInfo.m_TransformDependencies)
   {
     if (!ezPathUtils::HasExtension(dep, "bank"))
       continue;
@@ -193,7 +193,7 @@ ezString ezSoundBankAssetDocumentManager::GetSoundBankAssetTableEntry(const ezSu
 
   // if (pAssetProfile == ezAssetCurator::GetSingleton()->GetDevelopmentAssetProfile())
   {
-    for (const ezString& dep : pSubAsset->m_pAssetInfo->m_Info->m_AssetTransformDependencies)
+    for (const ezString& dep : pSubAsset->m_pAssetInfo->m_Info->m_TransformDependencies)
     {
       if (dep.EndsWith_NoCase(".bank") && !dep.EndsWith_NoCase(".strings.bank"))
       {

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -341,7 +341,7 @@ void ezJoltCollisionMeshAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentIn
   {
     // remove the mesh file dependency, if it is not actually used
     const auto& sMeshFile = GetProperties()->m_sMeshFile;
-    pInfo->m_AssetTransformDependencies.Remove(sMeshFile);
+    pInfo->m_TransformDependencies.Remove(sMeshFile);
   }
 }
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -9,7 +9,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezJoltSurfaceResourceSlot, ezNoBase, 1, ezRTTIDef
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Label", m_sLabel)->AddAttributes(new ezReadOnlyAttribute()),
-    EZ_MEMBER_PROPERTY("Resource", m_sResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Resource", m_sResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("Exclude", m_bExclude),
   }
   EZ_END_PROPERTIES;
@@ -45,7 +45,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 1, ezRTTIDef
     EZ_MEMBER_PROPERTY("Detail", m_uiDetail)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(0, 32)),
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes)),
     EZ_ARRAY_MEMBER_PROPERTY("Surfaces", m_Slots)->AddAttributes(new ezContainerAttribute(false, false, true)),
-    EZ_MEMBER_PROPERTY("Surface", m_sConvexMeshSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Surface", m_sConvexMeshSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
@@ -32,6 +32,7 @@ void OnLoadPlugin()
       ezStandardMenus::MapActions("JoltCollisionMeshAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezProjectActions::MapActions("JoltCollisionMeshAssetMenuBar");
       ezDocumentActions::MapActions("JoltCollisionMeshAssetMenuBar", "Menu.File", false);
+      ezAssetActions::MapMenuActions("JoltCollisionMeshAssetMenuBar", "Menu.File");
       ezCommandHistoryActions::MapActions("JoltCollisionMeshAssetMenuBar", "Menu.Edit");
     }
 
@@ -40,7 +41,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("JoltCollisionMeshAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("JoltCollisionMeshAssetToolBar", "");
-      ezAssetActions::MapActions("JoltCollisionMeshAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("JoltCollisionMeshAssetToolBar", true);
       ezCommonAssetActions::MapActions("JoltCollisionMeshAssetToolBar", "", ezCommonAssetUiState::Grid);
     }
   }

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
@@ -18,6 +18,7 @@ void OnLoadPlugin()
       ezStandardMenus::MapActions("KrautTreeAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezProjectActions::MapActions("KrautTreeAssetMenuBar");
       ezDocumentActions::MapActions("KrautTreeAssetMenuBar", "Menu.File", false);
+      ezAssetActions::MapMenuActions("KrautTreeAssetMenuBar", "Menu.File");
       ezCommandHistoryActions::MapActions("KrautTreeAssetMenuBar", "Menu.Edit");
     }
 
@@ -26,7 +27,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("KrautTreeAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("KrautTreeAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("KrautTreeAssetToolBar", "");
-      ezAssetActions::MapActions("KrautTreeAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("KrautTreeAssetToolBar", true);
     }
   }
 }

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetObjects.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetObjects.cpp
@@ -23,7 +23,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezKrautTreeAssetProperties, 1, ezRTTIDefaultAllo
     EZ_MEMBER_PROPERTY("LodDistanceScale", m_fLodDistanceScale)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("StaticColliderRadius", m_fStaticColliderRadius)->AddAttributes(new ezDefaultValueAttribute(0.4f), new ezClampValueAttribute(0.0f, 10.0f)),
     EZ_MEMBER_PROPERTY("TreeStiffness", m_fTreeStiffness)->AddAttributes(new ezDefaultValueAttribute(10.0f), new ezClampValueAttribute(1.0f, 10000.0f)),
-    EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ARRAY_MEMBER_PROPERTY("Materials", m_Materials)->AddAttributes(new ezContainerAttribute(false, false, false)),
     EZ_MEMBER_PROPERTY("DisplayRandomSeed", m_uiRandomSeedForDisplay),
     EZ_ARRAY_MEMBER_PROPERTY("GoodRandomSeeds", m_GoodRandomSeeds),

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
@@ -23,6 +23,7 @@ void OnLoadPlugin()
       ezStandardMenus::MapActions("ParticleEffectAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezProjectActions::MapActions("ParticleEffectAssetMenuBar");
       ezDocumentActions::MapActions("ParticleEffectAssetMenuBar", "Menu.File", false);
+      ezAssetActions::MapMenuActions("ParticleEffectAssetMenuBar", "Menu.File");
       ezCommandHistoryActions::MapActions("ParticleEffectAssetMenuBar", "Menu.Edit");
     }
 
@@ -31,7 +32,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("ParticleEffectAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("ParticleEffectAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("ParticleEffectAssetToolBar", "");
-      ezAssetActions::MapActions("ParticleEffectAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("ParticleEffectAssetToolBar", true);
       ezParticleActions::MapActions("ParticleEffectAssetToolBar", "");
     }
 

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.cpp
@@ -211,7 +211,7 @@ void ezParticleEffectAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo*
         if (pType->m_RenderMode != ezParticleTypeRenderMode::Distortion)
         {
           // remove unused dependencies
-          pInfo->m_AssetTransformDependencies.Remove(pType->m_sDistortionTexture);
+          pInfo->m_TransformDependencies.Remove(pType->m_sDistortionTexture);
         }
       }
 
@@ -220,7 +220,7 @@ void ezParticleEffectAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo*
         if (pType->m_RenderMode != ezParticleTypeRenderMode::Distortion)
         {
           // remove unused dependencies
-          pInfo->m_AssetTransformDependencies.Remove(pType->m_sDistortionTexture);
+          pInfo->m_TransformDependencies.Remove(pType->m_sDistortionTexture);
         }
       }
     }

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAsset.cpp
@@ -314,7 +314,7 @@ void ezCollisionMeshAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* 
   {
     // remove the mesh file dependency, if it is not actually used
     const auto& sMeshFile = GetProperties()->m_sMeshFile;
-    pInfo->m_AssetTransformDependencies.Remove(sMeshFile);
+    pInfo->m_TransformDependencies.Remove(sMeshFile);
   }
 }
 

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetObjects.cpp
@@ -9,7 +9,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezSurfaceResourceSlot, ezNoBase, 1, ezRTTIDefault
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Label", m_sLabel)->AddAttributes(new ezReadOnlyAttribute()),
-    EZ_MEMBER_PROPERTY("Resource", m_sResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Resource", m_sResource)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
@@ -32,6 +32,7 @@ void OnLoadPlugin()
       ezStandardMenus::MapActions("PxCollisionMeshAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezProjectActions::MapActions("PxCollisionMeshAssetMenuBar");
       ezDocumentActions::MapActions("PxCollisionMeshAssetMenuBar", "Menu.File", false);
+      ezAssetActions::MapMenuActions("PxCollisionMeshAssetMenuBar", "Menu.File");
       ezCommandHistoryActions::MapActions("PxCollisionMeshAssetMenuBar", "Menu.Edit");
     }
 
@@ -40,7 +41,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("PxCollisionMeshAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("PxCollisionMeshAssetToolBar", "");
-      ezAssetActions::MapActions("PxCollisionMeshAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("PxCollisionMeshAssetToolBar", true);
       ezCommonAssetActions::MapActions("PxCollisionMeshAssetToolBar", "", ezCommonAssetUiState::Grid);
     }
   }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/EditorPluginProcGen.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/EditorPluginProcGen.cpp
@@ -22,6 +22,7 @@ void OnLoadPlugin()
   ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
   ezProjectActions::MapActions(szMenuBar);
   ezDocumentActions::MapActions(szMenuBar, "Menu.File", false);
+  ezAssetActions::MapMenuActions(szMenuBar, "Menu.File");
   ezCommandHistoryActions::MapActions(szMenuBar, "Menu.Edit");
 
   ezEditActions::MapActions("ProcGenAssetMenuBar", "Menu.Edit", false, false);
@@ -33,7 +34,7 @@ void OnLoadPlugin()
   ezActionMapManager::RegisterActionMap(szToolBar).IgnoreResult();
   ezDocumentActions::MapActions(szToolBar, "", true);
   ezCommandHistoryActions::MapActions(szToolBar, "");
-  ezAssetActions::MapActions(szToolBar, true);
+  ezAssetActions::MapToolBarActions(szToolBar, true);
 }
 }
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -123,8 +123,7 @@ ezStatus ezProcGenGraphAssetDocument::WriteAsset(ezStreamWriter& inout_stream, c
 
   ezExpressionCompiler compiler;
 
-  auto WriteByteCode = [&](const ezDocumentObject* pOutputNode)
-  {
+  auto WriteByteCode = [&](const ezDocumentObject* pOutputNode) {
     context.m_GraphContext.m_VolumeTagSetIndices.Clear();
 
     if (pOutputNode->GetType()->IsDerivedFrom<ezProcGen_PlacementOutput>())

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -123,7 +123,8 @@ ezStatus ezProcGenGraphAssetDocument::WriteAsset(ezStreamWriter& inout_stream, c
 
   ezExpressionCompiler compiler;
 
-  auto WriteByteCode = [&](const ezDocumentObject* pOutputNode) {
+  auto WriteByteCode = [&](const ezDocumentObject* pOutputNode)
+  {
     context.m_GraphContext.m_VolumeTagSetIndices.Clear();
 
     if (pOutputNode->GetType()->IsDerivedFrom<ezProcGen_PlacementOutput>())
@@ -262,21 +263,26 @@ void ezProcGenGraphAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* p
         ezVariant prefab = typeAccessor.GetValue("Objects", i);
         if (prefab.IsA<ezString>())
         {
-          pInfo->m_RuntimeDependencies.Insert(prefab.Get<ezString>());
+          pInfo->m_PackageDependencies.Insert(prefab.Get<ezString>());
+          pInfo->m_ThumbnailDependencies.Insert(prefab.Get<ezString>());
         }
       }
 
       ezVariant colorGradient = typeAccessor.GetValue("ColorGradient");
       if (colorGradient.IsA<ezString>())
       {
-        pInfo->m_RuntimeDependencies.Insert(colorGradient.Get<ezString>());
+        pInfo->m_PackageDependencies.Insert(colorGradient.Get<ezString>());
+        pInfo->m_ThumbnailDependencies.Insert(colorGradient.Get<ezString>());
       }
     }
   }
   else
   {
-    pInfo->m_RuntimeDependencies.Insert(s_szSphereAssetId);
-    pInfo->m_RuntimeDependencies.Insert(s_szBWGradientAssetId);
+    pInfo->m_PackageDependencies.Insert(s_szSphereAssetId);
+    pInfo->m_PackageDependencies.Insert(s_szBWGradientAssetId);
+
+    pInfo->m_ThumbnailDependencies.Insert(s_szSphereAssetId);
+    pInfo->m_ThumbnailDependencies.Insert(s_szBWGradientAssetId);
   }
 }
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -135,7 +135,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_PlacementOutput, 1, ezRTTIDefaultAlloc
     EZ_MEMBER_PROPERTY("CullDistance", m_fCullDistance)->AddAttributes(new ezDefaultValueAttribute(30.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_ENUM_MEMBER_PROPERTY("PlacementMode", ezProcPlacementMode, m_PlacementMode),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
-    EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
 
     EZ_MEMBER_PROPERTY("Density", m_DensityPin),
     EZ_MEMBER_PROPERTY("Scale", m_ScalePin)->AddAttributes(new ezColorAttribute(ezColorScheme::DarkUI(ezColorScheme::Pink))),

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/EditorPluginRmlUi.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/EditorPluginRmlUi.cpp
@@ -19,6 +19,7 @@ void OnLoadPlugin()
       ezStandardMenus::MapActions("RmlUiAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezProjectActions::MapActions("RmlUiAssetMenuBar");
       ezDocumentActions::MapActions("RmlUiAssetMenuBar", "Menu.File", false);
+      ezAssetActions::MapMenuActions("RmlUiAssetMenuBar", "Menu.File");
       ezCommandHistoryActions::MapActions("RmlUiAssetMenuBar", "Menu.Edit");
     }
 
@@ -27,7 +28,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("RmlUiAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("RmlUiAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("RmlUiAssetToolBar", "");
-      ezAssetActions::MapActions("RmlUiAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("RmlUiAssetToolBar", true);
     }
   }
 }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -332,6 +332,33 @@ void ezSceneAction::Execute(const ezVariant& value)
         }
       }
 
+
+      // Convert collections
+      {
+        EZ_PROFILE_SCOPE("ConvertCollections");
+        ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+        ezSet<ezUuid> collections;
+        {
+          ezAssetCurator::ezLockedAssetTable allAssets = pCurator->GetKnownAssets();
+
+          ezTempHashedString sCollection = "Collection";
+          for (auto it : *allAssets)
+          {
+            if (it.Value()->m_Info->m_sAssetsDocumentTypeName == sCollection)
+            {
+              collections.Insert(it.Value()->m_Info->m_DocumentID);
+            }
+          }
+        }
+
+        const ezPlatformProfile* pCurrentProfile = pCurator->GetActiveAssetProfile();
+        for (const auto& guid : collections)
+        {
+          // Ignore result
+          pCurator->TransformAsset(guid, ezTransformFlags::TriggeredManually | ezTransformFlags::ForceTransform, pCurrentProfile);
+        }
+      }
+
       dlg.s_bUpdateThumbnail = false;
 
       range.BeginNextStep("Export Scene");

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -341,6 +341,7 @@ void ezSceneAction::Execute(const ezVariant& value)
         {
           ezAssetCurator::ezLockedAssetTable allAssets = pCurator->GetKnownAssets();
 
+          //#TODO_ASSET Instead of hard-coding this to 'Collection' add a virtual function to all asset managers that defines those that need to be transformed on scene export.
           ezTempHashedString sCollection = "Collection";
           for (auto it : *allAssets)
           {

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -161,12 +161,9 @@ void OnLoadPlugin()
   ezQuadViewActions::MapActions("EditorPluginScene_ViewToolBar", "");
 
   // Visualizers
-  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezPointLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter*
-    { return EZ_DEFAULT_NEW(ezPointLightVisualizerAdapter); });
-  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezSpotLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter*
-    { return EZ_DEFAULT_NEW(ezSpotLightVisualizerAdapter); });
-  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezBoxReflectionProbeVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter*
-    { return EZ_DEFAULT_NEW(ezBoxReflectionProbeVisualizerAdapter); });
+  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezPointLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezPointLightVisualizerAdapter); });
+  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezSpotLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezSpotLightVisualizerAdapter); });
+  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezBoxReflectionProbeVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezBoxReflectionProbeVisualizerAdapter); });
 
   // SceneGraph Context Menu
   ezActionMapManager::RegisterActionMap("EditorPluginScene_ScenegraphContextMenu").IgnoreResult();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -1,5 +1,6 @@
 #include <EditorPluginScene/EditorPluginScenePCH.h>
 
+#include <EditorFramework/Actions/AssetActions.h>
 #include <EditorFramework/Actions/GameObjectDocumentActions.h>
 #include <EditorFramework/Actions/GameObjectSelectionActions.h>
 #include <EditorFramework/Actions/ProjectActions.h>
@@ -114,6 +115,7 @@ void OnLoadPlugin()
     ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Scene | ezStandardMenuTypes::Panels | ezStandardMenuTypes::View | ezStandardMenuTypes::Help);
     ezProjectActions::MapActions(szMenuBar);
     ezDocumentActions::MapActions(szMenuBar, "Menu.File", false);
+    ezAssetActions::MapMenuActions(szMenuBar, "Menu.File");
     ezDocumentActions::MapToolsActions(szMenuBar, "Menu.Tools");
     ezCommandHistoryActions::MapActions(szMenuBar, "Menu.Edit");
     ezTransformGizmoActions::MapMenuActions(szMenuBar, "Menu.Edit");
@@ -159,9 +161,12 @@ void OnLoadPlugin()
   ezQuadViewActions::MapActions("EditorPluginScene_ViewToolBar", "");
 
   // Visualizers
-  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezPointLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezPointLightVisualizerAdapter); });
-  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezSpotLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezSpotLightVisualizerAdapter); });
-  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezBoxReflectionProbeVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezBoxReflectionProbeVisualizerAdapter); });
+  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezPointLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter*
+    { return EZ_DEFAULT_NEW(ezPointLightVisualizerAdapter); });
+  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezSpotLightVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter*
+    { return EZ_DEFAULT_NEW(ezSpotLightVisualizerAdapter); });
+  ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezBoxReflectionProbeVisualizerAttribute>(), [](const ezRTTI* pRtti) -> ezVisualizerAdapter*
+    { return EZ_DEFAULT_NEW(ezBoxReflectionProbeVisualizerAdapter); });
 
   // SceneGraph Context Menu
   ezActionMapManager::RegisterActionMap("EditorPluginScene_ScenegraphContextMenu").IgnoreResult();

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
@@ -28,6 +28,7 @@ void OnLoadPlugin()
       ezStandardMenus::MapActions("TypeScriptAssetMenuBar", ezStandardMenuTypes::File | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Panels | ezStandardMenuTypes::Help);
       ezProjectActions::MapActions("TypeScriptAssetMenuBar");
       ezDocumentActions::MapActions("TypeScriptAssetMenuBar", "Menu.File", false);
+      ezAssetActions::MapMenuActions("TypeScriptAssetMenuBar", "Menu.File");
       ezCommandHistoryActions::MapActions("TypeScriptAssetMenuBar", "Menu.Edit");
     }
 
@@ -36,7 +37,7 @@ void OnLoadPlugin()
       ezActionMapManager::RegisterActionMap("TypeScriptAssetToolBar").IgnoreResult();
       ezDocumentActions::MapActions("TypeScriptAssetToolBar", "", true);
       ezCommandHistoryActions::MapActions("TypeScriptAssetToolBar", "");
-      ezAssetActions::MapActions("TypeScriptAssetToolBar", true);
+      ezAssetActions::MapToolBarActions("TypeScriptAssetToolBar", true);
       ezTypeScriptActions::MapActions("TypeScriptAssetToolBar", "");
     }
   }

--- a/Code/Engine/Core/Collection/Implementation/CollectionComponent.cpp
+++ b/Code/Engine/Core/Collection/Implementation/CollectionComponent.cpp
@@ -9,7 +9,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezCollectionComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Collection", GetCollectionFile, SetCollectionFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_AssetCollection")),
+    EZ_ACCESSOR_PROPERTY("Collection", GetCollectionFile, SetCollectionFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_AssetCollection", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_ATTRIBUTES

--- a/Code/Engine/Core/Physics/Implementation/SurfaceResourceDescriptor.cpp
+++ b/Code/Engine/Core/Physics/Implementation/SurfaceResourceDescriptor.cpp
@@ -15,7 +15,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezSurfaceInteraction, ezNoBase, 1, ezRTTIDefaultA
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Type", m_sInteractionType)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum")),
-    EZ_ACCESSOR_PROPERTY("Prefab", GetPrefab, SetPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("Prefab", GetPrefab, SetPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     // this does not work yet (asset transform fails)
     //EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("CompatibleAsset_Prefab")),
     EZ_ENUM_MEMBER_PROPERTY("Alignment", ezSurfaceInteractionAlignment, m_Alignment),
@@ -31,13 +31,13 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceResourceDescriptor, 2, ezRTTIDefaultAll
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BaseSurface", GetBaseSurfaceFile, SetBaseSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("BaseSurface", GetBaseSurfaceFile, SetBaseSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("Restitution", m_fPhysicsRestitution)->AddAttributes(new ezDefaultValueAttribute(0.25f)),
     EZ_MEMBER_PROPERTY("StaticFriction", m_fPhysicsFrictionStatic)->AddAttributes(new ezDefaultValueAttribute(0.6f)),
     EZ_MEMBER_PROPERTY("DynamicFriction", m_fPhysicsFrictionDynamic)->AddAttributes(new ezDefaultValueAttribute(0.4f)),
     EZ_ACCESSOR_PROPERTY("OnCollideInteraction", GetCollisionInteraction, SetCollisionInteraction)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum")),
-    EZ_ACCESSOR_PROPERTY("SlideReaction", GetSlideReactionPrefabFile, SetSlideReactionPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
-    EZ_ACCESSOR_PROPERTY("RollReaction", GetRollReactionPrefabFile, SetRollReactionPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("SlideReaction", GetSlideReactionPrefabFile, SetSlideReactionPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
+    EZ_ACCESSOR_PROPERTY("RollReaction", GetRollReactionPrefabFile, SetRollReactionPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_ARRAY_MEMBER_PROPERTY("Interactions", m_Interactions),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -15,6 +15,10 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTemporaryAttribute, 1, ezRTTIDefaultAllocator<ezTemporaryAttribute>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_STATIC_REFLECTED_BITFLAGS(ezDependencyFlags, 1)
+  EZ_BITFLAGS_CONSTANTS(ezDependencyFlags::Package, ezDependencyFlags::Thumbnail, ezDependencyFlags::Transform)
+EZ_END_STATIC_REFLECTED_BITFLAGS;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCategoryAttribute, 1, ezRTTIDefaultAllocator<ezCategoryAttribute>)
 {
   EZ_BEGIN_PROPERTIES
@@ -281,6 +285,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezFileBrowserAttribute, 1, ezRTTIDefaultAllocato
   {
     EZ_MEMBER_PROPERTY("Title", m_sDialogTitle),
     EZ_MEMBER_PROPERTY("Filter", m_sTypeFilter),
+    EZ_MEMBER_PROPERTY("CustomAction", m_sCustomAction),
+    EZ_BITFLAGS_MEMBER_PROPERTY("DependencyFlags", ezDependencyFlags, m_DependencyFlags),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_FUNCTIONS
@@ -296,6 +302,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAssetBrowserAttribute, 1, ezRTTIDefaultAllocat
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Filter", m_sTypeFilter),
+    EZ_BITFLAGS_MEMBER_PROPERTY("DependencyFlags", ezDependencyFlags, m_DependencyFlags),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_FUNCTIONS

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -363,7 +363,7 @@ struct ezDependencyFlags
 
   enum Enum
   {
-    None = 0, ///< The reference is not needed for anything in production. An example of this is editor references that are only used at edit time, e.g. a default animation clip for a skeleton.
+    None = 0,              ///< The reference is not needed for anything in production. An example of this is editor references that are only used at edit time, e.g. a default animation clip for a skeleton.
     Thumbnail = EZ_BIT(0), ///< This reference is a dependency to generating a thumbnail. The material references of a mesh for example.
     Transform = EZ_BIT(1), ///< This reference is a dependency to transforming this asset. The input model of a mesh for example.
     Package = EZ_BIT(2),   ///< This reference is needs to be packaged as it is used at runtime by this asset. All sounds or debris generated on impact of a surface are common examples of this.

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -336,17 +336,37 @@ private:
   ezUntrackedString m_sConstantValueProperty;
 };
 
-/// \brief Defines how a reference set by ezFileBrowserAttribute is treated.
+/// \brief Defines how a reference set by ezFileBrowserAttribute and ezAssetBrowserAttribute is treated.
+///
+/// A few examples to explain the flags:
+/// ## Input for a mesh: **Transform | Thumbnail**
+/// * The input (e.g. fbx) is obviously needed for transforming the asset.
+/// * We also can't generate a thumbnail without it.
+/// * But we don't need to package it with the final game as it is not used by the runtime.
+///
+/// ## Material on a mesh: **Thumbnail | Package**
+/// * The default material on a mesh asset is not needed to transform the mesh. As only the material reference is stored in the mesh asset, any changes to the material do not affect the transform output of the mesh.
+/// * It is obviously needed for the thumbnail as that is what is displayed in it.
+/// * We also need to package this reference as otherwise the runtime would fail to instantiate the mesh without errors.
+///
+/// ## Surface on hit prefab: **Package**
+/// * Transforming a surface is not affected if the prefab it spawns on impact changes. Only the reference is stored.
+/// * The set prefab does not show up in the thumbnail so it is not needed.
+/// * We do however need to package it or otherwise the runtime would fail to spawn the prefab on impact.
+///
+/// As a rule of thumb (also the default for each):
+/// * ezFileBrowserAttribute are mostly Transform and Thumbnail.
+/// * ezAssetBrowserAttribute are mostly Thumbnail and Package.
 struct ezDependencyFlags
 {
   typedef ezUInt8 StorageType;
 
   enum Enum
   {
-    None = 0,
-    Thumbnail = EZ_BIT(0), ///< This reference is a dependency to generating a thumbnail.
-    Transform = EZ_BIT(1), ///< This reference is a dependency to transforming this asset.
-    Package = EZ_BIT(2),   ///< This reference is needs to be packaged as it is used at runtime by this asset.
+    None = 0, ///< The reference is not needed for anything in production. An example of this is editor references that are only used at edit time, e.g. a default animation clip for a skeleton.
+    Thumbnail = EZ_BIT(0), ///< This reference is a dependency to generating a thumbnail. The material references of a mesh for example.
+    Transform = EZ_BIT(1), ///< This reference is a dependency to transforming this asset. The input model of a mesh for example.
+    Package = EZ_BIT(2),   ///< This reference is needs to be packaged as it is used at runtime by this asset. All sounds or debris generated on impact of a surface are common examples of this.
     Default = 0
   };
 

--- a/Code/Engine/GameEngine/Gameplay/Implementation/PlayerStartPointComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/PlayerStartPointComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezPlayerStartPointComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("PlayerPrefab", GetPlayerPrefabFile, SetPlayerPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("PlayerPrefab", GetPlayerPrefabFile, SetPlayerPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("PlayerPrefab")),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/GameEngine/Gameplay/Implementation/SpawnComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/SpawnComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSpawnComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Prefab", GetPrefabFile, SetPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("Prefab", GetPrefabFile, SetPrefabFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Prefab")),
     EZ_ACCESSOR_PROPERTY("AttachAsChild", GetAttachAsChild, SetAttachAsChild),
     EZ_ACCESSOR_PROPERTY("SpawnAtStart", GetSpawnAtStart, SetSpawnAtStart),

--- a/Code/Engine/GameEngine/Gameplay/Implementation/TimedDeathComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/TimedDeathComponent.cpp
@@ -15,7 +15,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTimedDeathComponent, 2, ezComponentMode::Static)
   {
     EZ_MEMBER_PROPERTY("MinDelay", m_MinDelay)->AddAttributes(new ezClampValueAttribute(ezTime(), ezVariant()), new ezDefaultValueAttribute(ezTime::Seconds(1.0))),
     EZ_MEMBER_PROPERTY("DelayRange", m_DelayRange)->AddAttributes(new ezClampValueAttribute(ezTime(), ezVariant())),
-    EZ_ACCESSOR_PROPERTY("TimeoutPrefab", GetTimeoutPrefab, SetTimeoutPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("TimeoutPrefab", GetTimeoutPrefab, SetTimeoutPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
@@ -8,7 +8,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineState_NestedStateMachine, 1, ezRTT
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine")),
+    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("InitialState", GetInitialState, SetInitialState),
     EZ_MEMBER_PROPERTY("KeepCurrentStateOnExit", m_bKeepCurrentStateOnExit),
   }

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineComponent.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineComponent.cpp
@@ -253,7 +253,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezStateMachineComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine")),
+    EZ_ACCESSOR_PROPERTY("Resource", GetResourceFile, SetResourceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_StateMachine", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("InitialState", GetInitialState, SetInitialState),
     EZ_ACCESSOR_PROPERTY("BlackboardName", GetBlackboardName, SetBlackboardName),
   }

--- a/Code/Engine/GameEngine/VisualScript/Implementation/VisualScriptComponent.cpp
+++ b/Code/Engine/GameEngine/VisualScript/Implementation/VisualScriptComponent.cpp
@@ -84,7 +84,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezVisualScriptComponent, 5, ezComponentMode::Static);
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Script", GetScriptFile, SetScriptFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Code_VisualScript")),
+    EZ_ACCESSOR_PROPERTY("Script", GetScriptFile, SetScriptFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Code_VisualScript", ezDependencyFlags::Package)),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Script"), new ezExposeColorAlphaAttribute),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
@@ -30,7 +30,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeletonBoneShape, 1, ezRTTIDefaultAll
     EZ_MEMBER_PROPERTY("OverrideName", m_bOverrideName),
     EZ_MEMBER_PROPERTY("Name", m_sNameOverride),
     EZ_MEMBER_PROPERTY("OverrideSurface", m_bOverrideSurface),
-    EZ_MEMBER_PROPERTY("Surface", m_sSurfaceOverride)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Surface", m_sSurfaceOverride)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("OverrideCollisionLayer", m_bOverrideCollisionLayer),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayerOverride)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
 
@@ -77,7 +77,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeleton, 1, ezRTTIDefaultAllocator<ez
     EZ_MEMBER_PROPERTY("UniformScaling", m_fUniformScaling)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0001f, 10000.0f)),
     EZ_ENUM_MEMBER_PROPERTY("BoneDirection", ezBasisAxis, m_BoneDirection)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
-    EZ_MEMBER_PROPERTY("Surface", m_sSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_MEMBER_PROPERTY("Surface", m_sSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
 
     EZ_ARRAY_MEMBER_PROPERTY("Children", m_Children)->AddFlags(ezPropertyFlags::PointerOwner | ezPropertyFlags::Hidden),
   }

--- a/Code/Engine/RendererCore/Components/Implementation/CameraComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/CameraComponent.cpp
@@ -156,7 +156,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezCameraComponent, 10, ezComponentMode::Static)
     EZ_MEMBER_PROPERTY("EditorShortcut", m_iEditorShortcut)->AddAttributes(new ezDefaultValueAttribute(-1), new ezClampValueAttribute(-1, 9)),
     EZ_ENUM_ACCESSOR_PROPERTY("UsageHint", ezCameraUsageHint, GetUsageHint, SetUsageHint),
     EZ_ENUM_ACCESSOR_PROPERTY("Mode", ezCameraMode, GetCameraMode, SetCameraMode),
-    EZ_ACCESSOR_PROPERTY("RenderTarget", GetRenderTargetFile, SetRenderTargetFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Target")),
+    EZ_ACCESSOR_PROPERTY("RenderTarget", GetRenderTargetFile, SetRenderTargetFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Target", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("RenderTargetOffset", GetRenderTargetRectOffset, SetRenderTargetRectOffset)->AddAttributes(new ezClampValueAttribute(ezVec2(0.0f), ezVec2(0.9f))),
     EZ_ACCESSOR_PROPERTY("RenderTargetSize", GetRenderTargetRectSize, SetRenderTargetRectSize)->AddAttributes(new ezDefaultValueAttribute(ezVec2(1.0f)), new ezClampValueAttribute(ezVec2(0.1f), ezVec2(1.0f))),
     EZ_ACCESSOR_PROPERTY("NearPlane", GetNearPlane, SetNearPlane)->AddAttributes(new ezDefaultValueAttribute(0.25f), new ezClampValueAttribute(0.01f, 4.0f)),

--- a/Code/Engine/RendererCore/Components/Implementation/RenderTargetActivatorComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RenderTargetActivatorComponent.cpp
@@ -12,7 +12,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezRenderTargetActivatorComponent, 1, ezComponentMode::St
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("RenderTarget", GetRenderTargetFile, SetRenderTargetFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Target")),
+    EZ_ACCESSOR_PROPERTY("RenderTarget", GetRenderTargetFile, SetRenderTargetFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Target", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_ATTRIBUTES

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -233,7 +233,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezFmodEventComponent, 4, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("Paused", GetPaused, SetPaused),
     EZ_ACCESSOR_PROPERTY("Volume", GetVolume, SetVolume)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("Pitch", GetPitch, SetPitch)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.01f, 100.0f)),
-    EZ_ACCESSOR_PROPERTY("SoundEvent", GetSoundEventFile, SetSoundEventFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Fmod_Event")),
+    EZ_ACCESSOR_PROPERTY("SoundEvent", GetSoundEventFile, SetSoundEventFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Fmod_Event", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("UseOcclusion", GetUseOcclusion, SetUseOcclusion),
     EZ_ACCESSOR_PROPERTY("OcclusionThreshold", GetOcclusionThreshold, SetOcclusionThreshold)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
     EZ_ACCESSOR_PROPERTY("OcclusionCollisionLayer", GetOcclusionCollisionLayer, SetOcclusionCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -21,7 +21,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProjectileSurfaceInteraction, ezNoBase, 3, ezRT
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Surface", GetSurface, SetSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("Surface", GetSurface, SetSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ENUM_MEMBER_PROPERTY("Reaction", ezProjectileReaction, m_Reaction),
     EZ_MEMBER_PROPERTY("Interaction", m_sInteraction)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum")),
     EZ_MEMBER_PROPERTY("Impulse", m_fImpulse),
@@ -38,9 +38,9 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 4, ezComponentMode::Dynamic)
     EZ_MEMBER_PROPERTY("Speed", m_fMetersPerSecond)->AddAttributes(new ezDefaultValueAttribute(10.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_MEMBER_PROPERTY("GravityMultiplier", m_fGravityMultiplier),
     EZ_MEMBER_PROPERTY("MaxLifetime", m_MaxLifetime)->AddAttributes(new ezClampValueAttribute(ezTime(), ezVariant())),
-    EZ_ACCESSOR_PROPERTY("OnTimeoutSpawn", GetTimeoutPrefab, SetTimeoutPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("OnTimeoutSpawn", GetTimeoutPrefab, SetTimeoutPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
-    EZ_ACCESSOR_PROPERTY("FallbackSurface", GetFallbackSurfaceFile, SetFallbackSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("FallbackSurface", GetFallbackSurfaceFile, SetFallbackSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ARRAY_MEMBER_PROPERTY("Interactions", m_SurfaceInteractions),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
@@ -91,7 +91,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltDynamicActorComponent, 3, ezComponentMode::Dynamic
       EZ_MEMBER_PROPERTY("StartAsleep", m_bStartAsleep),
       EZ_MEMBER_PROPERTY("Mass", m_fMass)->AddAttributes(new ezSuffixAttribute(" kg"), new ezClampValueAttribute(0.0f, ezVariant())),
       EZ_MEMBER_PROPERTY("Density", m_fDensity)->AddAttributes(new ezDefaultValueAttribute(100.0f), new ezSuffixAttribute(" kg/m^3")),
-      EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+      EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
       EZ_ACCESSOR_PROPERTY("GravityFactor", GetGravityFactor, SetGravityFactor)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
       EZ_MEMBER_PROPERTY("LinearDamping", m_fLinearDamping)->AddAttributes(new ezDefaultValueAttribute(0.2f)),
       EZ_MEMBER_PROPERTY("AngularDamping", m_fAngularDamping)->AddAttributes(new ezDefaultValueAttribute(0.2f)),

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -50,7 +50,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltQueryShapeActorComponent, 1, ezComponentMode::Stat
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
@@ -22,10 +22,10 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltStaticActorComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("CollisionMesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Triangle")),
+    EZ_ACCESSOR_PROPERTY("CollisionMesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Triangle", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("IncludeInNavmesh", m_bIncludeInNavmesh)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("PullSurfacesFromGraphicsMesh", m_bPullSurfacesFromGraphicsMesh),
-    EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -38,7 +38,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltDefaultCharacterComponent, 1, ezComponentMode::Dyn
     EZ_ACCESSOR_PROPERTY("WalkSurfaceInteraction", GetWalkSurfaceInteraction, SetWalkSurfaceInteraction)->AddAttributes(new ezDynamicStringEnumAttribute("SurfaceInteractionTypeEnum"), new ezDefaultValueAttribute(ezStringView("Footstep"))),
     EZ_MEMBER_PROPERTY("WalkInteractionDistance", m_fWalkInteractionDistance)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("RunInteractionDistance", m_fRunInteractionDistance)->AddAttributes(new ezDefaultValueAttribute(3.0f)),
-    EZ_ACCESSOR_PROPERTY("FallbackWalkSurface", GetFallbackWalkSurfaceFile, SetFallbackWalkSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+    EZ_ACCESSOR_PROPERTY("FallbackWalkSurface", GetFallbackWalkSurfaceFile, SetFallbackWalkSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ACCESSOR_PROPERTY("HeadObject", DummyGetter, SetHeadObjectReference)->AddAttributes(new ezGameObjectReferenceAttribute()),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
@@ -39,7 +39,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltRopeComponent, 1, ezComponentMode::Dynamic)
       EZ_MEMBER_PROPERTY("MaxBend", m_MaxBend)->AddAttributes(new ezDefaultValueAttribute(ezAngle::Degree(30)), new ezClampValueAttribute(ezAngle::Degree(5), ezAngle::Degree(90))),
       EZ_MEMBER_PROPERTY("MaxTwist", m_MaxTwist)->AddAttributes(new ezDefaultValueAttribute(ezAngle::Degree(15)), new ezClampValueAttribute(ezAngle::Degree(0.01f), ezAngle::Degree(90))),
       EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
-      EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface")),
+      EZ_ACCESSOR_PROPERTY("Surface", GetSurfaceFile, SetSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
       EZ_ACCESSOR_PROPERTY("GravityFactor", GetGravityFactor, SetGravityFactor)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
       EZ_MEMBER_PROPERTY("SelfCollision", m_bSelfCollision),
       EZ_MEMBER_PROPERTY("ContinuousCollisionDetection", m_bCCD),

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
@@ -13,7 +13,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltVisColMeshComponent, 1, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("CollisionMesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Triangle;CompatibleAsset_Jolt_Colmesh_Convex")),
+    EZ_ACCESSOR_PROPERTY("CollisionMesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Triangle;CompatibleAsset_Jolt_Colmesh_Convex", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltShapeConvexHullComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltShapeConvexHullComponent.cpp
@@ -15,7 +15,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezJoltShapeConvexHullComponent, 1, ezComponentMode::Stat
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("CollisionMesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Convex")),
+    EZ_ACCESSOR_PROPERTY("CollisionMesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Jolt_Colmesh_Convex", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
@@ -65,7 +65,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezParticleComponent, 5, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Effect", GetParticleEffectFile, SetParticleEffectFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect")),
+    EZ_ACCESSOR_PROPERTY("Effect", GetParticleEffectFile, SetParticleEffectFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Particle_Effect", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("SpawnAtStart", m_bSpawnAtStart)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_ENUM_MEMBER_PROPERTY("OnFinishedAction", ezOnComponentFinishedAction2, m_OnFinishedAction),
     EZ_MEMBER_PROPERTY("MinRestartDelay", m_MinRestartDelay),

--- a/Code/EnginePlugins/TypeScriptPlugin/Components/TypeScriptComponent.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/Components/TypeScriptComponent.cpp
@@ -20,7 +20,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezTypeScriptComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Script", GetTypeScriptComponentFile, SetTypeScriptComponentFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Code_TypeScript")),
+    EZ_ACCESSOR_PROPERTY("Script", GetTypeScriptComponentFile, SetTypeScriptComponentFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Code_TypeScript", ezDependencyFlags::Package)),
     EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("Script")),
   }
   EZ_END_PROPERTIES;

--- a/Code/Samples/RtsGamePlugin/Components/UnitComponent.cpp
+++ b/Code/Samples/RtsGamePlugin/Components/UnitComponent.cpp
@@ -14,7 +14,7 @@ EZ_BEGIN_COMPONENT_TYPE(RtsUnitComponent, 2, ezComponentMode::Dynamic)
   {
     EZ_MEMBER_PROPERTY("MaxHealth", m_uiMaxHealth)->AddAttributes(new ezDefaultValueAttribute(100)),
     EZ_MEMBER_PROPERTY("CurHealth", m_uiCurHealth),
-    EZ_ACCESSOR_PROPERTY("OnDestroyedPrefab", GetOnDestroyedPrefab, SetOnDestroyedPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
+    EZ_ACCESSOR_PROPERTY("OnDestroyedPrefab", GetOnDestroyedPrefab, SetOnDestroyedPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
   }
   EZ_END_PROPERTIES;
 

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
@@ -35,22 +35,15 @@ ezActionDescriptorHandle ezDocumentActions::s_hDocumentCategory;
 void ezDocumentActions::RegisterActions()
 {
   s_hSaveCategory = EZ_REGISTER_CATEGORY("SaveCategory");
-  s_hSave =
-    EZ_REGISTER_ACTION_1("Document.Save", ezActionScope::Document, "Document", "Ctrl+S", ezDocumentAction, ezDocumentAction::ButtonType::Save);
-  s_hSaveAll = EZ_REGISTER_ACTION_1(
-    "Document.SaveAll", ezActionScope::Document, "Document", "Ctrl+Shift+S", ezDocumentAction, ezDocumentAction::ButtonType::SaveAll);
-  s_hSaveAs =
-    EZ_REGISTER_ACTION_1("Document.SaveAs", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::SaveAs);
+  s_hSave = EZ_REGISTER_ACTION_1("Document.Save", ezActionScope::Document, "Document", "Ctrl+S", ezDocumentAction, ezDocumentAction::ButtonType::Save);
+  s_hSaveAll = EZ_REGISTER_ACTION_1("Document.SaveAll", ezActionScope::Document, "Document", "Ctrl+Shift+S", ezDocumentAction, ezDocumentAction::ButtonType::SaveAll);
+  s_hSaveAs = EZ_REGISTER_ACTION_1("Document.SaveAs", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::SaveAs);
   s_hCloseCategory = EZ_REGISTER_CATEGORY("CloseCategory");
-  s_hClose =
-    EZ_REGISTER_ACTION_1("Document.Close", ezActionScope::Document, "Document", "Ctrl+W", ezDocumentAction, ezDocumentAction::ButtonType::Close);
-  s_hOpenContainingFolder = EZ_REGISTER_ACTION_1(
-    "Document.OpenContainingFolder", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::OpenContainingFolder);
-  s_hCopyAssetGuid = EZ_REGISTER_ACTION_1(
-    "Document.CopyAssetGuid", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::CopyAssetGuid);
+  s_hClose = EZ_REGISTER_ACTION_1("Document.Close", ezActionScope::Document, "Document", "Ctrl+W", ezDocumentAction, ezDocumentAction::ButtonType::Close);
+  s_hOpenContainingFolder = EZ_REGISTER_ACTION_1("Document.OpenContainingFolder", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::OpenContainingFolder);
+  s_hCopyAssetGuid = EZ_REGISTER_ACTION_1("Document.CopyAssetGuid", ezActionScope::Document, "Document", "", ezDocumentAction, ezDocumentAction::ButtonType::CopyAssetGuid);
   s_hDocumentCategory = EZ_REGISTER_CATEGORY("Tools.DocumentCategory");
-  s_hUpdatePrefabs = EZ_REGISTER_ACTION_1(
-    "Prefabs.UpdateAll", ezActionScope::Document, "Scene", "Ctrl+Shift+P", ezDocumentAction, ezDocumentAction::ButtonType::UpdatePrefabs);
+  s_hUpdatePrefabs = EZ_REGISTER_ACTION_1("Prefabs.UpdateAll", ezActionScope::Document, "Scene", "Ctrl+Shift+P", ezDocumentAction, ezDocumentAction::ButtonType::UpdatePrefabs);
 }
 
 void ezDocumentActions::UnregisterActions()

--- a/Code/UnitTests/EditorTest/Project/Project.cpp
+++ b/Code/UnitTests/EditorTest/Project/Project.cpp
@@ -70,8 +70,9 @@ ezTestAppRun ezEditorTestProject::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInv
     ezAssetCurator::GetSingleton()->GetAssetTransformStats(uiNumAssets, sections);
 
     EZ_TEST_INT(sections[ezAssetInfo::TransformState::TransformError], 0);
-    EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingDependency], 0);
-    EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingReference], 0);
+    EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingTransformDependency], 0);
+    EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingThumbnailDependency], 0);
+    EZ_TEST_INT(sections[ezAssetInfo::TransformState::CircularDependency], 0);
   }
   return ezTestAppRun::Quit;
 }

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -79,6 +79,7 @@ Help.ReportProblem;Report a Problem...
 # Assets
 
 Asset.Transform;Transform Asset;Transform: Creates the runtime data for this asset
+Asset.WriteDependencyDGML;Write Dependency DGML...;Creates a DGML file containing all transform and thumbnail dependencies this asset transitively depends on
 Asset.TransformAll;Transform All Assets;Transform All: Runs asset transformation on all modified assets
 Asset.ResaveAll;Resave All Assets;Opens every document and saves it. Used to get all documents to the latest version.
 Asset.CheckFilesystem;Check Filesystem;Checks for new or deleted assets on disk


### PR DESCRIPTION
## Asset Package References
* fixes #814 
* Added **ezDependencyFlags** which defines how a reference in an asset is used:
  *  **Thumbnail**: This reference is a dependency to generating a thumbnail.
  *  **Transform**: This reference is a dependency to transforming this asset.
  *  **Package**: This reference is needs to be packaged as it is used at runtime by this asset.
* **ezAssetBrowserAttribute** now has a new parameter to set the `ezDependencyFlags` for it. By default, **ezDependencyFlags::Thumbnail | ezDependencyFlags::Package** is set.
* Fixed naming of various enums and member variables to match the new `transform`, `thumbnail` and `package` dependency naming pattern.

## Circular Dependencies
* Circular dependencies will no longer deadlock the editor and instead result in a new error code on one of the assets in the circle: **ezAssetInfo::TransformState::CircularDependency**.
* **ezAssetCurator::GenerateTransitiveHull** is no longer recursive and can handle circular dependencies.
* Added **ezAssetCurator::GenerateInverseTransitiveHull** which generates a set of all assets that depend in the given asset. Used by the new **ezAssetCurator::CheckForCircularDependencies** function.
* **ezAssetCurator::InvalidateAssetTransformState** is no longer recursive, using **GenerateInverseTransitiveHull** instead.
* **ezQtAssetPropertyWidget::InternalSetValue** will prevent the user now from creating circular dependencies.

## Misc
* Added **Asset.WriteDependencyDGML** action which creates a DGML file containing all transform and thumbnail dependencies this asset transitively depends on. Very useful to understand circular dependencies.
* Added **ezAssetActions::MapMenuActions** to put `Transform Asset` and `Write Dependency DGML` into the edit menu.
* **ezCollectionAssetDocument** are no longer updated automatically as their transitive naturure can't be tracked correctly by the currently defined `ezDependencyFlags`. Instead, they are set to manual transform and will be auto-generated on every scene export.