### PR TITLE
Force app window top-most at startup

### DIFF
--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
@@ -6,8 +6,7 @@
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/System/Process.h>
 
-ezResult ezEditorProcessCommunicationChannel::StartClientProcess(
-  const char* szProcess, const QStringList& args, bool bRemote, const ezRTTI* pFirstAllowedMessageType, ezUInt32 uiMemSize)
+ezResult ezEditorProcessCommunicationChannel::StartClientProcess(const char* szProcess, const QStringList& args, bool bRemote, const ezRTTI* pFirstAllowedMessageType, ezUInt32 uiMemSize)
 {
   EZ_LOG_BLOCK("ezProcessCommunicationChannel::StartClientProcess");
 

--- a/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.h
+++ b/Code/Engine/Core/System/Implementation/Win/InputDevice_win32.h
@@ -43,6 +43,10 @@ private:
   bool m_bShowCursor = true;
   ezMouseCursorClipMode::Enum m_ClipCursorMode = ezMouseCursorClipMode::NoClip;
   bool m_bApplyClipRect = false;
+  // m_bFirstWndMsg and m_bFirstClick are used to fix issues Windows not giving focus to applications that have been launched
+  // through a parent process
+  bool m_bFirstWndMsg = true;
+  bool m_bFirstClick = true;
   ezUInt8 m_uiMouseButtonReceivedDown[5] = {0, 0, 0, 0, 0};
   ezUInt8 m_uiMouseButtonReceivedUp[5] = {0, 0, 0, 0, 0};
 };

--- a/Code/Engine/Core/System/Implementation/Win/Window_win32.inl
+++ b/Code/Engine/Core/System/Implementation/Win/Window_win32.inl
@@ -115,6 +115,14 @@ ezResult ezWindow::Initialize()
   DWORD dwExStyle = WS_EX_APPWINDOW;
   DWORD dwWindowStyle = WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
 
+  if (m_CreationDescription.m_bSetForegroundOnInit)
+  {
+    // use WS_EX_TOPMOST to force that the window shows up on top
+    // this is the only thing that seems to be working reliably
+    // but to prevent the window from staying on top, we need to remove this flag later again (see SetWindowPos)
+    dwExStyle |= WS_EX_TOPMOST;
+  }
+
   if (m_CreationDescription.m_WindowMode == ezWindowMode::WindowFixedResolution || m_CreationDescription.m_WindowMode == ezWindowMode::WindowResizable)
   {
     ezLog::Dev("Window is not fullscreen.");
@@ -297,6 +305,14 @@ void ezWindow::ProcessWindowMessages()
 
     TranslateMessage(&msg);
     DispatchMessageW(&msg);
+  }
+
+  if (m_CreationDescription.m_bSetForegroundOnInit)
+  {
+    // remove the WS_EX_TOPMOST flag again
+    m_CreationDescription.m_bSetForegroundOnInit = false;
+    HWND hWindow = ezMinWindows::ToNative(GetNativeWindowHandle());
+    SetWindowPos(hWindow, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
   }
 }
 


### PR DESCRIPTION
Uses a couple of hacks to make sure that the window is always shown on top, even when launched from a parent process.