### PR TITLE
Fixed #905: Greybox collision mesh geometry is not exported by prefabs anymore

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -495,9 +495,11 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
             }
 
             if (!pDocumentContext)
+            {
               pDocumentContext = pRtti->GetAllocator()->Allocate<ezEngineProcessDocumentContext>();
+            }
 
-            ezEngineProcessDocumentContext::AddDocumentContext(pMsg->m_DocumentGuid, pMsg->m_DocumentMetaData, pDocumentContext, &m_IPC);
+            ezEngineProcessDocumentContext::AddDocumentContext(pMsg->m_DocumentGuid, pMsg->m_DocumentMetaData, pDocumentContext, &m_IPC, pMsg->m_sDocumentType);
             break;
           }
         }

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
@@ -46,14 +46,17 @@ public:
   ezEngineProcessDocumentContext(ezBitflags<ezEngineProcessDocumentContextFlags> flags);
   virtual ~ezEngineProcessDocumentContext();
 
-  virtual void Initialize(const ezUuid& documentGuid, const ezVariant& metaData, ezEngineProcessCommunicationChannel* pIPC);
+  virtual void Initialize(const ezUuid& documentGuid, const ezVariant& metaData, ezEngineProcessCommunicationChannel* pIPC, ezStringView sDocumentType);
   void Deinitialize();
+
+  /// \brief Returns the document type for which this context was created. Useful in case a context may be used for multiple document types.
+  ezStringView GetDocumentType() const { return m_sDocumentType; }
 
   void SendProcessMessage(ezProcessMessage* pMsg = nullptr);
   virtual void HandleMessage(const ezEditorEngineDocumentMsg* pMsg);
 
   static ezEngineProcessDocumentContext* GetDocumentContext(ezUuid guid);
-  static void AddDocumentContext(ezUuid guid, const ezVariant& metaData, ezEngineProcessDocumentContext* pView, ezEngineProcessCommunicationChannel* pIPC);
+  static void AddDocumentContext(ezUuid guid, const ezVariant& metaData, ezEngineProcessDocumentContext* pView, ezEngineProcessCommunicationChannel* pIPC, ezStringView sDocumentType);
   static bool PendingOperationsInProgress();
   static void UpdateDocumentContexts();
   static void DestroyDocumentContext(ezUuid guid);
@@ -169,7 +172,7 @@ private:
   enum Constants
   {
     ThumbnailSuperscaleFactor =
-      2, ///< Thumbnail render target size is multiplied by this and then the final image is downscaled again. Needs to be power-of-two.
+      2,                                 ///< Thumbnail render target size is multiplied by this and then the final image is downscaled again. Needs to be power-of-two.
     ThumbnailConvergenceFramesTarget = 4 ///< Due to multi-threaded rendering, this must be at least 4
   };
 
@@ -181,6 +184,7 @@ private:
   ezGALTextureHandle m_hThumbnailColorRT;
   ezGALTextureHandle m_hThumbnailDepthRT;
   bool m_bWorldSimStateBeforeThumbnail = false;
+  ezString m_sDocumentType;
 
   //////////////////////////////////////////////////////////////////////////
   // GameObject reference resolution

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -28,12 +28,12 @@ ezEngineProcessDocumentContext* ezEngineProcessDocumentContext::GetDocumentConte
   return pResult;
 }
 
-void ezEngineProcessDocumentContext::AddDocumentContext(ezUuid guid, const ezVariant& metaData, ezEngineProcessDocumentContext* pContext, ezEngineProcessCommunicationChannel* pIPC)
+void ezEngineProcessDocumentContext::AddDocumentContext(ezUuid guid, const ezVariant& metaData, ezEngineProcessDocumentContext* pContext, ezEngineProcessCommunicationChannel* pIPC, ezStringView sDocumentType)
 {
   EZ_ASSERT_DEV(!s_DocumentContexts.Contains(guid), "Cannot add a view with an index that already exists");
   s_DocumentContexts[guid] = pContext;
 
-  pContext->Initialize(guid, metaData, pIPC);
+  pContext->Initialize(guid, metaData, pIPC, sDocumentType);
 }
 
 bool ezEngineProcessDocumentContext::PendingOperationsInProgress()
@@ -106,11 +106,16 @@ ezEngineProcessDocumentContext::~ezEngineProcessDocumentContext()
   m_Context.m_Events.RemoveEventHandler(ezMakeDelegate(&ezEngineProcessDocumentContext::WorldRttiConverterContextEventHandler, this));
 }
 
-void ezEngineProcessDocumentContext::Initialize(const ezUuid& documentGuid, const ezVariant& metaData, ezEngineProcessCommunicationChannel* pIPC)
+void ezEngineProcessDocumentContext::Initialize(const ezUuid& documentGuid, const ezVariant& metaData, ezEngineProcessCommunicationChannel* pIPC, ezStringView sDocumentType)
 {
   m_DocumentGuid = documentGuid;
   m_MetaData = metaData;
   m_pIPC = pIPC;
+
+  if (m_sDocumentType != sDocumentType)
+  {
+    m_sDocumentType = sDocumentType;
+  }
 
   if (m_Flags.IsSet(ezEngineProcessDocumentContextFlags::CreateWorld))
   {
@@ -387,7 +392,7 @@ void ezEngineProcessDocumentContext::Reset()
 
   Deinitialize();
 
-  Initialize(guid, m_MetaData, ipc);
+  Initialize(guid, m_MetaData, ipc, m_sDocumentType);
 }
 
 void ezEngineProcessDocumentContext::ClearExistingObjects()

--- a/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.cpp
@@ -36,14 +36,14 @@ void ezSceneExportModifier::DestroyModifiers(ezHybridArray<ezSceneExportModifier
   ref_modifiers.Clear();
 }
 
-void ezSceneExportModifier::ApplyAllModifiers(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport)
+void ezSceneExportModifier::ApplyAllModifiers(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
   ezHybridArray<ezSceneExportModifier*, 8> modifiers;
   CreateModifiers(modifiers);
 
   for (auto pMod : modifiers)
   {
-    pMod->ModifyWorld(ref_world, documentGuid, bForExport);
+    pMod->ModifyWorld(ref_world, sDocumentType, documentGuid, bForExport);
   }
 
   DestroyModifiers(modifiers);

--- a/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.h
+++ b/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.h
@@ -13,9 +13,9 @@ public:
   static void CreateModifiers(ezHybridArray<ezSceneExportModifier*, 8>& ref_modifiers);
   static void DestroyModifiers(ezHybridArray<ezSceneExportModifier*, 8>& ref_modifiers);
 
-  static void ApplyAllModifiers(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport);
+  static void ApplyAllModifiers(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport);
 
-  virtual void ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport) = 0;
+  virtual void ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport) = 0;
 
   static void CleanUpWorld(ezWorld& ref_world);
 };

--- a/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.cpp
+++ b/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.cpp
@@ -10,8 +10,21 @@
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneExportModifier_JoltStaticMeshConversion, 1, ezRTTIDefaultAllocator<ezSceneExportModifier_JoltStaticMeshConversion>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-void ezSceneExportModifier_JoltStaticMeshConversion::ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport)
+void ezSceneExportModifier_JoltStaticMeshConversion::ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
+  if (sDocumentType == "Prefab")
+  {
+    // the auto generated static meshes are needed in the prefab document, so that physical interactions for previewing purposes work
+    // however, the scene also exports the static colmesh, including all the prefabs (with overridden materials)
+    // in the final scene this would create double colmeshes in the same place, but the materials may differ
+    // therefore we don't want to export the colmesh other than for preview purposes, so we ignore this, if 'bForExport' is true
+
+    if (bForExport)
+    {
+      return;
+    }
+  }
+
   EZ_LOCK(ref_world.GetWriteMarker());
 
   ezSmcDescription desc;

--- a/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.h
+++ b/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.h
@@ -8,5 +8,5 @@ class EZ_ENGINEPLUGINJOLT_DLL ezSceneExportModifier_JoltStaticMeshConversion : p
   EZ_ADD_DYNAMIC_REFLECTION(ezSceneExportModifier_JoltStaticMeshConversion, ezSceneExportModifier);
 
 public:
-  virtual void ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport) override;
+  virtual void ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport) override;
 };

--- a/Code/EditorPlugins/PhysX/EnginePluginPhysX/SceneExport/StaticMeshConversion.cpp
+++ b/Code/EditorPlugins/PhysX/EnginePluginPhysX/SceneExport/StaticMeshConversion.cpp
@@ -10,7 +10,7 @@
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneExportModifier_StaticMeshConversion, 1, ezRTTIDefaultAllocator<ezSceneExportModifier_StaticMeshConversion>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-void ezSceneExportModifier_StaticMeshConversion::ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport)
+void ezSceneExportModifier_StaticMeshConversion::ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
   EZ_LOCK(ref_world.GetWriteMarker());
 

--- a/Code/EditorPlugins/PhysX/EnginePluginPhysX/SceneExport/StaticMeshConversion.h
+++ b/Code/EditorPlugins/PhysX/EnginePluginPhysX/SceneExport/StaticMeshConversion.h
@@ -8,5 +8,5 @@ class EZ_ENGINEPLUGINPHYSX_DLL ezSceneExportModifier_StaticMeshConversion : publ
   EZ_ADD_DYNAMIC_REFLECTION(ezSceneExportModifier_StaticMeshConversion, ezSceneExportModifier);
 
 public:
-  virtual void ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport) override;
+  virtual void ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport) override;
 };

--- a/Code/EditorPlugins/Scene/EnginePluginScene/Components/CommentComponent.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/Components/CommentComponent.cpp
@@ -41,7 +41,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneExportModifier_RemoveCommentComponents, 1
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezSceneExportModifier_RemoveCommentComponents::ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport)
+void ezSceneExportModifier_RemoveCommentComponents::ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
   EZ_LOCK(ref_world.GetWriteMarker());
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/Components/CommentComponent.h
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/Components/CommentComponent.h
@@ -35,5 +35,5 @@ class EZ_ENGINEPLUGINSCENE_DLL ezSceneExportModifier_RemoveCommentComponents : p
   EZ_ADD_DYNAMIC_REFLECTION(ezSceneExportModifier_RemoveCommentComponents, ezSceneExportModifier);
 
 public:
-  virtual void ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport) override;
+  virtual void ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport) override;
 };

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -466,7 +466,7 @@ void ezSceneContext::OnSimulationEnabled()
 {
   ezLog::Info("World Simulation enabled");
 
-  ezSceneExportModifier::ApplyAllModifiers(*m_pWorld, GetDocumentGuid(), false);
+  ezSceneExportModifier::ApplyAllModifiers(*m_pWorld, GetDocumentType(), GetDocumentGuid(), false);
 
   ezResourceManager::ReloadAllResources(false);
 
@@ -634,7 +634,7 @@ void ezSceneContext::OnPlayTheGameModeStarted(const ezTransform* pStartPosition)
 
   ezLog::Info("Starting Play-the-Game mode");
 
-  ezSceneExportModifier::ApplyAllModifiers(*m_pWorld, GetDocumentGuid(), false);
+  ezSceneExportModifier::ApplyAllModifiers(*m_pWorld, GetDocumentType(), GetDocumentGuid(), false);
 
   ezResourceManager::ReloadAllResources(false);
 
@@ -823,7 +823,7 @@ ezStatus ezSceneContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
   }
 
   // #TODO layers
-  ezSceneExportModifier::ApplyAllModifiers(*m_pWorld, GetDocumentGuid(), true);
+  ezSceneExportModifier::ApplyAllModifiers(*m_pWorld, GetDocumentType(), GetDocumentGuid(), true);
 
   ezDeferredFileWriter file;
   file.SetOutput(pMsg->m_sOutputFile);
@@ -939,7 +939,8 @@ void ezSceneContext::ExportExposedParameters(const ezWorldWriter& ww, ezDeferred
     paramdesc.m_sProperty.Assign(esp.m_sPropertyPath.GetData());
   }
 
-  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
+  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool
+    { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
 
   file << exposedParams.GetCount();
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -939,8 +939,7 @@ void ezSceneContext::ExportExposedParameters(const ezWorldWriter& ww, ezDeferred
     paramdesc.m_sProperty.Assign(esp.m_sPropertyPath.GetData());
   }
 
-  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool
-    { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
+  exposedParams.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
 
   file << exposedParams.GetCount();
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneExport/ExportModifiers.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneExport/ExportModifiers.cpp
@@ -11,7 +11,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneExportModifier_RemoveShapeIconComponents,
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezSceneExportModifier_RemoveShapeIconComponents::ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport)
+void ezSceneExportModifier_RemoveShapeIconComponents::ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
   EZ_LOCK(ref_world.GetWriteMarker());
 
@@ -31,7 +31,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSceneExportModifier_RemovePathNodeComponents, 
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezSceneExportModifier_RemovePathNodeComponents::ModifyWorld(ezWorld& world, const ezUuid& documentGuid, bool bForExport)
+void ezSceneExportModifier_RemovePathNodeComponents::ModifyWorld(ezWorld& world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport)
 {
   if (!bForExport)
     return;

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneExport/ExportModifiers.h
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneExport/ExportModifiers.h
@@ -10,7 +10,7 @@ class EZ_ENGINEPLUGINSCENE_DLL ezSceneExportModifier_RemoveShapeIconComponents :
   EZ_ADD_DYNAMIC_REFLECTION(ezSceneExportModifier_RemoveShapeIconComponents, ezSceneExportModifier);
 
 public:
-  virtual void ModifyWorld(ezWorld& ref_world, const ezUuid& documentGuid, bool bForExport) override;
+  virtual void ModifyWorld(ezWorld& ref_world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport) override;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -20,5 +20,5 @@ class EZ_ENGINEPLUGINSCENE_DLL ezSceneExportModifier_RemovePathNodeComponents : 
   EZ_ADD_DYNAMIC_REFLECTION(ezSceneExportModifier_RemovePathNodeComponents, ezSceneExportModifier);
 
 public:
-  virtual void ModifyWorld(ezWorld& world, const ezUuid& documentGuid, bool bForExport) override;
+  virtual void ModifyWorld(ezWorld& world, ezStringView sDocumentType, const ezUuid& documentGuid, bool bForExport) override;
 };


### PR DESCRIPTION
This created double collision meshes, both from the instantiated prefab and from the scene. This didn't work well, if the scene instantiated the prefab and overrode it's materials.