### PR TITLE
Fix shortcuts (e.g. Ctrl+S) while focus is inside the Visual Shader Editor

### DIFF
--- a/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
+++ b/Code/Tools/Libs/GuiFoundation/NodeEditor/Implementation/NodeScene.cpp
@@ -379,6 +379,12 @@ void ezQtNodeScene::keyPressEvent(QKeyEvent* event)
   {
     OpenSearchMenu(QCursor::pos());
   }
+
+  //Pass Shortcuts/KeyPresses up the chain again, so e.g. Ctrl+S work even if inside a window
+  if (event->type() == QEvent::ShortcutOverride || event->type() == QEvent::KeyPress)
+  {
+    event->ignore();
+  }
 }
 
 void ezQtNodeScene::Clear()


### PR DESCRIPTION
Fix shortcuts (e.g. Ctrl+S) while focus is inside the Visual Shader Editor

This issue only occurred for the Visual Shader Editor because of the workaround present for centralWidgets in ezQtDocumentWindow::eventFilter, but the Visual Shader Editor is not a centralWidget.

How to test:
Open Material, do some changes and while focus is inside Visual Shader Editor, press Ctrl+S.
With this change, the asset should now be saved.
