### PR TITLE
Make it possible to manually specify a precompiled tools

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
@@ -43,8 +43,7 @@ ezString ezQtEditorApp::FindToolApplication(const char* szToolName)
     sTool = folder;
     sTool.AppendPath(szToolName);
 
-    ezFileStats toolStats;
-    if (ezFileSystem::GetFileStats(sTool, toolStats).Succeeded() && !toolStats.m_bIsDirectory)
+    if (ezOSFile::ExistsFile(sTool))
       return sTool;
   }
 

--- a/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
@@ -18,24 +18,35 @@ ezString ezQtEditorApp::FindToolApplication(const char* szToolName)
 
   ezEditorPreferencesUser* pPref = ezPreferences::QueryPreferences<ezEditorPreferencesUser>();
 
-  bool bFolders[2] = {false, true};
+  ezHybridArray<ezString, 3> sFolders;
+  sFolders.PushBack(ezApplicationServices::GetSingleton()->GetPrecompiledToolsFolder(false));
+  sFolders.PushBack(ezApplicationServices::GetSingleton()->GetPrecompiledToolsFolder(true));
 
   if (pPref->m_bUsePrecompiledTools)
   {
-    ezMath::Swap(bFolders[0], bFolders[1]);
+    if(!pPref->m_sCustomPrecompiledToolsFolder.IsEmpty() && ezOSFile::ExistsDirectory(pPref->m_sCustomPrecompiledToolsFolder))
+    {
+      ezStringBuilder customToolsFolder = pPref->m_sCustomPrecompiledToolsFolder;
+      customToolsFolder.MakeCleanPath();
+      sFolders.PushBack(customToolsFolder);
+      ezMath::Swap(sFolders[0], sFolders[2]);
+    }
+    else
+    {
+      ezMath::Swap(sFolders[0], sFolders[1]);
+    }
   }
 
-  ezStringBuilder sTool = ezApplicationServices::GetSingleton()->GetPrecompiledToolsFolder(bFolders[0]);
-  sTool.AppendPath(szToolName);
+  ezStringBuilder sTool;
+  for(auto& folder : sFolders)
+  {
+    sTool = folder;
+    sTool.AppendPath(szToolName);
 
-  if (ezFileSystem::ExistsFile(sTool))
-    return sTool;
-
-  sTool = ezApplicationServices::GetSingleton()->GetPrecompiledToolsFolder(bFolders[1]);
-  sTool.AppendPath(szToolName);
-
-  if (ezFileSystem::ExistsFile(sTool))
-    return sTool;
+    ezFileStats toolStats;
+    if (ezFileSystem::GetFileStats(sTool, toolStats).Succeeded() && !toolStats.m_bIsDirectory)
+      return sTool;
+  }
 
   // just try the one in the same folder as the editor
   return szToolName;

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
@@ -24,6 +24,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorPreferencesUser, 1, ezRTTIDefaultAllocat
     EZ_MEMBER_PROPERTY("ScaleSnap", m_fScaleSnapValue)->AddAttributes(new ezDefaultValueAttribute(0.125f), new ezHiddenAttribute()),
     EZ_MEMBER_PROPERTY("TranslationSnap", m_fTranslationSnapValue)->AddAttributes(new ezDefaultValueAttribute(0.25f), new ezHiddenAttribute()),
     EZ_MEMBER_PROPERTY("UsePrecompiledTools", m_bUsePrecompiledTools)->AddAttributes(new ezDefaultValueAttribute(true)),
+    EZ_MEMBER_PROPERTY("CustomPrecompiledToolsFolder", m_sCustomPrecompiledToolsFolder),
     EZ_MEMBER_PROPERTY("ExpandSceneTreeOnSelection", m_bExpandSceneTreeOnSelection)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("ClearEditorLogsOnPlay", m_bClearEditorLogsOnPlay)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_ACCESSOR_PROPERTY("HighlightUntranslatedUI", GetHighlightUntranslatedUI, SetHighlightUntranslatedUI),

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
@@ -22,6 +22,7 @@ public:
   float m_fScaleSnapValue = 0.125f;
   float m_fTranslationSnapValue = 0.25f;
   bool m_bUsePrecompiledTools = true;
+  ezString m_sCustomPrecompiledToolsFolder;
   bool m_bLoadLastProjectAtStartup = true;
   bool m_bShowSplashscreen = true;
   bool m_bExpandSceneTreeOnSelection = true;

--- a/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.h
@@ -259,21 +259,16 @@ void ezOSFile::InternalSetFilePosition(ezInt64 iDistance, ezFileSeekMode::Enum P
 #endif
 }
 
-bool ezOSFile::InternalExistsFile(ezStringView sFile)
-{
-  FILE* pFile = fopen(ezString(sFile), "r");
-
-  if (pFile == nullptr)
-    return false;
-
-  fclose(pFile);
-  return true;
-}
-
 // this might not be defined on Windows
 #ifndef S_ISDIR
 #  define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
 #endif
+
+bool ezOSFile::InternalExistsFile(ezStringView sFile)
+{
+  struct stat sb;
+  return (stat(ezString(sFile), &sb) == 0 && !S_ISDIR(sb.st_mode));
+}
 
 bool ezOSFile::InternalExistsDirectory(ezStringView sDirectory)
 {

--- a/Code/UnitTests/FoundationTest/IO/OSFileTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/OSFileTest.cpp
@@ -268,6 +268,10 @@ Only concrete and clocks.\n\
 
     EZ_TEST_BOOL(ezOSFile::ExistsFile(sOutputFile.GetData()) == false);
     EZ_TEST_BOOL(ezOSFile::ExistsFile(sOutputFile2.GetData()) == false);
+
+    ezStringBuilder sOutputFolder = ezTestFramework::GetInstance()->GetAbsOutputPath();
+    // We should not report folders as files
+    EZ_TEST_BOOL(ezOSFile::ExistsFile(sOutputFolder) == false);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ExistsDirectory")


### PR DESCRIPTION
Given how complicated it is to build Linux executables which will work on all Linux distributions we can't realistically ship precompiled binary tools for Linux like we do on Windows.

This ads a value to the editor preferences allowing the user to precompile the binaries and then specify where the precompiled binaries are located. This is for example useful when running a debug build Editor on Linux but still wanting fast asset transforms with the dev / shipping tools. The current behavior on windows doesn't change, by default the Editor will use the checked in precompiled tools.