### PR TITLE
Android Basic Input Support

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -601,11 +601,11 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
   ezFileSystem::CreateDirectoryStructure(sUserData).AssertSuccess();
   ezFileSystem::CreateDirectoryStructure(">sdk/Output/").AssertSuccess();
 
-  ezFileSystem::AddDataDirectory("", "EngineProcess", ":", ezFileSystem::AllowWrites).AssertSuccess();                   // for absolute paths
-  ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "bin", ezFileSystem::ReadOnly).AssertSuccess();            // writing to the binary directory
+  ezFileSystem::AddDataDirectory("", "EngineProcess", ":", ezFileSystem::AllowWrites).AssertSuccess();                       // for absolute paths
+  ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "bin", ezFileSystem::ReadOnly).AssertSuccess();                // writing to the binary directory
   ezFileSystem::AddDataDirectory(">sdk/Output/", "EngineProcess", "shadercache", ezFileSystem::AllowWrites).AssertSuccess(); // for shader files
-  ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").AssertSuccess();                             // app specific data
-  ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezFileSystem::AllowWrites).AssertSuccess();      // for writing app user data
+  ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").AssertSuccess();                                 // app specific data
+  ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezFileSystem::AllowWrites).AssertSuccess();          // for writing app user data
 
   m_CustomFileSystemConfig.Apply();
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -597,14 +597,15 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
   ezStringBuilder sUserData = ">user/ezEngine Project/EditorEngineProcess";
 
   // make sure these directories exist
-  ezFileSystem::CreateDirectoryStructure(sAppDir).IgnoreResult();
-  ezFileSystem::CreateDirectoryStructure(sUserData).IgnoreResult();
+  ezFileSystem::CreateDirectoryStructure(sAppDir).AssertSuccess();
+  ezFileSystem::CreateDirectoryStructure(sUserData).AssertSuccess();
+  ezFileSystem::CreateDirectoryStructure(">sdk/Output/").AssertSuccess();
 
-  ezFileSystem::AddDataDirectory("", "EngineProcess", ":", ezFileSystem::AllowWrites).IgnoreResult();                   // for absolute paths
-  ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "bin", ezFileSystem::ReadOnly).IgnoreResult();            // writing to the binary directory
-  ezFileSystem::AddDataDirectory(">sdk/Output/", "EngineProcess", "shadercache", ezFileSystem::AllowWrites).IgnoreResult(); // for shader files
-  ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").IgnoreResult();                             // app specific data
-  ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezFileSystem::AllowWrites).IgnoreResult();      // for writing app user data
+  ezFileSystem::AddDataDirectory("", "EngineProcess", ":", ezFileSystem::AllowWrites).AssertSuccess();                   // for absolute paths
+  ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "bin", ezFileSystem::ReadOnly).AssertSuccess();            // writing to the binary directory
+  ezFileSystem::AddDataDirectory(">sdk/Output/", "EngineProcess", "shadercache", ezFileSystem::AllowWrites).AssertSuccess(); // for shader files
+  ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").AssertSuccess();                             // app specific data
+  ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezFileSystem::AllowWrites).AssertSuccess();      // for writing app user data
 
   m_CustomFileSystemConfig.Apply();
 

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
@@ -120,7 +120,7 @@ void ezGameApplicationBase::Init_FileSystem_ConfigureDataDirs()
 
   const ezStringBuilder sUserDataPath(">user/", GetApplicationName());
 
-  ezFileSystem::CreateDirectoryStructure(sUserDataPath).IgnoreResult();
+  ezFileSystem::CreateDirectoryStructure(sUserDataPath).AssertSuccess();
 
   ezString writableBinRoot = ">appdir/";
   ezString shaderCacheRoot = ">sdk/Output/";
@@ -131,18 +131,19 @@ void ezGameApplicationBase::Init_FileSystem_ConfigureDataDirs()
   writableBinRoot = sUserDataPath;
   shaderCacheRoot = sUserDataPath;
 #endif
+  ezFileSystem::CreateDirectoryStructure(shaderCacheRoot).AssertSuccess();
 
   // for absolute paths, read-only
-  ezFileSystem::AddDataDirectory("", "GameApplicationBase", ":", ezFileSystem::ReadOnly).IgnoreResult();
+  ezFileSystem::AddDataDirectory("", "GameApplicationBase", ":", ezFileSystem::ReadOnly).AssertSuccess();
 
   // ":bin/" : writing to the binary directory
-  ezFileSystem::AddDataDirectory(writableBinRoot, "GameApplicationBase", "bin", ezFileSystem::AllowWrites).IgnoreResult();
+  ezFileSystem::AddDataDirectory(writableBinRoot, "GameApplicationBase", "bin", ezFileSystem::AllowWrites).AssertSuccess();
 
   // ":shadercache/" for reading and writing shader files
-  ezFileSystem::AddDataDirectory(shaderCacheRoot, "GameApplicationBase", "shadercache", ezFileSystem::AllowWrites).IgnoreResult();
+  ezFileSystem::AddDataDirectory(shaderCacheRoot, "GameApplicationBase", "shadercache", ezFileSystem::AllowWrites).AssertSuccess();
 
   // ":appdata/" for reading and writing app user data
-  ezFileSystem::AddDataDirectory(sUserDataPath, "GameApplicationBase", "appdata", ezFileSystem::AllowWrites).IgnoreResult();
+  ezFileSystem::AddDataDirectory(sUserDataPath, "GameApplicationBase", "appdata", ezFileSystem::AllowWrites).AssertSuccess();
 
   // ":base/" for reading the core engine files
   ezFileSystem::AddDataDirectory(GetBaseDataDirectoryPath(), "GameApplicationBase", "base", ezFileSystem::DataDirUsage::ReadOnly).IgnoreResult();

--- a/Code/Engine/Core/Input/Implementation/InputManager.cpp
+++ b/Code/Engine/Core/Input/Implementation/InputManager.cpp
@@ -155,8 +155,9 @@ ezKeyState::Enum ezInputManager::GetInputSlotState(ezStringView sInputSlot, floa
   if (it.IsValid())
   {
     if (pValue)
-      *pValue = it.Value().m_fValue;
-
+    {
+      *pValue = s_bInputSlotResetRequired ? it.Value().m_fValue : it.Value().m_fValueOld;
+    }
     return it.Value().m_State;
   }
 
@@ -208,6 +209,7 @@ void ezInputManager::ResetInputSlotValues()
   // this is crucial for accumulating the new values and for resetting the input state later
   for (ezInputSlotsMap::Iterator it = GetInternals().s_InputSlots.GetIterator(); it.IsValid(); it.Next())
   {
+    it.Value().m_fValueOld = it.Value().m_fValue;
     it.Value().m_fValue = 0.0f;
   }
 }

--- a/Code/Engine/Core/Input/Implementation/VirtualThumbStick.cpp
+++ b/Code/Engine/Core/Input/Implementation/VirtualThumbStick.cpp
@@ -253,7 +253,7 @@ void ezVirtualThumbStick::UpdateInputSlotValues()
     vDir.y *= -1;
 
     const float fLength = ezMath::Min(vDir.GetLength(), m_fRadius) / m_fRadius;
-    vDir.Normalize();
+    vDir.NormalizeIfNotZero(ezVec2::MakeZero()).IgnoreResult();
 
     m_InputSlotValues[m_sOutputLeft] = ezMath::Max(0.0f, -vDir.x) * fLength;
     m_InputSlotValues[m_sOutputRight] = ezMath::Max(0.0f, vDir.x) * fLength;

--- a/Code/Engine/Core/Input/InputManager.h
+++ b/Code/Engine/Core/Input/InputManager.h
@@ -282,6 +282,7 @@ private:
 
     ezString m_sDisplayName;                  ///< The display name. Use this to present input slots in UIs.
     float m_fValue;                           ///< The current value.
+    float m_fValueOld = 0.0f;                 ///< The previous value. Needed so that GetInputSlotState can be called during input update phase.
     ezKeyState::Enum m_State;                 ///< The current state.
     float m_fDeadZone;                        ///< The dead zone. Unless the value exceeds this, it reports a zero value.
     ezBitflags<ezInputSlotFlags> m_SlotFlags; ///< Describes the capabilities of the slot.

--- a/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
+++ b/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
@@ -217,45 +217,45 @@ void ezStandardInputDevice::RegisterInputSlots()
   RegisterInputSlot(ezInputSlot_MousePositionY, "Mouse Position Y", ezInputSlotFlags::IsMouseAxisPosition);
 
 
-  RegisterInputSlot(ezInputSlot_TouchPoint0, "Touchpoint 1", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionX, "Touchpoint 1 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionY, "Touchpoint 1 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint0, "Touchpoint 0", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionX, "Touchpoint 0 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionY, "Touchpoint 0 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint1, "Touchpoint 2", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionX, "Touchpoint 2 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionY, "Touchpoint 2 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint1, "Touchpoint 1", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionX, "Touchpoint 1 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionY, "Touchpoint 1 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint2, "Touchpoint 3", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionX, "Touchpoint 3 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionY, "Touchpoint 3 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint2, "Touchpoint 2", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionX, "Touchpoint 2 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionY, "Touchpoint 2 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint3, "Touchpoint 4", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionX, "Touchpoint 4 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionY, "Touchpoint 4 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint3, "Touchpoint 3", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionX, "Touchpoint 3 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionY, "Touchpoint 3 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint4, "Touchpoint 5", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionX, "Touchpoint 5 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionY, "Touchpoint 5 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint4, "Touchpoint 4", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionX, "Touchpoint 4 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionY, "Touchpoint 4 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint5, "Touchpoint 6", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionX, "Touchpoint 6 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionY, "Touchpoint 6 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint5, "Touchpoint 5", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionX, "Touchpoint 5 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionY, "Touchpoint 5 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint6, "Touchpoint 7", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionX, "Touchpoint 7 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionY, "Touchpoint 7 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint6, "Touchpoint 6", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionX, "Touchpoint 6 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionY, "Touchpoint 6 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint7, "Touchpoint 8", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionX, "Touchpoint 8 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionY, "Touchpoint 8 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint7, "Touchpoint 7", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionX, "Touchpoint 7 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionY, "Touchpoint 7 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint8, "Touchpoint 9", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionX, "Touchpoint 9 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionY, "Touchpoint 9 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint8, "Touchpoint 8", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionX, "Touchpoint 8 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionY, "Touchpoint 8 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint9, "Touchpoint 10", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionX, "Touchpoint 10 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionY, "Touchpoint 10 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint9, "Touchpoint 9", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionX, "Touchpoint 9 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionY, "Touchpoint 9 Position Y", ezInputSlotFlags::IsTouchPosition);
 }
 
 void ezStandardInputDevice::ResetInputSlotValues()

--- a/Code/Engine/Core/System/Implementation/Window.cpp
+++ b/Code/Engine/Core/System/Implementation/Window.cpp
@@ -18,8 +18,8 @@
 #  include <Core/System/Implementation/uwp/InputDevice_uwp.inl>
 #  include <Core/System/Implementation/uwp/Window_uwp.inl>
 #elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
+#  include <Core/System/Implementation/android/InputDevice_android.inl>
 #  include <Core/System/Implementation/android/Window_android.inl>
-#  include <Core/System/Implementation/null/InputDevice_null.inl>
 #else
 #  include <Core/System/Implementation/null/InputDevice_null.inl>
 #  include <Core/System/Implementation/null/Window_null.inl>

--- a/Code/Engine/Core/System/Implementation/android/InputDevice_android.h
+++ b/Code/Engine/Core/System/Implementation/android/InputDevice_android.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Core/Input/DeviceTypes/MouseKeyboard.h>
+
+struct ezAndroidInputEvent;
+struct AInputEvent;
+
+/// \brief Android standard input device.
+class EZ_CORE_DLL ezStandardInputDevice : public ezInputDeviceMouseKeyboard
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezStandardInputDevice, ezInputDeviceMouseKeyboard);
+
+public:
+  ezStandardInputDevice(ezUInt32 uiWindowNumber);
+  ~ezStandardInputDevice();
+
+  virtual void SetShowMouseCursor(bool bShow) override;
+  virtual bool GetShowMouseCursor() const override;
+  virtual void SetClipMouseCursor(ezMouseCursorClipMode::Enum mode) override;
+  virtual ezMouseCursorClipMode::Enum GetClipMouseCursor() const override;
+
+private:
+  virtual void InitializeDevice() override;
+  virtual void RegisterInputSlots() override;
+  virtual void ResetInputSlotValues() override;
+
+private:
+  void AndroidInputEventHandler(ezAndroidInputEvent& event);
+  ezInt32 AndroidHandleInput(AInputEvent* pEvent);
+};

--- a/Code/Engine/Core/System/Implementation/android/InputDevice_android.h
+++ b/Code/Engine/Core/System/Implementation/android/InputDevice_android.h
@@ -26,5 +26,10 @@ private:
 
 private:
   void AndroidInputEventHandler(ezAndroidInputEvent& event);
-  ezInt32 AndroidHandleInput(AInputEvent* pEvent);
+  void AndroidAppCommandEventHandler(ezInt32 iCmd);
+  bool AndroidHandleInput(AInputEvent* pEvent);
+
+private:
+  ezInt32 m_iResolutionX = 0;
+  ezInt32 m_iResolutionY = 0;
 };

--- a/Code/Engine/Core/System/Implementation/android/InputDevice_android.inl
+++ b/Code/Engine/Core/System/Implementation/android/InputDevice_android.inl
@@ -1,0 +1,193 @@
+#include <Core/System/Implementation/android/InputDevice_android.h>
+
+#include <Core/Input/InputManager.h>
+#include <Foundation/Basics/Platform/Android/AndroidUtils.h>
+#include <android/log.h>
+#include <android_native_app_glue.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezStandardInputDevice, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+// Comment in to get verbose output on android input
+// #  define DEBUG_ANDROID_INPUT
+
+#  ifdef DEBUG_ANDROID_INPUT
+#    define DEBUG_LOG(...) ezLog::Debug(__VA_ARGS__)
+#  else
+#    define DEBUG_LOG(...)
+#  endif
+
+ezStandardInputDevice::ezStandardInputDevice(ezUInt32 uiWindowNumber)
+{
+  ezAndroidUtils::s_InputEvent.AddEventHandler(ezMakeDelegate(&ezStandardInputDevice::AndroidInputEventHandler, this));
+}
+
+ezStandardInputDevice::~ezStandardInputDevice()
+{
+  ezAndroidUtils::s_InputEvent.RemoveEventHandler(ezMakeDelegate(&ezStandardInputDevice::AndroidInputEventHandler, this));
+}
+
+void ezStandardInputDevice::SetShowMouseCursor(bool bShow) {}
+
+bool ezStandardInputDevice::GetShowMouseCursor() const
+{
+  return false;
+}
+
+void ezStandardInputDevice::SetClipMouseCursor(ezMouseCursorClipMode::Enum mode) {}
+
+ezMouseCursorClipMode::Enum ezStandardInputDevice::GetClipMouseCursor() const
+{
+  return ezMouseCursorClipMode::Default;
+}
+
+void ezStandardInputDevice::InitializeDevice()
+{
+}
+
+void ezStandardInputDevice::RegisterInputSlots()
+{
+  RegisterInputSlot(ezInputSlot_TouchPoint0, "Touchpoint 0", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionX, "Touchpoint 0 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionY, "Touchpoint 0 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint1, "Touchpoint 1", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionX, "Touchpoint 1 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionY, "Touchpoint 1 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint2, "Touchpoint 2", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionX, "Touchpoint 2 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionY, "Touchpoint 2 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint3, "Touchpoint 3", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionX, "Touchpoint 3 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionY, "Touchpoint 3 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint4, "Touchpoint 4", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionX, "Touchpoint 4 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionY, "Touchpoint 4 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint5, "Touchpoint 5", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionX, "Touchpoint 5 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionY, "Touchpoint 5 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint6, "Touchpoint 6", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionX, "Touchpoint 6 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionY, "Touchpoint 6 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint7, "Touchpoint 7", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionX, "Touchpoint 7 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionY, "Touchpoint 7 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint8, "Touchpoint 8", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionX, "Touchpoint 8 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionY, "Touchpoint 8 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_TouchPoint9, "Touchpoint 9", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionX, "Touchpoint 9 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionY, "Touchpoint 9 Position Y", ezInputSlotFlags::IsTouchPosition);
+}
+
+void ezStandardInputDevice::ResetInputSlotValues()
+{
+  for (int id = 0; id < 10; ++id)
+  {
+    // We can't reset the position inside AndroidHandleInput as we want the position to be valid when lifting a finger. Thus, we clear the position here after the update has been performed.
+    if (m_InputSlotValues[ezInputManager::GetInputSlotTouchPoint(id)] == 0)
+    {
+      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = 0;
+      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = 0;
+    }
+  }
+}
+
+void ezStandardInputDevice::AndroidInputEventHandler(ezAndroidInputEvent& event)
+{
+  event.m_iReturn = AndroidHandleInput(event.m_pEvent);
+  SUPER::UpdateInputSlotValues();
+}
+
+ezInt32 ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
+{
+  // #TODO_ANDROID Only touchscreen input is implemented right now.
+  const ezInt32 iEventType = AInputEvent_getType(pEvent);
+  const ezInt32 iEventSource = AInputEvent_getSource(pEvent);
+  const ezUInt32 uiAction = (ezUInt32)AMotionEvent_getAction(pEvent);
+  const ezInt32 iKeyCode = AKeyEvent_getKeyCode(pEvent);
+  const ezInt32 iButtonState = AMotionEvent_getButtonState(pEvent);
+  (void)iKeyCode;
+  (void)iButtonState;
+  DEBUG_LOG("Android INPUT: iEventType: {}, iEventSource: {}, uiAction: {}, iKeyCode: {}, iButtonState: {}", iEventType,
+    iEventSource, uiAction, iKeyCode, iButtonState);
+
+  ezHybridArray<ezScreenInfo, 2> screens;
+  if (ezScreen::EnumerateScreens(screens).Failed() || screens.IsEmpty())
+    return 0;
+
+  // I.e. fingers have touched the touchscreen.
+  if (iEventType == AINPUT_EVENT_TYPE_MOTION && (iEventSource & AINPUT_SOURCE_TOUCHSCREEN) != 0)
+  {
+    // Update pointer positions
+    const ezUInt64 uiPointerCount = AMotionEvent_getPointerCount(pEvent);
+    for (ezUInt32 uiPointerIndex = 0; uiPointerIndex < uiPointerCount; uiPointerIndex++)
+    {
+      const float fPixelX = AMotionEvent_getX(pEvent, uiPointerIndex);
+      const float fPixelY = AMotionEvent_getY(pEvent, uiPointerIndex);
+      const ezInt32 id = AMotionEvent_getPointerId(pEvent, uiPointerIndex);
+      if (id < 10)
+      {
+        m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = static_cast<float>(fPixelX / static_cast<float>(screens[0].m_iResolutionX));
+        m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = static_cast<float>(fPixelY / static_cast<float>(screens[0].m_iResolutionY));
+        DEBUG_LOG("Finger MOVE: {} = {} x {}", id, m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)], m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)]);
+      }
+    }
+
+    // Update pointer state
+    const ezUInt32 uiActionEvent = uiAction & AMOTION_EVENT_ACTION_MASK;
+    const ezUInt32 uiActionPointerIndex = (uiAction & AMOTION_EVENT_ACTION_POINTER_INDEX_MASK) >> AMOTION_EVENT_ACTION_POINTER_INDEX_SHIFT;
+
+    const ezInt32 id = AMotionEvent_getPointerId(pEvent, uiActionPointerIndex);
+    // We only support up to 10 touch points at the same time.
+    if (id >= 10)
+      return 0;
+
+    {
+      // Not sure if the action finger is always present in the upper loop of uiPointerCount, so we update it here for good measure.
+      const float fPixelX = AMotionEvent_getX(pEvent, uiActionPointerIndex);
+      const float fPixelY = AMotionEvent_getY(pEvent, uiActionPointerIndex);
+      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = static_cast<float>(fPixelX / static_cast<float>(screens[0].m_iResolutionX));
+      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = static_cast<float>(fPixelY / static_cast<float>(screens[0].m_iResolutionY));
+      DEBUG_LOG("Finger MOVE: {} = {} x {}", id, m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)], m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)]);
+    }
+
+    switch (uiActionEvent)
+    {
+      case AMOTION_EVENT_ACTION_DOWN:
+      case AMOTION_EVENT_ACTION_POINTER_DOWN:
+        m_InputSlotValues[ezInputManager::GetInputSlotTouchPoint(id)] = 1;
+        DEBUG_LOG("Finger DOWN: {}", id);
+        return 1;
+      case AMOTION_EVENT_ACTION_MOVE:
+        // Finger moved (we always update that at the top).
+        return 1;
+      case AMOTION_EVENT_ACTION_UP:
+      case AMOTION_EVENT_ACTION_POINTER_UP:
+      case AMOTION_EVENT_ACTION_CANCEL:
+      case AMOTION_EVENT_ACTION_OUTSIDE:
+        m_InputSlotValues[ezInputManager::GetInputSlotTouchPoint(id)] = 0;
+        DEBUG_LOG("Finger UP: {}", id);
+        return 1;
+      case AMOTION_EVENT_ACTION_SCROLL:
+      case AMOTION_EVENT_ACTION_HOVER_ENTER:
+      case AMOTION_EVENT_ACTION_HOVER_MOVE:
+      case AMOTION_EVENT_ACTION_HOVER_EXIT:
+        return 0;
+      default:
+        DEBUG_LOG("Unknown AMOTION_EVENT_ACTION: {}", uiActionEvent);
+        return 0;
+    }
+  }
+  return 0;
+}

--- a/Code/Engine/Core/System/Implementation/android/InputDevice_android.inl
+++ b/Code/Engine/Core/System/Implementation/android/InputDevice_android.inl
@@ -13,19 +13,21 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // Comment in to get verbose output on android input
 // #  define DEBUG_ANDROID_INPUT
 
-#  ifdef DEBUG_ANDROID_INPUT
-#    define DEBUG_LOG(...) ezLog::Debug(__VA_ARGS__)
-#  else
-#    define DEBUG_LOG(...)
-#  endif
+#ifdef DEBUG_ANDROID_INPUT
+#  define DEBUG_LOG(...) ezLog::Debug(__VA_ARGS__)
+#else
+#  define DEBUG_LOG(...)
+#endif
 
 ezStandardInputDevice::ezStandardInputDevice(ezUInt32 uiWindowNumber)
 {
   ezAndroidUtils::s_InputEvent.AddEventHandler(ezMakeDelegate(&ezStandardInputDevice::AndroidInputEventHandler, this));
+  ezAndroidUtils::s_AppCommandEvent.AddEventHandler(ezMakeDelegate(&ezStandardInputDevice::AndroidAppCommandEventHandler, this));
 }
 
 ezStandardInputDevice::~ezStandardInputDevice()
 {
+  ezAndroidUtils::s_AppCommandEvent.RemoveEventHandler(ezMakeDelegate(&ezStandardInputDevice::AndroidAppCommandEventHandler, this));
   ezAndroidUtils::s_InputEvent.RemoveEventHandler(ezMakeDelegate(&ezStandardInputDevice::AndroidInputEventHandler, this));
 }
 
@@ -45,6 +47,12 @@ ezMouseCursorClipMode::Enum ezStandardInputDevice::GetClipMouseCursor() const
 
 void ezStandardInputDevice::InitializeDevice()
 {
+  ezHybridArray<ezScreenInfo, 2> screens;
+  if (ezScreen::EnumerateScreens(screens).Succeeded())
+  {
+    m_iResolutionX = screens[0].m_iResolutionX;
+    m_iResolutionY = screens[0].m_iResolutionY;
+  }
 }
 
 void ezStandardInputDevice::RegisterInputSlots()
@@ -88,10 +96,15 @@ void ezStandardInputDevice::RegisterInputSlots()
   RegisterInputSlot(ezInputSlot_TouchPoint9, "Touchpoint 9", ezInputSlotFlags::IsTouchPoint);
   RegisterInputSlot(ezInputSlot_TouchPoint9_PositionX, "Touchpoint 9 Position X", ezInputSlotFlags::IsTouchPosition);
   RegisterInputSlot(ezInputSlot_TouchPoint9_PositionY, "Touchpoint 9 Position Y", ezInputSlotFlags::IsTouchPosition);
+
+  RegisterInputSlot(ezInputSlot_MouseWheelUp, "Mousewheel Up", ezInputSlotFlags::IsMouseWheel);
+  RegisterInputSlot(ezInputSlot_MouseWheelDown, "Mousewheel Down", ezInputSlotFlags::IsMouseWheel);
 }
 
 void ezStandardInputDevice::ResetInputSlotValues()
 {
+  m_InputSlotValues[ezInputSlot_MouseWheelUp] = 0;
+  m_InputSlotValues[ezInputSlot_MouseWheelDown] = 0;
   for (int id = 0; id < 10; ++id)
   {
     // We can't reset the position inside AndroidHandleInput as we want the position to be valid when lifting a finger. Thus, we clear the position here after the update has been performed.
@@ -105,11 +118,24 @@ void ezStandardInputDevice::ResetInputSlotValues()
 
 void ezStandardInputDevice::AndroidInputEventHandler(ezAndroidInputEvent& event)
 {
-  event.m_iReturn = AndroidHandleInput(event.m_pEvent);
+  event.m_bHandled = AndroidHandleInput(event.m_pEvent);
   SUPER::UpdateInputSlotValues();
 }
 
-ezInt32 ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
+void ezStandardInputDevice::AndroidAppCommandEventHandler(ezInt32 iCmd)
+{
+  if (iCmd == APP_CMD_WINDOW_RESIZED)
+  {
+    ezHybridArray<ezScreenInfo, 2> screens;
+    if (ezScreen::EnumerateScreens(screens).Succeeded())
+    {
+      m_iResolutionX = screens[0].m_iResolutionX;
+      m_iResolutionY = screens[0].m_iResolutionY;
+    }
+  }
+}
+
+bool ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
 {
   // #TODO_ANDROID Only touchscreen input is implemented right now.
   const ezInt32 iEventType = AInputEvent_getType(pEvent);
@@ -117,14 +143,13 @@ ezInt32 ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
   const ezUInt32 uiAction = (ezUInt32)AMotionEvent_getAction(pEvent);
   const ezInt32 iKeyCode = AKeyEvent_getKeyCode(pEvent);
   const ezInt32 iButtonState = AMotionEvent_getButtonState(pEvent);
-  (void)iKeyCode;
-  (void)iButtonState;
+  EZ_IGNORE_UNUSED(iKeyCode);
+  EZ_IGNORE_UNUSED(iButtonState);
   DEBUG_LOG("Android INPUT: iEventType: {}, iEventSource: {}, uiAction: {}, iKeyCode: {}, iButtonState: {}", iEventType,
     iEventSource, uiAction, iKeyCode, iButtonState);
 
-  ezHybridArray<ezScreenInfo, 2> screens;
-  if (ezScreen::EnumerateScreens(screens).Failed() || screens.IsEmpty())
-    return 0;
+  if (m_iResolutionX == 0 || m_iResolutionY == 0)
+    return false;
 
   // I.e. fingers have touched the touchscreen.
   if (iEventType == AINPUT_EVENT_TYPE_MOTION && (iEventSource & AINPUT_SOURCE_TOUCHSCREEN) != 0)
@@ -138,8 +163,8 @@ ezInt32 ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
       const ezInt32 id = AMotionEvent_getPointerId(pEvent, uiPointerIndex);
       if (id < 10)
       {
-        m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = static_cast<float>(fPixelX / static_cast<float>(screens[0].m_iResolutionX));
-        m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = static_cast<float>(fPixelY / static_cast<float>(screens[0].m_iResolutionY));
+        m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = static_cast<float>(fPixelX / static_cast<float>(m_iResolutionX));
+        m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = static_cast<float>(fPixelY / static_cast<float>(m_iResolutionY));
         DEBUG_LOG("Finger MOVE: {} = {} x {}", id, m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)], m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)]);
       }
     }
@@ -151,14 +176,14 @@ ezInt32 ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
     const ezInt32 id = AMotionEvent_getPointerId(pEvent, uiActionPointerIndex);
     // We only support up to 10 touch points at the same time.
     if (id >= 10)
-      return 0;
+      return false;
 
     {
       // Not sure if the action finger is always present in the upper loop of uiPointerCount, so we update it here for good measure.
       const float fPixelX = AMotionEvent_getX(pEvent, uiActionPointerIndex);
       const float fPixelY = AMotionEvent_getY(pEvent, uiActionPointerIndex);
-      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = static_cast<float>(fPixelX / static_cast<float>(screens[0].m_iResolutionX));
-      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = static_cast<float>(fPixelY / static_cast<float>(screens[0].m_iResolutionY));
+      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)] = static_cast<float>(fPixelX / static_cast<float>(m_iResolutionX));
+      m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)] = static_cast<float>(fPixelY / static_cast<float>(m_iResolutionY));
       DEBUG_LOG("Finger MOVE: {} = {} x {}", id, m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionX(id)], m_InputSlotValues[ezInputManager::GetInputSlotTouchPointPositionY(id)]);
     }
 
@@ -168,26 +193,34 @@ ezInt32 ezStandardInputDevice::AndroidHandleInput(AInputEvent* pEvent)
       case AMOTION_EVENT_ACTION_POINTER_DOWN:
         m_InputSlotValues[ezInputManager::GetInputSlotTouchPoint(id)] = 1;
         DEBUG_LOG("Finger DOWN: {}", id);
-        return 1;
+        return true;
       case AMOTION_EVENT_ACTION_MOVE:
         // Finger moved (we always update that at the top).
-        return 1;
+        return true;
       case AMOTION_EVENT_ACTION_UP:
       case AMOTION_EVENT_ACTION_POINTER_UP:
       case AMOTION_EVENT_ACTION_CANCEL:
       case AMOTION_EVENT_ACTION_OUTSIDE:
         m_InputSlotValues[ezInputManager::GetInputSlotTouchPoint(id)] = 0;
         DEBUG_LOG("Finger UP: {}", id);
-        return 1;
+        return true;
       case AMOTION_EVENT_ACTION_SCROLL:
+      {
+        float fRotated = AMotionEvent_getAxisValue(pEvent, AMOTION_EVENT_AXIS_VSCROLL, 0);
+        if (fRotated > 0)
+          m_InputSlotValues[ezInputSlot_MouseWheelUp] = fRotated;
+        else
+          m_InputSlotValues[ezInputSlot_MouseWheelDown] = fRotated;
+        return true;
+      }
       case AMOTION_EVENT_ACTION_HOVER_ENTER:
       case AMOTION_EVENT_ACTION_HOVER_MOVE:
       case AMOTION_EVENT_ACTION_HOVER_EXIT:
-        return 0;
+        return false;
       default:
         DEBUG_LOG("Unknown AMOTION_EVENT_ACTION: {}", uiActionEvent);
-        return 0;
+        return false;
     }
   }
-  return 0;
+  return false;
 }

--- a/Code/Engine/Core/System/Implementation/uwp/InputDevice_uwp.inl
+++ b/Code/Engine/Core/System/Implementation/uwp/InputDevice_uwp.inl
@@ -496,45 +496,45 @@ void ezStandardInputDevice::RegisterInputSlots()
 
 
   // Not yet supported
-  RegisterInputSlot(ezInputSlot_TouchPoint0, "Touchpoint 1", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionX, "Touchpoint 1 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionY, "Touchpoint 1 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint0, "Touchpoint 0", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionX, "Touchpoint 0 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint0_PositionY, "Touchpoint 0 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint1, "Touchpoint 2", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionX, "Touchpoint 2 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionY, "Touchpoint 2 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint1, "Touchpoint 1", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionX, "Touchpoint 1 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint1_PositionY, "Touchpoint 1 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint2, "Touchpoint 3", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionX, "Touchpoint 3 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionY, "Touchpoint 3 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint2, "Touchpoint 2", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionX, "Touchpoint 2 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint2_PositionY, "Touchpoint 2 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint3, "Touchpoint 4", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionX, "Touchpoint 4 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionY, "Touchpoint 4 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint3, "Touchpoint 3", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionX, "Touchpoint 3 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint3_PositionY, "Touchpoint 3 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint4, "Touchpoint 5", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionX, "Touchpoint 5 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionY, "Touchpoint 5 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint4, "Touchpoint 4", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionX, "Touchpoint 4 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint4_PositionY, "Touchpoint 4 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint5, "Touchpoint 6", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionX, "Touchpoint 6 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionY, "Touchpoint 6 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint5, "Touchpoint 5", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionX, "Touchpoint 5 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint5_PositionY, "Touchpoint 5 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint6, "Touchpoint 7", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionX, "Touchpoint 7 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionY, "Touchpoint 7 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint6, "Touchpoint 6", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionX, "Touchpoint 6 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint6_PositionY, "Touchpoint 6 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint7, "Touchpoint 8", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionX, "Touchpoint 8 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionY, "Touchpoint 8 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint7, "Touchpoint 7", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionX, "Touchpoint 7 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint7_PositionY, "Touchpoint 7 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint8, "Touchpoint 9", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionX, "Touchpoint 9 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionY, "Touchpoint 9 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint8, "Touchpoint 8", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionX, "Touchpoint 8 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint8_PositionY, "Touchpoint 8 Position Y", ezInputSlotFlags::IsTouchPosition);
 
-  RegisterInputSlot(ezInputSlot_TouchPoint9, "Touchpoint 10", ezInputSlotFlags::IsTouchPoint);
-  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionX, "Touchpoint 10 Position X", ezInputSlotFlags::IsTouchPosition);
-  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionY, "Touchpoint 10 Position Y", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint9, "Touchpoint 9", ezInputSlotFlags::IsTouchPoint);
+  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionX, "Touchpoint 9 Position X", ezInputSlotFlags::IsTouchPosition);
+  RegisterInputSlot(ezInputSlot_TouchPoint9_PositionY, "Touchpoint 9 Position Y", ezInputSlotFlags::IsTouchPosition);
 }
 
 void ezStandardInputDevice::ResetInputSlotValues()

--- a/Code/Engine/Core/System/Window.h
+++ b/Code/Engine/Core/System/Window.h
@@ -18,6 +18,8 @@ class ezOpenDdlReaderElement;
 #  include <Core/System/Implementation/Win/InputDevice_win32.h>
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS_UWP)
 #  include <Core/System/Implementation/uwp/InputDevice_uwp.h>
+#elif EZ_ENABLED(EZ_PLATFORM_ANDROID)
+#  include <Core/System/Implementation/android/InputDevice_android.h>
 #else
 #  include <Core/System/Implementation/null/InputDevice_null.h>
 #endif

--- a/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.cpp
+++ b/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.cpp
@@ -7,6 +7,7 @@
 android_app* ezAndroidUtils::s_app;
 JavaVM* ezAndroidUtils::s_vm;
 jobject ezAndroidUtils::s_na;
+ezEvent<ezAndroidInputEvent&> ezAndroidUtils::s_InputEvent;
 
 void ezAndroidUtils::SetAndroidApp(android_app* app)
 {

--- a/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.cpp
+++ b/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.cpp
@@ -8,6 +8,7 @@ android_app* ezAndroidUtils::s_app;
 JavaVM* ezAndroidUtils::s_vm;
 jobject ezAndroidUtils::s_na;
 ezEvent<ezAndroidInputEvent&> ezAndroidUtils::s_InputEvent;
+ezEvent<ezInt32> ezAndroidUtils::s_AppCommandEvent;
 
 void ezAndroidUtils::SetAndroidApp(android_app* app)
 {

--- a/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.h
+++ b/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.h
@@ -3,6 +3,7 @@
 #if EZ_DISABLED(EZ_PLATFORM_ANDROID)
 #  error "android util header should only be included in android builds!"
 #endif
+#include <Foundation/Communication/Event.h>
 
 struct android_app;
 struct _JavaVM;
@@ -11,6 +12,15 @@ struct _JNIEnv;
 using JNIEnv = _JNIEnv;
 class _jobject;
 using jobject = _jobject*;
+struct AInputEvent;
+
+/// \brief Event fired by ezAndroidUtils::s_InputEvent.
+/// Event listeners should inspect m_pEvent and set m_iReturn to 1 if they handled the event.
+struct ezAndroidInputEvent
+{
+  AInputEvent* m_pEvent = nullptr;
+  ezInt32 m_iReturn = 0;
+};
 
 class EZ_FOUNDATION_DLL ezAndroidUtils
 {
@@ -23,6 +33,9 @@ public:
 
   static void SetAndroidNativeActivity(jobject nativeActivity);
   static jobject GetAndroidNativeActivity();
+
+public:
+  static ezEvent<ezAndroidInputEvent&> s_InputEvent;
 
 private:
   static android_app* s_app;

--- a/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.h
+++ b/Code/Engine/Foundation/Basics/Platform/Android/AndroidUtils.h
@@ -15,11 +15,11 @@ using jobject = _jobject*;
 struct AInputEvent;
 
 /// \brief Event fired by ezAndroidUtils::s_InputEvent.
-/// Event listeners should inspect m_pEvent and set m_iReturn to 1 if they handled the event.
+/// Event listeners should inspect m_pEvent and set m_bHandled to true if they handled the event.
 struct ezAndroidInputEvent
 {
   AInputEvent* m_pEvent = nullptr;
-  ezInt32 m_iReturn = 0;
+  bool m_bHandled = false;
 };
 
 class EZ_FOUNDATION_DLL ezAndroidUtils
@@ -36,6 +36,7 @@ public:
 
 public:
   static ezEvent<ezAndroidInputEvent&> s_InputEvent;
+  static ezEvent<ezInt32> s_AppCommandEvent;
 
 private:
   static android_app* s_app;

--- a/Code/Engine/Foundation/Communication/Implementation/Telemetry.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/Telemetry.cpp
@@ -466,8 +466,6 @@ void ezTelemetry::Send(TransmitMode tm, ezUInt32 uiSystemID, ezUInt32 uiMsgID, e
 void ezTelemetry::CloseConnection()
 {
 #ifdef BUILDSYSTEM_ENABLE_ENET_SUPPORT
-  s_bConnectedToServer = false;
-  s_bConnectedToClient = false;
   s_ConnectionMode = None;
   s_uiServerID = 0;
   g_pConnectionToServer = nullptr;
@@ -491,6 +489,24 @@ void ezTelemetry::CloseConnection()
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(10));
   }
 
+  {
+    // Fire disconnect event.
+    if (s_bConnectedToClient)
+    {
+      TelemetryEventData e;
+      e.m_EventType = TelemetryEventData::DisconnectedFromClient;
+      s_TelemetryEvents.Broadcast(e);
+      s_bConnectedToClient = false;
+    }
+
+    if (s_bConnectedToServer)
+    {
+      TelemetryEventData e;
+      e.m_EventType = TelemetryEventData::DisconnectedFromServer;
+      s_TelemetryEvents.Broadcast(e);
+      s_bConnectedToServer = false;
+    }
+  }
   // finally close the network connection
   if (g_pHost)
   {

--- a/Code/Engine/Foundation/Platform/Android/Application_Android.cpp
+++ b/Code/Engine/Foundation/Platform/Android/Application_Android.cpp
@@ -89,8 +89,12 @@ void ezAndroidApplication::HandleCmd(int32_t cmd)
 
 int32_t ezAndroidApplication::HandleInput(AInputEvent* pEvent)
 {
-  // #TODO:
-  return 0;
+  ezAndroidInputEvent event;
+  event.m_pEvent = pEvent;
+  event.m_iReturn = 0;
+
+  ezAndroidUtils::s_InputEvent.Broadcast(event);
+  return event.m_iReturn;
 }
 
 void ezAndroidApplication::HandleIdent(ezInt32 iIdent)

--- a/Code/Engine/Foundation/Platform/Android/Application_Android.cpp
+++ b/Code/Engine/Foundation/Platform/Android/Application_Android.cpp
@@ -85,16 +85,17 @@ void ezAndroidApplication::HandleCmd(int32_t cmd)
     default:
       break;
   }
+  ezAndroidUtils::s_AppCommandEvent.Broadcast(cmd);
 }
 
 int32_t ezAndroidApplication::HandleInput(AInputEvent* pEvent)
 {
   ezAndroidInputEvent event;
   event.m_pEvent = pEvent;
-  event.m_iReturn = 0;
+  event.m_bHandled = false;
 
   ezAndroidUtils::s_InputEvent.Broadcast(event);
-  return event.m_iReturn;
+  return event.m_bHandled ? 1 : 0;
 }
 
 void ezAndroidApplication::HandleIdent(ezInt32 iIdent)

--- a/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
@@ -364,7 +364,9 @@ void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALTextureVulkan* pTextu
 void ezPipelineBarrierVulkan::SetInitialImageState(const ezGALTextureVulkan* pTexture, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess)
 {
   auto it = m_imageState.Find(pTexture->GetImage());
-  EZ_ASSERT_DEBUG(!it.IsValid(), "Can't set initial state, texture is already tracked.");
+
+  // A Vulkan runtime is free to provide us with the very same native object if we request a resize but didn't actually change the size, in which case we ignore that we are already tacking this resource.
+  EZ_ASSERT_DEBUG(!it.IsValid() || it.Value().m_pTexture->GetDescription().m_pExisitingNativeObject != nullptr, "Can't set initial state, texture is already tracked.");
 
   ImageState state;
   state.m_pTexture = pTexture;

--- a/Code/EnginePlugins/InspectorPlugin/GlobalEvents.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/GlobalEvents.cpp
@@ -91,7 +91,12 @@ namespace GlobalEventsDetail
       case ezTelemetry::TelemetryEventData::ConnectedToClient:
         SendAllGlobalEventTelemetry();
         break;
-
+      case ezTelemetry::TelemetryEventData::DisconnectedFromClient:
+      {
+        ezGlobalEvent::EventMap tmp;
+        s_LastState.Swap(tmp);
+        break;
+      }
       default:
         break;
     }

--- a/Code/EnginePlugins/InspectorPlugin/InspectorPlugin.cpp
+++ b/Code/EnginePlugins/InspectorPlugin/InspectorPlugin.cpp
@@ -54,7 +54,7 @@ void SetAppStats();
 EZ_BEGIN_SUBSYSTEM_DECLARATION(InspectorPlugin, InspectorPluginMain)
 
   BEGIN_SUBSYSTEM_DEPENDENCIES
-    "Foundation"
+    "Foundation", "ResourceManager"
   END_SUBSYSTEM_DEPENDENCIES
 
   ON_CORESYSTEMS_STARTUP

--- a/Code/Samples/ShaderExplorer/CMakeLists.txt
+++ b/Code/Samples/ShaderExplorer/CMakeLists.txt
@@ -12,7 +12,7 @@ if(EZ_CMAKE_PLATFORM_ANDROID)
     #apk gen steps that happen in POST_BUILD and which are already done via ez_create_target.
     add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${EZ_ROOT}/Output/ShaderCache/VULKAN/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/ShaderCache/VULKAN/)
+            ${EZ_ROOT}/Output/ShaderCache/VULKAN/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Output/ShaderCache/VULKAN/)
     add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${EZ_ROOT}/Data/Samples/ShaderExplorer/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/Samples/ShaderExplorer/)

--- a/Code/Samples/ShaderExplorer/CMakeLists.txt
+++ b/Code/Samples/ShaderExplorer/CMakeLists.txt
@@ -7,6 +7,25 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
+if(EZ_CMAKE_PLATFORM_ANDROID)
+    #TODO: Add actual packaging code. This is done in PRE_BUILD so that it happens before the
+    #apk gen steps that happen in POST_BUILD and which are already done via ez_create_target.
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Output/ShaderCache/VULKAN/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/ShaderCache/VULKAN/)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Data/Samples/ShaderExplorer/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/Samples/ShaderExplorer/)
+    add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_directory
+            ${EZ_ROOT}/Data/Base/Shaders/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/Base/Shaders/)
+
+    target_link_libraries(${PROJECT_NAME}
+            PUBLIC
+            InspectorPlugin
+    )
+endif()
+
 ez_add_renderers(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -42,6 +42,7 @@ public:
   }
   virtual void OnResize(const ezSizeU32& newWindowSize) override
   {
+    ezWindow::OnResize(newWindowSize);
     if (g_uiWindowWidth != newWindowSize.width || g_uiWindowHeight != newWindowSize.height)
     {
       g_uiWindowWidth = newWindowSize.width;
@@ -235,7 +236,7 @@ void ezShaderExplorerApp::AfterCoreSystemsStartup()
   ezGlobalLog::AddLogWriter(ezLogWriter::VisualStudio::LogMessageHandler);
 
   ezTelemetry::CreateServer();
-  ezPlugin::LoadPlugin("ezInspectorPlugin").IgnoreResult();
+  ezPlugin::LoadPlugin("ezInspectorPlugin", ezPluginLoadFlags::PluginIsOptional).IgnoreResult();
 
 #ifdef BUILDSYSTEM_ENABLE_VULKAN_SUPPORT
   constexpr const char* szDefaultRenderer = "Vulkan";

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.h
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.h
@@ -11,6 +11,7 @@ class ezShaderExplorerWindow;
 class ezCamera;
 class ezGALDevice;
 class ezDirectoryWatcher;
+class ezVirtualThumbStick;
 
 // A simple application that renders a full screen quad with a single shader and does live reloading of that shader
 // Can be used for singed distance rendering experiments or other single shader experiments.
@@ -30,7 +31,12 @@ public:
 private:
   void UpdateSwapChain();
   void CreateScreenQuad();
+
+#if EZ_ENABLED(EZ_SUPPORTS_DIRECTORY_WATCHER)
   void OnFileChanged(ezStringView sFilename, ezDirectoryWatcherAction action, ezDirectoryWatcherType type);
+
+  ezUniquePtr<ezDirectoryWatcher> m_pDirectoryWatcher;
+#endif
 
   ezShaderExplorerWindow* m_pWindow = nullptr;
   ezGALDevice* m_pDevice = nullptr;
@@ -42,7 +48,8 @@ private:
   ezMeshBufferResourceHandle m_hQuadMeshBuffer;
 
   ezUniquePtr<ezCamera> m_pCamera;
-  ezUniquePtr<ezDirectoryWatcher> m_pDirectoryWatcher;
+  ezUniquePtr<ezVirtualThumbStick> m_pLeftStick;
+  ezUniquePtr<ezVirtualThumbStick> m_pRightStick;
 
   bool m_bStuffChanged;
 };

--- a/Code/UnitTests/RendererTest/CMakeLists.txt
+++ b/Code/UnitTests/RendererTest/CMakeLists.txt
@@ -18,7 +18,7 @@ if(EZ_CMAKE_PLATFORM_ANDROID)
     #apk gen steps that happen in POST_BUILD and which are already done via ez_create_target.
     add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory
-            ${EZ_ROOT}/Output/ShaderCache/VULKAN/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/ShaderCache/VULKAN/)
+            ${EZ_ROOT}/Output/ShaderCache/VULKAN/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Output/ShaderCache/VULKAN/)
     add_custom_command(TARGET ${PROJECT_NAME} PRE_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${EZ_ROOT}/Data/UnitTests/RendererTest/ ${CMAKE_CURRENT_BINARY_DIR}/package/Assets/Data/UnitTests/RendererTest/)

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: D26472FD-C27A-56FB-AF83-AB1EFAF0541B
+Change me: D26472FD-1111-56FB-AF83-AB1EFAF0541B


### PR DESCRIPTION
# Input
* `ezVirtualThumbStick` no longer worked as all input manager values are reset during the update phase. This means that no input device can read input from another inout device. To fix this, We now double-buffer the input manager's values. The downside of this is, that `ezVirtualThumbStick` inout is one frame delayed.
* Added Android implementation of the `ezStandardInputDevice`. Currently, only touch input is implemented.
	* Input is generated by the new `ezAndroidUtils::s_InputEvent` event that anything can subscribe to.
* Changed naming of input slots, `ezInputSlot_TouchPoint0` is now named "Touchpoint 0" instead of "Touchpoint 1" etc.

# Telemetry
* Added `DisconnectedFromClient` event handling to the ezInspectorPlugin to fix a memory leak on shutdown.
* Added missing dependency to ezInspectorPlugin for `ResourceManager` to prevent crashing on Android.
* `DisconnectedFromClient` was not guaranteed to fire, so I added safety checks to `ezTelemetry::CloseConnection` to make sure the event is fired on a forced shutdown.
* ezInspector can now connect to Android devices.

# ShaderExplorer
* Added two `ezVirtualThumbStick` for testing touch input.
* Added `EZ_SUPPORTS_DIRECTORY_WATCHER` ifdefs to allow building on Android.
* Added `ezTelemetry::CreateServer` and `CloseConnection` calls to enable ezInspector to connect to the running app.