### PR TITLE
Various Build and Test improvements

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,8 +1,8 @@
 {
-  "version": 5,
+  "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 24,
+    "minor": 22,
     "patch": 0
   },
   "configurePresets": [

--- a/Code/BuildSystem/CMake/ezUtils.cmake
+++ b/Code/BuildSystem/CMake/ezUtils.cmake
@@ -559,8 +559,10 @@ function(ez_set_build_types)
 
 	# Fix for cl : Command line warning D9025 : overriding '/Ob0' with '/Ob1'
 	# We are adding /Ob1 to debug inside ./CMakeUtils/ezUtilsCppFlags.cmake
-	string(REPLACE "/Ob0" "/Ob1" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-	string(REPLACE "/Ob0" "/Ob1" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+	if(EZ_CMAKE_COMPILER_GCC)
+		string(REPLACE "/Ob0" "/Ob1" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+		string(REPLACE "/Ob0" "/Ob1" CMAKE_C_FLAGS_DEBUG ${CMAKE_C_FLAGS_DEBUG})
+	endif ()
 
 	set(CMAKE_CXX_FLAGS_${EZ_BUILDTYPENAME_DEBUG_UPPER} ${CMAKE_CXX_FLAGS_DEBUG} CACHE STRING "" FORCE)
 	set(CMAKE_CXX_FLAGS_${EZ_BUILDTYPENAME_DEV_UPPER} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} CACHE STRING "" FORCE)

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -1001,6 +1001,16 @@ namespace
     inout_json[sName] = sValue;
     inout_modified = ezCppProject::ModifyResult::MODIFIED;
   }
+
+  void Remove(ezVariantDictionary& inout_json, ezStringView sName, ezCppProject::ModifyResult& inout_modified)
+  {
+    if (inout_json.Contains(sName))
+    {
+      inout_json.Remove(sName);
+      inout_modified = ezCppProject::ModifyResult::MODIFIED;
+    }
+  }
+
 } // namespace
 
 ezCppProject::ModifyResult ezCppProject::ModifyCMakeUserPresetsJson(const ezCppSettings& cfg, ezVariantDictionary& inout_json)
@@ -1068,10 +1078,11 @@ ezCppProject::ModifyResult ezCppProject::ModifyCMakeUserPresetsJson(const ezCppS
       Modify(presetDict, "architecture", "x64", result);
     }
     else
-    {
-      presetDict.Remove("architecture");
-    }
 #endif
+    {
+      Remove(presetDict, "architecture", result);
+    }
+
   }
 
   return result;

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -1004,9 +1004,8 @@ namespace
 
   void Remove(ezVariantDictionary& inout_json, ezStringView sName, ezCppProject::ModifyResult& inout_modified)
   {
-    if (inout_json.Contains(sName))
+    if (inout_json.Remove(sName))
     {
-      inout_json.Remove(sName);
       inout_modified = ezCppProject::ModifyResult::MODIFIED;
     }
   }

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -1082,7 +1082,6 @@ ezCppProject::ModifyResult ezCppProject::ModifyCMakeUserPresetsJson(const ezCppS
     {
       Remove(presetDict, "architecture", result);
     }
-
   }
 
   return result;

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -367,7 +367,11 @@ ezStatus ezQtEditorApp::MakeRemoteProjectLocal(ezStringBuilder& inout_sFilePath)
 
     QProcess proc;
     proc.setWorkingDirectory(sTargetDir.GetData());
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
     proc.start("git.exe", args);
+#else
+    proc.start("git", args);
+#endif
 
     if (!proc.waitForStarted())
     {

--- a/Code/Editor/EditorFramework/EditorApp/StackTraceLogParser.h
+++ b/Code/Editor/EditorFramework/EditorApp/StackTraceLogParser.h
@@ -7,7 +7,7 @@
 namespace ezStackTraceLogParser
 {
   EZ_EDITORFRAMEWORK_DLL bool ParseStackTraceFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber); // [tested]
-  EZ_EDITORFRAMEWORK_DLL bool ParseAssertFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber); // [tested]
+  EZ_EDITORFRAMEWORK_DLL bool ParseAssertFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber);     // [tested]
   void Register();
   void Unregister();
 } // namespace ezStackTraceLogParser

--- a/Code/Editor/EditorFramework/EditorApp/StackTraceLogParser.h
+++ b/Code/Editor/EditorFramework/EditorApp/StackTraceLogParser.h
@@ -6,8 +6,8 @@
 
 namespace ezStackTraceLogParser
 {
-  bool EZ_EDITORFRAMEWORK_DLL ParseStackTraceFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber); // [tested]
-  bool EZ_EDITORFRAMEWORK_DLL ParseAssertFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber); // [tested]
+  EZ_EDITORFRAMEWORK_DLL bool ParseStackTraceFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber); // [tested]
+  EZ_EDITORFRAMEWORK_DLL bool ParseAssertFileNameAndLineNumber(const ezStringView& sLine, ezStringView& ref_sFileName, ezInt32& ref_iLineNumber); // [tested]
   void Register();
   void Unregister();
 } // namespace ezStackTraceLogParser

--- a/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
+++ b/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.inl
@@ -301,6 +301,12 @@ void ezStandardInputDevice::UpdateInputSlotValues()
         --m_uiMouseButtonReceivedDown[i];
         m_InputSlotValues[slotDown[i]] = 1.0f;
       }
+      // This is a workaround for a win32 bug: Double clicking on a title bar maximizes a window but only fires a single mouse up event. If that happens, no further clicks would be recognized because the balance between up and down events is broken. So if the slot is not signaled and there is no down event but an up event instead, we just consume it.
+      else if (m_uiMouseButtonReceivedUp[i] > 0)
+      {
+        --m_uiMouseButtonReceivedUp[i];
+        m_InputSlotValues[slotDown[i]] = 0;
+      }
     }
   }
 

--- a/Utilities/Android/AndroidTest.ps1
+++ b/Utilities/Android/AndroidTest.ps1
@@ -20,9 +20,9 @@ if ($apk) {
     $installFunction = {
         Adb-Cmd -ErrorAction Continue -s $deviceAdb install -r -t $apk
         # Starting the app right after install usually fails
-        Start-Sleep -Seconds 1
+        Start-Sleep -Seconds 2
     }
-    Invoke-WithRetry -ScriptBlock $installFunction -MaxRetryCount 5
+    Invoke-WithRetry -ScriptBlock $installFunction -MaxRetryCount 6
 }
 
 Write-Host "Clearing LogCat..."
@@ -44,7 +44,7 @@ $pinfo.FileName = "$adb"
 $pinfo.RedirectStandardError = $false
 $pinfo.RedirectStandardOutput = $true
 $pinfo.UseShellExecute = $false
-$pinfo.Arguments = "-s $deviceAdb logcat ezEngine:D *:S"
+$pinfo.Arguments = "-s $deviceAdb logcat"
 
 $process = New-Object System.Diagnostics.Process
 $process.StartInfo = $pinfo
@@ -83,7 +83,9 @@ while ((Get-Date) -lt ($startTime.AddSeconds($maxWaitTime)) -and !$process.HasEx
         $line = $stdoutTask.Result
         if ( $null -ne $line) {
             # Log to console
-            Write-Host "$line"
+            if ($line -match "ezEngine") {
+                Write-Host "$line"
+            }
 
             if ($line -match "All tests passed.") {
                 $testSuccess = $true

--- a/Utilities/Android/AndroidUtils.ps1
+++ b/Utilities/Android/AndroidUtils.ps1
@@ -172,14 +172,15 @@ function Invoke-WithRetry {
     )
 
     $retryCount = 0
-
+	$sleepInterval = 1
     do {
         try {
             & $ScriptBlock
             break
         }
         catch {
-			Start-Sleep -Seconds 1
+			Start-Sleep -Seconds $sleepInterval
+			$sleepInterval = $sleepInterval * 2
             if ($retryCount -ge $MaxRetryCount) {
                 RaiseError("Error: $_")
             }


### PR DESCRIPTION
* Add GCC checks to ezUtils.cmake as clang doesn't require the Ob1 fix.
* Fixed project compilation on Linux. The `architecture` field is only supported on MSVC and must be removed otherwise. Removing is now outside the MSVC scope and marks the settings as dirty.
* Allow pulling monster game on Linux by removing the .exe from the git command.
* Clang fix in StackTraceLogParser.h: `EZ_EDITORFRAMEWORK_DLL` must be at the start of the function declaration or a compiler error is triggered.
* Android testing: Tests now capture all logcat logs but only print ezEngine logs to console. Added exponential backoff in case of app install errors
* Reduced cmake preset version rquirements so the default Ubuntu LTS CMake version is working out of the box.