### PR TITLE
Vulkan Format cleanup and validation fixes

### DIFF
--- a/Code/Editor/Editor/CMakeLists.txt
+++ b/Code/Editor/Editor/CMakeLists.txt
@@ -23,6 +23,14 @@ add_dependencies(${PROJECT_NAME}
   Player
 )
 
+# For SetProcessDpiAwareness
+if (EZ_CMAKE_PLATFORM_WINDOWS_DESKTOP)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    Shcore.lib
+  )
+endif()
+
 # set all external projects as runtime dependencies of this application
 get_property(EXTERNAL_PROJECTS GLOBAL PROPERTY "EXTERNAL_PROJECTS")
 if(EXTERNAL_PROJECTS)

--- a/Code/Editor/Editor/Editor.cpp
+++ b/Code/Editor/Editor/Editor.cpp
@@ -3,6 +3,10 @@
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+#  include <shellscalingapi.h>
+#endif
+
 class ezEditorApplication : public ezApplication
 {
 public:
@@ -11,6 +15,9 @@ public:
   ezEditorApplication()
     : ezApplication("ezEditor")
   {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+    SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+#endif
     EnableMemoryLeakReporting(true);
 
     m_pEditorApp = new ezQtEditorApp;

--- a/Code/Editor/EditorEngineProcess/CMakeLists.txt
+++ b/Code/Editor/EditorEngineProcess/CMakeLists.txt
@@ -16,6 +16,14 @@ target_link_libraries(${PROJECT_NAME}
   EditorEngineProcessFramework
 )
 
+# For SetProcessDpiAwareness
+if (EZ_CMAKE_PLATFORM_WINDOWS_DESKTOP)
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+    Shcore.lib
+  )
+endif()
+
 # For plugins to work in UWP builds, they must be direct link dependencies, otherwise they are not packaged with the app.
 if (EZ_CMAKE_PLATFORM_WINDOWS_UWP)
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -14,9 +14,18 @@
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+#  include <shellscalingapi.h>
+#endif
+
+
 ezEngineProcessGameApplication::ezEngineProcessGameApplication()
   : ezGameApplication("ezEditorEngineProcess", nullptr)
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+  SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
+#endif
+
   m_LongOpWorkerManager.Startup(&m_IPC);
 }
 

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -106,7 +106,7 @@ void ezResourceCacheVulkan::GetRenderPassDesc(const ezGALRenderingSetup& renderi
     const auto& formatInfo = s_pDevice->GetFormatLookupTable().GetFormatInfo(format);
 
     AttachmentDesc& depthAttachment = out_desc.attachments.ExpandAndGetRef();
-    depthAttachment.format = formatInfo.m_eRenderTarget;
+    depthAttachment.format = formatInfo.m_format;
     if (pTex->GetFormatOverrideEnabled())
     {
       depthAttachment.format = pTex->GetImageFormat();
@@ -151,7 +151,7 @@ void ezResourceCacheVulkan::GetRenderPassDesc(const ezGALRenderingSetup& renderi
     const auto& formatInfo = s_pDevice->GetFormatLookupTable().GetFormatInfo(format);
 
     AttachmentDesc& colorAttachment = out_desc.attachments.ExpandAndGetRef();
-    colorAttachment.format = formatInfo.m_eRenderTarget;
+    colorAttachment.format = formatInfo.m_format;
     if (pTex->GetFormatOverrideEnabled())
     {
       colorAttachment.format = pTex->GetImageFormat();

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -695,7 +695,7 @@ void ezGALCommandEncoderImplVulkan::CopyTextureReadbackResultPlatform(const ezGA
   else // One of the buffer variants.
   {
     const ezGALBufferVulkan* pStagingBuffer = static_cast<const ezGALBufferVulkan*>(m_GALDeviceVulkan.GetBuffer(pVulkanTexture->GetStagingBuffer()));
-    const vk::Format stagingFormat = m_GALDeviceVulkan.GetFormatLookupTable().GetFormatInfo(pVulkanTexture->GetDescription().m_Format).m_eStorage;
+    const vk::Format stagingFormat = m_GALDeviceVulkan.GetFormatLookupTable().GetFormatInfo(pVulkanTexture->GetDescription().m_Format).m_readback;
 
     ezHybridArray<ezGALTextureVulkan::SubResourceOffset, 8> subResourceOffsets;
     const ezUInt32 uiBufferSize = pVulkanTexture->ComputeSubResourceOffsets(subResourceOffsets);

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -9,7 +9,35 @@
 
 #include <vulkan/vulkan.hpp>
 
-using ezGALFormatLookupEntryVulkan = ezGALFormatLookupEntry<vk::Format, (vk::Format)0>;
+EZ_DEFINE_AS_POD_TYPE(vk::Format);
+
+struct ezGALFormatLookupEntryVulkan
+{
+  ezGALFormatLookupEntryVulkan() = default;
+  ezGALFormatLookupEntryVulkan(vk::Format format)
+  {
+    m_format = format;
+    m_readback = format;
+  }
+
+  ezGALFormatLookupEntryVulkan(vk::Format format, ezArrayPtr<vk::Format> mutableFormats)
+  {
+    m_format = format;
+    m_readback = format;
+    m_mutableFormats = mutableFormats;
+  }
+
+  inline ezGALFormatLookupEntryVulkan& R(vk::Format readbackType)
+  {
+    m_readback = readbackType;
+    return *this;
+  }
+
+  vk::Format m_format = vk::Format::eUndefined;
+  vk::Format m_readback = vk::Format::eUndefined;
+  ezHybridArray<vk::Format, 6> m_mutableFormats;
+};
+
 using ezGALFormatLookupTableVulkan = ezGALFormatLookupTable<ezGALFormatLookupEntryVulkan>;
 
 class ezGALBufferVulkan;
@@ -72,6 +100,8 @@ public:
 
     vk::PhysicalDeviceCustomBorderColorFeaturesEXT m_borderColorEXT;
     bool m_bBorderColorFloat = false;
+
+    bool m_bImageFormatList = false;
   };
 
   struct Queue

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -183,10 +183,8 @@ vk::Result ezGALDeviceVulkan::SelectInstanceExtensions(ezHybridArray<const char*
   }
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result
-  {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop)
-      { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -233,10 +231,8 @@ vk::Result ezGALDeviceVulkan::SelectDeviceExtensions(vk::DeviceCreateInfo& devic
   }
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result
-  {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop)
-      { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> vk::Result {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const vk::ExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName.data(), extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -518,9 +514,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
 
   m_pDefaultPass = EZ_NEW(&m_Allocator, ezGALPassVulkan, *this);
 
-  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle
-    { return CreateSwapChain([this, &desc](ezAllocatorBase* pAllocator) -> ezGALSwapChain*
-        { return EZ_NEW(pAllocator, ezGALSwapChainVulkan, desc); }); });
+  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([this, &desc](ezAllocatorBase* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainVulkan, desc); }); });
 
   return EZ_SUCCESS;
 }
@@ -569,8 +563,7 @@ void ezGALDeviceVulkan::UploadTextureStaging(ezStagingBufferPoolVulkan* pStaging
   const vk::Offset3D imageOffset = {0, 0, 0};
   const vk::Extent3D imageExtent = pTexture->GetMipLevelSize(subResource.mipLevel);
 
-  auto getRange = [](const vk::ImageSubresourceLayers& layers) -> vk::ImageSubresourceRange
-  {
+  auto getRange = [](const vk::ImageSubresourceLayers& layers) -> vk::ImageSubresourceRange {
     vk::ImageSubresourceRange range;
     range.aspectMask = layers.aspectMask;
     range.baseMipLevel = layers.mipLevel;
@@ -1518,8 +1511,7 @@ void ezGALDeviceVulkan::FillFormatLookupTable()
 
   m_FormatLookupTable.SetFormatInfo(ezGALResourceFormat::AUByteNormalized, ezGALFormatLookupEntryVulkan(vk::Format::eR8Unorm));
 
-  auto SelectDepthFormat = [&](const std::vector<vk::Format>& list) -> vk::Format
-  {
+  auto SelectDepthFormat = [&](const std::vector<vk::Format>& list) -> vk::Format {
     for (auto& format : list)
     {
       vk::FormatProperties formatProperties;
@@ -1530,8 +1522,7 @@ void ezGALDeviceVulkan::FillFormatLookupTable()
     return vk::Format::eUndefined;
   };
 
-  auto SelectStorageFormat = [](vk::Format depthFormat) -> vk::Format
-  {
+  auto SelectStorageFormat = [](vk::Format depthFormat) -> vk::Format {
     switch (depthFormat)
     {
       case vk::Format::eD16Unorm:

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
@@ -56,7 +56,7 @@ ezResult ezGALResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
 
     ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat == ezGALResourceFormat::Invalid ? texDesc.m_Format : m_Description.m_OverrideViewFormat;
     vk::ImageViewCreateInfo viewCreateInfo;
-    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_eResourceViewType;
+    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
     viewCreateInfo.image = image;
     viewCreateInfo.subresourceRange = ezConversionUtilsVulkan::GetSubresourceRange(texDesc, m_Description);
     viewCreateInfo.subresourceRange.aspectMask &= ~vk::ImageAspectFlagBits::eStencil;
@@ -117,7 +117,7 @@ ezResult ezGALResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
 
       vk::BufferViewCreateInfo viewCreateInfo;
       viewCreateInfo.buffer = pParentBuffer->GetVkBuffer();
-      viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_eResourceViewType;
+      viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
       viewCreateInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
       viewCreateInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
 

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
@@ -55,7 +55,7 @@ ezResult ezGALUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice)
 
     ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat == ezGALResourceFormat::Invalid ? texDesc.m_Format : m_Description.m_OverrideViewFormat;
     vk::ImageViewCreateInfo viewCreateInfo;
-    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_eResourceViewType;
+    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
     viewCreateInfo.image = image;
     viewCreateInfo.subresourceRange = ezConversionUtilsVulkan::GetSubresourceRange(texDesc, m_Description);
     viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, bIsArrayView);

--- a/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
@@ -53,7 +53,7 @@ ezResult ezGALVertexDeclarationVulkan::InitPlatform(ezGALDevice* pDevice)
     vk::VertexInputAttributeDescription& attrib = m_attributes.ExpandAndGetRef();
     attrib.binding = Current.m_uiVertexBufferSlot;
     attrib.location = uiLocation;
-    attrib.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(Current.m_eFormat).m_eVertexAttributeType;
+    attrib.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(Current.m_eFormat).m_format;
     attrib.offset = Current.m_uiOffset;
 
     if (attrib.format == vk::Format::eUndefined)

--- a/Code/Engine/Texture/Image/ImageUtils.h
+++ b/Code/Engine/Texture/Image/ImageUtils.h
@@ -12,6 +12,9 @@ public:
   /// \brief Returns the image with the difference (absolute values) between ImageA and ImageB.
   static void ComputeImageDifferenceABS(const ezImageView& imageA, const ezImageView& imageB, ezImage& out_difference);
 
+  /// \brief Same as ComputeImageDifferenceABS, but for every pixel in imageA, the minimum diff in imageB is searched in a 1-pixel radius, allowing pixels in B to shift slightly without incurring a difference.
+  static void ComputeImageDifferenceABSRelaxed(const ezImageView& imageA, const ezImageView& imageB, ezImage& out_difference);
+
   /// \brief Computes the mean square error for the block at (offsetx, offsety) to (offsetx + uiBlockSize, offsety + uiBlockSize).
   /// DifferenceImage is expected to be an image that represents the difference between two images.
   static ezUInt32 ComputeMeanSquareError(const ezImageView& differenceImage, ezUInt8 uiBlockSize, ezUInt32 uiOffsetx, ezUInt32 uiOffsety);

--- a/Code/UnitTests/RendererTest/Basics/LineRendering.cpp
+++ b/Code/UnitTests/RendererTest/Basics/LineRendering.cpp
@@ -11,7 +11,7 @@ ezTestAppRun ezRendererTestBasics::SubtestLineRendering()
 
   RenderLineObjects(ezShaderBindFlags::Default);
 
-  EZ_TEST_IMAGE(0, 150);
+  EZ_TEST_LINE_IMAGE(0, 150);
 
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
@@ -126,7 +126,10 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
 
   RenderObjects(ezShaderBindFlags::NoRasterizerState);
 
-  EZ_TEST_IMAGE(m_iFrame, 150);
+  if (RasterStateDesc.m_bWireFrame)
+    EZ_TEST_LINE_IMAGE(m_iFrame, 300);
+  else
+    EZ_TEST_IMAGE(m_iFrame, 150);
 
   EndFrame();
 

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.h
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.h
@@ -108,8 +108,8 @@ public:
     ezImage& ref_capturedImgAlpha, ezImage& ref_diffImgRgb, ezImage& ref_diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb,
     ezUInt8 uiMaxDiffRgb, ezUInt8 uiMinDiffAlpha, ezUInt8 uiMaxDiffAlpha);
 
-  bool PerformImageComparison(ezStringBuilder sImgName, const ezImage& img, ezUInt32 uiMaxError, char* szErrorMsg);
-  bool CompareImages(ezUInt32 uiImageNumber, ezUInt32 uiMaxError, char* szErrorMsg, bool bIsDepthImage = false);
+  bool PerformImageComparison(ezStringBuilder sImgName, const ezImage& img, ezUInt32 uiMaxError, bool bIsLineImage, char* szErrorMsg);
+  bool CompareImages(ezUInt32 uiImageNumber, ezUInt32 uiMaxError, char* szErrorMsg, bool bIsDepthImage = false, bool bIsLineImage = false);
 
   /// \brief A function to be called to add extra info to image diff output, that is not available from here.
   /// E.g. device specific info like driver version.
@@ -540,13 +540,16 @@ EZ_TEST_DLL bool ezTestTextFiles(
 //////////////////////////////////////////////////////////////////////////
 
 EZ_TEST_DLL bool ezTestImage(
-  ezUInt32 uiImageNumber, ezUInt32 uiMaxError, bool bIsDepthImage, const char* szFile, ezInt32 iLine, const char* szFunction, const char* szMsg, ...);
+  ezUInt32 uiImageNumber, ezUInt32 uiMaxError, bool bIsDepthImage, bool bIsLineImage, const char* szFile, ezInt32 iLine, const char* szFunction, const char* szMsg, ...);
 
 /// \brief Same as EZ_TEST_IMAGE_MSG but uses an empty error message.
 #define EZ_TEST_IMAGE(ImageNumber, MaxError) EZ_TEST_IMAGE_MSG(ImageNumber, MaxError, "")
 
 /// \brief Same as EZ_TEST_DEPTH_IMAGE_MSG but uses an empty error message.
 #define EZ_TEST_DEPTH_IMAGE(ImageNumber, MaxError) EZ_TEST_DEPTH_IMAGE_MSG(ImageNumber, MaxError, "")
+
+/// \brief Same as EZ_TEST_LINE_IMAGE_MSG but uses an empty error message.
+#define EZ_TEST_LINE_IMAGE(ImageNumber, MaxError) EZ_TEST_LINE_IMAGE_MSG(ImageNumber, MaxError, "")
 
 /// \brief Executes an image comparison right now.
 ///
@@ -566,10 +569,14 @@ EZ_TEST_DLL bool ezTestImage(
 /// \note Some tests need to know at the start, whether an image comparison will be done at the end, so they
 /// can capture the image first. For such use cases, use EZ_SCHEDULE_IMAGE_TEST at the start of a sub-test instead.
 #define EZ_TEST_IMAGE_MSG(ImageNumber, MaxError, msg, ...) \
-  ezTestImage(ImageNumber, MaxError, false, EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, msg, ##__VA_ARGS__)
+  ezTestImage(ImageNumber, MaxError, false, false, EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, msg, ##__VA_ARGS__)
 
 #define EZ_TEST_DEPTH_IMAGE_MSG(ImageNumber, MaxError, msg, ...) \
-  ezTestImage(ImageNumber, MaxError, true, EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, msg, ##__VA_ARGS__)
+  ezTestImage(ImageNumber, MaxError, true, false, EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, msg, ##__VA_ARGS__)
+
+/// \brief Same as EZ_TEST_IMAGE_MSG, but allows for pixels to shift in a 1-pixel radius to account for different line rasterization of GPU vendors.
+#define EZ_TEST_LINE_IMAGE_MSG(ImageNumber, MaxError, msg, ...) \
+  ezTestImage(ImageNumber, MaxError, false, true, EZ_SOURCE_FILE, EZ_SOURCE_LINE, EZ_SOURCE_FUNCTION, msg, ##__VA_ARGS__)
 
 /// \brief Schedules an EZ_TEST_IMAGE to be executed after the current sub-test execution finishes.
 ///


### PR DESCRIPTION
# Format mappings
* Cleaned up **ezGALDeviceVulkan::FillFormatLookupTable**. ezGALFormatLookupEntryVulkan now just stores the GPU format, the CPU readback format and an array of mutable target formats.
* If **VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME** is supported. Textures are now created with a list of mutable target formats.
* Added test code to print out format mapping table.

# Tests
* Renderer tests should now succeed on Nvidia GPUs.
* Added custom line rendering image comparision via **EZ_TEST_LINE_IMAGE**. Reference pixels are searched for in the captured image in a 1 pixel radius to account for shifts in line rasterization. This allows us to use one line reference image for multiple GPU vendors.

# Misc
* Swapchain validation error fixes.
* Editor is now DPI aware on windows to support screen scaling.
* Workaround for bug in Nvidia drivers which pretends to support linear layout rendering but then doesn't.