### PR TITLE
Editor fixes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1537,6 +1537,7 @@ void ezAssetCurator::OnAssetFilesEvent(const ezFileChangedEvent& e)
       // If the asset was just added it is not tracked and thus no need to invalidate anything.
       if (e.m_Type == ezFileChangedEvent::Type::FileChanged)
       {
+        EZ_LOCK(m_CuratorMutex);
         ezUuid guid0 = e.m_Status.m_DocumentID;
         if (guid0.IsValid())
           InvalidateAssetTransformState(guid0);
@@ -1579,6 +1580,7 @@ void ezAssetCurator::OnAssetFilesEvent(const ezFileChangedEvent& e)
     break;
     case ezFileChangedEvent::Type::FileRemoved:
     {
+      EZ_LOCK(m_CuratorMutex);
       ezUuid guid0 = e.m_Status.m_DocumentID;
       if (guid0.IsValid())
       {

--- a/Code/Editor/EditorFramework/Object/Implementation/ObjectPropertyPath.cpp
+++ b/Code/Editor/EditorFramework/Object/Implementation/ObjectPropertyPath.cpp
@@ -115,16 +115,15 @@ ezStatus ezObjectPropertyPath::ResolvePath(const ezObjectPropertyPathContext& co
   {
     for (const ezDocumentObject* pObj : input)
     {
-      visitor.Visit(pObj, false, [&output, &sName](const ezDocumentObject* pObject) -> bool
+      visitor.Visit(pObj, false, [&output, &sName](const ezDocumentObject* pObject) -> bool {
+        const auto& sObjectName = pObject->GetTypeAccessor().GetValue("Name").Get<ezString>();
+        if (sObjectName == sName)
         {
-          const auto& sObjectName = pObject->GetTypeAccessor().GetValue("Name").Get<ezString>();
-          if (sObjectName == sName)
-          {
-            output.PushBack(pObject);
-            return false;
-          }
-          return true; //
-        });
+          output.PushBack(pObject);
+          return false;
+        }
+        return true; //
+      });
     }
     input.Clear();
     input.Swap(output);

--- a/Code/Editor/EditorFramework/Object/ObjectPropertyPath.h
+++ b/Code/Editor/EditorFramework/Object/ObjectPropertyPath.h
@@ -38,7 +38,7 @@ public:
     ezStringBuilder& out_sComponentType, ezStringBuilder& out_sPropertyPath);
   static ezStatus CreatePropertyPath(const ezObjectPropertyPathContext& context, const ezPropertyReference& prop, ezStringBuilder& out_sPropertyPath);
 
-  static ezStatus ResolvePath(const ezObjectPropertyPathContext& context, ezHybridArray<ezPropertyReference, 1>& out_keys,
+  static ezStatus ResolvePath(const ezObjectPropertyPathContext& context, ezDynamicArray<ezPropertyReference>& out_keys,
     const char* szObjectSearchSequence, const char* szComponentType, const char* szPropertyPath);
   static ezStatus ResolvePropertyPath(const ezObjectPropertyPathContext& context, const char* szPropertyPath, ezPropertyReference& out_key);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.cpp
@@ -348,7 +348,7 @@ void ezPropertyAnimAssetDocument::AddTrack(const ezUuid& track)
     return;
 
   auto pTrack = GetTrack(track);
-  FindTrackKeys(pTrack->m_sObjectSearchSequence.GetData(), pTrack->m_sComponentType.GetData(), pTrack->m_sPropertyPath.GetData(), keys);
+  FindTrackKeys(pTrack->m_sObjectSearchSequence.GetData(), pTrack->m_sComponentType.GetData(), pTrack->m_sPropertyPath.GetData(), keys).IgnoreResult();
 
   for (const ezPropertyReference& key : keys)
   {
@@ -367,12 +367,12 @@ void ezPropertyAnimAssetDocument::AddTrack(const ezUuid& track)
 }
 
 
-void ezPropertyAnimAssetDocument::FindTrackKeys(const char* szObjectSearchSequence, const char* szComponentType, const char* szPropertyPath, ezHybridArray<ezPropertyReference, 1>& keys) const
+ezStatus ezPropertyAnimAssetDocument::FindTrackKeys(const char* szObjectSearchSequence, const char* szComponentType, const char* szPropertyPath, ezHybridArray<ezPropertyReference, 1>& keys) const
 {
   ezObjectPropertyPathContext context = {GetContextObject(), m_pObjectAccessor.Borrow(), "TempObjects"};
 
   keys.Clear();
-  ezObjectPropertyPath::ResolvePath(context, keys, szObjectSearchSequence, szComponentType, szPropertyPath).AssertSuccess();
+  return ezObjectPropertyPath::ResolvePath(context, keys, szObjectSearchSequence, szComponentType, szPropertyPath);
 }
 
 
@@ -600,11 +600,7 @@ ezStatus ezPropertyAnimAssetDocument::CanAnimate(
   }
 
   ezHybridArray<ezPropertyReference, 1> keys;
-  FindTrackKeys(sObjectSearchSequence.GetData(), sComponentType.GetData(), sPropertyPath.GetData(), keys);
-  if (!keys.Contains(key))
-    return ezStatus("No node name set or property is not reachable.");
-
-  return ezStatus(EZ_SUCCESS);
+  return FindTrackKeys(sObjectSearchSequence.GetData(), sComponentType.GetData(), sPropertyPath.GetData(), keys);
 }
 
 ezUuid ezPropertyAnimAssetDocument::FindTrack(

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
@@ -142,7 +142,7 @@ private:
   void RebuildMapping();
   void RemoveTrack(const ezUuid& track);
   void AddTrack(const ezUuid& track);
-  void FindTrackKeys(
+  ezStatus FindTrackKeys(
     const char* szObjectSearchSequence, const char* szComponentType, const char* szPropertyPath, ezHybridArray<ezPropertyReference, 1>& keys) const;
   void GenerateTrackInfo(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index, ezStringBuilder& sObjectSearchSequence,
     ezStringBuilder& sComponentType, ezStringBuilder& sPropertyPath) const;

--- a/Code/Engine/Foundation/ezEngine.natvis
+++ b/Code/Engine/Foundation/ezEngine.natvis
@@ -7,13 +7,10 @@
 	<!-- Strings-->
 	<Type Name="ezHybridStringBase&lt;*&gt;">
 		<AlternativeType Name="ezStringBuilder" />
-		<DisplayString Condition="((intptr_t)m_Data.m_pAllocator.m_pPtr &amp; 0x1) == 0">{m_Data.m_pElements,s8}</DisplayString>
-		<DisplayString Condition="((intptr_t)m_Data.m_pAllocator.m_pPtr &amp; 0x1) != 0">{m_Data.m_StaticData,s8}</DisplayString>
-		<StringView Condition="((intptr_t)m_Data.m_pAllocator.m_pPtr &amp; 0x1) == 0">m_Data.m_pElements,s8</StringView>
-		<StringView Condition="((intptr_t)m_Data.m_pAllocator.m_pPtr &amp; 0x1) != 0">m_Data.m_StaticData,s8</StringView>
+    <DisplayString>{m_Data.m_pElements,s8}</DisplayString>
+    <StringView>m_Data.m_pElements,s8</StringView>
 		<Expand>
-			<Item Condition="((intptr_t)m_Data.m_pAllocator.m_pPtr &amp; 0x1) == 0" Name="String">m_Data.m_pElements,s8</Item>
-			<Item Condition="((intptr_t)m_Data.m_pAllocator.m_pPtr &amp; 0x1) != 0" Name="String">m_Data.m_StaticData,s8</Item>
+			<Item Name="String">m_Data.m_pElements,s8</Item>
 			<Item Name="CharacterCount">m_uiCharacterCount</Item>
 			<Item Name="ElementCount">m_Data.m_uiCount</Item>
 		</Expand>
@@ -57,7 +54,7 @@
 			<Item Name="capacity">m_uiCapacity</Item>
 			<ArrayItems>
 				<Size>m_uiCount</Size>
-				<ValuePointer>(((int64_t)m_pAllocator.m_pPtr &amp; 0x1) != 0) ? ($T1*)((intptr_t)this + (intptr_t)m_pElements) : m_pElements</ValuePointer>
+				<ValuePointer>m_pElements</ValuePointer>
 			</ArrayItems>
 		</Expand>
 	</Type>
@@ -187,8 +184,8 @@
 
 	<!-- Basic Types -->
 	<Type Name="ezVariant">
-		<DisplayString Condition="m_uiType == Type::TypedObject &amp;&amp; m_bIsShared">({m_Data.shared->m_pType->m_szTypeName,sb}*) {reinterpret_cast&lt;void*&gt;(m_Data.shared->m_Ptr)}</DisplayString>
-		<DisplayString Condition="m_uiType == Type::TypedObject &amp;&amp; !m_bIsShared">({m_Data.inlined.m_pType->m_szTypeName,sb}*) {reinterpret_cast&lt;void*&gt;(&amp;m_Data)}</DisplayString>
+		<DisplayString Condition="m_uiType == Type::TypedObject &amp;&amp; m_bIsShared">({m_Data.shared->m_pType->m_sTypeName,sb}*) {reinterpret_cast&lt;void*&gt;(m_Data.shared->m_Ptr)}</DisplayString>
+		<DisplayString Condition="m_uiType == Type::TypedObject &amp;&amp; !m_bIsShared">({m_Data.inlined.m_pType->m_sTypeName,sb}*) {reinterpret_cast&lt;void*&gt;(&amp;m_Data)}</DisplayString>
 		<Expand>
 			<Item Name="Type">(Type::Enum) m_uiType</Item>
 			<Item Name="Value" Condition="m_uiType == Type::Bool">*reinterpret_cast&lt;bool*&gt;(&amp;m_Data)</Item>

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -111,8 +111,7 @@ void ezEditorSceneDocumentTest::CloseSimpleScene()
   {
     bool bSaved = false;
     ezTaskGroupID id = m_pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res)
-      {
+      [&bSaved](ezDocument* pDoc, ezStatus res) {
         bSaved = true;
       },
       true);
@@ -140,8 +139,7 @@ void ezEditorSceneDocumentTest::LayerOperations()
   ezUuid layer1Guid;
   ezLayerDocument* pLayer1 = nullptr;
 
-  auto TestLayerEvents = [&expectedEvents](const ezScene2LayerEvent& e)
-  {
+  auto TestLayerEvents = [&expectedEvents](const ezScene2LayerEvent& e) {
     if (EZ_TEST_BOOL(!expectedEvents.IsEmpty()))
     {
       // If we pass in an invalid guid it's considered fine as we might not know the ID, e.g. when creating a layer.
@@ -211,8 +209,7 @@ void ezEditorSceneDocumentTest::LayerOperations()
   {
     bool bSaved = false;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res)
-      {
+      [&bSaved](ezDocument* pDoc, ezStatus res) {
         bSaved = true;
       },
       true);
@@ -305,8 +302,7 @@ void ezEditorSceneDocumentTest::LayerOperations()
   {
     bool bSaved = false;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res)
-      {
+      [&bSaved](ezDocument* pDoc, ezStatus res) {
         bSaved = true;
       },
       true);
@@ -374,8 +370,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("Components"));
 
       // Does default state match that of pSphere2 which is unmodified?
-      auto MatchesDefaultValue = [&](ezDefaultObjectState& ref_defaultState, const char* szProperty)
-      {
+      auto MatchesDefaultValue = [&](ezDefaultObjectState& ref_defaultState, const char* szProperty) {
         ezVariant defaultValue = ref_defaultState.GetDefaultValue(szProperty);
         ezVariant sphere2value;
         EZ_TEST_STATUS(pAccessor->GetValue(pSphere2, szProperty, sphere2value));
@@ -548,8 +543,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
     }
   }
 
-  auto IsObjectDefault = [&](const ezDocumentObject* pChild)
-  {
+  auto IsObjectDefault = [&](const ezDocumentObject* pChild) {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
     ezDefaultObjectState defaultState(pAccessor, selection);
@@ -720,15 +714,13 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   selection.PushBack(pRoot);
   m_pDoc->GetSelectionManager()->SetSelection(selection);
 
-  auto CreateComponent = [&](const ezRTTI* pType, const ezDocumentObject* pParent) -> const ezDocumentObject*
-  {
+  auto CreateComponent = [&](const ezRTTI* pType, const ezDocumentObject* pParent) -> const ezDocumentObject* {
     ezUuid compGuid;
     EZ_TEST_STATUS(pAccessor->AddObject(pParent, "Components", -1, pType, compGuid));
     return pAccessor->GetObject(compGuid);
   };
 
-  auto IsObjectDefault = [&](const ezDocumentObject* pChild)
-  {
+  auto IsObjectDefault = [&](const ezDocumentObject* pChild) {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
     ezDefaultObjectState defaultState(pAccessor, selection);
@@ -751,8 +743,7 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   };
 
   ezDynamicArray<const ezRTTI*> componentTypes;
-  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
-    { componentTypes.PushBack(pRtti); });
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti) { componentTypes.PushBack(pRtti); });
 
   ezSet<const ezRTTI*> blacklist;
   // The scene already has one and the code asserts otherwise. There needs to be a general way of preventing two settings components from existing at the same time.
@@ -805,8 +796,7 @@ void ezEditorSceneDocumentTest::ObjectPropertyPath()
 
   auto pAccessor = m_pDoc->GetObjectAccessor();
 
-  auto CreateComponent = [&](const ezDocumentObject* pParent) -> const ezDocumentObject*
-  {
+  auto CreateComponent = [&](const ezDocumentObject* pParent) -> const ezDocumentObject* {
     pAccessor->StartTransaction("AddComponent"_ezsv);
     ezUuid compGuid;
     EZ_TEST_STATUS(pAccessor->AddObject(pParent, "Components", -1, ezRTTI::FindTypeByName("ezDecalComponent"), compGuid));

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -5,15 +5,18 @@
 #include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorFramework/DragDrop/DragDropHandler.h>
 #include <EditorFramework/DragDrop/DragDropInfo.h>
+#include <EditorFramework/Object/ObjectPropertyPath.h>
 #include <EditorPluginScene/Panels/LayerPanel/LayerAdapter.moc.h>
 #include <EditorPluginScene/Scene/LayerDocument.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
 #include <EditorTest/SceneDocument/SceneDocumentTest.h>
 #include <Foundation/IO/OSFile.h>
+#include <Foundation/Reflection/Implementation/RTTI.h>
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
-#include <QMimeData>
 #include <RendererCore/Lights/SphereReflectionProbeComponent.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+#include <QMimeData>
 
 static ezEditorSceneDocumentTest s_EditorSceneDocumentTest;
 
@@ -27,6 +30,7 @@ void ezEditorSceneDocumentTest::SetupSubTests()
   AddSubTest("Layer Operations", SubTests::ST_LayerOperations);
   AddSubTest("Prefab Operations", SubTests::ST_PrefabOperations);
   AddSubTest("Component Operations", SubTests::ST_ComponentOperations);
+  AddSubTest("Object Property Path", SubTests::ST_ObjectPropertyPath);
 }
 
 ezResult ezEditorSceneDocumentTest::InitializeTest()
@@ -72,6 +76,9 @@ ezTestAppRun ezEditorSceneDocumentTest::RunSubTest(ezInt32 iIdentifier, ezUInt32
     case SubTests::ST_ComponentOperations:
       ComponentOperations();
       break;
+    case SubTests::ST_ObjectPropertyPath:
+      ObjectPropertyPath();
+      break;
   }
   return ezTestAppRun::Quit;
 }
@@ -104,7 +111,8 @@ void ezEditorSceneDocumentTest::CloseSimpleScene()
   {
     bool bSaved = false;
     ezTaskGroupID id = m_pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res) {
+      [&bSaved](ezDocument* pDoc, ezStatus res)
+      {
         bSaved = true;
       },
       true);
@@ -132,7 +140,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
   ezUuid layer1Guid;
   ezLayerDocument* pLayer1 = nullptr;
 
-  auto TestLayerEvents = [&expectedEvents](const ezScene2LayerEvent& e) {
+  auto TestLayerEvents = [&expectedEvents](const ezScene2LayerEvent& e)
+  {
     if (EZ_TEST_BOOL(!expectedEvents.IsEmpty()))
     {
       // If we pass in an invalid guid it's considered fine as we might not know the ID, e.g. when creating a layer.
@@ -202,7 +211,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
   {
     bool bSaved = false;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res) {
+      [&bSaved](ezDocument* pDoc, ezStatus res)
+      {
         bSaved = true;
       },
       true);
@@ -295,7 +305,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
   {
     bool bSaved = false;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res) {
+      [&bSaved](ezDocument* pDoc, ezStatus res)
+      {
         bSaved = true;
       },
       true);
@@ -363,7 +374,8 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("Components"));
 
       // Does default state match that of pSphere2 which is unmodified?
-      auto MatchesDefaultValue = [&](ezDefaultObjectState& ref_defaultState, const char* szProperty) {
+      auto MatchesDefaultValue = [&](ezDefaultObjectState& ref_defaultState, const char* szProperty)
+      {
         ezVariant defaultValue = ref_defaultState.GetDefaultValue(szProperty);
         ezVariant sphere2value;
         EZ_TEST_STATUS(pAccessor->GetValue(pSphere2, szProperty, sphere2value));
@@ -445,7 +457,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
   const ezDocumentObject* pPrefab3 = nullptr;
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Create Prefab from Selection")
   {
-    //ProcessEvents(999999999);
+    // ProcessEvents(999999999);
 
     ezStringBuilder sPrefabName;
     sPrefabName = m_sProjectPath;
@@ -536,7 +548,8 @@ void ezEditorSceneDocumentTest::PrefabOperations()
     }
   }
 
-  auto IsObjectDefault = [&](const ezDocumentObject* pChild) {
+  auto IsObjectDefault = [&](const ezDocumentObject* pChild)
+  {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
     ezDefaultObjectState defaultState(pAccessor, selection);
@@ -561,11 +574,11 @@ void ezEditorSceneDocumentTest::PrefabOperations()
     const ezAbstractProperty* pProp = pPrefab3->GetType()->FindPropertyByName("Children");
     const ezAbstractProperty* pCompProp = pPrefab3->GetType()->FindPropertyByName("Components");
 
-    //ProcessEvents(999999999);
+    // ProcessEvents(999999999);
 
     CheckHierarchy(pAccessor, pPrefab3, IsObjectDefault);
 
-    //ProcessEvents(999999999);
+    // ProcessEvents(999999999);
     {
       m_pDoc->UpdatePrefabs();
       // Update prefabs replaces object instances with new ones with the same IDs so the old ones are in the undo history now.
@@ -707,13 +720,15 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   selection.PushBack(pRoot);
   m_pDoc->GetSelectionManager()->SetSelection(selection);
 
-  auto CreateComponent = [&](const ezRTTI* pType, const ezDocumentObject* pParent) -> const ezDocumentObject* {
+  auto CreateComponent = [&](const ezRTTI* pType, const ezDocumentObject* pParent) -> const ezDocumentObject*
+  {
     ezUuid compGuid;
     EZ_TEST_STATUS(pAccessor->AddObject(pParent, "Components", -1, pType, compGuid));
     return pAccessor->GetObject(compGuid);
   };
 
-  auto IsObjectDefault = [&](const ezDocumentObject* pChild) {
+  auto IsObjectDefault = [&](const ezDocumentObject* pChild)
+  {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
     ezDefaultObjectState defaultState(pAccessor, selection);
@@ -736,7 +751,8 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   };
 
   ezDynamicArray<const ezRTTI*> componentTypes;
-  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti) { componentTypes.PushBack(pRtti); });
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
+    { componentTypes.PushBack(pRtti); });
 
   ezSet<const ezRTTI*> blacklist;
   // The scene already has one and the code asserts otherwise. There needs to be a general way of preventing two settings components from existing at the same time.
@@ -755,11 +771,146 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   }
 
   pAccessor->FinishTransaction();
-
   ProcessEvents(10);
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Re-open document")
+  {
+    ezUuid layerGuid = m_LayerGuid;
+    CloseSimpleScene();
+    ProcessEvents(10);
+
+    m_pDoc = ezDynamicCast<ezScene2Document*>(OpenDocument("ComponentOperations.ezScene"));
+    EZ_TEST_BOOL(m_pDoc != nullptr);
+    m_SceneGuid = m_pDoc->GetGuid();
+
+    ezHybridArray<ezUuid, 2> layers;
+    m_pDoc->GetAllLayers(layers);
+
+    EZ_TEST_BOOL(layers.Contains(layerGuid));
+    m_LayerGuid = layerGuid;
+
+    EZ_TEST_BOOL(m_pDoc->SetLayerLoaded(m_LayerGuid, true).Succeeded());
+    m_pLayer = ezDynamicCast<ezLayerDocument*>(m_pDoc->GetLayerDocument(m_LayerGuid));
+    EZ_TEST_BOOL(m_pLayer != nullptr);
+  }
+
   CloseSimpleScene();
 }
 
+
+void ezEditorSceneDocumentTest::ObjectPropertyPath()
+{
+  if (CreateSimpleScene("ObjectPropertyPath.ezScene").Failed())
+    return;
+
+  auto pAccessor = m_pDoc->GetObjectAccessor();
+
+  auto CreateComponent = [&](const ezDocumentObject* pParent) -> const ezDocumentObject*
+  {
+    pAccessor->StartTransaction("AddComponent"_ezsv);
+    ezUuid compGuid;
+    EZ_TEST_STATUS(pAccessor->AddObject(pParent, "Components", -1, ezRTTI::FindTypeByName("ezDecalComponent"), compGuid));
+    const ezDocumentObject* pComp = pAccessor->GetObject(compGuid);
+    EZ_TEST_STATUS(pAccessor->InsertValue(pComp, "Decals", "", 0));
+    pAccessor->FinishTransaction();
+    return pComp;
+  };
+
+  const ezDocumentObject* pRoot = CreateGameObject(m_pDoc, nullptr, "Root"_ezsv);
+  const ezDocumentObject* pDummy = CreateGameObject(m_pDoc, pRoot, "Dummy"_ezsv);
+  const ezDocumentObject* pC1 = CreateGameObject(m_pDoc, pDummy, "C"_ezsv);
+  const ezDocumentObject* pComp1 = CreateComponent(pC1);
+
+  const ezDocumentObject* pA = CreateGameObject(m_pDoc, pRoot, "A"_ezsv);
+  const ezDocumentObject* pB = CreateGameObject(m_pDoc, pA, "B"_ezsv);
+  const ezDocumentObject* pC2 = CreateGameObject(m_pDoc, pB, "C"_ezsv);
+  const ezDocumentObject* pComp2 = CreateComponent(pC2);
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GameObject property")
+  {
+    ezObjectPropertyPathContext context{pRoot, pAccessor, "Children"};
+    ezPropertyReference propertyRef{pC2->GetGuid(), pC2->GetType()->FindPropertyByName("Active"_ezsv)};
+
+    ezStringBuilder sObjectSearchSequence;
+    ezStringBuilder sComponentType;
+    ezStringBuilder sPropertyPath;
+    EZ_TEST_STATUS(ezObjectPropertyPath::CreatePath(context, propertyRef, sObjectSearchSequence, sComponentType, sPropertyPath));
+    EZ_TEST_STRING(sObjectSearchSequence, "A/B/C");
+    EZ_TEST_BOOL(sComponentType.IsEmpty());
+    EZ_TEST_STRING(sPropertyPath, "Active");
+
+    ezHybridArray<ezPropertyReference, 2> properties;
+    EZ_TEST_BOOL(ezObjectPropertyPath::ResolvePath(context, properties, "A/B/D", "", sPropertyPath).Failed());                                    // Path does not exist.
+    EZ_TEST_BOOL(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, "ezPointLightComponent", sPropertyPath).Failed()); // Component does not exist.
+    EZ_TEST_BOOL(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, "", "Bla").Failed());                              // Property does not exist.
+    EZ_TEST_STATUS(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, "", sPropertyPath));
+    EZ_TEST_INT(properties.GetCount(), 1);
+    EZ_TEST_BOOL(properties[0] == propertyRef);
+
+    properties.Clear();
+    EZ_TEST_STATUS(ezObjectPropertyPath::ResolvePath(context, properties, "C", "", sPropertyPath)); // ambiguous target
+    EZ_TEST_INT(properties.GetCount(), 2);
+    ezPropertyReference propertyRef2{pC1->GetGuid(), pC2->GetType()->FindPropertyByName("Active"_ezsv)};
+    EZ_TEST_BOOL(properties[0] == propertyRef2);
+    EZ_TEST_BOOL(properties[1] == propertyRef);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Component member property")
+  {
+    ezObjectPropertyPathContext context{pRoot, pAccessor, "Children"};
+    ezPropertyReference propertyRef{pComp2->GetGuid(), pComp2->GetType()->FindPropertyByName("Color"_ezsv)};
+
+    ezStringBuilder sObjectSearchSequence;
+    ezStringBuilder sComponentType;
+    ezStringBuilder sPropertyPath;
+    EZ_TEST_STATUS(ezObjectPropertyPath::CreatePath(context, propertyRef, sObjectSearchSequence, sComponentType, sPropertyPath));
+    EZ_TEST_STRING(sObjectSearchSequence, "A/B/C");
+    EZ_TEST_STRING(sComponentType, "ezDecalComponent");
+    EZ_TEST_STRING(sPropertyPath, "Color");
+
+    ezHybridArray<ezPropertyReference, 2> properties;
+    EZ_TEST_BOOL(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, sComponentType, "Bla").Failed()); // Property does not exist.
+    EZ_TEST_STATUS(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, sComponentType, sPropertyPath));
+    EZ_TEST_INT(properties.GetCount(), 1);
+    EZ_TEST_BOOL(properties[0] == propertyRef);
+
+    properties.Clear();
+    EZ_TEST_STATUS(ezObjectPropertyPath::ResolvePath(context, properties, "C", sComponentType, sPropertyPath)); // ambiguous target
+    EZ_TEST_INT(properties.GetCount(), 2);
+    ezPropertyReference propertyRef2{pComp1->GetGuid(), pComp1->GetType()->FindPropertyByName("Color"_ezsv)};
+    EZ_TEST_BOOL(properties[0] == propertyRef2);
+    EZ_TEST_BOOL(properties[1] == propertyRef);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Component array property")
+  {
+    ezObjectPropertyPathContext context{pRoot, pAccessor, "Children"};
+    ezPropertyReference propertyRef{pComp2->GetGuid(), pComp2->GetType()->FindPropertyByName("Decals"_ezsv), 0};
+
+    ezStringBuilder sObjectSearchSequence;
+    ezStringBuilder sComponentType;
+    ezStringBuilder sPropertyPath;
+    EZ_TEST_STATUS(ezObjectPropertyPath::CreatePath(context, propertyRef, sObjectSearchSequence, sComponentType, sPropertyPath));
+    EZ_TEST_STRING(sObjectSearchSequence, "A/B/C");
+    EZ_TEST_STRING(sComponentType, "ezDecalComponent");
+    EZ_TEST_STRING(sPropertyPath, "Decals[0]");
+
+    ezHybridArray<ezPropertyReference, 2> properties;
+    EZ_TEST_BOOL(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, sComponentType, "Decals[1]").Failed()); // Index out of range.
+    EZ_TEST_STATUS(ezObjectPropertyPath::ResolvePath(context, properties, sObjectSearchSequence, sComponentType, sPropertyPath));
+    EZ_TEST_INT(properties.GetCount(), 1);
+    EZ_TEST_BOOL(properties[0] == propertyRef);
+
+    properties.Clear();
+    EZ_TEST_STATUS(ezObjectPropertyPath::ResolvePath(context, properties, "C", sComponentType, sPropertyPath)); // ambiguous target
+    EZ_TEST_INT(properties.GetCount(), 2);
+    ezPropertyReference propertyRef2{pComp1->GetGuid(), pComp1->GetType()->FindPropertyByName("Decals"_ezsv), 0};
+    EZ_TEST_BOOL(properties[0] == propertyRef2);
+    EZ_TEST_BOOL(properties[1] == propertyRef);
+  }
+
+  CloseSimpleScene();
+}
 
 void ezEditorSceneDocumentTest::CheckHierarchy(ezObjectAccessorBase* pAccessor, const ezDocumentObject* pRoot, ezDelegate<void(const ezDocumentObject* pChild)> functor)
 {

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.h
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.h
@@ -17,6 +17,7 @@ private:
     ST_LayerOperations,
     ST_PrefabOperations,
     ST_ComponentOperations,
+    ST_ObjectPropertyPath,
   };
 
   virtual void SetupSubTests() override;
@@ -29,6 +30,7 @@ private:
   void LayerOperations();
   void PrefabOperations();
   void ComponentOperations();
+  void ObjectPropertyPath();
 
   static void CheckHierarchy(ezObjectAccessorBase* pAccessor, const ezDocumentObject* pRoot, ezDelegate<void(const ezDocumentObject* pChild)> functor);
 

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -416,14 +416,17 @@ const ezDocumentObject* ezEditorTest::DropAsset(ezScene2Document* pDoc, const ch
   return {};
 }
 
-const ezDocumentObject* ezEditorTest::CreateGameObject(ezScene2Document* pDoc)
+const ezDocumentObject* ezEditorTest::CreateGameObject(ezScene2Document* pDoc, const ezDocumentObject* pParent, ezStringView sName)
 {
   auto pAccessor = pDoc->GetObjectAccessor();
   pAccessor->StartTransaction("Add Game Object");
 
   ezUuid guid;
-  EZ_TEST_STATUS(pAccessor->AddObject(pDoc->GetObjectManager()->GetRootObject(), "Children", -1, ezRTTI::FindTypeByName("ezGameObject"), guid));
+  EZ_TEST_STATUS(pAccessor->AddObject(pParent != nullptr ? pParent : pDoc->GetObjectManager()->GetRootObject(), "Children", -1, ezRTTI::FindTypeByName("ezGameObject"), guid));
+  const ezDocumentObject* pObject = pAccessor->GetObject(guid);
+  EZ_TEST_STATUS(pAccessor->SetValue(pObject, "Name", sName));
+
   pAccessor->FinishTransaction();
 
-  return pAccessor->GetObject(guid);
+  return pObject;
 }

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.h
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.h
@@ -66,7 +66,7 @@ protected:
   std::unique_ptr<QMimeData> ObjectsDragMimeData(const ezDeque<const ezDocumentObject*>& objects);
   void MoveObjectsToLayer(ezScene2Document* pDoc, const ezDeque<const ezDocumentObject*>& objects, const ezUuid& layer, ezDeque<const ezDocumentObject*>& new_objects);
   const ezDocumentObject* DropAsset(ezScene2Document* pDoc, const char* szAssetGuidOrPath, bool bShift = false, bool bCtrl = false);
-  const ezDocumentObject* CreateGameObject(ezScene2Document* pDoc);
+  const ezDocumentObject* CreateGameObject(ezScene2Document* pDoc, const ezDocumentObject* pParent = nullptr, ezStringView sName = {});
 
 
   ezEditorTestApplication* m_pApplication = nullptr;


### PR DESCRIPTION
* Added missing locks to ezAssetCurator. Fixes #985
* Fix bugs in ezObjectPropertyPass and added unit tests. ResolvePath will now return failure if the path can't be resolved.
* natvis fixes.