### PR TITLE
Improved selection and copy/paste behavior

### DIFF
--- a/Code/Editor/EditorFramework/EditTools/Implementation/GizmoEditTool.cpp
+++ b/Code/Editor/EditorFramework/EditTools/Implementation/GizmoEditTool.cpp
@@ -161,6 +161,10 @@ void ezGameObjectGizmoEditTool::SelectionManagerEventHandler(const ezSelectionMa
       UpdateGizmoVisibleState();
       break;
 
+    case ezSelectionManagerEvent::Type::ObjectRemoved:
+      UpdateGizmoVisibleState();
+      break;
+
     default:
       break;
   }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -505,7 +505,7 @@ void ezMaterialAssetDocument::SetBaseMaterial(const char* szBaseMaterial)
   auto pAssetInfo = ezAssetCurator::GetSingleton()->FindSubAsset(szBaseMaterial);
   if (pAssetInfo == nullptr)
   {
-    ezDeque<const ezDocumentObject*> sel;
+    ezHybridArray<const ezDocumentObject*, 2> sel;
     sel.PushBack(pObject);
     UnlinkPrefabs(sel);
   }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
@@ -284,8 +284,17 @@ void ezSelectionAction::Execute(const ezVariant& value)
       if (ezQtUiServices::MessageBoxQuestion("Discard all modifications to the selected prefabs and revert to the prefab template state?",
             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
       {
-        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
-        m_pSceneDocument->RevertPrefabs(sel);
+        ezHybridArray<ezSelectionEntry, 64> selection;
+        m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), selection);
+
+        ezHybridArray<const ezDocumentObject*, 64> selection2;
+        selection2.SetCount(selection.GetCount());
+        for (ezUInt32 i = 0; i < selection.GetCount(); ++i)
+        {
+          selection2[i] = selection[i].m_pObject;
+        }
+
+        m_pSceneDocument->RevertPrefabs(selection2);
       }
     }
     break;
@@ -295,8 +304,17 @@ void ezSelectionAction::Execute(const ezVariant& value)
       if (ezQtUiServices::MessageBoxQuestion("Unlink the selected prefab instances from their templates?",
             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
       {
-        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
-        m_pSceneDocument->UnlinkPrefabs(sel);
+        ezHybridArray<ezSelectionEntry, 64> selection;
+        m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), selection);
+
+        ezHybridArray<const ezDocumentObject*, 64> selection2;
+        selection2.SetCount(selection.GetCount());
+        for (ezUInt32 i = 0; i < selection.GetCount(); ++i)
+        {
+          selection2[i] = selection[i].m_pObject;
+        }
+
+        m_pSceneDocument->UnlinkPrefabs(selection2);
       }
     }
     break;
@@ -330,8 +348,17 @@ void ezSelectionAction::Execute(const ezVariant& value)
 
     case ActionType::ConvertToEditorPrefab:
     {
-      const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
-      m_pSceneDocument->ConvertToEditorPrefab(sel);
+      ezHybridArray<ezSelectionEntry, 64> selection;
+      m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), selection);
+
+      ezHybridArray<const ezDocumentObject*, 64> selection2;
+      selection2.SetCount(selection.GetCount());
+      for (ezUInt32 i = 0; i < selection.GetCount(); ++i)
+      {
+        selection2[i] = selection[i].m_pObject;
+      }
+
+      m_pSceneDocument->ConvertToEditorPrefab(selection2);
     }
     break;
 
@@ -340,8 +367,17 @@ void ezSelectionAction::Execute(const ezVariant& value)
       if (ezQtUiServices::MessageBoxQuestion("Discard all modifications to the selected prefabs and convert them to engine prefabs?",
             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
       {
-        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
-        m_pSceneDocument->ConvertToEnginePrefab(sel);
+        ezHybridArray<ezSelectionEntry, 64> selection;
+        m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), selection);
+
+        ezHybridArray<const ezDocumentObject*, 64> selection2;
+        selection2.SetCount(selection.GetCount());
+        for (ezUInt32 i = 0; i < selection.GetCount(); ++i)
+        {
+          selection2[i] = selection[i].m_pObject;
+        }
+
+        m_pSceneDocument->ConvertToEnginePrefab(selection2);
       }
     }
     break;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
@@ -284,7 +284,7 @@ void ezSelectionAction::Execute(const ezVariant& value)
       if (ezQtUiServices::MessageBoxQuestion("Discard all modifications to the selected prefabs and revert to the prefab template state?",
             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
       {
-        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelection(ezGetStaticRTTI<ezGameObject>());
+        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
         m_pSceneDocument->RevertPrefabs(sel);
       }
     }
@@ -295,7 +295,7 @@ void ezSelectionAction::Execute(const ezVariant& value)
       if (ezQtUiServices::MessageBoxQuestion("Unlink the selected prefab instances from their templates?",
             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
       {
-        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelection(ezGetStaticRTTI<ezGameObject>());
+        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
         m_pSceneDocument->UnlinkPrefabs(sel);
       }
     }
@@ -330,7 +330,7 @@ void ezSelectionAction::Execute(const ezVariant& value)
 
     case ActionType::ConvertToEditorPrefab:
     {
-      const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelection(ezGetStaticRTTI<ezGameObject>());
+      const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
       m_pSceneDocument->ConvertToEditorPrefab(sel);
     }
     break;
@@ -340,7 +340,7 @@ void ezSelectionAction::Execute(const ezVariant& value)
       if (ezQtUiServices::MessageBoxQuestion("Discard all modifications to the selected prefabs and convert them to engine prefabs?",
             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
       {
-        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelection(ezGetStaticRTTI<ezGameObject>());
+        const ezDeque<const ezDocumentObject*> sel = m_pSceneDocument->GetSelectionManager()->GetTopLevelSelectionOfType(ezGetStaticRTTI<ezGameObject>(), true);
         m_pSceneDocument->ConvertToEnginePrefab(sel);
       }
     }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Commands/SceneCommands.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Commands/SceneCommands.cpp
@@ -189,23 +189,8 @@ void ezDuplicateObjectsCommand::CreateOneDuplicate(ezAbstractObjectGraph& graph,
 
         if (guidParent.IsValid())
           ref.m_pParent = pDocument->GetObjectManager()->GetObject(guidParent);
-
-        if (auto* pProperty = pNode->FindProperty("__Order"))
-        {
-          // we use m_Index for sorting, but then should clear it again, so it doesn't have an effect later
-          ref.m_Index = pProperty->m_Value.ConvertTo<ezInt32>();
-        }
       }
     }
-  }
-
-  ToBePasted.Sort([](const auto& lhs, const auto& rhs)
-    { return lhs.m_Index < rhs.m_Index; });
-
-  for (ezDocument::PasteInfo& item : ToBePasted)
-  {
-    // we don't want the index to have an effect later
-    item.m_Index = -1;
   }
 
   if (pDocument->DuplicateSelectedObjects(ToBePasted, graph, false))

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/DeltaTransformDlg.cpp
@@ -194,7 +194,7 @@ void ezQtDeltaTransformDlg::on_ButtonApply_clicked()
 
   auto history = m_pSceneDocument->GetCommandHistory();
   auto selman = m_pSceneDocument->GetSelectionManager();
-  const auto& selection = selman->GetTopLevelSelection();
+  const auto& selection = selman->GetTopLevelSelection(false);
 
   if (selection.IsEmpty())
     return;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Prefabs.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Prefabs.cpp
@@ -6,7 +6,7 @@
 #include <ToolsFoundation/Command/TreeCommands.h>
 
 
-void ezSceneDocument::UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection)
+void ezSceneDocument::UnlinkPrefabs(ezArrayPtr<const ezDocumentObject*> selection)
 {
   SUPER::UnlinkPrefabs(selection);
 
@@ -161,7 +161,7 @@ void ezSceneDocument::UpdatePrefabObject(ezDocumentObject* pObject, const ezUuid
   }
 }
 
-void ezSceneDocument::ConvertToEditorPrefab(const ezDeque<const ezDocumentObject*>& selection)
+void ezSceneDocument::ConvertToEditorPrefab(ezArrayPtr<const ezDocumentObject*> selection)
 {
   ezDeque<const ezDocumentObject*> newSelection;
 
@@ -198,7 +198,7 @@ void ezSceneDocument::ConvertToEditorPrefab(const ezDeque<const ezDocumentObject
   GetSelectionManager()->SetSelection(newSelection);
 }
 
-void ezSceneDocument::ConvertToEnginePrefab(const ezDeque<const ezDocumentObject*>& selection)
+void ezSceneDocument::ConvertToEnginePrefab(ezArrayPtr<const ezDocumentObject*> selection)
 {
   ezDeque<const ezDocumentObject*> newSelection;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -576,7 +576,7 @@ void ezSceneDocument::SetGameMode(GameMode::Enum mode)
 
 ezStatus ezSceneDocument::CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB /* = {} */, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB /* = {} */, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB /* = {} */)
 {
-  auto Selection = GetSelectionManager()->GetTopLevelSelection(pRootType);
+  auto Selection = GetSelectionManager()->GetTopLevelSelectionOfType(pRootType, true);
 
   if (Selection.IsEmpty())
     return ezStatus("To create a prefab, the selection must not be empty");

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -89,7 +89,7 @@ public:
     const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
   bool DuplicateSelectedObjects(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bSetSelected);
   bool CopySelectedObjects(ezAbstractObjectGraph& ref_graph, ezMap<ezUuid, ezUuid>* out_pParents) const;
-  bool PasteAt(const ezArrayPtr<PasteInfo>& info, const ezVec3& vPos);
+  bool PasteAt(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, const ezVec3& vPos);
   bool PasteAtOrignalPosition(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph);
 
   virtual void UpdatePrefabs() override;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -95,18 +95,17 @@ public:
   virtual void UpdatePrefabs() override;
 
   /// \brief Removes the link to the prefab template, making the editor prefab a simple object
-  virtual void UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection) override;
+  virtual void UnlinkPrefabs(ezArrayPtr<const ezDocumentObject*> selection) override;
 
-  virtual ezUuid ReplaceByPrefab(
-    const ezDocumentObject* pRootObject, ezStringView sPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab) override;
+  virtual ezUuid ReplaceByPrefab(const ezDocumentObject* pRootObject, ezStringView sPrefabFile, const ezUuid& prefabAsset, const ezUuid& prefabSeed, bool bEnginePrefab) override;
 
   /// \brief Reverts all selected editor prefabs to their original template state
   virtual ezUuid RevertPrefab(const ezDocumentObject* pObject) override;
 
   /// \brief Converts all objects in the selection that are engine prefabs to their respective editor prefab representation
-  virtual void ConvertToEditorPrefab(const ezDeque<const ezDocumentObject*>& selection);
+  virtual void ConvertToEditorPrefab(ezArrayPtr<const ezDocumentObject*> selection);
   /// \brief Converts all objects in the selection that are editor prefabs to their respective engine prefab representation
-  virtual void ConvertToEnginePrefab(const ezDeque<const ezDocumentObject*>& selection);
+  virtual void ConvertToEnginePrefab(ezArrayPtr<const ezDocumentObject*> selection);
 
   virtual ezStatus CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {}) override;
 

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/EditActions.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/EditActions.cpp
@@ -198,12 +198,21 @@ void ezEditAction::Execute(const ezVariant& value)
       QByteArray ba = mimedata->data(MimeTypes[iFormat].GetData());
       cmd.m_sGraphTextFormat = ba.data();
 
-      if (m_ButtonType == ButtonType::PasteAsChild)
+      const ezDocumentObject* pNewParent = m_Context.m_pDocument->GetSelectionManager()->GetCurrentObject();
+      if (pNewParent && m_ButtonType != ButtonType::PasteAsChild)
       {
-        if (!m_Context.m_pDocument->GetSelectionManager()->IsSelectionEmpty())
-          cmd.m_Parent = m_Context.m_pDocument->GetSelectionManager()->GetSelection().PeekBack()->GetGuid();
+        // default behavior copied from Unity: paste as a sibling of the currently selected item
+        // this way if you just select and object and copy/paste it, the new object has the same parent (the clone becomes a sibling of the original)
+        // but you can also select any other object as the reference, and clone as a sibling to that one
+        pNewParent = pNewParent->GetParent();
       }
-      else if (m_ButtonType == ButtonType::PasteAtOriginalLocation)
+
+      if (pNewParent)
+      {
+        cmd.m_Parent = pNewParent->GetGuid();
+      }
+
+      if (m_ButtonType == ButtonType::PasteAtOriginalLocation)
       {
         cmd.m_bAllowPickedPosition = false;
       }

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -225,10 +225,10 @@ public:
   virtual void UpdatePrefabs();
 
   /// \brief Resets the given objects to their template prefab state, if they have local modifications.
-  void RevertPrefabs(const ezDeque<const ezDocumentObject*>& selection);
+  void RevertPrefabs(ezArrayPtr<const ezDocumentObject*> selection);
 
   /// \brief Removes the link between a prefab instance and its template, turning the instance into a regular object.
-  virtual void UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection);
+  virtual void UnlinkPrefabs(ezArrayPtr<const ezDocumentObject*> selection);
 
   virtual ezStatus CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB = {}, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});
   virtual ezStatus CreatePrefabDocument(ezStringView sFile, ezArrayPtr<const ezDocumentObject*> rootObjects, const ezUuid& invPrefabSeed, ezUuid& out_newDocumentGuid, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB = {}, bool bKeepOpen = false, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB = {});

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
@@ -402,7 +402,8 @@ void ezDocument::BroadcastInterDocumentMessage(ezReflectedClass* pMessage, ezDoc
 
 void ezDocument::DeleteSelectedObjects() const
 {
-  auto objects = GetSelectionManager()->GetTopLevelSelection(false);
+  ezHybridArray<ezSelectionEntry, 64> objects;
+  GetSelectionManager()->GetTopLevelSelection(objects);
 
   // make sure the whole selection is cleared, otherwise each delete command would reduce the selection one by one
   GetSelectionManager()->Clear();
@@ -412,9 +413,9 @@ void ezDocument::DeleteSelectedObjects() const
 
   ezRemoveObjectCommand cmd;
 
-  for (const ezDocumentObject* pObject : objects)
+  for (const ezSelectionEntry& entry : objects)
   {
-    cmd.m_Object = pObject->GetGuid();
+    cmd.m_Object = entry.m_pObject->GetGuid();
 
     if (history->AddCommand(cmd).m_Result.Failed())
     {

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
@@ -147,7 +147,8 @@ ezStatus ezDocument::SaveDocument(bool bForce)
     m_ActiveSaveTask.Invalidate();
   }
   ezStatus result;
-  m_ActiveSaveTask = InternalSaveDocument([&result](ezDocument* pDoc, ezStatus res) { result = res; });
+  m_ActiveSaveTask = InternalSaveDocument([&result](ezDocument* pDoc, ezStatus res)
+    { result = res; });
   ezTaskSystem::WaitForGroup(m_ActiveSaveTask);
   m_ActiveSaveTask.Invalidate();
   return result;
@@ -401,7 +402,7 @@ void ezDocument::BroadcastInterDocumentMessage(ezReflectedClass* pMessage, ezDoc
 
 void ezDocument::DeleteSelectedObjects() const
 {
-  auto objects = GetSelectionManager()->GetTopLevelSelection();
+  auto objects = GetSelectionManager()->GetTopLevelSelection(false);
 
   // make sure the whole selection is cleared, otherwise each delete command would reduce the selection one by one
   GetSelectionManager()->Clear();

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentPrefab.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentPrefab.cpp
@@ -57,7 +57,7 @@ void ezDocument::UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection
 
 ezStatus ezDocument::CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB)
 {
-  auto Selection = GetSelectionManager()->GetTopLevelSelection(pRootType);
+  auto Selection = GetSelectionManager()->GetTopLevelSelectionOfType(pRootType, true);
 
   if (Selection.IsEmpty())
     return ezStatus("To create a prefab, the selection must not be empty");

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentPrefab.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/DocumentPrefab.cpp
@@ -19,7 +19,7 @@ void ezDocument::UpdatePrefabs()
   SetModified(true);
 }
 
-void ezDocument::RevertPrefabs(const ezDeque<const ezDocumentObject*>& selection)
+void ezDocument::RevertPrefabs(ezArrayPtr<const ezDocumentObject*> selection)
 {
   if (selection.IsEmpty())
     return;
@@ -36,7 +36,7 @@ void ezDocument::RevertPrefabs(const ezDeque<const ezDocumentObject*>& selection
   pHistory->FinishTransaction();
 }
 
-void ezDocument::UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection)
+void ezDocument::UnlinkPrefabs(ezArrayPtr<const ezDocumentObject*> selection)
 {
   if (selection.IsEmpty())
     return;
@@ -57,16 +57,17 @@ void ezDocument::UnlinkPrefabs(const ezDeque<const ezDocumentObject*>& selection
 
 ezStatus ezDocument::CreatePrefabDocumentFromSelection(ezStringView sFile, const ezRTTI* pRootType, ezDelegate<void(ezAbstractObjectNode*)> adjustGraphNodeCB, ezDelegate<void(ezDocumentObject*)> adjustNewNodesCB, ezDelegate<void(ezAbstractObjectGraph& graph, ezDynamicArray<ezAbstractObjectNode*>& graphRootNodes)> finalizeGraphCB)
 {
-  auto Selection = GetSelectionManager()->GetTopLevelSelectionOfType(pRootType, true);
+  ezHybridArray<ezSelectionEntry, 64> selection;
+  GetSelectionManager()->GetTopLevelSelectionOfType(pRootType, selection);
 
-  if (Selection.IsEmpty())
+  if (selection.IsEmpty())
     return ezStatus("To create a prefab, the selection must not be empty");
 
   ezHybridArray<const ezDocumentObject*, 32> nodes;
-  nodes.Reserve(Selection.GetCount());
-  for (auto pNode : Selection)
+  nodes.Reserve(selection.GetCount());
+  for (const auto& e : selection)
   {
-    nodes.PushBack(pNode);
+    nodes.PushBack(e.m_pObject);
   }
 
   ezUuid PrefabGuid, SeedGuid;

--- a/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
@@ -235,9 +235,9 @@ struct ezObjectHierarchyComparor
 {
   using Tree = ezHybridArray<const ezDocumentObject*, 4>;
 
-  ezObjectHierarchyComparor(ezArrayPtr<ezSelectionEntry> ref_items)
+  ezObjectHierarchyComparor(ezArrayPtr<ezSelectionEntry> items)
   {
-    for (const ezSelectionEntry& e : ref_items)
+    for (const ezSelectionEntry& e : items)
     {
       const ezDocumentObject* pObject = e.m_pObject;
 
@@ -276,10 +276,10 @@ struct ezObjectHierarchyComparor
   ezMap<const ezDocumentObject*, Tree> lookup;
 };
 
-void ezSelectionManager::GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& out_Entries) const
+void ezSelectionManager::GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& out_entries) const
 {
-  out_Entries.Clear();
-  out_Entries.Reserve(m_pSelectionStorage->m_SelectionList.GetCount());
+  out_entries.Clear();
+  out_entries.Reserve(m_pSelectionStorage->m_SelectionList.GetCount());
 
   ezUInt32 order = 0;
 
@@ -287,20 +287,20 @@ void ezSelectionManager::GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& 
   {
     if (!IsParentSelected(pObj))
     {
-      auto& e = out_Entries.ExpandAndGetRef();
+      auto& e = out_entries.ExpandAndGetRef();
       e.m_pObject = pObj;
       e.m_uiSelectionOrder = order++;
     }
   }
 
-  ezObjectHierarchyComparor c(out_Entries);
-  out_Entries.Sort(c);
+  ezObjectHierarchyComparor c(out_entries);
+  out_entries.Sort(c);
 }
 
-void ezSelectionManager::GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynamicArray<ezSelectionEntry>& out_Entries) const
+void ezSelectionManager::GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynamicArray<ezSelectionEntry>& out_entries) const
 {
-  out_Entries.Clear();
-  out_Entries.Reserve(m_pSelectionStorage->m_SelectionList.GetCount());
+  out_entries.Clear();
+  out_entries.Reserve(m_pSelectionStorage->m_SelectionList.GetCount());
 
   ezUInt32 order = 0;
 
@@ -311,12 +311,12 @@ void ezSelectionManager::GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynam
 
     if (!IsParentSelected(pObj))
     {
-      auto& e = out_Entries.ExpandAndGetRef();
+      auto& e = out_entries.ExpandAndGetRef();
       e.m_pObject = pObj;
       e.m_uiSelectionOrder = order++;
     }
   }
 
-  ezObjectHierarchyComparor c(out_Entries);
-  out_Entries.Sort(c);
+  ezObjectHierarchyComparor c(out_entries);
+  out_entries.Sort(c);
 }

--- a/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
@@ -294,7 +294,7 @@ const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(
   return items;
 }
 
-const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(const ezRTTI* pBase, bool bInOrderOfSceneTree) const
+const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelectionOfType(const ezRTTI* pBase, bool bInOrderOfSceneTree) const
 {
   ezDeque<const ezDocumentObject*> items;
 

--- a/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
@@ -224,7 +224,9 @@ ezSharedPtr<ezSelectionManager::Storage> ezSelectionManager::SwapStorage(ezShare
   m_pSelectionStorage = pNewStorage;
 
   m_pSelectionStorage->m_pObjectManager->m_StructureEvents.AddEventHandler(ezMakeDelegate(&ezSelectionManager::TreeEventHandler, this), m_ObjectStructureUnsubscriber);
-  m_pSelectionStorage->m_Events.AddEventHandler([this](const ezSelectionManagerEvent& e) { m_Events.Broadcast(e); }, m_EventsUnsubscriber);
+  m_pSelectionStorage->m_Events.AddEventHandler([this](const ezSelectionManagerEvent& e)
+    { m_Events.Broadcast(e); },
+    m_EventsUnsubscriber);
 
   return retVal;
 }
@@ -271,7 +273,7 @@ struct ezObjectHierarchyComparor
   ezMap<const ezDocumentObject*, Tree> lookup;
 };
 
-const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection() const
+const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(bool bInOrderOfSceneTree) const
 {
   ezDeque<const ezDocumentObject*> items;
 
@@ -283,13 +285,16 @@ const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(
     }
   }
 
-  ezObjectHierarchyComparor c(items);
-  items.Sort(c);
+  if (bInOrderOfSceneTree)
+  {
+    ezObjectHierarchyComparor c(items);
+    items.Sort(c);
+  }
 
   return items;
 }
 
-const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(const ezRTTI* pBase) const
+const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(const ezRTTI* pBase, bool bInOrderOfSceneTree) const
 {
   ezDeque<const ezDocumentObject*> items;
 
@@ -304,8 +309,11 @@ const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(
     }
   }
 
-  ezObjectHierarchyComparor c(items);
-  items.Sort(c);
+  if (bInOrderOfSceneTree)
+  {
+    ezObjectHierarchyComparor c(items);
+    items.Sort(c);
+  }
 
   return items;
 }

--- a/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
@@ -184,7 +184,7 @@ void ezSelectionManager::ToggleObject(const ezDocumentObject* pObject)
 
 const ezDocumentObject* ezSelectionManager::GetCurrentObject() const
 {
-  return m_pSelectionStorage->m_SelectionList.IsEmpty() ? nullptr : m_pSelectionStorage->m_SelectionList[m_pSelectionStorage->m_SelectionList.GetCount() - 1];
+  return m_pSelectionStorage->m_SelectionList.IsEmpty() ? nullptr : m_pSelectionStorage->m_SelectionList.PeekBack();
 }
 
 bool ezSelectionManager::IsSelected(const ezDocumentObject* pObject) const
@@ -234,10 +234,13 @@ ezSharedPtr<ezSelectionManager::Storage> ezSelectionManager::SwapStorage(ezShare
 struct ezObjectHierarchyComparor
 {
   using Tree = ezHybridArray<const ezDocumentObject*, 4>;
-  ezObjectHierarchyComparor(ezDeque<const ezDocumentObject*>& ref_items)
+
+  ezObjectHierarchyComparor(ezArrayPtr<ezSelectionEntry> ref_items)
   {
-    for (const ezDocumentObject* pObject : ref_items)
+    for (const ezSelectionEntry& e : ref_items)
     {
+      const ezDocumentObject* pObject = e.m_pObject;
+
       Tree& tree = lookup[pObject];
       while (pObject)
       {
@@ -248,10 +251,10 @@ struct ezObjectHierarchyComparor
     }
   }
 
-  EZ_ALWAYS_INLINE bool Less(const ezDocumentObject* lhs, const ezDocumentObject* rhs) const
+  EZ_ALWAYS_INLINE bool Less(const ezSelectionEntry& lhs, const ezSelectionEntry& rhs) const
   {
-    const Tree& A = *lookup.GetValue(lhs);
-    const Tree& B = *lookup.GetValue(rhs);
+    const Tree& A = *lookup.GetValue(lhs.m_pObject);
+    const Tree& B = *lookup.GetValue(rhs.m_pObject);
 
     const ezUInt32 minSize = ezMath::Min(A.GetCount(), B.GetCount());
     for (ezUInt32 i = 0; i < minSize; i++)
@@ -268,35 +271,38 @@ struct ezObjectHierarchyComparor
     return A.GetCount() < B.GetCount();
   }
 
-  EZ_ALWAYS_INLINE bool Equal(const ezDocumentObject* lhs, const ezDocumentObject* rhs) const { return lhs == rhs; }
+  EZ_ALWAYS_INLINE bool Equal(const ezSelectionEntry& lhs, const ezSelectionEntry& rhs) const { return lhs.m_pObject == rhs.m_pObject; }
 
   ezMap<const ezDocumentObject*, Tree> lookup;
 };
 
-const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelection(bool bInOrderOfSceneTree) const
+void ezSelectionManager::GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& out_Entries) const
 {
-  ezDeque<const ezDocumentObject*> items;
+  out_Entries.Clear();
+  out_Entries.Reserve(m_pSelectionStorage->m_SelectionList.GetCount());
+
+  ezUInt32 order = 0;
 
   for (const auto* pObj : m_pSelectionStorage->m_SelectionList)
   {
     if (!IsParentSelected(pObj))
     {
-      items.PushBack(pObj);
+      auto& e = out_Entries.ExpandAndGetRef();
+      e.m_pObject = pObj;
+      e.m_uiSelectionOrder = order++;
     }
   }
 
-  if (bInOrderOfSceneTree)
-  {
-    ezObjectHierarchyComparor c(items);
-    items.Sort(c);
-  }
-
-  return items;
+  ezObjectHierarchyComparor c(out_Entries);
+  out_Entries.Sort(c);
 }
 
-const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelectionOfType(const ezRTTI* pBase, bool bInOrderOfSceneTree) const
+void ezSelectionManager::GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynamicArray<ezSelectionEntry>& out_Entries) const
 {
-  ezDeque<const ezDocumentObject*> items;
+  out_Entries.Clear();
+  out_Entries.Reserve(m_pSelectionStorage->m_SelectionList.GetCount());
+
+  ezUInt32 order = 0;
 
   for (const auto* pObj : m_pSelectionStorage->m_SelectionList)
   {
@@ -305,15 +311,12 @@ const ezDeque<const ezDocumentObject*> ezSelectionManager::GetTopLevelSelectionO
 
     if (!IsParentSelected(pObj))
     {
-      items.PushBack(pObj);
+      auto& e = out_Entries.ExpandAndGetRef();
+      e.m_pObject = pObj;
+      e.m_uiSelectionOrder = order++;
     }
   }
 
-  if (bInOrderOfSceneTree)
-  {
-    ezObjectHierarchyComparor c(items);
-    items.Sort(c);
-  }
-
-  return items;
+  ezObjectHierarchyComparor c(out_Entries);
+  out_Entries.Sort(c);
 }

--- a/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
@@ -56,11 +56,15 @@ public:
 
   bool IsSelectionEmpty() const { return m_pSelectionStorage->m_SelectionList.IsEmpty(); }
 
-  /// \brief Returns the subset of selected items which have no parent selected. I.e. if an object is selected and one of its ancestors is selected, it is culled from the list. Items are returned in the order of appearance in an expanded scene tree.
-  const ezDeque<const ezDocumentObject*> GetTopLevelSelection() const;
+  /// \brief Returns the subset of selected items which have no parent selected.
+  ///
+  /// I.e. if an object is selected and one of its ancestors is selected, it is culled from the list.
+  /// if bInOrderOfSceneTree is true, items are returned in the order of appearance in an expanded scene tree.
+  /// Otherwise they are returned in the order that they were selected.
+  const ezDeque<const ezDocumentObject*> GetTopLevelSelection(bool bInOrderOfSceneTree) const;
 
   /// \brief Same as GetTopLevelSelection() but additionally requires that all objects are derived from type pBase.
-  const ezDeque<const ezDocumentObject*> GetTopLevelSelection(const ezRTTI* pBase) const;
+  const ezDeque<const ezDocumentObject*> GetTopLevelSelection(const ezRTTI* pBase, bool bInOrderOfSceneTree) const;
 
   bool IsSelected(const ezDocumentObject* pObject) const;
   bool IsParentSelected(const ezDocumentObject* pObject) const;

--- a/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
@@ -69,10 +69,10 @@ public:
   /// I.e. if an object is selected and one of its ancestors is selected, it is culled from the list.
   /// Items are returned in the order of appearance in an expanded scene tree.
   /// Their order in the selection is returned through ezSelectionEntry.
-  void GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& out_Entries) const;
+  void GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& out_entries) const;
 
   /// \brief Same as GetTopLevelSelection() but additionally requires that all objects are derived from type pBase.
-  void GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynamicArray<ezSelectionEntry>& out_Entries) const;
+  void GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynamicArray<ezSelectionEntry>& out_entries) const;
 
   bool IsSelected(const ezDocumentObject* pObject) const;
   bool IsParentSelected(const ezDocumentObject* pObject) const;

--- a/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
@@ -64,7 +64,7 @@ public:
   const ezDeque<const ezDocumentObject*> GetTopLevelSelection(bool bInOrderOfSceneTree) const;
 
   /// \brief Same as GetTopLevelSelection() but additionally requires that all objects are derived from type pBase.
-  const ezDeque<const ezDocumentObject*> GetTopLevelSelection(const ezRTTI* pBase, bool bInOrderOfSceneTree) const;
+  const ezDeque<const ezDocumentObject*> GetTopLevelSelectionOfType(const ezRTTI* pBase, bool bInOrderOfSceneTree) const;
 
   bool IsSelected(const ezDocumentObject* pObject) const;
   bool IsParentSelected(const ezDocumentObject* pObject) const;

--- a/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/SelectionManager.h
@@ -21,6 +21,12 @@ struct ezSelectionManagerEvent
   const ezDocumentObject* m_pObject;
 };
 
+struct ezSelectionEntry
+{
+  const ezDocumentObject* m_pObject;
+  ezUInt32 m_uiSelectionOrder = 0; // the index at which this item was in the selection
+};
+
 /// \brief Selection Manager stores a set of selected document objects.
 class EZ_TOOLSFOUNDATION_DLL ezSelectionManager
 {
@@ -56,15 +62,17 @@ public:
 
   bool IsSelectionEmpty() const { return m_pSelectionStorage->m_SelectionList.IsEmpty(); }
 
+
+
   /// \brief Returns the subset of selected items which have no parent selected.
   ///
   /// I.e. if an object is selected and one of its ancestors is selected, it is culled from the list.
-  /// if bInOrderOfSceneTree is true, items are returned in the order of appearance in an expanded scene tree.
-  /// Otherwise they are returned in the order that they were selected.
-  const ezDeque<const ezDocumentObject*> GetTopLevelSelection(bool bInOrderOfSceneTree) const;
+  /// Items are returned in the order of appearance in an expanded scene tree.
+  /// Their order in the selection is returned through ezSelectionEntry.
+  void GetTopLevelSelection(ezDynamicArray<ezSelectionEntry>& out_Entries) const;
 
   /// \brief Same as GetTopLevelSelection() but additionally requires that all objects are derived from type pBase.
-  const ezDeque<const ezDocumentObject*> GetTopLevelSelectionOfType(const ezRTTI* pBase, bool bInOrderOfSceneTree) const;
+  void GetTopLevelSelectionOfType(const ezRTTI* pBase, ezDynamicArray<ezSelectionEntry>& out_Entries) const;
 
   bool IsSelected(const ezDocumentObject* pObject) const;
   bool IsParentSelected(const ezDocumentObject* pObject) const;

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -111,7 +111,8 @@ void ezEditorSceneDocumentTest::CloseSimpleScene()
   {
     bool bSaved = false;
     ezTaskGroupID id = m_pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res) {
+      [&bSaved](ezDocument* pDoc, ezStatus res)
+      {
         bSaved = true;
       },
       true);
@@ -139,7 +140,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
   ezUuid layer1Guid;
   ezLayerDocument* pLayer1 = nullptr;
 
-  auto TestLayerEvents = [&expectedEvents](const ezScene2LayerEvent& e) {
+  auto TestLayerEvents = [&expectedEvents](const ezScene2LayerEvent& e)
+  {
     if (EZ_TEST_BOOL(!expectedEvents.IsEmpty()))
     {
       // If we pass in an invalid guid it's considered fine as we might not know the ID, e.g. when creating a layer.
@@ -209,7 +211,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
   {
     bool bSaved = false;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res) {
+      [&bSaved](ezDocument* pDoc, ezStatus res)
+      {
         bSaved = true;
       },
       true);
@@ -302,7 +305,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
   {
     bool bSaved = false;
     ezTaskGroupID id = pDoc->SaveDocumentAsync(
-      [&bSaved](ezDocument* pDoc, ezStatus res) {
+      [&bSaved](ezDocument* pDoc, ezStatus res)
+      {
         bSaved = true;
       },
       true);
@@ -370,7 +374,8 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("Components"));
 
       // Does default state match that of pSphere2 which is unmodified?
-      auto MatchesDefaultValue = [&](ezDefaultObjectState& ref_defaultState, const char* szProperty) {
+      auto MatchesDefaultValue = [&](ezDefaultObjectState& ref_defaultState, const char* szProperty)
+      {
         ezVariant defaultValue = ref_defaultState.GetDefaultValue(szProperty);
         ezVariant sphere2value;
         EZ_TEST_STATUS(pAccessor->GetValue(pSphere2, szProperty, sphere2value));
@@ -508,7 +513,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Change Prefab Type")
   {
     ezVariant oldIndex = pPrefab1->GetPropertyIndex();
-    ezDeque<const ezDocumentObject*> selection;
+    ezHybridArray<const ezDocumentObject*, 8> selection;
     {
       selection.PushBack(pPrefab1);
       m_pDoc->ConvertToEditorPrefab(selection);
@@ -543,7 +548,8 @@ void ezEditorSceneDocumentTest::PrefabOperations()
     }
   }
 
-  auto IsObjectDefault = [&](const ezDocumentObject* pChild) {
+  auto IsObjectDefault = [&](const ezDocumentObject* pChild)
+  {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
     ezDefaultObjectState defaultState(pAccessor, selection);
@@ -599,7 +605,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
 
     {
       // Revert prefab
-      ezDeque<const ezDocumentObject*> selection;
+      ezHybridArray<const ezDocumentObject*, 2> selection;
       selection.PushBack(pPrefab3);
       m_pDoc->RevertPrefabs(selection);
 
@@ -714,13 +720,15 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   selection.PushBack(pRoot);
   m_pDoc->GetSelectionManager()->SetSelection(selection);
 
-  auto CreateComponent = [&](const ezRTTI* pType, const ezDocumentObject* pParent) -> const ezDocumentObject* {
+  auto CreateComponent = [&](const ezRTTI* pType, const ezDocumentObject* pParent) -> const ezDocumentObject*
+  {
     ezUuid compGuid;
     EZ_TEST_STATUS(pAccessor->AddObject(pParent, "Components", -1, pType, compGuid));
     return pAccessor->GetObject(compGuid);
   };
 
-  auto IsObjectDefault = [&](const ezDocumentObject* pChild) {
+  auto IsObjectDefault = [&](const ezDocumentObject* pChild)
+  {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
     ezDefaultObjectState defaultState(pAccessor, selection);
@@ -743,7 +751,8 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   };
 
   ezDynamicArray<const ezRTTI*> componentTypes;
-  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti) { componentTypes.PushBack(pRtti); });
+  ezRTTI::ForEachDerivedType<ezComponent>([&](const ezRTTI* pRtti)
+    { componentTypes.PushBack(pRtti); });
 
   ezSet<const ezRTTI*> blacklist;
   // The scene already has one and the code asserts otherwise. There needs to be a general way of preventing two settings components from existing at the same time.
@@ -796,7 +805,8 @@ void ezEditorSceneDocumentTest::ObjectPropertyPath()
 
   auto pAccessor = m_pDoc->GetObjectAccessor();
 
-  auto CreateComponent = [&](const ezDocumentObject* pParent) -> const ezDocumentObject* {
+  auto CreateComponent = [&](const ezDocumentObject* pParent) -> const ezDocumentObject*
+  {
     pAccessor->StartTransaction("AddComponent"_ezsv);
     ezUuid compGuid;
     EZ_TEST_STATUS(pAccessor->AddObject(pParent, "Components", -1, ezRTTI::FindTypeByName("ezDecalComponent"), compGuid));

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -477,9 +477,9 @@ void ezEditorSceneDocumentTest::PrefabOperations()
 
     // Copy & paste should retain the order in the tree view, not the selection array so we push the elements in a random order here.
     ezDeque<const ezDocumentObject*> assets;
-    assets.PushBack(pPrefab3);
     assets.PushBack(pPrefab1);
     assets.PushBack(pPrefab2);
+    assets.PushBack(pPrefab3);
     ezDeque<const ezDocumentObject*> newObjects;
 
     MoveObjectsToLayer(m_pDoc, assets, m_LayerGuid, newObjects);


### PR DESCRIPTION
* When objects under multiple roots are copied, there transform is now as expected (moved but otherwise same relative transforms)
* Deselecting an object now correctly updates the Gizmo position
* When pasting an object, the new parent is now the parent of the currently selected object, meaning it becomes a sibling. This mirrors what Unity does, and makes it easier to keep objects grouped as desired while copy pasting. It also allows to reparent objects into a group while pasting.
* Fixed that the selection order after pasting object is now again identical to the selection order of the copied objects. Thus the gizmo stays at the proper object after pasting and doesn't jump around anymore.
* Changed: When pasting a group of objects, the reference point is not the average position anymore, but the last selected object.