### PR TITLE
Add tests and non-SSE implementations for SIMD vector GetCombined

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Android-arm64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-arm64.yml
@@ -1,0 +1,53 @@
+# Variable 'task.MSBuild.status' was defined in the Variables tab
+trigger:
+  branches:
+    include:
+    - dev
+resources:
+  repositories:
+  - repository: self
+    type: git
+    ref: dev
+jobs:
+- job: Job_1
+  displayName: Android-x64
+  timeoutInMinutes: 180
+  pool:
+    name: Default
+    demands:
+    - Agent.OS -equals Windows_NT
+    - EMULATOR
+  steps:
+  - checkout: self
+    submodules: true
+    lfs: true
+    clean: false
+
+  - task: PowerShell@2
+    displayName: Check force clean
+    inputs:
+      targetType: inline
+      script: |
+        $pathA = Join-Path $(System.DefaultWorkingDirectory) "gitClean.txt"
+        $pathB = Join-Path $(System.DefaultWorkingDirectory) "gitCleanCopy.txt"
+        $clean = -not (Test-Path $pathB) -or (compare-object (get-content $pathA) (get-content $pathB))
+        if ($clean)
+        {
+            Write-Host "Cleaning repo!"
+            git clean -dfx
+            Copy-Item -Path $pathA -Destination $pathB
+        }
+
+  - task: CMake@1
+    displayName: CMake android-arm64-dev
+    inputs:
+      cwd: $(System.DefaultWorkingDirectory)
+      cmakeArgs: --preset android-arm64-dev
+
+  - task: CmdLine@2
+    displayName: Build
+    inputs:
+      script: |
+        cd $(System.DefaultWorkingDirectory)/Workspace/android-arm64-dev
+        ninja
+...

--- a/Code/BuildSystem/AzurePipelines/Android-arm64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-arm64.yml
@@ -10,7 +10,7 @@ resources:
     ref: dev
 jobs:
 - job: Job_1
-  displayName: Android-x64
+  displayName: Android-arm64
   timeoutInMinutes: 180
   pool:
     name: Default
@@ -37,6 +37,27 @@ jobs:
             git clean -dfx
             Copy-Item -Path $pathA -Destination $pathB
         }
+        
+  - task: CMake@1
+    displayName: CMake vs2022x64
+    inputs:
+      cwd: $(System.DefaultWorkingDirectory)
+      cmakeArgs: --preset vs2022x64
+
+  - task: CMake@1
+    displayName: CMake build vs2022x64
+    inputs:
+      cwd: $(System.DefaultWorkingDirectory)/Workspace/vs2022x64
+      cmakeArgs: --build . --target ShaderCompiler --config dev
+
+  - task: CmdLine@2
+    displayName: Compile Shaders
+    inputs:
+      script: |
+        cd $(System.DefaultWorkingDirectory)/Output/Bin/WinVs2022Dev64
+        ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/Base -shader Shaders/Pipeline
+        ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/UnitTests -shader RendererTest/Shaders
+        ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/Samples/ShaderExplorer -shader Shaders
 
   - task: CMake@1
     displayName: CMake android-arm64-dev

--- a/Code/Engine/Foundation/Basics/Platform/Android/PlatformFeatures_Android.h
+++ b/Code/Engine/Foundation/Basics/Platform/Android/PlatformFeatures_Android.h
@@ -57,11 +57,12 @@
 #undef EZ_SIMD_IMPLEMENTATION
 
 #if EZ_ENABLED(EZ_PLATFORM_ARCH_X86)
-#  if __SSE4_1__ && __SSSE3__
-#    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_SSE
-#  else
+// Disabling SSE in emulator to increase FPU test coverage. Uncomment code below if performance is an issue for you.
+//#  if __SSE4_1__ && __SSSE3__
+//#    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_SSE
+//#  else
 #    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_FPU
-#  endif
+//#  endif
 #elif EZ_ENABLED(EZ_PLATFORM_ARCH_ARM)
 #  if EZ_ENABLED(EZ_PLATFORM_64BIT)
 #    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_NEON

--- a/Code/Engine/Foundation/Basics/Platform/Android/PlatformFeatures_Android.h
+++ b/Code/Engine/Foundation/Basics/Platform/Android/PlatformFeatures_Android.h
@@ -58,11 +58,11 @@
 
 #if EZ_ENABLED(EZ_PLATFORM_ARCH_X86)
 // Disabling SSE in emulator to increase FPU test coverage. Uncomment code below if performance is an issue for you.
-//#  if __SSE4_1__ && __SSSE3__
-//#    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_SSE
-//#  else
-#    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_FPU
-//#  endif
+// #  if __SSE4_1__ && __SSSE3__
+// #    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_SSE
+// #  else
+#  define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_FPU
+// #  endif
 #elif EZ_ENABLED(EZ_PLATFORM_ARCH_ARM)
 #  if EZ_ENABLED(EZ_PLATFORM_64BIT)
 #    define EZ_SIMD_IMPLEMENTATION EZ_SIMD_IMPLEMENTATION_NEON

--- a/Code/Engine/Foundation/SimdMath/Implementation/FPU/FPUVec4i_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/FPU/FPUVec4i_inl.h
@@ -124,6 +124,21 @@ EZ_ALWAYS_INLINE ezSimdVec4i ezSimdVec4i::Get() const
   return result;
 }
 
+template <ezSwizzle::Enum s>
+EZ_ALWAYS_INLINE ezSimdVec4i ezSimdVec4i::GetCombined(const ezSimdVec4i& other) const
+{
+  ezSimdVec4i result;
+
+  const ezInt32* v = &m_v.x;
+  const ezInt32* o = &other.m_v.x;
+  result.m_v.x = v[(s & 0x3000) >> 12];
+  result.m_v.y = v[(s & 0x0300) >> 8];
+  result.m_v.z = o[(s & 0x0030) >> 4];
+  result.m_v.w = o[(s & 0x0003)];
+
+  return result;
+}
+
 EZ_ALWAYS_INLINE ezSimdVec4i ezSimdVec4i::operator-() const
 {
   return -m_v;

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONVec4i_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONVec4i_inl.h
@@ -142,6 +142,12 @@ EZ_ALWAYS_INLINE ezSimdVec4i ezSimdVec4i::Get() const
   return __builtin_shufflevector(m_v, m_v, EZ_TO_SHUFFLE(s));
 }
 
+template <ezSwizzle::Enum s>
+EZ_ALWAYS_INLINE ezSimdVec4i ezSimdVec4i::GetCombined(const ezSimdVec4i& other) const
+{
+  return __builtin_shufflevector(m_v, other.m_v, EZ_TO_SHUFFLE(s));
+}
+
 EZ_ALWAYS_INLINE ezSimdVec4i ezSimdVec4i::operator-() const
 {
   return vnegq_s32(m_v);

--- a/Code/UnitTests/FoundationTest/SimdMath/SimdVec4fTest.cpp
+++ b/Code/UnitTests/FoundationTest/SimdMath/SimdVec4fTest.cpp
@@ -462,6 +462,36 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4f)
     EZ_TEST_BOOL(b.x() == 9.0f && b.y() == 7.0f && b.z() == 5.0f && b.w() == 3.0f);
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetCombined")
+  {
+    ezSimdVec4f a(2.0f, 4.0f, 6.0f, 8.0f);
+    ezSimdVec4f b(3.0f, 5.0f, 7.0f, 9.0f);
+
+    ezSimdVec4f c = a.GetCombined<ezSwizzle::XXXX>(b);
+    EZ_TEST_BOOL(c.x() == a.x() && c.y() == a.x() && c.z() == b.x() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::YYYX>(b);
+    EZ_TEST_BOOL(c.x() == a.y() && c.y() == a.y() && c.z() == b.y() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::ZZZX>(b);
+    EZ_TEST_BOOL(c.x() == a.z() && c.y() == a.z() && c.z() == b.z() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::WWWX>(b);
+    EZ_TEST_BOOL(c.x() == a.w() && c.y() == a.w() && c.z() == b.w() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::WZYX>(b);
+    EZ_TEST_BOOL(c.x() == a.w() && c.y() == a.z() && c.z() == b.y() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::XYZW>(b);
+    EZ_TEST_BOOL(c.x() == a.x() && c.y() == a.y() && c.z() == b.z() && c.w() == b.w());
+
+    c = a.GetCombined<ezSwizzle::WZYX>(b);
+    EZ_TEST_BOOL(c.x() == a.w() && c.y() == a.z() && c.z() == b.y() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::YYYY>(b);
+    EZ_TEST_BOOL(c.x() == a.y() && c.y() == a.y() && c.z() == b.y() && c.w() == b.y());
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Operators")
   {
     {

--- a/Code/UnitTests/FoundationTest/SimdMath/SimdVec4iTest.cpp
+++ b/Code/UnitTests/FoundationTest/SimdMath/SimdVec4iTest.cpp
@@ -153,6 +153,36 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4i)
     EZ_TEST_BOOL(b.x() == 9 && b.y() == 7 && b.z() == 5 && b.w() == 3);
   }
 
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "GetCombined")
+  {
+    ezSimdVec4i a(2, 4, 6, 8);
+    ezSimdVec4i b(3, 5, 7, 9);
+
+    ezSimdVec4i c = a.GetCombined<ezSwizzle::XXXX>(b);
+    EZ_TEST_BOOL(c.x() == a.x() && c.y() == a.x() && c.z() == b.x() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::YYYX>(b);
+    EZ_TEST_BOOL(c.x() == a.y() && c.y() == a.y() && c.z() == b.y() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::ZZZX>(b);
+    EZ_TEST_BOOL(c.x() == a.z() && c.y() == a.z() && c.z() == b.z() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::WWWX>(b);
+    EZ_TEST_BOOL(c.x() == a.w() && c.y() == a.w() && c.z() == b.w() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::WZYX>(b);
+    EZ_TEST_BOOL(c.x() == a.w() && c.y() == a.z() && c.z() == b.y() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::XYZW>(b);
+    EZ_TEST_BOOL(c.x() == a.x() && c.y() == a.y() && c.z() == b.z() && c.w() == b.w());
+
+    c = a.GetCombined<ezSwizzle::WZYX>(b);
+    EZ_TEST_BOOL(c.x() == a.w() && c.y() == a.z() && c.z() == b.y() && c.w() == b.x());
+
+    c = a.GetCombined<ezSwizzle::YYYY>(b);
+    EZ_TEST_BOOL(c.x() == a.y() && c.y() == a.y() && c.z() == b.y() && c.w() == b.y());
+  }
+
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Operators")
   {
     {


### PR DESCRIPTION
* Changed Android emulator to run FPU implementation to increase test coverage.
* Added Android arm64 build to at least detect future build breaks like this.
* Added NEON and FPU implementations of `GetCombined`.
* Added unit tests for `GetCombined`.