### PR TITLE
Force mouse position to the center if ezMouseCursorClipMode::ClipToPosition is used

### DIFF
--- a/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
+++ b/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
@@ -344,9 +344,9 @@ void ezStandardInputDevice::ApplyClipRect(ezMouseCursorClipMode::Enum mode, ezMi
     POINT mp;
     if (GetCursorPos(&mp))
     {
-      // make sure the position is inside the window rect
-      mp.x = ezMath::Clamp(mp.x, r.left, r.right);
-      mp.y = ezMath::Clamp(mp.y, r.top, r.bottom);
+      // center the position inside the window rect
+      mp.x = r.left + (r.right - r.left) / 2;
+      mp.y = r.top + (r.bottom - r.top) / 2;
 
       r.top = mp.y;
       r.bottom = mp.y;


### PR DESCRIPTION
Force mouse position to the center if ezMouseCursorClipMode::ClipToPosition is used

This fixes issues where mouse-clicks are not correctly registered as the mouse is stuck on the border of the screen and moving + clicking moves it out of the window, swallowing the mouse-click.

To reproduce in editor:
1. "Play the game" in windowed mode and call 'SetClipMouseCursor(ezMouseCursorClipMode::ClipToPosition)'
2. Change focus to another application
3. Ensure the mouse is outside of where the game window is when Alt-Tab into it
4. Alt-Tab back into the game window
5. The mouse will now be stuck to the game window border, resulting in spotty behavior when moving + clicking.