### PR TITLE
Renamed ezStringBuilder::Format to SetFormat

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -606,7 +606,7 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
     // We need the file system before we can start the html logger.
     ezOsProcessID uiProcessID = ezProcess::GetCurrentProcessID();
     ezStringBuilder sLogFile;
-    sLogFile.Format(":appdata/Log_{0}.htm", uiProcessID);
+    sLogFile.SetFormat(":appdata/Log_{0}.htm", uiProcessID);
     m_LogHTML.BeginLog(sLogFile, "EditorEngineProcess");
   }
 }

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoHandle.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoHandle.cpp
@@ -639,7 +639,7 @@ bool ezEngineGizmoHandle::SetupForEngine(ezWorld* pWorld, ezUInt32 uiNextCompone
   }
 
   ezStringBuilder sName;
-  sName.Format("Gizmo{0}", m_iHandleType);
+  sName.SetFormat("Gizmo{0}", m_iHandleType);
 
   ezGameObjectDesc god;
   god.m_LocalPosition = m_Transformation.m_vPosition;

--- a/Code/Editor/EditorEngineProcessFramework/LongOps/Implementation/LongOpWorkerManager.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/LongOps/Implementation/LongOpWorkerManager.cpp
@@ -23,7 +23,7 @@ public:
   ezLongOpTask()
   {
     ezStringBuilder name;
-    name.Format("Long Op: '{}'", "TODO: NAME"); // TODO
+    name.SetFormat("Long Op: '{}'", "TODO: NAME"); // TODO
     ConfigureTask(name, ezTaskNesting::Maybe);
   }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -905,7 +905,7 @@ void ezQtAssetBrowserWidget::OnListFindAllReferences(bool transitive)
   ezConversionUtils::ToString(guid, sAssetGuid);
 
   ezStringBuilder sFilter;
-  sFilter.Format("{}:{}", transitive ? "ref-all" : "ref", sAssetGuid);
+  sFilter.SetFormat("{}:{}", transitive ? "ref-all" : "ref", sAssetGuid);
   m_pFilter->SetTextFilter(sFilter);
   m_pFilter->SetPathFilter("");
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -368,7 +368,7 @@ void ezAssetCurator::StoreFullTransformDate()
     ezDateTime date;
     date.SetFromTimestamp(ezTimestamp::CurrentTimestamp()).AssertSuccess();
 
-    path.Format("{}", date);
+    path.SetFormat("{}", date);
     file.Write(path.GetData(), path.GetElementCount()).AssertSuccess();
   }
 }
@@ -1327,12 +1327,12 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
       if (subAsset.m_bMainAsset)
       {
         nd.m_Color = ezColor::Blue;
-        sTemp.Format("{}", pAssetInfo->m_Path.GetDataDirParentRelativePath());
+        sTemp.SetFormat("{}", pAssetInfo->m_Path.GetDataDirParentRelativePath());
       }
       else
       {
         nd.m_Color = ezColor::AliceBlue;
-        sTemp.Format("{} | {}", pAssetInfo->m_Path.GetDataDirParentRelativePath(), subAsset.GetName());
+        sTemp.SetFormat("{} | {}", pAssetInfo->m_Path.GetDataDirParentRelativePath(), subAsset.GetName());
       }
       nd.m_Shape = ezDGMLGraph::NodeShape::Rectangle;
     }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -35,7 +35,7 @@ bool ezAssetDocumentGenerator::SupportsFileType(ezStringView sFile) const
 void ezAssetDocumentGenerator::BuildFileDialogFilterString(ezStringBuilder& out_sFilter) const
 {
   bool semicolon = false;
-  out_sFilter.Format("{0} (", GetDocumentExtension());
+  out_sFilter.SetFormat("{0} (", GetDocumentExtension());
   AppendFileFilterStrings(out_sFilter, semicolon);
   out_sFilter.Append(")");
 }

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -146,17 +146,17 @@ namespace
     ezStringBuilder fmt;
     if (TestCompilerExecutable(compilerBaseName, &compilerVersion).Succeeded() && TestCompilerExecutable(compilerBaseNameCpp).Succeeded() && compilerVersion.StartsWith(requiredVersion))
     {
-      fmt.Format("{} (system default = {})", compilerBaseName, compilerVersion);
+      fmt.SetFormat("{} (system default = {})", compilerBaseName, compilerVersion);
       inout_compilers.PushBack({fmt.GetView(), compiler, compilerBaseName, compilerBaseNameCpp, false});
     }
 
     ezStringBuilder compilerExecutable;
     ezStringBuilder compilerExecutableCpp;
-    compilerExecutable.Format("{}-{}", compilerBaseName, sRequiredMajorVersion);
-    compilerExecutableCpp.Format("{}-{}", compilerBaseNameCpp, sRequiredMajorVersion);
+    compilerExecutable.SetFormat("{}-{}", compilerBaseName, sRequiredMajorVersion);
+    compilerExecutableCpp.SetFormat("{}-{}", compilerBaseNameCpp, sRequiredMajorVersion);
     if (TestCompilerExecutable(compilerExecutable, &compilerVersion).Succeeded() && TestCompilerExecutable(compilerExecutableCpp).Succeeded() && compilerVersion.StartsWith(requiredVersion))
     {
-      fmt.Format("{} (version {})", compilerBaseName, compilerVersion);
+      fmt.SetFormat("{} (version {})", compilerBaseName, compilerVersion);
       inout_compilers.PushBack({fmt.GetView(), compiler, compilerExecutable, compilerExecutableCpp, false});
     }
   }
@@ -229,7 +229,7 @@ ezString ezCppProject::GetPluginSourceDir(const ezCppSettings& cfg, ezStringView
 ezString ezCppProject::GetBuildDir(const ezCppSettings& cfg)
 {
   ezStringBuilder sBuildDir;
-  sBuildDir.Format("{}/Build/{}", GetTargetSourceDir(), GetGeneratorFolderName(cfg));
+  sBuildDir.SetFormat("{}/Build/{}", GetTargetSourceDir(), GetGeneratorFolderName(cfg));
   return sBuildDir;
 }
 
@@ -320,7 +320,7 @@ ezString ezCppProject::GetSdkCompilerMajorVersion()
 {
 #if EZ_ENABLED(EZ_COMPILER_MSVC)
   ezStringBuilder fmt;
-  fmt.Format("{}.{}", _MSC_VER / 100, _MSC_VER % 100);
+  fmt.SetFormat("{}.{}", _MSC_VER / 100, _MSC_VER % 100);
   return fmt;
 #elif EZ_ENABLED(EZ_COMPILER_CLANG)
   return EZ_PP_STRINGIFY(__clang_major__);
@@ -1086,7 +1086,7 @@ void ezCppProject::LoadPreferences()
     if (TestCompilerExecutable(clangDefaultPath, &clangVersion).Succeeded() && TestCompilerExecutable(clangCppDefaultPath).Succeeded() && clangVersion.StartsWith(clangMajorSdkVersion))
     {
       ezStringBuilder clangNiceName;
-      clangNiceName.Format("Clang (system default = {})", clangVersion);
+      clangNiceName.SetFormat("Clang (system default = {})", clangVersion);
       s_MachineSpecificCompilers.PushBack({clangNiceName, ezCompiler::Clang, clangDefaultPath, clangCppDefaultPath, false});
     }
   }
@@ -1109,7 +1109,7 @@ void ezCppProject::LoadPreferences()
   if (preferences->m_CompilerPreferences.m_Compiler != sdkCompiler)
   {
     ezStringBuilder incompatibleCompilerName = u8"⚠ ";
-    incompatibleCompilerName.Format(u8"⚠ {} (incompatible)", ezCppProject::CompilerToString(preferences->m_CompilerPreferences.m_Compiler));
+    incompatibleCompilerName.SetFormat(u8"⚠ {} (incompatible)", ezCppProject::CompilerToString(preferences->m_CompilerPreferences.m_Compiler));
     s_MachineSpecificCompilers.PushBack(
       {incompatibleCompilerName,
         preferences->m_CompilerPreferences.m_Compiler,

--- a/Code/Editor/EditorFramework/EditorApp/Documents.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Documents.cpp
@@ -22,7 +22,7 @@ ezDocument* ezQtEditorApp::OpenDocument(ezStringView sDocument, ezBitflags<ezDoc
   if (ezDocumentManager::FindDocumentTypeFromPath(sDocument, false, pTypeDesc).Failed())
   {
     ezStringBuilder sTemp;
-    sTemp.Format("The selected file extension '{0}' is not registered with any known type.\nCannot open file '{1}'", ezPathUtils::GetFileExtension(sDocument), sDocument);
+    sTemp.SetFormat("The selected file extension '{0}' is not registered with any known type.\nCannot open file '{1}'", ezPathUtils::GetFileExtension(sDocument), sDocument);
     ezQtUiServices::MessageBoxWarning(sTemp);
     return nullptr;
   }
@@ -40,7 +40,7 @@ ezDocument* ezQtEditorApp::OpenDocument(ezStringView sDocument, ezBitflags<ezDoc
     if (res.m_Result.Failed())
     {
       ezStringBuilder s;
-      s.Format("Failed to open document: \n'{0}'", sDocument);
+      s.SetFormat("Failed to open document: \n'{0}'", sDocument);
       ezQtUiServices::MessageBoxStatus(res, s);
       return nullptr;
     }
@@ -50,7 +50,7 @@ ezDocument* ezQtEditorApp::OpenDocument(ezStringView sDocument, ezBitflags<ezDoc
     if (pDocument->GetUnknownObjectTypeInstances() > 0)
     {
       ezStringBuilder s;
-      s.Format("The document contained {0} objects of an unknown type. Necessary plugins may be missing.\n\n\
+      s.SetFormat("The document contained {0} objects of an unknown type. Necessary plugins may be missing.\n\n\
 If you save this document, all data for these objects is lost permanently!\n\n\
 The following types are missing:\n",
         pDocument->GetUnknownObjectTypeInstances());
@@ -85,7 +85,7 @@ ezDocument* ezQtEditorApp::CreateDocument(ezStringView sDocument, ezBitflags<ezD
     if (res.Failed())
     {
       ezStringBuilder s;
-      s.Format("Failed to create document: \n'{0}'", sDocument);
+      s.SetFormat("Failed to create document: \n'{0}'", sDocument);
       ezQtUiServices::MessageBoxStatus(res, s);
       return nullptr;
     }
@@ -97,7 +97,7 @@ ezDocument* ezQtEditorApp::CreateDocument(ezStringView sDocument, ezBitflags<ezD
     if (result.m_Result.Failed())
     {
       ezStringBuilder s;
-      s.Format("Failed to create document: \n'{0}'", sDocument);
+      s.SetFormat("Failed to create document: \n'{0}'", sDocument);
       ezQtUiServices::MessageBoxStatus(result, s);
       return nullptr;
     }

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -170,7 +170,7 @@ bool ezQtEditorApp::IsProgressBarProcessingEvents() const
 void ezQtEditorApp::OnDemandDynamicStringEnumLoad(ezStringView sEnumName, ezDynamicStringEnum& e)
 {
   ezStringBuilder sFile;
-  sFile.Format(":project/Editor/{}.txt", sEnumName);
+  sFile.SetFormat(":project/Editor/{}.txt", sEnumName);
 
   // enums loaded this way are user editable
   e.SetStorageFile(sFile);
@@ -383,7 +383,7 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
 
     ezLog::Success("Cloned remote project '{}' from '{}' to '{}'", sName, sUrl, sTargetDir);
 
-    inout_sFilePath.Format("{}/{}/{}", sTargetDir, sName, sProjectFile);
+    inout_sFilePath.SetFormat("{}/{}/{}", sTargetDir, sName, sProjectFile);
 
     // write redirection file
     {

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -192,7 +192,7 @@ ezResult ezQtEditorApp::CreateOrOpenProject(bool bCreate, ezStringView sFile0)
   if (res.m_Result.Failed())
   {
     ezStringBuilder s;
-    s.Format("Failed to open project:\n'{0}'", sProjectFile);
+    s.SetFormat("Failed to open project:\n'{0}'", sProjectFile);
 
     ezQtUiServices::MessageBoxStatus(res, s);
     return EZ_FAILURE;

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -304,7 +304,7 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
     EZ_PROFILE_SCOPE("Logging");
     ezInt32 iApplicationID = pCmd->GetIntOption("-appid", 0);
     ezStringBuilder sLogFile;
-    sLogFile.Format(":appdata/Log_{0}.htm", iApplicationID);
+    sLogFile.SetFormat(":appdata/Log_{0}.htm", iApplicationID);
     m_LogHTML.BeginLog(sLogFile, sApplicationName);
 
     ezGlobalLog::AddLogWriter(ezLogWriter::Console::LogMessageHandler);

--- a/Code/Editor/EditorFramework/EditorApp/UserMessaging.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/UserMessaging.cpp
@@ -11,7 +11,7 @@ void ezQtEditorApp::AddRestartRequiredReason(const char* szReason)
   }
 
   ezStringBuilder s;
-  s.Format("The editor process must be restarted.\nReason: '{0}'\n\nDo you want to restart now?", szReason);
+  s.SetFormat("The editor process must be restarted.\nReason: '{0}'\n\nDo you want to restart now?", szReason);
 
   if (ezQtUiServices::MessageBoxQuestion(s, QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::Yes) == QMessageBox::StandardButton::Yes)
   {
@@ -32,7 +32,7 @@ void ezQtEditorApp::AddReloadProjectRequiredReason(const char* szReason)
     m_ReloadProjectRequiredReasons.Insert(szReason);
 
     ezStringBuilder s;
-    s.Format("The project must be reloaded.\nReason: '{0}'", szReason);
+    s.SetFormat("The project must be reloaded.\nReason: '{0}'", szReason);
 
     ezQtUiServices::MessageBoxInformation(s);
 

--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
@@ -94,7 +94,7 @@ const ezRTTI* ezExposedParametersTypeRegistry::GetExposedParametersType(const ch
 void ezExposedParametersTypeRegistry::UpdateExposedParametersType(ParamData& data, const ezExposedParameters& params)
 {
   ezStringBuilder name;
-  name.Format("ezExposedParameters_{0}", data.m_SubAssetGuid);
+  name.SetFormat("ezExposedParameters_{0}", data.m_SubAssetGuid);
   EZ_LOG_BLOCK("Updating Type", name.GetData());
   ezReflectedTypeDescriptor desc;
   desc.m_sTypeName = name;

--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
@@ -22,7 +22,7 @@ ezResult ezEditorProcessCommunicationChannel::StartClientProcess(
   ezTime time = ezTime::Now();
   uiUniqueHash = ezHashingUtils::xxHash64(&time, sizeof(time), uiUniqueHash);
   ezStringBuilder sMemName;
-  sMemName.Format("{0}", ezArgU(uiUniqueHash, 16, false, 16, true));
+  sMemName.SetFormat("{0}", ezArgU(uiUniqueHash, 16, false, 16, true));
   ++uiUniqueHash;
 
   if (bRemote)

--- a/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
@@ -73,7 +73,7 @@ void ezQtCuratorControl::paintEvent(QPaintEvent* e)
   }
 
   ezStringBuilder s;
-  s.Format("[Un: {0}, Imp: {4}, Tr: {1}, Th: {2}, Err: {3}]", sections[ezAssetInfo::TransformState::Unknown],
+  s.SetFormat("[Un: {0}, Imp: {4}, Tr: {1}, Th: {2}, Err: {3}]", sections[ezAssetInfo::TransformState::Unknown],
     sections[ezAssetInfo::TransformState::NeedsTransform], sections[ezAssetInfo::TransformState::NeedsThumbnail],
     sections[ezAssetInfo::TransformState::MissingTransformDependency] + sections[ezAssetInfo::TransformState::MissingThumbnailDependency] +
       sections[ezAssetInfo::TransformState::TransformError] + sections[ezAssetInfo::TransformState::CircularDependency],
@@ -136,7 +136,7 @@ void ezQtCuratorControl::SlotUpdateTransformStats()
 
   if (uiNumAssets > 0)
   {
-    s.Format("Unknown: {0}\nImport Needed: {1}\nTransform Needed: {2}\nThumbnail Needed: {3}\nMissing Dependency: {4}\nMissing Reference: {5}\nCircular Dependency: {6}\nFailed Transform: {7}",
+    s.SetFormat("Unknown: {0}\nImport Needed: {1}\nTransform Needed: {2}\nThumbnail Needed: {3}\nMissing Dependency: {4}\nMissing Reference: {5}\nCircular Dependency: {6}\nFailed Transform: {7}",
       sections[ezAssetInfo::TransformState::Unknown],
       sections[ezAssetInfo::TransformState::NeedsImport],
       sections[ezAssetInfo::TransformState::NeedsTransform],

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -170,7 +170,7 @@ void ezQtAssetCuratorPanel::UpdateIssueInfo()
       ezUInt64 uiHigh;
       guid.GetValues(uiLow, uiHigh);
       ezStringBuilder sTmp;
-      sTmp.Format("{} - u4{{},{}}", sDep, uiLow, uiHigh);
+      sTmp.SetFormat("{} - u4{{},{}}", sDep, uiLow, uiHigh);
 
       return sTmp;
     }

--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -186,7 +186,7 @@ ezResult ezProjectExport::CreateExportFilterFile(const char* szExpectedFile, con
 ezResult ezProjectExport::ReadExportFilters(ezPathPatternFilter& out_DataFilter, ezPathPatternFilter& out_BinariesFilter, const ezPlatformProfile* pPlatformProfile)
 {
   ezStringBuilder sDefine;
-  sDefine.Format("PLATFORM_PROFILE_{} 1", pPlatformProfile->GetConfigName());
+  sDefine.SetFormat("PLATFORM_PROFILE_{} 1", pPlatformProfile->GetConfigName());
   sDefine.ToUpper();
 
   ezHybridArray<ezString, 1> ppDefines;
@@ -303,7 +303,7 @@ ezResult ezProjectExport::ScanDataDirectories(DirectoryMapping& mapping, const e
     }
     else
     {
-      sDstPath.Format("Data/Extra{}", uiDataDirNumber);
+      sDstPath.SetFormat("Data/Extra{}", uiDataDirNumber);
       ++uiDataDirNumber;
 
       ddInfo.m_sTargetDirPath = sDstPath;
@@ -361,10 +361,10 @@ ezResult ezProjectExport::CreateLaunchConfig(const ezDynamicArray<ezString>& sce
   for (const auto& sf : sceneFiles)
   {
     ezStringBuilder cmd;
-    cmd.Format("start Bin/Player.exe -project \"Data/project\" -scene \"{}\"", sf);
+    cmd.SetFormat("start Bin/Player.exe -project \"Data/project\" -scene \"{}\"", sf);
 
     ezStringBuilder bat;
-    bat.Format("{}/Launch {}.bat", szTargetDirectory, ezPathUtils::GetFileName(sf));
+    bat.SetFormat("{}/Launch {}.bat", szTargetDirectory, ezPathUtils::GetFileName(sf));
 
     ezOSFile file;
     if (file.Open(bat, ezFileOpenMode::Write).Failed())

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphQt.cpp
@@ -75,7 +75,7 @@ void ezQtAnimationGraphNode::UpdateState()
         if (val.IsValid())
         {
 
-          tmp.Format("{}", val);
+          tmp.SetFormat("{}", val);
 
           if (ezConversionUtils::IsStringUuid(tmp))
           {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -107,7 +107,7 @@ ezTransformStatus ezDecalAssetDocument::InternalCreateThumbnail(const ThumbnailI
   {
     ezQtEditorApp* pEditorApp = ezQtEditorApp::GetSingleton();
 
-    temp.Format("-in0");
+    temp.SetFormat("-in0");
 
     ezStringBuilder sAbsPath = pProp->m_sBaseColor;
     if (!pEditorApp->MakeDataDirectoryRelativePathAbsolute(sAbsPath))

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -306,11 +306,11 @@ ezStatus ezDecalAssetDocumentManager::RunTexConv(const char* szTargetFile, const
     const ezUInt32 uiHashLow32 = uiHash64 & 0xFFFFFFFF;
     const ezUInt32 uiHashHigh32 = (uiHash64 >> 32) & 0xFFFFFFFF;
 
-    temp.Format("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
     arguments << "-assetHashLow";
     arguments << temp.GetData();
 
-    temp.Format("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
     arguments << "-assetHashHigh";
     arguments << temp.GetData();
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/ShaderTemplateDlg.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/ShaderTemplateDlg.cpp
@@ -155,13 +155,13 @@ void ezQtShaderTemplateDlg::on_Buttons_accepted()
       ezStringBuilder tmp;
       for (const auto& ed : enumDef.m_Values)
       {
-        tmp.Format("{} {}", ed.m_sValueName, ed.m_iValueValue);
+        tmp.SetFormat("{} {}", ed.m_sValueName, ed.m_iValueValue);
         pp.AddCustomDefine(tmp).IgnoreResult();
       }
 
       if (auto pWidget = qobject_cast<QComboBox*>(pTable->cellWidget(row, 1)))
       {
-        tmp.Format("{} {}", enumDef.m_sName, enumDef.m_Values[pWidget->currentIndex()].m_iValueValue);
+        tmp.SetFormat("{} {}", enumDef.m_sName, enumDef.m_Values[pWidget->currentIndex()].m_iValueValue);
         pp.AddCustomDefine(tmp).IgnoreResult();
       }
     }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.cpp
@@ -57,11 +57,11 @@ ezStatus ezImageDataAssetDocument::RunTexConv(const char* szTargetFile, const ez
     const ezUInt32 uiHashLow32 = uiHash64 & 0xFFFFFFFF;
     const ezUInt32 uiHashHigh32 = (uiHash64 >> 32) & 0xFFFFFFFF;
 
-    temp.Format("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
     arguments << "-assetHashLow";
     arguments << temp.GetData();
 
-    temp.Format("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
     arguments << "-assetHashHigh";
     arguments << temp.GetData();
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -37,7 +37,7 @@ namespace
       ezReflectionUtils::GetEnumKeysAndValues(pProp->GetSpecificType(), enumValues, ezReflectionUtils::EnumConversionMode::ValueNameOnly);
       for (auto& enumValue : enumValues)
       {
-        sDefine.Format("{} {}", enumValue.m_sKey, enumValue.m_iValue);
+        sDefine.SetFormat("{} {}", enumValue.m_sKey, enumValue.m_iValue);
         EZ_SUCCEED_OR_RETURN(inout_pp.AddCustomDefine(sDefine));
 
         if (enumValue.m_iValue == iValue)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -56,7 +56,7 @@ bool ezMaterialAssetDocumentManager::IsOutputUpToDate(ezStringView sDocumentPath
     const ezString sTargetFile = GetAbsoluteOutputFileName(pTypeDescriptor, sDocumentPath, sOutputTag);
 
     ezStringBuilder sExpectedHeader;
-    sExpectedHeader.Format("//{0}|{1}\n", uiHash, pTypeDescriptor->m_pDocumentType->GetTypeVersion());
+    sExpectedHeader.SetFormat("//{0}|{1}\n", uiHash, pTypeDescriptor->m_pDocumentType->GetTypeVersion());
 
     ezFileReader file;
     if (file.Open(sTargetFile, 256).Failed())

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -274,7 +274,7 @@ void ezQtMaterialAssetDocumentWindow::OnOpenShaderClicked(bool)
   else
   {
     ezStringBuilder msg;
-    msg.Format("The auto generated file does not exist (yet).\nThe supposed location is '{0}'", sAutoGenShader);
+    msg.SetFormat("The auto generated file does not exist (yet).\nThe supposed location is '{0}'", sAutoGenShader);
 
     ezQtUiServices::GetSingleton()->MessageBoxInformation(msg);
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -56,7 +56,7 @@ namespace
     }
 
     ezStringBuilder sTemp;
-    sTemp.Format("Shaders/PermutationVars/{0}.ezPermVar", def.m_sName);
+    sTemp.SetFormat("Shaders/PermutationVars/{0}.ezPermVar", def.m_sName);
 
     ezString sPath = sTemp;
     ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sPath);
@@ -94,14 +94,14 @@ namespace
         ezArrayPtr<ezPropertyAttribute* const> noAttributes;
 
         ezStringBuilder sEnumName;
-        sEnumName.Format("{0}::Default", def.m_sName);
+        sEnumName.SetFormat("{0}::Default", def.m_sName);
 
         descEnum.m_Properties.PushBack(ezReflectedPropertyDescriptor(sEnumName, defaultValue.Get<ezUInt32>(), noAttributes));
 
         for (const auto& ev : enumDefinition.m_Values)
         {
           ezStringBuilder sEnumName;
-          sEnumName.Format("{0}::{1}", def.m_sName, ev.m_sValueName);
+          sEnumName.SetFormat("{0}::{1}", def.m_sName, ev.m_sValueName);
 
           descEnum.m_Properties.PushBack(ezReflectedPropertyDescriptor(sEnumName, ev.m_iValueValue, noAttributes));
         }
@@ -133,14 +133,14 @@ namespace
     ezArrayPtr<ezPropertyAttribute* const> noAttributes;
 
     ezStringBuilder sEnumName;
-    sEnumName.Format("{0}::Default", def.m_sName);
+    sEnumName.SetFormat("{0}::Default", def.m_sName);
 
     descEnum.m_Properties.PushBack(ezReflectedPropertyDescriptor(sEnumName, def.m_uiDefaultValue, noAttributes));
 
     for (const auto& ev : def.m_Values)
     {
       ezStringBuilder sEnumName;
-      sEnumName.Format("{0}::{1}", def.m_sName, ev.m_sValueName);
+      sEnumName.SetFormat("{0}::{1}", def.m_sName, ev.m_sValueName);
 
       descEnum.m_Properties.PushBack(ezReflectedPropertyDescriptor(sEnumName, ev.m_iValueValue, noAttributes));
     }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -152,11 +152,11 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
     const ezUInt32 uiHashLow32 = uiHash64 & 0xFFFFFFFF;
     const ezUInt32 uiHashHigh32 = (uiHash64 >> 32) & 0xFFFFFFFF;
 
-    temp.Format("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
     arguments << "-assetHashLow";
     arguments << temp.GetData();
 
-    temp.Format("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
     arguments << "-assetHashHigh";
     arguments << temp.GetData();
   }
@@ -218,14 +218,14 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
   {
     arguments << "-mipsPreserveCoverage";
     arguments << "-mipsAlphaThreshold";
-    temp.Format("{0}", ezArgF(pProp->m_fAlphaThreshold, 2));
+    temp.SetFormat("{0}", ezArgF(pProp->m_fAlphaThreshold, 2));
     arguments << temp.GetData();
   }
 
   if (pProp->m_TextureUsage == ezTexConvUsage::Hdr)
   {
     arguments << "-hdrExposure";
-    temp.Format("{0}", ezArgF(pProp->m_fHdrExposureBias, 2));
+    temp.SetFormat("{0}", ezArgF(pProp->m_fHdrExposureBias, 2));
     arguments << temp.GetData();
   }
 
@@ -239,7 +239,7 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
   const ezInt32 iNumInputFiles = pProp->GetNumInputFiles();
   for (ezInt32 i = 0; i < iNumInputFiles; ++i)
   {
-    temp.Format("-in{0}", i);
+    temp.SetFormat("-in{0}", i);
 
     if (ezStringUtils::IsNullOrEmpty(pProp->GetInputFile(i)))
       break;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -42,11 +42,11 @@ ezStatus ezTextureCubeAssetDocument::RunTexConv(const char* szTargetFile, const 
     const ezUInt32 uiHashLow32 = uiHash64 & 0xFFFFFFFF;
     const ezUInt32 uiHashHigh32 = (uiHash64 >> 32) & 0xFFFFFFFF;
 
-    temp.Format("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
     arguments << "-assetHashLow";
     arguments << temp.GetData();
 
-    temp.Format("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
     arguments << "-assetHashHigh";
     arguments << temp.GetData();
   }
@@ -72,7 +72,7 @@ ezStatus ezTextureCubeAssetDocument::RunTexConv(const char* szTargetFile, const 
   if (pProp->m_TextureUsage == ezTexConvUsage::Hdr)
   {
     arguments << "-hdrExposure";
-    temp.Format("{0}", ezArgF(pProp->m_fHdrExposureBias, 2));
+    temp.SetFormat("{0}", ezArgF(pProp->m_fHdrExposureBias, 2));
     arguments << temp.GetData();
   }
 
@@ -145,7 +145,7 @@ ezStatus ezTextureCubeAssetDocument::RunTexConv(const char* szTargetFile, const 
     if (ezStringUtils::IsNullOrEmpty(pProp->GetInputFile(i)))
       break;
 
-    temp.Format("-in{0}", i);
+    temp.SetFormat("-in{0}", i);
     arguments << temp.GetData();
     arguments << QString(pProp->GetAbsoluteInputFilePath(i).GetData());
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
@@ -18,28 +18,28 @@ static ezString ToShaderString(const ezVariant& value)
     case ezVariantType::ColorGamma:
     {
       ezColor v = value.ConvertTo<ezColor>();
-      temp.Format("float4({0}, {1}, {2}, {3})", v.r, v.g, v.b, v.a);
+      temp.SetFormat("float4({0}, {1}, {2}, {3})", v.r, v.g, v.b, v.a);
     }
     break;
 
     case ezVariantType::Vector4:
     {
       ezVec4 v = value.Get<ezVec4>();
-      temp.Format("float4({0}, {1}, {2}, {3})", v.x, v.y, v.z, v.w);
+      temp.SetFormat("float4({0}, {1}, {2}, {3})", v.x, v.y, v.z, v.w);
     }
     break;
 
     case ezVariantType::Vector3:
     {
       ezVec3 v = value.Get<ezVec3>();
-      temp.Format("float3({0}, {1}, {2})", v.x, v.y, v.z);
+      temp.SetFormat("float3({0}, {1}, {2})", v.x, v.y, v.z);
     }
     break;
 
     case ezVariantType::Vector2:
     {
       ezVec2 v = value.Get<ezVec2>();
-      temp.Format("float2({0}, {1})", v.x, v.y);
+      temp.SetFormat("float2({0}, {1})", v.x, v.y);
     }
     break;
 
@@ -47,21 +47,21 @@ static ezString ToShaderString(const ezVariant& value)
     case ezVariantType::Int32:
     case ezVariantType::Bool:
     {
-      temp.Format("{0}", value);
+      temp.SetFormat("{0}", value);
     }
     break;
 
     case ezVariantType::Time:
     {
       float v = value.Get<ezTime>().GetSeconds();
-      temp.Format("{0}", v);
+      temp.SetFormat("{0}", v);
     }
     break;
 
     case ezVariantType::Angle:
     {
       float v = value.Get<ezAngle>().GetRadian();
-      temp.Format("{0}", v);
+      temp.SetFormat("{0}", v);
     }
     break;
 
@@ -330,7 +330,7 @@ ezStatus ezVisualShaderCodeGenerator::ReplaceInputPinsByCode(
   {
     const ezUInt32 i = i0 - 1;
 
-    sPinName.Format("$in{0}", i);
+    sPinName.SetFormat("$in{0}", i);
 
     auto connections = m_pNodeManager->GetConnections(*inputPins[i]);
     if (connections.IsEmpty())
@@ -385,7 +385,7 @@ void ezVisualShaderCodeGenerator::SetPinDefines(const ezDocumentObject* pOwnerNo
 
     for (ezUInt32 i = 0; i < pins.GetCount(); ++i)
     {
-      sDefineName.Format("INPUT_PIN_{0}_CONNECTED", i);
+      sDefineName.SetFormat("INPUT_PIN_{0}_CONNECTED", i);
 
       if (m_pNodeManager->HasConnections(*pins[i]) == false)
       {
@@ -403,7 +403,7 @@ void ezVisualShaderCodeGenerator::SetPinDefines(const ezDocumentObject* pOwnerNo
 
     for (ezUInt32 i = 0; i < pins.GetCount(); ++i)
     {
-      sDefineName.Format("OUTPUT_PIN_{0}_CONNECTED", i);
+      sDefineName.SetFormat("OUTPUT_PIN_{0}_CONNECTED", i);
 
       if (m_pNodeManager->HasConnections(*pins[i]) == false)
       {
@@ -479,7 +479,7 @@ ezStatus ezVisualShaderCodeGenerator::InsertPropertyValues(
   {
     const ezUInt32 p = p0 - 1;
 
-    sPropName.Format("$prop{0}", p);
+    sPropName.SetFormat("$prop{0}", p);
 
     const ezVariant value = TypeAccess.GetValue(props[p].m_sName);
     sPropValue = ToShaderString(value);

--- a/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.cpp
+++ b/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.cpp
@@ -510,7 +510,7 @@ void ezQtFileserveWidget::UpdateClientList()
   {
     QTreeWidgetItem* pClient = new QTreeWidgetItem();
 
-    sName.Format("Client: {0}", it.Key());
+    sName.SetFormat("Client: {0}", it.Key());
     pClient->setText(0, sName.GetData());
     pClient->setText(1, it.Value().m_bConnected ? "connected" : "disconnected");
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/Dialogs/FmodProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/Dialogs/FmodProjectSettingsDlg.cpp
@@ -33,7 +33,7 @@ ezResult ezQtFmodProjectSettingsDlg::Save()
   if (m_Configs.Save().Failed())
   {
     ezStringBuilder sError;
-    sError.Format("Failed to save the Fmod configuration file\n'{0}'", ezFmodAssetProfiles::s_sConfigFile);
+    sError.SetFormat("Failed to save the Fmod configuration file\n'{0}'", ezFmodAssetProfiles::s_sConfigFile);
 
     ezQtUiServices::GetSingleton()->MessageBoxWarning(sError);
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.cpp
@@ -68,7 +68,7 @@ void ezSoundBankAssetDocumentWindow::UpdatePreview()
   const auto& prop = ((ezSoundBankAssetDocument*)GetDocument())->GetProperties();
 
   // ezStringBuilder s;
-  // s.Format("Vertices: {0}\nTriangles: {1}\nSubMeshes: {2}", prop->m_uiVertices, prop->m_uiTriangles, prop->m_SlotNames.GetCount());
+  // s.SetFormat("Vertices: {0}\nTriangles: {1}\nSubMeshes: {2}", prop->m_uiVertices, prop->m_uiTriangles, prop->m_SlotNames.GetCount());
 
   // for (ezUInt32 m = 0; m < prop->m_SlotNames.GetCount(); ++m)
   //  s.AppendFormat("\nSlot {0}: {1}", m, prop->m_SlotNames[m]);

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetWindow.moc.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetWindow.moc.cpp
@@ -72,7 +72,7 @@ void ezSoundEventAssetDocumentWindow::UpdatePreview()
   const auto& prop = ((ezSoundEventAssetDocument*)GetDocument())->GetProperties();
 
   // ezStringBuilder s;
-  // s.Format("Vertices: {0}\nTriangles: {1}\nSubMeshes: {2}", prop->m_uiVertices, prop->m_uiTriangles, prop->m_SlotNames.GetCount());
+  // s.SetFormat("Vertices: {0}\nTriangles: {1}\nSubMeshes: {2}", prop->m_uiVertices, prop->m_uiTriangles, prop->m_SlotNames.GetCount());
 
   // for (ezUInt32 m = 0; m < prop->m_SlotNames.GetCount(); ++m)
   //  s.AppendFormat("\nSlot {0}: {1}", m, prop->m_SlotNames[m]);

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
@@ -155,7 +155,7 @@ ezResult ezQtJoltProjectSettingsDlg::Save()
   if (m_Config.Save().Failed())
   {
     ezStringBuilder sError;
-    sError.Format("Failed to save the Collision Layer file\n'{0}'", ezCollisionFilterConfig::s_sConfigFile);
+    sError.SetFormat("Failed to save the Collision Layer file\n'{0}'", ezCollisionFilterConfig::s_sConfigFile);
 
     ezQtUiServices::GetSingleton()->MessageBoxWarning(sError);
 

--- a/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.cpp
+++ b/Code/EditorPlugins/Jolt/EnginePluginJolt/SceneExport/JoltStaticMeshConversion.cpp
@@ -94,7 +94,7 @@ void ezSceneExportModifier_JoltStaticMeshConversion::ModifyWorld(ezWorld& ref_wo
   ezStringBuilder sDocGuid, sOutputFile;
   ezConversionUtils::ToString(documentGuid, sDocGuid);
 
-  sOutputFile.Format(":project/AssetCache/Generated/{0}.ezJoltMesh", sDocGuid);
+  sOutputFile.SetFormat(":project/AssetCache/Generated/{0}.ezJoltMesh", sDocGuid);
 
   ezDeferredFileWriter file;
   file.SetOutput(sOutputFile);

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
@@ -37,25 +37,25 @@ static void GetMaterialLabel(ezStringBuilder& ref_sOut, ezKrautBranchType branch
     case ezKrautBranchType::Trunk1:
     case ezKrautBranchType::Trunk2:
     case ezKrautBranchType::Trunk3:
-      ref_sOut.Format("Trunk {}", (int)branchType - (int)ezKrautBranchType::Trunk1 + 1);
+      ref_sOut.SetFormat("Trunk {}", (int)branchType - (int)ezKrautBranchType::Trunk1 + 1);
       break;
 
     case ezKrautBranchType::MainBranches1:
     case ezKrautBranchType::MainBranches2:
     case ezKrautBranchType::MainBranches3:
-      ref_sOut.Format("Branch {}", (int)branchType - (int)ezKrautBranchType::MainBranches1 + 1);
+      ref_sOut.SetFormat("Branch {}", (int)branchType - (int)ezKrautBranchType::MainBranches1 + 1);
       break;
 
     case ezKrautBranchType::SubBranches1:
     case ezKrautBranchType::SubBranches2:
     case ezKrautBranchType::SubBranches3:
-      ref_sOut.Format("Twig {}", (int)branchType - (int)ezKrautBranchType::SubBranches1 + 1);
+      ref_sOut.SetFormat("Twig {}", (int)branchType - (int)ezKrautBranchType::SubBranches1 + 1);
       break;
 
     case ezKrautBranchType::Twigs1:
     case ezKrautBranchType::Twigs2:
     case ezKrautBranchType::Twigs3:
-      ref_sOut.Format("Twigy {}", (int)branchType - (int)ezKrautBranchType::Twigs1 + 1);
+      ref_sOut.SetFormat("Twigy {}", (int)branchType - (int)ezKrautBranchType::Twigs1 + 1);
       break;
 
       EZ_DEFAULT_CASE_NOT_IMPLEMENTED;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -18,7 +18,7 @@ namespace
     ast.PrintGraph(dgmlGraph);
 
     ezStringBuilder sFileName;
-    sFileName.Format(":appdata/{0}_{1}_AST.dgml", sAssetName, sOutputName);
+    sFileName.SetFormat(":appdata/{0}_{1}_AST.dgml", sAssetName, sOutputName);
 
     ezDGMLGraphWriter dgmlGraphWriter;
     EZ_IGNORE_UNUSED(dgmlGraphWriter);
@@ -502,7 +502,7 @@ void ezProcGenGraphAssetDocument::DumpSelectedOutput(bool bAst, bool bDisassembl
     byteCode.Disassemble(sDisassembly);
 
     ezStringBuilder sFileName;
-    sFileName.Format(":appdata/{0}_{1}_ByteCode.txt", sAssetName, sOutputName);
+    sFileName.SetFormat(":appdata/{0}_{1}_ByteCode.txt", sAssetName, sOutputName);
 
     ezFileWriter fileWriter;
     if (fileWriter.Open(sFileName).Succeeded())

--- a/Code/EditorPlugins/Recast/EditorPluginRecast/NavMesh/NavMeshProxyOp.cpp
+++ b/Code/EditorPlugins/Recast/EditorPluginRecast/NavMesh/NavMeshProxyOp.cpp
@@ -22,7 +22,7 @@ void ezLongOpProxy_BuildNavMesh::GetReplicationInfo(ezStringBuilder& out_sReplic
     ezStringBuilder sComponentGuid, sOutputFile;
     ezConversionUtils::ToString(m_ComponentGuid, sComponentGuid);
 
-    sOutputFile.Format(":project/AssetCache/Generated/{0}.ezRecastNavMesh", sComponentGuid);
+    sOutputFile.SetFormat(":project/AssetCache/Generated/{0}.ezRecastNavMesh", sComponentGuid);
 
     ref_description << sOutputFile;
   }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/LayerActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/LayerActions.cpp
@@ -128,7 +128,7 @@ void ezLayerAction::ToggleLayerLoaded(ezScene2Document* pSceneDocument, ezUuid l
           sLayerName = subAsset->GetName();
         }
       }
-      sMsg.Format("The layer '{}' has been modified.\nSave before unloading?", sLayerName);
+      sMsg.SetFormat("The layer '{}' has been modified.\nSave before unloading?", sLayerName);
       QMessageBox::StandardButton res = ezQtUiServices::MessageBoxQuestion(sMsg, QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No | QMessageBox::StandardButton::Cancel, QMessageBox::StandardButton::No);
       switch (res)
       {

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Baking/BakeSceneProxyOp.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Baking/BakeSceneProxyOp.cpp
@@ -19,7 +19,7 @@ void ezLongOpProxy_BakeScene::GetReplicationInfo(ezStringBuilder& out_sReplicati
   out_sReplicationOpType = "ezLongOpWorker_BakeScene";
 
   ezStringBuilder sOutputPath;
-  sOutputPath.Format(":project/AssetCache/Generated/{0}", m_ComponentGuid);
+  sOutputPath.SetFormat(":project/AssetCache/Generated/{0}", m_ComponentGuid);
   ref_description << sOutputPath;
 }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.cpp
@@ -83,14 +83,14 @@ void ezQtDeltaTransformDlg::on_ButtonApply_clicked()
       if (s_vTranslate == ezVec3(0.0f))
         return;
 
-      sAction.Format("Translate: {0} | {1} | {2}", ezArgF(s_vTranslate.x, 2), ezArgF(s_vTranslate.y, 2), ezArgF(s_vTranslate.z, 2));
+      sAction.SetFormat("Translate: {0} | {1} | {2}", ezArgF(s_vTranslate.x, 2), ezArgF(s_vTranslate.y, 2), ezArgF(s_vTranslate.z, 2));
       break;
 
     case Mode::TranslateDeviation:
       if (s_vTranslateDeviation == ezVec3(0.0f))
         return;
 
-      sAction.Format("Translate (deviation): {0} | {1} | {2}", ezArgF(s_vTranslateDeviation.x, 2), ezArgF(s_vTranslateDeviation.y, 2),
+      sAction.SetFormat("Translate (deviation): {0} | {1} | {2}", ezArgF(s_vTranslateDeviation.x, 2), ezArgF(s_vTranslateDeviation.y, 2),
         ezArgF(s_vTranslateDeviation.z, 2));
       break;
 
@@ -98,77 +98,77 @@ void ezQtDeltaTransformDlg::on_ButtonApply_clicked()
       if (s_vRotate.x == 0.0f)
         return;
 
-      sAction.Format("Rotate X: {0}", ezArgF(s_vRotate.x, 1));
+      sAction.SetFormat("Rotate X: {0}", ezArgF(s_vRotate.x, 1));
       break;
 
     case Mode::RotateXRandom:
       if (s_vRotateRandom.x == 0.0f)
         return;
 
-      sAction.Format("Rotate X (random): {0}", ezArgF(s_vRotateRandom.x, 1));
+      sAction.SetFormat("Rotate X (random): {0}", ezArgF(s_vRotateRandom.x, 1));
       break;
 
     case Mode::RotateXDeviation:
       if (s_vRotateDeviation.x == 0.0f)
         return;
 
-      sAction.Format("Rotate X (deviation): {0}", ezArgF(s_vRotateDeviation.x, 1));
+      sAction.SetFormat("Rotate X (deviation): {0}", ezArgF(s_vRotateDeviation.x, 1));
       break;
 
     case Mode::RotateY:
       if (s_vRotate.y == 0.0f)
         return;
 
-      sAction.Format("Rotate Y: {0}", ezArgF(s_vRotate.y, 1));
+      sAction.SetFormat("Rotate Y: {0}", ezArgF(s_vRotate.y, 1));
       break;
 
     case Mode::RotateYRandom:
       if (s_vRotateRandom.y == 0.0f)
         return;
 
-      sAction.Format("Rotate Y (random): {0}", ezArgF(s_vRotateRandom.y, 1));
+      sAction.SetFormat("Rotate Y (random): {0}", ezArgF(s_vRotateRandom.y, 1));
       break;
 
     case Mode::RotateYDeviation:
       if (s_vRotateDeviation.y == 0.0f)
         return;
 
-      sAction.Format("Rotate Y (deviation): {0}", ezArgF(s_vRotateDeviation.y, 1));
+      sAction.SetFormat("Rotate Y (deviation): {0}", ezArgF(s_vRotateDeviation.y, 1));
       break;
 
     case Mode::RotateZ:
       if (s_vRotate.z == 0.0f)
         return;
 
-      sAction.Format("Rotate Z: {0}", ezArgF(s_vRotate.z, 1));
+      sAction.SetFormat("Rotate Z: {0}", ezArgF(s_vRotate.z, 1));
       break;
 
     case Mode::RotateZRandom:
       if (s_vRotateRandom.z == 0.0f)
         return;
 
-      sAction.Format("Rotate Z (random): {0}", ezArgF(s_vRotateRandom.z, 1));
+      sAction.SetFormat("Rotate Z (random): {0}", ezArgF(s_vRotateRandom.z, 1));
       break;
 
     case Mode::RotateZDeviation:
       if (s_vRotateDeviation.z == 0.0f)
         return;
 
-      sAction.Format("Rotate Z (deviation): {0}", ezArgF(s_vRotateDeviation.z, 1));
+      sAction.SetFormat("Rotate Z (deviation): {0}", ezArgF(s_vRotateDeviation.z, 1));
       break;
 
     case Mode::Scale:
       if (s_vScale == ezVec3(1.0f))
         return;
 
-      sAction.Format("Scale: {0} | {1} | {2}", ezArgF(s_vScale.x, 2), ezArgF(s_vScale.y, 2), ezArgF(s_vScale.z, 2));
+      sAction.SetFormat("Scale: {0} | {1} | {2}", ezArgF(s_vScale.x, 2), ezArgF(s_vScale.y, 2), ezArgF(s_vScale.z, 2));
       break;
 
     case Mode::ScaleDeviation:
       if (s_vScaleDeviation == ezVec3(1.0f))
         return;
 
-      sAction.Format(
+      sAction.SetFormat(
         "Scale (deviation): {0} | {1} | {2}", ezArgF(s_vScaleDeviation.x, 2), ezArgF(s_vScaleDeviation.y, 2), ezArgF(s_vScaleDeviation.z, 2));
       break;
 
@@ -176,18 +176,18 @@ void ezQtDeltaTransformDlg::on_ButtonApply_clicked()
       if (s_fUniformScale == 1.0f)
         return;
 
-      sAction.Format("Scale: {0}", ezArgF(s_fUniformScale, 2));
+      sAction.SetFormat("Scale: {0}", ezArgF(s_fUniformScale, 2));
       break;
 
     case Mode::UniformScaleDeviation:
       if (s_fUniformScaleDeviation == 1.0f)
         return;
 
-      sAction.Format("Scale (deviation): {0}", ezArgF(s_fUniformScaleDeviation, 2));
+      sAction.SetFormat("Scale (deviation): {0}", ezArgF(s_fUniformScaleDeviation, 2));
       break;
 
     case Mode::NaturalDeviationZ:
-      sAction.Format("Natural Deviation Z: {0}", ezArgF(s_fNaturalDeviationZ, 1));
+      sAction.SetFormat("Natural Deviation Z: {0}", ezArgF(s_fNaturalDeviationZ, 1));
       break;
   }
 

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/LayerContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/LayerContext.cpp
@@ -80,7 +80,7 @@ void ezLayerContext::OnInitialize()
 
   ezUInt32 uiLayerID = m_pParentSceneContext->RegisterLayer(this);
   ezStringBuilder sVisibilityTag;
-  sVisibilityTag.Format("Layer_{}", uiLayerID);
+  sVisibilityTag.SetFormat("Layer_{}", uiLayerID);
   m_LayerTag = ezTagRegistry::GetGlobalRegistry().RegisterTag(sVisibilityTag);
 
   ezShadowPool::AddExcludeTagToWhiteList(m_LayerTag);

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -414,7 +414,7 @@ namespace
     arguments << "--output-path";
     arguments << szOutputPath;
 
-    sTmp.Format("$outputsize@{},{}", uiOutputWidth, uiOutputHeight);
+    sTmp.SetFormat("$outputsize@{},{}", uiOutputWidth, uiOutputHeight);
     arguments << "--set-value";
     arguments << sTmp.GetData();
 
@@ -773,11 +773,11 @@ ezStatus ezSubstancePackageAssetDocument::RunTexConv(const char* szInputFile, co
     const ezUInt32 uiHashLow32 = uiHash64 & 0xFFFFFFFF;
     const ezUInt32 uiHashHigh32 = (uiHash64 >> 32) & 0xFFFFFFFF;
 
-    temp.Format("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashLow32, 8, true, 16, true));
     arguments << "-assetHashLow";
     arguments << temp.GetData();
 
-    temp.Format("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
+    temp.SetFormat("{0}", ezArgU(uiHashHigh32, 8, true, 16, true));
     arguments << "-assetHashHigh";
     arguments << temp.GetData();
   }

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAsset.cpp
@@ -149,7 +149,7 @@ ezResult ezTypeScriptAssetDocument::CreateTsConfigFile(const char* szDirectory)
     sTmp.AppendWithSeparator(", ", "\"", path, "\"");
   }
 
-  sTsConfig.Format(
+  sTsConfig.SetFormat(
     R"({
   "compilerOptions": {
     "target": "es5",

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/TypeScriptAsset/TypeScriptAssetManager.cpp
@@ -181,7 +181,7 @@ void ezTypeScriptAssetDocumentManager::ModifyTsBeforeTranspilation(ezStringBuild
       uiTypeNameHash = ezHashingUtils::StringHashTo32(ezHashingUtils::StringHash(sClassName.GetData()));
     }
 
-    sAutoGen.Format("public static GetTypeNameHash(): number { return {0}; }\nconstructor() { super(); this.TypeNameHash = {0}; }\n", uiTypeNameHash);
+    sAutoGen.SetFormat("public static GetTypeNameHash(): number { return {0}; }\nconstructor() { super(); this.TypeNameHash = {0}; }\n", uiTypeNameHash);
 
     uiContinueAfterOffset = szBeginAG - content.GetData();
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.cpp
@@ -82,7 +82,7 @@ ezTransformStatus ezVisualScriptClassAssetDocument::InternalTransformAsset(ezStr
   ezStringBuilder sDumpPath;
   if (GetProperties()->m_bDumpAST)
   {
-    sDumpPath.Format(":appdata/{}_AST.dgml", sScriptClassName);
+    sDumpPath.SetFormat(":appdata/{}_AST.dgml", sScriptClassName);
   }
   EZ_SUCCEED_OR_RETURN(compiler.Compile(sDumpPath));
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
@@ -31,7 +31,7 @@ namespace
     ezVariant sNameProperty = pObject->GetTypeAccessor().GetValue("Name");
     ezUInt32 uiHash = ezHashHelper<ezUuid>::Hash(pObject->GetGuid());
 
-    out_sName.Format("{}_{}_{}", pEntryObject != nullptr ? ezVisualScriptNodeManager::GetNiceFunctionName(pEntryObject) : "", sNameProperty, ezArgU(uiHash, 8, true, 16));
+    out_sName.SetFormat("{}_{}_{}", pEntryObject != nullptr ? ezVisualScriptNodeManager::GetNiceFunctionName(pEntryObject) : "", sNameProperty, ezArgU(uiHash, 8, true, 16));
   }
 
   ezVisualScriptDataType::Enum FinalizeDataType(ezVisualScriptDataType::Enum dataType)

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -1493,7 +1493,7 @@ void ezVisualScriptNodeRegistry::CreateFunctionCallNodeType(const ezRTTI* pRtti,
     {
       sArgName = pScriptableFunctionAttribute->GetArgumentName(argIdx);
       if (sArgName.IsEmpty())
-        sArgName.Format("Arg{}", argIdx);
+        sArgName.SetFormat("Arg{}", argIdx);
 
       auto pArgRtti = pFunction->GetArgumentType(argIdx);
       auto argType = pScriptableFunctionAttribute->GetArgumentType(argIdx);
@@ -1639,7 +1639,7 @@ void ezVisualScriptNodeRegistry::CreateCoroutineNodeType(const ezRTTI* pRtti)
   {
     sArgName = pScriptableFuncAttribute->GetArgumentName(argIdx);
     if (sArgName.IsEmpty())
-      sArgName.Format("Arg{}", argIdx);
+      sArgName.SetFormat("Arg{}", argIdx);
 
     auto pArgRtti = pStartFunc->GetArgumentType(argIdx);
     auto argType = pScriptableFuncAttribute->GetArgumentType(argIdx);

--- a/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
+++ b/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
@@ -12,7 +12,7 @@ void ezCommandInterpreter::FindPossibleCVars(ezStringView sVariable, ezDeque<ezS
   {
     if (pCVar->GetName().StartsWith_NoCase(sVariable))
     {
-      sText.Format("    {0} = {1}", pCVar->GetName(), ezQuakeConsole::GetFullInfoAsString(pCVar));
+      sText.SetFormat("    {0} = {1}", pCVar->GetName(), ezQuakeConsole::GetFullInfoAsString(pCVar));
 
       ezConsoleString cs;
       cs.m_sText = sText;
@@ -35,7 +35,7 @@ void ezCommandInterpreter::FindPossibleFunctions(ezStringView sVariable, ezDeque
   {
     if (pFunc->GetName().StartsWith_NoCase(sVariable))
     {
-      sText.Format("    {0} {1}", pFunc->GetName(), pFunc->GetDescription());
+      sText.SetFormat("    {0} {1}", pFunc->GetName(), pFunc->GetDescription());
 
       ezConsoleString cs;
       cs.m_sText = sText;
@@ -59,7 +59,7 @@ const ezString ezQuakeConsole::GetValueAsString(ezCVar* pCVar)
     case ezCVarType::Int:
     {
       ezCVarInt* pInt = static_cast<ezCVarInt*>(pCVar);
-      s.Format("{0}", pInt->GetValue());
+      s.SetFormat("{0}", pInt->GetValue());
     }
     break;
 
@@ -76,14 +76,14 @@ const ezString ezQuakeConsole::GetValueAsString(ezCVar* pCVar)
     case ezCVarType::String:
     {
       ezCVarString* pString = static_cast<ezCVarString*>(pCVar);
-      s.Format("\"{0}\"", pString->GetValue());
+      s.SetFormat("\"{0}\"", pString->GetValue());
     }
     break;
 
     case ezCVarType::Float:
     {
       ezCVarFloat* pFloat = static_cast<ezCVarFloat*>(pCVar);
-      s.Format("{0}", ezArgF(pFloat->GetValue(), 3));
+      s.SetFormat("{0}", ezArgF(pFloat->GetValue(), 3));
     }
     break;
 

--- a/Code/Engine/Core/Console/Implementation/Commands.cpp
+++ b/Code/Engine/Core/Console/Implementation/Commands.cpp
@@ -37,7 +37,7 @@ void ezQuakeConsole::ExecuteCommand(ezStringView sInput)
 void ezQuakeConsole::BindKey(ezStringView sKey, ezStringView sCommand)
 {
   ezStringBuilder s;
-  s.Format("Binding key '{0}' to command '{1}'", sKey, sCommand);
+  s.SetFormat("Binding key '{0}' to command '{1}'", sKey, sCommand);
   AddConsoleString(s, ezConsoleString::Type::Success);
 
   m_BoundKeys[sKey] = sCommand;
@@ -46,7 +46,7 @@ void ezQuakeConsole::BindKey(ezStringView sKey, ezStringView sCommand)
 void ezQuakeConsole::UnbindKey(ezStringView sKey)
 {
   ezStringBuilder s;
-  s.Format("Unbinding key '{0}'", sKey);
+  s.SetFormat("Unbinding key '{0}'", sKey);
   AddConsoleString(s, ezConsoleString::Type::Success);
 
   m_BoundKeys.Remove(sKey);

--- a/Code/Engine/Core/Console/Implementation/Console.cpp
+++ b/Code/Engine/Core/Console/Implementation/Console.cpp
@@ -97,7 +97,7 @@ void ezQuakeConsole::LogHandler(const ezLoggingEventData& data)
   }
 
   ezStringBuilder sFormat;
-  sFormat.Printf("%*s", data.m_uiIndentation, "");
+  sFormat.SetPrintf("%*s", data.m_uiIndentation, "");
   sFormat.Append(data.m_sText);
 
   AddConsoleString(sFormat.GetData(), type);

--- a/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
+++ b/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
@@ -191,18 +191,18 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_state)
           inout_state.AddOutputLine("  This change takes only effect after a restart.", ezConsoleString::Type::Note);
         }
 
-        sTemp.Format("  {0} = {1}", sRealVarName, ezQuakeConsole::GetFullInfoAsString(pCVAR));
+        sTemp.SetFormat("  {0} = {1}", sRealVarName, ezQuakeConsole::GetFullInfoAsString(pCVAR));
         inout_state.AddOutputLine(sTemp, ezConsoleString::Type::Success);
       }
     }
     else
     {
-      sTemp.Format("{0} = {1}", sRealVarName, ezQuakeConsole::GetFullInfoAsString(pCVAR));
+      sTemp.SetFormat("{0} = {1}", sRealVarName, ezQuakeConsole::GetFullInfoAsString(pCVAR));
       inout_state.AddOutputLine(sTemp);
 
       if (!pCVAR->GetDescription().IsEmpty())
       {
-        sTemp.Format("  Description: {0}", pCVAR->GetDescription());
+        sTemp.SetFormat("  Description: {0}", pCVAR->GetDescription());
         inout_state.AddOutputLine(sTemp, ezConsoleString::Type::Success);
       }
       else

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -113,7 +113,7 @@ void ezGameApplicationBase::StoreScreenshot(ezImage&& image, ezStringView sConte
   pWriteTask->ConfigureTask("Write Screenshot", ezTaskNesting::Never);
   pWriteTask->m_Image.ResetAndMove(std::move(image));
 
-  pWriteTask->m_sPath.Format(":appdata/Screenshots/{0}", ezApplication::GetApplicationInstance()->GetApplicationName());
+  pWriteTask->m_sPath.SetFormat(":appdata/Screenshots/{0}", ezApplication::GetApplicationInstance()->GetApplicationName());
   AppendCurrentTimestamp(pWriteTask->m_sPath);
   pWriteTask->m_sPath.Append(sContext);
   pWriteTask->m_sPath.Append(".png");

--- a/Code/Engine/Core/Input/Implementation/InputManager.cpp
+++ b/Code/Engine/Core/Input/Implementation/InputManager.cpp
@@ -39,7 +39,7 @@ void ezInputManager::RegisterInputSlot(ezStringView sInputSlot, ezStringView sDe
       if ((it.Value().m_SlotFlags != ezInputSlotFlags::Default) && (SlotFlags != ezInputSlotFlags::Default))
       {
         ezStringBuilder tmp, tmp2;
-        tmp.Printf("Different devices register Input Slot '%s' with different Slot Flags: %16b vs. %16b",
+        tmp.SetPrintf("Different devices register Input Slot '%s' with different Slot Flags: %16b vs. %16b",
           sInputSlot.GetData(tmp2), it.Value().m_SlotFlags.GetValue(), SlotFlags.GetValue());
 
         ezLog::Warning(tmp);

--- a/Code/Engine/Core/Input/Implementation/VirtualThumbStick.cpp
+++ b/Code/Engine/Core/Input/Implementation/VirtualThumbStick.cpp
@@ -18,7 +18,7 @@ ezVirtualThumbStick::ezVirtualThumbStick()
   SetInputArea(ezVec2(0.0f), ezVec2(0.0f), 0.0f, 0.0f);
 
   ezStringBuilder s;
-  s.Format("Thumbstick_{0}", s_iThumbsticks);
+  s.SetFormat("Thumbstick_{0}", s_iThumbsticks);
   m_sName = s;
 
   ++s_iThumbsticks;

--- a/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
+++ b/Code/Engine/Core/Prefabs/Implementation/PrefabReferenceComponent.cpp
@@ -64,7 +64,7 @@ void ezPrefabReferenceComponent::SerializePrefabParameters(const ezWorld& world,
             // and discard the string's value, and instead write a string that specifies the index of the serialized handle to use
 
             // local game object reference - index into GoReferences
-            tmp.Format("#!LGOR-{}", GoReferences.GetCount());
+            tmp.SetFormat("#!LGOR-{}", GoReferences.GetCount());
             var = tmp.GetData();
 
             GoReferences.PushBack(hObject);
@@ -148,7 +148,7 @@ void ezPrefabReferenceComponent::DeserializePrefabParameters(ezArrayMap<ezHashed
             // and stringify the handle into a 'global game object reference', ie. one that contains the internal integer data of the handle
             // a regular runtime world has a reference resolver that is capable to reverse this stringified format to a handle again
             // which will happen once 'InstantiatePrefab' passes the m_Parameters list to the newly created objects
-            tmp.Format("#!GGOR-{}", hObject.GetInternalID().m_Data);
+            tmp.SetFormat("#!GGOR-{}", hObject.GetInternalID().m_Data);
 
             // map local game object reference to global game object reference
             value = tmp.GetData();

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -72,7 +72,7 @@ void ezResourceManager::SetupWorkerTasks()
 
       for (ezUInt32 i = 0; i < InitialDataLoadTasks; ++i)
       {
-        s.Format("Resource Data Loader {0}", i);
+        s.SetFormat("Resource Data Loader {0}", i);
         auto& data = s_pState->m_WorkerTasksDataLoad.ExpandAndGetRef();
         data.m_pTask = EZ_DEFAULT_NEW(ezResourceManagerWorkerDataLoad);
         data.m_pTask->ConfigureTask(s, ezTaskNesting::Maybe);
@@ -84,7 +84,7 @@ void ezResourceManager::SetupWorkerTasks()
 
       for (ezUInt32 i = 0; i < InitialUpdateContentTasks; ++i)
       {
-        s.Format("Resource Content Updater {0}", i);
+        s.SetFormat("Resource Content Updater {0}", i);
         auto& data = s_pState->m_WorkerTasksUpdateContent.ExpandAndGetRef();
         data.m_pTask = EZ_DEFAULT_NEW(ezResourceManagerWorkerUpdateContent);
         data.m_pTask->ConfigureTask(s, ezTaskNesting::Maybe);
@@ -119,7 +119,7 @@ void ezResourceManager::RunWorkerTask(ezResource* pResource)
     // could not find any unused task -> need to create a new one
     {
       ezStringBuilder s;
-      s.Format("Resource Data Loader {0}", s_pState->m_WorkerTasksDataLoad.GetCount());
+      s.SetFormat("Resource Data Loader {0}", s_pState->m_WorkerTasksDataLoad.GetCount());
       auto& data = s_pState->m_WorkerTasksDataLoad.ExpandAndGetRef();
       data.m_pTask = EZ_DEFAULT_NEW(ezResourceManagerWorkerDataLoad);
       data.m_pTask->ConfigureTask(s, ezTaskNesting::Maybe);

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -774,7 +774,7 @@ const ezRTTI* ezResourceManager::FindResourceTypeOverride(const ezRTTI* pRtti, e
 ezString ezResourceManager::GenerateUniqueResourceID(ezStringView sResourceIDPrefix)
 {
   ezStringBuilder resourceID;
-  resourceID.Format("{}-{}", sResourceIDPrefix, s_pState->m_uiNextResourceID++);
+  resourceID.SetFormat("{}-{}", sResourceIDPrefix, s_pState->m_uiNextResourceID++);
   return resourceID;
 }
 

--- a/Code/Engine/Core/ResourceManager/Implementation/WorkerTasks.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/WorkerTasks.cpp
@@ -75,7 +75,7 @@ void ezResourceManagerWorkerDataLoad::Execute()
   if (pUpdateContentTask == nullptr)
   {
     ezStringBuilder s;
-    s.Format("Resource Content Updater {0}", ezResourceManager::s_pState->m_WorkerTasksUpdateContent.GetCount());
+    s.SetFormat("Resource Content Updater {0}", ezResourceManager::s_pState->m_WorkerTasksUpdateContent.GetCount());
 
     auto& td = ezResourceManager::s_pState->m_WorkerTasksUpdateContent.ExpandAndGetRef();
     td.m_pTask = EZ_DEFAULT_NEW(ezResourceManagerWorkerUpdateContent);

--- a/Code/Engine/Core/System/Implementation/glfw/ControllerInput_glfw.inl
+++ b/Code/Engine/Core/System/Implementation/glfw/ControllerInput_glfw.inl
@@ -99,8 +99,8 @@ void ezControllerInputGlfw::RegisterControllerButton(const char* szButton, const
 
   for (ezInt32 i = 0; i < MaxControllers; ++i)
   {
-    s.Format("controller{0}_{1}", i, szButton);
-    s2.Format("Cont {0}: {1}", i + 1, szName);
+    s.SetFormat("controller{0}_{1}", i, szButton);
+    s2.SetFormat("Cont {0}: {1}", i + 1, szName);
     RegisterInputSlot(s.GetData(), s2.GetData(), SlotFlags);
   }
 }
@@ -111,14 +111,14 @@ void ezControllerInputGlfw::SetDeadZone(const char* szButton)
 
   for (ezInt32 i = 0; i < MaxControllers; ++i)
   {
-    s.Format("controller{0}_{1}", i, szButton);
+    s.SetFormat("controller{0}_{1}", i, szButton);
     ezInputManager::SetInputSlotDeadZone(s.GetData(), 0.23f);
   }
 }
 
 void ezControllerInputGlfw::SetControllerValue(ezStringBuilder& tmp, ezUInt8 controllerIndex, const char* inputSlotName, float value)
 {
-  tmp.Format("controller{0}_{1}", controllerIndex, inputSlotName);
+  tmp.SetFormat("controller{0}_{1}", controllerIndex, inputSlotName);
   m_InputSlotValues[tmp] = value;
 }
 

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -447,7 +447,7 @@ void ezWorld::Update()
 
   {
     ezStringBuilder sStatName;
-    sStatName.Format("World Update/{0}/Game Object Count", m_Data.m_sName);
+    sStatName.SetFormat("World Update/{0}/Game Object Count", m_Data.m_sName);
 
     ezStringBuilder sStatValue;
     ezStats::SetStat(sStatName, GetObjectCount());

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionByteCode.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionByteCode.cpp
@@ -330,7 +330,7 @@ void ezExpressionByteCode::Disassemble(ezStringBuilder& out_sDisassembly) const
       ezStringBuilder sName;
       if (ezStringUtils::IsNullOrEmpty(szName))
       {
-        sName.Format("Unknown_{0}", uiIndex);
+        sName.SetFormat("Unknown_{0}", uiIndex);
       }
       else
       {

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Expand.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Expand.cpp
@@ -185,7 +185,7 @@ ezResult ezPreprocessor::ExpandObjectMacro(MacroDefinition& Macro, TokenStream& 
   if (pMacroToken->m_DataView.IsEqual("__LINE__"))
   {
     ezStringBuilder sLine;
-    sLine.Format("{0}", m_CurrentFileStack.PeekBack().m_iCurrentLine);
+    sLine.SetFormat("{0}", m_CurrentFileStack.PeekBack().m_iCurrentLine);
 
     ezToken* pNewToken = AddCustomToken(pMacroToken, sLine);
     pNewToken->m_iType = ezTokenType::Integer;

--- a/Code/Engine/Foundation/CodeUtils/Implementation/Preprocessor.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/Preprocessor.cpp
@@ -28,7 +28,7 @@ ezPreprocessor::ezPreprocessor()
   ezStringBuilder s;
   for (ezUInt32 i = 0; i < 32; ++i)
   {
-    s.Format("__Param{0}__", i);
+    s.SetFormat("__Param{0}__", i);
     s_ParamNames[i] = s;
 
     m_ParameterTokens[i].m_iType = s_iMacroParameter0 + i;

--- a/Code/Engine/Foundation/CodeUtils/Preprocessor.h
+++ b/Code/Engine/Foundation/CodeUtils/Preprocessor.h
@@ -389,7 +389,7 @@ private: // *** Other ***
       const_cast<ezToken*>(_pe.m_pToken)->m_File = m_CurrentFileStack.PeekBack().m_sVirtualFileName;                                                   \
     }                                                                                                                                                  \
     ezStringBuilder sInfo;                                                                                                                             \
-    sInfo.Format(FormatStr, ##__VA_ARGS__);                                                                                                            \
+    sInfo.SetFormat(FormatStr, ##__VA_ARGS__);                                                                                                            \
     _pe.m_sInfo = sInfo;                                                                                                                               \
     m_ProcessingEvents.Broadcast(_pe);                                                                                                                 \
     ezLog::Type(m_pLog, "File '{0}', Line {1} ({2}): {3}", _pe.m_pToken->m_File.GetString(), _pe.m_pToken->m_uiLine, _pe.m_pToken->m_uiColumn, sInfo); \

--- a/Code/Engine/Foundation/Configuration/Implementation/CVar.cpp
+++ b/Code/Engine/Foundation/Configuration/Implementation/CVar.cpp
@@ -190,7 +190,7 @@ void ezCVar::SaveCVars()
   while (it.IsValid())
   {
     // create the plugin specific file
-    sTemp.Format("{0}/CVars_{1}.cfg", s_sStorageFolder, it.Key());
+    sTemp.SetFormat("{0}/CVars_{1}.cfg", s_sStorageFolder, it.Key());
 
     SaveCVarsToFileInternal(sTemp, it.Value());
 
@@ -215,25 +215,25 @@ void ezCVar::SaveCVarsToFileInternal(ezStringView path, const ezDynamicArray<ezC
         case ezCVarType::Int:
         {
           ezCVarInt* pInt = (ezCVarInt*)pCVar;
-          sTemp.Format("{0} = {1}\n", pCVar->GetName(), pInt->GetValue(ezCVarValue::Restart));
+          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pInt->GetValue(ezCVarValue::Restart));
         }
         break;
         case ezCVarType::Bool:
         {
           ezCVarBool* pBool = (ezCVarBool*)pCVar;
-          sTemp.Format("{0} = {1}\n", pCVar->GetName(), pBool->GetValue(ezCVarValue::Restart) ? "true" : "false");
+          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pBool->GetValue(ezCVarValue::Restart) ? "true" : "false");
         }
         break;
         case ezCVarType::Float:
         {
           ezCVarFloat* pFloat = (ezCVarFloat*)pCVar;
-          sTemp.Format("{0} = {1}\n", pCVar->GetName(), pFloat->GetValue(ezCVarValue::Restart));
+          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pFloat->GetValue(ezCVarValue::Restart));
         }
         break;
         case ezCVarType::String:
         {
           ezCVarString* pString = (ezCVarString*)pCVar;
-          sTemp.Format("{0} = \"{1}\"\n", pCVar->GetName(), pString->GetValue(ezCVarValue::Restart));
+          sTemp.SetFormat("{0} = \"{1}\"\n", pCVar->GetName(), pString->GetValue(ezCVarValue::Restart));
         }
         break;
         default:
@@ -336,7 +336,7 @@ void ezCVar::LoadCVarsFromFile(bool bOnlyNewOnes, bool bSetAsCurrentValue, ezDyn
     while (it.IsValid())
     {
       // create the plugin specific file
-      sTemp.Format("{0}/CVars_{1}.cfg", s_sStorageFolder, it.Key());
+      sTemp.SetFormat("{0}/CVars_{1}.cfg", s_sStorageFolder, it.Key());
 
       LoadCVarsFromFileInternal(sTemp.GetView(), it.Value(), bOnlyNewOnes, bSetAsCurrentValue, pOutCVars);
 

--- a/Code/Engine/Foundation/IO/Implementation/JSONParser.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/JSONParser.cpp
@@ -91,7 +91,7 @@ void ezJSONParser::StartParsing()
       // document is malformed
 
       ezStringBuilder s;
-      s.Format("Start of document: Expected a { or [ or an empty document. Got '{0}' instead.", ezArgC(m_uiCurByte));
+      s.SetFormat("Start of document: Expected a { or [ or an empty document. Got '{0}' instead.", ezArgC(m_uiCurByte));
       ParsingError(s.GetData(), true);
 
       return;
@@ -232,7 +232,7 @@ void ezJSONParser::ContinueObject()
     default:
     {
       ezStringBuilder s;
-      s.Format("While parsing object: Expected \" to begin a new variable, or } to close the object. Got '{0}' instead.", ezArgC(m_uiCurByte));
+      s.SetFormat("While parsing object: Expected \" to begin a new variable, or } to close the object. Got '{0}' instead.", ezArgC(m_uiCurByte));
       ParsingError(s.GetData(), true);
     }
       return;
@@ -280,7 +280,7 @@ void ezJSONParser::ContinueVariable()
   if (m_uiCurByte != ':')
   {
     ezStringBuilder s;
-    s.Format("After parsing variable name: Expected : to separate variable and value, Got '{0}' instead.", ezArgC(m_uiCurByte));
+    s.SetFormat("After parsing variable name: Expected : to separate variable and value, Got '{0}' instead.", ezArgC(m_uiCurByte));
     ParsingError(s.GetData(), false);
   }
   else
@@ -365,7 +365,7 @@ void ezJSONParser::ContinueValue()
       if (ezConversionUtils::StringToBool((const char*)&m_TempString[0], bRes) == EZ_FAILURE)
       {
         ezStringBuilder s;
-        s.Format("Parsing value: Expected 'true' or 'false', Got '{0}' instead.", (const char*)&m_TempString[0]);
+        s.SetFormat("Parsing value: Expected 'true' or 'false', Got '{0}' instead.", (const char*)&m_TempString[0]);
         ParsingError(s.GetData(), false);
       }
 
@@ -391,7 +391,7 @@ void ezJSONParser::ContinueValue()
       if (!ezStringUtils::IsEqual((const char*)&m_TempString[0], "null"))
       {
         ezStringBuilder s;
-        s.Format("Parsing value: Expected 'null', Got '{0}' instead.", (const char*)&m_TempString[0]);
+        s.SetFormat("Parsing value: Expected 'null', Got '{0}' instead.", (const char*)&m_TempString[0]);
         ParsingError(s.GetData(), !bIsNull);
       }
 
@@ -435,7 +435,7 @@ void ezJSONParser::ContinueValue()
     default:
     {
       ezStringBuilder s;
-      s.Format("Parsing value: Expected [, {, f, t, \", 0-1, ., +, -, or even 'e'. Got '{0}' instead", ezArgC(m_uiCurByte));
+      s.SetFormat("Parsing value: Expected [, {, f, t, \", 0-1, ., +, -, or even 'e'. Got '{0}' instead", ezArgC(m_uiCurByte));
       ParsingError(s.GetData(), true);
     }
       return;
@@ -466,7 +466,7 @@ void ezJSONParser::ContinueSeparator()
     default:
     {
       ezStringBuilder s;
-      s.Format("After parsing value: Expected a comma or closing brackets/braces (], }). Got '{0}' instead.", ezArgC(m_uiCurByte));
+      s.SetFormat("After parsing value: Expected a comma or closing brackets/braces (], }). Got '{0}' instead.", ezArgC(m_uiCurByte));
       ParsingError(s.GetData(), true);
     }
       return;
@@ -688,7 +688,7 @@ void ezJSONParser::ReadString()
         default:
         {
           ezStringBuilder s;
-          s.Format("Unknown escape-sequence '\\{0}'", ezArgC(m_uiCurByte));
+          s.SetFormat("Unknown escape-sequence '\\{0}'", ezArgC(m_uiCurByte));
           ParsingError(s, false);
         }
         break;
@@ -745,7 +745,7 @@ double ezJSONParser::ReadNumber()
   if (ezConversionUtils::StringToFloat((const char*)&m_TempString[0], fResult) == EZ_FAILURE)
   {
     ezStringBuilder s;
-    s.Format("Reading number failed: Could not convert '{0}' to a floating point value.", (const char*)&m_TempString[0]);
+    s.SetFormat("Reading number failed: Could not convert '{0}' to a floating point value.", (const char*)&m_TempString[0]);
     ParsingError(s.GetData(), true);
   }
 

--- a/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
@@ -293,7 +293,7 @@ void ezOSFile::FindFreeFilename(ezStringBuilder& inout_sPath, ezStringView sSuff
 
   for (ezUInt32 i = 1; i < 100000; ++i)
   {
-    newName.Format("{}{}{}", orgName, sSuffix, i);
+    newName.SetFormat("{}{}{}", orgName, sSuffix, i);
 
     inout_sPath.ChangeFileName(newName);
     if (!ezOSFile::ExistsFile(inout_sPath))

--- a/Code/Engine/Foundation/IO/Implementation/OpenDdlParser.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OpenDdlParser.cpp
@@ -652,7 +652,7 @@ void ezOpenDdlParser::ReadString()
         default:
         {
           ezStringBuilder s;
-          s.Format("Unknown escape-sequence '\\{0}'", ezArgC(m_uiCurByte));
+          s.SetFormat("Unknown escape-sequence '\\{0}'", ezArgC(m_uiCurByte));
           ParsingError(s, false);
         }
         break;
@@ -866,7 +866,7 @@ void ezOpenDdlParser::ContinueBool()
       if (ezConversionUtils::StringToBool((const char*)&m_TempString[0], bRes) == EZ_FAILURE)
       {
         ezStringBuilder s;
-        s.Format("Parsing value: Expected 'true' or 'false', Got '{0}' instead.", (const char*)&m_TempString[0]);
+        s.SetFormat("Parsing value: Expected 'true' or 'false', Got '{0}' instead.", (const char*)&m_TempString[0]);
         ParsingError(s.GetData(), false);
       }
 
@@ -1108,7 +1108,7 @@ void ezOpenDdlParser::ContinueFloat()
     if (ezConversionUtils::StringToFloat((const char*)&m_TempString[0], dValue) == EZ_FAILURE)
     {
       ezStringBuilder s;
-      s.Format("Reading number failed: Could not convert '{0}' to a floating point value.", (const char*)&m_TempString[0]);
+      s.SetFormat("Reading number failed: Could not convert '{0}' to a floating point value.", (const char*)&m_TempString[0]);
       ParsingError(s.GetData(), true);
     }
 

--- a/Code/Engine/Foundation/IO/Implementation/OpenDdlWriter.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OpenDdlWriter.cpp
@@ -495,12 +495,12 @@ void ezOpenDdlWriter::WriteInt8(const ezInt8* pValues, ezUInt32 uiCount /*= 1*/)
 
   WritePrimitiveType(State::PrimitivesInt8);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -512,12 +512,12 @@ void ezOpenDdlWriter::WriteInt16(const ezInt16* pValues, ezUInt32 uiCount /*= 1*
 
   WritePrimitiveType(State::PrimitivesInt16);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -529,12 +529,12 @@ void ezOpenDdlWriter::WriteInt32(const ezInt32* pValues, ezUInt32 uiCount /*= 1*
 
   WritePrimitiveType(State::PrimitivesInt32);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -546,12 +546,12 @@ void ezOpenDdlWriter::WriteInt64(const ezInt64* pValues, ezUInt32 uiCount /*= 1*
 
   WritePrimitiveType(State::PrimitivesInt64);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -564,12 +564,12 @@ void ezOpenDdlWriter::WriteUInt8(const ezUInt8* pValues, ezUInt32 uiCount /*= 1*
 
   WritePrimitiveType(State::PrimitivesUInt8);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -581,12 +581,12 @@ void ezOpenDdlWriter::WriteUInt16(const ezUInt16* pValues, ezUInt32 uiCount /*= 
 
   WritePrimitiveType(State::PrimitivesUInt16);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -598,12 +598,12 @@ void ezOpenDdlWriter::WriteUInt32(const ezUInt32* pValues, ezUInt32 uiCount /*= 
 
   WritePrimitiveType(State::PrimitivesUInt32);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -615,12 +615,12 @@ void ezOpenDdlWriter::WriteUInt64(const ezUInt64* pValues, ezUInt32 uiCount /*= 
 
   WritePrimitiveType(State::PrimitivesUInt64);
 
-  m_sTemp.Format("{0}", pValues[0]);
+  m_sTemp.SetFormat("{0}", pValues[0]);
   OutputString(m_sTemp.GetData());
 
   for (ezUInt32 i = 1; i < uiCount; ++i)
   {
-    m_sTemp.Format(",{0}", pValues[i]);
+    m_sTemp.SetFormat(",{0}", pValues[i]);
     OutputString(m_sTemp.GetData());
   }
 }
@@ -634,12 +634,12 @@ void ezOpenDdlWriter::WriteFloat(const float* pValues, ezUInt32 uiCount /*= 1*/)
 
   if (m_FloatPrecisionMode == FloatPrecisionMode::Readable)
   {
-    m_sTemp.Format("{0}", pValues[0]);
+    m_sTemp.SetFormat("{0}", pValues[0]);
     OutputString(m_sTemp.GetData());
 
     for (ezUInt32 i = 1; i < uiCount; ++i)
     {
-      m_sTemp.Format(",{0}", pValues[i]);
+      m_sTemp.SetFormat(",{0}", pValues[i]);
       OutputString(m_sTemp.GetData());
     }
   }
@@ -681,12 +681,12 @@ void ezOpenDdlWriter::WriteDouble(const double* pValues, ezUInt32 uiCount /*= 1*
 
   if (m_FloatPrecisionMode == FloatPrecisionMode::Readable)
   {
-    m_sTemp.Format("{0}", pValues[0]);
+    m_sTemp.SetFormat("{0}", pValues[0]);
     OutputString(m_sTemp.GetData());
 
     for (ezUInt32 i = 1; i < uiCount; ++i)
     {
-      m_sTemp.Format(",{0}", pValues[i]);
+      m_sTemp.SetFormat(",{0}", pValues[i]);
       OutputString(m_sTemp.GetData());
     }
   }

--- a/Code/Engine/Foundation/IO/Implementation/StandardJSONWriter.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/StandardJSONWriter.cpp
@@ -122,7 +122,7 @@ void ezStandardJSONWriter::OutputIndentation()
     iIndentation = m_iIndentation;
 
   ezStringBuilder s;
-  s.Printf("%*s", iIndentation, "");
+  s.SetPrintf("%*s", iIndentation, "");
 
   OutputString(s.GetData());
 }
@@ -142,7 +142,7 @@ void ezStandardJSONWriter::WriteInt32(ezInt32 value)
   CommaWriter cw(this);
 
   ezStringBuilder s;
-  s.Format("{0}", value);
+  s.SetFormat("{0}", value);
 
   OutputString(s.GetData());
 }
@@ -152,7 +152,7 @@ void ezStandardJSONWriter::WriteUInt32(ezUInt32 value)
   CommaWriter cw(this);
 
   ezStringBuilder s;
-  s.Format("{0}", value);
+  s.SetFormat("{0}", value);
 
   OutputString(s.GetData());
 }
@@ -162,7 +162,7 @@ void ezStandardJSONWriter::WriteInt64(ezInt64 value)
   CommaWriter cw(this);
 
   ezStringBuilder s;
-  s.Format("{0}", value);
+  s.SetFormat("{0}", value);
 
   OutputString(s.GetData());
 }
@@ -172,7 +172,7 @@ void ezStandardJSONWriter::WriteUInt64(ezUInt64 value)
   CommaWriter cw(this);
 
   ezStringBuilder s;
-  s.Format("{0}", value);
+  s.SetFormat("{0}", value);
 
   OutputString(s.GetData());
 }
@@ -182,7 +182,7 @@ void ezStandardJSONWriter::WriteFloat(float value)
   CommaWriter cw(this);
 
   ezStringBuilder s;
-  s.Format("{0}", value);
+  s.SetFormat("{0}", value);
 
   OutputString(s.GetData());
 }
@@ -192,7 +192,7 @@ void ezStandardJSONWriter::WriteDouble(double value)
   CommaWriter cw(this);
 
   ezStringBuilder s;
-  s.Format("{0}", value);
+  s.SetFormat("{0}", value);
 
   OutputString(s.GetData());
 }
@@ -225,9 +225,9 @@ void ezStandardJSONWriter::WriteColor(const ezColor& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1},{2},{3})", ezArgF(value.r, 4), ezArgF(value.g, 4), ezArgF(value.b, 4), ezArgF(value.a, 4));
+    s.SetFormat("({0},{1},{2},{3})", ezArgF(value.r, 4), ezArgF(value.g, 4), ezArgF(value.b, 4), ezArgF(value.a, 4));
   else
-    s.Format("({0}, {1}, {2}, {3})", ezArgF(value.r, 4), ezArgF(value.g, 4), ezArgF(value.b, 4), ezArgF(value.a, 4));
+    s.SetFormat("({0}, {1}, {2}, {3})", ezArgF(value.r, 4), ezArgF(value.g, 4), ezArgF(value.b, 4), ezArgF(value.a, 4));
 
   WriteBinaryData("color", &temp, sizeof(temp), s.GetData());
 }
@@ -237,9 +237,9 @@ void ezStandardJSONWriter::WriteColorGamma(const ezColorGammaUB& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1},{2},{3})", value.r, value.g, value.b, value.a);
+    s.SetFormat("({0},{1},{2},{3})", value.r, value.g, value.b, value.a);
   else
-    s.Format("({0}, {1}, {2}, {3})", value.r, value.g, value.b, value.a);
+    s.SetFormat("({0}, {1}, {2}, {3})", value.r, value.g, value.b, value.a);
 
   WriteBinaryData("gamma", value.GetData(), sizeof(ezColorGammaUB), s.GetData());
 }
@@ -253,9 +253,9 @@ void ezStandardJSONWriter::WriteVec2(const ezVec2& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1})", ezArgF(value.x, 4), ezArgF(value.y, 4));
+    s.SetFormat("({0},{1})", ezArgF(value.x, 4), ezArgF(value.y, 4));
   else
-    s.Format("({0}, {1})", ezArgF(value.x, 4), ezArgF(value.y, 4));
+    s.SetFormat("({0}, {1})", ezArgF(value.x, 4), ezArgF(value.y, 4));
 
   WriteBinaryData("vec2", &temp, sizeof(temp), s.GetData());
 }
@@ -269,9 +269,9 @@ void ezStandardJSONWriter::WriteVec3(const ezVec3& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1},{2})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4));
+    s.SetFormat("({0},{1},{2})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4));
   else
-    s.Format("({0}, {1}, {2})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4));
+    s.SetFormat("({0}, {1}, {2})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4));
 
   WriteBinaryData("vec3", &temp, sizeof(temp), s.GetData());
 }
@@ -285,9 +285,9 @@ void ezStandardJSONWriter::WriteVec4(const ezVec4& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1},{2},{3})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4), ezArgF(value.w, 4));
+    s.SetFormat("({0},{1},{2},{3})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4), ezArgF(value.w, 4));
   else
-    s.Format("({0}, {1}, {2}, {3})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4), ezArgF(value.w, 4));
+    s.SetFormat("({0}, {1}, {2}, {3})", ezArgF(value.x, 4), ezArgF(value.y, 4), ezArgF(value.z, 4), ezArgF(value.w, 4));
 
   WriteBinaryData("vec4", &temp, sizeof(temp), s.GetData());
 }
@@ -303,9 +303,9 @@ void ezStandardJSONWriter::WriteVec2I32(const ezVec2I32& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1})", value.x, value.y);
+    s.SetFormat("({0},{1})", value.x, value.y);
   else
-    s.Format("({0}, {1})", value.x, value.y);
+    s.SetFormat("({0}, {1})", value.x, value.y);
 
   WriteBinaryData("vec2i", &temp, sizeof(temp), s.GetData());
 }
@@ -321,9 +321,9 @@ void ezStandardJSONWriter::WriteVec3I32(const ezVec3I32& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1},{2})", value.x, value.y, value.z);
+    s.SetFormat("({0},{1},{2})", value.x, value.y, value.z);
   else
-    s.Format("({0}, {1}, {2})", value.x, value.y, value.z);
+    s.SetFormat("({0}, {1}, {2})", value.x, value.y, value.z);
 
   WriteBinaryData("vec3i", &temp, sizeof(temp), s.GetData());
 }
@@ -339,9 +339,9 @@ void ezStandardJSONWriter::WriteVec4I32(const ezVec4I32& value)
   ezStringBuilder s;
 
   if (m_WhitespaceMode >= ezJSONWriter::WhitespaceMode::NewlinesOnly)
-    s.Format("({0},{1},{2},{3})", value.x, value.y, value.z, value.w);
+    s.SetFormat("({0},{1},{2},{3})", value.x, value.y, value.z, value.w);
   else
-    s.Format("({0}, {1}, {2}, {3})", value.x, value.y, value.z, value.w);
+    s.SetFormat("({0}, {1}, {2}, {3})", value.x, value.y, value.z, value.w);
 
   WriteBinaryData("vec4i", &temp, sizeof(temp), s.GetData());
 }
@@ -601,7 +601,7 @@ void ezStandardJSONWriter::WriteBinaryData(ezStringView sDataType, const void* p
 
   for (ezUInt32 i = 0; i < uiBytes; ++i)
   {
-    s.Format("{0}", ezArgU((ezUInt32)*pBytes, 2, true, 16, true));
+    s.SetFormat("{0}", ezArgU((ezUInt32)*pBytes, 2, true, 16, true));
     ++pBytes;
 
     OutputString(s.GetData());

--- a/Code/Engine/Foundation/Logging/Implementation/HTMLWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/HTMLWriter.cpp
@@ -19,7 +19,7 @@ void ezLogWriter::HTML::BeginLog(ezStringView sFile, ezStringView sAppTitle)
     {
       const ezStringBuilder sName = ezPathUtils::GetFileName(sFile);
 
-      sNewName.Format("{0}_{1}", sName, i);
+      sNewName.SetFormat("{0}_{1}", sName, i);
 
       ezStringBuilder sPath = sFile;
       sPath.ChangeFileName(sNewName);
@@ -36,7 +36,7 @@ void ezLogWriter::HTML::BeginLog(ezStringView sFile, ezStringView sAppTitle)
   }
 
   ezStringBuilder sText;
-  sText.Format("<HTML><HEAD><META HTTP-EQUIV=\"Content-Type\" content=\"text/html; charset=utf-8\"><TITLE>Log - {0}</TITLE></HEAD><BODY>", sAppTitle);
+  sText.SetFormat("<HTML><HEAD><META HTTP-EQUIV=\"Content-Type\" content=\"text/html; charset=utf-8\"><TITLE>Log - {0}</TITLE></HEAD><BODY>", sAppTitle);
 
   m_File.WriteBytes(sText.GetData(), sizeof(char) * sText.GetElementCount()).IgnoreResult();
 }
@@ -53,7 +53,7 @@ void ezLogWriter::HTML::EndLog()
   WriteString("", 0);
 
   ezStringBuilder sText;
-  sText.Format("</BODY></HTML>");
+  sText.SetFormat("</BODY></HTML>");
 
   m_File.WriteBytes(sText.GetData(), sizeof(char) * sText.GetElementCount()).IgnoreResult();
 
@@ -103,51 +103,51 @@ void ezLogWriter::HTML::LogMessageHandler(const ezLoggingEventData& eventData)
       break;
 
     case ezLogMsgType::BeginGroup:
-      sText.Format("<br><font color=\"#8080FF\"><b> <<< <u>{0}</u> >>> </b> ({1}) </font><br><table width=100%% border=0><tr width=100%%><td "
+      sText.SetFormat("<br><font color=\"#8080FF\"><b> <<< <u>{0}</u> >>> </b> ({1}) </font><br><table width=100%% border=0><tr width=100%%><td "
                    "width=10></td><td width=*>\n",
         sOriginalText, sTag);
       break;
 
     case ezLogMsgType::EndGroup:
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-      sText.Format("</td></tr></table><font color=\"#8080FF\"><b> <<< {0} ({1} sec)>>> </b></font><br><br>\n", sOriginalText, ezArgF(eventData.m_fSeconds, 4));
+      sText.SetFormat("</td></tr></table><font color=\"#8080FF\"><b> <<< {0} ({1} sec)>>> </b></font><br><br>\n", sOriginalText, ezArgF(eventData.m_fSeconds, 4));
 #else
-      sText.Format("</td></tr></table><font color=\"#8080FF\"><b> <<< {0} ({1})>>> </b></font><br><br>\n", sOriginalText, "timing info not available");
+      sText.SetFormat("</td></tr></table><font color=\"#8080FF\"><b> <<< {0} ({1})>>> </b></font><br><br>\n", sOriginalText, "timing info not available");
 #endif
       break;
 
     case ezLogMsgType::ErrorMsg:
       bFlushWriteCache = true;
-      sText.Format("{0}<font color=\"#FF0000\"><b><u>Error:</u> {1}</b></font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#FF0000\"><b><u>Error:</u> {1}</b></font><br>\n", sTimestamp, sOriginalText);
       break;
 
     case ezLogMsgType::SeriousWarningMsg:
       bFlushWriteCache = true;
-      sText.Format("{0}<font color=\"#FF4000\"><b><u>Seriously:</u> {1}</b></font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#FF4000\"><b><u>Seriously:</u> {1}</b></font><br>\n", sTimestamp, sOriginalText);
       break;
 
     case ezLogMsgType::WarningMsg:
-      sText.Format("{0}<font color=\"#FF8000\"><u>Warning:</u> {1}</font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#FF8000\"><u>Warning:</u> {1}</font><br>\n", sTimestamp, sOriginalText);
       break;
 
     case ezLogMsgType::SuccessMsg:
-      sText.Format("{0}<font color=\"#009000\">{1}</font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#009000\">{1}</font><br>\n", sTimestamp, sOriginalText);
       break;
 
     case ezLogMsgType::InfoMsg:
-      sText.Format("{0}<font color=\"#000000\">{1}</font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#000000\">{1}</font><br>\n", sTimestamp, sOriginalText);
       break;
 
     case ezLogMsgType::DevMsg:
-      sText.Format("{0}<font color=\"#3030F0\">{1}</font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#3030F0\">{1}</font><br>\n", sTimestamp, sOriginalText);
       break;
 
     case ezLogMsgType::DebugMsg:
-      sText.Format("{0}<font color=\"#A000FF\">{1}</font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#A000FF\">{1}</font><br>\n", sTimestamp, sOriginalText);
       break;
 
     default:
-      sText.Format("{0}<font color=\"#A0A0A0\">{1}</font><br>\n", sTimestamp, sOriginalText);
+      sText.SetFormat("{0}<font color=\"#A0A0A0\">{1}</font><br>\n", sTimestamp, sOriginalText);
 
       ezLog::Warning("Unknown Message Type {1}", eventData.m_EventType);
       break;
@@ -167,7 +167,7 @@ void ezLogWriter::HTML::LogMessageHandler(const ezLoggingEventData& eventData)
 void ezLogWriter::HTML::WriteString(ezStringView sText, ezUInt32 uiColor)
 {
   ezStringBuilder sTemp;
-  sTemp.Format("<font color=\"#{0}\">{1}</font>", ezArgU(uiColor, 1, false, 16, true), sText);
+  sTemp.SetFormat("<font color=\"#{0}\">{1}</font>", ezArgU(uiColor, 1, false, 16, true), sText);
 
   m_File.WriteBytes(sTemp.GetData(), sizeof(char) * sTemp.GetElementCount()).IgnoreResult();
 }

--- a/Code/Engine/Foundation/Logging/Implementation/Log.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/Log.cpp
@@ -308,13 +308,13 @@ void ezLog::GenerateFormattedTimestamp(TimestampMode mode, ezStringBuilder& ref_
   switch (mode)
   {
     case TimestampMode::Numeric:
-      ref_sTimestampOut.Format("[{}] ", ezArgDateTime(dateTime, ezArgDateTime::ShowDate | ezArgDateTime::ShowMilliseconds | ezArgDateTime::ShowTimeZone));
+      ref_sTimestampOut.SetFormat("[{}] ", ezArgDateTime(dateTime, ezArgDateTime::ShowDate | ezArgDateTime::ShowMilliseconds | ezArgDateTime::ShowTimeZone));
       break;
     case TimestampMode::TimeOnly:
-      ref_sTimestampOut.Format("[{}] ", ezArgDateTime(dateTime, ezArgDateTime::ShowMilliseconds));
+      ref_sTimestampOut.SetFormat("[{}] ", ezArgDateTime(dateTime, ezArgDateTime::ShowMilliseconds));
       break;
     case TimestampMode::Textual:
-      ref_sTimestampOut.Format(
+      ref_sTimestampOut.SetFormat(
         "[{}] ", ezArgDateTime(dateTime, ezArgDateTime::TextualDate | ezArgDateTime::ShowMilliseconds | ezArgDateTime::ShowTimeZone));
       break;
     default:

--- a/Code/Engine/Foundation/Logging/Implementation/VisualStudioWriter.cpp
+++ b/Code/Engine/Foundation/Logging/Implementation/VisualStudioWriter.cpp
@@ -25,56 +25,56 @@ void ezLogWriter::VisualStudio::LogMessageHandler(const ezLoggingEventData& even
   switch (eventData.m_EventType)
   {
     case ezLogMsgType::BeginGroup:
-      s.Format("+++++ {} ({}) +++++\n", eventData.m_sText, eventData.m_sTag);
+      s.SetFormat("+++++ {} ({}) +++++\n", eventData.m_sText, eventData.m_sTag);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::EndGroup:
 #  if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-      s.Format("----- {} ({} sec) -----\n\n", eventData.m_sText, eventData.m_fSeconds);
+      s.SetFormat("----- {} ({} sec) -----\n\n", eventData.m_sText, eventData.m_fSeconds);
 #  else
-      s.Format("----- {} (timing info not available) -----\n\n", eventData.m_sText);
+      s.SetFormat("----- {} (timing info not available) -----\n\n", eventData.m_sText);
 #  endif
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::ErrorMsg:
-      s.Format("Error: {}\n", eventData.m_sText);
+      s.SetFormat("Error: {}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::SeriousWarningMsg:
-      s.Format("Seriously: {}\n", eventData.m_sText);
+      s.SetFormat("Seriously: {}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::WarningMsg:
-      s.Format("Warning: {}\n", eventData.m_sText);
+      s.SetFormat("Warning: {}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::SuccessMsg:
-      s.Format("{}\n", eventData.m_sText);
+      s.SetFormat("{}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::InfoMsg:
-      s.Format("{}\n", eventData.m_sText);
+      s.SetFormat("{}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::DevMsg:
-      s.Format("{}\n", eventData.m_sText);
+      s.SetFormat("{}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     case ezLogMsgType::DebugMsg:
-      s.Format("{}\n", eventData.m_sText);
+      s.SetFormat("{}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
       break;
 
     default:
-      s.Format("{}\n", eventData.m_sText);
+      s.SetFormat("{}\n", eventData.m_sText);
       OutputDebugStringW(ezStringWChar(s));
 
       ezLog::Warning("Unknown Message Type {0}", eventData.m_EventType);

--- a/Code/Engine/Foundation/Profiling/Implementation/Profiling.cpp
+++ b/Code/Engine/Foundation/Profiling/Implementation/Profiling.cpp
@@ -460,7 +460,7 @@ ezResult ezProfilingSystem::ProfilingData::Write(ezStreamWriter& ref_outputStrea
         const ezTime t1 = m_FrameStartTimes[i];
 
         const ezUInt64 localFrameID = uiNumFrames - i - 1;
-        sFrameName.Format("Frame {}", m_uiFrameCount - localFrameID);
+        sFrameName.SetFormat("Frame {}", m_uiFrameCount - localFrameID);
 
         writer.BeginObject();
         writer.AddVariableString("name", sFrameName);

--- a/Code/Engine/Foundation/Serialization/Implementation/DdlSerializer.cpp
+++ b/Code/Engine/Foundation/Serialization/Implementation/DdlSerializer.cpp
@@ -263,7 +263,7 @@ void ezAbstractGraphDdlSerializer::WriteDocument(ezStreamWriter& inout_stream, c
     writer.SetIndentation(-1);
 
   ezStringBuilder sHeaderVersion;
-  sHeaderVersion.Format("HeaderV{0}", (int)EZ_DOCUMENT_VERSION);
+  sHeaderVersion.SetFormat("HeaderV{0}", (int)EZ_DOCUMENT_VERSION);
   WriteGraph(writer, pHeader, sHeaderVersion);
   WriteGraph(writer, pGraph, "Objects");
   WriteGraph(writer, pTypes, "Types");
@@ -299,7 +299,7 @@ ezResult ezAbstractGraphDdlSerializer::ReadDocument(ezStreamReader& inout_stream
   {
     // Move header into its own graph.
     ezStringBuilder sHeaderVersion;
-    sHeaderVersion.Format("HeaderV{0}", iVersion);
+    sHeaderVersion.SetFormat("HeaderV{0}", iVersion);
     pHB = GetOrCreateBlock(blocks, sHeaderVersion);
     ezAbstractObjectGraph& graph = *pOB->m_Graph.Borrow();
     if (auto* pHeaderNode = graph.GetNodeByName("Header"))

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder.cpp
@@ -144,7 +144,7 @@ void ezStringBuilder::Prepend(ezStringView sData1, ezStringView sData2, ezString
   }
 }
 
-void ezStringBuilder::PrintfArgs(const char* szUtf8Format, va_list szArgs0)
+void ezStringBuilder::SetPrintfArgs(const char* szUtf8Format, va_list szArgs0)
 {
   va_list args;
   va_copy(args, szArgs0);
@@ -1115,7 +1115,7 @@ bool ezStringBuilder::TrimWordEnd(ezStringView sWord)
   return trimmed;
 }
 
-void ezStringBuilder::Format(const ezFormatString& string)
+void ezStringBuilder::SetFormat(const ezFormatString& string)
 {
   Clear();
   ezStringView sText = string.GetText(*this);
@@ -1140,12 +1140,12 @@ void ezStringBuilder::PrependFormat(const ezFormatString& string)
   Prepend(string.GetText(tmp));
 }
 
-void ezStringBuilder::Printf(const char* szUtf8Format, ...)
+void ezStringBuilder::SetPrintf(const char* szUtf8Format, ...)
 {
   va_list args;
   va_start(args, szUtf8Format);
 
-  PrintfArgs(szUtf8Format, args);
+  SetPrintfArgs(szUtf8Format, args);
 
   va_end(args);
 }

--- a/Code/Engine/Foundation/Strings/StringBuilder.h
+++ b/Code/Engine/Foundation/Strings/StringBuilder.h
@@ -206,19 +206,19 @@ public:
     ezStringView sData5 = {}, ezStringView sData6 = {}); // [tested]
 
   /// \brief Sets this string to the formatted string, uses printf-style formatting.
-  void Printf(const char* szUtf8Format, ...); // [tested]
+  void SetPrintf(const char* szUtf8Format, ...); // [tested]
 
   /// \brief Sets this string to the formatted string, uses printf-style formatting.
-  void PrintfArgs(const char* szUtf8Format, va_list szArgs); // [tested]
+  void SetPrintfArgs(const char* szUtf8Format, va_list szArgs); // [tested]
 
   /// \brief Replaces this with a formatted string. Uses '{}' formatting placeholders, see ezFormatString for details.
-  void Format(const ezFormatString& string);
+  void SetFormat(const ezFormatString& string);
 
   /// \brief Replaces this with a formatted string. Uses '{}' formatting placeholders, see ezFormatString for details.
   template <typename... ARGS>
-  void Format(const char* szFormat, ARGS&&... args)
+  void SetFormat(const char* szFormat, ARGS&&... args)
   {
-    Format(ezFormatStringImpl<ARGS...>(szFormat, std::forward<ARGS>(args)...));
+    SetFormat(ezFormatStringImpl<ARGS...>(szFormat, std::forward<ARGS>(args)...));
   }
 
   /// \brief Appends a formatted string. Uses '{}' formatting placeholders, see ezFormatString for details.

--- a/Code/Engine/Foundation/System/Implementation/EnvironmentVariableUtils.cpp
+++ b/Code/Engine/Foundation/System/Implementation/EnvironmentVariableUtils.cpp
@@ -45,7 +45,7 @@ ezInt32 ezEnvironmentVariableUtils::GetValueInt(ezStringView sName, ezInt32 iDef
 ezResult ezEnvironmentVariableUtils::SetValueInt(ezStringView sName, ezInt32 iValue)
 {
   ezStringBuilder sb;
-  sb.Format("{}", iValue);
+  sb.SetFormat("{}", iValue);
 
   return SetValueString(sName, sb);
 }

--- a/Code/Engine/Foundation/Threading/Implementation/TaskSystemUtils.cpp
+++ b/Code/Engine/Foundation/Threading/Implementation/TaskSystemUtils.cpp
@@ -80,7 +80,7 @@ void ezTaskSystem::WriteStateSnapshotToDGML(ezDGMLGraph& ref_graph)
     if (!tg.m_bInUse)
       continue;
 
-    title.Format("Group {}", g);
+    title.SetFormat("Group {}", g);
 
     const ezDGMLGraph::NodeId taskGroupId = ref_graph.AddGroup(title, ezDGMLGraph::GroupType::Expanded, &taskGroupND);
     groupNodeIds[&tg] = taskGroupId;
@@ -99,10 +99,10 @@ void ezTaskSystem::WriteStateSnapshotToDGML(ezDGMLGraph& ref_graph)
       ref_graph.AddNodeProperty(taskNodeId, scheduledId, task.m_bTaskIsScheduled ? "true" : "false");
       ref_graph.AddNodeProperty(taskNodeId, finishedId, task.IsTaskFinished() ? "true" : "false");
 
-      tmp.Format("{}", task.GetMultiplicity());
+      tmp.SetFormat("{}", task.GetMultiplicity());
       ref_graph.AddNodeProperty(taskNodeId, multiplicityId, tmp);
 
-      tmp.Format("{}", task.m_iRemainingRuns);
+      tmp.SetFormat("{}", task.m_iRemainingRuns);
       ref_graph.AddNodeProperty(taskNodeId, remainingRunsId, tmp);
     }
   }

--- a/Code/Engine/Foundation/Threading/Implementation/TaskWorkerThread.cpp
+++ b/Code/Engine/Foundation/Threading/Implementation/TaskWorkerThread.cpp
@@ -9,7 +9,7 @@ thread_local ezTaskWorkerInfo tl_TaskWorkerInfo;
 static const char* GenerateThreadName(ezWorkerThreadType::Enum threadType, ezUInt32 uiThreadNumber)
 {
   static ezStringBuilder sTemp;
-  sTemp.Format("{} {}", ezWorkerThreadType::GetThreadTypeName(threadType), uiThreadNumber);
+  sTemp.SetFormat("{} {}", ezWorkerThreadType::GetThreadTypeName(threadType), uiThreadNumber);
   return sTemp.GetData();
 }
 

--- a/Code/Engine/Foundation/Utilities/Implementation/CommandLineOptions.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/CommandLineOptions.cpp
@@ -305,7 +305,7 @@ ezCommandLineOptionInt::ezCommandLineOptionInt(ezStringView sSortingGroup, ezStr
 
 void ezCommandLineOptionInt::GetParamDefaultValueDesc(ezStringBuilder& ref_sOut) const
 {
-  ref_sOut.Format("{}", m_iDefaultValue);
+  ref_sOut.SetFormat("{}", m_iDefaultValue);
 }
 
 
@@ -317,7 +317,7 @@ void ezCommandLineOptionInt::GetParamShortDesc(ezStringBuilder& ref_sOut) const
   }
   else
   {
-    ref_sOut.Format("<int> [{} .. {}]", m_iMinValue, m_iMaxValue);
+    ref_sOut.SetFormat("<int> [{} .. {}]", m_iMinValue, m_iMaxValue);
   }
 }
 
@@ -345,7 +345,7 @@ int ezCommandLineOptionInt::GetOptionValue(LogMode logMode, const ezCommandLineU
 
   if (ShouldLog(logMode, bSpecified))
   {
-    tmp.Format("{}", result);
+    tmp.SetFormat("{}", result);
     LogOption(sOption, tmp, bSpecified);
   }
 
@@ -368,7 +368,7 @@ ezCommandLineOptionFloat::ezCommandLineOptionFloat(ezStringView sSortingGroup, e
 
 void ezCommandLineOptionFloat::GetParamDefaultValueDesc(ezStringBuilder& ref_sOut) const
 {
-  ref_sOut.Format("{}", m_fDefaultValue);
+  ref_sOut.SetFormat("{}", m_fDefaultValue);
 }
 
 void ezCommandLineOptionFloat::GetParamShortDesc(ezStringBuilder& ref_sOut) const
@@ -379,7 +379,7 @@ void ezCommandLineOptionFloat::GetParamShortDesc(ezStringBuilder& ref_sOut) cons
   }
   else
   {
-    ref_sOut.Format("<float> [{} .. {}]", m_fMinValue, m_fMaxValue);
+    ref_sOut.SetFormat("<float> [{} .. {}]", m_fMinValue, m_fMaxValue);
   }
 }
 
@@ -407,7 +407,7 @@ float ezCommandLineOptionFloat::GetOptionValue(LogMode logMode, const ezCommandL
 
   if (ShouldLog(logMode, bSpecified))
   {
-    tmp.Format("{}", result);
+    tmp.SetFormat("{}", result);
     LogOption(sOption, tmp, bSpecified);
   }
 

--- a/Code/Engine/Foundation/Utilities/Implementation/ConversionUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/ConversionUtils.cpp
@@ -554,121 +554,121 @@ namespace ezConversionUtils
 
   const ezStringBuilder& ToString(ezInt8 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", (ezInt32)value);
+    out_sResult.SetFormat("{0}", (ezInt32)value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezUInt8 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", (ezUInt32)value);
+    out_sResult.SetFormat("{0}", (ezUInt32)value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezInt16 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", (ezInt32)value);
+    out_sResult.SetFormat("{0}", (ezInt32)value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezUInt16 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", (ezUInt32)value);
+    out_sResult.SetFormat("{0}", (ezUInt32)value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezInt32 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezUInt32 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezInt64 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(ezUInt64 value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(float value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(double value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezColor& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ r={0}, g={1}, b={2}, a={3} }", value.r, value.g, value.b, value.a);
+    out_sResult.SetFormat("{ r={0}, g={1}, b={2}, a={3} }", value.r, value.g, value.b, value.a);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezColorGammaUB& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ r={0}, g={1}, b={2}, a={3} }", value.r, value.g, value.b, value.a);
+    out_sResult.SetFormat("{ r={0}, g={1}, b={2}, a={3} }", value.r, value.g, value.b, value.a);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezVec2& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1} }", value.x, value.y);
+    out_sResult.SetFormat("{ x={0}, y={1} }", value.x, value.y);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezVec3& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1}, z={2} }", value.x, value.y, value.z);
+    out_sResult.SetFormat("{ x={0}, y={1}, z={2} }", value.x, value.y, value.z);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezVec4& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1}, z={2}, w={3} }", value.x, value.y, value.z, value.w);
+    out_sResult.SetFormat("{ x={0}, y={1}, z={2}, w={3} }", value.x, value.y, value.z, value.w);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezVec2I32& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1} }", value.x, value.y);
+    out_sResult.SetFormat("{ x={0}, y={1} }", value.x, value.y);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezVec3I32& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1}, z={2} }", value.x, value.y, value.z);
+    out_sResult.SetFormat("{ x={0}, y={1}, z={2} }", value.x, value.y, value.z);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezVec4I32& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1}, z={2}, w={3} }", value.x, value.y, value.z, value.w);
+    out_sResult.SetFormat("{ x={0}, y={1}, z={2}, w={3} }", value.x, value.y, value.z, value.w);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezQuat& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{ x={0}, y={1}, z={2}, w={3} }", value.x, value.y, value.z, value.w);
+    out_sResult.SetFormat("{ x={0}, y={1}, z={2}, w={3} }", value.x, value.y, value.z, value.w);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezMat3& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Printf("{ c1r1=%f, c2r1=%f, c3r1=%f, "
+    out_sResult.SetPrintf("{ c1r1=%f, c2r1=%f, c3r1=%f, "
                        "c1r2=%f, c2r2=%f, c3r2=%f, "
                        "c1r3=%f, c2r3=%f, c3r3=%f }",
       value.Element(0, 0), value.Element(1, 0), value.Element(2, 0), value.Element(0, 1), value.Element(1, 1), value.Element(2, 1),
@@ -678,7 +678,7 @@ namespace ezConversionUtils
 
   const ezStringBuilder& ToString(const ezMat4& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Printf("{ c1r1=%f, c2r1=%f, c3r1=%f, c4r1=%f, "
+    out_sResult.SetPrintf("{ c1r1=%f, c2r1=%f, c3r1=%f, c4r1=%f, "
                        "c1r2=%f, c2r2=%f, c3r2=%f, c4r2=%f, "
                        "c1r3=%f, c2r3=%f, c3r3=%f, c4r3=%f, "
                        "c1r4=%f, c2r4=%f, c3r4=%f, c4r4=%f }",
@@ -691,20 +691,20 @@ namespace ezConversionUtils
   const ezStringBuilder& ToString(const ezTransform& value, ezStringBuilder& out_sResult)
   {
     ezStringBuilder tmp1, tmp2, tmp3;
-    out_sResult.Format("{ position={0}, rotation={1}, scale={2} }", ToString(value.m_vPosition, tmp1), ToString(value.m_qRotation, tmp2),
+    out_sResult.SetFormat("{ position={0}, rotation={1}, scale={2} }", ToString(value.m_vPosition, tmp1), ToString(value.m_qRotation, tmp2),
       ToString(value.m_vScale, tmp3));
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezAngle& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
   const ezStringBuilder& ToString(const ezTime& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("{0}", value);
+    out_sResult.SetFormat("{0}", value);
     return out_sResult;
   }
 
@@ -716,7 +716,7 @@ namespace ezConversionUtils
 
   const ezStringBuilder& ToString(const ezTempHashedString& value, ezStringBuilder& out_sResult)
   {
-    out_sResult.Format("0x{}", ezArgU(value.GetHash(), 16, true, 16));
+    out_sResult.SetFormat("0x{}", ezArgU(value.GetHash(), 16, true, 16));
     return out_sResult;
   }
 
@@ -761,7 +761,7 @@ namespace ezConversionUtils
 
     const GUID* pGuid = reinterpret_cast<const GUID*>(&value);
 
-    out_sResult.Printf("{ %08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x }", pGuid->Data1, pGuid->Data2, pGuid->Data3, pGuid->Data4[0],
+    out_sResult.SetPrintf("{ %08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x }", pGuid->Data1, pGuid->Data2, pGuid->Data3, pGuid->Data4[0],
       pGuid->Data4[1], pGuid->Data4[2], pGuid->Data4[3], pGuid->Data4[4], pGuid->Data4[5], pGuid->Data4[6], pGuid->Data4[7]);
 
     return out_sResult;
@@ -1235,11 +1235,11 @@ namespace ezConversionUtils
 
     if (cg.a == 255)
     {
-      s.Format("#{0}{1}{2}", ezArgU(cg.r, 2, true, 16, true), ezArgU(cg.g, 2, true, 16, true), ezArgU(cg.b, 2, true, 16, true));
+      s.SetFormat("#{0}{1}{2}", ezArgU(cg.r, 2, true, 16, true), ezArgU(cg.g, 2, true, 16, true), ezArgU(cg.b, 2, true, 16, true));
     }
     else
     {
-      s.Format("#{0}{1}{2}{3}", ezArgU(cg.r, 2, true, 16, true), ezArgU(cg.g, 2, true, 16, true), ezArgU(cg.b, 2, true, 16, true),
+      s.SetFormat("#{0}{1}{2}{3}", ezArgU(cg.r, 2, true, 16, true), ezArgU(cg.g, 2, true, 16, true), ezArgU(cg.b, 2, true, 16, true),
         ezArgU(cg.a, 2, true, 16, true));
     }
 

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/MotionMatchingComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/MotionMatchingComponent.cpp
@@ -192,7 +192,7 @@
 //    const ezVec3 vTargetDir = GetInputDirection() / GetOwner()->GetGlobalScaling().x;
 //
 //    ezStringBuilder tmp;
-//    tmp.Format("Gamepad: {0} / {1}", ezArgF(vTargetDir.x, 1), ezArgF(vTargetDir.y, 1));
+//    tmp.SetFormat("Gamepad: {0} / {1}", ezArgF(vTargetDir.x, 1), ezArgF(vTargetDir.y, 1));
 //    ezDebugRenderer::DrawInfoText(GetWorld(), tmp, ezVec2I32(10, 10), ezColor::White);
 //
 //    m_fKeyframeLerp += fKeyframeFraction;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -182,7 +182,7 @@ void ezGameApplication::Run_FinishFrame()
 void ezGameApplication::UpdateWorldsAndExtractViews()
 {
   ezStringBuilder sb;
-  sb.Format("FRAME {}", ezRenderWorld::GetFrameCounter());
+  sb.SetFormat("FRAME {}", ezRenderWorld::GetFrameCounter());
   EZ_PROFILE_SCOPE(sb.GetData());
 
   Run_BeforeWorldUpdate();

--- a/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
@@ -532,39 +532,39 @@ void ezGreyBoxComponent::GenerateMeshName(ezStringBuilder& out_sName) const
   switch (m_Shape)
   {
     case ezGreyBoxShape::Box:
-      out_sName.Format("Grey-Box:{0}-{1},{2}-{3},{4}-{5}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ);
+      out_sName.SetFormat("Grey-Box:{0}-{1},{2}-{3},{4}-{5}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ);
       break;
 
     case ezGreyBoxShape::RampX:
-      out_sName.Format("Grey-RampX:{0}-{1},{2}-{3},{4}-{5}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ);
+      out_sName.SetFormat("Grey-RampX:{0}-{1},{2}-{3},{4}-{5}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ);
       break;
 
     case ezGreyBoxShape::RampY:
-      out_sName.Format("Grey-RampY:{0}-{1},{2}-{3},{4}-{5}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ);
+      out_sName.SetFormat("Grey-RampY:{0}-{1},{2}-{3},{4}-{5}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ);
       break;
 
     case ezGreyBoxShape::Column:
-      out_sName.Format("Grey-Column:{0}-{1},{2}-{3},{4}-{5}-d{6}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail);
+      out_sName.SetFormat("Grey-Column:{0}-{1},{2}-{3},{4}-{5}-d{6}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail);
       break;
 
     case ezGreyBoxShape::StairsX:
-      out_sName.Format("Grey-StairsX:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-st{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_bSlopedTop);
+      out_sName.SetFormat("Grey-StairsX:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-st{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_bSlopedTop);
       break;
 
     case ezGreyBoxShape::StairsY:
-      out_sName.Format("Grey-StairsY:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-st{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_bSlopedTop);
+      out_sName.SetFormat("Grey-StairsY:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-st{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_bSlopedTop);
       break;
 
     case ezGreyBoxShape::ArchX:
-      out_sName.Format("Grey-ArchX:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-t{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_fThickness);
+      out_sName.SetFormat("Grey-ArchX:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-t{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_fThickness);
       break;
 
     case ezGreyBoxShape::ArchY:
-      out_sName.Format("Grey-ArchY:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-t{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_fThickness);
+      out_sName.SetFormat("Grey-ArchY:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-t{8}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_fThickness);
       break;
 
     case ezGreyBoxShape::SpiralStairs:
-      out_sName.Format("Grey-Spiral:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-t{8}-st{9}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_fThickness, m_bSlopedTop);
+      out_sName.SetFormat("Grey-Spiral:{0}-{1},{2}-{3},{4}-{5}-d{6}-c{7}-t{8}-st{9}", m_fSizeNegX, m_fSizePosX, m_fSizeNegY, m_fSizePosY, m_fSizeNegZ, m_fSizePosZ, m_uiDetail, m_Curvature.GetDegree(), m_fThickness, m_bSlopedTop);
       out_sName.AppendFormat("-sb{0}", m_bSlopedBottom);
       break;
 

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BoneWeightsAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BoneWeightsAnimNode.cpp
@@ -111,7 +111,7 @@ void ezBoneWeightsAnimNode::Step(ezAnimController& ref_controller, ezAnimGraphIn
     const auto pOzzSkeleton = &pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
 
     ezStringBuilder name;
-    name.Format("{}", pSkeleton->GetResourceIDHash());
+    name.SetFormat("{}", pSkeleton->GetResourceIDHash());
 
     for (const auto& rootBone : m_RootBones)
     {

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
@@ -465,7 +465,7 @@ void ezBakedProbesComponent::RenderDebugOverlay()
 void ezBakedProbesComponent::OnObjectCreated(const ezAbstractObjectNode& node)
 {
   ezStringBuilder sPrefix;
-  sPrefix.Format(":project/AssetCache/Generated/{0}", node.GetGuid());
+  sPrefix.SetFormat(":project/AssetCache/Generated/{0}", node.GetGuid());
 
   m_sProbeTreeResourcePrefix.Assign(sPrefix);
 }

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesWorldModule.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesWorldModule.cpp
@@ -129,7 +129,7 @@ ezAmbientCube<float> ezBakedProbesWorldModule::GetSkyVisibility(const ProbeIndex
 void ezBakedProbesWorldModule::SetProbeTreeResourcePrefix(const ezHashedString& prefix)
 {
   ezStringBuilder sResourcePath;
-  sResourcePath.Format("{}_Global.ezProbeTreeSector", prefix);
+  sResourcePath.SetFormat("{}_Global.ezProbeTreeSector", prefix);
 
   m_hProbeTree = ezResourceManager::LoadResource<ezProbeTreeSectorResource>(sResourcePath);
 }

--- a/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
@@ -244,7 +244,7 @@ void ezBeamComponent::CreateMeshes()
   // Create the beam mesh name, it expresses the beam in local space with it's width
   // this way multiple beams in a corridor can share the same mesh for example.
   ezStringBuilder meshName;
-  meshName.Format("ezBeamComponent_{0}_{1}_{2}_{3}.createdAtRuntime.ezMesh", m_fWidth, ezArgF(targetPositionInOwnerSpace.x, 2), ezArgF(targetPositionInOwnerSpace.y, 2), ezArgF(targetPositionInOwnerSpace.z, 2));
+  meshName.SetFormat("ezBeamComponent_{0}_{1}_{2}_{3}.createdAtRuntime.ezMesh", m_fWidth, ezArgF(targetPositionInOwnerSpace.x, 2), ezArgF(targetPositionInOwnerSpace.y, 2), ezArgF(targetPositionInOwnerSpace.z, 2));
 
   m_hMesh = ezResourceManager::GetExistingResource<ezMeshResource>(meshName);
 

--- a/Code/Engine/RendererCore/Components/Implementation/CameraComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/CameraComponent.cpp
@@ -332,7 +332,7 @@ void ezCameraComponent::ShowStats(ezView* pView)
     const ezStringView sName = GetOwner()->GetName();
 
     ezStringBuilder sb;
-    sb.Format("Camera '{0}':\nEV100: {1}, Exposure: {2}", sName.IsEmpty() ? pView->GetName() : sName, GetEV100(), GetExposure());
+    sb.SetFormat("Camera '{0}':\nEV100: {1}, Exposure: {2}", sName.IsEmpty() ? pView->GetName() : sName, GetEV100(), GetExposure());
     ezDebugRenderer::DrawInfoText(pView->GetHandle(), ezDebugTextPlacement::TopLeft, "CamStats", sb, ezColor::White);
   }
 
@@ -648,7 +648,7 @@ void ezCameraComponent::ActivateRenderToTexture()
   EZ_ASSERT_DEV(m_hRenderTargetView.IsInvalidated(), "Render target view is already created");
 
   ezStringBuilder name;
-  name.Format("Camera RT: {0}", GetOwner()->GetName());
+  name.SetFormat("Camera RT: {0}", GetOwner()->GetName());
 
   ezView* pRenderTargetView = nullptr;
   m_hRenderTargetView = ezRenderWorld::CreateView(name, pRenderTargetView);

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -299,7 +299,7 @@ void ezRopeRenderComponent::OnRopePoseUpdated(ezMsgRopePoseUpdated& msg)
 void ezRopeRenderComponent::GenerateRenderMesh(ezUInt32 uiNumRopePieces)
 {
   ezStringBuilder sResourceName;
-  sResourceName.Format("Rope-Mesh:{}{}-d{}-u{}", uiNumRopePieces, m_bSubdivide ? "Sub" : "", m_uiDetail, m_fUScale);
+  sResourceName.SetFormat("Rope-Mesh:{}{}-d{}-u{}", uiNumRopePieces, m_bSubdivide ? "Sub" : "", m_uiDetail, m_fUScale);
 
   m_hMesh = ezResourceManager::GetExistingResource<ezMeshResource>(sResourceName);
   if (m_hMesh.IsValid())

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
@@ -78,7 +78,7 @@ void ezDebugTextComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   if (!m_sText.IsEmpty())
   {
     ezStringBuilder sb;
-    sb.Format(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);
+    sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);
 
     ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, GetOwner()->GetGlobalPosition(), m_Color);
   }

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalAtlasResource.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalAtlasResource.cpp
@@ -183,7 +183,7 @@ void ezDecalAtlasResource::CreateLayerTexture(const ezImage& img, bool bSRGB, ez
   ezTextureUtils::ConfigureSampler(ezTextureFilterSetting::HighQuality, td.m_SamplerDesc);
 
   ezStringBuilder sTexId;
-  sTexId.Format("{0}_Tex{1}", GetResourceID(), s_uiDecalAtlasResources);
+  sTexId.SetFormat("{0}_Tex{1}", GetResourceID(), s_uiDecalAtlasResources);
   ++s_uiDecalAtlasResources;
 
   out_hTexture = ezResourceManager::CreateResource<ezTexture2DResource>(sTexId, std::move(td));

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -116,7 +116,7 @@ void ezReflectionPool::ExtractReflectionProbe(const ezComponent* pComponent, ezM
       ezStringBuilder sEnum;
       ezReflectionUtils::BitflagsToString(probeData.m_Flags, sEnum, ezReflectionUtils::EnumConversionMode::ValueNameOnly);
       ezStringBuilder s;
-      s.Format("\n RefIdx: {}\nUpdating: {}\nFlags: {}\n", iMappedIndex, activeIndex, sEnum);
+      s.SetFormat("\n RefIdx: {}\nUpdating: {}\nFlags: {}\n", iMappedIndex, activeIndex, sEnum);
       ezDebugRenderer::Draw3DText(pWorld, s, pComponent->GetOwner()->GetGlobalPosition(), ezColorScheme::LightUI(ezColorScheme::Violet));
     }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
@@ -123,7 +123,7 @@ void ezReflectionPool::Data::UpdateProbeData(ProbeData& ref_probeData, const ezR
     ezConversionUtils::ToString(ref_probeData.m_desc.m_uniqueID, sComponentGuid);
 
     // this is where the editor will put the file for this probe
-    sCubeMapFile.Format(":project/AssetCache/Generated/{0}.ezTexture", sComponentGuid);
+    sCubeMapFile.SetFormat(":project/AssetCache/Generated/{0}.ezTexture", sComponentGuid);
 
     ref_probeData.m_hCubeMap = ezResourceManager::LoadResource<ezTextureCubeResource>(sCubeMapFile);
   }
@@ -161,7 +161,7 @@ bool ezReflectionPool::Data::UpdateSkyLightData(ProbeData& ref_probeData, const 
         ezConversionUtils::ToString(ref_probeData.m_desc.m_uniqueID, sComponentGuid);
 
         // this is where the editor will put the file for this probe
-        sCubeMapFile.Format(":project/AssetCache/Generated/{0}.ezTexture", sComponentGuid);
+        sCubeMapFile.SetFormat(":project/AssetCache/Generated/{0}.ezTexture", sComponentGuid);
 
         ref_probeData.m_hCubeMap = ezResourceManager::LoadResource<ezTextureCubeResource>(sCubeMapFile);
       }
@@ -387,7 +387,7 @@ void ezReflectionPool::Data::CreateReflectionViewsAndResources()
         desc.m_Parameters[uiMipLevel].m_Value = iMipLevel;
         desc.m_Parameters[uiReflectionProbeIndex].m_Value = iReflectionProbeIndex;
         ezStringBuilder sMaterialName;
-        sMaterialName.Format("ReflectionProbeVisualization - MipLevel {}, Index {}", iMipLevel, iReflectionProbeIndex);
+        sMaterialName.SetFormat("ReflectionProbeVisualization - MipLevel {}, Index {}", iMipLevel, iReflectionProbeIndex);
 
         ezMaterialResourceDescriptor desc2 = desc;
         m_hDebugMaterial[iReflectionProbeIndex * uiMipLevelCount + iMipLevel] = ezResourceManager::GetOrCreateResource<ezMaterialResource>(sMaterialName, std::move(desc2));

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeComponentBase.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeComponentBase.cpp
@@ -189,7 +189,7 @@ float ezReflectionProbeComponentBase::ComputePriority(ezMsgExtractRenderData& ms
 
 #ifdef EZ_SHOW_REFLECTION_PROBE_PRIORITIES
   ezStringBuilder s;
-  s.Format("{}, {}", pRenderData->m_uiSortingKey, fPriority);
+  s.SetFormat("{}, {}", pRenderData->m_uiSortingKey, fPriority);
   ezDebugRenderer::Draw3DText(GetWorld(), s, pRenderData->m_GlobalTransform.m_vPosition, ezColor::Wheat);
 #endif
   return fPriority;

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
@@ -45,7 +45,7 @@ ezReflectionProbeUpdater::ProbeUpdateInfo::ProbeUpdateInfo()
   {
     m_hCubemapProxies[i] = ezGALDevice::GetDefaultDevice()->CreateProxyTexture(m_hCubemap, i);
 
-    sName.Format("Reflection Cubemap Proxy {}", i);
+    sName.SetFormat("Reflection Cubemap Proxy {}", i);
     pDevice->GetTexture(m_hCubemapProxies[i])->SetDebugName(sName);
   }
 }
@@ -297,7 +297,7 @@ void ezReflectionProbeUpdater::CreateViews(
     {
       auto& renderView = views.ExpandAndGetRef();
 
-      sName.Format("Reflection Probe {} {}", szNameSuffix, i);
+      sName.SetFormat("Reflection Probe {} {}", szNameSuffix, i);
 
       ezView* pView = nullptr;
       renderView.m_hView = ezRenderWorld::CreateView(sName, pView);

--- a/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
@@ -149,7 +149,7 @@ void ezSpotLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   if (cvar_RenderingLightingVisScreenSpaceSize)
   {
     ezStringBuilder sb;
-    sb.Format("{0}", fScreenSpaceSize);
+    sb.SetFormat("{0}", fScreenSpaceSize);
     ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, t.m_vPosition, ezColor::Olive);
     ezDebugRenderer::DrawLineSphere(msg.m_pView->GetHandle(), bs, ezColor::Olive);
   }

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -95,7 +95,7 @@ ezDynamicMeshBufferResourceHandle ezCustomMeshComponent::CreateMeshResource(ezGA
   desc.m_bColorStream = true;
 
   ezStringBuilder sGuid;
-  sGuid.Format("CustomMesh_{}", s_iCustomMeshResources.Increment());
+  sGuid.SetFormat("CustomMesh_{}", s_iCustomMeshResources.Increment());
 
   m_hDynamicMesh = ezResourceManager::CreateResource<ezDynamicMeshBufferResource>(sGuid, std::move(desc));
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/DynamicMeshBufferResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/DynamicMeshBufferResource.cpp
@@ -125,7 +125,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezDynamicMeshBufferResource, ezDynamicMeshBuffe
   m_hVertexBuffer = pDevice->CreateVertexBuffer(sizeof(ezDynamicMeshVertex), m_Descriptor.m_uiMaxVertices /* no initial data -> mutable */);
 
   ezStringBuilder sName;
-  sName.Format("{0} - Dynamic Vertex Buffer", GetResourceDescription());
+  sName.SetFormat("{0} - Dynamic Vertex Buffer", GetResourceDescription());
   pDevice->GetBuffer(m_hVertexBuffer)->SetDebugName(sName);
 
   const ezUInt32 uiMaxIndices = ezGALPrimitiveTopology::VerticesPerPrimitive(m_Descriptor.m_Topology) * m_Descriptor.m_uiMaxPrimitives;
@@ -135,7 +135,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezDynamicMeshBufferResource, ezDynamicMeshBuffe
     m_ColorData.SetCountUninitialized(uiMaxIndices);
     m_hColorBuffer = pDevice->CreateVertexBuffer(sizeof(ezColorLinearUB), m_Descriptor.m_uiMaxVertices /* no initial data -> mutable */);
 
-    sName.Format("{0} - Dynamic Color Buffer", GetResourceDescription());
+    sName.SetFormat("{0} - Dynamic Color Buffer", GetResourceDescription());
     pDevice->GetBuffer(m_hColorBuffer)->SetDebugName(sName);
   }
 
@@ -145,7 +145,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezDynamicMeshBufferResource, ezDynamicMeshBuffe
 
     m_hIndexBuffer = pDevice->CreateIndexBuffer(ezGALIndexType::UInt, uiMaxIndices /* no initial data -> mutable */);
 
-    sName.Format("{0} - Dynamic Index32 Buffer", GetResourceDescription());
+    sName.SetFormat("{0} - Dynamic Index32 Buffer", GetResourceDescription());
     pDevice->GetBuffer(m_hIndexBuffer)->SetDebugName(sName);
   }
   else if (m_Descriptor.m_IndexType == ezGALIndexType::UShort)
@@ -154,7 +154,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezDynamicMeshBufferResource, ezDynamicMeshBuffe
 
     m_hIndexBuffer = pDevice->CreateIndexBuffer(ezGALIndexType::UShort, uiMaxIndices /* no initial data -> mutable */);
 
-    sName.Format("{0} - Dynamic Index16 Buffer", GetResourceDescription());
+    sName.SetFormat("{0} - Dynamic Index16 Buffer", GetResourceDescription());
     pDevice->GetBuffer(m_hIndexBuffer)->SetDebugName(sName);
   }
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshBufferResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshBufferResource.cpp
@@ -566,14 +566,14 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezMeshBufferResource, ezMeshBufferResourceDescr
   m_hVertexBuffer = pDevice->CreateVertexBuffer(descriptor.GetVertexDataSize(), descriptor.GetVertexCount(), descriptor.GetVertexBufferData().GetArrayPtr());
 
   ezStringBuilder sName;
-  sName.Format("{0} Vertex Buffer", GetResourceDescription());
+  sName.SetFormat("{0} Vertex Buffer", GetResourceDescription());
   pDevice->GetBuffer(m_hVertexBuffer)->SetDebugName(sName);
 
   if (descriptor.HasIndexBuffer())
   {
     m_hIndexBuffer = pDevice->CreateIndexBuffer(descriptor.Uses32BitIndices() ? ezGALIndexType::UInt : ezGALIndexType::UShort, m_uiPrimitiveCount * ezGALPrimitiveTopology::VerticesPerPrimitive(m_Topology), descriptor.GetIndexBufferData());
 
-    sName.Format("{0} Index Buffer", GetResourceDescription());
+    sName.SetFormat("{0} Index Buffer", GetResourceDescription());
     pDevice->GetBuffer(m_hIndexBuffer)->SetDebugName(sName);
 
     // we only know the memory usage here, so we write it back to the internal variable directly and then read it in UpdateMemoryUsage() again

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshResource.cpp
@@ -98,7 +98,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezMeshResource, ezMeshResourceDescriptor)
   {
     s_uiMeshBufferNameSuffix++;
     ezStringBuilder sMbName;
-    sMbName.Format("{0}  [MeshBuffer {1}]", GetResourceID(), ezArgU(s_uiMeshBufferNameSuffix, 4, true, 16, true));
+    sMbName.SetFormat("{0}  [MeshBuffer {1}]", GetResourceID(), ezArgU(s_uiMeshBufferNameSuffix, 4, true, 16, true));
 
     // note: this gets move'd, might be invalid afterwards
     ezMeshBufferResourceDescriptor& mb = descriptor.MeshBufferDesc();

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -341,10 +341,10 @@ void ezVisibleObjectsExtractor::Extract(
 
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "ExtractionStats", "Extraction Stats:");
 
-    sb.Format("Num Cached Render Data: {0}", m_uiNumCachedRenderData);
+    sb.SetFormat("Num Cached Render Data: {0}", m_uiNumCachedRenderData);
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "ExtractionStats", sb);
 
-    sb.Format("Num Uncached Render Data: {0}", m_uiNumUncachedRenderData);
+    sb.SetFormat("Num Uncached Render Data: {0}", m_uiNumUncachedRenderData);
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "ExtractionStats", sb);
   }
 #endif

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1054,19 +1054,19 @@ void ezRenderPipeline::FindVisibleObjects(const ezView& view)
 
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "VisCulling", "Visibility Culling Stats", ezColor::LimeGreen);
 
-    sb.Format("Total Num Objects: {0}", stats.m_uiTotalNumObjects);
+    sb.SetFormat("Total Num Objects: {0}", stats.m_uiTotalNumObjects);
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "VisCulling", sb, ezColor::LimeGreen);
 
-    sb.Format("Num Objects Tested: {0}", stats.m_uiNumObjectsTested);
+    sb.SetFormat("Num Objects Tested: {0}", stats.m_uiNumObjectsTested);
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "VisCulling", sb, ezColor::LimeGreen);
 
-    sb.Format("Num Objects Passed: {0}", stats.m_uiNumObjectsPassed);
+    sb.SetFormat("Num Objects Passed: {0}", stats.m_uiNumObjectsPassed);
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "VisCulling", sb, ezColor::LimeGreen);
 
     // Exponential moving average for better readability.
     m_AverageCullingTime = ezMath::Lerp(m_AverageCullingTime, stats.m_TimeTaken, 0.05f);
 
-    sb.Format("Time Taken: {0}ms", m_AverageCullingTime.GetMilliseconds());
+    sb.SetFormat("Time Taken: {0}ms", m_AverageCullingTime.GetMilliseconds());
     ezDebugRenderer::DrawInfoText(hView, ezDebugTextPlacement::TopLeft, "VisCulling", sb, ezColor::LimeGreen);
 
     view.GetWorld()->GetSpatialSystem()->GetInternalStats(sb);
@@ -1299,7 +1299,7 @@ void ezRenderPipeline::CreateDgmlGraph(ezDGMLGraph& ref_graph)
   for (ezUInt32 p = 0; p < m_Passes.GetCount(); ++p)
   {
     const auto& pPass = m_Passes[p];
-    sTmp.Format("#{}: {}", p, ezStringUtils::IsNullOrEmpty(pPass->GetName()) ? pPass->GetDynamicRTTI()->GetTypeName() : pPass->GetName());
+    sTmp.SetFormat("#{}: {}", p, ezStringUtils::IsNullOrEmpty(pPass->GetName()) ? pPass->GetDynamicRTTI()->GetTypeName() : pPass->GetName());
 
     ezDGMLGraph::NodeDesc nd;
     nd.m_Color = ezColor::Gray;
@@ -1321,9 +1321,9 @@ void ezRenderPipeline::CreateDgmlGraph(ezDGMLGraph& ref_graph)
       ezStringBuilder sFormat;
       if (!ezReflectionUtils::EnumerationToString(ezGetStaticRTTI<ezGALResourceFormat>(), pCon->m_Desc.m_Format, sFormat, ezReflectionUtils::EnumConversionMode::ValueNameOnly))
       {
-        sFormat.Format("Unknown Format {}", (int)pCon->m_Desc.m_Format);
+        sFormat.SetFormat("Unknown Format {}", (int)pCon->m_Desc.m_Format);
       }
-      sTmp.Format("{} #{}: {}x{}:{}, MSAA:{}, {}Format: {}", data.m_iTargetTextureIndex != -1 ? "RenderTarget" : "PoolTexture", i, pCon->m_Desc.m_uiWidth, pCon->m_Desc.m_uiHeight, pCon->m_Desc.m_uiArraySize, (int)pCon->m_Desc.m_SampleCount, ezGALResourceFormat::IsDepthFormat(pCon->m_Desc.m_Format) ? "Depth" : "Color", sFormat);
+      sTmp.SetFormat("{} #{}: {}x{}:{}, MSAA:{}, {}Format: {}", data.m_iTargetTextureIndex != -1 ? "RenderTarget" : "PoolTexture", i, pCon->m_Desc.m_uiWidth, pCon->m_Desc.m_uiHeight, pCon->m_Desc.m_uiArraySize, (int)pCon->m_Desc.m_SampleCount, ezGALResourceFormat::IsDepthFormat(pCon->m_Desc.m_Format) ? "Depth" : "Color", sFormat);
       ezUInt32 uiTextureNode = ref_graph.AddNode(sTmp, &nd);
 
       ezUInt32 uiOutputNode = *nodeMap.GetValue(pCon->m_pOutput->m_pParent);
@@ -1479,7 +1479,7 @@ void ezRenderPipeline::PreviewOcclusionBuffer(const ezRasterizerView& rasterizer
     name.Increment();
 
     ezStringBuilder sName;
-    sName.Format("RasterizerPreview-{}", name);
+    sName.SetFormat("RasterizerPreview-{}", name);
 
     ezTexture2DResourceHandle hDebug = ezResourceManager::CreateResource<ezTexture2DResource>(sName, std::move(d));
 

--- a/Code/Engine/RendererCore/Rasterizer/Implementation/RasterizerObject.cpp
+++ b/Code/Engine/RendererCore/Rasterizer/Implementation/RasterizerObject.cpp
@@ -99,7 +99,7 @@ ezSharedPtr<const ezRasterizerObject> ezRasterizerObject::CreateBox(const ezVec3
   EZ_LOCK(s_Mutex);
 
   ezStringBuilder sName;
-  sName.Format("Box-{}-{}-{}", vFullExtents.x, vFullExtents.y, vFullExtents.z);
+  sName.SetFormat("Box-{}-{}-{}", vFullExtents.x, vFullExtents.y, vFullExtents.z);
 
   ezSharedPtr<ezRasterizerObject>& pObj = s_Objects[sName];
 

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
@@ -178,7 +178,7 @@ ezUInt32 ezShaderStateResourceDescriptor::CalculateHash() const
 
 static const char* InsertNumber(const char* szString, ezUInt32 uiNumber, ezStringBuilder& ref_sTemp)
 {
-  ref_sTemp.Format(szString, uiNumber);
+  ref_sTemp.SetFormat(szString, uiNumber);
   return ref_sTemp.GetData();
 }
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -73,7 +73,7 @@ namespace
 
         for (const auto& ev : enumValues)
         {
-          sTemp.Format("{1} {2}", szName, ev.m_sValueName, ev.m_iValueValue);
+          sTemp.SetFormat("{1} {2}", szName, ev.m_sValueName, ev.m_iValueValue);
           out_defines.PushBack(sTemp);
         }
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
@@ -132,7 +132,7 @@ void ezShaderManager::ReloadPermutationVarConfig(const char* szName, const ezTem
   }
 
   ezStringBuilder sPath;
-  sPath.Format("{0}/{1}.ezPermVar", s_sPermVarSubDir, szName);
+  sPath.SetFormat("{0}/{1}.ezPermVar", s_sPermVarSubDir, szName);
 
   ezStringBuilder sTemp = s_sPlatform;
   sTemp.Append(" 1");

--- a/Code/Engine/RendererCore/Utils/Implementation/WorldGeoExtractionUtil.cpp
+++ b/Code/Engine/RendererCore/Utils/Implementation/WorldGeoExtractionUtil.cpp
@@ -109,7 +109,7 @@ void ezWorldGeoExtractionUtil::WriteWorldGeometryToOBJ(const char* szFile, const
     {
       const ezVec3 pos = finalTransform.TransformPosition(*pPositions);
 
-      line.Format("v {0} {1} {2}\n", ezArgF(pos.x, 8), ezArgF(pos.y, 8), ezArgF(pos.z, 8));
+      line.SetFormat("v {0} {1} {2}\n", ezArgF(pos.x, 8), ezArgF(pos.y, 8), ezArgF(pos.z, 8));
       file.WriteBytes(line.GetData(), line.GetElementCount()).IgnoreResult();
 
       pPositions = ezMemoryUtils::AddByteOffset(pPositions, uiElementStride);
@@ -160,7 +160,7 @@ void ezWorldGeoExtractionUtil::WriteWorldGeometryToOBJ(const char* szFile, const
   for (ezUInt32 i = 0; i < indices.GetCount(); i += 3)
   {
     // indices are 1 based in obj
-    line.Format("f {0} {1} {2}\n", indices[i + 0] + 1, indices[i + 1] + 1, indices[i + 2] + 1);
+    line.SetFormat("f {0} {1} {2}\n", indices[i + 0] + 1, indices[i + 1] + 1, indices[i + 2] + 1);
     file.WriteBytes(line.GetData(), line.GetElementCount()).IgnoreResult();
   }
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -741,7 +741,7 @@ void ezGALDeviceDX11::BeginFramePlatform(const ezUInt64 uiRenderFrame)
   auto& pCommandEncoder = m_pDefaultPass->m_pCommandEncoderImpl;
 
   ezStringBuilder sb;
-  sb.Format("Frame {}", uiRenderFrame);
+  sb.SetFormat("Frame {}", uiRenderFrame);
 
 #if EZ_ENABLED(EZ_USE_PROFILING)
   m_pFrameTimingScope = ezProfilingScopeAndMarker::Start(m_pDefaultPass->m_pRenderCommandEncoder.Borrow(), sb);

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1295,7 +1295,7 @@ void ezGALDeviceVulkan::BeginFramePlatform(const ezUInt64 uiRenderFrame)
 
 #if EZ_ENABLED(EZ_USE_PROFILING)
   ezStringBuilder sb;
-  sb.Format("Frame {}", uiRenderFrame);
+  sb.SetFormat("Frame {}", uiRenderFrame);
   m_pFrameTimingScope = ezProfilingScopeAndMarker::Start(m_pDefaultPass->m_pRenderCommandEncoder.Borrow(), sb);
 #endif
 }

--- a/Code/Engine/Texture/TexConv/Implementation/InputFiles.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/InputFiles.cpp
@@ -28,7 +28,7 @@ ezResult ezTexConvProcessor::LoadInputImages()
     ezStringBuilder tmp;
     for (ezUInt32 i = 0; i < m_Descriptor.m_InputFiles.GetCount(); ++i)
     {
-      tmp.Format("InputImage{}", ezArgI(i, 2, true));
+      tmp.SetFormat("InputImage{}", ezArgI(i, 2, true));
       m_Descriptor.m_InputFiles[i] = tmp;
     }
   }

--- a/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TextureAtlas.cpp
@@ -52,7 +52,7 @@ ezResult ezTexConvProcessor::GenerateTextureAtlas(ezMemoryStreamWriter& stream)
     if (false)
     {
       ezStringBuilder sOut;
-      sOut.Format("D:/atlas_{}.dds", layerIdx);
+      sOut.SetFormat("D:/atlas_{}.dds", layerIdx);
 
       ezFileWriter fOut;
       if (fOut.Open(sOut).Succeeded())

--- a/Code/Engine/Utilities/DGML/Implementation/DGMLCreator.cpp
+++ b/Code/Engine/Utilities/DGML/Implementation/DGMLCreator.cpp
@@ -28,7 +28,7 @@ void ezDGMLGraphCreator::FillGraphFromWorld(ezWorld* pWorld, ezDGMLGraph& ref_gr
     ezVisitorExecution::Enum Visit(ezGameObject* pObject)
     {
       ezStringBuilder name;
-      name.Format("GameObject: \"{0}\"", pObject->GetName().IsEmpty() ? "<Unnamed>" : pObject->GetName());
+      name.SetFormat("GameObject: \"{0}\"", pObject->GetName().IsEmpty() ? "<Unnamed>" : pObject->GetName());
 
       // Create node for game object
       ezDGMLGraph::NodeDesc gameobjectND;

--- a/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavigationConfig.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavigationConfig.cpp
@@ -12,7 +12,7 @@ ezAiNavigationConfig::ezAiNavigationConfig()
   ezStringBuilder tmp;
   for (ezUInt32 i = 2; i < ezAiNumGroundTypes; ++i)
   {
-    tmp.Format("Custom Ground Type {}", i + 1);
+    tmp.SetFormat("Custom Ground Type {}", i + 1);
     m_GroundTypes[i].m_sName = tmp;
   }
 

--- a/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.cpp
+++ b/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.cpp
@@ -316,7 +316,7 @@ void ezFileserveClient::ComputeDataDirMountPoint(ezStringView sDataDir, ezString
   EZ_ASSERT_DEV(sDataDir.IsEmpty() || sDataDir.EndsWith("/"), "Invalid path");
 
   const ezUInt32 uiMountPoint = ezHashingUtils::xxHash32String(sDataDir);
-  out_sMountPoint.Format("{0}", ezArgU(uiMountPoint, 8, true, 16));
+  out_sMountPoint.SetFormat("{0}", ezArgU(uiMountPoint, 8, true, 16));
 }
 
 void ezFileserveClient::GetFullDataDirCachePath(const char* szDataDir, ezStringBuilder& out_sFullPath, ezStringBuilder& out_sFullPathMeta) const
@@ -854,7 +854,7 @@ ezResult ezFileserveClient::WaitForServerInfo(ezTime timeout /*= ezTime::MakeFro
     ezStringBuilder sAddress;
     for (auto& ip : sServerIPs)
     {
-      sAddress.Format("{0}:{1}", ip, uiPort);
+      sAddress.SetFormat("{0}:{1}", ip, uiPort);
 
       ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(500));
 

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -740,7 +740,7 @@ void ezFmodEventComponent::Update()
       }
 
       ezStringBuilder sb;
-      sb.Format("{}\n{}", path, szCurrentState);
+      sb.SetFormat("{}\n{}", path, szCurrentState);
 
       if (GetUseOcclusion())
       {

--- a/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
@@ -597,7 +597,7 @@ ezTypedResourceHandle<ResourceType> ezHeightfieldComponent::GenerateMesh() const
     uiSettingsHash = ezHashingUtils::xxHash64(&m_vTexCoordScale, sizeof(m_vTexCoordScale), uiSettingsHash);
     uiSettingsHash = ezHashingUtils::xxHash64(&m_vTesselation, sizeof(m_vTesselation), uiSettingsHash);
 
-    sResourceName.Format("Heightfield:{}", uiSettingsHash);
+    sResourceName.SetFormat("Heightfield:{}", uiSettingsHash);
 
     ezTypedResourceHandle<ResourceType> hResource = ezResourceManager::GetExistingResource<ResourceType>(sResourceName);
     if (hResource.IsValid())

--- a/Code/EnginePlugins/InspectorPlugin/FileSystem.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/FileSystem.cpp
@@ -22,7 +22,7 @@ static void FileSystemEventHandler(const ezFileSystem::FileEvent& e)
       }
 
       ezStringBuilder sName;
-      sName.Format("IO/DataDirs/Dir{0}", ezArgI(it.Value(), 2, true));
+      sName.SetFormat("IO/DataDirs/Dir{0}", ezArgI(it.Value(), 2, true));
 
       ezStats::SetStat(sName.GetData(), e.m_sFileOrDirectory);
     }
@@ -36,7 +36,7 @@ static void FileSystemEventHandler(const ezFileSystem::FileEvent& e)
         break;
 
       ezStringBuilder sName;
-      sName.Format("IO/DataDirs/Dir{0}", ezArgI(it.Value(), 2, true));
+      sName.SetFormat("IO/DataDirs/Dir{0}", ezArgI(it.Value(), 2, true));
 
       ezStats::RemoveStat(sName.GetData());
     }

--- a/Code/EnginePlugins/InspectorPlugin/Stats.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/Stats.cpp
@@ -96,10 +96,10 @@ static void PerFrameUpdateHandler(const ezGameApplicationExecutionEvent& e)
           ezUInt32 uiNumTasks = 0;
           const double Utilization = ezTaskSystem::GetThreadUtilization(ezWorkerThreadType::ShortTasks, t, &uiNumTasks);
 
-          s.Format("Utilization/Short{0}_Load[%%]", ezArgI(t, 2, true));
+          s.SetFormat("Utilization/Short{0}_Load[%%]", ezArgI(t, 2, true));
           ezStats::SetStat(s.GetData(), Utilization * 100.0);
 
-          s.Format("Utilization/Short{0}_Tasks", ezArgI(t, 2, true));
+          s.SetFormat("Utilization/Short{0}_Tasks", ezArgI(t, 2, true));
           ezStats::SetStat(s.GetData(), uiNumTasks);
         }
 
@@ -108,10 +108,10 @@ static void PerFrameUpdateHandler(const ezGameApplicationExecutionEvent& e)
           ezUInt32 uiNumTasks = 0;
           const double Utilization = ezTaskSystem::GetThreadUtilization(ezWorkerThreadType::LongTasks, t, &uiNumTasks);
 
-          s.Format("Utilization/Long{0}_Load[%%]", ezArgI(t, 2, true));
+          s.SetFormat("Utilization/Long{0}_Load[%%]", ezArgI(t, 2, true));
           ezStats::SetStat(s.GetData(), Utilization * 100.0);
 
-          s.Format("Utilization/Long{0}_Tasks", ezArgI(t, 2, true));
+          s.SetFormat("Utilization/Long{0}_Tasks", ezArgI(t, 2, true));
           ezStats::SetStat(s.GetData(), uiNumTasks);
         }
 
@@ -120,10 +120,10 @@ static void PerFrameUpdateHandler(const ezGameApplicationExecutionEvent& e)
           ezUInt32 uiNumTasks = 0;
           const double Utilization = ezTaskSystem::GetThreadUtilization(ezWorkerThreadType::FileAccess, t, &uiNumTasks);
 
-          s.Format("Utilization/File{0}_Load[%%]", ezArgI(t, 2, true));
+          s.SetFormat("Utilization/File{0}_Load[%%]", ezArgI(t, 2, true));
           ezStats::SetStat(s.GetData(), Utilization * 100.0);
 
-          s.Format("Utilization/File{0}_Tasks", ezArgI(t, 2, true));
+          s.SetFormat("Utilization/File{0}_Tasks", ezArgI(t, 2, true));
           ezStats::SetStat(s.GetData(), uiNumTasks);
         }
       }

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
@@ -254,7 +254,7 @@ void ezJoltRopeComponent::CreateRope()
       // set previous name as parent name
       joint.mParentName = name;
 
-      name.Format("Link{}", idx);
+      name.SetFormat("Link{}", idx);
       joint.mName = name;
       joint.mParentJointIndex = static_cast<ezInt32>(idx) - 1;
     }

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
@@ -48,7 +48,7 @@ static void JoltTraceFunc(const char* szText, ...)
 
   va_list args;
   va_start(args, szText);
-  tmp.PrintfArgs(szText, args);
+  tmp.SetPrintfArgs(szText, args);
   va_end(args);
 
   ezLog::Dev("Jolt: {}", tmp);

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -991,7 +991,7 @@ void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, 
         desc.m_bColorStream = false;
 
         ezStringBuilder sGuid;
-        sGuid.Format("ColMeshVisGeo_{}", s_iColMeshVisGeoCounter.Increment());
+        sGuid.SetFormat("ColMeshVisGeo_{}", s_iColMeshVisGeoCounter.Increment());
 
         if (!shapeGeo.m_hMesh.IsValid())
         {

--- a/Code/EnginePlugins/KrautPlugin/Components/KrautTreeComponent.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Components/KrautTreeComponent.cpp
@@ -445,7 +445,7 @@ void ezKrautTreeComponent::ComputeWind() const
     ezDebugRenderer::DrawLines(GetWorld(), lines, ezColor::White);
 
     ezStringBuilder tmp;
-    tmp.Format("Wind: {}m/s", m_vWindSpringPos.GetLength());
+    tmp.SetFormat("Wind: {}m/s", m_vWindSpringPos.GetLength());
 
     ezDebugRenderer::Draw3DText(GetWorld(), tmp, GetOwner()->GetGlobalPosition() + ezVec3(0, 0, 1), ezColor::DeepSkyBlue);
   }
@@ -454,7 +454,7 @@ void ezKrautTreeComponent::ComputeWind() const
 void ezKrautTreeComponent::OnMsgExtractGeometry(ezMsgExtractGeometry& ref_msg) const
 {
   ezStringBuilder sResourceName;
-  sResourceName.Format("KrautTreeCpu:{}", m_hKrautGenerator.GetResourceID());
+  sResourceName.SetFormat("KrautTreeCpu:{}", m_hKrautGenerator.GetResourceID());
 
   ezCpuMeshResourceHandle hMesh = ezResourceManager::GetExistingResource<ezCpuMeshResource>(sResourceName);
   if (!hMesh.IsValid())

--- a/Code/EnginePlugins/KrautPlugin/Resources/KrautTreeResource.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Resources/KrautTreeResource.cpp
@@ -162,7 +162,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezKrautTreeResource, ezKrautTreeResourceDescrip
       md.SetMaterial(mat, descriptor.m_Materials[mat].m_sMaterial);
     }
 
-    sResName.Format("{0}_{1}_LOD{2}", GetResourceID(), GetCurrentResourceChangeCounter(), lodIdx);
+    sResName.SetFormat("{0}_{1}_LOD{2}", GetResourceID(), GetCurrentResourceChangeCounter(), lodIdx);
 
     if (GetResourceDescription().IsEmpty())
     {
@@ -170,7 +170,7 @@ EZ_RESOURCE_IMPLEMENT_CREATEABLE(ezKrautTreeResource, ezKrautTreeResourceDescrip
     }
     else
     {
-      sResDesc.Format("{0}_{1}_LOD{2}", GetResourceDescription(), GetCurrentResourceChangeCounter(), lodIdx);
+      sResDesc.SetFormat("{0}_{1}_LOD{2}", GetResourceDescription(), GetCurrentResourceChangeCounter(), lodIdx);
     }
 
     lodDst.m_hMesh = ezResourceManager::GetExistingResource<ezMeshResource>(sResName);

--- a/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleEffects.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleEffects.cpp
@@ -34,7 +34,7 @@ ezParticleEffectHandle ezParticleWorldModule::InternalCreateSharedEffectInstance
   EZ_LOCK(m_Mutex);
 
   ezStringBuilder fullName;
-  fullName.Format("{{0}}-{{1}}[{2}]", szSharedName, hResource.GetResourceID(), uiRandomSeed);
+  fullName.SetFormat("{{0}}-{{1}}[{2}]", szSharedName, hResource.GetResourceID(), uiRandomSeed);
 
   bool bExisted = false;
   auto it = m_SharedEffects.FindOrAdd(fullName, &bExisted);

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -215,7 +215,7 @@ void ezProcPlacementComponentManager::PreparePlace(const ezWorldModule::UpdateCo
   if (cvar_ProcGenVisTiles)
   {
     ezStringBuilder sb;
-    sb.Format("Procedural Placement Stats:\nNum Tiles to process: {}", m_NewTiles.GetCount());
+    sb.SetFormat("Procedural Placement Stats:\nNum Tiles to process: {}", m_NewTiles.GetCount());
 
     ezColor textColor = ezColorScheme::LightUI(ezColorScheme::Grape);
     ezDebugRenderer::DrawInfoText(GetWorld(), ezDebugTextPlacement::TopLeft, "ProcPlaceStats", sb, textColor);
@@ -376,7 +376,7 @@ void ezProcPlacementComponentManager::DebugDrawTile(const ezProcGenInternal::Pla
   ezStringBuilder sb;
   if (uiQueueIndex != ezInvalidIndex)
   {
-    sb.Format("Queue Index: {}\n", uiQueueIndex);
+    sb.SetFormat("Queue Index: {}\n", uiQueueIndex);
   }
   sb.AppendFormat("Age: {}\nDistance: {}", uiAge, desc.m_fDistanceToCamera);
   ezDebugRenderer::Draw3DText(GetWorld(), sb, bbox.GetCenter(), color);
@@ -444,10 +444,10 @@ ezUInt32 ezProcPlacementComponentManager::AllocateProcessingTask(ezUInt32 uiTile
     newTask.m_pData = EZ_DEFAULT_NEW(PlacementData);
 
     ezStringBuilder sName;
-    sName.Format("Prepare Task {}", uiNewTaskIndex);
+    sName.SetFormat("Prepare Task {}", uiNewTaskIndex);
     newTask.m_pPrepareTask = EZ_DEFAULT_NEW(PreparePlacementTask, newTask.m_pData.Borrow(), sName);
 
-    sName.Format("Placement Task {}", uiNewTaskIndex);
+    sName.SetFormat("Placement Task {}", uiNewTaskIndex);
     newTask.m_pPlacementTask = EZ_DEFAULT_NEW(PlacementTask, newTask.m_pData.Borrow(), sName);
   }
 

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/FindPlacementTilesTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/FindPlacementTilesTask.cpp
@@ -15,7 +15,7 @@ FindPlacementTilesTask::FindPlacementTilesTask(ezProcPlacementComponent* pCompon
   , m_uiOutputIndex(uiOutputIndex)
 {
   ezStringBuilder sName;
-  sName.Format("UpdateTiles {}", m_pComponent->m_OutputContexts[m_uiOutputIndex].m_pOutput->m_sName);
+  sName.SetFormat("UpdateTiles {}", m_pComponent->m_OutputContexts[m_uiOutputIndex].m_pOutput->m_sName);
 
   ConfigureTask(sName, ezTaskNesting::Never);
 }

--- a/Code/EnginePlugins/RecastPlugin/Components/RecastNavMeshComponent.cpp
+++ b/Code/EnginePlugins/RecastPlugin/Components/RecastNavMeshComponent.cpp
@@ -90,7 +90,7 @@ void ezRcNavMeshComponent::OnObjectCreated(const ezAbstractObjectNode& node)
   ezConversionUtils::ToString(node.GetGuid(), sComponentGuid);
 
   // this is where the editor will put the file for this component
-  sNavMeshFile.Format(":project/AssetCache/Generated/{0}.ezRecastNavMesh", sComponentGuid);
+  sNavMeshFile.SetFormat(":project/AssetCache/Generated/{0}.ezRecastNavMesh", sComponentGuid);
 
   m_hNavMesh = ezResourceManager::LoadResource<ezRecastNavMeshResource>(sNavMeshFile);
 }

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
@@ -146,7 +146,7 @@ namespace ezRmlUiInternal
     ezUInt64 uiHash = ezHashingUtils::xxHash64(pSource, uiSizeInBytes);
 
     ezStringBuilder sTextureName;
-    sTextureName.Format("RmlUiGeneratedTexture_{}x{}_{}", uiWidth, uiHeight, uiHash);
+    sTextureName.SetFormat("RmlUiGeneratedTexture_{}x{}_{}", uiWidth, uiHeight, uiHash);
 
     ezTexture2DResourceHandle hTexture = ezResourceManager::GetExistingResource<ezTexture2DResource>(sTextureName);
 

--- a/Code/EnginePlugins/TypeScriptPlugin/Transpiler/Transpiler.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/Transpiler/Transpiler.cpp
@@ -163,7 +163,7 @@ ezResult ezTypeScriptTranspiler::TranspileFileAndStoreJS(const char* szFile, ezS
     }
 
     ezStringBuilder sHashHeader;
-    sHashHeader.Format("/*SOURCE-HASH:{}*/\n", ezArgU(uiActualFileHash, 16, true, 16, true));
+    sHashHeader.SetFormat("/*SOURCE-HASH:{}*/\n", ezArgU(uiActualFileHash, 16, true, 16, true));
     out_sResult.Prepend(sHashHeader);
 
     EZ_SUCCEED_OR_RETURN(fileOut.WriteBytes(out_sResult.GetData(), out_sResult.GetElementCount()));

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/ComponentCodeGen.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/ComponentCodeGen.cpp
@@ -199,7 +199,7 @@ void ezTypeScriptBinding::InjectComponentImportExport(ezStringBuilder& content, 
 
   ezStringBuilder sImportExport, sTypeName;
 
-  sImportExport.Format(R"(import __AllComponents = require("{}")
+  sImportExport.SetFormat(R"(import __AllComponents = require("{}")
 )",
     szComponentFile);
 

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/PropertyBinding.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/PropertyBinding.cpp
@@ -65,10 +65,10 @@ void ezTypeScriptBinding::GeneratePropertiesCode(ezStringBuilder& out_Code, cons
     if (sTypeName.IsEmpty())
       continue;
 
-    sProp.Format("  get {0}(): {1} { return __CPP_ComponentProperty_get(this, {2}); }\n", pMember->GetPropertyName(), sTypeName, uiHash);
+    sProp.SetFormat("  get {0}(): {1} { return __CPP_ComponentProperty_get(this, {2}); }\n", pMember->GetPropertyName(), sTypeName, uiHash);
     out_Code.Append(sProp.GetView());
 
-    sProp.Format("  set {0}(value: {1}) { __CPP_ComponentProperty_set(this, {2}, value); }\n", pMember->GetPropertyName(), sTypeName, uiHash);
+    sProp.SetFormat("  set {0}(value: {1}) { __CPP_ComponentProperty_set(this, {2}, value); }\n", pMember->GetPropertyName(), sTypeName, uiHash);
     out_Code.Append(sProp.GetView());
   }
 }

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsBinding.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsBinding.cpp
@@ -153,7 +153,7 @@ ezResult ezTypeScriptBinding::LoadComponent(const ezUuid& typeGuid, TsComponentT
   m_Duk.PushGlobalObject();
 
   ezStringBuilder req;
-  req.Format("var {} = require(\"./{}\");", sCompModule, itType.Value().m_sComponentFilePath);
+  req.SetFormat("var {} = require(\"./{}\");", sCompModule, itType.Value().m_sComponentFilePath);
   if (m_Duk.ExecuteString(req).Failed())
   {
     ezLog::Error("Could not load component");
@@ -386,77 +386,77 @@ void ezTypeScriptBinding::GenerateConstructorString(ezStringBuilder& out_String,
     case ezVariant::Type::ColorGamma:
     {
       const ezColor c = value.ConvertTo<ezColor>();
-      out_String.Format("new Color({}, {}, {}, {})", c.r, c.g, c.b, c.a);
+      out_String.SetFormat("new Color({}, {}, {}, {})", c.r, c.g, c.b, c.a);
       break;
     }
 
     case ezVariant::Type::Vector2:
     {
       const ezVec2 v = value.Get<ezVec2>();
-      out_String.Format("new Vec2({}, {})", v.x, v.y);
+      out_String.SetFormat("new Vec2({}, {})", v.x, v.y);
       break;
     }
 
     case ezVariant::Type::Vector3:
     {
       const ezVec3 v = value.Get<ezVec3>();
-      out_String.Format("new Vec3({}, {}, {})", v.x, v.y, v.z);
+      out_String.SetFormat("new Vec3({}, {}, {})", v.x, v.y, v.z);
       break;
     }
 
     case ezVariant::Type::Vector4:
     {
       const ezVec4 v = value.Get<ezVec4>();
-      out_String.Format("new Vec4({}, {}, {}, {})", v.x, v.y, v.z, v.w);
+      out_String.SetFormat("new Vec4({}, {}, {}, {})", v.x, v.y, v.z, v.w);
       break;
     }
 
     case ezVariant::Type::Vector2I:
     {
       const ezVec2I32 v = value.Get<ezVec2I32>();
-      out_String.Format("new Vec2({}, {})", v.x, v.y);
+      out_String.SetFormat("new Vec2({}, {})", v.x, v.y);
       break;
     }
 
     case ezVariant::Type::Vector3I:
     {
       const ezVec3I32 v = value.Get<ezVec3I32>();
-      out_String.Format("new Vec3({}, {}, {})", v.x, v.y, v.z);
+      out_String.SetFormat("new Vec3({}, {}, {})", v.x, v.y, v.z);
       break;
     }
 
     case ezVariant::Type::Vector4I:
     {
       const ezVec4I32 v = value.Get<ezVec4I32>();
-      out_String.Format("new Vec4({}, {}, {}, {})", v.x, v.y, v.z, v.w);
+      out_String.SetFormat("new Vec4({}, {}, {}, {})", v.x, v.y, v.z, v.w);
       break;
     }
 
     case ezVariant::Type::Vector2U:
     {
       const ezVec2U32 v = value.Get<ezVec2U32>();
-      out_String.Format("new Vec2({}, {})", v.x, v.y);
+      out_String.SetFormat("new Vec2({}, {})", v.x, v.y);
       break;
     }
 
     case ezVariant::Type::Vector3U:
     {
       const ezVec3U32 v = value.Get<ezVec3U32>();
-      out_String.Format("new Vec3({}, {}, {})", v.x, v.y, v.z);
+      out_String.SetFormat("new Vec3({}, {}, {})", v.x, v.y, v.z);
       break;
     }
 
     case ezVariant::Type::Vector4U:
     {
       const ezVec4U32 v = value.Get<ezVec4U32>();
-      out_String.Format("new Vec4({}, {}, {}, {})", v.x, v.y, v.z, v.w);
+      out_String.SetFormat("new Vec4({}, {}, {}, {})", v.x, v.y, v.z, v.w);
       break;
     }
 
     case ezVariant::Type::Quaternion:
     {
       const ezQuat q = value.Get<ezQuat>();
-      out_String.Format("new Quat({}, {}, {}, {})", q.x, q.y, q.z, q.w);
+      out_String.SetFormat("new Quat({}, {}, {}, {})", q.x, q.y, q.z, q.w);
       break;
     }
 
@@ -479,11 +479,11 @@ void ezTypeScriptBinding::GenerateConstructorString(ezStringBuilder& out_String,
     }
 
     case ezVariant::Type::Time:
-      out_String.Format("{0}", value.Get<ezTime>().GetSeconds());
+      out_String.SetFormat("{0}", value.Get<ezTime>().GetSeconds());
       break;
 
     case ezVariant::Type::Angle:
-      out_String.Format("{0}", value.Get<ezAngle>().GetRadian());
+      out_String.SetFormat("{0}", value.Get<ezAngle>().GetRadian());
       break;
 
     case ezVariant::Type::Uuid:

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsCodeGen.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsCodeGen.cpp
@@ -58,7 +58,7 @@ void ezTypeScriptBinding::GenerateEnumsFile(const char* szFile, const ezSet<cons
   {
     const ezRTTI* pRtti = sortedItems.GetValue(i);
 
-    sType.Format("export enum {0} { ", sortedItems.GetKey(i));
+    sType.SetFormat("export enum {0} { ", sortedItems.GetKey(i));
 
     for (auto pProp : pRtti->GetProperties().GetSubArray(1))
     {
@@ -93,7 +93,7 @@ void ezTypeScriptBinding::InjectEnumImportExport(ezStringBuilder& content, const
 {
   ezStringBuilder sImportExport, sTypeName;
 
-  sImportExport.Format("import __AllEnums = require(\"{}\")\n", szEnumFile);
+  sImportExport.SetFormat("import __AllEnums = require(\"{}\")\n", szEnumFile);
 
   ezDynamicArray<const ezRTTI*> sorted;
   sorted.Reserve(s_RequiredEnums.GetCount());
@@ -116,7 +116,7 @@ void ezTypeScriptBinding::InjectFlagsImportExport(ezStringBuilder& content, cons
 {
   ezStringBuilder sImportExport, sTypeName;
 
-  sImportExport.Format("import __AllFlags = require(\"{}\")\n", szFlagsFile);
+  sImportExport.SetFormat("import __AllFlags = require(\"{}\")\n", szFlagsFile);
 
   ezDynamicArray<const ezRTTI*> sorted;
   sorted.Reserve(s_RequiredFlags.GetCount());

--- a/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsMessages.cpp
+++ b/Code/EnginePlugins/TypeScriptPlugin/TsBinding/TsMessages.cpp
@@ -146,11 +146,11 @@ void ezTypeScriptBinding::GenerateMessagePropertiesCode(ezStringBuilder& out_Cod
 
     if (!sDefault.IsEmpty())
     {
-      sProp.Format("  {0}: {1} = {2};\n", pMember->GetPropertyName(), szTypeName, sDefault);
+      sProp.SetFormat("  {0}: {1} = {2};\n", pMember->GetPropertyName(), szTypeName, sDefault);
     }
     else
     {
-      sProp.Format("  {0}: {1};\n", pMember->GetPropertyName(), szTypeName);
+      sProp.SetFormat("  {0}: {1};\n", pMember->GetPropertyName(), szTypeName);
     }
 
     out_Code.Append(sProp.GetView());
@@ -164,7 +164,7 @@ void ezTypeScriptBinding::InjectMessageImportExport(ezStringBuilder& content, co
 
   ezStringBuilder sImportExport, sTypeName;
 
-  sImportExport.Format(R"(import __AllMessages = require("{}")
+  sImportExport.SetFormat(R"(import __AllMessages = require("{}")
 )",
     szMessageFile);
 
@@ -376,7 +376,7 @@ bool ezTypeScriptBinding::DeliverMessage(const TsComponentTypeInfo& typeInfo, ez
 
         if (bSynchronizeAfterwards)
         {
-          sStashMsgName.Format("ezMsg-{}", m_iMsgDeliveryRecursion);
+          sStashMsgName.SetFormat("ezMsg-{}", m_iMsgDeliveryRecursion);
 
           duk.PushGlobalStash();                       // [ ... stash ]
           duk_dup(duk, -2);                            // [ ... stash msg ]

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -957,7 +957,7 @@ namespace
                   std::is_same_v<T, ezTypedPointer>)
     {
       ezTypedPointer p = inout_context.GetPointerData(node.GetInputDataOffset(0));
-      sb.Format("{} {}", p.m_pType->GetTypeName(), ezArgP(p.m_pObject));
+      sb.SetFormat("{} {}", p.m_pType->GetTypeName(), ezArgP(p.m_pObject));
       s = sb;
     }
     else if constexpr (std::is_same_v<T, ezString>)
@@ -1012,7 +1012,7 @@ namespace
                   std::is_same_v<T, ezTypedPointer>)
     {
       ezTypedPointer p = inout_context.GetPointerData(node.GetInputDataOffset(0));
-      sb.Format("{} {}", p.m_pType->GetTypeName(), ezArgP(p.m_pObject));
+      sb.SetFormat("{} {}", p.m_pType->GetTypeName(), ezArgP(p.m_pObject));
       s = sb;
     }
     else if constexpr (std::is_same_v<T, ezString>)

--- a/Code/EnginePlugins/XBoxControllerPlugin/InputDeviceXBox.cpp
+++ b/Code/EnginePlugins/XBoxControllerPlugin/InputDeviceXBox.cpp
@@ -22,8 +22,8 @@ void ezInputDeviceXBox360::RegisterControllerButton(const char* szButton, const 
 
   for (ezInt32 i = 0; i < MaxControllers; ++i)
   {
-    s.Format("controller{0}_{1}", i, szButton);
-    s2.Format("Cont {0}: {1}", i + 1, szName);
+    s.SetFormat("controller{0}_{1}", i, szButton);
+    s2.SetFormat("Cont {0}: {1}", i + 1, szName);
     RegisterInputSlot(s.GetData(), s2.GetData(), SlotFlags);
   }
 }
@@ -34,7 +34,7 @@ void ezInputDeviceXBox360::SetDeadZone(const char* szButton)
 
   for (ezInt32 i = 0; i < MaxControllers; ++i)
   {
-    s.Format("controller{0}_{1}", i, szButton);
+    s.SetFormat("controller{0}_{1}", i, szButton);
     ezInputManager::SetInputSlotDeadZone(s.GetData(), 0.23f);
   }
 }

--- a/Code/Samples/Asteroids/GameState.cpp
+++ b/Code/Samples/Asteroids/GameState.cpp
@@ -85,10 +85,10 @@ void AsteroidGameState::ConfigureInputActions()
     for (ezInt32 iAction = 0; iAction < MaxPlayerActions; ++iAction)
     {
       ezStringBuilder sAction;
-      sAction.Format("Player{0}_{1}", iPlayer, szPlayerActions[iAction]);
+      sAction.SetFormat("Player{0}_{1}", iPlayer, szPlayerActions[iAction]);
 
       ezStringBuilder sKey;
-      sKey.Format("controller{0}_{1}", iPlayer, szControlerKeys[iAction]);
+      sKey.SetFormat("controller{0}_{1}", iPlayer, szControlerKeys[iAction]);
 
       RegisterInputAction("Game", sAction.GetData(), sKey.GetData());
     }

--- a/Code/Samples/Asteroids/Level.cpp
+++ b/Code/Samples/Asteroids/Level.cpp
@@ -81,7 +81,7 @@ void Level::UpdatePlayerInput(ezInt32 iPlayer)
   ezStringBuilder sControls[MaxPlayerActions];
 
   for (ezInt32 iAction = 0; iAction < MaxPlayerActions; ++iAction)
-    sControls[iAction].Format("Player{0}_{1}", iPlayer, szPlayerActions[iAction]);
+    sControls[iAction].SetFormat("Player{0}_{1}", iPlayer, szPlayerActions[iAction]);
 
 
   if (ezInputManager::GetInputActionState("Game", sControls[0].GetData(), &fVal) != ezKeyState::Up)
@@ -158,7 +158,7 @@ void Level::CreatePlayerShip(ezInt32 iPlayer)
     // this only works because the materials are part of the Asset Collection and get a name like this from there
     // otherwise we would need to have the GUIDs of the 4 different material assets available
     ezStringBuilder sMaterialName;
-    sMaterialName.Format("MaterialPlayer{0}", iPlayer + 1);
+    sMaterialName.SetFormat("MaterialPlayer{0}", iPlayer + 1);
     pMeshComponent->SetMaterial(0, ezResourceManager::LoadResource<ezMaterialResource>(sMaterialName));
   }
   {

--- a/Code/Samples/Asteroids/ProjectileComponent.cpp
+++ b/Code/Samples/Asteroids/ProjectileComponent.cpp
@@ -123,7 +123,7 @@ void ProjectileComponent::Update()
               // this only works because the materials are part of the Asset Collection and get a name like this from there
               // otherwise we would need to have the GUIDs of the 4 different material assets available
               ezStringBuilder sMaterialName;
-              sMaterialName.Format("MaterialPlayer{0}", pShipComponent->m_iPlayerIndex + 1);
+              sMaterialName.SetFormat("MaterialPlayer{0}", pShipComponent->m_iPlayerIndex + 1);
               pMeshComponent->SetMaterial(0, ezResourceManager::LoadResource<ezMaterialResource>(sMaterialName));
             }
           }

--- a/Code/Samples/Asteroids/ShipComponent.cpp
+++ b/Code/Samples/Asteroids/ShipComponent.cpp
@@ -35,8 +35,8 @@ void ShipComponent::SetVelocity(const ezVec3& vVel)
   m_vVelocity += vVel * 0.1f;
 
   ezStringBuilder s, v;
-  s.Format("Game/Player{0}/Velocity", m_iPlayerIndex);
-  v.Format("{0} | {1} | {2}", ezArgF(m_vVelocity.x, 3), ezArgF(m_vVelocity.y, 3), ezArgF(m_vVelocity.z, 3));
+  s.SetFormat("Game/Player{0}/Velocity", m_iPlayerIndex);
+  v.SetFormat("{0} | {1} | {2}", ezArgF(m_vVelocity.x, 3), ezArgF(m_vVelocity.y, 3), ezArgF(m_vVelocity.z, 3));
 
   ezStats::SetStat(s.GetData(), v.GetData());
 }
@@ -49,7 +49,7 @@ void ShipComponent::SetIsShooting(bool b)
   m_bIsShooting = b;
 
   ezStringBuilder s, v;
-  s.Format("Game/Player{0}/Shooting", m_iPlayerIndex);
+  s.SetFormat("Game/Player{0}/Shooting", m_iPlayerIndex);
   v = b ? "Yes" : "No";
 
   ezStats::SetStat(s.GetData(), v.GetData());
@@ -130,7 +130,7 @@ void ShipComponent::Update()
       // this only works because the materials are part of the Asset Collection and get a name like this from there
       // otherwise we would need to have the GUIDs of the 4 different material assets available
       ezStringBuilder sMaterialName;
-      sMaterialName.Format("MaterialPlayer{0}", m_iPlayerIndex + 1);
+      sMaterialName.SetFormat("MaterialPlayer{0}", m_iPlayerIndex + 1);
       pMeshComponent->SetMaterial(0, ezResourceManager::LoadResource<ezMaterialResource>(sMaterialName));
     }
 
@@ -158,15 +158,15 @@ void ShipComponent::Update()
   ezStringBuilder s, v;
 
   {
-    s.Format("Game/Player{0}/Health", m_iPlayerIndex);
-    v.Format("{0}", m_fHealth);
+    s.SetFormat("Game/Player{0}/Health", m_iPlayerIndex);
+    v.SetFormat("{0}", m_fHealth);
 
     ezStats::SetStat(s.GetData(), v.GetData());
   }
 
   {
-    s.Format("Game/Player{0}/Ammo", m_iPlayerIndex);
-    v.Format("{0}", m_fAmmunition);
+    s.SetFormat("Game/Player{0}/Ammo", m_iPlayerIndex);
+    v.SetFormat("{0}", m_fAmmunition);
 
     ezStats::SetStat(s.GetData(), v.GetData());
   }

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -243,7 +243,7 @@ public:
       {
         for (ezInt32 x = -g_iMaxHalfExtent; x < g_iMaxHalfExtent; ++x)
         {
-          sResourceName.Printf("Loaded_%+03i_%+03i_D", x, y);
+          sResourceName.SetPrintf("Loaded_%+03i_%+03i_D", x, y);
 
           ezTexture2DResourceHandle hTexture = ezResourceManager::LoadResource<ezTexture2DResource>(sResourceName);
 
@@ -333,7 +333,7 @@ public:
             cb.ViewProjectionMatrix = Proj;
           }
 
-          sResourceName.Printf("Loaded_%+03i_%+03i_D", x, y);
+          sResourceName.SetPrintf("Loaded_%+03i_%+03i_D", x, y);
 
           ezTexture2DResourceHandle hTexture = ezResourceManager::LoadResource<ezTexture2DResource>(sResourceName);
 

--- a/Code/Tools/DependencyAnalysis/DependencyAnalysis.cpp
+++ b/Code/Tools/DependencyAnalysis/DependencyAnalysis.cpp
@@ -111,7 +111,7 @@ namespace
       if (!needed && sVarName != "directory" && sVarName != "output")
       {
         ezStringBuilder fmt;
-        fmt.Format("Unknown variable '{0}'", sVarName);
+        fmt.SetFormat("Unknown variable '{0}'", sVarName);
         ParsingError(fmt.GetView(), false);
       }
       return needed;

--- a/Code/Tools/Inspector/DataTransferWidget.cpp
+++ b/Code/Tools/Inspector/DataTransferWidget.cpp
@@ -236,7 +236,7 @@ void ezQtDataWidget::on_ComboItems_currentIndexChanged(int index)
   else
   {
     ezStringBuilder sText;
-    sText.Format("Cannot display data of Mime-Type '{0}'", sMime);
+    sText.SetFormat("Cannot display data of Mime-Type '{0}'", sMime);
 
     LabelImage->setText(sText.GetData());
   }

--- a/Code/Tools/Inspector/FileWidget.cpp
+++ b/Code/Tools/Inspector/FileWidget.cpp
@@ -189,7 +189,7 @@ void ezQtFileWidget::ProcessTelemetry(void* pUnuseed)
         Msg.GetReader() >> bSuccess;
 
         ezStringBuilder s;
-        s.Format("'{0}' -> '{1}'", sFile1, sFile2);
+        s.SetFormat("'{0}' -> '{1}'", sFile1, sFile2);
         data.m_sFile = s.GetData();
 
         data.m_State = bSuccess ? FileCopy : FileCopyFailed;

--- a/Code/Tools/Inspector/GlobalEventsWidget.cpp
+++ b/Code/Tools/Inspector/GlobalEventsWidget.cpp
@@ -116,16 +116,16 @@ void ezQtGlobalEventsWidget::UpdateTable(bool bRecreate)
       pIcon->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
       TableEvents->setCellWidget(iRow, 0, pIcon);
       
-      sTemp.Format("  {0}  ", it.Key());
+      sTemp.SetFormat("  {0}  ", it.Key());
       TableEvents->setCellWidget(iRow, 1, new QLabel(sTemp.GetData())); // Event
 
-      sTemp.Format("  {0}  ", it.Value().m_uiTimesFired);
+      sTemp.SetFormat("  {0}  ", it.Value().m_uiTimesFired);
       TableEvents->setCellWidget(iRow, 2, new QLabel(sTemp.GetData()));
 
-      sTemp.Format("  {0}  ", it.Value().m_uiNumHandlers);
+      sTemp.SetFormat("  {0}  ", it.Value().m_uiNumHandlers);
       TableEvents->setCellWidget(iRow, 3, new QLabel(sTemp.GetData()));
 
-      sTemp.Format("  {0}  ", it.Value().m_uiNumHandlersOnce);
+      sTemp.SetFormat("  {0}  ", it.Value().m_uiNumHandlersOnce);
       TableEvents->setCellWidget(iRow, 4, new QLabel(sTemp.GetData()));
 
       ++iRow;
@@ -140,13 +140,13 @@ void ezQtGlobalEventsWidget::UpdateTable(bool bRecreate)
     ezInt32 iRow = 0;
     for (ezMap<ezString, GlobalEventsData>::Iterator it = m_Events.GetIterator(); it.IsValid(); ++it)
     {
-      sTemp.Format("  {0}  ", it.Value().m_uiTimesFired);
+      sTemp.SetFormat("  {0}  ", it.Value().m_uiTimesFired);
       ((QLabel*)TableEvents->cellWidget(iRow, 2))->setText(sTemp.GetData());
 
-      sTemp.Format("  {0}  ", it.Value().m_uiNumHandlers);
+      sTemp.SetFormat("  {0}  ", it.Value().m_uiNumHandlers);
       ((QLabel*)TableEvents->cellWidget(iRow, 3))->setText(sTemp.GetData());
 
-      sTemp.Format("  {0}  ", it.Value().m_uiNumHandlersOnce);
+      sTemp.SetFormat("  {0}  ", it.Value().m_uiNumHandlersOnce);
       ((QLabel*)TableEvents->cellWidget(iRow, 4))->setText(sTemp.GetData());
 
       ++iRow;

--- a/Code/Tools/Inspector/InputWidget.cpp
+++ b/Code/Tools/Inspector/InputWidget.cpp
@@ -181,7 +181,7 @@ void ezQtInputWidget::UpdateSlotTable(bool bRecreate)
     {
       it.Value().m_iTableRow = iRow;
 
-      sTemp.Format("  {0}  ", it.Key());
+      sTemp.SetFormat("  {0}  ", it.Key());
 
       QLabel* pIcon = new QLabel();
       QIcon icon = ezQtUiServices::GetCachedIconResource(":/Icons/Icons/InputSlots.svg");
@@ -200,7 +200,7 @@ void ezQtInputWidget::UpdateSlotTable(bool bRecreate)
       // Flags
       {
         ezStringBuilder sFlags;
-        sFlags.Printf("  %16b  ", uiFlags);
+        sFlags.SetPrintf("  %16b  ", uiFlags);
 
         QLabel* pFlags = (QLabel*)TableInputSlots->cellWidget(iRow, 5);
         pFlags->setAlignment(Qt::AlignRight);
@@ -271,7 +271,7 @@ void ezQtInputWidget::UpdateSlotTable(bool bRecreate)
           pValue->setText("");
         else
         {
-          sTemp.Format(" {0} ", ezArgF(it.Value().m_fValue, 4));
+          sTemp.SetFormat(" {0} ", ezArgF(it.Value().m_fValue, 4));
           pValue->setText(sTemp.GetData());
         }
       }
@@ -322,7 +322,7 @@ void ezQtInputWidget::UpdateActionTable(bool bRecreate)
     {
       it.Value().m_iTableRow = iRow;
 
-      sTemp.Format("  {0}  ", it.Key());
+      sTemp.SetFormat("  {0}  ", it.Key());
 
       QLabel* pIcon = new QLabel();
       QIcon icon = ezQtUiServices::GetCachedIconResource(":/Icons/Icons/InputActions.svg");
@@ -344,7 +344,7 @@ void ezQtInputWidget::UpdateActionTable(bool bRecreate)
         if (it.Value().m_sTrigger[slot].IsEmpty())
           sTemp = "  ";
         else
-          sTemp.Format("  [Scale: {0}] {1}  ", ezArgF(it.Value().m_fTriggerScaling[slot], 2), it.Value().m_sTrigger[slot]);
+          sTemp.SetFormat("  [Scale: {0}] {1}  ", ezArgF(it.Value().m_fTriggerScaling[slot], 2), it.Value().m_sTrigger[slot]);
 
         QLabel* pValue = (QLabel*)TableInputActions->cellWidget(iRow, 4 + slot);
         pValue->setText(sTemp.GetData());
@@ -391,9 +391,9 @@ void ezQtInputWidget::UpdateActionTable(bool bRecreate)
         else
         {
           if (it.Value().m_bUseTimeScaling)
-            sTemp.Format(" {0} (Time-Scaled) ", ezArgF(it.Value().m_fValue, 4));
+            sTemp.SetFormat(" {0} (Time-Scaled) ", ezArgF(it.Value().m_fValue, 4));
           else
-            sTemp.Format(" {0} (Absolute) ", ezArgF(it.Value().m_fValue, 4));
+            sTemp.SetFormat(" {0} (Absolute) ", ezArgF(it.Value().m_fValue, 4));
 
           pValue->setText(sTemp.GetData());
         }

--- a/Code/Tools/Inspector/MainWindow.cpp
+++ b/Code/Tools/Inspector/MainWindow.cpp
@@ -223,7 +223,7 @@ void ezQtMainWindow::UpdateNetwork()
         bResetStats = true;
 
         ezStringBuilder s;
-        s.Format("Connected to new Server with ID {0}", uiServerID);
+        s.SetFormat("Connected to new Server with ID {0}", uiServerID);
 
         ezQtLogDockWidget::s_pWidget->Log(s.GetData());
       }

--- a/Code/Tools/Inspector/MemoryWidget.cpp
+++ b/Code/Tools/Inspector/MemoryWidget.cpp
@@ -27,13 +27,13 @@ namespace MemoryWidgetDetail
 void FormatSize(ezStringBuilder& s, ezStringView sPrefix, ezUInt64 uiSize)
 {
   if (uiSize < 1024)
-    s.Format("{0}{1} Bytes", sPrefix, uiSize);
+    s.SetFormat("{0}{1} Bytes", sPrefix, uiSize);
   else if (uiSize < 1024 * 1024)
-    s.Format("{0}{1} KB", sPrefix, ezArgF(uiSize / 1024.0, 1));
+    s.SetFormat("{0}{1} KB", sPrefix, ezArgF(uiSize / 1024.0, 1));
   else if (uiSize < 1024 * 1024 * 1024)
-    s.Format("{0}{1} MB", sPrefix, ezArgF(uiSize / 1024.0 / 1024.0, 2));
+    s.SetFormat("{0}{1} MB", sPrefix, ezArgF(uiSize / 1024.0 / 1024.0, 2));
   else
-    s.Format("{0}{1} GB", sPrefix, ezArgF(uiSize / 1024.0 / 1024.0 / 1024.0, 2));
+    s.SetFormat("{0}{1} GB", sPrefix, ezArgF(uiSize / 1024.0 / 1024.0 / 1024.0, 2));
 }
 
 ezQtMemoryWidget::ezQtMemoryWidget(QWidget* pParent)
@@ -175,7 +175,7 @@ void ezQtMemoryWidget::UpdateStats()
       sText.AppendFormat(" [{0}]", sSize);
 
       ezStringBuilder sTooltip;
-      sTooltip.Format("<p>Allocator: <b>{}</b><br>Current Memory Used: <b>{}</b><br>Max Memory Used: <b>{}</b><br>Live Allocations: <b>{}</b><br>Allocations: "
+      sTooltip.SetFormat("<p>Allocator: <b>{}</b><br>Current Memory Used: <b>{}</b><br>Max Memory Used: <b>{}</b><br>Live Allocations: <b>{}</b><br>Allocations: "
                       "<b>{}</b><br>Deallocations: <b>{}</b><br>",
         it.Value().m_sName,
         sSize.GetData(), sMaxSize.GetData(), it.Value().m_uiLiveAllocs, it.Value().m_uiAllocs, it.Value().m_uiDeallocs);
@@ -196,7 +196,7 @@ void ezQtMemoryWidget::UpdateStats()
       sText.AppendFormat(" [{0}]", sSize);
 
       ezStringBuilder sTooltip;
-      sTooltip.Format("<p>Current Memory Used: <b>{0}</b><br>Max Memory Used: <b>{1}</b><br>Live Allocations: <b>{2}</b><br>Allocations: "
+      sTooltip.SetFormat("<p>Current Memory Used: <b>{0}</b><br>Max Memory Used: <b>{1}</b><br>Live Allocations: <b>{2}</b><br>Allocations: "
                       "<b>{3}</b><br>Deallocations: <b>{4}</b><br>",
         sSize.GetData(), sMaxSize.GetData(), m_Accu.m_uiLiveAllocs, m_Accu.m_uiAllocs, m_Accu.m_uiDeallocs);
 
@@ -342,14 +342,14 @@ void ezQtMemoryWidget::UpdateStats()
     FormatSize(s, "Min: ", uiMinUsedMemory);
     LabelMinMemory->setText(QString::fromUtf8(s.GetData()));
 
-    s.Format("<p>Recent Minimum Memory Usage:<br>{0} GB<br>{1} MB<br>{2} KB<br>{3} Byte</p>", ezArgF(uiMinUsedMemory / 1024.0 / 1024.0 / 1024.0, 2),
+    s.SetFormat("<p>Recent Minimum Memory Usage:<br>{0} GB<br>{1} MB<br>{2} KB<br>{3} Byte</p>", ezArgF(uiMinUsedMemory / 1024.0 / 1024.0 / 1024.0, 2),
       ezArgF(uiMinUsedMemory / 1024.0 / 1024.0, 2), ezArgF(uiMinUsedMemory / 1024.0, 2), uiMinUsedMemory);
     LabelMinMemory->setToolTip(QString::fromUtf8(s.GetData()));
 
     FormatSize(s, "Max: ", uiMaxUsedMemory);
     LabelMaxMemory->setText(QString::fromUtf8(s.GetData()));
 
-    s.Format("<p>Recent Maximum Memory Usage:<br>{0} GB<br>{1} MB<br>{2} KB<br>{3} Byte</p>", ezArgF(uiMaxUsedMemory / 1024.0 / 1024.0 / 1024.0, 2),
+    s.SetFormat("<p>Recent Maximum Memory Usage:<br>{0} GB<br>{1} MB<br>{2} KB<br>{3} Byte</p>", ezArgF(uiMaxUsedMemory / 1024.0 / 1024.0 / 1024.0, 2),
       ezArgF(uiMaxUsedMemory / 1024.0 / 1024.0, 2), ezArgF(uiMaxUsedMemory / 1024.0, 2), uiMaxUsedMemory);
     LabelMaxMemory->setToolTip(QString::fromUtf8(s.GetData()));
 
@@ -358,17 +358,17 @@ void ezQtMemoryWidget::UpdateStats()
     FormatSize(s, "Sum: ", uiCurUsedMemory);
     LabelCurMemory->setText(QString::fromUtf8(s.GetData()));
 
-    s.Format("<p>Current Memory Usage:<br>{0} GB<br>{1} MB<br>{2} KB<br>{3} Byte</p>", ezArgF(uiCurUsedMemory / 1024.0 / 1024.0 / 1024.0, 2),
+    s.SetFormat("<p>Current Memory Usage:<br>{0} GB<br>{1} MB<br>{2} KB<br>{3} Byte</p>", ezArgF(uiCurUsedMemory / 1024.0 / 1024.0 / 1024.0, 2),
       ezArgF(uiCurUsedMemory / 1024.0 / 1024.0, 2), ezArgF(uiCurUsedMemory / 1024.0, 2), uiCurUsedMemory);
     LabelCurMemory->setToolTip(QString::fromUtf8(s.GetData()));
 
-    s.Format("Allocs: {0}", uiLiveAllocs);
+    s.SetFormat("Allocs: {0}", uiLiveAllocs);
     LabelNumLiveAllocs->setText(QString::fromUtf8(s.GetData()));
 
-    s.Format("Counter: {0} / {1}", uiAllocs, uiDeallocs);
+    s.SetFormat("Counter: {0} / {1}", uiAllocs, uiDeallocs);
     LabelNumAllocs->setText(QString::fromUtf8(s.GetData()));
 
-    s.Format("<p>Allocations: <b>{0}</b><br>Deallocations: <b>{1}</b></p>", uiAllocs, uiDeallocs);
+    s.SetFormat("<p>Allocations: <b>{0}</b><br>Deallocations: <b>{1}</b></p>", uiAllocs, uiDeallocs);
     LabelNumAllocs->setToolTip(QString::fromUtf8(s.GetData()));
   }
 }

--- a/Code/Tools/Inspector/PluginsWidget.cpp
+++ b/Code/Tools/Inspector/PluginsWidget.cpp
@@ -68,7 +68,7 @@ void ezQtPluginsWidget::UpdatePlugins()
       pIcon->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
       TablePlugins->setCellWidget(iRow, 0, pIcon);
 
-      sTemp.Format("  {0}  ", it.Key());
+      sTemp.SetFormat("  {0}  ", it.Key());
       TablePlugins->setCellWidget(iRow, 1, new QLabel(sTemp.GetData()));
 
       if (it.Value().m_bReloadable)

--- a/Code/Tools/Inspector/ReflectionWidget.cpp
+++ b/Code/Tools/Inspector/ReflectionWidget.cpp
@@ -128,7 +128,7 @@ bool ezQtReflectionWidget::UpdateTree()
       it.Value().m_pTreeItem = pItem;
 
       ezStringBuilder sText;
-      sText.Format("{0}", it.Value().m_uiSize);
+      sText.SetFormat("{0}", it.Value().m_uiSize);
 
       pItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
       pItem->setText(0, it.Key().GetData());

--- a/Code/Tools/Inspector/ResourceWidget.cpp
+++ b/Code/Tools/Inspector/ResourceWidget.cpp
@@ -290,26 +290,26 @@ void ezQtResourceWidget::UpdateTable()
       }
 
       pItem = Table->item(iTableRow, 3);
-      sTemp.Format("{0}", res.m_LoadingState.m_uiQualityLevelsDiscardable);
+      sTemp.SetFormat("{0}", res.m_LoadingState.m_uiQualityLevelsDiscardable);
       pItem->setText(sTemp.GetData());
       pItem->setToolTip("The number of quality levels that could be discarded to free up memory.");
 
       pItem = Table->item(iTableRow, 4);
-      sTemp.Format("{0}", res.m_LoadingState.m_uiQualityLevelsLoadable);
+      sTemp.SetFormat("{0}", res.m_LoadingState.m_uiQualityLevelsLoadable);
       pItem->setText(sTemp.GetData());
       pItem->setToolTip("The number of quality levels that could be additionally loaded for higher quality.");
 
       ByteSizeItem* pByteItem;
 
       pByteItem = (ByteSizeItem*)Table->item(iTableRow, 5);
-      sTemp.Format("{0} Bytes", res.m_Memory.m_uiMemoryCPU);
+      sTemp.SetFormat("{0} Bytes", res.m_Memory.m_uiMemoryCPU);
       pByteItem->setToolTip(sTemp.GetData());
       FormatSize(sTemp, "", res.m_Memory.m_uiMemoryCPU);
       pByteItem->setText(sTemp.GetData());
       pByteItem->m_uiBytes = static_cast<ezUInt32>(res.m_Memory.m_uiMemoryCPU);
 
       pByteItem = (ByteSizeItem*)Table->item(iTableRow, 6);
-      sTemp.Format("{0} Bytes", res.m_Memory.m_uiMemoryGPU);
+      sTemp.SetFormat("{0} Bytes", res.m_Memory.m_uiMemoryGPU);
       pByteItem->setToolTip(sTemp.GetData());
       FormatSize(sTemp, "", res.m_Memory.m_uiMemoryGPU);
       pByteItem->setText(sTemp.GetData());
@@ -445,7 +445,7 @@ void ezQtResourceWidget::on_ButtonSave_clicked()
         res.m_sResourceDescription.FindSubString_NoCase(m_sNameFilter) == nullptr)
       continue;
 
-    sLine.Format("{}, {}, {}, {}, {}, {}, {}\n", res.m_sResourceType, PriorityToString(res.m_Priority), StateToString(res.m_LoadingState.m_State),
+    sLine.SetFormat("{}, {}, {}, {}, {}, {}, {}\n", res.m_sResourceType, PriorityToString(res.m_Priority), StateToString(res.m_LoadingState.m_State),
       res.m_Memory.m_uiMemoryCPU, res.m_Memory.m_uiMemoryGPU, res.m_sResourceID, res.m_sResourceDescription);
     file.write(sLine);
   }

--- a/Code/Tools/Inspector/StatVisWidget.cpp
+++ b/Code/Tools/Inspector/StatVisWidget.cpp
@@ -72,7 +72,7 @@ ezQtStatVisWidget::ezQtStatVisWidget(QWidget* pParent, ezInt32 iWindowNumber)
   m_ShowWindowAction.setCheckable(true);
 
   ezStringBuilder sStatHistory;
-  sStatHistory.Format("StatHistory{0}", m_iWindowNumber);
+  sStatHistory.SetFormat("StatHistory{0}", m_iWindowNumber);
 
   QSettings Settings;
   Settings.beginGroup(sStatHistory.GetData());
@@ -104,7 +104,7 @@ void ezQtStatVisWidget::on_ComboTimeframe_currentIndexChanged(int index)
 void ezQtStatVisWidget::on_LineName_textChanged(const QString& text)
 {
   ezStringBuilder sStatHistory;
-  sStatHistory.Format("StatHistory{0}", m_iWindowNumber);
+  sStatHistory.SetFormat("StatHistory{0}", m_iWindowNumber);
 
   QSettings Settings;
   Settings.beginGroup(sStatHistory.GetData());
@@ -118,7 +118,7 @@ void ezQtStatVisWidget::on_LineName_textChanged(const QString& text)
 void ezQtStatVisWidget::on_SpinMin_valueChanged(double val)
 {
   ezStringBuilder sStatHistory;
-  sStatHistory.Format("StatHistory{0}", m_iWindowNumber);
+  sStatHistory.SetFormat("StatHistory{0}", m_iWindowNumber);
 
   QSettings Settings;
   Settings.beginGroup(sStatHistory.GetData());
@@ -129,7 +129,7 @@ void ezQtStatVisWidget::on_SpinMin_valueChanged(double val)
 void ezQtStatVisWidget::on_SpinMax_valueChanged(double val)
 {
   ezStringBuilder sStatHistory;
-  sStatHistory.Format("StatHistory{0}", m_iWindowNumber);
+  sStatHistory.SetFormat("StatHistory{0}", m_iWindowNumber);
 
   QSettings Settings;
   Settings.beginGroup(sStatHistory.GetData());
@@ -169,7 +169,7 @@ void ezQtStatVisWidget::on_ButtonRemove_clicked()
 void ezQtStatVisWidget::Save()
 {
   ezStringBuilder sStatHistory;
-  sStatHistory.Format("/StatWindow{0}.stats", m_iWindowNumber);
+  sStatHistory.SetFormat("/StatWindow{0}.stats", m_iWindowNumber);
 
   QString sFile = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
   QDir dir;
@@ -199,7 +199,7 @@ void ezQtStatVisWidget::Save()
 void ezQtStatVisWidget::Load()
 {
   ezStringBuilder sStatHistory;
-  sStatHistory.Format("/StatWindow{0}.stats", m_iWindowNumber);
+  sStatHistory.SetFormat("/StatWindow{0}.stats", m_iWindowNumber);
 
   QString sFile = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
   QDir dir;

--- a/Code/Tools/Inspector/SubsystemsWidget.cpp
+++ b/Code/Tools/Inspector/SubsystemsWidget.cpp
@@ -71,10 +71,10 @@ void ezQtSubsystemsWidget::UpdateSubSystems()
       pIcon->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
       TableSubsystems->setCellWidget(iRow, 0, pIcon);
 
-      sTemp.Format("  {0}  ", it.Key());
+      sTemp.SetFormat("  {0}  ", it.Key());
       TableSubsystems->setCellWidget(iRow, 1, new QLabel(sTemp.GetData()));
 
-      sTemp.Format("  {0}  ", ssd.m_sPlugin);
+      sTemp.SetFormat("  {0}  ", ssd.m_sPlugin);
       TableSubsystems->setCellWidget(iRow, 2, new QLabel(sTemp.GetData()));
 
       if (ssd.m_bStartupDone[ezStartupStage::HighLevelSystems])
@@ -88,7 +88,7 @@ void ezQtSubsystemsWidget::UpdateSubSystems()
 
       ((QLabel*)TableSubsystems->cellWidget(iRow, 3))->setAlignment(Qt::AlignHCenter);
 
-      sTemp.Format("  {0}  ", ssd.m_sDependencies);
+      sTemp.SetFormat("  {0}  ", ssd.m_sDependencies);
       TableSubsystems->setCellWidget(iRow, 4, new QLabel(sTemp.GetData()));
 
       ++iRow;

--- a/Code/Tools/Inspector/TimeWidget.cpp
+++ b/Code/Tools/Inspector/TimeWidget.cpp
@@ -180,7 +180,7 @@ void ezQtTimeWidget::UpdateStats()
     m_LastUpdatedClockList = ezTime::Now();
 
     ezStringBuilder s;
-    s.Format("Max: {0}ms", ezArgF(tShowMax.GetMilliseconds(), 0));
+    s.SetFormat("Max: {0}ms", ezArgF(tShowMax.GetMilliseconds(), 0));
     LabelMaxTime->setText(s.GetData());
 
     for (ezMap<ezString, ezQtTimeWidget::ClockData>::Iterator it = m_ClockData.GetIterator(); it.IsValid(); ++it)
@@ -191,7 +191,7 @@ void ezQtTimeWidget::UpdateStats()
         continue;
 
       ezStringBuilder sTooltip;
-      sTooltip.Format("<p>Clock: {0}<br>Max Time Step: <b>{1}ms</b><br>Min Time Step: <b>{2}ms</b><br></p>", it.Key().GetData(),
+      sTooltip.SetFormat("<p>Clock: {0}<br>Max Time Step: <b>{1}ms</b><br>Min Time Step: <b>{2}ms</b><br></p>", it.Key().GetData(),
         ezArgF(Clock.m_MaxTimestep.GetMilliseconds(), 2), ezArgF(Clock.m_MinTimestep.GetMilliseconds(), 2));
 
       Clock.m_pListItem->setToolTip(sTooltip.GetData());
@@ -213,7 +213,7 @@ void ezQtTimeWidget::ProcessTelemetry(void* pUnuseed)
     ezString sClockName;
     Msg.GetReader() >> sClockName;
 
-    sTemp.Format("{0} [smoothed]", sClockName);
+    sTemp.SetFormat("{0} [smoothed]", sClockName);
 
     ClockData& ad = s_pWidget->m_ClockData[sClockName];
     ClockData& ads = s_pWidget->m_ClockData[sTemp.GetData()];

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
@@ -217,7 +217,7 @@ void ezDocumentAction::Execute(const ezVariant& value)
           if (res.Failed())
           {
             ezStringBuilder s;
-            s.Format("Failed to save document: \n'{0}'", sFile);
+            s.SetFormat("Failed to save document: \n'{0}'", sFile);
             ezQtUiServices::MessageBoxStatus(res, s);
           }
           else

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ModifiedDocumentsDlg.cpp
@@ -91,8 +91,8 @@ ezResult ezQtModifiedDocumentsDlg::SaveDocument(ezDocument* pDoc)
   if (res.m_Result.Failed())
   {
     ezStringBuilder s, s2;
-    s.Format("Failed to save document:\n'{0}'", pDoc->GetDocumentPath());
-    s2.Format("Successfully saved document:\n'{0}'", pDoc->GetDocumentPath());
+    s.SetFormat("Failed to save document:\n'{0}'", pDoc->GetDocumentPath());
+    s2.SetFormat("Successfully saved document:\n'{0}'", pDoc->GetDocumentPath());
 
     ezQtUiServices::MessageBoxStatus(res, s, s2);
 

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -364,7 +364,7 @@ void ezQtDocumentWindow::SaveWindowLayout()
     showNormal();
 
   ezStringBuilder sGroup;
-  sGroup.Format("DocumentWnd_{0}", GetWindowLayoutGroupName());
+  sGroup.SetFormat("DocumentWnd_{0}", GetWindowLayoutGroupName());
 
   QSettings Settings;
   Settings.beginGroup(QString::fromUtf8(sGroup, sGroup.GetElementCount()));
@@ -383,7 +383,7 @@ void ezQtDocumentWindow::RestoreWindowLayout()
   ezQtScopedUpdatesDisabled _(this);
 
   ezStringBuilder sGroup;
-  sGroup.Format("DocumentWnd_{0}", GetWindowLayoutGroupName());
+  sGroup.SetFormat("DocumentWnd_{0}", GetWindowLayoutGroupName());
 
   {
     QSettings Settings;
@@ -434,8 +434,8 @@ ezStatus ezQtDocumentWindow::SaveDocument()
     ezStatus res = m_pDocument->SaveDocument();
 
     ezStringBuilder s, s2;
-    s.Format("Failed to save document:\n'{0}'", m_pDocument->GetDocumentPath());
-    s2.Format("Successfully saved document:\n'{0}'", m_pDocument->GetDocumentPath());
+    s.SetFormat("Failed to save document:\n'{0}'", m_pDocument->GetDocumentPath());
+    s2.SetFormat("Successfully saved document:\n'{0}'", m_pDocument->GetDocumentPath());
 
     ezQtUiServices::MessageBoxStatus(res, s, s2);
 

--- a/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
@@ -213,7 +213,7 @@ void ezQtLogModel::ProcessNewMessages()
 
       if (msg.m_Type == ezLogMsgType::BeginGroup || msg.m_Type == ezLogMsgType::EndGroup)
       {
-        s.Printf("%*s<<< %s", msg.m_uiIndentation, "", msg.m_sMsg.GetData());
+        s.SetPrintf("%*s<<< %s", msg.m_uiIndentation, "", msg.m_sMsg.GetData());
 
         if (msg.m_Type == ezLogMsgType::EndGroup)
         {
@@ -232,7 +232,7 @@ void ezQtLogModel::ProcessNewMessages()
       }
       else
       {
-        s.Printf("%*s%s", 4 * msg.m_uiIndentation, "", msg.m_sMsg.GetData());
+        s.SetPrintf("%*s%s", 4 * msg.m_uiIndentation, "", msg.m_sMsg.GetData());
         m_AllMessages.PeekBack().m_sMsg = s;
 
         if (msg.m_Type == ezLogMsgType::ErrorMsg)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -232,21 +232,21 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
       {
         pPaste->setEnabled(false);
         ezStringBuilder sTemp;
-        sTemp.Format("Cannot convert clipboard and property content between arrays and members.");
+        sTemp.SetFormat("Cannot convert clipboard and property content between arrays and members.");
         pPaste->setToolTip(sTemp.GetData());
       }
       else if (bEnumerationMissmatch || (!content.m_Value.CanConvertTo(m_pProp->GetSpecificType()->GetVariantType()) && content.m_Type != m_pProp->GetSpecificType()->GetTypeName()))
       {
         pPaste->setEnabled(false);
         ezStringBuilder sTemp;
-        sTemp.Format("Cannot convert clipboard of type '{}' to property of type '{}'", content.m_Type, m_pProp->GetSpecificType()->GetTypeName());
+        sTemp.SetFormat("Cannot convert clipboard of type '{}' to property of type '{}'", content.m_Type, m_pProp->GetSpecificType()->GetTypeName());
         pPaste->setToolTip(sTemp.GetData());
       }
       else if (clamped.Failed())
       {
         pPaste->setEnabled(false);
         ezStringBuilder sTemp;
-        sTemp.Format("The member property '{}' has an ezClampValueAttribute but ezReflectionUtils::ClampValue failed.", m_pProp->GetPropertyName());
+        sTemp.SetFormat("The member property '{}' has an ezClampValueAttribute but ezReflectionUtils::ClampValue failed.", m_pProp->GetPropertyName());
       }
 
       connect(pPaste, &QAction::triggered, this, [this, content]()
@@ -463,7 +463,7 @@ void ezQtPropertyWidget::PropertyChangedHandler(const ezPropertyEvent& ed)
     case ezPropertyEvent::Type::SingleValueChanged:
     {
       ezStringBuilder sTemp;
-      sTemp.Format("Change Property '{0}'", ezTranslate(ed.m_pProperty->GetPropertyName()));
+      sTemp.SetFormat("Change Property '{0}'", ezTranslate(ed.m_pProperty->GetPropertyName()));
       m_pObjectAccessor->StartTransaction(sTemp);
 
       ezStatus res;
@@ -486,7 +486,7 @@ void ezQtPropertyWidget::PropertyChangedHandler(const ezPropertyEvent& ed)
     case ezPropertyEvent::Type::BeginTemporary:
     {
       ezStringBuilder sTemp;
-      sTemp.Format("Change Property '{0}'", ezTranslate(ed.m_pProperty->GetPropertyName()));
+      sTemp.SetFormat("Change Property '{0}'", ezTranslate(ed.m_pProperty->GetPropertyName()));
       m_pObjectAccessor->BeginTemporaryCommands(sTemp);
     }
     break;
@@ -1566,9 +1566,9 @@ void ezQtPropertyStandardTypeContainerWidget::UpdateElement(ezUInt32 index)
 
   ezStringBuilder sTitle;
   if (m_pProp->GetCategory() == ezPropertyCategory::Map)
-    sTitle.Format("{0}", m_Keys[index].ConvertTo<ezString>());
+    sTitle.SetFormat("{0}", m_Keys[index].ConvertTo<ezString>());
   else
-    sTitle.Format("[{0}]", m_Keys[index].ConvertTo<ezString>());
+    sTitle.SetFormat("[{0}]", m_Keys[index].ConvertTo<ezString>());
 
   elem.m_pSubGroup->SetTitle(sTitle);
   m_pGrid->SetCollapseState(elem.m_pSubGroup);
@@ -1630,7 +1630,7 @@ void ezQtPropertyTypeContainerWidget::UpdateElement(ezUInt32 index)
     // Label
     {
       ezStringBuilder sTitle, tmp;
-      sTitle.Format("[{0}] - {1}", m_Keys[index].ConvertTo<ezString>(), ezTranslate(pCommonType->GetTypeName().GetData(tmp)));
+      sTitle.SetFormat("[{0}] - {1}", m_Keys[index].ConvertTo<ezString>(), ezTranslate(pCommonType->GetTypeName().GetData(tmp)));
 
       if (auto pInDev = pCommonType->GetAttributeByType<ezInDevelopmentAttribute>())
       {

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/ColorDialog.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/ColorDialog.cpp
@@ -143,12 +143,12 @@ void ezQtColorDialog::ApplyColor()
 
   if (m_bAlpha)
   {
-    s.Format("{0}{1}{2}{3}", ezArgU(m_uiGammaRed, 2, true, 16, true), ezArgU(m_uiGammaGreen, 2, true, 16, true), ezArgU(m_uiGammaBlue, 2, true, 16, true),
+    s.SetFormat("{0}{1}{2}{3}", ezArgU(m_uiGammaRed, 2, true, 16, true), ezArgU(m_uiGammaGreen, 2, true, 16, true), ezArgU(m_uiGammaBlue, 2, true, 16, true),
       ezArgU(m_uiAlpha, 2, true, 16, true));
   }
   else
   {
-    s.Format("{0}{1}{2}", ezArgU(m_uiGammaRed, 2, true, 16, true), ezArgU(m_uiGammaGreen, 2, true, 16, true), ezArgU(m_uiGammaBlue, 2, true, 16, true));
+    s.SetFormat("{0}{1}{2}", ezArgU(m_uiGammaRed, 2, true, 16, true), ezArgU(m_uiGammaGreen, 2, true, 16, true), ezArgU(m_uiGammaBlue, 2, true, 16, true));
   }
 
   LineHEX->setText(s.GetData());

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -114,7 +114,7 @@ const QIcon& ezQtUiServices::GetCachedIconResource(ezStringView sIdentifier, ezC
       const ezColorGammaUB color8 = svgTintColor;
 
       ezStringBuilder rep;
-      rep.Format("#{}{}{}", ezArgI((int)color8.r, 2, true, 16), ezArgI((int)color8.g, 2, true, 16), ezArgI((int)color8.b, 2, true, 16));
+      rep.SetFormat("#{}{}{}", ezArgI((int)color8.r, 2, true, 16), ezArgI((int)color8.g, 2, true, 16), ezArgI((int)color8.b, 2, true, 16));
 
       sContent.ReplaceAll_NoCase("#ffffff", rep);
 

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditWidget.cpp
@@ -1287,7 +1287,7 @@ void ezQtCurveEditWidget::RenderSideLinesAndText(QPainter* painter, const QRectF
       const QPoint pos = MapFromScene(QPointF(0, y));
 
       textRect.setRect(0, pos.y() - 15, areaRect.width(), 15);
-      tmp.Format("{0}", ezArgF(y));
+      tmp.SetFormat("{0}", ezArgF(y));
 
       painter->drawText(textRect, tmp.GetData(), textOpt);
     }

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/GridBarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/GridBarWidget.cpp
@@ -106,7 +106,7 @@ void ezQGridBarWidget::paintEvent(QPaintEvent* e)
       const QPointF pos = m_MapFromSceneFunc(QPointF(x, 0));
 
       textRect.setRect(pos.x() - 50, areaRect.top(), 99, areaRect.height());
-      tmp.Format("{0}", ezArgF(x));
+      tmp.SetFormat("{0}", ezArgF(x));
 
       painter->drawText(textRect, tmp.GetData(), textOpt);
     }

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/TimeScrubberWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/TimeScrubberWidget.cpp
@@ -131,7 +131,7 @@ void ezQtTimeScrubberWidget::paintEvent(QPaintEvent* event)
       const double scaledX = x * scale;
 
       textRect.setRect(scaledX - 20, areaTop, 39, areaHeight);
-      tmp.Format("{0}", ezArgF(x));
+      tmp.SetFormat("{0}", ezArgF(x));
 
       p.drawText(textRect, tmp.GetData(), textOpt);
     }

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
@@ -140,7 +140,7 @@ namespace ezModelImporter2
       {
         const auto& st = *m_pScene->mTextures[i];
 
-        refName.Format("*{}", i);
+        refName.SetFormat("*{}", i);
 
         auto& tex = m_OutputTextures[refName];
         tex.m_sFilename = st.mFilename.C_Str();

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentUtils.cpp
@@ -9,7 +9,7 @@ ezStatus ezDocumentUtils::IsValidSaveLocationForDocument(ezStringView sDocument,
   if (ezDocumentManager::FindDocumentTypeFromPath(sDocument, true, pTypeDesc).Failed())
   {
     ezStringBuilder sTemp;
-    sTemp.Format("The selected file extension '{0}' is not registered with any known type.\nCannot create file '{1}'",
+    sTemp.SetFormat("The selected file extension '{0}' is not registered with any known type.\nCannot create file '{1}'",
       ezPathUtils::GetFileExtension(sDocument), sDocument);
     return ezStatus(sTemp.GetData());
   }

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/PrefabUtils.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/PrefabUtils.cpp
@@ -18,7 +18,7 @@ ezString ToBinary(const ezUuid& guid)
 
   for (ezUInt32 i = 0; i < sizeof(ezUuid); ++i)
   {
-    s.Format("{0}", ezArgU((ezUInt32)*pBytes, 2, true, 16, true));
+    s.SetFormat("{0}", ezArgU((ezUInt32)*pBytes, 2, true, 16, true));
     ++pBytes;
 
     sResult.Append(s.GetData());

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/DocumentNodeManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/DocumentNodeManager.cpp
@@ -663,7 +663,7 @@ void ezDocumentNodeManager::GetDynamicPinNames(const ezDocumentObject* pObject, 
       ezUInt32 uiCount = value.ConvertTo<ezUInt32>();
       for (ezUInt32 i = 0; i < uiCount; ++i)
       {
-        sTemp.Format("{}[{}]", sPinName, i);
+        sTemp.SetFormat("{}[{}]", sPinName, i);
         out_Names.PushBack(sTemp);
       }
     }
@@ -680,7 +680,7 @@ void ezDocumentNodeManager::GetDynamicPinNames(const ezDocumentObject* pObject, 
     {
       for (ezUInt32 i = 0; i < uiCount; ++i)
       {
-        sTemp.Format("{}", a[i]);
+        sTemp.SetFormat("{}", a[i]);
         out_Names.PushBack(sTemp);
       }
     }
@@ -695,7 +695,7 @@ void ezDocumentNodeManager::GetDynamicPinNames(const ezDocumentObject* pObject, 
     {
       for (ezUInt32 i = 0; i < uiCount; ++i)
       {
-        sTemp.Format("{}[{}]", sPinName, i);
+        sTemp.SetFormat("{}[{}]", sPinName, i);
         out_Names.PushBack(sTemp);
       }
     }

--- a/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.cpp
@@ -292,7 +292,7 @@ const ezString ezToolsProject::GetProjectName(bool bSanitize) const
   if (!bAnyAscii)
   {
     const ezUInt32 uiHash = ezHashingUtils::xxHash32String(sTemp);
-    sTemp.Format("Project{}", uiHash);
+    sTemp.SetFormat("Project{}", uiHash);
   }
 
   if (sTemp.IsEmpty())

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/RecentFilesList.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/RecentFilesList.cpp
@@ -37,7 +37,7 @@ void ezRecentFilesList::Save(ezStringView sFile)
   for (const RecentFile& file : m_Files)
   {
     ezStringBuilder sTemp;
-    sTemp.Format("{0}|{1}", file.m_File, file.m_iContainerWindow);
+    sTemp.SetFormat("{0}|{1}", file.m_File, file.m_iContainerWindow);
     File.WriteBytes(sTemp.GetData(), sTemp.GetElementCount()).IgnoreResult();
     File.WriteBytes("\n", sizeof(char)).IgnoreResult();
   }

--- a/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
+++ b/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
@@ -499,7 +499,7 @@ public:
     if (m_FilesToLink.Contains(sFile))
     {
       m_AllRefPoints.Insert(sFileMarker.GetData());
-      sNewMarker.Format("EZ_STATICLINK_FILE({0}, {1});", sLibraryMarker, sFileMarker);
+      sNewMarker.SetFormat("EZ_STATICLINK_FILE({0}, {1});", sLibraryMarker, sFileMarker);
     }
 
     const char* szMarker = sFileContent.FindSubString("EZ_STATICLINK_FILE");
@@ -561,7 +561,7 @@ public:
     // generate the code that should be inserted into this file
     // this code will reference all the other files in the library
     {
-      sNewGroupMarker.Format("EZ_STATICLINK_LIBRARY({0})\n{\n  if (bReturn)\n    return;\n\n", GetLibraryMarkerName());
+      sNewGroupMarker.SetFormat("EZ_STATICLINK_LIBRARY({0})\n{\n  if (bReturn)\n    return;\n\n", GetLibraryMarkerName());
 
       auto it = m_AllRefPoints.GetIterator();
 

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -268,7 +268,7 @@ ezResult ezTexConv::ParseInputFiles()
 
   for (ezUInt32 i = 0; i < 64; ++i)
   {
-    tmp.Format("-in{0}", i);
+    tmp.SetFormat("-in{0}", i);
 
     res = pCmd->GetAbsolutePathOption(tmp);
 

--- a/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
+++ b/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
@@ -147,7 +147,7 @@ EZ_CREATE_SIMPLE_TEST(ResourceManager, Basics)
     ezStringBuilder sResourceID;
     for (ezUInt32 i = 0; i < uiNumResources; ++i)
     {
-      sResourceID.Format("Level0-{}", i);
+      sResourceID.SetFormat("Level0-{}", i);
       hResources.PushBack(ezResourceManager::LoadResource<TestResource>(sResourceID));
     }
 
@@ -209,7 +209,7 @@ EZ_CREATE_SIMPLE_TEST(ResourceManager, NestedLoading)
     ezStringBuilder sResourceID;
     for (ezUInt32 i = 0; i < uiNumResources; ++i)
     {
-      sResourceID.Format("NonBlockingLevel1-{}", i);
+      sResourceID.SetFormat("NonBlockingLevel1-{}", i);
       hResources.PushBack(ezResourceManager::LoadResource<TestResource>(sResourceID));
     }
 
@@ -250,7 +250,7 @@ EZ_CREATE_SIMPLE_TEST(ResourceManager, NestedLoading)
     ezStringBuilder sResourceID;
     for (ezUInt32 i = 0; i < uiNumResources; ++i)
     {
-      sResourceID.Format("BlockingLevel1-{}", i);
+      sResourceID.SetFormat("BlockingLevel1-{}", i);
       hResources.PushBack(ezResourceManager::LoadResource<TestResource>(sResourceID));
     }
 

--- a/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
@@ -116,7 +116,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
     for (ezUInt32 i = 0; i < 250; ++i)
     {
       ezStringBuilder TagName;
-      TagName.Format("TEST_TAG{0}", i);
+      TagName.SetFormat("TEST_TAG{0}", i);
 
       RegisteredTags[i] = TempTestRegistry.RegisterTag(TagName.GetData());
 
@@ -210,7 +210,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
     for (ezUInt32 i = 0; i < 250; ++i)
     {
       ezStringBuilder TagName;
-      TagName.Format("TEST_TAG{0}", i);
+      TagName.SetFormat("TEST_TAG{0}", i);
 
       RegisteredTags[i] = TempTestRegistry.RegisterTag(TagName.GetData());
 

--- a/Code/UnitTests/FoundationTest/CodeUtils/ExpressionTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/ExpressionTest.cpp
@@ -18,7 +18,7 @@ namespace
     ezUInt32 uiCounter = s_uiNumASTDumps;
     ++s_uiNumASTDumps;
 
-    out_sOutputPath.Format(":output/Expression/{}_{}_AST.dgml", ezArgU(uiCounter, 2, true), sOutputName);
+    out_sOutputPath.SetFormat(":output/Expression/{}_{}_AST.dgml", ezArgU(uiCounter, 2, true), sOutputName);
   }
 
   void DumpDisassembly(const ezExpressionByteCode& byteCode, ezStringView sOutputName, ezUInt32 uiCounter)
@@ -27,7 +27,7 @@ namespace
     byteCode.Disassemble(sDisassembly);
 
     ezStringBuilder sFileName;
-    sFileName.Format(":output/Expression/{}_{}_ByteCode.txt", ezArgU(uiCounter, 2, true), sOutputName);
+    sFileName.SetFormat(":output/Expression/{}_{}_ByteCode.txt", ezArgU(uiCounter, 2, true), sOutputName);
 
     ezFileWriter fileWriter;
     if (fileWriter.Open(sFileName).Succeeded())
@@ -254,13 +254,13 @@ namespace
     ezStringBuilder bValue;
     if constexpr (std::is_same<T, ezVec3>::value || std::is_same<T, ezVec3I32>::value)
     {
-      aValue.Format("vec3({}, {}, {})", a.x, a.y, a.z);
-      bValue.Format("vec3({}, {}, {})", b.x, b.y, b.z);
+      aValue.SetFormat("vec3({}, {}, {})", a.x, a.y, a.z);
+      bValue.SetFormat("vec3({}, {}, {})", b.x, b.y, b.z);
     }
     else
     {
-      aValue.Format("{}", a);
-      bValue.Format("{}", b);
+      aValue.SetFormat("{}", a);
+      bValue.SetFormat("{}", b);
     }
 
     int oneConstantInstructions = 3; // LoadX, OpX_RC, StoreX
@@ -294,11 +294,11 @@ namespace
     ezStringBuilder code;
     ezExpressionByteCode byteCode;
 
-    code.Format(formatString, sOp, aInput, bInput);
+    code.SetFormat(formatString, sOp, aInput, bInput);
     Compile<U>(code, byteCode, bDumpASTs ? "BinaryNoConstants" : "");
     TestRes(Execute<U>(byteCode, aAsU, bAsU), expectedResultAsU, code, aValue, bValue);
 
-    code.Format(formatString, sOp, aValue, bInput);
+    code.SetFormat(formatString, sOp, aValue, bInput);
     Compile<U>(code, byteCode, bDumpASTs ? "BinaryLeftConstant" : "");
     if constexpr ((flags & NoInstructionsCountCheck) == 0)
     {
@@ -319,7 +319,7 @@ namespace
     }
     TestRes(Execute<U>(byteCode, aAsU, bAsU), expectedResultAsU, code, aValue, bValue);
 
-    code.Format(formatString, sOp, aInput, bValue);
+    code.SetFormat(formatString, sOp, aInput, bValue);
     Compile<U>(code, byteCode, bDumpASTs ? "BinaryRightConstant" : "");
     if constexpr ((flags & NoInstructionsCountCheck) == 0)
     {
@@ -332,7 +332,7 @@ namespace
     }
     TestRes(Execute<U>(byteCode, aAsU, bAsU), expectedResultAsU, code, aValue, bValue);
 
-    code.Format(formatString, sOp, aValue, bValue);
+    code.SetFormat(formatString, sOp, aValue, bValue);
     Compile<U>(code, byteCode, bDumpASTs ? "BinaryConstant" : "");
     if (hasDifferentOutputElements == false)
     {
@@ -721,7 +721,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, Expression)
     for (int i = 0; i <= 16; ++i)
     {
       ezStringBuilder testCode;
-      testCode.Format("output = pow(a, {})", i);
+      testCode.SetFormat("output = pow(a, {})", i);
 
       ezExpressionByteCode testByteCode;
       Compile<int>(testCode, testByteCode);

--- a/Code/UnitTests/FoundationTest/CodeUtils/PreprocessorTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/PreprocessorTest.cpp
@@ -231,9 +231,9 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, Preprocessor)
         pp.SetPassThroughUnknownCmdsCB([](ezStringView s) -> bool { return s == "version"; }); // TestSettings[i].m_bPassThroughUnknownCommands);
 
         {
-          fileName.Format("Preprocessor/{0}.txt", TestSettings[i].m_szFileName);
-          fileNameExp.Format("Preprocessor/{0} - Expected.txt", TestSettings[i].m_szFileName);
-          fileNameOut.Format(":output/Preprocessor/{0} - Result.txt", TestSettings[i].m_szFileName);
+          fileName.SetFormat("Preprocessor/{0}.txt", TestSettings[i].m_szFileName);
+          fileNameExp.SetFormat("Preprocessor/{0} - Expected.txt", TestSettings[i].m_szFileName);
+          fileNameOut.SetFormat(":output/Preprocessor/{0} - Result.txt", TestSettings[i].m_szFileName);
 
           EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "File does not exist: '%s'", fileName.GetData());
 

--- a/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
@@ -1175,7 +1175,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
 
     ezTime t = sw.GetRunningTotal();
     ezStringBuilder s;
-    s.Format("ez-sort (random keys): {}", t);
+    s.SetFormat("ez-sort (random keys): {}", t);
     ezTestFramework::Output(ezTestOutput::Details, s);
 
     for (ezUInt32 i = 1; i < list.GetCount(); i++)
@@ -1201,7 +1201,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
 
     ezTime t = sw.GetRunningTotal();
     ezStringBuilder s;
-    s.Format("std::sort (random keys): {}", t);
+    s.SetFormat("std::sort (random keys): {}", t);
     ezTestFramework::Output(ezTestOutput::Details, s);
 
     for (ezUInt32 i = 1; i < list.GetCount(); i++)
@@ -1227,7 +1227,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
 
     ezTime t = sw.GetRunningTotal();
     ezStringBuilder s;
-    s.Format("ez-sort (equal keys): {}", t);
+    s.SetFormat("ez-sort (equal keys): {}", t);
     ezTestFramework::Output(ezTestOutput::Details, s);
 
     for (ezUInt32 i = 1; i < list.GetCount(); i++)
@@ -1253,7 +1253,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
 
     ezTime t = sw.GetRunningTotal();
     ezStringBuilder s;
-    s.Format("std::sort (equal keys): {}", t);
+    s.SetFormat("std::sort (equal keys): {}", t);
     ezTestFramework::Output(ezTestOutput::Details, s);
 
     for (ezUInt32 i = 1; i < list.GetCount(); i++)

--- a/Code/UnitTests/FoundationTest/Containers/HashSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HashSetTest.cpp
@@ -504,10 +504,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashSet)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       set1.Insert(tmp);
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       set2.Insert(tmp);
     }
 
@@ -515,10 +515,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashSet)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(set2.Contains(tmp));
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       EZ_TEST_BOOL(set1.Contains(tmp));
     }
   }
@@ -531,7 +531,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashSet)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       set.Insert(tmp);
     }
 

--- a/Code/UnitTests/FoundationTest/Containers/HashTableTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HashTableTest.cpp
@@ -498,10 +498,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashTable)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       map1[tmp] = i;
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       map2[tmp] = i;
     }
 
@@ -509,11 +509,11 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashTable)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(map2.Contains(tmp));
       EZ_TEST_INT(map2[tmp], i);
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       EZ_TEST_BOOL(map1.Contains(tmp));
       EZ_TEST_INT(map1[tmp], i);
     }
@@ -527,7 +527,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashTable)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       map[tmp] = i;
     }
 
@@ -575,13 +575,13 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashTable)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       map[tmp] = i;
     }
 
     for (ezInt32 i = map.GetCount() - 1; i > 0; --i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
 
       auto it = map.Find(tmp);
       auto cit = static_cast<const ezHashTable<ezString, ezInt32>&>(map).Find(tmp);

--- a/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
@@ -601,10 +601,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       map1[tmp] = i;
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       map2[tmp] = i;
     }
 
@@ -612,11 +612,11 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(map2.Contains(tmp));
       EZ_TEST_INT(map2[tmp], i);
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       EZ_TEST_BOOL(map1.Contains(tmp));
       EZ_TEST_INT(map1[tmp], i);
     }
@@ -637,10 +637,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       map1->Insert(tmp, i);
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       map2->Insert(tmp, i);
     }
 
@@ -649,11 +649,11 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     // test swapped elements
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(map2->Contains(tmp));
       EZ_TEST_INT((*map2)[tmp], i);
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       EZ_TEST_BOOL(map1->Contains(tmp));
       EZ_TEST_INT((*map1)[tmp], i);
     }
@@ -694,7 +694,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     for (ezUInt32 i = 0; i < 100; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       map1->Insert(tmp, i);
     }
 
@@ -707,7 +707,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     // test swapped elements
     for (ezUInt32 i = 0; i < 100; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(map2->Contains(tmp));
     }
 

--- a/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
@@ -597,10 +597,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
 
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       set1->Insert(tmp);
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       set2->Insert(tmp);
     }
 
@@ -609,10 +609,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
     // test swapped elements
     for (ezUInt32 i = 0; i < 1000; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(set2->Contains(tmp));
 
-      tmp.Format("{0}{0}{0}", i);
+      tmp.SetFormat("{0}{0}{0}", i);
       EZ_TEST_BOOL(set1->Contains(tmp));
     }
 
@@ -652,7 +652,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
 
     for (ezUInt32 i = 0; i < 100; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       set1->Insert(tmp);
     }
 
@@ -665,7 +665,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
     // test swapped elements
     for (ezUInt32 i = 0; i < 100; ++i)
     {
-      tmp.Format("stuff{}bla", i);
+      tmp.SetFormat("stuff{}bla", i);
       EZ_TEST_BOOL(set2->Contains(tmp));
     }
 

--- a/Code/UnitTests/FoundationTest/IO/JSONReaderTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/JSONReaderTest.cpp
@@ -109,7 +109,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Int8:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("int8 {0}", var.Get<ezInt8>());
+        sTemp.SetFormat("int8 {0}", var.Get<ezInt8>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -119,7 +119,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::UInt8:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("uint8 {0}", var.Get<ezUInt8>());
+        sTemp.SetFormat("uint8 {0}", var.Get<ezUInt8>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -129,7 +129,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Int16:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("int16 {0}", var.Get<ezInt16>());
+        sTemp.SetFormat("int16 {0}", var.Get<ezInt16>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -139,7 +139,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::UInt16:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("uint16 {0}", var.Get<ezUInt16>());
+        sTemp.SetFormat("uint16 {0}", var.Get<ezUInt16>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -149,7 +149,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Int32:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("int32 {0}", var.Get<ezInt32>());
+        sTemp.SetFormat("int32 {0}", var.Get<ezInt32>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -159,7 +159,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::UInt32:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("uint32 {0}", var.Get<ezUInt32>());
+        sTemp.SetFormat("uint32 {0}", var.Get<ezUInt32>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -169,7 +169,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Int64:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("int64 {0}", var.Get<ezInt64>());
+        sTemp.SetFormat("int64 {0}", var.Get<ezInt64>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -179,7 +179,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::UInt64:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("uint64 {0}", var.Get<ezUInt64>());
+        sTemp.SetFormat("uint64 {0}", var.Get<ezUInt64>());
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -189,7 +189,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Float:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("float {0}", ezArgF(var.Get<float>(), 4));
+        sTemp.SetFormat("float {0}", ezArgF(var.Get<float>(), 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -199,7 +199,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Double:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("double {0}", ezArgF(var.Get<double>(), 4));
+        sTemp.SetFormat("double {0}", ezArgF(var.Get<double>(), 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -209,7 +209,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Time:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("time {0}", ezArgF(var.Get<ezTime>().GetSeconds(), 4));
+        sTemp.SetFormat("time {0}", ezArgF(var.Get<ezTime>().GetSeconds(), 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -219,7 +219,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Angle:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("angle {0}", ezArgF(var.Get<ezAngle>().GetDegree(), 4));
+        sTemp.SetFormat("angle {0}", ezArgF(var.Get<ezAngle>().GetDegree(), 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -241,7 +241,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Vector2:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("vec2 ({0}, {1})", ezArgF(var.Get<ezVec2>().x, 4), ezArgF(var.Get<ezVec2>().y, 4));
+        sTemp.SetFormat("vec2 ({0}, {1})", ezArgF(var.Get<ezVec2>().x, 4), ezArgF(var.Get<ezVec2>().y, 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -251,7 +251,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Vector3:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("vec3 ({0}, {1}, {2})", ezArgF(var.Get<ezVec3>().x, 4), ezArgF(var.Get<ezVec3>().y, 4), ezArgF(var.Get<ezVec3>().z, 4));
+        sTemp.SetFormat("vec3 ({0}, {1}, {2})", ezArgF(var.Get<ezVec3>().x, 4), ezArgF(var.Get<ezVec3>().y, 4), ezArgF(var.Get<ezVec3>().z, 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -261,7 +261,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Vector4:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("vec4 ({0}, {1}, {2}, {3})", ezArgF(var.Get<ezVec4>().x, 4), ezArgF(var.Get<ezVec4>().y, 4), ezArgF(var.Get<ezVec4>().z, 4), ezArgF(var.Get<ezVec4>().w, 4));
+        sTemp.SetFormat("vec4 ({0}, {1}, {2}, {3})", ezArgF(var.Get<ezVec4>().x, 4), ezArgF(var.Get<ezVec4>().y, 4), ezArgF(var.Get<ezVec4>().z, 4), ezArgF(var.Get<ezVec4>().w, 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -271,7 +271,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Vector2I:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("vec2i ({0}, {1})", var.Get<ezVec2I32>().x, var.Get<ezVec2I32>().y);
+        sTemp.SetFormat("vec2i ({0}, {1})", var.Get<ezVec2I32>().x, var.Get<ezVec2I32>().y);
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -281,7 +281,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Vector3I:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("vec3i ({0}, {1}, {2})", var.Get<ezVec3I32>().x, var.Get<ezVec3I32>().y, var.Get<ezVec3I32>().z);
+        sTemp.SetFormat("vec3i ({0}, {1}, {2})", var.Get<ezVec3I32>().x, var.Get<ezVec3I32>().y, var.Get<ezVec3I32>().z);
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -291,7 +291,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Vector4I:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("vec4i ({0}, {1}, {2}, {3})", var.Get<ezVec4I32>().x, var.Get<ezVec4I32>().y, var.Get<ezVec4I32>().z, var.Get<ezVec4I32>().w);
+        sTemp.SetFormat("vec4i ({0}, {1}, {2}, {3})", var.Get<ezVec4I32>().x, var.Get<ezVec4I32>().y, var.Get<ezVec4I32>().z, var.Get<ezVec4I32>().w);
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -301,7 +301,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Color:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("color ({0}, {1}, {2}, {3})", ezArgF(var.Get<ezColor>().r, 4), ezArgF(var.Get<ezColor>().g, 4), ezArgF(var.Get<ezColor>().b, 4), ezArgF(var.Get<ezColor>().a, 4));
+        sTemp.SetFormat("color ({0}, {1}, {2}, {3})", ezArgF(var.Get<ezColor>().r, 4), ezArgF(var.Get<ezColor>().g, 4), ezArgF(var.Get<ezColor>().b, 4), ezArgF(var.Get<ezColor>().a, 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -313,7 +313,7 @@ namespace JSONReaderTestDetail
         ezStringBuilder sTemp;
         const ezColorGammaUB c = var.ConvertTo<ezColorGammaUB>();
 
-        sTemp.Format("gamma ({0}, {1}, {2}, {3})", c.r, c.g, c.b, c.a);
+        sTemp.SetFormat("gamma ({0}, {1}, {2}, {3})", c.r, c.g, c.b, c.a);
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -323,7 +323,7 @@ namespace JSONReaderTestDetail
       case ezVariant::Type::Quaternion:
       {
         ezStringBuilder sTemp;
-        sTemp.Format("quat ({0}, {1}, {2}, {3})", ezArgF(var.Get<ezQuat>().x, 4), ezArgF(var.Get<ezQuat>().y, 4), ezArgF(var.Get<ezQuat>().z, 4), ezArgF(var.Get<ezQuat>().w, 4));
+        sTemp.SetFormat("quat ({0}, {1}, {2}, {3})", ezArgF(var.Get<ezQuat>().x, 4), ezArgF(var.Get<ezQuat>().y, 4), ezArgF(var.Get<ezQuat>().z, 4), ezArgF(var.Get<ezQuat>().w, 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -335,7 +335,7 @@ namespace JSONReaderTestDetail
         ezMat3 m = var.Get<ezMat3>();
 
         ezStringBuilder sTemp;
-        sTemp.Format("mat3 ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})", ezArgF(m.m_fElementsCM[0], 4), ezArgF(m.m_fElementsCM[1], 4), ezArgF(m.m_fElementsCM[2], 4), ezArgF(m.m_fElementsCM[3], 4), ezArgF(m.m_fElementsCM[4], 4), ezArgF(m.m_fElementsCM[5], 4), ezArgF(m.m_fElementsCM[6], 4), ezArgF(m.m_fElementsCM[7], 4), ezArgF(m.m_fElementsCM[8], 4));
+        sTemp.SetFormat("mat3 ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8})", ezArgF(m.m_fElementsCM[0], 4), ezArgF(m.m_fElementsCM[1], 4), ezArgF(m.m_fElementsCM[2], 4), ezArgF(m.m_fElementsCM[3], 4), ezArgF(m.m_fElementsCM[4], 4), ezArgF(m.m_fElementsCM[5], 4), ezArgF(m.m_fElementsCM[6], 4), ezArgF(m.m_fElementsCM[7], 4), ezArgF(m.m_fElementsCM[8], 4));
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();
@@ -347,7 +347,7 @@ namespace JSONReaderTestDetail
         ezMat4 m = var.Get<ezMat4>();
 
         ezStringBuilder sTemp;
-        sTemp.Printf("mat4 (%.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f)", m.m_fElementsCM[0], m.m_fElementsCM[1], m.m_fElementsCM[2], m.m_fElementsCM[3], m.m_fElementsCM[4], m.m_fElementsCM[5], m.m_fElementsCM[6], m.m_fElementsCM[7], m.m_fElementsCM[8], m.m_fElementsCM[9], m.m_fElementsCM[10], m.m_fElementsCM[11], m.m_fElementsCM[12], m.m_fElementsCM[13], m.m_fElementsCM[14], m.m_fElementsCM[15]);
+        sTemp.SetPrintf("mat4 (%.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f, %.4f)", m.m_fElementsCM[0], m.m_fElementsCM[1], m.m_fElementsCM[2], m.m_fElementsCM[3], m.m_fElementsCM[4], m.m_fElementsCM[5], m.m_fElementsCM[6], m.m_fElementsCM[7], m.m_fElementsCM[8], m.m_fElementsCM[9], m.m_fElementsCM[10], m.m_fElementsCM[11], m.m_fElementsCM[12], m.m_fElementsCM[13], m.m_fElementsCM[14], m.m_fElementsCM[15]);
         // ezLog::Printf("Expect: %s - Is: %s\n", sTemp.GetData(), Compare.PeekFront().GetData());
         EZ_TEST_STRING(ref_compare.PeekFront().GetData(), sTemp.GetData());
         ref_compare.PopFront();

--- a/Code/UnitTests/FoundationTest/IO/StreamOperationsTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/StreamOperationsTest.cpp
@@ -366,7 +366,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StreamOperation)
 
       ezTime t = sw.GetRunningTotal();
       ezStringBuilder s;
-      s.Format("Write {} byte array: {}", ezArgFileSize(uiCount), t);
+      s.SetFormat("Write {} byte array: {}", ezArgFileSize(uiCount), t);
       ezTestFramework::Output(ezTestOutput::Details, s);
     }
 
@@ -377,7 +377,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StreamOperation)
 
       ezTime t = sw.GetRunningTotal();
       ezStringBuilder s;
-      s.Format("Read {} byte array: {}", ezArgFileSize(uiCount), t);
+      s.SetFormat("Read {} byte array: {}", ezArgFileSize(uiCount), t);
       ezTestFramework::Output(ezTestOutput::Details, s);
     }
 
@@ -411,7 +411,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StreamOperation)
 
       ezTime t = sw.GetRunningTotal();
       ezStringBuilder s;
-      s.Format("Write {} vec3 array: {}", ezArgFileSize(uiCount * sizeof(ezVec3)), t);
+      s.SetFormat("Write {} vec3 array: {}", ezArgFileSize(uiCount * sizeof(ezVec3)), t);
       ezTestFramework::Output(ezTestOutput::Details, s);
     }
 
@@ -422,7 +422,7 @@ EZ_CREATE_SIMPLE_TEST(IO, StreamOperation)
 
       ezTime t = sw.GetRunningTotal();
       ezStringBuilder s;
-      s.Format("Read {} vec3 array: {}", ezArgFileSize(uiCount * sizeof(ezVec3)), t);
+      s.SetFormat("Read {} vec3 array: {}", ezArgFileSize(uiCount * sizeof(ezVec3)), t);
       ezTestFramework::Output(ezTestOutput::Details, s);
     }
 

--- a/Code/UnitTests/FoundationTest/Image/ImageTest.cpp
+++ b/Code/UnitTests/FoundationTest/Image/ImageTest.cpp
@@ -39,7 +39,7 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
       ezImage image;
       {
         ezStringBuilder fileName;
-        fileName.Format("{0}.bmp", testImagesGood[i]);
+        fileName.SetFormat("{0}.bmp", testImagesGood[i]);
 
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "Image file does not exist: '%s'", fileName.GetData());
         EZ_TEST_BOOL_MSG(image.LoadFrom(fileName) == EZ_SUCCESS, "Reading image failed: '%s'", fileName.GetData());
@@ -47,7 +47,7 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
 
       {
         ezStringBuilder fileName;
-        fileName.Format(":output/{0}_out.bmp", testImagesGood[i]);
+        fileName.SetFormat(":output/{0}_out.bmp", testImagesGood[i]);
 
         EZ_TEST_BOOL_MSG(image.SaveTo(fileName) == EZ_SUCCESS, "Writing image failed: '%s'", fileName.GetData());
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "Output image file is missing: '%s'", fileName.GetData());
@@ -70,7 +70,7 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
       ezImage image;
       {
         ezStringBuilder fileName;
-        fileName.Format("{0}.bmp", testImagesBad[i]);
+        fileName.SetFormat("{0}.bmp", testImagesBad[i]);
 
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "File does not exist: '%s'", fileName.GetData());
 
@@ -89,7 +89,7 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
       ezImage image;
       {
         ezStringBuilder fileName;
-        fileName.Format("{0}.tga", testImagesGood[i]);
+        fileName.SetFormat("{0}.tga", testImagesGood[i]);
 
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "Image file does not exist: '%s'", fileName.GetData());
         EZ_TEST_BOOL_MSG(image.LoadFrom(fileName) == EZ_SUCCESS, "Reading image failed: '%s'", fileName.GetData());
@@ -97,10 +97,10 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
 
       {
         ezStringBuilder fileName;
-        fileName.Format(":output/{0}_out.bmp", testImagesGood[i]);
+        fileName.SetFormat(":output/{0}_out.bmp", testImagesGood[i]);
 
         ezStringBuilder fileNameExpected;
-        fileNameExpected.Format("{0}_expected.bmp", testImagesGood[i]);
+        fileNameExpected.SetFormat("{0}_expected.bmp", testImagesGood[i]);
 
         EZ_TEST_BOOL_MSG(image.SaveTo(fileName) == EZ_SUCCESS, "Writing image failed: '%s'", fileName.GetData());
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "Output image file is missing: '%s'", fileName.GetData());
@@ -110,10 +110,10 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
 
       {
         ezStringBuilder fileName;
-        fileName.Format(":output/{0}_out.tga", testImagesGood[i]);
+        fileName.SetFormat(":output/{0}_out.tga", testImagesGood[i]);
 
         ezStringBuilder fileNameExpected;
-        fileNameExpected.Format("{0}_expected.tga", testImagesGood[i]);
+        fileNameExpected.SetFormat("{0}_expected.tga", testImagesGood[i]);
 
         EZ_TEST_BOOL_MSG(image.SaveTo(fileName) == EZ_SUCCESS, "Writing image failed: '%s'", fileName.GetData());
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "Output image file is missing: '%s'", fileName.GetData());
@@ -152,7 +152,7 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
       ezImage image;
       {
         ezStringBuilder fileName;
-        fileName.Format("{}/{}.tga", szTestImagePath, imgTests[idx].szImage);
+        fileName.SetFormat("{}/{}.tga", szTestImagePath, imgTests[idx].szImage);
 
         EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(fileName), "Image file does not exist: '%s'", fileName.GetData());
         EZ_TEST_BOOL_MSG(image.LoadFrom(fileName) == EZ_SUCCESS, "Reading image failed: '%s'", fileName.GetData());
@@ -160,7 +160,7 @@ EZ_CREATE_SIMPLE_TEST(Image, Image)
 
       {
         ezStringBuilder fileName;
-        fileName.Format(":output/WriteImageTest/{}.{}", imgTests[idx].szImage, imgTests[idx].szFormat);
+        fileName.SetFormat(":output/WriteImageTest/{}.{}", imgTests[idx].szImage, imgTests[idx].szFormat);
 
         ezFileSystem::DeleteFile(fileName);
 

--- a/Code/UnitTests/FoundationTest/Math/RationalTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/RationalTest.cpp
@@ -46,12 +46,12 @@ EZ_CREATE_SIMPLE_TEST(Math, Rational)
     ezRational r1(50, 25);
 
     ezStringBuilder sb;
-    sb.Format("Rational: {}", r1);
+    sb.SetFormat("Rational: {}", r1);
     EZ_TEST_STRING(sb, "Rational: 2");
 
 
     ezRational r2(233, 76);
-    sb.Format("Rational: {}", r2);
+    sb.SetFormat("Rational: {}", r2);
     EZ_TEST_STRING(sb, "Rational: 233/76");
   }
 }

--- a/Code/UnitTests/FoundationTest/SimdMath/SimdNoiseTest.cpp
+++ b/Code/UnitTests/FoundationTest/SimdMath/SimdNoiseTest.cpp
@@ -58,12 +58,12 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdNoise)
       }
 
       ezStringBuilder sOutFile;
-      sOutFile.Format(":output/SimdNoise/result-perlin_{}.tga", uiNumOctaves);
+      sOutFile.SetFormat(":output/SimdNoise/result-perlin_{}.tga", uiNumOctaves);
 
       EZ_TEST_BOOL(image.SaveTo(sOutFile).Succeeded());
 
       ezStringBuilder sInFile;
-      sInFile.Format("SimdNoise/perlin_{}.tga", uiNumOctaves);
+      sInFile.SetFormat("SimdNoise/perlin_{}.tga", uiNumOctaves);
       EZ_TEST_BOOL_MSG(ezFileSystem::ExistsFile(sInFile), "Noise image file is missing: '%s'", sInFile.GetData());
 
       EZ_TEST_FILES(sOutFile, sInFile, "");
@@ -102,7 +102,7 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdNoise)
       ezStringBuilder sLine;
       for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(histogram); ++i)
       {
-        sLine.Format("{},\n", histogram[i]);
+        sLine.SetFormat("{},\n", histogram[i]);
         fileWriter.WriteBytes(sLine.GetData(), sLine.GetElementCount()).IgnoreResult();
       }
     }

--- a/Code/UnitTests/FoundationTest/Strings/FormatStringTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/FormatStringTest.cpp
@@ -245,10 +245,10 @@ EZ_CREATE_SIMPLE_TEST(Strings, FormatString)
 
     ezStringBuilder fmt;
 
-    fmt.Format("Password: {}", ezArgSensitive("hunter2", "pwd"));
+    fmt.SetFormat("Password: {}", ezArgSensitive("hunter2", "pwd"));
     EZ_TEST_STRING(fmt, "Password: sud:pwd#96d66ce6($7)");
 
-    fmt.Format("Password: {}", ezArgSensitive("hunter2"));
+    fmt.SetFormat("Password: {}", ezArgSensitive("hunter2"));
     EZ_TEST_STRING(fmt, "Password: sud:#96d66ce6($7)");
   }
 }

--- a/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
@@ -329,7 +329,7 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Printf")
   {
     ezStringBuilder s("abc");
-    s.Printf("Test%i%s%s", 42, "foo", ezStringUtf8(L"bär").GetData());
+    s.SetPrintf("Test%i%s%s", 42, "foo", ezStringUtf8(L"bär").GetData());
 
     EZ_TEST_BOOL(s == ezStringUtf8(L"Test42foobär").GetData());
   }
@@ -337,7 +337,7 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Format")
   {
     ezStringBuilder s("abc");
-    s.Format("Test{0}{1}{2}", 42, "foo", ezStringUtf8(L"bär").GetData());
+    s.SetFormat("Test{0}{1}{2}", 42, "foo", ezStringUtf8(L"bär").GetData());
 
     EZ_TEST_BOOL(s == ezStringUtf8(L"Test42foobär").GetData());
   }

--- a/Code/UnitTests/FoundationTest/Utility/EnvironmentVariableUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Utility/EnvironmentVariableUtilsTest.cpp
@@ -35,7 +35,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, EnvironmentVariableUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "IsVariableSet/SetValue")
   {
     ezStringBuilder szVarName;
-    szVarName.Format("EZ_THIS_SHOULDNT_EXIST_NOW_OR_THIS_TEST_WILL_FAIL_{0}", uiVersionForVariableSetting++);
+    szVarName.SetFormat("EZ_THIS_SHOULDNT_EXIST_NOW_OR_THIS_TEST_WILL_FAIL_{0}", uiVersionForVariableSetting++);
 
     EZ_TEST_BOOL(!ezEnvironmentVariableUtils::IsVariableSet(szVarName));
 
@@ -57,7 +57,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, EnvironmentVariableUtils)
       "SOME REALLY LONG VALUE, LETS TEST SOME LIMITS WE MIGHT HIT - 012456789 ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz";
 
     ezStringBuilder szVarName;
-    szVarName.Format("EZ_LONG_VARIABLE_TEST_{0}", uiVersionForVariableSetting++);
+    szVarName.SetFormat("EZ_LONG_VARIABLE_TEST_{0}", uiVersionForVariableSetting++);
 
     EZ_TEST_BOOL(!ezEnvironmentVariableUtils::IsVariableSet(szVarName));
 

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -367,7 +367,7 @@ ezTestAppRun ezRendererTestAdvancedFeatures::SharedTexture()
   m_SharedTextureQueue.PopFront();
 
   ezStringBuilder sTemp;
-  sTemp.Format("Render {}:{}|{}", m_uiReceivedTextures, texture.m_uiCurrentTextureIndex, texture.m_uiCurrentSemaphoreValue);
+  sTemp.SetFormat("Render {}:{}|{}", m_uiReceivedTextures, texture.m_uiCurrentTextureIndex, texture.m_uiCurrentSemaphoreValue);
   EZ_PROFILE_SCOPE(sTemp);
   BeginFrame(sTemp);
   {
@@ -435,7 +435,7 @@ void ezRendererTestAdvancedFeatures::OffscreenProcessMessageFunc(const ezProcess
   {
     m_uiReceivedTextures++;
     ezStringBuilder sTemp;
-    sTemp.Format("Receive {}|{}", pAction->m_Texture.m_uiCurrentTextureIndex, pAction->m_Texture.m_uiCurrentSemaphoreValue);
+    sTemp.SetFormat("Receive {}|{}", pAction->m_Texture.m_uiCurrentTextureIndex, pAction->m_Texture.m_uiCurrentSemaphoreValue);
     EZ_PROFILE_SCOPE(sTemp);
     m_SharedTextureQueue.PushBack(pAction->m_Texture);
   }

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -90,7 +90,7 @@ ezApplication::Execution ezOffscreenRendererTest::Run()
     pSwapChain->Arm(action.m_Texture.m_uiCurrentTextureIndex, action.m_Texture.m_uiCurrentSemaphoreValue);
 
     ezStringBuilder sTemp;
-    sTemp.Format("Render {}|{}", action.m_Texture.m_uiCurrentTextureIndex, action.m_Texture.m_uiCurrentSemaphoreValue);
+    sTemp.SetFormat("Render {}|{}", action.m_Texture.m_uiCurrentTextureIndex, action.m_Texture.m_uiCurrentSemaphoreValue);
     EZ_PROFILE_SCOPE(sTemp);
 
     // Before starting to render in a frame call this function
@@ -144,7 +144,7 @@ ezApplication::Execution ezOffscreenRendererTest::Run()
 void ezOffscreenRendererTest::OnPresent(ezUInt32 uiCurrentTexture, ezUInt64 uiCurrentSemaphoreValue)
 {
   ezStringBuilder sTemp;
-  sTemp.Format("Response {}|{}", uiCurrentTexture, uiCurrentSemaphoreValue);
+  sTemp.SetFormat("Response {}|{}", uiCurrentTexture, uiCurrentSemaphoreValue);
   EZ_PROFILE_SCOPE(sTemp);
 
   ezOffscreenTest_RenderResponseMsg msg = {};
@@ -161,7 +161,7 @@ void ezOffscreenRendererTest::AfterCoreSystemsStartup()
 
   ezGlobalLog::AddLogWriter(ezLoggingEvent::Handler(&ezLogWriter::HTML::LogMessageHandler, &m_LogHTML));
   ezStringBuilder sLogFile;
-  sLogFile.Format(":imgout/OffscreenLog.htm");
+  sLogFile.SetFormat(":imgout/OffscreenLog.htm");
   m_LogHTML.BeginLog(sLogFile, "OffscreenRenderer"_ezsv);
 
   // Setup Shaders and Materials

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -143,7 +143,7 @@ void ezRendererTestReadback::CompareReadbackImage(ezImage&& image)
   }
   else
   {
-    sTemp.Format("Readback_Color{}Channel", uiChannels);
+    sTemp.SetFormat("Readback_Color{}Channel", uiChannels);
   }
   m_sReadBackReferenceImage = sTemp;
   m_ReadBackResult.ResetAndMove(std::move(image));
@@ -161,7 +161,7 @@ void ezRendererTestReadback::CompareUploadImage()
   }
   else
   {
-    sTemp.Format("Readback_Upload_Color{}Channel", uiChannels);
+    sTemp.SetFormat("Readback_Upload_Color{}Channel", uiChannels);
   }
   m_sReadBackReferenceImage = sTemp;
   EZ_TEST_IMAGE(1, 3);

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -422,7 +422,7 @@ ezMeshBufferResourceHandle ezGraphicsTest::CreateSphere(ezInt32 iSubDivs, float 
   geom.AddGeodesicSphere(fRadius, static_cast<ezUInt8>(iSubDivs));
 
   ezStringBuilder sName;
-  sName.Format("Sphere_{0}", iSubDivs);
+  sName.SetFormat("Sphere_{0}", iSubDivs);
 
   return CreateMesh(geom, sName);
 }
@@ -433,7 +433,7 @@ ezMeshBufferResourceHandle ezGraphicsTest::CreateTorus(ezInt32 iSubDivs, float f
   geom.AddTorus(fInnerRadius, fOuterRadius, static_cast<ezUInt16>(iSubDivs), static_cast<ezUInt16>(iSubDivs), true);
 
   ezStringBuilder sName;
-  sName.Format("Torus_{0}", iSubDivs);
+  sName.SetFormat("Torus_{0}", iSubDivs);
 
   return CreateMesh(geom, sName);
 }
@@ -444,7 +444,7 @@ ezMeshBufferResourceHandle ezGraphicsTest::CreateBox(float fWidth, float fHeight
   geom.AddBox(ezVec3(fWidth, fHeight, fDepth), false);
 
   ezStringBuilder sName;
-  sName.Format("Box_{0}_{1}_{2}", ezArgF(fWidth, 1), ezArgF(fHeight, 1), ezArgF(fDepth, 1));
+  sName.SetFormat("Box_{0}_{1}_{2}", ezArgF(fWidth, 1), ezArgF(fHeight, 1), ezArgF(fDepth, 1));
 
   return CreateMesh(geom, sName);
 }
@@ -455,7 +455,7 @@ ezMeshBufferResourceHandle ezGraphicsTest::CreateLineBox(float fWidth, float fHe
   geom.AddLineBox(ezVec3(fWidth, fHeight, fDepth));
 
   ezStringBuilder sName;
-  sName.Format("LineBox_{0}_{1}_{2}", ezArgF(fWidth, 1), ezArgF(fHeight, 1), ezArgF(fDepth, 1));
+  sName.SetFormat("LineBox_{0}_{1}_{2}", ezArgF(fWidth, 1), ezArgF(fHeight, 1), ezArgF(fDepth, 1));
 
   return CreateMesh(geom, sName);
 }

--- a/Code/UnitTests/TestFramework/Framework/TestBaseClass.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestBaseClass.cpp
@@ -40,7 +40,7 @@ void ezTestBaseClass::UpdateConfiguration(ezTestConfiguration& ref_config) const
 
 void ezTestBaseClass::MapImageNumberToString(const char* szTestName, const ezSubTestEntry& subTest, ezUInt32 uiImageNumber, ezStringBuilder& out_sString) const
 {
-  out_sString.Format("{0}_{1}_{2}", szTestName, subTest.m_szSubTestName, ezArgI(uiImageNumber, 3, true));
+  out_sString.SetFormat("{0}_{1}_{2}", szTestName, subTest.m_szSubTestName, ezArgI(uiImageNumber, 3, true));
   out_sString.ReplaceAll(" ", "_");
 }
 

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -1433,14 +1433,14 @@ bool ezTestFramework::PerformImageComparison(ezStringBuilder sImgName, const ezI
     ezImageConversion::Convert(imgDiffRgba, imgDiffRgb, ezImageFormat::R8G8B8_UNORM).IgnoreResult();
 
     ezStringBuilder sImgDiffName;
-    sImgDiffName.Format(":imgout/Images_Diff/{0}.png", sImgName);
+    sImgDiffName.SetFormat(":imgout/Images_Diff/{0}.png", sImgName);
     imgDiffRgb.SaveTo(sImgDiffName).IgnoreResult();
 
     ezImage imgDiffAlpha;
     ezImageUtils::ExtractAlphaChannel(imgDiffRgba, imgDiffAlpha);
 
     ezStringBuilder sImgDiffAlphaName;
-    sImgDiffAlphaName.Format(":imgout/Images_Diff/{0}_alpha.png", sImgName);
+    sImgDiffAlphaName.SetFormat(":imgout/Images_Diff/{0}_alpha.png", sImgName);
     imgDiffAlpha.SaveTo(sImgDiffAlphaName).IgnoreResult();
 
     ezImage imgExpRgb;
@@ -1454,7 +1454,7 @@ bool ezTestFramework::PerformImageComparison(ezStringBuilder sImgName, const ezI
     ezImageUtils::ExtractAlphaChannel(imgRgba, imgAlpha);
 
     ezStringBuilder sDiffHtmlPath;
-    sDiffHtmlPath.Format(":imgout/Html_Diff/{0}.html", sImgName);
+    sDiffHtmlPath.SetFormat(":imgout/Html_Diff/{0}.html", sImgName);
     WriteImageDiffHtml(sDiffHtmlPath, imgExpRgb, imgExpAlpha, imgRgb, imgAlpha, imgDiffRgb, imgDiffAlpha, uiMeanError, uiMaxError, uiMinDiffRgb, uiMaxDiffRgb, uiMinDiffAlpha, uiMaxDiffAlpha);
 
     safeprintf(szErrorMsg, s_iMaxErrorMessageLength, "Error: Image Comparison Failed: MSE of %u exceeds threshold of %u for image '%s'.", uiMeanError, uiMaxError, sImgName.GetData());
@@ -1536,18 +1536,18 @@ ezResult ezTestFramework::CaptureRegressionStat(ezStringView sTestName, ezString
   ezStringBuilder perTestName;
   if (iTestId < 0)
   {
-    perTestName.Format("{}_{}", strippedTestName, sName);
+    perTestName.SetFormat("{}_{}", strippedTestName, sName);
   }
   else
   {
-    perTestName.Format("{}_{}_{}", strippedTestName, sName, iTestId);
+    perTestName.SetFormat("{}_{}_{}", strippedTestName, sName, iTestId);
   }
 
   {
     ezStringBuilder regression;
     // The 6 floating point digits are forced as per a requirement of the CI
     // feature that parses these values.
-    regression.Format("[test][REGRESSION:{}:{}:{}]", perTestName, sUnit, ezArgF(value, 6));
+    regression.SetFormat("[test][REGRESSION:{}:{}:{}]", perTestName, sUnit, ezArgF(value, 6));
     ezLog::Info(regression);
   }
 

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Increase me: 20
+Increase me: 21


### PR DESCRIPTION
It always bothered me, that these functions don't stick to the typical convention for how we name functions.