### PR TITLE
Changed ezStringView to work around an MSVC code generation bug

### DIFF
--- a/Code/Engine/Foundation/Strings/StringView.h
+++ b/Code/Engine/Foundation/Strings/StringView.h
@@ -84,7 +84,7 @@ public:
   /// \brief Returns the number of bytes from the start position up to its end.
   ///
   /// \note Note that the element count (bytes) may be larger than the number of characters in that string, due to Utf8 encoding.
-  ezUInt32 GetElementCount() const { return (ezUInt32)(m_pEnd - m_pStart); } // [tested]
+  ezUInt32 GetElementCount() const { return m_uiElementCount; } // [tested]
 
   /// \brief Allows to set the start position to a different value.
   ///
@@ -99,7 +99,7 @@ public:
   ///
   /// That means it might point to the '\0' terminator, UNLESS the view only represents a sub-string of a larger string.
   /// Accessing the value at 'GetEnd' has therefore no real use.
-  const char* GetEndPointer() const { return m_pEnd; } // [tested]
+  const char* GetEndPointer() const { return m_pStart + m_uiElementCount; } // [tested]
 
   /// Returns whether the string is an empty string.
   bool IsEmpty() const; // [tested]
@@ -294,7 +294,7 @@ public:
 
 private:
   const char* m_pStart = nullptr;
-  const char* m_pEnd = nullptr;
+  ezUInt32 m_uiElementCount = 0;
 };
 
 /// \brief String literal suffix to create a ezStringView.

--- a/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringBuilderTest.cpp
@@ -317,12 +317,14 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringBuilder)
     EZ_TEST_BOOL(s == ezStringUtf8(L"Test42foobär").GetData());
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Format")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SetFormat")
   {
     ezStringBuilder s("abc");
     s.SetFormat("Test{0}{1}{2}", 42, "foo", ezStringUtf8(L"bär").GetData());
-
     EZ_TEST_BOOL(s == ezStringUtf8(L"Test42foobär").GetData());
+
+    s.SetFormat("%%процент{}%%", 100);
+    EZ_TEST_BOOL(s == ezStringUtf8(L"%процент100%").GetData());
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ToUpper")

--- a/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
+++ b/Code/UnitTests/FoundationTest/Strings/StringViewTest.cpp
@@ -3,6 +3,14 @@
 #include <Foundation/Containers/Deque.h>
 #include <Foundation/Strings/String.h>
 
+#include <string_view>
+
+using namespace std;
+
+const ezStringView gConstant1 = "gConstant1"_ezsv;
+const ezStringView gConstant2("gConstant2");
+const std::string_view gConstant3 = "gConstant3"sv;
+
 EZ_CREATE_SIMPLE_TEST(Strings, StringView)
 {
   ezStringBuilder tmp;
@@ -55,6 +63,16 @@ EZ_CREATE_SIMPLE_TEST(Strings, StringView)
     ezStringView b = "Hello Worl"_ezsv;
     EZ_TEST_INT(b.GetElementCount(), 10);
     EZ_TEST_STRING(b.GetData(tmp), "Hello Worl");
+
+    // tests a special case in which the MSVC compiler would run into trouble
+    EZ_TEST_INT(gConstant1.GetElementCount(), 10);
+    EZ_TEST_STRING(gConstant1.GetData(tmp), "gConstant1");
+
+    EZ_TEST_INT(gConstant2.GetElementCount(), 10);
+    EZ_TEST_STRING(gConstant2.GetData(tmp), "gConstant2");
+
+    EZ_TEST_INT(gConstant3.size(), 10);
+    EZ_TEST_BOOL(gConstant3 == "gConstant3");
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "operator++")

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: D16371FD-C27A-46FB-AF82-AB1EFAF0540B
+Change me: D16372FD-C27A-56FB-AF82-AB1EFAF0540B


### PR DESCRIPTION
Under very specific circumstances the compile time evaluation of ezStringView got broken and it stored incorrect content. This could only happen because ezStringView stores two pointers, rather than a start pointer and a length, as other implementations do. To work around this, the ezStringView implementation was modified to also store a start pointer and a byte count.