### PR TITLE
Minor improvements to AssetBrowser & FmodPlugin

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
@@ -56,6 +56,7 @@ public:
   /// \brief In dialog mode, any modifications (folder movement, creation and deletion) are disabled.
   void SetDialogMode(bool bDialogMode);
 
+  virtual void mouseDoubleClickEvent(QMouseEvent* e) override;
   virtual void mousePressEvent(QMouseEvent* e) override;
 
 public Q_SLOTS:
@@ -74,6 +75,7 @@ private Q_SLOTS:
 
 protected:
   virtual void dragMoveEvent(QDragMoveEvent* e) override;
+  virtual void mouseMoveEvent(QMouseEvent* e) override;
   virtual void dropEvent(QDropEvent* event) override;
   virtual Qt::DropActions supportedDropActions() const override;
   ezStatus canDrop(QDropEvent* e, ezDynamicArray<ezString>& out_files, ezString& out_sTargetFolder);

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserView.moc.h
@@ -31,6 +31,9 @@ Q_SIGNALS:
 
 protected:
   virtual void wheelEvent(QWheelEvent* pEvent) override;
+  virtual void mousePressEvent(QMouseEvent* pEvent) override;
+  virtual void mouseDoubleClickEvent(QMouseEvent* pEvent) override;
+  virtual void mouseMoveEvent(QMouseEvent* pEvent) override;
 
 private:
   bool m_bDialogMode;

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -97,6 +97,7 @@ private Q_SLOTS:
 
 private:
   virtual void keyPressEvent(QKeyEvent* e) override;
+  virtual void mousePressEvent(QMouseEvent* e) override;
 
 private:
   void AssetCuratorEventHandler(const ezAssetCuratorEvent& e);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
@@ -231,6 +231,17 @@ void eqQtAssetBrowserFolderView::dragMoveEvent(QDragMoveEvent* e)
   }
 }
 
+void eqQtAssetBrowserFolderView::mouseMoveEvent(QMouseEvent* e)
+{
+  // only allow dragging with left mouse button
+  if (state() == DraggingState && !e->buttons().testFlag(Qt::MouseButton::LeftButton))
+  {
+    return;
+  }
+
+  QTreeWidget::mouseMoveEvent(e);
+}
+
 ezStatus eqQtAssetBrowserFolderView::canDrop(QDropEvent* e, ezDynamicArray<ezString>& out_files, ezString& out_sTargetFolder)
 {
   if (!e->mimeData()->hasFormat("application/ezEditor.files"))
@@ -422,8 +433,25 @@ void eqQtAssetBrowserFolderView::OnFlushFileSystemEvents()
   m_QueuedFolderEvents.Clear();
 }
 
+void eqQtAssetBrowserFolderView::mouseDoubleClickEvent(QMouseEvent* e)
+{
+  if (e->button() == Qt::MouseButton::BackButton)
+  {
+    e->ignore();
+    return;
+  }
+
+  QTreeWidget::mouseDoubleClickEvent(e);
+}
+
 void eqQtAssetBrowserFolderView::mousePressEvent(QMouseEvent* e)
 {
+  if (e->button() == Qt::MouseButton::BackButton)
+  {
+    e->ignore();
+    return;
+  }
+
   QModelIndex inx = indexAt(e->pos());
   if (!inx.isValid())
     return;
@@ -477,6 +505,7 @@ bool eqQtAssetBrowserFolderView::SelectPathFilter(QTreeWidgetItem* pParent, cons
   if (pParent->data(0, ezQtAssetBrowserModel::UserRoles::RelativePath).toString() == sPath)
   {
     pParent->setSelected(true);
+    setCurrentIndex(indexFromItem(pParent));
     return true;
   }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -198,6 +198,39 @@ void ezQtAssetBrowserView::wheelEvent(QWheelEvent* pEvent)
   QListView::wheelEvent(pEvent);
 }
 
+void ezQtAssetBrowserView::mouseDoubleClickEvent(QMouseEvent* pEvent)
+{
+  if (pEvent->button() == Qt::MouseButton::BackButton)
+  {
+    pEvent->ignore();
+    return;
+  }
+
+  QListView::mouseDoubleClickEvent(pEvent);
+}
+
+void ezQtAssetBrowserView::mousePressEvent(QMouseEvent* pEvent)
+{
+  if (pEvent->button() == Qt::MouseButton::BackButton)
+  {
+    pEvent->ignore();
+    return;
+  }
+
+  QListView::mousePressEvent(pEvent);
+}
+
+void ezQtAssetBrowserView::mouseMoveEvent(QMouseEvent* pEvent)
+{
+  // only allow dragging with left mouse button
+  if (state() == DraggingState && !pEvent->buttons().testFlag(Qt::MouseButton::LeftButton))
+  {
+    return;
+  }
+
+  QListView::mouseMoveEvent(pEvent);
+}
+
 ezQtIconViewDelegate::ezQtIconViewDelegate(ezQtAssetBrowserView* pParent)
   : ezQtItemDelegate(pParent)
 {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -634,6 +634,24 @@ void ezQtAssetBrowserWidget::keyPressEvent(QKeyEvent* e)
   }
 }
 
+void ezQtAssetBrowserWidget::mousePressEvent(QMouseEvent* e)
+{
+  if (e->button() == Qt::MouseButton::BackButton)
+  {
+    e->accept();
+    ezStringBuilder sPath = m_pFilter->GetPathFilter();
+    if (sPath.IsEmpty())
+      return;
+    sPath.PathParentDirectory();
+    sPath.Trim("/");
+
+    m_pFilter->SetPathFilter(sPath);
+    return;
+  }
+
+  QWidget::mousePressEvent(e);
+}
+
 void ezQtAssetBrowserWidget::RenameCurrent()
 {
   m_bOpenAfterRename = false;

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.cpp
@@ -8,8 +8,6 @@
 ezSoundBankAssetDocumentWindow::ezSoundBankAssetDocumentWindow(ezDocument* pDocument)
   : ezQtDocumentWindow(pDocument)
 {
-  GetDocument()->GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&ezSoundBankAssetDocumentWindow::PropertyEventHandler, this));
-
   // Menu Bar
   {
     ezQtMenuBarActionMapView* pMenuBar = static_cast<ezQtMenuBarActionMapView*>(menuBar());
@@ -48,38 +46,6 @@ ezSoundBankAssetDocumentWindow::ezSoundBankAssetDocumentWindow(ezDocument* pDocu
 
   m_pAssetDoc = static_cast<ezSoundBankAssetDocument*>(pDocument);
 
-  m_pLabelInfo = new QLabel(this);
-  setCentralWidget(m_pLabelInfo);
-
-  m_pLabelInfo->setText("<Information>");
-
   FinishWindowCreation();
-
-  UpdatePreview();
 }
 
-ezSoundBankAssetDocumentWindow::~ezSoundBankAssetDocumentWindow()
-{
-  GetDocument()->GetObjectManager()->m_PropertyEvents.RemoveEventHandler(ezMakeDelegate(&ezSoundBankAssetDocumentWindow::PropertyEventHandler, this));
-}
-
-void ezSoundBankAssetDocumentWindow::UpdatePreview()
-{
-  const auto& prop = ((ezSoundBankAssetDocument*)GetDocument())->GetProperties();
-
-  // ezStringBuilder s;
-  // s.SetFormat("Vertices: {0}\nTriangles: {1}\nSubMeshes: {2}", prop->m_uiVertices, prop->m_uiTriangles, prop->m_SlotNames.GetCount());
-
-  // for (ezUInt32 m = 0; m < prop->m_SlotNames.GetCount(); ++m)
-  //  s.AppendFormat("\nSlot {0}: {1}", m, prop->m_SlotNames[m]);
-
-  // m_pLabelInfo->setText(QString::fromUtf8(s.GetData()));
-}
-
-void ezSoundBankAssetDocumentWindow::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
-{
-  // if (e.m_sPropertyPath == "Texture File")
-  //{
-  //  UpdatePreview();
-  //}
-}

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.h
@@ -15,18 +15,10 @@ class ezSoundBankAssetDocumentWindow : public ezQtDocumentWindow
 
 public:
   ezSoundBankAssetDocumentWindow(ezDocument* pDocument);
-  ~ezSoundBankAssetDocumentWindow();
 
   virtual const char* GetGroupName() const { return "SoundBankAsset"; }
   virtual const char* GetWindowLayoutGroupName() const override { return "SoundBankAsset"; }
 
-private Q_SLOTS:
-
-
 private:
-  void UpdatePreview();
-  void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);
-
   ezSoundBankAssetDocument* m_pAssetDoc;
-  QLabel* m_pLabelInfo;
 };


### PR DESCRIPTION
AssetBrowser:
- Dragging is now only possible with LeftMouse button
- MouseBack button now goes up a directory (fixes a part of https://github.com/ezEngine/ezEngine/issues/1194)
- Ensure actual selection & keyboard focus always match for AssetBrowserFolderView by doing a setCurrentIndex when changing path

Fmod Plugin:
- ezSoundBankAssets properties are now displayed in the center window + cleaned up copy&paste code
