### PR TITLE
Marked many functions as deprecated

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -58,7 +58,12 @@ function(ez_set_build_flags_msvc TARGET_NAME)
 
 	# /WX: treat warnings as errors
 	if(NOT ${ARG_NO_WARNINGS_AS_ERRORS} AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-		target_compile_options(${TARGET_NAME} PRIVATE "/WX")
+		# target_compile_options(${TARGET_NAME} PRIVATE "/WX")
+		# switch Warning 4996 (deprecation warning) from warning level 3 to warning level 1
+		# since you can't mark warnings as "not errors" in MSVC, we must switch off
+		# the global warning-as-errors flag
+		# instead we could switch ON selected warnings as errors
+		target_compile_options(${TARGET_NAME} PRIVATE "/w14996")
 	endif()
 
 	if((CMAKE_SIZEOF_VOID_P EQUAL 4) AND EZ_CMAKE_ARCHITECTURE_X86)

--- a/Code/Engine/Foundation/Math/Angle.h
+++ b/Code/Engine/Foundation/Math/Angle.h
@@ -32,11 +32,11 @@ public:
 
   /// \brief Creates an instance of ezAngle that was initialized from degree. (Performs a conversion)
   [[nodiscard]] constexpr static ezAngle MakeFromDegree(float fDegree); // [tested]
-  /*[[deprecated("Use ezAngle::MakeFromDegree() instead.")]]*/ constexpr static ezAngle Degree(float fDegree) { return MakeFromDegree(fDegree); }
+  [[deprecated("Use ezAngle::MakeFromDegree() instead.")]] constexpr static ezAngle Degree(float fDegree) { return MakeFromDegree(fDegree); }
 
   /// \brief Creates an instance of ezAngle that was initialized from radian. (No need for any conversion)
   [[nodiscard]] constexpr static ezAngle MakeFromRadian(float fRadian); // [tested]
-  /*[[deprecated("Use ezAngle::MakeFromRadian() instead.")]]*/ constexpr static ezAngle Radian(float fRadian) { return MakeFromRadian(fRadian); }
+  [[deprecated("Use ezAngle::MakeFromRadian() instead.")]] constexpr static ezAngle Radian(float fRadian) { return MakeFromRadian(fRadian); }
 
   /// \brief Standard constructor, initializing with 0.
   constexpr ezAngle()

--- a/Code/Engine/Foundation/Math/BoundingBox.h
+++ b/Code/Engine/Foundation/Math/BoundingBox.h
@@ -47,10 +47,10 @@ public:
   [[nodiscard]] static ezBoundingBoxTemplate<Type> MakeFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>));
 
   /// \brief Resets the box to an invalid state. ExpandToInclude can then be used to make it into a bounding box for objects.
-  /*[[deprecated("Use MakeInvalid() instead.")]]*/ void SetInvalid(); // [tested]
+  [[deprecated("Use MakeInvalid() instead.")]] void SetInvalid(); // [tested]
 
   /// \brief Sets the box from a center point and half-extents for each axis.
-  /*[[deprecated("Use MakeFromCenterAndHalfExtents() instead.")]]*/ void SetCenterAndHalfExtents(const ezVec3Template<Type>& vCenter, const ezVec3Template<Type>& vHalfExtents); // [tested]
+  [[deprecated("Use MakeFromCenterAndHalfExtents() instead.")]] void SetCenterAndHalfExtents(const ezVec3Template<Type>& vCenter, const ezVec3Template<Type>& vHalfExtents); // [tested]
 
   /// \brief Checks whether the box is in an invalid state.
   bool IsValid() const; // [tested]
@@ -59,10 +59,10 @@ public:
   bool IsNaN() const; // [tested]
 
   /// \brief Directly sets the minimum and maximum values.
-  /*[[deprecated("Use MakeFromMinMax() instead.")]]*/ void SetElements(const ezVec3Template<Type>& vMin, const ezVec3Template<Type>& vMax); // [tested]
+  [[deprecated("Use MakeFromMinMax() instead.")]] void SetElements(const ezVec3Template<Type>& vMin, const ezVec3Template<Type>& vMax); // [tested]
 
   /// \brief Creates a new bounding-box around the given set of points.
-  /*[[deprecated("Use MakeFromPoints() instead.")]]*/ void SetFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>)); // [tested]
+  [[deprecated("Use MakeFromPoints() instead.")]] void SetFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>)); // [tested]
 
   /// \brief Writes the 8 different corners of the box to the given array.
   void GetCorners(ezVec3Template<Type>* out_pCorners) const; // [tested]

--- a/Code/Engine/Foundation/Math/BoundingBoxSphere.h
+++ b/Code/Engine/Foundation/Math/BoundingBoxSphere.h
@@ -25,10 +25,10 @@ public:
   void operator=(const ezBoundingBoxSphereTemplate& rhs);
 
   /// \brief Constructs the bounds from the center position, the box half extends and the sphere radius.
-  /*[[deprecated("Use MakeFromCenterExtents() instead.")]]*/ ezBoundingBoxSphereTemplate(const ezVec3Template<Type>& vCenter, const ezVec3Template<Type>& vBoxHalfExtents, Type fSphereRadius); // [tested]
+  [[deprecated("Use MakeFromCenterExtents() instead.")]] ezBoundingBoxSphereTemplate(const ezVec3Template<Type>& vCenter, const ezVec3Template<Type>& vBoxHalfExtents, Type fSphereRadius); // [tested]
 
   /// \brief Constructs the bounds from the given box and sphere.
-  /*[[deprecated("Use MakeFromBoxAndSphere() instead.")]]*/ ezBoundingBoxSphereTemplate(const ezBoundingBoxTemplate<Type>& box, const ezBoundingSphereTemplate<Type>& sphere); // [tested]
+  [[deprecated("Use MakeFromBoxAndSphere() instead.")]] ezBoundingBoxSphereTemplate(const ezBoundingBoxTemplate<Type>& box, const ezBoundingSphereTemplate<Type>& sphere); // [tested]
 
   /// \brief Constructs the bounds from the given box. The sphere radius is calculated from the box extends.
   ezBoundingBoxSphereTemplate(const ezBoundingBoxTemplate<Type>& box); // [tested]
@@ -70,7 +70,7 @@ public:
 #endif
 
   /// \brief Resets the bounds to an invalid state.
-  /*[[deprecated("Use MakeInvalid() instead.")]]*/ void SetInvalid(); // [tested]
+  [[deprecated("Use MakeInvalid() instead.")]] void SetInvalid(); // [tested]
 
   /// \brief Checks whether the bounds is in an invalid state.
   bool IsValid() const; // [tested]
@@ -79,7 +79,7 @@ public:
   bool IsNaN() const; // [tested]
 
   /// \brief Calculates the bounds from given set of points.
-  /*[[deprecated("Use MakeFromPoints() instead.")]]*/ void SetFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>)); // [tested]
+  [[deprecated("Use MakeFromPoints() instead.")]] void SetFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>)); // [tested]
 
   /// \brief Returns the bounding box.
   const ezBoundingBoxTemplate<Type> GetBox() const; // [tested]

--- a/Code/Engine/Foundation/Math/BoundingSphere.h
+++ b/Code/Engine/Foundation/Math/BoundingSphere.h
@@ -20,7 +20,7 @@ public:
   ezBoundingSphereTemplate();
 
   /// \brief Creates a sphere with the given radius around the given center.
-  /*[[deprecated("Use MakeFromCenterAndRadius() instead.")]]*/ ezBoundingSphereTemplate(const ezVec3Template<Type>& vCenter, Type fRadius); // [tested]
+  ezBoundingSphereTemplate(const ezVec3Template<Type>& vCenter, Type fRadius); // [tested]
 
   /// \brief Creates a sphere at the origin with radius zero.
   [[nodiscard]] static ezBoundingSphereTemplate<Type> MakeZero();
@@ -49,13 +49,13 @@ public:
 #endif
 
   /// \brief Sets all elements to Zero. The sphere is thus 'valid'.
-  /*[[deprecated("Use MakeZero() instead.")]]*/ void SetZero(); // [tested]
+  [[deprecated("Use MakeZero() instead.")]] void SetZero(); // [tested]
 
   /// \brief Checks whether the sphere is all zero.
   bool IsZero(Type fEpsilon = ezMath::DefaultEpsilon<Type>()) const; // [tested]
 
   /// \brief Sets the bounding sphere to invalid values.
-  /*[[deprecated("Use MakeInvalid() instead.")]]*/ void SetInvalid(); // [tested]
+  [[deprecated("Use MakeInvalid() instead.")]] void SetInvalid(); // [tested]
 
   /// \brief Returns whether the sphere has valid values.
   bool IsValid() const; // [tested]
@@ -64,10 +64,10 @@ public:
   bool IsNaN() const; // [tested]
 
   /// \brief Sets the sphere to the given values.
-  /*[[deprecated("Use MakeFromCenterAndRadius() instead.")]]*/ void SetElements(const ezVec3Template<Type>& vCenter, Type fRadius); // [tested]
+  [[deprecated("Use MakeFromCenterAndRadius() instead.")]] void SetElements(const ezVec3Template<Type>& vCenter, Type fRadius); // [tested]
 
   /// \brief Initializes the sphere to be the bounding sphere of all the given points (not necessarily the smallest one).
-  /*[[deprecated("Use MakeFromPoints() instead.")]]*/ void SetFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>)); // [tested]
+  [[deprecated("Use MakeFromPoints() instead.")]] void SetFromPoints(const ezVec3Template<Type>* pPoints, ezUInt32 uiNumPoints, ezUInt32 uiStride = sizeof(ezVec3Template<Type>)); // [tested]
 
   /// \brief Increases the sphere's radius to include this point. Does NOT change its position, thus the resulting sphere might be not a very tight
   /// fit.

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -210,7 +210,7 @@ public:
 
   /// \brief Returns a color with all four RGBA components set to zero. This is different to ezColor::Black, which has alpha still set to 1.0.
   [[nodiscard]] static ezColor MakeZero();
-  /*[[deprecated("Use ezColor::MakeZero() instead.")]]*/ static ezColor ZeroColor() { return MakeZero(); }
+  [[deprecated("Use ezColor::MakeZero() instead.")]] static ezColor ZeroColor() { return MakeZero(); }
 
   // *** Constructors ***
 public:
@@ -248,7 +248,7 @@ public:
   void SetRGBA(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // [tested]
 
   /// \brief Sets all four RGBA components to zero.
-  /*[[deprecated("Use ezColor::MakeZero() instead.")]]*/ void SetZero();
+  [[deprecated("Use ezColor::MakeZero() instead.")]] void SetZero();
 
   // *** Conversion Operators/Functions ***
 public:
@@ -256,7 +256,7 @@ public:
   ///
   /// \a hue is in range [0; 360], \a sat and \a val are in range [0; 1]
   [[nodiscard]] static ezColor MakeHSV(float fHue, float fSat, float fVal); // [tested]
-  /*[[deprecated("Use ezColor::MakeHSV() instead.")]]*/ void SetHSV(float fHue, float fSat, float fVal) { *this = MakeHSV(fHue, fSat, fVal); }
+  [[deprecated("Use ezColor::MakeHSV() instead.")]] void SetHSV(float fHue, float fSat, float fVal) { *this = MakeHSV(fHue, fSat, fVal); }
 
   /// \brief Converts the color part to HSV format.
   ///

--- a/Code/Engine/Foundation/Math/Frustum.h
+++ b/Code/Engine/Foundation/Math/Frustum.h
@@ -65,7 +65,7 @@ public:
   ///
   /// \note Make sure to pass in the planes in the order of the PlaneType enum, otherwise ezFrustum may not always work as expected.
   [[nodiscard]] static ezFrustum MakeFromPlanes(const ezPlane* pPlanes); // [tested]
-  /*[[deprecated("Use ezFrustum::MakeFromPlanes() instead.")]]*/ void SetFrustum(const ezPlane* pPlanes) { *this = MakeFromPlanes(pPlanes); }
+  [[deprecated("Use ezFrustum::MakeFromPlanes() instead.")]] void SetFrustum(const ezPlane* pPlanes) { *this = MakeFromPlanes(pPlanes); }
 
   /// \brief Creates the frustum by extracting the planes from the given (model-view / projection) matrix.
   ///
@@ -73,14 +73,14 @@ public:
   /// matrix to create the frustum in world-space. If the projection matrix contained in ModelViewProjection is an infinite
   /// plane projection matrix, the resulting frustum will yield a far plane with infinite distance.
   [[nodiscard]] static ezFrustum MakeFromMVP(const ezMat4& mModelViewProjection, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default, ezHandedness::Enum handedness = ezHandedness::Default); // [tested]
-  /*[[deprecated("Use ezFrustum::MakeFromMVP() instead.")]]*/ void SetFrustum(const ezMat4& mModelViewProjection, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default, ezHandedness::Enum handedness = ezHandedness::Default) { *this = MakeFromMVP(mModelViewProjection, depthRange, handedness); }
+  [[deprecated("Use ezFrustum::MakeFromMVP() instead.")]] void SetFrustum(const ezMat4& mModelViewProjection, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default, ezHandedness::Enum handedness = ezHandedness::Default) { *this = MakeFromMVP(mModelViewProjection, depthRange, handedness); }
 
   /// \brief Creates a frustum from the given camera position, direction vectors and the field-of-view along X and Y.
   ///
   /// The up vector does not need to be exactly orthogonal to the forwards vector, it will get recomputed properly.
   /// FOV X and Y define the entire field-of-view, so a FOV of 180 degree would mean the entire half-space in front of the camera.
   [[nodiscard]] static ezFrustum MakeFromFOV(const ezVec3& vPosition, const ezVec3& vForwards, const ezVec3& vUp, ezAngle fovX, ezAngle fovY, float fNearPlane, float fFarPlane); // [tested]
-  /*[[deprecated("Use ezFrustum::MakeFromFOV() instead.")]]*/ void SetFrustum(const ezVec3& vPosition, const ezVec3& vForwards, const ezVec3& vUp, ezAngle fovX, ezAngle fovY, float fNearPlane, float fFarPlane) { *this = MakeFromFOV(vPosition, vForwards, vUp, fovX, fovY, fNearPlane, fFarPlane); }
+  [[deprecated("Use ezFrustum::MakeFromFOV() instead.")]] void SetFrustum(const ezVec3& vPosition, const ezVec3& vForwards, const ezVec3& vUp, ezAngle fovX, ezAngle fovY, float fNearPlane, float fFarPlane) { *this = MakeFromFOV(vPosition, vForwards, vUp, fovX, fovY, fNearPlane, fFarPlane); }
 
   /// \brief Returns the n-th plane of the frustum.
   const ezPlane& GetPlane(ezUInt8 uiPlane) const; // [tested]

--- a/Code/Engine/Foundation/Math/Implementation/Mat4_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Mat4_inl.h
@@ -23,7 +23,22 @@ template <typename Type>
 ezMat4Template<Type>::ezMat4Template(Type c1r1, Type c2r1, Type c3r1, Type c4r1, Type c1r2, Type c2r2, Type c3r2, Type c4r2, Type c1r3, Type c2r3,
   Type c3r3, Type c4r3, Type c1r4, Type c2r4, Type c3r4, Type c4r4)
 {
-  SetElements(c1r1, c2r1, c3r1, c4r1, c1r2, c2r2, c3r2, c4r2, c1r3, c2r3, c3r3, c4r3, c1r4, c2r4, c3r4, c4r4);
+  Element(0, 0) = c1r1;
+  Element(1, 0) = c2r1;
+  Element(2, 0) = c3r1;
+  Element(3, 0) = c4r1;
+  Element(0, 1) = c1r2;
+  Element(1, 1) = c2r2;
+  Element(2, 1) = c3r2;
+  Element(3, 1) = c4r2;
+  Element(0, 2) = c1r3;
+  Element(1, 2) = c2r3;
+  Element(2, 2) = c3r3;
+  Element(3, 2) = c4r3;
+  Element(0, 3) = c1r4;
+  Element(1, 3) = c2r4;
+  Element(2, 3) = c3r4;
+  Element(3, 3) = c4r4;
 }
 
 template <typename Type>

--- a/Code/Engine/Foundation/Math/Mat3.h
+++ b/Code/Engine/Foundation/Math/Mat3.h
@@ -36,10 +36,10 @@ public:
   /// \param layout
   ///   The layout in which pData stores the matrix. The data will get transposed, if necessary.
   ///   The data should be in column-major format, if you want to prevent unnecessary transposes.
-  /*[[deprecated("Use ezMat3::MakeFromColumnMajorArray() instead.")]]*/ ezMat3Template(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
+  [[deprecated("Use ezMat3::MakeFromColumnMajorArray() instead.")]] ezMat3Template(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
 
   /// \brief Sets each element manually: Naming is "column-n row-m"
-  /*[[deprecated("Use ezMat3::MakeFromValues() instead.")]]*/ ezMat3Template(Type c1r1, Type c2r1, Type c3r1, Type c1r2, Type c2r2, Type c3r2, Type c1r3, Type c2r3, Type c3r3); // [tested]
+  [[deprecated("Use ezMat3::MakeFromValues() instead.")]] ezMat3Template(Type c1r1, Type c2r1, Type c3r1, Type c1r2, Type c2r2, Type c3r2, Type c1r3, Type c2r3, Type c3r3); // [tested]
 
   /// \brief Returns a zero matrix.
   [[nodiscard]] static ezMat3Template<Type> MakeZero();
@@ -86,14 +86,14 @@ public:
   /// \param layout
   ///   The layout in which pData stores the matrix. The data will get transposed, if necessary.
   ///   The data should be in column-major format, if you want to prevent unnecessary transposes.
-  /*[[deprecated("Use ezMat3::MakeFromColumnMajorArray() instead.")]]*/ void SetFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
+  [[deprecated("Use ezMat3::MakeFromColumnMajorArray() instead.")]] void SetFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
 
   /// \brief Copies the 9 values of this matrix into the given array. 'layout' defines whether the data should end up in column-major or row-major
   /// format.
   void GetAsArray(Type* out_pData, ezMatrixLayout::Enum layout) const; // [tested]
 
   /// \brief Sets each element manually: Naming is "column-n row-m"
-  /*[[deprecated("Use ezMat3::MakeFromValues() instead.")]]*/ void SetElements(Type c1r1, Type c2r1, Type c3r1, Type c1r2, Type c2r2, Type c3r2, Type c1r3, Type c2r3, Type c3r3); // [tested]
+  [[deprecated("Use ezMat3::MakeFromValues() instead.")]] void SetElements(Type c1r1, Type c2r1, Type c3r1, Type c1r2, Type c2r2, Type c3r2, Type c1r3, Type c2r3, Type c3r3); // [tested]
 
   // *** Special matrix constructors ***
 public:
@@ -104,27 +104,27 @@ public:
   void SetIdentity(); // [tested]
 
   /// \brief Sets the matrix to all zero, except the diagonal, which is set to x,y,z,1
-  /*[[deprecated("Use ezMat3::MakeScaling() instead.")]]*/ void SetScalingMatrix(const ezVec3Template<Type>& vScale); // [tested]
+  [[deprecated("Use ezMat3::MakeScaling() instead.")]] void SetScalingMatrix(const ezVec3Template<Type>& vScale); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the X-axis.
-  /*[[deprecated("Use ezMat3::MakeRotationX() instead.")]]*/ void SetRotationMatrixX(ezAngle angle); // [tested]
+  [[deprecated("Use ezMat3::MakeRotationX() instead.")]] void SetRotationMatrixX(ezAngle angle); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the Y-axis.
-  /*[[deprecated("Use ezMat3::MakeRotationY() instead.")]]*/ void SetRotationMatrixY(ezAngle angle); // [tested]
+  [[deprecated("Use ezMat3::MakeRotationY() instead.")]] void SetRotationMatrixY(ezAngle angle); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the Z-axis.
-  /*[[deprecated("Use ezMat3::MakeRotationZ() instead.")]]*/ void SetRotationMatrixZ(ezAngle angle); // [tested]
+  [[deprecated("Use ezMat3::MakeRotationZ() instead.")]] void SetRotationMatrixZ(ezAngle angle); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the given axis.
-  /*[[deprecated("Use ezMat3::MakeAxisRotation() instead.")]]*/ void SetRotationMatrix(const ezVec3Template<Type>& vAxis, ezAngle angle); // [tested]
+  [[deprecated("Use ezMat3::MakeAxisRotation() instead.")]] void SetRotationMatrix(const ezVec3Template<Type>& vAxis, ezAngle angle); // [tested]
 
   // *** Common Matrix Operations ***
 public:
   /// \brief Returns an Identity Matrix.
-  /*[[deprecated("Use ezMat3::MakeIdentity() instead.")]]*/ static const ezMat3Template<Type> IdentityMatrix(); // [tested]
+  [[deprecated("Use ezMat3::MakeIdentity() instead.")]] static const ezMat3Template<Type> IdentityMatrix(); // [tested]
 
   /// \brief Returns a Zero Matrix.
-  /*[[deprecated("Use ezMat3::MakeZero() instead.")]]*/ static const ezMat3Template<Type> ZeroMatrix(); // [tested]
+  [[deprecated("Use ezMat3::MakeZero() instead.")]] static const ezMat3Template<Type> ZeroMatrix(); // [tested]
 
   /// \brief Transposes this matrix.
   void Transpose(); // [tested]

--- a/Code/Engine/Foundation/Math/Mat4.h
+++ b/Code/Engine/Foundation/Math/Mat4.h
@@ -99,14 +99,14 @@ public:
   /// \param layout
   ///   The layout in which pData stores the matrix. The data will get transposed, if necessary.
   ///   The data should be in column-major format, if you want to prevent unnecessary transposes.
-  /*[[deprecated("Use ezMat4::MakeFromColumnMajorArray() instead.")]]*/ void SetFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
+  [[deprecated("Use ezMat4::MakeFromColumnMajorArray() instead.")]] void SetFromArray(const Type* const pData, ezMatrixLayout::Enum layout); // [tested]
 
   /// \brief Copies the 16 values of this matrix into the given array. 'layout' defines whether the data should end up in column-major or
   /// row-major format.
   void GetAsArray(Type* out_pData, ezMatrixLayout::Enum layout) const; // [tested]
 
   /// \brief Sets each element manually: Naming is "column-n row-m"
-  /*[[deprecated("Use ezMat4::MakeFromValues() instead.")]]*/ void SetElements(Type c1r1, Type c2r1, Type c3r1, Type c4r1, Type c1r2, Type c2r2, Type c3r2, Type c4r2, Type c1r3, Type c2r3, Type c3r3, Type c4r3, Type c1r4, Type c2r4, Type c3r4, Type c4r4); // [tested]
+  [[deprecated("Use ezMat4::MakeFromValues() instead.")]] void SetElements(Type c1r1, Type c2r1, Type c3r1, Type c4r1, Type c1r2, Type c2r2, Type c3r2, Type c4r2, Type c1r3, Type c2r3, Type c3r3, Type c4r3, Type c1r4, Type c2r4, Type c3r4, Type c4r4); // [tested]
 
   /// \brief Sets a transformation matrix from a rotation and a translation.
   void SetTransformationMatrix(const ezMat3Template<Type>& mRotation, const ezVec3Template<Type>& vTranslation); // [tested]
@@ -120,30 +120,30 @@ public:
   void SetIdentity(); // [tested]
 
   /// \brief Sets the matrix to all zero, except the last column, which is set to x,y,z,1
-  /*[[deprecated("Use ezMat4::MakeTranslation() instead.")]]*/ void SetTranslationMatrix(const ezVec3Template<Type>& vTranslation); // [tested]
+  [[deprecated("Use ezMat4::MakeTranslation() instead.")]] void SetTranslationMatrix(const ezVec3Template<Type>& vTranslation); // [tested]
 
   /// \brief Sets the matrix to all zero, except the diagonal, which is set to x,y,z,1
-  /*[[deprecated("Use ezMat4::MakeScaling() instead.")]]*/ void SetScalingMatrix(const ezVec3Template<Type>& vScale); // [tested]
+  [[deprecated("Use ezMat4::MakeScaling() instead.")]] void SetScalingMatrix(const ezVec3Template<Type>& vScale); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the X-axis.
-  /*[[deprecated("Use ezMat4::MakeRotationX() instead.")]]*/ void SetRotationMatrixX(ezAngle angle); // [tested]
+  [[deprecated("Use ezMat4::MakeRotationX() instead.")]] void SetRotationMatrixX(ezAngle angle); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the Y-axis.
-  /*[[deprecated("Use ezMat4::MakeRotationY() instead.")]]*/ void SetRotationMatrixY(ezAngle angle); // [tested]
+  [[deprecated("Use ezMat4::MakeRotationY() instead.")]] void SetRotationMatrixY(ezAngle angle); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the Z-axis.
-  /*[[deprecated("Use ezMat4::MakeRotationZ() instead.")]]*/ void SetRotationMatrixZ(ezAngle angle); // [tested]
+  [[deprecated("Use ezMat4::MakeRotationZ() instead.")]] void SetRotationMatrixZ(ezAngle angle); // [tested]
 
   /// \brief Sets this matrix to be a rotation matrix around the given axis.
-  /*[[deprecated("Use ezMat4::MakeAxisRotation() instead.")]]*/ void SetRotationMatrix(const ezVec3Template<Type>& vAxis, ezAngle angle); // [tested]
+  [[deprecated("Use ezMat4::MakeAxisRotation() instead.")]] void SetRotationMatrix(const ezVec3Template<Type>& vAxis, ezAngle angle); // [tested]
 
   // *** Common Matrix Operations ***
 public:
   /// \brief Returns an Identity Matrix.
-  /*[[deprecated("Use ezMat4::MakeIdentity() instead.")]]*/ static const ezMat4Template<Type> IdentityMatrix(); // [tested]
+  [[deprecated("Use ezMat4::MakeIdentity() instead.")]] static const ezMat4Template<Type> IdentityMatrix(); // [tested]
 
   /// \brief Returns a Zero Matrix.
-  /*[[deprecated("Use ezMat4::MakeZero() instead.")]]*/ static const ezMat4Template<Type> ZeroMatrix(); // [tested]
+  [[deprecated("Use ezMat4::MakeZero() instead.")]] static const ezMat4Template<Type> ZeroMatrix(); // [tested]
 
   /// \brief Transposes this matrix.
   void Transpose(); // [tested]

--- a/Code/Engine/Foundation/Math/Plane.h
+++ b/Code/Engine/Foundation/Math/Plane.h
@@ -37,17 +37,17 @@ public:
   ezPlaneTemplate(); // [tested]
 
   /// \brief Creates the plane-equation from a normal and a point on the plane.
-  /*[[deprecated("Use MakeFromNormalAndPoint() instead.")]]*/ ezPlaneTemplate(const ezVec3Template<Type>& vNormal, const ezVec3Template<Type>& vPointOnPlane); // [tested]
+  [[deprecated("Use MakeFromNormalAndPoint() instead.")]] ezPlaneTemplate(const ezVec3Template<Type>& vNormal, const ezVec3Template<Type>& vPointOnPlane); // [tested]
 
   /// \brief Creates the plane-equation from three points on the plane.
-  /*[[deprecated("Use MakeFromPoints() instead.")]]*/ ezPlaneTemplate(const ezVec3Template<Type>& v1, const ezVec3Template<Type>& v2, const ezVec3Template<Type>& v3); // [tested]
+  [[deprecated("Use MakeFromPoints() instead.")]] ezPlaneTemplate(const ezVec3Template<Type>& v1, const ezVec3Template<Type>& v2, const ezVec3Template<Type>& v3); // [tested]
 
   /// \brief Creates the plane-equation from three points on the plane, given as an array.
-  /*[[deprecated("Use SetFromPoints() instead.")]]*/ ezPlaneTemplate(const ezVec3Template<Type>* const pVertices); // [tested]
+  [[deprecated("Use SetFromPoints() instead.")]] ezPlaneTemplate(const ezVec3Template<Type>* const pVertices); // [tested]
 
   /// \brief Creates the plane-equation from a set of unreliable points lying on the same plane. Some points might be equal or too close to each other
   /// for the typical algorithm.
-  /*[[deprecated("Use SetFromPoints() instead.")]]*/ ezPlaneTemplate(const ezVec3Template<Type>* const pVertices, ezUInt32 uiMaxVertices); // [tested]
+  [[deprecated("Use SetFromPoints() instead.")]] ezPlaneTemplate(const ezVec3Template<Type>* const pVertices, ezUInt32 uiMaxVertices); // [tested]
 
   /// \brief Returns an invalid plane with a zero normal.
   [[nodiscard]] static ezPlaneTemplate<Type> MakeInvalid();
@@ -76,7 +76,7 @@ public:
   ezVec4Template<Type> GetAsVec4() const;
 
   /// \brief Creates the plane-equation from a normal and a point on the plane.
-  /*[[deprecated("Use MakeFromNormalAndPoint() instead.")]]*/ void SetFromNormalAndPoint(const ezVec3Template<Type>& vNormal, const ezVec3Template<Type>& vPointOnPlane); // [tested]
+  [[deprecated("Use MakeFromNormalAndPoint() instead.")]] void SetFromNormalAndPoint(const ezVec3Template<Type>& vNormal, const ezVec3Template<Type>& vPointOnPlane); // [tested]
 
   /// \brief Creates the plane-equation from three points on the plane.
   ezResult SetFromPoints(const ezVec3Template<Type>& v1, const ezVec3Template<Type>& v2, const ezVec3Template<Type>& v3); // [tested]
@@ -92,7 +92,7 @@ public:
   ezResult SetFromDirections(const ezVec3Template<Type>& vTangent1, const ezVec3Template<Type>& vTangent2, const ezVec3Template<Type>& vPointOnPlane); // [tested]
 
   /// \brief Sets the plane to an invalid state (all zero).
-  /*[[deprecated("Use MakeInvalid() instead.")]]*/ void SetInvalid(); // [tested]
+  [[deprecated("Use MakeInvalid() instead.")]] void SetInvalid(); // [tested]
 
   // *** Distance and Position ***
 public:

--- a/Code/Engine/Foundation/Math/Quat.h
+++ b/Code/Engine/Foundation/Math/Quat.h
@@ -47,7 +47,7 @@ public:
 
   /// \brief Static function that returns a quaternion that represents the identity rotation (none).
   [[nodiscard]] static const ezQuatTemplate<Type> MakeIdentity(); // [tested]
-  /*[[deprecated("Use ezQuat::MakeIdentity() instead.")]]*/ static const ezQuatTemplate<Type> IdentityQuaternion() { return ezQuatTemplate<Type>::MakeIdentity(); }
+  [[deprecated("Use ezQuat::MakeIdentity() instead.")]] static const ezQuatTemplate<Type> IdentityQuaternion() { return ezQuatTemplate<Type>::MakeIdentity(); }
 
   // *** Functions to create a quaternion ***
 public:
@@ -59,19 +59,19 @@ public:
   ///
   /// Use this function only if you have good understanding of quaternion math and know exactly what you are doing.
   [[nodiscard]] static ezQuatTemplate<Type> MakeFromElements(Type x, Type y, Type z, Type w); // [tested]
-  /*[[deprecated("Use ezQuat::MakeFromElements() instead.")]]*/ void SetElements(Type inX, Type inY, Type inZ, Type inW) { *this = MakeFromElements(inX, inY, inZ, inW); }
+  [[deprecated("Use ezQuat::MakeFromElements() instead.")]] void SetElements(Type inX, Type inY, Type inZ, Type inW) { *this = MakeFromElements(inX, inY, inZ, inW); }
 
   /// \brief Creates a quaternion from a rotation-axis and an angle.
   [[nodiscard]] static ezQuatTemplate<Type> MakeFromAxisAndAngle(const ezVec3Template<Type>& vRotationAxis, ezAngle angle); // [tested]
-  /*[[deprecated("Use ezQuat::MakeFromAxisAndAngle() instead.")]]*/ void SetFromAxisAndAngle(const ezVec3Template<Type>& vRotationAxis, ezAngle angle) { *this = MakeFromAxisAndAngle(vRotationAxis, angle); }
+  [[deprecated("Use ezQuat::MakeFromAxisAndAngle() instead.")]] void SetFromAxisAndAngle(const ezVec3Template<Type>& vRotationAxis, ezAngle angle) { *this = MakeFromAxisAndAngle(vRotationAxis, angle); }
 
   /// \brief Creates a quaternion, that rotates through the shortest arc from "vDirFrom" to "vDirTo".
   [[nodiscard]] static ezQuatTemplate<Type> MakeShortestRotation(const ezVec3Template<Type>& vDirFrom, const ezVec3Template<Type>& vDirTo); // [tested]
-  /*[[deprecated("Use ezQuat::MakeShortestRotation() instead.")]]*/ void SetShortestRotation(const ezVec3Template<Type>& vDirFrom, const ezVec3Template<Type>& vDirTo) { *this = MakeShortestRotation(vDirFrom, vDirTo); }
+  [[deprecated("Use ezQuat::MakeShortestRotation() instead.")]] void SetShortestRotation(const ezVec3Template<Type>& vDirFrom, const ezVec3Template<Type>& vDirTo) { *this = MakeShortestRotation(vDirFrom, vDirTo); }
 
   /// \brief Creates a quaternion from the given matrix.
   [[nodiscard]] static ezQuatTemplate<Type> MakeFromMat3(const ezMat3Template<Type>& m); // [tested]
-  /*[[deprecated("Use ezQuat::MakeFromMat3() instead.")]]*/ void SetFromMat3(const ezMat3Template<Type>& m) { *this = MakeFromMat3(m); }
+  [[deprecated("Use ezQuat::MakeFromMat3() instead.")]] void SetFromMat3(const ezMat3Template<Type>& m) { *this = MakeFromMat3(m); }
 
   /// \brief Reconstructs a rotation quaternion from a matrix that may contain scaling and mirroring.
   ///
@@ -88,7 +88,7 @@ public:
 
   /// \brief Returns a quaternion that is the spherical linear interpolation of the other two.
   [[nodiscard]] static ezQuatTemplate<Type> MakeSlerp(const ezQuatTemplate& qFrom, const ezQuatTemplate& qTo, Type t); // [tested]
-  /*[[deprecated("Use ezQuat::MakeSlerp() instead.")]]*/ void SetSlerp(const ezQuatTemplate& qFrom, const ezQuatTemplate& qTo, Type t) { *this = MakeSlerp(qFrom, qTo, t); }
+  [[deprecated("Use ezQuat::MakeSlerp() instead.")]] void SetSlerp(const ezQuatTemplate& qFrom, const ezQuatTemplate& qTo, Type t) { *this = MakeSlerp(qFrom, qTo, t); }
 
   // *** Common Functions ***
 public:
@@ -142,7 +142,7 @@ public:
 
   /// \brief Sets the quaternion from Euler angles
   [[nodiscard]] static ezQuatTemplate<Type> MakeFromEulerAngles(const ezAngle& x, const ezAngle& y, const ezAngle& z); // [tested]
-  /*[[deprecated("Use ezQuat::MakeFromEulerAngles() instead.")]]*/ void SetFromEulerAngles(const ezAngle& x, const ezAngle& y, const ezAngle& z) { *this = MakeFromEulerAngles(x, y, z); }
+  [[deprecated("Use ezQuat::MakeFromEulerAngles() instead.")]] void SetFromEulerAngles(const ezAngle& x, const ezAngle& y, const ezAngle& z) { *this = MakeFromEulerAngles(x, y, z); }
 };
 
 /// \brief Rotates v by q

--- a/Code/Engine/Foundation/Math/Rect.h
+++ b/Code/Engine/Foundation/Math/Rect.h
@@ -82,7 +82,7 @@ public:
   ///
   /// IsValid() will return false afterwards.
   /// It is possible to make an invalid rect valid using ExpandToInclude().
-  /*[[deprecated("Use MakeInvalid() instead.")]]*/ void SetInvalid();
+  [[deprecated("Use MakeInvalid() instead.")]] void SetInvalid();
 
   /// \brief Checks whether the position and size contain valid values.
   bool IsValid() const;
@@ -107,9 +107,9 @@ public:
   /// possible distance to the original point.
   [[nodiscard]] const ezVec2Template<Type> GetClampedPoint(const ezVec2Template<Type>& vPoint) const;
 
-  /*[[deprecated("Use MakeIntersection() instead.")]]*/ void SetIntersection(const ezRectTemplate<Type>& r0, const ezRectTemplate<Type>& r1);
+  [[deprecated("Use MakeIntersection() instead.")]] void SetIntersection(const ezRectTemplate<Type>& r0, const ezRectTemplate<Type>& r1);
 
-  /*[[deprecated("Use MakeUnion() instead.")]]*/ void SetUnion(const ezRectTemplate<Type>& r0, const ezRectTemplate<Type>& r1);
+  [[deprecated("Use MakeUnion() instead.")]] void SetUnion(const ezRectTemplate<Type>& r0, const ezRectTemplate<Type>& r1);
 
   /// \brief Moves the rectangle
   void Translate(Type tX, Type tY);

--- a/Code/Engine/Foundation/Math/Transform.h
+++ b/Code/Engine/Foundation/Math/Transform.h
@@ -68,13 +68,13 @@ public:
   [[nodiscard]] static ezTransformTemplate<Type> MakeGlobalTransform(const ezTransformTemplate& globalTransformParent, const ezTransformTemplate& localTransformChild); // [tested]
 
   /// \brief Attempts to extract position, scale and rotation from the matrix. Negative scaling and shearing will get lost in the process.
-  /*[[deprecated("Use MakeFromMat4() instead.")]]*/ void SetFromMat4(const ezMat4Template<Type>& mMat);
+  [[deprecated("Use MakeFromMat4() instead.")]] void SetFromMat4(const ezMat4Template<Type>& mMat);
 
   /// \brief Sets the position to be zero and the rotation to identity.
   void SetIdentity(); // [tested]
 
   /// \brief Returns an Identity Transform.
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ [[nodiscard]] static const ezTransformTemplate<Type> IdentityTransform();
+  [[deprecated("Use MakeIdentity() instead.")]] [[nodiscard]] static const ezTransformTemplate<Type> IdentityTransform();
 
   /// \brief Returns the scale component with maximum magnitude.
   Type GetMaxScale() const;
@@ -110,10 +110,10 @@ public:
   // *** Conversion operations ***
 public:
   /// \brief Sets this transform to be the local transformation needed to get from the parent's transform to the child's.
-  /*[[deprecated("Use MakeLocalTransform() instead.")]]*/ void SetLocalTransform(const ezTransformTemplate& globalTransformParent, const ezTransformTemplate& globalTransformChild); // [tested]
+  [[deprecated("Use MakeLocalTransform() instead.")]] void SetLocalTransform(const ezTransformTemplate& globalTransformParent, const ezTransformTemplate& globalTransformChild); // [tested]
 
   /// \brief Sets this transform to the global transform, that is reached by applying the child's local transform to the parent's global one.
-  /*[[deprecated("Use MakeGlobalTransform() instead.")]]*/ void SetGlobalTransform(const ezTransformTemplate& globalTransformParent, const ezTransformTemplate& localTransformChild); // [tested]
+  [[deprecated("Use MakeGlobalTransform() instead.")]] void SetGlobalTransform(const ezTransformTemplate& globalTransformParent, const ezTransformTemplate& localTransformChild); // [tested]
 
   /// \brief Returns the transformation as a matrix.
   const ezMat4Template<Type> GetAsMat4() const; // [tested]

--- a/Code/Engine/Foundation/Math/Vec2.h
+++ b/Code/Engine/Foundation/Math/Vec2.h
@@ -42,7 +42,7 @@ public:
 
   /// \brief Static function that returns a zero-vector.
   [[nodiscard]] static const ezVec2Template<Type> MakeZero() { return ezVec2Template(0); } // [tested]
-  /*[[deprecated("Use ezVec2::MakeZero() instead.")]]*/ static const ezVec2Template<Type> ZeroVector() { return ezVec2Template(0); }
+  [[deprecated("Use ezVec2::MakeZero() instead.")]] static const ezVec2Template<Type> ZeroVector() { return ezVec2Template(0); }
 
 #if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
   void AssertNotNaN() const

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -35,19 +35,19 @@ public:
 
   /// \brief Returns a vector with all components set to zero.
   [[nodiscard]] static ezVec3Template<Type> MakeZero() { return ezVec3Template<Type>(0); } // [tested]
-  /*[[deprecated("Use ezVec3::MakeZero() instead.")]]*/ static ezVec3Template<Type> ZeroVector() { return ezVec3Template<Type>(0); }
+  [[deprecated("Use ezVec3::MakeZero() instead.")]] static ezVec3Template<Type> ZeroVector() { return ezVec3Template<Type>(0); }
 
   /// \brief Returns a vector initialized to the X unit vector (1, 0, 0).
   [[nodiscard]] static ezVec3Template<Type> MakeAxisX() { return ezVec3Template<Type>(1, 0, 0); } // [tested]
-  /*[[deprecated("Use ezVec3::MakeAxisX() instead.")]]*/ static const ezVec3Template<Type> UnitXAxis() { return ezVec3Template(1, 0, 0); }
+  [[deprecated("Use ezVec3::MakeAxisX() instead.")]] static const ezVec3Template<Type> UnitXAxis() { return ezVec3Template(1, 0, 0); }
 
   /// \brief Returns a vector initialized to the Y unit vector (0, 1, 0).
   [[nodiscard]] static ezVec3Template<Type> MakeAxisY() { return ezVec3Template<Type>(0, 1, 0); } // [tested]
-  /*[[deprecated("Use ezVec3::MakeAxisY() instead.")]]*/ static const ezVec3Template<Type> UnitYAxis() { return ezVec3Template(0, 1, 0); }
+  [[deprecated("Use ezVec3::MakeAxisY() instead.")]] static const ezVec3Template<Type> UnitYAxis() { return ezVec3Template(0, 1, 0); }
 
   /// \brief Returns a vector initialized to the Z unit vector (0, 0, 1).
   [[nodiscard]] static ezVec3Template<Type> MakeAxisZ() { return ezVec3Template<Type>(0, 0, 1); } // [tested]
-  /*[[deprecated("Use ezVec3::MakeAxisZ() instead.")]]*/ static const ezVec3Template<Type> UnitZAxis() { return ezVec3Template(0, 0, 1); }
+  [[deprecated("Use ezVec3::MakeAxisZ() instead.")]] static const ezVec3Template<Type> UnitZAxis() { return ezVec3Template(0, 0, 1); }
 
 #if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
   void AssertNotNaN() const
@@ -216,32 +216,32 @@ public:
 
   /// \brief Returns a random point inside a unit sphere (radius 1).
   [[nodiscard]] static ezVec3Template<Type> MakeRandomPointInSphere(ezRandom& inout_rng);                                                          // [tested]
-  /*[[deprecated("Use ezVec3::MakeRandomPointInSphere() instead.")]]*/ static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomPointInSphere() instead.")]] static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng); // [tested]
 
   /// \brief Creates a random direction vector. The vector is normalized.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDirection(ezRandom& inout_rng);                                                      // [tested]
-  /*[[deprecated("Use ezVec3::MakeRandomDirection() instead.")]]*/ static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDirection() instead.")]] static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng); // [tested]
 
   /// \brief Creates a random vector around the x axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation);                                                       // [tested]
-  /*[[deprecated("Use ezVec3::MakeRandomDeviationX() instead.")]]*/ static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviationX() instead.")]] static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
 
   /// \brief Creates a random vector around the y axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation);                                                       // [tested]
-  /*[[deprecated("Use ezVec3::MakeRandomDeviationY() instead.")]]*/ static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviationY() instead.")]] static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
 
   /// \brief Creates a random vector around the z axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation);                                                       // [tested]
-  /*[[deprecated("Use ezVec3::MakeRandomDeviationZ() instead.")]]*/ static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviationZ() instead.")]] static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
 
   /// \brief Creates a random vector around the given normal with a maximum deviation.
   /// \note If you are going to do this many times with the same axis, rather than calling this function, instead manually
   /// do what this function does (see inline code) and only compute the quaternion once.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal);                                                      // [tested]
-  /*[[deprecated("Use ezVec3::MakeRandomDeviation() instead.")]]*/ static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviation() instead.")]] static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
 };
 
 // *** Operators ***

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -216,32 +216,32 @@ public:
 
   /// \brief Returns a random point inside a unit sphere (radius 1).
   [[nodiscard]] static ezVec3Template<Type> MakeRandomPointInSphere(ezRandom& inout_rng);                                                          // [tested]
-  [[deprecated("Use ezVec3::MakeRandomPointInSphere() instead.")]] static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomPointInSphere() instead.")]] static ezVec3Template<Type> CreateRandomPointInSphere(ezRandom& inout_rng);     // [tested]
 
   /// \brief Creates a random direction vector. The vector is normalized.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDirection(ezRandom& inout_rng);                                                      // [tested]
-  [[deprecated("Use ezVec3::MakeRandomDirection() instead.")]] static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDirection() instead.")]] static ezVec3Template<Type> CreateRandomDirection(ezRandom& inout_rng);     // [tested]
 
   /// \brief Creates a random vector around the x axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation);                                                       // [tested]
-  [[deprecated("Use ezVec3::MakeRandomDeviationX() instead.")]] static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviationX() instead.")]] static ezVec3Template<Type> CreateRandomDeviationX(ezRandom& inout_rng, const ezAngle& maxDeviation);     // [tested]
 
   /// \brief Creates a random vector around the y axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation);                                                       // [tested]
-  [[deprecated("Use ezVec3::MakeRandomDeviationY() instead.")]] static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviationY() instead.")]] static ezVec3Template<Type> CreateRandomDeviationY(ezRandom& inout_rng, const ezAngle& maxDeviation);     // [tested]
 
   /// \brief Creates a random vector around the z axis with a maximum deviation angle of \a maxDeviation. The vector is normalized.
   /// The deviation angle must be larger than zero.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation);                                                       // [tested]
-  [[deprecated("Use ezVec3::MakeRandomDeviationZ() instead.")]] static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviationZ() instead.")]] static ezVec3Template<Type> CreateRandomDeviationZ(ezRandom& inout_rng, const ezAngle& maxDeviation);     // [tested]
 
   /// \brief Creates a random vector around the given normal with a maximum deviation.
   /// \note If you are going to do this many times with the same axis, rather than calling this function, instead manually
   /// do what this function does (see inline code) and only compute the quaternion once.
   [[nodiscard]] static ezVec3Template<Type> MakeRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal);                                                      // [tested]
-  [[deprecated("Use ezVec3::MakeRandomDeviation() instead.")]] static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal); // [tested]
+  [[deprecated("Use ezVec3::MakeRandomDeviation() instead.")]] static ezVec3Template<Type> CreateRandomDeviation(ezRandom& inout_rng, const ezAngle& maxDeviation, const ezVec3Template<Type>& vNormal);     // [tested]
 };
 
 // *** Operators ***

--- a/Code/Engine/Foundation/Math/Vec4.h
+++ b/Code/Engine/Foundation/Math/Vec4.h
@@ -34,7 +34,7 @@ public:
 
   /// \brief Returns a vector with all components set to zero.
   [[nodiscard]] static ezVec4Template<Type> MakeZero() { return ezVec4Template<Type>(0); } // [tested]
-  /*[[deprecated("Use ezVec4::MakeZero() instead.")]]*/ static ezVec4Template<Type> ZeroVector() { return ezVec4Template<Type>(0); }
+  [[deprecated("Use ezVec4::MakeZero() instead.")]] static ezVec4Template<Type> ZeroVector() { return ezVec4Template<Type>(0); }
 
 #if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
   void AssertNotNaN() const

--- a/Code/Engine/Foundation/SimdMath/Implementation/SimdMat4f_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/SimdMat4f_inl.h
@@ -4,7 +4,10 @@ EZ_ALWAYS_INLINE ezSimdMat4f::ezSimdMat4f() = default;
 
 EZ_ALWAYS_INLINE ezSimdMat4f::ezSimdMat4f(const float* const pData, ezMatrixLayout::Enum layout)
 {
-  SetFromArray(pData, layout);
+  if (layout == ezMatrixLayout::ColumnMajor)
+    *this = MakeFromColumnMajorArray(pData);
+  else
+    *this = MakeFromRowMajorArray(pData);
 }
 
 EZ_ALWAYS_INLINE ezSimdMat4f::ezSimdMat4f(const ezSimdVec4f& vCol0, const ezSimdVec4f& vCol1, const ezSimdVec4f& vCol2, const ezSimdVec4f& vCol3)

--- a/Code/Engine/Foundation/SimdMath/SimdFloat.h
+++ b/Code/Engine/Foundation/SimdMath/SimdFloat.h
@@ -29,7 +29,7 @@ public:
   /// \brief Returns the stored number as a standard float.
   operator float() const; // [tested]
 
-  /*[[deprecated("Use MakeZero() instead.")]]*/ [[nodiscard]] static ezSimdFloat Zero(); // [tested]
+  [[deprecated("Use MakeZero() instead.")]] [[nodiscard]] static ezSimdFloat Zero(); // [tested]
 
   /// \brief Creates an ezSimdFloat that is initialized to zero.
   [[nodiscard]] static ezSimdFloat MakeZero(); // [tested]

--- a/Code/Engine/Foundation/SimdMath/SimdMat4f.h
+++ b/Code/Engine/Foundation/SimdMath/SimdMat4f.h
@@ -10,12 +10,12 @@ public:
 
   ezSimdMat4f();
 
-  /*[[deprecated("Use MakeFromColumnMajorArray() instead.")]]*/ ezSimdMat4f(const float* const pData, ezMatrixLayout::Enum layout); // [tested]
+  [[deprecated("Use MakeFromColumnMajorArray() instead.")]] ezSimdMat4f(const float* const pData, ezMatrixLayout::Enum layout); // [tested]
 
-  /*[[deprecated("Use MakeFromColumns() instead.")]]*/ ezSimdMat4f(const ezSimdVec4f& vCol0, const ezSimdVec4f& vCol1, const ezSimdVec4f& vCol2, const ezSimdVec4f& vCol3); // [tested]
+  [[deprecated("Use MakeFromColumns() instead.")]] ezSimdMat4f(const ezSimdVec4f& vCol0, const ezSimdVec4f& vCol1, const ezSimdVec4f& vCol2, const ezSimdVec4f& vCol3); // [tested]
 
   /// \brief Sets each element manually: Naming is "column-n row-m"
-  /*[[deprecated("Use MakeFromValues() instead.")]]*/ ezSimdMat4f(float f1r1, float f2r1, float f3r1, float f4r1, float f1r2, float f2r2, float f3r2, float f4r2, float f1r3, float f2r3, float f3r3,
+  [[deprecated("Use MakeFromValues() instead.")]] ezSimdMat4f(float f1r1, float f2r1, float f3r1, float f4r1, float f1r2, float f2r2, float f3r2, float f4r2, float f1r3, float f2r3, float f3r3,
     float f4r3, float f1r4, float f2r4, float f3r4, float f4r4); // [tested]
 
   /// \brief Returns a zero matrix.
@@ -36,21 +36,21 @@ public:
   /// \brief Creates a matrix from 16 values. Naming is "column-n row-m"
   [[nodiscard]] static ezSimdMat4f MakeFromValues(float f1r1, float f2r1, float f3r1, float f4r1, float f1r2, float f2r2, float f3r2, float f4r2, float f1r3, float f2r3, float f3r3, float f4r3, float f1r4, float f2r4, float f3r4, float f4r4);
 
-  /*[[deprecated("Use MakeFromColumnMajorArray() instead.")]]*/ void SetFromArray(const float* const pData, ezMatrixLayout::Enum layout); // [tested]
+  [[deprecated("Use MakeFromColumnMajorArray() instead.")]] void SetFromArray(const float* const pData, ezMatrixLayout::Enum layout); // [tested]
 
   void GetAsArray(float* out_pData, ezMatrixLayout::Enum layout) const; // [tested]
 
   /// \brief Sets all elements to zero, except the diagonal, which is set to one.
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ void SetIdentity(); // [tested]
+  void SetIdentity(); // [tested]
 
   /// \brief Sets all elements to zero.
-  /*[[deprecated("Use MakeZero() instead.")]]*/ void SetZero(); // [tested]
+  void SetZero(); // [tested]
 
   /// \brief Returns an Identity Matrix.
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ [[nodiscard]] static ezSimdMat4f IdentityMatrix(); // [tested]
+  [[deprecated("Use MakeIdentity() instead.")]] [[nodiscard]] static ezSimdMat4f IdentityMatrix(); // [tested]
 
   /// \brief Returns a Matrix where all elements are zero.
-  /*[[deprecated("Use MakeZero() instead.")]]*/ [[nodiscard]] static ezSimdMat4f ZeroMatrix(); // [tested]
+  [[deprecated("Use MakeZero() instead.")]] [[nodiscard]] static ezSimdMat4f ZeroMatrix(); // [tested]
 
 public:
   /// \brief Transposes this matrix.

--- a/Code/Engine/Foundation/SimdMath/SimdQuat.h
+++ b/Code/Engine/Foundation/SimdMath/SimdQuat.h
@@ -30,20 +30,20 @@ public:
   [[nodiscard]] static ezSimdQuat MakeSlerp(const ezSimdQuat& qFrom, const ezSimdQuat& qTo, const ezSimdFloat& t); // [tested]
 
   /// \brief Static function that returns a quaternion that represents the identity rotation (none).
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ static ezSimdQuat IdentityQuaternion(); // [tested]
+  [[deprecated("Use MakeIdentity() instead.")]] static ezSimdQuat IdentityQuaternion(); // [tested]
 
 public:
   /// \brief Sets the Quaternion to the identity.
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ void SetIdentity(); // [tested]
+  void SetIdentity(); // [tested]
 
   /// \brief Creates a quaternion from a rotation-axis and an angle (angle is given in Radians or as an ezAngle)
-  /*[[deprecated("Use MakeFromAxisAndAngle() instead.")]]*/ void SetFromAxisAndAngle(const ezSimdVec4f& vRotationAxis, const ezSimdFloat& fAngle); // [tested]
+  [[deprecated("Use MakeFromAxisAndAngle() instead.")]] void SetFromAxisAndAngle(const ezSimdVec4f& vRotationAxis, const ezSimdFloat& fAngle); // [tested]
 
   /// \brief Creates a quaternion, that rotates through the shortest arc from "vDirFrom" to "vDirTo".
-  /*[[deprecated("Use MakeShortestRotation() instead.")]]*/ void SetShortestRotation(const ezSimdVec4f& vDirFrom, const ezSimdVec4f& vDirTo); // [tested]
+  [[deprecated("Use MakeShortestRotation() instead.")]] void SetShortestRotation(const ezSimdVec4f& vDirFrom, const ezSimdVec4f& vDirTo); // [tested]
 
   /// \brief Sets this quaternion to be the spherical linear interpolation of the other two.
-  /*[[deprecated("Use MakeSlerp() instead.")]]*/ void SetSlerp(const ezSimdQuat& qFrom, const ezSimdQuat& qTo, const ezSimdFloat& t); // [tested]
+  [[deprecated("Use MakeSlerp() instead.")]] void SetSlerp(const ezSimdQuat& qFrom, const ezSimdQuat& qTo, const ezSimdFloat& t); // [tested]
 
 public:
   /// \brief Normalizes the quaternion to unit length. ALL rotation-quaternions should be normalized at all times (automatically).

--- a/Code/Engine/Foundation/SimdMath/SimdTransform.h
+++ b/Code/Engine/Foundation/SimdMath/SimdTransform.h
@@ -29,10 +29,10 @@ public:
   [[nodiscard]] static ezSimdTransform MakeGlobalTransform(const ezSimdTransform& globalTransformParent, const ezSimdTransform& localTransformChild); // [tested]
 
   /// \brief Sets the position to be zero and the rotation to identity.
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ void SetIdentity(); // [tested]
+  void SetIdentity(); // [tested]
 
   /// \brief Returns an Identity Transform.
-  /*[[deprecated("Use MakeIdentity() instead.")]]*/ static ezSimdTransform IdentityTransform(); // [tested]
+  [[deprecated("Use MakeIdentity() instead.")]] static ezSimdTransform IdentityTransform(); // [tested]
 
   /// \brief Returns the scale component with maximum magnitude.
   ezSimdFloat GetMaxScale() const; // [tested]
@@ -56,11 +56,11 @@ public:
 
 public:
   /// \brief Sets this transform to be the local transformation needed to get from the parent's transform to the child's.
-  /*[[deprecated("Use MakeLocalTransform() instead.")]]*/ void SetLocalTransform(const ezSimdTransform& globalTransformParent, const ezSimdTransform& globalTransformChild); // [tested]
+  [[deprecated("Use MakeLocalTransform() instead.")]] void SetLocalTransform(const ezSimdTransform& globalTransformParent, const ezSimdTransform& globalTransformChild); // [tested]
 
   /// \brief Sets this transform to the global transform, that is reached by applying the child's local transform to the parent's global
   /// one.
-  /*[[deprecated("Use MakeGlobalTransform() instead.")]]*/ void SetGlobalTransform(const ezSimdTransform& globalTransformParent, const ezSimdTransform& localTransformChild); // [tested]
+  [[deprecated("Use MakeGlobalTransform() instead.")]] void SetGlobalTransform(const ezSimdTransform& globalTransformParent, const ezSimdTransform& localTransformChild); // [tested]
 
   /// \brief Returns the transformation as a matrix.
   ezSimdMat4f GetAsMat4() const; // [tested]

--- a/Code/Engine/Foundation/SimdMath/SimdVec4f.h
+++ b/Code/Engine/Foundation/SimdMath/SimdVec4f.h
@@ -168,7 +168,7 @@ public:
   ///\brief Generates an arbitrary vector such that Dot<3>(GetOrthogonalVector()) == 0
   [[nodiscard]] ezSimdVec4f GetOrthogonalVector() const; // [tested]
 
-  /*[[deprecated("Use MakeZero() instead.")]]*/ [[nodiscard]] static ezSimdVec4f ZeroVector(); // [tested]
+  [[deprecated("Use MakeZero() instead.")]] [[nodiscard]] static ezSimdVec4f ZeroVector(); // [tested]
 
   [[nodiscard]] static ezSimdVec4f MulAdd(const ezSimdVec4f& a, const ezSimdVec4f& b, const ezSimdVec4f& c); // [tested]
   [[nodiscard]] static ezSimdVec4f MulAdd(const ezSimdVec4f& a, const ezSimdFloat& b, const ezSimdVec4f& c); // [tested]

--- a/Code/Engine/Foundation/SimdMath/SimdVec4i.h
+++ b/Code/Engine/Foundation/SimdMath/SimdVec4i.h
@@ -92,7 +92,7 @@ public:
   [[nodiscard]] ezSimdVec4b operator>=(const ezSimdVec4i& v) const; // [tested]
   [[nodiscard]] ezSimdVec4b operator>(const ezSimdVec4i& v) const;  // [tested]
 
-  /*[[deprecated("Use MakeZero() instead.")]]*/ [[nodiscard]] static ezSimdVec4i ZeroVector(); // [tested]
+  [[deprecated("Use MakeZero() instead.")]] [[nodiscard]] static ezSimdVec4i ZeroVector(); // [tested]
 
   [[nodiscard]] static ezSimdVec4i Select(const ezSimdVec4b& vCmp, const ezSimdVec4i& vTrue, const ezSimdVec4i& vFalse); // [tested]
 

--- a/Code/Engine/Foundation/SimdMath/SimdVec4u.h
+++ b/Code/Engine/Foundation/SimdMath/SimdVec4u.h
@@ -79,7 +79,7 @@ public:
   ezSimdVec4b operator>=(const ezSimdVec4u& v) const; // [tested]
   ezSimdVec4b operator>(const ezSimdVec4u& v) const;  // [tested]
 
-  /*[[deprecated("Use MakeZero() instead.")]]*/ [[nodiscard]] static ezSimdVec4u ZeroVector(); // [tested]
+  [[deprecated("Use MakeZero() instead.")]] [[nodiscard]] static ezSimdVec4u ZeroVector(); // [tested]
 
 public:
   ezInternal::QuadUInt m_v;

--- a/Code/Engine/Foundation/Time/Implementation/Timestamp_inl.h
+++ b/Code/Engine/Foundation/Time/Implementation/Timestamp_inl.h
@@ -7,7 +7,7 @@ inline ezTimestamp::ezTimestamp() = default;
 
 inline ezTimestamp::ezTimestamp(ezInt64 iTimeValue, ezSIUnitOfTime::Enum unitOfTime)
 {
-  SetInt64(iTimeValue, unitOfTime);
+  *this = MakeFromInt(iTimeValue, unitOfTime);
 }
 
 inline void ezTimestamp::Invalidate()

--- a/Code/Engine/Foundation/Time/Time.h
+++ b/Code/Engine/Foundation/Time/Time.h
@@ -40,7 +40,7 @@ public:
 
   /// \brief Creates an instance of ezTime that was initialized with zero.
   [[nodiscard]] EZ_ALWAYS_INLINE constexpr static ezTime MakeZero() { return ezTime(0.0); }
-  [[nodiscard]] /*[[deprecated("Use ezTime::MakeZero() instead.")]]*/ EZ_ALWAYS_INLINE constexpr static ezTime Zero() { return ezTime(0.0); }
+  [[nodiscard]] [[deprecated("Use ezTime::MakeZero() instead.")]] EZ_ALWAYS_INLINE constexpr static ezTime Zero() { return ezTime(0.0); }
 
   EZ_DECLARE_POD_TYPE();
 
@@ -48,7 +48,7 @@ public:
   EZ_ALWAYS_INLINE constexpr ezTime() = default;
 
   /// \brief Sets the time value to zero.
-  /*[[deprecated("Use ezTime::MakeZero() instead.")]]*/ void SetZero();
+  [[deprecated("Use ezTime::MakeZero() instead.")]] void SetZero();
 
   /// \brief Returns true if the stored time is exactly zero. That typically means the value was not changed from the default.
   EZ_ALWAYS_INLINE constexpr bool IsZero() const { return m_fTime == 0.0; }

--- a/Code/Engine/Foundation/Time/Timestamp.h
+++ b/Code/Engine/Foundation/Time/Timestamp.h
@@ -44,7 +44,7 @@ public:
   ezTimestamp(); // [tested]
 
   /// \brief Creates an new timestamp with the given time in the given unit of time since Unix epoch.
-  /*[[deprecated("Use ezTimestamp::MakeFromInt() instead.")]]*/ ezTimestamp(ezInt64 iTimeValue, ezSIUnitOfTime::Enum unitOfTime); // [tested]
+  [[deprecated("Use ezTimestamp::MakeFromInt() instead.")]] ezTimestamp(ezInt64 iTimeValue, ezSIUnitOfTime::Enum unitOfTime); // [tested]
 
   /// \brief Returns an invalid timestamp
   [[nodiscard]] static ezTimestamp MakeInvalid() { return ezTimestamp(); }
@@ -55,7 +55,7 @@ public:
   // *** Public Functions ***
 public:
   /// \brief Invalidates the timestamp.
-  /*[[deprecated("Use ezTimestamp::MakeInvalid() instead.")]]*/ void Invalidate(); // [tested]
+  [[deprecated("Use ezTimestamp::MakeInvalid() instead.")]] void Invalidate(); // [tested]
 
   /// \brief Returns whether the timestamp is valid.
   bool IsValid() const; // [tested]
@@ -64,7 +64,7 @@ public:
   ezInt64 GetInt64(ezSIUnitOfTime::Enum unitOfTime) const; // [tested]
 
   /// \brief Sets the timestamp as 'iTimeValue' in 'unitOfTime' since Unix epoch.
-  /*[[deprecated("Use ezTimestamp::MakeFromInt() instead.")]]*/ void SetInt64(ezInt64 iTimeValue, ezSIUnitOfTime::Enum unitOfTime) { *this = MakeFromInt(iTimeValue, unitOfTime); }
+  [[deprecated("Use ezTimestamp::MakeFromInt() instead.")]] void SetInt64(ezInt64 iTimeValue, ezSIUnitOfTime::Enum unitOfTime) { *this = MakeFromInt(iTimeValue, unitOfTime); }
 
   /// \brief Returns whether this timestamp is considered equal to 'rhs' in the given mode.
   ///
@@ -124,7 +124,7 @@ public:
   [[nodiscard]] static ezDateTime MakeZero() { return ezDateTime(); }
 
   /// \brief Creates a date time instance from the given timestamp.
-  /*[[deprecated("Use MakeFromTimestamp() instead.")]]*/ ezDateTime(ezTimestamp timestamp); // [tested]
+  [[deprecated("Use MakeFromTimestamp() instead.")]] ezDateTime(ezTimestamp timestamp); // [tested]
 
   /// \brief Sets this instance to the given timestamp.
   ///

--- a/Code/Engine/Foundation/Types/Uuid.h
+++ b/Code/Engine/Foundation/Types/Uuid.h
@@ -36,14 +36,14 @@ public:
 
   /// \brief Returns an invalid UUID.
   [[nodiscard]] EZ_ALWAYS_INLINE static ezUuid MakeInvalid() { return ezUuid(0, 0); }
-  /*[[deprecated("Use ezUuid::MakeInvalid() instead.")]]*/ EZ_ALWAYS_INLINE void SetInvalid();
+  [[deprecated("Use ezUuid::MakeInvalid() instead.")]] EZ_ALWAYS_INLINE void SetInvalid();
 
   /// \brief Creates a new Uuid and stores is it in this object.
-  /*[[deprecated("Use ezUuid::MakeUuid() instead.")]]*/ void CreateNewUuid() { *this = MakeUuid(); }
+  [[deprecated("Use ezUuid::MakeUuid() instead.")]] void CreateNewUuid() { *this = MakeUuid(); }
 
   /// \brief Returns a new Uuid.
   [[nodiscard]] static ezUuid MakeUuid();
-  [[nodiscard]] /*[[deprecated("Use ezUuid::MakeUuid() instead.")]]*/ EZ_ALWAYS_INLINE static ezUuid CreateUuid() { return MakeUuid(); }
+  [[nodiscard]] [[deprecated("Use ezUuid::MakeUuid() instead.")]] EZ_ALWAYS_INLINE static ezUuid CreateUuid() { return MakeUuid(); }
 
   /// \brief Returns the internal 128 Bit of data
   void GetValues(ezUInt64& ref_uiLow, ezUInt64& ref_uiHigh) const
@@ -54,11 +54,11 @@ public:
 
   /// \brief Creates a uuid from a string. The result is always the same for the same string.
   [[nodiscard]] static ezUuid MakeStableUuidFromString(ezStringView sString);
-  [[nodiscard]] /*[[deprecated("Use ezUuid::MakeStableUuidFromString() instead.")]]*/ static ezUuid StableUuidForString(ezStringView sString) { return MakeStableUuidFromString(sString); }
+  [[nodiscard]] [[deprecated("Use ezUuid::MakeStableUuidFromString() instead.")]] static ezUuid StableUuidForString(ezStringView sString) { return MakeStableUuidFromString(sString); }
 
   /// \brief Creates a uuid from an integer. The result is always the same for the same input.
   [[nodiscard]] static ezUuid MakeStableUuidFromInt(ezInt64 iInt);
-  [[nodiscard]] /*[[deprecated("Use ezUuid::MakeStableUuidFromInt() instead.")]]*/ static ezUuid StableUuidForInt(ezInt64 iInt) { return MakeStableUuidFromInt(iInt); }
+  [[nodiscard]] [[deprecated("Use ezUuid::MakeStableUuidFromInt() instead.")]] static ezUuid StableUuidForInt(ezInt64 iInt) { return MakeStableUuidFromInt(iInt); }
 
   /// \brief Adds the given seed value to this guid, creating a new guid. The process is reversible.
   EZ_ALWAYS_INLINE void CombineWithSeed(const ezUuid& seed);


### PR DESCRIPTION
The deprecation warning tells you what to use instead.

To make this not break everyone's build right away, "warnings as errors" has been disabled by default. Also the deprecation warning has been activated, so that these issues now show up during compilation.

Please fix your code very soon, as these functions will be removed in the near future.