### PR TITLE
Fixed #845: Improved Jolt rope and Fake rope

### DIFF
--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
@@ -110,3 +110,29 @@ static void ToolsProjectEventHandler(const ezToolsProjectEvent& e)
     UpdateCollisionLayerDynamicEnumValues();
   }
 }
+
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+#include <Foundation/Serialization/AbstractObjectGraph.h>
+#include <Foundation/Serialization/GraphPatch.h>
+
+class ezJoltRopeComponentPatch_1_2 : public ezGraphPatch
+{
+public:
+  ezJoltRopeComponentPatch_1_2()
+    : ezGraphPatch("ezJoltRopeComponent", 3)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    pNode->RenameProperty("Anchor", "Anchor2");
+    pNode->RenameProperty("AttachToOrigin", "AttachToAnchor1");
+    pNode->RenameProperty("AttachToAnchor", "AttachToAnchor2");
+  }
+};
+
+ezJoltRopeComponentPatch_1_2 g_ezJoltRopeComponentPatch_1_2;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Patches/GameComponentsPluginPatches.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Patches/GameComponentsPluginPatches.cpp
@@ -1,0 +1,26 @@
+#include <EditorPluginScene/EditorPluginScenePCH.h>
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+#include <Foundation/Serialization/AbstractObjectGraph.h>
+#include <Foundation/Serialization/GraphPatch.h>
+
+class ezFakeRopeComponentPatch_2_3 : public ezGraphPatch
+{
+public:
+  ezFakeRopeComponentPatch_2_3()
+    : ezGraphPatch("ezFakeRopeComponent", 3)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    pNode->RenameProperty("Anchor", "Anchor2");
+    pNode->RenameProperty("AttachToOrigin", "AttachToAnchor1");
+    pNode->RenameProperty("AttachToAnchor", "AttachToAnchor2");
+  }
+};
+
+ezFakeRopeComponentPatch_2_3 g_ezFakeRopeComponentPatch_2_3;

--- a/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
@@ -63,25 +63,25 @@ void ezQuatTemplate<Type>::Normalize()
 }
 
 template <typename Type>
-ezResult ezQuatTemplate<Type>::GetRotationAxisAndAngle(ezVec3Template<Type>& out_vAxis, ezAngle& out_angle, Type fEpsilon) const
+void ezQuatTemplate<Type>::GetRotationAxisAndAngle(ezVec3Template<Type>& out_vAxis, ezAngle& out_angle, Type fEpsilon) const
 {
   EZ_NAN_ASSERT(this);
 
-  const ezAngle acos = ezMath::ACos(static_cast<float>(w));
-  const float d = ezMath::Sin(acos);
+  out_angle = 2 * ezMath::ACos(static_cast<float>(w));
 
-  if (d < fEpsilon)
+  const float s = ezMath::Sqrt(1 - w * w);
+  const float ds = 1.0f / s;
+
+  if (s < fEpsilon)
   {
     out_vAxis.Set(1, 0, 0);
   }
   else
   {
-    out_vAxis = (v / static_cast<Type>(d));
+    out_vAxis.x = v.x * ds;
+    out_vAxis.y = v.y * ds;
+    out_vAxis.z = v.z * ds;
   }
-
-  out_angle = acos * 2;
-
-  return EZ_SUCCESS;
 }
 
 template <typename Type>
@@ -157,10 +157,8 @@ bool ezQuatTemplate<Type>::IsEqualRotation(const ezQuatTemplate<Type>& qOther, T
   ezVec3Template<Type> vA1, vA2;
   ezAngle A1, A2;
 
-  if (GetRotationAxisAndAngle(vA1, A1) == EZ_FAILURE)
-    return false;
-  if (qOther.GetRotationAxisAndAngle(vA2, A2) == EZ_FAILURE)
-    return false;
+  GetRotationAxisAndAngle(vA1, A1);
+  qOther.GetRotationAxisAndAngle(vA2, A2);
 
   if ((A1.IsEqualSimple(A2, ezAngle::Degree(static_cast<float>(fEpsilon)))) && (vA1.IsEqual(vA2, fEpsilon)))
     return true;

--- a/Code/Engine/Foundation/Math/Quat.h
+++ b/Code/Engine/Foundation/Math/Quat.h
@@ -88,7 +88,7 @@ public:
   void Normalize(); // [tested]
 
   /// \brief Returns the rotation-axis and angle, that this quaternion rotates around.
-  ezResult GetRotationAxisAndAngle(ezVec3Template<Type>& out_vAxis, ezAngle& out_angle, Type fEpsilon = ezMath::DefaultEpsilon<Type>()) const; // [tested]
+  void GetRotationAxisAndAngle(ezVec3Template<Type>& out_vAxis, ezAngle& out_angle, Type fEpsilon = ezMath::DefaultEpsilon<Type>()) const; // [tested]
 
   /// \brief Returns the Quaternion as a matrix.
   const ezMat3Template<Type> GetAsMat3() const; // [tested]
@@ -109,7 +109,7 @@ public:
   /// representations for 'identity', so it's difficult to check for it).
   bool IsEqualRotation(const ezQuatTemplate& qOther, Type fEpsilon) const; // [tested]
 
-  /// \brief Inverts the rotation, so instead of rotating N degrees around its axis, the quaternion will rotate -N degrees around that axis.
+  /// \brief Inverts the rotation, so instead of rotating N degrees around an axis, the quaternion will rotate -N degrees around its axis.
   ///
   /// This modifies the quaternion in place. If you want to get the inverse as a copy, use the negation operator (-).
   void Invert();

--- a/Code/Engine/GameEngine/Physics/RopeSimulator.h
+++ b/Code/Engine/GameEngine/Physics/RopeSimulator.h
@@ -50,6 +50,8 @@ public:
   void SimulateStep(const ezSimdFloat fDiffSqr, ezUInt32 uiMaxIterations, ezSimdFloat fAllowedError);
   void SimulateTillEquilibrium(ezSimdFloat fAllowedMovement = 0.005f, ezUInt32 uiMaxIterations = 1000);
   bool HasEquilibrium(ezSimdFloat fAllowedMovement) const;
+  float GetTotalLength() const;
+  ezSimdVec4f GetPositionAtLength(float length) const;
 
 private:
   ezSimdFloat EnforceDistanceConstraint();

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/FakeRopeComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/FakeRopeComponent.h
@@ -42,16 +42,18 @@ public:
 
   ezUInt16 m_uiPieces = 16; // [ property ]
 
-  void SetAnchorReference(const char* szReference); // [ property ]
-  void SetAnchor(ezGameObjectHandle hActor);
+  void SetAnchor1Reference(const char* szReference); // [ property ]
+  void SetAnchor2Reference(const char* szReference); // [ property ]
+  void SetAnchor1(ezGameObjectHandle hActor);
+  void SetAnchor2(ezGameObjectHandle hActor);
 
   void SetSlack(float fVal);
   float GetSlack() const { return m_fSlack; }
 
-  void SetAttachToOrigin(bool bVal);
-  bool GetAttachToOrigin() const;
-  void SetAttachToAnchor(bool bVal);
-  bool GetAttachToAnchor() const;
+  void SetAttachToAnchor1(bool bVal);
+  void SetAttachToAnchor2(bool bVal);
+  bool GetAttachToAnchor1() const;
+  bool GetAttachToAnchor2() const;
 
   float m_fSlack = 0.0f;
   float m_fDamping = 0.5f;
@@ -62,7 +64,8 @@ private:
   void SendPreviewPose();
   void RuntimeUpdate();
 
-  ezGameObjectHandle m_hAnchor;
+  ezGameObjectHandle m_hAnchor1;
+  ezGameObjectHandle m_hAnchor2;
 
   ezUInt32 m_uiPreviewHash = 0;
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
@@ -225,8 +225,6 @@ void ezFakeRopeComponent::SendPreviewPose()
   if (!IsActiveAndInitialized() || IsActiveAndSimulating())
     return;
 
-  ezUInt32 uiHash = 0;
-
   ezGameObject* pAnchor1 = nullptr;
   ezGameObject* pAnchor2 = nullptr;
   if (!GetWorld()->TryGetObject(m_hAnchor1, pAnchor1))
@@ -236,6 +234,8 @@ void ezFakeRopeComponent::SendPreviewPose()
 
   if (pAnchor1 == pAnchor2)
     return;
+
+  ezUInt32 uiHash = 0;
 
   ezVec3 pos = GetOwner()->GetGlobalPosition();
   uiHash = ezHashingUtils::xxHash32(&pos, sizeof(ezVec3), uiHash);

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
@@ -8,13 +8,14 @@
 #include <RendererCore/AnimationSystem/Declarations.h>
 
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezFakeRopeComponent, 2, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezFakeRopeComponent, 3, ezComponentMode::Static)
   {
     EZ_BEGIN_PROPERTIES
     {
-      EZ_ACCESSOR_PROPERTY("Anchor", DummyGetter, SetAnchorReference)->AddAttributes(new ezGameObjectReferenceAttribute()),
-      EZ_ACCESSOR_PROPERTY("AttachToOrigin", GetAttachToOrigin, SetAttachToOrigin)->AddAttributes(new ezDefaultValueAttribute(true)),
-      EZ_ACCESSOR_PROPERTY("AttachToAnchor", GetAttachToAnchor, SetAttachToAnchor)->AddAttributes(new ezDefaultValueAttribute(true)),
+      EZ_ACCESSOR_PROPERTY("Anchor1", DummyGetter, SetAnchor1Reference)->AddAttributes(new ezGameObjectReferenceAttribute()),
+      EZ_ACCESSOR_PROPERTY("Anchor2", DummyGetter, SetAnchor2Reference)->AddAttributes(new ezGameObjectReferenceAttribute()),
+      EZ_ACCESSOR_PROPERTY("AttachToAnchor1", GetAttachToAnchor1, SetAttachToAnchor1)->AddAttributes(new ezDefaultValueAttribute(true)),
+      EZ_ACCESSOR_PROPERTY("AttachToAnchor2", GetAttachToAnchor2, SetAttachToAnchor2)->AddAttributes(new ezDefaultValueAttribute(true)),
       EZ_MEMBER_PROPERTY("Pieces", m_uiPieces)->AddAttributes(new ezDefaultValueAttribute(32), new ezClampValueAttribute(2, 200)),
       EZ_ACCESSOR_PROPERTY("Slack", GetSlack, SetSlack)->AddAttributes(new ezDefaultValueAttribute(0.2f)),
       EZ_MEMBER_PROPERTY("Damping", m_fDamping)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
@@ -44,7 +45,8 @@ void ezFakeRopeComponent::SerializeComponent(ezWorldWriter& inout_stream) const
   s << m_RopeSim.m_bFirstNodeIsFixed;
   s << m_RopeSim.m_bLastNodeIsFixed;
 
-  inout_stream.WriteGameObjectHandle(m_hAnchor);
+  inout_stream.WriteGameObjectHandle(m_hAnchor1);
+  inout_stream.WriteGameObjectHandle(m_hAnchor2);
 
   s << m_fWindInfluence;
 }
@@ -61,7 +63,12 @@ void ezFakeRopeComponent::DeserializeComponent(ezWorldReader& inout_stream)
   s >> m_RopeSim.m_bFirstNodeIsFixed;
   s >> m_RopeSim.m_bLastNodeIsFixed;
 
-  m_hAnchor = inout_stream.ReadGameObjectHandle();
+  if (uiVersion >= 3)
+  {
+    m_hAnchor1 = inout_stream.ReadGameObjectHandle();
+  }
+
+  m_hAnchor2 = inout_stream.ReadGameObjectHandle();
 
   if (uiVersion >= 2)
   {
@@ -97,10 +104,42 @@ ezResult ezFakeRopeComponent::ConfigureRopeSimulator()
   if (!IsActiveAndInitialized())
     return EZ_FAILURE;
 
-  ezSimdVec4f anchorB;
+  ezGameObjectHandle hAnchor1 = m_hAnchor1;
+  ezGameObjectHandle hAnchor2 = m_hAnchor2;
 
-  ezGameObject* pAnchor = nullptr;
-  if (!GetWorld()->TryGetObject(m_hAnchor, pAnchor))
+  if (hAnchor1.IsInvalidated())
+    hAnchor1 = GetOwner()->GetHandle();
+  if (hAnchor2.IsInvalidated())
+    hAnchor2 = GetOwner()->GetHandle();
+
+  if (hAnchor1 == hAnchor2)
+    return EZ_FAILURE;
+
+  ezSimdVec4f anchor1;
+  ezSimdVec4f anchor2;
+
+  ezGameObject* pAnchor1 = nullptr;
+  ezGameObject* pAnchor2 = nullptr;
+
+  if (!GetWorld()->TryGetObject(hAnchor1, pAnchor1))
+  {
+    // never set up so far
+    if (m_RopeSim.m_Nodes.IsEmpty())
+      return EZ_FAILURE;
+
+    if (m_RopeSim.m_bFirstNodeIsFixed)
+    {
+      anchor1 = m_RopeSim.m_Nodes[0].m_vPosition;
+      m_RopeSim.m_bFirstNodeIsFixed = false;
+      m_uiSleepCounter = 0;
+    }
+  }
+  else
+  {
+    anchor1 = ezSimdConversion::ToVec3(pAnchor1->GetGlobalPosition());
+  }
+
+  if (!GetWorld()->TryGetObject(hAnchor2, pAnchor2))
   {
     // never set up so far
     if (m_RopeSim.m_Nodes.IsEmpty())
@@ -108,26 +147,24 @@ ezResult ezFakeRopeComponent::ConfigureRopeSimulator()
 
     if (m_RopeSim.m_bLastNodeIsFixed)
     {
-      anchorB = m_RopeSim.m_Nodes.PeekBack().m_vPosition;
+      anchor2 = m_RopeSim.m_Nodes.PeekBack().m_vPosition;
       m_RopeSim.m_bLastNodeIsFixed = false;
       m_uiSleepCounter = 0;
     }
   }
   else
   {
-    anchorB = ezSimdConversion::ToVec3(pAnchor->GetGlobalPosition());
+    anchor2 = ezSimdConversion::ToVec3(pAnchor2->GetGlobalPosition());
   }
 
   // only early out, if we are not in edit mode
-  m_bIsDynamic = !IsActiveAndSimulating() || GetOwner()->IsDynamic() || (pAnchor != nullptr && pAnchor->IsDynamic());
-
-  const ezSimdVec4f anchorA = ezSimdConversion::ToVec3(GetOwner()->GetGlobalPosition());
+  m_bIsDynamic = !IsActiveAndSimulating() || (pAnchor1 != nullptr && pAnchor1->IsDynamic()) || (pAnchor2 != nullptr && pAnchor2->IsDynamic());
 
   m_RopeSim.m_fDampingFactor = ezMath::Lerp(1.0f, 0.97f, m_fDamping);
 
   if (m_RopeSim.m_fSegmentLength < 0)
   {
-    const float len = (anchorA - anchorB).GetLength<3>();
+    const float len = (anchor1 - anchor2).GetLength<3>();
     m_RopeSim.m_fSegmentLength = (len + len * m_fSlack) / m_uiPieces;
   }
 
@@ -154,7 +191,7 @@ ezResult ezFakeRopeComponent::ConfigureRopeSimulator()
 
     for (ezUInt32 i = uiOldNum; i < m_uiPieces; ++i)
     {
-      m_RopeSim.m_Nodes[i].m_vPosition = anchorA + ((anchorB - anchorA) * (float)i / (m_uiPieces - 1));
+      m_RopeSim.m_Nodes[i].m_vPosition = anchor1 + ((anchor2 - anchor1) * (float)i / (m_uiPieces - 1));
       m_RopeSim.m_Nodes[i].m_vPreviousPosition = m_RopeSim.m_Nodes[i].m_vPosition;
     }
   }
@@ -163,19 +200,19 @@ ezResult ezFakeRopeComponent::ConfigureRopeSimulator()
   {
     if (m_RopeSim.m_bFirstNodeIsFixed)
     {
-      if ((m_RopeSim.m_Nodes[0].m_vPosition != anchorA).AnySet<3>())
+      if ((m_RopeSim.m_Nodes[0].m_vPosition != anchor1).AnySet<3>())
       {
         m_uiSleepCounter = 0;
-        m_RopeSim.m_Nodes[0].m_vPosition = anchorA;
+        m_RopeSim.m_Nodes[0].m_vPosition = anchor1;
       }
     }
 
     if (m_RopeSim.m_bLastNodeIsFixed)
     {
-      if ((m_RopeSim.m_Nodes.PeekBack().m_vPosition != anchorB).AnySet<3>())
+      if ((m_RopeSim.m_Nodes.PeekBack().m_vPosition != anchor2).AnySet<3>())
       {
         m_uiSleepCounter = 0;
-        m_RopeSim.m_Nodes.PeekBack().m_vPosition = anchorB;
+        m_RopeSim.m_Nodes.PeekBack().m_vPosition = anchor2;
       }
     }
   }
@@ -190,14 +227,23 @@ void ezFakeRopeComponent::SendPreviewPose()
 
   ezUInt32 uiHash = 0;
 
-  ezGameObject* pAnchor;
-  if (!GetWorld()->TryGetObject(m_hAnchor, pAnchor))
+  ezGameObject* pAnchor1 = nullptr;
+  ezGameObject* pAnchor2 = nullptr;
+  if (!GetWorld()->TryGetObject(m_hAnchor1, pAnchor1))
+    pAnchor1 = GetOwner();
+  if (!GetWorld()->TryGetObject(m_hAnchor2, pAnchor2))
+    pAnchor2 = GetOwner();
+
+  if (pAnchor1 == pAnchor2)
     return;
 
   ezVec3 pos = GetOwner()->GetGlobalPosition();
   uiHash = ezHashingUtils::xxHash32(&pos, sizeof(ezVec3), uiHash);
 
-  pos = pAnchor->GetGlobalPosition();
+  pos = pAnchor1->GetGlobalPosition();
+  uiHash = ezHashingUtils::xxHash32(&pos, sizeof(ezVec3), uiHash);
+
+  pos = pAnchor2->GetGlobalPosition();
   uiHash = ezHashingUtils::xxHash32(&pos, sizeof(ezVec3), uiHash);
 
   uiHash = ezHashingUtils::xxHash32(&m_fSlack, sizeof(float), uiHash);
@@ -321,26 +367,42 @@ void ezFakeRopeComponent::SendCurrentPose()
       pieces.PeekBack().SetLocalTransform(tRoot, tGlobal);
     }
 
-
     poseMsg.m_LinkTransforms = pieces;
   }
 
   GetOwner()->PostMessage(poseMsg, ezTime::Zero(), ezObjectMsgQueueType::AfterInitialized);
 }
 
-void ezFakeRopeComponent::SetAnchorReference(const char* szReference)
+void ezFakeRopeComponent::SetAnchor1Reference(const char* szReference)
 {
   auto resolver = GetWorld()->GetGameObjectReferenceResolver();
 
   if (!resolver.IsValid())
     return;
 
-  SetAnchor(resolver(szReference, GetHandle(), "Anchor"));
+  SetAnchor1(resolver(szReference, GetHandle(), "Anchor1"));
 }
 
-void ezFakeRopeComponent::SetAnchor(ezGameObjectHandle hActor)
+void ezFakeRopeComponent::SetAnchor2Reference(const char* szReference)
 {
-  m_hAnchor = hActor;
+  auto resolver = GetWorld()->GetGameObjectReferenceResolver();
+
+  if (!resolver.IsValid())
+    return;
+
+  SetAnchor2(resolver(szReference, GetHandle(), "Anchor2"));
+}
+
+void ezFakeRopeComponent::SetAnchor1(ezGameObjectHandle hActor)
+{
+  m_hAnchor1 = hActor;
+  m_bIsDynamic = true;
+  m_uiSleepCounter = 0;
+}
+
+void ezFakeRopeComponent::SetAnchor2(ezGameObjectHandle hActor)
+{
+  m_hAnchor2 = hActor;
   m_bIsDynamic = true;
   m_uiSleepCounter = 0;
 }
@@ -353,26 +415,26 @@ void ezFakeRopeComponent::SetSlack(float fVal)
   m_uiSleepCounter = 0;
 }
 
-void ezFakeRopeComponent::SetAttachToOrigin(bool bVal)
+void ezFakeRopeComponent::SetAttachToAnchor1(bool bVal)
 {
   m_RopeSim.m_bFirstNodeIsFixed = bVal;
   m_bIsDynamic = true;
   m_uiSleepCounter = 0;
 }
 
-bool ezFakeRopeComponent::GetAttachToOrigin() const
-{
-  return m_RopeSim.m_bFirstNodeIsFixed;
-}
-
-void ezFakeRopeComponent::SetAttachToAnchor(bool bVal)
+void ezFakeRopeComponent::SetAttachToAnchor2(bool bVal)
 {
   m_RopeSim.m_bLastNodeIsFixed = bVal;
   m_bIsDynamic = true;
   m_uiSleepCounter = 0;
 }
 
-bool ezFakeRopeComponent::GetAttachToAnchor() const
+bool ezFakeRopeComponent::GetAttachToAnchor1() const
+{
+  return m_RopeSim.m_bFirstNodeIsFixed;
+}
+
+bool ezFakeRopeComponent::GetAttachToAnchor2() const
 {
   return m_RopeSim.m_bLastNodeIsFixed;
 }

--- a/Code/EnginePlugins/JoltPlugin/Components/JoltRopeComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Components/JoltRopeComponent.h
@@ -12,6 +12,23 @@ namespace JPH
 
 using ezSurfaceResourceHandle = ezTypedResourceHandle<class ezSurfaceResource>;
 
+struct ezJoltRopeAnchorConstraintMode
+{
+  using StorageType = ezInt8;
+
+  enum Enum
+  {
+    None,
+    Point,
+    Fixed,
+    Cone,
+
+    Default = Point
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_JOLTPLUGIN_DLL, ezJoltRopeAnchorConstraintMode);
+
 //////////////////////////////////////////////////////////////////////////
 
 class EZ_JOLTPLUGIN_DLL ezJoltRopeComponentManager : public ezComponentManager<class ezJoltRopeComponent, ezBlockStorageType::Compact>
@@ -56,35 +73,39 @@ public:
   void SetSurfaceFile(const char* szFile); // [ property ]
   const char* GetSurfaceFile() const;      // [ property ]
 
-  ezUInt8 m_uiCollisionLayer = 0;           // [ property ]
-  ezUInt16 m_uiPieces = 16;                 // [ property ]
-  float m_fThickness = 0.05f;               // [ property ]
-  float m_fSlack = 0.3f;                    // [ property ]
-  bool m_bAttachToOrigin = true;            // [ property ]
-  bool m_bAttachToAnchor = true;            // [ property ]
-  bool m_bCCD = false;                      // [ property ]
-  ezAngle m_MaxBend = ezAngle::Degree(30);  // [ property ]
-  ezAngle m_MaxTwist = ezAngle::Degree(15); // [ property ]
+  ezUInt8 m_uiCollisionLayer = 0;                                 // [ property ]
+  ezUInt16 m_uiPieces = 16;                                       // [ property ]
+  float m_fThickness = 0.05f;                                     // [ property ]
+  float m_fSlack = 0.3f;                                          // [ property ]
+  ezEnum<ezJoltRopeAnchorConstraintMode> m_Anchor1ConstraintMode; // [ property ]
+  ezEnum<ezJoltRopeAnchorConstraintMode> m_Anchor2ConstraintMode; // [ property ]
+  bool m_bCCD = false;                                            // [ property ]
+  ezAngle m_MaxBend = ezAngle::Degree(30);                        // [ property ]
+  ezAngle m_MaxTwist = ezAngle::Degree(15);                       // [ property ]
 
-  void SetAnchorReference(const char* szReference); // [ property ]
-  void SetAnchor(ezGameObjectHandle hActor);
+  void SetAnchor1Reference(const char* szReference); // [ property ]
+  void SetAnchor2Reference(const char* szReference); // [ property ]
+
+  void SetAnchor1(ezGameObjectHandle hActor);
+  void SetAnchor2(ezGameObjectHandle hActor);
 
   void AddForceAtPos(ezMsgPhysicsAddForce& ref_msg);
   void AddImpulseAtPos(ezMsgPhysicsAddImpulse& ref_msg);
 
 private:
   void CreateRope();
-  ezResult CreateSegmentTransforms(ezDynamicArray<ezTransform>& transforms, float& out_fPieceLength) const;
+  ezResult CreateSegmentTransforms(ezDynamicArray<ezTransform>& transforms, float& out_fPieceLength, ezGameObjectHandle hAnchor1, ezGameObjectHandle hAnchor2);
   void DestroyPhysicsShapes();
   void Update();
   void SendPreviewPose();
   const ezJoltMaterial* GetJoltMaterial();
-  JPH::Constraint* CreateConstraint(const ezGameObjectHandle& hTarget, const ezTransform& dstLoc, ezUInt32 uiBodyID);
+  JPH::Constraint* CreateConstraint(const ezGameObjectHandle& hTarget, const ezTransform& dstLoc, ezUInt32 uiBodyID, ezJoltRopeAnchorConstraintMode::Enum mode);
   void UpdatePreview();
 
   ezSurfaceResourceHandle m_hSurface;
 
-  ezGameObjectHandle m_hAnchor;
+  ezGameObjectHandle m_hAnchor1;
+  ezGameObjectHandle m_hAnchor2;
 
   float m_fTotalMass = 1.0f;
   float m_fMaxForcePerFrame = 0.0f;
@@ -93,11 +114,11 @@ private:
   ezUInt32 m_uiUserDataIndex = ezInvalidIndex;
   bool m_bSelfCollision = false;
   float m_fGravityFactor = 1.0f;
-  ezVec3 m_vPreviewRefPos = ezVec3::ZeroVector();
+  ezUInt32 m_uiPreviewHash = 0;
 
   JPH::Ragdoll* m_pRagdoll = nullptr;
-  JPH::Constraint* m_pConstraintOrigin = nullptr;
-  JPH::Constraint* m_pConstraintAnchor = nullptr;
+  JPH::Constraint* m_pConstraintAnchor1 = nullptr;
+  JPH::Constraint* m_pConstraintAnchor2 = nullptr;
 
 
 private:

--- a/Code/UnitTests/FoundationTest/Math/QuatTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/QuatTest.cpp
@@ -137,24 +137,24 @@ EZ_CREATE_SIMPLE_TEST(Math, Quaternion)
     ezVec3T axis;
     ezAngle angle;
 
-    EZ_TEST_BOOL(q1.GetRotationAxisAndAngle(axis, angle) == EZ_SUCCESS);
+    q1.GetRotationAxisAndAngle(axis, angle);
     EZ_TEST_VEC3(axis, ezVec3T(0, 0, -1), 0.001f);
     EZ_TEST_FLOAT(angle.GetDegree(), 90, ezMath::LargeEpsilon<ezMat3T::ComponentType>());
 
-    EZ_TEST_BOOL(q2.GetRotationAxisAndAngle(axis, angle) == EZ_SUCCESS);
+    q2.GetRotationAxisAndAngle(axis, angle);
     EZ_TEST_VEC3(axis, ezVec3T(0, 0, -1), 0.001f);
     EZ_TEST_FLOAT(angle.GetDegree(), 90, ezMath::LargeEpsilon<ezMat3T::ComponentType>());
 
-    EZ_TEST_BOOL(q3.GetRotationAxisAndAngle(axis, angle) == EZ_SUCCESS);
+    q3.GetRotationAxisAndAngle(axis, angle);
     EZ_TEST_VEC3(axis, ezVec3T(0, 0, -1), 0.001f);
     EZ_TEST_FLOAT(angle.GetDegree(), 90, ezMath::LargeEpsilon<ezMat3T::ComponentType>());
 
-    EZ_TEST_BOOL(ezQuatT::IdentityQuaternion().GetRotationAxisAndAngle(axis, angle) == EZ_SUCCESS);
+    ezQuatT::IdentityQuaternion().GetRotationAxisAndAngle(axis, angle);
     EZ_TEST_VEC3(axis, ezVec3T(1, 0, 0), 0.001f);
     EZ_TEST_FLOAT(angle.GetDegree(), 0, ezMath::LargeEpsilon<ezMat3T::ComponentType>());
 
     ezQuatT otherIdentity(0, 0, 0, -1);
-    EZ_TEST_BOOL(otherIdentity.GetRotationAxisAndAngle(axis, angle) == EZ_SUCCESS);
+    otherIdentity.GetRotationAxisAndAngle(axis, angle);
     EZ_TEST_VEC3(axis, ezVec3T(1, 0, 0), 0.001f);
     EZ_TEST_FLOAT(angle.GetDegree(), 360, ezMath::LargeEpsilon<ezMat3T::ComponentType>());
   }
@@ -194,7 +194,7 @@ EZ_CREATE_SIMPLE_TEST(Math, Quaternion)
     EZ_TEST_BOOL(q.IsValid(0.001f));
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator-")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator-/Invert")
   {
     ezQuatT q, q1;
     q.SetFromAxisAndAngle(ezVec3T(0, 0, 1), ezAngle::Degree(90));
@@ -202,6 +202,10 @@ EZ_CREATE_SIMPLE_TEST(Math, Quaternion)
 
     ezQuatT q2 = -q;
     EZ_TEST_BOOL(q1.IsEqualRotation(q2, 0.0001f));
+
+    ezQuatT q3 = q;
+    q3.Invert();
+    EZ_TEST_BOOL(q1.IsEqualRotation(q3, 0.0001f));
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Dot")

--- a/Data/Samples/Testing Chambers/Objects/Barrel2.ezPrefab
+++ b/Data/Samples/Testing Chambers/Objects/Barrel2.ezPrefab
@@ -27,7 +27,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{17117916137065290683,4718395998851768835}}
-		u4 %Hash{8006905322000643005}
+		u4 %Hash{16233409757529521342}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{12245528259253396345,7105609957248947995}}
@@ -265,7 +265,7 @@ o
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
+		s %Name{"<Prefab-Root>"}
 		VarArray %Tags
 		{
 			s{"CastShadow"}


### PR DESCRIPTION
* Both rope components can now be defined with two reference points instead of just one, which makes it easier to connect two external objects (e.g. prefabs).
* Jolt ropes now have multiple options with which kind of constraint to fix the rope ends (none, point, fixed, cone).
* The effect of the attachment point is now also previewed properly, making it much easier to orient the attachment point as desired.
* Also various bugfixes in the rope body/joint creation.