### PR TITLE
Mesh instance custom data

### DIFF
--- a/Code/Engine/Core/Messages/Implementation/SetColorMessage.cpp
+++ b/Code/Engine/Core/Messages/Implementation/SetColorMessage.cpp
@@ -18,6 +18,17 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgSetColor, 1, ezRTTIDefaultAllocator<ezMsgSe
   EZ_END_PROPERTIES;
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgSetCustomData);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgSetCustomData, 1, ezRTTIDefaultAllocator<ezMsgSetCustomData>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Data", m_vData),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 void ezMsgSetColor::ModifyColor(ezColor& ref_color) const
@@ -68,6 +79,18 @@ void ezMsgSetColor::Deserialize(ezStreamReader& inout_stream, ezUInt8 uiTypeVers
 {
   inout_stream >> m_Color;
   inout_stream >> m_Mode;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+void ezMsgSetCustomData::Serialize(ezStreamWriter& inout_stream) const
+{
+  inout_stream << m_vData;
+}
+
+void ezMsgSetCustomData::Deserialize(ezStreamReader& inout_stream, ezUInt8 uiTypeVersion)
+{
+  inout_stream >> m_vData;
 }
 
 

--- a/Code/Engine/Core/Messages/SetColorMessage.h
+++ b/Code/Engine/Core/Messages/SetColorMessage.h
@@ -47,3 +47,13 @@ struct EZ_CORE_DLL ezMsgSetColor : public ezMessage
   virtual void Serialize(ezStreamWriter& inout_stream) const override;
   virtual void Deserialize(ezStreamReader& inout_stream, ezUInt8 uiTypeVersion) override;
 };
+
+struct EZ_CORE_DLL ezMsgSetCustomData : public ezMessage
+{
+  EZ_DECLARE_MESSAGE_TYPE(ezMsgSetCustomData, ezMessage);
+
+  ezVec4 m_vData;
+
+  virtual void Serialize(ezStreamWriter& inout_stream) const override;
+  virtual void Deserialize(ezStreamReader& inout_stream, ezUInt8 uiTypeVersion) override;
+};

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -204,6 +204,7 @@ void ezLodAnimatedMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& 
       pRenderData->m_hMesh = hMesh;
       pRenderData->m_hMaterial = hMaterial;
       pRenderData->m_Color = m_Color;
+      pRenderData->m_vCustomData = m_vCustomData;
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
@@ -281,6 +282,13 @@ float ezLodAnimatedMeshComponent::GetSortingDepthOffset() const
 void ezLodAnimatedMeshComponent::OnMsgSetColor(ezMsgSetColor& ref_msg)
 {
   ref_msg.ModifyColor(m_Color);
+
+  InvalidateCachedRenderData();
+}
+
+void ezLodAnimatedMeshComponent::OnMsgSetCustomData(ezMsgSetCustomData& ref_msg)
+{
+  m_vCustomData = ref_msg.m_vData;
 
   InvalidateCachedRenderData();
 }

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -51,6 +51,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezLodAnimatedMeshComponent, 1, ezComponentMode::Static)
   {
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
     EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+    EZ_MESSAGE_HANDLER(ezMsgSetCustomData, OnMsgSetCustomData),
     EZ_MESSAGE_HANDLER(ezMsgAnimationPoseUpdated, OnAnimationPoseUpdated),
     EZ_MESSAGE_HANDLER(ezMsgQueryAnimationSkeleton, OnQueryAnimationSkeleton),
   }

--- a/Code/Engine/GameEngine/Animation/Skeletal/LodAnimatedMeshComponent.h
+++ b/Code/Engine/GameEngine/Animation/Skeletal/LodAnimatedMeshComponent.h
@@ -75,10 +75,11 @@ public:
   bool GetShowDebugInfo() const;     // [ property ]
 
   /// \brief Disabling the LOD range overlap functionality can make it easier to determine the desired coverage thresholds.
-  void SetOverlapRanges(bool bOverlap);       // [ property ]
-  bool GetOverlapRanges() const;              // [ property ]
+  void SetOverlapRanges(bool bOverlap);                 // [ property ]
+  bool GetOverlapRanges() const;                        // [ property ]
 
-  void OnMsgSetColor(ezMsgSetColor& ref_msg); // [ msg handler ]
+  void OnMsgSetColor(ezMsgSetColor& ref_msg);           // [ msg handler ]
+  void OnMsgSetCustomData(ezMsgSetCustomData& ref_msg); // [ msg handler ]
 
   void RetrievePose(ezDynamicArray<ezMat4>& out_modelTransforms, ezTransform& out_rootTransform, const ezSkeleton& skeleton);
 
@@ -89,6 +90,7 @@ protected:
   mutable ezInt32 m_iCurLod = 0;
   ezDynamicArray<ezLodAnimatedMeshLod> m_Meshes;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
   float m_fSortingDepthOffset = 0.0f;
   ezVec3 m_vBoundsOffset = ezVec3::MakeZero();
   float m_fBoundsRadius = 1.0f;

--- a/Code/Engine/GameEngine/Gameplay/GreyBoxComponent.h
+++ b/Code/Engine/GameEngine/Gameplay/GreyBoxComponent.h
@@ -17,6 +17,7 @@ struct ezMsgExtractOccluderData;
 struct ezMsgSetMeshMaterial;
 struct ezMsgSetColor;
 class ezMeshResourceDescriptor;
+struct ezMsgSetCustomData;
 using ezMeshResourceHandle = ezTypedResourceHandle<class ezMeshResource>;
 using ezMaterialResourceHandle = ezTypedResourceHandle<class ezMaterialResource>;
 
@@ -151,10 +152,12 @@ protected:
 
   void OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& ref_msg); // [ msg handler ]
   void OnMsgSetColor(ezMsgSetColor& ref_msg);               // [ msg handler ]
+  void OnMsgSetCustomData(ezMsgSetCustomData& ref_msg);     // [ msg handler ]
 
   ezEnum<ezGreyBoxShape> m_Shape;
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
   float m_fSizeNegX = 0;
   float m_fSizePosX = 0;
   float m_fSizeNegY = 0;

--- a/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
@@ -196,6 +196,7 @@ void ezGreyBoxComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) con
       pRenderData->m_hMesh = m_hMesh;
       pRenderData->m_hMaterial = hMaterial;
       pRenderData->m_Color = m_Color;
+      pRenderData->m_vCustomData = m_vCustomData;
 
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiFlipWinding = uiFlipWinding;
@@ -444,6 +445,13 @@ void ezGreyBoxComponent::OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& ref_msg)
 void ezGreyBoxComponent::OnMsgSetColor(ezMsgSetColor& ref_msg)
 {
   ref_msg.ModifyColor(m_Color);
+
+  InvalidateCachedRenderData();
+}
+
+void ezGreyBoxComponent::OnMsgSetCustomData(ezMsgSetCustomData& ref_msg)
+{
+  m_vCustomData = ref_msg.m_vData;
 
   InvalidateCachedRenderData();
 }

--- a/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
@@ -62,6 +62,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezGreyBoxComponent, 6, ezComponentMode::Static)
     EZ_MESSAGE_HANDLER(ezMsgExtractOccluderData, OnMsgExtractOccluderData),
     EZ_MESSAGE_HANDLER(ezMsgSetMeshMaterial, OnMsgSetMeshMaterial),
     EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+    EZ_MESSAGE_HANDLER(ezMsgSetCustomData, OnMsgSetCustomData),
   }
   EZ_END_MESSAGEHANDLERS;
 }

--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -102,6 +102,7 @@ public:
   ezDynamicMeshBufferResourceHandle m_hMesh;
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_CustomData = ezVec4::MakeZero();
 
   ezUInt32 m_uiFlipWinding : 1;
   ezUInt32 m_uiUniformScale : 1;

--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -76,12 +76,14 @@ public:
 
   void OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& ref_msg); // [ msg handler ]
   void OnMsgSetColor(ezMsgSetColor& ref_msg);               // [ msg handler ]
+  void OnMsgSetCustomData(ezMsgSetCustomData& ref_msg);     // [ msg handler ]
 
 protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
 
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
   ezUInt32 m_uiFirstPrimitive = 0;
   ezUInt32 m_uiNumPrimitives = 0xFFFFFFFF;
   ezBoundingBoxSphere m_Bounds;
@@ -102,7 +104,7 @@ public:
   ezDynamicMeshBufferResourceHandle m_hMesh;
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
-  ezVec4 m_CustomData = ezVec4::MakeZero();
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
 
   ezUInt32 m_uiFlipWinding : 1;
   ezUInt32 m_uiUniformScale : 1;

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -34,6 +34,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezCustomMeshComponent, 2, ezComponentMode::Static)
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
     EZ_MESSAGE_HANDLER(ezMsgSetMeshMaterial, OnMsgSetMeshMaterial),
     EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+    EZ_MESSAGE_HANDLER(ezMsgSetCustomData, OnMsgSetCustomData),
   } EZ_END_MESSAGEHANDLERS;
 }
 EZ_END_COMPONENT_TYPE

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -333,6 +333,7 @@ void ezCustomMeshRenderer::RenderBatch(const ezRenderViewContext& renderViewCont
 
     instanceData[0].GameObjectID = pRenderData->m_uiUniqueID;
     instanceData[0].Color = pRenderData->m_Color;
+    instanceData[0].CustomData = pRenderData->m_CustomData;
     instanceData[0].ObjectToWorld = pRenderData->m_GlobalTransform;
 
     if (pRenderData->m_uiUniformScale)

--- a/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/CustomMeshComponent.cpp
@@ -171,6 +171,13 @@ void ezCustomMeshComponent::OnMsgSetColor(ezMsgSetColor& ref_msg)
   InvalidateCachedRenderData();
 }
 
+void ezCustomMeshComponent::OnMsgSetCustomData(ezMsgSetCustomData& ref_msg)
+{
+  m_vCustomData = ref_msg.m_vData;
+
+  InvalidateCachedRenderData();
+}
+
 void ezCustomMeshComponent::SetUsePrimitiveRange(ezUInt32 uiFirstPrimitive /*= 0*/, ezUInt32 uiNumPrimitives /*= ezMath::MaxValue<ezUInt32>()*/)
 {
   m_uiFirstPrimitive = uiFirstPrimitive;
@@ -191,6 +198,7 @@ void ezCustomMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
     pRenderData->m_hMesh = m_hDynamicMesh;
     pRenderData->m_hMaterial = m_hMaterial;
     pRenderData->m_Color = m_Color;
+    pRenderData->m_vCustomData = m_vCustomData;
     pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
     pRenderData->m_uiFirstPrimitive = ezMath::Min(m_uiFirstPrimitive, pMesh->GetDescriptor().m_uiMaxPrimitives);
     pRenderData->m_uiNumPrimitives = ezMath::Min(m_uiNumPrimitives, pMesh->GetDescriptor().m_uiMaxPrimitives - pRenderData->m_uiFirstPrimitive);
@@ -333,7 +341,7 @@ void ezCustomMeshRenderer::RenderBatch(const ezRenderViewContext& renderViewCont
 
     instanceData[0].GameObjectID = pRenderData->m_uiUniqueID;
     instanceData[0].Color = pRenderData->m_Color;
-    instanceData[0].CustomData = pRenderData->m_CustomData;
+    instanceData[0].CustomData = pRenderData->m_vCustomData;
     instanceData[0].ObjectToWorld = pRenderData->m_GlobalTransform;
 
     if (pRenderData->m_uiUniformScale)

--- a/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
@@ -351,6 +351,7 @@ ezArrayPtr<ezPerInstanceData> ezInstancedMeshComponent::GetInstanceData() const
     instanceData[i].BoundingSphereRadius = fBoundingSphereRadius * m_RawInstancedData[i].m_transform.GetMaxScale();
 
     instanceData[i].Color = m_Color * m_RawInstancedData[i].m_color;
+    instanceData[i].CustomData.SetZero(); // unused
   }
 
   return instanceData;

--- a/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
@@ -45,6 +45,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezLodMeshComponent, 1, ezComponentMode::Static)
   {
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
     EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+    EZ_MESSAGE_HANDLER(ezMsgSetCustomData, OnMsgSetCustomData),
   }
   EZ_END_MESSAGEHANDLERS;
 }

--- a/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
@@ -196,6 +196,7 @@ void ezLodMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) con
       pRenderData->m_hMesh = hMesh;
       pRenderData->m_hMaterial = hMaterial;
       pRenderData->m_Color = m_Color;
+      pRenderData->m_vCustomData = m_vCustomData;
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
@@ -242,6 +243,13 @@ float ezLodMeshComponent::GetSortingDepthOffset() const
 void ezLodMeshComponent::OnMsgSetColor(ezMsgSetColor& ref_msg)
 {
   ref_msg.ModifyColor(m_Color);
+
+  InvalidateCachedRenderData();
+}
+
+void ezLodMeshComponent::OnMsgSetCustomData(ezMsgSetCustomData& ref_msg)
+{
+  m_vCustomData = ref_msg.m_vData;
 
   InvalidateCachedRenderData();
 }

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
@@ -86,6 +86,7 @@ EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezMeshComponentBase, 3)
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
     EZ_MESSAGE_HANDLER(ezMsgSetMeshMaterial, OnMsgSetMeshMaterial),
     EZ_MESSAGE_HANDLER(ezMsgSetColor, OnMsgSetColor),
+    EZ_MESSAGE_HANDLER(ezMsgSetCustomData, OnMsgSetCustomData),
   } EZ_END_MESSAGEHANDLERS;
 }
 EZ_END_ABSTRACT_COMPONENT_TYPE;
@@ -185,6 +186,7 @@ void ezMeshComponentBase::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) co
       pRenderData->m_hMesh = m_hMesh;
       pRenderData->m_hMaterial = hMaterial;
       pRenderData->m_Color = m_Color;
+      pRenderData->m_vCustomData = m_vCustomData;
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
@@ -272,6 +274,16 @@ const ezColor& ezMeshComponentBase::GetColor() const
   return m_Color;
 }
 
+void ezMeshComponentBase::SetCustomData(const ezVec4& vData)
+{
+  m_vCustomData = vData;
+}
+
+const ezVec4& ezMeshComponentBase::GetCustomData() const
+{
+  return m_vCustomData;
+}
+
 void ezMeshComponentBase::SetSortingDepthOffset(float fOffset)
 {
   m_fSortingDepthOffset = fOffset;
@@ -293,6 +305,12 @@ void ezMeshComponentBase::OnMsgSetColor(ezMsgSetColor& ref_msg)
 {
   ref_msg.ModifyColor(m_Color);
 
+  InvalidateCachedRenderData();
+}
+
+void ezMeshComponentBase::OnMsgSetCustomData(ezMsgSetCustomData& ref_msg)
+{
+  m_vCustomData = ref_msg.m_vData;
   InvalidateCachedRenderData();
 }
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshRendererUtils.h
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshRendererUtils.h
@@ -32,5 +32,6 @@ namespace ezInternal
     ref_perInstanceData.GameObjectID = pRenderData->m_uiUniqueID;
     ref_perInstanceData.VertexColorAccessData = 0;
     ref_perInstanceData.Color = pRenderData->m_Color;
+    ref_perInstanceData.CustomData = pRenderData->m_vCustomData;
   }
 } // namespace ezInternal

--- a/Code/Engine/RendererCore/Meshes/LodMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/LodMeshComponent.h
@@ -64,10 +64,11 @@ public:
   bool GetShowDebugInfo() const;     // [ property ]
 
   /// \brief Disabling the LOD range overlap functionality can make it easier to determine the desired coverage thresholds.
-  void SetOverlapRanges(bool bOverlap);       // [ property ]
-  bool GetOverlapRanges() const;              // [ property ]
+  void SetOverlapRanges(bool bOverlap);                 // [ property ]
+  bool GetOverlapRanges() const;                        // [ property ]
 
-  void OnMsgSetColor(ezMsgSetColor& ref_msg); // [ msg handler ]
+  void OnMsgSetColor(ezMsgSetColor& ref_msg);           // [ msg handler ]
+  void OnMsgSetCustomData(ezMsgSetCustomData& ref_msg); // [ msg handler ]
 
 protected:
   virtual ezMeshRenderData* CreateRenderData() const;
@@ -78,6 +79,7 @@ protected:
   mutable ezInt32 m_iCurLod = 0;
   ezDynamicArray<ezLodMeshLod> m_Meshes;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
   float m_fSortingDepthOffset = 0.0f;
   ezVec3 m_vBoundsOffset = ezVec3::MakeZero();
   float m_fBoundsRadius = 1.0f;

--- a/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
+++ b/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
@@ -7,6 +7,7 @@
 #include <RendererCore/Pipeline/RenderData.h>
 
 struct ezMsgSetColor;
+struct ezMsgSetCustomData;
 struct ezInstanceData;
 
 class EZ_RENDERERCORE_DLL ezMeshRenderData : public ezRenderData
@@ -19,6 +20,7 @@ public:
   ezMeshResourceHandle m_hMesh;
   ezMaterialResourceHandle m_hMaterial;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
 
   ezUInt32 m_uiSubMeshIndex : 30;
   ezUInt32 m_uiFlipWinding : 1;
@@ -102,6 +104,10 @@ public:
   void SetColor(const ezColor& color); // [ property ]
   const ezColor& GetColor() const;     // [ property ]
 
+  /// \brief An additional vec4 passed to the renderer that can be used by custom material shaders for effects.
+  void SetCustomData(const ezVec4& vData); // [ property ]
+  const ezVec4& GetCustomData() const;     // [ property ]
+
   /// \brief The sorting depth offset allows to tweak the order in which this mesh is rendered relative to other meshes.
   ///
   /// This is mainly useful for transparent objects to render them before or after other meshes.
@@ -110,6 +116,7 @@ public:
 
   void OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& ref_msg); // [ msg handler ]
   void OnMsgSetColor(ezMsgSetColor& ref_msg);               // [ msg handler ]
+  void OnMsgSetCustomData(ezMsgSetCustomData& ref_msg);     // [ msg handler ]
 
 protected:
   virtual ezMeshRenderData* CreateRenderData() const;
@@ -125,5 +132,6 @@ protected:
   ezMeshResourceHandle m_hMesh;
   ezDynamicArray<ezMaterialResourceHandle> m_Materials;
   ezColor m_Color = ezColor::White;
+  ezVec4 m_vCustomData = ezVec4::MakeZero();
   float m_fSortingDepthOffset = 0.0f;
 };

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -503,6 +503,7 @@ void ezClothSheetRenderer::RenderBatch(const ezRenderViewContext& renderViewCont
     instanceData[0].ObjectToWorldNormal = instanceData[0].ObjectToWorld;
     instanceData[0].GameObjectID = pRenderData->m_uiUniqueID;
     instanceData[0].Color = pRenderData->m_Color;
+    instanceData[0].CustomData.SetZero(); // unused
 
     pInstanceData->UpdateInstanceData(pRenderContext, 1);
 

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltClothSheetComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltClothSheetComponent.cpp
@@ -683,6 +683,7 @@ void ezJoltClothSheetRenderer::RenderBatch(const ezRenderViewContext& renderView
     instanceData[0].ObjectToWorldNormal = instanceData[0].ObjectToWorld;
     instanceData[0].GameObjectID = pRenderData->m_uiUniqueID;
     instanceData[0].Color = pRenderData->m_Color;
+    instanceData[0].CustomData.SetZero(); // unused
 
     pInstanceData->UpdateInstanceData(pRenderContext, 1);
 

--- a/Code/EnginePlugins/KrautPlugin/Renderer/KrautRenderer.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Renderer/KrautRenderer.cpp
@@ -128,6 +128,7 @@ void ezKrautRenderer::FillPerInstanceData(const ezVec3& vLodCamPos, ezArrayPtr<e
     perInstanceData.ObjectToWorldNormal = objectToWorld;
     perInstanceData.GameObjectID = pRenderData->m_uiUniqueID;
     perInstanceData.Color = ezColor(pRenderData->m_vWindTrunk.x, pRenderData->m_vWindTrunk.y, pRenderData->m_vWindTrunk.z, pRenderData->m_vWindTrunk.GetLength());
+    perInstanceData.CustomData.SetZero(); // unused
 
     ++uiCurrentIndex;
   }

--- a/Data/Base/RenderPipelines/MainRenderPipeline.ezRenderPipelineAsset
+++ b/Data/Base/RenderPipelines/MainRenderPipeline.ezRenderPipelineAsset
@@ -11,7 +11,7 @@ o
 		s %AssetType{"RenderPipeline"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{12099190295688988325,5711173786673602835}}
-		u4 %Hash{16749140966956909268}
+		u4 %Hash{16451222835697307961}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -480,7 +480,7 @@ o
 		Color %HighlightColor{f{0xBEB1423F,0xA135683E,0x04BF123D,0x0000803F}}
 		s %Name{""}
 		Vec2 %Node::Pos{f{0x8E281D44,0x4E465CC3}}
-		f %OverlayOpacity{0xCDCCCC3D}
+		f %OverlayOpacity{0}
 	}
 }
 o

--- a/Data/Base/Shaders/Common/ObjectConstants.h
+++ b/Data/Base/Shaders/Common/ObjectConstants.h
@@ -13,6 +13,7 @@ struct EZ_SHADER_STRUCT ezPerInstanceData
 
   INT1(Reserved);
   COLOR4F(Color);
+  FLOAT4(CustomData);
 };
 
 #if EZ_ENABLED(PLATFORM_SHADER)
@@ -28,7 +29,7 @@ Buffer<uint> perInstanceVertexColors;
 
 EZ_DEFINE_AS_POD_TYPE(ezPerInstanceData);
 
-EZ_CHECK_AT_COMPILETIME(sizeof(ezPerInstanceData) == 128);
+EZ_CHECK_AT_COMPILETIME(sizeof(ezPerInstanceData) == 144);
 #endif
 
 CONSTANT_BUFFER(ezObjectConstants, 2)

--- a/Data/Tools/ezEditor/ShaderTemplates/PBR.ezShaderTemplate
+++ b/Data/Tools/ezEditor/ShaderTemplates/PBR.ezShaderTemplate
@@ -149,11 +149,12 @@ CONSTANT_BUFFER(ezMaterialConstants, 1)
   FLOAT1(MaskThreshold);
 %endif
   BOOL1(UseBaseTexture);
-  BOOL1(UseMetallicTexture);
   BOOL1(UseNormalTexture);
   BOOL1(UseRoughnessTexture);
+  BOOL1(UseMetallicTexture);
   BOOL1(UseEmissiveTexture);
   BOOL1(UseOcclusionTexture);
+  BOOL1(UseOrmTexture);
 };
 
 [VERTEXSHADER]

--- a/Data/Tools/ezEditor/VisualShader/Inputs.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Inputs.ddl
@@ -322,6 +322,13 @@ Node %InstanceData
     string %Tooltip { "Per instance color." }
   }
   
+  OutputPin %CustomData
+  {
+    string %Type { "float4" }
+    unsigned_int8 %Color { 200, 200, 200 }
+    string %Inline { "GetInstanceData().CustomData" }
+    string %Tooltip { "Per instance custom data" }
+  }
 }
 
 Node %Camera


### PR DESCRIPTION
Adds an additional vec4 as custom per mesh instance data, for passing custom data to materials, for advanced effects.

The custom data can either be set directly on the mesh instance, or sent via a message.

This means one can continue to use the per-instance color, and also doesn't have to change all objects to NOT use the per-instance color, because the color was previously the only way to pass custom data to materials.