### PR TITLE
Query fixes

### DIFF
--- a/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
@@ -64,6 +64,7 @@ private:
   {
     ezUInt64 m_uiNextIndex = 0;    // Next query index in this frame. Use % and / to find the pool / element index.
     ezUInt64 m_uiFrameCounter = 0; // ezGALDevice::GetCurrentFrame
+    ezUInt8 m_uiReadyFrames = 0;   ///< How many frames ago m_bReady was set on the last QueryPool in m_pools. Used to make sure frames are retained for s_uiRetainFrames after results become available.
     ezHybridArray<QueryPool*, 2> m_pools;
   };
 

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -92,7 +92,7 @@ namespace
 ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 {
   {
-    m_uiDelay = 0;
+    m_iDelay = 0;
     m_CPUTime[0] = {};
     m_CPUTime[1] = {};
     m_GPUTime[0] = {};
@@ -813,12 +813,12 @@ ezTestAppRun ezRendererTestPipelineStates::Timestamps()
         EZ_TEST_BOOL_MSG(m_CPUTime[0] <= (m_GPUTime[0] + epsilon), "%.4f < %.4f", m_CPUTime[0].GetMilliseconds(), m_GPUTime[0].GetMilliseconds());
         EZ_TEST_BOOL_MSG(m_GPUTime[0] <= m_GPUTime[1], "%.4f < %.4f", m_GPUTime[0].GetMilliseconds(), m_GPUTime[1].GetMilliseconds());
         EZ_TEST_BOOL_MSG(m_GPUTime[1] <= (m_CPUTime[1] + epsilon), "%.4f < %.4f", m_GPUTime[1].GetMilliseconds(), m_CPUTime[1].GetMilliseconds());
-        ezTestFramework::GetInstance()->Output(ezTestOutput::Message, "Timestamp results received after %d frames or %.2f ms (%d frames after fence)", m_iFrame - 2, (ezTime::Now() - m_CPUTime[0]).GetMilliseconds(), m_uiDelay);
+        ezTestFramework::GetInstance()->Output(ezTestOutput::Message, "Timestamp results received after %d frames or %.2f ms (%d frames after fence)", m_iFrame - 2, (ezTime::Now() - m_CPUTime[0]).GetMilliseconds(), m_iDelay);
         return ezTestAppRun::Quit;
       }
       else
       {
-        m_uiDelay++;
+        m_iDelay++;
       }
     }
   }
@@ -908,7 +908,7 @@ ezTestAppRun ezRendererTestPipelineStates::OcclusionQueries()
 
       if (bAllReady)
       {
-        ezTestFramework::GetInstance()->Output(ezTestOutput::Message, "Occlusion query results received after %d frames or %.2f ms (%d frames after fence)", m_iFrame - 3, (ezTime::Now() - m_CPUTime[0]).GetMilliseconds(), m_uiDelay);
+        ezTestFramework::GetInstance()->Output(ezTestOutput::Message, "Occlusion query results received after %d frames or %.2f ms (%d frames after fence)", m_iFrame - 3, (ezTime::Now() - m_CPUTime[0]).GetMilliseconds(), m_iDelay);
 
         EZ_TEST_INT(queryValues[0], 0);
         EZ_TEST_INT(queryValues[1], 0);
@@ -919,7 +919,7 @@ ezTestAppRun ezRendererTestPipelineStates::OcclusionQueries()
       }
       else
       {
-        m_uiDelay++;
+        m_iDelay++;
       }
     }
   }

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.h
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.h
@@ -102,14 +102,11 @@ private:
   ezGALTextureResourceViewHandle m_hTexture2DArray_Layer1_Mip0;
   ezGALTextureResourceViewHandle m_hTexture2DArray_Layer1_Mip1;
 
-  // Timestamps test
-  bool m_bTimestampsValid = false;
+  // Timestamps / Occlusion Queries test
+  ezInt32 m_uiDelay = 0;
   ezTime m_CPUTime[2];
   ezTime m_GPUTime[2];
   ezGALTimestampHandle m_timestamps[2];
-
-  // Occlusion Queries test
   ezGALOcclusionHandle m_queries[4];
-
   ezGALFenceHandle m_hFence = {};
 };

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.h
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.h
@@ -103,7 +103,7 @@ private:
   ezGALTextureResourceViewHandle m_hTexture2DArray_Layer1_Mip1;
 
   // Timestamps / Occlusion Queries test
-  ezInt32 m_uiDelay = 0;
+  ezInt32 m_iDelay = 0;
   ezTime m_CPUTime[2];
   ezTime m_GPUTime[2];
   ezGALTimestampHandle m_timestamps[2];


### PR DESCRIPTION
* Fixed bug in DX11: `FAILED` and `SUCCEEDED` macros must not be used as `S_FALSE` (results pending) and `S_OK` (results available) are both considered success codes.
* Some GPUs take much longer than the frame fence completing to return results. Thus, safe frames are ignored and we now count manually how many frames it has been since the results became available before dropping and resuing the query buffers. Here is a list of frame delays until results are available for timestamps and occlusion queries and how many frames after the frame fence the result become available:
TLDR: We can't use the frame fence to make any assumptions on the queries result state.

|                    | Timestamp frame delay | after frame fence | Occlusion frame delay | after frame fence |
|--------------------|-----------------------|-------------------|-----------------------|-------------------|
| RTX 3060 Vulkan    | 1                     | 0                 | 3-4                   | 2-3               |
| RTX 3060 DX11      | 2                     | 2                 | 0                     | 0                 |
| RX Vega APU Vulkan | 1-2                   | 0-1               | 1-2                   | 0-1               |
| RX Vega APU DX11   | 2-3                   | 1-2               | 0-1                   | 0                 |
| Radeon 760m Vulkan | 1                     | 0                 | 1-2                   | 0-1               |
| Radeon 760m DX11   | 2-3                   | 1-2               | 1                     | 0                 |