### PR TITLE
Fixed #429: Made it easier to import multiple files as assets

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -81,6 +81,8 @@ private Q_SLOTS:
   void ImportSelection();
   void OnOpenImportReferenceAsset();
   void DeleteSelection();
+  void OnImportAsAboutToShow();
+  void OnImportAsClicked();
 
 
 private:
@@ -92,6 +94,7 @@ private:
   void ProjectEventHandler(const ezToolsProjectEvent& e);
   void AddAssetCreatorMenu(QMenu* pMenu, bool useSelectedAsset);
   void AddImportedViaMenu(QMenu* pMenu);
+  void GetSelectedImportableFiles(ezDynamicArray<ezString>& out_Files) const;
 
   Mode m_Mode = Mode::Browser;
   ezQtToolBarActionMapView* m_pToolbar = nullptr;

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
@@ -15,6 +15,10 @@ enum class ezAssetDocGeneratorPriority
   ENUM_COUNT
 };
 
+/// \brief Provides functionality for importing files as asset documents.
+///
+/// Derived from this class to add a custom importer (see existing derived classes for examples).
+/// Each importer typically handles one target asset type.
 class EZ_EDITORFRAMEWORK_DLL ezAssetDocumentGenerator : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezAssetDocumentGenerator, ezReflectedClass);
@@ -23,55 +27,77 @@ public:
   ezAssetDocumentGenerator();
   ~ezAssetDocumentGenerator();
 
-  struct Info
+  /// \brief Describes one option to import an asset.
+  ///
+  /// The name is used to identify which option the user chose.
+  /// The priority should be set to pick a 'likely' option for the UI to prefer.
+  struct ImportMode
   {
     ezAssetDocumentGenerator* m_pGenerator = nullptr; ///< automatically set by ezAssetDocumentGenerator
-    ezAssetDocGeneratorPriority m_Priority;           ///< has to be specified by generator
-    ezString m_sOutputFileParentRelative;             ///< has to be specified by generator
-    ezString m_sOutputFileAbsolute;                   ///< automatically generated from m_sOutputFileParentRelative
-    ezString m_sName;                                 ///< has to be specified by generator, used to know which action to take by Generate()
-    ezString m_sIcon;                                 ///< has to be specified by generator
-  };
-
-  struct ImportData
-  {
-    ezString m_sGroup;
-    ezString m_sInputFileRelative;
-    ezString m_sInputFileParentRelative;
-    ezString m_sInputFileAbsolute;
-    ezInt32 m_iSelectedOption = -1;
-    ezString m_sImportMessage; // error text or "already exists"
-    bool m_bDoNotImport = false;
-
-    ezHybridArray<ezAssetDocumentGenerator::Info, 4> m_ImportOptions;
+    ezAssetDocGeneratorPriority m_Priority = ezAssetDocGeneratorPriority::Undecided;
+    ezString m_sName;
+    ezString m_sIcon;
   };
 
   /// \brief Creates a list of all importable file extensions. Note that this is an expensive function so the the result should be cached.
   /// \param out_Extensions List of all file extensions that can be imported.
   static void GetSupportsFileTypes(ezSet<ezString>& out_extensions);
-  static void ImportAssets();
-  static void ImportAssets(const ezDynamicArray<ezString>& filesToImport);
-  static void ExecuteImport(ezDynamicArray<ezAssetDocumentGenerator::ImportData>& ref_allImports);
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const = 0;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& mode, ezDocument*& out_pGeneratedDocument) = 0;
+  /// \brief Opens a file browse dialog to let the user choose which files to import.
+  ///
+  /// After the user chose one or multiple files, opens the "Asset Import" dialog to let them choose details.
+  static void ImportAssets();
+
+  /// \brief Opens the "Asset Import" dialog to let the user choose how to import the given files.
+  static void ImportAssets(const ezDynamicArray<ezString>& filesToImport);
+
+  /// \brief Imports the given file with the mode. Must be a mode that the generator supports.
+  ezStatus Import(ezStringView sInputFileAbs, ezStringView sMode, bool bOpenDocument);
+
+  /// \brief Used to fill out which import modes may be available for the given asset.
+  ///
+  /// Note: sAbsInputFile may be empty, in this case it should fill out the array for "general purpose" import (any file of the supported types).
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ImportMode>& out_Modes) const = 0;
+
+  /// \brief Returns the target asset document file extension.
   virtual ezStringView GetDocumentExtension() const = 0;
+
+  /// \brief Allows to merge the import modes of multiple generators in the UI in one group.
   virtual ezStringView GetGeneratorGroup() const = 0;
 
-  void GetSupportedFileTypes(ezSet<ezString>& ref_extensions) const;
+  /// \brief Tells the generator to create a new asset document with the chosen mode.
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) = 0;
+
+  /// \brief Returns whether this generator supports the given file type for import.
   bool SupportsFileType(ezStringView sFile) const;
-  void BuildFileDialogFilterString(ezStringBuilder& out_sFilter) const;
-  void AppendFileFilterStrings(ezStringBuilder& out_sFilter, bool& ref_bSemicolon) const;
+
+  /// \brief Instantiates all currently available generators.
+  static void CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_Generators);
+
+  /// \brief Destroys the previously instantiated generators.
+  static void DestroyGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
 
 protected:
   void AddSupportedFileType(ezStringView sExtension);
 
 private:
-  static void CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_Generators);
-  static void DestroyGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
-  static ezResult DetermineInputAndOutputFiles(ImportData& data, Info& option);
-  static void SortAndSelectBestImportOption(ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports);
-  static void CreateImportOptionList(const ezDynamicArray<ezString>& filesToImport, ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
+  void BuildFileDialogFilterString(ezStringBuilder& out_sFilter) const;
+  void AppendFileFilterStrings(ezStringBuilder& out_sFilter, bool& ref_bSemicolon) const;
+
+  friend class ezQtAssetImportDlg;
+
+  struct ImportGroupOptions
+  {
+    ezString m_sGroup;
+    ezString m_sInputFileRelative;
+    ezString m_sInputFileAbsolute;
+    ezInt32 m_iSelectedOption = -1;
+
+    ezHybridArray<ezAssetDocumentGenerator::ImportMode, 4> m_ImportOptions;
+  };
+
+  static void SortAndSelectBestImportOption(ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& allImports);
+  static void CreateImportOptionList(const ezDynamicArray<ezString>& filesToImport, ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
 
   ezHybridArray<ezString, 16> m_SupportedFileTypes;
 };

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
@@ -57,7 +57,7 @@ public:
   /// \brief Used to fill out which import modes may be available for the given asset.
   ///
   /// Note: sAbsInputFile may be empty, in this case it should fill out the array for "general purpose" import (any file of the supported types).
-  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ImportMode>& out_Modes) const = 0;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ImportMode>& out_modes) const = 0;
 
   /// \brief Returns the target asset document file extension.
   virtual ezStringView GetDocumentExtension() const = 0;
@@ -72,10 +72,10 @@ public:
   bool SupportsFileType(ezStringView sFile) const;
 
   /// \brief Instantiates all currently available generators.
-  static void CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_Generators);
+  static void CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_generators);
 
   /// \brief Destroys the previously instantiated generators.
-  static void DestroyGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
+  static void DestroyGenerators(const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators);
 
 protected:
   void AddSupportedFileType(ezStringView sExtension);

--- a/Code/Editor/EditorFramework/Assets/AssetImportDlg.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetImportDlg.moc.h
@@ -10,21 +10,16 @@ class ezQtAssetImportDlg : public QDialog, public Ui_AssetImportDlg
   Q_OBJECT
 
 public:
-  ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetDocumentGenerator::ImportData>& ref_allImports);
+  ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& ref_allImports);
   ~ezQtAssetImportDlg();
 
 private Q_SLOTS:
   void SelectedOptionChanged(int index);
   void on_ButtonImport_clicked();
-  void TableCellChanged(int row, int column);
-  void BrowseButtonClicked(bool);
 
 private:
   void InitRow(ezUInt32 uiRow);
-  void UpdateRow(ezUInt32 uiRow);
-  void QueryRow(ezUInt32 uiRow);
-  void UpdateAllRows();
 
-  ezDynamicArray<ezAssetDocumentGenerator::ImportData>& m_AllImports;
+  ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& m_AllImports;
 };
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -67,28 +67,26 @@ void ezAssetDocumentGenerator::AppendFileFilterStrings(ezStringBuilder& out_sFil
   }
 }
 
-void ezAssetDocumentGenerator::CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_Generators)
+void ezAssetDocumentGenerator::CreateGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& out_generators)
 {
   ezRTTI::ForEachDerivedType<ezAssetDocumentGenerator>(
     [&](const ezRTTI* pRtti)
     {
-      out_Generators.PushBack(pRtti->GetAllocator()->Allocate<ezAssetDocumentGenerator>());
+      out_generators.PushBack(pRtti->GetAllocator()->Allocate<ezAssetDocumentGenerator>());
     },
     ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
   // sort by name
-  out_Generators.Sort([](ezAssetDocumentGenerator* lhs, ezAssetDocumentGenerator* rhs) -> bool
+  out_generators.Sort([](ezAssetDocumentGenerator* lhs, ezAssetDocumentGenerator* rhs) -> bool
     { return lhs->GetDocumentExtension().Compare_NoCase(rhs->GetDocumentExtension()) < 0; });
 }
 
-void ezAssetDocumentGenerator::DestroyGenerators(ezHybridArray<ezAssetDocumentGenerator*, 16>& generators)
+void ezAssetDocumentGenerator::DestroyGenerators(const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators)
 {
   for (ezAssetDocumentGenerator* pGen : generators)
   {
     pGen->GetDynamicRTTI()->GetAllocator()->Deallocate(pGen);
   }
-
-  generators.Clear();
 }
 
 void ezAssetDocumentGenerator::ImportAssets(const ezDynamicArray<ezString>& filesToImport)

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -20,18 +20,13 @@ void ezAssetDocumentGenerator::AddSupportedFileType(ezStringView sExtension)
   m_SupportedFileTypes.PushBack(tmp);
 }
 
-
-void ezAssetDocumentGenerator::GetSupportedFileTypes(ezSet<ezString>& ref_extensions) const
-{
-  for (const ezString& ext : m_SupportedFileTypes)
-  {
-    ref_extensions.Insert(ext);
-  }
-}
-
 bool ezAssetDocumentGenerator::SupportsFileType(ezStringView sFile) const
 {
   ezStringBuilder tmp = ezPathUtils::GetFileExtension(sFile);
+
+  if (tmp.IsEmpty())
+    tmp = sFile;
+
   tmp.ToLower();
 
   return m_SupportedFileTypes.Contains(tmp);
@@ -96,94 +91,12 @@ void ezAssetDocumentGenerator::DestroyGenerators(ezHybridArray<ezAssetDocumentGe
   generators.Clear();
 }
 
-
-void ezAssetDocumentGenerator::ExecuteImport(ezDynamicArray<ImportData>& ref_allImports)
-{
-  for (auto& data : ref_allImports)
-  {
-    if (data.m_iSelectedOption < 0)
-      continue;
-
-    EZ_LOG_BLOCK("Asset Import", data.m_sInputFileParentRelative);
-
-    auto& option = data.m_ImportOptions[data.m_iSelectedOption];
-
-    if (DetermineInputAndOutputFiles(data, option).Failed())
-      continue;
-
-    ezDocument* pGeneratedDoc = nullptr;
-    const ezStatus status = option.m_pGenerator->Generate(data.m_sInputFileRelative, option, pGeneratedDoc);
-
-    if (pGeneratedDoc)
-    {
-      pGeneratedDoc->SaveDocument(true).LogFailure();
-      pGeneratedDoc->GetDocumentManager()->CloseDocument(pGeneratedDoc);
-
-      ezQtEditorApp::GetSingleton()->OpenDocumentQueued(option.m_sOutputFileAbsolute);
-    }
-
-    if (status.Failed())
-    {
-      data.m_sImportMessage = status.m_sMessage;
-      ezLog::Error("Asset import failed: '{0}'", status.m_sMessage);
-    }
-    else
-    {
-      data.m_sImportMessage.Clear();
-      data.m_bDoNotImport = true;
-      ezLog::Success("Generated asset document '{0}'", option.m_sOutputFileAbsolute);
-    }
-  }
-}
-
-
-ezResult ezAssetDocumentGenerator::DetermineInputAndOutputFiles(ImportData& data, Info& option)
-{
-  auto pApp = ezQtEditorApp::GetSingleton();
-
-  ezStringBuilder inputFile = data.m_sInputFileParentRelative;
-  if (!pApp->MakeParentDataDirectoryRelativePathAbsolute(inputFile, true))
-  {
-    data.m_sImportMessage = "Input file could not be located";
-    return EZ_FAILURE;
-  }
-
-  data.m_sInputFileAbsolute = inputFile;
-
-  if (!pApp->MakePathDataDirectoryRelative(inputFile))
-  {
-    data.m_sImportMessage = "Input file is not in any known data directory";
-    return EZ_FAILURE;
-  }
-
-  data.m_sInputFileRelative = inputFile;
-
-  ezStringBuilder outputFile = option.m_sOutputFileParentRelative;
-  if (!pApp->MakeParentDataDirectoryRelativePathAbsolute(outputFile, false))
-  {
-    data.m_sImportMessage = "Target file location could not be found";
-    return EZ_FAILURE;
-  }
-
-  option.m_sOutputFileAbsolute = outputFile;
-
-  // don't create it when it already exists
-  if (ezOSFile::ExistsFile(outputFile))
-  {
-    data.m_bDoNotImport = true;
-    data.m_sImportMessage = "Target file already exists";
-    return EZ_FAILURE;
-  }
-
-  return EZ_SUCCESS;
-}
-
 void ezAssetDocumentGenerator::ImportAssets(const ezDynamicArray<ezString>& filesToImport)
 {
   ezHybridArray<ezAssetDocumentGenerator*, 16> generators;
   CreateGenerators(generators);
 
-  ezDynamicArray<ezAssetDocumentGenerator::ImportData> allImports;
+  ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions> allImports;
   allImports.Reserve(filesToImport.GetCount());
 
   CreateImportOptionList(filesToImport, allImports, generators);
@@ -204,7 +117,10 @@ void ezAssetDocumentGenerator::GetSupportsFileTypes(ezSet<ezString>& out_extensi
   CreateGenerators(generators);
   for (auto pGen : generators)
   {
-    pGen->GetSupportedFileTypes(out_extensions);
+    for (const ezString& ext : pGen->m_SupportedFileTypes)
+    {
+      out_extensions.Insert(ext);
+    }
   }
   DestroyGenerators(generators);
 }
@@ -253,35 +169,28 @@ void ezAssetDocumentGenerator::ImportAssets()
   ImportAssets(filesToImport);
 }
 
-void ezAssetDocumentGenerator::CreateImportOptionList(const ezDynamicArray<ezString>& filesToImport,
-  ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators)
+void ezAssetDocumentGenerator::CreateImportOptionList(const ezDynamicArray<ezString>& filesToImport, ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& allImports, const ezHybridArray<ezAssetDocumentGenerator*, 16>& generators)
 {
   ezQtEditorApp* pApp = ezQtEditorApp::GetSingleton();
-  ezStringBuilder sInputParentRelative, sInputRelative, sGroup;
+  ezStringBuilder sInputRelative, sGroup;
 
   for (const ezString& sInputAbsolute : filesToImport)
   {
-    sInputParentRelative = sInputAbsolute;
     sInputRelative = sInputAbsolute;
 
-    if (!pApp->MakePathDataDirectoryParentRelative(sInputParentRelative) || !pApp->MakePathDataDirectoryRelative(sInputRelative))
+    if (!pApp->MakePathDataDirectoryRelative(sInputRelative))
     {
-      auto& data = allImports.ExpandAndGetRef();
-      data.m_sInputFileAbsolute = sInputAbsolute;
-      data.m_sInputFileParentRelative = sInputParentRelative;
-      data.m_sInputFileRelative = sInputRelative;
-      data.m_sImportMessage = "File is not located in any data directory.";
-      data.m_bDoNotImport = true;
+      // error, file is not in data directory -> skip
       continue;
     }
 
     for (ezAssetDocumentGenerator* pGen : generators)
     {
-      if (pGen->SupportsFileType(sInputParentRelative))
+      if (pGen->SupportsFileType(sInputRelative))
       {
         sGroup = pGen->GetGeneratorGroup();
 
-        ImportData* pData = nullptr;
+        ImportGroupOptions* pData = nullptr;
         for (auto& importer : allImports)
         {
           if (importer.m_sGroup == sGroup && importer.m_sInputFileAbsolute == sInputAbsolute)
@@ -295,12 +204,11 @@ void ezAssetDocumentGenerator::CreateImportOptionList(const ezDynamicArray<ezStr
           pData = &allImports.ExpandAndGetRef();
           pData->m_sGroup = sGroup;
           pData->m_sInputFileAbsolute = sInputAbsolute;
-          pData->m_sInputFileParentRelative = sInputParentRelative;
           pData->m_sInputFileRelative = sInputRelative;
         }
 
-        ezHybridArray<ezAssetDocumentGenerator::Info, 4> options;
-        pGen->GetImportModes(sInputParentRelative, options);
+        ezHybridArray<ezAssetDocumentGenerator::ImportMode, 4> options;
+        pGen->GetImportModes(sInputAbsolute, options);
 
         for (auto& option : options)
         {
@@ -313,14 +221,14 @@ void ezAssetDocumentGenerator::CreateImportOptionList(const ezDynamicArray<ezStr
   }
 }
 
-void ezAssetDocumentGenerator::SortAndSelectBestImportOption(ezDynamicArray<ezAssetDocumentGenerator::ImportData>& allImports)
+void ezAssetDocumentGenerator::SortAndSelectBestImportOption(ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& allImports)
 {
-  allImports.Sort([](const ezAssetDocumentGenerator::ImportData& lhs, const ezAssetDocumentGenerator::ImportData& rhs) -> bool
-    { return lhs.m_sInputFileParentRelative < rhs.m_sInputFileParentRelative; });
+  allImports.Sort([](const ezAssetDocumentGenerator::ImportGroupOptions& lhs, const ezAssetDocumentGenerator::ImportGroupOptions& rhs) -> bool
+    { return lhs.m_sInputFileRelative < rhs.m_sInputFileRelative; });
 
   for (auto& singleImport : allImports)
   {
-    singleImport.m_ImportOptions.Sort([](const ezAssetDocumentGenerator::Info& lhs, const ezAssetDocumentGenerator::Info& rhs) -> bool
+    singleImport.m_ImportOptions.Sort([](const ezAssetDocumentGenerator::ImportMode& lhs, const ezAssetDocumentGenerator::ImportMode& rhs) -> bool
       { return ezTranslate(lhs.m_sName).Compare_NoCase(ezTranslate(rhs.m_sName)) < 0; });
 
     ezUInt32 uiNumPrios[(ezUInt32)ezAssetDocGeneratorPriority::ENUM_COUNT] = {0};
@@ -345,4 +253,30 @@ void ezAssetDocumentGenerator::SortAndSelectBestImportOption(ezDynamicArray<ezAs
         break;
     }
   }
+}
+
+ezStatus ezAssetDocumentGenerator::Import(ezStringView sInputFileAbs, ezStringView sMode, bool bOpenDocument)
+{
+  ezStringBuilder ext = sInputFileAbs.GetFileExtension();
+  ext.ToLower();
+
+  if (!m_SupportedFileTypes.Contains(ext))
+    return ezStatus(ezFmt("Files of type '{}' cannot be imported as '{}' documents.", ext, GetDocumentExtension()));
+
+  ezDocument* pGeneratedDoc = nullptr;
+  EZ_SUCCEED_OR_RETURN(Generate(sInputFileAbs, sMode, pGeneratedDoc));
+
+  EZ_ASSERT_DEV(pGeneratedDoc != nullptr, "");
+
+  const ezString sDocPath = pGeneratedDoc->GetDocumentPath();
+
+  pGeneratedDoc->SaveDocument(true).LogFailure();
+  pGeneratedDoc->GetDocumentManager()->CloseDocument(pGeneratedDoc);
+
+  if (bOpenDocument)
+  {
+    ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sDocPath);
+  }
+
+  return ezStatus(EZ_SUCCESS);
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetImportDlg.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetImportDlg.cpp
@@ -7,13 +7,10 @@ enum Columns
 {
   Method,
   InputFile,
-  GeneratedDoc,
-  Browse,
-  Status,
   ENUM_COUNT
 };
 
-ezQtAssetImportDlg::ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetDocumentGenerator::ImportData>& ref_allImports)
+ezQtAssetImportDlg::ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetDocumentGenerator::ImportGroupOptions>& ref_allImports)
   : QDialog(pParent)
   , m_AllImports(ref_allImports)
 {
@@ -22,9 +19,6 @@ ezQtAssetImportDlg::ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetD
   QStringList headers;
   headers.push_back(QString::fromUtf8("Import Method"));
   headers.push_back(QString::fromUtf8("Input File"));
-  headers.push_back(QString::fromUtf8("Generated Document"));
-  headers.push_back(QString());
-  headers.push_back(QString("Status"));
 
   QTableWidget* table = AssetTable;
   table->setColumnCount(headers.size());
@@ -41,15 +35,7 @@ ezQtAssetImportDlg::ezQtAssetImportDlg(QWidget* pParent, ezDynamicArray<ezAssetD
   }
 
   table->horizontalHeader()->setSectionResizeMode(Columns::Method, QHeaderView::ResizeMode::ResizeToContents);
-  table->horizontalHeader()->setSectionResizeMode(Columns::InputFile, QHeaderView::ResizeMode::Interactive);
-  table->horizontalHeader()->setSectionResizeMode(Columns::GeneratedDoc, QHeaderView::ResizeMode::Interactive);
-  table->horizontalHeader()->setSectionResizeMode(Columns::Browse, QHeaderView::ResizeMode::ResizeToContents);
-  table->horizontalHeader()->setSectionResizeMode(Columns::Status, QHeaderView::ResizeMode::Stretch);
-
-  table->resizeColumnToContents(Columns::GeneratedDoc);
-  table->resizeColumnToContents(Columns::InputFile);
-  table->setColumnWidth(Columns::InputFile, table->columnWidth(Columns::InputFile) + 30);
-  table->setColumnWidth(Columns::GeneratedDoc, table->columnWidth(Columns::GeneratedDoc) + 30);
+  table->horizontalHeader()->setSectionResizeMode(Columns::InputFile, QHeaderView::ResizeMode::Stretch);
 }
 
 ezQtAssetImportDlg::~ezQtAssetImportDlg() = default;
@@ -59,10 +45,8 @@ void ezQtAssetImportDlg::InitRow(ezUInt32 uiRow)
   QTableWidget* table = AssetTable;
   const auto& data2 = m_AllImports[uiRow];
 
-  table->setItem(uiRow, Columns::InputFile, new QTableWidgetItem(data2.m_sInputFileParentRelative.GetData()));
-  table->setItem(uiRow, Columns::Status, new QTableWidgetItem());
+  table->setItem(uiRow, Columns::InputFile, new QTableWidgetItem(data2.m_sInputFileRelative.GetData()));
   table->item(uiRow, Columns::InputFile)->setFlags(Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsSelectable);
-  table->item(uiRow, Columns::Status)->setFlags(Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsSelectable);
 
   QComboBox* pCombo = new QComboBox();
   table->setCellWidget(uiRow, Columns::Method, pCombo);
@@ -77,57 +61,6 @@ void ezQtAssetImportDlg::InitRow(ezUInt32 uiRow)
   pCombo->setProperty("row", uiRow);
   pCombo->setCurrentIndex(data2.m_iSelectedOption + 1);
   connect(pCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(SelectedOptionChanged(int)));
-  connect(table, &QTableWidget::cellChanged, this, &ezQtAssetImportDlg::TableCellChanged);
-
-  table->setItem(uiRow, Columns::GeneratedDoc, new QTableWidgetItem(QString()));
-  table->item(uiRow, Columns::GeneratedDoc)->setFlags(Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsEditable | Qt::ItemFlag::ItemIsSelectable);
-
-  QToolButton* pBrowse = new QToolButton();
-  pBrowse->setText("Browse...");
-  pBrowse->setProperty("row", uiRow);
-  connect(pBrowse, &QToolButton::clicked, this, &ezQtAssetImportDlg::BrowseButtonClicked);
-  table->setCellWidget(uiRow, Columns::Browse, pBrowse);
-
-  UpdateRow(uiRow);
-}
-
-void ezQtAssetImportDlg::UpdateRow(ezUInt32 uiRow)
-{
-  QTableWidget* table = AssetTable;
-  ezQtScopedBlockSignals _1(table);
-
-  const auto& data2 = m_AllImports[uiRow];
-
-  QTableWidgetItem* pOutputItem = table->item(uiRow, Columns::GeneratedDoc);
-  QTableWidgetItem* pStatusItem = table->item(uiRow, Columns::Status);
-
-  if (data2.m_iSelectedOption < 0)
-    pOutputItem->setText(QString());
-  else
-    pOutputItem->setText(data2.m_ImportOptions[data2.m_iSelectedOption].m_sOutputFileParentRelative.GetData());
-
-  QToolButton* pBrowse = qobject_cast<QToolButton*>(table->cellWidget(uiRow, Columns::Browse));
-  pBrowse->setEnabled(data2.m_iSelectedOption >= 0);
-
-  pStatusItem->setForeground(QColor::fromRgba(qRgb(200, 0, 0)));
-  pStatusItem->setText(data2.m_sImportMessage.GetData());
-
-  if (data2.m_bDoNotImport)
-  {
-    pOutputItem->setFlags(Qt::ItemFlag::ItemIsSelectable);
-    pBrowse->setEnabled(false);
-    QComboBox* pCombo = qobject_cast<QComboBox*>(table->cellWidget(uiRow, Columns::Method));
-    pCombo->setEnabled(false);
-
-    pBrowse->setEnabled(true);
-    pBrowse->setText("Open");
-    pStatusItem->setForeground(QColor::fromRgba(qRgb(0, 200, 0)));
-
-    if (data2.m_sImportMessage.IsEmpty())
-    {
-      pStatusItem->setText("Asset Imported");
-    }
-  }
 }
 
 void ezQtAssetImportDlg::SelectedOptionChanged(int index)
@@ -135,86 +68,23 @@ void ezQtAssetImportDlg::SelectedOptionChanged(int index)
   QComboBox* pCombo = qobject_cast<QComboBox*>(sender());
   const ezUInt32 uiRow = pCombo->property("row").toInt();
 
-  QueryRow(uiRow);
   m_AllImports[uiRow].m_iSelectedOption = index - 1;
-  UpdateRow(uiRow);
-}
-
-void ezQtAssetImportDlg::QueryRow(ezUInt32 uiRow)
-{
-  QTableWidget* table = AssetTable;
-  auto& data2 = m_AllImports[uiRow];
-
-  if (data2.m_iSelectedOption < 0)
-    return;
-
-  auto& option = data2.m_ImportOptions[data2.m_iSelectedOption];
-
-  ezStringBuilder file = table->item(uiRow, Columns::GeneratedDoc)->text().toUtf8().data();
-  file.ChangeFileExtension(option.m_pGenerator->GetDocumentExtension());
-  option.m_sOutputFileParentRelative = file;
-}
-
-void ezQtAssetImportDlg::UpdateAllRows()
-{
-  for (ezUInt32 i = 0; i < m_AllImports.GetCount(); ++i)
-  {
-    UpdateRow(i);
-  }
 }
 
 void ezQtAssetImportDlg::on_ButtonImport_clicked()
 {
-  ezAssetDocumentGenerator::ExecuteImport(m_AllImports);
+  for (auto& data : m_AllImports)
+  {
+    if (data.m_iSelectedOption < 0)
+      continue;
 
-  UpdateAllRows();
+    EZ_LOG_BLOCK("Asset Import", data.m_sInputFileRelative);
+
+    const auto& option = data.m_ImportOptions[data.m_iSelectedOption];
+
+    option.m_pGenerator->Import(data.m_sInputFileAbsolute, option.m_sName, true).LogFailure();
+  }
+
+  accept();
 }
 
-void ezQtAssetImportDlg::TableCellChanged(int row, int column)
-{
-  if (column == Columns::GeneratedDoc)
-  {
-    QueryRow(row);
-    UpdateRow(row);
-  }
-}
-
-void ezQtAssetImportDlg::BrowseButtonClicked(bool)
-{
-  QToolButton* pButton = qobject_cast<QToolButton*>(sender());
-  const ezUInt32 uiRow = pButton->property("row").toInt();
-
-  auto& data2 = m_AllImports[uiRow];
-  if (data2.m_iSelectedOption < 0)
-    return;
-
-  auto& option = data2.m_ImportOptions[data2.m_iSelectedOption];
-
-  if (data2.m_bDoNotImport)
-  {
-    // asset was already imported
-
-    ezQtEditorApp::GetSingleton()->OpenDocumentQueued(option.m_sOutputFileAbsolute);
-  }
-  else
-  {
-    ezStringBuilder filter;
-    filter.Format("{0} (*.{0})", option.m_pGenerator->GetDocumentExtension());
-    QString result = QFileDialog::getSaveFileName(this, "Target Document", ezToolsProject::GetSingleton()->GetProjectDirectory().GetData(),
-      filter.GetData(), nullptr, QFileDialog::Option::DontResolveSymlinks);
-
-    if (result.isEmpty())
-      return;
-
-    ezStringBuilder tmp = result.toUtf8().data();
-    if (!ezQtEditorApp::GetSingleton()->MakePathDataDirectoryParentRelative(tmp))
-    {
-      ezQtUiServices::GetSingleton()->MessageBoxWarning("The selected file is not located in any of the project's data directories.");
-      return;
-    }
-
-    option.m_sOutputFileAbsolute = result.toUtf8().data();
-    option.m_sOutputFileParentRelative = tmp;
-    UpdateRow(uiRow);
-  }
-}

--- a/Code/Editor/EditorFramework/EditorApp/Documents.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Documents.cpp
@@ -5,9 +5,9 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <ToolsFoundation/Document/DocumentUtils.h>
 
-void ezQtEditorApp::OpenDocumentQueued(const char* szDocument, const ezDocumentObject* pOpenContext /*= nullptr*/)
+void ezQtEditorApp::OpenDocumentQueued(ezStringView sDocument, const ezDocumentObject* pOpenContext /*= nullptr*/)
 {
-  QMetaObject::invokeMethod(this, "SlotQueuedOpenDocument", Qt::ConnectionType::QueuedConnection, Q_ARG(QString, szDocument), Q_ARG(void*, (void*)pOpenContext));
+  QMetaObject::invokeMethod(this, "SlotQueuedOpenDocument", Qt::ConnectionType::QueuedConnection, Q_ARG(QString, ezMakeQString(sDocument)), Q_ARG(void*, (void*)pOpenContext));
 }
 
 ezDocument* ezQtEditorApp::OpenDocument(ezStringView sDocument, ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext)
@@ -71,7 +71,7 @@ The following types are missing:\n",
   return pDocument;
 }
 
-ezDocument* ezQtEditorApp::CreateDocument(const char* szDocument, ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext)
+ezDocument* ezQtEditorApp::CreateDocument(ezStringView sDocument, ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext)
 {
   EZ_PROFILE_SCOPE("CreateDocument");
 
@@ -81,11 +81,11 @@ ezDocument* ezQtEditorApp::CreateDocument(const char* szDocument, ezBitflags<ezD
   const ezDocumentTypeDescriptor* pTypeDesc = nullptr;
 
   {
-    ezStatus res = ezDocumentUtils::IsValidSaveLocationForDocument(szDocument, &pTypeDesc);
+    ezStatus res = ezDocumentUtils::IsValidSaveLocationForDocument(sDocument, &pTypeDesc);
     if (res.Failed())
     {
       ezStringBuilder s;
-      s.Format("Failed to create document: \n'{0}'", szDocument);
+      s.Format("Failed to create document: \n'{0}'", sDocument);
       ezQtUiServices::MessageBoxStatus(res, s);
       return nullptr;
     }
@@ -93,11 +93,11 @@ ezDocument* ezQtEditorApp::CreateDocument(const char* szDocument, ezBitflags<ezD
 
   ezDocument* pDocument = nullptr;
   {
-    ezStatus result = pTypeDesc->m_pManager->CreateDocument(pTypeDesc->m_sDocumentTypeName, szDocument, pDocument, flags, pOpenContext);
+    ezStatus result = pTypeDesc->m_pManager->CreateDocument(pTypeDesc->m_sDocumentTypeName, sDocument, pDocument, flags, pOpenContext);
     if (result.m_Result.Failed())
     {
       ezStringBuilder s;
-      s.Format("Failed to create document: \n'{0}'", szDocument);
+      s.Format("Failed to create document: \n'{0}'", sDocument);
       ezQtUiServices::MessageBoxStatus(result, s);
       return nullptr;
     }

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -166,9 +166,9 @@ public:
   bool GuiCreateProject(bool bImmediate = false);
   bool GuiOpenProject(bool bImmediate = false);
 
-  void OpenDocumentQueued(const char* szDocument, const ezDocumentObject* pOpenContext = nullptr);
+  void OpenDocumentQueued(ezStringView sDocument, const ezDocumentObject* pOpenContext = nullptr);
   ezDocument* OpenDocument(ezStringView sDocument, ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext = nullptr);
-  ezDocument* CreateDocument(const char* szDocument, ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext = nullptr);
+  ezDocument* CreateDocument(ezStringView sDocument, ezBitflags<ezDocumentFlags> flags, const ezDocumentObject* pOpenContext = nullptr);
 
   ezResult CreateOrOpenProject(bool bCreate, ezStringView sFile);
 

--- a/Code/Editor/EditorFramework/QtResources/Icons/ImportableFile.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ImportableFile.svg
@@ -5,37 +5,37 @@
    width="800px"
    height="800px"
    viewBox="0 0 24 24"
-   fill="none"
+   id="down-sign"
+   class="icon glyph"
+   fill="#ffffff"
+   stroke="#ffffff"
    version="1.1"
-   id="svg61"
-   sodipodi:docname="ImportableFile.svg"
+   sodipodi:docname="ImportableFileType.svg"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs65" />
+     id="defs1" />
   <sodipodi:namedview
-     id="namedview63"
-     pagecolor="#000000"
+     id="namedview1"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
-     inkscape:pageopacity="0"
+     inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     showguides="true"
-     inkscape:zoom="0.90774833"
-     inkscape:cx="548.05939"
-     inkscape:cy="473.14876"
+     inkscape:zoom="1.11375"
+     inkscape:cx="400"
+     inkscape:cy="400"
      inkscape:window-width="1920"
      inkscape:window-height="1129"
      inkscape:window-x="1912"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg61" />
+     inkscape:current-layer="down-sign" />
   <g
      id="SVGRepo_bgCarrier"
      stroke-width="0" />
@@ -43,22 +43,12 @@
      id="SVGRepo_tracerCarrier"
      stroke-linecap="round"
      stroke-linejoin="round" />
-  <path
-     d="M 3,10 C 3,6.22876 3,4.34315 4.17157,3.17157 5.34315,2 7.22876,2 11,2 h 2 c 3.7712,0 5.6569,0 6.8284,1.17157 C 21,4.34315 21,6.22876 21,10 v 4 c 0,3.7712 0,5.6569 -1.1716,6.8284 C 18.6569,22 16.7712,22 13,22 H 11 C 7.22876,22 5.34315,22 4.17157,20.8284 3,19.6569 3,17.7712 3,14 Z"
-     stroke="#ffffff"
-     stroke-width="1.5"
-     id="path54"
-     style="stroke:#fefdfd;stroke-opacity:1" />
-  <path
-     d="m 12.035053,5.940493 v 8.044913"
-     id="path1"
-     style="stroke:#b96b29;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 9.3534159,11.303769 2.6816371,2.681637 2.681638,-2.681637"
-     id="path2"
-     style="stroke:#b96b29;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="M 9.3534159,7.2813118 H 6.6717783 A 1.3408188,1.3408188 0 0 0 5.3309595,8.6221306 v 6.7040934 a 1.3408188,1.3408188 0 0 0 1.3408188,1.340819 H 17.398328 a 1.3408188,1.3408188 0 0 0 1.340819,-1.340819 V 8.6221306 A 1.3408188,1.3408188 0 0 0 17.398328,7.2813118 h -2.681637"
-     id="path3"
-     style="stroke:#b96b29;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <g
+     id="SVGRepo_iconCarrier"
+     style="stroke-width:0.99999;stroke-dasharray:none;fill:#b96b29;fill-opacity:1">
+    <path
+       d="M21.51,4.14a1,1,0,0,0-1,0L12,8.86,3.49,4.13a1,1,0,0,0-1,0A1,1,0,0,0,2,5v9a1,1,0,0,0,.51.87l9,5,.15.06.09,0A1,1,0,0,0,12,20h0a1,1,0,0,0,.25,0l.09,0,.15-.06,9-5A1,1,0,0,0,22,14V5A1,1,0,0,0,21.51,4.14Z"
+       style="fill:#b96b29;stroke-width:0.99999;stroke-dasharray:none;fill-opacity:1"
+       id="path1" />
+  </g>
 </svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/ImportableFileType.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ImportableFileType.svg
@@ -5,37 +5,37 @@
    width="800px"
    height="800px"
    viewBox="0 0 24 24"
-   fill="none"
+   id="down-sign"
+   class="icon glyph"
+   fill="#ffffff"
+   stroke="#ffffff"
    version="1.1"
-   id="svg61"
-   sodipodi:docname="ImportableFile.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="ImportableFileType.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs65" />
+     id="defs1" />
   <sodipodi:namedview
-     id="namedview63"
-     pagecolor="#000000"
+     id="namedview1"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="0"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     showguides="true"
-     inkscape:zoom="1.28375"
-     inkscape:cx="396.10516"
-     inkscape:cy="401.55794"
-     inkscape:window-width="2560"
-     inkscape:window-height="1351"
-     inkscape:window-x="-9"
-     inkscape:window-y="-9"
+     inkscape:zoom="1.11375"
+     inkscape:cx="400"
+     inkscape:cy="400"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg61" />
+     inkscape:current-layer="down-sign" />
   <g
      id="SVGRepo_bgCarrier"
      stroke-width="0" />
@@ -43,21 +43,12 @@
      id="SVGRepo_tracerCarrier"
      stroke-linecap="round"
      stroke-linejoin="round" />
-  <path
-     d="M 3,10 C 3,6.22876 3,4.34315 4.17157,3.17157 5.34315,2 7.22876,2 11,2 h 2 c 3.7712,0 5.6569,0 6.8284,1.17157 C 21,4.34315 21,6.22876 21,10 v 4 c 0,3.7712 0,5.6569 -1.1716,6.8284 C 18.6569,22 16.7712,22 13,22 H 11 C 7.22876,22 5.34315,22 4.17157,20.8284 3,19.6569 3,17.7712 3,14 Z"
-     stroke="#ffffff"
-     stroke-width="1.5"
-     id="path54" />
-  <path
-     d="m 12.035053,5.940493 v 8.044913"
-     id="path1"
-     style="stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 9.3534159,11.303769 2.6816371,2.681637 2.681638,-2.681637"
-     id="path2"
-     style="stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="M 9.3534159,7.2813118 H 6.6717783 A 1.3408188,1.3408188 0 0 0 5.3309595,8.6221306 v 6.7040934 a 1.3408188,1.3408188 0 0 0 1.3408188,1.340819 H 17.398328 a 1.3408188,1.3408188 0 0 0 1.340819,-1.340819 V 8.6221306 A 1.3408188,1.3408188 0 0 0 17.398328,7.2813118 h -2.681637"
-     id="path3"
-     style="stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <g
+     id="SVGRepo_iconCarrier"
+     style="stroke-width:0.99999;stroke-dasharray:none;fill:#b96b29;fill-opacity:1">
+    <path
+       d="M21.51,4.14a1,1,0,0,0-1,0L12,8.86,3.49,4.13a1,1,0,0,0-1,0A1,1,0,0,0,2,5v9a1,1,0,0,0,.51.87l9,5,.15.06.09,0A1,1,0,0,0,12,20h0a1,1,0,0,0,.25,0l.09,0,.15-.06,9-5A1,1,0,0,0,22,14V5A1,1,0,0,0,21.51,4.14Z"
+       style="fill:#b96b29;stroke-width:0.99999;stroke-dasharray:none;fill-opacity:1"
+       id="path1" />
+  </g>
 </svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/ImportedFile.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ImportedFile.svg
@@ -5,9 +5,11 @@
    width="800px"
    height="800px"
    viewBox="0 0 24 24"
-   fill="none"
+   id="down-sign"
+   class="icon glyph"
+   fill="#ffffff"
+   stroke="#ffffff"
    version="1.1"
-   id="svg61"
    sodipodi:docname="ImportedFile.svg"
    inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -15,27 +17,25 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs65" />
+     id="defs1" />
   <sodipodi:namedview
-     id="namedview63"
-     pagecolor="#000000"
+     id="namedview1"
+     pagecolor="#ffffff"
      bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
-     inkscape:pageopacity="0"
-     inkscape:pagecheckerboard="0"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     showguides="true"
-     inkscape:zoom="1.28375"
-     inkscape:cx="396.10516"
-     inkscape:cy="402.3369"
-     inkscape:window-width="1920"
-     inkscape:window-height="1129"
-     inkscape:window-x="1912"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg61" />
+     inkscape:zoom="0.556875"
+     inkscape:cx="361.84063"
+     inkscape:cy="378.90011"
+     inkscape:window-width="958"
+     inkscape:window-height="1120"
+     inkscape:window-x="2873"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="SVGRepo_iconCarrier" />
   <g
      id="SVGRepo_bgCarrier"
      stroke-width="0" />
@@ -43,21 +43,11 @@
      id="SVGRepo_tracerCarrier"
      stroke-linecap="round"
      stroke-linejoin="round" />
-  <path
-     d="M 3,10 C 3,6.22876 3,4.34315 4.17157,3.17157 5.34315,2 7.22876,2 11,2 h 2 c 3.7712,0 5.6569,0 6.8284,1.17157 C 21,4.34315 21,6.22876 21,10 v 4 c 0,3.7712 0,5.6569 -1.1716,6.8284 C 18.6569,22 16.7712,22 13,22 H 11 C 7.22876,22 5.34315,22 4.17157,20.8284 3,19.6569 3,17.7712 3,14 Z"
-     stroke="#ffffff"
-     stroke-width="1.5"
-     id="path54" />
-  <path
-     d="m 12.035053,5.940493 v 8.044913"
-     id="path1"
-     style="stroke:#7d7d7d;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="m 9.3534159,11.303769 2.6816371,2.681637 2.681638,-2.681637"
-     id="path2"
-     style="stroke:#7d7d7d;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
-  <path
-     d="M 9.3534159,7.2813118 H 6.6717783 A 1.3408188,1.3408188 0 0 0 5.3309595,8.6221306 v 6.7040934 a 1.3408188,1.3408188 0 0 0 1.3408188,1.340819 H 17.398328 a 1.3408188,1.3408188 0 0 0 1.340819,-1.340819 V 8.6221306 A 1.3408188,1.3408188 0 0 0 17.398328,7.2813118 h -2.681637"
-     id="path3"
-     style="stroke:#7d7d7d;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1" />
+  <g
+     id="SVGRepo_iconCarrier">
+    <path
+       d="M21.51,4.14a1,1,0,0,0-1,0L12,8.86,3.49,4.13a1,1,0,0,0-1,0A1,1,0,0,0,2,5v9a1,1,0,0,0,.51.87l9,5,.15.06.09,0A1,1,0,0,0,12,20h0a1,1,0,0,0,.25,0l.09,0,.15-.06,9-5A1,1,0,0,0,22,14V5A1,1,0,0,0,21.51,4.14Z"
+       style="fill:#717171;fill-opacity:1;stroke:#9b9b9b;stroke-opacity:1"
+       id="path1" />
+  </g>
 </svg>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -128,49 +128,49 @@ ezAnimatedMeshAssetDocumentGenerator::ezAnimatedMeshAssetDocumentGenerator()
 
 ezAnimatedMeshAssetDocumentGenerator::~ezAnimatedMeshAssetDocumentGenerator() = default;
 
-void ezAnimatedMeshAssetDocumentGenerator::GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const
+void ezAnimatedMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const
 {
-  ezStringBuilder baseOutputFile = sParentDirRelativePath;
-  baseOutputFile.ChangeFileExtension(GetDocumentExtension());
-
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::LowPriority;
     info.m_sName = "AnimatedMeshImport.WithMaterials";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Animated_Mesh.svg";
   }
 
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::LowPriority;
     info.m_sName = "AnimatedMeshImport.NoMaterials";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Animated_Mesh.svg";
   }
 }
 
-ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument)
+ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
 {
+  ezStringBuilder sOutFile = sInputFileAbs;
+  sOutFile.ChangeFileExtension(GetDocumentExtension());
+  ezOSFile::FindFreeFilename(sOutFile);
+
   auto pApp = ezQtEditorApp::GetSingleton();
 
-  out_pGeneratedDocument = pApp->CreateDocument(info.m_sOutputFileAbsolute, ezDocumentFlags::None);
+  ezStringBuilder sInputFileRel = sInputFileAbs;
+  pApp->MakePathDataDirectoryRelative(sInputFileRel);
+
+  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
   if (out_pGeneratedDocument == nullptr)
     return ezStatus("Could not create target document");
 
   ezAnimatedMeshAssetDocument* pAssetDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(out_pGeneratedDocument);
-  if (pAssetDoc == nullptr)
-    return ezStatus("Target document is not a valid ezAnimatedMeshAssetDocument");
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
-  accessor.SetValue("MeshFile", sDataDirRelativePath);
+  accessor.SetValue("MeshFile", sInputFileRel.GetView());
 
-  if (info.m_sName == "AnimatedMeshImport.WithMaterials")
+  if (sMode == "AnimatedMeshImport.WithMaterials")
   {
     accessor.SetValue("ImportMaterials", true);
   }
 
-  if (info.m_sName == "AnimatedMeshImport.NoMaterials")
+  if (sMode == "AnimatedMeshImport.NoMaterials")
   {
     accessor.SetValue("ImportMaterials", false);
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
@@ -34,8 +34,8 @@ public:
   ezAnimatedMeshAssetDocumentGenerator();
   ~ezAnimatedMeshAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimatedMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Meshes"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -360,34 +360,35 @@ ezAnimationClipAssetDocumentGenerator::ezAnimationClipAssetDocumentGenerator()
 
 ezAnimationClipAssetDocumentGenerator::~ezAnimationClipAssetDocumentGenerator() = default;
 
-void ezAnimationClipAssetDocumentGenerator::GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const
+void ezAnimationClipAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const
 {
-  ezStringBuilder baseOutputFile = sParentDirRelativePath;
-  baseOutputFile.ChangeFileExtension(GetDocumentExtension());
-
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::Undecided;
     info.m_sName = "AnimationClipImport";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Animation_Clip.svg";
   }
 }
 
-ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument)
+ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
 {
+  ezStringBuilder sOutFile = sInputFileAbs;
+  sOutFile.ChangeFileExtension(GetDocumentExtension());
+  ezOSFile::FindFreeFilename(sOutFile);
+
   auto pApp = ezQtEditorApp::GetSingleton();
 
-  out_pGeneratedDocument = pApp->CreateDocument(info.m_sOutputFileAbsolute, ezDocumentFlags::None);
+  ezStringBuilder sInputFileRel = sInputFileAbs;
+  pApp->MakePathDataDirectoryRelative(sInputFileRel);
+
+  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
   if (out_pGeneratedDocument == nullptr)
     return ezStatus("Could not create target document");
 
   ezAnimationClipAssetDocument* pAssetDoc = ezDynamicCast<ezAnimationClipAssetDocument*>(out_pGeneratedDocument);
-  if (pAssetDoc == nullptr)
-    return ezStatus("Target document is not a valid ezAnimationClipAssetDocument");
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
-  accessor.SetValue("File", sDataDirRelativePath);
+  accessor.SetValue("File", sInputFileRel.GetView());
 
   return ezStatus(EZ_SUCCESS);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -83,8 +83,8 @@ public:
   ezAnimationClipAssetDocumentGenerator();
   ~ezAnimationClipAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimationClipAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "AnimationClipGroup"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
@@ -73,8 +73,8 @@ public:
   ezDecalAssetDocumentGenerator();
   ~ezDecalAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezDecalAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
@@ -33,8 +33,8 @@ public:
   ezLUTAssetDocumentGenerator();
   ~ezLUTAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezLUTAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "LUTs"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -297,49 +297,49 @@ ezMeshAssetDocumentGenerator::ezMeshAssetDocumentGenerator()
 
 ezMeshAssetDocumentGenerator::~ezMeshAssetDocumentGenerator() = default;
 
-void ezMeshAssetDocumentGenerator::GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const
+void ezMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const
 {
-  ezStringBuilder baseOutputFile = sParentDirRelativePath;
-  baseOutputFile.ChangeFileExtension(GetDocumentExtension());
-
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::DefaultPriority;
     info.m_sName = "MeshImport.WithMaterials";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Mesh.svg";
   }
 
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::LowPriority;
     info.m_sName = "MeshImport.NoMaterials";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Mesh.svg";
   }
 }
 
-ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument)
+ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
 {
+  ezStringBuilder sOutFile = sInputFileAbs;
+  sOutFile.ChangeFileExtension(GetDocumentExtension());
+  ezOSFile::FindFreeFilename(sOutFile);
+
   auto pApp = ezQtEditorApp::GetSingleton();
 
-  out_pGeneratedDocument = pApp->CreateDocument(info.m_sOutputFileAbsolute, ezDocumentFlags::None);
+  ezStringBuilder sInputFileRel = sInputFileAbs;
+  pApp->MakePathDataDirectoryRelative(sInputFileRel);
+
+  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
   if (out_pGeneratedDocument == nullptr)
     return ezStatus("Could not create target document");
 
   ezMeshAssetDocument* pAssetDoc = ezDynamicCast<ezMeshAssetDocument*>(out_pGeneratedDocument);
-  if (pAssetDoc == nullptr)
-    return ezStatus("Target document is not a valid ezMeshAssetDocument");
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
-  accessor.SetValue("MeshFile", sDataDirRelativePath);
+  accessor.SetValue("MeshFile", sInputFileRel.GetView());
 
-  if (info.m_sName == "MeshImport.WithMaterials")
+  if (sMode == "MeshImport.WithMaterials")
   {
     accessor.SetValue("ImportMaterials", true);
   }
 
-  if (info.m_sName == "MeshImport.NoMaterials")
+  if (sMode == "MeshImport.NoMaterials")
   {
     accessor.SetValue("ImportMaterials", false);
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -36,8 +36,8 @@ public:
   ezMeshAssetDocumentGenerator();
   ~ezMeshAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Meshes"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -87,8 +87,8 @@ public:
   ezSkeletonAssetDocumentGenerator();
   ~ezSkeletonAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezSkeletonAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "AnimationSkeletonGroup"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
@@ -56,8 +56,23 @@ public:
   ezTextureAssetDocumentGenerator();
   ~ezTextureAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  enum class TextureType
+  {
+    Diffuse,
+    Normal,
+    Occlusion,
+    Roughness,
+    Metalness,
+    ORM,
+    Height,
+    HDR,
+    Linear,
+  };
+
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezTextureAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+
+  static TextureType DetermineTextureType(ezStringView sFile);
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
@@ -54,8 +54,8 @@ public:
   ezTextureCubeAssetDocumentGenerator();
   ~ezTextureCubeAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezTextureCubeAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -360,25 +360,28 @@ ezJoltCollisionMeshAssetDocumentGenerator::ezJoltCollisionMeshAssetDocumentGener
 
 ezJoltCollisionMeshAssetDocumentGenerator::~ezJoltCollisionMeshAssetDocumentGenerator() = default;
 
-void ezJoltCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const
+void ezJoltCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const
 {
-  ezStringBuilder baseOutputFile = sParentDirRelativePath;
-  baseOutputFile.ChangeFileExtension("ezJoltCollisionMeshAsset");
-
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::DefaultPriority;
     info.m_sName = "Jolt_Colmesh_Triangle";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Jolt_Collision_Mesh.svg";
   }
 }
 
-ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument)
+ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
 {
+  ezStringBuilder sOutFile = sInputFileAbs;
+  sOutFile.ChangeFileExtension(GetDocumentExtension());
+  ezOSFile::FindFreeFilename(sOutFile);
+
   auto pApp = ezQtEditorApp::GetSingleton();
 
-  out_pGeneratedDocument = pApp->CreateDocument(info.m_sOutputFileAbsolute, ezDocumentFlags::None);
+  ezStringBuilder sInputFileRel = sInputFileAbs;
+  pApp->MakePathDataDirectoryRelative(sInputFileRel);
+
+  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
   if (out_pGeneratedDocument == nullptr)
     return ezStatus("Could not create target document");
 
@@ -387,11 +390,10 @@ ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sDataD
     return ezStatus("Target document is not a valid ezJoltCollisionMeshAssetDocument");
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
-  accessor.SetValue("MeshFile", sDataDirRelativePath);
+  accessor.SetValue("MeshFile", sInputFileRel.GetView());
 
   return ezStatus(EZ_SUCCESS);
 }
-
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -408,25 +410,28 @@ ezJoltConvexCollisionMeshAssetDocumentGenerator::ezJoltConvexCollisionMeshAssetD
 
 ezJoltConvexCollisionMeshAssetDocumentGenerator::~ezJoltConvexCollisionMeshAssetDocumentGenerator() = default;
 
-void ezJoltConvexCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const
+void ezJoltConvexCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const
 {
-  ezStringBuilder baseOutputFile = sParentDirRelativePath;
-  baseOutputFile.ChangeFileExtension("ezJoltConvexCollisionMeshAsset");
-
   {
-    ezAssetDocumentGenerator::Info& info = out_modes.ExpandAndGetRef();
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::LowPriority;
     info.m_sName = "Jolt_Colmesh_Convex";
-    info.m_sOutputFileParentRelative = baseOutputFile;
     info.m_sIcon = ":/AssetIcons/Jolt_Collision_Mesh_Convex.svg";
   }
 }
 
-ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument)
+ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
 {
+  ezStringBuilder sOutFile = sInputFileAbs;
+  sOutFile.ChangeFileExtension(GetDocumentExtension());
+  ezOSFile::FindFreeFilename(sOutFile);
+
   auto pApp = ezQtEditorApp::GetSingleton();
 
-  out_pGeneratedDocument = pApp->CreateDocument(info.m_sOutputFileAbsolute, ezDocumentFlags::None);
+  ezStringBuilder sInputFileRel = sInputFileAbs;
+  pApp->MakePathDataDirectoryRelative(sInputFileRel);
+
+  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
   if (out_pGeneratedDocument == nullptr)
     return ezStatus("Could not create target document");
 
@@ -435,7 +440,7 @@ ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView 
     return ezStatus("Target document is not a valid ezJoltCollisionMeshAssetDocument");
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
-  accessor.SetValue("MeshFile", sDataDirRelativePath);
+  accessor.SetValue("MeshFile", sInputFileRel.GetView());
 
   return ezStatus(EZ_SUCCESS);
 }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
@@ -42,10 +42,10 @@ public:
   ezJoltCollisionMeshAssetDocumentGenerator();
   ~ezJoltCollisionMeshAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezJoltCollisionMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "JoltCollisionMeshes"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };
 
 class ezJoltConvexCollisionMeshAssetDocumentGenerator : public ezAssetDocumentGenerator
@@ -56,8 +56,8 @@ public:
   ezJoltConvexCollisionMeshAssetDocumentGenerator();
   ~ezJoltConvexCollisionMeshAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezJoltConvexCollisionMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "JoltCollisionMeshes"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
@@ -38,8 +38,8 @@ public:
   ezKrautTreeAssetDocumentGenerator();
   ~ezKrautTreeAssetDocumentGenerator();
 
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
+  virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezKrautTreeAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "KrautTrees"; }
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
 };

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
@@ -19,19 +19,3 @@ protected:
 
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 };
-
-//////////////////////////////////////////////////////////////////////////
-
-class ezRmlUiAssetDocumentGenerator : public ezAssetDocumentGenerator
-{
-  EZ_ADD_DYNAMIC_REFLECTION(ezRmlUiAssetDocumentGenerator, ezAssetDocumentGenerator);
-
-public:
-  ezRmlUiAssetDocumentGenerator();
-  ~ezRmlUiAssetDocumentGenerator();
-
-  virtual void GetImportModes(ezStringView sParentDirRelativePath, ezHybridArray<ezAssetDocumentGenerator::Info, 4>& out_modes) const override;
-  virtual ezStatus Generate(ezStringView sDataDirRelativePath, const ezAssetDocumentGenerator::Info& info, ezDocument*& out_pGeneratedDocument) override;
-  virtual ezStringView GetDocumentExtension() const override { return "ezRmlUiAsset"; }
-  virtual ezStringView GetGeneratorGroup() const override { return "RmlUis"; }
-};

--- a/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
@@ -280,14 +280,14 @@ bool ezOSFile::ExistsDirectory(ezStringView sDirectory)
   return bRes;
 }
 
-void ezOSFile::FindFreeFilename(ezStringBuilder& inout_Path, ezStringView sSuffix /*= {}*/)
+void ezOSFile::FindFreeFilename(ezStringBuilder& inout_sPath, ezStringView sSuffix /*= {}*/)
 {
-  EZ_ASSERT_DEV(!inout_Path.IsEmpty() && inout_Path.IsAbsolutePath(), "Invalid input path.");
+  EZ_ASSERT_DEV(!inout_sPath.IsEmpty() && inout_sPath.IsAbsolutePath(), "Invalid input path.");
 
-  if (!ezOSFile::ExistsFile(inout_Path))
+  if (!ezOSFile::ExistsFile(inout_sPath))
     return;
 
-  const ezString orgName = inout_Path.GetFileName();
+  const ezString orgName = inout_sPath.GetFileName();
 
   ezStringBuilder newName;
 
@@ -295,8 +295,8 @@ void ezOSFile::FindFreeFilename(ezStringBuilder& inout_Path, ezStringView sSuffi
   {
     newName.Format("{}{}{}", orgName, sSuffix, i);
 
-    inout_Path.ChangeFileName(newName);
-    if (!ezOSFile::ExistsFile(inout_Path))
+    inout_sPath.ChangeFileName(newName);
+    if (!ezOSFile::ExistsFile(inout_sPath))
       return;
   }
 

--- a/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
@@ -280,6 +280,29 @@ bool ezOSFile::ExistsDirectory(ezStringView sDirectory)
   return bRes;
 }
 
+void ezOSFile::FindFreeFilename(ezStringBuilder& inout_Path, ezStringView sSuffix /*= {}*/)
+{
+  EZ_ASSERT_DEV(!inout_Path.IsEmpty() && inout_Path.IsAbsolutePath(), "Invalid input path.");
+
+  if (!ezOSFile::ExistsFile(inout_Path))
+    return;
+
+  const ezString orgName = inout_Path.GetFileName();
+
+  ezStringBuilder newName;
+
+  for (ezUInt32 i = 1; i < 100000; ++i)
+  {
+    newName.Format("{}{}{}", orgName, sSuffix, i);
+
+    inout_Path.ChangeFileName(newName);
+    if (!ezOSFile::ExistsFile(inout_Path))
+      return;
+  }
+
+  EZ_REPORT_FAILURE("Something went wrong.");
+}
+
 ezResult ezOSFile::DeleteFile(ezStringView sFile)
 {
   const ezTime t0 = ezTime::Now();

--- a/Code/Engine/Foundation/IO/OSFile.h
+++ b/Code/Engine/Foundation/IO/OSFile.h
@@ -232,7 +232,7 @@ public:
   ///
   /// If the original file already exists, sSuffix is appended and then a number starting at 1.
   /// Loops until it finds a filename that is not yet taken.
-  static void FindFreeFilename(ezStringBuilder& inout_Path, ezStringView sSuffix = "-");
+  static void FindFreeFilename(ezStringBuilder& inout_sPath, ezStringView sSuffix = "-");
 
   /// \brief Deletes the given file. Returns EZ_SUCCESS, if the file was deleted or did not exist in the first place. Returns EZ_FAILURE
   static ezResult DeleteFile(ezStringView sFile); // [tested]

--- a/Code/Engine/Foundation/IO/OSFile.h
+++ b/Code/Engine/Foundation/IO/OSFile.h
@@ -228,6 +228,12 @@ public:
   /// \brief Checks whether the given file exists.
   static bool ExistsDirectory(ezStringView sDirectory); // [tested]
 
+  /// \brief If the given file already exists, determines a file path that doesn't exist yet.
+  ///
+  /// If the original file already exists, sSuffix is appended and then a number starting at 1.
+  /// Loops until it finds a filename that is not yet taken.
+  static void FindFreeFilename(ezStringBuilder& inout_Path, ezStringView sSuffix = "-");
+
   /// \brief Deletes the given file. Returns EZ_SUCCESS, if the file was deleted or did not exist in the first place. Returns EZ_FAILURE
   static ezResult DeleteFile(ezStringView sFile); // [tested]
 

--- a/Data/Tools/ezEditor/Localization/en/AnimatedMeshAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/AnimatedMeshAsset.txt
@@ -8,7 +8,7 @@ ezAnimatedMeshComponent;Animated Mesh;;https://ezengine.net/pages/docs/animation
 
 # UI
 
-AnimatedMeshImport.NoMaterials;Animated Mesh only
-AnimatedMeshImport.WithMaterials;Animated Mesh and Materials
+AnimatedMeshImport.NoMaterials;Animated Mesh
+AnimatedMeshImport.WithMaterials;Animated Mesh with Materials
 
 # Properties

--- a/Data/Tools/ezEditor/Localization/en/LutAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/LutAsset.txt
@@ -5,3 +5,7 @@ LUT;Lookup Table
 # Properties
 
 ezLUTAssetProperties::CUBEfile;CUBE File
+
+# UI
+
+LUTImport.Cube;Lookup Table

--- a/Data/Tools/ezEditor/Localization/en/MeshAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/MeshAsset.txt
@@ -6,8 +6,8 @@ Mesh;Mesh
 
 # UI
 
-MeshImport.WithMaterials;Mesh and Materials
-MeshImport.NoMaterials;Mesh only
+MeshImport.WithMaterials;Mesh with Materials
+MeshImport.NoMaterials;Mesh
 
 # Enums
 

--- a/Data/Tools/ezEditor/Localization/en/SkeletonAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/SkeletonAsset.txt
@@ -8,7 +8,7 @@ ezSkeletonComponent;Skeleton;;https://ezengine.net/pages/docs/animation/skeletal
 
 # UI
 
-SkeletonImport;Animation Skeleton
+SkeletonImport;Skeleton
 
 Skeleton.RenderBones;Render Bones
 Skeleton.RenderColliders;Render Colliders

--- a/Data/Tools/ezEditor/Localization/en/TextureAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/TextureAsset.txt
@@ -9,6 +9,7 @@ Render Target;Render Target
 TextureAsset.LodSlider;Mipmap
 TextureAsset.ChannelMode;Channel to Display
 
+TextureImport.Auto;Texture 2D
 TextureImport.Diffuse;Diffuse Texture
 TextureImport.Normal;Normal Map
 TextureImport.HDR;HDR Texture


### PR DESCRIPTION
Use the asset browser to select the source assets, then right-click on them and use the "Import As" sub-menu to choose a target type. No further UI interaction needed. If you select many different files, like jpg and fbx, and then select an option like "Import as Texture", then the fbx will be siltently skipped.

![image](https://github.com/ezEngine/ezEngine/assets/6001174/21b10eec-df8c-4ff7-8fad-5bf03fe294db)
