### PR TITLE
Fix Renderdoc captures in Play-the-game mode

### DIFF
--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -139,6 +139,7 @@ void ezGameApplication::Run_Present()
   ezHybridArray<ezActor*, 8> allActors;
   ezActorManager::GetSingleton()->GetAllActors(allActors);
 
+  bool bExecutedFrameCapture = false;
   for (ezActor* pActor : allActors)
   {
     EZ_PROFILE_SCOPE(pActor->GetName());
@@ -160,9 +161,10 @@ void ezGameApplication::Run_Present()
 
       ExecuteTakeScreenshot(pOutput, ctxt);
 
-      if (pWindowPlugin->GetWindow())
+      if (pWindowPlugin->GetWindow() && !bExecutedFrameCapture)
       {
         ExecuteFrameCapture(pWindowPlugin->GetWindow()->GetNativeWindowHandle(), ctxt);
+        bExecutedFrameCapture = true;
       }
 
       EZ_PROFILE_SCOPE("Present");


### PR DESCRIPTION
Fix Renderdoc captures in Play-the-game mode by only doing one ezGameApplication::ExecuteFrameCapture call per frame

This issue is caused by multiple windows existing at the same time (e.g. EditorView & MainWindow), so it happens that the first starts the capture and the 2nd immediately stops the capture via the 2nd call of ExecuteFrameCapture(), resulting in an nearly empty capture.

**How to reproduce**

1. Open ezEditor & Enable renderdoc
2. Play-the-game (Ctrl + F5) 
3. Take a capture (F11). 
4. Open the capture in Renderdoc & observe the nearly empty capture

With this fix, the capture contains a proper MainWindow capture.