### PR TITLE
Fixes for scripting error

### DIFF
--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/Assets/AssetBrowserDlg.moc.h>
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.moc.h>
 #include <EditorFramework/PropertyGrid/AssetBrowserPropertyWidget.moc.h>
@@ -158,7 +159,7 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
         m_uiThumbnailID = 0;
 
         m_pWidget->setText(ezMakeQString(sText));
-        
+
         m_pButton->setIcon(QIcon());
         m_pButton->setToolButtonStyle(Qt::ToolButtonStyle::ToolButtonTextOnly);
 
@@ -463,13 +464,30 @@ void ezQtAssetPropertyWidget::OnCreateNewAsset()
     {
       ezDocument* pDoc = nullptr;
 
-      const ezStatus res = ttu.pAssetMan->CreateDocument(
-        ttu.pDocType->m_sDocumentTypeName, sOutput, pDoc, ezDocumentFlags::RequestWindow | ezDocumentFlags::AddToRecentFilesList);
+      const ezStatus res = ttu.pAssetMan->CreateDocument(ttu.pDocType->m_sDocumentTypeName, sOutput, pDoc, ezDocumentFlags::RequestWindow | ezDocumentFlags::AddToRecentFilesList);
 
       ezQtUiServices::GetSingleton()->MessageBoxStatus(res, "Creating the document failed.");
 
       if (res.m_Result.Succeeded())
       {
+        // if this is an asset, make sure it gets transformed, so that the output file exists
+        // and make sure the filesystem knows about it (the asset lookup table is written)
+        // so that redirections inside the resource manager will work right away
+        // otherwise they may only work after a while (the world gets set up again) which would be irritating
+        if (ezAssetDocument* pAsset = ezDynamicCast<ezAssetDocument*>(pDoc))
+        {
+          ezAssetCurator::GetSingleton()->NotifyOfAssetChange(pAsset->GetGuid());
+
+          if (pAsset->TransformAsset(ezTransformFlags::Default).Failed())
+          {
+            ezLog::Error("Failed to transform newly created asset '{}'", pDoc->GetDocumentPath());
+            break;
+          }
+
+          ezAssetCurator::GetSingleton()->MainThreadTick(false);
+          ezAssetCurator::GetSingleton()->WriteAssetTables(nullptr, true).IgnoreResult();
+        }
+
         pDoc->EnsureVisible();
 
         InternalSetValue(sOutput.GetData());

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -1539,6 +1539,9 @@ void ezVisualScriptNodeRegistry::CreateFunctionCallNodeType(const ezRTTI* pRtti,
       }
     }
 
+    EZ_ASSERT_ALWAYS(pFunction->GetArgumentCount() == pScriptableFunctionAttribute->GetArgumentCount(),
+      "The function reflection for '{}::{}' does not match the actual signature. Num arguments: {}, reflected arguments: {}.", sTypeName, sFunctionName, pFunction->GetArgumentCount(), pScriptableFunctionAttribute->GetArgumentCount());
+
     ezUInt32 titleArgIdx = ezInvalidIndex;
 
     ezStringBuilder sArgName;

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -210,7 +210,8 @@ ezUInt32 ezResourceManager::FreeAllUnusedResources()
       bAnyFailed = false;
 
       ezInt32 iHelpExecTasksRounds = 1;
-      ezTaskSystem::WaitForCondition([&iHelpExecTasksRounds]() { return iHelpExecTasksRounds-- <= 0; });
+      ezTaskSystem::WaitForCondition([&iHelpExecTasksRounds]()
+        { return iHelpExecTasksRounds-- <= 0; });
     }
 
   } while (bFreeAllUnused && bUnloadedAny);
@@ -344,7 +345,8 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
 
     for (const ezRTTI* pRtti : info.m_NestedTypes)
     {
-      ezRTTI::ForEachDerivedType(pRtti, [&](const ezRTTI* pDerived) { todo.Insert(pDerived); });
+      ezRTTI::ForEachDerivedType(pRtti, [&](const ezRTTI* pDerived)
+        { todo.Insert(pDerived); });
     }
 
     while (!todo.IsEmpty())
@@ -363,7 +365,8 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
       {
         if (!visited.Contains(pNestedRtti))
         {
-          ezRTTI::ForEachDerivedType(pNestedRtti, [&](const ezRTTI* pDerived) { todo.Insert(pDerived); });
+          ezRTTI::ForEachDerivedType(pNestedRtti, [&](const ezRTTI* pDerived)
+            { todo.Insert(pDerived); });
         }
       }
     }
@@ -381,7 +384,7 @@ bool ezResourceManager::IsResourceTypeAcquireDuringUpdateContentAllowed(const ez
 
 ezResult ezResourceManager::DeallocateResource(ezResource* pResource)
 {
-  //EZ_ASSERT_DEBUG(pResource->m_iLockCount == 0, "Resource '{0}' has a refcount of zero, but is still in an acquired state.", pResource->GetResourceID());
+  // EZ_ASSERT_DEBUG(pResource->m_iLockCount == 0, "Resource '{0}' has a refcount of zero, but is still in an acquired state.", pResource->GetResourceID());
 
   if (RemoveFromLoadingQueue(pResource).Failed())
   {
@@ -682,6 +685,13 @@ ezResource* ezResourceManager::GetResource(const ezRTTI* pRtti, ezStringView sRe
   pRtti = FindResourceTypeOverride(pRtti, sResourceID);
 
   EZ_ASSERT_DEBUG(pRtti != nullptr, "There is no RTTI information available for the given resource type '{0}'", EZ_STRINGIZE(ResourceType));
+
+  if (pRtti->GetTypeFlags().IsSet(ezTypeFlags::Abstract))
+  {
+    // this can happen for assets that use a resource type override (such as scripts) shortly after they have been created
+    return nullptr;
+  }
+
   EZ_ASSERT_DEBUG(pRtti->GetAllocator() != nullptr && pRtti->GetAllocator()->CanAllocate(), "There is no RTTI allocator available for the given resource type '{0}'", EZ_STRINGIZE(ResourceType));
 
   ezResource* pResource = nullptr;

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -976,6 +976,7 @@ class EZ_FOUNDATION_DLL ezScriptableFunctionAttribute : public ezPropertyAttribu
     ArgType argType3 = In, const char* szArg3 = nullptr, ArgType argType4 = In, const char* szArg4 = nullptr, ArgType argType5 = In,
     const char* szArg5 = nullptr, ArgType argType6 = In, const char* szArg6 = nullptr);
 
+  ezUInt32 GetArgumentCount() const { return m_ArgNames.GetCount(); }
   const char* GetArgumentName(ezUInt32 uiIndex) const { return m_ArgNames[uiIndex]; }
 
   ArgType GetArgumentType(ezUInt32 uiIndex) const { return static_cast<ArgType>(m_ArgTypes[uiIndex]); }

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: D16372FD-C27A-56FB-AF82-AB1EFAF0540B
+Change me: D16372FD-C27A-56FB-AF83-AB1EFAF0541B


### PR DESCRIPTION
Better assert for a common user error.

Tried to fix that the editor would crash when you use the "Create New Asset" context menu option to add a visual script. This is a really annoying case, because the actual script type to use is decided by the file extension of the transformed asset, which does not exist at that point. It is now enforced to exist, but even if it doesn't exist in some other code path, it will not assert anymore.