### PR TITLE
Fixed #1146: Added physics collision geometry visualization

### DIFF
--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -207,6 +207,8 @@ void ezCustomMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
 
 void ezCustomMeshComponent::OnActivated()
 {
+  SUPER::OnActivated();
+
   if (false)
   {
     ezGeometry geo;

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -43,6 +43,8 @@ public:
   static void DeleteView(const ezViewHandle& hView);
 
   static bool TryGetView(const ezViewHandle& hView, ezView*& out_pView);
+
+  /// \brief Searches for an ezView with the desired usage hint or alternative usage hint.
   static ezView* GetViewByUsageHint(ezCameraUsageHint::Enum usageHint, ezCameraUsageHint::Enum alternativeUsageHint = ezCameraUsageHint::None, const ezWorld* pWorld = nullptr);
 
   static void AddMainView(const ezViewHandle& hView);

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.cpp
@@ -132,9 +132,9 @@ void ezJoltCustomShapeInfo::CollideSoftBodyVertices(JPH::Mat44Arg centerOfMassTr
   mInnerShape->CollideSoftBodyVertices(centerOfMassTransform, scale, pVertices, numVertices, fDeltaTime, displacementDueToGravity, iCollidingShapeIndex);
 }
 
-void ezJoltCustomShapeInfo::CollectTransformedShapes(const JPH::AABox& inBox, JPH::Vec3Arg inPositionCOM, JPH::QuatArg inRotation, JPH::Vec3Arg inScale, const JPH::SubShapeIDCreator& inSubShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter) const
+void ezJoltCustomShapeInfo::CollectTransformedShapes(const JPH::AABox& box, JPH::Vec3Arg positionCOM, JPH::QuatArg rotation, JPH::Vec3Arg scale, const JPH::SubShapeIDCreator& subShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& shapeFilter) const
 {
-  mInnerShape->CollectTransformedShapes(inBox, inPositionCOM, inRotation, inScale, inSubShapeIDCreator, ioCollector, inShapeFilter);
+  mInnerShape->CollectTransformedShapes(box, positionCOM, rotation, scale, subShapeIDCreator, ioCollector, shapeFilter);
 }
 
 void ezJoltCustomShapeInfo::sCollideUser1VsShape(const JPH::Shape* inShape1, const JPH::Shape* inShape2, JPH::Vec3Arg inScale1, JPH::Vec3Arg inScale2, JPH::Mat44Arg inCenterOfMassTransform1, JPH::Mat44Arg inCenterOfMassTransform2, const JPH::SubShapeIDCreator& inSubShapeIDCreator1, const JPH::SubShapeIDCreator& inSubShapeIDCreator2, const JPH::CollideShapeSettings& inCollideShapeSettings, JPH::CollideShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter)

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.cpp
@@ -132,9 +132,9 @@ void ezJoltCustomShapeInfo::CollideSoftBodyVertices(JPH::Mat44Arg centerOfMassTr
   mInnerShape->CollideSoftBodyVertices(centerOfMassTransform, scale, pVertices, numVertices, fDeltaTime, displacementDueToGravity, iCollidingShapeIndex);
 }
 
-void ezJoltCustomShapeInfo::CollectTransformedShapes(const JPH::AABox& box, JPH::Vec3Arg positionCOM, JPH::QuatArg rotation, JPH::Vec3Arg scale, const JPH::SubShapeIDCreator& subShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& shapeFilter) const
+void ezJoltCustomShapeInfo::CollectTransformedShapes(const JPH::AABox& box, JPH::Vec3Arg positionCOM, JPH::QuatArg rotation, JPH::Vec3Arg scale, const JPH::SubShapeIDCreator& subShapeIDCreator, JPH::TransformedShapeCollector& ref_ioCollector, const JPH::ShapeFilter& shapeFilter) const
 {
-  mInnerShape->CollectTransformedShapes(box, positionCOM, rotation, scale, subShapeIDCreator, ioCollector, shapeFilter);
+  mInnerShape->CollectTransformedShapes(box, positionCOM, rotation, scale, subShapeIDCreator, ref_ioCollector, shapeFilter);
 }
 
 void ezJoltCustomShapeInfo::sCollideUser1VsShape(const JPH::Shape* inShape1, const JPH::Shape* inShape2, JPH::Vec3Arg inScale1, JPH::Vec3Arg inScale2, JPH::Mat44Arg inCenterOfMassTransform1, JPH::Mat44Arg inCenterOfMassTransform2, const JPH::SubShapeIDCreator& inSubShapeIDCreator1, const JPH::SubShapeIDCreator& inSubShapeIDCreator2, const JPH::CollideShapeSettings& inCollideShapeSettings, JPH::CollideShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter)

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.cpp
@@ -132,6 +132,11 @@ void ezJoltCustomShapeInfo::CollideSoftBodyVertices(JPH::Mat44Arg centerOfMassTr
   mInnerShape->CollideSoftBodyVertices(centerOfMassTransform, scale, pVertices, numVertices, fDeltaTime, displacementDueToGravity, iCollidingShapeIndex);
 }
 
+void ezJoltCustomShapeInfo::CollectTransformedShapes(const JPH::AABox& inBox, JPH::Vec3Arg inPositionCOM, JPH::QuatArg inRotation, JPH::Vec3Arg inScale, const JPH::SubShapeIDCreator& inSubShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter) const
+{
+  mInnerShape->CollectTransformedShapes(inBox, inPositionCOM, inRotation, inScale, inSubShapeIDCreator, ioCollector, inShapeFilter);
+}
+
 void ezJoltCustomShapeInfo::sCollideUser1VsShape(const JPH::Shape* inShape1, const JPH::Shape* inShape2, JPH::Vec3Arg inScale1, JPH::Vec3Arg inScale2, JPH::Mat44Arg inCenterOfMassTransform1, JPH::Mat44Arg inCenterOfMassTransform2, const JPH::SubShapeIDCreator& inSubShapeIDCreator1, const JPH::SubShapeIDCreator& inSubShapeIDCreator2, const JPH::CollideShapeSettings& inCollideShapeSettings, JPH::CollideShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter)
 {
   JPH_ASSERT(inShape1->GetSubType() == EShapeSubType::User1);

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h
@@ -48,7 +48,7 @@ public:
 
   void CollideSoftBodyVertices(JPH::Mat44Arg centerOfMassTransform, JPH::Vec3Arg scale, JPH::SoftBodyVertex* pVertices, JPH::uint numVertices, float fDeltaTime, JPH::Vec3Arg displacementDueToGravity, int iCollidingShapeIndex) const override;
 
-  virtual void CollectTransformedShapes(const JPH::AABox& inBox, JPH::Vec3Arg inPositionCOM, JPH::QuatArg inRotation, JPH::Vec3Arg inScale, const JPH::SubShapeIDCreator& inSubShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter) const override;
+  virtual void CollectTransformedShapes(const JPH::AABox& box, JPH::Vec3Arg positionCOM, JPH::QuatArg rotation, JPH::Vec3Arg scale, const JPH::SubShapeIDCreator& subShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& shapeFilter) const override;
 
 private:
   // Helper functions called by CollisionDispatch

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h
@@ -48,6 +48,8 @@ public:
 
   void CollideSoftBodyVertices(JPH::Mat44Arg centerOfMassTransform, JPH::Vec3Arg scale, JPH::SoftBodyVertex* pVertices, JPH::uint numVertices, float fDeltaTime, JPH::Vec3Arg displacementDueToGravity, int iCollidingShapeIndex) const override;
 
+  virtual void CollectTransformedShapes(const JPH::AABox& inBox, JPH::Vec3Arg inPositionCOM, JPH::QuatArg inRotation, JPH::Vec3Arg inScale, const JPH::SubShapeIDCreator& inSubShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter) const override;
+
 private:
   // Helper functions called by CollisionDispatch
   static void sCollideUser1VsShape(const JPH::Shape* inShape1, const JPH::Shape* inShape2, JPH::Vec3Arg inScale1, JPH::Vec3Arg inScale2, JPH::Mat44Arg inCenterOfMassTransform1, JPH::Mat44Arg inCenterOfMassTransform2, const JPH::SubShapeIDCreator& inSubShapeIDCreator1, const JPH::SubShapeIDCreator& inSubShapeIDCreator2, const JPH::CollideShapeSettings& inCollideShapeSettings, JPH::CollideShapeCollector& ioCollector, const JPH::ShapeFilter& inShapeFilter);

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h
@@ -48,7 +48,7 @@ public:
 
   void CollideSoftBodyVertices(JPH::Mat44Arg centerOfMassTransform, JPH::Vec3Arg scale, JPH::SoftBodyVertex* pVertices, JPH::uint numVertices, float fDeltaTime, JPH::Vec3Arg displacementDueToGravity, int iCollidingShapeIndex) const override;
 
-  virtual void CollectTransformedShapes(const JPH::AABox& box, JPH::Vec3Arg positionCOM, JPH::QuatArg rotation, JPH::Vec3Arg scale, const JPH::SubShapeIDCreator& subShapeIDCreator, JPH::TransformedShapeCollector& ioCollector, const JPH::ShapeFilter& shapeFilter) const override;
+  virtual void CollectTransformedShapes(const JPH::AABox& box, JPH::Vec3Arg positionCOM, JPH::QuatArg rotation, JPH::Vec3Arg scale, const JPH::SubShapeIDCreator& subShapeIDCreator, JPH::TransformedShapeCollector& ref_ioCollector, const JPH::ShapeFilter& shapeFilter) const override;
 
 private:
   // Helper functions called by CollisionDispatch

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -774,89 +774,70 @@ void ezJoltWorldModule::UpdateConstraints()
 
 ezAtomicInteger32 s_iColMeshVisGeoCounter;
 
-ezView* ezJoltWorldModule::GetMainView() const
-{
-  for (ezViewHandle hView : ezRenderWorld::GetMainViews())
-  {
-    ezView* pView;
-    if (!ezRenderWorld::TryGetView(hView, pView))
-      continue;
-
-    if (pView->GetWorld() != GetWorld())
-      continue;
-
-    if (pView->GetCameraUsageHint() == ezCameraUsageHint::EditorView ||
-        pView->GetCameraUsageHint() == ezCameraUsageHint::MainView)
-    {
-      return pView;
-    }
-  }
-
-  return nullptr;
-}
-
 struct DebugVis
 {
   const char* m_szMaterial = nullptr;
   ezColor m_Color;
 };
 
-// "{ e6367876-ddb5-4149-ba80-180af553d463 }" = Data/Base/Materials/Common/PhysicsColliders.ezMaterialAsset
+const char* szMatSolid = "{ e6367876-ddb5-4149-ba80-180af553d463 }";       // Data/Base/Materials/Common/PhysicsColliders.ezMaterialAsset
+const char* szMatTransparent = "{ ca43dda3-a28c-41fe-ae20-419182e56f87 }"; // Data/Base/Materials/Common/PhysicsCollidersTransparent.ezMaterialAsset
+const char* szMatTwoSided = "{ b03df0e4-98b7-49ba-8413-d981014a77be }";    // Data/Base/Materials/Common/PhysicsCollidersSoft.ezMaterialAsset
 
 static const DebugVis s_Vis[ezPhysicsShapeType::Count][2] =
   {
     // Static
     {
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::LightSkyBlue}, // non-kinematic
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::Red}           // kinematic
+      {szMatSolid, ezColor::LightSkyBlue}, // non-kinematic
+      {szMatSolid, ezColor::Red}           // kinematic
     },
 
     // Dynamic
     {
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::Gold},      // non-kinematic
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::DodgerBlue} // kinematic
+      {szMatSolid, ezColor::Gold},      // non-kinematic
+      {szMatSolid, ezColor::DodgerBlue} // kinematic
     },
 
     // Query
     {
-      {"{ ca43dda3-a28c-41fe-ae20-419182e56f87 }", ezColor::GreenYellow.WithAlpha(0.5f)}, // non-kinematic
-      {"{ ca43dda3-a28c-41fe-ae20-419182e56f87 }", ezColor::GreenYellow.WithAlpha(0.5f)}  // kinematic
+      {szMatTransparent, ezColor::GreenYellow.WithAlpha(0.5f)}, // non-kinematic
+      {szMatTransparent, ezColor::GreenYellow.WithAlpha(0.5f)}  // kinematic
     },
 
     // Trigger
     {
-      {"{ ca43dda3-a28c-41fe-ae20-419182e56f87 }", ezColor::Purple.WithAlpha(0.3f)}, // non-kinematic
-      {"{ ca43dda3-a28c-41fe-ae20-419182e56f87 }", ezColor::Purple.WithAlpha(0.3f)}  // kinematic
+      {szMatTransparent, ezColor::Purple.WithAlpha(0.3f)}, // non-kinematic
+      {szMatTransparent, ezColor::Purple.WithAlpha(0.3f)}  // kinematic
     },
 
     // Character
     {
-      {"{ ca43dda3-a28c-41fe-ae20-419182e56f87 }", ezColor::DarkTurquoise.WithAlpha(0.5f)}, // non-kinematic
-      {"{ ca43dda3-a28c-41fe-ae20-419182e56f87 }", ezColor::DarkTurquoise.WithAlpha(0.5f)}  // kinematic
+      {szMatTransparent, ezColor::DarkTurquoise.WithAlpha(0.5f)}, // non-kinematic
+      {szMatTransparent, ezColor::DarkTurquoise.WithAlpha(0.5f)}  // kinematic
     },
 
     // Ragdoll
     {
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::DeepPink}, // non-kinematic
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::DeepPink}  // kinematic
+      {szMatSolid, ezColor::DeepPink}, // non-kinematic
+      {szMatSolid, ezColor::DeepPink}  // kinematic
     },
 
     // Rope
     {
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::MediumVioletRed}, // non-kinematic
-      {"{ e6367876-ddb5-4149-ba80-180af553d463 }", ezColor::MediumVioletRed}  // kinematic
+      {szMatSolid, ezColor::MediumVioletRed}, // non-kinematic
+      {szMatSolid, ezColor::MediumVioletRed}  // kinematic
     },
 
     // Cloth
     {
-      {"{ b03df0e4-98b7-49ba-8413-d981014a77be }", ezColor::Crimson}, // non-kinematic
-      {"{ b03df0e4-98b7-49ba-8413-d981014a77be }", ezColor::Red}      // kinematic
+      {szMatTwoSided, ezColor::Crimson}, // non-kinematic
+      {szMatTwoSided, ezColor::Red}      // kinematic
     },
 };
 
 void ezJoltWorldModule::DebugDrawGeometry()
 {
-  ezView* pView = GetMainView();
+  ezView* pView = ezRenderWorld::GetViewByUsageHint(ezCameraUsageHint::MainView, ezCameraUsageHint::EditorView, GetWorld());
 
   if (pView == nullptr)
     return;

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -15,6 +15,7 @@
 #include <JoltPlugin/System/JoltCore.h>
 #include <JoltPlugin/System/JoltDebugRenderer.h>
 #include <JoltPlugin/System/JoltWorldModule.h>
+#include <Physics/Collision/CollisionCollectorImpl.h>
 #include <Physics/Collision/Shape/Shape.h>
 #include <RendererCore/Meshes/CustomMeshComponent.h>
 #include <RendererCore/Meshes/DynamicMeshBufferResource.h>

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -134,7 +134,6 @@ private:
 
   void DebugDrawGeometry();
   void DebugDrawGeometry(const ezVec3& vCenter, float fRadius, ezPhysicsShapeType::Enum shapeType, const ezTag& tag);
-  ezView* GetMainView() const;
 
   struct DebugGeo
   {

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -8,11 +8,13 @@
 #include <JoltPlugin/JoltPluginDLL.h>
 #include <JoltPlugin/System/JoltCollisionFiltering.h>
 #include <JoltPlugin/Utilities/JoltUserData.h>
+#include <RendererCore/Meshes/DynamicMeshBufferResource.h>
 
 class ezJoltCharacterControllerComponent;
 class ezJoltContactListener;
 class ezJoltRagdollComponent;
 class ezJoltRopeComponent;
+class ezView;
 
 namespace JPH
 {
@@ -129,6 +131,47 @@ private:
   void UpdateConstraints();
 
   ezTime CalculateUpdateSteps();
+
+  void DebugDrawGeometry();
+  void DebugDrawGeometry(const ezVec3& vCenter, float fRadius, ezPhysicsShapeType::Enum shapeType, const ezTag& tag);
+  ezView* GetMainView() const;
+
+  struct DebugGeo
+  {
+    ezGameObjectHandle m_hObject;
+    ezUInt32 m_uiLastSeenCounter = 0;
+    bool m_bMutableGeometry = false;
+  };
+
+  struct DebugGeoShape
+  {
+    ezDynamicMeshBufferResourceHandle m_hMesh;
+    ezBoundingBox m_Bounds;
+    ezUInt32 m_uiLastSeenCounter = 0;
+  };
+
+  struct DebugBodyShapeKey
+  {
+    ezUInt32 m_uiBodyID;
+    const void* m_pShapePtr;
+
+    bool operator<(const DebugBodyShapeKey& rhs) const
+    {
+      if (m_uiBodyID == rhs.m_uiBodyID)
+        return m_pShapePtr < rhs.m_pShapePtr;
+
+      return m_uiBodyID < rhs.m_uiBodyID;
+    }
+
+    bool operator==(const DebugBodyShapeKey& rhs) const
+    {
+      return (m_uiBodyID == rhs.m_uiBodyID) && (m_pShapePtr == rhs.m_pShapePtr);
+    }
+  };
+
+  ezUInt32 m_uiDebugGeoLastSeenCounter = 0;
+  ezMap<DebugBodyShapeKey, DebugGeo> m_DebugDrawComponents;
+  ezMap<const void*, DebugGeoShape> m_DebugDrawShapeGeo;
 
   ezUInt32 m_uiNextObjectFilterID = 1;
   ezDynamicArray<ezUInt32> m_FreeObjectFilterIDs;

--- a/Data/Base/Materials/Common/Pattern.ezMaterialAsset
+++ b/Data/Base/Materials/Common/Pattern.ezMaterialAsset
@@ -20,7 +20,7 @@ o
 			s{":app/VisualShader/Textures.ddl"}
 		}
 		Uuid %DocumentID{u4{15150418825657775493,4791833822222609996}}
-		u4 %Hash{10548999125324942675}
+		u4 %Hash{11535315683463123584}
 		VarArray %MetaInfo{}
 		VarArray %Outputs
 		{
@@ -94,7 +94,7 @@ o
 	p
 	{
 		Color %Default{f{0x9218A33E,0x9218A33E,0x9218A33E,0x0000803F}}
-		Vec2 %Node::Pos{f{0xCB07C343,0x1C152842}}
+		Vec2 %Node::Pos{f{0xCB07C343,0xF888AE41}}
 		s %ParamName{"Color"}
 	}
 }
@@ -514,6 +514,7 @@ o
 			Uuid{u4{8648126710299805379,15926322808980556731}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Occlusion"}
 		s %Type{"float"}
@@ -566,6 +567,7 @@ o
 			Uuid{u4{107023027798387058,15125524156854853544}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"MaskThreshold"}
 		s %Type{"float"}
@@ -628,6 +630,7 @@ o
 			Uuid{u4{8877328514147020979,11814959309858965089}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"a"}
 		s %Type{"float"}
@@ -656,6 +659,7 @@ o
 			Uuid{u4{12975893279928312590,7112828226212987324}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Roughness"}
 		s %Type{"float"}
@@ -685,6 +689,7 @@ o
 			Uuid{u4{15236640119020884527,855336876119980132}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Color"}
 		s %Type{"ezColor"}
@@ -725,6 +730,7 @@ o
 			Uuid{u4{4232483372289112742,7210651523459784837}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Default"}
 		s %Type{"ezColor"}
@@ -742,6 +748,7 @@ o
 			Uuid{u4{13542406804441022416,9548951225033578222}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"SubsurfaceColor"}
 		s %Type{"ezVec3"}
@@ -761,6 +768,7 @@ o
 			Uuid{u4{1999704295365795047,1389115649292724264}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"BaseTexture"}
 		s %Type{"ezString"}
@@ -778,6 +786,7 @@ o
 			Uuid{u4{12496807453269888305,16412205064812982056}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"RefractionColor"}
 		s %Type{"ezVec4"}
@@ -820,6 +829,7 @@ o
 			Uuid{u4{1263665986699366714,7795821215980672176}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Opacity"}
 		s %Type{"float"}
@@ -852,6 +862,7 @@ o
 			Uuid{u4{11154057802738083180,8940345913792219569}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Reflectance"}
 		s %Type{"float"}
@@ -978,6 +989,7 @@ o
 			Uuid{u4{9774780989707894273,9848653915852827572}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"b"}
 		s %Type{"float"}
@@ -1025,6 +1037,7 @@ o
 			Uuid{u4{104119927068760414,2224364025861394794}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Name"}
 		s %Type{"ezString"}
@@ -1084,6 +1097,7 @@ o
 			Uuid{u4{17341142541700783556,1767195288279124191}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Tiling"}
 		s %Type{"float"}
@@ -1138,6 +1152,7 @@ o
 			Uuid{u4{4085023801481947262,4424431816763648179}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Metallic"}
 		s %Type{"float"}
@@ -1182,6 +1197,7 @@ o
 			Uuid{u4{6649753934969554305,13791166057793731169}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Emissive"}
 		s %Type{"ezVec3"}
@@ -1199,6 +1215,7 @@ o
 			Uuid{u4{11371768134586030039,1180325336512481617}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"TWO_SIDED"}
 		s %Type{"bool"}
@@ -1236,6 +1253,7 @@ o
 			Uuid{u4{12689300849278625136,16388205898017076391}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"b"}
 		s %Type{"float"}
@@ -1253,6 +1271,7 @@ o
 			Uuid{u4{1624458220477332965,3337055032107232622}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
 		s %Name{"BLEND_MODE"}
 		s %Type{"BLEND_MODE"}
@@ -1291,6 +1310,7 @@ o
 			Uuid{u4{2531204913114908651,14636118749865147444}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"BaseColor"}
 		s %Type{"ezVec3"}
@@ -1335,6 +1355,7 @@ o
 			Uuid{u4{8435977591727481336,164499438610169273}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"ParamName"}
 		s %Type{"ezString"}
@@ -1454,6 +1475,7 @@ o
 			Uuid{u4{17000903584766608131,5655927074471313008}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"MaskThreshold"}
 		s %Type{"float"}
@@ -1488,6 +1510,7 @@ o
 			Uuid{u4{10546328178433928928,3538178021212683011}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"ApplyFog"}
 		s %Type{"bool"}
@@ -1546,6 +1569,7 @@ o
 			Uuid{u4{9941951229153436944,17787021238125754260}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
 		s %Name{"SHADING_MODE"}
 		s %Type{"SHADING_MODE"}
@@ -1573,6 +1597,7 @@ o
 			Uuid{u4{7999768391447710917,2784851377566841839}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"a"}
 		s %Type{"float"}
@@ -1591,6 +1616,7 @@ o
 			Uuid{u4{7213929454977328898,16983898963733524216}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Texture"}
 		s %Type{"ezString"}

--- a/Data/Base/Materials/Common/PhysicsColliders.ezMaterialAsset
+++ b/Data/Base/Materials/Common/PhysicsColliders.ezMaterialAsset
@@ -1,0 +1,612 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{7193466816718995642,4704535059086342262}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Material"}
+		VarArray %Dependencies
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+		Uuid %DocumentID{u4{7193466816718995642,4704535059086342262}}
+		u4 %Hash{16488369518648520593}
+		VarArray %MetaInfo{}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+		VarArray %References
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{797072534186212360,4612683052441967724}}
+	s %t{"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader"}
+	u3 %v{2}
+	p
+	{
+		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %BaseTexture{"{ f962fc28-661b-485c-a527-c997e239a3f0 }"}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		f %MaskThreshold{0x0000803E}
+		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		b %TWO_SIDED{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13855984864455260344,4979647377340124895}}
+	s %t{"ezMaterialAssetProperties"}
+	u3 %v{4}
+	p
+	{
+		s %BaseMaterial{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		s %MetaBasePrefab{"HeaderV2\r\n{\r\no\r\n{\r\n\tUuid %id{u4{15150418825657775493,4791833822222609996}}\r\n\ts %t{\"ezAssetDocumentInfo\"}\r\n\tu3 %v{2}\r\n\ts %n{\"Header\"}\r\n\tp\r\n\t{\r\n\t\ts %AssetType{\"Material\"}\r\n\t\tVarArray %Dependencies\r\n\t\t{\r\n\t\t\ts{\":app/VisualShader/Conversions.ddl\"}\r\n\t\t\ts{\":app/VisualShader/DefaultMaterial.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Inputs.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Math_Basic.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Math_Clamping.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Parameters.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Textures.ddl\"}\r\n\t\t}\r\n\t\tUuid %DocumentID{u4{15150418825657775493,4791833822222609996}}\r\n\t\tu4 %Hash{10548999125324942675}\r\n\t\tVarArray %MetaInfo{}\r\n\t\tVarArray %Outputs\r\n\t\t{\r\n\t\t\ts{\"VISUAL_SHADER\"}\r\n\t\t}\r\n\t\tVarArray %PackageDeps\r\n\t\t{\r\n\t\t\ts{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\t}\r\n\t\tVarArray %References\r\n\t\t{\r\n\t\t\ts{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\t}\r\n\t}\r\n}\r\n}\r\nObjects\r\n{\r\no\r\n{\r\n\tUuid %id{u4{2459487586587091876,4633197246295569358}}\r\n\ts %t{\"ShaderNode::Multiply\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x37BFC343,0x8863EE42}}\r\n\t\tf %a{0x0000803F}\r\n\t\tf %b{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7349474629313198467,4810738493151362545}}\r\n\ts %t{\"ShaderNode::Multiply\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0xF733E643,0xE61B8343}}\r\n\t\tf %a{0x0000803F}\r\n\t\tf %b{0x0000003F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17236283789300039610,4868560560521882739}}\r\n\ts %t{\"ShaderNode::InstanceData\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x83684E43,0xD0388742}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16800557665973799072,4881531428617865611}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{15117791089842229394,5558965522422809899}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{17647047357382570685,5387283873938896650}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14133219756830928267,4925012257813864265}}\r\n\ts %t{\"ShaderNode::ParameterColor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tColor %Default{f{0x9218A33E,0x9218A33E,0x9218A33E,0x0000803F}}\r\n\t\tVec2 %Node::Pos{f{0xCB07C343,0x1C152842}}\r\n\t\ts %ParamName{\"Color\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14379145788071149748,4930371780979134301}}\r\n\ts %t{\"ShaderNode::MaterialOutput\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tb %ApplyFog{1}\r\n\t\tVec3 %BaseColor{f{0x0000803F,0x0000803F,0x0000803F}}\r\n\t\tVec3 %Emissive{f{0,0,0}}\r\n\t\tf %MaskThreshold{0x0000803E}\r\n\t\tf %Metallic{0}\r\n\t\tVec2 %Node::Pos{f{0xF9078544,0x7CD92B43}}\r\n\t\tf %Occlusion{0x0000803F}\r\n\t\tf %Opacity{0x0000803F}\r\n\t\tf %Reflectance{0x0000003F}\r\n\t\tVec4 %RefractionColor{f{0,0,0,0x0000803F}}\r\n\t\tf %Roughness{0x3333333F}\r\n\t\tVec3 %SubsurfaceColor{f{0,0,0}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10944281192714901918,4966421183176252690}}\r\n\ts %t{\"ShaderNode::Texture3Way\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Name{\"BaseTexture\"}\r\n\t\tVec2 %Node::Pos{f{0x7F6FE042,0xE8C41743}}\r\n\t\ts %Texture{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\tf %Tiling{0x0000803E}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15088359648894619524,4996394559286021889}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{10944281192714901918,4966421183176252690}}\r\n\t\ts %Connection::SourcePin{\"RGBA\"}\r\n\t\tUuid %Connection::Target{u4{7349474629313198467,4810738493151362545}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13222497084817888430,5054079070018530379}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{2459487586587091876,4633197246295569358}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::TargetPin{\"b\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15978132618202027444,5059498813077690081}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\r\n\t\ts %Connection::TargetPin{\"BaseColor\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7536618545610782135,5069894415224396238}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{18164215943830731940,5171638345806463557}}\r\n\t\ts %Connection::SourcePin{\"w\"}\r\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\r\n\t\ts %Connection::TargetPin{\"Opacity\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18164215943830731940,5171638345806463557}}\r\n\ts %t{\"ShaderNode::Split\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0xA79B6344,0x90DE9943}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15545298105995977356,5194159505050198860}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{7349474629313198467,4810738493151362545}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{15117791089842229394,5558965522422809899}}\r\n\t\ts %Connection::TargetPin{\"b\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12863162716129488036,5232719034011888947}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{17236283789300039610,4868560560521882739}}\r\n\t\ts %Connection::SourcePin{\"Color\"}\r\n\t\tUuid %Connection::Target{u4{2459487586587091876,4633197246295569358}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2330531622256203166,5273914467009442304}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{17647047357382570685,5387283873938896650}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\r\n\t\ts %Connection::TargetPin{\"Roughness\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10761525945405070802,5318978621122591656}}\r\n\ts %t{\"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\ts %BLEND_MODE{\"BLEND_MODE::BLEND_MODE_OPAQUE\"}\r\n\t\ts %BaseTexture{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\tColor %Color{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}\r\n\t\tf %MaskThreshold{0x0000803E}\r\n\t\ts %SHADING_MODE{\"SHADING_MODE::SHADING_MODE_LIT\"}\r\n\t\tb %TWO_SIDED{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4662199427941981878,5366641751202611600}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{14133219756830928267,4925012257813864265}}\r\n\t\ts %Connection::SourcePin{\"Value\"}\r\n\t\tUuid %Connection::Target{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17647047357382570685,5387283873938896650}}\r\n\ts %t{\"ShaderNode::Saturate\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x05BD3944,0xBE8E6F43}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17299396001716606134,5485458337053796313}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{18164215943830731940,5171638345806463557}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15117791089842229394,5558965522422809899}}\r\n\ts %t{\"ShaderNode::Subtract\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x3A441644,0x81056F43}}\r\n\t\tf %a{0x6666A63F}\r\n\t\tf %b{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4179884881945017511,5632952876414573985}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{10944281192714901918,4966421183176252690}}\r\n\t\ts %Connection::SourcePin{\"RGBA\"}\r\n\t\tUuid %Connection::Target{u4{2459487586587091876,4633197246295569358}}\r\n\t\ts %Connection::TargetPin{\"b\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13930787030624295041,5649136198918986637}}\r\n\ts %t{\"ShaderNode::Multiply\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x0D630C44,0x8965C642}}\r\n\t\tf %a{0x0000803F}\r\n\t\tf %b{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5373694201964567170,5685942946020748827}}\r\n\ts %t{\"ezMaterialAssetProperties\"}\r\n\tu3 %v{4}\r\n\tp\r\n\t{\r\n\t\ts %BaseMaterial{\"\"}\r\n\t\ts %Shader{\"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }\"}\r\n\t\ts %ShaderMode{\"ezMaterialShaderMode::Custom\"}\r\n\t\tUuid %ShaderProperties{u4{10761525945405070802,5318978621122591656}}\r\n\t\ts %Surface{\"\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18096612296587978288,6449934965513159559}}\r\n\ts %t{\"ezDocumentRoot\"}\r\n\tu3 %v{1}\r\n\ts %n{\"ObjectTree\"}\r\n\tp\r\n\t{\r\n\t\tVarArray %Children\r\n\t\t{\r\n\t\t\tUuid{u4{5373694201964567170,5685942946020748827}}\r\n\t\t\tUuid{u4{14379145788071149748,4930371780979134301}}\r\n\t\t\tUuid{u4{10944281192714901918,4966421183176252690}}\r\n\t\t\tUuid{u4{17236283789300039610,4868560560521882739}}\r\n\t\t\tUuid{u4{2459487586587091876,4633197246295569358}}\r\n\t\t\tUuid{u4{13930787030624295041,5649136198918986637}}\r\n\t\t\tUuid{u4{14133219756830928267,4925012257813864265}}\r\n\t\t\tUuid{u4{18164215943830731940,5171638345806463557}}\r\n\t\t\tUuid{u4{7536618545610782135,5069894415224396238}}\r\n\t\t\tUuid{u4{15978132618202027444,5059498813077690081}}\r\n\t\t\tUuid{u4{17299396001716606134,5485458337053796313}}\r\n\t\t\tUuid{u4{12863162716129488036,5232719034011888947}}\r\n\t\t\tUuid{u4{4179884881945017511,5632952876414573985}}\r\n\t\t\tUuid{u4{4662199427941981878,5366641751202611600}}\r\n\t\t\tUuid{u4{13222497084817888430,5054079070018530379}}\r\n\t\t\tUuid{u4{15117791089842229394,5558965522422809899}}\r\n\t\t\tUuid{u4{17647047357382570685,5387283873938896650}}\r\n\t\t\tUuid{u4{16800557665973799072,4881531428617865611}}\r\n\t\t\tUuid{u4{2330531622256203166,5273914467009442304}}\r\n\t\t\tUuid{u4{7349474629313198467,4810738493151362545}}\r\n\t\t\tUuid{u4{15088359648894619524,4996394559286021889}}\r\n\t\t\tUuid{u4{15545298105995977356,5194159505050198860}}\r\n\t\t}\r\n\t}\r\n}\r\n}\r\nTypes\r\n{\r\no\r\n{\r\n\tUuid %id{u4{8435977591727481336,164499438610169273}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"Parameter\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1799344192542079709,460455342058959212}}\r\n\ts %t{\"ezExposeColorAlphaAttribute\"}\r\n\tu3 %v{1}\r\n\tp{}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15236640119020884527,855336876119980132}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tColor %Value{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11371768134586030039,1180325336512481617}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Permutation\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1999704295365795047,1389115649292724264}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11040065101175624628,1662539785884692449}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{2589033904860476140,2941600109649901427}}\r\n\t\t\tUuid{u4{16804715233058764794,16291563085247070494}}\r\n\t\t\tUuid{u4{18411837506060015951,13397631608945770603}}\r\n\t\t\tUuid{u4{8531456234757106898,9843359760009772741}}\r\n\t\t\tUuid{u4{10978509386339080603,6055180187630064684}}\r\n\t\t\tUuid{u4{2493142764329470971,4237250110264931902}}\r\n\t\t\tUuid{u4{11381554768749103056,5747586724112780390}}\r\n\t\t\tUuid{u4{15388913065968328453,11188089115316402371}}\r\n\t\t\tUuid{u4{13652862081152275637,1931931446829192038}}\r\n\t\t\tUuid{u4{4737060376990519197,5534452074735684677}}\r\n\t\t\tUuid{u4{17888293823252574217,5278584362329602531}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::MaterialOutput\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17341142541700783556,1767195288279124191}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18311245008988910186,1895067994934075466}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezEnumBase\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{773668148553828920,15966949596821666881}}\r\n\t\t\tUuid{u4{540429536914844576,8213819539779215949}}\r\n\t\t\tUuid{u4{15543418230834458689,5548684801941186544}}\r\n\t\t\tUuid{u4{16393153594407016602,3744118329769567614}}\r\n\t\t\tUuid{u4{7757084663128585029,8011669779036733373}}\r\n\t\t\tUuid{u4{5650026407490086663,5768478847879086899}}\r\n\t\t}\r\n\t\ts %TypeName{\"BLEND_MODE\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2524718926845712419,1904526312384132727}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezVisualShaderNodeBase\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13652862081152275637,1931931446829192038}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{8648126710299805379,15926322808980556731}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Occlusion\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9182498974977327514,2041274447054354959}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"SHADING_MODE::SHADING_MODE_LIT\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{104119927068760414,2224364025861394794}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"CustomTexture\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7999768391447710917,2784851377566841839}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2589033904860476140,2941600109649901427}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{107023027798387058,15125524156854853544}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"MaskThreshold\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1624458220477332965,3337055032107232622}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Permutation\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9886528029320226984,3535181809827272072}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Constant\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10546328178433928928,3538178021212683011}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tb %Value{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16393153594407016602,3744118329769567614}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{2}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_TRANSPARENT\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11992629484154905888,3993029317059678037}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{8877328514147020979,11814959309858965089}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"a\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12006658088070062296,4118947064651693189}}\r\n\ts %t{\"ezAssetBrowserAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %DependencyFlags{\"\"}\r\n\t\ts %Filter{\";CompatibleAsset_Texture_2D;\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2493142764329470971,4237250110264931902}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12975893279928312590,7112828226212987324}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Roughness\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4085023801481947262,4424431816763648179}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8550663219316513911,4527800363216923412}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9886528029320226984,3535181809827272072}}\r\n\t\t\tUuid{u4{1799344192542079709,460455342058959212}}\r\n\t\t\tUuid{u4{15236640119020884527,855336876119980132}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Color\"}\r\n\t\ts %Type{\"ezColor\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7391777909638578846,4627435359128124703}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{4867771077753072654,8477027800294353094}}\r\n\t\t\tUuid{u4{779633777514843960,17137553788842299501}}\r\n\t\t\tUuid{u4{10671060504538806139,9031876421588392282}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::Texture3Way\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9913376037671254523,4739060951232517466}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9088240305599432259,14617687262857557833}}\r\n\t\t\tUuid{u4{4232483372289112742,7210651523459784837}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Default\"}\r\n\t\ts %Type{\"ezColor\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17888293823252574217,5278584362329602531}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{13542406804441022416,9548951225033578222}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"SubsurfaceColor\"}\r\n\t\ts %Type{\"ezVec3\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{751045648905853503,5376862066758454147}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{11003997451405858569,11450403177460148761}}\r\n\t\t\tUuid{u4{9440730022944438567,6673183220487140738}}\r\n\t\t\tUuid{u4{1999704295365795047,1389115649292724264}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"BaseTexture\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4737060376990519197,5534452074735684677}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12496807453269888305,16412205064812982056}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"RefractionColor\"}\r\n\t\ts %Type{\"ezVec4\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15543418230834458689,5548684801941186544}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{1}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_MASKED\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17000903584766608131,5655927074471313008}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\td %Value{0x000000000000D03F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11381554768749103056,5747586724112780390}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{1263665986699366714,7795821215980672176}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Opacity\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5650026407490086663,5768478847879086899}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{4}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_MODULATE\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10978509386339080603,6055180187630064684}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{11154057802738083180,8940345913792219569}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Reflectance\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11695727463527673381,6549777581474058039}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezEnumBase\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{1155205217496153151,16062411953539633064}}\r\n\t\t\tUuid{u4{9182498974977327514,2041274447054354959}}\r\n\t\t\tUuid{u4{14201946371216656691,8983156218640221597}}\r\n\t\t}\r\n\t\ts %TypeName{\"SHADING_MODE\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9440730022944438567,6673183220487140738}}\r\n\ts %t{\"ezAssetBrowserAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %DependencyFlags{\"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail\"}\r\n\t\ts %Filter{\";CompatibleAsset_Texture_2D;\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12975893279928312590,7112828226212987324}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000003F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4232483372289112742,7210651523459784837}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tColorGamma %Value{u1{255,255,255,255}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15857399435423166171,7430766950459069189}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{10954214981482726729,17111196752340869338}}\r\n\t\t\tUuid{u4{12609603033176210513,7964630687986868603}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::Subtract\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16081855956766033354,7781865574992326161}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezShaderTypeBase\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{8550663219316513911,4527800363216923412}}\r\n\t\t\tUuid{u4{751045648905853503,5376862066758454147}}\r\n\t\t\tUuid{u4{5553976233745113740,12028035296425892129}}\r\n\t\t\tUuid{u4{942431713766673469,16743105944200706269}}\r\n\t\t\tUuid{u4{14174762422381468600,11322359312170432733}}\r\n\t\t\tUuid{u4{2154011308533014433,16155609086885943006}}\r\n\t\t}\r\n\t\ts %TypeName{\"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader\"}\r\n\t\tu3 %TypeVersion{2}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1263665986699366714,7795821215980672176}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12609603033176210513,7964630687986868603}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9774780989707894273,9848653915852827572}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"b\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7757084663128585029,8011669779036733373}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{3}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_ADDITIVE\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{540429536914844576,8213819539779215949}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_OPAQUE\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4867771077753072654,8477027800294353094}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{104119927068760414,2224364025861394794}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Name\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{6089094783765586323,8705960867921430659}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezDocumentRoot\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11154057802738083180,8940345913792219569}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000003F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14201946371216656691,8983156218640221597}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{1}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"SHADING_MODE::SHADING_MODE_FULLBRIGHT\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10671060504538806139,9031876421588392282}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{17341142541700783556,1767195288279124191}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Tiling\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17717897218099796308,9033184167245688007}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezShaderTypeBase\"}\r\n\t\tu3 %TypeVersion{2}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18305304007866142843,9444700149217459826}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Constant\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13542406804441022416,9548951225033578222}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec3 %Value{f{0,0,0}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8531456234757106898,9843359760009772741}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{4085023801481947262,4424431816763648179}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Metallic\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9774780989707894273,9848653915852827572}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1988646526571382668,10729334715299371304}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"DocumentNodeManager_DefaultConnection\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15388913065968328453,11188089115316402371}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{6649753934969554305,13791166057793731169}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Emissive\"}\r\n\t\ts %Type{\"ezVec3\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14174762422381468600,11322359312170432733}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{11371768134586030039,1180325336512481617}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"TWO_SIDED\"}\r\n\t\ts %Type{\"bool\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11003997451405858569,11450403177460148761}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Texture 2D\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8877328514147020979,11814959309858965089}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10097442269101671049,12017415575322047640}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12689300849278625136,16388205898017076391}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"b\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5553976233745113740,12028035296425892129}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{1624458220477332965,3337055032107232622}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"BLEND_MODE\"}\r\n\t\ts %Type{\"BLEND_MODE\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4440304378651420221,12575431605907932885}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{11992629484154905888,3993029317059678037}}\r\n\t\t\tUuid{u4{10097442269101671049,12017415575322047640}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::Multiply\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18411837506060015951,13397631608945770603}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{2531204913114908651,14636118749865147444}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"BaseColor\"}\r\n\t\ts %Type{\"ezVec3\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{6649753934969554305,13791166057793731169}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec3 %Value{f{0,0,0}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10765536432168002227,14077301894287280531}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ShaderNode::InstanceData\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16422282166416556709,14502256122642309324}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{8435977591727481336,164499438610169273}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"ParamName\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9088240305599432259,14617687262857557833}}\r\n\ts %t{\"ezExposeColorAlphaAttribute\"}\r\n\tu3 %v{1}\r\n\tp{}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2531204913114908651,14636118749865147444}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec3 %Value{f{0x0000803F,0x0000803F,0x0000803F}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2947336711354777548,15013008608905564043}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezEnumBase\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{107023027798387058,15125524156854853544}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803E}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{574185834121239378,15422088015066052787}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ShaderNode::Split\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8648126710299805379,15926322808980556731}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{773668148553828920,15966949596821666881}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\tu3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::Default\"}\r\n\t\ts %Type{\"ezUInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1155205217496153151,16062411953539633064}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\tu3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"SHADING_MODE::Default\"}\r\n\t\ts %Type{\"ezUInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2154011308533014433,16155609086885943006}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{18305304007866142843,9444700149217459826}}\r\n\t\t\tUuid{u4{17000903584766608131,5655927074471313008}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"MaskThreshold\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18349806816312788076,16229247027635378395}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ShaderNode::Saturate\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16804715233058764794,16291563085247070494}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{10546328178433928928,3538178021212683011}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"ApplyFog\"}\r\n\t\ts %Type{\"bool\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12689300849278625136,16388205898017076391}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12496807453269888305,16412205064812982056}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec4 %Value{f{0,0,0,0x0000803F}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9055380125307899845,16548159432520566774}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{16422282166416556709,14502256122642309324}}\r\n\t\t\tUuid{u4{9913376037671254523,4739060951232517466}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::ParameterColor\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{942431713766673469,16743105944200706269}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9941951229153436944,17787021238125754260}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"SHADING_MODE\"}\r\n\t\ts %Type{\"SHADING_MODE\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7213929454977328898,16983898963733524216}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10954214981482726729,17111196752340869338}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{7999768391447710917,2784851377566841839}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"a\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{779633777514843960,17137553788842299501}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12006658088070062296,4118947064651693189}}\r\n\t\t\tUuid{u4{7213929454977328898,16983898963733524216}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Texture\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8721322561248882817,17579066505604714242}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezEnumBase\"}\r\n\t\ts %PluginName{\"ezEditorPluginAssets\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezMaterialShaderMode\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9941951229153436944,17787021238125754260}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Permutation\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{983387834180907111,17935407260904399048}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezReflectedClass\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5030680158680079231,18410952876772242771}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"ezEditorPluginAssets\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezMaterialAssetProperties\"}\r\n\t\tu3 %TypeVersion{4}\r\n\t}\r\n}\r\n}\r\n"}
+		Uuid %MetaFromPrefab{u4{15150418825657775493,4791833822222609996}}
+		Uuid %MetaPrefabSeed{u4{8482290662490693174,17740448505028927684}}
+		s %Shader{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		s %ShaderMode{"ezMaterialShaderMode::BaseMaterial"}
+		Uuid %ShaderProperties{u4{797072534186212360,4612683052441967724}}
+		s %Surface{""}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{13855984864455260344,4979647377340124895}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{1799344192542079709,460455342058959212}}
+	s %t{"ezExposeColorAlphaAttribute"}
+	u3 %v{1}
+	p{}
+}
+o
+{
+	Uuid %id{u4{15236640119020884527,855336876119980132}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Color %Value{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{11371768134586030039,1180325336512481617}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{1999704295365795047,1389115649292724264}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Value{"{ f962fc28-661b-485c-a527-c997e239a3f0 }"}
+	}
+}
+o
+{
+	Uuid %id{u4{18311245008988910186,1895067994934075466}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{773668148553828920,15966949596821666881}}
+			Uuid{u4{540429536914844576,8213819539779215949}}
+			Uuid{u4{15543418230834458689,5548684801941186544}}
+			Uuid{u4{16393153594407016602,3744118329769567614}}
+			Uuid{u4{7757084663128585029,8011669779036733373}}
+			Uuid{u4{5650026407490086663,5768478847879086899}}
+		}
+		s %TypeName{"BLEND_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9182498974977327514,2041274447054354959}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1624458220477332965,3337055032107232622}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{9886528029320226984,3535181809827272072}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{16393153594407016602,3744118329769567614}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{2}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{8550663219316513911,4527800363216923412}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9886528029320226984,3535181809827272072}}
+			Uuid{u4{1799344192542079709,460455342058959212}}
+			Uuid{u4{15236640119020884527,855336876119980132}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Color"}
+		s %Type{"ezColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{751045648905853503,5376862066758454147}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11003997451405858569,11450403177460148761}}
+			Uuid{u4{9440730022944438567,6673183220487140738}}
+			Uuid{u4{1999704295365795047,1389115649292724264}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseTexture"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{15543418230834458689,5548684801941186544}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17000903584766608131,5655927074471313008}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x000000000000D03F}
+	}
+}
+o
+{
+	Uuid %id{u4{5650026407490086663,5768478847879086899}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{4}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{11695727463527673381,6549777581474058039}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{1155205217496153151,16062411953539633064}}
+			Uuid{u4{9182498974977327514,2041274447054354959}}
+			Uuid{u4{14201946371216656691,8983156218640221597}}
+		}
+		s %TypeName{"SHADING_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9440730022944438567,6673183220487140738}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+	}
+}
+o
+{
+	Uuid %id{u4{16081855956766033354,7781865574992326161}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezShaderTypeBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{8550663219316513911,4527800363216923412}}
+			Uuid{u4{751045648905853503,5376862066758454147}}
+			Uuid{u4{5553976233745113740,12028035296425892129}}
+			Uuid{u4{942431713766673469,16743105944200706269}}
+			Uuid{u4{14174762422381468600,11322359312170432733}}
+			Uuid{u4{2154011308533014433,16155609086885943006}}
+		}
+		s %TypeName{"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{7757084663128585029,8011669779036733373}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{3}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{540429536914844576,8213819539779215949}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14201946371216656691,8983156218640221597}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17717897218099796308,9033184167245688007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezShaderTypeBase"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{18305304007866142843,9444700149217459826}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{14174762422381468600,11322359312170432733}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11371768134586030039,1180325336512481617}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"TWO_SIDED"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{11003997451405858569,11450403177460148761}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Texture 2D"}
+	}
+}
+o
+{
+	Uuid %id{u4{5553976233745113740,12028035296425892129}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1624458220477332965,3337055032107232622}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"BLEND_MODE"}
+		s %Type{"BLEND_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{773668148553828920,15966949596821666881}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1155205217496153151,16062411953539633064}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{2154011308533014433,16155609086885943006}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{18305304007866142843,9444700149217459826}}
+			Uuid{u4{17000903584766608131,5655927074471313008}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"MaskThreshold"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{942431713766673469,16743105944200706269}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9941951229153436944,17787021238125754260}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"SHADING_MODE"}
+		s %Type{"SHADING_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{8721322561248882817,17579066505604714242}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialShaderMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9941951229153436944,17787021238125754260}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5030680158680079231,18410952876772242771}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialAssetProperties"}
+		u3 %TypeVersion{4}
+	}
+}
+}

--- a/Data/Base/Materials/Common/PhysicsCollidersSoft.ezMaterialAsset
+++ b/Data/Base/Materials/Common/PhysicsCollidersSoft.ezMaterialAsset
@@ -1,0 +1,612 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{13724519759768785796,5312726625140207844}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Material"}
+		VarArray %Dependencies
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+		Uuid %DocumentID{u4{13724519759768785796,5312726625140207844}}
+		u4 %Hash{14755951239112780399}
+		VarArray %MetaInfo{}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+		VarArray %References
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{7328125477236002514,5220874618495833306}}
+	s %t{"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader"}
+	u3 %v{2}
+	p
+	{
+		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %BaseTexture{"{ f962fc28-661b-485c-a527-c997e239a3f0 }"}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		f %MaskThreshold{0x0000803E}
+		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		b %TWO_SIDED{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1940293733795498882,5587838943393990477}}
+	s %t{"ezMaterialAssetProperties"}
+	u3 %v{4}
+	p
+	{
+		s %BaseMaterial{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		s %MetaBasePrefab{"HeaderV2\r\n{\r\no\r\n{\r\n\tUuid %id{u4{15150418825657775493,4791833822222609996}}\r\n\ts %t{\"ezAssetDocumentInfo\"}\r\n\tu3 %v{2}\r\n\ts %n{\"Header\"}\r\n\tp\r\n\t{\r\n\t\ts %AssetType{\"Material\"}\r\n\t\tVarArray %Dependencies\r\n\t\t{\r\n\t\t\ts{\":app/VisualShader/Conversions.ddl\"}\r\n\t\t\ts{\":app/VisualShader/DefaultMaterial.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Inputs.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Math_Basic.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Math_Clamping.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Parameters.ddl\"}\r\n\t\t\ts{\":app/VisualShader/Textures.ddl\"}\r\n\t\t}\r\n\t\tUuid %DocumentID{u4{15150418825657775493,4791833822222609996}}\r\n\t\tu4 %Hash{10548999125324942675}\r\n\t\tVarArray %MetaInfo{}\r\n\t\tVarArray %Outputs\r\n\t\t{\r\n\t\t\ts{\"VISUAL_SHADER\"}\r\n\t\t}\r\n\t\tVarArray %PackageDeps\r\n\t\t{\r\n\t\t\ts{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\t}\r\n\t\tVarArray %References\r\n\t\t{\r\n\t\t\ts{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\t}\r\n\t}\r\n}\r\n}\r\nObjects\r\n{\r\no\r\n{\r\n\tUuid %id{u4{2459487586587091876,4633197246295569358}}\r\n\ts %t{\"ShaderNode::Multiply\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x37BFC343,0x8863EE42}}\r\n\t\tf %a{0x0000803F}\r\n\t\tf %b{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7349474629313198467,4810738493151362545}}\r\n\ts %t{\"ShaderNode::Multiply\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0xF733E643,0xE61B8343}}\r\n\t\tf %a{0x0000803F}\r\n\t\tf %b{0x0000003F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17236283789300039610,4868560560521882739}}\r\n\ts %t{\"ShaderNode::InstanceData\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x83684E43,0xD0388742}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16800557665973799072,4881531428617865611}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{15117791089842229394,5558965522422809899}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{17647047357382570685,5387283873938896650}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14133219756830928267,4925012257813864265}}\r\n\ts %t{\"ShaderNode::ParameterColor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tColor %Default{f{0x9218A33E,0x9218A33E,0x9218A33E,0x0000803F}}\r\n\t\tVec2 %Node::Pos{f{0xCB07C343,0x1C152842}}\r\n\t\ts %ParamName{\"Color\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14379145788071149748,4930371780979134301}}\r\n\ts %t{\"ShaderNode::MaterialOutput\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tb %ApplyFog{1}\r\n\t\tVec3 %BaseColor{f{0x0000803F,0x0000803F,0x0000803F}}\r\n\t\tVec3 %Emissive{f{0,0,0}}\r\n\t\tf %MaskThreshold{0x0000803E}\r\n\t\tf %Metallic{0}\r\n\t\tVec2 %Node::Pos{f{0xF9078544,0x7CD92B43}}\r\n\t\tf %Occlusion{0x0000803F}\r\n\t\tf %Opacity{0x0000803F}\r\n\t\tf %Reflectance{0x0000003F}\r\n\t\tVec4 %RefractionColor{f{0,0,0,0x0000803F}}\r\n\t\tf %Roughness{0x3333333F}\r\n\t\tVec3 %SubsurfaceColor{f{0,0,0}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10944281192714901918,4966421183176252690}}\r\n\ts %t{\"ShaderNode::Texture3Way\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Name{\"BaseTexture\"}\r\n\t\tVec2 %Node::Pos{f{0x7F6FE042,0xE8C41743}}\r\n\t\ts %Texture{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\tf %Tiling{0x0000803E}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15088359648894619524,4996394559286021889}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{10944281192714901918,4966421183176252690}}\r\n\t\ts %Connection::SourcePin{\"RGBA\"}\r\n\t\tUuid %Connection::Target{u4{7349474629313198467,4810738493151362545}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13222497084817888430,5054079070018530379}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{2459487586587091876,4633197246295569358}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::TargetPin{\"b\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15978132618202027444,5059498813077690081}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\r\n\t\ts %Connection::TargetPin{\"BaseColor\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7536618545610782135,5069894415224396238}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{18164215943830731940,5171638345806463557}}\r\n\t\ts %Connection::SourcePin{\"w\"}\r\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\r\n\t\ts %Connection::TargetPin{\"Opacity\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18164215943830731940,5171638345806463557}}\r\n\ts %t{\"ShaderNode::Split\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0xA79B6344,0x90DE9943}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15545298105995977356,5194159505050198860}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{7349474629313198467,4810738493151362545}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{15117791089842229394,5558965522422809899}}\r\n\t\ts %Connection::TargetPin{\"b\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12863162716129488036,5232719034011888947}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{17236283789300039610,4868560560521882739}}\r\n\t\ts %Connection::SourcePin{\"Color\"}\r\n\t\tUuid %Connection::Target{u4{2459487586587091876,4633197246295569358}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2330531622256203166,5273914467009442304}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{17647047357382570685,5387283873938896650}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\r\n\t\ts %Connection::TargetPin{\"Roughness\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10761525945405070802,5318978621122591656}}\r\n\ts %t{\"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\ts %BLEND_MODE{\"BLEND_MODE::BLEND_MODE_OPAQUE\"}\r\n\t\ts %BaseTexture{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t\tColor %Color{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}\r\n\t\tf %MaskThreshold{0x0000803E}\r\n\t\ts %SHADING_MODE{\"SHADING_MODE::SHADING_MODE_LIT\"}\r\n\t\tb %TWO_SIDED{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4662199427941981878,5366641751202611600}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{14133219756830928267,4925012257813864265}}\r\n\t\ts %Connection::SourcePin{\"Value\"}\r\n\t\tUuid %Connection::Target{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17647047357382570685,5387283873938896650}}\r\n\ts %t{\"ShaderNode::Saturate\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x05BD3944,0xBE8E6F43}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17299396001716606134,5485458337053796313}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{13930787030624295041,5649136198918986637}}\r\n\t\ts %Connection::SourcePin{\"result\"}\r\n\t\tUuid %Connection::Target{u4{18164215943830731940,5171638345806463557}}\r\n\t\ts %Connection::TargetPin{\"a\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15117791089842229394,5558965522422809899}}\r\n\ts %t{\"ShaderNode::Subtract\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x3A441644,0x81056F43}}\r\n\t\tf %a{0x6666A63F}\r\n\t\tf %b{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4179884881945017511,5632952876414573985}}\r\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tUuid %Connection::Source{u4{10944281192714901918,4966421183176252690}}\r\n\t\ts %Connection::SourcePin{\"RGBA\"}\r\n\t\tUuid %Connection::Target{u4{2459487586587091876,4633197246295569358}}\r\n\t\ts %Connection::TargetPin{\"b\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13930787030624295041,5649136198918986637}}\r\n\ts %t{\"ShaderNode::Multiply\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec2 %Node::Pos{f{0x0D630C44,0x8965C642}}\r\n\t\tf %a{0x0000803F}\r\n\t\tf %b{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5373694201964567170,5685942946020748827}}\r\n\ts %t{\"ezMaterialAssetProperties\"}\r\n\tu3 %v{4}\r\n\tp\r\n\t{\r\n\t\ts %BaseMaterial{\"\"}\r\n\t\ts %Shader{\"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }\"}\r\n\t\ts %ShaderMode{\"ezMaterialShaderMode::Custom\"}\r\n\t\tUuid %ShaderProperties{u4{10761525945405070802,5318978621122591656}}\r\n\t\ts %Surface{\"\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18096612296587978288,6449934965513159559}}\r\n\ts %t{\"ezDocumentRoot\"}\r\n\tu3 %v{1}\r\n\ts %n{\"ObjectTree\"}\r\n\tp\r\n\t{\r\n\t\tVarArray %Children\r\n\t\t{\r\n\t\t\tUuid{u4{5373694201964567170,5685942946020748827}}\r\n\t\t\tUuid{u4{14379145788071149748,4930371780979134301}}\r\n\t\t\tUuid{u4{10944281192714901918,4966421183176252690}}\r\n\t\t\tUuid{u4{17236283789300039610,4868560560521882739}}\r\n\t\t\tUuid{u4{2459487586587091876,4633197246295569358}}\r\n\t\t\tUuid{u4{13930787030624295041,5649136198918986637}}\r\n\t\t\tUuid{u4{14133219756830928267,4925012257813864265}}\r\n\t\t\tUuid{u4{18164215943830731940,5171638345806463557}}\r\n\t\t\tUuid{u4{7536618545610782135,5069894415224396238}}\r\n\t\t\tUuid{u4{15978132618202027444,5059498813077690081}}\r\n\t\t\tUuid{u4{17299396001716606134,5485458337053796313}}\r\n\t\t\tUuid{u4{12863162716129488036,5232719034011888947}}\r\n\t\t\tUuid{u4{4179884881945017511,5632952876414573985}}\r\n\t\t\tUuid{u4{4662199427941981878,5366641751202611600}}\r\n\t\t\tUuid{u4{13222497084817888430,5054079070018530379}}\r\n\t\t\tUuid{u4{15117791089842229394,5558965522422809899}}\r\n\t\t\tUuid{u4{17647047357382570685,5387283873938896650}}\r\n\t\t\tUuid{u4{16800557665973799072,4881531428617865611}}\r\n\t\t\tUuid{u4{2330531622256203166,5273914467009442304}}\r\n\t\t\tUuid{u4{7349474629313198467,4810738493151362545}}\r\n\t\t\tUuid{u4{15088359648894619524,4996394559286021889}}\r\n\t\t\tUuid{u4{15545298105995977356,5194159505050198860}}\r\n\t\t}\r\n\t}\r\n}\r\n}\r\nTypes\r\n{\r\no\r\n{\r\n\tUuid %id{u4{8435977591727481336,164499438610169273}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"Parameter\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1799344192542079709,460455342058959212}}\r\n\ts %t{\"ezExposeColorAlphaAttribute\"}\r\n\tu3 %v{1}\r\n\tp{}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15236640119020884527,855336876119980132}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tColor %Value{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11371768134586030039,1180325336512481617}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Permutation\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1999704295365795047,1389115649292724264}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11040065101175624628,1662539785884692449}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{2589033904860476140,2941600109649901427}}\r\n\t\t\tUuid{u4{16804715233058764794,16291563085247070494}}\r\n\t\t\tUuid{u4{18411837506060015951,13397631608945770603}}\r\n\t\t\tUuid{u4{8531456234757106898,9843359760009772741}}\r\n\t\t\tUuid{u4{10978509386339080603,6055180187630064684}}\r\n\t\t\tUuid{u4{2493142764329470971,4237250110264931902}}\r\n\t\t\tUuid{u4{11381554768749103056,5747586724112780390}}\r\n\t\t\tUuid{u4{15388913065968328453,11188089115316402371}}\r\n\t\t\tUuid{u4{13652862081152275637,1931931446829192038}}\r\n\t\t\tUuid{u4{4737060376990519197,5534452074735684677}}\r\n\t\t\tUuid{u4{17888293823252574217,5278584362329602531}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::MaterialOutput\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17341142541700783556,1767195288279124191}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18311245008988910186,1895067994934075466}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezEnumBase\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{773668148553828920,15966949596821666881}}\r\n\t\t\tUuid{u4{540429536914844576,8213819539779215949}}\r\n\t\t\tUuid{u4{15543418230834458689,5548684801941186544}}\r\n\t\t\tUuid{u4{16393153594407016602,3744118329769567614}}\r\n\t\t\tUuid{u4{7757084663128585029,8011669779036733373}}\r\n\t\t\tUuid{u4{5650026407490086663,5768478847879086899}}\r\n\t\t}\r\n\t\ts %TypeName{\"BLEND_MODE\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2524718926845712419,1904526312384132727}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezVisualShaderNodeBase\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13652862081152275637,1931931446829192038}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{8648126710299805379,15926322808980556731}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Occlusion\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9182498974977327514,2041274447054354959}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"SHADING_MODE::SHADING_MODE_LIT\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{104119927068760414,2224364025861394794}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"CustomTexture\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7999768391447710917,2784851377566841839}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2589033904860476140,2941600109649901427}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{107023027798387058,15125524156854853544}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"MaskThreshold\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1624458220477332965,3337055032107232622}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Permutation\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9886528029320226984,3535181809827272072}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Constant\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10546328178433928928,3538178021212683011}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tb %Value{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16393153594407016602,3744118329769567614}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{2}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_TRANSPARENT\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11992629484154905888,3993029317059678037}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{8877328514147020979,11814959309858965089}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"a\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12006658088070062296,4118947064651693189}}\r\n\ts %t{\"ezAssetBrowserAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %DependencyFlags{\"\"}\r\n\t\ts %Filter{\";CompatibleAsset_Texture_2D;\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2493142764329470971,4237250110264931902}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12975893279928312590,7112828226212987324}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Roughness\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4085023801481947262,4424431816763648179}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8550663219316513911,4527800363216923412}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9886528029320226984,3535181809827272072}}\r\n\t\t\tUuid{u4{1799344192542079709,460455342058959212}}\r\n\t\t\tUuid{u4{15236640119020884527,855336876119980132}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Color\"}\r\n\t\ts %Type{\"ezColor\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7391777909638578846,4627435359128124703}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{4867771077753072654,8477027800294353094}}\r\n\t\t\tUuid{u4{779633777514843960,17137553788842299501}}\r\n\t\t\tUuid{u4{10671060504538806139,9031876421588392282}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::Texture3Way\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9913376037671254523,4739060951232517466}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9088240305599432259,14617687262857557833}}\r\n\t\t\tUuid{u4{4232483372289112742,7210651523459784837}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Default\"}\r\n\t\ts %Type{\"ezColor\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17888293823252574217,5278584362329602531}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{13542406804441022416,9548951225033578222}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"SubsurfaceColor\"}\r\n\t\ts %Type{\"ezVec3\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{751045648905853503,5376862066758454147}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{11003997451405858569,11450403177460148761}}\r\n\t\t\tUuid{u4{9440730022944438567,6673183220487140738}}\r\n\t\t\tUuid{u4{1999704295365795047,1389115649292724264}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"BaseTexture\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4737060376990519197,5534452074735684677}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12496807453269888305,16412205064812982056}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"RefractionColor\"}\r\n\t\ts %Type{\"ezVec4\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15543418230834458689,5548684801941186544}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{1}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_MASKED\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17000903584766608131,5655927074471313008}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\td %Value{0x000000000000D03F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11381554768749103056,5747586724112780390}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{1263665986699366714,7795821215980672176}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Opacity\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5650026407490086663,5768478847879086899}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{4}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_MODULATE\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10978509386339080603,6055180187630064684}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{11154057802738083180,8940345913792219569}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Reflectance\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11695727463527673381,6549777581474058039}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezEnumBase\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{1155205217496153151,16062411953539633064}}\r\n\t\t\tUuid{u4{9182498974977327514,2041274447054354959}}\r\n\t\t\tUuid{u4{14201946371216656691,8983156218640221597}}\r\n\t\t}\r\n\t\ts %TypeName{\"SHADING_MODE\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9440730022944438567,6673183220487140738}}\r\n\ts %t{\"ezAssetBrowserAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %DependencyFlags{\"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail\"}\r\n\t\ts %Filter{\";CompatibleAsset_Texture_2D;\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12975893279928312590,7112828226212987324}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000003F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4232483372289112742,7210651523459784837}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tColorGamma %Value{u1{255,255,255,255}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15857399435423166171,7430766950459069189}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{10954214981482726729,17111196752340869338}}\r\n\t\t\tUuid{u4{12609603033176210513,7964630687986868603}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::Subtract\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16081855956766033354,7781865574992326161}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezShaderTypeBase\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{8550663219316513911,4527800363216923412}}\r\n\t\t\tUuid{u4{751045648905853503,5376862066758454147}}\r\n\t\t\tUuid{u4{5553976233745113740,12028035296425892129}}\r\n\t\t\tUuid{u4{942431713766673469,16743105944200706269}}\r\n\t\t\tUuid{u4{14174762422381468600,11322359312170432733}}\r\n\t\t\tUuid{u4{2154011308533014433,16155609086885943006}}\r\n\t\t}\r\n\t\ts %TypeName{\"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader\"}\r\n\t\tu3 %TypeVersion{2}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1263665986699366714,7795821215980672176}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12609603033176210513,7964630687986868603}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9774780989707894273,9848653915852827572}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"b\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7757084663128585029,8011669779036733373}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{3}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_ADDITIVE\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{540429536914844576,8213819539779215949}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_OPAQUE\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4867771077753072654,8477027800294353094}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{104119927068760414,2224364025861394794}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Name\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{6089094783765586323,8705960867921430659}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezDocumentRoot\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11154057802738083180,8940345913792219569}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000003F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14201946371216656691,8983156218640221597}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\ti3 %ConstantValue{1}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"SHADING_MODE::SHADING_MODE_FULLBRIGHT\"}\r\n\t\ts %Type{\"ezInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10671060504538806139,9031876421588392282}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{17341142541700783556,1767195288279124191}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Tiling\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{17717897218099796308,9033184167245688007}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"ShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezShaderTypeBase\"}\r\n\t\tu3 %TypeVersion{2}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18305304007866142843,9444700149217459826}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Constant\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{13542406804441022416,9548951225033578222}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec3 %Value{f{0,0,0}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8531456234757106898,9843359760009772741}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{4085023801481947262,4424431816763648179}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Metallic\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9774780989707894273,9848653915852827572}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1988646526571382668,10729334715299371304}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"DocumentNodeManager_DefaultConnection\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{15388913065968328453,11188089115316402371}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{6649753934969554305,13791166057793731169}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Emissive\"}\r\n\t\ts %Type{\"ezVec3\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{14174762422381468600,11322359312170432733}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{11371768134586030039,1180325336512481617}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"TWO_SIDED\"}\r\n\t\ts %Type{\"bool\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{11003997451405858569,11450403177460148761}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Texture 2D\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8877328514147020979,11814959309858965089}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10097442269101671049,12017415575322047640}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12689300849278625136,16388205898017076391}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"b\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5553976233745113740,12028035296425892129}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{1624458220477332965,3337055032107232622}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"BLEND_MODE\"}\r\n\t\ts %Type{\"BLEND_MODE\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{4440304378651420221,12575431605907932885}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{11992629484154905888,3993029317059678037}}\r\n\t\t\tUuid{u4{10097442269101671049,12017415575322047640}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::Multiply\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18411837506060015951,13397631608945770603}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{2531204913114908651,14636118749865147444}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"BaseColor\"}\r\n\t\ts %Type{\"ezVec3\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{6649753934969554305,13791166057793731169}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec3 %Value{f{0,0,0}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10765536432168002227,14077301894287280531}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ShaderNode::InstanceData\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16422282166416556709,14502256122642309324}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{8435977591727481336,164499438610169273}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"ParamName\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9088240305599432259,14617687262857557833}}\r\n\ts %t{\"ezExposeColorAlphaAttribute\"}\r\n\tu3 %v{1}\r\n\tp{}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2531204913114908651,14636118749865147444}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec3 %Value{f{0x0000803F,0x0000803F,0x0000803F}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2947336711354777548,15013008608905564043}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezEnumBase\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{107023027798387058,15125524156854853544}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803E}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{574185834121239378,15422088015066052787}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ShaderNode::Split\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8648126710299805379,15926322808980556731}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{773668148553828920,15966949596821666881}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\tu3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"BLEND_MODE::Default\"}\r\n\t\ts %Type{\"ezUInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{1155205217496153151,16062411953539633064}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\r\n\t\tu3 %ConstantValue{0}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\r\n\t\ts %Name{\"SHADING_MODE::Default\"}\r\n\t\ts %Type{\"ezUInt32\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{2154011308533014433,16155609086885943006}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{18305304007866142843,9444700149217459826}}\r\n\t\t\tUuid{u4{17000903584766608131,5655927074471313008}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"MaskThreshold\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{18349806816312788076,16229247027635378395}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ShaderNode::Saturate\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{16804715233058764794,16291563085247070494}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{10546328178433928928,3538178021212683011}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"ApplyFog\"}\r\n\t\ts %Type{\"bool\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12689300849278625136,16388205898017076391}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tf %Value{0x0000803F}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{12496807453269888305,16412205064812982056}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVec4 %Value{f{0,0,0,0x0000803F}}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9055380125307899845,16548159432520566774}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\r\n\t\ts %PluginName{\"VisualShaderTypes\"}\r\n\t\tVarArray %Properties\r\n\t\t{\r\n\t\t\tUuid{u4{16422282166416556709,14502256122642309324}}\r\n\t\t\tUuid{u4{9913376037671254523,4739060951232517466}}\r\n\t\t}\r\n\t\ts %TypeName{\"ShaderNode::ParameterColor\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{942431713766673469,16743105944200706269}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{9941951229153436944,17787021238125754260}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"SHADING_MODE\"}\r\n\t\ts %Type{\"SHADING_MODE\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{7213929454977328898,16983898963733524216}}\r\n\ts %t{\"ezDefaultValueAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Value{\"\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{10954214981482726729,17111196752340869338}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{7999768391447710917,2784851377566841839}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"a\"}\r\n\t\ts %Type{\"float\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{779633777514843960,17137553788842299501}}\r\n\ts %t{\"ezReflectedPropertyDescriptor\"}\r\n\tu3 %v{2}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes\r\n\t\t{\r\n\t\t\tUuid{u4{12006658088070062296,4118947064651693189}}\r\n\t\t\tUuid{u4{7213929454977328898,16983898963733524216}}\r\n\t\t}\r\n\t\ts %Category{\"ezPropertyCategory::Member\"}\r\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\r\n\t\ts %Name{\"Texture\"}\r\n\t\ts %Type{\"ezString\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{8721322561248882817,17579066505604714242}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezEnumBase\"}\r\n\t\ts %PluginName{\"ezEditorPluginAssets\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezMaterialShaderMode\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{9941951229153436944,17787021238125754260}}\r\n\ts %t{\"ezCategoryAttribute\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\ts %Category{\"Permutation\"}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{983387834180907111,17935407260904399048}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"\"}\r\n\t\ts %PluginName{\"Static\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezReflectedClass\"}\r\n\t\tu3 %TypeVersion{1}\r\n\t}\r\n}\r\no\r\n{\r\n\tUuid %id{u4{5030680158680079231,18410952876772242771}}\r\n\ts %t{\"ezReflectedTypeDescriptor\"}\r\n\tu3 %v{1}\r\n\tp\r\n\t{\r\n\t\tVarArray %Attributes{}\r\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\r\n\t\tVarArray %Functions{}\r\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\r\n\t\ts %PluginName{\"ezEditorPluginAssets\"}\r\n\t\tVarArray %Properties{}\r\n\t\ts %TypeName{\"ezMaterialAssetProperties\"}\r\n\t\tu3 %TypeVersion{4}\r\n\t}\r\n}\r\n}\r\n"}
+		Uuid %MetaFromPrefab{u4{15150418825657775493,4791833822222609996}}
+		Uuid %MetaPrefabSeed{u4{15013343605540483328,18348640071082793266}}
+		s %Shader{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		s %ShaderMode{"ezMaterialShaderMode::BaseMaterial"}
+		Uuid %ShaderProperties{u4{7328125477236002514,5220874618495833306}}
+		s %Surface{""}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{1940293733795498882,5587838943393990477}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{1799344192542079709,460455342058959212}}
+	s %t{"ezExposeColorAlphaAttribute"}
+	u3 %v{1}
+	p{}
+}
+o
+{
+	Uuid %id{u4{15236640119020884527,855336876119980132}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Color %Value{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{11371768134586030039,1180325336512481617}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{1999704295365795047,1389115649292724264}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Value{"{ f962fc28-661b-485c-a527-c997e239a3f0 }"}
+	}
+}
+o
+{
+	Uuid %id{u4{18311245008988910186,1895067994934075466}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{773668148553828920,15966949596821666881}}
+			Uuid{u4{540429536914844576,8213819539779215949}}
+			Uuid{u4{15543418230834458689,5548684801941186544}}
+			Uuid{u4{16393153594407016602,3744118329769567614}}
+			Uuid{u4{7757084663128585029,8011669779036733373}}
+			Uuid{u4{5650026407490086663,5768478847879086899}}
+		}
+		s %TypeName{"BLEND_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9182498974977327514,2041274447054354959}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1624458220477332965,3337055032107232622}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{9886528029320226984,3535181809827272072}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{16393153594407016602,3744118329769567614}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{2}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{8550663219316513911,4527800363216923412}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9886528029320226984,3535181809827272072}}
+			Uuid{u4{1799344192542079709,460455342058959212}}
+			Uuid{u4{15236640119020884527,855336876119980132}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Color"}
+		s %Type{"ezColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{751045648905853503,5376862066758454147}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11003997451405858569,11450403177460148761}}
+			Uuid{u4{9440730022944438567,6673183220487140738}}
+			Uuid{u4{1999704295365795047,1389115649292724264}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseTexture"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{15543418230834458689,5548684801941186544}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17000903584766608131,5655927074471313008}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x000000000000D03F}
+	}
+}
+o
+{
+	Uuid %id{u4{5650026407490086663,5768478847879086899}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{4}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{11695727463527673381,6549777581474058039}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{1155205217496153151,16062411953539633064}}
+			Uuid{u4{9182498974977327514,2041274447054354959}}
+			Uuid{u4{14201946371216656691,8983156218640221597}}
+		}
+		s %TypeName{"SHADING_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9440730022944438567,6673183220487140738}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+	}
+}
+o
+{
+	Uuid %id{u4{16081855956766033354,7781865574992326161}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezShaderTypeBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{8550663219316513911,4527800363216923412}}
+			Uuid{u4{751045648905853503,5376862066758454147}}
+			Uuid{u4{5553976233745113740,12028035296425892129}}
+			Uuid{u4{942431713766673469,16743105944200706269}}
+			Uuid{u4{14174762422381468600,11322359312170432733}}
+			Uuid{u4{2154011308533014433,16155609086885943006}}
+		}
+		s %TypeName{"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{7757084663128585029,8011669779036733373}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{3}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{540429536914844576,8213819539779215949}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14201946371216656691,8983156218640221597}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17717897218099796308,9033184167245688007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezShaderTypeBase"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{18305304007866142843,9444700149217459826}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{14174762422381468600,11322359312170432733}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11371768134586030039,1180325336512481617}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"TWO_SIDED"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{11003997451405858569,11450403177460148761}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Texture 2D"}
+	}
+}
+o
+{
+	Uuid %id{u4{5553976233745113740,12028035296425892129}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1624458220477332965,3337055032107232622}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"BLEND_MODE"}
+		s %Type{"BLEND_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{773668148553828920,15966949596821666881}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1155205217496153151,16062411953539633064}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{2154011308533014433,16155609086885943006}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{18305304007866142843,9444700149217459826}}
+			Uuid{u4{17000903584766608131,5655927074471313008}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"MaskThreshold"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{942431713766673469,16743105944200706269}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9941951229153436944,17787021238125754260}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"SHADING_MODE"}
+		s %Type{"SHADING_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{8721322561248882817,17579066505604714242}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialShaderMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9941951229153436944,17787021238125754260}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5030680158680079231,18410952876772242771}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialAssetProperties"}
+		u3 %TypeVersion{4}
+	}
+}
+}

--- a/Data/Base/Materials/Common/PhysicsCollidersTransparent.ezMaterialAsset
+++ b/Data/Base/Materials/Common/PhysicsCollidersTransparent.ezMaterialAsset
@@ -1,0 +1,612 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{9759271266480627886,4755416982122388899}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Material"}
+		VarArray %Dependencies
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+		Uuid %DocumentID{u4{9759271266480627886,4755416982122388899}}
+		u4 %Hash{10443623683861234036}
+		VarArray %MetaInfo{}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+		VarArray %References
+		{
+			s{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{3362876983947844604,4663564975478014361}}
+	s %t{"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader"}
+	u3 %v{2}
+	p
+	{
+		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		s %BaseTexture{"{ f962fc28-661b-485c-a527-c997e239a3f0 }"}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		f %MaskThreshold{0x0000803E}
+		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		b %TWO_SIDED{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16421789314216892588,5030529300376171532}}
+	s %t{"ezMaterialAssetProperties"}
+	u3 %v{4}
+	p
+	{
+		s %BaseMaterial{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		s %MetaBasePrefab{"HeaderV2\n{\no\n{\n\tUuid %id{u4{15150418825657775493,4791833822222609996}}\n\ts %t{\"ezAssetDocumentInfo\"}\n\tu3 %v{2}\n\ts %n{\"Header\"}\n\tp\n\t{\n\t\ts %AssetType{\"Material\"}\n\t\tVarArray %Dependencies\n\t\t{\n\t\t\ts{\":app/VisualShader/Conversions.ddl\"}\n\t\t\ts{\":app/VisualShader/DefaultMaterial.ddl\"}\n\t\t\ts{\":app/VisualShader/Inputs.ddl\"}\n\t\t\ts{\":app/VisualShader/Math_Basic.ddl\"}\n\t\t\ts{\":app/VisualShader/Math_Clamping.ddl\"}\n\t\t\ts{\":app/VisualShader/Parameters.ddl\"}\n\t\t\ts{\":app/VisualShader/Textures.ddl\"}\n\t\t}\n\t\tUuid %DocumentID{u4{15150418825657775493,4791833822222609996}}\n\t\tu4 %Hash{11535315683463123584}\n\t\tVarArray %MetaInfo{}\n\t\tVarArray %Outputs\n\t\t{\n\t\t\ts{\"VISUAL_SHADER\"}\n\t\t}\n\t\tVarArray %PackageDeps\n\t\t{\n\t\t\ts{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\n\t\t}\n\t\tVarArray %References\n\t\t{\n\t\t\ts{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\n\t\t}\n\t}\n}\n}\nObjects\n{\no\n{\n\tUuid %id{u4{2459487586587091876,4633197246295569358}}\n\ts %t{\"ShaderNode::Multiply\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0x37BFC343,0x8863EE42}}\n\t\tf %a{0x0000803F}\n\t\tf %b{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{7349474629313198467,4810738493151362545}}\n\ts %t{\"ShaderNode::Multiply\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0xF733E643,0xE61B8343}}\n\t\tf %a{0x0000803F}\n\t\tf %b{0x0000003F}\n\t}\n}\no\n{\n\tUuid %id{u4{17236283789300039610,4868560560521882739}}\n\ts %t{\"ShaderNode::InstanceData\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0x83684E43,0xD0388742}}\n\t}\n}\no\n{\n\tUuid %id{u4{16800557665973799072,4881531428617865611}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{15117791089842229394,5558965522422809899}}\n\t\ts %Connection::SourcePin{\"result\"}\n\t\tUuid %Connection::Target{u4{17647047357382570685,5387283873938896650}}\n\t\ts %Connection::TargetPin{\"a\"}\n\t}\n}\no\n{\n\tUuid %id{u4{14133219756830928267,4925012257813864265}}\n\ts %t{\"ShaderNode::ParameterColor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tColor %Default{f{0x9218A33E,0x9218A33E,0x9218A33E,0x0000803F}}\n\t\tVec2 %Node::Pos{f{0xCB07C343,0xF888AE41}}\n\t\ts %ParamName{\"Color\"}\n\t}\n}\no\n{\n\tUuid %id{u4{14379145788071149748,4930371780979134301}}\n\ts %t{\"ShaderNode::MaterialOutput\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tb %ApplyFog{1}\n\t\tVec3 %BaseColor{f{0x0000803F,0x0000803F,0x0000803F}}\n\t\tVec3 %Emissive{f{0,0,0}}\n\t\tf %MaskThreshold{0x0000803E}\n\t\tf %Metallic{0}\n\t\tVec2 %Node::Pos{f{0xF9078544,0x7CD92B43}}\n\t\tf %Occlusion{0x0000803F}\n\t\tf %Opacity{0x0000803F}\n\t\tf %Reflectance{0x0000003F}\n\t\tVec4 %RefractionColor{f{0,0,0,0x0000803F}}\n\t\tf %Roughness{0x3333333F}\n\t\tVec3 %SubsurfaceColor{f{0,0,0}}\n\t}\n}\no\n{\n\tUuid %id{u4{10944281192714901918,4966421183176252690}}\n\ts %t{\"ShaderNode::Texture3Way\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Name{\"BaseTexture\"}\n\t\tVec2 %Node::Pos{f{0x7F6FE042,0xE8C41743}}\n\t\ts %Texture{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\n\t\tf %Tiling{0x0000803E}\n\t}\n}\no\n{\n\tUuid %id{u4{15088359648894619524,4996394559286021889}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{10944281192714901918,4966421183176252690}}\n\t\ts %Connection::SourcePin{\"RGBA\"}\n\t\tUuid %Connection::Target{u4{7349474629313198467,4810738493151362545}}\n\t\ts %Connection::TargetPin{\"a\"}\n\t}\n}\no\n{\n\tUuid %id{u4{13222497084817888430,5054079070018530379}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{2459487586587091876,4633197246295569358}}\n\t\ts %Connection::SourcePin{\"result\"}\n\t\tUuid %Connection::Target{u4{13930787030624295041,5649136198918986637}}\n\t\ts %Connection::TargetPin{\"b\"}\n\t}\n}\no\n{\n\tUuid %id{u4{15978132618202027444,5059498813077690081}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{13930787030624295041,5649136198918986637}}\n\t\ts %Connection::SourcePin{\"result\"}\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\n\t\ts %Connection::TargetPin{\"BaseColor\"}\n\t}\n}\no\n{\n\tUuid %id{u4{7536618545610782135,5069894415224396238}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{18164215943830731940,5171638345806463557}}\n\t\ts %Connection::SourcePin{\"w\"}\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\n\t\ts %Connection::TargetPin{\"Opacity\"}\n\t}\n}\no\n{\n\tUuid %id{u4{18164215943830731940,5171638345806463557}}\n\ts %t{\"ShaderNode::Split\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0xA79B6344,0x90DE9943}}\n\t}\n}\no\n{\n\tUuid %id{u4{15545298105995977356,5194159505050198860}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{7349474629313198467,4810738493151362545}}\n\t\ts %Connection::SourcePin{\"result\"}\n\t\tUuid %Connection::Target{u4{15117791089842229394,5558965522422809899}}\n\t\ts %Connection::TargetPin{\"b\"}\n\t}\n}\no\n{\n\tUuid %id{u4{12863162716129488036,5232719034011888947}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{17236283789300039610,4868560560521882739}}\n\t\ts %Connection::SourcePin{\"Color\"}\n\t\tUuid %Connection::Target{u4{2459487586587091876,4633197246295569358}}\n\t\ts %Connection::TargetPin{\"a\"}\n\t}\n}\no\n{\n\tUuid %id{u4{2330531622256203166,5273914467009442304}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{17647047357382570685,5387283873938896650}}\n\t\ts %Connection::SourcePin{\"result\"}\n\t\tUuid %Connection::Target{u4{14379145788071149748,4930371780979134301}}\n\t\ts %Connection::TargetPin{\"Roughness\"}\n\t}\n}\no\n{\n\tUuid %id{u4{10761525945405070802,5318978621122591656}}\n\ts %t{\"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\ts %BLEND_MODE{\"BLEND_MODE::BLEND_MODE_OPAQUE\"}\n\t\ts %BaseTexture{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\n\t\tColor %Color{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}\n\t\tf %MaskThreshold{0x0000803E}\n\t\ts %SHADING_MODE{\"SHADING_MODE::SHADING_MODE_LIT\"}\n\t\tb %TWO_SIDED{0}\n\t}\n}\no\n{\n\tUuid %id{u4{4662199427941981878,5366641751202611600}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{14133219756830928267,4925012257813864265}}\n\t\ts %Connection::SourcePin{\"Value\"}\n\t\tUuid %Connection::Target{u4{13930787030624295041,5649136198918986637}}\n\t\ts %Connection::TargetPin{\"a\"}\n\t}\n}\no\n{\n\tUuid %id{u4{17647047357382570685,5387283873938896650}}\n\ts %t{\"ShaderNode::Saturate\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0x05BD3944,0xBE8E6F43}}\n\t}\n}\no\n{\n\tUuid %id{u4{17299396001716606134,5485458337053796313}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{13930787030624295041,5649136198918986637}}\n\t\ts %Connection::SourcePin{\"result\"}\n\t\tUuid %Connection::Target{u4{18164215943830731940,5171638345806463557}}\n\t\ts %Connection::TargetPin{\"a\"}\n\t}\n}\no\n{\n\tUuid %id{u4{15117791089842229394,5558965522422809899}}\n\ts %t{\"ShaderNode::Subtract\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0x3A441644,0x81056F43}}\n\t\tf %a{0x6666A63F}\n\t\tf %b{0}\n\t}\n}\no\n{\n\tUuid %id{u4{4179884881945017511,5632952876414573985}}\n\ts %t{\"DocumentNodeManager_DefaultConnection\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tUuid %Connection::Source{u4{10944281192714901918,4966421183176252690}}\n\t\ts %Connection::SourcePin{\"RGBA\"}\n\t\tUuid %Connection::Target{u4{2459487586587091876,4633197246295569358}}\n\t\ts %Connection::TargetPin{\"b\"}\n\t}\n}\no\n{\n\tUuid %id{u4{13930787030624295041,5649136198918986637}}\n\ts %t{\"ShaderNode::Multiply\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec2 %Node::Pos{f{0x0D630C44,0x8965C642}}\n\t\tf %a{0x0000803F}\n\t\tf %b{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{5373694201964567170,5685942946020748827}}\n\ts %t{\"ezMaterialAssetProperties\"}\n\tu3 %v{4}\n\tp\n\t{\n\t\ts %BaseMaterial{\"\"}\n\t\ts %Shader{\"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }\"}\n\t\ts %ShaderMode{\"ezMaterialShaderMode::Custom\"}\n\t\tUuid %ShaderProperties{u4{10761525945405070802,5318978621122591656}}\n\t\ts %Surface{\"\"}\n\t}\n}\no\n{\n\tUuid %id{u4{18096612296587978288,6449934965513159559}}\n\ts %t{\"ezDocumentRoot\"}\n\tu3 %v{1}\n\ts %n{\"ObjectTree\"}\n\tp\n\t{\n\t\tVarArray %Children\n\t\t{\n\t\t\tUuid{u4{5373694201964567170,5685942946020748827}}\n\t\t\tUuid{u4{14379145788071149748,4930371780979134301}}\n\t\t\tUuid{u4{10944281192714901918,4966421183176252690}}\n\t\t\tUuid{u4{17236283789300039610,4868560560521882739}}\n\t\t\tUuid{u4{2459487586587091876,4633197246295569358}}\n\t\t\tUuid{u4{13930787030624295041,5649136198918986637}}\n\t\t\tUuid{u4{14133219756830928267,4925012257813864265}}\n\t\t\tUuid{u4{18164215943830731940,5171638345806463557}}\n\t\t\tUuid{u4{7536618545610782135,5069894415224396238}}\n\t\t\tUuid{u4{15978132618202027444,5059498813077690081}}\n\t\t\tUuid{u4{17299396001716606134,5485458337053796313}}\n\t\t\tUuid{u4{12863162716129488036,5232719034011888947}}\n\t\t\tUuid{u4{4179884881945017511,5632952876414573985}}\n\t\t\tUuid{u4{4662199427941981878,5366641751202611600}}\n\t\t\tUuid{u4{13222497084817888430,5054079070018530379}}\n\t\t\tUuid{u4{15117791089842229394,5558965522422809899}}\n\t\t\tUuid{u4{17647047357382570685,5387283873938896650}}\n\t\t\tUuid{u4{16800557665973799072,4881531428617865611}}\n\t\t\tUuid{u4{2330531622256203166,5273914467009442304}}\n\t\t\tUuid{u4{7349474629313198467,4810738493151362545}}\n\t\t\tUuid{u4{15088359648894619524,4996394559286021889}}\n\t\t\tUuid{u4{15545298105995977356,5194159505050198860}}\n\t\t}\n\t}\n}\n}\nTypes\n{\no\n{\n\tUuid %id{u4{8435977591727481336,164499438610169273}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Value{\"Parameter\"}\n\t}\n}\no\n{\n\tUuid %id{u4{1799344192542079709,460455342058959212}}\n\ts %t{\"ezExposeColorAlphaAttribute\"}\n\tu3 %v{1}\n\tp{}\n}\no\n{\n\tUuid %id{u4{15236640119020884527,855336876119980132}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tColor %Value{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}\n\t}\n}\no\n{\n\tUuid %id{u4{11371768134586030039,1180325336512481617}}\n\ts %t{\"ezCategoryAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Category{\"Permutation\"}\n\t}\n}\no\n{\n\tUuid %id{u4{1999704295365795047,1389115649292724264}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Value{\"{ f962fc28-661b-485c-a527-c997e239a3f0 }\"}\n\t}\n}\no\n{\n\tUuid %id{u4{11040065101175624628,1662539785884692449}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{2589033904860476140,2941600109649901427}}\n\t\t\tUuid{u4{16804715233058764794,16291563085247070494}}\n\t\t\tUuid{u4{18411837506060015951,13397631608945770603}}\n\t\t\tUuid{u4{8531456234757106898,9843359760009772741}}\n\t\t\tUuid{u4{10978509386339080603,6055180187630064684}}\n\t\t\tUuid{u4{2493142764329470971,4237250110264931902}}\n\t\t\tUuid{u4{11381554768749103056,5747586724112780390}}\n\t\t\tUuid{u4{15388913065968328453,11188089115316402371}}\n\t\t\tUuid{u4{13652862081152275637,1931931446829192038}}\n\t\t\tUuid{u4{4737060376990519197,5534452074735684677}}\n\t\t\tUuid{u4{17888293823252574217,5278584362329602531}}\n\t\t}\n\t\ts %TypeName{\"ShaderNode::MaterialOutput\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{17341142541700783556,1767195288279124191}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{18311245008988910186,1895067994934075466}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezEnumBase\"}\n\t\ts %PluginName{\"ShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{773668148553828920,15966949596821666881}}\n\t\t\tUuid{u4{540429536914844576,8213819539779215949}}\n\t\t\tUuid{u4{15543418230834458689,5548684801941186544}}\n\t\t\tUuid{u4{16393153594407016602,3744118329769567614}}\n\t\t\tUuid{u4{7757084663128585029,8011669779036733373}}\n\t\t\tUuid{u4{5650026407490086663,5768478847879086899}}\n\t\t}\n\t\ts %TypeName{\"BLEND_MODE\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{2524718926845712419,1904526312384132727}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezVisualShaderNodeBase\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{13652862081152275637,1931931446829192038}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{8648126710299805379,15926322808980556731}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Occlusion\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{9182498974977327514,2041274447054354959}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{0}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"SHADING_MODE::SHADING_MODE_LIT\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{104119927068760414,2224364025861394794}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Value{\"CustomTexture\"}\n\t}\n}\no\n{\n\tUuid %id{u4{7999768391447710917,2784851377566841839}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0}\n\t}\n}\no\n{\n\tUuid %id{u4{2589033904860476140,2941600109649901427}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{107023027798387058,15125524156854853544}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"MaskThreshold\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{1624458220477332965,3337055032107232622}}\n\ts %t{\"ezCategoryAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Category{\"Permutation\"}\n\t}\n}\no\n{\n\tUuid %id{u4{9886528029320226984,3535181809827272072}}\n\ts %t{\"ezCategoryAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Category{\"Constant\"}\n\t}\n}\no\n{\n\tUuid %id{u4{10546328178433928928,3538178021212683011}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tb %Value{1}\n\t}\n}\no\n{\n\tUuid %id{u4{16393153594407016602,3744118329769567614}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{2}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_TRANSPARENT\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{11992629484154905888,3993029317059678037}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{8877328514147020979,11814959309858965089}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"a\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{12006658088070062296,4118947064651693189}}\n\ts %t{\"ezAssetBrowserAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %DependencyFlags{\"\"}\n\t\ts %Filter{\";CompatibleAsset_Texture_2D;\"}\n\t}\n}\no\n{\n\tUuid %id{u4{2493142764329470971,4237250110264931902}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{12975893279928312590,7112828226212987324}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Roughness\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{4085023801481947262,4424431816763648179}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0}\n\t}\n}\no\n{\n\tUuid %id{u4{8550663219316513911,4527800363216923412}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{9886528029320226984,3535181809827272072}}\n\t\t\tUuid{u4{1799344192542079709,460455342058959212}}\n\t\t\tUuid{u4{15236640119020884527,855336876119980132}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Color\"}\n\t\ts %Type{\"ezColor\"}\n\t}\n}\no\n{\n\tUuid %id{u4{7391777909638578846,4627435359128124703}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{4867771077753072654,8477027800294353094}}\n\t\t\tUuid{u4{779633777514843960,17137553788842299501}}\n\t\t\tUuid{u4{10671060504538806139,9031876421588392282}}\n\t\t}\n\t\ts %TypeName{\"ShaderNode::Texture3Way\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{9913376037671254523,4739060951232517466}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{9088240305599432259,14617687262857557833}}\n\t\t\tUuid{u4{4232483372289112742,7210651523459784837}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Default\"}\n\t\ts %Type{\"ezColor\"}\n\t}\n}\no\n{\n\tUuid %id{u4{17888293823252574217,5278584362329602531}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{13542406804441022416,9548951225033578222}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"SubsurfaceColor\"}\n\t\ts %Type{\"ezVec3\"}\n\t}\n}\no\n{\n\tUuid %id{u4{751045648905853503,5376862066758454147}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{11003997451405858569,11450403177460148761}}\n\t\t\tUuid{u4{9440730022944438567,6673183220487140738}}\n\t\t\tUuid{u4{1999704295365795047,1389115649292724264}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"BaseTexture\"}\n\t\ts %Type{\"ezString\"}\n\t}\n}\no\n{\n\tUuid %id{u4{4737060376990519197,5534452074735684677}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{12496807453269888305,16412205064812982056}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"RefractionColor\"}\n\t\ts %Type{\"ezVec4\"}\n\t}\n}\no\n{\n\tUuid %id{u4{15543418230834458689,5548684801941186544}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{1}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_MASKED\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{17000903584766608131,5655927074471313008}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\td %Value{0x000000000000D03F}\n\t}\n}\no\n{\n\tUuid %id{u4{11381554768749103056,5747586724112780390}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{1263665986699366714,7795821215980672176}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Opacity\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{5650026407490086663,5768478847879086899}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{4}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_MODULATE\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{10978509386339080603,6055180187630064684}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{11154057802738083180,8940345913792219569}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Reflectance\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{11695727463527673381,6549777581474058039}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezEnumBase\"}\n\t\ts %PluginName{\"ShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{1155205217496153151,16062411953539633064}}\n\t\t\tUuid{u4{9182498974977327514,2041274447054354959}}\n\t\t\tUuid{u4{14201946371216656691,8983156218640221597}}\n\t\t}\n\t\ts %TypeName{\"SHADING_MODE\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{9440730022944438567,6673183220487140738}}\n\ts %t{\"ezAssetBrowserAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %DependencyFlags{\"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail\"}\n\t\ts %Filter{\";CompatibleAsset_Texture_2D;\"}\n\t}\n}\no\n{\n\tUuid %id{u4{12975893279928312590,7112828226212987324}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000003F}\n\t}\n}\no\n{\n\tUuid %id{u4{4232483372289112742,7210651523459784837}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tColorGamma %Value{u1{255,255,255,255}}\n\t}\n}\no\n{\n\tUuid %id{u4{15857399435423166171,7430766950459069189}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{10954214981482726729,17111196752340869338}}\n\t\t\tUuid{u4{12609603033176210513,7964630687986868603}}\n\t\t}\n\t\ts %TypeName{\"ShaderNode::Subtract\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{16081855956766033354,7781865574992326161}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezShaderTypeBase\"}\n\t\ts %PluginName{\"ShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{8550663219316513911,4527800363216923412}}\n\t\t\tUuid{u4{751045648905853503,5376862066758454147}}\n\t\t\tUuid{u4{5553976233745113740,12028035296425892129}}\n\t\t\tUuid{u4{942431713766673469,16743105944200706269}}\n\t\t\tUuid{u4{14174762422381468600,11322359312170432733}}\n\t\t\tUuid{u4{2154011308533014433,16155609086885943006}}\n\t\t}\n\t\ts %TypeName{\"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader\"}\n\t\tu3 %TypeVersion{2}\n\t}\n}\no\n{\n\tUuid %id{u4{1263665986699366714,7795821215980672176}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{12609603033176210513,7964630687986868603}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{9774780989707894273,9848653915852827572}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"b\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{7757084663128585029,8011669779036733373}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{3}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_ADDITIVE\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{540429536914844576,8213819539779215949}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{0}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"BLEND_MODE::BLEND_MODE_OPAQUE\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{4867771077753072654,8477027800294353094}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{104119927068760414,2224364025861394794}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Name\"}\n\t\ts %Type{\"ezString\"}\n\t}\n}\no\n{\n\tUuid %id{u4{6089094783765586323,8705960867921430659}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\n\t\ts %PluginName{\"Static\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezDocumentRoot\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{11154057802738083180,8940345913792219569}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000003F}\n\t}\n}\no\n{\n\tUuid %id{u4{14201946371216656691,8983156218640221597}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\ti3 %ConstantValue{1}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"SHADING_MODE::SHADING_MODE_FULLBRIGHT\"}\n\t\ts %Type{\"ezInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{10671060504538806139,9031876421588392282}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{17341142541700783556,1767195288279124191}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Tiling\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{17717897218099796308,9033184167245688007}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\n\t\ts %PluginName{\"ShaderTypes\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezShaderTypeBase\"}\n\t\tu3 %TypeVersion{2}\n\t}\n}\no\n{\n\tUuid %id{u4{18305304007866142843,9444700149217459826}}\n\ts %t{\"ezCategoryAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Category{\"Constant\"}\n\t}\n}\no\n{\n\tUuid %id{u4{13542406804441022416,9548951225033578222}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec3 %Value{f{0,0,0}}\n\t}\n}\no\n{\n\tUuid %id{u4{8531456234757106898,9843359760009772741}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{4085023801481947262,4424431816763648179}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Metallic\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{9774780989707894273,9848653915852827572}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0}\n\t}\n}\no\n{\n\tUuid %id{u4{1988646526571382668,10729334715299371304}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\n\t\ts %PluginName{\"Static\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"DocumentNodeManager_DefaultConnection\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{15388913065968328453,11188089115316402371}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{6649753934969554305,13791166057793731169}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Emissive\"}\n\t\ts %Type{\"ezVec3\"}\n\t}\n}\no\n{\n\tUuid %id{u4{14174762422381468600,11322359312170432733}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{11371768134586030039,1180325336512481617}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"TWO_SIDED\"}\n\t\ts %Type{\"bool\"}\n\t}\n}\no\n{\n\tUuid %id{u4{11003997451405858569,11450403177460148761}}\n\ts %t{\"ezCategoryAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Category{\"Texture 2D\"}\n\t}\n}\no\n{\n\tUuid %id{u4{8877328514147020979,11814959309858965089}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{10097442269101671049,12017415575322047640}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{12689300849278625136,16388205898017076391}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"b\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{5553976233745113740,12028035296425892129}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{1624458220477332965,3337055032107232622}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"BLEND_MODE\"}\n\t\ts %Type{\"BLEND_MODE\"}\n\t}\n}\no\n{\n\tUuid %id{u4{4440304378651420221,12575431605907932885}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{11992629484154905888,3993029317059678037}}\n\t\t\tUuid{u4{10097442269101671049,12017415575322047640}}\n\t\t}\n\t\ts %TypeName{\"ShaderNode::Multiply\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{18411837506060015951,13397631608945770603}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{2531204913114908651,14636118749865147444}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"BaseColor\"}\n\t\ts %Type{\"ezVec3\"}\n\t}\n}\no\n{\n\tUuid %id{u4{6649753934969554305,13791166057793731169}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec3 %Value{f{0,0,0}}\n\t}\n}\no\n{\n\tUuid %id{u4{10765536432168002227,14077301894287280531}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ShaderNode::InstanceData\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{16422282166416556709,14502256122642309324}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{8435977591727481336,164499438610169273}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"ParamName\"}\n\t\ts %Type{\"ezString\"}\n\t}\n}\no\n{\n\tUuid %id{u4{9088240305599432259,14617687262857557833}}\n\ts %t{\"ezExposeColorAlphaAttribute\"}\n\tu3 %v{1}\n\tp{}\n}\no\n{\n\tUuid %id{u4{2531204913114908651,14636118749865147444}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec3 %Value{f{0x0000803F,0x0000803F,0x0000803F}}\n\t}\n}\no\n{\n\tUuid %id{u4{2947336711354777548,15013008608905564043}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"\"}\n\t\ts %PluginName{\"Static\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezEnumBase\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{107023027798387058,15125524156854853544}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000803E}\n\t}\n}\no\n{\n\tUuid %id{u4{574185834121239378,15422088015066052787}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ShaderNode::Split\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{8648126710299805379,15926322808980556731}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{773668148553828920,15966949596821666881}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\tu3 %ConstantValue{0}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"BLEND_MODE::Default\"}\n\t\ts %Type{\"ezUInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{1155205217496153151,16062411953539633064}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Category{\"ezPropertyCategory::Constant\"}\n\t\tu3 %ConstantValue{0}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly\"}\n\t\ts %Name{\"SHADING_MODE::Default\"}\n\t\ts %Type{\"ezUInt32\"}\n\t}\n}\no\n{\n\tUuid %id{u4{2154011308533014433,16155609086885943006}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{18305304007866142843,9444700149217459826}}\n\t\t\tUuid{u4{17000903584766608131,5655927074471313008}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"MaskThreshold\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{18349806816312788076,16229247027635378395}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ShaderNode::Saturate\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{16804715233058764794,16291563085247070494}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{10546328178433928928,3538178021212683011}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"ApplyFog\"}\n\t\ts %Type{\"bool\"}\n\t}\n}\no\n{\n\tUuid %id{u4{12689300849278625136,16388205898017076391}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tf %Value{0x0000803F}\n\t}\n}\no\n{\n\tUuid %id{u4{12496807453269888305,16412205064812982056}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVec4 %Value{f{0,0,0,0x0000803F}}\n\t}\n}\no\n{\n\tUuid %id{u4{9055380125307899845,16548159432520566774}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Phantom\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezVisualShaderNodeBase\"}\n\t\ts %PluginName{\"VisualShaderTypes\"}\n\t\tVarArray %Properties\n\t\t{\n\t\t\tUuid{u4{16422282166416556709,14502256122642309324}}\n\t\t\tUuid{u4{9913376037671254523,4739060951232517466}}\n\t\t}\n\t\ts %TypeName{\"ShaderNode::ParameterColor\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{942431713766673469,16743105944200706269}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{9941951229153436944,17787021238125754260}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"SHADING_MODE\"}\n\t\ts %Type{\"SHADING_MODE\"}\n\t}\n}\no\n{\n\tUuid %id{u4{7213929454977328898,16983898963733524216}}\n\ts %t{\"ezDefaultValueAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Value{\"\"}\n\t}\n}\no\n{\n\tUuid %id{u4{10954214981482726729,17111196752340869338}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{7999768391447710917,2784851377566841839}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"a\"}\n\t\ts %Type{\"float\"}\n\t}\n}\no\n{\n\tUuid %id{u4{779633777514843960,17137553788842299501}}\n\ts %t{\"ezReflectedPropertyDescriptor\"}\n\tu3 %v{2}\n\tp\n\t{\n\t\tVarArray %Attributes\n\t\t{\n\t\t\tUuid{u4{12006658088070062296,4118947064651693189}}\n\t\t\tUuid{u4{7213929454977328898,16983898963733524216}}\n\t\t}\n\t\ts %Category{\"ezPropertyCategory::Member\"}\n\t\tInvalid %ConstantValue{}\n\t\ts %Flags{\"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom\"}\n\t\ts %Name{\"Texture\"}\n\t\ts %Type{\"ezString\"}\n\t}\n}\no\n{\n\tUuid %id{u4{8721322561248882817,17579066505604714242}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::IsEnum|ezTypeFlags::Minimal\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezEnumBase\"}\n\t\ts %PluginName{\"ezEditorPluginAssets\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezMaterialShaderMode\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{9941951229153436944,17787021238125754260}}\n\ts %t{\"ezCategoryAttribute\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\ts %Category{\"Permutation\"}\n\t}\n}\no\n{\n\tUuid %id{u4{983387834180907111,17935407260904399048}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"\"}\n\t\ts %PluginName{\"Static\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezReflectedClass\"}\n\t\tu3 %TypeVersion{1}\n\t}\n}\no\n{\n\tUuid %id{u4{5030680158680079231,18410952876772242771}}\n\ts %t{\"ezReflectedTypeDescriptor\"}\n\tu3 %v{1}\n\tp\n\t{\n\t\tVarArray %Attributes{}\n\t\ts %Flags{\"ezTypeFlags::Class|ezTypeFlags::Minimal\"}\n\t\tVarArray %Functions{}\n\t\ts %ParentTypeName{\"ezReflectedClass\"}\n\t\ts %PluginName{\"ezEditorPluginAssets\"}\n\t\tVarArray %Properties{}\n\t\ts %TypeName{\"ezMaterialAssetProperties\"}\n\t\tu3 %TypeVersion{4}\n\t}\n}\n}\n"}
+		Uuid %MetaFromPrefab{u4{15150418825657775493,4791833822222609996}}
+		Uuid %MetaPrefabSeed{u4{11048095112252325418,17791330428064974321}}
+		s %Shader{"{ 1c47ee4c-0379-4280-85f5-b8cda61941d2 }"}
+		s %ShaderMode{"ezMaterialShaderMode::BaseMaterial"}
+		Uuid %ShaderProperties{u4{3362876983947844604,4663564975478014361}}
+		s %Surface{""}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{16421789314216892588,5030529300376171532}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{1799344192542079709,460455342058959212}}
+	s %t{"ezExposeColorAlphaAttribute"}
+	u3 %v{1}
+	p{}
+}
+o
+{
+	Uuid %id{u4{15236640119020884527,855336876119980132}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Color %Value{f{0x9818A33E,0x9818A33E,0x9818A33E,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{11371768134586030039,1180325336512481617}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{1999704295365795047,1389115649292724264}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Value{"{ f962fc28-661b-485c-a527-c997e239a3f0 }"}
+	}
+}
+o
+{
+	Uuid %id{u4{18311245008988910186,1895067994934075466}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{773668148553828920,15966949596821666881}}
+			Uuid{u4{540429536914844576,8213819539779215949}}
+			Uuid{u4{15543418230834458689,5548684801941186544}}
+			Uuid{u4{16393153594407016602,3744118329769567614}}
+			Uuid{u4{7757084663128585029,8011669779036733373}}
+			Uuid{u4{5650026407490086663,5768478847879086899}}
+		}
+		s %TypeName{"BLEND_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9182498974977327514,2041274447054354959}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1624458220477332965,3337055032107232622}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{9886528029320226984,3535181809827272072}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{16393153594407016602,3744118329769567614}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{2}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{8550663219316513911,4527800363216923412}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9886528029320226984,3535181809827272072}}
+			Uuid{u4{1799344192542079709,460455342058959212}}
+			Uuid{u4{15236640119020884527,855336876119980132}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Color"}
+		s %Type{"ezColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{751045648905853503,5376862066758454147}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11003997451405858569,11450403177460148761}}
+			Uuid{u4{9440730022944438567,6673183220487140738}}
+			Uuid{u4{1999704295365795047,1389115649292724264}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseTexture"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{15543418230834458689,5548684801941186544}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17000903584766608131,5655927074471313008}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x000000000000D03F}
+	}
+}
+o
+{
+	Uuid %id{u4{5650026407490086663,5768478847879086899}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{4}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{11695727463527673381,6549777581474058039}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{1155205217496153151,16062411953539633064}}
+			Uuid{u4{9182498974977327514,2041274447054354959}}
+			Uuid{u4{14201946371216656691,8983156218640221597}}
+		}
+		s %TypeName{"SHADING_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9440730022944438567,6673183220487140738}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+	}
+}
+o
+{
+	Uuid %id{u4{16081855956766033354,7781865574992326161}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezShaderTypeBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{8550663219316513911,4527800363216923412}}
+			Uuid{u4{751045648905853503,5376862066758454147}}
+			Uuid{u4{5553976233745113740,12028035296425892129}}
+			Uuid{u4{942431713766673469,16743105944200706269}}
+			Uuid{u4{14174762422381468600,11322359312170432733}}
+			Uuid{u4{2154011308533014433,16155609086885943006}}
+		}
+		s %TypeName{"AssetCache/Common/Materials/Common/Pattern.autogen.ezShader"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{7757084663128585029,8011669779036733373}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{3}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{540429536914844576,8213819539779215949}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14201946371216656691,8983156218640221597}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17717897218099796308,9033184167245688007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezShaderTypeBase"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{18305304007866142843,9444700149217459826}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{14174762422381468600,11322359312170432733}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11371768134586030039,1180325336512481617}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"TWO_SIDED"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{11003997451405858569,11450403177460148761}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Texture 2D"}
+	}
+}
+o
+{
+	Uuid %id{u4{5553976233745113740,12028035296425892129}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1624458220477332965,3337055032107232622}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"BLEND_MODE"}
+		s %Type{"BLEND_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{773668148553828920,15966949596821666881}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{1155205217496153151,16062411953539633064}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{2154011308533014433,16155609086885943006}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{18305304007866142843,9444700149217459826}}
+			Uuid{u4{17000903584766608131,5655927074471313008}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"MaskThreshold"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{942431713766673469,16743105944200706269}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9941951229153436944,17787021238125754260}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"SHADING_MODE"}
+		s %Type{"SHADING_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{8721322561248882817,17579066505604714242}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialShaderMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9941951229153436944,17787021238125754260}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5030680158680079231,18410952876772242771}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialAssetProperties"}
+		u3 %TypeVersion{4}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Prefabs/Player.ezPrefab
+++ b/Data/Samples/Testing Chambers/Prefabs/Player.ezPrefab
@@ -2,28 +2,15 @@ HeaderV2
 {
 o
 {
-	Uuid %id{u4{9568100928140647423,287431255237350083}}
-	s %t{"ezExposedParametersAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %ParametersSource{"Script"}
-	}
-}
-o
-{
 	Uuid %id{u4{5217645760467530089,740916499361678004}}
 	s %t{"ezExposedParameter"}
 	u3 %v{2}
 	p
 	{
-		VarArray %Attributes
-		{
-			Uuid{u4{9568100928140647423,287431255237350083}}
-		}
+		VarArray %Attributes{}
 		b %DefaultValue{0}
 		s %Name{"Invincible"}
-		s %Type{"ezVariant"}
+		s %Type{""}
 	}
 }
 o
@@ -33,13 +20,10 @@ o
 	u3 %v{2}
 	p
 	{
-		VarArray %Attributes
-		{
-			Uuid{u4{7003111624050277653,7519339875013479755}}
-		}
+		VarArray %Attributes{}
 		b %DefaultValue{0}
 		s %Name{"GiveAllWeapons"}
-		s %Type{"ezVariant"}
+		s %Type{""}
 	}
 }
 o
@@ -67,7 +51,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{8325318639183543703,4757176779305952111}}
-		u4 %Hash{13060980397134686859}
+		u4 %Hash{4308427267570972701}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{14146522745554303380,2902865256510917925}}
@@ -99,16 +83,6 @@ o
 			s{"{ d3446478-77cf-49bb-a6db-c8f65307deac }"}
 			s{"{ e2374f5b-ff29-4d06-8264-12b55f5d0176 }"}
 		}
-	}
-}
-o
-{
-	Uuid %id{u4{7003111624050277653,7519339875013479755}}
-	s %t{"ezExposedParametersAttribute"}
-	u3 %v{1}
-	p
-	{
-		s %ParametersSource{"Script"}
 	}
 }
 }
@@ -252,7 +226,7 @@ o
 	p
 	{
 		b %Active{1}
-		f %Radius{0xCDCCCC3D}
+		f %Radius{0x0AD7233C}
 	}
 }
 o
@@ -264,7 +238,7 @@ o
 	{
 		s %Flags{""}
 		i3 %InitialValue{0}
-		s %Name{"StrafeRight"}
+		HashedString %Name{s{"StrafeRight"}}
 	}
 }
 o
@@ -276,7 +250,7 @@ o
 	{
 		s %Flags{""}
 		i3 %InitialValue{0}
-		s %Name{"MoveBackwards"}
+		HashedString %Name{s{"MoveBackwards"}}
 	}
 }
 o
@@ -345,7 +319,7 @@ o
 	{
 		s %Flags{""}
 		i3 %InitialValue{1}
-		s %Name{"TouchingGround"}
+		HashedString %Name{s{"TouchingGround"}}
 	}
 }
 o
@@ -441,12 +415,13 @@ o
 {
 	Uuid %id{u4{8451598364577091999,5079810986549089868}}
 	s %t{"ezJoltGrabObjectComponent"}
-	u3 %v{1}
+	u3 %v{2}
 	p
 	{
 		b %Active{1}
 		s %AttachTo{"{ 01739dee-d14d-4cad-8ea6-8c03b449ffb3 }"}
 		f %BreakDistance{0x0000003F}
+		f %CastRadius{0}
 		u1 %CollisionLayer{0}
 		f %GrabAnyObjectWithSize{0x9A99993F}
 		f %MaxGrabPointDistance{0x00000040}
@@ -463,14 +438,14 @@ o
 	{
 		s %Flags{""}
 		i3 %InitialValue{0}
-		s %Name{"MoveForwards"}
+		HashedString %Name{s{"MoveForwards"}}
 	}
 }
 o
 {
 	Uuid %id{u4{14277641826211699617,5139911631931333399}}
-	s %t{"ezBlackboardComponent"}
-	u3 %v{2}
+	s %t{"ezLocalBlackboardComponent"}
+	u3 %v{1}
 	p
 	{
 		b %Active{1}
@@ -628,7 +603,7 @@ o
 	{
 		s %Flags{""}
 		i3 %InitialValue{0}
-		s %Name{"StrafeLeft"}
+		HashedString %Name{s{"StrafeLeft"}}
 	}
 }
 o
@@ -1091,6 +1066,23 @@ o
 }
 o
 {
+	Uuid %id{u4{18145823255500990886,658922949661762930}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{2762044006149116039,728775510129289791}}
 	s %t{"ezReflectedFunctionDescriptor"}
 	u3 %v{1}
@@ -1228,13 +1220,23 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{4211116292337394061,17925148218155573204}}
-			Uuid{u4{13182069855174295290,11732990450909772673}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"SpringStiffness"}
-		s %Type{"float"}
+		s %Name{"CollisionLayer"}
+		s %Type{"ezUInt8"}
+	}
+}
+o
+{
+	Uuid %id{u4{6584035477180661172,1214718775720500599}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Max{0x0000803F}
+		f %Min{0}
 	}
 }
 o
@@ -1269,9 +1271,9 @@ o
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Const|ezPropertyFlags::Phantom"}
-		s %Name{"AttachTo"}
-		s %Type{"ezConstCharPtr"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BreakDistance"}
+		s %Type{"float"}
 	}
 }
 o
@@ -1387,6 +1389,24 @@ o
 }
 o
 {
+	Uuid %id{u4{12003129937596094701,2128339964358125637}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{13734890228491784574,17294195772344026311}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"GrabAnyObjectWithSize"}
+		s %Type{"float"}
+	}
+}
+o
+{
 	Uuid %id{u4{18421542007173564945,2148381105670099816}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -1399,6 +1419,23 @@ o
 		s %PluginName{"ezEditorPluginRecast"}
 		VarArray %Properties{}
 		s %TypeName{"ezRcComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5827458717401089751,2275458197221607663}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDirectionVisualizerAttribute"}
 		u3 %TypeVersion{1}
 	}
 }
@@ -1685,6 +1722,23 @@ o
 }
 o
 {
+	Uuid %id{u4{17523044089822028024,3521005166208929094}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCategoryAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{6600083760482472499,3817224600172883890}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
@@ -1853,6 +1907,23 @@ o
 }
 o
 {
+	Uuid %id{u4{18348731351651790920,4897320743890407264}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBlackboardComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezLocalBlackboardComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{3560912613629860972,4902005526670913916}}
 	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
@@ -1961,9 +2032,10 @@ o
 			Uuid{u4{5488973819604933035,16755644218258307752}}
 			Uuid{u4{9431793516815083130,1271950617203112475}}
 			Uuid{u4{7001844416364588482,9869790392570224971}}
+			Uuid{u4{12003129937596094701,2128339964358125637}}
 		}
 		s %TypeName{"ezJoltGrabObjectComponent"}
-		u3 %TypeVersion{1}
+		u3 %TypeVersion{2}
 	}
 }
 o
@@ -1983,6 +2055,23 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Mass"}
 		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{8292420897755202943,5557531592713334243}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCapsuleVisualizerAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -2155,13 +2244,13 @@ o
 	p
 	{
 		VarArray %Attributes{}
-		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
 		VarArray %Functions{}
 		s %ParentTypeName{"ezComponent"}
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezBlackboardComponent"}
-		u3 %TypeVersion{2}
+		u3 %TypeVersion{3}
 	}
 }
 o
@@ -2219,6 +2308,23 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezAnimationInvisibleUpdateRate"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18327411855245510474,6668321287849544166}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Bitflags|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezBitflagsBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAnchor"}
 		u3 %TypeVersion{1}
 	}
 }
@@ -2527,12 +2633,9 @@ o
 o
 {
 	Uuid %id{u4{16723682621723718117,7654205951203165018}}
-	s %t{"ezDefaultValueAttribute"}
+	s %t{"ezGameObjectReferenceAttribute"}
 	u3 %v{1}
-	p
-	{
-		f %Value{0x0000403F}
-	}
+	p{}
 }
 o
 {
@@ -2549,7 +2652,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"SpringDamping"}
+		s %Name{"SpringStiffness"}
 		s %Type{"float"}
 	}
 }
@@ -2679,7 +2782,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x0000003F}
+		f %Value{0x0000803F}
 	}
 }
 o
@@ -2834,9 +2937,26 @@ o
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
-		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"GrabAnyObjectWithSize"}
-		s %Type{"float"}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Const|ezPropertyFlags::Phantom"}
+		s %Name{"AttachTo"}
+		s %Type{"ezConstCharPtr"}
+	}
+}
+o
+{
+	Uuid %id{u4{8228401658076077542,9903301473102603301}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezCameraVisualizerAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -2848,6 +2968,23 @@ o
 	{
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Const|ezPropertyFlags::Reference"}
 		s %Type{"ezVec3"}
+	}
+}
+o
+{
+	Uuid %id{u4{455663516835322266,10016785433957589977}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezTransformManipulatorAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -3043,6 +3180,23 @@ o
 }
 o
 {
+	Uuid %id{u4{5175953824557395014,10566581888453829842}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezConeAngleManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{13482947612910322887,10594957510423468085}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -3165,8 +3319,8 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Max{0x0000803F}
-		f %Min{0}
+		f %Max{0x00007042}
+		f %Min{0x0000803F}
 	}
 }
 o
@@ -3236,17 +3390,6 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"LinearDamping"}
 		s %Type{"float"}
-	}
-}
-o
-{
-	Uuid %id{u4{13182069855174295290,11732990450909772673}}
-	s %t{"ezClampValueAttribute"}
-	u3 %v{1}
-	p
-	{
-		f %Max{0x00007042}
-		f %Min{0x0000803F}
 	}
 }
 o
@@ -3326,11 +3469,12 @@ o
 o
 {
 	Uuid %id{u4{17271985988736078655,12053585232599998935}}
-	s %t{"ezDynamicEnumAttribute"}
+	s %t{"ezClampValueAttribute"}
 	u3 %v{1}
 	p
 	{
-		s %DynamicEnum{"PhysicsCollisionLayer"}
+		Invalid %Max{}
+		f %Min{0}
 	}
 }
 o
@@ -3502,6 +3646,23 @@ o
 }
 o
 {
+	Uuid %id{u4{9604010176759229512,12868035041842190965}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezPropertyAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{13551199574428377141,13101549388433474090}}
 	s %t{"ezReflectedFunctionDescriptor"}
 	u3 %v{1}
@@ -3632,7 +3793,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x0000803F}
+		f %Value{0x00000040}
 	}
 }
 o
@@ -3672,6 +3833,23 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezSpotLightComponent"}
 		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{3831974449523230585,14215314673498690831}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSpotLightVisualizerAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -3717,8 +3895,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"CollisionLayer"}
-		s %Type{"ezUInt8"}
+		s %Name{"CastRadius"}
+		s %Type{"float"}
 	}
 }
 o
@@ -3728,7 +3906,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Category{"Transform"}
+		s %Category{"Animation"}
 	}
 }
 o
@@ -4078,9 +4256,12 @@ o
 o
 {
 	Uuid %id{u4{14250515774572160038,16176534215771483735}}
-	s %t{"ezGameObjectReferenceAttribute"}
+	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
-	p{}
+	p
+	{
+		f %Value{0x0000003F}
+	}
 }
 o
 {
@@ -4120,6 +4301,40 @@ o
 	p
 	{
 		s %Category{"Physics/Jolt/Shapes"}
+	}
+}
+o
+{
+	Uuid %id{u4{18075037991921780250,16373560435556338007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{15796815132701145913,16426079668733115146}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereManipulatorAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -4177,11 +4392,12 @@ o
 		VarArray %Attributes
 		{
 			Uuid{u4{12724717917401909066,8775204452523577687}}
+			Uuid{u4{6584035477180661172,1214718775720500599}}
 		}
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"BreakDistance"}
+		s %Name{"SpringDamping"}
 		s %Type{"float"}
 	}
 }
@@ -4201,6 +4417,40 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"FootRadius"}
 		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{14469700887475489738,16951777026318265606}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBasisAxis"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14207082430471941233,17000358661146427261}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereVisualizerAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -4240,6 +4490,16 @@ o
 	{
 		s %Flags{""}
 		s %Type{""}
+	}
+}
+o
+{
+	Uuid %id{u4{13734890228491784574,17294195772344026311}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000403F}
 	}
 }
 o
@@ -4365,11 +4625,11 @@ o
 o
 {
 	Uuid %id{u4{4211116292337394061,17925148218155573204}}
-	s %t{"ezDefaultValueAttribute"}
+	s %t{"ezDynamicEnumAttribute"}
 	u3 %v{1}
 	p
 	{
-		f %Value{0x00000040}
+		s %DynamicEnum{"PhysicsCollisionLayer"}
 	}
 }
 o
@@ -4419,6 +4679,40 @@ o
 	{
 		s %Flags{""}
 		s %Type{""}
+	}
+}
+o
+{
+	Uuid %id{u4{2911337197746516424,18087631299254518308}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezConeLengthManipulatorAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{684881809177204240,18178687792501610043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezPropertyAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezInDevelopmentAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Vegetation/Quaternius/Tree4.ezMeshAsset_data/Tree4.ezJoltCollisionMeshAsset
+++ b/Data/Samples/Testing Chambers/Vegetation/Quaternius/Tree4.ezMeshAsset_data/Tree4.ezJoltCollisionMeshAsset
@@ -14,7 +14,7 @@ o
 			s{"Vegetation/Quaternius/Tree4.fbx"}
 		}
 		Uuid %DocumentID{u4{2195652096918748553,5559804039650000066}}
-		u4 %Hash{17509887694611259252}
+		u4 %Hash{4526978601102995116}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -59,7 +59,7 @@ o
 		s %MeshFile{"Vegetation/Quaternius/Tree4.fbx"}
 		f %Radius{0x0000003F}
 		f %Radius2{0x0000003F}
-		s %RightDir{"ezBasisAxis::PositiveX"}
+		s %RightDir{"ezBasisAxis::PositiveZ"}
 		s %Surface{""}
 		VarArray %Surfaces
 		{

--- a/Data/Tools/ezEditor/VisualShader/Textures.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Textures.ddl
@@ -342,7 +342,14 @@ SamplerState $prop0_AutoSampler;
     string %Type { "float" }
     string %DefaultValue { "1" }
   }
-  
+
+  InputPin %WorldPosition
+  {
+    string %Type { "float3" }
+    string %Color { "Indigo" }
+    string %DefaultValue { "G.Input.WorldPosition" }
+  }
+
   InputPin %WorldNormal
   {
     string %Type { "float3" }
@@ -355,7 +362,7 @@ SamplerState $prop0_AutoSampler;
   {
     string %Type { "float4" }
     unsigned_int8 %Color { 200, 200, 200 }
-    string %Inline { "SampleTexture3Way($prop0, $prop0_AutoSampler, $in0, G.Input.WorldPosition, $prop2)" }
+    string %Inline { "SampleTexture3Way($prop0, $prop0_AutoSampler, $in1, $in0, $prop2)" }
   }
 }
 


### PR DESCRIPTION
 Adds these CVars:
1. Jolt.Visualize.Geometry
2. Jolt.Visualize.Exclusive
3. Jolt.Visualize.Distance

Variable 1. enables visualization of physics collider geometry:

![image](https://github.com/ezEngine/ezEngine/assets/6001174/408e71f8-6e5b-4445-a15a-e37da6d435a0)

This is just rendered together with the regular geometry, which helps to figure out whether the physics geometry fits the render geometry. For example here the tree collision mesh is not imported the same way as the graphics mesh:

![image](https://github.com/ezEngine/ezEngine/assets/6001174/371c5f8a-6815-47e0-a31f-3a591dd69eca)

This gives a lot of z-fighting, if the meshes are identical and can be distracting. So variable 2 allows to disable rendering of regular geometry:

![image](https://github.com/ezEngine/ezEngine/assets/6001174/8fc32a6e-ba22-4f4b-b72c-ad0dab40640c)

Different types use different colors. In the image above:
* light blue = static geometry
* dark blue = kinematic
* yellow = dynamic bodies
* green = query shapes (hitboxes)
* pink = ragdolls + ropes
* red = soft bodies
* transparent = triggers

Geometry is only updated in a certain radius around the camera (to reduce the performance impact). Variable 3 configures this distance. Overall the rendering is very efficient, though, since it simply uses the CustomMeshComponent to add meshes to the scene and thus the typical rendering and culling is done on them, this is not using the ezDebugRenderer.