### PR TITLE
Fileserve usability improvement

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -969,7 +969,7 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
 
     if (bShowDocumentActions)
     {
-      m.addAction(QIcon(QLatin1String(":/EditorFramework/Icons/AssetNeedsTransform.svg")), QLatin1String("Transform"), this, SLOT(OnTransform()));
+      m.addAction(QIcon(QLatin1String(":/EditorFramework/Icons/TransformAsset.svg")), QLatin1String("Transform"), this, SLOT(OnTransform()));
       m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Guid.svg")), QLatin1String("Copy Asset Guid"), this, SLOT(OnListCopyAssetGuid()));
 
       m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Search.svg")), QLatin1String("Find all direct references to this asset"), this, [&]()

--- a/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
@@ -195,7 +195,7 @@ ezString ezQtEditorApp::BuildFileserveCommandLine() const
   ezStringBuilder params;
 
   ezStringBuilder cmd;
-  cmd.Set(sToolPath, " -specialdirs project \"", sProjectDir, "\" -fs_start");
+  cmd.Set(sToolPath, " -specialdirs project \"", sProjectDir, "\"");
 
   return cmd;
 }

--- a/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.cpp
+++ b/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.cpp
@@ -78,7 +78,7 @@ ezQtFileserveWidget::ezQtFileserveWidget(QWidget* pParent /*= nullptr*/)
 
   UpdateSpecialDirectoryUI();
 
-  if (ezCommandLineUtils::GetGlobalInstance()->GetBoolOption("-fs_start"))
+  if (!ezCommandLineUtils::GetGlobalInstance()->GetBoolOption("-fs_nostart"))
   {
     QTimer::singleShot(100, this, &ezQtFileserveWidget::on_StartServerButton_clicked);
   }

--- a/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.moc.h
+++ b/Code/EditorPlugins/Fileserve/EditorPluginFileserve/FileserveUI/FileserveWidget.moc.h
@@ -13,7 +13,7 @@ enum class ezFileserveActivityType;
 
 /// \brief A GUI for the ezFileServer
 ///
-/// By default the file server does not run at startup. Using the command line option "-fs_start" the server is started immediately.
+/// By default the file server does run at startup. Using the command line option "-fs_nostart" prevents that.
 class EZ_EDITORPLUGINFILESERVE_DLL ezQtFileserveWidget : public QWidget, public Ui_ezQtFileserveWidget
 {
   Q_OBJECT

--- a/Code/EditorPlugins/Recast/EditorPluginRecast/Recast.ezPluginBundle
+++ b/Code/EditorPlugins/Recast/EditorPluginRecast/Recast.ezPluginBundle
@@ -11,5 +11,5 @@ PluginInfo
 	string %PackageDependencies{"Recast.dll"}
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
-	string %EnabledInTemplates{"General3D"}
+	string %EnabledInTemplates{""}
 }

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -11,6 +11,8 @@
 #  include <Fileserve/Gui.moc.h>
 #  include <Foundation/Basics/Platform/Win/IncludeWindows.h>
 #  include <QApplication>
+#  include <QFileDialog>
+#  include <QSettings>
 #endif
 
 #ifdef EZ_USE_QT
@@ -66,6 +68,33 @@ ezResult ezFileserverApp::BeforeCoreSystemsStartup()
 {
   ezStartup::AddApplicationTag("tool");
   ezStartup::AddApplicationTag("fileserve");
+
+#ifdef EZ_USE_QT
+  if (!ezCommandLineUtils::GetGlobalInstance()->HasOption("-specialdirs"))
+  {
+    QString sLastFolder;
+
+    {
+      QSettings Settings;
+      Settings.beginGroup(QLatin1String("Fileserve"));
+      sLastFolder = Settings.value("LastProject", "").toString();
+      Settings.endGroup();
+    }
+
+    QString folder = QFileDialog::getExistingDirectory(nullptr, "Select Project Folder", sLastFolder);
+    if (!folder.isEmpty())
+    {
+      QSettings Settings;
+      Settings.beginGroup(QLatin1String("Fileserve"));
+      Settings.setValue("LastProject", folder);
+      Settings.endGroup();
+
+      ezCommandLineUtils::GetGlobalInstance()->InjectCustomArgument("-specialdirs");
+      ezCommandLineUtils::GetGlobalInstance()->InjectCustomArgument("project");
+      ezCommandLineUtils::GetGlobalInstance()->InjectCustomArgument(folder.toUtf8().data());
+    }
+  }
+#endif
 
   return SUPER::BeforeCoreSystemsStartup();
 }

--- a/Code/Tools/Fileserve/Fileserve.h
+++ b/Code/Tools/Fileserve/Fileserve.h
@@ -9,9 +9,9 @@
 ///
 /// If EZ_USE_QT is defined, the GUI from the EditorPluginFileserve is used. Otherwise the server runs as a console application.
 ///
-/// If the command line option "-fs_wait_timeout seconds" is specified, the server will wait for a limited time for any client to
-/// connect and close automatically, if no connection is established. Once a client connects, the timeout becomes irrelevant.
-/// If the command line option "-fs_close_timeout seconds" is specified, the application will automatically shut down when no
+/// If the command line option "-fs_wait_timeout seconds" is specified, the server waits for a limited time for any client to
+/// connect and closes automatically, if no connection is established. Once a client connects, this timeout becomes irrelevant.
+/// If the command line option "-fs_close_timeout seconds" is specified, the application automatically shuts down when no
 /// client is connected anymore and a certain timeout is reached. Once a client connects, the timeout is reset.
 /// This timeout has no effect as long as no client has connected.
 class ezFileserverApp : public ezApplication

--- a/Code/UnitTests/RemoteTestHarness/TestUwp.cs
+++ b/Code/UnitTests/RemoteTestHarness/TestUwp.cs
@@ -235,7 +235,7 @@ namespace ezUwpTestHarness
       {
         Console.WriteLine("Starting Fileserve ...");
 
-        // 60s timeout for connect, 2s timeout for closing after connection loss.
+        // 120s timeout for connect, 4s timeout for closing after connection loss.
         string args = string.Format("-specialdirs eztest \"{0}\" -fs_start -fs_wait_timeout 120 -fs_close_timeout 4", _absTestOutputDirectory);
         return ezProcessHelper.RunExternalExe(absFilerserveFilename, args, absBinDir, fileserveTimeoutMS);
       };


### PR DESCRIPTION
* Correct transform button in asset browser context menu
* Made "fs_start" the default for ezFileserve.
* Recast plugin is not added to projects by default.
* ezFileserve now asks for the project directory at startup.