### PR TITLE
Implemented codepath for inverted normalmaps

### DIFF
--- a/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
@@ -76,6 +76,8 @@ ezResult ezTexConvProcessor::Process()
     {
       EZ_SUCCEED_OR_RETURN(Assemble2DTexture(m_Descriptor.m_InputImages[0].GetHeader(), assembledImg));
 
+      EZ_SUCCEED_OR_RETURN(InvertNormalMap(assembledImg));
+
       EZ_SUCCEED_OR_RETURN(DilateColor2D(assembledImg));
     }
     else if (m_Descriptor.m_OutputType == ezTexConvOutputType::Cubemap)

--- a/Code/Engine/Texture/TexConv/Implementation/TextureModifications.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/TextureModifications.cpp
@@ -429,4 +429,19 @@ ezResult ezTexConvProcessor::DilateColor2D(ezImage& img) const
   return EZ_SUCCESS;
 }
 
+ezResult ezTexConvProcessor::InvertNormalMap(ezImage& image)
+{
+  if (m_Descriptor.m_Usage != ezTexConvUsage::NormalMap_Inverted)
+    return EZ_SUCCESS;
 
+  // we'll assume that at this point in the processing pipeline, the format is
+  // RGBA32F which should result in tightly packed mipmaps.
+  EZ_ASSERT_DEV(image.GetImageFormat() == ezImageFormat::R32G32B32A32_FLOAT && image.GetRowPitch() % sizeof(float[4]) == 0, "");
+
+  for (auto& value : image.GetBlobPtr<ezColor>())
+  {
+    value.g = 1.0f - value.g;
+  }
+
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/Texture/TexConv/TexConvProcessor.h
+++ b/Code/Engine/Texture/TexConv/TexConvProcessor.h
@@ -34,6 +34,7 @@ private:
   ezResult ClampInputValues(ezArrayPtr<ezImage> images, float maxValue) const;
   ezResult ClampInputValues(ezImage& image, float maxValue) const;
   ezResult DetectNumChannels(ezArrayPtr<const ezTexConvSliceChannelMapping> channelMapping, ezUInt32& uiNumChannels);
+  ezResult InvertNormalMap(ezImage& img);
 
   //////////////////////////////////////////////////////////////////////////
   // Reading from the descriptor

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: 43C0D99A-E366-4CAA-BE97-6C1F7ECED52E
+Change me: 43C0D99A-E366-4CAA-BE97-6C3F7ECED52E


### PR DESCRIPTION
This was already exposed in the UI, but forgotten to be implemented.
Flips the green channel, to make it possible to use normalmaps generated with DX vs OpenGL conventions:

![image](https://github.com/ezEngine/ezEngine/assets/6001174/b604d6be-fd3c-4534-b804-aeddce957337)

