### PR TITLE
Proposal for changing math class construction to static functions

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -149,7 +149,7 @@ function(ez_set_build_flags_msvc TARGET_NAME)
 	target_compile_options(${TARGET_NAME} PRIVATE /wd5240)
     
     # Disable deprecation warnings (qt, etc)
-    target_compile_options(${TARGET_NAME} PRIVATE /wd4996)
+    # target_compile_options(${TARGET_NAME} PRIVATE /wd4996)
 
 endfunction()
 

--- a/Code/Engine/Core/Graphics/Implementation/Camera.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Camera.cpp
@@ -35,8 +35,8 @@ EZ_END_STATIC_REFLECTED_ENUM;
 
 ezCamera::ezCamera()
 {
-  m_vCameraPosition[0].SetZero();
-  m_vCameraPosition[1].SetZero();
+  m_vCameraPosition[0] = ezVec3::sZero();
+  m_vCameraPosition[1] = ezVec3::sZero();
   m_mViewMatrix[0].SetIdentity();
   m_mViewMatrix[1].SetIdentity();
   m_mStereoProjectionMatrix[0].SetIdentity();

--- a/Code/Engine/Core/Graphics/Implementation/ConvexHull.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/ConvexHull.cpp
@@ -288,7 +288,7 @@ ezResult ezConvexHullGenerator::InitializeHull()
 
   // precompute the 'inside' position
   {
-    m_vInside.SetZero();
+    m_vInside = ezVec3d::sZero();
     for (ezUInt32 v = 0; v < 4; ++v)
       m_vInside += m_Vertices[v];
     m_vInside /= 4.0;

--- a/Code/Engine/Core/Graphics/Implementation/Geometry.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Geometry.cpp
@@ -156,7 +156,7 @@ void ezGeometry::ComputeSmoothVertexNormals()
   // reset all vertex normals
   for (ezUInt32 v = 0; v < m_Vertices.GetCount(); ++v)
   {
-    m_Vertices[v].m_vNormal.SetZero();
+    m_Vertices[v].m_vNormal = ezVec3::sZero();
   }
 
   // add face normal of all adjacent faces to each vertex
@@ -291,7 +291,7 @@ void ezGeometry::ValidateTangents(float fEpsilon)
     // checking for orthogonality to the normal and for squared unit length (standard case) or 3 (magic number for binormal inversion)
     if (!ezMath::IsEqual(vertex.m_vNormal.GetLengthSquared(), 1.f, fEpsilon) || !ezMath::IsEqual(vertex.m_vNormal.Dot(vertex.m_vTangent), 0.f, fEpsilon) || !(ezMath::IsEqual(vertex.m_vTangent.GetLengthSquared(), 1.f, fEpsilon) || ezMath::IsEqual(vertex.m_vTangent.GetLengthSquared(), 3.f, fEpsilon)))
     {
-      vertex.m_vTangent.SetZero();
+      vertex.m_vTangent = ezVec3::sZero();
     }
   }
 }

--- a/Code/Engine/Core/Interfaces/WindWorldModule.cpp
+++ b/Code/Engine/Core/Interfaces/WindWorldModule.cpp
@@ -64,19 +64,19 @@ ezWindWorldModuleInterface::ezWindWorldModuleInterface(ezWorld* pWorld)
 ezVec3 ezWindWorldModuleInterface::ComputeWindFlutter(const ezVec3& vWind, const ezVec3& vObjectDir, float fFlutterSpeed, ezUInt32 uiFlutterRandomOffset) const
 {
   if (vWind.IsZero(0.001f))
-    return ezVec3::ZeroVector();
+    return ezVec3::sZero();
 
   ezVec3 windDir = vWind;
   const float fWindStrength = windDir.GetLengthAndNormalize();
 
   if (fWindStrength <= 0.01f)
-    return ezVec3::ZeroVector();
+    return ezVec3::sZero();
 
   ezVec3 mainDir = vObjectDir;
-  mainDir.NormalizeIfNotZero(ezVec3::UnitZAxis()).IgnoreResult();
+  mainDir.NormalizeIfNotZero(ezVec3::sAxisZ()).IgnoreResult();
 
   ezVec3 flutterDir = windDir.CrossRH(mainDir);
-  flutterDir.NormalizeIfNotZero(ezVec3::UnitZAxis()).IgnoreResult();
+  flutterDir.NormalizeIfNotZero(ezVec3::sAxisZ()).IgnoreResult();
 
   const float fFlutterOffset = (uiFlutterRandomOffset & 1023u) / 256.0f;
 

--- a/Code/Engine/Foundation/Math/Angle.h
+++ b/Code/Engine/Foundation/Math/Angle.h
@@ -26,11 +26,16 @@ public:
   constexpr static Type RadToDeg(Type f); // [tested]
 
   /// \brief Creates an instance of ezAngle that was initialized from degree. (Performs a conversion)
+  // [[deprecated("Use sDegree instead")]]
   constexpr static ezAngle Degree(float fDegree); // [tested]
 
   /// \brief Creates an instance of ezAngle that was initialized from radian. (No need for any conversion)
+  //[[deprecated("Use sRadian instead")]]
   constexpr static ezAngle Radian(float fRadian); // [tested]
 
+  constexpr static ezAngle sZero();
+  constexpr static ezAngle sDegree(float fDegree);
+  constexpr static ezAngle sRadian(float fDegree);
 
 
   EZ_DECLARE_POD_TYPE();

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -47,6 +47,8 @@ public:
 
   // *** Predefined Colors ***
 public:
+  // turn into static functions and rename to sAliceBlue() etc ??? (probably not)
+
   static const ezColor AliceBlue;            ///< #F0F8FF
   static const ezColor AntiqueWhite;         ///< #FAEBD7
   static const ezColor Aqua;                 ///< #00FFFF
@@ -207,6 +209,7 @@ public:
 public:
   /// \brief Returns a color with all four RGBA components set to zero. This is different to ezColor::Black, which has alpha still set to 1.0.
   static ezColor ZeroColor();
+  static ezColor sZero();
 
   // *** Constructors ***
 public:
@@ -218,6 +221,9 @@ public:
   /// To initialize the color from a Gamma color space, e.g. when using a color value that was determined with a color picker,
   /// use the constructor that takes a ezColorGammaUB object for initialization.
   constexpr ezColor(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // [tested]
+  static ezColor sRGBA(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // ??
+
+  static ezColor sNaN();
 
   /// \brief Initializes this color from a ezColorLinearUB object.
   ///
@@ -252,6 +258,7 @@ public:
   ///
   /// \a hue is in range [0; 360], \a sat and \a val are in range [0; 1]
   void SetHSV(float fHue, float fSat, float fVal); // [tested]
+  static ezColor sHSV(float fHue, float fSat, float fVal);
 
   /// \brief Converts the color part to HSV format.
   ///

--- a/Code/Engine/Foundation/Math/Frustum.h
+++ b/Code/Engine/Foundation/Math/Frustum.h
@@ -65,6 +65,7 @@ public:
   ///
   /// \note Make sure to pass in the planes in the order of the PlaneType enum, otherwise ezFrustum may not always work as expected.
   void SetFrustum(const ezPlane* pPlanes); // [tested]
+  static ezFrustum sFromSixPlanes(const ezPlane* pPlanes);
 
   /// \brief Creates the frustum by extracting the planes from the given (model-view / projection) matrix.
   ///
@@ -73,13 +74,13 @@ public:
   /// plane projection matrix, the resulting frustum will yield a far plane with infinite distance.
   void SetFrustum(const ezMat4& mModelViewProjection, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default,
     ezHandedness::Enum handedness = ezHandedness::Default); // [tested]
+  static ezFrustum sFromMVP(const ezPlane* pPlanes);
 
   /// \brief Creates a frustum from the given camera position, direction vectors and the field-of-view along X and Y.
   ///
   /// The up vector does not need to be exactly orthogonal to the forwards vector, it will get recomputed properly.
   /// FOV X and Y define the entire field-of-view, so a FOV of 180 degree would mean the entire half-space in front of the camera.
-  void SetFrustum(
-    const ezVec3& vPosition, const ezVec3& vForwards, const ezVec3& vUp, ezAngle fovX, ezAngle fovY, float fNearPlane, float fFarPlane); // [tested]
+  void SetFrustum(const ezVec3& vPosition, const ezVec3& vForwards, const ezVec3& vUp, ezAngle fovX, ezAngle fovY, float fNearPlane, float fFarPlane); // [tested]
 
   /// \brief Returns the n-th plane of the frustum.
   const ezPlane& GetPlane(ezUInt8 uiPlane) const; // [tested]

--- a/Code/Engine/Foundation/Math/Implementation/AllClassesRandom_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/AllClassesRandom_inl.h
@@ -7,6 +7,12 @@
 template <typename Type>
 ezVec3Template<Type> ezVec3Template<Type>::CreateRandomPointInSphere(ezRandom& inout_rng)
 {
+  return sRandomPointInSphere(inout_rng);
+}
+
+template <typename Type>
+ezVec3Template<Type> ezVec3Template<Type>::sRandomPointInSphere(ezRandom& inout_rng)
+{
   double px, py, pz;
   double len = 0.0;
 
@@ -25,6 +31,12 @@ ezVec3Template<Type> ezVec3Template<Type>::CreateRandomPointInSphere(ezRandom& i
 template <typename Type>
 ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDirection(ezRandom& inout_rng)
 {
+  return sRandomDirection(inout_rng);
+}
+
+template <typename Type>
+ezVec3Template<Type> ezVec3Template<Type>::sRandomDirection(ezRandom& inout_rng)
+{
   ezVec3Template<Type> vec = CreateRandomPointInSphere(inout_rng);
   vec.Normalize();
   return vec;
@@ -32,6 +44,12 @@ ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDirection(ezRandom& inout
 
 template <typename Type>
 ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation)
+{
+  return sRandomDeviationX(inout_rng, maxDeviation);
+}
+
+template <typename Type>
+ezVec3Template<Type> ezVec3Template<Type>::sRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation)
 {
   const double twoPi = 2.0 * ezMath::Pi<double>();
 
@@ -49,6 +67,12 @@ ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviationX(ezRandom& inou
 template <typename Type>
 ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation)
 {
+  return sRandomDeviationY(inout_rng, maxDeviation);
+}
+
+template <typename Type>
+ezVec3Template<Type> ezVec3Template<Type>::sRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation)
+{
   ezVec3Template<Type> vec = CreateRandomDeviationX(inout_rng, maxDeviation);
   ezMath::Swap(vec.x, vec.y);
   return vec;
@@ -57,6 +81,12 @@ ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviationY(ezRandom& inou
 template <typename Type>
 ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation)
 {
+  return sRandomDeviationZ(inout_rng, maxDeviation);
+}
+
+template <typename Type>
+ezVec3Template<Type> ezVec3Template<Type>::sRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation)
+{
   ezVec3Template<Type> vec = CreateRandomDeviationX(inout_rng, maxDeviation);
   ezMath::Swap(vec.x, vec.z);
   return vec;
@@ -64,6 +94,12 @@ ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviationZ(ezRandom& inou
 
 template <typename Type>
 ezVec3Template<Type> ezVec3Template<Type>::CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal)
+{
+  return sRandomDeviation(inout_rng, maxDeviation, vNormal);
+}
+
+template <typename Type>
+ezVec3Template<Type> ezVec3Template<Type>::sRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal)
 {
   // If you need to do this very often:
   // *** Pre-compute this once: ***

--- a/Code/Engine/Foundation/Math/Implementation/BoundingBoxSphere_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/BoundingBoxSphere_inl.h
@@ -47,7 +47,7 @@ ezBoundingBoxSphereTemplate<Type>::ezBoundingBoxSphereTemplate(const ezBoundingS
 template <typename Type>
 EZ_FORCE_INLINE void ezBoundingBoxSphereTemplate<Type>::SetInvalid()
 {
-  m_vCenter.SetZero();
+  m_vCenter = ezVec3::sZero();
   m_fSphereRadius = -ezMath::SmallEpsilon<Type>();
   m_vBoxHalfExtends.Set(-ezMath::MaxValue<Type>());
 }

--- a/Code/Engine/Foundation/Math/Implementation/Math.cpp
+++ b/Code/Engine/Foundation/Math/Implementation/Math.cpp
@@ -285,7 +285,7 @@ ezVec3 ezBasisAxis::GetBasisVector(Enum basisAxis)
 
     default:
       EZ_REPORT_FAILURE("Invalid basis dir {0}", basisAxis);
-      return ezVec3::ZeroVector();
+      return ezVec3::sZero();
   }
 }
 
@@ -389,19 +389,19 @@ ezBasisAxis::Enum ezBasisAxis::GetOrthogonalAxis(Enum axis1, Enum axis2, bool bF
   if (bFlip)
     c = -c;
 
-  if (c.IsEqual(ezVec3::UnitXAxis(), 0.01f))
+  if (c.IsEqual(ezVec3::sAxisX(), 0.01f))
     return ezBasisAxis::PositiveX;
-  if (c.IsEqual(-ezVec3::UnitXAxis(), 0.01f))
+  if (c.IsEqual(-ezVec3::sAxisX(), 0.01f))
     return ezBasisAxis::NegativeX;
 
-  if (c.IsEqual(ezVec3::UnitYAxis(), 0.01f))
+  if (c.IsEqual(ezVec3::sAxisY(), 0.01f))
     return ezBasisAxis::PositiveY;
-  if (c.IsEqual(-ezVec3::UnitYAxis(), 0.01f))
+  if (c.IsEqual(-ezVec3::sAxisY(), 0.01f))
     return ezBasisAxis::NegativeY;
 
-  if (c.IsEqual(ezVec3::UnitZAxis(), 0.01f))
+  if (c.IsEqual(ezVec3::sAxisZ(), 0.01f))
     return ezBasisAxis::PositiveZ;
-  if (c.IsEqual(-ezVec3::UnitZAxis(), 0.01f))
+  if (c.IsEqual(-ezVec3::sAxisZ(), 0.01f))
     return ezBasisAxis::NegativeZ;
 
   return axis1;

--- a/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Quat_inl.h
@@ -36,7 +36,7 @@ EZ_ALWAYS_INLINE void ezQuatTemplate<Type>::SetElements(Type inX, Type inY, Type
 template <typename Type>
 EZ_ALWAYS_INLINE void ezQuatTemplate<Type>::SetIdentity()
 {
-  v.SetZero();
+  v = ezVec3::sZero();
   w = (Type)1;
 }
 

--- a/Code/Engine/Foundation/Math/Implementation/Transform_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Transform_inl.h
@@ -25,7 +25,7 @@ void ezTransformTemplate<Type>::SetFromMat4(const ezMat4Template<Type>& mMat)
 template <typename Type>
 inline void ezTransformTemplate<Type>::SetIdentity()
 {
-  m_vPosition.SetZero();
+  m_vPosition = ezVec3::sZero();
   m_qRotation.SetIdentity();
   m_vScale.Set(1);
 }
@@ -34,7 +34,7 @@ inline void ezTransformTemplate<Type>::SetIdentity()
 template <typename Type>
 inline const ezTransformTemplate<Type> ezTransformTemplate<Type>::IdentityTransform()
 {
-  return ezTransformTemplate<Type>(ezVec3Template<Type>::ZeroVector(), ezQuatTemplate<Type>::IdentityQuaternion(), ezVec3Template<Type>(1));
+  return ezTransformTemplate<Type>(ezVec3Template<Type>::sZero(), ezQuatTemplate<Type>::IdentityQuaternion(), ezVec3Template<Type>(1));
 }
 
 template <typename Type>

--- a/Code/Engine/Foundation/Math/Mat4.h
+++ b/Code/Engine/Foundation/Math/Mat4.h
@@ -55,8 +55,8 @@ public:
   }
 #endif
 
-  static const ezMat4Template<Type> sZero(); 
-  static const ezMat4Template<Type> sNaN(); 
+  static const ezMat4Template<Type> sZero();
+  static const ezMat4Template<Type> sNaN();
 
   /// \brief Copies 16 values from pData into the matrix. Can handle the data in row-major or column-major order.
   ///
@@ -67,8 +67,8 @@ public:
   ///   The data should be in column-major format, if you want to prevent unnecessary transposes.
   void SetFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
   static const ezMat4Template<Type> sFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // sLoad ??
-  static const ezMat4Template<Type> sFromColumnMajorArray(const Type* const pData); // ??
-  static const ezMat4Template<Type> sFromRowMajorArray(const Type* const pData); // ??
+  static const ezMat4Template<Type> sFromColumnMajorArray(const Type* const pData);                   // ??
+  static const ezMat4Template<Type> sFromRowMajorArray(const Type* const pData);                      // ??
 
   /// \brief Copies the 16 values of this matrix into the given array. 'layout' defines whether the data should end up in column-major or
   /// row-major format.

--- a/Code/Engine/Foundation/Math/Mat4.h
+++ b/Code/Engine/Foundation/Math/Mat4.h
@@ -55,7 +55,6 @@ public:
   }
 #endif
 
-  static const ezMat4Template<Type> sZero();
   static const ezMat4Template<Type> sNaN();
 
   /// \brief Copies 16 values from pData into the matrix. Can handle the data in row-major or column-major order.

--- a/Code/Engine/Foundation/Math/Mat4.h
+++ b/Code/Engine/Foundation/Math/Mat4.h
@@ -55,6 +55,9 @@ public:
   }
 #endif
 
+  static const ezMat4Template<Type> sZero(); 
+  static const ezMat4Template<Type> sNaN(); 
+
   /// \brief Copies 16 values from pData into the matrix. Can handle the data in row-major or column-major order.
   ///
   /// \param pData
@@ -63,6 +66,9 @@ public:
   ///   The layout in which pData stores the matrix. The data will get transposed, if necessary.
   ///   The data should be in column-major format, if you want to prevent unnecessary transposes.
   void SetFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
+  static const ezMat4Template<Type> sFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // sLoad ??
+  static const ezMat4Template<Type> sFromColumnMajorArray(const Type* const pData); // ??
+  static const ezMat4Template<Type> sFromRowMajorArray(const Type* const pData); // ??
 
   /// \brief Copies the 16 values of this matrix into the given array. 'layout' defines whether the data should end up in column-major or
   /// row-major format.
@@ -74,6 +80,7 @@ public:
 
   /// \brief Sets a transformation matrix from a rotation and a translation.
   void SetTransformationMatrix(const ezMat3Template<Type>& mRotation, const ezVec3Template<Type>& vTranslation); // [tested]
+  static const ezMat4Template<Type> sTransformation(const ezMat3Template<Type>& mRotation, const ezVec3Template<Type>& vTranslation); // ??
 
   // *** Special matrix constructors ***
 public:
@@ -85,29 +92,37 @@ public:
 
   /// \brief Sets the matrix to all zero, except the last column, which is set to x,y,z,1
   void SetTranslationMatrix(const ezVec3Template<Type>& vTranslation); // [tested]
+  static const ezMat4Template<Type> sTranslation(const ezVec3Template<Type>& vTranslation);
 
   /// \brief Sets the matrix to all zero, except the diagonal, which is set to x,y,z,1
   void SetScalingMatrix(const ezVec3Template<Type>& vScale); // [tested]
+  static const ezMat4Template<Type> sScale(const ezVec3Template<Type>& vScale);
 
   /// \brief Sets this matrix to be a rotation matrix around the X-axis.
   void SetRotationMatrixX(ezAngle angle); // [tested]
+  static const ezMat4Template<Type> sRotationX(ezAngle angle);
 
   /// \brief Sets this matrix to be a rotation matrix around the Y-axis.
   void SetRotationMatrixY(ezAngle angle); // [tested]
+  static const ezMat4Template<Type> sRotationY(ezAngle angle);
 
   /// \brief Sets this matrix to be a rotation matrix around the Z-axis.
   void SetRotationMatrixZ(ezAngle angle); // [tested]
+  static const ezMat4Template<Type> sRotationZ(ezAngle angle);
 
   /// \brief Sets this matrix to be a rotation matrix around the given axis.
   void SetRotationMatrix(const ezVec3Template<Type>& vAxis, ezAngle angle); // [tested]
+  static const ezMat4Template<Type> sRotation(const ezVec3Template<Type>& vAxis, ezAngle angle);
 
   // *** Common Matrix Operations ***
 public:
   /// \brief Returns an Identity Matrix.
   static const ezMat4Template<Type> IdentityMatrix(); // [tested]
+  static const ezMat4Template<Type> sIdentity();
 
   /// \brief Returns a Zero Matrix.
   static const ezMat4Template<Type> ZeroMatrix(); // [tested]
+  static const ezMat4Template<Type> sZero();
 
   /// \brief Transposes this matrix.
   void Transpose(); // [tested]

--- a/Code/Engine/Foundation/Math/Quat.h
+++ b/Code/Engine/Foundation/Math/Quat.h
@@ -45,6 +45,7 @@ public:
 
   /// \brief Static function that returns a quaternion that represents the identity rotation (none).
   static const ezQuatTemplate<Type> IdentityQuaternion(); // [tested]
+  static const ezQuatTemplate<Type> sIdentity();
 
   // *** Functions to create a quaternion ***
 public:
@@ -56,31 +57,38 @@ public:
   ///
   /// Use this function only if you have good understanding of quaternion math and know exactly what you are doing.
   void SetElements(Type x, Type y, Type z, Type w); // [tested]
+  static const ezQuatTemplate<Type> sFromComponents(Type x, Type y, Type z, Type w); // [tested]
 
   /// \brief Creates a quaternion from a rotation-axis and an angle.
   void SetFromAxisAndAngle(const ezVec3Template<Type>& vRotationAxis, ezAngle angle); // [tested]
+  static const ezQuatTemplate<Type> sFromAxisAndAngle(const ezVec3Template<Type>& vRotationAxis, ezAngle angle);
 
   /// \brief Creates a quaternion, that rotates through the shortest arc from "vDirFrom" to "vDirTo".
   void SetShortestRotation(const ezVec3Template<Type>& vDirFrom, const ezVec3Template<Type>& vDirTo); // [tested]
+  static const ezQuatTemplate<Type> sShortestRotation(const ezVec3Template<Type>& vDirFrom, const ezVec3Template<Type>& vDirTo);
 
   /// \brief Creates a quaternion from the given matrix.
   void SetFromMat3(const ezMat3Template<Type>& m); // [tested]
+  static const ezQuatTemplate<Type> sFromRotationMat3(const ezMat3Template<Type>& m);
 
   /// \brief Reconstructs a rotation quaternion from a matrix that may contain scaling and mirroring.
   ///
   /// In skeletal animation it is possible that matrices with mirroring are used, that need to be converted to a
   /// proper quaternion, even though a rotation with mirroring can't be represented by a quaternion.
   /// This function reconstructs a valid quaternion from such matrices. Obviously the mirroring information gets lost,
-  /// but it is typically not needed any further anway.
+  /// but it is typically not needed any further anyway.
   void ReconstructFromMat3(const ezMat3Template<Type>& m);
+  static const ezQuatTemplate<Type> sFromNonOrthogonalMat3(const ezMat3Template<Type>& m);
 
   /// \brief Reconstructs a rotation quaternion from a matrix that may contain scaling and mirroring.
   ///
   /// \sa ReconstructFromMat3()
   void ReconstructFromMat4(const ezMat4Template<Type>& m);
+  static const ezQuatTemplate<Type> sFromNonOrthogonalMat4(const ezMat4Template<Type>& m);
 
   /// \brief Sets this quaternion to be the spherical linear interpolation of the other two.
   void SetSlerp(const ezQuatTemplate& qFrom, const ezQuatTemplate& qTo, Type t); // [tested]
+  static const ezQuatTemplate<Type> sSlerp(const ezQuatTemplate& qFrom, const ezQuatTemplate& qTo, Type t); // ??
 
   // *** Common Functions ***
 public:

--- a/Code/Engine/Foundation/Math/Transform.h
+++ b/Code/Engine/Foundation/Math/Transform.h
@@ -48,14 +48,21 @@ public:
     const ezQuatTemplate<Type>& qRotation = ezQuatTemplate<Type>::IdentityQuaternion(),
     const ezVec3Template<Type>& vScale = ezVec3Template<Type>(1)); // [tested]
 
+  // ??
+  static ezTransformTemplate<Type> sFromComponents(const ezVec3Template<Type>& vPosition,
+    const ezQuatTemplate<Type>& qRotation = ezQuatTemplate<Type>::IdentityQuaternion(),
+    const ezVec3Template<Type>& vScale = ezVec3Template<Type>(1));
+
   /// \brief Attempts to extract position, scale and rotation from the matrix. Negative scaling and shearing will get lost in the process.
   void SetFromMat4(const ezMat4Template<Type>& mMat);
+  static ezTransformTemplate<Type> sFromMat4();
 
   /// \brief Sets the position to be zero and the rotation to identity.
   void SetIdentity(); // [tested]
 
   /// \brief Returns an Identity Transform.
   static const ezTransformTemplate<Type> IdentityTransform();
+  static ezTransformTemplate<Type> sIdentity();
 
   /// \brief Returns the scale component with maximum magnitude.
   Type GetMaxScale() const;

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -27,19 +27,31 @@ public:
 
   /// \brief Initializes all 3 components with xyz
   explicit ezVec3Template(Type v); // [tested]
+  static ezVec3Template<Type> sAll /*sReplicate? */ (Type value) { return ezVec3Template<Type>(value); }
+
   // no copy-constructor and operator= since the default-generated ones will be faster
 
+  static ezVec3Template<Type> sNaN() { return ZeroVector(); /* TODO */ }
+
   /// \brief Returns a vector with all components set to zero.
-  static ezVec3Template<Type> ZeroVector() { return ezVec3Template(0); } // [tested]
+  static ezVec3Template<Type> ZeroVector() { return ezVec3Template(0); } // [[deprecated]]
+  static ezVec3Template<Type> sZero() { return ZeroVector(); }
+
   /// \brief Returns a vector with all components set to one.
-  static ezVec3Template<Type> OneVector() { return ezVec3Template(1); }
+  static ezVec3Template<Type> OneVector() { return ezVec3Template(1); } // [[deprecated]]
 
   /// \brief Returns a vector initialized to the x unit vector (1, 0, 0).
-  static const ezVec3Template<Type> UnitXAxis() { return ezVec3Template(1, 0, 0); }
+  static const ezVec3Template<Type> UnitXAxis() { return ezVec3Template(1, 0, 0); } // [[deprecated]]
+  static ezVec3Template<Type> sAxisX() { return UnitXAxis(); }
+
   /// \brief Returns a vector initialized to the y unit vector (0, 1, 0).
-  static const ezVec3Template<Type> UnitYAxis() { return ezVec3Template(0, 1, 0); }
+  static const ezVec3Template<Type> UnitYAxis() { return ezVec3Template(0, 1, 0); } // [[deprecated]]
+  static ezVec3Template<Type> sAxisY() { return UnitYAxis(); }
+
   /// \brief Returns a vector initialized to the z unit vector (0, 0, 1).
-  static const ezVec3Template<Type> UnitZAxis() { return ezVec3Template(0, 0, 1); }
+  static const ezVec3Template<Type> UnitZAxis() { return ezVec3Template(0, 0, 1); } // [[deprecated]]
+  static ezVec3Template<Type> sAxisZ() { return UnitZAxis(); }
+
 
 #if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
   void AssertNotNaN() const
@@ -78,7 +90,7 @@ public:
   void Set(Type x, Type y, Type z); // [tested]
 
   /// \brief Sets the vector to all zero.
-  void SetZero(); // [tested]
+  void SetZero(); // [[deprecated]] ?
 
   // *** Functions dealing with length ***
 public:
@@ -163,23 +175,30 @@ public:
   /// \brief Returns the Dot-product of the two vectors (commutative, order does not matter)
   Type Dot(const ezVec3Template<Type>& rhs) const; // [tested]
 
+
+
   /// \brief Returns the Cross-product of the two vectors (NOT commutative, order DOES matter)
   const ezVec3Template<Type> CrossRH(const ezVec3Template<Type>& rhs) const; // [tested]
 
   /// \brief Returns the component-wise minimum of *this and rhs
   const ezVec3Template<Type> CompMin(const ezVec3Template<Type>& rhs) const; // [tested]
+  static ezVec3Template<Type> sMin(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs);
 
   /// \brief Returns the component-wise maximum of *this and rhs
   const ezVec3Template<Type> CompMax(const ezVec3Template<Type>& rhs) const; // [tested]
+  static ezVec3Template<Type> sMax(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs);
 
   /// \brief Returns the component-wise clamped value of *this between low and high.
   const ezVec3Template<Type> CompClamp(const ezVec3Template<Type>& vLow, const ezVec3Template<Type>& vHigh) const; // [tested]
+  static ezVec3Template<Type> sClamp(const ezVec3Template<Type>& value, const ezVec3Template<Type>& min, const ezVec3Template<Type>& max);
 
   /// \brief Returns the component-wise multiplication of *this and rhs
   const ezVec3Template<Type> CompMul(const ezVec3Template<Type>& rhs) const; // [tested]
+  // static ezVec3Template<Type> sMul(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs)  ??
 
   /// \brief Returns the component-wise division of *this and rhs
   const ezVec3Template<Type> CompDiv(const ezVec3Template<Type>& rhs) const; // [tested]
+  // static ezVec3Template<Type> sDiv(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs)  ??
 
   /// brief Returns the component-wise absolute of *this.
   const ezVec3Template<Type> Abs() const; // [tested]
@@ -207,26 +226,32 @@ public:
 
   /// \brief Sets the vector to a random point inside a unit sphere (radius 1).
   static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng); // [tested]
+  static ezVec3Template<Type> sRandomPointInSphere(ezRandom& inout_rng);
 
   /// \brief Creates a random direction vector. The vector is normalized.
   static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng); // [tested]
+  static ezVec3Template<Type> sRandomDirection(ezRandom& inout_rng);
 
   /// \brief Creates a random vector around the x axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  static ezVec3Template<Type> sRandomDeviationX(ezRandom& inout_rng);
 
   /// \brief Creates a random vector around the y axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  static ezVec3Template<Type> sRandomDeviationY(ezRandom& inout_rng);
 
   /// \brief Creates a random vector around the z axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  static ezVec3Template<Type> sRandomDeviationZ(ezRandom& inout_rng);
 
   /// \brief Creates a random vector around the given normal with a maximum deviation.
   /// \note If you are going to do this many times with the same axis, rather than calling this function, instead manually
   /// do what this function does (see inline code) and only compute the quaternion once.
   static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
+  static ezVec3Template<Type> sRandomDeviation(ezRandom& inout_rng);
 };
 
 // *** Operators ***

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -27,31 +27,31 @@ public:
 
   /// \brief Initializes all 3 components with xyz
   explicit ezVec3Template(Type v); // [tested]
-  static ezVec3Template<Type> sAll /*sReplicate? */ (Type value) { return ezVec3Template<Type>(value); }
 
   // no copy-constructor and operator= since the default-generated ones will be faster
 
-  static ezVec3Template<Type> sNaN() { return ZeroVector(); /* TODO */ }
+  /// \brief Returns a vector with all components set to Not-a-Number (NaN).
+  static ezVec3Template<Type> sNaN() { return ezVec3Template<Type>(ezMath::NaN<Type>()); }
+
+  [[deprecated("Use ezVec3::sZero() instead.")]] static ezVec3Template<Type> ZeroVector() { return ezVec3Template<Type>(0); } // [tested]
 
   /// \brief Returns a vector with all components set to zero.
-  static ezVec3Template<Type> ZeroVector() { return ezVec3Template(0); } // [[deprecated]]
-  static ezVec3Template<Type> sZero() { return ZeroVector(); }
+  static ezVec3Template<Type> sZero() { return ezVec3Template<Type>(0); } // [tested]
 
-  /// \brief Returns a vector with all components set to one.
-  static ezVec3Template<Type> OneVector() { return ezVec3Template(1); } // [[deprecated]]
+  [[deprecated("Use ezVec3::sAxisX() instead.")]] static const ezVec3Template<Type> UnitXAxis() { return ezVec3Template(1, 0, 0); } // [tested]
 
-  /// \brief Returns a vector initialized to the x unit vector (1, 0, 0).
-  static const ezVec3Template<Type> UnitXAxis() { return ezVec3Template(1, 0, 0); } // [[deprecated]]
-  static ezVec3Template<Type> sAxisX() { return UnitXAxis(); }
+  /// \brief Returns a vector initialized to the X unit vector (1, 0, 0).
+  static ezVec3Template<Type> sAxisX() { return ezVec3Template<Type>(1, 0, 0); } // [tested]
 
-  /// \brief Returns a vector initialized to the y unit vector (0, 1, 0).
-  static const ezVec3Template<Type> UnitYAxis() { return ezVec3Template(0, 1, 0); } // [[deprecated]]
-  static ezVec3Template<Type> sAxisY() { return UnitYAxis(); }
+  [[deprecated("Use ezVec3::sAxisY() instead.")]] static const ezVec3Template<Type> UnitYAxis() { return ezVec3Template(0, 1, 0); } // [tested]
 
-  /// \brief Returns a vector initialized to the z unit vector (0, 0, 1).
-  static const ezVec3Template<Type> UnitZAxis() { return ezVec3Template(0, 0, 1); } // [[deprecated]]
-  static ezVec3Template<Type> sAxisZ() { return UnitZAxis(); }
+  /// \brief Returns a vector initialized to the Y unit vector (0, 1, 0).
+  static ezVec3Template<Type> sAxisY() { return ezVec3Template<Type>(0, 1, 0); } // [tested]
 
+  [[deprecated("Use ezVec3::sAxisZ() instead.")]] static const ezVec3Template<Type> UnitZAxis() { return ezVec3Template(0, 0, 1); } // [tested]
+
+  /// \brief Returns a vector initialized to the Z unit vector (0, 0, 1).
+  static ezVec3Template<Type> sAxisZ() { return ezVec3Template<Type>(0, 0, 1); } // [tested]
 
 #if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
   void AssertNotNaN() const
@@ -90,7 +90,7 @@ public:
   void Set(Type x, Type y, Type z); // [tested]
 
   /// \brief Sets the vector to all zero.
-  void SetZero(); // [[deprecated]] ?
+  [[deprecated("Use ezVec3::sZero() instead.")]] void SetZero(); // [tested]
 
   // *** Functions dealing with length ***
 public:
@@ -117,8 +117,7 @@ public:
 
   /// \brief Tries to normalize this vector. If the vector is too close to zero, EZ_FAILURE is returned and the vector is set to the given
   /// fallback value.
-  ezResult NormalizeIfNotZero(
-    const ezVec3Template<Type>& vFallback = ezVec3Template(1, 0, 0), Type fEpsilon = ezMath::SmallEpsilon<Type>()); // [tested]
+  ezResult NormalizeIfNotZero(const ezVec3Template<Type>& vFallback = ezVec3Template(1, 0, 0), Type fEpsilon = ezMath::SmallEpsilon<Type>()); // [tested]
 
   /// \brief Returns, whether this vector is (0, 0, 0).
   bool IsZero() const; // [tested]
@@ -182,23 +181,18 @@ public:
 
   /// \brief Returns the component-wise minimum of *this and rhs
   const ezVec3Template<Type> CompMin(const ezVec3Template<Type>& rhs) const; // [tested]
-  static ezVec3Template<Type> sMin(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs);
 
   /// \brief Returns the component-wise maximum of *this and rhs
   const ezVec3Template<Type> CompMax(const ezVec3Template<Type>& rhs) const; // [tested]
-  static ezVec3Template<Type> sMax(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs);
 
   /// \brief Returns the component-wise clamped value of *this between low and high.
   const ezVec3Template<Type> CompClamp(const ezVec3Template<Type>& vLow, const ezVec3Template<Type>& vHigh) const; // [tested]
-  static ezVec3Template<Type> sClamp(const ezVec3Template<Type>& value, const ezVec3Template<Type>& min, const ezVec3Template<Type>& max);
 
   /// \brief Returns the component-wise multiplication of *this and rhs
   const ezVec3Template<Type> CompMul(const ezVec3Template<Type>& rhs) const; // [tested]
-  // static ezVec3Template<Type> sMul(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs)  ??
 
   /// \brief Returns the component-wise division of *this and rhs
   const ezVec3Template<Type> CompDiv(const ezVec3Template<Type>& rhs) const; // [tested]
-  // static ezVec3Template<Type> sDiv(const ezVec3Template<Type>& lhs, const ezVec3Template<Type>& rhs)  ??
 
   /// brief Returns the component-wise absolute of *this.
   const ezVec3Template<Type> Abs() const; // [tested]
@@ -224,34 +218,40 @@ public:
   /// \brief Returns this vector, refracted at vNormal, using the refraction index of the current medium and the medium it enters.
   const ezVec3Template<Type> GetRefractedVector(const ezVec3Template<Type>& vNormal, Type fRefIndex1, Type fRefIndex2) const;
 
-  /// \brief Sets the vector to a random point inside a unit sphere (radius 1).
-  static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng); // [tested]
-  static ezVec3Template<Type> sRandomPointInSphere(ezRandom& inout_rng);
+  [[deprecated("Use ezVec3::sRandomPointInSphere() instead.")]] static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng); // [tested]
+
+  /// \brief Returns a random point inside a unit sphere (radius 1).
+  static ezVec3Template<Type> sRandomPointInSphere(ezRandom& inout_rng); // [tested]
+
+  [[deprecated("Use ezVec3::sRandomDirection() instead.")]] static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng); // [tested]
 
   /// \brief Creates a random direction vector. The vector is normalized.
-  static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng); // [tested]
-  static ezVec3Template<Type> sRandomDirection(ezRandom& inout_rng);
+  static ezVec3Template<Type> sRandomDirection(ezRandom& inout_rng); // [tested]
+
+  [[deprecated("Use ezVec3::sRandomDeviationX() instead.")]] static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
 
   /// \brief Creates a random vector around the x axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
-  static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
-  static ezVec3Template<Type> sRandomDeviationX(ezRandom& inout_rng);
+  static ezVec3Template<Type> sRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+
+  [[deprecated("Use ezVec3::sRandomDeviationY() instead.")]] static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
 
   /// \brief Creates a random vector around the y axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
-  static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
-  static ezVec3Template<Type> sRandomDeviationY(ezRandom& inout_rng);
+  static ezVec3Template<Type> sRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+
+  [[deprecated("Use ezVec3::sRandomDeviationZ() instead.")]] static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
 
   /// \brief Creates a random vector around the z axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
-  static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
-  static ezVec3Template<Type> sRandomDeviationZ(ezRandom& inout_rng);
+  static ezVec3Template<Type> sRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+
+  [[deprecated("Use ezVec3::sRandomDeviation() instead.")]] static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
 
   /// \brief Creates a random vector around the given normal with a maximum deviation.
   /// \note If you are going to do this many times with the same axis, rather than calling this function, instead manually
   /// do what this function does (see inline code) and only compute the quaternion once.
-  static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
-  static ezVec3Template<Type> sRandomDeviation(ezRandom& inout_rng);
+  static ezVec3Template<Type> sRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
 };
 
 // *** Operators ***

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -735,7 +735,7 @@ class EZ_FOUNDATION_DLL ezBoxVisualizerAttribute : public ezVisualizerAttribute
 
 public:
   ezBoxVisualizerAttribute();
-  ezBoxVisualizerAttribute(const char* szSizeProperty, float fSizeScale = 1.0f, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::ZeroVector(), const char* szOffsetProperty = nullptr, const char* szRotationProperty = nullptr);
+  ezBoxVisualizerAttribute(const char* szSizeProperty, float fSizeScale = 1.0f, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::sZero(), const char* szOffsetProperty = nullptr, const char* szRotationProperty = nullptr);
 
   const ezUntrackedString& GetSizeProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetColorProperty() const { return m_sProperty2; }
@@ -755,7 +755,7 @@ class EZ_FOUNDATION_DLL ezSphereVisualizerAttribute : public ezVisualizerAttribu
 
 public:
   ezSphereVisualizerAttribute();
-  ezSphereVisualizerAttribute(const char* szRadiusProperty, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::ZeroVector(), const char* szOffsetProperty = nullptr);
+  ezSphereVisualizerAttribute(const char* szRadiusProperty, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::sZero(), const char* szOffsetProperty = nullptr);
 
   const ezUntrackedString& GetRadiusProperty() const { return m_sProperty1; }
   const ezUntrackedString& GetColorProperty() const { return m_sProperty2; }
@@ -791,8 +791,8 @@ class EZ_FOUNDATION_DLL ezCylinderVisualizerAttribute : public ezVisualizerAttri
 
 public:
   ezCylinderVisualizerAttribute();
-  ezCylinderVisualizerAttribute(ezEnum<ezBasisAxis> axis, const char* szHeightProperty, const char* szRadiusProperty, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::ZeroVector(), const char* szOffsetProperty = nullptr);
-  ezCylinderVisualizerAttribute(const char* szAxisProperty, const char* szHeightProperty, const char* szRadiusProperty, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::ZeroVector(), const char* szOffsetProperty = nullptr);
+  ezCylinderVisualizerAttribute(ezEnum<ezBasisAxis> axis, const char* szHeightProperty, const char* szRadiusProperty, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::sZero(), const char* szOffsetProperty = nullptr);
+  ezCylinderVisualizerAttribute(const char* szAxisProperty, const char* szHeightProperty, const char* szRadiusProperty, const ezColor& fixedColor = ezColorScheme::LightUI(ezColorScheme::Grape), const char* szColorProperty = nullptr, ezBitflags<ezVisualizerAnchor> anchor = ezVisualizerAnchor::Center, ezVec3 vOffsetOrScale = ezVec3::sZero(), const char* szOffsetProperty = nullptr);
 
   const ezUntrackedString& GetAxisProperty() const { return m_sProperty5; }
   const ezUntrackedString& GetHeightProperty() const { return m_sProperty1; }

--- a/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
@@ -461,7 +461,7 @@ ezMat3 ezGraphicsUtils::CreateLookAtViewMatrix(const ezVec3& vTarget, const ezVe
   EZ_ASSERT_DEBUG(!vTarget.IsZero(), "The target must not be at the origin.");
 
   ezVec3 vLookDir = vTarget;
-  vLookDir.NormalizeIfNotZero(ezVec3::UnitXAxis()).IgnoreResult();
+  vLookDir.NormalizeIfNotZero(ezVec3::sAxisX()).IgnoreResult();
 
   ezVec3 vNormalizedUpDir = vUpDir.GetNormalized();
 
@@ -489,7 +489,7 @@ ezMat3 ezGraphicsUtils::CreateInverseLookAtViewMatrix(const ezVec3& vTarget, con
   EZ_ASSERT_DEBUG(!vTarget.IsZero(), "The target must not be at the origin.");
 
   ezVec3 vLookDir = vTarget;
-  vLookDir.NormalizeIfNotZero(ezVec3::UnitXAxis()).IgnoreResult();
+  vLookDir.NormalizeIfNotZero(ezVec3::sAxisX()).IgnoreResult();
 
   ezVec3 vNormalizedUpDir = vUpDir.GetNormalized();
 

--- a/Code/ThirdParty/ads/CMakeLists.txt
+++ b/Code/ThirdParty/ads/CMakeLists.txt
@@ -39,7 +39,7 @@ set (MOC_FILES
 ez_qt_wrap_target_moc_files(${PROJECT_NAME} "${MOC_FILES}")
 
 if(EZ_CMAKE_COMPILER_MSVC)
-  target_compile_options(${PROJECT_NAME} PRIVATE /wd4458 /wd4996 /wd4456 /wd4702)
+  target_compile_options(${PROJECT_NAME} PRIVATE /wd4458 /wd4456 /wd4702)
 endif()
 
 if(EZ_CMAKE_PLATFORM_LINUX)


### PR DESCRIPTION
This has been inspired by how the math classes are designed in Jolt and I find this quite clean. It solves the problem that construction functions are not as easy to find (they all start with lower case s). It also removes the need for different constructors, that all have the same name, but may take very different parameters, and are thus difficult to know from a glance what they are doing.
It also allows to construct in different ways from the same kind of data, and use a different function name to differentiate.

It also makes it easier to construct a const variable, which is not possible if you need to call a non-const member function to configure a variable

It also gives you more options to be explicit. For example:

```
ezVec3 v; // < NaN in debug builds, uninitialized in release
ezVec3 v2 = ezVec3::sNaN(); // clearly always initialized to NaN
```

The only downside (apart from the huge change) might be that this would now always make a copy (though maybe the compilers are good enough to prevent that).

There is obviously lots of room for dicussions and opinions. This PR is mainly to get a rough idea how this could look and to then have a heated discussion about it.