### PR TITLE
Use PowerShell to download version HTML file

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
@@ -18,13 +18,13 @@ static ezString GetVersionFilePath()
   return sTemp;
 }
 
-PageDownloader::PageDownloader(const QString& url)
+PageDownloader::PageDownloader(const QString& sUrl)
 {
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   QStringList args;
 
   args << "-Command";
-  args << QString("(Invoke-webrequest -URI \"%1\").Content > \"%2\"").arg(url).arg(GetVersionFilePath().GetData());
+  args << QString("(Invoke-webrequest -URI \"%1\").Content > \"%2\"").arg(sUrl).arg(GetVersionFilePath().GetData());
 
   m_pProcess = EZ_DEFAULT_NEW(QProcess);
   connect(m_pProcess.Borrow(), &QProcess::finished, this, &PageDownloader::DownloadDone);

--- a/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
@@ -9,29 +9,53 @@
 #include <Foundation/IO/OpenDdlUtils.h>
 #include <Foundation/IO/OpenDdlWriter.h>
 #include <QNetworkReply>
+#include <QProcess>
 
-PageDownloader::PageDownloader(QUrl url)
+static ezString GetVersionFilePath()
 {
-  connect(&m_WebCtrl, &QNetworkAccessManager::finished, this, &PageDownloader::DownloadDone);
-
-  QNetworkRequest request(url);
-  m_WebCtrl.get(request);
+  ezStringBuilder sTemp = ezOSFile::GetTempDataFolder();
+  sTemp.AppendPath("ezEditor/version-page.htm");
+  return sTemp;
 }
 
-void PageDownloader::DownloadDone(QNetworkReply* pReply)
+PageDownloader::PageDownloader(const QString& url)
 {
-  QNetworkReply::NetworkError e = pReply->error();
+  QStringList args;
 
-  if (e != QNetworkReply::NetworkError::NoError)
+  args << "-Command";
+  args << QString("(Invoke-webrequest -URI \"%1\").Content > \"%2\"").arg(url).arg(GetVersionFilePath().GetData());
+
+  m_pProcess = EZ_DEFAULT_NEW(QProcess);
+  connect(m_pProcess.Borrow(), &QProcess::finished, this, &PageDownloader::DownloadDone);
+  m_pProcess->start("C:\\Windows\\System32\\WindowsPowershell\\v1.0\\powershell.exe", args);
+}
+
+void PageDownloader::DownloadDone(int exitCode, QProcess::ExitStatus exitStatus)
+{
+  m_pProcess = nullptr;
+
+  ezOSFile file;
+  if (file.Open(GetVersionFilePath(), ezFileOpenMode::Read).Failed())
+    return;
+
+  ezDataBuffer content;
+  file.ReadAll(content);
+
+  content.PushBack('\0');
+  content.PushBack('\0');
+
+  const ezUInt16* pStart = (ezUInt16*)content.GetData();
+  if (ezUnicodeUtils::SkipUtf16BomLE(pStart))
   {
-    m_DownloadedData = pReply->readAll();
+    m_sDownloadedPage = ezStringWChar(pStart);
   }
   else
   {
-    m_DownloadedData = pReply->readAll();
+    const char* szUtf8 = (const char*)content.GetData();
+    m_sDownloadedPage = ezStringWChar(szUtf8);
   }
 
-  pReply->deleteLater();
+  ezOSFile::DeleteFile(GetVersionFilePath()).IgnoreResult();
 
   Q_EMIT FinishedDownload();
 }
@@ -112,10 +136,9 @@ bool ezQtVersionChecker::Check(bool bForce)
 
   m_bCheckInProgresss = true;
 
-  // DON'T use HTTPS here, our Qt version only supports HTTP
-  m_pVersionPage = new PageDownloader(QUrl("http://ezengine.net/pages/getting-started/binaries.html"));
+  m_pVersionPage = EZ_DEFAULT_NEW(PageDownloader, "https://ezengine.net/pages/getting-started/binaries.html");
 
-  connect(m_pVersionPage.data(), &PageDownloader::FinishedDownload, this, &ezQtVersionChecker::PageDownloaded);
+  connect(m_pVersionPage.Borrow(), &PageDownloader::FinishedDownload, this, &ezQtVersionChecker::PageDownloaded);
 
   return true;
 }
@@ -179,7 +202,9 @@ bool ezQtVersionChecker::IsLatestNewer() const
 void ezQtVersionChecker::PageDownloaded()
 {
   m_bCheckInProgresss = false;
-  ezStringBuilder sPage = m_pVersionPage->GetDownloadedData().data();
+  ezStringBuilder sPage = m_pVersionPage->GetDownloadedData();
+
+  m_pVersionPage = nullptr;
 
   if (sPage.IsEmpty())
   {

--- a/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
@@ -20,6 +20,7 @@ static ezString GetVersionFilePath()
 
 PageDownloader::PageDownloader(const QString& url)
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   QStringList args;
 
   args << "-Command";
@@ -28,6 +29,9 @@ PageDownloader::PageDownloader(const QString& url)
   m_pProcess = EZ_DEFAULT_NEW(QProcess);
   connect(m_pProcess.Borrow(), &QProcess::finished, this, &PageDownloader::DownloadDone);
   m_pProcess->start("C:\\Windows\\System32\\WindowsPowershell\\v1.0\\powershell.exe", args);
+#else
+  EZ_ASSERT_NOT_IMPLEMENTED;
+#endif
 }
 
 void PageDownloader::DownloadDone(int exitCode, QProcess::ExitStatus exitStatus)
@@ -118,6 +122,11 @@ ezResult ezQtVersionChecker::StoreKnownVersion()
 
 bool ezQtVersionChecker::Check(bool bForce)
 {
+#if EZ_DISABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+  EZ_ASSERT_DEV(!bForce, "The version check is not yet implemented on this platform.");
+  return false;
+#endif
+
   if (bForce)
   {
     // to trigger a 'new release available' signal

--- a/Code/Editor/EditorFramework/EditorApp/CheckVersion.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/CheckVersion.moc.h
@@ -4,29 +4,28 @@
 
 #include <Foundation/Strings/String.h>
 
-#include <QByteArray>
-#include <QNetworkAccessManager>
+#include <Foundation/Types/UniquePtr.h>
 #include <QObject>
-#include <QPointer>
+#include <QProcess>
 
 class PageDownloader : public QObject
 {
   Q_OBJECT
 
 public:
-  explicit PageDownloader(QUrl url);
+  explicit PageDownloader(const QString& url);
 
-  const QByteArray& GetDownloadedData() const { return m_DownloadedData; }
+  ezStringView GetDownloadedData() const { return m_sDownloadedPage; }
 
 signals:
   void FinishedDownload();
 
 private slots:
-  void DownloadDone(QNetworkReply* pReply);
+  void DownloadDone(int exitCode, QProcess::ExitStatus exitStatus);
 
 private:
-  QNetworkAccessManager m_WebCtrl;
-  QByteArray m_DownloadedData;
+  ezUniquePtr<QProcess> m_pProcess;
+  ezStringBuilder m_sDownloadedPage;
 };
 
 /// \brief Downloads a web page and checks whether the latest version online is newer than the current one
@@ -60,6 +59,5 @@ private:
   bool m_bCheckInProgresss = false;
   ezString m_sConfigFile;
   ezString m_sKnownLatestVersion;
-  QPointer<PageDownloader> m_pVersionPage;
+  ezUniquePtr<PageDownloader> m_pVersionPage;
 };
-

--- a/Code/Editor/EditorFramework/EditorApp/CheckVersion.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/CheckVersion.moc.h
@@ -13,7 +13,7 @@ class PageDownloader : public QObject
   Q_OBJECT
 
 public:
-  explicit PageDownloader(const QString& url);
+  explicit PageDownloader(const QString& sUrl);
 
   ezStringView GetDownloadedData() const { return m_sDownloadedPage; }
 

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -61,13 +61,12 @@ void ezQtEditorApp::SlotTimedUpdate()
   if (m_bWroteCrashIndicatorFile)
   {
     m_bWroteCrashIndicatorFile = false;
-    QTimer::singleShot(2000, []()
-      {
-        ezStringBuilder sTemp = ezOSFile::GetTempDataFolder("ezEditor");
-        sTemp.AppendPath("ezEditorCrashIndicator");
-        ezOSFile::DeleteFile(sTemp).IgnoreResult();
-        //
-      });
+    QTimer::singleShot(2000, []() {
+      ezStringBuilder sTemp = ezOSFile::GetTempDataFolder("ezEditor");
+      sTemp.AppendPath("ezEditorCrashIndicator");
+      ezOSFile::DeleteFile(sTemp).IgnoreResult();
+      //
+    });
   }
 
   m_pTimer->start(1);

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -20,6 +20,7 @@ ezQtEditorApp::ezQtEditorApp()
   , m_RecentDocuments(100)
 {
   m_bSavePreferencesAfterOpenProject = false;
+  m_pVersionChecker = EZ_DEFAULT_NEW(ezQtVersionChecker);
 
   m_pTimer = new QTimer(nullptr);
 }
@@ -82,26 +83,26 @@ void ezQtEditorApp::SlotVersionCheckCompleted(bool bNewVersionReleased, bool bFo
 
   if (bForced || bNewVersionReleased)
   {
-    if (m_VersionChecker.IsLatestNewer())
+    if (m_pVersionChecker->IsLatestNewer())
     {
       ezQtUiServices::GetSingleton()->MessageBoxInformation(
         ezFmt("<html>A new version is available: {}<br><br>Your version is: {}<br><br>Please check the <A "
               "href=\"https://github.com/ezEngine/ezEngine/releases\">Releases</A> for details.</html>",
-          m_VersionChecker.GetKnownLatestVersion(), m_VersionChecker.GetOwnVersion()));
+          m_pVersionChecker->GetKnownLatestVersion(), m_pVersionChecker->GetOwnVersion()));
     }
     else
     {
       ezStringBuilder tmp("You have the latest version: \n");
-      tmp.Append(m_VersionChecker.GetOwnVersion());
+      tmp.Append(m_pVersionChecker->GetOwnVersion());
 
       ezQtUiServices::GetSingleton()->MessageBoxInformation(tmp);
     }
   }
 
-  if (m_VersionChecker.IsLatestNewer())
+  if (m_pVersionChecker->IsLatestNewer())
   {
     ezQtUiServices::GetSingleton()->ShowGlobalStatusBarMessage(
-      ezFmt("New version '{}' available, please update.", m_VersionChecker.GetKnownLatestVersion()));
+      ezFmt("New version '{}' available, please update.", m_pVersionChecker->GetKnownLatestVersion()));
   }
 }
 
@@ -136,7 +137,7 @@ void ezQtEditorApp::UiServicesEvents(const ezQtUiServices::Event& e)
 {
   if (e.m_Type == ezQtUiServices::Event::Type::CheckForUpdates)
   {
-    m_VersionChecker.Check(true);
+    m_pVersionChecker->Check(true);
   }
 }
 

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/EditorApp/CheckVersion.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/OSFile.h>
@@ -60,12 +61,13 @@ void ezQtEditorApp::SlotTimedUpdate()
   if (m_bWroteCrashIndicatorFile)
   {
     m_bWroteCrashIndicatorFile = false;
-    QTimer::singleShot(2000, []() {
-      ezStringBuilder sTemp = ezOSFile::GetTempDataFolder("ezEditor");
-      sTemp.AppendPath("ezEditorCrashIndicator");
-      ezOSFile::DeleteFile(sTemp).IgnoreResult();
-      //
-    });
+    QTimer::singleShot(2000, []()
+      {
+        ezStringBuilder sTemp = ezOSFile::GetTempDataFolder("ezEditor");
+        sTemp.AppendPath("ezEditorCrashIndicator");
+        ezOSFile::DeleteFile(sTemp).IgnoreResult();
+        //
+      });
   }
 
   m_pTimer->start(1);

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <EditorEngineProcessFramework/LongOps/LongOpControllerManager.h>
-#include <EditorFramework/EditorApp/CheckVersion.moc.h>
 #include <EditorFramework/EditorApp/Configuration/Plugins.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/IPC/EngineProcessConnection.h>
@@ -30,6 +29,7 @@ using QStringList = QList<QString>;
 class ezTranslatorFromFiles;
 class ezDynamicStringEnum;
 class QSplashScreen;
+class ezQtVersionChecker;
 
 struct EZ_EDITORFRAMEWORK_DLL ezEditorAppEvent
 {
@@ -313,7 +313,7 @@ private:
   ezSet<ezString> m_DynamicEnumStringsToClear;
   void OnDemandDynamicStringEnumLoad(ezStringView sEnumName, ezDynamicStringEnum& e);
 
-  ezQtVersionChecker m_VersionChecker;
+  ezUniquePtr<ezQtVersionChecker> m_pVersionChecker;
 };
 
 EZ_DECLARE_FLAGS_OPERATORS(ezQtEditorApp::StartupFlags);

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -330,10 +330,10 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
 
     if (!IsInUnitTestMode())
     {
-      connect(&m_VersionChecker, &ezQtVersionChecker::VersionCheckCompleted, this, &ezQtEditorApp::SlotVersionCheckCompleted, Qt::QueuedConnection);
+      connect(m_pVersionChecker.Borrow(), &ezQtVersionChecker::VersionCheckCompleted, this, &ezQtEditorApp::SlotVersionCheckCompleted, Qt::QueuedConnection);
 
-      m_VersionChecker.Initialize();
-      m_VersionChecker.Check(false);
+      m_pVersionChecker->Initialize();
+      m_pVersionChecker->Check(false);
     }
   }
 

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -10,6 +10,7 @@
 #include <EditorFramework/Actions/TransformGizmoActions.h>
 #include <EditorFramework/Actions/ViewActions.h>
 #include <EditorFramework/Actions/ViewLightActions.h>
+#include <EditorFramework/EditorApp/CheckVersion.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/GUI/DynamicDefaultStateProvider.h>
 #include <EditorFramework/GUI/ExposedParametersDefaultStateProvider.h>

--- a/Code/Engine/Foundation/Strings/UnicodeUtils.h
+++ b/Code/Engine/Foundation/Strings/UnicodeUtils.h
@@ -15,10 +15,10 @@ public:
 
 public:
   /// \brief Byte Order Mark for Little Endian Utf16 strings.
-  static constexpr ezUInt16 Utf16BomLE = 0xfffe;
+  static constexpr ezUInt16 Utf16BomLE = 0xfeff;
 
   /// \brief Byte Order Mark for Big Endian Utf16 strings.
-  static constexpr ezUInt16 Utf16BomBE = 0xfeff;
+  static constexpr ezUInt16 Utf16BomBE = 0xfffe;
 
   /// \brief Returns whether a character is a pure ASCII character (only the first 7 Bits are used)
   static bool IsASCII(ezUInt32 uiChar); // [tested]

--- a/Code/UnitTests/FoundationTest/Strings/UnicodeUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/UnicodeUtilsTest.cpp
@@ -266,7 +266,7 @@ EZ_CREATE_SIMPLE_TEST(Strings, UnicodeUtils)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SkipUtf16BomLE")
   {
-    ezUInt16 szWithBom[] = {0xfffe, 'a'};
+    ezUInt16 szWithBom[] = {0xfeff, 'a'};
     ezUInt16 szNoBom[] = {'a'};
 
     const ezUInt16* pString = szWithBom;
@@ -282,7 +282,7 @@ EZ_CREATE_SIMPLE_TEST(Strings, UnicodeUtils)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SkipUtf16BomBE")
   {
-    ezUInt16 szWithBom[] = {0xfeff, 'a'};
+    ezUInt16 szWithBom[] = {0xfffe, 'a'};
     ezUInt16 szNoBom[] = {'a'};
 
     const ezUInt16* pString = szWithBom;


### PR DESCRIPTION
Fixes #969.

Attempts to run a PowerShell command to download the webpage where the latest released version can be found. This is used so that we don't need support for encryption (OpenSSL) just for this task.

Also fixes that the Utf-16 Byte-Order-Marks for Big Endian and Little Endian were swapped.
