### PR TITLE
C++ plugin workflow improvements

### DIFF
--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -345,8 +345,7 @@ ezResult ezCppProject::CompileSolution(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = cfg.m_sMsBuildPath;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res)
-  {
+  po.m_onStdOut = [&](ezStringView res) {
     if (res.FindSubString_NoCase("error") != nullptr)
       errors.PushBack(res);
   };
@@ -426,8 +425,7 @@ ezResult ezCppProject::FindMsBuild(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = sVsWhere;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res)
-  { sStdOut.Append(res); };
+  po.m_onStdOut = [&](ezStringView res) { sStdOut.Append(res); };
 
   // TODO: search for VS2022 or VS2019 depending on cfg
   po.AddCommandLine("-latest -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -345,9 +345,9 @@ ezResult ezCppProject::CompileSolution(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = cfg.m_sMsBuildPath;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res) {
-    if (res.FindSubString_NoCase("error") != nullptr)
-      errors.PushBack(res);
+  po.m_onStdOut = [&](ezStringView sText) {
+    if (sText.FindSubString_NoCase("error") != nullptr)
+      errors.PushBack(sText);
   };
 
   po.AddArgument(ezCppProject::GetSolutionPath(cfg));
@@ -425,7 +425,7 @@ ezResult ezCppProject::FindMsBuild(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = sVsWhere;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res) { sStdOut.Append(res); };
+  po.m_onStdOut = [&](ezStringView sText) { sStdOut.Append(sText); };
 
   // TODO: search for VS2022 or VS2019 depending on cfg
   po.AddCommandLine("-latest -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -345,7 +345,8 @@ ezResult ezCppProject::CompileSolution(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = cfg.m_sMsBuildPath;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res) {
+  po.m_onStdOut = [&](ezStringView res)
+  {
     if (res.FindSubString_NoCase("error") != nullptr)
       errors.PushBack(res);
   };
@@ -425,7 +426,8 @@ ezResult ezCppProject::FindMsBuild(const ezCppSettings& cfg)
   ezProcessOptions po;
   po.m_sProcess = sVsWhere;
   po.m_bHideConsoleWindow = true;
-  po.m_onStdOut = [&](ezStringView res) { sStdOut.Append(res); };
+  po.m_onStdOut = [&](ezStringView res)
+  { sStdOut.Append(res); };
 
   // TODO: search for VS2022 or VS2019 depending on cfg
   po.AddCommandLine("-latest -requires Microsoft.Component.MSBuild -find MSBuild\\**\\Bin\\MSBuild.exe");
@@ -467,4 +469,57 @@ void ezCppProject::UpdatePluginConfig(const ezCppSettings& cfg)
   plugin.m_RuntimePlugins.PushBack(sPluginName);
 
   ezQtEditorApp::GetSingleton()->WritePluginSelectionStateDDL();
+}
+
+ezResult ezCppProject::EnsureCppPluginReady()
+{
+  if (!ExistsProjectCMakeListsTxt())
+    return EZ_SUCCESS;
+
+  ezCppSettings cppSettings;
+  if (cppSettings.Load().Failed())
+  {
+    ezQtUiServices::GetSingleton()->MessageBoxWarning(ezFmt("Failed to load the C++ plugin settings."));
+    return EZ_FAILURE;
+  }
+
+  if (ezCppProject::BuildCodeIfNecessary(cppSettings).Failed())
+  {
+    ezQtUiServices::GetSingleton()->MessageBoxWarning(ezFmt("Failed to build the C++ code. See log for details."));
+    return EZ_FAILURE;
+  }
+
+  ezQtEditorApp::GetSingleton()->RestartEngineProcessIfPluginsChanged(true);
+  return EZ_SUCCESS;
+}
+
+bool ezCppProject::IsBuildRequired()
+{
+  if (!ExistsProjectCMakeListsTxt())
+    return false;
+
+  ezCppSettings cfg;
+  if (cfg.Load().Failed())
+    return false;
+
+  if (!ezCppProject::ExistsSolution(cfg))
+    return true;
+
+  if (!ezCppProject::CheckCMakeCache(cfg))
+    return true;
+
+  ezStringBuilder sPath = ezOSFile::GetApplicationDirectory();
+  sPath.AppendPath(cfg.m_sPluginName);
+  sPath.Append("Plugin");
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+  sPath.Append(".dll");
+#else
+  sPath.Append(".so");
+#endif
+
+  if (!ezOSFile::ExistsFile(sPath))
+    return true;
+
+  return false;
 }

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.h
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.h
@@ -40,6 +40,10 @@ struct EZ_EDITORFRAMEWORK_DLL ezCppProject
 
   static void UpdatePluginConfig(const ezCppSettings& cfg);
 
+  static ezResult EnsureCppPluginReady();
+
+  static bool IsBuildRequired();
+
   /// \brief Fired when a notable change has been made.
   static ezEvent<const ezCppSettings&> s_ChangeEvents;
 };

--- a/Code/Editor/EditorFramework/Dialogs/CppProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/CppProjectDlg.cpp
@@ -87,7 +87,14 @@ void ezQtCppProjectDlg::on_OpenSolution_clicked()
 
 void ezQtCppProjectDlg::on_PluginName_textEdited(const QString& text)
 {
-  m_CppSettings.m_sPluginName = PluginName->text().toUtf8().data();
+  ezStringBuilder name = PluginName->text().toUtf8().data();
+
+  if (name.EndsWith_NoCase("Plugin"))
+  {
+    name.Shrink(0, 6);
+  }
+
+  m_CppSettings.m_sPluginName = name;
 
   UpdateUI();
 }

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -85,8 +85,7 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
 
   ezLogSystemToBuffer logFile;
 
-  auto WriteLogFile = [&]()
-  {
+  auto WriteLogFile = [&]() {
     ezStringBuilder sTemp;
     sTemp.Set(szDstFolder, "/ExportLog.txt");
 

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/CodeGen/CppProject.h>
 #include <EditorFramework/Dialogs/ExportProjectDlg.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Preferences/Preferences.h>

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -32,6 +32,17 @@ void ezQtExportProjectDlg::showEvent(QShowEvent* e)
   QDialog::showEvent(e);
 
   TransformAll->setChecked(s_bTransformAll);
+
+  if (!ezCppProject::ExistsProjectCMakeListsTxt())
+  {
+    CompileCpp->setEnabled(false);
+    CompileCpp->setToolTip("This project doesn't have a C++ plugin.");
+    CompileCpp->setChecked(false);
+  }
+  else
+  {
+    CompileCpp->setChecked(true);
+  }
 }
 
 void ezQtExportProjectDlg::on_BrowseDestination_clicked()
@@ -53,6 +64,12 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
   // select asset profile for export
   // copy inputs into resource: RML files
 
+  if (CompileCpp->isChecked())
+  {
+    if (ezCppProject::EnsureCppPluginReady().Failed())
+      return;
+  }
+
   if (TransformAll->isChecked())
   {
     ezStatus stat = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually);
@@ -68,7 +85,8 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
 
   ezLogSystemToBuffer logFile;
 
-  auto WriteLogFile = [&]() {
+  auto WriteLogFile = [&]()
+  {
     ezStringBuilder sTemp;
     sTemp.Set(szDstFolder, "/ExportLog.txt");
 

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.ui
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.ui
@@ -52,6 +52,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="CompileCpp">
+     <property name="text">
+      <string>Compile C++ Plugin</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="TransformAll">
      <property name="text">
       <string>Transform all Assets</string>

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -293,16 +293,14 @@ It is advised to compile the plugin now, but you can also do so later.</html>",
           if (clicked == QMessageBox::StandardButton::Ignore)
             break;
 
-          QTimer::singleShot(1000, this, [this]()
-            { ezCppProject::EnsureCppPluginReady().IgnoreResult(); });
+          QTimer::singleShot(1000, this, [this]() { ezCppProject::EnsureCppPluginReady().IgnoreResult(); });
         }
 
         ezTimestamp lastTransform = ezAssetCurator::GetSingleton()->GetLastFullTransformDate().GetTimestamp();
 
         if (pPreferences->m_bBackgroundAssetProcessing)
         {
-          QTimer::singleShot(2000, this, [this]()
-            { ezAssetProcessor::GetSingleton()->StartProcessTask(); });
+          QTimer::singleShot(2000, this, [this]() { ezAssetProcessor::GetSingleton()->StartProcessTask(); });
         }
         else if (!lastTransform.IsValid() || (ezTimestamp::CurrentTimestamp() - lastTransform).GetHours() > 5 * 24)
         {
@@ -317,8 +315,7 @@ Explanation: For assets to work properly, they must be <a href='https://ezengine
           }
 
           // check whether the project needs to be transformed
-          QTimer::singleShot(2000, this, [this]()
-            { ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::Default); });
+          QTimer::singleShot(2000, this, [this]() { ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::Default); });
         }
       }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -287,13 +287,8 @@ void ezSceneAction::Execute(const ezVariant& value)
       range.BeginNextStep("Build C++");
       if (dlg.s_bCompileCpp)
       {
-        if (ezCppProject::BuildCodeIfNecessary(dlg.m_CppSettings).Failed())
-        {
-          ezQtUiServices::GetSingleton()->MessageBoxWarning(ezFmt("Failed to build the C++ code. See log for details."));
+        if (ezCppProject::EnsureCppPluginReady().Failed())
           return;
-        }
-
-        ezQtEditorApp::GetSingleton()->RestartEngineProcessIfPluginsChanged(true);
       }
 
       range.BeginNextStep("Transform Assets");

--- a/Code/Engine/Foundation/IO/FileSystem/DeferredFileWriter.h
+++ b/Code/Engine/Foundation/IO/FileSystem/DeferredFileWriter.h
@@ -22,7 +22,7 @@ public:
 
   /// \brief Upon calling this the content is written to the file specified with SetOutput().
   /// The return value is EZ_FAILURE if the file could not be opened or not completely written.
-  ezResult Close(bool* out_bWasWrittenTo = nullptr); // [tested]
+  ezResult Close(bool* out_pWasWrittenTo = nullptr); // [tested]
 
   /// \brief Calling this abandons the content and a later Close or destruction of the instance
   /// will no longer write anything to file.

--- a/Code/Engine/Foundation/IO/FileSystem/Implementation/DeferredFileWriter.cpp
+++ b/Code/Engine/Foundation/IO/FileSystem/Implementation/DeferredFileWriter.cpp
@@ -21,11 +21,11 @@ ezResult ezDeferredFileWriter::WriteBytes(const void* pWriteBuffer, ezUInt64 uiB
   return m_Writer.WriteBytes(pWriteBuffer, uiBytesToWrite);
 }
 
-ezResult ezDeferredFileWriter::Close(bool* out_bWasWrittenTo /*= nullptr*/)
+ezResult ezDeferredFileWriter::Close(bool* out_pWasWrittenTo /*= nullptr*/)
 {
-  if (out_bWasWrittenTo)
+  if (out_pWasWrittenTo)
   {
-    *out_bWasWrittenTo = false;
+    *out_pWasWrittenTo = false;
   }
 
   if (m_bAlreadyClosed)
@@ -72,9 +72,9 @@ write_data:
   ezFileWriter file;
   EZ_SUCCEED_OR_RETURN(file.Open(m_sOutputFile, 0)); // use the minimum cache size, we want to pass data directly through to disk
 
-  if (out_bWasWrittenTo)
+  if (out_pWasWrittenTo)
   {
-    *out_bWasWrittenTo = true;
+    *out_pWasWrittenTo = true;
   }
 
   m_sOutputFile.Clear();

--- a/Code/Engine/Foundation/IO/Implementation/Posix/OSFile_posix.h
+++ b/Code/Engine/Foundation/IO/Implementation/Posix/OSFile_posix.h
@@ -365,7 +365,7 @@ ezResult ezOSFile::InternalGetFileStats(ezStringView sFileOrFolder, ezFileStats&
 
 #if EZ_DISABLED(EZ_PLATFORM_WINDOWS_UWP)
 
-const char* ezOSFile::GetApplicationDirectory()
+ezStringView ezOSFile::GetApplicationDirectory()
 {
   static ezString256 s_Path;
 
@@ -414,7 +414,7 @@ const char* ezOSFile::GetApplicationDirectory()
 #  endif
   }
 
-  return s_Path.GetData();
+  return s_Path;
 }
 
 ezString ezOSFile::GetUserDataFolder(ezStringView sSubFolder)

--- a/Code/Engine/Foundation/IO/Implementation/Win/OSFile_win.h
+++ b/Code/Engine/Foundation/IO/Implementation/Win/OSFile_win.h
@@ -519,7 +519,7 @@ ezInt32 ezFileSystemIterator::InternalNext()
 
 #endif
 
-const char* ezOSFile::GetApplicationDirectory()
+ezStringView ezOSFile::GetApplicationDirectory()
 {
   if (s_sApplicationPath.IsEmpty())
   {
@@ -554,7 +554,7 @@ const char* ezOSFile::GetApplicationDirectory()
     s_sApplicationPath = ezPathUtils::GetFileDirectory(ezStringUtf8(tmp.GetData()));
   }
 
-  return s_sApplicationPath.GetData();
+  return s_sApplicationPath;
 }
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)

--- a/Code/Engine/Foundation/IO/OSFile.h
+++ b/Code/Engine/Foundation/IO/OSFile.h
@@ -271,7 +271,7 @@ public:
 #endif
 
   /// \brief Returns the path in which the applications binary file is located.
-  static const char* GetApplicationDirectory();
+  static ezStringView GetApplicationDirectory();
 
   /// \brief Returns the folder into which user data may be safely written.
   /// Append a sub-folder for your application.

--- a/Code/Engine/Foundation/System/Implementation/Win/StackTracer_win.h
+++ b/Code/Engine/Foundation/System/Implementation/Win/StackTracer_win.h
@@ -136,7 +136,7 @@ void ezStackTracer::OnPluginEvent(const ezPluginEvent& e)
   if (false) // e.m_EventType == ezPluginEvent::AfterLoading)
   {
     char buffer[1024];
-    strcpy_s(buffer, ezOSFile::GetApplicationDirectory());
+    strcpy_s(buffer, ezOSFile::GetApplicationDirectory().GetStartPointer());
     strcat_s(buffer, e.m_szPluginBinary);
     strcat_s(buffer, ".dll");
 

--- a/Code/UnitTests/FoundationTest/IO/OSFileTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/OSFileTest.cpp
@@ -288,8 +288,8 @@ Only concrete and clocks.\n\
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetApplicationDirectory")
   {
-    const char* szAppDir = ezOSFile::GetApplicationDirectory();
-    EZ_IGNORE_UNUSED(szAppDir);
+    ezStringView sAppDir = ezOSFile::GetApplicationDirectory();
+    EZ_TEST_BOOL(!sAppDir.IsEmpty());
   }
 
 #if (EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS) && EZ_ENABLED(EZ_SUPPORTS_FILE_STATS))


### PR DESCRIPTION
Fixed #884:
* When opening a project, the user is now asked whether to compile the C++ plugin.
* When exporting a project, the compilation can be triggered as well.
* Prevent a plugin from being named 'Plugin'