### PR TITLE
Prevent mouse-wheel from changing property values

### DIFF
--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicEnumPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicEnumPropertyWidget.cpp
@@ -11,6 +11,7 @@ ezQtDynamicEnumPropertyWidget::ezQtDynamicEnumPropertyWidget()
   setLayout(m_pLayout);
 
   m_pWidget = new QComboBox(this);
+  m_pWidget->installEventFilter(this);
   m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   m_pLayout->addWidget(m_pWidget);
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
@@ -12,6 +12,7 @@ ezQtDynamicStringEnumPropertyWidget::ezQtDynamicStringEnumPropertyWidget()
   setLayout(m_pLayout);
 
   m_pWidget = new QComboBox(this);
+  m_pWidget->installEventFilter(this);
   m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   m_pLayout->addWidget(m_pWidget);
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -1750,6 +1750,7 @@ ezQtVariantPropertyWidget::ezQtVariantPropertyWidget()
   setLayout(m_pLayout);
 
   m_pTypeList = new QComboBox(this);
+  m_pTypeList->installEventFilter(this);
   m_pTypeList->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   m_pLayout->addWidget(m_pTypeList);
 }


### PR DESCRIPTION
Prevent mouse-wheel from changing property values
This just applies the fix done in 5f8a23d2e0b83deb179e806f610b25a205d2acd4 to more PropertyWidgets