### PR TITLE
Fixed race condition in particle bounds update

### DIFF
--- a/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.cpp
@@ -48,7 +48,7 @@ void ezParticleComponentManager::UpdatePfxTransformsAndBounds()
     ComponentType* pComponent = it;
     if (pComponent->IsActiveAndInitialized())
     {
-      pComponent->UpdatePfxTransform();
+      pComponent->UpdatePfxTransformAndBounds();
 
       // This function is called in the post-transform phase so the global bounds and transform have already been calculated at this point.
       // Therefore we need to manually update the global bounds again to ensure correct bounds for culling and rendering.
@@ -230,7 +230,7 @@ bool ezParticleComponent::StartEffect()
 
     m_EffectController.Create(m_hEffectResource, pModule, m_uiRandomSeed, m_sSharedInstanceName, this, m_FloatParams, m_ColorParams);
 
-    UpdatePfxTransform();
+    UpdatePfxTransformAndBounds();
 
     m_bFloatParamsChanged = false;
     m_bColorParamsChanged = false;
@@ -551,9 +551,10 @@ ezTransform ezParticleComponent::GetPfxTransform() const
   return transform;
 }
 
-void ezParticleComponent::UpdatePfxTransform()
+void ezParticleComponent::UpdatePfxTransformAndBounds()
 {
   m_EffectController.SetTransform(GetPfxTransform(), GetOwner()->GetLinearVelocity());
+  m_EffectController.CombineSystemBoundingVolumes();
 }
 
 EZ_STATICLINK_FILE(ParticlePlugin, ParticlePlugin_Components_ParticleComponent);

--- a/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.h
+++ b/Code/EnginePlugins/ParticlePlugin/Components/ParticleComponent.h
@@ -125,7 +125,7 @@ public:
 protected:
   void Update();
   ezTransform GetPfxTransform() const;
-  void UpdatePfxTransform();
+  void UpdatePfxTransformAndBounds();
 
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
   void OnMsgDeleteGameObject(ezMsgDeleteGameObject& msg);

--- a/Code/EnginePlugins/ParticlePlugin/Effect/ParticleEffectController.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Effect/ParticleEffectController.cpp
@@ -83,6 +83,14 @@ void ezParticleEffectController::SetTransform(const ezTransform& t, const ezVec3
   }
 }
 
+void ezParticleEffectController::CombineSystemBoundingVolumes()
+{
+  if (ezParticleEffectInstance* pEffect = GetInstance())
+  {
+    pEffect->CombineSystemBoundingVolumes();
+  }
+}
+
 void ezParticleEffectController::Tick(const ezTime& diff) const
 {
   ezParticleEffectInstance* pEffect = GetInstance();

--- a/Code/EnginePlugins/ParticlePlugin/Effect/ParticleEffectController.h
+++ b/Code/EnginePlugins/ParticlePlugin/Effect/ParticleEffectController.h
@@ -24,6 +24,8 @@ public:
 
   void SetTransform(const ezTransform& t, const ezVec3& vParticleStartVelocity) const;
 
+  void CombineSystemBoundingVolumes();
+
   void Tick(const ezTime& diff) const;
 
   void ExtractRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& systemTransform) const;

--- a/Code/EnginePlugins/ParticlePlugin/Effect/ParticleEffectInstance.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Effect/ParticleEffectInstance.cpp
@@ -518,8 +518,6 @@ bool ezParticleEffectInstance::StepSimulation(const ezTime& tDiff)
     }
   }
 
-  CombineSystemBoundingVolumes();
-
   m_iMinSimStepsToDo = ezMath::Max<ezInt8>(m_iMinSimStepsToDo - 1, 0);
 
   --m_uiReviveTimeout;


### PR DESCRIPTION
The particle effect instance bounding box was updated during the simulation task. This caused a race condition with the wind sample code that runs in the world update thread so it can access the wind module. 

This fix moves the particle effect instance bounding box update to the post transform phase right before the particle's game object bounds are updated. At this point no one else is accessing the bounding box as the simulation task has to be done at this point and wind samples are done in an earlier phase.