### PR TITLE
Convert ezToolsFoundation to use ezStringView instead of const char*

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -235,7 +235,7 @@ public:
   /// The string may be a stringyfied asset GUID or a relative or absolute path. The function will try all possibilities.
   /// If no asset can be found, an empty/invalid ezAssetInfo is returned.
   /// If bExhaustiveSearch is set the function will go through all known assets and find the closest match.
-  const ezLockedSubAsset FindSubAsset(const char* szPathOrGuid, bool bExhaustiveSearch = false) const;
+  const ezLockedSubAsset FindSubAsset(ezStringView sPathOrGuid, bool bExhaustiveSearch = false) const;
 
   /// \brief Same as GetAssteInfo, but wraps the return value into a ezLockedSubAsset struct
   const ezLockedSubAsset GetSubAsset(const ezUuid& assetGuid) const;
@@ -286,7 +286,7 @@ public:
   ///@{
 
   /// \brief Allows to tell the system of a new or changed file, that might be of interest to the Curator.
-  void NotifyOfFileChange(const char* szAbsolutePath);
+  void NotifyOfFileChange(ezStringView sAbsolutePath);
   /// \brief Allows to tell the system to re-evaluate an assets status.
   void NotifyOfAssetChange(const ezUuid& assetGuid);
   void UpdateAssetLastAccessTime(const ezUuid& assetGuid);

--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -71,7 +71,7 @@ public:
     ezUInt16 m_uiReserved = 0;
   };
 
-  ezAssetDocument(const char* szDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType);
+  ezAssetDocument(ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType);
   ~ezAssetDocument();
 
   /// \name Asset Functions
@@ -203,7 +203,7 @@ protected:
   /// \param szPlatform Platform for which is the output is to be created. Default is 'PC'.
   /// \param AssetHeader Header already written to the stream, provided for reference.
   /// \param transformFlags flags that affect the transform process, see ezTransformFlags.
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) = 0;
 
   /// \brief Only override this function, if the transformed file for the given szOutputTag must be written from another process.
@@ -211,7 +211,7 @@ protected:
   /// szTargetFile is where the transformed asset should be written to. The overriding function must ensure to first
   /// write \a AssetHeader to the file, to make it a valid asset file or provide a custom ezAssetDocumentManager::IsOutputUpToDate function.
   /// See ezTransformFlags for definition of transform flags.
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags);
 
   ezStatus RemoteExport(const ezAssetFileHeader& header, const char* szOutputTarget) const;

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
@@ -27,7 +27,7 @@ public:
 
   // ezDocumentManager overrides:
 public:
-  virtual ezStatus CloneDocument(const char* szPath, const char* szClonePath, ezUuid& inout_cloneGuid) override;
+  virtual ezStatus CloneDocument(ezStringView sPath, ezStringView sClonePath, ezUuid& inout_cloneGuid) override;
 
   /// \name Asset Profile Functions
   ///@{
@@ -56,25 +56,25 @@ private:
   ///@{
 public:
   /// \brief Returns the absolute path to the thumbnail that belongs to the given document.
-  static ezString GenerateResourceThumbnailPath(const char* szDocumentPath);
-  static bool IsThumbnailUpToDate(const char* szDocumentPath, ezUInt64 uiThumbnailHash, ezUInt32 uiTypeVersion);
+  static ezString GenerateResourceThumbnailPath(ezStringView sDocumentPath);
+  static bool IsThumbnailUpToDate(ezStringView sDocumentPath, ezUInt64 uiThumbnailHash, ezUInt32 uiTypeVersion);
 
   ///@}
   /// \name Output Functions
   ///@{
 
-  virtual void AddEntriesToAssetTable(const char* szDataDirectory, const ezPlatformProfile* pAssetProfile, ezDelegate<void(ezStringView sGuid, ezStringView sPath, ezStringView sType)> addEntry) const;
-  virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const;
+  virtual void AddEntriesToAssetTable(ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile, ezDelegate<void(ezStringView sGuid, ezStringView sPath, ezStringView sType)> addEntry) const;
+  virtual ezString GetAssetTableEntry(const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const;
 
   /// \brief Calls GetRelativeOutputFileName and prepends [DataDir]/AssetCache/ .
-  ezString GetAbsoluteOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
+  ezString GetAbsoluteOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
 
   /// \brief Relative to 'AssetCache' folder.
-  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
+  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
   virtual bool GeneratesProfileSpecificAssets() const = 0;
 
-  bool IsOutputUpToDate(const char* szDocumentPath, const ezDynamicArray<ezString>& outputs, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
-  virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
+  bool IsOutputUpToDate(ezStringView sDocumentPath, const ezDynamicArray<ezString>& outputs, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
+  virtual bool IsOutputUpToDate(ezStringView sDocumentPath, ezStringView sOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);
 
   /// Describes how likely it is that a generated file is 'corrupted', due to dependency issues and such.
   /// For example a prefab may not work correctly, if it was written with a very different C++ plugin state, but this can't be detected later.

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -564,28 +564,28 @@ ezResult ezAssetCurator::WriteAssetTables(const ezPlatformProfile* pAssetProfile
 // ezAssetCurator Asset Access
 ////////////////////////////////////////////////////////////////////////
 
-const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* szPathOrGuid, bool bExhaustiveSearch) const
+const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(ezStringView sPathOrGuid, bool bExhaustiveSearch) const
 {
   CURATOR_PROFILE("FindSubAsset");
   EZ_LOCK(m_CuratorMutex);
 
-  if (ezConversionUtils::IsStringUuid(szPathOrGuid))
+  if (ezConversionUtils::IsStringUuid(sPathOrGuid))
   {
-    return GetSubAsset(ezConversionUtils::ConvertStringToUuid(szPathOrGuid));
+    return GetSubAsset(ezConversionUtils::ConvertStringToUuid(sPathOrGuid));
   }
 
   // Split into mainAsset|subAsset
   ezStringBuilder mainAsset;
   ezStringView subAsset;
-  const char* szSeparator = ezStringUtils::FindSubString(szPathOrGuid, "|");
+  const char* szSeparator = sPathOrGuid.FindSubString("|");
   if (szSeparator != nullptr)
   {
-    mainAsset.SetSubString_FromTo(szPathOrGuid, szSeparator);
+    mainAsset.SetSubString_FromTo(sPathOrGuid.GetStartPointer(), szSeparator);
     subAsset = ezStringView(szSeparator + 1);
   }
   else
   {
-    mainAsset = szPathOrGuid;
+    mainAsset = sPathOrGuid;
   }
   mainAsset.MakeCleanPath();
 
@@ -664,11 +664,11 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
     return pBestInfo;
   };
 
-  szSeparator = ezStringUtils::FindSubString(szPathOrGuid, "|");
+  szSeparator = sPathOrGuid.FindSubString("|");
   if (szSeparator != nullptr)
   {
     ezStringBuilder mainAsset2;
-    mainAsset2.SetSubString_FromTo(szPathOrGuid, szSeparator);
+    mainAsset2.SetSubString_FromTo(sPathOrGuid.GetStartPointer(), szSeparator);
 
     ezStringView subAsset2(szSeparator + 1);
     if (ezAssetInfo* pAssetInfo = FindAsset(mainAsset2))
@@ -684,7 +684,7 @@ const ezAssetCurator::ezLockedSubAsset ezAssetCurator::FindSubAsset(const char* 
     }
   }
 
-  ezStringBuilder sPath = szPathOrGuid;
+  ezStringBuilder sPath = sPathOrGuid;
   sPath.MakeCleanPath();
   if (sPath.IsAbsolutePath())
   {
@@ -1055,9 +1055,9 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
 // ezAssetCurator Manual and Automatic Change Notification
 ////////////////////////////////////////////////////////////////////////
 
-void ezAssetCurator::NotifyOfFileChange(const char* szAbsolutePath)
+void ezAssetCurator::NotifyOfFileChange(ezStringView sAbsolutePath)
 {
-  ezStringBuilder sPath(szAbsolutePath);
+  ezStringBuilder sPath(sAbsolutePath);
   sPath.MakeCleanPath();
   ezFileSystemModel::GetSingleton()->NotifyOfChange(sPath);
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -17,8 +17,8 @@
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAssetDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezAssetDocument::ezAssetDocument(const char* szDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType)
-  : ezDocument(szDocumentPath, pObjectManager)
+ezAssetDocument::ezAssetDocument(ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType)
+  : ezDocument(sDocumentPath, pObjectManager)
 {
   m_EngineConnectionType = engineConnectionType;
   m_EngineStatus = (m_EngineConnectionType != ezAssetDocEngineConnection::None) ? EngineStatus::Disconnected : EngineStatus::Unsupported;
@@ -547,7 +547,7 @@ ezTransformStatus ezAssetDocument::CreateThumbnail()
   return ezTransformStatus(ezFmt("Asset state is {}", state));
 }
 
-ezTransformStatus ezAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezDeferredFileWriter file;
   file.SetOutput(szTargetFile);
@@ -558,7 +558,7 @@ ezTransformStatus ezAssetDocument::InternalTransformAsset(const char* szTargetFi
     return ezTransformStatus("Failed to write asset header");
   }
 
-  ezTransformStatus res = InternalTransformAsset(file, szOutputTag, pAssetProfile, AssetHeader, transformFlags);
+  ezTransformStatus res = InternalTransformAsset(file, sOutputTag, pAssetProfile, AssetHeader, transformFlags);
   if (res.m_Result != ezTransformResult::Success)
   {
     // We do not want to overwrite the old output file if we failed to transform the asset.

--- a/Code/Editor/EditorFramework/Assets/SimpleAssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/SimpleAssetDocument.h
@@ -22,8 +22,8 @@ template <typename PropertyType, typename BaseClass = ezAssetDocument>
 class ezSimpleAssetDocument : public BaseClass
 {
 public:
-  ezSimpleAssetDocument(const char* szDocumentPath, ezAssetDocEngineConnection engineConnectionType, bool bEnableDefaultLighting = false)
-    : BaseClass(szDocumentPath, EZ_DEFAULT_NEW(ezSimpleDocumentObjectManager<PropertyType>), engineConnectionType)
+  ezSimpleAssetDocument(ezStringView sDocumentPath, ezAssetDocEngineConnection engineConnectionType, bool bEnableDefaultLighting = false)
+    : BaseClass(sDocumentPath, EZ_DEFAULT_NEW(ezSimpleDocumentObjectManager<PropertyType>), engineConnectionType)
     , m_LightSettings(bEnableDefaultLighting)
   {
     if (bEnableDefaultLighting)
@@ -33,8 +33,8 @@ public:
     }
   }
 
-  ezSimpleAssetDocument(ezDocumentObjectManager* pObjectManager, const char* szDocumentPath, ezAssetDocEngineConnection engineConnectionType, bool bEnableDefaultLighting = false)
-    : BaseClass(szDocumentPath, pObjectManager, engineConnectionType)
+  ezSimpleAssetDocument(ezDocumentObjectManager* pObjectManager, ezStringView sDocumentPath, ezAssetDocEngineConnection engineConnectionType, bool bEnableDefaultLighting = false)
+    : BaseClass(sDocumentPath, pObjectManager, engineConnectionType)
     , m_LightSettings(bEnableDefaultLighting)
   {
     if (bEnableDefaultLighting)

--- a/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
@@ -17,8 +17,8 @@ class ezAssetProfilesDocument : public ezDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezAssetProfilesDocument, ezDocument);
 
 public:
-  ezAssetProfilesDocument(const char* szDocumentPath)
-    : ezDocument(szDocumentPath, EZ_DEFAULT_NEW(ezAssetProfilesObjectManager))
+  ezAssetProfilesDocument(ezStringView sDocumentPath)
+    : ezDocument(sDocumentPath, EZ_DEFAULT_NEW(ezAssetProfilesObjectManager))
   {
   }
 

--- a/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/PreferencesDlg.cpp
@@ -26,8 +26,8 @@ class ezPreferencesDocument : public ezDocument
 
 
 public:
-  ezPreferencesDocument(const char* szDocumentPath)
-    : ezDocument(szDocumentPath, EZ_DEFAULT_NEW(ezPreferencesObjectManager))
+  ezPreferencesDocument(ezStringView sDocumentPath)
+    : ezDocument(sDocumentPath, EZ_DEFAULT_NEW(ezPreferencesObjectManager))
   {
   }
 

--- a/Code/Editor/EditorFramework/Document/GameObjectContextDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectContextDocument.h
@@ -18,7 +18,7 @@ class EZ_EDITORFRAMEWORK_DLL ezGameObjectContextDocument : public ezGameObjectDo
   EZ_ADD_DYNAMIC_REFLECTION(ezGameObjectContextDocument, ezGameObjectDocument);
 
 public:
-  ezGameObjectContextDocument(const char* szDocumentPath, ezDocumentObjectManager* pObjectManager,
+  ezGameObjectContextDocument(ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager,
     ezAssetDocEngineConnection engineConnectionType = ezAssetDocEngineConnection::FullObjectMirroring);
   ~ezGameObjectContextDocument();
 

--- a/Code/Editor/EditorFramework/Document/GameObjectDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectDocument.h
@@ -96,7 +96,7 @@ class EZ_EDITORFRAMEWORK_DLL ezGameObjectDocument : public ezAssetDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezGameObjectDocument, ezAssetDocument);
 
 public:
-  ezGameObjectDocument(const char* szDocumentPath, ezDocumentObjectManager* pObjectManager,
+  ezGameObjectDocument(ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager,
     ezAssetDocEngineConnection engineConnectionType = ezAssetDocEngineConnection::FullObjectMirroring);
   ~ezGameObjectDocument();
 

--- a/Code/Editor/EditorFramework/Document/Implementation/GameObjectContextDocument.cpp
+++ b/Code/Editor/EditorFramework/Document/Implementation/GameObjectContextDocument.cpp
@@ -13,8 +13,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 ezGameObjectContextDocument::ezGameObjectContextDocument(
-  const char* szDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType)
-  : ezGameObjectDocument(szDocumentPath, pObjectManager, engineConnectionType)
+  ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType)
+  : ezGameObjectDocument(sDocumentPath, pObjectManager, engineConnectionType)
 {
 }
 

--- a/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
+++ b/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
@@ -33,8 +33,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezEvent<const ezGameObjectDocumentEvent&> ezGameObjectDocument::s_GameObjectDocumentEvents;
 
 ezGameObjectDocument::ezGameObjectDocument(
-  const char* szDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType)
-  : ezAssetDocument(szDocumentPath, pObjectManager, engineConnectionType)
+  ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType)
+  : ezAssetDocument(sDocumentPath, pObjectManager, engineConnectionType)
 {
   using Meta = ezObjectMetaData<ezUuid, ezGameObjectMetaData>;
   m_GameObjectMetaData = EZ_DEFAULT_NEW(Meta);

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -215,8 +215,7 @@ bool ezEditorEngineProcessConnection::ConnectToRemoteProcess()
   m_pRemoteProcess->ConnectToServer(dlg.GetResultingAddress().toUtf8().data()).IgnoreResult();
 
   ezQtWaitForOperationDlg waitDialog(QApplication::activeWindow());
-  waitDialog.m_OnIdle = [this]() -> bool
-  {
+  waitDialog.m_OnIdle = [this]() -> bool {
     if (m_pRemoteProcess->IsConnected())
       return false;
 
@@ -309,8 +308,7 @@ ezResult ezEditorEngineProcessConnection::WaitForDocumentMessage(const ezUuid& a
   data.m_AssetGuid = assetGuid;
   data.m_pCallback = pCallback;
 
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
-  {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
     ezEditorEngineDocumentMsg* pMsg2 = ezDynamicCast<ezEditorEngineDocumentMsg*>(pMsg);
     if (pMsg2 && data.m_AssetGuid == pMsg2->m_DocumentGuid)
     {
@@ -383,8 +381,7 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
   {
     docs.PushBack(it.Value());
   }
-  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b)
-    {
+  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b) {
     if (a->IsMainDocument() != b->IsMainDocument())
       return a->IsMainDocument();
     return a < b; });

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -215,7 +215,8 @@ bool ezEditorEngineProcessConnection::ConnectToRemoteProcess()
   m_pRemoteProcess->ConnectToServer(dlg.GetResultingAddress().toUtf8().data()).IgnoreResult();
 
   ezQtWaitForOperationDlg waitDialog(QApplication::activeWindow());
-  waitDialog.m_OnIdle = [this]() -> bool {
+  waitDialog.m_OnIdle = [this]() -> bool
+  {
     if (m_pRemoteProcess->IsConnected())
       return false;
 
@@ -308,7 +309,8 @@ ezResult ezEditorEngineProcessConnection::WaitForDocumentMessage(const ezUuid& a
   data.m_AssetGuid = assetGuid;
   data.m_pCallback = pCallback;
 
-  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool {
+  ezProcessCommunicationChannel::WaitForMessageCallback callback = [&data](ezProcessMessage* pMsg) -> bool
+  {
     ezEditorEngineDocumentMsg* pMsg2 = ezDynamicCast<ezEditorEngineDocumentMsg*>(pMsg);
     if (pMsg2 && data.m_AssetGuid == pMsg2->m_DocumentGuid)
     {
@@ -381,7 +383,8 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
   {
     docs.PushBack(it.Value());
   }
-  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b) {
+  docs.Sort([](const ezAssetDocument* a, const ezAssetDocument* b)
+    {
     if (a->IsMainDocument() != b->IsMainDocument())
       return a->IsMainDocument();
     return a < b; });
@@ -431,12 +434,15 @@ void ezEditorEngineProcessConnection::Update()
 
 bool ezEditorEngineConnection::SendMessage(ezEditorEngineDocumentMsg* pMessage)
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wtautological-undefined-compare"
+#endif
   EZ_ASSERT_DEV(this != nullptr, "No connection between editor and engine was created. This typically happens when an asset document does "
                                  "not enable the engine-connection through the constructor of ezAssetDocument."); // NOLINT
-#pragma GCC diagnostic pop
-
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
   pMessage->m_DocumentGuid = m_pDocument->GetGuid();
 
   return ezEditorEngineProcessConnection::GetSingleton()->SendMessage(pMessage);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -11,12 +11,12 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetDocument, 8, ezRTTINoAllocato
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezAnimatedMeshAssetDocument::ezAnimatedMeshAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezAnimatedMeshAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezAnimatedMeshAssetDocument::ezAnimatedMeshAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezAnimatedMeshAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
 }
 
-ezTransformStatus ezAnimatedMeshAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezAnimatedMeshAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezProgressRange range("Transforming Asset", 2, false);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
@@ -12,10 +12,10 @@ class ezAnimatedMeshAssetDocument : public ezSimpleAssetDocument<ezAnimatedMeshA
   EZ_ADD_DYNAMIC_REFLECTION(ezAnimatedMeshAssetDocument, ezSimpleAssetDocument<ezAnimatedMeshAssetProperties>);
 
 public:
-  ezAnimatedMeshAssetDocument(const char* szDocumentPath);
+  ezAnimatedMeshAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus CreateMeshFromFile(ezAnimatedMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.cpp
@@ -46,9 +46,9 @@ void ezAnimatedMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocument
   }
 }
 
-void ezAnimatedMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezAnimatedMeshAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezAnimatedMeshAssetDocument(szPath);
+  out_pDocument = new ezAnimatedMeshAssetDocument(sPath);
 }
 
 void ezAnimatedMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetManager.h
@@ -14,7 +14,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -61,8 +61,8 @@ void ezAnimationClipAssetProperties::PropertyMetaStateEventHandler(ezPropertyMet
   }
 }
 
-ezAnimationClipAssetDocument::ezAnimationClipAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezAnimationClipAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezAnimationClipAssetDocument::ezAnimationClipAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezAnimationClipAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
 }
 
@@ -94,7 +94,7 @@ double ezAnimationClipAssetDocument::GetCommonAssetUiState(ezCommonAssetUiState:
   return SUPER::GetCommonAssetUiState(state);
 }
 
-ezTransformStatus ezAnimationClipAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezAnimationClipAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezProgressRange range("Transforming Asset", 2, false);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -54,7 +54,7 @@ class ezAnimationClipAssetDocument : public ezSimpleAssetDocument<ezAnimationCli
   EZ_ADD_DYNAMIC_REFLECTION(ezAnimationClipAssetDocument, ezSimpleAssetDocument<ezAnimationClipAssetProperties>);
 
 public:
-  ezAnimationClipAssetDocument(const char* szDocumentPath);
+  ezAnimationClipAssetDocument(ezStringView sDocumentPath);
 
   virtual void SetCommonAssetUiState(ezCommonAssetUiState::Enum state, double value) override;
   virtual double GetCommonAssetUiState(ezCommonAssetUiState::Enum state) const override;
@@ -62,7 +62,7 @@ public:
   ezUuid InsertEventTrackCpAt(ezInt64 iTickX, const char* szValue);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 
   // void ApplyCustomRootMotion(ezAnimationClipResourceDescriptor& anim) const;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.cpp
@@ -51,9 +51,9 @@ void ezAnimationClipAssetDocumentManager::OnDocumentManagerEvent(const ezDocumen
   }
 }
 
-void ezAnimationClipAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezAnimationClipAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezAnimationClipAssetDocument(szPath);
+  out_pDocument = new ezAnimationClipAssetDocument(sPath);
 }
 
 void ezAnimationClipAssetDocumentManager::InternalGetSupportedDocumentTypes(

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetManager.h
@@ -14,7 +14,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAsset.cpp
@@ -259,13 +259,13 @@ bool ezAnimationGraphNodeManager::InternalIsDynamicPinProperty(const ezDocumentO
   return pProp->GetAttributeByType<ezDynamicPinAttribute>() != nullptr;
 }
 
-ezAnimationGraphAssetDocument::ezAnimationGraphAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezAnimationGraphAssetProperties>(EZ_DEFAULT_NEW(ezAnimationGraphNodeManager), szDocumentPath, ezAssetDocEngineConnection::None)
+ezAnimationGraphAssetDocument::ezAnimationGraphAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezAnimationGraphAssetProperties>(EZ_DEFAULT_NEW(ezAnimationGraphNodeManager), sDocumentPath, ezAssetDocEngineConnection::None)
 {
   m_pObjectAccessor = EZ_DEFAULT_NEW(ezNodeCommandAccessor, GetCommandHistory());
 }
 
-ezTransformStatus ezAnimationGraphAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezAnimationGraphAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const auto* pNodeManager = static_cast<const ezDocumentNodeManager*>(GetObjectManager());
 
@@ -375,7 +375,7 @@ bool ezAnimationGraphAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& o
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezAnimationGraphAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezAnimationGraphAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAsset.h
@@ -51,7 +51,7 @@ class ezAnimationGraphAssetDocument : public ezSimpleAssetDocument<ezAnimationGr
   EZ_ADD_DYNAMIC_REFLECTION(ezAnimationGraphAssetDocument, ezSimpleAssetDocument<ezAnimationGraphAssetProperties>);
 
 public:
-  ezAnimationGraphAssetDocument(const char* szDocumentPath);
+  ezAnimationGraphAssetDocument(ezStringView sDocumentPath);
 
 protected:
   struct PinCount
@@ -62,11 +62,11 @@ protected:
     ezUInt16 m_uiOutputIdx = 0;
   };
 
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_MimeType) const override;
-  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   virtual void InternalGetMetaDataHash(const ezDocumentObject* pObject, ezUInt64& inout_uiHash) const override;
   virtual void AttachMetaDataBeforeSaving(ezAbstractObjectGraph& graph) const override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAssetManager.cpp
@@ -48,9 +48,9 @@ void ezAnimationGraphAssetManager::OnDocumentManagerEvent(const ezDocumentManage
   }
 }
 
-void ezAnimationGraphAssetManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezAnimationGraphAssetManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezAnimationGraphAssetDocument(szPath);
+  out_pDocument = new ezAnimationGraphAssetDocument(sPath);
 }
 
 void ezAnimationGraphAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAssetManager.h
@@ -14,7 +14,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAsset.cpp
@@ -20,8 +20,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezBlackboardTemplateAssetDocument, 1, ezRTTINoAl
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezBlackboardTemplateAssetDocument::ezBlackboardTemplateAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezBlackboardTemplateAssetObject>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezBlackboardTemplateAssetDocument::ezBlackboardTemplateAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezBlackboardTemplateAssetObject>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -77,7 +77,7 @@ ezStatus ezBlackboardTemplateAssetDocument::RetrieveState(const ezBlackboardTemp
   return ezStatus(EZ_SUCCESS);
 }
 
-ezTransformStatus ezBlackboardTemplateAssetDocument::InternalTransformAsset(ezStreamWriter& inout_stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezBlackboardTemplateAssetDocument::InternalTransformAsset(ezStreamWriter& inout_stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   return WriteAsset(inout_stream, pAssetProfile);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAsset.h
@@ -18,12 +18,12 @@ class ezBlackboardTemplateAssetDocument : public ezSimpleAssetDocument<ezBlackbo
   EZ_ADD_DYNAMIC_REFLECTION(ezBlackboardTemplateAssetDocument, ezSimpleAssetDocument<ezBlackboardTemplateAssetObject>);
 
 public:
-  ezBlackboardTemplateAssetDocument(const char* szDocumentPath);
+  ezBlackboardTemplateAssetDocument(ezStringView sDocumentPath);
 
   ezStatus WriteAsset(ezStreamWriter& inout_stream, const ezPlatformProfile* pAssetProfile) const;
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& inout_stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& inout_stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus RetrieveState(const ezBlackboardTemplateAssetObject* pProp, ezBlackboardTemplateResourceDescriptor& inout_Desc) const;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetManager.cpp
@@ -48,9 +48,9 @@ void ezBlackboardTemplateAssetDocumentManager::OnDocumentManagerEvent(const ezDo
   }
 }
 
-void ezBlackboardTemplateAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezBlackboardTemplateAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezBlackboardTemplateAssetDocument(szPath);
+  out_pDocument = new ezBlackboardTemplateAssetDocument(sPath);
 }
 
 void ezBlackboardTemplateAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetManager.h
@@ -14,7 +14,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
 
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.cpp
@@ -30,8 +30,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCollectionAssetDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezCollectionAssetDocument::ezCollectionAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezCollectionAssetData>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezCollectionAssetDocument::ezCollectionAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezCollectionAssetData>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -81,7 +81,7 @@ static bool InsertEntry(ezStringView sID, ezStringView sLookupName, ezMap<ezStri
   return true;
 }
 
-ezTransformStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezCollectionAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const ezCollectionAssetData* pProp = GetProperties();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAsset.h
@@ -25,8 +25,8 @@ class ezCollectionAssetDocument : public ezSimpleAssetDocument<ezCollectionAsset
   EZ_ADD_DYNAMIC_REFLECTION(ezCollectionAssetDocument, ezSimpleAssetDocument<ezCollectionAssetData>);
 
 public:
-  ezCollectionAssetDocument(const char* szDocumentPath);
+  ezCollectionAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -49,9 +49,9 @@ void ezCollectionAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMa
 }
 
 void ezCollectionAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezCollectionAssetDocument(szPath);
+  out_pDocument = new ezCollectionAssetDocument(sPath);
 }
 
 void ezCollectionAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.cpp
@@ -78,8 +78,8 @@ void ezIntensityControlPoint::SetTickFromTime(ezTime time, ezInt64 iFps)
   m_iTick = (ezInt64)ezMath::RoundToMultiple(time.GetSeconds() * 4800.0, (double)uiTicksPerStep);
 }
 
-ezColorGradientAssetDocument::ezColorGradientAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezColorGradientAssetData>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezColorGradientAssetDocument::ezColorGradientAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezColorGradientAssetData>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -178,7 +178,7 @@ ezColor ezColorGradientAssetData::Evaluate(ezInt64 iTick) const
   return color;
 }
 
-ezTransformStatus ezColorGradientAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezColorGradientAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   WriteResource(stream);
   return ezStatus(EZ_SUCCESS);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h
@@ -67,12 +67,12 @@ class ezColorGradientAssetDocument : public ezSimpleAssetDocument<ezColorGradien
   EZ_ADD_DYNAMIC_REFLECTION(ezColorGradientAssetDocument, ezSimpleAssetDocument<ezColorGradientAssetData>);
 
 public:
-  ezColorGradientAssetDocument(const char* szDocumentPath);
+  ezColorGradientAssetDocument(ezStringView sDocumentPath);
 
   void WriteResource(ezStreamWriter& inout_stream) const;
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.cpp
@@ -47,9 +47,9 @@ void ezColorGradientAssetDocumentManager::OnDocumentManagerEvent(const ezDocumen
 }
 
 void ezColorGradientAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezColorGradientAssetDocument(szPath);
+  out_pDocument = new ezColorGradientAssetDocument(sPath);
 }
 
 void ezColorGradientAssetDocumentManager::InternalGetSupportedDocumentTypes(

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetManager.h
@@ -17,7 +17,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.cpp
@@ -6,8 +6,8 @@
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCurve1DAssetDocument, 3, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezCurve1DAssetDocument::ezCurve1DAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezCurveGroupData>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezCurve1DAssetDocument::ezCurve1DAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezCurveGroupData>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -41,7 +41,7 @@ void ezCurve1DAssetDocument::WriteResource(ezStreamWriter& inout_stream) const
   desc.Save(inout_stream);
 }
 
-ezTransformStatus ezCurve1DAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezCurve1DAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   WriteResource(stream);
   return ezStatus(EZ_SUCCESS);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.h
@@ -10,7 +10,7 @@ class ezCurve1DAssetDocument : public ezSimpleAssetDocument<ezCurveGroupData>
   EZ_ADD_DYNAMIC_REFLECTION(ezCurve1DAssetDocument, ezSimpleAssetDocument<ezCurveGroupData>);
 
 public:
-  ezCurve1DAssetDocument(const char* szDocumentPath);
+  ezCurve1DAssetDocument(ezStringView sDocumentPath);
   ~ezCurve1DAssetDocument();
 
   /// \brief Fills out the ezCurve1D structure with an exact copy of the data in the asset.
@@ -22,7 +22,7 @@ public:
   void WriteResource(ezStreamWriter& inout_stream) const;
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.cpp
@@ -47,9 +47,9 @@ void ezCurve1DAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManag
 }
 
 void ezCurve1DAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezCurve1DAssetDocument(szPath);
+  out_pDocument = new ezCurve1DAssetDocument(sPath);
 }
 
 void ezCurve1DAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetManager.h
@@ -17,7 +17,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -70,12 +70,12 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDecalAssetDocument, 5, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezDecalAssetDocument::ezDecalAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezDecalAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezDecalAssetDocument::ezDecalAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezDecalAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
 }
 
-ezTransformStatus ezDecalAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezDecalAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   return static_cast<ezDecalAssetDocumentManager*>(GetAssetDocumentManager())->GenerateDecalTexture(pAssetProfile);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
@@ -54,10 +54,10 @@ class ezDecalAssetDocument : public ezSimpleAssetDocument<ezDecalAssetProperties
   EZ_ADD_DYNAMIC_REFLECTION(ezDecalAssetDocument, ezSimpleAssetDocument<ezDecalAssetProperties>);
 
 public:
-  ezDecalAssetDocument(const char* szDocumentPath);
+  ezDecalAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -42,19 +42,19 @@ ezDecalAssetDocumentManager::~ezDecalAssetDocumentManager()
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezDecalAssetDocumentManager::OnDocumentManagerEvent, this));
 }
 
-void ezDecalAssetDocumentManager::AddEntriesToAssetTable(const char* szDataDirectory, const ezPlatformProfile* pAssetProfile, ezDelegate<void(ezStringView sGuid, ezStringView sPath, ezStringView sType)> addEntry) const
+void ezDecalAssetDocumentManager::AddEntriesToAssetTable(ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile, ezDelegate<void(ezStringView sGuid, ezStringView sPath, ezStringView sType)> addEntry) const
 {
   ezStringBuilder projectDir = ezToolsProject::GetSingleton()->GetProjectDirectory();
   projectDir.MakeCleanPath();
   projectDir.Append("/");
 
-  if (projectDir.StartsWith_NoCase(szDataDirectory))
+  if (projectDir.StartsWith_NoCase(sDataDirectory))
   {
     addEntry("{ ProjectDecalAtlas }", "PC/Decals.ezTextureAtlas", "Decal Atlas");
   }
 }
 
-ezString ezDecalAssetDocumentManager::GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const
+ezString ezDecalAssetDocumentManager::GetAssetTableEntry(const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const
 {
   // means NO table entry will be written, because for decals we don't need a redirection
   return ezString();
@@ -78,9 +78,9 @@ void ezDecalAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager
   }
 }
 
-void ezDecalAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezDecalAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezDecalAssetDocument(szPath);
+  out_pDocument = new ezDecalAssetDocument(sPath);
 }
 
 void ezDecalAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.h
@@ -12,9 +12,9 @@ public:
   ~ezDecalAssetDocumentManager();
 
   virtual void AddEntriesToAssetTable(
-    const char* szDataDirectory, const ezPlatformProfile* pAssetProfile, ezDelegate<void(ezStringView sGuid, ezStringView sPath, ezStringView sType)> addEntry) const override;
+    ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile, ezDelegate<void(ezStringView sGuid, ezStringView sPath, ezStringView sType)> addEntry) const override;
   virtual ezString GetAssetTableEntry(
-    const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const override;
+    const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const override;
 
   /// \brief There is only a single decal texture per project. This function creates it, in case any decal asset was modified.
   ezStatus GenerateDecalTexture(const ezPlatformProfile* pAssetProfile);
@@ -26,7 +26,7 @@ private:
   ezStatus RunTexConv(const char* szTargetFile, const char* szInputFile, const ezAssetFileHeader& AssetHeader);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.cpp
@@ -8,12 +8,12 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezImageDataAssetDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezImageDataAssetDocument::ezImageDataAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezImageDataAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezImageDataAssetDocument::ezImageDataAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezImageDataAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
-ezTransformStatus ezImageDataAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezImageDataAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const bool bUpdateThumbnail = pAssetProfile == ezAssetCurator::GetSingleton()->GetDevelopmentAssetProfile();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.h
@@ -19,15 +19,15 @@ class ezImageDataAssetDocument : public ezSimpleAssetDocument<ezImageDataAssetPr
   EZ_ADD_DYNAMIC_REFLECTION(ezImageDataAssetDocument, ezSimpleAssetDocument<ezImageDataAssetProperties>);
 
 public:
-  ezImageDataAssetDocument(const char* szDocumentPath);
+  ezImageDataAssetDocument(ezStringView sDocumentPath);
 
   const ezEvent<const ezImageDataAssetEvent&>& Events() const { return m_Events; }
 
 protected:
   ezEvent<const ezImageDataAssetEvent&> m_Events;
 
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override { return ezStatus(EZ_SUCCESS); }
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override { return ezStatus(EZ_SUCCESS); }
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus RunTexConv(const char* szTargetFile, const ezAssetFileHeader& AssetHeader, bool bUpdateThumbnail);
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetManager.cpp
@@ -49,9 +49,9 @@ void ezImageDataAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMan
   }
 }
 
-void ezImageDataAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezImageDataAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  ezImageDataAssetDocument* pDoc = new ezImageDataAssetDocument(szPath);
+  ezImageDataAssetDocument* pDoc = new ezImageDataAssetDocument(sPath);
   out_pDocument = pDoc;
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetManager.h
@@ -17,7 +17,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.cpp
@@ -17,12 +17,12 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezLUTAssetDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezLUTAssetDocument::ezLUTAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezLUTAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezLUTAssetDocument::ezLUTAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezLUTAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
-ezTransformStatus ezLUTAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezLUTAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const auto props = GetProperties();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
@@ -11,15 +11,15 @@ class ezLUTAssetDocument : public ezSimpleAssetDocument<ezLUTAssetProperties>
   EZ_ADD_DYNAMIC_REFLECTION(ezLUTAssetDocument, ezSimpleAssetDocument<ezLUTAssetProperties>);
 
 public:
-  ezLUTAssetDocument(const char* szDocumentPath);
+  ezLUTAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override
   {
     return ezStatus(EZ_SUCCESS);
   }
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetManager.cpp
@@ -58,9 +58,9 @@ void ezLUTAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::
 }
 
 void ezLUTAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  ezLUTAssetDocument* pDoc = new ezLUTAssetDocument(szPath);
+  ezLUTAssetDocument* pDoc = new ezLUTAssetDocument(sPath);
   out_pDocument = pDoc;
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetManager.h
@@ -18,7 +18,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -513,8 +513,8 @@ ezString ezMaterialAssetProperties::ResolveRelativeShaderPath() const
 
 //////////////////////////////////////////////////////////////////////////
 
-ezMaterialAssetDocument::ezMaterialAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezMaterialAssetProperties>(EZ_DEFAULT_NEW(ezMaterialObjectManager), szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezMaterialAssetDocument::ezMaterialAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezMaterialAssetProperties>(EZ_DEFAULT_NEW(ezMaterialObjectManager), sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
   ezQtEditorApp::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&ezMaterialAssetDocument::EditorEventHandler, this));
 }
@@ -626,11 +626,11 @@ ezUuid ezMaterialAssetDocument::GetMaterialNodeGuid(const ezAbstractObjectGraph&
   return ezUuid();
 }
 
-void ezMaterialAssetDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, const char* szBasePrefab)
+void ezMaterialAssetDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, ezStringView sBasePrefab)
 {
   // Base
   ezAbstractObjectGraph baseGraph;
-  ezPrefabUtils::LoadGraph(baseGraph, szBasePrefab);
+  ezPrefabUtils::LoadGraph(baseGraph, sBasePrefab);
   baseGraph.PruneGraph(GetMaterialNodeGuid(baseGraph));
 
   // NewBase
@@ -790,9 +790,9 @@ public:
   }
 };
 
-ezTransformStatus ezMaterialAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezMaterialAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
-  if (ezStringUtils::IsEqual(szOutputTag, ezMaterialAssetDocumentManager::s_szShaderOutputTag))
+  if (sOutputTag.IsEqual(ezMaterialAssetDocumentManager::s_szShaderOutputTag))
   {
     ezStatus ret = RecreateVisualShaderFile(AssetHeader);
 
@@ -877,13 +877,13 @@ ezTransformStatus ezMaterialAssetDocument::InternalTransformAsset(const char* sz
   }
   else
   {
-    return SUPER::InternalTransformAsset(szTargetFile, szOutputTag, pAssetProfile, AssetHeader, transformFlags);
+    return SUPER::InternalTransformAsset(szTargetFile, sOutputTag, pAssetProfile, AssetHeader, transformFlags);
   }
 }
 
-ezTransformStatus ezMaterialAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezMaterialAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
-  EZ_ASSERT_DEV(ezStringUtils::IsNullOrEmpty(szOutputTag), "Additional output '{0}' not implemented!", szOutputTag);
+  EZ_ASSERT_DEV(sOutputTag.IsEmpty(), "Additional output '{0}' not implemented!", sOutputTag);
 
   return WriteMaterialAsset(stream, pAssetProfile, true);
 }
@@ -1399,7 +1399,7 @@ bool ezMaterialAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& out_obj
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezMaterialAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezMaterialAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.h
@@ -103,7 +103,7 @@ class ezMaterialAssetDocument : public ezSimpleAssetDocument<ezMaterialAssetProp
   EZ_ADD_DYNAMIC_REFLECTION(ezMaterialAssetDocument, ezSimpleAssetDocument<ezMaterialAssetProperties>);
 
 public:
-  ezMaterialAssetDocument(const char* szDocumentPath);
+  ezMaterialAssetDocument(ezStringView sDocumentPath);
   ~ezMaterialAssetDocument();
 
   ezDocumentObject* GetShaderPropertyObject();
@@ -130,7 +130,7 @@ public:
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_mimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_sMimeType) const override;
-  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   ezEvent<const ezMaterialVisualShaderEvent&> m_VisualShaderEvents;
   ezEnum<ezMaterialAssetPreview> m_PreviewModel;
@@ -138,11 +138,11 @@ public:
 protected:
   ezUuid GetSeedFromBaseMaterial(const ezAbstractObjectGraph* pBaseGraph);
   static ezUuid GetMaterialNodeGuid(const ezAbstractObjectGraph& graph);
-  virtual void UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, const char* szBasePrefab) override;
+  virtual void UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, ezStringView sBasePrefab) override;
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
 
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 
   virtual void InternalGetMetaDataHash(const ezDocumentObject* pObject, ezUInt64& inout_uiHash) const override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -35,25 +35,25 @@ ezMaterialAssetDocumentManager::~ezMaterialAssetDocumentManager()
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezMaterialAssetDocumentManager::OnDocumentManagerEvent, this));
 }
 
-ezString ezMaterialAssetDocumentManager::GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const
+ezString ezMaterialAssetDocumentManager::GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const
 {
-  if (ezStringUtils::IsEqual(szOutputTag, s_szShaderOutputTag))
+  if (sOutputTag.IsEqual(s_szShaderOutputTag))
   {
-    ezStringBuilder sRelativePath(szDocumentPath);
-    sRelativePath.MakeRelativeTo(szDataDirectory).IgnoreResult();
+    ezStringBuilder sRelativePath(sDocumentPath);
+    sRelativePath.MakeRelativeTo(sDataDirectory).IgnoreResult();
     ezAssetDocumentManager::GenerateOutputFilename(sRelativePath, pAssetProfile, "autogen.ezShader", false);
     return sRelativePath;
   }
 
-  return SUPER::GetRelativeOutputFileName(pTypeDescriptor, szDataDirectory, szDocumentPath, szOutputTag, pAssetProfile);
+  return SUPER::GetRelativeOutputFileName(pTypeDescriptor, sDataDirectory, sDocumentPath, sOutputTag, pAssetProfile);
 }
 
 
-bool ezMaterialAssetDocumentManager::IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor)
+bool ezMaterialAssetDocumentManager::IsOutputUpToDate(ezStringView sDocumentPath, ezStringView sOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor)
 {
-  if (ezStringUtils::IsEqual(szOutputTag, s_szShaderOutputTag))
+  if (sOutputTag.IsEqual(s_szShaderOutputTag))
   {
-    const ezString sTargetFile = GetAbsoluteOutputFileName(pTypeDescriptor, szDocumentPath, szOutputTag);
+    const ezString sTargetFile = GetAbsoluteOutputFileName(pTypeDescriptor, sDocumentPath, sOutputTag);
 
     ezStringBuilder sExpectedHeader;
     sExpectedHeader.Format("//{0}|{1}\n", uiHash, pTypeDescriptor->m_pDocumentType->GetTypeVersion());
@@ -73,7 +73,7 @@ bool ezMaterialAssetDocumentManager::IsOutputUpToDate(const char* szDocumentPath
     return sFileHeader.IsEqual(sExpectedHeader);
   }
 
-  return ezAssetDocumentManager::IsOutputUpToDate(szDocumentPath, szOutputTag, uiHash, pTypeDescriptor);
+  return ezAssetDocumentManager::IsOutputUpToDate(sDocumentPath, sOutputTag, uiHash, pTypeDescriptor);
 }
 
 
@@ -95,9 +95,9 @@ void ezMaterialAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMana
   }
 }
 
-void ezMaterialAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezMaterialAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezMaterialAssetDocument(szPath);
+  out_pDocument = new ezMaterialAssetDocument(sPath);
 }
 
 void ezMaterialAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
@@ -11,15 +11,15 @@ public:
   ezMaterialAssetDocumentManager();
   ~ezMaterialAssetDocumentManager();
 
-  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const override;
-  virtual bool IsOutputUpToDate(const char* szDocumentPath, const char* szOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor) override;
+  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const override;
+  virtual bool IsOutputUpToDate(ezStringView sDocumentPath, ezStringView sOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor) override;
 
   static const char* const s_szShaderOutputTag;
 
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -21,12 +21,12 @@ static ezMat3 CalculateTransformationMatrix(const ezMeshAssetProperties* pProp)
   return ezBasisAxis::CalculateTransformationMatrix(forwardDir, pProp->m_RightDir, pProp->m_UpDir, us);
 }
 
-ezMeshAssetDocument::ezMeshAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezMeshAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezMeshAssetDocument::ezMeshAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezMeshAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
 }
 
-ezTransformStatus ezMeshAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezMeshAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezProgressRange range("Transforming Asset", 2, false);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -13,10 +13,10 @@ class ezMeshAssetDocument : public ezSimpleAssetDocument<ezMeshAssetProperties>
   EZ_ADD_DYNAMIC_REFLECTION(ezMeshAssetDocument, ezSimpleAssetDocument<ezMeshAssetProperties>);
 
 public:
-  ezMeshAssetDocument(const char* szDocumentPath);
+  ezMeshAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   void CreateMeshFromGeom(ezMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc);
   ezTransformStatus CreateMeshFromFile(ezMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc, bool bAllowMaterialImport);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.cpp
@@ -119,9 +119,9 @@ void ezMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager:
 }
 
 void ezMeshAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezMeshAssetDocument(szPath);
+  out_pDocument = new ezMeshAssetDocument(sPath);
 }
 
 void ezMeshAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetManager.h
@@ -17,7 +17,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.cpp
@@ -231,11 +231,9 @@ void ezPropertyAnimAssetDocument::InitializeAfterLoading(bool bFirstTimeCreation
   m_pMirror = EZ_DEFAULT_NEW(ezIPCObjectMirrorEditor);
   // Filter needs to be set before base class init as that one sends the doc.
   // (Local mirror ignores temporaries, i.e. only mirrors the asset itself)
-  m_ObjectMirror.SetFilterFunction([this](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
-    { return !static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, sProperty); });
+  m_ObjectMirror.SetFilterFunction([this](const ezDocumentObject* pObject, ezStringView sProperty) -> bool { return !static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, sProperty); });
   // (Remote IPC mirror only sends temporaries, i.e. the context)
-  m_pMirror->SetFilterFunction([this](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
-    { return static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, sProperty); });
+  m_pMirror->SetFilterFunction([this](const ezDocumentObject* pObject, ezStringView sProperty) -> bool { return static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, sProperty); });
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
   // Important to do these after base class init as we want our subscriptions to happen after the mirror of the base class.
   GetObjectManager()->m_StructureEvents.AddEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocument::TreeStructureEventHandler, this));

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.cpp
@@ -45,9 +45,9 @@ ezPropertyAnimationTrackGroup::~ezPropertyAnimationTrackGroup()
   }
 }
 
-ezPropertyAnimAssetDocument::ezPropertyAnimAssetDocument(const char* szDocumentPath)
+ezPropertyAnimAssetDocument::ezPropertyAnimAssetDocument(ezStringView sDocumentPath)
   : ezSimpleAssetDocument<ezPropertyAnimationTrackGroup, ezGameObjectContextDocument>(
-      EZ_DEFAULT_NEW(ezPropertyAnimObjectManager), szDocumentPath, ezAssetDocEngineConnection::FullObjectMirroring)
+      EZ_DEFAULT_NEW(ezPropertyAnimObjectManager), sDocumentPath, ezAssetDocEngineConnection::FullObjectMirroring)
 {
   m_GameObjectContextEvents.AddEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocument::GameObjectContextEventHandler, this));
   m_pObjectAccessor = EZ_DEFAULT_NEW(ezPropertyAnimObjectAccessor, this, GetCommandHistory());
@@ -161,7 +161,7 @@ bool ezPropertyAnimAssetDocument::SetScrubberPosition(ezUInt64 uiTick)
   return true;
 }
 
-ezTransformStatus ezPropertyAnimAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+ezTransformStatus ezPropertyAnimAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
   const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const ezPropertyAnimationTrackGroup* pProp = GetProperties();
@@ -231,9 +231,11 @@ void ezPropertyAnimAssetDocument::InitializeAfterLoading(bool bFirstTimeCreation
   m_pMirror = EZ_DEFAULT_NEW(ezIPCObjectMirrorEditor);
   // Filter needs to be set before base class init as that one sends the doc.
   // (Local mirror ignores temporaries, i.e. only mirrors the asset itself)
-  m_ObjectMirror.SetFilterFunction([this](const ezDocumentObject* pObject, const char* szProperty) -> bool { return !static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, szProperty); });
+  m_ObjectMirror.SetFilterFunction([this](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
+    { return !static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, sProperty); });
   // (Remote IPC mirror only sends temporaries, i.e. the context)
-  m_pMirror->SetFilterFunction([this](const ezDocumentObject* pObject, const char* szProperty) -> bool { return static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, szProperty); });
+  m_pMirror->SetFilterFunction([this](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
+    { return static_cast<ezPropertyAnimObjectManager*>(GetObjectManager())->IsTemporary(pObject, sProperty); });
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
   // Important to do these after base class init as we want our subscriptions to happen after the mirror of the base class.
   GetObjectManager()->m_StructureEvents.AddEventHandler(ezMakeDelegate(&ezPropertyAnimAssetDocument::TreeStructureEventHandler, this));

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
@@ -64,7 +64,7 @@ class ezPropertyAnimAssetDocument : public ezSimpleAssetDocument<ezPropertyAnima
   EZ_ADD_DYNAMIC_REFLECTION(ezPropertyAnimAssetDocument, BaseClass);
 
 public:
-  ezPropertyAnimAssetDocument(const char* szDocumentPath);
+  ezPropertyAnimAssetDocument(ezStringView sDocumentPath);
   ~ezPropertyAnimAssetDocument();
 
   void SetAnimationDurationTicks(ezUInt64 uiNumTicks);
@@ -111,7 +111,7 @@ public:
   }
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.cpp
@@ -49,9 +49,9 @@ void ezPropertyAnimAssetDocumentManager::OnDocumentManagerEvent(const ezDocument
 }
 
 void ezPropertyAnimAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezPropertyAnimAssetDocument(szPath);
+  out_pDocument = new ezPropertyAnimAssetDocument(sPath);
 }
 
 void ezPropertyAnimAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectManager.cpp
@@ -7,12 +7,12 @@ ezPropertyAnimObjectManager::ezPropertyAnimObjectManager() = default;
 ezPropertyAnimObjectManager::~ezPropertyAnimObjectManager() = default;
 
 ezStatus ezPropertyAnimObjectManager::InternalCanAdd(
-  const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const
+  const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const
 {
   if (m_bAllowStructureChangeOnTemporaries)
     return ezStatus(EZ_SUCCESS);
 
-  if (IsTemporary(pParent, szParentProperty))
+  if (IsTemporary(pParent, sParentProperty))
     return ezStatus("The structure of the context cannot be animated.");
   return ezStatus(EZ_SUCCESS);
 }
@@ -28,7 +28,7 @@ ezStatus ezPropertyAnimObjectManager::InternalCanRemove(const ezDocumentObject* 
 }
 
 ezStatus ezPropertyAnimObjectManager::InternalCanMove(
-  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const
+  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const
 {
   if (m_bAllowStructureChangeOnTemporaries)
     return ezStatus(EZ_SUCCESS);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectManager.h
@@ -13,10 +13,10 @@ public:
 
 private:
   virtual ezStatus InternalCanAdd(
-    const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const override;
+    const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const override;
   virtual ezStatus InternalCanRemove(const ezDocumentObject* pObject) const override;
   virtual ezStatus InternalCanMove(
-    const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const override;
+    const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const override;
 
 private:
   bool m_bAllowStructureChangeOnTemporaries = false;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.cpp
@@ -89,8 +89,8 @@ ezStatus ezRenderPipelineNodeManager::InternalCanConnect(const ezPin& source, co
   return ezStatus(EZ_SUCCESS);
 }
 
-ezRenderPipelineAssetDocument::ezRenderPipelineAssetDocument(const char* szDocumentPath)
-  : ezAssetDocument(szDocumentPath, EZ_DEFAULT_NEW(ezRenderPipelineNodeManager), ezAssetDocEngineConnection::FullObjectMirroring)
+ezRenderPipelineAssetDocument::ezRenderPipelineAssetDocument(ezStringView sDocumentPath)
+  : ezAssetDocument(sDocumentPath, EZ_DEFAULT_NEW(ezRenderPipelineNodeManager), ezAssetDocEngineConnection::FullObjectMirroring)
 {
 }
 
@@ -106,13 +106,13 @@ void ezRenderPipelineAssetDocument::InitializeAfterLoading(bool bFirstTimeCreati
   static_cast<ezRenderPipelineObjectMirrorEditor*>(m_pMirror.Borrow())->InitNodeSender(static_cast<const ezDocumentNodeManager*>(GetObjectManager()));
 }
 
-ezTransformStatus ezRenderPipelineAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+ezTransformStatus ezRenderPipelineAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
   const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   return ezAssetDocument::RemoteExport(AssetHeader, szTargetFile);
 }
 
-ezTransformStatus ezRenderPipelineAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezRenderPipelineAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   EZ_REPORT_FAILURE("Should not be called");
   return ezTransformStatus();
@@ -153,7 +153,7 @@ bool ezRenderPipelineAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& o
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezRenderPipelineAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezRenderPipelineAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAsset.h
@@ -36,20 +36,20 @@ class ezRenderPipelineAssetDocument : public ezAssetDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezRenderPipelineAssetDocument, ezAssetDocument);
 
 public:
-  ezRenderPipelineAssetDocument(const char* szDocumentPath);
+  ezRenderPipelineAssetDocument(ezStringView sDocumentPath);
   ~ezRenderPipelineAssetDocument();
 
 protected:
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_MimeType) const override;
   virtual bool Paste(
-    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   virtual void InternalGetMetaDataHash(const ezDocumentObject* pObject, ezUInt64& inout_uiHash) const override;
   virtual void AttachMetaDataBeforeSaving(ezAbstractObjectGraph& graph) const override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.cpp
@@ -49,9 +49,9 @@ void ezRenderPipelineAssetManager::OnDocumentManagerEvent(const ezDocumentManage
 }
 
 void ezRenderPipelineAssetManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezRenderPipelineAssetDocument(szPath);
+  out_pDocument = new ezRenderPipelineAssetDocument(sPath);
 }
 
 void ezRenderPipelineAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetManager.h
@@ -17,7 +17,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -64,8 +64,8 @@ static ezTransform CalculateTransformationMatrix(const ezEditableSkeleton* pProp
   return t;
 }
 
-ezSkeletonAssetDocument::ezSkeletonAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezEditableSkeleton>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezSkeletonAssetDocument::ezSkeletonAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezEditableSkeleton>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
 }
 
@@ -282,7 +282,7 @@ void ezSkeletonAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
   pInfo->m_MetaInfo.PushBack(pExposedParams);
 }
 
-ezTransformStatus ezSkeletonAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezSkeletonAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   {
     m_bIsTransforming = true;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -26,7 +26,7 @@ class ezSkeletonAssetDocument : public ezSimpleAssetDocument<ezEditableSkeleton>
   EZ_ADD_DYNAMIC_REFLECTION(ezSkeletonAssetDocument, ezSimpleAssetDocument<ezEditableSkeleton>);
 
 public:
-  ezSkeletonAssetDocument(const char* szDocumentPath);
+  ezSkeletonAssetDocument(ezStringView sDocumentPath);
   ~ezSkeletonAssetDocument();
 
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
@@ -62,7 +62,7 @@ public:
 
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.cpp
@@ -46,9 +46,9 @@ void ezSkeletonAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMana
 }
 
 void ezSkeletonAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezSkeletonAssetDocument(szPath);
+  out_pDocument = new ezSkeletonAssetDocument(sPath);
 }
 
 void ezSkeletonAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAsset.cpp
@@ -11,12 +11,12 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStateMachineAssetDocument, 3, ezRTTINoAllocato
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezStateMachineAssetDocument::ezStateMachineAssetDocument(const char* szDocumentPath)
-  : ezAssetDocument(szDocumentPath, EZ_DEFAULT_NEW(ezStateMachineNodeManager), ezAssetDocEngineConnection::None)
+ezStateMachineAssetDocument::ezStateMachineAssetDocument(ezStringView sDocumentPath)
+  : ezAssetDocument(sDocumentPath, EZ_DEFAULT_NEW(ezStateMachineNodeManager), ezAssetDocEngineConnection::None)
 {
 }
 
-ezTransformStatus ezStateMachineAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezStateMachineAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   auto pManager = static_cast<ezStateMachineNodeManager*>(GetObjectManager());
 
@@ -181,7 +181,7 @@ bool ezStateMachineAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& out
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezStateMachineAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezStateMachineAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAsset.h
@@ -8,16 +8,16 @@ class ezStateMachineAssetDocument : public ezAssetDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezStateMachineAssetDocument, ezAssetDocument);
 
 public:
-  ezStateMachineAssetDocument(const char* szDocumentPath);
+  ezStateMachineAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_MimeType) const override;
   virtual bool Paste(
-    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   virtual void InternalGetMetaDataHash(const ezDocumentObject* pObject, ezUInt64& inout_uiHash) const override;
   virtual void AttachMetaDataBeforeSaving(ezAbstractObjectGraph& graph) const override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAssetManager.cpp
@@ -49,9 +49,9 @@ void ezStateMachineAssetManager::OnDocumentManagerEvent(const ezDocumentManager:
 }
 
 void ezStateMachineAssetManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezStateMachineAssetDocument(szPath);
+  out_pDocument = new ezStateMachineAssetDocument(sPath);
 }
 
 void ezStateMachineAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAssetManager.h
@@ -16,7 +16,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.cpp
@@ -5,12 +5,12 @@
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSurfaceAssetDocument, 2, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezSurfaceAssetDocument::ezSurfaceAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezSurfaceResourceDescriptor>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezSurfaceAssetDocument::ezSurfaceAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezSurfaceResourceDescriptor>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
-ezTransformStatus ezSurfaceAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+ezTransformStatus ezSurfaceAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
   const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const ezSurfaceResourceDescriptor* pProp = GetProperties();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAsset.h
@@ -8,9 +8,9 @@ class ezSurfaceAssetDocument : public ezSimpleAssetDocument<ezSurfaceResourceDes
   EZ_ADD_DYNAMIC_REFLECTION(ezSurfaceAssetDocument, ezSimpleAssetDocument<ezSurfaceResourceDescriptor>);
 
 public:
-  ezSurfaceAssetDocument(const char* szDocumentPath);
+  ezSurfaceAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.cpp
@@ -48,9 +48,9 @@ void ezSurfaceAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManag
   }
 }
 
-void ezSurfaceAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezSurfaceAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezSurfaceAssetDocument(szPath);
+  out_pDocument = new ezSurfaceAssetDocument(sPath);
 }
 
 void ezSurfaceAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetManager.h
@@ -16,7 +16,7 @@ public:
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -19,8 +19,8 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezTextureChannelMode, 1)
 EZ_END_STATIC_REFLECTED_ENUM;
 // clang-format on
 
-ezTextureAssetDocument::ezTextureAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezTextureAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple)
+ezTextureAssetDocument::ezTextureAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezTextureAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple)
 {
   m_iTextureLod = -1;
 }
@@ -380,9 +380,9 @@ void ezTextureAssetDocument::InitializeAfterLoading(bool bFirstTimeCreation)
   }
 }
 
-ezTransformStatus ezTextureAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezTextureAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
-  if (ezStringUtils::IsEqual(szOutputTag, "LOWRES"))
+  if (sOutputTag.IsEqual("LOWRES"))
   {
     // no need to generate this file, it will be generated together with the main output
     return ezTransformStatus();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
@@ -29,7 +29,7 @@ class ezTextureAssetDocument : public ezSimpleAssetDocument<ezTextureAssetProper
   EZ_ADD_DYNAMIC_REFLECTION(ezTextureAssetDocument, ezSimpleAssetDocument<ezTextureAssetProperties>);
 
 public:
-  ezTextureAssetDocument(const char* szDocumentPath);
+  ezTextureAssetDocument(ezStringView sDocumentPath);
 
   // for previewing purposes
   ezEnum<ezTextureChannelMode> m_ChannelMode;
@@ -38,8 +38,8 @@ public:
 
 protected:
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override { return ezStatus(EZ_SUCCESS); }
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override { return ezStatus(EZ_SUCCESS); }
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus RunTexConv(const char* szTargetFile, const ezAssetFileHeader& AssetHeader, bool bUpdateThumbnail, const ezTextureAssetProfileConfig* pAssetConfig);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.cpp
@@ -86,12 +86,12 @@ void ezTextureAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManag
   }
 }
 
-void ezTextureAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezTextureAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  ezTextureAssetDocument* pDoc = new ezTextureAssetDocument(szPath);
+  ezTextureAssetDocument* pDoc = new ezTextureAssetDocument(sPath);
   out_pDocument = pDoc;
 
-  if (ezStringUtils::IsEqual(szDocumentTypeName, "Render Target"))
+  if (sDocumentTypeName.IsEqual("Render Target"))
   {
     pDoc->m_bIsRenderTarget = true;
   }
@@ -103,17 +103,17 @@ void ezTextureAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicA
   inout_DocumentTypes.PushBack(&m_DocTypeDesc2);
 }
 
-ezString ezTextureAssetDocumentManager::GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const
+ezString ezTextureAssetDocumentManager::GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const
 {
-  if (ezStringUtils::IsEqual(szOutputTag, "LOWRES"))
+  if (sOutputTag.IsEqual("LOWRES"))
   {
-    ezStringBuilder sRelativePath(szDocumentPath);
-    sRelativePath.MakeRelativeTo(szDataDirectory).IgnoreResult();
+    ezStringBuilder sRelativePath(sDocumentPath);
+    sRelativePath.MakeRelativeTo(sDataDirectory).IgnoreResult();
     sRelativePath.RemoveFileExtension();
     sRelativePath.Append("-lowres");
     ezAssetDocumentManager::GenerateOutputFilename(sRelativePath, pAssetProfile, "ezTexture2D", true);
     return sRelativePath;
   }
 
-  return SUPER::GetRelativeOutputFileName(pTypeDescriptor, szDataDirectory, szDocumentPath, szOutputTag, pAssetProfile);
+  return SUPER::GetRelativeOutputFileName(pTypeDescriptor, sDataDirectory, sDocumentPath, sOutputTag, pAssetProfile);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetManager.h
@@ -27,12 +27,12 @@ private:
 
   virtual ezUInt64 ComputeAssetProfileHashImpl(const ezPlatformProfile* pAssetProfile) const override;
 
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }
 
-  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, const char* szDataDirectory, const char* szDocumentPath, const char* szOutputTag, const ezPlatformProfile* pAssetProfile) const override;
+  virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const override;
 
 private:
   ezAssetDocumentTypeDescriptor m_DocTypeDesc;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -17,8 +17,8 @@ const char* ToUsageMode(ezTexConvUsage::Enum mode);
 const char* ToCompressionMode(ezTexConvCompressionMode::Enum mode);
 const char* ToMipmapMode(ezTexConvMipmapMode::Enum mode);
 
-ezTextureCubeAssetDocument::ezTextureCubeAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezTextureCubeAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple)
+ezTextureCubeAssetDocument::ezTextureCubeAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezTextureCubeAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple)
 {
   m_iTextureLod = -1;
 }
@@ -193,7 +193,7 @@ void ezTextureCubeAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pI
   }
 }
 
-ezTransformStatus ezTextureCubeAssetDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezTextureCubeAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   // EZ_ASSERT_DEV(ezStringUtils::IsEqual(szPlatform, "PC"), "Platform '{0}' is not supported", szPlatform);
   const bool bUpdateThumbnail = pAssetProfile == ezAssetCurator::GetSingleton()->GetDevelopmentAssetProfile();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
@@ -26,18 +26,18 @@ class ezTextureCubeAssetDocument : public ezSimpleAssetDocument<ezTextureCubeAss
   EZ_ADD_DYNAMIC_REFLECTION(ezTextureCubeAssetDocument, ezSimpleAssetDocument<ezTextureCubeAssetProperties>);
 
 public:
-  ezTextureCubeAssetDocument(const char* szDocumentPath);
+  ezTextureCubeAssetDocument(ezStringView sDocumentPath);
 
   // for previewing purposes
   ezEnum<ezTextureCubeChannelMode> m_ChannelMode;
   ezInt32 m_iTextureLod; // -1 == regular sampling, >= 0 == sample that level
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override
   {
     return ezStatus(EZ_SUCCESS);
   }
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus RunTexConv(const char* szTargetFile, const ezAssetFileHeader& AssetHeader, bool bUpdateThumbnail);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.cpp
@@ -51,9 +51,9 @@ void ezTextureCubeAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentM
 }
 
 void ezTextureCubeAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezTextureCubeAssetDocument(szPath);
+  out_pDocument = new ezTextureCubeAssetDocument(sPath);
 }
 
 void ezTextureCubeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetManager.h
@@ -17,7 +17,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
@@ -364,11 +364,11 @@ namespace ezMeshImportUtils
     pAccessor->FinishTransaction();
   }
 
-  void ImportMeshAssetMaterials(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, const char* szDocumentDirectory, const ezModelImporter2::Importer* pImporter)
+  void ImportMeshAssetMaterials(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, ezStringView sDocumentDirectory, const ezModelImporter2::Importer* pImporter)
   {
     EZ_PROFILE_SCOPE("ImportMeshAssetMaterials");
 
-    ezStringBuilder targetDirectory = szDocumentDirectory;
+    ezStringBuilder targetDirectory = sDocumentDirectory;
     targetDirectory.RemoveFileExtension();
     targetDirectory.Append("_data/");
     const ezStringBuilder sourceDirectory = ezPathUtils::GetFileDirectory(pImporter->GetImportOptions().m_sSourceFile);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.h
@@ -26,7 +26,7 @@ namespace ezMeshImportUtils
 
   // EZ_EDITORPLUGINASSETS_DLL void AddMeshToDescriptor(ezMeshResourceDescriptor& meshDescriptor, const ezModelImporter::Scene& scene, const ezModelImporter::Mesh& mesh, const ezHybridArray<ezMaterialResourceSlot, 8>& materialSlots);
 
-  // EZ_EDITORPLUGINASSETS_DLL void UpdateMaterialSlots(const char* szDocumentPath, const ezModelImporter::Scene& scene, const ezModelImporter::Mesh& mesh, bool bImportMaterials, bool bUseSubFolderForImportedMaterials, const char* szMeshFile, ezHybridArray<ezMaterialResourceSlot, 8>& inout_MaterialSlots);
+  // EZ_EDITORPLUGINASSETS_DLL void UpdateMaterialSlots(ezStringView sDocumentPath, const ezModelImporter::Scene& scene, const ezModelImporter::Mesh& mesh, bool bImportMaterials, bool bUseSubFolderForImportedMaterials, const char* szMeshFile, ezHybridArray<ezMaterialResourceSlot, 8>& inout_MaterialSlots);
 
   // EZ_EDITORPLUGINASSETS_DLL void PrepareMeshForImport(ezModelImporter::Mesh& mesh, bool bRecalculateNormals, ezProgressRange& range);
 
@@ -36,5 +36,5 @@ namespace ezMeshImportUtils
 
   EZ_EDITORPLUGINASSETS_DLL void SetMeshAssetMaterialSlots(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, const ezModelImporter2::Importer* pImporter);
   EZ_EDITORPLUGINASSETS_DLL void CopyMeshAssetMaterialSlotToResource(ezMeshResourceDescriptor& ref_desc, const ezHybridArray<ezMaterialResourceSlot, 8>& materialSlots);
-  EZ_EDITORPLUGINASSETS_DLL void ImportMeshAssetMaterials(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, const char* szDocumentDirectory, const ezModelImporter2::Importer* pImporter);
+  EZ_EDITORPLUGINASSETS_DLL void ImportMeshAssetMaterials(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, ezStringView sDocumentDirectory, const ezModelImporter2::Importer* pImporter);
 } // namespace ezMeshImportUtils

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAsset.cpp
@@ -73,8 +73,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptAssetDocument, 6, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezVisualScriptAssetDocument::ezVisualScriptAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezVisualScriptAssetProperties>(EZ_DEFAULT_NEW(ezVisualScriptNodeManager_Legacy), szDocumentPath, ezAssetDocEngineConnection::None)
+ezVisualScriptAssetDocument::ezVisualScriptAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezVisualScriptAssetProperties>(EZ_DEFAULT_NEW(ezVisualScriptNodeManager_Legacy), sDocumentPath, ezAssetDocEngineConnection::None)
 {
   ezVisualScriptTypeRegistry::GetSingleton()->UpdateNodeTypes();
 }
@@ -118,7 +118,7 @@ void ezVisualScriptAssetDocument::HandleVsActivityMsg(const ezVisualScriptActivi
   m_ActivityEvents.Broadcast(ae);
 }
 
-ezTransformStatus ezVisualScriptAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezVisualScriptAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezVisualScriptResourceDescriptor desc;
   if (GenerateVisualScriptDescriptor(desc).Failed())
@@ -425,7 +425,7 @@ bool ezVisualScriptAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& out
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezVisualScriptAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezVisualScriptAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAsset.h
@@ -62,7 +62,7 @@ class ezVisualScriptAssetDocument : public ezSimpleAssetDocument<ezVisualScriptA
   EZ_ADD_DYNAMIC_REFLECTION(ezVisualScriptAssetDocument, ezSimpleAssetDocument<ezVisualScriptAssetProperties>);
 
 public:
-  ezVisualScriptAssetDocument(const char* szDocumentPath);
+  ezVisualScriptAssetDocument(ezStringView sDocumentPath);
 
   void HandleVsActivityMsg(const ezVisualScriptActivityMsgToEditor* pActivityMsg);
   void OnInterDocumentMessage(ezReflectedClass* pMessage, ezDocument* pSender) override;
@@ -71,12 +71,12 @@ public:
   ezEvent<ezReflectedClass*> m_InterDocumentMessages;
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_MimeType) const override;
-  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   virtual void InternalGetMetaDataHash(const ezDocumentObject* pObject, ezUInt64& inout_uiHash) const override;
   virtual void AttachMetaDataBeforeSaving(ezAbstractObjectGraph& graph) const override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.cpp
@@ -49,9 +49,9 @@ void ezVisualScriptAssetManager::OnDocumentManagerEvent(const ezDocumentManager:
 }
 
 void ezVisualScriptAssetManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezVisualScriptAssetDocument(szPath);
+  out_pDocument = new ezVisualScriptAssetDocument(sPath);
 }
 
 void ezVisualScriptAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.cpp
@@ -128,12 +128,12 @@ ezStatus ezVisualScriptNodeManager_Legacy::InternalCanConnect(const ezPin& sourc
   return ezStatus(EZ_SUCCESS);
 }
 
-const char* ezVisualScriptNodeManager_Legacy::GetTypeCategory(const ezRTTI* pRtti) const
+ezStringView ezVisualScriptNodeManager_Legacy::GetTypeCategory(const ezRTTI* pRtti) const
 {
   const ezVisualScriptNodeDescriptor* pDesc = ezVisualScriptTypeRegistry::GetSingleton()->GetDescriptorForType(pRtti);
 
   if (pDesc == nullptr)
-    return nullptr;
+    return {};
 
   return pDesc->m_sCategory;
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualScriptAsset/VisualScriptGraph.h
@@ -34,7 +34,7 @@ public:
   virtual void InternalCreatePins(const ezDocumentObject* pObject, NodeInternal& ref_node) override;
   virtual void GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const override;
   virtual const ezRTTI* GetConnectionType() const override;
-  virtual const char* GetTypeCategory(const ezRTTI* pRtti) const override;
+  virtual ezStringView GetTypeCategory(const ezRTTI* pRtti) const override;
 
   virtual ezStatus InternalCanConnect(const ezPin& source, const ezPin& target, CanConnectResult& out_result) const override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.cpp
@@ -97,18 +97,18 @@ ezStatus ezVisualShaderNodeManager::InternalCanConnect(const ezPin& source, cons
   return ezStatus(EZ_SUCCESS);
 }
 
-const char* ezVisualShaderNodeManager::GetTypeCategory(const ezRTTI* pRtti) const
+ezStringView ezVisualShaderNodeManager::GetTypeCategory(const ezRTTI* pRtti) const
 {
   const ezVisualShaderNodeDescriptor* pDesc = ezVisualShaderTypeRegistry::GetSingleton()->GetDescriptorForType(pRtti);
 
   if (pDesc == nullptr)
-    return nullptr;
+    return {};
 
   return pDesc->m_sCategory;
 }
 
 
-ezStatus ezVisualShaderNodeManager::InternalCanAdd(const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const
+ezStatus ezVisualShaderNodeManager::InternalCanAdd(const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const
 {
   auto pDesc = ezVisualShaderTypeRegistry::GetSingleton()->GetDescriptorForType(pRtti);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderNodeManager.h
@@ -28,11 +28,11 @@ public:
   virtual void GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const override;
 
   virtual ezStatus InternalCanConnect(const ezPin& source, const ezPin& target, CanConnectResult& out_result) const override;
-  virtual const char* GetTypeCategory(const ezRTTI* pRtti) const override;
+  virtual ezStringView GetTypeCategory(const ezRTTI* pRtti) const override;
 
 private:
   virtual ezStatus InternalCanAdd(
-    const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const override;
+    const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const override;
 
   ezUInt32 CountNodesOfType(ezVisualShaderNodeType::Enum type) const;
 };

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.cpp
@@ -18,8 +18,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSoundBankAssetProperties, 1, ezRTTIDefaultAllo
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezSoundBankAssetDocument::ezSoundBankAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezSoundBankAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezSoundBankAssetDocument::ezSoundBankAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezSoundBankAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -32,7 +32,7 @@ void ezSoundBankAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInf
   pInfo->m_TransformDependencies.Insert(pProp->m_sSoundBank);
 }
 
-ezTransformStatus ezSoundBankAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezSoundBankAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   const ezSoundBankAssetProperties* pProp = GetProperties();
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAsset.h
@@ -17,10 +17,10 @@ class ezSoundBankAssetDocument : public ezSimpleAssetDocument<ezSoundBankAssetPr
   EZ_ADD_DYNAMIC_REFLECTION(ezSoundBankAssetDocument, ezSimpleAssetDocument<ezSoundBankAssetProperties>);
 
 public:
-  ezSoundBankAssetDocument(const char* szDocumentPath);
+  ezSoundBankAssetDocument(ezStringView sDocumentPath);
 
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.cpp
@@ -183,7 +183,7 @@ void ezSoundBankAssetDocumentManager::FillOutSubAssetList(const ezAssetDocumentI
   }
 }
 
-ezString ezSoundBankAssetDocumentManager::GetSoundBankAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const
+ezString ezSoundBankAssetDocumentManager::GetSoundBankAssetTableEntry(const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const
 {
   // at the moment we don't reference the actual transformed asset file
   // instead we reference the source Fmod sound bank file
@@ -212,15 +212,15 @@ ezString ezSoundBankAssetDocumentManager::GetSoundBankAssetTableEntry(const ezSu
   return ezString();
 }
 
-ezString ezSoundBankAssetDocumentManager::GetAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const
+ezString ezSoundBankAssetDocumentManager::GetAssetTableEntry(const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const
 {
   if (pSubAsset->m_bMainAsset)
   {
-    return GetSoundBankAssetTableEntry(pSubAsset, szDataDirectory, pAssetProfile);
+    return GetSoundBankAssetTableEntry(pSubAsset, sDataDirectory, pAssetProfile);
   }
   else
   {
-    ezStringBuilder result = GetSoundBankAssetTableEntry(pSubAsset, szDataDirectory, pAssetProfile);
+    ezStringBuilder result = GetSoundBankAssetTableEntry(pSubAsset, sDataDirectory, pAssetProfile);
 
     ezStringBuilder sGuid;
     ezConversionUtils::ToString(pSubAsset->m_Data.m_Guid, sGuid);
@@ -248,9 +248,9 @@ void ezSoundBankAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMan
   }
 }
 
-void ezSoundBankAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezSoundBankAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezSoundBankAssetDocument(szPath);
+  out_pDocument = new ezSoundBankAssetDocument(sPath);
 }
 
 void ezSoundBankAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetManager.h
@@ -17,14 +17,14 @@ public:
 
   virtual void FillOutSubAssetList(const ezAssetDocumentInfo& assetInfo, ezHybridArray<ezSubAssetData, 4>& out_subAssets) const override;
   virtual ezString GetAssetTableEntry(
-    const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const override;
+    const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const override;
 
 private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
-  ezString GetSoundBankAssetTableEntry(const ezSubAsset* pSubAsset, const char* szDataDirectory, const ezPlatformProfile* pAssetProfile) const;
+  ezString GetSoundBankAssetTableEntry(const ezSubAsset* pSubAsset, ezStringView sDataDirectory, const ezPlatformProfile* pAssetProfile) const;
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.cpp
@@ -10,8 +10,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSoundEventAssetProperties, 1, ezRTTIDefaultAll
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezSoundEventAssetDocument::ezSoundEventAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezSoundEventAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezSoundEventAssetDocument::ezSoundEventAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezSoundEventAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -20,7 +20,7 @@ void ezSoundEventAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pIn
   SUPER::UpdateAssetDocumentInfo(pInfo);
 }
 
-ezTransformStatus ezSoundEventAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+ezTransformStatus ezSoundEventAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
   const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   return ezStatus(EZ_SUCCESS);

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAsset.h
@@ -16,10 +16,10 @@ class ezSoundEventAssetDocument : public ezSimpleAssetDocument<ezSoundEventAsset
   EZ_ADD_DYNAMIC_REFLECTION(ezSoundEventAssetDocument, ezSimpleAssetDocument<ezSoundEventAssetProperties>);
 
 public:
-  ezSoundEventAssetDocument(const char* szDocumentPath);
+  ezSoundEventAssetDocument(ezStringView sDocumentPath);
 
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 };

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.cpp
@@ -47,9 +47,9 @@ void ezSoundEventAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMa
   }
 }
 
-void ezSoundEventAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezSoundEventAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezSoundEventAssetDocument(szPath);
+  out_pDocument = new ezSoundEventAssetDocument(sPath);
 }
 
 void ezSoundEventAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetManager.h
@@ -17,7 +17,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -26,8 +26,8 @@ static ezMat3 CalculateTransformationMatrix(const ezJoltCollisionMeshAssetProper
   return ezBasisAxis::CalculateTransformationMatrix(forwardDir, pProp->m_RightDir, pProp->m_UpDir, us);
 }
 
-ezJoltCollisionMeshAssetDocument::ezJoltCollisionMeshAssetDocument(const char* szDocumentPath, bool bConvexMesh)
-  : ezSimpleAssetDocument<ezJoltCollisionMeshAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple)
+ezJoltCollisionMeshAssetDocument::ezJoltCollisionMeshAssetDocument(ezStringView sDocumentPath, bool bConvexMesh)
+  : ezSimpleAssetDocument<ezJoltCollisionMeshAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple)
 {
   m_bIsConvexMesh = bConvexMesh;
 }
@@ -54,7 +54,7 @@ void ezJoltCollisionMeshAssetDocument::InitializeAfterLoading(bool bFirstTimeCre
 //////////////////////////////////////////////////////////////////////////
 
 
-ezTransformStatus ezJoltCollisionMeshAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezJoltCollisionMeshAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezProgressRange range("Transforming Asset", 2, false);
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
@@ -13,14 +13,14 @@ class ezJoltCollisionMeshAssetDocument : public ezSimpleAssetDocument<ezJoltColl
   EZ_ADD_DYNAMIC_REFLECTION(ezJoltCollisionMeshAssetDocument, ezSimpleAssetDocument<ezJoltCollisionMeshAssetProperties>);
 
 public:
-  ezJoltCollisionMeshAssetDocument(const char* szDocumentPath, bool bConvexMesh);
+  ezJoltCollisionMeshAssetDocument(ezStringView sDocumentPath, bool bConvexMesh);
 
   static ezStatus WriteToStream(ezChunkStreamWriter& inout_stream, const ezJoltCookingMesh& mesh, const ezJoltCollisionMeshAssetProperties* pProp);
 
 protected:
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
 
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus CreateMeshFromFile(ezJoltCookingMesh& outMesh);
   ezStatus CreateMeshFromGeom(ezGeometry& geom, ezJoltCookingMesh& outMesh);

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.cpp
@@ -56,15 +56,15 @@ void ezJoltCollisionMeshAssetDocumentManager::OnDocumentManagerEvent(const ezDoc
   }
 }
 
-void ezJoltCollisionMeshAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezJoltCollisionMeshAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  if (ezStringUtils::IsEqual(szDocumentTypeName, "Jolt_Colmesh_Convex"))
+  if (sDocumentTypeName.IsEqual("Jolt_Colmesh_Convex"))
   {
-    out_pDocument = new ezJoltCollisionMeshAssetDocument(szPath, true);
+    out_pDocument = new ezJoltCollisionMeshAssetDocument(sPath, true);
   }
   else
   {
-    out_pDocument = new ezJoltCollisionMeshAssetDocument(szPath, false);
+    out_pDocument = new ezJoltCollisionMeshAssetDocument(sPath, false);
   }
 }
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return true; }

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
@@ -12,8 +12,8 @@ using namespace AE_NS_FOUNDATION;
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezKrautTreeAssetDocument, 4, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezKrautTreeAssetDocument::ezKrautTreeAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezKrautTreeAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezKrautTreeAssetDocument::ezKrautTreeAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezKrautTreeAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
 }
 
@@ -77,7 +77,7 @@ static void GetMaterialLabel(ezStringBuilder& ref_sOut, ezKrautBranchType branch
   }
 }
 
-ezTransformStatus ezKrautTreeAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezKrautTreeAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezProgressRange range("Transforming Asset", 2, false);
 

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
@@ -17,10 +17,10 @@ class ezKrautTreeAssetDocument : public ezSimpleAssetDocument<ezKrautTreeAssetPr
   EZ_ADD_DYNAMIC_REFLECTION(ezKrautTreeAssetDocument, ezSimpleAssetDocument<ezKrautTreeAssetProperties>);
 
 public:
-  ezKrautTreeAssetDocument(const char* szDocumentPath);
+  ezKrautTreeAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   void SyncBackAssetProperties(ezKrautTreeAssetProperties*& pProp, const ezKrautGeneratorResourceDescriptor& desc);
 

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.cpp
@@ -46,9 +46,9 @@ void ezKrautTreeAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMan
 }
 
 void ezKrautTreeAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezKrautTreeAssetDocument(szPath);
+  out_pDocument = new ezKrautTreeAssetDocument(sPath);
 }
 
 void ezKrautTreeAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.cpp
@@ -16,8 +16,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEffectAssetDocument, 6, ezRTTINoAlloca
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezParticleEffectAssetDocument::ezParticleEffectAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezParticleEffectDescriptor>(szDocumentPath, ezAssetDocEngineConnection::Simple, true)
+ezParticleEffectAssetDocument::ezParticleEffectAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezParticleEffectDescriptor>(sDocumentPath, ezAssetDocEngineConnection::Simple, true)
 {
   ezVisualizerManager::GetSingleton()->SetVisualizersActive(this, m_bRenderVisualizers);
 }
@@ -250,7 +250,7 @@ void ezParticleEffectAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo*
   }
 }
 
-ezTransformStatus ezParticleEffectAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag,
+ezTransformStatus ezParticleEffectAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag,
   const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   WriteResource(stream);

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAsset.h
@@ -26,7 +26,7 @@ class ezParticleEffectAssetDocument : public ezSimpleAssetDocument<ezParticleEff
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEffectAssetDocument, ezSimpleAssetDocument<ezParticleEffectDescriptor>);
 
 public:
-  ezParticleEffectAssetDocument(const char* szDocumentPath);
+  ezParticleEffectAssetDocument(ezStringView sDocumentPath);
 
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
@@ -53,7 +53,7 @@ public:
 
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.cpp
@@ -46,9 +46,9 @@ void ezParticleEffectAssetDocumentManager::OnDocumentManagerEvent(const ezDocume
 }
 
 void ezParticleEffectAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezParticleEffectAssetDocument(szPath);
+  out_pDocument = new ezParticleEffectAssetDocument(sPath);
 }
 
 void ezParticleEffectAssetDocumentManager::InternalGetSupportedDocumentTypes(

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetManager.h
@@ -16,7 +16,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
@@ -392,7 +392,7 @@ void ezQtParticleEffectAssetDocumentWindow::onAddSystem(bool)
 
       for (auto pChild : children)
       {
-        if (ezStringUtils::IsEqual(pChild->GetParentProperty(), "LifeTime"))
+        if (pChild->GetParentProperty() == "LifeTime"_ezsv)
         {
           ezSetObjectPropertyCommand cmd;
           cmd.m_Object = pChild->GetGuid();
@@ -448,7 +448,7 @@ void ezQtParticleEffectAssetDocumentWindow::onAddSystem(bool)
 
         for (auto pChild : children)
         {
-          if (ezStringUtils::IsEqual(pChild->GetParentProperty(), "Speed"))
+          if (pChild->GetParentProperty() == "Speed"_ezsv)
           {
             ezSetObjectPropertyCommand cmd2;
             cmd2.m_Object = pChild->GetGuid();
@@ -713,7 +713,7 @@ void ezQtParticleEffectAssetDocumentWindow::UpdateSystemList()
 
   for (ezDocumentObject* pChild : pRootObject->GetChildren())
   {
-    if (ezStringUtils::IsEqual(pChild->GetParentProperty(), "ParticleSystems"))
+    if (pChild->GetParentProperty() == "ParticleSystems"_ezsv)
     {
       s = pChild->GetTypeAccessor().GetValue("Name").ConvertTo<ezString>();
       newParticleSystems[s] = pChild;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -85,8 +85,8 @@ struct ezProcGenGraphAssetDocument::GenerateContext
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenGraphAssetDocument, 6, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezProcGenGraphAssetDocument::ezProcGenGraphAssetDocument(const char* szDocumentPath)
-  : ezAssetDocument(szDocumentPath, EZ_DEFAULT_NEW(ezProcGenNodeManager), ezAssetDocEngineConnection::None)
+ezProcGenGraphAssetDocument::ezProcGenGraphAssetDocument(ezStringView sDocumentPath)
+  : ezAssetDocument(sDocumentPath, EZ_DEFAULT_NEW(ezProcGenNodeManager), ezAssetDocEngineConnection::None)
 {
 }
 
@@ -285,9 +285,9 @@ void ezProcGenGraphAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* p
   }
 }
 
-ezTransformStatus ezProcGenGraphAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezProcGenGraphAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
-  EZ_ASSERT_DEV(ezStringUtils::IsNullOrEmpty(szOutputTag), "Additional output '{0}' not implemented!", szOutputTag);
+  EZ_ASSERT_DEV(sOutputTag.IsEmpty(), "Additional output '{0}' not implemented!", sOutputTag);
 
   return WriteAsset(stream, pAssetProfile, false);
 }
@@ -305,7 +305,7 @@ bool ezProcGenGraphAssetDocument::CopySelectedObjects(ezAbstractObjectGraph& out
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezProcGenGraphAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezProcGenGraphAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h
@@ -10,7 +10,7 @@ class ezProcGenGraphAssetDocument : public ezAssetDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezProcGenGraphAssetDocument, ezAssetDocument);
 
 public:
-  ezProcGenGraphAssetDocument(const char* szDocumentPath);
+  ezProcGenGraphAssetDocument(ezStringView sDocumentPath);
 
   void SetDebugPin(const ezPin* pDebugPin);
 
@@ -18,13 +18,13 @@ public:
 
 protected:
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_MimeType) const override;
   virtual bool Paste(
-    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   virtual void AttachMetaDataBeforeSaving(ezAbstractObjectGraph& graph) const override;
   virtual void RestoreMetaDataAfterLoading(const ezAbstractObjectGraph& graph, bool bUndoable) override;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.cpp
@@ -50,9 +50,9 @@ void ezProcGenGraphAssetDocumentManager::OnDocumentManagerEvent(const ezDocument
 }
 
 void ezProcGenGraphAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezProcGenGraphAssetDocument(szPath);
+  out_pDocument = new ezProcGenGraphAssetDocument(sPath);
 }
 
 void ezProcGenGraphAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.cpp
@@ -87,14 +87,14 @@ void ezProcGenNodeManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& 
     ezRTTI::ForEachOptions::ExcludeAbstract);
 }
 
-const char* ezProcGenNodeManager::GetTypeCategory(const ezRTTI* pRtti) const
+ezStringView ezProcGenNodeManager::GetTypeCategory(const ezRTTI* pRtti) const
 {
   if (const ezCategoryAttribute* pAttr = pRtti->GetAttributeByType<ezCategoryAttribute>())
   {
     return pAttr->GetCategory();
   }
 
-  return nullptr;
+  return {};
 }
 
 ezStatus ezProcGenNodeManager::InternalCanConnect(const ezPin& source, const ezPin& target, CanConnectResult& out_result) const

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodeManager.h
@@ -20,7 +20,7 @@ public:
   virtual bool InternalIsNode(const ezDocumentObject* pObject) const override;
   virtual void InternalCreatePins(const ezDocumentObject* pObject, NodeInternal& ref_node) override;
   virtual void GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& ref_types) const override;
-  virtual const char* GetTypeCategory(const ezRTTI* pRtti) const override;
+  virtual ezStringView GetTypeCategory(const ezRTTI* pRtti) const override;
 
   virtual ezStatus InternalCanConnect(const ezPin& source, const ezPin& target, CanConnectResult& out_result) const override;
 };

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
@@ -46,12 +46,12 @@ ezStringView FindRCSSReference(ezStringView& ref_sRml)
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRmlUiAssetDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezRmlUiAssetDocument::ezRmlUiAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezRmlUiAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::Simple)
+ezRmlUiAssetDocument::ezRmlUiAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezRmlUiAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::Simple)
 {
 }
 
-ezTransformStatus ezRmlUiAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezRmlUiAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   ezRmlUiAssetProperties* pProp = GetProperties();
 

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
@@ -11,10 +11,10 @@ class ezRmlUiAssetDocument : public ezSimpleAssetDocument<ezRmlUiAssetProperties
   EZ_ADD_DYNAMIC_REFLECTION(ezRmlUiAssetDocument, ezSimpleAssetDocument<ezRmlUiAssetProperties>);
 
 public:
-  ezRmlUiAssetDocument(const char* szDocumentPath);
+  ezRmlUiAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetManager.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetManager.cpp
@@ -46,9 +46,9 @@ void ezRmlUiAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager
 }
 
 void ezRmlUiAssetDocumentManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezRmlUiAssetDocument(szPath);
+  out_pDocument = new ezRmlUiAssetDocument(sPath);
 }
 
 void ezRmlUiAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetManager.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetManager.h
@@ -15,7 +15,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.cpp
@@ -53,9 +53,9 @@ void ezSceneObjectManager::GetCreateableTypes(ezHybridArray<const ezRTTI*, 32>& 
 }
 
 ezStatus ezSceneObjectManager::InternalCanAdd(
-  const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const
+  const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const
 {
-  if (IsUnderRootProperty("Children", pParent, szParentProperty))
+  if (IsUnderRootProperty("Children", pParent, sParentProperty))
   {
     if (pParent == nullptr)
     {
@@ -94,7 +94,7 @@ ezStatus ezSceneObjectManager::InternalCanAdd(
 }
 
 ezStatus ezSceneObjectManager::InternalCanMove(
-  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const
+  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const
 {
   // code to disallow attaching nodes to a prefab node
   // if (pNewParent != nullptr)

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Objects/SceneObjectManager.h
@@ -41,8 +41,8 @@ public:
 
 private:
   virtual ezStatus InternalCanAdd(
-    const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const override;
+    const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const override;
   virtual ezStatus InternalCanSelect(const ezDocumentObject* pObject) const override;
   virtual ezStatus InternalCanMove(
-    const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const override;
+    const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const override;
 };

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.cpp
@@ -9,8 +9,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezLayerDocument, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezLayerDocument::ezLayerDocument(const char* szDocumentPath, ezScene2Document* pParentScene)
-  : ezSceneDocument(szDocumentPath, ezSceneDocument::DocumentType::Layer)
+ezLayerDocument::ezLayerDocument(ezStringView sDocumentPath, ezScene2Document* pParentScene)
+  : ezSceneDocument(sDocumentPath, ezSceneDocument::DocumentType::Layer)
 {
   m_pHostDocument = pParentScene;
 }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.h
@@ -9,7 +9,7 @@ class EZ_EDITORPLUGINSCENE_DLL ezLayerDocument : public ezSceneDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezLayerDocument, ezSceneDocument);
 
 public:
-  ezLayerDocument(const char* szDocumentPath, ezScene2Document* pParentScene);
+  ezLayerDocument(ezStringView sDocumentPath, ezScene2Document* pParentScene);
   ~ezLayerDocument();
 
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Prefabs.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Prefabs.cpp
@@ -81,9 +81,9 @@ void ezSceneDocument::UpdatePrefabs()
 }
 
 
-ezUuid ezSceneDocument::ReplaceByPrefab(const ezDocumentObject* pRootObject, const char* szPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab)
+ezUuid ezSceneDocument::ReplaceByPrefab(const ezDocumentObject* pRootObject, ezStringView sPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab)
 {
-  ezUuid newGuid = SUPER::ReplaceByPrefab(pRootObject, szPrefabFile, prefabAsset, prefabSeed, bEnginePrefab);
+  ezUuid newGuid = SUPER::ReplaceByPrefab(pRootObject, sPrefabFile, prefabAsset, prefabSeed, bEnginePrefab);
   if (newGuid.IsValid())
   {
     auto pMeta = m_GameObjectMetaData->BeginModifyMetaData(newGuid);
@@ -127,7 +127,7 @@ ezUuid ezSceneDocument::RevertPrefab(const ezDocumentObject* pObject)
   return newGuid;
 }
 
-void ezSceneDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, const char* szBasePrefab)
+void ezSceneDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, ezStringView sBasePrefab)
 {
   auto pHistory = GetCommandHistory();
   const ezVec3 vLocalPos = pObject->GetTypeAccessor().GetValue("LocalPosition").ConvertTo<ezVec3>();
@@ -135,7 +135,7 @@ void ezSceneDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid
   const ezVec3 vLocalScale = pObject->GetTypeAccessor().GetValue("LocalScaling").ConvertTo<ezVec3>();
   const float fLocalUniformScale = pObject->GetTypeAccessor().GetValue("LocalUniformScaling").ConvertTo<float>();
 
-  SUPER::UpdatePrefabObject(pObject, PrefabAsset, PrefabSeed, szBasePrefab);
+  SUPER::UpdatePrefabObject(pObject, PrefabAsset, PrefabSeed, sBasePrefab);
 
   // the root object has the same GUID as the PrefabSeed
   if (PrefabSeed.IsValid())

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -70,8 +70,8 @@ ezSceneDocumentSettings::~ezSceneDocumentSettings()
   }
 }
 
-ezScene2Document::ezScene2Document(const char* szDocumentPath)
-  : ezSceneDocument(szDocumentPath, ezSceneDocument::DocumentType::Scene)
+ezScene2Document::ezScene2Document(ezStringView sDocumentPath)
+  : ezSceneDocument(sDocumentPath, ezSceneDocument::DocumentType::Scene)
 {
   // Separate selection for the layer panel.
   m_pLayerSelection = EZ_DEFAULT_NEW(ezSelectionManager, m_pObjectManager.Borrow());

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
@@ -67,7 +67,7 @@ class EZ_EDITORPLUGINSCENE_DLL ezScene2Document : public ezSceneDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezScene2Document, ezSceneDocument);
 
 public:
-  ezScene2Document(const char* szDocumentPath);
+  ezScene2Document(ezStringView sDocumentPath);
   ~ezScene2Document();
 
   /// \name Scene Data Accessors

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -56,8 +56,8 @@ void ezSceneDocument_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e)
   props["Tags"].m_Visibility = ezPropertyUiState::Invisible;
 }
 
-ezSceneDocument::ezSceneDocument(const char* szDocumentPath, DocumentType documentType)
-  : ezGameObjectDocument(szDocumentPath, EZ_DEFAULT_NEW(ezSceneObjectManager))
+ezSceneDocument::ezSceneDocument(ezStringView sDocumentPath, DocumentType documentType)
+  : ezGameObjectDocument(sDocumentPath, EZ_DEFAULT_NEW(ezSceneObjectManager))
 {
   m_DocumentType = documentType;
   m_GameMode = GameMode::Off;
@@ -82,10 +82,11 @@ void ezSceneDocument::InitializeAfterLoading(bool bFirstTimeCreation)
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
 
   // (Local mirror only mirrors settings)
-  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool
-    { return pManager->IsUnderRootProperty("Settings", pObject, szProperty); });
+  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
+    { return pManager->IsUnderRootProperty("Settings", pObject, sProperty); });
   // (Remote IPC mirror only sends scene)
-  m_pMirror->SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, const char* szProperty) -> bool { return pManager->IsUnderRootProperty("Children", pObject, szProperty); });
+  m_pMirror->SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
+    { return pManager->IsUnderRootProperty("Children", pObject, sProperty); });
 
   EnsureSettingsObjectExist();
 
@@ -567,7 +568,7 @@ void ezSceneDocument::SetGameMode(GameMode::Enum mode)
   ScheduleSendObjectSelection();
 }
 
-ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB /* = {} */, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB /* = {} */, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB /* = {} */)
+ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB /* = {} */, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB /* = {} */, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB /* = {} */)
 {
   auto Selection = GetSelectionManager()->GetTopLevelSelection(pRootType);
 
@@ -640,7 +641,7 @@ ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(const char* szFile, 
   if (!finalizeGraphCB.IsValid())
     finalizeGraphCB = finalizeGraph;
 
-  return SUPER::CreatePrefabDocumentFromSelection(szFile, pRootType, adjustGraphNodeCB, adjustNewNodesCB, finalizeGraphCB);
+  return SUPER::CreatePrefabDocumentFromSelection(sFile, pRootType, adjustGraphNodeCB, adjustNewNodesCB, finalizeGraphCB);
 }
 
 bool ezSceneDocument::CanEngineProcessBeRestarted() const
@@ -870,7 +871,7 @@ bool ezSceneDocument::PasteAtOrignalPosition(const ezArrayPtr<PasteInfo>& info, 
   return true;
 }
 
-bool ezSceneDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezSceneDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   const auto& ctxt = ezQtEngineViewWidget::GetInteractionContext();
 
@@ -1571,7 +1572,7 @@ void ezSceneDocument::HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg)
   }
 }
 
-ezTransformStatus ezSceneDocument::InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezSceneDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   if (m_DocumentType == DocumentType::Prefab)
   {
@@ -1589,7 +1590,7 @@ ezTransformStatus ezSceneDocument::InternalTransformAsset(const char* szTargetFi
 }
 
 
-ezTransformStatus ezSceneDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezSceneDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   EZ_ASSERT_NOT_IMPLEMENTED;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -82,11 +82,9 @@ void ezSceneDocument::InitializeAfterLoading(bool bFirstTimeCreation)
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
 
   // (Local mirror only mirrors settings)
-  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
-    { return pManager->IsUnderRootProperty("Settings", pObject, sProperty); });
+  m_ObjectMirror.SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, ezStringView sProperty) -> bool { return pManager->IsUnderRootProperty("Settings", pObject, sProperty); });
   // (Remote IPC mirror only sends scene)
-  m_pMirror->SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, ezStringView sProperty) -> bool
-    { return pManager->IsUnderRootProperty("Children", pObject, sProperty); });
+  m_pMirror->SetFilterFunction([pManager = GetObjectManager()](const ezDocumentObject* pObject, ezStringView sProperty) -> bool { return pManager->IsUnderRootProperty("Children", pObject, sProperty); });
 
   EnsureSettingsObjectExist();
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -31,7 +31,7 @@ public:
   };
 
 public:
-  ezSceneDocument(const char* szDocumentPath, DocumentType documentType);
+  ezSceneDocument(ezStringView sDocumentPath, DocumentType documentType);
   ~ezSceneDocument();
 
   enum class ShowOrHide
@@ -86,7 +86,7 @@ public:
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_mimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_sMimeType) const override;
   virtual bool Paste(
-    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
   bool DuplicateSelectedObjects(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bSetSelected);
   bool CopySelectedObjects(ezAbstractObjectGraph& ref_graph, ezMap<ezUuid, ezUuid>* out_pParents) const;
   bool PasteAt(const ezArrayPtr<PasteInfo>& info, const ezVec3& vPos);
@@ -98,7 +98,7 @@ public:
   virtual void UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection) override;
 
   virtual ezUuid ReplaceByPrefab(
-    const ezDocumentObject* pRootObject, const char* szPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab) override;
+    const ezDocumentObject* pRootObject, ezStringView sPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab) override;
 
   /// \brief Reverts all selected editor prefabs to their original template state
   virtual ezUuid RevertPrefab(const ezDocumentObject* pObject) override;
@@ -108,7 +108,7 @@ public:
   /// \brief Converts all objects in the selection that are editor prefabs to their respective engine prefab representation
   virtual void ConvertToEnginePrefab(const ezDeque<const ezDocumentObject*>& selection);
 
-  virtual ezStatus CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {}) override;
+  virtual ezStatus CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {}) override;
 
   GameMode::Enum GetGameMode() const { return m_GameMode; }
 
@@ -180,7 +180,7 @@ protected:
   void SetGameMode(GameMode::Enum mode);
 
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
-  virtual void UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, const char* szBasePrefab) override;
+  virtual void UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, ezStringView sBasePrefab) override;
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 
   template <typename Func>
@@ -202,9 +202,9 @@ protected:
 
   ezStatus RequestExportScene(const char* szTargetFile, const ezAssetFileHeader& header);
 
-  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -64,33 +64,33 @@ ezSceneDocumentManager::ezSceneDocumentManager()
   }
 }
 
-void ezSceneDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezSceneDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  if (ezStringUtils::IsEqual(szDocumentTypeName, "Scene"))
+  if (sDocumentTypeName.IsEqual("Scene"))
   {
-    out_pDocument = new ezScene2Document(szPath);
+    out_pDocument = new ezScene2Document(sPath);
 
     if (bCreateNewDocument)
     {
       SetupDefaultScene(out_pDocument);
     }
   }
-  else if (ezStringUtils::IsEqual(szDocumentTypeName, "Prefab"))
+  else if (sDocumentTypeName.IsEqual("Prefab"))
   {
-    out_pDocument = new ezSceneDocument(szPath, ezSceneDocument::DocumentType::Prefab);
+    out_pDocument = new ezSceneDocument(sPath, ezSceneDocument::DocumentType::Prefab);
   }
-  else if (ezStringUtils::IsEqual(szDocumentTypeName, "Layer"))
+  else if (sDocumentTypeName.IsEqual("Layer"))
   {
     if (pOpenContext == nullptr)
     {
       // Opened individually
-      out_pDocument = new ezSceneDocument(szPath, ezSceneDocument::DocumentType::Layer);
+      out_pDocument = new ezSceneDocument(sPath, ezSceneDocument::DocumentType::Layer);
     }
     else
     {
       // Opened via a parent scene document
       ezScene2Document* pDoc = const_cast<ezScene2Document*>(ezDynamicCast<const ezScene2Document*>(pOpenContext->GetDocumentObjectManager()->GetDocument()));
-      out_pDocument = new ezLayerDocument(szPath, pDoc);
+      out_pDocument = new ezLayerDocument(sPath, pDoc);
     }
   }
 }
@@ -103,9 +103,9 @@ void ezSceneDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<co
   }
 }
 
-void ezSceneDocumentManager::InternalCloneDocument(const char* szPath, const char* szClonePath, const ezUuid& documentId, const ezUuid& seedGuid, const ezUuid& cloneGuid, ezAbstractObjectGraph* pHeader, ezAbstractObjectGraph* pObjects, ezAbstractObjectGraph* pTypes)
+void ezSceneDocumentManager::InternalCloneDocument(ezStringView sPath, ezStringView sClonePath, const ezUuid& documentId, const ezUuid& seedGuid, const ezUuid& cloneGuid, ezAbstractObjectGraph* pHeader, ezAbstractObjectGraph* pObjects, ezAbstractObjectGraph* pTypes)
 {
-  ezAssetDocumentManager::InternalCloneDocument(szPath, szClonePath, documentId, seedGuid, cloneGuid, pHeader, pObjects, pTypes);
+  ezAssetDocumentManager::InternalCloneDocument(sPath, sClonePath, documentId, seedGuid, cloneGuid, pHeader, pObjects, pTypes);
 
 
   auto pRoot = pObjects->GetNodeByName("ObjectTree");
@@ -148,7 +148,7 @@ void ezSceneDocumentManager::InternalCloneDocument(const char* szPath, const cha
             ezUuid newLayerGuid = pLayer->m_Layer;
             newLayerGuid.CombineWithSeed(seedGuid);
 
-            ezStringBuilder sLayerClonePath = szClonePath;
+            ezStringBuilder sLayerClonePath = sClonePath;
             sLayerClonePath.RemoveFileExtension();
             sLayerClonePath.Append("_data");
             ezStringBuilder sCloneFleName = ezPathUtils::GetFileNameAndExtension(sLayerPath.GetData());

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.h
@@ -14,9 +14,9 @@ public:
   ezSceneDocumentManager();
 
 private:
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
-  virtual void InternalCloneDocument(const char* szPath, const char* szClonePath, const ezUuid& documentId, const ezUuid& seedGuid, const ezUuid& cloneGuid, ezAbstractObjectGraph* pHeader, ezAbstractObjectGraph* pObjects, ezAbstractObjectGraph* pTypes) override;
+  virtual void InternalCloneDocument(ezStringView sPath, ezStringView sClonePath, const ezUuid& documentId, const ezUuid& seedGuid, const ezUuid& cloneGuid, ezAbstractObjectGraph* pHeader, ezAbstractObjectGraph* pObjects, ezAbstractObjectGraph* pTypes) override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }
 

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.cpp
@@ -19,8 +19,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTypeScriptAssetDocument, 2, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezTypeScriptAssetDocument::ezTypeScriptAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezTypeScriptAssetProperties>(szDocumentPath, ezAssetDocEngineConnection::None)
+ezTypeScriptAssetDocument::ezTypeScriptAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezTypeScriptAssetProperties>(sDocumentPath, ezAssetDocEngineConnection::None)
 {
 }
 
@@ -234,7 +234,7 @@ void ezTypeScriptAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pIn
   pInfo->m_MetaInfo.PushBack(pExposedParams);
 }
 
-ezTransformStatus ezTypeScriptAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezTypeScriptAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   EZ_SUCCEED_OR_RETURN(ValidateScriptCode());
   EZ_SUCCEED_OR_RETURN(AutoGenerateVariablesCode());

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.h
@@ -25,7 +25,7 @@ class ezTypeScriptAssetDocument : public ezSimpleAssetDocument<ezTypeScriptAsset
   EZ_ADD_DYNAMIC_REFLECTION(ezTypeScriptAssetDocument, ezSimpleAssetDocument<ezTypeScriptAssetProperties>);
 
 public:
-  ezTypeScriptAssetDocument(const char* szDocumentPath);
+  ezTypeScriptAssetDocument(ezStringView sDocumentPath);
 
   void EditScript();
 
@@ -38,7 +38,7 @@ protected:
 
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile,
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ezStatus ValidateScriptCode();

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -82,9 +82,9 @@ void ezTypeScriptAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentMa
   }
 }
 
-void ezTypeScriptAssetDocumentManager::InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+void ezTypeScriptAssetDocumentManager::InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezTypeScriptAssetDocument(szPath);
+  out_pDocument = new ezTypeScriptAssetDocument(sPath);
 }
 
 void ezTypeScriptAssetDocumentManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.h
@@ -27,7 +27,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.cpp
@@ -24,13 +24,13 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptClassAssetDocument, 1, ezRTTINoAll
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezVisualScriptClassAssetDocument::ezVisualScriptClassAssetDocument(const char* szDocumentPath)
-  : ezSimpleAssetDocument<ezVisualScriptClassAssetProperties>(EZ_DEFAULT_NEW(ezVisualScriptNodeManager), szDocumentPath, ezAssetDocEngineConnection::None)
+ezVisualScriptClassAssetDocument::ezVisualScriptClassAssetDocument(ezStringView sDocumentPath)
+  : ezSimpleAssetDocument<ezVisualScriptClassAssetProperties>(EZ_DEFAULT_NEW(ezVisualScriptNodeManager), sDocumentPath, ezAssetDocEngineConnection::None)
 {
   m_pObjectAccessor = EZ_DEFAULT_NEW(ezNodeCommandAccessor, GetCommandHistory());
 }
 
-ezTransformStatus ezVisualScriptClassAssetDocument::InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezVisualScriptClassAssetDocument::InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   auto pManager = static_cast<ezVisualScriptNodeManager*>(GetObjectManager());
 
@@ -147,7 +147,7 @@ bool ezVisualScriptClassAssetDocument::CopySelectedObjects(ezAbstractObjectGraph
   return pManager->CopySelectedObjects(out_objectGraph);
 }
 
-bool ezVisualScriptClassAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+bool ezVisualScriptClassAssetDocument::Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
 {
   ezDocumentNodeManager* pManager = static_cast<ezDocumentNodeManager*>(GetObjectManager());
   return pManager->PasteObjects(info, objectGraph, ezQtNodeScene::GetLastMouseInteractionPos(), bAllowPickedPosition);

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.h
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.h
@@ -19,16 +19,16 @@ class ezVisualScriptClassAssetDocument : public ezSimpleAssetDocument<ezVisualSc
   EZ_ADD_DYNAMIC_REFLECTION(ezVisualScriptClassAssetDocument, ezAssetDocument);
 
 public:
-  ezVisualScriptClassAssetDocument(const char* szDocumentPath);
+  ezVisualScriptClassAssetDocument(ezStringView sDocumentPath);
 
 protected:
-  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, const char* szOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_MimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_MimeType) const override;
   virtual bool Paste(
-    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType) override;
+    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
 
   virtual void InternalGetMetaDataHash(const ezDocumentObject* pObject, ezUInt64& inout_uiHash) const override;
   virtual void AttachMetaDataBeforeSaving(ezAbstractObjectGraph& graph) const override;

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAssetManager.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAssetManager.cpp
@@ -49,9 +49,9 @@ void ezVisualScriptClassAssetManager::OnDocumentManagerEvent(const ezDocumentMan
 }
 
 void ezVisualScriptClassAssetManager::InternalCreateDocument(
-  const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
+  ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext)
 {
-  out_pDocument = new ezVisualScriptClassAssetDocument(szPath);
+  out_pDocument = new ezVisualScriptClassAssetDocument(sPath);
 }
 
 void ezVisualScriptClassAssetManager::InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAssetManager.h
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAssetManager.h
@@ -14,7 +14,7 @@ private:
   void OnDocumentManagerEvent(const ezDocumentManager::Event& e);
 
   virtual void InternalCreateDocument(
-    const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
+    ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) override;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const override;
 
   virtual bool GeneratesProfileSpecificAssets() const override { return false; }

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRHandTracking.cpp
@@ -126,7 +126,7 @@ ezXRHandTrackingInterface::HandPartTrackingState ezOpenXRHandTracking::TryGetBon
         for (ezXRHandBone& bone : out_bones)
         {
           ezTransform local = bone.m_Transform;
-          bone.m_Transform.SetGlobalTransform(globalStageTransform, local);
+          bone.m_Transform = ezTransform::MakeGlobalTransform(globalStageTransform, local);
         }
       }
     }

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRInputDevice.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRInputDevice.cpp
@@ -232,7 +232,7 @@ XrResult ezOpenXRInputDevice::CreateActions(XrSession session, XrSpace sceneSpac
 
 
   XrActionSpaceCreateInfo spaceCreateInfo{XR_TYPE_ACTION_SPACE_CREATE_INFO};
-  spaceCreateInfo.poseInActionSpace = m_pOpenXR->ConvertTransform(ezTransform::IdentityTransform());
+  spaceCreateInfo.poseInActionSpace = m_pOpenXR->ConvertTransform(ezTransform::MakeIdentity());
   for (ezUInt32 uiSide : {0, 1})
   {
     spaceCreateInfo.subactionPath = m_subActionPath[uiSide];

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRSpatialAnchors.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRSpatialAnchors.cpp
@@ -43,7 +43,7 @@ ezXRSpatialAnchorID ezOpenXRSpatialAnchors::CreateAnchor(const ezTransform& glob
     }
   }
   ezTransform local;
-  local.SetLocalTransform(globalStageTransform, globalTransform);
+  local = ezTransform::MakeLocalTransform(globalStageTransform, globalTransform);
 
   XrSpatialAnchorCreateInfoMSFT createInfo{XR_TYPE_SPATIAL_ANCHOR_CREATE_INFO_MSFT};
   createInfo.space = m_pOpenXR->GetBaseSpace();
@@ -58,7 +58,7 @@ ezXRSpatialAnchorID ezOpenXRSpatialAnchors::CreateAnchor(const ezTransform& glob
 
   XrSpatialAnchorSpaceCreateInfoMSFT createSpaceInfo{XR_TYPE_SPATIAL_ANCHOR_SPACE_CREATE_INFO_MSFT};
   createSpaceInfo.anchor = anchor;
-  createSpaceInfo.poseInAnchorSpace = ezOpenXR::ConvertTransform(ezTransform::IdentityTransform());
+  createSpaceInfo.poseInAnchorSpace = ezOpenXR::ConvertTransform(ezTransform::MakeIdentity());
 
   XrSpace space;
   res = m_pOpenXR->m_extensions.pfn_xrCreateSpatialAnchorSpaceMSFT(m_pOpenXR->m_session, &createSpaceInfo, &space);
@@ -108,7 +108,7 @@ ezResult ezOpenXRSpatialAnchors::TryGetAnchorTransform(ezXRSpatialAnchorID id, e
       }
     }
     ezTransform local(ezOpenXR::ConvertPosition(viewInScene.pose.position), ezOpenXR::ConvertOrientation(viewInScene.pose.orientation));
-    out_globalTransform.SetGlobalTransform(globalStageTransform, local);
+    out_globalTransform = ezTransform::MakeGlobalTransform(globalStageTransform, local);
 
     return EZ_SUCCESS;
   }

--- a/Code/Tools/Libs/GuiFoundation/Action/BaseActions.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/BaseActions.h
@@ -19,10 +19,10 @@ public:
 
   const char* GetName() const { return m_sName; }
 
-  const char* GetAdditionalDisplayString() { return m_sAdditionalDisplayString; }
-  void SetAdditionalDisplayString(const char* szString, bool bTriggerUpdate = true)
+  ezStringView GetAdditionalDisplayString() { return m_sAdditionalDisplayString; }
+  void SetAdditionalDisplayString(ezStringView sString, bool bTriggerUpdate = true)
   {
-    m_sAdditionalDisplayString = szString;
+    m_sAdditionalDisplayString = sString;
     if (bTriggerUpdate)
       TriggerUpdate();
   }

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
@@ -191,7 +191,7 @@ void ezDocumentAction::Execute(const ezVariant& value)
         sAllFilters.Append(desc->m_sDocumentTypeName, " (*.", desc->m_sFileExtension, ")");
         QString sSelectedExt;
         ezString sFile = QFileDialog::getSaveFileName(QApplication::activeWindow(), QLatin1String("Create Document"),
-          m_Context.m_pDocument->GetDocumentPath(), QString::fromUtf8(sAllFilters.GetData()), &sSelectedExt, QFileDialog::Option::DontResolveSymlinks)
+          ezMakeQString(m_Context.m_pDocument->GetDocumentPath()), QString::fromUtf8(sAllFilters.GetData()), &sSelectedExt, QFileDialog::Option::DontResolveSymlinks)
                            .toUtf8()
                            .data();
 

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
@@ -328,7 +328,7 @@ void ezQtButtonProxy::Update()
     sTooltip.append(")");
   }
 
-  if (!ezStringUtils::IsNullOrEmpty(pButton->GetAdditionalDisplayString()))
+  if (!pButton->GetAdditionalDisplayString().IsEmpty())
     sDisplay.Append(" '", pButton->GetAdditionalDisplayString(), "'"); // TODO: translate this as well?
 
   m_pQtAction->setIcon(ezQtUiServices::GetCachedIconResource(pButton->GetIconPath()));
@@ -507,7 +507,7 @@ void ezQtDynamicActionAndMenuProxy::Update()
 
   ezStringBuilder sDisplay = ezTranslate(pButton->GetName());
 
-  if (!ezStringUtils::IsNullOrEmpty(pButton->GetAdditionalDisplayString()))
+  if (!pButton->GetAdditionalDisplayString().IsEmpty())
     sDisplay.Append(" '", pButton->GetAdditionalDisplayString(), "'"); // TODO: translate this as well?
 
   const QString sDisplayShortcut = m_pQtAction->shortcut().toString(QKeySequence::NativeText);

--- a/Code/Tools/Libs/GuiFoundation/GuiFoundationDLL.h
+++ b/Code/Tools/Libs/GuiFoundation/GuiFoundationDLL.h
@@ -58,3 +58,8 @@ EZ_ALWAYS_INLINE ezColorGammaUB qtToEzColor(const QColor& c)
 {
   return ezColorGammaUB(c.red(), c.green(), c.blue(), c.alpha());
 }
+
+EZ_ALWAYS_INLINE QString ezMakeQString(ezStringView sString)
+{
+  return QString::fromUtf8(sString.GetStartPointer(), sString.GetElementCount());
+}

--- a/Code/Tools/Libs/ToolsFoundation/Assets/AssetFileExtensionWhitelist.h
+++ b/Code/Tools/Libs/ToolsFoundation/Assets/AssetFileExtensionWhitelist.h
@@ -11,11 +11,11 @@
 class EZ_TOOLSFOUNDATION_DLL ezAssetFileExtensionWhitelist
 {
 public:
-  static void AddAssetFileExtension(const char* szAssetType, const char* szAllowedFileExtension);
+  static void AddAssetFileExtension(ezStringView sAssetType, ezStringView sAllowedFileExtension);
 
-  static bool IsFileOnAssetWhitelist(const char* szAssetType, const char* szFile);
+  static bool IsFileOnAssetWhitelist(ezStringView sAssetType, ezStringView sFile);
 
-  static const ezSet<ezString>& GetAssetFileExtensions(const char* szAssetType);
+  static const ezSet<ezString>& GetAssetFileExtensions(ezStringView sAssetType);
 
 private:
   static ezMap<ezString, ezSet<ezString>> s_ExtensionWhitelist;

--- a/Code/Tools/Libs/ToolsFoundation/Assets/Implementation/AssetFileExtensionWhitelist.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Assets/Implementation/AssetFileExtensionWhitelist.cpp
@@ -4,24 +4,24 @@
 
 ezMap<ezString, ezSet<ezString>> ezAssetFileExtensionWhitelist::s_ExtensionWhitelist;
 
-void ezAssetFileExtensionWhitelist::AddAssetFileExtension(const char* szAssetType, const char* szAllowedFileExtension)
+void ezAssetFileExtensionWhitelist::AddAssetFileExtension(ezStringView sAssetType, ezStringView sAllowedFileExtension)
 {
-  ezStringBuilder sLowerType = szAssetType;
+  ezStringBuilder sLowerType = sAssetType;
   sLowerType.ToLower();
 
-  ezStringBuilder sLowerExt = szAllowedFileExtension;
+  ezStringBuilder sLowerExt = sAllowedFileExtension;
   sLowerExt.ToLower();
 
   s_ExtensionWhitelist[sLowerType].Insert(sLowerExt);
 }
 
 
-bool ezAssetFileExtensionWhitelist::IsFileOnAssetWhitelist(const char* szAssetType, const char* szFile)
+bool ezAssetFileExtensionWhitelist::IsFileOnAssetWhitelist(ezStringView sAssetType, ezStringView sFile)
 {
-  ezStringBuilder sLowerExt = ezPathUtils::GetFileExtension(szFile);
+  ezStringBuilder sLowerExt = ezPathUtils::GetFileExtension(sFile);
   sLowerExt.ToLower();
 
-  ezStringBuilder sLowerType = szAssetType;
+  ezStringBuilder sLowerType = sAssetType;
   sLowerType.ToLower();
 
   ezHybridArray<ezString, 16> Types;
@@ -36,7 +36,7 @@ bool ezAssetFileExtensionWhitelist::IsFileOnAssetWhitelist(const char* szAssetTy
   return false;
 }
 
-const ezSet<ezString>& ezAssetFileExtensionWhitelist::GetAssetFileExtensions(const char* szAssetType)
+const ezSet<ezString>& ezAssetFileExtensionWhitelist::GetAssetFileExtensions(ezStringView sAssetType)
 {
-  return s_ExtensionWhitelist[szAssetType];
+  return s_ExtensionWhitelist[sAssetType];
 }

--- a/Code/Tools/Libs/ToolsFoundation/Command/Implementation/TreeCommands.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Command/Implementation/TreeCommands.cpp
@@ -375,7 +375,7 @@ ezStatus ezInstantiatePrefabCommand::DoInternal(bool bRedo)
   {
     // TODO: this is hard-coded, it only works for scene documents !
     const ezRTTI* pRootObjectType = ezRTTI::FindTypeByName("ezGameObject");
-    const char* szParentProperty = "Children";
+    ezStringView sParentProperty = "Children"_ezsv;
 
     ezDocumentObject* pRootObject = nullptr;
     ezHybridArray<ezDocument::PasteInfo, 16> ToBePasted;
@@ -383,7 +383,7 @@ ezStatus ezInstantiatePrefabCommand::DoInternal(bool bRedo)
 
     // create root object
     {
-      EZ_SUCCEED_OR_RETURN(pDocument->GetObjectManager()->CanAdd(pRootObjectType, pParent, szParentProperty, m_Index));
+      EZ_SUCCEED_OR_RETURN(pDocument->GetObjectManager()->CanAdd(pRootObjectType, pParent, sParentProperty, m_Index));
 
       // use the same GUID for the root object ID as the remap GUID, this way the object ID is deterministic and reproducible
       m_CreatedRootObject = m_RemapGuid;
@@ -458,7 +458,7 @@ ezStatus ezInstantiatePrefabCommand::DoInternal(bool bRedo)
         reader.ApplyPropertiesToObject(pPrefabRoot, pNewObject);
 
         // attach all prefab nodes to the main group node
-        pDocument->GetObjectManager()->AddObject(pNewObject, pRootObject, szParentProperty, -1);
+        pDocument->GetObjectManager()->AddObject(pNewObject, pRootObject, sParentProperty, -1);
       }
     }
   }

--- a/Code/Tools/Libs/ToolsFoundation/CommandHistory/CommandHistory.h
+++ b/Code/Tools/Libs/ToolsFoundation/CommandHistory/CommandHistory.h
@@ -77,8 +77,8 @@ public:
   bool CanUndo() const;
   bool CanRedo() const;
 
-  const char* GetUndoDisplayString() const;
-  const char* GetRedoDisplayString() const;
+  ezStringView GetUndoDisplayString() const;
+  ezStringView GetRedoDisplayString() const;
 
   void StartTransaction(const ezFormatString& displayString);
   void CancelTransaction() { EndTransaction(true); }
@@ -91,7 +91,7 @@ public:
   /// \brief Call this to start a series of transactions that typically change the same value over and over (e.g. dragging an object to a position).
   /// Every time a new transaction is started, the previous one is undone first. At the end of a series of temporary transactions, only the last
   /// transaction will be stored as a single undo step. Call this first and then start a transaction inside it.
-  void BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands = false);
+  void BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands = false);
   void CancelTemporaryCommands();
   void FinishTemporaryCommands();
 

--- a/Code/Tools/Libs/ToolsFoundation/CommandHistory/Implementation/CommandHistory.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/CommandHistory/Implementation/CommandHistory.cpp
@@ -64,10 +64,10 @@ ezCommandHistory::~ezCommandHistory()
   }
 }
 
-void ezCommandHistory::BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands)
+void ezCommandHistory::BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands)
 {
   EZ_ASSERT_DEV(!m_bTemporaryMode, "Temporary Mode cannot be nested");
-  StartTransaction(szDisplayString);
+  StartTransaction(sDisplayString);
   StartTransaction("[Temporary]");
 
   m_bFireEventsWhenUndoingTempCommands = bFireEventsWhenUndoingTempCommands;
@@ -236,7 +236,7 @@ bool ezCommandHistory::CanRedo() const
 }
 
 
-const char* ezCommandHistory::GetUndoDisplayString() const
+ezStringView ezCommandHistory::GetUndoDisplayString() const
 {
   if (m_pHistoryStorage->m_UndoHistory.IsEmpty())
     return "";
@@ -245,7 +245,7 @@ const char* ezCommandHistory::GetUndoDisplayString() const
 }
 
 
-const char* ezCommandHistory::GetRedoDisplayString() const
+ezStringView ezCommandHistory::GetRedoDisplayString() const
 {
   if (m_pHistoryStorage->m_RedoHistory.IsEmpty())
     return "";

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -58,7 +58,7 @@ class EZ_TOOLSFOUNDATION_DLL ezDocument : public ezReflectedClass
   EZ_ADD_DYNAMIC_REFLECTION(ezDocument, ezReflectedClass);
 
 public:
-  ezDocument(const char* szPath, ezDocumentObjectManager* pDocumentObjectManagerImpl);
+  ezDocument(ezStringView sPath, ezDocumentObjectManager* pDocumentObjectManagerImpl);
   virtual ~ezDocument();
 
   /// \name Document State Functions
@@ -99,7 +99,7 @@ protected:
 
 public:
   /// \brief Returns the absolute path to the document.
-  const char* GetDocumentPath() const { return m_sDocumentPath; }
+  ezStringView GetDocumentPath() const { return m_sDocumentPath; }
 
   /// \brief Saves the document, if it is modified.
   /// If bForce is true, the document will be written, even if it is not considered modified.
@@ -161,7 +161,7 @@ public:
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_mimeTypes) const {}
   /// \brief Creates the abstract graph of data to be copied and returns the mime type for the clipboard to identify the data
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_sMimeType) const { return false; };
-  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, const char* szMimeType)
+  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType)
   {
     return false;
   };
@@ -230,11 +230,11 @@ public:
   /// \brief Removes the link between a prefab instance and its template, turning the instance into a regular object.
   virtual void UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection);
 
-  virtual ezStatus CreatePrefabDocumentFromSelection(const char* szFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
-  virtual ezStatus CreatePrefabDocument(const char* szFile, ezArrayPtr<const ezDocumentObject*> rootObjects, const ezUuid& invPrefabSeed, ezUuid& out_newDocumentGuid, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, bool bKeepOpen = false, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
+  virtual ezStatus CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
+  virtual ezStatus CreatePrefabDocument(ezStringView sFile, ezArrayPtr<const ezDocumentObject*> rootObjects, const ezUuid& invPrefabSeed, ezUuid& out_newDocumentGuid, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, bool bKeepOpen = false, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
 
   // Returns new guid of replaced object.
-  virtual ezUuid ReplaceByPrefab(const ezDocumentObject* pRootObject, const char* szPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab);
+  virtual ezUuid ReplaceByPrefab(const ezDocumentObject* pRootObject, ezStringView sPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab);
   // Returns new guid of reverted object.
   virtual ezUuid RevertPrefab(const ezDocumentObject* pObject);
 
@@ -272,7 +272,7 @@ protected:
   ///@{
 
   virtual void UpdatePrefabsRecursive(ezDocumentObject* pObject);
-  virtual void UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, const char* szBasePrefab);
+  virtual void UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid& PrefabAsset, const ezUuid& PrefabSeed, ezStringView sBasePrefab);
 
   ///@}
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/DocumentManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/DocumentManager.h
@@ -15,7 +15,7 @@ public:
 
   static ezResult FindDocumentTypeFromPath(ezStringView sPath, bool bForCreation, const ezDocumentTypeDescriptor*& out_pTypeDesc);
 
-  ezStatus CanOpenDocument(const char* szFilePath) const;
+  ezStatus CanOpenDocument(ezStringView sFilePath) const;
 
   /// \brief Creates a new document.
   /// \param szDocumentTypeName Document type to create. See ezDocumentTypeDescriptor.
@@ -25,7 +25,7 @@ public:
   /// \param pOpenContext An generic context object. Allows for custom data to be passed along into the construction. E.g. inform a sub-document which main document it belongs to.
   /// \return Returns the error in case the operations failed.
   ezStatus CreateDocument(
-    const char* szDocumentTypeName, const char* szPath, ezDocument*& out_pDocument, ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::None, const ezDocumentObject* pOpenContext = nullptr);
+    ezStringView sDocumentTypeName, ezStringView sPath, ezDocument*& out_pDocument, ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::None, const ezDocumentObject* pOpenContext = nullptr);
 
   /// \brief Opens an existing document.
   /// \param szDocumentTypeName Document type to open. See ezDocumentTypeDescriptor.
@@ -35,10 +35,10 @@ public:
   /// \param pOpenContext  An generic context object. Allows for custom data to be passed along into the construction. E.g. inform a sub-document which main document it belongs to.
   /// \return Returns the error in case the operations failed.
   /// \return Returns the error in case the operations failed.
-  ezStatus OpenDocument(const char* szDocumentTypeName, const char* szPath, ezDocument*& out_pDocument,
+  ezStatus OpenDocument(ezStringView sDocumentTypeName, ezStringView sPath, ezDocument*& out_pDocument,
     ezBitflags<ezDocumentFlags> flags = ezDocumentFlags::AddToRecentFilesList | ezDocumentFlags::RequestWindow,
     const ezDocumentObject* pOpenContext = nullptr);
-  virtual ezStatus CloneDocument(const char* szPath, const char* szClonePath, ezUuid& inout_cloneGuid);
+  virtual ezStatus CloneDocument(ezStringView sPath, ezStringView sClonePath, ezUuid& inout_cloneGuid);
   void CloseDocument(ezDocument* pDocument);
   void EnsureWindowRequested(ezDocument* pDocument, const ezDocumentObject* pOpenContext = nullptr);
 
@@ -99,7 +99,7 @@ public:
   static ezCopyOnBroadcastEvent<const Event&> s_Events;
   static ezEvent<Request&> s_Requests;
 
-  static const ezDocumentTypeDescriptor* GetDescriptorForDocumentType(const char* szDocumentType);
+  static const ezDocumentTypeDescriptor* GetDescriptorForDocumentType(ezStringView sDocumentType);
   static const ezMap<ezString, const ezDocumentTypeDescriptor*>& GetAllDocumentDescriptors();
 
   void GetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_documentTypes) const;
@@ -108,14 +108,14 @@ public:
   static ezMap<ezString, CustomAction> s_CustomActions;
 
 protected:
-  virtual void InternalCloneDocument(const char* szPath, const char* szClonePath, const ezUuid& documentId, const ezUuid& seedGuid, const ezUuid& cloneGuid, ezAbstractObjectGraph* pHeader, ezAbstractObjectGraph* pObjects, ezAbstractObjectGraph* pTypes);
+  virtual void InternalCloneDocument(ezStringView sPath, ezStringView sClonePath, const ezUuid& documentId, const ezUuid& seedGuid, const ezUuid& cloneGuid, ezAbstractObjectGraph* pHeader, ezAbstractObjectGraph* pObjects, ezAbstractObjectGraph* pTypes);
 
 private:
-  virtual void InternalCreateDocument(const char* szDocumentTypeName, const char* szPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) = 0;
+  virtual void InternalCreateDocument(ezStringView sDocumentTypeName, ezStringView sPath, bool bCreateNewDocument, ezDocument*& out_pDocument, const ezDocumentObject* pOpenContext) = 0;
   virtual void InternalGetSupportedDocumentTypes(ezDynamicArray<const ezDocumentTypeDescriptor*>& inout_DocumentTypes) const = 0;
 
 private:
-  ezStatus CreateOrOpenDocument(bool bCreate, const char* szDocumentTypeName, const char* szPath, ezDocument*& out_pDocument,
+  ezStatus CreateOrOpenDocument(bool bCreate, ezStringView sDocumentTypeName, ezStringView sPath, ezDocument*& out_pDocument,
     ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext = nullptr);
 
 private:

--- a/Code/Tools/Libs/ToolsFoundation/Document/DocumentUtils.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/DocumentUtils.h
@@ -9,5 +9,5 @@ struct ezDocumentTypeDescriptor;
 class EZ_TOOLSFOUNDATION_DLL ezDocumentUtils
 {
 public:
-  static ezStatus IsValidSaveLocationForDocument(const char* szDocument, const ezDocumentTypeDescriptor** out_pTypeDesc = nullptr);
+  static ezStatus IsValidSaveLocationForDocument(ezStringView sDocument, const ezDocumentTypeDescriptor** out_pTypeDesc = nullptr);
 };

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
@@ -56,12 +56,12 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezEvent<const ezDocumentEvent&> ezDocument::s_EventsAny;
 
-ezDocument::ezDocument(const char* szPath, ezDocumentObjectManager* pDocumentObjectManagerImpl)
+ezDocument::ezDocument(ezStringView sPath, ezDocumentObjectManager* pDocumentObjectManagerImpl)
 {
   using ObjectMetaData = ezObjectMetaData<ezUuid, ezDocumentObjectMetaData>;
   m_DocumentObjectMetaData = EZ_DEFAULT_NEW(ObjectMetaData);
   m_pDocumentInfo = nullptr;
-  m_sDocumentPath = szPath;
+  m_sDocumentPath = sPath;
   m_pObjectManager = ezUniquePtr<ezDocumentObjectManager>(pDocumentObjectManagerImpl, ezFoundation::GetDefaultAllocator());
   m_pObjectManager->SetDocument(this);
   m_pCommandHistory = EZ_DEFAULT_NEW(ezCommandHistory, this);

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentUtils.cpp
@@ -3,18 +3,18 @@
 #include <ToolsFoundation/Document/DocumentManager.h>
 #include <ToolsFoundation/Document/DocumentUtils.h>
 
-ezStatus ezDocumentUtils::IsValidSaveLocationForDocument(const char* szDocument, const ezDocumentTypeDescriptor** out_pTypeDesc)
+ezStatus ezDocumentUtils::IsValidSaveLocationForDocument(ezStringView sDocument, const ezDocumentTypeDescriptor** out_pTypeDesc)
 {
   const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
-  if (ezDocumentManager::FindDocumentTypeFromPath(szDocument, true, pTypeDesc).Failed())
+  if (ezDocumentManager::FindDocumentTypeFromPath(sDocument, true, pTypeDesc).Failed())
   {
     ezStringBuilder sTemp;
     sTemp.Format("The selected file extension '{0}' is not registered with any known type.\nCannot create file '{1}'",
-      ezPathUtils::GetFileExtension(szDocument), szDocument);
+      ezPathUtils::GetFileExtension(sDocument), sDocument);
     return ezStatus(sTemp.GetData());
   }
 
-  if (ezDocument* pDocument = pTypeDesc->m_pManager->GetDocumentByPath(szDocument))
+  if (ezDocument* pDocument = pTypeDesc->m_pManager->GetDocumentByPath(sDocument))
   {
     return ezStatus("The selected document is already open. You need to close the document before you can re-create it.");
   }

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/PrefabUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/PrefabUtils.cpp
@@ -27,9 +27,9 @@ ezString ToBinary(const ezUuid& guid)
   return sResult;
 }
 
-void ezPrefabUtils::LoadGraph(ezAbstractObjectGraph& out_graph, const char* szGraph)
+void ezPrefabUtils::LoadGraph(ezAbstractObjectGraph& out_graph, ezStringView sGraph)
 {
-  ezPrefabCache::GetSingleton()->LoadGraph(out_graph, ezStringView(szGraph));
+  ezPrefabCache::GetSingleton()->LoadGraph(out_graph, ezStringView(sGraph));
 }
 
 
@@ -117,7 +117,7 @@ ezUuid ezPrefabUtils::GetPrefabRoot(const ezDocumentObject* pObject, const ezObj
 }
 
 
-ezVariant ezPrefabUtils::GetDefaultValue(const ezAbstractObjectGraph& graph, const ezUuid& objectGuid, const char* szProperty, ezVariant index, bool* pValueFound)
+ezVariant ezPrefabUtils::GetDefaultValue(const ezAbstractObjectGraph& graph, const ezUuid& objectGuid, ezStringView sProperty, ezVariant index, bool* pValueFound)
 {
   if (pValueFound)
     *pValueFound = false;
@@ -126,7 +126,7 @@ ezVariant ezPrefabUtils::GetDefaultValue(const ezAbstractObjectGraph& graph, con
   if (!pNode)
     return ezVariant();
 
-  const ezAbstractObjectNode::Property* pProp = pNode->FindProperty(szProperty);
+  const ezAbstractObjectNode::Property* pProp = pNode->FindProperty(sProperty);
   if (pProp)
   {
     const ezVariant& value = pProp->m_Value;
@@ -244,11 +244,11 @@ void ezPrefabUtils::Merge(const ezAbstractObjectGraph& baseGraph, const ezAbstra
   }
 }
 
-void ezPrefabUtils::Merge(const char* szBase, const char* szLeft, ezDocumentObject* pRight, bool bRightIsNotPartOfPrefab, const ezUuid& prefabSeed, ezStringBuilder& out_sNewGraph)
+void ezPrefabUtils::Merge(ezStringView sBase, ezStringView sLeft, ezDocumentObject* pRight, bool bRightIsNotPartOfPrefab, const ezUuid& prefabSeed, ezStringBuilder& out_sNewGraph)
 {
   // prepare the original prefab as a graph
   ezAbstractObjectGraph baseGraph;
-  ezPrefabUtils::LoadGraph(baseGraph, szBase);
+  ezPrefabUtils::LoadGraph(baseGraph, sBase);
   if (auto pHeader = baseGraph.GetNodeByName("Header"))
   {
     baseGraph.RemoveNode(pHeader->GetGuid());
@@ -257,7 +257,7 @@ void ezPrefabUtils::Merge(const char* szBase, const char* szLeft, ezDocumentObje
   {
     // read the new template as a graph
     ezAbstractObjectGraph leftGraph;
-    ezPrefabUtils::LoadGraph(leftGraph, szLeft);
+    ezPrefabUtils::LoadGraph(leftGraph, sLeft);
     if (auto pHeader = leftGraph.GetNodeByName("Header"))
     {
       leftGraph.RemoveNode(pHeader->GetGuid());
@@ -318,12 +318,12 @@ void ezPrefabUtils::Merge(const char* szBase, const char* szLeft, ezDocumentObje
   }
 }
 
-ezString ezPrefabUtils::ReadDocumentAsString(const char* szFile)
+ezString ezPrefabUtils::ReadDocumentAsString(ezStringView sFile)
 {
   ezFileReader file;
-  if (file.Open(szFile) == EZ_FAILURE)
+  if (file.Open(sFile) == EZ_FAILURE)
   {
-    ezLog::Error("Failed to open document file '{0}'", szFile);
+    ezLog::Error("Failed to open document file '{0}'", sFile);
     return ezString();
   }
 

--- a/Code/Tools/Libs/ToolsFoundation/Document/PrefabUtils.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/PrefabUtils.h
@@ -11,7 +11,7 @@ class EZ_TOOLSFOUNDATION_DLL ezPrefabUtils
 {
 public:
   /// \brief
-  static void LoadGraph(ezAbstractObjectGraph& out_graph, const char* szGraph);
+  static void LoadGraph(ezAbstractObjectGraph& out_graph, ezStringView sGraph);
 
   static ezAbstractObjectNode* GetFirstRootNode(ezAbstractObjectGraph& ref_graph);
 
@@ -20,7 +20,7 @@ public:
   static ezUuid GetPrefabRoot(const ezDocumentObject* pObject, const ezObjectMetaData<ezUuid, ezDocumentObjectMetaData>& documentObjectMetaData, ezInt32* pDepth = nullptr);
 
   static ezVariant GetDefaultValue(
-    const ezAbstractObjectGraph& graph, const ezUuid& objectGuid, const char* szProperty, ezVariant index = ezVariant(), bool* pValueFound = nullptr);
+    const ezAbstractObjectGraph& graph, const ezUuid& objectGuid, ezStringView sProperty, ezVariant index = ezVariant(), bool* pValueFound = nullptr);
 
   static void WriteDiff(const ezDeque<ezAbstractGraphDiffOperation>& mergedDiff, ezStringBuilder& out_sText);
 
@@ -30,8 +30,8 @@ public:
 
   /// \brief Merges diffs of left and right graphs relative to their base graph. Conflicts prefer the right graph. Base and left are provided as
   /// serialized DDL graphs and the right graph is build directly from pRight and its PrefabSeed.
-  static void Merge(const char* szBase, const char* szLeft, ezDocumentObject* pRight, bool bRightIsNotPartOfPrefab, const ezUuid& prefabSeed,
+  static void Merge(ezStringView sBase, ezStringView sLeft, ezDocumentObject* pRight, bool bRightIsNotPartOfPrefab, const ezUuid& prefabSeed,
     ezStringBuilder& out_sNewGraph);
 
-  static ezString ReadDocumentAsString(const char* szFile);
+  static ezString ReadDocumentAsString(ezStringView sFile);
 };

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/DocumentNodeManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/DocumentNodeManager.h
@@ -112,8 +112,8 @@ public:
   ezVec2 GetNodePos(const ezDocumentObject* pObject) const;
   const ezConnection& GetConnection(const ezDocumentObject* pObject) const;
 
-  const ezPin* GetInputPinByName(const ezDocumentObject* pObject, const char* szName) const;
-  const ezPin* GetOutputPinByName(const ezDocumentObject* pObject, const char* szName) const;
+  const ezPin* GetInputPinByName(const ezDocumentObject* pObject, ezStringView sName) const;
+  const ezPin* GetOutputPinByName(const ezDocumentObject* pObject, ezStringView sName) const;
   ezArrayPtr<const ezUniquePtr<const ezPin>> GetInputPins(const ezDocumentObject* pObject) const;
   ezArrayPtr<const ezUniquePtr<const ezPin>> GetOutputPins(const ezDocumentObject* pObject) const;
 
@@ -157,7 +157,7 @@ protected:
   /// \brief Returns true if adding a connection between the two pins would create a circular graph
   bool WouldConnectionCreateCircle(const ezPin& source, const ezPin& target) const;
 
-  void GetDynamicPinNames(const ezDocumentObject* pObject, const char* szPropertyName, ezStringView sPinName, ezDynamicArray<ezString>& out_Names) const;
+  void GetDynamicPinNames(const ezDocumentObject* pObject, ezStringView sPropertyName, ezStringView sPinName, ezDynamicArray<ezString>& out_Names) const;
   virtual bool TryRecreatePins(const ezDocumentObject* pObject);
 
   struct NodeInternal

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/DocumentNodeManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/DocumentNodeManager.cpp
@@ -108,27 +108,27 @@ const ezConnection& ezDocumentNodeManager::GetConnection(const ezDocumentObject*
   return *it.Value();
 }
 
-const ezPin* ezDocumentNodeManager::GetInputPinByName(const ezDocumentObject* pObject, const char* szName) const
+const ezPin* ezDocumentNodeManager::GetInputPinByName(const ezDocumentObject* pObject, ezStringView sName) const
 {
   EZ_ASSERT_DEV(pObject != nullptr, "Invalid input!");
   auto it = m_ObjectToNode.Find(pObject->GetGuid());
   EZ_ASSERT_DEV(it.IsValid(), "Can't get input pins of objects that aren't nodes!");
   for (auto& pPin : it.Value().m_Inputs)
   {
-    if (ezStringUtils::IsEqual(pPin->GetName(), szName))
+    if (pPin->GetName() == sName)
       return pPin.Borrow();
   }
   return nullptr;
 }
 
-const ezPin* ezDocumentNodeManager::GetOutputPinByName(const ezDocumentObject* pObject, const char* szName) const
+const ezPin* ezDocumentNodeManager::GetOutputPinByName(const ezDocumentObject* pObject, ezStringView sName) const
 {
   EZ_ASSERT_DEV(pObject != nullptr, "Invalid input!");
   auto it = m_ObjectToNode.Find(pObject->GetGuid());
   EZ_ASSERT_DEV(it.IsValid(), "Can't get input pins of objects that aren't nodes!");
   for (auto& pPin : it.Value().m_Outputs)
   {
-    if (ezStringUtils::IsEqual(pPin->GetName(), szName))
+    if (pPin->GetName() == sName)
       return pPin.Borrow();
   }
   return nullptr;
@@ -614,19 +614,19 @@ bool ezDocumentNodeManager::WouldConnectionCreateCircle(const ezPin& source, con
   return CanReachNode(pTargetNode, pSourceNode, Visited);
 }
 
-void ezDocumentNodeManager::GetDynamicPinNames(const ezDocumentObject* pObject, const char* szPropertyName, ezStringView sPinName, ezDynamicArray<ezString>& out_Names) const
+void ezDocumentNodeManager::GetDynamicPinNames(const ezDocumentObject* pObject, ezStringView sPropertyName, ezStringView sPinName, ezDynamicArray<ezString>& out_Names) const
 {
   out_Names.Clear();
 
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szPropertyName);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sPropertyName);
   if (pProp == nullptr)
   {
-    ezLog::Warning("Property '{0}' not found in type '{1}'", szPropertyName, pObject->GetType()->GetTypeName());
+    ezLog::Warning("Property '{0}' not found in type '{1}'", sPropertyName, pObject->GetType()->GetTypeName());
     return;
   }
 
   ezStringBuilder sTemp;
-  ezVariant value = pObject->GetTypeAccessor().GetValue(szPropertyName);
+  ezVariant value = pObject->GetTypeAccessor().GetValue(sPropertyName);
 
   if (pProp->GetCategory() == ezPropertyCategory::Member)
   {

--- a/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectBase.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectBase.h
@@ -28,7 +28,7 @@ public:
   // Ownership
   const ezDocumentObject* GetParent() const { return m_pParent; }
 
-  virtual void InsertSubObject(ezDocumentObject* pObject, const char* szProperty, const ezVariant& index);
+  virtual void InsertSubObject(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& index);
   virtual void RemoveSubObject(ezDocumentObject* pObject);
 
   // Helper
@@ -36,7 +36,7 @@ public:
   const ezHybridArray<ezDocumentObject*, 8>& GetChildren() const { return m_Children; }
   ezDocumentObject* GetChild(const ezUuid& guid);
   const ezDocumentObject* GetChild(const ezUuid& guid) const;
-  const char* GetParentProperty() const { return m_sParentProperty; }
+  ezStringView GetParentProperty() const { return m_sParentProperty; }
   const ezAbstractProperty* GetParentPropertyType() const;
   ezVariant GetPropertyIndex() const;
   bool IsOnHeap() const;

--- a/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectManager.h
@@ -36,7 +36,7 @@ public:
   }
 
 public:
-  virtual void InsertSubObject(ezDocumentObject* pObject, const char* szProperty, const ezVariant& index) override;
+  virtual void InsertSubObject(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& index) override;
   virtual void RemoveSubObject(ezDocumentObject* pObject) override;
 };
 
@@ -150,7 +150,7 @@ public:
 
   /// \brief Allows to annotate types with a category (group), such that things like creator menus can use this to present the types in a more user
   /// friendly way
-  virtual const char* GetTypeCategory(const ezRTTI* pRtti) const { return nullptr; }
+  virtual ezStringView GetTypeCategory(const ezRTTI* pRtti) const { return {}; }
   void PatchEmbeddedClassObjects(const ezDocumentObject* pObject) const;
 
   const ezDocumentObject* GetRootObject() const { return &m_pObjectStorage->m_RootObject; }
@@ -161,26 +161,26 @@ public:
   ezDocument* GetDocument() { return m_pObjectStorage->m_pDocument; }
 
   // Property Change
-  ezStatus SetValue(ezDocumentObject* pObject, const char* szProperty, const ezVariant& newValue, ezVariant index = ezVariant());
-  ezStatus InsertValue(ezDocumentObject* pObject, const char* szProperty, const ezVariant& newValue, ezVariant index = ezVariant());
-  ezStatus RemoveValue(ezDocumentObject* pObject, const char* szProperty, ezVariant index = ezVariant());
-  ezStatus MoveValue(ezDocumentObject* pObject, const char* szProperty, const ezVariant& oldIndex, const ezVariant& newIndex);
+  ezStatus SetValue(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& newValue, ezVariant index = ezVariant());
+  ezStatus InsertValue(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& newValue, ezVariant index = ezVariant());
+  ezStatus RemoveValue(ezDocumentObject* pObject, ezStringView sProperty, ezVariant index = ezVariant());
+  ezStatus MoveValue(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& oldIndex, const ezVariant& newIndex);
 
   // Structure Change
-  void AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, const char* szParentProperty, ezVariant index);
+  void AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, ezStringView sParentProperty, ezVariant index);
   void RemoveObject(ezDocumentObject* pObject);
-  void MoveObject(ezDocumentObject* pObject, ezDocumentObject* pNewParent, const char* szParentProperty, ezVariant index);
+  void MoveObject(ezDocumentObject* pObject, ezDocumentObject* pNewParent, ezStringView sParentProperty, ezVariant index);
 
   // Structure Change Test
-  ezStatus CanAdd(const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const;
+  ezStatus CanAdd(const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const;
   ezStatus CanRemove(const ezDocumentObject* pObject) const;
-  ezStatus CanMove(const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const;
+  ezStatus CanMove(const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const;
   ezStatus CanSelect(const ezDocumentObject* pObject) const;
 
-  bool IsUnderRootProperty(const char* szRootProperty, const ezDocumentObject* pObject) const;
-  bool IsUnderRootProperty(const char* szRootProperty, const ezDocumentObject* pParent, const char* szParentProperty) const;
+  bool IsUnderRootProperty(ezStringView sRootProperty, const ezDocumentObject* pObject) const;
+  bool IsUnderRootProperty(ezStringView sRootProperty, const ezDocumentObject* pParent, ezStringView sParentProperty) const;
   bool IsTemporary(const ezDocumentObject* pObject) const;
-  bool IsTemporary(const ezDocumentObject* pParent, const char* szParentProperty) const;
+  bool IsTemporary(const ezDocumentObject* pParent, ezStringView sParentProperty) const;
 
   ezSharedPtr<ezDocumentObjectManager::Storage> SwapStorage(ezSharedPtr<ezDocumentObjectManager::Storage> pNewStorage);
   ezSharedPtr<ezDocumentObjectManager::Storage> GetStorage() { return m_pObjectStorage; }
@@ -189,17 +189,17 @@ private:
   virtual ezDocumentObject* InternalCreateObject(const ezRTTI* pRtti) { return EZ_DEFAULT_NEW(ezDocumentStorageObject, pRtti); }
   virtual void InternalDestroyObject(ezDocumentObject* pObject) { EZ_DEFAULT_DELETE(pObject); }
 
-  void InternalAddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, const char* szParentProperty, ezVariant index);
+  void InternalAddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, ezStringView sParentProperty, ezVariant index);
   void InternalRemoveObject(ezDocumentObject* pObject);
-  void InternalMoveObject(ezDocumentObject* pNewParent, ezDocumentObject* pObject, const char* szParentProperty, ezVariant index);
+  void InternalMoveObject(ezDocumentObject* pNewParent, ezDocumentObject* pObject, ezStringView sParentProperty, ezVariant index);
 
-  virtual ezStatus InternalCanAdd(const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const
+  virtual ezStatus InternalCanAdd(const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const
   {
     return ezStatus(EZ_SUCCESS);
   };
   virtual ezStatus InternalCanRemove(const ezDocumentObject* pObject) const { return ezStatus(EZ_SUCCESS); };
   virtual ezStatus InternalCanMove(
-    const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const
+    const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const
   {
     return ezStatus(EZ_SUCCESS);
   };

--- a/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectMirror.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectMirror.h
@@ -40,7 +40,7 @@ public:
   void InitReceiver(ezRttiConverterContext* pContext);
   void DeInit();
 
-  using FilterFunction = ezDelegate<bool(const ezDocumentObject*, const char*)>;
+  using FilterFunction = ezDelegate<bool(const ezDocumentObject*, ezStringView)>;
   /// \brief
   ///
   /// \param filter
@@ -58,9 +58,9 @@ public:
 
 protected:
   bool IsRootObject(const ezDocumentObject* pParent);
-  bool IsHeapAllocated(const ezDocumentObject* pParent, const char* szParentProperty);
-  bool IsDiscardedByFilter(const ezDocumentObject* pObject, const char* szProperty) const;
-  static void CreatePath(ezObjectChange& out_change, const ezDocumentObject* pRoot, const char* szProperty);
+  bool IsHeapAllocated(const ezDocumentObject* pParent, ezStringView sParentProperty);
+  bool IsDiscardedByFilter(const ezDocumentObject* pObject, ezStringView sProperty) const;
+  static void CreatePath(ezObjectChange& out_change, const ezDocumentObject* pRoot, ezStringView sProperty);
   static ezUuid FindRootOpObject(const ezDocumentObject* pObject, ezHybridArray<const ezDocumentObject*, 8>& path);
   static void FlattenSteps(const ezArrayPtr<const ezDocumentObject* const> path, ezHybridArray<ezPropertyPathStep, 2>& out_steps);
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectVisitor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/DocumentObjectVisitor.h
@@ -20,7 +20,7 @@ public:
   /// \param szRootProperty
   ///   Same as szChildrenProperty, but for the root object of the document.
   ezDocumentObjectVisitor(
-    const ezDocumentObjectManager* pManager, const char* szChildrenProperty = "Children", const char* szRootProperty = "Children");
+    const ezDocumentObjectManager* pManager, ezStringView sChildrenProperty = "Children", ezStringView sRootProperty = "Children");
 
   using VisitorFunction = ezDelegate<bool(const ezDocumentObject*)>;
   /// \brief Executes depth first traversal starting at the given node.
@@ -34,7 +34,7 @@ public:
   void Visit(const ezDocumentObject* pObject, bool bVisitStart, VisitorFunction function);
 
 private:
-  void TraverseChildren(const ezDocumentObject* pObject, const char* szProperty, VisitorFunction& function);
+  void TraverseChildren(const ezDocumentObject* pObject, ezStringView sProperty, VisitorFunction& function);
 
   const ezDocumentObjectManager* m_pManager = nullptr;
   ezString m_sChildrenProperty;

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectBase.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectBase.cpp
@@ -14,14 +14,14 @@ ezUInt32 ezDocumentObject::GetChildIndex(const ezDocumentObject* pChild) const
   return m_Children.IndexOf(const_cast<ezDocumentObject*>(pChild));
 }
 
-void ezDocumentObject::InsertSubObject(ezDocumentObject* pObject, const char* szProperty, const ezVariant& index)
+void ezDocumentObject::InsertSubObject(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& index)
 {
   EZ_ASSERT_DEV(pObject != nullptr, "");
-  EZ_ASSERT_DEV(!ezStringUtils::IsNullOrEmpty(szProperty), "Child objects must have a parent property to insert into");
+  EZ_ASSERT_DEV(!sProperty.IsEmpty(), "Child objects must have a parent property to insert into");
   ezIReflectedTypeAccessor& accessor = GetTypeAccessor();
 
   const ezRTTI* pType = accessor.GetType();
-  auto* pProp = pType->FindPropertyByName(szProperty);
+  auto* pProp = pType->FindPropertyByName(sProperty);
   EZ_ASSERT_DEV(pProp && pProp->GetFlags().IsSet(ezPropertyFlags::Class) &&
                   (!pProp->GetFlags().IsSet(ezPropertyFlags::Pointer) || pProp->GetFlags().IsSet(ezPropertyFlags::PointerOwner)),
     "Only class type or pointer to class type that own the object can be inserted, everything else is handled by value.");
@@ -30,30 +30,30 @@ void ezDocumentObject::InsertSubObject(ezDocumentObject* pObject, const char* sz
   {
     if (!index.IsValid() || (index.CanConvertTo<ezInt32>() && index.ConvertTo<ezInt32>() == -1))
     {
-      ezVariant newIndex = accessor.GetCount(szProperty);
-      bool bRes = accessor.InsertValue(szProperty, newIndex, pObject->GetGuid());
+      ezVariant newIndex = accessor.GetCount(sProperty);
+      bool bRes = accessor.InsertValue(sProperty, newIndex, pObject->GetGuid());
       EZ_ASSERT_DEV(bRes, "");
     }
     else
     {
-      bool bRes = accessor.InsertValue(szProperty, index, pObject->GetGuid());
+      bool bRes = accessor.InsertValue(sProperty, index, pObject->GetGuid());
       EZ_ASSERT_DEV(bRes, "");
     }
   }
   else if (pProp->GetCategory() == ezPropertyCategory::Map)
   {
     EZ_ASSERT_DEV(index.IsA<ezString>(), "Map key must be a string.");
-    bool bRes = accessor.InsertValue(szProperty, index, pObject->GetGuid());
+    bool bRes = accessor.InsertValue(sProperty, index, pObject->GetGuid());
     EZ_ASSERT_DEV(bRes, "");
   }
   else if (pProp->GetCategory() == ezPropertyCategory::Member)
   {
-    bool bRes = accessor.SetValue(szProperty, pObject->GetGuid());
+    bool bRes = accessor.SetValue(sProperty, pObject->GetGuid());
     EZ_ASSERT_DEV(bRes, "");
   }
 
   // Object patching
-  pObject->m_sParentProperty = szProperty;
+  pObject->m_sParentProperty = sProperty;
   pObject->m_pParent = this;
   m_Children.PushBack(pObject);
 }

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectManager.cpp
@@ -24,7 +24,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 void ezDocumentRootObject::InsertSubObject(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& index)
 {
-if (sProperty.IsEmpty())
+  if (sProperty.IsEmpty())
     sProperty = "Children";
   return ezDocumentObject::InsertSubObject(pObject, sProperty, index);
 }

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectManager.cpp
@@ -22,11 +22,11 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDocumentRoot, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezDocumentRootObject::InsertSubObject(ezDocumentObject* pObject, const char* szProperty, const ezVariant& index)
+void ezDocumentRootObject::InsertSubObject(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& index)
 {
-  if (ezStringUtils::IsNullOrEmpty(szProperty))
-    szProperty = "Children";
-  return ezDocumentObject::InsertSubObject(pObject, szProperty, index);
+if (sProperty.IsEmpty())
+    sProperty = "Children";
+  return ezDocumentObject::InsertSubObject(pObject, sProperty, index);
 }
 
 void ezDocumentRootObject::RemoveSubObject(ezDocumentObject* pObject)
@@ -157,15 +157,15 @@ ezDocumentObject* ezDocumentObjectManager::GetObject(const ezUuid& guid)
 // ezDocumentObjectManager Property Change
 ////////////////////////////////////////////////////////////////////////
 
-ezStatus ezDocumentObjectManager::SetValue(ezDocumentObject* pObject, const char* szProperty, const ezVariant& newValue, ezVariant index)
+ezStatus ezDocumentObjectManager::SetValue(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& newValue, ezVariant index)
 {
   EZ_ASSERT_DEBUG(pObject, "Object must not be null.");
   ezIReflectedTypeAccessor& accessor = pObject->GetTypeAccessor();
-  ezVariant oldValue = accessor.GetValue(szProperty, index);
+  ezVariant oldValue = accessor.GetValue(sProperty, index);
 
-  if (!accessor.SetValue(szProperty, newValue, index))
+  if (!accessor.SetValue(sProperty, newValue, index))
   {
-    return ezStatus(ezFmt("Set Property: The property '{0}' does not exist or value type does not match", szProperty));
+    return ezStatus(ezFmt("Set Property: The property '{0}' does not exist or value type does not match", sProperty));
   }
 
   ezDocumentObjectPropertyEvent e;
@@ -173,7 +173,7 @@ ezStatus ezDocumentObjectManager::SetValue(ezDocumentObject* pObject, const char
   e.m_pObject = pObject;
   e.m_OldValue = oldValue;
   e.m_NewValue = newValue;
-  e.m_sProperty = szProperty;
+  e.m_sProperty = sProperty;
   e.m_NewIndex = index;
 
   // Allow a recursion depth of 2 for property setters. This allowed for two levels of side-effects on property setters.
@@ -181,16 +181,16 @@ ezStatus ezDocumentObjectManager::SetValue(ezDocumentObject* pObject, const char
   return ezStatus(EZ_SUCCESS);
 }
 
-ezStatus ezDocumentObjectManager::InsertValue(ezDocumentObject* pObject, const char* szProperty, const ezVariant& newValue, ezVariant index)
+ezStatus ezDocumentObjectManager::InsertValue(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& newValue, ezVariant index)
 {
   ezIReflectedTypeAccessor& accessor = pObject->GetTypeAccessor();
-  if (!accessor.InsertValue(szProperty, index, newValue))
+  if (!accessor.InsertValue(sProperty, index, newValue))
   {
-    if (!accessor.GetType()->FindPropertyByName(szProperty))
+    if (!accessor.GetType()->FindPropertyByName(sProperty))
     {
-      return ezStatus(ezFmt("Insert Property: The property '{0}' does not exist", szProperty));
+      return ezStatus(ezFmt("Insert Property: The property '{0}' does not exist", sProperty));
     }
-    return ezStatus(ezFmt("Insert Property: The property '{0}' already has the key '{1}'", szProperty, index));
+    return ezStatus(ezFmt("Insert Property: The property '{0}' already has the key '{1}'", sProperty, index));
   }
 
   ezDocumentObjectPropertyEvent e;
@@ -198,21 +198,21 @@ ezStatus ezDocumentObjectManager::InsertValue(ezDocumentObject* pObject, const c
   e.m_pObject = pObject;
   e.m_NewValue = newValue;
   e.m_NewIndex = index;
-  e.m_sProperty = szProperty;
+  e.m_sProperty = sProperty;
 
   m_pObjectStorage->m_PropertyEvents.Broadcast(e);
 
   return ezStatus(EZ_SUCCESS);
 }
 
-ezStatus ezDocumentObjectManager::RemoveValue(ezDocumentObject* pObject, const char* szProperty, ezVariant index)
+ezStatus ezDocumentObjectManager::RemoveValue(ezDocumentObject* pObject, ezStringView sProperty, ezVariant index)
 {
   ezIReflectedTypeAccessor& accessor = pObject->GetTypeAccessor();
-  ezVariant oldValue = accessor.GetValue(szProperty, index);
+  ezVariant oldValue = accessor.GetValue(sProperty, index);
 
-  if (!accessor.RemoveValue(szProperty, index))
+  if (!accessor.RemoveValue(sProperty, index))
   {
-    return ezStatus(ezFmt("Remove Property: The index '{0}' in property '{1}' does not exist!", index.ConvertTo<ezString>(), szProperty));
+    return ezStatus(ezFmt("Remove Property: The index '{0}' in property '{1}' does not exist!", index.ConvertTo<ezString>(), sProperty));
   }
 
   ezDocumentObjectPropertyEvent e;
@@ -220,20 +220,20 @@ ezStatus ezDocumentObjectManager::RemoveValue(ezDocumentObject* pObject, const c
   e.m_pObject = pObject;
   e.m_OldValue = oldValue;
   e.m_OldIndex = index;
-  e.m_sProperty = szProperty;
+  e.m_sProperty = sProperty;
 
   m_pObjectStorage->m_PropertyEvents.Broadcast(e);
 
   return ezStatus(EZ_SUCCESS);
 }
 
-ezStatus ezDocumentObjectManager::MoveValue(ezDocumentObject* pObject, const char* szProperty, const ezVariant& oldIndex, const ezVariant& newIndex)
+ezStatus ezDocumentObjectManager::MoveValue(ezDocumentObject* pObject, ezStringView sProperty, const ezVariant& oldIndex, const ezVariant& newIndex)
 {
   if (!oldIndex.CanConvertTo<ezInt32>() || !newIndex.CanConvertTo<ezInt32>())
     return ezStatus("Move Property: Invalid indices provided.");
 
   ezIReflectedTypeAccessor& accessor = pObject->GetTypeAccessor();
-  ezInt32 iCount = accessor.GetCount(szProperty);
+  ezInt32 iCount = accessor.GetCount(sProperty);
   if (iCount < 0)
     return ezStatus("Move Property: Invalid property.");
   if (oldIndex.ConvertTo<ezInt32>() < 0 || oldIndex.ConvertTo<ezInt32>() >= iCount)
@@ -241,7 +241,7 @@ ezStatus ezDocumentObjectManager::MoveValue(ezDocumentObject* pObject, const cha
   if (newIndex.ConvertTo<ezInt32>() < 0 || newIndex.ConvertTo<ezInt32>() > iCount)
     return ezStatus(ezFmt("Move Property: Invalid new index '{0}'.", newIndex.ConvertTo<ezInt32>()));
 
-  if (!accessor.MoveValue(szProperty, oldIndex, newIndex))
+  if (!accessor.MoveValue(sProperty, oldIndex, newIndex))
     return ezStatus("Move Property: Move value failed.");
 
   {
@@ -250,8 +250,8 @@ ezStatus ezDocumentObjectManager::MoveValue(ezDocumentObject* pObject, const cha
     e.m_pObject = pObject;
     e.m_OldIndex = oldIndex;
     e.m_NewIndex = newIndex;
-    e.m_sProperty = szProperty;
-    e.m_NewValue = accessor.GetValue(szProperty, e.getInsertIndex());
+    e.m_sProperty = sProperty;
+    e.m_NewValue = accessor.GetValue(sProperty, e.getInsertIndex());
     // NewValue can be invalid if an invalid variant in a variant array is moved
     //EZ_ASSERT_DEV(e.m_NewValue.IsValid(), "Value at new pos should be valid now, index missmatch?");
     m_pObjectStorage->m_PropertyEvents.Broadcast(e);
@@ -264,18 +264,18 @@ ezStatus ezDocumentObjectManager::MoveValue(ezDocumentObject* pObject, const cha
 // ezDocumentObjectManager Structure Change
 ////////////////////////////////////////////////////////////////////////
 
-void ezDocumentObjectManager::AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, const char* szParentProperty, ezVariant index)
+void ezDocumentObjectManager::AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, ezStringView sParentProperty, ezVariant index)
 {
   if (pParent == nullptr)
     pParent = &m_pObjectStorage->m_RootObject;
-  if (pParent == &m_pObjectStorage->m_RootObject && ezStringUtils::IsNullOrEmpty(szParentProperty))
-    szParentProperty = "Children";
+  if (pParent == &m_pObjectStorage->m_RootObject && sParentProperty.IsEmpty())
+    sParentProperty = "Children";
 
   EZ_ASSERT_DEV(pObject->GetGuid().IsValid(), "Object Guid invalid! Object was not created via an ezObjectManagerBase!");
   EZ_ASSERT_DEV(
-    CanAdd(pObject->GetTypeAccessor().GetType(), pParent, szParentProperty, index).m_Result.Succeeded(), "Trying to execute invalid add!");
+    CanAdd(pObject->GetTypeAccessor().GetType(), pParent, sParentProperty, index).m_Result.Succeeded(), "Trying to execute invalid add!");
 
-  InternalAddObject(pObject, pParent, szParentProperty, index);
+  InternalAddObject(pObject, pParent, sParentProperty, index);
 }
 
 void ezDocumentObjectManager::RemoveObject(ezDocumentObject* pObject)
@@ -284,11 +284,11 @@ void ezDocumentObjectManager::RemoveObject(ezDocumentObject* pObject)
   InternalRemoveObject(pObject);
 }
 
-void ezDocumentObjectManager::MoveObject(ezDocumentObject* pObject, ezDocumentObject* pNewParent, const char* szParentProperty, ezVariant index)
+void ezDocumentObjectManager::MoveObject(ezDocumentObject* pObject, ezDocumentObject* pNewParent, ezStringView sParentProperty, ezVariant index)
 {
-  EZ_ASSERT_DEV(CanMove(pObject, pNewParent, szParentProperty, index).m_Result.Succeeded(), "Trying to execute invalid move!");
+  EZ_ASSERT_DEV(CanMove(pObject, pNewParent, sParentProperty, index).m_Result.Succeeded(), "Trying to execute invalid move!");
 
-  InternalMoveObject(pNewParent, pObject, szParentProperty, index);
+  InternalMoveObject(pNewParent, pObject, sParentProperty, index);
 }
 
 
@@ -297,7 +297,7 @@ void ezDocumentObjectManager::MoveObject(ezDocumentObject* pObject, ezDocumentOb
 ////////////////////////////////////////////////////////////////////////
 
 ezStatus ezDocumentObjectManager::CanAdd(
-  const ezRTTI* pRtti, const ezDocumentObject* pParent, const char* szParentProperty, const ezVariant& index) const
+  const ezRTTI* pRtti, const ezDocumentObject* pParent, ezStringView sParentProperty, const ezVariant& index) const
 {
   // Test whether parent exists in tree.
   if (pParent == GetRootObject())
@@ -312,9 +312,9 @@ ezStatus ezDocumentObjectManager::CanAdd(
 
     const ezIReflectedTypeAccessor& accessor = pParent->GetTypeAccessor();
     const ezRTTI* pType = accessor.GetType();
-    auto* pProp = pType->FindPropertyByName(szParentProperty);
+    auto* pProp = pType->FindPropertyByName(sParentProperty);
     if (pProp == nullptr)
-      return ezStatus(ezFmt("Property '{0}' could not be found in type '{1}'", szParentProperty, pType->GetTypeName()));
+      return ezStatus(ezFmt("Property '{0}' could not be found in type '{1}'", sParentProperty, pType->GetTypeName()));
 
     const bool bIsValueType = ezReflectionUtils::IsValueType(pProp);
 
@@ -327,28 +327,28 @@ ezStatus ezDocumentObjectManager::CanAdd(
       if (pProp->GetFlags().IsSet(ezPropertyFlags::Pointer))
       {
         if (!pProp->GetFlags().IsSet(ezPropertyFlags::PointerOwner))
-          return ezStatus(ezFmt("Cannot add object to the pointer property '{0}' as it does not hold ownership.", szParentProperty));
+          return ezStatus(ezFmt("Cannot add object to the pointer property '{0}' as it does not hold ownership.", sParentProperty));
 
         if (!pRtti->IsDerivedFrom(pProp->GetSpecificType()))
           return ezStatus(ezFmt("Cannot add object to the pointer property '{0}' as its type '{1}' is not derived from the property type '{2}'!",
-            szParentProperty, pRtti->GetTypeName(), pProp->GetSpecificType()->GetTypeName()));
+            sParentProperty, pRtti->GetTypeName(), pProp->GetSpecificType()->GetTypeName()));
       }
       else
       {
         if (pRtti != pProp->GetSpecificType())
-          return ezStatus(ezFmt("Cannot add object to the property '{0}' as its type '{1}' does not match the property type '{2}'!", szParentProperty,
+          return ezStatus(ezFmt("Cannot add object to the property '{0}' as its type '{1}' does not match the property type '{2}'!", sParentProperty,
             pRtti->GetTypeName(), pProp->GetSpecificType()->GetTypeName()));
       }
     }
 
     if (pProp->GetCategory() == ezPropertyCategory::Array || pProp->GetCategory() == ezPropertyCategory::Set)
     {
-      ezInt32 iCount = accessor.GetCount(szParentProperty);
+      ezInt32 iCount = accessor.GetCount(sParentProperty);
       if (!index.CanConvertTo<ezInt32>())
       {
         return ezStatus(ezFmt("Cannot add object to the property '{0}', the given index is an invalid ezVariant (Either use '-1' to append "
                               "or a valid index).",
-          szParentProperty));
+          sParentProperty));
       }
       ezInt32 iNewIndex = index.ConvertTo<ezInt32>();
       if (iNewIndex > (ezInt32)iCount)
@@ -356,19 +356,19 @@ ezStatus ezDocumentObjectManager::CanAdd(
           "Cannot add object to its new location '{0}' is out of the bounds of the parent's property range '{1}'!", iNewIndex, (ezInt32)iCount));
       if (iNewIndex < 0 && iNewIndex != -1)
         return ezStatus(ezFmt("Cannot add object to the property '{0}', the index '{1}' is not valid (Either use '-1' to append or a valid index).",
-          szParentProperty, iNewIndex));
+          sParentProperty, iNewIndex));
     }
     if (pProp->GetCategory() == ezPropertyCategory::Map)
     {
       if (!index.IsA<ezString>())
-        return ezStatus(ezFmt("Cannot add object to the map property '{0}' as its index type is not a string.", szParentProperty));
-      ezVariant value = accessor.GetValue(szParentProperty, index);
+        return ezStatus(ezFmt("Cannot add object to the map property '{0}' as its index type is not a string.", sParentProperty));
+      ezVariant value = accessor.GetValue(sParentProperty, index);
       if (value.IsValid() && value.IsA<ezUuid>())
       {
         ezUuid guid = value.Get<ezUuid>();
         if (guid.IsValid())
           return ezStatus(
-            ezFmt("Cannot add object to the map property '{0}' at key '{1}'. Delete old value first.", szParentProperty, index.Get<ezString>()));
+            ezFmt("Cannot add object to the map property '{0}' at key '{1}'. Delete old value first.", sParentProperty, index.Get<ezString>()));
       }
     }
     else if (pProp->GetCategory() == ezPropertyCategory::Member)
@@ -376,7 +376,7 @@ ezStatus ezDocumentObjectManager::CanAdd(
       if (!pProp->GetFlags().IsSet(ezPropertyFlags::Pointer))
         return ezStatus("Embedded classes cannot be changed manually.");
 
-      ezVariant value = accessor.GetValue(szParentProperty);
+      ezVariant value = accessor.GetValue(sParentProperty);
       if (!value.IsA<ezUuid>())
         return ezStatus("Property is not a pointer and thus can't be added to.");
 
@@ -385,7 +385,7 @@ ezStatus ezDocumentObjectManager::CanAdd(
     }
   }
 
-  return InternalCanAdd(pRtti, pParent, szParentProperty, index);
+  return InternalCanAdd(pRtti, pParent, sParentProperty, index);
 }
 
 ezStatus ezDocumentObjectManager::CanRemove(const ezDocumentObject* pObject) const
@@ -408,9 +408,9 @@ ezStatus ezDocumentObjectManager::CanRemove(const ezDocumentObject* pObject) con
 }
 
 ezStatus ezDocumentObjectManager::CanMove(
-  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProperty, const ezVariant& index) const
+  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProperty, const ezVariant& index) const
 {
-  EZ_SUCCEED_OR_RETURN(CanAdd(pObject->GetTypeAccessor().GetType(), pNewParent, szParentProperty, index));
+  EZ_SUCCEED_OR_RETURN(CanAdd(pObject->GetTypeAccessor().GetType(), pNewParent, sParentProperty, index));
 
   EZ_SUCCEED_OR_RETURN(CanRemove(pObject));
 
@@ -450,24 +450,24 @@ ezStatus ezDocumentObjectManager::CanMove(
   const ezIReflectedTypeAccessor& accessor = pNewParent->GetTypeAccessor();
   const ezRTTI* pType = accessor.GetType();
 
-  auto* pProp = pType->FindPropertyByName(szParentProperty);
+  auto* pProp = pType->FindPropertyByName(sParentProperty);
 
   if (pProp == nullptr)
-    return ezStatus(ezFmt("Property '{0}' could not be found in type '{1}'", szParentProperty, pType->GetTypeName()));
+    return ezStatus(ezFmt("Property '{0}' could not be found in type '{1}'", sParentProperty, pType->GetTypeName()));
 
   if (pProp->GetCategory() == ezPropertyCategory::Array || pProp->GetCategory() == ezPropertyCategory::Set)
   {
     ezInt32 iChildIndex = index.ConvertTo<ezInt32>();
     if (iChildIndex == -1)
     {
-      iChildIndex = pNewParent->GetTypeAccessor().GetCount(szParentProperty);
+      iChildIndex = pNewParent->GetTypeAccessor().GetCount(sParentProperty);
     }
 
     if (pNewParent == pObject->GetParent())
     {
       // Test whether we are moving before or after ourselves, both of which are not allowed and would not change the tree.
       ezIReflectedTypeAccessor& oldAccessor = pObject->m_pParent->GetTypeAccessor();
-      ezInt32 iCurrentIndex = oldAccessor.GetPropertyChildIndex(szParentProperty, pObject->GetGuid()).ConvertTo<ezInt32>();
+      ezInt32 iCurrentIndex = oldAccessor.GetPropertyChildIndex(sParentProperty, pObject->GetGuid()).ConvertTo<ezInt32>();
       if (iChildIndex == iCurrentIndex || iChildIndex == iCurrentIndex + 1)
         return ezStatus("Can't move object onto itself!");
     }
@@ -475,21 +475,21 @@ ezStatus ezDocumentObjectManager::CanMove(
   if (pProp->GetCategory() == ezPropertyCategory::Map)
   {
     if (!index.IsA<ezString>())
-      return ezStatus(ezFmt("Cannot add object to the map property '{0}' as its index type is not a string.", szParentProperty));
-    ezVariant value = accessor.GetValue(szParentProperty, index);
+      return ezStatus(ezFmt("Cannot add object to the map property '{0}' as its index type is not a string.", sParentProperty));
+    ezVariant value = accessor.GetValue(sParentProperty, index);
     if (value.IsValid() && value.IsA<ezUuid>())
     {
       ezUuid guid = value.Get<ezUuid>();
       if (guid.IsValid())
         return ezStatus(
-          ezFmt("Cannot add object to the map property '{0}' at key '{1}'. Delete old value first.", szParentProperty, index.Get<ezString>()));
+          ezFmt("Cannot add object to the map property '{0}' at key '{1}'. Delete old value first.", sParentProperty, index.Get<ezString>()));
     }
   }
 
   if (pNewParent == GetRootObject())
     pNewParent = nullptr;
 
-  return InternalCanMove(pObject, pNewParent, szParentProperty, index);
+  return InternalCanMove(pObject, pNewParent, sParentProperty, index);
 }
 
 ezStatus ezDocumentObjectManager::CanSelect(const ezDocumentObject* pObject) const
@@ -505,25 +505,25 @@ ezStatus ezDocumentObjectManager::CanSelect(const ezDocumentObject* pObject) con
 }
 
 
-bool ezDocumentObjectManager::IsUnderRootProperty(const char* szRootProperty, const ezDocumentObject* pObject) const
+bool ezDocumentObjectManager::IsUnderRootProperty(ezStringView sRootProperty, const ezDocumentObject* pObject) const
 {
   EZ_ASSERT_DEBUG(m_pObjectStorage->m_RootObject.GetDocumentObjectManager() == pObject->GetDocumentObjectManager(), "Passed in object does not belong to this object manager.");
   while (pObject->GetParent() != GetRootObject())
   {
     pObject = pObject->GetParent();
   }
-  return ezStringUtils::IsEqual(pObject->GetParentProperty(), szRootProperty);
+  return sRootProperty == pObject->GetParentProperty();
 }
 
 
-bool ezDocumentObjectManager::IsUnderRootProperty(const char* szRootProperty, const ezDocumentObject* pParent, const char* szParentProperty) const
+bool ezDocumentObjectManager::IsUnderRootProperty(ezStringView sRootProperty, const ezDocumentObject* pParent, ezStringView sParentProperty) const
 {
   EZ_ASSERT_DEBUG(pParent == nullptr || m_pObjectStorage->m_RootObject.GetDocumentObjectManager() == pParent->GetDocumentObjectManager(), "Passed in object does not belong to this object manager.");
   if (pParent == nullptr || pParent == GetRootObject())
   {
-    return ezStringUtils::IsEqual(szParentProperty, szRootProperty);
+    return sParentProperty == sRootProperty;
   }
-  return IsUnderRootProperty(szRootProperty, pParent);
+  return IsUnderRootProperty(sRootProperty, pParent);
 }
 
 bool ezDocumentObjectManager::IsTemporary(const ezDocumentObject* pObject) const
@@ -531,9 +531,9 @@ bool ezDocumentObjectManager::IsTemporary(const ezDocumentObject* pObject) const
   return IsUnderRootProperty("TempObjects", pObject);
 }
 
-bool ezDocumentObjectManager::IsTemporary(const ezDocumentObject* pParent, const char* szParentProperty) const
+bool ezDocumentObjectManager::IsTemporary(const ezDocumentObject* pParent, ezStringView sParentProperty) const
 {
-  return IsUnderRootProperty("TempObjects", pParent, szParentProperty);
+  return IsUnderRootProperty("TempObjects", pParent, sParentProperty);
 }
 
 ezSharedPtr<ezDocumentObjectManager::Storage> ezDocumentObjectManager::SwapStorage(ezSharedPtr<ezDocumentObjectManager::Storage> pNewStorage)
@@ -559,7 +559,7 @@ ezSharedPtr<ezDocumentObjectManager::Storage> ezDocumentObjectManager::SwapStora
 // ezDocumentObjectManager Private Functions
 ////////////////////////////////////////////////////////////////////////
 
-void ezDocumentObjectManager::InternalAddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, const char* szParentProperty, ezVariant index)
+void ezDocumentObjectManager::InternalAddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, ezStringView sParentProperty, ezVariant index)
 {
   ezDocumentObjectStructureEvent e;
   e.m_pDocument = m_pObjectStorage->m_pDocument;
@@ -567,17 +567,17 @@ void ezDocumentObjectManager::InternalAddObject(ezDocumentObject* pObject, ezDoc
   e.m_pObject = pObject;
   e.m_pPreviousParent = nullptr;
   e.m_pNewParent = pParent;
-  e.m_sParentProperty = szParentProperty;
+  e.m_sParentProperty = sParentProperty;
   e.m_NewPropertyIndex = index;
 
   if (e.m_NewPropertyIndex.CanConvertTo<ezInt32>() && e.m_NewPropertyIndex.ConvertTo<ezInt32>() == -1)
   {
     ezIReflectedTypeAccessor& accessor = pParent->GetTypeAccessor();
-    e.m_NewPropertyIndex = accessor.GetCount(szParentProperty);
+    e.m_NewPropertyIndex = accessor.GetCount(sParentProperty);
   }
   m_pObjectStorage->m_StructureEvents.Broadcast(e);
 
-  pParent->InsertSubObject(pObject, szParentProperty, e.m_NewPropertyIndex);
+  pParent->InsertSubObject(pObject, sParentProperty, e.m_NewPropertyIndex);
   RecursiveAddGuids(pObject);
 
   e.m_EventType = ezDocumentObjectStructureEvent::Type::AfterObjectAdded;
@@ -604,7 +604,7 @@ void ezDocumentObjectManager::InternalRemoveObject(ezDocumentObject* pObject)
 }
 
 void ezDocumentObjectManager::InternalMoveObject(
-  ezDocumentObject* pNewParent, ezDocumentObject* pObject, const char* szParentProperty, ezVariant index)
+  ezDocumentObject* pNewParent, ezDocumentObject* pObject, ezStringView sParentProperty, ezVariant index)
 {
   if (pNewParent == nullptr)
     pNewParent = &m_pObjectStorage->m_RootObject;
@@ -615,13 +615,13 @@ void ezDocumentObjectManager::InternalMoveObject(
   e.m_pObject = pObject;
   e.m_pPreviousParent = pObject->m_pParent;
   e.m_pNewParent = pNewParent;
-  e.m_sParentProperty = szParentProperty;
+  e.m_sParentProperty = sParentProperty;
   e.m_OldPropertyIndex = pObject->GetPropertyIndex();
   e.m_NewPropertyIndex = index;
   if (e.m_NewPropertyIndex.CanConvertTo<ezInt32>() && e.m_NewPropertyIndex.ConvertTo<ezInt32>() == -1)
   {
     ezIReflectedTypeAccessor& accessor = pNewParent->GetTypeAccessor();
-    e.m_NewPropertyIndex = accessor.GetCount(szParentProperty);
+    e.m_NewPropertyIndex = accessor.GetCount(sParentProperty);
   }
 
   m_pObjectStorage->m_StructureEvents.Broadcast(e);
@@ -629,7 +629,7 @@ void ezDocumentObjectManager::InternalMoveObject(
   ezVariant newIndex = e.getInsertIndex();
 
   pObject->m_pParent->RemoveSubObject(pObject);
-  pNewParent->InsertSubObject(pObject, szParentProperty, newIndex);
+  pNewParent->InsertSubObject(pObject, sParentProperty, newIndex);
 
   e.m_EventType = ezDocumentObjectStructureEvent::Type::AfterObjectMoved;
   m_pObjectStorage->m_StructureEvents.Broadcast(e);

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectMirror.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectMirror.cpp
@@ -364,28 +364,28 @@ bool ezDocumentObjectMirror::IsRootObject(const ezDocumentObject* pParent)
   return (pParent == nullptr || pParent == m_pManager->GetRootObject());
 }
 
-bool ezDocumentObjectMirror::IsHeapAllocated(const ezDocumentObject* pParent, const char* szParentProperty)
+bool ezDocumentObjectMirror::IsHeapAllocated(const ezDocumentObject* pParent, ezStringView sParentProperty)
 {
   if (pParent == nullptr || pParent == m_pManager->GetRootObject())
     return true;
 
   const ezRTTI* pRtti = pParent->GetTypeAccessor().GetType();
 
-  auto* pProp = pRtti->FindPropertyByName(szParentProperty);
+  auto* pProp = pRtti->FindPropertyByName(sParentProperty);
   return pProp->GetFlags().IsSet(ezPropertyFlags::PointerOwner);
 }
 
 
-bool ezDocumentObjectMirror::IsDiscardedByFilter(const ezDocumentObject* pObject, const char* szProperty) const
+bool ezDocumentObjectMirror::IsDiscardedByFilter(const ezDocumentObject* pObject, ezStringView sProperty) const
 {
   if (m_Filter.IsValid())
   {
-    return !m_Filter(pObject, szProperty);
+    return !m_Filter(pObject, sProperty);
   }
   return false;
 }
 
-void ezDocumentObjectMirror::CreatePath(ezObjectChange& out_change, const ezDocumentObject* pRoot, const char* szProperty)
+void ezDocumentObjectMirror::CreatePath(ezObjectChange& out_change, const ezDocumentObject* pRoot, ezStringView sProperty)
 {
   if (pRoot && pRoot->GetDocumentObjectManager()->GetRootObject() != pRoot)
   {
@@ -394,7 +394,7 @@ void ezDocumentObjectMirror::CreatePath(ezObjectChange& out_change, const ezDocu
     FlattenSteps(path, out_change.m_Steps);
   }
 
-  out_change.m_Change.m_sProperty = szProperty;
+  out_change.m_Change.m_sProperty = sProperty;
 }
 
 ezUuid ezDocumentObjectMirror::FindRootOpObject(const ezDocumentObject* pParent, ezHybridArray<const ezDocumentObject*, 8>& path)

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectVisitor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectVisitor.cpp
@@ -4,13 +4,13 @@
 #include <ToolsFoundation/Object/DocumentObjectVisitor.h>
 
 ezDocumentObjectVisitor::ezDocumentObjectVisitor(
-  const ezDocumentObjectManager* pManager, const char* szChildrenProperty /*= "Children"*/, const char* szRootProperty /*= "Children"*/)
+  const ezDocumentObjectManager* pManager, ezStringView sChildrenProperty /*= "Children"*/, ezStringView sRootProperty /*= "Children"*/)
   : m_pManager(pManager)
-  , m_sChildrenProperty(szChildrenProperty)
-  , m_sRootProperty(szRootProperty)
+  , m_sChildrenProperty(sChildrenProperty)
+  , m_sRootProperty(sRootProperty)
 {
-  const ezAbstractProperty* pRootProp = m_pManager->GetRootObject()->GetType()->FindPropertyByName(szRootProperty);
-  EZ_ASSERT_DEV(pRootProp, "Given root property '{0}' does not exist on root object", szRootProperty);
+  const ezAbstractProperty* pRootProp = m_pManager->GetRootObject()->GetType()->FindPropertyByName(sRootProperty);
+  EZ_ASSERT_DEV(pRootProp, "Given root property '{0}' does not exist on root object", sRootProperty);
   EZ_ASSERT_DEV(pRootProp->GetCategory() == ezPropertyCategory::Set || pRootProp->GetCategory() == ezPropertyCategory::Array,
     "Traverser only works on arrays and sets.");
 
@@ -22,25 +22,25 @@ ezDocumentObjectVisitor::ezDocumentObjectVisitor(
 
 void ezDocumentObjectVisitor::Visit(const ezDocumentObject* pObject, bool bVisitStart, VisitorFunction function)
 {
-  const char* szProperty = m_sChildrenProperty;
+  ezStringView sProperty = m_sChildrenProperty;
   if (pObject == nullptr || pObject == m_pManager->GetRootObject())
   {
     pObject = m_pManager->GetRootObject();
-    szProperty = m_sRootProperty;
+    sProperty = m_sRootProperty;
   }
 
   if (!bVisitStart || function(pObject))
   {
-    TraverseChildren(pObject, szProperty, function);
+    TraverseChildren(pObject, sProperty, function);
   }
 }
 
-void ezDocumentObjectVisitor::TraverseChildren(const ezDocumentObject* pObject, const char* szProperty, VisitorFunction& function)
+void ezDocumentObjectVisitor::TraverseChildren(const ezDocumentObject* pObject, ezStringView sProperty, VisitorFunction& function)
 {
-  const ezInt32 iChildren = pObject->GetTypeAccessor().GetCount(szProperty);
+  const ezInt32 iChildren = pObject->GetTypeAccessor().GetCount(sProperty);
   for (ezInt32 i = 0; i < iChildren; i++)
   {
-    ezVariant obj = pObject->GetTypeAccessor().GetValue(szProperty, i);
+    ezVariant obj = pObject->GetTypeAccessor().GetValue(sProperty, i);
     EZ_ASSERT_DEBUG(obj.IsValid() && obj.IsA<ezUuid>(), "null obj found during traversal.");
     const ezDocumentObject* pChild = m_pManager->GetObject(obj.Get<ezUuid>());
     if (function(pChild))

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase.cpp
@@ -11,7 +11,7 @@ void ezObjectAccessorBase::CancelTransaction() {}
 void ezObjectAccessorBase::FinishTransaction() {}
 
 
-void ezObjectAccessorBase::BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands /*= false*/) {}
+void ezObjectAccessorBase::BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands /*= false*/) {}
 
 
 void ezObjectAccessorBase::CancelTemporaryCommands() {}
@@ -20,113 +20,113 @@ void ezObjectAccessorBase::CancelTemporaryCommands() {}
 void ezObjectAccessorBase::FinishTemporaryCommands() {}
 
 
-ezStatus ezObjectAccessorBase::GetValue(const ezDocumentObject* pObject, const char* szProp, ezVariant& out_value, ezVariant index /*= ezVariant()*/)
+ezStatus ezObjectAccessorBase::GetValue(const ezDocumentObject* pObject, ezStringView sProp, ezVariant& out_value, ezVariant index /*= ezVariant()*/)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return GetValue(pObject, pProp, out_value, index);
 }
 
 
 ezStatus ezObjectAccessorBase::SetValue(
-  const ezDocumentObject* pObject, const char* szProp, const ezVariant& newValue, ezVariant index /*= ezVariant()*/)
+  const ezDocumentObject* pObject, ezStringView sProp, const ezVariant& newValue, ezVariant index /*= ezVariant()*/)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return SetValue(pObject, pProp, newValue, index);
 }
 
 
 ezStatus ezObjectAccessorBase::InsertValue(
-  const ezDocumentObject* pObject, const char* szProp, const ezVariant& newValue, ezVariant index /*= ezVariant()*/)
+  const ezDocumentObject* pObject, ezStringView sProp, const ezVariant& newValue, ezVariant index /*= ezVariant()*/)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return InsertValue(pObject, pProp, newValue, index);
 }
 
 
-ezStatus ezObjectAccessorBase::RemoveValue(const ezDocumentObject* pObject, const char* szProp, ezVariant index /*= ezVariant()*/)
+ezStatus ezObjectAccessorBase::RemoveValue(const ezDocumentObject* pObject, ezStringView sProp, ezVariant index /*= ezVariant()*/)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return RemoveValue(pObject, pProp, index);
 }
 
 
-ezStatus ezObjectAccessorBase::MoveValue(const ezDocumentObject* pObject, const char* szProp, const ezVariant& oldIndex, const ezVariant& newIndex)
+ezStatus ezObjectAccessorBase::MoveValue(const ezDocumentObject* pObject, ezStringView sProp, const ezVariant& oldIndex, const ezVariant& newIndex)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return MoveValue(pObject, pProp, oldIndex, newIndex);
 }
 
 
-ezStatus ezObjectAccessorBase::GetCount(const ezDocumentObject* pObject, const char* szProp, ezInt32& out_iCount)
+ezStatus ezObjectAccessorBase::GetCount(const ezDocumentObject* pObject, ezStringView sProp, ezInt32& out_iCount)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return GetCount(pObject, pProp, out_iCount);
 }
 
 
 ezStatus ezObjectAccessorBase::AddObject(
-  const ezDocumentObject* pParent, const char* szParentProp, const ezVariant& index, const ezRTTI* pType, ezUuid& inout_objectGuid)
+  const ezDocumentObject* pParent, ezStringView sParentProp, const ezVariant& index, const ezRTTI* pType, ezUuid& inout_objectGuid)
 {
-  const ezAbstractProperty* pProp = pParent->GetType()->FindPropertyByName(szParentProp);
+  const ezAbstractProperty* pProp = pParent->GetType()->FindPropertyByName(sParentProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szParentProp, pParent->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sParentProp, pParent->GetType()->GetTypeName()));
   return AddObject(pParent, pProp, index, pType, inout_objectGuid);
 }
 
 ezStatus ezObjectAccessorBase::MoveObject(
-  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProp, const ezVariant& index)
+  const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProp, const ezVariant& index)
 {
-  const ezAbstractProperty* pProp = pNewParent->GetType()->FindPropertyByName(szParentProp);
+  const ezAbstractProperty* pProp = pNewParent->GetType()->FindPropertyByName(sParentProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szParentProp, pNewParent->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sParentProp, pNewParent->GetType()->GetTypeName()));
   return MoveObject(pObject, pNewParent, pProp, index);
 }
 
 
-ezStatus ezObjectAccessorBase::GetKeys(const ezDocumentObject* pObject, const char* szProp, ezDynamicArray<ezVariant>& out_keys)
+ezStatus ezObjectAccessorBase::GetKeys(const ezDocumentObject* pObject, ezStringView sProp, ezDynamicArray<ezVariant>& out_keys)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return GetKeys(pObject, pProp, out_keys);
 }
 
 
-ezStatus ezObjectAccessorBase::GetValues(const ezDocumentObject* pObject, const char* szProp, ezDynamicArray<ezVariant>& out_values)
+ezStatus ezObjectAccessorBase::GetValues(const ezDocumentObject* pObject, ezStringView sProp, ezDynamicArray<ezVariant>& out_values)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
   return GetValues(pObject, pProp, out_values);
 }
 
-const ezDocumentObject* ezObjectAccessorBase::GetChildObject(const ezDocumentObject* pObject, const char* szProp, ezVariant index)
+const ezDocumentObject* ezObjectAccessorBase::GetChildObject(const ezDocumentObject* pObject, ezStringView sProp, ezVariant index)
 {
   ezVariant value;
-  if (GetValue(pObject, szProp, value, index).Succeeded() && value.IsA<ezUuid>())
+  if (GetValue(pObject, sProp, value, index).Succeeded() && value.IsA<ezUuid>())
   {
     return GetObject(value.Get<ezUuid>());
   }
   return nullptr;
 }
 
-ezStatus ezObjectAccessorBase::Clear(const ezDocumentObject* pObject, const char* szProp)
+ezStatus ezObjectAccessorBase::Clear(const ezDocumentObject* pObject, ezStringView sProp)
 {
-  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(szProp);
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName(sProp);
   if (!pProp)
-    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", szProp, pObject->GetType()->GetTypeName()));
+    return ezStatus(ezFmt("The property '{0}' does not exist in type '{1}'.", sProp, pObject->GetType()->GetTypeName()));
 
   ezHybridArray<ezVariant, 8> keys;
   ezStatus res = GetKeys(pObject, pProp, keys);

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase_inl.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase_inl.h
@@ -11,10 +11,10 @@ T ezObjectAccessorBase::Get(const ezDocumentObject* pObject, const ezAbstractPro
 }
 
 template <typename T>
-T ezObjectAccessorBase::Get(const ezDocumentObject* pObject, const char* szProp, ezVariant index /*= ezVariant()*/)
+T ezObjectAccessorBase::Get(const ezDocumentObject* pObject, ezStringView sProp, ezVariant index /*= ezVariant()*/)
 {
   ezVariant value;
-  ezStatus res = GetValue(pObject, szProp, value, index);
+  ezStatus res = GetValue(pObject, sProp, value, index);
   if (res.m_Result.Failed())
     ezLog::Error("GetValue failed: {0}", res.m_sMessage);
   return value.ConvertTo<T>();
@@ -29,10 +29,10 @@ inline ezInt32 ezObjectAccessorBase::GetCount(const ezDocumentObject* pObject, c
   return iCount;
 }
 
-inline ezInt32 ezObjectAccessorBase::GetCount(const ezDocumentObject* pObject, const char* szProp)
+inline ezInt32 ezObjectAccessorBase::GetCount(const ezDocumentObject* pObject, ezStringView sProp)
 {
   ezInt32 iCount = 0;
-  ezStatus res = GetCount(pObject, szProp, iCount);
+  ezStatus res = GetCount(pObject, sProp, iCount);
   if (res.m_Result.Failed())
     ezLog::Error("GetCount failed: {0}", res.m_sMessage);
   return iCount;

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectCommandAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectCommandAccessor.cpp
@@ -26,9 +26,9 @@ void ezObjectCommandAccessor::FinishTransaction()
   m_pHistory->FinishTransaction();
 }
 
-void ezObjectCommandAccessor::BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands /*= false*/)
+void ezObjectCommandAccessor::BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands /*= false*/)
 {
-  m_pHistory->BeginTemporaryCommands(szDisplayString, bFireEventsWhenUndoingTempCommands);
+  m_pHistory->BeginTemporaryCommands(sDisplayString, bFireEventsWhenUndoingTempCommands);
 }
 
 void ezObjectCommandAccessor::CancelTemporaryCommands()

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectProxyAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectProxyAccessor.cpp
@@ -25,9 +25,9 @@ void ezObjectProxyAccessor::FinishTransaction()
   m_pSource->FinishTransaction();
 }
 
-void ezObjectProxyAccessor::BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands /*= false*/)
+void ezObjectProxyAccessor::BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands /*= false*/)
 {
-  m_pSource->BeginTemporaryCommands(szDisplayString, bFireEventsWhenUndoingTempCommands);
+  m_pSource->BeginTemporaryCommands(sDisplayString, bFireEventsWhenUndoingTempCommands);
 }
 
 void ezObjectProxyAccessor::CancelTemporaryCommands()

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
@@ -16,7 +16,7 @@ public:
   virtual void StartTransaction(ezStringView sDisplayString);
   virtual void CancelTransaction();
   virtual void FinishTransaction();
-  virtual void BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands = false);
+  virtual void BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands = false);
   virtual void CancelTemporaryCommands();
   virtual void FinishTemporaryCommands();
 
@@ -49,29 +49,29 @@ public:
   /// \name Object Access Convenience Functions
   ///@{
 
-  ezStatus GetValue(const ezDocumentObject* pObject, const char* szProp, ezVariant& out_value, ezVariant index = ezVariant());
-  ezStatus SetValue(const ezDocumentObject* pObject, const char* szProp, const ezVariant& newValue, ezVariant index = ezVariant());
-  ezStatus InsertValue(const ezDocumentObject* pObject, const char* szProp, const ezVariant& newValue, ezVariant index = ezVariant());
-  ezStatus RemoveValue(const ezDocumentObject* pObject, const char* szProp, ezVariant index = ezVariant());
-  ezStatus MoveValue(const ezDocumentObject* pObject, const char* szProp, const ezVariant& oldIndex, const ezVariant& newIndex);
-  ezStatus GetCount(const ezDocumentObject* pObject, const char* szProp, ezInt32& out_iCount);
+  ezStatus GetValue(const ezDocumentObject* pObject, ezStringView sProp, ezVariant& out_value, ezVariant index = ezVariant());
+  ezStatus SetValue(const ezDocumentObject* pObject, ezStringView sProp, const ezVariant& newValue, ezVariant index = ezVariant());
+  ezStatus InsertValue(const ezDocumentObject* pObject, ezStringView sProp, const ezVariant& newValue, ezVariant index = ezVariant());
+  ezStatus RemoveValue(const ezDocumentObject* pObject, ezStringView sProp, ezVariant index = ezVariant());
+  ezStatus MoveValue(const ezDocumentObject* pObject, ezStringView sProp, const ezVariant& oldIndex, const ezVariant& newIndex);
+  ezStatus GetCount(const ezDocumentObject* pObject, ezStringView sProp, ezInt32& out_iCount);
 
   ezStatus AddObject(
-    const ezDocumentObject* pParent, const char* szParentProp, const ezVariant& index, const ezRTTI* pType, ezUuid& inout_objectGuid);
-  ezStatus MoveObject(const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, const char* szParentProp, const ezVariant& index);
+    const ezDocumentObject* pParent, ezStringView sParentProp, const ezVariant& index, const ezRTTI* pType, ezUuid& inout_objectGuid);
+  ezStatus MoveObject(const ezDocumentObject* pObject, const ezDocumentObject* pNewParent, ezStringView sParentProp, const ezVariant& index);
 
-  ezStatus GetKeys(const ezDocumentObject* pObject, const char* szProp, ezDynamicArray<ezVariant>& out_keys);
-  ezStatus GetValues(const ezDocumentObject* pObject, const char* szProp, ezDynamicArray<ezVariant>& out_values);
-  const ezDocumentObject* GetChildObject(const ezDocumentObject* pObject, const char* szProp, ezVariant index);
+  ezStatus GetKeys(const ezDocumentObject* pObject, ezStringView sProp, ezDynamicArray<ezVariant>& out_keys);
+  ezStatus GetValues(const ezDocumentObject* pObject, ezStringView sProp, ezDynamicArray<ezVariant>& out_values);
+  const ezDocumentObject* GetChildObject(const ezDocumentObject* pObject, ezStringView sProp, ezVariant index);
 
-  ezStatus Clear(const ezDocumentObject* pObject, const char* szProp);
+  ezStatus Clear(const ezDocumentObject* pObject, ezStringView sProp);
 
   template <typename T>
   T Get(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant());
   template <typename T>
-  T Get(const ezDocumentObject* pObject, const char* szProp, ezVariant index = ezVariant());
+  T Get(const ezDocumentObject* pObject, ezStringView sProp, ezVariant index = ezVariant());
   ezInt32 GetCount(const ezDocumentObject* pObject, const ezAbstractProperty* pProp);
-  ezInt32 GetCount(const ezDocumentObject* pObject, const char* szProp);
+  ezInt32 GetCount(const ezDocumentObject* pObject, ezStringView sProp);
 
   ///@}
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectCommandAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectCommandAccessor.h
@@ -13,7 +13,7 @@ public:
   virtual void StartTransaction(ezStringView sDisplayString) override;
   virtual void CancelTransaction() override;
   virtual void FinishTransaction() override;
-  virtual void BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands = false) override;
+  virtual void BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands = false) override;
   virtual void CancelTemporaryCommands() override;
   virtual void FinishTemporaryCommands() override;
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
@@ -16,7 +16,7 @@ public:
   virtual void StartTransaction(ezStringView sDisplayString) override;
   virtual void CancelTransaction() override;
   virtual void FinishTransaction() override;
-  virtual void BeginTemporaryCommands(const char* szDisplayString, bool bFireEventsWhenUndoingTempCommands = false) override;
+  virtual void BeginTemporaryCommands(ezStringView sDisplayString, bool bFireEventsWhenUndoingTempCommands = false) override;
   virtual void CancelTemporaryCommands() override;
   virtual void FinishTemporaryCommands() override;
 

--- a/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.cpp
@@ -17,12 +17,12 @@ ezToolsProjectRequest::ezToolsProjectRequest()
   m_iContainerWindowUniqueIdentifier = 0;
 }
 
-ezToolsProject::ezToolsProject(const char* szProjectPath)
+ezToolsProject::ezToolsProject(ezStringView sProjectPath)
   : m_SingletonRegistrar(this)
 {
   m_bIsClosing = false;
 
-  m_sProjectPath = szProjectPath;
+  m_sProjectPath = sProjectPath;
   EZ_ASSERT_DEV(!m_sProjectPath.IsEmpty(), "Path cannot be empty.");
 }
 
@@ -38,9 +38,9 @@ ezStatus ezToolsProject::Create()
     }
     else
     {
-      const char* szToken = "ezEditor Project File";
+      ezStringView szToken = "ezEditor Project File";
 
-      EZ_SUCCEED_OR_RETURN(ProjectFile.Write(szToken, ezStringUtils::GetStringElementCount(szToken) + 1));
+      EZ_SUCCEED_OR_RETURN(ProjectFile.Write(szToken.GetStartPointer(), szToken.GetElementCount() + 1));
       ProjectFile.Close();
     }
   }
@@ -71,13 +71,13 @@ ezStatus ezToolsProject::Open()
   return ezStatus(EZ_SUCCESS);
 }
 
-void ezToolsProject::CreateSubFolder(const char* szFolder) const
+void ezToolsProject::CreateSubFolder(ezStringView sFolder) const
 {
   ezStringBuilder sPath;
 
   sPath = m_sProjectPath;
   sPath.PathParentDirectory();
-  sPath.AppendPath(szFolder);
+  sPath.AppendPath(sFolder);
 
   ezOSFile::CreateDirectoryStructure(sPath).IgnoreResult();
 }
@@ -165,11 +165,11 @@ ezStringBuilder ezToolsProject::GetPathForDocumentGuid(const ezUuid& guid)
   return e.m_sAbsDocumentPath;
 }
 
-ezStatus ezToolsProject::CreateOrOpenProject(const char* szProjectPath, bool bCreate)
+ezStatus ezToolsProject::CreateOrOpenProject(ezStringView sProjectPath, bool bCreate)
 {
   CloseProject();
 
-  new ezToolsProject(szProjectPath);
+  new ezToolsProject(sProjectPath);
 
   ezStatus ret;
 
@@ -190,16 +190,16 @@ ezStatus ezToolsProject::CreateOrOpenProject(const char* szProjectPath, bool bCr
   return ezStatus(EZ_SUCCESS);
 }
 
-ezStatus ezToolsProject::OpenProject(const char* szProjectPath)
+ezStatus ezToolsProject::OpenProject(ezStringView sProjectPath)
 {
-  ezStatus status = CreateOrOpenProject(szProjectPath, false);
+  ezStatus status = CreateOrOpenProject(sProjectPath, false);
 
   return status;
 }
 
-ezStatus ezToolsProject::CreateProject(const char* szProjectPath)
+ezStatus ezToolsProject::CreateProject(ezStringView sProjectPath)
 {
-  return CreateOrOpenProject(szProjectPath, true);
+  return CreateOrOpenProject(sProjectPath, true);
 }
 
 void ezToolsProject::BroadcastSaveAll()
@@ -220,9 +220,9 @@ void ezToolsProject::BroadcastConfigChanged()
   s_Events.Broadcast(e);
 }
 
-void ezToolsProject::AddAllowedDocumentRoot(const char* szPath)
+void ezToolsProject::AddAllowedDocumentRoot(ezStringView sPath)
 {
-  ezStringBuilder s = szPath;
+  ezStringBuilder s = sPath;
   s.MakeCleanPath();
   s.Trim("", "/");
 
@@ -230,19 +230,19 @@ void ezToolsProject::AddAllowedDocumentRoot(const char* szPath)
 }
 
 
-bool ezToolsProject::IsDocumentInAllowedRoot(const char* szDocumentPath, ezString* out_pRelativePath) const
+bool ezToolsProject::IsDocumentInAllowedRoot(ezStringView sDocumentPath, ezString* out_pRelativePath) const
 {
   for (ezUInt32 i = m_AllowedDocumentRoots.GetCount(); i > 0; --i)
   {
     const auto& root = m_AllowedDocumentRoots[i - 1];
 
-    ezStringBuilder s = szDocumentPath;
+    ezStringBuilder s = sDocumentPath;
     if (!s.IsPathBelowFolder(root))
       continue;
 
     if (out_pRelativePath)
     {
-      ezStringBuilder sText = szDocumentPath;
+      ezStringBuilder sText = sDocumentPath;
       sText.MakeRelativeTo(root).IgnoreResult();
 
       *out_pRelativePath = sText;
@@ -326,9 +326,9 @@ ezString ezToolsProject::GetProjectDataFolder() const
   return s;
 }
 
-ezString ezToolsProject::FindProjectDirectoryForDocument(const char* szDocumentPath)
+ezString ezToolsProject::FindProjectDirectoryForDocument(ezStringView sDocumentPath)
 {
-  ezStringBuilder sPath = szDocumentPath;
+  ezStringBuilder sPath = sDocumentPath;
   sPath.PathParentDirectory();
 
   ezStringBuilder sTemp;

--- a/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.h
+++ b/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.h
@@ -72,8 +72,8 @@ public:
   static ezInt32 SuggestContainerWindow(ezDocument* pDoc);
   /// \brief Resolve document GUID into an absolute path.
   ezStringBuilder GetPathForDocumentGuid(const ezUuid& guid);
-  static ezStatus OpenProject(const char* szProjectPath);
-  static ezStatus CreateProject(const char* szProjectPath);
+  static ezStatus OpenProject(ezStringView sProjectPath);
+  static ezStatus CreateProject(ezStringView sProjectPath);
 
   /// \brief Broadcasts the SaveAll event, though otherwise has no direct effect.
   static void BroadcastSaveAll();
@@ -97,20 +97,20 @@ public:
   ezString GetProjectDataFolder() const;
 
   /// \brief Starts at the  given document and then searches the tree upwards until it finds an ezProject file.
-  static ezString FindProjectDirectoryForDocument(const char* szDocumentPath);
+  static ezString FindProjectDirectoryForDocument(ezStringView sDocumentPath);
 
-  bool IsDocumentInAllowedRoot(const char* szDocumentPath, ezString* out_pRelativePath = nullptr) const;
+  bool IsDocumentInAllowedRoot(ezStringView sDocumentPath, ezString* out_pRelativePath = nullptr) const;
 
-  void AddAllowedDocumentRoot(const char* szPath);
+  void AddAllowedDocumentRoot(ezStringView sPath);
 
   /// \brief Makes sure the given sub-folder exists inside the project directory
-  void CreateSubFolder(const char* szFolder) const;
+  void CreateSubFolder(ezStringView sFolder) const;
 
 private:
-  static ezStatus CreateOrOpenProject(const char* szProjectPath, bool bCreate);
+  static ezStatus CreateOrOpenProject(ezStringView sProjectPath, bool bCreate);
 
 private:
-  ezToolsProject(const char* szProjectPath);
+  ezToolsProject(ezStringView sProjectPath);
   ~ezToolsProject();
 
   ezStatus Create();

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/IReflectedTypeAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/IReflectedTypeAccessor.h
@@ -25,23 +25,23 @@ public:
   const ezRTTI* GetType() const { return m_pRtti; } // [tested]
 
   /// \brief Returns the value of the property defined by its path. Return value is invalid iff the path was invalid.
-  virtual const ezVariant GetValue(const char* szProperty, ezVariant index = ezVariant(), ezStatus* pRes = nullptr) const = 0;
+  virtual const ezVariant GetValue(ezStringView sProperty, ezVariant index = ezVariant(), ezStatus* pRes = nullptr) const = 0;
 
   /// \brief Sets a property defined by its path to the given value. Returns whether the operation was successful.
-  virtual bool SetValue(const char* szProperty, const ezVariant& value, ezVariant index = ezVariant()) = 0;
+  virtual bool SetValue(ezStringView sProperty, const ezVariant& value, ezVariant index = ezVariant()) = 0;
 
-  virtual ezInt32 GetCount(const char* szProperty) const = 0;
-  virtual bool GetKeys(const char* szProperty, ezDynamicArray<ezVariant>& out_keys) const = 0;
+  virtual ezInt32 GetCount(ezStringView sProperty) const = 0;
+  virtual bool GetKeys(ezStringView sProperty, ezDynamicArray<ezVariant>& out_keys) const = 0;
 
-  virtual bool InsertValue(const char* szProperty, ezVariant index, const ezVariant& value) = 0;
-  virtual bool RemoveValue(const char* szProperty, ezVariant index) = 0;
-  virtual bool MoveValue(const char* szProperty, ezVariant oldIndex, ezVariant newIndex) = 0;
+  virtual bool InsertValue(ezStringView sProperty, ezVariant index, const ezVariant& value) = 0;
+  virtual bool RemoveValue(ezStringView sProperty, ezVariant index) = 0;
+  virtual bool MoveValue(ezStringView sProperty, ezVariant oldIndex, ezVariant newIndex) = 0;
 
-  virtual ezVariant GetPropertyChildIndex(const char* szProperty, const ezVariant& value) const = 0;
+  virtual ezVariant GetPropertyChildIndex(ezStringView sProperty, const ezVariant& value) const = 0;
 
   const ezDocumentObject* GetOwner() const { return m_pOwner; }
 
-  bool GetValues(const char* szProperty, ezDynamicArray<ezVariant>& out_values) const;
+  bool GetValues(ezStringView sProperty, ezDynamicArray<ezVariant>& out_values) const;
 
 
 private:

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/IReflectedTypeAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/IReflectedTypeAccessor.cpp
@@ -2,17 +2,17 @@
 
 #include <ToolsFoundation/Reflection/IReflectedTypeAccessor.h>
 
-bool ezIReflectedTypeAccessor::GetValues(const char* szProperty, ezDynamicArray<ezVariant>& out_values) const
+bool ezIReflectedTypeAccessor::GetValues(ezStringView sProperty, ezDynamicArray<ezVariant>& out_values) const
 {
   ezHybridArray<ezVariant, 16> keys;
-  if (!GetKeys(szProperty, keys))
+  if (!GetKeys(sProperty, keys))
     return false;
 
   out_values.Clear();
   out_values.Reserve(keys.GetCount());
   for (ezVariant key : keys)
   {
-    out_values.PushBack(GetValue(szProperty, key));
+    out_values.PushBack(GetValue(sProperty, key));
   }
   return true;
 }

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
@@ -4,14 +4,14 @@
 #include <ToolsFoundation/Reflection/PhantomProperty.h>
 #include <ToolsFoundation/Reflection/PhantomRtti.h>
 
-ezPhantomRTTI::ezPhantomRTTI(const char* szName, const ezRTTI* pParentType, ezUInt32 uiTypeSize, ezUInt32 uiTypeVersion, ezUInt8 uiVariantType,
-  ezBitflags<ezTypeFlags> flags, const char* szPluginName)
+ezPhantomRTTI::ezPhantomRTTI(ezStringView sName, const ezRTTI* pParentType, ezUInt32 uiTypeSize, ezUInt32 uiTypeVersion, ezUInt8 uiVariantType,
+  ezBitflags<ezTypeFlags> flags, ezStringView sPluginName)
   : ezRTTI(nullptr, pParentType, uiTypeSize, uiTypeVersion, uiVariantType, flags | ezTypeFlags::Phantom, nullptr, ezArrayPtr<const ezAbstractProperty*>(),
       ezArrayPtr<const ezAbstractFunctionProperty*>(), ezArrayPtr<const ezPropertyAttribute*>(), ezArrayPtr<ezAbstractMessageHandler*>(),
       ezArrayPtr<ezMessageSenderInfo>(), nullptr)
 {
-  m_sTypeNameStorage = szName;
-  m_sPluginNameStorage = szPluginName;
+  m_sTypeNameStorage = sName;
+  m_sPluginNameStorage = sPluginName;
 
   m_sTypeName = m_sTypeNameStorage.GetData();
   m_sPluginName = m_sPluginNameStorage.GetData();

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageAccessor.cpp
@@ -37,20 +37,20 @@ ezReflectedTypeStorageAccessor::~ezReflectedTypeStorageAccessor()
   ezReflectedTypeStorageManager::RemoveStorageAccessor(this);
 }
 
-const ezVariant ezReflectedTypeStorageAccessor::GetValue(const char* szProperty, ezVariant index, ezStatus* pRes) const
+const ezVariant ezReflectedTypeStorageAccessor::GetValue(ezStringView sProperty, ezVariant index, ezStatus* pRes) const
 {
-  const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+  const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
   if (pProp == nullptr)
   {
     if (pRes)
-      *pRes = ezStatus(ezFmt("Property '{0}' not found in type '{1}'", szProperty, GetType()->GetTypeName()));
+      *pRes = ezStatus(ezFmt("Property '{0}' not found in type '{1}'", sProperty, GetType()->GetTypeName()));
     return ezVariant();
   }
 
   if (pRes)
     *pRes = ezStatus(EZ_SUCCESS);
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     switch (pProp->GetCategory())
     {
@@ -74,7 +74,7 @@ const ezVariant ezReflectedTypeStorageAccessor::GetValue(const char* szProperty,
           }
         }
         if (pRes)
-          *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid or out of bounds.", index, szProperty));
+          *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid or out of bounds.", index, sProperty));
       }
       break;
       case ezPropertyCategory::Map:
@@ -94,7 +94,7 @@ const ezVariant ezReflectedTypeStorageAccessor::GetValue(const char* szProperty,
           }
         }
         if (pRes)
-          *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid or out of bounds.", index, szProperty));
+          *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid or out of bounds.", index, sProperty));
       }
       break;
       default:
@@ -104,12 +104,12 @@ const ezVariant ezReflectedTypeStorageAccessor::GetValue(const char* szProperty,
   return ezVariant();
 }
 
-bool ezReflectedTypeStorageAccessor::SetValue(const char* szProperty, const ezVariant& value, ezVariant index)
+bool ezReflectedTypeStorageAccessor::SetValue(ezStringView sProperty, const ezVariant& value, ezVariant index)
 {
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return false;
     EZ_ASSERT_DEV(pProp->GetSpecificType() == ezGetStaticRTTI<ezVariant>() || value.IsValid(), "");
@@ -218,15 +218,15 @@ bool ezReflectedTypeStorageAccessor::SetValue(const char* szProperty, const ezVa
   return false;
 }
 
-ezInt32 ezReflectedTypeStorageAccessor::GetCount(const char* szProperty) const
+ezInt32 ezReflectedTypeStorageAccessor::GetCount(ezStringView sProperty) const
 {
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     if (storageInfo->m_Type == ezVariant::Type::Invalid)
       return -1;
 
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return -1;
 
@@ -250,17 +250,17 @@ ezInt32 ezReflectedTypeStorageAccessor::GetCount(const char* szProperty) const
   return -1;
 }
 
-bool ezReflectedTypeStorageAccessor::GetKeys(const char* szProperty, ezDynamicArray<ezVariant>& out_keys) const
+bool ezReflectedTypeStorageAccessor::GetKeys(ezStringView sProperty, ezDynamicArray<ezVariant>& out_keys) const
 {
   out_keys.Clear();
 
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     if (storageInfo->m_Type == ezVariant::Type::Invalid)
       return false;
 
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return false;
 
@@ -296,15 +296,15 @@ bool ezReflectedTypeStorageAccessor::GetKeys(const char* szProperty, ezDynamicAr
   }
   return false;
 }
-bool ezReflectedTypeStorageAccessor::InsertValue(const char* szProperty, ezVariant index, const ezVariant& value)
+bool ezReflectedTypeStorageAccessor::InsertValue(ezStringView sProperty, ezVariant index, const ezVariant& value)
 {
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     if (storageInfo->m_Type == ezVariant::Type::Invalid)
       return false;
 
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return false;
 
@@ -378,15 +378,15 @@ bool ezReflectedTypeStorageAccessor::InsertValue(const char* szProperty, ezVaria
   return false;
 }
 
-bool ezReflectedTypeStorageAccessor::RemoveValue(const char* szProperty, ezVariant index)
+bool ezReflectedTypeStorageAccessor::RemoveValue(ezStringView sProperty, ezVariant index)
 {
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     if (storageInfo->m_Type == ezVariant::Type::Invalid)
       return false;
 
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return false;
 
@@ -429,15 +429,15 @@ bool ezReflectedTypeStorageAccessor::RemoveValue(const char* szProperty, ezVaria
   return false;
 }
 
-bool ezReflectedTypeStorageAccessor::MoveValue(const char* szProperty, ezVariant oldIndex, ezVariant newIndex)
+bool ezReflectedTypeStorageAccessor::MoveValue(ezStringView sProperty, ezVariant oldIndex, ezVariant newIndex)
 {
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     if (storageInfo->m_Type == ezVariant::Type::Invalid)
       return false;
 
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return false;
 
@@ -488,15 +488,15 @@ bool ezReflectedTypeStorageAccessor::MoveValue(const char* szProperty, ezVariant
   return false;
 }
 
-ezVariant ezReflectedTypeStorageAccessor::GetPropertyChildIndex(const char* szProperty, const ezVariant& value) const
+ezVariant ezReflectedTypeStorageAccessor::GetPropertyChildIndex(ezStringView sProperty, const ezVariant& value) const
 {
   const ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::StorageInfo* storageInfo = nullptr;
-  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(szProperty, storageInfo))
+  if (m_pMapping->m_PathToStorageInfoTable.TryGetValue(sProperty, storageInfo))
   {
     if (storageInfo->m_Type == ezVariant::Type::Invalid)
       return ezVariant();
 
-    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(szProperty);
+    const ezAbstractProperty* pProp = GetType()->FindPropertyByName(sProperty);
     if (pProp == nullptr)
       return ezVariant();
 

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/PhantomRtti.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/PhantomRtti.h
@@ -11,8 +11,8 @@ public:
   ~ezPhantomRTTI();
 
 private:
-  ezPhantomRTTI(const char* szName, const ezRTTI* pParentType, ezUInt32 uiTypeSize, ezUInt32 uiTypeVersion, ezUInt8 uiVariantType,
-    ezBitflags<ezTypeFlags> flags, const char* szPluginName);
+  ezPhantomRTTI(ezStringView sName, const ezRTTI* pParentType, ezUInt32 uiTypeSize, ezUInt32 uiTypeVersion, ezUInt8 uiVariantType,
+    ezBitflags<ezTypeFlags> flags, ezStringView sPluginName);
 
   void SetProperties(ezDynamicArray<ezReflectedPropertyDescriptor>& properties);
   void SetFunctions(ezDynamicArray<ezReflectedFunctionDescriptor>& functions);

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageAccessor.h
@@ -17,17 +17,17 @@ public:
   ezReflectedTypeStorageAccessor(const ezRTTI* pReflectedType, ezDocumentObject* pOwner); // [tested]
   ~ezReflectedTypeStorageAccessor();
 
-  virtual const ezVariant GetValue(const char* szProperty, ezVariant index = ezVariant(), ezStatus* pRes = nullptr) const override; // [tested]
-  virtual bool SetValue(const char* szProperty, const ezVariant& value, ezVariant index = ezVariant()) override;                   // [tested]
+  virtual const ezVariant GetValue(ezStringView sProperty, ezVariant index = ezVariant(), ezStatus* pRes = nullptr) const override; // [tested]
+  virtual bool SetValue(ezStringView sProperty, const ezVariant& value, ezVariant index = ezVariant()) override;                   // [tested]
 
-  virtual ezInt32 GetCount(const char* szProperty) const override;
-  virtual bool GetKeys(const char* szProperty, ezDynamicArray<ezVariant>& out_keys) const override;
+  virtual ezInt32 GetCount(ezStringView sProperty) const override;
+  virtual bool GetKeys(ezStringView sProperty, ezDynamicArray<ezVariant>& out_keys) const override;
 
-  virtual bool InsertValue(const char* szProperty, ezVariant index, const ezVariant& value) override;
-  virtual bool RemoveValue(const char* szProperty, ezVariant index) override;
-  virtual bool MoveValue(const char* szProperty, ezVariant oldIndex, ezVariant newIndex) override;
+  virtual bool InsertValue(ezStringView sProperty, ezVariant index, const ezVariant& value) override;
+  virtual bool RemoveValue(ezStringView sProperty, ezVariant index) override;
+  virtual bool MoveValue(ezStringView sProperty, ezVariant oldIndex, ezVariant newIndex) override;
 
-  virtual ezVariant GetPropertyChildIndex(const char* szProperty, const ezVariant& value) const override;
+  virtual ezVariant GetPropertyChildIndex(ezStringView sProperty, const ezVariant& value) const override;
 
 private:
   ezDynamicArray<ezVariant> m_Data;

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageAccessor.h
@@ -18,7 +18,7 @@ public:
   ~ezReflectedTypeStorageAccessor();
 
   virtual const ezVariant GetValue(ezStringView sProperty, ezVariant index = ezVariant(), ezStatus* pRes = nullptr) const override; // [tested]
-  virtual bool SetValue(ezStringView sProperty, const ezVariant& value, ezVariant index = ezVariant()) override;                   // [tested]
+  virtual bool SetValue(ezStringView sProperty, const ezVariant& value, ezVariant index = ezVariant()) override;                    // [tested]
 
   virtual ezInt32 GetCount(ezStringView sProperty) const override;
   virtual bool GetKeys(ezStringView sProperty, ezDynamicArray<ezVariant>& out_keys) const override;

--- a/Code/Tools/Libs/ToolsFoundation/Serialization/DocumentObjectConverter.h
+++ b/Code/Tools/Libs/ToolsFoundation/Serialization/DocumentObjectConverter.h
@@ -20,13 +20,13 @@ public:
     m_Filter = filter;
   }
 
-  ezAbstractObjectNode* AddObjectToGraph(const ezDocumentObject* pObject, const char* szNodeName = nullptr);
+  ezAbstractObjectNode* AddObjectToGraph(const ezDocumentObject* pObject, ezStringView sNodeName = nullptr);
 
 private:
   void AddProperty(ezAbstractObjectNode* pNode, const ezAbstractProperty* pProp, const ezDocumentObject* pObject);
   void AddProperties(ezAbstractObjectNode* pNode, const ezDocumentObject* pObject);
 
-  ezAbstractObjectNode* AddSubObjectToGraph(const ezDocumentObject* pObject, const char* szNodeName);
+  ezAbstractObjectNode* AddSubObjectToGraph(const ezDocumentObject* pObject, ezStringView sNodeName);
 
   const ezDocumentObjectManager* m_pManager;
   ezAbstractObjectGraph* m_pGraph;
@@ -54,7 +54,7 @@ public:
   static void ApplyDiffToObject(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pObject, ezDeque<ezAbstractGraphDiffOperation>& ref_diff);
 
 private:
-  void AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, const char* szParentProperty, ezVariant index);
+  void AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, ezStringView sParentProperty, ezVariant index);
   void ApplyProperty(ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezAbstractObjectNode::Property* pSource);
   static void ApplyDiff(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp,
     ezAbstractGraphDiffOperation& op, ezDeque<ezAbstractGraphDiffOperation>& diff);

--- a/Code/Tools/Libs/ToolsFoundation/Serialization/Implementation/DocumentObjectConverter.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Serialization/Implementation/DocumentObjectConverter.cpp
@@ -6,9 +6,9 @@
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 #include <ToolsFoundation/Serialization/DocumentObjectConverter.h>
 
-ezAbstractObjectNode* ezDocumentObjectConverterWriter::AddObjectToGraph(const ezDocumentObject* pObject, const char* szNodeName)
+ezAbstractObjectNode* ezDocumentObjectConverterWriter::AddObjectToGraph(const ezDocumentObject* pObject, ezStringView sNodeName)
 {
-  ezAbstractObjectNode* pNode = AddSubObjectToGraph(pObject, szNodeName);
+  ezAbstractObjectNode* pNode = AddSubObjectToGraph(pObject, sNodeName);
 
   while (!m_QueuedObjects.IsEmpty())
   {
@@ -135,9 +135,9 @@ void ezDocumentObjectConverterWriter::AddProperties(ezAbstractObjectNode* pNode,
   }
 }
 
-ezAbstractObjectNode* ezDocumentObjectConverterWriter::AddSubObjectToGraph(const ezDocumentObject* pObject, const char* szNodeName)
+ezAbstractObjectNode* ezDocumentObjectConverterWriter::AddSubObjectToGraph(const ezDocumentObject* pObject, ezStringView sNodeName)
 {
-  ezAbstractObjectNode* pNode = m_pGraph->AddNode(pObject->GetGuid(), pObject->GetType()->GetTypeName(), pObject->GetType()->GetTypeVersion(), szNodeName);
+  ezAbstractObjectNode* pNode = m_pGraph->AddNode(pObject->GetGuid(), pObject->GetType()->GetTypeName(), pObject->GetType()->GetTypeVersion(), sNodeName);
   AddProperties(pNode, pObject);
   return pNode;
 }
@@ -170,16 +170,16 @@ ezDocumentObject* ezDocumentObjectConverterReader::CreateObjectFromNode(const ez
   return pObject;
 }
 
-void ezDocumentObjectConverterReader::AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, const char* szParentProperty, ezVariant index)
+void ezDocumentObjectConverterReader::AddObject(ezDocumentObject* pObject, ezDocumentObject* pParent, ezStringView sParentProperty, ezVariant index)
 {
   EZ_ASSERT_DEV(pObject && pParent, "Need to have valid objects to add them to the document");
   if (m_Mode == ezDocumentObjectConverterReader::Mode::CreateAndAddToDocument && pParent->GetDocumentObjectManager()->GetObject(pParent->GetGuid()))
   {
-    m_pManager->AddObject(pObject, pParent, szParentProperty, index);
+    m_pManager->AddObject(pObject, pParent, sParentProperty, index);
   }
   else
   {
-    pParent->InsertSubObject(pObject, szParentProperty, index);
+    pParent->InsertSubObject(pObject, sParentProperty, index);
   }
 }
 

--- a/Code/Tools/Libs/ToolsFoundation/Settings/ToolsTagRegistry.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Settings/ToolsTagRegistry.cpp
@@ -127,9 +127,9 @@ bool ezToolsTagRegistry::AddTag(const ezToolsTag& tag)
   }
 }
 
-bool ezToolsTagRegistry::RemoveTag(const char* szName)
+bool ezToolsTagRegistry::RemoveTag(ezStringView sName)
 {
-  auto it = s_NameToTags.Find(szName);
+  auto it = s_NameToTags.Find(sName);
   if (it.IsValid())
   {
     s_NameToTags.Remove(it);

--- a/Code/Tools/Libs/ToolsFoundation/Settings/ToolsTagRegistry.h
+++ b/Code/Tools/Libs/ToolsFoundation/Settings/ToolsTagRegistry.h
@@ -8,9 +8,9 @@
 struct EZ_TOOLSFOUNDATION_DLL ezToolsTag
 {
   ezToolsTag() = default;
-  ezToolsTag(const char* szCategory, const char* szName, bool bBuiltIn = false)
-    : m_sCategory(szCategory)
-    , m_sName(szName)
+  ezToolsTag(ezStringView sCategory, ezStringView sName, bool bBuiltIn = false)
+    : m_sCategory(sCategory)
+    , m_sName(sName)
     , m_bBuiltInTag(bBuiltIn)
   {
   }
@@ -30,7 +30,7 @@ public:
   static ezStatus ReadFromDDL(ezStreamReader& inout_stream);
 
   static bool AddTag(const ezToolsTag& tag);
-  static bool RemoveTag(const char* szName);
+  static bool RemoveTag(ezStringView sName);
 
   static void GetAllTags(ezHybridArray<const ezToolsTag*, 16>& out_tags);
   static void GetTagsByCategory(const ezArrayPtr<ezStringView>& categories, ezHybridArray<const ezToolsTag*, 16>& out_tags);

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/PathPatternFilter.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/PathPatternFilter.cpp
@@ -83,7 +83,7 @@ void ezPathPatternFilter::AddFilter(ezStringView sText, bool bIncludeFilter)
     m_ExcludePatterns.ExpandAndGetRef().Configure(text);
 }
 
-ezResult ezPathPatternFilter::ReadConfigFile(const char* szFile, const ezDynamicArray<ezString>& preprocessorDefines)
+ezResult ezPathPatternFilter::ReadConfigFile(ezStringView sFile, const ezDynamicArray<ezString>& preprocessorDefines)
 {
   ezStringBuilder content;
 
@@ -98,7 +98,7 @@ ezResult ezPathPatternFilter::ReadConfigFile(const char* szFile, const ezDynamic
 
   // keep comments, because * and / can form a multi-line comment, and then we could lose vital information
   // instead only allow single-line comments and filter those out in AddFilter().
-  if (pp.Process(szFile, content, true, true).Failed())
+  if (pp.Process(sFile, content, true, true).Failed())
     return EZ_FAILURE;
 
   ezDynamicArray<ezStringView> lines;

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/RecentFilesList.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/RecentFilesList.cpp
@@ -8,9 +8,9 @@
 #include <Foundation/Utilities/ConversionUtils.h>
 #include <ToolsFoundation/Utilities/RecentFilesList.h>
 
-void ezRecentFilesList::Insert(const char* szFile, ezInt32 iContainerWindow)
+void ezRecentFilesList::Insert(ezStringView sFile, ezInt32 iContainerWindow)
 {
-  ezStringBuilder sCleanPath = szFile;
+  ezStringBuilder sCleanPath = sFile;
   sCleanPath.MakeCleanPath();
 
   ezString s = sCleanPath;
@@ -29,13 +29,13 @@ void ezRecentFilesList::Insert(const char* szFile, ezInt32 iContainerWindow)
     m_Files.SetCount(m_uiMaxElements);
 }
 
-void ezRecentFilesList::Save(const char* szFile)
+void ezRecentFilesList::Save(ezStringView sFile)
 {
   if (m_Files.IsEmpty())
     return;
 
   ezDeferredFileWriter File;
-  File.SetOutput(szFile);
+  File.SetOutput(sFile);
 
   for (const RecentFile& file : m_Files)
   {
@@ -46,15 +46,15 @@ void ezRecentFilesList::Save(const char* szFile)
   }
 
   if (File.Close().Failed())
-    ezLog::Error("Unable to open file '{0}' for writing!", szFile);
+    ezLog::Error("Unable to open file '{0}' for writing!", sFile);
 }
 
-void ezRecentFilesList::Load(const char* szFile)
+void ezRecentFilesList::Load(ezStringView sFile)
 {
   m_Files.Clear();
 
   ezFileReader File;
-  if (File.Open(szFile).Failed())
+  if (File.Open(sFile).Failed())
     return;
 
   ezStringBuilder sAllLines;

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/PathPatternFilter.h
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/PathPatternFilter.h
@@ -43,7 +43,7 @@ struct EZ_TOOLSFOUNDATION_DLL ezPathPatternFilter
   /// After preprocessing, every line represents a single pattern.
   /// Lines that contain '[INCLUDE]' or '[EXCLUDE]' are special and change whether the
   /// following lines are considered as include patterns or exclude patterns.
-  ezResult ReadConfigFile(const char* szFile, const ezDynamicArray<ezString>& preprocessorDefines);
+  ezResult ReadConfigFile(ezStringView sFile, const ezDynamicArray<ezString>& preprocessorDefines);
 
   /// \brief Adds a pattern.
   void AddFilter(ezStringView sText, bool bIncludeFilter);

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/RecentFilesList.h
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/RecentFilesList.h
@@ -25,7 +25,7 @@ public:
     ezInt32 m_iContainerWindow;
   };
   /// \brief Moves the inserted file to the front with the given container ID.
-  void Insert(const char* szFile, ezInt32 iContainerWindow);
+  void Insert(ezStringView sFile, ezInt32 iContainerWindow);
 
   /// \brief Returns all files in the list.
   const ezDeque<RecentFile>& GetFileList() const { return m_Files; }
@@ -34,10 +34,10 @@ public:
   void Clear() { m_Files.Clear(); }
 
   /// \brief Saves the recent files list to the given file. Uses a simple text file format (one line per item).
-  void Save(const char* szFile);
+  void Save(ezStringView sFile);
 
   /// \brief Loads the recent files list from the given file. Uses a simple text file format (one line per item).
-  void Load(const char* szFile);
+  void Load(ezStringView sFile);
 
 private:
   ezUInt32 m_uiMaxElements;

--- a/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.cpp
@@ -8,8 +8,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezTestDocumentObjectManager::ezTestDocumentObjectManager() = default;
 ezTestDocumentObjectManager::~ezTestDocumentObjectManager() = default;
 
-ezTestDocument::ezTestDocument(const char* szDocumentPath, bool bUseIPCObjectMirror /*= false*/)
-  : ezDocument(szDocumentPath, EZ_DEFAULT_NEW(ezTestDocumentObjectManager))
+ezTestDocument::ezTestDocument(ezStringView sDocumentPath, bool bUseIPCObjectMirror /*= false*/)
+  : ezDocument(sDocumentPath, EZ_DEFAULT_NEW(ezTestDocumentObjectManager))
   , m_bUseIPCObjectMirror(bUseIPCObjectMirror)
 {
 }

--- a/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.h
+++ b/Code/UnitTests/ToolsFoundationTest/Object/TestObjectManager.h
@@ -21,7 +21,7 @@ class ezTestDocument : public ezDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezTestDocument, ezDocument);
 
 public:
-  ezTestDocument(const char* szDocumentPath, bool bUseIPCObjectMirror = false);
+  ezTestDocument(ezStringView sDocumentPath, bool bUseIPCObjectMirror = false);
   ~ezTestDocument();
 
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;


### PR DESCRIPTION
* Added `ezMakeQString` to easily convert an ezStringView into a QString
* Fixed OpenXR compile issues.