### PR TITLE
Scripting and reflection fixes

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -205,11 +205,17 @@ void ezEngineProcessGameApplication::SendReflectionInformation()
     return;
 
   ezSet<const ezRTTI*> types;
-
-  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezReflectedClass>(), types, true);
+  ezRTTI::ForEachType(
+    [&](const ezRTTI* pRtti)
+    {
+      if (pRtti->GetTypeFlags().IsSet(ezTypeFlags::StandardType) == false)
+      {
+        types.Insert(pRtti);
+      }
+    });
 
   ezDynamicArray<const ezRTTI*> sortedTypes;
-  ezReflectionUtils::CreateDependencySortedTypeArray(types, sortedTypes);
+  EZ_VERIFY(ezReflectionUtils::CreateDependencySortedTypeArray(types, sortedTypes), "Sorting types failed");
 
   for (auto type : sortedTypes)
   {
@@ -471,7 +477,8 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
   if (pDocumentContext == nullptr)
   {
     ezRTTI::ForEachDerivedType<ezEngineProcessDocumentContext>(
-      [&](const ezRTTI* pRtti) {
+      [&](const ezRTTI* pRtti)
+      {
         auto* pProp = pRtti->FindPropertyByName("DocumentType");
         if (pProp && pProp->GetCategory() == ezPropertyCategory::Constant)
         {
@@ -521,7 +528,8 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
 
 void ezEngineProcessGameApplication::Init_LoadProjectPlugins()
 {
-  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool {
+  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool
+    {
     const bool isEnginePluginLhs = lhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
     const bool isEnginePluginRhs = rhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -206,8 +206,7 @@ void ezEngineProcessGameApplication::SendReflectionInformation()
 
   ezSet<const ezRTTI*> types;
   ezRTTI::ForEachType(
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       if (pRtti->GetTypeFlags().IsSet(ezTypeFlags::StandardType) == false)
       {
         types.Insert(pRtti);
@@ -477,8 +476,7 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
   if (pDocumentContext == nullptr)
   {
     ezRTTI::ForEachDerivedType<ezEngineProcessDocumentContext>(
-      [&](const ezRTTI* pRtti)
-      {
+      [&](const ezRTTI* pRtti) {
         auto* pProp = pRtti->FindPropertyByName("DocumentType");
         if (pProp && pProp->GetCategory() == ezPropertyCategory::Constant)
         {
@@ -528,8 +526,7 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
 
 void ezEngineProcessGameApplication::Init_LoadProjectPlugins()
 {
-  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool
-    {
+  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool {
     const bool isEnginePluginLhs = lhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
     const bool isEnginePluginRhs = rhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -214,7 +214,7 @@ void ezEngineProcessGameApplication::SendReflectionInformation()
     });
 
   ezDynamicArray<const ezRTTI*> sortedTypes;
-  EZ_VERIFY(ezReflectionUtils::CreateDependencySortedTypeArray(types, sortedTypes), "Sorting types failed");
+  ezReflectionUtils::CreateDependencySortedTypeArray(types, sortedTypes).AssertSuccess("Sorting failed");
 
   for (auto type : sortedTypes)
   {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAsset.cpp
@@ -187,7 +187,7 @@ void ezAnimationGraphNodeManager::InternalCreatePins(const ezDocumentObject* pOb
 void ezAnimationGraphNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const
 {
   ezSet<const ezRTTI*> typeSet;
-  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezAnimGraphNode>(), typeSet, false);
+  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezAnimGraphNode>(), typeSet);
 
   ref_types.Clear();
   for (auto pType : typeSet)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.cpp
@@ -71,8 +71,8 @@ void ezRenderPipelineNodeManager::InternalCreatePins(const ezDocumentObject* pOb
 void ezRenderPipelineNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const
 {
   ezSet<const ezRTTI*> typeSet;
-  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezRenderPipelinePass>(), typeSet, false);
-  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezExtractor>(), typeSet, false);
+  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezRenderPipelinePass>(), typeSet);
+  ezReflectionUtils::GatherTypesDerivedFromClass(ezGetStaticRTTI<ezExtractor>(), typeSet);
   ref_types.Clear();
   for (auto pType : typeSet)
   {

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -258,6 +258,9 @@ ezVisualScriptNodeRegistry::~ezVisualScriptNodeRegistry()
 
 void ezVisualScriptNodeRegistry::PhantomTypeRegistryEventHandler(const ezPhantomRttiManagerEvent& e)
 {
+  if (e.m_pChangedType->GetPluginName() == "EditorPluginVisualScript")
+    return;
+
   if ((e.m_Type == ezPhantomRttiManagerEvent::Type::TypeAdded && m_TypeToNodeDescs.Contains(e.m_pChangedType) == false) ||
       e.m_Type == ezPhantomRttiManagerEvent::Type::TypeChanged)
   {

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -44,6 +44,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezWorld, ezNoBase, 1, ezRTTINoAllocator)
     EZ_SCRIPT_FUNCTION_PROPERTY(DeleteObjectDelayed, In, "GameObject", In, "DeleteEmptyParents")->AddAttributes(
       new ezFunctionArgumentAttributes(1, new ezDefaultValueAttribute(true))),
     EZ_SCRIPT_FUNCTION_PROPERTY(Reflection_TryGetObjectWithGlobalKey, In, "GlobalKey")->AddFlags(ezPropertyFlags::Const),
+    EZ_SCRIPT_FUNCTION_PROPERTY(Reflection_GetClock)->AddFlags(ezPropertyFlags::Const),
   }
   EZ_END_FUNCTIONS;
 }
@@ -626,6 +627,11 @@ ezGameObject* ezWorld::Reflection_TryGetObjectWithGlobalKey(ezTempHashedString s
   bool res = TryGetObjectWithGlobalKey(sGlobalKey, pObject);
   EZ_IGNORE_UNUSED(res);
   return pObject;
+}
+
+ezClock* ezWorld::Reflection_GetClock()
+{
+  return &m_Data.m_Clock;
 }
 
 void ezWorld::SetParent(ezGameObject* pObject, ezGameObject* pNewParent, ezGameObject::TransformPreservation preserve)

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -363,6 +363,7 @@ private:
   EZ_ALLOW_PRIVATE_PROPERTIES(ezWorld);
 
   ezGameObject* Reflection_TryGetObjectWithGlobalKey(ezTempHashedString sGlobalKey);
+  ezClock* Reflection_GetClock();
 
   void CheckForReadAccess() const;
   void CheckForWriteAccess() const;

--- a/Code/Engine/Foundation/Communication/Event.h
+++ b/Code/Engine/Foundation/Communication/Event.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Threading/Lock.h>
 #include <Foundation/Threading/Mutex.h>

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -912,7 +912,7 @@ void ezReflectionUtils::GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ez
   }
 }
 
-bool ezReflectionUtils::CreateDependencySortedTypeArray(const ezSet<const ezRTTI*>& types, ezDynamicArray<const ezRTTI*>& out_sortedTypes)
+ezResult ezReflectionUtils::CreateDependencySortedTypeArray(const ezSet<const ezRTTI*>& types, ezDynamicArray<const ezRTTI*>& out_sortedTypes)
 {
   out_sortedTypes.Clear();
   out_sortedTypes.Reserve(types.GetCount());
@@ -934,7 +934,7 @@ bool ezReflectionUtils::CreateDependencySortedTypeArray(const ezSet<const ezRTTI
       tmpStack.PopBack();
 
       if (types.Contains(pDependentType) == false)
-        return false;
+        return EZ_FAILURE;
 
       out_sortedTypes.PushBack(pDependentType);
     }
@@ -944,7 +944,7 @@ bool ezReflectionUtils::CreateDependencySortedTypeArray(const ezSet<const ezRTTI
   }
 
   EZ_ASSERT_DEV(types.GetCount() == out_sortedTypes.GetCount(), "Not all types have been sorted or the sorted list contains duplicates");
-  return true;
+  return EZ_SUCCESS;
 }
 
 bool ezReflectionUtils::EnumerationToString(const ezRTTI* pEnumerationRtti, ezInt64 iValue, ezStringBuilder& out_sOutput, ezEnum<EnumConversionMode> conversionMode)

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -861,16 +861,14 @@ const ezAbstractMemberProperty* ezReflectionUtils::GetMemberProperty(const ezRTT
 void ezReflectionUtils::GatherTypesDerivedFromClass(const ezRTTI* pBaseRtti, ezSet<const ezRTTI*>& out_types)
 {
   ezRTTI::ForEachDerivedType(pBaseRtti,
-    [&](const ezRTTI* pRtti)
-    {
+    [&](const ezRTTI* pRtti) {
       out_types.Insert(pRtti);
     });
 }
 
 void ezReflectionUtils::GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ezRTTI*>& inout_typesAsSet, ezDynamicArray<const ezRTTI*>* out_pTypesAsStack /*= nullptr*/)
 {
-  auto AddType = [&](const ezRTTI* pNewRtti)
-  {
+  auto AddType = [&](const ezRTTI* pNewRtti) {
     if (pNewRtti != pRtti && pNewRtti->GetTypeFlags().IsSet(ezTypeFlags::StandardType) == false && inout_typesAsSet.Contains(pNewRtti) == false)
     {
       inout_typesAsSet.Insert(pNewRtti);

--- a/Code/Engine/Foundation/Reflection/ReflectionUtils.h
+++ b/Code/Engine/Foundation/Reflection/ReflectionUtils.h
@@ -58,16 +58,16 @@ public:
   ///
   /// Dependencies are either member properties or base classes. The output contains the transitive closure of the dependencies.
   /// Note that inout_typesAsSet is not cleared when this function is called.
-  /// out_pTypesAsStack is all the dependencies sorted by their appearance in the depedency chain.
-  /// The last entry is the lowest in the chain and has no depedencies on its own.
+  /// out_pTypesAsStack is all the dependencies sorted by their appearance in the dependency chain.
+  /// The last entry is the lowest in the chain and has no dependencies on its own.
   static void GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ezRTTI*>& inout_typesAsSet, ezDynamicArray<const ezRTTI*>* out_pTypesAsStack = nullptr);
 
   /// \brief Sorts the input types according to their dependencies.
   ///
   /// Types that have no dependences come first in the output followed by types that have their dependencies met by
   /// the previous entries in the output.
-  /// If circular dependencies are found the function returns false.
-  static bool CreateDependencySortedTypeArray(const ezSet<const ezRTTI*>& types, ezDynamicArray<const ezRTTI*>& out_sortedTypes);
+  /// If a dependent type is not in the given types set the function will fail.
+  static ezResult CreateDependencySortedTypeArray(const ezSet<const ezRTTI*>& types, ezDynamicArray<const ezRTTI*>& out_sortedTypes);
 
   struct EnumConversionMode
   {

--- a/Code/Engine/Foundation/Reflection/ReflectionUtils.h
+++ b/Code/Engine/Foundation/Reflection/ReflectionUtils.h
@@ -50,16 +50,17 @@ public:
   /// \brief Gathers all RTTI types that are derived from pRtti.
   ///
   /// This includes all classes that have pRtti as a base class, either direct or indirect.
-  /// If bIncludeDependencies is set to true, the resulting set will also contain all dependent types.
   ///
   /// \sa GatherDependentTypes
-  static void GatherTypesDerivedFromClass(const ezRTTI* pRtti, ezSet<const ezRTTI*>& out_types, bool bIncludeDependencies);
+  static void GatherTypesDerivedFromClass(const ezRTTI* pRtti, ezSet<const ezRTTI*>& out_types);
 
   /// \brief Gathers all RTTI types that pRtti depends on and adds them to inout_types.
   ///
   /// Dependencies are either member properties or base classes. The output contains the transitive closure of the dependencies.
-  /// Note that inout_types is not cleared when this function is called.
-  static void GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ezRTTI*>& inout_types);
+  /// Note that inout_typesAsSet is not cleared when this function is called.
+  /// out_pTypesAsStack is all the dependencies sorted by their appearance in the depedency chain.
+  /// The last entry is the lowest in the chain and has no depedencies on its own.
+  static void GatherDependentTypes(const ezRTTI* pRtti, ezSet<const ezRTTI*>& inout_typesAsSet, ezDynamicArray<const ezRTTI*>* out_pTypesAsStack = nullptr);
 
   /// \brief Sorts the input types according to their dependencies.
   ///

--- a/Code/Engine/Foundation/Time/Clock.h
+++ b/Code/Engine/Foundation/Time/Clock.h
@@ -4,8 +4,8 @@
 
 #include <Foundation/Basics.h>
 #include <Foundation/Communication/Event.h>
-#include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/IO/Stream.h>
+#include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Time/Time.h>
 
 class ezTimeStepSmoothing;
@@ -196,6 +196,6 @@ public:
   virtual void Reset(const ezClock* pClock) = 0;
 };
 
-
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_FOUNDATION_DLL, ezClock);
 
 #include <Foundation/Time/Implementation/Clock_inl.h>

--- a/Code/Engine/Foundation/Time/Implementation/Clock.cpp
+++ b/Code/Engine/Foundation/Time/Implementation/Clock.cpp
@@ -19,6 +19,25 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(Foundation, Clock)
   }
 
 EZ_END_SUBSYSTEM_DECLARATION;
+
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezClock, ezNoBase, 1, ezRTTINoAllocator)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Paused", GetPaused, SetPaused),
+    EZ_ACCESSOR_PROPERTY("Speed", GetSpeed, SetSpeed),
+  }
+  EZ_END_PROPERTIES;
+
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetGlobalClock),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetAccumulatedTime),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetTimeDiff)
+  }
+  EZ_END_FUNCTIONS;
+}
+EZ_END_STATIC_REFLECTED_TYPE;
 // clang-format on
 
 ezClock::ezClock(ezStringView sName)

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -523,7 +523,8 @@ namespace
                   std::is_same_v<T, ezVec3> ||
                   std::is_same_v<T, ezTime> ||
                   std::is_same_v<T, ezAngle> ||
-                  std::is_same_v<T, ezString>)
+                  std::is_same_v<T, ezString> ||
+                  std::is_same_v<T, ezHashedString>)
     {
       const T& a = inout_context.GetData<T>(node.GetInputDataOffset(0));
       const T& b = inout_context.GetData<T>(node.GetInputDataOffset(1));

--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/Connection.cpp
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/Connection.cpp
@@ -94,11 +94,14 @@ void ezQtConnection::UpdateGeometry()
   else
   {
     p.moveTo(m_OutPoint);
-    float fDotOut = QPointF::dotProduct(m_OutDir, dir);
-    float fDotIn = QPointF::dotProduct(m_InDir, -dir);
+    float fDotOut = ezMath::Abs(QPointF::dotProduct(m_OutDir, dir));
+    float fDotIn = ezMath::Abs(QPointF::dotProduct(m_InDir, -dir));
 
-    fDotOut = ezMath::Max(100.0f, ezMath::Abs(fDotOut));
-    fDotIn = ezMath::Max(100.0f, ezMath::Abs(fDotIn));
+    float fMinDistance = ezMath::Abs(QPointF::dotProduct(m_OutDir.transposed(), dir));
+    fMinDistance = ezMath::Min(200.0f, fMinDistance);
+
+    fDotOut = ezMath::Max(fMinDistance, fDotOut);
+    fDotIn = ezMath::Max(fMinDistance, fDotIn);
 
     QPointF ctr1 = m_OutPoint + m_OutDir * (fDotOut * 0.5f);
     QPointF ctr2 = m_InPoint + m_InDir * (fDotIn * 0.5f);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
@@ -135,7 +135,7 @@ void ezQtAddSubElementButton::onMenuAboutToShow()
     if (pProp->GetFlags().IsSet(ezPropertyFlags::Pointer))
     {
       m_SupportedTypes.Clear();
-      ezReflectionUtils::GatherTypesDerivedFromClass(pProp->GetSpecificType(), m_SupportedTypes, false);
+      ezReflectionUtils::GatherTypesDerivedFromClass(pProp->GetSpecificType(), m_SupportedTypes);
     }
     m_SupportedTypes.Insert(pProp->GetSpecificType());
 

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedType.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedType.cpp
@@ -262,6 +262,7 @@ void ezReflectedFunctionDescriptor::operator=(const ezReflectedFunctionDescripto
 {
   m_sName = rhs.m_sName;
   m_Flags = rhs.m_Flags;
+  m_Type = rhs.m_Type;
   m_ReturnValue = rhs.m_ReturnValue;
   m_Arguments = rhs.m_Arguments;
   ezAttributeHolder::operator=(rhs);


### PR DESCRIPTION
* Exposed Clock to scripting.
* Fixed correctness of ezReflectionUtils::CreateDependencySortedTypeArray and improved performance. It would fail previously when a type had itself as dependency like ezGameObject does (Children, Parent), but the failure was just silently ignored.
* Include function arguments and attributes in the dependency collection.
* Send all types to the editor not only the ones derived from ezReflectedClass.
* Fixed that the reflected function type was not properly send to the editor.
* Slight tweak to connection curvature in node graphs.