### PR TITLE
Store full last transform in ezGameObject

### DIFF
--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -557,7 +557,7 @@ private:
     ezSimdTransform m_globalTransform;
 
 #if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
-    ezSimdTransform m_lastGlobalTransform; // m_Scale.w = invDeltaSeconds
+    ezSimdTransform m_lastGlobalTransform;
 #endif
 
     ezSimdBBoxSphere m_localBounds; // m_BoxHalfExtents.w != 0 indicates that the object should be always visible
@@ -598,7 +598,6 @@ private:
     void UpdateGlobalBoundsAndSpatialData(ezSpatialSystem& ref_spatialSystem);
 
     void UpdateLastGlobalTransform(ezUInt32 uiUpdateCounter);
-    void UpdateInvDeltaSeconds(const ezSimdFloat& fInvDeltaSeconds);
 
     void RecreateSpatialData(ezSpatialSystem& ref_spatialSystem);
   };

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -619,9 +619,22 @@ ezVec3 ezGameObject::GetGlobalDirUp() const
 }
 
 #if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
+void ezGameObject::SetLastGlobalTransform(const ezSimdTransform& transform)
+{
+  m_pTransformationData->m_lastGlobalTransform = transform;
+  m_pTransformationData->m_uiLastGlobalTransformUpdateCounter = GetWorld()->GetUpdateCounter();
+}
+
+ezVec3 ezGameObject::GetLinearVelocity() const
+{
+  const ezSimdFloat invDeltaSeconds = GetWorld()->GetInvDeltaSeconds();
+  const ezSimdVec4f linearVelocity = (m_pTransformationData->m_globalTransform.m_Position - m_pTransformationData->m_lastGlobalTransform.m_Position) * invDeltaSeconds;
+  return ezSimdConversion::ToVec3(linearVelocity);
+}
+
 ezVec3 ezGameObject::GetAngularVelocity() const
 {
-  const ezSimdFloat invDeltaSeconds = m_pTransformationData->m_lastGlobalTransform.m_Scale.w();
+  const ezSimdFloat invDeltaSeconds = GetWorld()->GetInvDeltaSeconds();
   const ezSimdQuat q = m_pTransformationData->m_globalTransform.m_Rotation * -m_pTransformationData->m_lastGlobalTransform.m_Rotation;
   ezSimdVec4f angularVelocity = ezSimdVec4f::ZeroVector();
 

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -618,6 +618,23 @@ ezVec3 ezGameObject::GetGlobalDirUp() const
   return GetGlobalRotation() * coordinateSystem.m_vUpDir;
 }
 
+#if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
+ezVec3 ezGameObject::GetAngularVelocity() const
+{
+  const ezSimdFloat invDeltaSeconds = m_pTransformationData->m_lastGlobalTransform.m_Scale.w();
+  const ezSimdQuat q = m_pTransformationData->m_globalTransform.m_Rotation * -m_pTransformationData->m_lastGlobalTransform.m_Rotation;
+  ezSimdVec4f angularVelocity = ezSimdVec4f::ZeroVector();
+
+  ezSimdVec4f axis;
+  ezSimdFloat angle;
+  if (q.GetRotationAxisAndAngle(axis, angle).Succeeded())
+  {
+    angularVelocity = axis * (angle * invDeltaSeconds);
+  }
+  return ezSimdConversion::ToVec3(angularVelocity);
+}
+#endif
+
 void ezGameObject::UpdateGlobalTransform()
 {
   m_pTransformationData->UpdateGlobalTransformRecursive(GetWorld()->GetUpdateCounter());

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -208,7 +208,7 @@ void ezGameObject::UpdateGlobalTransformAndBoundsRecursive()
 
   ezSimdTransform oldGlobalTransform = GetGlobalTransformSimd();
 
-  m_pTransformationData->UpdateGlobalTransformNonRecursive();
+  m_pTransformationData->UpdateGlobalTransformNonRecursive(GetWorld()->GetUpdateCounter());
 
   if (ezSpatialSystem* pSpatialSystem = GetWorld()->GetSpatialSystem())
   {
@@ -232,6 +232,11 @@ void ezGameObject::UpdateGlobalTransformAndBoundsRecursive()
   {
     it->UpdateGlobalTransformAndBoundsRecursive();
   }
+}
+
+void ezGameObject::UpdateLastGlobalTransform()
+{
+  m_pTransformationData->UpdateLastGlobalTransform(GetWorld()->GetUpdateCounter());
 }
 
 void ezGameObject::ConstChildIterator::Next()
@@ -613,6 +618,11 @@ ezVec3 ezGameObject::GetGlobalDirUp() const
   return GetGlobalRotation() * coordinateSystem.m_vUpDir;
 }
 
+void ezGameObject::UpdateGlobalTransform()
+{
+  m_pTransformationData->UpdateGlobalTransformRecursive(GetWorld()->GetUpdateCounter());
+}
+
 void ezGameObject::UpdateLocalBounds()
 {
   ezMsgUpdateLocalBounds msg;
@@ -653,7 +663,7 @@ void ezGameObject::UpdateLocalBounds()
 
 void ezGameObject::UpdateGlobalTransformAndBounds()
 {
-  m_pTransformationData->UpdateGlobalTransformRecursive();
+  m_pTransformationData->UpdateGlobalTransformRecursive(GetWorld()->GetUpdateCounter());
   m_pTransformationData->UpdateGlobalBounds(GetWorld()->GetSpatialSystem());
 }
 
@@ -1054,28 +1064,28 @@ void ezGameObject::TransformationData::UpdateLocalTransform()
   m_localScaling.SetW(1.0f);
 }
 
-void ezGameObject::TransformationData::UpdateGlobalTransformNonRecursive()
+void ezGameObject::TransformationData::UpdateGlobalTransformNonRecursive(ezUInt32 uiUpdateCounter)
 {
   if (m_pParentData != nullptr)
   {
-    UpdateGlobalTransformWithParent();
+    UpdateGlobalTransformWithParent(uiUpdateCounter);
   }
   else
   {
-    UpdateGlobalTransformWithoutParent();
+    UpdateGlobalTransformWithoutParent(uiUpdateCounter);
   }
 }
 
-void ezGameObject::TransformationData::UpdateGlobalTransformRecursive()
+void ezGameObject::TransformationData::UpdateGlobalTransformRecursive(ezUInt32 uiUpdateCounter)
 {
   if (m_pParentData != nullptr)
   {
-    m_pParentData->UpdateGlobalTransformRecursive();
-    UpdateGlobalTransformWithParent();
+    m_pParentData->UpdateGlobalTransformRecursive(uiUpdateCounter);
+    UpdateGlobalTransformWithParent(uiUpdateCounter);
   }
   else
   {
-    UpdateGlobalTransformWithoutParent();
+    UpdateGlobalTransformWithoutParent(uiUpdateCounter);
   }
 }
 

--- a/Code/Engine/Core/World/Implementation/GameObject_inl.h
+++ b/Code/Engine/Core/World/Implementation/GameObject_inl.h
@@ -432,22 +432,6 @@ EZ_ALWAYS_INLINE const ezSimdTransform& ezGameObject::GetLastGlobalTransformSimd
 #endif
 }
 
-#if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
-EZ_ALWAYS_INLINE void ezGameObject::SetLastGlobalTransform(const ezSimdTransform& transform)
-{
-  ezSimdFloat invDeltaSeconds = m_pTransformationData->m_lastGlobalTransform.m_Scale.w();
-  m_pTransformationData->m_lastGlobalTransform = transform;
-  m_pTransformationData->m_lastGlobalTransform.m_Scale.SetW(invDeltaSeconds);
-}
-
-EZ_ALWAYS_INLINE ezVec3 ezGameObject::GetLinearVelocity() const
-{
-  const ezSimdFloat invDeltaSeconds = m_pTransformationData->m_lastGlobalTransform.m_Scale.w();
-  const ezSimdVec4f linearVelocity = (m_pTransformationData->m_globalTransform.m_Position - m_pTransformationData->m_lastGlobalTransform.m_Position) * invDeltaSeconds;
-  return ezSimdConversion::ToVec3(linearVelocity);
-}
-#endif
-
 EZ_ALWAYS_INLINE void ezGameObject::EnableStaticTransformChangesNotifications()
 {
   m_Flags.Add(ezObjectFlags::StaticTransformChangesNotifications);
@@ -616,18 +600,8 @@ EZ_ALWAYS_INLINE void ezGameObject::TransformationData::UpdateLastGlobalTransfor
 #if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
   if (m_uiLastGlobalTransformUpdateCounter != uiUpdateCounter)
   {
-    ezSimdFloat invDeltaSeconds = m_lastGlobalTransform.m_Scale.w();
     m_lastGlobalTransform = m_globalTransform;
-    m_lastGlobalTransform.m_Scale.SetW(invDeltaSeconds);
-
     m_uiLastGlobalTransformUpdateCounter = uiUpdateCounter;
   }
-#endif
-}
-
-EZ_ALWAYS_INLINE void ezGameObject::TransformationData::UpdateInvDeltaSeconds(const ezSimdFloat& fInvDeltaSeconds)
-{
-#if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
-  m_lastGlobalTransform.m_Scale.SetW(fInvDeltaSeconds);
 #endif
 }

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -519,15 +519,8 @@ void ezWorld::Update()
 
   // update transforms
   {
-    float fInvDelta = 0.0f;
-
-    // when the clock is paused just use zero
-    const float fDelta = (float)m_Data.m_Clock.GetTimeDiff().GetSeconds();
-    if (fDelta > 0.0f)
-      fInvDelta = 1.0f / fDelta;
-
     EZ_PROFILE_SCOPE("Update Transforms");
-    m_Data.UpdateGlobalTransforms(fInvDelta);
+    m_Data.UpdateGlobalTransforms();
   }
 
   // post-transform phase

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -66,7 +66,7 @@ namespace ezInternal
     m_Objects.Insert(nullptr);
 
 #if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
-    EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject::TransformationData) == 224);
+    EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject::TransformationData) == 240);
 #else
     EZ_CHECK_AT_COMPILETIME(sizeof(ezGameObject::TransformationData) == 192);
 #endif
@@ -306,44 +306,50 @@ namespace ezInternal
     {
       ezSimdFloat m_fInvDt;
       ezSpatialSystem* m_pSpatialSystem;
+      ezUInt32 m_uiUpdateCounter;
     };
 
     UserData userData;
     userData.m_fInvDt = fInvDeltaSeconds;
     userData.m_pSpatialSystem = m_pSpatialSystem.Borrow();
+    userData.m_uiUpdateCounter = m_uiUpdateCounter;
 
     struct RootLevel
     {
-      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData)
+      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
-        WorldData::UpdateGlobalTransform(pData, static_cast<UserData*>(pUserData)->m_fInvDt);
+        auto pUserData = static_cast<const UserData*>(pUserData0);
+        WorldData::UpdateGlobalTransform(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt);
         return ezVisitorExecution::Continue;
       }
     };
 
     struct WithParent
     {
-      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData)
+      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
-        WorldData::UpdateGlobalTransformWithParent(pData, static_cast<UserData*>(pUserData)->m_fInvDt);
+        auto pUserData = static_cast<const UserData*>(pUserData0);
+        WorldData::UpdateGlobalTransformWithParent(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt);
         return ezVisitorExecution::Continue;
       }
     };
 
     struct RootLevelWithSpatialData
     {
-      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData)
+      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
-        WorldData::UpdateGlobalTransformAndSpatialData(pData, static_cast<UserData*>(pUserData)->m_fInvDt, *static_cast<UserData*>(pUserData)->m_pSpatialSystem);
+        auto pUserData = static_cast<UserData*>(pUserData0);
+        WorldData::UpdateGlobalTransformAndSpatialData(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt, *pUserData->m_pSpatialSystem);
         return ezVisitorExecution::Continue;
       }
     };
 
     struct WithParentWithSpatialData
     {
-      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData)
+      EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
-        WorldData::UpdateGlobalTransformWithParentAndSpatialData(pData, static_cast<UserData*>(pUserData)->m_fInvDt, *static_cast<UserData*>(pUserData)->m_pSpatialSystem);
+        auto pUserData = static_cast<UserData*>(pUserData0);
+        WorldData::UpdateGlobalTransformWithParentAndSpatialData(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt, *pUserData->m_pSpatialSystem);
         return ezVisitorExecution::Continue;
       }
     };

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -300,17 +300,15 @@ namespace ezInternal
     return ezVisitorExecution::Continue;
   }
 
-  void WorldData::UpdateGlobalTransforms(float fInvDeltaSeconds)
+  void WorldData::UpdateGlobalTransforms()
   {
     struct UserData
     {
-      ezSimdFloat m_fInvDt;
       ezSpatialSystem* m_pSpatialSystem;
       ezUInt32 m_uiUpdateCounter;
     };
 
     UserData userData;
-    userData.m_fInvDt = fInvDeltaSeconds;
     userData.m_pSpatialSystem = m_pSpatialSystem.Borrow();
     userData.m_uiUpdateCounter = m_uiUpdateCounter;
 
@@ -319,7 +317,7 @@ namespace ezInternal
       EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
         auto pUserData = static_cast<const UserData*>(pUserData0);
-        WorldData::UpdateGlobalTransform(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt);
+        WorldData::UpdateGlobalTransform(pData, pUserData->m_uiUpdateCounter);
         return ezVisitorExecution::Continue;
       }
     };
@@ -329,7 +327,7 @@ namespace ezInternal
       EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
         auto pUserData = static_cast<const UserData*>(pUserData0);
-        WorldData::UpdateGlobalTransformWithParent(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt);
+        WorldData::UpdateGlobalTransformWithParent(pData, pUserData->m_uiUpdateCounter);
         return ezVisitorExecution::Continue;
       }
     };
@@ -339,7 +337,7 @@ namespace ezInternal
       EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
         auto pUserData = static_cast<UserData*>(pUserData0);
-        WorldData::UpdateGlobalTransformAndSpatialData(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt, *pUserData->m_pSpatialSystem);
+        WorldData::UpdateGlobalTransformAndSpatialData(pData, pUserData->m_uiUpdateCounter, *pUserData->m_pSpatialSystem);
         return ezVisitorExecution::Continue;
       }
     };
@@ -349,7 +347,7 @@ namespace ezInternal
       EZ_ALWAYS_INLINE static ezVisitorExecution::Enum Visit(ezGameObject::TransformationData* pData, void* pUserData0)
       {
         auto pUserData = static_cast<UserData*>(pUserData0);
-        WorldData::UpdateGlobalTransformWithParentAndSpatialData(pData, pUserData->m_uiUpdateCounter, pUserData->m_fInvDt, *pUserData->m_pSpatialSystem);
+        WorldData::UpdateGlobalTransformWithParentAndSpatialData(pData, pUserData->m_uiUpdateCounter, *pUserData->m_pSpatialSystem);
         return ezVisitorExecution::Continue;
       }
     };

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -133,11 +133,11 @@ namespace ezInternal
     void TraverseDepthFirst(VisitorFunc& func);
     static ezVisitorExecution::Enum TraverseObjectDepthFirst(ezGameObject* pObject, VisitorFunc& func);
 
-    static void UpdateGlobalTransform(ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds);
-    static void UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds);
+    static void UpdateGlobalTransform(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds);
+    static void UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds);
 
-    static void UpdateGlobalTransformAndSpatialData(ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem);
-    static void UpdateGlobalTransformWithParentAndSpatialData(ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem);
+    static void UpdateGlobalTransformAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem);
+    static void UpdateGlobalTransformWithParentAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem);
 
     void UpdateGlobalTransforms(float fInvDeltaSeconds);
 
@@ -237,6 +237,7 @@ namespace ezInternal
     ezInt32 m_iWriteCounter = 0;
     mutable ezAtomicInteger32 m_iReadCounter;
 
+    ezUInt32 m_uiUpdateCounter = 0;
     bool m_bSimulateWorld = true;
     bool m_bReportErrorWhenStaticObjectMoves = true;
 

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -133,13 +133,13 @@ namespace ezInternal
     void TraverseDepthFirst(VisitorFunc& func);
     static ezVisitorExecution::Enum TraverseObjectDepthFirst(ezGameObject* pObject, VisitorFunc& func);
 
-    static void UpdateGlobalTransform(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds);
-    static void UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds);
+    static void UpdateGlobalTransform(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter);
+    static void UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter);
 
-    static void UpdateGlobalTransformAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem);
-    static void UpdateGlobalTransformWithParentAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem);
+    static void UpdateGlobalTransformAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, ezSpatialSystem& spatialSystem);
+    static void UpdateGlobalTransformWithParentAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, ezSpatialSystem& spatialSystem);
 
-    void UpdateGlobalTransforms(float fInvDeltaSeconds);
+    void UpdateGlobalTransforms();
 
     // game object lookups
     ezHashTable<ezUInt64, ezGameObjectId, ezHashHelper<ezUInt64>, ezLocalAllocatorWrapper> m_GlobalKeyToIdTable;

--- a/Code/Engine/Core/World/Implementation/WorldData_inl.h
+++ b/Code/Engine/Core/World/Implementation/WorldData_inl.h
@@ -60,36 +60,36 @@ namespace ezInternal
   }
 
   // static
-  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransform(ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds)
+  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransform(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds)
   {
-    pData->UpdateGlobalTransformWithoutParent();
-    pData->UpdateVelocity(fInvDeltaSeconds);
+    pData->UpdateGlobalTransformWithoutParent(uiUpdateCounter);
+    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBounds();
   }
 
   // static
-  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds)
-  {
-    pData->UpdateGlobalTransformWithParent();
-    pData->UpdateVelocity(fInvDeltaSeconds);
+  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds)
+  {    
+    pData->UpdateGlobalTransformWithParent(uiUpdateCounter);
+    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBounds();
   }
 
   // static
   EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformAndSpatialData(
-    ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem)
+    ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem)
   {
-    pData->UpdateGlobalTransformWithoutParent();
-    pData->UpdateVelocity(fInvDeltaSeconds);
+    pData->UpdateGlobalTransformWithoutParent(uiUpdateCounter);
+    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBoundsAndSpatialData(spatialSystem);
   }
 
   // static
   EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParentAndSpatialData(
-    ezGameObject::TransformationData* pData, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem)
+    ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem)
   {
-    pData->UpdateGlobalTransformWithParent();
-    pData->UpdateVelocity(fInvDeltaSeconds);
+    pData->UpdateGlobalTransformWithParent(uiUpdateCounter);
+    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBoundsAndSpatialData(spatialSystem);
   }
 

--- a/Code/Engine/Core/World/Implementation/WorldData_inl.h
+++ b/Code/Engine/Core/World/Implementation/WorldData_inl.h
@@ -41,8 +41,7 @@ namespace ezInternal
 
     ezTaskSystem::ParallelFor(
       blocks.GetArrayPtr(),
-      [pUserData](ezArrayPtr<WorldData::Hierarchy::DataBlock> blocksSlice)
-      {
+      [pUserData](ezArrayPtr<WorldData::Hierarchy::DataBlock> blocksSlice) {
         for (WorldData::Hierarchy::DataBlock& block : blocksSlice)
         {
           ezGameObject::TransformationData* pCurrentData = block.m_pData;

--- a/Code/Engine/Core/World/Implementation/WorldData_inl.h
+++ b/Code/Engine/Core/World/Implementation/WorldData_inl.h
@@ -41,7 +41,8 @@ namespace ezInternal
 
     ezTaskSystem::ParallelFor(
       blocks.GetArrayPtr(),
-      [pUserData](ezArrayPtr<WorldData::Hierarchy::DataBlock> blocksSlice) {
+      [pUserData](ezArrayPtr<WorldData::Hierarchy::DataBlock> blocksSlice)
+      {
         for (WorldData::Hierarchy::DataBlock& block : blocksSlice)
         {
           ezGameObject::TransformationData* pCurrentData = block.m_pData;
@@ -60,46 +61,49 @@ namespace ezInternal
   }
 
   // static
-  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransform(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds)
+  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransform(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter)
   {
     pData->UpdateGlobalTransformWithoutParent(uiUpdateCounter);
-    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBounds();
   }
 
   // static
-  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds)
-  {    
+  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParent(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter)
+  {
     pData->UpdateGlobalTransformWithParent(uiUpdateCounter);
-    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBounds();
   }
 
   // static
-  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformAndSpatialData(
-    ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem)
+  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, ezSpatialSystem& spatialSystem)
   {
     pData->UpdateGlobalTransformWithoutParent(uiUpdateCounter);
-    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBoundsAndSpatialData(spatialSystem);
   }
 
   // static
-  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParentAndSpatialData(
-    ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, const ezSimdFloat& fInvDeltaSeconds, ezSpatialSystem& spatialSystem)
+  EZ_FORCE_INLINE void WorldData::UpdateGlobalTransformWithParentAndSpatialData(ezGameObject::TransformationData* pData, ezUInt32 uiUpdateCounter, ezSpatialSystem& spatialSystem)
   {
     pData->UpdateGlobalTransformWithParent(uiUpdateCounter);
-    pData->UpdateInvDeltaSeconds(fInvDeltaSeconds);
     pData->UpdateGlobalBoundsAndSpatialData(spatialSystem);
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-  EZ_ALWAYS_INLINE const ezGameObject& WorldData::ConstObjectIterator::operator*() const { return *m_Iterator; }
+  EZ_ALWAYS_INLINE const ezGameObject& WorldData::ConstObjectIterator::operator*() const
+  {
+    return *m_Iterator;
+  }
 
-  EZ_ALWAYS_INLINE const ezGameObject* WorldData::ConstObjectIterator::operator->() const { return m_Iterator; }
+  EZ_ALWAYS_INLINE const ezGameObject* WorldData::ConstObjectIterator::operator->() const
+  {
+    return m_Iterator;
+  }
 
-  EZ_ALWAYS_INLINE WorldData::ConstObjectIterator::operator const ezGameObject*() const { return m_Iterator; }
+  EZ_ALWAYS_INLINE WorldData::ConstObjectIterator::operator const ezGameObject*() const
+  {
+    return m_Iterator;
+  }
 
   EZ_ALWAYS_INLINE void WorldData::ConstObjectIterator::Next()
   {
@@ -111,9 +115,15 @@ namespace ezInternal
     }
   }
 
-  EZ_ALWAYS_INLINE bool WorldData::ConstObjectIterator::IsValid() const { return m_Iterator.IsValid(); }
+  EZ_ALWAYS_INLINE bool WorldData::ConstObjectIterator::IsValid() const
+  {
+    return m_Iterator.IsValid();
+  }
 
-  EZ_ALWAYS_INLINE void WorldData::ConstObjectIterator::operator++() { Next(); }
+  EZ_ALWAYS_INLINE void WorldData::ConstObjectIterator::operator++()
+  {
+    Next();
+  }
 
   EZ_ALWAYS_INLINE WorldData::ConstObjectIterator::ConstObjectIterator(ObjectStorage::ConstIterator iterator)
     : m_Iterator(iterator)
@@ -126,11 +136,20 @@ namespace ezInternal
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-  EZ_ALWAYS_INLINE ezGameObject& WorldData::ObjectIterator::operator*() { return *m_Iterator; }
+  EZ_ALWAYS_INLINE ezGameObject& WorldData::ObjectIterator::operator*()
+  {
+    return *m_Iterator;
+  }
 
-  EZ_ALWAYS_INLINE ezGameObject* WorldData::ObjectIterator::operator->() { return m_Iterator; }
+  EZ_ALWAYS_INLINE ezGameObject* WorldData::ObjectIterator::operator->()
+  {
+    return m_Iterator;
+  }
 
-  EZ_ALWAYS_INLINE WorldData::ObjectIterator::operator ezGameObject*() { return m_Iterator; }
+  EZ_ALWAYS_INLINE WorldData::ObjectIterator::operator ezGameObject*()
+  {
+    return m_Iterator;
+  }
 
   EZ_ALWAYS_INLINE void WorldData::ObjectIterator::Next()
   {
@@ -142,9 +161,15 @@ namespace ezInternal
     }
   }
 
-  EZ_ALWAYS_INLINE bool WorldData::ObjectIterator::IsValid() const { return m_Iterator.IsValid(); }
+  EZ_ALWAYS_INLINE bool WorldData::ObjectIterator::IsValid() const
+  {
+    return m_Iterator.IsValid();
+  }
 
-  EZ_ALWAYS_INLINE void WorldData::ObjectIterator::operator++() { Next(); }
+  EZ_ALWAYS_INLINE void WorldData::ObjectIterator::operator++()
+  {
+    Next();
+  }
 
   EZ_ALWAYS_INLINE WorldData::ObjectIterator::ObjectIterator(ObjectStorage::Iterator iterator)
     : m_Iterator(iterator)
@@ -202,7 +227,10 @@ namespace ezInternal
     m_Data.m_iReadCounter.Increment();
   }
 
-  EZ_ALWAYS_INLINE void WorldData::ReadMarker::Unlock() { m_Data.m_iReadCounter.Decrement(); }
+  EZ_ALWAYS_INLINE void WorldData::ReadMarker::Unlock()
+  {
+    m_Data.m_iReadCounter.Decrement();
+  }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -555,3 +555,15 @@ EZ_ALWAYS_INLINE bool ezWorld::ReportErrorWhenStaticObjectMoves() const
 {
   return m_Data.m_bReportErrorWhenStaticObjectMoves;
 }
+
+EZ_ALWAYS_INLINE float ezWorld::GetInvDeltaSeconds() const
+{
+  const float fDelta = (float)m_Data.m_Clock.GetTimeDiff().GetSeconds();
+  if (fDelta > 0.0f)
+  {
+    return 1.0f / fDelta;
+  }
+
+  // when the clock is paused just use zero
+  return 0.0f;
+}

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -393,6 +393,11 @@ EZ_ALWAYS_INLINE const ezSharedPtr<ezTask>& ezWorld::GetUpdateTask()
   return m_pUpdateTask;
 }
 
+EZ_ALWAYS_INLINE ezUInt32 ezWorld::GetUpdateCounter() const
+{
+  return m_Data.m_uiUpdateCounter;
+}
+
 EZ_FORCE_INLINE ezSpatialSystem* ezWorld::GetSpatialSystem()
 {
   CheckForWriteAccess();

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -400,6 +400,8 @@ private:
 
   bool ReportErrorWhenStaticObjectMoves() const;
 
+  float GetInvDeltaSeconds() const;
+
   ezSharedPtr<ezTask> m_pUpdateTask;
 
   ezInternal::WorldData m_Data;

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -255,6 +255,8 @@ public:
   /// \brief Returns a task implementation that calls Update on this world.
   const ezSharedPtr<ezTask>& GetUpdateTask();
 
+  /// \brief Returns the number of update calls. Can be used to determine whether an operation has already been done during a frame.
+  ezUInt32 GetUpdateCounter() const;
 
   /// \brief Returns the spatial system that is associated with this world.
   ezSpatialSystem* GetSpatialSystem();

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -144,6 +144,8 @@ void ezFmodEventComponentManager::RemoveOcclusionState(ezUInt32 uiIndex)
 
 void ezFmodEventComponentManager::ShootOcclusionRays(OcclusionState& state, ezVec3 listenerPos, ezUInt32 uiNumRays, const ezPhysicsWorldModuleInterface* pPhysicsWorldModule, ezTime deltaTime)
 {
+  uiNumRays = ezMath::Min(uiNumRays, 32u);
+
   ezVec3 centerPos = state.m_pComponent->GetOwner()->GetGlobalPosition();
   ezUInt8 uiCollisionLayer = state.m_pComponent->m_uiOcclusionCollisionLayer;
   ezPhysicsCastResult hitResult;
@@ -186,7 +188,7 @@ void ezFmodEventComponentManager::UpdateOcclusion(const ezWorldModule::UpdateCon
     ezVec3 listenerPos = ezFmod::GetSingleton()->GetListenerPosition();
     ezTime deltaTime = GetWorld()->GetClock().GetTimeDiff();
 
-    ezUInt32 uiNumRays = ezMath::Max<int>(cvar_FmodOcclusionNumRays, 1);
+    ezUInt32 uiNumRays = ezMath::Clamp<int>(cvar_FmodOcclusionNumRays, 1, 32);
 
     for (auto& occlusionState : m_OcclusionStates)
     {
@@ -764,9 +766,9 @@ void ezFmodEventComponent::Update()
 void ezFmodEventComponent::UpdateParameters(FMOD::Studio::EventInstance* pInstance)
 {
   const auto pos = GetOwner()->GetGlobalPosition();
-  const auto vel = GetOwner()->GetVelocity();
-  const auto fwd = GetOwner()->GetGlobalRotation() * ezVec3(1, 0, 0);
-  const auto up = GetOwner()->GetGlobalRotation() * ezVec3(0, 0, 1);
+  const auto vel = GetOwner()->GetLinearVelocity();
+  const auto fwd = GetOwner()->GetGlobalRotation() * ezVec3::UnitXAxis();
+  const auto up = GetOwner()->GetGlobalRotation() * ezVec3::UnitZAxis();
 
   FMOD_3D_ATTRIBUTES attr;
   attr.position.x = pos.x;

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodListenerComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodListenerComponent.cpp
@@ -6,6 +6,38 @@
 #include <FmodPlugin/FmodIncludes.h>
 #include <FmodPlugin/FmodSingleton.h>
 
+ezFmodListenerComponentManager::ezFmodListenerComponentManager(ezWorld* pWorld)
+  : ezComponentManager(pWorld)
+{
+}
+
+void ezFmodListenerComponentManager::Initialize()
+{
+  SUPER::Initialize();
+
+  {
+    auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezFmodListenerComponentManager::UpdateListeners, this);
+    desc.m_Phase = ezWorldModule::UpdateFunctionDesc::Phase::PostTransform;
+    desc.m_bOnlyUpdateWhenSimulating = true;
+
+    this->RegisterUpdateFunction(desc);
+  }
+}
+
+void ezFmodListenerComponentManager::UpdateListeners(const ezWorldModule::UpdateContext& context)
+{
+  for (auto it = this->m_ComponentStorage.GetIterator(context.m_uiFirstComponentIndex, context.m_uiComponentCount); it.IsValid(); ++it)
+  {
+    ComponentType* pComponent = it;
+    if (pComponent->IsActiveAndInitialized())
+    {
+      pComponent->Update();
+    }
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////
+
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ezFmodListenerComponent, 1, ezComponentMode::Static)
 {
@@ -43,9 +75,9 @@ void ezFmodListenerComponent::DeserializeComponent(ezWorldReader& inout_stream)
 void ezFmodListenerComponent::Update()
 {
   const auto pos = GetOwner()->GetGlobalPosition();
-  const auto vel = GetOwner()->GetVelocity();
-  const auto fwd = (GetOwner()->GetGlobalRotation() * ezVec3(1, 0, 0)).GetNormalized();
-  const auto up = (GetOwner()->GetGlobalRotation() * ezVec3(0, 0, 1)).GetNormalized();
+  const auto vel = GetOwner()->GetLinearVelocity();
+  const auto fwd = (GetOwner()->GetGlobalRotation() * ezVec3::UnitXAxis()).GetNormalized();
+  const auto up = (GetOwner()->GetGlobalRotation() * ezVec3::UnitZAxis()).GetNormalized();
 
   ezFmod::GetSingleton()->SetListener(m_uiListenerIndex, pos, fwd, up, vel);
 }

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodListenerComponent.h
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodListenerComponent.h
@@ -2,7 +2,18 @@
 
 #include <FmodPlugin/Components/FmodComponent.h>
 
-using ezFmodListenerComponentManager = ezComponentManagerSimple<class ezFmodListenerComponent, ezComponentUpdateType::WhenSimulating>;
+class ezFmodListenerComponentManager : public ezComponentManager<class ezFmodListenerComponent, ezBlockStorageType::Compact>
+{
+public:
+  ezFmodListenerComponentManager(ezWorld* pWorld);
+
+  virtual void Initialize() override;
+
+private:
+  void UpdateListeners(const ezWorldModule::UpdateContext& context);
+};
+
+//////////////////////////////////////////////////////////////////////////
 
 /// \brief Represents the position of the sound listener
 class EZ_FMODPLUGIN_DLL ezFmodListenerComponent : public ezFmodComponent

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -379,7 +379,7 @@ void ezClothSheetComponent::Update()
   --m_uiVisibleCounter;
 
   {
-    ezVec3 acc = -GetOwner()->GetVelocity();
+    ezVec3 acc = -GetOwner()->GetLinearVelocity();
 
     if (const ezPhysicsWorldModuleInterface* pModule = GetWorld()->GetModuleReadOnly<ezPhysicsWorldModuleInterface>())
     {

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
@@ -685,7 +685,7 @@ void ezJoltRagdollComponent::ConfigureRagdollPart(void* pRagdollSettingsPart, co
 
 void ezJoltRagdollComponent::ApplyPartInitialVelocity()
 {
-  JPH::Vec3 vCommonVelocity = ezJoltConversionUtils::ToVec3(GetOwner()->GetVelocity() * m_fOwnerVelocityScale);
+  JPH::Vec3 vCommonVelocity = ezJoltConversionUtils::ToVec3(GetOwner()->GetLinearVelocity() * m_fOwnerVelocityScale);
   const JPH::Vec3 vCenterPos = ezJoltConversionUtils::ToVec3(GetOwner()->GetGlobalTransform() * m_vCenterPosition);
 
   ezCoordinateSystem coord;

--- a/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
@@ -548,7 +548,7 @@ ezTransform ezParticleComponent::GetPfxTransform() const
 
 void ezParticleComponent::UpdatePfxTransform()
 {
-  m_EffectController.SetTransform(GetPfxTransform(), GetOwner()->GetVelocity());
+  m_EffectController.SetTransform(GetPfxTransform(), GetOwner()->GetLinearVelocity());
 }
 
 EZ_STATICLINK_FILE(ParticlePlugin, ParticlePlugin_Components_ParticleComponent);

--- a/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxRagdollComponent.cpp
+++ b/Code/EnginePlugins/PhysXPlugin/Components/Implementation/PxRagdollComponent.cpp
@@ -597,7 +597,7 @@ void ezPxRagdollComponent::SetupLimbBodiesAndGeometry(const ezSkeletonResource* 
 
   const auto& skeleton = pSkeleton->GetDescriptor().m_Skeleton;
   const auto srcBoneDir = pSkeleton->GetDescriptor().m_Skeleton.m_BoneDirection;
-  physx::PxVec3 vPxVelocity = ezPxConversionUtils::ToVec3(GetOwner()->GetVelocity());
+  physx::PxVec3 vPxVelocity = ezPxConversionUtils::ToVec3(GetOwner()->GetLinearVelocity());
 
   for (const auto& geo : pSkeleton->GetDescriptor().m_Geometry)
   {

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsGameObject.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsGameObject.cpp
@@ -91,7 +91,6 @@ ezResult ezTypeScriptBinding::Init_GameObject()
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetGlobalDirForwards", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::GlobalDirForwards);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetGlobalDirRight", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::GlobalDirRight);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetGlobalDirUp", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::GlobalDirUp);
-  m_Duk.RegisterGlobalFunction("__CPP_GameObject_SetVelocity", __CPP_GameObject_SetX_Vec3, 2, GameObject_X::Velocity);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetVelocity", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::Velocity);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_SetName", __CPP_GameObject_SetString, 2, 0);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetName", __CPP_GameObject_GetString, 1, 0);
@@ -254,10 +253,6 @@ static int __CPP_GameObject_SetX_Vec3(duk_context* pDuk)
       pGameObject->SetGlobalScaling(value);
       break;
 
-    case GameObject_X::Velocity:
-      pGameObject->SetVelocity(value);
-      break;
-
     default:
       EZ_ASSERT_NOT_IMPLEMENTED;
   }
@@ -304,7 +299,7 @@ static int __CPP_GameObject_GetX_Vec3(duk_context* pDuk)
       break;
 
     case GameObject_X::Velocity:
-      value = pGameObject->GetVelocity();
+      value = pGameObject->GetLinearVelocity();
       break;
 
     default:

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsGameObject.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsGameObject.cpp
@@ -48,7 +48,7 @@ namespace GameObject_X
     GlobalDirForwards,
     GlobalDirRight,
     GlobalDirUp,
-    Velocity,
+    LinearVelocity,
     ActiveFlag,
     Active,
     ChildCount,
@@ -91,7 +91,7 @@ ezResult ezTypeScriptBinding::Init_GameObject()
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetGlobalDirForwards", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::GlobalDirForwards);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetGlobalDirRight", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::GlobalDirRight);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetGlobalDirUp", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::GlobalDirUp);
-  m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetVelocity", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::Velocity);
+  m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetLinearVelocity", __CPP_GameObject_GetX_Vec3, 1, GameObject_X::LinearVelocity);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_SetName", __CPP_GameObject_SetString, 2, 0);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_GetName", __CPP_GameObject_GetString, 1, 0);
   m_Duk.RegisterGlobalFunction("__CPP_GameObject_SetGlobalKey", __CPP_GameObject_SetString, 2, 1);
@@ -298,7 +298,7 @@ static int __CPP_GameObject_GetX_Vec3(duk_context* pDuk)
       value = pGameObject->GetGlobalDirUp();
       break;
 
-    case GameObject_X::Velocity:
+    case GameObject_X::LinearVelocity:
       value = pGameObject->GetLinearVelocity();
       break;
 

--- a/Code/UnitTests/CoreTest/World/WorldTest.cpp
+++ b/Code/UnitTests/CoreTest/World/WorldTest.cpp
@@ -129,6 +129,78 @@ namespace
       out_coordinateSystem.m_vForwardDir = mTmp.GetRow(2);
     }
   };
+
+  class VelocityTestModule : public ezWorldModule
+  {
+    EZ_ADD_DYNAMIC_REFLECTION(VelocityTestModule, ezWorldModule);
+    EZ_DECLARE_WORLD_MODULE();
+
+  public:
+    VelocityTestModule(ezWorld* pWorld)
+      : ezWorldModule(pWorld)
+    {
+    }
+
+    virtual void Initialize() override
+    {
+      {
+        auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(VelocityTestModule::SetLocalPos, this);
+        RegisterUpdateFunction(desc);
+      }
+
+      {
+        auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(VelocityTestModule::ResetGlobalPos, this);
+        RegisterUpdateFunction(desc);
+      }
+    }
+
+    void SetLocalPos(const UpdateContext&)
+    {
+      if (m_bSetLocalPos == false)
+        return;
+
+      for (auto it = GetWorld()->GetObjects(); it.IsValid(); ++it)
+      {
+        ezUInt32 i = it->GetHandle().GetInternalID().m_InstanceIndex;
+
+        ezVec3 newPos = ezVec3(i * 10, 0, 0);
+        it->SetLocalPosition(newPos);
+
+        ezQuat newRot;
+        newRot.SetFromAxisAndAngle(ezVec3::UnitZAxis(), ezAngle::Degree(i * 30));
+        it->SetLocalRotation(newRot);
+
+        if (i > 5)
+        {
+          it->UpdateGlobalTransform();
+        }
+        if (i > 8)
+        {
+          it->UpdateGlobalTransformAndBounds();
+        }
+      }
+    }
+
+    void ResetGlobalPos(const UpdateContext&)
+    {
+      if (m_bResetGlobalPos == false)
+        return;
+
+      for (auto it = GetWorld()->GetObjects(); it.IsValid(); ++it)
+      {
+        it->SetGlobalPosition(ezVec3::ZeroVector());
+      }
+    }
+
+    bool m_bSetLocalPos = false;
+    bool m_bResetGlobalPos = false;
+  };
+
+  // clang-format off
+  EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(VelocityTestModule, 1, ezRTTINoAllocator)
+  EZ_END_DYNAMIC_REFLECTED_TYPE;
+  EZ_IMPLEMENT_WORLD_MODULE(VelocityTestModule);
+  // clang-format on
 } // namespace
 
 class ezGameObjectTest
@@ -641,4 +713,58 @@ EZ_CREATE_SIMPLE_TEST(World, World)
       EZ_TEST_BOOL(pObjects[i]->IsActive() == (i < iTopDisabled));
     }
   }
+
+#if EZ_ENABLED(EZ_GAMEOBJECT_VELOCITY)
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Velocity")
+  {
+    constexpr ezUInt32 numObjects = 10;
+
+    ezWorldDesc worldDesc("Test");
+    ezWorld world(worldDesc);
+    EZ_LOCK(world.GetWriteMarker());
+
+    auto pModule = world.GetOrCreateModule<VelocityTestModule>();
+
+    ezGameObjectDesc objectDesc;
+    objectDesc.m_bDynamic = true;
+
+    ezGameObjectHandle hObjects[numObjects];
+    ezGameObject* pObjects[numObjects];
+    for (ezUInt32 i = 0; i < numObjects; ++i)
+    {
+      hObjects[i] = world.CreateObject(objectDesc, pObjects[i]);
+    }
+
+    pModule->m_bSetLocalPos = true;
+    pModule->m_bResetGlobalPos = false;
+
+    world.GetClock().SetFixedTimeStep(ezTime::Milliseconds(100));
+    world.Update();
+
+    for (auto& pObject : pObjects)
+    {
+      ezUInt32 i = pObject->GetHandle().GetInternalID().m_InstanceIndex;
+      ezVec3 expectedPos = ezVec3(i * 10, 0, 0);
+      ezVec3 expectedLinearVelocity = ezVec3(i * 100, 0, 0);
+      EZ_TEST_VEC3(pObject->GetLastGlobalTransform().m_vPosition, ezVec3::ZeroVector(), ezMath::DefaultEpsilon<float>());
+      EZ_TEST_VEC3(pObject->GetGlobalPosition(), expectedPos, ezMath::DefaultEpsilon<float>());
+      EZ_TEST_VEC3(pObject->GetLinearVelocity(), expectedLinearVelocity, ezMath::DefaultEpsilon<float>());
+    }
+
+    pModule->m_bSetLocalPos = false;
+    pModule->m_bResetGlobalPos = true;
+
+    world.Update();
+
+    for (auto& pObject : pObjects)
+    {
+      ezUInt32 i = pObject->GetHandle().GetInternalID().m_InstanceIndex;
+      ezVec3 expectedLastPos = ezVec3(i * 10, 0, 0);
+      ezVec3 expectedLinearVelocity = ezVec3(i * -100.0f, 0, 0);
+      EZ_TEST_VEC3(pObject->GetLastGlobalTransform().m_vPosition, expectedLastPos, ezMath::DefaultEpsilon<float>());
+      EZ_TEST_VEC3(pObject->GetGlobalPosition(), ezVec3::ZeroVector(), ezMath::DefaultEpsilon<float>());
+      EZ_TEST_VEC3(pObject->GetLinearVelocity(), expectedLinearVelocity, ezMath::DefaultEpsilon<float>());
+    }
+  }
+#endif
 }

--- a/Code/UnitTests/CoreTest/World/WorldTest.cpp
+++ b/Code/UnitTests/CoreTest/World/WorldTest.cpp
@@ -732,6 +732,9 @@ EZ_CREATE_SIMPLE_TEST(World, World)
     ezGameObject* pObjects[numObjects];
     for (ezUInt32 i = 0; i < numObjects; ++i)
     {
+      objectDesc.m_LocalPosition = ezVec3(0, 0, 5);
+      objectDesc.m_LocalRotation.SetFromAxisAndAngle(ezVec3::UnitZAxis(), ezAngle::Degree(90));
+
       hObjects[i] = world.CreateObject(objectDesc, pObjects[i]);
     }
 
@@ -744,11 +747,16 @@ EZ_CREATE_SIMPLE_TEST(World, World)
     for (auto& pObject : pObjects)
     {
       ezUInt32 i = pObject->GetHandle().GetInternalID().m_InstanceIndex;
+      ezVec3 expectedLastPos = ezVec3(0, 0, 5);
       ezVec3 expectedPos = ezVec3(i * 10, 0, 0);
-      ezVec3 expectedLinearVelocity = ezVec3(i * 100, 0, 0);
-      EZ_TEST_VEC3(pObject->GetLastGlobalTransform().m_vPosition, ezVec3::ZeroVector(), ezMath::DefaultEpsilon<float>());
+      ezVec3 expectedLinearVelocity = ezVec3(i * 100, 0, -50);
+      EZ_TEST_VEC3(pObject->GetLastGlobalTransform().m_vPosition, expectedLastPos, ezMath::DefaultEpsilon<float>());
       EZ_TEST_VEC3(pObject->GetGlobalPosition(), expectedPos, ezMath::DefaultEpsilon<float>());
       EZ_TEST_VEC3(pObject->GetLinearVelocity(), expectedLinearVelocity, ezMath::DefaultEpsilon<float>());
+
+      ezVec3 expectedAngularVelocity = ezVec3(0, 0, (ezAngle::Degree(i * 30) - ezAngle::Degree(90)).GetRadian() * 10);
+      ezVec3 angularVelocity = pObject->GetAngularVelocity();
+      EZ_TEST_VEC3(angularVelocity, expectedAngularVelocity, ezMath::DefaultEpsilon<float>());
     }
 
     pModule->m_bSetLocalPos = false;

--- a/Data/Plugins/TypeScript/ez/GameObject.ts
+++ b/Data/Plugins/TypeScript/ez/GameObject.ts
@@ -40,8 +40,7 @@ declare function __CPP_GameObject_GetGlobalDirForwards(_this: GameObject): Vec3;
 declare function __CPP_GameObject_GetGlobalDirRight(_this: GameObject): Vec3;
 declare function __CPP_GameObject_GetGlobalDirUp(_this: GameObject): Vec3;
 
-declare function __CPP_GameObject_SetVelocity(_this: GameObject, value: Vec3): void;
-declare function __CPP_GameObject_GetVelocity(_this: GameObject): Vec3;
+declare function __CPP_GameObject_GetLinearVelocity(_this: GameObject): Vec3;
 
 declare function __CPP_GameObject_SetActiveFlag(_this: GameObject, active: boolean): void;
 declare function __CPP_GameObject_GetActiveFlag(_this: GameObject): boolean;
@@ -287,20 +286,10 @@ export class GameObject {
     }
 
     /**
-     * Sets the velocity value of the GameObject.
-     * The velocity value only has an effect in some scenarios. It does not affect the GameObject's position.
-     * E.g. velocity is used by sound-sources to compute Doppler effects.
-     * By default this value is computed out of position changes.
+     * Returns the linear velocity of the object over the last two world updates.
      */
-    SetVelocity(velocity: Vec3): void { // [tested]
-        __CPP_GameObject_SetVelocity(this, velocity);
-    }
-
-    /**
-     * Returns the velocity of the object over the last two world updates.
-     */
-    GetVelocity(): Vec3 { // [tested]
-        return __CPP_GameObject_GetVelocity(this);
+    GetLinearVelocity(): Vec3 { // [tested]
+        return __CPP_GameObject_GetLinearVelocity(this);
     }
 
     /**

--- a/Data/UnitTests/GameEngineTest/TypeScript/Scripts/TestGameObject.ts
+++ b/Data/UnitTests/GameEngineTest/TypeScript/Scripts/TestGameObject.ts
@@ -140,10 +140,7 @@ export class TestGameObject extends ez.TypescriptComponent {
 
         // Velocity
         {
-            EZ_TEST.VEC3(child1.GetVelocity(), ez.Vec3.ZeroVector());
-
-            child1.SetVelocity(new ez.Vec3(1, 2, 3));
-            EZ_TEST.VEC3(child1.GetVelocity(), new ez.Vec3(1, 2, 3));
+            EZ_TEST.VEC3(child1.GetLinearVelocity(), new ez.Vec3(300, 600, 900));
         }
 
         // Team ID

--- a/Data/UnitTests/GameEngineTest/TypeScript/TypeScript/ez/AllComponents.ts
+++ b/Data/UnitTests/GameEngineTest/TypeScript/TypeScript/ez/AllComponents.ts
@@ -497,6 +497,8 @@ export class MeshComponent extends MeshComponentBase
   set Mesh(value: string) { __CPP_ComponentProperty_set(this, 1864394775, value); }
   get Color(): Color { return __CPP_ComponentProperty_get(this, 1079163548); }
   set Color(value: Color) { __CPP_ComponentProperty_set(this, 1079163548, value); }
+  get SortingDepthOffset(): number { return __CPP_ComponentProperty_get(this, 3099356804); }
+  set SortingDepthOffset(value: number) { __CPP_ComponentProperty_set(this, 3099356804, value); }
 }
 
 export class GizmoComponent extends MeshComponent


### PR DESCRIPTION
This is necessary for render effects that require velocity e.g. motion blur or any form of temporal reprojection.
Also this allows us to obtain angular velocity from a gameobject as well.

Fixes #948