### PR TITLE
Changed slider attribute to display an image to visualize the value range

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -1,6 +1,5 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
-#include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <EditorFramework/Actions/AssetActions.h>
 #include <EditorFramework/Actions/CommonAssetActions.h>
 #include <EditorFramework/Actions/GameObjectContextActions.h>
@@ -50,8 +49,8 @@
 #include <Foundation/Application/Application.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/Logging/ConsoleWriter.h>
-#include <Foundation/Logging/VisualStudioWriter.h>
 #include <Foundation/Logging/ETWWriter.h>
+#include <Foundation/Logging/VisualStudioWriter.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <Foundation/Reflection/Implementation/PropertyAttributes.h>
 #include <Foundation/Threading/TaskSystem.h>
@@ -59,6 +58,7 @@
 #include <GuiFoundation/Action/StandardMenus.h>
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
+#include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/UIServices/ImageCache.moc.h>
 #include <GuiFoundation/UIServices/QtProgressbar.h>
 #include <QSvgRenderer>
@@ -110,6 +110,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezGameObjectReferenceAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtGameObjectReferencePropertyWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezExposedBone>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtExposedBoneWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezCompilerPreferences>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtCompilerPreferencesWidget(); });
+    ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezImageSliderUiAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtPropertyEditorSliderWidget(); });
 
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezSphereManipulatorAttribute>(), [](const ezRTTI* pRtti)->ezManipulatorAdapter* { return EZ_DEFAULT_NEW(ezSphereManipulatorAdapter); });
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezCapsuleManipulatorAttribute>(), [](const ezRTTI* pRtti)->ezManipulatorAdapter* { return EZ_DEFAULT_NEW(ezCapsuleManipulatorAdapter); });
@@ -155,6 +156,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezExposedParametersAttribute>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezExposedBone>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezCompilerPreferences>());
+    ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezImageSliderUiAttribute>());
 
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezSphereManipulatorAttribute>());
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezCapsuleManipulatorAttribute>());
@@ -393,13 +395,14 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
 
   if (m_bWroteCrashIndicatorFile)
   {
-    QTimer::singleShot(1000, [this]() {
-      ezStringBuilder sTemp = ezOSFile::GetTempDataFolder("ezEditor");
-      sTemp.AppendPath("ezEditorCrashIndicator");
-      ezOSFile::DeleteFile(sTemp).IgnoreResult();
-      m_bWroteCrashIndicatorFile = false;
-      //
-    });
+    QTimer::singleShot(1000, [this]()
+      {
+        ezStringBuilder sTemp = ezOSFile::GetTempDataFolder("ezEditor");
+        sTemp.AppendPath("ezEditorCrashIndicator");
+        ezOSFile::DeleteFile(sTemp).IgnoreResult();
+        m_bWroteCrashIndicatorFile = false;
+        //
+      });
   }
 
   if (m_StartupFlags.AreNoneSet(StartupFlags::Headless | StartupFlags::UnitTest) && !ezToolsProject::GetSingleton()->IsProjectOpen())

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -92,7 +92,7 @@ void ezGreyBoxComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& 
 void ezLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 void ezSceneDocument_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
-QImage SliderImageGenerator_LightTemperature(ezUInt32 uiWidth, ezUInt32 uiHeight)
+QImage SliderImageGenerator_LightTemperature(ezUInt32 uiWidth, ezUInt32 uiHeight, double fMinValue, double fMaxValue)
 {
   // can use a 1D image, height doesn't need to be all used
   QImage image = QImage(uiWidth, 1, QImage::Format::Format_RGB32);
@@ -100,7 +100,7 @@ QImage SliderImageGenerator_LightTemperature(ezUInt32 uiWidth, ezUInt32 uiHeight
   for (int x = 0; x < uiWidth; ++x)
   {
     const double pos = (double)x / (uiWidth - 1.0);
-    ezColor c = ezColor::MakeFromKelvin(static_cast<ezUInt32>((pos * 14000) + 1000));
+    ezColor c = ezColor::MakeFromKelvin(static_cast<ezUInt32>((pos * (fMaxValue - fMinValue)) + fMinValue));
 
     ezColorGammaUB cg = c;
     image.setPixel(x, 0, qRgb(cg.r, cg.g, cg.b));

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -92,14 +92,14 @@ void ezGreyBoxComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& 
 void ezLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 void ezSceneDocument_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
-QImage SliderImageGenerator_LightTemperature(ezUInt32 width, ezUInt32 height)
+QImage SliderImageGenerator_LightTemperature(ezUInt32 uiWidth, ezUInt32 uiHeight)
 {
   // can use a 1D image, height doesn't need to be all used
-  QImage image = QImage(width, 1, QImage::Format::Format_RGB32);
+  QImage image = QImage(uiWidth, 1, QImage::Format::Format_RGB32);
 
-  for (int x = 0; x < width; ++x)
+  for (int x = 0; x < uiWidth; ++x)
   {
-    const double pos = (double)x / (width - 1.0);
+    const double pos = (double)x / (uiWidth - 1.0);
     ezColor c = ezColor::MakeFromKelvin(static_cast<ezUInt32>((pos * 14000) + 1000));
 
     ezColorGammaUB cg = c;

--- a/Code/Engine/Foundation/Math/Implementation/Math_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Math_inl.h
@@ -13,7 +13,8 @@ namespace ezMath
   template <typename T>
   constexpr EZ_ALWAYS_INLINE T Sign(T f)
   {
-    return (f < 0 ? T(-1) : f > 0 ? T(1) : 0);
+    return (f < 0 ? T(-1) : f > 0 ? T(1)
+                                  : 0);
   }
 
   template <typename T>
@@ -241,6 +242,12 @@ namespace ezMath
     EZ_ASSERT_DEBUG((fFactor >= -0.00001) && (fFactor <= 1.0 + 0.00001), "lerp: factor is not in the range [0; 1]");
 
     return (T)(f1 + (fFactor * (f2 - f1)));
+  }
+
+  template <typename T>
+  EZ_FORCE_INLINE constexpr float Unlerp(T fMin, T fMax, T fValue)
+  {
+    return static_cast<float>(fValue - fMin) / static_cast<float>(fMax - fMin);
   }
 
   ///  Returns 0, if value < edge, and 1, if value >= edge.

--- a/Code/Engine/Foundation/Math/Math.h
+++ b/Code/Engine/Foundation/Math/Math.h
@@ -280,6 +280,10 @@ namespace ezMath
   template <typename T>
   [[nodiscard]] T Lerp(T f1, T f2, double fFactor); // [tested]
 
+  /// \brief Returns the interpolation factor such that Lerp(fMin, fMax, factor) == fValue.
+  template <typename T>
+  [[nodiscard]] constexpr float Unlerp(T fMin, T fMax, T fValue); // [tested]
+
   /// \brief Returns 0, if value < edge, and 1, if value >= edge.
   template <typename T>
   [[nodiscard]] constexpr T Step(T value, T edge); // [tested]

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -144,17 +144,16 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDefaultValueAttribute, 1, ezRTTIDefaultAllocat
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSliderAttribute, 1, ezRTTIDefaultAllocator<ezSliderAttribute>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezImageSliderUiAttribute, 1, ezRTTIDefaultAllocator<ezImageSliderUiAttribute>)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Min", m_MinValue),
-    EZ_MEMBER_PROPERTY("Max", m_MaxValue),
+    EZ_MEMBER_PROPERTY("ImageGenerator", m_sImageGenerator),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_FUNCTIONS
   {
-    EZ_CONSTRUCTOR_PROPERTY(const ezVariant&, const ezVariant&),
+    EZ_CONSTRUCTOR_PROPERTY(const char*),
   }
   EZ_END_FUNCTIONS;
 }

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -193,27 +193,6 @@ private:
   ezVariant m_Value;
 };
 
-/// \brief A property attribute that provides a ui slider between the min and max values
-class EZ_FOUNDATION_DLL ezSliderAttribute : public ezPropertyAttribute
-{
-  EZ_ADD_DYNAMIC_REFLECTION(ezSliderAttribute, ezPropertyAttribute);
-
-public:
-  ezSliderAttribute() = default;
-  ezSliderAttribute(const ezVariant& min, const ezVariant& max)
-    : m_MinValue(min)
-    , m_MaxValue(max)
-  {
-  }
-
-  const ezVariant& GetMinValue() const { return m_MinValue; }
-  const ezVariant& GetMaxValue() const { return m_MaxValue; }
-
-private:
-  ezVariant m_MinValue;
-  ezVariant m_MaxValue;
-};
-
 /// \brief A property attribute that allows to define min and max values for the UI. Min or max may be set to an invalid variant to indicate
 /// unbounded values in one direction.
 class EZ_FOUNDATION_DLL ezClampValueAttribute : public ezPropertyAttribute
@@ -231,7 +210,7 @@ public:
   const ezVariant& GetMinValue() const { return m_MinValue; }
   const ezVariant& GetMaxValue() const { return m_MaxValue; }
 
-private:
+protected:
   ezVariant m_MinValue;
   ezVariant m_MaxValue;
 };
@@ -1058,4 +1037,28 @@ class EZ_FOUNDATION_DLL ezGameObjectReferenceAttribute : public ezTypeWidgetAttr
 
 public:
   ezGameObjectReferenceAttribute() = default;
+};
+
+//////////////////////////////////////////////////////////////////////////
+
+/// \brief Displays the value range as an image, allowing users to pick a value like on a slider.
+///
+/// This attribute always has to be combined with an ezClampValueAttribute to define the min and max value range.
+/// The constructor takes the name of an image generator. The generator is used to build the QImage used for the slider background.
+///
+/// Image generators are registered through ezQtImageSliderWidget::s_ImageGenerators. Search the codebase for that variable
+/// to determine which types of image generators are available.
+/// You can register custom generators as well.
+class EZ_FOUNDATION_DLL ezImageSliderUiAttribute : public ezTypeWidgetAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezImageSliderUiAttribute, ezTypeWidgetAttribute);
+
+public:
+  ezImageSliderUiAttribute() = default;
+  ezImageSliderUiAttribute(const char* szImageGenerator)
+  {
+    m_sImageGenerator = szImageGenerator;
+  }
+
+  ezUntrackedString m_sImageGenerator;
 };

--- a/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/LightComponent.cpp
@@ -25,7 +25,7 @@ EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezLightComponent, 5)
   {
     EZ_ACCESSOR_PROPERTY("UseColorTemperature", GetUsingColorTemperature, SetUsingColorTemperature),
     EZ_ACCESSOR_PROPERTY("LightColor", GetLightColor, SetLightColor),
-    EZ_ACCESSOR_PROPERTY("Temperature", GetTemperature, SetTemperature)->AddAttributes(new ezSliderAttribute(1000, 15000), new ezDefaultValueAttribute(6550), new ezSuffixAttribute(" K")),
+    EZ_ACCESSOR_PROPERTY("Temperature", GetTemperature, SetTemperature)->AddAttributes(new ezImageSliderUiAttribute("LightTemperature"), new ezDefaultValueAttribute(6550), new ezClampValueAttribute(1000, 15000)),
     EZ_ACCESSOR_PROPERTY("Intensity", GetIntensity, SetIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
     EZ_ACCESSOR_PROPERTY("SpecularMultiplier", GetSpecularMultiplier, SetSpecularMultiplier)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),
     EZ_ACCESSOR_PROPERTY("CastShadows", GetCastShadows, SetCastShadows),
@@ -262,8 +262,8 @@ float ezLightComponent::CalculateScreenSpaceSize(const ezBoundingSphere& sphere,
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-#include <Foundation/Serialization/GraphPatch.h>
 #include <Foundation/Serialization/AbstractObjectGraph.h>
+#include <Foundation/Serialization/GraphPatch.h>
 
 class ezLightComponentPatch_1_2 : public ezGraphPatch
 {

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -513,7 +513,6 @@ void ezQtPropertyEditorAngleWidget::SlotValueChanged()
 
 /// *** INT SPINBOX ***
 
-
 ezQtPropertyEditorIntSpinboxWidget::ezQtPropertyEditorIntSpinboxWidget(ezInt8 iNumComponents, ezInt32 iMinValue, ezInt32 iMaxValue)
   : ezQtStandardPropertyWidget()
 {
@@ -552,35 +551,7 @@ void ezQtPropertyEditorIntSpinboxWidget::OnInit()
   auto pNoTemporaryTransactions = m_pProp->GetAttributeByType<ezNoTemporaryTransactionsAttribute>();
   m_bUseTemporaryTransaction = (pNoTemporaryTransactions == nullptr);
 
-  if (const ezSliderAttribute* pSlider = m_pProp->GetAttributeByType <ezSliderAttribute>())
-  {
-    EZ_ASSERT_DEV(m_iNumComponents == 1, "Sliders only suport 1 component");
-
-    const ezInt32 iMinValue = pSlider->GetMinValue().ConvertTo<ezInt32>();
-    const ezInt32 iMaxValue = pSlider->GetMaxValue().ConvertTo<ezInt32>();
-
-    ezQtScopedBlockSignals bs(m_pWidget[0]);
-    m_pWidget[0]->setMinimum(pSlider->GetMinValue());
-    m_pWidget[0]->setMaximum(pSlider->GetMaxValue());
-
-    if (pSlider->GetMinValue().IsValid() && pSlider->GetMaxValue().IsValid() && m_bUseTemporaryTransaction)
-    {
-      ezQtScopedBlockSignals bs2(m_pSlider);
-
-      // we have to create the slider here, because in the constructor we don't know the real
-      // min and max values from the ezClampValueAttribute (only the rough type ranges)
-      m_pSlider = new QSlider(this);
-      m_pSlider->installEventFilter(this);
-      m_pSlider->setOrientation(Qt::Orientation::Horizontal);
-      m_pSlider->setMinimum(iMinValue);
-      m_pSlider->setMaximum(iMaxValue);
-
-      m_pLayout->insertWidget(0, m_pSlider, 5); // make it take up most of the space
-      connect(m_pSlider, SIGNAL(valueChanged(int)), this, SLOT(SlotSliderValueChanged(int)));
-      connect(m_pSlider, SIGNAL(sliderReleased()), this, SLOT(on_EditingFinished_triggered()));
-    }
-  }
-  else if (const ezClampValueAttribute* pClamp = m_pProp->GetAttributeByType<ezClampValueAttribute>())
+  if (const ezClampValueAttribute* pClamp = m_pProp->GetAttributeByType<ezClampValueAttribute>())
   {
     switch (m_iNumComponents)
     {
@@ -840,6 +811,201 @@ void ezQtPropertyEditorIntSpinboxWidget::SlotSliderValueChanged(int value)
 void ezQtPropertyEditorIntSpinboxWidget::on_EditingFinished_triggered()
 {
   if (m_bUseTemporaryTransaction && m_bTemporaryCommand)
+    Broadcast(ezPropertyEvent::Type::EndTemporary);
+
+  m_bTemporaryCommand = false;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////
+
+ezMap<ezString, ezQtImageSliderWidget::ImageGeneratorFunc> ezQtImageSliderWidget::s_ImageGenerators;
+
+ezQtImageSliderWidget::ezQtImageSliderWidget(ImageGeneratorFunc generator, QWidget* pParent)
+  : QWidget(pParent)
+{
+  m_Generator = generator;
+
+  setAutoFillBackground(false);
+}
+
+void ezQtImageSliderWidget::SetValue(double fValue)
+{
+  if (m_fValue == fValue)
+    return;
+
+  m_fValue = fValue;
+  update();
+}
+
+void ezQtImageSliderWidget::paintEvent(QPaintEvent* event)
+{
+  QPainter painter(this);
+  painter.setRenderHint(QPainter::RenderHint::Antialiasing);
+
+  const QRect area = rect();
+
+  if (area.width() != m_Image.width())
+    UpdateImage();
+
+  painter.drawTiledPixmap(area, QPixmap::fromImage(m_Image));
+
+  const double pos = (int)(m_fValue * area.width()) + 0.5f;
+
+  const double top = area.top() + 0.5;
+  const double bot = area.bottom() + 0.5;
+  const double len = 5.0;
+  const double wid = 2.0;
+
+  const QColor col = qRgb(80, 80, 80);
+
+  painter.setPen(col);
+  painter.setBrush(col);
+
+  {
+    QPainterPath path;
+    path.moveTo(QPointF(pos - wid, top));
+    path.lineTo(QPointF(pos, top + len));
+    path.lineTo(QPointF(pos + wid, top));
+    path.closeSubpath();
+
+    painter.drawPath(path);
+  }
+
+  {
+    QPainterPath path;
+    path.moveTo(QPointF(pos - wid, bot));
+    path.lineTo(QPointF(pos, bot - len));
+    path.lineTo(QPointF(pos + wid, bot));
+    path.closeSubpath();
+
+    painter.drawPath(path);
+  }
+}
+
+void ezQtImageSliderWidget::UpdateImage()
+{
+  const int width = rect().width();
+
+  if (m_Generator)
+  {
+    m_Image = m_Generator(rect().width(), rect().height());
+  }
+  else
+  {
+    m_Image = QImage(width, 1, QImage::Format::Format_RGB32);
+
+    ezColorGammaUB cg = ezColor::HotPink;
+    for (int x = 0; x < width; ++x)
+    {
+      m_Image.setPixel(x, 0, qRgb(cg.r, cg.g, cg.b));
+    }
+  }
+}
+
+void ezQtImageSliderWidget::mouseMoveEvent(QMouseEvent* event)
+{
+  if (event->buttons().testFlag(Qt::LeftButton))
+  {
+    const int width = rect().width();
+    const int height = rect().height();
+
+    QPoint coord = event->pos();
+    const int x = ezMath::Clamp(coord.x(), 0, width - 1);
+
+    const double fx = (double)x / (width - 1);
+
+    valueChanged(fx);
+  }
+
+  event->accept();
+}
+
+void ezQtImageSliderWidget::mousePressEvent(QMouseEvent* event)
+{
+  mouseMoveEvent(event);
+  event->accept();
+}
+
+void ezQtImageSliderWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+  if (event->button() == Qt::LeftButton)
+  {
+    Q_EMIT sliderReleased();
+  }
+  event->accept();
+}
+
+/// *** SLIDER ***
+
+ezQtPropertyEditorSliderWidget::ezQtPropertyEditorSliderWidget()
+  : ezQtStandardPropertyWidget()
+{
+  m_pLayout = new QHBoxLayout(this);
+  m_pLayout->setContentsMargins(0, 0, 0, 0);
+  setLayout(m_pLayout);
+}
+
+ezQtPropertyEditorSliderWidget::~ezQtPropertyEditorSliderWidget() = default;
+
+void ezQtPropertyEditorSliderWidget::OnInit()
+{
+  const ezImageSliderUiAttribute* pSliderAttr = m_pProp->GetAttributeByType<ezImageSliderUiAttribute>();
+  const ezClampValueAttribute* pRange = m_pProp->GetAttributeByType<ezClampValueAttribute>();
+  EZ_ASSERT_DEV(pRange != nullptr, "ezImageSliderUiAttribute always has to be compined with ezClampValueAttribute to specify the valid range.");
+  EZ_ASSERT_DEV(pRange->GetMinValue().IsValid() && pRange->GetMaxValue().IsValid(), "The min and max values used with ezImageSliderUiAttribute both have to be valid.");
+
+  m_fMinValue = pRange->GetMinValue().ConvertTo<double>();
+  m_fMaxValue = pRange->GetMaxValue().ConvertTo<double>();
+
+  m_pSlider = new ezQtImageSliderWidget(ezQtImageSliderWidget::s_ImageGenerators[pSliderAttr->m_sImageGenerator], this);
+
+  m_pLayout->insertWidget(0, m_pSlider);
+  connect(m_pSlider, SIGNAL(valueChanged(double)), this, SLOT(SlotSliderValueChanged(double)));
+  connect(m_pSlider, SIGNAL(sliderReleased()), this, SLOT(on_EditingFinished_triggered()));
+
+  if (const ezDefaultValueAttribute* pDefault = m_pProp->GetAttributeByType<ezDefaultValueAttribute>())
+  {
+    ezQtScopedBlockSignals bs(m_pSlider);
+
+    if (pDefault->GetValue().CanConvertTo<double>())
+    {
+      const ezInt32 val = pDefault->GetValue().ConvertTo<double>();
+      const double pos = (val - m_fMinValue) / (m_fMaxValue - m_fMinValue);
+      m_pSlider->SetValue(pos);
+    }
+  }
+}
+
+void ezQtPropertyEditorSliderWidget::InternalSetValue(const ezVariant& value)
+{
+  ezQtScopedBlockSignals bs(m_pSlider);
+
+  m_OriginalType = value.GetType();
+
+  const double val = value.ConvertTo<double>();
+  const double pos = static_cast<double>(val - m_fMinValue) / static_cast<double>(m_fMaxValue - m_fMinValue);
+  m_pSlider->SetValue(pos);
+}
+
+void ezQtPropertyEditorSliderWidget::SlotSliderValueChanged(double value)
+{
+  if (!m_bTemporaryCommand)
+    Broadcast(ezPropertyEvent::Type::BeginTemporary);
+
+  m_bTemporaryCommand = true;
+
+  const double fValue = ezMath::Lerp(m_fMinValue, m_fMaxValue, value);
+
+  BroadcastValueChanged(ezVariant(fValue).ConvertTo(m_OriginalType));
+
+  m_pSlider->SetValue(value);
+}
+
+void ezQtPropertyEditorSliderWidget::on_EditingFinished_triggered()
+{
+  if (m_bTemporaryCommand)
     Broadcast(ezPropertyEvent::Type::EndTemporary);
 
   m_bTemporaryCommand = false;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
@@ -153,9 +153,9 @@ class EZ_GUIFOUNDATION_DLL ezQtImageSliderWidget : public QWidget
 {
   Q_OBJECT
 public:
-  using ImageGeneratorFunc = QImage (*)(ezUInt32 width, ezUInt32 height);
+  using ImageGeneratorFunc = QImage (*)(ezUInt32 uiWidth, ezUInt32 uiHeight, double fMinValue, double fMaxValue);
 
-  ezQtImageSliderWidget(ImageGeneratorFunc generator, QWidget* pParent);
+  ezQtImageSliderWidget(ImageGeneratorFunc generator, double fMinValue, double fMaxValue, QWidget* pParent);
 
   static ezMap<ezString, ImageGeneratorFunc> s_ImageGenerators;
 
@@ -177,6 +177,8 @@ protected:
   ImageGeneratorFunc m_Generator = nullptr;
   QImage m_Image;
   double m_fValue = 0;
+  double m_fMinValue = 0;
+  double m_fMaxValue = 0;
 };
 
 class EZ_GUIFOUNDATION_DLL ezQtPropertyEditorSliderWidget : public ezQtStandardPropertyWidget
@@ -188,7 +190,7 @@ public:
   ~ezQtPropertyEditorSliderWidget();
 
 private Q_SLOTS:
-  void SlotSliderValueChanged(double value);
+  void SlotSliderValueChanged(double fValue);
   void on_EditingFinished_triggered();
 
 protected:

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
@@ -147,6 +147,63 @@ protected:
   QSlider* m_pSlider = nullptr;
 };
 
+/// *** SLIDER ***
+
+class EZ_GUIFOUNDATION_DLL ezQtImageSliderWidget : public QWidget
+{
+  Q_OBJECT
+public:
+  using ImageGeneratorFunc = QImage (*)(ezUInt32 width, ezUInt32 height);
+
+  ezQtImageSliderWidget(ImageGeneratorFunc generator, QWidget* pParent);
+
+  static ezMap<ezString, ImageGeneratorFunc> s_ImageGenerators;
+
+  double GetValue() const { return m_fValue; }
+  void SetValue(double fValue);
+
+Q_SIGNALS:
+  void valueChanged(double x);
+  void sliderReleased();
+
+protected:
+  virtual void paintEvent(QPaintEvent*) override;
+  virtual void mouseMoveEvent(QMouseEvent*) override;
+  virtual void mousePressEvent(QMouseEvent*) override;
+  virtual void mouseReleaseEvent(QMouseEvent*) override;
+
+  void UpdateImage();
+
+  ImageGeneratorFunc m_Generator = nullptr;
+  QImage m_Image;
+  double m_fValue = 0;
+};
+
+class EZ_GUIFOUNDATION_DLL ezQtPropertyEditorSliderWidget : public ezQtStandardPropertyWidget
+{
+  Q_OBJECT
+
+public:
+  ezQtPropertyEditorSliderWidget();
+  ~ezQtPropertyEditorSliderWidget();
+
+private Q_SLOTS:
+  void SlotSliderValueChanged(double value);
+  void on_EditingFinished_triggered();
+
+protected:
+  virtual void OnInit() override;
+  virtual void InternalSetValue(const ezVariant& value) override;
+
+  bool m_bTemporaryCommand = false;
+  ezEnum<ezVariantType> m_OriginalType;
+  QHBoxLayout* m_pLayout = nullptr;
+  ezQtImageSliderWidget* m_pSlider = nullptr;
+
+  double m_fMinValue = 0;
+  double m_fMaxValue = 0;
+};
+
 /// *** QUATERNION ***
 
 class EZ_GUIFOUNDATION_DLL ezQtPropertyEditorQuaternionWidget : public ezQtStandardPropertyWidget

--- a/Code/UnitTests/FoundationTest/Math/MathTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/MathTest.cpp
@@ -522,6 +522,14 @@ EZ_CREATE_SIMPLE_TEST(Math, General)
     EZ_TEST_FLOAT(ezMath::Lerp(-5.0f, 5.0f, 1.0f), 5.0f, 0.000001);
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Unlerp")
+  {
+    EZ_TEST_FLOAT(ezMath::Unlerp(-5.0f, 5.0f, 0.0f), 0.5f, 0.000001);
+    EZ_TEST_FLOAT(ezMath::Unlerp(0.0f, 5.0f, 2.5f), 0.5f, 0.000001);
+    EZ_TEST_FLOAT(ezMath::Unlerp(-5.0f, 5.0f, -5.0f), 0.0f, 0.000001);
+    EZ_TEST_FLOAT(ezMath::Unlerp(-5.0f, 5.0f, 5.0f), 1.0f, 0.000001);
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Step")
   {
     EZ_TEST_FLOAT(ezMath::Step(0.5f, 0.4f), 1.0f, 0.00001f);


### PR DESCRIPTION
This is currently only used by the light component for the color temperature:

![image](https://github.com/ezEngine/ezEngine/assets/6001174/ca5f78a6-080e-4922-a5aa-6bc2f40d7c9c)

The image used is generated in code, so it looks exactly like the values that it produces.