### PR TITLE
Moved "Resave all assets" into context menu

### DIFF
--- a/Code/Editor/EditorFramework/Actions/AssetActions.h
+++ b/Code/Editor/EditorFramework/Actions/AssetActions.h
@@ -16,7 +16,6 @@ public:
   static ezActionDescriptorHandle s_hAssetCategory;
   static ezActionDescriptorHandle s_hTransformAsset;
   static ezActionDescriptorHandle s_hTransformAllAssets;
-  static ezActionDescriptorHandle s_hResaveAllAssets;
   static ezActionDescriptorHandle s_hCheckFileSystem;
   static ezActionDescriptorHandle s_hWriteLookupTable;
   static ezActionDescriptorHandle s_hWriteDependencyDGML;
@@ -32,7 +31,6 @@ public:
   {
     TransformAsset,
     TransformAllAssets,
-    ResaveAllAssets,
     CheckFileSystem,
     WriteLookupTable,
     WriteDependencyDGML,

--- a/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
@@ -6,7 +6,6 @@
 ezActionDescriptorHandle ezAssetActions::s_hAssetCategory;
 ezActionDescriptorHandle ezAssetActions::s_hTransformAsset;
 ezActionDescriptorHandle ezAssetActions::s_hTransformAllAssets;
-ezActionDescriptorHandle ezAssetActions::s_hResaveAllAssets;
 ezActionDescriptorHandle ezAssetActions::s_hCheckFileSystem;
 ezActionDescriptorHandle ezAssetActions::s_hWriteLookupTable;
 ezActionDescriptorHandle ezAssetActions::s_hWriteDependencyDGML;
@@ -16,7 +15,6 @@ void ezAssetActions::RegisterActions()
   s_hAssetCategory = EZ_REGISTER_CATEGORY("AssetCategory");
   s_hTransformAsset = EZ_REGISTER_ACTION_1("Asset.Transform", ezActionScope::Document, "Assets", "Ctrl+E", ezAssetAction, ezAssetAction::ButtonType::TransformAsset);
   s_hTransformAllAssets = EZ_REGISTER_ACTION_1("Asset.TransformAll", ezActionScope::Global, "Assets", "Ctrl+Shift+E", ezAssetAction, ezAssetAction::ButtonType::TransformAllAssets);
-  s_hResaveAllAssets = EZ_REGISTER_ACTION_1("Asset.ResaveAll", ezActionScope::Global, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::ResaveAllAssets);
   s_hCheckFileSystem = EZ_REGISTER_ACTION_1("Asset.CheckFilesystem", ezActionScope::Global, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::CheckFileSystem);
   s_hWriteLookupTable = EZ_REGISTER_ACTION_1("Asset.WriteLookupTable", ezActionScope::Global, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::WriteLookupTable);
   s_hWriteDependencyDGML = EZ_REGISTER_ACTION_1("Asset.WriteDependencyDGML", ezActionScope::Document, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::WriteDependencyDGML);
@@ -27,7 +25,6 @@ void ezAssetActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hAssetCategory);
   ezActionManager::UnregisterAction(s_hTransformAsset);
   ezActionManager::UnregisterAction(s_hTransformAllAssets);
-  ezActionManager::UnregisterAction(s_hResaveAllAssets);
   ezActionManager::UnregisterAction(s_hCheckFileSystem);
   ezActionManager::UnregisterAction(s_hWriteLookupTable);
   ezActionManager::UnregisterAction(s_hWriteDependencyDGML);
@@ -59,7 +56,6 @@ void ezAssetActions::MapToolBarActions(ezStringView sMapping, bool bDocument)
   {
     pMap->MapAction(s_hCheckFileSystem, "AssetCategory", 1.0f);
     pMap->MapAction(s_hTransformAllAssets, "AssetCategory", 2.0f);
-    pMap->MapAction(s_hResaveAllAssets, "AssetCategory", 3.0f);
   }
 }
 
@@ -82,9 +78,6 @@ ezAssetAction::ezAssetAction(const ezActionContext& context, const char* szName,
       break;
     case ezAssetAction::ButtonType::TransformAllAssets:
       SetIconPath(":/EditorFramework/Icons/TransformAllAssets.svg");
-      break;
-    case ezAssetAction::ButtonType::ResaveAllAssets:
-      SetIconPath(":/EditorFramework/Icons/ResavAllAssets.svg");
       break;
     case ezAssetAction::ButtonType::CheckFileSystem:
       SetIconPath(":/EditorFramework/Icons/CheckFileSystem.svg");
@@ -132,12 +125,6 @@ void ezAssetAction::Execute(const ezVariant& value)
     {
       ezAssetCurator::GetSingleton()->CheckFileSystem();
       ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::None).IgnoreResult();
-    }
-    break;
-
-    case ezAssetAction::ButtonType::ResaveAllAssets:
-    {
-      ezAssetCurator::GetSingleton()->ResaveAllAssets();
     }
     break;
 

--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -265,9 +265,9 @@ void ezProjectActions::MapActions(ezStringView sMapping, const ezBitflags<ezStan
 
   if (menus.IsSet(ezStandardMenuTypes::File))
   {
-    pMap->MapAction(s_hCreateDocument, "G.File", 1.0f);
-    pMap->MapAction(s_hOpenDocument, "G.File", 2.0f);
-    pMap->MapAction(s_hRecentDocuments, "G.File", 3.0f);
+    pMap->MapAction(s_hCreateDocument, "G.Files.General", 1.0f);
+    pMap->MapAction(s_hOpenDocument, "G.Files.General", 2.0f);
+    pMap->MapAction(s_hRecentDocuments, "G.Files.General", 3.0f);
   }
 }
 

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -70,6 +70,7 @@ private Q_SLOTS:
   void OnScrollToFile(QString sPreselectedFile);
   void OnShowSubFolderItemsToggled();
   void OnShowHiddenFolderItemsToggled();
+  void OnResaveAssets();
   void on_ListAssets_customContextMenuRequested(const QPoint& pt);
   void OnListOpenExplorer();
   void OnListOpenAssetDocument();

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -218,9 +218,10 @@ public:
 
   /// \brief Transforms all assets and writes the lookup tables. If the given platform is empty, the active platform is used.
   ezStatus TransformAllAssets(ezBitflags<ezTransformFlags> transformFlags, const ezPlatformProfile* pAssetProfile = nullptr);
-  void ResaveAllAssets();
   ezTransformStatus TransformAsset(const ezUuid& assetGuid, ezBitflags<ezTransformFlags> transformFlags, const ezPlatformProfile* pAssetProfile = nullptr);
   ezTransformStatus CreateThumbnail(const ezUuid& assetGuid);
+
+  void ResaveAllAssets(ezStringView sPrefixPath);
 
   /// Some assets are not automatically updated by the asset dependency detection (mainly Collections) because of their transitive data dependencies.
   /// So we must update them when the user does something 'significant' like doing TransformAllAssets or a scene export.

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -817,6 +817,11 @@ void ezQtAssetBrowserWidget::on_TreeFolderFilter_customContextMenuRequested(cons
     pAction->setToolTip("Whether to ignore '_data' folders when showing items in sub-folders is enabled.");
   }
 
+  {
+    QAction* pAction = m.addAction(QIcon(":/GuiFoundation/Icons/SaveAll.svg"), QLatin1String("Re-save Assets in Folder"), this, SLOT(OnResaveAssets()));
+    pAction->setToolTip("Opens every document and saves it. Used to get all documents to the latest version.");
+  }
+
   m.exec(TreeFolderFilter->viewport()->mapToGlobal(pt));
 }
 
@@ -869,6 +874,17 @@ void ezQtAssetBrowserWidget::OnShowSubFolderItemsToggled()
 void ezQtAssetBrowserWidget::OnShowHiddenFolderItemsToggled()
 {
   m_pFilter->SetShowItemsInHiddenFolders(!m_pFilter->GetShowItemsInHiddenFolders());
+}
+
+void ezQtAssetBrowserWidget::OnResaveAssets()
+{
+  if (QTreeWidgetItem* pCurrentItem = TreeFolderFilter->currentItem())
+  {
+    QModelIndex id = TreeFolderFilter->indexFromItem(pCurrentItem);
+    ezStringBuilder sAbsPath = qtToEzString(id.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString());
+
+    ezAssetCurator::GetSingleton()->ResaveAllAssets(sAbsPath);
+  }
 }
 
 void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoint& pt)

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -241,7 +241,7 @@ public:
 
       ezQtEditorApp::GetSingleton()->connect(ezQtEditorApp::GetSingleton(), &ezQtEditorApp::IdleEvent, ezQtEditorApp::GetSingleton(), [this]()
         {
-        ezAssetCurator::GetSingleton()->ResaveAllAssets();
+        ezAssetCurator::GetSingleton()->ResaveAllAssets("");
 
         if (opt_SaveProfilingData.GetOptionValue(ezCommandLineOption::LogMode::Always))
         {

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/DocumentActions.cpp
@@ -72,7 +72,6 @@ void ezDocumentActions::MapMenuActions(ezStringView sMapping, ezStringView sTarg
   pMap->MapAction(s_hCloseAll, sTargetMenu, 9.0f);
   pMap->MapAction(s_hCloseAllButThis, sTargetMenu, 10.0f);
   pMap->MapAction(s_hOpenContainingFolder, sTargetMenu, 11.0f);
-
   pMap->MapAction(s_hCopyAssetGuid, sTargetMenu, 12.0f);
 }
 


### PR DESCRIPTION
Resave assets is now a context menu option in the asset browser, and only operates on files in the selected folder.

Alos fixed incorrectly mapped menu entries.