### PR TITLE
Fix clang linker error and add Ubuntu 24 support

### DIFF
--- a/Code/ThirdParty/Jolt/Core/Core.h
+++ b/Code/ThirdParty/Jolt/Core/Core.h
@@ -230,10 +230,18 @@
 				#define JPH_EXPORT_GCC_BUG_WORKAROUND [[gnu::visibility("default")]]
 			#endif
 		#endif
+        #endif
+
+	#if defined(JPH_PLATFORM_LINUX) && defined(JPH_COMPILER_CLANG)
+		// Linux clang requires dll export on static thread_local variables, while Windows forbids it.
+		#define JPH_EXPORT_THREAD_LOCAL JPH_EXPORT
+	#else
+		#define JPH_EXPORT_THREAD_LOCAL
 	#endif
 #else
 	// If the define is not set, we use static linking and symbols don't need to be imported or exported
 	#define JPH_EXPORT
+        #define JPH_EXPORT_THREAD_LOCAL
 #endif
 
 #ifndef JPH_EXPORT_GCC_BUG_WORKAROUND
@@ -574,16 +582,5 @@ static_assert(sizeof(void *) == (JPH_CPU_ADDRESS_BITS == 64? 8 : 4), "Invalid si
 #else
 	#error Undefined
 #endif
-
-/// EZ Modification start
-/// This is a workaround for clang requiring dll export of static thread_local members.
-/// Required on BodyAccess and PhysicsLock classes.
-#undef EZ_CLANG_JPH_EXPORT
-#if defined(__linux__) && defined(__clang__)
-  #define EZ_CLANG_JPH_EXPORT JPH_EXPORT
-#else
-  #define EZ_CLANG_JPH_EXPORT
-#endif
-/// EZ Modification end
 
 JPH_NAMESPACE_END

--- a/Code/ThirdParty/Jolt/Core/Core.h
+++ b/Code/ThirdParty/Jolt/Core/Core.h
@@ -230,7 +230,7 @@
 				#define JPH_EXPORT_GCC_BUG_WORKAROUND [[gnu::visibility("default")]]
 			#endif
 		#endif
-        #endif
+	#endif
 
 	#if defined(JPH_PLATFORM_LINUX) && defined(JPH_COMPILER_CLANG)
 		// Linux clang requires dll export on static thread_local variables, while Windows forbids it.
@@ -241,7 +241,7 @@
 #else
 	// If the define is not set, we use static linking and symbols don't need to be imported or exported
 	#define JPH_EXPORT
-        #define JPH_EXPORT_THREAD_LOCAL
+	#define JPH_EXPORT_THREAD_LOCAL
 #endif
 
 #ifndef JPH_EXPORT_GCC_BUG_WORKAROUND

--- a/Code/ThirdParty/Jolt/Core/Core.h
+++ b/Code/ThirdParty/Jolt/Core/Core.h
@@ -575,4 +575,15 @@ static_assert(sizeof(void *) == (JPH_CPU_ADDRESS_BITS == 64? 8 : 4), "Invalid si
 	#error Undefined
 #endif
 
+/// EZ Modification start
+/// This is a workaround for clang requiring dll export of static thread_local members.
+/// Required on BodyAccess and PhysicsLock classes.
+#undef EZ_CLANG_JPH_EXPORT
+#if defined(__linux__) && defined(__clang__)
+  #define EZ_CLANG_JPH_EXPORT JPH_EXPORT
+#else
+  #define EZ_CLANG_JPH_EXPORT
+#endif
+/// EZ Modification end
+
 JPH_NAMESPACE_END

--- a/Code/ThirdParty/Jolt/Core/Profiler.h
+++ b/Code/ThirdParty/Jolt/Core/Profiler.h
@@ -220,7 +220,7 @@ public:
 	static inline ProfileThread *sGetInstance()														{ return sInstance; }
 
 private:
-	static thread_local ProfileThread *sInstance;
+	static JPH_EXPORT_THREAD_LOCAL thread_local ProfileThread *sInstance;
 #endif
 };
 

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyAccess.h
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyAccess.h
@@ -8,17 +8,6 @@
 
 JPH_NAMESPACE_BEGIN
 
-/// EZ Modification start
-/// This is a workaround for clang requiring dll export of static thread_local members.
-#ifdef __clang__
-  #undef EZ_CLANG_JPH_EXPORT
-  #define EZ_CLANG_JPH_EXPORT JPH_EXPORT
-#else
-  #undef EZ_CLANG_JPH_EXPORT
-  #define EZ_CLANG_JPH_EXPORT
-#endif
-/// EZ Modification end
-
 class EZ_CLANG_JPH_EXPORT BodyAccess
 {
 public:

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyAccess.h
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyAccess.h
@@ -8,7 +8,18 @@
 
 JPH_NAMESPACE_BEGIN
 
-class BodyAccess
+/// EZ Modification start
+/// This is a workaround for clang requiring dll export of static thread_local members.
+#ifdef __clang__
+  #undef EZ_CLANG_JPH_EXPORT
+  #define EZ_CLANG_JPH_EXPORT JPH_EXPORT
+#else
+  #undef EZ_CLANG_JPH_EXPORT
+  #define EZ_CLANG_JPH_EXPORT
+#endif
+/// EZ Modification end
+
+class EZ_CLANG_JPH_EXPORT BodyAccess
 {
 public:
 	/// Access rules, used to detect race conditions during simulation

--- a/Code/ThirdParty/Jolt/Physics/Body/BodyAccess.h
+++ b/Code/ThirdParty/Jolt/Physics/Body/BodyAccess.h
@@ -8,7 +8,7 @@
 
 JPH_NAMESPACE_BEGIN
 
-class EZ_CLANG_JPH_EXPORT BodyAccess
+class BodyAccess
 {
 public:
 	/// Access rules, used to detect race conditions during simulation
@@ -46,8 +46,8 @@ public:
 	}
 
 	// Various permissions that can be granted
-	static thread_local EAccess			sVelocityAccess;
-	static thread_local EAccess			sPositionAccess;
+	static JPH_EXPORT_THREAD_LOCAL thread_local EAccess			sVelocityAccess;
+	static JPH_EXPORT_THREAD_LOCAL thread_local EAccess			sPositionAccess;
 };
 
 JPH_NAMESPACE_END

--- a/Code/ThirdParty/Jolt/Physics/PhysicsLock.h
+++ b/Code/ThirdParty/Jolt/Physics/PhysicsLock.h
@@ -27,9 +27,20 @@ using PhysicsLockContext = const BodyManager *;
 
 #endif // !JPH_ENABLE_ASSERTS
 
+/// EZ Modification start
+/// This is a workaround for clang requiring dll export of static thread_local members.
+#ifdef __clang__
+  #undef EZ_CLANG_JPH_EXPORT
+  #define EZ_CLANG_JPH_EXPORT JPH_EXPORT
+#else
+  #undef EZ_CLANG_JPH_EXPORT
+  #define EZ_CLANG_JPH_EXPORT
+#endif
+/// EZ Modification end
+
 /// Helpers to safely lock the different mutexes that are part of the physics system while preventing deadlock
 /// Class that keeps track per thread which lock are taken and if the order of locking is correct
-class PhysicsLock
+class EZ_CLANG_JPH_EXPORT PhysicsLock
 {
 public:
 #ifdef JPH_ENABLE_ASSERTS

--- a/Code/ThirdParty/Jolt/Physics/PhysicsLock.h
+++ b/Code/ThirdParty/Jolt/Physics/PhysicsLock.h
@@ -29,7 +29,7 @@ using PhysicsLockContext = const BodyManager *;
 
 /// Helpers to safely lock the different mutexes that are part of the physics system while preventing deadlock
 /// Class that keeps track per thread which lock are taken and if the order of locking is correct
-class EZ_CLANG_JPH_EXPORT PhysicsLock
+class PhysicsLock
 {
 public:
 #ifdef JPH_ENABLE_ASSERTS
@@ -86,7 +86,7 @@ private:
 		PhysicsLockContext		mContext = nullptr;
 	};
 
-	static thread_local LockData sLocks[4];
+	static JPH_EXPORT_THREAD_LOCAL thread_local LockData sLocks[4];
 
 	// Helper function to find the locked mutexes for a particular context
 	static uint32 &				sGetLockedMutexes(PhysicsLockContext inContext)

--- a/Code/ThirdParty/Jolt/Physics/PhysicsLock.h
+++ b/Code/ThirdParty/Jolt/Physics/PhysicsLock.h
@@ -27,17 +27,6 @@ using PhysicsLockContext = const BodyManager *;
 
 #endif // !JPH_ENABLE_ASSERTS
 
-/// EZ Modification start
-/// This is a workaround for clang requiring dll export of static thread_local members.
-#ifdef __clang__
-  #undef EZ_CLANG_JPH_EXPORT
-  #define EZ_CLANG_JPH_EXPORT JPH_EXPORT
-#else
-  #undef EZ_CLANG_JPH_EXPORT
-  #define EZ_CLANG_JPH_EXPORT
-#endif
-/// EZ Modification end
-
 /// Helpers to safely lock the different mutexes that are part of the physics system while preventing deadlock
 /// Class that keeps track per thread which lock are taken and if the order of locking is correct
 class EZ_CLANG_JPH_EXPORT PhysicsLock

--- a/RunCMake.sh
+++ b/RunCMake.sh
@@ -91,11 +91,11 @@ verlt() {
     [ "$1" = "$2" ] && return 1 || verlte $1 $2
 }
 
-if [ "$Distribution" = "Ubuntu" -a "$Version" = "22" ] || [ "$Distribution" = "Mint" -a "$Version" = "21" ]; then
+if [ "$Distribution" = "Ubuntu" -a "$Version" = "22" ] || [ "$Distribution" = "Ubuntu" -a "$Version" = "24" ] || [ "$Distribution" = "Mint" -a "$Version" = "21" ]; then
   packages=(cmake build-essential ninja-build libxrandr-dev libxinerama-dev libomp-dev libxcursor-dev libxi-dev uuid-dev mold libfreetype-dev libtinfo5 libomp-dev)
 
   if [ "$UseClang" = true ]; then
-    packages+=(clang-14 libstdc++-12-dev)
+    packages+=(clang-14 libomp-14-dev libstdc++-12-dev)
   else
     packages+=(gcc-12 g++-12)
   fi
@@ -103,6 +103,7 @@ else
   >&2 echo "Your Distribution or Distribution version is not supported by this script"
   >&2 echo "Currently supported are:"
   >&2 echo "  * Ubuntu 22"
+  >&2 echo "  * Ubuntu 24"
   >&2 echo "  * Linux Mint 21"
   >&2 echo "Yours is: $Issue"
   


### PR DESCRIPTION
For some reason, clang requires dll export of static thread_local members while all other copilers don't.