### PR TITLE
Updated assimp, fixed selection order after duplicating objects

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/TransformGizmoActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/TransformGizmoActions.cpp
@@ -97,7 +97,7 @@ void ezTransformGizmoActions::RegisterActions()
   s_hDragToPositionGizmo = EZ_REGISTER_ACTION_1(
     "Gizmo.Mode.DragToPosition", ezActionScope::Document, "Gizmo", "T", ezGizmoAction, ezGetStaticRTTI<ezDragToPositionGizmoEditTool>());
   s_hWorldSpace = EZ_REGISTER_ACTION_1(
-    "Gizmo.TransformSpace", ezActionScope::Document, "Gizmo", "", ezTransformGizmoAction, ezTransformGizmoAction::ActionType::GizmoToggleWorldSpace);
+    "Gizmo.TransformSpace", ezActionScope::Document, "Gizmo", "X", ezTransformGizmoAction, ezTransformGizmoAction::ActionType::GizmoToggleWorldSpace);
   s_hMoveParentOnly = EZ_REGISTER_ACTION_1("Gizmo.MoveParentOnly", ezActionScope::Document, "Gizmo", "", ezTransformGizmoAction,
     ezTransformGizmoAction::ActionType::GizmoToggleMoveParentOnly);
   s_SnapSettings = EZ_REGISTER_ACTION_1(

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Commands/SceneCommands.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Commands/SceneCommands.cpp
@@ -119,6 +119,9 @@ void ezDuplicateObjectsCommand::SetAsSelection()
 {
   if (!m_DuplicatedObjects.IsEmpty())
   {
+    m_DuplicatedObjects.Sort([](const auto& lhs, const auto& rhs)
+      { return lhs.m_uiSelectionOrder < rhs.m_uiSelectionOrder; });
+
     auto pSelMan = m_pDocument->GetSelectionManager();
 
     ezDeque<const ezDocumentObject*> NewSelection = m_OriginalSelection;
@@ -168,6 +171,8 @@ void ezDuplicateObjectsCommand::CreateOneDuplicate(ezAbstractObjectGraph& graph,
     ParentGuids[guidObj] = ezConversionUtils::ConvertStringToUuid(sNextParentGuid);
   }
 
+  ezHybridArray<ezUInt32, 32> selectionOrder;
+
   auto& nodes = graph.GetAllNodes();
   for (auto it = nodes.GetIterator(); it.IsValid(); ++it)
   {
@@ -180,6 +185,13 @@ void ezDuplicateObjectsCommand::CreateOneDuplicate(ezAbstractObjectGraph& graph,
       if (pNewObject)
       {
         reader.ApplyPropertiesToObject(pNode, pNewObject);
+
+        selectionOrder.PushBack(0);
+
+        if (auto* pProperty = pNode->FindProperty("__SelectionOrder"))
+        {
+          selectionOrder.PeekBack() = pProperty->m_Value.ConvertTo<ezUInt32>();
+        }
 
         auto& ref = ToBePasted.ExpandAndGetRef();
         ref.m_pObject = pNewObject;
@@ -195,13 +207,16 @@ void ezDuplicateObjectsCommand::CreateOneDuplicate(ezAbstractObjectGraph& graph,
 
   if (pDocument->DuplicateSelectedObjects(ToBePasted, graph, false))
   {
-    for (const auto& item : ToBePasted)
+    for (ezUInt32 i = 0; i < ToBePasted.GetCount(); ++i)
     {
+      const auto& item = ToBePasted[i];
+
       auto& po = m_DuplicatedObjects.ExpandAndGetRef();
       po.m_pObject = item.m_pObject;
       po.m_Index = item.m_pObject->GetPropertyIndex();
       po.m_pParent = item.m_pParent;
       po.m_sParentProperty = item.m_pObject->GetParentProperty();
+      po.m_uiSelectionOrder = selectionOrder[i];
     }
   }
   else

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Commands/SceneCommands.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Commands/SceneCommands.h
@@ -51,6 +51,7 @@ private:
     ezDocumentObject* m_pParent;
     ezString m_sParentProperty;
     ezVariant m_Index;
+    ezUInt32 m_uiSelectionOrder = 0;
   };
 
   ezDeque<const ezDocumentObject*> m_OriginalSelection;

--- a/Code/Engine/Foundation/Platform/Win/OSFile_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/OSFile_Win.cpp
@@ -368,8 +368,6 @@ void ezFileSystemIterator::StartSearch(ezStringView sSearchStart, ezBitflags<ezF
 
   m_sCurPath = sSearch.GetFileDirectory();
 
-  EZ_ASSERT_DEV(sSearch.IsAbsolutePath(), "The path '{0}' is not absolute.", m_sCurPath);
-
   m_Flags = flags;
 
   WIN32_FIND_DATAW data;


### PR DESCRIPTION
* Latest assimp version should work again with all our assets.
* Added 'X' shortcut to toggle world-space / local-space (like in Unity)
* When shift-dragging items to duplicate, the selection now uses the same order