### PR TITLE
Fixed crash in JoltDefaultCharacterComponent

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -628,7 +628,7 @@ void ezJoltDefaultCharacterComponent::UpdateCharacter()
 
   ezVec3 vRootVelocity = GetInverseUpdateTimeDelta() * (GetOwner()->GetGlobalRotation() * m_vAbsoluteRootMotion);
 
-  if (!m_vVelocityLateral.IsZero())
+  if (!m_vVelocityLateral.IsZero(ezMath::FloatEpsilon<float>()))
   {
     // remove the lateral velocity component from the root motion
     // to prevent root motion being amplified when both values are active


### PR DESCRIPTION
Fixed crash inJoltDefaultCharacterComponent when m_vVelocityLateral is nearly zero, but not quite, causing NaN values.

![image](https://github.com/user-attachments/assets/8b643b18-61d4-462c-883f-a97edde823bf)


This actually happened pretty easily when jumping against slightly slanted walls, see attached video.
Without the fix this crashes nearly 100% of the time

https://github.com/user-attachments/assets/6bf4f449-28b1-4b3c-96c2-e515232e30a4