### PR TITLE
Fix Incorrect Window Position Calculation.

### DIFF
--- a/Code/Engine/Core/System/Implementation/Window.cpp
+++ b/Code/Engine/Core/System/Implementation/Window.cpp
@@ -73,7 +73,7 @@ ezResult ezWindowCreationDesc::AdjustWindowSizeAndPosition()
 
   if (m_bCenterWindowOnDisplay)
   {
-    m_Position.Set(pScreen->m_iOffsetX + (pScreen->m_iResolutionX - m_Resolution.width) / 2, pScreen->m_iOffsetY + (pScreen->m_iResolutionY - m_Resolution.height) / 2);
+    m_Position.Set(pScreen->m_iOffsetX + (pScreen->m_iResolutionX - (ezInt32)m_Resolution.width) / 2, pScreen->m_iOffsetY + (pScreen->m_iResolutionY - (ezInt32)m_Resolution.height) / 2);
   }
   else
   {


### PR DESCRIPTION
This occurred when either the expected window width or height was greater than the monitor's width or height.

On a vertical monitor setup, I encountered this scenario that the window won't be visible when the width of the window exceeds that of the monitor. It turns out that the window parameters are unsigned integers, so the subtraction gets promoted to that (becomes UINT_MAX).

![image](https://github.com/ezEngine/ezEngine/assets/65521326/1130adc6-4fc8-4865-a842-54df2c7f159e)
