### PR TITLE
Fix Changing SetWorldSimulationEnabled creates inconsistent behavior

### DIFF
--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -455,7 +455,7 @@ void ezWorld::Update()
   }
 
   ++m_Data.m_uiUpdateCounter;
-  m_Data.m_bSimulateWorld = m_Data.m_bDesiredSimulateWorld;
+  m_Data.m_bSimulateWorld = m_Data.m_bShouldSimulateWorld;
 
   if (!m_Data.m_bSimulateWorld)
   {
@@ -549,7 +549,7 @@ void ezWorld::Update()
   }
 
   // Flush desired state again so GetSimulationState instantly returns the correct state
-  m_Data.m_bSimulateWorld = m_Data.m_bDesiredSimulateWorld;
+  m_Data.m_bSimulateWorld = m_Data.m_bShouldSimulateWorld;
 
   // Swap our double buffered stack allocator
   m_Data.m_StackAllocator.Swap();

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -455,6 +455,7 @@ void ezWorld::Update()
   }
 
   ++m_Data.m_uiUpdateCounter;
+  m_Data.m_bSimulateWorld = m_Data.m_bDesiredSimulateWorld;
 
   if (!m_Data.m_bSimulateWorld)
   {
@@ -546,6 +547,9 @@ void ezWorld::Update()
 
     ProcessQueuedMessages(ezObjectMsgQueueType::AfterInitialized);
   }
+
+  // Flush desired state again so GetSimulationState instantly returns the correct state
+  m_Data.m_bSimulateWorld = m_Data.m_bDesiredSimulateWorld;
 
   // Swap our double buffered stack allocator
   m_Data.m_StackAllocator.Swap();

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -241,7 +241,7 @@ namespace ezInternal
     mutable ezAtomicInteger32 m_iReadCounter;
 
     ezUInt32 m_uiUpdateCounter = 0;
-    bool m_bDesiredSimulateWorld = true;
+    bool m_bShouldSimulateWorld = true;
     bool m_bSimulateWorld = true;
     bool m_bReportErrorWhenStaticObjectMoves = true;
 

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -241,6 +241,7 @@ namespace ezInternal
     mutable ezAtomicInteger32 m_iReadCounter;
 
     ezUInt32 m_uiUpdateCounter = 0;
+    bool m_bDesiredSimulateWorld = true;
     bool m_bSimulateWorld = true;
     bool m_bReportErrorWhenStaticObjectMoves = true;
 

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -380,7 +380,7 @@ EZ_FORCE_INLINE void ezWorld::SendMessage(const ezComponentHandle& hReceiverComp
 
 EZ_ALWAYS_INLINE void ezWorld::SetWorldSimulationEnabled(bool bEnable)
 {
-  m_Data.m_bDesiredSimulateWorld = bEnable;
+  m_Data.m_bShouldSimulateWorld = bEnable;
 }
 
 EZ_ALWAYS_INLINE bool ezWorld::GetWorldSimulationEnabled() const

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -380,7 +380,7 @@ EZ_FORCE_INLINE void ezWorld::SendMessage(const ezComponentHandle& hReceiverComp
 
 EZ_ALWAYS_INLINE void ezWorld::SetWorldSimulationEnabled(bool bEnable)
 {
-  m_Data.m_bSimulateWorld = bEnable;
+  m_Data.m_bDesiredSimulateWorld = bEnable;
 }
 
 EZ_ALWAYS_INLINE bool ezWorld::GetWorldSimulationEnabled() const

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -251,12 +251,12 @@ public:
   ///@}
 
   /// \brief If enabled, the full simulation should be executed, otherwise only the rendering related updates should be done
-  /// Note the state returned by \link GetWorldSimulationEnabled() will not reflect state of \param bEnable immediately,
-  /// it is only updated in the beginning/end of an \link Update() call.
+  /// Note the state returned by ezWorld::GetWorldSimulationEnabled() will not reflect state of \param bEnable immediately,
+  /// it is only updated in the beginning/end of an ezWorld::Update() call.
   void SetWorldSimulationEnabled(bool bEnable);
 
   /// \brief If enabled, the full simulation should be executed, otherwise only the rendering related updates should be done
-  /// \link SetWorldSimulationEnabled() for implementation specifics.
+  /// See ezWorld::SetWorldSimulationEnabled() for implementation specifics.
   bool GetWorldSimulationEnabled() const;
 
   /// \brief Updates the world by calling the various update methods on the component managers and also updates the transformation data of

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -251,9 +251,12 @@ public:
   ///@}
 
   /// \brief If enabled, the full simulation should be executed, otherwise only the rendering related updates should be done
+  /// Note the state returned by \link GetWorldSimulationEnabled() will not reflect state of \param bEnable immediately,
+  /// it is only updated in the beginning/end of an \link Update() call.
   void SetWorldSimulationEnabled(bool bEnable);
 
   /// \brief If enabled, the full simulation should be executed, otherwise only the rendering related updates should be done
+  /// \link SetWorldSimulationEnabled() for implementation specifics.
   bool GetWorldSimulationEnabled() const;
 
   /// \brief Updates the world by calling the various update methods on the component managers and also updates the transformation data of


### PR DESCRIPTION
`ezWorld::SetWorldSimulation` will now be cached and is only flushed into the actual simulation state in the beginning/end of `ezWorld::Update()` calls.

This ensures consistency for the Update-functions which only execute when the simulation is active - either all of them are run, or none. Its no longer possible to get an in between state where only some of them are run if the simulation state is changed during an `ezWorld::Update()` call.

This fixes #1300