### PR TITLE
Fixed #1280: Added tracking of missing package dependencies

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -75,6 +75,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
     TransformError,
     MissingTransformDependency,
     MissingThumbnailDependency,
+    MissingPackageDependency,
     CircularDependency,
     COUNT,
   };
@@ -84,6 +85,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
   TransformState m_TransformState = TransformState::Unknown;
   ezUInt64 m_AssetHash = 0;      ///< Valid if m_TransformState != Unknown and asset not in Curator's m_TransformStateStale list.
   ezUInt64 m_ThumbHash = 0;      ///< Valid if m_TransformState != Unknown and asset not in Curator's m_TransformStateStale list.
+  ezUInt64 m_PackageHash = 0;    ///< Valid if m_TransformState != Unknown and asset not in Curator's m_TransformStateStale list.
 
   ezDynamicArray<ezLogEntry> m_LogEntries;
 
@@ -94,6 +96,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetInfo
 
   ezSet<ezString> m_MissingTransformDeps;
   ezSet<ezString> m_MissingThumbnailDeps;
+  ezSet<ezString> m_MissingPackageDeps;
   ezSet<ezString> m_CircularDependencies;
 
   ezSet<ezUuid> m_SubAssets; ///< Main asset uses the same GUID as this (see m_Info), but is NOT stored in m_SubAssets
@@ -261,7 +264,7 @@ public:
   /// \brief Computes the combined hash for the asset and its references. Returns 0 if anything went wrong.
   ezUInt64 GetAssetReferenceHash(ezUuid assetGuid);
 
-  ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, bool bForce = false);
+  ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, ezUInt64& out_uiPackageHash, bool bForce = false);
   /// \brief Returns the number of assets in the system and how many are in what transform state
   void GetAssetTransformStats(ezUInt32& out_uiNumAssets, ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT>& out_count);
 
@@ -370,9 +373,8 @@ private:
   /// \name Asset Hashing and Status Updates (AssetUpdates.cpp)
   ///@{
 
-  ezAssetInfo::TransformState HashAsset(
-    ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDeps, const ezHybridArray<ezString, 16>& assetThumbnailDeps, ezSet<ezString>& missingTransformDeps, ezSet<ezString>& missingThumbnailDeps, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
-  bool AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
+  bool AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce);
+  ezAssetInfo::TransformState HashAsset(ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDeps, const ezHybridArray<ezString, 16>& assetThumbnailDeps, const ezHybridArray<ezString, 16>& assetPackageDeps, ezSet<ezString>& missingTransformDeps, ezSet<ezString>& missingThumbnailDeps, ezSet<ezString>& missingPackageDeps, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce);
 
   ezResult EnsureAssetInfoUpdated(const ezDataDirPath& absFilePath, const ezFileStatus& stat, bool bForce = false);
   void TrackDependencies(ezAssetInfo* pAssetInfo);
@@ -386,7 +388,7 @@ private:
   void RemoveAssetTransformState(const ezUuid& assetGuid);
   void InvalidateAssetTransformState(const ezUuid& assetGuid);
 
-  ezAssetInfo::TransformState UpdateAssetTransformState(ezUuid assetGuid, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce);
+  ezAssetInfo::TransformState UpdateAssetTransformState(ezUuid assetGuid, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce);
   void UpdateAssetTransformState(const ezUuid& assetGuid, ezAssetInfo::TransformState state);
   void UpdateAssetTransformLog(const ezUuid& assetGuid, ezDynamicArray<ezLogEntry>& logEntries);
   void SetAssetExistanceState(ezAssetInfo& assetInfo, ezAssetExistanceState::Enum state);

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -90,6 +90,7 @@ private:
   ezUuid m_AssetGuid;
   ezUInt64 m_uiAssetHash = 0;
   ezUInt64 m_uiThumbHash = 0;
+  ezUInt64 m_uiPackageHash = 0;
   ezDataDirPath m_AssetPath;
   ezEditorProcessCommunicationChannel* m_pIPC;
   bool m_bProcessShouldBeRunning = false;

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -14,6 +14,7 @@ public:
   ezUuid m_AssetGuid;
   ezUInt64 m_AssetHash = 0;
   ezUInt64 m_ThumbHash = 0;
+  ezUInt64 m_PackageHash = 0;
   ezString m_sAssetPath;
   ezString m_sPlatform;
   ezDynamicArray<ezString> m_DepRefHull;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -563,6 +563,9 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int iRole) const
           case ezAssetInfo::MissingTransformDependency:
             sToolTip.Append("Missing Transform Dependency");
             break;
+          case ezAssetInfo::MissingPackageDependency:
+            sToolTip.Append("Missing Package Dependency");
+            break;
           case ezAssetInfo::MissingThumbnailDependency:
             sToolTip.Append("Missing Thumbnail Dependency");
             break;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -454,6 +454,9 @@ void ezQtIconViewDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem&
         case ezAssetInfo::TransformState::MissingTransformDependency:
           ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingDependency.svg").paint(pPainter, thumbnailRect);
           break;
+        case ezAssetInfo::TransformState::MissingPackageDependency:
+          ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingDependency.svg").paint(pPainter, thumbnailRect);
+          break;
         case ezAssetInfo::TransformState::MissingThumbnailDependency:
           ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetMissingReference.svg").paint(pPainter, thumbnailRect);
           break;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -452,7 +452,9 @@ ezTransformStatus ezAssetDocument::DoTransformAsset(const ezPlatformProfile* pAs
 
   ezUInt64 uiHash = 0;
   ezUInt64 uiThumbHash = 0;
-  ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(GetGuid(), pAssetProfile, GetAssetDocumentTypeDescriptor(), uiHash, uiThumbHash);
+  ezUInt64 uiPackageHash = 0;
+  ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(GetGuid(), pAssetProfile, GetAssetDocumentTypeDescriptor(), uiHash, uiThumbHash, uiPackageHash);
+
   if (state == ezAssetInfo::TransformState::UpToDate && !transformFlags.IsSet(ezTransformFlags::ForceTransform))
     return ezStatus(EZ_SUCCESS, "Transformed asset is already up to date");
 
@@ -527,8 +529,9 @@ ezTransformStatus ezAssetDocument::CreateThumbnail()
 {
   ezUInt64 uiHash = 0;
   ezUInt64 uiThumbHash = 0;
+  ezUInt64 uiPackageHash = 0;
 
-  ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(GetGuid(), ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), GetAssetDocumentTypeDescriptor(), uiHash, uiThumbHash);
+  ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(GetGuid(), ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), GetAssetDocumentTypeDescriptor(), uiHash, uiThumbHash, uiPackageHash);
 
   if (state == ezAssetInfo::TransformState::UpToDate)
     return ezStatus(EZ_SUCCESS, "Transformed asset is already up to date");

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -288,6 +288,7 @@ bool ezProcessTask::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, 
           case ezAssetInfo::TransformState::Unknown:
           case ezAssetInfo::TransformState::TransformError:
           case ezAssetInfo::TransformState::MissingTransformDependency:
+          case ezAssetInfo::TransformState::MissingPackageDependency:
           case ezAssetInfo::TransformState::MissingThumbnailDependency:
           case ezAssetInfo::TransformState::CircularDependency:
           {
@@ -413,7 +414,7 @@ bool ezProcessTask::Tick(bool bStartNewWork)
             return bStartNewWork; // call again if we should be looking for new work
           }
 
-          ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(m_AssetGuid, nullptr, nullptr, m_uiAssetHash, m_uiThumbHash);
+          ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(m_AssetGuid, nullptr, nullptr, m_uiAssetHash, m_uiThumbHash, m_uiPackageHash);
           EZ_ASSERT_DEV(state == ezAssetInfo::TransformState::NeedsTransform || state == ezAssetInfo::TransformState::NeedsThumbnail, "An asset was selected that is already up to date.");
 
           ezSet<ezString> dependencies;
@@ -469,6 +470,7 @@ bool ezProcessTask::Tick(bool bStartNewWork)
         msg.m_AssetGuid = m_AssetGuid;
         msg.m_AssetHash = m_uiAssetHash;
         msg.m_ThumbHash = m_uiThumbHash;
+        msg.m_PackageHash = m_uiPackageHash;
         msg.m_sAssetPath = m_AssetPath;
         msg.m_DepRefHull.Swap(m_TransitiveHull);
         msg.m_sPlatform = ezAssetCurator::GetSingleton()->GetActiveAssetProfile()->GetConfigName();

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
@@ -10,6 +10,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcessAssetMsg, 1, ezRTTIDefaultAllocator<ezP
     EZ_MEMBER_PROPERTY("AssetGuid", m_AssetGuid),
     EZ_MEMBER_PROPERTY("AssetHash", m_AssetHash),
     EZ_MEMBER_PROPERTY("ThumbHash", m_ThumbHash),
+    EZ_MEMBER_PROPERTY("PackageHash", m_PackageHash),
     EZ_MEMBER_PROPERTY("AssetPath", m_sAssetPath),
     EZ_MEMBER_PROPERTY("Platform", m_sPlatform),
     EZ_ARRAY_MEMBER_PROPERTY("DepRefHull", m_DepRefHull),

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -12,7 +12,7 @@
 // ezAssetCurator Asset Hashing and Status Updates
 ////////////////////////////////////////////////////////////////////////
 
-ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDeps, const ezHybridArray<ezString, 16>& assetThumbnailDeps, ezSet<ezString>& missingTransformDeps, ezSet<ezString>& missingThumbnailDeps, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce)
+ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDeps, const ezHybridArray<ezString, 16>& assetThumbnailDeps, const ezHybridArray<ezString, 16>& assetPackageDeps, ezSet<ezString>& missingTransformDeps, ezSet<ezString>& missingThumbnailDeps, ezSet<ezString>& missingPackageDeps, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce)
 {
   CURATOR_PROFILE("HashAsset");
   ezStringBuilder tmp;
@@ -21,12 +21,13 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
     // hash of the main asset file
     out_AssetHash = uiSettingsHash;
     out_ThumbHash = uiSettingsHash;
+    out_PackageHash = uiSettingsHash;
 
     // Iterate dependencies
     for (const auto& dep : assetTransformDeps)
     {
       ezString sPath = dep;
-      if (!AddAssetHash(sPath, false, out_AssetHash, out_ThumbHash, bForce))
+      if (!AddAssetHash(sPath, false, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
       {
         missingTransformDeps.Insert(sPath);
       }
@@ -35,9 +36,18 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
     for (const auto& dep : assetThumbnailDeps)
     {
       ezString sPath = dep;
-      if (!AddAssetHash(sPath, true, out_AssetHash, out_ThumbHash, bForce))
+      if (!AddAssetHash(sPath, true, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
       {
         missingThumbnailDeps.Insert(sPath);
+      }
+    }
+
+    for (const auto& dep : assetPackageDeps)
+    {
+      ezString sPath = dep;
+      if (!AddAssetHash(sPath, true, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
+      {
+        missingPackageDeps.Insert(sPath);
       }
     }
   }
@@ -53,11 +63,17 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
     out_ThumbHash = 0;
     state = ezAssetInfo::MissingTransformDependency;
   }
+  if (!missingPackageDeps.IsEmpty())
+  {
+    out_AssetHash = 0;
+    out_ThumbHash = 0;
+    state = ezAssetInfo::MissingPackageDependency;
+  }
 
   return state;
 }
 
-bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, bool bForce)
+bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce)
 {
   if (sPath.IsEmpty())
     return true;
@@ -67,8 +83,9 @@ bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& 
     const ezUuid guid = ezConversionUtils::ConvertStringToUuid(sPath);
     ezUInt64 assetHash = 0;
     ezUInt64 thumbHash = 0;
-    ezAssetInfo::TransformState state = UpdateAssetTransformState(guid, assetHash, thumbHash, bForce);
-    if (state == ezAssetInfo::Unknown || state == ezAssetInfo::MissingTransformDependency || state == ezAssetInfo::MissingThumbnailDependency || state == ezAssetInfo::CircularDependency)
+    ezUInt64 packageHash = 0;
+    ezAssetInfo::TransformState state = UpdateAssetTransformState(guid, assetHash, thumbHash, packageHash, bForce);
+    if (state == ezAssetInfo::Unknown || state == ezAssetInfo::MissingTransformDependency || state == ezAssetInfo::MissingThumbnailDependency || state == ezAssetInfo::MissingPackageDependency || state == ezAssetInfo::CircularDependency)
     {
       ezLog::Error("Failed to hash dependency asset '{0}'", sPath);
       return false;
@@ -76,6 +93,7 @@ bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& 
 
     // Thumbs hash is affected by both transform dependencies and references.
     out_ThumbHash += thumbHash;
+    out_PackageHash += packageHash;
     if (!bIsReference)
     {
       // References do not affect the asset hash.
@@ -547,6 +565,7 @@ void ezAssetCurator::InvalidateAssetTransformState(const ezUuid& assetGuid)
       pAssetInfo->m_LastStateUpdate++;
       pAssetInfo->m_AssetHash = 0;
       pAssetInfo->m_ThumbHash = 0;
+      pAssetInfo->m_PackageHash = 0;
     }
   }
 }
@@ -707,11 +726,12 @@ void ezUpdateTask::Execute()
 
   ezUInt64 uiAssetHash = 0;
   ezUInt64 uiThumbHash = 0;
+  ezUInt64 uiPackageHash = 0;
 
   // Do not log update errors done on the background thread. Only if done explicitly on the main thread or the GUI will not be responsive
   // if the user deleted some base asset and everything starts complaining about it.
   ezLogEntryDelegate logger([&](ezLogEntry& ref_entry) -> void {}, ezLogMsgType::All);
   ezLogSystemScope logScope(&logger);
 
-  ezAssetCurator::GetSingleton()->IsAssetUpToDate(assetGuid, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), static_cast<const ezAssetDocumentTypeDescriptor*>(pTypeDescriptor), uiAssetHash, uiThumbHash);
+  ezAssetCurator::GetSingleton()->IsAssetUpToDate(assetGuid, ezAssetCurator::GetSingleton()->GetActiveAssetProfile(), static_cast<const ezAssetDocumentTypeDescriptor*>(pTypeDescriptor), uiAssetHash, uiThumbHash, uiPackageHash);
 }

--- a/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
@@ -49,6 +49,7 @@ void ezQtCuratorControl::paintEvent(QPaintEvent* e)
   colors[ezAssetInfo::TransformState::NeedsThumbnail] = ezToQtColor(ezColorScheme::DarkUI(float(ezColorScheme::Blue + ezColorScheme::Green) * 0.5f * ezColorScheme::s_fIndexNormalizer));
   colors[ezAssetInfo::TransformState::UpToDate] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Green));
   colors[ezAssetInfo::TransformState::MissingTransformDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
+  colors[ezAssetInfo::TransformState::MissingPackageDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Orange));
   colors[ezAssetInfo::TransformState::MissingThumbnailDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Orange));
   colors[ezAssetInfo::TransformState::CircularDependency] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
   colors[ezAssetInfo::TransformState::TransformError] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
@@ -73,11 +74,7 @@ void ezQtCuratorControl::paintEvent(QPaintEvent* e)
   }
 
   ezStringBuilder s;
-  s.SetFormat("[Un: {0}, Imp: {4}, Tr: {1}, Th: {2}, Err: {3}]", sections[ezAssetInfo::TransformState::Unknown],
-    sections[ezAssetInfo::TransformState::NeedsTransform], sections[ezAssetInfo::TransformState::NeedsThumbnail],
-    sections[ezAssetInfo::TransformState::MissingTransformDependency] + sections[ezAssetInfo::TransformState::MissingThumbnailDependency] +
-      sections[ezAssetInfo::TransformState::TransformError] + sections[ezAssetInfo::TransformState::CircularDependency],
-    sections[ezAssetInfo::TransformState::NeedsImport]);
+  s.SetFormat("[Un: {0}, Imp: {4}, Tr: {1}, Th: {2}, Err: {3}]", sections[ezAssetInfo::TransformState::Unknown], sections[ezAssetInfo::TransformState::NeedsTransform], sections[ezAssetInfo::TransformState::NeedsThumbnail], sections[ezAssetInfo::TransformState::MissingTransformDependency] + sections[ezAssetInfo::TransformState::MissingThumbnailDependency] + sections[ezAssetInfo::TransformState::MissingPackageDependency] + sections[ezAssetInfo::TransformState::TransformError] + sections[ezAssetInfo::TransformState::CircularDependency], sections[ezAssetInfo::TransformState::NeedsImport]);
 
   painter.setPen(QPen(Qt::white));
   painter.drawText(rect, s.GetData(), QTextOption(Qt::AlignCenter));
@@ -136,13 +133,12 @@ void ezQtCuratorControl::SlotUpdateTransformStats()
 
   if (uiNumAssets > 0)
   {
-    s.SetFormat("Unknown: {0}\nImport Needed: {1}\nTransform Needed: {2}\nThumbnail Needed: {3}\nMissing Dependency: {4}\nMissing Reference: {5}\nCircular Dependency: {6}\nFailed Transform: {7}",
+    s.SetFormat("Unknown: {}\nImport Needed: {}\nTransform Needed: {}\nThumbnail Needed: {}\nMissing Dependency: {}\nCircular Dependency: {}\nFailed Transform: {}",
       sections[ezAssetInfo::TransformState::Unknown],
       sections[ezAssetInfo::TransformState::NeedsImport],
       sections[ezAssetInfo::TransformState::NeedsTransform],
       sections[ezAssetInfo::TransformState::NeedsThumbnail],
-      sections[ezAssetInfo::TransformState::MissingTransformDependency],
-      sections[ezAssetInfo::TransformState::MissingThumbnailDependency],
+      sections[ezAssetInfo::TransformState::MissingTransformDependency] + sections[ezAssetInfo::TransformState::MissingThumbnailDependency] + sections[ezAssetInfo::TransformState::MissingPackageDependency],
       sections[ezAssetInfo::TransformState::CircularDependency],
       sections[ezAssetInfo::TransformState::TransformError]);
     setToolTip(s.GetData());

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -24,8 +24,7 @@ bool ezQtAssetCuratorFilter::IsAssetFiltered(ezStringView sDataDirParentRelative
   if (!pInfo->m_bMainAsset)
     return true;
 
-  if (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingTransformDependency && pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::CircularDependency &&
-      pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingThumbnailDependency && pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::TransformError)
+  if ((pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingTransformDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::CircularDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingThumbnailDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::MissingPackageDependency) && (pInfo->m_pAssetInfo->m_TransformState != ezAssetInfo::TransformError))
   {
     return true;
   }
@@ -35,6 +34,19 @@ bool ezQtAssetCuratorFilter::IsAssetFiltered(ezStringView sDataDirParentRelative
     if (pInfo->m_pAssetInfo->m_TransformState == ezAssetInfo::MissingThumbnailDependency)
     {
       for (auto& ref : pInfo->m_pAssetInfo->m_MissingThumbnailDeps)
+      {
+        if (!ezAssetCurator::GetSingleton()->FindSubAsset(ref).isValid())
+        {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    if (pInfo->m_pAssetInfo->m_TransformState == ezAssetInfo::MissingPackageDependency)
+    {
+      for (auto& ref : pInfo->m_pAssetInfo->m_MissingPackageDeps)
       {
         if (!ezAssetCurator::GetSingleton()->FindSubAsset(ref).isValid())
         {
@@ -203,6 +215,15 @@ void ezQtAssetCuratorPanel::UpdateIssueInfo()
   {
     ezLog::Error(&logger, "Missing Thumbnail Dependency:");
     for (const ezString& ref : pAssetInfo->m_MissingThumbnailDeps)
+    {
+      ezStringBuilder m_sNiceName = getNiceName(ref);
+      ezLog::Error(&logger, "{0}", m_sNiceName);
+    }
+  }
+  else if (pAssetInfo->m_TransformState == ezAssetInfo::MissingPackageDependency)
+  {
+    ezLog::Error(&logger, "Missing Package Dependency:");
+    for (const ezString& ref : pAssetInfo->m_MissingPackageDeps)
     {
       ezStringBuilder m_sNiceName = getNiceName(ref);
       ezLog::Error(&logger, "{0}", m_sNiceName);

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -92,6 +92,7 @@ public:
         {
           ezUInt64 uiAssetHash = 0;
           ezUInt64 uiThumbHash = 0;
+          ezUInt64 uiPackageHash = 0;
 
           // TODO: there is currently no 'nice' way to switch the active platform for the asset processors
           // it is also not clear whether this is actually safe to execute here
@@ -115,11 +116,11 @@ public:
           ezAssetCurator::GetSingleton()->NotifyOfFileChange(pMsg->m_sAssetPath);
 
           // Next, we force checking that the asset is up to date. This EditorProcessor instance might not have observed the generation of the output files of various dependencies yet and incorrectly assume that some dependencies still need to be transformed. To prevent this, we force checking the asset and all its dependencies via the filesystem, ignoring the caching.
-          ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(pMsg->m_AssetGuid, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, true);
+          ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(pMsg->m_AssetGuid, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, uiPackageHash, true);
 
-          if (uiAssetHash != pMsg->m_AssetHash || uiThumbHash != pMsg->m_ThumbHash)
+          if ((uiAssetHash != pMsg->m_AssetHash) || (uiThumbHash != pMsg->m_ThumbHash) || (uiPackageHash != pMsg->m_PackageHash))
           {
-            ezLog::Warning("Asset '{}' of state '{}' in processor with hashes '{}{}' differs from the state in the editor with hashes '{}{}'", pMsg->m_sAssetPath, (int)state, uiAssetHash, uiThumbHash, pMsg->m_AssetHash, pMsg->m_ThumbHash);
+            ezLog::Warning("Asset '{}' of state '{}' in processor with hashes '{}|{}|{}' differs from the state in the editor with hashes '{}|{}|{}'", pMsg->m_sAssetPath, (int)state, uiAssetHash, uiThumbHash, uiPackageHash, pMsg->m_AssetHash, pMsg->m_ThumbHash, pMsg->m_PackageHash);
           }
 
           if (state == ezAssetInfo::NeedsThumbnail || state == ezAssetInfo::NeedsTransform)

--- a/Code/UnitTests/EditorTest/Project/Project.cpp
+++ b/Code/UnitTests/EditorTest/Project/Project.cpp
@@ -90,6 +90,7 @@ ezTestAppRun ezEditorTestProject::CreateDocuments()
 
     EZ_TEST_INT(sections[ezAssetInfo::TransformState::TransformError], 0);
     EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingTransformDependency], 0);
+    EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingPackageDependency], 0);
     EZ_TEST_INT(sections[ezAssetInfo::TransformState::MissingThumbnailDependency], 0);
     EZ_TEST_INT(sections[ezAssetInfo::TransformState::CircularDependency], 0);
   }


### PR DESCRIPTION
This is a fix for #1280, but in practice this didn't only affect sub-assets, but really all package dependencies.

So far we completely ignored looking at package dependencies.

They are technically not that important, because they are already covered by the regular asset file hash, since they are just strings that point to another asset, but they are not needed for transforming assets, and if they aren't also tagged as thumbnail dependencies, then they are also not needed for that.

Unfortunately, this meant that if an asset was deleted, the asset curator would not point this missing dependency out. Which makes it really, really hard to find assets that have a missing dependeny (which may crash at runtime).

So I've now added that we also track this, similar to the thumbnail dependencies.

This does mean, that an asset gets retransformed when a missing package dependency is fixed, even though technically this isn't needed. Well, at least if the editor was already open. It may not get retransformed, if the editor was not open while the missing asset gets restored.

Not 100% certain this is "the right fix" for this, though.