### PR TITLE
Minor Improvements to Light Components

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -88,6 +88,7 @@ void AssetCuratorEventHandler(const ezAssetCuratorEvent& e)
 void ezCameraComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 void ezSkyLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 void ezGreyBoxComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
+void ezLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
 void ezSceneDocument_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
@@ -188,6 +189,7 @@ void OnLoadPlugin()
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezCameraComponent_PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezSkyLightComponent_PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezGreyBoxComponent_PropertyMetaStateEventHandler);
+  ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezLightComponent_PropertyMetaStateEventHandler);
 }
 
 void OnUnloadPlugin()
@@ -200,6 +202,7 @@ void OnUnloadPlugin()
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezGreyBoxComponent_PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezSkyLightComponent_PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezCameraComponent_PropertyMetaStateEventHandler);
+  ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezLightComponent_PropertyMetaStateEventHandler);
 
 
   ezSelectionActions::UnregisterActions();
@@ -304,5 +307,29 @@ void ezGreyBoxComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& 
       props["SlopedBottom"].m_Visibility = ezPropertyUiState::Default;
       props["Detail"].m_sNewLabelText = "Steps";
       break;
+  }
+}
+
+void ezLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e)
+{
+  static const ezRTTI* pRtti = ezRTTI::FindTypeByName("ezLightComponent");
+  EZ_ASSERT_DEBUG(pRtti != nullptr, "Did the typename change?");
+
+  if (!e.m_pObject-> GetTypeAccessor().GetType()->IsDerivedFrom(pRtti))
+    return;
+
+  auto& props = *e.m_pPropertyStates;
+
+  const bool bUseColorTemperature = e.m_pObject->GetTypeAccessor().GetValue("UseColorTemperature").ConvertTo<bool>();
+
+  if (bUseColorTemperature)
+  {
+    props["Temperature"].m_Visibility = ezPropertyUiState::Default;
+    props["LightColor"].m_Visibility = ezPropertyUiState::Invisible;
+  }
+  else
+  {
+    props["Temperature"].m_Visibility = ezPropertyUiState::Invisible;
+    props["LightColor"].m_Visibility = ezPropertyUiState::Default;
   }
 }

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -247,6 +247,9 @@ public:
   void SetRGBA(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // [tested]
 
   /// \brief Returns a color created from the kelvin temperature. https://wikipedia.org/wiki/Color_temperature
+  /// Originally inspired from https://tannerhelland.com/2012/09/18/convert-temperature-rgb-algorithm-code.html
+  /// But with heavy modification to better fit the mapping shown out in https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf
+  /// Physically accurate clipping points are 6580K for Red and 6560K for G and B. but approximated to 6570k for all to give a better mapping.
   static ezColor MakeFromKelvin(ezUInt32 uiKelvin);
   // *** Conversion Operators/Functions ***
 public:

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -246,6 +246,7 @@ public:
   /// \brief Sets all four RGBA components.
   void SetRGBA(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // [tested]
 
+  /// \brief Returns a color created from the kelvin temperature. https://wikipedia.org/wiki/Color_temperature
   static ezColor MakeFromKelvin(ezUInt32 uiKelvin);
   // *** Conversion Operators/Functions ***
 public:

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -246,7 +246,7 @@ public:
   /// \brief Sets all four RGBA components.
   void SetRGBA(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // [tested]
 
-  void SetKelvin(ezUInt32 uKelvin);
+  static ezColor MakeFromKelvin(ezUInt32 uiKelvin);
   // *** Conversion Operators/Functions ***
 public:
   /// \brief Sets this color from a HSV (hue, saturation, value) format.

--- a/Code/Engine/Foundation/Math/Color.h
+++ b/Code/Engine/Foundation/Math/Color.h
@@ -246,6 +246,7 @@ public:
   /// \brief Sets all four RGBA components.
   void SetRGBA(float fLinearRed, float fLinearGreen, float fLinearBlue, float fLinearAlpha = 1.0f); // [tested]
 
+  void SetKelvin(ezUInt32 uKelvin);
   // *** Conversion Operators/Functions ***
 public:
   /// \brief Sets this color from a HSV (hue, saturation, value) format.

--- a/Code/Engine/Foundation/Math/Implementation/Color_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Color_inl.h
@@ -46,17 +46,20 @@ inline void ezColor::SetRGBA(float fLinearRed, float fLinearGreen, float fLinear
   a = fLinearAlpha;
 }
 
-inline void ezColor::SetKelvin(ezUInt32 uKelvin)
+inline ezColor ezColor::MakeFromKelvin(ezUInt32 uiKelvin)
 {
-  float kelvin = ezMath::Clamp(uKelvin, 1000u, 40000u) / 1000.0f;
+  ezColor finalColor;
+  float kelvin = ezMath::Clamp(uiKelvin, 1000u, 40000u) / 1000.0f;
   float kelvin2 = kelvin * kelvin;
 
   // Red
-  r = kelvin < 6.580f ? 1.0f : ezMath::Clamp((1.35651f + 0.216422f * kelvin + 0.000633715f * kelvin2) / (-3.24223f + 0.918711f * kelvin), 0.0f, 1.0f);
+  finalColor.r = kelvin < 6.570f ? 1.0f : ezMath::Clamp((1.35651f + 0.216422f * kelvin + 0.000633715f * kelvin2) / (-3.24223f + 0.918711f * kelvin), 0.0f, 1.0f);
   // Green
-  g = kelvin < 6.560f ? ezMath::Clamp((-399.809f + 414.271f * kelvin + 111.543f * kelvin2) / (2779.24f + 164.143f * kelvin + 84.7356f * kelvin2), 0.0f, 1.0f) : ezMath::Clamp((1370.38f + 734.616f * kelvin + 0.689955f * kelvin2) / (-4625.69f + 1699.87f * kelvin), 0.0f, 1.0f);
+  finalColor.g = kelvin < 6.570f ? ezMath::Clamp((-399.809f + 414.271f * kelvin + 111.543f * kelvin2) / (2779.24f + 164.143f * kelvin + 84.7356f * kelvin2), 0.0f, 1.0f) : ezMath::Clamp((1370.38f + 734.616f * kelvin + 0.689955f * kelvin2) / (-4625.69f + 1699.87f * kelvin), 0.0f, 1.0f);
   // Blue
-  b = kelvin > 6.580f ? 1.0f : ezMath::Clamp((348.963f - 523.53f * kelvin + 183.62f * kelvin2) / (2848.82f - 214.52f * kelvin + 78.8614f * kelvin2), 0.0f, 1.0f);
+  finalColor.b = kelvin > 6.570f ? 1.0f : ezMath::Clamp((348.963f - 523.53f * kelvin + 183.62f * kelvin2) / (2848.82f - 214.52f * kelvin + 78.8614f * kelvin2), 0.0f, 1.0f);
+
+  return finalColor;
 }
 
 // http://en.wikipedia.org/wiki/Luminance_%28relative%29

--- a/Code/Engine/Foundation/Math/Implementation/Color_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Color_inl.h
@@ -1,3 +1,4 @@
+#include "Color.h"
 #pragma once
 
 inline ezColor::ezColor()
@@ -43,6 +44,19 @@ inline void ezColor::SetRGBA(float fLinearRed, float fLinearGreen, float fLinear
   g = fLinearGreen;
   b = fLinearBlue;
   a = fLinearAlpha;
+}
+
+inline void ezColor::SetKelvin(ezUInt32 uKelvin)
+{
+  float kelvin = ezMath::Clamp(uKelvin, 1000u, 40000u) / 1000.0f;
+  float kelvin2 = kelvin * kelvin;
+
+  // Red
+  r = kelvin < 6.580f ? 1.0f : ezMath::Clamp((1.35651f + 0.216422f * kelvin + 0.000633715f * kelvin2) / (-3.24223f + 0.918711f * kelvin), 0.0f, 1.0f);
+  // Green
+  g = kelvin < 6.560f ? ezMath::Clamp((-399.809f + 414.271f * kelvin + 111.543f * kelvin2) / (2779.24f + 164.143f * kelvin + 84.7356f * kelvin2), 0.0f, 1.0f) : ezMath::Clamp((1370.38f + 734.616f * kelvin + 0.689955f * kelvin2) / (-4625.69f + 1699.87f * kelvin), 0.0f, 1.0f);
+  // Blue
+  b = kelvin > 6.580f ? 1.0f : ezMath::Clamp((348.963f - 523.53f * kelvin + 183.62f * kelvin2) / (2848.82f - 214.52f * kelvin + 78.8614f * kelvin2), 0.0f, 1.0f);
 }
 
 // http://en.wikipedia.org/wiki/Luminance_%28relative%29

--- a/Code/Engine/Foundation/Math/Implementation/Color_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Color_inl.h
@@ -1,4 +1,3 @@
-#include "Color.h"
 #pragma once
 
 inline ezColor::ezColor()

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -144,6 +144,22 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDefaultValueAttribute, 1, ezRTTIDefaultAllocat
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSliderAttribute, 1, ezRTTIDefaultAllocator<ezSliderAttribute>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Min", m_MinValue),
+    EZ_MEMBER_PROPERTY("Max", m_MaxValue),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_CONSTRUCTOR_PROPERTY(const ezVariant&, const ezVariant&),
+  }
+  EZ_END_FUNCTIONS;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezClampValueAttribute, 1, ezRTTIDefaultAllocator<ezClampValueAttribute>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -193,6 +193,27 @@ private:
   ezVariant m_Value;
 };
 
+/// \brief A property attribute that provides a ui slider between the min and max values
+class EZ_FOUNDATION_DLL ezSliderAttribute : public ezPropertyAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSliderAttribute, ezPropertyAttribute);
+
+public:
+  ezSliderAttribute() = default;
+  ezSliderAttribute(const ezVariant& min, const ezVariant& max)
+    : m_MinValue(min)
+    , m_MaxValue(max)
+  {
+  }
+
+  const ezVariant& GetMinValue() const { return m_MinValue; }
+  const ezVariant& GetMaxValue() const { return m_MaxValue; }
+
+private:
+  ezVariant m_MinValue;
+  ezVariant m_MaxValue;
+};
+
 /// \brief A property attribute that allows to define min and max values for the UI. Min or max may be set to an invalid variant to indicate
 /// unbounded values in one direction.
 class EZ_FOUNDATION_DLL ezClampValueAttribute : public ezPropertyAttribute

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
@@ -262,7 +262,7 @@ void ezLensFlareComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   const ezLightComponent* pLightComponent = nullptr;
   if (GetWorld()->TryGetComponent(m_hLightComponent, pLightComponent))
   {
-    lightColor = pLightComponent->GetLightColor();
+    lightColor = pLightComponent->GetFinalLightColor();
     lightColor *= pLightComponent->GetIntensity() * 0.1f;
   }
 

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
@@ -262,7 +262,7 @@ void ezLensFlareComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   const ezLightComponent* pLightComponent = nullptr;
   if (GetWorld()->TryGetComponent(m_hLightComponent, pLightComponent))
   {
-    lightColor = pLightComponent->GetFinalLightColor();
+    lightColor = pLightComponent->GetLightColor();
     lightColor *= pLightComponent->GetIntensity() * 0.1f;
   }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
@@ -170,6 +170,7 @@ namespace
 
     ref_perLightData.colorAndType = *reinterpret_cast<ezUInt32*>(&lightColor.r);
     ref_perLightData.intensity = pLightRenderData->m_fIntensity;
+    ref_perLightData.specularMultiplier = pLightRenderData->m_fSpecularMultiplier;
     ref_perLightData.shadowDataOffset = pLightRenderData->m_uiShadowDataOffset;
   }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/DirectionalLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/DirectionalLightComponent.cpp
@@ -116,15 +116,7 @@ void ezDirectionalLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData&
   auto pRenderData = ezCreateRenderDataForThisFrame<ezDirectionalLightRenderData>(GetOwner());
 
   pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform();
-
-  if (m_bUseColorTemperature)
-  {
-    pRenderData->m_LightColor.SetKelvin(m_uTemperature);
-  }
-  else
-  {
-    pRenderData->m_LightColor = m_LightColor;
-  }
+  pRenderData->m_LightColor = GetLightColor();
   pRenderData->m_fIntensity = m_fIntensity;
   pRenderData->m_fSpecularMultiplier = m_fSpecularMultiplier;
   pRenderData->m_uiShadowDataOffset = m_bCastShadows ? ezShadowPool::AddDirectionalLight(this, msg.m_pView) : ezInvalidIndex;

--- a/Code/Engine/RendererCore/Lights/Implementation/DirectionalLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/DirectionalLightComponent.cpp
@@ -116,8 +116,17 @@ void ezDirectionalLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData&
   auto pRenderData = ezCreateRenderDataForThisFrame<ezDirectionalLightRenderData>(GetOwner());
 
   pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform();
-  pRenderData->m_LightColor = m_LightColor;
+
+  if (m_bUseColorTemperature)
+  {
+    pRenderData->m_LightColor.SetKelvin(m_uTemperature);
+  }
+  else
+  {
+    pRenderData->m_LightColor = m_LightColor;
+  }
   pRenderData->m_fIntensity = m_fIntensity;
+  pRenderData->m_fSpecularMultiplier = m_fSpecularMultiplier;
   pRenderData->m_uiShadowDataOffset = m_bCastShadows ? ezShadowPool::AddDirectionalLight(this, msg.m_pView) : ezInvalidIndex;
 
   pRenderData->FillBatchIdAndSortingKey(1.0f);

--- a/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
@@ -24,7 +24,7 @@ EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezLightComponent, 5)
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("UseColorTemperature", GetUsingColorTemperature, SetUsingColorTemperature),
-    EZ_ACCESSOR_PROPERTY("LightColor", GetLightColor, SetLightColor),
+    EZ_ACCESSOR_PROPERTY("LightColor", GetBaseLightColor, SetLightColor),
     EZ_ACCESSOR_PROPERTY("Temperature", GetTemperature, SetTemperature)->AddAttributes(new ezSliderAttribute(1000, 15000), new ezDefaultValueAttribute(6550), new ezSuffixAttribute(" K")),
     EZ_ACCESSOR_PROPERTY("Intensity", GetIntensity, SetIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
     EZ_ACCESSOR_PROPERTY("SpecularMultiplier", GetSpecularMultiplier, SetSpecularMultiplier)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),

--- a/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
@@ -70,18 +70,16 @@ void ezLightComponent::SetLightColor(ezColorGammaUB lightColor)
   InvalidateCachedRenderData();
 }
 
-ezColorGammaUB ezLightComponent::GetLightColor() const
+ezColorGammaUB ezLightComponent::GetBaseLightColor() const
 {
   return m_LightColor;
 }
 
-ezColorGammaUB ezLightComponent::GetFinalLightColor() const
+ezColorGammaUB ezLightComponent::GetLightColor() const
 {
   if (m_bUseColorTemperature)
   {
-    ezColor kelvinColor;
-    kelvinColor.SetKelvin(m_uTemperature);
-    return kelvinColor;
+    return ezColor::MakeFromKelvin(m_uiTemperature);
   }
   else
   {
@@ -96,16 +94,16 @@ void ezLightComponent::SetIntensity(float fIntensity)
   TriggerLocalBoundsUpdate();
 }
 
-void ezLightComponent::SetTemperature(ezUInt32 uTemperature)
+void ezLightComponent::SetTemperature(ezUInt32 uiTemperature)
 {
-  m_uTemperature = ezMath::Clamp(uTemperature, 1500u, 40000u);
+  m_uiTemperature = ezMath::Clamp(uiTemperature, 1500u, 40000u);
 
   InvalidateCachedRenderData();
 }
 
 ezUInt32 ezLightComponent::GetTemperature() const
 {
-  return m_uTemperature;
+  return m_uiTemperature;
 }
 
 float ezLightComponent::GetIntensity() const
@@ -185,7 +183,7 @@ void ezLightComponent::SerializeComponent(ezWorldWriter& inout_stream) const
   s << m_fConstantBias;
   s << m_bCastShadows;
   s << m_bUseColorTemperature;
-  s << m_uTemperature;
+  s << m_uiTemperature;
   s << m_fSpecularMultiplier;
 }
 
@@ -216,7 +214,7 @@ void ezLightComponent::DeserializeComponent(ezWorldReader& inout_stream)
   {
 
     s >> m_bUseColorTemperature;
-    s >> m_uTemperature;
+    s >> m_uiTemperature;
     s >> m_fSpecularMultiplier;
   }
 }

--- a/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
@@ -24,7 +24,7 @@ EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezLightComponent, 5)
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("UseColorTemperature", GetUsingColorTemperature, SetUsingColorTemperature),
-    EZ_ACCESSOR_PROPERTY("LightColor", GetBaseLightColor, SetLightColor),
+    EZ_ACCESSOR_PROPERTY("LightColor", GetLightColor, SetLightColor),
     EZ_ACCESSOR_PROPERTY("Temperature", GetTemperature, SetTemperature)->AddAttributes(new ezSliderAttribute(1000, 15000), new ezDefaultValueAttribute(6550), new ezSuffixAttribute(" K")),
     EZ_ACCESSOR_PROPERTY("Intensity", GetIntensity, SetIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
     EZ_ACCESSOR_PROPERTY("SpecularMultiplier", GetSpecularMultiplier, SetSpecularMultiplier)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),

--- a/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
@@ -19,12 +19,15 @@ void ezLightRenderData::FillBatchIdAndSortingKey(float fScreenSpaceSize)
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezLightComponent, 4)
+EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezLightComponent, 5)
 {
   EZ_BEGIN_PROPERTIES
   {
+    EZ_ACCESSOR_PROPERTY("UseColorTemperature", GetUsingColorTemperature, SetUsingColorTemperature),
     EZ_ACCESSOR_PROPERTY("LightColor", GetLightColor, SetLightColor),
+    EZ_ACCESSOR_PROPERTY("Temperature", GetTemperature, SetTemperature)->AddAttributes(new ezSliderAttribute(1000, 15000), new ezDefaultValueAttribute(6550), new ezSuffixAttribute(" K")),
     EZ_ACCESSOR_PROPERTY("Intensity", GetIntensity, SetIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
+    EZ_ACCESSOR_PROPERTY("SpecularMultiplier", GetSpecularMultiplier, SetSpecularMultiplier)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),
     EZ_ACCESSOR_PROPERTY("CastShadows", GetCastShadows, SetCastShadows),
     EZ_ACCESSOR_PROPERTY("PenumbraSize", GetPenumbraSize, SetPenumbraSize)->AddAttributes(new ezClampValueAttribute(0.0f, 0.5f), new ezDefaultValueAttribute(0.1f), new ezSuffixAttribute(" m")),
     EZ_ACCESSOR_PROPERTY("SlopeBias", GetSlopeBias, SetSlopeBias)->AddAttributes(new ezClampValueAttribute(0.0f, 10.0f), new ezDefaultValueAttribute(0.25f)),
@@ -48,6 +51,18 @@ EZ_END_ABSTRACT_COMPONENT_TYPE
 ezLightComponent::ezLightComponent() = default;
 ezLightComponent::~ezLightComponent() = default;
 
+void ezLightComponent::SetUsingColorTemperature(bool bUseColorTemperature)
+{
+  m_bUseColorTemperature = bUseColorTemperature;
+
+  InvalidateCachedRenderData();
+}
+
+bool ezLightComponent::GetUsingColorTemperature() const
+{
+  return m_bUseColorTemperature;
+}
+
 void ezLightComponent::SetLightColor(ezColorGammaUB lightColor)
 {
   m_LightColor = lightColor;
@@ -60,6 +75,20 @@ ezColorGammaUB ezLightComponent::GetLightColor() const
   return m_LightColor;
 }
 
+ezColorGammaUB ezLightComponent::GetFinalLightColor() const
+{
+  if (m_bUseColorTemperature)
+  {
+    ezColor kelvinColor;
+    kelvinColor.SetKelvin(m_uTemperature);
+    return kelvinColor;
+  }
+  else
+  {
+    return m_LightColor;
+  }
+}
+
 void ezLightComponent::SetIntensity(float fIntensity)
 {
   m_fIntensity = ezMath::Max(fIntensity, 0.0f);
@@ -67,9 +96,33 @@ void ezLightComponent::SetIntensity(float fIntensity)
   TriggerLocalBoundsUpdate();
 }
 
+void ezLightComponent::SetTemperature(ezUInt32 uTemperature)
+{
+  m_uTemperature = ezMath::Clamp(uTemperature, 1500u, 40000u);
+
+  InvalidateCachedRenderData();
+}
+
+ezUInt32 ezLightComponent::GetTemperature() const
+{
+  return m_uTemperature;
+}
+
 float ezLightComponent::GetIntensity() const
 {
   return m_fIntensity;
+}
+
+void ezLightComponent::SetSpecularMultiplier(float fSpecularMultiplier)
+{
+  m_fSpecularMultiplier = ezMath::Max(fSpecularMultiplier, 0.0f);
+
+  InvalidateCachedRenderData();
+}
+
+float ezLightComponent::GetSpecularMultiplier() const
+{
+  return m_fSpecularMultiplier;
 }
 
 void ezLightComponent::SetCastShadows(bool bCastShadows)
@@ -131,6 +184,9 @@ void ezLightComponent::SerializeComponent(ezWorldWriter& inout_stream) const
   s << m_fSlopeBias;
   s << m_fConstantBias;
   s << m_bCastShadows;
+  s << m_bUseColorTemperature;
+  s << m_uTemperature;
+  s << m_fSpecularMultiplier;
 }
 
 void ezLightComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -155,6 +211,14 @@ void ezLightComponent::DeserializeComponent(ezWorldReader& inout_stream)
   }
 
   s >> m_bCastShadows;
+
+  if (uiVersion >= 5)
+  {
+
+    s >> m_bUseColorTemperature;
+    s >> m_uTemperature;
+    s >> m_fSpecularMultiplier;
+  }
 }
 
 void ezLightComponent::OnMsgSetColor(ezMsgSetColor& ref_msg)

--- a/Code/Engine/RendererCore/Lights/Implementation/PointLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/PointLightComponent.cpp
@@ -113,16 +113,7 @@ void ezPointLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   auto pRenderData = ezCreateRenderDataForThisFrame<ezPointLightRenderData>(GetOwner());
 
   pRenderData->m_GlobalTransform = t;
-
-  if (m_bUseColorTemperature)
-  {
-    pRenderData->m_LightColor.SetKelvin(m_uTemperature);
-  }
-  else
-  {
-    pRenderData->m_LightColor = m_LightColor;
-  }
-
+  pRenderData->m_LightColor = GetLightColor();
   pRenderData->m_fIntensity = m_fIntensity;
   pRenderData->m_fSpecularMultiplier = m_fSpecularMultiplier;
   pRenderData->m_fRange = m_fEffectiveRange;

--- a/Code/Engine/RendererCore/Lights/Implementation/PointLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/PointLightComponent.cpp
@@ -113,8 +113,18 @@ void ezPointLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   auto pRenderData = ezCreateRenderDataForThisFrame<ezPointLightRenderData>(GetOwner());
 
   pRenderData->m_GlobalTransform = t;
-  pRenderData->m_LightColor = m_LightColor;
+
+  if (m_bUseColorTemperature)
+  {
+    pRenderData->m_LightColor.SetKelvin(m_uTemperature);
+  }
+  else
+  {
+    pRenderData->m_LightColor = m_LightColor;
+  }
+
   pRenderData->m_fIntensity = m_fIntensity;
+  pRenderData->m_fSpecularMultiplier = m_fSpecularMultiplier;
   pRenderData->m_fRange = m_fEffectiveRange;
   // pRenderData->m_hProjectedTexture = m_hProjectedTexture;
   pRenderData->m_uiShadowDataOffset = m_bCastShadows ? ezShadowPool::AddPointLight(this, fScreenSpaceSize, msg.m_pView) : ezInvalidIndex;

--- a/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
@@ -158,16 +158,7 @@ void ezSpotLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   auto pRenderData = ezCreateRenderDataForThisFrame<ezSpotLightRenderData>(GetOwner());
 
   pRenderData->m_GlobalTransform = t;
-
-  if (m_bUseColorTemperature)
-  {
-    pRenderData->m_LightColor.SetKelvin(m_uTemperature);
-  }
-  else
-  {
-    pRenderData->m_LightColor = m_LightColor;
-  }
-
+  pRenderData->m_LightColor = GetLightColor();
   pRenderData->m_fIntensity = m_fIntensity;
   pRenderData->m_fSpecularMultiplier = m_fSpecularMultiplier;
   pRenderData->m_fRange = m_fEffectiveRange;

--- a/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
@@ -158,8 +158,18 @@ void ezSpotLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   auto pRenderData = ezCreateRenderDataForThisFrame<ezSpotLightRenderData>(GetOwner());
 
   pRenderData->m_GlobalTransform = t;
-  pRenderData->m_LightColor = m_LightColor;
+
+  if (m_bUseColorTemperature)
+  {
+    pRenderData->m_LightColor.SetKelvin(m_uTemperature);
+  }
+  else
+  {
+    pRenderData->m_LightColor = m_LightColor;
+  }
+
   pRenderData->m_fIntensity = m_fIntensity;
+  pRenderData->m_fSpecularMultiplier = m_fSpecularMultiplier;
   pRenderData->m_fRange = m_fEffectiveRange;
   pRenderData->m_InnerSpotAngle = m_InnerSpotAngle;
   pRenderData->m_OuterSpotAngle = m_OuterSpotAngle;

--- a/Code/Engine/RendererCore/Lights/LightComponent.h
+++ b/Code/Engine/RendererCore/Lights/LightComponent.h
@@ -15,6 +15,7 @@ public:
 
   ezColor m_LightColor;
   float m_fIntensity;
+  float m_fSpecularMultiplier;
   ezUInt32 m_uiShadowDataOffset;
 };
 
@@ -37,12 +38,23 @@ public:
   ezLightComponent();
   ~ezLightComponent();
 
+  void SetUsingColorTemperature(bool bUseColorTemperature);
+  bool GetUsingColorTemperature() const;
+
   void SetLightColor(ezColorGammaUB lightColor); // [ property ]
   ezColorGammaUB GetLightColor() const;          // [ property ]
+
+  ezColorGammaUB GetFinalLightColor() const;
+
+  void SetTemperature(ezUInt32 uTemperature); // [ property ]
+  ezUInt32 GetTemperature() const;            // [ property ]
 
   /// \brief Sets the brightness of the lightsource.
   void SetIntensity(float fIntensity); // [ property ]
   float GetIntensity() const;          // [ property ]
+
+  void SetSpecularMultiplier(float fSpecularMultiplier); // [ property ]
+  float GetSpecularMultiplier() const;                   // [ property ]
 
   /// \brief Sets whether the lightsource shall cast dynamic shadows.
   void SetCastShadows(bool bCastShadows); // [ property ]
@@ -72,8 +84,11 @@ public:
   static float CalculateScreenSpaceSize(const ezBoundingSphere& sphere, const ezCamera& camera);
 
 protected:
+  bool m_bUseColorTemperature = false;
   ezColorGammaUB m_LightColor = ezColor::White;
+  ezUInt32 m_uTemperature = 6550;
   float m_fIntensity = 10.0f;
+  float m_fSpecularMultiplier = 1.0f;
   float m_fPenumbraSize = 0.1f;
   float m_fSlopeBias = 0.25f;
   float m_fConstantBias = 0.1f;

--- a/Code/Engine/RendererCore/Lights/LightComponent.h
+++ b/Code/Engine/RendererCore/Lights/LightComponent.h
@@ -86,7 +86,6 @@ public:
   static float CalculateScreenSpaceSize(const ezBoundingSphere& sphere, const ezCamera& camera);
 
 protected:
-  bool m_bUseColorTemperature = false;
   ezColorGammaUB m_LightColor = ezColor::White;
   ezUInt32 m_uiTemperature = 6550;
   float m_fIntensity = 10.0f;
@@ -95,4 +94,5 @@ protected:
   float m_fSlopeBias = 0.25f;
   float m_fConstantBias = 0.1f;
   bool m_bCastShadows = false;
+  bool m_bUseColorTemperature = false;
 };

--- a/Code/Engine/RendererCore/Lights/LightComponent.h
+++ b/Code/Engine/RendererCore/Lights/LightComponent.h
@@ -38,15 +38,17 @@ public:
   ezLightComponent();
   ~ezLightComponent();
 
+  /// \brief Used to enable kelvin color values. This is a physical representation of light color using.
+  /// for more detail: https://wikipedia.org/wiki/Color_temperature
   void SetUsingColorTemperature(bool bUseColorTemperature);
   bool GetUsingColorTemperature() const;
 
   void SetLightColor(ezColorGammaUB lightColor); // [ property ]
-  ezColorGammaUB GetLightColor() const;          // [ property ]
+  ezColorGammaUB GetBaseLightColor() const;          // [ property ]
 
-  ezColorGammaUB GetFinalLightColor() const;
+  ezColorGammaUB GetLightColor() const;
 
-  void SetTemperature(ezUInt32 uTemperature); // [ property ]
+  void SetTemperature(ezUInt32 uiTemperature); // [ property ]
   ezUInt32 GetTemperature() const;            // [ property ]
 
   /// \brief Sets the brightness of the lightsource.
@@ -86,7 +88,7 @@ public:
 protected:
   bool m_bUseColorTemperature = false;
   ezColorGammaUB m_LightColor = ezColor::White;
-  ezUInt32 m_uTemperature = 6550;
+  ezUInt32 m_uiTemperature = 6550;
   float m_fIntensity = 10.0f;
   float m_fSpecularMultiplier = 1.0f;
   float m_fPenumbraSize = 0.1f;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Light/ParticleTypeLight.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Light/ParticleTypeLight.cpp
@@ -177,6 +177,7 @@ void ezParticleTypeLight::ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg,
     pRenderData->m_GlobalTransform.m_vPosition = transform * pPosition[i].GetAsVec3();
     pRenderData->m_LightColor = tintColor * pColor[i].ToLinearFloat();
     pRenderData->m_fIntensity = intensity;
+    pRenderData->m_fSpecularMultiplier = 1.0f;
     pRenderData->m_fRange = pSize[i] * sizeFactor;
     pRenderData->m_uiShadowDataOffset = ezInvalidIndex;
 

--- a/Data/Base/Shaders/Common/BRDF.h
+++ b/Data/Base/Shaders/Common/BRDF.h
@@ -32,6 +32,12 @@ void AccumulateLight(inout AccumulatedLight result, AccumulatedLight light, floa
   result.specularLight += light.specularLight * color;
 }
 
+void AccumulateLight(inout AccumulatedLight result, AccumulatedLight light, float3 color, float specularMultiplier)
+{
+  result.diffuseLight += light.diffuseLight * color;
+  result.specularLight += (light.specularLight * color) * specularMultiplier;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////
 
 float RoughnessFromMipLevel(uint mipLevel, uint mipCount)

--- a/Data/Base/Shaders/Common/LightData.h
+++ b/Data/Base/Shaders/Common/LightData.h
@@ -26,8 +26,7 @@ struct EZ_SHADER_STRUCT ezPerLightData
   UINT1(spotParams); // scale and offset as 16 bit floats
   UINT1(projectorAtlasOffset); // xy as 16 bit floats
   UINT1(projectorAtlasScale); // xy as 16 bit floats
-
-  UINT1(reserved);
+  FLOAT1(specularMultiplier);
 };
 
 #if EZ_ENABLED(PLATFORM_SHADER)

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -533,6 +533,8 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
       #if defined(USE_MATERIAL_SUBSURFACE_COLOR)
         AccumulateLight(totalLight, SubsurfaceShading(matData, lightVector, viewVector), lightColor * (attenuation * subsurfaceShadow));        
       #endif
+
+      totalLight.specularLight *= lightData.specularMultiplier;
     }
   }
   

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -528,13 +528,11 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
         lightColor = lerp(1.0f, debugColor, 0.5f);
       #endif
 
-      AccumulateLight(totalLight, DefaultShading(matData, lightVector, viewVector), lightColor * (attenuation * shadowTerm));
+      AccumulateLight(totalLight, DefaultShading(matData, lightVector, viewVector), lightColor * (attenuation * shadowTerm), lightData.specularMultiplier);
 
       #if defined(USE_MATERIAL_SUBSURFACE_COLOR)
         AccumulateLight(totalLight, SubsurfaceShading(matData, lightVector, viewVector), lightColor * (attenuation * subsurfaceShadow));        
       #endif
-
-      totalLight.specularLight *= lightData.specularMultiplier;
     }
   }
   


### PR DESCRIPTION
This consists of 2 major changes and a few supporting improvements.

First and smallest change is the addition of a specular multiplier control. This allows people to have diffuse only lights. Can be very useful when adding fake light to an area such as boosting the light through a window. 

Second and most important feature is the addition of kelvin temperature for lights.
This includes a new ezSliderAttribute that allows for single item sliders of any min and max. In future it would be good to skin the slider with an image in this case a gradient of the temperature.
![image](https://github.com/ezEngine/ezEngine/assets/3044415/25c7686b-34a8-42ab-bf03-25089346c692)

![Property](https://github.com/ezEngine/ezEngine/assets/3044415/19bec27a-b547-4e36-8c91-545c95c09b03)