### PR TITLE
Fix assert triggering in DocumentObjectMirror

### DIFF
--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyPath.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyPath.cpp
@@ -104,14 +104,14 @@ ezResult ezPropertyPath::InitializeFromPath(const ezRTTI& rootObjectRtti, const 
   return EZ_SUCCESS;
 }
 
-ezResult ezPropertyPath::InitializeFromPath(const ezRTTI* rootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path)
+ezResult ezPropertyPath::InitializeFromPath(const ezRTTI* pRootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path)
 {
   m_bIsValid = false;
 
   m_PathSteps.Clear();
   m_PathSteps.Reserve(path.GetCount());
 
-  const ezRTTI* pCurRtti = rootObjectRtti;
+  const ezRTTI* pCurRtti = pRootObjectRtti;
   for (const ezPropertyPathStep& pathStep : path)
   {
     ezAbstractProperty* pAbsProp = pCurRtti->FindPropertyByName(pathStep.m_sProperty);

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyPath.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyPath.cpp
@@ -104,14 +104,14 @@ ezResult ezPropertyPath::InitializeFromPath(const ezRTTI& rootObjectRtti, const 
   return EZ_SUCCESS;
 }
 
-ezResult ezPropertyPath::InitializeFromPath(const ezRTTI& rootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path)
+ezResult ezPropertyPath::InitializeFromPath(const ezRTTI* rootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path)
 {
   m_bIsValid = false;
 
   m_PathSteps.Clear();
   m_PathSteps.Reserve(path.GetCount());
 
-  const ezRTTI* pCurRtti = &rootObjectRtti;
+  const ezRTTI* pCurRtti = rootObjectRtti;
   for (const ezPropertyPathStep& pathStep : path)
   {
     ezAbstractProperty* pAbsProp = pCurRtti->FindPropertyByName(pathStep.m_sProperty);

--- a/Code/Engine/Foundation/Reflection/PropertyPath.h
+++ b/Code/Engine/Foundation/Reflection/PropertyPath.h
@@ -33,7 +33,7 @@ public:
   /// The '[index]' part is only added for properties that require indices (arrays and maps).
   ezResult InitializeFromPath(const ezRTTI& rootObjectRtti, const char* szPath);
   ///\brief Resolves a path provided as an array of ezPropertyPathStep.
-  ezResult InitializeFromPath(const ezRTTI* rootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path);
+  ezResult InitializeFromPath(const ezRTTI* pRootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path);
 
   ///\brief Applies the entire path and allows writing to the target object.
   ezResult WriteToLeafObject(void* pRootObject, const ezRTTI& type, ezDelegate<void(void* pLeaf, const ezRTTI& pType)> func) const;

--- a/Code/Engine/Foundation/Reflection/PropertyPath.h
+++ b/Code/Engine/Foundation/Reflection/PropertyPath.h
@@ -33,7 +33,7 @@ public:
   /// The '[index]' part is only added for properties that require indices (arrays and maps).
   ezResult InitializeFromPath(const ezRTTI& rootObjectRtti, const char* szPath);
   ///\brief Resolves a path provided as an array of ezPropertyPathStep.
-  ezResult InitializeFromPath(const ezRTTI& rootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path);
+  ezResult InitializeFromPath(const ezRTTI* rootObjectRtti, const ezArrayPtr<const ezPropertyPathStep> path);
 
   ///\brief Applies the entire path and allows writing to the target object.
   ezResult WriteToLeafObject(void* pRootObject, const ezRTTI& type, ezDelegate<void(void* pLeaf, const ezRTTI& pType)> func) const;

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectMirror.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectMirror.cpp
@@ -440,8 +440,7 @@ void ezDocumentObjectMirror::ApplyOp(ezObjectChange& change)
   }
 
   ezPropertyPath propPath;
-  EZ_ASSERT_DEBUG(object.m_pType != nullptr, "Object does not have a type");
-  if (propPath.InitializeFromPath(*object.m_pType, change.m_Steps).Failed())
+  if (propPath.InitializeFromPath(object.m_pType, change.m_Steps).Failed())
   {
     ezLog::Error("Failed to init property path on object of type '{0}'.", object.m_pType->GetTypeName());
     return;


### PR DESCRIPTION
Fix an assert triggering in DocumentObjectMirror when opening a scene in the editor.

This assert was added because clang-tidy complained we might be converting a nullptr to a reference. It turns out that we indeed do this and that this is intended behavior. Thus the rootObjectRTTI argument was converted to a pointer, so it can be null.