### PR TITLE
Adding parent mapping support for action maps

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -195,12 +195,10 @@ void ezProjectActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hPluginSelection);
 }
 
-void ezProjectActions::MapActions(ezStringView sMapping)
+void ezProjectActions::MapActions(ezStringView sMapping, const ezBitflags<ezStandardMenuTypes> menus)
 {
   ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
   EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);
-
-  ezStringBuilder sPath;
 
   // Add categories
   pMap->MapAction(s_hCatProjectGeneral, "G.Project", 1.0f);
@@ -216,12 +214,12 @@ void ezProjectActions::MapActions(ezStringView sMapping)
   pMap->MapAction(s_hCatProjectSettings, "G.Project.Config", 1.0f);
   pMap->MapAction(s_hCatPluginSettings, "G.Project.Config", 1.0f);
 
-  if (pMap->SearchPathForAction("G.File", sPath).Succeeded())
+  if (menus.IsSet(ezStandardMenuTypes::File))
   {
-    pMap->MapAction(s_hCatFilesGeneral, sPath, 1.0f);
-    pMap->MapAction(s_hCatFileCommon, sPath, 2.0f);
-    pMap->MapAction(s_hCatAssetDoc, sPath, 3.0f);
-    pMap->MapAction(s_hCatFileSpecial, sPath, 4.0f);
+    pMap->MapAction(s_hCatFilesGeneral, "G.File", 1.0f);
+    pMap->MapAction(s_hCatFileCommon, "G.File", 2.0f);
+    pMap->MapAction(s_hCatAssetDoc, "G.File", 3.0f);
+    pMap->MapAction(s_hCatFileSpecial, "G.File", 4.0f);
   }
 
   // Add actions
@@ -260,16 +258,16 @@ void ezProjectActions::MapActions(ezStringView sMapping)
   pMap->MapAction(s_hShortcutEditor, "G.Editor.Settings", 1.0f);
   pMap->MapAction(s_hPreferencesDlg, "G.Editor.Settings", 2.0f);
 
-  if (pMap->SearchPathForAction("G.Help", sPath).Succeeded())
+  if (menus.IsSet(ezStandardMenuTypes::Help))
   {
-    pMap->MapAction(s_hDocsAndCommunity, sPath, 0.0f);
+    pMap->MapAction(s_hDocsAndCommunity, "G.Help", 0.0f);
   }
 
-  if (pMap->SearchPathForAction("G.File.Common", sPath).Succeeded())
+  if (menus.IsSet(ezStandardMenuTypes::File))
   {
-    pMap->MapAction(s_hCreateDocument, sPath, 1.0f);
-    pMap->MapAction(s_hOpenDocument, sPath, 2.0f);
-    pMap->MapAction(s_hRecentDocuments, sPath, 3.0f);
+    pMap->MapAction(s_hCreateDocument, "G.File", 1.0f);
+    pMap->MapAction(s_hOpenDocument, "G.File", 2.0f);
+    pMap->MapAction(s_hRecentDocuments, "G.File", 3.0f);
   }
 }
 

--- a/Code/Editor/EditorFramework/Actions/ProjectActions.h
+++ b/Code/Editor/EditorFramework/Actions/ProjectActions.h
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <GuiFoundation/Action/BaseActions.h>
+#include <GuiFoundation/Action/StandardMenus.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
 
 class ezCppSettings;
@@ -13,7 +14,7 @@ public:
   static void RegisterActions();
   static void UnregisterActions();
 
-  static void MapActions(ezStringView sMapping);
+  static void MapActions(ezStringView sMapping, const ezBitflags<ezStandardMenuTypes> menus = ezStandardMenuTypes::Default);
 
   static ezActionDescriptorHandle s_hCatProjectGeneral;
   static ezActionDescriptorHandle s_hCatProjectAssets;

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -104,7 +104,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     // All asset menu bar mappings should derive from this to allow for actions to be defined that show up in every asset document editor's menu bar.
     {
       const char* szMenuBar = "AssetMenuBar";
-      ezActionMapManager::RegisterActionMap(szMenuBar).AssertSuccess();
+      ezActionMapManager::RegisterActionMap(szMenuBar);
       ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
       ezProjectActions::MapActions(szMenuBar);
       ezDocumentActions::MapMenuActions(szMenuBar);
@@ -116,7 +116,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     // All asset toolbar mappings should derive from this to allow for actions to be defined that show up in every asset document editor's tool bar.
     {
       const char* szToolbar = "AssetToolbar";
-      ezActionMapManager::RegisterActionMap(szToolbar).AssertSuccess();
+      ezActionMapManager::RegisterActionMap(szToolbar);
 
       ezDocumentActions::MapToolbarActions(szToolbar);
       ezCommandHistoryActions::MapActions(szToolbar, "");
@@ -126,19 +126,19 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     // Default Asset View Toolbar
     // All asset view toolbar mappings should derive from this or its derived "SimpleAssetViewToolbar" to allow for actions to be defined that show up in every asset document editor's view toolbar.
     {
-      ezActionMapManager::RegisterActionMap("AssetViewToolbar").AssertSuccess();
+      ezActionMapManager::RegisterActionMap("AssetViewToolbar");
       // Convenience mapping that adds the most common view settings:
       const char* szSimpleViewToolbar = "SimpleAssetViewToolbar";
-      ezActionMapManager::RegisterActionMap(szSimpleViewToolbar, "AssetViewToolbar").AssertSuccess();
+      ezActionMapManager::RegisterActionMap(szSimpleViewToolbar, "AssetViewToolbar");
       ezViewActions::MapToolbarActions(szSimpleViewToolbar, ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
       ezViewLightActions::MapToolbarActions(szSimpleViewToolbar);
     }
 
-    ezActionMapManager::RegisterActionMap("SettingsTabMenuBar").IgnoreResult();
+    ezActionMapManager::RegisterActionMap("SettingsTabMenuBar");
     ezStandardMenus::MapActions("SettingsTabMenuBar", ezStandardMenuTypes::Default);
     ezProjectActions::MapActions("SettingsTabMenuBar");
 
-    ezActionMapManager::RegisterActionMap("AssetBrowserToolBar").IgnoreResult();
+    ezActionMapManager::RegisterActionMap("AssetBrowserToolBar");
     ezAssetActions::MapToolBarActions("AssetBrowserToolBar", false);
 
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezFileBrowserAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtFilePropertyWidget(); });

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -57,6 +57,8 @@
 #include <Foundation/Reflection/Implementation/PropertyAttributes.h>
 #include <Foundation/Threading/TaskSystem.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
+#include <GuiFoundation/Action/CommandHistoryActions.h>
+#include <GuiFoundation/Action/DocumentActions.h>
 #include <GuiFoundation/Action/StandardMenus.h>
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
@@ -97,6 +99,40 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezTransformGizmoActions::RegisterActions();
     ezTranslateGizmoAction::RegisterActions();
     ezCommonAssetActions::RegisterActions();
+
+    // Default Asset Menu Bar
+    // All asset menu bar mappings should derive from this to allow for actions to be defined that show up in every asset document editor's menu bar.
+    {
+      const char* szMenuBar = "AssetMenuBar";
+      ezActionMapManager::RegisterActionMap(szMenuBar).AssertSuccess();
+      ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
+      ezProjectActions::MapActions(szMenuBar);
+      ezDocumentActions::MapMenuActions(szMenuBar);
+      ezAssetActions::MapMenuActions(szMenuBar);
+      ezCommandHistoryActions::MapActions(szMenuBar);
+    }
+
+    // Default Asset Toolbar
+    // All asset toolbar mappings should derive from this to allow for actions to be defined that show up in every asset document editor's tool bar.
+    {
+      const char* szToolbar = "AssetToolbar";
+      ezActionMapManager::RegisterActionMap(szToolbar).AssertSuccess();
+
+      ezDocumentActions::MapToolbarActions(szToolbar);
+      ezCommandHistoryActions::MapActions(szToolbar, "");
+      ezAssetActions::MapToolBarActions(szToolbar, true);
+    }
+
+    // Default Asset View Toolbar
+    // All asset view toolbar mappings should derive from this or its derived "SimpleAssetViewToolbar" to allow for actions to be defined that show up in every asset document editor's view toolbar.
+    {
+      ezActionMapManager::RegisterActionMap("AssetViewToolbar").AssertSuccess();
+      // Convenience mapping that adds the most common view settings:
+      const char* szSimpleViewToolbar = "SimpleAssetViewToolbar";
+      ezActionMapManager::RegisterActionMap(szSimpleViewToolbar, "AssetViewToolbar").AssertSuccess();
+      ezViewActions::MapToolbarActions(szSimpleViewToolbar, ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
+      ezViewLightActions::MapToolbarActions(szSimpleViewToolbar);
+    }
 
     ezActionMapManager::RegisterActionMap("SettingsTabMenuBar").IgnoreResult();
     ezStandardMenus::MapActions("SettingsTabMenuBar", ezStandardMenuTypes::Default);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -35,13 +35,13 @@ static void ConfigureAnimationGraphAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationGraphAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimationGraphAssetMenuBar", "AssetMenuBar");
     ezEditActions::MapActions("AnimationGraphAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationGraphAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimationGraphAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -53,12 +53,12 @@ static void ConfigureTexture2DAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("TextureAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("TextureAssetToolBar", "AssetToolbar");
     ezTextureAssetActions::MapToolbarActions("TextureAssetToolBar");
   }
 }
@@ -69,12 +69,12 @@ static void ConfigureTextureCubeAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureCubeAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("TextureCubeAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureCubeAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("TextureCubeAssetToolBar", "AssetToolbar");
     ezTextureAssetActions::MapToolbarActions("TextureCubeAssetToolBar");
   }
 }
@@ -87,12 +87,12 @@ static void ConfigureLUTAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("LUTAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("LUTAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("LUTAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("LUTAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -102,14 +102,14 @@ static void ConfigureMaterialAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("MaterialAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("MaterialAssetMenuBar", "AssetMenuBar");
     ezDocumentActions::MapToolsActions("MaterialAssetMenuBar");
     ezEditActions::MapActions("MaterialAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MaterialAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("MaterialAssetToolBar", "AssetToolbar");
 
     ezMaterialAssetActions::RegisterActions();
     ezMaterialAssetActions::MapToolbarActions("MaterialAssetToolBar");
@@ -120,7 +120,7 @@ static void ConfigureMaterialAsset()
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MaterialAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("MaterialAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -128,13 +128,13 @@ static void ConfigureRenderPipelineAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("RenderPipelineAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("RenderPipelineAssetMenuBar", "AssetMenuBar");
     ezEditActions::MapActions("RenderPipelineAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("RenderPipelineAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("RenderPipelineAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -144,18 +144,18 @@ static void ConfigureMeshAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("MeshAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("MeshAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MeshAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("MeshAssetToolBar", "AssetToolbar");
     ezCommonAssetActions::MapToolbarActions("MeshAssetToolBar", ezCommonAssetUiState::Grid);
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MeshAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("MeshAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -163,13 +163,13 @@ static void ConfigureSurfaceAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("SurfaceAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("SurfaceAssetMenuBar", "AssetMenuBar");
     ezDocumentActions::MapToolsActions("SurfaceAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("SurfaceAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("SurfaceAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -177,13 +177,13 @@ static void ConfigureCollectionAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("CollectionAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("CollectionAssetMenuBar", "AssetMenuBar");
     ezDocumentActions::MapToolsActions("CollectionAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("CollectionAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("CollectionAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -191,13 +191,13 @@ static void ConfigureColorGradientAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("ColorGradientAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("ColorGradientAssetMenuBar", "AssetMenuBar");
     ezDocumentActions::MapToolsActions("ColorGradientAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("ColorGradientAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("ColorGradientAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -205,13 +205,13 @@ static void ConfigureCurve1DAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("Curve1DAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("Curve1DAssetMenuBar", "AssetMenuBar");
     ezDocumentActions::MapToolsActions("Curve1DAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("Curve1DAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("Curve1DAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -219,7 +219,7 @@ static void ConfigurePropertyAnimAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("PropertyAnimAssetMenuBar", "AssetMenuBar");
     ezStandardMenus::MapActions("PropertyAnimAssetMenuBar", ezStandardMenuTypes::Scene | ezStandardMenuTypes::View);
     ezDocumentActions::MapToolsActions("PropertyAnimAssetMenuBar");
     ezGameObjectSelectionActions::MapActions("PropertyAnimAssetMenuBar");
@@ -231,7 +231,7 @@ static void ConfigurePropertyAnimAsset()
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("PropertyAnimAssetToolBar", "AssetToolbar");
     ezGameObjectContextActions::MapToolbarActions("PropertyAnimAssetToolBar");
     ezGameObjectDocumentActions::MapToolbarActions("PropertyAnimAssetToolBar");
     ezTransformGizmoActions::MapToolbarActions("PropertyAnimAssetToolBar");
@@ -239,14 +239,14 @@ static void ConfigurePropertyAnimAsset()
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAssetViewToolBar", "AssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("PropertyAnimAssetViewToolBar", "AssetViewToolbar");
     ezViewActions::MapToolbarActions("PropertyAnimAssetViewToolBar", ezViewActions::PerspectiveMode | ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
     ezQuadViewActions::MapToolbarActions("PropertyAnimAssetViewToolBar");
   }
 
   // SceneGraph Context Menu
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAsset_ScenegraphContextMenu").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("PropertyAnimAsset_ScenegraphContextMenu");
     ezGameObjectSelectionActions::MapContextMenuActions("PropertyAnimAsset_ScenegraphContextMenu");
     ezGameObjectContextActions::MapContextMenuActions("PropertyAnimAsset_ScenegraphContextMenu");
   }
@@ -258,17 +258,17 @@ static void ConfigureDecalAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("DecalAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("DecalAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("DecalAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("DecalAssetToolBar", "AssetToolbar");
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("DecalAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("DecalAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -278,18 +278,18 @@ static void ConfigureAnimationClipAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationClipAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimationClipAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationClipAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimationClipAssetToolBar", "AssetToolbar");
     ezCommonAssetActions::MapToolbarActions("AnimationClipAssetToolBar", ezCommonAssetUiState::Loop | ezCommonAssetUiState::Pause | ezCommonAssetUiState::Restart | ezCommonAssetUiState::SimulationSpeed | ezCommonAssetUiState::Grid);
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationClipAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimationClipAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -301,19 +301,19 @@ static void ConfigureSkeletonAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("SkeletonAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("SkeletonAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("SkeletonAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("SkeletonAssetToolBar", "AssetToolbar");
     ezCommonAssetActions::MapToolbarActions("SkeletonAssetToolBar", ezCommonAssetUiState::Grid);
     ezSkeletonActions::MapActions("SkeletonAssetToolBar");
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("SkeletonAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("SkeletonAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -321,18 +321,18 @@ static void ConfigureAnimatedMeshAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetToolBar", "AssetToolbar");
     ezCommonAssetActions::MapToolbarActions("AnimatedMeshAssetToolBar", ezCommonAssetUiState::Grid);
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -340,17 +340,17 @@ static void ConfigureImageDataAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("ImageDataAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("ImageDataAssetMenuBar", "AssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("ImageDataAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("ImageDataAssetToolBar", "AssetToolbar");
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("ImageDataAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("ImageDataAssetViewToolBar", "SimpleAssetViewToolbar");
   }
 }
 
@@ -358,26 +358,26 @@ static void ConfigureStateMachineAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("StateMachineAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("StateMachineAssetMenuBar", "AssetMenuBar");
     ezEditActions::MapActions("StateMachineAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("StateMachineAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("StateMachineAssetToolBar", "AssetToolbar");
   }
 }
 static void ConfigureBlackboardTemplateAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetMenuBar", "AssetMenuBar");
     ezEditActions::MapActions("BlackboardTemplateAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetToolBar", "AssetToolbar");
   }
 }
 
@@ -385,13 +385,13 @@ static void ConfigureCustomDataAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("CustomDataAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("CustomDataAssetMenuBar", "AssetMenuBar");
     ezDocumentActions::MapToolsActions("CustomDataAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("CustomDataAssetToolBar", "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("CustomDataAssetToolBar", "AssetToolbar");
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -35,22 +35,13 @@ static void ConfigureAnimationGraphAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationGraphAssetMenuBar").AssertSuccess();
-
-    ezStandardMenus::MapActions("AnimationGraphAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("AnimationGraphAssetMenuBar");
-    ezDocumentActions::MapMenuActions("AnimationGraphAssetMenuBar");
-    ezAssetActions::MapMenuActions("AnimationGraphAssetMenuBar");
-    ezCommandHistoryActions::MapActions("AnimationGraphAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("AnimationGraphAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezEditActions::MapActions("AnimationGraphAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationGraphAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("AnimationGraphAssetToolBar");
-    ezCommandHistoryActions::MapActions("AnimationGraphAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("AnimationGraphAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("AnimationGraphAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -62,20 +53,12 @@ static void ConfigureTexture2DAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("TextureAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("TextureAssetMenuBar");
-    ezDocumentActions::MapMenuActions("TextureAssetMenuBar");
-    ezAssetActions::MapMenuActions("TextureAssetMenuBar");
-    ezCommandHistoryActions::MapActions("TextureAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("TextureAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("TextureAssetToolBar");
-    ezCommandHistoryActions::MapActions("TextureAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("TextureAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("TextureAssetToolBar", "AssetToolbar").AssertSuccess();
     ezTextureAssetActions::MapToolbarActions("TextureAssetToolBar");
   }
 }
@@ -86,20 +69,12 @@ static void ConfigureTextureCubeAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureCubeAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("TextureCubeAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("TextureCubeAssetMenuBar");
-    ezDocumentActions::MapMenuActions("TextureCubeAssetMenuBar");
-    ezAssetActions::MapMenuActions("TextureCubeAssetMenuBar");
-    ezCommandHistoryActions::MapActions("TextureCubeAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("TextureCubeAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("TextureCubeAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("TextureCubeAssetToolBar");
-    ezCommandHistoryActions::MapActions("TextureCubeAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("TextureCubeAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("TextureCubeAssetToolBar", "AssetToolbar").AssertSuccess();
     ezTextureAssetActions::MapToolbarActions("TextureCubeAssetToolBar");
   }
 }
@@ -112,20 +87,12 @@ static void ConfigureLUTAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("LUTAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("LUTAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("LUTAssetMenuBar");
-    ezDocumentActions::MapMenuActions("LUTAssetMenuBar");
-    ezAssetActions::MapMenuActions("LUTAssetMenuBar");
-    ezCommandHistoryActions::MapActions("LUTAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("LUTAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("LUTAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("LUTAssetToolBar");
-    ezCommandHistoryActions::MapActions("LUTAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("LUTAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("LUTAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -135,22 +102,14 @@ static void ConfigureMaterialAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("MaterialAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("MaterialAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("MaterialAssetMenuBar");
-    ezDocumentActions::MapMenuActions("MaterialAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("MaterialAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezDocumentActions::MapToolsActions("MaterialAssetMenuBar");
-    ezAssetActions::MapMenuActions("MaterialAssetMenuBar");
-    ezCommandHistoryActions::MapActions("MaterialAssetMenuBar");
     ezEditActions::MapActions("MaterialAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MaterialAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("MaterialAssetToolBar");
-    ezCommandHistoryActions::MapActions("MaterialAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("MaterialAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("MaterialAssetToolBar", "AssetToolbar").AssertSuccess();
 
     ezMaterialAssetActions::RegisterActions();
     ezMaterialAssetActions::MapToolbarActions("MaterialAssetToolBar");
@@ -161,9 +120,7 @@ static void ConfigureMaterialAsset()
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MaterialAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("MaterialAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("MaterialAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("MaterialAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -171,22 +128,13 @@ static void ConfigureRenderPipelineAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("RenderPipelineAssetMenuBar").AssertSuccess();
-
-    ezStandardMenus::MapActions("RenderPipelineAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("RenderPipelineAssetMenuBar");
-    ezDocumentActions::MapMenuActions("RenderPipelineAssetMenuBar");
-    ezAssetActions::MapMenuActions("RenderPipelineAssetMenuBar");
-    ezCommandHistoryActions::MapActions("RenderPipelineAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("RenderPipelineAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezEditActions::MapActions("RenderPipelineAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("RenderPipelineAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("RenderPipelineAssetToolBar");
-    ezCommandHistoryActions::MapActions("RenderPipelineAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("RenderPipelineAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("RenderPipelineAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -196,28 +144,18 @@ static void ConfigureMeshAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("MeshAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("MeshAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("MeshAssetMenuBar");
-    ezDocumentActions::MapMenuActions("MeshAssetMenuBar");
-    ezAssetActions::MapMenuActions("MeshAssetMenuBar");
-    ezCommandHistoryActions::MapActions("MeshAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("MeshAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MeshAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("MeshAssetToolBar");
-    ezCommandHistoryActions::MapActions("MeshAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("MeshAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("MeshAssetToolBar", "AssetToolbar").AssertSuccess();
     ezCommonAssetActions::MapToolbarActions("MeshAssetToolBar", ezCommonAssetUiState::Grid);
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("MeshAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("MeshAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("MeshAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("MeshAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -225,21 +163,13 @@ static void ConfigureSurfaceAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("SurfaceAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("SurfaceAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("SurfaceAssetMenuBar");
-    ezDocumentActions::MapMenuActions("SurfaceAssetMenuBar");
-    ezAssetActions::MapMenuActions("SurfaceAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("SurfaceAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezDocumentActions::MapToolsActions("SurfaceAssetMenuBar");
-    ezCommandHistoryActions::MapActions("SurfaceAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("SurfaceAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("SurfaceAssetToolBar");
-    ezCommandHistoryActions::MapActions("SurfaceAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("SurfaceAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("SurfaceAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -247,21 +177,13 @@ static void ConfigureCollectionAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("CollectionAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("CollectionAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("CollectionAssetMenuBar");
-    ezDocumentActions::MapMenuActions("CollectionAssetMenuBar");
-    ezAssetActions::MapMenuActions("CollectionAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("CollectionAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezDocumentActions::MapToolsActions("CollectionAssetMenuBar");
-    ezCommandHistoryActions::MapActions("CollectionAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("CollectionAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("CollectionAssetToolBar");
-    ezCommandHistoryActions::MapActions("CollectionAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("CollectionAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("CollectionAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -269,21 +191,13 @@ static void ConfigureColorGradientAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("ColorGradientAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("ColorGradientAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("ColorGradientAssetMenuBar");
-    ezDocumentActions::MapMenuActions("ColorGradientAssetMenuBar");
-    ezAssetActions::MapMenuActions("ColorGradientAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("ColorGradientAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezDocumentActions::MapToolsActions("ColorGradientAssetMenuBar");
-    ezCommandHistoryActions::MapActions("ColorGradientAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("ColorGradientAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("ColorGradientAssetToolBar");
-    ezCommandHistoryActions::MapActions("ColorGradientAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("ColorGradientAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("ColorGradientAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -291,21 +205,13 @@ static void ConfigureCurve1DAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("Curve1DAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("Curve1DAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("Curve1DAssetMenuBar");
-    ezDocumentActions::MapMenuActions("Curve1DAssetMenuBar");
-    ezAssetActions::MapMenuActions("Curve1DAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("Curve1DAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezDocumentActions::MapToolsActions("Curve1DAssetMenuBar");
-    ezCommandHistoryActions::MapActions("Curve1DAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("Curve1DAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("Curve1DAssetToolBar");
-    ezCommandHistoryActions::MapActions("Curve1DAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("Curve1DAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("Curve1DAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -313,13 +219,9 @@ static void ConfigurePropertyAnimAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("PropertyAnimAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Scene | ezStandardMenuTypes::View);
-    ezProjectActions::MapActions("PropertyAnimAssetMenuBar");
-    ezDocumentActions::MapMenuActions("PropertyAnimAssetMenuBar");
-    ezAssetActions::MapMenuActions("PropertyAnimAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("PropertyAnimAssetMenuBar", "AssetMenuBar").AssertSuccess();
+    ezStandardMenus::MapActions("PropertyAnimAssetMenuBar", ezStandardMenuTypes::Scene | ezStandardMenuTypes::View);
     ezDocumentActions::MapToolsActions("PropertyAnimAssetMenuBar");
-    ezCommandHistoryActions::MapActions("PropertyAnimAssetMenuBar");
     ezGameObjectSelectionActions::MapActions("PropertyAnimAssetMenuBar");
     ezGameObjectDocumentActions::MapMenuActions("PropertyAnimAssetMenuBar");
     ezGameObjectDocumentActions::MapMenuSimulationSpeed("PropertyAnimAssetMenuBar");
@@ -329,10 +231,7 @@ static void ConfigurePropertyAnimAsset()
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("PropertyAnimAssetToolBar");
-    ezCommandHistoryActions::MapActions("PropertyAnimAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("PropertyAnimAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("PropertyAnimAssetToolBar", "AssetToolbar").AssertSuccess();
     ezGameObjectContextActions::MapToolbarActions("PropertyAnimAssetToolBar");
     ezGameObjectDocumentActions::MapToolbarActions("PropertyAnimAssetToolBar");
     ezTransformGizmoActions::MapToolbarActions("PropertyAnimAssetToolBar");
@@ -340,7 +239,7 @@ static void ConfigurePropertyAnimAsset()
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("PropertyAnimAssetViewToolBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap("PropertyAnimAssetViewToolBar", "AssetViewToolbar").AssertSuccess();
     ezViewActions::MapToolbarActions("PropertyAnimAssetViewToolBar", ezViewActions::PerspectiveMode | ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
     ezQuadViewActions::MapToolbarActions("PropertyAnimAssetViewToolBar");
   }
@@ -359,27 +258,17 @@ static void ConfigureDecalAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("DecalAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("DecalAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("DecalAssetMenuBar");
-    ezDocumentActions::MapMenuActions("DecalAssetMenuBar");
-    ezAssetActions::MapMenuActions("DecalAssetMenuBar");
-    ezCommandHistoryActions::MapActions("DecalAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("DecalAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("DecalAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("DecalAssetToolBar");
-    ezCommandHistoryActions::MapActions("DecalAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("DecalAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("DecalAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("DecalAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("DecalAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("DecalAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("DecalAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -389,28 +278,18 @@ static void ConfigureAnimationClipAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationClipAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("AnimationClipAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("AnimationClipAssetMenuBar");
-    ezDocumentActions::MapMenuActions("AnimationClipAssetMenuBar");
-    ezAssetActions::MapMenuActions("AnimationClipAssetMenuBar");
-    ezCommandHistoryActions::MapActions("AnimationClipAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("AnimationClipAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationClipAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("AnimationClipAssetToolBar");
-    ezCommandHistoryActions::MapActions("AnimationClipAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("AnimationClipAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("AnimationClipAssetToolBar", "AssetToolbar").AssertSuccess();
     ezCommonAssetActions::MapToolbarActions("AnimationClipAssetToolBar", ezCommonAssetUiState::Loop | ezCommonAssetUiState::Pause | ezCommonAssetUiState::Restart | ezCommonAssetUiState::SimulationSpeed | ezCommonAssetUiState::Grid);
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimationClipAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("AnimationClipAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("AnimationClipAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("AnimationClipAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -422,29 +301,19 @@ static void ConfigureSkeletonAsset()
 
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("SkeletonAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("SkeletonAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("SkeletonAssetMenuBar");
-    ezDocumentActions::MapMenuActions("SkeletonAssetMenuBar");
-    ezAssetActions::MapMenuActions("SkeletonAssetMenuBar");
-    ezCommandHistoryActions::MapActions("SkeletonAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("SkeletonAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("SkeletonAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("SkeletonAssetToolBar");
-    ezCommandHistoryActions::MapActions("SkeletonAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("SkeletonAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("SkeletonAssetToolBar", "AssetToolbar").AssertSuccess();
     ezCommonAssetActions::MapToolbarActions("SkeletonAssetToolBar", ezCommonAssetUiState::Grid);
     ezSkeletonActions::MapActions("SkeletonAssetToolBar");
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("SkeletonAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("SkeletonAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("SkeletonAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("SkeletonAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -452,28 +321,18 @@ static void ConfigureAnimatedMeshAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("AnimatedMeshAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("AnimatedMeshAssetMenuBar");
-    ezDocumentActions::MapMenuActions("AnimatedMeshAssetMenuBar");
-    ezAssetActions::MapMenuActions("AnimatedMeshAssetMenuBar");
-    ezCommandHistoryActions::MapActions("AnimatedMeshAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("AnimatedMeshAssetToolBar");
-    ezCommandHistoryActions::MapActions("AnimatedMeshAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("AnimatedMeshAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetToolBar", "AssetToolbar").AssertSuccess();
     ezCommonAssetActions::MapToolbarActions("AnimatedMeshAssetToolBar", ezCommonAssetUiState::Grid);
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("AnimatedMeshAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("AnimatedMeshAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("AnimatedMeshAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -481,27 +340,17 @@ static void ConfigureImageDataAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("ImageDataAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("ImageDataAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("ImageDataAssetMenuBar");
-    ezDocumentActions::MapMenuActions("ImageDataAssetMenuBar");
-    ezAssetActions::MapMenuActions("ImageDataAssetMenuBar");
-    ezCommandHistoryActions::MapActions("ImageDataAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("ImageDataAssetMenuBar", "AssetMenuBar").AssertSuccess();
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("ImageDataAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("ImageDataAssetToolBar");
-    ezCommandHistoryActions::MapActions("ImageDataAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("ImageDataAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("ImageDataAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 
   // View Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("ImageDataAssetViewToolBar").AssertSuccess();
-    ezViewActions::MapToolbarActions("ImageDataAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-    ezViewLightActions::MapToolbarActions("ImageDataAssetViewToolBar");
+    ezActionMapManager::RegisterActionMap("ImageDataAssetViewToolBar", "SimpleAssetViewToolbar").AssertSuccess();
   }
 }
 
@@ -509,44 +358,26 @@ static void ConfigureStateMachineAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("StateMachineAssetMenuBar").AssertSuccess();
-
-    ezStandardMenus::MapActions("StateMachineAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("StateMachineAssetMenuBar");
-    ezDocumentActions::MapMenuActions("StateMachineAssetMenuBar");
-    ezAssetActions::MapMenuActions("StateMachineAssetMenuBar");
-    ezCommandHistoryActions::MapActions("StateMachineAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("StateMachineAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezEditActions::MapActions("StateMachineAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("StateMachineAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("StateMachineAssetToolBar");
-    ezCommandHistoryActions::MapActions("StateMachineAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("StateMachineAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("StateMachineAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 static void ConfigureBlackboardTemplateAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetMenuBar").AssertSuccess();
-
-    ezStandardMenus::MapActions("BlackboardTemplateAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("BlackboardTemplateAssetMenuBar");
-    ezDocumentActions::MapMenuActions("BlackboardTemplateAssetMenuBar");
-    ezAssetActions::MapMenuActions("BlackboardTemplateAssetMenuBar");
-    ezCommandHistoryActions::MapActions("BlackboardTemplateAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezEditActions::MapActions("BlackboardTemplateAssetMenuBar", false, false);
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("BlackboardTemplateAssetToolBar");
-    ezCommandHistoryActions::MapActions("BlackboardTemplateAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("BlackboardTemplateAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("BlackboardTemplateAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 
@@ -554,21 +385,13 @@ static void ConfigureCustomDataAsset()
 {
   // Menu Bar
   {
-    ezActionMapManager::RegisterActionMap("CustomDataAssetMenuBar").AssertSuccess();
-    ezStandardMenus::MapActions("CustomDataAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("CustomDataAssetMenuBar");
-    ezDocumentActions::MapMenuActions("CustomDataAssetMenuBar");
-    ezAssetActions::MapMenuActions("CustomDataAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("CustomDataAssetMenuBar", "AssetMenuBar").AssertSuccess();
     ezDocumentActions::MapToolsActions("CustomDataAssetMenuBar");
-    ezCommandHistoryActions::MapActions("CustomDataAssetMenuBar");
   }
 
   // Tool Bar
   {
-    ezActionMapManager::RegisterActionMap("CustomDataAssetToolBar").AssertSuccess();
-    ezDocumentActions::MapToolbarActions("CustomDataAssetToolBar");
-    ezCommandHistoryActions::MapActions("CustomDataAssetToolBar", "");
-    ezAssetActions::MapToolBarActions("CustomDataAssetToolBar", true);
+    ezActionMapManager::RegisterActionMap("CustomDataAssetToolBar", "AssetToolbar").AssertSuccess();
   }
 }
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
@@ -18,19 +18,11 @@ void OnLoadPlugin()
   // Mesh
   {
     // Menu Bar
-    ezActionMapManager::RegisterActionMap("SoundBankAssetMenuBar").IgnoreResult();
-    ezStandardMenus::MapActions("SoundBankAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-    ezProjectActions::MapActions("SoundBankAssetMenuBar");
-    ezDocumentActions::MapMenuActions("SoundBankAssetMenuBar");
-    ezAssetActions::MapMenuActions("SoundBankAssetMenuBar");
-    ezCommandHistoryActions::MapActions("SoundBankAssetMenuBar");
+    ezActionMapManager::RegisterActionMap("SoundBankAssetMenuBar", "AssetMenuBar").IgnoreResult();
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("SoundBankAssetToolBar");
-      ezCommandHistoryActions::MapActions("SoundBankAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("SoundBankAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar", "AssetToolbar").IgnoreResult();
     }
   }
 

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/EditorPluginFmod.cpp
@@ -18,11 +18,11 @@ void OnLoadPlugin()
   // Mesh
   {
     // Menu Bar
-    ezActionMapManager::RegisterActionMap("SoundBankAssetMenuBar", "AssetMenuBar").IgnoreResult();
+    ezActionMapManager::RegisterActionMap("SoundBankAssetMenuBar", "AssetMenuBar");
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("SoundBankAssetToolBar", "AssetToolbar");
     }
   }
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
@@ -28,20 +28,12 @@ void OnLoadPlugin()
 
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("JoltCollisionMeshAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("JoltCollisionMeshAssetMenuBar");
-      ezDocumentActions::MapMenuActions("JoltCollisionMeshAssetMenuBar");
-      ezAssetActions::MapMenuActions("JoltCollisionMeshAssetMenuBar");
-      ezCommandHistoryActions::MapActions("JoltCollisionMeshAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetMenuBar", "AssetMenuBar").IgnoreResult();
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("JoltCollisionMeshAssetToolBar");
-      ezCommandHistoryActions::MapActions("JoltCollisionMeshAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("JoltCollisionMeshAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetToolBar", "AssetToolbar").IgnoreResult();
       ezCommonAssetActions::MapToolbarActions("JoltCollisionMeshAssetToolBar", ezCommonAssetUiState::Grid);
     }
   }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
@@ -28,12 +28,12 @@ void OnLoadPlugin()
 
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetMenuBar", "AssetMenuBar");
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("JoltCollisionMeshAssetToolBar", "AssetToolbar");
       ezCommonAssetActions::MapToolbarActions("JoltCollisionMeshAssetToolBar", ezCommonAssetUiState::Grid);
     }
   }

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
@@ -14,20 +14,12 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("KrautTreeAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("KrautTreeAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("KrautTreeAssetMenuBar");
-      ezDocumentActions::MapMenuActions("KrautTreeAssetMenuBar");
-      ezAssetActions::MapMenuActions("KrautTreeAssetMenuBar");
-      ezCommandHistoryActions::MapActions("KrautTreeAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("KrautTreeAssetMenuBar", "AssetMenuBar").IgnoreResult();
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("KrautTreeAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("KrautTreeAssetToolBar");
-      ezCommandHistoryActions::MapActions("KrautTreeAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("KrautTreeAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("KrautTreeAssetToolBar", "AssetToolbar").IgnoreResult();
     }
   }
 }

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/EditorPluginKraut.cpp
@@ -14,12 +14,12 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("KrautTreeAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("KrautTreeAssetMenuBar", "AssetMenuBar");
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("KrautTreeAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("KrautTreeAssetToolBar", "AssetToolbar");
     }
   }
 }

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
@@ -19,18 +19,18 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("ParticleEffectAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("ParticleEffectAssetMenuBar", "AssetMenuBar");
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("ParticleEffectAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("ParticleEffectAssetToolBar", "AssetToolbar");
       ezParticleActions::MapActions("ParticleEffectAssetToolBar");
     }
 
     // View Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("ParticleEffectAssetViewToolBar", "SimpleAssetViewToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("ParticleEffectAssetViewToolBar", "SimpleAssetViewToolbar");
     }
 
     ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezParticleEffectAssetDocument::PropertyMetaStateEventHandler);

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/EditorPluginParticle.cpp
@@ -19,28 +19,18 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("ParticleEffectAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("ParticleEffectAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("ParticleEffectAssetMenuBar");
-      ezDocumentActions::MapMenuActions("ParticleEffectAssetMenuBar");
-      ezAssetActions::MapMenuActions("ParticleEffectAssetMenuBar");
-      ezCommandHistoryActions::MapActions("ParticleEffectAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("ParticleEffectAssetMenuBar", "AssetMenuBar").IgnoreResult();
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("ParticleEffectAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("ParticleEffectAssetToolBar");
-      ezCommandHistoryActions::MapActions("ParticleEffectAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("ParticleEffectAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("ParticleEffectAssetToolBar", "AssetToolbar").IgnoreResult();
       ezParticleActions::MapActions("ParticleEffectAssetToolBar");
     }
 
     // View Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("ParticleEffectAssetViewToolBar").IgnoreResult();
-      ezViewActions::MapToolbarActions("ParticleEffectAssetViewToolBar", ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
-      ezViewLightActions::MapToolbarActions("ParticleEffectAssetViewToolBar");
+      ezActionMapManager::RegisterActionMap("ParticleEffectAssetViewToolBar", "SimpleAssetViewToolbar").IgnoreResult();
     }
 
     ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezParticleEffectAssetDocument::PropertyMetaStateEventHandler);

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
@@ -28,20 +28,12 @@ void OnLoadPlugin()
 
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("PxCollisionMeshAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("PxCollisionMeshAssetMenuBar");
-      ezDocumentActions::MapMenuActions("PxCollisionMeshAssetMenuBar");
-      ezAssetActions::MapMenuActions("PxCollisionMeshAssetMenuBar");
-      ezCommandHistoryActions::MapActions("PxCollisionMeshAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetMenuBar", "AssetMenuBar").IgnoreResult();
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("PxCollisionMeshAssetToolBar");
-      ezCommandHistoryActions::MapActions("PxCollisionMeshAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("PxCollisionMeshAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetToolBar", "AssetToolbar").IgnoreResult();
       ezCommonAssetActions::MapToolbarActions("PxCollisionMeshAssetToolBar", ezCommonAssetUiState::Grid);
     }
   }

--- a/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
+++ b/Code/EditorPlugins/PhysX/EditorPluginPhysX/EditorPluginPhysX.cpp
@@ -28,12 +28,12 @@ void OnLoadPlugin()
 
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetMenuBar", "AssetMenuBar");
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("PxCollisionMeshAssetToolBar", "AssetToolbar");
       ezCommonAssetActions::MapToolbarActions("PxCollisionMeshAssetToolBar", ezCommonAssetUiState::Grid);
     }
   }

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/EditorPluginProcGen.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/EditorPluginProcGen.cpp
@@ -17,14 +17,14 @@ void OnLoadPlugin()
     // Menu Bar
     {
       const char* szMenuBar = "ProcGenAssetMenuBar";
-      ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar");
       ezEditActions::MapActions(szMenuBar, false, false);
     }
 
     // Tool Bar
     {
       const char* szToolBar = "ProcGenAssetToolBar";
-      ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar");
     }
   }
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/EditorPluginProcGen.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/EditorPluginProcGen.cpp
@@ -17,24 +17,14 @@ void OnLoadPlugin()
     // Menu Bar
     {
       const char* szMenuBar = "ProcGenAssetMenuBar";
-
-      ezActionMapManager::RegisterActionMap(szMenuBar).IgnoreResult();
-      ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions(szMenuBar);
-      ezDocumentActions::MapMenuActions(szMenuBar);
-      ezAssetActions::MapMenuActions(szMenuBar);
-      ezCommandHistoryActions::MapActions(szMenuBar);
-
-      ezEditActions::MapActions("ProcGenAssetMenuBar", false, false);
+      ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar").IgnoreResult();
+      ezEditActions::MapActions(szMenuBar, false, false);
     }
 
     // Tool Bar
     {
       const char* szToolBar = "ProcGenAssetToolBar";
-      ezActionMapManager::RegisterActionMap(szToolBar).IgnoreResult();
-      ezDocumentActions::MapToolbarActions(szToolBar);
-      ezCommandHistoryActions::MapActions(szToolBar, "");
-      ezAssetActions::MapToolBarActions(szToolBar, true);
+      ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar").IgnoreResult();
     }
   }
 

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/EditorPluginRmlUi.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/EditorPluginRmlUi.cpp
@@ -15,20 +15,12 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("RmlUiAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("RmlUiAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("RmlUiAssetMenuBar");
-      ezDocumentActions::MapMenuActions("RmlUiAssetMenuBar");
-      ezAssetActions::MapMenuActions("RmlUiAssetMenuBar");
-      ezCommandHistoryActions::MapActions("RmlUiAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("RmlUiAssetMenuBar", "AssetMenuBar").IgnoreResult();
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("RmlUiAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("RmlUiAssetToolBar");
-      ezCommandHistoryActions::MapActions("RmlUiAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("RmlUiAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("RmlUiAssetToolBar", "AssetToolbar").IgnoreResult();
     }
   }
 }

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/EditorPluginRmlUi.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/EditorPluginRmlUi.cpp
@@ -15,12 +15,12 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("RmlUiAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("RmlUiAssetMenuBar", "AssetMenuBar");
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("RmlUiAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("RmlUiAssetToolBar", "AssetToolbar");
     }
   }
 }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -139,13 +139,9 @@ void OnLoadPlugin()
   const char* MenuBars[] = {"EditorPluginScene_DocumentMenuBar", "EditorPluginScene_Scene2MenuBar"};
   for (const char* szMenuBar : MenuBars)
   {
-    ezActionMapManager::RegisterActionMap(szMenuBar).AssertSuccess();
-    ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit | ezStandardMenuTypes::Scene | ezStandardMenuTypes::View);
-    ezProjectActions::MapActions(szMenuBar);
-    ezDocumentActions::MapMenuActions(szMenuBar);
-    ezAssetActions::MapMenuActions(szMenuBar);
+    ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar").AssertSuccess();
+    ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Scene | ezStandardMenuTypes::View);
     ezDocumentActions::MapToolsActions(szMenuBar);
-    ezCommandHistoryActions::MapActions(szMenuBar);
     ezTransformGizmoActions::MapMenuActions(szMenuBar);
     ezSceneGizmoActions::MapMenuActions(szMenuBar);
     ezGameObjectSelectionActions::MapActions(szMenuBar);
@@ -159,7 +155,7 @@ void OnLoadPlugin()
   // Scene2 Menu bar adjustments
   {
     ezActionMap* pMap = ezActionMapManager::GetActionMap(MenuBars[1]);
-    pMap->UnmapAction(ezDocumentActions::s_hSave, "G.File.Common").AssertSuccess();
+    pMap->HideAction(ezDocumentActions::s_hSave, "G.File.Common");
     pMap->MapAction(ezLayerActions::s_hSaveActiveLayer, "G.File.Common", 6.5f);
   }
 
@@ -168,9 +164,8 @@ void OnLoadPlugin()
   const char* ToolBars[] = {"EditorPluginScene_DocumentToolBar", "EditorPluginScene_Scene2ToolBar"};
   for (const char* szToolBar : ToolBars)
   {
-    ezActionMapManager::RegisterActionMap(szToolBar).AssertSuccess();
-    ezDocumentActions::MapToolbarActions(szToolBar);
-    ezCommandHistoryActions::MapActions(szToolBar, "");
+    ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar").AssertSuccess();
+
     ezTransformGizmoActions::MapToolbarActions(szToolBar);
     ezSceneGizmoActions::MapToolbarActions(szToolBar);
     ezGameObjectDocumentActions::MapToolbarActions(szToolBar);
@@ -179,12 +174,13 @@ void OnLoadPlugin()
   // Scene2 Tool bar adjustments
   {
     ezActionMap* pMap = ezActionMapManager::GetActionMap(ToolBars[1]);
-    pMap->UnmapAction(ezDocumentActions::s_hSave, "SaveCategory").AssertSuccess();
+    pMap->HideAction(ezDocumentActions::s_hSave, "SaveCategory");
     pMap->MapAction(ezLayerActions::s_hSaveActiveLayer, "SaveCategory", 1.0f);
+    pMap->HideAction(ezAssetActions::s_hTransformAsset, "AssetCategory");
   }
 
   // View Tool Bar
-  ezActionMapManager::RegisterActionMap("EditorPluginScene_ViewToolBar").AssertSuccess();
+  ezActionMapManager::RegisterActionMap("EditorPluginScene_ViewToolBar", "AssetViewToolbar").AssertSuccess();
   ezViewActions::MapToolbarActions("EditorPluginScene_ViewToolBar", ezViewActions::PerspectiveMode | ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
   ezQuadViewActions::MapToolbarActions("EditorPluginScene_ViewToolBar");
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -139,7 +139,7 @@ void OnLoadPlugin()
   const char* MenuBars[] = {"EditorPluginScene_DocumentMenuBar", "EditorPluginScene_Scene2MenuBar"};
   for (const char* szMenuBar : MenuBars)
   {
-    ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar");
     ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Scene | ezStandardMenuTypes::View);
     ezDocumentActions::MapToolsActions(szMenuBar);
     ezTransformGizmoActions::MapMenuActions(szMenuBar);
@@ -164,7 +164,7 @@ void OnLoadPlugin()
   const char* ToolBars[] = {"EditorPluginScene_DocumentToolBar", "EditorPluginScene_Scene2ToolBar"};
   for (const char* szToolBar : ToolBars)
   {
-    ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar").AssertSuccess();
+    ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar");
 
     ezTransformGizmoActions::MapToolbarActions(szToolBar);
     ezSceneGizmoActions::MapToolbarActions(szToolBar);
@@ -180,7 +180,7 @@ void OnLoadPlugin()
   }
 
   // View Tool Bar
-  ezActionMapManager::RegisterActionMap("EditorPluginScene_ViewToolBar", "AssetViewToolbar").AssertSuccess();
+  ezActionMapManager::RegisterActionMap("EditorPluginScene_ViewToolBar", "AssetViewToolbar");
   ezViewActions::MapToolbarActions("EditorPluginScene_ViewToolBar", ezViewActions::PerspectiveMode | ezViewActions::RenderMode | ezViewActions::ActivateRemoteProcess);
   ezQuadViewActions::MapToolbarActions("EditorPluginScene_ViewToolBar");
 
@@ -193,13 +193,13 @@ void OnLoadPlugin()
     { return EZ_DEFAULT_NEW(ezBoxReflectionProbeVisualizerAdapter); });
 
   // SceneGraph Context Menu
-  ezActionMapManager::RegisterActionMap("EditorPluginScene_ScenegraphContextMenu").AssertSuccess();
+  ezActionMapManager::RegisterActionMap("EditorPluginScene_ScenegraphContextMenu");
   ezGameObjectSelectionActions::MapContextMenuActions("EditorPluginScene_ScenegraphContextMenu");
   ezSelectionActions::MapContextMenuActions("EditorPluginScene_ScenegraphContextMenu");
   ezEditActions::MapContextMenuActions("EditorPluginScene_ScenegraphContextMenu");
 
   // Layer Context Menu
-  ezActionMapManager::RegisterActionMap("EditorPluginScene_LayerContextMenu").AssertSuccess();
+  ezActionMapManager::RegisterActionMap("EditorPluginScene_LayerContextMenu");
   ezLayerActions::MapContextMenuActions("EditorPluginScene_LayerContextMenu");
 
   // component property meta states

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
@@ -51,7 +51,7 @@ void ezQtSceneViewWidget::OnOpenContextMenu(QPoint globalPos)
   {
     s_bContextMenuInitialized = true;
 
-    ezActionMapManager::RegisterActionMap("SceneViewContextMenu").IgnoreResult();
+    ezActionMapManager::RegisterActionMap("SceneViewContextMenu");
 
     ezGameObjectSelectionActions::MapViewContextMenuActions("SceneViewContextMenu");
     ezSelectionActions::MapViewContextMenuActions("SceneViewContextMenu");

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/EditorPluginSubstance.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/EditorPluginSubstance.cpp
@@ -17,14 +17,14 @@ void OnLoadPlugin()
     {
       const char* szMenuBar = "SubstanceAssetMenuBar";
 
-      ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar");
       ezEditActions::MapActions(szMenuBar, false, false);
     }
 
     // Tool Bar
     {
       const char* szToolBar = "SubstanceAssetToolBar";
-      ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar");
     }
   }
 

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/EditorPluginSubstance.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/EditorPluginSubstance.cpp
@@ -17,23 +17,14 @@ void OnLoadPlugin()
     {
       const char* szMenuBar = "SubstanceAssetMenuBar";
 
-      ezActionMapManager::RegisterActionMap(szMenuBar).IgnoreResult();
-      ezStandardMenus::MapActions(szMenuBar, ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions(szMenuBar);
-      ezDocumentActions::MapMenuActions(szMenuBar);
-      ezAssetActions::MapMenuActions(szMenuBar);
-      ezCommandHistoryActions::MapActions(szMenuBar);
-
-      ezEditActions::MapActions("SubstanceAssetMenuBar", false, false);
+      ezActionMapManager::RegisterActionMap(szMenuBar, "AssetMenuBar").IgnoreResult();
+      ezEditActions::MapActions(szMenuBar, false, false);
     }
 
     // Tool Bar
     {
       const char* szToolBar = "SubstanceAssetToolBar";
-      ezActionMapManager::RegisterActionMap(szToolBar).IgnoreResult();
-      ezDocumentActions::MapToolbarActions(szToolBar);
-      ezCommandHistoryActions::MapActions(szToolBar, "");
-      ezAssetActions::MapToolBarActions(szToolBar, true);
+      ezActionMapManager::RegisterActionMap(szToolBar, "AssetToolbar").IgnoreResult();
     }
   }
 

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
@@ -24,12 +24,12 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("TypeScriptAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("TypeScriptAssetMenuBar", "AssetMenuBar");
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("TypeScriptAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("TypeScriptAssetToolBar", "AssetToolbar");
       ezTypeScriptActions::MapActions("TypeScriptAssetToolBar");
     }
   }

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/EditorPluginTypeScript.cpp
@@ -24,20 +24,12 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("TypeScriptAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("TypeScriptAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("TypeScriptAssetMenuBar");
-      ezDocumentActions::MapMenuActions("TypeScriptAssetMenuBar");
-      ezAssetActions::MapMenuActions("TypeScriptAssetMenuBar");
-      ezCommandHistoryActions::MapActions("TypeScriptAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("TypeScriptAssetMenuBar", "AssetMenuBar").IgnoreResult();
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("TypeScriptAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("TypeScriptAssetToolBar");
-      ezCommandHistoryActions::MapActions("TypeScriptAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("TypeScriptAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("TypeScriptAssetToolBar", "AssetToolbar").IgnoreResult();
       ezTypeScriptActions::MapActions("TypeScriptAssetToolBar");
     }
   }

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/EditorPluginVisualScript.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/EditorPluginVisualScript.cpp
@@ -14,21 +14,13 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("VisualScriptAssetMenuBar").IgnoreResult();
-      ezStandardMenus::MapActions("VisualScriptAssetMenuBar", ezStandardMenuTypes::Default | ezStandardMenuTypes::Edit);
-      ezProjectActions::MapActions("VisualScriptAssetMenuBar");
-      ezDocumentActions::MapMenuActions("VisualScriptAssetMenuBar");
-      ezAssetActions::MapMenuActions("VisualScriptAssetMenuBar");
-      ezCommandHistoryActions::MapActions("VisualScriptAssetMenuBar");
+      ezActionMapManager::RegisterActionMap("VisualScriptAssetMenuBar", "AssetMenuBar").IgnoreResult();
       ezEditActions::MapActions("VisualScriptAssetMenuBar", false, false);
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("VisualScriptAssetToolBar").IgnoreResult();
-      ezDocumentActions::MapToolbarActions("VisualScriptAssetToolBar");
-      ezCommandHistoryActions::MapActions("VisualScriptAssetToolBar", "");
-      ezAssetActions::MapToolBarActions("VisualScriptAssetToolBar", true);
+      ezActionMapManager::RegisterActionMap("VisualScriptAssetToolBar", "AssetToolbar").IgnoreResult();
     }
   }
 }

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/EditorPluginVisualScript.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/EditorPluginVisualScript.cpp
@@ -14,13 +14,13 @@ void OnLoadPlugin()
   {
     // Menu Bar
     {
-      ezActionMapManager::RegisterActionMap("VisualScriptAssetMenuBar", "AssetMenuBar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("VisualScriptAssetMenuBar", "AssetMenuBar");
       ezEditActions::MapActions("VisualScriptAssetMenuBar", false, false);
     }
 
     // Tool Bar
     {
-      ezActionMapManager::RegisterActionMap("VisualScriptAssetToolBar", "AssetToolbar").IgnoreResult();
+      ezActionMapManager::RegisterActionMap("VisualScriptAssetToolBar", "AssetToolbar");
     }
   }
 }

--- a/Code/Tools/Libs/GuiFoundation/Action/ActionMapManager.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/ActionMapManager.h
@@ -7,11 +7,13 @@
 class EZ_GUIFOUNDATION_DLL ezActionMapManager
 {
 public:
-  /// \brief Adds a new action map with the given name. Returns EZ_FAILURE if the name was already used before.
-  static ezResult RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping = {});
+  /// \brief Adds a new action map with the given name and an optional inherited parent mapping. Asserts if the name was already used before.
+  /// \param sMapping Name of the new mapping. This string has to be used when adding actions to the map.
+  /// \param sParentMapping If set, the new mapping will inherit all actions of this mapping. The name must exist and resolve to a valid mapping once ezActionMap::BuildActionTree is called to generate the action tree.
+  static void RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping = {});
 
-  /// \brief Deletes the action map with the given name. Returns EZ_FAILURE, if no such map exists.
-  static ezResult UnregisterActionMap(ezStringView sMapping);
+  /// \brief Deletes the action map with the given name. Asserts, if no such map exists.
+  static void UnregisterActionMap(ezStringView sMapping);
 
   /// \brief Returns the action map with the given name, or nullptr, if it doesn't exist.
   static ezActionMap* GetActionMap(ezStringView sMapping);

--- a/Code/Tools/Libs/GuiFoundation/Action/ActionMapManager.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/ActionMapManager.h
@@ -8,7 +8,7 @@ class EZ_GUIFOUNDATION_DLL ezActionMapManager
 {
 public:
   /// \brief Adds a new action map with the given name. Returns EZ_FAILURE if the name was already used before.
-  static ezResult RegisterActionMap(ezStringView sMapping);
+  static ezResult RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping = {});
 
   /// \brief Deletes the action map with the given name. Returns EZ_FAILURE, if no such map exists.
   static ezResult UnregisterActionMap(ezStringView sMapping);

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMapManager.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMapManager.cpp
@@ -30,25 +30,19 @@ EZ_END_SUBSYSTEM_DECLARATION;
 // ezActionMapManager public functions
 ////////////////////////////////////////////////////////////////////////
 
-ezResult ezActionMapManager::RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping)
+void ezActionMapManager::RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping)
 {
   auto it = s_Mappings.Find(sMapping);
-  if (it.IsValid())
-    return EZ_FAILURE;
-
+  EZ_ASSERT_ALWAYS(!it.IsValid(), "Mapping '{}' already exists", sMapping);
   s_Mappings.Insert(sMapping, EZ_DEFAULT_NEW(ezActionMap, sParentMapping));
-  return EZ_SUCCESS;
 }
 
-ezResult ezActionMapManager::UnregisterActionMap(ezStringView sMapping)
+void ezActionMapManager::UnregisterActionMap(ezStringView sMapping)
 {
   auto it = s_Mappings.Find(sMapping);
-  if (!it.IsValid())
-    return EZ_FAILURE;
-
+  EZ_ASSERT_ALWAYS(it.IsValid(), "Mapping '{}' not found", sMapping);
   EZ_DEFAULT_DELETE(it.Value());
   s_Mappings.Remove(it);
-  return EZ_SUCCESS;
 }
 
 ezActionMap* ezActionMapManager::GetActionMap(ezStringView sMapping)
@@ -67,18 +61,16 @@ ezActionMap* ezActionMapManager::GetActionMap(ezStringView sMapping)
 
 void ezActionMapManager::Startup()
 {
-  ezActionMapManager::RegisterActionMap("DocumentWindowTabMenu").IgnoreResult();
+  ezActionMapManager::RegisterActionMap("DocumentWindowTabMenu");
   ezDocumentActions::MapMenuActions("DocumentWindowTabMenu", "");
 }
 
 void ezActionMapManager::Shutdown()
 {
-  ezActionMapManager::UnregisterActionMap("DocumentWindowTabMenu").IgnoreResult();
+  ezActionMapManager::UnregisterActionMap("DocumentWindowTabMenu");
 
   while (!s_Mappings.IsEmpty())
   {
-    ezResult res = UnregisterActionMap(s_Mappings.GetIterator().Key());
-    EZ_ASSERT_DEV(res == EZ_SUCCESS, "Failed to call UnregisterActionMap successfully!");
-    res.IgnoreResult();
+    UnregisterActionMap(s_Mappings.GetIterator().Key());
   }
 }

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMapManager.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMapManager.cpp
@@ -30,13 +30,13 @@ EZ_END_SUBSYSTEM_DECLARATION;
 // ezActionMapManager public functions
 ////////////////////////////////////////////////////////////////////////
 
-ezResult ezActionMapManager::RegisterActionMap(ezStringView sMapping)
+ezResult ezActionMapManager::RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping)
 {
   auto it = s_Mappings.Find(sMapping);
   if (it.IsValid())
     return EZ_FAILURE;
 
-  s_Mappings.Insert(sMapping, EZ_DEFAULT_NEW(ezActionMap));
+  s_Mappings.Insert(sMapping, EZ_DEFAULT_NEW(ezActionMap, sParentMapping));
   return EZ_SUCCESS;
 }
 

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/MenuActionMapView.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/MenuActionMapView.cpp
@@ -88,7 +88,7 @@ void ezQtMenuActionMapView::CreateView()
 {
   ClearView();
 
-  auto pObject = m_pActionMap->GetRootObject();
+  auto pObject = m_pActionMap->BuildActionTree();
 
   AddDocumentObjectToMenu(m_Proxies, m_Context, m_pActionMap, this, pObject);
 }

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/MenuBarActionMapView.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/MenuBarActionMapView.cpp
@@ -37,7 +37,7 @@ void ezQtMenuBarActionMapView::CreateView()
 {
   ClearView();
 
-  auto pObject = m_pActionMap->GetRootObject();
+  auto pObject = m_pActionMap->BuildActionTree();
 
   for (auto pChild : pObject->GetChildren())
   {

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/ToolBarActionMapView.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/ToolBarActionMapView.cpp
@@ -50,7 +50,7 @@ void ezQtToolBarActionMapView::CreateView()
 {
   ClearView();
 
-  auto pObject = m_pActionMap->GetRootObject();
+  auto pObject = m_pActionMap->BuildActionTree();
 
   CreateView(pObject);
 


### PR DESCRIPTION
Previously, it was impossible to make a plugin that adds an action to every editor as you would manually have to add the action to every editor's mappings. To fix this, inheritance has been introduced into the action mapping system. When registering an action via `ezActionMapManager::RegisterActionMap` a  parent mapping can be provided. Once a mapping is mapped to a view, all actions of the entire parent hierarchy as show in the view.

The `ezActionMap` had to be changed slightly to account for this:
1. `MapAction` just accumulates the mappings in an array until `BuildActionTree` is called which builds the hierarchy of the inherited and local actions. This is necessary as mappings can be defined in any order so the parent mapping might not be defined yet and mapping an action into the parent mapping's hierarchy might not be possible yet. 
2. `UnmapAction` has been removed from the public interface and replaced with `HideAction` which practically does the same, but later at the `BuildActionTree` phase.
3. `SearchPathForAction` has been made private as is requires the hierarchy to be built already which is not possible when defining the mapping across parent hierarchies which are not defined yet. The few use cases we had, have been fixed by adding a parameter `const ezBitflags<ezStandardMenuTypes> menus` to `ezProjectActions::MapActions` to allow for partial mapping of actions.

Right now, the following base action mappings have been defined which can now be extended via plugins to easily map to every asset document editor's UI:
1. **AssetMenuBar**: The bare minimum of actions every asset document's menu bar should have.
2. **AssetToolbar**: The bare minimum of actions every asset document's toolbar should have.
3. **AssetViewToolbar**: Empty but should be the base mapping of every view.
4. **SimpleAssetViewToolbar**: Convenience mapping that is derived from *AssetViewToolbar* and provides the most common actions used by engine views.