### PR TITLE
FileServe tool can now remote compile shaders

### DIFF
--- a/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.cpp
+++ b/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.cpp
@@ -400,6 +400,12 @@ void ezQtFileserveWidget::FileserverEventHandler(const ezFileserverEvent& e)
       LogActivity("Client searching for Server", ezFileserveActivityType::Other);
     }
     break;
+
+    case ezFileserverEvent::Type::LogCustomActivity:
+    {
+      LogActivity(e.m_szName, ezFileserveActivityType::Other);
+    }
+    break;
   }
 }
 

--- a/Code/Engine/Core/Interfaces/RemoteToolingInterface.h
+++ b/Code/Engine/Core/Interfaces/RemoteToolingInterface.h
@@ -1,0 +1,13 @@
+#pragma once
+
+class ezRemoteInterface;
+
+/// \brief Interface to give access to the FileServe client for additional tooling needs.
+///
+/// For now, this interface just gives access to the ezRemoteInterface that is used to communicate with the FileServe server.
+/// This allows for maximum flexibility sending and receiving custom messages.
+class ezRemoteToolingInterface
+{
+public:
+  virtual ezRemoteInterface* GetRemoteInterface() = 0;
+};

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
@@ -194,6 +194,11 @@ void ezRemoteInterface::SetMessageHandler(ezUInt32 uiSystemID, ezRemoteMessageHa
   m_MessageQueues[uiSystemID].m_MessageHandler = messageHandler;
 }
 
+void ezRemoteInterface::SetUnhandledMessageHandler(ezRemoteMessageHandler messageHandler)
+{
+  m_UnhandledMessageHandler = messageHandler;
+}
+
 ezUInt32 ezRemoteInterface::ExecuteMessageHandlers(ezUInt32 uiSystem)
 {
   EZ_LOCK(m_Mutex);
@@ -224,6 +229,13 @@ ezUInt32 ezRemoteInterface::ExecuteMessageHandlersForQueue(ezRemoteMessageQueue&
     for (auto& msg : queue.m_MessageQueueOut)
     {
       queue.m_MessageHandler(msg);
+    }
+  }
+  else if (m_UnhandledMessageHandler.IsValid())
+  {
+    for (auto& msg : queue.m_MessageQueueOut)
+    {
+      m_UnhandledMessageHandler(msg);
     }
   }
 
@@ -309,10 +321,6 @@ void ezRemoteInterface::ReportMessage(ezUInt32 uiApplicationID, ezUInt32 uiSyste
   EZ_LOCK(m_Mutex);
 
   auto& queue = m_MessageQueues[uiSystemID];
-
-  // discard messages for which we have no message handler
-  if (!queue.m_MessageHandler.IsValid())
-    return;
 
   // store the data for later
   auto& msg = queue.m_MessageQueueIn.ExpandAndGetRef();

--- a/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/RemoteInterface.cpp
@@ -219,7 +219,6 @@ ezUInt32 ezRemoteInterface::ExecuteMessageHandlersForQueue(ezRemoteMessageQueue&
   queue.m_MessageQueueIn.Swap(queue.m_MessageQueueOut);
   const ezUInt32 ret = queue.m_MessageQueueOut.GetCount();
 
-
   if (queue.m_MessageHandler.IsValid())
   {
     for (auto& msg : queue.m_MessageQueueOut)

--- a/Code/Engine/Foundation/Communication/RemoteInterface.h
+++ b/Code/Engine/Foundation/Communication/RemoteInterface.h
@@ -180,6 +180,9 @@ public:
   /// \brief Registers a message handler that is executed for all incoming messages for the given system
   void SetMessageHandler(ezUInt32 uiSystemID, ezRemoteMessageHandler messageHandler);
 
+  /// \brief Registers a message handler that is executed for all incoming messages for systems for which there are no dedicated message handlers.
+  void SetUnhandledMessageHandler(ezRemoteMessageHandler messageHandler);
+
   /// \brief Executes the message handler for all messages that have arrived for the given system
   ezUInt32 ExecuteMessageHandlers(ezUInt32 uiSystem);
 
@@ -255,6 +258,7 @@ private:
   ezInt32 m_iConnectionsToClients = 0;
   ezDynamicArray<ezUInt8> m_TempSendBuffer;
   ezHashTable<ezUInt32, ezRemoteMessageQueue> m_MessageQueues;
+  ezRemoteMessageHandler m_UnhandledMessageHandler;
 };
 
 /// \brief The remote interface thread updates in regular intervals to keep the connection alive.

--- a/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/SmallArray_inl.h
@@ -190,8 +190,8 @@ template <typename> // Second template needed so that the compiler does only ins
 void ezSmallArrayBase<T, Size>::SetCountUninitialized(ezUInt16 uiCount, ezAllocator* pAllocator)
 {
   static_assert(ezIsPodType<T>::value == ezTypeIsPod::value, "SetCountUninitialized is only supported for POD types.");
-  const ezUInt32 uiOldCount = m_uiCount;
-  const ezUInt32 uiNewCount = uiCount;
+  const ezUInt16 uiOldCount = m_uiCount;
+  const ezUInt16 uiNewCount = uiCount;
 
   if (uiNewCount > uiOldCount)
   {

--- a/Code/Engine/Foundation/IO/MemoryStream.h
+++ b/Code/Engine/Foundation/IO/MemoryStream.h
@@ -119,7 +119,7 @@ public:
   }
 
   /// \brief The data is guaranteed to be contiguous.
-  const ezUInt8* GetData() const { return &m_Storage[0]; }
+  const ezUInt8* GetData() const { return m_Storage.GetData(); }
 
 private:
   virtual void SetInternalSize(ezUInt64 uiSize) override

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
@@ -113,7 +113,7 @@ ezResourceLoadDesc ezShaderPermutationResource::UpdateContent(ezStreamReader* St
     if (uiStageHash == 0) // not used
       continue;
 
-    ezShaderStageBinary* pStageBin = ezShaderStageBinary::LoadStageBinary((ezGALShaderStage::Enum)stage, uiStageHash);
+    ezShaderStageBinary* pStageBin = ezShaderStageBinary::LoadStageBinary((ezGALShaderStage::Enum)stage, uiStageHash, ezShaderManager::GetActivePlatform());
 
     if (pStageBin == nullptr)
     {
@@ -343,7 +343,7 @@ ezResourceLoadData ezShaderPermutationResourceLoader::OpenDataStream(const ezRes
         continue;
 
       // this is where the preloading happens
-      ezShaderStageBinary::LoadStageBinary((ezGALShaderStage::Enum)stage, uiStageHash);
+      ezShaderStageBinary::LoadStageBinary((ezGALShaderStage::Enum)stage, uiStageHash, ezShaderManager::GetActivePlatform());
     }
   }
 

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStageBinary.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStageBinary.cpp
@@ -201,15 +201,15 @@ ezSharedPtr<const ezGALShaderByteCode> ezShaderStageBinary::GetByteCode() const
   return m_pGALByteCode;
 }
 
-ezResult ezShaderStageBinary::WriteStageBinary(ezLogInterface* pLog) const
+ezResult ezShaderStageBinary::WriteStageBinary(ezLogInterface* pLog, ezStringView sPlatform) const
 {
   ezStringBuilder sShaderStageFile = ezShaderManager::GetCacheDirectory();
 
-  sShaderStageFile.AppendPath(ezShaderManager::GetActivePlatform().GetData());
+  sShaderStageFile.AppendPath(sPlatform);
   sShaderStageFile.AppendFormat("/{0}_{1}.ezShaderStage", ezGALShaderStage::Names[m_pGALByteCode->m_Stage], ezArgU(m_uiSourceHash, 8, true, 16, true));
 
   ezFileWriter StageFileOut;
-  if (StageFileOut.Open(sShaderStageFile.GetData()).Failed())
+  if (StageFileOut.Open(sShaderStageFile).Failed())
   {
     ezLog::Error(pLog, "Could not open shader stage file '{0}' for writing", sShaderStageFile);
     return EZ_FAILURE;
@@ -225,7 +225,7 @@ ezResult ezShaderStageBinary::WriteStageBinary(ezLogInterface* pLog) const
 }
 
 // static
-ezShaderStageBinary* ezShaderStageBinary::LoadStageBinary(ezGALShaderStage::Enum Stage, ezUInt32 uiHash)
+ezShaderStageBinary* ezShaderStageBinary::LoadStageBinary(ezGALShaderStage::Enum Stage, ezUInt32 uiHash, ezStringView sPlatform)
 {
   auto itStage = s_ShaderStageBinaries[Stage].Find(uiHash);
 
@@ -233,7 +233,7 @@ ezShaderStageBinary* ezShaderStageBinary::LoadStageBinary(ezGALShaderStage::Enum
   {
     ezStringBuilder sShaderStageFile = ezShaderManager::GetCacheDirectory();
 
-    sShaderStageFile.AppendPath(ezShaderManager::GetActivePlatform().GetData());
+    sShaderStageFile.AppendPath(sPlatform);
     sShaderStageFile.AppendFormat("/{0}_{1}.ezShaderStage", ezGALShaderStage::Names[Stage], ezArgU(uiHash, 8, true, 16, true));
 
     ezFileReader StageFileIn;

--- a/Code/Engine/RendererCore/Shader/ShaderStageBinary.h
+++ b/Code/Engine/RendererCore/Shader/ShaderStageBinary.h
@@ -40,7 +40,7 @@ private:
   friend class ezShaderPermutationResource;
   friend class ezShaderPermutationResourceLoader;
 
-  ezResult WriteStageBinary(ezLogInterface* pLog) const;
+  ezResult WriteStageBinary(ezLogInterface* pLog, ezStringView sPlatform) const;
   ezResult Write(ezStreamWriter& inout_stream) const;
   ezResult Read(ezStreamReader& inout_stream);
   ezResult Write(ezStreamWriter& inout_stream, const ezShaderConstantBufferLayout& layout) const;
@@ -51,7 +51,7 @@ private:
   ezSharedPtr<ezGALShaderByteCode> m_pGALByteCode;
 
 private: // statics
-  static ezShaderStageBinary* LoadStageBinary(ezGALShaderStage::Enum Stage, ezUInt32 uiHash);
+  static ezShaderStageBinary* LoadStageBinary(ezGALShaderStage::Enum Stage, ezUInt32 uiHash, ezStringView sPlatform);
 
   static void OnEngineShutdown();
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -417,7 +417,7 @@ ezResult ezShaderCompiler::RunShaderCompiler(ezStringView sFile, ezStringView sP
 
       if (spd.m_uiSourceHash[stage] != 0)
       {
-        ezShaderStageBinary* pBinary = ezShaderStageBinary::LoadStageBinary((ezGALShaderStage::Enum)stage, spd.m_uiSourceHash[stage]);
+        ezShaderStageBinary* pBinary = ezShaderStageBinary::LoadStageBinary((ezGALShaderStage::Enum)stage, spd.m_uiSourceHash[stage], sPlatform);
 
         if (pBinary)
         {
@@ -456,7 +456,7 @@ ezResult ezShaderCompiler::RunShaderCompiler(ezStringView sFile, ezStringView sP
         bin.m_uiSourceHash = spd.m_uiSourceHash[stage];
         bin.m_pGALByteCode = spd.m_ByteCode[stage];
 
-        if (bin.WriteStageBinary(pLog).Failed())
+        if (bin.WriteStageBinary(pLog, sPlatform).Failed())
         {
           ezLog::Error(pLog, "Writing stage {0} binary failed", stage);
           return EZ_FAILURE;

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
@@ -112,14 +112,12 @@ namespace
 
 void ezShaderManager::Configure(const char* szActivePlatform, bool bEnableRuntimeCompilation, const char* szShaderCacheDirectory, const char* szPermVarSubDirectory)
 {
-  s_sShaderCacheDirectory = szShaderCacheDirectory;
-  s_sPermVarSubDir = szPermVarSubDirectory;
-
   ezStringBuilder s = szActivePlatform;
   s.ToUpper();
-
-  s_bEnableRuntimeCompilation = bEnableRuntimeCompilation;
   s_sPlatform = s;
+  s_bEnableRuntimeCompilation = bEnableRuntimeCompilation;
+  s_sShaderCacheDirectory = szShaderCacheDirectory;
+  s_sPermVarSubDir = szPermVarSubDirectory;
 }
 
 void ezShaderManager::ReloadPermutationVarConfig(const char* szName, const ezTempHashedString& sHashedName)

--- a/Code/Engine/RendererCore/ShaderCompiler/ShaderCompiler.h
+++ b/Code/Engine/RendererCore/ShaderCompiler/ShaderCompiler.h
@@ -10,6 +10,8 @@
 #include <RendererCore/ShaderCompiler/ShaderParser.h>
 #include <RendererFoundation/Descriptors/Descriptors.h>
 
+class ezRemoteMessage;
+
 /// \brief Shader compiler interface.
 /// Custom shader compiles need to derive from this class and implement the pure virtual interface functions. Instances are created via reflection so each implementation must be properly reflected.
 class EZ_RENDERERCORE_DLL ezShaderProgramCompiler : public ezReflectedClass
@@ -46,6 +48,8 @@ private:
 
   bool PassThroughUnknownCommandCB(ezStringView sCmd) { return sCmd == "version"; }
 
+  void ShaderCompileMsg(ezRemoteMessage& msg);
+
   struct ezShaderData
   {
     ezString m_Platforms;
@@ -63,4 +67,6 @@ private:
   ezShaderData m_ShaderData;
 
   ezSet<ezString> m_IncludeFiles;
+  bool m_bCompilingShaderRemote = false;
+  ezResult m_RemoteShaderCompileResult = EZ_FAILURE;
 };

--- a/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.cpp
+++ b/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.cpp
@@ -370,6 +370,21 @@ void ezFileserveClient::NetworkMsgHandler(ezRemoteMessage& msg)
     return;
   }
 
+  if (msg.GetMessageID() == 'INVC')
+  {
+    // invalidate caches, so that next read will go to the server
+
+    for (auto& dd : m_MountedDataDirs)
+    {
+      for (auto& it : dd.m_CacheStatus)
+      {
+        it.Value().m_LastCheck = ezTime::MakeZero();
+      }
+    }
+
+    return;
+  }
+
   ezLog::Error("Unknown FSRV message: '{0}' - {1} bytes", msg.GetMessageID(), msg.GetMessageData().GetCount());
 }
 

--- a/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.h
+++ b/Code/EnginePlugins/FileservePlugin/Client/FileserveClient.h
@@ -2,6 +2,7 @@
 
 #include <FileservePlugin/FileservePluginDLL.h>
 
+#include <Core/Interfaces/RemoteToolingInterface.h>
 #include <Foundation/Communication/RemoteInterface.h>
 #include <Foundation/Configuration/Singleton.h>
 #include <Foundation/Types/UniquePtr.h>
@@ -24,13 +25,18 @@ namespace ezDataDirectory
 /// The timeout for connecting to the server can be configured through the command line option "-fs_timeout seconds"
 /// The server to connect to can be configured through command line option "-fs_server address".
 /// The default address is "localhost:1042".
-class EZ_FILESERVEPLUGIN_DLL ezFileserveClient
+class EZ_FILESERVEPLUGIN_DLL ezFileserveClient : public ezRemoteToolingInterface
 {
-  EZ_DECLARE_SINGLETON(ezFileserveClient);
+  EZ_DECLARE_SINGLETON_OF_INTERFACE(ezFileserveClient, ezRemoteToolingInterface);
 
 public:
   ezFileserveClient();
   ~ezFileserveClient();
+
+  /// ezRemoteToolingInterface
+
+  /// \brief Returns the network connection interface.
+  ezRemoteInterface* GetRemoteInterface() override { return m_pNetwork.Borrow(); }
 
   /// \brief Can be called at startup to go through multiple sources and search for a valid server address
   ///

--- a/Code/EnginePlugins/FileservePlugin/Fileserver/Fileserver.h
+++ b/Code/EnginePlugins/FileservePlugin/Fileserver/Fileserver.h
@@ -30,6 +30,7 @@ struct ezFileserverEvent
     FileUploading,
     FileUploadFinished,
     AreYouThereRequest,
+    LogCustomActivity,
   };
 
   Type m_Type = Type::None;
@@ -89,10 +90,15 @@ public:
   static ezResult SendConnectionInfo(
     const char* szClientAddress, ezUInt16 uiMyPort, const ezArrayPtr<ezStringBuilder>& myIPs, ezTime timeout = ezTime::MakeFromSeconds(10));
 
+  using ClientMessageHandler = ezDelegate<void(ezFileserveClientContext&, ezRemoteMessage&, ezRemoteInterface&, ezDelegate<void(const char*)>)>;
+
+  void SetCustomMessageHandler(ezUInt32 uiSystemID, ClientMessageHandler handler);
+
 private:
   void NetworkEventHandler(const ezRemoteEvent& e);
   ezFileserveClientContext& DetermineClient(ezRemoteMessage& msg);
   void NetworkMsgHandler(ezRemoteMessage& msg);
+  void UnknownNetworkMsgHandler(ezRemoteMessage& msg);
   void HandleMountRequest(ezFileserveClientContext& client, ezRemoteMessage& msg);
   void HandleUnmountRequest(ezFileserveClientContext& client, ezRemoteMessage& msg);
   void HandleFileRequest(ezFileserveClientContext& client, ezRemoteMessage& msg);
@@ -100,6 +106,7 @@ private:
   void HandleUploadFileHeader(ezFileserveClientContext& client, ezRemoteMessage& msg);
   void HandleUploadFileTransfer(ezFileserveClientContext& client, ezRemoteMessage& msg);
   void HandleUploadFileFinished(ezFileserveClientContext& client, ezRemoteMessage& msg);
+  void LogCustomActivity(const char* szText);
 
   ezHashTable<ezUInt32, ezFileserveClientContext> m_Clients;
   ezUniquePtr<ezRemoteInterface> m_pNetwork;
@@ -109,4 +116,5 @@ private:
   ezUuid m_FileUploadGuid;
   ezUInt32 m_uiFileUploadSize;
   ezUInt16 m_uiPort = 1042;
+  ezMap<ezUInt32, ClientMessageHandler> m_CustomMessageHandlers;
 };

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -6,6 +6,7 @@
 #include <Core/Input/VirtualThumbStick.h>
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Core/System/Window.h>
+#include <Foundation/Communication/GlobalEvent.h>
 #include <Foundation/Communication/Telemetry.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/FileSystem/FileSystem.h>
@@ -208,6 +209,9 @@ ezApplication::Execution ezShaderExplorerApp::Run()
   // this has to be done at the very end, so that the task system will only use up the time that is left in this frame for
   // uploading GPU data etc.
   ezTaskSystem::FinishFrameTasks();
+
+  // for plugins (like FileServe) that need to hook into the game update
+  EZ_BROADCAST_EVENT(GameApp_UpdatePlugins);
 
   return ezApplication::Execution::Continue;
 }

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.h
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.h
@@ -15,12 +15,17 @@
 //
 // ezFileServe.exe -fs_start -specialdirs project "C:\ez\Data\Samples\ShaderExplorer"
 
-#if !defined(USE_FILESERVE) && EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)
+#if !defined(USE_FILESERVE)
+
+#  if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)
 // on sandboxed platforms, we can only load data through fileserve, so enforce use of this plugin
-#  define USE_FILESERVE EZ_ON
-#else
-#  define USE_FILESERVE EZ_OFF
+#    define USE_FILESERVE EZ_ON
+#  else
+#    define USE_FILESERVE EZ_OFF
+#  endif
+
 #endif
+
 
 #if EZ_DISABLED(USE_FILESERVE) && EZ_ENABLED(EZ_SUPPORTS_DIRECTORY_WATCHER)
 #  define USE_DIRECTORY_WATCHER EZ_ON

--- a/Code/Tools/Fileserve/App.cpp
+++ b/Code/Tools/Fileserve/App.cpp
@@ -26,6 +26,11 @@ void ezFileserverApp::AfterCoreSystemsStartup()
   ezFileserver::GetSingleton()->StartServer();
 #endif
 
+  ezPlugin::LoadPlugin("ezShaderCompilerDXC", ezPluginLoadFlags::PluginIsOptional).IgnoreResult();
+  ezPlugin::LoadPlugin("ezShaderCompilerHLSL", ezPluginLoadFlags::PluginIsOptional).IgnoreResult();
+
+  ezFileserver::GetSingleton()->SetCustomMessageHandler('SHDR', ezMakeDelegate(&ezFileserverApp::ShaderMessageHandler, this));
+
   // TODO: CommandLine Option
   m_CloseAppTimeout = ezTime::MakeFromSeconds(ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-fs_close_timeout", 0));
   m_TimeTillClosing = ezTime::MakeFromSeconds(ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-fs_wait_timeout", 0));

--- a/Code/Tools/Fileserve/CMakeLists.txt
+++ b/Code/Tools/Fileserve/CMakeLists.txt
@@ -25,5 +25,6 @@ ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets Network)
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
   EditorPluginFileserve
+  RendererCore
 )
 

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -94,16 +94,16 @@ void ezFileserverApp::FileserverEventHandler(const ezFileserverEvent& e)
   }
 }
 
-void ezFileserverApp::ShaderMessageHandler(ezFileserveClientContext& ctxt, ezRemoteMessage& msg, ezRemoteInterface& clientChannel, ezDelegate<void(const char*)> logActivity)
+void ezFileserverApp::ShaderMessageHandler(ezFileserveClientContext& ref_ctxt, ezRemoteMessage& ref_msg, ezRemoteInterface& ref_clientChannel, ezDelegate<void(const char*)> logActivity)
 {
-  if (msg.GetMessageID() == 'CMPL')
+  if (ref_msg.GetMessageID() == 'CMPL')
   {
-    for (auto& dd : ctxt.m_MountedDataDirs)
+    for (auto& dd : ref_ctxt.m_MountedDataDirs)
     {
       ezFileSystem::AddDataDirectory(dd.m_sPathOnServer, "FileServe", dd.m_sRootName, ezFileSystem::AllowWrites).IgnoreResult();
     }
 
-    auto& r = msg.GetReader();
+    auto& r = ref_msg.GetReader();
 
     ezStringBuilder tmp;
     ezStringBuilder file, platform;
@@ -143,7 +143,7 @@ void ezFileserverApp::ShaderMessageHandler(ezFileserveClientContext& ctxt, ezRem
     {
       // invalidate read cache to not short-circuit the next file read operation
       ezRemoteMessage msg2('FSRV', 'INVC');
-      clientChannel.Send(ezRemoteTransmitMode::Reliable, msg2);
+      ref_clientChannel.Send(ezRemoteTransmitMode::Reliable, msg2);
     }
     else
     {
@@ -164,7 +164,7 @@ void ezFileserverApp::ShaderMessageHandler(ezFileserveClientContext& ctxt, ezRem
       msg2.GetWriter() << (res == EZ_SUCCESS);
       msg2.GetWriter() << log.m_sBuffer;
 
-      clientChannel.Send(ezRemoteTransmitMode::Reliable, msg2);
+      ref_clientChannel.Send(ezRemoteTransmitMode::Reliable, msg2);
     }
   }
 }

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -4,6 +4,8 @@
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/FileSystem/FileSystem.h>
 #include <Foundation/Utilities/CommandLineUtils.h>
+#include <RendererCore/ShaderCompiler/ShaderCompiler.h>
+#include <RendererCore/ShaderCompiler/ShaderManager.h>
 
 #ifdef EZ_USE_QT
 #  include <Fileserve/Gui.moc.h>
@@ -89,5 +91,80 @@ void ezFileserverApp::FileserverEventHandler(const ezFileserverEvent& e)
       break;
     default:
       break;
+  }
+}
+
+void ezFileserverApp::ShaderMessageHandler(ezFileserveClientContext& ctxt, ezRemoteMessage& msg, ezRemoteInterface& clientChannel, ezDelegate<void(const char*)> logActivity)
+{
+  if (msg.GetMessageID() == 'CMPL')
+  {
+    for (auto& dd : ctxt.m_MountedDataDirs)
+    {
+      ezFileSystem::AddDataDirectory(dd.m_sPathOnServer, "FileServe", dd.m_sRootName, ezFileSystem::AllowWrites).IgnoreResult();
+    }
+
+    auto& r = msg.GetReader();
+
+    ezStringBuilder tmp;
+    ezStringBuilder file, platform;
+    ezUInt32 numPermVars;
+    ezHybridArray<ezPermutationVar, 16> permVars;
+
+    r >> file;
+    r >> platform;
+    r >> numPermVars;
+    permVars.SetCount(numPermVars);
+
+    tmp.SetFormat("Compiling Shader '{}' - '{}'", file, platform);
+
+    for (auto& pv : permVars)
+    {
+      r >> pv.m_sName;
+      r >> pv.m_sValue;
+
+      tmp.AppendWithSeparator(" | ", pv.m_sName, "=", pv.m_sValue);
+    }
+
+    logActivity(tmp);
+
+    // enable runtime shader compilation and set the shader cache directories (this only works, if the user doesn't change the default values)
+    // the 'active platform' value should never be used during shader compilation, because there it is passed in
+    ezShaderManager::Configure("FILESERVE_UNUSED", true);
+
+    ezLogSystemToBuffer log;
+    ezLogSystemScope ls(&log);
+
+    ezShaderCompiler sc;
+    ezResult res = sc.CompileShaderPermutationForPlatforms(file, permVars, ezLog::GetThreadLocalLogSystem(), platform);
+
+    ezFileSystem::RemoveDataDirectoryGroup("FileServe");
+
+    if (res.Succeeded())
+    {
+      // invalidate read cache to not short-circuit the next file read operation
+      ezRemoteMessage msg2('FSRV', 'INVC');
+      clientChannel.Send(ezRemoteTransmitMode::Reliable, msg2);
+    }
+    else
+    {
+      logActivity("[ERROR] Shader Compilation failed:");
+
+      ezHybridArray<ezStringView, 32> lines;
+      log.m_sBuffer.Split(false, lines, "\n", "\r");
+
+      for (auto line : lines)
+      {
+        tmp.Set(">   ", line);
+        logActivity(tmp);
+      }
+    }
+
+    {
+      ezRemoteMessage msg2('SHDR', 'CRES');
+      msg2.GetWriter() << (res == EZ_SUCCESS);
+      msg2.GetWriter() << log.m_sBuffer;
+
+      clientChannel.Send(ezRemoteTransmitMode::Reliable, msg2);
+    }
   }
 }

--- a/Code/Tools/Fileserve/Fileserve.h
+++ b/Code/Tools/Fileserve/Fileserve.h
@@ -32,7 +32,7 @@ public:
   void FileserverEventHandlerConsole(const ezFileserverEvent& e);
   void FileserverEventHandler(const ezFileserverEvent& e);
 
-  void ShaderMessageHandler(ezFileserveClientContext& ctxt, ezRemoteMessage& msg, ezRemoteInterface& clientChannel, ezDelegate<void(const char*)> logActivity);
+  void ShaderMessageHandler(ezFileserveClientContext& ref_ctxt, ezRemoteMessage& ref_msg, ezRemoteInterface& ref_clientChannel, ezDelegate<void(const char*)> logActivity);
 
   ezUInt32 m_uiSleepCounter = 0;
   ezUInt32 m_uiConnections = 0;

--- a/Code/Tools/Fileserve/Fileserve.h
+++ b/Code/Tools/Fileserve/Fileserve.h
@@ -32,6 +32,8 @@ public:
   void FileserverEventHandlerConsole(const ezFileserverEvent& e);
   void FileserverEventHandler(const ezFileserverEvent& e);
 
+  void ShaderMessageHandler(ezFileserveClientContext& ctxt, ezRemoteMessage& msg, ezRemoteInterface& clientChannel, ezDelegate<void(const char*)> logActivity);
+
   ezUInt32 m_uiSleepCounter = 0;
   ezUInt32 m_uiConnections = 0;
   ezTime m_CloseAppTimeout;


### PR DESCRIPTION
Some devices can't compile shaders themselves. For example on Android we need the HLSL shaders to already be compiled for SPIR-V and can't do this on-device on-demand.

This is inconvenient, and when using FileServe to read data from a PC, it wouldn't allow to modify and hot-reload shaders. It also requires to precompile all shaders up front before launching the app.

This PR adds on-demand shader compilation through FileServe. Whenever the app needs a shader, it checks whether the shader needs to be compiled and if so, requests from FileServe to do that. FileServe then executes the shader compiler and stores the result locally on the PC. Afterwards the app attempts to read the result again, but now will find the (updated) compiled shader file through FileServe and continues normally.

Shader compilation activity shows up in the FileServe activity log, and in case of an error, the log is displayed both in the FileServe GUI and also on the remove device log.

![image](https://github.com/ezEngine/ezEngine/assets/6001174/601fdcab-3b55-4196-acad-d850dbdb31c0)
