### PR TITLE
LOD support for collision meshes and animated meshes

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -78,6 +78,13 @@ ezStatus ezAnimatedMeshAssetDocument::CreateMeshFromFile(ezAnimatedMeshAssetProp
   opt.m_bNormalizeWeights = pProp->m_bNormalizeWeights;
   // opt.m_RootTransform = CalculateTransformationMatrix(pProp);
 
+  if (pProp->m_bSimplifyMesh)
+  {
+    opt.m_uiMeshSimplification = pProp->m_uiMeshSimplification;
+    opt.m_uiMaxSimplificationError = pProp->m_uiMaxSimplificationError;
+    opt.m_bAggressiveSimplification = pProp->m_bAggressiveSimplification;
+  }
+
   if (pImporter->Import(opt).Failed())
     return ezStatus("Model importer was unable to read this asset.");
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
@@ -17,6 +17,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetProperties, 2, ezRTTIDefaultA
     EZ_MEMBER_PROPERTY("NormalizeWeights", m_bNormalizeWeights)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("ImportMaterials", m_bImportMaterials)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_ARRAY_MEMBER_PROPERTY("Materials", m_Slots)->AddAttributes(new ezContainerAttribute(false, true, true)),
+    EZ_MEMBER_PROPERTY("SimplifyMesh", m_bSimplifyMesh),
+    EZ_MEMBER_PROPERTY("MeshSimplification", m_uiMeshSimplification)->AddAttributes(new ezDefaultValueAttribute(50), new ezClampValueAttribute(1, 100)),
+    EZ_MEMBER_PROPERTY("MaxSimplificationError", m_uiMaxSimplificationError)->AddAttributes(new ezDefaultValueAttribute(5), new ezClampValueAttribute(1, 100)),
+    EZ_MEMBER_PROPERTY("AggressiveSimplification", m_bAggressiveSimplification),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.h
@@ -24,4 +24,9 @@ public:
   ezEnum<ezMeshBoneWeigthPrecision> m_BoneWeightPrecision;
 
   ezHybridArray<ezMaterialResourceSlot, 8> m_Slots;
+
+  bool m_bSimplifyMesh = false;
+  bool m_bAggressiveSimplification = false;
+  ezUInt8 m_uiMeshSimplification = 50;
+  ezUInt8 m_uiMaxSimplificationError = 5;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
@@ -73,6 +73,6 @@ public:
 
   bool m_bSimplifyMesh = false;
   bool m_bAggressiveSimplification = false;
-  ezUInt8 m_uiMeshSimplification = 0;
+  ezUInt8 m_uiMeshSimplification = 50;
   ezUInt8 m_uiMaxSimplificationError = 5;
 };

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -141,6 +141,13 @@ ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltCookingMesh&
   opt.m_pMeshOutput = &meshDesc;
   opt.m_RootTransform = CalculateTransformationMatrix(pProp);
 
+  if (pProp->m_bSimplifyMesh)
+  {
+    opt.m_uiMeshSimplification = pProp->m_uiMeshSimplification;
+    opt.m_uiMaxSimplificationError = pProp->m_uiMaxSimplificationError;
+    opt.m_bAggressiveSimplification = pProp->m_bAggressiveSimplification;
+  }
+
   if (pImporter->Import(opt).Failed())
     return ezStatus("Model importer was unable to read this asset.");
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -46,6 +46,11 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 1, ezRTTIDef
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes)),
     EZ_ARRAY_MEMBER_PROPERTY("Surfaces", m_Slots)->AddAttributes(new ezContainerAttribute(false, false, true)),
     EZ_MEMBER_PROPERTY("Surface", m_sConvexMeshSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
+
+    EZ_MEMBER_PROPERTY("SimplifyMesh", m_bSimplifyMesh),
+    EZ_MEMBER_PROPERTY("MeshSimplification", m_uiMeshSimplification)->AddAttributes(new ezDefaultValueAttribute(50), new ezClampValueAttribute(1, 100)),
+    EZ_MEMBER_PROPERTY("MaxSimplificationError", m_uiMaxSimplificationError)->AddAttributes(new ezDefaultValueAttribute(20), new ezClampValueAttribute(1, 100)),
+    EZ_MEMBER_PROPERTY("AggressiveSimplification", m_bAggressiveSimplification),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
@@ -77,4 +77,9 @@ public:
 
   ezUInt32 m_uiVertices = 0;
   ezUInt32 m_uiTriangles = 0;
+
+  bool m_bSimplifyMesh = false;
+  bool m_bAggressiveSimplification = false;
+  ezUInt8 m_uiMeshSimplification = 50;
+  ezUInt8 m_uiMaxSimplificationError = 10;
 };

--- a/Code/Engine/Foundation/Math/Implementation/Frustum.cpp
+++ b/Code/Engine/Foundation/Math/Implementation/Frustum.cpp
@@ -370,14 +370,6 @@ ezFrustum ezFrustum::MakeFromCorners(const ezVec3 pCorners[FrustumCorner::CORNER
 
   res.m_Planes[PlaneType::NearPlane] = ezPlane::MakeFromPoints(pCorners[FrustumCorner::NearTopLeft], pCorners[FrustumCorner::NearBottomRight], pCorners[FrustumCorner::NearTopRight]);
 
-  if (true)
-  {
-    for (int i = 0; i < 6; ++i)
-    {
-      res.m_Planes[i].Flip();
-    }
-  }
-
   EZ_ASSERT_DEV(res.IsValid(), "Frustum is not valid after construction.");
 
   return res;

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -431,7 +431,7 @@ void ezLodAnimatedMeshComponent::InitializeAnimationPose()
 {
   m_MaxBounds = ezBoundingBox::MakeInvalid();
 
-  if (!m_Meshes[0].m_hMesh.IsValid())
+  if (m_Meshes.IsEmpty() || !m_Meshes[0].m_hMesh.IsValid())
     return;
 
   ezResourceLock<ezMeshResource> pMesh(m_Meshes[0].m_hMesh, ezResourceAcquireMode::BlockTillLoaded);

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -8,6 +8,12 @@
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
 #include <RendererFoundation/Device/Device.h>
+#include <ozz/animation/runtime/local_to_model_job.h>
+#include <ozz/animation/runtime/skeleton.h>
+#include <ozz/base/containers/vector.h>
+#include <ozz/base/maths/simd_math.h>
+#include <ozz/base/maths/soa_transform.h>
+#include <ozz/base/span.h>
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_TYPE(ezLodAnimatedMeshLod, ezNoBase, 1, ezRTTIDefaultAllocator<ezLodAnimatedMeshLod>)

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -1,0 +1,551 @@
+#include <RendererCore/RendererCorePCH.h>
+
+#include <Core/Messages/SetColorMessage.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <GameEngine/Animation/Skeletal/LodAnimatedMeshComponent.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+#include <RendererCore/Pipeline/View.h>
+#include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererFoundation/Device/Device.h>
+
+// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezLodAnimatedMeshLod, ezNoBase, 1, ezRTTIDefaultAllocator<ezLodAnimatedMeshLod>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Mesh", GetMeshFile, SetMeshFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned")),
+    EZ_MEMBER_PROPERTY("Threshold", m_fThreshold)
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_STATIC_REFLECTED_TYPE;
+
+EZ_BEGIN_COMPONENT_TYPE(ezLodAnimatedMeshComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezExposeColorAlphaAttribute()),
+    EZ_ACCESSOR_PROPERTY("SortingDepthOffset", GetSortingDepthOffset, SetSortingDepthOffset),
+    EZ_MEMBER_PROPERTY("BoundsOffset", m_vBoundsOffset),
+    EZ_MEMBER_PROPERTY("BoundsRadius", m_fBoundsRadius)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.01f, 100.0f)),
+    EZ_ACCESSOR_PROPERTY("ShowDebugInfo", GetShowDebugInfo, SetShowDebugInfo),
+    EZ_ACCESSOR_PROPERTY("OverlapRanges", GetOverlapRanges, SetOverlapRanges)->AddAttributes(new ezDefaultValueAttribute(true)),
+    EZ_ARRAY_MEMBER_PROPERTY("Meshes", m_Meshes)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Static")),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("Animation"),
+    new ezSphereVisualizerAttribute("BoundsRadius", ezColor::MediumVioletRed, nullptr, ezVisualizerAnchor::Center, ezVec3(1.0f), "BoundsOffset"),
+    new ezTransformManipulatorAttribute("BoundsOffset"),
+  }
+  EZ_END_ATTRIBUTES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+    EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+    EZ_MESSAGE_HANDLER(ezMsgAnimationPoseUpdated, OnAnimationPoseUpdated),
+    EZ_MESSAGE_HANDLER(ezMsgQueryAnimationSkeleton, OnQueryAnimationSkeleton),
+  }
+  EZ_END_MESSAGEHANDLERS;
+}
+EZ_END_COMPONENT_TYPE;
+// clang-format on
+
+const char* ezLodAnimatedMeshLod::GetMeshFile() const
+{
+  if (!m_hMesh.IsValid())
+    return "";
+
+  return m_hMesh.GetResourceID();
+}
+
+void ezLodAnimatedMeshLod::SetMeshFile(const char* szFile)
+{
+  ezMeshResourceHandle hMesh;
+
+  if (!ezStringUtils::IsNullOrEmpty(szFile))
+  {
+    hMesh = ezResourceManager::LoadResource<ezMeshResource>(szFile);
+  }
+
+  if (m_hMesh != hMesh)
+  {
+    m_hMesh = hMesh;
+
+    // TriggerLocalBoundsUpdate();
+    // InvalidateCachedRenderData();
+  }
+}
+
+struct LodAnimatedMeshCompFlags
+{
+  enum Enum
+  {
+    ShowDebugInfo = 0,
+    OverlapRanges = 1,
+  };
+};
+
+ezLodAnimatedMeshComponent::ezLodAnimatedMeshComponent() = default;
+ezLodAnimatedMeshComponent::~ezLodAnimatedMeshComponent() = default;
+
+void ezLodAnimatedMeshComponent::SetShowDebugInfo(bool bShow)
+{
+  SetUserFlag(LodAnimatedMeshCompFlags::ShowDebugInfo, bShow);
+}
+
+bool ezLodAnimatedMeshComponent::GetShowDebugInfo() const
+{
+  return GetUserFlag(LodAnimatedMeshCompFlags::ShowDebugInfo);
+}
+
+void ezLodAnimatedMeshComponent::SetOverlapRanges(bool bShow)
+{
+  SetUserFlag(LodAnimatedMeshCompFlags::OverlapRanges, bShow);
+}
+
+bool ezLodAnimatedMeshComponent::GetOverlapRanges() const
+{
+  return GetUserFlag(LodAnimatedMeshCompFlags::OverlapRanges);
+}
+
+void ezLodAnimatedMeshComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+  ezStreamWriter& s = inout_stream.GetStream();
+
+  s << m_Meshes.GetCount();
+  for (const auto& mesh : m_Meshes)
+  {
+    s << mesh.m_hMesh;
+    s << mesh.m_fThreshold;
+  }
+
+  s << m_Color;
+  s << m_fSortingDepthOffset;
+
+  s << m_vBoundsOffset;
+  s << m_fBoundsRadius;
+}
+
+void ezLodAnimatedMeshComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+
+  ezStreamReader& s = inout_stream.GetStream();
+
+  ezUInt32 uiMeshes = 0;
+  s >> uiMeshes;
+
+  m_Meshes.SetCount(uiMeshes);
+
+  for (auto& mesh : m_Meshes)
+  {
+    s >> mesh.m_hMesh;
+    s >> mesh.m_fThreshold;
+  }
+
+  s >> m_Color;
+  s >> m_fSortingDepthOffset;
+
+  s >> m_vBoundsOffset;
+  s >> m_fBoundsRadius;
+}
+
+ezResult ezLodAnimatedMeshComponent::GetLocalBounds(ezBoundingBoxSphere& out_bounds, bool& out_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg)
+{
+  out_bounds = ezBoundingSphere::MakeFromCenterAndRadius(m_vBoundsOffset, m_fBoundsRadius);
+  out_bAlwaysVisible = false;
+  return EZ_SUCCESS;
+}
+
+void ezLodAnimatedMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
+{
+  if (m_Meshes.IsEmpty())
+    return;
+
+  if (msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::EditorView || msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::MainView)
+  {
+    UpdateSelectedLod(*msg.m_pView);
+  }
+
+  if (m_iCurLod >= m_Meshes.GetCount())
+    return;
+
+  auto hMesh = m_Meshes[m_iCurLod].m_hMesh;
+
+  if (!hMesh.IsValid())
+    return;
+
+  ezResourceLock<ezMeshResource> pMesh(hMesh, ezResourceAcquireMode::AllowLoadingFallback);
+  ezArrayPtr<const ezMeshResourceDescriptor::SubMesh> parts = pMesh->GetSubMeshes();
+
+  for (ezUInt32 uiPartIndex = 0; uiPartIndex < parts.GetCount(); ++uiPartIndex)
+  {
+    const ezUInt32 uiMaterialIndex = parts[uiPartIndex].m_uiMaterialIndex;
+    ezMaterialResourceHandle hMaterial;
+
+    hMaterial = pMesh->GetMaterials()[uiMaterialIndex];
+
+    ezMeshRenderData* pRenderData = CreateRenderData();
+    {
+      pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform() * pRenderData->m_GlobalTransform;
+      pRenderData->m_GlobalBounds = GetOwner()->GetGlobalBounds();
+      pRenderData->m_fSortingDepthOffset = m_fSortingDepthOffset;
+      pRenderData->m_hMesh = hMesh;
+      pRenderData->m_hMaterial = hMaterial;
+      pRenderData->m_Color = m_Color;
+      pRenderData->m_uiSubMeshIndex = uiPartIndex;
+      pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
+
+      pRenderData->FillBatchIdAndSortingKey();
+    }
+
+    // Determine render data category.
+    ezRenderData::Category category = ezDefaultRenderDataCategories::LitOpaque;
+    if (hMaterial.IsValid())
+    {
+      ezResourceLock<ezMaterialResource> pMaterial(hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+
+      category = pMaterial->GetRenderDataCategory();
+    }
+
+    msg.AddRenderData(pRenderData, category, ezRenderData::Caching::Never);
+  }
+}
+
+void ezLodAnimatedMeshComponent::MapModelSpacePoseToSkinningSpace(const ezHashTable<ezHashedString, ezMeshResourceDescriptor::BoneData>& bones, const ezSkeleton& skeleton, ezArrayPtr<const ezMat4> modelSpaceTransforms, ezBoundingBox* bounds)
+{
+  m_SkinningState.m_Transforms.SetCountUninitialized(bones.GetCount());
+
+  if (bounds)
+  {
+    for (auto itBone : bones)
+    {
+      const ezUInt16 uiJointIdx = skeleton.FindJointByName(itBone.Key());
+
+      if (uiJointIdx == ezInvalidJointIndex)
+        continue;
+
+      bounds->ExpandToInclude(modelSpaceTransforms[uiJointIdx].GetTranslationVector());
+      m_SkinningState.m_Transforms[itBone.Value().m_uiBoneIndex] = modelSpaceTransforms[uiJointIdx] * itBone.Value().m_GlobalInverseRestPoseMatrix;
+    }
+  }
+  else
+  {
+    for (auto itBone : bones)
+    {
+      const ezUInt16 uiJointIdx = skeleton.FindJointByName(itBone.Key());
+
+      if (uiJointIdx == ezInvalidJointIndex)
+        continue;
+
+      m_SkinningState.m_Transforms[itBone.Value().m_uiBoneIndex] = modelSpaceTransforms[uiJointIdx] * itBone.Value().m_GlobalInverseRestPoseMatrix;
+    }
+  }
+}
+
+void ezLodAnimatedMeshComponent::SetColor(const ezColor& color)
+{
+  m_Color = color;
+
+  InvalidateCachedRenderData();
+}
+
+const ezColor& ezLodAnimatedMeshComponent::GetColor() const
+{
+  return m_Color;
+}
+
+void ezLodAnimatedMeshComponent::SetSortingDepthOffset(float fOffset)
+{
+  m_fSortingDepthOffset = fOffset;
+
+  InvalidateCachedRenderData();
+}
+
+float ezLodAnimatedMeshComponent::GetSortingDepthOffset() const
+{
+  return m_fSortingDepthOffset;
+}
+
+void ezLodAnimatedMeshComponent::OnMsgSetColor(ezMsgSetColor& ref_msg)
+{
+  ref_msg.ModifyColor(m_Color);
+
+  InvalidateCachedRenderData();
+}
+
+ezMeshRenderData* ezLodAnimatedMeshComponent::CreateRenderData() const
+{
+  auto pRenderData = ezCreateRenderDataForThisFrame<ezSkinnedMeshRenderData>(GetOwner());
+  pRenderData->m_GlobalTransform = m_RootTransform;
+
+  m_SkinningState.FillSkinnedMeshRenderData(*pRenderData);
+
+  return pRenderData;
+}
+
+static float CalculateSphereScreenSpaceCoverage(const ezBoundingSphere& sphere, const ezCamera& camera)
+{
+  if (camera.IsPerspective())
+  {
+    return ezGraphicsUtils::CalculateSphereScreenCoverage(sphere, camera.GetCenterPosition(), camera.GetFovY(1.0f));
+  }
+  else
+  {
+    return ezGraphicsUtils::CalculateSphereScreenCoverage(sphere.m_fRadius, camera.GetDimensionY(1.0f));
+  }
+}
+
+void ezLodAnimatedMeshComponent::UpdateSelectedLod(const ezView& view) const
+{
+  const ezInt32 iNumLods = (ezInt32)m_Meshes.GetCount();
+
+  const ezVec3 vScale = GetOwner()->GetGlobalScaling();
+  const float fScale = ezMath::Max(vScale.x, vScale.y, vScale.z);
+  const ezVec3 vCenter = GetOwner()->GetGlobalTransform() * m_vBoundsOffset;
+
+  const float fCoverage = CalculateSphereScreenSpaceCoverage(ezBoundingSphere::MakeFromCenterAndRadius(vCenter, fScale * m_fBoundsRadius), *view.GetLodCamera());
+
+  // clamp the input value, this is to prevent issues while editing the threshold array
+  ezInt32 iNewLod = ezMath::Clamp<ezInt32>(m_iCurLod, 0, iNumLods);
+
+  float fCoverageP = 1;
+  float fCoverageN = 0;
+
+  if (iNewLod > 0)
+  {
+    fCoverageP = m_Meshes[iNewLod - 1].m_fThreshold;
+  }
+
+  if (iNewLod < iNumLods)
+  {
+    fCoverageN = m_Meshes[iNewLod].m_fThreshold;
+  }
+
+  if (GetOverlapRanges())
+  {
+    const float fLodRangeOverlap = 0.40f;
+
+    if (iNewLod + 1 < iNumLods)
+    {
+      float range = (fCoverageN - m_Meshes[iNewLod + 1].m_fThreshold);
+      fCoverageN -= range * fLodRangeOverlap; // overlap into the next range
+    }
+    else
+    {
+      float range = (fCoverageN - 0.0f);
+      fCoverageN -= range * fLodRangeOverlap; // overlap into the next range
+    }
+  }
+
+  if (fCoverage < fCoverageN)
+  {
+    ++iNewLod;
+  }
+  else if (fCoverage > fCoverageP)
+  {
+    --iNewLod;
+  }
+
+  iNewLod = ezMath::Clamp(iNewLod, 0, iNumLods);
+  m_iCurLod = iNewLod;
+
+  if (GetShowDebugInfo())
+  {
+    ezStringBuilder sb;
+    sb.SetFormat("Coverage: {}\nLOD {}\nRange: {} - {}", ezArgF(fCoverage, 3), iNewLod, ezArgF(fCoverageP, 3), ezArgF(fCoverageN, 3));
+    ezDebugRenderer::Draw3DText(view.GetHandle(), sb, GetOwner()->GetGlobalPosition(), ezColor::White);
+  }
+}
+
+void ezLodAnimatedMeshComponent::OnAnimationPoseUpdated(ezMsgAnimationPoseUpdated& msg)
+{
+  if (m_Meshes.IsEmpty() || !m_Meshes[0].m_hMesh.IsValid())
+    return;
+
+  m_RootTransform = *msg.m_pRootTransform;
+
+  ezResourceLock<ezMeshResource> pMesh(m_Meshes[0].m_hMesh, ezResourceAcquireMode::BlockTillLoaded);
+
+  ezBoundingBox poseBounds;
+  poseBounds = ezBoundingBox::MakeInvalid();
+  MapModelSpacePoseToSkinningSpace(pMesh->m_Bones, *msg.m_pSkeleton, msg.m_ModelTransforms, &poseBounds);
+
+  if (poseBounds.IsValid() && (!m_MaxBounds.IsValid() || !m_MaxBounds.Contains(poseBounds)))
+  {
+    m_MaxBounds.ExpandToInclude(poseBounds);
+    TriggerLocalBoundsUpdate();
+  }
+  else if (((ezRenderWorld::GetFrameCounter() + GetUniqueIdForRendering()) & (EZ_BIT(10) - 1)) == 0) // reset the bbox every once in a while
+  {
+    m_MaxBounds = poseBounds;
+    TriggerLocalBoundsUpdate();
+  }
+
+  m_SkinningState.TransformsChanged();
+}
+
+void ezLodAnimatedMeshComponent::OnQueryAnimationSkeleton(ezMsgQueryAnimationSkeleton& msg)
+{
+  if (m_Meshes.IsEmpty() || !m_Meshes[0].m_hMesh.IsValid())
+    return;
+
+  if (!msg.m_hSkeleton.IsValid())
+  {
+    // only overwrite, if no one else had a better skeleton (e.g. the ezSkeletonComponent)
+
+    ezResourceLock<ezMeshResource> pMesh(m_Meshes[0].m_hMesh, ezResourceAcquireMode::BlockTillLoaded);
+    if (pMesh.GetAcquireResult() == ezResourceAcquireResult::Final)
+    {
+      msg.m_hSkeleton = pMesh->m_hDefaultSkeleton;
+    }
+  }
+}
+
+void ezLodAnimatedMeshComponent::OnActivated()
+{
+  SUPER::OnActivated();
+
+  InitializeAnimationPose();
+}
+
+void ezLodAnimatedMeshComponent::OnDeactivated()
+{
+  m_SkinningState.Clear();
+
+  SUPER::OnDeactivated();
+}
+
+void ezLodAnimatedMeshComponent::InitializeAnimationPose()
+{
+  m_MaxBounds = ezBoundingBox::MakeInvalid();
+
+  if (!m_Meshes[0].m_hMesh.IsValid())
+    return;
+
+  ezResourceLock<ezMeshResource> pMesh(m_Meshes[0].m_hMesh, ezResourceAcquireMode::BlockTillLoaded);
+  if (pMesh.GetAcquireResult() != ezResourceAcquireResult::Final)
+    return;
+
+  m_hDefaultSkeleton = pMesh->m_hDefaultSkeleton;
+  const auto hSkeleton = m_hDefaultSkeleton;
+
+  if (!hSkeleton.IsValid())
+    return;
+
+  ezResourceLock<ezSkeletonResource> pSkeleton(hSkeleton, ezResourceAcquireMode::BlockTillLoaded);
+  if (pSkeleton.GetAcquireResult() != ezResourceAcquireResult::Final)
+    return;
+
+  {
+    const ozz::animation::Skeleton* pOzzSkeleton = &pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
+    const ezUInt32 uiNumSkeletonJoints = pOzzSkeleton->num_joints();
+
+    ezArrayPtr<ezMat4> pPoseMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezMat4, uiNumSkeletonJoints);
+
+    {
+      ozz::animation::LocalToModelJob job;
+      job.input = pOzzSkeleton->joint_rest_poses();
+      job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(pPoseMatrices.GetPtr()), reinterpret_cast<ozz::math::Float4x4*>(pPoseMatrices.GetEndPtr()));
+      job.skeleton = pOzzSkeleton;
+      job.Run();
+    }
+
+    ezMsgAnimationPoseUpdated msg;
+    msg.m_ModelTransforms = pPoseMatrices;
+    msg.m_pRootTransform = &pSkeleton->GetDescriptor().m_RootTransform;
+    msg.m_pSkeleton = &pSkeleton->GetDescriptor().m_Skeleton;
+
+    OnAnimationPoseUpdated(msg);
+  }
+
+  TriggerLocalBoundsUpdate();
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+
+ezLodAnimatedMeshComponentManager::ezLodAnimatedMeshComponentManager(ezWorld* pWorld)
+  : ezComponentManager<ComponentType, ezBlockStorageType::FreeList>(pWorld)
+{
+  ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&ezLodAnimatedMeshComponentManager::ResourceEventHandler, this));
+}
+
+ezLodAnimatedMeshComponentManager::~ezLodAnimatedMeshComponentManager()
+{
+  ezResourceManager::GetResourceEvents().RemoveEventHandler(ezMakeDelegate(&ezLodAnimatedMeshComponentManager::ResourceEventHandler, this));
+}
+
+void ezLodAnimatedMeshComponentManager::Initialize()
+{
+  auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezLodAnimatedMeshComponentManager::Update, this);
+
+  RegisterUpdateFunction(desc);
+}
+
+void ezLodAnimatedMeshComponentManager::ResourceEventHandler(const ezResourceEvent& e)
+{
+  if (e.m_Type == ezResourceEvent::Type::ResourceContentUnloading)
+  {
+    if (ezMeshResource* pResource = ezDynamicCast<ezMeshResource*>(e.m_pResource))
+    {
+      ezMeshResourceHandle hMesh(pResource);
+
+      for (auto it = GetComponents(); it.IsValid(); it.Next())
+      {
+        for (auto& am : it->m_Meshes)
+        {
+          if (am.m_hMesh == hMesh)
+          {
+            AddToUpdateList(it);
+          }
+        }
+      }
+    }
+
+    if (ezSkeletonResource* pResource = ezDynamicCast<ezSkeletonResource*>(e.m_pResource))
+    {
+      ezSkeletonResourceHandle hSkeleton(pResource);
+
+      for (auto it = GetComponents(); it.IsValid(); it.Next())
+      {
+        if (it->m_hDefaultSkeleton == hSkeleton)
+        {
+          AddToUpdateList(it);
+        }
+      }
+    }
+  }
+}
+
+void ezLodAnimatedMeshComponentManager::Update(const ezWorldModule::UpdateContext& context)
+{
+  for (auto hComp : m_ComponentsToUpdate)
+  {
+    ezLodAnimatedMeshComponent* pComponent = nullptr;
+    if (!TryGetComponent(hComp, pComponent))
+      continue;
+
+    if (!pComponent->IsActive())
+      continue;
+
+    pComponent->InitializeAnimationPose();
+  }
+
+  m_ComponentsToUpdate.Clear();
+}
+
+void ezLodAnimatedMeshComponentManager::AddToUpdateList(ezLodAnimatedMeshComponent* pComponent)
+{
+  ezComponentHandle hComponent = pComponent->GetHandle();
+
+  if (m_ComponentsToUpdate.IndexOf(hComponent) == ezInvalidIndex)
+  {
+    m_ComponentsToUpdate.PushBack(hComponent);
+  }
+}

--- a/Code/Engine/GameEngine/Animation/Skeletal/LodAnimatedMeshComponent.h
+++ b/Code/Engine/GameEngine/Animation/Skeletal/LodAnimatedMeshComponent.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <Core/World/World.h>
+#include <GameEngine/Animation/Skeletal/AnimatedMeshComponent.h>
+
+class EZ_GAMEENGINE_DLL ezLodAnimatedMeshComponentManager : public ezComponentManager<class ezLodAnimatedMeshComponent, ezBlockStorageType::FreeList>
+{
+public:
+  ezLodAnimatedMeshComponentManager(ezWorld* pWorld);
+  ~ezLodAnimatedMeshComponentManager();
+
+  virtual void Initialize() override;
+
+  void Update(const ezWorldModule::UpdateContext& context);
+  void AddToUpdateList(ezLodAnimatedMeshComponent* pComponent);
+
+private:
+  void ResourceEventHandler(const ezResourceEvent& e);
+
+  ezDeque<ezComponentHandle> m_ComponentsToUpdate;
+};
+
+struct ezLodAnimatedMeshLod
+{
+  const char* GetMeshFile() const;
+  void SetMeshFile(const char* szFile);
+
+  ezMeshResourceHandle m_hMesh;
+  float m_fThreshold;
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMEENGINE_DLL, ezLodAnimatedMeshLod);
+
+class EZ_GAMEENGINE_DLL ezLodAnimatedMeshComponent : public ezRenderComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezLodAnimatedMeshComponent, ezRenderComponent, ezLodAnimatedMeshComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+protected:
+  virtual void OnActivated() override;
+  virtual void OnDeactivated() override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezRenderComponent
+
+public:
+  virtual ezMeshRenderData* CreateRenderData() const;
+  virtual ezResult GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg) override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezLodAnimatedMeshComponent
+
+public:
+  ezLodAnimatedMeshComponent();
+  ~ezLodAnimatedMeshComponent();
+
+  /// \brief An additional tint color passed to the renderer to modify the mesh.
+  void SetColor(const ezColor& color); // [ property ]
+  const ezColor& GetColor() const;     // [ property ]
+
+  /// \brief The sorting depth offset allows to tweak the order in which this mesh is rendered relative to other meshes.
+  ///
+  /// This is mainly useful for transparent objects to render them before or after other meshes.
+  void SetSortingDepthOffset(float fOffset); // [ property ]
+  float GetSortingDepthOffset() const;       // [ property ]
+
+  /// \brief Enables text output to show the current coverage value and selected LOD.
+  void SetShowDebugInfo(bool bShow); // [ property ]
+  bool GetShowDebugInfo() const;     // [ property ]
+
+  /// \brief Disabling the LOD range overlap functionality can make it easier to determine the desired coverage thresholds.
+  void SetOverlapRanges(bool bOverlap); // [ property ]
+  bool GetOverlapRanges() const;        // [ property ]
+
+  void OnMsgSetColor(ezMsgSetColor& ref_msg); // [ msg handler ]
+
+  void RetrievePose(ezDynamicArray<ezMat4>& out_modelTransforms, ezTransform& out_rootTransform, const ezSkeleton& skeleton);
+
+protected:
+  void UpdateSelectedLod(const ezView& view) const;
+  void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
+
+  mutable ezInt32 m_iCurLod = 0;
+  ezDynamicArray<ezLodAnimatedMeshLod> m_Meshes;
+  ezColor m_Color = ezColor::White;
+  float m_fSortingDepthOffset = 0.0f;
+  ezVec3 m_vBoundsOffset = ezVec3::MakeZero();
+  float m_fBoundsRadius = 1.0f;
+
+protected:
+  void OnAnimationPoseUpdated(ezMsgAnimationPoseUpdated& msg);     // [ msg handler ]
+  void OnQueryAnimationSkeleton(ezMsgQueryAnimationSkeleton& msg); // [ msg handler ]
+
+  void InitializeAnimationPose();
+
+  void MapModelSpacePoseToSkinningSpace(const ezHashTable<ezHashedString, ezMeshResourceDescriptor::BoneData>& bones, const ezSkeleton& skeleton, ezArrayPtr<const ezMat4> modelSpaceTransforms, ezBoundingBox* bounds);
+
+  ezTransform m_RootTransform = ezTransform::MakeIdentity();
+  ezBoundingBox m_MaxBounds;
+  ezSkinningState m_SkinningState;
+  ezSkeletonResourceHandle m_hDefaultSkeleton;
+};

--- a/Code/UnitTests/FoundationTest/Math/FrustumTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/FrustumTest.cpp
@@ -303,4 +303,30 @@ EZ_CREATE_SIMPLE_TEST(Math, Frustum)
       }
     }
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "MakeFromCorners")
+  {
+    const ezFrustum fOrg = ezFrustum::MakeFromFOV(ezVec3(1, 2, 3), ezVec3(1, 1, 0).GetNormalized(), ezVec3(0, 0, 1).GetNormalized(), ezAngle::MakeFromDegree(110), ezAngle::MakeFromDegree(70), 0.1f, 100.0f);
+
+    ezVec3 corners[8];
+    fOrg.ComputeCornerPoints(corners).AssertSuccess();
+
+    const ezFrustum fNew = ezFrustum::MakeFromCorners(corners);
+
+    for (ezUInt32 i = 0; i < 6; ++i)
+    {
+      ezPlane p1 = fOrg.GetPlane(i);
+      ezPlane p2 = fNew.GetPlane(i);
+
+      EZ_TEST_BOOL(p1.IsEqual(p2));
+    }
+
+    ezVec3 corners2[8];
+    fNew.ComputeCornerPoints(corners2).AssertSuccess();
+
+    for (ezUInt32 i = 0; i < 8; ++i)
+    {
+      EZ_TEST_BOOL(corners[i].IsEqual(corners2[i], 0.001f));
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1151

* Added mesh simplification to collision meshes and animated meshes.
* Added a LOD animation component, that switches between different animated meshes.

Lots of code duplication at the moment, could be improved in the future.
Also the animated mesh LOD really only reduces the mesh complexity, there is currently no reduction in animation sampling complexity, which is a whole different topic.