### PR TITLE
Minor container improvements

### DIFF
--- a/Code/Engine/Foundation/Containers/HashSet.h
+++ b/Code/Engine/Foundation/Containers/HashSet.h
@@ -34,7 +34,7 @@ public:
     const KeyType& Key() const; // [tested]
 
     /// \brief Returns the 'key' of the element that this iterator points to.
-    EZ_ALWAYS_INLINE const KeyType& operator*() { return Key(); } // [tested]
+    EZ_ALWAYS_INLINE const KeyType& operator*() const { return Key(); } // [tested]
 
     /// \brief Advances the iterator to the next element in the map. The iterator will not be valid anymore, if the end is reached.
     void Next(); // [tested]
@@ -139,6 +139,10 @@ public:
 
   /// \brief Swaps this map with the other one.
   void Swap(ezHashSetBase<KeyType, Hasher>& other); // [tested]
+
+  /// \brief Searches for key, returns a ConstIterator to it or an invalid iterator, if no such key is found. O(1) operation.
+  template <typename CompatibleKeyType>
+  ConstIterator Find(const CompatibleKeyType& key) const;
 
 private:
   KeyType* m_pEntries;

--- a/Code/Engine/Foundation/Containers/Implementation/HashSet_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/HashSet_inl.h
@@ -370,6 +370,23 @@ EZ_FORCE_INLINE bool ezHashSetBase<K, H>::Contains(const CompatibleKeyType& key)
 }
 
 template <typename K, typename H>
+template <typename CompatibleKeyType>
+EZ_FORCE_INLINE typename ezHashSetBase<K, H>::ConstIterator ezHashSetBase<K, H>::Find(const CompatibleKeyType& key) const
+{
+  ezUInt32 uiIndex = FindEntry(key);
+  if (uiIndex == ezInvalidIndex)
+  {
+    return GetEndIterator();
+  }
+
+  ConstIterator it(*this);
+  it.m_uiCurrentIndex = uiIndex;
+  it.m_uiCurrentCount = 0; // we do not know the 'count' (which is used as an optimization), so we just use 0
+
+  return it;
+}
+
+template <typename K, typename H>
 bool ezHashSetBase<K, H>::ContainsSet(const ezHashSetBase<K, H>& operand) const
 {
   for (const K& key : operand)

--- a/Code/Engine/Foundation/Containers/Implementation/List_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/List_inl.h
@@ -107,12 +107,6 @@ EZ_ALWAYS_INLINE typename ezListBase<T>::Iterator ezListBase<T>::GetIterator()
 }
 
 template <typename T>
-EZ_ALWAYS_INLINE typename ezListBase<T>::Iterator ezListBase<T>::GetLastIterator()
-{
-  return Iterator(m_Last.m_pPrev);
-}
-
-template <typename T>
 EZ_ALWAYS_INLINE typename ezListBase<T>::Iterator ezListBase<T>::GetEndIterator()
 {
   return m_End;
@@ -122,12 +116,6 @@ template <typename T>
 EZ_ALWAYS_INLINE typename ezListBase<T>::ConstIterator ezListBase<T>::GetIterator() const
 {
   return ConstIterator(m_First.m_pNext);
-}
-
-template <typename T>
-EZ_ALWAYS_INLINE typename ezListBase<T>::ConstIterator ezListBase<T>::GetLastIterator() const
-{
-  return ConstIterator(m_Last.m_pPrev);
 }
 
 template <typename T>

--- a/Code/Engine/Foundation/Containers/Implementation/Map_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/Map_inl.h
@@ -201,18 +201,6 @@ EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::ConstIterator
 }
 
 template <typename KeyType, typename ValueType, typename Comparer>
-EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::Iterator ezMapBase<KeyType, ValueType, Comparer>::GetLastIterator()
-{
-  return Iterator(GetRightMost());
-}
-
-template <typename KeyType, typename ValueType, typename Comparer>
-EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::ConstIterator ezMapBase<KeyType, ValueType, Comparer>::GetLastIterator() const
-{
-  return ConstIterator(GetRightMost());
-}
-
-template <typename KeyType, typename ValueType, typename Comparer>
 typename ezMapBase<KeyType, ValueType, Comparer>::Node* ezMapBase<KeyType, ValueType, Comparer>::GetLeftMost() const
 {
   if (IsEmpty())

--- a/Code/Engine/Foundation/Containers/Implementation/Map_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/Map_inl.h
@@ -7,11 +7,9 @@
 #define STACK_SIZE 64
 
 template <typename KeyType, typename ValueType, typename Comparer>
-void ezMapBase<KeyType, ValueType, Comparer>::ConstIterator::Next()
+template <bool REVERSE>
+void ezMapBase<KeyType, ValueType, Comparer>::ConstIteratorBase<REVERSE>::Advance(const ezInt32 dir0, const ezInt32 dir1)
 {
-  const ezInt32 dir0 = 0;
-  const ezInt32 dir1 = 1;
-
   if (m_pElement == nullptr)
   {
     EZ_ASSERT_DEBUG(m_pElement != nullptr, "The Iterator is invalid (end).");
@@ -58,54 +56,31 @@ void ezMapBase<KeyType, ValueType, Comparer>::ConstIterator::Next()
 }
 
 template <typename KeyType, typename ValueType, typename Comparer>
-void ezMapBase<KeyType, ValueType, Comparer>::ConstIterator::Prev()
+template <bool REVERSE>
+void ezMapBase<KeyType, ValueType, Comparer>::ConstIteratorBase<REVERSE>::Next()
 {
-  const ezInt32 dir0 = 1;
-  const ezInt32 dir1 = 0;
-
-  if (m_pElement == nullptr)
+  if constexpr (REVERSE)
   {
-    EZ_ASSERT_DEBUG(m_pElement != nullptr, "The Iterator is invalid (end).");
-    return;
+    Advance(1, 0);
   }
-
-  // if this element has a right child, go there and then search for the left most child of that
-  if (m_pElement->m_pLink[dir1] != m_pElement->m_pLink[dir1]->m_pLink[dir1])
+  else
   {
-    m_pElement = m_pElement->m_pLink[dir1];
-
-    while (m_pElement->m_pLink[dir0] != m_pElement->m_pLink[dir0]->m_pLink[dir0])
-      m_pElement = m_pElement->m_pLink[dir0];
-
-    return;
+    Advance(0, 1);
   }
+}
 
-  // if this element has a parent and this element is that parents left child, go directly to the parent
-  if ((m_pElement->m_pParent != m_pElement->m_pParent->m_pParent) && (m_pElement->m_pParent->m_pLink[dir0] == m_pElement))
+template <typename KeyType, typename ValueType, typename Comparer>
+template <bool REVERSE>
+void ezMapBase<KeyType, ValueType, Comparer>::ConstIteratorBase<REVERSE>::Prev()
+{
+  if constexpr (REVERSE)
   {
-    m_pElement = m_pElement->m_pParent;
-    return;
+    Advance(0, 1);
   }
-
-  // if this element has a parent and this element is that parents right child, search for the next parent, whose left child this is
-  if ((m_pElement->m_pParent != m_pElement->m_pParent->m_pParent) && (m_pElement->m_pParent->m_pLink[dir1] == m_pElement))
+  else
   {
-    while (m_pElement->m_pParent->m_pLink[dir1] == m_pElement)
-      m_pElement = m_pElement->m_pParent;
-
-    // if we are at the root node..
-    if ((m_pElement->m_pParent == nullptr) || (m_pElement->m_pParent == m_pElement->m_pParent->m_pParent))
-    {
-      m_pElement = nullptr;
-      return;
-    }
-
-    m_pElement = m_pElement->m_pParent;
-    return;
+    Advance(1, 0);
   }
-
-  m_pElement = nullptr;
-  return;
 }
 
 // ***** ezMapBase *****
@@ -198,6 +173,18 @@ template <typename KeyType, typename ValueType, typename Comparer>
 EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::ConstIterator ezMapBase<KeyType, ValueType, Comparer>::GetIterator() const
 {
   return ConstIterator(GetLeftMost());
+}
+
+template <typename KeyType, typename ValueType, typename Comparer>
+EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::ReverseIterator ezMapBase<KeyType, ValueType, Comparer>::GetReverseIterator()
+{
+  return ReverseIterator(GetRightMost());
+}
+
+template <typename KeyType, typename ValueType, typename Comparer>
+EZ_ALWAYS_INLINE typename ezMapBase<KeyType, ValueType, Comparer>::ConstReverseIterator ezMapBase<KeyType, ValueType, Comparer>::GetReverseIterator() const
+{
+  return ConstReverseIterator(GetRightMost());
 }
 
 template <typename KeyType, typename ValueType, typename Comparer>

--- a/Code/Engine/Foundation/Containers/Implementation/Set_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/Set_inl.h
@@ -195,12 +195,6 @@ EZ_ALWAYS_INLINE typename ezSetBase<KeyType, Comparer>::Iterator ezSetBase<KeyTy
 }
 
 template <typename KeyType, typename Comparer>
-EZ_ALWAYS_INLINE typename ezSetBase<KeyType, Comparer>::Iterator ezSetBase<KeyType, Comparer>::GetLastIterator() const
-{
-  return Iterator(GetRightMost());
-}
-
-template <typename KeyType, typename Comparer>
 typename ezSetBase<KeyType, Comparer>::Node* ezSetBase<KeyType, Comparer>::GetLeftMost() const
 {
   if (IsEmpty())

--- a/Code/Engine/Foundation/Containers/Implementation/Set_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/Set_inl.h
@@ -5,13 +5,10 @@
 #define STACK_SIZE 64
 
 // ***** Const Iterator *****
-
 template <typename KeyType, typename Comparer>
-void ezSetBase<KeyType, Comparer>::Iterator::Next()
+template <bool REVERSE>
+void ezSetBase<KeyType, Comparer>::IteratorBase<REVERSE>::Advance(ezInt32 dir0, ezInt32 dir1)
 {
-  const ezInt32 dir0 = 0;
-  const ezInt32 dir1 = 1;
-
   if (m_pElement == nullptr)
   {
     EZ_ASSERT_DEBUG(m_pElement != nullptr, "The Iterator is invalid (end).");
@@ -54,58 +51,34 @@ void ezSetBase<KeyType, Comparer>::Iterator::Next()
   }
 
   m_pElement = nullptr;
-  return;
 }
 
 template <typename KeyType, typename Comparer>
-void ezSetBase<KeyType, Comparer>::Iterator::Prev()
+template <bool REVERSE>
+void ezSetBase<KeyType, Comparer>::IteratorBase<REVERSE>::Next()
 {
-  const ezInt32 dir0 = 1;
-  const ezInt32 dir1 = 0;
-
-  if (m_pElement == nullptr)
+  if constexpr (REVERSE)
   {
-    EZ_ASSERT_DEBUG(m_pElement != nullptr, "The Iterator is invalid (end).");
-    return;
+    Advance(1, 0);
   }
-
-  // if this element has a right child, go there and then search for the left most child of that
-  if (m_pElement->m_pLink[dir1] != m_pElement->m_pLink[dir1]->m_pLink[dir1])
+  else
   {
-    m_pElement = m_pElement->m_pLink[dir1];
-
-    while (m_pElement->m_pLink[dir0] != m_pElement->m_pLink[dir0]->m_pLink[dir0])
-      m_pElement = m_pElement->m_pLink[dir0];
-
-    return;
+    Advance(0, 1);
   }
+}
 
-  // if this element has a parent and this element is that parents left child, go directly to the parent
-  if ((m_pElement->m_pParent != m_pElement->m_pParent->m_pParent) && (m_pElement->m_pParent->m_pLink[dir0] == m_pElement))
+template <typename KeyType, typename Comparer>
+template <bool REVERSE>
+void ezSetBase<KeyType, Comparer>::IteratorBase<REVERSE>::Prev()
+{
+  if constexpr (REVERSE)
   {
-    m_pElement = m_pElement->m_pParent;
-    return;
+    Advance(0, 1);
   }
-
-  // if this element has a parent and this element is that parents right child, search for the next parent, whose left child this is
-  if ((m_pElement->m_pParent != m_pElement->m_pParent->m_pParent) && (m_pElement->m_pParent->m_pLink[dir1] == m_pElement))
+  else
   {
-    while (m_pElement->m_pParent->m_pLink[dir1] == m_pElement)
-      m_pElement = m_pElement->m_pParent;
-
-    // if we are at the root node..
-    if ((m_pElement->m_pParent == nullptr) || (m_pElement->m_pParent == m_pElement->m_pParent->m_pParent))
-    {
-      m_pElement = nullptr;
-      return;
-    }
-
-    m_pElement = m_pElement->m_pParent;
-    return;
+    Advance(1, 0);
   }
-
-  m_pElement = nullptr;
-  return;
 }
 
 // ***** ezSetBase *****
@@ -192,6 +165,12 @@ template <typename KeyType, typename Comparer>
 EZ_ALWAYS_INLINE typename ezSetBase<KeyType, Comparer>::Iterator ezSetBase<KeyType, Comparer>::GetIterator() const
 {
   return Iterator(GetLeftMost());
+}
+
+template <typename KeyType, typename Comparer>
+EZ_ALWAYS_INLINE typename ezSetBase<KeyType, Comparer>::ReverseIterator ezSetBase<KeyType, Comparer>::GetReverseIterator() const
+{
+  return ReverseIterator(GetRightMost());
 }
 
 template <typename KeyType, typename Comparer>

--- a/Code/Engine/Foundation/Containers/List.h
+++ b/Code/Engine/Foundation/Containers/List.h
@@ -185,17 +185,11 @@ public:
   /// \brief Returns an iterator to the first list-element.
   Iterator GetIterator(); // [tested]
 
-  /// \brief Returns an iterator to the last list-element. Can be used for reverse iteration.
-  Iterator GetLastIterator(); // [tested]
-
   /// \brief Returns an iterator pointing behind the last element. Necessary if one wants to insert elements at the end of a list.
   Iterator GetEndIterator(); // [tested]
 
   /// \brief Returns a const-iterator to the first list-element.
   ConstIterator GetIterator() const; // [tested]
-
-  /// \brief Returns a const-iterator to the last list-element. Can be used for reverse iteration.
-  ConstIterator GetLastIterator() const; // [tested]
 
   /// \brief Returns a const-iterator pointing behind the last element. Necessary if one wants to insert elements at the end of a list.
   ConstIterator GetEndIterator() const; // [tested]

--- a/Code/Engine/Foundation/Containers/Map.h
+++ b/Code/Engine/Foundation/Containers/Map.h
@@ -36,18 +36,19 @@ private:
 
 public:
   /// \brief Base class for all iterators.
-  struct ConstIterator
+  template <bool REVERSE>
+  struct ConstIteratorBase
   {
     using iterator_category = std::forward_iterator_tag;
-    using value_type = ConstIterator;
+    using value_type = ConstIteratorBase<false>;
     using difference_type = std::ptrdiff_t;
-    using pointer = ConstIterator*;
-    using reference = ConstIterator&;
+    using pointer = ConstIteratorBase<false>*;
+    using reference = ConstIteratorBase<false>&;
 
     EZ_DECLARE_POD_TYPE();
 
     /// \brief Constructs an invalid iterator.
-    EZ_ALWAYS_INLINE ConstIterator()
+    EZ_ALWAYS_INLINE ConstIteratorBase()
       : m_pElement(nullptr)
     {
     } // [tested]
@@ -56,8 +57,8 @@ public:
     EZ_ALWAYS_INLINE bool IsValid() const { return (m_pElement != nullptr); } // [tested]
 
     /// \brief Checks whether the two iterators point to the same element.
-    EZ_ALWAYS_INLINE bool operator==(const typename ezMapBase<KeyType, ValueType, Comparer>::ConstIterator& it2) const { return (m_pElement == it2.m_pElement); }
-    EZ_ADD_DEFAULT_OPERATOR_NOTEQUAL(const typename ezMapBase<KeyType, ValueType, Comparer>::ConstIterator&);
+    EZ_ALWAYS_INLINE bool operator==(const typename ezMapBase<KeyType, ValueType, Comparer>::ConstIteratorBase<REVERSE>& it2) const { return (m_pElement == it2.m_pElement); }
+    EZ_ADD_DEFAULT_OPERATOR_NOTEQUAL(const typename ezMapBase<KeyType, ValueType, Comparer>::ConstIteratorBase<REVERSE>&);
 
     /// \brief Returns the 'key' of the element that this iterator points to.
     EZ_FORCE_INLINE const KeyType& Key() const
@@ -74,7 +75,7 @@ public:
     } // [tested]
 
     /// \brief Returns '*this' to enable foreach
-    EZ_ALWAYS_INLINE ConstIterator& operator*() { return *this; } // [tested]
+    EZ_ALWAYS_INLINE ConstIteratorBase<REVERSE>& operator*() { return *this; } // [tested]
 
     /// \brief Advances the iterator to the next element in the map. The iterator will not be valid anymore, if the end is reached.
     void Next(); // [tested]
@@ -89,9 +90,11 @@ public:
     EZ_ALWAYS_INLINE void operator--() { Prev(); } // [tested]
 
   protected:
+    void Advance(const ezInt32 dir0, const ezInt32 dir1);
+
     friend class ezMapBase<KeyType, ValueType, Comparer>;
 
-    EZ_ALWAYS_INLINE explicit ConstIterator(Node* pInit)
+    EZ_ALWAYS_INLINE explicit ConstIteratorBase(Node* pInit)
       : m_pElement(pInit)
     {
     }
@@ -99,23 +102,27 @@ public:
     Node* m_pElement;
   };
 
+  using ConstIterator = ConstIteratorBase<false>;
+  using ConstReverseIterator = ConstIteratorBase<true>;
+
   /// \brief Forward Iterator to iterate over all elements in sorted order.
-  struct Iterator : public ConstIterator
+  template <bool REVERSE>
+  struct IteratorBase : public ConstIteratorBase<REVERSE>
   {
     using iterator_category = std::forward_iterator_tag;
-    using value_type = Iterator;
+    using value_type = IteratorBase<REVERSE>;
     using difference_type = std::ptrdiff_t;
-    using pointer = Iterator*;
-    using reference = Iterator&;
+    using pointer = IteratorBase<REVERSE>*;
+    using reference = IteratorBase<REVERSE>&;
 
     // this is required to pull in the const version of this function
-    using ConstIterator::Value;
+    using ConstIteratorBase<REVERSE>::Value;
 
     EZ_DECLARE_POD_TYPE();
 
     /// \brief Constructs an invalid iterator.
-    EZ_ALWAYS_INLINE Iterator()
-      : ConstIterator()
+    EZ_ALWAYS_INLINE IteratorBase()
+      : ConstIteratorBase<REVERSE>()
     {
     }
 
@@ -127,16 +134,19 @@ public:
     }
 
     /// \brief Returns '*this' to enable foreach
-    EZ_ALWAYS_INLINE Iterator& operator*() { return *this; } // [tested]
+    EZ_ALWAYS_INLINE IteratorBase<REVERSE>& operator*() { return *this; } // [tested]
 
   private:
     friend class ezMapBase<KeyType, ValueType, Comparer>;
 
-    EZ_ALWAYS_INLINE explicit Iterator(Node* pInit)
-      : ConstIterator(pInit)
+    EZ_ALWAYS_INLINE explicit IteratorBase(Node* pInit)
+      : ConstIteratorBase<REVERSE>(pInit)
     {
     }
   };
+
+  using Iterator = IteratorBase<false>;
+  using ReverseIterator = IteratorBase<true>;
 
 protected:
   /// \brief Initializes the map to be empty.
@@ -164,8 +174,14 @@ public:
   /// \brief Returns an Iterator to the very first element.
   Iterator GetIterator(); // [tested]
 
+  /// \brief Returns a ReverseIterator to the very last element.
+  ReverseIterator GetReverseIterator(); // [tested]
+
   /// \brief Returns a constant Iterator to the very first element.
   ConstIterator GetIterator() const; // [tested]
+
+  /// \brief Returns a constant ReverseIterator to the very last element.
+  ConstReverseIterator GetReverseIterator() const; // [tested]
 
   /// \brief Inserts the key/value pair into the tree and returns an Iterator to it. O(log n) operation.
   template <typename CompatibleKeyType, typename CompatibleValueType>

--- a/Code/Engine/Foundation/Containers/Map.h
+++ b/Code/Engine/Foundation/Containers/Map.h
@@ -167,12 +167,6 @@ public:
   /// \brief Returns a constant Iterator to the very first element.
   ConstIterator GetIterator() const; // [tested]
 
-  /// \brief Returns an Iterator to the very last element. For reverse traversal.
-  Iterator GetLastIterator(); // [tested]
-
-  /// \brief Returns a constant Iterator to the very last element. For reverse traversal.
-  ConstIterator GetLastIterator() const; // [tested]
-
   /// \brief Inserts the key/value pair into the tree and returns an Iterator to it. O(log n) operation.
   template <typename CompatibleKeyType, typename CompatibleValueType>
   Iterator Insert(CompatibleKeyType&& key, CompatibleValueType&& value); // [tested]

--- a/Code/Engine/Foundation/Containers/Set.h
+++ b/Code/Engine/Foundation/Containers/Set.h
@@ -112,9 +112,6 @@ public:
   /// \brief Returns a constant Iterator to the very first element.
   Iterator GetIterator() const; // [tested]
 
-  /// \brief Returns a constant Iterator to the very last element. For reverse traversal.
-  Iterator GetLastIterator() const; // [tested]
-
   /// \brief Inserts the key into the tree and returns an Iterator to it. O(log n) operation.
   template <typename CompatibleKeyType>
   Iterator Insert(CompatibleKeyType&& key); // [tested]

--- a/Code/Engine/Foundation/Containers/Set.h
+++ b/Code/Engine/Foundation/Containers/Set.h
@@ -61,7 +61,7 @@ public:
     } // [tested]
 
     /// \brief Returns the 'key' of the element that this iterator points to.
-    EZ_ALWAYS_INLINE const KeyType& operator*() { return Key(); }
+    EZ_ALWAYS_INLINE const KeyType& operator*() const { return Key(); }
 
     /// \brief Advances the iterator to the next element in the set. The iterator will not be valid anymore, if the end is reached.
     void Next(); // [tested]

--- a/Code/Engine/Foundation/Containers/Set.h
+++ b/Code/Engine/Foundation/Containers/Set.h
@@ -30,18 +30,19 @@ private:
 
 public:
   /// \brief Base class for all iterators.
-  struct Iterator
+  template <bool REVERSE>
+  struct IteratorBase
   {
     using iterator_category = std::forward_iterator_tag;
-    using value_type = Iterator;
+    using value_type = IteratorBase<REVERSE>;
     using difference_type = std::ptrdiff_t;
-    using pointer = Iterator*;
-    using reference = Iterator&;
+    using pointer = IteratorBase<REVERSE>*;
+    using reference = IteratorBase<REVERSE>&;
 
     EZ_DECLARE_POD_TYPE();
 
     /// \brief Constructs an invalid iterator.
-    EZ_ALWAYS_INLINE Iterator()
+    EZ_ALWAYS_INLINE IteratorBase()
       : m_pElement(nullptr)
     {
     } // [tested]
@@ -50,8 +51,8 @@ public:
     EZ_ALWAYS_INLINE bool IsValid() const { return (m_pElement != nullptr); } // [tested]
 
     /// \brief Checks whether the two iterators point to the same element.
-    EZ_ALWAYS_INLINE bool operator==(const typename ezSetBase<KeyType, Comparer>::Iterator& it2) const { return (m_pElement == it2.m_pElement); }
-    EZ_ADD_DEFAULT_OPERATOR_NOTEQUAL(const typename ezSetBase<KeyType, Comparer>::Iterator&);
+    EZ_ALWAYS_INLINE bool operator==(const typename ezSetBase<KeyType, Comparer>::IteratorBase<REVERSE>& it2) const { return (m_pElement == it2.m_pElement); }
+    EZ_ADD_DEFAULT_OPERATOR_NOTEQUAL(const typename ezSetBase<KeyType, Comparer>::IteratorBase<REVERSE>&);
 
     /// \brief Returns the 'key' of the element that this iterator points to.
     EZ_FORCE_INLINE const KeyType& Key() const
@@ -76,15 +77,20 @@ public:
     EZ_ALWAYS_INLINE void operator--() { Prev(); } // [tested]
 
   protected:
+    void Advance(ezInt32 dir0, ezInt32 dir1);
+
     friend class ezSetBase<KeyType, Comparer>;
 
-    EZ_ALWAYS_INLINE explicit Iterator(Node* pInit)
+    EZ_ALWAYS_INLINE explicit IteratorBase(Node* pInit)
       : m_pElement(pInit)
     {
     }
 
     Node* m_pElement;
   };
+
+  using Iterator = IteratorBase<false>;
+  using ReverseIterator = IteratorBase<true>;
 
 protected:
   /// \brief Initializes the set to be empty.
@@ -111,6 +117,9 @@ public:
 
   /// \brief Returns a constant Iterator to the very first element.
   Iterator GetIterator() const; // [tested]
+
+  /// \brief Returns a constant ReverseIterator to the very last element.
+  ReverseIterator GetReverseIterator() const; // [tested]
 
   /// \brief Inserts the key into the tree and returns an Iterator to it. O(log n) operation.
   template <typename CompatibleKeyType>

--- a/Code/UnitTests/FoundationTest/Containers/HashSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HashSetTest.cpp
@@ -556,4 +556,35 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashSet)
 
     EZ_TEST_BOOL(set2.IsEmpty());
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Find")
+  {
+    ezStringBuilder tmp;
+    ezHashSet<ezString> set;
+
+    for (ezUInt32 i = 0; i < 1000; ++i)
+    {
+      tmp.SetFormat("stuff{}bla", i);
+      set.Insert(tmp);
+    }
+
+    for (ezInt32 i = set.GetCount() - 1; i > 0; --i)
+    {
+      tmp.SetFormat("stuff{}bla", i);
+
+      auto it = set.Find(tmp);
+
+      EZ_TEST_STRING(it.Key(), tmp);
+
+      int allowedIterations = set.GetCount();
+      for (auto it2 = it; it2.IsValid(); ++it2)
+      {
+        // just test that iteration is possible and terminates correctly
+        --allowedIterations;
+        EZ_TEST_BOOL(allowedIterations >= 0);
+      }
+
+      set.Remove(it);
+    }
+  }
 }

--- a/Code/UnitTests/FoundationTest/Containers/HashTableTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HashTableTest.cpp
@@ -611,4 +611,47 @@ EZ_CREATE_SIMPLE_TEST(Containers, HashTable)
       map.Remove(it);
     }
   }
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Find")
+  {
+    ezStringBuilder tmp;
+    ezHashTable<ezString, ezInt32> map;
+
+    for (ezUInt32 i = 0; i < 1000; ++i)
+    {
+      tmp.SetFormat("stuff{}bla", i);
+      map[tmp] = i;
+    }
+
+    for (ezInt32 i = map.GetCount() - 1; i > 0; --i)
+    {
+      tmp.SetFormat("stuff{}bla", i);
+
+      auto it = map.Find(tmp);
+      auto cit = static_cast<const ezHashTable<ezString, ezInt32>&>(map).Find(tmp);
+
+      EZ_TEST_STRING(it.Key(), tmp);
+      EZ_TEST_INT(it.Value(), i);
+
+      EZ_TEST_STRING(cit.Key(), tmp);
+      EZ_TEST_INT(cit.Value(), i);
+
+      int allowedIterations = map.GetCount();
+      for (auto it2 = it; it2.IsValid(); ++it2)
+      {
+        // just test that iteration is possible and terminates correctly
+        --allowedIterations;
+        EZ_TEST_BOOL(allowedIterations >= 0);
+      }
+
+      allowedIterations = map.GetCount();
+      for (auto cit2 = cit; cit2.IsValid(); ++cit2)
+      {
+        // just test that iteration is possible and terminates correctly
+        --allowedIterations;
+        EZ_TEST_BOOL(allowedIterations >= 0);
+      }
+
+      map.Remove(it);
+    }
+  }
 }

--- a/Code/UnitTests/FoundationTest/Containers/ListTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/ListTest.cpp
@@ -4,7 +4,10 @@
 
 EZ_CREATE_SIMPLE_TEST(Containers, List)
 {
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor") { ezList<ezInt32> l; }
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Constructor")
+  {
+    ezList<ezInt32> l;
+  }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "PushBack() / PeekBack")
   {
@@ -247,13 +250,16 @@ EZ_CREATE_SIMPLE_TEST(Containers, List)
       l.Insert(it, *it + 10000);
     }
 
+    i = 1;
+
     // now remove every second element and only keep the larger values
-    for (ezList<ezInt32>::Iterator it = l.GetLastIterator(); it.IsValid(); --it)
+    for (ezList<ezInt32>::Iterator it = l.GetIterator(); it.IsValid(); )
     {
-      it = l.Remove(it);
-      --it;
-      --i;
       EZ_TEST_INT(*it, i + 10000);
+
+      ++it;
+      it = l.Remove(it);
+      ++i;
     }
 
     i = 1;

--- a/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
@@ -382,40 +382,6 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
     EZ_TEST_INT(i, 1000);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetLastIterator / Backward Iteration")
-  {
-    ezMap<ezUInt32, ezUInt32> m;
-
-    for (ezInt32 i = 0; i < 1000; ++i)
-      m[i] = i * 10;
-
-    ezInt32 i = 1000 - 1;
-    for (ezMap<ezUInt32, ezUInt32>::Iterator it = m.GetLastIterator(); it.IsValid(); --it)
-    {
-      EZ_TEST_INT(it.Key(), i);
-      EZ_TEST_INT(it.Value(), i * 10);
-      --i;
-    }
-  }
-
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetLastIterator / Backward Iteration (const)")
-  {
-    ezMap<ezUInt32, ezUInt32> m;
-
-    for (ezInt32 i = 0; i < 1000; ++i)
-      m[i] = i * 10;
-
-    const ezMap<ezUInt32, ezUInt32> m2(m);
-
-    ezInt32 i = 1000 - 1;
-    for (ezMap<ezUInt32, ezUInt32>::ConstIterator it = m2.GetLastIterator(); it.IsValid(); --it)
-    {
-      EZ_TEST_INT(it.Key(), i);
-      EZ_TEST_INT(it.Value(), i * 10);
-      --i;
-    }
-  }
-
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "LowerBound")
   {
     ezMap<ezInt32, ezInt32> m, m2;

--- a/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/MapTest.cpp
@@ -16,7 +16,8 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     // EZ_TEST_INT(std::find(begin(m), end(m), 500).Key(), 499);
 
-    auto itfound = std::find_if(begin(m), end(m), [](ezMap<ezUInt32, ezUInt32>::ConstIterator val) { return val.Value() == 500; });
+    auto itfound = std::find_if(begin(m), end(m), [](ezMap<ezUInt32, ezUInt32>::ConstIterator val)
+      { return val.Value() == 500; });
 
     // EZ_TEST_BOOL(std::find(begin(m), end(m), 500) == itfound);
 
@@ -687,5 +688,39 @@ EZ_CREATE_SIMPLE_TEST(Containers, Map)
 
     map2->~ezMap<ezString, ezInt32>();
     ezMemoryUtils::PatternFill(map2Mem, 0xBA, uiMapSize);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetReverseIterator")
+  {
+    ezMap<ezUInt32, ezUInt32> m;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      m[i] = i * 10;
+
+    ezInt32 i = 1000 - 1;
+    for (ezMap<ezUInt32, ezUInt32>::ReverseIterator it = m.GetReverseIterator(); it.IsValid(); ++it)
+    {
+      EZ_TEST_INT(it.Key(), i);
+      EZ_TEST_INT(it.Value(), i * 10);
+      --i;
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetReverseIterator (const)")
+  {
+    ezMap<ezUInt32, ezUInt32> m;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      m[i] = i * 10;
+
+    const ezMap<ezUInt32, ezUInt32> m2(m);
+
+    ezInt32 i = 1000 - 1;
+    for (ezMap<ezUInt32, ezUInt32>::ConstReverseIterator it = m2.GetReverseIterator(); it.IsValid(); ++it)
+    {
+      EZ_TEST_INT(it.Key(), i);
+      EZ_TEST_INT(it.Value(), i * 10);
+      --i;
+    }
   }
 }

--- a/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
@@ -648,4 +648,36 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
     set2->~ezSet<ezString>();
     ezMemoryUtils::PatternFill(set2Mem, 0xBA, uiSetSize);
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetReverseIterator")
+  {
+    ezSet<ezUInt32> m;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      m.Insert(i);
+
+    ezInt32 i = 1000 - 1;
+    for (ezSet<ezUInt32>::ReverseIterator it = m.GetReverseIterator(); it.IsValid(); ++it)
+    {
+      EZ_TEST_INT(it.Key(), i);
+      --i;
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetReverseIterator (const)")
+  {
+    ezSet<ezUInt32> m;
+
+    for (ezInt32 i = 0; i < 1000; ++i)
+      m.Insert(i);
+
+    const ezSet<ezUInt32> m2(m);
+
+    ezInt32 i = 1000 - 1;
+    for (ezSet<ezUInt32>::ReverseIterator it = m2.GetReverseIterator(); it.IsValid(); ++it)
+    {
+      EZ_TEST_INT(it.Key(), i);
+      --i;
+    }
+  }
 }

--- a/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SetTest.cpp
@@ -370,38 +370,6 @@ EZ_CREATE_SIMPLE_TEST(Containers, Set)
     EZ_TEST_INT(i, 1000);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetLastIterator / Backward Iteration")
-  {
-    ezSet<ezUInt32> m;
-
-    for (ezInt32 i = 0; i < 1000; ++i)
-      m.Insert(i);
-
-    ezInt32 i = 1000 - 1;
-    for (ezSet<ezUInt32>::Iterator it = m.GetLastIterator(); it.IsValid(); --it)
-    {
-      EZ_TEST_INT(it.Key(), i);
-      --i;
-    }
-  }
-
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetLastIterator / Backward Iteration (const)")
-  {
-    ezSet<ezUInt32> m;
-
-    for (ezInt32 i = 0; i < 1000; ++i)
-      m.Insert(i);
-
-    const ezSet<ezUInt32> m2(m);
-
-    ezInt32 i = 1000 - 1;
-    for (ezSet<ezUInt32>::Iterator it = m2.GetLastIterator(); it.IsValid(); --it)
-    {
-      EZ_TEST_INT(it.Key(), i);
-      --i;
-    }
-  }
-
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "LowerBound")
   {
     ezSet<ezInt32> m, m2;

--- a/Code/UnitTests/FoundationTest/Performance/Container.cpp
+++ b/Code/UnitTests/FoundationTest/Performance/Container.cpp
@@ -330,8 +330,6 @@ EZ_CREATE_SIMPLE_TEST(Performance, Container)
   {
     ezUInt32 sum = 0;
 
-
-
     for (ezUInt32 size = 1024; size < 4096 * 32; size += 1024)
     {
       ezMap<void*, ezUInt32> map;
@@ -357,21 +355,19 @@ EZ_CREATE_SIMPLE_TEST(Performance, Container)
         for (ezUInt32 i = 0; i < 1024; i++)
           free(ptrs[i]);
 
-        auto last = map.GetLastIterator();
-        for (auto it = map.GetIterator(); it != last; ++it)
+        for (auto it = map.GetIterator(); it.IsValid(); ++it)
         {
           sum += it.Value();
         }
       }
       ezTime t1 = ezTime::Now();
 
-      auto last = map.GetLastIterator();
-      for (auto it = map.GetIterator(); it != last; ++it)
+      for (auto it = map.GetIterator(); it.IsValid(); ++it)
       {
         free(it.Key());
       }
-      ezLog::Info(
-        "[test]ezMap<void*, ezUInt32> size = {0} => {1}ms", size, ezArgF((t1 - t0).GetMilliseconds() / static_cast<double>(NUM_SAMPLES), 4), sum);
+
+      ezLog::Info("[test]ezMap<void*, ezUInt32> size = {0} => {1}ms", size, ezArgF((t1 - t0).GetMilliseconds() / static_cast<double>(NUM_SAMPLES), 4), sum);
     }
   }
 


### PR DESCRIPTION
* Removed GetLastIterator function because it wasn't used, at all, and had irritating behavior. If needed, we can add reverse iterators instead in the future.
* Added ezHashSet::Find, which was missing compared to ezHashTable.