### PR TITLE
Fix particles disappearing on Nvidia DX11

### DIFF
--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationBinary.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationBinary.cpp
@@ -11,6 +11,7 @@ struct ezShaderPermutationBinaryVersion
     Version3 = 3,
     Version4 = 4,
     Version5 = 5,
+    Version6 = 6, // Fixed DX11 particles vanishing
 
     // Increase this version number to trigger shader recompilation
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -844,7 +844,6 @@ void ezShaderParser::ApplyShaderResourceBindings(ezStringView sPlatform, ezStrin
     bindings.TryGetValue(resources[i].m_Binding.m_sName, pBinding);
 
     EZ_ASSERT_DEV(pBinding != nullptr, "Every resource should be present in the map.");
-    EZ_ASSERT_DEV(pBinding->m_iSlot >= 0 && pBinding->m_iSet >= 0, "Unbound shader resource binding found: '{}', slot: {}, set: {}", pBinding->m_sName, pBinding->m_iSlot, pBinding->m_iSet);
     createDeclaration(sPlatform, resources[i].m_sDeclaration, *pBinding, sDeclaration);
     ezString& sStorage = partStorage.ExpandAndGetRef();
     sStorage = sDeclaration;

--- a/Code/Engine/RendererDX11/Shader/Implementation/ShaderDX11.cpp
+++ b/Code/Engine/RendererDX11/Shader/Implementation/ShaderDX11.cpp
@@ -50,7 +50,7 @@ void ezGALShaderDX11::SetDebugName(const char* szName) const
 
 ezResult ezGALShaderDX11::InitPlatform(ezGALDevice* pDevice)
 {
-  EZ_SUCCEED_OR_RETURN(CreateBindingMapping());
+  EZ_SUCCEED_OR_RETURN(CreateBindingMapping(true));
 
   ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
   ID3D11Device* pD3D11Device = pDXDevice->GetDXDevice();

--- a/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
@@ -33,7 +33,7 @@ ezArrayPtr<const ezShaderVertexInputAttribute> ezGALShader::GetVertexInputAttrib
   return {};
 }
 
-ezResult ezGALShader::CreateBindingMapping()
+ezResult ezGALShader::CreateBindingMapping(bool bAllowMultipleBindingPerName)
 {
   ezHybridArray<ezArrayPtr<const ezShaderResourceBinding>, ezGALShaderStage::ENUM_COUNT> resourceBinding;
   resourceBinding.SetCount(ezGALShaderStage::ENUM_COUNT);
@@ -44,7 +44,7 @@ ezResult ezGALShader::CreateBindingMapping()
       resourceBinding[stage] = m_Description.m_ByteCodes[stage]->m_ShaderResourceBindings;
     }
   }
-  return ezShaderResourceBinding::CreateMergedShaderResourceBinding(resourceBinding, m_BindingMapping);
+  return ezShaderResourceBinding::CreateMergedShaderResourceBinding(resourceBinding, m_BindingMapping, bAllowMultipleBindingPerName);
 }
 
 void ezGALShader::DestroyBindingMapping()

--- a/Code/Engine/RendererFoundation/Shader/Shader.h
+++ b/Code/Engine/RendererFoundation/Shader/Shader.h
@@ -22,7 +22,7 @@ protected:
   virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 
-  ezResult CreateBindingMapping();
+  ezResult CreateBindingMapping(bool bAllowMultipleBindingPerName);
   void DestroyBindingMapping();
 
   ezGALShader(const ezGALShaderCreationDescription& Description);

--- a/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
+++ b/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
@@ -85,7 +85,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezShaderResourceBinding
   ezHashedString m_sName;                                     //< Name under which a resource must be bound to fulfill this resource binding.
   ezScopedRefPointer<ezShaderConstantBufferLayout> m_pLayout; //< Only valid if ezGALShaderResourceType is ConstantBuffer or PushConstants. #TODO_SHADER We could also support this for StructuredBuffer / StructuredBufferRW, but currently there is no use case for that.
 
-  static ezResult CreateMergedShaderResourceBinding(const ezArrayPtr<ezArrayPtr<const ezShaderResourceBinding>>& resourcesPerStage, ezDynamicArray<ezShaderResourceBinding>& out_bindings);
+  static ezResult CreateMergedShaderResourceBinding(const ezArrayPtr<ezArrayPtr<const ezShaderResourceBinding>>& resourcesPerStage, ezDynamicArray<ezShaderResourceBinding>& out_bindings, bool bAllowMultipleBindingPerName);
 };
 
 /// \brief This class wraps shader byte code storage.

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -42,7 +42,7 @@ void ezGALShaderVulkan::SetDebugName(const char* szName) const
 
 ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
 {
-  EZ_SUCCEED_OR_RETURN(CreateBindingMapping());
+  EZ_SUCCEED_OR_RETURN(CreateBindingMapping(false));
 
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
 

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: F5342168-CDD3-41FE-BD86-AAF7F826A1B2
+Change me: FQ342168-CDD3-41FE-BD86-AAF7F826A1B2


### PR DESCRIPTION
* The DX11 shader compiler no longer sets binding information for samplers and SRVs as Nvidia drivers can't cope with binding mappings that have gaps.
* This relaxes the renderer resource binding contraints in that it allows a resource name to exist multiple times inside the shader resource binding. This is fine as we don't do name lookups on `ezGALShader::GetBindingMapping` except for in `ezMaterialResource::UpdateConstantBuffer` which uses `ezGALShader::GetShaderResourceBinding(const ezTempHashedString& sName)` to lookup the first binding of a given name but as it's only used for constant buffers no ambiguity is possible.