### PR TITLE
ezString and ezStringBuilder don't track the character count anymore

### DIFF
--- a/Code/Engine/Foundation/IO/Implementation/Stream.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/Stream.cpp
@@ -25,7 +25,6 @@ ezResult ezStreamReader::ReadString(ezStringBuilder& ref_sBuilder)
       ref_sBuilder.m_Data.Reserve(uiCount + 1);
       ref_sBuilder.m_Data.SetCountUninitialized(uiCount);
       ReadBytes(ref_sBuilder.m_Data.GetData(), uiCount);
-      ref_sBuilder.m_uiCharacterCount = uiCount;
       ref_sBuilder.AppendTerminator();
     }
     else

--- a/Code/Engine/Foundation/Strings/Implementation/AllStrings_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/AllStrings_inl.h
@@ -33,14 +33,12 @@ EZ_ALWAYS_INLINE ezHybridString<Size, A>::ezHybridString(ezStringBuilder&& rhs)
 template <ezUInt16 Size>
 void ezHybridStringBase<Size>::operator=(const ezStringBuilder& rhs)
 {
-  m_uiCharacterCount = rhs.m_uiCharacterCount;
   m_Data = rhs.m_Data;
 }
 
 template <ezUInt16 Size>
 void ezHybridStringBase<Size>::operator=(ezStringBuilder&& rhs)
 {
-  m_uiCharacterCount = rhs.m_uiCharacterCount;
   m_Data = std::move(rhs.m_Data);
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/PathUtils.cpp
@@ -10,7 +10,7 @@ const char* ezPathUtils::FindPreviousSeparator(const char* szPathStart, const ch
 
   while (szStartSearchAt > szPathStart)
   {
-    ezUnicodeUtils::MoveToPriorUtf8(szStartSearchAt);
+    ezUnicodeUtils::MoveToPriorUtf8(szStartSearchAt, szPathStart).AssertSuccess();
 
     if (IsPathSeparator(*szStartSearchAt))
       return szStartSearchAt;
@@ -174,7 +174,7 @@ void ezPathUtils::GetRootedPathParts(ezStringView sPath, ezStringView& ref_sRoot
 
   do
   {
-    ezUnicodeUtils::MoveToNextUtf8(szStart, szPathEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szStart, szPathEnd).AssertSuccess();
 
     if (*szStart == '\0')
       return;
@@ -182,10 +182,10 @@ void ezPathUtils::GetRootedPathParts(ezStringView sPath, ezStringView& ref_sRoot
   } while (IsPathSeparator(*szStart));
 
   const char* szEnd = szStart;
-  ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd);
+  ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd).AssertSuccess();
 
   while (*szEnd != '\0' && !IsPathSeparator(*szEnd))
-    ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd).AssertSuccess();
 
   ref_sRoot = ezStringView(szStart, szEnd);
   if (*szEnd == '\0')
@@ -195,7 +195,7 @@ void ezPathUtils::GetRootedPathParts(ezStringView sPath, ezStringView& ref_sRoot
   else
   {
     // skip path separator for the relative path
-    ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szEnd, szPathEnd).AssertSuccess();
     ref_sRelPath = ezStringView(szEnd, szPathEnd);
   }
 }

--- a/Code/Engine/Foundation/Strings/Implementation/StringBase_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBase_inl.h
@@ -171,7 +171,9 @@ template <typename Derived>
 const char* ezStringBase<Derived>::ComputeCharacterPosition(ezUInt32 uiCharacterIndex) const
 {
   const char* pos = InternalGetData();
-  ezUnicodeUtils::MoveToNextUtf8(pos, InternalGetDataEnd(), uiCharacterIndex);
+  if (ezUnicodeUtils::MoveToNextUtf8(pos, InternalGetDataEnd(), uiCharacterIndex).Failed())
+    return nullptr;
+
   return pos;
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/StringBuilder_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringBuilder_inl.h
@@ -5,14 +5,12 @@
 inline ezStringBuilder::ezStringBuilder(ezAllocator* pAllocator)
   : m_Data(pAllocator)
 {
-  m_uiCharacterCount = 0;
   AppendTerminator();
 }
 
 inline ezStringBuilder::ezStringBuilder(const ezStringBuilder& rhs)
   : m_Data(rhs.GetAllocator())
 {
-  m_uiCharacterCount = 0;
   AppendTerminator();
 
   *this = rhs;
@@ -21,7 +19,6 @@ inline ezStringBuilder::ezStringBuilder(const ezStringBuilder& rhs)
 inline ezStringBuilder::ezStringBuilder(ezStringBuilder&& rhs) noexcept
   : m_Data(rhs.GetAllocator())
 {
-  m_uiCharacterCount = 0;
   AppendTerminator();
 
   *this = std::move(rhs);
@@ -30,7 +27,6 @@ inline ezStringBuilder::ezStringBuilder(ezStringBuilder&& rhs) noexcept
 inline ezStringBuilder::ezStringBuilder(const char* szUTF8, ezAllocator* pAllocator)
   : m_Data(pAllocator)
 {
-  m_uiCharacterCount = 0;
   AppendTerminator();
 
   *this = szUTF8;
@@ -39,7 +35,6 @@ inline ezStringBuilder::ezStringBuilder(const char* szUTF8, ezAllocator* pAlloca
 inline ezStringBuilder::ezStringBuilder(const wchar_t* pWChar, ezAllocator* pAllocator)
   : m_Data(pAllocator)
 {
-  m_uiCharacterCount = 0;
   AppendTerminator();
 
   *this = pWChar;
@@ -48,7 +43,6 @@ inline ezStringBuilder::ezStringBuilder(const wchar_t* pWChar, ezAllocator* pAll
 inline ezStringBuilder::ezStringBuilder(ezStringView rhs, ezAllocator* pAllocator)
   : m_Data(pAllocator)
 {
-  m_uiCharacterCount = 0;
   AppendTerminator();
 
   *this = rhs;
@@ -73,13 +67,11 @@ EZ_FORCE_INLINE void ezStringBuilder::operator=(const wchar_t* pWChar)
 
 EZ_ALWAYS_INLINE void ezStringBuilder::operator=(const ezStringBuilder& rhs)
 {
-  m_uiCharacterCount = rhs.m_uiCharacterCount;
   m_Data = rhs.m_Data;
 }
 
 EZ_ALWAYS_INLINE void ezStringBuilder::operator=(ezStringBuilder&& rhs) noexcept
 {
-  m_uiCharacterCount = rhs.m_uiCharacterCount;
   m_Data = std::move(rhs.m_Data);
 }
 
@@ -90,12 +82,11 @@ EZ_ALWAYS_INLINE ezUInt32 ezStringBuilder::GetElementCount() const
 
 EZ_ALWAYS_INLINE ezUInt32 ezStringBuilder::GetCharacterCount() const
 {
-  return m_uiCharacterCount;
+  return ezStringUtils::GetCharacterCount(m_Data.GetData());
 }
 
 EZ_FORCE_INLINE void ezStringBuilder::Clear()
 {
-  m_uiCharacterCount = 0;
   m_Data.SetCountUninitialized(1);
   m_Data[0] = '\0';
 }
@@ -115,7 +106,6 @@ inline void ezStringBuilder::Append(ezUInt32 uiChar)
     m_Data[uiOldCount + i] = szChar[i];
   }
   m_Data[uiOldCount + uiCharLen] = '\0';
-  ++m_uiCharacterCount;
 }
 
 inline void ezStringBuilder::Prepend(ezUInt32 uiChar)
@@ -204,11 +194,6 @@ inline void ezStringBuilder::ChangeCharacter(iterator& ref_it, ezUInt32 uiCharac
   }
 
   ChangeCharacterNonASCII(ref_it, uiCharacter);
-}
-
-EZ_ALWAYS_INLINE bool ezStringBuilder::IsPureASCII() const
-{
-  return m_uiCharacterCount + 1 == m_Data.GetCount();
 }
 
 EZ_ALWAYS_INLINE void ezStringBuilder::Reserve(ezUInt32 uiNumElements)

--- a/Code/Engine/Foundation/Strings/Implementation/StringIterator.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringIterator.h
@@ -48,7 +48,7 @@ struct ezStringIterator
 
     if (m_pCurPtr < m_pEndPtr)
     {
-      ezUnicodeUtils::MoveToNextUtf8(m_pCurPtr);
+      ezUnicodeUtils::MoveToNextUtf8(m_pCurPtr).AssertSuccess();
     }
 
     return static_cast<ezUInt32>(m_pCurPtr - pPrevElement);
@@ -59,7 +59,7 @@ struct ezStringIterator
   {
     if (m_pCurPtr < m_pEndPtr)
     {
-      ezUnicodeUtils::MoveToNextUtf8(m_pCurPtr);
+      ezUnicodeUtils::MoveToNextUtf8(m_pCurPtr).AssertSuccess();
     }
 
     return *this;
@@ -70,7 +70,7 @@ struct ezStringIterator
   {
     if (m_pStartPtr < m_pCurPtr)
     {
-      ezUnicodeUtils::MoveToPriorUtf8(m_pCurPtr);
+      ezUnicodeUtils::MoveToPriorUtf8(m_pCurPtr, m_pStartPtr).AssertSuccess();
     }
 
     return *this;
@@ -183,7 +183,7 @@ struct ezStringReverseIterator
     }
     else if (m_pCurPtr == m_pEndPtr)
     {
-      ezUnicodeUtils::MoveToPriorUtf8(m_pCurPtr);
+      ezUnicodeUtils::MoveToPriorUtf8(m_pCurPtr, m_pStartPtr).AssertSuccess();
     }
   }
 
@@ -207,7 +207,7 @@ struct ezStringReverseIterator
   EZ_FORCE_INLINE ezStringReverseIterator& operator++() // [tested]
   {
     if (m_pCurPtr != nullptr && m_pStartPtr < m_pCurPtr)
-      ezUnicodeUtils::MoveToPriorUtf8(m_pCurPtr);
+      ezUnicodeUtils::MoveToPriorUtf8(m_pCurPtr, m_pStartPtr).AssertSuccess();
     else
       m_pCurPtr = nullptr;
 
@@ -220,7 +220,7 @@ struct ezStringReverseIterator
     if (m_pCurPtr != nullptr)
     {
       const char* szOldPos = m_pCurPtr;
-      ezUnicodeUtils::MoveToNextUtf8(m_pCurPtr);
+      ezUnicodeUtils::MoveToNextUtf8(m_pCurPtr).AssertSuccess();
 
       if (m_pCurPtr == m_pEndPtr)
         m_pCurPtr = szOldPos;

--- a/Code/Engine/Foundation/Strings/Implementation/StringUtils.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/StringUtils.cpp
@@ -545,8 +545,8 @@ bool ezStringUtils::StartsWith_NoCase(const char* szString, const char* szStarts
     if (ezStringUtils::CompareChars_NoCase(szStartsWith, szString) != 0)
       return false;
 
-    ezUnicodeUtils::MoveToNextUtf8(szString, pStringEnd);
-    ezUnicodeUtils::MoveToNextUtf8(szStartsWith, szStartsWithEnd);
+    ezUnicodeUtils::MoveToNextUtf8(szString, pStringEnd).AssertSuccess();
+    ezUnicodeUtils::MoveToNextUtf8(szStartsWith, szStartsWithEnd).AssertSuccess();
   }
 
   // if both are equally long, this comparison will return true
@@ -589,8 +589,8 @@ bool ezStringUtils::EndsWith_NoCase(const char* szString, const char* szEndsWith
       return true;
 
     // move to the previous character
-    ezUnicodeUtils::MoveToPriorUtf8(pCur1);
-    ezUnicodeUtils::MoveToPriorUtf8(pCur2);
+    ezUnicodeUtils::MoveToPriorUtf8(pCur1, szString).AssertSuccess();
+    ezUnicodeUtils::MoveToPriorUtf8(pCur2, szEndsWith).AssertSuccess();
 
     if (ezStringUtils::CompareChars_NoCase(pCur1, pCur2) != 0)
       return false;
@@ -615,7 +615,7 @@ const char* ezStringUtils::FindSubString(const char* szSource, const char* szStr
     if (ezStringUtils::StartsWith(pCurPos, szStringToFind, pSourceEnd, szStringToFindEnd))
       return pCurPos;
 
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pSourceEnd);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pSourceEnd).AssertSuccess();
   }
 
   return nullptr;
@@ -634,7 +634,7 @@ const char* ezStringUtils::FindSubString_NoCase(const char* szSource, const char
     if (ezStringUtils::StartsWith_NoCase(pCurPos, szStringToFind, pSourceEnd, szStringToFindEnd))
       return pCurPos;
 
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pSourceEnd);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pSourceEnd).AssertSuccess();
   }
 
   return nullptr;
@@ -654,7 +654,7 @@ const char* ezStringUtils::FindLastSubString(const char* szSource, const char* s
   // while we haven't reached the stars .. erm, start
   while (szStartSearchAt > szSource)
   {
-    ezUnicodeUtils::MoveToPriorUtf8(szStartSearchAt);
+    ezUnicodeUtils::MoveToPriorUtf8(szStartSearchAt, szSource).AssertSuccess();
 
     if (ezStringUtils::StartsWith(szStartSearchAt, szStringToFind, pSourceEnd, szStringToFindEnd))
       return szStartSearchAt;
@@ -674,7 +674,7 @@ const char* ezStringUtils::FindLastSubString_NoCase(const char* szSource, const 
 
   while (szStartSearchAt > szSource)
   {
-    ezUnicodeUtils::MoveToPriorUtf8(szStartSearchAt);
+    ezUnicodeUtils::MoveToPriorUtf8(szStartSearchAt, szSource).AssertSuccess();
 
     if (ezStringUtils::StartsWith_NoCase(szStartSearchAt, szStringToFind, pSourceEnd, szStringToFindEnd))
       return szStartSearchAt;
@@ -708,14 +708,13 @@ const char* ezStringUtils::FindWholeWord(const char* szString, const char* szSea
     }
 
     pPrevPos = pCurPos;
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pStringEnd);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pStringEnd).AssertSuccess();
   }
 
   return nullptr;
 }
 
-const char* ezStringUtils::FindWholeWord_NoCase(
-  const char* szString, const char* szSearchFor, EZ_CHARACTER_FILTER isDelimiterCB, const char* pStringEnd)
+const char* ezStringUtils::FindWholeWord_NoCase(const char* szString, const char* szSearchFor, EZ_CHARACTER_FILTER isDelimiterCB, const char* pStringEnd)
 {
   // Handle nullptr-pointer strings
   if ((IsNullOrEmpty(szString)) || (IsNullOrEmpty(szSearchFor)))
@@ -738,7 +737,7 @@ const char* ezStringUtils::FindWholeWord_NoCase(
     }
 
     pPrevPos = pCurPos;
-    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pStringEnd);
+    ezUnicodeUtils::MoveToNextUtf8(pCurPos, pStringEnd).AssertSuccess();
   }
 
   return nullptr;
@@ -804,7 +803,8 @@ const char* ezStringUtils::SkipCharacters(const char* szString, EZ_CHARACTER_FIL
       break;
 
     bAlwaysSkipFirst = false;
-    ezUnicodeUtils::MoveToNextUtf8(szString);
+
+    ezUnicodeUtils::MoveToNextUtf8(szString).AssertSuccess();
   }
 
   return szString;
@@ -820,7 +820,7 @@ const char* ezStringUtils::FindWordEnd(const char* szString, EZ_CHARACTER_FILTER
       break;
 
     bAlwaysSkipFirst = false;
-    ezUnicodeUtils::MoveToNextUtf8(szString);
+    ezUnicodeUtils::MoveToNextUtf8(szString).AssertSuccess();
   }
 
   return szString;

--- a/Code/Engine/Foundation/Strings/Implementation/StringUtils_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringUtils_inl.h
@@ -95,8 +95,7 @@ inline ezUInt32 ezStringUtils::GetCharacterCount(const char* szUtf8, const char*
   return uiCharacters;
 }
 
-inline void ezStringUtils::GetCharacterAndElementCount(
-  const char* szUtf8, ezUInt32& ref_uiCharacterCount, ezUInt32& ref_uiElementCount, const char* pStringEnd)
+inline void ezStringUtils::GetCharacterAndElementCount(const char* szUtf8, ezUInt32& ref_uiCharacterCount, ezUInt32& ref_uiElementCount, const char* pStringEnd)
 {
   ref_uiCharacterCount = 0;
   ref_uiElementCount = 0;

--- a/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/StringView_inl.h
@@ -57,12 +57,12 @@ inline void ezStringView::operator++()
   if (!IsValid())
     return;
 
-  ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd);
+  ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd).IgnoreResult(); // if it fails, the string is just empty
 }
 
 inline void ezStringView::operator+=(ezUInt32 d)
 {
-  ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd, d);
+  ezUnicodeUtils::MoveToNextUtf8(m_pStart, m_pEnd, d).IgnoreResult(); // if it fails, the string is just empty
 }
 EZ_ALWAYS_INLINE bool ezStringView::IsValid() const
 {

--- a/Code/Engine/Foundation/Strings/Implementation/String_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/String_inl.h
@@ -50,7 +50,6 @@ void ezHybridStringBase<Size>::Clear()
 {
   m_Data.SetCountUninitialized(1);
   m_Data[0] = '\0';
-  m_uiCharacterCount = 0;
 }
 
 template <ezUInt16 Size>
@@ -71,14 +70,13 @@ EZ_ALWAYS_INLINE ezUInt32 ezHybridStringBase<Size>::GetElementCount() const
 template <ezUInt16 Size>
 EZ_ALWAYS_INLINE ezUInt32 ezHybridStringBase<Size>::GetCharacterCount() const
 {
-  return m_uiCharacterCount;
+  return ezStringUtils::GetCharacterCount(GetData());
 }
 
 template <ezUInt16 Size>
 void ezHybridStringBase<Size>::operator=(const char* szString)
 {
-  ezUInt32 uiElementCount = 0;
-  ezStringUtils::GetCharacterAndElementCount(szString, m_uiCharacterCount, uiElementCount);
+  ezUInt32 uiElementCount = ezStringUtils::GetStringElementCount(szString);
 
   if (szString + uiElementCount < m_Data.GetData() || szString >= m_Data.GetData() + m_Data.GetCount())
   {
@@ -100,7 +98,6 @@ void ezHybridStringBase<Size>::operator=(const ezHybridStringBase& rhs)
   if (this == &rhs)
     return;
 
-  m_uiCharacterCount = rhs.m_uiCharacterCount;
   m_Data = rhs.m_Data;
 }
 
@@ -110,7 +107,6 @@ void ezHybridStringBase<Size>::operator=(ezHybridStringBase&& rhs)
   if (this == &rhs)
     return;
 
-  m_uiCharacterCount = rhs.m_uiCharacterCount;
   m_Data = std::move(rhs.m_Data);
 }
 
@@ -129,20 +125,17 @@ void ezHybridStringBase<Size>::operator=(const ezStringView& rhs)
 
   m_Data.SetCountUninitialized(rhs.GetElementCount() + 1);
   ezStringUtils::Copy(&m_Data[0], m_Data.GetCount(), rhs.GetStartPointer(), rhs.GetEndPointer());
-  m_uiCharacterCount = ezStringUtils::GetCharacterCount(GetData());
 }
 
 template <ezUInt16 Size>
 ezStringView ezHybridStringBase<Size>::GetSubString(ezUInt32 uiFirstCharacter, ezUInt32 uiNumCharacters) const
 {
-  EZ_ASSERT_DEV(uiFirstCharacter + uiNumCharacters <= m_uiCharacterCount,
-    "The string only has {0} characters, cannot get a sub-string up to character {1}.", m_uiCharacterCount, uiFirstCharacter + uiNumCharacters);
-
   const char* szStart = GetData();
-  ezUnicodeUtils::MoveToNextUtf8(szStart, uiFirstCharacter);
+  if (ezUnicodeUtils::MoveToNextUtf8(szStart, uiFirstCharacter).Failed())
+    return {}; // szStart was moved too far, the result is just an empty string
 
   const char* szEnd = szStart;
-  ezUnicodeUtils::MoveToNextUtf8(szEnd, uiNumCharacters);
+  ezUnicodeUtils::MoveToNextUtf8(szEnd, uiNumCharacters).IgnoreResult(); // if it fails, szEnd just points to the end of this string
 
   return ezStringView(szStart, szEnd);
 }
@@ -156,9 +149,10 @@ ezStringView ezHybridStringBase<Size>::GetFirst(ezUInt32 uiNumCharacters) const
 template <ezUInt16 Size>
 ezStringView ezHybridStringBase<Size>::GetLast(ezUInt32 uiNumCharacters) const
 {
-  EZ_ASSERT_DEV(uiNumCharacters < m_uiCharacterCount, "The string only contains {0} characters, cannot return the last {1} characters.",
-    m_uiCharacterCount, uiNumCharacters);
-  return GetSubString(m_uiCharacterCount - uiNumCharacters, uiNumCharacters);
+  const ezUInt32 uiMaxCharacterCount = GetCharacterCount();
+  EZ_ASSERT_DEV(uiNumCharacters < uiMaxCharacterCount, "The string only contains {0} characters, cannot return the last {1} characters.",
+    uiMaxCharacterCount, uiNumCharacters);
+  return GetSubString(uiMaxCharacterCount - uiNumCharacters, uiNumCharacters);
 }
 
 
@@ -283,7 +277,6 @@ void ezHybridStringBase<Size>::operator=(const std::string_view& rhs)
   {
     m_Data.SetCountUninitialized(((ezUInt32)rhs.size() + 1));
     ezStringUtils::Copy(&m_Data[0], m_Data.GetCount(), rhs.data(), rhs.data() + rhs.size());
-    m_uiCharacterCount = ezStringUtils::GetCharacterCount(GetData());
   }
 }
 

--- a/Code/Engine/Foundation/Strings/Implementation/UnicodeUtils_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/UnicodeUtils_inl.h
@@ -194,13 +194,14 @@ inline bool ezUnicodeUtils::SkipUtf16BomBE(const ezUInt16*& ref_pUtf16)
   return false;
 }
 
-inline void ezUnicodeUtils::MoveToNextUtf8(const char*& ref_szUtf8, ezUInt32 uiNumCharacters)
+inline ezResult ezUnicodeUtils::MoveToNextUtf8(const char*& ref_szUtf8, ezUInt32 uiNumCharacters)
 {
-  EZ_ASSERT_DEBUG(ref_szUtf8 != nullptr, "Bad programmer!");
+  EZ_ASSERT_DEBUG(ref_szUtf8 != nullptr, "Invalid string pointer to advance!");
 
   while (uiNumCharacters > 0)
   {
-    EZ_ASSERT_DEV(*ref_szUtf8 != '\0', "The given string must not point to the zero terminator.");
+    if (*ref_szUtf8 == '\0')
+      return EZ_FAILURE;
 
     do
     {
@@ -209,15 +210,18 @@ inline void ezUnicodeUtils::MoveToNextUtf8(const char*& ref_szUtf8, ezUInt32 uiN
 
     --uiNumCharacters;
   }
+
+  return EZ_SUCCESS;
 }
 
-inline void ezUnicodeUtils::MoveToNextUtf8(const char*& ref_szUtf8, const char* szUtf8End, ezUInt32 uiNumCharacters)
+inline ezResult ezUnicodeUtils::MoveToNextUtf8(const char*& ref_szUtf8, const char* szUtf8End, ezUInt32 uiNumCharacters)
 {
-  EZ_ASSERT_DEBUG(ref_szUtf8 != nullptr, "Bad programmer!");
+  EZ_ASSERT_DEBUG(ref_szUtf8 != nullptr, "Invalid string pointer to advance!");
 
-  while (uiNumCharacters > 0 && ref_szUtf8 < szUtf8End)
+  while (uiNumCharacters > 0)
   {
-    EZ_ASSERT_DEV(*ref_szUtf8 != '\0', "The given string must not point to the zero terminator.");
+    if (ref_szUtf8 >= szUtf8End || *ref_szUtf8 == '\0')
+      return EZ_FAILURE;
 
     do
     {
@@ -226,14 +230,19 @@ inline void ezUnicodeUtils::MoveToNextUtf8(const char*& ref_szUtf8, const char* 
 
     --uiNumCharacters;
   }
+
+  return EZ_SUCCESS;
 }
 
-inline void ezUnicodeUtils::MoveToPriorUtf8(const char*& ref_szUtf8, ezUInt32 uiNumCharacters)
+inline ezResult ezUnicodeUtils::MoveToPriorUtf8(const char*& ref_szUtf8, const char* szUtf8Start, ezUInt32 uiNumCharacters)
 {
-  EZ_ASSERT_DEBUG(ref_szUtf8 != nullptr, "Bad programmer!");
+  EZ_ASSERT_DEBUG(ref_szUtf8 != nullptr, "Invalid string pointer to advance!");
 
   while (uiNumCharacters > 0)
   {
+    if (ref_szUtf8 <= szUtf8Start)
+      return EZ_FAILURE;
+
     do
     {
       --ref_szUtf8;
@@ -241,6 +250,8 @@ inline void ezUnicodeUtils::MoveToPriorUtf8(const char*& ref_szUtf8, ezUInt32 ui
 
     --uiNumCharacters;
   }
+
+  return EZ_SUCCESS;
 }
 template <typename T>
 constexpr T* ezUnicodeUtils::GetMaxStringEnd()

--- a/Code/Engine/Foundation/Strings/String.h
+++ b/Code/Engine/Foundation/Strings/String.h
@@ -101,7 +101,11 @@ public:
   /// \brief Returns the amount of bytes that this string takes (excluding the '\0' terminator).
   ezUInt32 GetElementCount() const; // [tested]
 
-  /// \brief Returns the number of characters in this string.
+  /// \brief Returns the number of characters in this string. Might be less than GetElementCount, if it contains Utf8
+  /// multi-byte characters.
+  ///
+  /// \note This is a slow operation, as it has to run through the entire string to count the Unicode characters.
+  /// Only call this once and use the result as long as the string doesn't change. Don't call this in a loop.
   ezUInt32 GetCharacterCount() const; // [tested]
 
   /// \brief Returns a view to a sub-string of this string, starting at character uiFirstCharacter, up until uiFirstCharacter +
@@ -133,7 +137,6 @@ private:
   friend class ezStringBuilder;
 
   ezHybridArray<char, Size> m_Data;
-  ezUInt32 m_uiCharacterCount = 0;
 };
 
 

--- a/Code/Engine/Foundation/Strings/StringBuilder.h
+++ b/Code/Engine/Foundation/Strings/StringBuilder.h
@@ -46,16 +46,14 @@ public:
   /// \brief Copies the given string into this one.
   template <ezUInt16 Size>
   ezStringBuilder(const ezHybridStringBase<Size>& rhs)
-    : m_uiCharacterCount(rhs.m_uiCharacterCount)
-    , m_Data(rhs.m_Data)
+    : m_Data(rhs.m_Data)
   {
   }
 
   /// \brief Copies the given string into this one.
   template <ezUInt16 Size, typename A>
   ezStringBuilder(const ezHybridString<Size, A>& rhs)
-    : m_uiCharacterCount(rhs.m_uiCharacterCount)
-    , m_Data(rhs.m_Data)
+    : m_Data(rhs.m_Data)
   {
   }
 
@@ -63,16 +61,14 @@ public:
   /// \brief Moves the given string into this one.
   template <ezUInt16 Size>
   ezStringBuilder(ezHybridStringBase<Size>&& rhs)
-    : m_uiCharacterCount(rhs.m_uiCharacterCount)
-    , m_Data(std::move(rhs.m_Data))
+    : m_Data(std::move(rhs.m_Data))
   {
   }
 
   /// \brief Moves the given string into this one.
   template <ezUInt16 Size, typename A>
   ezStringBuilder(ezHybridString<Size, A>&& rhs)
-    : m_uiCharacterCount(rhs.m_uiCharacterCount)
-    , m_Data(std::move(rhs.m_Data))
+    : m_Data(std::move(rhs.m_Data))
   {
   }
 
@@ -108,7 +104,6 @@ public:
   template <ezUInt16 Size>
   void operator=(const ezHybridStringBase<Size>& rhs)
   {
-    m_uiCharacterCount = rhs.m_uiCharacterCount;
     m_Data = rhs.m_Data;
   }
 
@@ -116,7 +111,6 @@ public:
   template <ezUInt16 Size, typename A>
   void operator=(const ezHybridString<Size, A>& rhs)
   {
-    m_uiCharacterCount = rhs.m_uiCharacterCount;
     m_Data = rhs.m_Data;
   }
 
@@ -124,7 +118,6 @@ public:
   template <ezUInt16 Size>
   void operator=(ezHybridStringBase<Size>&& rhs)
   {
-    m_uiCharacterCount = rhs.m_uiCharacterCount;
     m_Data = std::move(rhs.m_Data);
   }
 
@@ -132,7 +125,6 @@ public:
   template <ezUInt16 Size, typename A>
   void operator=(ezHybridString<Size, A>&& rhs) noexcept
   {
-    m_uiCharacterCount = rhs.m_uiCharacterCount;
     m_Data = std::move(rhs.m_Data);
   }
 
@@ -150,10 +142,10 @@ public:
 
   /// \brief Returns the number of characters of which this string consists. Might be less than GetElementCount, if it contains Utf8
   /// multi-byte characters.
+  ///
+  /// \note This is a slow operation, as it has to run through the entire string to count the Unicode characters.
+  /// Only call this once and use the result as long as the string doesn't change. Don't call this in a loop.
   ezUInt32 GetCharacterCount() const; // [tested]
-
-  /// \brief Returns whether this string only contains ASCII characters, which means that GetElementCount() == GetCharacterCount()
-  bool IsPureASCII() const; // [tested]
 
   /// \brief Converts all characters to upper case. Might move the string data around, so all iterators to the data will be invalid
   /// afterwards.
@@ -418,7 +410,6 @@ private:
 
   friend ezStreamReader;
 
-  ezUInt32 m_uiCharacterCount;
   ezHybridArray<char, 128> m_Data;
 };
 

--- a/Code/Engine/Foundation/Strings/UnicodeUtils.h
+++ b/Code/Engine/Foundation/Strings/UnicodeUtils.h
@@ -42,19 +42,19 @@ public:
   ///
   /// The string may point to an invalid position (in between a character sequence).
   /// It may not point to a zero terminator already.
-  static void MoveToNextUtf8(const char*& ref_szUtf8, ezUInt32 uiNumCharacters = 1); // [tested]
+  static ezResult MoveToNextUtf8(const char*& ref_szUtf8, ezUInt32 uiNumCharacters = 1); // [tested]
 
   /// \brief Moves the given string pointer ahead to the next Utf8 character sequence.
   ///
   /// The string may point to an invalid position (in between a character sequence).
   /// It may not point to a zero terminator already.
-  static void MoveToNextUtf8(const char*& ref_szUtf8, const char* szUtf8End, ezUInt32 uiNumCharacters = 1); // [tested]
+  static ezResult MoveToNextUtf8(const char*& ref_szUtf8, const char* szUtf8End, ezUInt32 uiNumCharacters = 1); // [tested]
 
   /// \brief Moves the given string pointer backwards to the previous Utf8 character sequence.
   ///
   /// The string may point to an invalid position (in between a character sequence), or even the \0 terminator,
   /// as long as there is a valid string before it (and the user knows when to stop).
-  static void MoveToPriorUtf8(const char*& ref_szUtf8, ezUInt32 uiNumCharacters = 1); // [tested]
+  static ezResult MoveToPriorUtf8(const char*& ref_szUtf8, const char* szUtf8Start, ezUInt32 uiNumCharacters = 1); // [tested]
 
   /// \brief Returns false if the given string does not contain a completely valid Utf8 string.
   static bool IsValidUtf8(const char* szString, const char* szStringEnd = GetMaxStringEnd<char>());

--- a/Code/Engine/Foundation/Utilities/Implementation/CommandLineUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/CommandLineUtils.cpp
@@ -45,7 +45,7 @@ void ezCommandLineUtils::SplitCommandLineString(const char* szCommandString, boo
       out_args.PushBack(path);
       lastEnd = currentChar + 1;
     }
-    ezUnicodeUtils::MoveToNextUtf8(currentChar);
+    ezUnicodeUtils::MoveToNextUtf8(currentChar).IgnoreResult();
   }
 
   out_argsV.Reserve(out_argsV.GetCount());

--- a/Code/Engine/Foundation/ezEngine.natvis
+++ b/Code/Engine/Foundation/ezEngine.natvis
@@ -11,7 +11,6 @@
 		<StringView>m_Data.m_pElements,s8</StringView>
 		<Expand>
 			<Item Name="String">m_Data.m_pElements,s8</Item>
-			<Item Name="CharacterCount">m_uiCharacterCount</Item>
 			<Item Name="ElementCount">m_Data.m_uiCount</Item>
 		</Expand>
 	</Type>

--- a/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
@@ -17,7 +17,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s.IsEmpty());
     EZ_TEST_INT(s.GetCharacterCount(), 0);
     EZ_TEST_INT(s.GetElementCount(), 0);
-    EZ_TEST_BOOL(s.IsPureASCII());
     EZ_TEST_BOOL(s == "");
   }
 
@@ -30,14 +29,12 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s == sUtf8.GetData());
     EZ_TEST_INT(s.GetElementCount(), 18);
     EZ_TEST_INT(s.GetCharacterCount(), 13);
-    EZ_TEST_BOOL(!s.IsPureASCII());
 
     ezStringBuilder s2("test test");
 
     EZ_TEST_BOOL(s2 == "test test");
     EZ_TEST_INT(s2.GetElementCount(), 9);
     EZ_TEST_INT(s2.GetCharacterCount(), 9);
-    EZ_TEST_BOOL(s2.IsPureASCII());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor(wchar_t)")
@@ -48,14 +45,12 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s == sUtf8.GetData());
     EZ_TEST_INT(s.GetElementCount(), 18);
     EZ_TEST_INT(s.GetCharacterCount(), 13);
-    EZ_TEST_BOOL(!s.IsPureASCII());
 
     ezStringBuilder s2(L"test test");
 
     EZ_TEST_BOOL(s2 == "test test");
     EZ_TEST_INT(s2.GetElementCount(), 9);
     EZ_TEST_INT(s2.GetCharacterCount(), 9);
-    EZ_TEST_BOOL(s2.IsPureASCII());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor(copy)")
@@ -67,7 +62,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s2 == sUtf8.GetData());
     EZ_TEST_INT(s2.GetElementCount(), 18);
     EZ_TEST_INT(s2.GetCharacterCount(), 13);
-    EZ_TEST_BOOL(!s2.IsPureASCII());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor(StringView)")
@@ -80,7 +74,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
 
     EZ_TEST_INT(s.GetElementCount(), 6);
     EZ_TEST_INT(s.GetCharacterCount(), 4);
-    EZ_TEST_BOOL(!s.IsPureASCII());
     EZ_TEST_BOOL(s == ezStringUtf8(L"c äö").GetData());
   }
 
@@ -104,7 +97,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s == sUtf8.GetData());
     EZ_TEST_INT(s.GetElementCount(), 18);
     EZ_TEST_INT(s.GetCharacterCount(), 13);
-    EZ_TEST_BOOL(!s.IsPureASCII());
 
     ezStringBuilder s2("bla");
     s2 = "test test";
@@ -112,7 +104,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s2 == "test test");
     EZ_TEST_INT(s2.GetElementCount(), 9);
     EZ_TEST_INT(s2.GetCharacterCount(), 9);
-    EZ_TEST_BOOL(s2.IsPureASCII());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator=(wchar_t)")
@@ -124,7 +115,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s == sUtf8.GetData());
     EZ_TEST_INT(s.GetElementCount(), 18);
     EZ_TEST_INT(s.GetCharacterCount(), 13);
-    EZ_TEST_BOOL(!s.IsPureASCII());
 
     ezStringBuilder s2("bla");
     s2 = L"test test";
@@ -132,7 +122,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s2 == "test test");
     EZ_TEST_INT(s2.GetElementCount(), 9);
     EZ_TEST_INT(s2.GetCharacterCount(), 9);
-    EZ_TEST_BOOL(s2.IsPureASCII());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator=(copy)")
@@ -145,7 +134,6 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s2 == sUtf8.GetData());
     EZ_TEST_INT(s2.GetElementCount(), 18);
     EZ_TEST_INT(s2.GetCharacterCount(), 13);
-    EZ_TEST_BOOL(!s2.IsPureASCII());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator=(StringView)")
@@ -182,32 +170,27 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     ezStringBuilder s(L"abc äöü € def");
 
     EZ_TEST_BOOL(!s.IsEmpty());
-    EZ_TEST_BOOL(!s.IsPureASCII());
 
     s.Clear();
     EZ_TEST_BOOL(s.IsEmpty());
     EZ_TEST_INT(s.GetElementCount(), 0);
     EZ_TEST_INT(s.GetCharacterCount(), 0);
-    EZ_TEST_BOOL(s.IsPureASCII());
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetElementCount / GetCharacterCount / IsPureASCII")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetElementCount / GetCharacterCount")
   {
     ezStringBuilder s(L"abc äöü € def");
 
-    EZ_TEST_BOOL(!s.IsPureASCII());
     EZ_TEST_INT(s.GetElementCount(), 18);
     EZ_TEST_INT(s.GetCharacterCount(), 13);
 
     s = "abc";
 
-    EZ_TEST_BOOL(s.IsPureASCII());
     EZ_TEST_INT(s.GetElementCount(), 3);
     EZ_TEST_INT(s.GetCharacterCount(), 3);
 
     s = L"Hällo! I love €";
 
-    EZ_TEST_BOOL(!s.IsPureASCII());
     EZ_TEST_INT(s.GetElementCount(), 18);
     EZ_TEST_INT(s.GetCharacterCount(), 15);
   }

--- a/Code/UnitTests/FoundationTest/Strings/StringIteratorTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringIteratorTest.cpp
@@ -45,7 +45,7 @@ void TestConstruction(const STRING& value, const char* szStart, const char* szEn
   EZ_TEST_BOOL(itBeginR.IsValid());
   EZ_TEST_BOOL(itBeginR == itBeginR);
   const char* szEndPrior = szEnd;
-  ezUnicodeUtils::MoveToPriorUtf8(szEndPrior);
+  ezUnicodeUtils::MoveToPriorUtf8(szEndPrior, szStart).AssertSuccess();
   EZ_TEST_BOOL(itBeginR.GetData() == szEndPrior);
   EZ_TEST_BOOL(itBeginR.GetCharacter() == ezUnicodeUtils::ConvertUtf8ToUtf32("F"));
   EZ_TEST_BOOL(*itBeginR == ezUnicodeUtils::ConvertUtf8ToUtf32("F"));

--- a/Code/UnitTests/FoundationTest/Strings/UnicodeUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/UnicodeUtilsTest.cpp
@@ -165,50 +165,50 @@ EZ_CREATE_SIMPLE_TEST(Strings, UnicodeUtils)
 
     // test how far it skips ahead
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[1]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[2]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[4]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[6]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[8]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[11]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz);
+    ezUnicodeUtils::MoveToNextUtf8(sz).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[12]);
 
     sz = s.GetData();
     const char* szEnd = s.GetView().GetEndPointer();
 
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[1]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[2]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[4]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[6]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[8]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[11]);
 
-    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd);
+    ezUnicodeUtils::MoveToNextUtf8(sz, szEnd).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[12]);
   }
 
@@ -222,28 +222,28 @@ EZ_CREATE_SIMPLE_TEST(Strings, UnicodeUtils)
 
     // test how far it skips ahead
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[12]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[11]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[8]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[6]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[4]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[2]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[1]);
 
-    ezUnicodeUtils::MoveToPriorUtf8(sz);
+    ezUnicodeUtils::MoveToPriorUtf8(sz, s.GetData()).AssertSuccess();
     EZ_TEST_BOOL(sz == &s.GetData()[0]);
   }
 


### PR DESCRIPTION
The string character count is rarely needed, usually you need the byte count. However, so far we have been computing it on every assign and string modification, which costs performance.

This change removes this overhead, and instead the character count is only computed on demand.