### PR TITLE
Fixed ezTypedComponentHandle type safety with TryGetComponent

### DIFF
--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -178,11 +178,11 @@ public:
   [[nodiscard]] bool TryGetComponent(const ezComponentHandle& hComponent, const ComponentType*& out_pComponent) const;
 
   /// \brief Explicitly delete TryGetComponent overload when handle type is not related to a pointer type given by out_pComponent.
-  template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_convertible<T*, U*>, std::is_base_of<T, U>>, bool> = true>
+  template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_base_of<U, T>, std::is_base_of<T, U>>, bool> = true>
   [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<T>& hComponent, U*& out_pComponent) = delete;
 
   /// \brief Explicitly delete TryGetComponent overload when handle type is not related to a pointer type given by out_pComponent.
-  template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_convertible<T*, U*>, std::is_base_of<T, U>>, bool> = true>
+  template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_base_of<U, T>, std::is_base_of<T, U>>, bool> = true>
   [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<T>& hComponent, const U*& out_pComponent) const = delete;
 
   /// \brief Creates a new component init batch.

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -177,17 +177,13 @@ public:
   template <typename ComponentType>
   [[nodiscard]] bool TryGetComponent(const ezComponentHandle& hComponent, const ComponentType*& out_pComponent) const;
 
-  template <typename ComponentType>
-  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<ComponentType>& hComponent, ComponentType*& out_pComponent)
-  {
-    return TryGetComponent<ComponentType>(static_cast<const ezComponentHandle&>(hComponent), out_pComponent);
-  }
+  /// \brief Explicitly delete TryGetComponent overload when handle type is not related to a pointer type given by out_pComponent.
+  template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_convertible<T*, U*>, std::is_base_of<T, U>>, bool> = true>
+  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<T>& hComponent, U*& out_pComponent) = delete;
 
-  template <typename ComponentType>
-  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<ComponentType>& hComponent, const ComponentType*& out_pComponent) const
-  {
-    return TryGetComponent<ComponentType>(static_cast<const ezComponentHandle&>(hComponent), out_pComponent);
-  }
+  /// \brief Explicitly delete TryGetComponent overload when handle type is not related to a pointer type given by out_pComponent.
+  template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_convertible<T*, U*>, std::is_base_of<T, U>>, bool> = true>
+  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<T>& hComponent, U*& out_pComponent) const = delete;
 
   /// \brief Creates a new component init batch.
   /// It is ensured that the Initialize function is called for all components in a batch before the OnSimulationStarted is called.

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -183,7 +183,7 @@ public:
 
   /// \brief Explicitly delete TryGetComponent overload when handle type is not related to a pointer type given by out_pComponent.
   template <typename T, typename U, std::enable_if_t<!std::disjunction_v<std::is_convertible<T*, U*>, std::is_base_of<T, U>>, bool> = true>
-  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<T>& hComponent, U*& out_pComponent) const = delete;
+  [[nodiscard]] bool TryGetComponent(const ezTypedComponentHandle<T>& hComponent, const U*& out_pComponent) const = delete;
 
   /// \brief Creates a new component init batch.
   /// It is ensured that the Initialize function is called for all components in a batch before the OnSimulationStarted is called.

--- a/Code/UnitTests/CoreTest/World/ComponentTest.cpp
+++ b/Code/UnitTests/CoreTest/World/ComponentTest.cpp
@@ -197,6 +197,9 @@ EZ_CREATE_SIMPLE_TEST(World, Components)
     EZ_TEST_BOOL(pTest == pTestComponent);
     EZ_TEST_BOOL(pTestComponent->GetHandle() == handle);
 
+    TestComponent2* pTest2 = nullptr;
+    EZ_TEST_BOOL(!world.TryGetComponent(ezComponentHandle(handle), pTest2));
+
     EZ_TEST_INT(pTestComponent->m_iSomeData, 1);
     EZ_TEST_INT(TestComponent::s_iInitCounter, 0);
 

--- a/Code/UnitTests/CoreTest/World/ComponentTest.cpp
+++ b/Code/UnitTests/CoreTest/World/ComponentTest.cpp
@@ -197,9 +197,6 @@ EZ_CREATE_SIMPLE_TEST(World, Components)
     EZ_TEST_BOOL(pTest == pTestComponent);
     EZ_TEST_BOOL(pTestComponent->GetHandle() == handle);
 
-    TestComponent2* pTest2 = nullptr;
-    EZ_TEST_BOOL(!world.TryGetComponent(handle, pTest2));
-
     EZ_TEST_INT(pTestComponent->m_iSomeData, 1);
     EZ_TEST_INT(TestComponent::s_iInitCounter, 0);
 


### PR DESCRIPTION
Fixes https://github.com/ezEngine/ezEngine/issues/1259

If handle and pointer types are not related they will match a deleted TryGetComponent signature and therefore throw a compile time error. Otherwise, the untyped overload will be called.

By "related" I mean if handle type is convertible to the pointer type or if a handle type is a base of a pointer type (so querying a derived type from a handle to a base type is allowed).

~~Also removed a test that does not compile anymore and is now irrelevant. Tell me if you want me to replace it with some other test maybe?~~ Nevermind, the test is still useful.