### PR TITLE
More Node Graph Improvements

### DIFF
--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeView.cpp
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeView.cpp
@@ -138,19 +138,26 @@ void ezQtNodeView::resizeEvent(QResizeEvent* event)
 
 void ezQtNodeView::drawBackground(QPainter* painter, const QRectF& r)
 {
-#if(false)
   QGraphicsView::drawBackground(painter, r);
 
-  QPen pfine(ezToQtColor(ezColorScheme::GetColor(ezColorScheme::Gray, 0)), 1.0);
+  if(m_ViewScale.manhattanLength() > 1.0)
+  {
+    QPen pfine(ezToQtColor(ezColorScheme::GetColor(ezColorScheme::Gray, 0)), 1.0);
 
-  painter->setPen(pfine);
-  DrawGrid(painter, 15);
+    painter->setPen(pfine);
+    DrawGrid(painter, 15);
+  }
 
-  QPen p(ezToQtColor(ezColorScheme::GetColor(ezColorScheme::Gray, 2)), 1.0);
+  if(m_ViewScale.manhattanLength() > 0.1)
+  {
+    double scale = m_ViewScale.manhattanLength() < 0.25 ? 150.0 : 300.0;
 
-  painter->setPen(p);
-  DrawGrid(painter, 150);
-#endif
+    QPen p(ezToQtColor(ezColorScheme::GetColor(ezColorScheme::Gray, 2)), 1.0);
+
+    painter->setPen(p);
+    DrawGrid(painter, scale);
+  }
+  
   // Only force constant redraws when doing the debug animation.
   if (GetScene()->GetConnectionDecorationFlags().IsSet(ezQtNodeScene::ConnectionDecorationFlags::DrawDebugging))
   {

--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/NodeScene.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/NodeScene.moc.h
@@ -123,6 +123,7 @@ private:
   bool m_bIgnoreSelectionChange = false;
   ezQtPin* m_pStartPin = nullptr;
   ezQtConnection* m_pTempConnection = nullptr;
+  ezQtNode* m_pTempNode = nullptr;
   ezDeque<const ezDocumentObject*> m_Selection;
   ezVec2 m_vMousePos = ezVec2::MakeZero();
   QString m_sContextMenuSearchText;


### PR DESCRIPTION
Improve performance on grid background so should be capable of being enabled by default.
Also added a create on connection drag feature shown in the gif. If you drop into an empty space it will prompt you with the create node popup. If you create a node it will try connect to the first valid input

![Create on drag](https://github.com/ezEngine/ezEngine/assets/3044415/68bc4f36-6a41-483b-9ee6-b40d5b89907b)
