### PR TITLE
Asset Curator fixes for external file operations

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -124,6 +124,7 @@ struct ezAssetCuratorEvent
   {
     AssetAdded,
     AssetRemoved,
+    AssetMoved,
     AssetUpdated,
     AssetListReset,
     ActivePlatformChanged,

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -14,10 +14,13 @@ class ezAssetFileHeader;
 
 struct ezAssetExistanceState
 {
+  using StorageType = ezUInt8;
+
   enum Enum : ezUInt8
   {
     FileAdded,
     FileRemoved,
+    FileMoved,
     FileModified,
     FileUnchanged,
   };

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetTableWriter.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetTableWriter.cpp
@@ -276,6 +276,7 @@ void ezAssetTableWriter::AssetCuratorEvents(const ezAssetCuratorEvent& e)
         return;
       [[fallthrough]];*/
     case ezAssetCuratorEvent::Type::AssetAdded:
+    case ezAssetCuratorEvent::Type::AssetMoved:
     {
       ezUInt32 uiDataDirIndex = FindDataDir(*e.m_pInfo);
       if (ezAssetTable* pTable = GetAssetTable(uiDataDirIndex, pProfile))

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -239,11 +239,7 @@ ezResult ezAssetCurator::EnsureAssetInfoUpdated(ezStringView sAbsFilePath, const
   UpdateSubAssets(*pCurrentAssetInfo);
 
   InvalidateAssetTransformState(newGuid);
-  if (pFiles->LinkDocument(sAbsFilePath, pCurrentAssetInfo->m_Info->m_DocumentID).Failed())
-  {
-    // #TODO_ASSET
-    ezLog::Error("Failed to link asset: {}", sAbsFilePath);
-  }
+  pFiles->LinkDocument(sAbsFilePath, pCurrentAssetInfo->m_Info->m_DocumentID).AssertSuccess("Failed to link document in file system model");
   return EZ_SUCCESS;
 }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -448,8 +448,8 @@ ezResult ezAssetCurator::ReadAssetDocumentInfo(ezStringView sAbsFilePath, const 
   // try to read the asset file
   ezStatus infoStatus;
   ezResult res = pFiles->ReadDocument(sAbsFilePath, [&out_assetInfo, &infoStatus](const ezFileStatus& stat, ezStreamReader& ref_reader) {
-      infoStatus = out_assetInfo->GetManager()->ReadAssetDocumentInfo(out_assetInfo->m_Info, ref_reader);
-   });
+    infoStatus = out_assetInfo->GetManager()->ReadAssetDocumentInfo(out_assetInfo->m_Info, ref_reader);
+  });
 
   if (infoStatus.Failed())
   {

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -395,6 +395,22 @@ void ezQtContainerWindow::AddDocumentWindow(ezQtDocumentWindow* pDocWindow)
   QMetaObject::invokeMethod(this, "SlotUpdateWindowDecoration", Qt::ConnectionType::QueuedConnection, Q_ARG(void*, pDocWindow));
 }
 
+void ezQtContainerWindow::DocumentWindowRenamed(ezQtDocumentWindow* pDocWindow)
+{
+  const ezUInt32 uiListIndex = m_DocumentWindows.IndexOf(pDocWindow);
+  if (uiListIndex == ezInvalidIndex)
+    return;
+
+  ads::CDockWidget* dock = m_DocumentDocks[uiListIndex];
+  EZ_ASSERT_DEV(m_DockNames.contains(dock->objectName()), "Object name must not change during lifetime.");
+  m_DockNames.remove(dock->objectName());
+
+  dock->setObjectName(pDocWindow->GetUniqueName());
+  EZ_ASSERT_DEV(!dock->objectName().isEmpty(), "Dock name must not be empty.");
+  EZ_ASSERT_DEV(!m_DockNames.contains(dock->objectName()), "Dock name must be unique.");
+  m_DockNames.insert(dock->objectName());
+}
+
 void ezQtContainerWindow::AddApplicationPanel(ezQtApplicationPanel* pPanel)
 {
   // panel already in container window ?
@@ -515,7 +531,8 @@ void ezQtContainerWindow::SlotDocumentTabCloseRequested()
   if (!pDocWindow->CanCloseWindow())
   {
     // TODO: There is no CloseRequested event so we just reopen on a timer.
-    QTimer::singleShot(1, [dock]() { dock->toggleView(); });
+    QTimer::singleShot(1, [dock]()
+      { dock->toggleView(); });
     return;
   }
   pDocWindow->CloseDocumentWindow();

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -531,8 +531,7 @@ void ezQtContainerWindow::SlotDocumentTabCloseRequested()
   if (!pDocWindow->CanCloseWindow())
   {
     // TODO: There is no CloseRequested event so we just reopen on a timer.
-    QTimer::singleShot(1, [dock]()
-      { dock->toggleView(); });
+    QTimer::singleShot(1, [dock]() { dock->toggleView(); });
     return;
   }
   pDocWindow->CloseDocumentWindow();

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.moc.h
@@ -36,6 +36,7 @@ public:
   static ezQtContainerWindow* GetContainerWindow() { return s_pContainerWindow; }
 
   void AddDocumentWindow(ezQtDocumentWindow* pDocWindow);
+  void DocumentWindowRenamed(ezQtDocumentWindow* pDocWindow);
   void AddApplicationPanel(ezQtApplicationPanel* pPanel);
 
   ads::CDockManager* GetDockManager() { return m_pDockManager; }

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -175,6 +175,15 @@ void ezQtDocumentWindow::DocumentEventHandler(const ezDocumentEvent& e)
 {
   switch (e.m_Type)
   {
+    case ezDocumentEvent::Type::DocumentRenamed:
+    {
+      m_sUniqueName = m_pDocument->GetDocumentPath();
+      setObjectName(GetUniqueName());
+      ezQtContainerWindow* pContainer = ezQtContainerWindow::GetContainerWindow();
+      pContainer->DocumentWindowRenamed(this);
+
+      [[fallthrough]];
+    }
     case ezDocumentEvent::Type::ModifiedChanged:
     {
       ezQtDocumentWindowEvent dwe;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
@@ -214,6 +214,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, PropertyGrid)
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezColorGammaUB>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezAngle>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezVariant>());
+    ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezHashedString>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezEnumBase>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezBitflagsBase>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezTagSetWidgetAttribute>());

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -106,8 +106,9 @@ public:
   ezStatus SaveDocument(bool bForce = false);
   using AfterSaveCallback = ezDelegate<void(ezDocument*, ezStatus)>;
   ezTaskGroupID SaveDocumentAsync(AfterSaveCallback callback, bool bForce = false);
+  void DocumentRenamed(ezStringView sNewDocumentPath);
 
-  static ezStatus ReadDocument(const char* szDocumentPath, ezUniquePtr<ezAbstractObjectGraph>& ref_pHeader, ezUniquePtr<ezAbstractObjectGraph>& ref_pObjects,
+  static ezStatus ReadDocument(ezStringView sDocumentPath, ezUniquePtr<ezAbstractObjectGraph>& ref_pHeader, ezUniquePtr<ezAbstractObjectGraph>& ref_pObjects,
     ezUniquePtr<ezAbstractObjectGraph>& ref_pTypes);
   static ezStatus ReadAndRegisterTypes(const ezAbstractObjectGraph& types);
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Declarations.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Declarations.h
@@ -57,6 +57,7 @@ struct ezDocumentEvent
     ReadOnlyChanged,
     EnsureVisible,
     DocumentSaved,
+    DocumentRenamed,
     DocumentStatusMsg,
   };
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
@@ -163,6 +163,18 @@ ezTaskGroupID ezDocument::SaveDocumentAsync(AfterSaveCallback callback, bool bFo
   return m_ActiveSaveTask;
 }
 
+void ezDocument::DocumentRenamed(ezStringView sNewDocumentPath)
+{
+  m_sDocumentPath = sNewDocumentPath;
+
+  ezDocumentEvent e;
+  e.m_pDocument = this;
+  e.m_Type = ezDocumentEvent::Type::DocumentRenamed;
+
+  m_EventsOne.Broadcast(e);
+  s_EventsAny.Broadcast(e);
+}
+
 void ezDocument::EnsureVisible()
 {
   ezDocumentEvent e;
@@ -228,7 +240,7 @@ ezTaskGroupID ezDocument::InternalSaveDocument(AfterSaveCallback callback)
   return afterSaveID;
 }
 
-ezStatus ezDocument::ReadDocument(const char* szDocumentPath, ezUniquePtr<ezAbstractObjectGraph>& ref_pHeader, ezUniquePtr<ezAbstractObjectGraph>& ref_pObjects,
+ezStatus ezDocument::ReadDocument(ezStringView sDocumentPath, ezUniquePtr<ezAbstractObjectGraph>& ref_pHeader, ezUniquePtr<ezAbstractObjectGraph>& ref_pObjects,
   ezUniquePtr<ezAbstractObjectGraph>& ref_pTypes)
 {
   ezDefaultMemoryStreamStorage storage;
@@ -237,7 +249,7 @@ ezStatus ezDocument::ReadDocument(const char* szDocumentPath, ezUniquePtr<ezAbst
   {
     EZ_PROFILE_SCOPE("Read File");
     ezFileReader file;
-    if (file.Open(szDocumentPath) == EZ_FAILURE)
+    if (file.Open(sDocumentPath) == EZ_FAILURE)
     {
       return ezStatus("Unable to open file for reading!");
     }

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/FileSystemModel.h
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/FileSystemModel.h
@@ -149,9 +149,9 @@ public:
 
   /// \brief Creates a file reader to the given file. Will also link the document and hash it in a file-system-atomic operation.
   /// \param sAbsolutePath Path to the document. Must be in the model.
-  /// \param callback Called once the file was opened and hashed. The ezFileStatus contains the up to date info for the file, including hash. This function should return the document Id as it will automatically call LinkDocument.
+  /// \param callback Called once the file was opened and hashed. The ezFileStatus contains the up to date info for the file, including hash.
   /// \return Returns EZ_SUCCESS if the file existed and could be opened. Returns EZ_FAILURE if the file is not in the model or the file can't be opened for read access. On read failure, the file will be marked as locked.
-  ezResult ReadDocument(ezStringView sAbsolutePath, const ezDelegate<ezUuid(const ezFileStatus&, ezStreamReader&)>& callback);
+  ezResult ReadDocument(ezStringView sAbsolutePath, const ezDelegate<void(const ezFileStatus&, ezStreamReader&)>& callback);
 
   /// \brief Returns an up-to-date hash for the given file. Will trigger m_FileChangedEvents if the file has been modified since the last check. Hashes are cached so in the best case this will just check the timestamp on disk against the model and then return the cached hash. This function will also work on files outside of the data directories.
   /// \param sAbsolutePath Path to the document. Must be in the model.
@@ -162,8 +162,8 @@ public:
   ///@}
 
 public:
-  ezEvent<const ezFolderChangedEvent&, ezMutex> m_FolderChangedEvents;
-  ezEvent<const ezFileChangedEvent&, ezMutex> m_FileChangedEvents;
+  ezCopyOnBroadcastEvent<const ezFolderChangedEvent&, ezMutex> m_FolderChangedEvents;
+  ezCopyOnBroadcastEvent<const ezFileChangedEvent&, ezMutex> m_FileChangedEvents;
 
 private:
   void SetAllStatusUnknown();

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/FileSystemWatcher.h
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/FileSystemWatcher.h
@@ -46,8 +46,11 @@ public:
   ezEvent<const ezFileSystemWatcherEvent&, ezMutex> m_Events;
 
 private:
+  // On file move / rename operations we want the new file to be seen first before the old file delete event so that we can correctly detect this as a move instead of a delete operation. We achieve this by delaying each event by a fixed number of frames.
   static constexpr ezUInt32 s_AddedFrameDelay = 5;
   static constexpr ezUInt32 s_RemovedFrameDelay = 10;
+  // Sometimes moving a file triggers a modified event on the old file. To prevent this from triggering the removal to be seen before the addition, we also delay modified events by the same amount as remove events.
+  static constexpr ezUInt32 s_ModifiedFrameDelay = 10;
 
   struct WatcherResult
   {

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemModel.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemModel.cpp
@@ -220,11 +220,10 @@ void ezFileSystemModel::CheckFileSystem()
   if (ezThreadUtils::IsMainThread())
   {
     range = nullptr;
-    // Broadcast reset only if we are on the main thread.
-    // Otherwise we are on the init task thread and the reset will be called on the main thread by WaitForInitialize.
-    FireFileChangedEvent({}, {}, ezFileChangedEvent::Type::ModelReset);
-    FireFolderChangedEvent({}, ezFolderChangedEvent::Type::ModelReset);
   }
+
+  FireFileChangedEvent({}, {}, ezFileChangedEvent::Type::ModelReset);
+  FireFolderChangedEvent({}, ezFolderChangedEvent::Type::ModelReset);
 }
 
 
@@ -298,15 +297,15 @@ ezResult ezFileSystemModel::LinkDocument(ezStringView sAbsolutePath, const ezUui
     return EZ_FAILURE;
 
   ezFileStatus fileStatus;
-  bool bDocumentLinkChanged = false;
   {
     EZ_LOCK(m_FilesMutex);
     auto it = m_ReferencedFiles.Find(sAbsolutePath);
     if (it.IsValid())
     {
-      bDocumentLinkChanged = it.Value().m_DocumentID != documentId;
-      it.Value().m_DocumentID = documentId;
+      // Store status before updates so we can fire the unlink if a guid was already set.
       fileStatus = it.Value();
+      it.Value().m_DocumentID = documentId;
+
     }
     else
     {
@@ -314,8 +313,13 @@ ezResult ezFileSystemModel::LinkDocument(ezStringView sAbsolutePath, const ezUui
     }
   }
 
-  if (bDocumentLinkChanged)
+  if (fileStatus.m_DocumentID != documentId)
   {
+    if (fileStatus.m_DocumentID.IsValid())
+    {
+      FireFileChangedEvent(sAbsolutePath, fileStatus, ezFileChangedEvent::Type::DocumentUnlinked);
+    }
+    fileStatus.m_DocumentID = documentId;
     FireFileChangedEvent(sAbsolutePath, fileStatus, ezFileChangedEvent::Type::DocumentLinked);
   }
   return EZ_SUCCESS;
@@ -334,8 +338,8 @@ ezResult ezFileSystemModel::UnlinkDocument(ezStringView sAbsolutePath)
     if (it.IsValid())
     {
       bDocumentLinkChanged = it.Value().m_DocumentID != ezUuid();
-      it.Value().m_DocumentID = ezUuid::MakeInvalid();
       fileStatus = it.Value();
+      it.Value().m_DocumentID = ezUuid::MakeInvalid();
     }
     else
     {
@@ -482,7 +486,7 @@ ezUInt64 ezFileSystemModel::HashFile(ezStreamReader& ref_inputStream, ezStreamWr
   return hsw.GetHashValue();
 }
 
-ezResult ezFileSystemModel::ReadDocument(ezStringView sAbsolutePath, const ezDelegate<ezUuid(const ezFileStatus&, ezStreamReader&)>& callback)
+ezResult ezFileSystemModel::ReadDocument(ezStringView sAbsolutePath, const ezDelegate<void(const ezFileStatus&, ezStreamReader&)>& callback)
 {
   if (!m_bInitialized)
     return EZ_FAILURE;
@@ -526,11 +530,10 @@ ezResult ezFileSystemModel::ReadDocument(ezStringView sAbsolutePath, const ezDel
 
   if (callback.IsValid())
   {
-    stat.m_DocumentID = callback(stat, MemReader);
+    callback(stat, MemReader);
   }
 
   bool bFileChanged = false;
-  bool bDocumentLinkChanged = false;
   {
     // Update state. No need to compare timestamps we hold a lock on the file via the reader.
     EZ_LOCK(m_FilesMutex);
@@ -538,7 +541,6 @@ ezResult ezFileSystemModel::ReadDocument(ezStringView sAbsolutePath, const ezDel
     if (it.IsValid())
     {
       bFileChanged = !it.Value().m_LastModified.Compare(stat.m_LastModified, ezTimestamp::CompareMode::Identical);
-      bDocumentLinkChanged = it.Value().m_DocumentID != stat.m_DocumentID;
       it.Value() = stat;
     }
     else
@@ -549,10 +551,6 @@ ezResult ezFileSystemModel::ReadDocument(ezStringView sAbsolutePath, const ezDel
     if (bFileChanged)
     {
       FireFileChangedEvent(sAbsolutePath, stat, ezFileChangedEvent::Type::FileChanged);
-    }
-    if (bDocumentLinkChanged)
-    {
-      FireFileChangedEvent(sAbsolutePath, stat, ezFileChangedEvent::Type::DocumentLinked);
     }
   }
 
@@ -684,7 +682,8 @@ void ezFileSystemModel::CheckFolder(ezStringView sAbsolutePath)
   }
 
   // Delete sub-folders before parent folders.
-  missingFolders.Sort([](const ezString& lhs, const ezString& rhs) -> bool { return ezStringUtils::Compare(lhs, rhs) > 0; });
+  missingFolders.Sort([](const ezString& lhs, const ezString& rhs) -> bool
+    { return ezStringUtils::Compare(lhs, rhs) > 0; });
   for (const ezString& sFolder : missingFolders)
   {
     HandleSingleFile(sFolder, false);
@@ -861,7 +860,9 @@ void ezFileSystemModel::FireFileChangedEvent(ezStringView sFile, ezFileStatus fi
 
   for (ezUInt32 i = 0; i < g_PostponedFiles.GetCount(); i++)
   {
-    m_FileChangedEvents.Broadcast(g_PostponedFiles[i]);
+    // Need to make a copy as new elements can be added and the array resized during broadcast.
+    ezFileChangedEvent tempEvent = std::move(g_PostponedFiles[i]);
+    m_FileChangedEvents.Broadcast(tempEvent);
   }
   g_PostponedFiles.Clear();
 }
@@ -883,7 +884,9 @@ void ezFileSystemModel::FireFolderChangedEvent(ezStringView sFile, ezFolderChang
 
   for (ezUInt32 i = 0; i < g_PostponedFolders.GetCount(); i++)
   {
-    m_FolderChangedEvents.Broadcast(g_PostponedFolders[i]);
+    // Need to make a copy as new elements can be added and the array resized during broadcast.
+    ezFolderChangedEvent tempEvent = std::move(g_PostponedFolders[i]);
+    m_FolderChangedEvents.Broadcast(tempEvent);
   }
   g_PostponedFolders.Clear();
 }

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemModel.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemModel.cpp
@@ -305,7 +305,6 @@ ezResult ezFileSystemModel::LinkDocument(ezStringView sAbsolutePath, const ezUui
       // Store status before updates so we can fire the unlink if a guid was already set.
       fileStatus = it.Value();
       it.Value().m_DocumentID = documentId;
-
     }
     else
     {
@@ -682,8 +681,7 @@ void ezFileSystemModel::CheckFolder(ezStringView sAbsolutePath)
   }
 
   // Delete sub-folders before parent folders.
-  missingFolders.Sort([](const ezString& lhs, const ezString& rhs) -> bool
-    { return ezStringUtils::Compare(lhs, rhs) > 0; });
+  missingFolders.Sort([](const ezString& lhs, const ezString& rhs) -> bool { return ezStringUtils::Compare(lhs, rhs) > 0; });
   for (const ezString& sFolder : missingFolders)
   {
     HandleSingleFile(sFolder, false);

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemWatcher.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemWatcher.cpp
@@ -162,7 +162,7 @@ void ezFileSystemWatcher::HandleWatcherChange(const WatcherResult& res)
       }
       else
       {
-        AddEntry(m_FileChanged, res.m_sFile, s_AddedFrameDelay);
+        AddEntry(m_FileChanged, res.m_sFile, s_ModifiedFrameDelay);
       }
     }
     break;

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -184,19 +184,17 @@ void ezEditorAssetDocumentTest::FileOperations()
   class EventHandler : public ezRefCounted
   {
   public:
-    EventHandler() {}
-
-    void Init(const ezSharedPtr<EventHandler>& strongThis)
+    void Init(const ezSharedPtr<EventHandler>& pStrongThis)
     {
       // Multi-threaded event subscription can outlive the target lifetime if we don't capture a string reference to it.
-      m_uiFileID = ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler([strongThis](const ezFileChangedEvent& e) { strongThis->OnAssetFilesEvent(e); });
-      m_uiAssetID = ezAssetCurator::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&EventHandler::OnAssetEvent, this));
+      m_FileID = ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler([pStrongThis](const ezFileChangedEvent& e) { pStrongThis->OnAssetFilesEvent(e); });
+      m_AssetID = ezAssetCurator::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&EventHandler::OnAssetEvent, this));
     }
 
     void DeInit()
     {
-      ezFileSystemModel::GetSingleton()->m_FileChangedEvents.RemoveEventHandler(m_uiFileID);
-      ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(m_uiAssetID);
+      ezFileSystemModel::GetSingleton()->m_FileChangedEvents.RemoveEventHandler(m_FileID);
+      ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(m_AssetID);
     }
 
     void OnAssetFilesEvent(const ezFileChangedEvent& e)
@@ -204,7 +202,7 @@ void ezEditorAssetDocumentTest::FileOperations()
       if (e.m_sPath.GetFileExtension().IsEqual_NoCase("ezAidlt"_ezsv))
         return;
 
-      if (m_uiFileID == 0)
+      if (m_FileID == 0)
         return;
 
       EZ_LOCK(m_EventMutex);
@@ -223,8 +221,8 @@ void ezEditorAssetDocumentTest::FileOperations()
     ezHybridArray<AssetEvent, 4> m_AssetEvents;
 
   private:
-    ezEventSubscriptionID m_uiFileID = 0;
-    ezEventSubscriptionID m_uiAssetID = 0;
+    ezEventSubscriptionID m_FileID = 0;
+    ezEventSubscriptionID m_AssetID = 0;
   };
 
   ezSharedPtr<EventHandler> events = EZ_DEFAULT_NEW(EventHandler);

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -4,6 +4,8 @@
 #include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorTest/AssetDocument/AssetDocumentTest.h>
 #include <Foundation/IO/OSFile.h>
+#include <TestFramework/Utilities/TestLogInterface.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
 static ezEditorAssetDocumentTest s_EditorAssetDocumentTest;
@@ -17,6 +19,7 @@ void ezEditorAssetDocumentTest::SetupSubTests()
 {
   AddSubTest("Async Save", SubTests::ST_AsyncSave);
   AddSubTest("Save on Transform", SubTests::ST_SaveOnTransform);
+  AddSubTest("File Operations", SubTests::ST_FileOperations);
 }
 
 ezResult ezEditorAssetDocumentTest::InitializeTest()
@@ -48,6 +51,9 @@ ezTestAppRun ezEditorAssetDocumentTest::RunSubTest(ezInt32 iIdentifier, ezUInt32
     case SubTests::ST_SaveOnTransform:
       SaveOnTransform();
       break;
+    case SubTests::ST_FileOperations:
+      FileOperations();
+      break;
   }
   return ezTestAppRun::Quit;
 }
@@ -72,7 +78,8 @@ void ezEditorAssetDocumentTest::AsyncSave()
     ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
     ezInt32 iOrder = 0;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&iOrder](ezDocument* pDoc, ezStatus res) {
+      [&iOrder](ezDocument* pDoc, ezStatus res)
+      {
         EZ_TEST_INT(iOrder, 0);
         iOrder = 1;
       },
@@ -84,10 +91,10 @@ void ezEditorAssetDocumentTest::AsyncSave()
 
     // Saving while another save is in progress should block. This ensures the correct state on disk.
     ezString sFile = pAcc->Get<ezString>(pMeshAsset, "MeshFile");
-    ezTaskGroupID id2 = pDoc->SaveDocumentAsync([&iOrder](ezDocument* pDoc, ezStatus res) {
+    ezTaskGroupID id2 = pDoc->SaveDocumentAsync([&iOrder](ezDocument* pDoc, ezStatus res)
+      {
       EZ_TEST_INT(iOrder, 1);
-      iOrder = 2;
-    });
+      iOrder = 2; });
 
     // Closing the document should wait for the async save to finish.
     pDoc->GetDocumentManager()->CloseDocument(pDoc);
@@ -156,4 +163,314 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
     EZ_TEST_STRING(sLabel, "initialShadingGroup");
   }
   pDoc->GetDocumentManager()->CloseDocument(pDoc);
+}
+
+
+void ezEditorAssetDocumentTest::FileOperations()
+{
+  struct AssetEvent
+  {
+    AssetEvent() = default;
+    AssetEvent(ezStringView sAbsPath, ezUuid assetGuid, ezAssetCuratorEvent::Type type)
+      : m_sAbsPath(sAbsPath)
+      , m_AssetGuid(assetGuid)
+      , m_Type(type)
+    {
+    }
+
+    ezString m_sAbsPath;
+    ezUuid m_AssetGuid;
+    ezAssetCuratorEvent::Type m_Type;
+  };
+
+  class EventHandler : public ezRefCounted
+  {
+  public:
+    EventHandler() {}
+
+    void Init(const ezSharedPtr<EventHandler>& strongThis)
+    {
+      // Multi-threaded event subscription can outlive the target lifetime if we don't capture a string reference to it.
+      m_uiFileID = ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler([strongThis](const ezFileChangedEvent& e)
+        { strongThis->OnAssetFilesEvent(e); });
+      m_uiAssetID = ezAssetCurator::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&EventHandler::OnAssetEvent, this));
+    }
+
+    void DeInit()
+    {
+      ezFileSystemModel::GetSingleton()->m_FileChangedEvents.RemoveEventHandler(m_uiFileID);
+      ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(m_uiAssetID);
+    }
+
+    void OnAssetFilesEvent(const ezFileChangedEvent& e)
+    {
+      if (e.m_sPath.GetFileExtension().IsEqual_NoCase("ezAidlt"_ezsv))
+        return;
+
+      if (m_uiFileID == 0)
+        return;
+
+      EZ_LOCK(m_EventMutex);
+      m_FileEvents.PushBack(e);
+    }
+
+    void OnAssetEvent(const ezAssetCuratorEvent& e)
+    {
+      m_AssetEvents.PushBack({e.m_pInfo->m_pAssetInfo->m_sAbsolutePath, e.m_AssetGuid, e.m_Type});
+    }
+
+
+
+    ezMutex m_EventMutex;
+    ezHybridArray<ezFileChangedEvent, 4> m_FileEvents;
+    ezHybridArray<AssetEvent, 4> m_AssetEvents;
+
+  private:
+    ezEventSubscriptionID m_uiFileID = 0;
+    ezEventSubscriptionID m_uiAssetID = 0;
+  };
+
+  ezSharedPtr<EventHandler> events = EZ_DEFAULT_NEW(EventHandler);
+  events->Init(events);
+  EZ_SCOPE_EXIT(events->DeInit());
+
+  auto CompareFiles = [&](ezArrayPtr<ezFileChangedEvent> expectedFiles, ezArrayPtr<AssetEvent> expectedAssets)
+  {
+    EZ_LOCK(events->m_EventMutex);
+    if (EZ_TEST_INT(expectedFiles.GetCount(), events->m_FileEvents.GetCount()))
+    {
+      for (size_t i = 0; i < expectedFiles.GetCount(); i++)
+      {
+        EZ_TEST_INT((int)expectedFiles[i].m_Type, (int)events->m_FileEvents[i].m_Type);
+        EZ_TEST_STRING(expectedFiles[i].m_sPath, events->m_FileEvents[i].m_sPath);
+        // Ignore stats
+      }
+    }
+
+    if (EZ_TEST_INT(expectedAssets.GetCount(), events->m_AssetEvents.GetCount()))
+    {
+      for (size_t i = 0; i < expectedAssets.GetCount(); i++)
+      {
+        EZ_TEST_INT((int)expectedAssets[i].m_Type, (int)events->m_AssetEvents[i].m_Type);
+        EZ_TEST_STRING(expectedAssets[i].m_sAbsPath, events->m_AssetEvents[i].m_sAbsPath);
+        EZ_TEST_BOOL(expectedAssets[i].m_AssetGuid == events->m_AssetEvents[i].m_AssetGuid);
+        // Ignore stats
+      }
+    }
+    events->m_FileEvents.Clear();
+    events->m_AssetEvents.Clear();
+  };
+
+  auto WaitForFileEvents = [&](ezUInt32 uiFileEventCount, ezUInt32 uiAssetEventCount)
+  {
+    constexpr ezUInt32 WAIT_LOOPS = 500;
+    for (ezUInt32 i = 0; i < WAIT_LOOPS; i++)
+    {
+      ProcessEvents();
+      ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(16));
+
+      EZ_LOCK(events->m_EventMutex);
+      if (events->m_FileEvents.GetCount() == uiFileEventCount && events->m_AssetEvents.GetCount() == uiAssetEventCount)
+        break;
+    }
+  };
+
+  auto FlushEvents = [&]()
+  {
+    constexpr ezUInt32 WAIT_LOOPS = 60;
+    for (ezUInt32 i = 0; i < WAIT_LOOPS; i++)
+    {
+      ProcessEvents();
+      ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(16));
+
+      EZ_LOCK(events->m_EventMutex);
+      if (!events->m_FileEvents.IsEmpty() || !events->m_AssetEvents.IsEmpty())
+      {
+        i = 0;
+        events->m_FileEvents.Clear();
+        events->m_AssetEvents.Clear();
+      }
+    }
+  };
+
+  auto CheckSubAsset = [](const ezAssetCurator::ezLockedSubAsset& subAsset, ezUuid documentGuid, ezString sAbsAssetPath)
+  {
+    if (EZ_TEST_BOOL(subAsset))
+    {
+      EZ_TEST_BOOL(subAsset->m_ExistanceState == ezAssetExistanceState::FileUnchanged);
+      EZ_TEST_BOOL(subAsset->m_bMainAsset);
+      EZ_TEST_BOOL(subAsset->m_Data.m_Guid == documentGuid);
+      EZ_TEST_STRING(subAsset->m_Data.m_sSubAssetsDocumentTypeName, "Mesh");
+      EZ_TEST_STRING(subAsset->m_Data.m_sName, "");
+      EZ_TEST_BOOL(subAsset->m_pAssetInfo->m_ExistanceState == ezAssetExistanceState::FileUnchanged);
+      EZ_TEST_BOOL(subAsset->m_pAssetInfo->m_TransformState == ezAssetInfo::NeedsTransform);
+      EZ_TEST_BOOL(subAsset->m_pAssetInfo->m_Info->m_DocumentID == documentGuid);
+      EZ_TEST_STRING(subAsset->m_pAssetInfo->m_sAbsolutePath, sAbsAssetPath);
+    }
+  };
+
+  // Wait for the asset curator to process all file events from opening the project.
+  FlushEvents();
+
+  ezAssetDocument* pDoc = nullptr;
+  ezString sAbsAssetPath;
+  ezUuid documentGuid;
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Create Document")
+  {
+    ezStringBuilder sName = m_sProjectPath;
+    sName.AppendPath("mesh3.ezMeshAsset");
+    pDoc = static_cast<ezAssetDocument*>(m_pApplication->m_pEditorApp->CreateDocument(sName, ezDocumentFlags::RequestWindow));
+    EZ_TEST_BOOL(pDoc != nullptr);
+    sAbsAssetPath = pDoc->GetDocumentPath();
+    documentGuid = pDoc->GetGuid();
+    ProcessEvents();
+
+    WaitForFileEvents(2, 1);
+    ezFileStatus stat;
+    stat.m_DocumentID = documentGuid;
+    ezFileChangedEvent expected[] = {
+      ezFileChangedEvent(sAbsAssetPath, {}, ezFileChangedEvent::Type::FileAdded),
+      ezFileChangedEvent(sAbsAssetPath, stat, ezFileChangedEvent::Type::DocumentLinked)};
+    AssetEvent expected2[] = {AssetEvent(sAbsAssetPath, documentGuid, ezAssetCuratorEvent::Type::AssetAdded)};
+    CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
+
+    CheckSubAsset(ezAssetCurator::GetSingleton()->GetSubAsset(documentGuid), documentGuid, sAbsAssetPath);
+  }
+
+  ezStringBuilder sAbsAssetCopyPath = sAbsAssetPath;
+  sAbsAssetCopyPath.ChangeFileName("meshCopy");
+  ezUuid copyGuid;
+
+  // Tests that copy gets a unique ID to resolev conflict.
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Copy Asset")
+  {
+    const ezUuid mod = ezUuid::MakeStableUuidFromString(sAbsAssetCopyPath);
+    copyGuid = documentGuid;
+    copyGuid.CombineWithSeed(mod);
+
+    ezTestLogInterface log;
+    ezTestLogSystemScope logSystemScope(&log, true);
+    log.ExpectMessage("Two assets have identical GUIDs:", ezLogMsgType::ErrorMsg, 1);
+
+    ezOSFile::CopyFile(sAbsAssetPath, sAbsAssetCopyPath).AssertSuccess("Failed to copy file");
+
+    WaitForFileEvents(3, 1);
+    ezFileStatus stat;
+    stat.m_DocumentID = copyGuid;
+    ezFileChangedEvent expected[] = {
+      ezFileChangedEvent(sAbsAssetCopyPath, {}, ezFileChangedEvent::Type::FileAdded),
+      ezFileChangedEvent(sAbsAssetCopyPath, {}, ezFileChangedEvent::Type::FileChanged),
+      ezFileChangedEvent(sAbsAssetCopyPath, stat, ezFileChangedEvent::Type::DocumentLinked)};
+    AssetEvent expected2[] = {AssetEvent(sAbsAssetCopyPath, copyGuid, ezAssetCuratorEvent::Type::AssetAdded)};
+    CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
+
+    CheckSubAsset(ezAssetCurator::GetSingleton()->GetSubAsset(documentGuid), documentGuid, sAbsAssetPath);
+    CheckSubAsset(ezAssetCurator::GetSingleton()->GetSubAsset(copyGuid), copyGuid, sAbsAssetCopyPath);
+  }
+
+  ezStringBuilder sAbsAssetCopyRenamedPath = sAbsAssetCopyPath;
+  sAbsAssetCopyRenamedPath.ChangeFileName("meshCopyRenamed");
+
+  // Simple rename of not opened document
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Rename Copied Asset")
+  {
+    ezOSFile::MoveFileOrDirectory(sAbsAssetCopyPath, sAbsAssetCopyRenamedPath).AssertSuccess("Failed to rename file");
+
+    WaitForFileEvents(4, 2);
+    ezFileStatus stat;
+    stat.m_DocumentID = copyGuid;
+    ezFileChangedEvent expected[] = {
+      ezFileChangedEvent(sAbsAssetCopyRenamedPath, {}, ezFileChangedEvent::Type::FileAdded),
+      ezFileChangedEvent(sAbsAssetCopyPath, stat, ezFileChangedEvent::Type::DocumentUnlinked),
+      ezFileChangedEvent(sAbsAssetCopyPath, {}, ezFileChangedEvent::Type::FileRemoved),
+      ezFileChangedEvent(sAbsAssetCopyRenamedPath, stat, ezFileChangedEvent::Type::DocumentLinked)};
+    AssetEvent expected2[] = {
+      AssetEvent(sAbsAssetCopyRenamedPath, copyGuid, ezAssetCuratorEvent::Type::AssetMoved),  // Moved
+      AssetEvent(sAbsAssetCopyRenamedPath, copyGuid, ezAssetCuratorEvent::Type::AssetUpdated)}; // Asset transform state updated
+    CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
+
+    EZ_TEST_BOOL(!ezAssetCurator::GetSingleton()->FindSubAsset(sAbsAssetCopyPath));
+    CheckSubAsset(ezAssetCurator::GetSingleton()->GetSubAsset(copyGuid), copyGuid, sAbsAssetCopyRenamedPath);
+  }
+
+
+  m_pApplication->m_pEditorApp->OpenDocument(sAbsAssetCopyRenamedPath, ezDocumentFlags::RequestWindow);
+  ProcessEvents();
+
+  // Delete an open document, make sure document gets closed.
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Delete Copied Asset")
+  {
+    ezOSFile::DeleteFile(sAbsAssetCopyRenamedPath).AssertSuccess("Failed to delete file");
+
+    WaitForFileEvents(1, 1);
+    ezFileStatus stat;
+    stat.m_DocumentID = copyGuid;
+    ezFileChangedEvent expected[] = {
+      ezFileChangedEvent(sAbsAssetCopyRenamedPath, {}, ezFileChangedEvent::Type::FileRemoved)};
+    AssetEvent expected2[] = {AssetEvent(sAbsAssetCopyRenamedPath, copyGuid, ezAssetCuratorEvent::Type::AssetRemoved)};
+    CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
+    EZ_TEST_BOOL(!ezAssetCurator::GetSingleton()->FindSubAsset(sAbsAssetCopyPath));
+    EZ_TEST_BOOL(!ezAssetCurator::GetSingleton()->FindSubAsset(sAbsAssetCopyRenamedPath));
+    EZ_TEST_BOOL(ezDocumentManager::GetDocumentByGuid(copyGuid) == nullptr);
+  }
+
+  ezStringBuilder sAbsAssetRenamedPath = sAbsAssetPath;
+  sAbsAssetRenamedPath.ChangeFileName("meshRenamed");
+  // Test that a renamed asset renames the open document as well.
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Rename Asset")
+  {
+    ezOSFile::MoveFileOrDirectory(sAbsAssetPath, sAbsAssetRenamedPath).AssertSuccess("Failed to rename file");
+
+    WaitForFileEvents(4, 2);
+    ezFileStatus stat;
+    stat.m_DocumentID = documentGuid;
+    ezFileChangedEvent expected[] = {
+      ezFileChangedEvent(sAbsAssetRenamedPath, {}, ezFileChangedEvent::Type::FileAdded),
+      ezFileChangedEvent(sAbsAssetPath, stat, ezFileChangedEvent::Type::DocumentUnlinked),
+      ezFileChangedEvent(sAbsAssetPath, {}, ezFileChangedEvent::Type::FileRemoved),
+      ezFileChangedEvent(sAbsAssetRenamedPath, stat, ezFileChangedEvent::Type::DocumentLinked)};
+    AssetEvent expected2[] = {
+      AssetEvent(sAbsAssetRenamedPath, documentGuid, ezAssetCuratorEvent::Type::AssetMoved), // Moved
+      AssetEvent(sAbsAssetRenamedPath, documentGuid, ezAssetCuratorEvent::Type::AssetUpdated)}; // Asset transform state updated
+    CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
+    EZ_TEST_BOOL(!ezAssetCurator::GetSingleton()->FindSubAsset(sAbsAssetPath));
+    CheckSubAsset(ezAssetCurator::GetSingleton()->GetSubAsset(documentGuid), documentGuid, sAbsAssetRenamedPath);
+
+    EZ_TEST_STRING(pDoc->GetDocumentPath(), sAbsAssetRenamedPath);
+  }
+
+  // OVERWRITTEN TEST
+  {
+    const ezDocumentTypeDescriptor * pTypeDesc = pDoc->GetAssetDocumentTypeDescriptor();
+
+    ezUuid overwriteGuid = documentGuid;
+    overwriteGuid.CombineWithSeed(ezUuid::MakeStableUuidFromString("Overwritten"));
+
+    ezStringBuilder sTemp;
+    ezStringBuilder sTempTarget = ezOSFile::GetTempDataFolder();
+    sTempTarget.AppendPath(ezPathUtils::GetFileNameAndExtension(sAbsAssetRenamedPath));
+    sTempTarget.ChangeFileName(ezConversionUtils::ToString(overwriteGuid, sTemp));
+
+    EZ_TEST_RESULT(pTypeDesc->m_pManager->CloneDocument(sAbsAssetRenamedPath, sTempTarget, overwriteGuid).m_Result);
+    EZ_TEST_RESULT(ezOSFile::CopyFile(sTempTarget, sAbsAssetRenamedPath));
+    ezOSFile::DeleteFile(sTempTarget).IgnoreResult();
+
+    WaitForFileEvents(3, 2);
+
+    ezFileStatus stat;
+    stat.m_DocumentID = documentGuid;
+    ezFileStatus newStat;
+    stat.m_DocumentID = overwriteGuid;
+    ezFileChangedEvent expected[] = {
+      ezFileChangedEvent(sAbsAssetRenamedPath, stat, ezFileChangedEvent::Type::FileChanged),
+      ezFileChangedEvent(sAbsAssetRenamedPath, stat, ezFileChangedEvent::Type::DocumentUnlinked),
+      ezFileChangedEvent(sAbsAssetRenamedPath, newStat, ezFileChangedEvent::Type::DocumentLinked)};
+    AssetEvent expected2[] = {
+      AssetEvent(sAbsAssetRenamedPath, documentGuid, ezAssetCuratorEvent::Type::AssetRemoved),
+      AssetEvent(sAbsAssetRenamedPath, overwriteGuid, ezAssetCuratorEvent::Type::AssetAdded)};
+    CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
+    EZ_TEST_BOOL(ezAssetCurator::GetSingleton()->FindSubAsset(sAbsAssetRenamedPath));
+    EZ_TEST_BOOL(!ezAssetCurator::GetSingleton()->GetSubAsset(documentGuid));
+    CheckSubAsset(ezAssetCurator::GetSingleton()->GetSubAsset(overwriteGuid), overwriteGuid, sAbsAssetRenamedPath);
+  }
 }

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -78,8 +78,7 @@ void ezEditorAssetDocumentTest::AsyncSave()
     ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
     ezInt32 iOrder = 0;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&iOrder](ezDocument* pDoc, ezStatus res)
-      {
+      [&iOrder](ezDocument* pDoc, ezStatus res) {
         EZ_TEST_INT(iOrder, 0);
         iOrder = 1;
       },
@@ -91,8 +90,7 @@ void ezEditorAssetDocumentTest::AsyncSave()
 
     // Saving while another save is in progress should block. This ensures the correct state on disk.
     ezString sFile = pAcc->Get<ezString>(pMeshAsset, "MeshFile");
-    ezTaskGroupID id2 = pDoc->SaveDocumentAsync([&iOrder](ezDocument* pDoc, ezStatus res)
-      {
+    ezTaskGroupID id2 = pDoc->SaveDocumentAsync([&iOrder](ezDocument* pDoc, ezStatus res) {
       EZ_TEST_INT(iOrder, 1);
       iOrder = 2; });
 
@@ -191,8 +189,7 @@ void ezEditorAssetDocumentTest::FileOperations()
     void Init(const ezSharedPtr<EventHandler>& strongThis)
     {
       // Multi-threaded event subscription can outlive the target lifetime if we don't capture a string reference to it.
-      m_uiFileID = ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler([strongThis](const ezFileChangedEvent& e)
-        { strongThis->OnAssetFilesEvent(e); });
+      m_uiFileID = ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler([strongThis](const ezFileChangedEvent& e) { strongThis->OnAssetFilesEvent(e); });
       m_uiAssetID = ezAssetCurator::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&EventHandler::OnAssetEvent, this));
     }
 
@@ -234,8 +231,7 @@ void ezEditorAssetDocumentTest::FileOperations()
   events->Init(events);
   EZ_SCOPE_EXIT(events->DeInit());
 
-  auto CompareFiles = [&](ezArrayPtr<ezFileChangedEvent> expectedFiles, ezArrayPtr<AssetEvent> expectedAssets)
-  {
+  auto CompareFiles = [&](ezArrayPtr<ezFileChangedEvent> expectedFiles, ezArrayPtr<AssetEvent> expectedAssets) {
     EZ_LOCK(events->m_EventMutex);
     if (EZ_TEST_INT(expectedFiles.GetCount(), events->m_FileEvents.GetCount()))
     {
@@ -261,8 +257,7 @@ void ezEditorAssetDocumentTest::FileOperations()
     events->m_AssetEvents.Clear();
   };
 
-  auto WaitForFileEvents = [&](ezUInt32 uiFileEventCount, ezUInt32 uiAssetEventCount)
-  {
+  auto WaitForFileEvents = [&](ezUInt32 uiFileEventCount, ezUInt32 uiAssetEventCount) {
     constexpr ezUInt32 WAIT_LOOPS = 500;
     for (ezUInt32 i = 0; i < WAIT_LOOPS; i++)
     {
@@ -275,8 +270,7 @@ void ezEditorAssetDocumentTest::FileOperations()
     }
   };
 
-  auto FlushEvents = [&]()
-  {
+  auto FlushEvents = [&]() {
     constexpr ezUInt32 WAIT_LOOPS = 60;
     for (ezUInt32 i = 0; i < WAIT_LOOPS; i++)
     {
@@ -293,8 +287,7 @@ void ezEditorAssetDocumentTest::FileOperations()
     }
   };
 
-  auto CheckSubAsset = [](const ezAssetCurator::ezLockedSubAsset& subAsset, ezUuid documentGuid, ezString sAbsAssetPath)
-  {
+  auto CheckSubAsset = [](const ezAssetCurator::ezLockedSubAsset& subAsset, ezUuid documentGuid, ezString sAbsAssetPath) {
     if (EZ_TEST_BOOL(subAsset))
     {
       EZ_TEST_BOOL(subAsset->m_ExistanceState == ezAssetExistanceState::FileUnchanged);
@@ -385,7 +378,7 @@ void ezEditorAssetDocumentTest::FileOperations()
       ezFileChangedEvent(sAbsAssetCopyPath, {}, ezFileChangedEvent::Type::FileRemoved),
       ezFileChangedEvent(sAbsAssetCopyRenamedPath, stat, ezFileChangedEvent::Type::DocumentLinked)};
     AssetEvent expected2[] = {
-      AssetEvent(sAbsAssetCopyRenamedPath, copyGuid, ezAssetCuratorEvent::Type::AssetMoved),  // Moved
+      AssetEvent(sAbsAssetCopyRenamedPath, copyGuid, ezAssetCuratorEvent::Type::AssetMoved),    // Moved
       AssetEvent(sAbsAssetCopyRenamedPath, copyGuid, ezAssetCuratorEvent::Type::AssetUpdated)}; // Asset transform state updated
     CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
 
@@ -430,7 +423,7 @@ void ezEditorAssetDocumentTest::FileOperations()
       ezFileChangedEvent(sAbsAssetPath, {}, ezFileChangedEvent::Type::FileRemoved),
       ezFileChangedEvent(sAbsAssetRenamedPath, stat, ezFileChangedEvent::Type::DocumentLinked)};
     AssetEvent expected2[] = {
-      AssetEvent(sAbsAssetRenamedPath, documentGuid, ezAssetCuratorEvent::Type::AssetMoved), // Moved
+      AssetEvent(sAbsAssetRenamedPath, documentGuid, ezAssetCuratorEvent::Type::AssetMoved),    // Moved
       AssetEvent(sAbsAssetRenamedPath, documentGuid, ezAssetCuratorEvent::Type::AssetUpdated)}; // Asset transform state updated
     CompareFiles(ezMakeArrayPtr(expected), ezMakeArrayPtr(expected2));
     EZ_TEST_BOOL(!ezAssetCurator::GetSingleton()->FindSubAsset(sAbsAssetPath));
@@ -441,7 +434,7 @@ void ezEditorAssetDocumentTest::FileOperations()
 
   // OVERWRITTEN TEST
   {
-    const ezDocumentTypeDescriptor * pTypeDesc = pDoc->GetAssetDocumentTypeDescriptor();
+    const ezDocumentTypeDescriptor* pTypeDesc = pDoc->GetAssetDocumentTypeDescriptor();
 
     ezUuid overwriteGuid = documentGuid;
     overwriteGuid.CombineWithSeed(ezUuid::MakeStableUuidFromString("Overwritten"));

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.h
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.h
@@ -16,6 +16,7 @@ private:
   {
     ST_AsyncSave,
     ST_SaveOnTransform,
+    ST_FileOperations,
   };
 
   virtual void SetupSubTests() override;
@@ -25,4 +26,5 @@ private:
 
   void AsyncSave();
   void SaveOnTransform();
+  void FileOperations();
 };

--- a/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
@@ -621,23 +621,23 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
 
       ezUuid guid = ezUuid::MakeUuid();
       ezUuid guid2 = ezUuid::MakeUuid();
-    {
-      EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid));
-      EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid));
-      EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid2));
+      {
+        EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid));
+        EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid));
+        EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid2));
 
-      ezFileStatus stat;
-      stat.m_DocumentID = guid;
-      ezFileStatus stat2;
-      stat2.m_DocumentID = guid2;
+        ezFileStatus stat;
+        stat.m_DocumentID = guid;
+        ezFileStatus stat2;
+        stat2.m_DocumentID = guid2;
 
-      ezFileChangedEvent expected[] = {
-        ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentLinked),
-        ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentUnlinked),
-        ezFileChangedEvent(sFilePathNew, stat2, ezFileChangedEvent::Type::DocumentLinked)};
-      CompareFiles(ezMakeArrayPtr(expected));
-      ClearFiles();
-    }
+        ezFileChangedEvent expected[] = {
+          ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentLinked),
+          ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentUnlinked),
+          ezFileChangedEvent(sFilePathNew, stat2, ezFileChangedEvent::Type::DocumentLinked)};
+        CompareFiles(ezMakeArrayPtr(expected));
+        ClearFiles();
+      }
     {
       EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->UnlinkDocument(sFilePathNew));
       EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->UnlinkDocument(sFilePathNew));

--- a/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
@@ -103,7 +103,8 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
       {
         EZ_TEST_INT((int)expected[i].m_Type, (int)fileEvents[i].m_Type);
         EZ_TEST_STRING(expected[i].m_sPath, fileEvents[i].m_sPath);
-        // Ignore stats
+        EZ_TEST_BOOL(expected[i].m_Status.m_DocumentID == fileEvents[i].m_Status.m_DocumentID);
+        // Ignore stats besudes GUID.
       }
     }
   };
@@ -598,14 +599,17 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
     ezStringBuilder sFilePathNew(sOutputFolder);
     sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
 
-    auto callback = [](const ezFileStatus& status, ezStreamReader& ref_reader) -> ezUuid {
+    ezUuid docGuid = ezUuid::MakeUuid();
+    auto callback = [&](const ezFileStatus& status, ezStreamReader& ref_reader) {
       EZ_TEST_INT((ezInt64)status.m_uiHash, (ezInt64)10983861097202158394u);
-      return ezUuid::MakeUuid();
+      ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, docGuid).IgnoreResult();
     };
 
     EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->ReadDocument(sFilePathNew, callback));
 
-    ezFileChangedEvent expected[] = {ezFileChangedEvent(sFilePathNew, {}, ezFileChangedEvent::Type::DocumentLinked)};
+    ezFileStatus stat;
+    stat.m_DocumentID = docGuid;
+    ezFileChangedEvent expected[] = {ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentLinked)};
     CompareFiles(ezMakeArrayPtr(expected));
     ClearFiles();
   }
@@ -615,12 +619,22 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
     ezStringBuilder sFilePathNew(sOutputFolder);
     sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
 
-    {
       ezUuid guid = ezUuid::MakeUuid();
+      ezUuid guid2 = ezUuid::MakeUuid();
+    {
       EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid));
       EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid));
+      EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->LinkDocument(sFilePathNew, guid2));
 
-      ezFileChangedEvent expected[] = {ezFileChangedEvent(sFilePathNew, {}, ezFileChangedEvent::Type::DocumentLinked)};
+      ezFileStatus stat;
+      stat.m_DocumentID = guid;
+      ezFileStatus stat2;
+      stat2.m_DocumentID = guid2;
+
+      ezFileChangedEvent expected[] = {
+        ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentLinked),
+        ezFileChangedEvent(sFilePathNew, stat, ezFileChangedEvent::Type::DocumentUnlinked),
+        ezFileChangedEvent(sFilePathNew, stat2, ezFileChangedEvent::Type::DocumentLinked)};
       CompareFiles(ezMakeArrayPtr(expected));
       ClearFiles();
     }
@@ -628,7 +642,10 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
       EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->UnlinkDocument(sFilePathNew));
       EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->UnlinkDocument(sFilePathNew));
 
-      ezFileChangedEvent expected[] = {ezFileChangedEvent(sFilePathNew, {}, ezFileChangedEvent::Type::DocumentUnlinked)};
+      ezFileStatus stat2;
+      stat2.m_DocumentID = guid2;
+
+      ezFileChangedEvent expected[] = {ezFileChangedEvent(sFilePathNew, stat2, ezFileChangedEvent::Type::DocumentUnlinked)};
       CompareFiles(ezMakeArrayPtr(expected));
       ClearFiles();
     }


### PR DESCRIPTION
## Asset Curator
* Copy, rename, overwrite and move file are now correctly handled and tested.
* Added **AssetMoved** event type.
* Renaming a file that is open as a document updates the document in place now.
* As the file system model is multi-threaded, any code that was touching **ezDocument** was moved to the main thread.

## File System Model
* Fixed deadlock due to events firing under the lock by changing to **ezCopyOnBroadcastEvent** type.
* Linking a document that is already linked will first fire **DocumentUnlinked** event before firing **DocumentLinked**.
* **ReadDocument** no longer requires setting the document GUID, this was removed as it caused linkege that needed to be immediately removed again, e.g. during duplicate asset detection. Now linking is always done outside the code when neccessary.
* Fixed a crash when **g_PostponedFiles** was resized while firing events.

## Misc Changes
* Fixed debug asset due to missing unregister of **ezHashedString** property grid GUI factory.
* ezDocument now has a **DocumentRenamed** function and event type.
* Sometimes moving a file triggers a modified watcher event on the source file name. This would make the removal of the file detected before the addition at the new location. To mitigate, modified events are now also queued up for 10 frames before firing like delete events.