### PR TITLE
Fixed #1163: Import all animation clips from one asset as separate documents

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserDlg.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserDlg.moc.h
@@ -4,12 +4,12 @@
 #include <EditorFramework/ui_AssetBrowserDlg.h>
 #include <QDialog>
 
-class ezQtAssetBrowserDlg : public QDialog, public Ui_AssetBrowserDlg
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserDlg : public QDialog, public Ui_AssetBrowserDlg
 {
   Q_OBJECT
 
 public:
-  ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& preselectedAsset, ezStringView sVisibleFilters);
+  ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& preselectedAsset, ezStringView sVisibleFilters, ezStringView sWindowTitle = {});
   ezQtAssetBrowserDlg(QWidget* pParent, ezStringView sWindowTitle, ezStringView sPreselectedFileAbs, ezStringView sFileExtensions);
   ~ezQtAssetBrowserDlg();
 
@@ -38,4 +38,3 @@ private:
   static ezMap<ezString, ezString> s_PathFilter;
   static ezMap<ezString, ezString> s_TypeFilter;
 };
-

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
@@ -66,7 +66,7 @@ public:
   virtual ezStringView GetGeneratorGroup() const = 0;
 
   /// \brief Tells the generator to create a new asset document with the chosen mode.
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) = 0;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) = 0;
 
   /// \brief Returns whether this generator supports the given file type for import.
   bool SupportsFileType(ezStringView sFile) const;

--- a/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentGenerator.h
@@ -66,7 +66,7 @@ public:
   virtual ezStringView GetGeneratorGroup() const = 0;
 
   /// \brief Tells the generator to create a new asset document with the chosen mode.
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) = 0;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) = 0;
 
   /// \brief Returns whether this generator supports the given file type for import.
   bool SupportsFileType(ezStringView sFile) const;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserDlg.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserDlg.cpp
@@ -42,7 +42,7 @@ void ezQtAssetBrowserDlg::Init(QWidget* pParent)
     AssetBrowserWidget->GetAssetBrowserFilter()->SetTypeFilter(s_TypeFilter[m_sVisibleFilters]);
 }
 
-ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& preselectedAsset, ezStringView sVisibleFilters)
+ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& preselectedAsset, ezStringView sVisibleFilters, ezStringView sWindowTitle)
   : QDialog(pParent)
 {
   {
@@ -77,6 +77,11 @@ ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, const ezUuid& presele
   AssetBrowserWidget->SetSelectedAsset(preselectedAsset);
 
   AssetBrowserWidget->SearchWidget->setFocus();
+
+  if (!sWindowTitle.IsEmpty())
+  {
+    setWindowTitle(ezMakeQString(sWindowTitle));
+  }
 }
 
 ezQtAssetBrowserDlg::ezQtAssetBrowserDlg(QWidget* pParent, ezStringView sWindowTitle, ezStringView sPreselectedFileAbs, ezStringView sFileExtensions)

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentGenerator.cpp
@@ -261,19 +261,20 @@ ezStatus ezAssetDocumentGenerator::Import(ezStringView sInputFileAbs, ezStringVi
   if (!m_SupportedFileTypes.Contains(ext))
     return ezStatus(ezFmt("Files of type '{}' cannot be imported as '{}' documents.", ext, GetDocumentExtension()));
 
-  ezDocument* pGeneratedDoc = nullptr;
-  EZ_SUCCEED_OR_RETURN(Generate(sInputFileAbs, sMode, pGeneratedDoc));
+  ezHybridArray<ezDocument*, 16> pGeneratedDocs;
+  EZ_SUCCEED_OR_RETURN(Generate(sInputFileAbs, sMode, pGeneratedDocs));
 
-  EZ_ASSERT_DEV(pGeneratedDoc != nullptr, "");
-
-  const ezString sDocPath = pGeneratedDoc->GetDocumentPath();
-
-  pGeneratedDoc->SaveDocument(true).LogFailure();
-  pGeneratedDoc->GetDocumentManager()->CloseDocument(pGeneratedDoc);
-
-  if (bOpenDocument)
+  for (ezDocument* pDoc : pGeneratedDocs)
   {
-    ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sDocPath);
+    const ezString sDocPath = pDoc->GetDocumentPath();
+
+    pDoc->SaveDocument(true).LogFailure();
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+
+    if (bOpenDocument)
+    {
+      ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sDocPath);
+    }
   }
 
   return ezStatus(EZ_SUCCESS);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -145,7 +145,7 @@ void ezAnimatedMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInput
   }
 }
 
-ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -160,7 +160,7 @@ ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileA
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezAnimatedMeshAssetDocument* pAssetDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -145,7 +145,7 @@ void ezAnimatedMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInput
   }
 }
 
-ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -156,11 +156,13 @@ ezStatus ezAnimatedMeshAssetDocumentGenerator::Generate(ezStringView sInputFileA
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezAnimatedMeshAssetDocument* pAssetDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezAnimatedMeshAssetDocument* pAssetDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(pDoc);
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
   accessor.SetValue("MeshFile", sInputFileRel.GetView());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
@@ -37,5 +37,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimatedMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Meshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
@@ -37,5 +37,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimatedMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Meshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -378,7 +378,7 @@ void ezAnimationClipAssetDocumentGenerator::GetImportModes(ezStringView sAbsInpu
   }
 }
 
-ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -409,7 +409,7 @@ ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFile
     if (pDoc == nullptr)
       return ezStatus("Could not create target document");
 
-    out_pGeneratedDocuments.PushBack(pDoc);
+    out_generatedDocuments.PushBack(pDoc);
 
     ezAnimationClipAssetDocument* pAssetDoc = ezDynamicCast<ezAnimationClipAssetDocument*>(pDoc);
 
@@ -449,7 +449,7 @@ ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFile
       if (pDoc == nullptr)
         return ezStatus("Could not create target document");
 
-      out_pGeneratedDocuments.PushBack(pDoc);
+      out_generatedDocuments.PushBack(pDoc);
 
       ezAnimationClipAssetDocument* pAssetDoc = ezDynamicCast<ezAnimationClipAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -1,5 +1,6 @@
 #include <EditorPluginAssets/EditorPluginAssetsPCH.h>
 
+#include <EditorFramework/Assets/AssetBrowserDlg.moc.h>
 #include <EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h>
 #include <Foundation/Utilities/Progress.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
@@ -365,12 +366,19 @@ void ezAnimationClipAssetDocumentGenerator::GetImportModes(ezStringView sAbsInpu
   {
     ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
     info.m_Priority = ezAssetDocGeneratorPriority::Undecided;
-    info.m_sName = "AnimationClipImport";
+    info.m_sName = "AnimationClipImport_Single";
+    info.m_sIcon = ":/AssetIcons/Animation_Clip.svg";
+  }
+
+  {
+    ezAssetDocumentGenerator::ImportMode& info = out_modes.ExpandAndGetRef();
+    info.m_Priority = ezAssetDocGeneratorPriority::Undecided;
+    info.m_sName = "AnimationClipImport_All";
     info.m_sIcon = ":/AssetIcons/Animation_Clip.svg";
   }
 }
 
-ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -381,14 +389,79 @@ ezStatus ezAnimationClipAssetDocumentGenerator::Generate(ezStringView sInputFile
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
-    return ezStatus("Could not create target document");
+  ezStringBuilder title;
+  title.SetFormat("Select Preview Mesh for Animation Clip '{}'", sInputFileAbs.GetFileName());
 
-  ezAnimationClipAssetDocument* pAssetDoc = ezDynamicCast<ezAnimationClipAssetDocument*>(out_pGeneratedDocument);
+  ezStringBuilder sPreviewMesh;
 
-  auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
-  accessor.SetValue("File", sInputFileRel.GetView());
+  ezQtAssetBrowserDlg dlg(nullptr, ezUuid::MakeInvalid(), "CompatibleAsset_Mesh_Skinned", title);
+  if (dlg.exec() != 0)
+  {
+    if (dlg.GetSelectedAssetGuid().IsValid())
+    {
+      ezConversionUtils::ToString(dlg.GetSelectedAssetGuid(), sPreviewMesh);
+    }
+  }
 
-  return ezStatus(EZ_SUCCESS);
+  if (sMode == "AnimationClipImport_Single")
+  {
+    ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+    if (pDoc == nullptr)
+      return ezStatus("Could not create target document");
+
+    out_pGeneratedDocuments.PushBack(pDoc);
+
+    ezAnimationClipAssetDocument* pAssetDoc = ezDynamicCast<ezAnimationClipAssetDocument*>(pDoc);
+
+    auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
+    accessor.SetValue("File", sInputFileRel.GetView());
+    accessor.SetValue("PreviewMesh", sPreviewMesh.GetView());
+
+    return ezStatus(EZ_SUCCESS);
+  }
+
+  if (sMode == "AnimationClipImport_All")
+  {
+    ezModelImporter2::ImportOptions opt;
+    opt.m_sSourceFile = sInputFileAbs;
+
+    ezUniquePtr<ezModelImporter2::Importer> pImporter = ezModelImporter2::RequestImporterForFileType(opt.m_sSourceFile);
+    if (pImporter == nullptr)
+      return ezStatus("No known importer for this file type.");
+
+    if (pImporter->Import(opt).Failed())
+      return ezStatus("Failed to import asset.");
+
+    ezStringBuilder sFilename;
+    ezStringBuilder sOutFile2;
+
+    for (const auto& clip : pImporter->m_OutputAnimationNames)
+    {
+      sFilename = clip;
+      sFilename.ReplaceAll(" ", "-");
+      sFilename.Prepend(sOutFile.GetFileName(), "_");
+
+      sOutFile2 = sOutFile;
+      sOutFile2.ChangeFileName(sFilename);
+      ezOSFile::FindFreeFilename(sOutFile2);
+
+      ezDocument* pDoc = pApp->CreateDocument(sOutFile2, ezDocumentFlags::None);
+      if (pDoc == nullptr)
+        return ezStatus("Could not create target document");
+
+      out_pGeneratedDocuments.PushBack(pDoc);
+
+      ezAnimationClipAssetDocument* pAssetDoc = ezDynamicCast<ezAnimationClipAssetDocument*>(pDoc);
+
+      auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
+      accessor.SetValue("File", sInputFileRel.GetView());
+      accessor.SetValue("UseAnimationClip", clip);
+      accessor.SetValue("PreviewMesh", sPreviewMesh.GetView());
+    }
+
+    return ezStatus(EZ_SUCCESS);
+  }
+
+  EZ_ASSERT_NOT_IMPLEMENTED;
+  return ezStatus(EZ_FAILURE);
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -86,5 +86,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimationClipAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "AnimationClipGroup"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -86,5 +86,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimationClipAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "AnimationClipGroup"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -188,7 +188,7 @@ void ezDecalAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, e
   }
 }
 
-ezStatus ezDecalAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezDecalAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -199,12 +199,13 @@ ezStatus ezDecalAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezS
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezDecalAssetDocument* pAssetDoc = ezDynamicCast<ezDecalAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezDecalAssetDocument* pAssetDoc = ezDynamicCast<ezDecalAssetDocument*>(pDoc);
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
   accessor.SetValue("BaseColor", sInputFileRel.GetView());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -188,7 +188,7 @@ void ezDecalAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, e
   }
 }
 
-ezStatus ezDecalAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezDecalAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -203,7 +203,7 @@ ezStatus ezDecalAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezS
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezDecalAssetDocument* pAssetDoc = ezDynamicCast<ezDecalAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
@@ -76,5 +76,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezDecalAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.h
@@ -76,5 +76,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezDecalAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.cpp
@@ -121,7 +121,7 @@ void ezLUTAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezD
   info.m_sIcon = ":/AssetIcons/LUT.svg";
 }
 
-ezStatus ezLUTAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezLUTAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -132,11 +132,13 @@ ezStatus ezLUTAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStr
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezLUTAssetDocument* pAssetDoc = ezDynamicCast<ezLUTAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezLUTAssetDocument* pAssetDoc = ezDynamicCast<ezLUTAssetDocument*>(pDoc);
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
   accessor.SetValue("Input", sInputFileRel.GetView());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.cpp
@@ -121,7 +121,7 @@ void ezLUTAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ezD
   info.m_sIcon = ":/AssetIcons/LUT.svg";
 }
 
-ezStatus ezLUTAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezLUTAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -136,7 +136,7 @@ ezStatus ezLUTAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStr
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezLUTAssetDocument* pAssetDoc = ezDynamicCast<ezLUTAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
@@ -36,5 +36,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezLUTAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "LUTs"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAsset.h
@@ -36,5 +36,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezLUTAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "LUTs"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -314,7 +314,7 @@ void ezMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ez
   }
 }
 
-ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -325,11 +325,13 @@ ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezSt
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezMeshAssetDocument* pAssetDoc = ezDynamicCast<ezMeshAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezMeshAssetDocument* pAssetDoc = ezDynamicCast<ezMeshAssetDocument*>(pDoc);
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
   accessor.SetValue("MeshFile", sInputFileRel.GetView());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -314,7 +314,7 @@ void ezMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile, ez
   }
 }
 
-ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -329,7 +329,7 @@ ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezSt
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezMeshAssetDocument* pAssetDoc = ezDynamicCast<ezMeshAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -39,5 +39,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Meshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -39,5 +39,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Meshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -445,7 +445,7 @@ void ezSkeletonAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile
   }
 }
 
-ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -456,11 +456,13 @@ ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, 
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezSkeletonAssetDocument* pAssetDoc = ezDynamicCast<ezSkeletonAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezSkeletonAssetDocument* pAssetDoc = ezDynamicCast<ezSkeletonAssetDocument*>(pDoc);
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
   accessor.SetValue("File", sInputFileRel.GetView());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -445,7 +445,7 @@ void ezSkeletonAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile
   }
 }
 
-ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -460,7 +460,7 @@ ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, 
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezSkeletonAssetDocument* pAssetDoc = ezDynamicCast<ezSkeletonAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -90,5 +90,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezSkeletonAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "AnimationSkeletonGroup"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.h
@@ -90,5 +90,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezSkeletonAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "AnimationSkeletonGroup"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -762,7 +762,7 @@ void ezTextureAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile,
   }
 }
 
-ezStatus ezTextureAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezTextureAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   if (sMode == "TextureImport.Auto")
   {
@@ -809,11 +809,13 @@ ezStatus ezTextureAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, e
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezTextureAssetDocument* pAssetDoc = ezDynamicCast<ezTextureAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezTextureAssetDocument* pAssetDoc = ezDynamicCast<ezTextureAssetDocument*>(pDoc);
   if (pAssetDoc == nullptr)
     return ezStatus("Target document is not a valid ezTextureAssetDocument");
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -762,7 +762,7 @@ void ezTextureAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFile,
   }
 }
 
-ezStatus ezTextureAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezTextureAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   if (sMode == "TextureImport.Auto")
   {
@@ -813,7 +813,7 @@ ezStatus ezTextureAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, e
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezTextureAssetDocument* pAssetDoc = ezDynamicCast<ezTextureAssetDocument*>(pDoc);
   if (pAssetDoc == nullptr)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
@@ -72,7 +72,7 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezTextureAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 
   static TextureType DetermineTextureType(ezStringView sFile);
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.h
@@ -72,7 +72,7 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezTextureAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 
   static TextureType DetermineTextureType(ezStringView sFile);
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -263,7 +263,7 @@ void ezTextureCubeAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputF
   }
 }
 
-ezStatus ezTextureCubeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezTextureCubeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -274,11 +274,13 @@ ezStatus ezTextureCubeAssetDocumentGenerator::Generate(ezStringView sInputFileAb
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezTextureCubeAssetDocument* pAssetDoc = ezDynamicCast<ezTextureCubeAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezTextureCubeAssetDocument* pAssetDoc = ezDynamicCast<ezTextureCubeAssetDocument*>(pDoc);
 
   auto& accessor = pAssetDoc->GetPropertyObject()->GetTypeAccessor();
   accessor.SetValue("Input1", sInputFileRel.GetView());

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -263,7 +263,7 @@ void ezTextureCubeAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputF
   }
 }
 
-ezStatus ezTextureCubeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezTextureCubeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -278,7 +278,7 @@ ezStatus ezTextureCubeAssetDocumentGenerator::Generate(ezStringView sInputFileAb
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezTextureCubeAssetDocument* pAssetDoc = ezDynamicCast<ezTextureCubeAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
@@ -57,5 +57,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezTextureCubeAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.h
@@ -57,5 +57,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezTextureCubeAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "Images"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -370,7 +370,7 @@ void ezJoltCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbs
   }
 }
 
-ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -385,7 +385,7 @@ ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInput
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezJoltCollisionMeshAssetDocument* pAssetDoc = ezDynamicCast<ezJoltCollisionMeshAssetDocument*>(pDoc);
   if (pAssetDoc == nullptr)
@@ -422,7 +422,7 @@ void ezJoltConvexCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringVie
   }
 }
 
-ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -437,7 +437,7 @@ ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView 
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezJoltCollisionMeshAssetDocument* pAssetDoc = ezDynamicCast<ezJoltCollisionMeshAssetDocument*>(pDoc);
   if (pAssetDoc == nullptr)

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -370,7 +370,7 @@ void ezJoltCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbs
   }
 }
 
-ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -381,11 +381,13 @@ ezStatus ezJoltCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInput
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezJoltCollisionMeshAssetDocument* pAssetDoc = ezDynamicCast<ezJoltCollisionMeshAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezJoltCollisionMeshAssetDocument* pAssetDoc = ezDynamicCast<ezJoltCollisionMeshAssetDocument*>(pDoc);
   if (pAssetDoc == nullptr)
     return ezStatus("Target document is not a valid ezJoltCollisionMeshAssetDocument");
 
@@ -420,7 +422,7 @@ void ezJoltConvexCollisionMeshAssetDocumentGenerator::GetImportModes(ezStringVie
   }
 }
 
-ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -431,11 +433,13 @@ ezStatus ezJoltConvexCollisionMeshAssetDocumentGenerator::Generate(ezStringView 
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezJoltCollisionMeshAssetDocument* pAssetDoc = ezDynamicCast<ezJoltCollisionMeshAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezJoltCollisionMeshAssetDocument* pAssetDoc = ezDynamicCast<ezJoltCollisionMeshAssetDocument*>(pDoc);
   if (pAssetDoc == nullptr)
     return ezStatus("Target document is not a valid ezJoltCollisionMeshAssetDocument");
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
@@ -45,7 +45,7 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezJoltCollisionMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "JoltCollisionMeshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };
 
 class ezJoltConvexCollisionMeshAssetDocumentGenerator : public ezAssetDocumentGenerator
@@ -59,5 +59,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezJoltConvexCollisionMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "JoltCollisionMeshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h
@@ -45,7 +45,7 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezJoltCollisionMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "JoltCollisionMeshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };
 
 class ezJoltConvexCollisionMeshAssetDocumentGenerator : public ezAssetDocumentGenerator
@@ -59,5 +59,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezJoltConvexCollisionMeshAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "JoltCollisionMeshes"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
@@ -235,7 +235,7 @@ void ezKrautTreeAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFil
   }
 }
 
-ezStatus ezKrautTreeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
+ezStatus ezKrautTreeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -250,7 +250,7 @@ ezStatus ezKrautTreeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs,
   if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  out_pGeneratedDocuments.PushBack(pDoc);
+  out_generatedDocuments.PushBack(pDoc);
 
   ezKrautTreeAssetDocument* pAssetDoc = ezDynamicCast<ezKrautTreeAssetDocument*>(pDoc);
 

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.cpp
@@ -235,7 +235,7 @@ void ezKrautTreeAssetDocumentGenerator::GetImportModes(ezStringView sAbsInputFil
   }
 }
 
-ezStatus ezKrautTreeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument)
+ezStatus ezKrautTreeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments)
 {
   ezStringBuilder sOutFile = sInputFileAbs;
   sOutFile.ChangeFileExtension(GetDocumentExtension());
@@ -246,12 +246,13 @@ ezStatus ezKrautTreeAssetDocumentGenerator::Generate(ezStringView sInputFileAbs,
   ezStringBuilder sInputFileRel = sInputFileAbs;
   pApp->MakePathDataDirectoryRelative(sInputFileRel);
 
-  out_pGeneratedDocument = pApp->CreateDocument(sInputFileAbs, ezDocumentFlags::None);
-
-  if (out_pGeneratedDocument == nullptr)
+  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pDoc == nullptr)
     return ezStatus("Could not create target document");
 
-  ezKrautTreeAssetDocument* pAssetDoc = ezDynamicCast<ezKrautTreeAssetDocument*>(out_pGeneratedDocument);
+  out_pGeneratedDocuments.PushBack(pDoc);
+
+  ezKrautTreeAssetDocument* pAssetDoc = ezDynamicCast<ezKrautTreeAssetDocument*>(pDoc);
 
   if (pAssetDoc == nullptr)
     return ezStatus("Target document is not a valid ezKrautTreeAssetDocument");

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
@@ -41,5 +41,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezKrautTreeAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "KrautTrees"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAsset.h
@@ -41,5 +41,5 @@ public:
   virtual void GetImportModes(ezStringView sAbsInputFile, ezDynamicArray<ezAssetDocumentGenerator::ImportMode>& out_modes) const override;
   virtual ezStringView GetDocumentExtension() const override { return "ezKrautTreeAsset"; }
   virtual ezStringView GetGeneratorGroup() const override { return "KrautTrees"; }
-  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDocument*& out_pGeneratedDocument) override;
+  virtual ezStatus Generate(ezStringView sInputFileAbs, ezStringView sMode, ezDynamicArray<ezDocument*>& out_pGeneratedDocuments) override;
 };

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/AssimpAnimationImport.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/AssimpAnimationImport.cpp
@@ -42,6 +42,15 @@ namespace ezModelImporter2
 
   ezResult ImporterAssimp::ImportAnimations()
   {
+    // always output the available animation clips, even if no clip is supposed to be read
+    {
+      m_OutputAnimationNames.SetCount(m_pScene->mNumAnimations);
+      for (ezUInt32 animIdx = 0; animIdx < m_pScene->mNumAnimations; ++animIdx)
+      {
+        m_OutputAnimationNames[animIdx] = m_pScene->mAnimations[animIdx]->mName.C_Str();
+      }
+    }
+
     auto* pAnimOut = m_Options.m_pAnimationOutput;
 
     if (pAnimOut == nullptr)
@@ -51,12 +60,6 @@ namespace ezModelImporter2
       return EZ_FAILURE;
 
     pAnimOut->m_bAdditive = m_Options.m_bAdditiveAnimation;
-
-    m_OutputAnimationNames.SetCount(m_pScene->mNumAnimations);
-    for (ezUInt32 animIdx = 0; animIdx < m_pScene->mNumAnimations; ++animIdx)
-    {
-      m_OutputAnimationNames[animIdx] = m_pScene->mAnimations[animIdx]->mName.C_Str();
-    }
 
     if (m_Options.m_sAnimationToImport.IsEmpty())
       m_Options.m_sAnimationToImport = m_pScene->mAnimations[0]->mName.C_Str();

--- a/Data/Tools/ezEditor/Localization/en/AnimationClipAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/AnimationClipAsset.txt
@@ -6,7 +6,8 @@ Animation Clip;Animation Clip
 
 # UI
 
-AnimationClipImport;Animation Clip
+AnimationClipImport_Single;Animation Clip (Single)
+AnimationClipImport_All;Animation Clips (All)
 
 # Properties
 


### PR DESCRIPTION
Makes it much easier to import all animation clips of an animated mesh in few clicks. Automatically sets up the animation clip to use.
Also automatically sets the Preview Mesh option, after asking the user which one to use.

Fixes #1163