### PR TITLE
OpenXR and editor bug fixes

### DIFF
--- a/Code/Engine/GameEngine/GameState/Implementation/FallbackGameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/FallbackGameState.cpp
@@ -388,7 +388,7 @@ void ezFallbackGameState::AfterWorldUpdate()
   // Setting the camera transform in ProcessInput introduces one frame delay.
   if (const ezCameraComponent* pCamComp = FindActiveCameraComponent())
   {
-    if (pCamComp->GetCameraMode() != ezCameraMode::Stereo)
+    if (pCamComp->GetCameraMode() != ezCameraMode::Stereo && m_MainCamera.GetCameraMode() != ezCameraMode::Stereo)
     {
       const ezGameObject* pOwner = pCamComp->GetOwner();
       ezVec3 vPosition = pOwner->GetGlobalPosition();

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRSingleton.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRSingleton.cpp
@@ -98,10 +98,8 @@ XrResult ezOpenXR::SelectExtensions(ezHybridArray<const char*, 6>& extensions)
   XR_SUCCEED_OR_RETURN_LOG(xrEnumerateInstanceExtensionProperties(nullptr, extensionCount, &extensionCount, extensionProperties.data()));
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> XrResult
-  {
-    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const XrExtensionProperties& prop)
-      { return ezStringUtils::IsEqual(prop.extensionName, extensionName); });
+  auto AddExtIfSupported = [&](const char* extensionName, bool& enableFlag) -> XrResult {
+    auto it = std::find_if(begin(extensionProperties), end(extensionProperties), [&](const XrExtensionProperties& prop) { return ezStringUtils::IsEqual(prop.extensionName, extensionName); });
     if (it != end(extensionProperties))
     {
       extensions.PushBack(extensionName);
@@ -147,10 +145,8 @@ XrResult ezOpenXR::SelectLayers(ezHybridArray<const char*, 6>& layers)
   XR_SUCCEED_OR_RETURN_LOG(xrEnumerateApiLayerProperties(layerCount, &layerCount, layerProperties.data()));
 
   // Add a specific extension to the list of extensions to be enabled, if it is supported.
-  auto AddExtIfSupported = [&](const char* layerName, bool& enableFlag) -> XrResult
-  {
-    auto it = std::find_if(begin(layerProperties), end(layerProperties), [&](const XrApiLayerProperties& prop)
-      { return ezStringUtils::IsEqual(prop.layerName, layerName); });
+  auto AddExtIfSupported = [&](const char* layerName, bool& enableFlag) -> XrResult {
+    auto it = std::find_if(begin(layerProperties), end(layerProperties), [&](const XrApiLayerProperties& prop) { return ezStringUtils::IsEqual(prop.layerName, layerName); });
     if (it != end(layerProperties))
     {
       layers.PushBack(layerName);
@@ -324,9 +320,7 @@ ezUniquePtr<ezActor> ezOpenXR::CreateActor(ezView* pView, ezGALMSAASampleCount::
     return {};
   }
 
-  ezGALXRSwapChain::SetFactoryMethod([this, msaaCount](ezXRInterface* pXrInterface) -> ezGALSwapChainHandle
-    { return ezGALDevice::GetDefaultDevice()->CreateSwapChain([this, pXrInterface, msaaCount](ezAllocatorBase* pAllocator) -> ezGALSwapChain*
-        { return EZ_NEW(pAllocator, ezGALOpenXRSwapChain, this, msaaCount); }); });
+  ezGALXRSwapChain::SetFactoryMethod([this, msaaCount](ezXRInterface* pXrInterface) -> ezGALSwapChainHandle { return ezGALDevice::GetDefaultDevice()->CreateSwapChain([this, pXrInterface, msaaCount](ezAllocatorBase* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALOpenXRSwapChain, this, msaaCount); }); });
   EZ_SCOPE_EXIT(ezGALXRSwapChain::SetFactoryMethod({}););
 
   m_hSwapChain = ezGALXRSwapChain::Create(this);
@@ -731,13 +725,11 @@ void ezOpenXR::UpdatePoses()
   }
 
   // Needed as workaround for broken XR runtimes.
-  auto FovIsNull = [](const XrFovf& fov)
-  {
+  auto FovIsNull = [](const XrFovf& fov) {
     return fov.angleLeft == 0.0f && fov.angleRight == 0.0f && fov.angleDown == 0.0f && fov.angleUp == 0.0f;
   };
 
-  auto IdentityFov = [](XrFovf& fov)
-  {
+  auto IdentityFov = [](XrFovf& fov) {
     fov.angleLeft = -ezAngle::Degree(45.0f).GetRadian();
     fov.angleRight = ezAngle::Degree(45.0f).GetRadian();
     fov.angleUp = ezAngle::Degree(45.0f).GetRadian();
@@ -759,7 +751,6 @@ void ezOpenXR::UpdatePoses()
     {
       m_views[uiEyeIndex].pose.orientation = XrQuaternionf{0, 0, 0, 1};
     }
-
   }
 
   UpdateCamera();
@@ -781,8 +772,7 @@ void ezOpenXR::UpdateCamera()
   {
     m_projectionChanged = false;
     const float fAspectRatio = (float)m_Info.m_vEyeRenderTargetSize.width / (float)m_Info.m_vEyeRenderTargetSize.height;
-    auto CreateProjection = [](const XrView& view, ezCamera* cam)
-    {
+    auto CreateProjection = [](const XrView& view, ezCamera* cam) {
       return ezGraphicsUtils::CreatePerspectiveProjectionMatrix(ezMath::Tan(ezAngle::Radian(view.fov.angleLeft)) * cam->GetNearPlane(), ezMath::Tan(ezAngle::Radian(view.fov.angleRight)) * cam->GetNearPlane(), ezMath::Tan(ezAngle::Radian(view.fov.angleDown)) * cam->GetNearPlane(),
         ezMath::Tan(ezAngle::Radian(view.fov.angleUp)) * cam->GetNearPlane(), cam->GetNearPlane(), cam->GetFarPlane());
     };

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRSingleton.h
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRSingleton.h
@@ -167,6 +167,7 @@ private:
   ezGALSwapChainHandle m_hSwapChain;
 
   // Views
+  XrViewState m_viewState{XR_TYPE_VIEW_STATE};
   XrView m_views[2];
   bool m_projectionChanged = true;
   XrCompositionLayerProjection m_layer{XR_TYPE_COMPOSITION_LAYER_PROJECTION};

--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
@@ -26,6 +26,7 @@ ezQtNodeScene::ezQtNodeScene(QObject* pParent)
 
 ezQtNodeScene::~ezQtNodeScene()
 {
+  disconnect(this, &QGraphicsScene::selectionChanged, this, &ezQtNodeScene::OnSelectionChanged);
   SetDocumentNodeManager(nullptr);
 }
 
@@ -58,7 +59,10 @@ void ezQtNodeScene::SetDocumentNodeManager(const ezDocumentNodeManager* pManager
       {
         CreateQtNode(pObject);
       }
-      else if (pManager->IsConnection(pObject))
+    }
+    for (const auto& pObject : rootObjects)
+    {
+      if (pManager->IsConnection(pObject))
       {
         CreateQtConnection(pObject);
       }


### PR DESCRIPTION
* Copy&paste in node graphs now works.
* Handle OpenXR invalid poses gracefully. Even if we don't have a pose, we need to generate one for xrEndFrame to succeed.
* Only apply FallBackGameState camera transform if target camera mode != stereo
* Fixed crash when closing a node editor that had an active selection.
* Fixes #1006