### PR TITLE
Fix segfault in RecastAgentComponent

### DIFF
--- a/Code/EnginePlugins/RecastPlugin/Components/RecastAgentComponent.cpp
+++ b/Code/EnginePlugins/RecastPlugin/Components/RecastAgentComponent.cpp
@@ -276,7 +276,7 @@ bool ezRcAgentComponent::IsPositionVisible(const ezVec3& vPos) const
 {
   ezRcPos endPos = vPos;
 
-  dtRaycastHit hit;
+  dtRaycastHit hit{};
   if (dtStatusFailed(m_pQuery->raycast(m_pCorridor->getFirstPoly(), m_pCorridor->getPos(), endPos, &m_QueryFilter, 0, &hit)))
     return false;
 


### PR DESCRIPTION
The `dtNavMeshQuery::raycast` method expects `dtRaycastHit::maxPath` field to be the size of a buffer given by `dtRaycastHit::path`. So if `maxPath` is > 0, it tries to write to `path`. But here `maxPath` is uninitialized (as well as `path`) which leads to a segfault.