### PR TITLE
Prevent Jolt crash when a joined physics actor is deleted

### DIFF
--- a/Code/Engine/Core/Messages/SetColorMessage.h
+++ b/Code/Engine/Core/Messages/SetColorMessage.h
@@ -5,7 +5,7 @@
 
 struct ezSetColorMode
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/Engine/Core/Scripting/DuktapeHelper.h
+++ b/Code/Engine/Core/Scripting/DuktapeHelper.h
@@ -12,7 +12,7 @@ typedef int (*duk_c_function)(duk_context* ctx);
 
 struct ezDuktapeTypeMask
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/Engine/Core/World/Declarations.h
+++ b/Code/Engine/Core/World/Declarations.h
@@ -167,7 +167,7 @@ EZ_DECLARE_CUSTOM_VARIANT_TYPE(ezComponentHandle);
 /// \brief Internal flags of game objects or components.
 struct ezObjectFlags
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/Engine/Foundation/Memory/MemoryTracker.h
+++ b/Code/Engine/Foundation/Memory/MemoryTracker.h
@@ -6,7 +6,7 @@
 
 struct ezMemoryTrackingFlags
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/Engine/Foundation/System/Process.h
+++ b/Code/Engine/Foundation/System/Process.h
@@ -66,7 +66,7 @@ struct EZ_FOUNDATION_DLL ezProcessOptions
 /// \brief Flags for ezProcess::Launch()
 struct ezProcessLaunchFlags
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/Engine/Foundation/Types/Bitflags.h
+++ b/Code/Engine/Foundation/Types/Bitflags.h
@@ -41,7 +41,7 @@
 /// \code{.cpp}
 ///   struct SimpleRenderFlags
 ///   {
-///     typedef ezUInt32 StorageType;
+///     using StorageType = ezUInt32;
 ///
 ///     enum Enum
 ///     {

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
@@ -9,7 +9,7 @@
 
 struct EZ_RENDERERCORE_DLL ezShaderBindFlags
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {
@@ -44,7 +44,7 @@ EZ_DECLARE_FLAGS_OPERATORS(ezShaderBindFlags);
 
 struct EZ_RENDERERCORE_DLL ezRenderContextFlags
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {
@@ -84,7 +84,7 @@ EZ_DECLARE_FLAGS_OPERATORS(ezRenderContextFlags);
 
 struct EZ_RENDERERCORE_DLL ezDefaultSamplerFlags
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltActorComponent.cpp
@@ -14,6 +14,12 @@
 #include <JoltPlugin/Utilities/JoltConversionUtils.h>
 
 // clang-format off
+EZ_IMPLEMENT_MESSAGE_TYPE(ezJoltMsgDisconnectConstraints);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltMsgDisconnectConstraints, 1, ezRTTIDefaultAllocator<ezJoltMsgDisconnectConstraints>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+// clang-format off
 EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezJoltActorComponent, 2)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
@@ -326,6 +326,20 @@ void ezJoltDynamicActorComponent::OnDeactivated()
     GetWorld()->GetOrCreateComponentManager<ezJoltDynamicActorComponentManager>()->m_KinematicActorComponents.RemoveAndSwap(this);
   }
 
+  ezDynamicArray<ezComponentHandle> allConstraints;
+  allConstraints.Swap(m_Constraints);
+
+  ezJoltMsgDisconnectConstraints msg;
+  msg.m_pActor = this;
+  msg.m_uiJoltBodyID = GetJoltBodyID();
+
+  ezWorld* pWorld = GetWorld();
+
+  for (ezComponentHandle hConstraint : allConstraints)
+  {
+    pWorld->SendMessage(hConstraint, msg);
+  }
+
   SUPER::OnDeactivated();
 }
 
@@ -363,6 +377,16 @@ void ezJoltDynamicActorComponent::AddAngularImpulse(const ezVec3& vImpulse)
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
   pBodies->AddAngularImpulse(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(vImpulse));
+}
+
+void ezJoltDynamicActorComponent::AddConstraint(ezComponentHandle hComponent)
+{
+  m_Constraints.PushBack(hComponent);
+}
+
+void ezJoltDynamicActorComponent::RemoveConstraint(ezComponentHandle hComponent)
+{
+  m_Constraints.RemoveAndSwap(hComponent);
 }
 
 void ezJoltDynamicActorComponent::AddForceAtPos(ezMsgPhysicsAddForce& ref_msg)
@@ -419,4 +443,3 @@ const char* ezJoltDynamicActorComponent::GetSurfaceFile() const
 
 
 EZ_STATICLINK_FILE(JoltPlugin, JoltPlugin_Actors_Implementation_JoltDynamicActorComponent);
-

--- a/Code/EnginePlugins/JoltPlugin/Actors/JoltDynamicActorComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Actors/JoltDynamicActorComponent.h
@@ -74,9 +74,20 @@ public:
   void AddAngularForce(const ezVec3& vForce);     // [ scriptable ]
   void AddAngularImpulse(const ezVec3& vImpulse); // [ scriptable ]
 
+  /// \brief Should be called by components that add Jolt constraints to this body.
+  ///
+  /// All registered components receive ezJoltMsgDisconnectConstraints in case the body is deleted.
+  /// It is necessary to react to that by removing the Jolt constraint, otherwise Jolt will crash during the next update.
+  void AddConstraint(ezComponentHandle hComponent);
+
+  /// \brief Should be called when a constraint is removed (though not strictly required) to prevent unnecessary message sending.
+  void RemoveConstraint(ezComponentHandle hComponent);
+
 protected:
   const ezJoltMaterial* GetJoltMaterial() const;
 
   bool m_bKinematic = false;
   float m_fGravityFactor = 1.0f; // [ property ]
+
+  ezDynamicArray<ezComponentHandle> m_Constraints;
 };

--- a/Code/EnginePlugins/JoltPlugin/Components/JoltRopeComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Components/JoltRopeComponent.h
@@ -92,6 +92,9 @@ public:
   void AddForceAtPos(ezMsgPhysicsAddForce& ref_msg);
   void AddImpulseAtPos(ezMsgPhysicsAddImpulse& ref_msg);
 
+  /// \brief Makes sure that the rope's connection to a removed body also gets removed.
+  void OnJoltMsgDisconnectConstraints(ezJoltMsgDisconnectConstraints& msg); // [ msg handler ]
+
 private:
   void CreateRope();
   ezResult CreateSegmentTransforms(ezDynamicArray<ezTransform>& transforms, float& out_fPieceLength, ezGameObjectHandle hAnchor1, ezGameObjectHandle hAnchor2);
@@ -99,7 +102,7 @@ private:
   void Update();
   void SendPreviewPose();
   const ezJoltMaterial* GetJoltMaterial();
-  JPH::Constraint* CreateConstraint(const ezGameObjectHandle& hTarget, const ezTransform& dstLoc, ezUInt32 uiBodyID, ezJoltRopeAnchorConstraintMode::Enum mode);
+  JPH::Constraint* CreateConstraint(const ezGameObjectHandle& hTarget, const ezTransform& dstLoc, ezUInt32 uiBodyID, ezJoltRopeAnchorConstraintMode::Enum mode, ezUInt32& out_uiConnectedToBodyID);
   void UpdatePreview();
 
   ezSurfaceResourceHandle m_hSurface;
@@ -119,6 +122,8 @@ private:
   JPH::Ragdoll* m_pRagdoll = nullptr;
   JPH::Constraint* m_pConstraintAnchor1 = nullptr;
   JPH::Constraint* m_pConstraintAnchor2 = nullptr;
+  ezUInt32 m_uiAnchor1BodyID = ezInvalidIndex;
+  ezUInt32 m_uiAnchor2BodyID = ezInvalidIndex;
 
 
 private:

--- a/Code/EnginePlugins/JoltPlugin/Constraints/JoltConstraintComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Constraints/JoltConstraintComponent.h
@@ -3,6 +3,8 @@
 #include <Core/World/ComponentManager.h>
 #include <JoltPlugin/Declarations.h>
 
+class ezJoltDynamicActorComponent;
+
 namespace JPH
 {
   class Body;
@@ -70,6 +72,9 @@ public:
   ezJoltConstraintComponent();
   ~ezJoltConstraintComponent();
 
+  /// \brief Removes the connection between the joined bodies. This cannot be reversed.
+  void BreakConstraint();
+
   void SetBreakForce(float value);                      // [ property ]
   float GetBreakForce() const { return m_fBreakForce; } // [ property ]
 
@@ -93,9 +98,12 @@ public:
 
   virtual bool ExceededBreakingPoint() = 0;
 
+  /// \brief Forwards to BreakConstraint().
+  void OnJoltMsgDisconnectConstraints(ezJoltMsgDisconnectConstraints& msg); // [ msg handler ]
+
 protected:
-  ezResult FindParentBody(ezUInt32& out_uiJoltBodyID);
-  ezResult FindChildBody(ezUInt32& out_uiJoltBodyID);
+  ezResult FindParentBody(ezUInt32& out_uiJoltBodyID, ezJoltDynamicActorComponent*& pRbComp);
+  ezResult FindChildBody(ezUInt32& out_uiJoltBodyID, ezJoltDynamicActorComponent*& pRbComp);
 
   virtual void CreateContstraintType(JPH::Body* pBody0, JPH::Body* pBody1) = 0;
 

--- a/Code/EnginePlugins/JoltPlugin/Declarations.h
+++ b/Code/EnginePlugins/JoltPlugin/Declarations.h
@@ -5,9 +5,11 @@
 #include <Foundation/Types/Enum.h>
 #include <JoltPlugin/JoltPluginDLL.h>
 
-struct EZ_JOLTPLUGIN_DLL ezJoltSteppingMode
+class ezJoltActorComponent;
+
+struct ezJoltSteppingMode
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {
@@ -25,12 +27,12 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_JOLTPLUGIN_DLL, ezJoltSteppingMode);
 
 struct ezOnJoltContact
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {
     None = 0,
-    //SendReportMsg = EZ_BIT(0),
+    // SendReportMsg = EZ_BIT(0),
     ImpactReactions = EZ_BIT(1),
     SlideReactions = EZ_BIT(2),
     RollXReactions = EZ_BIT(3),
@@ -70,4 +72,17 @@ struct ezJoltSettings
   ezUInt32 m_uiMaxSubSteps = 4;
 
   ezUInt32 m_uiMaxBodies = 1000 * 10;
+};
+
+//////////////////////////////////////////////////////////////////////////
+
+struct EZ_JOLTPLUGIN_DLL ezJoltMsgDisconnectConstraints : public ezMessage
+{
+  EZ_DECLARE_MESSAGE_TYPE(ezJoltMsgDisconnectConstraints, ezMessage);
+
+  /// The actor that is being deleted. All constraints that are linked to it must be removed for Jolt not to crash.
+  ezJoltActorComponent* m_pActor = nullptr;
+
+  /// The ID of the Jolt body that is being removed. If an actor were to have multiple bodies, this message may be sent multiple times.
+  ezUInt32 m_uiJoltBodyID = 0;
 };

--- a/Code/EnginePlugins/JoltPlugin/Declarations.h
+++ b/Code/EnginePlugins/JoltPlugin/Declarations.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Foundation/Communication/Message.h>
 #include <Foundation/Math/Vec3.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/Enum.h>

--- a/Code/Tools/Libs/GuiFoundation/Action/Action.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/Action.h
@@ -26,7 +26,8 @@ typedef void (*DeleteActionFunc)(ezAction* pAction);
 class EZ_GUIFOUNDATION_DLL ezActionDescriptorHandle
 {
 public:
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
+
   EZ_DECLARE_HANDLE_TYPE(ezActionDescriptorHandle, ezActionId);
   friend class ezActionManager;
 

--- a/Code/Tools/Libs/GuiFoundation/Action/StandardMenus.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/StandardMenus.h
@@ -5,7 +5,7 @@
 
 struct ezStandardMenuTypes
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   enum Enum
   {

--- a/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
@@ -8,7 +8,7 @@ namespace
   // declare bitflags manually
   struct ManualFlags
   {
-    typedef ezUInt32 StorageType;
+    using StorageType = ezUInt32;
 
     enum Enum
     {

--- a/Code/UnitTests/FoundationTest/Basics/Types/IdTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/IdTest.cpp
@@ -7,7 +7,7 @@
 
 struct TestId
 {
-  typedef ezUInt32 StorageType;
+  using StorageType = ezUInt32;
 
   EZ_DECLARE_ID_TYPE(TestId, 20, 6);
 


### PR DESCRIPTION
If there is a constraint between two physics bodies, and one of the bodies is removed, the constraint that joined the two together also has to be removed, otherwise Jolt will try to access the deleted objects.