### PR TITLE
clang-tidy improvements

### DIFF
--- a/Code/BuildSystem/AzurePipelines/clang-tidy.yml
+++ b/Code/BuildSystem/AzurePipelines/clang-tidy.yml
@@ -35,15 +35,19 @@ jobs:
       targetType: filePath
       filePath: './Utilities/RunClangTidy.ps1'
       arguments: '-DiffTo "origin/$(system.pullRequest.targetBranch)" -LlvmInstallDir "$pwd\llvm" -Workspace "workspace-clang"'
-  - pwsh: |
-      # Changes done by clang tidy on MemberProperty.h are always incorrect
-      git checkout "Code/Engine/Foundation/Reflection/Implementation/MemberProperty.h"
-      if(@(git status -s --untracked-files=no).Length -gt 0)
-      {
-        Write-Host "##vso[task.logissue type=error]clang-tidy suggested changes. Clang tidy check failed! See artifact 'clang-tidy.patch' for suggested changes. Apply patch with: git apply clang-tidy.patch" -foreground red
-        git diff | Out-File -Encoding utf8NoBOM -FilePath "$(Build.ArtifactStagingDirectory)\clang-tidy.patch"
-      }
-    displayName: 'Fetch suggested changes' 
+  - task: PowerShell@2
+    displayName: 'Fetch suggested changes'
+    condition: always()
+    inputs:
+      targetType: 'inline'
+      script: |
+        # Changes done by clang tidy on MemberProperty.h are always incorrect
+        git checkout "Code/Engine/Foundation/Reflection/Implementation/MemberProperty.h"
+        if(@(git status -s --untracked-files=no).Length -gt 0)
+        {
+          Write-Host "##vso[task.logissue type=error]clang-tidy suggested changes. Clang tidy check failed! See artifact 'clang-tidy.patch' for suggested changes. Apply patch with: git apply clang-tidy.patch" -foreground red
+          git diff | Out-File -Encoding utf8NoBOM -FilePath "$(Build.ArtifactStagingDirectory)\clang-tidy.patch"
+        }
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Suggested Changes'
     inputs:

--- a/Code/Engine/Foundation/IO/Implementation/Shared/FileSystemMirror.h
+++ b/Code/Engine/Foundation/IO/Implementation/Shared/FileSystemMirror.h
@@ -28,28 +28,27 @@ public:
   ~ezFileSystemMirror();
 
   // \brief Adds the directory, and all files in it recursively.
-  ezResult AddDirectory(const char* path, bool* outDirectoryExistsAlready = nullptr);
+  ezResult AddDirectory(const char* szPath, bool* out_pDirectoryExistsAlready = nullptr);
 
   // \brief Adds a file. Creates directories if they do not exist.
-  ezResult AddFile(const char* path, const T& value, bool* outFileExistsAlready, T* outOldValue);
+  ezResult AddFile(const char* szPath, const T& value, bool* out_pFileExistsAlready, T* out_pOldValue);
 
   // \brief Removes a file.
-  ezResult RemoveFile(const char* path);
+  ezResult RemoveFile(const char* szPath);
 
   // \brief Removes a directory. Deletes any files & directories inside.
-  ezResult RemoveDirectory(const char* path);
+  ezResult RemoveDirectory(const char* szPath);
 
   // \brief Moves a directory. Any files & folders inside are moved with it.
-  ezResult MoveDirectory(const char* fromPath, const char* toPath);
+  ezResult MoveDirectory(const char* szFromPath, const char* szToPath);
 
   using EnumerateFunc = ezDelegate<void(const ezStringBuilder& path, Type type)>;
 
   // \brief Enumerates the files & directories under the given path
-  ezResult Enumerate(const char* path, EnumerateFunc callbackFunc);
+  ezResult Enumerate(const char* szPath, EnumerateFunc callbackFunc);
 
 private:
   DirEntry* FindDirectory(ezStringBuilder& path);
-  DirEntry* AddDirectoryImpl(DirEntry* startDir, ezStringBuilder& path);
 
 private:
   DirEntry m_TopLevelDir;
@@ -82,9 +81,9 @@ template <typename T>
 ezFileSystemMirror<T>::~ezFileSystemMirror() = default;
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::AddDirectory(const char* path, bool* outDirectoryExistsAlready)
+ezResult ezFileSystemMirror<T>::AddDirectory(const char* szPath, bool* out_pDirectoryExistsAlready)
 {
-  ezStringBuilder currentDirAbsPath = path;
+  ezStringBuilder currentDirAbsPath = szPath;
   currentDirAbsPath.MakeCleanPath();
   EnsureTrailingSlash(currentDirAbsPath);
 
@@ -127,9 +126,9 @@ ezResult ezFileSystemMirror<T>::AddDirectory(const char* path, bool* outDirector
         currentDir->m_files.Insert(std::move(stats.m_sName), T{});
       }
     }
-    if (outDirectoryExistsAlready != nullptr)
+    if (out_pDirectoryExistsAlready != nullptr)
     {
-      *outDirectoryExistsAlready = false;
+      *out_pDirectoryExistsAlready = false;
     }
   }
   else
@@ -140,9 +139,9 @@ ezResult ezFileSystemMirror<T>::AddDirectory(const char* path, bool* outDirector
       return EZ_FAILURE;
     }
 
-    if (outDirectoryExistsAlready != nullptr)
+    if (out_pDirectoryExistsAlready != nullptr)
     {
-      *outDirectoryExistsAlready = currentDirAbsPath.IsEmpty();
+      *out_pDirectoryExistsAlready = currentDirAbsPath.IsEmpty();
     }
 
     while (!currentDirAbsPath.IsEmpty())
@@ -159,9 +158,9 @@ ezResult ezFileSystemMirror<T>::AddDirectory(const char* path, bool* outDirector
 }
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::AddFile(const char* path, const T& value, bool* outFileExistsAlready, T* outOldValue)
+ezResult ezFileSystemMirror<T>::AddFile(const char* szPath, const T& value, bool* out_pFileExistsAlready, T* out_pOldValue)
 {
-  ezStringBuilder sPath = path;
+  ezStringBuilder sPath = szPath;
   DirEntry* dir = FindDirectory(sPath);
   if (dir == nullptr)
   {
@@ -184,20 +183,20 @@ ezResult ezFileSystemMirror<T>::AddFile(const char* path, const T& value, bool* 
   if (!it.IsValid())
   {
     dir->m_files.Insert(sPath, value);
-    if (outFileExistsAlready != nullptr)
+    if (out_pFileExistsAlready != nullptr)
     {
-      *outFileExistsAlready = false;
+      *out_pFileExistsAlready = false;
     }
   }
   else
   {
-    if (outFileExistsAlready != nullptr)
+    if (out_pFileExistsAlready != nullptr)
     {
-      *outFileExistsAlready = true;
+      *out_pFileExistsAlready = true;
     }
-    if (outOldValue != nullptr)
+    if (out_pOldValue != nullptr)
     {
-      *outOldValue = it.Value();
+      *out_pOldValue = it.Value();
     }
     it.Value() = value;
   }
@@ -205,9 +204,9 @@ ezResult ezFileSystemMirror<T>::AddFile(const char* path, const T& value, bool* 
 }
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::RemoveFile(const char* path)
+ezResult ezFileSystemMirror<T>::RemoveFile(const char* szPath)
 {
-  ezStringBuilder sPath = path;
+  ezStringBuilder sPath = szPath;
   DirEntry* dir = FindDirectory(sPath);
   if (dir == nullptr)
   {
@@ -235,10 +234,10 @@ ezResult ezFileSystemMirror<T>::RemoveFile(const char* path)
 }
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::RemoveDirectory(const char* path)
+ezResult ezFileSystemMirror<T>::RemoveDirectory(const char* szPath)
 {
-  ezStringBuilder parentPath = path;
-  ezStringBuilder dirName = path;
+  ezStringBuilder parentPath = szPath;
+  ezStringBuilder dirName = szPath;
   parentPath.PathParentDirectory();
   EnsureTrailingSlash(parentPath);
   dirName.Shrink(parentPath.GetCharacterCount(), 0);
@@ -259,18 +258,18 @@ ezResult ezFileSystemMirror<T>::RemoveDirectory(const char* path)
 }
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::MoveDirectory(const char* fromPath, const char* toPath)
+ezResult ezFileSystemMirror<T>::MoveDirectory(const char* szFromPath, const char* szToPath)
 {
-  ezStringBuilder sFromPath = fromPath;
-  ezStringBuilder sFromName = fromPath;
+  ezStringBuilder sFromPath = szFromPath;
+  ezStringBuilder sFromName = szFromPath;
   sFromPath.PathParentDirectory();
   EnsureTrailingSlash(sFromPath);
   sFromName.Shrink(sFromPath.GetCharacterCount(), 0);
   EnsureTrailingSlash(sFromName);
 
 
-  ezStringBuilder sToPath = toPath;
-  ezStringBuilder sToName = toPath;
+  ezStringBuilder sToPath = szToPath;
+  ezStringBuilder sToName = szToPath;
   sToPath.PathParentDirectory();
   EnsureTrailingSlash(sToPath);
   sToName.Shrink(sToPath.GetCharacterCount(), 0);
@@ -329,10 +328,10 @@ namespace
 } // namespace
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::Enumerate(const char* path, EnumerateFunc callbackFunc)
+ezResult ezFileSystemMirror<T>::Enumerate(const char* szPath, EnumerateFunc callbackFunc)
 {
   ezHybridArray<ezDirEnumerateState<T>, 16> dirStack;
-  ezStringBuilder sPath = path;
+  ezStringBuilder sPath = szPath;
   if (!sPath.EndsWith("/"))
   {
     sPath.Append("/");
@@ -348,7 +347,7 @@ ezResult ezFileSystemMirror<T>::Enumerate(const char* path, EnumerateFunc callba
   }
   DirEntry* currentDir = dirToEnumerate;
   typename ezMap<ezString, ezFileSystemMirror::DirEntry>::Iterator currentSubDirIt = currentDir->m_subDirectories.GetIterator();
-  sPath = path;
+  sPath = szPath;
 
   while (currentDir != nullptr)
   {

--- a/Code/Engine/GameEngine/VisualScript/Implementation/VisualScriptNode.cpp
+++ b/Code/Engine/GameEngine/VisualScript/Implementation/VisualScriptNode.cpp
@@ -8,7 +8,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptNode, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezVisualScriptNode::ezVisualScriptNode() : m_uiNodeID(0) {}
+ezVisualScriptNode::ezVisualScriptNode() = default;
 ezVisualScriptNode::~ezVisualScriptNode() = default;
 
 

--- a/Code/Engine/GameEngine/VisualScript/Nodes/VisualScriptMessageNodes.cpp
+++ b/Code/Engine/GameEngine/VisualScript/Nodes/VisualScriptMessageNodes.cpp
@@ -145,7 +145,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptNode_PhysicsTriggerEvent, 1, ezRTT
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezVisualScriptNode_PhysicsTriggerEvent::ezVisualScriptNode_PhysicsTriggerEvent() : m_State(ezTriggerState::Enum::Default) {}
+ezVisualScriptNode_PhysicsTriggerEvent::ezVisualScriptNode_PhysicsTriggerEvent() = default;
 ezVisualScriptNode_PhysicsTriggerEvent::~ezVisualScriptNode_PhysicsTriggerEvent() = default;
 
 void ezVisualScriptNode_PhysicsTriggerEvent::Execute(ezVisualScriptInstance* pInstance, ezUInt8 uiExecPin)
@@ -260,7 +260,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptNode_InputEvent, 1, ezRTTIDefaultA
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezVisualScriptNode_InputEvent::ezVisualScriptNode_InputEvent() : m_State(ezTriggerState::Default) {}
+ezVisualScriptNode_InputEvent::ezVisualScriptNode_InputEvent() = default;
 ezVisualScriptNode_InputEvent::~ezVisualScriptNode_InputEvent() = default;
 
 void ezVisualScriptNode_InputEvent::Execute(ezVisualScriptInstance* pInstance, ezUInt8 uiExecPin)

--- a/Code/Engine/GameEngine/VisualScript/Nodes/VisualScriptMessageNodes.h
+++ b/Code/Engine/GameEngine/VisualScript/Nodes/VisualScriptMessageNodes.h
@@ -79,7 +79,7 @@ public:
 private:
   ezHashedString m_sTriggerMessage;
   ezGameObjectHandle m_hObject;
-  ezTriggerState::Enum m_State;
+  ezTriggerState::Enum m_State = ezTriggerState::Enum::Default;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -122,7 +122,7 @@ private:
   ezHashedString m_sInputAction;
   ezGameObjectHandle m_hSenderObject;
   ezComponentHandle m_hSenderComponent;
-  ezTriggerState::Enum m_State;
+  ezTriggerState::Enum m_State = ezTriggerState::Default;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/GameEngine/VisualScript/VisualScriptNode.h
+++ b/Code/Engine/GameEngine/VisualScript/VisualScriptNode.h
@@ -43,7 +43,7 @@ protected:
 private:
   friend class ezVisualScriptInstance;
 
-  ezUInt16 m_uiNodeID;
+  ezUInt16 m_uiNodeID = 0;
 };
 
 

--- a/Code/Engine/Utilities/DataStructures/DynamicOctree.h
+++ b/Code/Engine/Utilities/DataStructures/DynamicOctree.h
@@ -135,10 +135,10 @@ private:
   ezBoundingBox m_BBox;
 
   /// \brief The actual bounding box (to discard objects that are outside the world)
-  float m_fRealMinX, m_fRealMaxX, m_fRealMinY, m_fRealMaxY, m_fRealMinZ, m_fRealMaxZ;
+  float m_fRealMinX = 0, m_fRealMaxX = 0, m_fRealMinY = 0, m_fRealMaxY = 0, m_fRealMinZ = 0, m_fRealMaxZ = 0;
 
   /// \brief Used to turn the map into a multi-map.
-  ezUInt32 m_uiMultiMapCounter;
+  ezUInt32 m_uiMultiMapCounter = 0;
 
   /// \brief Every node has a unique index, the map allows to store many objects at each node, using that index
   ezMap<ezDynamicTree::ezMultiMapKey, ezDynamicTree::ezObjectData> m_NodeMap;

--- a/Code/Engine/Utilities/DataStructures/DynamicQuadtree.h
+++ b/Code/Engine/Utilities/DataStructures/DynamicQuadtree.h
@@ -134,10 +134,10 @@ private:
   ezBoundingBox m_BBox;
 
   /// \brief The actual bounding box (to discard objects that are outside the world)
-  float m_fRealMinX, m_fRealMaxX, m_fRealMinZ, m_fRealMaxZ;
+  float m_fRealMinX = 0, m_fRealMaxX = 0, m_fRealMinZ = 0, m_fRealMaxZ = 0;
 
   /// \brief Used to turn the map into a multi-map.
-  ezUInt32 m_uiMultiMapCounter;
+  ezUInt32 m_uiMultiMapCounter = 0;
 
   /// \brief Every node has a unique index, the map allows to store many objects at each node, using that index
   ezMap<ezDynamicTree::ezMultiMapKey, ezDynamicTree::ezObjectData> m_NodeMap;

--- a/Code/Engine/Utilities/DataStructures/Implementation/DynamicOctree.cpp
+++ b/Code/Engine/Utilities/DataStructures/Implementation/DynamicOctree.cpp
@@ -4,16 +4,7 @@
 
 const float ezDynamicOctree::s_fLooseOctreeFactor = 1.1f;
 
-ezDynamicOctree::ezDynamicOctree()
-  : m_fRealMinX(0)
-  , m_fRealMaxX(0)
-  , m_fRealMinY(0)
-  , m_fRealMaxY(0)
-  , m_fRealMinZ(0)
-  , m_fRealMaxZ(0)
-  , m_uiMultiMapCounter(0)
-{
-}
+ezDynamicOctree::ezDynamicOctree() = default;
 
 void ezDynamicOctree::CreateTree(const ezVec3& vCenter, const ezVec3& vHalfExtents, float fMinNodeSize)
 {

--- a/Code/Engine/Utilities/DataStructures/Implementation/DynamicQuadtree.cpp
+++ b/Code/Engine/Utilities/DataStructures/Implementation/DynamicQuadtree.cpp
@@ -4,14 +4,7 @@
 
 const float ezDynamicQuadtree::s_fLooseOctreeFactor = 1.1f;
 
-ezDynamicQuadtree::ezDynamicQuadtree()
-  : m_fRealMinX(0)
-  , m_fRealMaxX(0)
-  , m_fRealMinZ(0)
-  , m_fRealMaxZ(0)
-  , m_uiMultiMapCounter(0)
-{
-}
+ezDynamicQuadtree::ezDynamicQuadtree() = default;
 
 void ezDynamicQuadtree::CreateTree(const ezVec3& vCenter, const ezVec3& vHalfExtents, float fMinNodeSize)
 {

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.cpp
@@ -14,7 +14,6 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEventReactionFactory_Prefab, 1, ezRTTI
   {
     EZ_MEMBER_PROPERTY("Prefab", m_sPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab")),
     EZ_ENUM_MEMBER_PROPERTY("Alignment", ezSurfaceInteractionAlignment, m_Alignment),
-    //EZ_MAP_ACCESSOR_PROPERTY("Parameters", GetParameters, GetParameter, SetParameter, RemoveParameter)->AddAttributes(new ezExposedParametersAttribute("CompatibleAsset_Prefab"), new ezExposeColorAlphaAttribute),
   }
   EZ_END_PROPERTIES;
 }
@@ -24,17 +23,13 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEventReaction_Prefab, 1, ezRTTIDefault
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezParticleEventReactionFactory_Prefab::ezParticleEventReactionFactory_Prefab()
-{
-  // m_Parameters = EZ_DEFAULT_NEW(ezParticlePrefabParameters);
-}
+ezParticleEventReactionFactory_Prefab::ezParticleEventReactionFactory_Prefab() = default;
 
 enum class ReactionPrefabVersion
 {
   Version_0 = 0,
   Version_1,
   Version_2,
-  // Version_3, // added Prefab parameters
 
   // insert new version numbers above
   Version_Count,
@@ -53,20 +48,6 @@ void ezParticleEventReactionFactory_Prefab::Save(ezStreamWriter& inout_stream) c
 
   // Version 2
   inout_stream << m_Alignment;
-
-  // Version 3
-  // stream << m_Parameters->m_FloatParams.GetCount();
-  // for (ezUInt32 i = 0; i < m_Parameters->m_FloatParams.GetCount(); ++i)
-  //{
-  //  stream << m_Parameters->m_FloatParams[i].m_sName;
-  //  stream << m_Parameters->m_FloatParams[i].m_Value;
-  //}
-  // stream << m_Parameters->m_ColorParams.GetCount();
-  // for (ezUInt32 i = 0; i < m_Parameters->m_ColorParams.GetCount(); ++i)
-  //{
-  //  stream << m_Parameters->m_ColorParams[i].m_sName;
-  //  stream << m_Parameters->m_ColorParams[i].m_Value;
-  //}
 }
 
 void ezParticleEventReactionFactory_Prefab::Load(ezStreamReader& inout_stream)
@@ -85,29 +66,6 @@ void ezParticleEventReactionFactory_Prefab::Load(ezStreamReader& inout_stream)
   {
     inout_stream >> m_Alignment;
   }
-
-  // if (uiVersion >= 3)
-  //{
-  //  ezUInt32 numFloats, numColors;
-
-  //  stream >> numFloats;
-  //  m_Parameters->m_FloatParams.SetCountUninitialized(numFloats);
-
-  //  for (ezUInt32 i = 0; i < m_Parameters->m_FloatParams.GetCount(); ++i)
-  //  {
-  //    stream >> m_Parameters->m_FloatParams[i].m_sName;
-  //    stream >> m_Parameters->m_FloatParams[i].m_Value;
-  //  }
-
-  //  stream >> numColors;
-  //  m_Parameters->m_ColorParams.SetCountUninitialized(numColors);
-
-  //  for (ezUInt32 i = 0; i < m_Parameters->m_ColorParams.GetCount(); ++i)
-  //  {
-  //    stream >> m_Parameters->m_ColorParams[i].m_sName;
-  //    stream >> m_Parameters->m_ColorParams[i].m_Value;
-  //  }
-  //}
 }
 
 
@@ -126,119 +84,7 @@ void ezParticleEventReactionFactory_Prefab::CopyReactionProperties(ezParticleEve
 
   if (!m_sPrefab.IsEmpty())
     pReaction->m_hPrefab = ezResourceManager::LoadResource<ezPrefabResource>(m_sPrefab);
-
-  // pReaction->m_Parameters = m_Parameters;
 }
-//
-// const ezRangeView<const char*, ezUInt32> ezParticleEventReactionFactory_Prefab::GetParameters() const
-//{
-//  return ezRangeView<const char*, ezUInt32>(
-//      [this]() -> ezUInt32 { return 0; },
-//      [this]() -> ezUInt32 { return m_Parameters->m_FloatParams.GetCount() + m_Parameters->m_ColorParams.GetCount(); },
-//      [this](ezUInt32& it) { ++it; },
-//      [this](const ezUInt32& it) -> const char* {
-//        if (it < m_Parameters->m_FloatParams.GetCount())
-//          return m_Parameters->m_FloatParams[it].m_sName.GetData();
-//        else
-//          return m_Parameters->m_ColorParams[it - m_Parameters->m_FloatParams.GetCount()].m_sName.GetData();
-//      });
-//}
-//
-// void ezParticleEventReactionFactory_Prefab::SetParameter(const char* szKey, const ezVariant& var)
-//{
-//  const ezTempHashedString th(szKey);
-//  if (var.CanConvertTo<float>())
-//  {
-//    float value = var.ConvertTo<float>();
-//
-//    for (ezUInt32 i = 0; i < m_Parameters->m_FloatParams.GetCount(); ++i)
-//    {
-//      if (m_Parameters->m_FloatParams[i].m_sName == th)
-//      {
-//        if (m_Parameters->m_FloatParams[i].m_Value != value)
-//        {
-//          m_Parameters->m_FloatParams[i].m_Value = value;
-//        }
-//        return;
-//      }
-//    }
-//
-//    auto& e = m_Parameters->m_FloatParams.ExpandAndGetRef();
-//    e.m_sName.Assign(szKey);
-//    e.m_Value = value;
-//
-//    return;
-//  }
-//
-//  if (var.CanConvertTo<ezColor>())
-//  {
-//    ezColor value = var.ConvertTo<ezColor>();
-//
-//    for (ezUInt32 i = 0; i < m_Parameters->m_ColorParams.GetCount(); ++i)
-//    {
-//      if (m_Parameters->m_ColorParams[i].m_sName == th)
-//      {
-//        if (m_Parameters->m_ColorParams[i].m_Value != value)
-//        {
-//          m_Parameters->m_ColorParams[i].m_Value = value;
-//        }
-//        return;
-//      }
-//    }
-//
-//    auto& e = m_Parameters->m_ColorParams.ExpandAndGetRef();
-//    e.m_sName.Assign(szKey);
-//    e.m_Value = value;
-//
-//    return;
-//  }
-//}
-//
-// void ezParticleEventReactionFactory_Prefab::RemoveParameter(const char* szKey)
-//{
-//  const ezTempHashedString th(szKey);
-//
-//  for (ezUInt32 i = 0; i < m_Parameters->m_FloatParams.GetCount(); ++i)
-//  {
-//    if (m_Parameters->m_FloatParams[i].m_sName == th)
-//    {
-//      m_Parameters->m_FloatParams.RemoveAtAndSwap(i);
-//      return;
-//    }
-//  }
-//
-//  for (ezUInt32 i = 0; i < m_Parameters->m_ColorParams.GetCount(); ++i)
-//  {
-//    if (m_Parameters->m_ColorParams[i].m_sName == th)
-//    {
-//      m_Parameters->m_ColorParams.RemoveAtAndSwap(i);
-//      return;
-//    }
-//  }
-//}
-//
-// bool ezParticleEventReactionFactory_Prefab::GetParameter(const char* szKey, ezVariant& out_value) const
-//{
-//  const ezTempHashedString th(szKey);
-//
-//  for (const auto& e : m_Parameters->m_FloatParams)
-//  {
-//    if (e.m_sName == th)
-//    {
-//      out_value = e.m_Value;
-//      return true;
-//    }
-//  }
-//  for (const auto& e : m_Parameters->m_ColorParams)
-//  {
-//    if (e.m_sName == th)
-//    {
-//      out_value = e.m_Value;
-//      return true;
-//    }
-//  }
-//  return false;
-//}
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMap.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMap.cpp
@@ -16,17 +16,9 @@ EZ_END_STATIC_REFLECTED_TYPE;
 // ezActionMap public functions
 ////////////////////////////////////////////////////////////////////////
 
-ezActionMap::ezActionMap()
-{
-  // ezReflectedTypeDescriptor desc;
-  // ezToolsReflectionUtils::GetReflectedTypeDescriptorFromRtti(ezGetStaticRTTI<ezActionMapDescriptor>(), desc);
-  // m_pRtti = ezPhantomRttiManager::RegisterType(desc);
-}
+ezActionMap::ezActionMap() = default;
 
-ezActionMap::~ezActionMap()
-{
-  // DestroyAllObjects();
-}
+ezActionMap::~ezActionMap() = default;
 
 void ezActionMap::MapAction(ezActionDescriptorHandle hAction, const char* szPath, float fOrder)
 {


### PR DESCRIPTION
* Improve output of clang tidy to not report redundant or useless messages
* clang-tidy check will now also fail for issues clang-tidy finds but can't fix automatically. This is a neccessary prerequesite for using the clang-tidy static analysis features.
* Fix remaining clang-tidy issues.