### PR TITLE
Show Files and Folders in Asset Browser

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFilter.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFilter.moc.h
@@ -12,12 +12,16 @@ public:
 
   /// Resets all filters to their default state.
   void Reset();
+  void UpdateImportExtensions(const ezSet<ezString>& extensions);
 
   void SetShowItemsInSubFolders(bool bShow);
   bool GetShowItemsInSubFolders() const { return m_bShowItemsInSubFolders; }
 
-  void SetShowFilesAndFolders(bool bShow);
-  bool GetShowFilesAndFolders() const { return m_bShowFilesAndFolders; }
+  void SetShowFiles(bool bShow);
+  bool GetShowFiles() const { return m_bShowFiles; }
+
+  void SetShowNonImportableFiles(bool bShow);
+  bool GetShowNonImportableFiles() const { return m_bShowNonImportableFiles; }
 
   void SetShowItemsInHiddenFolders(bool bShow);
   bool GetShowItemsInHiddenFolders() const { return m_bShowItemsInHiddenFolders; }
@@ -54,7 +58,8 @@ private:
   ezString m_sTemporaryPinnedItem;
   ezSearchPatternFilter m_SearchFilter;
   bool m_bShowItemsInSubFolders = true;
-  bool m_bShowFilesAndFolders = true;
+  bool m_bShowFiles = true;
+  bool m_bShowNonImportableFiles = true;
   bool m_bShowItemsInHiddenFolders = false;
   bool m_bSortByRecentUse = false;
   mutable ezStringBuilder m_sTemp; // stored here to reduce unnecessary allocations
@@ -63,4 +68,5 @@ private:
   bool m_bUsesSearchActive = false;
   bool m_bTransitive = false;
   ezSet<ezUuid> m_Uses;
+  ezSet<ezString> m_ImportExtensions;
 };

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFilter.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFilter.moc.h
@@ -16,6 +16,9 @@ public:
   void SetShowItemsInSubFolders(bool bShow);
   bool GetShowItemsInSubFolders() const { return m_bShowItemsInSubFolders; }
 
+  void SetShowFilesAndFolders(bool bShow);
+  bool GetShowFilesAndFolders() const { return m_bShowFilesAndFolders; }
+
   void SetShowItemsInHiddenFolders(bool bShow);
   bool GetShowItemsInHiddenFolders() const { return m_bShowItemsInHiddenFolders; }
 
@@ -26,10 +29,15 @@ public:
   const char* GetTextFilter() const { return m_SearchFilter.GetSearchText(); }
 
   void SetPathFilter(const char* szPath);
-  const char* GetPathFilter() const { return m_sPathFilter; }
+  ezStringView GetPathFilter() const;
 
   void SetTypeFilter(const char* szTypes);
   const char* GetTypeFilter() const { return m_sTypeFilter; }
+
+  /// \brief If set, the given item will be visible no matter what until any other filter is changed.
+  /// This is used to ensure that newly created assets are always visible, even if they are excluded from the current filter.
+  void SetTemporaryPinnedItem(ezStringView sDataDirParentRelativePath);
+  ezStringView GetTemporaryPinnedItem() const { return m_sTemporaryPinnedItem; }
 
 Q_SIGNALS:
   void TextFilterChanged();
@@ -38,13 +46,15 @@ Q_SIGNALS:
   void SortByRecentUseChanged();
 
 public:
-  virtual bool IsAssetFiltered(const ezSubAsset* pInfo) const override;
-  virtual bool Less(const ezSubAsset* pInfoA, const ezSubAsset* pInfoB) const override;
+  virtual bool IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const override;
 
 private:
-  ezString m_sTypeFilter, m_sPathFilter;
+  ezString m_sTypeFilter;
+  ezString m_sPathFilter;
+  ezString m_sTemporaryPinnedItem;
   ezSearchPatternFilter m_SearchFilter;
   bool m_bShowItemsInSubFolders = true;
+  bool m_bShowFilesAndFolders = true;
   bool m_bShowItemsInHiddenFolders = false;
   bool m_bSortByRecentUse = false;
   mutable ezStringBuilder m_sTemp; // stored here to reduce unnecessary allocations

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
@@ -17,7 +17,7 @@ public:
   /// \brief Constructor. Validator requires the current location and name of the file.
   /// \param sParentFolder Absolute path to the location of the file.
   /// \param sCurrentName Current filename. If set, this name is marked as valid, even though it is already in use.
-  ezFileNameValidator(ezStringView sParentFolder, ezStringView sCurrentName);
+  ezFileNameValidator(QObject* pParent, ezStringView sParentFolder, ezStringView sCurrentName);
   virtual QValidator::State validate(QString& ref_sInput, int& ref_iPos) const override;
 
 private:

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+#include <ToolsFoundation/Project/ToolsProject.h>
+
+#include <QItemDelegate>
+#include <QTreeWidget>
+#include <QValidator>
+
+class ezQtAssetBrowserFilter;
+
+/// \brief Basic file name validator. Makes sure that under a given parent folder, the new file name is valid and not already in use by a different file.
+class ezFileNameValidator : public QValidator
+{
+public:
+  /// \brief Constructor. Validator requires the current location and name of the file.
+  /// \param sParentFolder Absolute path to the location of the file.
+  /// \param sCurrentName Current filename. If set, this name is marked as valid, even though it is already in use.
+  ezFileNameValidator(ezStringView sParentFolder, ezStringView sCurrentName);
+  virtual QValidator::State validate(QString& ref_sInput, int& ref_iPos) const override;
+
+private:
+  ezString m_sParentFolder;
+  ezString m_sCurrentName;
+};
+
+/// \brief Custom delegate for the eqQtAssetBrowserFolderView to enable renaming folders. Does not do any model modifications. Instead, it fires editingFinished when the delegate editor closes.
+class ezFolderNameDelegate : public QItemDelegate
+{
+  Q_OBJECT
+
+public:
+  ezFolderNameDelegate(QObject* pParent = nullptr);
+
+  virtual QWidget* createEditor(QWidget* pParent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+  virtual void setModelData(QWidget* pEditor, QAbstractItemModel* pModel, const QModelIndex& index) const override;
+
+signals:
+  void editingFinished(const QString& sAbsPath, const QString& sNewName) const;
+};
+
+/// \brief Folder tree of the asset browser to allow filtering by folder.
+///
+/// This class keeps up to date with the folder structure in ezFileSystemModel. Events from ezFileSystemModel are cached ans flushed via OnFlushFileSystemEvents.
+/// Folder movement, creation and deletion is supported and handled by this class. The context menu is implemented in ezQtAssetBrowserWidget as it requires a global context of the asset browser instance.
+class eqQtAssetBrowserFolderView : public QTreeWidget
+{
+  Q_OBJECT
+public:
+  eqQtAssetBrowserFolderView(QWidget* pParent);
+  ~eqQtAssetBrowserFolderView();
+
+  /// \brief Required to be set right after the ctor. This class will call ezQtAssetBrowserFilter::SetPathFilter whenever the current selected item changes.
+  void SetFilter(ezQtAssetBrowserFilter* pFilter);
+  /// \brief In dialog mode, any modifications (folder movement, creation and deletion) are disabled.
+  void SetDialogMode(bool bDialogMode);
+
+public Q_SLOTS:
+  /// \brief Creates a new folder under the current selected item and enters edit mode to allow the user to rename it.
+  void OnNewFolder();
+  /// \brief Opens the current selected item in the windows explorer or OS equivalent.
+  void OnTreeOpenExplorer();
+
+private Q_SLOTS:
+  void OnFolderEditingFinished(const QString& sAbsPath, const QString& sNewName);
+  void OnFlushFileSystemEvents();
+  void OnItemSelectionChanged();
+  void OnPathFilterChanged();
+
+protected:
+  virtual void dragMoveEvent(QDragMoveEvent* e) override;
+  virtual void dropEvent(QDropEvent* event) override;
+  virtual Qt::DropActions supportedDropActions() const override;
+  ezStatus canDrop(QDropEvent* e, ezDynamicArray<ezString>& out_files, ezString& out_sTargetFolder);
+  virtual QStringList mimeTypes() const override;
+  virtual QMimeData* mimeData(const QList<QTreeWidgetItem*>& items) const override;
+  virtual void keyPressEvent(QKeyEvent* e) override;
+
+private:
+  bool SelectPathFilter(QTreeWidgetItem* pParent, const QString& sPath);
+  void UpdateDirectoryTree();
+  void ClearDirectoryTree();
+  void BuildDirectoryTree(const ezDataDirPath& path, ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem, bool bIsHidden);
+  void RemoveDirectoryTreeItem(ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem);
+  QTreeWidgetItem* FindDirectoryTreeItem(ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem);
+  void FileSystemModelFolderEventHandler(const ezFolderChangedEvent& e);
+  void ProjectEventHandler(const ezToolsProjectEvent& e);
+
+private:
+  bool m_bDialogMode = false;
+  ezUInt32 m_uiKnownAssetFolderCount = 0;
+  bool m_bTreeSelectionChangeInProgress = false;
+
+  ezQtAssetBrowserFilter* m_pFilter = nullptr;
+
+  ezMutex m_FolderStructureMutex;
+  ezHybridArray<ezFolderChangedEvent, 2> m_QueuedFolderEvents;
+};

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
@@ -58,9 +58,11 @@ public:
 
 public Q_SLOTS:
   /// \brief Creates a new folder under the current selected item and enters edit mode to allow the user to rename it.
-  void OnNewFolder();
+  void NewFolder();
   /// \brief Opens the current selected item in the windows explorer or OS equivalent.
-  void OnTreeOpenExplorer();
+  void TreeOpenExplorer();
+  /// \brief Deletes the currently selected folder after confirmation.
+  void DeleteFolder();
 
 private Q_SLOTS:
   void OnFolderEditingFinished(const QString& sAbsPath, const QString& sNewName);

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserModel.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserModel.moc.h
@@ -5,35 +5,68 @@
 #include <Foundation/Containers/Set.h>
 #include <Foundation/Types/Uuid.h>
 #include <QAbstractItemModel>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
 
 struct ezAssetInfo;
 struct ezAssetCuratorEvent;
 struct ezSubAsset;
+class ezQtAssetFilter;
 
+/// \brief Interface class of the asset filter used to decide which items are shown in the asset browser.
 class EZ_EDITORFRAMEWORK_DLL ezQtAssetFilter : public QObject
 {
   Q_OBJECT
 public:
   explicit ezQtAssetFilter(QObject* pParent);
-  virtual bool IsAssetFiltered(const ezSubAsset* pInfo) const = 0;
-  virtual bool Less(const ezSubAsset* pInfoA, const ezSubAsset* pInfoB) const = 0;
+  virtual bool IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const = 0;
+  virtual ezStringView GetFilterRelativePath(ezStringView sDataDirParentRelativePath) const { return sDataDirParentRelativePath; }
 
 Q_SIGNALS:
   void FilterChanged();
 };
 
+/// \brief Each item in the asset browser can be multiple things at the same time as described by these flags.
+/// Retrieved via user role ezQtAssetBrowserModel::UserRoles::ItemFlags.
+struct EZ_EDITORFRAMEWORK_DLL ezAssetBrowserItemFlags
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    Folder = EZ_BIT(0),        // Any folder inside a data directory
+    DataDirectory = EZ_BIT(1), // mutually exclusive with Folder
+    File = EZ_BIT(2),          // any file, could also be an Asset
+    Asset = EZ_BIT(3),         // main asset: mutually exclusive with SubAsset
+    SubAsset = EZ_BIT(4),      // sub-asset (imaginary, not a File or Asset)
+    Default = 0
+  };
+
+  struct Bits
+  {
+    StorageType Folder : 1;
+    StorageType DataDirectory : 1;
+    StorageType File : 1;
+    StorageType Asset : 1;
+    StorageType SubAsset : 1;
+  };
+};
+EZ_DECLARE_FLAGS_OPERATORS(ezAssetBrowserItemFlags);
+
+/// \brief Model of the item view in the asset browser.
 class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserModel : public QAbstractItemModel
 {
   Q_OBJECT
 public:
   enum UserRoles
   {
-    SubAssetGuid = Qt::UserRole + 0,
-    AssetGuid,
-    AbsolutePath,
-    RelativePath,
-    AssetIcon,
-    TransformState,
+    SubAssetGuid = Qt::UserRole + 0, // ezUuid
+    AssetGuid,                       // ezUuid
+    AbsolutePath,                    // QString
+    RelativePath,                    // QString
+    AssetIcon,                       // QIcon
+    TransformState,                  // QString
+    Importable,                      // bool
+    ItemFlags,                       // ezAssetBrowserItemFlags as int
   };
 
   ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* pFilter);
@@ -44,12 +77,20 @@ public:
   void SetIconMode(bool bIconMode) { m_bIconMode = bIconMode; }
   bool GetIconMode() { return m_bIconMode; }
 
-private Q_SLOTS:
-  void ThumbnailLoaded(QString sPath, QModelIndex index, QVariant UserData1, QVariant UserData2);
+  ezInt32 FindAssetIndex(const ezUuid& assetGuid) const;
+  ezInt32 FindIndex(ezStringView sAbsPath) const;
+
+public Q_SLOTS:
+  void ThumbnailLoaded(QString sPath, QModelIndex index, QVariant userData1, QVariant userData2);
   void ThumbnailInvalidated(QString sPath, ezUInt32 uiImageID);
+  void OnFileSystemUpdate();
+
+signals:
+  void editingFinished(const QString& sAbsPath, const QString& sNewName, bool bIsAsset) const;
 
 public: // QAbstractItemModel interface
   virtual QVariant data(const QModelIndex& index, int iRole) const override;
+  virtual bool setData(const QModelIndex& index, const QVariant& value, int iRole = Qt::EditRole) override;
   virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
   virtual QVariant headerData(int iSection, Qt::Orientation orientation, int iRole = Qt::DisplayRole) const override;
   virtual QModelIndex index(int iRow, int iColumn, const QModelIndex& parent = QModelIndex()) const override;
@@ -58,14 +99,10 @@ public: // QAbstractItemModel interface
   virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override;
   virtual QStringList mimeTypes() const override;
   virtual QMimeData* mimeData(const QModelIndexList& indexes) const override;
+  virtual Qt::DropActions supportedDropActions() const override;
 
 private:
-  friend struct AssetComparer;
-  struct AssetEntry
-  {
-    ezUuid m_Guid;
-    mutable ezUInt32 m_uiThumbnailID;
-  };
+  friend struct FileComparer;
 
   enum class AssetOp
   {
@@ -73,15 +110,37 @@ private:
     Remove,
     Updated,
   };
+
+  struct VisibleEntry
+  {
+    ezDataDirPath m_sAbsFilePath;
+    ezUuid m_Guid;
+    ezBitflags<ezAssetBrowserItemFlags> m_Flags;
+    mutable ezUInt32 m_uiThumbnailID;
+  };
+
+  struct FsEvent
+  {
+    ezFileChangedEvent m_FileEvent;
+    ezFolderChangedEvent m_FolderEvent;
+  };
+
+private:
   void AssetCuratorEventHandler(const ezAssetCuratorEvent& e);
-  ezInt32 FindAssetIndex(const ezUuid& assetGuid) const;
-  void HandleAsset(const ezSubAsset* pInfo, AssetOp op);
-  void Init(AssetEntry& ae, const ezSubAsset* pInfo);
+  void HandleEntry(const VisibleEntry& entry, AssetOp op);
+  void FileSystemFileEventHandler(const ezFileChangedEvent& e);
+  void FileSystemFolderEventHandler(const ezFolderChangedEvent& e);
+  void HandleFile(const ezFileChangedEvent& e);
+  void HandleFolder(const ezFolderChangedEvent& e);
 
-  ezQtAssetFilter* m_pFilter;
-  ezDynamicArray<AssetEntry> m_AssetsToDisplay;
+private:
+  ezQtAssetFilter* m_pFilter = nullptr;
+  bool m_bIconMode = true;
+  ezSet<ezString> m_ImportExtensions;
+
+  ezMutex m_Mutex;
+  ezDynamicArray<FsEvent> m_QueuedFileSystemEvents;
+
+  ezDynamicArray<VisibleEntry> m_EntriesToDisplay;
   ezSet<ezUuid> m_DisplayedEntries;
-
-  bool m_bIconMode;
 };
-

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserView.moc.h
@@ -5,6 +5,7 @@
 #include <GuiFoundation/Widgets/ItemView.moc.h>
 #include <QItemDelegate>
 #include <QListView>
+#include <EditorFramework/Assets/AssetBrowserFolderView.moc.h>
 
 class ezQtIconViewDelegate;
 
@@ -47,9 +48,13 @@ public:
   virtual bool mousePressEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index) override;
   virtual bool mouseReleaseEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index) override;
 
+
 public:
   virtual void paint(QPainter* pPainter, const QStyleOptionViewItem& opt, const QModelIndex& index) const override;
   virtual QSize sizeHint(const QStyleOptionViewItem& opt, const QModelIndex& index) const override;
+  virtual QWidget* createEditor(QWidget* pParent, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+  virtual void setModelData(QWidget* pEditor, QAbstractItemModel* pModel, const QModelIndex& index) const override;
+  virtual void updateEditorGeometry(QWidget* pEditor, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
 private:
   QSize ItemSize() const;

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -68,10 +68,12 @@ private Q_SLOTS:
   void OnAssetSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
   void OnAssetSelectionCurrentChanged(const QModelIndex& current, const QModelIndex& previous);
   void OnModelReset();
-  void OnNewAsset();
+  void NewAsset();
   void OnFileEditingFinished(const QString& sAbsPath, const QString& sNewName, bool bIsAsset);
-  void OnImport();
+  void ImportSelection();
   void OnOpenImportReferenceAsset();
+  void DeleteSelection();
+
 
 private:
   virtual void keyPressEvent(QKeyEvent* e) override;

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -2,12 +2,16 @@
 
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/ui_AssetBrowserWidget.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
+
+
 
 class ezQtToolBarActionMapView;
 class ezQtAssetBrowserFilter;
 class ezQtAssetBrowserModel;
 struct ezAssetCuratorEvent;
+class ezQtAssetBrowserModel;
 
 class ezQtAssetBrowserWidget : public QWidget, public Ui_AssetBrowserWidget
 {
@@ -46,12 +50,11 @@ private Q_SLOTS:
   void on_ListAssets_ViewZoomed(ezInt32 iIconSizePercentage);
   void OnSearchWidgetTextChanged(const QString& text);
   void on_ListTypeFilter_itemChanged(QListWidgetItem* item);
-  void on_TreeFolderFilter_itemSelectionChanged();
   void on_TreeFolderFilter_customContextMenuRequested(const QPoint& pt);
   void on_TypeFilter_currentIndexChanged(int index);
   void OnScrollToItem(ezUuid preselectedAsset);
-  void OnTreeOpenExplorer();
   void OnShowSubFolderItemsToggled();
+  void OnShowFilesAndFoldersToggled();
   void OnShowHiddenFolderItemsToggled();
   void on_ListAssets_customContextMenuRequested(const QPoint& pt);
   void OnListOpenExplorer();
@@ -66,24 +69,26 @@ private Q_SLOTS:
   void OnAssetSelectionCurrentChanged(const QModelIndex& current, const QModelIndex& previous);
   void OnModelReset();
   void OnNewAsset();
+  void OnFileEditingFinished(const QString& sAbsPath, const QString& sNewName, bool bIsAsset);
+  void OnImport();
+  void OnOpenImportReferenceAsset();
+
+private:
+  virtual void keyPressEvent(QKeyEvent* e) override;
 
 private:
   void AssetCuratorEventHandler(const ezAssetCuratorEvent& e);
-  void UpdateDirectoryTree();
-  void ClearDirectoryTree();
-  void BuildDirectoryTree(const char* szCurPath, QTreeWidgetItem* pParent, const char* szCurPathToItem, bool bIsHidden);
-  bool SelectPathFilter(QTreeWidgetItem* pParent, const QString& sPath);
   void UpdateAssetTypes();
   void ProjectEventHandler(const ezToolsProjectEvent& e);
   void AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedAsset);
+  void AddImportedViaMenu(QMenu* pMenu);
 
-  bool m_bDialogMode;
-  ezUInt32 m_uiKnownAssetFolderCount;
-  bool m_bTreeSelectionChangeInProgress = false;
-
-  ezQtToolBarActionMapView* m_pToolbar;
+  bool m_bDialogMode = false;
+  ezQtToolBarActionMapView* m_pToolbar = nullptr;
   ezString m_sAllTypesFilter;
-  ezQtAssetBrowserModel* m_pModel;
-  ezQtAssetBrowserFilter* m_pFilter;
-};
+  ezQtAssetBrowserModel* m_pModel = nullptr;
+  ezQtAssetBrowserFilter* m_pFilter = nullptr;
 
+  /// \brief After creating a new asset and renaming it, we want to open it as well.
+  bool m_bOpenAfterRename = false;
+};

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -54,7 +54,8 @@ private Q_SLOTS:
   void on_TypeFilter_currentIndexChanged(int index);
   void OnScrollToItem(ezUuid preselectedAsset);
   void OnShowSubFolderItemsToggled();
-  void OnShowFilesAndFoldersToggled();
+  void OnShowFilesToggled();
+  void OnShowNonImportableFilesToggled();
   void OnShowHiddenFolderItemsToggled();
   void on_ListAssets_customContextMenuRequested(const QPoint& pt);
   void OnListOpenExplorer();

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.ui
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.ui
@@ -54,7 +54,7 @@
           <enum>Qt::Vertical</enum>
          </property>
          <widget class="QListWidget" name="ListTypeFilter"/>
-         <widget class="QTreeWidget" name="TreeFolderFilter">
+         <widget class="eqQtAssetBrowserFolderView" name="TreeFolderFilter">
           <property name="uniformRowHeights">
            <bool>true</bool>
           </property>
@@ -154,8 +154,11 @@
        </item>
        <item>
         <widget class="ezQtAssetBrowserView" name="ListAssets">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
          <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
+          <set>QAbstractItemView::EditKeyPressed</set>
          </property>
          <property name="dragEnabled">
           <bool>true</bool>
@@ -164,7 +167,7 @@
           <enum>QAbstractItemView::DragOnly</enum>
          </property>
          <property name="alternatingRowColors">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="selectionMode">
           <enum>QAbstractItemView::ExtendedSelection</enum>
@@ -191,6 +194,11 @@
    <extends>QWidget</extends>
    <header location="global">GuiFoundation/Widgets/SearchWidget.moc.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>eqQtAssetBrowserFolderView</class>
+   <extends>QTreeWidget</extends>
+   <header location="global">EditorFramework/Assets/AssetBrowserFolderView.moc.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -276,10 +276,21 @@ public:
   /// \param assetGuid
   ///   The asset to find use cases for.
   /// \param uses
-  ///   List of assets that use 'assetGuid'.
+  ///   List of assets that use 'assetGuid'. Any previous content of the set is not removed.
   /// \param transitive
   ///   If set, will also find indirect uses of the asset.
   void FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool bTransitive) const;
+
+  /// \brief Returns all assets that use a file for transform. Use this to e.g. figure which assets still reference a .tga file in the project.
+  /// \param sAbsolutePath Absolute path to any file inside a data directory.
+  /// \param ref_uses List of assets that use 'sAbsolutePath'. Any previous content of the set is not removed.
+  void FindAllUses(ezStringView sAbsolutePath, ezSet<ezUuid>& ref_uses) const;
+
+  /// \brief Returns whether a file is referenced, i.e. used for transforming an asset. Use this to e.g. figure out whether a .tga file is still in use by any asset.
+  /// \param sAbsolutePath Absolute path to any file inside a data directory.
+  /// \return True, if at least one asset references the given file.
+  bool IsReferenced(ezStringView sAbsolutePath) const;
+
 
   ///@}
   /// \name Manual and Automatic Change Notification

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
@@ -46,8 +46,11 @@ public:
     ezHybridArray<ezAssetDocumentGenerator::Info, 4> m_ImportOptions;
   };
 
+  /// \brief Creates a list of all importable file extensions. Note that this is an expensive function so the the result should be cached.
+  /// \param out_Extensions List of all file extensions that can be imported.
+  static void GetSupportsFileTypes(ezSet<ezString>& out_extensions);
   static void ImportAssets();
-  static void ImportAssets(const ezHybridArray<ezString, 16>& filesToImport);
+  static void ImportAssets(const ezDynamicArray<ezString>& filesToImport);
   static void ExecuteImport(ezDynamicArray<ezAssetDocumentGenerator::ImportData>& ref_allImports);
 
   virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const = 0;
@@ -55,6 +58,7 @@ public:
   virtual ezStringView GetDocumentExtension() const = 0;
   virtual ezStringView GetGeneratorGroup() const = 0;
 
+  void GetSupportedFileTypes(ezSet<ezString>& ref_extensions) const;
   bool SupportsFileType(ezStringView sFile) const;
   void BuildFileDialogFilterString(ezStringBuilder& out_sFilter) const;
   void AppendFileFilterStrings(ezStringBuilder& out_sFilter, bool& ref_bSemicolon) const;
@@ -67,7 +71,7 @@ private:
   static void DestroyGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
   static ezResult DetermineInputAndOutputFiles(ImportData& data, Info& option);
   static void SortAndSelectBestImportOption(ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports);
-  static void CreateImportOptionList(const ezHybridArray<ezString, 16>& filesToImport, ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
+  static void CreateImportOptionList(const ezDynamicArray<ezString>& filesToImport, ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
 
   ezHybridArray<ezString, 16> m_SupportedFileTypes;
 };

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFilter.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFilter.cpp
@@ -13,6 +13,7 @@ ezQtAssetBrowserFilter::ezQtAssetBrowserFilter(QObject* pParent)
 void ezQtAssetBrowserFilter::Reset()
 {
   SetShowItemsInSubFolders(true);
+  SetShowFilesAndFolders(true);
   SetShowItemsInHiddenFolders(false);
   SetSortByRecentUse(false);
   SetTextFilter("");
@@ -25,7 +26,20 @@ void ezQtAssetBrowserFilter::SetShowItemsInSubFolders(bool bShow)
   if (m_bShowItemsInSubFolders == bShow)
     return;
 
+  m_sTemporaryPinnedItem.Clear();
   m_bShowItemsInSubFolders = bShow;
+
+  Q_EMIT FilterChanged();
+}
+
+
+void ezQtAssetBrowserFilter::SetShowFilesAndFolders(bool bShow)
+{
+  if (m_bShowFilesAndFolders == bShow)
+    return;
+
+  m_sTemporaryPinnedItem.Clear();
+  m_bShowFilesAndFolders = bShow;
 
   Q_EMIT FilterChanged();
 }
@@ -35,6 +49,7 @@ void ezQtAssetBrowserFilter::SetShowItemsInHiddenFolders(bool bShow)
   if (m_bShowItemsInHiddenFolders == bShow)
     return;
 
+  m_sTemporaryPinnedItem.Clear();
   m_bShowItemsInHiddenFolders = bShow;
 
   Q_EMIT FilterChanged();
@@ -89,14 +104,30 @@ void ezQtAssetBrowserFilter::SetPathFilter(const char* szPath)
 {
   ezStringBuilder sCleanText = szPath;
   sCleanText.MakeCleanPath();
+  // The assumption is that only full directory names are set as path filters. Thus, we can ensure they end with a / to make it easier to filter items inside the path.
+  if (!sCleanText.IsEmpty() && !sCleanText.EndsWith_NoCase("/"))
+  {
+    sCleanText.Append("/");
+  }
 
   if (m_sPathFilter == sCleanText)
     return;
 
+  m_sTemporaryPinnedItem.Clear();
   m_sPathFilter = sCleanText;
 
   Q_EMIT FilterChanged();
   Q_EMIT PathFilterChanged();
+}
+
+
+ezStringView ezQtAssetBrowserFilter::GetPathFilter() const
+{
+  if (m_sPathFilter.EndsWith_NoCase("/"))
+  {
+    return m_sPathFilter.GetSubString(0, m_sPathFilter.GetCharacterCount() - 1);
+  }
+  return m_sPathFilter;
 }
 
 void ezQtAssetBrowserFilter::SetTypeFilter(const char* szTypes)
@@ -104,32 +135,57 @@ void ezQtAssetBrowserFilter::SetTypeFilter(const char* szTypes)
   if (m_sTypeFilter == szTypes)
     return;
 
+  m_sTemporaryPinnedItem.Clear();
   m_sTypeFilter = szTypes;
 
   Q_EMIT FilterChanged();
   Q_EMIT TypeFilterChanged();
 }
 
-bool ezQtAssetBrowserFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
+
+void ezQtAssetBrowserFilter::SetTemporaryPinnedItem(ezStringView sDataDirParentRelativePath)
 {
-  if (!m_sPathFilter.IsEmpty())
+  if (m_sTemporaryPinnedItem == sDataDirParentRelativePath)
+    return;
+
+  m_sTemporaryPinnedItem = sDataDirParentRelativePath;
+  Q_EMIT FilterChanged();
+}
+
+bool ezQtAssetBrowserFilter::IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const
+{
+  // ignore all paths leading into the AssetCache
+  if (sDataDirParentRelativePath.FindSubString("/AssetCache/"))
+    return true;
+
+  // also ignore the AssetCache folder directly
+  if (bIsFolder && sDataDirParentRelativePath.GetFileNameAndExtension() == "AssetCache")
+    return true;
+
+  if (sDataDirParentRelativePath == m_sTemporaryPinnedItem)
+    return false;
+
+  if (!m_bShowFilesAndFolders && !pInfo)
+    return true;
+
+  if (!m_sPathFilter.IsEmpty() || bIsFolder)
   {
     // if the string is not found in the path, ignore this asset
-    if (!pInfo->m_pAssetInfo->m_Path.GetDataDirParentRelativePath().StartsWith_NoCase(m_sPathFilter))
+    if (!sDataDirParentRelativePath.StartsWith(m_sPathFilter))
       return true;
 
-    if (!m_bShowItemsInSubFolders)
+    if (!m_bShowItemsInSubFolders || bIsFolder)
     {
       // do we find another path separator after the prefix path?
       // if so, there is a sub-folder, and thus we ignore it
-      if (ezStringUtils::FindSubString(pInfo->m_pAssetInfo->m_Path.GetDataDirParentRelativePath().GetStartPointer() + m_sPathFilter.GetElementCount() + 1, "/") != nullptr)
+      if (ezStringUtils::FindSubString(sDataDirParentRelativePath.GetStartPointer() + m_sPathFilter.GetElementCount(), "/", sDataDirParentRelativePath.GetEndPointer()) != nullptr)
         return true;
     }
   }
 
   if (!m_bShowItemsInHiddenFolders)
   {
-    if (ezStringUtils::FindSubString_NoCase(pInfo->m_pAssetInfo->m_Path.GetDataDirParentRelativePath().GetStartPointer() + m_sPathFilter.GetElementCount() + 1, "_data/") !=
+    if (ezStringUtils::FindSubString_NoCase(sDataDirParentRelativePath.GetStartPointer() + m_sPathFilter.GetElementCount() + 1, "_data/", sDataDirParentRelativePath.GetEndPointer()) !=
         nullptr)
       return true;
   }
@@ -138,15 +194,18 @@ bool ezQtAssetBrowserFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
   {
     if (m_bUsesSearchActive)
     {
+      if (pInfo == nullptr)
+        return true;
+
       if (!m_Uses.Contains(pInfo->m_Data.m_Guid))
         return true;
     }
     else
     {
       // if the string is not found in the path, ignore this asset
-      if (m_SearchFilter.PassesFilters(pInfo->m_pAssetInfo->m_Path.GetDataDirRelativePath()) == false)
+      if (m_SearchFilter.PassesFilters(sDataDirParentRelativePath) == false)
       {
-        if (m_SearchFilter.PassesFilters(pInfo->GetName()) == false)
+        if (pInfo && m_SearchFilter.PassesFilters(pInfo->GetName()) == false)
         {
           ezConversionUtils::ToString(pInfo->m_Data.m_Guid, m_sTemp);
           if (m_SearchFilter.PassesFilters(m_sTemp) == false)
@@ -154,34 +213,26 @@ bool ezQtAssetBrowserFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
 
           // we could actually (partially) match the GUID
         }
+        else
+          return true;
       }
     }
   }
 
   if (!m_sTypeFilter.IsEmpty())
   {
+    // Always show folders even if type filter is set.
+    if (bIsFolder)
+      return false;
+
+    if (pInfo == nullptr) // if this is no asset, but we have an asset type filter active, always hide this thing
+      return true;
+
     m_sTemp.Set(";", pInfo->m_Data.m_sSubAssetsDocumentTypeName, ";");
 
     if (!m_sTypeFilter.FindSubString(m_sTemp))
       return true;
   }
+
   return false;
-}
-
-bool ezQtAssetBrowserFilter::Less(const ezSubAsset* pInfoA, const ezSubAsset* pInfoB) const
-{
-  if (m_bSortByRecentUse && pInfoA->m_LastAccess.GetSeconds() != pInfoB->m_LastAccess.GetSeconds())
-  {
-    return pInfoA->m_LastAccess > pInfoB->m_LastAccess;
-  }
-
-  ezStringView sSortA = pInfoA->GetName();
-  ezStringView sSortB = pInfoB->GetName();
-
-  ezInt32 iValue = ezStringUtils::Compare_NoCase(sSortA.GetStartPointer(), sSortB.GetStartPointer(), sSortA.GetEndPointer(), sSortB.GetEndPointer());
-  if (iValue == 0)
-  {
-    return pInfoA->m_Data.m_Guid < pInfoB->m_Data.m_Guid;
-  }
-  return iValue < 0;
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
@@ -1,0 +1,638 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetBrowserFilter.moc.h>
+#include <EditorFramework/Assets/AssetBrowserFolderView.moc.h>
+#include <EditorFramework/Assets/AssetBrowserModel.moc.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <Foundation/IO/FileSystem/FileSystem.h>
+#include <Foundation/IO/OSFile.h>
+#include <ToolsFoundation/FileSystem/FileSystemModel.h>
+
+
+ezFileNameValidator::ezFileNameValidator(ezStringView sParentFolder, ezStringView sCurrentName)
+  : m_sParentFolder(sParentFolder)
+  , m_sCurrentName(sCurrentName)
+{
+}
+
+QValidator::State ezFileNameValidator::validate(QString& ref_sInput, int& ref_iPos) const
+{
+  ezStringBuilder sTemp = ref_sInput.toUtf8().constData();
+  if (sTemp.IsEmpty())
+    return QValidator::State::Intermediate;
+  if (ezPathUtils::ContainsInvalidFilenameChars(sTemp))
+    return QValidator::State::Invalid;
+  if (sTemp.StartsWith_NoCase(" ") || sTemp.EndsWith(" "))
+    return QValidator::State::Intermediate;
+
+  if (!m_sCurrentName.IsEmpty() && sTemp == m_sCurrentName)
+    return QValidator::State::Acceptable;
+
+  ezStringBuilder sAbsPath = m_sParentFolder;
+  sAbsPath.AppendPath(sTemp);
+  if (ezOSFile::ExistsDirectory(sAbsPath) || ezOSFile::ExistsFile(sAbsPath))
+    return QValidator::State::Intermediate;
+
+  return QValidator::State::Acceptable;
+}
+
+
+ezFolderNameDelegate::ezFolderNameDelegate(QObject* pParent /*= nullptr*/)
+  : QItemDelegate(pParent)
+{
+}
+
+QWidget* ezFolderNameDelegate::createEditor(QWidget* pParent, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+  // auto bla = qobject_cast<QTreeWidget*>(parent);
+  ezStringBuilder sAbsPath = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().constData();
+
+  QLineEdit* editor = new QLineEdit(pParent);
+  editor->setValidator(new ezFileNameValidator(sAbsPath.GetFileDirectory(), sAbsPath.GetFileNameAndExtension()));
+  return editor;
+}
+
+void ezFolderNameDelegate::setModelData(QWidget* pEditor, QAbstractItemModel* pModel, const QModelIndex& index) const
+{
+  QString sOldName = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+  QLineEdit* pLineEdit = qobject_cast<QLineEdit*>(pEditor);
+  emit editingFinished(sOldName, pLineEdit->text());
+}
+
+
+
+eqQtAssetBrowserFolderView::eqQtAssetBrowserFolderView(QWidget* pParent)
+  : QTreeWidget(pParent)
+{
+  viewport()->setAcceptDrops(true);
+  setAcceptDrops(true);
+
+  setDropIndicatorShown(true);
+  setDefaultDropAction(Qt::MoveAction);
+
+  SetDialogMode(false);
+
+  setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+  auto pDelegate = new ezFolderNameDelegate(this);
+  EZ_VERIFY(connect(pDelegate, &ezFolderNameDelegate::editingFinished, this, &eqQtAssetBrowserFolderView::OnFolderEditingFinished, Qt::QueuedConnection), "signal/slot connection failed");
+  setItemDelegate(pDelegate);
+
+  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.AddEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::FileSystemModelFolderEventHandler, this));
+  ezToolsProject::s_Events.AddEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::ProjectEventHandler, this));
+
+  EZ_VERIFY(connect(this, SIGNAL(itemSelectionChanged()), this, SLOT(OnItemSelectionChanged())) != nullptr, "signal/slot connection failed");
+
+  UpdateDirectoryTree();
+}
+
+eqQtAssetBrowserFolderView::~eqQtAssetBrowserFolderView()
+{
+  ezToolsProject::s_Events.RemoveEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::ProjectEventHandler, this));
+  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.RemoveEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::FileSystemModelFolderEventHandler, this));
+}
+
+
+void eqQtAssetBrowserFolderView::SetFilter(ezQtAssetBrowserFilter* pFilter)
+{
+  m_pFilter = pFilter;
+  EZ_VERIFY(connect(m_pFilter, SIGNAL(PathFilterChanged()), this, SLOT(OnPathFilterChanged())) != nullptr, "signal/slot connection failed");
+}
+
+
+void eqQtAssetBrowserFolderView::SetDialogMode(bool bDialogMode)
+{
+  m_bDialogMode = bDialogMode;
+
+  if (m_bDialogMode)
+  {
+    setDragEnabled(false);
+    setDragDropMode(QAbstractItemView::DragDropMode::NoDragDrop);
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
+  }
+  else
+  {
+    setDragEnabled(true);
+    setDragDropMode(QAbstractItemView::DragDrop);
+    setEditTriggers(QAbstractItemView::EditKeyPressed);
+  }
+}
+
+void eqQtAssetBrowserFolderView::OnNewFolder()
+{
+  QAction* pSender = qobject_cast<QAction*>(sender());
+
+  if (!currentItem())
+    return;
+
+  ezStringBuilder sPath = currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
+  ezStringBuilder sNewFolder = sPath;
+  sNewFolder.AppendFormat("/NewFolder");
+
+  for (ezUInt32 i = 0; ezOSFile::ExistsDirectory(sNewFolder); i++)
+  {
+    sNewFolder = sPath;
+    sNewFolder.AppendFormat("/NewFolder{}", i);
+  }
+
+  if (ezFileSystem::CreateDirectoryStructure(sNewFolder).Succeeded())
+  {
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sNewFolder);
+    OnFlushFileSystemEvents();
+
+    if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sNewFolder))
+    {
+      QTreeWidgetItem* pItem = FindDirectoryTreeItem(sNewFolder, topLevelItem(0), {});
+      if (pItem)
+      {
+        m_bTreeSelectionChangeInProgress = true;
+        scrollToItem(pItem);
+        clearSelection();
+        pItem->setSelected(true);
+        setCurrentItem(pItem);
+        editItem(pItem);
+        m_bTreeSelectionChangeInProgress = false;
+      }
+    }
+  }
+}
+
+void eqQtAssetBrowserFolderView::OnFolderEditingFinished(const QString& sAbsPath, const QString& sNewName)
+{
+  ezStringBuilder sPath = sAbsPath.toUtf8().data();
+  ezStringBuilder sNewPath = sPath;
+  sNewPath.ChangeFileNameAndExtension(sNewName.toUtf8().data());
+
+  if (sPath != sNewPath)
+  {
+    if (ezOSFile::MoveFileOrDirectory(sPath, sNewPath).Failed())
+    {
+      ezLog::Error("Failed to rename '{}' to '{}'", sPath, sNewPath);
+      return;
+    }
+
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sNewPath);
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sPath);
+    OnFlushFileSystemEvents();
+
+    if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sNewPath))
+    {
+      QTreeWidgetItem* pItem = FindDirectoryTreeItem(sNewPath, topLevelItem(0), {});
+      if (pItem)
+      {
+        scrollToItem(pItem);
+        clearSelection();
+        pItem->setSelected(true);
+        topLevelItem(0)->setSelected(false);
+        setCurrentItem(pItem);
+      }
+    }
+  }
+}
+
+void eqQtAssetBrowserFolderView::FileSystemModelFolderEventHandler(const ezFolderChangedEvent& e)
+{
+  EZ_LOCK(m_FolderStructureMutex);
+  m_QueuedFolderEvents.PushBack(e);
+
+  QTimer::singleShot(0, this, SLOT(OnFlushFileSystemEvents()));
+}
+
+void eqQtAssetBrowserFolderView::ProjectEventHandler(const ezToolsProjectEvent& e)
+{
+  switch (e.m_Type)
+  {
+    case ezToolsProjectEvent::Type::ProjectClosed:
+    {
+      // remove project structure from asset browser
+      ClearDirectoryTree();
+    }
+    break;
+    default:
+      break;
+  }
+}
+
+void eqQtAssetBrowserFolderView::dragMoveEvent(QDragMoveEvent* e)
+{
+  QTreeWidget::dragMoveEvent(e);
+
+  ezHybridArray<ezString, 1> files;
+  ezString sTarget;
+  ezStatus res = canDrop(e, files, sTarget);
+  if (res.Failed())
+  {
+    ezQtUiServices::ShowGlobalStatusBarMessage(res.m_sMessage.GetView());
+    e->ignore();
+  }
+  else
+  {
+    ezQtUiServices::ShowGlobalStatusBarMessage({});
+  }
+}
+
+ezStatus eqQtAssetBrowserFolderView::canDrop(QDropEvent* e, ezDynamicArray<ezString>& out_files, ezString& out_sTargetFolder)
+{
+  if (!e->mimeData()->hasFormat("application/ezEditor.files"))
+  {
+    return ezStatus(EZ_FAILURE);
+  }
+
+  DropIndicatorPosition dropIndicator = dropIndicatorPosition();
+  if (dropIndicator != QAbstractItemView::OnItem)
+  {
+    return ezStatus(EZ_FAILURE);
+  }
+
+  auto action = e->dropAction();
+  if (action != Qt::MoveAction)
+  {
+    return ezStatus(EZ_FAILURE);
+  }
+
+  out_files.Clear();
+  QByteArray encodedData = e->mimeData()->data("application/ezEditor.files");
+  QDataStream stream(&encodedData, QIODevice::ReadOnly);
+  ezHybridArray<QString, 1> files;
+  stream >> files;
+
+  QModelIndex dropIndex = indexAt(e->position().toPoint());
+  if (dropIndex.isValid())
+  {
+    QString sAbsTarget = dropIndex.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+    out_sTargetFolder = qtToEzString(sAbsTarget);
+
+    for (const QString& sFile : files)
+    {
+      ezString sFileToMove = qtToEzString(sFile);
+      out_files.PushBack(sFileToMove);
+
+      if (ezPathUtils::IsSubPath(sFileToMove, out_sTargetFolder))
+      {
+        return ezStatus(ezFmt("Can't move '{}' into its own sub-folder '{}'", sFileToMove, out_sTargetFolder));
+      }
+    }
+  }
+
+  return ezStatus(EZ_SUCCESS);
+}
+
+void eqQtAssetBrowserFolderView::dropEvent(QDropEvent* e)
+{
+  ezQtUiServices::ShowGlobalStatusBarMessage({});
+  ezHybridArray<ezString, 1> files;
+  ezString sTargetFolder;
+  // Always accept and call base class to end the drop operation as a no-op in the base class.
+  e->accept();
+  QTreeWidget::dropEvent(e);
+  if (canDrop(e, files, sTargetFolder).Failed())
+  {
+    return;
+  }
+
+
+  QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Do you want to move {} files / folders into '{}'?", files.GetCount(), sTargetFolder), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
+  if (choice == QMessageBox::StandardButton::Cancel)
+    return;
+
+  ezStringBuilder sNewLocation;
+  for (const ezString& sFile : files)
+  {
+    sNewLocation = sTargetFolder;
+    sNewLocation.AppendPath(ezPathUtils::GetFileNameAndExtension(sFile));
+    if (ezOSFile::MoveFileOrDirectory(sFile, sNewLocation).Failed())
+    {
+      ezLog::Error("Failed to move '{}' to '{}'", sFile, sNewLocation);
+    }
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sNewLocation);
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sFile);
+  }
+  OnFlushFileSystemEvents();
+
+  if (e->source() == this && files.GetCount() == 1)
+  {
+    if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sNewLocation))
+    {
+      QTreeWidgetItem* pItem = FindDirectoryTreeItem(sNewLocation, topLevelItem(0), {});
+      if (pItem)
+      {
+        m_bTreeSelectionChangeInProgress = true;
+        scrollToItem(pItem);
+        clearSelection();
+        pItem->setSelected(true);
+        setCurrentItem(pItem);
+        m_bTreeSelectionChangeInProgress = false;
+      }
+    }
+  }
+}
+
+
+QStringList eqQtAssetBrowserFolderView::mimeTypes() const
+{
+  QStringList types;
+  types << "application/ezEditor.files";
+  return types;
+}
+
+
+Qt::DropActions eqQtAssetBrowserFolderView::supportedDropActions() const
+{
+  return Qt::DropAction::MoveAction | Qt::DropAction::CopyAction;
+}
+
+QMimeData* eqQtAssetBrowserFolderView::mimeData(const QList<QTreeWidgetItem*>& items) const
+{
+  ezHybridArray<QString, 1> files;
+  for (const QTreeWidgetItem* pItem : items)
+  {
+    QModelIndex id = indexFromItem(pItem);
+    QString text = id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+    files.PushBack(text);
+  }
+
+  QByteArray encodedData;
+  QDataStream stream(&encodedData, QIODevice::WriteOnly);
+  stream << files;
+
+  QMimeData* mimeData = new QMimeData();
+  mimeData->setData("application/ezEditor.files", encodedData);
+  return mimeData;
+}
+
+void eqQtAssetBrowserFolderView::keyPressEvent(QKeyEvent* e)
+{
+  QTreeWidget::keyPressEvent(e);
+
+  if (e->key() == Qt::Key_Delete && !m_bDialogMode)
+  {
+    e->accept();
+    if (QTreeWidgetItem* pCurrentItem = currentItem())
+    {
+      QModelIndex id = indexFromItem(pCurrentItem);
+      QString sQtAbsPath = id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+      ezString sAbsPath = qtToEzString(sQtAbsPath);
+      QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Do you want to delete the folder\n'{}'?", sAbsPath), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
+      if (choice == QMessageBox::StandardButton::Cancel)
+        return;
+
+      if (ezOSFile::DeleteFolder(sAbsPath).Failed())
+      {
+        ezLog::Error("Failed to delete folder '{}'", sAbsPath);
+      }
+      ezFileSystemModel::GetSingleton()->NotifyOfChange(sAbsPath);
+    }
+  }
+}
+
+void eqQtAssetBrowserFolderView::OnFlushFileSystemEvents()
+{
+  EZ_LOCK(m_FolderStructureMutex);
+
+  for (const auto& e : m_QueuedFolderEvents)
+  {
+    switch (e.m_Type)
+    {
+      case ezFolderChangedEvent::Type::FolderAdded:
+      {
+        BuildDirectoryTree(e.m_Path, e.m_Path.GetDataDirParentRelativePath(), topLevelItem(0), "", false);
+      }
+      break;
+
+      case ezFolderChangedEvent::Type::FolderRemoved:
+      {
+        RemoveDirectoryTreeItem(e.m_Path.GetDataDirParentRelativePath(), topLevelItem(0), "");
+      }
+      break;
+
+      case ezFolderChangedEvent::Type::ModelReset:
+        UpdateDirectoryTree();
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  m_QueuedFolderEvents.Clear();
+}
+
+
+void eqQtAssetBrowserFolderView::OnItemSelectionChanged()
+{
+  if (m_bTreeSelectionChangeInProgress)
+    return;
+
+  ezStringBuilder sCurPath;
+
+  if (!selectedItems().isEmpty())
+  {
+    sCurPath = selectedItems()[0]->data(0, ezQtAssetBrowserModel::UserRoles::RelativePath).toString().toUtf8().data();
+  }
+
+  m_pFilter->SetPathFilter(sCurPath);
+}
+
+void eqQtAssetBrowserFolderView::OnPathFilterChanged()
+{
+  const QString sPath = ezMakeQString(m_pFilter->GetPathFilter());
+
+  if (topLevelItemCount() == 1)
+  {
+    if (m_bTreeSelectionChangeInProgress)
+      return;
+
+    m_bTreeSelectionChangeInProgress = true;
+    clearSelection();
+    SelectPathFilter(topLevelItem(0), sPath);
+    m_bTreeSelectionChangeInProgress = false;
+  }
+}
+
+
+void eqQtAssetBrowserFolderView::OnTreeOpenExplorer()
+{
+  if (!currentItem())
+    return;
+
+  ezStringBuilder sPath = currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
+  ezQtUiServices::OpenInExplorer(sPath, false);
+}
+
+bool eqQtAssetBrowserFolderView::SelectPathFilter(QTreeWidgetItem* pParent, const QString& sPath)
+{
+  if (pParent->data(0, ezQtAssetBrowserModel::UserRoles::RelativePath).toString() == sPath)
+  {
+    pParent->setSelected(true);
+    return true;
+  }
+
+  for (ezInt32 i = 0; i < pParent->childCount(); ++i)
+  {
+    if (SelectPathFilter(pParent->child(i), sPath))
+    {
+      pParent->setExpanded(true);
+      return true;
+    }
+  }
+
+  return false;
+}
+void eqQtAssetBrowserFolderView::UpdateDirectoryTree()
+{
+  ezQtScopedBlockSignals block(this);
+
+  if (topLevelItemCount() == 0)
+  {
+    QTreeWidgetItem* pNewParent = new QTreeWidgetItem();
+    pNewParent->setText(0, QLatin1String("<root>"));
+
+    addTopLevelItem(pNewParent);
+
+    pNewParent->setExpanded(true);
+  }
+
+  auto Folders = ezFileSystemModel::GetSingleton()->GetFolders();
+
+  if (m_uiKnownAssetFolderCount == Folders->GetCount())
+    return;
+
+  m_uiKnownAssetFolderCount = Folders->GetCount();
+
+  ezStringBuilder tmp;
+
+  for (const auto& sDir : *Folders)
+  {
+    BuildDirectoryTree(sDir.Key(), sDir.Key().GetDataDirParentRelativePath(), topLevelItem(0), "", false);
+  }
+
+  setSortingEnabled(true);
+  sortItems(0, Qt::SortOrder::AscendingOrder);
+}
+
+
+void eqQtAssetBrowserFolderView::ClearDirectoryTree()
+{
+  clear();
+  m_uiKnownAssetFolderCount = 0;
+}
+
+void eqQtAssetBrowserFolderView::BuildDirectoryTree(const ezDataDirPath& path, ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem, bool bIsHidden)
+{
+  if (sCurPath.IsEmpty())
+    return;
+
+  const char* szNextSep = sCurPath.FindSubString("/");
+
+  QTreeWidgetItem* pNewParent = nullptr;
+
+  ezString sFolderName;
+
+  if (szNextSep == nullptr)
+    sFolderName = sCurPath;
+  else
+    sFolderName = ezStringView(sCurPath.GetStartPointer(), szNextSep);
+
+  if (sFolderName.EndsWith_NoCase("_data"))
+  {
+    bIsHidden = true;
+  }
+
+  ezStringBuilder sCurPath2 = sCurPathToItem;
+  sCurPath2.AppendPath(sFolderName);
+
+  const QString sQtFolderName = ezMakeQString(sFolderName.GetView());
+
+  if (sQtFolderName == "AssetCache")
+    return;
+
+  for (ezInt32 i = 0; i < pParent->childCount(); ++i)
+  {
+    if (pParent->child(i)->text(0) == sQtFolderName)
+    {
+      // item already exists
+      pNewParent = pParent->child(i);
+      goto godown;
+    }
+  }
+
+  { // #TODO_ASSET data for folder
+    const bool bIsDataDir = sCurPathToItem.IsEmpty();
+    pNewParent = new QTreeWidgetItem();
+    pNewParent->setText(0, sQtFolderName);
+    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath, ezMakeQString(path.GetAbsolutePath().GetView()));
+    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::RelativePath, ezMakeQString(path.GetDataDirParentRelativePath()));
+    ezBitflags<ezAssetBrowserItemFlags> flags = bIsDataDir ? ezAssetBrowserItemFlags::DataDirectory : ezAssetBrowserItemFlags::Folder;
+    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::ItemFlags, (int)flags.GetValue());
+    pNewParent->setIcon(0, ezQtUiServices::GetCachedIconResource(bIsDataDir ? ":/EditorFramework/Icons/DataDirectory.svg" : ":/EditorFramework/Icons/Folder.svg"));
+    if (!bIsDataDir)
+      pNewParent->setFlags(pNewParent->flags() | Qt::ItemFlag::ItemIsEditable | Qt::ItemFlag::ItemIsDragEnabled | Qt::ItemFlag::ItemIsDropEnabled);
+    else
+      pNewParent->setFlags(pNewParent->flags() | Qt::ItemFlag::ItemIsDropEnabled);
+
+    if (bIsHidden)
+    {
+      pNewParent->setForeground(0, QColor::fromRgba(qRgb(110, 110, 120)));
+    }
+
+    pParent->addChild(pNewParent);
+  }
+
+godown:
+
+  if (szNextSep == nullptr)
+    return;
+
+  BuildDirectoryTree(path, szNextSep + 1, pNewParent, sCurPath2, bIsHidden);
+}
+
+void eqQtAssetBrowserFolderView::RemoveDirectoryTreeItem(ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem)
+{
+  if (QTreeWidgetItem* pTreeItem = FindDirectoryTreeItem(sCurPath, pParent, sCurPathToItem))
+  {
+    delete pTreeItem;
+  }
+}
+
+
+QTreeWidgetItem* eqQtAssetBrowserFolderView::FindDirectoryTreeItem(ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem)
+{
+  if (sCurPath.IsEmpty())
+    return nullptr;
+
+  const char* szNextSep = sCurPath.FindSubString("/");
+
+  QTreeWidgetItem* pNewParent = nullptr;
+
+  ezString sFolderName;
+
+  if (szNextSep == nullptr)
+    sFolderName = sCurPath;
+  else
+    sFolderName = ezStringView(sCurPath.GetStartPointer(), szNextSep);
+
+  ezStringBuilder sCurPath2 = sCurPathToItem;
+  sCurPath2.AppendPath(sFolderName);
+
+  const QString sQtFolderName = ezMakeQString(sFolderName.GetView());
+
+  for (ezInt32 i = 0; i < pParent->childCount(); ++i)
+  {
+    if (pParent->child(i)->text(0) == sQtFolderName)
+    {
+      // item already exists
+      pNewParent = pParent->child(i);
+      goto godown;
+    }
+  }
+
+  return nullptr;
+
+godown:
+
+  if (szNextSep == nullptr)
+  {
+    return pNewParent;
+  }
+
+  return FindDirectoryTreeItem(szNextSep + 1, pNewParent, sCurPath2);
+}

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
@@ -9,8 +9,9 @@
 #include <ToolsFoundation/FileSystem/FileSystemModel.h>
 
 
-ezFileNameValidator::ezFileNameValidator(ezStringView sParentFolder, ezStringView sCurrentName)
-  : m_sParentFolder(sParentFolder)
+ezFileNameValidator::ezFileNameValidator(QObject* pParent, ezStringView sParentFolder, ezStringView sCurrentName)
+  : QValidator(pParent)
+  , m_sParentFolder(sParentFolder)
   , m_sCurrentName(sCurrentName)
 {
 }
@@ -47,7 +48,7 @@ QWidget* ezFolderNameDelegate::createEditor(QWidget* pParent, const QStyleOption
   ezStringBuilder sAbsPath = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().constData();
 
   QLineEdit* editor = new QLineEdit(pParent);
-  editor->setValidator(new ezFileNameValidator(sAbsPath.GetFileDirectory(), sAbsPath.GetFileNameAndExtension()));
+  editor->setValidator(new ezFileNameValidator(editor, sAbsPath.GetFileDirectory(), sAbsPath.GetFileNameAndExtension()));
   return editor;
 }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -155,7 +155,7 @@ QWidget* ezQtIconViewDelegate::createEditor(QWidget* pParent, const QStyleOption
   ezStringBuilder sAbsPath = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().constData();
 
   QLineEdit* editor = new QLineEdit(pParent);
-  editor->setValidator(new ezFileNameValidator(sAbsPath.GetFileDirectory(), sAbsPath.GetFileNameAndExtension()));
+  editor->setValidator(new ezFileNameValidator(editor, sAbsPath.GetFileDirectory(), sAbsPath.GetFileNameAndExtension()));
   return editor;
 }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -13,8 +13,6 @@ ezQtAssetBrowserView::ezQtAssetBrowserView(QWidget* pParent)
   m_pDelegate = new ezQtIconViewDelegate(this);
 
   SetDialogMode(false);
-
-  setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectItems);
   setViewMode(QListView::ViewMode::IconMode);
   setUniformItemSizes(true);
   setResizeMode(QListView::ResizeMode::Adjust);
@@ -29,12 +27,14 @@ void ezQtAssetBrowserView::SetDialogMode(bool bDialogMode)
 
   if (m_bDialogMode)
   {
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_pDelegate->SetDrawTransformState(false);
     setDragDropMode(QAbstractItemView::DragDropMode::NoDragDrop);
     setSelectionMode(QAbstractItemView::SelectionMode::SingleSelection);
   }
   else
   {
+    setEditTriggers(QAbstractItemView::EditKeyPressed);
     m_pDelegate->SetDrawTransformState(true);
     setDragDropMode(QAbstractItemView::DragOnly);
     setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
@@ -104,6 +104,10 @@ void ezQtIconViewDelegate::SetIconScale(ezInt32 iIconSizePercentage)
 
 bool ezQtIconViewDelegate::mousePressEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& opt, const QModelIndex& index)
 {
+  const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+  if (!itemType.IsSet(ezAssetBrowserItemFlags::Asset))
+    return false;
+
   const ezUInt32 uiThumbnailSize = ThumbnailSize();
   QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin + uiThumbnailSize - 16 + 2, ItemSideMargin + uiThumbnailSize - 16 + 2, 0, 0);
   thumbnailRect.setSize(QSize(16, 16));
@@ -117,6 +121,10 @@ bool ezQtIconViewDelegate::mousePressEvent(QMouseEvent* pEvent, const QStyleOpti
 
 bool ezQtIconViewDelegate::mouseReleaseEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& opt, const QModelIndex& index)
 {
+  const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+  if (!itemType.IsSet(ezAssetBrowserItemFlags::Asset))
+    return false;
+
   const ezUInt32 uiThumbnailSize = ThumbnailSize();
   QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin + uiThumbnailSize - 16 + 2, ItemSideMargin + uiThumbnailSize - 16 + 2, 0, 0);
   thumbnailRect.setSize(QSize(16, 16));
@@ -142,6 +150,32 @@ bool ezQtIconViewDelegate::mouseReleaseEvent(QMouseEvent* pEvent, const QStyleOp
   return false;
 }
 
+QWidget* ezQtIconViewDelegate::createEditor(QWidget* pParent, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+  ezStringBuilder sAbsPath = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().constData();
+
+  QLineEdit* editor = new QLineEdit(pParent);
+  editor->setValidator(new ezFileNameValidator(sAbsPath.GetFileDirectory(), sAbsPath.GetFileNameAndExtension()));
+  return editor;
+}
+
+void ezQtIconViewDelegate::setModelData(QWidget* pEditor, QAbstractItemModel* pModel, const QModelIndex& index) const
+{
+  QString sOldName = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+  QLineEdit* pLineEdit = qobject_cast<QLineEdit*>(pEditor);
+  pModel->setData(index, pLineEdit->text());
+}
+
+void ezQtIconViewDelegate::updateEditorGeometry(QWidget* pEditor, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+  if (!pEditor)
+    return;
+
+  const ezUInt32 uiThumbnailSize = ThumbnailSize();
+  const QRect textRect = option.rect.adjusted(ItemSideMargin, ItemSideMargin + uiThumbnailSize + TextSpacing, -ItemSideMargin, -ItemSideMargin - TextSpacing);
+  pEditor->setGeometry(textRect);
+}
+
 void ezQtIconViewDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem& opt, const QModelIndex& index) const
 {
   if (!IsInIconMode())
@@ -151,6 +185,7 @@ void ezQtIconViewDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem&
   }
 
   const ezUInt32 uiThumbnailSize = ThumbnailSize();
+  const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
 
   // Prepare painter.
   {
@@ -159,6 +194,18 @@ void ezQtIconViewDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem&
       pPainter->setClipRect(opt.rect);
 
     pPainter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+  }
+
+  // Draw assets with a background to distinguish them easily from normal files / folders.
+  if (itemType.IsAnySet(ezAssetBrowserItemFlags::Asset | ezAssetBrowserItemFlags::SubAsset))
+  {
+    QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled ? QPalette::Normal : QPalette::Disabled;
+    if (cg == QPalette::Normal && !(opt.state & QStyle::State_Active))
+      cg = QPalette::Inactive;
+
+    ezInt32 border = ItemSideMargin - HighlightBorderWidth;
+    QRect assetRect = opt.rect.adjusted(border, border, -border, -border);
+    pPainter->fillRect(assetRect, opt.palette.brush(cg, QPalette::AlternateBase));
   }
 
   // Draw highlight background (copy of QItemDelegate::drawBackground)
@@ -188,61 +235,74 @@ void ezQtIconViewDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem&
     }
   }
 
-  // Draw thumbnail.
+  if (!itemType.IsAnySet(ezAssetBrowserItemFlags::Asset | ezAssetBrowserItemFlags::SubAsset))
   {
-    QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin, ItemSideMargin, 0, 0);
-    thumbnailRect.setSize(QSize(uiThumbnailSize, uiThumbnailSize));
-    QPixmap pixmap = qvariant_cast<QPixmap>(index.data(Qt::DecorationRole));
-    pPainter->drawPixmap(thumbnailRect, pixmap);
-  }
-
-  // Draw icon.
-  {
-    QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin - 2, ItemSideMargin + uiThumbnailSize - 16 + 2, 0, 0);
-    thumbnailRect.setSize(QSize(16, 16));
-    QIcon icon = qvariant_cast<QIcon>(index.data(ezQtAssetBrowserModel::UserRoles::AssetIcon));
-    icon.paint(pPainter, thumbnailRect);
-  }
-
-  // Draw Transform State Icon
-  if (m_bDrawTransformState)
-  {
-    QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin + uiThumbnailSize - 16 + 2, ItemSideMargin + uiThumbnailSize - 16 + 2, 0, 0);
-    thumbnailRect.setSize(QSize(16, 16));
-
-    ezAssetInfo::TransformState state = (ezAssetInfo::TransformState)index.data(ezQtAssetBrowserModel::UserRoles::TransformState).toInt();
-
-    switch (state)
+    // Draw icon.
     {
-      case ezAssetInfo::TransformState::Unknown:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetUnknown.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::NeedsThumbnail:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetNeedsThumbnail.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::NeedsTransform:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetNeedsTransform.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::UpToDate:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetOk.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::MissingTransformDependency:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingDependency.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::MissingThumbnailDependency:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingReference.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::CircularDependency:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetFailedTransform.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::TransformError:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetFailedTransform.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::NeedsImport:
-        ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetNeedsImport.svg").paint(pPainter, thumbnailRect);
-        break;
-      case ezAssetInfo::TransformState::COUNT:
-        break;
+      QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin, ItemSideMargin, 0, 0);
+      thumbnailRect.setSize(QSize(uiThumbnailSize, uiThumbnailSize));
+      QIcon icon = qvariant_cast<QIcon>(index.data(ezQtAssetBrowserModel::UserRoles::AssetIcon));
+      icon.paint(pPainter, thumbnailRect);
+    }
+  }
+  else
+  {
+    // Draw thumbnail.
+    {
+      QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin, ItemSideMargin, 0, 0);
+      thumbnailRect.setSize(QSize(uiThumbnailSize, uiThumbnailSize));
+      QPixmap pixmap = qvariant_cast<QPixmap>(index.data(Qt::DecorationRole));
+      pPainter->drawPixmap(thumbnailRect, pixmap);
+    }
+
+    // Draw icon.
+    {
+      QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin - 2, ItemSideMargin + uiThumbnailSize - 16 + 2, 0, 0);
+      thumbnailRect.setSize(QSize(16, 16));
+      QIcon icon = qvariant_cast<QIcon>(index.data(ezQtAssetBrowserModel::UserRoles::AssetIcon));
+      icon.paint(pPainter, thumbnailRect);
+    }
+
+    // Draw Transform State Icon
+    if (m_bDrawTransformState)
+    {
+      QRect thumbnailRect = opt.rect.adjusted(ItemSideMargin + uiThumbnailSize - 16 + 2, ItemSideMargin + uiThumbnailSize - 16 + 2, 0, 0);
+      thumbnailRect.setSize(QSize(16, 16));
+
+      ezAssetInfo::TransformState state = (ezAssetInfo::TransformState)index.data(ezQtAssetBrowserModel::UserRoles::TransformState).toInt();
+
+      switch (state)
+      {
+        case ezAssetInfo::TransformState::Unknown:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetUnknown.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::NeedsThumbnail:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetNeedsThumbnail.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::NeedsTransform:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetNeedsTransform.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::UpToDate:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetOk.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::MissingTransformDependency:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingDependency.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::MissingThumbnailDependency:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingReference.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::CircularDependency:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetFailedTransform.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::TransformError:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetFailedTransform.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::NeedsImport:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetNeedsImport.svg").paint(pPainter, thumbnailRect);
+          break;
+        case ezAssetInfo::TransformState::COUNT:
+          break;
+      }
     }
   }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -1,8 +1,11 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/Assets/AssetBrowserFilter.moc.h>
+#include <EditorFramework/Assets/AssetBrowserFolderView.moc.h>
+#include <EditorFramework/Assets/AssetBrowserModel.moc.h>
 #include <EditorFramework/Assets/AssetBrowserWidget.moc.h>
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocumentGenerator.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <Foundation/Strings/TranslationLookup.h>
@@ -12,7 +15,6 @@
 ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* pParent)
   : QWidget(pParent)
 {
-  m_uiKnownAssetFolderCount = 0;
   m_bDialogMode = false;
 
   setupUi(this);
@@ -25,8 +27,9 @@ ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* pParent)
   TypeFilter->setVisible(bAssetFilterCombobox);
 
   m_pFilter = new ezQtAssetBrowserFilter(this);
-  m_pModel = new ezQtAssetBrowserModel(this, m_pFilter);
+  TreeFolderFilter->SetFilter(m_pFilter);
 
+  m_pModel = new ezQtAssetBrowserModel(this, m_pFilter);
   SearchWidget->setPlaceholderText("Search Assets");
 
   IconSizeSlider->setValue(50);
@@ -50,12 +53,14 @@ ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* pParent)
     ToolBarLayout->insertWidget(0, m_pToolbar);
   }
 
-  TreeFolderFilter->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+
 
   EZ_VERIFY(connect(m_pFilter, SIGNAL(TextFilterChanged()), this, SLOT(OnTextFilterChanged())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pFilter, SIGNAL(TypeFilterChanged()), this, SLOT(OnTypeFilterChanged())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pFilter, SIGNAL(PathFilterChanged()), this, SLOT(OnPathFilterChanged())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pModel, SIGNAL(modelReset()), this, SLOT(OnModelReset())) != nullptr, "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pModel, &ezQtAssetBrowserModel::editingFinished, this, &ezQtAssetBrowserWidget::OnFileEditingFinished, Qt::QueuedConnection), "signal/slot connection failed");
+
   EZ_VERIFY(connect(ListAssets->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this, SLOT(OnAssetSelectionChanged(const QItemSelection&, const QItemSelection&))) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(ListAssets->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this, SLOT(OnAssetSelectionCurrentChanged(const QModelIndex&, const QModelIndex&))) != nullptr, "signal/slot connection failed");
   connect(SearchWidget, &ezQtSearchWidget::textChanged, this, &ezQtAssetBrowserWidget::OnSearchWidgetTextChanged);
@@ -70,6 +75,7 @@ ezQtAssetBrowserWidget::~ezQtAssetBrowserWidget()
 {
   ezToolsProject::s_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetBrowserWidget::ProjectEventHandler, this));
   ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetBrowserWidget::AssetCuratorEventHandler, this));
+
 
   ListAssets->setModel(nullptr);
 }
@@ -126,8 +132,6 @@ void ezQtAssetBrowserWidget::UpdateAssetTypes()
     }
   }
 
-  UpdateDirectoryTree();
-
   // make sure to apply the previously active type filter settings to the UI
   OnTypeFilterChanged();
 }
@@ -137,6 +141,7 @@ void ezQtAssetBrowserWidget::SetDialogMode()
   m_pToolbar->hide();
   m_bDialogMode = true;
 
+  TreeFolderFilter->SetDialogMode(true);
   ListAssets->SetDialogMode(true);
 }
 
@@ -182,9 +187,6 @@ void ezQtAssetBrowserWidget::ProjectEventHandler(const ezToolsProjectEvent& e)
     break;
     case ezToolsProjectEvent::Type::ProjectClosed:
     {
-      // remove project structure from asset browser
-      ClearDirectoryTree();
-
       m_pFilter->Reset();
     }
     break;
@@ -215,7 +217,14 @@ void ezQtAssetBrowserWidget::AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedA
     pMan->GetSupportedDocumentTypes(documentTypes);
   }
 
-  documentTypes.Sort([](const ezDocumentTypeDescriptor* a, const ezDocumentTypeDescriptor* b) -> bool { return ezStringUtils::Compare(ezTranslate(a->m_sDocumentTypeName), ezTranslate(b->m_sDocumentTypeName)) < 0; });
+  documentTypes.Sort([](const ezDocumentTypeDescriptor* a, const ezDocumentTypeDescriptor* b) -> bool
+    { return ezStringUtils::Compare(ezTranslate(a->m_sDocumentTypeName), ezTranslate(b->m_sDocumentTypeName)) < 0; });
+
+  QAction* pAction = pSubMenu->addAction(ezTranslate("Folder"));
+  pAction->setIcon(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/Folder.svg"));
+  connect(pAction, &QAction::triggered, static_cast<eqQtAssetBrowserFolderView*>(TreeFolderFilter), &eqQtAssetBrowserFolderView::OnNewFolder);
+
+  pSubMenu->addSeparator();
 
   for (const ezDocumentTypeDescriptor* desc : documentTypes)
   {
@@ -233,6 +242,58 @@ void ezQtAssetBrowserWidget::AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedA
   }
 }
 
+
+void ezQtAssetBrowserWidget::AddImportedViaMenu(QMenu* pMenu)
+{
+  QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
+
+  // Find all uses
+  ezSet<ezUuid> importedVia;
+  for (const QModelIndex& id : selection)
+  {
+    const bool bImportable = id.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+    if (!bImportable)
+      continue;
+
+    ezString sAbsPath = qtToEzString(m_pModel->data(id, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+    ezAssetCurator::GetSingleton()->FindAllUses(sAbsPath, importedVia);
+  }
+
+  // Sort by path
+  ezHybridArray<ezUuid, 8> importedViaSorted;
+  {
+    importedViaSorted.Reserve(importedVia.GetCount());
+    ezAssetCurator::ezLockedSubAssetTable allAssets = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
+    for (const ezUuid& guid : importedVia)
+    {
+      if (allAssets->Contains(guid))
+        importedViaSorted.PushBack(guid);
+    }
+
+    importedViaSorted.Sort([&](const ezUuid& a, const ezUuid& b) -> bool
+      { return allAssets->Find(a).Value().m_pAssetInfo->m_Path.GetDataDirParentRelativePath().Compare(allAssets->Find(b).Value().m_pAssetInfo->m_Path.GetDataDirParentRelativePath()) < 0; });
+  }
+
+  if (importedViaSorted.IsEmpty())
+    return;
+
+  // Create actions to open
+  QMenu* pSubMenu = pMenu->addMenu("Imported via");
+  pSubMenu->setIcon(QIcon(QLatin1String(":/GuiFoundation/Icons/Import.svg")));
+
+  for (const ezUuid& guid : importedViaSorted)
+  {
+    const ezAssetCurator::ezLockedSubAsset pSubAsset = ezAssetCurator::GetSingleton()->GetSubAsset(guid);
+    QIcon icon = ezQtUiServices::GetCachedIconResource(pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor->m_sIcon, ezColorScheme::GetCategoryColor(pSubAsset->m_pAssetInfo->m_pDocumentTypeDescriptor->m_sAssetCategory, ezColorScheme::CategoryColorUsage::OverlayIcon));
+    QString sRelPath = ezMakeQString(pSubAsset->m_pAssetInfo->m_Path.GetDataDirParentRelativePath());
+
+    QAction* pAction = pSubMenu->addAction(sRelPath);
+    pAction->setIcon(icon);
+    pAction->setProperty("AbsPath", ezMakeQString(pSubAsset->m_pAssetInfo->m_Path.GetAbsolutePath()));
+    connect(pAction, &QAction::triggered, this, &ezQtAssetBrowserWidget::OnOpenImportReferenceAsset);
+  }
+}
+
 void ezQtAssetBrowserWidget::on_ListAssets_clicked(const QModelIndex& index)
 {
   Q_EMIT ItemSelected(m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>(), m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(), m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
@@ -245,14 +306,26 @@ void ezQtAssetBrowserWidget::on_ListAssets_activated(const QModelIndex& index)
 
 void ezQtAssetBrowserWidget::on_ListAssets_doubleClicked(const QModelIndex& index)
 {
-  ezUuid guid = m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>();
+  const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+  const ezUuid guid = m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>();
 
-  if (guid.IsValid())
+  if (itemType.IsAnySet(ezAssetBrowserItemFlags::Asset | ezAssetBrowserItemFlags::SubAsset))
   {
-    ezAssetCurator::GetSingleton()->UpdateAssetLastAccessTime(guid);
+    if (guid.IsValid())
+    {
+      ezAssetCurator::GetSingleton()->UpdateAssetLastAccessTime(guid);
+    }
+    Q_EMIT ItemChosen(guid, m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(), m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
   }
-
-  Q_EMIT ItemChosen(guid, m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString(), m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+  else if (itemType.IsSet(ezAssetBrowserItemFlags::File))
+  {
+    QString sAbsPath = m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+    ezQtUiServices::OpenFileInDefaultProgram(qtToEzString(sAbsPath));
+  }
+  else if (itemType.IsAnySet(ezAssetBrowserItemFlags::Folder | ezAssetBrowserItemFlags::DataDirectory))
+  {
+    m_pFilter->SetPathFilter(m_pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString().toUtf8().data());
+  }
 }
 
 void ezQtAssetBrowserWidget::on_ButtonListMode_clicked()
@@ -353,6 +426,10 @@ void ezQtAssetBrowserWidget::OnTypeFilterChanged()
   QTimer::singleShot(0, this, SLOT(OnSelectionTimer()));
 }
 
+void ezQtAssetBrowserWidget::OnPathFilterChanged()
+{
+  QTimer::singleShot(0, this, SLOT(OnSelectionTimer()));
+}
 
 void ezQtAssetBrowserWidget::OnSearchWidgetTextChanged(const QString& text)
 {
@@ -431,6 +508,53 @@ void ezQtAssetBrowserWidget::on_ListTypeFilter_itemChanged(QListWidgetItem* item
   m_pFilter->SetTypeFilter(sFilter);
 }
 
+void ezQtAssetBrowserWidget::keyPressEvent(QKeyEvent* e)
+{
+  QWidget::keyPressEvent(e);
+
+  if (e->key() == Qt::Key_Delete && !m_bDialogMode)
+  {
+    e->accept();
+    QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
+    for (const QModelIndex& id : selection)
+    {
+      const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)id.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+      if (itemType.IsAnySet(ezAssetBrowserItemFlags::SubAsset | ezAssetBrowserItemFlags::DataDirectory))
+      {
+        ezQtUiServices::MessageBoxWarning(ezFmt("Sub-assets and data directories can't be deleted."));
+        return;
+      }
+    }
+
+    QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Do you want to permanently delete the selected items?"), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
+    if (choice == QMessageBox::StandardButton::Cancel)
+      return;
+
+    for (const QModelIndex& id : selection)
+    {
+      const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)id.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+      QString sQtAbsPath = id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+      ezString sAbsPath = qtToEzString(sQtAbsPath);
+
+      if (itemType.IsSet(ezAssetBrowserItemFlags::File))
+      {
+        if (ezOSFile::DeleteFile(sAbsPath).Failed())
+        {
+          ezLog::Error("Failed to delete file '{}'", sAbsPath);
+        }
+      }
+      else
+      {
+        if (ezOSFile::DeleteFolder(sAbsPath).Failed())
+        {
+          ezLog::Error("Failed to delete folder '{}'", sAbsPath);
+        }
+      }
+      ezFileSystemModel::GetSingleton()->NotifyOfChange(sAbsPath);
+    }
+  }
+}
+
 void ezQtAssetBrowserWidget::AssetCuratorEventHandler(const ezAssetCuratorEvent& e)
 {
   switch (e.m_Type)
@@ -438,143 +562,32 @@ void ezQtAssetBrowserWidget::AssetCuratorEventHandler(const ezAssetCuratorEvent&
     case ezAssetCuratorEvent::Type::AssetListReset:
       UpdateAssetTypes();
       break;
-    case ezAssetCuratorEvent::Type::AssetAdded:
-    case ezAssetCuratorEvent::Type::AssetRemoved:
-      UpdateDirectoryTree();
-      break;
     default:
       break;
   }
 }
 
-void ezQtAssetBrowserWidget::UpdateDirectoryTree()
-{
-  ezQtScopedBlockSignals block(TreeFolderFilter);
-
-  if (TreeFolderFilter->topLevelItemCount() == 0)
-  {
-    QTreeWidgetItem* pNewParent = new QTreeWidgetItem();
-    pNewParent->setText(0, QLatin1String("<root>"));
-
-    TreeFolderFilter->addTopLevelItem(pNewParent);
-
-    pNewParent->setExpanded(true);
-  }
-
-  auto Folders = ezFileSystemModel::GetSingleton()->GetFolders();
-
-  if (m_uiKnownAssetFolderCount == Folders->GetCount())
-    return;
-
-  m_uiKnownAssetFolderCount = Folders->GetCount();
-
-  ezStringBuilder tmp;
-
-  for (const auto& sDir : *Folders)
-  {
-    tmp = sDir.Key();
-
-    if (!ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(tmp))
-      continue;
-
-    BuildDirectoryTree(tmp, TreeFolderFilter->topLevelItem(0), "", false);
-  }
-
-  TreeFolderFilter->setSortingEnabled(true);
-  TreeFolderFilter->sortItems(0, Qt::SortOrder::AscendingOrder);
-}
-
-
-void ezQtAssetBrowserWidget::ClearDirectoryTree()
-{
-  TreeFolderFilter->clear();
-  m_uiKnownAssetFolderCount = 0;
-}
-
-void ezQtAssetBrowserWidget::BuildDirectoryTree(const char* szCurPath, QTreeWidgetItem* pParent, const char* szCurPathToItem, bool bIsHidden)
-{
-  if (ezStringUtils::IsNullOrEmpty(szCurPath))
-    return;
-
-  const char* szNextSep = ezStringUtils::FindSubString(szCurPath, "/");
-
-  QTreeWidgetItem* pNewParent = nullptr;
-
-  ezString sFolderName;
-
-  if (szNextSep == nullptr)
-    sFolderName = szCurPath;
-  else
-    sFolderName = ezStringView(szCurPath, szNextSep);
-
-  if (sFolderName.EndsWith_NoCase("_data"))
-  {
-    bIsHidden = true;
-  }
-
-  ezStringBuilder sCurPath = szCurPathToItem;
-  sCurPath.AppendPath(sFolderName);
-
-  const QString sQtFolderName = QString::fromUtf8(sFolderName.GetData());
-
-  for (ezInt32 i = 0; i < pParent->childCount(); ++i)
-  {
-    if (pParent->child(i)->text(0) == sQtFolderName)
-    {
-      // item already exists
-      pNewParent = pParent->child(i);
-      goto godown;
-    }
-  }
-
-  pNewParent = new QTreeWidgetItem();
-  pNewParent->setText(0, sQtFolderName);
-  pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath, QString::fromUtf8(sCurPath.GetData()));
-
-  if (bIsHidden)
-  {
-    pNewParent->setForeground(0, QColor::fromRgba(qRgb(110, 110, 120)));
-  }
-
-  pParent->addChild(pNewParent);
-
-godown:
-
-  if (szNextSep == nullptr)
-    return;
-
-  BuildDirectoryTree(szNextSep + 1, pNewParent, sCurPath, bIsHidden);
-}
-
-void ezQtAssetBrowserWidget::on_TreeFolderFilter_itemSelectionChanged()
-{
-  if (m_bTreeSelectionChangeInProgress)
-    return;
-
-  ezStringBuilder sCurPath;
-
-  if (!TreeFolderFilter->selectedItems().isEmpty())
-  {
-    sCurPath = TreeFolderFilter->selectedItems()[0]->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
-  }
-
-  m_pFilter->SetPathFilter(sCurPath);
-}
-
 void ezQtAssetBrowserWidget::on_TreeFolderFilter_customContextMenuRequested(const QPoint& pt)
 {
+  // #TODO_PATH folder
   QMenu m;
   m.setToolTipsVisible(true);
 
   if (TreeFolderFilter->currentItem())
   {
-    m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder.svg")), QLatin1String("Open in Explorer"), this, SLOT(OnTreeOpenExplorer()));
+    m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder.svg")), QLatin1String("Open in Explorer"), TreeFolderFilter, SLOT(OnTreeOpenExplorer()));
   }
 
   {
     QAction* pAction = m.addAction(QLatin1String("Show Items in sub-folders"), this, SLOT(OnShowSubFolderItemsToggled()));
     pAction->setCheckable(true);
     pAction->setChecked(m_pFilter->GetShowItemsInSubFolders());
+  }
+
+  {
+    QAction* pAction = m.addAction(QLatin1String("Show files and folders"), this, SLOT(OnShowFilesAndFoldersToggled()));
+    pAction->setCheckable(true);
+    pAction->setChecked(m_pFilter->GetShowFilesAndFolders());
   }
 
   {
@@ -613,26 +626,19 @@ void ezQtAssetBrowserWidget::OnShowSubFolderItemsToggled()
   m_pFilter->SetShowItemsInSubFolders(!m_pFilter->GetShowItemsInSubFolders());
 }
 
+void ezQtAssetBrowserWidget::OnShowFilesAndFoldersToggled()
+{
+  m_pFilter->SetShowFilesAndFolders(!m_pFilter->GetShowFilesAndFolders());
+}
+
 void ezQtAssetBrowserWidget::OnShowHiddenFolderItemsToggled()
 {
   m_pFilter->SetShowItemsInHiddenFolders(!m_pFilter->GetShowItemsInHiddenFolders());
 }
 
-void ezQtAssetBrowserWidget::OnTreeOpenExplorer()
-{
-  if (!TreeFolderFilter->currentItem())
-    return;
-
-  ezStringBuilder sPath = TreeFolderFilter->currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
-
-  if (!ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(sPath, true))
-    return;
-
-  ezQtUiServices::OpenInExplorer(sPath, false);
-}
-
 void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoint& pt)
 {
+  // #TODO_PATH file
   QMenu m;
   m.setToolTipsVisible(true);
 
@@ -647,8 +653,10 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
 
     m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder.svg")), QLatin1String("Open in Explorer"), this, SLOT(OnListOpenExplorer()));
     m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Guid.svg")), QLatin1String("Copy Asset Guid"), this, SLOT(OnListCopyAssetGuid()));
-    m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Search.svg")), QLatin1String("Find all direct references to this asset"), this, [&]() { OnListFindAllReferences(false); });
-    m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Search.svg")), QLatin1String("Find all direct and indirect references to this asset"), this, [&]() { OnListFindAllReferences(true); });
+    m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Search.svg")), QLatin1String("Find all direct references to this asset"), this, [&]()
+      { OnListFindAllReferences(false); });
+    m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Search.svg")), QLatin1String("Find all direct and indirect references to this asset"), this, [&]()
+      { OnListFindAllReferences(true); });
     m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/ZoomOut.svg")), QLatin1String("Filter to this Path"), this, SLOT(OnFilterToThisPath()));
   }
 
@@ -656,6 +664,27 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
   pSortAction->setCheckable(true);
   pSortAction->setChecked(m_pFilter->GetSortByRecentUse());
 
+  // Import assets
+  if (!m_bDialogMode && ListAssets->selectionModel()->hasSelection())
+  {
+    QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
+    bool bImportable = false;
+    for (const QModelIndex& id : selection)
+    {
+      bImportable = id.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+      if (bImportable)
+        break;
+    }
+
+    if (bImportable)
+    {
+      m.addSeparator();
+      m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Import.svg")), QLatin1String("Import..."), this, SLOT(OnImport()));
+      AddImportedViaMenu(&m);
+    }
+  }
+
+  m.addSeparator();
   AddAssetCreatorMenu(&m, true);
 
   m.exec(ListAssets->viewport()->mapToGlobal(pt));
@@ -739,12 +768,9 @@ void ezQtAssetBrowserWidget::OnFilterToThisPath()
   if (!ListAssets->selectionModel()->hasSelection())
     return;
 
-  ezStringBuilder sPath = m_pModel->data(ListAssets->currentIndex(), ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
+  ezStringBuilder sPath = m_pModel->data(ListAssets->currentIndex(), ezQtAssetBrowserModel::UserRoles::RelativePath).toString().toUtf8().data();
   sPath.PathParentDirectory();
   sPath.Trim("/");
-
-  if (!ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sPath))
-    return;
 
   m_pFilter->SetPathFilter(sPath);
 }
@@ -828,10 +854,7 @@ void ezQtAssetBrowserWidget::OnNewAsset()
   {
     if (TreeFolderFilter->currentItem())
     {
-      ezStringBuilder sPath = TreeFolderFilter->currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
-
-      if (!sPath.IsEmpty() && ezQtEditorApp::GetSingleton()->MakeParentDataDirectoryRelativePathAbsolute(sPath, true))
-        sStartDir = sPath.GetData();
+      sStartDir = TreeFolderFilter->currentItem()->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
     }
 
     // this will take precedence
@@ -839,7 +862,7 @@ void ezQtAssetBrowserWidget::OnNewAsset()
     {
       ezString sPath = m_pModel->data(ListAssets->currentIndex(), ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
 
-      if (!sPath.IsEmpty() && ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sPath))
+      if (!sPath.IsEmpty())
       {
         ezStringBuilder temp = sPath;
         sPath = temp.GetFileDirectory();
@@ -849,21 +872,137 @@ void ezQtAssetBrowserWidget::OnNewAsset()
     }
   }
 
-  ezStringBuilder title("Create ", sTranslateAssetType), sFilter;
+  //
+  ezStringBuilder sNewAsset = qtToEzString(sStartDir);
+  ezStringBuilder sBaseFileName;
+  ezPathUtils::MakeValidFilename(sTranslateAssetType, ' ', sBaseFileName);
+  sNewAsset.AppendFormat("/{}.{}", sBaseFileName, sExtension);
 
-  sFilter.Format("{0} (*.{1})", sTranslateAssetType, sExtension);
-
-  QString sSelectedFilter = sFilter.GetData();
-  ezStringBuilder sOutput = QFileDialog::getSaveFileName(QApplication::activeWindow(), title.GetData(), sStartDir, sFilter.GetData(), &sSelectedFilter, QFileDialog::Option::DontResolveSymlinks).toUtf8().data();
-
-  if (sOutput.IsEmpty())
-    return;
+  for (ezUInt32 i = 0; ezOSFile::ExistsFile(sNewAsset); i++)
+  {
+    sNewAsset = qtToEzString(sStartDir);
+    sNewAsset.AppendFormat("/{}{}.{}", sBaseFileName, i, sExtension);
+  }
 
   ezDocument* pDoc;
-  if (pManager->CreateDocument(sAssetType, sOutput, pDoc, ezDocumentFlags::RequestWindow | ezDocumentFlags::AddToRecentFilesList).m_Result.Succeeded())
+  if (pManager->CreateDocument(sAssetType, sNewAsset, pDoc, ezDocumentFlags::Default).m_Result.Failed())
   {
-    pDoc->EnsureVisible();
+    ezLog::Error("Failed to create document: {}", sNewAsset);
+    return;
   }
+
+  {
+    ezStringBuilder sRelativePath = sNewAsset;
+    if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sRelativePath))
+    {
+      m_pFilter->SetTemporaryPinnedItem(sRelativePath);
+    }
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sNewAsset);
+    m_pModel->OnFileSystemUpdate();
+  }
+
+  ezInt32 iNewIndex = m_pModel->FindIndex(sNewAsset);
+  if (iNewIndex != -1)
+  {
+    m_bOpenAfterRename = true;
+    QModelIndex idx = m_pModel->index(iNewIndex, 0);
+    ListAssets->selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+    ListAssets->selectionModel()->setCurrentIndex(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+    ListAssets->scrollTo(idx, QAbstractItemView::ScrollHint::EnsureVisible);
+    ListAssets->edit(idx);
+  }
+}
+
+
+void ezQtAssetBrowserWidget::OnFileEditingFinished(const QString& sAbsPath, const QString& sNewName, bool bIsAsset)
+{
+  ezStringBuilder sOldPath = qtToEzString(sAbsPath);
+  ezStringBuilder sNewPath = sOldPath;
+  if (bIsAsset)
+    sNewPath.ChangeFileName(qtToEzString(sNewName));
+  else
+    sNewPath.ChangeFileNameAndExtension(qtToEzString(sNewName));
+
+  if (sOldPath != sNewPath)
+  {
+    if (ezOSFile::MoveFileOrDirectory(sOldPath, sNewPath).Failed())
+    {
+      ezLog::Error("Failed to rename '{}' to '{}'", sOldPath, sNewPath);
+      return;
+    }
+
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sNewPath);
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sOldPath);
+
+    // If we have a temporary item, make sure that any renames ensure that the item is still set as the new temporary
+    // A common case is: a type filter is active that excludes a newly created asset. Thus, on creation the new asset is set as the pinned item. Editing of the item is started and the user gives it a new name and we end up here. We want the item to remain pinned.
+    if (!m_pFilter->GetTemporaryPinnedItem().IsEmpty())
+    {
+      ezStringBuilder sOldRelativePath = sOldPath;
+      ezStringBuilder sNewRelativePath = sNewPath;
+      if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sOldRelativePath) && ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(sNewRelativePath))
+      {
+        if (sOldRelativePath == m_pFilter->GetTemporaryPinnedItem())
+        {
+          m_pFilter->SetTemporaryPinnedItem(sNewRelativePath);
+        }
+      }
+    }
+    m_pModel->OnFileSystemUpdate();
+
+    ezInt32 iNewIndex = m_pModel->FindIndex(sNewPath);
+    if (iNewIndex != -1)
+    {
+      QModelIndex idx = m_pModel->index(iNewIndex, 0);
+      ListAssets->selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+      ListAssets->selectionModel()->setCurrentIndex(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+      ListAssets->scrollTo(idx, QAbstractItemView::ScrollHint::EnsureVisible);
+    }
+  }
+
+  if (m_bOpenAfterRename)
+  {
+    m_bOpenAfterRename = false;
+    ezInt32 iNewIndex = m_pModel->FindIndex(sNewPath);
+    if (iNewIndex != -1)
+    {
+      QModelIndex idx = m_pModel->index(iNewIndex, 0);
+      on_ListAssets_doubleClicked(idx);
+    }
+  }
+}
+
+
+void ezQtAssetBrowserWidget::OnImport()
+{
+  ezHybridArray<ezString, 4> filesToImport;
+  QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
+  for (const QModelIndex& id : selection)
+  {
+    const bool bImportable = id.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+    if (bImportable)
+    {
+      filesToImport.PushBack(qtToEzString(id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString()));
+    }
+  }
+  if (filesToImport.IsEmpty())
+    return;
+
+  ezAssetDocumentGenerator::ImportAssets(filesToImport);
+
+  for (const QModelIndex& id : selection)
+  {
+    Q_EMIT m_pModel->dataChanged(id, id);
+  }
+}
+
+
+void ezQtAssetBrowserWidget::OnOpenImportReferenceAsset()
+{
+  QAction* pSender = qobject_cast<QAction*>(sender());
+  ezString sAbsPath = qtToEzString(pSender->property("AbsPath").toString());
+
+  ezQtEditorApp::GetSingleton()->OpenDocument(sAbsPath, ezDocumentFlags::RequestWindow | ezDocumentFlags::AddToRecentFilesList);
 }
 
 void ezQtAssetBrowserWidget::OnListToggleSortByRecentlyUsed()
@@ -871,43 +1010,6 @@ void ezQtAssetBrowserWidget::OnListToggleSortByRecentlyUsed()
   m_pFilter->SetSortByRecentUse(!m_pFilter->GetSortByRecentUse());
 }
 
-void ezQtAssetBrowserWidget::OnPathFilterChanged()
-{
-  const QString sPath = QString::fromUtf8(m_pFilter->GetPathFilter());
-
-  if (TreeFolderFilter->topLevelItemCount() == 1)
-  {
-    if (m_bTreeSelectionChangeInProgress)
-      return;
-
-    m_bTreeSelectionChangeInProgress = true;
-    TreeFolderFilter->clearSelection();
-    SelectPathFilter(TreeFolderFilter->topLevelItem(0), sPath);
-    m_bTreeSelectionChangeInProgress = false;
-  }
-
-  QTimer::singleShot(0, this, SLOT(OnSelectionTimer()));
-}
-
-bool ezQtAssetBrowserWidget::SelectPathFilter(QTreeWidgetItem* pParent, const QString& sPath)
-{
-  if (pParent->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString() == sPath)
-  {
-    pParent->setSelected(true);
-    return true;
-  }
-
-  for (ezInt32 i = 0; i < pParent->childCount(); ++i)
-  {
-    if (SelectPathFilter(pParent->child(i), sPath))
-    {
-      pParent->setExpanded(true);
-      return true;
-    }
-  }
-
-  return false;
-}
 
 void ezQtAssetBrowserWidget::SetSelectedAsset(ezUuid preselectedAsset)
 {
@@ -924,10 +1026,12 @@ void ezQtAssetBrowserWidget::OnScrollToItem(ezUuid preselectedAsset)
 {
   for (ezInt32 i = 0; i < m_pModel->rowCount(); ++i)
   {
-    if (m_pModel->data(m_pModel->index(i, 0), ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>() == preselectedAsset)
+    QModelIndex idx = m_pModel->index(i, 0);
+    if (m_pModel->data(idx, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>() == preselectedAsset)
     {
-      ListAssets->selectionModel()->select(m_pModel->index(i, 0), QItemSelectionModel::SelectionFlag::ClearAndSelect);
-      ListAssets->scrollTo(m_pModel->index(i, 0), QAbstractItemView::ScrollHint::EnsureVisible);
+      ListAssets->selectionModel()->select(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+      ListAssets->selectionModel()->setCurrentIndex(idx, QItemSelectionModel::SelectionFlag::ClearAndSelect);
+      ListAssets->scrollTo(idx, QAbstractItemView::ScrollHint::EnsureVisible);
       return;
     }
   }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -135,6 +135,9 @@ void ezQtAssetBrowserWidget::UpdateAssetTypes()
   }
 
   // make sure to apply the previously active type filter settings to the UI
+  ezSet<ezString> importExtensions;
+  ezAssetDocumentGenerator::GetSupportsFileTypes(importExtensions);
+  m_pFilter->UpdateImportExtensions(importExtensions);
   OnTypeFilterChanged();
 }
 
@@ -594,9 +597,15 @@ void ezQtAssetBrowserWidget::on_TreeFolderFilter_customContextMenuRequested(cons
   }
 
   {
-    QAction* pAction = m.addAction(QLatin1String("Show files and folders"), this, SLOT(OnShowFilesAndFoldersToggled()));
+    QAction* pAction = m.addAction(QLatin1String("Show files"), this, SLOT(OnShowFilesToggled()));
     pAction->setCheckable(true);
-    pAction->setChecked(m_pFilter->GetShowFilesAndFolders());
+    pAction->setChecked(m_pFilter->GetShowFiles());
+  }
+
+  {
+    QAction* pAction = m.addAction(QLatin1String("Show non-importable files"), this, SLOT(OnShowNonImportableFilesToggled()));
+    pAction->setCheckable(true);
+    pAction->setChecked(m_pFilter->GetShowNonImportableFiles());
   }
 
   {
@@ -649,9 +658,14 @@ void ezQtAssetBrowserWidget::OnShowSubFolderItemsToggled()
   m_pFilter->SetShowItemsInSubFolders(!m_pFilter->GetShowItemsInSubFolders());
 }
 
-void ezQtAssetBrowserWidget::OnShowFilesAndFoldersToggled()
+void ezQtAssetBrowserWidget::OnShowFilesToggled()
 {
-  m_pFilter->SetShowFilesAndFolders(!m_pFilter->GetShowFilesAndFolders());
+  m_pFilter->SetShowFiles(!m_pFilter->GetShowFiles());
+}
+
+void ezQtAssetBrowserWidget::OnShowNonImportableFilesToggled()
+{
+  m_pFilter->SetShowNonImportableFiles(!m_pFilter->GetShowNonImportableFiles());
 }
 
 void ezQtAssetBrowserWidget::OnShowHiddenFolderItemsToggled()

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1061,6 +1061,25 @@ void ezAssetCurator::FindAllUses(ezUuid assetGuid, ezSet<ezUuid>& ref_uses, bool
   } while (bTransitive && !todoList.IsEmpty());
 }
 
+void ezAssetCurator::FindAllUses(ezStringView sAbsolutePath, ezSet<ezUuid>& ref_uses) const
+{
+  EZ_LOCK(m_CuratorMutex);
+  if (auto it = m_InverseTransformDeps.Find(sAbsolutePath); it.IsValid())
+  {
+    for (const ezUuid& guid : it.Value())
+    {
+      ref_uses.Insert(guid);
+    }
+  }
+}
+
+bool ezAssetCurator::IsReferenced(ezStringView sAbsolutePath) const
+{
+  EZ_LOCK(m_CuratorMutex);
+  auto it = m_InverseTransformDeps.Find(sAbsolutePath);
+  return it.IsValid() && !it.Value().IsEmpty();
+}
+
 ////////////////////////////////////////////////////////////////////////
 // ezAssetCurator Manual and Automatic Change Notification
 ////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -20,6 +20,15 @@ void ezAssetDocumentGenerator::AddSupportedFileType(ezStringView sExtension)
   m_SupportedFileTypes.PushBack(tmp);
 }
 
+
+void ezAssetDocumentGenerator::GetSupportedFileTypes(ezSet<ezString>& ref_extensions) const
+{
+  for (const ezString& ext : m_SupportedFileTypes)
+  {
+    ref_extensions.Insert(ext);
+  }
+}
+
 bool ezAssetDocumentGenerator::SupportsFileType(ezStringView sFile) const
 {
   ezStringBuilder tmp = ezPathUtils::GetFileExtension(sFile);
@@ -38,7 +47,7 @@ void ezAssetDocumentGenerator::BuildFileDialogFilterString(ezStringBuilder& out_
 
 void ezAssetDocumentGenerator::AppendFileFilterStrings(ezStringBuilder& out_sFilter, bool& ref_bSemicolon) const
 {
-  for (const ezString ext : m_SupportedFileTypes)
+  for (const ezString& ext : m_SupportedFileTypes)
   {
     ezStringBuilder extWithStarDot;
     extWithStarDot.AppendFormat("*.{0}", ext);
@@ -167,7 +176,7 @@ ezResult ezAssetDocumentGenerator::DetermineInputAndOutputFiles(ImportData& data
   return EZ_SUCCESS;
 }
 
-void ezAssetDocumentGenerator::ImportAssets(const ezHybridArray<ezString, 16>& filesToImport)
+void ezAssetDocumentGenerator::ImportAssets(const ezDynamicArray<ezString>& filesToImport)
 {
   ezHybridArray<ezAssetDocumentGenerator*, 16> generators;
   CreateGenerators(generators);
@@ -182,6 +191,19 @@ void ezAssetDocumentGenerator::ImportAssets(const ezHybridArray<ezString, 16>& f
   ezQtAssetImportDlg dlg(QApplication::activeWindow(), allImports);
   dlg.exec();
 
+  DestroyGenerators(generators);
+}
+
+void ezAssetDocumentGenerator::GetSupportsFileTypes(ezSet<ezString>& out_extensions)
+{
+  out_extensions.Clear();
+
+  ezHybridArray<ezAssetDocumentGenerator*, 16> generators;
+  CreateGenerators(generators);
+  for (auto pGen : generators)
+  {
+    pGen->GetSupportedFileTypes(out_extensions);
+  }
   DestroyGenerators(generators);
 }
 
@@ -229,7 +251,7 @@ void ezAssetDocumentGenerator::ImportAssets()
   ImportAssets(filesToImport);
 }
 
-void ezAssetDocumentGenerator::CreateImportOptionList(const ezHybridArray<ezString, 16>& filesToImport,
+void ezAssetDocumentGenerator::CreateImportOptionList(const ezDynamicArray<ezString>& filesToImport,
   ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators)
 {
   ezQtEditorApp* pApp = ezQtEditorApp::GetSingleton();

--- a/Code/Editor/EditorFramework/DragDrop/AssetDragDropHandler.cpp
+++ b/Code/Editor/EditorFramework/DragDrop/AssetDragDropHandler.cpp
@@ -18,18 +18,15 @@ ezString ezAssetDragDropHandler::GetAssetGuidString(const ezDragDropInfo* pInfo)
   QByteArray ba = pInfo->m_pMimeData->data("application/ezEditor.AssetGuid");
   QDataStream stream(&ba, QIODevice::ReadOnly);
 
-  int iGuids = 0;
-  stream >> iGuids;
+  ezHybridArray<QString, 1> guids;
+  stream >> guids;
 
-  if (iGuids > 1)
+  if (guids.GetCount() > 1)
   {
     ezLog::Warning("Dragging more than one asset type is currently not supported");
   }
 
-  QString sGuid;
-  stream >> sGuid;
-
-  return sGuid.toUtf8().data();
+  return guids[0].toUtf8().data();
 }
 
 ezString ezAssetDragDropHandler::GetAssetsDocumentTypeName(const ezUuid& assetTypeGuid) const

--- a/Code/Editor/EditorFramework/DragDrop/DragDropInfo.h
+++ b/Code/Editor/EditorFramework/DragDrop/DragDropInfo.h
@@ -66,12 +66,3 @@ public:
   /// Whether the currently selected objects (ie the dragged objects) should be considered for picking or not. Default is disabled.
   bool m_bPickSelectedObjects;
 };
-
-/// \brief Helper operator to retrieve the "application/ezEditor.ObjectSelection" mime data from a ezDragDropInfo::m_pMimeData.
-/// \code{.cpp}
-///   ezHybridArray<const ezDocumentObject*, 32> Dragged;
-///   QByteArray encodedData = m_pMimeData->data("application/ezEditor.ObjectSelection");
-///   QDataStream stream(&encodedData, QIODevice::ReadOnly);
-///   stream >> Dragged;
-/// \endcode
-EZ_EDITORFRAMEWORK_DLL void operator>>(QDataStream& inout_stream, ezDynamicArray<ezDocumentObject*>& rhs);

--- a/Code/Editor/EditorFramework/DragDrop/Implementation/DragDropInfo.cpp
+++ b/Code/Editor/EditorFramework/DragDrop/Implementation/DragDropInfo.cpp
@@ -23,23 +23,3 @@ ezDragDropConfig::ezDragDropConfig()
 {
   m_bPickSelectedObjects = false;
 }
-
-void operator>>(QDataStream& inout_stream, ezDynamicArray<ezDocumentObject*>& rhs)
-{
-  int iIndices = 0;
-  inout_stream >> iIndices;
-  rhs.Clear();
-  rhs.Reserve(static_cast<ezUInt32>(iIndices));
-
-  for (int i = 0; i < iIndices; ++i)
-  {
-    void* p = nullptr;
-
-    uint len = sizeof(void*);
-    inout_stream.readRawData((char*)&p, len);
-
-    ezDocumentObject* pDocObject = (ezDocumentObject*)p;
-
-    rhs.PushBack(pDocObject);
-  }
-}

--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeModel.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeModel.cpp
@@ -599,30 +599,21 @@ QMimeData* ezQtDocumentTreeModel::mimeData(const QModelIndexList& indexes) const
   if (!m_bAllowDragDrop)
     return nullptr;
 
-  QMimeData* mimeData = new QMimeData();
-  QByteArray encodedData;
-
-  QDataStream stream(&encodedData, QIODevice::WriteOnly);
-
-  int iCount = 0;
-
-  foreach (QModelIndex index, indexes)
-  {
-    if (index.isValid())
-      ++iCount;
-  }
-
-  stream << iCount;
-
-  foreach (QModelIndex index, indexes)
+  ezHybridArray<void*, 1> ptrs;
+  for (const QModelIndex& index : indexes)
   {
     if (index.isValid())
     {
       void* pObject = index.internalPointer();
-      stream.writeRawData((const char*)&pObject, sizeof(void*));
+      ptrs.PushBack(pObject);
     }
   }
 
+  QByteArray encodedData;
+  QDataStream stream(&encodedData, QIODevice::WriteOnly);
+  stream << ptrs;
+
+  QMimeData* mimeData = new QMimeData();
   mimeData->setData("application/ezEditor.ObjectSelection", encodedData);
   return mimeData;
 }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
@@ -18,8 +18,7 @@ public:
   void SetFilterTransitive(bool bFilterTransitive);
 
 public:
-  virtual bool IsAssetFiltered(const ezSubAsset* pInfo) const override;
-  virtual bool Less(const ezSubAsset* pInfoA, const ezSubAsset* pInfoB) const override;
+  virtual bool IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const override;
 
   bool m_bFilterTransitive = true;
 };

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -16,8 +16,11 @@ void ezQtAssetCuratorFilter::SetFilterTransitive(bool bFilterTransitive)
   m_bFilterTransitive = bFilterTransitive;
 }
 
-bool ezQtAssetCuratorFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
+bool ezQtAssetCuratorFilter::IsAssetFiltered(ezStringView sDataDirParentRelativePath, bool bIsFolder, const ezSubAsset* pInfo) const
 {
+  if (!pInfo)
+    return true;
+
   if (!pInfo->m_bMainAsset)
     return true;
 
@@ -44,23 +47,6 @@ bool ezQtAssetCuratorFilter::IsAssetFiltered(const ezSubAsset* pInfo) const
   }
 
   return false;
-}
-
-bool ezQtAssetCuratorFilter::Less(const ezSubAsset* pInfoA, const ezSubAsset* pInfoB) const
-{
-  // TODO: We can't sort on mutable data here as it destroys the set order, need to add a sorting model on top.
-  // if (pInfoA->m_pAssetInfo->m_TransformState != pInfoB->m_pAssetInfo->m_TransformState)
-  //  return pInfoA->m_pAssetInfo->m_TransformState < pInfoB->m_pAssetInfo->m_TransformState;
-
-  ezStringView sSortA = pInfoA->GetName();
-  ezStringView sSortB = pInfoB->GetName();
-
-  ezInt32 iValue = ezStringUtils::Compare_NoCase(sSortA.GetStartPointer(), sSortB.GetStartPointer(), sSortA.GetEndPointer(), sSortB.GetEndPointer());
-  if (iValue == 0)
-  {
-    return pInfoA->m_Data.m_Guid < pInfoB->m_Data.m_Guid;
-  }
-  return iValue < 0;
 }
 
 EZ_IMPLEMENT_SINGLETON(ezQtAssetCuratorPanel);

--- a/Code/Editor/EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h
@@ -4,12 +4,15 @@
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
 #include <QLineEdit>
 
+class ezQtFileLineEdit;
+
 class EZ_EDITORFRAMEWORK_DLL ezQtFilePropertyWidget : public ezQtStandardPropertyWidget
 {
   Q_OBJECT
 
 public:
   ezQtFilePropertyWidget();
+  bool IsValidFileReference(ezStringView sFile) const;
 
 private Q_SLOTS:
   void on_BrowseFile_clicked();
@@ -26,8 +29,8 @@ protected:
   virtual void InternalSetValue(const ezVariant& value) override;
 
 protected:
-  QHBoxLayout* m_pLayout;
-  QLineEdit* m_pWidget;
-  QToolButton* m_pButton;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtFileLineEdit* m_pWidget = nullptr;
+  QToolButton* m_pButton = nullptr;
 };
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/FileBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/FileBrowserPropertyWidget.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h>
+#include <EditorFramework/PropertyGrid/QtFileLineEdit.moc.h>
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 
 
@@ -12,7 +13,7 @@ ezQtFilePropertyWidget::ezQtFilePropertyWidget()
   m_pLayout->setContentsMargins(0, 0, 0, 0);
   setLayout(m_pLayout);
 
-  m_pWidget = new QLineEdit(this);
+  m_pWidget = new ezQtFileLineEdit(this);
   m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   m_pWidget->setFocusPolicy(Qt::FocusPolicy::StrongFocus);
   setFocusProxy(m_pWidget);
@@ -33,13 +34,31 @@ ezQtFilePropertyWidget::ezQtFilePropertyWidget()
     QAction* pDocAction = pMenu->addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Document.svg")), QLatin1String("Open File"), this, SLOT(OnOpenFile())) /*->setEnabled(!m_pWidget->text().isEmpty())*/;
     pMenu->addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/OpenFolder.svg")), QLatin1String("Open in Explorer"), this, SLOT(OnOpenExplorer()));
 
-    connect(pMenu, &QMenu::aboutToShow, pMenu, [=]() { pDocAction->setEnabled(!m_pWidget->text().isEmpty()); });
+    connect(pMenu, &QMenu::aboutToShow, pMenu, [=]()
+      { pDocAction->setEnabled(!m_pWidget->text().isEmpty()); });
 
     m_pButton->setMenu(pMenu);
   }
 
   m_pLayout->addWidget(m_pWidget);
   m_pLayout->addWidget(m_pButton);
+}
+
+bool ezQtFilePropertyWidget::IsValidFileReference(ezStringView sFile) const
+{
+  auto pAttr = m_pProp->GetAttributeByType<ezFileBrowserAttribute>();
+
+  ezHybridArray<ezStringView, 8> extensions;
+  ezStringView sTemp = pAttr->GetTypeFilter();
+  sTemp.Split(false, extensions, ";");
+  for (ezStringView& ext : extensions)
+  {
+    ext.TrimWordStart("*.");
+    if (sFile.GetFileExtension().IsEqual_NoCase(ext))
+      return true;
+  }
+
+  return false;
 }
 
 void ezQtFilePropertyWidget::OnInit()

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/QtFileLineEdit.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/QtFileLineEdit.cpp
@@ -1,0 +1,81 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorFramework/PropertyGrid/QtFileLineEdit.moc.h>
+#include <EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h>
+
+ezQtFileLineEdit::ezQtFileLineEdit(ezQtFilePropertyWidget* pParent)
+  : QLineEdit(pParent)
+{
+  m_pOwner = pParent;
+}
+
+void ezQtFileLineEdit::dragMoveEvent(QDragMoveEvent* e)
+{
+  if (e->mimeData()->hasUrls() && !e->mimeData()->urls().isEmpty())
+  {
+    QString str = e->mimeData()->urls()[0].toLocalFile();
+
+    if (m_pOwner->IsValidFileReference(qtToEzString(str)))
+      e->acceptProposedAction();
+
+    return;
+  }
+
+  QLineEdit::dragMoveEvent(e);
+}
+
+void ezQtFileLineEdit::dragEnterEvent(QDragEnterEvent* e)
+{
+  if (e->mimeData()->hasUrls() && !e->mimeData()->urls().isEmpty())
+  {
+    QString str = e->mimeData()->urls()[0].toLocalFile();
+
+    if (m_pOwner->IsValidFileReference(qtToEzString(str)))
+      e->acceptProposedAction();
+
+    return;
+  }
+
+  QLineEdit::dragEnterEvent(e);
+}
+
+void ezQtFileLineEdit::dropEvent(QDropEvent* e)
+{
+  if (e->source() == this)
+  {
+    QLineEdit::dropEvent(e);
+    return;
+  }
+
+  if (e->mimeData()->hasUrls() && !e->mimeData()->urls().isEmpty())
+  {
+    QString str = e->mimeData()->urls()[0].toLocalFile();
+
+    ezString sPath = str.toUtf8().data();
+    if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryRelative(sPath))
+    {
+      setText(ezMakeQString(sPath));
+    }
+    else
+      setText(QString());
+
+    return;
+  }
+
+
+  if (e->mimeData()->hasText())
+  {
+    QString str = e->mimeData()->text();
+
+    ezString sPath = str.toUtf8().data();
+    if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryRelative(sPath))
+    {
+      setText(QString::fromUtf8(sPath.GetData()));
+    }
+    else
+      setText(QString());
+
+    return;
+  }
+}

--- a/Code/Editor/EditorFramework/PropertyGrid/QtFileLineEdit.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/QtFileLineEdit.moc.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <QLineEdit>
+
+class ezQtFilePropertyWidget;
+
+  /// \brief A QLineEdit that is used by ezQtFilePropertyWidget
+class EZ_EDITORFRAMEWORK_DLL ezQtFileLineEdit : public QLineEdit
+{
+  Q_OBJECT
+
+public:
+  explicit ezQtFileLineEdit(ezQtFilePropertyWidget* pParent = nullptr);
+  virtual void dragMoveEvent(QDragMoveEvent* e) override;
+  virtual void dragEnterEvent(QDragEnterEvent* e) override;
+  virtual void dropEvent(QDropEvent* e) override;
+
+  ezQtFilePropertyWidget* m_pOwner = nullptr;
+};
+

--- a/Code/Editor/EditorFramework/QtResources/Icons/DataDirectory.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/DataDirectory.svg
@@ -1,7 +1,83 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="SVGRepo_bgCarrier" stroke-width="0"/>
-<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
-<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" clip-rule="evenodd" d="M1 5C1 3.34315 2.34315 2 4 2H8.43845C9.81505 2 11.015 2.93689 11.3489 4.27239L11.7808 6H13.5H20C21.6569 6 23 7.34315 23 9V19C23 20.6569 21.6569 22 20 22H4C2.34315 22 1 20.6569 1 19V10V9V5ZM3 9V10V19C3 19.5523 3.44772 20 4 20H20C20.5523 20 21 19.5523 21 19V9C21 8.44772 20.5523 8 20 8H13.5H11.7808H4C3.44772 8 3 8.44772 3 9ZM9.71922 6H4C3.64936 6 3.31278 6.06015 3 6.17071V5C3 4.44772 3.44772 4 4 4H8.43845C8.89732 4 9.2973 4.3123 9.40859 4.75746L9.71922 6Z" fill="#ffffff"/> </g>
-</svg>
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg3151"
+   sodipodi:docname="DataDirectory.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs3155" />
+  <sodipodi:namedview
+     id="namedview3153"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.28375"
+     inkscape:cx="399.61052"
+     inkscape:cy="400.77897"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="2551"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3151" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round" />
+  <g
+     id="SVGRepo_iconCarrier">
+    <path
+       fill-rule="evenodd"
+       clip-rule="evenodd"
+       d="M1 5C1 3.34315 2.34315 2 4 2H8.43845C9.81505 2 11.015 2.93689 11.3489 4.27239L11.7808 6H13.5H20C21.6569 6 23 7.34315 23 9V19C23 20.6569 21.6569 22 20 22H4C2.34315 22 1 20.6569 1 19V10V9V5ZM3 9V10V19C3 19.5523 3.44772 20 4 20H20C20.5523 20 21 19.5523 21 19V9C21 8.44772 20.5523 8 20 8H13.5H11.7808H4C3.44772 8 3 8.44772 3 9ZM9.71922 6H4C3.64936 6 3.31278 6.06015 3 6.17071V5C3 4.44772 3.44772 4 4 4H8.43845C8.89732 4 9.2973 4.3123 9.40859 4.75746L9.71922 6Z"
+       fill="#ffffff"
+       id="path3148" />
+  </g>
+  <g
+     id="g4078"
+     transform="matrix(0.45775271,0,0,0.45775271,7.308483,6.6860943)"
+     style="fill:#ffffff;stroke-width:0;stroke-dasharray:none">
+    <path
+       d="m 11.179007,6.2206848 6.51,3.51 c 0.76,0.4100002 0.76,1.5800002 0,1.9900002 l -6.51,3.51003 c -0.58,0.31 -1.2600002,0.31 -1.8400002,0 l -6.51,-3.51003 c -0.76,-0.41 -0.76,-1.58 0,-1.9900002 l 6.51,-3.51 c 0.58,-0.31 1.2600002,-0.31 1.8400002,0 z"
+       stroke="#ffffff"
+       stroke-width="1.5"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       id="path1"
+       style="stroke:#b96b29;stroke-opacity:1;fill:#ffffff;stroke-width:0;stroke-dasharray:none" />
+    <path
+       d="m 1.8690068,14.090715 6.05,3.03 c 0.75,0.38 1.23,1.15 1.23,1.99 v 5.7201 c 0,0.83 -0.87,1.36 -1.61,0.99 l -6.05,-3.0301 c -0.75,-0.38 -1.23,-1.15 -1.23,-1.99 v -5.72 c 0,-0.83 0.87,-1.35995 1.61,-0.99 z"
+       stroke="#ffffff"
+       stroke-width="1.5"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       id="path2"
+       style="stroke:#b96b29;stroke-opacity:1;fill:#ffffff;stroke-width:0;stroke-dasharray:none" />
+    <path
+       d="m 18.649007,14.090715 -6.05,3.03 c -0.75,0.38 -1.23,1.15 -1.23,1.99 v 5.7201 c 0,0.83 0.87,1.36 1.61,0.99 l 6.05,-3.0301 c 0.75,-0.38 1.23,-1.15 1.23,-1.99 v -5.72 c 0,-0.83 -0.87,-1.35995 -1.61,-0.99 z"
+       stroke="#ffffff"
+       stroke-width="1.5"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       id="path3"
+       style="stroke:#b96b29;stroke-opacity:1;fill:#ffffff;stroke-width:0;stroke-dasharray:none" />
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Folder.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Folder.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" clip-rule="evenodd" d="M1 5C1 3.34315 2.34315 2 4 2H8.43845C9.81505 2 11.015 2.93689 11.3489 4.27239L11.7808 6H13.5H20C21.6569 6 23 7.34315 23 9V19C23 20.6569 21.6569 22 20 22H4C2.34315 22 1 20.6569 1 19V10V9V5ZM3 9V10V19C3 19.5523 3.44772 20 4 20H20C20.5523 20 21 19.5523 21 19V9C21 8.44772 20.5523 8 20 8H13.5H11.7808H4C3.44772 8 3 8.44772 3 9ZM9.71922 6H4C3.64936 6 3.31278 6.06015 3 6.17071V5C3 4.44772 3.44772 4 4 4H8.43845C8.89732 4 9.2973 4.3123 9.40859 4.75746L9.71922 6Z" fill="#ffffff"/> </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/ImportableFile.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ImportableFile.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg61"
+   sodipodi:docname="ImportableFile.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs65" />
+  <sodipodi:namedview
+     id="namedview63"
+     pagecolor="#000000"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     showguides="true"
+     inkscape:zoom="1.28375"
+     inkscape:cx="396.88413"
+     inkscape:cy="402.3369"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg61" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round" />
+  <path
+     d="M 3,10 C 3,6.22876 3,4.34315 4.17157,3.17157 5.34315,2 7.22876,2 11,2 h 2 c 3.7712,0 5.6569,0 6.8284,1.17157 C 21,4.34315 21,6.22876 21,10 v 4 c 0,3.7712 0,5.6569 -1.1716,6.8284 C 18.6569,22 16.7712,22 13,22 H 11 C 7.22876,22 5.34315,22 4.17157,20.8284 3,19.6569 3,17.7712 3,14 Z"
+     stroke="#ffffff"
+     stroke-width="1.5"
+     id="path54"
+     style="stroke:#b96b29;stroke-opacity:1" />
+  <path
+     d="m 12.035053,5.940493 v 8.044913"
+     id="path1"
+     style="stroke:#b96b29;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 9.3534159,11.303769 2.6816371,2.681637 2.681638,-2.681637"
+     id="path2"
+     style="stroke:#b96b29;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="M 9.3534159,7.2813118 H 6.6717783 A 1.3408188,1.3408188 0 0 0 5.3309595,8.6221306 v 6.7040934 a 1.3408188,1.3408188 0 0 0 1.3408188,1.340819 H 17.398328 a 1.3408188,1.3408188 0 0 0 1.340819,-1.340819 V 8.6221306 A 1.3408188,1.3408188 0 0 0 17.398328,7.2813118 h -2.681637"
+     id="path3"
+     style="stroke:#b96b29;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/ImportedFile.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ImportedFile.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg61"
+   sodipodi:docname="ImportableFile.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs65" />
+  <sodipodi:namedview
+     id="namedview63"
+     pagecolor="#000000"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     showguides="true"
+     inkscape:zoom="1.28375"
+     inkscape:cx="396.10516"
+     inkscape:cy="401.55794"
+     inkscape:window-width="2560"
+     inkscape:window-height="1351"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg61" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round" />
+  <path
+     d="M 3,10 C 3,6.22876 3,4.34315 4.17157,3.17157 5.34315,2 7.22876,2 11,2 h 2 c 3.7712,0 5.6569,0 6.8284,1.17157 C 21,4.34315 21,6.22876 21,10 v 4 c 0,3.7712 0,5.6569 -1.1716,6.8284 C 18.6569,22 16.7712,22 13,22 H 11 C 7.22876,22 5.34315,22 4.17157,20.8284 3,19.6569 3,17.7712 3,14 Z"
+     stroke="#ffffff"
+     stroke-width="1.5"
+     id="path54" />
+  <path
+     d="m 12.035053,5.940493 v 8.044913"
+     id="path1"
+     style="stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 9.3534159,11.303769 2.6816371,2.681637 2.681638,-2.681637"
+     id="path2"
+     style="stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="M 9.3534159,7.2813118 H 6.6717783 A 1.3408188,1.3408188 0 0 0 5.3309595,8.6221306 v 6.7040934 a 1.3408188,1.3408188 0 0 0 1.3408188,1.340819 H 17.398328 a 1.3408188,1.3408188 0 0 0 1.340819,-1.340819 V 8.6221306 A 1.3408188,1.3408188 0 0 0 17.398328,7.2813118 h -2.681637"
+     id="path3"
+     style="stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/resources.qrc
+++ b/Code/Editor/EditorFramework/QtResources/resources.qrc
@@ -17,6 +17,9 @@
     <file>Icons/SpawnView.svg</file>
     <file>Icons/Plugins.svg</file>
     <file>Icons/DataDirectory.svg</file>
+    <file>Icons/Folder.svg</file>
+    <file>Icons/ImportableFile.svg</file>
+    <file>Icons/ImportedFile.svg</file>
     <file>Icons/StoredSettings.svg</file>
     <file>Icons/Input.svg</file>
     <file>Icons/AssetUnknown.svg</file>

--- a/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
@@ -266,7 +266,32 @@ bool ezPathUtils::IsSubPath(ezStringView sPrefixPath, ezStringView sFullPath)
   tmp.MakeCleanPath();
   tmp.AppendPath("");
 
-  return sFullPath.StartsWith_NoCase(tmp);
+  if (sFullPath.StartsWith(tmp))
+  {
+    if (tmp.GetElementCount() == sFullPath.GetElementCount())
+      return true;
+
+    return sFullPath.GetStartPointer()[tmp.GetElementCount()] == '/';
+  }
+
+  return false;
+}
+
+bool ezPathUtils::IsSubPath_NoCase(ezStringView sPrefixPath, ezStringView sFullPath)
+{
+  ezStringBuilder tmp = sPrefixPath;
+  tmp.MakeCleanPath();
+  tmp.AppendPath("");
+
+  if (sFullPath.StartsWith_NoCase(tmp))
+  {
+    if (tmp.GetElementCount() == sFullPath.GetElementCount())
+      return true;
+
+    return sFullPath.GetStartPointer()[tmp.GetElementCount()] == '/';
+  }
+
+  return false;
 }
 
 EZ_STATICLINK_FILE(Foundation, Foundation_Strings_Implementation_PathUtils);

--- a/Code/Engine/Foundation/Strings/PathUtils.h
+++ b/Code/Engine/Foundation/Strings/PathUtils.h
@@ -91,7 +91,9 @@ public:
   static void MakeValidFilename(ezStringView sFilename, ezUInt32 uiReplacementCharacter, ezStringBuilder& out_sFilename);
 
   /// \brief Checks whether \a sFullPath starts with \a sPrefixPath.
-  static bool IsSubPath(ezStringView sPrefixPath, ezStringView sFullPath);
+  static bool IsSubPath(ezStringView sPrefixPath, ezStringView sFullPath); // [tested]
+  /// \brief Checks whether \a sFullPath starts with \a sPrefixPath. Case insensitive.
+  static bool IsSubPath_NoCase(ezStringView sPrefixPath, ezStringView sFullPath); // [tested]
 };
 
 #include <Foundation/Strings/Implementation/PathUtils_inl.h>

--- a/Code/Engine/Foundation/Strings/String.h
+++ b/Code/Engine/Foundation/Strings/String.h
@@ -173,12 +173,12 @@ static_assert(ezGetTypeClass<ezString>::value == ezTypeIsClass::value);
 template <ezUInt16 Size>
 struct ezCompareHelper<ezHybridString<Size>>
 {
-  EZ_ALWAYS_INLINE bool Less(ezStringView lhs, ezStringView rhs) const
+  static EZ_ALWAYS_INLINE bool Less(ezStringView lhs, ezStringView rhs)
   {
     return lhs.Compare(rhs) < 0;
   }
 
-  EZ_ALWAYS_INLINE bool Equal(ezStringView lhs, ezStringView rhs) const
+  static EZ_ALWAYS_INLINE bool Equal(ezStringView lhs, ezStringView rhs)
   {
     return lhs.IsEqual(rhs);
   }
@@ -186,12 +186,12 @@ struct ezCompareHelper<ezHybridString<Size>>
 
 struct ezCompareString_NoCase
 {
-  EZ_ALWAYS_INLINE bool Less(ezStringView lhs, ezStringView rhs) const
+  static EZ_ALWAYS_INLINE bool Less(ezStringView lhs, ezStringView rhs)
   {
     return lhs.Compare_NoCase(rhs) < 0;
   }
 
-  EZ_ALWAYS_INLINE bool Equal(ezStringView lhs, ezStringView rhs) const
+  static EZ_ALWAYS_INLINE bool Equal(ezStringView lhs, ezStringView rhs)
   {
     return lhs.IsEqual_NoCase(rhs);
   }
@@ -200,10 +200,10 @@ struct ezCompareString_NoCase
 struct CompareConstChar
 {
   /// \brief Returns true if a is less than b
-  EZ_ALWAYS_INLINE bool Less(const char* a, const char* b) const { return ezStringUtils::Compare(a, b) < 0; }
+  static EZ_ALWAYS_INLINE bool Less(const char* a, const char* b) { return ezStringUtils::Compare(a, b) < 0; }
 
   /// \brief Returns true if a is equal to b
-  EZ_ALWAYS_INLINE bool Equal(const char* a, const char* b) const { return ezStringUtils::IsEqual(a, b); }
+  static EZ_ALWAYS_INLINE bool Equal(const char* a, const char* b) { return ezStringUtils::IsEqual(a, b); }
 };
 
 // For ezFormatString

--- a/Code/Engine/Foundation/Threading/LockedObject.h
+++ b/Code/Engine/Foundation/Threading/LockedObject.h
@@ -45,6 +45,10 @@ public:
   /// \brief Whether the encapsulated object exists at all or is nullptr
   EZ_ALWAYS_INLINE bool isValid() const { return m_pObject != nullptr; }
 
+  O* Borrow() { return m_pObject; }
+
+  const O* Borrow() const { return m_pObject; }
+
   O* operator->() { return m_pObject; }
 
   const O* operator->() const { return m_pObject; }

--- a/Code/Tools/Libs/GuiFoundation/GuiFoundationDLL.h
+++ b/Code/Tools/Libs/GuiFoundation/GuiFoundationDLL.h
@@ -73,7 +73,7 @@ EZ_ALWAYS_INLINE QString ezMakeQString(ezStringView sString)
 }
 
 template <typename T>
-void operator>>(QDataStream& inout_stream, T* rhs)
+void operator>>(QDataStream& inout_stream, T*& rhs)
 {
   void* p = nullptr;
   uint len = sizeof(void*);

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/FileSystemModel.h
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/FileSystemModel.h
@@ -189,8 +189,6 @@ private:
   void FireFileChangedEvent(const ezDataDirPath& file, ezFileStatus fileStatus, ezFileChangedEvent::Type type);
   void FireFolderChangedEvent(const ezDataDirPath& file, ezFolderChangedEvent::Type type);
 
-  int FindDataDir(const ezStringView path);
-
 private:
   // Immutable data after Initialize
   ezApplicationFileSystemConfig m_FileSystemConfig;

--- a/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemModel.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/FileSystem/Implementation/FileSystemModel.cpp
@@ -714,7 +714,7 @@ void ezFileSystemModel::CheckFolder(ezStringView sAbsolutePath)
     // As we are using ezCompareDataDirPath, entries of different casing interleave but we are only interested in the ones with matching casing so we skip the rest.
     for (auto it = m_ReferencedFiles.LowerBound(sAbsolutePath2.GetView()); it.IsValid(); ++it)
     {
-      if (it.Key().GetAbsolutePath().StartsWith(sAbsolutePath2) && !visitedFiles.Contains(it.Key().GetAbsolutePath()))
+      if (ezPathUtils::IsSubPath(sAbsolutePath2, it.Key().GetAbsolutePath()) && !visitedFiles.Contains(it.Key().GetAbsolutePath()))
         missingFiles.PushBack(it.Key().GetAbsolutePath());
       if (!it.Key().GetAbsolutePath().StartsWith_NoCase(sAbsolutePath2))
         break;
@@ -722,7 +722,7 @@ void ezFileSystemModel::CheckFolder(ezStringView sAbsolutePath)
 
     for (auto it = m_ReferencedFolders.LowerBound(sAbsolutePath2.GetView()); it.IsValid(); ++it)
     {
-      if (it.Key().GetAbsolutePath().StartsWith(sAbsolutePath2) && !visitedFolders.Contains(it.Key().GetAbsolutePath()))
+      if (ezPathUtils::IsSubPath(sAbsolutePath2, it.Key().GetAbsolutePath()) && !visitedFolders.Contains(it.Key().GetAbsolutePath()))
         missingFolders.PushBack(it.Key().GetAbsolutePath());
       if (!it.Key().GetAbsolutePath().StartsWith_NoCase(sAbsolutePath2))
         break;
@@ -887,7 +887,7 @@ void ezFileSystemModel::RemoveFileOrFolder(const ezDataDirPath& absolutePath, bo
         auto itlowerBound = m_ReferencedFiles.LowerBound(absolutePath);
         while (itlowerBound.IsValid())
         {
-          if (itlowerBound.Key().GetAbsolutePath().StartsWith(absolutePath.GetAbsolutePath()))
+          if (ezPathUtils::IsSubPath(absolutePath, itlowerBound.Key().GetAbsolutePath()))
           {
             previouslyKnownFiles.Insert(itlowerBound.Key());
           }
@@ -972,18 +972,6 @@ void ezFileSystemModel::FireFolderChangedEvent(const ezDataDirPath& file, ezFold
     m_FolderChangedEvents.Broadcast(tempEvent);
   }
   g_PostponedFolders.Clear();
-}
-
-ezInt32 ezFileSystemModel::FindDataDir(const ezStringView path)
-{
-  for (ezUInt32 i = 0; i < m_DataDirRoots.GetCount(); ++i)
-  {
-    if (path.StartsWith(m_DataDirRoots[i]))
-    {
-      return (ezInt32)i;
-    }
-  }
-  return -1;
 }
 
 #endif

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -360,19 +360,17 @@ std::unique_ptr<QMimeData> ezEditorTest::AssetsToDragMimeData(ezArrayPtr<ezUuid>
 
 std::unique_ptr<QMimeData> ezEditorTest::ObjectsDragMimeData(const ezDeque<const ezDocumentObject*>& objects)
 {
-  std::unique_ptr<QMimeData> mimeData(new QMimeData());
-  QByteArray encodedData;
-
-  QDataStream stream(&encodedData, QIODevice::WriteOnly);
-
-  int iCount = (int)objects.GetCount();
-  stream << iCount;
-
+  ezHybridArray<const ezDocumentObject*, 32> Dragged;
   for (const ezDocumentObject* pObject : objects)
   {
-    stream.writeRawData((const char*)&pObject, sizeof(void*));
+    Dragged.PushBack(pObject);
   }
 
+  QByteArray encodedData;
+  QDataStream stream(&encodedData, QIODevice::WriteOnly);
+  stream << Dragged;
+
+  std::unique_ptr<QMimeData> mimeData(new QMimeData());
   mimeData->setData("application/ezEditor.ObjectSelection", encodedData);
   return std::move(mimeData);
 }

--- a/Code/UnitTests/FoundationTest/Strings/PathUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/PathUtilsTest.cpp
@@ -130,4 +130,44 @@ EZ_CREATE_SIMPLE_TEST(Strings, PathUtils)
     EZ_TEST_BOOL(root.IsEmpty());
     EZ_TEST_BOOL(relPath == "folder\\file2.txt");
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsSubPath")
+  {
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:/DataDir", "C:/DataDir/SomeFolder"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:/DataDir", "C:/DataDir"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:/DataDir", "C:/DataDir/"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:/DataDir", "C:/DataDir2"));
+
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:\\DataDir", "C:/DataDir/SomeFolder"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:\\DataDir", "C:/DataDir"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath("C:\\DataDir", "C:/DataDir/"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:\\DataDir", "C:/DataDir2"));
+
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:\\DataDiR", "C:/DataDir/SomeFolder"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:\\DataDiR", "C:/DataDir"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:\\DataDiR", "C:/DataDir/"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:\\DataDiR", "C:/DataDir2"));
+
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath("C:/DataDir/SomeFolder", "C:/DataDir"));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsSubPath_NoCase")
+  {
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:/DataDir", "C:/DataDir/SomeFolder"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:/DataDir", "C:/DataDir"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:/DataDir", "C:/DataDir/"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath_NoCase("C:/DataDir", "C:/DataDir2"));
+
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:\\DataDir", "C:/DataDir/SomeFolder"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:\\DataDir", "C:/DataDir"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:\\DataDir", "C:/DataDir/"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath_NoCase("C:\\DataDir", "C:/DataDir2"));
+
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:\\DataDiR", "C:/DataDir/SomeFolder"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:\\DataDiR", "C:/DataDir"));
+    EZ_TEST_BOOL(ezPathUtils::IsSubPath_NoCase("C:\\DataDiR", "C:/DataDir/"));
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath_NoCase("C:\\DataDiR", "C:/DataDir2"));
+
+    EZ_TEST_BOOL(!ezPathUtils::IsSubPath_NoCase("C:/DataDir/SomeFolder", "C:/DataDir"));
+  }
 }

--- a/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
@@ -461,10 +461,10 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
     sFilePathOld.AppendPath("Folder1", "rootFile2.txt");
 
     ezStringBuilder sFolderPathNew(sOutputFolder);
-    sFolderPathNew.AppendPath("Folder2");
+    sFolderPathNew.AppendPath("Folder12");
 
     ezStringBuilder sFilePathNew(sOutputFolder);
-    sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
+    sFilePathNew.AppendPath("Folder12", "rootFile2.txt");
 
     EZ_TEST_RESULT(ezOSFile::MoveFileOrDirectory(sFolderPathOld, sFolderPathNew));
 
@@ -511,7 +511,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "HashFile")
   {
     ezStringBuilder sFilePathNew(sOutputFolder);
-    sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
+    sFilePathNew.AppendPath("Folder12", "rootFile2.txt");
 
     ezFileStatus status;
     EZ_TEST_RESULT(ezFileSystemModel::GetSingleton()->HashFile(sFilePathNew, status));
@@ -577,7 +577,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetFiles")
   {
     ezStringBuilder sFilePathNew(sOutputFolder);
-    sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
+    sFilePathNew.AppendPath("Folder12", "rootFile2.txt");
 
     ezFileSystemModel::LockedFiles files = ezFileSystemModel::GetSingleton()->GetFiles();
     EZ_TEST_INT(files->GetCount(), 1);
@@ -591,7 +591,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetFolders")
   {
     ezStringBuilder sFolder(sOutputFolder);
-    sFolder.AppendPath("Folder2");
+    sFolder.AppendPath("Folder12");
 
     ezFileSystemModel::LockedFolders folders = ezFileSystemModel::GetSingleton()->GetFolders();
     EZ_TEST_INT(folders->GetCount(), 3);
@@ -613,10 +613,10 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "CheckFileSystem")
   {
     ezStringBuilder sFolderPath(sOutputFolder);
-    sFolderPath.AppendPath("Folder2");
+    sFolderPath.AppendPath("Folder12");
 
     ezStringBuilder sFilePath(sOutputFolder);
-    sFilePath.AppendPath("Folder2", "rootFile2.txt");
+    sFilePath.AppendPath("Folder12", "rootFile2.txt");
 
     ezFileSystemModel::GetSingleton()->CheckFileSystem();
 
@@ -713,7 +713,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "CheckFolder - File")
   {
     ezStringBuilder sFilePath(sOutputFolder);
-    sFilePath.AppendPath("Folder2", "subFile.txt");
+    sFilePath.AppendPath("Folder12", "subFile.txt");
     {
       EZ_TEST_RESULT(eztCreateFile(sFilePath));
       ezFileSystemModel::GetSingleton()->CheckFolder(sOutputFolder);
@@ -793,7 +793,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ReadDocument")
   {
     ezStringBuilder sFilePathNew(sOutputFolder);
-    sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
+    sFilePathNew.AppendPath("Folder12", "rootFile2.txt");
 
     ezUuid docGuid = ezUuid::MakeUuid();
     auto callback = [&](const ezFileStatus& status, ezStreamReader& ref_reader) {
@@ -813,7 +813,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "LinkDocument")
   {
     ezStringBuilder sFilePathNew(sOutputFolder);
-    sFilePathNew.AppendPath("Folder2", "rootFile2.txt");
+    sFilePathNew.AppendPath("Folder12", "rootFile2.txt");
 
     ezUuid guid = ezUuid::MakeUuid();
     ezUuid guid2 = ezUuid::MakeUuid();
@@ -857,10 +857,10 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Change file casing")
   {
     ezStringBuilder sFilePathOld(sOutputFolder);
-    sFilePathOld.AppendPath("Folder2", "rootFile2.txt");
+    sFilePathOld.AppendPath("Folder12", "rootFile2.txt");
 
     ezStringBuilder sFilePathNew(sOutputFolder);
-    sFilePathNew.AppendPath("Folder2", "RootFile2.txt");
+    sFilePathNew.AppendPath("Folder12", "RootFile2.txt");
 
     EZ_TEST_RESULT(ezOSFile::MoveFileOrDirectory(sFilePathOld, sFilePathNew));
 
@@ -888,10 +888,10 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Change folder casing")
   {
     ezStringBuilder sFolderPathOld(sOutputFolder);
-    sFolderPathOld.AppendPath("Folder2");
+    sFolderPathOld.AppendPath("Folder12");
 
     ezStringBuilder sFolderPathNew(sOutputFolder);
-    sFolderPathNew.AppendPath("FOLDER2");
+    sFolderPathNew.AppendPath("FOLDER12");
 
     EZ_TEST_RESULT(ezOSFile::MoveFileOrDirectory(sFolderPathOld, sFolderPathNew));
 
@@ -915,9 +915,9 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
 
     {
       ezStringBuilder sFilePathOld(sOutputFolder);
-      sFilePathOld.AppendPath("Folder2", "RootFile2.txt");
+      sFilePathOld.AppendPath("Folder12", "RootFile2.txt");
       ezStringBuilder sFilePathNew(sOutputFolder);
-      sFilePathNew.AppendPath("FOLDER2", "RootFile2.txt");
+      sFilePathNew.AppendPath("FOLDER12", "RootFile2.txt");
 
       ezFileChangedEvent expected[] = {
         ezFileChangedEvent(MakePath(sFilePathNew), {}, ezFileChangedEvent::Type::FileAdded),
@@ -933,10 +933,10 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "delete folder")
   {
     ezStringBuilder sFolderPath(sOutputFolder);
-    sFolderPath.AppendPath("FOLDER2");
+    sFolderPath.AppendPath("FOLDER12");
 
     ezStringBuilder sFilePath(sOutputFolder);
-    sFilePath.AppendPath("FOLDER2", "RootFile2.txt");
+    sFilePath.AppendPath("FOLDER12", "RootFile2.txt");
 
     EZ_TEST_RESULT(ezOSFile::DeleteFolder(sFolderPath));
 


### PR DESCRIPTION

![image](https://github.com/ezEngine/ezEngine/assets/11784812/920743ac-8a99-46d8-a8d3-60ed275b98f4)

# Asset Browser Folder View
* Added ability to create, delete, rename and move via drag and drop folders. Press F2 to rename, del to delete a folder.

# Asset Browser
* Any files and folders are now shown in the asset browser view.
* Files can be renamed by pressing F2 and deleted by pressing the del key.
* Assets can be drag & dropped into the folder view to move them around.
* Creating assets via context menu now adds them directly to the view and enters name edit mode. After a name was set, the newly created asset is opened.
* Changed rendering of items:
  * Assets are the only items using alternate background color to easily distinguish them from normal files.
  * Files that can be imported (e.g. tga) have a different icon than regular files (e.g. txt). Files can can be imported but haven't yet turn into an orange icon.

# Asset Import
* Added `ezAssetDocumentGenerator::GetSupportsFileTypes` to create a list of all files that can potentially be imported.
* Asset browser context menu now has an import action. Allowing the import dialog to be opened for the current multi-selection of files.
* Asset browser context menu also shows an *importd via* menu, showing all assets that imported one of the selected files.

# Code Changes
* Created `eqQtAssetBrowserFolderView`, extracted out of `ezQtAssetBrowserWidget`.
* ezQtAssetBrowserFilter
  * `SetShowFilesAndFolders` to toggle the feature on and off.
  * `SetTemporaryPinnedItem` to force an item to be always visible. Used when creating new assets to make sure that they are always visible regardless of type filter etc.
* Drag and drop code simplified byadding QDataStream operators for `T*`, `ezDynamicArray<T>`.
* Added `ezAssetCurator::FindAllUses` and `ezAssetCurator::IsReferenced` for files to quickly check which files are already imported.
* `ezQtAssetBrowserModel::VisibleEntry` added that contains an `ezDataDirPath` which simplifies many of the models data queries.
* Added `ezAssetBrowserItemFlags` to categorize each asset browser item.
* Fixed `ezPathUtils::IsSubPath` and added `ezPathUtils::IsSubPath_NoCase`.
  * Fixed a bug in `ezFileSystemModel` when renaming an item to the same name with additional characters at the end, causing the item to be removed from the model.

# Known issues
* Moving files between data directories does not correctly update the `ezAssetTable`.