### PR TITLE
Fix compilation error when building with EZ_3RDPARTY_ZSTD_SUPPORT=OFF

### DIFF
--- a/Code/Engine/Foundation/IO/Archive/Implementation/ArchiveUtils.cpp
+++ b/Code/Engine/Foundation/IO/Archive/Implementation/ArchiveUtils.cpp
@@ -117,9 +117,9 @@ ezResult ezArchiveUtils::WriteEntry(
 
   const ezUInt64 uiMaxBytes = file.GetFileSize();
 
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
   constexpr ezUInt32 uiMaxNumWorkerThreads = 12u;
 
-#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
   ezUInt32 uiWorkerThreadCount;
   if (uiMaxBytes > ezMath::MaxValue<ezUInt32>())
   {


### PR DESCRIPTION
uiMaxNumWorkerThreads emits 'unused variable' warning which gets treated as an error