### PR TITLE
Android Renderer Support

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -602,7 +602,7 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
 
   ezFileSystem::AddDataDirectory("", "EngineProcess", ":", ezFileSystem::AllowWrites).IgnoreResult();                   // for absolute paths
   ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "bin", ezFileSystem::ReadOnly).IgnoreResult();            // writing to the binary directory
-  ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "shadercache", ezFileSystem::AllowWrites).IgnoreResult(); // for shader files
+  ezFileSystem::AddDataDirectory(">sdk/Output/", "EngineProcess", "shadercache", ezFileSystem::AllowWrites).IgnoreResult(); // for shader files
   ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").IgnoreResult();                             // app specific data
   ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezFileSystem::AllowWrites).IgnoreResult();      // for writing app user data
 

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
@@ -123,7 +123,7 @@ void ezGameApplicationBase::Init_FileSystem_ConfigureDataDirs()
   ezFileSystem::CreateDirectoryStructure(sUserDataPath).IgnoreResult();
 
   ezString writableBinRoot = ">appdir/";
-  ezString shaderCacheRoot = ">appdir/";
+  ezString shaderCacheRoot = ">sdk/Output/";
 
 #if EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)
   // On platforms where this is disabled, one can usually only write to the user directory

--- a/Code/Engine/Core/System/Implementation/Window.cpp
+++ b/Code/Engine/Core/System/Implementation/Window.cpp
@@ -17,6 +17,9 @@
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
 #  include <Core/System/Implementation/uwp/InputDevice_uwp.inl>
 #  include <Core/System/Implementation/uwp/Window_uwp.inl>
+#elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
+#  include <Core/System/Implementation/null/InputDevice_null.inl>
+#  include <Core/System/Implementation/android/Window_android.inl>
 #else
 #  include <Core/System/Implementation/null/InputDevice_null.inl>
 #  include <Core/System/Implementation/null/Window_null.inl>

--- a/Code/Engine/Core/System/Implementation/Window.cpp
+++ b/Code/Engine/Core/System/Implementation/Window.cpp
@@ -18,8 +18,8 @@
 #  include <Core/System/Implementation/uwp/InputDevice_uwp.inl>
 #  include <Core/System/Implementation/uwp/Window_uwp.inl>
 #elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
-#  include <Core/System/Implementation/null/InputDevice_null.inl>
 #  include <Core/System/Implementation/android/Window_android.inl>
+#  include <Core/System/Implementation/null/InputDevice_null.inl>
 #else
 #  include <Core/System/Implementation/null/InputDevice_null.inl>
 #  include <Core/System/Implementation/null/Window_null.inl>

--- a/Code/Engine/Core/System/Implementation/android/Window_android.inl
+++ b/Code/Engine/Core/System/Implementation/android/Window_android.inl
@@ -2,9 +2,9 @@
 
 #include <Core/System/Window.h>
 #include <Foundation/Basics.h>
+#include <Foundation/Basics/Platform/Android/AndroidUtils.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Types/UniquePtr.h>
-#include <Foundation/Basics/Platform/Android/AndroidUtils.h>
 #include <android_native_app_glue.h>
 
 struct ANativeWindow;
@@ -24,24 +24,10 @@ ezResult ezWindow::Initialize()
   }
 
   // Checking and adjustments to creation desc.
-  {
-//    if (m_CreationDescription.m_WindowMode == ezWindowMode::WindowFixedResolution)
-//    {
-//      ezLog::Warning("Only Fullscreen modes are supported on Android. Falling back to ezWindowMode::FullscreenFixedResolution.");
-//      m_CreationDescription.m_WindowMode = ezWindowMode::FullscreenFixedResolution;
-//    }
-//    else if (m_CreationDescription.m_WindowMode == ezWindowMode::WindowResizable)
-//    {
-//      ezLog::Warning("Only FullscreenFixedResolution and FullscreenBorderlessNativeResolution modes are supported on Android. Falling back to ezWindowMode::FullscreenBorderlessNativeResolution.");
-//      m_CreationDescription.m_WindowMode = ezWindowMode::FullscreenBorderlessNativeResolution;
-//    }
+  if (m_CreationDescription.AdjustWindowSizeAndPosition().Failed())
+    ezLog::Warning("Failed to adjust window size and position settings.");
 
-    if (m_CreationDescription.AdjustWindowSizeAndPosition().Failed())
-      ezLog::Warning("Failed to adjust window size and position settings.");
-
-    EZ_ASSERT_RELEASE(m_CreationDescription.m_Resolution.HasNonZeroArea(), "The client area size can't be zero sized!");
-  }
-
+  EZ_ASSERT_RELEASE(m_CreationDescription.m_Resolution.HasNonZeroArea(), "The client area size can't be zero sized!");
   EZ_ASSERT_RELEASE(s_androidWindow == nullptr, "Window already exists. Only one Android window is supported at any time!");
 
   s_androidWindow = ezAndroidUtils::GetAndroidApp()->window;

--- a/Code/Engine/Core/System/Implementation/android/Window_android.inl
+++ b/Code/Engine/Core/System/Implementation/android/Window_android.inl
@@ -1,0 +1,89 @@
+#include <Core/CorePCH.h>
+
+#include <Core/System/Window.h>
+#include <Foundation/Basics.h>
+#include <Foundation/Logging/Log.h>
+#include <Foundation/Types/UniquePtr.h>
+#include <Foundation/Basics/Platform/Android/AndroidUtils.h>
+#include <android_native_app_glue.h>
+
+struct ANativeWindow;
+
+namespace
+{
+  ANativeWindow* s_androidWindow = nullptr;
+} // namespace
+
+ezResult ezWindow::Initialize()
+{
+  EZ_LOG_BLOCK("ezWindow::Initialize", m_CreationDescription.m_Title.GetData());
+
+  if (m_bInitialized)
+  {
+    Destroy().IgnoreResult();
+  }
+
+  // Checking and adjustments to creation desc.
+  {
+//    if (m_CreationDescription.m_WindowMode == ezWindowMode::WindowFixedResolution)
+//    {
+//      ezLog::Warning("Only Fullscreen modes are supported on Android. Falling back to ezWindowMode::FullscreenFixedResolution.");
+//      m_CreationDescription.m_WindowMode = ezWindowMode::FullscreenFixedResolution;
+//    }
+//    else if (m_CreationDescription.m_WindowMode == ezWindowMode::WindowResizable)
+//    {
+//      ezLog::Warning("Only FullscreenFixedResolution and FullscreenBorderlessNativeResolution modes are supported on Android. Falling back to ezWindowMode::FullscreenBorderlessNativeResolution.");
+//      m_CreationDescription.m_WindowMode = ezWindowMode::FullscreenBorderlessNativeResolution;
+//    }
+
+    if (m_CreationDescription.AdjustWindowSizeAndPosition().Failed())
+      ezLog::Warning("Failed to adjust window size and position settings.");
+
+    EZ_ASSERT_RELEASE(m_CreationDescription.m_Resolution.HasNonZeroArea(), "The client area size can't be zero sized!");
+  }
+
+  EZ_ASSERT_RELEASE(s_androidWindow == nullptr, "Window already exists. Only one Android window is supported at any time!");
+
+  s_androidWindow = ezAndroidUtils::GetAndroidApp()->window;
+  m_hWindowHandle = s_androidWindow;
+  m_pInputDevice = EZ_DEFAULT_NEW(ezStandardInputDevice, 0);
+  m_bInitialized = true;
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezWindow::Destroy()
+{
+  if (!m_bInitialized)
+    return EZ_SUCCESS;
+
+  EZ_LOG_BLOCK("ezWindow::Destroy");
+
+  s_androidWindow = nullptr;
+
+
+  ezLog::Success("Window destroyed.");
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezWindow::Resize(const ezSizeU32& newWindowSize)
+{
+  // No need to resize on Android, swapchain can take any size at any time.
+  return EZ_SUCCESS;
+}
+
+void ezWindow::ProcessWindowMessages()
+{
+  EZ_ASSERT_RELEASE(s_androidWindow != nullptr, "No uwp window data available.");
+}
+
+void ezWindow::OnResize(const ezSizeU32& newWindowSize)
+{
+  ezLog::Info("Window resized to ({0}, {1})", newWindowSize.width, newWindowSize.height);
+}
+
+ezWindowHandle ezWindow::GetNativeWindowHandle() const
+{
+  return m_hWindowHandle;
+}

--- a/Code/Engine/Core/System/Implementation/null/InputDevice_null.h
+++ b/Code/Engine/Core/System/Implementation/null/InputDevice_null.h
@@ -11,6 +11,7 @@ public:
   ~ezStandardInputDevice();
 
   virtual void SetShowMouseCursor(bool bShow) override;
+  virtual bool GetShowMouseCursor() const override;
   virtual void SetClipMouseCursor(ezMouseCursorClipMode::Enum mode) override;
   virtual ezMouseCursorClipMode::Enum GetClipMouseCursor() const override;
 

--- a/Code/Engine/Core/System/Implementation/null/InputDevice_null.inl
+++ b/Code/Engine/Core/System/Implementation/null/InputDevice_null.inl
@@ -10,6 +10,11 @@ ezStandardInputDevice::~ezStandardInputDevice() = default;
 
 void ezStandardInputDevice::SetShowMouseCursor(bool bShow) {}
 
+bool ezStandardInputDevice::GetShowMouseCursor() const
+{
+  return false;
+}
+
 void ezStandardInputDevice::SetClipMouseCursor(ezMouseCursorClipMode::Enum mode) {}
 
 ezMouseCursorClipMode::Enum ezStandardInputDevice::GetClipMouseCursor() const

--- a/Code/Engine/Core/System/Window.h
+++ b/Code/Engine/Core/System/Window.h
@@ -108,6 +108,13 @@ using ezWindowHandle = IUnknown*;
 using ezWindowInternalHandle = ezWindowHandle;
 #  define INVALID_WINDOW_HANDLE_VALUE nullptr
 
+#elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
+
+struct ANativeWindow;
+using ezWindowHandle = ANativeWindow*;
+using ezWindowInternalHandle = ezWindowHandle;
+#  define INVALID_WINDOW_HANDLE_VALUE nullptr
+
 #else
 
 using ezWindowHandle = void*;

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -954,14 +954,14 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
       if (SUCCEEDED(m_pDevice3->CheckFormatSupport(entry.m_eDepthOnlyType, &uiSampleSupport)))
       {
         if (uiSampleSupport & D3D11_FORMAT_SUPPORT::D3D11_FORMAT_SUPPORT_SHADER_SAMPLE)
-          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::Sample);
+          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::Texture);
       }
 
       UINT uiRenderSupport;
       if (SUCCEEDED(m_pDevice3->CheckFormatSupport(entry.m_eDepthStencilType, &uiRenderSupport)))
       {
         if (uiRenderSupport & D3D11_FORMAT_SUPPORT::D3D11_FORMAT_SUPPORT_DEPTH_STENCIL)
-          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::Render);
+          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::RenderTarget);
       }
     }
     else
@@ -971,7 +971,10 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
       {
         UINT uiSampleFlag = ezGALResourceFormat::IsIntegerFormat(format) ? D3D11_FORMAT_SUPPORT::D3D11_FORMAT_SUPPORT_SHADER_LOAD : D3D11_FORMAT_SUPPORT::D3D11_FORMAT_SUPPORT_SHADER_SAMPLE;
         if (uiSampleSupport & uiSampleFlag)
-          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::Sample);
+          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::Texture);
+
+        if (uiSampleSupport & D3D11_FORMAT_SUPPORT::D3D11_FORMAT_SUPPORT_TYPED_UNORDERED_ACCESS_VIEW)
+          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::TextureRW);
       }
 
       UINT uiVertexSupport;
@@ -985,7 +988,7 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
       if (SUCCEEDED(m_pDevice3->CheckFormatSupport(entry.m_eRenderTarget, &uiRenderSupport)))
       {
         if (uiRenderSupport & D3D11_FORMAT_SUPPORT::D3D11_FORMAT_SUPPORT_RENDER_TARGET)
-          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::Render);
+          m_Capabilities.m_FormatSupport[i].Add(ezGALResourceFormatSupport::RenderTarget);
       }
 
       UINT uiMSAALevels;

--- a/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
+++ b/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
@@ -13,23 +13,25 @@ struct ezGALResourceFormatSupport
   enum Enum
   {
     None = 0,
-    Sample = EZ_BIT(0),          ///< The format can be sampled as a texture in a shader or in case of integer textures load can be called.
-    Render = EZ_BIT(1),          ///< The format can be used as a render target texture.
-    VertexAttribute = EZ_BIT(2), ///< The format can be used as a vertex attribute.
+    Texture = EZ_BIT(0),         ///< Can be used as a texture and bound to a ezGALShaderResourceType::Texture slot.
+    RenderTarget = EZ_BIT(1),    ///< Can be used as a texture and bound as a render target.
+    TextureRW = EZ_BIT(2),       ///< Can be used as a texture and bound to a ezGALShaderResourceType::TextureRW slot.
     MSAA2x = EZ_BIT(3),          ///< The format supports 2x MSAA
     MSAA4x = EZ_BIT(4),          ///< The format supports 4x MSAA
     MSAA8x = EZ_BIT(5),          ///< The format supports 8x MSAA
+    VertexAttribute = EZ_BIT(6), ///< The format can be used as a vertex attribute.
     Default = 0
   };
 
   struct Bits
   {
-    StorageType Sample : 1;
-    StorageType Render : 1;
-    StorageType VertexAttribute : 1;
+    StorageType Texture : 1;
+    StorageType RenderTarget : 1;
+    StorageType TextureRW : 1;
     StorageType MSAA2x : 1;
     StorageType MSAA4x : 1;
     StorageType MSAA8x : 1;
+    StorageType VertexAttribute : 1;
   };
 };
 EZ_DECLARE_FLAGS_OPERATORS(ezGALResourceFormatSupport);

--- a/Code/Engine/RendererFoundation/Profiling/Implementation/Profiling.cpp
+++ b/Code/Engine/RendererFoundation/Profiling/Implementation/Profiling.cpp
@@ -44,7 +44,7 @@ public:
           if (warnOnRingBufferOverun && endTime < beginTime)
           {
             warnOnRingBufferOverun = false;
-            ezLog::Error("Profiling end is before start, the DX11 timestamp ring buffer was probably overrun.");
+            ezLog::Warning("Profiling end is before start, the DX11 timestamp ring buffer was probably overrun.");
           }
 #  endif
           ezProfilingSystem::AddGPUScope(timingScope.m_szName, beginTime, endTime);

--- a/Code/Engine/RendererVulkan/CMakeLists.txt
+++ b/Code/Engine/RendererVulkan/CMakeLists.txt
@@ -8,9 +8,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(LIBRARY ${PROJECT_NAME})
 
-if (EZ_CMAKE_PLATFORM_WINDOWS)
-	target_compile_definitions(${PROJECT_NAME} PRIVATE VK_USE_PLATFORM_WIN32_KHR)
-elseif (EZ_CMAKE_PLATFORM_LINUX)
+if (EZ_CMAKE_PLATFORM_LINUX)
 	target_compile_options(${PROJECT_NAME} PRIVATE "-Wno-nullability-completeness" "-Wno-enum-compare" "-Wno-switch")
 endif()
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -5,8 +5,8 @@
 #include <Foundation/Types/UniquePtr.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererVulkan/Device/DispatchContext.h>
-#include <RendererVulkan/RendererVulkanDLL.h>
 #include <RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
 
 #include <vulkan/vulkan.hpp>
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -6,6 +6,7 @@
 #include <RendererFoundation/Device/Device.h>
 #include <RendererVulkan/Device/DispatchContext.h>
 #include <RendererVulkan/RendererVulkanDLL.h>
+#include <RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h>
 
 #include <vulkan/vulkan.hpp>
 
@@ -105,6 +106,8 @@ public:
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     bool m_bWin32Surface = false;
 #elif EZ_ENABLED(EZ_SUPPORTS_GLFW)
+#elif defined(VK_USE_PLATFORM_ANDROID_KHR)
+    bool m_bAndroidSurface = false;
 #else
 #  error "Vulkan Platform not supported"
 #endif

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -68,16 +68,10 @@ void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
   EZ_ASSERT_DEV(!m_currentPipelineImageAvailableSemaphore, "Pipeline semaphores leaked");
   m_currentPipelineImageAvailableSemaphore = ezSemaphorePoolVulkan::RequestSemaphore();
 
-  if (m_swapChainImageInUseFences[m_uiCurrentSwapChainImage])
-  {
-    // #TODO_VULKAN waiting for fence does not seem to be necessary, is it already done by acquireNextImageKHR?
-    //  m_pVulkanDevice->GetVulkanDevice().waitForFences(1, &m_swapChainImageInUseFences[m_uiCurrentSwapChainImage], true, 1000000000ui64);
-    m_swapChainImageInUseFences[m_uiCurrentSwapChainImage] = nullptr;
-  }
-
   int retryCount = 0;
   while (true)
   {
+    // #TODO_VULKAN We leave the fence parameter blank as we do not care on the CPU whether a swap chain image is still in use or not. Currently, we daisy-chain each frame to the previous frame's semaphore. Not sure if this won't break if we stop doing that. If we call acquireNextImageKHR, can we be sure that the image is no longer in use?
     vk::Result result = m_pVulkanDevice->GetVulkanDevice().acquireNextImageKHR(m_vulkanSwapChain, std::numeric_limits<uint64_t>::max(), m_currentPipelineImageAvailableSemaphore, nullptr, &m_uiCurrentSwapChainImage);
     if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR)
     {
@@ -139,8 +133,7 @@ void ezGALSwapChainVulkan::PresentRenderTarget(ezGALDevice* pDevice)
 
   pVulkanDevice->AddWaitSemaphore(ezGALDeviceVulkan::SemaphoreInfo::MakeWaitSemaphore(m_currentPipelineImageAvailableSemaphore, vk::PipelineStageFlagBits::eColorAttachmentOutput));
   pVulkanDevice->AddSignalSemaphore(ezGALDeviceVulkan::SemaphoreInfo::MakeSignalSemaphore(currentPipelineRenderFinishedSemaphore));
-  vk::Fence renderFence = pVulkanDevice->Submit();
-  // vk::Fence renderFence = pVulkanDevice->Submit(m_currentPipelineImageAvailableSemaphore, vk::PipelineStageFlagBits::eColorAttachmentOutput, currentPipelineRenderFinishedSemaphore);
+  pVulkanDevice->Submit();
   pVulkanDevice->ReclaimLater(m_currentPipelineImageAvailableSemaphore);
 
   {
@@ -157,8 +150,6 @@ void ezGALSwapChainVulkan::PresentRenderTarget(ezGALDevice* pDevice)
 #ifdef VK_LOG_LAYOUT_CHANGES
     ezLog::Warning("PresentInfoKHR {}", ezArgP(m_swapChainImages[m_uiCurrentSwapChainImage]));
 #endif
-
-    m_swapChainImageInUseFences[m_uiCurrentSwapChainImage] = renderFence;
   }
 
   pVulkanDevice->ReclaimLater(currentPipelineRenderFinishedSemaphore);
@@ -219,6 +210,10 @@ ezResult ezGALSwapChainVulkan::InitPlatform(ezGALDevice* pDevice)
   VkSurfaceKHR glfwSurface = VK_NULL_HANDLE;
   VK_SUCCEED_OR_RETURN_EZ_FAILURE(glfwCreateWindowSurface(m_pVulkanDevice->GetVulkanInstance(), m_WindowDesc.m_pWindow->GetNativeWindowHandle(), nullptr, &glfwSurface));
   m_vulkanSurface = glfwSurface;
+#elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
+  vk::AndroidSurfaceCreateInfoKHR info;
+  info.window = reinterpret_cast<ANativeWindow*>(m_WindowDesc.m_pWindow->GetNativeWindowHandle());
+  VK_SUCCEED_OR_RETURN_EZ_FAILURE(m_pVulkanDevice->GetVulkanInstance().createAndroidSurfaceKHR(&info, nullptr, &m_vulkanSurface));
 #else
 #  error Platform not supported
 #endif
@@ -355,9 +350,6 @@ ezResult ezGALSwapChainVulkan::CreateSwapChainInternal()
   m_swapChainImages.SetCount(uiSwapChainImages);
   VK_SUCCEED_OR_RETURN_EZ_FAILURE(m_pVulkanDevice->GetVulkanDevice().getSwapchainImagesKHR(m_vulkanSwapChain, &uiSwapChainImages, m_swapChainImages.GetData()));
 
-  EZ_ASSERT_DEV(uiSwapChainImages < 4, "If we have more than 3 swap chain images we can't hold ontp fences owned by ezDeviceVulkan::PerFrameData anymore as that reclaims all fences once it reuses the frame data (which is 4 right now). Thus, we can't safely pass in the fence in ezGALSwapChainVulkan::PresentRenderTarget as it will be reclaimed before we use it.");
-  m_swapChainImageInUseFences.SetCount(uiSwapChainImages);
-
   for (ezUInt32 i = 0; i < uiSwapChainImages; i++)
   {
     m_pVulkanDevice->SetDebugName("SwapChainImage", m_swapChainImages[i]);
@@ -405,4 +397,4 @@ ezResult ezGALSwapChainVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Device_Implementation_SwapChainVulkan);
+

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -396,5 +396,3 @@ ezResult ezGALSwapChainVulkan::DeInitPlatform(ezGALDevice* pDevice)
   }
   return EZ_SUCCESS;
 }
-
-

--- a/Code/Engine/RendererVulkan/Device/SwapChainVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/SwapChainVulkan.h
@@ -39,7 +39,6 @@ protected:
   vk::SwapchainKHR m_vulkanSwapChain;
   ezHybridArray<vk::Image, 3> m_swapChainImages;
   ezHybridArray<ezGALTextureHandle, 3> m_swapChainTextures;
-  ezHybridArray<vk::Fence, 3> m_swapChainImageInUseFences;
   ezUInt32 m_uiCurrentSwapChainImage = 0;
 
   vk::Semaphore m_currentPipelineImageAvailableSemaphore;

--- a/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
@@ -39,20 +39,20 @@ VKAPI_ATTR void VKAPI_CALL vkGetDeviceBufferMemoryRequirements(
 
 #include VA_INCLUDE_HIDDEN
 
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT == ezVulkanAllocationCreateFlags::DedicatedMemory);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT == ezVulkanAllocationCreateFlags::NeverAllocate);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_MAPPED_BIT == ezVulkanAllocationCreateFlags::Mapped);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT == ezVulkanAllocationCreateFlags::CanAlias);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT == ezVulkanAllocationCreateFlags::HostAccessSequentialWrite);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT == ezVulkanAllocationCreateFlags::HostAccessRandom);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT == ezVulkanAllocationCreateFlags::StrategyMinMemory);
-EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT == ezVulkanAllocationCreateFlags::StrategyMinTime);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::DedicatedMemory);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_NEVER_ALLOCATE_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::NeverAllocate);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_MAPPED_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::Mapped);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_CAN_ALIAS_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::CanAlias);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::HostAccessSequentialWrite);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::HostAccessRandom);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_STRATEGY_MIN_MEMORY_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::StrategyMinMemory);
+EZ_CHECK_AT_COMPILETIME(VMA_ALLOCATION_CREATE_STRATEGY_MIN_TIME_BIT == (ezUInt32)ezVulkanAllocationCreateFlags::StrategyMinTime);
 
-EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_UNKNOWN == ezVulkanMemoryUsage::Unknown);
-EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED == ezVulkanMemoryUsage::GpuLazilyAllocated);
-EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_AUTO == ezVulkanMemoryUsage::Auto);
-EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE == ezVulkanMemoryUsage::AutoPreferDevice);
-EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_AUTO_PREFER_HOST == ezVulkanMemoryUsage::AutoPreferHost);
+EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_UNKNOWN == (ezUInt32)ezVulkanMemoryUsage::Unknown);
+EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED == (ezUInt32)ezVulkanMemoryUsage::GpuLazilyAllocated);
+EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_AUTO == (ezUInt32)ezVulkanMemoryUsage::Auto);
+EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE == (ezUInt32)ezVulkanMemoryUsage::AutoPreferDevice);
+EZ_CHECK_AT_COMPILETIME(VMA_MEMORY_USAGE_AUTO_PREFER_HOST == (ezUInt32)ezVulkanMemoryUsage::AutoPreferHost);
 
 EZ_CHECK_AT_COMPILETIME(sizeof(ezVulkanAllocation) == sizeof(VmaAllocation));
 
@@ -91,7 +91,11 @@ vk::Result ezMemoryAllocatorVulkan::Initialize(vk::PhysicalDevice physicalDevice
   vulkanFunctions.vkGetDeviceProcAddr = &vkGetDeviceProcAddr;
 
   VmaAllocatorCreateInfo allocatorCreateInfo = {};
+#if EZ_ENABLED(EZ_PLATFORM_ANDROID)
+  allocatorCreateInfo.vulkanApiVersion = VK_API_VERSION_1_0;
+#else
   allocatorCreateInfo.vulkanApiVersion = VK_API_VERSION_1_1;
+#endif
   allocatorCreateInfo.physicalDevice = physicalDevice;
   allocatorCreateInfo.device = device;
   allocatorCreateInfo.instance = instance;

--- a/Code/Engine/RendererVulkan/RendererVulkanDLL.h
+++ b/Code/Engine/RendererVulkan/RendererVulkanDLL.h
@@ -1,7 +1,28 @@
 #pragma once
 
-#include <Foundation/Basics.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+// Needed for vulkan.hpp which includes headers that include windows.h which then define min, breaking std::min used in vulkan.hpp :-/
+#  include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#endif
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#  define VK_USE_PLATFORM_WIN32_KHR
+#elif EZ_ENABLED(EZ_PLATFORM_LINUX)
+#  define VK_USE_PLATFORM_XCB_KHR
+#elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
+#  define VK_USE_PLATFORM_ANDROID_KHR
+#endif
+
+#define VULKAN_HPP_NO_NODISCARD_WARNINGS // TODO: temporarily disable warnings to make it compile. Need to fix all the warnings later.
+#include <vulkan/vulkan.hpp>
+
+#if EZ_ENABLED(EZ_PLATFORM_ANDROID)
+#  include <vulkan/vulkan_android.h>
+#elif EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+#  include <vulkan/vulkan_win32.h>
+#endif
 
 // Configure the DLL Import/Export Define
 #if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)

--- a/Code/Engine/RendererVulkan/RendererVulkanPCH.cpp
+++ b/Code/Engine/RendererVulkan/RendererVulkanPCH.cpp
@@ -5,18 +5,6 @@ EZ_STATICLINK_LIBRARY(RendererVulkan)
   if (bReturn)
     return;
 
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Context_Implementation_ContextVulkan);
   EZ_STATICLINK_REFERENCE(RendererVulkan_Device_Implementation_DeviceVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Device_Implementation_SwapChainVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_BufferVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_FenceVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_QueryVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_RenderTargetViewVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_ResourceViewVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_TextureVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_SharedTextureVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_UnorderedAccessViewVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Shader_Implementation_ShaderVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_Shader_Implementation_VertexDeclarationVulkan);
-  EZ_STATICLINK_REFERENCE(RendererVulkan_State_Implementation_StateVulkan);
+  EZ_STATICLINK_REFERENCE(RendererVulkan_Resources_Implementation_FallbackResourcesVulkan);
 }

--- a/Code/Engine/RendererVulkan/RendererVulkanPCH.h
+++ b/Code/Engine/RendererVulkan/RendererVulkanPCH.h
@@ -2,25 +2,11 @@
 
 #include <Foundation/Basics.h>
 #include <Foundation/Logging/Log.h>
-
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-#  include <Foundation/Basics/Platform/Win/IncludeWindows.h>
-#endif
+#include <RendererVulkan/RendererVulkanDLL.h>
+#include <vulkan/vulkan_format_traits.hpp>
 
 
-#define VULKAN_HPP_NO_NODISCARD_WARNINGS // TODO: temporarily disable warnings to make it compile. Need to fix all the warnings later.
-
-#if EZ_ENABLED(EZ_PLATFORM_LINUX)
-#  define VK_USE_PLATFORM_XCB_KHR
-#endif
-
-#include <vulkan/vulkan.hpp>
-// Some of the functionality we need has moved from vulkan.hpp to vulkan_format_traits.hpp in later versions of the vulkan SDK.
-#if __has_include(<vulkan/vulkan_format_traits.hpp>)
-#  include <vulkan/vulkan_format_traits.hpp>
-#endif
-
-#if VK_HEADER_VERSION < 211
+#if VK_HEADER_VERSION < 268
 #  error "Your vulkan headers are to old. The headers of SDK 1.3.211 or newer are required"
 #endif
 

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -206,5 +206,3 @@ vk::DeviceSize ezGALBufferVulkan::GetAlignment(const ezGALDeviceVulkan* pDevice,
 
   return alignment;
 }
-
-

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -207,4 +207,4 @@ vk::DeviceSize ezGALBufferVulkan::GetAlignment(const ezGALDeviceVulkan* pDevice,
   return alignment;
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_BufferVulkan);
+

--- a/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
@@ -92,7 +92,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
       }
 
       // Swift shader can only do 4x MSAA. Add a check anyways.
-      const bool bSupported = s_pDevice->GetCapabilities().m_FormatSupport[ezGALResourceFormat::BGRAUByteNormalizedsRGB].AreAllSet(ezGALResourceFormatSupport::Sample | ezGALResourceFormatSupport::MSAA4x);
+      const bool bSupported = s_pDevice->GetCapabilities().m_FormatSupport[ezGALResourceFormat::BGRAUByteNormalizedsRGB].AreAllSet(ezGALResourceFormatSupport::Texture | ezGALResourceFormatSupport::MSAA4x);
 
       if (bSupported)
       {
@@ -262,3 +262,7 @@ bool ezFallbackResourcesVulkan::KeyHash::Equal(const Key& a, const Key& b)
 {
   return a.m_ResourceType == b.m_ResourceType && a.m_ezType == b.m_ezType && a.m_bDepth == b.m_bDepth;
 }
+
+
+EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_FallbackResourcesVulkan);
+

--- a/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
@@ -265,4 +265,3 @@ bool ezFallbackResourcesVulkan::KeyHash::Equal(const Key& a, const Key& b)
 
 
 EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_FallbackResourcesVulkan);
-

--- a/Code/Engine/RendererVulkan/Resources/Implementation/QueryVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/QueryVulkan.cpp
@@ -38,4 +38,4 @@ void ezGALQueryVulkan::SetDebugNamePlatform(const char* szName) const
   // TODO
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_QueryVulkan);
+

--- a/Code/Engine/RendererVulkan/Resources/Implementation/QueryVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/QueryVulkan.cpp
@@ -37,5 +37,3 @@ void ezGALQueryVulkan::SetDebugNamePlatform(const char* szName) const
 
   // TODO
 }
-
-

--- a/Code/Engine/RendererVulkan/Resources/Implementation/RenderTargetViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/RenderTargetViewVulkan.cpp
@@ -99,5 +99,3 @@ ezResult ezGALRenderTargetViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
 }
 
 
-
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_RenderTargetViewVulkan);

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
@@ -135,5 +135,3 @@ ezResult ezGALResourceViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
 }
 
 
-
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_ResourceViewVulkan);

--- a/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
@@ -385,4 +385,4 @@ void ezGALSharedTextureVulkan::SignalSemaphoreGPU(ezUInt64 uiValue) const
   m_pDevice->GetCurrentPipelineBarrier().EnsureImageLayout(this, GetPreferredLayout(), GetUsedByPipelineStage(), GetAccessMask());
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_SharedTextureVulkan);
+

--- a/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
@@ -384,5 +384,3 @@ void ezGALSharedTextureVulkan::SignalSemaphoreGPU(ezUInt64 uiValue) const
   // TODO, transition texture into GENERAL layout
   m_pDevice->GetCurrentPipelineBarrier().EnsureImageLayout(this, GetPreferredLayout(), GetUsedByPipelineStage(), GetAccessMask());
 }
-
-

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
@@ -363,5 +363,3 @@ void ezGALTextureVulkan::SetDebugNamePlatform(const char* szName) const
 }
 
 
-
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_TextureVulkan);

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
@@ -119,4 +119,4 @@ ezResult ezGALUnorderedAccessViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Resources_Implementation_UnorderedAccessViewVulkan);
+

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
@@ -118,5 +118,3 @@ ezResult ezGALUnorderedAccessViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
   pVulkanDevice->DeleteLater(m_bufferView);
   return EZ_SUCCESS;
 }
-
-

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -161,4 +161,4 @@ ezResult ezGALShaderVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Shader_Implementation_ShaderVulkan);
+

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -160,5 +160,3 @@ ezResult ezGALShaderVulkan::DeInitPlatform(ezGALDevice* pDevice)
   }
   return EZ_SUCCESS;
 }
-
-

--- a/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
@@ -95,5 +95,3 @@ ezResult ezGALVertexDeclarationVulkan::DeInitPlatform(ezGALDevice* pDevice)
 }
 
 
-
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Shader_Implementation_VertexDeclarationVulkan);

--- a/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
@@ -262,5 +262,3 @@ ezResult ezGALSamplerStateVulkan::DeInitPlatform(ezGALDevice* pDevice)
   pVulkanDevice->DeleteLater(m_resourceImageInfo.sampler);
   return EZ_SUCCESS;
 }
-
-

--- a/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
@@ -263,4 +263,4 @@ ezResult ezGALSamplerStateVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_State_Implementation_StateVulkan);
+

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
@@ -301,6 +301,10 @@ EZ_ALWAYS_INLINE vk::DescriptorType ezConversionUtilsVulkan::GetDescriptorType(e
   {
     case ezGALShaderResourceType::Unknown:
       EZ_REPORT_FAILURE("Unknown descriptor type");
+      break;
+    case ezGALShaderResourceType::PushConstants:
+      EZ_REPORT_FAILURE("Push constants should never appear as shader resources");
+      break;
     case ezGALShaderResourceType::Sampler:
       return vk::DescriptorType::eSampler;
     case ezGALShaderResourceType::ConstantBuffer:

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -493,6 +493,8 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
         {
           write.pImageInfo = &sourceInfo;
         }
+        default:
+          break;
       }
     }
     ezDescriptorSetPoolVulkan::UpdateDescriptorSet(descriptorSet, descriptorWrites);

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -487,6 +487,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
           // #TODO_VULKAN constant buffer for offset in the shader to allow region copy
           // const ezGALBufferVulkan* pBuffer = m_pBoundConstantBuffers[mapping.m_uiSource];
           // write.pBufferInfo = &pBuffer->GetBufferInfo();
+          EZ_REPORT_FAILURE("ConstantBuffer resource type not supported in copy shader.");
         }
         break;
         case ezGALShaderResourceType::Texture:
@@ -494,6 +495,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
           write.pImageInfo = &sourceInfo;
         }
         default:
+          EZ_REPORT_FAILURE("Resource type '{}' not supported in copy shader.", mapping.m_ResourceType);
           break;
       }
     }

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -494,6 +494,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
         {
           write.pImageInfo = &sourceInfo;
         }
+        break;
         default:
           EZ_REPORT_FAILURE("Resource type '{}' not supported in copy shader.", mapping.m_ResourceType);
           break;

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -220,7 +220,7 @@ void ezShaderExplorerApp::AfterCoreSystemsStartup()
 
   ezFileSystem::AddDataDirectory("", "", ":", ezFileSystem::AllowWrites).IgnoreResult();
   ezFileSystem::AddDataDirectory(">appdir/", "AppBin", "bin", ezFileSystem::AllowWrites).IgnoreResult();                                    // writing to the binary directory
-  ezFileSystem::AddDataDirectory(">sdk/Output/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites).AssertSuccess();                      // for shader files
+  ezFileSystem::AddDataDirectory(">sdk/Output/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites).AssertSuccess();                  // for shader files
   ezFileSystem::CreateDirectoryStructure(">user/ezEngine Project/ShaderExplorer").AssertSuccess();
   ezFileSystem::AddDataDirectory(">user/ezEngine Project/ShaderExplorer", "AppData", "appdata", ezFileSystem::AllowWrites).AssertSuccess(); // app user data
 

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -219,9 +219,10 @@ void ezShaderExplorerApp::AfterCoreSystemsStartup()
   EZ_VERIFY(m_pDirectoryWatcher->OpenDirectory(sProjectDirResolved, ezDirectoryWatcher::Watch::Writes | ezDirectoryWatcher::Watch::Subdirectories).Succeeded(), "Failed to watch project directory");
 
   ezFileSystem::AddDataDirectory("", "", ":", ezFileSystem::AllowWrites).IgnoreResult();
-  ezFileSystem::AddDataDirectory(">appdir/", "AppBin", "bin", ezFileSystem::AllowWrites).IgnoreResult();                                   // writing to the binary directory
-  ezFileSystem::AddDataDirectory(">appdir/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites).IgnoreResult();                      // for shader files
-  ezFileSystem::AddDataDirectory(">user/ezEngine Project/ShaderExplorer", "AppData", "appdata", ezFileSystem::AllowWrites).IgnoreResult(); // app user data
+  ezFileSystem::AddDataDirectory(">appdir/", "AppBin", "bin", ezFileSystem::AllowWrites).IgnoreResult();                                    // writing to the binary directory
+  ezFileSystem::AddDataDirectory(">sdk/Output/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites).AssertSuccess();                      // for shader files
+  ezFileSystem::CreateDirectoryStructure(">user/ezEngine Project/ShaderExplorer").AssertSuccess();
+  ezFileSystem::AddDataDirectory(">user/ezEngine Project/ShaderExplorer", "AppData", "appdata", ezFileSystem::AllowWrites).AssertSuccess(); // app user data
 
   ezFileSystem::AddDataDirectory(">sdk/Data/Base", "Base", "base").IgnoreResult();
   ezFileSystem::AddDataDirectory(">project/", "Project", "project", ezFileSystem::AllowWrites).IgnoreResult();

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -95,7 +95,7 @@ public:
 
     ezFileSystem::AddDataDirectory("", "", ":", ezFileSystem::AllowWrites).IgnoreResult();
     ezFileSystem::AddDataDirectory(">appdir/", "AppBin", "bin", ezFileSystem::AllowWrites).IgnoreResult();              // writing to the binary directory
-    ezFileSystem::AddDataDirectory(">appdir/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites).IgnoreResult(); // for shader files
+    ezFileSystem::AddDataDirectory(">sdk/Output/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites).IgnoreResult(); // for shader files
     ezFileSystem::AddDataDirectory(">user/ezEngine Project/TextureSample", "AppData", "appdata",
       ezFileSystem::AllowWrites)
       .IgnoreResult();                                                                                                  // app user data

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
@@ -51,18 +51,19 @@ private:
   ezMeshBufferResourceHandle m_hSphereMesh;
 
   // Shared Texture Test
+#if EZ_ENABLED(EZ_SUPPORTS_PROCESSES)
   ezUniquePtr<ezProcess> m_pOffscreenProcess;
   ezUniquePtr<ezIpcChannel> m_pChannel;
   ezUniquePtr<ezIpcProcessMessageProtocol> m_pProtocol;
-
   ezGALTextureCreationDescription m_SharedTextureDesc;
 
   static constexpr ezUInt32 s_SharedTextureCount = 3;
+
   bool m_bExiting = false;
   ezGALTextureHandle m_hSharedTextures[s_SharedTextureCount];
   ezDeque<ezOffscreenTest_SharedTexture> m_SharedTextureQueue;
   ezUInt32 m_uiReceivedTextures = 0;
   float m_fOldProfilingThreshold = 0.0f;
-
   ezShaderUtils::ezBuiltinShader m_CopyShader;
+#endif
 };

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -29,7 +29,7 @@ void ezRendererTestReadback::SetupSubTests()
 
       default:
       {
-        if (caps.m_FormatSupport[i].AreAllSet(ezGALResourceFormatSupport::Sample | ezGALResourceFormatSupport::Render))
+        if (caps.m_FormatSupport[i].AreAllSet(ezGALResourceFormatSupport::Texture | ezGALResourceFormatSupport::RenderTarget))
         {
           m_TestableFormats.PushBack((ezGALResourceFormat::Enum)i);
         }

--- a/Code/UnitTests/RendererTest/Basics/Textures.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Textures.cpp
@@ -16,84 +16,107 @@ ezTestAppRun ezRendererTestBasics::SubtestTextures2D()
   const ezInt32 iNumFrames = 14;
 
   m_hShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Textured.ezShader");
+  ezEnum<ezGALResourceFormat> textureFormat;
+  ezStringView sTextureResourceId;
 
   if (m_iFrame == 0)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_ABGR_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_ABGR_Mips_D.dds";
   }
 
   if (m_iFrame == 1)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_ABGR_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_ABGR_NoMips_D.dds";
   }
 
   if (m_iFrame == 2)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_ARGB_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_ARGB_Mips_D.dds";
   }
 
   if (m_iFrame == 3)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_ARGB_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_ARGB_NoMips_D.dds";
   }
 
   if (m_iFrame == 4)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_DXT1_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BC1sRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_DXT1_Mips_D.dds";
   }
 
   if (m_iFrame == 5)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_DXT1_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BC1sRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_DXT1_NoMips_D.dds";
   }
 
   if (m_iFrame == 6)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_DXT3_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BC2sRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_DXT3_Mips_D.dds";
   }
 
   if (m_iFrame == 7)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_DXT3_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BC2sRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_DXT3_NoMips_D.dds";
   }
 
   if (m_iFrame == 8)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_DXT5_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BC3sRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_DXT5_Mips_D.dds";
   }
 
   if (m_iFrame == 9)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_DXT5_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BC3sRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_DXT5_NoMips_D.dds";
   }
 
   if (m_iFrame == 10)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_RGB_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_RGB_Mips_D.dds";
   }
 
   if (m_iFrame == 11)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_RGB_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/ezLogo_RGB_NoMips_D.dds";
   }
 
   if (m_iFrame == 12)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_R5G6B5_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::B5G6R5UNormalized;
+    sTextureResourceId = "SharedData/Textures/ezLogo_R5G6B5_NoMips_D.dds";
   }
 
   if (m_iFrame == 13)
   {
-    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>("SharedData/Textures/ezLogo_R5G6B5_MipsD.dds");
+    textureFormat = ezGALResourceFormat::B5G6R5UNormalized;
+    sTextureResourceId = "SharedData/Textures/ezLogo_R5G6B5_MipsD.dds";
   }
 
-  ezRenderContext::GetDefaultInstance()->BindTexture2D("DiffuseTexture", m_hTexture2D);
-
+  const bool bSupported = m_pDevice->GetCapabilities().m_FormatSupport[textureFormat].AreAllSet(ezGALResourceFormatSupport::Texture);
+  if (bSupported)
+  {
+    m_hTexture2D = ezResourceManager::LoadResource<ezTexture2DResource>(sTextureResourceId);
+    ezRenderContext::GetDefaultInstance()->BindTexture2D("DiffuseTexture", m_hTexture2D);
+  }
   BeginRendering(ezColor::Black);
 
-  RenderObjects(ezShaderBindFlags::Default);
+  if (bSupported)
+  {
+    RenderObjects(ezShaderBindFlags::Default);
 
-  EZ_TEST_IMAGE(m_iFrame, 100);
+    EZ_TEST_IMAGE(m_iFrame, 100);
+  }
   EndRendering();
   EndPass();
   EndFrame();

--- a/Code/UnitTests/RendererTest/CMakeLists.txt
+++ b/Code/UnitTests/RendererTest/CMakeLists.txt
@@ -13,6 +13,23 @@ target_link_libraries(${PROJECT_NAME}
   RendererCore
 )
 
+if(EZ_CMAKE_PLATFORM_ANDROID)
+    #TODO: Add actual packaging code. This is done in PRE_BUILD so that it happens before the
+    #apk gen steps that happen in POST_BUILD and which are already done via ez_create_target.
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Output/ShaderCache/VULKAN/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/ShaderCache/VULKAN/)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Data/UnitTests/RendererTest/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/UnitTests/RendererTest/)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Data/UnitTests/SharedData/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/UnitTests/SharedData/)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Data/Base/Shaders/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/Base/Shaders/)
+endif()
+
 ez_add_renderers(${PROJECT_NAME})
 
 ez_ci_add_test(${PROJECT_NAME} NEEDS_HW_ACCESS)

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -70,7 +70,7 @@ ezResult ezGraphicsTest::CreateRenderer(ezGALDevice*& out_pDevice)
     ezStringBuilder sReadDir(">sdk/", ezTestFramework::GetInstance()->GetRelTestDataPath());
     sReadDir.PathParentDirectory();
 
-    EZ_SUCCEED_OR_RETURN(ezFileSystem::AddDataDirectory(">appdir/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites)); // for shader files
+    EZ_SUCCEED_OR_RETURN(ezFileSystem::AddDataDirectory(">sdk/Output/", "ShaderCache", "shadercache", ezFileSystem::AllowWrites)); // for shader files
 
     EZ_SUCCEED_OR_RETURN(ezFileSystem::AddDataDirectory(sBaseDir, "Base"));
 
@@ -94,7 +94,8 @@ ezResult ezGraphicsTest::CreateRenderer(ezGALDevice*& out_pDevice)
   ezGALDeviceFactory::GetShaderModelAndCompiler(sRendererName, szShaderModel, szShaderCompiler);
 
   ezShaderManager::Configure(szShaderModel, true);
-  EZ_VERIFY(ezPlugin::LoadPlugin(szShaderCompiler).Succeeded(), "Shader compiler '{}' plugin not found", szShaderCompiler);
+  if (ezPlugin::LoadPlugin(szShaderCompiler).Failed())
+    ezLog::Warning("Shader compiler '{}' plugin not found", szShaderCompiler);
 
   // Create a device
   {

--- a/Data/Base/Shaders/Common/LightingSimplified.h
+++ b/Data/Base/Shaders/Common/LightingSimplified.h
@@ -19,9 +19,24 @@ float GetFogAmount(float3 worldPosition)
   return 1.0f;
 }
 
+float3 ApplyFog(float3 color, float3 worldPosition, float fogAmount)
+{
+  return color;
+}
+
+float3 ApplyFog(float3 color, float3 worldPosition)
+{
+  return color;
+}
+
 float DepthFade(float3 screenPosition, float fadeDistance)
 {
   return 1.0f;
+}
+
+float3 SampleSceneColor(float2 screenPosition)
+{
+  return float3(1.0, 1.0, 1.0);
 }
 
 AccumulatedLight CalculateLightingSimplified(ezMaterialData matData)

--- a/Data/Base/Shaders/Materials/HitBoxVisualization.ezShader
+++ b/Data/Base/Shaders/Materials/HitBoxVisualization.ezShader
@@ -98,31 +98,31 @@ void main( triangle GS_IN input[3], inout TriangleStream<GS_OUT> outputStream )
 Texture2D BaseTexture;
 SamplerState BaseTexture_AutoSampler;
 
-float3 GetNormal(PS_IN Input)
+float3 GetNormal()
 {
   #if TOPOLOGY == TOPOLOGY_TRIANGLES
-    return Input.Normal;
+    return G.Input.Normal;
   #else
     return float3(0.0f, 0.0f, 1.0f);
   #endif
 }
 
-float3 GetDiffuseColor(PS_IN Input)
+float3 GetDiffuseColor()
 {
   return float3(0.1, 0.7, 0.1);
 }
 
-float3 GetSpecularColor(PS_IN Input)
+float3 GetSpecularColor()
 {
   return 0.04f;
 }
 
-float GetRoughness(PS_IN Input)
+float GetRoughness()
 {
   return 1.0f;
 }
 
-float GetOpacity(PS_IN Input)
+float GetOpacity()
 {
   return 1.0f;
 }

--- a/Data/Base/Shaders/Materials/LensFlareMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/LensFlareMaterial.ezShader
@@ -177,6 +177,7 @@ void CopyCustomInterpolators(GS_OUT output, VS_OUT input)
 
 [PIXELSHADER]
 
+#include <Shaders/Common/GlobalConstants.h>
 #include <Shaders/Materials/MaterialInterpolator.h>
 #include <Shaders/Materials/LensFlareData.h>
 

--- a/Data/Base/Shaders/Materials/MaterialPixelShaderSimplified.h
+++ b/Data/Base/Shaders/Materials/MaterialPixelShaderSimplified.h
@@ -83,7 +83,7 @@ PS_OUT main(PS_IN Input)
 
 #else
   Output.Color = float4(litColor, matData.opacity);
-  #  error "RENDER_PASS uses undefined value."
+#  error "RENDER_PASS uses undefined value."
 #endif
 
   return Output;

--- a/Data/Base/Shaders/Materials/SkeletonVisualization.ezShader
+++ b/Data/Base/Shaders/Materials/SkeletonVisualization.ezShader
@@ -95,41 +95,40 @@ void main( triangle GS_IN input[3], inout TriangleStream<GS_OUT> outputStream )
 Texture2D BaseTexture;
 SamplerState BaseTexture_AutoSampler;
 
-float edgeFactor(PS_IN Input)
+float edgeFactor()
 {
-  float3 d = fwidth(Input.Barycentric);
-  float3 a3 = smoothstep(float3(0.0, 0.0, 0.0), d, Input.Barycentric);
+  float3 d = fwidth(G.Input.Barycentric);
+  float3 a3 = smoothstep(float3(0.0, 0.0, 0.0), d, G.Input.Barycentric);
   return min(min(a3.x, a3.y), a3.z);
 }
 
-float3 GetNormal(PS_IN Input)
+float3 GetNormal()
 {
   #if TOPOLOGY == TOPOLOGY_TRIANGLES
-    return Input.Normal;
+    return G.Input.Normal;
   #else
     return float3(0.0f, 0.0f, 1.0f);
   #endif
 }
 
-float3 GetDiffuseColor(PS_IN Input)
+float3 GetDiffuseColor()
 {
-  float3 color = lerp(0.2, 0.5, edgeFactor(Input));
-
-  float light = clamp(dot(Input.Normal.xyz, normalize(float3(1, 0.5, 2))), 0.2, 0.9);
+  float3 color = lerp(0.2, 0.5, edgeFactor());
+  float light = clamp(dot(GetNormal(), normalize(float3(1, 0.5, 2))), 0.2, 0.9);
   return color * light;
 }
 
-float3 GetSpecularColor(PS_IN Input)
+float3 GetSpecularColor()
 {
   return 0.04f;
 }
 
-float GetRoughness(PS_IN Input)
+float GetRoughness()
 {
   return 1.0f;
 }
 
-float GetOpacity(PS_IN Input)
+float GetOpacity()
 {
   return 1.0f;
 }

--- a/Data/Base/Shaders/Pipeline/Blur.ezShader
+++ b/Data/Base/Shaders/Pipeline/Blur.ezShader
@@ -35,11 +35,11 @@ Texture2DArray Input;
 float4 main(PS_IN input) : SV_Target
 {
   #if CAMERA_MODE == CAMERA_MODE_STEREO
-    s_ActiveCameraEyeIndex = Input.RenderTargetArrayIndex;
+    s_ActiveCameraEyeIndex = input.RenderTargetArrayIndex;
   #endif
 
-  float width, height, levels;
-  Input.GetDimensions(0, width, height, levels);
+  uint width, height, elements, levels;
+  Input.GetDimensions(0, width, height, elements, levels);
   float2 vPixelSize = float2(1.0f / width, 1.0f / height);
 
   // TODO I know this is stupid, give me a break ;-)

--- a/Data/Base/Shaders/Pipeline/SelectionHighlight.ezShader
+++ b/Data/Base/Shaders/Pipeline/SelectionHighlight.ezShader
@@ -37,7 +37,13 @@ struct PS_IN
 {
   float4 Position : SV_Position;
   float2 TexCoord0 : TEXCOORD0;
-
+  #if CAMERA_MODE == CAMERA_MODE_STEREO
+  #  if defined(VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX)
+    uint RenderTargetArrayIndex : SV_RenderTargetArrayIndex;
+  #  else
+    uint RenderTargetArrayIndex : RENDERTARGETARRAYINDEX;
+  #  endif
+  #endif
   #if MSAA
     uint SampleIndex : SV_SampleIndex;
   #endif

--- a/Data/Base/Shaders/Pipeline/SeparatedBilateralBlur.ezShader
+++ b/Data/Base/Shaders/Pipeline/SeparatedBilateralBlur.ezShader
@@ -57,10 +57,10 @@ float4 BlurFunction(int2 texelCoord, float gaussianExp, float centerDepth, inout
 float4 main(PS_IN input) : SV_Target
 {
 #if CAMERA_MODE == CAMERA_MODE_STEREO
-  s_ActiveCameraEyeIndex = Input.RenderTargetArrayIndex;
+  s_ActiveCameraEyeIndex = input.RenderTargetArrayIndex;
 #endif
-  float width, height, levels;
-  BlurSource.GetDimensions(0, width, height, levels);
+  uint width, height, elements, levels;
+  BlurSource.GetDimensions(0, width, height, elements, levels);
 
   int2 texelCoord = int2(input.TexCoord0 * float2(width, height));
 


### PR DESCRIPTION
# Shaders
* ⚠️The `ShaderCache` folder has moved to `>sdk/Output/ShaderCache`. This is because shaders are always the same, regardless of platform, debug/release etc. So it does not make sense to have separate shader folders for all platform flavours if the all use the same Vulkan shaders at the end. This also makes it easier to cross-compile as Android builds can't build their own shaders.
* Fixed all compile errors so that `ShaderCompiler.exe -renderer DX11 -platform DX11_SM50 -project C:\Code\ezEngine\Data\Base -shader Shaders` runs through without errors, same for `-renderer Vulkan -platform VULKAN`. Fixes #411 and fixes #236.

# Renderer / Core
* Device Capabilities: `ezGALResourceFormatSupport` cleaned up a bit and added `TextureRW` as a flag.
* Added Android window support. Android automatically creates a window for you and is very accomadating regarding the size of the swapchain: anything between 1x1 and 4kx4k is allowed on my phone at least. Thus, we enable all window modes and pretend we can handle both windowed and fullscreen windows as we have no choice in that matter anyways and always get the same window.

# Vulkan
* An Android, we require Vulkan 1.0 and `VK_KHR_maintenance1`, on all other platforms Vulkan 1.1.
* Transfer queue is now optional.
* Removed unused fence from swap chain code and added `vk::AndroidSurfaceCreateInfoKHR` support.
* Various compile fixes for pedantic Android clang.
* Static linker tools now runs over Vulkan plugin code.
* Moved required headers into `RendererVulkanDLL.h` to allow other libraries to include stuff without throwing hundreds of errors.

# Renderer Tests
* AdvancedFeatures test now checks for a proper format that can be used for the compute test.
* Added `ifdef` blocks to remove shared texture code on platforms that don't support processes.
* Textures test now checks each texture if its format is supported before testing.
* A shader compiler plugin is now optional as we won't have one on Android.
* All tests pass now on Android. However, `ShaderCompiler.exe` has to be run on the `Data\Base` and the `Assets/Data/UnitTests` before building.