### PR TITLE
Prefabs may now attach components to their parent instance node

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -87,8 +87,13 @@ void AssetCuratorEventHandler(const ezAssetCuratorEvent& e)
 void ezCameraComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 void ezSkyLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
+void ezSceneDocument_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
+
+
 void OnLoadPlugin()
 {
+  ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezSceneDocument_PropertyMetaStateEventHandler);
+
   ezDocumentManager::s_Events.AddEventHandler(ezMakeDelegate(OnDocumentManagerEvent));
 
   ezQtEditorApp::GetSingleton()->m_Events.AddEventHandler(ToolsProjectEventHandler);
@@ -182,6 +187,8 @@ void OnLoadPlugin()
 
 void OnUnloadPlugin()
 {
+  ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezSceneDocument_PropertyMetaStateEventHandler);
+
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(OnDocumentManagerEvent));
   ezQtEditorApp::GetSingleton()->m_Events.RemoveEventHandler(ToolsProjectEventHandler);
   ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(AssetCuratorEventHandler);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -81,11 +81,9 @@ ezSceneDocument::ezSceneDocument(const char* szDocumentPath, DocumentType docume
 void ezSceneDocument::InitializeAfterLoading(bool bFirstTimeCreation)
 {
   // (Local mirror only mirrors settings)
-  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
-    { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
+  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
   // (Remote IPC mirror only sends scene)
-  m_Mirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
-    { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
+  m_Mirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
 
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
   EnsureSettingsObjectExist();
@@ -506,8 +504,7 @@ void ezSceneDocument::ShowOrHideSelectedObjects(ShowOrHide action)
     if (!pItem->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
       continue;
 
-    ApplyRecursive(pItem, [this, bHide](const ezDocumentObject* pObj)
-      {
+    ApplyRecursive(pItem, [this, bHide](const ezDocumentObject* pObj) {
       // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
       // return;
 
@@ -584,8 +581,7 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(const char* szFile, 
 
   ezVariantArray varChildren;
 
-  auto centerNodes = [tReference, &varChildren](ezAbstractObjectNode* pGraphNode)
-  {
+  auto centerNodes = [tReference, &varChildren](ezAbstractObjectNode* pGraphNode) {
     if (auto pPosition = pGraphNode->FindProperty("LocalPosition"))
     {
       ezVec3 pos = pPosition->m_Value.ConvertTo<ezVec3>();
@@ -605,8 +601,7 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(const char* szFile, 
     varChildren.PushBack(pGraphNode->GetGuid());
   };
 
-  auto adjustResult = [tReference, this](ezDocumentObject* pObject)
-  {
+  auto adjustResult = [tReference, this](ezDocumentObject* pObject) {
     const ezTransform tOld = QueryLocalTransform(pObject);
 
     ezSetObjectPropertyCommand cmd;
@@ -621,8 +616,7 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(const char* szFile, 
     GetCommandHistory()->AddCommand(cmd);
   };
 
-  auto finalizeGraph = [this, &varChildren](ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)
-  {
+  auto finalizeGraph = [this, &varChildren](ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes) {
     if (graphRootNodes.GetCount() == 1)
     {
       graphRootNodes[0]->ChangeProperty("Name", "<Prefab-Root>");
@@ -749,8 +743,7 @@ void ezSceneDocument::ShowOrHideAllObjects(ShowOrHide action)
 {
   const bool bHide = action == ShowOrHide::Hide;
 
-  ApplyRecursive(GetObjectManager()->GetRootObject(), [this, bHide](const ezDocumentObject* pObj)
-    {
+  ApplyRecursive(GetObjectManager()->GetRootObject(), [this, bHide](const ezDocumentObject* pObj) {
     // if (!pObj->GetTypeAccessor().GetType()->IsDerivedFrom<ezGameObject>())
     // return;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -108,9 +108,7 @@ public:
   /// \brief Converts all objects in the selection that are editor prefabs to their respective engine prefab representation
   virtual void ConvertToEnginePrefab(const ezDeque<const ezDocumentObject*>& selection);
 
-  virtual ezStatus CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType,
-    ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = ezDelegate<void(ezAbstractObjectNode*)>(),
-    ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = ezDelegate<void(ezDocumentObject*)>()) override;
+  virtual ezStatus CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {}) override;
 
   GameMode::Enum GetGameMode() const { return m_GameMode; }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -61,8 +61,7 @@ ezSceneDocumentManager::ezSceneDocumentManager()
   }
 }
 
-void ezSceneDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezSceneDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
   if (ezStringUtils::IsEqual(szDocumentTypeName, "Scene"))
   {

--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
@@ -64,14 +64,15 @@ void ezEditorShapeIconsExtractor::Extract(
   }
 }
 
-void ezEditorShapeIconsExtractor::ExtractShapeIcon(
-  const ezGameObject* pObject, const ezView& view, ezExtractedRenderData& extractedRenderData, ezRenderData::Category category)
+void ezEditorShapeIconsExtractor::ExtractShapeIcon(const ezGameObject* pObject, const ezView& view, ezExtractedRenderData& extractedRenderData, ezRenderData::Category category)
 {
   static const ezTag& tagHidden = ezTagRegistry::GetGlobalRegistry().RegisterTag("EditorHidden");
   static const ezTag& tagEditor = ezTagRegistry::GetGlobalRegistry().RegisterTag("Editor");
-  static const ezTag& tagPrefab = ezTagRegistry::GetGlobalRegistry().RegisterTag("EditorPrefabInstance");
 
-  if (pObject->GetTags().IsSet(tagEditor) || pObject->GetTags().IsSet(tagHidden) || pObject->GetTags().IsSet(tagPrefab))
+  if (pObject->GetTags().IsSet(tagEditor) || pObject->GetTags().IsSet(tagHidden))
+    return;
+
+  if (pObject->WasCreatedByPrefab())
     return;
 
   if (pObject->GetComponents().IsEmpty())

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -842,11 +842,9 @@ ezStatus ezSceneContext::ExportDocument(const ezExportDocumentMsgToEngine* pMsg)
 
     const ezTag& tagEditor = ezTagRegistry::GetGlobalRegistry().RegisterTag("Editor");
     const ezTag& tagNoExport = ezTagRegistry::GetGlobalRegistry().RegisterTag("Exclude From Export");
-    const ezTag& tagEditorPrefabInstance = ezTagRegistry::GetGlobalRegistry().RegisterTag("EditorPrefabInstance");
 
     ezTagSet tags;
     tags.Set(tagEditor);
-    tags.Set(tagEditorPrefabInstance);
     tags.Set(tagNoExport);
 
     ezWorldWriter ww;

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -381,14 +381,10 @@ void ezPrefabReferenceComponent::OnSimulationStarted()
 
 const ezRangeView<const char*, ezUInt32> ezPrefabReferenceComponent::GetParameters() const
 {
-  return ezRangeView<const char*, ezUInt32>([]() -> ezUInt32
-    { return 0; },
-    [this]() -> ezUInt32
-    { return m_Parameters.GetCount(); },
-    [](ezUInt32& ref_uiIt)
-    { ++ref_uiIt; },
-    [this](const ezUInt32& uiIt) -> const char*
-    { return m_Parameters.GetKey(uiIt).GetString().GetData(); });
+  return ezRangeView<const char*, ezUInt32>([]() -> ezUInt32 { return 0; },
+    [this]() -> ezUInt32 { return m_Parameters.GetCount(); },
+    [](ezUInt32& ref_uiIt) { ++ref_uiIt; },
+    [this](const ezUInt32& uiIt) -> const char* { return m_Parameters.GetKey(uiIt).GetString().GetData(); });
 }
 
 void ezPrefabReferenceComponent::SetParameter(const char* szKey, const ezVariant& value)

--- a/Code/Engine/Core/World/Component.h
+++ b/Code/Engine/Core/World/Component.h
@@ -129,6 +129,12 @@ public:
   /// \brief Retrieves a custom flag. Index must be between 0 and 7.
   bool GetUserFlag(ezUInt8 uiFlagIndex) const;
 
+  /// \brief Adds ezObjectFlags::CreatedByPrefab to the component. See the flag for details.
+  void SetCreatedByPrefab() { m_ComponentFlags.Add(ezObjectFlags::CreatedByPrefab); }
+
+  /// \brief Checks whether the ezObjectFlags::CreatedByPrefab flag is set on this component.
+  bool WasCreatedByPrefab() const { return m_ComponentFlags.IsSet(ezObjectFlags::CreatedByPrefab); }
+
 protected:
   friend class ezWorld;
   friend class ezGameObject;

--- a/Code/Engine/Core/World/Declarations.h
+++ b/Code/Engine/Core/World/Declarations.h
@@ -188,6 +188,8 @@ struct ezObjectFlags
     StaticTransformChangesNotifications = EZ_BIT(11), ///< The object should send a notification message if it is static and its transform changes.
     ParentChangesNotifications = EZ_BIT(12),          ///< The object should send a notification message when the parent is changes.
 
+    CreatedByPrefab = EZ_BIT(13), ///< Such flagged objects and components are ignored during scene export (see ezWorldWriter) and will be removed when a prefab needs to be re-instantiated.
+
     UserFlag0 = EZ_BIT(24),
     UserFlag1 = EZ_BIT(25),
     UserFlag2 = EZ_BIT(26),
@@ -216,7 +218,9 @@ struct ezObjectFlags
     StorageType StaticTransformChangesNotifications : 1; //< 11
     StorageType ParentChangesNotifications : 1;          //< 12
 
-    StorageType Padding : 11; // 13 - 23
+    StorageType CreatedByPrefab : 1; //< 13
+
+    StorageType Padding : 10; // 14 - 23
 
     StorageType UserFlag0 : 1; //< 24
     StorageType UserFlag1 : 1; //< 25

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -133,6 +133,12 @@ public:
   /// \sa ezGameObject::SetActiveFlag(), ezComponent::IsActive()
   bool IsActive() const;
 
+  /// \brief Adds ezObjectFlags::CreatedByPrefab to the object. See the flag for details.
+  void SetCreatedByPrefab() { m_Flags.Add(ezObjectFlags::CreatedByPrefab); }
+
+  /// \brief Checks whether the ezObjectFlags::CreatedByPrefab flag is set on this object.
+  bool WasCreatedByPrefab() const { return m_Flags.IsSet(ezObjectFlags::CreatedByPrefab); }
+
   /// \brief Sets the name to identify this object. Does not have to be a unique name.
   void SetName(ezStringView sName);
   void SetName(const ezHashedString& sName);

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -243,7 +243,8 @@ void ezWorldReader::ReadComponentTypeInfo(ezUInt32 uiComponentTypeIdx)
 
 void ezWorldReader::ReadComponentDataToMemStream(bool warningOnUnknownSkip)
 {
-  auto WriteToMemStream = [&](ezMemoryStreamWriter& ref_writer, bool bReadNumComponents) {
+  auto WriteToMemStream = [&](ezMemoryStreamWriter& ref_writer, bool bReadNumComponents)
+  {
     ezUInt8 Temp[4096];
     for (auto& compTypeInfo : m_ComponentTypes)
     {
@@ -376,6 +377,26 @@ ezWorldReader::InstantiationContext::StepResult ezWorldReader::InstantiationCont
 
   if (m_Phase == Phase::CreateRootObjects)
   {
+    if (!m_Options.m_ReplaceNamedRootWithParent.IsEmpty())
+    {
+      EZ_ASSERT_DEBUG(!m_Options.m_hParent.IsInvalidated(), "Parent must be provided when m_ReplaceNamedRootWithParent is specified.");
+
+      if (m_WorldReader.m_RootObjectsToCreate.GetCount() == 1 && m_WorldReader.m_RootObjectsToCreate[0].m_Desc.m_sName == m_Options.m_ReplaceNamedRootWithParent)
+      {
+        m_uiCurrentIndex = 1;
+        m_WorldReader.m_IndexToGameObjectHandle.PushBack(m_Options.m_hParent);
+
+        if (m_WorldReader.m_RootObjectsToCreate[0].m_Desc.m_bDynamic)
+        {
+          ezGameObject* pParent = nullptr;
+          if (m_WorldReader.m_pWorld->TryGetObject(m_Options.m_hParent, pParent))
+          {
+            pParent->MakeDynamic();
+          }
+        }
+      }
+    }
+
     if (m_bUseTransform)
     {
       if (!CreateGameObjects<true>(m_WorldReader.m_RootObjectsToCreate, m_Options.m_hParent, m_Options.m_pCreatedRootObjectsOut, endTime))

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -243,8 +243,7 @@ void ezWorldReader::ReadComponentTypeInfo(ezUInt32 uiComponentTypeIdx)
 
 void ezWorldReader::ReadComponentDataToMemStream(bool warningOnUnknownSkip)
 {
-  auto WriteToMemStream = [&](ezMemoryStreamWriter& ref_writer, bool bReadNumComponents)
-  {
+  auto WriteToMemStream = [&](ezMemoryStreamWriter& ref_writer, bool bReadNumComponents) {
     ezUInt8 Temp[4096];
     for (auto& compTypeInfo : m_ComponentTypes)
     {

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldWriter.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldWriter.cpp
@@ -250,6 +250,8 @@ ezVisitorExecution::Enum ezWorldWriter::ObjectTraverser(ezGameObject* pObject)
 {
   if (m_pExclude && pObject->GetTags().IsAnySet(*m_pExclude))
     return ezVisitorExecution::Skip;
+  if (pObject->WasCreatedByPrefab())
+    return ezVisitorExecution::Skip;
 
   if (pObject->GetParent())
     m_AllChildObjects.PushBack(pObject);
@@ -260,6 +262,9 @@ ezVisitorExecution::Enum ezWorldWriter::ObjectTraverser(ezGameObject* pObject)
 
   for (const ezComponent* pComp : components)
   {
+    if (pComp->WasCreatedByPrefab())
+      continue;
+
     m_AllComponents[pComp->GetDynamicRTTI()].m_Components.PushBack(pComp);
   }
 

--- a/Code/Engine/Core/WorldSerializer/WorldReader.h
+++ b/Code/Engine/Core/WorldSerializer/WorldReader.h
@@ -20,6 +20,9 @@ struct ezPrefabInstantiationOptions
 
   bool m_bForceDynamic = false;
 
+  /// \brief If the prefab has a single root node with this non-empty name, rather than creating a new object, instead the m_hParent object is used.
+  ezTempHashedString m_ReplaceNamedRootWithParent;
+
   enum class RandomSeedMode
   {
     DeterministicFromParent,

--- a/Code/Engine/Foundation/Types/Implementation/Uuid_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/Uuid_inl.h
@@ -11,6 +11,13 @@ void ezUuid::SetInvalid()
   m_uiLow = 0;
 }
 
+ezUuid ezUuid::CreateUuid()
+{
+  ezUuid guid;
+  guid.CreateNewUuid();
+  return guid;
+}
+
 bool ezUuid::operator==(const ezUuid& other) const
 {
   return m_uiHigh == other.m_uiHigh && m_uiLow == other.m_uiLow;

--- a/Code/Engine/Foundation/Types/Uuid.h
+++ b/Code/Engine/Foundation/Types/Uuid.h
@@ -40,6 +40,9 @@ public:
   /// \brief Creates a new Uuid and stores is it in this object.
   void CreateNewUuid();
 
+  /// \brief Returns a new Uuid.
+  EZ_ALWAYS_INLINE static ezUuid CreateUuid();
+
   /// \brief Returns the internal 128 Bit of data
   void GetValues(ezUInt64& ref_uiLow, ezUInt64& ref_uiHigh) const
   {

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -220,14 +220,11 @@ public:
   /// \brief Removes the link between a prefab instance and its template, turning the instance into a regular object.
   virtual void UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection);
 
-  virtual ezStatus CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType,
-    ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = ezDelegate<void(ezAbstractObjectNode*)>(),
-    ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = ezDelegate<void(ezDocumentObject*)>());
-  virtual ezStatus CreatePrefabDocument(const char* szFile, ezArrayPtr<const ezDocumentObject*> rootObjects, const ezUuid& invPrefabSeed,
-    ezUuid& out_newDocumentGuid, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, bool bKeepOpen = false);
+  virtual ezStatus CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
+  virtual ezStatus CreatePrefabDocument(const char* szFile, ezArrayPtr<const ezDocumentObject*> rootObjects, const ezUuid& invPrefabSeed, ezUuid& out_newDocumentGuid, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, bool bKeepOpen = false, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
+
   // Returns new guid of replaced object.
-  virtual ezUuid ReplaceByPrefab(
-    const ezDocumentObject* pRootObject, const char* szPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab);
+  virtual ezUuid ReplaceByPrefab(const ezDocumentObject* pRootObject, const char* szPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab);
   // Returns new guid of reverted object.
   virtual ezUuid RevertPrefab(const ezDocumentObject* pObject);
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Declarations.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Declarations.h
@@ -12,9 +12,10 @@ struct ezDocumentFlags
   enum Enum
   {
     None = 0,
-    RequestWindow = EZ_BIT(0),
-    AddToRecentFilesList = EZ_BIT(1),
-    AsyncSave = EZ_BIT(2),
+    RequestWindow = EZ_BIT(0),        ///< Open the document visibly (not just internally)
+    AddToRecentFilesList = EZ_BIT(1), ///< Add the document path to the recently used list for users
+    AsyncSave = EZ_BIT(2),            ///<
+    EmptyDocument = EZ_BIT(3),        ///< Don't populate a new document with default state (templates etc)
     Default = None,
   };
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -222,7 +222,7 @@ ezStatus ezDocumentManager::CreateOrOpenDocument(bool bCreate, const char* szDoc
     {
       // See if there is a default asset document registered for the type, if so clone
       // it and use that as the new document instead of creating one from scratch.
-      if (bCreate)
+      if (bCreate && !flags.IsSet(ezDocumentFlags::EmptyDocument))
       {
         ezStringBuilder sTemplateDoc = "Editor/DocumentTemplates/Default";
         sTemplateDoc.ChangeFileExtension(sPath.GetFileExtension());

--- a/Code/Tools/Libs/ToolsFoundation/Serialization/Implementation/DocumentObjectConverter.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Serialization/Implementation/DocumentObjectConverter.cpp
@@ -137,13 +137,10 @@ void ezDocumentObjectConverterWriter::AddProperties(ezAbstractObjectNode* pNode,
 
 ezAbstractObjectNode* ezDocumentObjectConverterWriter::AddSubObjectToGraph(const ezDocumentObject* pObject, const char* szNodeName)
 {
-  ezAbstractObjectNode* pNode =
-    m_pGraph->AddNode(pObject->GetGuid(), pObject->GetType()->GetTypeName(), pObject->GetType()->GetTypeVersion(), szNodeName);
+  ezAbstractObjectNode* pNode = m_pGraph->AddNode(pObject->GetGuid(), pObject->GetType()->GetTypeName(), pObject->GetType()->GetTypeVersion(), szNodeName);
   AddProperties(pNode, pObject);
   return pNode;
 }
-
-
 
 ezDocumentObjectConverterReader::ezDocumentObjectConverterReader(const ezAbstractObjectGraph* pGraph, ezDocumentObjectManager* pManager, Mode mode)
 {

--- a/Data/Base/Editor/DocumentTemplates/Default.ezPrefab
+++ b/Data/Base/Editor/DocumentTemplates/Default.ezPrefab
@@ -1,0 +1,259 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{2920325690362896519,5128321439156194886}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Prefab"}
+		VarArray %Dependencies{}
+		Uuid %DocumentID{u4{2920325690362896519,5128321439156194886}}
+		u4 %Hash{15876521683149008668}
+		VarArray %MetaInfo
+		{
+			Uuid{u4{11350417277513919656,15935983041589108641}}
+		}
+		VarArray %Outputs{}
+		VarArray %PackageDeps{}
+		VarArray %References{}
+	}
+}
+o
+{
+	Uuid %id{u4{11350417277513919656,15935983041589108641}}
+	s %t{"ezExposedParameters"}
+	u3 %v{3}
+	p
+	{
+		VarArray %Parameters{}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{4101444527326631661,640178856013021176}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"<Prefab-Root>"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{11862571400376107657,5154596112371680847}}
+	s %t{"ezPrefabDocumentSettings"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ExposedProperties{}
+	}
+}
+o
+{
+	Uuid %id{u4{8221144114749658163,6937315010754014048}}
+	s %t{"ezSceneDocumentRoot"}
+	u3 %v{2}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{4101444527326631661,640178856013021176}}
+		}
+		Uuid %Settings{u4{11862571400376107657,5154596112371680847}}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{6914292285925798136,1108246313736053318}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11638255232360359673,3108610646416571142}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezExposedSceneProperty"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14332645745114734426,3197497487504472660}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezSceneDocumentSettingsBase"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezPrefabDocumentSettings"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13649880205026559927,7297274558339895637}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezGameObject"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3251891958765718680,9159887340540620231}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezDocumentRoot"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentRoot"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{14543630447052729839,9459039542380974471}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezObjectMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14700230518358869173,11472901527618371423}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginScene"}
+		VarArray %Properties{}
+		s %TypeName{"ezSceneDocumentSettingsBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+}

--- a/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
@@ -194,3 +194,5 @@ ezUpdateRate::Max2fps;Max 2 FPS
 ezUpdateRate::Max1fps;Max 1 FPS
 
 ezRootMotionMode::SendMoveCharacterMsg;Send MoveCharacterMsg
+
+Prefab.NameLabel;Proxy For;When this is set to '<Prefab-Root>' the node represents the game object in a scene on which the prefab gets instantiated. In this case you cannot edit its name, transform, etc, but you can attach additional components.


### PR DESCRIPTION
Fixes #844:

In a prefab document, when there is only one top-most game object, you can name it "<Prefab-Root>" to turn it into a proxy object for the game object on which the prefab gets instantiated. This makes it possible to attach components directly to the game object in a scene on which the Prefab Reference Component is attached. This is particularly useful for physics objects, since you can then have the physics components on the right node, so that prefabs can, for example, be joined together.