### PR TITLE
Fixes and improvements for the C++ workflow

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -695,8 +695,7 @@ void ezProjectAction::Execute(const ezVariant& value)
       ezStringBuilder sEngineProfilingFile;
       {
         // Wait for engine process response
-        auto callback = [&](ezProcessMessage* pMsg) -> bool
-        {
+        auto callback = [&](ezProcessMessage* pMsg) -> bool {
           auto pSimpleCfg = static_cast<ezSaveProfilingResponseToEditor*>(pMsg);
           sEngineProfilingFile = pSimpleCfg->m_sProfilingFile;
           return true;

--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -549,7 +549,13 @@ void ezProjectAction::Execute(const ezVariant& value)
 
     case ezProjectAction::ButtonType::PluginSelection:
     {
-      ezQtEditorApp::GetSingleton()->DetectAvailablePluginBundles();
+      ezQtEditorApp::GetSingleton()->DetectAvailablePluginBundles(ezOSFile::GetApplicationDirectory());
+
+      ezCppSettings cppSettings;
+      if (cppSettings.Load().Succeeded())
+      {
+        ezQtEditorApp::GetSingleton()->DetectAvailablePluginBundles(ezCppProject::GetPluginSourceDir(cppSettings));
+      }
 
       ezQtPluginSelectionDlg dlg(&ezQtEditorApp::GetSingleton()->GetPluginBundles());
       dlg.exec();
@@ -689,7 +695,8 @@ void ezProjectAction::Execute(const ezVariant& value)
       ezStringBuilder sEngineProfilingFile;
       {
         // Wait for engine process response
-        auto callback = [&](ezProcessMessage* pMsg) -> bool {
+        auto callback = [&](ezProcessMessage* pMsg) -> bool
+        {
           auto pSimpleCfg = static_cast<ezSaveProfilingResponseToEditor*>(pMsg);
           sEngineProfilingFile = pSimpleCfg->m_sProfilingFile;
           return true;

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -345,8 +345,7 @@ ezResult ezCppProject::CompileSolution(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = cfg.m_sMsBuildPath;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res)
-  {
+  po.m_onStdOut = [&](ezStringView res) {
     if (res.FindSubString_NoCase("error") != nullptr)
       errors.PushBack(res);
   };
@@ -426,8 +425,7 @@ ezResult ezCppProject::FindMsBuild(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = sVsWhere;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res)
-  { sStdOut.Append(res); };
+  po.m_onStdOut = [&](ezStringView res) { sStdOut.Append(res); };
 
   // TODO: search for VS2022 or VS2019 depending on cfg
   po.AddCommandLine("-latest -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.h
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.h
@@ -6,15 +6,19 @@
 
 struct EZ_EDITORFRAMEWORK_DLL ezCppProject
 {
-  static ezString GetTargetSourceDir();
+  static ezString GetTargetSourceDir(ezStringView sProjectDirectory = {});
 
   static ezString GetGeneratorFolderName(const ezCppSettings& cfg);
 
   static ezString GetCMakeGeneratorName(const ezCppSettings& cfg);
 
+  static ezString GetPluginSourceDir(const ezCppSettings& cfg, ezStringView sProjectDirectory = {});
+
   static ezString GetBuildDir(const ezCppSettings& cfg);
 
   static ezString GetSolutionPath(const ezCppSettings& cfg);
+
+  static ezResult CheckCMakeCache(const ezCppSettings& cfg);
 
   static bool ExistsSolution(const ezCppSettings& cfg);
 

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
@@ -154,12 +154,12 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
   return EZ_SUCCESS;
 }
 
-void ezQtEditorApp::DetectAvailablePluginBundles()
+void ezQtEditorApp::DetectAvailablePluginBundles(ezStringView sSearchDirectory)
 {
 #if EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS)
   // find all ezPluginBundle files
   {
-    ezStringBuilder sSearch = ezOSFile::GetApplicationDirectory();
+    ezStringBuilder sSearch = sSearchDirectory;
 
     sSearch.AppendPath("*.ezPluginBundle");
 
@@ -241,7 +241,7 @@ void ezQtEditorApp::DetectAvailablePluginBundles()
 void ezQtEditorApp::LoadEditorPlugins()
 {
   EZ_PROFILE_SCOPE("LoadEditorPlugins");
-  DetectAvailablePluginBundles();
+  DetectAvailablePluginBundles(ezOSFile::GetApplicationDirectory());
 
   ezPlugin::InitializeStaticallyLinkedPlugins();
 }

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EnginePlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EnginePlugins.cpp
@@ -1,5 +1,6 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
+#include <EditorFramework/CodeGen/CppProject.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Profiling/Profiling.h>
@@ -36,7 +37,14 @@ bool ezQtEditorApp::CheckForEnginePluginModifications()
 
     if (plugin.m_bMissing)
     {
-      DetectAvailablePluginBundles();
+      DetectAvailablePluginBundles(ezOSFile::GetApplicationDirectory());
+
+      ezCppSettings cppSettings;
+      if (cppSettings.Load().Succeeded())
+      {
+        ezQtEditorApp::GetSingleton()->DetectAvailablePluginBundles(ezCppProject::GetPluginSourceDir(cppSettings));
+      }
+
       break;
     }
   }

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -177,7 +177,7 @@ public:
   void WritePluginSelectionStateDDL(const char* szProjectDir = ":project");
   void CreatePluginSelectionDDL(const char* szProjectFile, const char* szTemplate);
   void LoadPluginBundleDlls(const char* szProjectFile);
-  void DetectAvailablePluginBundles();
+  void DetectAvailablePluginBundles(ezStringView sSearchDirectory);
 
   /// \brief Launches a new instance of the editor to open the given project.
   void LaunchEditor(const char* szProject, bool bCreate);

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -287,8 +287,7 @@ void ezQtEditorApp::ProjectEventHandler(const ezToolsProjectEvent& r)
 
         if (pPreferences->m_bBackgroundAssetProcessing)
         {
-          QTimer::singleShot(1000, this, [this]()
-            { ezAssetProcessor::GetSingleton()->StartProcessTask(); });
+          QTimer::singleShot(1000, this, [this]() { ezAssetProcessor::GetSingleton()->StartProcessTask(); });
         }
         else if (!lastTransform.IsValid() || (ezTimestamp::CurrentTimestamp() - lastTransform).GetHours() > 5 * 24)
         {
@@ -303,8 +302,7 @@ Explanation: For assets to work properly, they must be <a href='https://ezengine
           }
 
           // check whether the project needs to be transformed
-          QTimer::singleShot(1000, this, [this]()
-            { ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::Default); });
+          QTimer::singleShot(1000, this, [this]() { ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::Default); });
         }
       }
 

--- a/Code/Engine/Foundation/IO/FileSystem/DeferredFileWriter.h
+++ b/Code/Engine/Foundation/IO/FileSystem/DeferredFileWriter.h
@@ -22,7 +22,7 @@ public:
 
   /// \brief Upon calling this the content is written to the file specified with SetOutput().
   /// The return value is EZ_FAILURE if the file could not be opened or not completely written.
-  ezResult Close(); // [tested]
+  ezResult Close(bool* out_bWasWrittenTo = nullptr); // [tested]
 
   /// \brief Calling this abandons the content and a later Close or destruction of the instance
   /// will no longer write anything to file.

--- a/Code/Engine/Foundation/IO/FileSystem/Implementation/DeferredFileWriter.cpp
+++ b/Code/Engine/Foundation/IO/FileSystem/Implementation/DeferredFileWriter.cpp
@@ -21,8 +21,13 @@ ezResult ezDeferredFileWriter::WriteBytes(const void* pWriteBuffer, ezUInt64 uiB
   return m_Writer.WriteBytes(pWriteBuffer, uiBytesToWrite);
 }
 
-ezResult ezDeferredFileWriter::Close()
+ezResult ezDeferredFileWriter::Close(bool* out_bWasWrittenTo /*= nullptr*/)
 {
+  if (out_bWasWrittenTo)
+  {
+    *out_bWasWrittenTo = false;
+  }
+
   if (m_bAlreadyClosed)
     return EZ_SUCCESS;
 
@@ -66,6 +71,11 @@ ezResult ezDeferredFileWriter::Close()
 write_data:
   ezFileWriter file;
   EZ_SUCCEED_OR_RETURN(file.Open(m_sOutputFile, 0)); // use the minimum cache size, we want to pass data directly through to disk
+
+  if (out_bWasWrittenTo)
+  {
+    *out_bWasWrittenTo = true;
+  }
 
   m_sOutputFile.Clear();
   return m_Storage.CopyToStream(file);

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeLists.txt
@@ -10,8 +10,3 @@ target_link_libraries(${PROJECT_NAME}
   GameEngine
   Utilities
 )
-
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/CppProjectPlugin.ezPluginBundle" $<TARGET_FILE_DIR:${PROJECT_NAME}>
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-	  )


### PR DESCRIPTION
* Fixed #817: Project specific plugin bundles don't need to be copied to the Bin folder anymore. This prevents plugin references getting lost when switching between build types.
* When building the C++ code, the CMake solution is now automatically regenerated when the build type differs (Debug, Dev, Shipping).
* The editor warns now that the build may fail, when a debugger is attached.