### PR TITLE
Sort log-messages before copy pasting

### DIFF
--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
@@ -76,6 +76,8 @@ bool ezQtLogWidget::eventFilter(QObject* pObject, QEvent* pEvent)
       if (keyEvent->matches(QKeySequence::StandardKey::Copy))
       {
         QModelIndexList selection = ListViewLog->selectionModel()->selectedRows(0);
+        std::sort(selection.begin(), selection.end());
+
         QStringList sTemp;
         sTemp.reserve(selection.count());
         for (const QModelIndex& index : selection)


### PR DESCRIPTION
This ensures that the C&P log will always be from top to bottom, no matter in what order the selection happened inside the log view.

e.g. select log entries in a random order via Ctrl+Left Click and copy&paste into a text editor. 
Previously the order would be preserved (which is unintuitive), now the log messages are always from olders to newest
