### PR TITLE
Improvements to asset drag & drop

### DIFF
--- a/Code/Editor/EditorFramework/DragDrop/ComponentDragDropHandler.cpp
+++ b/Code/Editor/EditorFramework/DragDrop/ComponentDragDropHandler.cpp
@@ -194,7 +194,7 @@ void ezComponentDragDropHandler::OnDragUpdate(const ezDragDropInfo* pInfo)
   if (!vNormal.IsValid() || vNormal.IsZero())
     vNormal = ezVec3(1, 0, 0);
 
-  MoveDraggedObjectsToPosition(vPos, !pInfo->m_bCtrlKeyDown, vNormal);
+  MoveDraggedObjectsToPosition(vPos, !pInfo->m_bShiftKeyDown, vNormal);
 }
 
 void ezComponentDragDropHandler::OnDragCancel()

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/DragDropHandlers/SoundEventDragDropHandler.cpp
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/DragDropHandlers/SoundEventDragDropHandler.cpp
@@ -19,11 +19,27 @@ void ezSoundEventComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pIn
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezFmodEventComponent";
+  constexpr const char* szPropertyName = "SoundEvent";
+
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezFmodEventComponent", "SoundEvent", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  {
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezFmodEventComponent", "SoundEvent", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
-      pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/DragDropHandlers/JoltCollisionMeshDragDropHandler.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/DragDropHandlers/JoltCollisionMeshDragDropHandler.cpp
@@ -19,20 +19,26 @@ void ezJoltCollisionMeshComponentDragDropHandler::OnDragBegin(const ezDragDropIn
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezJoltStaticActorComponent";
+  constexpr const char* szPropertyName = "CollisionMesh";
+
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezJoltStaticActorComponent", "CollisionMesh", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  {
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  }
   else
   {
-    if (pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
     {
-      AttachComponentToObject("ezJoltStaticActorComponent", "CollisionMesh", GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
 
       // make sure this object gets selected
       m_DraggedObjects.PushBack(pInfo->m_TargetObject);
     }
     else
-      CreateDropObject(pInfo->m_vDropPosition, "ezJoltStaticActorComponent", "CollisionMesh", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
-        pInfo->m_iTargetObjectInsertChildIndex);
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
   }
 
   SelectCreatedObjects();

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/DragDropHandlers/KrautTreeDragDropHandler.cpp
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/DragDropHandlers/KrautTreeDragDropHandler.cpp
@@ -19,11 +19,27 @@ void ezKrautTreeComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInf
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezKrautTreeComponent";
+  constexpr const char* szPropertyName = "KrautTree";
+
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezKrautTreeComponent", "KrautTree", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  {
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezKrautTreeComponent", "KrautTree", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
-      pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/DragDropHandlers/ParticleDragDropHandler.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/DragDropHandlers/ParticleDragDropHandler.cpp
@@ -19,14 +19,27 @@ void ezParticleComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezParticleComponent";
+  constexpr const char* szPropertyName = "Effect";
+
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezParticleComponent", "Effect", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
-
-    m_vAlignAxisWithNormal = ezVec3::MakeAxisZ();
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezParticleComponent", "Effect", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/DragDropHandlers/ProcGenDragDropHandler.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/DragDropHandlers/ProcGenDragDropHandler.cpp
@@ -19,16 +19,27 @@ void ezProcPlacementComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* 
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
-  ezUuid targetObject;
-  ezInt32 iTargetInsertChildIndex = -1;
+  constexpr const char* szComponentType = "ezProcPlacementComponent";
+  constexpr const char* szPropertyName = "Resource";
 
-  if (pInfo->m_sTargetContext != "viewport")
+  if (pInfo->m_sTargetContext == "viewport")
   {
-    targetObject = pInfo->m_TargetObject;
-    iTargetInsertChildIndex = pInfo->m_iTargetObjectInsertChildIndex;
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
+  else
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
 
-  CreateDropObject(pInfo->m_vDropPosition, "ezProcPlacementComponent", "Resource", GetAssetGuidString(pInfo), targetObject, iTargetInsertChildIndex);
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/DragDropHandlers/RmlUiDragDropHandler.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/DragDropHandlers/RmlUiDragDropHandler.cpp
@@ -19,14 +19,26 @@ void ezRmlUiComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezRmlUiCanvas2DComponent";
+  constexpr const char* szPropertyName = "RmlFile";
+
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezRmlUiCanvas2DComponent", "RmlFile", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
   else
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezRmlUiCanvas2DComponent", "RmlFile", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
-      pInfo->m_iTargetObjectInsertChildIndex);
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
   }
 
   SelectCreatedObjects();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/DecalDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/DecalDragDropHandler.cpp
@@ -21,15 +21,29 @@ void ezDecalComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
 
   ezVariantArray var;
   var.PushBack(GetAssetGuidString(pInfo));
+  constexpr const char* szComponentType = "ezDecalComponent";
+  constexpr const char* szPropertyName = "Decals";
 
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezDecalComponent", "Decals", var, pInfo->m_ActiveParentObject, -1);
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, var, pInfo->m_ActiveParentObject, -1);
 
     m_vAlignAxisWithNormal = -ezVec3::MakeAxisX();
   }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezDecalComponent", "Decals", var, pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, var, pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, var, pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/MeshDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/MeshDragDropHandler.cpp
@@ -20,10 +20,27 @@ void ezMeshComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo)
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezMeshComponent";
+  constexpr const char* szPropertyName = "Mesh";
+
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  {
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();
@@ -46,10 +63,27 @@ void ezAnimatedMeshComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* p
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezAnimatedMeshComponent";
+  constexpr const char* szPropertyName = "Mesh";
+
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezAnimatedMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  {
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezAnimatedMeshComponent", "Mesh", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/SkeletonDragDropHandler.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/DragDropHandlers/SkeletonDragDropHandler.cpp
@@ -20,10 +20,27 @@ void ezSkeletonComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pInfo
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezSkeletonComponent";
+  constexpr const char* szPropertyName = "Skeleton";
+
   if (pInfo->m_sTargetContext == "viewport")
-    CreateDropObject(pInfo->m_vDropPosition, "ezSkeletonComponent", "Skeleton", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  {
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+  }
   else
-    CreateDropObject(pInfo->m_vDropPosition, "ezSkeletonComponent", "Skeleton", GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+  {
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    {
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+
+      // make sure this object gets selected
+      m_DraggedObjects.PushBack(pInfo->m_TargetObject);
+    }
+    else
+    {
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
+    }
+  }
 
   SelectCreatedObjects();
   BeginTemporaryCommands();

--- a/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/DragDropHandlers/TypeScriptDragDropHandler.cpp
+++ b/Code/EditorPlugins/TypeScript/EditorPluginTypeScript/DragDropHandlers/TypeScriptDragDropHandler.cpp
@@ -19,23 +19,25 @@ void ezTypeScriptComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* pIn
 {
   ezComponentDragDropHandler::OnDragBegin(pInfo);
 
+  constexpr const char* szComponentType = "ezTypeScriptComponent";
+  constexpr const char* szPropertyName = "Script";
+
   if (pInfo->m_sTargetContext == "viewport")
   {
-    CreateDropObject(pInfo->m_vDropPosition, "ezTypeScriptComponent", "Script", GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
+    CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_ActiveParentObject, -1);
   }
   else
   {
-    if (pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
     {
-      AttachComponentToObject("ezTypeScriptComponent", "Script", GetAssetGuidString(pInfo), pInfo->m_TargetObject);
+      AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
 
       // make sure this object gets selected
       m_DraggedObjects.PushBack(pInfo->m_TargetObject);
     }
     else
     {
-      CreateDropObject(pInfo->m_vDropPosition, "ezTypeScriptComponent", "Script", GetAssetGuidString(pInfo), pInfo->m_TargetObject,
-        pInfo->m_iTargetObjectInsertChildIndex);
+      CreateDropObject(pInfo->m_vDropPosition, szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject, pInfo->m_iTargetObjectInsertChildIndex);
     }
   }
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/DragDropHandlers/VisualScriptDragDropHandler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/DragDropHandlers/VisualScriptDragDropHandler.cpp
@@ -28,7 +28,7 @@ void ezVisualScriptComponentDragDropHandler::OnDragBegin(const ezDragDropInfo* p
   }
   else
   {
-    if (pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
+    if (!pInfo->m_bCtrlKeyDown && pInfo->m_iTargetObjectInsertChildIndex == -1) // dropped directly on a node -> attach component only
     {
       AttachComponentToObject(szComponentType, szPropertyName, GetAssetGuidString(pInfo), pInfo->m_TargetObject);
 

--- a/Code/Engine/GameEngine/Animation/Implementation/ResetTransformComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Implementation/ResetTransformComponent.cpp
@@ -8,6 +8,11 @@
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ezResetTransformComponent, 1, ezComponentMode::Dynamic)
 {
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("Animation"),
+  }
+  EZ_END_ATTRIBUTES;
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("ResetPositionX", m_bResetLocalPositionX)->AddAttributes(new ezDefaultValueAttribute(true)),


### PR DESCRIPTION
When dragging assets (meshes etc) into the scene tree directly, no sub-object gets created by default, instead the component is attached directly to the target object. Unless you hold down CTRL, in which case the sub-object gets created anyway.