### PR TITLE
TexConv.exe can now do image comparison and output diff images and HTML

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EditorEngineProcessFrameworkPCH.h
+++ b/Code/Editor/EditorEngineProcessFramework/EditorEngineProcessFrameworkPCH.h
@@ -7,7 +7,7 @@
 // all include's AFTER this will be removed by the StaticLinkUtil and updated by what is actually used throughout the library
 
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/WorldSerializer/WorldReader.h>
 #include <Core/WorldSerializer/WorldWriter.h>
 #include <Foundation/Communication/RemoteMessage.h>

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -1,6 +1,6 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorEngineProcessFramework/IPC/SyncObject.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocument.h>

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentManager.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentManager.cpp
@@ -1,6 +1,6 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorFramework/Assets/AssetDocumentManager.h>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssetsPCH.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssetsPCH.h
@@ -23,7 +23,7 @@
 #include <Foundation/Strings/TranslationLookup.h>
 #include <Texture/Image/ImageConversion.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/World/GameObject.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <GuiFoundation/Action/ActionManager.h>

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/RenderPipelineAsset/RenderPipelineContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/RenderPipelineAsset/RenderPipelineContext.cpp
@@ -2,7 +2,7 @@
 
 #include <EnginePluginAssets/RenderPipelineAsset/RenderPipelineContext.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 #include <Foundation/IO/StringDeduplicationContext.h>
 #include <Foundation/IO/TypeVersionContext.h>

--- a/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.cpp
+++ b/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.cpp
@@ -1,6 +1,6 @@
 #include <EnginePluginJolt/EnginePluginJoltPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EnginePluginJolt/SceneExport/JoltStaticMeshConversion.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
@@ -1,6 +1,6 @@
 #include <EditorPluginParticle/EditorPluginParticlePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorFramework/DocumentWindow/OrbitCamViewWidget.moc.h>
 #include <EditorFramework/InputContexts/EditorInputContext.h>
 #include <EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.moc.h>

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.cpp
@@ -1,6 +1,6 @@
 #include <EditorPluginProcGen/EditorPluginProcGenPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.h>
 #include <EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.moc.h>

--- a/Code/EditorPlugins/Recast/EnginePluginRecast/NavMesh/NavMeshWorkerOp.cpp
+++ b/Code/EditorPlugins/Recast/EnginePluginRecast/NavMesh/NavMeshWorkerOp.cpp
@@ -2,7 +2,7 @@
 
 #include <EnginePluginRecast/NavMesh/NavMeshWorkerOp.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h>
 #include <Foundation/IO/FileSystem/FileWriter.h>
 #include <Foundation/Utilities/Progress.h>

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -3,7 +3,7 @@
 #include <EnginePluginScene/SceneContext/SceneContext.h>
 #include <EnginePluginScene/SceneView/SceneView.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Interfaces/SoundInterface.h>
 #include <Core/Prefabs/PrefabResource.h>
 #include <Core/World/EventMessageHandlerComponent.h>

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -1,6 +1,6 @@
 #include <EditorPluginSubstance/EditorPluginSubstancePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorPluginAssets/TextureAsset/TextureAssetManager.h>
 #include <EditorPluginSubstance/Assets/SubstancePackageAsset.h>

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -1,6 +1,6 @@
 #include <EditorPluginTypeScript/EditorPluginTypeScriptPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Document/GameObjectDocument.h>
 #include <EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.h>

--- a/Code/Engine/Core/Collection/Implementation/CollectionResource.cpp
+++ b/Code/Engine/Core/Collection/Implementation/CollectionResource.cpp
@@ -1,6 +1,6 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Collection/CollectionResource.h>
 #include <Foundation/Profiling/Profiling.h>
 

--- a/Code/Engine/Core/Curves/Implementation/ColorGradientResource.cpp
+++ b/Code/Engine/Core/Curves/Implementation/ColorGradientResource.cpp
@@ -1,6 +1,6 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Curves/ColorGradientResource.h>
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezColorGradientResource, 1, ezRTTIDefaultAllocator<ezColorGradientResource>)

--- a/Code/Engine/Core/Curves/Implementation/Curve1DResource.cpp
+++ b/Code/Engine/Core/Curves/Implementation/Curve1DResource.cpp
@@ -1,6 +1,6 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Curves/Curve1DResource.h>
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCurve1DResource, 1, ezRTTIDefaultAllocator<ezCurve1DResource>)

--- a/Code/Engine/Core/Physics/Implementation/SurfaceResource.cpp
+++ b/Code/Engine/Core/Physics/Implementation/SurfaceResource.cpp
@@ -1,6 +1,6 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Messages/ApplyOnlyToMessage.h>
 #include <Core/Messages/CommonMessages.h>
 #include <Core/Physics/SurfaceResource.h>

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabResource.cpp
@@ -1,6 +1,6 @@
 #include <Core/CorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Prefabs/PrefabResource.h>
 #include <Foundation/Reflection/PropertyPath.h>
 #include <Foundation/Reflection/ReflectionUtils.h>

--- a/Code/Engine/Foundation/Utilities/AssetFileHeader.h
+++ b/Code/Engine/Foundation/Utilities/AssetFileHeader.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <Core/CoreDLL.h>
 #include <Foundation/IO/Stream.h>
 #include <Foundation/Strings/HashedString.h>
 
 /// \brief Simple class to handle asset file headers (the very first bytes in all transformed asset files)
-class EZ_CORE_DLL ezAssetFileHeader
+class EZ_FOUNDATION_DLL ezAssetFileHeader
 {
 public:
   ezAssetFileHeader();
@@ -39,7 +38,9 @@ public:
   void SetGenerator(ezStringView sGenerator) { m_sGenerator.Assign(sGenerator); }
 
 private:
-  ezUInt64 m_uiHash;
-  ezUInt16 m_uiVersion;
+  // initialize to a 'valid' hash
+  // this may get stored, unless someone sets the hash
+  ezUInt64 m_uiHash = 0;
+  ezUInt16 m_uiVersion = 0;
   ezHashedString m_sGenerator;
 };

--- a/Code/Engine/Foundation/Utilities/Implementation/AssetFileHeader.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/AssetFileHeader.cpp
@@ -1,17 +1,11 @@
-#include <Core/CorePCH.h>
+#include <Foundation/FoundationPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
 #include <Foundation/IO/MemoryStream.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 
 static const char* g_szAssetTag = "ezAsset";
 
-ezAssetFileHeader::ezAssetFileHeader()
-{
-  // initialize to a 'valid' hash
-  // this may get stored, unless someone sets the hash
-  m_uiHash = 0;
-  m_uiVersion = 0;
-}
+ezAssetFileHeader::ezAssetFileHeader() = default;
 
 enum ezAssetFileHeaderVersion : ezUInt8
 {
@@ -90,5 +84,3 @@ ezResult ezAssetFileHeader::Read(ezStreamReader& inout_stream)
 
   return EZ_SUCCESS;
 }
-
-

--- a/Code/Engine/GameEngine/Animation/Implementation/PropertyAnimResource.cpp
+++ b/Code/Engine/GameEngine/Animation/Implementation/PropertyAnimResource.cpp
@@ -1,6 +1,6 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Curves/ColorGradientResource.h>
 #include <Core/Curves/Curve1DResource.h>
 #include <GameEngine/Animation/PropertyAnimResource.h>

--- a/Code/Engine/GameEngine/GameState/Implementation/FallbackGameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/FallbackGameState.cpp
@@ -1,6 +1,6 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Collection/CollectionResource.h>
 #include <Core/Input/InputManager.h>
 #include <Core/WorldSerializer/WorldReader.h>

--- a/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineResource.cpp
+++ b/Code/Engine/GameEngine/StateMachine/Implementation/StateMachineResource.cpp
@@ -1,6 +1,6 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <GameEngine/StateMachine/StateMachineResource.h>
 
 // clang-format off

--- a/Code/Engine/GameEngine/Utils/Implementation/BlackboardTemplateResource.cpp
+++ b/Code/Engine/GameEngine/Utils/Implementation/BlackboardTemplateResource.cpp
@@ -1,6 +1,6 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <GameEngine/Utils/BlackboardTemplateResource.h>
 
 // clang-format off

--- a/Code/Engine/GameEngine/Utils/Implementation/ImageDataResource.cpp
+++ b/Code/Engine/GameEngine/Utils/Implementation/ImageDataResource.cpp
@@ -1,6 +1,6 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <GameEngine/Utils/ImageDataResource.h>
 #include <Texture/Image/Formats/DdsFileFormat.h>
 #include <Texture/Image/Formats/ImageFileFormat.h>

--- a/Code/Engine/GameEngine/Utils/Implementation/SceneLoadUtil.cpp
+++ b/Code/Engine/GameEngine/Utils/Implementation/SceneLoadUtil.cpp
@@ -1,6 +1,6 @@
 #include <GameEngine/GameEnginePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Collection/CollectionResource.h>
 #include <GameEngine/GameApplication/GameApplication.h>
 #include <GameEngine/Utils/SceneLoadUtil.h>

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimGraphResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimGraphResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/MemoryStream.h>
 #include <Foundation/IO/Stream.h>
 #include <RendererCore/AnimationSystem/AnimGraph/AnimGraph.h>

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/AnimationSystem/AnimationClipResource.h>
 #include <RendererCore/AnimationSystem/AnimationPose.h>
 #include <RendererCore/AnimationSystem/Skeleton.h>

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/AnimationSystem/Implementation/OzzUtils.h>
 #include <RendererCore/AnimationSystem/SkeletonResource.h>
 #include <ozz/animation/runtime/skeleton.h>

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/ProbeTreeSectorResource.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/ProbeTreeSectorResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <RendererCore/BakedProbes/ProbeTreeSectorResource.h>
 

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalAtlasResource.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalAtlasResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/FileSystem/FileSystem.h>

--- a/Code/Engine/RendererCore/Material/Implementation/MaterialResource.cpp
+++ b/Code/Engine/RendererCore/Material/Implementation/MaterialResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/OpenDdlReader.h>
 #include <Foundation/IO/OpenDdlUtils.h>

--- a/Code/Engine/RendererCore/Meshes/Implementation/CpuMeshResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CpuMeshResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/Meshes/CpuMeshResource.h>
 
 // clang-format off

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/Material/MaterialResource.h>
 #include <RendererCore/Meshes/MeshResource.h>
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshResourceDescriptor.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshResourceDescriptor.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/FileSystem/FileWriter.h>

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelineResource.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelineResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/Pipeline/Implementation/RenderPipelineResourceLoader.h>
 #include <RendererCore/Pipeline/Passes/SimpleRenderPass.h>
 #include <RendererCore/Pipeline/Passes/SourcePass.h>

--- a/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/Configuration/CVar.h>
 #include <Foundation/Configuration/Startup.h>
 #include <RendererCore/RenderContext/RenderContext.h>

--- a/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
@@ -1,7 +1,7 @@
 
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/Configuration/CVar.h>
 #include <Foundation/Configuration/Startup.h>
 

--- a/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/Textures/TextureCubeResource.h>
 #include <RendererCore/Textures/TextureUtils.h>

--- a/Code/Engine/RendererCore/Textures/TextureLoader.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureLoader.cpp
@@ -1,6 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/Configuration/CVar.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/FileSystem/FileReader.h>

--- a/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
@@ -3057,6 +3057,7 @@ static ezImageConversion_CompressBC5 s_conversion_compressBC5;
 
 #endif
 
+// EZ_STATICLINK_FORCE
 static ezImageConversion_BC1_RGBA s_conversion_BC1_RGBA;
 static ezImageConversion_BC2_RGBA s_conversion_BC2_RGBA;
 static ezImageConversion_BC3_RGBA s_conversion_BC3_RGBA;
@@ -3065,4 +3066,8 @@ static ezImageConversion_BC5_RG s_conversion_BC5_RG;
 static ezImageConversion_BC6_RGB s_conversion_BC6_RGB;
 static ezImageConversion_BC7_RGBA s_conversion_BC7_RGBA;
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Conversions_DXTConversions);
 

--- a/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
@@ -387,6 +387,7 @@ public:
   }
 };
 
+// EZ_STATICLINK_FORCE
 static ezImageConversion_CompressDxTex s_conversion_compressDxTex;
 
 #endif

--- a/Code/Engine/Texture/Image/Conversions/DXTexCpuConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTexCpuConversions.cpp
@@ -130,8 +130,13 @@ public:
   }
 };
 
+// EZ_STATICLINK_FORCE
 static ezImageConversion_CompressDxTexCpu s_conversion_compressDxTexCpu;
 
 #endif
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Conversions_DXTexCpuConversions);
 

--- a/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
@@ -1561,6 +1561,7 @@ ADD_16BPP_CONVERSION(B5G5R5A1);
 ADD_16BPP_CONVERSION(X1B5G5R5);
 ADD_16BPP_CONVERSION(A1B5G5R5);
 
+// EZ_STATICLINK_FORCE
 static ezImageSwizzleConversion32_2103 s_conversion_swizzle2103;
 static ezImageConversion_BGRX_BGRA s_conversion_BGRX_BGRA;
 static ezImageConversion_F32_U8 s_conversion_F32_U8;
@@ -1589,4 +1590,8 @@ static ezImageConversion_R11G11B10_to_FLOAT s_conversion_R11G11B10_to_FLOAT;
 static ezImageConversion_R11G11B10_to_HALF s_conversion_R11G11B10_to_HALF;
 static ezImageConversion_FLOAT_to_R11G11B10 s_conversion_FLOAT_to_R11G11B10;
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Conversions_PixelConversions);
 

--- a/Code/Engine/Texture/Image/Conversions/PlanarConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/PlanarConversions.cpp
@@ -141,7 +141,12 @@ struct ezImageConversion_sRGB_NV12 : public ezImageConversionStepPlanarize
   }
 };
 
+// EZ_STATICLINK_FORCE
 static ezImageConversion_NV12_sRGB s_conversion_NV12_sRGB;
 static ezImageConversion_sRGB_NV12 s_conversion_sRGB_NV12;
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Conversions_PlanarConversions);
 

--- a/Code/Engine/Texture/Image/Conversions/SwizzleConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/SwizzleConversions.cpp
@@ -1,3 +1,0 @@
-#include <Texture/TexturePCH.h>
-
-

--- a/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
@@ -6,6 +6,7 @@
 #include <Texture/Image/Formats/BmpFileFormat.h>
 #include <Texture/Image/ImageConversion.h>
 
+// EZ_STATICLINK_FORCE
 ezBmpFileFormat g_bmpFormat;
 
 enum ezBmpCompression
@@ -773,4 +774,8 @@ bool ezBmpFileFormat::CanWriteFileType(ezStringView sExtension) const
   return CanReadFileType(sExtension);
 }
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Formats_BmpFileFormat);
 

--- a/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
@@ -6,6 +6,7 @@
 #include <Texture/Image/Formats/ImageFormatMappings.h>
 #include <Texture/Image/Image.h>
 
+// EZ_STATICLINK_FORCE
 ezDdsFileFormat g_ddsFormat;
 
 struct ezDdsPixelFormat
@@ -522,4 +523,8 @@ bool ezDdsFileFormat::CanWriteFileType(ezStringView sExtension) const
   return CanReadFileType(sExtension);
 }
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Formats_DdsFileFormat);
 

--- a/Code/Engine/Texture/Image/Formats/ExrFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/ExrFileFormat.cpp
@@ -11,6 +11,7 @@
 
 #  include <tinyexr/tinyexr.h>
 
+// EZ_STATICLINK_FORCE
 ezExrFileFormat g_ExrFileFormat;
 
 ezResult ReadImageData(ezStreamReader& ref_stream, ezDynamicArray<ezUInt8>& ref_fileBuffer, ezImageHeader& ref_header, EXRHeader& ref_exrHeader, EXRImage& ref_exrImage)
@@ -320,4 +321,8 @@ bool ezExrFileFormat::CanWriteFileType(ezStringView sExtension) const
 
 #endif
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Formats_ExrFileFormat);
 

--- a/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
+++ b/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
@@ -10,7 +10,7 @@
 #include <stb_image/stb_image.h>
 #include <stb_image/stb_image_write.h>
 
-
+// EZ_STATICLINK_FORCE
 ezStbImageFileFormats g_StbImageFormats;
 
 // stb_image callbacks would be better than loading the entire file into memory.
@@ -230,4 +230,8 @@ bool ezStbImageFileFormats::CanWriteFileType(ezStringView sExtension) const
   return false;
 }
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Formats_StbImageFileFormats);
 

--- a/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
@@ -6,7 +6,7 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <Texture/Image/ImageConversion.h>
 
-
+// EZ_STATICLINK_FORCE
 ezTgaFileFormat g_TgaFormat;
 
 struct TgaImageDescriptor
@@ -510,4 +510,8 @@ bool ezTgaFileFormat::CanWriteFileType(ezStringView sExtension) const
   return CanReadFileType(sExtension);
 }
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Formats_TgaFileFormat);
 

--- a/Code/Engine/Texture/Image/Formats/WicFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/WicFileFormat.cpp
@@ -18,6 +18,7 @@ using namespace DirectX;
 
 EZ_DEFINE_AS_POD_TYPE(DirectX::Image); // Allow for storing this struct in ez containers
 
+// EZ_STATICLINK_FORCE
 ezWicFileFormat g_wicFormat;
 
 namespace
@@ -313,4 +314,8 @@ bool ezWicFileFormat::CanWriteFileType(ezStringView sExtension) const
 
 #endif
 
+
+
+
+EZ_STATICLINK_FILE(Texture, Texture_Image_Formats_WicFileFormat);
 

--- a/Code/Engine/Texture/Image/ImageUtils.h
+++ b/Code/Engine/Texture/Image/ImageUtils.h
@@ -155,4 +155,10 @@ public:
   /// Currently only supports images of format R32G32B32A32_FLOAT and with identical resolution.
   /// Returns failure if any of those requirements are not met.
   static ezResult CopyChannel(ezImage& ref_dstImg, ezUInt8 uiDstChannelIdx, const ezImage& srcImg, ezUInt8 uiSrcChannelIdx);
+
+  /// \brief Embeds the image as Base64 encoded text into an HTML file.
+  static void EmbedImageData(ezStringBuilder& out_sHtml, const ezImage& image);
+
+  /// \brief Generates an HTML file containing the given images with mouse-over functionality to compare them.
+  static void CreateImageDiffHtml(ezStringBuilder& out_sHtml, ezStringView sTitle, const ezImage& referenceImgRgb, const ezImage& referenceImgAlpha, const ezImage& capturedImgRgb, const ezImage& capturedImgAlpha, const ezImage& diffImgRgb, const ezImage& diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb, ezUInt8 uiMaxDiffRgb, ezUInt8 uiMinDiffAlpha, ezUInt8 uiMaxDiffAlpha);
 };

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -5,6 +5,7 @@
 #include <Foundation/IO/MemoryStream.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <Foundation/SimdMath/SimdVec4f.h>
+#include <Foundation/Time/Timestamp.h>
 #include <Texture/Image/ImageConversion.h>
 #include <Texture/Image/ImageEnums.h>
 #include <Texture/Image/ImageFilter.h>
@@ -2001,5 +2002,3 @@ void ezImageUtils::CreateImageDiffHtml(ezStringBuilder& out_sHtml, ezStringView 
                 "</div>\n"
                 "</BODY> </HTML>");
 }
-
-

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -2,6 +2,7 @@
 
 #include <Texture/Image/ImageUtils.h>
 
+#include <Foundation/IO/MemoryStream.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <Foundation/SimdMath/SimdVec4f.h>
 #include <Texture/Image/ImageConversion.h>
@@ -1769,6 +1770,236 @@ ezResult ezImageUtils::CopyChannel(ezImage& ref_dstImg, ezUInt8 uiDstChannelIdx,
   }
 
   return EZ_SUCCESS;
+}
+
+static const ezUInt8 s_Base64EncodingTable[64] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
+  'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
+
+static const ezUInt8 BASE64_CHARS_PER_LINE = 76;
+
+static ezUInt32 GetBase64EncodedLength(ezUInt32 uiInputLength, bool bInsertLineBreaks)
+{
+  ezUInt32 outputLength = (uiInputLength + 2) / 3 * 4;
+
+  if (bInsertLineBreaks)
+  {
+    outputLength += outputLength / BASE64_CHARS_PER_LINE;
+  }
+
+  return outputLength;
+}
+
+static ezDynamicArray<char> ArrayToBase64(ezArrayPtr<const ezUInt8> in, bool bInsertLineBreaks = true)
+{
+  ezDynamicArray<char> out;
+  out.SetCountUninitialized(GetBase64EncodedLength(in.GetCount(), bInsertLineBreaks));
+
+  ezUInt32 offsetIn = 0;
+  ezUInt32 offsetOut = 0;
+
+  ezUInt32 blocksTillNewline = BASE64_CHARS_PER_LINE / 4;
+  while (offsetIn < in.GetCount())
+  {
+    ezUInt8 ibuf[3] = {0};
+
+    ezUInt32 ibuflen = ezMath::Min(in.GetCount() - offsetIn, 3u);
+
+    for (ezUInt32 i = 0; i < ibuflen; ++i)
+    {
+      ibuf[i] = in[offsetIn++];
+    }
+
+    char obuf[4];
+    obuf[0] = s_Base64EncodingTable[(ibuf[0] >> 2)];
+    obuf[1] = s_Base64EncodingTable[((ibuf[0] << 4) & 0x30) | (ibuf[1] >> 4)];
+    obuf[2] = s_Base64EncodingTable[((ibuf[1] << 2) & 0x3c) | (ibuf[2] >> 6)];
+    obuf[3] = s_Base64EncodingTable[(ibuf[2] & 0x3f)];
+
+    if (ibuflen >= 3)
+    {
+      out[offsetOut++] = obuf[0];
+      out[offsetOut++] = obuf[1];
+      out[offsetOut++] = obuf[2];
+      out[offsetOut++] = obuf[3];
+    }
+    else // need to pad up to 4
+    {
+      switch (ibuflen)
+      {
+        case 1:
+          out[offsetOut++] = obuf[0];
+          out[offsetOut++] = obuf[1];
+          out[offsetOut++] = '=';
+          out[offsetOut++] = '=';
+          break;
+        case 2:
+          out[offsetOut++] = obuf[0];
+          out[offsetOut++] = obuf[1];
+          out[offsetOut++] = obuf[2];
+          out[offsetOut++] = '=';
+          break;
+      }
+    }
+
+    if (--blocksTillNewline == 0)
+    {
+      if (bInsertLineBreaks)
+      {
+        out[offsetOut++] = '\n';
+      }
+      blocksTillNewline = 19;
+    }
+  }
+
+  EZ_ASSERT_DEV(offsetOut == out.GetCount(), "All output data should have been written");
+  return out;
+}
+
+void ezImageUtils::EmbedImageData(ezStringBuilder& out_sHtml, const ezImage& image)
+{
+  ezImageFileFormat* format = ezImageFileFormat::GetWriterFormat("png");
+  EZ_ASSERT_DEV(format != nullptr, "No PNG writer found");
+
+  ezDynamicArray<ezUInt8> imgData;
+  ezMemoryStreamContainerWrapperStorage<ezDynamicArray<ezUInt8>> storage(&imgData);
+  ezMemoryStreamWriter writer(&storage);
+  format->WriteImage(writer, image, "png").IgnoreResult();
+
+  ezDynamicArray<char> imgDataBase64 = ArrayToBase64(imgData.GetArrayPtr());
+  ezStringView imgDataBase64StringView(imgDataBase64.GetArrayPtr().GetPtr(), imgDataBase64.GetArrayPtr().GetEndPtr());
+  out_sHtml.AppendFormat("data:image/png;base64,{0}", imgDataBase64StringView);
+}
+
+void ezImageUtils::CreateImageDiffHtml(ezStringBuilder& out_sHtml, ezStringView sTitle, const ezImage& referenceImgRgb, const ezImage& referenceImgAlpha, const ezImage& capturedImgRgb, const ezImage& capturedImgAlpha, const ezImage& diffImgRgb, const ezImage& diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb, ezUInt8 uiMaxDiffRgb, ezUInt8 uiMinDiffAlpha, ezUInt8 uiMaxDiffAlpha)
+{
+  ezStringBuilder& output = out_sHtml;
+  output.Append("<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
+                "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
+                "<HTML> <HEAD>\n");
+
+  output.AppendFormat("<TITLE>{}</TITLE>\n", sTitle);
+  output.Append("<script type = \"text/javascript\">\n"
+                "function showReferenceImage()\n"
+                "{\n"
+                "    document.getElementById('image_current_rgb').style.display = 'none'\n"
+                "    document.getElementById('image_current_a').style.display = 'none'\n"
+                "    document.getElementById('image_reference_rgb').style.display = 'inline-block'\n"
+                "    document.getElementById('image_reference_a').style.display = 'inline-block'\n"
+                "    document.getElementById('image_caption_rgb').innerHTML = 'Displaying: Reference Image RGB'\n"
+                "    document.getElementById('image_caption_a').innerHTML = 'Displaying: Reference Image Alpha'\n"
+                "}\n"
+                "function showCurrentImage()\n"
+                "{\n"
+                "    document.getElementById('image_current_rgb').style.display = 'inline-block'\n"
+                "    document.getElementById('image_current_a').style.display = 'inline-block'\n"
+                "    document.getElementById('image_reference_rgb').style.display = 'none'\n"
+                "    document.getElementById('image_reference_a').style.display = 'none'\n"
+                "    document.getElementById('image_caption_rgb').innerHTML = 'Displaying: Current Image RGB'\n"
+                "    document.getElementById('image_caption_a').innerHTML = 'Displaying: Current Image Alpha'\n"
+                "}\n"
+                "function imageover()\n"
+                "{\n"
+                "    var mode = document.querySelector('input[name=\"image_interaction_mode\"]:checked').value\n"
+                "    if (mode == 'interactive')\n"
+                "    {\n"
+                "        showReferenceImage()\n"
+                "    }\n"
+                "}\n"
+                "function imageout()\n"
+                "{\n"
+                "    var mode = document.querySelector('input[name=\"image_interaction_mode\"]:checked').value\n"
+                "    if (mode == 'interactive')\n"
+                "    {\n"
+                "        showCurrentImage()\n"
+                "    }\n"
+                "}\n"
+                "function handleModeClick(clickedItem)\n"
+                "{\n"
+                "    if (clickedItem.value == 'current_image' || clickedItem.value == 'interactive')\n"
+                "    {\n"
+                "        showCurrentImage()\n"
+                "    }\n"
+                "    else if (clickedItem.value == 'reference_image')\n"
+                "    {\n"
+                "        showReferenceImage()\n"
+                "    }\n"
+                "}\n"
+                "</script>\n"
+                "</HEAD>\n"
+                "<BODY bgcolor=\"#ccdddd\">\n"
+                "<div style=\"line-height: 1.5; margin-top: 0px; margin-left: 10px; font-family: sans-serif;\">\n");
+
+  output.AppendFormat("<b>Test result for \"{}\" from ", sTitle);
+  ezDateTime dateTime = ezDateTime::MakeFromTimestamp(ezTimestamp::CurrentTimestamp());
+  output.AppendFormat("{}-{}-{} {}:{}:{}</b><br>\n", dateTime.GetYear(), ezArgI(dateTime.GetMonth(), 2, true), ezArgI(dateTime.GetDay(), 2, true), ezArgI(dateTime.GetHour(), 2, true), ezArgI(dateTime.GetMinute(), 2, true), ezArgI(dateTime.GetSecond(), 2, true));
+
+  output.Append("<table cellpadding=\"0\" cellspacing=\"0\" border=\"0\">\n");
+
+  output.Append("<!-- STATS-TABLE-START -->\n");
+
+  output.AppendFormat("<tr>\n"
+                      "<td>Error metric:</td>\n"
+                      "<td align=\"right\" style=\"padding-left: 2em;\">{}</td>\n"
+                      "</tr>\n",
+    uiError);
+  output.AppendFormat("<tr>\n"
+                      "<td>Error threshold:</td>\n"
+                      "<td align=\"right\" style=\"padding-left: 2em;\">{}</td>\n"
+                      "</tr>\n",
+    uiThreshold);
+
+  output.Append("<!-- STATS-TABLE-END -->\n");
+
+  output.Append("</table>\n"
+                "<div style=\"margin-top: 0.5em; margin-bottom: -0.75em\">\n"
+                "    <input type=\"radio\" name=\"image_interaction_mode\" onclick=\"handleModeClick(this)\" value=\"interactive\" "
+                "checked=\"checked\"> Mouse-Over Image Switching\n"
+                "    <input type=\"radio\" name=\"image_interaction_mode\" onclick=\"handleModeClick(this)\" value=\"current_image\"> "
+                "Current Image\n"
+                "    <input type=\"radio\" name=\"image_interaction_mode\" onclick=\"handleModeClick(this)\" value=\"reference_image\"> "
+                "Reference Image\n"
+                "</div>\n");
+
+  output.AppendFormat("<div style=\"width:{}px;display: inline-block;\">\n", capturedImgRgb.GetWidth());
+
+  output.Append("<p id=\"image_caption_rgb\">Displaying: Current Image RGB</p>\n"
+
+                "<div style=\"block;\" onmouseover=\"imageover()\" onmouseout=\"imageout()\">\n"
+                "<img id=\"image_current_rgb\" alt=\"Captured Image RGB\" src=\"");
+  EmbedImageData(output, capturedImgRgb);
+  output.Append("\" />\n"
+                "<img id=\"image_reference_rgb\" style=\"display: none\" alt=\"Reference Image RGB\" src=\"");
+  EmbedImageData(output, referenceImgRgb);
+  output.Append("\" />\n"
+                "</div>\n"
+                "<div style=\"display: block;\">\n");
+  output.AppendFormat("<p>RGB Difference (min: {}, max: {}):</p>\n", uiMinDiffRgb, uiMaxDiffRgb);
+  output.Append("<img alt=\"Diff Image RGB\" src=\"");
+  EmbedImageData(output, diffImgRgb);
+  output.Append("\" />\n"
+                "</div>\n"
+                "</div>\n");
+
+  output.AppendFormat("<div style=\"width:{}px;display: inline-block;\">\n", capturedImgAlpha.GetWidth());
+
+  output.Append("<p id=\"image_caption_a\">Displaying: Current Image Alpha</p>\n"
+                "<div style=\"display: block;\" onmouseover=\"imageover()\" onmouseout=\"imageout()\">\n"
+                "<img id=\"image_current_a\" alt=\"Captured Image Alpha\" src=\"");
+  EmbedImageData(output, capturedImgAlpha);
+  output.Append("\" />\n"
+                "<img id=\"image_reference_a\" style=\"display: none\" alt=\"Reference Image Alpha\" src=\"");
+  EmbedImageData(output, referenceImgAlpha);
+  output.Append("\" />\n"
+                "</div>\n"
+                "<div style=\"px;display: block;\">\n");
+  output.AppendFormat("<p>Alpha Difference (min: {}, max: {}):</p>\n", uiMinDiffAlpha, uiMaxDiffAlpha);
+  output.Append("<img alt=\"Diff Image Alpha\" src=\"");
+  EmbedImageData(output, diffImgAlpha);
+  output.Append("\" />\n"
+                "</div>\n"
+                "</div>\n"
+                "</div>\n"
+                "</BODY> </HTML>");
 }
 
 

--- a/Code/Engine/Texture/TexConv/Implementation/TexComparer.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TexComparer.cpp
@@ -1,5 +1,6 @@
 #include <Texture/TexturePCH.h>
 
+#include <Foundation/Profiling/Profiling.h>
 #include <Texture/Image/ImageUtils.h>
 #include <Texture/TexConv/TexComparer.h>
 
@@ -7,6 +8,8 @@ ezTexComparer::ezTexComparer() = default;
 
 ezResult ezTexComparer::Compare()
 {
+  EZ_PROFILE_SCOPE("Compare");
+
   EZ_SUCCEED_OR_RETURN(LoadInputImages());
 
   if ((m_Descriptor.m_ActualImage.GetWidth() != m_Descriptor.m_ExpectedImage.GetWidth()) ||
@@ -91,6 +94,8 @@ ezResult ezTexComparer::LoadInputImages()
 
 ezResult ezTexComparer::ComputeMSE()
 {
+  EZ_PROFILE_SCOPE("ComputeMSE");
+
   if (m_Descriptor.m_bRelaxedComparison)
     ezImageUtils::ComputeImageDifferenceABSRelaxed(m_Descriptor.m_ActualImage, m_Descriptor.m_ExpectedImage, m_OutputImageDiff);
   else
@@ -103,6 +108,8 @@ ezResult ezTexComparer::ComputeMSE()
 
 ezResult ezTexComparer::ExtractImages()
 {
+  EZ_PROFILE_SCOPE("ExtractImages");
+
   ezImageUtils::Normalize(m_OutputImageDiff, m_uiOutputMinDiffRgb, m_uiOutputMaxDiffRgb, m_uiOutputMinDiffAlpha, m_uiOutputMaxDiffAlpha);
 
   EZ_SUCCEED_OR_RETURN(ezImageConversion::Convert(m_OutputImageDiff, m_OutputImageDiffRgb, ezImageFormat::R8G8B8_UNORM));
@@ -117,5 +124,3 @@ ezResult ezTexComparer::ExtractImages()
 
   return EZ_SUCCESS;
 }
-
-

--- a/Code/Engine/Texture/TexConv/Implementation/TexComparer.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TexComparer.cpp
@@ -1,6 +1,7 @@
 #include <Texture/TexturePCH.h>
 
 #include <Foundation/Profiling/Profiling.h>
+#include <Texture/Image/ImageConversion.h>
 #include <Texture/Image/ImageUtils.h>
 #include <Texture/TexConv/TexComparer.h>
 

--- a/Code/Engine/Texture/TexConv/Implementation/TexComparer.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TexComparer.cpp
@@ -1,0 +1,121 @@
+#include <Texture/TexturePCH.h>
+
+#include <Texture/Image/ImageUtils.h>
+#include <Texture/TexConv/TexComparer.h>
+
+ezTexComparer::ezTexComparer() = default;
+
+ezResult ezTexComparer::Compare()
+{
+  EZ_SUCCEED_OR_RETURN(LoadInputImages());
+
+  if ((m_Descriptor.m_ActualImage.GetWidth() != m_Descriptor.m_ExpectedImage.GetWidth()) ||
+      (m_Descriptor.m_ActualImage.GetHeight() != m_Descriptor.m_ExpectedImage.GetHeight()))
+  {
+    ezLog::Error("Image sizes are not identical: {}x{} != {}x{}", m_Descriptor.m_ActualImage.GetWidth(), m_Descriptor.m_ActualImage.GetHeight(), m_Descriptor.m_ExpectedImage.GetWidth(), m_Descriptor.m_ExpectedImage.GetHeight());
+    return EZ_FAILURE;
+  }
+
+  EZ_SUCCEED_OR_RETURN(ComputeMSE());
+
+  if (m_OutputMSE > m_Descriptor.m_MeanSquareErrorThreshold)
+  {
+    m_bExceededMSE = true;
+
+    EZ_SUCCEED_OR_RETURN(ExtractImages());
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezTexComparer::LoadInputImages()
+{
+  EZ_PROFILE_SCOPE("Load Images");
+
+  if (!m_Descriptor.m_sActualFile.IsEmpty())
+  {
+    if (m_Descriptor.m_ActualImage.LoadFrom(m_Descriptor.m_sActualFile).Failed())
+    {
+      ezLog::Error("Could not load image file '{0}'.", ezArgSensitive(m_Descriptor.m_sActualFile, "File"));
+      return EZ_FAILURE;
+    }
+  }
+
+  if (!m_Descriptor.m_sExpectedFile.IsEmpty())
+  {
+    if (m_Descriptor.m_ExpectedImage.LoadFrom(m_Descriptor.m_sExpectedFile).Failed())
+    {
+      ezLog::Error("Could not load reference file '{0}'.", ezArgSensitive(m_Descriptor.m_sExpectedFile, "File"));
+      return EZ_FAILURE;
+    }
+  }
+
+  if (!m_Descriptor.m_ActualImage.IsValid())
+  {
+    ezLog::Error("No image available.");
+    return EZ_FAILURE;
+  }
+
+  if (!m_Descriptor.m_ExpectedImage.IsValid())
+  {
+    ezLog::Error("No reference image available.");
+    return EZ_FAILURE;
+  }
+
+  if (m_Descriptor.m_ActualImage.GetImageFormat() == ezImageFormat::UNKNOWN)
+  {
+    ezLog::Error("Unknown image format for '{}'", ezArgSensitive(m_Descriptor.m_sActualFile, "File"));
+    return EZ_FAILURE;
+  }
+
+  if (m_Descriptor.m_ExpectedImage.GetImageFormat() == ezImageFormat::UNKNOWN)
+  {
+    ezLog::Error("Unknown image format for '{}'", ezArgSensitive(m_Descriptor.m_sExpectedFile, "File"));
+    return EZ_FAILURE;
+  }
+
+  if (ezImageConversion::Convert(m_Descriptor.m_ActualImage, m_Descriptor.m_ActualImage, ezImageFormat::R8G8B8A8_UNORM).Failed())
+  {
+    ezLog::Error("Could not convert to RGBA8: '{}'", ezArgSensitive(m_Descriptor.m_sActualFile, "File"));
+    return EZ_FAILURE;
+  }
+
+  if (ezImageConversion::Convert(m_Descriptor.m_ExpectedImage, m_Descriptor.m_ExpectedImage, ezImageFormat::R8G8B8A8_UNORM).Failed())
+  {
+    ezLog::Error("Could not convert to RGBA8: '{}'", ezArgSensitive(m_Descriptor.m_sExpectedFile, "File"));
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezTexComparer::ComputeMSE()
+{
+  if (m_Descriptor.m_bRelaxedComparison)
+    ezImageUtils::ComputeImageDifferenceABSRelaxed(m_Descriptor.m_ActualImage, m_Descriptor.m_ExpectedImage, m_OutputImageDiff);
+  else
+    ezImageUtils::ComputeImageDifferenceABS(m_Descriptor.m_ActualImage, m_Descriptor.m_ExpectedImage, m_OutputImageDiff);
+
+  m_OutputMSE = ezImageUtils::ComputeMeanSquareError(m_OutputImageDiff, 32);
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezTexComparer::ExtractImages()
+{
+  ezImageUtils::Normalize(m_OutputImageDiff, m_uiOutputMinDiffRgb, m_uiOutputMaxDiffRgb, m_uiOutputMinDiffAlpha, m_uiOutputMaxDiffAlpha);
+
+  EZ_SUCCEED_OR_RETURN(ezImageConversion::Convert(m_OutputImageDiff, m_OutputImageDiffRgb, ezImageFormat::R8G8B8_UNORM));
+
+  ezImageUtils::ExtractAlphaChannel(m_OutputImageDiff, m_OutputImageDiffAlpha);
+
+  EZ_SUCCEED_OR_RETURN(ezImageConversion::Convert(m_Descriptor.m_ActualImage, m_ExtractedActualRgb, ezImageFormat::R8G8B8_UNORM));
+  ezImageUtils::ExtractAlphaChannel(m_Descriptor.m_ActualImage, m_ExtractedActualAlpha);
+
+  EZ_SUCCEED_OR_RETURN(ezImageConversion::Convert(m_Descriptor.m_ExpectedImage, m_ExtractedExpectedRgb, ezImageFormat::R8G8B8_UNORM));
+  ezImageUtils::ExtractAlphaChannel(m_Descriptor.m_ExpectedImage, m_ExtractedExpectedAlpha);
+
+  return EZ_SUCCESS;
+}
+
+

--- a/Code/Engine/Texture/TexConv/TexComparer.h
+++ b/Code/Engine/Texture/TexConv/TexComparer.h
@@ -1,0 +1,76 @@
+#pragma once
+
+/// \brief Input options for ezTexComparer
+class EZ_TEXTURE_DLL ezTexCompareDesc
+{
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezTexCompareDesc);
+
+public:
+  ezTexCompareDesc() = default;
+
+  /// Path to a file to load as a reference image. Optional, if m_ExpectedImage is already filled out.
+  ezString m_sExpectedFile;
+
+  /// Path to a file to load as the input image. Optional, if m_ActualImage is already filled out.
+  ezString m_sActualFile;
+
+  /// The reference image to compare. Ignored if m_sExpectedFile is filled out.
+  ezImage m_ExpectedImage;
+
+  /// The image to compare. Ignored if m_sActualFile is filled out.
+  ezImage m_ActualImage;
+
+  /// If enabled, the image comparison allows for more wiggle room.
+  /// For images containing single-pixel rasterized lines.
+  bool m_bRelaxedComparison = false;
+
+  /// If the comparison yields a larger MSE than this, the images are considered to be too different.
+  ezUInt32 m_MeanSquareErrorThreshold = 100;
+};
+
+/// \brief Compares two images and generates various outputs.
+class EZ_TEXTURE_DLL ezTexComparer
+{
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezTexComparer);
+
+public:
+  ezTexComparer();
+
+  /// The input data to compare.
+  ezTexCompareDesc m_Descriptor;
+
+  /// Executes the comparison and fill out the public variables to describe the result.
+  ezResult Compare();
+
+  /// If true, the mean-square error of the difference was larger than the threshold.
+  bool m_bExceededMSE = false;
+  /// The MSE of the difference image.
+  ezUInt32 m_OutputMSE = 0;
+
+  /// The (normalized) difference image.
+  ezImage m_OutputImageDiff;
+  /// Only the RGB part of the (normalized) difference image.
+  ezImage m_OutputImageDiffRgb;
+  /// Only the Alpha part of the (normalized) difference image.
+  ezImage m_OutputImageDiffAlpha;
+
+  /// Only the RGB part of the actual input image.
+  ezImage m_ExtractedActualRgb;
+  /// Only the RGB part of the reference input image.
+  ezImage m_ExtractedExpectedRgb;
+  /// Only the Alpha part of the actual input image.
+  ezImage m_ExtractedActualAlpha;
+  /// Only the Alpha part of the reference input image.
+  ezImage m_ExtractedExpectedAlpha;
+
+  /// Min/Max difference of the RGB and Alpha images.
+  ezUInt8 m_uiOutputMinDiffRgb = 0;
+  ezUInt8 m_uiOutputMaxDiffRgb = 0;
+  ezUInt8 m_uiOutputMinDiffAlpha = 0;
+  ezUInt8 m_uiOutputMaxDiffAlpha = 0;
+
+private:
+  ezResult LoadInputImages();
+  ezResult ComputeMSE();
+  ezResult ExtractImages();
+};

--- a/Code/Engine/Texture/TexturePCH.cpp
+++ b/Code/Engine/Texture/TexturePCH.cpp
@@ -5,7 +5,17 @@ EZ_STATICLINK_LIBRARY(Texture)
   if (bReturn)
     return;
 
+  EZ_STATICLINK_REFERENCE(Texture_Image_Conversions_DXTConversions);
   EZ_STATICLINK_REFERENCE(Texture_Image_Conversions_DXTexConversions);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Conversions_DXTexCpuConversions);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Conversions_PixelConversions);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Conversions_PlanarConversions);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Formats_BmpFileFormat);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Formats_DdsFileFormat);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Formats_ExrFileFormat);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Formats_StbImageFileFormats);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Formats_TgaFileFormat);
+  EZ_STATICLINK_REFERENCE(Texture_Image_Formats_WicFileFormat);
   EZ_STATICLINK_REFERENCE(Texture_Image_Implementation_ImageEnums);
   EZ_STATICLINK_REFERENCE(Texture_Image_Implementation_ImageFormat);
   EZ_STATICLINK_REFERENCE(Texture_TexConv_Implementation_Processor);

--- a/Code/EnginePlugins/FmodPlugin/Resources/FmodSoundBankResourceLoader.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Resources/FmodSoundBankResourceLoader.cpp
@@ -1,6 +1,6 @@
 #include <FmodPlugin/FmodPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <FmodPlugin/FmodIncludes.h>
 #include <FmodPlugin/FmodSingleton.h>
 #include <FmodPlugin/Resources/FmodSoundBankResource.h>

--- a/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResource.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResource.cpp
@@ -1,6 +1,6 @@
 #include <JoltPlugin/JoltPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Physics/SurfaceResource.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/IO/MemoryStream.h>

--- a/Code/EnginePlugins/KrautPlugin/Resources/KrautGeneratorResource.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Resources/KrautGeneratorResource.cpp
@@ -3,7 +3,7 @@
 #include <KrautPlugin/Resources/KrautGeneratorResource.h>
 #include <KrautPlugin/Resources/KrautTreeResource.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/ResourceManager/ResourceTypeLoader.h>
 #include <Foundation/Containers/StaticRingBuffer.h>
 #include <Foundation/Math/BoundingSphere.h>

--- a/Code/EnginePlugins/KrautPlugin/Resources/KrautTreeResource.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Resources/KrautTreeResource.cpp
@@ -1,6 +1,6 @@
 #include <KrautPlugin/KrautPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <KrautPlugin/Resources/KrautTreeResource.h>
 #include <RendererCore/Material/MaterialResource.h>
 #include <RendererCore/Meshes/MeshBufferUtils.h>

--- a/Code/EnginePlugins/ParticlePlugin/Resources/ParticleEffectResource.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Resources/ParticleEffectResource.cpp
@@ -1,6 +1,6 @@
 #include <ParticlePlugin/ParticlePluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <ParticlePlugin/Resources/ParticleEffectResource.h>
 
 // clang-format off

--- a/Code/EnginePlugins/ProcGenPlugin/Resources/Implementation/ProcGenGraphResource.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Resources/Implementation/ProcGenGraphResource.cpp
@@ -1,6 +1,6 @@
 #include <ProcGenPlugin/ProcGenPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Curves/ColorGradientResource.h>
 #include <Core/Physics/SurfaceResource.h>
 #include <Core/Prefabs/PrefabResource.h>

--- a/Code/EnginePlugins/RecastPlugin/Resources/RecastNavMeshResource.cpp
+++ b/Code/EnginePlugins/RecastPlugin/Resources/RecastNavMeshResource.cpp
@@ -1,6 +1,6 @@
 #include <RecastPlugin/RecastPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <DetourNavMesh.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Recast.h>

--- a/Code/EnginePlugins/RmlUiPlugin/Resources/RmlUiResource.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Resources/RmlUiResource.cpp
@@ -1,6 +1,6 @@
 #include <RmlUiPlugin/RmlUiPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <RmlUiPlugin/Resources/RmlUiResource.h>
 

--- a/Code/EnginePlugins/TypeScriptPlugin/Resources/ScriptCompendiumResource.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/Resources/ScriptCompendiumResource.cpp
@@ -1,6 +1,6 @@
 #include <TypeScriptPlugin/TypeScriptPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <TypeScriptPlugin/Resources/ScriptCompendiumResource.h>
 
 // clang-format off

--- a/Code/EnginePlugins/TypeScriptPlugin/Resources/TypeScriptResource.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/Resources/TypeScriptResource.cpp
@@ -1,6 +1,6 @@
 #include <TypeScriptPlugin/TypeScriptPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Scripting/DuktapeContext.h>
 #include <Foundation/Configuration/Startup.h>
 #include <TypeScriptPlugin/Components/TypeScriptComponent.h>

--- a/Code/EnginePlugins/VisualScriptPlugin/Resources/VisualScriptClassResource.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Resources/VisualScriptClassResource.cpp
@@ -1,6 +1,6 @@
 #include <VisualScriptPlugin/VisualScriptPluginPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/IO/StringDeduplicationContext.h>

--- a/Code/Tools/Player/Player.cpp
+++ b/Code/Tools/Player/Player.cpp
@@ -1,6 +1,6 @@
 #include <Player/Player.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/Input/InputManager.h>
 #include <Core/World/World.h>
 #include <Core/WorldSerializer/WorldReader.h>

--- a/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
+++ b/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
@@ -729,6 +729,7 @@ public:
 
           bool bContainsGlobals = false;
 
+          bContainsGlobals = bContainsGlobals || (sFileContent.FindSubString("EZ_STATICLINK_FORCE") != nullptr);
           bContainsGlobals = bContainsGlobals || (sFileContent.FindSubString("EZ_STATICLINK_LIBRARY") != nullptr);
           bContainsGlobals = bContainsGlobals || (sFileContent.FindSubString("EZ_BEGIN_") != nullptr);
           bContainsGlobals = bContainsGlobals || (sFileContent.FindSubString("EZ_PLUGIN_") != nullptr);

--- a/Code/Tools/TexConv/CMakeLists.txt
+++ b/Code/Tools/TexConv/CMakeLists.txt
@@ -9,6 +9,5 @@ ez_create_target(APPLICATION ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-  Core
   Texture
 )

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -112,6 +112,8 @@ ezCommandLineOptionPath opt_CompareExpected("_TexConv", "-cmpRef", "Path to a re
 ezCommandLineOptionInt opt_CompareThreshold("_TexConv", "-cmpMSE", "The error threshold for the comparison to be considered as failed.\n\
   No output files are written, if the image difference is below this value.",
   100, 0);
+ezCommandLineOptionBool opt_CompareRelaxed("_TexConv", "-cmpRelaxed", "Use a more lenient comparison method.\nUseful for images with single-pixel wide rasterized lines.", false);
+
 
 ezResult ezTexConv::ParseCommandLine()
 {
@@ -182,6 +184,7 @@ ezResult ezTexConv::ParseCompareMode()
   m_Comparer.m_Descriptor.m_sActualFile = opt_CompareActual.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
   m_Comparer.m_Descriptor.m_sExpectedFile = opt_CompareExpected.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
   m_Comparer.m_Descriptor.m_MeanSquareErrorThreshold = opt_CompareThreshold.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
+  m_Comparer.m_Descriptor.m_bRelaxedComparison = opt_CompareRelaxed.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
 
   if (m_Comparer.m_Descriptor.m_sActualFile.IsEmpty())
   {

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -172,8 +172,7 @@ ezResult ezTexConv::ParseCompareMode()
 
   if (m_sOutputFile.IsEmpty())
   {
-    ezLog::Error("Output folder is not specified. Use option '-out \"path/to/folder\"' to specify a target directory.");
-    return EZ_FAILURE;
+    ezLog::Warning("Output path is not specified. Use option '-out \"path\"' to set the prefix path for the output files.");
   }
 
   m_sHtmlTitle = opt_CompareHtmlTitle.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -4,6 +4,11 @@
 
 #include <Foundation/Utilities/CommandLineOptions.h>
 
+ezCommandLineOptionEnum opt_Mode("_TexConv", "-mode", "Mode determines which arguments need to be set.\n\
+  In compare mode the mean-square error (MSE) is returned. 0 if it is below the threshold.\
+",
+  "Convert | Compare", 0);
+
 ezCommandLineOptionPath opt_Out("_TexConv", "-out",
   "Absolute path to main output file.\n\
    ext = tga, dds, ezTexture2D, ezTexture3D, ezTextureCube or ezTextureAtlas.",
@@ -101,27 +106,94 @@ ezCommandLineOptionEnum opt_BumpMapFilter("_TexConv", "-bumpMapFilter", "Filter 
 
 ezCommandLineOptionEnum opt_Platform("_TexConv", "-platform", "What platform to generate the textures for.", "PC | Android", 0);
 
+ezCommandLineOptionString opt_CompareHtmlTitle("_TexConv", "-cmpHtml", "Title for the compare result HTML. If empty no HTML file is written.", "");
+ezCommandLineOptionPath opt_CompareActual("_TexConv", "-cmpImg", "Path to an image to compare with another.", "");
+ezCommandLineOptionPath opt_CompareExpected("_TexConv", "-cmpRef", "Path to a reference image to compare against.", "");
+ezCommandLineOptionInt opt_CompareThreshold("_TexConv", "-cmpMSE", "The error threshold for the comparison to be considered as failed.\n\
+  No output files are written, if the image difference is below this value.",
+  100, 0);
+
 ezResult ezTexConv::ParseCommandLine()
 {
   if (ezCommandLineOption::LogAvailableOptions(ezCommandLineOption::LogAvailableModes::IfHelpRequested, "_TexConv"))
     return EZ_FAILURE;
 
-  EZ_SUCCEED_OR_RETURN(ParseOutputFiles());
-  EZ_SUCCEED_OR_RETURN(DetectOutputFormat());
+  EZ_SUCCEED_OR_RETURN(ParseMode());
 
-  EZ_SUCCEED_OR_RETURN(ParseOutputType());
-  EZ_SUCCEED_OR_RETURN(ParseAssetHeader());
-  EZ_SUCCEED_OR_RETURN(ParseTargetPlatform());
-  EZ_SUCCEED_OR_RETURN(ParseCompressionMode());
-  EZ_SUCCEED_OR_RETURN(ParseUsage());
-  EZ_SUCCEED_OR_RETURN(ParseMipmapMode());
-  EZ_SUCCEED_OR_RETURN(ParseWrapModes());
-  EZ_SUCCEED_OR_RETURN(ParseFilterModes());
-  EZ_SUCCEED_OR_RETURN(ParseResolutionModifiers());
-  EZ_SUCCEED_OR_RETURN(ParseMiscOptions());
-  EZ_SUCCEED_OR_RETURN(ParseInputFiles());
-  EZ_SUCCEED_OR_RETURN(ParseChannelMappings());
-  EZ_SUCCEED_OR_RETURN(ParseBumpMapFilter());
+  if (m_Mode == ezTexConvMode::Compare)
+  {
+    EZ_SUCCEED_OR_RETURN(ParseCompareMode());
+  }
+  else
+  {
+    EZ_SUCCEED_OR_RETURN(ParseOutputFiles());
+    EZ_SUCCEED_OR_RETURN(DetectOutputFormat());
+
+    EZ_SUCCEED_OR_RETURN(ParseOutputType());
+    EZ_SUCCEED_OR_RETURN(ParseAssetHeader());
+    EZ_SUCCEED_OR_RETURN(ParseTargetPlatform());
+    EZ_SUCCEED_OR_RETURN(ParseCompressionMode());
+    EZ_SUCCEED_OR_RETURN(ParseUsage());
+    EZ_SUCCEED_OR_RETURN(ParseMipmapMode());
+    EZ_SUCCEED_OR_RETURN(ParseWrapModes());
+    EZ_SUCCEED_OR_RETURN(ParseFilterModes());
+    EZ_SUCCEED_OR_RETURN(ParseResolutionModifiers());
+    EZ_SUCCEED_OR_RETURN(ParseMiscOptions());
+    EZ_SUCCEED_OR_RETURN(ParseInputFiles());
+    EZ_SUCCEED_OR_RETURN(ParseChannelMappings());
+    EZ_SUCCEED_OR_RETURN(ParseBumpMapFilter());
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezTexConv::ParseMode()
+{
+  switch (opt_Mode.GetOptionValue(ezCommandLineOption::LogMode::FirstTime))
+  {
+    case 0:
+      m_Mode = ezTexConvMode::Convert;
+      return EZ_SUCCESS;
+
+    case 1:
+      m_Mode = ezTexConvMode::Compare;
+      return EZ_SUCCESS;
+  }
+
+  ezLog::Error("Invalid mode selected.");
+  return EZ_FAILURE;
+}
+
+ezResult ezTexConv::ParseCompareMode()
+{
+  m_sOutputFile = opt_Out.GetOptionValue(ezCommandLineOption::LogMode::Always);
+
+  if (m_sOutputFile.IsEmpty())
+  {
+    ezLog::Error("Output folder is not specified. Use option '-out \"path/to/folder\"' to specify a target directory.");
+    return EZ_FAILURE;
+  }
+
+  m_sHtmlTitle = opt_CompareHtmlTitle.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
+
+  ezStringBuilder tmp, res;
+  const auto pCmd = ezCommandLineUtils::GetGlobalInstance();
+
+  m_Comparer.m_Descriptor.m_sActualFile = opt_CompareActual.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
+  m_Comparer.m_Descriptor.m_sExpectedFile = opt_CompareExpected.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
+  m_Comparer.m_Descriptor.m_MeanSquareErrorThreshold = opt_CompareThreshold.GetOptionValue(ezCommandLineOption::LogMode::FirstTime);
+
+  if (m_Comparer.m_Descriptor.m_sActualFile.IsEmpty())
+  {
+    ezLog::Error("Image to compare is not specified.");
+    return EZ_FAILURE;
+  }
+
+  if (m_Comparer.m_Descriptor.m_sExpectedFile.IsEmpty())
+  {
+    ezLog::Error("Reference image to compare against is not specified.");
+    return EZ_FAILURE;
+  }
 
   return EZ_SUCCESS;
 }

--- a/Code/Tools/TexConv/TexConv.cpp
+++ b/Code/Tools/TexConv/TexConv.cpp
@@ -1,6 +1,6 @@
 #include <TexConv/TexConvPCH.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
 #include <TexConv/TexConv.h>
 #include <Texture/Image/Formats/DdsFileFormat.h>

--- a/Code/Tools/TexConv/TexConv.cpp
+++ b/Code/Tools/TexConv/TexConv.cpp
@@ -1,7 +1,7 @@
 #include <TexConv/TexConvPCH.h>
 
-#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <TexConv/TexConv.h>
 #include <Texture/Image/Formats/DdsFileFormat.h>
 #include <Texture/Image/Formats/StbImageFileFormats.h>
@@ -227,26 +227,29 @@ ezApplication::Execution ezTexConv::Run()
     {
       SetReturnCode(m_Comparer.m_OutputMSE);
 
-      ezStringBuilder tmp;
-
-      tmp.Set(m_sOutputFile, "-rgb.png");
-      m_Comparer.m_OutputImageDiffRgb.SaveTo(tmp).IgnoreResult();
-
-      tmp.Set(m_sOutputFile, "-alpha.png");
-      m_Comparer.m_OutputImageDiffAlpha.SaveTo(tmp).IgnoreResult();
-
-      if (!m_sHtmlTitle.IsEmpty())
+      if (!m_sOutputFile.IsEmpty())
       {
-        tmp.Set(m_sOutputFile, ".htm");
+        ezStringBuilder tmp;
 
-        ezFileWriter file;
-        if (file.Open(tmp).Succeeded())
+        tmp.Set(m_sOutputFile, "-rgb.png");
+        m_Comparer.m_OutputImageDiffRgb.SaveTo(tmp).IgnoreResult();
+
+        tmp.Set(m_sOutputFile, "-alpha.png");
+        m_Comparer.m_OutputImageDiffAlpha.SaveTo(tmp).IgnoreResult();
+
+        if (!m_sHtmlTitle.IsEmpty())
         {
-          ezStringBuilder html;
+          tmp.Set(m_sOutputFile, ".htm");
 
-          ezImageUtils::CreateImageDiffHtml(html, m_sHtmlTitle, m_Comparer.m_ExtractedExpectedRgb, m_Comparer.m_ExtractedExpectedAlpha, m_Comparer.m_ExtractedActualRgb, m_Comparer.m_ExtractedActualAlpha, m_Comparer.m_OutputImageDiffRgb, m_Comparer.m_OutputImageDiffAlpha, m_Comparer.m_OutputMSE, m_Comparer.m_Descriptor.m_MeanSquareErrorThreshold, m_Comparer.m_uiOutputMinDiffRgb, m_Comparer.m_uiOutputMaxDiffRgb, m_Comparer.m_uiOutputMinDiffAlpha, m_Comparer.m_uiOutputMaxDiffAlpha);
+          ezFileWriter file;
+          if (file.Open(tmp).Succeeded())
+          {
+            ezStringBuilder html;
 
-          file.WriteBytes(html.GetData(), html.GetElementCount()).AssertSuccess();
+            ezImageUtils::CreateImageDiffHtml(html, m_sHtmlTitle, m_Comparer.m_ExtractedExpectedRgb, m_Comparer.m_ExtractedExpectedAlpha, m_Comparer.m_ExtractedActualRgb, m_Comparer.m_ExtractedActualAlpha, m_Comparer.m_OutputImageDiffRgb, m_Comparer.m_OutputImageDiffAlpha, m_Comparer.m_OutputMSE, m_Comparer.m_Descriptor.m_MeanSquareErrorThreshold, m_Comparer.m_uiOutputMinDiffRgb, m_Comparer.m_uiOutputMaxDiffRgb, m_Comparer.m_uiOutputMinDiffAlpha, m_Comparer.m_uiOutputMaxDiffAlpha);
+
+            file.WriteBytes(html.GetData(), html.GetElementCount()).AssertSuccess();
+          }
         }
       }
     }

--- a/Code/Tools/TexConv/TexConv.h
+++ b/Code/Tools/TexConv/TexConv.h
@@ -1,8 +1,22 @@
 #pragma once
 
 #include <Foundation/Application/Application.h>
+#include <Texture/TexConv/TexComparer.h>
 
 class ezStreamWriter;
+
+struct ezTexConvMode
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    Convert,
+    Compare,
+
+    Default = Convert
+  };
+};
 
 class ezTexConv : public ezApplication
 {
@@ -30,6 +44,8 @@ public:
   virtual void BeforeCoreSystemsShutdown() override;
 
   ezResult ParseCommandLine();
+  ezResult ParseMode();
+  ezResult ParseCompareMode();
   ezResult ParseOutputType();
   ezResult DetectOutputFormat();
   ezResult ParseInputFiles();
@@ -71,5 +87,11 @@ private:
   bool m_bOutputSupportsFiltering = false;
   bool m_bOutputSupportsCompression = false;
 
+  ezEnum<ezTexConvMode> m_Mode;
   ezTexConvProcessor m_Processor;
+
+  // Comparer specific
+
+  ezTexComparer m_Comparer;
+  ezString m_sHtmlTitle;
 };

--- a/Code/UnitTests/EditorTest/EditorTestPCH.h
+++ b/Code/UnitTests/EditorTest/EditorTestPCH.h
@@ -15,6 +15,6 @@
 #include <Foundation/Math/Declarations.h>
 #include <Foundation/Math/Rect.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 
 #include <EditorPluginScene/EditorPluginSceneDLL.h>

--- a/Code/UnitTests/GameEngineTest/GameEngineTestPCH.h
+++ b/Code/UnitTests/GameEngineTest/GameEngineTestPCH.h
@@ -15,7 +15,7 @@
 #include <Foundation/Math/Declarations.h>
 #include <Foundation/Math/Rect.h>
 
-#include <Core/Assets/AssetFileHeader.h>
+#include <Foundation/Utilities/AssetFileHeader.h>
 #include <Core/World/World.h>
 #include <Core/World/WorldDesc.h>
 #include <RendererCore/Debug/DebugRenderer.h>

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -1282,109 +1282,9 @@ void ezTestFramework::SetImageReferenceOverrideFolderName(const char* szFolderNa
   }
 }
 
-static const ezUInt8 s_Base64EncodingTable[64] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
-  'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
-
-static const ezUInt8 BASE64_CHARS_PER_LINE = 76;
-
-static ezUInt32 GetBase64EncodedLength(ezUInt32 uiInputLength, bool bInsertLineBreaks)
-{
-  ezUInt32 outputLength = (uiInputLength + 2) / 3 * 4;
-
-  if (bInsertLineBreaks)
-  {
-    outputLength += outputLength / BASE64_CHARS_PER_LINE;
-  }
-
-  return outputLength;
-}
-
-
-static ezDynamicArray<char> ArrayToBase64(ezArrayPtr<const ezUInt8> in, bool bInsertLineBreaks = true)
-{
-  ezDynamicArray<char> out;
-  out.SetCountUninitialized(GetBase64EncodedLength(in.GetCount(), bInsertLineBreaks));
-
-  ezUInt32 offsetIn = 0;
-  ezUInt32 offsetOut = 0;
-
-  ezUInt32 blocksTillNewline = BASE64_CHARS_PER_LINE / 4;
-  while (offsetIn < in.GetCount())
-  {
-    ezUInt8 ibuf[3] = {0};
-
-    ezUInt32 ibuflen = ezMath::Min(in.GetCount() - offsetIn, 3u);
-
-    for (ezUInt32 i = 0; i < ibuflen; ++i)
-    {
-      ibuf[i] = in[offsetIn++];
-    }
-
-    char obuf[4];
-    obuf[0] = s_Base64EncodingTable[(ibuf[0] >> 2)];
-    obuf[1] = s_Base64EncodingTable[((ibuf[0] << 4) & 0x30) | (ibuf[1] >> 4)];
-    obuf[2] = s_Base64EncodingTable[((ibuf[1] << 2) & 0x3c) | (ibuf[2] >> 6)];
-    obuf[3] = s_Base64EncodingTable[(ibuf[2] & 0x3f)];
-
-    if (ibuflen >= 3)
-    {
-      out[offsetOut++] = obuf[0];
-      out[offsetOut++] = obuf[1];
-      out[offsetOut++] = obuf[2];
-      out[offsetOut++] = obuf[3];
-    }
-    else // need to pad up to 4
-    {
-      switch (ibuflen)
-      {
-        case 1:
-          out[offsetOut++] = obuf[0];
-          out[offsetOut++] = obuf[1];
-          out[offsetOut++] = '=';
-          out[offsetOut++] = '=';
-          break;
-        case 2:
-          out[offsetOut++] = obuf[0];
-          out[offsetOut++] = obuf[1];
-          out[offsetOut++] = obuf[2];
-          out[offsetOut++] = '=';
-          break;
-      }
-    }
-
-    if (--blocksTillNewline == 0)
-    {
-      if (bInsertLineBreaks)
-      {
-        out[offsetOut++] = '\n';
-      }
-      blocksTillNewline = 19;
-    }
-  }
-
-  EZ_ASSERT_DEV(offsetOut == out.GetCount(), "All output data should have been written");
-  return out;
-}
-
-static void AppendImageData(ezStringBuilder& ref_sOutput, ezImage& ref_img)
-{
-  ezImageFileFormat* format = ezImageFileFormat::GetWriterFormat("png");
-  EZ_ASSERT_DEV(format != nullptr, "No PNG writer found");
-
-  ezDynamicArray<ezUInt8> imgData;
-  ezMemoryStreamContainerWrapperStorage<ezDynamicArray<ezUInt8>> storage(&imgData);
-  ezMemoryStreamWriter writer(&storage);
-  format->WriteImage(writer, ref_img, "png").IgnoreResult();
-
-  ezDynamicArray<char> imgDataBase64 = ArrayToBase64(imgData.GetArrayPtr());
-  ezStringView imgDataBase64StringView(imgDataBase64.GetArrayPtr().GetPtr(), imgDataBase64.GetArrayPtr().GetEndPtr());
-  ref_sOutput.AppendFormat("data:image/png;base64,{0}", imgDataBase64StringView);
-}
-
-void ezTestFramework::WriteImageDiffHtml(const char* szFileName, ezImage& ref_referenceImgRgb, ezImage& ref_referenceImgAlpha, ezImage& ref_capturedImgRgb, ezImage& ref_capturedImgAlpha, ezImage& ref_diffImgRgb, ezImage& ref_diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb, ezUInt8 uiMaxDiffRgb,
+void ezTestFramework::WriteImageDiffHtml(const char* szFileName, const ezImage& referenceImgRgb, const ezImage& referenceImgAlpha, const ezImage& capturedImgRgb, const ezImage& capturedImgAlpha, const ezImage& diffImgRgb, const ezImage& diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb, ezUInt8 uiMaxDiffRgb,
   ezUInt8 uiMinDiffAlpha, ezUInt8 uiMaxDiffAlpha)
 {
-
   ezFileWriter outputFile;
   if (outputFile.Open(szFileName).Failed())
   {
@@ -1392,146 +1292,33 @@ void ezTestFramework::WriteImageDiffHtml(const char* szFileName, ezImage& ref_re
     return;
   }
 
-  ezStringBuilder output;
-  output.Append("<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
-                "<!DOCTYPE html PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
-                "<HTML> <HEAD>\n");
   const char* szTestName = GetTest(GetCurrentTestIndex())->m_szTestName;
   const char* szSubTestName = GetTest(GetCurrentTestIndex())->m_SubTests[GetCurrentSubTestIndex()].m_szSubTestName;
-  output.AppendFormat("<TITLE>{} - {}</TITLE>\n", szTestName, szSubTestName);
-  output.Append("<script type = \"text/javascript\">\n"
-                "function showReferenceImage()\n"
-                "{\n"
-                "    document.getElementById('image_current_rgb').style.display = 'none'\n"
-                "    document.getElementById('image_current_a').style.display = 'none'\n"
-                "    document.getElementById('image_reference_rgb').style.display = 'inline-block'\n"
-                "    document.getElementById('image_reference_a').style.display = 'inline-block'\n"
-                "    document.getElementById('image_caption_rgb').innerHTML = 'Displaying: Reference Image RGB'\n"
-                "    document.getElementById('image_caption_a').innerHTML = 'Displaying: Reference Image Alpha'\n"
-                "}\n"
-                "function showCurrentImage()\n"
-                "{\n"
-                "    document.getElementById('image_current_rgb').style.display = 'inline-block'\n"
-                "    document.getElementById('image_current_a').style.display = 'inline-block'\n"
-                "    document.getElementById('image_reference_rgb').style.display = 'none'\n"
-                "    document.getElementById('image_reference_a').style.display = 'none'\n"
-                "    document.getElementById('image_caption_rgb').innerHTML = 'Displaying: Current Image RGB'\n"
-                "    document.getElementById('image_caption_a').innerHTML = 'Displaying: Current Image Alpha'\n"
-                "}\n"
-                "function imageover()\n"
-                "{\n"
-                "    var mode = document.querySelector('input[name=\"image_interaction_mode\"]:checked').value\n"
-                "    if (mode == 'interactive')\n"
-                "    {\n"
-                "        showReferenceImage()\n"
-                "    }\n"
-                "}\n"
-                "function imageout()\n"
-                "{\n"
-                "    var mode = document.querySelector('input[name=\"image_interaction_mode\"]:checked').value\n"
-                "    if (mode == 'interactive')\n"
-                "    {\n"
-                "        showCurrentImage()\n"
-                "    }\n"
-                "}\n"
-                "function handleModeClick(clickedItem)\n"
-                "{\n"
-                "    if (clickedItem.value == 'current_image' || clickedItem.value == 'interactive')\n"
-                "    {\n"
-                "        showCurrentImage()\n"
-                "    }\n"
-                "    else if (clickedItem.value == 'reference_image')\n"
-                "    {\n"
-                "        showReferenceImage()\n"
-                "    }\n"
-                "}\n"
-                "</script>\n"
-                "</HEAD>\n"
-                "<BODY bgcolor=\"#ccdddd\">\n"
-                "<div style=\"line-height: 1.5; margin-top: 0px; margin-left: 10px; font-family: sans-serif;\">\n");
 
-  output.AppendFormat("<b>Test result for \"{} > {}\" from ", szTestName, szSubTestName);
-  ezDateTime dateTime = ezDateTime::MakeFromTimestamp(ezTimestamp::CurrentTimestamp());
-  output.AppendFormat("{}-{}-{} {}:{}:{}</b><br>\n", dateTime.GetYear(), ezArgI(dateTime.GetMonth(), 2, true), ezArgI(dateTime.GetDay(), 2, true), ezArgI(dateTime.GetHour(), 2, true), ezArgI(dateTime.GetMinute(), 2, true), ezArgI(dateTime.GetSecond(), 2, true));
+  ezStringBuilder tmp(szTestName, " - ", szSubTestName);
 
-  output.Append("<table cellpadding=\"0\" cellspacing=\"0\" border=\"0\">\n");
+  ezStringBuilder output;
+  ezImageUtils::CreateImageDiffHtml(output, tmp, referenceImgRgb, referenceImgAlpha, capturedImgRgb, capturedImgAlpha, diffImgRgb, diffImgAlpha, uiError, uiThreshold, uiMinDiffRgb, uiMaxDiffRgb, uiMinDiffAlpha, uiMaxDiffAlpha);
 
   if (m_ImageDiffExtraInfoCallback)
   {
+    tmp.Clear();
+
     ezDynamicArray<std::pair<ezString, ezString>> extraInfo = m_ImageDiffExtraInfoCallback();
 
     for (const auto& labelValuePair : extraInfo)
     {
-      output.AppendFormat("<tr>\n"
-                          "<td>{}:</td>\n"
-                          "<td align=\"right\" style=\"padding-left: 2em;\">{}</td>\n"
-                          "</tr>\n",
+      tmp.AppendFormat("<tr>\n"
+                       "<td>{}:</td>\n"
+                       "<td align=\"right\" style=\"padding-left: 2em;\">{}</td>\n"
+                       "</tr>\n",
         labelValuePair.first, labelValuePair.second);
     }
+
+    output.ReplaceFirst("<!-- STATS-TABLE-START -->", tmp);
   }
 
-  output.AppendFormat("<tr>\n"
-                      "<td>Error metric:</td>\n"
-                      "<td align=\"right\" style=\"padding-left: 2em;\">{}</td>\n"
-                      "</tr>\n",
-    uiError);
-  output.AppendFormat("<tr>\n"
-                      "<td>Error threshold:</td>\n"
-                      "<td align=\"right\" style=\"padding-left: 2em;\">{}</td>\n"
-                      "</tr>\n",
-    uiThreshold);
-  output.Append("</table>\n"
-                "<div style=\"margin-top: 0.5em; margin-bottom: -0.75em\">\n"
-                "    <input type=\"radio\" name=\"image_interaction_mode\" onclick=\"handleModeClick(this)\" value=\"interactive\" "
-                "checked=\"checked\"> Mouse-Over Image Switching\n"
-                "    <input type=\"radio\" name=\"image_interaction_mode\" onclick=\"handleModeClick(this)\" value=\"current_image\"> "
-                "Current Image\n"
-                "    <input type=\"radio\" name=\"image_interaction_mode\" onclick=\"handleModeClick(this)\" value=\"reference_image\"> "
-                "Reference Image\n"
-                "</div>\n");
-
-  output.AppendFormat("<div style=\"width:{}px;display: inline-block;\">\n", ref_capturedImgRgb.GetWidth());
-
-  output.Append("<p id=\"image_caption_rgb\">Displaying: Current Image RGB</p>\n"
-
-                "<div style=\"block;\" onmouseover=\"imageover()\" onmouseout=\"imageout()\">\n"
-                "<img id=\"image_current_rgb\" alt=\"Captured Image RGB\" src=\"");
-  AppendImageData(output, ref_capturedImgRgb);
-  output.Append("\" />\n"
-                "<img id=\"image_reference_rgb\" style=\"display: none\" alt=\"Reference Image RGB\" src=\"");
-  AppendImageData(output, ref_referenceImgRgb);
-  output.Append("\" />\n"
-                "</div>\n"
-                "<div style=\"display: block;\">\n");
-  output.AppendFormat("<p>RGB Difference (min: {}, max: {}):</p>\n", uiMinDiffRgb, uiMaxDiffRgb);
-  output.Append("<img alt=\"Diff Image RGB\" src=\"");
-  AppendImageData(output, ref_diffImgRgb);
-  output.Append("\" />\n"
-                "</div>\n"
-                "</div>\n");
-
-  output.AppendFormat("<div style=\"width:{}px;display: inline-block;\">\n", ref_capturedImgAlpha.GetWidth());
-
-  output.Append("<p id=\"image_caption_a\">Displaying: Current Image Alpha</p>\n"
-                "<div style=\"display: block;\" onmouseover=\"imageover()\" onmouseout=\"imageout()\">\n"
-                "<img id=\"image_current_a\" alt=\"Captured Image Alpha\" src=\"");
-  AppendImageData(output, ref_capturedImgAlpha);
-  output.Append("\" />\n"
-                "<img id=\"image_reference_a\" style=\"display: none\" alt=\"Reference Image Alpha\" src=\"");
-  AppendImageData(output, ref_referenceImgAlpha);
-  output.Append("\" />\n"
-                "</div>\n"
-                "<div style=\"px;display: block;\">\n");
-  output.AppendFormat("<p>Alpha Difference (min: {}, max: {}):</p>\n", uiMinDiffAlpha, uiMaxDiffAlpha);
-  output.Append("<img alt=\"Diff Image Alpha\" src=\"");
-  AppendImageData(output, ref_diffImgAlpha);
-  output.Append("\" />\n"
-                "</div>\n"
-                "</div>\n"
-                "</div>\n"
-                "</BODY> </HTML>");
-
-  outputFile.WriteBytes(output.GetData(), output.GetCharacterCount()).IgnoreResult();
+  outputFile.WriteBytes(output.GetData(), output.GetElementCount()).AssertSuccess();
   outputFile.Close();
 }
 
@@ -1570,7 +1357,8 @@ bool ezTestFramework::PerformImageComparison(ezStringBuilder sImgName, const ezI
   sImgPathResult.AppendPath(sImgName);
   sImgPathResult.ChangeFileExtension(".png");
 
-  auto SaveResultImage = [&]() {
+  auto SaveResultImage = [&]()
+  {
     imgRgba.SaveTo(sImgPathResult).IgnoreResult();
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.h
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.h
@@ -111,8 +111,7 @@ public:
   void SetImageReferenceOverrideFolderName(const char* szFolderName);
 
   /// \brief Writes an Html file that contains test information and an image diff view for failed image comparisons.
-  void WriteImageDiffHtml(const char* szFileName, ezImage& ref_referenceImgRgb, ezImage& ref_referenceImgAlpha, ezImage& ref_capturedImgRgb,
-    ezImage& ref_capturedImgAlpha, ezImage& ref_diffImgRgb, ezImage& ref_diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb,
+  void WriteImageDiffHtml(const char* szFileName, const ezImage& referenceImgRgb, const ezImage& referenceImgAlpha, const ezImage& capturedImgRgb, const ezImage& capturedImgAlpha, const ezImage& diffImgRgb, const ezImage& diffImgAlpha, ezUInt32 uiError, ezUInt32 uiThreshold, ezUInt8 uiMinDiffRgb,
     ezUInt8 uiMaxDiffRgb, ezUInt8 uiMinDiffAlpha, ezUInt8 uiMaxDiffAlpha);
 
   bool PerformImageComparison(ezStringBuilder sImgName, const ezImage& img, ezUInt32 uiMaxError, bool bIsLineImage, char* szErrorMsg);


### PR DESCRIPTION
Moved the test framework code for comparing images and generating diffs into the Texture library.
TexConv.exe now has a mode to compute the difference MSE between two images and output the difference + HTML file.
This enables other applications to use TexConv as a comparison tool.
Also moved some code to Foundation, to remove the link dependency on Core.dll.