### PR TITLE
Render data category is now determined by the material

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -134,6 +134,15 @@ public:
   ezString m_sResult;
 };
 
+class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezDynamicStringEnumMsgToEditor : public ezEditorEngineMsg
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezDynamicStringEnumMsgToEditor, ezEditorEngineMsg);
+
+public:
+  ezString m_sEnumName;
+  ezHybridArray<ezString, 8> m_EnumValues;
+};
+
 ///////////////////////////////////// ezEditorEngineDocumentMsg /////////////////////////////////////
 
 /// \brief Base class for all messages that are tied to some document.

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -147,6 +147,17 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezConsoleCmdResultMsgToEditor, 1, ezRTTIDefaultA
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDynamicStringEnumMsgToEditor, 1, ezRTTIDefaultAllocator<ezDynamicStringEnumMsgToEditor>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("EnumName", m_sEnumName),
+    EZ_ARRAY_MEMBER_PROPERTY("EnumValues", m_EnumValues),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezLongOpReplicationMsg, 1, ezRTTIDefaultAllocator<ezLongOpReplicationMsg>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoComponent.h
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoComponent.h
@@ -9,7 +9,6 @@ class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezGizmoRenderData : public ezMeshRende
 
 public:
   ezColor m_GizmoColor;
-  bool m_bUseDepthPrepass;
   bool m_bIsPickable;
 };
 
@@ -41,6 +40,5 @@ public:
   ~ezGizmoComponent();
 
   ezColor m_GizmoColor;
-  bool m_bUseDepthPrepass = false;
   bool m_bIsPickable = true;
 };

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoComponent.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoComponent.cpp
@@ -37,7 +37,6 @@ ezMeshRenderData* ezGizmoComponent::CreateRenderData() const
 
   ezGizmoRenderData* pRenderData = ezCreateRenderDataForThisFrame<ezGizmoRenderData>(GetOwner());
   pRenderData->m_GizmoColor = color;
-  pRenderData->m_bUseDepthPrepass = m_bUseDepthPrepass;
   pRenderData->m_bIsPickable = m_bIsPickable;
 
   return pRenderData;

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoHandle.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoHandle.cpp
@@ -690,10 +690,7 @@ bool ezEngineGizmoHandle::SetupForEngine(ezWorld* pWorld, ezUInt32 uiNextCompone
     hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandle.ezMaterial");
   }
 
-  m_pGizmoComponent->SetRenderDataCategory(
-    m_bVisualizer ? ezDefaultRenderDataCategories::SimpleOpaque : ezDefaultRenderDataCategories::SimpleForeground);
   m_pGizmoComponent->m_GizmoColor = m_Color;
-  m_pGizmoComponent->m_bUseDepthPrepass = !m_bVisualizer;
   m_pGizmoComponent->m_bIsPickable = m_bIsPickable;
   m_pGizmoComponent->SetMesh(hMesh);
 
@@ -716,7 +713,6 @@ void ezEngineGizmoHandle::UpdateForEngine(ezWorld* pWorld)
   pObject->SetLocalScaling(m_Transformation.m_vScale);
 
   m_pGizmoComponent->m_GizmoColor = m_Color;
-  m_pGizmoComponent->m_bUseDepthPrepass = !m_bVisualizer;
   m_pGizmoComponent->SetActiveFlag(m_bVisible);
 }
 

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -113,10 +113,18 @@ void ezQtEditorApp::EngineProcessMsgHandler(const ezEditorEngineProcessConnectio
   {
     case ezEditorEngineProcessConnection::Event::Type::ProcessMessage:
     {
-      if (e.m_pMsg->GetDynamicRTTI()->IsDerivedFrom<ezUpdateReflectionTypeMsgToEditor>())
+      if (auto pTypeMsg = ezDynamicCast<const ezUpdateReflectionTypeMsgToEditor*>(e.m_pMsg))
       {
-        const ezUpdateReflectionTypeMsgToEditor* pMsg = static_cast<const ezUpdateReflectionTypeMsgToEditor*>(e.m_pMsg);
-        ezPhantomRttiManager::RegisterType(pMsg->m_desc);
+        ezPhantomRttiManager::RegisterType(pTypeMsg->m_desc);
+      }
+      if (auto pDynEnumMsg = ezDynamicCast<const ezDynamicStringEnumMsgToEditor*>(e.m_pMsg))
+      {
+        auto& dynEnum = ezDynamicStringEnum::CreateDynamicEnum(pDynEnumMsg->m_sEnumName);
+        for (auto& sEnumValue : pDynEnumMsg->m_EnumValues)
+        {
+          dynEnum.AddValidValue(sEnumValue);
+        }
+        dynEnum.SortValues();
       }
       else if (e.m_pMsg->GetDynamicRTTI()->IsDerivedFrom<ezProjectReadyMsgToEditor>())
       {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -4,16 +4,171 @@
 #include <EditorPluginAssets/MaterialAsset/MaterialAssetManager.h>
 #include <EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.h>
 #include <EditorPluginAssets/VisualShader/VsCodeGenerator.h>
+#include <Foundation/CodeUtils/Preprocessor.h>
 #include <GuiFoundation/NodeEditor/NodeScene.moc.h>
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <RendererCore/Material/MaterialResource.h>
+#include <RendererCore/Shader/Implementation/Helper.h>
 #include <ToolsFoundation/Document/PrefabCache.h>
 #include <ToolsFoundation/Document/PrefabUtils.h>
 
 #ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
 #  include <Foundation/IO/CompressedStreamZstd.h>
 #endif
+
+namespace
+{
+  ezResult AddDefines(ezPreprocessor& inout_pp, const ezDocumentObject* pObject, const ezAbstractProperty* pProp)
+  {
+    ezStringBuilder sDefine;
+
+    const char* szName = pProp->GetPropertyName();
+    if (pProp->GetSpecificType()->GetVariantType() == ezVariantType::Bool)
+    {
+      sDefine.Set(szName, " ", pObject->GetTypeAccessor().GetValue(szName).Get<bool>() ? "TRUE" : "FALSE");
+      return inout_pp.AddCustomDefine(sDefine);
+    }
+    else if (pProp->GetFlags().IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags))
+    {
+      ezInt64 iValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezInt64>();
+
+      ezHybridArray<ezReflectionUtils::EnumKeyValuePair, 16> enumValues;
+      ezReflectionUtils::GetEnumKeysAndValues(pProp->GetSpecificType(), enumValues, ezReflectionUtils::EnumConversionMode::ValueNameOnly);
+      for (auto& enumValue : enumValues)
+      {
+        sDefine.Format("{} {}", enumValue.m_sKey, enumValue.m_iValue);
+        EZ_SUCCEED_OR_RETURN(inout_pp.AddCustomDefine(sDefine));
+
+        if (enumValue.m_iValue == iValue)
+        {
+          sDefine.Set(szName, " ", enumValue.m_sKey);
+          EZ_SUCCEED_OR_RETURN(inout_pp.AddCustomDefine(sDefine));
+        }
+      }
+
+      return EZ_SUCCESS;
+    }
+
+    EZ_REPORT_FAILURE("Invalid shader permutation property type '{0}'", pProp->GetSpecificType()->GetTypeName());
+    return EZ_FAILURE;
+  }
+
+  ezResult ParseMaterialConfig(ezStringView sRelativeFileName, const ezDocumentObject* pShaderPropertyObject, ezVariantDictionary& out_materialConfig)
+  {
+    ezStringBuilder sFileContent;
+    {
+      ezFileReader File;
+      if (File.Open(sRelativeFileName).Failed())
+        return EZ_FAILURE;
+
+      sFileContent.ReadAll(File);
+    }
+
+    ezShaderHelper::ezTextSectionizer sections;
+    ezShaderHelper::GetShaderSections(sFileContent, sections);
+
+    ezUInt32 uiFirstLine = 0;
+    ezStringView sMaterialConfig = sections.GetSectionContent(ezShaderHelper::ezShaderSections::MATERIALCONFIG, uiFirstLine);
+
+    ezPreprocessor pp;
+    pp.SetPassThroughPragma(false);
+    pp.SetPassThroughLine(false);
+
+    // set material permutation var
+    {
+      EZ_SUCCEED_OR_RETURN(pp.AddCustomDefine("TRUE 1"));
+      EZ_SUCCEED_OR_RETURN(pp.AddCustomDefine("FALSE 0"));
+
+      ezHybridArray<ezAbstractProperty*, 32> properties;
+      pShaderPropertyObject->GetType()->GetAllProperties(properties);
+
+      ezStringBuilder sDefine;
+      ezStringBuilder sValue;
+      for (auto& pProp : properties)
+      {
+        const ezCategoryAttribute* pCategory = pProp->GetAttributeByType<ezCategoryAttribute>();
+        if (pCategory == nullptr || ezStringUtils::IsEqual(pCategory->GetCategory(), "Permutation") == false)
+          continue;
+
+        EZ_SUCCEED_OR_RETURN(AddDefines(pp, pShaderPropertyObject, pProp));
+      }
+    }
+
+    pp.SetFileOpenFunction([&](ezStringView sAbsoluteFile, ezDynamicArray<ezUInt8>& FileContent, ezTimestamp& out_FileModification)
+      {
+        if (sAbsoluteFile == "MaterialConfig")
+        {
+          FileContent.PushBackRange(ezMakeArrayPtr((const ezUInt8*)sMaterialConfig.GetStartPointer(), sMaterialConfig.GetElementCount()));
+          return EZ_SUCCESS;
+        }
+
+        ezFileReader r;
+        if (r.Open(sAbsoluteFile).Failed())
+        {
+          ezLog::Error("Could not find include file '{0}'", sAbsoluteFile);
+          return EZ_FAILURE;
+        }
+
+#if EZ_ENABLED(EZ_SUPPORTS_FILE_STATS)
+        ezFileStats stats;
+        if (ezFileSystem::GetFileStats(sAbsoluteFile, stats).Succeeded())
+        {
+          out_FileModification = stats.m_LastModificationTime;
+        }
+#endif
+
+        ezUInt8 Temp[4096];
+        while (ezUInt64 uiRead = r.ReadBytes(Temp, 4096))
+        {
+          FileContent.PushBackRange(ezArrayPtr<ezUInt8>(Temp, (ezUInt32)uiRead));
+        }
+
+        return EZ_SUCCESS; });
+
+    bool bFoundUndefinedVars = false;
+    pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e)
+      {
+        if (e.m_Type == ezPreprocessor::ProcessingEvent::EvaluateUnknown)
+        {
+          bFoundUndefinedVars = true;
+
+          ezLog::Error("Undefined variable is evaluated: '{0}' (File: '{1}', Line: {2}. Only material permutation variables are allowed in material config sections.", e.m_pToken->m_DataView, e.m_pToken->m_File, e.m_pToken->m_uiLine);
+        } });
+
+    ezStringBuilder sOutput;
+    if (pp.Process("MaterialConfig", sOutput, false).Failed() || bFoundUndefinedVars)
+    {
+      ezLog::Error("Preprocessing the material config section failed");
+      return EZ_FAILURE;
+    }
+
+    ezHybridArray<ezStringView, 32> allAssignments;
+    sOutput.Split(false, allAssignments, "\n", ";", "\r");
+
+    ezStringBuilder temp;
+    ezHybridArray<ezStringView, 4> components;
+    for (const ezStringView& assignment : allAssignments)
+    {
+      temp = assignment;
+      temp.Trim(" \t\r\n;");
+      if (temp.IsEmpty())
+        continue;
+
+      temp.Split(false, components, " ", "\t", "=", "\r");
+
+      if (components.GetCount() != 2)
+      {
+        ezLog::Error("Malformed shader state assignment: '{0}'", temp);
+        continue;
+      }
+
+      out_materialConfig[components[0]] = components[1];
+    }
+
+    return EZ_SUCCESS;
+  }
+} // namespace
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezMaterialAssetPreview, 1)
@@ -44,7 +199,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetProperties, 4, ezRTTIDefaultAlloc
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetDocument, 6, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetDocument, 7, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
@@ -810,7 +965,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
   // now generate the .ezMaterialBin file
   {
-    const ezUInt8 uiVersion = 6;
+    const ezUInt8 uiVersion = 7;
 
     inout_stream0 << uiVersion;
 
@@ -827,81 +982,80 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
     stream << pProp->m_sBaseMaterial;
     stream << pProp->m_sSurface;
-    stream << pProp->ResolveRelativeShaderPath();
+
+    ezString sRelativeShaderPath = pProp->ResolveRelativeShaderPath();
+    stream << sRelativeShaderPath;
 
     ezHybridArray<ezAbstractProperty*, 16> Textures2D;
     ezHybridArray<ezAbstractProperty*, 16> TexturesCube;
-    ezHybridArray<ezAbstractProperty*, 16> Permutation;
+    ezHybridArray<ezAbstractProperty*, 16> Permutations;
     ezHybridArray<ezAbstractProperty*, 16> Constants;
 
     const ezDocumentObject* pObject = GetShaderPropertyObject();
-    if (pObject)
+    if (pObject == nullptr)
+      return ezStatus("Invalid shader property object");
+
+    bool hasBaseMaterial = ezPrefabUtils::GetPrefabRoot(pObject, *m_DocumentObjectMetaData).IsValid();
+    auto pType = pObject->GetTypeAccessor().GetType();
+    ezHybridArray<ezAbstractProperty*, 32> properties;
+    pType->GetAllProperties(properties);
+
+    ezHybridArray<ezPropertySelection, 1> selection;
+    selection.PushBack({pObject, ezVariant()});
+    ezDefaultObjectState defaultState(GetObjectAccessor(), selection.GetArrayPtr());
+
+    for (auto* pProp : properties)
     {
-      bool hasBaseMaterial = ezPrefabUtils::GetPrefabRoot(pObject, *m_DocumentObjectMetaData).IsValid();
-      auto pType = pObject->GetTypeAccessor().GetType();
-      ezHybridArray<ezAbstractProperty*, 32> properties;
-      pType->GetAllProperties(properties);
+      if (hasBaseMaterial && defaultState.IsDefaultValue(pProp))
+        continue;
 
-      ezHybridArray<ezPropertySelection, 1> selection;
-      selection.PushBack({pObject, ezVariant()});
-      ezDefaultObjectState defaultState(GetObjectAccessor(), selection.GetArrayPtr());
+      const ezCategoryAttribute* pCategory = pProp->GetAttributeByType<ezCategoryAttribute>();
 
-      for (auto* pProp : properties)
+      EZ_ASSERT_DEBUG(pCategory, "Category cannot be null for a shader property");
+      if (pCategory == nullptr)
+        continue;
+
+      if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture 2D"))
       {
-        if (hasBaseMaterial && defaultState.IsDefaultValue(pProp))
-          continue;
-
-        const ezCategoryAttribute* pCategory = pProp->GetAttributeByType<ezCategoryAttribute>();
-
-        EZ_ASSERT_DEBUG(pCategory, "Category cannot be null for a shader property");
-        if (pCategory == nullptr)
-          continue;
-
-        if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture 2D"))
-        {
-          Textures2D.PushBack(pProp);
-        }
-        else if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture Cube"))
-        {
-          TexturesCube.PushBack(pProp);
-        }
-        else if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Permutation"))
-        {
-          Permutation.PushBack(pProp);
-        }
-        else if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Constant"))
-        {
-          Constants.PushBack(pProp);
-        }
-        else
-        {
-          EZ_REPORT_FAILURE("Invalid shader property type '{0}'", pCategory->GetCategory());
-        }
+        Textures2D.PushBack(pProp);
+      }
+      else if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture Cube"))
+      {
+        TexturesCube.PushBack(pProp);
+      }
+      else if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Permutation"))
+      {
+        Permutations.PushBack(pProp);
+      }
+      else if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Constant"))
+      {
+        Constants.PushBack(pProp);
+      }
+      else
+      {
+        EZ_REPORT_FAILURE("Invalid shader property type '{0}'", pCategory->GetCategory());
       }
     }
 
     // write out the permutation variables
     {
-      const ezUInt16 uiPermVars = Permutation.GetCount();
+      const ezUInt16 uiPermVars = Permutations.GetCount();
       stream << uiPermVars;
 
-      for (ezUInt32 p = 0; p < uiPermVars; ++p)
+      for (auto pProp : Permutations)
       {
-        const char* szName = Permutation[p]->GetPropertyName();
-        if (Permutation[p]->GetSpecificType()->GetVariantType() == ezVariantType::Bool)
+        const char* szName = pProp->GetPropertyName();
+        if (pProp->GetSpecificType()->GetVariantType() == ezVariantType::Bool)
         {
           sValue = pObject->GetTypeAccessor().GetValue(szName).Get<bool>() ? "TRUE" : "FALSE";
         }
-        else if (Permutation[p]->GetFlags().IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags))
+        else if (pProp->GetFlags().IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags))
         {
-          ezStringBuilder s;
-          ezReflectionUtils::EnumerationToString(Permutation[p]->GetSpecificType(), pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezInt64>(), s);
-
-          sValue = s.FindLastSubString("::") + 2;
+          ezReflectionUtils::EnumerationToString(pProp->GetSpecificType(), pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezInt64>(), sValue, ezReflectionUtils::EnumConversionMode::ValueNameOnly);
         }
         else
         {
-          EZ_REPORT_FAILURE("Invalid shader permutation property type '{0}'", Permutation[p]->GetSpecificType()->GetTypeName());
+          EZ_REPORT_FAILURE("Invalid shader permutation property type '{0}'", pProp->GetSpecificType()->GetTypeName());
         }
 
         stream << szName;
@@ -914,9 +1068,9 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
       const ezUInt16 uiTextures = Textures2D.GetCount();
       stream << uiTextures;
 
-      for (ezUInt32 p = 0; p < uiTextures; ++p)
+      for (auto pProp : Textures2D)
       {
-        const char* szName = Textures2D[p]->GetPropertyName();
+        const char* szName = pProp->GetPropertyName();
         sValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezString>();
 
         stream << szName;
@@ -929,9 +1083,9 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
       const ezUInt16 uiTextures = TexturesCube.GetCount();
       stream << uiTextures;
 
-      for (ezUInt32 p = 0; p < uiTextures; ++p)
+      for (auto pProp : TexturesCube)
       {
-        const char* szName = TexturesCube[p]->GetPropertyName();
+        const char* szName = pProp->GetPropertyName();
         sValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezString>();
 
         stream << szName;
@@ -944,14 +1098,25 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
       const ezUInt16 uiConstants = Constants.GetCount();
       stream << uiConstants;
 
-      for (ezUInt32 p = 0; p < uiConstants; ++p)
+      for (auto pProp : Constants)
       {
-        const char* szName = Constants[p]->GetPropertyName();
+        const char* szName = pProp->GetPropertyName();
         ezVariant value = pObject->GetTypeAccessor().GetValue(szName);
 
         stream << szName;
         stream << value;
       }
+    }
+
+    // render data category
+    {
+      ezVariantDictionary materialConfig;
+      EZ_SUCCEED_OR_RETURN(ParseMaterialConfig(sRelativeShaderPath, pObject, materialConfig));
+
+      ezVariant renderDataCategory;
+      materialConfig.TryGetValue("RenderDataCategory", renderDataCategory);
+
+      stream << renderDataCategory.ConvertTo<ezString>();
     }
 
     // find and embed low res texture data

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -95,8 +95,7 @@ namespace
       }
     }
 
-    pp.SetFileOpenFunction([&](ezStringView sAbsoluteFile, ezDynamicArray<ezUInt8>& FileContent, ezTimestamp& out_FileModification)
-      {
+    pp.SetFileOpenFunction([&](ezStringView sAbsoluteFile, ezDynamicArray<ezUInt8>& FileContent, ezTimestamp& out_FileModification) {
         if (sAbsoluteFile == "MaterialConfig")
         {
           FileContent.PushBackRange(ezMakeArrayPtr((const ezUInt8*)sMaterialConfig.GetStartPointer(), sMaterialConfig.GetElementCount()));
@@ -127,8 +126,7 @@ namespace
         return EZ_SUCCESS; });
 
     bool bFoundUndefinedVars = false;
-    pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e)
-      {
+    pp.m_ProcessingEvents.AddEventHandler([&bFoundUndefinedVars](const ezPreprocessor::ProcessingEvent& e) {
         if (e.m_Type == ezPreprocessor::ProcessingEvent::EvaluateUnknown)
         {
           bFoundUndefinedVars = true;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -95,10 +95,10 @@ namespace
       }
     }
 
-    pp.SetFileOpenFunction([&](ezStringView sAbsoluteFile, ezDynamicArray<ezUInt8>& FileContent, ezTimestamp& out_FileModification) {
+    pp.SetFileOpenFunction([&](ezStringView sAbsoluteFile, ezDynamicArray<ezUInt8>& out_fileContent, ezTimestamp& out_fileModification) {
         if (sAbsoluteFile == "MaterialConfig")
         {
-          FileContent.PushBackRange(ezMakeArrayPtr((const ezUInt8*)sMaterialConfig.GetStartPointer(), sMaterialConfig.GetElementCount()));
+          out_fileContent.PushBackRange(ezMakeArrayPtr((const ezUInt8*)sMaterialConfig.GetStartPointer(), sMaterialConfig.GetElementCount()));
           return EZ_SUCCESS;
         }
 
@@ -113,14 +113,14 @@ namespace
         ezFileStats stats;
         if (ezFileSystem::GetFileStats(sAbsoluteFile, stats).Succeeded())
         {
-          out_FileModification = stats.m_LastModificationTime;
+          out_fileModification = stats.m_LastModificationTime;
         }
 #endif
 
         ezUInt8 Temp[4096];
         while (ezUInt64 uiRead = r.ReadBytes(Temp, 4096))
         {
-          FileContent.PushBackRange(ezArrayPtr<ezUInt8>(Temp, (ezUInt32)uiRead));
+          out_fileContent.PushBackRange(ezArrayPtr<ezUInt8>(Temp, (ezUInt32)uiRead));
         }
 
         return EZ_SUCCESS; });

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -302,8 +302,11 @@ void ezQtMaterialAssetDocumentWindow::UpdatePreview()
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, GetMaterialDocument()->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();
+
   // Write Asset Data
-  GetMaterialDocument()->WriteMaterialAsset(memoryWriter, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), false).AssertSuccess();
+  if (GetMaterialDocument()->WriteMaterialAsset(memoryWriter, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), false).Failed())
+    return;
+
   msg.m_Data = ezArrayPtr<const ezUInt8>(streamStorage.GetData(), streamStorage.GetStorageSize32());
 
   ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);

--- a/Code/Engine/Core/World/Declarations.h
+++ b/Code/Engine/Core/World/Declarations.h
@@ -268,7 +268,9 @@ struct ezComponentMode
 /// \brief Specifies at which phase the queued message should be processed.
 struct ezObjectMsgQueueType
 {
-  enum Enum
+  using StorageType = ezUInt8;
+
+  enum Enum : StorageType
   {
     PostAsync,        ///< Process the message in the PostAsync phase.
     PostTransform,    ///< Process the message in the PostTransform phase.

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -231,6 +231,7 @@ namespace ezInternal
     using MessageQueue = ezMessageQueue<QueuedMsgMetaData, ezLocalAllocatorWrapper>;
     mutable MessageQueue m_MessageQueues[ezObjectMsgQueueType::COUNT];
     mutable MessageQueue m_TimedMessageQueues[ezObjectMsgQueueType::COUNT];
+    ezObjectMsgQueueType::Enum m_ProcessingMessageQueue = ezObjectMsgQueueType::COUNT;
 
     ezThreadID m_WriteThreadID;
     ezInt32 m_iWriteCounter = 0;

--- a/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
@@ -207,19 +207,7 @@ void ezGreyBoxComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) con
       if (pMaterial.GetAcquireResult() == ezResourceAcquireResult::LoadingFallback)
         bDontCacheYet = true;
 
-      ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-      if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-      {
-        category = ezDefaultRenderDataCategories::LitOpaque;
-      }
-      else if (blendModeValue == "BLEND_MODE_MASKED")
-      {
-        category = ezDefaultRenderDataCategories::LitMasked;
-      }
-      else
-      {
-        category = ezDefaultRenderDataCategories::LitTransparent;
-      }
+      category = pMaterial->GetRenderDataCategory();
     }
 
     msg.AddRenderData(pRenderData, category, bDontCacheYet ? ezRenderData::Caching::Never : ezRenderData::Caching::IfStatic);

--- a/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
@@ -163,21 +163,8 @@ void ezBeamComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
   }
 
   // Determine render data category.
-  ezRenderData::Category category = ezDefaultRenderDataCategories::LitTransparent;
   ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-  ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-  if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-  {
-    category = ezDefaultRenderDataCategories::LitOpaque;
-  }
-  else if (blendModeValue == "BLEND_MODE_MASKED")
-  {
-    category = ezDefaultRenderDataCategories::LitMasked;
-  }
-  else
-  {
-    category = ezDefaultRenderDataCategories::LitTransparent;
-  }
+  ezRenderData::Category category = pMaterial->GetRenderDataCategory();
 
   msg.AddRenderData(pRenderData, category, ezRenderData::Caching::Never);
 }

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -132,20 +132,7 @@ void ezRopeRenderComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   if (hMaterial.IsValid())
   {
     ezResourceLock<ezMaterialResource> pMaterial(hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-
-    ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-    if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-    {
-      category = ezDefaultRenderDataCategories::LitOpaque;
-    }
-    else if (blendModeValue == "BLEND_MODE_MASKED")
-    {
-      category = ezDefaultRenderDataCategories::LitMasked;
-    }
-    else
-    {
-      category = ezDefaultRenderDataCategories::LitTransparent;
-    }
+    category = pMaterial->GetRenderDataCategory();
   }
 
   msg.AddRenderData(pRenderData, category, ezRenderData::Caching::Never);

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -275,7 +275,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(
         }
         else
         {
-          EZ_ASSERT_NOT_IMPLEMENTED;
+          ezLog::Warning("Unhandled render data type '{}' in 'Light' category", it->GetDynamicRTTI()->GetTypeName());
         }
       }
     }
@@ -317,7 +317,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(
         }
         else
         {
-          EZ_ASSERT_NOT_IMPLEMENTED;
+          ezLog::Warning("Unhandled render data type '{}' in 'Decal' category", it->GetDynamicRTTI()->GetTypeName());
         }
       }
     }
@@ -390,7 +390,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(
         }
         else
         {
-          EZ_ASSERT_NOT_IMPLEMENTED;
+          ezLog::Warning("Unhandled render data type '{}' in 'ReflectionProbe' category", it->GetDynamicRTTI()->GetTypeName());
         }
       }
     }

--- a/Code/Engine/RendererCore/Material/MaterialResource.h
+++ b/Code/Engine/RendererCore/Material/MaterialResource.h
@@ -4,6 +4,7 @@
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Strings/HashedString.h>
 #include <RendererCore/Declarations.h>
+#include <RendererCore/Pipeline/RenderData.h>
 #include <RendererCore/Shader/ConstantBufferStorage.h>
 #include <RendererCore/Shader/ShaderResource.h>
 
@@ -51,6 +52,7 @@ struct ezMaterialResourceDescriptor
   ezDynamicArray<Parameter> m_Parameters;
   ezDynamicArray<Texture2DBinding> m_Texture2DBindings;
   ezDynamicArray<TextureCubeBinding> m_TextureCubeBindings;
+  ezRenderData::Category m_RenderDataCategory;
 };
 
 class EZ_RENDERERCORE_DLL ezMaterialResource final : public ezResource
@@ -77,6 +79,8 @@ public:
   void SetTextureCubeBinding(const ezHashedString& sName, const ezTextureCubeResourceHandle& value);
   void SetTextureCubeBinding(const char* szName, const ezTextureCubeResourceHandle& value);
   ezTextureCubeResourceHandle GetTextureCubeBinding(const ezTempHashedString& sName);
+
+  ezRenderData::Category GetRenderDataCategory();
 
   /// \brief Copies current desc to original desc so the material is not modified on reset
   void PreserveCurrentDesc();
@@ -114,7 +118,7 @@ private:
   void OnBaseMaterialModified(const ezMaterialResource* pModifiedMaterial);
   void OnResourceEvent(const ezResourceEvent& resourceEvent);
 
-  void AddPermutationVar(const char* szName, const char* szValue);
+  void AddPermutationVar(ezStringView sName, ezStringView sValue);
 
   ezAtomicInteger32 m_iLastModified;
   ezAtomicInteger32 m_iLastConstantsModified;
@@ -135,6 +139,9 @@ private:
     ezHashTable<ezHashedString, ezVariant> m_Parameters;
     ezHashTable<ezHashedString, ezTexture2DResourceHandle> m_Texture2DBindings;
     ezHashTable<ezHashedString, ezTextureCubeResourceHandle> m_TextureCubeBindings;
+    ezRenderData::Category m_RenderDataCategory;
+
+    void Reset();
   };
 
   ezUInt32 m_uiCacheIndex;

--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -68,12 +68,6 @@ public:
   void SetMaterialFile(const char* szMaterial); // [ property ]
   const char* GetMaterialFile() const;          // [ property ]
 
-  /// \brief Sets a specific render data category used for rendering.
-  ///
-  /// Typically it is not necessary to change this, but it can be used to render the object in a
-  /// certain render pass.
-  EZ_ALWAYS_INLINE void SetRenderDataCategory(ezRenderData::Category category) { m_RenderDataCategory = category; }
-
   /// \brief Sets the mesh instance color.
   void SetColor(const ezColor& color); // [ property ]
 
@@ -86,7 +80,6 @@ public:
 protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
 
-  ezRenderData::Category m_RenderDataCategory = ezInvalidRenderDataCategory;
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
   ezUInt32 m_uiFirstPrimitive = 0;

--- a/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
+++ b/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
@@ -88,8 +88,6 @@ public:
   void SetMaterial(ezUInt32 uiIndex, const ezMaterialResourceHandle& hMaterial);
   ezMaterialResourceHandle GetMaterial(ezUInt32 uiIndex) const;
 
-  EZ_ALWAYS_INLINE void SetRenderDataCategory(ezRenderData::Category category) { m_RenderDataCategory = category; }
-
   void SetMeshFile(const char* szFile); // [ property ]
   const char* GetMeshFile() const;      // [ property ]
 
@@ -110,7 +108,6 @@ protected:
 
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
 
-  ezRenderData::Category m_RenderDataCategory = ezInvalidRenderDataCategory;
   ezMeshResourceHandle m_hMesh;
   ezDynamicArray<ezMaterialResourceHandle> m_Materials;
   ezColor m_Color = ezColor::White;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -53,31 +53,43 @@ bool ezRenderData::s_bRendererInstancesDirty = false;
 // static
 ezRenderData::Category ezRenderData::RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc)
 {
-  Category oldCategory = FindCategory(szCategoryName);
+  ezHashedString sCategoryName;
+  sCategoryName.Assign(szCategoryName);
+
+  Category oldCategory = FindCategory(sCategoryName);
   if (oldCategory != ezInvalidRenderDataCategory)
     return oldCategory;
 
   Category newCategory = Category(static_cast<ezUInt16>(s_CategoryData.GetCount()));
 
   auto& data = s_CategoryData.ExpandAndGetRef();
-  data.m_sName.Assign(szCategoryName);
+  data.m_sName = sCategoryName;
   data.m_sortingKeyFunc = sortingKeyFunc;
 
   return newCategory;
 }
 
 // static
-ezRenderData::Category ezRenderData::FindCategory(const char* szCategoryName)
+ezRenderData::Category ezRenderData::FindCategory(ezTempHashedString sCategoryName)
 {
-  ezTempHashedString categoryName(szCategoryName);
-
   for (ezUInt32 uiCategoryIndex = 0; uiCategoryIndex < s_CategoryData.GetCount(); ++uiCategoryIndex)
   {
-    if (s_CategoryData[uiCategoryIndex].m_sName == categoryName)
+    if (s_CategoryData[uiCategoryIndex].m_sName == sCategoryName)
       return Category(static_cast<ezUInt16>(uiCategoryIndex));
   }
 
   return ezInvalidRenderDataCategory;
+}
+
+// static
+void ezRenderData::GetAllCategoryNames(ezDynamicArray<ezHashedString>& out_categoryNames)
+{
+  out_categoryNames.Clear();
+
+  for (auto& data : s_CategoryData)
+  {
+    out_categoryNames.PushBack(data.m_sName);
+  }
 }
 
 // static

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData_inl.h
@@ -1,9 +1,6 @@
 #include <Core/World/GameObject.h>
 
-EZ_ALWAYS_INLINE ezRenderData::Category::Category()
-  : m_uiValue(0xFFFF)
-{
-}
+EZ_ALWAYS_INLINE ezRenderData::Category::Category() = default;
 
 EZ_ALWAYS_INLINE ezRenderData::Category::Category(ezUInt16 uiValue)
   : m_uiValue(uiValue)
@@ -42,9 +39,14 @@ EZ_FORCE_INLINE const ezRenderer* ezRenderData::GetCategoryRenderer(Category cat
 }
 
 // static
-EZ_FORCE_INLINE const char* ezRenderData::GetCategoryName(Category category)
+EZ_FORCE_INLINE ezHashedString ezRenderData::GetCategoryName(Category category)
 {
-  return s_CategoryData[category.m_uiValue].m_sName.GetString();
+  if (category.m_uiValue < s_CategoryData.GetCount())
+  {
+    return s_CategoryData[category.m_uiValue].m_sName;
+  }
+
+  return ezHashedString();
 }
 
 EZ_FORCE_INLINE ezUInt64 ezRenderData::GetCategorySortingKey(Category category, const ezCamera& camera) const

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -36,7 +36,7 @@ public:
   };
 
   /// \brief This function generates a 64bit sorting key for the given render data. Data with lower sorting key is rendered first.
-  using SortingKeyFunc = ezUInt64(*)(const ezRenderData*, ezUInt32, const ezCamera&);
+  using SortingKeyFunc = ezUInt64 (*)(const ezRenderData*, ezUInt32, const ezCamera&);
 
   static Category RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc);
   static Category FindCategory(ezTempHashedString sCategoryName);

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -23,7 +23,7 @@ public:
     bool operator==(const Category& other) const;
     bool operator!=(const Category& other) const;
 
-    ezUInt16 m_uiValue;
+    ezUInt16 m_uiValue = 0xFFFF;
   };
 
   struct Caching
@@ -36,14 +36,16 @@ public:
   };
 
   /// \brief This function generates a 64bit sorting key for the given render data. Data with lower sorting key is rendered first.
-  using SortingKeyFunc = ezDelegate<ezUInt64(const ezRenderData*, ezUInt32, const ezCamera&)>;
+  using SortingKeyFunc = ezUInt64(*)(const ezRenderData*, ezUInt32, const ezCamera&);
 
   static Category RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc);
-  static Category FindCategory(const char* szCategoryName);
+  static Category FindCategory(ezTempHashedString sCategoryName);
+
+  static void GetAllCategoryNames(ezDynamicArray<ezHashedString>& out_categoryNames);
 
   static const ezRenderer* GetCategoryRenderer(Category category, const ezRTTI* pRenderDataType);
 
-  static const char* GetCategoryName(Category category);
+  static ezHashedString GetCategoryName(Category category);
 
   ezUInt64 GetCategorySortingKey(Category category, const ezCamera& camera) const;
 

--- a/Code/Engine/RendererCore/Shader/Implementation/Helper.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/Helper.cpp
@@ -76,6 +76,7 @@ namespace ezShaderHelper
     out_sections.AddSection("[PLATFORMS]");
     out_sections.AddSection("[PERMUTATIONS]");
     out_sections.AddSection("[MATERIALPARAMETER]");
+    out_sections.AddSection("[MATERIALCONFIG]");
     out_sections.AddSection("[RENDERSTATE]");
     out_sections.AddSection("[SHADER]");
     out_sections.AddSection("[VERTEXSHADER]");

--- a/Code/Engine/RendererCore/Shader/Implementation/Helper.h
+++ b/Code/Engine/RendererCore/Shader/Implementation/Helper.h
@@ -49,6 +49,7 @@ namespace ezShaderHelper
       PLATFORMS,
       PERMUTATIONS,
       MATERIALPARAMETER,
+      MATERIALCONFIG,
       RENDERSTATE,
       SHADER,
       VERTEXSHADER,

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
@@ -283,7 +283,7 @@ static ezMap<ezString, ezInt32> StateValuesCullMode;
 static ezMap<ezString, ezInt32> StateValuesCompareFunc;
 static ezMap<ezString, ezInt32> StateValuesStencilOp;
 
-ezResult ezShaderStateResourceDescriptor::Load(const char* szSource)
+ezResult ezShaderStateResourceDescriptor::Parse(const char* szSource)
 {
   ezMap<ezString, ezString> VariableValues;
 
@@ -295,26 +295,23 @@ ezResult ezShaderStateResourceDescriptor::Load(const char* szSource)
     ezHybridArray<ezStringView, 4> components;
     sSource.Split(false, allAssignments, "\n", ";", "\r");
 
-    ezStringBuilder temp1, temp2;
-    for (const ezStringView& ass : allAssignments)
+    ezStringBuilder temp;
+    for (const ezStringView& assignment : allAssignments)
     {
-      temp1 = ass;
-      temp1.Trim(" \t\r\n;");
-      if (temp1.IsEmpty())
+      temp = assignment;
+      temp.Trim(" \t\r\n;");
+      if (temp.IsEmpty())
         continue;
 
-      temp1.Split(false, components, " ", "\t", "=", "\r");
+      temp.Split(false, components, " ", "\t", "=", "\r");
 
       if (components.GetCount() != 2)
       {
-        ezLog::Error("Malformed shader state assignment: '{0}'", temp1);
+        ezLog::Error("Malformed shader state assignment: '{0}'", temp);
         continue;
       }
 
-      temp1 = components[0];
-      temp2 = components[1];
-
-      VariableValues[temp1] = temp2;
+      VariableValues[components[0]] = components[1];
     }
   }
 

--- a/Code/Engine/RendererCore/Shader/ShaderPermutationBinary.h
+++ b/Code/Engine/RendererCore/Shader/ShaderPermutationBinary.h
@@ -11,7 +11,7 @@ struct EZ_RENDERERCORE_DLL ezShaderStateResourceDescriptor
   ezGALDepthStencilStateCreationDescription m_DepthStencilDesc;
   ezGALRasterizerStateCreationDescription m_RasterizerDesc;
 
-  ezResult Load(const char* szSource);
+  ezResult Parse(const char* szSource);
   void Load(ezStreamReader& inout_stream);
   void Save(ezStreamWriter& inout_stream) const;
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -346,7 +346,7 @@ ezResult ezShaderCompiler::RunShaderCompiler(ezStringView sFile, ezStringView sP
       }
       else
       {
-        if (shaderPermutationBinary.m_StateDescriptor.Load(sOutput).Failed())
+        if (shaderPermutationBinary.m_StateDescriptor.Parse(sOutput).Failed())
         {
           ezLog::Error(pLog, "Failed to interpret the shader state block");
           return EZ_FAILURE;

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -339,20 +339,7 @@ void ezClothSheetComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   if (m_hMaterial.IsValid())
   {
     ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-
-    ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-    if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-    {
-      category = ezDefaultRenderDataCategories::LitOpaque;
-    }
-    else if (blendModeValue == "BLEND_MODE_MASKED")
-    {
-      category = ezDefaultRenderDataCategories::LitMasked;
-    }
-    else
-    {
-      category = ezDefaultRenderDataCategories::LitTransparent;
-    }
+    category = pMaterial->GetRenderDataCategory();
   }
 
   msg.AddRenderData(pRenderData, category, ezRenderData::Caching::Never);

--- a/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
@@ -177,19 +177,7 @@ void ezHeightfieldComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg)
       if (pMaterial.GetAcquireResult() == ezResourceAcquireResult::LoadingFallback)
         bDontCacheYet = true;
 
-      ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-      if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-      {
-        category = ezDefaultRenderDataCategories::LitOpaque;
-      }
-      else if (blendModeValue == "BLEND_MODE_MASKED")
-      {
-        category = ezDefaultRenderDataCategories::LitMasked;
-      }
-      else
-      {
-        category = ezDefaultRenderDataCategories::LitTransparent;
-      }
+      category = pMaterial->GetRenderDataCategory();
     }
 
     msg.AddRenderData(pRenderData, category, bDontCacheYet ? ezRenderData::Caching::Never : ezRenderData::Caching::IfStatic);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
@@ -145,7 +145,7 @@ bool ezParticleTypeMesh::QueryMeshAndMaterialInfo() const
 
   m_Bounds = pMesh->GetBounds();
   m_RenderCategory = pMaterial->GetRenderDataCategory();
-  
+
   m_bRenderDataCached = true;
   return true;
 }

--- a/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
@@ -144,25 +144,8 @@ bool ezParticleTypeMesh::QueryMeshAndMaterialInfo() const
     return false;
 
   m_Bounds = pMesh->GetBounds();
-
-  {
-    m_RenderCategory = ezDefaultRenderDataCategories::LitOpaque;
-
-    ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-    if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-    {
-      m_RenderCategory = ezDefaultRenderDataCategories::LitOpaque;
-    }
-    else if (blendModeValue == "BLEND_MODE_MASKED")
-    {
-      m_RenderCategory = ezDefaultRenderDataCategories::LitMasked;
-    }
-    else
-    {
-      m_RenderCategory = ezDefaultRenderDataCategories::LitTransparent;
-    }
-  }
-
+  m_RenderCategory = pMaterial->GetRenderDataCategory();
+  
   m_bRenderDataCached = true;
   return true;
 }

--- a/Code/EnginePlugins/PhysXPlugin/Components/Implementation/BreakableSheet.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Components/Implementation/BreakableSheet.cpp
@@ -296,19 +296,7 @@ void ezBreakableSheetComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& m
   if (hMaterial.IsValid())
   {
     ezResourceLock<ezMaterialResource> pMaterial(hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-    ezTempHashedString blendModeValue = pMaterial->GetPermutationValue("BLEND_MODE");
-    if (blendModeValue == "BLEND_MODE_OPAQUE" || blendModeValue == "")
-    {
-      category = ezDefaultRenderDataCategories::LitOpaque;
-    }
-    else if (blendModeValue == "BLEND_MODE_MASKED")
-    {
-      category = ezDefaultRenderDataCategories::LitMasked;
-    }
-    else
-    {
-      category = ezDefaultRenderDataCategories::LitTransparent;
-    }
+    category = pMaterial->GetRenderDataCategory();
   }
 
   msg.AddRenderData(pRenderData, category, ezRenderData::Caching::Never);

--- a/Data/Base/Editor/Materials/GizmoHandle.ezMaterial
+++ b/Data/Base/Editor/Materials/GizmoHandle.ezMaterial
@@ -1,4 +1,5 @@
 string %Shader { "Shaders/Editor/GizmoHandle.ezShader" }
+string %RenderDataCategory { "SimpleForeground" }
 
 Permutation
 {

--- a/Data/Base/Editor/Materials/GizmoHandleConstantSize.ezMaterial
+++ b/Data/Base/Editor/Materials/GizmoHandleConstantSize.ezMaterial
@@ -1,4 +1,5 @@
 string %Shader { "Shaders/Editor/GizmoHandle.ezShader" }
+string %RenderDataCategory { "SimpleForeground" }
 
 Permutation
 {

--- a/Data/Base/Editor/Materials/GizmoHandleConstantSizeCamFacing.ezMaterial
+++ b/Data/Base/Editor/Materials/GizmoHandleConstantSizeCamFacing.ezMaterial
@@ -1,4 +1,5 @@
 string %Shader { "Shaders/Editor/GizmoHandle.ezShader" }
+string %RenderDataCategory { "SimpleForeground" }
 
 Permutation
 {

--- a/Data/Base/Editor/Materials/Visualizer.ezMaterial
+++ b/Data/Base/Editor/Materials/Visualizer.ezMaterial
@@ -1,1 +1,2 @@
 string %Shader { "Shaders/Editor/Visualizer.ezShader" }
+string %RenderDataCategory { "SimpleOpaque" }

--- a/Data/Base/Shaders/Editor/GizmoHandle.ezShader
+++ b/Data/Base/Shaders/Editor/GizmoHandle.ezShader
@@ -37,6 +37,10 @@ GIZMO_FACE_CAMERA
 	DestBlendAlpha0 = Blend_InvSrcAlpha
 #endif
 
+[MATERIALCONFIG]
+
+RenderDataCategory = SimpleForeground
+
 [VERTEXSHADER]
 
 #define USE_COLOR0

--- a/Data/Base/Shaders/Editor/Visualizer.ezShader
+++ b/Data/Base/Shaders/Editor/Visualizer.ezShader
@@ -13,6 +13,10 @@ WireFrame = true
 CullMode = CullMode_None
 DepthTestFunc = CompareFunc_Less
 
+[MATERIALCONFIG]
+
+RenderDataCategory = SimpleOpaque
+
 [VERTEXSHADER]
 
 #define USE_COLOR0

--- a/Data/Base/Shaders/Materials/DefaultMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/DefaultMaterial.ezShader
@@ -48,6 +48,9 @@ Color EmissiveColor @Default(Color(0.0, 0.0, 0.0));
 bool UseEmissiveTexture;
 Texture2D EmissiveTexture;
 
+[MATERIALCONFIG]
+
+#include <Shaders/Materials/MaterialConfig.h>
 
 [RENDERSTATE]
 

--- a/Data/Base/Shaders/Materials/MaterialConfig.h
+++ b/Data/Base/Shaders/Materials/MaterialConfig.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if (BLEND_MODE == BLEND_MODE_OPAQUE)
+RenderDataCategory = LitOpaque
+#elif (BLEND_MODE == BLEND_MODE_MASKED)
+RenderDataCategory = LitMasked
+#else
+RenderDataCategory = LitTransparent
+#endif


### PR DESCRIPTION
Render data categories determine where objects are rendered in the pipeline. The mesh component had its own member to define the render data category but that was rarely used. The usecases were very limited anyways since not all shaders can be used for any render data category. Therefore the render data category is now determined by the material and can be derived from the shader during material transform. 
This also allows us to remove the render data category selection depending on the blend mode in every component. This selection is still there as a fallback for materials that don't specify a render data category but it is now in one central place in the material resource.

Furthermore fixed #867 by adding a slight delay to messages that are queued while messages are being processed.