### PR TITLE
Moved the index for array Insert methods to the front

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -303,7 +303,7 @@ void ezQtAssetBrowserModel::HandleEntry(const VisibleEntry& entry, AssetOp op)
       return;
 
     beginInsertRows(QModelIndex(), uiInsertIndex, uiInsertIndex);
-    m_EntriesToDisplay.Insert(entry, uiInsertIndex);
+    m_EntriesToDisplay.InsertAt(uiInsertIndex, entry);
     if (entry.m_Guid.IsValid())
       m_DisplayedEntries.Insert(entry.m_Guid);
     endInsertRows();

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProfile.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProfile.cpp
@@ -209,7 +209,7 @@ ezResult ezAssetCurator::LoadAssetProfiles()
     pCfg->SetTargetPlatform("Windows");
 
     pCfg->AddMissingConfigs();
-    m_AssetProfiles.Insert(pCfg, 0);
+    m_AssetProfiles.InsertAt(0, pCfg);
   }
 
   return EZ_SUCCESS;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -650,7 +650,7 @@ void ezMaterialAssetDocument::UpdatePrefabObject(ezDocumentObject* pObject, cons
     {
       ezAbstractGraphDiffOperation op = newInstanceToCurrentInstance[i];
       newInstanceToCurrentInstance.RemoveAtAndCopy(i);
-      newInstanceToCurrentInstance.Insert(op, 0);
+      newInstanceToCurrentInstance.InsertAt(0, op);
       break;
     }
   }

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -1326,7 +1326,7 @@ ezResult ezWorld::RegisterUpdateFunctionInternal(const ezWorldModule::UpdateFunc
     ++uiInsertionIndex;
   }
 
-  updateFunctions.Insert(newFunction, uiInsertionIndex);
+  updateFunctions.InsertAt(uiInsertionIndex, newFunction);
 
   return EZ_SUCCESS;
 }

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionASTTransforms.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionASTTransforms.cpp
@@ -1038,7 +1038,7 @@ ezResult ezExpressionAST::ScalarizeInputs()
       {
         ezEnum<VectorComponent> component = static_cast<VectorComponent::Enum>(i);
         auto pNewInput = CreateInput(CreateScalarizedStreamDesc(pInput->m_Desc, component));
-        m_InputNodes.Insert(pNewInput, uiInputIndex + i);
+        m_InputNodes.InsertAt(uiInputIndex + i, pNewInput);
       }
     }
   }
@@ -1064,7 +1064,7 @@ ezResult ezExpressionAST::ScalarizeOutputs()
         ezEnum<VectorComponent> component = static_cast<VectorComponent::Enum>(i);
         auto pSwizzle = CreateSwizzle(component, pOutput->m_pExpression);
         auto pNewOutput = CreateOutput(CreateScalarizedStreamDesc(pOutput->m_Desc, component), pSwizzle);
-        m_OutputNodes.Insert(pNewOutput, uiOutputIndex + i);
+        m_OutputNodes.InsertAt(uiOutputIndex + i, pNewOutput);
       }
     }
   }

--- a/Code/Engine/Foundation/Containers/ArrayBase.h
+++ b/Code/Engine/Foundation/Containers/ArrayBase.h
@@ -78,10 +78,10 @@ public:
   bool Contains(const T& value) const; // [tested]
 
   /// \brief Inserts value at index by shifting all following elements.
-  void Insert(const T& value, ezUInt32 uiIndex); // [tested]
+  void InsertAt(ezUInt32 uiIndex, const T& value); // [tested]
 
   /// \brief Inserts value at index by shifting all following elements.
-  void Insert(T&& value, ezUInt32 uiIndex); // [tested]
+  void InsertAt(ezUInt32 uiIndex, T&& value); // [tested]
 
   /// \brief Inserts all elements in the range starting at the given index, shifting the elements after the index.
   void InsertRange(const ezArrayPtr<const T>& range, ezUInt32 uiIndex); // [tested]

--- a/Code/Engine/Foundation/Containers/Deque.h
+++ b/Code/Engine/Foundation/Containers/Deque.h
@@ -154,7 +154,7 @@ public:
   bool RemoveAndSwap(const T& value); // [tested]
 
   /// \brief Inserts value at index by shifting all following elements. Valid insert positions are [0; GetCount].
-  void Insert(const T& value, ezUInt32 uiIndex); // [tested]
+  void InsertAt(ezUInt32 uiIndex, const T& value); // [tested]
 
   /// \brief Sort with explicit comparer
   template <typename Comparer>

--- a/Code/Engine/Foundation/Containers/Implementation/ArrayBase_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/ArrayBase_inl.h
@@ -194,7 +194,7 @@ bool ezArrayBase<T, Derived>::Contains(const T& value) const
 }
 
 template <typename T, typename Derived>
-void ezArrayBase<T, Derived>::Insert(const T& value, ezUInt32 uiIndex)
+void ezArrayBase<T, Derived>::InsertAt(ezUInt32 uiIndex, const T& value)
 {
   EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
 
@@ -205,7 +205,7 @@ void ezArrayBase<T, Derived>::Insert(const T& value, ezUInt32 uiIndex)
 }
 
 template <typename T, typename Derived>
-void ezArrayBase<T, Derived>::Insert(T&& value, ezUInt32 uiIndex)
+void ezArrayBase<T, Derived>::InsertAt(ezUInt32 uiIndex, T&& value)
 {
   EZ_ASSERT_DEV(uiIndex <= m_uiCount, "Invalid index. Array has {0} elements, trying to insert element at index {1}.", m_uiCount, uiIndex);
 

--- a/Code/Engine/Foundation/Containers/Implementation/Deque_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/Deque_inl.h
@@ -934,7 +934,7 @@ bool ezDequeBase<T, Construct>::RemoveAndSwap(const T& value)
 }
 
 template <typename T, bool Construct>
-void ezDequeBase<T, Construct>::Insert(const T& value, ezUInt32 uiIndex)
+void ezDequeBase<T, Construct>::InsertAt(ezUInt32 uiIndex, const T& value)
 {
   EZ_CHECK_AT_COMPILETIME_MSG(Construct, "This function is not supported on Deques that do not construct their data.");
 

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -668,13 +668,13 @@ EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::SetCountUninitial
 }
 
 template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
-EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::Insert(const T& value, ezUInt32 uiIndex)
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::InsertAt(ezUInt32 uiIndex, const T& value)
 {
   SUPER::Insert(value, uiIndex, AllocatorWrapper::GetAllocator());
 }
 
 template <typename T, ezUInt16 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
-EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::Insert(T&& value, ezUInt32 uiIndex)
+EZ_ALWAYS_INLINE void ezSmallArray<T, Size, AllocatorWrapper>::InsertAt(ezUInt32 uiIndex, T&& value)
 {
   SUPER::Insert(value, uiIndex, AllocatorWrapper::GetAllocator());
 }

--- a/Code/Engine/Foundation/Containers/SmallArray.h
+++ b/Code/Engine/Foundation/Containers/SmallArray.h
@@ -240,8 +240,8 @@ public:
   template <typename = void>
   void SetCountUninitialized(ezUInt16 uiCount);         // [tested]
 
-  void Insert(const T& value, ezUInt32 uiIndex);        // [tested]
-  void Insert(T&& value, ezUInt32 uiIndex);             // [tested]
+  void InsertAt(ezUInt32 uiIndex, const T& value);      // [tested]
+  void InsertAt(ezUInt32 uiIndex, T&& value);           // [tested]
 
   T& ExpandAndGetRef();                                 // [tested]
   void PushBack(const T& value);                        // [tested]

--- a/Code/Engine/Foundation/Reflection/Implementation/ArrayProperty.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/ArrayProperty.h
@@ -178,7 +178,7 @@ public:
     EZ_ASSERT_DEBUG(uiIndex <= GetCount(pInstance), "Insert: uiIndex ('{0}') is out of range ('{1}')", uiIndex, GetCount(pInstance));
     EZ_ASSERT_DEBUG(m_Getter != nullptr, "The property '{0}' has no non-const array accessor function, thus it is read-only.",
       ezAbstractProperty::GetPropertyName());
-    m_Getter(static_cast<Class*>(pInstance)).Insert(*static_cast<const RealType*>(pObject), uiIndex);
+    m_Getter(static_cast<Class*>(pInstance)).InsertAt(uiIndex, * static_cast<const RealType*>(pObject));
   }
 
   virtual void Remove(void* pInstance, ezUInt32 uiIndex) const override

--- a/Code/Engine/Foundation/Reflection/Implementation/ArrayProperty.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/ArrayProperty.h
@@ -178,7 +178,7 @@ public:
     EZ_ASSERT_DEBUG(uiIndex <= GetCount(pInstance), "Insert: uiIndex ('{0}') is out of range ('{1}')", uiIndex, GetCount(pInstance));
     EZ_ASSERT_DEBUG(m_Getter != nullptr, "The property '{0}' has no non-const array accessor function, thus it is read-only.",
       ezAbstractProperty::GetPropertyName());
-    m_Getter(static_cast<Class*>(pInstance)).InsertAt(uiIndex, * static_cast<const RealType*>(pObject));
+    m_Getter(static_cast<Class*>(pInstance)).InsertAt(uiIndex, *static_cast<const RealType*>(pObject));
   }
 
   virtual void Remove(void* pInstance, ezUInt32 uiIndex) const override

--- a/Code/Engine/GameEngine/Animation/Implementation/PathComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Implementation/PathComponent.cpp
@@ -147,7 +147,7 @@ void ezPathComponent::Nodes_SetNode(ezUInt32 i, const ezString& node)
 
 void ezPathComponent::Nodes_Insert(ezUInt32 uiIndex, const ezString& node)
 {
-  m_Nodes.Insert(node, uiIndex);
+  m_Nodes.InsertAt(uiIndex, node);
   m_bControlPointsChanged = true;
   m_bLinearizedRepresentationChanged = true;
 }

--- a/Code/Engine/GameEngine/Effects/PostProcessing/Implementation/PostProcessingComponent.cpp
+++ b/Code/Engine/GameEngine/Effects/PostProcessing/Implementation/PostProcessingComponent.cpp
@@ -175,7 +175,7 @@ void ezPostProcessingComponent::Mappings_SetMapping(ezUInt32 i, const ezPostProc
 
 void ezPostProcessingComponent::Mappings_Insert(ezUInt32 uiIndex, const ezPostProcessingValueMapping& mapping)
 {
-  m_Mappings.Insert(mapping, uiIndex);
+  m_Mappings.InsertAt(uiIndex, mapping);
 
   RegisterSamplerValues();
 }

--- a/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
@@ -456,7 +456,7 @@ void ezLocalBlackboardComponent::Entries_SetValue(ezUInt32 uiIndex, const ezBlac
 
 void ezLocalBlackboardComponent::Entries_Insert(ezUInt32 uiIndex, const ezBlackboardEntry& entry)
 {
-  m_InitialEntries.Insert(entry, uiIndex);
+  m_InitialEntries.InsertAt(uiIndex, entry);
 
   m_pBoard->SetEntryValue(entry.m_sName, entry.m_InitialValue);
   m_pBoard->SetEntryFlags(entry.m_sName, entry.m_Flags).AssertSuccess();

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BoneWeightsAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BoneWeightsAnimNode.cpp
@@ -53,7 +53,7 @@ void ezBoneWeightsAnimNode::RootBones_Insert(ezUInt32 uiIndex, const char* value
 {
   ezHashedString tmp;
   tmp.Assign(value);
-  m_RootBones.Insert(tmp, uiIndex);
+  m_RootBones.InsertAt(uiIndex, tmp);
 }
 
 void ezBoneWeightsAnimNode::RootBones_Remove(ezUInt32 uiIndex)

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipSequenceAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipSequenceAnimNode.cpp
@@ -115,7 +115,7 @@ void ezSampleAnimClipSequenceAnimNode::Clips_Insert(ezUInt32 uiIndex, const char
 {
   ezHashedString s;
   s.Assign(szValue);
-  m_Clips.Insert(s, uiIndex);
+  m_Clips.InsertAt(uiIndex, s);
 }
 
 void ezSampleAnimClipSequenceAnimNode::Clips_Remove(ezUInt32 uiIndex)

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalComponent.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalComponent.cpp
@@ -620,7 +620,7 @@ void ezDecalComponent::DecalFile_Set(ezUInt32 uiIndex, const char* szFile)
 
 void ezDecalComponent::DecalFile_Insert(ezUInt32 uiIndex, const char* szFile)
 {
-  m_Decals.Insert(ezDecalResourceHandle(), uiIndex);
+  m_Decals.InsertAt(uiIndex, ezDecalResourceHandle());
   DecalFile_Set(uiIndex, szFile);
 }
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
@@ -295,7 +295,7 @@ void ezInstancedMeshComponent::Instances_SetValue(ezUInt32 uiIndex, ezMeshInstan
 
 void ezInstancedMeshComponent::Instances_Insert(ezUInt32 uiIndex, ezMeshInstanceData value)
 {
-  m_RawInstancedData.Insert(value, uiIndex);
+  m_RawInstancedData.InsertAt(uiIndex, value);
 
   TriggerLocalBoundsUpdate();
 }

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
@@ -336,7 +336,7 @@ void ezMeshComponentBase::Materials_Insert(ezUInt32 uiIndex, const char* value)
   if (!ezStringUtils::IsNullOrEmpty(value))
     hMat = ezResourceManager::LoadResource<ezMaterialResource>(value);
 
-  m_Materials.Insert(hMat, uiIndex);
+  m_Materials.InsertAt(uiIndex, hMat);
 
   InvalidateCachedRenderData();
 }

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1814,7 +1814,7 @@ void ezGALDeviceVulkan::AddWaitSemaphore(const SemaphoreInfo& waitSemaphore)
 {
   // #TODO_VULKAN Assert is in render pipeline, thread safety
   if (waitSemaphore.m_type == vk::SemaphoreType::eTimeline)
-    m_waitSemaphores.Insert(waitSemaphore, 0);
+    m_waitSemaphores.InsertAt(0, waitSemaphore);
   else
     m_waitSemaphores.PushBack(waitSemaphore);
 }
@@ -1823,7 +1823,7 @@ void ezGALDeviceVulkan::AddSignalSemaphore(const SemaphoreInfo& signalSemaphore)
 {
   // #TODO_VULKAN Assert is in render pipeline, thread safety
   if (signalSemaphore.m_type == vk::SemaphoreType::eTimeline)
-    m_signalSemaphores.Insert(signalSemaphore, 0);
+    m_signalSemaphores.InsertAt(0, signalSemaphore);
   else
     m_signalSemaphores.PushBack(signalSemaphore);
 }

--- a/Code/Engine/Texture/Image/Implementation/ImageConversion.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageConversion.cpp
@@ -252,7 +252,7 @@ ezResult ezImageConversion::BuildPath(ezImageFormat::Enum sourceFormat, ezImageF
           allocateScratchBufferIndex(scratchBuffers, ezImageFormat::GetBitsPerBlock(ref_path_out[0].m_sourceFormat), ref_path_out[0].m_sourceBufferIndex);
         ref_path_out[0].m_sourceBufferIndex = copy.m_targetBufferIndex;
         copy.m_step = nullptr;
-        ref_path_out.Insert(copy, 0);
+        ref_path_out.InsertAt(0, copy);
       }
       else
       {

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -754,7 +754,7 @@ void ezProcPlacementComponent::BoxExtents_SetValue(ezUInt32 uiIndex, const ezPro
 
 void ezProcPlacementComponent::BoxExtents_Insert(ezUInt32 uiIndex, const ezProcGenBoxExtents& value)
 {
-  m_BoxExtents.Insert(value, uiIndex);
+  m_BoxExtents.InsertAt(uiIndex, value);
 
   UpdateBoundsAndTiles();
 }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -502,7 +502,7 @@ ezUInt32 ezProcVertexColorComponent::OutputDescs_GetCount() const
 
 void ezProcVertexColorComponent::OutputDescs_Insert(ezUInt32 uiIndex, const ezProcVertexColorOutputDesc& outputDesc)
 {
-  m_OutputDescs.Insert(outputDesc, uiIndex);
+  m_OutputDescs.InsertAt(uiIndex, outputDesc);
 
   if (IsActiveAndInitialized())
   {

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -1245,7 +1245,7 @@ namespace
     int iIndex = inout_context.GetData<int>(node.GetInputDataOffset(2));
     if (iIndex >= 0 && iIndex <= int(a.GetCount()))
     {
-      a.Insert(element, iIndex);
+      a.InsertAt(iIndex, element);
       return ExecResult::RunNext(0);
     }
 

--- a/Code/Tools/Libs/GuiFoundation/Action/ActionMap.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/ActionMap.h
@@ -45,7 +45,7 @@ public:
   {
     ezTreeNode<T>* pNode = EZ_DEFAULT_NEW(ezTreeNode<T>, data);
     pNode->m_Guid = ezUuid::MakeUuid();
-    m_Children.Insert(pNode, uiIndex);
+    m_Children.InsertAt(uiIndex, pNode);
     pNode->m_pParent = this;
     return pNode;
   }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -1266,7 +1266,7 @@ ezQtPropertyContainerWidget::Element& ezQtPropertyContainerWidget::AddElement(ez
     connect(pDeleteButton, &QToolButton::clicked, this, &ezQtPropertyContainerWidget::OnElementButtonClicked);
   }
 
-  m_Elements.Insert(Element(pSubGroup, pNewWidget, pHelpButton), index);
+  m_Elements.InsertAt(index, Element(pSubGroup, pNewWidget, pHelpButton));
   return m_Elements[index];
 }
 

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedType.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedType.cpp
@@ -68,7 +68,7 @@ void ezAttributeHolder::SetValue(ezUInt32 uiIndex, const ezPropertyAttribute* va
 
 void ezAttributeHolder::Insert(ezUInt32 uiIndex, const ezPropertyAttribute* value)
 {
-  m_Attributes.Insert(value, uiIndex);
+  m_Attributes.InsertAt(uiIndex, value);
 }
 
 void ezAttributeHolder::Remove(ezUInt32 uiIndex)

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageAccessor.cpp
@@ -331,7 +331,7 @@ bool ezReflectedTypeStorageAccessor::InsertValue(ezStringView sProperty, ezVaria
             ezVariantArray changedValues = values;
             if (pProp->GetSpecificType() == ezGetStaticRTTI<ezVariant>())
             {
-              changedValues.Insert(value, uiIndex);
+              changedValues.InsertAt(uiIndex, value);
               m_Data[storageInfo->m_uiIndex] = changedValues;
               return true;
             }
@@ -339,7 +339,7 @@ bool ezReflectedTypeStorageAccessor::InsertValue(ezStringView sProperty, ezVaria
             {
               // We are lenient here regarding the type, as we may have stored values in the undo-redo stack
               // that may have a different type now as someone reloaded the type information and replaced a type.
-              changedValues.Insert(value.ConvertTo(SpecVarType), uiIndex);
+              changedValues.InsertAt(uiIndex, value.ConvertTo(SpecVarType));
               m_Data[storageInfo->m_uiIndex] = changedValues;
               return true;
             }
@@ -460,7 +460,7 @@ bool ezReflectedTypeStorageAccessor::MoveValue(ezStringView sProperty, ezVariant
             {
               uiNewIndex -= 1;
             }
-            changedValues.Insert(value, uiNewIndex);
+            changedValues.InsertAt(uiNewIndex, value);
 
             m_Data[storageInfo->m_uiIndex] = changedValues;
             return true;

--- a/Code/UnitTests/FoundationTest/Containers/DequeTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DequeTest.cpp
@@ -539,7 +539,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Deque)
 
     // always inserts at the front
     for (ezInt32 i = 0; i < 100; ++i)
-      a1.Insert(i, 0);
+      a1.InsertAt(0, i);
 
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(a1[i], 99 - i);
@@ -567,7 +567,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Deque)
     ezDeque<ezInt32> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAndSwap(9);
     a1.RemoveAndSwap(7);
@@ -586,7 +586,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Deque)
     ezDeque<ezInt32> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndCopy(9);
     a1.RemoveAtAndCopy(7);
@@ -605,7 +605,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Deque)
     ezDeque<ezInt32> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndSwap(9);
     a1.RemoveAtAndSwap(7);
@@ -700,7 +700,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, Deque)
       a1.PushBack(DequeTestDetail::st(1));
       EZ_TEST_BOOL(DequeTestDetail::st::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
-      a1.Insert(DequeTestDetail::st(2), 0);
+      a1.InsertAt(0, DequeTestDetail::st(2));
       EZ_TEST_BOOL(DequeTestDetail::st::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
       a2 = a1;

--- a/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/DynamicArrayTest.cpp
@@ -428,7 +428,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
 
     // always inserts at the front
     for (ezInt32 i = 0; i < 100; ++i)
-      a1.Insert(i, 0);
+      a1.InsertAt(0, i);
 
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(a1[i], 99 - i);
@@ -439,9 +439,9 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     {
       ezDynamicArray<ezUniquePtr<DynamicArrayTestDetail::st>> a2;
       for (ezUInt32 i = 0; i < 10; ++i)
-        a2.Insert(ezUniquePtr<DynamicArrayTestDetail::st>(), 0);
+        a2.InsertAt(0, ezUniquePtr<DynamicArrayTestDetail::st>());
 
-      a2.Insert(std::move(ptr), 0);
+      a2.InsertAt(0, std::move(ptr));
       EZ_TEST_BOOL(ptr == nullptr);
       EZ_TEST_BOOL(a2[0] != nullptr);
 
@@ -591,7 +591,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     ezDynamicArray<ezInt32> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAndSwap(9);
     a1.RemoveAndSwap(7);
@@ -610,7 +610,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     ezDynamicArray<ezInt32> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndCopy(9);
     a1.RemoveAtAndCopy(7);
@@ -629,7 +629,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     {
       ezDynamicArray<ezUniquePtr<DynamicArrayTestDetail::st>> a2;
       for (ezUInt32 i = 0; i < 10; ++i)
-        a2.Insert(ezUniquePtr<DynamicArrayTestDetail::st>(), 0);
+        a2.InsertAt(0, ezUniquePtr<DynamicArrayTestDetail::st>());
 
       a2.PushBack(std::move(ptr));
       EZ_TEST_BOOL(ptr == nullptr);
@@ -648,7 +648,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     ezDynamicArray<ezInt32> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndSwap(9);
     a1.RemoveAtAndSwap(7);
@@ -667,7 +667,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     {
       ezDynamicArray<ezUniquePtr<DynamicArrayTestDetail::st>> a2;
       for (ezUInt32 i = 0; i < 10; ++i)
-        a2.Insert(ezUniquePtr<DynamicArrayTestDetail::st>(), 0);
+        a2.InsertAt(0, ezUniquePtr<DynamicArrayTestDetail::st>());
 
       a2.PushBack(std::move(ptr));
       EZ_TEST_BOOL(ptr == nullptr);
@@ -737,7 +737,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
       a1.PushBack(DynamicArrayTestDetail::st(1));
       EZ_TEST_BOOL(DynamicArrayTestDetail::st::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
-      a1.Insert(DynamicArrayTestDetail::st(2), 0);
+      a1.InsertAt(0, DynamicArrayTestDetail::st(2));
       EZ_TEST_BOOL(DynamicArrayTestDetail::st::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
       a2 = a1;
@@ -833,9 +833,9 @@ EZ_CREATE_SIMPLE_TEST(Containers, DynamicArray)
     list.PushBack(1);
     list.PushBack(2);
     list.PushBack(3);
-    list.Insert(4, 3);
-    list.Insert(0, 1);
-    list.Insert(0, 5);
+    list.InsertAt(3, 4);
+    list.InsertAt(1, 0);
+    list.InsertAt(5, 0);
 
     EZ_TEST_BOOL(list[0].a == 1);
     EZ_TEST_BOOL(list[1].a == 0);

--- a/Code/UnitTests/FoundationTest/Containers/HybridArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/HybridArrayTest.cpp
@@ -462,13 +462,13 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
     }
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Insert")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "InsertAt")
   {
     ezHybridArray<ezInt32, 16> a1;
 
     // always inserts at the front
     for (ezInt32 i = 0; i < 100; ++i)
-      a1.Insert(i, 0);
+      a1.InsertAt(0, i);
 
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(a1[i], 99 - i);
@@ -496,7 +496,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
     ezHybridArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAndSwap(9);
     a1.RemoveAndSwap(7);
@@ -515,7 +515,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
     ezHybridArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndCopy(9);
     a1.RemoveAtAndCopy(7);
@@ -534,7 +534,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
     ezHybridArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndSwap(9);
     a1.RemoveAtAndSwap(7);
@@ -605,7 +605,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
       a1.PushBack(ezConstructionCounter(1));
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
-      a1.Insert(ezConstructionCounter(2), 0);
+      a1.InsertAt(0, ezConstructionCounter(2));
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
       a2 = a1;
@@ -714,9 +714,9 @@ EZ_CREATE_SIMPLE_TEST(Containers, HybridArray)
     list.PushBack(1);
     list.PushBack(2);
     list.PushBack(3);
-    list.Insert(4, 3);
-    list.Insert(0, 1);
-    list.Insert(0, 5);
+    list.InsertAt(3, 4);
+    list.InsertAt(1, 0);
+    list.InsertAt(5, 0);
 
     EZ_TEST_BOOL(list[0].a == 1);
     EZ_TEST_BOOL(list[1].a == 0);

--- a/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/SmallArrayTest.cpp
@@ -468,7 +468,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
 
     // always inserts at the front
     for (ezInt32 i = 0; i < 100; ++i)
-      a1.Insert(i, 0);
+      a1.InsertAt(0, i);
 
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(a1[i], 99 - i);
@@ -496,7 +496,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAndSwap(9);
     a1.RemoveAndSwap(7);
@@ -515,7 +515,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndCopy(9);
     a1.RemoveAtAndCopy(7);
@@ -534,7 +534,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     ezSmallArray<ezInt32, 16> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndSwap(9);
     a1.RemoveAtAndSwap(7);
@@ -605,7 +605,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
       a1.PushBack(ezConstructionCounter(1));
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
-      a1.Insert(ezConstructionCounter(2), 0);
+      a1.InsertAt(0, ezConstructionCounter(2));
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
       a2 = a1;
@@ -713,9 +713,9 @@ EZ_CREATE_SIMPLE_TEST(Containers, SmallArray)
     list.PushBack(1);
     list.PushBack(2);
     list.PushBack(3);
-    list.Insert(4, 3);
-    list.Insert(0, 1);
-    list.Insert(0, 5);
+    list.InsertAt(3, 4);
+    list.InsertAt(1, 0);
+    list.InsertAt(5, 0);
 
     EZ_TEST_BOOL(list[0].a == 1);
     EZ_TEST_BOOL(list[1].a == 0);

--- a/Code/UnitTests/FoundationTest/Containers/StaticArrayTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/StaticArrayTest.cpp
@@ -214,13 +214,13 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticArray)
     }
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Insert")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "InsertAt")
   {
     ezStaticArray<ezInt32, 128> a1;
 
     // always inserts at the front
     for (ezInt32 i = 0; i < 100; ++i)
-      a1.Insert(i, 0);
+      a1.InsertAt(0, i);
 
     for (ezInt32 i = 0; i < 100; ++i)
       EZ_TEST_INT(a1[i], 99 - i);
@@ -248,7 +248,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticArray)
     ezStaticArray<ezInt32, 128> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAndSwap(9);
     a1.RemoveAndSwap(7);
@@ -267,7 +267,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticArray)
     ezStaticArray<ezInt32, 128> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndCopy(9);
     a1.RemoveAtAndCopy(7);
@@ -286,7 +286,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticArray)
     ezStaticArray<ezInt32, 128> a1;
 
     for (ezInt32 i = 0; i < 10; ++i)
-      a1.Insert(i, i); // inserts at the end
+      a1.InsertAt(i, i); // inserts at the end
 
     a1.RemoveAtAndSwap(9);
     a1.RemoveAtAndSwap(7);
@@ -338,7 +338,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticArray)
       a1.PushBack(ezConstructionCounter(1));
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
-      a1.Insert(ezConstructionCounter(2), 0);
+      a1.InsertAt(0, ezConstructionCounter(2));
       EZ_TEST_BOOL(ezConstructionCounter::HasDone(2, 1)); // one temporary, one final (copy constructed)
 
       a2 = a1;
@@ -415,9 +415,9 @@ EZ_CREATE_SIMPLE_TEST(Containers, StaticArray)
     list.PushBack(1);
     list.PushBack(2);
     list.PushBack(3);
-    list.Insert(4, 3);
-    list.Insert(0, 1);
-    list.Insert(0, 5);
+    list.InsertAt(3, 4);
+    list.InsertAt(1, 0);
+    list.InsertAt(5, 0);
 
     EZ_TEST_BOOL(list[0].a == 1);
     EZ_TEST_BOOL(list[1].a == 0);

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.cpp
@@ -161,7 +161,7 @@ void ezTestArrays::SetValue(ezUInt32 uiIndex, double value)
 }
 void ezTestArrays::Insert(ezUInt32 uiIndex, double value)
 {
-  m_Hybrid.Insert(value, uiIndex);
+  m_Hybrid.InsertAt(uiIndex, value);
 }
 void ezTestArrays::Remove(ezUInt32 uiIndex)
 {
@@ -182,7 +182,7 @@ void ezTestArrays::SetValueChar(ezUInt32 uiIndex, const char* value)
 }
 void ezTestArrays::InsertChar(ezUInt32 uiIndex, const char* value)
 {
-  m_HybridChar.Insert(value, uiIndex);
+  m_HybridChar.InsertAt(uiIndex, value);
 }
 void ezTestArrays::RemoveChar(ezUInt32 uiIndex)
 {
@@ -203,7 +203,7 @@ void ezTestArrays::SetValueDyn(ezUInt32 uiIndex, const ezTestStruct3& value)
 }
 void ezTestArrays::InsertDyn(ezUInt32 uiIndex, const ezTestStruct3& value)
 {
-  m_Dynamic.Insert(value, uiIndex);
+  m_Dynamic.InsertAt(uiIndex, value);
 }
 void ezTestArrays::RemoveDyn(ezUInt32 uiIndex)
 {
@@ -224,7 +224,7 @@ void ezTestArrays::SetValueDeq(ezUInt32 uiIndex, const ezTestArrays& value)
 }
 void ezTestArrays::InsertDeq(ezUInt32 uiIndex, const ezTestArrays& value)
 {
-  m_Deque.Insert(value, uiIndex);
+  m_Deque.InsertAt(uiIndex, value);
 }
 void ezTestArrays::RemoveDeq(ezUInt32 uiIndex)
 {
@@ -245,7 +245,7 @@ void ezTestArrays::SetValueCustom(ezUInt32 uiIndex, ezVarianceTypeAngle value)
 }
 void ezTestArrays::InsertCustom(ezUInt32 uiIndex, ezVarianceTypeAngle value)
 {
-  m_CustomVariant.Insert(value, uiIndex);
+  m_CustomVariant.InsertAt(uiIndex, value);
 }
 void ezTestArrays::RemoveCustom(ezUInt32 uiIndex)
 {
@@ -444,9 +444,12 @@ void ezTestMaps::Remove2(const char* szKey)
 const ezRangeView<const char*, ezUInt32> ezTestMaps::GetKeys3() const
 {
   return ezRangeView<const char*, ezUInt32>([this]() -> ezUInt32
-    { return 0; }, [this]() -> ezUInt32
-    { return m_Accessor3.GetCount(); }, [this](ezUInt32& ref_uiIt)
-    { ++ref_uiIt; }, [this](const ezUInt32& uiIt) -> const char*
+    { return 0; },
+    [this]() -> ezUInt32
+    { return m_Accessor3.GetCount(); },
+    [this](ezUInt32& ref_uiIt)
+    { ++ref_uiIt; },
+    [this](const ezUInt32& uiIt) -> const char*
     { return m_Accessor3[uiIt].m_Key; });
 }
 

--- a/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
@@ -139,7 +139,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, DataDirPath)
     CheckIsValid(path);
     EZ_TEST_INT(path.GetDataDirIndex(), 0);
 
-    newRootFolders.Insert("C:/Some/Other/DataDir2", 0);
+    newRootFolders.InsertAt(0, "C:/Some/Other/DataDir2");
     path.UpdateDataDirInfos(newRootFolders);
     CheckIsValid(path);
     EZ_TEST_INT(path.GetDataDirIndex(), 1);
@@ -558,8 +558,8 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
       dataDir.m_sDataDirSpecialPath = sOutputFolder2;
       dataDir.m_sRootName = "output2";
 
-      rootFolders.Insert(sOutputFolder, 0);
-      fsConfig.m_DataDirs.Insert(dataDir, 0);
+      rootFolders.InsertAt(0, sOutputFolder);
+      fsConfig.m_DataDirs.InsertAt(0, dataDir);
     }
 
     ezFileSystemModel::GetSingleton()->Initialize(fsConfig, std::move(referencedFiles), std::move(referencedFolders));


### PR DESCRIPTION
This is what our other containers and the STL do, the other order was unintuitive. Renamed the function to prevent accidental behavior change if the array type is an int.