### PR TITLE
Fix #902: Compute Shader Histogram Duplicate Windows.

### DIFF
--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
@@ -38,8 +38,8 @@ private:
   ezGALUnorderedAccessViewHandle m_hHistogramUAV;
   ezGALResourceViewHandle m_hHistogramSRV;
 
+  ezWindowBase* m_pWindow;
   ezGALSwapChainHandle m_hSwapChain;
-  ezGALRenderTargetViewHandle m_hBackbufferRTV;
 
   ezShaderResourceHandle m_hScreenShader;
   ezShaderResourceHandle m_hHistogramDisplayShader;


### PR DESCRIPTION
Fixed the Compute Shader Histogram sample recreating the main window and output target.