### PR TITLE
Render Buffer Refactor and SRV / UAV split

### DIFF
--- a/Code/EditorPlugins/Scene/EnginePluginScene/Grid/GridRenderer.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/Grid/GridRenderer.cpp
@@ -59,7 +59,7 @@ void ezGridRenderer::CreateVertexBuffer()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(GridVertex);
     desc.m_uiTotalSize = s_uiBufferSize;
-    desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::VertexBuffer;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hVertexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/EditorPlugins/Scene/EnginePluginScene/Grid/GridRenderer.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/Grid/GridRenderer.cpp
@@ -59,7 +59,7 @@ void ezGridRenderer::CreateVertexBuffer()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(GridVertex);
     desc.m_uiTotalSize = s_uiBufferSize;
-    desc.m_BufferType = ezGALBufferType::VertexBuffer;
+    desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hVertexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
@@ -220,7 +220,7 @@ void ezImguiRenderer::SetupRenderer()
   // Create the vertex buffer
   {
     ezGALBufferCreationDescription desc;
-    desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::VertexBuffer;
 
     desc.m_uiStructSize = sizeof(ezImguiVertex);
     desc.m_uiTotalSize = s_uiVertexBufferSize * desc.m_uiStructSize;
@@ -234,7 +234,7 @@ void ezImguiRenderer::SetupRenderer()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ImDrawIdx);
     desc.m_uiTotalSize = s_uiIndexBufferSize * desc.m_uiStructSize;
-    desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::IndexBuffer;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hIndexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
@@ -220,9 +220,10 @@ void ezImguiRenderer::SetupRenderer()
   // Create the vertex buffer
   {
     ezGALBufferCreationDescription desc;
+    desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
+
     desc.m_uiStructSize = sizeof(ezImguiVertex);
     desc.m_uiTotalSize = s_uiVertexBufferSize * desc.m_uiStructSize;
-    desc.m_BufferType = ezGALBufferType::VertexBuffer;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hVertexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);
@@ -233,7 +234,7 @@ void ezImguiRenderer::SetupRenderer()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ImDrawIdx);
     desc.m_uiTotalSize = s_uiIndexBufferSize * desc.m_uiStructSize;
-    desc.m_BufferType = ezGALBufferType::IndexBuffer;
+    desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hIndexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
+++ b/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
@@ -127,7 +127,7 @@ void ezWindowOutputTargetXR::RenderCompanionView(bool bThrottleCompanionView)
     auto* constants = ezRenderContext::GetConstantBufferData<ezVRCompanionViewConstants>(m_hCompanionConstantBuffer);
     constants->TargetSize = targetSize;
 
-    ezGALResourceViewHandle hInputView = pDevice->GetDefaultResourceView(m_hColorRT);
+    ezGALTextureResourceViewHandle hInputView = pDevice->GetDefaultResourceView(m_hColorRT);
     m_pRenderContext->BindTexture2D("VRTexture", hInputView);
     m_pRenderContext->DrawMeshBuffer().IgnoreResult();
 

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareRenderer.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareRenderer.cpp
@@ -64,9 +64,7 @@ ezGALBufferHandle ezLensFlareRenderer::CreateLensFlareDataBuffer(ezUInt32 uiBuff
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = sizeof(ezPerLensFlareData);
   desc.m_uiTotalSize = desc.m_uiStructSize * uiBufferSize;
-  desc.m_BufferType = ezGALBufferType::Generic;
-  desc.m_bUseAsStructuredBuffer = true;
-  desc.m_bAllowShaderResourceView = true;
+  desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   return ezGPUResourcePool::GetDefaultInstance()->GetBuffer(desc);

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareRenderer.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareRenderer.cpp
@@ -64,7 +64,7 @@ ezGALBufferHandle ezLensFlareRenderer::CreateLensFlareDataBuffer(ezUInt32 uiBuff
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = sizeof(ezPerLensFlareData);
   desc.m_uiTotalSize = desc.m_uiStructSize * uiBufferSize;
-  desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   return ezGPUResourcePool::GetDefaultInstance()->GetBuffer(desc);

--- a/Code/Engine/RendererCore/Components/Implementation/SpriteRenderer.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SpriteRenderer.cpp
@@ -71,7 +71,7 @@ ezGALBufferHandle ezSpriteRenderer::CreateSpriteDataBuffer(ezUInt32 uiBufferSize
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = sizeof(ezPerSpriteData);
   desc.m_uiTotalSize = desc.m_uiStructSize * uiBufferSize;
-  desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   return ezGPUResourcePool::GetDefaultInstance()->GetBuffer(desc);

--- a/Code/Engine/RendererCore/Components/Implementation/SpriteRenderer.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SpriteRenderer.cpp
@@ -71,9 +71,7 @@ ezGALBufferHandle ezSpriteRenderer::CreateSpriteDataBuffer(ezUInt32 uiBufferSize
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = sizeof(ezPerSpriteData);
   desc.m_uiTotalSize = desc.m_uiStructSize * uiBufferSize;
-  desc.m_BufferType = ezGALBufferType::Generic;
-  desc.m_bUseAsStructuredBuffer = true;
-  desc.m_bAllowShaderResourceView = true;
+  desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   return ezGPUResourcePool::GetDefaultInstance()->GetBuffer(desc);

--- a/Code/Engine/RendererCore/Debug/DebugRenderer.h
+++ b/Code/Engine/RendererCore/Debug/DebugRenderer.h
@@ -158,7 +158,7 @@ public:
   static void Draw2DRectangle(const ezDebugRendererContext& context, const ezRectFloat& rectInPixel, float fDepth, const ezColor& color, const ezTexture2DResourceHandle& hTexture, ezVec2 vScale = ezVec2(1, 1));
 
   /// \brief Renders a textured 2D rectangle in screen-space for one frame.
-  static void Draw2DRectangle(const ezDebugRendererContext& context, const ezRectFloat& rectInPixel, float fDepth, const ezColor& color, ezGALResourceViewHandle hResourceView, ezVec2 vScale = ezVec2(1, 1));
+  static void Draw2DRectangle(const ezDebugRendererContext& context, const ezRectFloat& rectInPixel, float fDepth, const ezColor& color, ezGALTextureResourceViewHandle hResourceView, ezVec2 vScale = ezVec2(1, 1));
 
   /// \brief Displays a string in screen-space for one frame.
   ///

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -238,7 +238,7 @@ namespace
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = uiStructSize;
       desc.m_uiTotalSize = DEBUG_BUFFER_SIZE;
-      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       s_hDataBuffer[bufferType] = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);
@@ -252,7 +252,7 @@ namespace
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = uiVertexSize;
       desc.m_uiTotalSize = DEBUG_BUFFER_SIZE;
-      desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::VertexBuffer;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       s_hDataBuffer[bufferType] = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -238,9 +238,7 @@ namespace
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = uiStructSize;
       desc.m_uiTotalSize = DEBUG_BUFFER_SIZE;
-      desc.m_BufferType = ezGALBufferType::Generic;
-      desc.m_bUseAsStructuredBuffer = true;
-      desc.m_bAllowShaderResourceView = true;
+      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       s_hDataBuffer[bufferType] = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);
@@ -254,7 +252,7 @@ namespace
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = uiVertexSize;
       desc.m_uiTotalSize = DEBUG_BUFFER_SIZE;
-      desc.m_BufferType = ezGALBufferType::VertexBuffer;
+      desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       s_hDataBuffer[bufferType] = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -114,8 +114,8 @@ namespace
     ezDynamicArray<Vertex, ezAlignedAllocatorWrapper> m_line2DVertices;
     ezDynamicArray<BoxData, ezAlignedAllocatorWrapper> m_lineBoxes;
     ezDynamicArray<BoxData, ezAlignedAllocatorWrapper> m_solidBoxes;
-    ezMap<ezGALResourceViewHandle, ezDynamicArray<TexVertex, ezAlignedAllocatorWrapper>> m_texTriangle2DVertices;
-    ezMap<ezGALResourceViewHandle, ezDynamicArray<TexVertex, ezAlignedAllocatorWrapper>> m_texTriangle3DVertices;
+    ezMap<ezGALTextureResourceViewHandle, ezDynamicArray<TexVertex, ezAlignedAllocatorWrapper>> m_texTriangle2DVertices;
+    ezMap<ezGALTextureResourceViewHandle, ezDynamicArray<TexVertex, ezAlignedAllocatorWrapper>> m_texTriangle3DVertices;
 
     ezDynamicArray<InfoTextData> m_infoTextData[(int)ezDebugTextPlacement::ENUM_COUNT];
     ezDynamicArray<TextLineData2D> m_textLines2D;
@@ -954,7 +954,7 @@ void ezDebugRenderer::Draw2DRectangle(const ezDebugRendererContext& context, con
   Draw2DRectangle(context, rectInPixel, fDepth, color, ezGALDevice::GetDefaultDevice()->GetDefaultResourceView(pTexture->GetGALTexture()), vScale);
 }
 
-void ezDebugRenderer::Draw2DRectangle(const ezDebugRendererContext& context, const ezRectFloat& rectInPixel, float fDepth, const ezColor& color, ezGALResourceViewHandle hResourceView, ezVec2 vScale)
+void ezDebugRenderer::Draw2DRectangle(const ezDebugRendererContext& context, const ezRectFloat& rectInPixel, float fDepth, const ezColor& color, ezGALTextureResourceViewHandle hResourceView, ezVec2 vScale)
 {
   TexVertex vertices[6];
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
@@ -21,9 +21,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     {
       desc.m_uiStructSize = sizeof(ezPerLightData);
       desc.m_uiTotalSize = desc.m_uiStructSize * ezClusteredDataCPU::MAX_LIGHT_DATA;
-      desc.m_BufferType = ezGALBufferType::Generic;
-      desc.m_bUseAsStructuredBuffer = true;
-      desc.m_bAllowShaderResourceView = true;
+      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hLightDataBuffer = pDevice->CreateBuffer(desc);
@@ -32,9 +30,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     {
       desc.m_uiStructSize = sizeof(ezPerDecalData);
       desc.m_uiTotalSize = desc.m_uiStructSize * ezClusteredDataCPU::MAX_DECAL_DATA;
-      desc.m_BufferType = ezGALBufferType::Generic;
-      desc.m_bUseAsStructuredBuffer = true;
-      desc.m_bAllowShaderResourceView = true;
+      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hDecalDataBuffer = pDevice->CreateBuffer(desc);
@@ -43,9 +39,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     {
       desc.m_uiStructSize = sizeof(ezPerReflectionProbeData);
       desc.m_uiTotalSize = desc.m_uiStructSize * ezClusteredDataCPU::MAX_REFLECTION_PROBE_DATA;
-      desc.m_BufferType = ezGALBufferType::Generic;
-      desc.m_bUseAsStructuredBuffer = true;
-      desc.m_bAllowShaderResourceView = true;
+      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hReflectionProbeDataBuffer = pDevice->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
@@ -21,7 +21,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     {
       desc.m_uiStructSize = sizeof(ezPerLightData);
       desc.m_uiTotalSize = desc.m_uiStructSize * ezClusteredDataCPU::MAX_LIGHT_DATA;
-      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hLightDataBuffer = pDevice->CreateBuffer(desc);
@@ -30,7 +30,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     {
       desc.m_uiStructSize = sizeof(ezPerDecalData);
       desc.m_uiTotalSize = desc.m_uiStructSize * ezClusteredDataCPU::MAX_DECAL_DATA;
-      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hDecalDataBuffer = pDevice->CreateBuffer(desc);
@@ -39,7 +39,7 @@ ezClusteredDataGPU::ezClusteredDataGPU()
     {
       desc.m_uiStructSize = sizeof(ezPerReflectionProbeData);
       desc.m_uiTotalSize = desc.m_uiStructSize * ezClusteredDataCPU::MAX_REFLECTION_PROBE_DATA;
-      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hReflectionProbeDataBuffer = pDevice->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -325,7 +325,7 @@ struct ezShadowPool::Data
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = sizeof(ezVec4);
       desc.m_uiTotalSize = desc.m_uiStructSize * MAX_SHADOW_DATA;
-      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hShadowDataBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -325,9 +325,7 @@ struct ezShadowPool::Data
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = sizeof(ezVec4);
       desc.m_uiTotalSize = desc.m_uiStructSize * MAX_SHADOW_DATA;
-      desc.m_BufferType = ezGALBufferType::Generic;
-      desc.m_bUseAsStructuredBuffer = true;
-      desc.m_bAllowShaderResourceView = true;
+      desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
       desc.m_ResourceAccess.m_bImmutable = false;
 
       m_hShadowDataBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -47,7 +47,7 @@ void ezSkinningState::TransformsChanged()
     ezGALBufferCreationDescription BufferDesc;
     BufferDesc.m_uiStructSize = sizeof(ezShaderTransform);
     BufferDesc.m_uiTotalSize = BufferDesc.m_uiStructSize * m_Transforms.GetCount();
-    BufferDesc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+    BufferDesc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
     BufferDesc.m_ResourceAccess.m_bImmutable = false;
 
     m_hGpuBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(BufferDesc, m_Transforms.GetArrayPtr().ToByteArray());

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -47,8 +47,7 @@ void ezSkinningState::TransformsChanged()
     ezGALBufferCreationDescription BufferDesc;
     BufferDesc.m_uiStructSize = sizeof(ezShaderTransform);
     BufferDesc.m_uiTotalSize = BufferDesc.m_uiStructSize * m_Transforms.GetCount();
-    BufferDesc.m_bUseAsStructuredBuffer = true;
-    BufferDesc.m_bAllowShaderResourceView = true;
+    BufferDesc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
     BufferDesc.m_ResourceAccess.m_bImmutable = false;
 
     m_hGpuBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(BufferDesc, m_Transforms.GetArrayPtr().ToByteArray());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
@@ -73,7 +73,7 @@ void ezInstanceData::CreateBuffer(ezUInt32 uiSize)
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = sizeof(ezPerInstanceData);
   desc.m_uiTotalSize = desc.m_uiStructSize * uiSize;
-  desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   m_hInstanceDataBuffer = pDevice->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
@@ -73,9 +73,7 @@ void ezInstanceData::CreateBuffer(ezUInt32 uiSize)
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = sizeof(ezPerInstanceData);
   desc.m_uiTotalSize = desc.m_uiStructSize * uiSize;
-  desc.m_BufferType = ezGALBufferType::Generic;
-  desc.m_bUseAsStructuredBuffer = true;
-  desc.m_bAllowShaderResourceView = true;
+  desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   m_hInstanceDataBuffer = pDevice->CreateBuffer(desc);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
@@ -123,7 +123,7 @@ void ezAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezArr
   // Find temp targets
   ezGALTextureHandle hzbTexture;
   ezHybridArray<ezVec2, 8> hzbSizes;
-  ezHybridArray<ezGALResourceViewHandle, 8> hzbResourceViews;
+  ezHybridArray<ezGALTextureResourceViewHandle, 8> hzbResourceViews;
   ezHybridArray<ezGALRenderTargetViewHandle, 8> hzbRenderTargetViews;
 
   ezGALTextureHandle tempSSAOTexture;
@@ -151,7 +151,7 @@ void ezAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezArr
       hzbSizes.PushBack(ezVec2((float)uiHzbWidth, (float)uiHzbHeight));
 
       {
-        ezGALResourceViewCreationDescription desc;
+        ezGALTextureResourceViewCreationDescription desc;
         desc.m_hTexture = hzbTexture;
         desc.m_uiMostDetailedMipLevel = i;
         desc.m_uiMipLevelsToUse = 1;
@@ -179,7 +179,7 @@ void ezAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezArr
 
     for (ezUInt32 i = 0; i < uiNumMips; ++i)
     {
-      ezGALResourceViewHandle hInputView;
+      ezGALTextureResourceViewHandle hInputView;
       ezVec2 pixelSize;
 
       if (i == 0)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlurPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlurPass.cpp
@@ -81,9 +81,9 @@ void ezBlurPass::Execute(const ezRenderViewContext& renderViewContext, const ezA
     auto pCommandEncoder = ezRenderContext::BeginPassAndRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());
 
     // Setup input view and sampler
-    ezGALResourceViewCreationDescription rvcd;
+    ezGALTextureResourceViewCreationDescription rvcd;
     rvcd.m_hTexture = inputs[m_PinInput.m_uiInputIndex]->m_TextureHandle;
-    ezGALResourceViewHandle hResourceView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
+    ezGALTextureResourceViewHandle hResourceView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
 
     // Bind shader and inputs
     renderViewContext.m_pRenderContext->BindShader(m_hShader);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -405,12 +405,7 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       ezGALBufferCreationDescription bufferDesc;
       bufferDesc.m_uiStructSize = 4;
       bufferDesc.m_uiTotalSize = imageResolution.z * 2 * totalNumberOfSamples;
-      bufferDesc.m_BufferType = ezGALBufferType::Generic;
-      bufferDesc.m_bUseForIndirectArguments = false;
-      bufferDesc.m_bUseAsStructuredBuffer = false;
-      bufferDesc.m_bAllowRawViews = false;
-      bufferDesc.m_bAllowShaderResourceView = true;
-      bufferDesc.m_bAllowUAV = true;
+      bufferDesc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource | ezGALBufferFlags::UnorderedAccess;
       bufferDesc.m_ResourceAccess.m_bReadBack = false;
       bufferDesc.m_ResourceAccess.m_bImmutable = false;
 
@@ -439,12 +434,7 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       ezGALBufferCreationDescription bufferDesc;
       bufferDesc.m_uiStructSize = sizeof(LineInstruction);
       bufferDesc.m_uiTotalSize = sizeof(LineInstruction) * m_uiNumSweepLines;
-      bufferDesc.m_BufferType = ezGALBufferType::Generic;
-      bufferDesc.m_bUseForIndirectArguments = false;
-      bufferDesc.m_bUseAsStructuredBuffer = true;
-      bufferDesc.m_bAllowRawViews = false;
-      bufferDesc.m_bAllowShaderResourceView = true;
-      bufferDesc.m_bAllowUAV = false;
+      bufferDesc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
       bufferDesc.m_ResourceAccess.m_bReadBack = false;
       bufferDesc.m_ResourceAccess.m_bImmutable = true;
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -420,7 +420,7 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       uavDesc.m_bAppend = false;
       m_hLineSweepOutputUAV = device->CreateUnorderedAccessView(uavDesc);
 
-      ezGALResourceViewCreationDescription srvDesc;
+      ezGALBufferResourceViewCreationDescription srvDesc;
       srvDesc.m_hBuffer = m_hLineSweepOutputBuffer;
       srvDesc.m_OverrideViewFormat = ezGALResourceFormat::RUInt;
       srvDesc.m_uiFirstElement = 0;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -405,7 +405,7 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       ezGALBufferCreationDescription bufferDesc;
       bufferDesc.m_uiStructSize = 4;
       bufferDesc.m_uiTotalSize = imageResolution.z * 2 * totalNumberOfSamples;
-      bufferDesc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource | ezGALBufferFlags::UnorderedAccess;
+      bufferDesc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
       bufferDesc.m_ResourceAccess.m_bReadBack = false;
       bufferDesc.m_ResourceAccess.m_bImmutable = false;
 
@@ -431,7 +431,7 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       ezGALBufferCreationDescription bufferDesc;
       bufferDesc.m_uiStructSize = sizeof(LineInstruction);
       bufferDesc.m_uiTotalSize = sizeof(LineInstruction) * m_uiNumSweepLines;
-      bufferDesc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+      bufferDesc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
       bufferDesc.m_ResourceAccess.m_bReadBack = false;
       bufferDesc.m_ResourceAccess.m_bImmutable = true;
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -411,7 +411,7 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
 
       m_hLineSweepOutputBuffer = device->CreateBuffer(bufferDesc);
 
-      ezGALUnorderedAccessViewCreationDescription uavDesc;
+      ezGALBufferUnorderedAccessViewCreationDescription uavDesc;
       uavDesc.m_hBuffer = m_hLineSweepOutputBuffer;
       uavDesc.m_OverrideViewFormat = ezGALResourceFormat::RUInt;
       uavDesc.m_uiFirstElement = 0;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -416,8 +416,6 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       uavDesc.m_OverrideViewFormat = ezGALResourceFormat::RUInt;
       uavDesc.m_uiFirstElement = 0;
       uavDesc.m_uiNumElements = imageResolution.z * totalNumberOfSamples / 2;
-      uavDesc.m_bRawView = false;
-      uavDesc.m_bAppend = false;
       m_hLineSweepOutputUAV = device->CreateUnorderedAccessView(uavDesc);
 
       ezGALBufferResourceViewCreationDescription srvDesc;
@@ -425,7 +423,6 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       srvDesc.m_OverrideViewFormat = ezGALResourceFormat::RUInt;
       srvDesc.m_uiFirstElement = 0;
       srvDesc.m_uiNumElements = imageResolution.z * totalNumberOfSamples / 2;
-      srvDesc.m_bRawView = false;
       m_hLineSweepOutputSRV = device->CreateResourceView(srvDesc);
     }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/OpaqueForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/OpaqueForwardRenderPass.cpp
@@ -64,7 +64,7 @@ void ezOpaqueForwardRenderPass::SetupResources(ezGALPass* pGALPass, const ezRend
   {
     if (inputs[m_PinSSAO.m_uiInputIndex])
     {
-      ezGALResourceViewHandle ssaoResourceViewHandle = pDevice->GetDefaultResourceView(inputs[m_PinSSAO.m_uiInputIndex]->m_TextureHandle);
+      ezGALTextureResourceViewHandle ssaoResourceViewHandle = pDevice->GetDefaultResourceView(inputs[m_PinSSAO.m_uiInputIndex]->m_TextureHandle);
       renderViewContext.m_pRenderContext->BindTexture2D("SSAOTexture", ssaoResourceViewHandle);
     }
     else

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
@@ -110,9 +110,9 @@ void ezReflectionFilterPass::Execute(const ezRenderViewContext& renderViewContex
 
       for (ezUInt32 uiMipMapIndex = 0; uiMipMapIndex < uiNumMipMaps; ++uiMipMapIndex)
       {
-        ezGALUnorderedAccessViewHandle hFilterOutput;
+        ezGALTextureUnorderedAccessViewHandle hFilterOutput;
         {
-          ezGALUnorderedAccessViewCreationDescription desc;
+          ezGALTextureUnorderedAccessViewCreationDescription desc;
           desc.m_hTexture = pFilteredSpecularOutput->m_TextureHandle;
           desc.m_uiMipLevelToUse = uiMipMapIndex;
           desc.m_uiFirstArraySlice = m_uiSpecularOutputIndex * 6;
@@ -140,9 +140,9 @@ void ezReflectionFilterPass::Execute(const ezRenderViewContext& renderViewContex
   {
     auto pCommandEncoder = ezRenderContext::BeginComputeScope(pGALPass, renderViewContext, "Irradiance");
 
-    ezGALUnorderedAccessViewHandle hIrradianceOutput;
+    ezGALTextureUnorderedAccessViewHandle hIrradianceOutput;
     {
-      ezGALUnorderedAccessViewCreationDescription desc;
+      ezGALTextureUnorderedAccessViewCreationDescription desc;
       desc.m_hTexture = pIrradianceOutput->m_TextureHandle;
 
       hIrradianceOutput = pDevice->CreateUnorderedAccessView(desc);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SeparatedBilateralBlur.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SeparatedBilateralBlur.cpp
@@ -98,11 +98,11 @@ void ezSeparatedBilateralBlurPass::Execute(const ezRenderViewContext& renderView
     EZ_SCOPE_EXIT(pDevice->EndPass(pGALPass));
 
     // Setup input view and sampler
-    ezGALResourceViewCreationDescription rvcd;
+    ezGALTextureResourceViewCreationDescription rvcd;
     rvcd.m_hTexture = inputs[m_PinBlurSourceInput.m_uiInputIndex]->m_TextureHandle;
-    ezGALResourceViewHandle hBlurSourceInputView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
+    ezGALTextureResourceViewHandle hBlurSourceInputView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
     rvcd.m_hTexture = inputs[m_PinDepthInput.m_uiInputIndex]->m_TextureHandle;
-    ezGALResourceViewHandle hDepthInputView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
+    ezGALTextureResourceViewHandle hDepthInputView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
 
     // Get temp texture for horizontal target / vertical source.
     ezGALTextureCreationDescription tempTextureDesc = outputs[m_PinBlurSourceInput.m_uiInputIndex]->m_Desc;
@@ -110,7 +110,7 @@ void ezSeparatedBilateralBlurPass::Execute(const ezRenderViewContext& renderView
     tempTextureDesc.m_bCreateRenderTarget = true;
     ezGALTextureHandle tempTexture = ezGPUResourcePool::GetDefaultInstance()->GetRenderTarget(tempTextureDesc);
     rvcd.m_hTexture = tempTexture;
-    ezGALResourceViewHandle hTempTextureRView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
+    ezGALTextureResourceViewHandle hTempTextureRView = ezGALDevice::GetDefaultDevice()->CreateResourceView(rvcd);
 
     ezGALRenderingSetup renderingSetup;
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
@@ -150,7 +150,7 @@ void ezTonemapPass::Execute(const ezRenderViewContext& renderViewContext, const 
     constants->ContrastParams = ezVec4(a, b, m, 0.0f);
   }
 
-  ezGALResourceViewHandle hBloomTextureView;
+  ezGALTextureResourceViewHandle hBloomTextureView;
   auto pBloomInput = inputs[m_PinBloomInput.m_uiInputIndex];
   if (pBloomInput != nullptr)
   {

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
@@ -60,7 +60,7 @@ void ezTransparentForwardRenderPass::Execute(const ezRenderViewContext& renderVi
 
   UpdateSceneColorTexture(renderViewContext, hSceneColor, pColorInput->m_TextureHandle);
 
-  ezGALResourceViewHandle colorResourceViewHandle = pDevice->GetDefaultResourceView(hSceneColor);
+  ezGALTextureResourceViewHandle colorResourceViewHandle = pDevice->GetDefaultResourceView(hSceneColor);
   renderViewContext.m_pRenderContext->BindTexture2D("SceneColor", colorResourceViewHandle);
   renderViewContext.m_pRenderContext->BindSamplerState("SceneColorSampler", m_hSceneColorSamplerState);
 
@@ -81,7 +81,7 @@ void ezTransparentForwardRenderPass::SetupResources(ezGALPass* pGALPass, const e
 
   if (inputs[m_PinResolvedDepth.m_uiInputIndex])
   {
-    ezGALResourceViewHandle depthResourceViewHandle = pDevice->GetDefaultResourceView(inputs[m_PinResolvedDepth.m_uiInputIndex]->m_TextureHandle);
+    ezGALTextureResourceViewHandle depthResourceViewHandle = pDevice->GetDefaultResourceView(inputs[m_PinResolvedDepth.m_uiInputIndex]->m_TextureHandle);
     renderViewContext.m_pRenderContext->BindTexture2D("SceneDepth", depthResourceViewHandle);
   }
 }

--- a/Code/Engine/RendererCore/Pipeline/Passes/LSAOPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/LSAOPass.h
@@ -84,11 +84,11 @@ protected:
   /// Output of the line sweep pass.
   ezGALBufferHandle m_hLineSweepOutputBuffer;
   ezGALUnorderedAccessViewHandle m_hLineSweepOutputUAV;
-  ezGALResourceViewHandle m_hLineSweepOutputSRV;
+  ezGALBufferResourceViewHandle m_hLineSweepOutputSRV;
 
   /// Structured buffer containing instructions for every single line to trace.
   ezGALBufferHandle m_hLineInfoBuffer;
-  ezGALResourceViewHandle m_hLineSweepInfoSRV;
+  ezGALBufferResourceViewHandle m_hLineSweepInfoSRV;
 
   /// Total number of lines to be traced.
   ezUInt32 m_uiNumSweepLines = 0;

--- a/Code/Engine/RendererCore/Pipeline/Passes/LSAOPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/LSAOPass.h
@@ -83,7 +83,7 @@ protected:
 
   /// Output of the line sweep pass.
   ezGALBufferHandle m_hLineSweepOutputBuffer;
-  ezGALUnorderedAccessViewHandle m_hLineSweepOutputUAV;
+  ezGALBufferUnorderedAccessViewHandle m_hLineSweepOutputUAV;
   ezGALBufferResourceViewHandle m_hLineSweepOutputSRV;
 
   /// Structured buffer containing instructions for every single line to trace.

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -369,7 +369,7 @@ void ezRenderContext::BindUAV(const ezTempHashedString& sSlotName, ezGALBufferUn
   {
     if (*pOldResourceView == hUnorderedAccessView)
       return;
-    
+
     *pOldResourceView = hUnorderedAccessView;
   }
   else

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -256,7 +256,7 @@ void ezRenderContext::BindTexture2D(const ezTempHashedString& sSlotName, const e
   }
   else
   {
-    BindTexture2D(sSlotName, ezGALResourceViewHandle());
+    BindTexture2D(sSlotName, ezGALTextureResourceViewHandle());
   }
 }
 
@@ -271,7 +271,7 @@ void ezRenderContext::BindTexture3D(const ezTempHashedString& sSlotName, const e
   }
   else
   {
-    BindTexture3D(sSlotName, ezGALResourceViewHandle());
+    BindTexture3D(sSlotName, ezGALTextureResourceViewHandle());
   }
 }
 
@@ -286,13 +286,13 @@ void ezRenderContext::BindTextureCube(const ezTempHashedString& sSlotName, const
   }
   else
   {
-    BindTextureCube(sSlotName, ezGALResourceViewHandle());
+    BindTextureCube(sSlotName, ezGALTextureResourceViewHandle());
   }
 }
 
-void ezRenderContext::BindTexture2D(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView)
+void ezRenderContext::BindTexture2D(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView)
 {
-  ezGALResourceViewHandle* pOldResourceView = nullptr;
+  ezGALTextureResourceViewHandle* pOldResourceView = nullptr;
   if (m_BoundTextures2D.TryGetValue(sSlotName.GetHash(), pOldResourceView))
   {
     if (*pOldResourceView == hResourceView)
@@ -308,9 +308,9 @@ void ezRenderContext::BindTexture2D(const ezTempHashedString& sSlotName, ezGALRe
   m_StateFlags.Add(ezRenderContextFlags::TextureBindingChanged);
 }
 
-void ezRenderContext::BindTexture3D(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView)
+void ezRenderContext::BindTexture3D(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView)
 {
-  ezGALResourceViewHandle* pOldResourceView = nullptr;
+  ezGALTextureResourceViewHandle* pOldResourceView = nullptr;
   if (m_BoundTextures3D.TryGetValue(sSlotName.GetHash(), pOldResourceView))
   {
     if (*pOldResourceView == hResourceView)
@@ -326,9 +326,9 @@ void ezRenderContext::BindTexture3D(const ezTempHashedString& sSlotName, ezGALRe
   m_StateFlags.Add(ezRenderContextFlags::TextureBindingChanged);
 }
 
-void ezRenderContext::BindTextureCube(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView)
+void ezRenderContext::BindTextureCube(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView)
 {
-  ezGALResourceViewHandle* pOldResourceView = nullptr;
+  ezGALTextureResourceViewHandle* pOldResourceView = nullptr;
   if (m_BoundTexturesCube.TryGetValue(sSlotName.GetHash(), pOldResourceView))
   {
     if (*pOldResourceView == hResourceView)
@@ -386,9 +386,9 @@ void ezRenderContext::BindSamplerState(const ezTempHashedString& sSlotName, ezGA
   m_StateFlags.Add(ezRenderContextFlags::SamplerBindingChanged);
 }
 
-void ezRenderContext::BindBuffer(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView)
+void ezRenderContext::BindBuffer(const ezTempHashedString& sSlotName, ezGALBufferResourceViewHandle hResourceView)
 {
-  ezGALResourceViewHandle* pOldResourceView = nullptr;
+  ezGALBufferResourceViewHandle* pOldResourceView = nullptr;
   if (m_BoundBuffer.TryGetValue(sSlotName.GetHash(), pOldResourceView))
   {
     if (*pOldResourceView == hResourceView)
@@ -1224,7 +1224,7 @@ void ezRenderContext::ApplyTextureBindings(const ezGALShader* pShader)
   for (const ezShaderResourceBinding& binding : bindings)
   {
     const ezUInt64 uiResourceHash = binding.m_sName.GetHash();
-    ezGALResourceViewHandle hResourceView;
+    ezGALTextureResourceViewHandle hResourceView;
 
     if (binding.m_ResourceType == ezGALShaderResourceType::Texture || binding.m_ResourceType == ezGALShaderResourceType::TextureAndSampler)
     {
@@ -1305,7 +1305,7 @@ void ezRenderContext::ApplyBufferBindings(const ezGALShader* pShader)
     {
       const ezUInt64 uiResourceHash = binding.m_sName.GetHash();
 
-      ezGALResourceViewHandle hResourceView;
+      ezGALBufferResourceViewHandle hResourceView;
       m_BoundBuffer.TryGetValue(uiResourceHash, hResourceView);
 
       m_pGALCommandEncoder->SetResourceView(binding, hResourceView);

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -150,16 +150,16 @@ public:
   void BindTexture3D(const ezTempHashedString& sSlotName, const ezTexture3DResourceHandle& hTexture, ezResourceAcquireMode acquireMode = ezResourceAcquireMode::AllowLoadingFallback);
   void BindTextureCube(const ezTempHashedString& sSlotName, const ezTextureCubeResourceHandle& hTexture, ezResourceAcquireMode acquireMode = ezResourceAcquireMode::AllowLoadingFallback);
 
-  void BindTexture2D(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView);
-  void BindTexture3D(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView);
-  void BindTextureCube(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView);
+  void BindTexture2D(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView);
+  void BindTexture3D(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView);
+  void BindTextureCube(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView);
 
   /// Binds a read+write texture or buffer
   void BindUAV(const ezTempHashedString& sSlotName, ezGALUnorderedAccessViewHandle hUnorderedAccessViewHandle);
 
   void BindSamplerState(const ezTempHashedString& sSlotName, ezGALSamplerStateHandle hSamplerSate);
 
-  void BindBuffer(const ezTempHashedString& sSlotName, ezGALResourceViewHandle hResourceView);
+  void BindBuffer(const ezTempHashedString& sSlotName, ezGALBufferResourceViewHandle hResourceView);
 
   void BindConstantBuffer(const ezTempHashedString& sSlotName, ezGALBufferHandle hConstantBuffer);
   void BindConstantBuffer(const ezTempHashedString& sSlotName, ezConstantBufferStorageHandle hConstantBufferStorage);
@@ -311,12 +311,12 @@ private:
   bool m_bAllowAsyncShaderLoading;
   bool m_bStereoRendering = false;
 
-  ezHashTable<ezUInt64, ezGALResourceViewHandle> m_BoundTextures2D;
-  ezHashTable<ezUInt64, ezGALResourceViewHandle> m_BoundTextures3D;
-  ezHashTable<ezUInt64, ezGALResourceViewHandle> m_BoundTexturesCube;
+  ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTextures2D;
+  ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTextures3D;
+  ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTexturesCube;
   ezHashTable<ezUInt64, ezGALUnorderedAccessViewHandle> m_BoundUAVs;
   ezHashTable<ezUInt64, ezGALSamplerStateHandle> m_BoundSamplers;
-  ezHashTable<ezUInt64, ezGALResourceViewHandle> m_BoundBuffer;
+  ezHashTable<ezUInt64, ezGALBufferResourceViewHandle> m_BoundBuffer;
   ezGALSamplerStateHandle m_hFallbackSampler;
 
   struct BoundConstantBuffer

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -155,7 +155,8 @@ public:
   void BindTextureCube(const ezTempHashedString& sSlotName, ezGALTextureResourceViewHandle hResourceView);
 
   /// Binds a read+write texture or buffer
-  void BindUAV(const ezTempHashedString& sSlotName, ezGALUnorderedAccessViewHandle hUnorderedAccessViewHandle);
+  void BindUAV(const ezTempHashedString& sSlotName, ezGALTextureUnorderedAccessViewHandle hUnorderedAccessViewHandle);
+  void BindUAV(const ezTempHashedString& sSlotName, ezGALBufferUnorderedAccessViewHandle hUnorderedAccessViewHandle);
 
   void BindSamplerState(const ezTempHashedString& sSlotName, ezGALSamplerStateHandle hSamplerSate);
 
@@ -314,9 +315,12 @@ private:
   ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTextures2D;
   ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTextures3D;
   ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTexturesCube;
-  ezHashTable<ezUInt64, ezGALUnorderedAccessViewHandle> m_BoundUAVs;
+  ezHashTable<ezUInt64, ezGALTextureUnorderedAccessViewHandle> m_BoundTextureUAVs;
+
   ezHashTable<ezUInt64, ezGALSamplerStateHandle> m_BoundSamplers;
+
   ezHashTable<ezUInt64, ezGALBufferResourceViewHandle> m_BoundBuffer;
+  ezHashTable<ezUInt64, ezGALBufferUnorderedAccessViewHandle> m_BoundBufferUAVs;
   ezGALSamplerStateHandle m_hFallbackSampler;
 
   struct BoundConstantBuffer

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -34,7 +34,8 @@ public:
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) override;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView) override;
-  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView) override;
+  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureUnorderedAccessView* pUnorderedAccessView) override;
+  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferUnorderedAccessView* pUnorderedAccessView) override;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) override;
 
   // Query functions
@@ -49,8 +50,11 @@ public:
 
   // Resource update functions
 
-  virtual void ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues) override;
-  virtual void ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues) override;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues) override;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues) override;
+
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues) override;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues) override;
 
   virtual void CopyBufferPlatform(const ezGALBuffer* pDestination, const ezGALBuffer* pSource) override;
   virtual void CopyBufferRegionPlatform(const ezGALBuffer* pDestination, ezUInt32 uiDestOffset, const ezGALBuffer* pSource, ezUInt32 uiSourceOffset, ezUInt32 uiByteCount) override;
@@ -143,9 +147,9 @@ private:
   ezHybridArray<const ezGALResourceBase*, 16> m_ResourcesForResourceViews[ezGALShaderStage::ENUM_COUNT];
   ezGAL::ModifiedRange m_BoundShaderResourceViewsRange[ezGALShaderStage::ENUM_COUNT];
 
-  ezHybridArray<ID3D11UnorderedAccessView*, 16> m_BoundUnoderedAccessViews;
+  ezHybridArray<ID3D11UnorderedAccessView*, 16> m_BoundUnorderedAccessViews;
   ezHybridArray<const ezGALResourceBase*, 16> m_ResourcesForUnorderedAccessViews;
-  ezGAL::ModifiedRange m_BoundUnoderedAccessViewsRange;
+  ezGAL::ModifiedRange m_BoundUnorderedAccessViewsRange;
 
   ID3D11SamplerState* m_pBoundSamplerStates[ezGALShaderStage::ENUM_COUNT][EZ_GAL_MAX_SAMPLER_COUNT] = {};
   ezGAL::ModifiedRange m_BoundSamplerStatesRange[ezGALShaderStage::ENUM_COUNT];
@@ -163,4 +167,5 @@ private:
   ezUInt32 m_VertexBufferStrides[EZ_GAL_MAX_VERTEX_BUFFER_COUNT] = {};
   ezUInt32 m_VertexBufferOffsets[EZ_GAL_MAX_VERTEX_BUFFER_COUNT] = {};
   void SetResourceView(const ezShaderResourceBinding& binding, const ezGALResourceBase* pResource, ID3D11ShaderResourceView* pResourceViewDX11);
+  void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ID3D11UnorderedAccessView* pUnorderedAccessViewDX11, ezGALResourceBase* pResource);
 };

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -32,7 +32,8 @@ public:
 
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) override;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
-  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALResourceView* pResourceView) override;
+  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) override;
+  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView) override;
   virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView) override;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) override;
 
@@ -69,7 +70,7 @@ public:
 
   virtual void CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData) override;
 
-  virtual void GenerateMipMapsPlatform(const ezGALResourceView* pResourceView) override;
+  virtual void GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView) override;
 
   // Misc
 
@@ -161,4 +162,5 @@ private:
 
   ezUInt32 m_VertexBufferStrides[EZ_GAL_MAX_VERTEX_BUFFER_COUNT] = {};
   ezUInt32 m_VertexBufferOffsets[EZ_GAL_MAX_VERTEX_BUFFER_COUNT] = {};
+  void SetResourceView(const ezShaderResourceBinding& binding, const ezGALResourceBase* pResource, ID3D11ShaderResourceView* pResourceViewDX11);
 };

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -238,7 +238,7 @@ void ezGALCommandEncoderImplDX11::UpdateBufferPlatform(const ezGALBuffer* pDesti
 
   ID3D11Buffer* pDXDestination = static_cast<const ezGALBufferDX11*>(pDestination)->GetDXBuffer();
 
-  if (pDestination->GetDescription().m_BufferType == ezGALBufferType::ConstantBuffer)
+  if (pDestination->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ConstantBuffer))
   {
     EZ_ASSERT_DEV(uiDestOffset == 0 && sourceData.GetCount() == pDestination->GetSize(),
       "Constant buffers can't be updated partially (and we don't check for DX11.1)!");

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -124,15 +124,32 @@ void ezGALCommandEncoderImplDX11::SetSamplerStatePlatform(const ezShaderResource
   }
 }
 
-void ezGALCommandEncoderImplDX11::SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALResourceView* pResourceView)
+void ezGALCommandEncoderImplDX11::SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView)
 {
   if (pResourceView != nullptr && UnsetUnorderedAccessViews(pResourceView->GetResource()))
   {
     FlushPlatform();
   }
 
-  ID3D11ShaderResourceView* pResourceViewDX11 = pResourceView != nullptr ? static_cast<const ezGALResourceViewDX11*>(pResourceView)->GetDXResourceView() : nullptr;
+  ID3D11ShaderResourceView* pResourceViewDX11 = pResourceView != nullptr ? static_cast<const ezGALTextureResourceViewDX11*>(pResourceView)->GetDXResourceView() : nullptr;
 
+  SetResourceView(binding, pResourceView != nullptr ? pResourceView->GetResource() : nullptr, pResourceViewDX11);
+}
+
+void ezGALCommandEncoderImplDX11::SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView)
+{
+  if (pResourceView != nullptr && UnsetUnorderedAccessViews(pResourceView->GetResource()))
+  {
+    FlushPlatform();
+  }
+
+  ID3D11ShaderResourceView* pResourceViewDX11 = pResourceView != nullptr ? static_cast<const ezGALBufferResourceViewDX11*>(pResourceView)->GetDXResourceView() : nullptr;
+
+  SetResourceView(binding, pResourceView != nullptr ? pResourceView->GetResource() : nullptr, pResourceViewDX11);
+}
+
+void ezGALCommandEncoderImplDX11::SetResourceView(const ezShaderResourceBinding& binding, const ezGALResourceBase* pResource, ID3D11ShaderResourceView* pResourceViewDX11)
+{
   for (ezGALShaderStage::Enum stage : ezIterateBitIndices<ezUInt16, ezGALShaderStage::Enum>(binding.m_Stages.GetValue()))
   {
     auto& boundShaderResourceViews = m_pBoundShaderResourceViews[stage];
@@ -142,7 +159,7 @@ void ezGALCommandEncoderImplDX11::SetResourceViewPlatform(const ezShaderResource
     if (boundShaderResourceViews[binding.m_iSlot] != pResourceViewDX11)
     {
       boundShaderResourceViews[binding.m_iSlot] = pResourceViewDX11;
-      resourcesForResourceViews[binding.m_iSlot] = pResourceView != nullptr ? pResourceView->GetResource() : nullptr;
+      resourcesForResourceViews[binding.m_iSlot] = pResource;
       m_BoundShaderResourceViewsRange[stage].SetToIncludeValue(binding.m_iSlot);
     }
   }
@@ -461,9 +478,9 @@ void ezGALCommandEncoderImplDX11::CopyTextureReadbackResultPlatform(const ezGALT
   }
 }
 
-void ezGALCommandEncoderImplDX11::GenerateMipMapsPlatform(const ezGALResourceView* pResourceView)
+void ezGALCommandEncoderImplDX11::GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView)
 {
-  const ezGALResourceViewDX11* pDXResourceView = static_cast<const ezGALResourceViewDX11*>(pResourceView);
+  const ezGALTextureResourceViewDX11* pDXResourceView = static_cast<const ezGALTextureResourceViewDX11*>(pResourceView);
 
   m_pDXContext->GenerateMips(pDXResourceView->GetDXResourceView());
 }

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -282,7 +282,7 @@ void ezGALCommandEncoderImplDX11::UpdateBufferPlatform(const ezGALBuffer* pDesti
 
   ID3D11Buffer* pDXDestination = static_cast<const ezGALBufferDX11*>(pDestination)->GetDXBuffer();
 
-  if (pDestination->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ConstantBuffer))
+  if (pDestination->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::ConstantBuffer))
   {
     EZ_ASSERT_DEV(uiDestOffset == 0 && sourceData.GetCount() == pDestination->GetSize(),
       "Constant buffers can't be updated partially (and we don't check for DX11.1)!");

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -165,22 +165,37 @@ void ezGALCommandEncoderImplDX11::SetResourceView(const ezShaderResourceBinding&
   }
 }
 
-void ezGALCommandEncoderImplDX11::SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView)
+void ezGALCommandEncoderImplDX11::SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureUnorderedAccessView* pUnorderedAccessView)
 {
   if (pUnorderedAccessView != nullptr && UnsetResourceViews(pUnorderedAccessView->GetResource()))
   {
     FlushPlatform();
   }
 
-  ID3D11UnorderedAccessView* pUnorderedAccessViewDX11 = pUnorderedAccessView != nullptr ? static_cast<const ezGALUnorderedAccessViewDX11*>(pUnorderedAccessView)->GetDXResourceView() : nullptr;
+  ID3D11UnorderedAccessView* pUnorderedAccessViewDX11 = pUnorderedAccessView != nullptr ? static_cast<const ezGALTextureUnorderedAccessViewDX11*>(pUnorderedAccessView)->GetDXResourceView() : nullptr;
+  SetUnorderedAccessView(binding, pUnorderedAccessViewDX11, pUnorderedAccessView != nullptr ? pUnorderedAccessView->GetResource() : nullptr);
+}
 
-  m_BoundUnoderedAccessViews.EnsureCount(binding.m_iSlot + 1);
-  m_ResourcesForUnorderedAccessViews.EnsureCount(binding.m_iSlot + 1);
-  if (m_BoundUnoderedAccessViews[binding.m_iSlot] != pUnorderedAccessViewDX11)
+void ezGALCommandEncoderImplDX11::SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferUnorderedAccessView* pUnorderedAccessView)
+{
+  if (pUnorderedAccessView != nullptr && UnsetResourceViews(pUnorderedAccessView->GetResource()))
   {
-    m_BoundUnoderedAccessViews[binding.m_iSlot] = pUnorderedAccessViewDX11;
-    m_ResourcesForUnorderedAccessViews[binding.m_iSlot] = pUnorderedAccessView != nullptr ? pUnorderedAccessView->GetResource() : nullptr;
-    m_BoundUnoderedAccessViewsRange.SetToIncludeValue(binding.m_iSlot);
+    FlushPlatform();
+  }
+  
+  ID3D11UnorderedAccessView* pUnorderedAccessViewDX11 = pUnorderedAccessView != nullptr ? static_cast<const ezGALBufferUnorderedAccessViewDX11*>(pUnorderedAccessView)->GetDXResourceView() : nullptr;
+  SetUnorderedAccessView(binding, pUnorderedAccessViewDX11, pUnorderedAccessView != nullptr ? pUnorderedAccessView->GetResource() : nullptr);
+}
+
+void ezGALCommandEncoderImplDX11::SetUnorderedAccessView(const ezShaderResourceBinding& binding, ID3D11UnorderedAccessView* pUnorderedAccessViewDX11, ezGALResourceBase* pResource)
+{
+  m_BoundUnorderedAccessViews.EnsureCount(binding.m_iSlot + 1);
+  m_ResourcesForUnorderedAccessViews.EnsureCount(binding.m_iSlot + 1);
+  if (m_BoundUnorderedAccessViews[binding.m_iSlot] != pUnorderedAccessViewDX11)
+  {
+    m_BoundUnorderedAccessViews[binding.m_iSlot] = pUnorderedAccessViewDX11;
+    m_ResourcesForUnorderedAccessViews[binding.m_iSlot] = pResource;
+    m_BoundUnorderedAccessViewsRange.SetToIncludeValue(binding.m_iSlot);
   }
 }
 
@@ -220,15 +235,27 @@ void ezGALCommandEncoderImplDX11::InsertTimestampPlatform(ezGALTimestampHandle h
 
 // Resource update functions
 
-void ezGALCommandEncoderImplDX11::ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues)
+void ezGALCommandEncoderImplDX11::ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues)
 {
-  const ezGALUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<const ezGALUnorderedAccessViewDX11*>(pUnorderedAccessView);
+  const ezGALTextureUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<const ezGALTextureUnorderedAccessViewDX11*>(pUnorderedAccessView);
   m_pDXContext->ClearUnorderedAccessViewFloat(pUnorderedAccessViewDX11->GetDXResourceView(), &vClearValues.x);
 }
 
-void ezGALCommandEncoderImplDX11::ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues)
+void ezGALCommandEncoderImplDX11::ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues)
 {
-  const ezGALUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<const ezGALUnorderedAccessViewDX11*>(pUnorderedAccessView);
+  const ezGALBufferUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<const ezGALBufferUnorderedAccessViewDX11*>(pUnorderedAccessView);
+  m_pDXContext->ClearUnorderedAccessViewFloat(pUnorderedAccessViewDX11->GetDXResourceView(), &vClearValues.x);
+}
+
+void ezGALCommandEncoderImplDX11::ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues)
+{
+  const ezGALTextureUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<const ezGALTextureUnorderedAccessViewDX11*>(pUnorderedAccessView);
+  m_pDXContext->ClearUnorderedAccessViewUint(pUnorderedAccessViewDX11->GetDXResourceView(), &vClearValues.x);
+}
+
+void ezGALCommandEncoderImplDX11::ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues)
+{
+  const ezGALBufferUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<const ezGALBufferUnorderedAccessViewDX11*>(pUnorderedAccessView);
   m_pDXContext->ClearUnorderedAccessViewUint(pUnorderedAccessViewDX11->GetDXResourceView(), &vClearValues.x);
 }
 
@@ -926,13 +953,13 @@ ezResult ezGALCommandEncoderImplDX11::FlushDeferredStateChanges()
   }
 
   // Do UAV bindings before SRV since UAV are outputs which need to be unbound before they are potentially rebound as SRV again.
-  if (m_BoundUnoderedAccessViewsRange.IsValid())
+  if (m_BoundUnorderedAccessViewsRange.IsValid())
   {
-    const ezUInt32 uiStartSlot = m_BoundUnoderedAccessViewsRange.m_uiMin;
-    const ezUInt32 uiNumSlots = m_BoundUnoderedAccessViewsRange.GetCount();
-    m_pDXContext->CSSetUnorderedAccessViews(uiStartSlot, uiNumSlots, m_BoundUnoderedAccessViews.GetData() + uiStartSlot, nullptr); // Todo: Count reset.
+    const ezUInt32 uiStartSlot = m_BoundUnorderedAccessViewsRange.m_uiMin;
+    const ezUInt32 uiNumSlots = m_BoundUnorderedAccessViewsRange.GetCount();
+    m_pDXContext->CSSetUnorderedAccessViews(uiStartSlot, uiNumSlots, m_BoundUnorderedAccessViews.GetData() + uiStartSlot, nullptr); // Todo: Count reset.
 
-    m_BoundUnoderedAccessViewsRange.Reset();
+    m_BoundUnorderedAccessViewsRange.Reset();
   }
 
   for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
@@ -976,8 +1003,8 @@ bool ezGALCommandEncoderImplDX11::UnsetUnorderedAccessViews(const ezGALResourceB
     if (m_ResourcesForUnorderedAccessViews[uiSlot] == pResource)
     {
       m_ResourcesForUnorderedAccessViews[uiSlot] = nullptr;
-      m_BoundUnoderedAccessViews[uiSlot] = nullptr;
-      m_BoundUnoderedAccessViewsRange.SetToIncludeValue(uiSlot);
+      m_BoundUnorderedAccessViews[uiSlot] = nullptr;
+      m_BoundUnorderedAccessViewsRange.SetToIncludeValue(uiSlot);
       bResult = true;
     }
   }

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -182,7 +182,7 @@ void ezGALCommandEncoderImplDX11::SetUnorderedAccessViewPlatform(const ezShaderR
   {
     FlushPlatform();
   }
-  
+
   ID3D11UnorderedAccessView* pUnorderedAccessViewDX11 = pUnorderedAccessView != nullptr ? static_cast<const ezGALBufferUnorderedAccessViewDX11*>(pUnorderedAccessView)->GetDXResourceView() : nullptr;
   SetUnorderedAccessView(binding, pUnorderedAccessViewDX11, pUnorderedAccessView != nullptr ? pUnorderedAccessView->GetResource() : nullptr);
 }

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -103,8 +103,11 @@ protected:
   virtual ezGALTexture* CreateSharedTexturePlatform(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle handle) override;
   virtual void DestroySharedTexturePlatform(ezGALTexture* pTexture) override;
 
-  virtual ezGALResourceView* CreateResourceViewPlatform(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description) override;
-  virtual void DestroyResourceViewPlatform(ezGALResourceView* pResourceView) override;
+  virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) override;
+  virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) override;
+
+  virtual ezGALBufferResourceView* CreateResourceViewPlatform(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description) override;
+  virtual void DestroyResourceViewPlatform(ezGALBufferResourceView* pResourceView) override;
 
   virtual ezGALRenderTargetView* CreateRenderTargetViewPlatform(ezGALTexture* pTexture, const ezGALRenderTargetViewCreationDescription& Description) override;
   virtual void DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRenderTargetView) override;

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -117,7 +117,7 @@ protected:
 
   ezGALBufferUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description) override;
   virtual void DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView) override;
-  
+
   // Other rendering creation functions
 
   virtual ezGALQuery* CreateQueryPlatform(const ezGALQueryCreationDescription& Description) override;

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -112,9 +112,12 @@ protected:
   virtual ezGALRenderTargetView* CreateRenderTargetViewPlatform(ezGALTexture* pTexture, const ezGALRenderTargetViewCreationDescription& Description) override;
   virtual void DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRenderTargetView) override;
 
-  ezGALUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description) override;
-  virtual void DestroyUnorderedAccessViewPlatform(ezGALUnorderedAccessView* pUnorderedAccessView) override;
+  ezGALTextureUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description) override;
+  virtual void DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAccessView* pUnorderedAccessView) override;
 
+  ezGALBufferUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description) override;
+  virtual void DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView) override;
+  
   // Other rendering creation functions
 
   virtual ezGALQuery* CreateQueryPlatform(const ezGALQueryCreationDescription& Description) override;

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -59,6 +59,7 @@ protected:
   ///   Null means default adapter.
   ezResult InitPlatform(DWORD flags, IDXGIAdapter* pUsedAdapter);
 
+  virtual ezStringView GetRendererPlatform() override;
   virtual ezResult InitPlatform() override;
   virtual ezResult ShutdownPlatform() override;
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -133,7 +133,7 @@ retry:
         {
           pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_CORRUPTION, TRUE);
           pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_ERROR, TRUE);
-          pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_WARNING, TRUE);
+          //pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_WARNING, TRUE);
         }
 
         // Ignore list.
@@ -237,6 +237,11 @@ retry:
         { return EZ_NEW(pAllocator, ezGALSwapChainDX11, desc); }); });
 
   return EZ_SUCCESS;
+}
+
+ezStringView ezGALDeviceDX11::GetRendererPlatform()
+{
+  return "DX11";
 }
 
 ezResult ezGALDeviceDX11::InitPlatform()

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -583,9 +583,9 @@ void ezGALDeviceDX11::DestroySharedTexturePlatform(ezGALTexture* pTexture)
   EZ_DELETE(&m_Allocator, pDX11Texture);
 }
 
-ezGALResourceView* ezGALDeviceDX11::CreateResourceViewPlatform(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description)
+ezGALTextureResourceView* ezGALDeviceDX11::CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description)
 {
-  ezGALResourceViewDX11* pResourceView = EZ_NEW(&m_Allocator, ezGALResourceViewDX11, pResource, Description);
+  ezGALTextureResourceViewDX11* pResourceView = EZ_NEW(&m_Allocator, ezGALTextureResourceViewDX11, pResource, Description);
 
   if (!pResourceView->InitPlatform(this).Succeeded())
   {
@@ -596,9 +596,29 @@ ezGALResourceView* ezGALDeviceDX11::CreateResourceViewPlatform(ezGALResourceBase
   return pResourceView;
 }
 
-void ezGALDeviceDX11::DestroyResourceViewPlatform(ezGALResourceView* pResourceView)
+void ezGALDeviceDX11::DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView)
 {
-  ezGALResourceViewDX11* pDX11ResourceView = static_cast<ezGALResourceViewDX11*>(pResourceView);
+  ezGALTextureResourceViewDX11* pDX11ResourceView = static_cast<ezGALTextureResourceViewDX11*>(pResourceView);
+  pDX11ResourceView->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pDX11ResourceView);
+}
+
+ezGALBufferResourceView* ezGALDeviceDX11::CreateResourceViewPlatform(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description)
+{
+  ezGALBufferResourceViewDX11* pResourceView = EZ_NEW(&m_Allocator, ezGALBufferResourceViewDX11, pResource, Description);
+
+  if (!pResourceView->InitPlatform(this).Succeeded())
+  {
+    EZ_DELETE(&m_Allocator, pResourceView);
+    return nullptr;
+  }
+
+  return pResourceView;
+}
+
+void ezGALDeviceDX11::DestroyResourceViewPlatform(ezGALBufferResourceView* pResourceView)
+{
+  ezGALBufferResourceViewDX11* pDX11ResourceView = static_cast<ezGALBufferResourceViewDX11*>(pResourceView);
   pDX11ResourceView->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pDX11ResourceView);
 }

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -643,9 +643,9 @@ void ezGALDeviceDX11::DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRe
   EZ_DELETE(&m_Allocator, pDX11RenderTargetView);
 }
 
-ezGALUnorderedAccessView* ezGALDeviceDX11::CreateUnorderedAccessViewPlatform(ezGALResourceBase* pTextureOfBuffer, const ezGALUnorderedAccessViewCreationDescription& Description)
+ezGALTextureUnorderedAccessView* ezGALDeviceDX11::CreateUnorderedAccessViewPlatform(ezGALTexture* pTextureOfBuffer, const ezGALTextureUnorderedAccessViewCreationDescription& Description)
 {
-  ezGALUnorderedAccessViewDX11* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALUnorderedAccessViewDX11, pTextureOfBuffer, Description);
+  ezGALTextureUnorderedAccessViewDX11* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALTextureUnorderedAccessViewDX11, pTextureOfBuffer, Description);
 
   if (!pUnorderedAccessView->InitPlatform(this).Succeeded())
   {
@@ -656,14 +656,32 @@ ezGALUnorderedAccessView* ezGALDeviceDX11::CreateUnorderedAccessViewPlatform(ezG
   return pUnorderedAccessView;
 }
 
-void ezGALDeviceDX11::DestroyUnorderedAccessViewPlatform(ezGALUnorderedAccessView* pUnorderedAccessView)
+void ezGALDeviceDX11::DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAccessView* pUnorderedAccessView)
 {
-  ezGALUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<ezGALUnorderedAccessViewDX11*>(pUnorderedAccessView);
+  ezGALTextureUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<ezGALTextureUnorderedAccessViewDX11*>(pUnorderedAccessView);
   pUnorderedAccessViewDX11->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pUnorderedAccessViewDX11);
 }
 
+ezGALBufferUnorderedAccessView* ezGALDeviceDX11::CreateUnorderedAccessViewPlatform(ezGALBuffer* pBufferOfBuffer, const ezGALBufferUnorderedAccessViewCreationDescription& Description)
+{
+  ezGALBufferUnorderedAccessViewDX11* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALBufferUnorderedAccessViewDX11, pBufferOfBuffer, Description);
+  
+  if (!pUnorderedAccessView->InitPlatform(this).Succeeded())
+  {
+    EZ_DELETE(&m_Allocator, pUnorderedAccessView);
+    return nullptr;
+  }
 
+  return pUnorderedAccessView;
+}
+
+void ezGALDeviceDX11::DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView)
+{
+  ezGALBufferUnorderedAccessViewDX11* pUnorderedAccessViewDX11 = static_cast<ezGALBufferUnorderedAccessViewDX11*>(pUnorderedAccessView);
+  pUnorderedAccessViewDX11->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pUnorderedAccessViewDX11);
+}
 
 // Other rendering creation functions
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -133,7 +133,7 @@ retry:
         {
           pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_CORRUPTION, TRUE);
           pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_ERROR, TRUE);
-          //pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_WARNING, TRUE);
+          // pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_WARNING, TRUE);
         }
 
         // Ignore list.
@@ -666,7 +666,7 @@ void ezGALDeviceDX11::DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAc
 ezGALBufferUnorderedAccessView* ezGALDeviceDX11::CreateUnorderedAccessViewPlatform(ezGALBuffer* pBufferOfBuffer, const ezGALBufferUnorderedAccessViewCreationDescription& Description)
 {
   ezGALBufferUnorderedAccessViewDX11* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALBufferUnorderedAccessViewDX11, pBufferOfBuffer, Description);
-  
+
   if (!pUnorderedAccessView->InitPlatform(this).Succeeded())
   {
     EZ_DELETE(&m_Allocator, pUnorderedAccessView);

--- a/Code/Engine/RendererDX11/Resources/Implementation/BufferDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/BufferDX11.cpp
@@ -18,52 +18,50 @@ ezResult ezGALBufferDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ez
 {
   ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
 
-  D3D11_BUFFER_DESC BufferDesc;
+  D3D11_BUFFER_DESC BufferDesc = {};
 
-  switch (m_Description.m_BufferType)
+  for (ezGALBufferFlags::Enum flag : m_Description.m_BufferFlags)
   {
-    case ezGALBufferType::ConstantBuffer:
-      BufferDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
-      break;
-    case ezGALBufferType::IndexBuffer:
-      BufferDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
-
-      m_IndexFormat = m_Description.m_uiStructSize == 2 ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
-
-      break;
-    case ezGALBufferType::VertexBuffer:
-      BufferDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
-      break;
-    case ezGALBufferType::Generic:
-      BufferDesc.BindFlags = 0;
-      break;
-    default:
-      ezLog::Error("Unknown buffer type supplied to CreateBuffer()!");
-      return EZ_FAILURE;
+    switch (flag)
+    {
+      case ezGALBufferFlags::ConstantBuffer:
+        BufferDesc.BindFlags |= D3D11_BIND_CONSTANT_BUFFER;
+        break;
+      case ezGALBufferFlags::IndexBuffer:
+        BufferDesc.BindFlags |= D3D11_BIND_INDEX_BUFFER;
+        m_IndexFormat = m_Description.m_uiStructSize == 2 ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
+        break;
+      case ezGALBufferFlags::VertexBuffer:
+        BufferDesc.BindFlags |= D3D11_BIND_VERTEX_BUFFER;
+        break;
+      case ezGALBufferFlags::TexelBuffer:
+        break;
+      case ezGALBufferFlags::StructuredBuffer:
+        BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
+        break;
+      case ezGALBufferFlags::ByteAddressBuffer:
+        BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
+        break;
+      case ezGALBufferFlags::ShaderResource:
+        BufferDesc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
+        break;
+      case ezGALBufferFlags::UnorderedAccess:
+        BufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
+        break;
+      case ezGALBufferFlags::DrawIndirect:
+        BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
+        break;
+      default:
+        ezLog::Error("Unknown buffer type supplied to CreateBuffer()!");
+        return EZ_FAILURE;
+    }
   }
-
-  if (m_Description.m_bAllowShaderResourceView)
-    BufferDesc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
-
-  if (m_Description.m_bAllowUAV)
-    BufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
 
   BufferDesc.ByteWidth = m_Description.m_uiTotalSize;
   BufferDesc.CPUAccessFlags = 0;
-  BufferDesc.MiscFlags = 0;
-
-  if (m_Description.m_bUseForIndirectArguments)
-    BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
-
-  if (m_Description.m_bAllowRawViews)
-    BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
-
-  if (m_Description.m_bUseAsStructuredBuffer)
-    BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
-
   BufferDesc.StructureByteStride = m_Description.m_uiStructSize;
 
-  if (m_Description.m_BufferType == ezGALBufferType::ConstantBuffer)
+  if (m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::ConstantBuffer))
   {
     BufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
     BufferDesc.Usage = D3D11_USAGE_DYNAMIC;
@@ -79,7 +77,7 @@ ezResult ezGALBufferDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ez
     }
     else
     {
-      if (m_Description.m_bAllowUAV) // UAVs allow writing from the GPU which cannot be combined with CPU write access.
+      if (m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::UnorderedAccess))// UAVs allow writing from the GPU which cannot be combined with CPU write access.
       {
         BufferDesc.Usage = D3D11_USAGE_DEFAULT;
       }

--- a/Code/Engine/RendererDX11/Resources/Implementation/BufferDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/BufferDX11.cpp
@@ -20,35 +20,35 @@ ezResult ezGALBufferDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ez
 
   D3D11_BUFFER_DESC BufferDesc = {};
 
-  for (ezGALBufferFlags::Enum flag : m_Description.m_BufferFlags)
+  for (ezGALBufferUsageFlags::Enum flag : m_Description.m_BufferFlags)
   {
     switch (flag)
     {
-      case ezGALBufferFlags::ConstantBuffer:
+      case ezGALBufferUsageFlags::ConstantBuffer:
         BufferDesc.BindFlags |= D3D11_BIND_CONSTANT_BUFFER;
         break;
-      case ezGALBufferFlags::IndexBuffer:
+      case ezGALBufferUsageFlags::IndexBuffer:
         BufferDesc.BindFlags |= D3D11_BIND_INDEX_BUFFER;
         m_IndexFormat = m_Description.m_uiStructSize == 2 ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
         break;
-      case ezGALBufferFlags::VertexBuffer:
+      case ezGALBufferUsageFlags::VertexBuffer:
         BufferDesc.BindFlags |= D3D11_BIND_VERTEX_BUFFER;
         break;
-      case ezGALBufferFlags::TexelBuffer:
+      case ezGALBufferUsageFlags::TexelBuffer:
         break;
-      case ezGALBufferFlags::StructuredBuffer:
+      case ezGALBufferUsageFlags::StructuredBuffer:
         BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_STRUCTURED;
         break;
-      case ezGALBufferFlags::ByteAddressBuffer:
+      case ezGALBufferUsageFlags::ByteAddressBuffer:
         BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_BUFFER_ALLOW_RAW_VIEWS;
         break;
-      case ezGALBufferFlags::ShaderResource:
+      case ezGALBufferUsageFlags::ShaderResource:
         BufferDesc.BindFlags |= D3D11_BIND_SHADER_RESOURCE;
         break;
-      case ezGALBufferFlags::UnorderedAccess:
+      case ezGALBufferUsageFlags::UnorderedAccess:
         BufferDesc.BindFlags |= D3D11_BIND_UNORDERED_ACCESS;
         break;
-      case ezGALBufferFlags::DrawIndirect:
+      case ezGALBufferUsageFlags::DrawIndirect:
         BufferDesc.MiscFlags |= D3D11_RESOURCE_MISC_DRAWINDIRECT_ARGS;
         break;
       default:
@@ -61,7 +61,7 @@ ezResult ezGALBufferDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ez
   BufferDesc.CPUAccessFlags = 0;
   BufferDesc.StructureByteStride = m_Description.m_uiStructSize;
 
-  if (m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::ConstantBuffer))
+  if (m_Description.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ConstantBuffer))
   {
     BufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
     BufferDesc.Usage = D3D11_USAGE_DYNAMIC;
@@ -77,7 +77,7 @@ ezResult ezGALBufferDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ez
     }
     else
     {
-      if (m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::UnorderedAccess)) // UAVs allow writing from the GPU which cannot be combined with CPU write access.
+      if (m_Description.m_BufferFlags.IsSet(ezGALBufferUsageFlags::UnorderedAccess)) // UAVs allow writing from the GPU which cannot be combined with CPU write access.
       {
         BufferDesc.Usage = D3D11_USAGE_DEFAULT;
       }

--- a/Code/Engine/RendererDX11/Resources/Implementation/BufferDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/BufferDX11.cpp
@@ -77,7 +77,7 @@ ezResult ezGALBufferDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ez
     }
     else
     {
-      if (m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::UnorderedAccess))// UAVs allow writing from the GPU which cannot be combined with CPU write access.
+      if (m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::UnorderedAccess)) // UAVs allow writing from the GPU which cannot be combined with CPU write access.
       {
         BufferDesc.Usage = D3D11_USAGE_DEFAULT;
       }

--- a/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11.cpp
@@ -179,7 +179,7 @@ ezResult ezGALBufferResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
   if (ViewFormat == ezGALResourceFormat::Invalid)
     ViewFormat = ezGALResourceFormat::RUInt;
 
-  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
+  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::ByteAddressBuffer) && m_Description.m_bRawView)
   {
     ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
     return EZ_FAILURE;
@@ -210,7 +210,7 @@ ezResult ezGALBufferResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
 
   pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
 
-  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer))
     DXSRVDesc.Format = DXGI_FORMAT_UNKNOWN;
 
   DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;

--- a/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11.cpp
@@ -7,57 +7,37 @@
 
 #include <d3d11.h>
 
-bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALResourceViewCreationDescription& viewDesc)
+bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALTextureResourceViewCreationDescription& viewDesc)
 {
   return texDesc.m_uiArraySize > 1 || viewDesc.m_uiFirstArraySlice > 0;
 }
 
-ezGALResourceViewDX11::ezGALResourceViewDX11(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description)
-  : ezGALResourceView(pResource, Description)
+ezGALTextureResourceViewDX11::ezGALTextureResourceViewDX11(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description)
+  : ezGALTextureResourceView(pResource, Description)
 
 {
 }
 
-ezGALResourceViewDX11::~ezGALResourceViewDX11() = default;
+ezGALTextureResourceViewDX11::~ezGALTextureResourceViewDX11() = default;
 
-ezResult ezGALResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
 {
   const ezGALTexture* pTexture = nullptr;
   if (!m_Description.m_hTexture.IsInvalidated())
     pTexture = pDevice->GetTexture(m_Description.m_hTexture);
 
-  const ezGALBuffer* pBuffer = nullptr;
-  if (!m_Description.m_hBuffer.IsInvalidated())
-    pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
-
-  if (pTexture == nullptr && pBuffer == nullptr)
+  if (pTexture == nullptr)
   {
-    ezLog::Error("No valid texture handle or buffer handle given for resource view creation!");
+    ezLog::Error("No valid texture handle given for resource view creation!");
     return EZ_FAILURE;
   }
 
-
   ezGALResourceFormat::Enum ViewFormat = m_Description.m_OverrideViewFormat;
 
-  if (pTexture)
-  {
-    if (ViewFormat == ezGALResourceFormat::Invalid)
-      ViewFormat = pTexture->GetDescription().m_Format;
-  }
-  else if (pBuffer)
-  {
-    if (ViewFormat == ezGALResourceFormat::Invalid)
-      ViewFormat = ezGALResourceFormat::RUInt;
-
-    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
-    {
-      ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
-      return EZ_FAILURE;
-    }
-  }
+  if (ViewFormat == ezGALResourceFormat::Invalid)
+    ViewFormat = pTexture->GetDescription().m_Format;
 
   ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
-
 
   DXGI_FORMAT DXViewFormat = DXGI_FORMAT_UNKNOWN;
   if (ezGALResourceFormat::IsDepthFormat(ViewFormat))
@@ -80,95 +60,80 @@ ezResult ezGALResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
 
   ID3D11Resource* pDXResource = nullptr;
 
-  if (pTexture)
+  pDXResource = static_cast<const ezGALTextureDX11*>(pTexture->GetParentResource())->GetDXTexture();
+  const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
+
+  const bool bIsArrayView = IsArrayView(texDesc, m_Description);
+
+  switch (texDesc.m_Type)
   {
-    pDXResource = static_cast<const ezGALTextureDX11*>(pTexture->GetParentResource())->GetDXTexture();
-    const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
+    case ezGALTextureType::Texture2D:
+    case ezGALTextureType::Texture2DProxy:
+    case ezGALTextureType::Texture2DShared:
 
-    const bool bIsArrayView = IsArrayView(texDesc, m_Description);
-
-    switch (texDesc.m_Type)
-    {
-      case ezGALTextureType::Texture2D:
-      case ezGALTextureType::Texture2DProxy:
-      case ezGALTextureType::Texture2DShared:
-
-        if (!bIsArrayView)
+      if (!bIsArrayView)
+      {
+        if (texDesc.m_SampleCount == ezGALMSAASampleCount::None)
         {
-          if (texDesc.m_SampleCount == ezGALMSAASampleCount::None)
-          {
-            DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-            DXSRVDesc.Texture2D.MipLevels = m_Description.m_uiMipLevelsToUse;
-            DXSRVDesc.Texture2D.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
-          }
-          else
-          {
-            DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMS;
-          }
+          DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+          DXSRVDesc.Texture2D.MipLevels = m_Description.m_uiMipLevelsToUse;
+          DXSRVDesc.Texture2D.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
         }
         else
         {
-          if (texDesc.m_SampleCount == ezGALMSAASampleCount::None)
-          {
-            DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
-            DXSRVDesc.Texture2DArray.MipLevels = m_Description.m_uiMipLevelsToUse;
-            DXSRVDesc.Texture2DArray.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
-            DXSRVDesc.Texture2DArray.ArraySize = m_Description.m_uiArraySize;
-            DXSRVDesc.Texture2DArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
-          }
-          else
-          {
-            DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
-            DXSRVDesc.Texture2DMSArray.ArraySize = m_Description.m_uiArraySize;
-            DXSRVDesc.Texture2DMSArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
-          }
+          DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMS;
         }
-
-        break;
-
-      case ezGALTextureType::TextureCube:
-
-        if (!bIsArrayView)
+      }
+      else
+      {
+        if (texDesc.m_SampleCount == ezGALMSAASampleCount::None)
         {
-          DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
-          DXSRVDesc.TextureCube.MipLevels = m_Description.m_uiMipLevelsToUse;
-          DXSRVDesc.TextureCube.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
+          DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+          DXSRVDesc.Texture2DArray.MipLevels = m_Description.m_uiMipLevelsToUse;
+          DXSRVDesc.Texture2DArray.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
+          DXSRVDesc.Texture2DArray.ArraySize = m_Description.m_uiArraySize;
+          DXSRVDesc.Texture2DArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
         }
         else
         {
-          DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
-          DXSRVDesc.TextureCube.MipLevels = m_Description.m_uiMipLevelsToUse;
-          DXSRVDesc.TextureCube.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
-          DXSRVDesc.TextureCubeArray.NumCubes = m_Description.m_uiArraySize;
-          DXSRVDesc.TextureCubeArray.First2DArrayFace = m_Description.m_uiFirstArraySlice;
+          DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DMSARRAY;
+          DXSRVDesc.Texture2DMSArray.ArraySize = m_Description.m_uiArraySize;
+          DXSRVDesc.Texture2DMSArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
         }
+      }
 
-        break;
+      break;
 
-      case ezGALTextureType::Texture3D:
+    case ezGALTextureType::TextureCube:
 
-        DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
-        DXSRVDesc.Texture3D.MipLevels = m_Description.m_uiMipLevelsToUse;
-        DXSRVDesc.Texture3D.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
+      if (!bIsArrayView)
+      {
+        DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBE;
+        DXSRVDesc.TextureCube.MipLevels = m_Description.m_uiMipLevelsToUse;
+        DXSRVDesc.TextureCube.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
+      }
+      else
+      {
+        DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURECUBEARRAY;
+        DXSRVDesc.TextureCube.MipLevels = m_Description.m_uiMipLevelsToUse;
+        DXSRVDesc.TextureCube.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
+        DXSRVDesc.TextureCubeArray.NumCubes = m_Description.m_uiArraySize;
+        DXSRVDesc.TextureCubeArray.First2DArrayFace = m_Description.m_uiFirstArraySlice;
+      }
 
-        break;
+      break;
 
-      default:
-        EZ_ASSERT_NOT_IMPLEMENTED;
-        return EZ_FAILURE;
-    }
-  }
-  else if (pBuffer)
-  {
-    pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
+    case ezGALTextureType::Texture3D:
 
-    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
-      DXSRVDesc.Format = DXGI_FORMAT_UNKNOWN;
+      DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE3D;
+      DXSRVDesc.Texture3D.MipLevels = m_Description.m_uiMipLevelsToUse;
+      DXSRVDesc.Texture3D.MostDetailedMip = m_Description.m_uiMostDetailedMipLevel;
 
-    DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
-    DXSRVDesc.BufferEx.FirstElement = DXSRVDesc.Buffer.FirstElement = m_Description.m_uiFirstElement;
-    DXSRVDesc.BufferEx.NumElements = DXSRVDesc.Buffer.NumElements = m_Description.m_uiNumElements;
-    DXSRVDesc.BufferEx.Flags = m_Description.m_bRawView ? D3D11_BUFFEREX_SRV_FLAG_RAW : 0;
+      break;
+
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+      return EZ_FAILURE;
   }
 
   if (FAILED(pDXDevice->GetDXDevice()->CreateShaderResourceView(pDXResource, &DXSRVDesc, &m_pDXResourceView)))
@@ -181,7 +146,89 @@ ezResult ezGALResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
   }
 }
 
-ezResult ezGALResourceViewDX11::DeInitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureResourceViewDX11::DeInitPlatform(ezGALDevice* pDevice)
+{
+  EZ_GAL_DX11_RELEASE(m_pDXResourceView);
+  return EZ_SUCCESS;
+}
+
+///////////////////////////////////////////////////////////////////////////////////
+
+ezGALBufferResourceViewDX11::ezGALBufferResourceViewDX11(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description)
+  : ezGALBufferResourceView(pResource, Description)
+
+{
+}
+
+ezGALBufferResourceViewDX11::~ezGALBufferResourceViewDX11() = default;
+
+ezResult ezGALBufferResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
+{
+  const ezGALBuffer* pBuffer = nullptr;
+  if (!m_Description.m_hBuffer.IsInvalidated())
+    pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
+
+  if (pBuffer == nullptr)
+  {
+    ezLog::Error("No valid buffer handle given for resource view creation!");
+    return EZ_FAILURE;
+  }
+
+  ezGALResourceFormat::Enum ViewFormat = m_Description.m_OverrideViewFormat;
+
+  if (ViewFormat == ezGALResourceFormat::Invalid)
+    ViewFormat = ezGALResourceFormat::RUInt;
+
+  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
+  {
+    ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
+    return EZ_FAILURE;
+  }
+
+  ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
+
+  DXGI_FORMAT DXViewFormat = DXGI_FORMAT_UNKNOWN;
+  if (ezGALResourceFormat::IsDepthFormat(ViewFormat))
+  {
+    DXViewFormat = pDXDevice->GetFormatLookupTable().GetFormatInfo(ViewFormat).m_eDepthOnlyType;
+  }
+  else
+  {
+    DXViewFormat = pDXDevice->GetFormatLookupTable().GetFormatInfo(ViewFormat).m_eResourceViewType;
+  }
+
+  if (DXViewFormat == DXGI_FORMAT_UNKNOWN)
+  {
+    ezLog::Error("Couldn't get valid DXGI format for resource view! ({0})", ViewFormat);
+    return EZ_FAILURE;
+  }
+
+  D3D11_SHADER_RESOURCE_VIEW_DESC DXSRVDesc;
+  DXSRVDesc.Format = DXViewFormat;
+
+  ID3D11Resource* pDXResource = nullptr;
+
+  pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
+
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+    DXSRVDesc.Format = DXGI_FORMAT_UNKNOWN;
+
+  DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;
+  DXSRVDesc.BufferEx.FirstElement = DXSRVDesc.Buffer.FirstElement = m_Description.m_uiFirstElement;
+  DXSRVDesc.BufferEx.NumElements = DXSRVDesc.Buffer.NumElements = m_Description.m_uiNumElements;
+  DXSRVDesc.BufferEx.Flags = m_Description.m_bRawView ? D3D11_BUFFEREX_SRV_FLAG_RAW : 0;
+
+  if (FAILED(pDXDevice->GetDXDevice()->CreateShaderResourceView(pDXResource, &DXSRVDesc, &m_pDXResourceView)))
+  {
+    return EZ_FAILURE;
+  }
+  else
+  {
+    return EZ_SUCCESS;
+  }
+}
+
+ezResult ezGALBufferResourceViewDX11::DeInitPlatform(ezGALDevice* pDevice)
 {
   EZ_GAL_DX11_RELEASE(m_pDXResourceView);
   return EZ_SUCCESS;

--- a/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11.cpp
@@ -49,7 +49,7 @@ ezResult ezGALResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
     if (ViewFormat == ezGALResourceFormat::Invalid)
       ViewFormat = ezGALResourceFormat::RUInt;
 
-    if (!pBuffer->GetDescription().m_bAllowRawViews && m_Description.m_bRawView)
+    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
     {
       ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
       return EZ_FAILURE;
@@ -162,7 +162,7 @@ ezResult ezGALResourceViewDX11::InitPlatform(ezGALDevice* pDevice)
   {
     pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
 
-    if (pBuffer->GetDescription().m_bUseAsStructuredBuffer)
+    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
       DXSRVDesc.Format = DXGI_FORMAT_UNKNOWN;
 
     DXSRVDesc.ViewDimension = D3D11_SRV_DIMENSION_BUFFER;

--- a/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11_inl.h
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ResourceViewDX11_inl.h
@@ -1,5 +1,10 @@
 
-ID3D11ShaderResourceView* ezGALResourceViewDX11::GetDXResourceView() const
+ID3D11ShaderResourceView* ezGALTextureResourceViewDX11::GetDXResourceView() const
+{
+  return m_pDXResourceView;
+}
+
+ID3D11ShaderResourceView* ezGALBufferResourceViewDX11::GetDXResourceView() const
 {
   return m_pDXResourceView;
 }

--- a/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
@@ -171,7 +171,7 @@ ezResult ezGALBufferUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
 
   ID3D11Resource* pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
 
-  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer))
     DXUAVDesc.Format = DXGI_FORMAT_UNKNOWN;
 
   DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;

--- a/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
@@ -7,49 +7,41 @@
 
 #include <d3d11.h>
 
-bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc)
+bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALTextureUnorderedAccessViewCreationDescription& viewDesc)
 {
   return texDesc.m_uiArraySize > 1 || viewDesc.m_uiFirstArraySlice > 0;
 }
 
-ezGALUnorderedAccessViewDX11::ezGALUnorderedAccessViewDX11(
-  ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description)
-  : ezGALUnorderedAccessView(pResource, Description)
+ezGALTextureUnorderedAccessViewDX11::ezGALTextureUnorderedAccessViewDX11(
+  ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description)
+  : ezGALTextureUnorderedAccessView(pResource, Description)
 
 {
 }
 
-ezGALUnorderedAccessViewDX11::~ezGALUnorderedAccessViewDX11() = default;
+ezGALTextureUnorderedAccessViewDX11::~ezGALTextureUnorderedAccessViewDX11() = default;
 
-ezResult ezGALUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
 {
   const ezGALTexture* pTexture = nullptr;
   if (!m_Description.m_hTexture.IsInvalidated())
     pTexture = pDevice->GetTexture(m_Description.m_hTexture);
 
-  const ezGALBuffer* pBuffer = nullptr;
-  if (!m_Description.m_hBuffer.IsInvalidated())
-    pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
-
-  if (pTexture == nullptr && pBuffer == nullptr)
+  if (pTexture == nullptr)
   {
-    ezLog::Error("No valid texture handle or buffer handle given for unordered access view creation!");
+    ezLog::Error("No valid texture handle given for unordered access view creation!");
     return EZ_FAILURE;
   }
 
-
   ezGALResourceFormat::Enum ViewFormat = m_Description.m_OverrideViewFormat;
 
-  if (pTexture)
   {
     const ezGALTextureCreationDescription& TexDesc = pTexture->GetDescription();
-
     if (ViewFormat == ezGALResourceFormat::Invalid)
       ViewFormat = TexDesc.m_Format;
   }
 
   ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
-
 
   DXGI_FORMAT DXViewFormat = DXGI_FORMAT_UNKNOWN;
   if (ezGALResourceFormat::IsDepthFormat(ViewFormat))
@@ -70,70 +62,49 @@ ezResult ezGALUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
   D3D11_UNORDERED_ACCESS_VIEW_DESC DXUAVDesc;
   DXUAVDesc.Format = DXViewFormat;
 
-  ID3D11Resource* pDXResource = nullptr;
+  ID3D11Resource* pDXResource = static_cast<const ezGALTextureDX11*>(pTexture->GetParentResource())->GetDXTexture();
+  const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
 
-  if (pTexture)
+  const bool bIsArrayView = IsArrayView(texDesc, m_Description);
+
+  switch (texDesc.m_Type)
   {
-    pDXResource = static_cast<const ezGALTextureDX11*>(pTexture->GetParentResource())->GetDXTexture();
-    const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
+    case ezGALTextureType::Texture2D:
+    case ezGALTextureType::Texture2DProxy:
+    case ezGALTextureType::Texture2DShared:
 
-    const bool bIsArrayView = IsArrayView(texDesc, m_Description);
-
-    switch (texDesc.m_Type)
-    {
-      case ezGALTextureType::Texture2D:
-      case ezGALTextureType::Texture2DProxy:
-      case ezGALTextureType::Texture2DShared:
-
-        if (!bIsArrayView)
-        {
-          DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
-          DXUAVDesc.Texture2D.MipSlice = m_Description.m_uiMipLevelToUse;
-        }
-        else
-        {
-          DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
-          DXUAVDesc.Texture2DArray.MipSlice = m_Description.m_uiMipLevelToUse;
-          DXUAVDesc.Texture2DArray.ArraySize = m_Description.m_uiArraySize;
-          DXUAVDesc.Texture2DArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
-        }
-        break;
-
-      case ezGALTextureType::TextureCube:
+      if (!bIsArrayView)
+      {
+        DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+        DXUAVDesc.Texture2D.MipSlice = m_Description.m_uiMipLevelToUse;
+      }
+      else
+      {
         DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
         DXUAVDesc.Texture2DArray.MipSlice = m_Description.m_uiMipLevelToUse;
         DXUAVDesc.Texture2DArray.ArraySize = m_Description.m_uiArraySize;
         DXUAVDesc.Texture2DArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
-        break;
+      }
+      break;
 
-      case ezGALTextureType::Texture3D:
+    case ezGALTextureType::TextureCube:
+      DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
+      DXUAVDesc.Texture2DArray.MipSlice = m_Description.m_uiMipLevelToUse;
+      DXUAVDesc.Texture2DArray.ArraySize = m_Description.m_uiArraySize;
+      DXUAVDesc.Texture2DArray.FirstArraySlice = m_Description.m_uiFirstArraySlice;
+      break;
 
-        DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE3D;
-        DXUAVDesc.Texture3D.MipSlice = m_Description.m_uiMipLevelToUse;
-        DXUAVDesc.Texture3D.FirstWSlice = m_Description.m_uiFirstArraySlice;
-        DXUAVDesc.Texture3D.WSize = m_Description.m_uiArraySize;
-        break;
+    case ezGALTextureType::Texture3D:
 
-      default:
-        EZ_ASSERT_NOT_IMPLEMENTED;
-        return EZ_FAILURE;
-    }
-  }
-  else if (pBuffer)
-  {
-    pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
+      DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE3D;
+      DXUAVDesc.Texture3D.MipSlice = m_Description.m_uiMipLevelToUse;
+      DXUAVDesc.Texture3D.FirstWSlice = m_Description.m_uiFirstArraySlice;
+      DXUAVDesc.Texture3D.WSize = m_Description.m_uiArraySize;
+      break;
 
-    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
-      DXUAVDesc.Format = DXGI_FORMAT_UNKNOWN;
-
-    DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
-    DXUAVDesc.Buffer.FirstElement = m_Description.m_uiFirstElement;
-    DXUAVDesc.Buffer.NumElements = m_Description.m_uiNumElements;
-    DXUAVDesc.Buffer.Flags = 0;
-    if (m_Description.m_bRawView)
-      DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_RAW;
-    if (m_Description.m_bAppend)
-      DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_APPEND;
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+      return EZ_FAILURE;
   }
 
   if (FAILED(pDXDevice->GetDXDevice()->CreateUnorderedAccessView(pDXResource, &DXUAVDesc, &m_pDXUnorderedAccessView)))
@@ -146,12 +117,85 @@ ezResult ezGALUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
   }
 }
 
-ezResult ezGALUnorderedAccessViewDX11::DeInitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureUnorderedAccessViewDX11::DeInitPlatform(ezGALDevice* pDevice)
 {
   EZ_GAL_DX11_RELEASE(m_pDXUnorderedAccessView);
   return EZ_SUCCESS;
 }
 
+/////////////////////////////////////////////////////////////////////
 
+ezGALBufferUnorderedAccessViewDX11::ezGALBufferUnorderedAccessViewDX11(
+  ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description)
+  : ezGALBufferUnorderedAccessView(pResource, Description)
 
+{
+}
+
+ezGALBufferUnorderedAccessViewDX11::~ezGALBufferUnorderedAccessViewDX11() = default;
+
+ezResult ezGALBufferUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
+{
+  const ezGALBuffer* pBuffer = nullptr;
+  if (!m_Description.m_hBuffer.IsInvalidated())
+    pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
+
+  if (pBuffer == nullptr)
+  {
+    ezLog::Error("No valid buffer handle given for unordered access view creation!");
+    return EZ_FAILURE;
+  }
+
+  ezGALResourceFormat::Enum ViewFormat = m_Description.m_OverrideViewFormat;
+
+  ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
+
+  DXGI_FORMAT DXViewFormat = DXGI_FORMAT_UNKNOWN;
+  if (ezGALResourceFormat::IsDepthFormat(ViewFormat))
+  {
+    DXViewFormat = pDXDevice->GetFormatLookupTable().GetFormatInfo(ViewFormat).m_eDepthOnlyType;
+  }
+  else
+  {
+    DXViewFormat = pDXDevice->GetFormatLookupTable().GetFormatInfo(ViewFormat).m_eResourceViewType;
+  }
+
+  if (DXViewFormat == DXGI_FORMAT_UNKNOWN)
+  {
+    ezLog::Error("Couldn't get valid DXGI format for resource view! ({0})", ViewFormat);
+    return EZ_FAILURE;
+  }
+
+  D3D11_UNORDERED_ACCESS_VIEW_DESC DXUAVDesc;
+  DXUAVDesc.Format = DXViewFormat;
+
+  ID3D11Resource* pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
+
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+    DXUAVDesc.Format = DXGI_FORMAT_UNKNOWN;
+
+  DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;
+  DXUAVDesc.Buffer.FirstElement = m_Description.m_uiFirstElement;
+  DXUAVDesc.Buffer.NumElements = m_Description.m_uiNumElements;
+  DXUAVDesc.Buffer.Flags = 0;
+  if (m_Description.m_bRawView)
+    DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_RAW;
+  if (m_Description.m_bAppend)
+    DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_APPEND;
+
+  if (FAILED(pDXDevice->GetDXDevice()->CreateUnorderedAccessView(pDXResource, &DXUAVDesc, &m_pDXUnorderedAccessView)))
+  {
+    return EZ_FAILURE;
+  }
+  else
+  {
+    return EZ_SUCCESS;
+  }
+}
+
+ezResult ezGALBufferUnorderedAccessViewDX11::DeInitPlatform(ezGALDevice* pDevice)
+{
+  EZ_GAL_DX11_RELEASE(m_pDXUnorderedAccessView);
+  return EZ_SUCCESS;
+}
 EZ_STATICLINK_FILE(RendererDX11, RendererDX11_Resources_Implementation_UnorderedAccessViewDX11);

--- a/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
@@ -123,7 +123,7 @@ ezResult ezGALUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
   {
     pDXResource = static_cast<const ezGALBufferDX11*>(pBuffer)->GetDXBuffer();
 
-    if (pBuffer->GetDescription().m_bUseAsStructuredBuffer)
+    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
       DXUAVDesc.Format = DXGI_FORMAT_UNKNOWN;
 
     DXUAVDesc.ViewDimension = D3D11_UAV_DIMENSION_BUFFER;

--- a/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
@@ -181,7 +181,7 @@ ezResult ezGALBufferUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
   if (m_Description.m_bRawView)
     DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_RAW;
   // #TODO_VULKAN Append / counter buffers can't easily be implemented in Vulkan on top of the same buffer infrastructure. So it's best to make these their own resource type similiar to shared textures.
-  //if (m_Description.m_bAppend)
+  // if (m_Description.m_bAppend)
   //  DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_APPEND;
 
   if (FAILED(pDXDevice->GetDXDevice()->CreateUnorderedAccessView(pDXResource, &DXUAVDesc, &m_pDXUnorderedAccessView)))

--- a/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11.cpp
@@ -180,8 +180,9 @@ ezResult ezGALBufferUnorderedAccessViewDX11::InitPlatform(ezGALDevice* pDevice)
   DXUAVDesc.Buffer.Flags = 0;
   if (m_Description.m_bRawView)
     DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_RAW;
-  if (m_Description.m_bAppend)
-    DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_APPEND;
+  // #TODO_VULKAN Append / counter buffers can't easily be implemented in Vulkan on top of the same buffer infrastructure. So it's best to make these their own resource type similiar to shared textures.
+  //if (m_Description.m_bAppend)
+  //  DXUAVDesc.Buffer.Flags |= D3D11_BUFFER_UAV_FLAG_APPEND;
 
   if (FAILED(pDXDevice->GetDXDevice()->CreateUnorderedAccessView(pDXResource, &DXUAVDesc, &m_pDXUnorderedAccessView)))
   {

--- a/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11_inl.h
+++ b/Code/Engine/RendererDX11/Resources/Implementation/UnorderedAccessViewDX11_inl.h
@@ -1,5 +1,10 @@
 
-ID3D11UnorderedAccessView* ezGALUnorderedAccessViewDX11::GetDXResourceView() const
+ID3D11UnorderedAccessView* ezGALTextureUnorderedAccessViewDX11::GetDXResourceView() const
+{
+  return m_pDXUnorderedAccessView;
+}
+
+ID3D11UnorderedAccessView* ezGALBufferUnorderedAccessViewDX11::GetDXResourceView() const
 {
   return m_pDXUnorderedAccessView;
 }

--- a/Code/Engine/RendererDX11/Resources/ResourceViewDX11.h
+++ b/Code/Engine/RendererDX11/Resources/ResourceViewDX11.h
@@ -5,7 +5,7 @@
 
 struct ID3D11ShaderResourceView;
 
-class ezGALResourceViewDX11 : public ezGALResourceView
+class ezGALTextureResourceViewDX11 : public ezGALTextureResourceView
 {
 public:
   EZ_ALWAYS_INLINE ID3D11ShaderResourceView* GetDXResourceView() const;
@@ -14,9 +14,30 @@ protected:
   friend class ezGALDeviceDX11;
   friend class ezMemoryUtils;
 
-  ezGALResourceViewDX11(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description);
+  ezGALTextureResourceViewDX11(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description);
 
-  ~ezGALResourceViewDX11();
+  ~ezGALTextureResourceViewDX11();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  ID3D11ShaderResourceView* m_pDXResourceView = nullptr;
+};
+
+
+class ezGALBufferResourceViewDX11 : public ezGALBufferResourceView
+{
+public:
+  EZ_ALWAYS_INLINE ID3D11ShaderResourceView* GetDXResourceView() const;
+
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  ezGALBufferResourceViewDX11(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description);
+
+  ~ezGALBufferResourceViewDX11();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
 

--- a/Code/Engine/RendererDX11/Resources/UnorderedAccessViewDX11.h
+++ b/Code/Engine/RendererDX11/Resources/UnorderedAccessViewDX11.h
@@ -27,7 +27,7 @@ class ezGALBufferUnorderedAccessViewDX11 : public ezGALBufferUnorderedAccessView
 {
 public:
   EZ_ALWAYS_INLINE ID3D11UnorderedAccessView* GetDXResourceView() const;
-  
+
 protected:
   friend class ezGALDeviceDX11;
   friend class ezMemoryUtils;

--- a/Code/Engine/RendererDX11/Resources/UnorderedAccessViewDX11.h
+++ b/Code/Engine/RendererDX11/Resources/UnorderedAccessViewDX11.h
@@ -5,7 +5,7 @@
 
 struct ID3D11UnorderedAccessView;
 
-class ezGALUnorderedAccessViewDX11 : public ezGALUnorderedAccessView
+class ezGALTextureUnorderedAccessViewDX11 : public ezGALTextureUnorderedAccessView
 {
 public:
   EZ_ALWAYS_INLINE ID3D11UnorderedAccessView* GetDXResourceView() const;
@@ -14,12 +14,28 @@ protected:
   friend class ezGALDeviceDX11;
   friend class ezMemoryUtils;
 
-  ezGALUnorderedAccessViewDX11(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description);
-
-  ~ezGALUnorderedAccessViewDX11();
+  ezGALTextureUnorderedAccessViewDX11(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description);
+  ~ezGALTextureUnorderedAccessViewDX11();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
+  ID3D11UnorderedAccessView* m_pDXUnorderedAccessView = nullptr;
+};
+
+class ezGALBufferUnorderedAccessViewDX11 : public ezGALBufferUnorderedAccessView
+{
+public:
+  EZ_ALWAYS_INLINE ID3D11UnorderedAccessView* GetDXResourceView() const;
+  
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  ezGALBufferUnorderedAccessViewDX11(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description);
+  ~ezGALBufferUnorderedAccessViewDX11();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
   ID3D11UnorderedAccessView* m_pDXUnorderedAccessView = nullptr;

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -16,7 +16,8 @@ public:
 
   void SetConstantBuffer(const ezShaderResourceBinding& binding, ezGALBufferHandle hBuffer);
   void SetSamplerState(const ezShaderResourceBinding& binding, ezGALSamplerStateHandle hSamplerState);
-  void SetResourceView(const ezShaderResourceBinding& binding, ezGALResourceViewHandle hResourceView);
+  void SetResourceView(const ezShaderResourceBinding& binding, ezGALTextureResourceViewHandle hResourceView);
+  void SetResourceView(const ezShaderResourceBinding& binding, ezGALBufferResourceViewHandle hResourceView);
   void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALUnorderedAccessViewHandle hUnorderedAccessView);
   void SetPushConstants(ezArrayPtr<const ezUInt8> data);
 
@@ -54,7 +55,7 @@ public:
   void ReadbackTexture(ezGALTextureHandle hTexture);
   void CopyTextureReadbackResult(ezGALTextureHandle hTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData);
 
-  void GenerateMipMaps(ezGALResourceViewHandle hResourceView);
+  void GenerateMipMaps(ezGALTextureResourceViewHandle hResourceView);
 
   // Misc
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -18,7 +18,8 @@ public:
   void SetSamplerState(const ezShaderResourceBinding& binding, ezGALSamplerStateHandle hSamplerState);
   void SetResourceView(const ezShaderResourceBinding& binding, ezGALTextureResourceViewHandle hResourceView);
   void SetResourceView(const ezShaderResourceBinding& binding, ezGALBufferResourceViewHandle hResourceView);
-  void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALUnorderedAccessViewHandle hUnorderedAccessView);
+  void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView);
+  void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView);
   void SetPushConstants(ezArrayPtr<const ezUInt8> data);
 
   // Query functions
@@ -36,10 +37,12 @@ public:
   // Resource functions
 
   /// Clears an unordered access view with a float value.
-  void ClearUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues);
+  void ClearUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues);
+  void ClearUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues);
 
   /// Clears an unordered access view with an int value.
-  void ClearUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView, ezVec4U32 vClearValues);
+  void ClearUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView, ezVec4U32 vClearValues);
+  void ClearUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView, ezVec4U32 vClearValues);
 
   void CopyBuffer(ezGALBufferHandle hDest, ezGALBufferHandle hSource);
   void CopyBufferRegion(ezGALBufferHandle hDest, ezUInt32 uiDestOffset, ezGALBufferHandle hSource, ezUInt32 uiSourceOffset, ezUInt32 uiByteCount);

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
@@ -16,7 +16,8 @@ public:
 
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) = 0;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) = 0;
-  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALResourceView* pResourceView) = 0;
+  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) = 0;
+  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView) = 0;
   virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView) = 0;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) = 0;
 
@@ -51,7 +52,7 @@ public:
 
   virtual void CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData) = 0;
 
-  virtual void GenerateMipMapsPlatform(const ezGALResourceView* pResourceView) = 0;
+  virtual void GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView) = 0;
 
   // Misc
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
@@ -18,7 +18,8 @@ public:
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) = 0;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) = 0;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView) = 0;
-  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView) = 0;
+  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureUnorderedAccessView* pUnorderedAccessView) = 0;
+  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferUnorderedAccessView* pUnorderedAccessView) = 0;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) = 0;
 
   // Query functions
@@ -33,8 +34,11 @@ public:
 
   // Resource update functions
 
-  virtual void ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues) = 0;
-  virtual void ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues) = 0;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues) = 0;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues) = 0;
+
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4 vClearValues) = 0;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4U32 vClearValues) = 0;
 
   virtual void CopyBufferPlatform(const ezGALBuffer* pDestination, const ezGALBuffer* pSource) = 0;
   virtual void CopyBufferRegionPlatform(const ezGALBuffer* pDestination, ezUInt32 uiDestOffset, const ezGALBuffer* pSource, ezUInt32 uiSourceOffset, ezUInt32 uiByteCount) = 0;

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -30,7 +30,7 @@ void ezGALCommandEncoder::SetConstantBuffer(const ezShaderResourceBinding& bindi
   AssertRenderingThread();
 
   const ezGALBuffer* pBuffer = m_Device.GetBuffer(hBuffer);
-  EZ_ASSERT_DEV(pBuffer == nullptr || pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ConstantBuffer), "Wrong buffer type");
+  EZ_ASSERT_DEV(pBuffer == nullptr || pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::ConstantBuffer), "Wrong buffer type");
 
   m_CommonImpl.SetConstantBufferPlatform(binding, pBuffer);
 }

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -44,11 +44,20 @@ void ezGALCommandEncoder::SetSamplerState(const ezShaderResourceBinding& binding
   m_CommonImpl.SetSamplerStatePlatform(binding, pSamplerState);
 }
 
-void ezGALCommandEncoder::SetResourceView(const ezShaderResourceBinding& binding, ezGALResourceViewHandle hResourceView)
+void ezGALCommandEncoder::SetResourceView(const ezShaderResourceBinding& binding, ezGALTextureResourceViewHandle hResourceView)
 {
   AssertRenderingThread();
 
-  const ezGALResourceView* pResourceView = m_Device.GetResourceView(hResourceView);
+  const ezGALTextureResourceView* pResourceView = m_Device.GetResourceView(hResourceView);
+
+  m_CommonImpl.SetResourceViewPlatform(binding, pResourceView);
+}
+
+void ezGALCommandEncoder::SetResourceView(const ezShaderResourceBinding& binding, ezGALBufferResourceViewHandle hResourceView)
+{
+  AssertRenderingThread();
+
+  const ezGALBufferResourceView* pResourceView = m_Device.GetResourceView(hResourceView);
 
   m_CommonImpl.SetResourceViewPlatform(binding, pResourceView);
 }
@@ -301,11 +310,11 @@ void ezGALCommandEncoder::CopyTextureReadbackResult(ezGALTextureHandle hTexture,
   }
 }
 
-void ezGALCommandEncoder::GenerateMipMaps(ezGALResourceViewHandle hResourceView)
+void ezGALCommandEncoder::GenerateMipMaps(ezGALTextureResourceViewHandle hResourceView)
 {
   AssertRenderingThread();
 
-  const ezGALResourceView* pResourceView = m_Device.GetResourceView(hResourceView);
+  const ezGALTextureResourceView* pResourceView = m_Device.GetResourceView(hResourceView);
   if (pResourceView != nullptr)
   {
     EZ_ASSERT_DEV(!pResourceView->GetDescription().m_hTexture.IsInvalidated(), "Resource view needs a valid texture to generate mip maps.");

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -62,11 +62,19 @@ void ezGALCommandEncoder::SetResourceView(const ezShaderResourceBinding& binding
   m_CommonImpl.SetResourceViewPlatform(binding, pResourceView);
 }
 
-void ezGALCommandEncoder::SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALUnorderedAccessViewHandle hUnorderedAccessView)
+void ezGALCommandEncoder::SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView)
 {
   AssertRenderingThread();
 
-  const ezGALUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
+  const ezGALTextureUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
+  m_CommonImpl.SetUnorderedAccessViewPlatform(binding, pUnorderedAccessView);
+}
+
+void ezGALCommandEncoder::SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView)
+{
+  AssertRenderingThread();
+  
+  const ezGALBufferUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
   m_CommonImpl.SetUnorderedAccessViewPlatform(binding, pUnorderedAccessView);
 }
 
@@ -115,11 +123,11 @@ ezGALTimestampHandle ezGALCommandEncoder::InsertTimestamp()
   return hTimestamp;
 }
 
-void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues)
+void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues)
 {
   AssertRenderingThread();
 
-  const ezGALUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
+  const ezGALTextureUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
   if (pUnorderedAccessView == nullptr)
   {
     EZ_REPORT_FAILURE("ClearUnorderedAccessView failed, unordered access view handle invalid.");
@@ -129,11 +137,39 @@ void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALUnorderedAccessViewHandl
   m_CommonImpl.ClearUnorderedAccessViewPlatform(pUnorderedAccessView, vClearValues);
 }
 
-void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView, ezVec4U32 vClearValues)
+void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues)
 {
   AssertRenderingThread();
 
-  const ezGALUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
+  const ezGALBufferUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
+  if (pUnorderedAccessView == nullptr)
+  {
+    EZ_REPORT_FAILURE("ClearUnorderedAccessView failed, unordered access view handle invalid.");
+    return;
+  }
+
+  m_CommonImpl.ClearUnorderedAccessViewPlatform(pUnorderedAccessView, vClearValues);
+}
+
+void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView, ezVec4U32 vClearValues)
+{
+  AssertRenderingThread();
+
+  const ezGALTextureUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
+  if (pUnorderedAccessView == nullptr)
+  {
+    EZ_REPORT_FAILURE("ClearUnorderedAccessView failed, unordered access view handle invalid.");
+    return;
+  }
+
+  m_CommonImpl.ClearUnorderedAccessViewPlatform(pUnorderedAccessView, vClearValues);
+}
+
+void ezGALCommandEncoder::ClearUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView, ezVec4U32 vClearValues)
+{
+  AssertRenderingThread();
+
+  const ezGALBufferUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
   if (pUnorderedAccessView == nullptr)
   {
     EZ_REPORT_FAILURE("ClearUnorderedAccessView failed, unordered access view handle invalid.");

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -73,7 +73,7 @@ void ezGALCommandEncoder::SetUnorderedAccessView(const ezShaderResourceBinding& 
 void ezGALCommandEncoder::SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView)
 {
   AssertRenderingThread();
-  
+
   const ezGALBufferUnorderedAccessView* pUnorderedAccessView = m_Device.GetUnorderedAccessView(hUnorderedAccessView);
   m_CommonImpl.SetUnorderedAccessViewPlatform(binding, pUnorderedAccessView);
 }

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -30,7 +30,7 @@ void ezGALCommandEncoder::SetConstantBuffer(const ezShaderResourceBinding& bindi
   AssertRenderingThread();
 
   const ezGALBuffer* pBuffer = m_Device.GetBuffer(hBuffer);
-  EZ_ASSERT_DEV(pBuffer == nullptr || pBuffer->GetDescription().m_BufferType == ezGALBufferType::ConstantBuffer, "Wrong buffer type");
+  EZ_ASSERT_DEV(pBuffer == nullptr || pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ConstantBuffer), "Wrong buffer type");
 
   m_CommonImpl.SetConstantBufferPlatform(binding, pBuffer);
 }

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -167,17 +167,9 @@ struct ezGALResourceAccess
 
 struct ezGALBufferCreationDescription : public ezHashableStruct<ezGALBufferCreationDescription>
 {
-  ezUInt32 m_uiStructSize = 0;
   ezUInt32 m_uiTotalSize = 0;
-
-  ezEnum<ezGALBufferType> m_BufferType = ezGALBufferType::Generic;
-
-  bool m_bUseForIndirectArguments = false;
-  bool m_bUseAsStructuredBuffer = false;
-  bool m_bAllowRawViews = false;
-  bool m_bAllowShaderResourceView = false;
-  bool m_bAllowUAV = false;
-
+  ezUInt32 m_uiStructSize = 0; // Struct or texel size
+  ezBitflags<ezGALBufferFlags> m_BufferFlags;
   ezGALResourceAccess m_ResourceAccess;
 };
 

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -246,7 +246,6 @@ struct ezGALBufferUnorderedAccessViewCreationDescription : public ezHashableStru
   ezUInt32 m_uiNumElements = 0;
   ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
   bool m_bRawView = false;
-  bool m_bAppend = false; // Allows appending data to the end of the buffer.
 };
 
 struct ezGALQueryCreationDescription : public ezHashableStruct<ezGALQueryCreationDescription>

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -230,22 +230,21 @@ struct ezGALRenderTargetViewCreationDescription : public ezHashableStruct<ezGALR
   bool m_bReadOnly = false; ///< Can be used for depth stencil views to create read only views (e.g. for soft particles using the native depth buffer)
 };
 
-struct ezGALUnorderedAccessViewCreationDescription : public ezHashableStruct<ezGALUnorderedAccessViewCreationDescription>
+struct ezGALTextureUnorderedAccessViewCreationDescription : public ezHashableStruct<ezGALTextureUnorderedAccessViewCreationDescription>
 {
   ezGALTextureHandle m_hTexture;
-
-  ezGALBufferHandle m_hBuffer;
-
-  ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
-
-  // Texture only
-  ezUInt32 m_uiMipLevelToUse = 0;   ///< Which MipLevel is accessed with this UAV
   ezUInt32 m_uiFirstArraySlice = 0; ///< First depth slice for 3D Textures.
   ezUInt32 m_uiArraySize = 1;       ///< Number of depth slices for 3D textures.
+  ezUInt16 m_uiMipLevelToUse = 0;   ///< Which MipLevel is accessed with this UAV
+  ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
+};
 
-  // Buffer only
+struct ezGALBufferUnorderedAccessViewCreationDescription : public ezHashableStruct<ezGALBufferUnorderedAccessViewCreationDescription>
+{
+  ezGALBufferHandle m_hBuffer;
   ezUInt32 m_uiFirstElement = 0;
   ezUInt32 m_uiNumElements = 0;
+  ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
   bool m_bRawView = false;
   bool m_bAppend = false; // Allows appending data to the end of the buffer.
 };

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -169,7 +169,7 @@ struct ezGALBufferCreationDescription : public ezHashableStruct<ezGALBufferCreat
 {
   ezUInt32 m_uiTotalSize = 0;
   ezUInt32 m_uiStructSize = 0; // Struct or texel size
-  ezBitflags<ezGALBufferFlags> m_BufferFlags;
+  ezBitflags<ezGALBufferUsageFlags> m_BufferFlags;
   ezGALResourceAccess m_ResourceAccess;
 };
 

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -197,22 +197,20 @@ struct ezGALTextureCreationDescription : public ezHashableStruct<ezGALTextureCre
   void* m_pExisitingNativeObject = nullptr; ///< Can be used to encapsulate existing native textures in objects usable by the GAL
 };
 
-struct ezGALResourceViewCreationDescription : public ezHashableStruct<ezGALResourceViewCreationDescription>
+struct ezGALTextureResourceViewCreationDescription : public ezHashableStruct<ezGALTextureResourceViewCreationDescription>
 {
   ezGALTextureHandle m_hTexture;
-
-  ezGALBufferHandle m_hBuffer;
-
   ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
-
-  // Texture only
   ezUInt32 m_uiMostDetailedMipLevel = 0;
   ezUInt32 m_uiMipLevelsToUse = 0xFFFFFFFFu;
-
   ezUInt32 m_uiFirstArraySlice = 0; // For cubemap array: index of first 2d slice to start with
   ezUInt32 m_uiArraySize = 1;       // For cubemap array: number of cubemaps
+};
 
-  // Buffer only
+struct ezGALBufferResourceViewCreationDescription : public ezHashableStruct<ezGALBufferResourceViewCreationDescription>
+{
+  ezGALBufferHandle m_hBuffer;
+  ezEnum<ezGALResourceFormat> m_OverrideViewFormat = ezGALResourceFormat::Invalid;
   ezUInt32 m_uiFirstElement = 0;
   ezUInt32 m_uiNumElements = 0;
   bool m_bRawView = false;

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -19,7 +19,7 @@ struct ezGALShaderResourceType
     // Read-only struct. Set directly via ezGALCommandEncoder::SetPushConstants. HLSL: Use macro BEGIN_PUSH_CONSTANTS, END_PUSH_CONSTANTS, GET_PUSH_CONSTANT
     PushConstants,
 
-    /// \name Shader Resource Views (SRVs). These are set via ezGALResourceViewHandle.
+    /// \name Shader Resource Views (SRVs). These are set via ezGALTextureResourceViewHandle.
     ///@{
 
     /// Read-only texture view. When set, ezGALShaderTextureType is also set. HLSL: Texture*
@@ -65,7 +65,7 @@ struct ezGALShaderResourceCategory
   {
     Sampler = EZ_BIT(0),        //< Sampler (ezGALSamplerStateHandle).
     ConstantBuffer = EZ_BIT(1), //< Constant Buffer (ezGALBufferHandle)
-    SRV = EZ_BIT(2),            //< Shader Resource Views (ezGALResourceViewHandle).
+    SRV = EZ_BIT(2),            //< Shader Resource Views (ezGALTextureResourceViewHandle / ezGALBufferResourceViewHandle).
     UAV = EZ_BIT(3),            //< Unordered Access Views (ezGALUnorderedAccessViewHandle).
     Default = 0
   };

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -164,22 +164,40 @@ struct ezGALVertexAttributeSemantic
 
 /// \brief General type of buffer.
 /// \sa ezGALBufferCreationDescription
-struct ezGALBufferType
+struct ezGALBufferFlags
 {
-  using StorageType = ezUInt8;
+  using StorageType = ezUInt16;
 
   enum Enum
   {
-    Generic = 0,
-    VertexBuffer,
-    IndexBuffer,
-    ConstantBuffer,
+    VertexBuffer = EZ_BIT(0), // Can be used as a vertex buffer.
+    IndexBuffer = EZ_BIT(1), // Can be used as an index buffer.
+    ConstantBuffer = EZ_BIT(2), // Can be used as a constant buffer.
+    TexelBuffer = EZ_BIT(3), // Can be used as a texel buffer.
+    StructuredBuffer = EZ_BIT(4),  // ezGALShaderResourceType::StructuredBuffer
+    ByteAddressBuffer = EZ_BIT(5), // ezGALShaderResourceType::ByteAddressBuffer (RAW)
 
-    ENUM_COUNT,
+    ShaderResource = EZ_BIT(6), // Can be used for ezGALShaderResourceCategory::SRV
+    UnorderedAccess = EZ_BIT(7), // Can be used for ezGALShaderResourceCategory::UAV
+    DrawIndirect = EZ_BIT(8),
 
-    Default = Generic
+    Default = 0
+  };
+
+  struct Bits
+  {
+    StorageType VertexBuffer : 1;
+    StorageType IndexBuffer : 1;
+    StorageType ConstantBuffer : 1;
+    StorageType TexelBuffer : 1;
+    StorageType StructuredBuffer : 1;
+    StorageType ByteAddressBuffer : 1;
+    StorageType ShaderResource : 1;
+    StorageType UnorderedAccess : 1;
+    StorageType DrawIndirect : 1;
   };
 };
+EZ_DECLARE_FLAGS_OPERATORS(ezGALBufferFlags);
 
 /// \brief Type of GPU->CPU query.
 /// \sa ezGALQueryCreationDescription

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -168,7 +168,7 @@ struct ezGALVertexAttributeSemantic
 
 /// \brief Defines for what purpose a buffer can be used for.
 /// \sa ezGALBufferCreationDescription
-struct ezGALBufferFlags
+struct ezGALBufferUsageFlags
 {
   using StorageType = ezUInt16;
 
@@ -201,7 +201,7 @@ struct ezGALBufferFlags
     StorageType DrawIndirect : 1;
   };
 };
-EZ_DECLARE_FLAGS_OPERATORS(ezGALBufferFlags);
+EZ_DECLARE_FLAGS_OPERATORS(ezGALBufferUsageFlags);
 
 /// \brief Type of GPU->CPU query.
 /// \sa ezGALQueryCreationDescription

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -166,7 +166,7 @@ struct ezGALVertexAttributeSemantic
   };
 };
 
-/// \brief General type of buffer.
+/// \brief Defines for what purpose a buffer can be used for.
 /// \sa ezGALBufferCreationDescription
 struct ezGALBufferFlags
 {
@@ -174,16 +174,16 @@ struct ezGALBufferFlags
 
   enum Enum
   {
-    VertexBuffer = EZ_BIT(0), // Can be used as a vertex buffer.
-    IndexBuffer = EZ_BIT(1), // Can be used as an index buffer.
-    ConstantBuffer = EZ_BIT(2), // Can be used as a constant buffer. Can't be combined with any of the other *Buffer flags.
-    TexelBuffer = EZ_BIT(3), // Can be used as a texel buffer.
-    StructuredBuffer = EZ_BIT(4),  // ezGALShaderResourceType::StructuredBuffer
-    ByteAddressBuffer = EZ_BIT(5), // ezGALShaderResourceType::ByteAddressBuffer (RAW)
+    VertexBuffer = EZ_BIT(0), ///< Can be used as a vertex buffer.
+    IndexBuffer = EZ_BIT(1), ///< Can be used as an index buffer.
+    ConstantBuffer = EZ_BIT(2), ///< Can be used as a constant buffer. Can't be combined with any of the other *Buffer flags.
+    TexelBuffer = EZ_BIT(3), ///< Can be used as a texel buffer.
+    StructuredBuffer = EZ_BIT(4),  ///< ezGALShaderResourceType::StructuredBuffer
+    ByteAddressBuffer = EZ_BIT(5), ///< ezGALShaderResourceType::ByteAddressBuffer (RAW)
 
-    ShaderResource = EZ_BIT(6), // Can be used for ezGALShaderResourceCategory::SRV
-    UnorderedAccess = EZ_BIT(7), // Can be used for ezGALShaderResourceCategory::UAV
-    DrawIndirect = EZ_BIT(8),
+    ShaderResource = EZ_BIT(6), ///< Can be used for ezGALShaderResourceType in the SRV section.
+    UnorderedAccess = EZ_BIT(7), ///< Can be used for ezGALShaderResourceType in the UAV section.
+    DrawIndirect = EZ_BIT(8), ///< Can be used in an indirect draw call.
 
     Default = 0
   };

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -19,7 +19,7 @@ struct ezGALShaderResourceType
     // Read-only struct. Set directly via ezGALCommandEncoder::SetPushConstants. HLSL: Use macro BEGIN_PUSH_CONSTANTS, END_PUSH_CONSTANTS, GET_PUSH_CONSTANT
     PushConstants,
 
-    /// \name Shader Resource Views (SRVs). These are set via ezGALTextureResourceViewHandle.
+    /// \name Shader Resource Views (SRVs). These are set via ezGALTextureResourceViewHandle / ezGALBufferResourceViewHandle.
     ///@{
 
     /// Read-only texture view. When set, ezGALShaderTextureType is also set. HLSL: Texture*
@@ -32,7 +32,7 @@ struct ezGALShaderResourceType
     StructuredBuffer,
 
     ///@}
-    /// \name Unordered Access Views (UAVs). These are set via ezGALUnorderedAccessViewHandle.
+    /// \name Unordered Access Views (UAVs). These are set via ezGALTextureUnorderedAccessViewHandle / ezGALBufferUnorderedAccessViewHandle.
     ///@{
 
     /// Read-write texture view. When set, ezGALShaderTextureType is also set. HLSL: RWTexture*
@@ -65,8 +65,10 @@ struct ezGALShaderResourceCategory
   {
     Sampler = EZ_BIT(0),        //< Sampler (ezGALSamplerStateHandle).
     ConstantBuffer = EZ_BIT(1), //< Constant Buffer (ezGALBufferHandle)
-    SRV = EZ_BIT(2),            //< Shader Resource Views (ezGALTextureResourceViewHandle / ezGALBufferResourceViewHandle).
-    UAV = EZ_BIT(3),            //< Unordered Access Views (ezGALUnorderedAccessViewHandle).
+    TextureSRV = EZ_BIT(2),            //< Shader Resource Views (ezGALTextureResourceViewHandle).
+    BufferSRV = EZ_BIT(3),            //< Shader Resource Views (ezGALBufferResourceViewHandle).
+    TextureUAV = EZ_BIT(4),            //< Unordered Access Views (ezGALTextureUnorderedAccessViewHandle).
+    BufferUAV = EZ_BIT(5),            //< Unordered Access Views (ezGALBufferUnorderedAccessViewHandle).
     Default = 0
   };
 
@@ -74,8 +76,10 @@ struct ezGALShaderResourceCategory
   {
     StorageType Sampler : 1;
     StorageType ConstantBuffer : 1;
-    StorageType SRV : 1;
-    StorageType UAV : 1;
+    StorageType TextureSRV : 1;
+    StorageType BufferSRV : 1;
+    StorageType TextureUAV : 1;
+    StorageType BufferUAV : 1;
   };
 
   static ezBitflags<ezGALShaderResourceCategory> MakeFromShaderDescriptorType(ezGALShaderResourceType::Enum type);
@@ -172,7 +176,7 @@ struct ezGALBufferFlags
   {
     VertexBuffer = EZ_BIT(0), // Can be used as a vertex buffer.
     IndexBuffer = EZ_BIT(1), // Can be used as an index buffer.
-    ConstantBuffer = EZ_BIT(2), // Can be used as a constant buffer.
+    ConstantBuffer = EZ_BIT(2), // Can be used as a constant buffer. Can't be combined with any of the other *Buffer flags.
     TexelBuffer = EZ_BIT(3), // Can be used as a texel buffer.
     StructuredBuffer = EZ_BIT(4),  // ezGALShaderResourceType::StructuredBuffer
     ByteAddressBuffer = EZ_BIT(5), // ezGALShaderResourceType::ByteAddressBuffer (RAW)

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -65,10 +65,10 @@ struct ezGALShaderResourceCategory
   {
     Sampler = EZ_BIT(0),        //< Sampler (ezGALSamplerStateHandle).
     ConstantBuffer = EZ_BIT(1), //< Constant Buffer (ezGALBufferHandle)
-    TextureSRV = EZ_BIT(2),            //< Shader Resource Views (ezGALTextureResourceViewHandle).
-    BufferSRV = EZ_BIT(3),            //< Shader Resource Views (ezGALBufferResourceViewHandle).
-    TextureUAV = EZ_BIT(4),            //< Unordered Access Views (ezGALTextureUnorderedAccessViewHandle).
-    BufferUAV = EZ_BIT(5),            //< Unordered Access Views (ezGALBufferUnorderedAccessViewHandle).
+    TextureSRV = EZ_BIT(2),     //< Shader Resource Views (ezGALTextureResourceViewHandle).
+    BufferSRV = EZ_BIT(3),      //< Shader Resource Views (ezGALBufferResourceViewHandle).
+    TextureUAV = EZ_BIT(4),     //< Unordered Access Views (ezGALTextureUnorderedAccessViewHandle).
+    BufferUAV = EZ_BIT(5),      //< Unordered Access Views (ezGALBufferUnorderedAccessViewHandle).
     Default = 0
   };
 
@@ -174,16 +174,16 @@ struct ezGALBufferFlags
 
   enum Enum
   {
-    VertexBuffer = EZ_BIT(0), ///< Can be used as a vertex buffer.
-    IndexBuffer = EZ_BIT(1), ///< Can be used as an index buffer.
-    ConstantBuffer = EZ_BIT(2), ///< Can be used as a constant buffer. Can't be combined with any of the other *Buffer flags.
-    TexelBuffer = EZ_BIT(3), ///< Can be used as a texel buffer.
+    VertexBuffer = EZ_BIT(0),      ///< Can be used as a vertex buffer.
+    IndexBuffer = EZ_BIT(1),       ///< Can be used as an index buffer.
+    ConstantBuffer = EZ_BIT(2),    ///< Can be used as a constant buffer. Can't be combined with any of the other *Buffer flags.
+    TexelBuffer = EZ_BIT(3),       ///< Can be used as a texel buffer.
     StructuredBuffer = EZ_BIT(4),  ///< ezGALShaderResourceType::StructuredBuffer
     ByteAddressBuffer = EZ_BIT(5), ///< ezGALShaderResourceType::ByteAddressBuffer (RAW)
 
-    ShaderResource = EZ_BIT(6), ///< Can be used for ezGALShaderResourceType in the SRV section.
-    UnorderedAccess = EZ_BIT(7), ///< Can be used for ezGALShaderResourceType in the UAV section.
-    DrawIndirect = EZ_BIT(8), ///< Can be used in an indirect draw call.
+    ShaderResource = EZ_BIT(6),    ///< Can be used for ezGALShaderResourceType in the SRV section.
+    UnorderedAccess = EZ_BIT(7),   ///< Can be used for ezGALShaderResourceType in the UAV section.
+    DrawIndirect = EZ_BIT(8),      ///< Can be used in an indirect draw call.
 
     Default = 0
   };

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Enumerations_inl.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Enumerations_inl.h
@@ -9,15 +9,17 @@ inline ezBitflags<ezGALShaderResourceCategory> ezGALShaderResourceCategory::Make
     case ezGALShaderResourceType::PushConstants:
       return ezGALShaderResourceCategory::ConstantBuffer;
     case ezGALShaderResourceType::Texture:
+      return ezGALShaderResourceCategory::TextureSRV;
     case ezGALShaderResourceType::TexelBuffer:
     case ezGALShaderResourceType::StructuredBuffer:
-      return ezGALShaderResourceCategory::SRV;
+      return ezGALShaderResourceCategory::BufferSRV;
     case ezGALShaderResourceType::TextureRW:
+      return ezGALShaderResourceCategory::TextureUAV;
     case ezGALShaderResourceType::TexelBufferRW:
     case ezGALShaderResourceType::StructuredBufferRW:
-      return ezGALShaderResourceCategory::UAV;
+      return ezGALShaderResourceCategory::BufferUAV;
     case ezGALShaderResourceType::TextureAndSampler:
-      return ezGALShaderResourceCategory::SRV | ezGALShaderResourceCategory::Sampler;
+      return ezGALShaderResourceCategory::TextureSRV | ezGALShaderResourceCategory::Sampler;
     default:
       EZ_REPORT_FAILURE("Missing enum");
       return {};

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -315,7 +315,7 @@ protected:
 
   virtual ezGALTextureUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description) = 0;
   virtual void DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAccessView* pUnorderedAccessView) = 0;
-  
+
   virtual ezGALBufferUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description) = 0;
   virtual void DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView) = 0;
 

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -73,11 +73,14 @@ public:
   void DestroySharedTexture(ezGALTextureHandle hTexture);
 
   // Resource views
-  ezGALResourceViewHandle GetDefaultResourceView(ezGALTextureHandle hTexture);
-  ezGALResourceViewHandle GetDefaultResourceView(ezGALBufferHandle hBuffer);
+  ezGALTextureResourceViewHandle GetDefaultResourceView(ezGALTextureHandle hTexture);
+  ezGALBufferResourceViewHandle GetDefaultResourceView(ezGALBufferHandle hBuffer);
 
-  ezGALResourceViewHandle CreateResourceView(const ezGALResourceViewCreationDescription& description);
-  void DestroyResourceView(ezGALResourceViewHandle hResourceView);
+  ezGALTextureResourceViewHandle CreateResourceView(const ezGALTextureResourceViewCreationDescription& description);
+  void DestroyResourceView(ezGALTextureResourceViewHandle hResourceView);
+
+  ezGALBufferResourceViewHandle CreateResourceView(const ezGALBufferResourceViewCreationDescription& description);
+  void DestroyResourceView(ezGALBufferResourceViewHandle hResourceView);
 
   // Render target views
   ezGALRenderTargetViewHandle GetDefaultRenderTargetView(ezGALTextureHandle hTexture);
@@ -139,7 +142,8 @@ public:
   const ezGALRasterizerState* GetRasterizerState(ezGALRasterizerStateHandle hRasterizerState) const;
   const ezGALVertexDeclaration* GetVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration) const;
   const ezGALSamplerState* GetSamplerState(ezGALSamplerStateHandle hSamplerState) const;
-  const ezGALResourceView* GetResourceView(ezGALResourceViewHandle hResourceView) const;
+  const ezGALTextureResourceView* GetResourceView(ezGALTextureResourceViewHandle hResourceView) const;
+  const ezGALBufferResourceView* GetResourceView(ezGALBufferResourceViewHandle hResourceView) const;
   const ezGALRenderTargetView* GetRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView) const;
   const ezGALUnorderedAccessView* GetUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView) const;
   const ezGALQuery* GetQuery(ezGALQueryHandle hQuery) const;
@@ -172,7 +176,8 @@ protected:
   template <typename IdTableType, typename ReturnType>
   ReturnType* Get(typename IdTableType::TypeOfId hHandle, const IdTableType& IdTable) const;
 
-  void DestroyViews(ezGALResourceBase* pResource);
+  void DestroyViews(ezGALTexture* pResource);
+  void DestroyViews(ezGALBuffer* pResource);
 
   template <typename HandleType>
   void AddDeadObject(ezUInt32 uiType, HandleType handle);
@@ -199,7 +204,8 @@ protected:
   using RasterizerStateTable = ezIdTable<ezGALRasterizerStateHandle::IdType, ezGALRasterizerState*, ezLocalAllocatorWrapper>;
   using BufferTable = ezIdTable<ezGALBufferHandle::IdType, ezGALBuffer*, ezLocalAllocatorWrapper>;
   using TextureTable = ezIdTable<ezGALTextureHandle::IdType, ezGALTexture*, ezLocalAllocatorWrapper>;
-  using ResourceViewTable = ezIdTable<ezGALResourceViewHandle::IdType, ezGALResourceView*, ezLocalAllocatorWrapper>;
+  using TextureResourceViewTable = ezIdTable<ezGALTextureResourceViewHandle::IdType, ezGALTextureResourceView*, ezLocalAllocatorWrapper>;
+  using BufferResourceViewTable = ezIdTable<ezGALBufferResourceViewHandle::IdType, ezGALBufferResourceView*, ezLocalAllocatorWrapper>;
   using SamplerStateTable = ezIdTable<ezGALSamplerStateHandle::IdType, ezGALSamplerState*, ezLocalAllocatorWrapper>;
   using RenderTargetViewTable = ezIdTable<ezGALRenderTargetViewHandle::IdType, ezGALRenderTargetView*, ezLocalAllocatorWrapper>;
   using UnorderedAccessViewTable = ezIdTable<ezGALUnorderedAccessViewHandle::IdType, ezGALUnorderedAccessView*, ezLocalAllocatorWrapper>;
@@ -213,7 +219,8 @@ protected:
   RasterizerStateTable m_RasterizerStates;
   BufferTable m_Buffers;
   TextureTable m_Textures;
-  ResourceViewTable m_ResourceViews;
+  TextureResourceViewTable m_TextureResourceViews;
+  BufferResourceViewTable m_BufferResourceViews;
   SamplerStateTable m_SamplerStates;
   RenderTargetViewTable m_RenderTargetViews;
   UnorderedAccessViewTable m_UnorderedAccessViews;
@@ -292,8 +299,11 @@ protected:
   virtual ezGALTexture* CreateSharedTexturePlatform(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle handle) = 0;
   virtual void DestroySharedTexturePlatform(ezGALTexture* pTexture) = 0;
 
-  virtual ezGALResourceView* CreateResourceViewPlatform(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description) = 0;
-  virtual void DestroyResourceViewPlatform(ezGALResourceView* pResourceView) = 0;
+  virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) = 0;
+  virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) = 0;
+
+  virtual ezGALBufferResourceView* CreateResourceViewPlatform(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description) = 0;
+  virtual void DestroyResourceViewPlatform(ezGALBufferResourceView* pResourceView) = 0;
 
   virtual ezGALRenderTargetView* CreateRenderTargetViewPlatform(ezGALTexture* pTexture, const ezGALRenderTargetViewCreationDescription& Description) = 0;
   virtual void DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRenderTargetView) = 0;

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -89,9 +89,11 @@ public:
   void DestroyRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView);
 
   // Unordered access views
-  ezGALUnorderedAccessViewHandle CreateUnorderedAccessView(const ezGALUnorderedAccessViewCreationDescription& description);
-  void DestroyUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView);
+  ezGALTextureUnorderedAccessViewHandle CreateUnorderedAccessView(const ezGALTextureUnorderedAccessViewCreationDescription& description);
+  void DestroyUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView);
 
+  ezGALBufferUnorderedAccessViewHandle CreateUnorderedAccessView(const ezGALBufferUnorderedAccessViewCreationDescription& description);
+  void DestroyUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView);
 
   // Other rendering creation functions
 
@@ -145,7 +147,8 @@ public:
   const ezGALTextureResourceView* GetResourceView(ezGALTextureResourceViewHandle hResourceView) const;
   const ezGALBufferResourceView* GetResourceView(ezGALBufferResourceViewHandle hResourceView) const;
   const ezGALRenderTargetView* GetRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView) const;
-  const ezGALUnorderedAccessView* GetUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView) const;
+  const ezGALTextureUnorderedAccessView* GetUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView) const;
+  const ezGALBufferUnorderedAccessView* GetUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView) const;
   const ezGALQuery* GetQuery(ezGALQueryHandle hQuery) const;
 
   const ezGALDeviceCapabilities& GetCapabilities() const;
@@ -208,7 +211,8 @@ protected:
   using BufferResourceViewTable = ezIdTable<ezGALBufferResourceViewHandle::IdType, ezGALBufferResourceView*, ezLocalAllocatorWrapper>;
   using SamplerStateTable = ezIdTable<ezGALSamplerStateHandle::IdType, ezGALSamplerState*, ezLocalAllocatorWrapper>;
   using RenderTargetViewTable = ezIdTable<ezGALRenderTargetViewHandle::IdType, ezGALRenderTargetView*, ezLocalAllocatorWrapper>;
-  using UnorderedAccessViewTable = ezIdTable<ezGALUnorderedAccessViewHandle::IdType, ezGALUnorderedAccessView*, ezLocalAllocatorWrapper>;
+  using TextureUnorderedAccessViewTable = ezIdTable<ezGALTextureUnorderedAccessViewHandle::IdType, ezGALTextureUnorderedAccessView*, ezLocalAllocatorWrapper>;
+  using BufferUnorderedAccessViewTable = ezIdTable<ezGALBufferUnorderedAccessViewHandle::IdType, ezGALBufferUnorderedAccessView*, ezLocalAllocatorWrapper>;
   using SwapChainTable = ezIdTable<ezGALSwapChainHandle::IdType, ezGALSwapChain*, ezLocalAllocatorWrapper>;
   using QueryTable = ezIdTable<ezGALQueryHandle::IdType, ezGALQuery*, ezLocalAllocatorWrapper>;
   using VertexDeclarationTable = ezIdTable<ezGALVertexDeclarationHandle::IdType, ezGALVertexDeclaration*, ezLocalAllocatorWrapper>;
@@ -223,7 +227,8 @@ protected:
   BufferResourceViewTable m_BufferResourceViews;
   SamplerStateTable m_SamplerStates;
   RenderTargetViewTable m_RenderTargetViews;
-  UnorderedAccessViewTable m_UnorderedAccessViews;
+  TextureUnorderedAccessViewTable m_TextureUnorderedAccessViews;
+  BufferUnorderedAccessViewTable m_BufferUnorderedAccessViews;
   SwapChainTable m_SwapChains;
   QueryTable m_Queries;
   VertexDeclarationTable m_VertexDeclarations;
@@ -308,8 +313,11 @@ protected:
   virtual ezGALRenderTargetView* CreateRenderTargetViewPlatform(ezGALTexture* pTexture, const ezGALRenderTargetViewCreationDescription& Description) = 0;
   virtual void DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRenderTargetView) = 0;
 
-  virtual ezGALUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description) = 0;
-  virtual void DestroyUnorderedAccessViewPlatform(ezGALUnorderedAccessView* pUnorderedAccessView) = 0;
+  virtual ezGALTextureUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description) = 0;
+  virtual void DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAccessView* pUnorderedAccessView) = 0;
+  
+  virtual ezGALBufferUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description) = 0;
+  virtual void DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView) = 0;
 
   // Other rendering creation functions
 

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -24,6 +24,7 @@ public:
 
   ezResult Init();
   ezResult Shutdown();
+  ezStringView GetRenderer();
 
   // Pipeline & Pass functions
 
@@ -253,6 +254,7 @@ protected:
 
   virtual ezResult InitPlatform() = 0;
   virtual ezResult ShutdownPlatform() = 0;
+  virtual ezStringView GetRendererPlatform() = 0;
 
   // Pipeline & Pass functions
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -603,10 +603,10 @@ ezGALBufferHandle ezGALDevice::FinalizeBufferInternal(const ezGALBufferCreationD
     ezGALBufferHandle hBuffer(m_Buffers.Insert(pBuffer));
 
     // Create default resource view
-    if (desc.m_BufferFlags.IsSet(ezGALBufferFlags::ShaderResource))
+    if (desc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ShaderResource))
     {
       // #TODO_VULKAN TexelBuffer requires a format, should we store it in the buffer desc?
-      if (desc.m_BufferFlags.IsAnySet(ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ByteAddressBuffer))
+      if (desc.m_BufferFlags.IsAnySet(ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ByteAddressBuffer))
       {
         ezGALBufferResourceViewCreationDescription viewDesc;
         viewDesc.m_hBuffer = hBuffer;
@@ -644,7 +644,7 @@ ezGALBufferHandle ezGALDevice::CreateVertexBuffer(ezUInt32 uiVertexSize, ezUInt3
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = uiVertexSize;
   desc.m_uiTotalSize = uiVertexSize * ezMath::Max(1u, uiVertexCount);
-  desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::VertexBuffer;
   desc.m_ResourceAccess.m_bImmutable = !initialData.IsEmpty() && !bDataIsMutable;
 
   return CreateBuffer(desc, initialData);
@@ -655,7 +655,7 @@ ezGALBufferHandle ezGALDevice::CreateIndexBuffer(ezGALIndexType::Enum indexType,
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = ezGALIndexType::GetSize(indexType);
   desc.m_uiTotalSize = desc.m_uiStructSize * ezMath::Max(1u, uiIndexCount);
-  desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::IndexBuffer;
   desc.m_ResourceAccess.m_bImmutable = !bDataIsMutable && !initialData.IsEmpty();
 
   return CreateBuffer(desc, initialData);
@@ -666,7 +666,7 @@ ezGALBufferHandle ezGALDevice::CreateConstantBuffer(ezUInt32 uiBufferSize)
   ezGALBufferCreationDescription desc;
   desc.m_uiStructSize = 0;
   desc.m_uiTotalSize = uiBufferSize;
-  desc.m_BufferFlags = ezGALBufferFlags::ConstantBuffer;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::ConstantBuffer;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   return CreateBuffer(desc);
@@ -1167,7 +1167,7 @@ ezGALBufferUnorderedAccessViewHandle ezGALDevice::CreateUnorderedAccessView(cons
       return ezGALBufferUnorderedAccessViewHandle();
     }
 
-    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && desc.m_bRawView)
+    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::ByteAddressBuffer) && desc.m_bRawView)
     {
       ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
       return ezGALBufferUnorderedAccessViewHandle();

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -90,7 +90,7 @@ ezGALDevice::~ezGALDevice()
 
     if (!m_TextureResourceViews.IsEmpty())
       ezLog::Warning("{0} texture resource views have not been cleaned up", m_TextureResourceViews.GetCount());
-    
+
     if (!m_BufferResourceViews.IsEmpty())
       ezLog::Warning("{0} buffer resource views have not been cleaned up", m_BufferResourceViews.GetCount());
 
@@ -956,9 +956,9 @@ ezGALTextureResourceViewHandle ezGALDevice::CreateResourceView(const ezGALTextur
 ezGALBufferResourceViewHandle ezGALDevice::CreateResourceView(const ezGALBufferResourceViewCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   ezGALBuffer* pResource = nullptr;
-  
+
   if (!desc.m_hBuffer.IsInvalidated())
     pResource = Get<BufferTable, ezGALBuffer>(desc.m_hBuffer, m_Buffers);
 
@@ -1011,7 +1011,7 @@ void ezGALDevice::DestroyResourceView(ezGALTextureResourceViewHandle hResourceVi
 void ezGALDevice::DestroyResourceView(ezGALBufferResourceViewHandle hResourceView)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   ezGALBufferResourceView* pResourceView = nullptr;
 
   if (m_BufferResourceViews.TryGetValue(hResourceView, pResourceView))
@@ -1094,9 +1094,9 @@ void ezGALDevice::DestroyRenderTargetView(ezGALRenderTargetViewHandle hRenderTar
 ezGALTextureUnorderedAccessViewHandle ezGALDevice::CreateUnorderedAccessView(const ezGALTextureUnorderedAccessViewCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   ezGALTexture* pTexture = nullptr;
- 
+
   if (!desc.m_hTexture.IsInvalidated())
   {
     pTexture = Get<TextureTable, ezGALTexture>(desc.m_hTexture, m_Textures);
@@ -1145,9 +1145,9 @@ ezGALTextureUnorderedAccessViewHandle ezGALDevice::CreateUnorderedAccessView(con
 ezGALBufferUnorderedAccessViewHandle ezGALDevice::CreateUnorderedAccessView(const ezGALBufferUnorderedAccessViewCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   ezGALBuffer* pBuffer = nullptr;
-  
+
   if (!desc.m_hBuffer.IsInvalidated())
   {
     pBuffer = Get<BufferTable, ezGALBuffer>(desc.m_hBuffer, m_Buffers);
@@ -1217,7 +1217,7 @@ void ezGALDevice::DestroyUnorderedAccessView(ezGALTextureUnorderedAccessViewHand
 void ezGALDevice::DestroyUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessViewHandle)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   ezGALBufferUnorderedAccessView* pUnorderedAccesssView = nullptr;
 
   if (m_BufferUnorderedAccessViews.TryGetValue(hUnorderedAccessViewHandle, pUnorderedAccesssView))
@@ -1541,7 +1541,7 @@ void ezGALDevice::DestroyViews(ezGALTexture* pResource)
 void ezGALDevice::DestroyViews(ezGALBuffer* pResource)
 {
   EZ_ASSERT_DEBUG(pResource != nullptr, "Must provide valid resource");
-  
+
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   for (auto it = pResource->m_ResourceViews.GetIterator(); it.IsValid(); ++it)
@@ -1691,7 +1691,7 @@ void ezGALDevice::DestroyDeadObjects()
       {
         ezGALBufferResourceViewHandle hResourceView(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALBufferResourceView* pResourceView = nullptr;
-        
+
         m_BufferResourceViews.Remove(hResourceView, &pResourceView);
 
         ezGALBuffer* pResource = pResourceView->m_pResource;
@@ -1740,7 +1740,7 @@ void ezGALDevice::DestroyDeadObjects()
       {
         ezGALBufferUnorderedAccessViewHandle hUnorderedAccessViewHandle(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALBufferUnorderedAccessView* pUnorderedAccesssView = nullptr;
-        
+
         m_BufferUnorderedAccessViews.Remove(hUnorderedAccessViewHandle, &pUnorderedAccesssView);
 
         ezGALBuffer* pResource = pUnorderedAccesssView->m_pResource;

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -74,9 +74,14 @@ inline const ezGALSamplerState* ezGALDevice::GetSamplerState(ezGALSamplerStateHa
   return Get<SamplerStateTable, ezGALSamplerState>(hSamplerState, m_SamplerStates);
 }
 
-inline const ezGALResourceView* ezGALDevice::GetResourceView(ezGALResourceViewHandle hResourceView) const
+inline const ezGALTextureResourceView* ezGALDevice::GetResourceView(ezGALTextureResourceViewHandle hResourceView) const
 {
-  return Get<ResourceViewTable, ezGALResourceView>(hResourceView, m_ResourceViews);
+  return Get<TextureResourceViewTable, ezGALTextureResourceView>(hResourceView, m_TextureResourceViews);
+}
+
+inline const ezGALBufferResourceView* ezGALDevice::GetResourceView(ezGALBufferResourceViewHandle hResourceView) const
+{
+  return Get<BufferResourceViewTable, ezGALBufferResourceView>(hResourceView, m_BufferResourceViews);
 }
 
 inline const ezGALRenderTargetView* ezGALDevice::GetRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView) const

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -89,9 +89,14 @@ inline const ezGALRenderTargetView* ezGALDevice::GetRenderTargetView(ezGALRender
   return Get<RenderTargetViewTable, ezGALRenderTargetView>(hRenderTargetView, m_RenderTargetViews);
 }
 
-inline const ezGALUnorderedAccessView* ezGALDevice::GetUnorderedAccessView(ezGALUnorderedAccessViewHandle hUnorderedAccessView) const
+inline const ezGALTextureUnorderedAccessView* ezGALDevice::GetUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView) const
 {
-  return Get<UnorderedAccessViewTable, ezGALUnorderedAccessView>(hUnorderedAccessView, m_UnorderedAccessViews);
+  return Get<TextureUnorderedAccessViewTable, ezGALTextureUnorderedAccessView>(hUnorderedAccessView, m_TextureUnorderedAccessViews);
+}
+
+inline const ezGALBufferUnorderedAccessView* ezGALDevice::GetUnorderedAccessView(ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView) const
+{
+  return Get<BufferUnorderedAccessViewTable, ezGALBufferUnorderedAccessView>(hUnorderedAccessView, m_BufferUnorderedAccessViews);
 }
 
 inline const ezGALQuery* ezGALDevice::GetQuery(ezGALQueryHandle hQuery) const

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -41,7 +41,8 @@ struct ezGALSamplerStateCreationDescription;
 struct ezGALTextureResourceViewCreationDescription;
 struct ezGALBufferResourceViewCreationDescription;
 struct ezGALRenderTargetViewCreationDescription;
-struct ezGALUnorderedAccessViewCreationDescription;
+struct ezGALTextureUnorderedAccessViewCreationDescription;
+struct ezGALBufferUnorderedAccessViewCreationDescription;
 
 class ezGALSwapChain;
 class ezGALShader;
@@ -59,7 +60,8 @@ class ezGALSamplerState;
 class ezGALTextureResourceView;
 class ezGALBufferResourceView;
 class ezGALRenderTargetView;
-class ezGALUnorderedAccessView;
+class ezGALTextureUnorderedAccessView;
+class ezGALBufferUnorderedAccessView;
 class ezGALDevice;
 class ezGALPass;
 class ezGALCommandEncoder;
@@ -423,9 +425,16 @@ class ezGALBufferResourceViewHandle
   friend class ezGALDevice;
 };
 
-class ezGALUnorderedAccessViewHandle
+class ezGALTextureUnorderedAccessViewHandle
 {
-  EZ_DECLARE_HANDLE_TYPE(ezGALUnorderedAccessViewHandle, ezGAL::ez18_14Id);
+  EZ_DECLARE_HANDLE_TYPE(ezGALTextureUnorderedAccessViewHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALBufferUnorderedAccessViewHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALBufferUnorderedAccessViewHandle, ezGAL::ez18_14Id);
 
   friend class ezGALDevice;
 };

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -38,7 +38,8 @@ struct ezGALRasterizerStateCreationDescription;
 struct ezGALVertexDeclarationCreationDescription;
 struct ezGALQueryCreationDescription;
 struct ezGALSamplerStateCreationDescription;
-struct ezGALResourceViewCreationDescription;
+struct ezGALTextureResourceViewCreationDescription;
+struct ezGALBufferResourceViewCreationDescription;
 struct ezGALRenderTargetViewCreationDescription;
 struct ezGALUnorderedAccessViewCreationDescription;
 
@@ -55,7 +56,8 @@ class ezGALRenderTargetSetup;
 class ezGALVertexDeclaration;
 class ezGALQuery;
 class ezGALSamplerState;
-class ezGALResourceView;
+class ezGALTextureResourceView;
+class ezGALBufferResourceView;
 class ezGALRenderTargetView;
 class ezGALUnorderedAccessView;
 class ezGALDevice;
@@ -407,9 +409,16 @@ class ezGALBufferHandle
   friend class ezGALDevice;
 };
 
-class ezGALResourceViewHandle
+class ezGALTextureResourceViewHandle
 {
-  EZ_DECLARE_HANDLE_TYPE(ezGALResourceViewHandle, ezGAL::ez18_14Id);
+  EZ_DECLARE_HANDLE_TYPE(ezGALTextureResourceViewHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALBufferResourceViewHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALBufferResourceViewHandle, ezGAL::ez18_14Id);
 
   friend class ezGALDevice;
 };

--- a/Code/Engine/RendererFoundation/Resources/Buffer.h
+++ b/Code/Engine/RendererFoundation/Resources/Buffer.h
@@ -19,6 +19,10 @@ protected:
   virtual ezResult InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ezUInt8> pInitialData) = 0;
 
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+
+protected:
+  ezGALBufferResourceViewHandle m_hDefaultResourceView;
+  ezHashTable<ezUInt32, ezGALBufferResourceViewHandle> m_ResourceViews;
 };
 
 #include <RendererFoundation/Resources/Implementation/Buffer_inl.h>

--- a/Code/Engine/RendererFoundation/Resources/Buffer.h
+++ b/Code/Engine/RendererFoundation/Resources/Buffer.h
@@ -23,6 +23,7 @@ protected:
 protected:
   ezGALBufferResourceViewHandle m_hDefaultResourceView;
   ezHashTable<ezUInt32, ezGALBufferResourceViewHandle> m_ResourceViews;
+  ezHashTable<ezUInt32, ezGALBufferUnorderedAccessViewHandle> m_UnorderedAccessViews;
 };
 
 #include <RendererFoundation/Resources/Implementation/Buffer_inl.h>

--- a/Code/Engine/RendererFoundation/Resources/Implementation/Buffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/Buffer.cpp
@@ -7,4 +7,8 @@ ezGALBuffer::ezGALBuffer(const ezGALBufferCreationDescription& Description)
 {
 }
 
-ezGALBuffer::~ezGALBuffer() = default;
+ezGALBuffer::~ezGALBuffer()
+{
+  EZ_ASSERT_DEV(m_hDefaultResourceView.IsInvalidated(), "");
+  EZ_ASSERT_DEV(m_ResourceViews.IsEmpty(), "Dangling resource views");
+}

--- a/Code/Engine/RendererFoundation/Resources/Implementation/Buffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/Buffer.cpp
@@ -11,4 +11,5 @@ ezGALBuffer::~ezGALBuffer()
 {
   EZ_ASSERT_DEV(m_hDefaultResourceView.IsInvalidated(), "");
   EZ_ASSERT_DEV(m_ResourceViews.IsEmpty(), "Dangling resource views");
+  EZ_ASSERT_DEV(m_UnorderedAccessViews.IsEmpty(), "Dangling unordered access views");
 }

--- a/Code/Engine/RendererFoundation/Resources/Implementation/ResourceView.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/ResourceView.cpp
@@ -3,11 +3,20 @@
 #include <RendererFoundation/Resources/ResourceView.h>
 
 
-ezGALResourceView::ezGALResourceView(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& description)
+ezGALTextureResourceView::ezGALTextureResourceView(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& description)
   : ezGALObject(description)
   , m_pResource(pResource)
 {
   EZ_ASSERT_DEV(m_pResource != nullptr, "Resource must not be null");
 }
 
-ezGALResourceView::~ezGALResourceView() = default;
+ezGALTextureResourceView::~ezGALTextureResourceView() = default;
+
+ezGALBufferResourceView::ezGALBufferResourceView(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& description)
+  : ezGALObject(description)
+  , m_pResource(pResource)
+{
+  EZ_ASSERT_DEV(m_pResource != nullptr, "Resource must not be null");
+}
+
+ezGALBufferResourceView::~ezGALBufferResourceView() = default;

--- a/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
@@ -7,4 +7,11 @@ ezGALTexture::ezGALTexture(const ezGALTextureCreationDescription& Description)
 {
 }
 
-ezGALTexture::~ezGALTexture() = default;
+ezGALTexture::~ezGALTexture()
+{
+  EZ_ASSERT_DEV(m_hDefaultResourceView.IsInvalidated(), "");
+  EZ_ASSERT_DEV(m_hDefaultRenderTargetView.IsInvalidated(), "");
+
+  EZ_ASSERT_DEV(m_ResourceViews.IsEmpty(), "Dangling resource views");
+  EZ_ASSERT_DEV(m_RenderTargetViews.IsEmpty(), "Dangling render target views");
+}

--- a/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
@@ -14,4 +14,5 @@ ezGALTexture::~ezGALTexture()
 
   EZ_ASSERT_DEV(m_ResourceViews.IsEmpty(), "Dangling resource views");
   EZ_ASSERT_DEV(m_RenderTargetViews.IsEmpty(), "Dangling render target views");
+  EZ_ASSERT_DEV(m_UnorderedAccessViews.IsEmpty(), "Dangling unordered access views");
 }

--- a/Code/Engine/RendererFoundation/Resources/Implementation/UnorderedAccessView.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/UnorderedAccessView.cpp
@@ -2,11 +2,20 @@
 
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
 
-ezGALUnorderedAccessView::ezGALUnorderedAccessView(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& description)
+ezGALTextureUnorderedAccessView::ezGALTextureUnorderedAccessView(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& description)
   : ezGALObject(description)
   , m_pResource(pResource)
 {
   EZ_ASSERT_DEV(m_pResource != nullptr, "Resource must not be null");
 }
 
-ezGALUnorderedAccessView::~ezGALUnorderedAccessView() = default;
+ezGALTextureUnorderedAccessView::~ezGALTextureUnorderedAccessView() = default;
+
+ezGALBufferUnorderedAccessView::ezGALBufferUnorderedAccessView(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& description)
+  : ezGALObject(description)
+  , m_pResource(pResource)
+{
+  EZ_ASSERT_DEV(m_pResource != nullptr, "Resource must not be null");
+}
+
+ezGALBufferUnorderedAccessView::~ezGALBufferUnorderedAccessView() = default;

--- a/Code/Engine/RendererFoundation/Resources/Resource.h
+++ b/Code/Engine/RendererFoundation/Resources/Resource.h
@@ -22,9 +22,7 @@ public:
 protected:
   friend class ezGALDevice;
 
-  inline ~ezGALResourceBase()
-  {
-  }
+  inline ~ezGALResourceBase() = default;
 
   virtual void SetDebugNamePlatform(const char* szName) const = 0;
 

--- a/Code/Engine/RendererFoundation/Resources/Resource.h
+++ b/Code/Engine/RendererFoundation/Resources/Resource.h
@@ -24,7 +24,6 @@ protected:
 
   inline ~ezGALResourceBase()
   {
-    EZ_ASSERT_DEV(m_UnorderedAccessViews.IsEmpty(), "Dangling unordered access views");
   }
 
   virtual void SetDebugNamePlatform(const char* szName) const = 0;
@@ -32,7 +31,6 @@ protected:
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   mutable ezHashedString m_sDebugName;
 #endif
-  ezHashTable<ezUInt32, ezGALUnorderedAccessViewHandle> m_UnorderedAccessViews;
 };
 
 /// \brief Base class for GAL resources, stores a creation description of the object and also allows for reference counting.

--- a/Code/Engine/RendererFoundation/Resources/Resource.h
+++ b/Code/Engine/RendererFoundation/Resources/Resource.h
@@ -24,11 +24,6 @@ protected:
 
   inline ~ezGALResourceBase()
   {
-    EZ_ASSERT_DEV(m_hDefaultResourceView.IsInvalidated(), "");
-    EZ_ASSERT_DEV(m_hDefaultRenderTargetView.IsInvalidated(), "");
-
-    EZ_ASSERT_DEV(m_ResourceViews.IsEmpty(), "Dangling resource views");
-    EZ_ASSERT_DEV(m_RenderTargetViews.IsEmpty(), "Dangling render target views");
     EZ_ASSERT_DEV(m_UnorderedAccessViews.IsEmpty(), "Dangling unordered access views");
   }
 
@@ -37,12 +32,6 @@ protected:
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   mutable ezHashedString m_sDebugName;
 #endif
-
-  ezGALResourceViewHandle m_hDefaultResourceView;
-  ezGALRenderTargetViewHandle m_hDefaultRenderTargetView;
-
-  ezHashTable<ezUInt32, ezGALResourceViewHandle> m_ResourceViews;
-  ezHashTable<ezUInt32, ezGALRenderTargetViewHandle> m_RenderTargetViews;
   ezHashTable<ezUInt32, ezGALUnorderedAccessViewHandle> m_UnorderedAccessViews;
 };
 

--- a/Code/Engine/RendererFoundation/Resources/ResourceView.h
+++ b/Code/Engine/RendererFoundation/Resources/ResourceView.h
@@ -4,21 +4,43 @@
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Resources/Resource.h>
 
-class EZ_RENDERERFOUNDATION_DLL ezGALResourceView : public ezGALObject<ezGALResourceViewCreationDescription>
+class ezGALTexture;
+class ezGALBuffer;
+
+class EZ_RENDERERFOUNDATION_DLL ezGALTextureResourceView : public ezGALObject<ezGALTextureResourceViewCreationDescription>
 {
 public:
-  EZ_ALWAYS_INLINE ezGALResourceBase* GetResource() const { return m_pResource; }
+  EZ_ALWAYS_INLINE ezGALTexture* GetResource() const { return m_pResource; }
 
 protected:
   friend class ezGALDevice;
 
-  ezGALResourceView(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& description);
+  ezGALTextureResourceView(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& description);
 
-  virtual ~ezGALResourceView();
+  virtual ~ezGALTextureResourceView();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
 
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 
-  ezGALResourceBase* m_pResource;
+  ezGALTexture* m_pResource;
+};
+
+class EZ_RENDERERFOUNDATION_DLL ezGALBufferResourceView : public ezGALObject<ezGALBufferResourceViewCreationDescription>
+{
+public:
+  EZ_ALWAYS_INLINE ezGALBuffer* GetResource() const { return m_pResource; }
+
+protected:
+  friend class ezGALDevice;
+
+  ezGALBufferResourceView(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& description);
+
+  virtual ~ezGALBufferResourceView();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+
+  ezGALBuffer* m_pResource;
 };

--- a/Code/Engine/RendererFoundation/Resources/Texture.h
+++ b/Code/Engine/RendererFoundation/Resources/Texture.h
@@ -24,6 +24,7 @@ protected:
 
   ezHashTable<ezUInt32, ezGALTextureResourceViewHandle> m_ResourceViews;
   ezHashTable<ezUInt32, ezGALRenderTargetViewHandle> m_RenderTargetViews;
+  ezHashTable<ezUInt32, ezGALTextureUnorderedAccessViewHandle> m_UnorderedAccessViews;
 };
 
 /// \brief Optional interface for ezGALTexture if it was created via ezGALDevice::CreateSharedTexture.

--- a/Code/Engine/RendererFoundation/Resources/Texture.h
+++ b/Code/Engine/RendererFoundation/Resources/Texture.h
@@ -17,6 +17,13 @@ protected:
   virtual ezResult InitPlatform(ezGALDevice* pDevice, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData) = 0;
 
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+
+protected:
+  ezGALTextureResourceViewHandle m_hDefaultResourceView;
+  ezGALRenderTargetViewHandle m_hDefaultRenderTargetView;
+
+  ezHashTable<ezUInt32, ezGALTextureResourceViewHandle> m_ResourceViews;
+  ezHashTable<ezUInt32, ezGALRenderTargetViewHandle> m_RenderTargetViews;
 };
 
 /// \brief Optional interface for ezGALTexture if it was created via ezGALDevice::CreateSharedTexture.

--- a/Code/Engine/RendererFoundation/Resources/UnorderedAccesView.h
+++ b/Code/Engine/RendererFoundation/Resources/UnorderedAccesView.h
@@ -4,7 +4,10 @@
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Resources/Resource.h>
 
-class EZ_RENDERERFOUNDATION_DLL ezGALUnorderedAccessView : public ezGALObject<ezGALUnorderedAccessViewCreationDescription>
+class ezGALTexture;
+class ezGALBuffer;
+
+class EZ_RENDERERFOUNDATION_DLL ezGALTextureUnorderedAccessView : public ezGALObject<ezGALTextureUnorderedAccessViewCreationDescription>
 {
 public:
   EZ_ALWAYS_INLINE ezGALResourceBase* GetResource() const { return m_pResource; }
@@ -12,13 +15,28 @@ public:
 protected:
   friend class ezGALDevice;
 
-  ezGALUnorderedAccessView(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& description);
+  ezGALTextureUnorderedAccessView(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& description);
 
-  virtual ~ezGALUnorderedAccessView();
-
+  virtual ~ezGALTextureUnorderedAccessView();
   virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 
-  ezGALResourceBase* m_pResource;
+  ezGALTexture* m_pResource;
+};
+
+class EZ_RENDERERFOUNDATION_DLL ezGALBufferUnorderedAccessView : public ezGALObject<ezGALBufferUnorderedAccessViewCreationDescription>
+{
+public:
+  EZ_ALWAYS_INLINE ezGALBuffer* GetResource() const { return m_pResource; }
+  
+protected:
+  friend class ezGALDevice;
+
+  ezGALBufferUnorderedAccessView(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& description);
+
+  virtual ~ezGALBufferUnorderedAccessView();
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+
+  ezGALBuffer* m_pResource;
 };

--- a/Code/Engine/RendererFoundation/Resources/UnorderedAccesView.h
+++ b/Code/Engine/RendererFoundation/Resources/UnorderedAccesView.h
@@ -28,7 +28,7 @@ class EZ_RENDERERFOUNDATION_DLL ezGALBufferUnorderedAccessView : public ezGALObj
 {
 public:
   EZ_ALWAYS_INLINE ezGALBuffer* GetResource() const { return m_pResource; }
-  
+
 protected:
   friend class ezGALDevice;
 

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -14,7 +14,8 @@ class ezGALBlendStateVulkan;
 class ezGALBufferVulkan;
 class ezGALDepthStencilStateVulkan;
 class ezGALRasterizerStateVulkan;
-class ezGALResourceViewVulkan;
+class ezGALTextureResourceViewVulkan;
+class ezGALBufferResourceViewVulkan;
 class ezGALSamplerStateVulkan;
 class ezGALShaderVulkan;
 class ezGALUnorderedAccessViewVulkan;
@@ -37,7 +38,8 @@ public:
 
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) override;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
-  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALResourceView* pResourceView) override;
+  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) override;
+  virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView) override;
   virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView) override;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) override;
 
@@ -72,7 +74,7 @@ public:
 
   virtual void CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> SourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> TargetData) override;
 
-  virtual void GenerateMipMapsPlatform(const ezGALResourceView* pResourceView) override;
+  virtual void GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView) override;
 
   void CopyImageToBuffer(const ezGALTextureVulkan* pSource, const ezGALBufferVulkan* pDestination);
 
@@ -128,14 +130,16 @@ private:
   struct SetResources
   {
     ezDynamicArray<const ezGALBufferVulkan*> m_pBoundConstantBuffers;
-    ezDynamicArray<const ezGALResourceViewVulkan*> m_pBoundShaderResourceViews;
+    ezDynamicArray<const ezGALTextureResourceViewVulkan*> m_pBoundTextureResourceViews;
+    ezDynamicArray<const ezGALBufferResourceViewVulkan*> m_pBoundBufferResourceViews;
     ezDynamicArray<const ezGALUnorderedAccessViewVulkan*> m_pBoundUnoderedAccessViews;
     ezDynamicArray<const ezGALSamplerStateVulkan*> m_pBoundSamplerStates;
   };
 
 private:
   ezResult FlushDeferredStateChanges();
-  const ezGALResourceViewVulkan* GetShaderResourceView(const SetResources& resources, const ezShaderResourceBinding& mapping);
+  const ezGALTextureResourceViewVulkan* GetTextureResourceView(const SetResources& resources, const ezShaderResourceBinding& mapping);
+  const ezGALBufferResourceViewVulkan* GetBufferResourceView(const SetResources& resources, const ezShaderResourceBinding& mapping);
   const ezGALUnorderedAccessViewVulkan* GetShaderUAV(const SetResources& resources, const ezShaderResourceBinding& mapping);
 
 private:

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -18,7 +18,8 @@ class ezGALTextureResourceViewVulkan;
 class ezGALBufferResourceViewVulkan;
 class ezGALSamplerStateVulkan;
 class ezGALShaderVulkan;
-class ezGALUnorderedAccessViewVulkan;
+class ezGALTextureUnorderedAccessViewVulkan;
+class ezGALBufferUnorderedAccessViewVulkan;
 class ezGALDeviceVulkan;
 
 class EZ_RENDERERVULKAN_DLL ezGALCommandEncoderImplVulkan : public ezGALCommandEncoderCommonPlatformInterface, public ezGALCommandEncoderRenderPlatformInterface, public ezGALCommandEncoderComputePlatformInterface
@@ -40,7 +41,8 @@ public:
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) override;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferResourceView* pResourceView) override;
-  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALUnorderedAccessView* pUnorderedAccessView) override;
+  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureUnorderedAccessView* pUnorderedAccessView) override;
+  virtual void SetUnorderedAccessViewPlatform(const ezShaderResourceBinding& binding, const ezGALBufferUnorderedAccessView* pUnorderedAccessView) override;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) override;
 
   // Query functions
@@ -55,8 +57,11 @@ public:
 
   // Resource update functions
 
-  virtual void ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4 clearValues) override;
-  virtual void ClearUnorderedAccessViewPlatform(const ezGALUnorderedAccessView* pUnorderedAccessView, ezVec4U32 clearValues) override;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4 clearValues) override;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4 clearValues) override;
+
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALTextureUnorderedAccessView* pUnorderedAccessView, ezVec4U32 clearValues) override;
+  virtual void ClearUnorderedAccessViewPlatform(const ezGALBufferUnorderedAccessView* pUnorderedAccessView, ezVec4U32 clearValues) override;
 
   virtual void CopyBufferPlatform(const ezGALBuffer* pDestination, const ezGALBuffer* pSource) override;
   virtual void CopyBufferRegionPlatform(const ezGALBuffer* pDestination, ezUInt32 uiDestOffset, const ezGALBuffer* pSource, ezUInt32 uiSourceOffset, ezUInt32 uiByteCount) override;
@@ -132,7 +137,8 @@ private:
     ezDynamicArray<const ezGALBufferVulkan*> m_pBoundConstantBuffers;
     ezDynamicArray<const ezGALTextureResourceViewVulkan*> m_pBoundTextureResourceViews;
     ezDynamicArray<const ezGALBufferResourceViewVulkan*> m_pBoundBufferResourceViews;
-    ezDynamicArray<const ezGALUnorderedAccessViewVulkan*> m_pBoundUnoderedAccessViews;
+    ezDynamicArray<const ezGALTextureUnorderedAccessViewVulkan*> m_pBoundTextureUnorderedAccessViews;
+    ezDynamicArray<const ezGALBufferUnorderedAccessViewVulkan*> m_pBoundBufferUnorderedAccessViews;
     ezDynamicArray<const ezGALSamplerStateVulkan*> m_pBoundSamplerStates;
   };
 
@@ -140,7 +146,8 @@ private:
   ezResult FlushDeferredStateChanges();
   const ezGALTextureResourceViewVulkan* GetTextureResourceView(const SetResources& resources, const ezShaderResourceBinding& mapping);
   const ezGALBufferResourceViewVulkan* GetBufferResourceView(const SetResources& resources, const ezShaderResourceBinding& mapping);
-  const ezGALUnorderedAccessViewVulkan* GetShaderUAV(const SetResources& resources, const ezShaderResourceBinding& mapping);
+  const ezGALTextureUnorderedAccessViewVulkan* GetTextureUAV(const SetResources& resources, const ezShaderResourceBinding& mapping);
+  const ezGALBufferUnorderedAccessViewVulkan* GetBufferUAV(const SetResources& resources, const ezShaderResourceBinding& mapping);
 
 private:
   ezGALDeviceVulkan& m_GALDeviceVulkan;

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1538,7 +1538,7 @@ const ezGALBufferResourceViewVulkan* ezGALCommandEncoderImplVulkan::GetBufferRes
   {
     pResourceView = resources.m_pBoundBufferResourceViews[mapping.m_iSlot];
   }
-  
+
   if (!pResourceView)
   {
     ezStringBuilder sName = mapping.m_sName.GetData();
@@ -1570,7 +1570,7 @@ const ezGALBufferUnorderedAccessViewVulkan* ezGALCommandEncoderImplVulkan::GetBu
   {
     pUAV = resources.m_pBoundBufferUnorderedAccessViews[mapping.m_iSlot];
   }
-  
+
   if (!pUAV)
   {
     pUAV = ezFallbackResourcesVulkan::GetFallbackBufferUnorderedAccessView(mapping.m_ResourceType);

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -346,8 +346,11 @@ protected:
   virtual ezGALRenderTargetView* CreateRenderTargetViewPlatform(ezGALTexture* pTexture, const ezGALRenderTargetViewCreationDescription& Description) override;
   virtual void DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRenderTargetView) override;
 
-  ezGALUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description) override;
-  virtual void DestroyUnorderedAccessViewPlatform(ezGALUnorderedAccessView* pResource) override;
+  ezGALTextureUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description) override;
+  virtual void DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAccessView* pUnorderedAccessView) override;
+
+  ezGALBufferUnorderedAccessView* CreateUnorderedAccessViewPlatform(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description) override;
+  virtual void DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView) override;
 
   // Other rendering creation functions
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -337,8 +337,11 @@ protected:
   virtual ezGALTexture* CreateSharedTexturePlatform(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle handle) override;
   virtual void DestroySharedTexturePlatform(ezGALTexture* pTexture) override;
 
-  virtual ezGALResourceView* CreateResourceViewPlatform(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description) override;
-  virtual void DestroyResourceViewPlatform(ezGALResourceView* pResourceView) override;
+  virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) override;
+  virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) override;
+  
+  virtual ezGALBufferResourceView* CreateResourceViewPlatform(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description) override;
+  virtual void DestroyResourceViewPlatform(ezGALBufferResourceView* pResourceView) override;
 
   virtual ezGALRenderTargetView* CreateRenderTargetViewPlatform(ezGALTexture* pTexture, const ezGALRenderTargetViewCreationDescription& Description) override;
   virtual void DestroyRenderTargetViewPlatform(ezGALRenderTargetView* pRenderTargetView) override;

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -293,6 +293,7 @@ protected:
   vk::Result SelectInstanceExtensions(ezHybridArray<const char*, 6>& extensions);
   vk::Result SelectDeviceExtensions(vk::DeviceCreateInfo& deviceCreateInfo, ezHybridArray<const char*, 6>& extensions);
 
+  virtual ezStringView GetRendererPlatform() override;
   virtual ezResult InitPlatform() override;
   virtual ezResult ShutdownPlatform() override;
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -339,7 +339,7 @@ protected:
 
   virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) override;
   virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) override;
-  
+
   virtual ezGALBufferResourceView* CreateResourceViewPlatform(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description) override;
   virtual void DestroyResourceViewPlatform(ezGALBufferResourceView* pResourceView) override;
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1253,10 +1253,10 @@ void ezGALDeviceVulkan::DestroyRenderTargetViewPlatform(ezGALRenderTargetView* p
   EZ_DELETE(&m_Allocator, pVulkanRenderTargetView);
 }
 
-ezGALUnorderedAccessView* ezGALDeviceVulkan::CreateUnorderedAccessViewPlatform(
-  ezGALResourceBase* pTextureOfBuffer, const ezGALUnorderedAccessViewCreationDescription& Description)
+ezGALTextureUnorderedAccessView* ezGALDeviceVulkan::CreateUnorderedAccessViewPlatform(
+  ezGALTexture* pTextureOfBuffer, const ezGALTextureUnorderedAccessViewCreationDescription& Description)
 {
-  ezGALUnorderedAccessViewVulkan* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALUnorderedAccessViewVulkan, pTextureOfBuffer, Description);
+  ezGALTextureUnorderedAccessViewVulkan* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALTextureUnorderedAccessViewVulkan, pTextureOfBuffer, Description);
 
   if (!pUnorderedAccessView->InitPlatform(this).Succeeded())
   {
@@ -1267,14 +1267,33 @@ ezGALUnorderedAccessView* ezGALDeviceVulkan::CreateUnorderedAccessViewPlatform(
   return pUnorderedAccessView;
 }
 
-void ezGALDeviceVulkan::DestroyUnorderedAccessViewPlatform(ezGALUnorderedAccessView* pUnorderedAccessView)
+void ezGALDeviceVulkan::DestroyUnorderedAccessViewPlatform(ezGALTextureUnorderedAccessView* pUnorderedAccessView)
 {
-  ezGALUnorderedAccessViewVulkan* pUnorderedAccessViewVulkan = static_cast<ezGALUnorderedAccessViewVulkan*>(pUnorderedAccessView);
+  ezGALTextureUnorderedAccessViewVulkan* pUnorderedAccessViewVulkan = static_cast<ezGALTextureUnorderedAccessViewVulkan*>(pUnorderedAccessView);
   pUnorderedAccessViewVulkan->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pUnorderedAccessViewVulkan);
 }
 
+ezGALBufferUnorderedAccessView* ezGALDeviceVulkan::CreateUnorderedAccessViewPlatform(
+  ezGALBuffer* pBufferOfBuffer, const ezGALBufferUnorderedAccessViewCreationDescription& Description)
+{
+  ezGALBufferUnorderedAccessViewVulkan* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALBufferUnorderedAccessViewVulkan, pBufferOfBuffer, Description);
+  
+  if (!pUnorderedAccessView->InitPlatform(this).Succeeded())
+  {
+    EZ_DELETE(&m_Allocator, pUnorderedAccessView);
+    return nullptr;
+  }
 
+  return pUnorderedAccessView;
+}
+
+void ezGALDeviceVulkan::DestroyUnorderedAccessViewPlatform(ezGALBufferUnorderedAccessView* pUnorderedAccessView)
+{
+  ezGALBufferUnorderedAccessViewVulkan* pUnorderedAccessViewVulkan = static_cast<ezGALBufferUnorderedAccessViewVulkan*>(pUnorderedAccessView);
+  pUnorderedAccessViewVulkan->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pUnorderedAccessViewVulkan);
+}
 
 // Other rendering creation functions
 ezGALQuery* ezGALDeviceVulkan::CreateQueryPlatform(const ezGALQueryCreationDescription& Description)

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -453,7 +453,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
     // TODO making sure we have a hardware device?
     m_physicalDevice = physicalDevices[0];
     m_properties = m_physicalDevice.getProperties();
-    ezLog::Info("Selected physical device \"{}\" for device creation.", m_properties.deviceName);
+    ezLog::Warning("Selected physical device \"{}\" for device creation.", m_properties.deviceName);
 
     // This is a workaround for broken lavapipe drivers which cannot handle label scopes that span across multiple command buffers.
     ezStringBuilder sDeviceName = ezStringUtf8(m_properties.deviceName).GetView();
@@ -1192,10 +1192,9 @@ void ezGALDeviceVulkan::DestroySharedTexturePlatform(ezGALTexture* pTexture)
   EZ_DELETE(&m_Allocator, pVulkanTexture);
 }
 
-ezGALResourceView* ezGALDeviceVulkan::CreateResourceViewPlatform(
-  ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description)
+ezGALTextureResourceView* ezGALDeviceVulkan::CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description)
 {
-  ezGALResourceViewVulkan* pResourceView = EZ_NEW(&m_Allocator, ezGALResourceViewVulkan, pResource, Description);
+  ezGALTextureResourceViewVulkan* pResourceView = EZ_NEW(&m_Allocator, ezGALTextureResourceViewVulkan, pResource, Description);
 
   if (!pResourceView->InitPlatform(this).Succeeded())
   {
@@ -1206,9 +1205,29 @@ ezGALResourceView* ezGALDeviceVulkan::CreateResourceViewPlatform(
   return pResourceView;
 }
 
-void ezGALDeviceVulkan::DestroyResourceViewPlatform(ezGALResourceView* pResourceView)
+void ezGALDeviceVulkan::DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView)
 {
-  ezGALResourceViewVulkan* pVulkanResourceView = static_cast<ezGALResourceViewVulkan*>(pResourceView);
+  ezGALTextureResourceViewVulkan* pVulkanResourceView = static_cast<ezGALTextureResourceViewVulkan*>(pResourceView);
+  pVulkanResourceView->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pVulkanResourceView);
+}
+
+ezGALBufferResourceView* ezGALDeviceVulkan::CreateResourceViewPlatform(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description)
+{
+  ezGALBufferResourceViewVulkan* pResourceView = EZ_NEW(&m_Allocator, ezGALBufferResourceViewVulkan, pResource, Description);
+
+  if (!pResourceView->InitPlatform(this).Succeeded())
+  {
+    EZ_DELETE(&m_Allocator, pResourceView);
+    return nullptr;
+  }
+
+  return pResourceView;
+}
+
+void ezGALDeviceVulkan::DestroyResourceViewPlatform(ezGALBufferResourceView* pResourceView)
+{
+  ezGALBufferResourceViewVulkan* pVulkanResourceView = static_cast<ezGALBufferResourceViewVulkan*>(pResourceView);
   pVulkanResourceView->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanResourceView);
 }

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1278,7 +1278,7 @@ ezGALBufferUnorderedAccessView* ezGALDeviceVulkan::CreateUnorderedAccessViewPlat
   ezGALBuffer* pBufferOfBuffer, const ezGALBufferUnorderedAccessViewCreationDescription& Description)
 {
   ezGALBufferUnorderedAccessViewVulkan* pUnorderedAccessView = EZ_NEW(&m_Allocator, ezGALBufferUnorderedAccessViewVulkan, pBufferOfBuffer, Description);
-  
+
   if (!pUnorderedAccessView->InitPlatform(this).Succeeded())
   {
     EZ_DELETE(&m_Allocator, pUnorderedAccessView);

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -323,6 +323,11 @@ vk::Result ezGALDeviceVulkan::SelectDeviceExtensions(vk::DeviceCreateInfo& devic
 
 #define EZ_GET_INSTANCE_PROC_ADDR(name) m_extensions.pfn_##name = reinterpret_cast<PFN_##name>(vkGetInstanceProcAddr(m_instance, #name));
 
+ezStringView ezGALDeviceVulkan::GetRendererPlatform()
+{
+  return "Vulkan";
+}
+
 ezResult ezGALDeviceVulkan::InitPlatform()
 {
   EZ_LOG_BLOCK("ezGALDeviceVulkan::InitPlatform");

--- a/Code/Engine/RendererVulkan/Resources/FallbackResourcesVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/FallbackResourcesVulkan.h
@@ -7,7 +7,8 @@
 class ezGALDeviceVulkan;
 class ezGALTextureResourceViewVulkan;
 class ezGALBufferResourceViewVulkan;
-class ezGALUnorderedAccessViewVulkan;
+class ezGALTextureUnorderedAccessViewVulkan;
+class ezGALBufferUnorderedAccessViewVulkan;
 
 /// \brief Creates fallback resources in case the high-level renderer did not map a resource to a descriptor slot.
 /// #TODO_VULKAN: Although the class has 'Vulkan' in the name, it could be made GAL agnostic by just returning the base class of the resource views and then it will work for any device type so it could be moved to RendererFoundation if needed for another GAL implementation.
@@ -21,7 +22,8 @@ public:
   /// \return
   static const ezGALTextureResourceViewVulkan* GetFallbackTextureResourceView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType, bool bDepth);
   static const ezGALBufferResourceViewVulkan* GetFallbackBufferResourceView(ezGALShaderResourceType::Enum descriptorType);
-  static const ezGALUnorderedAccessViewVulkan* GetFallbackUnorderedAccessView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType);
+  static const ezGALTextureUnorderedAccessViewVulkan* GetFallbackTextureUnorderedAccessView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType);
+  static const ezGALBufferUnorderedAccessViewVulkan* GetFallbackBufferUnorderedAccessView(ezGALShaderResourceType::Enum descriptorType);
 
 private:
   EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(RendererVulkan, FallbackResourcesVulkan)
@@ -51,7 +53,8 @@ private:
 
   static ezHashTable<Key, ezGALTextureResourceViewHandle, KeyHash> m_TextureResourceViews;
   static ezHashTable<ezEnum<ezGALShaderResourceType>, ezGALBufferResourceViewHandle, KeyHash> m_BufferResourceViews;
-  static ezHashTable<Key, ezGALUnorderedAccessViewHandle, KeyHash> m_UAVs;
+  static ezHashTable<Key, ezGALTextureUnorderedAccessViewHandle, KeyHash> m_TextureUAVs;
+  static ezHashTable<ezEnum<ezGALShaderResourceType>, ezGALBufferUnorderedAccessViewHandle, KeyHash> m_BufferUAVs;
 
   static ezDynamicArray<ezGALBufferHandle> m_Buffers;
   static ezDynamicArray<ezGALTextureHandle> m_Textures;

--- a/Code/Engine/RendererVulkan/Resources/FallbackResourcesVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/FallbackResourcesVulkan.h
@@ -5,7 +5,8 @@
 #include <vulkan/vulkan.hpp>
 
 class ezGALDeviceVulkan;
-class ezGALResourceViewVulkan;
+class ezGALTextureResourceViewVulkan;
+class ezGALBufferResourceViewVulkan;
 class ezGALUnorderedAccessViewVulkan;
 
 /// \brief Creates fallback resources in case the high-level renderer did not map a resource to a descriptor slot.
@@ -18,7 +19,8 @@ public:
   /// \param textureType In case descriptorType is a texture, this specifies the texture type.
   /// \param bDepth Whether the shader resource is using a depth sampler.
   /// \return
-  static const ezGALResourceViewVulkan* GetFallbackResourceView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType, bool bDepth);
+  static const ezGALTextureResourceViewVulkan* GetFallbackTextureResourceView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType, bool bDepth);
+  static const ezGALBufferResourceViewVulkan* GetFallbackBufferResourceView(ezGALShaderResourceType::Enum descriptorType);
   static const ezGALUnorderedAccessViewVulkan* GetFallbackUnorderedAccessView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType);
 
 private:
@@ -42,9 +44,13 @@ private:
   {
     static ezUInt32 Hash(const Key& a);
     static bool Equal(const Key& a, const Key& b);
+
+    static ezUInt32 Hash(const ezEnum<ezGALShaderResourceType>& a);
+    static bool Equal(const ezEnum<ezGALShaderResourceType>& a, const ezEnum<ezGALShaderResourceType>& b);
   };
 
-  static ezHashTable<Key, ezGALResourceViewHandle, KeyHash> m_ResourceViews;
+  static ezHashTable<Key, ezGALTextureResourceViewHandle, KeyHash> m_TextureResourceViews;
+  static ezHashTable<ezEnum<ezGALShaderResourceType>, ezGALBufferResourceViewHandle, KeyHash> m_BufferResourceViews;
   static ezHashTable<Key, ezGALUnorderedAccessViewHandle, KeyHash> m_UAVs;
 
   static ezDynamicArray<ezGALBufferHandle> m_Buffers;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -29,14 +29,14 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
         m_usage |= vk::BufferUsageFlagBits::eVertexBuffer;
         m_stages |= vk::PipelineStageFlagBits::eVertexInput;
         m_access |= vk::AccessFlagBits::eVertexAttributeRead;
-        //EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
+        // EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
         break;
       case ezGALBufferFlags::IndexBuffer:
         m_usage |= vk::BufferUsageFlagBits::eIndexBuffer;
         m_stages |= vk::PipelineStageFlagBits::eVertexInput;
         m_access |= vk::AccessFlagBits::eIndexRead;
         m_indexType = m_Description.m_uiStructSize == 2 ? vk::IndexType::eUint16 : vk::IndexType::eUint32;
-        //EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
+        // EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
         break;
       case ezGALBufferFlags::ConstantBuffer:
         m_usage |= vk::BufferUsageFlagBits::eUniformBuffer;
@@ -72,7 +72,7 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
     }
   }
 
-  //if (m_Description.m_ResourceAccess.m_bReadBack)
+  // if (m_Description.m_ResourceAccess.m_bReadBack)
   {
     m_usage |= vk::BufferUsageFlagBits::eTransferSrc;
     m_access |= vk::AccessFlagBits::eTransferRead;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -19,49 +19,49 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
   m_device = m_pDeviceVulkan->GetVulkanDevice();
   m_stages = vk::PipelineStageFlagBits::eTransfer;
 
-  const bool bSRV = m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::ShaderResource);
-  const bool bUAV = m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::UnorderedAccess);
-  for (ezGALBufferFlags::Enum flag : m_Description.m_BufferFlags)
+  const bool bSRV = m_Description.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ShaderResource);
+  const bool bUAV = m_Description.m_BufferFlags.IsSet(ezGALBufferUsageFlags::UnorderedAccess);
+  for (ezGALBufferUsageFlags::Enum flag : m_Description.m_BufferFlags)
   {
     switch (flag)
     {
-      case ezGALBufferFlags::VertexBuffer:
+      case ezGALBufferUsageFlags::VertexBuffer:
         m_usage |= vk::BufferUsageFlagBits::eVertexBuffer;
         m_stages |= vk::PipelineStageFlagBits::eVertexInput;
         m_access |= vk::AccessFlagBits::eVertexAttributeRead;
         // EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
         break;
-      case ezGALBufferFlags::IndexBuffer:
+      case ezGALBufferUsageFlags::IndexBuffer:
         m_usage |= vk::BufferUsageFlagBits::eIndexBuffer;
         m_stages |= vk::PipelineStageFlagBits::eVertexInput;
         m_access |= vk::AccessFlagBits::eIndexRead;
         m_indexType = m_Description.m_uiStructSize == 2 ? vk::IndexType::eUint16 : vk::IndexType::eUint32;
         // EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
         break;
-      case ezGALBufferFlags::ConstantBuffer:
+      case ezGALBufferUsageFlags::ConstantBuffer:
         m_usage |= vk::BufferUsageFlagBits::eUniformBuffer;
         m_stages |= m_pDeviceVulkan->GetSupportedStages();
         m_access |= vk::AccessFlagBits::eUniformRead;
         break;
-      case ezGALBufferFlags::TexelBuffer:
+      case ezGALBufferUsageFlags::TexelBuffer:
         if (bSRV)
           m_usage |= vk::BufferUsageFlagBits::eUniformTexelBuffer;
         if (bUAV)
           m_usage |= vk::BufferUsageFlagBits::eStorageTexelBuffer;
         break;
-      case ezGALBufferFlags::StructuredBuffer:
-      case ezGALBufferFlags::ByteAddressBuffer:
+      case ezGALBufferUsageFlags::StructuredBuffer:
+      case ezGALBufferUsageFlags::ByteAddressBuffer:
         m_usage |= vk::BufferUsageFlagBits::eStorageBuffer;
         break;
-      case ezGALBufferFlags::ShaderResource:
+      case ezGALBufferUsageFlags::ShaderResource:
         m_stages |= m_pDeviceVulkan->GetSupportedStages();
         m_access |= vk::AccessFlagBits::eShaderRead;
         break;
-      case ezGALBufferFlags::UnorderedAccess:
+      case ezGALBufferUsageFlags::UnorderedAccess:
         m_stages |= m_pDeviceVulkan->GetSupportedStages();
         m_access |= vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
         break;
-      case ezGALBufferFlags::DrawIndirect:
+      case ezGALBufferUsageFlags::DrawIndirect:
         m_usage |= vk::BufferUsageFlagBits::eIndirectBuffer;
         m_stages |= vk::PipelineStageFlagBits::eDrawIndirect;
         m_access |= vk::AccessFlagBits::eIndirectCommandRead;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -17,57 +17,62 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
 {
   m_pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
   m_device = m_pDeviceVulkan->GetVulkanDevice();
-
   m_stages = vk::PipelineStageFlagBits::eTransfer;
 
-  switch (m_Description.m_BufferType)
+  const bool bSRV = m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::ShaderResource);
+  const bool bUAV = m_Description.m_BufferFlags.IsSet(ezGALBufferFlags::UnorderedAccess);
+  for (ezGALBufferFlags::Enum flag : m_Description.m_BufferFlags)
   {
-    case ezGALBufferType::ConstantBuffer:
-      m_usage = vk::BufferUsageFlagBits::eUniformBuffer;
-      m_stages |= m_pDeviceVulkan->GetSupportedStages();
-      m_access |= vk::AccessFlagBits::eUniformRead;
-      break;
-    case ezGALBufferType::IndexBuffer:
-      m_usage = vk::BufferUsageFlagBits::eIndexBuffer;
-      m_stages |= vk::PipelineStageFlagBits::eVertexInput;
-      m_access |= vk::AccessFlagBits::eIndexRead;
-      m_indexType = m_Description.m_uiStructSize == 2 ? vk::IndexType::eUint16 : vk::IndexType::eUint32;
-
-      break;
-    case ezGALBufferType::VertexBuffer:
-      m_usage = vk::BufferUsageFlagBits::eVertexBuffer;
-      m_stages |= vk::PipelineStageFlagBits::eVertexInput;
-      m_access |= vk::AccessFlagBits::eVertexAttributeRead;
-      break;
-    case ezGALBufferType::Generic:
-      m_usage = m_Description.m_bUseAsStructuredBuffer ? vk::BufferUsageFlagBits::eStorageBuffer : vk::BufferUsageFlagBits::eUniformTexelBuffer;
-      m_stages |= m_pDeviceVulkan->GetSupportedStages();
-      break;
-    default:
-      ezLog::Error("Unknown buffer type supplied to CreateBuffer()!");
-      return EZ_FAILURE;
+    switch (flag)
+    {
+      case ezGALBufferFlags::VertexBuffer:
+        m_usage |= vk::BufferUsageFlagBits::eVertexBuffer;
+        m_stages |= vk::PipelineStageFlagBits::eVertexInput;
+        m_access |= vk::AccessFlagBits::eVertexAttributeRead;
+        //EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
+        break;
+      case ezGALBufferFlags::IndexBuffer:
+        m_usage |= vk::BufferUsageFlagBits::eIndexBuffer;
+        m_stages |= vk::PipelineStageFlagBits::eVertexInput;
+        m_access |= vk::AccessFlagBits::eIndexRead;
+        m_indexType = m_Description.m_uiStructSize == 2 ? vk::IndexType::eUint16 : vk::IndexType::eUint32;
+        //EZ_ASSERT_DEBUG(!bSRV && !bUAV, "Not implemented");
+        break;
+      case ezGALBufferFlags::ConstantBuffer:
+        m_usage |= vk::BufferUsageFlagBits::eUniformBuffer;
+        m_stages |= m_pDeviceVulkan->GetSupportedStages();
+        m_access |= vk::AccessFlagBits::eUniformRead;
+        break;
+      case ezGALBufferFlags::TexelBuffer:
+        if (bSRV)
+          m_usage |= vk::BufferUsageFlagBits::eUniformTexelBuffer;
+        if (bUAV)
+          m_usage |= vk::BufferUsageFlagBits::eStorageTexelBuffer;
+        break;
+      case ezGALBufferFlags::StructuredBuffer:
+      case ezGALBufferFlags::ByteAddressBuffer:
+        m_usage |= vk::BufferUsageFlagBits::eStorageBuffer;
+        break;
+      case ezGALBufferFlags::ShaderResource:
+        m_stages |= m_pDeviceVulkan->GetSupportedStages();
+        m_access |= vk::AccessFlagBits::eShaderRead;
+        break;
+      case ezGALBufferFlags::UnorderedAccess:
+        m_stages |= m_pDeviceVulkan->GetSupportedStages();
+        m_access |= vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
+        break;
+      case ezGALBufferFlags::DrawIndirect:
+        m_usage |= vk::BufferUsageFlagBits::eIndirectBuffer;
+        m_stages |= vk::PipelineStageFlagBits::eDrawIndirect;
+        m_access |= vk::AccessFlagBits::eIndirectCommandRead;
+        break;
+      default:
+        ezLog::Error("Unknown buffer type supplied to CreateBuffer()!");
+        return EZ_FAILURE;
+    }
   }
 
-  if (m_Description.m_bAllowShaderResourceView)
-  {
-    m_stages |= m_pDeviceVulkan->GetSupportedStages();
-    m_access |= vk::AccessFlagBits::eShaderRead;
-  }
-
-  if (m_Description.m_bAllowUAV)
-  {
-    m_stages |= m_pDeviceVulkan->GetSupportedStages();
-    m_access |= vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite;
-  }
-
-  if (m_Description.m_bUseForIndirectArguments)
-  {
-    m_usage |= vk::BufferUsageFlagBits::eIndirectBuffer;
-    m_stages |= vk::PipelineStageFlagBits::eDrawIndirect;
-    m_access |= vk::AccessFlagBits::eIndirectCommandRead;
-  }
-
-  if (m_Description.m_ResourceAccess.m_bReadBack)
+  //if (m_Description.m_ResourceAccess.m_bReadBack)
   {
     m_usage |= vk::BufferUsageFlagBits::eTransferSrc;
     m_access |= vk::AccessFlagBits::eTransferRead;
@@ -79,11 +84,6 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
   EZ_ASSERT_DEBUG(pInitialData.GetCount() <= m_Description.m_uiTotalSize, "Initial data is bigger than target buffer.");
   vk::DeviceSize alignment = GetAlignment(m_pDeviceVulkan, m_usage);
   m_size = ezMemoryUtils::AlignSize((vk::DeviceSize)m_Description.m_uiTotalSize, alignment);
-
-  if (m_Description.m_bAllowRawViews)
-  {
-    // TODO Vulkan?
-  }
 
   CreateBuffer();
 
@@ -199,7 +199,7 @@ vk::DeviceSize ezGALBufferVulkan::GetAlignment(const ezGALDeviceVulkan* pDevice,
     alignment = ezMath::Max(alignment, properties.limits.minTexelBufferOffsetAlignment);
 
   if (usage & (vk::BufferUsageFlagBits::eIndexBuffer | vk::BufferUsageFlagBits::eVertexBuffer | vk::BufferUsageFlagBits::eIndirectBuffer))
-    alignment = ezMath::Max(alignment, VkDeviceSize(16));
+    alignment = ezMath::Max(alignment, VkDeviceSize(16)); // If no cache line aligned perf will suffer.
 
   if (usage & (vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst))
     alignment = ezMath::Max(alignment, properties.limits.optimalBufferCopyOffsetAlignment);

--- a/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
@@ -116,11 +116,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
       }
       {
         ezGALBufferCreationDescription desc;
-        desc.m_bUseForIndirectArguments = false;
-        desc.m_bUseAsStructuredBuffer = true;
-        desc.m_bAllowRawViews = true;
-        desc.m_bAllowShaderResourceView = true;
-        desc.m_bAllowUAV = true;
+        desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ByteAddressBuffer | ezGALBufferFlags::ShaderResource;
         desc.m_uiStructSize = 128;
         desc.m_uiTotalSize = 1280;
         desc.m_ResourceAccess.m_bImmutable = false;
@@ -137,7 +133,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferCreationDescription desc;
         desc.m_uiStructSize = sizeof(ezUInt32);
         desc.m_uiTotalSize = 1024;
-        desc.m_bAllowShaderResourceView = true;
+        desc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource;
         desc.m_ResourceAccess.m_bImmutable = false;
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackTexelBufferVulkan");
@@ -172,8 +168,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferCreationDescription desc;
         desc.m_uiStructSize = sizeof(ezUInt32);
         desc.m_uiTotalSize = 1024;
-        desc.m_bAllowShaderResourceView = true;
-        desc.m_bAllowUAV = true;
+        desc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource | ezGALBufferFlags::UnorderedAccess;
         desc.m_ResourceAccess.m_bImmutable = false;
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackTexelBufferRWVulkan");
@@ -184,11 +179,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
       }
       {
         ezGALBufferCreationDescription desc;
-        desc.m_bUseForIndirectArguments = false;
-        desc.m_bUseAsStructuredBuffer = true;
-        desc.m_bAllowRawViews = true;
-        desc.m_bAllowShaderResourceView = true;
-        desc.m_bAllowUAV = true;
+        desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ByteAddressBuffer | ezGALBufferFlags::ShaderResource | ezGALBufferFlags::UnorderedAccess;
         desc.m_uiStructSize = 128;
         desc.m_uiTotalSize = 1280;
         desc.m_ResourceAccess.m_bImmutable = false;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
@@ -35,7 +35,8 @@ EZ_END_SUBSYSTEM_DECLARATION;
 ezGALDevice* ezFallbackResourcesVulkan::s_pDevice = nullptr;
 ezEventSubscriptionID ezFallbackResourcesVulkan::s_EventID = 0;
 
-ezHashTable<ezFallbackResourcesVulkan::Key, ezGALResourceViewHandle, ezFallbackResourcesVulkan::KeyHash> ezFallbackResourcesVulkan::m_ResourceViews;
+ezHashTable<ezFallbackResourcesVulkan::Key, ezGALTextureResourceViewHandle, ezFallbackResourcesVulkan::KeyHash> ezFallbackResourcesVulkan::m_TextureResourceViews;
+ezHashTable<ezEnum<ezGALShaderResourceType>, ezGALBufferResourceViewHandle, ezFallbackResourcesVulkan::KeyHash> ezFallbackResourcesVulkan::m_BufferResourceViews;
 ezHashTable<ezFallbackResourcesVulkan::Key, ezGALUnorderedAccessViewHandle, ezFallbackResourcesVulkan::KeyHash> ezFallbackResourcesVulkan::m_UAVs;
 ezDynamicArray<ezGALBufferHandle> ezFallbackResourcesVulkan::m_Buffers;
 ezDynamicArray<ezGALTextureHandle> ezFallbackResourcesVulkan::m_Textures;
@@ -56,7 +57,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
     case ezGALDeviceEvent::AfterInit:
     {
       s_pDevice = e.m_pDevice;
-      auto CreateTexture = [](ezGALTextureType::Enum type, ezGALMSAASampleCount::Enum samples, bool bDepth) -> ezGALResourceViewHandle
+      auto CreateTexture = [](ezGALTextureType::Enum type, ezGALMSAASampleCount::Enum samples, bool bDepth) -> ezGALTextureResourceViewHandle
       {
         ezGALTextureCreationDescription desc;
         desc.m_uiWidth = 4;
@@ -77,18 +78,18 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         return s_pDevice->GetDefaultResourceView(hTexture);
       };
       {
-        ezGALResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture2D, ezGALMSAASampleCount::None, false);
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2D, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DArray, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2D, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DArray, false}] = hView;
+        ezGALTextureResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture2D, ezGALMSAASampleCount::None, false);
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2D, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DArray, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2D, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DArray, false}] = hView;
       }
       {
-        ezGALResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture2D, ezGALMSAASampleCount::None, true);
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2D, true}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DArray, true}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2D, true}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DArray, true}] = hView;
+        ezGALTextureResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture2D, ezGALMSAASampleCount::None, true);
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2D, true}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DArray, true}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2D, true}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DArray, true}] = hView;
       }
 
       // Swift shader can only do 4x MSAA. Add a check anyways.
@@ -96,23 +97,23 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
 
       if (bSupported)
       {
-        ezGALResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture2D, ezGALMSAASampleCount::FourSamples, false);
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DMS, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DMSArray, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DMS, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DMSArray, false}] = hView;
+        ezGALTextureResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture2D, ezGALMSAASampleCount::FourSamples, false);
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DMS, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture2DMSArray, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DMS, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture2DMSArray, false}] = hView;
       }
       {
-        ezGALResourceViewHandle hView = CreateTexture(ezGALTextureType::TextureCube, ezGALMSAASampleCount::None, false);
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::TextureCube, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::TextureCubeArray, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::TextureCube, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::TextureCubeArray, false}] = hView;
+        ezGALTextureResourceViewHandle hView = CreateTexture(ezGALTextureType::TextureCube, ezGALMSAASampleCount::None, false);
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::TextureCube, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::TextureCubeArray, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::TextureCube, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::TextureCubeArray, false}] = hView;
       }
       {
-        ezGALResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture3D, ezGALMSAASampleCount::None, false);
-        m_ResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture3D, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture3D, false}] = hView;
+        ezGALTextureResourceViewHandle hView = CreateTexture(ezGALTextureType::Texture3D, ezGALMSAASampleCount::None, false);
+        m_TextureResourceViews[{ezGALShaderResourceType::Texture, ezGALShaderTextureType::Texture3D, false}] = hView;
+        m_TextureResourceViews[{ezGALShaderResourceType::TextureAndSampler, ezGALShaderTextureType::Texture3D, false}] = hView;
       }
       {
         ezGALBufferCreationDescription desc;
@@ -123,11 +124,11 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackStructuredBufferVulkan");
         m_Buffers.PushBack(hBuffer);
-        ezGALResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
-        m_ResourceViews[{ezGALShaderResourceType::ConstantBuffer, ezGALShaderTextureType::Unknown, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::ConstantBuffer, ezGALShaderTextureType::Unknown, true}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::StructuredBuffer, ezGALShaderTextureType::Unknown, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::StructuredBuffer, ezGALShaderTextureType::Unknown, true}] = hView;
+        ezGALBufferResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
+        m_BufferResourceViews[ezGALShaderResourceType::ConstantBuffer] = hView;
+        m_BufferResourceViews[ezGALShaderResourceType::ConstantBuffer] = hView;
+        m_BufferResourceViews[ezGALShaderResourceType::StructuredBuffer] = hView;
+        m_BufferResourceViews[ezGALShaderResourceType::StructuredBuffer] = hView;
       }
       {
         ezGALBufferCreationDescription desc;
@@ -138,9 +139,8 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackTexelBufferVulkan");
         m_Buffers.PushBack(hBuffer);
-        ezGALResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
-        m_ResourceViews[{ezGALShaderResourceType::TexelBuffer, ezGALShaderTextureType::Unknown, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TexelBuffer, ezGALShaderTextureType::Unknown, true}] = hView;
+        ezGALBufferResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
+        m_BufferResourceViews[ezGALShaderResourceType::TexelBuffer] = hView;
       }
       {
         ezGALTextureCreationDescription desc;
@@ -173,9 +173,8 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackTexelBufferRWVulkan");
         m_Buffers.PushBack(hBuffer);
-        ezGALResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
-        m_ResourceViews[{ezGALShaderResourceType::TexelBufferRW, ezGALShaderTextureType::Unknown, false}] = hView;
-        m_ResourceViews[{ezGALShaderResourceType::TexelBufferRW, ezGALShaderTextureType::Unknown, true}] = hView;
+        ezGALBufferResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
+        m_BufferResourceViews[ezGALShaderResourceType::TexelBufferRW] = hView;
       }
       {
         ezGALBufferCreationDescription desc;
@@ -186,15 +185,17 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackStructuredBufferRWVulkan");
         m_Buffers.PushBack(hBuffer);
-        ezGALResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
-        m_ResourceViews[{ezGALShaderResourceType::StructuredBufferRW, ezGALShaderTextureType::Unknown, false}] = hView;
+        ezGALBufferResourceViewHandle hView = s_pDevice->GetDefaultResourceView(hBuffer);
+        m_BufferResourceViews[ezGALShaderResourceType::StructuredBufferRW] = hView;
       }
     }
     break;
     case ezGALDeviceEvent::BeforeShutdown:
     {
-      m_ResourceViews.Clear();
-      m_ResourceViews.Compact();
+      m_TextureResourceViews.Clear();
+      m_TextureResourceViews.Compact();
+      m_BufferResourceViews.Clear();
+      m_BufferResourceViews.Compact();
 
       m_UAVs.Clear();
       m_UAVs.Compact();
@@ -220,11 +221,21 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
   }
 }
 
-const ezGALResourceViewVulkan* ezFallbackResourcesVulkan::GetFallbackResourceView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType, bool bDepth)
+const ezGALTextureResourceViewVulkan* ezFallbackResourcesVulkan::GetFallbackTextureResourceView(ezGALShaderResourceType::Enum descriptorType, ezGALShaderTextureType::Enum textureType, bool bDepth)
 {
-  if (ezGALResourceViewHandle* pView = m_ResourceViews.GetValue(Key{descriptorType, textureType, bDepth}))
+  if (ezGALTextureResourceViewHandle* pView = m_TextureResourceViews.GetValue(Key{descriptorType, textureType, bDepth}))
   {
-    return static_cast<const ezGALResourceViewVulkan*>(s_pDevice->GetResourceView(*pView));
+    return static_cast<const ezGALTextureResourceViewVulkan*>(s_pDevice->GetResourceView(*pView));
+  }
+  EZ_REPORT_FAILURE("No fallback resource set, update ezFallbackResourcesVulkan::GALDeviceEventHandler.");
+  return nullptr;
+}
+
+const ezGALBufferResourceViewVulkan* ezFallbackResourcesVulkan::GetFallbackBufferResourceView(ezGALShaderResourceType::Enum descriptorType)
+{
+  if (ezGALBufferResourceViewHandle* pView = m_BufferResourceViews.GetValue(descriptorType))
+  {
+    return static_cast<const ezGALBufferResourceViewVulkan*>(s_pDevice->GetResourceView(*pView));
   }
   EZ_REPORT_FAILURE("No fallback resource set, update ezFallbackResourcesVulkan::GALDeviceEventHandler.");
   return nullptr;
@@ -252,6 +263,18 @@ ezUInt32 ezFallbackResourcesVulkan::KeyHash::Hash(const Key& a)
 bool ezFallbackResourcesVulkan::KeyHash::Equal(const Key& a, const Key& b)
 {
   return a.m_ResourceType == b.m_ResourceType && a.m_ezType == b.m_ezType && a.m_bDepth == b.m_bDepth;
+}
+
+ezUInt32 ezFallbackResourcesVulkan::KeyHash::Hash(const ezEnum<ezGALShaderResourceType>& a)
+{
+  ezHashStreamWriter32 writer;
+  writer << a.GetValue();
+  return writer.GetHashValue();
+}
+
+bool ezFallbackResourcesVulkan::KeyHash::Equal(const ezEnum<ezGALShaderResourceType>& a, const ezEnum<ezGALShaderResourceType>& b)
+{
+  return a == b;
 }
 
 

--- a/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/FallbackResourcesVulkan.cpp
@@ -118,7 +118,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
       }
       {
         ezGALBufferCreationDescription desc;
-        desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ByteAddressBuffer | ezGALBufferFlags::ShaderResource;
+        desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ByteAddressBuffer | ezGALBufferUsageFlags::ShaderResource;
         desc.m_uiStructSize = 128;
         desc.m_uiTotalSize = 1280;
         desc.m_ResourceAccess.m_bImmutable = false;
@@ -135,7 +135,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferCreationDescription desc;
         desc.m_uiStructSize = sizeof(ezUInt32);
         desc.m_uiTotalSize = 1024;
-        desc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource;
+        desc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource;
         desc.m_ResourceAccess.m_bImmutable = false;
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackTexelBufferVulkan");
@@ -169,7 +169,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
         ezGALBufferCreationDescription desc;
         desc.m_uiStructSize = sizeof(ezUInt32);
         desc.m_uiTotalSize = 1024;
-        desc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource | ezGALBufferFlags::UnorderedAccess;
+        desc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
         desc.m_ResourceAccess.m_bImmutable = false;
         ezGALBufferHandle hBuffer = s_pDevice->CreateBuffer(desc);
         s_pDevice->GetBuffer(hBuffer)->SetDebugName("FallbackTexelBufferRWVulkan");
@@ -179,7 +179,7 @@ void ezFallbackResourcesVulkan::GALDeviceEventHandler(const ezGALDeviceEvent& e)
       }
       {
         ezGALBufferCreationDescription desc;
-        desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ByteAddressBuffer | ezGALBufferFlags::ShaderResource | ezGALBufferFlags::UnorderedAccess;
+        desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ByteAddressBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
         desc.m_uiStructSize = 128;
         desc.m_uiTotalSize = 1280;
         desc.m_ResourceAccess.m_bImmutable = false;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
@@ -86,14 +86,14 @@ ezResult ezGALResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
   }
   else if (pBuffer)
   {
-    if (!pBuffer->GetDescription().m_bAllowRawViews && m_Description.m_bRawView)
+    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
     {
       ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
       return EZ_FAILURE;
     }
 
     auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-    if (pBuffer->GetDescription().m_bUseAsStructuredBuffer)
+    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
     {
       m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
       m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
@@ -7,27 +7,19 @@
 #include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 
-bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALResourceViewCreationDescription& viewDesc)
+bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALTextureResourceViewCreationDescription& viewDesc)
 {
   return texDesc.m_uiArraySize > 1 || viewDesc.m_uiArraySize > 1;
 }
 
-const vk::DescriptorBufferInfo& ezGALResourceViewVulkan::GetBufferInfo() const
-{
-  // Vulkan buffers get constantly swapped out for new ones so the vk::Buffer pointer is not persistent.
-  // We need to acquire the latest one on every request for rendering.
-  m_resourceBufferInfo.buffer = static_cast<const ezGALBufferVulkan*>(GetResource())->GetVkBuffer();
-  return m_resourceBufferInfo;
-}
-
-ezGALResourceViewVulkan::ezGALResourceViewVulkan(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description)
-  : ezGALResourceView(pResource, Description)
+ezGALTextureResourceViewVulkan::ezGALTextureResourceViewVulkan(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description)
+  : ezGALTextureResourceView(pResource, Description)
 {
 }
 
-ezGALResourceViewVulkan::~ezGALResourceViewVulkan() {}
+ezGALTextureResourceViewVulkan::~ezGALTextureResourceViewVulkan() = default;
 
-ezResult ezGALResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
 {
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
 
@@ -35,100 +27,131 @@ ezResult ezGALResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
   if (!m_Description.m_hTexture.IsInvalidated())
     pTexture = pDevice->GetTexture(m_Description.m_hTexture);
 
-  const ezGALBuffer* pBuffer = nullptr;
-  if (!m_Description.m_hBuffer.IsInvalidated())
-    pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
-
-  if (pTexture == nullptr && pBuffer == nullptr)
+  if (pTexture == nullptr)
   {
-    ezLog::Error("No valid texture handle or buffer handle given for resource view creation!");
+    ezLog::Error("No valid texture handle given for resource view creation!");
     return EZ_FAILURE;
   }
 
-  if (pTexture)
+  auto pParentTexture = static_cast<const ezGALTextureVulkan*>(pTexture->GetParentResource());
+  auto image = pParentTexture->GetImage();
+  const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
+
+  const bool bIsArrayView = IsArrayView(texDesc, m_Description);
+  const bool bIsDepth = ezGALResourceFormat::IsDepthFormat(pTexture->GetDescription().m_Format);
+
+  ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat == ezGALResourceFormat::Invalid ? texDesc.m_Format : m_Description.m_OverrideViewFormat;
+  vk::ImageViewCreateInfo viewCreateInfo;
+  viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
+  viewCreateInfo.image = image;
+  viewCreateInfo.subresourceRange = ezConversionUtilsVulkan::GetSubresourceRange(texDesc, m_Description);
+  viewCreateInfo.subresourceRange.aspectMask &= ~vk::ImageAspectFlagBits::eStencil;
+
+
+  m_resourceImageInfo.imageLayout = ezConversionUtilsVulkan::GetDefaultLayout(pParentTexture->GetImageFormat());
+  m_resourceImageInfoArray.imageLayout = m_resourceImageInfo.imageLayout;
+
+  m_range = viewCreateInfo.subresourceRange;
+  if (texDesc.m_Type == ezGALTextureType::Texture3D) // no array support
   {
-    auto pParentTexture = static_cast<const ezGALTextureVulkan*>(pTexture->GetParentResource());
-    auto image = pParentTexture->GetImage();
-    const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
-
-    const bool bIsArrayView = IsArrayView(texDesc, m_Description);
-    const bool bIsDepth = ezGALResourceFormat::IsDepthFormat(pTexture->GetDescription().m_Format);
-
-    ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat == ezGALResourceFormat::Invalid ? texDesc.m_Format : m_Description.m_OverrideViewFormat;
-    vk::ImageViewCreateInfo viewCreateInfo;
-    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
-    viewCreateInfo.image = image;
-    viewCreateInfo.subresourceRange = ezConversionUtilsVulkan::GetSubresourceRange(texDesc, m_Description);
-    viewCreateInfo.subresourceRange.aspectMask &= ~vk::ImageAspectFlagBits::eStencil;
-
-
-    m_resourceImageInfo.imageLayout = ezConversionUtilsVulkan::GetDefaultLayout(pParentTexture->GetImageFormat());
-    m_resourceImageInfoArray.imageLayout = m_resourceImageInfo.imageLayout;
-
-    m_range = viewCreateInfo.subresourceRange;
-    if (texDesc.m_Type == ezGALTextureType::Texture3D) // no array support
-    {
-      viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, false);
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfo.imageView));
-    }
-    else if (m_Description.m_uiArraySize == 1) // can be array or not
-    {
-      viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, false);
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfo.imageView));
-      viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, true);
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfoArray.imageView));
-    }
-    else // Can only be array
-    {
-      viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, true);
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfoArray.imageView));
-    }
+    viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, false);
+    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfo.imageView));
   }
-  else if (pBuffer)
+  else if (m_Description.m_uiArraySize == 1) // can be array or not
   {
-    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
-    {
-      ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
-      return EZ_FAILURE;
-    }
-
-    auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
-    {
-      m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
-      m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
-    }
-    else if (m_Description.m_bRawView)
-    {
-      m_resourceBufferInfo.offset = sizeof(ezUInt32) * m_Description.m_uiFirstElement;
-      m_resourceBufferInfo.range = sizeof(ezUInt32) * m_Description.m_uiNumElements;
-    }
-    else
-    {
-      ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat;
-      if (viewFormat == ezGALResourceFormat::Invalid)
-        viewFormat = ezGALResourceFormat::RUInt;
-
-      vk::BufferViewCreateInfo viewCreateInfo;
-      viewCreateInfo.buffer = pParentBuffer->GetVkBuffer();
-      viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
-      viewCreateInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
-      viewCreateInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
-
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createBufferView(&viewCreateInfo, nullptr, &m_bufferView));
-    }
+    viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, false);
+    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfo.imageView));
+    viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, true);
+    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfoArray.imageView));
+  }
+  else // Can only be array
+  {
+    viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, true);
+    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfoArray.imageView));
   }
 
   return EZ_SUCCESS;
 }
 
-ezResult ezGALResourceViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureResourceViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   pVulkanDevice->DeleteLater(m_resourceImageInfo.imageView);
   pVulkanDevice->DeleteLater(m_resourceImageInfoArray.imageView);
   m_resourceImageInfo = vk::DescriptorImageInfo();
   m_resourceImageInfoArray = vk::DescriptorImageInfo();
+  return EZ_SUCCESS;
+}
+
+/////////////////////////////////////////////////////////
+
+const vk::DescriptorBufferInfo& ezGALBufferResourceViewVulkan::GetBufferInfo() const
+{
+  // Vulkan buffers get constantly swapped out for new ones so the vk::Buffer pointer is not persistent.
+  // We need to acquire the latest one on every request for rendering.
+  m_resourceBufferInfo.buffer = static_cast<const ezGALBufferVulkan*>(GetResource())->GetVkBuffer();
+  return m_resourceBufferInfo;
+}
+
+ezGALBufferResourceViewVulkan::ezGALBufferResourceViewVulkan(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description)
+  : ezGALBufferResourceView(pResource, Description)
+{
+}
+
+ezGALBufferResourceViewVulkan::~ezGALBufferResourceViewVulkan() = default;
+
+ezResult ezGALBufferResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  const ezGALBuffer* pBuffer = nullptr;
+  if (!m_Description.m_hBuffer.IsInvalidated())
+    pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
+
+  if (pBuffer == nullptr)
+  {
+    ezLog::Error("No valid buffer handle given for resource view creation!");
+    return EZ_FAILURE;
+  }
+
+  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
+  {
+    ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
+    return EZ_FAILURE;
+  }
+
+  auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+  {
+    m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
+    m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
+  }
+  else if (m_Description.m_bRawView)
+  {
+    m_resourceBufferInfo.offset = sizeof(ezUInt32) * m_Description.m_uiFirstElement;
+    m_resourceBufferInfo.range = sizeof(ezUInt32) * m_Description.m_uiNumElements;
+  }
+  else
+  {
+    ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat;
+    if (viewFormat == ezGALResourceFormat::Invalid)
+      viewFormat = ezGALResourceFormat::RUInt;
+
+    vk::BufferViewCreateInfo viewCreateInfo;
+    viewCreateInfo.buffer = pParentBuffer->GetVkBuffer();
+    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
+    viewCreateInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
+    viewCreateInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
+
+    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createBufferView(&viewCreateInfo, nullptr, &m_bufferView));
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALBufferResourceViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   m_resourceBufferInfo = vk::DescriptorBufferInfo();
   pVulkanDevice->DeleteLater(m_bufferView);
   return EZ_SUCCESS;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
@@ -114,14 +114,14 @@ ezResult ezGALBufferResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
     return EZ_FAILURE;
   }
 
-  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
+  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::ByteAddressBuffer) && m_Description.m_bRawView)
   {
     ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
     return EZ_FAILURE;
   }
 
   auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer))
   {
     m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
     m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan_inl.h
@@ -1,15 +1,15 @@
-EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& ezGALResourceViewVulkan::GetImageInfo(bool bIsArray) const
+EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& ezGALTextureResourceViewVulkan::GetImageInfo(bool bIsArray) const
 {
   EZ_ASSERT_DEBUG((bIsArray ? m_resourceImageInfoArray : m_resourceImageInfo).imageView, "View does not support bIsArray: {}", bIsArray);
   return bIsArray ? m_resourceImageInfoArray : m_resourceImageInfo;
 }
 
-EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezGALResourceViewVulkan::GetRange() const
+EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezGALTextureResourceViewVulkan::GetRange() const
 {
   return m_range;
 }
 
-EZ_ALWAYS_INLINE const vk::BufferView& ezGALResourceViewVulkan::GetBufferView() const
+EZ_ALWAYS_INLINE const vk::BufferView& ezGALBufferResourceViewVulkan::GetBufferView() const
 {
   return m_bufferView;
 }

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
@@ -313,12 +313,11 @@ ezResult ezGALTextureVulkan::CreateStagingBuffer(const vk::ImageCreateInfo& crea
   if (m_stagingMode == StagingMode::Buffer || m_stagingMode == StagingMode::TextureAndBuffer)
   {
     ezGALBufferCreationDescription stagingBuffer;
-    stagingBuffer.m_BufferType = ezGALBufferType::Generic;
-
+    stagingBuffer.m_BufferFlags = ezGALBufferFlags::ByteAddressBuffer;
     ezHybridArray<SubResourceOffset, 8> subResourceSizes;
     stagingBuffer.m_uiTotalSize = ComputeSubResourceOffsets(subResourceSizes);
     stagingBuffer.m_uiStructSize = 1;
-    stagingBuffer.m_bAllowRawViews = true;
+
     stagingBuffer.m_ResourceAccess.m_bImmutable = false;
 
     m_hStagingBuffer = m_pDevice->CreateBufferInternal(stagingBuffer, {}, true);

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
@@ -313,7 +313,7 @@ ezResult ezGALTextureVulkan::CreateStagingBuffer(const vk::ImageCreateInfo& crea
   if (m_stagingMode == StagingMode::Buffer || m_stagingMode == StagingMode::TextureAndBuffer)
   {
     ezGALBufferCreationDescription stagingBuffer;
-    stagingBuffer.m_BufferFlags = ezGALBufferFlags::ByteAddressBuffer;
+    stagingBuffer.m_BufferFlags = ezGALBufferUsageFlags::ByteAddressBuffer;
     ezHybridArray<SubResourceOffset, 8> subResourceSizes;
     stagingBuffer.m_uiTotalSize = ComputeSubResourceOffsets(subResourceSizes);
     stagingBuffer.m_uiStructSize = 1;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
@@ -6,28 +6,20 @@
 #include <RendererVulkan/Resources/UnorderedAccessViewVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 
-bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc)
+bool IsArrayView(const ezGALTextureCreationDescription& texDesc, const ezGALTextureUnorderedAccessViewCreationDescription& viewDesc)
 {
   return texDesc.m_uiArraySize > 1 || viewDesc.m_uiFirstArraySlice > 0;
 }
 
-const vk::DescriptorBufferInfo& ezGALUnorderedAccessViewVulkan::GetBufferInfo() const
-{
-  // Vulkan buffers get constantly swapped out for new ones so the vk::Buffer pointer is not persistent.
-  // We need to acquire the latest one on every request for rendering.
-  m_resourceBufferInfo.buffer = static_cast<const ezGALBufferVulkan*>(GetResource())->GetVkBuffer();
-  return m_resourceBufferInfo;
-}
-
-ezGALUnorderedAccessViewVulkan::ezGALUnorderedAccessViewVulkan(
-  ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description)
-  : ezGALUnorderedAccessView(pResource, Description)
+ezGALTextureUnorderedAccessViewVulkan::ezGALTextureUnorderedAccessViewVulkan(
+  ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description)
+  : ezGALTextureUnorderedAccessView(pResource, Description)
 {
 }
 
-ezGALUnorderedAccessViewVulkan::~ezGALUnorderedAccessViewVulkan() {}
+ezGALTextureUnorderedAccessViewVulkan::~ezGALTextureUnorderedAccessViewVulkan() = default;
 
-ezResult ezGALUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice)
+ezResult ezGALTextureUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice)
 {
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
 
@@ -35,85 +27,117 @@ ezResult ezGALUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice)
   if (!m_Description.m_hTexture.IsInvalidated())
     pTexture = pDevice->GetTexture(m_Description.m_hTexture);
 
+  if (pTexture == nullptr)
+  {
+    ezLog::Error("No valid texture handle given for resource view creation!");
+    return EZ_FAILURE;
+  }
+
+  auto pParentTexture = static_cast<const ezGALTextureVulkan*>(pTexture->GetParentResource());
+  auto image = pParentTexture->GetImage();
+  const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
+
+  const bool bIsArrayView = IsArrayView(texDesc, m_Description);
+
+  ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat == ezGALResourceFormat::Invalid ? texDesc.m_Format : m_Description.m_OverrideViewFormat;
+  vk::ImageViewCreateInfo viewCreateInfo;
+  viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
+  viewCreateInfo.image = image;
+  viewCreateInfo.subresourceRange = ezConversionUtilsVulkan::GetSubresourceRange(texDesc, m_Description);
+  viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, bIsArrayView);
+  if (texDesc.m_Type == ezGALTextureType::TextureCube)
+    viewCreateInfo.viewType = vk::ImageViewType::e2DArray; // There is no RWTextureCube / RWTextureCubeArray in HLSL
+
+  m_resourceImageInfo.imageLayout = vk::ImageLayout::eGeneral;
+
+  m_range = viewCreateInfo.subresourceRange;
+  VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfo.imageView));
+  pVulkanDevice->SetDebugName("UAV-Texture", m_resourceImageInfo.imageView);
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALTextureUnorderedAccessViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+  pVulkanDevice->DeleteLater(m_resourceImageInfo.imageView);
+  m_resourceImageInfo = vk::DescriptorImageInfo();
+  return EZ_SUCCESS;
+}
+
+/////////////////////////////////////////////////////
+
+const vk::DescriptorBufferInfo& ezGALBufferUnorderedAccessViewVulkan::GetBufferInfo() const
+{
+  // Vulkan buffers get constantly swapped out for new ones so the vk::Buffer pointer is not persistent.
+  // We need to acquire the latest one on every request for rendering.
+  m_resourceBufferInfo.buffer = static_cast<const ezGALBufferVulkan*>(GetResource())->GetVkBuffer();
+  return m_resourceBufferInfo;
+}
+
+ezGALBufferUnorderedAccessViewVulkan::ezGALBufferUnorderedAccessViewVulkan(
+  ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description)
+  : ezGALBufferUnorderedAccessView(pResource, Description)
+{
+}
+
+ezGALBufferUnorderedAccessViewVulkan::~ezGALBufferUnorderedAccessViewVulkan() = default;
+
+ezResult ezGALBufferUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+
   const ezGALBuffer* pBuffer = nullptr;
   if (!m_Description.m_hBuffer.IsInvalidated())
     pBuffer = pDevice->GetBuffer(m_Description.m_hBuffer);
 
-  if (pTexture == nullptr && pBuffer == nullptr)
+  if (pBuffer == nullptr)
   {
-    ezLog::Error("No valid texture handle or buffer handle given for resource view creation!");
+    ezLog::Error("No valid buffer handle given for resource view creation!");
     return EZ_FAILURE;
   }
 
-  if (pTexture)
+  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
   {
-    auto pParentTexture = static_cast<const ezGALTextureVulkan*>(pTexture->GetParentResource());
-    auto image = pParentTexture->GetImage();
-    const ezGALTextureCreationDescription& texDesc = pTexture->GetDescription();
-
-    const bool bIsArrayView = IsArrayView(texDesc, m_Description);
-
-    ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat == ezGALResourceFormat::Invalid ? texDesc.m_Format : m_Description.m_OverrideViewFormat;
-    vk::ImageViewCreateInfo viewCreateInfo;
-    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
-    viewCreateInfo.image = image;
-    viewCreateInfo.subresourceRange = ezConversionUtilsVulkan::GetSubresourceRange(texDesc, m_Description);
-    viewCreateInfo.viewType = ezConversionUtilsVulkan::GetImageViewType(texDesc.m_Type, bIsArrayView);
-    if (texDesc.m_Type == ezGALTextureType::TextureCube)
-      viewCreateInfo.viewType = vk::ImageViewType::e2DArray; // There is no RWTextureCube / RWTextureCubeArray in HLSL
-
-    m_resourceImageInfo.imageLayout = vk::ImageLayout::eGeneral;
-
-    m_range = viewCreateInfo.subresourceRange;
-    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createImageView(&viewCreateInfo, nullptr, &m_resourceImageInfo.imageView));
-    pVulkanDevice->SetDebugName("UAV-Texture", m_resourceImageInfo.imageView);
+    ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
+    return EZ_FAILURE;
   }
-  else if (pBuffer)
+
+  auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
   {
-    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
-    {
-      ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
-      return EZ_FAILURE;
-    }
+    m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
+    m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
+  }
+  else if (m_Description.m_bRawView)
+  {
+    m_resourceBufferInfo.offset = sizeof(ezUInt32) * m_Description.m_uiFirstElement;
+    m_resourceBufferInfo.range = sizeof(ezUInt32) * m_Description.m_uiNumElements;
+  }
+  else
+  {
+    m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
+    m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
 
-    auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
-    {
-      m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
-      m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
-    }
-    else if (m_Description.m_bRawView)
-    {
-      m_resourceBufferInfo.offset = sizeof(ezUInt32) * m_Description.m_uiFirstElement;
-      m_resourceBufferInfo.range = sizeof(ezUInt32) * m_Description.m_uiNumElements;
-    }
-    else
-    {
-      m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
-      m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
+    ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat;
+    if (viewFormat == ezGALResourceFormat::Invalid)
+      viewFormat = ezGALResourceFormat::RUInt;
 
-      ezGALResourceFormat::Enum viewFormat = m_Description.m_OverrideViewFormat;
-      if (viewFormat == ezGALResourceFormat::Invalid)
-        viewFormat = ezGALResourceFormat::RUInt;
+    vk::BufferViewCreateInfo viewCreateInfo;
+    viewCreateInfo.buffer = pParentBuffer->GetVkBuffer();
+    viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
+    viewCreateInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
+    viewCreateInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
 
-      vk::BufferViewCreateInfo viewCreateInfo;
-      viewCreateInfo.buffer = pParentBuffer->GetVkBuffer();
-      viewCreateInfo.format = pVulkanDevice->GetFormatLookupTable().GetFormatInfo(viewFormat).m_format;
-      viewCreateInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
-      viewCreateInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;
-
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createBufferView(&viewCreateInfo, nullptr, &m_bufferView));
-    }
+    VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createBufferView(&viewCreateInfo, nullptr, &m_bufferView));
   }
 
   return EZ_SUCCESS;
 }
 
-ezResult ezGALUnorderedAccessViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
+ezResult ezGALBufferUnorderedAccessViewVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
-  pVulkanDevice->DeleteLater(m_resourceImageInfo.imageView);
-  m_resourceImageInfo = vk::DescriptorImageInfo();
   m_resourceBufferInfo = vk::DescriptorBufferInfo();
   pVulkanDevice->DeleteLater(m_bufferView);
   return EZ_SUCCESS;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
@@ -70,14 +70,14 @@ ezResult ezGALUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice)
   }
   else if (pBuffer)
   {
-    if (!pBuffer->GetDescription().m_bAllowRawViews && m_Description.m_bRawView)
+    if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
     {
       ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
       return EZ_FAILURE;
     }
 
     auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-    if (pBuffer->GetDescription().m_bUseAsStructuredBuffer)
+    if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
     {
       m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
       m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan.cpp
@@ -97,14 +97,14 @@ ezResult ezGALBufferUnorderedAccessViewVulkan::InitPlatform(ezGALDevice* pDevice
     return EZ_FAILURE;
   }
 
-  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::ByteAddressBuffer) && m_Description.m_bRawView)
+  if (!pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::ByteAddressBuffer) && m_Description.m_bRawView)
   {
     ezLog::Error("Trying to create a raw view for a buffer with no raw view flag is invalid!");
     return EZ_FAILURE;
   }
 
   auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferFlags::StructuredBuffer))
+  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer))
   {
     m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
     m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h
@@ -1,17 +1,16 @@
 
-#include <RendererVulkan/Resources/UnorderedAccessViewVulkan.h>
 
-EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& ezGALUnorderedAccessViewVulkan::GetImageInfo() const
+EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& ezGALTextureUnorderedAccessViewVulkan::GetImageInfo() const
 {
   return m_resourceImageInfo;
 }
 
-EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezGALUnorderedAccessViewVulkan::GetRange() const
+EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezGALTextureUnorderedAccessViewVulkan::GetRange() const
 {
   return m_range;
 }
 
-EZ_ALWAYS_INLINE const vk::BufferView& ezGALUnorderedAccessViewVulkan::GetBufferView() const
+EZ_ALWAYS_INLINE const vk::BufferView& ezGALBufferUnorderedAccessViewVulkan::GetBufferView() const
 {
   return m_bufferView;
 }

--- a/Code/Engine/RendererVulkan/Resources/ResourceViewVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/ResourceViewVulkan.h
@@ -8,20 +8,18 @@
 class ezGALBufferVulkan;
 class ezGALTextureVulkan;
 
-class ezGALResourceViewVulkan : public ezGALResourceView
+class ezGALTextureResourceViewVulkan : public ezGALTextureResourceView
 {
 public:
   const vk::DescriptorImageInfo& GetImageInfo(bool bIsArray) const;
-  const vk::DescriptorBufferInfo& GetBufferInfo() const;
   vk::ImageSubresourceRange GetRange() const;
-  const vk::BufferView& GetBufferView() const;
 
 protected:
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
-  ezGALResourceViewVulkan(ezGALResourceBase* pResource, const ezGALResourceViewCreationDescription& Description);
-  ~ezGALResourceViewVulkan();
+  ezGALTextureResourceViewVulkan(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description);
+  ~ezGALTextureResourceViewVulkan();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
@@ -29,6 +27,24 @@ protected:
   vk::ImageSubresourceRange m_range;
   mutable vk::DescriptorImageInfo m_resourceImageInfo;
   mutable vk::DescriptorImageInfo m_resourceImageInfoArray;
+};
+
+class ezGALBufferResourceViewVulkan : public ezGALBufferResourceView
+{
+public:
+  const vk::DescriptorBufferInfo& GetBufferInfo() const;
+  const vk::BufferView& GetBufferView() const;
+
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  ezGALBufferResourceViewVulkan(ezGALBuffer* pResource, const ezGALBufferResourceViewCreationDescription& Description);
+  ~ezGALBufferResourceViewVulkan();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
   mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
   vk::BufferView m_bufferView;
 };

--- a/Code/Engine/RendererVulkan/Resources/UnorderedAccessViewVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/UnorderedAccessViewVulkan.h
@@ -7,29 +7,50 @@
 
 class ezGALBufferVulkan;
 
-class ezGALUnorderedAccessViewVulkan : public ezGALUnorderedAccessView
+class ezGALTextureUnorderedAccessViewVulkan : public ezGALTextureUnorderedAccessView
 {
 public:
   EZ_ALWAYS_INLINE const vk::DescriptorImageInfo& GetImageInfo() const;
-  const vk::DescriptorBufferInfo& GetBufferInfo() const;
-  const vk::BufferView& GetBufferView() const;
   vk::ImageSubresourceRange GetRange() const;
 
 protected:
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
-  ezGALUnorderedAccessViewVulkan(ezGALResourceBase* pResource, const ezGALUnorderedAccessViewCreationDescription& Description);
-  ~ezGALUnorderedAccessViewVulkan();
+  ezGALTextureUnorderedAccessViewVulkan(ezGALTexture* pResource, const ezGALTextureUnorderedAccessViewCreationDescription& Description);
+  ~ezGALTextureUnorderedAccessViewVulkan();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
 private:
   mutable vk::DescriptorImageInfo m_resourceImageInfo;
+  //mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
+  //vk::BufferView m_bufferView;
+  vk::ImageSubresourceRange m_range;
+};
+
+class ezGALBufferUnorderedAccessViewVulkan : public ezGALBufferUnorderedAccessView
+{
+public:
+  const vk::DescriptorBufferInfo& GetBufferInfo() const;
+  const vk::BufferView& GetBufferView() const;
+
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  ezGALBufferUnorderedAccessViewVulkan(ezGALBuffer* pResource, const ezGALBufferUnorderedAccessViewCreationDescription& Description);
+  ~ezGALBufferUnorderedAccessViewVulkan();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+private:
+  //mutable vk::DescriptorImageInfo m_resourceImageInfo;
   mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
   vk::BufferView m_bufferView;
-  vk::ImageSubresourceRange m_range;
+  //vk::ImageSubresourceRange m_range;
 };
 
 #include <RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/Resources/UnorderedAccessViewVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/UnorderedAccessViewVulkan.h
@@ -25,8 +25,8 @@ protected:
 
 private:
   mutable vk::DescriptorImageInfo m_resourceImageInfo;
-  //mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
-  //vk::BufferView m_bufferView;
+  // mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
+  // vk::BufferView m_bufferView;
   vk::ImageSubresourceRange m_range;
 };
 
@@ -47,10 +47,10 @@ protected:
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
 private:
-  //mutable vk::DescriptorImageInfo m_resourceImageInfo;
+  // mutable vk::DescriptorImageInfo m_resourceImageInfo;
   mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
   vk::BufferView m_bufferView;
-  //vk::ImageSubresourceRange m_range;
+  // vk::ImageSubresourceRange m_range;
 };
 
 #include <RendererVulkan/Resources/Implementation/UnorderedAccessViewVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
@@ -31,7 +31,7 @@ public:
   static vk::PresentModeKHR GetPresentMode(ezEnum<ezGALPresentMode> presentMode, const ezDynamicArray<vk::PresentModeKHR>& supportedModes);
   static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALRenderTargetViewCreationDescription& desc);
   static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALTextureResourceViewCreationDescription& viewDesc);
-  static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc);
+  static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALTextureUnorderedAccessViewCreationDescription& viewDesc);
   static vk::ImageSubresourceRange GetSubresourceRange(const vk::ImageSubresourceLayers& layers);
   static vk::ImageViewType GetImageViewType(ezEnum<ezGALTextureType> texType, bool bIsArray);
 

--- a/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
@@ -30,7 +30,7 @@ public:
   static vk::SampleCountFlagBits GetSamples(ezEnum<ezGALMSAASampleCount> samples);
   static vk::PresentModeKHR GetPresentMode(ezEnum<ezGALPresentMode> presentMode, const ezDynamicArray<vk::PresentModeKHR>& supportedModes);
   static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALRenderTargetViewCreationDescription& desc);
-  static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALResourceViewCreationDescription& viewDesc);
+  static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALTextureResourceViewCreationDescription& viewDesc);
   static vk::ImageSubresourceRange GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc);
   static vk::ImageSubresourceRange GetSubresourceRange(const vk::ImageSubresourceLayers& layers);
   static vk::ImageViewType GetImageViewType(ezEnum<ezGALTextureType> texType, bool bIsArray);

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -10,7 +10,7 @@
 class ezGALBufferVulkan;
 class ezGALTextureVulkan;
 class ezGALRenderTargetViewVulkan;
-class ezGALResourceViewVulkan;
+class ezGALTextureResourceViewVulkan;
 class ezGALUnorderedAccessViewVulkan;
 
 

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -11,7 +11,9 @@ class ezGALBufferVulkan;
 class ezGALTextureVulkan;
 class ezGALRenderTargetViewVulkan;
 class ezGALTextureResourceViewVulkan;
-class ezGALUnorderedAccessViewVulkan;
+class ezGALBufferResourceViewVulkan;
+class ezGALTextureUnorderedAccessViewVulkan;
+class ezGALBufferUnorderedAccessViewVulkan;
 
 
 /// \brief

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
@@ -8,7 +8,7 @@ namespace
   {
     return texDesc.m_uiArraySize > 1 || viewDesc.m_uiFirstArraySlice > 0;
   }
-  bool IsArrayViewInternal(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc)
+  bool IsArrayViewInternal(const ezGALTextureCreationDescription& texDesc, const ezGALTextureUnorderedAccessViewCreationDescription& viewDesc)
   {
     return texDesc.m_uiArraySize > 1 || viewDesc.m_uiFirstArraySlice > 0;
   }
@@ -99,7 +99,7 @@ EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezConversionUtilsVulkan::GetSubresour
 }
 
 
-EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezConversionUtilsVulkan::GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALUnorderedAccessViewCreationDescription& viewDesc)
+EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezConversionUtilsVulkan::GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALTextureUnorderedAccessViewCreationDescription& viewDesc)
 {
   vk::ImageSubresourceRange range;
 

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
@@ -4,7 +4,7 @@
 
 namespace
 {
-  bool IsArrayViewInternal(const ezGALTextureCreationDescription& texDesc, const ezGALResourceViewCreationDescription& viewDesc)
+  bool IsArrayViewInternal(const ezGALTextureCreationDescription& texDesc, const ezGALTextureResourceViewCreationDescription& viewDesc)
   {
     return texDesc.m_uiArraySize > 1 || viewDesc.m_uiFirstArraySlice > 0;
   }
@@ -62,7 +62,7 @@ EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezConversionUtilsVulkan::GetSubresour
   return range;
 }
 
-EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezConversionUtilsVulkan::GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALResourceViewCreationDescription& viewDesc)
+EZ_ALWAYS_INLINE vk::ImageSubresourceRange ezConversionUtilsVulkan::GetSubresourceRange(const ezGALTextureCreationDescription& texDesc, const ezGALTextureResourceViewCreationDescription& viewDesc)
 {
   vk::ImageSubresourceRange range;
 

--- a/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
@@ -185,7 +185,7 @@ void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALTextureResourceViewVu
   EnsureImageLayout(pTexture, pTextureView->GetRange(), dstLayout, dstStages, dstAccess, bDiscardSource);
 }
 
-void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALUnorderedAccessViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource)
+void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALTextureUnorderedAccessViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource)
 {
   auto pTexture = static_cast<const ezGALTextureVulkan*>(pTextureView->GetResource()->GetParentResource());
   EnsureImageLayout(pTexture, pTextureView->GetRange(), dstLayout, dstStages, dstAccess, bDiscardSource);

--- a/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
@@ -179,7 +179,7 @@ void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALRenderTargetViewVulka
   EnsureImageLayout(pTexture, pTextureView->GetRange(), dstLayout, dstStages, dstAccess, bDiscardSource);
 }
 
-void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALResourceViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource)
+void ezPipelineBarrierVulkan::EnsureImageLayout(const ezGALTextureResourceViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource)
 {
   auto pTexture = static_cast<const ezGALTextureVulkan*>(pTextureView->GetResource()->GetParentResource());
   EnsureImageLayout(pTexture, pTextureView->GetRange(), dstLayout, dstStages, dstAccess, bDiscardSource);
@@ -377,7 +377,7 @@ void ezPipelineBarrierVulkan::SetInitialImageState(const ezGALTextureVulkan* pTe
   auto it = m_imageState.Find(pTexture->GetImage());
 
   // A Vulkan runtime is free to provide us with the very same native object if we request a resize but didn't actually change the size, in which case we ignore that we are already tacking this resource.
-  EZ_ASSERT_DEBUG(!it.IsValid() || it.Value().m_pTexture->GetDescription().m_pExisitingNativeObject != nullptr, "Can't set initial state, texture is already tracked.");
+  EZ_ASSERT_DEBUG(!it.IsValid(), "");// || it.Value().m_pTexture->GetDescription().m_pExisitingNativeObject != nullptr, "Can't set initial state, texture is already tracked.");
 
   ImageState state;
   state.m_pTexture = pTexture;
@@ -425,7 +425,7 @@ void ezPipelineBarrierVulkan::FullBarrier()
   memoryBarrier.srcAccessMask = s_writeAccess | s_readAccess;
   memoryBarrier.dstAccessMask = s_writeAccess | s_readAccess;
 
-  m_pCommandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands, vk::DependencyFlags(), 1, &memoryBarrier, 0, nullptr, 0, nullptr);
+  m_pCommandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands | vk::PipelineStageFlagBits::eTopOfPipe, vk::DependencyFlags(), 1, &memoryBarrier, 0, nullptr, 0, nullptr);
 }
 
 bool ezPipelineBarrierVulkan::AddBufferBarrierInternal(vk::Buffer buffer, vk::DeviceSize offset, vk::DeviceSize length, vk::PipelineStageFlags srcStages, vk::AccessFlags srcAccess, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess)

--- a/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
@@ -377,7 +377,7 @@ void ezPipelineBarrierVulkan::SetInitialImageState(const ezGALTextureVulkan* pTe
   auto it = m_imageState.Find(pTexture->GetImage());
 
   // A Vulkan runtime is free to provide us with the very same native object if we request a resize but didn't actually change the size, in which case we ignore that we are already tacking this resource.
-  EZ_ASSERT_DEBUG(!it.IsValid(), "");// || it.Value().m_pTexture->GetDescription().m_pExisitingNativeObject != nullptr, "Can't set initial state, texture is already tracked.");
+  EZ_ASSERT_DEBUG(!it.IsValid() || it.Value().m_pTexture->GetDescription().m_pExisitingNativeObject != nullptr, "Can't set initial state, texture is already tracked.");
 
   ImageState state;
   state.m_pTexture = pTexture;
@@ -425,7 +425,7 @@ void ezPipelineBarrierVulkan::FullBarrier()
   memoryBarrier.srcAccessMask = s_writeAccess | s_readAccess;
   memoryBarrier.dstAccessMask = s_writeAccess | s_readAccess;
 
-  m_pCommandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands | vk::PipelineStageFlagBits::eTopOfPipe, vk::DependencyFlags(), 1, &memoryBarrier, 0, nullptr, 0, nullptr);
+  m_pCommandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands, vk::DependencyFlags(), 1, &memoryBarrier, 0, nullptr, 0, nullptr);
 }
 
 bool ezPipelineBarrierVulkan::AddBufferBarrierInternal(vk::Buffer buffer, vk::DeviceSize offset, vk::DeviceSize length, vk::PipelineStageFlags srcStages, vk::AccessFlags srcAccess, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess)

--- a/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
@@ -124,12 +124,12 @@ private:
                                                   vk::AccessFlagBits::eInputAttachmentRead | vk::AccessFlagBits::eShaderRead |
                                                   vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentRead |
                                                   vk::AccessFlagBits::eTransferRead | vk::AccessFlagBits::eHostRead |
-                                                  vk::AccessFlagBits::eMemoryRead  // | vk::AccessFlagBits::eTransformFeedbackCounterReadEXT |
-                                                  // vk::AccessFlagBits::eConditionalRenderingReadEXT | vk::AccessFlagBits::eColorAttachmentReadNoncoherentEXT |
-                                                  // vk::AccessFlagBits::eAccelerationStructureReadKHR | vk::AccessFlagBits::eFragmentDensityMapReadEXT |
-                                                  // vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | vk::AccessFlagBits::eCommandPreprocessReadNV |
-                                                  // vk::AccessFlagBits::eAccelerationStructureReadKHR | vk::AccessFlagBits::eFragmentDensityMapReadEXT |
-                                                  /*vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | vk::AccessFlagBits::eCommandPreprocessReadNV*/;
+                                                  vk::AccessFlagBits::eMemoryRead // | vk::AccessFlagBits::eTransformFeedbackCounterReadEXT |
+                                                                                  // vk::AccessFlagBits::eConditionalRenderingReadEXT | vk::AccessFlagBits::eColorAttachmentReadNoncoherentEXT |
+                                                                                  // vk::AccessFlagBits::eAccelerationStructureReadKHR | vk::AccessFlagBits::eFragmentDensityMapReadEXT |
+                                                                                  // vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | vk::AccessFlagBits::eCommandPreprocessReadNV |
+                                                                                  // vk::AccessFlagBits::eAccelerationStructureReadKHR | vk::AccessFlagBits::eFragmentDensityMapReadEXT |
+    /*vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | vk::AccessFlagBits::eCommandPreprocessReadNV*/;
   static constexpr vk::AccessFlags s_writeAccess = vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eColorAttachmentWrite |
                                                    vk::AccessFlagBits::eDepthStencilAttachmentWrite | vk::AccessFlagBits::eTransferWrite |
                                                    vk::AccessFlagBits::eHostWrite | vk::AccessFlagBits::eMemoryWrite

--- a/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
@@ -122,12 +122,12 @@ private:
                                                   vk::AccessFlagBits::eInputAttachmentRead | vk::AccessFlagBits::eShaderRead |
                                                   vk::AccessFlagBits::eColorAttachmentRead | vk::AccessFlagBits::eDepthStencilAttachmentRead |
                                                   vk::AccessFlagBits::eTransferRead | vk::AccessFlagBits::eHostRead |
-                                                  vk::AccessFlagBits::eMemoryRead | // vk::AccessFlagBits::eTransformFeedbackCounterReadEXT |
-                                                  /* vk::AccessFlagBits::eConditionalRenderingReadEXT |*/ vk::AccessFlagBits::eColorAttachmentReadNoncoherentEXT |
+                                                  vk::AccessFlagBits::eMemoryRead  // | vk::AccessFlagBits::eTransformFeedbackCounterReadEXT |
+                                                  // vk::AccessFlagBits::eConditionalRenderingReadEXT | vk::AccessFlagBits::eColorAttachmentReadNoncoherentEXT |
                                                   // vk::AccessFlagBits::eAccelerationStructureReadKHR | vk::AccessFlagBits::eFragmentDensityMapReadEXT |
-                                                  vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | // vk::AccessFlagBits::eCommandPreprocessReadNV |
+                                                  // vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | vk::AccessFlagBits::eCommandPreprocessReadNV |
                                                   // vk::AccessFlagBits::eAccelerationStructureReadKHR | vk::AccessFlagBits::eFragmentDensityMapReadEXT |
-                                                  vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR /*| vk::AccessFlagBits::eCommandPreprocessReadNV*/;
+                                                  /*vk::AccessFlagBits::eFragmentShadingRateAttachmentReadKHR | vk::AccessFlagBits::eCommandPreprocessReadNV*/;
   static constexpr vk::AccessFlags s_writeAccess = vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eColorAttachmentWrite |
                                                    vk::AccessFlagBits::eDepthStencilAttachmentWrite | vk::AccessFlagBits::eTransferWrite |
                                                    vk::AccessFlagBits::eHostWrite | vk::AccessFlagBits::eMemoryWrite

--- a/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
@@ -11,7 +11,8 @@ class ezGALTextureVulkan;
 class ezGALRenderTargetViewVulkan;
 class ezGALTextureResourceViewVulkan;
 class ezGALBufferResourceViewVulkan;
-class ezGALUnorderedAccessViewVulkan;
+class ezGALTextureUnorderedAccessViewVulkan;
+class ezGALBufferUnorderedAccessViewVulkan;
 
 /// \brief
 class EZ_RENDERERVULKAN_DLL ezPipelineBarrierVulkan
@@ -66,7 +67,7 @@ public:
   void EnsureImageLayout(const ezGALTextureVulkan* pTexture, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
   void EnsureImageLayout(const ezGALRenderTargetViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
   void EnsureImageLayout(const ezGALTextureResourceViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
-  void EnsureImageLayout(const ezGALUnorderedAccessViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
+  void EnsureImageLayout(const ezGALTextureUnorderedAccessViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
   void EnsureImageLayout(const ezGALTextureVulkan* pTexture, vk::ImageSubresourceRange subResources, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
 
   bool IsDirty(vk::Image image, const vk::ImageSubresourceRange& subResources) const;

--- a/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
@@ -9,7 +9,8 @@
 class ezGALBufferVulkan;
 class ezGALTextureVulkan;
 class ezGALRenderTargetViewVulkan;
-class ezGALResourceViewVulkan;
+class ezGALTextureResourceViewVulkan;
+class ezGALBufferResourceViewVulkan;
 class ezGALUnorderedAccessViewVulkan;
 
 /// \brief
@@ -64,7 +65,7 @@ public:
   /// \param bDiscardSource Discard the previous layout, replaces current layout with unknown.
   void EnsureImageLayout(const ezGALTextureVulkan* pTexture, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
   void EnsureImageLayout(const ezGALRenderTargetViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
-  void EnsureImageLayout(const ezGALResourceViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
+  void EnsureImageLayout(const ezGALTextureResourceViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
   void EnsureImageLayout(const ezGALUnorderedAccessViewVulkan* pTextureView, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
   void EnsureImageLayout(const ezGALTextureVulkan* pTexture, vk::ImageSubresourceRange subResources, vk::ImageLayout dstLayout, vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess, bool bDiscardSource = false);
 

--- a/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
+++ b/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
@@ -407,7 +407,7 @@ void ezShaderCompilerDXC::CreateNewShaderResourceDeclaration(ezStringView sPlatf
   // There will be two declarations in the HLSL code, the sampler and the texture.
   if (binding.m_ResourceType == ezGALShaderResourceType::TextureAndSampler)
   {
-    type = binding.m_TextureType == ezGALShaderTextureType::Unknown ? ezGALShaderResourceCategory::Sampler : ezGALShaderResourceCategory::SRV;
+    type = binding.m_TextureType == ezGALShaderTextureType::Unknown ? ezGALShaderResourceCategory::Sampler : ezGALShaderResourceCategory::TextureSRV;
   }
 
   switch (type.GetValue())
@@ -418,10 +418,12 @@ void ezShaderCompilerDXC::CreateNewShaderResourceDeclaration(ezStringView sPlatf
     case ezGALShaderResourceCategory::ConstantBuffer:
       sResourcePrefix = "b"_ezsv;
       break;
-    case ezGALShaderResourceCategory::SRV:
+    case ezGALShaderResourceCategory::TextureSRV:
+    case ezGALShaderResourceCategory::BufferSRV:
       sResourcePrefix = "t"_ezsv;
       break;
-    case ezGALShaderResourceCategory::UAV:
+    case ezGALShaderResourceCategory::TextureUAV:
+    case ezGALShaderResourceCategory::BufferUAV:
       sResourcePrefix = "u"_ezsv;
       break;
     default:

--- a/Code/Engine/ShaderCompilerHLSL/ShaderCompilerHLSL.cpp
+++ b/Code/Engine/ShaderCompilerHLSL/ShaderCompilerHLSL.cpp
@@ -513,7 +513,7 @@ namespace
   };
 
   EZ_DECLARE_FLAGS_OPERATORS(DX11ResourceCategory);
-}
+} // namespace
 
 inline ezBitflags<DX11ResourceCategory> DX11ResourceCategory::MakeFromShaderDescriptorType(ezGALShaderResourceType::Enum type)
 {

--- a/Code/EnginePlugins/OpenVRPlugin/OpenVRSingleton.cpp
+++ b/Code/EnginePlugins/OpenVRPlugin/OpenVRSingleton.cpp
@@ -411,7 +411,7 @@ void ezOpenVR::GameApplicationEventHandler(const ezGameApplicationExecutionEvent
       auto* constants = ezRenderContext::GetConstantBufferData<ezVRCompanionViewConstants>(m_hCompanionConstantBuffer);
       constants->TargetSize = targetSize;
 
-      ezGALResourceViewHandle hInputView = pDevice->GetDefaultResourceView(m_hColorRT);
+      ezGALTextureResourceViewHandle hInputView = pDevice->GetDefaultResourceView(m_hColorRT);
       m_pRenderContext->BindTexture2D("VRTexture", hInputView);
       m_pRenderContext->DrawMeshBuffer();
     }

--- a/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.cpp
@@ -64,9 +64,7 @@ void ezParticleRenderer::CreateParticleDataBuffer(ezGALBufferHandle& inout_hBuff
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = uiDataTypeSize;
     desc.m_uiTotalSize = uiNumParticlesPerBatch * desc.m_uiStructSize;
-    desc.m_BufferType = ezGALBufferType::Generic;
-    desc.m_bUseAsStructuredBuffer = true;
-    desc.m_bAllowShaderResourceView = true;
+    desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     inout_hBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.cpp
@@ -64,7 +64,7 @@ void ezParticleRenderer::CreateParticleDataBuffer(ezGALBufferHandle& inout_hBuff
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = uiDataTypeSize;
     desc.m_uiTotalSize = uiNumParticlesPerBatch * desc.m_uiStructSize;
-    desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     inout_hBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -50,7 +50,7 @@ void ezProcVertexColorComponentManager::Initialize()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezUInt32);
     desc.m_uiTotalSize = desc.m_uiStructSize * VERTEX_COLOR_BUFFER_SIZE;
-    desc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hVertexColorBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -50,7 +50,7 @@ void ezProcVertexColorComponentManager::Initialize()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezUInt32);
     desc.m_uiTotalSize = desc.m_uiStructSize * VERTEX_COLOR_BUFFER_SIZE;
-    desc.m_bAllowShaderResourceView = true;
+    desc.m_BufferFlags = ezGALBufferFlags::TexelBuffer | ezGALBufferFlags::ShaderResource;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hVertexColorBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
@@ -53,7 +53,7 @@ namespace ezRmlUiInternal
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = sizeof(Vertex);
       desc.m_uiTotalSize = vertexStorage.GetCount() * desc.m_uiStructSize;
-      desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::VertexBuffer;
 
       geometry.m_hVertexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc, vertexStorage.GetByteArrayPtr());
     }
@@ -63,7 +63,7 @@ namespace ezRmlUiInternal
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = sizeof(ezUInt32);
       desc.m_uiTotalSize = iNum_indices * desc.m_uiStructSize;
-      desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::IndexBuffer;
 
       geometry.m_hIndexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc, ezMakeArrayPtr(pIndices, iNum_indices).ToByteArray());
     }

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
@@ -53,7 +53,7 @@ namespace ezRmlUiInternal
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = sizeof(Vertex);
       desc.m_uiTotalSize = vertexStorage.GetCount() * desc.m_uiStructSize;
-      desc.m_BufferType = ezGALBufferType::VertexBuffer;
+      desc.m_BufferFlags = ezGALBufferFlags::VertexBuffer;
 
       geometry.m_hVertexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc, vertexStorage.GetByteArrayPtr());
     }
@@ -63,7 +63,7 @@ namespace ezRmlUiInternal
       ezGALBufferCreationDescription desc;
       desc.m_uiStructSize = sizeof(ezUInt32);
       desc.m_uiTotalSize = iNum_indices * desc.m_uiStructSize;
-      desc.m_BufferType = ezGALBufferType::IndexBuffer;
+      desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
 
       geometry.m_hIndexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc, ezMakeArrayPtr(pIndices, iNum_indices).ToByteArray());
     }

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiRenderer.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiRenderer.cpp
@@ -36,7 +36,7 @@ ezRmlUiRenderer::ezRmlUiRenderer()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezUInt32);
     desc.m_uiTotalSize = EZ_ARRAY_SIZE(indices) * desc.m_uiStructSize;
-    desc.m_BufferType = ezGALBufferType::IndexBuffer;
+    desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
 
     m_hQuadIndexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc, ezMakeArrayPtr(indices).ToByteArray());
   }

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiRenderer.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiRenderer.cpp
@@ -36,7 +36,7 @@ ezRmlUiRenderer::ezRmlUiRenderer()
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezUInt32);
     desc.m_uiTotalSize = EZ_ARRAY_SIZE(indices) * desc.m_uiStructSize;
-    desc.m_BufferFlags = ezGALBufferFlags::IndexBuffer;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::IndexBuffer;
 
     m_hQuadIndexBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc, ezMakeArrayPtr(indices).ToByteArray());
   }

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
@@ -208,7 +208,7 @@ void ezComputeShaderHistogramApp::AfterCoreSystemsStartup()
     m_hHistogramTexture = device->CreateTexture(texDesc);
     m_hHistogramSRV = device->GetDefaultResourceView(m_hHistogramTexture);
 
-    ezGALUnorderedAccessViewCreationDescription uavDesc;
+    ezGALTextureUnorderedAccessViewCreationDescription uavDesc;
     uavDesc.m_hTexture = m_hHistogramTexture;
     m_hHistogramUAV = device->CreateUnorderedAccessView(uavDesc);
   }

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
@@ -35,7 +35,7 @@ private:
 
   // Could use buffer, but access and organisation with texture is more straight forward.
   ezGALTextureHandle m_hHistogramTexture;
-  ezGALUnorderedAccessViewHandle m_hHistogramUAV;
+  ezGALTextureUnorderedAccessViewHandle m_hHistogramUAV;
   ezGALTextureResourceViewHandle m_hHistogramSRV;
 
   ezWindowBase* m_pWindow = nullptr;

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
@@ -31,12 +31,12 @@ private:
 
   ezGALTextureHandle m_hScreenTexture;
   ezGALRenderTargetViewHandle m_hScreenRTV;
-  ezGALResourceViewHandle m_hScreenSRV;
+  ezGALTextureResourceViewHandle m_hScreenSRV;
 
   // Could use buffer, but access and organisation with texture is more straight forward.
   ezGALTextureHandle m_hHistogramTexture;
   ezGALUnorderedAccessViewHandle m_hHistogramUAV;
-  ezGALResourceViewHandle m_hHistogramSRV;
+  ezGALTextureResourceViewHandle m_hHistogramSRV;
 
   ezWindowBase* m_pWindow = nullptr;
   ezGALSwapChainHandle m_hSwapChain;

--- a/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
+++ b/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
@@ -553,7 +553,10 @@ ezTestAppRun ezGameEngineTestApplication_Basics::SubTestDebugRenderingExec(ezInt
   if (iCurFrame < 1)
     return ezTestAppRun::Continue;
 
-  EZ_TEST_LINE_IMAGE(0, 150);
+  ezStringView sRendererName = ezGALDevice::GetDefaultDevice()->GetRenderer();
+  const bool bRandomlyChangesLineThicknessOnDriverUpdate = sRendererName.IsEqual_NoCase("DX11") && ezGALDevice::GetDefaultDevice()->GetCapabilities().m_sAdapterName.FindSubString_NoCase("Nvidia");
+
+  EZ_TEST_LINE_IMAGE(0, bRandomlyChangesLineThicknessOnDriverUpdate ? 700 : 150);
 
   return ezTestAppRun::Quit;
 }

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -56,7 +56,7 @@ ezResult ezRendererTestAdvancedFeatures::InitializeSubTest(ezInt32 iIdentifier)
     desc.SetAsRenderTarget(8, 8, ezGALResourceFormat::BGRAUByteNormalizedsRGB, ezGALMSAASampleCount::None);
     m_hTexture2D = m_pDevice->CreateTexture(desc);
 
-    ezGALResourceViewCreationDescription viewDesc;
+    ezGALTextureResourceViewCreationDescription viewDesc;
     viewDesc.m_hTexture = m_hTexture2D;
     viewDesc.m_uiMipLevelsToUse = 1;
     for (ezUInt32 i = 0; i < 4; i++)
@@ -93,7 +93,7 @@ ezResult ezRendererTestAdvancedFeatures::InitializeSubTest(ezInt32 iIdentifier)
     desc.m_ResourceAccess.m_bImmutable = false;
     m_hTexture2D = m_pDevice->CreateTexture(desc);
 
-    ezGALResourceViewCreationDescription viewDesc;
+    ezGALTextureResourceViewCreationDescription viewDesc;
     viewDesc.m_hTexture = m_hTexture2D;
     viewDesc.m_uiMipLevelsToUse = 1;
     viewDesc.m_uiMostDetailedMipLevel = 0;

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -470,9 +470,9 @@ void ezRendererTestAdvancedFeatures::Compute()
     {
       ezRenderContext::GetDefaultInstance()->BindShader(m_hShader2);
 
-      ezGALUnorderedAccessViewHandle hFilterOutput;
+      ezGALTextureUnorderedAccessViewHandle hFilterOutput;
       {
-        ezGALUnorderedAccessViewCreationDescription desc;
+        ezGALTextureUnorderedAccessViewCreationDescription desc;
         desc.m_hTexture = m_hTexture2D;
         desc.m_uiMipLevelToUse = 0;
         desc.m_uiFirstArraySlice = 0;

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
@@ -44,7 +44,7 @@ private:
   ezShaderResourceHandle m_hShader2;
 
   ezGALTextureHandle m_hTexture2D;
-  ezGALResourceViewHandle m_hTexture2DMips[4];
+  ezGALTextureResourceViewHandle m_hTexture2DMips[4];
   ezGALTextureHandle m_hTexture2DArray;
 
   // Tessellation Test

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -157,7 +157,7 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
     FillStructuredBuffer(instanceData);
     m_hInstancingData = m_pDevice->CreateBuffer(desc, instanceData.GetByteArrayPtr());
 
-    ezGALResourceViewCreationDescription viewDesc;
+    ezGALBufferResourceViewCreationDescription viewDesc;
     viewDesc.m_hBuffer = m_hInstancingData;
     viewDesc.m_uiFirstElement = 8;
     viewDesc.m_uiNumElements = 4;
@@ -211,7 +211,7 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
     }
     m_hTexture2D = m_pDevice->CreateTexture(desc, initialData);
 
-    ezGALResourceViewCreationDescription viewDesc;
+    ezGALTextureResourceViewCreationDescription viewDesc;
     viewDesc.m_hTexture = m_hTexture2D;
     viewDesc.m_uiMostDetailedMipLevel = 0;
     viewDesc.m_uiMipLevelsToUse = 1;
@@ -252,7 +252,7 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
     }
     m_hTexture2DArray = m_pDevice->CreateTexture(desc, initialData);
 
-    ezGALResourceViewCreationDescription viewDesc;
+    ezGALTextureResourceViewCreationDescription viewDesc;
     viewDesc.m_hTexture = m_hTexture2DArray;
     viewDesc.m_uiMipLevelsToUse = 1;
     viewDesc.m_uiFirstArraySlice = 0;

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -149,7 +149,7 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezTestShaderData);
     desc.m_uiTotalSize = 16 * desc.m_uiStructSize;
-    desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
+    desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     // We only fill the first 8 elements with data. The rest is dynamically updated during testing.

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -149,9 +149,7 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezTestShaderData);
     desc.m_uiTotalSize = 16 * desc.m_uiStructSize;
-    desc.m_BufferType = ezGALBufferType::Generic;
-    desc.m_bUseAsStructuredBuffer = true;
-    desc.m_bAllowShaderResourceView = true;
+    desc.m_BufferFlags = ezGALBufferFlags::StructuredBuffer | ezGALBufferFlags::ShaderResource;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     // We only fill the first 8 elements with data. The rest is dynamically updated during testing.

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.h
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.h
@@ -85,19 +85,19 @@ private:
   ezConstantBufferStorageHandle m_hTestPositionsConstantBuffer;
 
   ezGALBufferHandle m_hInstancingData;
-  ezGALResourceViewHandle m_hInstancingDataView_8_4;
-  ezGALResourceViewHandle m_hInstancingDataView_12_4;
+  ezGALBufferResourceViewHandle m_hInstancingDataView_8_4;
+  ezGALBufferResourceViewHandle m_hInstancingDataView_12_4;
 
   ezGALTextureHandle m_hTexture2D;
-  ezGALResourceViewHandle m_hTexture2D_Mip0;
-  ezGALResourceViewHandle m_hTexture2D_Mip1;
-  ezGALResourceViewHandle m_hTexture2D_Mip2;
-  ezGALResourceViewHandle m_hTexture2D_Mip3;
+  ezGALTextureResourceViewHandle m_hTexture2D_Mip0;
+  ezGALTextureResourceViewHandle m_hTexture2D_Mip1;
+  ezGALTextureResourceViewHandle m_hTexture2D_Mip2;
+  ezGALTextureResourceViewHandle m_hTexture2D_Mip3;
   ezGALTextureHandle m_hTexture2DArray;
-  ezGALResourceViewHandle m_hTexture2DArray_Layer0_Mip0;
-  ezGALResourceViewHandle m_hTexture2DArray_Layer0_Mip1;
-  ezGALResourceViewHandle m_hTexture2DArray_Layer1_Mip0;
-  ezGALResourceViewHandle m_hTexture2DArray_Layer1_Mip1;
+  ezGALTextureResourceViewHandle m_hTexture2DArray_Layer0_Mip0;
+  ezGALTextureResourceViewHandle m_hTexture2DArray_Layer0_Mip1;
+  ezGALTextureResourceViewHandle m_hTexture2DArray_Layer1_Mip0;
+  ezGALTextureResourceViewHandle m_hTexture2DArray_Layer1_Mip1;
 
   bool m_bTimestampsValid = false;
   ezTime m_CPUTime[2];

--- a/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
@@ -130,7 +130,7 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
   {
     ezStringView sRendererName = m_pDevice->GetRenderer();
     const bool bRandomlyChangesLineThicknessOnDriverUpdate = sRendererName.IsEqual_NoCase("DX11") && m_pDevice->GetCapabilities().m_sAdapterName.FindSubString_NoCase("Nvidia");
-    
+
     EZ_TEST_LINE_IMAGE(m_iFrame, bRandomlyChangesLineThicknessOnDriverUpdate ? 1000 : 300);
   }
   else

--- a/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
@@ -127,7 +127,12 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
   RenderObjects(ezShaderBindFlags::NoRasterizerState);
 
   if (RasterStateDesc.m_bWireFrame)
-    EZ_TEST_LINE_IMAGE(m_iFrame, 300);
+  {
+    ezStringView sRendererName = m_pDevice->GetRenderer();
+    const bool bRandomlyChangesLineThicknessOnDriverUpdate = sRendererName.IsEqual_NoCase("DX11") && m_pDevice->GetCapabilities().m_sAdapterName.FindSubString_NoCase("Nvidia");
+    
+    EZ_TEST_LINE_IMAGE(m_iFrame, bRandomlyChangesLineThicknessOnDriverUpdate ? 1000 : 300);
+  }
   else
     EZ_TEST_IMAGE(m_iFrame, 200);
   EndRendering();

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -346,7 +346,7 @@ void ezGraphicsTest::SetClipSpace()
   ezRenderContext::GetDefaultInstance()->SetShaderPermutationVariable(sClipSpaceFlipped, clipSpace == ezClipSpaceYMode::Flipped ? sTrue : sFalse);
 }
 
-void ezGraphicsTest::RenderCube(ezRectFloat viewport, ezMat4 mMVP, ezUInt32 uiRenderTargetClearMask, ezGALResourceViewHandle hSRV)
+void ezGraphicsTest::RenderCube(ezRectFloat viewport, ezMat4 mMVP, ezUInt32 uiRenderTargetClearMask, ezGALTextureResourceViewHandle hSRV)
 {
   ezGALRenderCommandEncoder* pCommandEncoder = BeginRendering(ezColor::RebeccaPurple, uiRenderTargetClearMask, &viewport);
 

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -124,7 +124,7 @@ ezResult ezGraphicsTest::CreateRenderer(ezGALDevice*& out_pDevice)
     }
     else if (out_pDevice->GetCapabilities().m_sAdapterName.FindSubString_NoCase("Nvidia") || out_pDevice->GetCapabilities().m_sAdapterName.FindSubString_NoCase("GeForce"))
     {
-      // Line rendering is different on AMD and requires separate images for tests rendering lines.
+      // Line rendering is different on Nvidia and requires separate images for tests rendering lines.
       ezTestFramework::GetInstance()->SetImageReferenceOverrideFolderName("Images_Reference_D3D11Nvidia");
     }
     else

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.h
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.h
@@ -62,7 +62,7 @@ protected:
   /// \param mMVP Model View Projection matrix for camera. Use CreateSimpleMVP for convenience.
   /// \param uiRenderTargetClearMask What render targets if any should be cleared.
   /// \param hSRV The texture to render onto the cube.
-  void RenderCube(ezRectFloat viewport, ezMat4 mMVP, ezUInt32 uiRenderTargetClearMask, ezGALResourceViewHandle hSRV);
+  void RenderCube(ezRectFloat viewport, ezMat4 mMVP, ezUInt32 uiRenderTargetClearMask, ezGALTextureResourceViewHandle hSRV);
 
   ezMat4 CreateSimpleMVP(float fAspectRatio);
 


### PR DESCRIPTION
This PR is mostly boilerplate code, the only change of interest is in *Code/Engine/RendererFoundation/Descriptors/Descriptors.h* and *Code/Engine/RendererFoundation/Descriptors/Enumerations.h*.

## Buffer Refactor
* `ezGALBufferCreationDescription` has all its bools and `ezGALBufferType` removed. Especially `ezGALBufferType::Generic` was very confusing. This has been replaced with a single bitflags field: `ezGALBufferFlags`
* `ezGALBufferFlags` defines what you are going to use the buffer for: `VertexBuffer`, `IndexBuffer`, `ConstantBuffer`, `TexelBuffer`, `StructuredBuffer` or `ByteAddressBuffer`. These use the same name as you woud find in the `ezGALShaderResourceType` enum. Note that these are flags, as you can have for example a `VertexBuffer` that you want to write as a `ByteAddressBuffer`.
* Additionally, `ezGALBufferFlags` contains flags where the buffer can be used: `ShaderResource`, `UnorderedAccess` and `DrawIndirect`.

## SRV / UAV split
* `ezGALResourceViewCreationDescription` has been split into `ezGALBufferResourceViewCreationDescription` and `ezGALTextureResourceViewCreationDescription`.
* `ezGALUnorderedAccessViewCreationDescription` has been split into `ezGALBufferUnorderedAccessViewCreationDescription` and `ezGALTextureUnorderedAccessViewCreationDescription`.
* This remove ambiguity and a source of errors as you could bind idiotic views to descriptors of incompatible types and the low level renderer needed to account for this. It also makes it much clearer which fields are actually usable when creating the view.
* The old code forced all UAV / SRV / RenderTarget caches to be on the `ezGALResourceBase` causing every resource type to be bloated with the cache arrays although no resource outside of texture and buffer uses these. The caches have now been moved into the `ezGALBuffer` and `ezGALTexture` classes.
* Removed `m_bAppend` from `ezGALBufferUnorderedAccessViewCreationDescription` as it was not used and this feature (append / consume) requires a dedicated resource type to work cross platform.

## Misc
* Disable debug break on warnings in DX11 debug layer.
* Added `ezGALDevice::GetRendererPlatform` to query what renderer is currently active.
* Increased image compare threshold for Nvidia cards running on DX11 as the latest driver decided to render all lines twice as thick for no reason.