### PR TITLE
GUIFoundation: Add Document Close Window Options.

### DIFF
--- a/Code/Tools/Libs/GuiFoundation/Action/DocumentActions.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/DocumentActions.h
@@ -20,6 +20,9 @@ public:
   static ezActionDescriptorHandle s_hSaveAll;
 
   static ezActionDescriptorHandle s_hClose;
+  static ezActionDescriptorHandle s_hCloseAll;
+  static ezActionDescriptorHandle s_hCloseAllButThis;
+
   static ezActionDescriptorHandle s_hOpenContainingFolder;
   static ezActionDescriptorHandle s_hCopyAssetGuid;
 
@@ -39,6 +42,8 @@ public:
     SaveAs,
     SaveAll,
     Close,
+    CloseAll,
+    CloseAllButThis,
     OpenContainingFolder,
     UpdatePrefabs,
     CopyAssetGuid,

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -64,6 +64,8 @@ Document.Save;&Save
 Document.SaveAll;Save All
 Document.SaveAs;Save &As...
 Document.Close;Close
+Document.CloseAll;Close All
+Document.CloseAllButThis;Close All But This
 Document.OpenContainingFolder;Open in Explorer
 Document.CopyAssetGuid;Copy Asset Guid;Stores the assets GUID in the clipboard.
 Document.MoveWindow;Move to Container Window


### PR DESCRIPTION
Adds options to **Close All** and **Close All But This** window to document windows. There is a bug (not sure if its reported), but the last closed window is not properly serialized, which causes it to open undocked on reopening project. Adequate short cuts have been included (which I think are easy to use), feel free to suggest changes or future improvements.