### PR TITLE
Fix animation events being sent as const

### DIFF
--- a/Code/Engine/RendererCore/AnimationSystem/AnimPoseGenerator.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimPoseGenerator.h
@@ -215,7 +215,7 @@ public:
   ezAnimPoseGenerator();
   ~ezAnimPoseGenerator();
 
-  void Reset(const ezSkeletonResource* pSkeleton, const ezGameObject* pTarget);
+  void Reset(const ezSkeletonResource* pSkeleton, ezGameObject* pTarget);
 
   const ezSkeletonResource* GetSkeleton() const { return m_pSkeleton; }
   const ezGameObject* GetTargetObject() const { return m_pTargetGameObject; }
@@ -254,7 +254,7 @@ private:
   ezArrayPtr<ozz::math::SoaTransform> AcquireLocalPoseTransforms(ezAnimPoseGeneratorLocalPoseID id);
   ezArrayPtr<ezMat4> AcquireModelPoseTransforms(ezAnimPoseGeneratorModelPoseID id);
 
-  const ezGameObject* m_pTargetGameObject = nullptr;
+  ezGameObject* m_pTargetGameObject = nullptr;
   const ezSkeletonResource* m_pSkeleton = nullptr;
 
   ezArrayPtr<ezMat4> m_OutputPose;

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimPoseGenerator.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimPoseGenerator.cpp
@@ -16,7 +16,7 @@
 #include <ozz/base/maths/simd_quaternion.h>
 #include <ozz/base/span.h>
 
-void ezAnimPoseGenerator::Reset(const ezSkeletonResource* pSkeleton, const ezGameObject* pTarget)
+void ezAnimPoseGenerator::Reset(const ezSkeletonResource* pSkeleton, ezGameObject* pTarget)
 {
   m_pSkeleton = pSkeleton;
   m_pTargetGameObject = pTarget;


### PR DESCRIPTION
Which means the handler has to be a const method and therefore has limited usability. Also, if users unaware of this limitation would declare their message handlers as non-const then it would be silently ignored.