### PR TITLE
Implement ez_enable_strict_warnings cmake function for clang

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -334,12 +334,16 @@ endfunction()
 # ## ez_enable_strict_warnings(<target>)
 # #####################################
 function(ez_enable_strict_warnings TARGET_NAME)
-	if(MSVC)
+	if(EZ_CMAKE_COMPILER_MSVC)
 		# In case there is W3 already, remove it so it doesn't spam warnings when using Ninja builds.
 		get_target_property(TARGET_COMPILE_OPTS ${PROJECT_NAME} COMPILE_OPTIONS)
 		list(REMOVE_ITEM TARGET_COMPILE_OPTS /W3)
 		set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_OPTIONS "${TARGET_COMPILE_OPTS}")
 		
 		target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX)
+	endif()
+
+	if(EZ_CMAKE_COMPILER_CLANG)
+		target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall)
 	endif()
 endfunction()

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -344,6 +344,6 @@ function(ez_enable_strict_warnings TARGET_NAME)
 	endif()
 
 	if(EZ_CMAKE_COMPILER_CLANG)
-		target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall)
+		target_compile_options(${PROJECT_NAME} PRIVATE -Werror -Wall -Wlogical-op-parentheses)
 	endif()
 endfunction()

--- a/Code/Engine/Core/Scripting/Duktape/DuktapeContext.cpp
+++ b/Code/Engine/Core/Scripting/Duktape/DuktapeContext.cpp
@@ -56,6 +56,7 @@ void ezDuktapeContext::DestroyContext()
   m_pContext = nullptr;
 
   const auto stats = m_Allocator.GetStats();
+  EZ_IGNORE_UNUSED(stats);
   EZ_ASSERT_DEBUG(stats.m_uiAllocationSize == 0, "Duktape did not free all data");
   EZ_ASSERT_DEBUG(stats.m_uiNumAllocations == stats.m_uiNumDeallocations, "Duktape did not free all data");
 }

--- a/Code/Engine/Core/Scripting/Implementation/ScriptWorldModule.cpp
+++ b/Code/Engine/Core/Scripting/Implementation/ScriptWorldModule.cpp
@@ -102,7 +102,7 @@ void ezScriptWorldModule::StartCoroutine(ezScriptCoroutineHandle hCoroutine, ezA
   ezUniquePtr<ezScriptCoroutine>* pCoroutine = nullptr;
   if (m_RunningScriptCoroutines.TryGetValue(hCoroutine.GetInternalID(), pCoroutine))
   {
-    (*pCoroutine)->Start(arguments);
+    (*pCoroutine)->StartWithVarargs(arguments);
     (*pCoroutine)->UpdateAndSchedule();
   }
 }

--- a/Code/Engine/Core/Scripting/ScriptCoroutine.h
+++ b/Code/Engine/Core/Scripting/ScriptCoroutine.h
@@ -104,7 +104,6 @@ private:
     static_cast<Derived*>(this)->Start(ezVariantAdapter<typename getArgument<I, Args...>::Type>(arguments[I])...);
   }
 
-protected:
   virtual void StartWithVarargs(ezArrayPtr<ezVariant> arguments) override
   {
     StartImpl(arguments, std::make_index_sequence<sizeof...(Args)>{});

--- a/Code/Engine/Core/Scripting/ScriptCoroutine.h
+++ b/Code/Engine/Core/Scripting/ScriptCoroutine.h
@@ -72,7 +72,7 @@ public:
     ezTime m_MaxDelay = ezTime::MakeZero();
   };
 
-  virtual void Start(ezArrayPtr<ezVariant> arguments) = 0;
+  virtual void StartWithVarargs(ezArrayPtr<ezVariant> arguments) = 0;
   virtual void Stop() {}
   virtual Result Update(ezTime deltaTimeSinceLastUpdate) = 0;
 
@@ -104,7 +104,8 @@ private:
     static_cast<Derived*>(this)->Start(ezVariantAdapter<typename getArgument<I, Args...>::Type>(arguments[I])...);
   }
 
-  virtual void Start(ezArrayPtr<ezVariant> arguments) override
+protected:
+  virtual void StartWithVarargs(ezArrayPtr<ezVariant> arguments) override
   {
     StartImpl(arguments, std::make_index_sequence<sizeof...(Args)>{});
   }

--- a/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
+++ b/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
@@ -604,11 +604,6 @@ void ezStandardInputDevice::WindowMessage(
 
         bWasStupidLeftShift = false;
 
-        int iRequest = raw->data.keyboard.MakeCode << 16;
-
-        if (raw->data.keyboard.Flags & RI_KEY_E0)
-          iRequest |= 1 << 24;
-
         const bool bPressed = !(raw->data.keyboard.Flags & 0x01);
 
         m_InputSlotValues[sInputSlotName] = bPressed ? 1.0f : 0.0f;
@@ -693,7 +688,6 @@ void ezStandardInputDevice::WindowMessage(
           else
           {
             static int iTouchPoint = 0;
-            static bool bTouchPointDown = false;
 
             ezStringView sSlot = ezInputManager::GetInputSlotTouchPoint(iTouchPoint);
             ezStringView sSlotX = ezInputManager::GetInputSlotTouchPointPositionX(iTouchPoint);
@@ -704,13 +698,11 @@ void ezStandardInputDevice::WindowMessage(
 
             if ((uiButtons & (RI_MOUSE_BUTTON_1_DOWN | RI_MOUSE_BUTTON_2_DOWN)) != 0)
             {
-              bTouchPointDown = true;
               m_InputSlotValues[sSlot] = 1.0f;
             }
 
             if ((uiButtons & (RI_MOUSE_BUTTON_1_UP | RI_MOUSE_BUTTON_2_UP)) != 0)
             {
-              bTouchPointDown = false;
               m_InputSlotValues[sSlot] = 0.0f;
             }
           }

--- a/Code/Engine/Core/World/Implementation/SpatialSystem_RegularGrid.cpp
+++ b/Code/Engine/Core/World/Implementation/SpatialSystem_RegularGrid.cpp
@@ -60,11 +60,6 @@ namespace
     return ezSimdBBox(bmin, bmax);
   }
 
-  EZ_ALWAYS_INLINE bool FilterByCategory(ezUInt32 uiCategoryBitmask, ezUInt32 uiQueryBitmask)
-  {
-    return (uiCategoryBitmask & uiQueryBitmask) == 0;
-  }
-
   EZ_ALWAYS_INLINE bool FilterByTags(const ezTagSet& tags, const ezTagSet* pIncludeTags, const ezTagSet* pExcludeTags)
   {
     if (pExcludeTags && !pExcludeTags->IsEmpty() && pExcludeTags->IsAnySet(tags))
@@ -81,6 +76,8 @@ namespace
     return ezSpatialData::GetCategoryFlags(category).IsSet(ezSpatialData::Flags::FrequentChanges) == false;
   }
 
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   void TagsToString(const ezTagSet& tags, ezStringBuilder& out_sSb)
   {
     out_sSb.Append("{ ");
@@ -98,6 +95,7 @@ namespace
 
     out_sSb.Append(" }");
   }
+#endif
 
   EZ_FORCE_INLINE bool SphereFrustumIntersect(const ezSimdBSphere& sphere, const PlaneData& planeData)
   {
@@ -602,11 +600,11 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezSpatialSystem_RegularGrid::ezSpatialSystem_RegularGrid(ezUInt32 uiCellSize /*= 128*/)
   : m_AlignedAllocator("Spatial System Aligned", ezFoundation::GetAlignedAllocator())
-  , m_Grids(&m_Allocator)
-  , m_DataTable(&m_Allocator)
   , m_vCellSize(uiCellSize)
   , m_vOverlapSize(uiCellSize / 4.0f)
   , m_fInvCellSize(1.0f / uiCellSize)
+  , m_Grids(&m_Allocator)
+  , m_DataTable(&m_Allocator)
 {
   EZ_CHECK_AT_COMPILETIME(sizeof(Data) == 8);
 

--- a/Code/Engine/Core/World/Implementation/SpatialSystem_RegularGrid.cpp
+++ b/Code/Engine/Core/World/Implementation/SpatialSystem_RegularGrid.cpp
@@ -1042,8 +1042,8 @@ void ezSpatialSystem_RegularGrid::ForEachCellInBoxInMatchingGrids(const ezSimdBB
       continue;
 
     if ((pGrid->m_Category.GetBitmask() & uiGridBitmask) == 0 ||
-        (queryParams.m_pIncludeTags && pGrid->m_IncludeTags != *queryParams.m_pIncludeTags || !queryParams.m_pIncludeTags && !pGrid->m_IncludeTags.IsEmpty()) ||
-        (queryParams.m_pExcludeTags && pGrid->m_ExcludeTags != *queryParams.m_pExcludeTags || !queryParams.m_pExcludeTags && !pGrid->m_ExcludeTags.IsEmpty()))
+        ((queryParams.m_pIncludeTags && pGrid->m_IncludeTags != *queryParams.m_pIncludeTags) || (!queryParams.m_pIncludeTags && !pGrid->m_IncludeTags.IsEmpty())) ||
+        ((queryParams.m_pExcludeTags && pGrid->m_ExcludeTags != *queryParams.m_pExcludeTags) || (!queryParams.m_pExcludeTags && !pGrid->m_ExcludeTags.IsEmpty())))
       continue;
 
     uiGridBitmask &= ~pGrid->m_Category.GetBitmask();
@@ -1066,7 +1066,7 @@ void ezSpatialSystem_RegularGrid::ForEachCellInBoxInMatchingGrids(const ezSimdBB
   }
 
   // then search for the rest
-  const bool useTagsFilter = queryParams.m_pIncludeTags && queryParams.m_pIncludeTags->IsEmpty() == false || queryParams.m_pExcludeTags && queryParams.m_pExcludeTags->IsEmpty() == false;
+  const bool useTagsFilter = (queryParams.m_pIncludeTags && queryParams.m_pIncludeTags->IsEmpty() == false) || (queryParams.m_pExcludeTags && queryParams.m_pExcludeTags->IsEmpty() == false);
   CellCallback cellCallback = useTagsFilter ? filterByTagsCallback : noFilterCallback;
 
   while (uiGridBitmask > 0)
@@ -1211,8 +1211,8 @@ void ezSpatialSystem_RegularGrid::UpdateCacheCandidate(const ezTagSet* pIncludeT
   for (auto& cacheCandidate : m_CacheCandidates)
   {
     if (cacheCandidate.m_Category == category &&
-        (pIncludeTags && cacheCandidate.m_IncludeTags == *pIncludeTags || !pIncludeTags && cacheCandidate.m_IncludeTags.IsEmpty()) &&
-        (pExcludeTags && cacheCandidate.m_ExcludeTags == *pExcludeTags || !pExcludeTags && cacheCandidate.m_ExcludeTags.IsEmpty()))
+        ((pIncludeTags && cacheCandidate.m_IncludeTags == *pIncludeTags) || (!pIncludeTags && cacheCandidate.m_IncludeTags.IsEmpty())) &&
+        ((pExcludeTags && cacheCandidate.m_ExcludeTags == *pExcludeTags) || (!pExcludeTags && cacheCandidate.m_ExcludeTags.IsEmpty())))
     {
       pCacheCandiate = &cacheCandidate;
       break;

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -317,6 +317,7 @@ ezComponentInitBatchHandle ezWorld::CreateComponentInitBatch(ezStringView sBatch
 void ezWorld::DeleteComponentInitBatch(const ezComponentInitBatchHandle& hBatch)
 {
   auto& pInitBatch = m_Data.m_InitBatches[hBatch.GetInternalID()];
+  EZ_IGNORE_UNUSED(pInitBatch);
   EZ_ASSERT_DEV(pInitBatch->m_ComponentsToInitialize.IsEmpty() && pInitBatch->m_ComponentsToStartSimulation.IsEmpty(), "Init batch has not been completely processed");
   m_Data.m_InitBatches.Remove(hBatch.GetInternalID());
 }

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -703,8 +703,6 @@ bool ezWorldReader::InstantiationContext::AddComponentsToBatch(ezTime endTime)
 {
   EZ_PROFILE_SCOPE("ezWorldReader::AddComponentsToBatch");
 
-  ezUInt32 uiInitializedComponents = 0;
-
   if (!m_hComponentInitBatch.IsInvalidated())
   {
     m_WorldReader.m_pWorld->BeginAddingComponentsToInitBatch(m_hComponentInitBatch);
@@ -722,7 +720,6 @@ bool ezWorldReader::InstantiationContext::AddComponentsToBatch(ezTime endTime)
       if (m_WorldReader.m_pWorld->TryGetComponent(compTypeInfo.m_ComponentIndexToHandle[m_uiCurrentIndex++], pComponent))
       {
         pComponent->GetOwningManager()->InitializeComponent(pComponent);
-        ++uiInitializedComponents;
 
         ++m_uiCurrentNumComponentsProcessed;
 

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -665,8 +665,6 @@ bool ezWorldReader::InstantiationContext::DeserializeComponents(ezTime endTime)
 {
   EZ_PROFILE_SCOPE("ezWorldReader::DeserializeComponents");
 
-  ezStreamReader& s = *m_WorldReader.m_pStream;
-
   for (; m_uiCurrentComponentTypeIndex < m_WorldReader.m_ComponentTypes.GetCount(); ++m_uiCurrentComponentTypeIndex)
   {
     auto& compTypeInfo = m_WorldReader.m_ComponentTypes[m_uiCurrentComponentTypeIndex];

--- a/Code/Engine/Foundation/Algorithm/Implementation/HashStream.cpp
+++ b/Code/Engine/Foundation/Algorithm/Implementation/HashStream.cpp
@@ -2,8 +2,13 @@
 
 #include <Foundation/Algorithm/HashStream.h>
 
+EZ_WARNING_PUSH()
+EZ_WARNING_DISABLE_CLANG("-Wunused-function")
+
 #define XXH_INLINE_ALL
 #include <Foundation/ThirdParty/xxHash/xxhash.h>
+
+EZ_WARNING_POP()
 
 ezHashStreamWriter32::ezHashStreamWriter32(ezUInt32 uiSeed)
 {

--- a/Code/Engine/Foundation/Algorithm/Implementation/HashingUtils.cpp
+++ b/Code/Engine/Foundation/Algorithm/Implementation/HashingUtils.cpp
@@ -197,8 +197,13 @@ ezUInt32 ezHashingUtils::CRC32Hash(const void* pKey, size_t uiSizeInBytes)
   return static_cast<ezUInt32>(uiCRC32 ^ 0xFFFFFFFF);
 }
 
+EZ_WARNING_PUSH()
+EZ_WARNING_DISABLE_CLANG("-Wunused-function")
+
 #define XXH_INLINE_ALL
 #include <Foundation/ThirdParty/xxHash/xxhash.h>
+
+EZ_WARNING_POP()
 
 // static
 ezUInt32 ezHashingUtils::xxHash32(const void* pKey, size_t uiSizeInByte, ezUInt32 uiSeed /*= 0*/)

--- a/Code/Engine/Foundation/CMakeLists.txt
+++ b/Code/Engine/Foundation/CMakeLists.txt
@@ -15,6 +15,10 @@ endif()
 
 ez_enable_strict_warnings(${PROJECT_NAME})
 
+if (EZ_CMAKE_COMPILER_CLANG)
+  set_source_files_properties(ThirdParty/xxHash/xxHash.c PROPERTIES COMPILE_FLAGS "-Wno-unused-function")
+endif()
+
 if (EZ_CMAKE_PLATFORM_LINUX)
   CHECK_INCLUDE_FILE_CXX("uuid/uuid.h" UUID_HEADER)
   if (NOT UUID_HEADER)

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionAST.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionAST.cpp
@@ -509,6 +509,7 @@ ezExpressionAST::TernaryOperator* ezExpressionAST::CreateTernaryOperator(NodeTyp
 ezExpressionAST::Constant* ezExpressionAST::CreateConstant(const ezVariant& value, DataType::Enum dataType /*= DataType::Float*/)
 {
   ezVariantType::Enum variantType = DataType::GetVariantType(dataType);
+  EZ_IGNORE_UNUSED(variantType);
   EZ_ASSERT_DEV(variantType != ezVariantType::Invalid, "Invalid constant type '{}'", DataType::GetName(dataType));
 
   auto pConstant = EZ_NEW(&m_Allocator, Constant);

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionVMOperations.h
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionVMOperations.h
@@ -22,13 +22,15 @@ namespace
 
 #define DEFINE_TARGET_REGISTER()                                                                                                        \
   ezExpression::Register* r = context.m_pRegisters + ezExpressionByteCode::GetRegisterIndex(pByteCode) * context.m_uiNumSimd4Instances; \
-  ezExpression::Register* re = r + context.m_uiNumSimd4Instances;
+  ezExpression::Register* re = r + context.m_uiNumSimd4Instances;                                                                       \
+  EZ_IGNORE_UNUSED(re);
 
 #define DEFINE_OP_REGISTER(name) \
   const ezExpression::Register* name = context.m_pRegisters + ezExpressionByteCode::GetRegisterIndex(pByteCode) * context.m_uiNumSimd4Instances;
 
 #define DEFINE_CONSTANT(name)                                                      \
   const ezUInt32 EZ_CONCAT(name, Raw) = *pByteCode;                                \
+  EZ_IGNORE_UNUSED(EZ_CONCAT(name, Raw));                                          \
   const ezExpression::Register tmp = ezExpressionByteCode::GetConstant(pByteCode); \
   const ezExpression::Register* name = &tmp;
 
@@ -37,28 +39,15 @@ namespace
   ++r;                            \
   ++a;
 
-#define DEFINE_UNARY_OP(name, code)                                                    \
-  void EZ_CONCAT(name, _4)(const ByteCodeType*& pByteCode, ExecutionContext& context)  \
-  {                                                                                    \
-    DEFINE_TARGET_REGISTER();                                                          \
-    DEFINE_OP_REGISTER(a);                                                             \
-    while (r != re)                                                                    \
-    {                                                                                  \
-      UNARY_OP_INNER_LOOP(code)                                                        \
-    }                                                                                  \
-  }                                                                                    \
-                                                                                       \
-  void EZ_CONCAT(name, _16)(const ByteCodeType*& pByteCode, ExecutionContext& context) \
-  {                                                                                    \
-    DEFINE_TARGET_REGISTER();                                                          \
-    DEFINE_OP_REGISTER(a);                                                             \
-    while (r != re)                                                                    \
-    {                                                                                  \
-      UNARY_OP_INNER_LOOP(code)                                                        \
-      UNARY_OP_INNER_LOOP(code)                                                        \
-      UNARY_OP_INNER_LOOP(code)                                                        \
-      UNARY_OP_INNER_LOOP(code)                                                        \
-    }                                                                                  \
+#define DEFINE_UNARY_OP(name, code)                                                   \
+  void EZ_CONCAT(name, _4)(const ByteCodeType*& pByteCode, ExecutionContext& context) \
+  {                                                                                   \
+    DEFINE_TARGET_REGISTER();                                                         \
+    DEFINE_OP_REGISTER(a);                                                            \
+    while (r != re)                                                                   \
+    {                                                                                 \
+      UNARY_OP_INNER_LOOP(code)                                                       \
+    }                                                                                 \
   }
 
 #define BINARY_OP_INNER_LOOP(code)        \

--- a/Code/Engine/Foundation/IO/Archive/Implementation/ArchiveUtils.cpp
+++ b/Code/Engine/Foundation/IO/Archive/Implementation/ArchiveUtils.cpp
@@ -442,6 +442,7 @@ namespace ZipFormat
     inout_stream >> ref_value.signature >> ref_value.version >> ref_value.versionNeeded >> ref_value.flags >> ref_value.compression >> ref_value.modTime >> ref_value.modDate;
     inout_stream >> ref_value.crc32 >> ref_value.compressedSize >> ref_value.uncompressedSize >> ref_value.fileNameLength >> ref_value.extraFieldLength;
     inout_stream >> ref_value.fileCommentLength >> ref_value.diskNumStart >> ref_value.internalAttr >> ref_value.externalAttr >> ref_value.offsetLocalHeader;
+    EZ_IGNORE_UNUSED(CDFileMagicSignature);
     EZ_ASSERT_DEBUG(ref_value.signature == CDFileMagicSignature, "ZIP: Corrupt central directory file entry header.");
     return inout_stream;
   }

--- a/Code/Engine/Foundation/IO/Implementation/CompressedStreamZstd.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/CompressedStreamZstd.cpp
@@ -78,6 +78,7 @@ ezUInt64 ezCompressedStreamReaderZstd::ReadBytes(void* pReadBuffer, ezUInt64 uiB
       return outBuffer.pos;
 
     const size_t res = ZSTD_decompressStream(reinterpret_cast<ZSTD_DStream*>(m_pZstdDStream), &outBuffer, reinterpret_cast<ZSTD_inBuffer*>(&m_InBuffer));
+    EZ_IGNORE_UNUSED(res);
     EZ_ASSERT_DEV(!ZSTD_isError(res), "Decompressing the stream failed: '{0}'", ZSTD_getErrorName(res));
   }
 

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyGuarding.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyGuarding.h
@@ -19,7 +19,5 @@ public:
 private:
   ezMutex m_Mutex;
 
-  ezUInt32 m_uiPageSize;
-
   ezStaticRingBuffer<void*, (1 << 16)> m_AllocationsToFreeLater;
 };

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyGuarding.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyGuarding.h
@@ -19,5 +19,7 @@ public:
 private:
   ezMutex m_Mutex;
 
+  ezUInt32 m_uiPageSize;
+
   ezStaticRingBuffer<void*, (1 << 16)> m_AllocationsToFreeLater;
 };

--- a/Code/Engine/Foundation/Platform/Android/StackTracer_Android.cpp
+++ b/Code/Engine/Foundation/Platform/Android/StackTracer_Android.cpp
@@ -36,6 +36,7 @@ ezUInt32 ezStackTracer::GetStackTrace(ezArrayPtr<void*>& trace, void* pContext)
   Backtrace backtrace;
   backtrace.trace = trace;
   _Unwind_Reason_Code res = _Unwind_Backtrace(BacktraceCallback, &backtrace);
+  EZ_IGNORE_UNUSED(res);
   return backtrace.uiPos;
 }
 

--- a/Code/Engine/Foundation/Platform/Linux/MessageLoop_Linux.cpp
+++ b/Code/Engine/Foundation/Platform/Linux/MessageLoop_Linux.cpp
@@ -55,7 +55,7 @@ bool ezMessageLoop_linux::WaitForMessages(ezInt32 iTimeout, ezIpcChannel* pFilte
     if (m_pollInfos[0].revents != 0)
     {
       ezUInt8 wakeupByte;
-      auto readResult = read(m_wakeupPipeReadEndFd, &wakeupByte, sizeof(wakeupByte));
+      read(m_wakeupPipeReadEndFd, &wakeupByte, sizeof(wakeupByte));
       m_pollInfos[0].revents = 0;
       return true;
     }
@@ -154,7 +154,7 @@ void ezMessageLoop_linux::RemovePendingWaits(ezPipeChannel_linux* pChannel)
 void ezMessageLoop_linux::WakeUp()
 {
   ezUInt8 wakeupByte = 0;
-  int writeResult = write(m_wakeupPipeWriteEndFd, &wakeupByte, sizeof(wakeupByte));
+  write(m_wakeupPipeWriteEndFd, &wakeupByte, sizeof(wakeupByte));
 }
 
 #endif

--- a/Code/Engine/Foundation/Platform/Linux/MessageLoop_Linux.cpp
+++ b/Code/Engine/Foundation/Platform/Linux/MessageLoop_Linux.cpp
@@ -55,7 +55,9 @@ bool ezMessageLoop_linux::WaitForMessages(ezInt32 iTimeout, ezIpcChannel* pFilte
     if (m_pollInfos[0].revents != 0)
     {
       ezUInt8 wakeupByte;
-      read(m_wakeupPipeReadEndFd, &wakeupByte, sizeof(wakeupByte));
+      auto readResult = read(m_wakeupPipeReadEndFd, &wakeupByte, sizeof(wakeupByte));
+      EZ_IGNORE_UNUSED(readResult);
+      EZ_ASSERT_DEV(readResult == sizeof(wakeupByte), "Wakeup byte not read");
       m_pollInfos[0].revents = 0;
       return true;
     }
@@ -154,7 +156,9 @@ void ezMessageLoop_linux::RemovePendingWaits(ezPipeChannel_linux* pChannel)
 void ezMessageLoop_linux::WakeUp()
 {
   ezUInt8 wakeupByte = 0;
-  write(m_wakeupPipeWriteEndFd, &wakeupByte, sizeof(wakeupByte));
+  int writeResult = write(m_wakeupPipeWriteEndFd, &wakeupByte, sizeof(wakeupByte));
+  EZ_IGNORE_UNUSED(writeResult);
+  EZ_ASSERT_DEV(writeResult == sizeof(wakeupByte), "Wakeup byte not written");
 }
 
 #endif

--- a/Code/Engine/Foundation/Platform/Linux/PipeChannel_Linux.cpp
+++ b/Code/Engine/Foundation/Platform/Linux/PipeChannel_Linux.cpp
@@ -122,7 +122,7 @@ void ezPipeChannel_linux::InternalConnect()
     serverAddress.sun_family = AF_UNIX;
     strcpy(serverAddress.sun_path, m_serverSocketPath.GetData());
 
-    int connectResult = connect(m_clientSocketFd, (struct sockaddr*)&serverAddress, SUN_LEN(&serverAddress));
+    connect(m_clientSocketFd, (struct sockaddr*)&serverAddress, SUN_LEN(&serverAddress));
 
     static_cast<ezMessageLoop_linux*>(m_pOwner)->RegisterWait(this, ezMessageLoop_linux::WaitType::Connect, m_clientSocketFd);
   }

--- a/Code/Engine/Foundation/Platform/NoImpl/GuardedAllocation_NoImpl.h
+++ b/Code/Engine/Foundation/Platform/NoImpl/GuardedAllocation_NoImpl.h
@@ -3,6 +3,9 @@
 ezAllocPolicyGuarding::ezAllocPolicyGuarding(ezAllocator* pParent)
 {
   EZ_ASSERT_NOT_IMPLEMENTED;
+  EZ_IGNORE_UNUSED(m_uiPageSize);
+  EZ_IGNORE_UNUSED(m_Mutex);
+  EZ_IGNORE_UNUSED(m_AllocationsToFreeLater);
 }
 
 void* ezAllocPolicyGuarding::Allocate(size_t uiSize, size_t uiAlign)

--- a/Code/Engine/Foundation/Platform/OSX/SystemInformation_OSX.cpp
+++ b/Code/Engine/Foundation/Platform/OSX/SystemInformation_OSX.cpp
@@ -35,6 +35,7 @@ bool ezSystemInformation::IsDebuggerAttached()
   // Call sysctl.
   size = sizeof(info);
   junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+  EZ_IGNORE_UNUSED(junk);
   assert(junk == 0);
 
   // We're being debugged if the P_TRACED flag is set.

--- a/Code/Engine/Foundation/Platform/Posix/DirectoryWatcher_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/DirectoryWatcher_Posix.h
@@ -197,7 +197,6 @@ ezDirectoryWatcher::ezDirectoryWatcher()
 
 ezDirectoryWatcher::~ezDirectoryWatcher()
 {
-  const int inotifyFd = m_pImpl->m_inotifyFd;
   CloseDirectory();
   EZ_DEFAULT_DELETE(m_pImpl);
 }

--- a/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.h
@@ -458,8 +458,6 @@ ezString ezOSFile::GetUserDocumentsFolder(ezStringView sSubFolder)
   if (s_sUserDocumentsPath.IsEmpty())
   {
 #  if EZ_ENABLED(EZ_PLATFORM_ANDROID)
-    android_app* app = ezAndroidUtils::GetAndroidApp();
-    // s_sUserDataPath = app->activity->internalDataPath;
     EZ_ASSERT_NOT_IMPLEMENTED;
 #  else
     s_sUserDataPath = getenv("HOME");

--- a/Code/Engine/Foundation/Platform/Posix/Semaphore_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/Semaphore_Posix.h
@@ -9,6 +9,10 @@ EZ_FOUNDATION_INTERNAL_HEADER
 #include <semaphore.h>
 #include <sys/stat.h>
 
+EZ_WARNING_PUSH()
+// On OSX sem_destroy and sem_init are deprecated
+EZ_WARNING_DISABLE_CLANG("-Wdeprecated-declarations")
+
 ezSemaphore::ezSemaphore() = default;
 
 ezSemaphore::~ezSemaphore()
@@ -97,3 +101,5 @@ ezResult ezSemaphore::TryAcquireToken()
 
   return EZ_FAILURE;
 }
+
+EZ_WARNING_POP()

--- a/Code/Engine/Foundation/Platform/Win/ProcessGroup_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/ProcessGroup_Win.cpp
@@ -45,7 +45,7 @@ void ezProcessGroupImpl::Initialize()
     // configure the job object such that it kill all processes once this job object is cleaned up
     // ie. either when all job object handles are closed, or the application crashes
 
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION exinfo = {0};
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION exinfo = {};
     exinfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
     if (SetInformationJobObject(m_hJobObject, JobObjectExtendedLimitInformation, &exinfo, sizeof(exinfo)) == FALSE)
     {

--- a/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/RTTI.cpp
@@ -175,6 +175,7 @@ void ezRTTI::VerifyCorrectness() const
         const bool bNewProperty = !Known.Find(pInstance->m_Properties[i]->GetPropertyName()).IsValid();
         Known.Insert(pInstance->m_Properties[i]->GetPropertyName());
 
+        EZ_IGNORE_UNUSED(bNewProperty);
         EZ_ASSERT_DEV(bNewProperty, "{0}: The property with name '{1}' is already defined in type '{2}'.", m_sTypeName,
           pInstance->m_Properties[i]->GetPropertyName(), pInstance->GetTypeName());
       }
@@ -186,6 +187,7 @@ void ezRTTI::VerifyCorrectness() const
   {
     for (const ezAbstractProperty* pFunc : m_Functions)
     {
+      EZ_IGNORE_UNUSED(pFunc);
       EZ_ASSERT_DEV(pFunc->GetCategory() == ezPropertyCategory::Function, "Invalid function property '{}'", pFunc->GetPropertyName());
     }
   }
@@ -418,10 +420,7 @@ void ezRTTI::AssignPlugin(ezStringView sPluginName)
   }
 }
 
-// warning C4505: 'IsValidIdentifierName': unreferenced function with internal linkage has been removed
-// happens in Release builds, because the function is only used in a debug assert
-EZ_WARNING_PUSH()
-EZ_WARNING_DISABLE_MSVC(4505)
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
 
 static bool IsValidIdentifierName(ezStringView sIdentifier)
 {
@@ -455,7 +454,7 @@ static bool IsValidIdentifierName(ezStringView sIdentifier)
   return true;
 }
 
-EZ_WARNING_POP()
+#endif
 
 void ezRTTI::SanityCheckType(ezRTTI* pType)
 {
@@ -482,6 +481,7 @@ void ezRTTI::SanityCheckType(ezRTTI* pType)
     {
       case ezPropertyCategory::Constant:
       {
+        EZ_IGNORE_UNUSED(pSpecificType);
         EZ_ASSERT_DEV(pSpecificType->GetTypeFlags().IsSet(ezTypeFlags::StandardType), "Only standard type constants are supported!");
       }
       break;

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -65,22 +65,6 @@ namespace
 
 #undef CALL_FUNCTOR
 
-  ezVariantType::Enum GetDispatchType(const ezAbstractProperty* pProp)
-  {
-    if (pProp->GetFlags().IsSet(ezPropertyFlags::Pointer))
-    {
-      return ezVariantType::TypedPointer;
-    }
-    else if (pProp->GetFlags().IsSet(ezPropertyFlags::StandardType))
-    {
-      return pProp->GetSpecificType()->GetVariantType();
-    }
-    else
-    {
-      return ezVariantType::TypedObject;
-    }
-  }
-
   struct GetTypeFromVariantTypeFunc
   {
     template <typename T>

--- a/Code/Engine/Foundation/Serialization/RttiConverter.h
+++ b/Code/Engine/Foundation/Serialization/RttiConverter.h
@@ -100,8 +100,6 @@ private:
   ezRttiConverterContext* m_pContext = nullptr;
   ezAbstractObjectGraph* m_pGraph = nullptr;
   FilterFunction m_Filter;
-  bool m_bSerializeReadOnly = false;
-  bool m_bSerializeOwnerPtrs = false;
 };
 
 class EZ_FOUNDATION_DLL ezRttiConverterReader

--- a/Code/Engine/Foundation/Types/Implementation/Variant_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/Variant_inl.h
@@ -526,6 +526,7 @@ T ezVariant::Cast() const
   const ezTypedPointer& ptr = *reinterpret_cast<const ezTypedPointer*>(&m_Data);
 
   const ezRTTI* pType = GetReflectedType();
+  EZ_IGNORE_UNUSED(pType);
   using NonRefPtrT = typename ezTypeTraits<T>::NonConstReferencePointerType;
   if constexpr (!std::is_same<T, void*>::value && !std::is_same<T, const void*>::value)
   {
@@ -547,6 +548,7 @@ template <typename T, typename std::enable_if_t<ezVariantTypeDeduction<T>::class
 const T& ezVariant::Cast() const
 {
   const ezRTTI* pType = GetReflectedType();
+  EZ_IGNORE_UNUSED(pType);
   using NonRefT = typename ezTypeTraits<T>::NonConstReferenceType;
   EZ_ASSERT_DEV(IsDerivedFrom(pType, ezGetStaticRTTI<NonRefT>()), "Object of type '{0}' does not derive from '{}'", GetTypeName(pType), GetTypeName(ezGetStaticRTTI<NonRefT>()));
 

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -19,7 +19,7 @@ struct ID3D11Query;
 
 class ezGALDeviceDX11;
 
-class EZ_RENDERERDX11_DLL ezGALCommandEncoderImplDX11 : public ezGALCommandEncoderCommonPlatformInterface, public ezGALCommandEncoderRenderPlatformInterface, public ezGALCommandEncoderComputePlatformInterface
+class EZ_RENDERERDX11_DLL ezGALCommandEncoderImplDX11 final : public ezGALCommandEncoderCommonPlatformInterface, public ezGALCommandEncoderRenderPlatformInterface, public ezGALCommandEncoderComputePlatformInterface
 {
 public:
   ezGALCommandEncoderImplDX11(ezGALDeviceDX11& ref_deviceDX11);

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -232,7 +232,7 @@ retry:
 
   m_SyncTimeDiff = ezTime::MakeZero();
 
-  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([this, &desc](ezAllocator* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainDX11, desc); }); });
+  ezGALWindowSwapChain::SetFactoryMethod([this](const ezGALWindowSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([&desc](ezAllocator* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSwapChainDX11, desc); }); });
 
   return EZ_SUCCESS;
 }
@@ -738,8 +738,6 @@ void ezGALDeviceDX11::PresentPlatform(const ezGALSwapChain* pSwapChain, bool bVS
 
 void ezGALDeviceDX11::BeginFramePlatform(const ezUInt64 uiRenderFrame)
 {
-  auto& pCommandEncoder = m_pDefaultPass->m_pCommandEncoderImpl;
-
   ezStringBuilder sb;
   sb.SetFormat("Frame {}", uiRenderFrame);
 
@@ -771,8 +769,6 @@ void ezGALDeviceDX11::BeginFramePlatform(const ezUInt64 uiRenderFrame)
 
 void ezGALDeviceDX11::EndFramePlatform()
 {
-  auto& pCommandEncoder = m_pDefaultPass->m_pCommandEncoderImpl;
-
 #if EZ_ENABLED(EZ_USE_PROFILING)
   ezProfilingScopeAndMarker::Stop(m_pDefaultPass->m_pRenderCommandEncoder.Borrow(), m_pFrameTimingScope);
 #endif

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderState.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderState.h
@@ -22,7 +22,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderState
   ezGALSamplerStateHandle m_hSamplerStates[ezGALShaderStage::ENUM_COUNT][EZ_GAL_MAX_SAMPLER_COUNT];
 };
 
-struct EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderRenderState : public ezGALCommandEncoderState
+struct EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderRenderState final : public ezGALCommandEncoderState
 {
   virtual void InvalidateState() override;
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -280,7 +280,9 @@ void ezGALCommandEncoder::CopyBufferRegion(
     const ezUInt32 uiDestSize = pDest->GetSize();
     const ezUInt32 uiSourceSize = pSource->GetSize();
 
+    EZ_IGNORE_UNUSED(uiDestSize);
     EZ_ASSERT_DEV(uiDestSize >= uiDestOffset + uiByteCount, "Destination buffer too small (or offset too big)");
+    EZ_IGNORE_UNUSED(uiSourceSize);
     EZ_ASSERT_DEV(uiSourceSize >= uiSourceOffset + uiByteCount, "Source buffer too small (or offset too big)");
 
     m_CommonImpl.CopyBufferRegionPlatform(pDest, uiDestOffset, pSource, uiSourceOffset, uiByteCount);
@@ -424,6 +426,7 @@ void ezGALCommandEncoder::GenerateMipMaps(ezGALResourceViewHandle hResourceView)
   {
     EZ_ASSERT_DEV(!pResourceView->GetDescription().m_hTexture.IsInvalidated(), "Resource view needs a valid texture to generate mip maps.");
     const ezGALTexture* pTexture = m_Device.GetTexture(pResourceView->GetDescription().m_hTexture);
+    EZ_IGNORE_UNUSED(pTexture);
     EZ_ASSERT_DEV(pTexture->GetDescription().m_bAllowDynamicMipGeneration,
       "Dynamic mip map generation needs to be enabled (m_bAllowDynamicMipGeneration = true)!");
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -115,7 +115,7 @@ ezResult ezGALDevice::Init()
     return EZ_FAILURE;
   }
 
-  ezGALSharedTextureSwapChain::SetFactoryMethod([this](const ezGALSharedTextureSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([this, &desc](ezAllocator* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSharedTextureSwapChain, desc); }); });
+  ezGALSharedTextureSwapChain::SetFactoryMethod([this](const ezGALSharedTextureSwapChainCreationDescription& desc) -> ezGALSwapChainHandle { return CreateSwapChain([&desc](ezAllocator* pAllocator) -> ezGALSwapChain* { return EZ_NEW(pAllocator, ezGALSharedTextureSwapChain, desc); }); });
 
   // Fill the capabilities
   FillCapabilitiesPlatform();
@@ -700,6 +700,7 @@ ezGALTextureHandle ezGALDevice::CreateProxyTexture(ezGALTextureHandle hParentTex
   }
 
   const auto& parentDesc = pParentTexture->GetDescription();
+  EZ_IGNORE_UNUSED(parentDesc);
   EZ_ASSERT_DEV(parentDesc.m_Type != ezGALTextureType::Texture2DProxy, "Can't create a proxy texture of a proxy texture.");
   EZ_ASSERT_DEV(parentDesc.m_Type == ezGALTextureType::TextureCube || parentDesc.m_uiArraySize > 1,
     "Proxy textures can only be created for cubemaps or array textures.");

--- a/Code/Engine/Texture/CMakeLists.txt
+++ b/Code/Engine/Texture/CMakeLists.txt
@@ -11,6 +11,10 @@ if(MSVC)
 	target_compile_options(${PROJECT_NAME} PRIVATE /wd4005)
 endif()
 
+if(EZ_CMAKE_COMPILER_CLANG)
+    target_compile_options(${PROJECT_NAME} PRIVATE -Wno-unknown-pragmas -Wno-unused-const-variable)
+endif()
+
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
     Foundation

--- a/Code/Engine/Texture/DirectXTex/DirectXTexD3D12.cpp
+++ b/Code/Engine/Texture/DirectXTex/DirectXTexD3D12.cpp
@@ -2,6 +2,9 @@
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 
+EZ_WARNING_PUSH()
+EZ_WARNING_DISABLE_CLANG("-Wunused-but-set-variable")
+
 //-------------------------------------------------------------------------------------
 // DirectXTexD3D12.cpp
 //
@@ -830,6 +833,8 @@ HRESULT DirectX::CaptureTexture(
 
     return S_OK;
 }
+
+EZ_WARNING_POP()
 
 #endif
 

--- a/Code/Engine/Texture/DirectXTex/DirectXTexDDS.cpp
+++ b/Code/Engine/Texture/DirectXTex/DirectXTexDDS.cpp
@@ -2,6 +2,9 @@
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 
+EZ_WARNING_PUSH()
+EZ_WARNING_DISABLE_CLANG("-Wunused-but-set-variable")
+
 //-------------------------------------------------------------------------------------
 // DirectXTexDDS.cpp
 //
@@ -2427,6 +2430,8 @@ HRESULT DirectX::SaveToDDSFile(
 
     return S_OK;
 }
+
+EZ_WARNING_POP()
 
 #endif
 

--- a/Code/Engine/Texture/Image/Implementation/Image.cpp
+++ b/Code/Engine/Texture/Image/Implementation/Image.cpp
@@ -35,6 +35,7 @@ void ezImageView::ResetAndViewExternalStorage(const ezImageHeader& header, ezCon
 
   ezUInt64 dataSize = ComputeLayout();
 
+  EZ_IGNORE_UNUSED(dataSize);
   EZ_ASSERT_DEV(imageData.GetCount() == dataSize, "Provided image storage ({} bytes) doesn't match required data size ({} bytes)",
     imageData.GetCount(), dataSize);
 

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -282,6 +282,7 @@ static void ApplyFunc(ImageType& inout_image, Func func)
   ezUInt32 uiHeight = inout_image.GetHeight();
   ezUInt32 uiDepth = inout_image.GetDepth();
 
+  EZ_IGNORE_UNUSED(uiDepth);
   EZ_ASSERT_DEV(uiWidth > 0 && uiHeight > 0 && uiDepth > 0, "The image passed to FindMinMax has illegal dimension {}x{}x{}.", uiWidth, uiHeight, uiDepth);
 
   ezUInt64 uiRowPitch = inout_image.GetRowPitch();
@@ -315,6 +316,7 @@ static void ApplyFunc(ImageType& inout_image, Func func)
 static void FindMinMax(const ezImageView& image, ezUInt8& out_uiMinRgb, ezUInt8& out_uiMaxRgb, ezUInt8& out_uiMinAlpha, ezUInt8& out_uiMaxAlpha)
 {
   ezImageFormat::Enum imageFormat = image.GetImageFormat();
+  EZ_IGNORE_UNUSED(imageFormat);
   EZ_ASSERT_DEV(ezImageFormat::GetBitsPerChannel(imageFormat, ezImageFormatChannel::R) == 8 && ezImageFormat::GetDataType(imageFormat) == ezImageFormatDataType::UNORM, "Only 8bpp unorm formats are supported in FindMinMax");
 
   out_uiMinRgb = 255u;

--- a/Code/Engine/Texture/Image/Implementation/Image_inl.h
+++ b/Code/Engine/Texture/Image/Implementation/Image_inl.h
@@ -80,5 +80,6 @@ template <typename T>
 void ezImageView::ValidateDataTypeAccessor(ezUInt32 uiPlaneIndex) const
 {
   ezUInt32 bytesPerBlock = ezImageFormat::GetBitsPerBlock(GetImageFormat(), uiPlaneIndex) / 8;
+  EZ_IGNORE_UNUSED(bytesPerBlock);
   EZ_ASSERT_DEV(bytesPerBlock % ezImageSizeofHelper<T>::Size == 0, "Accessor type is not suitable for interpreting contained data");
 }

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.cpp
@@ -11,7 +11,7 @@ ezVisualScriptCoroutine::ezVisualScriptCoroutine(const ezSharedPtr<const ezVisua
 
 ezVisualScriptCoroutine::~ezVisualScriptCoroutine() = default;
 
-void ezVisualScriptCoroutine::Start(ezArrayPtr<ezVariant> arguments)
+void ezVisualScriptCoroutine::StartWithVarargs(ezArrayPtr<ezVariant> arguments)
 {
   m_LocalDataStorage.AllocateStorage();
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.h
@@ -9,7 +9,7 @@ public:
   ezVisualScriptCoroutine(const ezSharedPtr<const ezVisualScriptGraphDescription>& pDesc);
   ~ezVisualScriptCoroutine();
 
-  virtual void Start(ezArrayPtr<ezVariant> arguments) override;
+  virtual void StartWithVarargs(ezArrayPtr<ezVariant> arguments) override;
   virtual void Stop() override;
   virtual Result Update(ezTime deltaTimeSinceLastUpdate) override;
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -254,7 +254,7 @@ namespace
         return ExecResult::Error();
       }
 
-      pCoroutine->Start(args);
+      pCoroutine->StartWithVarargs(args);
 
       inout_context.SetCurrentCoroutine(pCoroutine);
     }


### PR DESCRIPTION
The cmake function ez_enable_strict_warnings is currently a no-op when using the clang compiler. This commit implements ez_enable_strict_warnings for clang and fixes the resulting errors.