### PR TITLE
Added ezTypedComponentHandle

### DIFF
--- a/Code/Engine/Core/World/ComponentManager.h
+++ b/Code/Engine/Core/World/ComponentManager.h
@@ -43,7 +43,7 @@ public:
 
   /// \brief Create a new component instance and returns a handle to it.
   template <typename ComponentType>
-  ezComponentHandle CreateComponent(ezGameObject* pOwnerObject, ComponentType*& out_pComponent);
+  ezTypedComponentHandle<ComponentType> CreateComponent(ezGameObject* pOwnerObject, ComponentType*& out_pComponent);
 
   /// \brief Deletes the given component. Note that the component will be invalidated first and the actual deletion is postponed.
   void DeleteComponent(const ezComponentHandle& hComponent);
@@ -154,18 +154,19 @@ private:
 
 //////////////////////////////////////////////////////////////////////////
 
-#define EZ_ADD_COMPONENT_FUNCTIONALITY(componentType, baseType, managerType)                        \
-public:                                                                                             \
-  using ComponentManagerType = managerType;                                                         \
-  virtual ezWorldModuleTypeId GetTypeId() const override { return s_TypeId; }                       \
-  static EZ_ALWAYS_INLINE ezWorldModuleTypeId TypeId() { return s_TypeId; }                         \
-  virtual ezComponentMode::Enum GetMode() const override;                                           \
-  static ezComponentHandle CreateComponent(ezGameObject* pOwnerObject, componentType*& pComponent); \
-  static void DeleteComponent(componentType* pComponent);                                           \
-  void DeleteComponent();                                                                           \
-                                                                                                    \
-private:                                                                                            \
-  friend managerType;                                                                               \
+#define EZ_ADD_COMPONENT_FUNCTIONALITY(componentType, baseType, managerType)                                                         \
+public:                                                                                                                              \
+  using ComponentManagerType = managerType;                                                                                          \
+  virtual ezWorldModuleTypeId GetTypeId() const override { return s_TypeId; }                                                        \
+  static EZ_ALWAYS_INLINE ezWorldModuleTypeId TypeId() { return s_TypeId; }                                                          \
+  ezTypedComponentHandle<componentType> GetHandle() const { return ezTypedComponentHandle<componentType>(ezComponent::GetHandle());} \
+  virtual ezComponentMode::Enum GetMode() const override;                                                                            \
+  static ezTypedComponentHandle<componentType> CreateComponent(ezGameObject* pOwnerObject, componentType*& pComponent);              \
+  static void DeleteComponent(componentType* pComponent);                                                                            \
+  void DeleteComponent();                                                                                                            \
+                                                                                                                                     \
+private:                                                                                                                             \
+  friend managerType;                                                                                                                \
   static ezWorldModuleTypeId s_TypeId
 
 #define EZ_ADD_ABSTRACT_COMPONENT_FUNCTIONALITY(componentType, baseType)                     \
@@ -187,16 +188,16 @@ public:                                                                         
 /// \brief Implements rtti and component specific functionality. Add this macro to a cpp file.
 ///
 /// \see EZ_BEGIN_DYNAMIC_REFLECTED_TYPE
-#define EZ_BEGIN_COMPONENT_TYPE(componentType, version, mode)                                                                                  \
-  ezWorldModuleTypeId componentType::s_TypeId =                                                                                                \
-    ezWorldModuleFactory::GetInstance()->RegisterWorldModule<typename componentType::ComponentManagerType, componentType>();                   \
-  ezComponentMode::Enum componentType::GetMode() const { return mode; }                                                                        \
-  ezComponentHandle componentType::CreateComponent(ezGameObject* pOwnerObject, componentType*& out_pComponent)                                 \
-  {                                                                                                                                            \
-    return pOwnerObject->GetWorld()->GetOrCreateComponentManager<ComponentManagerType>()->CreateComponent(pOwnerObject, out_pComponent);       \
-  }                                                                                                                                            \
-  void componentType::DeleteComponent(componentType* pComponent) { pComponent->GetOwningManager()->DeleteComponent(pComponent->GetHandle()); } \
-  void componentType::DeleteComponent() { GetOwningManager()->DeleteComponent(GetHandle()); }                                                  \
+#define EZ_BEGIN_COMPONENT_TYPE(componentType, version, mode)                                                                                                                   \
+  ezWorldModuleTypeId componentType::s_TypeId =                                                                                                                                 \
+    ezWorldModuleFactory::GetInstance()->RegisterWorldModule<typename componentType::ComponentManagerType, componentType>();                                                    \
+  ezComponentMode::Enum componentType::GetMode() const { return mode; }                                                                                                         \
+  ezTypedComponentHandle<componentType> componentType::CreateComponent(ezGameObject* pOwnerObject, componentType*& out_pComponent)                                              \
+  {                                                                                                                                                                             \
+    return pOwnerObject->GetWorld()->GetOrCreateComponentManager<ComponentManagerType>()->CreateComponent(pOwnerObject, out_pComponent);                                        \
+  }                                                                                                                                                                             \
+  void componentType::DeleteComponent(componentType* pComponent) { pComponent->GetOwningManager()->DeleteComponent(pComponent->GetHandle()); }                                  \
+  void componentType::DeleteComponent() { GetOwningManager()->DeleteComponent(GetHandle()); }                                                                                   \
   EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(componentType, version, ezRTTINoAllocator)
 
 /// \brief Implements rtti and abstract component specific functionality. Add this macro to a cpp file.

--- a/Code/Engine/Core/World/Declarations.h
+++ b/Code/Engine/Core/World/Declarations.h
@@ -143,6 +143,25 @@ struct ezComponentHandle
   friend class ezComponent;
 };
 
+template <typename TYPE>
+struct ezTypedComponentHandle : public ezComponentHandle
+{
+  ezTypedComponentHandle() = default;
+  explicit ezTypedComponentHandle(const ezComponentHandle& untyped)
+  {
+    m_InternalId = untyped.GetInternalID();
+  }
+
+  template <typename T, std::enable_if_t<std::is_convertible_v<T*, TYPE*>,bool> = true>
+  explicit ezTypedComponentHandle(const ezTypedComponentHandle<T>& other) : ezTypedComponentHandle(static_cast<const ezComponentHandle&>(other)) {}
+
+  template <typename T, std::enable_if_t<std::is_convertible_v<T*, TYPE*>,bool> = true>
+  EZ_ALWAYS_INLINE void operator=(const ezTypedComponentHandle<T>& other)
+  {
+    ezComponentHandle::operator=(other);
+  }
+};
+
 /// \brief HashHelper implementation so component handles can be used as key in a hashtable.
 template <>
 struct ezHashHelper<ezComponentHandle>

--- a/Code/Engine/Core/World/Declarations.h
+++ b/Code/Engine/Core/World/Declarations.h
@@ -143,6 +143,12 @@ struct ezComponentHandle
   friend class ezComponent;
 };
 
+/// \brief A typed handle to a component.
+///
+/// This should be preferred if the component type to be stored inside the handle is known, as it provides
+/// compile time checks against wrong usages (e.g. assigning unrelated types) and more clearly conveys intent.
+///
+/// See struct \see ezComponentHandle for more information about general component handle usage.
 template <typename TYPE>
 struct ezTypedComponentHandle : public ezComponentHandle
 {

--- a/Code/Engine/Core/World/Implementation/ComponentManager_inl.h
+++ b/Code/Engine/Core/World/Implementation/ComponentManager_inl.h
@@ -23,7 +23,7 @@ EZ_ALWAYS_INLINE ezUInt32 ezComponentManagerBase::GetComponentCount() const
 }
 
 template <typename ComponentType>
-EZ_ALWAYS_INLINE ezComponentHandle ezComponentManagerBase::CreateComponent(ezGameObject* pOwnerObject, ComponentType*& out_pComponent)
+EZ_ALWAYS_INLINE ezTypedComponentHandle<ComponentType> ezComponentManagerBase::CreateComponent(ezGameObject* pOwnerObject, ComponentType*& out_pComponent)
 {
   ezComponent* pComponent = nullptr;
   ezComponentHandle hComponent = CreateComponentNoInit(pOwnerObject, pComponent);
@@ -34,7 +34,7 @@ EZ_ALWAYS_INLINE ezComponentHandle ezComponentManagerBase::CreateComponent(ezGam
   }
 
   out_pComponent = ezStaticCast<ComponentType*>(pComponent);
-  return hComponent;
+  return ezTypedComponentHandle<ComponentType>(hComponent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -177,6 +177,18 @@ public:
   template <typename ComponentType>
   [[nodiscard]] bool TryGetComponent(const ezComponentHandle& hComponent, const ComponentType*& out_pComponent) const;
 
+  template <typename ComponentType>
+  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<ComponentType>& hComponent, ComponentType*& out_pComponent)
+  {
+    return TryGetComponent<ComponentType>(static_cast<const ezComponentHandle&>(hComponent), out_pComponent);
+  }
+
+  template <typename ComponentType>
+  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<ComponentType>& hComponent, const ComponentType*& out_pComponent) const
+  {
+    return TryGetComponent<ComponentType>(static_cast<const ezComponentHandle&>(hComponent), out_pComponent);
+  }
+
   /// \brief Creates a new component init batch.
   /// It is ensured that the Initialize function is called for all components in a batch before the OnSimulationStarted is called.
   /// If bMustFinishWithinOneFrame is set to false the processing of an init batch can be distributed over multiple frames if

--- a/Code/UnitTests/CoreTest/World/ComponentTest.cpp
+++ b/Code/UnitTests/CoreTest/World/ComponentTest.cpp
@@ -184,7 +184,7 @@ EZ_CREATE_SIMPLE_TEST(World, Components)
     // test recursive write lock
     EZ_LOCK(world.GetWriteMarker());
 
-    ezComponentHandle handle;
+    ezTypedComponentHandle<TestComponent> handle;
     EZ_TEST_BOOL(!world.TryGetComponent(handle, pTestComponent));
 
     // Update with no components created
@@ -278,9 +278,9 @@ EZ_CREATE_SIMPLE_TEST(World, Components)
     TestComponent* pComponentB = nullptr;
     TestComponent* pComponentC = nullptr;
 
-    ezComponentHandle hComponentA = TestComponent::CreateComponent(pObjectA, pComponentA);
-    ezComponentHandle hComponentB = TestComponent::CreateComponent(pObjectB, pComponentB);
-    ezComponentHandle hComponentC = TestComponent::CreateComponent(pObjectC, pComponentC);
+    ezTypedComponentHandle<TestComponent> hComponentA = TestComponent::CreateComponent(pObjectA, pComponentA);
+    ezTypedComponentHandle<TestComponent> hComponentB = TestComponent::CreateComponent(pObjectB, pComponentB);
+    ezTypedComponentHandle<TestComponent> hComponentC = TestComponent::CreateComponent(pObjectC, pComponentC);
 
     EZ_TEST_BOOL(!hComponentA.IsInvalidated());
     EZ_TEST_BOOL(!hComponentB.IsInvalidated());
@@ -321,7 +321,7 @@ EZ_CREATE_SIMPLE_TEST(World, Components)
 
     // creating a new component should reuse memory from component B
     TestComponent* pComponentB2 = nullptr;
-    ezComponentHandle hComponentB2 = TestComponent::CreateComponent(pObjectB, pComponentB2);
+    ezTypedComponentHandle<TestComponent> hComponentB2 = TestComponent::CreateComponent(pObjectB, pComponentB2);
     EZ_TEST_BOOL(!hComponentB2.IsInvalidated());
     EZ_TEST_BOOL(pComponentB2 == pComponentB);
   }
@@ -334,7 +334,7 @@ EZ_CREATE_SIMPLE_TEST(World, Components)
 
     for (auto it = pConstManager->GetComponents(); it.IsValid(); it.Next())
     {
-      ezComponentHandle hComponent = it->GetHandle();
+      ezTypedComponentHandle<TestComponent> hComponent = it->GetHandle();
 
       const TestComponent* pConstComponent = nullptr;
       EZ_TEST_BOOL(constWorld.TryGetComponent(hComponent, pConstComponent));

--- a/Code/UnitTests/CoreTest/World/DerivedComponentTest.cpp
+++ b/Code/UnitTests/CoreTest/World/DerivedComponentTest.cpp
@@ -66,7 +66,7 @@ EZ_CREATE_SIMPLE_TEST(World, DerivedComponents)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Derived Component Update")
   {
     TestComponentBase* pComponentBase = nullptr;
-    ezComponentHandle hComponentBase = TestComponentBase::CreateComponent(pObject, pComponentBase);
+    ezTypedComponentHandle<TestComponentBase> hComponentBase = TestComponentBase::CreateComponent(pObject, pComponentBase);
 
     TestComponentBase* pTestBase = nullptr;
     EZ_TEST_BOOL(world.TryGetComponent(hComponentBase, pTestBase));
@@ -75,7 +75,7 @@ EZ_CREATE_SIMPLE_TEST(World, DerivedComponents)
     EZ_TEST_BOOL(pComponentBase->GetOwningManager() == pManagerBase);
 
     TestComponentDerived1* pComponentDerived1 = nullptr;
-    ezComponentHandle hComponentDerived1 = TestComponentDerived1::CreateComponent(pObject2, pComponentDerived1);
+    ezTypedComponentHandle<TestComponentDerived1> hComponentDerived1 = TestComponentDerived1::CreateComponent(pObject2, pComponentDerived1);
 
     TestComponentDerived1* pTestDerived1 = nullptr;
     EZ_TEST_BOOL(world.TryGetComponent(hComponentDerived1, pTestDerived1));
@@ -91,5 +91,23 @@ EZ_CREATE_SIMPLE_TEST(World, DerivedComponents)
     // Get component manager via rtti
     EZ_TEST_BOOL(world.GetManagerForComponentType(ezGetStaticRTTI<TestComponentBase>()) == pManagerBase);
     EZ_TEST_BOOL(world.GetManagerForComponentType(ezGetStaticRTTI<TestComponentDerived1>()) == pManagerDerived1);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Derived Component TypedComponentHandle Assign")
+  {
+    TestComponentDerived1* pComponentDerived1 = nullptr;
+    ezTypedComponentHandle<TestComponentBase> hComponentBase(TestComponentDerived1::CreateComponent(pObject2, pComponentDerived1));
+
+    TestComponentDerived1* pTestDerived1 = nullptr;
+    EZ_TEST_BOOL(world.TryGetComponent(hComponentBase, pTestDerived1));
+    EZ_TEST_BOOL(pTestDerived1 == pComponentDerived1);
+    EZ_TEST_BOOL(pComponentDerived1->GetHandle() == hComponentBase);
+    EZ_TEST_BOOL(pComponentDerived1->GetOwningManager() == pManagerDerived1);
+
+    //Assignment test Derived -> Base
+    hComponentBase = pTestDerived1->GetHandle();
+    EZ_TEST_BOOL(world.TryGetComponent(hComponentBase, pTestDerived1));
+    EZ_TEST_BOOL(pComponentDerived1->GetHandle() == hComponentBase);
+    EZ_TEST_BOOL(pComponentDerived1->GetOwningManager() == pManagerDerived1);
   }
 }


### PR DESCRIPTION
Added ezTypedComponentHandle and adapted the unit test to get some converage as well.

However, I'm unsure how to properly test serialization (mentioned in this [Discord discussion](https://discord.com/channels/806092968346779699/1192661940556812369)) as `ezWorldReader::ReadComponentHandle` and ` ezWorldWriter::WriteComponentHandle` exist (and they compile b/c of the implicit downcast from ezTypedComponentHandle to ezComponentHandle), but there is no obvious way to set this via the editor, as only GameObjects can be exposed as properties.