### PR TITLE
cang-tidy static analysis fixes

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraphQt.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraphQt.cpp
@@ -212,7 +212,7 @@ void ezQtVisualScriptPin_Legacy::SetPin(const ezPin& pin)
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-ezQtVisualScriptConnection_Legacy::ezQtVisualScriptConnection_Legacy(QGraphicsItem* parent /*= 0*/) {}
+ezQtVisualScriptConnection_Legacy::ezQtVisualScriptConnection_Legacy(QGraphicsItem* pParent /*= 0*/) {}
 
 
 QPen ezQtVisualScriptConnection_Legacy::DeterminePen() const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraphQt.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraphQt.moc.h
@@ -44,7 +44,7 @@ public:
 class ezQtVisualScriptConnection_Legacy : public ezQtConnection
 {
 public:
-  ezQtVisualScriptConnection_Legacy(QGraphicsItem* parent = 0);
+  ezQtVisualScriptConnection_Legacy(QGraphicsItem* pParent = 0);
 
   virtual QPen DeterminePen() const override;
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
@@ -8,7 +8,7 @@
 
 namespace
 {
-  ezResult ExtractPropertyName(ezStringView sPinName, ezStringView& out_sPropertyName, ezUInt32* out_uiArrayIndex = nullptr)
+  ezResult ExtractPropertyName(ezStringView sPinName, ezStringView& out_sPropertyName, ezUInt32* out_pArrayIndex = nullptr)
   {
     const char* szBracket = sPinName.FindSubString("[");
     if (szBracket == nullptr)
@@ -16,9 +16,9 @@ namespace
 
     out_sPropertyName = ezStringView(sPinName.GetStartPointer(), szBracket);
 
-    if (out_uiArrayIndex != nullptr)
+    if (out_pArrayIndex != nullptr)
     {
-      return ezConversionUtils::StringToUInt(szBracket + 1, *out_uiArrayIndex);
+      return ezConversionUtils::StringToUInt(szBracket + 1, *out_pArrayIndex);
     }
 
     return EZ_SUCCESS;

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
@@ -201,8 +201,8 @@ void ezQtVisualScriptNode::UpdateState()
 
 //////////////////////////////////////////////////////////////////////////
 
-ezQtVisualScriptNodeScene::ezQtVisualScriptNodeScene(QObject* parent /*= nullptr*/)
-  : ezQtNodeScene(parent)
+ezQtVisualScriptNodeScene::ezQtVisualScriptNodeScene(QObject* pParent /*= nullptr*/)
+  : ezQtNodeScene(pParent)
 {
 }
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.moc.h
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.moc.h
@@ -34,7 +34,7 @@ class ezQtVisualScriptNodeScene : public ezQtNodeScene
   Q_OBJECT
 
 public:
-  ezQtVisualScriptNodeScene(QObject* parent = nullptr);
+  ezQtVisualScriptNodeScene(QObject* pParent = nullptr);
   ~ezQtVisualScriptNodeScene();
 
   virtual void SetDocumentNodeManager(const ezDocumentNodeManager* pManager);

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -37,10 +37,10 @@ namespace
     return EZ_SUCCESS;
   }
 
-  void AddInputProperty(ezReflectedTypeDescriptor& typeDesc, ezStringView name, ezVisualScriptDataType::Enum scriptDataType)
+  void AddInputProperty(ezReflectedTypeDescriptor& ref_typeDesc, ezStringView sName, ezVisualScriptDataType::Enum scriptDataType)
   {
-    auto& propDesc = typeDesc.m_Properties.ExpandAndGetRef();
-    propDesc.m_sName = name;
+    auto& propDesc = ref_typeDesc.m_Properties.ExpandAndGetRef();
+    propDesc.m_sName = sName;
     propDesc.m_Flags = ezPropertyFlags::StandardType;
 
     if (scriptDataType == ezVisualScriptDataType::Variant)
@@ -69,38 +69,38 @@ namespace
   }
 
   template <typename T>
-  void AddInputDataPin(ezReflectedTypeDescriptor& typeDesc, ezVisualScriptNodeRegistry::NodeDesc& nodeDesc, ezStringView name)
+  void AddInputDataPin(ezReflectedTypeDescriptor& ref_typeDesc, ezVisualScriptNodeRegistry::NodeDesc& ref_nodeDesc, ezStringView sName)
   {
     const ezRTTI* pDataType = ezGetStaticRTTI<T>();
 
     ezVisualScriptDataType::Enum scriptDataType;
-    EZ_VERIFY(GetScriptDataType(pDataType, scriptDataType, "", name).Succeeded(), "Invalid script data type");
+    EZ_VERIFY(GetScriptDataType(pDataType, scriptDataType, "", sName).Succeeded(), "Invalid script data type");
 
-    AddInputProperty(typeDesc, name, scriptDataType);
+    AddInputProperty(ref_typeDesc, sName, scriptDataType);
 
-    nodeDesc.AddInputDataPin(name, pDataType, scriptDataType, false);
+    ref_nodeDesc.AddInputDataPin(sName, pDataType, scriptDataType, false);
   };
 
-  void AddInputDataPin_Any(ezReflectedTypeDescriptor& typeDesc, ezVisualScriptNodeRegistry::NodeDesc& nodeDesc, ezStringView name, bool bRequired, bool bAddVariantProperty = false)
+  void AddInputDataPin_Any(ezReflectedTypeDescriptor& ref_typeDesc, ezVisualScriptNodeRegistry::NodeDesc& ref_nodeDesc, ezStringView sName, bool bRequired, bool bAddVariantProperty = false)
   {
     if (bAddVariantProperty)
     {
-      AddInputProperty(typeDesc, name, ezVisualScriptDataType::Variant);
+      AddInputProperty(ref_typeDesc, sName, ezVisualScriptDataType::Variant);
     }
 
-    nodeDesc.AddInputDataPin(name, nullptr, ezVisualScriptDataType::Any, bRequired);
-    nodeDesc.m_bNeedsDataTypeDeduction = true;
+    ref_nodeDesc.AddInputDataPin(sName, nullptr, ezVisualScriptDataType::Any, bRequired);
+    ref_nodeDesc.m_bNeedsDataTypeDeduction = true;
   }
 
   template <typename T>
-  void AddOutputDataPin(ezVisualScriptNodeRegistry::NodeDesc& nodeDesc, ezStringView name)
+  void AddOutputDataPin(ezVisualScriptNodeRegistry::NodeDesc& ref_nodeDesc, ezStringView sName)
   {
     const ezRTTI* pDataType = ezGetStaticRTTI<T>();
 
     ezVisualScriptDataType::Enum scriptDataType;
-    EZ_VERIFY(GetScriptDataType(pDataType, scriptDataType, "", name).Succeeded(), "Invalid script data type");
+    EZ_VERIFY(GetScriptDataType(pDataType, scriptDataType, "", sName).Succeeded(), "Invalid script data type");
 
-    nodeDesc.AddOutputDataPin(name, pDataType, scriptDataType);
+    ref_nodeDesc.AddOutputDataPin(sName, pDataType, scriptDataType);
   };
 
   ezStringView StripTypeName(ezStringView sTypeName)
@@ -190,15 +190,15 @@ ezColor ezVisualScriptNodeRegistry::PinDesc::GetColor() const
 
 //////////////////////////////////////////////////////////////////////////
 
-void AddExecutionPin(ezVisualScriptNodeRegistry::NodeDesc& nodeDesc, ezStringView sName, ezHashedString sDynamicPinProperty, ezSmallArray<ezVisualScriptNodeRegistry::PinDesc, 4>& pins)
+void AddExecutionPin(ezVisualScriptNodeRegistry::NodeDesc& ref_nodeDesc, ezStringView sName, ezHashedString sDynamicPinProperty, ezSmallArray<ezVisualScriptNodeRegistry::PinDesc, 4>& ref_pins)
 {
-  auto& pin = pins.ExpandAndGetRef();
+  auto& pin = ref_pins.ExpandAndGetRef();
   pin.m_sName.Assign(sName);
   pin.m_sDynamicPinProperty = sDynamicPinProperty;
   pin.m_pDataType = nullptr;
   pin.m_ScriptDataType = ezVisualScriptDataType::Invalid;
 
-  nodeDesc.m_bHasDynamicPins |= (sDynamicPinProperty.IsEmpty() == false);
+  ref_nodeDesc.m_bHasDynamicPins |= (sDynamicPinProperty.IsEmpty() == false);
 }
 
 void ezVisualScriptNodeRegistry::NodeDesc::AddInputExecutionPin(ezStringView sName, const ezHashedString& sDynamicPinProperty /*= ezHashedString()*/)
@@ -211,16 +211,16 @@ void ezVisualScriptNodeRegistry::NodeDesc::AddOutputExecutionPin(ezStringView sN
   AddExecutionPin(*this, sName, sDynamicPinProperty, m_OutputPins);
 }
 
-void AddDataPin(ezVisualScriptNodeRegistry::NodeDesc& nodeDesc, ezStringView sName, const ezRTTI* pDataType, ezVisualScriptDataType::Enum scriptDataType, bool bRequired, ezHashedString sDynamicPinProperty, ezSmallArray<ezVisualScriptNodeRegistry::PinDesc, 4>& pins)
+void AddDataPin(ezVisualScriptNodeRegistry::NodeDesc& ref_nodeDesc, ezStringView sName, const ezRTTI* pDataType, ezVisualScriptDataType::Enum scriptDataType, bool bRequired, ezHashedString sDynamicPinProperty, ezSmallArray<ezVisualScriptNodeRegistry::PinDesc, 4>& ref_pins)
 {
-  auto& pin = pins.ExpandAndGetRef();
+  auto& pin = ref_pins.ExpandAndGetRef();
   pin.m_sName.Assign(sName);
   pin.m_sDynamicPinProperty = sDynamicPinProperty;
   pin.m_pDataType = pDataType;
   pin.m_ScriptDataType = scriptDataType;
   pin.m_bRequired = bRequired;
 
-  nodeDesc.m_bHasDynamicPins |= (sDynamicPinProperty.IsEmpty() == false);
+  ref_nodeDesc.m_bHasDynamicPins |= (sDynamicPinProperty.IsEmpty() == false);
 }
 
 void ezVisualScriptNodeRegistry::NodeDesc::AddInputDataPin(ezStringView sName, const ezRTTI* pDataType, ezVisualScriptDataType::Enum scriptDataType, bool bRequired, const ezHashedString& sDynamicPinProperty /*= ezHashedString()*/)

--- a/Code/Engine/Core/Console/QuakeConsole.h
+++ b/Code/Engine/Core/Console/QuakeConsole.h
@@ -12,7 +12,7 @@ struct ezLoggingEventData;
 /// easily.
 /// The default implementation uses ezConsoleInterpreter::Lua as the interpreter for commands typed into it.
 /// The interpreter can be replaced with custom implementations.
-class EZ_CORE_DLL ezQuakeConsole : public ezConsole
+class EZ_CORE_DLL ezQuakeConsole final : public ezConsole
 {
 public:
   ezQuakeConsole();

--- a/Code/Engine/Core/Input/VirtualThumbStick.h
+++ b/Code/Engine/Core/Input/VirtualThumbStick.h
@@ -11,7 +11,7 @@
 /// allows easier control over a game. The virtual thumb-stick takes input inside a certain screen area. It tracks the users finger
 /// movements inside this area and translates those into input from a controller thumb-stick, which it then feeds back into the input
 /// system. That makes it then possible to be mapped to input actions again. This way a game controller type of input is emulated.
-class EZ_CORE_DLL ezVirtualThumbStick : public ezInputDevice
+class EZ_CORE_DLL ezVirtualThumbStick final : public ezInputDevice
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezVirtualThumbStick, ezInputDevice);
 

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -203,7 +203,7 @@ void ezResourceManager::PreloadResource(const ezTypelessResourceHandle& hResourc
   EZ_ASSERT_DEV(hResource.IsValid(), "Cannot acquire a resource through an invalid handle!");
 
   ezResource* pResource = hResource.m_pResource;
-  PreloadResource(hResource.m_pResource);
+  PreloadResource(pResource);
 }
 
 ezResourceState ezResourceManager::GetLoadingState(const ezTypelessResourceHandle& hResource)

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -173,7 +173,6 @@ ezUInt32 ezResourceManager::FreeAllUnusedResources()
 
       for (auto itType = s_pState->m_LoadedResources.GetIterator(); itType.IsValid(); ++itType)
       {
-        const ezRTTI* pRtti = itType.Key();
         LoadedResources& lr = itType.Value();
 
         for (auto it = lr.m_Resources.GetIterator(); it.IsValid(); /* empty */)

--- a/Code/Engine/Core/Scripting/Implementation/ScriptComponent.cpp
+++ b/Code/Engine/Core/Scripting/Implementation/ScriptComponent.cpp
@@ -108,21 +108,21 @@ void ezScriptComponent::OnSimulationStarted()
   CallScriptFunction(ezComponent_ScriptBaseClassFunctions::OnSimulationStarted);
 }
 
-void ezScriptComponent::BroadcastEventMsg(ezEventMessage& msg)
+void ezScriptComponent::BroadcastEventMsg(ezEventMessage& inout_msg)
 {
-  const ezRTTI* pType = msg.GetDynamicRTTI();
+  const ezRTTI* pType = inout_msg.GetDynamicRTTI();
   for (auto& sender : m_EventSenders)
   {
     if (sender.m_pMsgType == pType)
     {
-      sender.m_Sender.SendEventMessage(msg, this, GetOwner());
+      sender.m_Sender.SendEventMessage(inout_msg, this, GetOwner());
       return;
     }
   }
 
   auto& sender = m_EventSenders.ExpandAndGetRef();
   sender.m_pMsgType = pType;
-  sender.m_Sender.SendEventMessage(msg, this, GetOwner());
+  sender.m_Sender.SendEventMessage(inout_msg, this, GetOwner());
 }
 
 void ezScriptComponent::SetScriptClass(const ezScriptClassResourceHandle& hScript)
@@ -179,8 +179,8 @@ const ezRangeView<const char*, ezUInt32> ezScriptComponent::GetParameters() cons
 {
   return ezRangeView<const char*, ezUInt32>([]() -> ezUInt32 { return 0; },
     [this]() -> ezUInt32 { return m_Parameters.GetCount(); },
-    [](ezUInt32& it) { ++it; },
-    [this](const ezUInt32& it) -> const char* { return m_Parameters.GetKey(it).GetString().GetData(); });
+    [](ezUInt32& ref_uiIt) { ++ref_uiIt; },
+    [this](const ezUInt32& uiIt) -> const char* { return m_Parameters.GetKey(uiIt).GetString().GetData(); });
 }
 
 void ezScriptComponent::SetParameter(const char* szKey, const ezVariant& value)

--- a/Code/Engine/Core/Scripting/ScriptComponent.h
+++ b/Code/Engine/Core/Scripting/ScriptComponent.h
@@ -39,7 +39,7 @@ public:
   ezScriptComponent();
   ~ezScriptComponent();
 
-  void BroadcastEventMsg(ezEventMessage& msg);
+  void BroadcastEventMsg(ezEventMessage& inout_msg);
 
   void SetScriptClass(const ezScriptClassResourceHandle& hScript);
   const ezScriptClassResourceHandle& GetScriptClass() const { return m_hScriptClass; }

--- a/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
+++ b/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
@@ -329,7 +329,8 @@ ezResult ezBlackboardCondition::Serialize(ezStreamWriter& inout_stream) const
 
 ezResult ezBlackboardCondition::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezTypeVersion uiVersion = inout_stream.ReadVersion(s_BlackboardConditionVersion); // NOLINT: Ignore the dead store warning
+  const ezTypeVersion uiVersion = inout_stream.ReadVersion(s_BlackboardConditionVersion);
+  EZ_IGNORE_UNUSED(uiVersion);
 
   inout_stream >> m_sEntryName;
   inout_stream >> m_Operator;

--- a/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
+++ b/Code/Engine/Core/Utils/Implementation/Blackboard.cpp
@@ -329,7 +329,7 @@ ezResult ezBlackboardCondition::Serialize(ezStreamWriter& inout_stream) const
 
 ezResult ezBlackboardCondition::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezTypeVersion uiVersion = inout_stream.ReadVersion(s_BlackboardConditionVersion);
+  const ezTypeVersion uiVersion = inout_stream.ReadVersion(s_BlackboardConditionVersion); // NOLINT: Ignore the dead store warning
 
   inout_stream >> m_sEntryName;
   inout_stream >> m_Operator;

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -359,7 +359,7 @@ void ezGameObject::SetParent(const ezGameObjectHandle& hParent, ezGameObject::Tr
   ezWorld* pWorld = GetWorld();
 
   ezGameObject* pParent = nullptr;
-  bool _ = pWorld->TryGetObject(hParent, pParent);
+  bool _ = pWorld->TryGetObject(hParent, pParent); // NOLINT: Ignore dead store warning.
   pWorld->SetParent(this, pParent, preserve);
 }
 

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -359,7 +359,8 @@ void ezGameObject::SetParent(const ezGameObjectHandle& hParent, ezGameObject::Tr
   ezWorld* pWorld = GetWorld();
 
   ezGameObject* pParent = nullptr;
-  bool _ = pWorld->TryGetObject(hParent, pParent); // NOLINT: Ignore dead store warning.
+  bool _ = pWorld->TryGetObject(hParent, pParent);
+  EZ_IGNORE_UNUSED(_);
   pWorld->SetParent(this, pParent, preserve);
 }
 

--- a/Code/Engine/Foundation/Basics/Assert.h
+++ b/Code/Engine/Foundation/Basics/Assert.h
@@ -59,29 +59,43 @@ inline const char* ezFmt(const char* szFormat)
 EZ_FOUNDATION_DLL void MSVC_OutOfLine_DebugBreak(...);
 #endif
 
+#ifdef BUILDSYSTEM_CLANG_TIDY
+[[noreturn]] void ClangTidyDoNotReturn();
+#  define EZ_REPORT_FAILURE(szErrorMsg, ...) ClangTidyDoNotReturn()
+#else
 /// \brief Macro to report a failure when that code is reached. This will ALWAYS be executed, even in release builds, therefore might crash the
 /// application (or trigger a debug break).
-#define EZ_REPORT_FAILURE(szErrorMsg, ...)                                                                       \
-  do                                                                                                             \
-  {                                                                                                              \
-    if (ezFailedCheck(EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, "", ezFmt(szErrorMsg, ##__VA_ARGS__))) \
-      EZ_DEBUG_BREAK;                                                                                            \
-  } while (false)
+#  define EZ_REPORT_FAILURE(szErrorMsg, ...)                                                                       \
+    do                                                                                                             \
+    {                                                                                                              \
+      if (ezFailedCheck(EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, "", ezFmt(szErrorMsg, ##__VA_ARGS__))) \
+        EZ_DEBUG_BREAK;                                                                                            \
+    } while (false)
+#endif
 
+#ifdef BUILDSYSTEM_CLANG_TIDY
+#  define EZ_ASSERT_ALWAYS(bCondition, szErrorMsg, ...) \
+    do                                                  \
+    {                                                   \
+      if (!!(bCondition) == false)                      \
+        ClangTidyDoNotReturn();                         \
+    } while (false)
+#else
 /// \brief Macro to raise an error, if a condition is not met. Allows to write a message using printf style. This assert will be triggered, even in
 /// non-development builds and cannot be deactivated.
-#define EZ_ASSERT_ALWAYS(bCondition, szErrorMsg, ...)                                                                       \
-  do                                                                                                                        \
-  {                                                                                                                         \
-    EZ_MSVC_ANALYSIS_WARNING_PUSH                                                                                           \
-    EZ_MSVC_ANALYSIS_WARNING_DISABLE(6326) /* disable static analysis for the comparison */                                 \
-    if (!!(bCondition) == false)                                                                                            \
-    {                                                                                                                       \
-      if (ezFailedCheck(EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, #bCondition, ezFmt(szErrorMsg, ##__VA_ARGS__))) \
-        EZ_DEBUG_BREAK;                                                                                                     \
-    }                                                                                                                       \
-    EZ_MSVC_ANALYSIS_WARNING_POP                                                                                            \
-  } while (false)
+#  define EZ_ASSERT_ALWAYS(bCondition, szErrorMsg, ...)                                                                       \
+    do                                                                                                                        \
+    {                                                                                                                         \
+      EZ_MSVC_ANALYSIS_WARNING_PUSH                                                                                           \
+      EZ_MSVC_ANALYSIS_WARNING_DISABLE(6326) /* disable static analysis for the comparison */                                 \
+      if (!!(bCondition) == false)                                                                                            \
+      {                                                                                                                       \
+        if (ezFailedCheck(EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, #bCondition, ezFmt(szErrorMsg, ##__VA_ARGS__))) \
+          EZ_DEBUG_BREAK;                                                                                                     \
+      }                                                                                                                       \
+      EZ_MSVC_ANALYSIS_WARNING_POP                                                                                            \
+    } while (false)
+#endif
 
 /// \brief This type of assert can be used to mark code as 'not (yet) implemented' and makes it easier to find it later on by just searching for these
 /// asserts.

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionParser.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionParser.cpp
@@ -404,6 +404,7 @@ ezExpressionAST::Node* ezExpressionParser::ParseFactor()
       if (pVariable == nullptr)
       {
         ReportError(pIdentifierToken, ezFmt("Undeclared identifier '{}'", sIdentifier));
+        return nullptr;
       }
       return ParseSwizzle(Unpack(pVariable));
     }
@@ -680,7 +681,7 @@ ezExpressionAST::Node* ezExpressionParser::GetVariable(ezStringView sVarName)
   ezHashedString sHashedVarName;
   sHashedVarName.Assign(sVarName);
 
-  ezExpressionAST::Node* pVariableNode;
+  ezExpressionAST::Node* pVariableNode = nullptr;
   if (m_KnownVariables.TryGetValue(sHashedVarName, pVariableNode) == false && m_Options.m_bTreatUnknownVariablesAsInputs)
   {
     pVariableNode = m_pAST->CreateInput({sHashedVarName, ezProcessingStream::DataType::Float});

--- a/Code/Engine/Foundation/Containers/Implementation/HashTable_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/HashTable_inl.h
@@ -444,6 +444,7 @@ inline bool ezHashTableBase<K, V, H>::TryGetValue(const CompatibleKeyType& key, 
   ezUInt32 uiIndex = FindEntry(key);
   if (uiIndex != ezInvalidIndex)
   {
+    EZ_ASSERT_DEBUG(m_pEntries != nullptr, "No entries present"); // To fix static analysis
     out_value = m_pEntries[uiIndex].value;
     return true;
   }

--- a/Code/Engine/Foundation/Containers/Map.h
+++ b/Code/Engine/Foundation/Containers/Map.h
@@ -306,17 +306,17 @@ private:
   /// \brief Root node of the tree.
   Node* m_pRoot;
 
+  /// \brief Stack of recently discarded nodes to quickly acquire new nodes.
+  Node* m_pFreeElementStack;
+
   /// \brief Sentinel node.
   NilNode m_NilNode;
-
-  /// \brief Number of active nodes in the tree.
-  ezUInt32 m_uiCount;
 
   /// \brief Data store. Keeps all the nodes.
   ezDeque<Node, ezNullAllocatorWrapper, false> m_Elements;
 
-  /// \brief Stack of recently discarded nodes to quickly acquire new nodes.
-  Node* m_pFreeElementStack;
+  /// \brief Number of active nodes in the tree.
+  ezUInt32 m_uiCount;
 
   /// \brief Comparer object
   Comparer m_Comparer;

--- a/Code/Engine/Foundation/IO/CompressedStreamZstd.h
+++ b/Code/Engine/Foundation/IO/CompressedStreamZstd.h
@@ -58,7 +58,7 @@ private:
 /// compression ratio and it should only be used to reduce output lag. However, there is absolutely no guarantee that all the data that was
 /// put into the stream will be readable from the output stream, after calling Flush(). In fact, it is quite likely that a large amount of
 /// data has still not been written to it, because it is still inside the compressor.
-class EZ_FOUNDATION_DLL ezCompressedStreamWriterZstd : public ezStreamWriter
+class EZ_FOUNDATION_DLL ezCompressedStreamWriterZstd final : public ezStreamWriter
 {
 public:
   /// \brief Specifies the compression level of the stream.

--- a/Code/Engine/Foundation/IO/FileSystem/Implementation/DeferredFileWriter.cpp
+++ b/Code/Engine/Foundation/IO/FileSystem/Implementation/DeferredFileWriter.cpp
@@ -44,8 +44,6 @@ ezResult ezDeferredFileWriter::Close(bool* out_pWasWrittenTo /*= nullptr*/)
       ezUInt8 tmp1[1024 * 4];
       ezUInt8 tmp2[1024 * 4];
 
-      ezUInt64 readLeft = m_Storage.GetStorageSize64();
-
       ezMemoryStreamReader storageReader(&m_Storage);
 
       while (true)

--- a/Code/Engine/Foundation/IO/MemoryStream.h
+++ b/Code/Engine/Foundation/IO/MemoryStream.h
@@ -157,7 +157,7 @@ public:
 /// To grow, additional chunks of data are allocated. No memory ever needs to be copied to grow the container.
 /// However, that also means that the memory isn't stored in one contiguous array, therefore data has to be accessed piece-wise
 /// through GetContiguousMemoryRange().
-class EZ_FOUNDATION_DLL ezDefaultMemoryStreamStorage : public ezMemoryStreamStorageInterface
+class EZ_FOUNDATION_DLL ezDefaultMemoryStreamStorage final : public ezMemoryStreamStorageInterface
 {
 public:
   ezDefaultMemoryStreamStorage(ezUInt32 uiInitialCapacity = 0, ezAllocatorBase* pAllocator = ezFoundation::GetDefaultAllocator());

--- a/Code/Engine/Foundation/Strings/Implementation/snprintf.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/snprintf.cpp
@@ -319,7 +319,7 @@ static void OutputReverseString(char* szOutputBuffer, unsigned int uiBufferSize,
   {
     --iStringLength;
 
-    OutputChar(szOutputBuffer, uiBufferSize, ref_uiWritePos, szString[iStringLength]);
+    OutputChar(szOutputBuffer, uiBufferSize, ref_uiWritePos, szString[iStringLength]); // NOLINT: False positive from clang-tidy
   }
 }
 

--- a/Code/Engine/Foundation/Time/Implementation/Timestamp.cpp
+++ b/Code/Engine/Foundation/Time/Implementation/Timestamp.cpp
@@ -226,7 +226,7 @@ ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezArgDateTime& ar
 
     if ((arg.m_uiFormattingFlags & ezArgDateTime::ShowTimeZone) == ezArgDateTime::ShowTimeZone)
     {
-      offset += ezStringUtils::snprintf(szTmp + offset, uiLength - offset, " (UTC)");
+      ezStringUtils::snprintf(szTmp + offset, uiLength - offset, " (UTC)");
     }
   }
 

--- a/Code/Engine/Foundation/Types/Implementation/Variant_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/Variant_inl.h
@@ -397,7 +397,7 @@ T ezVariant::ConvertTo(ezResult* out_pConversionStatus /* = nullptr*/) const
     return Cast<T>();
   }
 
-  T result;
+  T result = {};
   bool bSuccessful = true;
   ezVariantHelper::To(*this, result, bSuccessful);
 

--- a/Code/Engine/Foundation/Utilities/Implementation/ConversionUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/ConversionUtils.cpp
@@ -852,6 +852,17 @@ namespace ezConversionUtils
 
     const ezUInt32 uiLen = sColorName.GetElementCount();
 
+    auto twoCharsToByte = [](const char* szColorChars, ezUInt8& out_uiByte) -> ezResult {
+      ezInt8 firstChar = HexCharacterToIntValue(szColorChars[0]);
+      ezInt8 secondChar = HexCharacterToIntValue(szColorChars[1]);
+      if (firstChar < 0 || secondChar < 0)
+      {
+        return EZ_FAILURE;
+      }
+      out_uiByte = (static_cast<ezUInt8>(firstChar) << 4) | static_cast<ezUInt8>(secondChar);
+      return EZ_SUCCESS;
+    };
+
     if (sColorName.StartsWith("#"))
     {
       if (uiLen == 7 || uiLen == 9) // #RRGGBB or #RRGGBBAA
@@ -860,12 +871,18 @@ namespace ezConversionUtils
 
         const char* szColorName = sColorName.GetStartPointer();
 
-        cv[0] = static_cast<ezUInt8>((HexCharacterToIntValue(*(szColorName + 1)) << 4) | HexCharacterToIntValue(*(szColorName + 2)));
-        cv[1] = static_cast<ezUInt8>((HexCharacterToIntValue(*(szColorName + 3)) << 4) | HexCharacterToIntValue(*(szColorName + 4)));
-        cv[2] = static_cast<ezUInt8>((HexCharacterToIntValue(*(szColorName + 5)) << 4) | HexCharacterToIntValue(*(szColorName + 6)));
+        if (twoCharsToByte(szColorName + 1, cv[0]).Failed())
+          return ezColor::Black;
+        if (twoCharsToByte(szColorName + 3, cv[1]).Failed())
+          return ezColor::Black;
+        if (twoCharsToByte(szColorName + 5, cv[2]).Failed())
+          return ezColor::Black;
 
         if (uiLen == 9)
-          cv[3] = static_cast<ezUInt8>((HexCharacterToIntValue(*(szColorName + 7)) << 4) | HexCharacterToIntValue(*(szColorName + 8)));
+        {
+          if (twoCharsToByte(szColorName + 7, cv[3]).Failed())
+            return ezColor::Black;
+        }
 
         if (out_pValidColorName)
           *out_pValidColorName = true;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -78,7 +78,9 @@ void ezGameApplication::Init_SetupDefaultResources()
   {
     ezShaderResourceDescriptor desc;
     ezShaderResourceHandle hFallbackShader = ezResourceManager::CreateResource<ezShaderResource>("FallbackShaderResource", std::move(desc), "FallbackShaderResource");
-    ezShaderResourceHandle hMissingShader = ezResourceManager::CreateResource<ezShaderResource>("MissingShaderResource", std::move(desc), "MissingShaderResource");
+
+    ezShaderResourceDescriptor desc2;
+    ezShaderResourceHandle hMissingShader = ezResourceManager::CreateResource<ezShaderResource>("MissingShaderResource", std::move(desc2), "MissingShaderResource");
 
     ezResourceManager::SetResourceTypeLoadingFallback<ezShaderResource>(hFallbackShader);
     ezResourceManager::SetResourceTypeMissingFallback<ezShaderResource>(hMissingShader);

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -202,7 +202,6 @@ void ezGameState::SetupMainView(ezGALSwapChainHandle hSwapChain, ezSizeU32 viewp
   if (m_bXREnabled)
   {
     const ezXRConfig* pConfig = ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetTypeConfig<ezXRConfig>();
-    ezXRInterface* pXRInterface = ezSingletonRegistry::GetSingletonInstance<ezXRInterface>();
 
     auto renderPipeline = ezResourceManager::LoadResource<ezRenderPipelineResource>(pConfig->m_sXRRenderPipeline);
     pView->SetRenderPipelineResource(renderPipeline);

--- a/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
@@ -172,7 +172,8 @@ void ezBlackboardComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezBlackboardComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  EZ_IGNORE_UNUSED(uiVersion);
 
   ezStreamReader& s = inout_stream.GetStream();
 

--- a/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
@@ -172,7 +172,7 @@ void ezBlackboardComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezBlackboardComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
 
   ezStreamReader& s = inout_stream.GetStream();
 

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachine.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachine.cpp
@@ -49,7 +49,7 @@ ezResult ezStateMachineState::Serialize(ezStreamWriter& inout_stream) const
 
 ezResult ezStateMachineState::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
 
   inout_stream >> m_sName;
   return EZ_SUCCESS;

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachine.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachine.cpp
@@ -49,7 +49,7 @@ ezResult ezStateMachineState::Serialize(ezStreamWriter& inout_stream) const
 
 ezResult ezStateMachineState::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  // const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
 
   inout_stream >> m_sName;
   return EZ_SUCCESS;

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
@@ -84,7 +84,7 @@ ezResult ezStateMachineState_NestedStateMachine::Serialize(ezStreamWriter& inout
 ezResult ezStateMachineState_NestedStateMachine::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
 
   inout_stream >> m_hResource;
   inout_stream >> m_sInitialState;
@@ -213,7 +213,7 @@ ezResult ezStateMachineState_Compound::Serialize(ezStreamWriter& inout_stream) c
 ezResult ezStateMachineState_Compound::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
 
   ezUInt32 uiNumSubStates = 0;
   inout_stream >> uiNumSubStates;
@@ -410,7 +410,7 @@ ezResult ezStateMachineTransition_Compound::Serialize(ezStreamWriter& inout_stre
 ezResult ezStateMachineTransition_Compound::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
 
   inout_stream >> m_Operator;
 

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineBuiltins.cpp
@@ -84,7 +84,7 @@ ezResult ezStateMachineState_NestedStateMachine::Serialize(ezStreamWriter& inout
 ezResult ezStateMachineState_NestedStateMachine::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  // const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
 
   inout_stream >> m_hResource;
   inout_stream >> m_sInitialState;
@@ -213,7 +213,7 @@ ezResult ezStateMachineState_Compound::Serialize(ezStreamWriter& inout_stream) c
 ezResult ezStateMachineState_Compound::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  // const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
 
   ezUInt32 uiNumSubStates = 0;
   inout_stream >> uiNumSubStates;
@@ -410,7 +410,7 @@ ezResult ezStateMachineTransition_Compound::Serialize(ezStreamWriter& inout_stre
 ezResult ezStateMachineTransition_Compound::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
-  const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  // const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
 
   inout_stream >> m_Operator;
 

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineState_Script.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineState_Script.cpp
@@ -234,8 +234,8 @@ const ezRangeView<const char*, ezUInt32> ezStateMachineState_Script::GetParamete
 {
   return ezRangeView<const char*, ezUInt32>([]() -> ezUInt32 { return 0; },
     [this]() -> ezUInt32 { return m_Parameters.GetCount(); },
-    [](ezUInt32& it) { ++it; },
-    [this](const ezUInt32& it) -> const char* { return m_Parameters.GetKey(it).GetString().GetData(); });
+    [](ezUInt32& ref_uiIt) { ++ref_uiIt; },
+    [this](const ezUInt32& uiIt) -> const char* { return m_Parameters.GetKey(uiIt).GetString().GetData(); });
 }
 
 void ezStateMachineState_Script::SetParameter(const char* szKey, const ezVariant& value)

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/DebugAnimNodes.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/DebugAnimNodes.cpp
@@ -47,7 +47,8 @@ ezResult ezLogAnimNode::SerializeNode(ezStreamWriter& stream) const
 
 ezResult ezLogAnimNode::DeserializeNode(ezStreamReader& stream)
 {
-  const auto version = stream.ReadVersion(1); // NOLINT: ignore dead store warning
+  const auto version = stream.ReadVersion(1);
+  EZ_IGNORE_UNUSED(version);
 
   EZ_SUCCEED_OR_RETURN(SUPER::DeserializeNode(stream));
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/DebugAnimNodes.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/DebugAnimNodes.cpp
@@ -47,7 +47,7 @@ ezResult ezLogAnimNode::SerializeNode(ezStreamWriter& stream) const
 
 ezResult ezLogAnimNode::DeserializeNode(ezStreamReader& stream)
 {
-  const auto version = stream.ReadVersion(1);
+  const auto version = stream.ReadVersion(1); // NOLINT: ignore dead store warning
 
   EZ_SUCCEED_OR_RETURN(SUPER::DeserializeNode(stream));
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips1DAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips1DAnimNode.cpp
@@ -94,7 +94,7 @@ ezResult ezMixClips1DAnimNode::SerializeNode(ezStreamWriter& stream) const
 
 ezResult ezMixClips1DAnimNode::DeserializeNode(ezStreamReader& stream)
 {
-  const auto version = stream.ReadVersion(1);
+  const auto version = stream.ReadVersion(1); // NOLINT: ignore dead store warning
 
   EZ_SUCCEED_OR_RETURN(SUPER::DeserializeNode(stream));
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips1DAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips1DAnimNode.cpp
@@ -94,7 +94,8 @@ ezResult ezMixClips1DAnimNode::SerializeNode(ezStreamWriter& stream) const
 
 ezResult ezMixClips1DAnimNode::DeserializeNode(ezStreamReader& stream)
 {
-  const auto version = stream.ReadVersion(1); // NOLINT: ignore dead store warning
+  const auto version = stream.ReadVersion(1);
+  EZ_IGNORE_UNUSED(version);
 
   EZ_SUCCEED_OR_RETURN(SUPER::DeserializeNode(stream));
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips2DAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips2DAnimNode.cpp
@@ -104,7 +104,7 @@ ezResult ezMixClips2DAnimNode::SerializeNode(ezStreamWriter& stream) const
 
 ezResult ezMixClips2DAnimNode::DeserializeNode(ezStreamReader& stream)
 {
-  const auto version = stream.ReadVersion(1);
+  const auto version = stream.ReadVersion(1); // NOLINT: ignore dead store warning
 
   EZ_SUCCEED_OR_RETURN(SUPER::DeserializeNode(stream));
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips2DAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/MixClips2DAnimNode.cpp
@@ -104,7 +104,8 @@ ezResult ezMixClips2DAnimNode::SerializeNode(ezStreamWriter& stream) const
 
 ezResult ezMixClips2DAnimNode::DeserializeNode(ezStreamReader& stream)
 {
-  const auto version = stream.ReadVersion(1); // NOLINT: ignore dead store warning
+  const auto version = stream.ReadVersion(1);
+  EZ_IGNORE_UNUSED(version);
 
   EZ_SUCCEED_OR_RETURN(SUPER::DeserializeNode(stream));
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/PlaySequenceAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/PlaySequenceAnimNode.cpp
@@ -331,8 +331,6 @@ void ezPlaySequenceAnimNode::Step(ezAnimGraph& graph, ezTime tDiff, const ezSkel
     return;
   }
 
-  ezAnimGraphPinDataLocalTransforms* pOutputTransform = graph.AddPinDataLocalTransforms();
-
   void* pThis = this;
   auto& cmd = graph.GetPoseGenerator().AllocCommandSampleTrack(ezHashingUtils::xxHash32(&pThis, sizeof(pThis)));
   cmd.m_hAnimationClip = hCurrentClip;

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
@@ -85,7 +85,7 @@ void ezSkeletonPoseComponent::SerializeComponent(ezWorldWriter& inout_stream) co
 void ezSkeletonPoseComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: Ignore dead store warning
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
@@ -85,7 +85,7 @@ void ezSkeletonPoseComponent::SerializeComponent(ezWorldWriter& inout_stream) co
 void ezSkeletonPoseComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: Ignore dead store warning
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakingInterface.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakingInterface.cpp
@@ -30,7 +30,7 @@ ezResult ezBakingSettings::Serialize(ezStreamWriter& inout_stream) const
 
 ezResult ezBakingSettings::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezTypeVersion version = inout_stream.ReadVersion(s_BakingSettingsVersion);
+  const ezTypeVersion version = inout_stream.ReadVersion(s_BakingSettingsVersion); // Ignore dead store warning
 
   inout_stream >> m_vProbeSpacing;
   inout_stream >> m_uiNumSamplesPerProbe;

--- a/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
@@ -149,9 +149,6 @@ void ezBeamComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
   if (!m_hMesh.IsValid() || !m_hMaterial.IsValid())
     return;
 
-  const ezUInt32 uiFlipWinding = GetOwner()->GetGlobalTransformSimd().ContainsNegativeScale() ? 1 : 0;
-  const ezUInt32 uiUniformScale = GetOwner()->GetGlobalTransformSimd().ContainsUniformScale() ? 1 : 0;
-
   ezMeshRenderData* pRenderData = ezCreateRenderDataForThisFrame<ezMeshRenderData>(GetOwner());
   {
     pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform();

--- a/Code/Engine/RendererCore/Components/Implementation/OccluderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/OccluderComponent.cpp
@@ -86,7 +86,7 @@ void ezOccluderComponent::SerializeComponent(ezWorldWriter& inout_stream) const
 void ezOccluderComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
   ezStreamReader& s = inout_stream.GetStream();
 
   s >> m_vExtents;

--- a/Code/Engine/RendererCore/Components/Implementation/OccluderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/OccluderComponent.cpp
@@ -86,7 +86,7 @@ void ezOccluderComponent::SerializeComponent(ezWorldWriter& inout_stream) const
 void ezOccluderComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   ezStreamReader& s = inout_stream.GetStream();
 
   s >> m_vExtents;

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -65,7 +65,7 @@ void ezRopeRenderComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezRopeRenderComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_Color;

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -30,7 +30,7 @@ namespace
     float fAspectRatio = view.GetViewport().width / view.GetViewport().height;
 
     ezMat4 mProj;
-    pCamera->GetProjectionMatrix(view.GetViewport().width / (float)view.GetViewport().height, mProj);
+    pCamera->GetProjectionMatrix(fAspectRatio, mProj);
 
     ezAngle fFovLeft;
     ezAngle fFovRight;

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
@@ -371,8 +371,6 @@ void ezReflectionProbeUpdater::AddViewToRender(const ProbeUpdateInfo::Step& step
     ezVec3(0.0f, 0.0f, 1.0f),
   };
 
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
-
   // Setup view and camera
   {
     ReflectionView* pReflectionView = nullptr;
@@ -399,7 +397,6 @@ void ezReflectionProbeUpdater::AddViewToRender(const ProbeUpdateInfo::Step& step
     ezGALRenderTargets renderTargets;
     if (step.m_UpdateStep == UpdateStep::Filter)
     {
-      const ezUInt32 uiWorldIndex = pWorld->GetIndex();
       renderTargets.m_hRTs[0] = updateInfo.m_TargetSlot.m_hSpecularOutputTexture;
 
       if (updateInfo.m_flags.IsSet(ezReflectionProbeUpdaterFlags::SkyLight))

--- a/Code/Engine/RendererCore/Lights/Implementation/SimplifiedDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SimplifiedDataExtractor.cpp
@@ -28,9 +28,6 @@ ezSimplifiedDataExtractor::~ezSimplifiedDataExtractor() = default;
 void ezSimplifiedDataExtractor::PostSortAndBatch(
   const ezView& view, const ezDynamicArray<const ezGameObject*>& visibleObjects, ezExtractedRenderData& ref_extractedRenderData)
 {
-  const ezCamera* pCamera = view.GetCullingCamera();
-  const float fAspectRatio = view.GetViewport().width / view.GetViewport().height;
-
   ezSimplifiedDataCPU* pData = EZ_NEW(ezFrameAllocator::GetCurrentAllocator(), ezSimplifiedDataCPU);
 
   pData->m_uiSkyIrradianceIndex = view.GetWorld()->GetIndex();

--- a/Code/Engine/RendererCore/Lights/Implementation/SimplifiedDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SimplifiedDataProvider.cpp
@@ -12,13 +12,11 @@ EZ_DEFINE_AS_POD_TYPE(ezSimplifiedDataConstants);
 
 ezSimplifiedDataGPU::ezSimplifiedDataGPU()
 {
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   m_hConstantBuffer = ezRenderContext::CreateConstantBufferStorage<ezSimplifiedDataConstants>();
 }
 
 ezSimplifiedDataGPU::~ezSimplifiedDataGPU()
 {
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   ezRenderContext::DeleteConstantBufferStorage(m_hConstantBuffer);
 }
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -63,7 +63,7 @@ void ezCustomMeshComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezCustomMeshComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   ezStreamReader& s = inout_stream.GetStream();
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -63,7 +63,7 @@ void ezCustomMeshComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezCustomMeshComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore dead store warning
 
   ezStreamReader& s = inout_stream.GetStream();
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshRenderer.cpp
@@ -39,7 +39,6 @@ void ezMeshRenderer::GetSupportedRenderDataCategories(ezHybridArray<ezRenderData
 
 void ezMeshRenderer::RenderBatch(const ezRenderViewContext& renderViewContext, const ezRenderPipelinePass* pPass, const ezRenderDataBatch& batch) const
 {
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   ezRenderContext* pContext = renderViewContext.m_pRenderContext;
 
   const ezMeshRenderData* pRenderData = batch.GetFirstData<ezMeshRenderData>();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaResolvePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaResolvePass.cpp
@@ -35,8 +35,6 @@ ezMsaaResolvePass::~ezMsaaResolvePass() = default;
 
 bool ezMsaaResolvePass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)
 {
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
-
   auto pInput = inputs[m_PinInput.m_uiInputIndex];
   if (pInput != nullptr)
   {

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaUpscalePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaUpscalePass.cpp
@@ -36,8 +36,6 @@ ezMsaaUpscalePass::~ezMsaaUpscalePass() = default;
 
 bool ezMsaaUpscalePass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)
 {
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
-
   auto pInput = inputs[m_PinInput.m_uiInputIndex];
   if (pInput != nullptr)
   {

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -601,13 +601,20 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
                                          ezRenderContextFlags::ConstantBufferBindingChanged)))
     {
       if (pShaderPermutation == nullptr)
+      {
         pShaderPermutation = ezResourceManager::BeginAcquireResource(m_hActiveShaderPermutation, ezResourceAcquireMode::BlockTillLoaded);
+      }
     }
 
     ezLogBlock applyBindingsBlock("Applying Shader Bindings", pShaderPermutation != nullptr ? pShaderPermutation->GetResourceDescription().GetData() : "");
 
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::UAVBindingChanged))
     {
+      if (pShaderPermutation == nullptr)
+      {
+        return EZ_FAILURE;
+      }
+
       // RWTextures/UAV are usually only supported in compute and pixel shader.
       if (auto pBin = pShaderPermutation->GetShaderStageBinary(ezGALShaderStage::ComputeShader))
       {
@@ -623,6 +630,11 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
 
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::TextureBindingChanged))
     {
+      if (pShaderPermutation == nullptr)
+      {
+        return EZ_FAILURE;
+      }
+
       for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
       {
         if (auto pBin = pShaderPermutation->GetShaderStageBinary((ezGALShaderStage::Enum)stage))
@@ -636,6 +648,11 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
 
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::SamplerBindingChanged))
     {
+      if (pShaderPermutation == nullptr)
+      {
+        return EZ_FAILURE;
+      }
+
       for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
       {
         if (auto pBin = pShaderPermutation->GetShaderStageBinary((ezGALShaderStage::Enum)stage))
@@ -649,6 +666,11 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
 
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::BufferBindingChanged))
     {
+      if (pShaderPermutation == nullptr)
+      {
+        return EZ_FAILURE;
+      }
+
       for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
       {
         if (auto pBin = pShaderPermutation->GetShaderStageBinary((ezGALShaderStage::Enum)stage))
@@ -670,6 +692,11 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
 
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::ConstantBufferBindingChanged))
     {
+      if (pShaderPermutation == nullptr)
+      {
+        return EZ_FAILURE;
+      }
+
       for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
       {
         if (auto pBin = pShaderPermutation->GetShaderStageBinary((ezGALShaderStage::Enum)stage))

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -399,7 +399,6 @@ ezResult ezShaderCompiler::RunShaderCompiler(const char* szFile, const char* szP
       {
         sProcessed[stage].Clear();
         spd.m_szShaderSource[stage] = m_StageSourceFile[stage];
-        uiSourceStringLen = m_StageSourceFile[stage].GetElementCount();
 
         ezLog::Error(pLog, "Shader preprocessing failed");
         return EZ_FAILURE;

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1376,7 +1376,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALTextureHandle hTexture(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALTexture* pTexture = nullptr;
 
-        m_Textures.Remove(hTexture, &pTexture);
+        EZ_VERIFY(m_Textures.Remove(hTexture, &pTexture), "Unexpected invalild texture handle");
 
         DestroyViews(pTexture);
         DestroyTexturePlatform(pTexture);
@@ -1464,7 +1464,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALVertexDeclarationHandle hVertexDeclaration(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALVertexDeclaration* pVertexDeclaration = nullptr;
 
-        m_VertexDeclarations.Remove(hVertexDeclaration, &pVertexDeclaration);
+        EZ_VERIFY(m_VertexDeclarations.Remove(hVertexDeclaration, &pVertexDeclaration), "Unexpected invalid handle");
         m_VertexDeclarationTable.Remove(pVertexDeclaration->GetDescription().CalculateHash());
 
         DestroyVertexDeclarationPlatform(pVertexDeclaration);

--- a/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
@@ -2058,7 +2058,7 @@ namespace
   {
   public:
     ezInt32 r, g, b;
-    ezInt32 pad;
+    ezInt32 pad = 0;
 
   public:
     BC6IntColor() = default;

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -105,8 +105,13 @@ ezUInt32 ezImageUtils::ComputeMeanSquareError(const ezImageView& differenceImage
 
   EZ_ASSERT_DEV(uiBlockSize > 1, "Blocksize must be at least 2");
 
+  ezUInt32 uiNumComponents = ezImageFormat::GetNumChannels(differenceImage.GetImageFormat());
+
   ezUInt32 uiWidth = ezMath::Min(differenceImage.GetWidth(), uiOffsetx + uiBlockSize) - uiOffsetx;
   ezUInt32 uiHeight = ezMath::Min(differenceImage.GetHeight(), uiOffsety + uiBlockSize) - uiOffsety;
+
+  // Treat image as single-component format and scale the width instead
+  uiWidth *= uiNumComponents;
 
   if (uiWidth == 0 || uiHeight == 0)
     return 0;
@@ -134,10 +139,6 @@ ezUInt32 ezImageUtils::ComputeMeanSquareError(const ezImageView& differenceImage
 
   ezUInt64 uiRowPitch = differenceImage.GetRowPitch();
   ezUInt64 uiDepthPitch = differenceImage.GetDepthPitch();
-  ezUInt32 uiNumComponents = ezImageFormat::GetNumChannels(differenceImage.GetImageFormat());
-
-  // Treat image as single-component format and scale the width instead
-  uiWidth *= uiNumComponents;
 
   const ezUInt32 uiSize2D = uiWidth * uiHeight;
   const ezUInt8* pSlicePointer = differenceImage.GetPixelPointer<ezUInt8>(0, 0, 0, uiOffsetx, uiOffsety);
@@ -657,6 +658,7 @@ inline static void FilterLine(
 static void DownScaleFastLine(ezUInt32 uiPixelStride, const ezUInt8* pSrc, ezUInt8* pDest, ezUInt32 uiLengthIn, ezUInt32 uiStrideIn, ezUInt32 uiLengthOut, ezUInt32 uiStrideOut)
 {
   const ezUInt32 downScaleFactor = uiLengthIn / uiLengthOut;
+  EZ_ASSERT_DEBUG(downScaleFactor >= 1, "Can't upscale");
 
   const ezUInt32 downScaleFactorLog2 = ezMath::Log2i(static_cast<ezUInt32>(downScaleFactor));
   const ezUInt32 roundOffset = downScaleFactor / 2;

--- a/Code/Engine/Texture/TexConv/Implementation/AutoUsage.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/AutoUsage.cpp
@@ -121,6 +121,7 @@ static ezTexConvUsage::Enum DetectUsageFromImage(const ezImage& image)
     ezUInt32 uiExtremeNormals = 0;
 
     ezUInt32 uiNumPixels = header.GetWidth() * header.GetHeight();
+    EZ_ASSERT_DEBUG(uiNumPixels > 0, "Unexpected empty image");
 
     // Sample no more than 10000 pixels
     ezUInt32 uiStride = ezMath::Max(1U, uiNumPixels / 10000);
@@ -141,9 +142,9 @@ static ezTexConvUsage::Enum DetectUsageFromImage(const ezImage& image)
     }
 
     // the average color in the image
-    sr /= uiNumPixels;
-    sg /= uiNumPixels;
-    sb /= uiNumPixels;
+    sr /= uiNumPixels; // NOLINT: not a division by zero
+    sg /= uiNumPixels; // NOLINT: not a division by zero
+    sb /= uiNumPixels; // NOLINT: not a division by zero
 
     if (sb < 230 || sr < 128 - 60 || sr > 128 + 60 || sg < 128 - 60 || sg > 128 + 60)
     {

--- a/Code/EnginePlugins/FileservePlugin/FileservePlugin.cpp
+++ b/Code/EnginePlugins/FileservePlugin/FileservePlugin.cpp
@@ -21,7 +21,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(FileservePlugin, FileservePluginMain)
 
     if (fs == nullptr)
     {
-      fs = EZ_DEFAULT_NEW(ezFileserveClient);
+      fs = EZ_DEFAULT_NEW(ezFileserveClient); // NOLINT: fs wil be used if EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS is active
 
       // on sandboxed platforms we must go through fileserve, so we enforce a fileserve connection
       // on unrestricted platforms, we use fileserve, if a connection can be established,

--- a/Code/EnginePlugins/FileservePlugin/FileservePlugin.cpp
+++ b/Code/EnginePlugins/FileservePlugin/FileservePlugin.cpp
@@ -21,7 +21,8 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(FileservePlugin, FileservePluginMain)
 
     if (fs == nullptr)
     {
-      fs = EZ_DEFAULT_NEW(ezFileserveClient); // NOLINT: fs wil be used if EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS is active
+      fs = EZ_DEFAULT_NEW(ezFileserveClient);
+      EZ_IGNORE_UNUSED(fs);
 
       // on sandboxed platforms we must go through fileserve, so we enforce a fileserve connection
       // on unrestricted platforms, we use fileserve, if a connection can be established,

--- a/Code/EnginePlugins/FmodPlugin/FmodSingleton.cpp
+++ b/Code/EnginePlugins/FmodPlugin/FmodSingleton.cpp
@@ -99,10 +99,10 @@ void ezFmod::Startup()
   {
 #  if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     // mutex handle will be closed automatically on process termination
-    DWORD err = GetLastError();
+    GetLastError(); // clear any pending error codes
     g_hLiveUpdateMutex = CreateMutexW(nullptr, TRUE, L"ezFmodLiveUpdate");
 
-    err = GetLastError();
+    DWORD err = GetLastError();
     if (g_hLiveUpdateMutex != NULL && err != ERROR_ALREADY_EXISTS)
     {
       studioflags |= FMOD_STUDIO_INIT_LIVEUPDATE;

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Shake/Implementation/CameraShakeVolumeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Shake/Implementation/CameraShakeVolumeComponent.cpp
@@ -78,7 +78,7 @@ void ezCameraShakeVolumeComponent::SerializeComponent(ezWorldWriter& inout_strea
 void ezCameraShakeVolumeComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
   auto& s = inout_stream.GetStream();
 
   s >> m_BurstDuration;
@@ -153,7 +153,7 @@ void ezCameraShakeVolumeSphereComponent::SerializeComponent(ezWorldWriter& inout
 void ezCameraShakeVolumeSphereComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
   auto& s = inout_stream.GetStream();
 
   s >> m_fRadius;

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Shake/Implementation/CameraShakeVolumeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Shake/Implementation/CameraShakeVolumeComponent.cpp
@@ -78,7 +78,7 @@ void ezCameraShakeVolumeComponent::SerializeComponent(ezWorldWriter& inout_strea
 void ezCameraShakeVolumeComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_BurstDuration;
@@ -153,7 +153,7 @@ void ezCameraShakeVolumeSphereComponent::SerializeComponent(ezWorldWriter& inout
 void ezCameraShakeVolumeSphereComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); 
   auto& s = inout_stream.GetStream();
 
   s >> m_fRadius;

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Shake/Implementation/CameraShakeVolumeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Shake/Implementation/CameraShakeVolumeComponent.cpp
@@ -153,7 +153,7 @@ void ezCameraShakeVolumeSphereComponent::SerializeComponent(ezWorldWriter& inout
 void ezCameraShakeVolumeSphereComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); 
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_fRadius;

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -110,7 +110,7 @@ void ezClothSheetComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezClothSheetComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_vSize;

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -110,7 +110,7 @@ void ezClothSheetComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 void ezClothSheetComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
   auto& s = inout_stream.GetStream();
 
   s >> m_vSize;
@@ -492,7 +492,6 @@ void ezClothSheetRenderer::RenderBatch(const ezRenderViewContext& renderViewCont
 
 
   ezRenderContext* pRenderContext = renderViewContext.m_pRenderContext;
-  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   ezGALCommandEncoder* pGALCommandEncoder = pRenderContext->GetCommandEncoder();
 
   ezInstanceData* pInstanceData = pPass->GetPipeline()->GetFrameDataProvider<ezInstanceDataProvider>()->GetData(renderViewContext);

--- a/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
@@ -376,7 +376,6 @@ void ezHeightfieldComponent::BuildGeometry(ezGeometry& geom) const
 
   const ezUInt32 uiNumVerticesX = ezMath::Clamp(m_vColMeshTesselation.x + 1u, 5u, 512u);
   const ezUInt32 uiNumVerticesY = ezMath::Clamp(m_vColMeshTesselation.y + 1u, 5u, 512u);
-  const ezUInt32 uiNumTriangles = (uiNumVerticesX - 1) * (uiNumVerticesY - 1) * 2;
 
   const ezVec3 vSize(m_vHalfExtents.x * 2, m_vHalfExtents.y * 2, m_fHeight);
   const ezVec2 vToNDC = ezVec2(1.0f / (uiNumVerticesX - 1), 1.0f / (uiNumVerticesY - 1));

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltActorComponent.cpp
@@ -56,7 +56,7 @@ void ezJoltActorComponent::SerializeComponent(ezWorldWriter& inout_stream) const
 void ezJoltActorComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltActorComponent.cpp
@@ -56,7 +56,7 @@ void ezJoltActorComponent::SerializeComponent(ezWorldWriter& inout_stream) const
 void ezJoltActorComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -71,7 +71,7 @@ void ezJoltQueryShapeActorComponent::SerializeComponent(ezWorldWriter& inout_str
 void ezJoltQueryShapeActorComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -71,7 +71,7 @@ void ezJoltQueryShapeActorComponent::SerializeComponent(ezWorldWriter& inout_str
 void ezJoltQueryShapeActorComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
@@ -59,7 +59,7 @@ void ezJoltStaticActorComponent::SerializeComponent(ezWorldWriter& inout_stream)
 void ezJoltStaticActorComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
@@ -59,7 +59,7 @@ void ezJoltStaticActorComponent::SerializeComponent(ezWorldWriter& inout_stream)
 void ezJoltStaticActorComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOLINT: ignore unused variable
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltTriggerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltTriggerComponent.cpp
@@ -67,7 +67,7 @@ void ezJoltTriggerComponent::SerializeComponent(ezWorldWriter& inout_stream) con
 void ezJoltTriggerComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI()); // NOINT: ignore unused variable
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -69,7 +69,7 @@ void ezJoltCharacterControllerComponent::SerializeComponent(ezWorldWriter& inout
 void ezJoltCharacterControllerComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_DebugFlags;
@@ -572,7 +572,6 @@ void ezJoltCharacterControllerComponent::CreatePresenceBody()
 
   auto* pSystem = pModule->GetJoltSystem();
   auto* pBodies = &pSystem->GetBodyInterface();
-  auto* pMaterial = ezJoltCore::GetDefaultMaterial();
 
   JPH::BodyCreationSettings bodyCfg;
   bodyCfg.SetShape(m_pCharacter->GetShape());

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -113,7 +113,7 @@ void ezJoltDefaultCharacterComponent::SerializeComponent(ezWorldWriter& inout_st
 void ezJoltDefaultCharacterComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_RotateSpeed;
@@ -405,13 +405,10 @@ void ezJoltDefaultCharacterComponent::DebugVisualizations()
         break;
     }
 
-    const ezTransform newTransform = GetOwner()->GetGlobalTransform();
-    const float fDistTraveled = (m_PreviousTransform.m_vPosition - newTransform.m_vPosition).GetLength();
-    const float fSpeedTraveled = fDistTraveled * GetInverseUpdateTimeDelta();
-
-    const float fDistTraveledLateral = (m_PreviousTransform.m_vPosition.GetAsVec2() - newTransform.m_vPosition.GetAsVec2()).GetLength();
-    const float fSpeedTraveledLateral = fDistTraveled * GetInverseUpdateTimeDelta();
-
+    // const ezTransform newTransform = GetOwner()->GetGlobalTransform();
+    // const float fDistTraveled = (m_PreviousTransform.m_vPosition - newTransform.m_vPosition).GetLength();
+    // const float fSpeedTraveled = fDistTraveled * GetInverseUpdateTimeDelta();
+    // const float fSpeedTraveledLateral = fDistTraveled * GetInverseUpdateTimeDelta();
     // ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugRenderer::ScreenPlacement::TopLeft, "JCC", ezFmt("Speed 1: {} m/s", fSpeedTraveled), ezColor::WhiteSmoke);
     // ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugRenderer::ScreenPlacement::TopLeft, "JCC", ezFmt("Speed 2: {} m/s", fSpeedTraveledLateral), ezColor::WhiteSmoke);
   }

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltBoneColliderComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltBoneColliderComponent.cpp
@@ -56,7 +56,7 @@ void ezJoltBoneColliderComponent::SerializeComponent(ezWorldWriter& inout_stream
 void ezJoltBoneColliderComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   s >> m_bQueryShapeOnly;
@@ -197,14 +197,11 @@ void ezJoltBoneColliderComponent::CreatePhysicsShapes(const ezSkeletonResourceHa
     shape.m_qOffsetRot = qFinalBoneRot * geo.m_Transform.m_qRotation;
 
 
-    ezJoltShapeComponent* pShape = nullptr;
-
     if (geo.m_Type == ezSkeletonJointGeometryType::Sphere)
     {
       ezJoltShapeSphereComponent* pShapeComp = nullptr;
       ezJoltShapeSphereComponent::CreateComponent(pGO, pShapeComp);
       pShapeComp->SetRadius(geo.m_Transform.m_vScale.z);
-      pShape = pShapeComp;
     }
     else if (geo.m_Type == ezSkeletonJointGeometryType::Box)
     {
@@ -219,7 +216,6 @@ void ezJoltBoneColliderComponent::CreatePhysicsShapes(const ezSkeletonResourceHa
       ezJoltShapeBoxComponent* pShapeComp = nullptr;
       ezJoltShapeBoxComponent::CreateComponent(pGO, pShapeComp);
       pShapeComp->SetHalfExtents(ext * 0.5f);
-      pShape = pShapeComp;
     }
     else if (geo.m_Type == ezSkeletonJointGeometryType::Capsule)
     {
@@ -232,7 +228,6 @@ void ezJoltBoneColliderComponent::CreatePhysicsShapes(const ezSkeletonResourceHa
       ezJoltShapeCapsuleComponent::CreateComponent(pGO, pShapeComp);
       pShapeComp->SetRadius(geo.m_Transform.m_vScale.z);
       pShapeComp->SetHeight(geo.m_Transform.m_vScale.x);
-      pShape = pShapeComp;
     }
     else
     {

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
@@ -155,7 +155,7 @@ void ezJoltRagdollComponent::SerializeComponent(ezWorldWriter& inout_stream) con
 void ezJoltRagdollComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   if (uiVersion < 2)

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
@@ -155,7 +155,7 @@ void ezJoltRagdollComponent::SerializeComponent(ezWorldWriter& inout_stream) con
 void ezJoltRagdollComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
   auto& s = inout_stream.GetStream();
 
   if (uiVersion < 2)
@@ -517,6 +517,7 @@ void ezJoltRagdollComponent::RetrieveRagdollPose()
     }
 
     const JPH::BodyID bodyId = m_pRagdoll->GetBodyID(m_Limbs[uiLimbIdx].m_uiPartIndex);
+    EZ_ASSERT_DEBUG(!bodyId.IsInvalid(), "Invalid limb -> body mapping");
     JPH::BodyLockRead bodyRead(pModule->GetJoltSystem()->GetBodyLockInterface(), bodyId);
 
     const ezTransform limbGlobalPose = ezJoltConversionUtils::ToTransform(bodyRead.GetBody().GetPosition(), bodyRead.GetBody().GetRotation());
@@ -939,7 +940,7 @@ void ezJoltRagdollComponent::SetupLimbJoints(const ezSkeletonResource* pSkeleton
 
   // the main direction of Jolt bones is +X (for bone limits and such)
   // therefore the main direction of the source bones has to be adjusted
-  const ezQuat qBoneDirAdjustment = -ezBasisAxis::GetBasisRotation(srcBoneDir, ezBasisAxis::PositiveX);
+  // const ezQuat qBoneDirAdjustment = -ezBasisAxis::GetBasisRotation(srcBoneDir, ezBasisAxis::PositiveX);
 
   const auto& skeleton = pSkeleton->GetDescriptor().m_Skeleton;
 

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
@@ -208,8 +208,6 @@ void ezJoltRopeComponent::CreateRope()
   if (hAnchor1 == hAnchor2)
     return;
 
-  const ezTransform tRoot = GetOwner()->GetGlobalTransform();
-
   ezHybridArray<ezTransform, 65> nodes;
   float fPieceLength;
   if (CreateSegmentTransforms(nodes, fPieceLength, hAnchor1, hAnchor2).Failed())
@@ -968,9 +966,6 @@ void ezJoltRopeComponent::SetAnchor2ConstraintMode(ezEnum<ezJoltRopeAnchorConstr
 
 void ezJoltRopeComponent::OnJoltMsgDisconnectConstraints(ezJoltMsgDisconnectConstraints& ref_msg)
 {
-  ezGameObjectHandle hBody = ref_msg.m_pActor->GetOwner()->GetHandle();
-  ezWorld* pWorld = GetWorld();
-
   if (m_pConstraintAnchor1 && ref_msg.m_uiJoltBodyID == m_uiAnchor1BodyID)
   {
     ezJoltWorldModule* pModule = GetWorld()->GetOrCreateModule<ezJoltWorldModule>();
@@ -1033,7 +1028,6 @@ void ezJoltRopeComponentManager::Update(const ezWorldModule::UpdateContext& cont
   }
 
   ezJoltWorldModule* pModule = GetWorld()->GetOrCreateModule<ezJoltWorldModule>();
-  auto* pSystem = pModule->GetJoltSystem();
 
   for (auto itActor : pModule->GetActiveRopes())
   {

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltSettingsComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltSettingsComponent.cpp
@@ -46,7 +46,7 @@ void ezJoltSettingsComponent::SerializeComponent(ezWorldWriter& inout_stream) co
 void ezJoltSettingsComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
@@ -46,7 +46,7 @@ void ezJoltVisColMeshComponent::SerializeComponent(ezWorldWriter& inout_stream) 
 void ezJoltVisColMeshComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltConeConstraintComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltConeConstraintComponent.cpp
@@ -37,7 +37,7 @@ void ezJoltConeConstraintComponent::SerializeComponent(ezWorldWriter& inout_stre
 void ezJoltConeConstraintComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 

--- a/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltConstraintComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltConstraintComponent.cpp
@@ -214,7 +214,7 @@ void ezJoltConstraintComponent::SerializeComponent(ezWorldWriter& inout_stream) 
 void ezJoltConstraintComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  // const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
 
   auto& s = inout_stream.GetStream();
@@ -346,6 +346,13 @@ ezResult ezJoltConstraintComponent::FindParentBody(ezUInt32& out_uiJoltBodyID, e
         break;
 
       pObject = pObject->GetParent();
+    }
+
+    if (pObject == nullptr)
+    {
+      ezLog::Error("{0} '{1}' couldn't find ezJoltDynamicActorComponent in hierarchy. Constraint is ignored.", GetDynamicRTTI()->GetTypeName(),
+        GetOwner()->GetName());
+      return EZ_FAILURE;
     }
 
     if (pRbComp == nullptr)

--- a/Code/EnginePlugins/TypeScriptPlugin/Resources/TypeScriptResource.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/Resources/TypeScriptResource.cpp
@@ -23,7 +23,7 @@ namespace
     virtual const ezRTTI* GetArgumentType(ezUInt32 uiParamIndex) const override { return nullptr; }
     virtual ezBitflags<ezPropertyFlags> GetArgumentFlags(ezUInt32 uiParamIndex) const override { return ezPropertyFlags::Void; }
 
-    virtual void Execute(void* pInstance, ezArrayPtr<ezVariant> arguments, ezVariant& returnValue) const override
+    virtual void Execute(void* pInstance, ezArrayPtr<ezVariant> arguments, ezVariant& ref_returnValue) const override
     {
       auto pTypeScriptInstance = static_cast<ezTypeScriptInstance*>(pInstance);
       ezTypeScriptBinding& binding = pTypeScriptInstance->GetBinding();
@@ -53,9 +53,9 @@ namespace
 
 //////////////////////////////////////////////////////////////////////////
 
-ezTypeScriptInstance::ezTypeScriptInstance(ezComponent& owner, ezTypeScriptBinding& binding)
-  : m_Binding(binding)
-  , m_Component(owner)
+ezTypeScriptInstance::ezTypeScriptInstance(ezComponent& in_owner, ezTypeScriptBinding& ref_binding)
+  : m_Binding(ref_binding)
+  , m_Component(in_owner)
 {
 }
 

--- a/Code/EnginePlugins/TypeScriptPlugin/Resources/TypeScriptResource.h
+++ b/Code/EnginePlugins/TypeScriptPlugin/Resources/TypeScriptResource.h
@@ -9,7 +9,7 @@ class ezTypeScriptBinding;
 class EZ_TYPESCRIPTPLUGIN_DLL ezTypeScriptInstance : public ezScriptInstance
 {
 public:
-  ezTypeScriptInstance(ezComponent& owner, ezTypeScriptBinding& binding);
+  ezTypeScriptInstance(ezComponent& in_owner, ezTypeScriptBinding& ref_binding);
 
   virtual void ApplyParameters(const ezArrayMap<ezHashedString, ezVariant>& parameters) override;
 

--- a/Utilities/RunClangTidy.ps1
+++ b/Utilities/RunClangTidy.ps1
@@ -26,7 +26,7 @@ param
 	$FilterPattern
 )
 
-$ErrorActionPreference = "Break"
+$ErrorActionPreference = "Stop"
 
 $Workspace = (Resolve-Path $Workspace).Path
 

--- a/Utilities/RunClangTidy.ps1
+++ b/Utilities/RunClangTidy.ps1
@@ -291,9 +291,9 @@ $job = $files | Foreach-Object -Parallel `
    
    $output += "////////////////////////////////////////////////////////////////////////////////////////////////////////////`r`n"
    $output += "// $_`r`n"
-   $output += "// $ClangTidy -p $Workspace --checks=$Checks --header-filter=$HeaderPattern --export-fixes=$fixesFile `"--extra-arg=-isystem$ClangLibPath`" $_ `r`n"
+   $output += "// $ClangTidy -p $Workspace --checks=$Checks `"--header-filter=$HeaderPattern`" --extra-arg=-DBUILDSYSTEM_CLANG_TIDY=1 `"--extra-arg=-isystem$ClangLibPath`" $_ `r`n"
    $output += "////////////////////////////////////////////////////////////////////////////////////////////////////////////`r`n"
-   $tidyOutput = (& $ClangTidy -p $Workspace --checks=$Checks --header-filter=$HeaderPattern --export-fixes=$fixesFile "--extra-arg=-isystem$ClangLibPath" $_ *>&1) | Out-String -Stream
+   $tidyOutput = (& $ClangTidy -p $Workspace --checks=$Checks --header-filter=$HeaderPattern --export-fixes=$fixesFile --extra-arg=-DBUILDSYSTEM_CLANG_TIDY=1 "--extra-arg=-isystem$ClangLibPath" $_ *>&1) | Out-String -Stream
    
    $filteredTidyOutput = @($tidyOutput | ? {!$_.StartsWith("Suppressed") -and !$_.StartsWith("Use -header-filter") -and !($_ -match "warnings generated.") -and $_.trim() -ne "" })
    $filteredTidyOutputWithIndex = @($filteredTidyOutput | % {$i=0} {$value = @{msg = $_; index = $i}; $i++; return $value})


### PR DESCRIPTION
* Enable various clang-tidy static analysis checks
* Fix issues found by clang-tidy

Full list of issues clang-tidy found: [clang-tidy.log](https://github.com/ezEngine/ezEngine/files/11585123/clang-tidy.log)
