### PR TITLE
Support ezDirectoryWatcher on non NTFS drives

### DIFF
--- a/Code/Engine/Foundation/IO/Implementation/FileSystemMirror.h
+++ b/Code/Engine/Foundation/IO/Implementation/FileSystemMirror.h
@@ -47,6 +47,9 @@ public:
   // \brief Enumerates the files & directories under the given path
   ezResult Enumerate(ezStringView sPath, EnumerateFunc callbackFunc);
 
+  // \brief On success, out_Type will contains the type of the object (file or folder).
+  ezResult GetType(ezStringView sPath, Type& out_Type);
+
 private:
   DirEntry* FindDirectory(ezStringBuilder& path);
 
@@ -397,6 +400,33 @@ ezResult ezFileSystemMirror<T>::Enumerate(ezStringView sPath0, EnumerateFunc cal
   }
 
   return EZ_SUCCESS;
+}
+
+template <typename T>
+typename ezResult ezFileSystemMirror<T>::GetType(ezStringView sPath0, Type& out_Type)
+{
+  ezStringBuilder sPath = sPath0;
+  DirEntry* dir = FindDirectory(sPath);
+  if (dir == nullptr)
+  {
+    return EZ_FAILURE; // file not under top level directory
+  }
+
+  auto it = dir->m_files.Find(sPath);
+  if (it.IsValid())
+  {
+    out_Type = ezFileSystemMirror::Type::File;
+    return EZ_SUCCESS;
+  }
+
+  auto itDir = dir->m_subDirectories.Find(sPath);
+  if (itDir.IsValid())
+  {
+    out_Type = ezFileSystemMirror::Type::Directory;
+    return EZ_SUCCESS;
+  }
+
+  return EZ_FAILURE;
 }
 
 template <typename T>

--- a/Code/Engine/Foundation/IO/Implementation/FileSystemMirror.h
+++ b/Code/Engine/Foundation/IO/Implementation/FileSystemMirror.h
@@ -48,7 +48,7 @@ public:
   ezResult Enumerate(ezStringView sPath, EnumerateFunc callbackFunc);
 
   // \brief On success, out_Type will contains the type of the object (file or folder).
-  ezResult GetType(ezStringView sPath, Type& out_Type);
+  ezResult GetType(ezStringView sPath, Type& out_type);
 
 private:
   DirEntry* FindDirectory(ezStringBuilder& path);
@@ -403,7 +403,7 @@ ezResult ezFileSystemMirror<T>::Enumerate(ezStringView sPath0, EnumerateFunc cal
 }
 
 template <typename T>
-ezResult ezFileSystemMirror<T>::GetType(ezStringView sPath0, Type& out_Type)
+ezResult ezFileSystemMirror<T>::GetType(ezStringView sPath0, Type& out_type)
 {
   ezStringBuilder sPath = sPath0;
   DirEntry* dir = FindDirectory(sPath);
@@ -415,14 +415,14 @@ ezResult ezFileSystemMirror<T>::GetType(ezStringView sPath0, Type& out_Type)
   auto it = dir->m_files.Find(sPath);
   if (it.IsValid())
   {
-    out_Type = ezFileSystemMirror::Type::File;
+    out_type = ezFileSystemMirror::Type::File;
     return EZ_SUCCESS;
   }
 
   auto itDir = dir->m_subDirectories.Find(sPath);
   if (itDir.IsValid())
   {
-    out_Type = ezFileSystemMirror::Type::Directory;
+    out_type = ezFileSystemMirror::Type::Directory;
     return EZ_SUCCESS;
   }
 

--- a/Code/Engine/Foundation/IO/Implementation/FileSystemMirror.h
+++ b/Code/Engine/Foundation/IO/Implementation/FileSystemMirror.h
@@ -403,7 +403,7 @@ ezResult ezFileSystemMirror<T>::Enumerate(ezStringView sPath0, EnumerateFunc cal
 }
 
 template <typename T>
-typename ezResult ezFileSystemMirror<T>::GetType(ezStringView sPath0, Type& out_Type)
+ezResult ezFileSystemMirror<T>::GetType(ezStringView sPath0, Type& out_Type)
 {
   ezStringBuilder sPath = sPath0;
   DirEntry* dir = FindDirectory(sPath);

--- a/Code/Engine/Foundation/Platform/Win/DirectoryWatcher_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/DirectoryWatcher_Win.cpp
@@ -3,6 +3,7 @@
 #if (EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP) && EZ_ENABLED(EZ_SUPPORTS_DIRECTORY_WATCHER))
 
 #  include <Foundation/Basics/Platform/Win/IncludeWindows.h>
+#  include <Foundation/Configuration/CVar.h>
 #  include <Foundation/Containers/DynamicArray.h>
 #  include <Foundation/IO/DirectoryWatcher.h>
 #  include <Foundation/IO/Implementation/FileSystemMirror.h>
@@ -20,6 +21,8 @@
 
 namespace
 {
+  ezCVarBool cvar_ForceNonNTFS("DirectoryWatcher.ForceNonNTFS", false, ezCVarFlags::Default, "Forces the use of ReadDirectoryChanges instead of ReadDirectoryChangesEx");
+
   struct MoveEvent
   {
     ezString path;
@@ -36,13 +39,246 @@ namespace
     }
   };
 
+  struct Change
+  {
+    ezStringBuilder eventFilePath;
+    bool isFile;
+    DWORD Action;
+    LARGE_INTEGER LastModificationTime;
+  };
+
   using ezFileSystemMirrorType = ezFileSystemMirror<bool>;
+
+  void GetChangesNTFS(ezStringView sDirectoryPath, ezHybridArray<ezUInt8, 4096>& buffer, ezDynamicArray<Change>& changes)
+  {
+    ezUInt32 uiChanges = 1;
+    auto info = (const FILE_NOTIFY_EXTENDED_INFORMATION*)buffer.GetData();
+    while (info->NextEntryOffset != 0)
+    {
+      uiChanges++;
+      info = (const FILE_NOTIFY_EXTENDED_INFORMATION*)(((ezUInt8*)info) + info->NextEntryOffset);
+    }
+    changes.Reserve(uiChanges);
+    info = (const FILE_NOTIFY_EXTENDED_INFORMATION*)buffer.GetData();
+
+    while (true)
+    {
+      auto directory = ezArrayPtr<const WCHAR>(info->FileName, info->FileNameLength / sizeof(WCHAR));
+      int bytesNeeded = WideCharToMultiByte(CP_UTF8, 0, directory.GetPtr(), directory.GetCount(), nullptr, 0, nullptr, nullptr);
+      if (bytesNeeded > 0)
+      {
+        ezHybridArray<char, 1024> dir;
+        dir.SetCountUninitialized(bytesNeeded);
+        WideCharToMultiByte(CP_UTF8, 0, directory.GetPtr(), directory.GetCount(), dir.GetData(), dir.GetCount(), nullptr, nullptr);
+
+        Change& currentChange = changes.ExpandAndGetRef();
+        currentChange.eventFilePath = sDirectoryPath;
+        currentChange.eventFilePath.AppendPath(ezStringView(dir.GetData(), dir.GetCount()));
+        currentChange.eventFilePath.MakeCleanPath();
+        currentChange.Action = info->Action;
+        currentChange.LastModificationTime = info->LastModificationTime;
+        currentChange.isFile = (info->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
+      }
+
+      if (info->NextEntryOffset == 0)
+      {
+        break;
+      }
+      else
+        info = (const FILE_NOTIFY_EXTENDED_INFORMATION*)(((ezUInt8*)info) + info->NextEntryOffset);
+    }
+  }
+
+  void GetChangesNonNTFS(ezStringView sDirectoryPath, ezFileSystemMirrorType* mirror, ezHybridArray<ezUInt8, 4096>& buffer, ezDynamicArray<Change>& changes)
+  {
+    ezUInt32 uiChanges = 1;
+    auto info = (const FILE_NOTIFY_INFORMATION*)buffer.GetData();
+    while (info->NextEntryOffset != 0)
+    {
+      uiChanges++;
+      info = (const FILE_NOTIFY_INFORMATION*)(((ezUInt8*)info) + info->NextEntryOffset);
+    }
+    changes.Reserve(changes.GetCount() + uiChanges);
+    info = (const FILE_NOTIFY_INFORMATION*)buffer.GetData();
+
+    while (true)
+    {
+      auto directory = ezArrayPtr<const WCHAR>(info->FileName, info->FileNameLength / sizeof(WCHAR));
+      int bytesNeeded = WideCharToMultiByte(CP_UTF8, 0, directory.GetPtr(), directory.GetCount(), nullptr, 0, nullptr, nullptr);
+      if (bytesNeeded > 0)
+      {
+        ezHybridArray<char, 1024> dir;
+        dir.SetCountUninitialized(bytesNeeded);
+        WideCharToMultiByte(CP_UTF8, 0, directory.GetPtr(), directory.GetCount(), dir.GetData(), dir.GetCount(), nullptr, nullptr);
+
+        Change& currentChange = changes.ExpandAndGetRef();
+        currentChange.eventFilePath = sDirectoryPath;
+        currentChange.eventFilePath.AppendPath(ezStringView(dir.GetData(), dir.GetCount()));
+        currentChange.eventFilePath.MakeCleanPath();
+        currentChange.Action = info->Action;
+        currentChange.LastModificationTime = {};
+        currentChange.isFile = true; // Pretend it's a file for now.
+      }
+
+      if (info->NextEntryOffset == 0)
+      {
+        break;
+      }
+      else
+        info = (const FILE_NOTIFY_INFORMATION*)(((ezUInt8*)info) + info->NextEntryOffset);
+    }
+  }
+
+  void PostProcessNonNTFSChanges(ezDynamicArray<Change>& changes, ezFileSystemMirrorType* mirror)
+  {
+    ezHybridArray<ezInt32, 4> nextOp;
+    // Figure what changes belong to the same object by creating a linked list of changes. This part is tricky as we basically have to handle all the oddities that ezDirectoryWatcher::EnumerateChanges already does again to figure out which operations belong to the same object.
+    {
+      ezMap<ezStringView, ezUInt32> lastChangeAtPath;
+      nextOp.SetCount(changes.GetCount(), -1);
+
+      ezInt32 pendingRemoveOrRename = -1;
+      ezInt32 lastMoveFrom = -1;
+
+      for (ezUInt32 i = 0; i < changes.GetCount(); i++)
+      {
+        const auto& currentChange = changes[i];
+        if (pendingRemoveOrRename != -1 && currentChange.Action == FILE_ACTION_RENAMED_OLD_NAME && changes[pendingRemoveOrRename].eventFilePath == currentChange.eventFilePath)
+        {
+          // This is the bogus removed event because we changed the casing of a file / directory, ignore.
+          lastChangeAtPath.Insert(changes[pendingRemoveOrRename].eventFilePath, pendingRemoveOrRename);
+          pendingRemoveOrRename = -1;
+        }
+
+        if (pendingRemoveOrRename != -1)
+        {
+          // An actual remove: Stop tracking the change.
+          lastChangeAtPath.Remove(changes[pendingRemoveOrRename].eventFilePath);
+          pendingRemoveOrRename = -1;
+        }
+
+        ezUInt32* uiUniqueItemIndex = nullptr;
+        switch (currentChange.Action)
+        {
+          case FILE_ACTION_ADDED:
+            lastChangeAtPath.Insert(currentChange.eventFilePath, i);
+            break;
+          case FILE_ACTION_REMOVED:
+            if (lastChangeAtPath.TryGetValue(currentChange.eventFilePath, uiUniqueItemIndex))
+            {
+              nextOp[*uiUniqueItemIndex] = i;
+              *uiUniqueItemIndex = i;
+            }
+            pendingRemoveOrRename = i;
+            break;
+          case FILE_ACTION_MODIFIED:
+            if (lastChangeAtPath.TryGetValue(currentChange.eventFilePath, uiUniqueItemIndex))
+            {
+              nextOp[*uiUniqueItemIndex] = i;
+              *uiUniqueItemIndex = i;
+            }
+            else
+            {
+              lastChangeAtPath[currentChange.eventFilePath] = i;
+            }
+            break;
+          case FILE_ACTION_RENAMED_OLD_NAME:
+            if (lastChangeAtPath.TryGetValue(currentChange.eventFilePath, uiUniqueItemIndex))
+            {
+              nextOp[*uiUniqueItemIndex] = i;
+              *uiUniqueItemIndex = i;
+            }
+            else
+            {
+              lastChangeAtPath[currentChange.eventFilePath] = i;
+            }
+            lastMoveFrom = i;
+            break;
+          case FILE_ACTION_RENAMED_NEW_NAME:
+            EZ_ASSERT_DEBUG(lastMoveFrom != -1, "last move from should be present when encountering FILE_ACTION_RENAMED_NEW_NAME");
+            nextOp[lastMoveFrom] = i;
+            lastChangeAtPath.Remove(changes[lastMoveFrom].eventFilePath);
+            lastChangeAtPath.Insert(currentChange.eventFilePath, i);
+            break;
+        }
+      }
+    }
+
+    // Anything that is chained via the nextOp linked list must be given the same type.
+    // Instead of building arrays of arrays, we create a bit field of all changes and then flatten the linked list at the first set bit. While iterating we remove everything we reached via the linked list so on the next call to get the first bit we will find another object that needs processing. As the operations are ordered, the first bit will always point to the very first operation of an object (nextOp can never point to a previous element).
+    ezBitfield<ezHybridArray<ezUInt32, 4>> pendingChanges;
+    pendingChanges.SetCount(changes.GetCount(), true);
+
+    // Get start of first object.
+    ezHybridArray<Change*, 4> objectChanges;
+    auto it = pendingChanges.GetIterator();
+    while (it.IsValid())
+    {
+      // Flatten the changes for one object into a list for easier processing.
+      {
+        objectChanges.Clear();
+        ezUInt32 currentIndex = it.Value();
+        objectChanges.PushBack(&changes[currentIndex]);
+        pendingChanges.ClearBit(currentIndex);
+        while (nextOp[currentIndex] != -1)
+        {
+          currentIndex = nextOp[currentIndex];
+          pendingChanges.ClearBit(currentIndex);
+          objectChanges.PushBack(&changes[currentIndex]);
+        }
+      }
+
+      // Figure out what type the object is. There is no correct way of doing this, which is the reason why ReadDirectoryChangesExW exists. There are however some good heuristics we can use:
+      // 1. If the change is on an existing object, we should know it's type from the mirror. This is 100% correct.
+      // 2. If object still exists, we can query its stats on disk to determine its type. In rare cases, this can be wrong but you would need to create a case where a file is replaced with a folder of the same name or something.
+      // 3. If the object was created and deleted in the same enumeration, we cannot know what type it was, so we take a guess.
+      {
+        bool isFile = true;
+        bool typeFound = false;
+        for (Change* currentChange : objectChanges)
+        {
+          ezFileSystemMirrorType::Type type;
+          if (mirror->GetType(currentChange->eventFilePath, type).Succeeded())
+          {
+            isFile = type == ezFileSystemMirrorType::Type::File;
+            typeFound = true;
+            break;
+          }
+          ezFileStats stats;
+          if (ezOSFile::GetFileStats(currentChange->eventFilePath, stats).Succeeded())
+          {
+            isFile = !stats.m_bIsDirectory;
+            typeFound = true;
+            break;
+          }
+        }
+
+        if (!typeFound)
+        {
+          // No stats and no entry in mirror: It's guessing time!
+          isFile = objectChanges[0]->eventFilePath.FindSubString(".") != nullptr;
+        }
+
+        // Apply type to all objects in the chain.
+        for (Change* currentChange : objectChanges)
+        {
+          currentChange->isFile = isFile;
+        }
+      }
+
+      // Find start of next object.
+      it = pendingChanges.GetIterator();
+    }
+  }
+
 } // namespace
 
 struct ezDirectoryWatcherImpl
 {
   void DoRead();
+  void EnumerateChangesImpl(ezStringView sDirectoryPath, ezTime waitUpTo, const ezDelegate<void(const Change&)>& callback);
 
+  bool m_bNTFS = false;
   HANDLE m_directoryHandle;
   DWORD m_filter;
   OVERLAPPED m_overlapped;
@@ -60,6 +296,27 @@ ezDirectoryWatcher::ezDirectoryWatcher()
 
 ezResult ezDirectoryWatcher::OpenDirectory(ezStringView sAbsolutePath, ezBitflags<Watch> whatToWatch)
 {
+  m_pImpl->m_bNTFS = false;
+  {
+    // Get drive root:
+    ezStringBuilder sTemp = sAbsolutePath;
+    sTemp.MakeCleanPath();
+    const char* szFirst = sTemp.FindSubString("/");
+    EZ_ASSERT_DEV(szFirst != nullptr, "The path '{}' is not absolute", sTemp);
+    ezStringView sRoot = sAbsolutePath.GetSubString(0, szFirst - sTemp.GetData() + 1);
+
+    WCHAR szFileSystemName[8];
+    BOOL res = GetVolumeInformationW(ezStringWChar(sRoot),
+      nullptr,
+      0,
+      nullptr,
+      nullptr,
+      nullptr,
+      szFileSystemName,
+      sizeof(szFileSystemName));
+    m_pImpl->m_bNTFS = res == TRUE && ezStringUtf8(szFileSystemName).GetView() == "NTFS" && !cvar_ForceNonNTFS.GetValue();
+  }
+
   EZ_ASSERT_DEV(m_sDirectoryPath.IsEmpty(), "Directory already open, call CloseDirectory first!");
   ezStringBuilder sPath(sAbsolutePath);
   sPath.MakeCleanPath();
@@ -67,9 +324,14 @@ ezResult ezDirectoryWatcher::OpenDirectory(ezStringView sAbsolutePath, ezBitflag
 
   m_pImpl->m_whatToWatch = whatToWatch;
   m_pImpl->m_filter = FILE_NOTIFY_CHANGE_FILE_NAME;
-  if (whatToWatch.IsSet(Watch::Writes) || whatToWatch.AreAllSet(Watch::Deletes | Watch::Subdirectories))
+  const bool bRequiresMirror = whatToWatch.IsSet(Watch::Writes) || whatToWatch.AreAllSet(Watch::Deletes | Watch::Subdirectories);
+  if (bRequiresMirror)
   {
     m_pImpl->m_filter |= FILE_NOTIFY_CHANGE_LAST_WRITE;
+  }
+
+  if (!m_pImpl->m_bNTFS || bRequiresMirror)
+  {
     m_pImpl->m_mirror = EZ_DEFAULT_NEW(ezFileSystemMirrorType);
     m_pImpl->m_mirror->AddDirectory(sPath).AssertSuccess();
   }
@@ -120,17 +382,79 @@ void ezDirectoryWatcherImpl::DoRead()
   ResetEvent(m_overlappedEvent);
   memset(&m_overlapped, 0, sizeof(m_overlapped));
   m_overlapped.hEvent = m_overlappedEvent;
-  BOOL success =
-    ReadDirectoryChangesExW(m_directoryHandle, m_buffer.GetData(), m_buffer.GetCount(), m_whatToWatch.IsSet(ezDirectoryWatcher::Watch::Subdirectories), m_filter, nullptr, &m_overlapped, nullptr, ReadDirectoryNotifyExtendedInformation);
-  EZ_ASSERT_DEV(success, "ReadDirectoryChangesW failed.");
-  EZ_IGNORE_UNUSED(success);
+
+  if (m_bNTFS)
+  {
+    BOOL success =
+      ReadDirectoryChangesExW(m_directoryHandle, m_buffer.GetData(), m_buffer.GetCount(), m_whatToWatch.IsSet(ezDirectoryWatcher::Watch::Subdirectories), m_filter, nullptr, &m_overlapped, nullptr, ReadDirectoryNotifyExtendedInformation);
+    EZ_ASSERT_DEV(success, "ReadDirectoryChangesExW failed.");
+  }
+  else
+  {
+    BOOL success =
+      ReadDirectoryChangesW(m_directoryHandle, m_buffer.GetData(), m_buffer.GetCount(), m_whatToWatch.IsSet(ezDirectoryWatcher::Watch::Subdirectories), m_filter, nullptr, &m_overlapped, nullptr);
+    EZ_ASSERT_DEV(success, "ReadDirectoryChangesW failed.");
+  }
+}
+
+void ezDirectoryWatcherImpl::EnumerateChangesImpl(ezStringView sDirectoryPath, ezTime waitUpTo, const ezDelegate<void(const Change&)>& callback)
+{
+  ezDynamicArray<Change> changes;
+
+  ezHybridArray<ezUInt8, 4096> buffer;
+  while (WaitForSingleObject(m_overlappedEvent, static_cast<DWORD>(waitUpTo.GetMilliseconds())) == WAIT_OBJECT_0)
+  {
+    waitUpTo = ezTime::MakeZero(); // only wait on the first call to GetQueuedCompletionStatus
+
+    DWORD numberOfBytes = 0;
+    GetOverlappedResult(m_directoryHandle, &m_overlapped, &numberOfBytes, FALSE);
+
+    // Copy the buffer
+    buffer.SetCountUninitialized(numberOfBytes);
+    buffer.GetArrayPtr().CopyFrom(m_buffer.GetArrayPtr().GetSubArray(0, numberOfBytes));
+
+    // Reissue the read request
+    DoRead();
+
+    if (numberOfBytes == 0)
+    {
+      return;
+    }
+
+    // We can fire NTFS events right away as they don't need post processing which prevents us from resizing the changes array unnecessarily.
+    if (m_bNTFS)
+    {
+      GetChangesNTFS(sDirectoryPath, buffer, changes);
+      for (const Change& change : changes)
+      {
+        callback(change);
+      }
+      changes.Clear();
+    }
+    else
+    {
+      GetChangesNonNTFS(sDirectoryPath, m_mirror.Borrow(), buffer, changes);
+    }
+  }
+
+  // Non-NTFS changes need to be collected and processed in one go to be able to reconstruct the type of the change.
+  if (!m_bNTFS)
+  {
+    PostProcessNonNTFSChanges(changes, m_mirror.Borrow());
+    for (const Change& change : changes)
+    {
+      callback(change);
+    }
+  }
 }
 
 void ezDirectoryWatcher::EnumerateChanges(EnumerateChangesFunction func, ezTime waitUpTo)
 {
+  ezFileSystemMirrorType* mirror = m_pImpl->m_mirror.Borrow();
+  EZ_ASSERT_DEV(!m_sDirectoryPath.IsEmpty(), "No directory opened!");
+
   MoveEvent pendingRemoveOrRename;
   const ezBitflags<ezDirectoryWatcher::Watch> whatToWatch = m_pImpl->m_whatToWatch;
-  ezFileSystemMirrorType* mirror = m_pImpl->m_mirror.Borrow();
   // Renaming a file to the same filename with different casing triggers the events REMOVED (old casing) -> RENAMED_OLD_NAME -> _RENAMED_NEW_NAME.
   // Thus, we need to cache every remove event to make sure the very next event is not a rename of the exact same file.
   auto FirePendingRemove = [&]()
@@ -171,219 +495,176 @@ void ezDirectoryWatcher::EnumerateChanges(EnumerateChangesFunction func, ezTime 
 
   EZ_SCOPE_EXIT(FirePendingRemove());
 
+  MoveEvent lastMoveFrom;
 
-  EZ_ASSERT_DEV(!m_sDirectoryPath.IsEmpty(), "No directory opened!");
-  while (WaitForSingleObject(m_pImpl->m_overlappedEvent, static_cast<DWORD>(waitUpTo.GetMilliseconds())) == WAIT_OBJECT_0)
-  {
-    waitUpTo = ezTime::MakeZero(); // only wait on the first call to GetQueuedCompletionStatus
-
-    DWORD numberOfBytes = 0;
-    GetOverlappedResult(m_pImpl->m_directoryHandle, &m_pImpl->m_overlapped, &numberOfBytes, FALSE);
-
-    // Copy the buffer
-    ezHybridArray<ezUInt8, 4096> buffer;
-    buffer.SetCountUninitialized(numberOfBytes);
-    buffer.GetArrayPtr().CopyFrom(m_pImpl->m_buffer.GetArrayPtr().GetSubArray(0, numberOfBytes));
-
-    // Reissue the read request
-    m_pImpl->DoRead();
-
-    if (numberOfBytes == 0)
+  // Process the messages
+  m_pImpl->EnumerateChangesImpl(m_sDirectoryPath, waitUpTo, [&](const Change& info)
     {
-      return;
-    }
+      ezDirectoryWatcherAction action = ezDirectoryWatcherAction::None;
+      bool fireEvent = false;
 
-    MoveEvent lastMoveFrom;
-
-    // Progress the messages
-    auto info = (const FILE_NOTIFY_EXTENDED_INFORMATION*)buffer.GetData();
-    while (true)
-    {
-      auto directory = ezArrayPtr<const WCHAR>(info->FileName, info->FileNameLength / sizeof(WCHAR));
-      int bytesNeeded = WideCharToMultiByte(CP_UTF8, 0, directory.GetPtr(), directory.GetCount(), nullptr, 0, nullptr, nullptr);
-      if (bytesNeeded > 0)
+      if (!pendingRemoveOrRename.IsEmpty() && info.isFile == !pendingRemoveOrRename.isDirectory && info.Action == FILE_ACTION_RENAMED_OLD_NAME && pendingRemoveOrRename.path == info.eventFilePath)
       {
-        ezHybridArray<char, 1024> dir;
-        dir.SetCountUninitialized(bytesNeeded);
-        WideCharToMultiByte(CP_UTF8, 0, directory.GetPtr(), directory.GetCount(), dir.GetData(), dir.GetCount(), nullptr, nullptr);
-        ezDirectoryWatcherAction action = ezDirectoryWatcherAction::None;
-        bool fireEvent = false;
+        // This is the bogus removed event because we changed the casing of a file / directory, ignore.
+        pendingRemoveOrRename.Clear();
+      }
+      FirePendingRemove();
 
-        ezStringBuilder eventFilePath = m_sDirectoryPath;
-        eventFilePath.AppendPath(ezStringView(dir.GetData(), dir.GetCount()));
-        eventFilePath.MakeCleanPath();
-
-        const bool isFile = (info->FileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0;
-        if (!pendingRemoveOrRename.IsEmpty() && isFile == !pendingRemoveOrRename.isDirectory && info->Action == FILE_ACTION_RENAMED_OLD_NAME && pendingRemoveOrRename.path == eventFilePath)
+      if (info.isFile)
+      {
+        switch (info.Action)
         {
-          // This is the bogus removed event because we changed the casing of a file / directory, ignore.
-          pendingRemoveOrRename.Clear();
-        }
-        FirePendingRemove();
-
-        if (isFile)
-        {
-          switch (info->Action)
-          {
-            case FILE_ACTION_ADDED:
-              DEBUG_LOG("FILE_ACTION_ADDED {} ({})", eventFilePath, info->LastModificationTime.QuadPart);
-              action = ezDirectoryWatcherAction::Added;
-              fireEvent = whatToWatch.IsSet(ezDirectoryWatcher::Watch::Creates);
-              if (mirror)
-              {
-                bool fileAlreadyExists = false;
-                mirror->AddFile(eventFilePath.GetData(), true, &fileAlreadyExists, nullptr).AssertSuccess();
-                if (fileAlreadyExists)
-                {
-                  fireEvent = false;
-                }
-              }
-              break;
-            case FILE_ACTION_REMOVED:
-              DEBUG_LOG("FILE_ACTION_REMOVED {} ({})", eventFilePath, info->LastModificationTime.QuadPart);
-              action = ezDirectoryWatcherAction::Removed;
-              fireEvent = false;
-              pendingRemoveOrRename = {eventFilePath, false};
-              break;
-            case FILE_ACTION_MODIFIED:
+          case FILE_ACTION_ADDED:
+            DEBUG_LOG("FILE_ACTION_ADDED {} ({})", eventFilePath, info.LastModificationTime.QuadPart);
+            action = ezDirectoryWatcherAction::Added;
+            fireEvent = whatToWatch.IsSet(ezDirectoryWatcher::Watch::Creates);
+            if (mirror)
             {
-              DEBUG_LOG("FILE_ACTION_MODIFIED {} ({})", eventFilePath, info->LastModificationTime.QuadPart);
-              action = ezDirectoryWatcherAction::Modified;
-              fireEvent = whatToWatch.IsAnySet(ezDirectoryWatcher::Watch::Writes);
-              bool fileAreadyKnown = false;
-              bool addPending = false;
-              if (mirror)
-              {
-                mirror->AddFile(eventFilePath.GetData(), false, &fileAreadyKnown, &addPending).AssertSuccess();
-              }
-              if (fileAreadyKnown && addPending)
+              bool fileAlreadyExists = false;
+              mirror->AddFile(info.eventFilePath, true, &fileAlreadyExists, nullptr).AssertSuccess();
+              if (fileAlreadyExists)
               {
                 fireEvent = false;
               }
             }
             break;
-            case FILE_ACTION_RENAMED_OLD_NAME:
-              DEBUG_LOG("FILE_ACTION_RENAMED_OLD_NAME {} ({})", eventFilePath, info->LastModificationTime.QuadPart);
-              EZ_ASSERT_DEV(lastMoveFrom.IsEmpty(), "there should be no pending move from");
-              action = ezDirectoryWatcherAction::RenamedOldName;
-              fireEvent = whatToWatch.IsAnySet(ezDirectoryWatcher::Watch::Renames);
-              EZ_ASSERT_DEV(lastMoveFrom.IsEmpty(), "there should be no pending last move from");
-              lastMoveFrom = {eventFilePath, false};
-              break;
-            case FILE_ACTION_RENAMED_NEW_NAME:
-              DEBUG_LOG("FILE_ACTION_RENAMED_NEW_NAME {} ({})", eventFilePath, info->LastModificationTime.QuadPart);
-              action = ezDirectoryWatcherAction::RenamedNewName;
-              fireEvent = whatToWatch.IsAnySet(ezDirectoryWatcher::Watch::Renames);
-              EZ_ASSERT_DEV(!lastMoveFrom.IsEmpty() && !lastMoveFrom.isDirectory, "last move from doesn't match");
-              if (mirror)
-              {
-                mirror->RemoveFile(lastMoveFrom.path).AssertSuccess();
-                mirror->AddFile(eventFilePath, false, nullptr, nullptr).AssertSuccess();
-              }
-              lastMoveFrom.Clear();
-              break;
-          }
-
-          if (fireEvent)
+          case FILE_ACTION_REMOVED:
+            DEBUG_LOG("FILE_ACTION_REMOVED {} ({})", eventFilePath, info.LastModificationTime.QuadPart);
+            action = ezDirectoryWatcherAction::Removed;
+            fireEvent = false;
+            pendingRemoveOrRename = {info.eventFilePath, false};
+            break;
+          case FILE_ACTION_MODIFIED:
           {
-            func(eventFilePath, action, ezDirectoryWatcherType::File);
-          }
-        }
-        else
-        {
-          switch (info->Action)
-          {
-            case FILE_ACTION_ADDED:
+            DEBUG_LOG("FILE_ACTION_MODIFIED {} ({})", eventFilePath, info.LastModificationTime.QuadPart);
+            action = ezDirectoryWatcherAction::Modified;
+            fireEvent = whatToWatch.IsAnySet(ezDirectoryWatcher::Watch::Writes);
+            bool fileAreadyKnown = false;
+            bool addPending = false;
+            if (mirror)
             {
-              DEBUG_LOG("DIR_ACTION_ADDED {}", eventFilePath);
-              bool directoryAlreadyKnown = false;
-              if (mirror)
+              mirror->AddFile(info.eventFilePath, false, &fileAreadyKnown, &addPending).AssertSuccess();
+            }
+            if (fileAreadyKnown && addPending)
+            {
+              fireEvent = false;
+            }
+          }
+          break;
+          case FILE_ACTION_RENAMED_OLD_NAME:
+            DEBUG_LOG("FILE_ACTION_RENAMED_OLD_NAME {} ({})", eventFilePath, info.LastModificationTime.QuadPart);
+            EZ_ASSERT_DEV(lastMoveFrom.IsEmpty(), "there should be no pending move from");
+            action = ezDirectoryWatcherAction::RenamedOldName;
+            fireEvent = whatToWatch.IsAnySet(ezDirectoryWatcher::Watch::Renames);
+            EZ_ASSERT_DEV(lastMoveFrom.IsEmpty(), "there should be no pending last move from");
+            lastMoveFrom = {info.eventFilePath, false};
+            break;
+          case FILE_ACTION_RENAMED_NEW_NAME:
+            DEBUG_LOG("FILE_ACTION_RENAMED_NEW_NAME {} ({})", eventFilePath, info.LastModificationTime.QuadPart);
+            action = ezDirectoryWatcherAction::RenamedNewName;
+            fireEvent = whatToWatch.IsAnySet(ezDirectoryWatcher::Watch::Renames);
+            EZ_ASSERT_DEV(!lastMoveFrom.IsEmpty() && !lastMoveFrom.isDirectory, "last move from doesn't match");
+            if (mirror)
+            {
+              mirror->RemoveFile(lastMoveFrom.path).AssertSuccess();
+              mirror->AddFile(info.eventFilePath, false, nullptr, nullptr).AssertSuccess();
+            }
+            lastMoveFrom.Clear();
+            break;
+        }
+
+        if (fireEvent)
+        {
+          func(info.eventFilePath, action, ezDirectoryWatcherType::File);
+        }
+      }
+      else
+      {
+        switch (info.Action)
+        {
+          case FILE_ACTION_ADDED:
+          {
+            DEBUG_LOG("DIR_ACTION_ADDED {}", eventFilePath);
+            bool directoryAlreadyKnown = false;
+            if (mirror)
+            {
+              mirror->AddDirectory(info.eventFilePath, &directoryAlreadyKnown).AssertSuccess();
+            }
+
+            if (whatToWatch.IsSet(Watch::Creates) && !directoryAlreadyKnown)
+            {
+              func(info.eventFilePath, ezDirectoryWatcherAction::Added, ezDirectoryWatcherType::Directory);
+            }
+
+            // Whenever we add a directory we might be "to late" to see changes inside it.
+            // So iterate the file system and make sure we track all files / subdirectories
+            ezFileSystemIterator subdirIt;
+
+            subdirIt.StartSearch(info.eventFilePath.GetData(),
+              whatToWatch.IsSet(ezDirectoryWatcher::Watch::Subdirectories)
+                ? ezFileSystemIteratorFlags::ReportFilesAndFoldersRecursive
+                : ezFileSystemIteratorFlags::ReportFiles);
+
+            ezStringBuilder tmpPath2;
+            for (; subdirIt.IsValid(); subdirIt.Next())
+            {
+              const ezFileStats& stats = subdirIt.GetStats();
+              stats.GetFullPath(tmpPath2);
+              if (stats.m_bIsDirectory)
               {
-                mirror->AddDirectory(eventFilePath, &directoryAlreadyKnown).AssertSuccess();
-              }
-
-              if (whatToWatch.IsSet(Watch::Creates) && !directoryAlreadyKnown)
-              {
-                func(eventFilePath, ezDirectoryWatcherAction::Added, ezDirectoryWatcherType::Directory);
-              }
-
-              // Whenever we add a directory we might be "to late" to see changes inside it.
-              // So iterate the file system and make sure we track all files / subdirectories
-              ezFileSystemIterator subdirIt;
-
-              subdirIt.StartSearch(eventFilePath.GetData(),
-                whatToWatch.IsSet(ezDirectoryWatcher::Watch::Subdirectories)
-                  ? ezFileSystemIteratorFlags::ReportFilesAndFoldersRecursive
-                  : ezFileSystemIteratorFlags::ReportFiles);
-
-              ezStringBuilder tmpPath2;
-              for (; subdirIt.IsValid(); subdirIt.Next())
-              {
-                const ezFileStats& stats = subdirIt.GetStats();
-                stats.GetFullPath(tmpPath2);
-                if (stats.m_bIsDirectory)
+                directoryAlreadyKnown = false;
+                if (mirror)
                 {
-                  directoryAlreadyKnown = false;
-                  if (mirror)
-                  {
-                    mirror->AddDirectory(tmpPath2, &directoryAlreadyKnown).AssertSuccess();
-                  }
-                  if (whatToWatch.IsSet(ezDirectoryWatcher::Watch::Creates) && !directoryAlreadyKnown)
-                  {
-                    func(tmpPath2, ezDirectoryWatcherAction::Added, ezDirectoryWatcherType::Directory);
-                  }
+                  mirror->AddDirectory(tmpPath2, &directoryAlreadyKnown).AssertSuccess();
                 }
-                else
+                if (whatToWatch.IsSet(ezDirectoryWatcher::Watch::Creates) && !directoryAlreadyKnown)
                 {
-                  bool fileExistsAlready = false;
-                  if (mirror)
-                  {
-                    mirror->AddFile(tmpPath2, false, &fileExistsAlready, nullptr).AssertSuccess();
-                  }
-                  if (whatToWatch.IsSet(ezDirectoryWatcher::Watch::Creates) && !fileExistsAlready)
-                  {
-                    func(tmpPath2, ezDirectoryWatcherAction::Added, ezDirectoryWatcherType::File);
-                  }
+                  func(tmpPath2, ezDirectoryWatcherAction::Added, ezDirectoryWatcherType::Directory);
+                }
+              }
+              else
+              {
+                bool fileExistsAlready = false;
+                if (mirror)
+                {
+                  mirror->AddFile(tmpPath2, false, &fileExistsAlready, nullptr).AssertSuccess();
+                }
+                if (whatToWatch.IsSet(ezDirectoryWatcher::Watch::Creates) && !fileExistsAlready)
+                {
+                  func(tmpPath2, ezDirectoryWatcherAction::Added, ezDirectoryWatcherType::File);
                 }
               }
             }
-            break;
-            case FILE_ACTION_REMOVED:
-              DEBUG_LOG("DIR_ACTION_REMOVED {}", eventFilePath);
-              pendingRemoveOrRename = {eventFilePath, true};
-              break;
-            case FILE_ACTION_RENAMED_OLD_NAME:
-              DEBUG_LOG("DIR_ACTION_OLD_NAME {}", eventFilePath);
-              EZ_ASSERT_DEV(lastMoveFrom.IsEmpty(), "there should be no pending move from");
-              lastMoveFrom = {eventFilePath, true};
-              break;
-            case FILE_ACTION_RENAMED_NEW_NAME:
-              DEBUG_LOG("DIR_ACTION_NEW_NAME {}", eventFilePath);
-              EZ_ASSERT_DEV(!lastMoveFrom.IsEmpty(), "rename old name and rename new name should always appear in pairs");
-              if (mirror)
-              {
-                mirror->MoveDirectory(lastMoveFrom.path, eventFilePath).AssertSuccess();
-              }
-              if (whatToWatch.IsSet(Watch::Renames))
-              {
-                func(lastMoveFrom.path, ezDirectoryWatcherAction::RenamedOldName, ezDirectoryWatcherType::Directory);
-                func(eventFilePath, ezDirectoryWatcherAction::RenamedNewName, ezDirectoryWatcherType::Directory);
-              }
-              lastMoveFrom.Clear();
-              break;
-            default:
-              break;
           }
+          break;
+          case FILE_ACTION_REMOVED:
+            DEBUG_LOG("DIR_ACTION_REMOVED {}", eventFilePath);
+            pendingRemoveOrRename = {info.eventFilePath, true};
+            break;
+          case FILE_ACTION_RENAMED_OLD_NAME:
+            DEBUG_LOG("DIR_ACTION_OLD_NAME {}", eventFilePath);
+            EZ_ASSERT_DEV(lastMoveFrom.IsEmpty(), "there should be no pending move from");
+            lastMoveFrom = {info.eventFilePath, true};
+            break;
+          case FILE_ACTION_RENAMED_NEW_NAME:
+            DEBUG_LOG("DIR_ACTION_NEW_NAME {}", eventFilePath);
+            EZ_ASSERT_DEV(!lastMoveFrom.IsEmpty(), "rename old name and rename new name should always appear in pairs");
+            if (mirror)
+            {
+              mirror->MoveDirectory(lastMoveFrom.path, info.eventFilePath).AssertSuccess();
+            }
+            if (whatToWatch.IsSet(Watch::Renames))
+            {
+              func(lastMoveFrom.path, ezDirectoryWatcherAction::RenamedOldName, ezDirectoryWatcherType::Directory);
+              func(info.eventFilePath, ezDirectoryWatcherAction::RenamedNewName, ezDirectoryWatcherType::Directory);
+            }
+            lastMoveFrom.Clear();
+            break;
+          default:
+            break;
         }
-      }
-      if (info->NextEntryOffset == 0)
-      {
-        break;
-      }
-      else
-        info = (const FILE_NOTIFY_EXTENDED_INFORMATION*)(((ezUInt8*)info) + info->NextEntryOffset);
-    }
-  }
+      } //
+    });
 }
 
 

--- a/Code/UnitTests/FoundationTest/IO/DirectoryWatcherTest.cpp
+++ b/Code/UnitTests/FoundationTest/IO/DirectoryWatcherTest.cpp
@@ -2,6 +2,7 @@
 
 #if EZ_ENABLED(EZ_SUPPORTS_DIRECTORY_WATCHER)
 
+#  include <Foundation/Configuration/CVar.h>
 #  include <Foundation/IO/DirectoryWatcher.h>
 #  include <Foundation/IO/OSFile.h>
 #  include <Foundation/Threading/ThreadUtils.h>
@@ -37,7 +38,8 @@ namespace DirectoryWatcherTestHelpers
   }
 } // namespace DirectoryWatcherTestHelpers
 
-EZ_CREATE_SIMPLE_TEST(IO, DirectoryWatcher)
+
+void DirectoryWatcherTest()
 {
   using namespace DirectoryWatcherTestHelpers;
 
@@ -757,5 +759,20 @@ EZ_CREATE_SIMPLE_TEST(IO, DirectoryWatcher)
 
   ezOSFile::DeleteFolder(sTestRootPath).IgnoreResult();
 }
+
+EZ_CREATE_SIMPLE_TEST(IO, DirectoryWatcher)
+{
+  DirectoryWatcherTest();
+}
+
+#  if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+EZ_CREATE_SIMPLE_TEST(IO, DirectoryWatcherNonNTFS)
+{
+  auto* pForceNonNTFS = static_cast<ezCVarBool*>(ezCVar::FindCVarByName("DirectoryWatcher.ForceNonNTFS"));
+  *pForceNonNTFS = true;
+  DirectoryWatcherTest();
+  *pForceNonNTFS = false;
+}
+#  endif
 
 #endif

--- a/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/FileSystem/FileSystemModelTest.cpp
@@ -3,6 +3,7 @@
 #if EZ_ENABLED(EZ_SUPPORTS_DIRECTORY_WATCHER) && EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS)
 
 #  include <Foundation/Application/Config/FileSystemConfig.h>
+#  include <Foundation/Configuration/CVar.h>
 #  include <Foundation/IO/FileSystem/DataDirTypeFolder.h>
 #  include <Foundation/IO/FileSystem/FileReader.h>
 #  include <Foundation/IO/FileSystem/FileSystem.h>
@@ -157,7 +158,7 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, DataDirPath)
   }
 }
 
-EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
+void FileSystemModelTest()
 {
   constexpr ezUInt32 WAIT_LOOPS = 1000;
 
@@ -1059,5 +1060,20 @@ EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
     ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.RemoveEventHandler(folderId);
   }
 }
+
+EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModel)
+{
+  FileSystemModelTest();
+}
+
+#  if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+EZ_CREATE_SIMPLE_TEST(FileSystem, FileSystemModelNonNTFS)
+{
+  auto* pForceNonNTFS = static_cast<ezCVarBool*>(ezCVar::FindCVarByName("DirectoryWatcher.ForceNonNTFS"));
+  *pForceNonNTFS = true;
+  FileSystemModelTest();
+  *pForceNonNTFS = false;
+}
+#  endif
 
 #endif


### PR DESCRIPTION
Several changes were necessary to make this work:
1. The logic of enumerating the changes has been separated from processing the changes. `ezDirectoryWatcher::EnumerateChanges` now only does the processing and the OS enumeration is done by `ezDirectoryWatcherImpl::EnumerateChangesImpl`.
2. `ezDirectoryWatcher::OpenDirectory` now checks the file system of the root of the drive via `GetVolumeInformationW`. Depending on whether NTFS is supported, `m_bNTFS` is set. If set, `ReadDirectoryChangesExW` is used as before. If not, `ReadDirectoryChangesW` is used instead.
3. Depending on `m_bNTFS`, `ezDirectoryWatcherImpl::EnumerateChangesImpl` will call either `GetChangesNTFS` and process those directly or call `GetChangesNonNTFS` in a loop until all changes are collected and then call `PostProcessNonNTFSChanges`.
4. `PostProcessNonNTFSChanges` main goal is to recover the type of the change (file ord directory). This can't be done perfectly, but it uses the following heursitics:
    1. First, a linked list of changes is built that belong to the same object (e.g. create, rename, rename again, modify etc.).
    2. For each object we itterate through all its changes and try to detect its type.
    3. Objects that have a state stored in the mirror can be given a type with 100% acuracy.
    4. Objects that still exit on disk can get their type by calling `ezOSFile::GetFileStats`. This is almost always correct except for cases that shouldn't appear in practice.
    5. Objects that got created and deleted in the same enumeration call can't be figured out, so we guess by looking for a `.` in the file and if present determine that it probably was a file.
5. A unit test (Windows only) has been added that forces logic for non-NTFS drives. All current Directory Watcher tests succeed.