### PR TITLE
Force MacOS build to use macOS-13

### DIFF
--- a/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
@@ -27,7 +27,7 @@ jobs:
 - job: Job_1
   displayName: MacOS-x64
   pool:
-    vmImage: 'macOS-latest'
+    vmImage: 'macOS-13'
   steps:
   - checkout: self
     submodules: true

--- a/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/MacOS-x64.yml
@@ -58,14 +58,18 @@ jobs:
       publishJUnitResults: true
   - task: Bash@3
     displayName: Bash Script
+    timeoutInMinutes: 180
     inputs:
       targetType: inline
       filePath: brew install Caskroom/cask/xquartz
       script: |
         # Brew update takes very long. Only enable if below steps start failing.
         brew update
+        echo "--- BREW LIST ---"
         brew list --versions qt@6
-        brew install qt@6
+        echo "--- BREW INSTALL QT6 ---"
+        brew install --verbose qt@6
+        echo "--- BREW INFO QT6 ---"
         brew info qt@6
         brew install Caskroom/cask/xquartz
         brew info Caskroom/cask/xquartz


### PR DESCRIPTION
`macOS-latest` still points to `macOS-12` which is so outdated that brew has no binaries and tries to compile Qt and all its dependencies from scratch.