### PR TITLE
Bit Iterators

### DIFF
--- a/Code/Engine/Foundation/Containers/Bitfield.h
+++ b/Code/Engine/Foundation/Containers/Bitfield.h
@@ -2,6 +2,7 @@
 
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Containers/Implementation/BitIterator.h>
 #include <Foundation/IO/Stream.h>
 #include <Foundation/Math/Constants.h>
 
@@ -66,7 +67,55 @@ public:
   /// \brief Clears the range starting at uiFirstBit up to (and including) uiLastBit to 0.
   void ClearBitRange(ezUInt32 uiFirstBit, ezUInt32 uiNumBits); // [tested]
 
+  struct ConstIterator
+  {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ezUInt32;
+    using sub_iterator = ::ezBitIterator<ezUInt32, true>;
+
+    // Invalid iterator (end)
+    EZ_FORCE_INLINE ConstIterator() = default; // [tested]
+
+    // Start iterator.
+    explicit ConstIterator(const ezBitfield<Container>& bitfield); // [tested]
+
+    /// \brief Checks whether this iterator points to a valid element.
+    bool IsValid() const; // [tested]
+
+    /// \brief Returns the 'value' of the element that this iterator points to.
+    ezUInt32 Value() const; // [tested]
+
+    /// \brief Advances the iterator to the next element in the map. The iterator will not be valid anymore, if the end is reached.
+    void Next(); // [tested]
+
+    bool operator==(const ConstIterator& other) const; // [tested]
+    bool operator!=(const ConstIterator& other) const; // [tested]
+
+    /// \brief Returns '*this' to enable foreach.
+    ezUInt32 operator*() const; // [tested]
+
+    /// \brief Shorthand for 'Next'.
+    void operator++(); // [tested]
+
+  private:
+    void FindNextChunk(ezUInt32 uiStartChunk);
+
+  private:
+    ezUInt32 m_uiChunk = 0;
+    sub_iterator m_Iterator;
+    const ezBitfield<Container>* m_pBitfield = nullptr;
+  };
+
+  /// \brief Returns a constant iterator to the very first set bit.
+  /// Note that due to the way iterating through bits is accelerated, changes to the bitfield while iterating through the bits has undefined behaviour.
+  ConstIterator GetIterator() const; // [tested]
+
+  /// \brief Returns an invalid iterator. Needed to support range based for loops.
+  ConstIterator GetEndIterator() const; // [tested]
+
 private:
+  friend struct ConstIterator;
+
   ezUInt32 GetBitInt(ezUInt32 uiBitIndex) const;
   ezUInt32 GetBitMask(ezUInt32 uiBitIndex) const;
 
@@ -82,6 +131,32 @@ template <ezUInt32 BITS>
 using ezHybridBitfield = ezBitfield<ezHybridArray<ezUInt32, (BITS + 31) / 32>>;
 
 //////////////////////////////////////////////////////////////////////////
+// begin() /end() for range-based for-loop support
+template <typename Container>
+typename ezBitfield<Container>::ConstIterator begin(const ezBitfield<Container>& container)
+{
+  return container.GetIterator();
+}
+
+template <typename Container>
+typename ezBitfield<Container>::ConstIterator cbegin(const ezBitfield<Container>& container)
+{
+  return container.GetIterator();
+}
+
+template <typename Container>
+typename ezBitfield<Container>::ConstIterator end(const ezBitfield<Container>& container)
+{
+  return container.GetEndIterator();
+}
+
+template <typename Container>
+typename ezBitfield<Container>::ConstIterator cend(const ezBitfield<Container>& container)
+{
+  return container.GetEndIterator();
+}
+
+//////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
@@ -90,6 +165,8 @@ class ezStaticBitfield
 {
 public:
   using StorageType = T;
+  using ConstIterator = ezBitIterator<StorageType, true, ezUInt32>;
+
   static constexpr ezUInt32 GetStorageTypeBitCount() { return ezMath::NumBits<T>(); }
 
   /// \brief Initializes the bitfield to all zero.
@@ -165,6 +242,19 @@ public:
     return EZ_SUCCESS;
   }
 
+  /// \brief Returns a constant iterator to the very first set bit.
+  /// Note that due to the way iterating through bits is accelerated, changes to the bitfield while iterating through the bits has undefined behaviour.
+  ConstIterator GetIterator() const // [tested]
+  {
+    return ConstIterator(m_Storage);
+  };
+
+  /// \brief Returns an invalid iterator. Needed to support range based for loops.
+  ConstIterator GetEndIterator() const // [tested]
+  {
+    return ConstIterator();
+  };
+
 private:
   static constexpr ezTypeVersion s_Version = 1;
 
@@ -219,6 +309,32 @@ template <typename T>
 inline bool operator!=(ezStaticBitfield<T> lhs, ezStaticBitfield<T> rhs)
 {
   return lhs.m_Storage != rhs.m_Storage;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// begin() /end() for range-based for-loop support
+template <typename Container>
+typename ezStaticBitfield<Container>::ConstIterator begin(const ezStaticBitfield<Container>& container)
+{
+  return container.GetIterator();
+}
+
+template <typename Container>
+typename ezStaticBitfield<Container>::ConstIterator cbegin(const ezStaticBitfield<Container>& container)
+{
+  return container.GetIterator();
+}
+
+template <typename Container>
+typename ezStaticBitfield<Container>::ConstIterator end(const ezStaticBitfield<Container>& container)
+{
+  return container.GetEndIterator();
+}
+
+template <typename Container>
+typename ezStaticBitfield<Container>::ConstIterator cend(const ezStaticBitfield<Container>& container)
+{
+  return container.GetEndIterator();
 }
 
 using ezStaticBitfield8 = ezStaticBitfield<ezUInt8>;

--- a/Code/Engine/Foundation/Containers/Bitfield.h
+++ b/Code/Engine/Foundation/Containers/Bitfield.h
@@ -91,7 +91,7 @@ public:
     bool operator==(const ConstIterator& other) const; // [tested]
     bool operator!=(const ConstIterator& other) const; // [tested]
 
-    /// \brief Returns '*this' to enable foreach.
+    /// \brief Returns 'Value()' to enable foreach.
     ezUInt32 operator*() const; // [tested]
 
     /// \brief Shorthand for 'Next'.

--- a/Code/Engine/Foundation/Containers/Implementation/BitIterator.h
+++ b/Code/Engine/Foundation/Containers/Implementation/BitIterator.h
@@ -4,11 +4,18 @@
 
 /// Chooses either ezUInt32 or ezUInt64 as the storage type for a given type T depending on its size. Required as ezMath::FirstBitLow only supports ezUInt32 or ezUInt64.
 /// \tparam T Type for which the storage should be inferred.
-template<typename T, typename = std::void_t<>> struct ezBitIteratorStorage;
-template<typename T>
-struct ezBitIteratorStorage<T, std::enable_if_t<sizeof(T) <= 4>> { typedef ezUInt32 Type; };
-template<typename T>
-struct ezBitIteratorStorage<T, std::enable_if_t<sizeof(T) >= 5>> { typedef ezUInt64 Type; };
+template <typename T, typename = std::void_t<>>
+struct ezBitIteratorStorage;
+template <typename T>
+struct ezBitIteratorStorage<T, std::enable_if_t<sizeof(T) <= 4>>
+{
+  using Type = ezUInt32;
+};
+template <typename T>
+struct ezBitIteratorStorage<T, std::enable_if_t<sizeof(T) >= 5>>
+{
+  using Type = ezUInt64;
+};
 
 /// Configurable bit iterator. Allows for iterating over the bits in an integer, returning either the bit index or value.
 /// \tparam DataType The type of data that is being iterated over.

--- a/Code/Engine/Foundation/Containers/Implementation/BitIterator.h
+++ b/Code/Engine/Foundation/Containers/Implementation/BitIterator.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <Foundation/Math/Math.h>
+
+/// Chooses either ezUInt32 or ezUInt64 as the storage type for a given type T depending on its size. Required as ezMath::FirstBitLow only supports ezUInt32 or ezUInt64.
+/// \tparam T Type for which the storage should be inferred.
+template<typename T, typename = std::void_t<>> struct ezBitIteratorStorage;
+template<typename T>
+struct ezBitIteratorStorage<T, std::enable_if_t<sizeof(T) <= 4>> { typedef ezUInt32 Type; };
+template<typename T>
+struct ezBitIteratorStorage<T, std::enable_if_t<sizeof(T) >= 5>> { typedef ezUInt64 Type; };
+
+/// Configurable bit iterator. Allows for iterating over the bits in an integer, returning either the bit index or value.
+/// \tparam DataType The type of data that is being iterated over.
+/// \tparam ReturnsIndex If set, returns the index of the bit. Otherwise returns the value of the bit, i.e. EZ_BIT(value).
+/// \tparam ReturnType Returned value type of the iterator. Defaults to same as DataType.
+/// \tparam StorageType The storage type that the bit operations are performed on (either ezUInt32 or ezUInt64). Auto-computed.
+template <typename DataType, bool ReturnsIndex = true, typename ReturnType = DataType, typename StorageType = typename ezBitIteratorStorage<DataType>::Type>
+struct ezBitIterator
+{
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = DataType;
+  EZ_CHECK_AT_COMPILETIME(sizeof(DataType) <= 8);
+
+  // Invalid iterator (end)
+  EZ_ALWAYS_INLINE ezBitIterator() = default;
+
+  // Start iterator.
+  EZ_ALWAYS_INLINE explicit ezBitIterator(DataType data)
+  {
+    m_uiMask = static_cast<StorageType>(data);
+  }
+
+  EZ_ALWAYS_INLINE bool IsValid() const
+  {
+    return m_uiMask != 0;
+  }
+
+  EZ_ALWAYS_INLINE ReturnType Value() const
+  {
+    if constexpr (ReturnsIndex)
+    {
+      return static_cast<ReturnType>(ezMath::FirstBitLow(m_uiMask));
+    }
+    else
+    {
+      return static_cast<ReturnType>(EZ_BIT(ezMath::FirstBitLow(m_uiMask)));
+    }
+  }
+
+  EZ_ALWAYS_INLINE void Next()
+  {
+    // Clear the lowest set bit. Why this works: https://www.geeksforgeeks.org/turn-off-the-rightmost-set-bit/
+    m_uiMask = m_uiMask & (m_uiMask - 1);
+  }
+
+  EZ_ALWAYS_INLINE bool operator==(const ezBitIterator& other) const
+  {
+    return m_uiMask == other.m_uiMask;
+  }
+
+  EZ_ALWAYS_INLINE bool operator!=(const ezBitIterator& other) const
+  {
+    return m_uiMask != other.m_uiMask;
+  }
+
+  EZ_ALWAYS_INLINE ReturnType operator*() const
+  {
+    return Value();
+  }
+
+  EZ_ALWAYS_INLINE void operator++()
+  {
+    Next();
+  }
+
+  StorageType m_uiMask = 0;
+};

--- a/Code/Engine/Foundation/Containers/IterateBits.h
+++ b/Code/Engine/Foundation/Containers/IterateBits.h
@@ -1,0 +1,67 @@
+#include <Foundation/Containers/Implementation/BitIterator.h>
+
+/// Helper base class to iterate over the bit indices or bit values of an integer.
+/// \tparam DataType The type of data that is being iterated over.
+/// \tparam ReturnsIndex If set, returns the index of the bit. Otherwise returns the value of the bit, i.e. EZ_BIT(value).
+/// \tparam ReturnType Returned value type of the iterator.
+/// \sa ezIterateBitValues, ezIterateBitIndices
+template <typename DataType, bool ReturnsIndex, typename ReturnType = DataType>
+struct ezIterateBits
+{
+  explicit ezIterateBits(DataType data)
+  {
+    m_Data = data;
+  }
+
+  ezBitIterator<DataType, ReturnsIndex, ReturnType> begin() const
+  {
+    return ezBitIterator<DataType, ReturnsIndex, ReturnType>(m_Data);
+  };
+
+  ezBitIterator<DataType, ReturnsIndex, ReturnType> end() const
+  {
+    return ezBitIterator<DataType, ReturnsIndex, ReturnType>();
+  };
+
+  DataType m_Data = {};
+};
+
+/// \brief Helper class to iterate over the bit values of an integer.
+/// The class can iterate over the bits of any unsigned integer type that is equal to or smaller than ezUInt64.
+/// \code{.cpp}
+///    ezUInt64 bits = 0b1101;
+///    for (auto bit : ezIterateBitValues(bits))
+///    {
+///      ezLog::Info("{}", bit); // Outputs 1, 4, 8
+///    }
+/// \endcode
+/// \tparam DataType The type of data that is being iterated over.
+/// \tparam ReturnType Returned value type of the iterator. Defaults to same as DataType.
+template <typename DataType, typename ReturnType = DataType>
+struct ezIterateBitValues : public ezIterateBits<DataType, false, ReturnType>
+{
+  explicit ezIterateBitValues(DataType data)
+    : ezIterateBits<DataType, false, ReturnType>(data)
+  {
+  }
+};
+
+/// \brief Helper class to iterate over the bit indices of an integer.
+/// The class can iterate over the bits of any unsigned integer type that is equal to or smaller than ezUInt64.
+/// \code{.cpp}
+///    ezUInt64 bits = 0b1101;
+///    for (auto bit : ezIterateBitIndices(bits))
+///    {
+///      ezLog::Info("{}", bit); // Outputs 0, 2, 3
+///    }
+/// \endcode
+/// \tparam DataType The type of data that is being iterated over.
+/// \tparam ReturnType Returned value type of the iterator. Defaults to same as DataType.
+template <typename DataType, typename ReturnType = DataType>
+struct ezIterateBitIndices : public ezIterateBits<DataType, true, ReturnType>
+{
+  explicit ezIterateBitIndices(DataType data)
+    : ezIterateBits<DataType, true, ReturnType>(data)
+  {
+  }
+};

--- a/Code/Engine/Foundation/Types/Bitflags.h
+++ b/Code/Engine/Foundation/Types/Bitflags.h
@@ -4,6 +4,7 @@
 
 #include <Foundation/Basics.h>
 #include <Foundation/Types/Enum.h>
+#include <Foundation/Containers/Implementation/BitIterator.h>
 
 /// \brief The ezBitflags class allows you to work with type-safe bitflags.
 ///
@@ -85,6 +86,8 @@ private:
   using StorageType = typename T::StorageType;
 
 public:
+  using ConstIterator = ezBitIterator<Enum, false>;
+
   /// \brief Constructor. Initializes the flags to the default value.
   EZ_ALWAYS_INLINE ezBitflags()
     : m_Value(T::Default) // [tested]
@@ -216,6 +219,19 @@ public:
     return m_Value != 0;
   }
 
+  /// \brief Returns a constant iterator to the very first set bit.
+  /// Note that due to the way iterating through bits is accelerated, changes to the bitflags will not affect the iterator after creation.
+  EZ_ALWAYS_INLINE ConstIterator GetIterator() const // [tested]
+  {
+    return ConstIterator((Enum)m_Value);
+  }
+
+  /// \brief Returns an invalid iterator. Needed to support range based for loops.
+  EZ_ALWAYS_INLINE ConstIterator GetEndIterator() const // [tested]
+  {
+    return ConstIterator();
+  }
+
 private:
   EZ_ALWAYS_INLINE explicit ezBitflags(StorageType flags)
     : m_Value(flags)
@@ -229,6 +245,31 @@ private:
   };
 };
 
+//////////////////////////////////////////////////////////////////////////
+// begin() /end() for range-based for-loop support
+template <typename T>
+typename ezBitflags<T>::ConstIterator begin(const ezBitflags<T>& container)
+{
+  return container.GetIterator();
+}
+
+template <typename T>
+typename ezBitflags<T>::ConstIterator cbegin(const ezBitflags<T>& container)
+{
+  return container.GetIterator();
+}
+
+template <typename T>
+typename ezBitflags<T>::ConstIterator end(const ezBitflags<T>& container)
+{
+  return container.GetEndIterator();
+}
+
+template <typename T>
+typename ezBitflags<T>::ConstIterator cend(const ezBitflags<T>& container)
+{
+  return container.GetEndIterator();
+}
 
 /// \brief This macro will define the operator| and operator& function that is required for class \a FlagsType to work with ezBitflags.
 /// See class ezBitflags for more information.

--- a/Code/Engine/Foundation/ezEngine.natvis
+++ b/Code/Engine/Foundation/ezEngine.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 	<Type Name="vk::Flags&lt;*&gt;">
-		<DisplayString>[{($T1)m_mask}]</DisplayString>
+		<DisplayString>[{($T1)m_uiMask}]</DisplayString>
 	</Type>
 
 	<!-- Strings-->

--- a/Code/Engine/Foundation/ezEngine.natvis
+++ b/Code/Engine/Foundation/ezEngine.natvis
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 	<Type Name="vk::Flags&lt;*&gt;">
-		<DisplayString>[{($T1)m_uiMask}]</DisplayString>
+		<DisplayString>[{($T1)m_mask}]</DisplayString>
 	</Type>
 
 	<!-- Strings-->

--- a/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
@@ -6,7 +6,7 @@ namespace
 {
   // declare bitflags using macro magic
   EZ_DECLARE_FLAGS(ezUInt32, AutoFlags, Bit1, Bit2, Bit3, Bit4);
-  EZ_DEFINE_AS_POD_TYPE(AutoFlags::Enum);
+
   // declare bitflags manually
   struct ManualFlags
   {
@@ -34,8 +34,8 @@ namespace
   EZ_DECLARE_FLAGS_OPERATORS(ManualFlags);
 } // namespace
 
+EZ_DEFINE_AS_POD_TYPE(AutoFlags::Enum);
 EZ_CHECK_AT_COMPILETIME(sizeof(ezBitflags<AutoFlags>) == 4);
-
 
 
 EZ_CREATE_SIMPLE_TEST(Basics, Bitflags)

--- a/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
@@ -1,10 +1,12 @@
 #include <FoundationTest/FoundationTestPCH.h>
 
+#include <Foundation/Containers/IterateBits.h>
+
 namespace
 {
   // declare bitflags using macro magic
   EZ_DECLARE_FLAGS(ezUInt32, AutoFlags, Bit1, Bit2, Bit3, Bit4);
-
+  EZ_DEFINE_AS_POD_TYPE(AutoFlags::Enum);
   // declare bitflags manually
   struct ManualFlags
   {
@@ -33,6 +35,8 @@ namespace
 } // namespace
 
 EZ_CHECK_AT_COMPILETIME(sizeof(ezBitflags<AutoFlags>) == 4);
+
+
 
 EZ_CREATE_SIMPLE_TEST(Basics, Bitflags)
 {
@@ -100,6 +104,52 @@ EZ_CREATE_SIMPLE_TEST(Basics, Bitflags)
     f &= AutoFlags::Bit3;
 
     EZ_TEST_BOOL(f.GetValue() == AutoFlags::Bit3);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Iterator")
+  {
+    {
+      // Empty
+      ezBitflags<AutoFlags> f;
+      auto it = f.GetIterator();
+      EZ_TEST_BOOL(it == f.GetEndIterator());
+      EZ_TEST_BOOL(!it.IsValid());
+
+      for (AutoFlags::Enum flag : f)
+      {
+        EZ_REPORT_FAILURE("No bit should be set");
+      }
+    }
+
+    {
+      // All flags
+      ezBitflags<AutoFlags> f = AutoFlags::Bit1 | AutoFlags::Bit2 | AutoFlags::Bit3 | AutoFlags::Bit4;
+      ezHybridArray<AutoFlags::Enum, 4> flags;
+      flags.PushBack(AutoFlags::Bit1);
+      flags.PushBack(AutoFlags::Bit2);
+      flags.PushBack(AutoFlags::Bit3);
+      flags.PushBack(AutoFlags::Bit4);
+
+      ezUInt32 uiIndex = 0;
+      // Iterator
+      for (auto it = f.GetIterator(); it.IsValid(); ++it)
+      {
+        EZ_TEST_INT(*it, flags[uiIndex]);
+        EZ_TEST_INT(it.Value(), flags[uiIndex]);
+        EZ_TEST_BOOL(it.IsValid());
+        ++uiIndex;
+      }
+      EZ_TEST_INT(uiIndex, 4);
+
+      // Range-base for loop
+      uiIndex = 0;
+      for (AutoFlags::Enum flag : f)
+      {
+        EZ_TEST_INT(flag, flags[uiIndex]);
+        ++uiIndex;
+      }
+      EZ_TEST_INT(uiIndex, 4);
+    }
   }
 }
 

--- a/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/BitflagsTest.cpp
@@ -117,7 +117,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Bitflags)
 
       for (AutoFlags::Enum flag : f)
       {
-        EZ_REPORT_FAILURE("No bit should be set");
+        EZ_TEST_BOOL_MSG(false, "No bit should be set");
       }
     }
 

--- a/Code/UnitTests/FoundationTest/Containers/BitfieldTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/BitfieldTest.cpp
@@ -214,12 +214,12 @@ EZ_CREATE_SIMPLE_TEST(Containers, Bitfield)
         }
         for (ezUInt32 uiBit : bitfield)
         {
-          EZ_REPORT_FAILURE("No bit should be set");
+          EZ_TEST_BOOL_MSG(false, "No bit should be set");
         }
 
         for (auto it = bitfield.GetIterator(); it.IsValid(); it.Next())
         {
-          EZ_REPORT_FAILURE("No bit should be set");
+          EZ_TEST_BOOL_MSG(false, "No bit should be set");
         }
         EZ_TEST_BOOL(bitfield.GetIterator() == bitfield.GetEndIterator());
         EZ_TEST_BOOL(!bitfield.GetIterator().IsValid());
@@ -460,11 +460,11 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticBitfield)
       ezStaticBitfield32 bitfield = ezStaticBitfield32::MakeFromMask(0u);
       for (ezUInt32 uiBit : bitfield)
       {
-        EZ_REPORT_FAILURE("No bit should be set");
+        EZ_TEST_BOOL_MSG(false, "No bit should be set");
       }
       for (auto it = bitfield.GetIterator(); it.IsValid(); it.Next())
       {
-        EZ_REPORT_FAILURE("No bit should be set");
+        EZ_TEST_BOOL_MSG(false, "No bit should be set");
       }
       EZ_TEST_BOOL(bitfield.GetIterator() == bitfield.GetEndIterator());
       EZ_TEST_BOOL(!bitfield.GetIterator().IsValid());
@@ -473,11 +473,11 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticBitfield)
       ezStaticBitfield64 bitfield64 = ezStaticBitfield64::MakeFromMask(0u);
       for (ezUInt32 uiBit : bitfield64)
       {
-        EZ_REPORT_FAILURE("No bit should be set");
+        EZ_TEST_BOOL_MSG(false, "No bit should be set");
       }
       for (auto it = bitfield64.GetIterator(); it.IsValid(); it.Next())
       {
-        EZ_REPORT_FAILURE("No bit should be set");
+        EZ_TEST_BOOL_MSG(false, "No bit should be set");
       }
       EZ_TEST_BOOL(bitfield64.GetIterator() == bitfield64.GetEndIterator());
       EZ_TEST_BOOL(!bitfield64.GetIterator().IsValid());

--- a/Code/UnitTests/FoundationTest/Containers/BitfieldTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/BitfieldTest.cpp
@@ -3,6 +3,7 @@
 #include <Foundation/Containers/Bitfield.h>
 #include <Foundation/Containers/Deque.h>
 #include <Foundation/Strings/String.h>
+#include <Foundation/Math/Random.h>
 
 EZ_CREATE_SIMPLE_TEST(Containers, Bitfield)
 {
@@ -198,6 +199,92 @@ EZ_CREATE_SIMPLE_TEST(Containers, Bitfield)
     EZ_TEST_BOOL(bf.IsNoBitSet() == false);
     EZ_TEST_BOOL(bf.AreAllBitsSet() == true);
   }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Iterator")
+  {
+    {
+      // Check empty bitfields of varying sizes.
+      for (ezUInt32 uiNumBits = 0; uiNumBits <= 65; ++uiNumBits)
+      {
+        ezHybridBitfield<128> bitfield;
+        bitfield.SetCount(uiNumBits, true);
+        for (ezUInt32 b = 0; b < uiNumBits; ++b)
+        {
+          bitfield.ClearBit(b);
+        }
+        for (ezUInt32 uiBit : bitfield)
+        {
+          EZ_REPORT_FAILURE("No bit should be set");
+        }
+
+        for (auto it = bitfield.GetIterator(); it.IsValid(); it.Next())
+        {
+          EZ_REPORT_FAILURE("No bit should be set");
+        }
+        EZ_TEST_BOOL(bitfield.GetIterator() == bitfield.GetEndIterator());
+        EZ_TEST_BOOL(!bitfield.GetIterator().IsValid());
+        EZ_TEST_BOOL(!bitfield.GetEndIterator().IsValid());
+      }
+    }
+
+    {
+      // Full bits.
+      for (ezUInt32 uiNumBits = 0; uiNumBits <= 65; ++uiNumBits)
+      {
+        ezHybridBitfield<128> bitfield;
+        bitfield.SetCount(uiNumBits, true);
+        ezUInt32 uiNextBit = 0;
+        for (ezUInt32 uiBit : bitfield)
+        {
+          EZ_TEST_INT(uiBit, uiNextBit);
+          uiNextBit++;
+        }
+        EZ_TEST_INT(uiNumBits, uiNextBit);
+
+        uiNextBit = 0;
+        for (auto it = bitfield.GetIterator(); it.IsValid(); ++it)
+        {
+          EZ_TEST_INT(it.Value(), uiNextBit);
+          EZ_TEST_INT(*it, uiNextBit);
+          EZ_TEST_BOOL(it.IsValid());
+          uiNextBit++;
+        }
+        EZ_TEST_INT(uiNumBits, uiNextBit);
+      }
+    }
+
+    {
+      // Partial bits set.
+      ezRandom rnd;
+      rnd.Initialize(42);
+      
+      for (ezUInt32 uiNumBits = 2; uiNumBits <= 65; ++uiNumBits)
+      {
+        ezHybridBitfield<128> bitfield;
+        bitfield.SetCount(uiNumBits, false);
+
+        // Add some random bits and ensure they appear in the iterator in order.
+        ezHybridArray<ezUInt32, 3> bits;
+        for (int i = 0; i < uiNumBits / 2; ++i)
+        {
+          ezUInt32 bit = (ezUInt32)rnd.IntMinMax(0, uiNumBits - 1);
+          if (!bitfield.IsBitSet(bit))
+          {
+            bits.PushBack(bit);
+            bitfield.SetBit(bit);
+          }
+        }
+        bits.Sort();
+
+        for (ezUInt32 uiBit : bitfield)
+        {
+          EZ_TEST_INT(uiBit, bits[0]);
+          bits.RemoveAtAndCopy(0);
+        }
+        EZ_TEST_BOOL(bits.IsEmpty());
+      }
+    }
+  }
 }
 
 
@@ -364,5 +451,145 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticBitfield)
     EZ_TEST_INT(ezStaticBitfield32::MakeFromMask(0x80000000u).GetHighestBitSet(), 31);
     EZ_TEST_INT(ezStaticBitfield32::MakeFromMask(0xffffffffu).GetHighestBitSet(), 31);
     EZ_TEST_INT(ezStaticBitfield64::MakeFromMask(0xffffffffffffffffull).GetHighestBitSet(), 63);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Iterator")
+  {
+    {
+      // Empty bitfield
+      ezStaticBitfield32 bitfield = ezStaticBitfield32::MakeFromMask(0u);
+      for (ezUInt32 uiBit : bitfield)
+      {
+        EZ_REPORT_FAILURE("No bit should be set");
+      }
+      for (auto it = bitfield.GetIterator(); it.IsValid(); it.Next())
+      {
+        EZ_REPORT_FAILURE("No bit should be set");
+      }
+      EZ_TEST_BOOL(bitfield.GetIterator() == bitfield.GetEndIterator());
+      EZ_TEST_BOOL(!bitfield.GetIterator().IsValid());
+      EZ_TEST_BOOL(!bitfield.GetEndIterator().IsValid());
+
+      ezStaticBitfield64 bitfield64 = ezStaticBitfield64::MakeFromMask(0u);
+      for (ezUInt32 uiBit : bitfield64)
+      {
+        EZ_REPORT_FAILURE("No bit should be set");
+      }
+      for (auto it = bitfield64.GetIterator(); it.IsValid(); it.Next())
+      {
+        EZ_REPORT_FAILURE("No bit should be set");
+      }
+      EZ_TEST_BOOL(bitfield64.GetIterator() == bitfield64.GetEndIterator());
+      EZ_TEST_BOOL(!bitfield64.GetIterator().IsValid());
+      EZ_TEST_BOOL(!bitfield64.GetEndIterator().IsValid());
+    }
+
+    {
+      // Full 32 bits
+      ezStaticBitfield32 bitfield = ezStaticBitfield32::MakeFromMask(0xffffffffu);
+      ezUInt32 uiNextBit = 0;
+      for (ezUInt32 uiBit : bitfield)
+      {
+        EZ_TEST_INT(uiBit, uiNextBit);
+        uiNextBit++;
+      }
+      EZ_TEST_INT(32, uiNextBit);
+
+      uiNextBit = 0;
+      for (auto it = bitfield.GetIterator(); it.IsValid(); ++it)
+      {
+        EZ_TEST_INT(it.Value(), uiNextBit);
+        EZ_TEST_INT(*it, uiNextBit);
+        EZ_TEST_BOOL(it.IsValid());
+        uiNextBit++;
+      }
+      EZ_TEST_INT(32, uiNextBit);
+    }
+
+    {
+      // Full 64 bits
+      ezStaticBitfield64 bitfield = ezStaticBitfield64::MakeFromMask(0xffffffffffffffffull);
+      ezUInt32 uiNextBit = 0;
+      for (ezUInt32 uiBit : bitfield)
+      {
+        EZ_TEST_INT(uiBit, uiNextBit);
+        uiNextBit++;
+      }
+      EZ_TEST_INT(64, uiNextBit);
+
+      uiNextBit = 0;
+      for (auto it = bitfield.GetIterator(); it.IsValid(); ++it)
+      {
+        EZ_TEST_INT(it.Value(), uiNextBit);
+        EZ_TEST_INT(*it, uiNextBit);
+        EZ_TEST_BOOL(it.IsValid());
+        uiNextBit++;
+      }
+      EZ_TEST_INT(64, uiNextBit);
+    }
+
+    {
+      // Partial bits set 32 bit.
+      ezRandom rnd;
+      rnd.Initialize(42);
+
+      for (ezUInt32 uiNumBits = 2; uiNumBits <= 32; ++uiNumBits)
+      {
+        // Add some random bits and ensure they appear in the iterator in order.
+        ezHybridArray<ezUInt32, 3> bits;
+        ezUInt32 uiBits = 0;
+        for (int i = 0; i < uiNumBits; ++i)
+        {
+          const ezUInt32 bit = (ezUInt32)rnd.IntMinMax(0, 31);
+          if (!bits.Contains(bit))
+          {
+            bits.PushBack(bit);
+            uiBits |= EZ_BIT(bit);
+          }
+        }
+        bits.Sort();
+
+        ezStaticBitfield32 bitfield = ezStaticBitfield32::MakeFromMask(uiBits);
+
+        for (ezUInt32 uiBit : bitfield)
+        {
+          EZ_TEST_INT(uiBit, bits[0]);
+          bits.RemoveAtAndCopy(0);
+        }
+        EZ_TEST_BOOL(bits.IsEmpty());
+      }
+    }
+
+    {
+      // Partial bits set 64 bit.
+      ezRandom rnd;
+      rnd.Initialize(42);
+
+      for (ezUInt32 uiNumBits = 2; uiNumBits <= 63; ++uiNumBits)
+      {
+        // Add some random bits and ensure they appear in the iterator in order.
+        ezHybridArray<ezUInt32, 3> bits;
+        ezUInt64 uiBits = 0;
+        for (int i = 0; i < uiNumBits; ++i)
+        {
+          const ezUInt32 bit = (ezUInt32)rnd.IntMinMax(0, 63);
+          if (!bits.Contains(bit))
+          {
+            bits.PushBack(bit);
+            uiBits |= EZ_BIT(bit);
+          }
+        }
+        bits.Sort();
+
+        ezStaticBitfield64 bitfield = ezStaticBitfield64::MakeFromMask(uiBits);
+
+        for (ezUInt32 uiBit : bitfield)
+        {
+          EZ_TEST_INT(uiBit, bits[0]);
+          bits.RemoveAtAndCopy(0);
+        }
+        EZ_TEST_BOOL(bits.IsEmpty());
+      }
+    }
   }
 }

--- a/Code/UnitTests/FoundationTest/Containers/IterateBitsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/IterateBitsTest.cpp
@@ -10,7 +10,7 @@ namespace
     ezUInt32 uiNextBit = 1;
     for (auto bit : ezIterateBitValues(static_cast<T>(0)))
     {
-      EZ_REPORT_FAILURE("No bit should be present");
+      EZ_TEST_BOOL_MSG(false, "No bit should be present");
     }
   }
 
@@ -35,7 +35,7 @@ namespace
     ezUInt32 uiNextBit = 1;
     for (auto bit : ezIterateBitIndices(static_cast<T>(0)))
     {
-      EZ_REPORT_FAILURE("No bit should be present");
+      EZ_TEST_BOOL_MSG(false, "No bit should be present");
     }
   }
 

--- a/Code/UnitTests/FoundationTest/Containers/IterateBitsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/IterateBitsTest.cpp
@@ -1,0 +1,127 @@
+#include <FoundationTest/FoundationTestPCH.h>
+
+#include <Foundation/Containers/IterateBits.h>
+
+namespace
+{
+  template<typename T>
+  void TestEmptyIntegerBitValues()
+  {
+    ezUInt32 uiNextBit = 1;
+    for (auto bit : ezIterateBitValues(static_cast<T>(0)))
+    {
+      EZ_REPORT_FAILURE("No bit should be present");
+    }
+  }
+
+  template<typename T>
+  void TestFullIntegerBitValues()
+  {
+    constexpr ezUInt64 uiBitCount = sizeof(T) * 8;
+    ezUInt64 uiNextBit = 1;
+    ezUInt64 uiCount = 0;
+    for (auto bit : ezIterateBitValues(ezMath::MaxValue<T>()))
+    {
+      EZ_TEST_INT(bit, uiNextBit);
+      uiNextBit *= 2;
+      uiCount++;
+    }
+    EZ_TEST_INT(uiBitCount, uiCount);
+  }
+
+  template<typename T>
+  void TestEmptyIntegerBitIndices()
+  {
+    ezUInt32 uiNextBit = 1;
+    for (auto bit : ezIterateBitIndices(static_cast<T>(0)))
+    {
+      EZ_REPORT_FAILURE("No bit should be present");
+    }
+  }
+
+  template<typename T>
+  void TestFullIntegerBitIndices()
+  {
+    constexpr ezUInt64 uiBitCount = sizeof(T) * 8;
+    ezUInt64 uiNextBitIndex = 0;
+    for (auto bit : ezIterateBitIndices(ezMath::MaxValue<T>()))
+    {
+      EZ_TEST_INT(bit, uiNextBitIndex);
+      ++uiNextBitIndex;
+    }
+    EZ_TEST_INT(uiBitCount, uiNextBitIndex);
+  }
+}
+
+EZ_CREATE_SIMPLE_TEST(Containers, IterateBits)
+{
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezIterateBitValues")
+  {
+    {
+      // Empty set
+      TestEmptyIntegerBitValues<ezUInt8>();
+      TestEmptyIntegerBitValues<ezUInt16>();
+      TestEmptyIntegerBitValues<ezUInt32>();
+      TestEmptyIntegerBitValues<ezUInt64>();
+    }
+
+    {
+      // Full sets
+      TestFullIntegerBitValues<ezUInt8>();
+      TestFullIntegerBitValues<ezUInt16>();
+      TestFullIntegerBitValues<ezUInt32>();
+      TestFullIntegerBitValues<ezUInt64>();
+    }
+
+    {
+      // Some bits set
+      ezUInt64 uiBitMask = 0b1101;
+      ezHybridArray<ezUInt64, 3> bits;
+      bits.PushBack(0b0001);
+      bits.PushBack(0b0100);
+      bits.PushBack(0b1000);
+
+      for (ezUInt64 bit : ezIterateBitValues(uiBitMask))
+      {
+        EZ_TEST_INT(bit, bits[0]);
+        bits.RemoveAtAndCopy(0);
+      }
+      EZ_TEST_BOOL(bits.IsEmpty());
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezIterateBitIndices")
+  {
+    {
+      // Empty set
+      TestEmptyIntegerBitIndices<ezUInt8>();
+      TestEmptyIntegerBitIndices<ezUInt16>();
+      TestEmptyIntegerBitIndices<ezUInt32>();
+      TestEmptyIntegerBitIndices<ezUInt64>();
+    }
+
+    {
+      // Full sets
+      TestFullIntegerBitIndices<ezUInt8>();
+      TestFullIntegerBitIndices<ezUInt16>();
+      TestFullIntegerBitIndices<ezUInt32>();
+      TestFullIntegerBitIndices<ezUInt64>();
+    }
+
+    {
+      // Some bits set
+      ezUInt64 uiBitMask = 0b1101;
+      ezHybridArray<ezUInt64, 3> bits;
+      bits.PushBack(0);
+      bits.PushBack(2);
+      bits.PushBack(3);
+
+      for (ezUInt64 bit : ezIterateBitIndices(uiBitMask))
+      {
+        EZ_TEST_INT(bit, bits[0]);
+        bits.RemoveAtAndCopy(0);
+      }
+      EZ_TEST_BOOL(bits.IsEmpty());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds iterators to various bit-based classes: `ezBitfield`, `ezStaticBitfield` and `ezBitflags`. Both the `GetIterator` pattern as well as ranged-based for loops are supported. It also adds two helper classes to iterate over the bits of any integer: `ezIterateBitValues` and `ezIterateBitIndices`. All iterators are based on the new helper class `ezBitIterator`.
```
// ezBitfield iterator iterates of bit indices
ezHybridBitfield<128> bitfield;
bitfield.SetCount(128, true);
for (ezUInt32 uiBitIndex : bitfield)
{
  ezLog::Info("{}", uiBitIndex ); // Outputs 0, 1, ... 127
}

// ezStaticBitfield iterator iterates of bit indices
ezStaticBitfield32 staticBitfield = ezStaticBitfield32::MakeFromMask(0xffffffffu);
for (auto it = staticBitfield.GetIterator(); it.IsValid(); ++it)
{
  ezLog::Info("{}", it.Value()); // Outputs 0, 1, ... 31
}

// ezBitflags iterator iterates of the bit values, i.e. EZ_BIT(bitIndex)
ezBitflags<AutoFlags> f = AutoFlags::Bit1 | AutoFlags::Bit2 | AutoFlags::Bit3 | AutoFlags::Bit4;
for (AutoFlags::Enum flag : f)
{
}

// ezIterateBitValues forces iterating over bit values
ezUInt64 bits = 0b1101;
for (auto bit : ezIterateBitValues(bits))
{
  ezLog::Info("{}", bit); // Outputs 1, 4, 8
}

// ezIterateBitIndices forces iterating over bit indices
for (auto bit : ezIterateBitIndices(bits))
{
  ezLog::Info("{}", bit); // Outputs 0, 2, 3
}
```