### PR TITLE
Editor Engine Process logging

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.h
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.h
@@ -6,6 +6,7 @@
 #include <Foundation/Application/Config/PluginConfig.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <GameEngine/GameApplication/GameApplication.h>
+#include <Foundation/Logging/HTMLWriter.h>
 
 class ezEditorEngineProcessApp;
 class ezDocumentOpenMsgToEngine;
@@ -45,6 +46,9 @@ private:
   void ConnectToHost();
   void DisableErrorReport();
   void WaitForDebugger();
+  static bool EditorAssertHandler(const char* szSourceFile, ezUInt32 uiLine, const char* szFunction, const char* szExpression, const char* szAssertMsg);
+  void AddEditorAssertHandler();
+  void RemoveEditorAssertHandler();
 
   bool ProcessIPCMessages(bool bPendingOpInProgress);
   void SendProjectReadyMessage();
@@ -69,6 +73,7 @@ private:
   ezEngineProcessCommunicationChannel m_IPC;
   ezUniquePtr<ezEditorEngineProcessApp> m_pApp;
   ezLongOpWorkerManager m_LongOpWorkerManager;
+  ezLogWriter::HTML m_LogHTML;
 
   ezUInt32 m_uiRedrawCountReceived = 0;
   ezUInt32 m_uiRedrawCountExecuted = 0;

--- a/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
@@ -113,9 +113,18 @@ QVariant ezQtLogModel::data(const QModelIndex& index, int iRole) const
   switch (iRole)
   {
     case Qt::DisplayRole:
+    {
+      if (msg.m_sMsg.FindSubString("\n") != nullptr)
+      {
+        ezStringBuilder sTemp = msg.m_sMsg;
+        sTemp.ReplaceAll("\n", " ");
+        return ezMakeQString(sTemp);
+      }
+      return ezMakeQString(msg.m_sMsg);
+    }
     case Qt::ToolTipRole:
     {
-      return QString::fromUtf8(msg.m_sMsg.GetData());
+      return ezMakeQString(msg.m_sMsg);
     }
     case Qt::ForegroundRole:
     {


### PR DESCRIPTION
* Engine process writes a html log file in the app dir (on windows: `%AppData%\ezEngine Project\EditorEngineProcess\Log_{ProcessID}.htm`)
* Added custom assert handler that sends over the assert to the editor process as IPC message.
* Added custom print function that forwards top level exception handler and other low-level log messages to the ez logging system which in turn will forward to the editor. While this is not safe, it is better than no logs when the child process crashes.
* Editor log view will flatten multi-line log messages in the view but show them as tooltips.