### PR TITLE
Add experimental support for DXVK-native on Linux

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -200,4 +200,10 @@ jobs:
     inputs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)\AssetCache
       ArtifactName: AssetCache
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: ShaderCache'
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    inputs:
+      PathtoPublish: $(System.DefaultWorkingDirectory)\Output\ShaderCache
+      ArtifactName: ShaderCache
 ...

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsDX11.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsDX11.cmake
@@ -1,4 +1,10 @@
 # #####################################
+# ## DXVK Support
+# #####################################
+
+set(EZ_BUILD_EXPERIMENTAL_DXVK OFF CACHE BOOL "Whether to emulate DX11 on Linux using DXVK-native support.")
+
+# #####################################
 # ## ez_link_target_dx11(<target>)
 # #####################################
 
@@ -9,16 +15,37 @@ function(ez_link_target_dx11 TARGET_NAME)
 
 	# only execute find_package once
 	if(NOT EZ_DX11_LIBRARY)
-		find_package(DirectX11 REQUIRED)
+	
+		if(EZ_CMAKE_PLATFORM_WINDOWS)
+			find_package(DirectX11 REQUIRED)
 
-		if(DirectX11_FOUND)
-			set_property(GLOBAL PROPERTY EZ_DX11_LIBRARY ${DirectX11_LIBRARY})
-			set_property(GLOBAL PROPERTY EZ_DX11_LIBRARIES ${DirectX11_D3D11_LIBRARIES})
-		endif()
+			if(DirectX11_FOUND)
+				set_property(GLOBAL PROPERTY EZ_DX11_LIBRARY ${DirectX11_LIBRARY})
+				set_property(GLOBAL PROPERTY EZ_DX11_LIBRARIES ${DirectX11_D3D11_LIBRARIES})
+			endif()
+
+		elseif(EZ_CMAKE_PLATFORM_LINUX AND EZ_BUILD_EXPERIMENTAL_DXVK)
+			pkg_search_module(DirectX11 REQUIRED dxvk-d3d11)
+			pkg_search_module(DirectX11GI REQUIRED dxvk-dxgi)
+			if(DirectX11_FOUND AND DirectX11GI_FOUND)
+				list(APPEND allDxLibs ${DirectX11_LINK_LIBRARIES} ${DirectX11GI_LINK_LIBRARIES})
+				list(APPEND allDxIncludes ${DirectX11_INCLUDE_DIRS} ${DirectX11GI_INCLUDE_DIRS})
+				set_property(GLOBAL PROPERTY EZ_DX11_LIBRARY "DXVK")
+				set_property(GLOBAL PROPERTY EZ_DX11_LIBRARIES ${allDxLibs})
+				set_property(GLOBAL PROPERTY EZ_DX11_INCLUDES ${allDxIncludes})
+			endif()
+		endif()		
 	endif()
 
 	get_property(EZ_DX11_LIBRARY GLOBAL PROPERTY EZ_DX11_LIBRARY)
 	get_property(EZ_DX11_LIBRARIES GLOBAL PROPERTY EZ_DX11_LIBRARIES)
+
+	if(${EZ_DX11_LIBRARY} MATCHES "DXVK")
+		# Add DXVK headers as system headers so that clang does not complain about warnings.
+		get_property(EZ_DX11_INCLUDES GLOBAL PROPERTY EZ_DX11_INCLUDES)
+		target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${EZ_DX11_INCLUDES})
+		target_compile_definitions(${TARGET_NAME} PUBLIC EZ_USE_DXVK)
+	endif()
 
 	target_link_libraries(${TARGET_NAME}
 		PRIVATE
@@ -38,7 +65,7 @@ function(ez_link_target_dx11 TARGET_NAME)
 		endif()
 	endif()
 
-	# arm dll is not provide in the windows SDK.
+	# arm dll is not provided in the windows SDK.
 	if(NOT EZ_CMAKE_ARCHITECTURE_ARM)
 		if(${EZ_DX11_LIBRARY} MATCHES "/8\\.0/")
 			set(DX11_COPY_DLLS_WINSDKVERSION "8.0")
@@ -66,5 +93,5 @@ endfunction()
 # ## ez_requires_d3d()
 # #####################################
 macro(ez_requires_d3d)
-	ez_requires(EZ_CMAKE_PLATFORM_WINDOWS)
+	ez_requires_one_of(EZ_CMAKE_PLATFORM_WINDOWS EZ_BUILD_EXPERIMENTAL_DXVK)
 endmacro()

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -104,7 +104,7 @@ void ezQtAssetBrowserView::dropEvent(QDropEvent* pEvent)
     return;
 
   QList<QUrl> paths = pEvent->mimeData()->urls();
-  const ezString targetDirectory = indexAt(pEvent->pos()).data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
+  const ezString targetDirectory = indexAt(pEvent->position().toPoint()).data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString().toUtf8().data();
   if (targetDirectory.IsEmpty())
   {
     return;

--- a/Code/Engine/Foundation/Basics/Platform/Win/HResultUtils.cpp
+++ b/Code/Engine/Foundation/Basics/Platform/Win/HResultUtils.cpp
@@ -27,5 +27,12 @@ EZ_FOUNDATION_DLL ezString ezHRESULTtoString(ezMinWindows::HRESULT result)
 
   return message;
 }
+#else
 
+#  include <Foundation/Basics/Platform/Win/HResultUtils.h>
+
+EZ_FOUNDATION_DLL ezString ezHRESULTtoString(ezMinWindows::HRESULT result)
+{
+  return "NOT_SUPPORTED";
+}
 #endif

--- a/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
@@ -413,6 +413,11 @@ ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezArgErrorCode& a
   LocalFree(lpMsgBuf);
   return ezStringView(FullMessage);
 }
+#else
+ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezArgErrorCode& arg)
+{
+  return "NOT_SUPPORTED";
+}
 #endif
 
 #if EZ_ENABLED(EZ_PLATFORM_LINUX) || EZ_ENABLED(EZ_PLATFORM_ANDROID)

--- a/Code/Engine/Foundation/Strings/Implementation/FormatStringArgs.h
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatStringArgs.h
@@ -133,7 +133,6 @@ struct ezArgFileSize : public ezArgHumanReadable
   const char* const m_ByteSuffixes[6] = {"B", "KB", "MB", "GB", "TB", "PB"};
 };
 
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 /// \brief Converts a windows HRESULT into an error code and a human-readable error message.
 /// Pass in `GetLastError()` function or an HRESULT from another error source. Be careful when printing multiple values, a function could clear `GetLastError` as a side-effect so it is best to store it in a temp variable before printing a complex error message.
 /// \sa https://learn.microsoft.com/en-gb/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
@@ -148,7 +147,6 @@ struct ezArgErrorCode
 };
 EZ_FOUNDATION_DLL ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezArgErrorCode& arg);
 
-#endif
 
 #if EZ_ENABLED(EZ_PLATFORM_LINUX) || EZ_ENABLED(EZ_PLATFORM_ANDROID)
 /// \brief Many Linux APIs will fill out error on failure. This converts the error into an error code and a human-readable error message.

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -3,8 +3,8 @@
 
 #include <Foundation/Types/Bitflags.h>
 #include <Foundation/Types/UniquePtr.h>
-#include <RendererDX11/RendererDX11DLL.h>
 #include <RendererDX11/CommandEncoder/CommandEncoderImplDX11.h>
+#include <RendererDX11/RendererDX11DLL.h>
 #include <RendererFoundation/Device/Device.h>
 
 // TODO: This should not be included in a header, it exposes Windows.h to the outside

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -4,6 +4,7 @@
 #include <Foundation/Types/Bitflags.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <RendererDX11/RendererDX11DLL.h>
+#include <RendererDX11/CommandEncoder/CommandEncoderImplDX11.h>
 #include <RendererFoundation/Device/Device.h>
 
 // TODO: This should not be included in a header, it exposes Windows.h to the outside

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -3,6 +3,7 @@
 #include <Core/System/Window.h>
 #include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #include <Foundation/Configuration/Startup.h>
+#include <Foundation/System/SystemInformation.h>
 #include <RendererDX11/CommandEncoder/CommandEncoderImplDX11.h>
 #include <RendererDX11/Device/DeviceDX11.h>
 #include <RendererDX11/Device/SwapChainDX11.h>
@@ -19,7 +20,6 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Profiling/Profiling.h>
-#include <Foundation/System/SystemInformation.h>
 
 #include <d3d11.h>
 #include <d3d11_3.h>

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -19,6 +19,7 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Profiling/Profiling.h>
+#include <Foundation/System/SystemInformation.h>
 
 #include <d3d11.h>
 #include <d3d11_3.h>
@@ -128,7 +129,7 @@ retry:
       if (SUCCEEDED(m_pDebug->QueryInterface(__uuidof(ID3D11InfoQueue), (void**)&pInfoQueue)))
       {
         // only do this when a debugger is attached, otherwise the app would crash on every DX error
-        if (IsDebuggerPresent())
+        if (ezSystemInformation::IsDebuggerAttached())
         {
           pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_CORRUPTION, TRUE);
           pInfoQueue->SetBreakOnSeverity(D3D11_MESSAGE_SEVERITY_ERROR, TRUE);
@@ -146,7 +147,7 @@ retry:
           };
           D3D11_INFO_QUEUE_FILTER filter;
           ezMemoryUtils::ZeroFill(&filter, 1);
-          filter.DenyList.NumIDs = _countof(hide);
+          filter.DenyList.NumIDs = EZ_ARRAY_SIZE(hide);
           filter.DenyList.pIDList = hide;
           pInfoQueue->AddStorageFilterEntries(&filter);
         }
@@ -256,7 +257,7 @@ void ezGALDeviceDX11::ReportLiveGpuObjects()
   // not implemented
   return;
 
-#else
+#elif EZ_ENABLED(EZ_PLATFORM_WINDOWS)
 
   const HMODULE hDxgiDebugDLL = LoadLibraryW(L"Dxgidebug.dll");
 

--- a/Code/Engine/RendererDX11/RendererDX11PCH.h
+++ b/Code/Engine/RendererDX11/RendererDX11PCH.h
@@ -2,3 +2,28 @@
 
 #include <Foundation/Basics.h>
 #include <Foundation/Logging/Log.h>
+
+#ifdef EZ_USE_DXVK
+// These are shims to make DXVK compile our RendererDX11 library
+
+#  if EZ_ENABLED(EZ_PLATFORM_LINUX)
+#    define INFINITE 0xFFFFFFFF
+#  endif
+
+#  include <Core/System/Window.h>
+#  include <Foundation/Basics/Platform/Win/MinWindows.h>
+#  include <windows_base.h>
+namespace ezMinWindows
+{
+  template <>
+  struct ToNativeImpl<ezWindowHandle>
+  {
+    using type = ::HWND;
+    static EZ_ALWAYS_INLINE ::HWND ToNative(ezWindowHandle hWnd)
+    {
+      EZ_ASSERT_DEV(hWnd.type == ezWindowHandle::Type::GLFW, "Only GLFW is supported on DXVK");
+      return reinterpret_cast<::HWND>(hWnd.glfwWindow);
+    }
+  };
+} // namespace ezMinWindows
+#endif

--- a/Code/Engine/ShaderCompilerHLSL/CMakeLists.txt
+++ b/Code/Engine/ShaderCompilerHLSL/CMakeLists.txt
@@ -1,6 +1,6 @@
 ez_cmake_init()
 
-
+ez_requires(EZ_CMAKE_PLATFORM_WINDOWS)
 ez_requires_d3d()
 
 # Get the name of this folder as the project name

--- a/Code/UnitTests/GameEngineTest/CMakeLists.txt
+++ b/Code/UnitTests/GameEngineTest/CMakeLists.txt
@@ -1,8 +1,6 @@
 ez_cmake_init()
 
-
-
-ez_requires_d3d()
+ez_requires_renderer()
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
@@ -13,7 +11,7 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC
   TestFramework
   GameEngine
-  RendererDX11
+  RendererCore
   Utilities
   ParticlePlugin
   VisualScriptPlugin
@@ -41,11 +39,8 @@ if (EZ_CMAKE_PLATFORM_WINDOWS_UWP)
 endif()
 
 
-ez_link_target_dx11(${PROJECT_NAME})
+ez_add_renderers(${PROJECT_NAME})
 
 ez_ci_add_test(${PROJECT_NAME} NEEDS_HW_ACCESS)
 
-add_dependencies(${PROJECT_NAME}
-  ShaderCompilerHLSL
-)
 


### PR DESCRIPTION
This allows compiling the DX11 renderer on Linux. The main goal is to make it easier to make renderer changes on Linux without having to boot Windows. To use:
1. Clone DXVK
1. Change `meson.build` to `lib_glfw = dependency('glfw3', required: false)` instead of just `'glfw'`.
1. Run `./package-native.sh master ~/libDXVK --no-package`
1. `export PKG_CONFIG_PATH="~/libDXVK/dxvk-native-master/usr/lib/pkgconfig"`
1. Enable `EZ_BUILD_EXPERIMENTAL_DXVK`

Note that you won't be able to run this without considerable effort so right now it's merely to make sure the code compiles:
1. There is no shader compiler so if you want to run DX11, you need to get a shader cache from a Windows machine or from the Windows CI build artifacts.
3. We conflict between two GLFW versions as EZ does not use the system version but DXVK does. You can delete our version and replace it with the system version but it's tedious.
4. For some reason you can't load two renderers at the same time under Linux. Sub-system init for DX11 is simply skipped. Can't figure out why.
5. Latest release of dxvk has a bug, so you need to apply at least this patch: https://github.com/doitsujin/dxvk/pull/4061
6. You need to set the env var `DXVK_WSI_DRIVER=GLFW` before running any app.