### PR TITLE
Fix pasting objects in the scene tree pastes twice

### DIFF
--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
@@ -147,20 +147,24 @@ void ezQtDocumentTreeView::SetAllowDeleteObjects(bool bAllow)
   m_bAllowDeleteObjects = bAllow;
 }
 
-void ezQtDocumentTreeView::keyPressEvent(QKeyEvent* e)
+bool ezQtDocumentTreeView::event(QEvent* pEvent)
 {
-  if (ezQtProxy::TriggerDocumentAction(m_pDocument, e))
-    return;
-
-  if (e == QKeySequence::Delete)
+  if (pEvent->type() == QEvent::ShortcutOverride || pEvent->type() == QEvent::KeyPress)
   {
-    if (m_bAllowDeleteObjects)
+    QKeyEvent* keyEvent = static_cast<QKeyEvent*>(pEvent);
+    if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent, pEvent->type() == QEvent::ShortcutOverride))
+      return true;
+
+    if (pEvent->type() == QEvent::KeyPress && keyEvent == QKeySequence::Delete)
     {
-      m_pDocument->DeleteSelectedObjects();
+      if (m_bAllowDeleteObjects)
+      {
+        m_pDocument->DeleteSelectedObjects();
+      }
+      pEvent->accept();
+      return true;
     }
   }
-  else
-  {
-    QTreeView::keyPressEvent(e);
-  }
+
+  return QTreeView::event(pEvent);
 }

--- a/Code/Editor/EditorFramework/GUI/RawDocumentTreeWidget.moc.h
+++ b/Code/Editor/EditorFramework/GUI/RawDocumentTreeWidget.moc.h
@@ -31,7 +31,7 @@ public:
   ezQtTreeSearchFilterModel* GetProxyFilterModel() const { return m_pFilterModel.get(); }
 
 protected:
-  virtual void keyPressEvent(QKeyEvent* e) override;
+  virtual bool event(QEvent* pEvent) override;
 
 private Q_SLOTS:
   void on_selectionChanged_triggered(const QItemSelection& selected, const QItemSelection& deselected);

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
@@ -88,9 +88,9 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, QtProxies)
 EZ_END_SUBSYSTEM_DECLARATION;
 // clang-format on
 
-bool ezQtProxy::TriggerDocumentAction(ezDocument* pDocument, QKeyEvent* pEvent)
+bool ezQtProxy::TriggerDocumentAction(ezDocument* pDocument, QKeyEvent* pEvent, bool bTestOnly)
 {
-  auto CheckActions = [](QKeyEvent* pEvent, ezMap<ezActionDescriptorHandle, QWeakPointer<ezQtProxy>>& ref_actions) -> bool {
+  auto CheckActions = [&](QKeyEvent* pEvent, ezMap<ezActionDescriptorHandle, QWeakPointer<ezQtProxy>>& ref_actions) -> bool {
     for (auto weakActionProxy : ref_actions)
     {
       if (auto pProxy = weakActionProxy.Value().toStrongRef())
@@ -110,7 +110,10 @@ bool ezQtProxy::TriggerDocumentAction(ezDocument* pDocument, QKeyEvent* pEvent)
           QKeySequence ks = pQAction->shortcut();
           if (pQAction->isEnabled() && QKeySequence(pEvent->key() | pEvent->modifiers()) == ks)
           {
-            pQAction->trigger();
+            if (!bTestOnly)
+            {
+              pQAction->trigger();
+            }
             pEvent->accept();
             return true;
           }

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/QtProxy.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/QtProxy.moc.h
@@ -37,11 +37,15 @@ public:
   /// \brief Converts the QKeyEvent into a shortcut and tries to find a matching action in the document and global action list.
   ///
   /// Document actions are not mapped as ShortcutContext::WindowShortcut because docking allows for multiple documents to be mapped into the same window. Instead, ShortcutContext::WidgetWithChildrenShortcut is used to prevent ambiguous action shortcuts and the actions are executed manually via filtering QEvent::ShortcutOverride at the dock widget level.
+  /// The function always has to be called two times:
+  /// A: QEvent::ShortcutOverride: Only check with bTestOnly = true that we want to override the shortcut. This will instruct Qt to send the event as a regular key press event to the widget that accepted the override.
+  /// B: QEvent::keyPressEvent: Execute the actual action with bTestOnly = false;
   ///
   /// \param pDocument The document for which matching actions should be searched for. If null, only global actions are searched.
-  /// \param event The key event that should be converted into a shortcut.
+  /// \param pEvent The key event that should be converted into a shortcut.
+  /// \param bTestOnly Accept the event and return true but don't execute the action. Use this inside QEvent::ShortcutOverride.
   /// \return Whether the key event was consumed and an action executed.
-  static bool TriggerDocumentAction(ezDocument* pDocument, QKeyEvent* pEvent);
+  static bool TriggerDocumentAction(ezDocument* pDocument, QKeyEvent* pEvent, bool bTestOnly);
 
   static ezRttiMappedObjectFactory<ezQtProxy>& GetFactory();
   static QSharedPointer<ezQtProxy> GetProxy(ezActionContext& ref_context, ezActionDescriptorHandle hAction);

--- a/Code/Tools/Libs/GuiFoundation/DockPanels/ApplicationPanel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DockPanels/ApplicationPanel.cpp
@@ -73,13 +73,13 @@ void ezQtApplicationPanel::ToolsProjectEventHandler(const ezToolsProjectEvent& e
   }
 }
 
-bool ezQtApplicationPanel::event(QEvent* event)
+bool ezQtApplicationPanel::event(QEvent* pEvent)
 {
-  if (event->type() == QEvent::ShortcutOverride)
+  if (pEvent->type() == QEvent::ShortcutOverride || pEvent->type() == QEvent::KeyPress)
   {
-    QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-    if (ezQtProxy::TriggerDocumentAction(nullptr, keyEvent))
+    QKeyEvent* keyEvent = static_cast<QKeyEvent*>(pEvent);
+    if (ezQtProxy::TriggerDocumentAction(nullptr, keyEvent, pEvent->type() == QEvent::ShortcutOverride))
       return true;
   }
-  return ads::CDockWidget::event(event);
+  return ads::CDockWidget::event(pEvent);
 }

--- a/Code/Tools/Libs/GuiFoundation/DockPanels/DocumentPanel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DockPanels/DocumentPanel.cpp
@@ -29,10 +29,10 @@ void ezQtDocumentPanel::closeEvent(QCloseEvent* e)
 
 bool ezQtDocumentPanel::event(QEvent* pEvent)
 {
-  if (pEvent->type() == QEvent::ShortcutOverride)
+  if (pEvent->type() == QEvent::ShortcutOverride || pEvent->type() == QEvent::KeyPress)
   {
     QKeyEvent* keyEvent = static_cast<QKeyEvent*>(pEvent);
-    if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent))
+    if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent, pEvent->type() == QEvent::ShortcutOverride))
       return true;
   }
   return QDockWidget::event(pEvent);

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -297,14 +297,14 @@ void ezQtDocumentWindow::hideEvent(QHideEvent* event)
 
 bool ezQtDocumentWindow::eventFilter(QObject* obj, QEvent* e)
 {
-  if (e->type() == QEvent::ShortcutOverride)
+  if (e->type() == QEvent::ShortcutOverride || e->type() == QEvent::KeyPress)
   {
     // This filter is added by ezQtContainerWindow::AddDocumentWindow as that ones is the ony code path that can connect dock container to their content.
     // This filter is necessary as clicking any action in a menu bar sets the focus to the parent CDockWidget at which point further shortcuts would stop working.
     if (qobject_cast<ads::CDockWidget*>(obj))
     {
       QKeyEvent* keyEvent = static_cast<QKeyEvent*>(e);
-      if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent))
+      if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent, e->type() == QEvent::ShortcutOverride))
         return true;
     }
   }
@@ -313,10 +313,10 @@ bool ezQtDocumentWindow::eventFilter(QObject* obj, QEvent* e)
 
 bool ezQtDocumentWindow::event(QEvent* event)
 {
-  if (event->type() == QEvent::ShortcutOverride)
+  if (event->type() == QEvent::ShortcutOverride || event->type() == QEvent::KeyPress)
   {
     QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
-    if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent))
+    if (ezQtProxy::TriggerDocumentAction(m_pDocument, keyEvent, event->type() == QEvent::ShortcutOverride))
       return true;
   }
   return QMainWindow::event(event);


### PR DESCRIPTION
Qt's QEvent::ShortcutOverride pattern works like this:
* If inside `QEvent::ShortcutOverride` you accept the event, it will be fired again as a regular `QEvent::keyPressEvent` to the widget the accepted the override.
* Inside `QEvent::keyPressEvent` you can execute the actual action that you requested the override for.

In our case, this means that we have to call TriggerDocumentAction twice, once to determine if we want to override and then a second time to execute the action. Fixes #991