### PR TITLE
Added different types of following modes for FollowPathComponent

### DIFF
--- a/Code/Engine/GameEngine/Animation/FollowPathComponent.h
+++ b/Code/Engine/GameEngine/Animation/FollowPathComponent.h
@@ -67,13 +67,13 @@ public:
   /// \brief Sets the reference to the game object on which an ezPathComponent should be attached.
   void SetPathObject(const char* szReference); // [ property ]
 
-  ezEnum<ezPropertyAnimMode> m_Mode;     ///< [ property ] How the path should be traversed.
-  ezEnum<ezFollowPathMode> m_FollowMode; ///< [ property ] How the transform of the follower should be affected by the path.
-  float m_fSpeed = 1.0f;                 ///< [ property ] How fast to move along the path.
-  float m_fLookAhead = 1.0f;             ///< [ property ] How far along the path to 'look ahead' to smooth the rotation. A small distance means rotations are very abrupt.
-  float m_fSmoothing = 0.5f;             ///< [ property ] How much to combine the current position with the new position. 0 to 1. At zero, the position follows the path perfectly, but therefore also has very abrupt changes. With a lot of smoothing, the path becomes very sluggish.
-  ezAngle m_TiltAmount;                 ///< [ property ] How much to tilt when turning.
-  ezAngle m_MaxTilt;                    ///< [ property ] The max tilt of the object.
+  ezEnum<ezPropertyAnimMode> m_Mode;                    ///< [ property ] How the path should be traversed.
+  ezEnum<ezFollowPathMode> m_FollowMode;                ///< [ property ] How the transform of the follower should be affected by the path.
+  float m_fSpeed = 1.0f;                                ///< [ property ] How fast to move along the path.
+  float m_fLookAhead = 1.0f;                            ///< [ property ] How far along the path to 'look ahead' to smooth the rotation. A small distance means rotations are very abrupt.
+  float m_fSmoothing = 0.5f;                            ///< [ property ] How much to combine the current position with the new position. 0 to 1. At zero, the position follows the path perfectly, but therefore also has very abrupt changes. With a lot of smoothing, the path becomes very sluggish.
+  float m_fTiltAmount = 5.0f;                           ///< [ property ] How much to tilt when turning.
+  ezAngle m_MaxTilt = ezAngle::MakeFromDegree(30.0f);   ///< [ property ] The max tilt angle of the object.
 
   /// \brief Distance along the path at which the ezFollowPathComponent should start off.
   void SetDistanceAlongPath(float fDistance); // [ property ]

--- a/Code/Engine/GameEngine/Animation/FollowPathComponent.h
+++ b/Code/Engine/GameEngine/Animation/FollowPathComponent.h
@@ -12,6 +12,22 @@ struct ezMsgAnimationReachedEnd;
 
 using ezFollowPathComponentManager = ezComponentManagerSimple<class ezFollowPathComponent, ezComponentUpdateType::WhenSimulating>;
 
+struct EZ_GAMEENGINE_DLL ezFollowPathMode
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    OnlyPosition,
+    AlignUpZ,
+    FullRotation,
+
+    Default = OnlyPosition
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMEENGINE_DLL, ezFollowPathMode)
+
 /// \brief This component makes the ezGameObject, that it is attached to, move along a path defined by an ezPathComponent.
 ///
 /// Build a path using an ezPathComponent and ezPathNodeComponents.
@@ -51,10 +67,13 @@ public:
   /// \brief Sets the reference to the game object on which an ezPathComponent should be attached.
   void SetPathObject(const char* szReference); // [ property ]
 
-  ezEnum<ezPropertyAnimMode> m_Mode; ///< [ property ] How the path should be traversed.
-  float m_fSpeed = 1.0f;             ///< [ property ] How fast to move along the path.
-  float m_fLookAhead = 1.0f;         ///< [ property ] How far along the path to 'look ahead' to smooth the rotation. A small distance means rotations are very abrupt.
-  float m_fSmoothing = 0.5f;         ///< [ property ] How much to combine the current position with the new position. 0 to 1. At zero, the position follows the path perfectly, but therefore also has very abrupt changes. With a lot of smoothing, the path becomes very sluggish.
+  ezEnum<ezPropertyAnimMode> m_Mode;     ///< [ property ] How the path should be traversed.
+  ezEnum<ezFollowPathMode> m_FollowMode; ///< [ property ] How the transform of the follower should be affected by the path.
+  float m_fSpeed = 1.0f;                 ///< [ property ] How fast to move along the path.
+  float m_fLookAhead = 1.0f;             ///< [ property ] How far along the path to 'look ahead' to smooth the rotation. A small distance means rotations are very abrupt.
+  float m_fSmoothing = 0.5f;             ///< [ property ] How much to combine the current position with the new position. 0 to 1. At zero, the position follows the path perfectly, but therefore also has very abrupt changes. With a lot of smoothing, the path becomes very sluggish.
+  ezAngle m_TiltAmount;                 ///< [ property ] How much to tilt when turning.
+  ezAngle m_MaxTilt;                    ///< [ property ] The max tilt of the object.
 
   /// \brief Distance along the path at which the ezFollowPathComponent should start off.
   void SetDistanceAlongPath(float fDistance); // [ property ]
@@ -91,6 +110,7 @@ protected:
   ezVec3 m_vLastPosition;
   ezVec3 m_vLastTargetPosition;
   ezVec3 m_vLastUpDir;
+  ezAngle m_vLastTiltAngle;
 
   const char* DummyGetter() const { return nullptr; }
 };


### PR DESCRIPTION
- PositionOnly (move the object along the path with only the position being altered)
- AlignUpZ (keeps the object aligned with the path up direction)
- FullRotation (moves the object along the path, matching its transform with the sampled path transform)

Related to Issue: **FollowPathComponent: Mode for position only #947**

https://github.com/ezEngine/ezEngine/assets/90158160/eed0df36-4390-4871-977c-186490f95a84