### PR TITLE
Tokenizer changes

### DIFF
--- a/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
@@ -128,6 +128,42 @@ namespace ezTokenParseUtils
     return false;
   }
 
+  bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezArrayPtr<const TokenMatch> matches, ezDynamicArray<ezUInt32>* pAccepted)
+  {
+    if (pAccepted)
+      pAccepted->Clear();
+
+    ezUInt32 uiCurToken = ref_uiCurToken;
+    bool bAccepted = true;
+    for (ezUInt32 i = 0; i < matches.GetCount() && bAccepted; ++i)
+    {
+      ezUInt32 uiAcceptedToken = uiCurToken;
+      const TokenMatch& match = matches[i];
+      if (match.m_Type == ezTokenType::Unknown)
+      {
+        bAccepted = Accept(tokens, uiCurToken, match.m_sToken, &uiAcceptedToken);
+      }
+      else
+      {
+        bAccepted = Accept(tokens, uiCurToken, match.m_Type, &uiAcceptedToken);
+      }
+
+      if (pAccepted && bAccepted)
+        pAccepted->PushBack(uiAcceptedToken);
+    }
+
+    if (bAccepted)
+    {
+      ref_uiCurToken = uiCurToken;
+    }
+    else
+    {
+      if (pAccepted)
+        pAccepted->Clear();
+    }
+    return bAccepted;
+  }
+
   void CombineRelevantTokensToString(const TokenStream& tokens, ezUInt32 uiCurToken, ezStringBuilder& ref_sResult)
   {
     ref_sResult.Clear();
@@ -143,7 +179,7 @@ namespace ezTokenParseUtils
     }
   }
 
-  void CreateCleanTokenStream(const TokenStream& tokens, ezUInt32 uiCurToken, TokenStream& ref_destination, bool bKeepComments)
+  void CreateCleanTokenStream(const TokenStream& tokens, ezUInt32 uiCurToken, TokenStream& ref_destination)
   {
     SkipWhitespace(tokens, uiCurToken);
 
@@ -170,7 +206,7 @@ namespace ezTokenParseUtils
 
     if (bRemoveRedundantWhitespace)
     {
-      CreateCleanTokenStream(tokens0, uiCurToken, Tokens, bKeepComments);
+      CreateCleanTokenStream(tokens0, uiCurToken, Tokens);
       uiCurToken = 0;
     }
     else

--- a/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
+++ b/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
@@ -7,17 +7,109 @@ namespace ezTokenParseUtils
 {
   using TokenStream = ezHybridArray<const ezToken*, 32>;
 
-  EZ_FOUNDATION_DLL void SkipWhitespace(const TokenStream& tokens, ezUInt32& ref_uiCurToken);
-  EZ_FOUNDATION_DLL void SkipWhitespaceAndNewline(const TokenStream& tokens, ezUInt32& ref_uiCurToken);
-  EZ_FOUNDATION_DLL bool IsEndOfLine(const TokenStream& tokens, ezUInt32 uiCurToken, bool bIgnoreWhitespace);
-  EZ_FOUNDATION_DLL void CopyRelevantTokens(const TokenStream& source, ezUInt32 uiFirstSourceToken, TokenStream& ref_destination, bool bPreserveNewLines);
+  /// \brief Moves ref_uiCurToken forward as long as it is a whitespace token (Whitespace, BlockComment, LineComment).
+  /// \param tokens Token input.
+  /// \param ref_uiCurToken Current location inside 'tokens'. On return, will either stay the same of move forward.
+  EZ_FOUNDATION_DLL void SkipWhitespace(const TokenStream& tokens, ezUInt32& ref_uiCurToken); // [tested]
 
-  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezStringView sToken, ezUInt32* pAccepted = nullptr);
-  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezTokenType::Enum type, ezUInt32* pAccepted = nullptr);
-  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezStringView sToken1, ezStringView sToken2, ezUInt32* pAccepted = nullptr);
-  EZ_FOUNDATION_DLL bool AcceptUnless(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezStringView sToken1, ezStringView sToken2, ezUInt32* pAccepted = nullptr);
+  /// \brief Moves ref_uiCurToken forward as long as it is a whitespace token (Whitespace, BlockComment, LineComment) or Newline.
+  /// \param tokens Token input.
+  /// \param ref_uiCurToken Current location inside 'tokens'. On return, will either stay the same of move forward.
+  EZ_FOUNDATION_DLL void SkipWhitespaceAndNewline(const TokenStream& tokens, ezUInt32& ref_uiCurToken); // [tested]
 
+  /// \brief Checks whether we are at the end of a line.
+  /// \param tokens Token input.
+  /// \param uiCurToken Current location inside 'tokens'.
+  /// \param bIgnoreWhitespace If false, only uiCurToken is checked. If true, whitespace will be skipped in search for a Newline token.
+  /// \return Whether we are at the end of a line.
+  EZ_FOUNDATION_DLL bool IsEndOfLine(const TokenStream& tokens, ezUInt32 uiCurToken, bool bIgnoreWhitespace); // [tested]
+
+  /// \brief Strips out BlockComment, LineComment, EndOfFile tokens and Newline as well if requested and copies the rest to ref_destination.
+  /// \param source From where to copy the tokens.
+  /// \param uiFirstSourceToken Start token in 'source'. Whitespace at the start will be stripped as well.
+  /// \param ref_destination Copy target of the tokens.
+  /// \param bPreserveNewLines Whether to preserve Newline tokens.
+  EZ_FOUNDATION_DLL void CopyRelevantTokens(const TokenStream& source, ezUInt32 uiFirstSourceToken, TokenStream& ref_destination, bool bPreserveNewLines); // [tested]
+
+  /// \brief Tries to move ref_uiCurToken forward by matching against 'sToken'. The function will skip whitespace tokens (Whitespace, BlockComment, LineComment) in search of 'sToken'.
+  /// \param tokens Token input.
+  /// \param ref_uiCurToken Current location inside 'tokens'. If false is returned it will stay the same. If true is returned, it will be the next index after matching 'sToken'.
+  /// \param sToken The token to be matched.
+  /// \param pAccepted If not null and true was returned, will be set to the index at which 'sToken' was matched.
+  /// \return Whether the token was found.
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezStringView sToken, ezUInt32* pAccepted = nullptr); // [tested]
+
+  /// \brief Overload that matches against a token type instead.
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezTokenType::Enum type, ezUInt32* pAccepted = nullptr); // [tested]
+
+  /// \brief Tries to move ref_uiCurToken forward by matching against a token tuple. The function will skip whitespace tokens (Whitespace, BlockComment, LineComment) in search of the tokens.
+  /// \param tokens Token input.
+  /// \param ref_uiCurToken Current location inside 'tokens'. If false is returned it will stay the same. If true is returned, it will be the next index after matching after the matched 'sToken2'.
+  /// \param sToken1 First token to match.
+  /// \param sToken2 Second token to match. Must be followed right after 'sToken1'.
+  /// \param pAccepted If not null and true was returned, will be set to the index at which 'sToken1' was matched.
+  /// \return Whether the token tuple was found.
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezStringView sToken1, ezStringView sToken2, ezUInt32* pAccepted = nullptr); // [tested]
+
+  /// \brief Tries to move ref_uiCurToken forward by matching against 'sToken1' unless it is followed right after by 'sToken2'. The function will skip whitespace tokens (Whitespace, BlockComment, LineComment) in search of 'sToken1'.
+  /// \param tokens Token input.
+  /// \param ref_uiCurToken Current location inside 'tokens'. If false is returned it will stay the same. If true is returned, it will be the next index after matching 'sToken1'.
+  /// \param sToken1 The token to be matched.
+  /// \param sToken2 The token that must not follow right after 'sToken1'.
+  /// \param pAccepted If not null and true was returned, will be set to the index at which 'sToken1' was matched.
+  /// \return Whether the token was found.
+  EZ_FOUNDATION_DLL bool AcceptUnless(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezStringView sToken1, ezStringView sToken2, ezUInt32* pAccepted = nullptr); // [tested]
+
+  /// \brief A token to be matched by the ezTokenParseUtils::Accept overload for arrays of tokens.
+  /// Can either match a token string or type. If type is ezTokenType::Unknown, the token string will be matched.
+  struct TokenMatch
+  {
+    /// \brief This matches a token string of any type.
+    TokenMatch(ezStringView sToken) : m_sToken(sToken) {}
+    /// \brief This matches a token type of any string value.
+    TokenMatch(ezTokenType::Enum type) : m_Type(type) {}
+
+    /// \brief For internal use. Use one of the other constructors instead.
+    TokenMatch(ezTokenType::Enum type, ezStringView sToken) : m_Type(type), m_sToken(sToken) {}
+
+    ezTokenType::Enum m_Type = ezTokenType::Unknown;
+    ezStringView m_sToken;
+  };
+
+  /// \brief Tries to move ref_uiCurToken forward by matching against an array of tokens. The function will skip whitespace tokens (Whitespace, BlockComment, LineComment) between the tokens it tries to match within 'matches'.
+  ///
+  /// Here is an example how to parse a vector declaration:
+  /// \code{.cpp}
+  ///   ezTokenParseUtils::TokenMatch pattern[] = {"Vec2"_ezsv, "("_ezsv, ezTokenType::Float, ","_ezsv, ezTokenType::Float, ")"_ezsv};
+  ///   ezHybridArray<ezUInt32, 6> matchedTokens;
+  ///   EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, pattern, &matchedTokens));
+  /// \endcode
+  ///
+  /// \param tokens Token input.
+  /// \param ref_uiCurToken Current location inside 'tokens'. If false is returned it will stay the same. If true is returned, it will be the next index after matching all of 'matches'.
+  /// \param matches The tokens to be matched. These can be separated by whitespace tokens.
+  /// \param pAccepted If not null and true was returned, will be filled with the indices at which each token inside 'matches' was matched.
+  /// \return Whether the array of tokens was found.
+  EZ_FOUNDATION_DLL bool Accept(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezArrayPtr<const TokenMatch> matches, ezDynamicArray<ezUInt32>* pAccepted = nullptr); // [tested]
+
+  /// \brief Combines tokens to a string.
+  /// \param tokens The token stream to combine.
+  /// \param uiCurToken The start location inside 'tokens' from which point the tokens should be combined.
+  /// \param ref_sResult Holds the resulting string after the function call.
+  /// \param bKeepComments Whether comments should be written into the string.
+  /// \param bRemoveRedundantWhitespace Whether redundant whitespace should be removed.
+  /// \param bInsertLine If set, will insert macros in the form of '#line <LINE> "<FILE>"' where appropriate. This is used as a hint by debuggers and other tools to reconstruct in which line/file a failure in a script occurred.
   EZ_FOUNDATION_DLL void CombineTokensToString(const TokenStream& tokens, ezUInt32 uiCurToken, ezStringBuilder& ref_sResult, bool bKeepComments = true, bool bRemoveRedundantWhitespace = false, bool bInsertLine = false);
+
+  /// \brief Strips out BlockComment, LineComment, EndOfFile and NewLine tokens and combines the rest into a string.
+  /// \param tokens The token stream to combine.
+  /// \param uiCurToken The start location inside 'tokens' from which point the tokens should be combined.
+  /// \param ref_sResult Holds the resulting string after the function call.
   EZ_FOUNDATION_DLL void CombineRelevantTokensToString(const TokenStream& tokens, ezUInt32 uiCurToken, ezStringBuilder& ref_sResult);
-  EZ_FOUNDATION_DLL void CreateCleanTokenStream(const TokenStream& tokens, ezUInt32 uiCurToken, TokenStream& ref_destination, bool bKeepComments);
+
+  /// \brief Removes whitespace at the end of each line and removes NewLine that follow each other.
+  /// \param tokens The token stream to cleaned up.
+  /// \param uiCurToken The start location inside 'tokens' from which point the tokens should be copied to 'ref_destination'.
+  /// \param ref_destination Target stream to store the cleaned up tokens into.
+  EZ_FOUNDATION_DLL void CreateCleanTokenStream(const TokenStream& tokens, ezUInt32 uiCurToken, TokenStream& ref_destination);
 } // namespace ezTokenParseUtils

--- a/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
+++ b/Code/Engine/Foundation/CodeUtils/TokenParseUtils.h
@@ -9,12 +9,12 @@ namespace ezTokenParseUtils
 
   /// \brief Moves ref_uiCurToken forward as long as it is a whitespace token (Whitespace, BlockComment, LineComment).
   /// \param tokens Token input.
-  /// \param ref_uiCurToken Current location inside 'tokens'. On return, will either stay the same of move forward.
+  /// \param ref_uiCurToken Current location inside 'tokens'. On return, will either stay the same or move forward.
   EZ_FOUNDATION_DLL void SkipWhitespace(const TokenStream& tokens, ezUInt32& ref_uiCurToken); // [tested]
 
   /// \brief Moves ref_uiCurToken forward as long as it is a whitespace token (Whitespace, BlockComment, LineComment) or Newline.
   /// \param tokens Token input.
-  /// \param ref_uiCurToken Current location inside 'tokens'. On return, will either stay the same of move forward.
+  /// \param ref_uiCurToken Current location inside 'tokens'. On return, will either stay the same or move forward.
   EZ_FOUNDATION_DLL void SkipWhitespaceAndNewline(const TokenStream& tokens, ezUInt32& ref_uiCurToken); // [tested]
 
   /// \brief Checks whether we are at the end of a line.

--- a/Code/Engine/Foundation/CodeUtils/Tokenizer.h
+++ b/Code/Engine/Foundation/CodeUtils/Tokenizer.h
@@ -86,7 +86,10 @@ public:
   ~ezTokenizer();
 
   /// \brief Clears any previous result and creates a new token stream for the given array.
-  void Tokenize(ezArrayPtr<const ezUInt8> data, ezLogInterface* pLog);
+  /// \param data The string data to be tokenized.
+  /// \param pLog A log interface that will receive any tokenization errors.
+  /// \param bCopyData If set, 'data' will be copied into a member variable and tokenization is run on the copy, allowing for the original data storage to be deallocated after this call. If false, tokenization will reference 'data' directly and thus, 'data' must outlive this instance.
+  void Tokenize(ezArrayPtr<const ezUInt8> data, ezLogInterface* pLog, bool bCopyData = true);
 
   /// \brief Gives read access to the token stream.
   const ezDeque<ezToken>& GetTokens() const { return m_Tokens; }
@@ -94,8 +97,11 @@ public:
   /// \brief Gives read and write access to the token stream.
   ezDeque<ezToken>& GetTokens() { return m_Tokens; }
 
+  /// \brief Returns an array with a copy of all tokens. Use this when using ezTokenParseUtils.
+  void GetAllTokens(ezDynamicArray<const ezToken*>& ref_tokens) const;
+
   /// \brief Returns an array of all tokens. New line tokens are ignored.
-  void GetAllLines(ezHybridArray<const ezToken*, 32>& ref_tokens) const;
+  void GetAllLines(ezDynamicArray<const ezToken*>& ref_tokens) const;
 
   /// \brief Returns an array of tokens that represent the next line in the file.
   ///
@@ -111,8 +117,8 @@ public:
 
   ezResult GetNextLine(ezUInt32& ref_uiFirstToken, ezHybridArray<ezToken*, 32>& ref_tokens);
 
-  /// \brief Returns the internal copy of the tokenized data
-  const ezDynamicArray<ezUInt8>& GetTokenizedData() const { return m_Data; }
+  /// \brief Returns the internal copy of the tokenized data. Will be empty if Tokenize was called with 'bCopyData' equals 'false'.
+  const ezArrayPtr<const ezUInt8> GetTokenizedData() const { return m_Data; }
 
   /// \brief Enables treating lines that start with # character as line comments
   ///

--- a/Code/UnitTests/FoundationTest/CodeUtils/TokenParseUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/TokenParseUtilsTest.cpp
@@ -1,0 +1,203 @@
+#include <FoundationTest/FoundationTestPCH.h>
+
+#include <Foundation/CodeUtils/Tokenizer.h>
+#include <Foundation/CodeUtils/TokenParseUtils.h>
+
+EZ_CREATE_SIMPLE_TEST(CodeUtils, TokenParseUtils)
+{
+  const char* stringLiteral = R"(
+// Some comment
+/* A block comment
+Some block
+*/
+Identifier
+)";
+
+  ezTokenizer tokenizer(ezFoundation::GetDefaultAllocator());
+  tokenizer.Tokenize(ezMakeArrayPtr(reinterpret_cast<const ezUInt8*>(stringLiteral), ezStringUtils::GetStringElementCount(stringLiteral)), ezLog::GetThreadLocalLogSystem(), false);
+
+  ezTokenParseUtils::TokenStream tokens;
+  tokenizer.GetAllTokens(tokens);
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SkipWhitespace / IsEndOfLine")
+  {
+    ezUInt32 uiCurToken = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    uiCurToken++;
+    EZ_TEST_BOOL(!ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, true));
+    ezTokenParseUtils::SkipWhitespace(tokens, uiCurToken);
+    EZ_TEST_INT(uiCurToken, 2);
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    uiCurToken++;
+    EZ_TEST_BOOL(!ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, true));
+    ezTokenParseUtils::SkipWhitespace(tokens, uiCurToken);
+    EZ_TEST_INT(uiCurToken, 4);
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    uiCurToken++;
+    EZ_TEST_BOOL(!ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    EZ_TEST_BOOL(!ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, true));
+    EZ_TEST_INT(tokens[uiCurToken]->m_iType, ezTokenType::Identifier);
+    uiCurToken++;
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    uiCurToken++;
+    EZ_TEST_INT(tokens[uiCurToken]->m_iType, ezTokenType::EndOfFile);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SkipWhitespaceAndNewline")
+  {
+    ezUInt32 uiCurToken = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    ezTokenParseUtils::SkipWhitespaceAndNewline(tokens, uiCurToken);
+    EZ_TEST_INT(uiCurToken, 5);
+    EZ_TEST_INT(tokens[uiCurToken]->m_iType, ezTokenType::Identifier);
+    uiCurToken++;
+    EZ_TEST_BOOL(ezTokenParseUtils::IsEndOfLine(tokens, uiCurToken, false));
+    ezTokenParseUtils::SkipWhitespaceAndNewline(tokens, uiCurToken);
+    EZ_TEST_INT(tokens[uiCurToken]->m_iType, ezTokenType::EndOfFile);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "CopyRelevantTokens")
+  {
+    ezUInt32 uiCurToken = 0;
+    ezTokenParseUtils::TokenStream relevantTokens;
+    ezTokenParseUtils::CopyRelevantTokens(tokens, uiCurToken, relevantTokens, true);
+
+    EZ_TEST_INT(relevantTokens.GetCount(), 5);
+    for (ezUInt32 i = 0; i < relevantTokens.GetCount(); ++i)
+    {
+      if (i == 3)
+      {
+        EZ_TEST_INT(relevantTokens[i]->m_iType, ezTokenType::Identifier);
+      }
+      else
+      {
+        EZ_TEST_INT(relevantTokens[i]->m_iType, ezTokenType::Newline);
+      }
+    }
+
+    relevantTokens.Clear();
+    ezTokenParseUtils::CopyRelevantTokens(tokens, uiCurToken, relevantTokens, false);
+    EZ_TEST_INT(relevantTokens.GetCount(), 1);
+    EZ_TEST_INT(relevantTokens[0]->m_iType, ezTokenType::Identifier);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Accept")
+  {
+    ezUInt32 uiCurToken = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, "\n"_ezsv, nullptr));
+    EZ_TEST_INT(uiCurToken, 1);
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, ezTokenType::Newline, nullptr));
+    EZ_TEST_INT(uiCurToken, 3);
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, "\n"_ezsv, nullptr));
+    EZ_TEST_INT(uiCurToken, 5);
+
+    ezUInt32 uiIdentifierToken = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, ezTokenType::Identifier, &uiIdentifierToken));
+    EZ_TEST_INT(uiIdentifierToken, 5);
+    EZ_TEST_INT(uiCurToken, 6);
+
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, ezTokenType::Newline, nullptr));
+
+    EZ_TEST_BOOL(!ezTokenParseUtils::Accept(tokens, uiCurToken, ezTokenType::Newline, nullptr));
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, ezTokenType::EndOfFile, nullptr));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Accept2")
+  {
+    ezUInt32 uiCurToken = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, "\n"_ezsv, "// Some comment"_ezsv, nullptr));
+    EZ_TEST_INT(uiCurToken, 2);
+    ezUInt32 uiTouple1Token = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, "\n"_ezsv, "/* A block comment\nSome block\n*/"_ezsv, &uiTouple1Token));
+    EZ_TEST_INT(uiTouple1Token, 2);
+    EZ_TEST_INT(uiCurToken, 4);
+    EZ_TEST_BOOL(!ezTokenParseUtils::AcceptUnless(tokens, uiCurToken, "\n"_ezsv, "Identifier"_ezsv, nullptr));
+    uiCurToken++;
+    ezUInt32 uiIdentifierToken = 0;
+    EZ_TEST_BOOL(ezTokenParseUtils::AcceptUnless(tokens, uiCurToken, "Identifier"_ezsv, "ScaryString"_ezsv, &uiIdentifierToken));
+    EZ_TEST_INT(uiIdentifierToken, 5);
+    EZ_TEST_INT(uiCurToken, 6);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Accept3")
+  {
+    ezUInt32 uiCurToken = 0;
+    ezTokenParseUtils::TokenMatch templatePattern[] = {ezTokenType::Newline, ezTokenType::Newline, "Identifier"_ezsv};
+    ezHybridArray<ezUInt32, 8> acceptedTokens;
+    EZ_TEST_BOOL(!ezTokenParseUtils::Accept(tokens, uiCurToken, templatePattern, &acceptedTokens));
+    uiCurToken++;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens, uiCurToken, templatePattern, &acceptedTokens));
+
+    EZ_TEST_INT(acceptedTokens.GetCount(), EZ_ARRAY_SIZE(templatePattern));
+    EZ_TEST_INT(acceptedTokens[0], 2);
+    EZ_TEST_INT(acceptedTokens[1], 4);
+    EZ_TEST_INT(acceptedTokens[2], 5);
+    EZ_TEST_INT(uiCurToken, 6);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Accept4")
+  {
+    const char* vectorString = "Vec2(2.2, 1.1)";
+
+    ezTokenizer tokenizer2(ezFoundation::GetDefaultAllocator());
+    tokenizer2.Tokenize(ezMakeArrayPtr(reinterpret_cast<const ezUInt8*>(vectorString), ezStringUtils::GetStringElementCount(vectorString)), ezLog::GetThreadLocalLogSystem(), false);
+
+    ezTokenParseUtils::TokenStream tokens2;
+    tokenizer2.GetAllTokens(tokens2);
+
+    ezUInt32 uiCurToken = 0;
+    ezTokenParseUtils::TokenMatch templatePattern[] = {"Vec2"_ezsv, "("_ezsv, ezTokenType::Float, ","_ezsv, ezTokenType::Float, ")"_ezsv};
+    ezHybridArray<ezUInt32, 6> acceptedTokens;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(tokens2, uiCurToken, templatePattern, &acceptedTokens));
+    EZ_TEST_INT(uiCurToken, 7);
+    EZ_TEST_INT(acceptedTokens.GetCount(), EZ_ARRAY_SIZE(templatePattern));
+    EZ_TEST_INT(acceptedTokens[2], 2);
+    EZ_TEST_INT(acceptedTokens[4], 5);
+    EZ_TEST_STRING(tokens2[acceptedTokens[2]]->m_DataView, "2.2");
+    EZ_TEST_STRING(tokens2[acceptedTokens[4]]->m_DataView, "1.1");
+
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "CombineTokensToString")
+  {
+    ezUInt32 uiCurToken = 0;
+    ezStringBuilder sResult;
+    ezTokenParseUtils::CombineTokensToString(tokens, uiCurToken, sResult);
+    EZ_TEST_STRING(sResult, stringLiteral);
+
+    ezTokenParseUtils::CombineTokensToString(tokens, uiCurToken, sResult, false, true);
+    EZ_TEST_STRING(sResult, "\n\n\nIdentifier\n");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "CombineRelevantTokensToString")
+  {
+    ezUInt32 uiCurToken = 0;
+    ezStringBuilder sResult;
+    ezTokenParseUtils::CombineRelevantTokensToString(tokens, uiCurToken, sResult);
+    EZ_TEST_STRING(sResult, "Identifier");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "CreateCleanTokenStream")
+  {
+    const char* stringLiteralWithRedundantStuff = "\n\nID1 \nID2";
+
+    ezTokenizer tokenizer2(ezFoundation::GetDefaultAllocator());
+    tokenizer2.Tokenize(ezMakeArrayPtr(reinterpret_cast<const ezUInt8*>(stringLiteralWithRedundantStuff), ezStringUtils::GetStringElementCount(stringLiteralWithRedundantStuff)), ezLog::GetThreadLocalLogSystem(), false);
+
+    ezTokenParseUtils::TokenStream tokens2;
+    tokenizer2.GetAllTokens(tokens2);
+
+    ezUInt32 uiCurToken = 0;
+    ezTokenParseUtils::TokenStream result;
+    ezTokenParseUtils::CreateCleanTokenStream(tokens2, uiCurToken, result);
+
+    EZ_TEST_INT(result.GetCount(), 5);
+
+    ezTokenParseUtils::TokenMatch templatePattern[] = {ezTokenType::Newline, "ID1"_ezsv, ezTokenType::Newline, "ID2"_ezsv, ezTokenType::EndOfFile};
+    ezHybridArray<ezUInt32, 8> acceptedTokens;
+    EZ_TEST_BOOL(ezTokenParseUtils::Accept(result, uiCurToken, templatePattern, nullptr));
+    EZ_TEST_INT(uiCurToken, 5);
+  }
+}

--- a/Code/UnitTests/FoundationTest/CodeUtils/TokenizerTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/TokenizerTest.cpp
@@ -1,16 +1,13 @@
 #include <FoundationTest/FoundationTestPCH.h>
 
 #include <Foundation/CodeUtils/Tokenizer.h>
+#include <Foundation/CodeUtils/TokenParseUtils.h>
 
 namespace
 {
-  struct ExpectedToken
-  {
-    ezTokenType::Enum type;
-    ezStringView value;
-  };
+  using TokenMatch = ezTokenParseUtils::TokenMatch;
 
-  void CompareResults(const ezDynamicArray<ExpectedToken>& expected, ezTokenizer& inout_tokenizer, bool bIgnoreWhitespace)
+  void CompareResults(const ezDynamicArray<TokenMatch>& expected, ezTokenizer& inout_tokenizer, bool bIgnoreWhitespace)
   {
     auto& tokens = inout_tokenizer.GetTokens();
 
@@ -29,12 +26,12 @@ namespace
 
       auto& e = expected[expectedIndex];
 
-      if (!EZ_TEST_BOOL_MSG(e.type == token.m_iType, "Token with index %u does not match in type, expected %d actual %d", expectedIndex, e.type, token.m_iType))
+      if (!EZ_TEST_BOOL_MSG(e.m_Type == token.m_iType, "Token with index %u does not match in type, expected %d actual %d", expectedIndex, e.m_Type, token.m_iType))
       {
         return;
       }
 
-      if (!EZ_TEST_BOOL_MSG(e.value == token.m_DataView, "Token with index %u does not match, expected '%.*s' actual '%.*s'", expectedIndex, e.value.GetElementCount(), e.value.GetStartPointer(), token.m_DataView.GetElementCount(), token.m_DataView.GetStartPointer()))
+      if (!EZ_TEST_BOOL_MSG(e.m_sToken == token.m_DataView, "Token with index %u does not match, expected '%.*s' actual '%.*s'", expectedIndex, e.m_sToken.GetElementCount(), e.m_sToken.GetStartPointer(), token.m_DataView.GetElementCount(), token.m_DataView.GetStartPointer()))
       {
         return;
       }
@@ -80,9 +77,11 @@ char c='f';
 const char* bla =  "blup";
 )";
     ezTokenizer tokenizer(ezFoundation::GetDefaultAllocator());
-    tokenizer.Tokenize(ezMakeArrayPtr(reinterpret_cast<const ezUInt8*>(stringLiteral), ezStringUtils::GetStringElementCount(stringLiteral)), ezLog::GetThreadLocalLogSystem());
+    tokenizer.Tokenize(ezMakeArrayPtr(reinterpret_cast<const ezUInt8*>(stringLiteral), ezStringUtils::GetStringElementCount(stringLiteral)), ezLog::GetThreadLocalLogSystem(), false);
 
-    ezDynamicArray<ExpectedToken> expectedResult;
+    EZ_TEST_BOOL(tokenizer.GetTokenizedData().IsEmpty());
+
+    ezDynamicArray<TokenMatch> expectedResult;
     expectedResult.PushBack({ezTokenType::Newline, "\n"});
 
     expectedResult.PushBack({ezTokenType::Identifier, "float"});
@@ -152,7 +151,7 @@ fuenf
     ezTokenizer tokenizer(ezFoundation::GetDefaultAllocator());
     tokenizer.Tokenize(ezMakeArrayPtr(reinterpret_cast<const ezUInt8*>(stringLiteral), ezStringUtils::GetStringElementCount(stringLiteral)), ezLog::GetThreadLocalLogSystem());
 
-    ezDynamicArray<ExpectedToken> expectedResult;
+    ezDynamicArray<TokenMatch> expectedResult;
     expectedResult.PushBack({ezTokenType::Identifier, "const"});
     expectedResult.PushBack({ezTokenType::Identifier, "char"});
     expectedResult.PushBack({ezTokenType::NonIdentifier, "*"});


### PR DESCRIPTION
* Added `bCopyData` parameter to `ezTokenizer::Tokenize` to prevent creating a copy of the passed in data.
* Added `ezTokenizer::Accept` overload where you pass in an array of tokens to match.
* Added documentation and tests to all `ezTokenParseUtils` functions.