### PR TITLE
Rewrote how the orbit camera behaves

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -324,10 +324,10 @@ public:
   ///@{
 
   /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
-  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false, bool bIncludePackageDeps = false) const;
+  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false, bool bIncludePackageDeps = false) const;
 
   /// \brief Generates one inverse transitive hull for all the types dependencies that are enabled. The set will contain inverse dependencies that can reach the given asset (pAssetInfo) via any combination of the enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.
-  void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inverseDeps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false) const;
+  void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inout_inverseDeps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false) const;
 
   /// \brief Generates a DGML graph of all transform and thumbnail dependencies.
   void WriteDependencyDGML(const ezUuid& guid, ezStringView sOutputFile) const;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1311,8 +1311,9 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
 
       ezMap<ezUInt32, ezString> connection;
 
-      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel) {
-        ezUInt32 uiOutputNode = *nodeMap.GetValue(ref);
+      auto ExtendConnection = [&](const ezString& sRef, ezStringView sLabel)
+      {
+        ezUInt32 uiOutputNode = *nodeMap.GetValue(sRef);
         sTemp = connection[uiOutputNode];
         if (sTemp.IsEmpty())
           sTemp = sLabel;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1311,8 +1311,7 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
 
       ezMap<ezUInt32, ezString> connection;
 
-      auto ExtendConnection = [&](const ezString& sRef, ezStringView sLabel)
-      {
+      auto ExtendConnection = [&](const ezString& sRef, ezStringView sLabel) {
         ezUInt32 uiOutputNode = *nodeMap.GetValue(sRef);
         sTemp = connection[uiOutputNode];
         if (sTemp.IsEmpty())

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -155,8 +155,7 @@ void ezAssetCurator::StartInitialize(const ezApplicationFileSystemConfig& cfg)
   m_pWatcher = EZ_DEFAULT_NEW(ezAssetWatcher, m_FileSystemConfig);
   m_pAssetTableWriter = EZ_DEFAULT_NEW(ezAssetTableWriter, m_FileSystemConfig);
 
-  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]()
-    {
+  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]() {
     EZ_LOCK(m_CuratorMutex);
     LoadCaches();
 
@@ -642,8 +641,7 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
   // TODO: This is the old slow code path that will find the longest substring match.
   // Should be removed or folded into FindBestMatchForFile once it's surely not needed anymore.
 
-  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo*
-  {
+  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo* {
     // try to find the 'exact' relative path
     // otherwise find the shortest possible path
     ezUInt32 uiMinLength = 0xFFFFFFFF;
@@ -989,8 +987,7 @@ ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArra
   {
     EZ_LOCK(m_CuratorMutex);
 
-    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool
-    {
+    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool {
       for (auto it = m_ReferencedFiles.GetIterator(); it.IsValid(); ++it)
       {
         if (it.Value().m_Status != ezFileStatus::Status::Valid)
@@ -1041,8 +1038,7 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   ezSet<ezUuid> todoList;
   todoList.Insert(assetGuid);
 
-  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset)
-  {
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset) {
     auto it = inverseTracker.Find(sAsset);
     if (it.IsValid())
     {
@@ -1315,8 +1311,7 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
 
       ezMap<ezUInt32, ezString> connection;
 
-      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel)
-      {
+      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel) {
         ezUInt32 uiOutputNode = *nodeMap.GetValue(ref);
         sTemp = connection[uiOutputNode];
         if (sTemp.IsEmpty())

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -155,7 +155,8 @@ void ezAssetCurator::StartInitialize(const ezApplicationFileSystemConfig& cfg)
   m_pWatcher = EZ_DEFAULT_NEW(ezAssetWatcher, m_FileSystemConfig);
   m_pAssetTableWriter = EZ_DEFAULT_NEW(ezAssetTableWriter, m_FileSystemConfig);
 
-  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]() {
+  ezSharedPtr<ezDelegateTask<void>> pInitTask = EZ_DEFAULT_NEW(ezDelegateTask<void>, "AssetCuratorUpdateCache", [this]()
+    {
     EZ_LOCK(m_CuratorMutex);
     LoadCaches();
 
@@ -641,7 +642,8 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
   // TODO: This is the old slow code path that will find the longest substring match.
   // Should be removed or folded into FindBestMatchForFile once it's surely not needed anymore.
 
-  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo* {
+  auto FindAsset = [this](ezStringView sPathView) -> ezAssetInfo*
+  {
     // try to find the 'exact' relative path
     // otherwise find the shortest possible path
     ezUInt32 uiMinLength = 0xFFFFFFFF;
@@ -987,7 +989,8 @@ ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArra
   {
     EZ_LOCK(m_CuratorMutex);
 
-    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool {
+    auto SearchFile = [this](ezStringBuilder& ref_sName) -> bool
+    {
       for (auto it = m_ReferencedFiles.GetIterator(); it.IsValid(); ++it)
       {
         if (it.Value().m_Status != ezFileStatus::Status::Valid)
@@ -1038,7 +1041,8 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   ezSet<ezUuid> todoList;
   todoList.Insert(assetGuid);
 
-  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset) {
+  auto GatherReferences = [&](const ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, const ezStringBuilder& sAsset)
+  {
     auto it = inverseTracker.Find(sAsset);
     if (it.IsValid())
     {
@@ -1149,12 +1153,12 @@ void ezAssetCurator::NeedsReloadResources(const ezUuid& assetGuid)
   }
 }
 
-void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& deps, bool bIncludeTransformDeps, bool bIncludeThumbnailDeps, bool bIncludePackageDeps) const
+void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, bool bIncludeTransformDeps, bool bIncludeThumbnailDeps, bool bIncludePackageDeps) const
 {
   EZ_LOCK(m_CuratorMutex);
 
   ezHybridArray<ezString, 6> toDoList;
-  deps.Insert(sAssetOrPath);
+  inout_deps.Insert(sAssetOrPath);
   toDoList.PushBack(sAssetOrPath);
 
   while (!toDoList.IsEmpty())
@@ -1171,9 +1175,9 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_TransformDependencies)
         {
-          if (!deps.Contains(dep))
+          if (!inout_deps.Contains(dep))
           {
-            deps.Insert(dep);
+            inout_deps.Insert(dep);
             toDoList.PushBack(dep);
           }
         }
@@ -1182,9 +1186,9 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_ThumbnailDependencies)
         {
-          if (!deps.Contains(dep))
+          if (!inout_deps.Contains(dep))
           {
-            deps.Insert(dep);
+            inout_deps.Insert(dep);
             toDoList.PushBack(dep);
           }
         }
@@ -1193,9 +1197,9 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_PackageDependencies)
         {
-          if (!deps.Contains(dep))
+          if (!inout_deps.Contains(dep))
           {
-            deps.Insert(dep);
+            inout_deps.Insert(dep);
             toDoList.PushBack(dep);
           }
         }
@@ -1204,13 +1208,13 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
   }
 }
 
-void ezAssetCurator::GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inverseDeps, bool bIncludeTransformDebs, bool bIncludeThumbnailDebs) const
+void ezAssetCurator::GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inout_inverseDeps, bool bIncludeTransformDebs, bool bIncludeThumbnailDebs) const
 {
   EZ_LOCK(m_CuratorMutex);
 
   ezHybridArray<const ezAssetInfo*, 6> toDoList;
   toDoList.PushBack(pAssetInfo);
-  inverseDeps.Insert(pAssetInfo->m_Info->m_DocumentID);
+  inout_inverseDeps.Insert(pAssetInfo->m_Info->m_DocumentID);
 
   while (!toDoList.IsEmpty())
   {
@@ -1223,13 +1227,13 @@ void ezAssetCurator::GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo
       {
         for (const ezUuid& asset : it.Value())
         {
-          if (!inverseDeps.Contains(asset))
+          if (!inout_inverseDeps.Contains(asset))
           {
             ezAssetInfo* pAssetInfo = nullptr;
             if (m_KnownAssets.TryGetValue(asset, pAssetInfo))
             {
               toDoList.PushBack(pAssetInfo);
-              inverseDeps.Insert(asset);
+              inout_inverseDeps.Insert(asset);
             }
           }
         }
@@ -1242,13 +1246,13 @@ void ezAssetCurator::GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo
       {
         for (const ezUuid& asset : it.Value())
         {
-          if (!inverseDeps.Contains(asset))
+          if (!inout_inverseDeps.Contains(asset))
           {
             ezAssetInfo* pAssetInfo = nullptr;
             if (m_KnownAssets.TryGetValue(asset, pAssetInfo))
             {
               toDoList.PushBack(pAssetInfo);
-              inverseDeps.Insert(asset);
+              inout_inverseDeps.Insert(asset);
             }
           }
         }
@@ -1311,7 +1315,8 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
 
       ezMap<ezUInt32, ezString> connection;
 
-      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel) {
+      auto ExtendConnection = [&](const ezString& ref, ezStringView sLabel)
+      {
         ezUInt32 uiOutputNode = *nodeMap.GetValue(ref);
         sTemp = connection[uiOutputNode];
         if (sTemp.IsEmpty())

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/OrbitCamViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/OrbitCamViewWidget.cpp
@@ -11,7 +11,6 @@ ezQtOrbitCamViewWidget::ezQtOrbitCamViewWidget(ezQtEngineDocumentWindow* pOwnerW
 
   m_pOrbitCameraContext = EZ_DEFAULT_NEW(ezOrbitCameraContext, pOwnerWindow, this);
   m_pOrbitCameraContext->SetCamera(&m_pViewConfig->m_Camera);
-  m_pOrbitCameraContext->SetOrbitVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2), true);
 
   if (bPicking)
   {
@@ -25,9 +24,37 @@ ezQtOrbitCamViewWidget::ezQtOrbitCamViewWidget(ezQtEngineDocumentWindow* pOwnerW
 ezQtOrbitCamViewWidget::~ezQtOrbitCamViewWidget() = default;
 
 
-void ezQtOrbitCamViewWidget::ConfigureOrbitCameraVolume(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vDefaultCameraPosition)
+void ezQtOrbitCamViewWidget::ConfigureFixed(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vCamPosition)
 {
-  m_pOrbitCameraContext->SetOrbitVolume(vCenterPos, vHalfBoxSize, vDefaultCameraPosition, true);
+  m_pOrbitCameraContext->SetDefaultCameraFixed(vCamPosition);
+  m_pOrbitCameraContext->SetOrbitVolume(vCenterPos, vHalfBoxSize);
+  m_pOrbitCameraContext->MoveCameraToDefaultPosition();
+  m_bSetDefaultCamPos = false;
+}
+
+void ezQtOrbitCamViewWidget::ConfigureRelative(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vCamDirection, float fCamDistanceScale)
+{
+  m_pOrbitCameraContext->SetDefaultCameraRelative(vCamDirection, fCamDistanceScale);
+  m_pOrbitCameraContext->SetOrbitVolume(vCenterPos, vHalfBoxSize);
+  m_pOrbitCameraContext->MoveCameraToDefaultPosition();
+  m_bSetDefaultCamPos = true;
+}
+
+void ezQtOrbitCamViewWidget::SetOrbitVolume(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize)
+{
+  m_pOrbitCameraContext->SetOrbitVolume(vCenterPos, vHalfBoxSize);
+
+  if (m_bSetDefaultCamPos)
+  {
+    if (vHalfBoxSize != ezVec3(0.1f))
+    {
+      // 0.1f is a hard-coded value for the bounding box, in case nothing is available yet
+      // not pretty, but somehow we need to know when the first 'proper' bounds are available
+
+      m_bSetDefaultCamPos = false;
+      m_pOrbitCameraContext->MoveCameraToDefaultPosition();
+    }
+  }
 }
 
 ezOrbitCameraContext* ezQtOrbitCamViewWidget::GetOrbitCamera()

--- a/Code/Editor/EditorFramework/DocumentWindow/OrbitCamViewWidget.moc.h
+++ b/Code/Editor/EditorFramework/DocumentWindow/OrbitCamViewWidget.moc.h
@@ -14,14 +14,18 @@ public:
   ezQtOrbitCamViewWidget(ezQtEngineDocumentWindow* pOwnerWindow, ezEngineViewConfig* pViewConfig, bool bPicking = false);
   ~ezQtOrbitCamViewWidget();
 
-  void ConfigureOrbitCameraVolume(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vDefaultCameraPosition);
+  void ConfigureFixed(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vCamPosition);
+  void ConfigureRelative(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vCamDirection, float fCamDistanceScale);
+
+  void SetOrbitVolume(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize);
 
   ezOrbitCameraContext* GetOrbitCamera();
-
 
   virtual void SyncToEngine() override;
 
 private:
+  bool m_bSetDefaultCamPos = true;
+
   ezUniquePtr<ezOrbitCameraContext> m_pOrbitCameraContext;
   ezUniquePtr<ezSelectionContext> m_pSelectionContext;
 };

--- a/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
+++ b/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
@@ -55,17 +55,17 @@ private:
 
   ezCamera* m_pCamera;
 
-  bool m_bRun;
-  bool m_bSlowDown;
-  bool m_bMoveForwards;
-  bool m_bMoveBackwards;
-  bool m_bMoveRight;
-  bool m_bMoveLeft;
-  bool m_bMoveUp;
-  bool m_bMoveDown;
-  bool m_bMoveForwardsInPlane;
-  bool m_bMoveBackwardsInPlane;
-  bool m_bDidMoveMouse[3]; // Left Click, Right Click, Middle Click
+  bool m_bRun = false;
+  bool m_bSlowDown = false;
+  bool m_bMoveForwards = false;
+  bool m_bMoveBackwards = false;
+  bool m_bMoveRight = false;
+  bool m_bMoveLeft = false;
+  bool m_bMoveUp = false;
+  bool m_bMoveDown = false;
+  bool m_bMoveForwardsInPlane = false;
+  bool m_bMoveBackwardsInPlane = false;
+  bool m_bDidMoveMouse[3] = {false, false, false}; // Left Click, Right Click, Middle Click
 
   bool m_bRotateLeft = false;
   bool m_bRotateRight = false;

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/OrbitCameraContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/OrbitCameraContext.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <Core/Graphics/Camera.h>
+#include <EditorFramework/DocumentWindow/EngineViewWidget.moc.h>
 #include <EditorFramework/InputContexts/OrbitCameraContext.h>
 
 ezOrbitCameraContext::ezOrbitCameraContext(ezQtEngineDocumentWindow* pOwnerWindow, ezQtEngineViewWidget* pOwnerView)

--- a/Code/Editor/EditorFramework/InputContexts/OrbitCameraContext.h
+++ b/Code/Editor/EditorFramework/InputContexts/OrbitCameraContext.h
@@ -14,8 +14,13 @@ public:
   void SetCamera(ezCamera* pCamera);
   ezCamera* GetCamera() const;
 
+  void SetDefaultCameraRelative(const ezVec3& vDirection, float fDistanceScale);
+  void SetDefaultCameraFixed(const ezVec3& vPosition);
+
+  void MoveCameraToDefaultPosition();
+
   /// \brief Defines the box in which the user may move the camera around
-  void SetOrbitVolume(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize, const ezVec3& vDefaultCameraPosition, bool bSetCamLookat);
+  void SetOrbitVolume(const ezVec3& vCenterPos, const ezVec3& vHalfBoxSize);
 
   /// \brief The center point around which the camera can be moved and rotated.
   ezVec3 GetVolumeCenter() const { return m_Volume.GetCenter(); }
@@ -31,13 +36,14 @@ protected:
   virtual ezEditorInput DoMouseMoveEvent(QMouseEvent* e) override;
   virtual ezEditorInput DoWheelEvent(QWheelEvent* e) override;
   virtual ezEditorInput DoKeyPressEvent(QKeyEvent* e) override;
+  virtual ezEditorInput DoKeyReleaseEvent(QKeyEvent* e) override;
 
   virtual void OnSetOwner(ezQtEngineDocumentWindow* pOwnerWindow, ezQtEngineViewWidget* pOwnerView) override {}
 
-
-
 private:
-  virtual void UpdateContext() override{};
+  virtual void UpdateContext() override;
+
+  float GetCameraSpeed() const;
 
   void ResetCursor();
   void SetCurrentMouseMode();
@@ -48,16 +54,25 @@ private:
   {
     Off,
     Orbit,
-    UpDown,
-    MovePlane,
+    Free,
     Pan,
   };
 
-  Mode m_Mode;
+  Mode m_Mode = Mode::Off;
   ezCamera* m_pCamera;
 
-  ezVec3 m_vDefaultCameraPosition;
-  ezVec3 m_vOrbitPoint;
-
   ezBoundingBox m_Volume;
+
+  bool m_bFixedDefaultCamera = true;
+  ezVec3 m_vDefaultCamera = ezVec3(1, 0, 0);
+
+  bool m_bRun = false;
+  bool m_bMoveForwards = false;
+  bool m_bMoveBackwards = false;
+  bool m_bMoveRight = false;
+  bool m_bMoveLeft = false;
+  bool m_bMoveUp = false;
+  bool m_bMoveDown = false;
+
+  ezTime m_LastUpdate;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetWindow.moc.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetWindow.moc.cpp
@@ -45,7 +45,7 @@ ezQtAnimatedMeshAssetDocumentWindow::ezQtAnimatedMeshAssetDocumentWindow(ezAnima
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "AnimatedMeshAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -67,8 +67,6 @@ ezQtAnimatedMeshAssetDocumentWindow::ezQtAnimatedMeshAssetDocumentWindow(ezAnima
   }
 
   FinishWindowCreation();
-
-  QueryObjectBBox(0);
 
   UpdatePreview();
 
@@ -103,10 +101,10 @@ void ezQtAnimatedMeshAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtAnimatedMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtAnimatedMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /* = 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -174,11 +172,9 @@ void ezQtAnimatedMeshAssetDocumentWindow::ProcessMessageEventHandler(const ezEdi
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetWindow.moc.h
@@ -32,7 +32,7 @@ protected Q_SLOTS:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
   void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);
   bool UpdatePreview();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.cpp
@@ -46,7 +46,7 @@ ezQtAnimationClipAssetDocumentWindow::ezQtAnimationClipAssetDocumentWindow(ezAni
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0, 0, 1), ezVec3(5.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "AnimationClipAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -106,8 +106,6 @@ ezQtAnimationClipAssetDocumentWindow::ezQtAnimationClipAssetDocumentWindow(ezAni
 
   FinishWindowCreation();
 
-  QueryObjectBBox(0);
-
   GetAnimationClipDocument()->m_CommonAssetUiChangeEvent.AddEventHandler(ezMakeDelegate(&ezQtAnimationClipAssetDocumentWindow::CommonAssetUiEventHandler, this));
   GetDocument()->GetCommandHistory()->m_Events.AddEventHandler(ezMakeDelegate(&ezQtAnimationClipAssetDocumentWindow::CommandHistoryEventHandler, this));
 }
@@ -162,10 +160,10 @@ void ezQtAnimationClipAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtAnimationClipAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtAnimationClipAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /*= 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -226,11 +224,9 @@ void ezQtAnimationClipAssetDocumentWindow::ProcessMessageEventHandler(const ezEd
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h
@@ -45,7 +45,7 @@ protected Q_SLOTS:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
   void UpdateEventTrackEditor();
 
   ezClock m_Clock;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetWindow.cpp
@@ -46,7 +46,7 @@ ezQtDecalAssetDocumentWindow::ezQtDecalAssetDocumentWindow(ezDecalAssetDocument*
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0), ezVec3(0.0f), ezVec3(2, 0, 0));
+    m_pViewWidget->ConfigureFixed(ezVec3(0), ezVec3(0.0f), ezVec3(2, 0, 0));
     AddViewWidget(m_pViewWidget);
 
     ezQtViewWidgetContainer* pContainer = new ezQtViewWidgetContainer(nullptr, m_pViewWidget, "DecalAssetViewToolBar");

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -111,7 +111,8 @@ ezQtMaterialAssetDocumentWindow::ezQtMaterialAssetDocumentWindow(ezMaterialAsset
     m_ViewConfig.ApplyPerspectiveSetting(90, 0.01f, 100.0f);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0), ezVec3(0.0f), ezVec3(+0.23f, -0.04f, 0.02f));
+    m_pViewWidget->ConfigureFixed(ezVec3(0), ezVec3(0.0f), ezVec3(+0.23f, -0.04f, 0.02f));
+
     AddViewWidget(m_pViewWidget);
     ezQtViewWidgetContainer* pContainer = new ezQtViewWidgetContainer(nullptr, m_pViewWidget, "MaterialAssetViewToolBar");
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetWindow.cpp
@@ -45,7 +45,7 @@ ezQtMeshAssetDocumentWindow::ezQtMeshAssetDocumentWindow(ezMeshAssetDocument* pD
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0, 0, 1), ezVec3(5.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "MeshAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -67,8 +67,6 @@ ezQtMeshAssetDocumentWindow::ezQtMeshAssetDocumentWindow(ezMeshAssetDocument* pD
   }
 
   FinishWindowCreation();
-
-  QueryObjectBBox(0);
 
   UpdatePreview();
 
@@ -103,10 +101,10 @@ void ezQtMeshAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /*= 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -116,7 +114,7 @@ void ezQtMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
 
 void ezQtMeshAssetDocumentWindow::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
 {
-  //if (e.m_sProperty == "Resource") // any material change
+  // if (e.m_sProperty == "Resource") // any material change
   {
     UpdatePreview();
   }
@@ -174,11 +172,9 @@ void ezQtMeshAssetDocumentWindow::ProcessMessageEventHandler(const ezEditorEngin
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetWindow.moc.h
@@ -32,7 +32,7 @@ protected Q_SLOTS:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
   void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);
   bool UpdatePreview();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.cpp
@@ -45,7 +45,7 @@ ezQtSkeletonAssetDocumentWindow::ezQtSkeletonAssetDocumentWindow(ezSkeletonAsset
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig, true);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0, 0, 1), ezVec3(5.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "SkeletonAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -81,8 +81,6 @@ ezQtSkeletonAssetDocumentWindow::ezQtSkeletonAssetDocumentWindow(ezSkeletonAsset
   GetDocument()->GetCommandHistory()->m_Events.AddEventHandler(ezMakeDelegate(&ezQtSkeletonAssetDocumentWindow::CommandEventHandler, this));
 
   FinishWindowCreation();
-
-  QueryObjectBBox(0);
 }
 
 ezQtSkeletonAssetDocumentWindow::~ezQtSkeletonAssetDocumentWindow()
@@ -151,10 +149,10 @@ void ezQtSkeletonAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtSkeletonAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtSkeletonAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /*= 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -289,11 +287,9 @@ void ezQtSkeletonAssetDocumentWindow::ProcessMessageEventHandler(const ezEditorE
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.moc.h
@@ -26,7 +26,7 @@ protected:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
   void SelectionEventHandler(const ezSelectionManagerEvent& e);
   void SkeletonAssetEventHandler(const ezSkeletonAssetEvent& e);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetWindow.cpp
@@ -125,7 +125,7 @@ ezQtTextureAssetDocumentWindow::ezQtTextureAssetDocumentWindow(ezTextureAssetDoc
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0), ezVec3(1.0f), ezVec3(-1, 0, 0));
+    m_pViewWidget->ConfigureFixed(ezVec3(0), ezVec3(0.0f), ezVec3(-1, 0, 0));
     AddViewWidget(m_pViewWidget);
     ezQtViewWidgetContainer* pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, nullptr);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetWindow.cpp
@@ -126,7 +126,7 @@ ezQtTextureCubeAssetDocumentWindow::ezQtTextureCubeAssetDocumentWindow(ezTexture
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0), ezVec3(1.0f), ezVec3(-1, 0, 0));
+    m_pViewWidget->ConfigureFixed(ezVec3(0), ezVec3(0.0f), ezVec3(-1, 0, 0));
     AddViewWidget(m_pViewWidget);
     ezQtViewWidgetContainer* pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, nullptr);
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetWindow.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetWindow.cpp
@@ -42,7 +42,7 @@ ezQtJoltCollisionMeshAssetDocumentWindow::ezQtJoltCollisionMeshAssetDocumentWind
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0), ezVec3(5.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "MeshAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -66,8 +66,6 @@ ezQtJoltCollisionMeshAssetDocumentWindow::ezQtJoltCollisionMeshAssetDocumentWind
   m_pAssetDoc = pDocument;
 
   FinishWindowCreation();
-
-  QueryObjectBBox(0);
 }
 
 
@@ -84,10 +82,10 @@ void ezQtJoltCollisionMeshAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtJoltCollisionMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtJoltCollisionMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /*= 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -110,11 +108,9 @@ void ezQtJoltCollisionMeshAssetDocumentWindow::ProcessMessageEventHandler(const 
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetWindow.moc.h
@@ -22,7 +22,7 @@ protected:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
 
   ezEngineViewConfig m_ViewConfig;
   ezQtOrbitCamViewWidget* m_pViewWidget;

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetWindow.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetWindow.cpp
@@ -42,7 +42,7 @@ ezQtKrautTreeAssetDocumentWindow::ezQtKrautTreeAssetDocumentWindow(ezAssetDocume
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0, 0, 2), ezVec3(10.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "MeshAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -67,8 +67,6 @@ ezQtKrautTreeAssetDocumentWindow::ezQtKrautTreeAssetDocumentWindow(ezAssetDocume
 
   FinishWindowCreation();
 
-  QueryObjectBBox(0);
-
   GetDocument()->GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&ezQtKrautTreeAssetDocumentWindow::PropertyEventHandler, this));
 }
 
@@ -90,10 +88,10 @@ void ezQtKrautTreeAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtKrautTreeAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtKrautTreeAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /*= 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -116,11 +114,9 @@ void ezQtKrautTreeAssetDocumentWindow::ProcessMessageEventHandler(const ezEditor
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetWindow.moc.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetWindow.moc.h
@@ -24,7 +24,7 @@ protected:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
 
   ezEngineViewConfig m_ViewConfig;
   ezQtOrbitCamViewWidget* m_pViewWidget;

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
@@ -227,7 +227,7 @@ ezQtParticleEffectAssetDocumentWindow::ezQtParticleEffectAssetDocumentWindow(ezA
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0), ezVec3(5.0f), ezVec3(-2, 0, 0.5f));
+    m_pViewWidget->ConfigureRelative(ezVec3(0), ezVec3(5.0f), ezVec3(-2, 0, 0.5f), 1.0f);
     AddViewWidget(m_pViewWidget);
     ezQtViewWidgetContainer* pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "ParticleEffectAssetViewToolBar");
     setCentralWidget(pContainer);

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetWindow.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetWindow.cpp
@@ -42,7 +42,7 @@ ezQtCollisionMeshAssetDocumentWindow::ezQtCollisionMeshAssetDocumentWindow(ezAss
     m_ViewConfig.ApplyPerspectiveSetting(90);
 
     m_pViewWidget = new ezQtOrbitCamViewWidget(this, &m_ViewConfig);
-    m_pViewWidget->ConfigureOrbitCameraVolume(ezVec3(0, 0, 1), ezVec3(10.0f), ezVec3(-5, 1, 2));
+    m_pViewWidget->ConfigureRelative(ezVec3(0), ezVec3(5.0f), ezVec3(5, -2, 3), 2.0f);
     AddViewWidget(m_pViewWidget);
     pContainer = new ezQtViewWidgetContainer(this, m_pViewWidget, "MeshAssetViewToolBar");
     setCentralWidget(pContainer);
@@ -66,8 +66,6 @@ ezQtCollisionMeshAssetDocumentWindow::ezQtCollisionMeshAssetDocumentWindow(ezAss
   m_pAssetDoc = pDocument;
 
   FinishWindowCreation();
-
-  QueryObjectBBox(0);
 }
 
 
@@ -84,10 +82,10 @@ void ezQtCollisionMeshAssetDocumentWindow::SendRedrawMsg()
     pView->SyncToEngine();
   }
 
-  QueryObjectBBox(-1);
+  QueryObjectBBox();
 }
 
-void ezQtCollisionMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose)
+void ezQtCollisionMeshAssetDocumentWindow::QueryObjectBBox(ezInt32 iPurpose /*= 0*/)
 {
   ezQuerySelectionBBoxMsgToEngine msg;
   msg.m_uiViewID = 0xFFFFFFFF;
@@ -110,11 +108,9 @@ void ezQtCollisionMeshAssetDocumentWindow::ProcessMessageEventHandler(const ezEd
 
     if (pMessage->m_vCenter.IsValid() && pMessage->m_vHalfExtents.IsValid())
     {
-      const ezVec3 vHalfExtents = pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f));
-
-      m_pViewWidget->GetOrbitCamera()->SetOrbitVolume(pMessage->m_vCenter, vHalfExtents * 2.0f, pMessage->m_vCenter + ezVec3(5, -2, 3) * vHalfExtents.GetLength() * 0.3f, pMessage->m_iPurpose == 0);
+      m_pViewWidget->SetOrbitVolume(pMessage->m_vCenter, pMessage->m_vHalfExtents.CompMax(ezVec3(0.1f)));
     }
-    else if (pMessage->m_iPurpose == 0)
+    else
     {
       // try again
       QueryObjectBBox(pMessage->m_iPurpose);

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/CollisionMeshAsset/CollisionMeshAssetWindow.moc.h
@@ -22,7 +22,7 @@ protected:
 
 private:
   void SendRedrawMsg();
-  void QueryObjectBBox(ezInt32 iPurpose);
+  void QueryObjectBBox(ezInt32 iPurpose = 0);
 
   ezEngineViewConfig m_ViewConfig;
   ezQtOrbitCamViewWidget* m_pViewWidget;

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder_inl.h
@@ -227,15 +227,15 @@ EZ_ALWAYS_INLINE void ezStringBuilder::Remove(const char* szRemoveFromPos, const
 }
 
 template <typename Container>
-bool ezUnicodeUtils::RepairNonUtf8Text(const char* pStartData, const char* pEndData, Container& out_Result)
+bool ezUnicodeUtils::RepairNonUtf8Text(const char* pStartData, const char* pEndData, Container& out_result)
 {
   if (ezUnicodeUtils::IsValidUtf8(pStartData, pEndData))
   {
-    out_Result = ezStringView(pStartData, pEndData);
+    out_result = ezStringView(pStartData, pEndData);
     return false;
   }
 
-  out_Result.Clear();
+  out_result.Clear();
 
   ezHybridArray<char, 1024> fixedText;
   ezUnicodeUtils::UtfInserter<char, decltype(fixedText)> inserter(&fixedText);
@@ -248,7 +248,7 @@ bool ezUnicodeUtils::RepairNonUtf8Text(const char* pStartData, const char* pEndD
 
   EZ_ASSERT_DEV(ezUnicodeUtils::IsValidUtf8(fixedText.GetData(), fixedText.GetData() + fixedText.GetCount()), "Repaired text is still not a valid Utf8 string.");
 
-  out_Result = ezStringView(fixedText.GetData(), fixedText.GetCount());
+  out_result = ezStringView(fixedText.GetData(), fixedText.GetCount());
   return true;
 }
 

--- a/Code/Engine/Foundation/Strings/UnicodeUtils.h
+++ b/Code/Engine/Foundation/Strings/UnicodeUtils.h
@@ -126,7 +126,7 @@ public:
   ///
   /// \note That the for #include order reasons, the implementation is in StringBuilder_inl.h, so you need to have StringBuilder.h included to use it.
   template <typename Container>
-  static bool RepairNonUtf8Text(const char* pStartData, const char* pEndData, Container& out_Result);
+  static bool RepairNonUtf8Text(const char* pStartData, const char* pEndData, Container& out_result);
 };
 
 #include <Foundation/Strings/Implementation/UnicodeUtils_inl.h>

--- a/Data/Samples/Testing Chambers/Vegetation/Quaternius/Tree4.ezMeshAsset
+++ b/Data/Samples/Testing Chambers/Vegetation/Quaternius/Tree4.ezMeshAsset
@@ -14,7 +14,7 @@ o
 			s{"Vegetation/Quaternius/Tree4.fbx"}
 		}
 		Uuid %DocumentID{u4{15161069987595283885,5114199460025476296}}
-		u4 %Hash{10420116242101834105}
+		u4 %Hash{11425879192967618597}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -71,7 +71,7 @@ o
 		f %Radius2{0x0000003F}
 		b %RecalculateNormals{0}
 		b %RecalculateTangents{1}
-		s %RightDir{"ezBasisAxis::PositiveX"}
+		s %RightDir{"ezBasisAxis::PositiveZ"}
 		s %TexCoordPrecision{"ezMeshTexCoordPrecision::_16Bit"}
 		f %UniformScaling{0x0000803F}
 		s %UpDir{"ezBasisAxis::PositiveY"}


### PR DESCRIPTION
The orbit camera now also allows free rotation and movement using right-click + WSAD and panning via left+right click.
Left click+drag and mouse wheel will focus back on the object center.
This also fixed #919, the camera doesn't reset to default position all the time anymore.