### PR TITLE
Added interface to provide custom geometry for runtime navmesh generation

### DIFF
--- a/Code/Engine/Core/Interfaces/NavmeshGeoWorldModule.cpp
+++ b/Code/Engine/Core/Interfaces/NavmeshGeoWorldModule.cpp
@@ -1,0 +1,6 @@
+#include <Core/Interfaces/NavmeshGeoWorldModule.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezNavmeshGeoWorldModuleInterface, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on

--- a/Code/Engine/Core/Interfaces/NavmeshGeoWorldModule.h
+++ b/Code/Engine/Core/Interfaces/NavmeshGeoWorldModule.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Core/Interfaces/PhysicsQuery.h>
+#include <Core/World/WorldModule.h>
+
+struct ezNavmeshTriangle
+{
+  ezVec3 m_Vertices[3];
+  const ezSurfaceResource* m_pSurface = nullptr;
+};
+
+/// \brief A world module that retrieves triangle data that should be used for building navmeshes at runtime.
+///
+/// If a physics engine is active, it usually automatically provides such a world module to retrieve the triangle data
+/// through physics queries.
+///
+/// In other types of games, a custom world module can be implemented, to generate this data in a different way.
+/// If a physics engine is active, but a custom method should be used, you can write a custom world module
+/// and then use ezWorldModuleFactory::RegisterInterfaceImplementation() to specify which module to use.
+/// Also see ezWorldModuleConfig.
+class EZ_CORE_DLL ezNavmeshGeoWorldModuleInterface : public ezWorldModule
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezNavmeshGeoWorldModuleInterface, ezWorldModule);
+
+protected:
+  ezNavmeshGeoWorldModuleInterface(ezWorld* pWorld)
+    : ezWorldModule(pWorld)
+  {
+  }
+
+public:
+  virtual void RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_Triangles) const = 0;
+};

--- a/Code/Engine/Core/Interfaces/NavmeshGeoWorldModule.h
+++ b/Code/Engine/Core/Interfaces/NavmeshGeoWorldModule.h
@@ -29,5 +29,5 @@ protected:
   }
 
 public:
-  virtual void RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_Triangles) const = 0;
+  virtual void RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_triangles) const = 0;
 };

--- a/Code/Engine/Core/Interfaces/PhysicsQuery.h
+++ b/Code/Engine/Core/Interfaces/PhysicsQuery.h
@@ -57,12 +57,6 @@ struct ezPhysicsOverlapResultArray
   ezHybridArray<ezPhysicsOverlapResult, 16> m_Results;
 };
 
-struct ezPhysicsTriangle
-{
-  ezVec3 m_Vertices[3];
-  const ezSurfaceResource* m_pSurface = nullptr;
-};
-
 /// \brief Flags for selecting which types of physics shapes should be included in things like overlap queries and raycasts.
 ///
 /// This is mainly for optimization purposes. It is up to the physics integration to support some or all of these flags.

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -43,8 +43,6 @@ public:
 
   virtual ezVec3 GetGravity() const = 0;
 
-  virtual void QueryGeometryInBox(const ezPhysicsQueryParameters& params, ezBoundingBox box, ezDynamicArray<ezPhysicsTriangle>& out_triangles) const = 0;
-
   //////////////////////////////////////////////////////////////////////////
   // ABSTRACTION HELPERS
   //

--- a/Code/Engine/Utilities/DataStructures/GameGrid.h
+++ b/Code/Engine/Utilities/DataStructures/GameGrid.h
@@ -110,6 +110,8 @@ public:
   bool GetRayIntersectionExpandedBBox(const ezVec3& vRayStartWorldSpace, const ezVec3& vRayDirNormalizedWorldSpace, float fMaxLength,
     float& out_fIntersection, const ezVec3& vExpandBBoxByThis) const;
 
+  void ComputeWorldSpaceCorners(ezVec3* pCorners) const;
+
 private:
   ezUInt16 m_uiGridSizeX;
   ezUInt16 m_uiGridSizeY;

--- a/Code/Engine/Utilities/DataStructures/Implementation/GameGrid_inl.h
+++ b/Code/Engine/Utilities/DataStructures/Implementation/GameGrid_inl.h
@@ -191,3 +191,12 @@ bool ezGameGrid<CellData>::GetRayIntersectionExpandedBBox(const ezVec3& vRayStar
 
   return true;
 }
+
+template <class CellData>
+void ezGameGrid<CellData>::ComputeWorldSpaceCorners(ezVec3* pCorners) const
+{
+  pCorners[0] = m_vWorldSpaceOrigin;
+  pCorners[1] = m_vWorldSpaceOrigin + m_mRotateToWorldspace * ezVec3(m_uiGridSizeX * m_vLocalSpaceCellSize.x, 0, 0);
+  pCorners[2] = m_vWorldSpaceOrigin + m_mRotateToWorldspace * ezVec3(0, m_uiGridSizeY * m_vLocalSpaceCellSize.y, 0);
+  pCorners[3] = m_vWorldSpaceOrigin + m_mRotateToWorldspace * ezVec3(m_uiGridSizeX * m_vLocalSpaceCellSize.x, m_uiGridSizeY * m_vLocalSpaceCellSize.y, 0);
+}

--- a/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavMeshGeneration.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavMeshGeneration.cpp
@@ -316,8 +316,16 @@ void ezAiNavMesh::BuildSector(SectorID sectorID, const ezNavmeshGeoWorldModuleIn
   const ezBoundingBox bounds = GetSectorBounds(sectorCoord, -1000, +1000);
 
   ezAiNavMeshInputGeo inputGeo;
-  QueryInputGeo(pGeo, m_NavmeshConfig.m_uiCollisionLayer, bounds, inputGeo);
-
+  {
+    ezBoundingBox boundsWithBorder = bounds;
+    const float cs = m_NavmeshConfig.m_fCellSize;
+    const float borderSize = (int)ceilf(m_NavmeshConfig.m_fAgentRadius / cs) + 3;
+    boundsWithBorder.m_vMin.x -= borderSize * cs;
+    boundsWithBorder.m_vMin.y -= borderSize * cs;
+    boundsWithBorder.m_vMax.x += borderSize * cs;
+    boundsWithBorder.m_vMax.y += borderSize * cs;
+    QueryInputGeo(pGeo, m_NavmeshConfig.m_uiCollisionLayer, boundsWithBorder, inputGeo);
+  }
   if (!inputGeo.m_Vertices.IsEmpty())
   {
     rcContext recastContext;

--- a/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavMeshGeneration.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavMeshGeneration.h
@@ -3,14 +3,14 @@
 #include <AiPlugin/Navigation/NavMesh.h>
 #include <Foundation/Threading/TaskSystem.h>
 
-class ezPhysicsWorldModuleInterface;
+class ezNavmeshGeoWorldModuleInterface;
 
 class ezNavMeshSectorGenerationTask : public ezTask
 {
 public:
   ezAiNavMesh::SectorID m_SectorID = ezInvalidIndex;
   ezAiNavMesh* m_pWorldNavMesh = nullptr;
-  const ezPhysicsWorldModuleInterface* m_pPhysics = nullptr;
+  const ezNavmeshGeoWorldModuleInterface* m_pNavGeo = nullptr;
 
 protected:
   virtual void Execute() override;

--- a/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavMeshWorldModule.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Implementation/NavMeshWorldModule.cpp
@@ -1,6 +1,6 @@
 #include <AiPlugin/Navigation/NavMesh.h>
 #include <AiPlugin/Navigation/NavMeshWorldModule.h>
-#include <Core/Interfaces/PhysicsWorldModule.h>
+#include <Core/Interfaces/NavmeshGeoWorldModule.h>
 #include <Core/World/World.h>
 #include <DetourNavMesh.h>
 #include <Foundation/Configuration/CVar.h>
@@ -124,8 +124,8 @@ void ezAiNavMeshWorldModule::Update(const UpdateContext& ctxt)
   if (!ezTaskSystem::IsTaskGroupFinished(m_GenerateSectorTaskID))
     return;
 
-  auto pPhysics = GetWorld()->GetModule<ezPhysicsWorldModuleInterface>();
-  if (pPhysics == nullptr)
+  auto pNavGeo = GetWorld()->GetOrCreateModule<ezNavmeshGeoWorldModuleInterface>();
+  if (pNavGeo == nullptr)
     return;
 
   for (auto& nm : m_WorldNavMeshes)
@@ -136,7 +136,7 @@ void ezAiNavMeshWorldModule::Update(const UpdateContext& ctxt)
 
     m_pGenerateSectorTask->m_pWorldNavMesh = nm.Value();
     m_pGenerateSectorTask->m_SectorID = sectorID;
-    m_pGenerateSectorTask->m_pPhysics = pPhysics;
+    m_pGenerateSectorTask->m_pNavGeo = pNavGeo;
 
     m_GenerateSectorTaskID = ezTaskSystem::StartSingleTask(m_pGenerateSectorTask, ezTaskPriority::LongRunning);
 

--- a/Code/EnginePlugins/AiPlugin/Navigation/NavMesh.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation/NavMesh.h
@@ -14,7 +14,7 @@
 
 using ezDataBuffer = ezDynamicArray<ezUInt8>;
 
-class ezPhysicsWorldModuleInterface;
+class ezNavmeshGeoWorldModuleInterface;
 class dtNavMesh;
 
 /// \brief Stores indices for a triangle.
@@ -112,7 +112,7 @@ public:
   void FinalizeSectorUpdates();
 
   SectorID RetrieveRequestedSector();
-  void BuildSector(SectorID sectorID, const ezPhysicsWorldModuleInterface* pPhysics);
+  void BuildSector(SectorID sectorID, const ezNavmeshGeoWorldModuleInterface* pGeo);
 
   const dtNavMesh* GetDetourNavMesh() const { return m_pNavMesh; }
 

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -43,19 +43,6 @@ ezCVarInt cvar_FmodOcclusionNumRays("Fmod.Occlusion.NumRays", 2, ezCVarFlags::De
 static ezVec3 s_InSpherePositions[32];
 static bool s_bInSpherePositionsInitialized = false;
 
-struct ezFmodEventComponentManager::OcclusionState
-{
-  ezFmodEventComponent* m_pComponent = nullptr;
-  ezFmodParameterId m_OcclusionParamId;
-  ezUInt32 m_uiRaycastHits = 0;
-  ezUInt8 m_uiNextRayIndex = 0;
-  ezUInt8 m_uiNumUsedRays = 0;
-  float m_fRadius = 0.0f;
-  float m_fLastOcclusionValue = -1.0f;
-
-  float GetOcclusionValue(float fThreshold) const { return ezMath::Clamp((m_fLastOcclusionValue - fThreshold) / ezMath::Max(1.0f - fThreshold, 0.0001f), 0.0f, 1.0f); }
-};
-
 ezFmodEventComponentManager::ezFmodEventComponentManager(ezWorld* pWorld)
   : ezComponentManager(pWorld)
 {

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.h
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.h
@@ -15,6 +15,7 @@ private:
 };
 
 class ezPhysicsWorldModuleInterface;
+struct ezMsgSetFloatParameter;
 
 class ezFmodEventComponentManager : public ezComponentManager<class ezFmodEventComponent, ezBlockStorageType::FreeList>
 {
@@ -27,7 +28,19 @@ public:
 private:
   friend class ezFmodEventComponent;
 
-  struct OcclusionState;
+  struct OcclusionState
+  {
+    ezFmodEventComponent* m_pComponent = nullptr;
+    ezFmodParameterId m_OcclusionParamId;
+    ezUInt32 m_uiRaycastHits = 0;
+    ezUInt8 m_uiNextRayIndex = 0;
+    ezUInt8 m_uiNumUsedRays = 0;
+    float m_fRadius = 0.0f;
+    float m_fLastOcclusionValue = -1.0f;
+
+    float GetOcclusionValue(float fThreshold) const { return ezMath::Clamp((m_fLastOcclusionValue - fThreshold) / ezMath::Max(1.0f - fThreshold, 0.0001f), 0.0f, 1.0f); }
+  };
+
   ezDynamicArray<OcclusionState> m_OcclusionStates;
 
   ezUInt32 AddOcclusionState(ezFmodEventComponent* pComponent, ezFmodParameterId occlusionParamId, float fRadius);

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -365,7 +365,7 @@ void ezJoltWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_res
   }
 }
 
-void ezJoltWorldModule::QueryGeometryInBox(const ezPhysicsQueryParameters& params, ezBoundingBox box, ezDynamicArray<ezPhysicsTriangle>& out_triangles) const
+void ezJoltWorldModule::QueryGeometryInBox(const ezPhysicsQueryParameters& params, ezBoundingBox box, ezDynamicArray<ezNavmeshTriangle>& out_triangles) const
 {
   JPH::AABox aabb;
   aabb.mMin = ezJoltConversionUtils::ToVec3(box.m_vMin);

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -1107,10 +1107,10 @@ ezJoltNavmeshGeoWorldModule::ezJoltNavmeshGeoWorldModule(ezWorld* pWorld)
   m_pJoltModule = pWorld->GetOrCreateModule<ezJoltWorldModule>();
 }
 
-void ezJoltNavmeshGeoWorldModule::RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_Triangles) const
+void ezJoltNavmeshGeoWorldModule::RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_triangles) const
 {
   const ezPhysicsQueryParameters params(uiCollisionLayer, ezPhysicsShapeType::Static);
-  m_pJoltModule->QueryGeometryInBox(params, box, out_Triangles);
+  m_pJoltModule->QueryGeometryInBox(params, box, out_triangles);
 }
 
 EZ_STATICLINK_FILE(JoltPlugin, JoltPlugin_System_JoltWorldModule);

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -1093,4 +1093,24 @@ void ezJoltWorldModule::DebugDrawGeometry(const ezVec3& vCenter, float fRadius, 
   }
 }
 
+//////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_IMPLEMENT_WORLD_MODULE(ezJoltNavmeshGeoWorldModule);
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltNavmeshGeoWorldModule, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE
+// clang-format on
+
+ezJoltNavmeshGeoWorldModule::ezJoltNavmeshGeoWorldModule(ezWorld* pWorld)
+  : ezNavmeshGeoWorldModuleInterface(pWorld)
+{
+  m_pJoltModule = pWorld->GetOrCreateModule<ezJoltWorldModule>();
+}
+
+void ezJoltNavmeshGeoWorldModule::RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_Triangles) const
+{
+  const ezPhysicsQueryParameters params(uiCollisionLayer, ezPhysicsShapeType::Static);
+  m_pJoltModule->QueryGeometryInBox(params, box, out_Triangles);
+}
+
 EZ_STATICLINK_FILE(JoltPlugin, JoltPlugin_System_JoltWorldModule);

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Interfaces/NavmeshGeoWorldModule.h>
 #include <Core/Interfaces/PhysicsWorldModule.h>
 #include <Core/World/Declarations.h>
 #include <Core/World/WorldModule.h>
@@ -73,8 +74,6 @@ public:
 
   virtual void QueryShapesInSphere(ezPhysicsOverlapResultArray& out_results, float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const override;
 
-  virtual void QueryGeometryInBox(const ezPhysicsQueryParameters& params, ezBoundingBox box, ezDynamicArray<ezPhysicsTriangle>& out_triangles) const override;
-
   virtual void AddStaticCollisionBox(ezGameObject* pObject, ezVec3 vBoxSize) override;
 
   virtual void AddFixedJointComponent(ezGameObject* pOwner, const ezPhysicsWorldModuleInterface::FixedJointConfig& cfg) override;
@@ -115,6 +114,7 @@ public:
 
   ezSet<ezComponentHandle> m_BreakableConstraints;
 
+  void QueryGeometryInBox(const ezPhysicsQueryParameters& params, ezBoundingBox box, ezDynamicArray<ezNavmeshTriangle>& out_triangles) const;
 
 private:
   bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
@@ -213,4 +213,20 @@ private:
 
   ezHybridArray<ezTime, 4> m_UpdateSteps;
   ezHybridArray<ezJoltCharacterControllerComponent*, 4> m_ActiveCharacters;
+};
+
+/// \brief Implementation of the ezNavmeshGeoWorldModuleInterface that uses Jolt physics to retrieve the geometry
+/// from which to generate a navmesh.
+class EZ_JOLTPLUGIN_DLL ezJoltNavmeshGeoWorldModule : public ezNavmeshGeoWorldModuleInterface
+{
+  EZ_DECLARE_WORLD_MODULE();
+  EZ_ADD_DYNAMIC_REFLECTION(ezJoltNavmeshGeoWorldModule, ezNavmeshGeoWorldModuleInterface);
+
+public:
+  ezJoltNavmeshGeoWorldModule(ezWorld* pWorld);
+
+  virtual void RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_Triangles) const override;
+
+private:
+  ezJoltWorldModule* m_pJoltModule = nullptr;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -225,7 +225,7 @@ class EZ_JOLTPLUGIN_DLL ezJoltNavmeshGeoWorldModule : public ezNavmeshGeoWorldMo
 public:
   ezJoltNavmeshGeoWorldModule(ezWorld* pWorld);
 
-  virtual void RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_Triangles) const override;
+  virtual void RetrieveGeometryInArea(ezUInt32 uiCollisionLayer, const ezBoundingBox& box, ezDynamicArray<ezNavmeshTriangle>& out_triangles) const override;
 
 private:
   ezJoltWorldModule* m_pJoltModule = nullptr;


### PR DESCRIPTION
So far the runtime navmesh was just generated from the physics world.
There is now a new world module, that is used to request the geometry from which to build the navmesh.
If Jolt is used, it automatically provides such a world module implementation, that redirects to the Jolt physics data.

If Jolt isn't used (e.g. in a 2D game) or you want to customize this part, you can now also implement a custom world module for this interface and provide your own geometry.

Also fixed an issue with generating navmeshes for large player radii and a link issue in the Fmod plugin.