### PR TITLE
Added way to mark an object as the parent for newly created objects

### DIFF
--- a/Code/Editor/EditorFramework/Document/GameObjectDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectDocument.h
@@ -191,10 +191,21 @@ public:
   bool GetPickTransparent() const { return m_bPickTransparent; }
   void SetPickTransparent(bool b);
 
+  /// \brief Specifies which object is the 'active parent', which is the object under which newly created objects should be parented.
+  void SetActiveParent(ezUuid object);
+  /// \brief Returns the object under which newly created objects should be parented.
+  ///
+  /// \note The object may not exist anymore! So check with the ObjectManager first.
+  ezUuid GetActiveParent() const { return m_ActiveParent; }
+
+private:
+  ezUuid m_ActiveParent = ezUuid::MakeInvalid();
+
   ///@}
   /// \name Transform
   ///@{
 
+public:
   /// \brief Sets the new global transformation of the given object.
   /// The transformationChanges bitmask (of type TransformationChanges) allows to tell the system that, e.g. only translation has changed and thus
   /// some work can be spared.

--- a/Code/Editor/EditorFramework/DragDrop/DragDropInfo.h
+++ b/Code/Editor/EditorFramework/DragDrop/DragDropInfo.h
@@ -31,6 +31,9 @@ public:
   /// can be ignored.
   ezUuid m_TargetObject;
 
+  /// GUID of the ezDocumentObject that may be used as the parent, if no other target is more important.
+  ezUuid m_ActiveParentObject;
+
   /// GUID of the ezDocumentObject that is the more specific component (of m_TargetObject) that was dragged on. May be invalid.
   ezUuid m_TargetComponent;
 

--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeModel.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeModel.cpp
@@ -146,12 +146,14 @@ bool ezQtNameableAdapter::setData(const ezDocumentObject* pObject, int iRow, int
 
 Qt::ItemFlags ezQtNameableAdapter::flags(const ezDocumentObject* pObject, int iRow, int iColumn) const
 {
+  Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+
   if (iColumn == 0)
   {
-    return (Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled);
+    return flags | Qt::ItemIsEditable;
   }
 
-  return Qt::ItemFlag::NoItemFlags;
+  return flags;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -181,7 +183,9 @@ void ezQtDocumentTreeModel::AddAdapter(ezQtDocumentTreeModelAdapter* pAdapter)
     auto index = ComputeModelIndex(pObject);
     if (!index.isValid())
       return;
-    dataChanged(index, index, roles); });
+
+    QModelIndex idx2 = index.siblingAtColumn(columnCount() - 1); // mark the entire row as modified
+    Q_EMIT dataChanged(index, idx2, roles); });
   m_Adapters.Insert(pAdapter->GetType(), pAdapter);
   beginResetModel();
   endResetModel();

--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
@@ -68,7 +68,7 @@ void ezQtDocumentTreeView::on_selectionChanged_triggered(const QItemSelection& s
 
   foreach (QModelIndex index, selection)
   {
-    if (index.isValid())
+    if (index.isValid() && index.column() == 0)
     {
       index = m_pFilterModel->mapToSource(index);
 
@@ -114,8 +114,7 @@ void ezQtDocumentTreeView::SelectionEventHandler(const ezSelectionManagerEvent& 
         // We need to change the current index as well because the current index can trigger side effects. E.g. deleting the current index row triggers a selection change event.
         selectionModel()->setCurrentIndex(currentIndex, QItemSelectionModel::SelectCurrent);
       }
-      selectionModel()
-        ->select(selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows | QItemSelectionModel::NoUpdate);
+      selectionModel()->select(selection, QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows | QItemSelectionModel::NoUpdate);
       m_bBlockSelectionSignal = false;
     }
     break;

--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/GameObjectModel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/GameObjectModel.moc.h
@@ -4,15 +4,39 @@
 
 #include <EditorFramework/Document/GameObjectDocument.h>
 #include <EditorFramework/GUI/RawDocumentTreeModel.moc.h>
+#include <GuiFoundation/Widgets/ItemView.moc.h>
 #include <ToolsFoundation/Object/ObjectMetaData.h>
 
 class ezSceneDocument;
+
+
+/// \brief Custom delegate for game objects, used in ezQtGameObjectWidget.
+///
+/// Renders additional icons to display stats.
+class EZ_EDITORFRAMEWORK_DLL ezQtGameObjectDelegate : public ezQtItemDelegate
+{
+  Q_OBJECT
+public:
+  ezQtGameObjectDelegate(QObject* pParent, ezGameObjectDocument* pDocument);
+  virtual void paint(QPainter* pPainter, const QStyleOptionViewItem& opt, const QModelIndex& index) const override;
+  virtual bool helpEvent(QHelpEvent* pEvent, QAbstractItemView* pView, const QStyleOptionViewItem& option, const QModelIndex& index) override;
+  static QRect GetHiddenIconRect(const QStyleOptionViewItem& opt);
+  static QRect GetActiveParentIconRect(const QStyleOptionViewItem& opt);
+
+  ezGameObjectDocument* m_pDocument = nullptr;
+};
 
 class EZ_EDITORFRAMEWORK_DLL ezQtGameObjectAdapter : public ezQtNameableAdapter
 {
   Q_OBJECT;
 
 public:
+  enum UserRoles
+  {
+    HiddenRole = Qt::UserRole + 0,
+    ActiveParentRole = Qt::UserRole + 1,
+  };
+
   ezQtGameObjectAdapter(ezDocumentObjectManager* pObjectManager, ezObjectMetaData<ezUuid, ezDocumentObjectMetaData>* pObjectMetaData = nullptr, ezObjectMetaData<ezUuid, ezGameObjectMetaData>* pGameObjectMetaData = nullptr);
   ~ezQtGameObjectAdapter();
   virtual QVariant data(const ezDocumentObject* pObject, int iRow, int iColumn, int iRole) const override;

--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/GameObjectPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/GameObjectPanel.moc.h
@@ -7,14 +7,14 @@
 class ezQtSearchWidget;
 class ezGameObjectDocument;
 struct ezGameObjectEvent;
+class ezQtGameObjectDelegate;
 
 class EZ_EDITORFRAMEWORK_DLL ezQtGameObjectWidget : public QWidget
 {
   Q_OBJECT
 
 public:
-  ezQtGameObjectWidget(
-    QWidget* pParent, ezGameObjectDocument* pDocument, const char* szContextMenuMapping, std::unique_ptr<ezQtDocumentTreeModel> pCustomModel, ezSelectionManager* pSelection = nullptr);
+  ezQtGameObjectWidget(QWidget* pParent, ezGameObjectDocument* pDocument, const char* szContextMenuMapping, std::unique_ptr<ezQtDocumentTreeModel> pCustomModel, ezSelectionManager* pSelection = nullptr);
   ~ezQtGameObjectWidget();
 
 private Q_SLOTS:
@@ -26,6 +26,7 @@ private:
   void DocumentSceneEventHandler(const ezGameObjectEvent& e);
 
 protected:
+  ezQtGameObjectDelegate* m_pDelegate = nullptr;
   ezGameObjectDocument* m_pDocument;
   ezQtDocumentTreeView* m_pTreeWidget;
   ezQtSearchWidget* m_pFilterWidget;

--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectPanel.cpp
@@ -11,6 +11,7 @@ ezQtGameObjectWidget::ezQtGameObjectWidget(QWidget* pParent, ezGameObjectDocumen
 {
   m_pDocument = pDocument;
   m_sContextMenuMapping = szContextMenuMapping;
+  m_pDelegate = new ezQtGameObjectDelegate(this, pDocument);
 
   setLayout(new QVBoxLayout());
   setContentsMargins(0, 0, 0, 0);
@@ -25,6 +26,7 @@ ezQtGameObjectWidget::ezQtGameObjectWidget(QWidget* pParent, ezGameObjectDocumen
   m_pTreeWidget->SetAllowDragDrop(true);
   m_pTreeWidget->SetAllowDeleteObjects(true);
   layout()->addWidget(m_pTreeWidget);
+  m_pTreeWidget->setItemDelegate(m_pDelegate);
 
   m_pDocument->m_GameObjectEvents.AddEventHandler(ezMakeDelegate(&ezQtGameObjectWidget::DocumentSceneEventHandler, this));
 

--- a/Code/Editor/EditorFramework/QtResources/Icons/ActiveParent.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ActiveParent.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ffffff" width="800px" height="800px" viewBox="0 0 256 256" id="Flat" xmlns="http://www.w3.org/2000/svg">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <path d="M152,48a12,12,0,0,1-12,12H116a12,12,0,0,1,0-24h24A12,12,0,0,1,152,48ZM140,196H116a12,12,0,0,0,0,24h24a12,12,0,0,0,0-24ZM180,60h16V76a12,12,0,0,0,24,0V56a20.02292,20.02292,0,0,0-20-20H180a12,12,0,0,0,0,24Zm28,43.99951a12,12,0,0,0-12,12v24a12,12,0,0,0,24,0v-24A12,12,0,0,0,208,103.99951Zm-160,48a12,12,0,0,0,12-12v-24a12,12,0,1,0-24,0v24A12,12,0,0,0,48,151.99951ZM76,196H60V180a12,12,0,0,0-24,0v20a20.02292,20.02292,0,0,0,20,20H76a12,12,0,0,0,0-24ZM76,36H56A20.02292,20.02292,0,0,0,36,56V76a12,12,0,0,0,24,0V60H76a12,12,0,0,0,0-24ZM236,196H220V180a12,12,0,0,0-24,0v16H180a12,12,0,0,0,0,24h16v16a12,12,0,0,0,24,0V220h16a12,12,0,0,0,0-24Z"/> </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/resources.qrc
+++ b/Code/Editor/EditorFramework/QtResources/resources.qrc
@@ -64,6 +64,7 @@
     <file>Icons/VisualStudio.svg</file>
     <file>Icons/MoveCameraHere.svg</file>
     <file>Icons/id.svg</file>
+    <file>Icons/ActiveParent.svg</file>
   </qresource>
   <qresource prefix="TypeIcons">
     <file>ezDragToPositionGizmoEditTool.svg</file>

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/DragDropHandlers/SoundEventDragDropHandler.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/DragDropHandlers/SoundEventDragDropHandler.cpp
@@ -20,7 +20,7 @@ void ezSoundEventComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pIn
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezFmodEventComponent", "SoundEvent", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezFmodEventComponent", "SoundEvent", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   else
     CreateDropObject(pInfo->m_vDropPosition, "ezFmodEventComponent", "SoundEvent", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
       pInfo->m_iTargetObjectInsertChildIndex);

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/DragDropHandlers/JoltCollisionMeshDragDropHandler.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/DragDropHandlers/JoltCollisionMeshDragDropHandler.cpp
@@ -20,7 +20,7 @@ void ezJoltCollisionMeshComponentDragDropHandler::OnDragBegin(const ezDragDropIn
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezJoltStaticActorComponent", "CollisionMesh", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezJoltStaticActorComponent", "CollisionMesh", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   else
   {
     if (pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/DragDropHandlers/KrautTreeDragDropHandler.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/DragDropHandlers/KrautTreeDragDropHandler.cpp
@@ -20,7 +20,7 @@ void ezKrautTreeComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInf
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezKrautTreeComponent", "KrautTree", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezKrautTreeComponent", "KrautTree", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   else
     CreateDropObject(pInfo->m_vDropPosition, "ezKrautTreeComponent", "KrautTree", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
       pInfo->m_iTargetObjectInsertChildIndex);

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/DragDropHandlers/ParticleDragDropHandler.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/DragDropHandlers/ParticleDragDropHandler.cpp
@@ -21,7 +21,7 @@ void ezParticleComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo
 
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezParticleComponent", "Effect", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezParticleComponent", "Effect", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
 
     m_vAlignAxisWithNormal = ezVec3::MakeAxisZ();
   }

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/DragDropHandlers/RmlUiDragDropHandler.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/DragDropHandlers/RmlUiDragDropHandler.cpp
@@ -21,7 +21,7 @@ void ezRmlUiComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
 
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezRmlUiCanvas2DComponent", "RmlFile", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezRmlUiCanvas2DComponent", "RmlFile", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
   else
   {

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.h
@@ -37,6 +37,8 @@ public:
   static ezActionDescriptorHandle s_hConvertToEditorPrefab;
   static ezActionDescriptorHandle s_hCopyReference;
   static ezActionDescriptorHandle s_hSelectParent;
+  static ezActionDescriptorHandle s_hSetActiveParent;
+  static ezActionDescriptorHandle s_hClearActiveParent;
 };
 
 ///
@@ -68,6 +70,9 @@ public:
     DetachFromParent,
     CopyReference,
     SelectParent,
+
+    SetActiveParent,
+    ClearActiveParent,
   };
 
   ezSelectionAction(const ezActionContext& context, const char* szName, ActionType type);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/DecalDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/DecalDragDropHandler.cpp
@@ -24,7 +24,7 @@ void ezDecalComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
 
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezDecalComponent", "Decals", var, ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezDecalComponent", "Decals", var, pInfo->m_ActiveParentObject, -1);
 
     m_vAlignAxisWithNormal = -ezVec3::MakeAxisX();
   }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/MeshDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/MeshDragDropHandler.cpp
@@ -21,7 +21,7 @@ void ezMeshComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezMeshComponent", "Mesh", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   else
     CreateDropObject(pInfo->m_vDropPosition, "ezMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
 
@@ -47,7 +47,7 @@ void ezAnimatedMeshComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* p
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezAnimatedMeshComponent", "Mesh", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezAnimatedMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   else
     CreateDropObject(pInfo->m_vDropPosition, "ezAnimatedMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/PrefabDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/PrefabDragDropHandler.cpp
@@ -25,14 +25,14 @@ void ezPrefabComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
   if (pInfo->m_bShiftKeyDown)
   {
     if (pInfo->m_sTargetContext == "viewport")
-      CreatePrefab(pInfo->m_vDropPosition, GetAssetGuid(pInfo), ezUuid(), -1);
+      CreatePrefab(pInfo->m_vDropPosition, GetAssetGuid(pInfo), pInfo->m_ActiveParentObject, -1);
     else
       CreatePrefab(pInfo->m_vDropPosition, GetAssetGuid(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
   }
   else
   {
     if (pInfo->m_sTargetContext == "viewport")
-      CreateDropObject(pInfo->m_vDropPosition, "ezPrefabReferenceComponent", "Prefab", GetAssetGuidString(pInfo), ezUuid(), -1);
+      CreateDropObject(pInfo->m_vDropPosition, "ezPrefabReferenceComponent", "Prefab", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
     else
       CreateDropObject(pInfo->m_vDropPosition, "ezPrefabReferenceComponent", "Prefab", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
         pInfo->m_iTargetObjectInsertChildIndex);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/SkeletonDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/SkeletonDragDropHandler.cpp
@@ -21,7 +21,7 @@ void ezSkeletonComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezSkeletonComponent", "Skeleton", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezSkeletonComponent", "Skeleton", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   else
     CreateDropObject(pInfo->m_vDropPosition, "ezSkeletonComponent", "Skeleton", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/resources.qrc
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/resources.qrc
@@ -20,8 +20,8 @@
     <file>Icons/Layer.svg</file>
     <file>Icons/LayerVisible.svg</file>
     <file>Icons/LayerLoaded.svg</file>
-	<file>Icons/LayerUnloaded.svg</file>
-	<file>Icons/SelectParent.svg</file>
+    <file>Icons/LayerUnloaded.svg</file>
+    <file>Icons/SelectParent.svg</file>
   </qresource>
   <qresource prefix="TypeIcons">
     <file>ezMeshComponent.svg</file>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -40,10 +40,16 @@ public:
     Hide
   };
 
+  /// \brief Creates a new object and attaches all currently selected objects to it.
   void GroupSelection();
 
   /// \brief Changes the selection to the parent object.
   void SelectParentObject();
+
+  /// \brief Sets the last selected object as the 'active parent'.
+  void SetSelectedAsActiveParent();
+  /// \brief Clears the 'active parent' object.
+  void ClearActiveParent();
 
   /// \brief Opens the Duplicate Special dialog
   void DuplicateSpecial();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
@@ -102,6 +102,17 @@ void ezQtSceneViewWidget::dragEnterEvent(QDragEnterEvent* e)
     info.m_bShiftKeyDown = e->modifiers() & Qt::ShiftModifier;
     info.m_bCtrlKeyDown = e->modifiers() & Qt::ControlModifier;
 
+    if (ezSceneDocument* pSceneDoc = ezDynamicCast<ezSceneDocument*>(m_pDocumentWindow->GetDocument()))
+    {
+      const ezUuid guid = pSceneDoc->GetActiveParent();
+
+      // the object may not exist anymore
+      if (pSceneDoc->GetObjectManager()->GetObject(guid) != nullptr)
+      {
+        info.m_ActiveParentObject = guid;
+      }
+    }
+
     ezDragDropConfig cfg;
     if (ezDragDropHandler::BeginDragDropOperation(&info, &cfg))
     {

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/DragDropHandlers/TypeScriptDragDropHandler.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/DragDropHandlers/TypeScriptDragDropHandler.cpp
@@ -21,7 +21,7 @@ void ezTypeScriptComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pIn
 
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezTypeScriptComponent", "Script", GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, "ezTypeScriptComponent", "Script", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
   else
   {

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/DragDropHandlers/VisualScriptDragDropHandler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/DragDropHandlers/VisualScriptDragDropHandler.cpp
@@ -24,7 +24,7 @@ void ezVisualScriptComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* p
 
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), ezUuid(), -1);
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
   else
   {

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -33,13 +33,12 @@ public:
   {
     HiddenFlag = EZ_BIT(0),
     PrefabFlag = EZ_BIT(1),
+    ActiveParentFlag = EZ_BIT(2), /// This flag is used to update an entry, even though there is no meta data for it.
 
     AllFlags = 0xFFFFFFFF
   };
 
-  ezDocumentObjectMetaData() { m_bHidden = false; }
-
-  bool m_bHidden;            /// Whether the object should be rendered in the editor view (no effect on the runtime)
+  bool m_bHidden = false;    /// Whether the object should be rendered in the editor view (no effect on the runtime)
   ezUuid m_CreateFromPrefab; /// The asset GUID of the prefab from which this object was created. Invalid GUID, if this is not a prefab instance.
   ezUuid m_PrefabSeedGuid;   /// The seed GUID used to remap the object GUIDs from the prefab asset into this instance.
   ezString m_sBasePrefab;    /// The prefab from which this instance was created as complete DDL text (this describes the entire object!). Necessary for

--- a/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Selection/Implementation/SelectionManager.cpp
@@ -149,6 +149,7 @@ void ezSelectionManager::SetSelection(const ezDeque<const ezDocumentObject*>& se
 
   for (ezUInt32 i = 0; i < selection.GetCount(); ++i)
   {
+    // actually == nullptr should never happen, unless we have an error somewhere else
     if (selection[i] != nullptr)
     {
       EZ_ASSERT_DEV(selection[i]->GetDocumentObjectManager() == m_pSelectionStorage->m_pObjectManager, "Passed in object does not belong to same object manager.");
@@ -158,9 +159,12 @@ void ezSelectionManager::SetSelection(const ezDeque<const ezDocumentObject*>& se
         ezLog::Error("{0}", res.m_sMessage);
         continue;
       }
-      // actually == nullptr should never happen, unless we have an error somewhere else
-      m_pSelectionStorage->m_SelectionList.PushBack(selection[i]);
-      m_pSelectionStorage->m_SelectionSet.Insert(selection[i]->GetGuid());
+
+      if (!m_pSelectionStorage->m_SelectionSet.Contains(selection[i]->GetGuid()))
+      {
+        m_pSelectionStorage->m_SelectionList.PushBack(selection[i]);
+        m_pSelectionStorage->m_SelectionSet.Insert(selection[i]->GetGuid());
+      }
     }
   }
 

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -167,6 +167,8 @@ Selection.Attach;Attach to This
 Selection.Detach;Detach
 Selection.CopyReference;Copy Object Reference
 Selection.SelectParent;Select Parent Object
+Selection.SetActiveParent;Set Active Parent
+Selection.ClearActiveParent;Clear Active Parent
 
 # Profile Configs
 


### PR DESCRIPTION
In the context menu (or through a shortcut) you can now mark one object as the "active parent". An icon to the right indicates that an object is marked as this:

![image](https://github.com/user-attachments/assets/648cedbf-e48e-487a-96c4-719f1deb394e)

If an object is the active parent, all newly created objects (e.g. through drag & drop from the asset browser) will be created as children of that object.

This makes it easier to automatically group new objects.

It does not affect copy&paste or duplicate, these operations still use the parent of the currently selected object, such that the new objects become siblings of the selected object.

Fixes https://github.com/ezEngine/ezEngine/issues/1377