### PR TITLE
ezPlayer prefix fix

### DIFF
--- a/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
+++ b/Code/Editor/EditorFramework/Project/Implementation/ProjectExport.cpp
@@ -361,7 +361,7 @@ ezResult ezProjectExport::CreateLaunchConfig(const ezDynamicArray<ezString>& sce
   for (const auto& sf : sceneFiles)
   {
     ezStringBuilder cmd;
-    cmd.SetFormat("start Bin/Player.exe -project \"Data/project\" -scene \"{}\"", sf);
+    cmd.SetFormat("start Bin/ezPlayer.exe -project \"Data/project\" -scene \"{}\"", sf);
 
     ezStringBuilder bat;
     bat.SetFormat("{}/Launch {}.bat", szTargetDirectory, ezPathUtils::GetFileName(sf));

--- a/Data/Base/CommonBinaries.ezExportFilter
+++ b/Data/Base/CommonBinaries.ezExportFilter
@@ -15,8 +15,8 @@
 
 [INCLUDE]
 
-#if PLATFORM_PROFILE_PC
-/Player.exe
+#if PLATFORM_PROFILE_DEFAULT
+/ezPlayer.exe
 /ezFoundation.dll
 /ezCore.dll
 /ezGameEngine.dll


### PR DESCRIPTION
Fixes project export errors. I'm still unable to launch exported project due to missing TracyClient.dll but i'm not sure how to fix it