### PR TITLE
Fixed #1081: Auto transform collection assets

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetManager.cpp
@@ -20,7 +20,7 @@ ezCollectionAssetDocumentManager::ezCollectionAssetDocumentManager()
   m_DocTypeDesc.m_CompatibleTypes.PushBack("CompatibleAsset_AssetCollection");
 
   m_DocTypeDesc.m_sResourceFileExtension = "ezCollection";
-  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave | ezAssetDocumentFlags::OnlyTransformManually;
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::AutoTransformOnSave;
 
   ezQtImageCache::GetSingleton()->RegisterTypeImage("Collection", QPixmap(":/AssetIcons/Collection.svg"));
 }


### PR DESCRIPTION
Since the dependency flag refactor, changes to referenced assets don't mark collections as changed anymore, so it is now save to auto transform them.