### PR TITLE
Thread safe type registration

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -461,10 +461,8 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
 
   if (pDocumentContext == nullptr)
   {
-    ezRTTI* pRtti = ezRTTI::GetFirstInstance();
-    while (pRtti)
-    {
-      if (pRtti->IsDerivedFrom<ezEngineProcessDocumentContext>())
+    ezRTTI::ForEachDerivedType<ezEngineProcessDocumentContext>(
+      [&](const ezRTTI* pRtti)
       {
         auto* pProp = pRtti->FindPropertyByName("DocumentType");
         if (pProp && pProp->GetCategory() == ezPropertyCategory::Constant)
@@ -500,13 +498,9 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
             }
 
             ezEngineProcessDocumentContext::AddDocumentContext(pMsg->m_DocumentGuid, pMsg->m_DocumentMetaData, pDocumentContext, &m_IPC, pMsg->m_sDocumentType);
-            break;
           }
         }
-      }
-
-      pRtti = pRtti->GetNextInstance();
-    }
+      });
   }
   else
   {
@@ -519,7 +513,8 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
 
 void ezEngineProcessGameApplication::Init_LoadProjectPlugins()
 {
-  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool {
+  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool
+    {
     const bool isEnginePluginLhs = lhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
     const bool isEnginePluginRhs = rhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -462,8 +462,7 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
   if (pDocumentContext == nullptr)
   {
     ezRTTI::ForEachDerivedType<ezEngineProcessDocumentContext>(
-      [&](const ezRTTI* pRtti)
-      {
+      [&](const ezRTTI* pRtti) {
         auto* pProp = pRtti->FindPropertyByName("DocumentType");
         if (pProp && pProp->GetCategory() == ezPropertyCategory::Constant)
         {
@@ -513,8 +512,7 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
 
 void ezEngineProcessGameApplication::Init_LoadProjectPlugins()
 {
-  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool
-    {
+  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool {
     const bool isEnginePluginLhs = lhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
     const bool isEnginePluginRhs = rhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
 

--- a/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.cpp
@@ -9,21 +9,13 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 void ezSceneExportModifier::CreateModifiers(ezHybridArray<ezSceneExportModifier*, 8>& ref_modifiers)
 {
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (!pRtti->IsDerivedFrom<ezSceneExportModifier>())
-      continue;
-
-    if (pRtti->GetTypeFlags().IsAnySet(ezTypeFlags::Abstract))
-      continue;
-
-    if (pRtti->GetAllocator() == nullptr || !pRtti->GetAllocator()->CanAllocate())
-      continue;
-
-    ezSceneExportModifier* pMod = pRtti->GetAllocator()->Allocate<ezSceneExportModifier>();
-
-    ref_modifiers.PushBack(pMod);
-  }
+  ezRTTI::ForEachDerivedType<ezSceneExportModifier>(
+    [&](const ezRTTI* pRtti)
+    {
+      ezSceneExportModifier* pMod = pRtti->GetAllocator()->Allocate<ezSceneExportModifier>();
+      ref_modifiers.PushBack(pMod);
+    },
+    ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 }
 
 void ezSceneExportModifier::DestroyModifiers(ezHybridArray<ezSceneExportModifier*, 8>& ref_modifiers)

--- a/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/SceneExport/SceneExportModifier.cpp
@@ -10,8 +10,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 void ezSceneExportModifier::CreateModifiers(ezHybridArray<ezSceneExportModifier*, 8>& ref_modifiers)
 {
   ezRTTI::ForEachDerivedType<ezSceneExportModifier>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       ezSceneExportModifier* pMod = pRtti->GetAllocator()->Allocate<ezSceneExportModifier>();
       ref_modifiers.PushBack(pMod);
     },

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -65,13 +65,12 @@ void ezAssetDocumentGenerator::AppendFileFilterStrings(ezStringBuilder& out_sFil
 
 void ezAssetDocumentGenerator::CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_Generators)
 {
-  for (ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (!pRtti->IsDerivedFrom<ezAssetDocumentGenerator>() || !pRtti->GetAllocator()->CanAllocate())
-      continue;
-
-    out_Generators.PushBack(pRtti->GetAllocator()->Allocate<ezAssetDocumentGenerator>());
-  }
+  ezRTTI::ForEachDerivedType<ezAssetDocumentGenerator>(
+    [&](const ezRTTI* pRtti)
+    {
+      out_Generators.PushBack(pRtti->GetAllocator()->Allocate<ezAssetDocumentGenerator>());
+    },
+    ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   // sort by name
   out_Generators.Sort([](ezAssetDocumentGenerator* lhs, ezAssetDocumentGenerator* rhs) -> bool { return lhs->GetDocumentExtension().Compare_NoCase(rhs->GetDocumentExtension()) < 0; });

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -66,8 +66,7 @@ void ezAssetDocumentGenerator::AppendFileFilterStrings(ezStringBuilder& out_sFil
 void ezAssetDocumentGenerator::CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_Generators)
 {
   ezRTTI::ForEachDerivedType<ezAssetDocumentGenerator>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       out_Generators.PushBack(pRtti->GetAllocator()->Allocate<ezAssetDocumentGenerator>());
     },
     ezRTTI::ForEachOptions::ExcludeNonAllocatable);

--- a/Code/Editor/EditorFramework/DragDrop/Implementation/DragDropHandler.cpp
+++ b/Code/Editor/EditorFramework/DragDrop/Implementation/DragDropHandler.cpp
@@ -15,9 +15,8 @@ ezDragDropHandler* ezDragDropHandler::FindDragDropHandler(const ezDragDropInfo* 
   float fBestValue = 0.0f;
   ezDragDropHandler* pBestDnD = nullptr;
 
-  for (ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (pRtti->IsDerivedFrom<ezDragDropHandler>() && pRtti->GetAllocator()->CanAllocate())
+  ezRTTI::ForEachDerivedType<ezDragDropHandler>(
+    [&](const ezRTTI* pRtti)
     {
       ezDragDropHandler* pDnD = pRtti->GetAllocator()->Allocate<ezDragDropHandler>();
 
@@ -36,8 +35,8 @@ ezDragDropHandler* ezDragDropHandler::FindDragDropHandler(const ezDragDropInfo* 
       {
         pDnD->GetDynamicRTTI()->GetAllocator()->Deallocate(pDnD);
       }
-    }
-  }
+    },
+    ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   return pBestDnD;
 }

--- a/Code/Editor/EditorFramework/DragDrop/Implementation/DragDropHandler.cpp
+++ b/Code/Editor/EditorFramework/DragDrop/Implementation/DragDropHandler.cpp
@@ -16,8 +16,7 @@ ezDragDropHandler* ezDragDropHandler::FindDragDropHandler(const ezDragDropInfo* 
   ezDragDropHandler* pBestDnD = nullptr;
 
   ezRTTI::ForEachDerivedType<ezDragDropHandler>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       ezDragDropHandler* pDnD = pRtti->GetAllocator()->Allocate<ezDragDropHandler>();
 
       const float fValue = pDnD->CanHandle(pInfo);

--- a/Code/Editor/EditorFramework/LongOps/Implementation/LongOpsAdapter.cpp
+++ b/Code/Editor/EditorFramework/LongOps/Implementation/LongOpsAdapter.cpp
@@ -116,13 +116,14 @@ void ezLongOpsAdapter::PhantomTypeRegistryEventHandler(const ezPhantomRttiManage
 
 void ezLongOpsAdapter::CheckAllTypes()
 {
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (pRtti->GetAttributeByType<ezLongOpAttribute>() != nullptr)
+  ezRTTI::ForEachType(
+    [&](const ezRTTI* pRtti)
     {
-      m_TypesWithLongOps.Insert(pRtti);
-    }
-  }
+      if (pRtti->GetAttributeByType<ezLongOpAttribute>() != nullptr)
+      {
+        m_TypesWithLongOps.Insert(pRtti);
+      }
+    });
 }
 
 void ezLongOpsAdapter::ObjectAdded(const ezDocumentObject* pObject)

--- a/Code/Editor/EditorFramework/LongOps/Implementation/LongOpsAdapter.cpp
+++ b/Code/Editor/EditorFramework/LongOps/Implementation/LongOpsAdapter.cpp
@@ -117,8 +117,7 @@ void ezLongOpsAdapter::PhantomTypeRegistryEventHandler(const ezPhantomRttiManage
 void ezLongOpsAdapter::CheckAllTypes()
 {
   ezRTTI::ForEachType(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       if (pRtti->GetAttributeByType<ezLongOpAttribute>() != nullptr)
       {
         m_TypesWithLongOps.Insert(pRtti);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.cpp
@@ -69,11 +69,11 @@ void ezVisualScriptNodeManager_Legacy::GetCreateableTypes(ezHybridArray<const ez
 {
   const ezRTTI* pNodeBaseType = ezVisualScriptTypeRegistry::GetSingleton()->GetNodeBaseType();
 
-  for (auto it = ezRTTI::GetFirstInstance(); it != nullptr; it = it->GetNextInstance())
-  {
-    if (it->IsDerivedFrom(pNodeBaseType) && !it->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
-      ref_types.PushBack(it);
-  }
+  ezRTTI::ForEachDerivedType(
+    pNodeBaseType,
+    [&](const ezRTTI* pRtti)
+    { ref_types.PushBack(pRtti); },
+    ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 
 const ezRTTI* ezVisualScriptNodeManager_Legacy::GetConnectionType() const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.cpp
@@ -71,8 +71,7 @@ void ezVisualScriptNodeManager_Legacy::GetCreateableTypes(ezHybridArray<const ez
 
   ezRTTI::ForEachDerivedType(
     pNodeBaseType,
-    [&](const ezRTTI* pRtti)
-    { ref_types.PushBack(pRtti); },
+    [&](const ezRTTI* pRtti) { ref_types.PushBack(pRtti); },
     ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptTypeRegistry.cpp
@@ -120,18 +120,16 @@ void ezVisualScriptTypeRegistry::UpdateNodeTypes()
 
   auto& dynEnum = ezDynamicStringEnum::CreateDynamicEnum("ComponentTypes");
 
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (pRtti->IsDerivedFrom<ezComponent>())
+  ezRTTI::ForEachType(
+    [&](const ezRTTI* pRtti)
     {
-      dynEnum.AddValidValue(pRtti->GetTypeName(), true);
-    }
-  }
+      if (pRtti->IsDerivedFrom<ezComponent>())
+      {
+        dynEnum.AddValidValue(pRtti->GetTypeName(), true);
+      }
 
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    UpdateNodeType(pRtti);
-  }
+      UpdateNodeType(pRtti);
+    });
 }
 
 static ezColorGammaUB PinTypeColor(ezVisualScriptDataPinType::Enum type)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptTypeRegistry.cpp
@@ -121,8 +121,7 @@ void ezVisualScriptTypeRegistry::UpdateNodeTypes()
   auto& dynEnum = ezDynamicStringEnum::CreateDynamicEnum("ComponentTypes");
 
   ezRTTI::ForEachType(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       if (pRtti->IsDerivedFrom<ezComponent>())
       {
         dynEnum.AddValidValue(pRtti->GetTypeName(), true);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.cpp
@@ -61,11 +61,11 @@ void ezVisualShaderNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 
 {
   const ezRTTI* pNodeBaseType = ezVisualShaderTypeRegistry::GetSingleton()->GetNodeBaseType();
 
-  for (auto it = ezRTTI::GetFirstInstance(); it != nullptr; it = it->GetNextInstance())
-  {
-    if (it->IsDerivedFrom(pNodeBaseType) && !it->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
-      ref_types.PushBack(it);
-  }
+  ezRTTI::ForEachDerivedType(
+    pNodeBaseType,
+    [&](const ezRTTI* pRtti)
+    { ref_types.PushBack(pRtti); },
+    ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 
 ezStatus ezVisualShaderNodeManager::InternalCanConnect(const ezPin& source, const ezPin& target, CanConnectResult& out_result) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.cpp
@@ -63,8 +63,7 @@ void ezVisualShaderNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 
 
   ezRTTI::ForEachDerivedType(
     pNodeBaseType,
-    [&](const ezRTTI* pRtti)
-    { ref_types.PushBack(pRtti); },
+    [&](const ezRTTI* pRtti) { ref_types.PushBack(pRtti); },
     ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.cpp
@@ -83,8 +83,7 @@ void ezProcGenNodeManager::InternalCreatePins(const ezDocumentObject* pObject, N
 void ezProcGenNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const
 {
   ezRTTI::ForEachDerivedType<ezProcGenNodeBase>(
-    [&](const ezRTTI* pRtti)
-    { ref_types.PushBack(pRtti); },
+    [&](const ezRTTI* pRtti) { ref_types.PushBack(pRtti); },
     ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.cpp
@@ -82,13 +82,10 @@ void ezProcGenNodeManager::InternalCreatePins(const ezDocumentObject* pObject, N
 
 void ezProcGenNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const
 {
-  const ezRTTI* pNodeBaseType = ezGetStaticRTTI<ezProcGenNodeBase>();
-
-  for (auto it = ezRTTI::GetFirstInstance(); it != nullptr; it = it->GetNextInstance())
-  {
-    if (it->IsDerivedFrom(pNodeBaseType) && !it->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
-      ref_types.PushBack(it);
-  }
+  ezRTTI::ForEachDerivedType<ezProcGenNodeBase>(
+    [&](const ezRTTI* pRtti)
+    { ref_types.PushBack(pRtti); },
+    ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 
 const char* ezProcGenNodeManager::GetTypeCategory(const ezRTTI* pRtti) const

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
@@ -48,8 +48,7 @@ void ezSceneObjectManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& 
   ref_types.PushBack(ezGetStaticRTTI<ezGameObject>());
 
   ezRTTI::ForEachDerivedType<ezComponent>(
-    [&](const ezRTTI* pRtti)
-    { ref_types.PushBack(pRtti); },
+    [&](const ezRTTI* pRtti) { ref_types.PushBack(pRtti); },
     ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
@@ -45,15 +45,12 @@ ezSceneObjectManager::ezSceneObjectManager()
 
 void ezSceneObjectManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const
 {
-  ref_types.PushBack(ezRTTI::FindTypeByName(ezGetStaticRTTI<ezGameObject>()->GetTypeName()));
+  ref_types.PushBack(ezGetStaticRTTI<ezGameObject>());
 
-  const ezRTTI* pComponentType = ezRTTI::FindTypeByName(ezGetStaticRTTI<ezComponent>()->GetTypeName());
-
-  for (auto it = ezRTTI::GetFirstInstance(); it != nullptr; it = it->GetNextInstance())
-  {
-    if (it->IsDerivedFrom(pComponentType) && !it->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
-      ref_types.PushBack(it);
-  }
+  ezRTTI::ForEachDerivedType<ezComponent>(
+    [&](const ezRTTI* pRtti)
+    { ref_types.PushBack(pRtti); },
+    ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 
 ezStatus ezSceneObjectManager::InternalCanAdd(

--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
@@ -171,8 +171,7 @@ void ezEditorShapeIconsExtractor::FillShapeIconInfo()
   ezStringBuilder sPath;
 
   ezRTTI::ForEachDerivedType<ezComponent>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       sPath.Set("Editor/ShapeIcons/", pRtti->GetTypeName(), ".dds");
 
       if (ezFileSystem::ExistsFile(sPath))

--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
@@ -170,19 +170,17 @@ void ezEditorShapeIconsExtractor::FillShapeIconInfo()
 
   ezStringBuilder sPath;
 
-  for (ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (!pRtti->IsDerivedFrom<ezComponent>())
-      continue;
-
-    sPath.Set("Editor/ShapeIcons/", pRtti->GetTypeName(), ".dds");
-
-    if (ezFileSystem::ExistsFile(sPath))
+  ezRTTI::ForEachDerivedType<ezComponent>(
+    [&](const ezRTTI* pRtti)
     {
-      auto& shapeIconInfo = m_ShapeIconInfos[pRtti];
-      shapeIconInfo.m_hTexture = ezResourceManager::LoadResource<ezTexture2DResource>(sPath);
-      shapeIconInfo.m_pColorProperty = FindColorProperty(pRtti);
-      shapeIconInfo.m_pColorGammaProperty = FindColorGammaProperty(pRtti);
-    }
-  }
+      sPath.Set("Editor/ShapeIcons/", pRtti->GetTypeName(), ".dds");
+
+      if (ezFileSystem::ExistsFile(sPath))
+      {
+        auto& shapeIconInfo = m_ShapeIconInfos[pRtti];
+        shapeIconInfo.m_hTexture = ezResourceManager::LoadResource<ezTexture2DResource>(sPath);
+        shapeIconInfo.m_pColorProperty = FindColorProperty(pRtti);
+        shapeIconInfo.m_pColorGammaProperty = FindColorGammaProperty(pRtti);
+      }
+    });
 }

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -303,10 +303,8 @@ void ezVisualScriptNodeRegistry::UpdateNodeTypes()
   auto& componentTypesDynEnum = ezDynamicStringEnum::CreateDynamicEnum("ComponentTypes");
   auto& scriptBaseClassesDynEnum = ezDynamicStringEnum::CreateDynamicEnum("ScriptBaseClasses");
 
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    UpdateNodeType(pRtti);
-  }
+  ezRTTI::ForEachType([this](const ezRTTI* pRtti)
+    { UpdateNodeType(pRtti); });
 }
 
 void ezVisualScriptNodeRegistry::UpdateNodeType(const ezRTTI* pRtti)

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -303,8 +303,7 @@ void ezVisualScriptNodeRegistry::UpdateNodeTypes()
   auto& componentTypesDynEnum = ezDynamicStringEnum::CreateDynamicEnum("ComponentTypes");
   auto& scriptBaseClassesDynEnum = ezDynamicStringEnum::CreateDynamicEnum("ScriptBaseClasses");
 
-  ezRTTI::ForEachType([this](const ezRTTI* pRtti)
-    { UpdateNodeType(pRtti); });
+  ezRTTI::ForEachType([this](const ezRTTI* pRtti) { UpdateNodeType(pRtti); });
 }
 
 void ezVisualScriptNodeRegistry::UpdateNodeType(const ezRTTI* pRtti)

--- a/Code/Engine/Core/Configuration/Implementation/PlatformProfile.cpp
+++ b/Code/Engine/Core/Configuration/Implementation/PlatformProfile.cpp
@@ -62,11 +62,10 @@ void ezPlatformProfile::Clear()
 
 void ezPlatformProfile::AddMissingConfigs()
 {
-  for (auto pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    // find all types derived from ezProfileConfigData
-    if (!pRtti->GetTypeFlags().IsAnySet(ezTypeFlags::Abstract) && pRtti->IsDerivedFrom<ezProfileConfigData>() && pRtti->GetAllocator()->CanAllocate())
+  ezRTTI::ForEachDerivedType<ezProfileConfigData>(
+    [this](const ezRTTI* pRtti)
     {
+      // find all types derived from ezProfileConfigData
       bool bHasTypeAlready = false;
 
       // check whether we already have an instance of this type
@@ -88,11 +87,12 @@ void ezPlatformProfile::AddMissingConfigs()
 
         m_Configs.PushBack(pObject);
       }
-    }
-  }
+    },
+    ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   // sort all configs alphabetically
-  m_Configs.Sort([](const ezProfileConfigData* lhs, const ezProfileConfigData* rhs) -> bool { return lhs->GetDynamicRTTI()->GetTypeName().Compare(rhs->GetDynamicRTTI()->GetTypeName()) < 0; });
+  m_Configs.Sort([](const ezProfileConfigData* lhs, const ezProfileConfigData* rhs) -> bool
+    { return lhs->GetDynamicRTTI()->GetTypeName().Compare(rhs->GetDynamicRTTI()->GetTypeName()) < 0; });
 }
 
 const ezProfileConfigData* ezPlatformProfile::GetTypeConfig(const ezRTTI* pRtti) const

--- a/Code/Engine/Core/Configuration/Implementation/PlatformProfile.cpp
+++ b/Code/Engine/Core/Configuration/Implementation/PlatformProfile.cpp
@@ -63,8 +63,7 @@ void ezPlatformProfile::Clear()
 void ezPlatformProfile::AddMissingConfigs()
 {
   ezRTTI::ForEachDerivedType<ezProfileConfigData>(
-    [this](const ezRTTI* pRtti)
-    {
+    [this](const ezRTTI* pRtti) {
       // find all types derived from ezProfileConfigData
       bool bHasTypeAlready = false;
 
@@ -91,8 +90,7 @@ void ezPlatformProfile::AddMissingConfigs()
     ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   // sort all configs alphabetically
-  m_Configs.Sort([](const ezProfileConfigData* lhs, const ezProfileConfigData* rhs) -> bool
-    { return lhs->GetDynamicRTTI()->GetTypeName().Compare(rhs->GetDynamicRTTI()->GetTypeName()) < 0; });
+  m_Configs.Sort([](const ezProfileConfigData* lhs, const ezProfileConfigData* rhs) -> bool { return lhs->GetDynamicRTTI()->GetTypeName().Compare(rhs->GetDynamicRTTI()->GetTypeName()) < 0; });
 }
 
 const ezProfileConfigData* ezPlatformProfile::GetTypeConfig(const ezRTTI* pRtti) const

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -270,8 +270,7 @@ ezUniquePtr<ezGameStateBase> ezGameApplicationBase::CreateGameState(ezWorld* pWo
     ezInt32 iBestPriority = -1;
 
     ezRTTI::ForEachDerivedType<ezGameStateBase>(
-      [&](const ezRTTI* pRtti)
-      {
+      [&](const ezRTTI* pRtti) {
         ezUniquePtr<ezGameStateBase> pState = pRtti->GetAllocator()->Allocate<ezGameStateBase>();
 
         const ezInt32 iPriority = (ezInt32)pState->DeterminePriority(pWorld);

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
@@ -197,8 +197,7 @@ ezResourceLoadDesc ezPrefabResource::UpdateContent(ezStreamReader* Stream)
     }
 
     // sort exposed parameter descriptions by name hash for quicker access
-    m_PrefabParamDescs.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool
-      { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
+    m_PrefabParamDescs.Sort([](const ezExposedPrefabParameterDesc& lhs, const ezExposedPrefabParameterDesc& rhs) -> bool { return lhs.m_sExposeName.GetHash() < rhs.m_sExposeName.GetHash(); });
   }
 
   res.m_State = ezResourceState::Loaded;

--- a/Code/Engine/Core/Prefabs/PrefabResource.h
+++ b/Code/Engine/Core/Prefabs/PrefabResource.h
@@ -22,7 +22,6 @@ struct EZ_CORE_DLL ezExposedPrefabParameterDesc
 
   void Save(ezStreamWriter& inout_stream) const;
   void Load(ezStreamReader& inout_stream);
-  void LoadOld(ezStreamReader& inout_stream);
 };
 
 class EZ_CORE_DLL ezPrefabResource : public ezResource

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -344,13 +344,8 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
 
     for (const ezRTTI* pRtti : info.m_NestedTypes)
     {
-      ezHybridArray<const ezRTTI*, 16> derived;
-      ezRTTI::GetAllTypesDerivedFrom(pRtti, derived, false);
-
-      for (const ezRTTI* pDerived : derived)
-      {
-        todo.Insert(pDerived);
-      }
+      ezRTTI::ForEachDerivedType(pRtti, [&](const ezRTTI* pDerived)
+        { todo.Insert(pDerived); });
     }
 
     while (!todo.IsEmpty())
@@ -369,13 +364,8 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
       {
         if (!visited.Contains(pNestedRtti))
         {
-          ezHybridArray<const ezRTTI*, 16> derived;
-          ezRTTI::GetAllTypesDerivedFrom(pNestedRtti, derived, false);
-
-          for (const ezRTTI* pDerived : derived)
-          {
-            todo.Insert(pDerived);
-          }
+          ezRTTI::ForEachDerivedType(pNestedRtti, [&](const ezRTTI* pDerived)
+            { todo.Insert(pDerived); });
         }
       }
     }

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -344,8 +344,7 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
 
     for (const ezRTTI* pRtti : info.m_NestedTypes)
     {
-      ezRTTI::ForEachDerivedType(pRtti, [&](const ezRTTI* pDerived)
-        { todo.Insert(pDerived); });
+      ezRTTI::ForEachDerivedType(pRtti, [&](const ezRTTI* pDerived) { todo.Insert(pDerived); });
     }
 
     while (!todo.IsEmpty())
@@ -364,8 +363,7 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
       {
         if (!visited.Contains(pNestedRtti))
         {
-          ezRTTI::ForEachDerivedType(pNestedRtti, [&](const ezRTTI* pDerived)
-            { todo.Insert(pDerived); });
+          ezRTTI::ForEachDerivedType(pNestedRtti, [&](const ezRTTI* pDerived) { todo.Insert(pDerived); });
         }
       }
     }

--- a/Code/Engine/Core/World/Implementation/WorldModule.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldModule.cpp
@@ -298,8 +298,7 @@ void ezWorldModuleFactory::FillBaseTypeIds()
 void ezWorldModuleFactory::ClearUnloadedTypeToIDs()
 {
   ezSet<const ezRTTI*> allRttis;
-  ezRTTI::ForEachType([&](const ezRTTI* pRtti)
-    { allRttis.Insert(pRtti); });
+  ezRTTI::ForEachType([&](const ezRTTI* pRtti) { allRttis.Insert(pRtti); });
 
   ezSet<ezWorldModuleTypeId> mappedIdsToRemove;
 

--- a/Code/Engine/Core/World/Implementation/WorldModule.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldModule.cpp
@@ -298,11 +298,8 @@ void ezWorldModuleFactory::FillBaseTypeIds()
 void ezWorldModuleFactory::ClearUnloadedTypeToIDs()
 {
   ezSet<const ezRTTI*> allRttis;
-
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    allRttis.Insert(pRtti);
-  }
+  ezRTTI::ForEachType([&](const ezRTTI* pRtti)
+    { allRttis.Insert(pRtti); });
 
   ezSet<ezWorldModuleTypeId> mappedIdsToRemove;
 

--- a/Code/Engine/Foundation/Communication/Implementation/Message.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/Message.cpp
@@ -29,21 +29,7 @@ ezUniquePtr<ezMessage> ezMessage::ReplicatePackedMessage(ezStreamReader& inout_s
   ezUInt8 uiTypeVersion = 0;
   inout_stream >> uiTypeVersion;
 
-  static ezHashTable<ezUInt64, const ezRTTI*, ezHashHelper<ezUInt64>, ezStaticAllocatorWrapper> MessageTypes;
-
-  const ezRTTI* pRtti = nullptr;
-  if (!MessageTypes.TryGetValue(uiTypeHash, pRtti))
-  {
-    for (pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-    {
-      if (pRtti->GetTypeNameHash() == uiTypeHash)
-      {
-        MessageTypes[uiTypeHash] = pRtti;
-        break;
-      }
-    }
-  }
-
+  const ezRTTI* pRtti = ezRTTI::FindTypeByNameHash(uiTypeHash);
   if (pRtti == nullptr || !pRtti->GetAllocator()->CanAllocate())
     return nullptr;
 

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
@@ -360,7 +360,10 @@ void ezRTTI::ForEachType(VisitorFunc func, ezBitflags<ForEachOptions> options /*
 
   for (const ezRTTI* pRtti : pData->m_AllTypes)
   {
-    if (options.IsSet(ForEachOptions::ExcludeNonAllocatable) && pRtti->GetAllocator()->CanAllocate() == false)
+    if (options.IsSet(ForEachOptions::ExcludeNonAllocatable) && (pRtti->GetAllocator() == nullptr || pRtti->GetAllocator()->CanAllocate() == false))
+      continue;
+
+    if (options.IsSet(ForEachOptions::ExcludeAbstract) && pRtti->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
       continue;
 
     func(pRtti);
@@ -377,7 +380,10 @@ void ezRTTI::ForEachDerivedType(const ezRTTI* pBaseType, VisitorFunc func, ezBit
     if (!pRtti->IsDerivedFrom(pBaseType))
       continue;
 
-    if (options.IsSet(ForEachOptions::ExcludeNonAllocatable) && pRtti->GetAllocator()->CanAllocate() == false)
+    if (options.IsSet(ForEachOptions::ExcludeNonAllocatable) && (pRtti->GetAllocator() == nullptr || pRtti->GetAllocator()->CanAllocate() == false))
+      continue;
+
+    if (options.IsSet(ForEachOptions::ExcludeAbstract) && pRtti->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
       continue;
 
     func(pRtti);

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
@@ -18,8 +18,7 @@ ezTypeData* GetTypeData()
 {
   // Prevent static initialization hazard between first ezRTTI instance
   // and type data and also make sure it is sufficiently sized before first use.
-  auto CreateData = []() -> ezTypeData*
-  {
+  auto CreateData = []() -> ezTypeData* {
     ezTypeData* pData = new ezTypeData();
     pData->m_TypeNameHashToType.Reserve(512);
     pData->m_AllTypes.Reserve(512);
@@ -192,8 +191,7 @@ void ezRTTI::VerifyCorrectness() const
 
 void ezRTTI::VerifyCorrectnessForAllTypes()
 {
-  ezRTTI::ForEachType([](const ezRTTI* pRtti)
-    { pRtti->VerifyCorrectness(); });
+  ezRTTI::ForEachType([](const ezRTTI* pRtti) { pRtti->VerifyCorrectness(); });
 }
 
 
@@ -266,8 +264,7 @@ const ezRTTI* ezRTTI::FindTypeByNameHash(ezUInt64 uiNameHash)
 
 const ezRTTI* ezRTTI::FindTypeByNameHash32(ezUInt32 uiNameHash)
 {
-  return FindTypeIf([=](const ezRTTI* pRtti)
-    { return (ezHashingUtils::StringHashTo32(pRtti->GetTypeNameHash()) == uiNameHash); });
+  return FindTypeIf([=](const ezRTTI* pRtti) { return (ezHashingUtils::StringHashTo32(pRtti->GetTypeNameHash()) == uiNameHash); });
 }
 
 const ezRTTI* ezRTTI::FindTypeIf(PredicateFunc func)

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
@@ -153,6 +153,7 @@ public:
     {
       None = 0,
       ExcludeNonAllocatable = EZ_BIT(0),
+      ExcludeAbstract = EZ_BIT(1),
 
       Default = None
     };
@@ -217,6 +218,8 @@ private:
   /// \brief Handles events by ezPlugin, to figure out which types were provided by which plugin
   static void PluginEventHandler(const ezPluginEvent& EventData);
 };
+
+EZ_DECLARE_FLAGS_OPERATORS(ezRTTI::ForEachOptions);
 
 
 // ***********************************

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
@@ -165,7 +165,7 @@ public:
   };
 
   using VisitorFunc = ezDelegate<void(const ezRTTI*), 48>;
-  static void ForEachType(VisitorFunc func, ezBitflags<ForEachOptions> options = ForEachOptions::Default);// [tested]
+  static void ForEachType(VisitorFunc func, ezBitflags<ForEachOptions> options = ForEachOptions::Default); // [tested]
 
   static void ForEachDerivedType(const ezRTTI* pBaseType, VisitorFunc func, ezBitflags<ForEachOptions> options = ForEachOptions::Default);
 

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.h
@@ -165,7 +165,7 @@ public:
   };
 
   using VisitorFunc = ezDelegate<void(const ezRTTI*), 48>;
-  static void ForEachType(VisitorFunc func, ezBitflags<ForEachOptions> options = ForEachOptions::Default);
+  static void ForEachType(VisitorFunc func, ezBitflags<ForEachOptions> options = ForEachOptions::Default);// [tested]
 
   static void ForEachDerivedType(const ezRTTI* pBaseType, VisitorFunc func, ezBitflags<ForEachOptions> options = ForEachOptions::Default);
 

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -861,8 +861,7 @@ ezAbstractMemberProperty* ezReflectionUtils::GetMemberProperty(const ezRTTI* pRt
 void ezReflectionUtils::GatherTypesDerivedFromClass(const ezRTTI* pBaseRtti, ezSet<const ezRTTI*>& out_types, bool bIncludeDependencies)
 {
   ezRTTI::ForEachDerivedType(pBaseRtti,
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       out_types.Insert(pRtti);
       if (bIncludeDependencies)
       {

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -858,21 +858,17 @@ ezAbstractMemberProperty* ezReflectionUtils::GetMemberProperty(const ezRTTI* pRt
   return nullptr;
 }
 
-void ezReflectionUtils::GatherTypesDerivedFromClass(const ezRTTI* pRtti, ezSet<const ezRTTI*>& out_types, bool bIncludeDependencies)
+void ezReflectionUtils::GatherTypesDerivedFromClass(const ezRTTI* pBaseRtti, ezSet<const ezRTTI*>& out_types, bool bIncludeDependencies)
 {
-  ezRTTI* pFirst = ezRTTI::GetFirstInstance();
-  while (pFirst != nullptr)
-  {
-    if (pFirst->IsDerivedFrom(pRtti))
+  ezRTTI::ForEachDerivedType(pBaseRtti,
+    [&](const ezRTTI* pRtti)
     {
-      out_types.Insert(pFirst);
+      out_types.Insert(pRtti);
       if (bIncludeDependencies)
       {
-        GatherDependentTypes(pFirst, out_types);
+        GatherDependentTypes(pRtti, out_types);
       }
-    }
-    pFirst = pFirst->GetNextInstance();
-  }
+    });
 }
 
 void ezReflectionUtils::GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ezRTTI*>& inout_types)
@@ -1133,7 +1129,7 @@ ezInt64 ezReflectionUtils::MakeEnumerationValid(const ezRTTI* pEnumerationRtti, 
 
 bool ezReflectionUtils::IsEqual(const void* pObject, const void* pObject2, ezAbstractProperty* pProp)
 {
-  //#VAR TEST
+  // #VAR TEST
   const ezRTTI* pPropType = pProp->GetSpecificType();
 
   ezVariant vTemp;

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachine.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachine.cpp
@@ -265,7 +265,7 @@ ezResult ezStateMachineDescription::Deserialize(ezStreamReader& inout_stream)
       inout_stream >> uiToStateIndex;
 
       inout_stream >> sTypeName;
-      if (ezRTTI* pType = ezRTTI::FindTypeByName(sTypeName))
+      if (const ezRTTI* pType = ezRTTI::FindTypeByName(sTypeName))
       {
         ezUniquePtr<ezStateMachineTransition> pTransition = pType->GetAllocator()->Allocate<ezStateMachineTransition>();
         EZ_SUCCEED_OR_RETURN(pTransition->Deserialize(inout_stream));

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -99,8 +99,7 @@ void ezRenderData::UpdateRendererTypes()
 {
   s_RendererTypes.Clear();
 
-  ezRTTI::ForEachDerivedType<ezRenderer>([](const ezRTTI* pRtti)
-    { s_RendererTypes.PushBack(pRtti); },
+  ezRTTI::ForEachDerivedType<ezRenderer>([](const ezRTTI* pRtti) { s_RendererTypes.PushBack(pRtti); },
     ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   s_bRendererInstancesDirty = true;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -99,13 +99,9 @@ void ezRenderData::UpdateRendererTypes()
 {
   s_RendererTypes.Clear();
 
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (!pRtti->IsDerivedFrom<ezRenderer>() || pRtti->GetTypeFlags().IsAnySet(ezTypeFlags::Abstract) || !pRtti->GetAllocator()->CanAllocate())
-      continue;
-
-    s_RendererTypes.PushBack(pRtti);
-  }
+  ezRTTI::ForEachDerivedType<ezRenderer>([](const ezRTTI* pRtti)
+    { s_RendererTypes.PushBack(pRtti); },
+    ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   s_bRendererInstancesDirty = true;
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelineResourceLoader.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelineResourceLoader.cpp
@@ -123,7 +123,7 @@ ezInternal::NewInstance<ezRenderPipeline> ezRenderPipelineResourceLoader::Create
   for (auto it = nodes.GetIterator(); it.IsValid(); ++it)
   {
     auto pNode = it.Value();
-    ezRTTI* pType = ezRTTI::FindTypeByName(pNode->GetType());
+    const ezRTTI* pType = ezRTTI::FindTypeByName(pNode->GetType());
     if (pType && pType->IsDerivedFrom<ezRenderPipelinePass>())
     {
       auto pPass = rttiConverter.CreateObjectFromNode(pNode);

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -261,8 +261,7 @@ ezResult ezShaderCompiler::CompileShaderPermutationForPlatforms(ezStringView sFi
   // try out every compiler that we can find
   ezResult result = EZ_SUCCESS;
   ezRTTI::ForEachDerivedType<ezShaderProgramCompiler>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       ezUniquePtr<ezShaderProgramCompiler> pCompiler = pRtti->GetAllocator()->Allocate<ezShaderProgramCompiler>();
 
       if (RunShaderCompiler(sFile, sPlatform, pCompiler.Borrow(), pLog).Failed())
@@ -331,8 +330,7 @@ ezResult ezShaderCompiler::RunShaderCompiler(ezStringView sFile, ezStringView sP
       }
 
       bool bFoundUndefinedVars = false;
-      pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e)
-        {
+      pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e) {
         if (e.m_Type == ezPreprocessor::ProcessingEvent::EvaluateUnknown)
         {
           bFoundUndefinedVars = true;
@@ -373,8 +371,7 @@ ezResult ezShaderCompiler::RunShaderCompiler(ezStringView sFile, ezStringView sP
       pp.SetPassThroughPragma(true);
       pp.SetPassThroughUnknownCmdsCB(ezMakeDelegate(&ezShaderCompiler::PassThroughUnknownCommandCB, this));
       pp.SetPassThroughLine(false);
-      pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e)
-        {
+      pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e) {
         if (e.m_Type == ezPreprocessor::ProcessingEvent::EvaluateUnknown)
         {
           bFoundUndefinedVars = true;

--- a/Code/EnginePlugins/InspectorPlugin/Reflection.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/Reflection.cpp
@@ -96,8 +96,7 @@ namespace ReflectionDetail
 
     SendBasicTypesGroup();
 
-    ezRTTI::ForEachType([](const ezRTTI* pRtti)
-      { SendReflectionTelemetry(pRtti); });
+    ezRTTI::ForEachType([](const ezRTTI* pRtti) { SendReflectionTelemetry(pRtti); });
   }
 
 

--- a/Code/EnginePlugins/InspectorPlugin/Reflection.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/Reflection.cpp
@@ -20,7 +20,7 @@ namespace ReflectionDetail
     ezTelemetry::Broadcast(ezTelemetry::Reliable, msg);
   }
 
-  static ezStringView GetParentType(ezRTTI* pRTTI)
+  static ezStringView GetParentType(const ezRTTI* pRTTI)
   {
     if (pRTTI->GetParentType())
     {
@@ -45,7 +45,7 @@ namespace ReflectionDetail
     return {};
   }
 
-  static void SendReflectionTelemetry(ezRTTI* pRTTI)
+  static void SendReflectionTelemetry(const ezRTTI* pRTTI)
   {
     ezTelemetryMessage msg;
     msg.SetMessageID('RFLC', 'DATA');
@@ -96,14 +96,8 @@ namespace ReflectionDetail
 
     SendBasicTypesGroup();
 
-    ezRTTI* pRTTI = ezRTTI::GetFirstInstance();
-
-    while (pRTTI)
-    {
-      SendReflectionTelemetry(pRTTI);
-
-      pRTTI = pRTTI->GetNextInstance();
-    }
+    ezRTTI::ForEachType([](const ezRTTI* pRtti)
+      { SendReflectionTelemetry(pRtti); });
   }
 
 

--- a/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleWorldModule.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleWorldModule.cpp
@@ -57,8 +57,7 @@ void ezParticleWorldModule::Initialize()
   ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&ezParticleWorldModule::ResourceEventHandler, this));
 
   ezRTTI::ForEachDerivedType<ezParticleModule>(
-    [this](const ezRTTI* pRtti)
-    {
+    [this](const ezRTTI* pRtti) {
       ezUniquePtr<ezParticleModule> pModule = pRtti->GetAllocator()->Allocate<ezParticleModule>();
       pModule->RequestRequiredWorldModulesForCache(this);
     },
@@ -150,8 +149,7 @@ void ezParticleWorldModule::ConfigureParticleStreamFactories()
   ezStringBuilder fullName;
 
   ezRTTI::ForEachDerivedType<ezParticleStreamFactory>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       ezParticleStreamFactory* pFactory = pRtti->GetAllocator()->Allocate<ezParticleStreamFactory>();
 
       ezParticleStreamFactory::GetFullStreamName(pFactory->GetStreamName(), pFactory->GetStreamDataType(), fullName);

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/ComponentCodeGen.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/ComponentCodeGen.cpp
@@ -110,10 +110,8 @@ static void CreateComponentTypeList(ezDynamicArray<const ezRTTI*>& out_sorted)
   out_sorted.Reserve(100);
 
   ezHybridArray<const ezRTTI*, 64> alphabetical;
-  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
-    { alphabetical.PushBack(pRtti); });
-  alphabetical.Sort([](const ezRTTI* p1, const ezRTTI* p2) -> bool
-    { return p1->GetTypeName().Compare(p2->GetTypeName()) < 0; });
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti) { alphabetical.PushBack(pRtti); });
+  alphabetical.Sort([](const ezRTTI* p1, const ezRTTI* p2) -> bool { return p1->GetTypeName().Compare(p2->GetTypeName()) < 0; });
 
   for (auto pRtti : alphabetical)
   {

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/ComponentCodeGen.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/ComponentCodeGen.cpp
@@ -104,20 +104,27 @@ static void CreateComponentTypeList(ezSet<const ezRTTI*>& ref_found, ezDynamicAr
   ref_sorted.PushBack(pRtti);
 }
 
-void ezTypeScriptBinding::GenerateAllComponentsCode(ezStringBuilder& out_Code)
+static void CreateComponentTypeList(ezDynamicArray<const ezRTTI*>& out_sorted)
 {
   ezSet<const ezRTTI*> found;
-  ezDynamicArray<const ezRTTI*> sorted;
-  sorted.Reserve(100);
+  out_sorted.Reserve(100);
 
   ezHybridArray<const ezRTTI*, 64> alphabetical;
-  for (auto pRtti : ezRTTI::GetAllTypesDerivedFrom(ezGetStaticRTTI<ezComponent>(), alphabetical, true))
-  {
-    if (pRtti == ezGetStaticRTTI<ezComponent>() || pRtti == ezGetStaticRTTI<ezTypeScriptComponent>())
-      continue;
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
+    { alphabetical.PushBack(pRtti); });
+  alphabetical.Sort([](const ezRTTI* p1, const ezRTTI* p2) -> bool
+    { return p1->GetTypeName().Compare(p2->GetTypeName()) < 0; });
 
-    CreateComponentTypeList(found, sorted, pRtti);
+  for (auto pRtti : alphabetical)
+  {
+    CreateComponentTypeList(found, out_sorted, pRtti);
   }
+}
+
+void ezTypeScriptBinding::GenerateAllComponentsCode(ezStringBuilder& out_Code)
+{
+  ezDynamicArray<const ezRTTI*> sorted;
+  CreateComponentTypeList(sorted);
 
   for (auto pRtti : sorted)
   {
@@ -189,15 +196,8 @@ declare function __CPP_ComponentFunction_Call(component: Component, id: number, 
 
 void ezTypeScriptBinding::InjectComponentImportExport(ezStringBuilder& content, const char* szComponentFile)
 {
-  ezSet<const ezRTTI*> found;
   ezDynamicArray<const ezRTTI*> sorted;
-  sorted.Reserve(100);
-
-  ezHybridArray<const ezRTTI*, 64> alphabetical;
-  for (auto pRtti : ezRTTI::GetAllTypesDerivedFrom(ezGetStaticRTTI<ezComponent>(), alphabetical, true))
-  {
-    CreateComponentTypeList(found, sorted, pRtti);
-  }
+  CreateComponentTypeList(sorted);
 
   ezStringBuilder sImportExport, sTypeName;
 

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/FunctionBinding.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/FunctionBinding.cpp
@@ -28,8 +28,7 @@ void ezTypeScriptBinding::SetupRttiFunctionBindings()
     return;
 
   ezRTTI::ForEachDerivedType<ezComponent>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       for (ezAbstractFunctionProperty* pFunc : pRtti->GetFunctions())
       {
         // TODO: static members ?

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/FunctionBinding.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/FunctionBinding.cpp
@@ -27,26 +27,24 @@ void ezTypeScriptBinding::SetupRttiFunctionBindings()
   if (!s_BoundFunctions.IsEmpty())
     return;
 
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (!pRtti->IsDerivedFrom<ezComponent>())
-      continue;
-
-    for (ezAbstractFunctionProperty* pFunc : pRtti->GetFunctions())
+  ezRTTI::ForEachDerivedType<ezComponent>(
+    [&](const ezRTTI* pRtti)
     {
-      // TODO: static members ?
-      if (pFunc->GetFunctionType() != ezFunctionType::Member)
-        continue;
-
-      const ezUInt32 uiHash = ComputeFunctionBindingHash(pRtti, pFunc);
-      if (auto pExistingBinding = s_BoundFunctions.GetValue(uiHash))
+      for (ezAbstractFunctionProperty* pFunc : pRtti->GetFunctions())
       {
-        EZ_ASSERT_DEV(ezStringUtils::IsEqual(pExistingBinding->m_pFunc->GetPropertyName(), pFunc->GetPropertyName()), "Hash collision for bound function name!");
-      }
+        // TODO: static members ?
+        if (pFunc->GetFunctionType() != ezFunctionType::Member)
+          continue;
 
-      s_BoundFunctions[uiHash].m_pFunc = pFunc;
-    }
-  }
+        const ezUInt32 uiHash = ComputeFunctionBindingHash(pRtti, pFunc);
+        if (auto pExistingBinding = s_BoundFunctions.GetValue(uiHash))
+        {
+          EZ_ASSERT_DEV(ezStringUtils::IsEqual(pExistingBinding->m_pFunc->GetPropertyName(), pFunc->GetPropertyName()), "Hash collision for bound function name!");
+        }
+
+        s_BoundFunctions[uiHash].m_pFunc = pFunc;
+      }
+    });
 }
 
 const char* ezTypeScriptBinding::TsType(const ezRTTI* pRtti)

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/PropertyBinding.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/PropertyBinding.cpp
@@ -30,22 +30,20 @@ void ezTypeScriptBinding::SetupRttiPropertyBindings()
   if (!s_BoundProperties.IsEmpty())
     return;
 
-  for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti != nullptr; pRtti = pRtti->GetNextInstance())
-  {
-    if (!pRtti->IsDerivedFrom<ezComponent>())
-      continue;
-
-    for (ezAbstractProperty* pProp : pRtti->GetProperties())
+  ezRTTI::ForEachDerivedType<ezComponent>(
+    [&](const ezRTTI* pRtti)
     {
-      if (pProp->GetCategory() != ezPropertyCategory::Member)
-        continue;
+      for (ezAbstractProperty* pProp : pRtti->GetProperties())
+      {
+        if (pProp->GetCategory() != ezPropertyCategory::Member)
+          continue;
 
-      const ezUInt32 uiHash = ComputePropertyBindingHash(pRtti, static_cast<ezAbstractMemberProperty*>(pProp));
-      EZ_ASSERT_DEV(!s_BoundProperties.Contains(uiHash), "Hash collision for bound property name!");
+        const ezUInt32 uiHash = ComputePropertyBindingHash(pRtti, static_cast<ezAbstractMemberProperty*>(pProp));
+        EZ_ASSERT_DEV(!s_BoundProperties.Contains(uiHash), "Hash collision for bound property name!");
 
-      s_BoundProperties[uiHash].m_pMember = static_cast<ezAbstractMemberProperty*>(pProp);
-    }
-  }
+        s_BoundProperties[uiHash].m_pMember = static_cast<ezAbstractMemberProperty*>(pProp);
+      }
+    });
 }
 
 void ezTypeScriptBinding::GeneratePropertiesCode(ezStringBuilder& out_Code, const ezRTTI* pRtti)

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/PropertyBinding.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/PropertyBinding.cpp
@@ -31,8 +31,7 @@ void ezTypeScriptBinding::SetupRttiPropertyBindings()
     return;
 
   ezRTTI::ForEachDerivedType<ezComponent>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       for (ezAbstractProperty* pProp : pRtti->GetProperties())
       {
         if (pProp->GetCategory() != ezPropertyCategory::Member)

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsMessages.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsMessages.cpp
@@ -90,10 +90,8 @@ static void CreateMessageTypeList(ezDynamicArray<const ezRTTI*>& out_sorted)
   out_sorted.Reserve(100);
 
   ezHybridArray<const ezRTTI*, 64> alphabetical;
-  ezRTTI::ForEachDerivedType<ezMessage>([&](const ezRTTI* pRtti)
-    { alphabetical.PushBack(pRtti); });
-  alphabetical.Sort([](const ezRTTI* p1, const ezRTTI* p2) -> bool
-    { return p1->GetTypeName().Compare(p2->GetTypeName()) < 0; });
+  ezRTTI::ForEachDerivedType<ezMessage>([&](const ezRTTI* pRtti) { alphabetical.PushBack(pRtti); });
+  alphabetical.Sort([](const ezRTTI* p1, const ezRTTI* p2) -> bool { return p1->GetTypeName().Compare(p2->GetTypeName()) < 0; });
 
   for (auto pRtti : alphabetical)
   {
@@ -187,8 +185,7 @@ static ezUniquePtr<ezMessage> CreateMessage(ezUInt32 uiTypeHash, const ezRTTI*& 
 
   if (!MessageTypes.TryGetValue(uiTypeHash, ref_pRtti))
   {
-    ref_pRtti = ezRTTI::FindTypeIf([=](const ezRTTI* pRtti)
-      { return ezHashingUtils::StringHashTo32(pRtti->GetTypeNameHash()) == uiTypeHash; });
+    ref_pRtti = ezRTTI::FindTypeIf([=](const ezRTTI* pRtti) { return ezHashingUtils::StringHashTo32(pRtti->GetTypeNameHash()) == uiTypeHash; });
     MessageTypes[uiTypeHash] = ref_pRtti;
   }
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -94,12 +94,8 @@ void ezDocumentManager::UpdatedAfterLoadingPlugins()
 {
   bool bChanges = false;
 
-  ezRTTI* pRtti = ezRTTI::GetFirstInstance();
-
-  while (pRtti)
-  {
-    // find all types derived from ezDocumentManager
-    if (pRtti->IsDerivedFrom<ezDocumentManager>())
+  ezRTTI::ForEachDerivedType<ezDocumentManager>(
+    [&](const ezRTTI* pRtti)
     {
       // add the ones that we don't know yet
       if (!s_KnownManagers.Find(pRtti).IsValid())
@@ -116,15 +112,11 @@ void ezDocumentManager::UpdatedAfterLoadingPlugins()
           bChanges = true;
         }
       }
-    }
-
-    pRtti = pRtti->GetNextInstance();
-  }
+    });
 
   // triggers a reevaluation next time
   s_AllDocumentDescriptors.Clear();
   GetAllDocumentDescriptors();
-
 
   if (bChanges)
   {

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentManager.cpp
@@ -95,8 +95,7 @@ void ezDocumentManager::UpdatedAfterLoadingPlugins()
   bool bChanges = false;
 
   ezRTTI::ForEachDerivedType<ezDocumentManager>(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       // add the ones that we don't know yet
       if (!s_KnownManagers.Find(pRtti).IsValid())
       {

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRttiManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRttiManager.cpp
@@ -39,7 +39,7 @@ EZ_END_SUBSYSTEM_DECLARATION;
 const ezRTTI* ezPhantomRttiManager::RegisterType(ezReflectedTypeDescriptor& ref_desc)
 {
   EZ_PROFILE_SCOPE("RegisterType");
-  ezRTTI* pType = ezRTTI::FindTypeByName(ref_desc.m_sTypeName);
+  const ezRTTI* pType = ezRTTI::FindTypeByName(ref_desc.m_sTypeName);
   ezPhantomRTTI* pPhantom = nullptr;
   s_NameToPhantom.TryGetValue(ref_desc.m_sTypeName, pPhantom);
 

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/PhantomProperty.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/PhantomProperty.h
@@ -16,7 +16,7 @@ public:
 private:
   ezVariant m_Value;
   ezString m_sPropertyNameStorage;
-  ezRTTI* m_pPropertyType;
+  const ezRTTI* m_pPropertyType;
 };
 
 class ezPhantomMemberProperty : public ezAbstractMemberProperty
@@ -32,7 +32,7 @@ public:
 
 private:
   ezString m_sPropertyNameStorage;
-  ezRTTI* m_pPropertyType;
+  const ezRTTI* m_pPropertyType;
 };
 
 class ezPhantomFunctionProperty : public ezAbstractFunctionProperty
@@ -75,7 +75,7 @@ public:
 
 private:
   ezString m_sPropertyNameStorage;
-  ezRTTI* m_pPropertyType;
+  const ezRTTI* m_pPropertyType;
 };
 
 
@@ -95,7 +95,7 @@ public:
 
 private:
   ezString m_sPropertyNameStorage;
-  ezRTTI* m_pPropertyType;
+  const ezRTTI* m_pPropertyType;
 };
 
 
@@ -116,5 +116,5 @@ public:
 
 private:
   ezString m_sPropertyNameStorage;
-  ezRTTI* m_pPropertyType;
+  const ezRTTI* m_pPropertyType;
 };

--- a/Code/Tools/Libs/ToolsFoundation/Serialization/Implementation/DocumentObjectConverter.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Serialization/Implementation/DocumentObjectConverter.cpp
@@ -153,7 +153,7 @@ ezDocumentObjectConverterReader::ezDocumentObjectConverterReader(const ezAbstrac
 ezDocumentObject* ezDocumentObjectConverterReader::CreateObjectFromNode(const ezAbstractObjectNode* pNode)
 {
   ezDocumentObject* pObject = nullptr;
-  ezRTTI* pType = ezRTTI::FindTypeByName(pNode->GetType());
+  const ezRTTI* pType = ezRTTI::FindTypeByName(pNode->GetType());
   if (pType)
   {
     pObject = m_pManager->CreateObject(pType, pNode->GetGuid());

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -736,7 +736,8 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   };
 
   ezDynamicArray<const ezRTTI*> componentTypes;
-  ezRTTI::GetAllTypesDerivedFrom(ezGetStaticRTTI<ezComponent>(), componentTypes, true);
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
+    { componentTypes.PushBack(pRtti); });
 
   ezSet<const ezRTTI*> blacklist;
   // The scene already has one and the code asserts otherwise. There needs to be a general way of preventing two settings components from existing at the same time.

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -736,8 +736,7 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   };
 
   ezDynamicArray<const ezRTTI*> componentTypes;
-  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
-    { componentTypes.PushBack(pRtti); });
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti) { componentTypes.PushBack(pRtti); });
 
   ezSet<const ezRTTI*> blacklist;
   // The scene already has one and the code asserts otherwise. There needs to be a general way of preventing two settings components from existing at the same time.

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -107,8 +107,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
     bool bFoundClass1 = false;
     bool bFoundClass2 = false;
 
-    ezRTTI::ForEachType([&](const ezRTTI* pRtti)
-      {
+    ezRTTI::ForEachType([&](const ezRTTI* pRtti) {
         if (pRtti->GetTypeName() == "ezTestStruct")
           bFoundStruct = true;
         if (pRtti->GetTypeName() == "ezTestClass1")
@@ -126,12 +125,10 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsDerivedFrom")
   {
     ezDynamicArray<const ezRTTI*> allTypes;
-    ezRTTI::ForEachType([&](const ezRTTI* pRtti)
-      { allTypes.PushBack(pRtti); });
+    ezRTTI::ForEachType([&](const ezRTTI* pRtti) { allTypes.PushBack(pRtti); });
 
     // ground truth - traversing up the parent list
-    auto ManualIsDerivedFrom = [](const ezRTTI* t, const ezRTTI* pBaseType) -> bool
-    {
+    auto ManualIsDerivedFrom = [](const ezRTTI* t, const ezRTTI* pBaseType) -> bool {
       while (t != nullptr)
       {
         if (t == pBaseType)
@@ -319,8 +316,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
     bool bFoundStruct2 = false;
 
     ezRTTI::ForEachType(
-      [&](const ezRTTI* pRtti)
-      {
+      [&](const ezRTTI* pRtti) {
         if (pRtti->GetTypeName() == "ezTestStruct2")
         {
           bFoundStruct2 = true;

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -107,21 +107,16 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
     bool bFoundClass1 = false;
     bool bFoundClass2 = false;
 
-    ezRTTI* pRtti = ezRTTI::GetFirstInstance();
+    ezRTTI::ForEachType([&](const ezRTTI* pRtti)
+      {
+        if (pRtti->GetTypeName() == "ezTestStruct")
+          bFoundStruct = true;
+        if (pRtti->GetTypeName() == "ezTestClass1")
+          bFoundClass1 = true;
+        if (pRtti->GetTypeName() == "ezTestClass2")
+          bFoundClass2 = true;
 
-    while (pRtti)
-    {
-      if (pRtti->GetTypeName() == "ezTestStruct")
-        bFoundStruct = true;
-      if (pRtti->GetTypeName() == "ezTestClass1")
-        bFoundClass1 = true;
-      if (pRtti->GetTypeName() == "ezTestClass2")
-        bFoundClass2 = true;
-
-      EZ_TEST_STRING(pRtti->GetPluginName(), "Static");
-
-      pRtti = pRtti->GetNextInstance();
-    }
+        EZ_TEST_STRING(pRtti->GetPluginName(), "Static"); });
 
     EZ_TEST_BOOL(bFoundStruct);
     EZ_TEST_BOOL(bFoundClass1);
@@ -131,13 +126,12 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsDerivedFrom")
   {
     ezDynamicArray<const ezRTTI*> allTypes;
-    for (const ezRTTI* pRtti = ezRTTI::GetFirstInstance(); pRtti; pRtti = pRtti->GetNextInstance())
-    {
-      allTypes.PushBack(pRtti);
-    }
+    ezRTTI::ForEachType([&](const ezRTTI* pRtti)
+      { allTypes.PushBack(pRtti); });
 
     // ground truth - traversing up the parent list
-    auto ManualIsDerivedFrom = [](const ezRTTI* t, const ezRTTI* pBaseType) -> bool {
+    auto ManualIsDerivedFrom = [](const ezRTTI* t, const ezRTTI* pBaseType) -> bool
+    {
       while (t != nullptr)
       {
         if (t == pBaseType)
@@ -206,38 +200,38 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "FindTypeByName")
   {
-    ezRTTI* pFloat = ezRTTI::FindTypeByName("float");
+    const ezRTTI* pFloat = ezRTTI::FindTypeByName("float");
     EZ_TEST_BOOL(pFloat != nullptr);
     EZ_TEST_STRING(pFloat->GetTypeName(), "float");
 
-    ezRTTI* pStruct = ezRTTI::FindTypeByName("ezTestStruct");
+    const ezRTTI* pStruct = ezRTTI::FindTypeByName("ezTestStruct");
     EZ_TEST_BOOL(pStruct != nullptr);
     EZ_TEST_STRING(pStruct->GetTypeName(), "ezTestStruct");
 
-    ezRTTI* pClass2 = ezRTTI::FindTypeByName("ezTestClass2");
+    const ezRTTI* pClass2 = ezRTTI::FindTypeByName("ezTestClass2");
     EZ_TEST_BOOL(pClass2 != nullptr);
     EZ_TEST_STRING(pClass2->GetTypeName(), "ezTestClass2");
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "FindTypeByNameHash")
   {
-    ezRTTI* pFloat = ezRTTI::FindTypeByName("float");
-    ezRTTI* pFloat2 = ezRTTI::FindTypeByNameHash(pFloat->GetTypeNameHash());
+    const ezRTTI* pFloat = ezRTTI::FindTypeByName("float");
+    const ezRTTI* pFloat2 = ezRTTI::FindTypeByNameHash(pFloat->GetTypeNameHash());
     EZ_TEST_BOOL(pFloat == pFloat2);
 
-    ezRTTI* pStruct = ezRTTI::FindTypeByName("ezTestStruct");
-    ezRTTI* pStruct2 = ezRTTI::FindTypeByNameHash(pStruct->GetTypeNameHash());
+    const ezRTTI* pStruct = ezRTTI::FindTypeByName("ezTestStruct");
+    const ezRTTI* pStruct2 = ezRTTI::FindTypeByNameHash(pStruct->GetTypeNameHash());
     EZ_TEST_BOOL(pStruct == pStruct2);
 
-    ezRTTI* pClass = ezRTTI::FindTypeByName("ezTestClass2");
-    ezRTTI* pClass2 = ezRTTI::FindTypeByNameHash(pClass->GetTypeNameHash());
+    const ezRTTI* pClass = ezRTTI::FindTypeByName("ezTestClass2");
+    const ezRTTI* pClass2 = ezRTTI::FindTypeByNameHash(pClass->GetTypeNameHash());
     EZ_TEST_BOOL(pClass == pClass2);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetProperties")
   {
     {
-      ezRTTI* pType = ezRTTI::FindTypeByName("ezTestStruct");
+      const ezRTTI* pType = ezRTTI::FindTypeByName("ezTestStruct");
 
       auto Props = pType->GetProperties();
       EZ_TEST_INT(Props.GetCount(), 9);
@@ -253,7 +247,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
     }
 
     {
-      ezRTTI* pType = ezRTTI::FindTypeByName("ezTestClass2");
+      const ezRTTI* pType = ezRTTI::FindTypeByName("ezTestClass2");
 
       auto Props = pType->GetProperties();
       EZ_TEST_INT(Props.GetCount(), 6);
@@ -314,7 +308,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
     if (loadPlugin.Failed())
       return;
 
-    ezRTTI* pStruct2 = ezRTTI::FindTypeByName("ezTestStruct2");
+    const ezRTTI* pStruct2 = ezRTTI::FindTypeByName("ezTestStruct2");
     EZ_TEST_BOOL(pStruct2 != nullptr);
 
     if (pStruct2)
@@ -324,43 +318,40 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
 
     bool bFoundStruct2 = false;
 
-    ezRTTI* pRtti = ezRTTI::GetFirstInstance();
-
-    while (pRtti)
-    {
-      if (pRtti->GetTypeName() == "ezTestStruct2")
+    ezRTTI::ForEachType(
+      [&](const ezRTTI* pRtti)
       {
-        bFoundStruct2 = true;
+        if (pRtti->GetTypeName() == "ezTestStruct2")
+        {
+          bFoundStruct2 = true;
 
-        EZ_TEST_STRING(pRtti->GetPluginName(), ezFoundationTest_Plugin1);
+          EZ_TEST_STRING(pRtti->GetPluginName(), ezFoundationTest_Plugin1);
 
-        void* pInstance = pRtti->GetAllocator()->Allocate<void>();
-        EZ_TEST_BOOL(pInstance != nullptr);
+          void* pInstance = pRtti->GetAllocator()->Allocate<void>();
+          EZ_TEST_BOOL(pInstance != nullptr);
 
-        ezAbstractProperty* pProp = pRtti->FindPropertyByName("Float2");
+          ezAbstractProperty* pProp = pRtti->FindPropertyByName("Float2");
 
-        EZ_TEST_BOOL(pProp != nullptr);
+          EZ_TEST_BOOL(pProp != nullptr);
 
-        EZ_TEST_BOOL(pProp->GetCategory() == ezPropertyCategory::Member);
-        ezAbstractMemberProperty* pAbsMember = (ezAbstractMemberProperty*)pProp;
+          EZ_TEST_BOOL(pProp->GetCategory() == ezPropertyCategory::Member);
+          ezAbstractMemberProperty* pAbsMember = (ezAbstractMemberProperty*)pProp;
 
-        EZ_TEST_BOOL(pAbsMember->GetSpecificType() == ezGetStaticRTTI<float>());
+          EZ_TEST_BOOL(pAbsMember->GetSpecificType() == ezGetStaticRTTI<float>());
 
-        ezTypedMemberProperty<float>* pMember = (ezTypedMemberProperty<float>*)pAbsMember;
+          ezTypedMemberProperty<float>* pMember = (ezTypedMemberProperty<float>*)pAbsMember;
 
-        EZ_TEST_FLOAT(pMember->GetValue(pInstance), 42.0f, 0);
-        pMember->SetValue(pInstance, 43.0f);
-        EZ_TEST_FLOAT(pMember->GetValue(pInstance), 43.0f, 0);
+          EZ_TEST_FLOAT(pMember->GetValue(pInstance), 42.0f, 0);
+          pMember->SetValue(pInstance, 43.0f);
+          EZ_TEST_FLOAT(pMember->GetValue(pInstance), 43.0f, 0);
 
-        pRtti->GetAllocator()->Deallocate(pInstance);
-      }
-      else
-      {
-        EZ_TEST_STRING(pRtti->GetPluginName(), "Static");
-      }
-
-      pRtti = pRtti->GetNextInstance();
-    }
+          pRtti->GetAllocator()->Deallocate(pInstance);
+        }
+        else
+        {
+          EZ_TEST_STRING(pRtti->GetPluginName(), "Static");
+        }
+      });
 
     EZ_TEST_BOOL(bFoundStruct2);
 

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -224,8 +224,7 @@ ezUInt32 AccessorPropertiesTest(ezIReflectedTypeAccessor& ref_accessor)
 static ezUInt32 GetTypeCount()
 {
   ezUInt32 uiCount = 0;
-  ezRTTI::ForEachType([&](const ezRTTI* pRtti)
-    { uiCount++; });
+  ezRTTI::ForEachType([&](const ezRTTI* pRtti) { uiCount++; });
   return uiCount;
 }
 

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -65,7 +65,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectionUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Float Properties")
   {
     ezFloatStruct floatStruct;
-    ezRTTI* pRttiFloat = ezRTTI::FindTypeByName("ezFloatStruct");
+    const ezRTTI* pRttiFloat = ezRTTI::FindTypeByName("ezFloatStruct");
     EZ_TEST_BOOL(pRttiFloat != nullptr);
 
     VariantToPropertyTest(&floatStruct, pRttiFloat, "Float", ezVariant::Type::Float);
@@ -81,7 +81,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectionUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Misc Properties")
   {
     ezPODClass podClass;
-    ezRTTI* pRttiPOD = ezRTTI::FindTypeByName("ezPODClass");
+    const ezRTTI* pRttiPOD = ezRTTI::FindTypeByName("ezPODClass");
     EZ_TEST_BOOL(pRttiPOD != nullptr);
 
     VariantToPropertyTest(&podClass, pRttiPOD, "Bool", ezVariant::Type::Bool);
@@ -99,7 +99,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectionUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Math Properties")
   {
     ezMathClass mathClass;
-    ezRTTI* pRttiMath = ezRTTI::FindTypeByName("ezMathClass");
+    const ezRTTI* pRttiMath = ezRTTI::FindTypeByName("ezMathClass");
     EZ_TEST_BOOL(pRttiMath != nullptr);
 
     VariantToPropertyTest(&mathClass, pRttiMath, "Vec2", ezVariant::Type::Vector2);
@@ -125,7 +125,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectionUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Enumeration Properties")
   {
     ezEnumerationsClass enumClass;
-    ezRTTI* pRttiEnum = ezRTTI::FindTypeByName("ezEnumerationsClass");
+    const ezRTTI* pRttiEnum = ezRTTI::FindTypeByName("ezEnumerationsClass");
     EZ_TEST_BOOL(pRttiEnum != nullptr);
 
     VariantToPropertyTest(&enumClass, pRttiEnum, "Enum", ezVariant::Type::Int64);
@@ -224,12 +224,8 @@ ezUInt32 AccessorPropertiesTest(ezIReflectedTypeAccessor& ref_accessor)
 static ezUInt32 GetTypeCount()
 {
   ezUInt32 uiCount = 0;
-  ezRTTI* pType = ezRTTI::GetFirstInstance();
-  while (pType != nullptr)
-  {
-    uiCount++;
-    pType = pType->GetNextInstance();
-  }
+  ezRTTI::ForEachType([&](const ezRTTI* pRtti)
+    { uiCount++; });
   return uiCount;
 }
 


### PR DESCRIPTION
With this change ezRTTI is not derived from ezEnumerable anymore but internally keeps an array of all registered types. This allows us to lock the internal data structure for iterating types and thus makes it possible to create and register new types in worker threads. We need this for the new scripting infrastructure that creates new types during resource load.
To iterate over all types (or derived types) a ForEachType and a ForEachDerivedType function has been introduces to ezRTTI. 