### PR TITLE
Fixed #1128: Made shadow map settings configurable per platform

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -1,8 +1,8 @@
 #include <EditorEngineProcess/EditorEngineProcessPCH.h>
 
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
-#include <Foundation/System/SystemInformation.h>
 #include <Foundation/Logging/ETWWriter.h>
+#include <Foundation/System/SystemInformation.h>
 
 #include <Core/Console/QuakeConsole.h>
 #include <EditorEngineProcess/EngineProcGameApp.h>
@@ -248,7 +248,8 @@ void ezEngineProcessGameApplication::SendReflectionInformation()
 
   ezSet<const ezRTTI*> types;
   ezRTTI::ForEachType(
-    [&](const ezRTTI* pRtti) {
+    [&](const ezRTTI* pRtti)
+    {
       if (pRtti->GetTypeFlags().IsSet(ezTypeFlags::StandardType) == false)
       {
         types.Insert(pRtti);
@@ -360,7 +361,7 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
 
       ezFileSystem::ReloadAllExternalDataDirectoryConfigs();
 
-      m_PlatformProfile.m_sName = pMsg1->m_sPayload;
+      m_PlatformProfile.SetConfigName(pMsg1->m_sPayload);
       Init_PlatformProfile_LoadForRuntime();
 
       ezResourceManager::ReloadAllResources(false);
@@ -512,7 +513,8 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
   if (pDocumentContext == nullptr)
   {
     ezRTTI::ForEachDerivedType<ezEngineProcessDocumentContext>(
-      [&](const ezRTTI* pRtti) {
+      [&](const ezRTTI* pRtti)
+      {
         auto* pProp = pRtti->FindPropertyByName("DocumentType");
         if (pProp && pProp->GetCategory() == ezPropertyCategory::Constant)
         {
@@ -562,7 +564,8 @@ ezEngineProcessDocumentContext* ezEngineProcessGameApplication::CreateDocumentCo
 
 void ezEngineProcessGameApplication::Init_LoadProjectPlugins()
 {
-  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool {
+  m_CustomPluginConfig.m_Plugins.Sort([](const ezApplicationPluginConfig::PluginConfig& lhs, const ezApplicationPluginConfig::PluginConfig& rhs) -> bool
+    {
     const bool isEnginePluginLhs = lhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
     const bool isEnginePluginRhs = rhs.m_sAppDirRelativePath.FindSubString_NoCase("EnginePlugin") != nullptr;
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProfile.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProfile.cpp
@@ -31,7 +31,7 @@ ezUInt32 ezAssetCurator::FindAssetProfileByName(const char* szPlatform)
 
   for (ezUInt32 i = 0; i < m_AssetProfiles.GetCount(); ++i)
   {
-    if (m_AssetProfiles[i]->m_sName.IsEqual_NoCase(szPlatform))
+    if (m_AssetProfiles[i]->GetConfigName().IsEqual_NoCase(szPlatform))
     {
       return i;
     }
@@ -150,7 +150,7 @@ ezResult ezAssetCurator::SaveAssetProfiles()
 
   for (const auto* pCfg : m_AssetProfiles)
   {
-    ddl.BeginObject("Config", pCfg->m_sName);
+    ddl.BeginObject("Config", pCfg->GetConfigName());
 
     // make sure to create the same GUID every time, otherwise the serialized file changes all the time
     const ezUuid guid = ezUuid::MakeStableUuidFromString(pCfg->GetConfigName());
@@ -221,7 +221,7 @@ void ezAssetCurator::SetupDefaultAssetProfiles()
 
   {
     ezPlatformProfile* pCfg = EZ_DEFAULT_NEW(ezPlatformProfile);
-    pCfg->m_sName = "PC";
+    pCfg->SetConfigName("PC");
     pCfg->AddMissingConfigs();
     m_AssetProfiles.PushBack(pCfg);
   }

--- a/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/AssetProfilesDlg.cpp
@@ -163,7 +163,8 @@ void ezQtAssetProfilesDlg::ObjectToNative(ezUuid objectGuid, ezPlatformProfile* 
 
   // Write object to graph.
   ezAbstractObjectGraph graph;
-  auto filter = [](const ezDocumentObject*, const ezAbstractProperty* pProp) -> bool {
+  auto filter = [](const ezDocumentObject*, const ezAbstractProperty* pProp) -> bool
+  {
     if (pProp->GetFlags().IsSet(ezPropertyFlags::ReadOnly))
       return false;
     return true;
@@ -280,7 +281,7 @@ void ezQtAssetProfilesDlg::on_AddButton_clicked()
     return;
 
   ezPlatformProfile profile;
-  profile.m_sName = sProfileName;
+  profile.SetConfigName(sProfileName);
   profile.AddMissingConfigs();
 
   auto& binding = m_ProfileBindings[NativeToObject(&profile)];

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -32,6 +32,7 @@
 #include <RendererCore/Lights/BoxReflectionProbeComponent.h>
 #include <RendererCore/Lights/PointLightComponent.h>
 #include <RendererCore/Lights/SpotLightComponent.h>
+#include <RendererCore/Utils/CoreRenderProfile.h>
 #include <ToolsFoundation/Settings/ToolsTagRegistry.h>
 
 void OnDocumentManagerEvent(const ezDocumentManager::Event& e)
@@ -341,15 +342,11 @@ void ezLightComponent_PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e)
   auto& props = *e.m_pPropertyStates;
 
   const bool bUseColorTemperature = e.m_pObject->GetTypeAccessor().GetValue("UseColorTemperature").ConvertTo<bool>();
+  props["Temperature"].m_Visibility = bUseColorTemperature ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  props["LightColor"].m_Visibility = bUseColorTemperature ? ezPropertyUiState::Invisible : ezPropertyUiState::Default;
 
-  if (bUseColorTemperature)
-  {
-    props["Temperature"].m_Visibility = ezPropertyUiState::Default;
-    props["LightColor"].m_Visibility = ezPropertyUiState::Invisible;
-  }
-  else
-  {
-    props["Temperature"].m_Visibility = ezPropertyUiState::Invisible;
-    props["LightColor"].m_Visibility = ezPropertyUiState::Default;
-  }
+  const bool bCastShadows = e.m_pObject->GetTypeAccessor().GetValue("CastShadows").ConvertTo<bool>();
+  props["PenumbraSize"].m_Visibility = bCastShadows ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  props["SlopeBias"].m_Visibility = bCastShadows ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  props["ConstantBias"].m_Visibility = bCastShadows ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
 }

--- a/Code/Engine/Core/Configuration/Implementation/PlatformProfile.cpp
+++ b/Code/Engine/Core/Configuration/Implementation/PlatformProfile.cpp
@@ -63,7 +63,8 @@ void ezPlatformProfile::Clear()
 void ezPlatformProfile::AddMissingConfigs()
 {
   ezRTTI::ForEachDerivedType<ezProfileConfigData>(
-    [this](const ezRTTI* pRtti) {
+    [this](const ezRTTI* pRtti)
+    {
       // find all types derived from ezProfileConfigData
       bool bHasTypeAlready = false;
 
@@ -89,8 +90,12 @@ void ezPlatformProfile::AddMissingConfigs()
     },
     ezRTTI::ForEachOptions::ExcludeNonAllocatable);
 
+  // in case unknown configs were loaded from disk, remove them
+  m_Configs.RemoveAndSwap(nullptr);
+
   // sort all configs alphabetically
-  m_Configs.Sort([](const ezProfileConfigData* lhs, const ezProfileConfigData* rhs) -> bool { return lhs->GetDynamicRTTI()->GetTypeName().Compare(rhs->GetDynamicRTTI()->GetTypeName()) < 0; });
+  m_Configs.Sort([](const ezProfileConfigData* lhs, const ezProfileConfigData* rhs) -> bool
+    { return lhs->GetDynamicRTTI()->GetTypeName().Compare(rhs->GetDynamicRTTI()->GetTypeName()) < 0; });
 }
 
 const ezProfileConfigData* ezPlatformProfile::GetTypeConfig(const ezRTTI* pRtti) const
@@ -150,6 +155,7 @@ ezResult ezPlatformProfile::LoadForRuntime(ezStringView sFile)
 
   chunk.EndStream();
 
+  ++m_uiLastModificationCounter;
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/Core/Configuration/PlatformProfile.h
+++ b/Code/Engine/Core/Configuration/PlatformProfile.h
@@ -47,6 +47,7 @@ public:
   ezPlatformProfile();
   ~ezPlatformProfile();
 
+  void SetConfigName(ezStringView sName) { m_sName = sName; }
   ezStringView GetConfigName() const { return m_sName; }
 
   void Clear();
@@ -70,6 +71,11 @@ public:
   ezResult SaveForRuntime(ezStringView sFile) const;
   ezResult LoadForRuntime(ezStringView sFile);
 
+  /// \brief Returns a number indicating when the profile counter changed last. By storing and comparing this value, other code can update their state if necessary.
+  ezUInt32 GetLastModificationCounter() const { return m_uiLastModificationCounter; }
+
+private:
+  ezUInt32 m_uiLastModificationCounter = 0;
   ezString m_sName;
   ezEnum<ezProfileTargetPlatform> m_TargetPlatform;
   ezDynamicArray<ezProfileConfigData*> m_Configs;

--- a/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
+++ b/Code/Engine/Core/Console/Implementation/Autocomplete.cpp
@@ -98,7 +98,7 @@ ezString ezQuakeConsole::GetFullInfoAsString(ezCVar* pCVar)
 {
   ezStringBuilder s = GetValueAsString(pCVar);
 
-  const bool bAnyFlags = pCVar->GetFlags().IsAnySet(ezCVarFlags::RequiresRestart | ezCVarFlags::Save);
+  const bool bAnyFlags = pCVar->GetFlags().IsAnySet(ezCVarFlags::Save | ezCVarFlags::ShowRequiresRestartMsg);
 
   if (bAnyFlags)
     s.Append(" [ ");
@@ -106,7 +106,7 @@ ezString ezQuakeConsole::GetFullInfoAsString(ezCVar* pCVar)
   if (pCVar->GetFlags().IsAnySet(ezCVarFlags::Save))
     s.Append("SAVE ");
 
-  if (pCVar->GetFlags().IsAnySet(ezCVarFlags::RequiresRestart))
+  if (pCVar->GetFlags().IsAnySet(ezCVarFlags::ShowRequiresRestartMsg))
     s.Append("RESTART ");
 
   if (bAnyFlags)
@@ -192,5 +192,3 @@ void ezCommandInterpreter::AutoComplete(ezCommandInterpreterState& inout_state)
     inout_state.m_sInput.Append(FindCommonString(AutoCompleteOptions).GetData());
   }
 }
-
-

--- a/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
+++ b/Code/Engine/Core/Console/Implementation/LuaInterpreter.cpp
@@ -186,7 +186,7 @@ void ezCommandInterpreterLua::Interpret(ezCommandInterpreterState& inout_state)
       }
       else
       {
-        if (pCVAR->GetFlags().IsAnySet(ezCVarFlags::RequiresRestart))
+        if (pCVAR->GetFlags().IsAnySet(ezCVarFlags::ShowRequiresRestartMsg))
         {
           inout_state.AddOutputLine("  This change takes only effect after a restart.", ezConsoleString::Type::Note);
         }

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
@@ -51,7 +51,7 @@ void ezGameApplicationBase::ExecuteInitFunctions()
 
 void ezGameApplicationBase::Init_PlatformProfile_SetPreferred()
 {
-  m_PlatformProfile.m_sName = opt_Profile.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
+  m_PlatformProfile.SetConfigName(opt_Profile.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified));
   m_PlatformProfile.AddMissingConfigs();
 }
 
@@ -176,7 +176,7 @@ void ezGameApplicationBase::Init_LoadProjectPlugins()
 
 void ezGameApplicationBase::Init_PlatformProfile_LoadForRuntime()
 {
-  const ezStringBuilder sRuntimeProfileFile(":project/RuntimeConfigs/", m_PlatformProfile.m_sName, ".ezProfile");
+  const ezStringBuilder sRuntimeProfileFile(":project/RuntimeConfigs/", m_PlatformProfile.GetConfigName(), ".ezProfile");
   m_PlatformProfile.AddMissingConfigs();
   m_PlatformProfile.LoadForRuntime(sRuntimeProfileFile).IgnoreResult();
 }
@@ -260,5 +260,3 @@ void ezGameApplicationBase::Deinit_ShutdownLogging()
   ezGlobalLog::RemoveLogWriter(m_LogToVsID);
 #endif
 }
-
-

--- a/Code/Engine/Foundation/Configuration/CVar.h
+++ b/Code/Engine/Foundation/Configuration/CVar.h
@@ -34,10 +34,17 @@ struct ezCVarFlags
     /// Otherwise all changes to it will be lost on shutdown.
     Save = EZ_BIT(0),
 
-    /// \brief Indicates that changing this cvar will only take effect after the proper subsystem has been reinitialized.
+    /// \brief If the CVar value is changed, the new value will not be visible by default, until SetToDelayedSyncValue() is called on it.
+    /// This allows to finalize the value change at a specific sync point in code.
+    /// When this flag is set the ezCVarEvent::DelayedSyncValueChanged will be broadcast.
+    RequiresDelayedSync = EZ_BIT(1),
+
+    ShowRequiresRestartMsg = EZ_BIT(2),
+
+    /// \brief Indicates that changing this CVar will only take effect after the proper subsystem has been reinitialized.
     /// This will always enforce the 'Save' flag as well.
-    /// With this flag set, the 'Current' value never changes, unless 'SetToRestartValue' is called.
-    RequiresRestart = EZ_BIT(1),
+    /// With this flag set, the 'Current' value never changes, unless 'SetToDelayedSyncValue' is called.
+    RequiresRestart = Save | RequiresDelayedSync | ShowRequiresRestartMsg,
 
     /// \brief By default CVars are not saved.
     Default = None
@@ -46,7 +53,8 @@ struct ezCVarFlags
   struct Bits
   {
     StorageType Save : 1;
-    StorageType RequiresRestart : 1;
+    StorageType RequiresDelayedSync : 1;
+    StorageType ShowRequiresRestartMsg : 1;
   };
 };
 
@@ -62,9 +70,9 @@ struct ezCVarEvent
 
   enum Type
   {
-    ValueChanged,        ///< Sent whenever the 'Current' value of the CVar is changed.
-    RestartValueChanged, ///< Sent whenever the 'Restart' value of the CVar changes. It might actually change back to the 'Current' value though.
-    ListOfVarsChanged,   ///< A CVar was added or removed dynamically (not just by loading a plugin), some stuff may need to update its state
+    ValueChanged,            ///< Sent whenever the 'Current' value of the CVar is changed.
+    DelayedSyncValueChanged, ///< Sent whenever the 'DelayedSync' value of the CVar changes. It might actually change back to the 'Current' value though.
+    ListOfVarsChanged,       ///< A CVar was added or removed dynamically (not just by loading a plugin), some stuff may need to update its state
   };
 
   /// \brief The type of this event.
@@ -143,9 +151,9 @@ public:
   /// If \a bOnlyNewOnes is set, only CVars that have never been loaded from file before are loaded.
   /// All other CVars will stay unchanged.
   /// If \a bSetAsCurrentValue is true, variables that are flagged as 'RequiresRestart', will be set
-  /// to the restart value immediately ('SetToRestartValue' is called on them).
+  /// to the restart value immediately ('SetToDelayedSyncValue' is called on them).
   /// Otherwise their 'Current' value will always stay unchanged and the value from disk will only be
-  /// stored in the 'Restart' value.
+  /// stored in the 'DelayedSync' value.
   /// Independent on the parameter settings, all CVar changes during loading will always trigger change events.
   ///
   ///
@@ -163,9 +171,9 @@ public:
   /// If \a bOnlyNewOnes is set, only CVars that have never been loaded from file before are loaded.
   /// All other CVars will stay unchanged.
   /// If \a bSetAsCurrentValue is true, variables that are flagged as 'RequiresRestart', will be set
-  /// to the restart value immediately ('SetToRestartValue' is called on them).
+  /// to the restart value immediately ('SetToDelayedSyncValue' is called on them).
   /// Otherwise their 'Current' value will always stay unchanged and the value from disk will only be
-  /// stored in the 'Restart' value.
+  /// stored in the 'DelayedSync' value.
   /// Independent on the parameter settings, all CVar changes during loading will always trigger change events.
   /// If bIgnoreSaveFlag is set all CVars are loaded whether they have the ezCVarFlags::Save set or not.
   ///
@@ -183,12 +191,12 @@ public:
   /// otherwise it could get flagged as 'already loaded' even if the value was never taken from file or command line.
   static void LoadCVarsFromCommandLine(bool bOnlyNewOnes = true, bool bSetAsCurrentValue = true, ezDynamicArray<ezCVar*>* pOutCVars = nullptr); // [tested]
 
-  /// \brief Copies the 'Restart' value into the 'Current' value.
+  /// \brief Copies the 'DelayedSync' value into the 'Current' value.
   ///
-  /// This change will not trigger a 'restart value changed' event, but it might trigger a 'current value changed' event.
-  /// Code that uses a CVar that is flagged as 'RequiresRestart' for its initialization (and which is the reason, that that CVar
+  /// This change will not trigger a 'delayed sync value changed' event, but it might trigger a 'current value changed' event.
+  /// Code that uses a CVar that is flagged as 'RequiresDelayedSync' for its initialization (and which is the reason, that that CVar
   /// is flagged as such) should always call this BEFORE it uses the CVar value.
-  virtual void SetToRestartValue() = 0; // [tested]
+  virtual void SetToDelayedSyncValue() = 0; // [tested]
 
   /// \brief Returns the (display) name of the CVar.
   ezStringView GetName() const { return m_sName; } // [tested]
@@ -245,11 +253,10 @@ struct ezCVarValue
 {
   enum Enum
   {
-    Current, ///< The value that should be used.
-    Default, ///< The 'default' value of the CVar. Can be used to reset a variable to its default state.
-    Stored,  ///< The value that was read from disk (or the default). Can be used to reset a CVar to the 'saved' state, if desired.
-    Restart, ///< The state that will be saved to disk. This is identical to 'Current' unless the 'RequiresRestart' flag is set (in which case the
-             ///< 'Current' value never changes).
+    Current,     ///< The value that should be used.
+    Default,     ///< The 'default' value of the CVar. Can be used to reset a variable to its default state.
+    Stored,      ///< The value that was read from disk (or the default). Can be used to reset a CVar to the 'saved' state, if desired.
+    DelayedSync, ///< The state that will be stored for later. This is identical to 'Current' unless the 'RequiresDelayedSync' flag is set (in which case the 'Current' value only changes when the code requests so).
     ENUM_COUNT
   };
 };
@@ -269,12 +276,18 @@ public:
 
   /// \brief Changes the CVar's value and broadcasts the proper events.
   ///
-  /// Usually the 'Current' value is changed, unless the 'RequiresRestart' flag is set.
-  /// In that case only the 'Restart' value is modified.
+  /// Usually the 'Current' value is changed, unless the 'RequiresDelayedSync' flag is set.
+  /// In that case only the 'DelayedSync' value is modified.
   void operator=(const Type& value); // [tested]
 
   virtual ezCVarType::Enum GetType() const override;
-  virtual void SetToRestartValue() override;
+  virtual void SetToDelayedSyncValue() override;
+
+  /// \brief Checks whether a new value was set and now won't be visible until SetToDelayedSyncValue() is called.
+  bool HasDelayedSyncValueChanged() const
+  {
+    return m_Values[ezCVarValue::Current] != m_Values[ezCVarValue::DelayedSync];
+  }
 
 private:
   friend class ezCVar;

--- a/Code/Engine/Foundation/Configuration/Implementation/CVar.cpp
+++ b/Code/Engine/Foundation/Configuration/Implementation/CVar.cpp
@@ -109,10 +109,6 @@ ezCVar::ezCVar(ezStringView sName, ezBitflags<ezCVarFlags> Flags, ezStringView s
   , m_sDescription(sDescription)
   , m_Flags(Flags)
 {
-  // 'RequiresRestart' only works together with 'Save'
-  if (m_Flags.IsAnySet(ezCVarFlags::RequiresRestart))
-    m_Flags.Add(ezCVarFlags::Save);
-
   EZ_ASSERT_DEV(!m_sDescription.IsEmpty(), "Please add a useful description for CVar '{}'.", sName);
 }
 
@@ -215,25 +211,25 @@ void ezCVar::SaveCVarsToFileInternal(ezStringView path, const ezDynamicArray<ezC
         case ezCVarType::Int:
         {
           ezCVarInt* pInt = (ezCVarInt*)pCVar;
-          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pInt->GetValue(ezCVarValue::Restart));
+          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pInt->GetValue(ezCVarValue::DelayedSync));
         }
         break;
         case ezCVarType::Bool:
         {
           ezCVarBool* pBool = (ezCVarBool*)pCVar;
-          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pBool->GetValue(ezCVarValue::Restart) ? "true" : "false");
+          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pBool->GetValue(ezCVarValue::DelayedSync) ? "true" : "false");
         }
         break;
         case ezCVarType::Float:
         {
           ezCVarFloat* pFloat = (ezCVarFloat*)pCVar;
-          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pFloat->GetValue(ezCVarValue::Restart));
+          sTemp.SetFormat("{0} = {1}\n", pCVar->GetName(), pFloat->GetValue(ezCVarValue::DelayedSync));
         }
         break;
         case ezCVarType::String:
         {
           ezCVarString* pString = (ezCVarString*)pCVar;
-          sTemp.SetFormat("{0} = \"{1}\"\n", pCVar->GetName(), pString->GetValue(ezCVarValue::Restart));
+          sTemp.SetFormat("{0} = \"{1}\"\n", pCVar->GetName(), pString->GetValue(ezCVarValue::DelayedSync));
         }
         break;
         default:
@@ -453,7 +449,7 @@ void ezCVar::LoadCVarsFromFileInternal(ezStringView path, const ezDynamicArray<e
         }
 
         if (bSetAsCurrentValue)
-          pCVar->SetToRestartValue();
+          pCVar->SetToDelayedSyncValue();
       }
     }
   }
@@ -535,7 +531,7 @@ void ezCVar::LoadCVarsFromCommandLine(bool bOnlyNewOnes /*= true*/, bool bSetAsC
       }
 
       if (bSetAsCurrentValue)
-        pCVar->SetToRestartValue();
+        pCVar->SetToDelayedSyncValue();
     }
   }
 }

--- a/Code/Engine/Foundation/Configuration/Implementation/CVar_inl.h
+++ b/Code/Engine/Foundation/Configuration/Implementation/CVar_inl.h
@@ -25,19 +25,19 @@ ezCVarType::Enum ezTypedCVar<Type, CVarType>::GetType() const
 }
 
 template <typename Type, ezCVarType::Enum CVarType>
-void ezTypedCVar<Type, CVarType>::SetToRestartValue()
+void ezTypedCVar<Type, CVarType>::SetToDelayedSyncValue()
 {
-  if (m_Values[ezCVarValue::Current] == m_Values[ezCVarValue::Restart])
+  if (m_Values[ezCVarValue::Current] == m_Values[ezCVarValue::DelayedSync])
     return;
 
   // this will NOT trigger a 'restart value changed' event
-  m_Values[ezCVarValue::Current] = m_Values[ezCVarValue::Restart];
+  m_Values[ezCVarValue::Current] = m_Values[ezCVarValue::DelayedSync];
 
   ezCVarEvent e(this);
   e.m_EventType = ezCVarEvent::ValueChanged;
   m_CVarEvents.Broadcast(e);
 
-  // broadcast the same to the 'all cvars' event handlers
+  // broadcast the same to the 'all CVars' event handlers
   s_AllCVarEvents.Broadcast(e);
 }
 
@@ -52,12 +52,12 @@ void ezTypedCVar<Type, CVarType>::operator=(const Type& value)
 {
   ezCVarEvent e(this);
 
-  if (GetFlags().IsAnySet(ezCVarFlags::RequiresRestart))
+  if (GetFlags().IsAnySet(ezCVarFlags::RequiresDelayedSync))
   {
-    if (value == m_Values[ezCVarValue::Restart]) // no change
+    if (value == m_Values[ezCVarValue::DelayedSync]) // no change
       return;
 
-    e.m_EventType = ezCVarEvent::RestartValueChanged;
+    e.m_EventType = ezCVarEvent::DelayedSyncValueChanged;
   }
   else
   {
@@ -68,7 +68,7 @@ void ezTypedCVar<Type, CVarType>::operator=(const Type& value)
     e.m_EventType = ezCVarEvent::ValueChanged;
   }
 
-  m_Values[ezCVarValue::Restart] = value;
+  m_Values[ezCVarValue::DelayedSync] = value;
 
   m_CVarEvents.Broadcast(e);
 

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -38,7 +38,7 @@ ezCommandLineOptionString opt_Renderer("app", "-renderer", "The renderer impleme
 
 void ezGameApplication::Init_ConfigureAssetManagement()
 {
-  const ezStringBuilder sAssetRedirFile("AssetCache/", m_PlatformProfile.m_sName, ".ezAidlt");
+  const ezStringBuilder sAssetRedirFile("AssetCache/", m_PlatformProfile.GetConfigName(), ".ezAidlt");
 
   // which redirection table to search
   ezDataDirectory::FolderType::s_sRedirectionFile = sAssetRedirFile;

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -4,6 +4,7 @@
 #include <Core/ActorSystem/Actor.h>
 #include <Core/ActorSystem/ActorManager.h>
 #include <Core/ActorSystem/ActorPluginWindow.h>
+#include <Core/GameApplication/GameApplicationBase.h>
 #include <Core/GameState/GameStateWindow.h>
 #include <Core/Prefabs/PrefabResource.h>
 #include <Core/World/World.h>
@@ -22,6 +23,7 @@
 #include <RendererCore/Pipeline/RenderPipelineResource.h>
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererCore/Utils/CoreRenderProfile.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Device/SwapChain.h>
 
@@ -33,7 +35,6 @@ EZ_STATICLINK_FILE(GameEngine, GameEngine_GameState_Implementation_GameState);
 // clang-format on
 
 ezGameState::ezGameState() = default;
-
 ezGameState::~ezGameState() = default;
 
 void ezGameState::OnActivation(ezWorld* pWorld, const ezTransform* pStartPosition)
@@ -199,6 +200,7 @@ void ezGameState::SetupMainView(ezGALSwapChainHandle hSwapChain, ezSizeU32 viewp
     ezLog::Error("Main view is invalid, SetupMainView canceled.");
     return;
   }
+
   if (m_bXREnabled)
   {
     const ezXRConfig* pConfig = ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetTypeConfig<ezXRConfig>();
@@ -356,7 +358,8 @@ ezUniquePtr<ezWindow> ezGameState::CreateMainWindow()
   wndDesc.LoadFromDDL(sWndCfg).IgnoreResult();
 
   ezUniquePtr<ezGameStateWindow> pWindow = EZ_DEFAULT_NEW(ezGameStateWindow, wndDesc, [] {});
-  pWindow->ResetOnClickClose([this]() { this->RequestQuit(); });
+  pWindow->ResetOnClickClose([this]()
+    { this->RequestQuit(); });
   if (pWindow->GetInputDevice())
     pWindow->GetInputDevice()->SetMouseSpeed(ezVec2(0.002f));
 
@@ -365,9 +368,8 @@ ezUniquePtr<ezWindow> ezGameState::CreateMainWindow()
 
 ezUniquePtr<ezWindowOutputTargetGAL> ezGameState::CreateMainOutputTarget(ezWindow* pMainWindow)
 {
-  ezUniquePtr<ezWindowOutputTargetGAL> pOutput = EZ_DEFAULT_NEW(ezWindowOutputTargetGAL, [this](ezGALSwapChainHandle hSwapChain, ezSizeU32 size) {
-    SetupMainView(hSwapChain, size);
-  });
+  ezUniquePtr<ezWindowOutputTargetGAL> pOutput = EZ_DEFAULT_NEW(ezWindowOutputTargetGAL, [this](ezGALSwapChainHandle hSwapChain, ezSizeU32 size)
+    { SetupMainView(hSwapChain, size); });
 
   ezGALWindowSwapChainCreationDescription desc;
   desc.m_pWindow = pMainWindow;

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -46,7 +46,8 @@ EZ_END_SUBSYSTEM_DECLARATION;
 ezCVarBool cvar_RenderingShadowsShowPoolStats("Rendering.Shadows.ShowPoolStats", false, ezCVarFlags::Default, "Display same stats of the shadow pool");
 #endif
 
-/// NOTE: These are set up in ezGameState::SetupMainView from the ezCoreRenderProfileConfig
+/// NOTE: The default values for these are defined in ezCoreRenderProfileConfig
+///       but they can also be overwritten in custom game states at startup.
 EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingShadowsAtlasSize("Rendering.Shadows.AtlasSize", 4096, ezCVarFlags::RequiresDelayedSync, "The size of the shadow atlas texture.");
 EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingShadowsMaxShadowMapSize("Rendering.Shadows.MaxShadowMapSize", 1024, ezCVarFlags::RequiresDelayedSync, "The max shadow map size used.");
 EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingShadowsMinShadowMapSize("Rendering.Shadows.MinShadowMapSize", 64, ezCVarFlags::RequiresDelayedSync, "The min shadow map size used.");

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -748,12 +748,6 @@ void ezShadowPool::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 
   EZ_PROFILE_SCOPE("Shadow Pool Update");
 
-  if (cvar_RenderingShadowsAtlasSize.HasDelayedSyncValueChanged() || cvar_RenderingShadowsMinShadowMapSize.HasDelayedSyncValueChanged() || cvar_RenderingShadowsMaxShadowMapSize.HasDelayedSyncValueChanged() || s_uiLastConfigModification != ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter())
-  {
-    OnEngineShutdown();
-    OnEngineStartup();
-  }
-
   ezUInt32 uiDataIndex = ezRenderWorld::GetDataIndexForExtraction();
   auto& packedShadowData = s_pData->m_PackedShadowData[uiDataIndex];
   packedShadowData.SetCountUninitialized(s_pData->m_uiUsedPackedShadowData);
@@ -1031,6 +1025,12 @@ void ezShadowPool::OnRenderEvent(const ezRenderWorldRenderEvent& e)
 
   if (s_pData->m_hShadowAtlasTexture.IsInvalidated() || s_pData->m_hShadowDataBuffer.IsInvalidated())
     return;
+
+  if (cvar_RenderingShadowsAtlasSize.HasDelayedSyncValueChanged() || cvar_RenderingShadowsMinShadowMapSize.HasDelayedSyncValueChanged() || cvar_RenderingShadowsMaxShadowMapSize.HasDelayedSyncValueChanged() || s_uiLastConfigModification != ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter())
+  {
+    OnEngineShutdown();
+    OnEngineStartup();
+  }
 
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
   ezGALPass* pGALPass = pDevice->BeginPass("Shadow Atlas");

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -1,8 +1,10 @@
 #include <RendererCore/RendererCorePCH.h>
 
+#include <Core/GameApplication/GameApplicationBase.h>
 #include <Core/Graphics/Camera.h>
 #include <Foundation/Configuration/CVar.h>
 #include <Foundation/Configuration/Startup.h>
+#include <Foundation/Math/Math.h>
 #include <Foundation/Math/Rect.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <RendererCore/Debug/DebugRenderer.h>
@@ -12,6 +14,7 @@
 #include <RendererCore/Lights/SpotLightComponent.h>
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererCore/Utils/CoreRenderProfile.h>
 #include <RendererFoundation/CommandEncoder/RenderCommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Device/Pass.h>
@@ -21,35 +24,36 @@
 
 // clang-format off
 EZ_BEGIN_SUBSYSTEM_DECLARATION(RendererCore, ShadowPool)
-BEGIN_SUBSYSTEM_DEPENDENCIES
-"Foundation",
-"Core",
-"RenderWorld"
-END_SUBSYSTEM_DEPENDENCIES
+  BEGIN_SUBSYSTEM_DEPENDENCIES
+    "Foundation",
+    "Core",
+    "RenderWorld"
+  END_SUBSYSTEM_DEPENDENCIES
 
-ON_HIGHLEVELSYSTEMS_STARTUP
-{
-  ezShadowPool::OnEngineStartup();
-}
+  ON_HIGHLEVELSYSTEMS_STARTUP
+  {
+    ezShadowPool::OnEngineStartup();
+  }
 
-ON_HIGHLEVELSYSTEMS_SHUTDOWN
-{
-  ezShadowPool::OnEngineShutdown();
-}
-
+  ON_HIGHLEVELSYSTEMS_SHUTDOWN
+  {
+    ezShadowPool::OnEngineShutdown();
+  }
 EZ_END_SUBSYSTEM_DECLARATION;
-  // clang-format on
+// clang-format on
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
 ezCVarBool cvar_RenderingShadowsShowPoolStats("Rendering.Shadows.ShowPoolStats", false, ezCVarFlags::Default, "Display same stats of the shadow pool");
 #endif
 
-static ezUInt32 s_uiShadowAtlasTextureWidth = 4096; ///\todo make this configurable
-static ezUInt32 s_uiShadowAtlasTextureHeight = 4096;
-static ezUInt32 s_uiShadowMapSize = 1024;
-static ezUInt32 s_uiMinShadowMapSize = 64;
-static float s_fFadeOutScaleStart = (s_uiMinShadowMapSize + 1.0f) / s_uiShadowMapSize;
-static float s_fFadeOutScaleEnd = s_fFadeOutScaleStart * 0.5f;
+/// NOTE: These are set up in ezGameState::SetupMainView from the ezCoreRenderProfileConfig
+EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingShadowsAtlasSize("Rendering.Shadows.AtlasSize", 4096, ezCVarFlags::RequiresDelayedSync, "The size of the shadow atlas texture.");
+EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingShadowsMaxShadowMapSize("Rendering.Shadows.MaxShadowMapSize", 1024, ezCVarFlags::RequiresDelayedSync, "The max shadow map size used.");
+EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingShadowsMinShadowMapSize("Rendering.Shadows.MinShadowMapSize", 64, ezCVarFlags::RequiresDelayedSync, "The min shadow map size used.");
+
+static ezUInt32 s_uiLastConfigModification = 0;
+static float s_fFadeOutScaleStart = 0.0f;
+static float s_fFadeOutScaleEnd = 0.0f;
 
 struct ShadowView
 {
@@ -256,10 +260,58 @@ struct ezShadowPool::Data
   {
     if (m_hShadowAtlasTexture.IsInvalidated())
     {
+      // use the current CVar values to initialize the values
+      ezUInt32 uiAtlas = cvar_RenderingShadowsAtlasSize;
+      ezUInt32 uiMax = cvar_RenderingShadowsMaxShadowMapSize;
+      ezUInt32 uiMin = cvar_RenderingShadowsMinShadowMapSize;
+
+      // if the platform profile has changed, use it to reset the defaults
+      if (s_uiLastConfigModification != ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter())
+      {
+        s_uiLastConfigModification = ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter();
+
+        const auto* pConfig = ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetTypeConfig<ezCoreRenderProfileConfig>();
+
+        uiAtlas = pConfig->m_uiShadowAtlasTextureSize;
+        uiMax = pConfig->m_uiMaxShadowMapSize;
+        uiMin = pConfig->m_uiMinShadowMapSize;
+      }
+
+      // if the CVars were modified recently (e.g. during game startup), use those values to override the default
+      if (cvar_RenderingShadowsAtlasSize.HasDelayedSyncValueChanged())
+        uiAtlas = cvar_RenderingShadowsAtlasSize.GetValue(ezCVarValue::DelayedSync);
+
+      if (cvar_RenderingShadowsMaxShadowMapSize.HasDelayedSyncValueChanged())
+        uiMax = cvar_RenderingShadowsMaxShadowMapSize.GetValue(ezCVarValue::DelayedSync);
+
+      if (cvar_RenderingShadowsMinShadowMapSize.HasDelayedSyncValueChanged())
+        uiMin = cvar_RenderingShadowsMinShadowMapSize.GetValue(ezCVarValue::DelayedSync);
+
+      // make sure the values are valid
+      uiAtlas = ezMath::Clamp(ezMath::PowerOfTwo_Floor(uiAtlas), 512u, 8192u);
+      uiMax = ezMath::Clamp(ezMath::PowerOfTwo_Floor(uiMax), 64u, 2048u);
+      uiMin = ezMath::Clamp(ezMath::PowerOfTwo_Floor(uiMin), 8u, 512u);
+
+      uiMax = ezMath::Min(uiMax, uiAtlas);
+      uiMin = ezMath::Min(uiMin, uiMax);
+
+      // write back the clamped values, so that everyone sees the valid values
+      cvar_RenderingShadowsAtlasSize = uiAtlas;
+      cvar_RenderingShadowsMaxShadowMapSize = uiMax;
+      cvar_RenderingShadowsMinShadowMapSize = uiMin;
+
+      // apply the new values
+      cvar_RenderingShadowsAtlasSize.SetToDelayedSyncValue();
+      cvar_RenderingShadowsMaxShadowMapSize.SetToDelayedSyncValue();
+      cvar_RenderingShadowsMinShadowMapSize.SetToDelayedSyncValue();
+
       ezGALTextureCreationDescription desc;
-      desc.SetAsRenderTarget(s_uiShadowAtlasTextureWidth, s_uiShadowAtlasTextureHeight, ezGALResourceFormat::D16);
+      desc.SetAsRenderTarget(cvar_RenderingShadowsAtlasSize, cvar_RenderingShadowsAtlasSize, ezGALResourceFormat::D16);
 
       m_hShadowAtlasTexture = ezGALDevice::GetDefaultDevice()->CreateTexture(desc);
+
+      s_fFadeOutScaleStart = (cvar_RenderingShadowsMinShadowMapSize + 1.0f) / cvar_RenderingShadowsMaxShadowMapSize;
+      s_fFadeOutScaleEnd = s_fFadeOutScaleStart * 0.5f;
     }
   }
 
@@ -408,7 +460,7 @@ ezUInt32 ezShadowPool::AddDirectionalLight(const ezDirectionalLightComponent* pD
   }
 
   float fMaxReferenceSize = ezMath::Max(pReferenceView->GetViewport().width, pReferenceView->GetViewport().height);
-  float fShadowMapScale = fMaxReferenceSize / s_uiShadowMapSize;
+  float fShadowMapScale = fMaxReferenceSize / cvar_RenderingShadowsMaxShadowMapSize;
 
   ShadowData* pData = nullptr;
   if (s_pData->GetDataForExtraction(pDirLight, pReferenceView, fShadowMapScale, sizeof(ezDirShadowData), pData))
@@ -513,7 +565,7 @@ ezUInt32 ezShadowPool::AddDirectionalLight(const ezDirectionalLightComponent* pD
       // stabilize
       ezMat4 worldToLightMatrix = pView->GetViewMatrix(ezCameraEye::Left);
       ezVec3 offset = worldToLightMatrix.TransformPosition(ezVec3::MakeZero());
-      float texelInWorld = (2.0f * radius) / s_uiShadowMapSize;
+      float texelInWorld = (2.0f * radius) / cvar_RenderingShadowsMaxShadowMapSize;
       offset.x -= ezMath::Floor(offset.x / texelInWorld) * texelInWorld;
       offset.y -= ezMath::Floor(offset.y / texelInWorld) * texelInWorld;
 
@@ -567,7 +619,7 @@ ezUInt32 ezShadowPool::AddPointLight(const ezPointLightComponent* pPointLight, f
   ezVec3 vPosition = pOwner->GetGlobalPosition();
   ezVec3 vUp = ezVec3(0.0f, 0.0f, 1.0f);
 
-  float fPenumbraSize = ezMath::Max(pPointLight->GetPenumbraSize(), (0.5f / s_uiMinShadowMapSize)); // at least one texel for hardware pcf
+  float fPenumbraSize = ezMath::Max(pPointLight->GetPenumbraSize(), (0.5f / cvar_RenderingShadowsMinShadowMapSize)); // at least one texel for hardware pcf
   float fFov = AddSafeBorder(ezAngle::MakeFromDegree(90.0f), fPenumbraSize);
 
   float fNearPlane = 0.1f; ///\todo expose somewhere
@@ -696,6 +748,12 @@ void ezShadowPool::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 
   EZ_PROFILE_SCOPE("Shadow Pool Update");
 
+  if (cvar_RenderingShadowsAtlasSize.HasDelayedSyncValueChanged() || cvar_RenderingShadowsMinShadowMapSize.HasDelayedSyncValueChanged() || cvar_RenderingShadowsMaxShadowMapSize.HasDelayedSyncValueChanged() || s_uiLastConfigModification != ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter())
+  {
+    OnEngineShutdown();
+    OnEngineStartup();
+  }
+
   ezUInt32 uiDataIndex = ezRenderWorld::GetDataIndexForExtraction();
   auto& packedShadowData = s_pData->m_PackedShadowData[uiDataIndex];
   packedShadowData.SetCountUninitialized(s_pData->m_uiUsedPackedShadowData);
@@ -719,13 +777,13 @@ void ezShadowPool::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 
   // Prepare atlas
   s_AtlasCells.Clear();
-  s_AtlasCells.ExpandAndGetRef().m_Rect = ezRectU32(0, 0, s_uiShadowAtlasTextureWidth, s_uiShadowAtlasTextureHeight);
+  s_AtlasCells.ExpandAndGetRef().m_Rect = ezRectU32(0, 0, cvar_RenderingShadowsAtlasSize, cvar_RenderingShadowsAtlasSize);
 
-  float fAtlasInvWidth = 1.0f / s_uiShadowAtlasTextureWidth;
-  float fAtlasInvHeight = 1.0f / s_uiShadowAtlasTextureWidth;
+  float fAtlasInvWidth = 1.0f / cvar_RenderingShadowsAtlasSize;
+  float fAtlasInvHeight = 1.0f / cvar_RenderingShadowsAtlasSize;
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-  ezUInt32 uiTotalAtlasSize = s_uiShadowAtlasTextureWidth * s_uiShadowAtlasTextureHeight;
+  ezUInt32 uiTotalAtlasSize = cvar_RenderingShadowsAtlasSize * cvar_RenderingShadowsAtlasSize;
   ezUInt32 uiUsedAtlasSize = 0;
 
   ezDebugRendererContext debugContext(ezWorld::GetWorld(0));
@@ -747,7 +805,7 @@ void ezShadowPool::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
     ezUInt32 uiShadowDataIndex = sorted.m_uiIndex;
     auto& shadowData = s_pData->m_ShadowData[uiShadowDataIndex];
 
-    ezUInt32 uiShadowMapSize = s_uiShadowMapSize;
+    ezUInt32 uiShadowMapSize = cvar_RenderingShadowsMaxShadowMapSize;
     float fadeOutStart = s_fFadeOutScaleStart;
     float fadeOutEnd = s_fFadeOutScaleEnd;
 
@@ -943,7 +1001,7 @@ void ezShadowPool::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
       float relativeShadowSize = uiShadowMapSize * fAtlasInvHeight;
 
       float slopeBias = shadowData.m_fSlopeBias * penumbraSize * ezMath::Tan(fov * 0.5f);
-      float constantBias = shadowData.m_fConstantBias * s_uiShadowMapSize / uiShadowMapSize;
+      float constantBias = shadowData.m_fConstantBias * cvar_RenderingShadowsMaxShadowMapSize / uiShadowMapSize;
       float fadeOut = ezMath::Clamp((shadowData.m_fShadowMapScale - fadeOutEnd) / (fadeOutStart - fadeOutEnd), 0.0f, 1.0f);
 
       ezUInt32 uiParamsIndex = GET_SHADOW_PARAMS_INDEX(shadowData.m_uiPackedDataOffset);

--- a/Code/Engine/RendererCore/Utils/CoreRenderProfile.h
+++ b/Code/Engine/RendererCore/Utils/CoreRenderProfile.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Core/Configuration/PlatformProfile.h>
+#include <Foundation/Configuration/CVar.h>
+#include <RendererCore/RendererCoreDLL.h>
+
+class EZ_RENDERERCORE_DLL ezCoreRenderProfileConfig : public ezProfileConfigData
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezCoreRenderProfileConfig, ezProfileConfigData);
+
+public:
+  virtual void SaveRuntimeData(ezChunkStreamWriter& inout_stream) const override;
+  virtual void LoadRuntimeData(ezChunkStreamReader& inout_stream) override;
+
+  ezUInt32 m_uiShadowAtlasTextureSize = 4096;
+  ezUInt32 m_uiMaxShadowMapSize = 1024;
+  ezUInt32 m_uiMinShadowMapSize = 64;
+};
+
+EZ_RENDERERCORE_DLL extern ezCVarInt cvar_RenderingShadowsAtlasSize;
+EZ_RENDERERCORE_DLL extern ezCVarInt cvar_RenderingShadowsMaxShadowMapSize;
+EZ_RENDERERCORE_DLL extern ezCVarInt cvar_RenderingShadowsMinShadowMapSize;

--- a/Code/Engine/RendererCore/Utils/Implementation/CoreRenderProfile.cpp
+++ b/Code/Engine/RendererCore/Utils/Implementation/CoreRenderProfile.cpp
@@ -1,0 +1,41 @@
+#include <RendererCore/RendererCorePCH.h>
+
+#include <Foundation/IO/ChunkStream.h>
+#include <RendererCore/Utils/CoreRenderProfile.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCoreRenderProfileConfig, 1, ezRTTIDefaultAllocator<ezCoreRenderProfileConfig>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("ShadowAtlasTextureSize", m_uiShadowAtlasTextureSize)->AddAttributes(new ezDefaultValueAttribute(4096), new ezClampValueAttribute(512, 8192)),
+    EZ_MEMBER_PROPERTY("MaxShadowMapSize", m_uiMaxShadowMapSize)->AddAttributes(new ezDefaultValueAttribute(1024), new ezClampValueAttribute(64, 4096)),
+    EZ_MEMBER_PROPERTY("MinShadowMapSize", m_uiMinShadowMapSize)->AddAttributes(new ezDefaultValueAttribute(64), new ezClampValueAttribute(8, 512)),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+void ezCoreRenderProfileConfig::SaveRuntimeData(ezChunkStreamWriter& inout_stream) const
+{
+  inout_stream.BeginChunk("ezCoreRenderProfileConfig", 1);
+
+  inout_stream << m_uiShadowAtlasTextureSize;
+  inout_stream << m_uiMaxShadowMapSize;
+  inout_stream << m_uiMinShadowMapSize;
+
+  inout_stream.EndChunk();
+}
+
+void ezCoreRenderProfileConfig::LoadRuntimeData(ezChunkStreamReader& inout_stream)
+{
+  const auto& chunk = inout_stream.GetCurrentChunk();
+
+  if (chunk.m_sChunkName == "ezCoreRenderProfileConfig" && chunk.m_uiChunkVersion >= 1)
+  {
+    inout_stream >> m_uiShadowAtlasTextureSize;
+    inout_stream >> m_uiMaxShadowMapSize;
+    inout_stream >> m_uiMinShadowMapSize;
+  }
+}

--- a/Code/UnitTests/FoundationTest/Configuration/CVarsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Configuration/CVarsTest.cpp
@@ -9,7 +9,7 @@ EZ_CREATE_SIMPLE_TEST_GROUP(Configuration);
 
 #define ezCVarValueDefault ezCVarValue::Default
 #define ezCVarValueStored ezCVarValue::Stored
-#define ezCVarValueRestart ezCVarValue::Restart
+#define ezCVarValueRestart ezCVarValue::DelayedSync
 
 // Interestingly using 'ezCVarValue::Default' directly inside a macro does not work. (?!)
 #define CHECK_CVAR(var, Current, Default, Stored, Restart)      \
@@ -34,7 +34,7 @@ static void ChangedCVar(const ezCVarEvent& e)
     case ezCVarEvent::ValueChanged:
       ++iChangedValue;
       break;
-    case ezCVarEvent::RestartValueChanged:
+    case ezCVarEvent::DelayedSyncValueChanged:
       ++iChangedRestart;
       break;
     default:
@@ -347,7 +347,7 @@ EZ_CREATE_SIMPLE_TEST(Configuration, CVars)
         EZ_TEST_INT(iChangedValue, 1);
         EZ_TEST_INT(iChangedRestart, 1);
 
-        pFloat->SetToRestartValue();
+        pFloat->SetToDelayedSyncValue();
         CHECK_CVAR(pFloat, 1.2f, 1.1f, 1.1f, 1.2f);
 
         EZ_TEST_INT(iChangedValue, 2);
@@ -422,7 +422,7 @@ EZ_CREATE_SIMPLE_TEST(Configuration, CVars)
         *pString = "test2_value2";
         CHECK_CVAR(pString, "test2", "test2", "test2", "test2_value2");
 
-        pString->SetToRestartValue();
+        pString->SetToDelayedSyncValue();
         CHECK_CVAR(pString, "test2_value2", "test2", "test2", "test2_value2");
       }
     }

--- a/Data/Base/Editor/AssetProfiles.ddl
+++ b/Data/Base/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/Samples/Testing Chambers/Editor/AssetProfiles.ddl
+++ b/Data/Samples/Testing Chambers/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -38,23 +62,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -166,9 +166,11 @@ Selection.Attach;Attach to This
 Selection.Detach;Detach
 Selection.CopyReference;Copy Object Reference
 
-ezRenderPipelineProfileConfig;Render Pipelines
+# Profile Configs
 
+ezRenderPipelineProfileConfig;Render Pipelines
 ezTextureAssetProfileConfig;Texture Assets
+ezCoreRenderProfileConfig;Rendering Options
 
 # Gizmo
 

--- a/Data/UnitTests/GameEngineTest/Animations/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/Animations/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/Basics/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/Basics/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/Effects/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/Effects/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/Particles/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/Particles/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/PlatformWin/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/PlatformWin/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/StateMachine/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/StateMachine/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/TypeScript/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/TypeScript/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/VisualScript/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/VisualScript/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{false}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{false}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/Data/UnitTests/GameEngineTest/XR/Editor/AssetProfiles.ddl
+++ b/Data/UnitTests/GameEngineTest/XR/Editor/AssetProfiles.ddl
@@ -17,6 +17,7 @@ AssetProfiles
 						Uuid{uint64{11754538365307859884,8572204067211736280}}
 						Uuid{uint64{18165925277888737543,17003377905246685588}}
 						Uuid{uint64{10688866045028468411,17021851764261564183}}
+						Uuid{uint64{12803743945353238805,11270308862817989453}}
 					}
 					string %Name{"PC"}
 					string %Platform{"ezProfileTargetPlatform::PC"}
@@ -25,6 +26,29 @@ AssetProfiles
 			o
 			{
 				Uuid %id{uint64{11754538365307859884,8572204067211736280}}
+				string %t{"ezCoreRenderProfileConfig"}
+				uint32 %v{1}
+				p
+				{
+					uint32 %MaxShadowMapSize{1024}
+					uint32 %MinShadowMapSize{64}
+					uint32 %ShadowAtlasTextureSize{4096}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{12803743945353238805,11270308862817989453}}
+				string %t{"ezXRConfig"}
+				uint32 %v{2}
+				p
+				{
+					bool %EnableXR{true}
+					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
+				}
+			}
+			o
+			{
+				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
 				string %t{"ezRenderPipelineProfileConfig"}
 				uint32 %v{1}
 				p
@@ -35,23 +59,12 @@ AssetProfiles
 			}
 			o
 			{
-				Uuid %id{uint64{18165925277888737543,17003377905246685588}}
+				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
 				string %t{"ezTextureAssetProfileConfig"}
 				uint32 %v{1}
 				p
 				{
 					uint16 %MaxResolution{16384}
-				}
-			}
-			o
-			{
-				Uuid %id{uint64{10688866045028468411,17021851764261564183}}
-				string %t{"ezXRConfig"}
-				uint32 %v{2}
-				p
-				{
-					bool %EnableXR{true}
-					string %XRRenderPipeline{"{ 2fe25ded-776c-7f9e-354f-e4c52a33d125 }"}
 				}
 			}
 		}

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: 43C0D99A-E366-4CAA-BE97-6C3F7ECED52E
+Change me: D16371FD-C27A-46FB-AF82-AB1EFAF0540B


### PR DESCRIPTION
* Added CVars for shadow map settings. Means you can edit the values at runtime.
* Added a platform config which allows to set the default values.