### PR TITLE
Asset browser fixes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
@@ -601,11 +601,26 @@ void eqQtAssetBrowserFolderView::BuildDirectoryTree(const ezDataDirPath& path, e
   }
 
   { // #TODO_ASSET data for folder
+
+    QString sPathAbs = pParent->data(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+    QString sPathRel = pParent->data(0, ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
+
+    if (sPathAbs.isEmpty())
+    {
+      sPathAbs = ezMakeQString(path.GetAbsolutePath());
+      sPathRel = ezMakeQString(path.GetDataDirParentRelativePath());
+    }
+    else
+    {
+      sPathAbs += "/" + sQtFolderName;
+      sPathRel += "/" + sQtFolderName;
+    }
+
     const bool bIsDataDir = sCurPathToItem.IsEmpty();
     pNewParent = new QTreeWidgetItem();
     pNewParent->setText(0, sQtFolderName);
-    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath, ezMakeQString(path.GetAbsolutePath().GetView()));
-    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::RelativePath, ezMakeQString(path.GetDataDirParentRelativePath()));
+    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::AbsolutePath, sPathAbs);
+    pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::RelativePath, sPathRel);
     ezBitflags<ezAssetBrowserItemFlags> flags = bIsDataDir ? ezAssetBrowserItemFlags::DataDirectory : ezAssetBrowserItemFlags::Folder;
     pNewParent->setData(0, ezQtAssetBrowserModel::UserRoles::ItemFlags, (int)flags.GetValue());
     pNewParent->setIcon(0, ezQtUiServices::GetCachedIconResource(bIsDataDir ? ":/EditorFramework/Icons/DataDirectory.svg" : ":/EditorFramework/Icons/Folder.svg"));

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -648,9 +648,14 @@ Qt::ItemFlags ezQtAssetBrowserModel::flags(const QModelIndex& index) const
 
   Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 
-  if (entry.m_Flags.IsAnySet(ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Folder))
+  if (entry.m_Flags.IsAnySet(ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Folder | ezAssetBrowserItemFlags::Asset))
   {
     flags |= Qt::ItemIsDragEnabled | Qt::ItemIsEditable;
+  }
+
+  if (entry.m_Flags.IsAnySet(ezAssetBrowserItemFlags::SubAsset))
+  {
+    flags |= Qt::ItemIsDragEnabled;
   }
 
   return flags;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -121,11 +121,17 @@ void ezQtAssetBrowserView::dropEvent(QDropEvent* pEvent)
     src.MakeCleanPath();
 
     ezStringBuilder dst = targetDirectory;
-    dst.AppendPath(qtToEzString(it->fileName()));
     dst.MakeCleanPath();
 
+    // prevent moving stuff into itself
     if (src == dst)
       continue;
+
+    // don't allow dropping anything onto an existing file
+    if (ezOSFile::ExistsFile(dst))
+      continue;
+
+    dst.AppendPath(qtToEzString(it->fileName()));
 
     if (ezOSFile::ExistsDirectory(src))
     {


### PR DESCRIPTION
Fixed #1348 and #1367.
Also fixed dragging files or folders onto themselves not being forbidden.