### PR TITLE
Core clang-tidy static analysis for Engine & Editor

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -993,6 +993,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
       for (auto pProp : Permutations)
       {
+        EZ_ASSERT_DEBUG(pObject != nullptr, "Need object to write out permutation");
         const char* szName = pProp->GetPropertyName();
         if (pProp->GetSpecificType()->GetVariantType() == ezVariantType::Bool)
         {
@@ -1019,6 +1020,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
       for (auto pProp : Textures2D)
       {
+        EZ_ASSERT_DEBUG(pObject != nullptr, "Need object to write out texture");
         const char* szName = pProp->GetPropertyName();
         sValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezString>();
 
@@ -1034,6 +1036,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
       for (auto pProp : TexturesCube)
       {
+        EZ_ASSERT_DEBUG(pObject != nullptr, "Need object to write out texture cube");
         const char* szName = pProp->GetPropertyName();
         sValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezString>();
 
@@ -1049,6 +1052,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
       for (auto pProp : Constants)
       {
+        EZ_ASSERT_DEBUG(pObject != nullptr, "Need object to write out constant");
         const char* szName = pProp->GetPropertyName();
         ezVariant value = pObject->GetTypeAccessor().GetValue(szName);
 
@@ -1081,6 +1085,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
         // embed 2D texture data
         for (auto prop : Textures2D)
         {
+          EZ_ASSERT_DEBUG(pObject != nullptr, "Need object to write out texture2d");
           const char* szName = prop->GetPropertyName();
           sValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezString>();
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
@@ -899,6 +899,7 @@ ezResult ezVisualScriptCompiler::ReplaceUnsupportedNodes(AstNode* pEntryAstNode)
         branchNode.m_Next.PushBack(pNode->m_Next[1]);
 
         compareNode.m_Next.PushBack(&branchNode);
+        EZ_ASSERT_DEBUG(connection.m_pSource != nullptr, "");
         connection.m_pSource->m_Next[connection.m_uiSourcePinIndex] = &compareNode;
         connection.m_pTarget = &branchNode;
       }

--- a/Code/Engine/Foundation/IO/Implementation/DeduplicationReadContext_inl.h
+++ b/Code/Engine/Foundation/IO/Implementation/DeduplicationReadContext_inl.h
@@ -30,6 +30,7 @@ ezResult ezDeduplicationReadContext::ReadObject(ezStreamReader& inout_stream, T*
 
   if (bIsRealObject)
   {
+    EZ_ASSERT_DEBUG(pAllocator != nullptr, "Valid allocator required");
     ref_pObject = EZ_NEW(pAllocator, T);
     EZ_SUCCEED_OR_RETURN(ezStreamReaderUtil::Deserialize<T>(inout_stream, *ref_pObject));
 

--- a/Code/Engine/Foundation/Platform/Win/StackTracer_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/StackTracer_Win.cpp
@@ -117,6 +117,11 @@ namespace
     // and we don't get any callstacks
     // the multi-step approach below has worked in known problematic scenarios, but no guarantee that there isn't a better "right way" to do it
 
+    if(s_pImplementation->symbolInitialize == nullptr || s_pImplementation->symRefreshModuleList == nullptr || s_pImplementation->symCleanup == nullptr)
+    {
+      return false;
+    }
+
     // try SymInitialize first
     if ((*s_pImplementation->symbolInitialize)(GetCurrentProcess(), nullptr, TRUE))
       return true;

--- a/Code/Engine/Foundation/Platform/Win/StackTracer_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/StackTracer_Win.cpp
@@ -117,7 +117,7 @@ namespace
     // and we don't get any callstacks
     // the multi-step approach below has worked in known problematic scenarios, but no guarantee that there isn't a better "right way" to do it
 
-    if(s_pImplementation->symbolInitialize == nullptr || s_pImplementation->symRefreshModuleList == nullptr || s_pImplementation->symCleanup == nullptr)
+    if (s_pImplementation->symbolInitialize == nullptr || s_pImplementation->symRefreshModuleList == nullptr || s_pImplementation->symCleanup == nullptr)
     {
       return false;
     }

--- a/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/ReflectionUtils.cpp
@@ -423,6 +423,7 @@ namespace
   {
     EZ_FORCE_INLINE static void impl(ezVariant* pVector, ezUInt32 uiComponent, double fValue)
     {
+      EZ_ASSERT_DEBUG(uiComponent < 2, "uiComponent out of range");
       auto vec = pVector->Get<ezVec2Template<T>>();
       switch (uiComponent)
       {
@@ -442,6 +443,7 @@ namespace
   {
     EZ_FORCE_INLINE static void impl(ezVariant* pVector, ezUInt32 uiComponent, double fValue)
     {
+      EZ_ASSERT_DEBUG(uiComponent < 3, "uiComponent out of range");
       auto vec = pVector->Get<ezVec3Template<T>>();
       switch (uiComponent)
       {
@@ -464,6 +466,7 @@ namespace
   {
     EZ_FORCE_INLINE static void impl(ezVariant* pVector, ezUInt32 uiComponent, double fValue)
     {
+      EZ_ASSERT_DEBUG(uiComponent < 4, "uiComponent out of range");
       auto vec = pVector->Get<ezVec4Template<T>>();
       switch (uiComponent)
       {
@@ -513,6 +516,7 @@ namespace
   {
     EZ_FORCE_INLINE static void impl(const ezVariant* pVector, ezUInt32 uiComponent, double& out_fValue)
     {
+      EZ_ASSERT_DEBUG(uiComponent < 2, "uiComponent out of range");
       const auto& vec = pVector->Get<ezVec2Template<T>>();
       switch (uiComponent)
       {
@@ -531,6 +535,7 @@ namespace
   {
     EZ_FORCE_INLINE static void impl(const ezVariant* pVector, ezUInt32 uiComponent, double& out_fValue)
     {
+      EZ_ASSERT_DEBUG(uiComponent < 3, "uiComponent out of range");
       const auto& vec = pVector->Get<ezVec3Template<T>>();
       switch (uiComponent)
       {
@@ -552,6 +557,7 @@ namespace
   {
     EZ_FORCE_INLINE static void impl(const ezVariant* pVector, ezUInt32 uiComponent, double& out_fValue)
     {
+      EZ_ASSERT_DEBUG(uiComponent < 4, "uiComponent out of range");
       const auto& vec = pVector->Get<ezVec4Template<T>>();
       switch (uiComponent)
       {

--- a/Code/Engine/Foundation/Types/Implementation/SharedPtr_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/SharedPtr_inl.h
@@ -295,6 +295,7 @@ EZ_ALWAYS_INLINE void ezSharedPtr<T>::ReleaseReferenceIfValid()
     if (m_pInstance->ReleaseRef() == 0)
     {
       auto pNonConstInstance = const_cast<typename ezTypeTraits<T>::NonConstType*>(m_pInstance);
+      EZ_ASSERT_DEV(m_pAllocator != nullptr, "Fake shared pointers should never be released");
       EZ_DELETE(m_pAllocator, pNonConstInstance);
     }
 

--- a/Code/Engine/Foundation/Types/Implementation/VariantHelper_inl.h
+++ b/Code/Engine/Foundation/Types/Implementation/VariantHelper_inl.h
@@ -530,7 +530,7 @@ class ezVariantHelper
     EZ_ALWAYS_INLINE void operator()()
     {
       ezStringBuilder tmp;
-      *m_pResult = ezConversionUtils::ToString(m_pThis->Cast<T>(), tmp);
+      *m_pResult = ezConversionUtils::ToString(m_pThis->Cast<T>(), tmp); // NOLINT (clang-analyzer-core.CallAndMessage)
     }
 
     const ezVariant* m_pThis;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -456,9 +456,12 @@ void ezRenderContext::SetPushConstants(const ezTempHashedString& sSlotName, ezAr
     EZ_ASSERT_DEBUG(data.GetCount() <= 128, "Push constants are not allowed to be bigger than 128 bytes.");
     ezConstantBufferStorageBase* pStorage = nullptr;
     bool bResult = TryGetConstantBufferStorage(m_hPushConstantsStorage, pStorage);
-    ezArrayPtr<ezUInt8> targetStorage = pStorage->GetRawDataForWriting();
-    ezMemoryUtils::Copy(targetStorage.GetPtr(), data.GetPtr(), data.GetCount());
-    BindConstantBuffer(sSlotName, m_hPushConstantsStorage);
+    if(bResult)
+    {
+      ezArrayPtr<ezUInt8> targetStorage = pStorage->GetRawDataForWriting();
+      ezMemoryUtils::Copy(targetStorage.GetPtr(), data.GetPtr(), data.GetCount());
+      BindConstantBuffer(sSlotName, m_hPushConstantsStorage);
+    }
   }
   else
   {

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -456,7 +456,7 @@ void ezRenderContext::SetPushConstants(const ezTempHashedString& sSlotName, ezAr
     EZ_ASSERT_DEBUG(data.GetCount() <= 128, "Push constants are not allowed to be bigger than 128 bytes.");
     ezConstantBufferStorageBase* pStorage = nullptr;
     bool bResult = TryGetConstantBufferStorage(m_hPushConstantsStorage, pStorage);
-    if(bResult)
+    if (bResult)
     {
       ezArrayPtr<ezUInt8> targetStorage = pStorage->GetRawDataForWriting();
       ezMemoryUtils::Copy(targetStorage.GetPtr(), data.GetPtr(), data.GetCount());

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -67,7 +67,14 @@ void ezGALCommandEncoderImplDX11::SetShaderPlatform(const ezGALShader* pShader)
   {
     m_pDXContext->HSSetShader(pHS, nullptr, 0);
     m_pBoundShaders[ezGALShaderStage::HullShader] = pHS;
-    m_uiTessellationPatchControlPoints = pShader->GetDescription().m_ByteCodes[ezGALShaderStage::HullShader]->m_uiTessellationPatchControlPoints;
+    if (pShader)
+    {
+      m_uiTessellationPatchControlPoints = pShader->GetDescription().m_ByteCodes[ezGALShaderStage::HullShader]->m_uiTessellationPatchControlPoints;
+    }
+    else
+    {
+      m_uiTessellationPatchControlPoints = 0;
+    }
   }
 
   if (pDS != m_pBoundShaders[ezGALShaderStage::DomainShader])

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1571,7 +1571,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALShaderHandle hShader(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALShader* pShader = nullptr;
 
-        m_Shaders.Remove(hShader, &pShader);
+        EZ_VERIFY(m_Shaders.Remove(hShader, &pShader), "");
 
         DestroyShaderPlatform(pShader);
 
@@ -1582,7 +1582,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALBufferHandle hBuffer(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALBuffer* pBuffer = nullptr;
 
-        m_Buffers.Remove(hBuffer, &pBuffer);
+        EZ_VERIFY(m_Buffers.Remove(hBuffer, &pBuffer), "");
 
         DestroyViews(pBuffer);
         DestroyBufferPlatform(pBuffer);
@@ -1648,7 +1648,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALRenderTargetViewHandle hRenderTargetView(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALRenderTargetView* pRenderTargetView = nullptr;
 
-        m_RenderTargetViews.Remove(hRenderTargetView, &pRenderTargetView);
+        EZ_VERIFY(m_RenderTargetViews.Remove(hRenderTargetView, &pRenderTargetView), "");
 
         ezGALTexture* pTexture = pRenderTargetView->m_pTexture;
         EZ_ASSERT_DEBUG(pTexture != nullptr, "");
@@ -1696,7 +1696,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALSwapChainHandle hSwapChain(ezGAL::ez16_16Id(deadObject.m_uiHandle));
         ezGALSwapChain* pSwapChain = nullptr;
 
-        m_SwapChains.Remove(hSwapChain, &pSwapChain);
+        EZ_VERIFY(m_SwapChains.Remove(hSwapChain, &pSwapChain), "");
 
         if (pSwapChain != nullptr)
         {

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1614,7 +1614,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALTextureResourceViewHandle hResourceView(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALTextureResourceView* pResourceView = nullptr;
 
-        m_TextureResourceViews.Remove(hResourceView, &pResourceView);
+        EZ_VERIFY(m_TextureResourceViews.Remove(hResourceView, &pResourceView), "");
 
         ezGALTexture* pResource = pResourceView->m_pResource;
         EZ_ASSERT_DEBUG(pResource != nullptr, "");
@@ -1631,7 +1631,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALBufferResourceViewHandle hResourceView(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALBufferResourceView* pResourceView = nullptr;
 
-        m_BufferResourceViews.Remove(hResourceView, &pResourceView);
+        EZ_VERIFY(m_BufferResourceViews.Remove(hResourceView, &pResourceView), "");
 
         ezGALBuffer* pResource = pResourceView->m_pResource;
         EZ_ASSERT_DEBUG(pResource != nullptr, "");
@@ -1664,7 +1664,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALTextureUnorderedAccessViewHandle hUnorderedAccessViewHandle(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALTextureUnorderedAccessView* pUnorderedAccesssView = nullptr;
 
-        m_TextureUnorderedAccessViews.Remove(hUnorderedAccessViewHandle, &pUnorderedAccesssView);
+        EZ_VERIFY(m_TextureUnorderedAccessViews.Remove(hUnorderedAccessViewHandle, &pUnorderedAccesssView), "");
 
         ezGALTexture* pResource = pUnorderedAccesssView->m_pResource;
         EZ_ASSERT_DEBUG(pResource != nullptr, "");
@@ -1680,7 +1680,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALBufferUnorderedAccessViewHandle hUnorderedAccessViewHandle(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALBufferUnorderedAccessView* pUnorderedAccesssView = nullptr;
 
-        m_BufferUnorderedAccessViews.Remove(hUnorderedAccessViewHandle, &pUnorderedAccesssView);
+        EZ_VERIFY(m_BufferUnorderedAccessViews.Remove(hUnorderedAccessViewHandle, &pUnorderedAccesssView), "");
 
         ezGALBuffer* pResource = pUnorderedAccesssView->m_pResource;
         EZ_ASSERT_DEBUG(pResource != nullptr, "");

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -10,6 +10,7 @@
 void FillCastResult(ezPhysicsCastResult& ref_result, const ezVec3& vStart, const ezVec3& vDir, float fDistance, const JPH::BodyID& bodyId, const JPH::SubShapeID& subShapeId, const JPH::BodyLockInterface& lockInterface, const JPH::BodyInterface& bodyInterface, const ezJoltWorldModule* pModule)
 {
   JPH::BodyLockRead bodyLock(lockInterface, bodyId);
+  EZ_ASSERT_DEBUG(bodyLock.Succeeded(), "Failed to get body lock");
   const auto& body = bodyLock.GetBody();
   ref_result.m_vNormal = ezJoltConversionUtils::ToVec3(body.GetWorldSpaceSurfaceNormal(subShapeId, ezJoltConversionUtils::ToVec3(ref_result.m_vPosition)));
   ref_result.m_uiObjectFilterID = body.GetCollisionGroup().GetGroupID();
@@ -343,6 +344,7 @@ void ezJoltWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_res
     auto& overlapHit = collector.m_Results[i];
 
     JPH::BodyLockRead bodyLock(lockInterface, overlapHit.mBodyID2);
+    EZ_ASSERT_DEBUG(bodyLock.Succeeded(), "Failed to get body lock");
     const auto& body = bodyLock.GetBody();
 
     overlapResult.m_uiObjectFilterID = body.GetCollisionGroup().GetGroupID();

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXRSpatialAnchors.cpp
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXRSpatialAnchors.cpp
@@ -20,9 +20,11 @@ ezOpenXRSpatialAnchors::~ezOpenXRSpatialAnchors()
   for (auto it = m_Anchors.GetIterator(); it.IsValid(); ++it)
   {
     AnchorData anchorData;
-    m_Anchors.TryGetValue(it.Id(), anchorData);
-    XR_LOG_ERROR(m_pOpenXR->m_Extensions.pfn_xrDestroySpatialAnchorMSFT(anchorData.m_Anchor));
-    XR_LOG_ERROR(xrDestroySpace(anchorData.m_Space));
+    if (m_Anchors.TryGetValue(it.Id(), anchorData))
+    {
+      XR_LOG_ERROR(m_pOpenXR->m_Extensions.pfn_xrDestroySpatialAnchorMSFT(anchorData.m_Anchor));
+      XR_LOG_ERROR(xrDestroySpace(anchorData.m_Space));
+    }
   }
   m_Anchors.Clear();
 }

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
@@ -415,6 +415,7 @@ void ezParticleTypeQuad::CreateExtractedData(const ezHybridArray<sod, 64>* pSort
     }
     else if (m_Orientation == ezQuadParticleOrientation::FixedAxis_ParticleDir)
     {
+      EZ_ASSERT_DEBUG(pLastPosition != nullptr, "FixedAxis_ParticleDir needs the last position attribute");
       for (ezUInt32 p = 0; p < numParticles; ++p)
       {
         SetTangentDataAligned_ParticleDir(p, redirect(p, pSorted));

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.cpp
@@ -255,9 +255,9 @@ ezScriptMessageDesc ezVisualScriptGraphDescription::GetMessageDesc() const
 {
   auto pEntryNode = GetNode(0);
   EZ_ASSERT_DEBUG(pEntryNode != nullptr &&
-                      pEntryNode->m_Type == ezVisualScriptNodeDescription::Type::MessageHandler ||
-                    pEntryNode->m_Type == ezVisualScriptNodeDescription::Type::MessageHandler_Coroutine ||
-                    pEntryNode->m_Type == ezVisualScriptNodeDescription::Type::SendMessage,
+                    (pEntryNode->m_Type == ezVisualScriptNodeDescription::Type::MessageHandler ||
+                      pEntryNode->m_Type == ezVisualScriptNodeDescription::Type::MessageHandler_Coroutine ||
+                      pEntryNode->m_Type == ezVisualScriptNodeDescription::Type::SendMessage),
     "Entry node is invalid or not a message handler");
 
   auto& userData = pEntryNode->GetUserData<NodeUserData_TypeAndProperties>();

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -86,8 +86,7 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
   {
     QAction* pRevert = m.addAction("Revert to Default");
     pRevert->setEnabled(!m_bIsDefault);
-    connect(pRevert, &QAction::triggered, this, [this]()
-      {
+    connect(pRevert, &QAction::triggered, this, [this]() {
       m_pObjectAccessor->StartTransaction("Revert to Default");
 
       switch (m_pProp->GetCategory())
@@ -171,8 +170,7 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
       pCopy->setToolTip("No common value in selection");
     }
 
-    connect(pCopy, &QAction::triggered, this, [this, szMimeType, commonValue]()
-      {
+    connect(pCopy, &QAction::triggered, this, [this, szMimeType, commonValue]() {
       ezPropertyClipboard content;
       content.m_Type = m_pProp->GetSpecificType()->GetTypeName();
       content.m_Value = commonValue;
@@ -250,8 +248,7 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
         sTemp.SetFormat("The member property '{}' has an ezClampValueAttribute but ezReflectionUtils::ClampValue failed.", m_pProp->GetPropertyName());
       }
 
-      connect(pPaste, &QAction::triggered, this, [this, content]()
-        {
+      connect(pPaste, &QAction::triggered, this, [this, content]() {
         m_pObjectAccessor->StartTransaction("Paste Value");
         if (content.m_Value.IsA<ezVariantArray>())
         {
@@ -291,8 +288,7 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
 
   // copy internal name
   {
-    auto lambda = [this]()
-    {
+    auto lambda = [this]() {
       QClipboard* clipboard = QApplication::clipboard();
       QMimeData* mimeData = new QMimeData();
       mimeData->setText(m_pProp->GetPropertyName());
@@ -746,8 +742,7 @@ void ezQtPropertyPointerWidget::StructureEventHandler(const ezDocumentObjectStru
         return;
 
       if (std::none_of(cbegin(m_Items), cend(m_Items),
-            [&](const ezPropertySelection& sel)
-            { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
+            [&](const ezPropertySelection& sel) { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
         return;
 
       SetSelection(m_Items);
@@ -831,8 +826,7 @@ void ezQtEmbeddedClassPropertyWidget::PropertyEventHandler(const ezDocumentObjec
   if (IsUndead())
     return;
 
-  if (std::none_of(cbegin(m_ResolvedObjects), cend(m_ResolvedObjects), [=](const ezPropertySelection& sel)
-        { return e.m_pObject == sel.m_pObject; }))
+  if (std::none_of(cbegin(m_ResolvedObjects), cend(m_ResolvedObjects), [=](const ezPropertySelection& sel) { return e.m_pObject == sel.m_pObject; }))
     return;
 
   if (!m_QueuedChanges.Contains(e.m_sProperty))
@@ -1046,8 +1040,7 @@ void ezQtPropertyContainerWidget::dropEvent(QDropEvent* event)
   {
     ezQtGroupBoxBase* pGroup = qobject_cast<ezQtGroupBoxBase*>(event->source());
     Element* pDragElement =
-      std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool
-        { return elem.m_pSubGroup == pGroup; });
+      std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool { return elem.m_pSubGroup == pGroup; });
     if (pDragElement)
     {
       const ezAbstractProperty* pProp = pDragElement->m_pWidget->GetProperty();
@@ -1176,8 +1169,7 @@ void ezQtPropertyContainerWidget::OnDragStarted(QMimeData& ref_mimeData)
 {
   ezQtGroupBoxBase* pGroup = qobject_cast<ezQtGroupBoxBase*>(sender());
   Element* pDragElement =
-    std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool
-      { return elem.m_pSubGroup == pGroup; });
+    std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool { return elem.m_pSubGroup == pGroup; });
   if (pDragElement)
   {
     ref_mimeData.setData("application/x-groupBoxDragProperty", QByteArray());
@@ -1201,8 +1193,7 @@ void ezQtPropertyContainerWidget::OnContainerContextMenu(const QPoint& pt)
 void ezQtPropertyContainerWidget::OnCustomElementContextMenu(const QPoint& pt)
 {
   ezQtGroupBoxBase* pGroup = qobject_cast<ezQtGroupBoxBase*>(sender());
-  Element* pElement = std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool
-    { return elem.m_pSubGroup == pGroup; });
+  Element* pElement = std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool { return elem.m_pSubGroup == pGroup; });
 
   if (pElement)
   {
@@ -1334,8 +1325,7 @@ ezUInt32 ezQtPropertyContainerWidget::GetRequiredElementCount() const
         }
       }
     }
-    m_Keys.Sort([](const ezVariant& a, const ezVariant& b)
-      { return a.Get<ezString>().Compare(b.Get<ezString>()) < 0; });
+    m_Keys.Sort([](const ezVariant& a, const ezVariant& b) { return a.Get<ezString>().Compare(b.Get<ezString>()) < 0; });
     return m_Keys.GetCount();
   }
   else
@@ -1678,8 +1668,7 @@ void ezQtPropertyTypeContainerWidget::UpdateElement(ezUInt32 index)
       if (!url.isEmpty())
       {
         elem.m_pHelpButton->setVisible(true);
-        connect(elem.m_pHelpButton, &QToolButton::clicked, this, [=]()
-          { QDesktopServices::openUrl(QUrl(url)); });
+        connect(elem.m_pHelpButton, &QToolButton::clicked, this, [=]() { QDesktopServices::openUrl(QUrl(url)); });
       }
       else
       {
@@ -1708,8 +1697,7 @@ void ezQtPropertyTypeContainerWidget::StructureEventHandler(const ezDocumentObje
         return;
 
       if (std::none_of(cbegin(m_Items), cend(m_Items),
-            [&](const ezPropertySelection& sel)
-            { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
+            [&](const ezPropertySelection& sel) { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
         return;
 
       m_bNeedsUpdate = true;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -86,7 +86,8 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
   {
     QAction* pRevert = m.addAction("Revert to Default");
     pRevert->setEnabled(!m_bIsDefault);
-    connect(pRevert, &QAction::triggered, this, [this]() {
+    connect(pRevert, &QAction::triggered, this, [this]()
+      {
       m_pObjectAccessor->StartTransaction("Revert to Default");
 
       switch (m_pProp->GetCategory())
@@ -170,7 +171,8 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
       pCopy->setToolTip("No common value in selection");
     }
 
-    connect(pCopy, &QAction::triggered, this, [this, szMimeType, commonValue]() {
+    connect(pCopy, &QAction::triggered, this, [this, szMimeType, commonValue]()
+      {
       ezPropertyClipboard content;
       content.m_Type = m_pProp->GetSpecificType()->GetTypeName();
       content.m_Value = commonValue;
@@ -248,7 +250,8 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
         sTemp.SetFormat("The member property '{}' has an ezClampValueAttribute but ezReflectionUtils::ClampValue failed.", m_pProp->GetPropertyName());
       }
 
-      connect(pPaste, &QAction::triggered, this, [this, content]() {
+      connect(pPaste, &QAction::triggered, this, [this, content]()
+        {
         m_pObjectAccessor->StartTransaction("Paste Value");
         if (content.m_Value.IsA<ezVariantArray>())
         {
@@ -288,7 +291,8 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
 
   // copy internal name
   {
-    auto lambda = [this]() {
+    auto lambda = [this]()
+    {
       QClipboard* clipboard = QApplication::clipboard();
       QMimeData* mimeData = new QMimeData();
       mimeData->setText(m_pProp->GetPropertyName());
@@ -742,7 +746,8 @@ void ezQtPropertyPointerWidget::StructureEventHandler(const ezDocumentObjectStru
         return;
 
       if (std::none_of(cbegin(m_Items), cend(m_Items),
-            [&](const ezPropertySelection& sel) { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
+            [&](const ezPropertySelection& sel)
+            { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
         return;
 
       SetSelection(m_Items);
@@ -826,7 +831,8 @@ void ezQtEmbeddedClassPropertyWidget::PropertyEventHandler(const ezDocumentObjec
   if (IsUndead())
     return;
 
-  if (std::none_of(cbegin(m_ResolvedObjects), cend(m_ResolvedObjects), [=](const ezPropertySelection& sel) { return e.m_pObject == sel.m_pObject; }))
+  if (std::none_of(cbegin(m_ResolvedObjects), cend(m_ResolvedObjects), [=](const ezPropertySelection& sel)
+        { return e.m_pObject == sel.m_pObject; }))
     return;
 
   if (!m_QueuedChanges.Contains(e.m_sProperty))
@@ -1040,7 +1046,8 @@ void ezQtPropertyContainerWidget::dropEvent(QDropEvent* event)
   {
     ezQtGroupBoxBase* pGroup = qobject_cast<ezQtGroupBoxBase*>(event->source());
     Element* pDragElement =
-      std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool { return elem.m_pSubGroup == pGroup; });
+      std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool
+        { return elem.m_pSubGroup == pGroup; });
     if (pDragElement)
     {
       const ezAbstractProperty* pProp = pDragElement->m_pWidget->GetProperty();
@@ -1169,7 +1176,8 @@ void ezQtPropertyContainerWidget::OnDragStarted(QMimeData& ref_mimeData)
 {
   ezQtGroupBoxBase* pGroup = qobject_cast<ezQtGroupBoxBase*>(sender());
   Element* pDragElement =
-    std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool { return elem.m_pSubGroup == pGroup; });
+    std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool
+      { return elem.m_pSubGroup == pGroup; });
   if (pDragElement)
   {
     ref_mimeData.setData("application/x-groupBoxDragProperty", QByteArray());
@@ -1193,7 +1201,8 @@ void ezQtPropertyContainerWidget::OnContainerContextMenu(const QPoint& pt)
 void ezQtPropertyContainerWidget::OnCustomElementContextMenu(const QPoint& pt)
 {
   ezQtGroupBoxBase* pGroup = qobject_cast<ezQtGroupBoxBase*>(sender());
-  Element* pElement = std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool { return elem.m_pSubGroup == pGroup; });
+  Element* pElement = std::find_if(begin(m_Elements), end(m_Elements), [pGroup](const Element& elem) -> bool
+    { return elem.m_pSubGroup == pGroup; });
 
   if (pElement)
   {
@@ -1325,7 +1334,8 @@ ezUInt32 ezQtPropertyContainerWidget::GetRequiredElementCount() const
         }
       }
     }
-    m_Keys.Sort([](const ezVariant& a, const ezVariant& b) { return a.Get<ezString>().Compare(b.Get<ezString>()) < 0; });
+    m_Keys.Sort([](const ezVariant& a, const ezVariant& b)
+      { return a.Get<ezString>().Compare(b.Get<ezString>()) < 0; });
     return m_Keys.GetCount();
   }
   else
@@ -1668,7 +1678,8 @@ void ezQtPropertyTypeContainerWidget::UpdateElement(ezUInt32 index)
       if (!url.isEmpty())
       {
         elem.m_pHelpButton->setVisible(true);
-        connect(elem.m_pHelpButton, &QToolButton::clicked, this, [=]() { QDesktopServices::openUrl(QUrl(url)); });
+        connect(elem.m_pHelpButton, &QToolButton::clicked, this, [=]()
+          { QDesktopServices::openUrl(QUrl(url)); });
       }
       else
       {
@@ -1697,7 +1708,8 @@ void ezQtPropertyTypeContainerWidget::StructureEventHandler(const ezDocumentObje
         return;
 
       if (std::none_of(cbegin(m_Items), cend(m_Items),
-            [&](const ezPropertySelection& sel) { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
+            [&](const ezPropertySelection& sel)
+            { return e.m_pNewParent == sel.m_pObject || e.m_pPreviousParent == sel.m_pObject; }))
         return;
 
       m_bNeedsUpdate = true;

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectMirror.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/DocumentObjectMirror.cpp
@@ -439,6 +439,8 @@ void ezDocumentObjectMirror::ApplyOp(ezObjectChange& change)
     // EZ_ASSERT_DEV(object.m_pObject != nullptr, "Root object does not exist in mirrored native object!");
   }
 
+  EZ_ASSERT_DEBUG(object.m_pType != nullptr, "Object must have valid type");
+
   ezPropertyPath propPath;
   if (propPath.InitializeFromPath(object.m_pType, change.m_Steps).Failed())
   {

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -67,7 +67,8 @@ void ezEditorAssetDocumentTest::AsyncSave()
     sName = m_sProjectPath;
     sName.AppendPath("mesh.ezMeshAsset");
     pDoc = static_cast<ezAssetDocument*>(m_pApplication->m_pEditorApp->CreateDocument(sName, ezDocumentFlags::RequestWindow));
-    EZ_TEST_BOOL(pDoc != nullptr);
+    if (!EZ_TEST_BOOL(pDoc != nullptr))
+      return;
     ProcessEvents();
   }
 
@@ -122,7 +123,8 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
     ezStringBuilder sName = m_sProjectPath;
     sName.AppendPath("mesh2.ezMeshAsset");
     pDoc = static_cast<ezAssetDocument*>(m_pApplication->m_pEditorApp->CreateDocument(sName, ezDocumentFlags::RequestWindow));
-    EZ_TEST_BOOL(pDoc != nullptr);
+    if(!EZ_TEST_BOOL(pDoc != nullptr))
+      return;
     ProcessEvents();
   }
 

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -123,7 +123,7 @@ void ezEditorAssetDocumentTest::SaveOnTransform()
     ezStringBuilder sName = m_sProjectPath;
     sName.AppendPath("mesh2.ezMeshAsset");
     pDoc = static_cast<ezAssetDocument*>(m_pApplication->m_pEditorApp->CreateDocument(sName, ezDocumentFlags::RequestWindow));
-    if(!EZ_TEST_BOOL(pDoc != nullptr))
+    if (!EZ_TEST_BOOL(pDoc != nullptr))
       return;
     ProcessEvents();
   }

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -57,6 +57,7 @@ ezTestAppRun ezEditorTestMisc::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvoca
     if (!EZ_TEST_BOOL(m_pDocument != nullptr))
       return ezTestAppRun::Quit;
 
+    EZ_ANALYSIS_ASSUME(m_pDocument != nullptr);
     ezAssetCurator::GetSingleton()->TransformAsset(m_pDocument->GetGuid(), ezTransformFlags::Default);
 
     ezQtEngineDocumentWindow* pWindow = qobject_cast<ezQtEngineDocumentWindow*>(ezQtDocumentWindow::FindWindowByDocument(m_pDocument));
@@ -64,6 +65,7 @@ ezTestAppRun ezEditorTestMisc::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvoca
     if (!EZ_TEST_BOOL(pWindow != nullptr))
       return ezTestAppRun::Quit;
 
+    EZ_ANALYSIS_ASSUME(pWindow != nullptr);
     auto viewWidgets = pWindow->GetViewWidgets();
 
     if (!EZ_TEST_BOOL(!viewWidgets.IsEmpty()))

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -95,6 +95,7 @@ ezResult ezEditorSceneDocumentTest::CreateSimpleScene(const char* szSceneName)
     if (!EZ_TEST_BOOL(m_pDoc != nullptr))
       return EZ_FAILURE;
 
+    EZ_ANALYSIS_ASSUME(m_pDoc != nullptr);
     m_SceneGuid = m_pDoc->GetGuid();
     ProcessEvents();
     EZ_TEST_STATUS(m_pDoc->CreateLayer("Layer1", m_LayerGuid));
@@ -157,6 +158,7 @@ void ezEditorSceneDocumentTest::LayerOperations()
     if (!EZ_TEST_BOOL(pDoc != nullptr))
       return;
 
+    EZ_ANALYSIS_ASSUME(pDoc != nullptr);
     sceneGuid = pDoc->GetGuid();
     layerEventsID = pDoc->m_LayerEvents.AddEventHandler(TestLayerEvents);
     ProcessEvents();
@@ -228,6 +230,8 @@ void ezEditorSceneDocumentTest::LayerOperations()
     pDoc = static_cast<ezScene2Document*>(m_pApplication->m_pEditorApp->OpenDocument(sName, ezDocumentFlags::RequestWindow));
     if (!EZ_TEST_BOOL(pDoc != nullptr))
       return;
+
+    EZ_ANALYSIS_ASSUME(pDoc != nullptr);
     layerEventsID = pDoc->m_LayerEvents.AddEventHandler(TestLayerEvents);
     ProcessEvents();
 

--- a/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/TagSetTest.cpp
@@ -32,12 +32,15 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
 
     const ezTag* SecondInstance2 = TempTestRegistry.GetTagByName("BASIC_TAG_TEST");
 
-    EZ_TEST_BOOL(SecondInstance2 != nullptr);
-    EZ_TEST_BOOL(SecondInstance2->IsValid());
+    if (EZ_TEST_BOOL(SecondInstance2 != nullptr))
+    {
+      EZ_ANALYSIS_ASSUME(SecondInstance2 != nullptr);
+      EZ_TEST_BOOL(SecondInstance2->IsValid());
 
-    EZ_TEST_BOOL(&SecondInstance == SecondInstance2);
+      EZ_TEST_BOOL(&SecondInstance == SecondInstance2);
 
-    EZ_TEST_STRING(SecondInstance2->GetTagString(), "BASIC_TAG_TEST");
+      EZ_TEST_STRING(SecondInstance2->GetTagString(), "BASIC_TAG_TEST");
+    }
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Basic Tag Registration")
@@ -64,39 +67,42 @@ EZ_CREATE_SIMPLE_TEST(Basics, TagSet)
     TempTestRegistry.RegisterTag("TEST_TAG1");
 
     const ezTag* TestTag1 = TempTestRegistry.GetTagByName("TEST_TAG1");
-    EZ_TEST_BOOL(TestTag1 != nullptr);
+    if (EZ_TEST_BOOL(TestTag1 != nullptr))
+    {
+      EZ_ANALYSIS_ASSUME(TestTag1 != nullptr);
 
-    const ezTag& TestTag2 = TempTestRegistry.RegisterTag("TEST_TAG2");
+      const ezTag& TestTag2 = TempTestRegistry.RegisterTag("TEST_TAG2");
 
-    EZ_TEST_BOOL(TestTag2.IsValid());
+      EZ_TEST_BOOL(TestTag2.IsValid());
 
-    ezTagSet tagSet;
+      ezTagSet tagSet;
 
-    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
+      EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+      EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == false);
 
-    tagSet.Set(TestTag2);
+      tagSet.Set(TestTag2);
 
-    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
-    EZ_TEST_INT(tagSet.GetNumTagsSet(), 1);
+      EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+      EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
+      EZ_TEST_INT(tagSet.GetNumTagsSet(), 1);
 
-    tagSet.Set(*TestTag1);
+      tagSet.Set(*TestTag1);
 
-    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == true);
-    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
-    EZ_TEST_INT(tagSet.GetNumTagsSet(), 2);
+      EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == true);
+      EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
+      EZ_TEST_INT(tagSet.GetNumTagsSet(), 2);
 
-    tagSet.Remove(*TestTag1);
+      tagSet.Remove(*TestTag1);
 
-    EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
-    EZ_TEST_INT(tagSet.GetNumTagsSet(), 1);
+      EZ_TEST_BOOL(tagSet.IsSet(*TestTag1) == false);
+      EZ_TEST_BOOL(tagSet.IsSet(TestTag2) == true);
+      EZ_TEST_INT(tagSet.GetNumTagsSet(), 1);
 
-    ezTagSet tagSet2 = tagSet;
-    EZ_TEST_BOOL(tagSet2.IsSet(*TestTag1) == false);
-    EZ_TEST_BOOL(tagSet2.IsSet(TestTag2) == true);
-    EZ_TEST_INT(tagSet2.GetNumTagsSet(), 1);
+      ezTagSet tagSet2 = tagSet;
+      EZ_TEST_BOOL(tagSet2.IsSet(*TestTag1) == false);
+      EZ_TEST_BOOL(tagSet2.IsSet(TestTag2) == true);
+      EZ_TEST_INT(tagSet2.GetNumTagsSet(), 1);
+    }
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Many Tags")

--- a/Code/UnitTests/FoundationTest/CodeUtils/PreprocessorTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/PreprocessorTest.cpp
@@ -70,7 +70,8 @@ public:
           m_sOutput.Append("Warning: ");
           break;
         case ezPreprocessor::ProcessingEvent::BeginExpansion:
-          m_sOutput.AppendFormat("In Macro: '{0}'", ezString(event.m_pToken->m_DataView));
+          if(event.m_pToken != nullptr)
+            m_sOutput.AppendFormat("In Macro: '{0}'", ezString(event.m_pToken->m_DataView));
           break;
         case ezPreprocessor::ProcessingEvent::EndExpansion:
           break;

--- a/Code/UnitTests/FoundationTest/CodeUtils/PreprocessorTest.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/PreprocessorTest.cpp
@@ -70,7 +70,7 @@ public:
           m_sOutput.Append("Warning: ");
           break;
         case ezPreprocessor::ProcessingEvent::BeginExpansion:
-          if(event.m_pToken != nullptr)
+          if (event.m_pToken != nullptr)
             m_sOutput.AppendFormat("In Macro: '{0}'", ezString(event.m_pToken->m_DataView));
           break;
         case ezPreprocessor::ProcessingEvent::EndExpansion:

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.h
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.h
@@ -270,7 +270,7 @@ struct ezTestBlock
 
 //////////////////////////////////////////////////////////////////////////
 
-EZ_TEST_DLL bool ezTestBool(
+bool ezTestBool(
   bool bCondition, const char* szErrorText, const char* szFile, ezInt32 iLine, const char* szFunction, const char* szMsg, ...);
 
 /// \brief Tests for a boolean condition, does not output an extra message.

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.h
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.h
@@ -270,7 +270,7 @@ struct ezTestBlock
 
 //////////////////////////////////////////////////////////////////////////
 
-bool ezTestBool(
+EZ_TEST_DLL bool ezTestBool(
   bool bCondition, const char* szErrorText, const char* szFile, ezInt32 iLine, const char* szFunction, const char* szMsg, ...);
 
 /// \brief Tests for a boolean condition, does not output an extra message.

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -185,7 +185,7 @@ ezUInt32 AccessorPropertiesTest(ezIReflectedTypeAccessor& ref_accessor, const ez
 {
   ezUInt32 uiPropertiesSet = 0;
   if(!EZ_TEST_BOOL(pType != nullptr))
-    return;
+    return 0;
 
   EZ_ANALYSIS_ASSUME(pType != nullptr);
 

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -184,7 +184,7 @@ void AccessorPropertyTest(ezIReflectedTypeAccessor& ref_accessor, const char* sz
 ezUInt32 AccessorPropertiesTest(ezIReflectedTypeAccessor& ref_accessor, const ezRTTI* pType)
 {
   ezUInt32 uiPropertiesSet = 0;
-  if(!EZ_TEST_BOOL(pType != nullptr))
+  if (!EZ_TEST_BOOL(pType != nullptr))
     return 0;
 
   EZ_ANALYSIS_ASSUME(pType != nullptr);

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTest.cpp
@@ -184,7 +184,10 @@ void AccessorPropertyTest(ezIReflectedTypeAccessor& ref_accessor, const char* sz
 ezUInt32 AccessorPropertiesTest(ezIReflectedTypeAccessor& ref_accessor, const ezRTTI* pType)
 {
   ezUInt32 uiPropertiesSet = 0;
-  EZ_TEST_BOOL(pType != nullptr);
+  if(!EZ_TEST_BOOL(pType != nullptr))
+    return;
+
+  EZ_ANALYSIS_ASSUME(pType != nullptr);
 
   // Call for base class
   if (pType->GetParentType() != nullptr)

--- a/Utilities/RunClangTidy.ps1
+++ b/Utilities/RunClangTidy.ps1
@@ -200,7 +200,7 @@ if($DiffTo)
     }
 }
 
-& $ClangTidy --checks=$Checks,$ChecksGroup1 --list-checks
+& $ClangTidy "--checks=$Checks,$ChecksGroup1" --list-checks
 if($lastexitcode -ne 0)
 {
     Write-Error "Inital clang-tidy test run failed"

--- a/Utilities/RunClangTidy.ps1
+++ b/Utilities/RunClangTidy.ps1
@@ -3,9 +3,13 @@ param
     [string]
     $Workspace,
     [string]
-    $Checks = "-*,clang-analyzer-core.*,ez-name-check,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-using",
+    $Checks = "-*,ez-name-check,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-using",
+    [string]
+    $ChecksGroup1 = "clang-analyzer-core.*",
     [string]
     $ExcludeRootFiles = "DirectXTex|ThirdParty|\.rc$|qrc_resources.cpp$",
+    [string]
+    $Group1Pattern = "Code\\Engine\\|Code\\EnginePlugins\\|Code\\Editor\\|Code\\EditorPlugins\\",
     [string]
     $HeaderPattern = "^((?!ThirdParty|DirectXTex|ogt_vox|ui_).)*$",
     [string]
@@ -196,7 +200,7 @@ if($DiffTo)
     }
 }
 
-& $ClangTidy --checks=$Checks --list-checks
+& $ClangTidy --checks=$Checks,$ChecksGroup1 --list-checks
 if($lastexitcode -ne 0)
 {
     Write-Error "Inital clang-tidy test run failed"
@@ -322,6 +326,7 @@ $syncStore.NumMessages = 0
 if($FilterPattern)
 {
     $files = $files | ? {$_ -match $FilterPattern}
+    Write-Host $files
 }
 
 if($FileLimit -gt 0)
@@ -343,6 +348,13 @@ $job = $files | Foreach-Object -Parallel `
    $syncStore = $using:syncStore
    $ClangLibPath = $using:ClangLibPath
    $warningSeen = $using:warningSeen
+   $ChecksGroup1 = $using:ChecksGroup1
+   $Group1Pattern = $using:Group1Pattern
+   
+   if($Group1Pattern -and $_ -match $Group1Pattern)
+   {
+       $Checks += ",$ChecksGroup1"
+   }
    
    $fixesFile = Join-Path $TempDir "$(New-Guid).yaml"
    
@@ -383,6 +395,11 @@ $job = $files | Foreach-Object -Parallel `
    if($lastexitcode -ne 0)
    {
        $syncStore.NumErrors++
+       if($numMessages -eq 0) # If we didn't find any errors or warnings but compilation still failed, just forward the entire output.
+       {
+         $numMessages++
+         $output += $tidyOutput
+       }
    }
    
    if($numMessages -gt 0)

--- a/Utilities/RunClangTidy.ps1
+++ b/Utilities/RunClangTidy.ps1
@@ -3,7 +3,7 @@ param
     [string]
     $Workspace,
     [string]
-    $Checks = "-*,ez-name-check,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-using",
+    $Checks = "-*,clang-analyzer-core.*,ez-name-check,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-using",
     [string]
     $ExcludeRootFiles = "DirectXTex|ThirdParty|\.rc$|qrc_resources.cpp$",
     [string]


### PR DESCRIPTION
This adds the core set of static analysis rules from clang-tidy to Engine, EnginePlugins, Editor and EditorPlugins. 

All code in other folders currently doesn't get static analysis. Thea idea is to both extend the amount of enabled rules as well as the amount of code it is run on continously until full code coverage is achieved and all static analysis rules from clang-tidy that make sense are enabled.

This PR also contains fixes of all issues that clang-tidy static analysis has raised.