### PR TITLE
ezStringView property support

### DIFF
--- a/Code/Engine/Foundation/Reflection/Implementation/VariantAdapter.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/VariantAdapter.h
@@ -462,3 +462,16 @@ struct ezVariantAdapter<const char*, const char*, 1, 0>
 
   ezVariant& m_value;
 };
+
+template <class T>
+struct ezVariantAdapter<T, ezStringView, 1, 0>
+{
+  ezVariantAdapter(ezVariant& value)
+    : m_value(value)
+  {
+  }
+
+  operator const ezStringView() { return m_value.IsA<ezStringView>() ? m_value.Get<ezStringView>() :  m_value.Get<ezString>().GetView(); }
+
+  ezVariant& m_value;
+};

--- a/Code/Engine/Foundation/Types/Implementation/Variant_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/Variant_inl.h
@@ -251,6 +251,20 @@ EZ_FORCE_INLINE bool ezVariant::operator==(const T& other) const
       return Cast<ezHashedString>() == other;
     }
   }
+  else if constexpr (std::is_same_v<T, ezStringView>)
+  {
+    if (m_uiType == Type::String)
+    {
+      return Cast<ezString>().GetView() == other;
+    }
+  }
+  else if constexpr (std::is_same_v<T, ezString>)
+  {
+    if (m_uiType == Type::StringView)
+    {
+      return Cast<ezStringView>() == other.GetView();
+    }
+  }
 
   using StorageType = typename TypeDeduction<T>::StorageType;
   EZ_ASSERT_DEV(IsA<StorageType>(), "Stored type '{0}' does not match comparison type '{1}'", m_uiType, TypeDeduction<T>::value);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
@@ -93,6 +93,7 @@ static ezQtPropertyWidget* StandardTypeCreator(const ezRTTI* pRtti)
       return new ezQtPropertyEditorIntSpinboxWidget(1, 0, 2147483645);
 
     case ezVariant::Type::String:
+    case ezVariant::Type::StringView:
       return new ezQtPropertyEditorLineEditWidget();
 
     case ezVariant::Type::Color:
@@ -173,6 +174,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, PropertyGrid)
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezUInt64>(), StandardTypeCreator);
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezConstCharPtr>(), StandardTypeCreator);
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezString>(), StandardTypeCreator);
+    ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezStringView>(), StandardTypeCreator);
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezTime>(), StandardTypeCreator);
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezColor>(), StandardTypeCreator);
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezColorGammaUB>(), StandardTypeCreator);
@@ -215,6 +217,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, PropertyGrid)
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezUInt64>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezConstCharPtr>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezString>());
+    ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezStringView>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezTime>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezColor>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezColorGammaUB>());

--- a/Code/Tools/Libs/ToolsFoundation/Command/Implementation/TreeCommands.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Command/Implementation/TreeCommands.cpp
@@ -701,6 +701,8 @@ ezStatus ezSetObjectPropertyCommand::DoInternal(bool bRedo)
 
   if (!bRedo)
   {
+    EZ_ASSERT_DEBUG(m_NewValue.GetType() != ezVariantType::StringView && m_NewValue.GetType() != ezVariantType::TypedPointer, "Variants that are stored in the command history must hold ownership of their value.");
+
     if (m_Object.IsValid())
     {
       m_pObject = pDocument->GetObjectManager()->GetObject(m_Object);

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageManager.cpp
@@ -76,7 +76,7 @@ void ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::AddPropertiesRe
     if (m_PathToStorageInfoTable.TryGetValue(path, storageInfo))
     {
       // Value already present, update type and instances
-      storageInfo->m_Type = GetStorageType(pProperty);
+      storageInfo->m_Type = ezToolsReflectionUtils::GetStorageType(pProperty);
       storageInfo->m_DefaultValue = ezToolsReflectionUtils::GetStorageDefault(pProperty);
       UpdateInstances(storageInfo->m_uiIndex, pProperty, ref_requiresPatchingEmbeddedClass);
     }
@@ -85,7 +85,7 @@ void ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::AddPropertiesRe
       const ezUInt16 uiIndex = (ezUInt16)m_PathToStorageInfoTable.GetCount();
 
       // Add value, new entries are appended
-      m_PathToStorageInfoTable.Insert(path, StorageInfo(uiIndex, GetStorageType(pProperty), ezToolsReflectionUtils::GetStorageDefault(pProperty)));
+      m_PathToStorageInfoTable.Insert(path, StorageInfo(uiIndex, ezToolsReflectionUtils::GetStorageType(pProperty), ezToolsReflectionUtils::GetStorageDefault(pProperty)));
       AddPropertyToInstances(uiIndex, pProperty, ref_requiresPatchingEmbeddedClass);
     }
   }
@@ -100,7 +100,7 @@ void ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::UpdateInstances
     EZ_ASSERT_DEV(uiIndex < data.GetCount(), "ezReflectedTypeStorageAccessor found with fewer properties that is should have!");
     ezVariant& value = data[uiIndex];
 
-    const auto SpecVarType = GetStorageType(pProperty);
+    const auto SpecVarType = ezToolsReflectionUtils::GetStorageType(pProperty);
 
     switch (pProperty->GetCategory())
     {
@@ -235,41 +235,6 @@ void ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::AddPropertyToIn
       ref_requiresPatchingEmbeddedClass.Insert(it.Key()->GetOwner());
     }
   }
-}
-
-
-ezVariantType::Enum ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::GetStorageType(const ezAbstractProperty* pProperty)
-{
-  ezVariantType::Enum type = ezVariantType::Uuid;
-
-  const bool bIsValueType = ezReflectionUtils::IsValueType(pProperty);
-
-  switch (pProperty->GetCategory())
-  {
-    case ezPropertyCategory::Member:
-    {
-      if (bIsValueType)
-        type = pProperty->GetSpecificType()->GetVariantType();
-      else if (pProperty->GetFlags().IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags))
-        type = ezVariantType::Int64;
-    }
-    break;
-    case ezPropertyCategory::Array:
-    case ezPropertyCategory::Set:
-    {
-      type = ezVariantType::VariantArray;
-    }
-    break;
-    case ezPropertyCategory::Map:
-    {
-      type = ezVariantType::VariantDictionary;
-    }
-    break;
-    default:
-      break;
-  }
-
-  return type;
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageManager.h
@@ -48,8 +48,6 @@ private:
     void UpdateInstances(ezUInt32 uiIndex, const ezAbstractProperty* pProperty, ezSet<const ezDocumentObject*>& ref_requiresPatchingEmbeddedClass);
     void AddPropertyToInstances(ezUInt32 uiIndex, const ezAbstractProperty* pProperty, ezSet<const ezDocumentObject*>& ref_requiresPatchingEmbeddedClass);
 
-    ezVariantType::Enum GetStorageType(const ezAbstractProperty* pProperty);
-
     ezSet<ezReflectedTypeStorageAccessor*> m_Instances;
     ezHashTable<ezString, StorageInfo> m_PathToStorageInfoTable;
   };

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ToolsReflectionUtils.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ToolsReflectionUtils.h
@@ -13,6 +13,10 @@ class ezAbstractObjectGraph;
 class EZ_TOOLSFOUNDATION_DLL ezToolsReflectionUtils
 {
 public:
+
+  /// \brief Returns the type under which the property is stored on the editor side.
+  static ezVariantType::Enum GetStorageType(const ezAbstractProperty* pProperty);
+
   /// \brief Returns the default value for the entire property as it is stored on the editor side.
   static ezVariant GetStorageDefault(const ezAbstractProperty* pProperty);
 

--- a/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
@@ -760,6 +760,9 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
 
     EZ_TEST_BOOL(v.IsNumber() == false);
     EZ_TEST_BOOL(v.IsString());
+    EZ_TEST_BOOL(v.CanConvertTo<ezStringView>());
+    ezStringView view = v.ConvertTo<ezStringView>();
+    EZ_TEST_BOOL(view == v.Get<ezString>());
     EZ_TEST_BOOL(v.IsFloatingPoint() == false);
   }
 
@@ -771,6 +774,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
     EZ_TEST_BOOL(v.Get<ezString>() == ezString("This is an ezString"));
 
     EZ_TEST_BOOL(v == ezVariant(ezString("This is an ezString")));
+    EZ_TEST_BOOL(v == ezVariant(ezStringView("This is an ezString"), false));
     EZ_TEST_BOOL(v != ezVariant(ezString("This is something else")));
 
     EZ_TEST_BOOL(v == ezString("This is an ezString"));
@@ -784,6 +788,9 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
 
     EZ_TEST_BOOL(v.IsNumber() == false);
     EZ_TEST_BOOL(v.IsString());
+    EZ_TEST_BOOL(v.CanConvertTo<ezStringView>());
+    ezStringView view = v.ConvertTo<ezStringView>();
+    EZ_TEST_BOOL(view == v.Get<ezString>());
     EZ_TEST_BOOL(v.IsFloatingPoint() == false);
   }
 
@@ -798,6 +805,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
     EZ_TEST_BOOL(v.Get<ezStringView>() == sCopy);
 
     EZ_TEST_BOOL(v == ezVariant(ezStringView(sCopy.GetData()), false));
+    EZ_TEST_BOOL(v == ezVariant(ezString("This is an ezStringView")));
     EZ_TEST_BOOL(v != ezVariant(ezStringView("This is something else"), false));
 
     EZ_TEST_BOOL(v == ezStringView(sCopy.GetData()));
@@ -808,6 +816,9 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
 
     EZ_TEST_BOOL(v.IsNumber() == false);
     EZ_TEST_BOOL(v.IsString());
+    EZ_TEST_BOOL(v.CanConvertTo<ezString>());
+    ezString sString = v.ConvertTo<ezString>();
+    EZ_TEST_BOOL(sString == v.Get<ezStringView>());
     EZ_TEST_BOOL(v.IsFloatingPoint() == false);
   }
 

--- a/Code/UnitTests/FoundationTest/Reflection/FunctionReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/FunctionReflectionTest.cpp
@@ -436,17 +436,33 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Functions)
     test.m_values.PushBack(ezVariant(ezString("String1")));
     test.m_values.PushBack(ezVariant(ezStringView("String2"), false));
 
-    ezVariant ret;
-    funccall.Execute(&test, test.m_values, ret);
-    EZ_TEST_BOOL(ret.GetType() == ezVariantType::String);
-    EZ_TEST_BOOL(ret == ezString("StringRet"));
+    {
+      // Exact types
+      ezVariant ret;
+      funccall.Execute(&test, test.m_values, ret);
+      EZ_TEST_BOOL(ret.GetType() == ezVariantType::String);
+      EZ_TEST_BOOL(ret == ezString("StringRet"));
+    }
 
-    test.m_bPtrAreNull = true;
-    test.m_values[0] = ezVariant();
-    ret = ezVariant();
-    funccall.Execute(&test, test.m_values, ret);
-    EZ_TEST_BOOL(ret.GetType() == ezVariantType::String);
-    EZ_TEST_BOOL(ret == ezString("StringRet"));
+    {
+      // Using ezString instead of ezStringView
+      test.m_values[2] = ezString("String2");
+      ezVariant ret;
+      funccall.Execute(&test, test.m_values, ret);
+      EZ_TEST_BOOL(ret.GetType() == ezVariantType::String);
+      EZ_TEST_BOOL(ret == ezString("StringRet"));
+      test.m_values[2] = ezVariant(ezStringView("String2"), false);
+    }
+
+    {
+      // Using nullptr instead of const char*
+      test.m_bPtrAreNull = true;
+      test.m_values[0] = ezVariant();
+      ezVariant ret;
+      funccall.Execute(&test, test.m_values, ret);
+      EZ_TEST_BOOL(ret.GetType() == ezVariantType::String);
+      EZ_TEST_BOOL(ret == ezString("StringRet"));
+    }
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Member Functions - Enum")

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -247,27 +247,31 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Types)
       const ezRTTI* pType = ezRTTI::FindTypeByName("ezTestClass2");
 
       auto Props = pType->GetProperties();
-      EZ_TEST_INT(Props.GetCount(), 6);
-      EZ_TEST_STRING(Props[0]->GetPropertyName(), "Text");
-      EZ_TEST_STRING(Props[1]->GetPropertyName(), "Time");
-      EZ_TEST_STRING(Props[2]->GetPropertyName(), "Enum");
-      EZ_TEST_STRING(Props[3]->GetPropertyName(), "Bitflags");
-      EZ_TEST_STRING(Props[4]->GetPropertyName(), "Array");
-      EZ_TEST_STRING(Props[5]->GetPropertyName(), "Variant");
+      EZ_TEST_INT(Props.GetCount(), 8);
+      EZ_TEST_STRING(Props[0]->GetPropertyName(), "CharPtr");
+      EZ_TEST_STRING(Props[1]->GetPropertyName(), "String");
+      EZ_TEST_STRING(Props[2]->GetPropertyName(), "StringView");
+      EZ_TEST_STRING(Props[3]->GetPropertyName(), "Time");
+      EZ_TEST_STRING(Props[4]->GetPropertyName(), "Enum");
+      EZ_TEST_STRING(Props[5]->GetPropertyName(), "Bitflags");
+      EZ_TEST_STRING(Props[6]->GetPropertyName(), "Array");
+      EZ_TEST_STRING(Props[7]->GetPropertyName(), "Variant");
 
       ezHybridArray<const ezAbstractProperty*, 32> AllProps;
       pType->GetAllProperties(AllProps);
 
-      EZ_TEST_INT(AllProps.GetCount(), 9);
+      EZ_TEST_INT(AllProps.GetCount(), 11);
       EZ_TEST_STRING(AllProps[0]->GetPropertyName(), "SubStruct");
       EZ_TEST_STRING(AllProps[1]->GetPropertyName(), "Color");
       EZ_TEST_STRING(AllProps[2]->GetPropertyName(), "SubVector");
-      EZ_TEST_STRING(AllProps[3]->GetPropertyName(), "Text");
-      EZ_TEST_STRING(AllProps[4]->GetPropertyName(), "Time");
-      EZ_TEST_STRING(AllProps[5]->GetPropertyName(), "Enum");
-      EZ_TEST_STRING(AllProps[6]->GetPropertyName(), "Bitflags");
-      EZ_TEST_STRING(AllProps[7]->GetPropertyName(), "Array");
-      EZ_TEST_STRING(AllProps[8]->GetPropertyName(), "Variant");
+      EZ_TEST_STRING(AllProps[3]->GetPropertyName(), "CharPtr");
+      EZ_TEST_STRING(AllProps[4]->GetPropertyName(), "String");
+      EZ_TEST_STRING(AllProps[5]->GetPropertyName(), "StringView");
+      EZ_TEST_STRING(AllProps[6]->GetPropertyName(), "Time");
+      EZ_TEST_STRING(AllProps[7]->GetPropertyName(), "Enum");
+      EZ_TEST_STRING(AllProps[8]->GetPropertyName(), "Bitflags");
+      EZ_TEST_STRING(AllProps[9]->GetPropertyName(), "Array");
+      EZ_TEST_STRING(AllProps[10]->GetPropertyName(), "Variant");
     }
   }
 
@@ -528,7 +532,15 @@ EZ_CREATE_SIMPLE_TEST(Reflection, MemberProperties)
     const ezRTTI* pRtti = ezGetStaticRTTI<ezTestClass2>();
 
     {
-      TestMemberProperty<const char*>("Text", &Instance, pRtti, ezPropertyFlags::StandardType | ezPropertyFlags::Const, ezString("Legen"), ezString("dary"));
+      TestMemberProperty<const char*>("CharPtr", &Instance, pRtti, ezPropertyFlags::StandardType | ezPropertyFlags::Const, ezString("AAA"), ezString("aaaa"));
+
+      TestMemberProperty<ezString>("String", &Instance, pRtti, ezPropertyFlags::StandardType, ezString("BBB"), ezString("bbbb"));
+
+      TestMemberProperty<ezStringView>("StringView", &Instance, pRtti, ezPropertyFlags::StandardType, "CCC"_ezsv, "cccc"_ezsv);
+
+      Instance.SetStringView("CCC");
+      TestMemberProperty<ezStringView>("StringView", &Instance, pRtti, ezPropertyFlags::StandardType, ezString("CCC"), ezString("cccc"));
+
       const ezAbstractProperty* pProp = pRtti->FindPropertyByName("SubVector", false);
       EZ_TEST_BOOL(pProp == nullptr);
     }

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.cpp
@@ -90,7 +90,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTestClass2, 22, ezTestClass2Allocator)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Text", GetText, SetText)->AddAttributes(new ezDefaultValueAttribute("Legen")),
+    EZ_ACCESSOR_PROPERTY("CharPtr", GetCharPtr, SetCharPtr)->AddAttributes(new ezDefaultValueAttribute("AAA")),
+    EZ_ACCESSOR_PROPERTY("String", GetString, SetString)->AddAttributes(new ezDefaultValueAttribute("BBB")),
+    EZ_ACCESSOR_PROPERTY("StringView", GetStringView, SetStringView)->AddAttributes(new ezDefaultValueAttribute("CCC")),
     EZ_MEMBER_PROPERTY("Time", m_Time),
     EZ_ENUM_MEMBER_PROPERTY("Enum", ezExampleEnum, m_enumClass),
     EZ_BITFLAGS_MEMBER_PROPERTY("Bitflags", ezExampleBitflags, m_bitflagsClass),

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.h
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.h
@@ -212,12 +212,18 @@ class ezTestClass2 : public ezTestClass1
   EZ_ADD_DYNAMIC_REFLECTION(ezTestClass2, ezTestClass1);
 
 public:
-  ezTestClass2() { m_sText = "Legen"; }
+  ezTestClass2() { m_sCharPtr = "AAA"; m_sString = "BBB"; m_sStringView = "CCC"; }
 
-  bool operator==(const ezTestClass2& rhs) const { return m_Time == rhs.m_Time && m_enumClass == rhs.m_enumClass && m_bitflagsClass == rhs.m_bitflagsClass && m_array == rhs.m_array && m_Variant == rhs.m_Variant && m_sText == rhs.m_sText; }
+  bool operator==(const ezTestClass2& rhs) const { return m_Time == rhs.m_Time && m_enumClass == rhs.m_enumClass && m_bitflagsClass == rhs.m_bitflagsClass && m_array == rhs.m_array && m_Variant == rhs.m_Variant && m_sCharPtr == rhs.m_sCharPtr && m_sString == rhs.m_sString && m_sStringView == rhs.m_sStringView; }
 
-  const char* GetText() const { return m_sText.GetData(); }
-  void SetText(const char* szSz) { m_sText = szSz; }
+  const char* GetCharPtr() const { return m_sCharPtr.GetData(); }
+  void SetCharPtr(const char* szSz) { m_sCharPtr = szSz; }
+
+  const ezString& GetString() const { return m_sString; }
+  void SetString(const ezString& sStr) { m_sString = sStr; }
+
+  ezStringView GetStringView() const { return m_sStringView.GetView(); }
+  void SetStringView(ezStringView sStrView) { m_sStringView = sStrView; }
 
   ezTime m_Time;
   ezEnum<ezExampleEnum> m_enumClass;
@@ -226,7 +232,9 @@ public:
   ezVariant m_Variant;
 
 private:
-  ezString m_sText;
+  ezString m_sCharPtr;
+  ezString m_sString;
+  ezString m_sStringView;
 };
 
 

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionUtilsTest.cpp
@@ -77,7 +77,9 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Utils)
     ezMemoryStreamWriter FileOut(&StreamStorage);
 
     ezTestClass2 c2;
-    c2.SetText("Hallo");
+    c2.SetCharPtr("Hallo");
+    c2.SetString("World");
+    c2.SetStringView("!!!");
     c2.m_MyVector.Set(14, 16, 18);
     c2.m_Struct.m_fFloat1 = 128;
     c2.m_Struct.m_UInt8 = 234;
@@ -103,7 +105,9 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Utils)
 
     ezReflectionSerializer::ReadObjectPropertiesFromDDL(FileIn, *c2.GetDynamicRTTI(), &c2);
 
-    EZ_TEST_STRING(c2.GetText(), "Hallo");
+    EZ_TEST_STRING(c2.GetCharPtr(), "Hallo");
+    EZ_TEST_STRING(c2.GetString(), "World");
+    EZ_TEST_STRING(c2.GetStringView(), "!!!");
     EZ_TEST_VEC3(c2.m_MyVector, ezVec3(3, 4, 5), 0.0f);
     EZ_TEST_FLOAT(c2.m_Time.GetSeconds(), 91.0f, 0.0f);
     EZ_TEST_FLOAT(c2.m_Color.r, 0.1f, 0.0f);
@@ -153,7 +157,9 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Utils)
 
     ezTestClass2& c2 = *((ezTestClass2*)pObject);
 
-    EZ_TEST_STRING(c2.GetText(), "Hallo");
+    EZ_TEST_STRING(c2.GetCharPtr(), "Hallo");
+    EZ_TEST_STRING(c2.GetString(), "World");
+    EZ_TEST_STRING(c2.GetStringView(), "!!!");
     EZ_TEST_VEC3(c2.m_MyVector, ezVec3(3, 4, 5), 0.0f);
     EZ_TEST_FLOAT(c2.m_Time.GetSeconds(), 91.0f, 0.0f);
     EZ_TEST_FLOAT(c2.m_Color.r, 0.1f, 0.0f);

--- a/Code/UnitTests/FoundationTest/Serialization/RttiConverterTest.cpp
+++ b/Code/UnitTests/FoundationTest/Serialization/RttiConverterTest.cpp
@@ -235,7 +235,9 @@ EZ_CREATE_SIMPLE_TEST(Serialization, RttiConverter)
     t1.m_array.PushBack(40.0f);
     t1.m_array.PushBack(-1.5f);
     t1.m_Variant = ezVec4(1, 2, 3, 4);
-    t1.SetText("LALALALA");
+    t1.SetCharPtr("Hello");
+    t1.SetString("World");
+    t1.SetStringView("!!!");
     TestSerialize(&t1);
 
     {

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -88,8 +88,36 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectionUtils)
     EZ_TEST_BOOL(podClass.GetBool() == false);
     VariantToPropertyTest(&podClass, pRttiPOD, "Color", ezVariant::Type::Color);
     EZ_TEST_BOOL(podClass.GetColor() == ezColor(1.0f, 1.0f, 1.0f, 1.0f));
+
+    VariantToPropertyTest(&podClass, pRttiPOD, "CharPtr", ezVariant::Type::String);
+    EZ_TEST_STRING(podClass.GetCharPtr(), "");
+
     VariantToPropertyTest(&podClass, pRttiPOD, "String", ezVariant::Type::String);
     EZ_TEST_STRING(podClass.GetString(), "");
+
+    // An ezStringView is special, ezReflectionUtils::GetMemberPropertyValue will return an ezString as that is the default assignment behaviour of ezStringView to ezVariant. However, ezReflectionUtils::GetDefaultValue will still return an ezStringView.
+    {
+      const ezAbstractMemberProperty* pProp = ezReflectionUtils::GetMemberProperty(pRttiPOD, "StringView");
+      EZ_TEST_BOOL(pProp != nullptr);
+      if (pProp)
+      {
+        ezVariant oldValue = ezReflectionUtils::GetMemberPropertyValue(pProp, &podClass);
+        EZ_TEST_BOOL(oldValue.IsValid());
+        EZ_TEST_BOOL(oldValue.GetType() == ezVariant::Type::String);
+
+        ezVariant defaultValue = ezReflectionUtils::GetDefaultValue(pProp);
+        EZ_TEST_BOOL(defaultValue.GetType() == ezVariant::Type::StringView);
+        ezReflectionUtils::SetMemberPropertyValue(pProp, &podClass, defaultValue);
+
+        ezVariant newValue = ezReflectionUtils::GetMemberPropertyValue(pProp, &podClass);
+        EZ_TEST_BOOL(newValue.IsValid());
+        EZ_TEST_BOOL(newValue.GetType() == ezVariant::Type::String);
+        EZ_TEST_BOOL(newValue == defaultValue);
+        EZ_TEST_BOOL(newValue != oldValue);
+      }
+      EZ_TEST_STRING(podClass.GetStringView(), "");
+    }
+
     VariantToPropertyTest(&podClass, pRttiPOD, "Buffer", ezVariant::Type::DataBuffer);
     EZ_TEST_BOOL(podClass.GetBuffer() == ezDataBuffer());
     VariantToPropertyTest(&podClass, pRttiPOD, "VarianceAngle", ezVariant::Type::TypedObject);
@@ -142,7 +170,7 @@ void AccessorPropertyTest(ezIReflectedTypeAccessor& ref_accessor, const char* sz
   EZ_TEST_BOOL(oldValue.GetType() == type);
 
   const ezAbstractProperty* pProp = ref_accessor.GetType()->FindPropertyByName(szProperty);
-  ezVariant defaultValue = ezReflectionUtils::GetDefaultValue(pProp);
+  ezVariant defaultValue = ezToolsReflectionUtils::GetStorageDefault(pProp);
   EZ_TEST_BOOL(defaultValue.GetType() == type);
   bool bSetSuccess = ref_accessor.SetValue(szProperty, defaultValue);
   EZ_TEST_BOOL(bSetSuccess);
@@ -188,7 +216,8 @@ ezUInt32 AccessorPropertiesTest(ezIReflectedTypeAccessor& ref_accessor, const ez
         }
         else if (bIsValueType)
         {
-          AccessorPropertyTest(ref_accessor, pProp->GetPropertyName(), pProp3->GetSpecificType()->GetVariantType());
+          ezVariantType::Enum storageType = ezToolsReflectionUtils::GetStorageType(pProp);
+          AccessorPropertyTest(ref_accessor, pProp->GetPropertyName(), storageType);
           uiPropertiesSet++;
         }
         else // ezPropertyFlags::Class
@@ -268,12 +297,12 @@ EZ_CREATE_SIMPLE_TEST(Reflection, ReflectedType)
     }
     {
       ezDocumentObject* pObject = manager.CreateObject(pRttiPOD);
-      EZ_TEST_INT(AccessorPropertiesTest(pObject->GetTypeAccessor()), 18);
+      EZ_TEST_INT(AccessorPropertiesTest(pObject->GetTypeAccessor()), 20);
       manager.DestroyObject(pObject);
     }
     {
       ezDocumentObject* pObject = manager.CreateObject(pRttiMath);
-      EZ_TEST_INT(AccessorPropertiesTest(pObject->GetTypeAccessor()), 27);
+      EZ_TEST_INT(AccessorPropertiesTest(pObject->GetTypeAccessor()), 29);
       manager.DestroyObject(pObject);
     }
     {

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.cpp
@@ -45,7 +45,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPODClass, 1, ezRTTIDefaultAllocator<ezPODClass
     EZ_ACCESSOR_PROPERTY("Bool", GetBool, SetBool),
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor),
     EZ_MEMBER_PROPERTY("ColorUB", m_Color2),
+    EZ_ACCESSOR_PROPERTY("CharPtr", GetCharPtr, SetCharPtr),
     EZ_ACCESSOR_PROPERTY("String", GetString, SetString),
+    EZ_ACCESSOR_PROPERTY("StringView", GetStringView, SetStringView),
     EZ_ACCESSOR_PROPERTY("Buffer", GetBuffer, SetBuffer),
     EZ_ACCESSOR_PROPERTY("VarianceAngle", GetCustom, SetCustom),
   }

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.h
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.h
@@ -81,7 +81,9 @@ public:
     m_bBool = true;
     m_Color = ezColor(1.0f, 0.0f, 0.0f, 0.0f);
     m_Color2 = ezColorGammaUB(255, 10, 1);
+    m_sCharPtr = "Test";
     m_sString = "Test";
+    m_sStringView = "Test";
     m_Buffer.PushBack(0xFF);
     m_Buffer.PushBack(0x0);
     m_Buffer.PushBack(0xCD);
@@ -91,12 +93,20 @@ public:
   ezIntegerStruct m_IntegerStruct;
   ezFloatStruct m_FloatStruct;
 
-  void SetBool(bool b) { m_bBool = b; }
   bool GetBool() const { return m_bBool; }
-  void SetColor(ezColor c) { m_Color = c; }
+  void SetBool(bool b) { m_bBool = b; }
+
   ezColor GetColor() const { return m_Color; }
-  const char* GetString() const { return m_sString.GetData(); }
-  void SetString(const char* szSz) { m_sString = szSz; }
+  void SetColor(ezColor c) { m_Color = c; }
+
+  const char* GetCharPtr() const { return m_sCharPtr.GetData(); }
+  void SetCharPtr(const char* szSz) { m_sCharPtr = szSz; }
+
+  const ezString& GetString() const { return m_sString; }
+  void SetString(const ezString& sStr) { m_sString = sStr; }
+
+  ezStringView GetStringView() const { return m_sStringView.GetView(); }
+  void SetStringView(ezStringView sStrView) { m_sStringView = sStrView; }
 
   const ezDataBuffer& GetBuffer() const { return m_Buffer; }
   void SetBuffer(const ezDataBuffer& data) { m_Buffer = data; }
@@ -108,7 +118,9 @@ private:
   bool m_bBool;
   ezColor m_Color;
   ezColorGammaUB m_Color2;
+  ezString m_sCharPtr;
   ezString m_sString;
+  ezString m_sStringView;
   ezDataBuffer m_Buffer;
   ezVarianceTypeAngle m_VarianceAngle;
 };


### PR DESCRIPTION
* Fixes #819 
## Foundation
* `ezVariantAdapter` was extended to allow ezStringView function parameters to be passed in as either `ezStringView` or `ezString`.
* `ezVariant` equal function was extended to allow comparision between `ezString` / `ezStringView` combinations.

## ToolsFoundation
* `ezReflectedTypeStorageManager::GetStorageType` moved to `ezToolsReflectionUtils`. This is what defines how the editor stores a property. The function was extended to store `ezStringView` as `ezString`.
* `ezToolsReflectionUtils::GetStorageDefault` now ensures that member property default values match the type of `ezToolsReflectionUtils::GetStorageType`.
* Assert if `ezStringView` pops up in the command history.

## Misc
* Lots of unit test additions.