### PR TITLE
Changed TrimWordStart and TrimWordEnd to only trim a single occurrance

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
@@ -108,7 +108,8 @@ void ezQtExportAndRunDlg::on_AddToolButton_clicked()
 
   ezStringBuilder path = sFile.toUtf8().data();
   path.MakeCleanPath();
-  path.TrimWordStart(appDir, "/");
+  path.TrimWordStart(appDir);
+  path.Trim("/", "");
 
   ezStringBuilder tmp;
   ToolCombo->addItem(QString::fromUtf8(path.GetFileName().GetData(tmp)), QString::fromUtf8(path.GetData()));

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraph.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraph.cpp
@@ -170,10 +170,16 @@ void ezVisualScriptNodeManager::GetOutputDataPins(const ezDocumentObject* pObjec
 ezStringView ezVisualScriptNodeManager::GetNiceTypeName(const ezDocumentObject* pObject)
 {
   ezStringView sTypeName = pObject->GetType()->GetTypeName();
-  sTypeName.TrimWordStart(ezVisualScriptNodeRegistry::s_szTypeNamePrefix, "Builtin_");
+
+  while (sTypeName.TrimWordStart(ezVisualScriptNodeRegistry::s_szTypeNamePrefix) ||
+         sTypeName.TrimWordStart("Builtin_"))
+  {
+  }
 
   if (const char* szAngleBracket = sTypeName.FindSubString("<"))
+  {
     sTypeName = ezStringView(sTypeName.GetStartPointer(), szAngleBracket);
+  }
 
   return sTypeName;
 }

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
@@ -1076,100 +1076,43 @@ void ezStringBuilder::Trim(const char* szTrimCharsStart, const char* szTrimChars
   Shrink(ezStringUtils::GetCharacterCount(GetData(), szNewStart), ezStringUtils::GetCharacterCount(szNewEnd, GetData() + GetElementCount()));
 }
 
-bool ezStringBuilder::TrimWordStart(const char* szWord1, const char* szWord2 /*= nullptr*/, const char* szWord3 /*= nullptr*/,
-  const char* szWord4 /*= nullptr*/, const char* szWord5 /*= nullptr*/)
+bool ezStringBuilder::TrimWordStart(ezStringView sWord)
 {
-  /// \test TrimWordStart
+  const bool bTrimAll = false;
+
   bool trimmed = false;
 
-  while (true)
+  do
   {
-    if (!ezStringUtils::IsNullOrEmpty(szWord1) && StartsWith_NoCase(szWord1))
+    if (!sWord.IsEmpty() && StartsWith_NoCase(sWord))
     {
-      Shrink(ezStringUtils::GetCharacterCount(szWord1), 0);
+      Shrink(ezStringUtils::GetCharacterCount(sWord.GetStartPointer(), sWord.GetEndPointer()), 0);
       trimmed = true;
-      continue;
     }
 
-    if (!ezStringUtils::IsNullOrEmpty(szWord2) && StartsWith_NoCase(szWord2))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(szWord2), 0);
-      trimmed = true;
-      continue;
-    }
+  } while (bTrimAll);
 
-    if (!ezStringUtils::IsNullOrEmpty(szWord3) && StartsWith_NoCase(szWord3))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(szWord3), 0);
-      trimmed = true;
-      continue;
-    }
-
-    if (!ezStringUtils::IsNullOrEmpty(szWord4) && StartsWith_NoCase(szWord4))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(szWord4), 0);
-      trimmed = true;
-      continue;
-    }
-
-    if (!ezStringUtils::IsNullOrEmpty(szWord5) && StartsWith_NoCase(szWord5))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(szWord5), 0);
-      trimmed = true;
-      continue;
-    }
-
-    return trimmed;
-  }
+  return trimmed;
 }
 
-bool ezStringBuilder::TrimWordEnd(const char* szWord1, const char* szWord2 /*= nullptr*/, const char* szWord3 /*= nullptr*/,
-  const char* szWord4 /*= nullptr*/, const char* szWord5 /*= nullptr*/)
+bool ezStringBuilder::TrimWordEnd(ezStringView sWord)
 {
-  /// \test TrimWordEnd
+  const bool bTrimAll = false;
 
   bool trimmed = false;
 
-  while (true)
+  do
   {
 
-    if (!ezStringUtils::IsNullOrEmpty(szWord1) && EndsWith_NoCase(szWord1))
+    if (!sWord.IsEmpty() && EndsWith_NoCase(sWord))
     {
-      Shrink(0, ezStringUtils::GetCharacterCount(szWord1));
+      Shrink(0, ezStringUtils::GetCharacterCount(sWord.GetStartPointer(), sWord.GetEndPointer()));
       trimmed = true;
-      continue;
     }
 
-    if (!ezStringUtils::IsNullOrEmpty(szWord2) && EndsWith_NoCase(szWord2))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(szWord2));
-      trimmed = true;
-      continue;
-    }
+  } while (bTrimAll);
 
-    if (!ezStringUtils::IsNullOrEmpty(szWord3) && EndsWith_NoCase(szWord3))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(szWord3));
-      trimmed = true;
-      continue;
-    }
-
-    if (!ezStringUtils::IsNullOrEmpty(szWord4) && EndsWith_NoCase(szWord4))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(szWord4));
-      trimmed = true;
-      continue;
-    }
-
-    if (!ezStringUtils::IsNullOrEmpty(szWord5) && EndsWith_NoCase(szWord5))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(szWord5));
-      trimmed = true;
-      continue;
-    }
-
-    return trimmed;
-  }
+  return trimmed;
 }
 
 void ezStringBuilder::Format(const ezFormatString& string)

--- a/Code/Engine/Foundation/Strings/Implementation/StringView.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView.cpp
@@ -155,97 +155,42 @@ void ezStringView::ChopAwayFirstCharacterAscii()
   }
 }
 
-bool ezStringView::TrimWordStart(ezStringView sWord1, ezStringView sWord2, ezStringView sWord3, ezStringView sWord4, ezStringView sWord5)
+bool ezStringView::TrimWordStart(ezStringView sWord)
 {
-  /// \test TrimWordStart
+  const bool bTrimAll = false;
+
   bool trimmed = false;
 
-  while (true)
+  do
   {
-    if (!sWord1.IsEmpty() && StartsWith_NoCase(sWord1))
+    if (!sWord.IsEmpty() && StartsWith_NoCase(sWord))
     {
-      Shrink(ezStringUtils::GetCharacterCount(sWord1.GetStartPointer(), sWord1.GetEndPointer()), 0);
+      Shrink(ezStringUtils::GetCharacterCount(sWord.GetStartPointer(), sWord.GetEndPointer()), 0);
       trimmed = true;
-      continue;
     }
 
-    if (!sWord2.IsEmpty() && StartsWith_NoCase(sWord2))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(sWord2.GetStartPointer(), sWord2.GetEndPointer()), 0);
-      trimmed = true;
-      continue;
-    }
+  } while (bTrimAll);
 
-    if (!sWord3.IsEmpty() && StartsWith_NoCase(sWord3))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(sWord3.GetStartPointer(), sWord3.GetEndPointer()), 0);
-      trimmed = true;
-      continue;
-    }
-
-    if (!sWord4.IsEmpty() && StartsWith_NoCase(sWord4))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(sWord4.GetStartPointer(), sWord4.GetEndPointer()), 0);
-      trimmed = true;
-      continue;
-    }
-
-    if (!sWord5.IsEmpty() && StartsWith_NoCase(sWord5))
-    {
-      Shrink(ezStringUtils::GetCharacterCount(sWord5.GetStartPointer(), sWord5.GetEndPointer()), 0);
-      trimmed = true;
-      continue;
-    }
-
-    return trimmed;
-  }
+  return trimmed;
 }
 
-bool ezStringView::TrimWordEnd(ezStringView sWord1, ezStringView sWord2, ezStringView sWord3, ezStringView sWord4, ezStringView sWord5)
+bool ezStringView::TrimWordEnd(ezStringView sWord)
 {
-  /// \test TrimWordEnd
+  const bool bTrimAll = false;
 
   bool trimmed = false;
 
-  while (true)
+  do
   {
-    if (!sWord1.IsEmpty() && EndsWith_NoCase(sWord1))
+    if (!sWord.IsEmpty() && EndsWith_NoCase(sWord))
     {
-      Shrink(0, ezStringUtils::GetCharacterCount(sWord1.GetStartPointer(), sWord1.GetEndPointer()));
+      Shrink(0, ezStringUtils::GetCharacterCount(sWord.GetStartPointer(), sWord.GetEndPointer()));
       trimmed = true;
-      continue;
     }
 
-    if (!sWord2.IsEmpty() && EndsWith_NoCase(sWord2))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(sWord2.GetStartPointer(), sWord2.GetEndPointer()));
-      trimmed = true;
-      continue;
-    }
+  } while (bTrimAll);
 
-    if (!sWord3.IsEmpty() && EndsWith_NoCase(sWord3))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(sWord3.GetStartPointer(), sWord3.GetEndPointer()));
-      trimmed = true;
-      continue;
-    }
-
-    if (!sWord4.IsEmpty() && EndsWith_NoCase(sWord4))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(sWord4.GetStartPointer(), sWord4.GetEndPointer()));
-      trimmed = true;
-      continue;
-    }
-
-    if (!sWord5.IsEmpty() && EndsWith_NoCase(sWord5))
-    {
-      Shrink(0, ezStringUtils::GetCharacterCount(sWord5.GetStartPointer(), sWord5.GetEndPointer()));
-      trimmed = true;
-      continue;
-    }
-
-    return trimmed;
-  }
+  return trimmed;
 }
 
 ezStringView::iterator ezStringView::GetIteratorFront() const

--- a/Code/Engine/Foundation/Strings/StringBuilder.h
+++ b/Code/Engine/Foundation/Strings/StringBuilder.h
@@ -384,11 +384,11 @@ public:
   /// \brief Removes all characters from the start and/or end that appear in the given strings.
   void Trim(const char* szTrimCharsStart, const char* szTrimCharsEnd); // [tested]
 
-  /// \brief If the string starts with one of the given words (case insensitive), it is removed and the function returns true.
-  bool TrimWordStart(const char* szWord1, const char* szWord2 = nullptr, const char* szWord3 = nullptr, const char* szWord4 = nullptr, const char* szWord5 = nullptr); // [tested]
+  /// \brief If the string starts with the given word (case insensitive), it is removed and the function returns true.
+  bool TrimWordStart(ezStringView sWord); // [tested]
 
-  /// \brief If the string ends with one of the given words (case insensitive), it is removed and the function returns true.
-  bool TrimWordEnd(const char* szWord1, const char* szWord2 = nullptr, const char* szWord3 = nullptr, const char* szWord4 = nullptr, const char* szWord5 = nullptr); // [tested]
+  /// \brief If the string ends with the given word (case insensitive), it is removed and the function returns true.
+  bool TrimWordEnd(ezStringView sWord); // [tested]
 
 private:
   /// \brief Will remove all double path separators (slashes and backslashes) in a path, except if the path starts with two (back-)slashes,

--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -192,11 +192,11 @@ public:
   /// \brief Removes all characters from the start and/or end that appear in the given strings by adjusting the begin and end of the view.
   void Trim(const char* szTrimCharsStart, const char* szTrimCharsEnd); // [tested]
 
-  /// \brief If the string starts with one of the given words (case insensitive), it is removed and the function returns true.
-  bool TrimWordStart(ezStringView sWord1, ezStringView sWord2 = {}, ezStringView sWord3 = {}, ezStringView sWord4 = {}, ezStringView sWord5 = {}); // [tested]
+  /// \brief If the string starts with the given word (case insensitive), it is removed and the function returns true.
+  bool TrimWordStart(ezStringView sWord); // [tested]
 
-  /// \brief If the string ends with one of the given words (case insensitive), it is removed and the function returns true.
-  bool TrimWordEnd(ezStringView sWord1, ezStringView sWord2 = {}, ezStringView sWord3 = {}, ezStringView sWord4 = {}, ezStringView sWord5 = {}); // [tested]
+  /// \brief If the string ends with the given word (case insensitive), it is removed and the function returns true.
+  bool TrimWordEnd(ezStringView sWord); // [tested]
 
   /// \brief Fills the given container with ezStringView's which represent each found substring.
   /// If bReturnEmptyStrings is true, even empty strings between separators are returned.

--- a/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
@@ -1520,21 +1520,43 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
 
     {
       sb = "<test><tut><test><test><tut>abc<tut><test>";
-      EZ_TEST_BOOL(sb.TrimWordStart("<tut>", "<test>"));
+      EZ_TEST_BOOL(!sb.TrimWordStart("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<tut>"));
       EZ_TEST_STRING(sb, "abc<tut><test>");
-      EZ_TEST_BOOL(sb.TrimWordStart("<tut>", "<test>") == false);
+      EZ_TEST_BOOL(sb.TrimWordStart("<tut>") == false);
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>") == false);
       EZ_TEST_STRING(sb, "abc<tut><test>");
     }
 
     {
       sb = "<a><b><c><d><e><a><b><c><d><e>abc";
-      EZ_TEST_BOOL(sb.TrimWordStart("<a>", "<b>", "<c>", "<d>", "<e>"));
+
+      while (sb.TrimWordStart("<a>") ||
+             sb.TrimWordStart("<b>") ||
+             sb.TrimWordStart("<c>") ||
+             sb.TrimWordStart("<d>") ||
+             sb.TrimWordStart("<e>"))
+      {
+      }
+
       EZ_TEST_STRING(sb, "abc");
     }
 
     {
       sb = "<a><b><c><d><e><a><b><c><d><e>";
-      EZ_TEST_BOOL(sb.TrimWordStart("<a>", "<b>", "<c>", "<d>", "<e>"));
+
+      while (sb.TrimWordStart("<a>") ||
+             sb.TrimWordStart("<b>") ||
+             sb.TrimWordStart("<c>") ||
+             sb.TrimWordStart("<d>") ||
+             sb.TrimWordStart("<e>"))
+      {
+      }
+
       EZ_TEST_STRING(sb, "");
     }
   }
@@ -1553,21 +1575,42 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
 
     {
       sb = "<tut><test>abc<test><tut><test><test><tut>";
-      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>", "<test>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
       EZ_TEST_STRING(sb, "<tut><test>abc");
-      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>", "<test>") == false);
+      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>") == false);
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>") == false);
       EZ_TEST_STRING(sb, "<tut><test>abc");
     }
 
     {
       sb = "abc<a><b><c><d><e><a><b><c><d><e>";
-      EZ_TEST_BOOL(sb.TrimWordEnd("<a>", "<b>", "<c>", "<d>", "<e>"));
+
+      while (sb.TrimWordEnd("<a>") ||
+             sb.TrimWordEnd("<b>") ||
+             sb.TrimWordEnd("<c>") ||
+             sb.TrimWordEnd("<d>") ||
+             sb.TrimWordEnd("<e>"))
+      {
+      }
+
       EZ_TEST_STRING(sb, "abc");
     }
 
     {
       sb = "<a><b><c><d><e><a><b><c><d><e>";
-      EZ_TEST_BOOL(sb.TrimWordEnd("<a>", "<b>", "<c>", "<d>", "<e>"));
+
+      while (sb.TrimWordEnd("<a>") ||
+             sb.TrimWordEnd("<b>") ||
+             sb.TrimWordEnd("<c>") ||
+             sb.TrimWordEnd("<d>") ||
+             sb.TrimWordEnd("<e>"))
+      {
+      }
+
       EZ_TEST_STRING(sb, "");
     }
   }

--- a/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
@@ -375,29 +375,51 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringView)
     {
       sb = "<test>abc<test>";
       EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
-      EZ_TEST_BOOL(sb == "abc<test>");
+      EZ_TEST_STRING(sb, "abc<test>");
       EZ_TEST_BOOL(sb.TrimWordStart("<test>") == false);
-      EZ_TEST_BOOL(sb == "abc<test>");
+      EZ_TEST_STRING(sb, "abc<test>");
     }
 
     {
       sb = "<test><tut><test><test><tut>abc<tut><test>";
-      EZ_TEST_BOOL(sb.TrimWordStart("<tut>", "<test>"));
-      EZ_TEST_BOOL(sb == "abc<tut><test>");
-      EZ_TEST_BOOL(sb.TrimWordStart("<tut>", "<test>") == false);
-      EZ_TEST_BOOL(sb == "abc<tut><test>");
+      EZ_TEST_BOOL(!sb.TrimWordStart("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordStart("<tut>"));
+      EZ_TEST_STRING(sb, "abc<tut><test>");
+      EZ_TEST_BOOL(sb.TrimWordStart("<tut>") == false);
+      EZ_TEST_BOOL(sb.TrimWordStart("<test>") == false);
+      EZ_TEST_STRING(sb, "abc<tut><test>");
     }
 
     {
       sb = "<a><b><c><d><e><a><b><c><d><e>abc";
-      EZ_TEST_BOOL(sb.TrimWordStart("<a>", "<b>", "<c>", "<d>", "<e>"));
-      EZ_TEST_BOOL(sb == "abc");
+
+      while (sb.TrimWordStart("<a>") ||
+             sb.TrimWordStart("<b>") ||
+             sb.TrimWordStart("<c>") ||
+             sb.TrimWordStart("<d>") ||
+             sb.TrimWordStart("<e>"))
+      {
+      }
+
+      EZ_TEST_STRING(sb, "abc");
     }
 
     {
       sb = "<a><b><c><d><e><a><b><c><d><e>";
-      EZ_TEST_BOOL(sb.TrimWordStart("<a>", "<b>", "<c>", "<d>", "<e>"));
-      EZ_TEST_BOOL(sb == "");
+
+      while (sb.TrimWordStart("<a>") ||
+             sb.TrimWordStart("<b>") ||
+             sb.TrimWordStart("<c>") ||
+             sb.TrimWordStart("<d>") ||
+             sb.TrimWordStart("<e>"))
+      {
+      }
+
+      EZ_TEST_STRING(sb, "");
     }
   }
 
@@ -408,32 +430,52 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringView)
     {
       sb = "<test>abc<test>";
       EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
-      EZ_TEST_BOOL(sb == "<test>abc");
+      EZ_TEST_STRING(sb, "<test>abc");
       EZ_TEST_BOOL(sb.TrimWordEnd("<test>") == false);
-      EZ_TEST_BOOL(sb == "<test>abc");
+      EZ_TEST_STRING(sb, "<test>abc");
     }
 
     {
       sb = "<tut><test>abc<test><tut><test><test><tut>";
-      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>", "<test>"));
-      EZ_TEST_BOOL(sb == "<tut><test>abc");
-      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>", "<test>") == false);
-      EZ_TEST_BOOL(sb == "<tut><test>abc");
+      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>"));
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>"));
+      EZ_TEST_STRING(sb, "<tut><test>abc");
+      EZ_TEST_BOOL(sb.TrimWordEnd("<tut>") == false);
+      EZ_TEST_BOOL(sb.TrimWordEnd("<test>") == false);
+      EZ_TEST_STRING(sb, "<tut><test>abc");
     }
 
     {
       sb = "abc<a><b><c><d><e><a><b><c><d><e>";
-      EZ_TEST_BOOL(sb.TrimWordEnd("<a>", "<b>", "<c>", "<d>", "<e>"));
-      EZ_TEST_BOOL(sb == "abc");
+
+      while (sb.TrimWordEnd("<a>") ||
+             sb.TrimWordEnd("<b>") ||
+             sb.TrimWordEnd("<c>") ||
+             sb.TrimWordEnd("<d>") ||
+             sb.TrimWordEnd("<e>"))
+      {
+      }
+
+      EZ_TEST_STRING(sb, "abc");
     }
 
     {
       sb = "<a><b><c><d><e><a><b><c><d><e>";
-      EZ_TEST_BOOL(sb.TrimWordEnd("<a>", "<b>", "<c>", "<d>", "<e>"));
-      EZ_TEST_BOOL(sb == "");
+
+      while (sb.TrimWordEnd("<a>") ||
+             sb.TrimWordEnd("<b>") ||
+             sb.TrimWordEnd("<c>") ||
+             sb.TrimWordEnd("<d>") ||
+             sb.TrimWordEnd("<e>"))
+      {
+      }
+
+      EZ_TEST_STRING(sb, "");
     }
   }
-
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Split")
   {


### PR DESCRIPTION
This fixes a bug in ezFormatString and generally should be more in line with what people expect it to do.