### PR TITLE
Adjusted modifiers for gizmos to prevent unwanted input

### DIFF
--- a/Code/Editor/EditorFramework/EditTools/Implementation/StandardGizmoEditTools.cpp
+++ b/Code/Editor/EditorFramework/EditTools/Implementation/StandardGizmoEditTools.cpp
@@ -63,19 +63,21 @@ void ezTranslateGizmoEditTool::TransformationGizmoEventHandlerImpl(const ezGizmo
     case ezGizmoEvent::Type::BeginInteractions:
     {
       const bool bDuplicate =
-        QApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ShiftModifier) && GetGizmoInterface()->CanDuplicateSelection();
+        (QApplication::keyboardModifiers() == Qt::KeyboardModifier::ControlModifier) && GetGizmoInterface()->CanDuplicateSelection();
 
-      // duplicate the object when shift is held while dragging the item
+      // duplicate the object when CTRL is held while dragging the item
       if (bDuplicate && (e.m_pGizmo == &m_TranslateGizmo || e.m_pGizmo->GetDynamicRTTI()->IsDerivedFrom<ezOrthoGizmoContext>()))
       {
         m_bMergeTransactions = true;
         GetGizmoInterface()->DuplicateSelection();
       }
 
-      if (e.m_pGizmo == &m_TranslateGizmo && QApplication::keyboardModifiers() & Qt::KeyboardModifier::ControlModifier)
-      {
-        m_TranslateGizmo.SetMovementMode(ezTranslateGizmo::MovementMode::MouseDiff);
-      }
+      // UE style move along with the moving gizmo
+      // could be re-enabled, but doesn't feel useful
+      // if (e.m_pGizmo == &m_TranslateGizmo && QApplication::keyboardModifiers() & Qt::KeyboardModifier::ControlModifier)
+      //{
+      //   m_TranslateGizmo.SetMovementMode(ezTranslateGizmo::MovementMode::MouseDiff);
+      // }
     }
     break;
 
@@ -101,18 +103,20 @@ void ezTranslateGizmoEditTool::TransformationGizmoEventHandlerImpl(const ezGizmo
             pDocument->SetGlobalTransform(obj.m_pObject, tNew, TransformationChanges::Translation);
         }
 
-        if (e.m_pGizmo == &m_TranslateGizmo && QApplication::keyboardModifiers() & Qt::KeyboardModifier::ControlModifier)
-        {
-          m_TranslateGizmo.SetMovementMode(ezTranslateGizmo::MovementMode::MouseDiff);
+        // UE style move along with the moving gizmo
+        // could be re-enabled, but doesn't feel useful
+        // if (e.m_pGizmo == &m_TranslateGizmo && QApplication::keyboardModifiers() & Qt::KeyboardModifier::ControlModifier)
+        //{
+        //   m_TranslateGizmo.SetMovementMode(ezTranslateGizmo::MovementMode::MouseDiff);
 
-          auto* pFocusedView = GetWindow()->GetFocusedViewWidget();
-          if (pFocusedView != nullptr)
-          {
-            const ezVec3 d = m_TranslateGizmo.GetTranslationDiff();
-            pFocusedView->m_pViewConfig->m_Camera.MoveGlobally(d.x, d.y, d.z);
-          }
-        }
-        else
+        //  auto* pFocusedView = GetWindow()->GetFocusedViewWidget();
+        //  if (pFocusedView != nullptr)
+        //  {
+        //    const ezVec3 d = m_TranslateGizmo.GetTranslationDiff();
+        //    pFocusedView->m_pViewConfig->m_Camera.MoveGlobally(d.x, d.y, d.z);
+        //  }
+        //}
+        // else
         {
           m_TranslateGizmo.SetMovementMode(ezTranslateGizmo::MovementMode::ScreenProjection);
         }
@@ -134,17 +138,18 @@ void ezTranslateGizmoEditTool::TransformationGizmoEventHandlerImpl(const ezGizmo
           pDocument->SetGlobalTransform(obj.m_pObject, tNew, TransformationChanges::Translation);
         }
 
-        if (QApplication::keyboardModifiers() & Qt::KeyboardModifier::ControlModifier)
-        {
-          // move the camera with the translated object
-
-          auto* pFocusedView = GetWindow()->GetFocusedViewWidget();
-          if (pFocusedView != nullptr)
-          {
-            const ezVec3 d = pOrtho->GetTranslationDiff();
-            pFocusedView->m_pViewConfig->m_Camera.MoveGlobally(d.x, d.y, d.z);
-          }
-        }
+        // UE style move along with the moving gizmo
+        // could be re-enabled, but doesn't feel useful
+        // if (QApplication::keyboardModifiers() & Qt::KeyboardModifier::ControlModifier)
+        //{
+        //   // move the camera with the translated object
+        //  auto* pFocusedView = GetWindow()->GetFocusedViewWidget();
+        //  if (pFocusedView != nullptr)
+        //  {
+        //    const ezVec3 d = pOrtho->GetTranslationDiff();
+        //    pFocusedView->m_pViewConfig->m_Camera.MoveGlobally(d.x, d.y, d.z);
+        //  }
+        //}
       }
 
       pAccessor->FinishTransaction();
@@ -285,9 +290,9 @@ void ezRotateGizmoEditTool::TransformationGizmoEventHandlerImpl(const ezGizmoEve
     case ezGizmoEvent::Type::BeginInteractions:
     {
       const bool bDuplicate =
-        QApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ShiftModifier) && GetGizmoInterface()->CanDuplicateSelection();
+        QApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ControlModifier) && GetGizmoInterface()->CanDuplicateSelection();
 
-      // duplicate the object when shift is held while dragging the item
+      // duplicate the object when CTRL is held while dragging the item
       if (e.m_pGizmo == &m_RotateGizmo && bDuplicate)
       {
         m_bMergeTransactions = true;
@@ -327,15 +332,12 @@ void ezRotateGizmoEditTool::TransformationGizmoEventHandlerImpl(const ezGizmoEve
 
         const ezQuat qRotation = pOrtho->GetRotationResult();
 
-        // const ezVec3 vPivot(0);
-
         for (ezUInt32 sel = 0; sel < m_GizmoSelection.GetCount(); ++sel)
         {
           const auto& obj = m_GizmoSelection[sel];
 
           tNew = obj.m_GlobalTransform;
           tNew.m_qRotation = qRotation * obj.m_GlobalTransform.m_qRotation;
-          // tNew.m_vPosition = vPivot + qRotation * (obj.m_GlobalTransform.m_vPosition - vPivot);
 
           pDocument->SetGlobalTransform(obj.m_pObject, tNew, TransformationChanges::Rotation);
         }
@@ -521,9 +523,9 @@ void ezDragToPositionGizmoEditTool::TransformationGizmoEventHandlerImpl(const ez
     case ezGizmoEvent::Type::BeginInteractions:
     {
       const bool bDuplicate =
-        QApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ShiftModifier) && GetGizmoInterface()->CanDuplicateSelection();
+        QApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ControlModifier) && GetGizmoInterface()->CanDuplicateSelection();
 
-      // duplicate the object when shift is held while dragging the item
+      // duplicate the object when CTRL is held while dragging the item
       if (e.m_pGizmo == &m_DragToPosGizmo && bDuplicate)
       {
         m_bMergeTransactions = true;

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/DragToPositionGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/DragToPositionGizmo.cpp
@@ -190,8 +190,8 @@ ezEditorInput ezDragToPositionGizmo::DoMouseMoveEvent(QMouseEvent* e)
 
   ezVec3 vSnappedPosition = res.m_vPickedPosition;
 
-  // disable snapping when ALT is pressed
-  if (!e->modifiers().testFlag(Qt::AltModifier))
+  // disable snapping when SHIFT is pressed
+  if (!e->modifiers().testFlag(Qt::ShiftModifier))
     ezSnapProvider::SnapTranslation(vSnappedPosition);
 
   ezTransform mTrans = GetTransformation();

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/DrawBoxGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/DrawBoxGizmo.cpp
@@ -73,7 +73,7 @@ bool ezDrawBoxGizmo::PickPosition(QMouseEvent* e)
 
 ezEditorInput ezDrawBoxGizmo::DoMousePressEvent(QMouseEvent* e)
 {
-  if (e->buttons() == Qt::LeftButton && e->modifiers().testFlag(Qt::ControlModifier))
+  if (e->buttons() == Qt::LeftButton && e->modifiers() == Qt::ControlModifier)
   {
     if (m_ManipulateMode == ManipulateMode::None)
     {

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/NonUniformBoxGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/NonUniformBoxGizmo.cpp
@@ -230,8 +230,8 @@ ezEditorInput ezNonUniformBoxGizmo::DoMouseMoveEvent(QMouseEvent* e)
 
     ezVec3 vTranslate = GetTransformation().m_qRotation.GetInverse() * (vNewPos - m_vStartPosition);
 
-    // disable snapping when ALT is pressed
-    if (!e->modifiers().testFlag(Qt::AltModifier))
+    // disable snapping when SHIFT is pressed
+    if (!e->modifiers().testFlag(Qt::ShiftModifier))
     {
       ezSnapProvider::SnapTranslation(vTranslate);
     }

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/RotateGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/RotateGizmo.cpp
@@ -197,8 +197,8 @@ ezEditorInput ezRotateGizmo::DoMouseMoveEvent(QMouseEvent* e)
 
   ezAngle rot = m_Rotation;
 
-  // disable snapping when ALT is pressed
-  if (!e->modifiers().testFlag(Qt::AltModifier))
+  // disable snapping when SHIFT is pressed
+  if (!e->modifiers().testFlag(Qt::ShiftModifier))
     ezSnapProvider::SnapRotation(rot);
 
   m_qCurrentRotation = ezQuat::MakeFromAxisAndAngle(m_vRotationAxis, rot);

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/ScaleGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/ScaleGizmo.cpp
@@ -181,8 +181,8 @@ ezEditorInput ezScaleGizmo::DoMouseMoveEvent(QMouseEvent* e)
   if (m_vScaleMouseMove.z < 0.0f)
     m_vScalingResult.z = 1.0f / (1.0f - m_vScaleMouseMove.z * fScaleSpeed);
 
-  // disable snapping when ALT is pressed
-  if (!e->modifiers().testFlag(Qt::AltModifier))
+  // disable snapping when SHIFT is pressed
+  if (!e->modifiers().testFlag(Qt::ShiftModifier))
     ezSnapProvider::SnapScale(m_vScalingResult);
 
   GetOwnerWindow()->SetPermanentStatusBarMsg(

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/TranslateGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/TranslateGizmo.cpp
@@ -323,8 +323,8 @@ ezEditorInput ezTranslateGizmo::DoMouseMoveEvent(QMouseEvent* e)
 
   m_vLastMousePos = UpdateMouseMode(e);
 
-  // disable snapping when ALT is pressed
-  if (!e->modifiers().testFlag(Qt::AltModifier))
+  // disable snapping when SHIFT is pressed
+  if (!e->modifiers().testFlag(Qt::ShiftModifier))
   {
     ezSnapProvider::SnapTranslationInLocalSpace(mTrans.m_qRotation, vTranslate);
   }

--- a/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
+++ b/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
@@ -33,7 +33,7 @@ protected:
   virtual void OnSetOwner(ezQtEngineDocumentWindow* pOwnerWindow, ezQtEngineViewWidget* pOwnerView) override {}
 
 
- void OnActivated() override;
+  void OnActivated() override;
 
 private:
   virtual void UpdateContext() override;

--- a/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
+++ b/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
@@ -32,6 +32,9 @@ protected:
 
   virtual void OnSetOwner(ezQtEngineDocumentWindow* pOwnerWindow, ezQtEngineViewWidget* pOwnerView) override {}
 
+
+ void OnActivated() override;
+
 private:
   virtual void UpdateContext() override;
 

--- a/Code/Editor/EditorFramework/InputContexts/EditorInputContext.h
+++ b/Code/Editor/EditorFramework/InputContexts/EditorInputContext.h
@@ -36,7 +36,7 @@ public:
   ezEditorInput MouseMoveEvent(QMouseEvent* e);
   ezEditorInput WheelEvent(QWheelEvent* e) { return DoWheelEvent(e); }
 
-  static void SetActiveInputContext(ezEditorInputContext* pContext) { s_pActiveInputContext = pContext; }
+  static void SetActiveInputContext(ezEditorInputContext* pContext);
 
   void MakeActiveInputContext(bool bActive = true);
 
@@ -89,6 +89,8 @@ protected:
 
   virtual void OnSetOwner(ezQtEngineDocumentWindow* pOwnerWindow, ezQtEngineViewWidget* pOwnerView) = 0;
 
+  virtual void OnActivated() {}
+  virtual void OnDeactivated() {}
   virtual ezEditorInput DoKeyPressEvent(QKeyEvent* e);
   virtual ezEditorInput DoKeyReleaseEvent(QKeyEvent* e) { return ezEditorInput::MayBeHandledByOthers; }
   virtual ezEditorInput DoMousePressEvent(QMouseEvent* e) { return ezEditorInput::MayBeHandledByOthers; }

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
@@ -373,9 +373,13 @@ ezEditorInput ezCameraMoveContext::DoMousePressEvent(QMouseEvent* e)
       m_bMoveCamera = false;
 
       if ((e->modifiers() & Qt::KeyboardModifier::AltModifier) != 0)
+      {
         m_bOrbitCamera = true;
-      else
+      }
+      else if (!e->modifiers().testAnyFlags(Qt::KeyboardModifier::ControlModifier | Qt::KeyboardModifier::ShiftModifier))
+      {
         m_bMoveCamera = true;
+      }
 
       m_vLastMousePos = SetMouseMode(ezEditorInputContext::MouseMode::HideAndWrapAtScreenBorders);
       m_bDidMoveMouse[0] = false;
@@ -394,8 +398,10 @@ ezEditorInput ezCameraMoveContext::DoMousePressEvent(QMouseEvent* e)
       {
         m_bPanOrbitPoint = true;
       }
-      else
+      else if (!e->modifiers().testAnyFlags(Qt::KeyboardModifier::ControlModifier | Qt::KeyboardModifier::ShiftModifier))
+      {
         m_bMoveCameraInPlane = true;
+      }
 
       m_vLastMousePos = SetMouseMode(ezEditorInputContext::MouseMode::HideAndWrapAtScreenBorders);
       m_bDidMoveMouse[2] = false;
@@ -723,12 +729,31 @@ void ezCameraMoveContext::SetMoveSpeed(ezInt32 iSpeed)
   }
 }
 
+void ezCameraMoveContext::OnActivated()
+{
+  m_LastUpdate = ezTime::Now();
+}
+
 ezEditorInput ezCameraMoveContext::DoWheelEvent(QWheelEvent* e)
 {
-  if (m_bMoveCamera || m_bMoveCameraInPlane || m_bOrbitCamera || m_bRotateCamera)
-    return ezEditorInput::WasExclusivelyHandled; // ignore it, but others should not handle it either
-
   const ezScenePreferencesUser* pPreferences = ezPreferences::QueryPreferences<ezScenePreferencesUser>(GetOwnerWindow()->GetDocument());
+
+  if (m_bMoveCamera || m_bMoveCameraInPlane || m_bOrbitCamera || m_bRotateCamera)
+  {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+    if (e->angleDelta().y() > 0)
+#else
+    if (e->delta() > 0)
+#endif
+    {
+      SetMoveSpeed(pPreferences->GetCameraSpeed() + 1);
+    }
+    else
+    {
+      SetMoveSpeed(pPreferences->GetCameraSpeed() - 1);
+    }
+    return ezEditorInput::WasExclusivelyHandled; // ignore it, but others should not handle it either
+  }
 
   if (m_pCamera->IsOrthographic())
   {

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/EditorInputContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/EditorInputContext.cpp
@@ -75,12 +75,24 @@ ezEditorInput ezEditorInputContext::MouseMoveEvent(QMouseEvent* e)
   return DoMouseMoveEvent(e);
 }
 
+
+void ezEditorInputContext::SetActiveInputContext(ezEditorInputContext* pContext)
+{
+  if (s_pActiveInputContext)
+    s_pActiveInputContext->OnDeactivated();
+
+  s_pActiveInputContext = pContext;
+
+  if (s_pActiveInputContext)
+    s_pActiveInputContext->OnActivated();
+}
+
 void ezEditorInputContext::MakeActiveInputContext(bool bActive /*= true*/)
 {
   if (bActive)
-    s_pActiveInputContext = this;
+    SetActiveInputContext(this);
   else
-    s_pActiveInputContext = nullptr;
+    SetActiveInputContext(nullptr);
 }
 
 void ezEditorInputContext::UpdateActiveInputContext()

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/OrthoGizmoContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/OrthoGizmoContext.cpp
@@ -94,8 +94,8 @@ ezEditorInput ezOrthoGizmoContext::DoMouseMoveEvent(QMouseEvent* e)
 
     m_vTranslationResult = m_vUnsnappedTranslationResult;
 
-    // disable snapping when ALT is pressed
-    if (!e->modifiers().testFlag(Qt::AltModifier))
+    // disable snapping when SHIFT is pressed
+    if (!e->modifiers().testFlag(Qt::ShiftModifier))
       ezSnapProvider::SnapTranslation(m_vTranslationResult);
 
     m_vTranslationDiff = m_vTranslationResult - vLastTranslationResult;
@@ -104,8 +104,8 @@ ezEditorInput ezOrthoGizmoContext::DoMouseMoveEvent(QMouseEvent* e)
 
     ezAngle snappedRotation = m_UnsnappedRotationResult;
 
-    // disable snapping when ALT is pressed
-    if (!e->modifiers().testFlag(Qt::AltModifier))
+    // disable snapping when SHIFT is pressed
+    if (!e->modifiers().testFlag(Qt::ShiftModifier))
       ezSnapProvider::SnapRotation(snappedRotation);
 
     m_qRotationResult = ezQuat::MakeFromAxisAndAngle(m_pCamera->GetDirForwards(), snappedRotation);
@@ -123,8 +123,8 @@ ezEditorInput ezOrthoGizmoContext::DoMouseMoveEvent(QMouseEvent* e)
 
       m_fScalingResult = m_fUnsnappedScalingResult;
 
-      // disable snapping when ALT is pressed
-      if (!e->modifiers().testFlag(Qt::AltModifier))
+      // disable snapping when SHIFT is pressed
+      if (!e->modifiers().testFlag(Qt::ShiftModifier))
         ezSnapProvider::SnapScale(m_fScalingResult);
     }
 

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/SelectionContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/SelectionContext.cpp
@@ -77,7 +77,7 @@ ezEditorInput ezSelectionContext::DoMousePressEvent(QMouseEvent* e)
       m_uiMarqueeID += 23;
       m_vMarqueeStartPos.Set(e->pos().x(), e->pos().y(), 0.01f);
 
-      // only shift -> add, shift AND control -> remove
+      // no modifier -> add, CTRL -> remove
       m_Mode = e->modifiers().testFlag(Qt::ControlModifier) ? Mode::MarqueeRemove : Mode::MarqueeAdd;
       MakeActiveInputContext();
 


### PR DESCRIPTION
With the current way the gizmos use modifiers (shift, alt, ctrl), there is often unwanted input when you accidentally click next to the gizmo instead of on it.

Pressing ALT+LMB will orbit around the currently framed object. ALT+drag on a gizmo disables snapping. Thus ALT+ accidentally not hitting the gizmo will move the camera to a completely different position, which is really annoying.

Similarly SHIFT+drag on the gizmos duplicates objects, and SHIFT+LMB drag moves the camera really fast (SHIFT makes it move faster). Thus accidentally not hitting the gizmo again makes the camera move really fast away.

This PR changes the behavior to reduce this problem.

Instead of ALT to toggle snapping, it is now using SHIFT. This is actually inspired by Unity, and thus more intuitive for many people. Since it is commonly used, using a different modifier than ALT prevents frequent collision with the orbit camera behavior.

Camera movement can only be triggered via LMB+drag, not when SHIFT is already down. Thus SHIFT+LMB-drag while accidentally not hitting a gizmo simply does nothing.

Instead of SHIFT+drag on gizmo to duplicate, use CTRL+drag. Accidentally not hitting the gizmo then has either no effect, or only toggles the selection, which is quickly restorable with a second click.

Also fixed that using the arrow keys to navigate was very jarring, due to a large timestep.

We also had UE's move-camera-with-gizmo feature implemented (CTRL+drag on gizmo), but I don't think this was really used, so I've deactivated those code paths.