### PR TITLE
Improved documentation for ezComponent::OnSimulationStarted()

### DIFF
--- a/Code/Engine/Core/World/Component.h
+++ b/Code/Engine/Core/World/Component.h
@@ -196,10 +196,8 @@ protected:
   /// editor. If instead the sound gets started in OnSimulationStarted(), it will only play once the user starts the game mode inside the
   /// editor.
   ///
-  /// Additionally, OnSimulationStarted() is only ever executed once on a component, even if the ezWorld pauses and resumes world simulation
-  /// multiple times. Thus components that should only execute a thing exactly once, will work correctly. In contrast OnActivated() and
-  /// OnDeactivated() will be executed every time the component's active state is toggled, which could re-execute the same behavior multiple
-  /// times.
+  /// Additionally, OnSimulationStarted() is only executed once, even if the ezWorld pauses and resumes world simulation multiple times.
+  /// However, note that it will be called again after the component has been deactivated and is activated again.
   ///
   /// \sa OnActivated(), OnDeactivated(), Initialize(), Deinitialize(), OnSimulationStarted()
   virtual void OnSimulationStarted();


### PR DESCRIPTION
As discussed in Discord [here](https://discord.com/channels/806092968346779699/806092968346779702/1243229973175865374), the documentation for ezComponent::OnSimulationStarted() was improved by explicitly mentioning that OnSimulationStarted() gets called again after a component has been deactivated & is activated again.