### PR TITLE
Fix EZ_DEBUG_BREAK on linux

### DIFF
--- a/Code/Engine/Foundation/Basics/Compiler/Clang/Clang.h
+++ b/Code/Engine/Foundation/Basics/Compiler/Clang/Clang.h
@@ -15,10 +15,30 @@
 
 #  define EZ_ALIGNMENT_OF(type) EZ_COMPILE_TIME_MAX(__alignof(type), EZ_ALIGNMENT_MINIMUM)
 
-#  define EZ_DEBUG_BREAK \
-    {                    \
-      __builtin_trap();  \
-    }
+#  if __has_builtin(__builtin_debugtrap)
+#    define EZ_DEBUG_BREAK     \
+      {                        \
+        __builtin_debugtrap(); \
+      }
+#  elif __has_builtin(__debugbreak)
+#    define EZ_DEBUG_BREAK \
+      {                    \
+        __debugbreak();    \
+      }
+#  else
+#    include <signal.h>
+#    if defined(SIGTRAP)
+#      define EZ_DEBUG_BREAK \
+        {                    \
+          raise(SIGTRAP);    \
+        }
+#    else
+#      define EZ_DEBUG_BREAK \
+        {                    \
+          raise(SIGABRT);    \
+        }
+#    endif
+#  endif
 
 #  define EZ_SOURCE_FUNCTION __PRETTY_FUNCTION__
 #  define EZ_SOURCE_LINE __LINE__

--- a/Code/Engine/Foundation/Basics/Compiler/GCC/GCC.h
+++ b/Code/Engine/Foundation/Basics/Compiler/GCC/GCC.h
@@ -12,10 +12,30 @@
 
 #  define EZ_ALIGNMENT_OF(type) EZ_COMPILE_TIME_MAX(__alignof(type), EZ_ALIGNMENT_MINIMUM)
 
-#  define EZ_DEBUG_BREAK \
-    {                    \
-      __builtin_trap();  \
-    }
+#  if __has_builtin(__builtin_debugtrap)
+#    define EZ_DEBUG_BREAK     \
+      {                        \
+        __builtin_debugtrap(); \
+      }
+#elif defined(__i386__) || defined(__x86_64__)
+#    define EZ_DEBUG_BREAK     \
+      {                        \
+        __asm__ __volatile__("int3"); \
+      }
+#  else
+#    include <signal.h>
+#    if defined(SIGTRAP)
+#      define EZ_DEBUG_BREAK \
+        {                    \
+          raise(SIGTRAP);    \
+        }
+#    else
+#      define EZ_DEBUG_BREAK \
+        {                    \
+          raise(SIGABRT);    \
+        }
+#    endif
+#  endif
 
 #  define EZ_SOURCE_FUNCTION __PRETTY_FUNCTION__
 #  define EZ_SOURCE_LINE __LINE__

--- a/Code/Engine/Foundation/Basics/Compiler/GCC/GCC.h
+++ b/Code/Engine/Foundation/Basics/Compiler/GCC/GCC.h
@@ -17,9 +17,9 @@
       {                        \
         __builtin_debugtrap(); \
       }
-#elif defined(__i386__) || defined(__x86_64__)
-#    define EZ_DEBUG_BREAK     \
-      {                        \
+#  elif defined(__i386__) || defined(__x86_64__)
+#    define EZ_DEBUG_BREAK            \
+      {                               \
         __asm__ __volatile__("int3"); \
       }
 #  else

--- a/Code/Engine/Foundation/headerCheckerIgnore.json
+++ b/Code/Engine/Foundation/headerCheckerIgnore.json
@@ -38,7 +38,8 @@
 			"unistd.h",
 			"jni.h",
 			"float.h",
-			"arm_neon.h"
+			"arm_neon.h",
+            "signal.h"
 		]
 	},
 	"includeSource" : 


### PR DESCRIPTION
Make EZ_DEBUG_BREAK continue-able in the debugger when compiling for Linux with GCC or Clang.