### PR TITLE
Clean up and simplify application abstractions

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsTargetCS.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsTargetCS.cmake
@@ -50,7 +50,7 @@ macro(ez_create_target_cs TYPE TARGET_NAME)
 	target_compile_options(${TARGET_NAME} PRIVATE "/langversion:default")
 
 	# setting this turns the app into a "Windows" application, not a "Console" application
-	# use ez_make_winmain_executable if this is desired
+	# use ez_make_windowapp if this is desired
 	# set_property(TARGET ${TARGET_NAME} PROPERTY WIN32_EXECUTABLE TRUE)
 	if(ARG_DOTNET_VERSION)
 		# message(STATUS "Custom .NET version: ${ARG_DOTNET_VERSION}")

--- a/Code/BuildSystem/CMake/Platforms/Configure_UWP.cmake
+++ b/Code/BuildSystem/CMake/Platforms/Configure_UWP.cmake
@@ -58,3 +58,7 @@ macro(ez_platform_detect_generator)
         message(FATAL_ERROR "Generator '${CMAKE_GENERATOR}' is not supported on UWP! Please extend ez_platform_detect_generator()")
     endif()
 endmacro()
+
+macro (ez_platformhook_make_windowapp TARGET_NAME)
+    set_property(TARGET ${TARGET_NAME} PROPERTY WIN32_EXECUTABLE ON)
+endmacro()

--- a/Code/BuildSystem/CMake/Platforms/Configure_Win.cmake
+++ b/Code/BuildSystem/CMake/Platforms/Configure_Win.cmake
@@ -68,6 +68,10 @@ macro(ez_platform_detect_generator)
     endif()
 endmacro()
 
+macro (ez_platformhook_make_windowapp TARGET_NAME)
+    set_property(TARGET ${TARGET_NAME} PROPERTY WIN32_EXECUTABLE ON)
+endmacro()
+
 macro(ez_platformhook_find_vulkan)
     if(EZ_CMAKE_ARCHITECTURE_64BIT)
         if((EZ_VULKAN_DIR STREQUAL "EZ_VULKAN_DIR-NOTFOUND") OR(EZ_VULKAN_DIR STREQUAL ""))

--- a/Code/BuildSystem/CMake/ezUtils.cmake
+++ b/Code/BuildSystem/CMake/ezUtils.cmake
@@ -277,6 +277,7 @@ endfunction()
 # #####################################
 function(ez_make_winmain_executable TARGET_NAME)
 	set_property(TARGET ${TARGET_NAME} PROPERTY WIN32_EXECUTABLE ON)
+	target_compile_definitions(${TARGET_NAME} PRIVATE EZ_WIN32_EXECUTABLE=1)
 endfunction()
 
 # #####################################

--- a/Code/BuildSystem/CMake/ezUtils.cmake
+++ b/Code/BuildSystem/CMake/ezUtils.cmake
@@ -273,11 +273,18 @@ function(ez_add_output_ez_prefix TARGET_NAME)
 endfunction()
 
 # #####################################
-# ## ez_make_winmain_executable(<target>)
+# ## ez_make_windowapp(<target>)
+# 
+# Turns the target application from a 'console app' into a 'window app', which means it doesn't
+# show a command prompt with the log output on systems that differentiate between the these app types.
 # #####################################
-function(ez_make_winmain_executable TARGET_NAME)
+function(ez_make_windowapp TARGET_NAME)
 	set_property(TARGET ${TARGET_NAME} PROPERTY WIN32_EXECUTABLE ON)
-	target_compile_definitions(${TARGET_NAME} PRIVATE EZ_WIN32_EXECUTABLE=1)
+	target_compile_definitions(${TARGET_NAME} PRIVATE EZ_WINDOWAPP=1)
+
+	if (COMMAND ez_platformhook_make_windowapp)
+		ez_platformhook_make_windowapp(${TARGET_NAME})
+	endif()	
 endfunction()
 
 # #####################################

--- a/Code/Editor/Editor/CMakeLists.txt
+++ b/Code/Editor/Editor/CMakeLists.txt
@@ -7,7 +7,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})
 

--- a/Code/Editor/Editor/Editor.cpp
+++ b/Code/Editor/Editor/Editor.cpp
@@ -42,14 +42,15 @@ public:
     m_pEditorApp = nullptr;
   }
 
-  virtual Execution Run() override
+  virtual void Run() override
   {
     {
       ezStringBuilder cmdHelp;
       if (ezCommandLineOption::LogAvailableOptionsToBuffer(cmdHelp, ezCommandLineOption::LogAvailableModes::IfHelpRequested, "_Editor;cvar"))
       {
         ezQtUiServices::GetSingleton()->MessageBoxInformation(cmdHelp);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
     }
 
@@ -60,7 +61,7 @@ public:
     }
     ezQtEditorApp::GetSingleton()->ShutdownEditor();
 
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 
 private:

--- a/Code/Editor/EditorEngineProcess/CMakeLists.txt
+++ b/Code/Editor/EditorEngineProcess/CMakeLists.txt
@@ -7,7 +7,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -155,7 +155,7 @@ void ezEngineProcessGameApplication::BeforeCoreSystemsShutdown()
   SUPER::BeforeCoreSystemsShutdown();
 }
 
-ezApplication::Execution ezEngineProcessGameApplication::Run()
+void ezEngineProcessGameApplication::Run()
 {
   bool bPendingOpInProgress = false;
   do
@@ -170,9 +170,8 @@ ezApplication::Execution ezEngineProcessGameApplication::Run()
   m_uiRedrawCountExecuted = m_uiRedrawCountReceived;
 
   // Normally rendering is done in EventHandlerIPC as a response to ezSyncWithProcessMsgToEngine. However, when playing or when pending operations are in progress we need to render even if we didn't receive a draw request.
-  ezApplication::Execution res = SUPER::Run();
+  SUPER::Run();
   ezRenderWorld::ClearMainViews();
-  return res;
 }
 
 void ezEngineProcessGameApplication::LogWriter(const ezLoggingEventData& e)
@@ -293,7 +292,7 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
     // in non-remote mode, the process needs to be properly killed, to prevent error messages
     // this is taken care of by the editor process
     if (ezEditorEngineProcessApp::GetSingleton()->IsRemoteMode())
-      RequestQuit();
+      RequestApplicationQuit();
 
     return;
   }
@@ -607,8 +606,8 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
   ezFileSystem::AddDataDirectory("", "EngineProcess", ":", ezDataDirUsage::AllowWrites).AssertSuccess();                       // for absolute paths
   ezFileSystem::AddDataDirectory(">appdir/", "EngineProcess", "bin", ezDataDirUsage::ReadOnly).AssertSuccess();                // writing to the binary directory
   ezFileSystem::AddDataDirectory(">sdk/Output/", "EngineProcess", "shadercache", ezDataDirUsage::AllowWrites).AssertSuccess(); // for shader files
-  ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").AssertSuccess();                                 // app specific data
-  ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezDataDirUsage::AllowWrites).AssertSuccess();        // for writing app user data
+  ezFileSystem::AddDataDirectory(sAppDir.GetData(), "EngineProcess", "app").AssertSuccess();                                   // app specific data
+  ezFileSystem::AddDataDirectory(sUserData, "EngineProcess", "appdata", ezDataDirUsage::AllowWrites).AssertSuccess();          // for writing app user data
 
   m_CustomFileSystemConfig.Apply();
 

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.h
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.h
@@ -27,7 +27,7 @@ public:
 
   virtual void BeforeCoreSystemsShutdown() override;
 
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
 
   void LogWriter(const ezLoggingEventData& e);
 

--- a/Code/Editor/EditorProcessor/CMakeLists.txt
+++ b/Code/Editor/EditorProcessor/CMakeLists.txt
@@ -7,7 +7,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})
 

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -149,14 +149,15 @@ public:
     }
   }
 
-  virtual Execution Run() override
+  virtual void Run() override
   {
     {
       ezStringBuilder cmdHelp;
       if (ezCommandLineOption::LogAvailableOptionsToBuffer(cmdHelp, ezCommandLineOption::LogAvailableModes::IfHelpRequested, "_EditorProcessor;cvar"))
       {
         ezQtUiServices::GetSingleton()->MessageBoxInformation(cmdHelp);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
     }
 
@@ -181,7 +182,8 @@ public:
       if (ezQtEditorApp::GetSingleton()->OpenProject(sProject).Failed())
       {
         SetReturnCode(2);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
 
       // before we transform any assets, make sure the C++ code is properly built
@@ -192,7 +194,8 @@ public:
           if (ezCppProject::BuildCodeIfNecessary(cppSettings).Failed())
           {
             SetReturnCode(3);
-            return ezApplication::Execution::Quit;
+            RequestApplicationQuit();
+            return;
           }
 
           ezQtEditorApp::GetSingleton()->RestartEngineProcessIfPluginsChanged(true);
@@ -288,8 +291,7 @@ public:
     }
 
     ezQtEditorApp::GetSingleton()->ShutdownEditor();
-
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 
 private:

--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -240,7 +240,7 @@ protected:
   ///@{
 
 public:
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
 
   void RunOneFrame();
 

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -318,7 +318,7 @@ void ezGameApplicationBase::AfterCoreSystemsStartup()
   // If one of the init functions already requested the application to quit,
   // something must have gone wrong. Don't continue initialization and let the
   // application exit.
-  if (WasQuitRequested())
+  if (ShouldApplicationQuit())
   {
     return;
   }
@@ -387,13 +387,9 @@ EZ_ON_GLOBAL_EVENT(GameApp_UpdatePlugins)
   s_bUpdatePluginsExecuted = true;
 }
 
-ezApplication::Execution ezGameApplicationBase::Run()
+void ezGameApplicationBase::Run()
 {
-  if (m_bWasQuitRequested)
-    return ezApplication::Execution::Quit;
-
   RunOneFrame();
-  return ezApplication::Execution::Continue;
 }
 
 void ezGameApplicationBase::RunOneFrame()

--- a/Code/Engine/Foundation/Application/Application.h
+++ b/Code/Engine/Foundation/Application/Application.h
@@ -51,12 +51,11 @@ EZ_FOUNDATION_DLL void ezRun_Shutdown(ezApplication* pApplicationInstance);
 ///       // Close log file, etc.
 ///     }
 ///
-///     virtual ezApplication::Execution Run() override
+///     virtual void Run() override
 ///     {
-///       // Either run a one-time application (e.g. console script) and return ezApplication::Quit
-///       // Or run one update (frame) of your game loop and return ezApplication::Continue
+///       // Run will be called repeatedly, until RequestApplicationQuit() has been called (at any time in the frame).
 ///
-///       return ezApplication::Quit;
+///       RequestApplicationQuit();
 ///     }
 ///   };
 ///
@@ -67,13 +66,6 @@ class EZ_FOUNDATION_DLL ezApplication
   EZ_DISALLOW_COPY_AND_ASSIGN(ezApplication);
 
 public:
-  /// \brief Defines the possible return values for the ezApplication::Run() function.
-  enum class Execution
-  {
-    Continue, ///< The 'Run' function should return this to keep the application running
-    Quit,     ///< The 'Run' function should return this to quit the application
-  };
-
   /// \brief Constructor.
   ezApplication(ezStringView sAppName);
 
@@ -141,8 +133,8 @@ public:
 
   /// \brief Main run function which is called periodically. This function must be overridden.
   ///
-  /// Return Execution::Quit when the application should quit. You may set a return code via SetReturnCode() beforehand.
-  virtual Execution Run() = 0;
+  /// Call RequestApplicationQuit() at any point to prevent Run() from being called again.
+  virtual void Run() = 0;
 
   /// \brief Sets the value that the application will return to the OS.
   /// You can call this function at any point during execution to update the return value of the application.
@@ -183,10 +175,10 @@ public:
   /// Can be overridden to implement custom behavior. There is no other logic associated with this
   /// function and flag so the respective derived application class has to implement logic to perform the actual
   /// quit when this function is called or m_bWasQuitRequested is set to true.
-  virtual void RequestQuit();
+  virtual void RequestApplicationQuit();
 
   /// \brief Returns whether RequestQuit() was called.
-  EZ_ALWAYS_INLINE bool WasQuitRequested() const { return m_bWasQuitRequested; }
+  EZ_ALWAYS_INLINE bool ShouldApplicationQuit() const { return m_bWasQuitRequested; }
 
 protected:
   bool m_bWasQuitRequested = false;

--- a/Code/Engine/Foundation/Application/Application.h
+++ b/Code/Engine/Foundation/Application/Application.h
@@ -13,7 +13,7 @@ class ezApplication;
 
 /// \brief Platform independent run function for main loop based systems (e.g. Win32, ..)
 ///
-/// This is automatically called by EZ_APPLICATION_ENTRY_POINT() and EZ_CONSOLEAPP_ENTRY_POINT().
+/// This is automatically called by EZ_APPLICATION_ENTRY_POINT().
 ///
 /// ezRun simply calls ezRun_Startup(), ezRun_MainLoop() and ezRun_Shutdown().
 EZ_FOUNDATION_DLL void ezRun(ezApplication* pApplicationInstance);
@@ -31,7 +31,7 @@ EZ_FOUNDATION_DLL void ezRun_Shutdown(ezApplication* pApplicationInstance);
 /// (traditional or event-based). Derive an application specific class from ezApplication and implement at least the abstract Run()
 /// function. Additional virtual functions allow to hook into specific events to run application specific code at the correct times.
 ///
-/// Finally pass the name of your derived class to one of the macros EZ_APPLICATION_ENTRY_POINT() or EZ_CONSOLEAPP_ENTRY_POINT().
+/// Finally pass the name of your derived class to the macro EZ_APPLICATION_ENTRY_POINT().
 /// Those are used to abstract away the platform specific code to run an application.
 ///
 /// A simple example how to get started is as follows:
@@ -156,7 +156,7 @@ public:
   virtual const char* TranslateReturnCode() const { return ""; }
 
   /// \brief Will set the command line arguments that were passed to the app by the OS.
-  /// This is automatically called by EZ_APPLICATION_ENTRY_POINT() and EZ_CONSOLEAPP_ENTRY_POINT().
+  /// This is automatically called by EZ_APPLICATION_ENTRY_POINT().
   void SetCommandLineArguments(ezUInt32 uiArgumentCount, const char** pArguments);
 
   /// \brief Returns the one instance of ezApplication that is available.

--- a/Code/Engine/Foundation/Application/Implementation/Android/ApplicationEntryPoint_android.h
+++ b/Code/Engine/Foundation/Application/Implementation/Android/ApplicationEntryPoint_android.h
@@ -24,10 +24,6 @@ namespace ezApplicationDetails
   }
 } // namespace ezApplicationDetails
 
-
-/// \brief Same as EZ_APPLICATION_ENTRY_POINT but should be used for applications that shall always show a console window.
-#define EZ_CONSOLEAPP_ENTRY_POINT(...) EZ_APPLICATION_ENTRY_POINT(__VA_ARGS__)
-
 /// \brief This macro allows for easy creation of application entry points (since they can't be placed in DLLs)
 ///
 /// Just use the macro in a cpp file of your application and supply your app class (must be derived from ezApplication).

--- a/Code/Engine/Foundation/Application/Implementation/Application.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/Application.cpp
@@ -64,7 +64,7 @@ const char* ezApplication::GetArgument(ezUInt32 uiArgument) const
 }
 
 
-void ezApplication::RequestQuit()
+void ezApplication::RequestApplicationQuit()
 {
   m_bWasQuitRequested = true;
 }

--- a/Code/Engine/Foundation/Application/Implementation/MainLoop.cpp
+++ b/Code/Engine/Foundation/Application/Implementation/MainLoop.cpp
@@ -47,9 +47,9 @@ ezResult ezRun_Startup(ezApplication* pApplicationInstance)
 
 void ezRun_MainLoop(ezApplication* pApplicationInstance)
 {
-  while (pApplicationInstance->Run() == ezApplication::Execution::Continue)
+  while (!pApplicationInstance->ShouldApplicationQuit())
   {
-    // do nothing
+    pApplicationInstance->Run();
   }
 }
 
@@ -78,7 +78,7 @@ void ezRun_Shutdown(ezApplication* pApplicationInstance)
   // Destructor is called by entry point function
   ezApplication::s_pApplicationInstance = nullptr;
 
-  #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && defined(LIVEPP_ENABLED)
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && defined(LIVEPP_ENABLED)
   // destroy the Live++ agent
   lpp::LppDestroyDefaultAgent(&lppAgent);
 #endif

--- a/Code/Engine/Foundation/Application/Implementation/Posix/ApplicationEntryPoint_posix.h
+++ b/Code/Engine/Foundation/Application/Implementation/Posix/ApplicationEntryPoint_posix.h
@@ -2,10 +2,6 @@
 
 /// \file
 
-/// \brief Same as EZ_APPLICATION_ENTRY_POINT but should be used for applications that shall always show a console window.
-#define EZ_CONSOLEAPP_ENTRY_POINT EZ_APPLICATION_ENTRY_POINT
-
-
 /// \brief This macro allows for easy creation of application entry points (since they can't be placed in DLLs)
 ///
 /// Just use the macro in a cpp file of your application and supply your app class (must be derived from ezApplication).

--- a/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
+++ b/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
@@ -37,7 +37,7 @@ namespace ezApplicationDetails
       // We have to wait until the application has shut down orderly
       // since Windows will kill everything after this handler returns
       pApp->SetReturnCode(ctrlType);
-      pApp->RequestQuit();
+      pApp->RequestApplicationQuit();
       EZ_LOCK(GetShutdownMutex());
       return 1; // returns TRUE, which deactivates the default console control handler
     };

--- a/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
+++ b/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
@@ -95,7 +95,7 @@ namespace ezApplicationDetails
   }
 } // namespace ezApplicationDetails
 
-/// \brief Same as EZ_APPLICATION_ENTRY_POINT but should be used for applications that shall always show a console window.
+/// \brief Same as EZ_WINDOWAPP_ENTRY_POINT but should be used for applications that shall always show a console window.
 #define EZ_CONSOLEAPP_ENTRY_POINT(AppClass, ...)                                                \
   /* Enables that on machines with multiple GPUs the NVIDIA / AMD GPU is preferred */           \
   extern "C"                                                                                    \
@@ -111,14 +111,14 @@ namespace ezApplicationDetails
 
 // If windows.h is already included use the native types, otherwise use types from ezMinWindows
 //
-// In EZ_APPLICATION_ENTRY_POINT we use macro magic to concatenate strings in such a way that depending on whether windows.h has
+// In EZ_WINDOWAPP_ENTRY_POINT we use macro magic to concatenate strings in such a way that depending on whether windows.h has
 // been included in the mean time, either the macro is chosen which expands to the proper Windows.h type
 // or the macro that expands to our ezMinWindows type.
 // Unfortunately we cannot do the decision right here, as Windows.h may not yet be included, but may get included later.
-#define _EZ_APPLICATION_ENTRY_POINT_HINSTANCE HINSTANCE
-#define _EZ_APPLICATION_ENTRY_POINT_LPSTR LPSTR
-#define _EZ_APPLICATION_ENTRY_POINT_HINSTANCE_WINDOWS_ ezMinWindows::HINSTANCE
-#define _EZ_APPLICATION_ENTRY_POINT_LPSTR_WINDOWS_ ezMinWindows::LPSTR
+#define _EZ_WINDOWAPP_ENTRY_POINT_HINSTANCE HINSTANCE
+#define _EZ_WINDOWAPP_ENTRY_POINT_LPSTR LPSTR
+#define _EZ_WINDOWAPP_ENTRY_POINT_HINSTANCE_WINDOWS_ ezMinWindows::HINSTANCE
+#define _EZ_WINDOWAPP_ENTRY_POINT_LPSTR_WINDOWS_ ezMinWindows::LPSTR
 
 #ifndef _In_
 #  define UndefSAL
@@ -130,20 +130,26 @@ namespace ezApplicationDetails
 ///
 /// Just use the macro in a cpp file of your application and supply your app class (must be derived from ezApplication).
 /// The additional (optional) parameters are passed to the constructor of your app class.
-#define EZ_APPLICATION_ENTRY_POINT(AppClass, ...)                                                                                \
-  /* Enables that on machines with multiple GPUs the NVIDIA / AMD GPU is preferred */                                            \
-  extern "C"                                                                                                                     \
-  {                                                                                                                              \
-    _declspec(dllexport) ezMinWindows::DWORD NvOptimusEnablement = 0x00000001;                                                   \
-    _declspec(dllexport) ezMinWindows::DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;                                  \
-  }                                                                                                                              \
-  EZ_APPLICATION_ENTRY_POINT_CODE_INJECTION                                                                                      \
-  int EZ_WINDOWS_CALLBACK WinMain(_In_ EZ_PP_CONCAT(_EZ_, EZ_PP_CONCAT(APPLICATION_ENTRY_POINT_HINSTANCE, _WINDOWS_)) hInstance, \
-    _In_opt_ EZ_PP_CONCAT(_EZ_, EZ_PP_CONCAT(APPLICATION_ENTRY_POINT_HINSTANCE, _WINDOWS_)) hPrevInstance,                       \
-    _In_ EZ_PP_CONCAT(_EZ_, EZ_PP_CONCAT(APPLICATION_ENTRY_POINT_LPSTR, _WINDOWS_)) lpCmdLine, _In_ int nCmdShow)                \
-  {                                                                                                                              \
-    return ezApplicationDetails::ApplicationEntry<AppClass>(__VA_ARGS__);                                                        \
+#define EZ_WINDOWAPP_ENTRY_POINT(AppClass, ...)                                                                                \
+  /* Enables that on machines with multiple GPUs the NVIDIA / AMD GPU is preferred */                                          \
+  extern "C"                                                                                                                   \
+  {                                                                                                                            \
+    _declspec(dllexport) ezMinWindows::DWORD NvOptimusEnablement = 0x00000001;                                                 \
+    _declspec(dllexport) ezMinWindows::DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;                                \
+  }                                                                                                                            \
+  EZ_APPLICATION_ENTRY_POINT_CODE_INJECTION                                                                                    \
+  int EZ_WINDOWS_CALLBACK WinMain(_In_ EZ_PP_CONCAT(_EZ_, EZ_PP_CONCAT(WINDOWAPP_ENTRY_POINT_HINSTANCE, _WINDOWS_)) hInstance, \
+    _In_opt_ EZ_PP_CONCAT(_EZ_, EZ_PP_CONCAT(WINDOWAPP_ENTRY_POINT_HINSTANCE, _WINDOWS_)) hPrevInstance,                       \
+    _In_ EZ_PP_CONCAT(_EZ_, EZ_PP_CONCAT(WINDOWAPP_ENTRY_POINT_LPSTR, _WINDOWS_)) lpCmdLine, _In_ int nCmdShow)                \
+  {                                                                                                                            \
+    return ezApplicationDetails::ApplicationEntry<AppClass>(__VA_ARGS__);                                                      \
   }
+
+#if EZ_WIN32_EXECUTABLE
+#  define EZ_APPLICATION_ENTRY_POINT EZ_WINDOWAPP_ENTRY_POINT
+#else
+#  define EZ_APPLICATION_ENTRY_POINT EZ_CONSOLEAPP_ENTRY_POINT
+#endif
 
 #ifdef UndefSAL
 #  undef _In_

--- a/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
+++ b/Code/Engine/Foundation/Application/Implementation/Win/ApplicationEntryPoint_win.h
@@ -145,7 +145,7 @@ namespace ezApplicationDetails
     return ezApplicationDetails::ApplicationEntry<AppClass>(__VA_ARGS__);                                                      \
   }
 
-#if EZ_WIN32_EXECUTABLE
+#if EZ_WINDOWAPP
 #  define EZ_APPLICATION_ENTRY_POINT EZ_WINDOWAPP_ENTRY_POINT
 #else
 #  define EZ_APPLICATION_ENTRY_POINT EZ_CONSOLEAPP_ENTRY_POINT

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
@@ -65,7 +65,7 @@ namespace ezApplicationDetails
     return ::ezApplicationDetails::EntryFunc<AppClass>(__VA_ARGS__);                                \
   }
 
-#if EZ_WIN32_EXECUTABLE
+#if EZ_WINDOWAPP
 #  define EZ_APPLICATION_ENTRY_POINT EZ_WINDOWAPP_ENTRY_POINT
 #else
 #  define EZ_APPLICATION_ENTRY_POINT EZ_CONSOLEAPP_ENTRY_POINT

--- a/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
+++ b/Code/Engine/Foundation/Application/Implementation/uwp/ApplicationEntryPoint_uwp.h
@@ -58,9 +58,15 @@ namespace ezApplicationDetails
 ///
 /// Just use the macro in a cpp file of your application and supply your app class (must be derived from ezApplication).
 /// The additional (optional) parameters are passed to the constructor of your app class.
-#define EZ_APPLICATION_ENTRY_POINT(AppClass, ...)                                                   \
+#define EZ_WINDOWAPP_ENTRY_POINT(AppClass, ...)                                                     \
   EZ_APPLICATION_ENTRY_POINT_CODE_INJECTION                                                         \
   int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) \
   {                                                                                                 \
     return ::ezApplicationDetails::EntryFunc<AppClass>(__VA_ARGS__);                                \
   }
+
+#if EZ_WIN32_EXECUTABLE
+#  define EZ_APPLICATION_ENTRY_POINT EZ_WINDOWAPP_ENTRY_POINT
+#else
+#  define EZ_APPLICATION_ENTRY_POINT EZ_CONSOLEAPP_ENTRY_POINT
+#endif

--- a/Code/Engine/Foundation/Platform/Android/Application_Android.cpp
+++ b/Code/Engine/Foundation/Platform/Android/Application_Android.cpp
@@ -52,11 +52,17 @@ void ezAndroidApplication::AndroidRun()
     if (!m_bStarted)
       continue;
 
-    if (bRun && m_pEzApp->Run() != ezApplication::Execution::Continue)
+    if (bRun)
     {
-      bRun = false;
-      ANativeActivity_finish(m_pApp->activity);
+      m_pEzApp->Run();
+
+      if (m_pEzApp->ShouldApplicationQuit())
+      {
+        bRun = false;
+        ANativeActivity_finish(m_pApp->activity);
+      }
     }
+
     if (m_pApp->destroyRequested)
     {
       break;
@@ -80,7 +86,7 @@ void ezAndroidApplication::HandleCmd(int32_t cmd)
       }
       break;
     case APP_CMD_TERM_WINDOW:
-      m_pEzApp->RequestQuit();
+      m_pEzApp->RequestApplicationQuit();
       break;
     default:
       break;

--- a/Code/Engine/GameEngine/GameApplication/GameApplication.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplication.h
@@ -88,7 +88,6 @@ protected:
 
   /// \brief Stores what is given to the constructor
   ezString m_sAppProjectPath;
-  bool m_bIgnoreErrors = false;
 
 protected:
   static ezGameApplication* s_pGameApplicationInstance;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -457,7 +457,7 @@ bool ezGameApplication::Run_ProcessApplicationInput()
 
   if (ezInputManager::GetInputActionState(s_szInputSet, s_szCloseAppAction) == ezKeyState::Pressed)
   {
-    RequestQuit();
+    RequestApplicationQuit();
   }
 
   return true;

--- a/Code/Samples/Asteroids/CMakeLists.txt
+++ b/Code/Samples/Asteroids/CMakeLists.txt
@@ -22,7 +22,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_renderers(${PROJECT_NAME})
 

--- a/Code/Samples/ComputeShaderHistogram/CMakeLists.txt
+++ b/Code/Samples/ComputeShaderHistogram/CMakeLists.txt
@@ -8,7 +8,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
@@ -24,7 +24,7 @@ ezComputeShaderHistogramApp::ezComputeShaderHistogramApp()
 
 ezComputeShaderHistogramApp::~ezComputeShaderHistogramApp() = default;
 
-ezApplication::Execution ezComputeShaderHistogramApp::Run()
+void ezComputeShaderHistogramApp::Run()
 {
   ezActorManager::GetSingleton()->Update();
 
@@ -137,8 +137,6 @@ ezApplication::Execution ezComputeShaderHistogramApp::Run()
   // this has to be done at the very end, so that the task system will only use up the time that is left in this frame for
   // uploading GPU data etc.
   ezTaskSystem::FinishFrameTasks();
-
-  return WasQuitRequested() ? ezApplication::Execution::Quit : ezApplication::Execution::Continue;
 }
 
 void ezComputeShaderHistogramApp::AfterCoreSystemsStartup()

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.h
@@ -20,7 +20,7 @@ public:
   ezComputeShaderHistogramApp();
   ~ezComputeShaderHistogramApp();
 
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
 
   virtual void AfterCoreSystemsStartup() override;
   virtual void BeforeHighLevelSystemsShutdown() override;

--- a/Code/Samples/LineCount/LineCount.cpp
+++ b/Code/Samples/LineCount/LineCount.cpp
@@ -235,7 +235,7 @@ public:
     g_HtmlLog.EndLog();
   }
 
-  virtual ezApplication::Execution Run() override
+  virtual void Run() override
   {
 #if EZ_ENABLED(EZ_SUPPORTS_FILE_ITERATORS) || defined(EZ_DOCS)
 
@@ -310,7 +310,8 @@ public:
 #else
     EZ_REPORT_FAILURE("No file system iterator support, LineCount sample can't run.");
 #endif
-    return ezApplication::Execution::Quit;
+
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Samples/LineCount/LineCount.cpp
+++ b/Code/Samples/LineCount/LineCount.cpp
@@ -314,5 +314,4 @@ public:
   }
 };
 
-
-EZ_CONSOLEAPP_ENTRY_POINT(ezLineCountApp);
+EZ_APPLICATION_ENTRY_POINT(ezLineCountApp);

--- a/Code/Samples/MeshRenderSample/CMakeLists.txt
+++ b/Code/Samples/MeshRenderSample/CMakeLists.txt
@@ -6,7 +6,7 @@ ez_requires_renderer()
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Code/Samples/MeshRenderSample/CMakeLists.txt
+++ b/Code/Samples/MeshRenderSample/CMakeLists.txt
@@ -6,6 +6,7 @@ ez_requires_renderer()
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
+ez_make_winmain_executable(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC

--- a/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
+++ b/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
@@ -148,14 +148,17 @@ public:
   }
 
 
-  Execution Run() override
+  void Run() override
   {
     EZ_LOG_BLOCK("Frame");
 
     m_pWindow->ProcessWindowMessages();
 
     if (m_pWindow->m_bCloseRequested)
-      return Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     // make sure time goes on
     ezClock::GetGlobalClock()->Update();
@@ -224,8 +227,6 @@ public:
     // this has to be done at the very end, so that the task system will only use up the time that is left in this frame for
     // uploading GPU data etc.
     ezTaskSystem::FinishFrameTasks();
-
-    return ezApplication::Execution::Continue;
   }
 
   void BeforeCoreSystemsShutdown() override

--- a/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
+++ b/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
@@ -37,7 +37,7 @@ public:
 };
 
 /// \brief The application class.
-/// Instantiated and run through the EZ_CONSOLEAPP_ENTRY_POINT macro at the end of this file.
+/// Instantiated and run through the EZ_APPLICATION_ENTRY_POINT macro at the end of this file.
 class MeshRenderSample : public ezApplication
 {
 public:
@@ -313,4 +313,4 @@ private:
   ezAngle m_CameraRotation = ezAngle::MakeZero();
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(MeshRenderSample);
+EZ_APPLICATION_ENTRY_POINT(MeshRenderSample);

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -60,13 +60,13 @@ ezShaderExplorerApp::ezShaderExplorerApp()
 {
 }
 
-ezApplication::Execution ezShaderExplorerApp::Run()
+void ezShaderExplorerApp::Run()
 {
   m_pWindow->ProcessWindowMessages();
   if (!m_pWindow->IsVisible())
   {
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(16));
-    return Execution::Continue;
+    return;
   }
 
   if (g_bWindowResized)
@@ -76,7 +76,10 @@ ezApplication::Execution ezShaderExplorerApp::Run()
   }
 
   if (m_pWindow->m_bCloseRequested || ezInputManager::GetInputActionState("Main", "CloseApp") == ezKeyState::Pressed)
-    return Execution::Quit;
+  {
+    RequestApplicationQuit();
+    return;
+  }
 
   // make sure time goes on
   ezClock::GetGlobalClock()->Update();
@@ -217,8 +220,6 @@ ezApplication::Execution ezShaderExplorerApp::Run()
 
   // for plugins (like FileServe) that need to hook into the game update
   EZ_BROADCAST_EVENT(GameApp_UpdatePlugins);
-
-  return ezApplication::Execution::Continue;
 }
 
 void ezShaderExplorerApp::AfterCoreSystemsStartup()

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -516,4 +516,4 @@ void ezShaderExplorerApp::OnFileChanged(ezStringView sFilename, ezDirectoryWatch
 }
 #endif
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezShaderExplorerApp);
+EZ_APPLICATION_ENTRY_POINT(ezShaderExplorerApp);

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.h
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.h
@@ -48,7 +48,7 @@ public:
 
   ezShaderExplorerApp();
 
-  virtual Execution Run() override;
+  virtual void Run() override;
 
   virtual void AfterCoreSystemsStartup() override;
 

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -251,12 +251,15 @@ public:
   }
 
 
-  Execution Run() override
+  void Run() override
   {
     m_pWindow->ProcessWindowMessages();
 
     if (m_pWindow->m_bCloseRequested || ezInputManager::GetInputActionState("Main", "CloseApp") == ezKeyState::Pressed)
-      return Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     // make sure time goes on
     ezClock::GetGlobalClock()->Update();
@@ -357,8 +360,6 @@ public:
     // this has to be done at the very end, so that the task system will only use up the time that is left in this frame for
     // uploading GPU data etc.
     ezTaskSystem::FinishFrameTasks();
-
-    return ezApplication::Execution::Continue;
   }
 
   void BeforeCoreSystemsShutdown() override

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -518,4 +518,4 @@ ezResourceLoadData CustomTextureResourceLoader::OpenDataStream(const ezResource*
   return res;
 }
 
-EZ_CONSOLEAPP_ENTRY_POINT(TextureSample);
+EZ_APPLICATION_ENTRY_POINT(TextureSample);

--- a/Code/Tools/ArchiveTool/ArchiveTool.cpp
+++ b/Code/Tools/ArchiveTool/ArchiveTool.cpp
@@ -416,4 +416,4 @@ public:
   }
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezArchiveTool);
+EZ_APPLICATION_ENTRY_POINT(ezArchiveTool);

--- a/Code/Tools/ArchiveTool/ArchiveTool.cpp
+++ b/Code/Tools/ArchiveTool/ArchiveTool.cpp
@@ -368,14 +368,15 @@ public:
     return EZ_SUCCESS;
   }
 
-  virtual Execution Run() override
+  virtual void Run() override
   {
     {
       ezStringBuilder cmdHelp;
       if (ezCommandLineOption::LogAvailableOptionsToBuffer(cmdHelp, ezCommandLineOption::LogAvailableModes::IfHelpRequested, "_ArchiveTool"))
       {
         ezLog::Print(cmdHelp);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
     }
 
@@ -384,7 +385,8 @@ public:
     if (ParseArguments().Failed())
     {
       SetReturnCode(1);
-      return ezApplication::Execution::Quit;
+      RequestApplicationQuit();
+      return;
     }
 
     if (m_Mode == ArchiveMode::Pack)
@@ -396,7 +398,8 @@ public:
       }
 
       ezLog::Success("Finished packing archive in {}", sw.GetRunningTotal());
-      return ezApplication::Execution::Quit;
+      RequestApplicationQuit();
+      return;
     }
 
     if (m_Mode == ArchiveMode::Unpack)
@@ -408,11 +411,12 @@ public:
       }
 
       ezLog::Success("Finished extracting archive in {}", sw.GetRunningTotal());
-      return ezApplication::Execution::Quit;
+      RequestApplicationQuit();
+      return;
     }
 
     ezLog::Error("Unknown mode");
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Tools/DependencyAnalysis/DependencyAnalysis.cpp
+++ b/Code/Tools/DependencyAnalysis/DependencyAnalysis.cpp
@@ -1147,4 +1147,4 @@ void CollectDependenciesTask::OnParsingFinished(ezTaskGroupID taskGroupId)
   }
 }
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezDependencyAnalysisApp);
+EZ_APPLICATION_ENTRY_POINT(ezDependencyAnalysisApp);

--- a/Code/Tools/DependencyAnalysis/DependencyAnalysis.cpp
+++ b/Code/Tools/DependencyAnalysis/DependencyAnalysis.cpp
@@ -984,11 +984,14 @@ public:
     }
   }
 
-  virtual ezApplication::Execution Run() override
+  virtual void Run() override
   {
     // something basic has gone wrong
     if (m_bHadSeriousWarnings || m_bHadErrors)
-      return ezApplication::Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     auto start = ezTimestamp::CurrentTimestamp();
 
@@ -1039,7 +1042,7 @@ public:
     ezLog::Info("Time to write out results: {0}s", (writeOutResultsEnd - checkDependendtFilesEnd).AsFloatInSeconds());
     ezLog::Info("Total time taken: {0}s", (writeOutResultsEnd - start).AsFloatInSeconds());
 
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Tools/Fileserve/App.cpp
+++ b/Code/Tools/Fileserve/App.cpp
@@ -57,12 +57,13 @@ void ezFileserverApp::BeforeCoreSystemsShutdown()
   SUPER::BeforeCoreSystemsShutdown();
 }
 
-ezApplication::Execution ezFileserverApp::Run()
+void ezFileserverApp::Run()
 {
   // if there are no more connections, and we have a timeout to close when no connections are left, we return Quit
   if (m_uiConnections == 0 && m_TimeTillClosing > ezTime::MakeFromSeconds(0) && ezTime::Now() > m_TimeTillClosing)
   {
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
+    return;
   }
 
   if (ezFileserver::GetSingleton()->UpdateServer() == false)
@@ -84,6 +85,4 @@ ezApplication::Execution ezFileserverApp::Run()
   {
     m_uiSleepCounter = 0;
   }
-
-  return ezApplication::Execution::Continue;
 }

--- a/Code/Tools/Fileserve/CMakeLists.txt
+++ b/Code/Tools/Fileserve/CMakeLists.txt
@@ -10,7 +10,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})
 

--- a/Code/Tools/Fileserve/Fileserve.h
+++ b/Code/Tools/Fileserve/Fileserve.h
@@ -28,7 +28,7 @@ public:
   virtual void AfterCoreSystemsStartup() override;
   virtual void BeforeCoreSystemsShutdown() override;
 
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
   void FileserverEventHandlerConsole(const ezFileserverEvent& e);
   void FileserverEventHandler(const ezFileserverEvent& e);
 

--- a/Code/Tools/Fileserve/Gui.cpp
+++ b/Code/Tools/Fileserve/Gui.cpp
@@ -38,13 +38,15 @@ ezQtFileserveMainWnd::ezQtFileserveMainWnd(ezApplication* pApp, QWidget* pParent
 
 void ezQtFileserveMainWnd::UpdateNetworkSlot()
 {
-  if (m_pApp->Run() == ezApplication::Execution::Continue)
+  m_pApp->Run();
+
+  if (m_pApp->ShouldApplicationQuit())
   {
-    QTimer::singleShot(0, this, &ezQtFileserveMainWnd::UpdateNetworkSlot);
+    close();
   }
   else
   {
-    close();
+    QTimer::singleShot(0, this, &ezQtFileserveMainWnd::UpdateNetworkSlot);
   }
 }
 

--- a/Code/Tools/HeaderCheck/HeaderCheck.cpp
+++ b/Code/Tools/HeaderCheck/HeaderCheck.cpp
@@ -560,4 +560,4 @@ public:
   }
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezHeaderCheckApp);
+EZ_APPLICATION_ENTRY_POINT(ezHeaderCheckApp);

--- a/Code/Tools/HeaderCheck/HeaderCheck.cpp
+++ b/Code/Tools/HeaderCheck/HeaderCheck.cpp
@@ -548,15 +548,17 @@ public:
     }
   }
 
-  virtual ezApplication::Execution Run() override
+  virtual void Run() override
   {
     // something basic has gone wrong
     if (m_bHadSeriousWarnings || m_bHadErrors)
-      return ezApplication::Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     IterateOverFiles();
-
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Tools/Inspector/CMakeLists.txt
+++ b/Code/Tools/Inspector/CMakeLists.txt
@@ -10,7 +10,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})
 

--- a/Code/Tools/Inspector/Inspector.cpp
+++ b/Code/Tools/Inspector/Inspector.cpp
@@ -75,7 +75,7 @@ public:
     return ezApplication::BeforeCoreSystemsStartup();
   }
 
-  virtual Execution Run() override
+  virtual void Run() override
   {
     int iArgs = GetArgumentCount();
     char** cArgs = (char**)GetArgumentsArray();
@@ -115,8 +115,7 @@ public:
     SetReturnCode(app.exec());
 
     ezTelemetry::CloseConnection();
-
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Tools/MiniDumpTool/MiniDumpTool.cpp
+++ b/Code/Tools/MiniDumpTool/MiniDumpTool.cpp
@@ -62,25 +62,27 @@ public:
     SUPER::BeforeCoreSystemsShutdown();
   }
 
-  virtual Execution Run() override
+  virtual void Run() override
   {
     {
       ezStringBuilder cmdHelp;
       if (ezCommandLineOption::LogAvailableOptionsToBuffer(cmdHelp, ezCommandLineOption::LogAvailableModes::IfHelpRequested, "_MiniDumpTool"))
       {
         ezLog::Print(cmdHelp);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
     }
 
     if (ParseArguments().Failed())
     {
       SetReturnCode(1);
-      return ezApplication::Execution::Quit;
+      RequestApplicationQuit();
+      return;
     }
 
     ezMiniDumpUtils::WriteExternalProcessMiniDump(m_sDumpFile, m_uiProcessID).IgnoreResult();
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Tools/MiniDumpTool/MiniDumpTool.cpp
+++ b/Code/Tools/MiniDumpTool/MiniDumpTool.cpp
@@ -84,4 +84,4 @@ public:
   }
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezMiniDumpTool);
+EZ_APPLICATION_ENTRY_POINT(ezMiniDumpTool);

--- a/Code/Tools/Player/CMakeLists.txt
+++ b/Code/Tools/Player/CMakeLists.txt
@@ -10,7 +10,6 @@ endif()
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
-
 ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})

--- a/Code/Tools/Player/CMakeLists.txt
+++ b/Code/Tools/Player/CMakeLists.txt
@@ -11,7 +11,7 @@ get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
 
 ez_create_target(APPLICATION ${PROJECT_NAME})
 
-ez_make_winmain_executable(${PROJECT_NAME})
+ez_make_windowapp(${PROJECT_NAME})
 
 ez_add_output_ez_prefix(${PROJECT_NAME})
 

--- a/Code/Tools/Player/Player.cpp
+++ b/Code/Tools/Player/Player.cpp
@@ -78,7 +78,7 @@ void ezPlayerApplication::Run_InputUpdate()
   {
     if (pGameState->WasQuitRequested())
     {
-      RequestQuit();
+      RequestApplicationQuit();
     }
   }
 }

--- a/Code/Tools/ShaderCompiler/ShaderCompiler.cpp
+++ b/Code/Tools/ShaderCompiler/ShaderCompiler.cpp
@@ -75,7 +75,7 @@ ezResult ezShaderCompilerApplication::BeforeCoreSystemsStartup()
 
   m_sPlatforms = opt_Platform.GetOptionValue(ezCommandLineOption::LogMode::Always);
 
-  m_bIgnoreErrors = opt_IgnoreErrors.GetOptionValue(ezCommandLineOption::LogMode::Always);
+  opt_IgnoreErrors.GetOptionValue(ezCommandLineOption::LogMode::Always);
 
   const ezUInt32 pvs = cmd->GetStringOptionArguments("-perm");
 
@@ -269,7 +269,7 @@ void ezShaderCompilerApplication::Run()
   {
     if (CompileShader(shader).Failed())
     {
-      if (!m_bIgnoreErrors)
+      if (!opt_IgnoreErrors.GetOptionValue(ezCommandLineOption::LogMode::Never))
       {
         RequestApplicationQuit();
         return;

--- a/Code/Tools/ShaderCompiler/ShaderCompiler.cpp
+++ b/Code/Tools/ShaderCompiler/ShaderCompiler.cpp
@@ -212,7 +212,7 @@ void ezShaderCompilerApplication::PrintConfig()
   ezLog::Info("Platform: '{0}'", m_sPlatforms);
 }
 
-ezApplication::Execution ezShaderCompilerApplication::Run()
+void ezShaderCompilerApplication::Run()
 {
   PrintConfig();
 
@@ -271,12 +271,13 @@ ezApplication::Execution ezShaderCompilerApplication::Run()
     {
       if (!m_bIgnoreErrors)
       {
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
     }
   }
 
-  return ezApplication::Execution::Quit;
+  RequestApplicationQuit();
 }
 
 EZ_APPLICATION_ENTRY_POINT(ezShaderCompilerApplication);

--- a/Code/Tools/ShaderCompiler/ShaderCompiler.cpp
+++ b/Code/Tools/ShaderCompiler/ShaderCompiler.cpp
@@ -279,4 +279,4 @@ ezApplication::Execution ezShaderCompilerApplication::Run()
   return ezApplication::Execution::Quit;
 }
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezShaderCompilerApplication);
+EZ_APPLICATION_ENTRY_POINT(ezShaderCompilerApplication);

--- a/Code/Tools/ShaderCompiler/ShaderCompiler.h
+++ b/Code/Tools/ShaderCompiler/ShaderCompiler.h
@@ -10,7 +10,7 @@ public:
 
   ezShaderCompilerApplication();
 
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
 
 private:
   void PrintConfig();

--- a/Code/Tools/StackResolver/StackResolver.cpp
+++ b/Code/Tools/StackResolver/StackResolver.cpp
@@ -378,4 +378,4 @@ ezApplication::Execution ezStackResolver::Run()
   return Execution::Quit;
 }
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezStackResolver);
+EZ_APPLICATION_ENTRY_POINT(ezStackResolver);

--- a/Code/Tools/StackResolver/StackResolver.cpp
+++ b/Code/Tools/StackResolver/StackResolver.cpp
@@ -54,7 +54,7 @@ public:
   virtual void AfterCoreSystemsStartup() override;
   virtual void BeforeCoreSystemsShutdown() override;
 
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
 
   ezResult LoadModules();
   ezResult ParseModules();
@@ -301,10 +301,13 @@ void ezStackResolver::FormatAsJSON(ezStringBuilder& ref_sOutput)
   ref_sOutput.Append(text);
 }
 
-ezApplication::Execution ezStackResolver::Run()
+void ezStackResolver::Run()
 {
   if (ezCommandLineOption::LogAvailableOptions(ezCommandLineOption::LogAvailableModes::IfHelpRequested, "_app"))
-    return Execution::Quit;
+  {
+    RequestApplicationQuit();
+    return;
+  }
 
   ezString sMissingOpt;
   if (ezCommandLineOption::RequireOptions("-ModuleList;-Callstack", &sMissingOpt).Failed())
@@ -312,7 +315,8 @@ ezApplication::Execution ezStackResolver::Run()
     ezLog::Error("Command line option '{}' was not specified.", sMissingOpt);
 
     ezCommandLineOption::LogAvailableOptions(ezCommandLineOption::LogAvailableModes::Always, "_app");
-    return Execution::Quit;
+    RequestApplicationQuit();
+    return;
   }
 
   m_hProcess = GetCurrentProcess();
@@ -326,13 +330,22 @@ ezApplication::Execution ezStackResolver::Run()
   m_SystemRootDir.Trim("", "/");
 
   if (ParseModules().Failed())
-    return Execution::Quit;
+  {
+    RequestApplicationQuit();
+    return;
+  }
 
   if (ParseCallstack().Failed())
-    return Execution::Quit;
+  {
+    RequestApplicationQuit();
+    return;
+  }
 
   if (LoadModules().Failed())
-    return Execution::Quit;
+  {
+    RequestApplicationQuit();
+    return;
+  }
 
   ResolveStackFrames();
 
@@ -355,7 +368,8 @@ ezApplication::Execution ezStackResolver::Run()
     if (file.Open(opt_OutputFile.GetOptionValue(ezCommandLineOption::LogMode::Never), ezFileOpenMode::Write).Failed())
     {
       ezLog::Error("Could not open file for writing: '{}'", opt_OutputFile.GetOptionValue(ezCommandLineOption::LogMode::Never));
-      return Execution::Quit;
+      RequestApplicationQuit();
+      return;
     }
 
     file.Write(output.GetData(), output.GetElementCount()).IgnoreResult();
@@ -375,7 +389,7 @@ ezApplication::Execution ezStackResolver::Run()
     }
   }
 
-  return Execution::Quit;
+  RequestApplicationQuit();
 }
 
 EZ_APPLICATION_ENTRY_POINT(ezStackResolver);

--- a/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
+++ b/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
@@ -779,11 +779,14 @@ public:
     MakeSureStaticLinkLibraryMacroExists();
   }
 
-  virtual ezApplication::Execution Run() override
+  virtual void Run() override
   {
     // something basic has gone wrong
     if (m_bHadSeriousWarnings || m_bHadErrors)
-      return ezApplication::Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     GatherInformation();
 
@@ -794,8 +797,7 @@ public:
     // RewritePrecompiledHeaderIncludes();
 
     OverwriteModifiedFiles();
-
-    return ezApplication::Execution::Quit;
+    RequestApplicationQuit();
   }
 };
 

--- a/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
+++ b/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
@@ -799,4 +799,4 @@ public:
   }
 };
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezStaticLinkerApp);
+EZ_APPLICATION_ENTRY_POINT(ezStaticLinkerApp);

--- a/Code/Tools/TexConv/TexConv.cpp
+++ b/Code/Tools/TexConv/TexConv.cpp
@@ -328,4 +328,4 @@ ezApplication::Execution ezTexConv::Run()
   return ezApplication::Execution::Quit;
 }
 
-EZ_CONSOLEAPP_ENTRY_POINT(ezTexConv);
+EZ_APPLICATION_ENTRY_POINT(ezTexConv);

--- a/Code/Tools/TexConv/TexConv.cpp
+++ b/Code/Tools/TexConv/TexConv.cpp
@@ -209,17 +209,23 @@ ezResult ezTexConv::WriteOutputFile(ezStringView sFile, const ezImage& image)
   }
 }
 
-ezApplication::Execution ezTexConv::Run()
+void ezTexConv::Run()
 {
   SetReturnCode(-1);
 
   if (ParseCommandLine().Failed())
-    return ezApplication::Execution::Quit;
+  {
+    RequestApplicationQuit();
+    return;
+  }
 
   if (m_Mode == ezTexConvMode::Compare)
   {
     if (m_Comparer.Compare().Failed())
-      return ezApplication::Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     SetReturnCode(0);
 
@@ -257,7 +263,10 @@ ezApplication::Execution ezTexConv::Run()
   else
   {
     if (m_Processor.Process().Failed())
-      return ezApplication::Execution::Quit;
+    {
+      RequestApplicationQuit();
+      return;
+    }
 
     if (m_Processor.m_Descriptor.m_OutputType == ezTexConvOutputType::Atlas)
     {
@@ -280,7 +289,8 @@ ezApplication::Execution ezTexConv::Run()
         ezLog::Error("Failed to write atlas output image.");
       }
 
-      return ezApplication::Execution::Quit;
+      RequestApplicationQuit();
+      return;
     }
 
     if (!m_sOutputFile.IsEmpty() && m_Processor.m_OutputImage.IsValid())
@@ -288,7 +298,8 @@ ezApplication::Execution ezTexConv::Run()
       if (WriteOutputFile(m_sOutputFile, m_Processor.m_OutputImage).Failed())
       {
         ezLog::Error("Failed to write main result to '{}'", m_sOutputFile);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
 
       ezLog::Success("Wrote main result to '{}'", m_sOutputFile);
@@ -299,7 +310,8 @@ ezApplication::Execution ezTexConv::Run()
       if (m_Processor.m_ThumbnailOutputImage.SaveTo(m_sOutputThumbnailFile).Failed())
       {
         ezLog::Error("Failed to write thumbnail result to '{}'", m_sOutputThumbnailFile);
-        return ezApplication::Execution::Quit;
+        RequestApplicationQuit();
+        return;
       }
 
       ezLog::Success("Wrote thumbnail to '{}'", m_sOutputThumbnailFile);
@@ -315,7 +327,8 @@ ezApplication::Execution ezTexConv::Run()
         if (WriteOutputFile(m_sOutputLowResFile, m_Processor.m_LowResOutputImage).Failed())
         {
           ezLog::Error("Failed to write low-res result to '{}'", m_sOutputLowResFile);
-          return ezApplication::Execution::Quit;
+          RequestApplicationQuit();
+          return;
         }
 
         ezLog::Success("Wrote low-res result to '{}'", m_sOutputLowResFile);
@@ -325,7 +338,7 @@ ezApplication::Execution ezTexConv::Run()
     SetReturnCode(0);
   }
 
-  return ezApplication::Execution::Quit;
+  RequestApplicationQuit();
 }
 
 EZ_APPLICATION_ENTRY_POINT(ezTexConv);

--- a/Code/Tools/TexConv/TexConv.h
+++ b/Code/Tools/TexConv/TexConv.h
@@ -38,7 +38,7 @@ public:
   ezTexConv();
 
 public:
-  virtual Execution Run() override;
+  virtual void Run() override;
   virtual ezResult BeforeCoreSystemsStartup() override;
   virtual void AfterCoreSystemsStartup() override;
   virtual void BeforeCoreSystemsShutdown() override;

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -46,10 +46,9 @@ void ezEditorTestApplication::AfterCoreSystemsShutdown()
   m_pEditorApp = nullptr;
 }
 
-ezApplication::Execution ezEditorTestApplication::Run()
+void ezEditorTestApplication::Run()
 {
   qApp->processEvents();
-  return ezApplication::Execution::Continue;
 }
 
 void ezEditorTestApplication::AfterCoreSystemsStartup()

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.h
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.h
@@ -23,7 +23,7 @@ public:
   ezEditorTestApplication();
   virtual ezResult BeforeCoreSystemsStartup() override;
   virtual void AfterCoreSystemsShutdown() override;
-  virtual Execution Run() override;
+  virtual void Run() override;
 
 
   virtual void AfterCoreSystemsStartup() override;

--- a/Code/UnitTests/GameEngineTest/AnimationsTest/AnimationsTest.cpp
+++ b/Code/UnitTests/GameEngineTest/AnimationsTest/AnimationsTest.cpp
@@ -48,7 +48,9 @@ ezTestAppRun ezGameEngineTestAnimations::RunSubTest(ezInt32 iIdentifier, ezUInt3
   const bool bVulkan = ezGameApplication::GetActiveRenderer().IsEqual_NoCase("Vulkan");
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+
+  if (m_pOwnApplication->ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (m_ImgCompFrames[m_uiImgCompIdx] == m_iFrame)

--- a/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
+++ b/Code/UnitTests/GameEngineTest/Basics/Basics.cpp
@@ -376,7 +376,8 @@ ezTestAppRun ezGameEngineTestApplication_Basics::SubTestManyMeshesExec(ezInt32 i
 
   ezResourceManager::ForceNoFallbackAcquisition(3);
 
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (iCurFrame > 3)
@@ -451,7 +452,8 @@ ezTestAppRun ezGameEngineTestApplication_Basics::SubTestSkyboxExec(ezInt32 iCurF
   pCamera->LookAt(pos, pos + ezVec3(1, 0, 0), ezVec3(0, 0, 1));
   pCamera->RotateGlobally(ezAngle::MakeFromDegree(0), ezAngle::MakeFromDegree(0), ezAngle::MakeFromDegree(iCurFrame * 80.0f));
 
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (iCurFrame < 5)
@@ -553,7 +555,8 @@ ezTestAppRun ezGameEngineTestApplication_Basics::SubTestDebugRenderingExec(ezInt
     ezDebugRenderer::DrawSolidTriangles(m_pWorld.Borrow(), tris, ezColor::Gainsboro);
   }
 
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   // first frame no image is captured yet
@@ -585,7 +588,8 @@ ezTestAppRun ezGameEngineTestApplication_Basics::SubTestDebugRenderingExec2(ezIn
     ezDebugRenderer::DrawInfoText(m_pWorld.Borrow(), ezDebugTextPlacement::BottomRight, "test", "| Col 1\t| Col 2\t| Col 3\t|\n| abc\t| 42\t| 11.23\t|");
   }
 
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   // first frame no image is captured yet
@@ -609,7 +613,8 @@ void ezGameEngineTestApplication_Basics::SubTestLoadSceneSetup()
 
 ezTestAppRun ezGameEngineTestApplication_Basics::SubTestLoadSceneExec(ezInt32 iCurFrame)
 {
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   switch (iCurFrame)
@@ -636,7 +641,8 @@ void ezGameEngineTestApplication_Basics::SubTestGoReferenceSetup()
 
 ezTestAppRun ezGameEngineTestApplication_Basics::SubTestGoReferenceExec(ezInt32 iCurFrame)
 {
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   switch (iCurFrame)

--- a/Code/UnitTests/GameEngineTest/EffectsTest/EffectsTest.cpp
+++ b/Code/UnitTests/GameEngineTest/EffectsTest/EffectsTest.cpp
@@ -96,7 +96,8 @@ ezTestAppRun ezGameEngineTestEffects::RunSubTest(ezInt32 iIdentifier, ezUInt32 u
 {
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (m_ImgCompFrames[m_uiImgCompIdx].m_uiFrame == m_iFrame)

--- a/Code/UnitTests/GameEngineTest/KrautTest/KrautTest.cpp
+++ b/Code/UnitTests/GameEngineTest/KrautTest/KrautTest.cpp
@@ -49,7 +49,8 @@ ezTestAppRun ezGameEngineTestKraut::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiI
 {
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (m_ImgCompFrames[m_uiImgCompIdx] == m_iFrame)

--- a/Code/UnitTests/GameEngineTest/ParticlesTest/ParticlesTest.cpp
+++ b/Code/UnitTests/GameEngineTest/ParticlesTest/ParticlesTest.cpp
@@ -198,7 +198,8 @@ void ezGameEngineTestApplication_Particles::SetupParticleSubTest(const char* szF
 
 ezTestAppRun ezGameEngineTestApplication_Particles::ExecParticleSubTest(ezInt32 iCurFrame)
 {
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   switch (iCurFrame)

--- a/Code/UnitTests/GameEngineTest/ProcGenTest/ProcGenTest.cpp
+++ b/Code/UnitTests/GameEngineTest/ProcGenTest/ProcGenTest.cpp
@@ -46,7 +46,8 @@ ezTestAppRun ezGameEngineTestProcGen::RunSubTest(ezInt32 iIdentifier, ezUInt32 u
   const bool bVulkan = ezGameApplication::GetActiveRenderer().IsEqual_NoCase("Vulkan");
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
   {
     return ezTestAppRun::Quit;
   }

--- a/Code/UnitTests/GameEngineTest/StateMachineTest/StateMachineTest.cpp
+++ b/Code/UnitTests/GameEngineTest/StateMachineTest/StateMachineTest.cpp
@@ -60,7 +60,8 @@ ezTestAppRun ezGameEngineTestStateMachine::RunSubTest(ezInt32 iIdentifier, ezUIn
   const bool bVulkan = ezGameApplication::GetActiveRenderer().IsEqual_NoCase("Vulkan");
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (m_ImgCompFrames[m_uiImgCompIdx] == m_iFrame)

--- a/Code/UnitTests/GameEngineTest/StereoTest/StereoTest.cpp
+++ b/Code/UnitTests/GameEngineTest/StereoTest/StereoTest.cpp
@@ -103,7 +103,8 @@ ezTestAppRun ezStereoTest::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocation
 
   ezDebugRenderer::Draw2DText(m_pApplication->GetWorld(), sb, ezVec2I32(50, 50), ezColor::Brown, 60);
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (m_ImgCompFrames[m_uiImgCompIdx] == m_iFrame)

--- a/Code/UnitTests/GameEngineTest/SubstanceTest/SubstanceTest.cpp
+++ b/Code/UnitTests/GameEngineTest/SubstanceTest/SubstanceTest.cpp
@@ -90,7 +90,8 @@ ezTestAppRun ezGameEngineTestSubstance::RunSubTest(ezInt32 iIdentifier, ezUInt32
   const bool bVulkan = ezGameApplication::GetActiveRenderer().IsEqual_NoCase("Vulkan");
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   if (m_ImgCompFrames[m_uiImgCompIdx] == m_iFrame)

--- a/Code/UnitTests/GameEngineTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/GameEngineTest/TestClass/TestClass.cpp
@@ -65,11 +65,12 @@ ezResult ezGameEngineTest::DeInitializeTest()
 {
   if (m_pApplication)
   {
-    m_pApplication->RequestQuit();
+    m_pApplication->RequestApplicationQuit();
 
     ezInt32 iSteps = 2;
-    while (m_pApplication->Run() == ezApplication::Execution::Continue && iSteps > 0)
+    while (!m_pApplication->ShouldApplicationQuit() && iSteps > 0)
     {
+      m_pApplication->Run();
       --iSteps;
     }
 

--- a/Code/UnitTests/GameEngineTest/TypeScriptTest/TypeScriptTest.cpp
+++ b/Code/UnitTests/GameEngineTest/TypeScriptTest/TypeScriptTest.cpp
@@ -88,7 +88,8 @@ void ezGameEngineTestApplication_TypeScript::SubTestBasicsSetup()
 
 ezTestAppRun ezGameEngineTestApplication_TypeScript::SubTestBasisExec(const char* szSubTestName)
 {
-  if (Run() == ezApplication::Execution::Quit)
+  Run();
+  if (ShouldApplicationQuit())
     return ezTestAppRun::Quit;
 
   EZ_LOCK(m_pWorld->GetWriteMarker());

--- a/Code/UnitTests/GameEngineTest/VisualScriptTest/VisualScriptTest.cpp
+++ b/Code/UnitTests/GameEngineTest/VisualScriptTest/VisualScriptTest.cpp
@@ -143,7 +143,8 @@ ezTestAppRun ezGameEngineTestVisualScript::RunSubTest(ezInt32 iIdentifier, ezUIn
   const bool bVulkan = ezGameApplication::GetActiveRenderer().IsEqual_NoCase("Vulkan");
   ++m_iFrame;
 
-  if (m_pOwnApplication->Run() == ezApplication::Execution::Quit)
+  m_pOwnApplication->Run();
+  if (m_pOwnApplication->ShouldApplicationQuit())
   {
     m_pTestLog = nullptr;
     return ezTestAppRun::Quit;

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -65,7 +65,7 @@ ezOffscreenRendererTest::ezOffscreenRendererTest()
 
 ezOffscreenRendererTest::~ezOffscreenRendererTest() = default;
 
-ezApplication::Execution ezOffscreenRendererTest::Run()
+void ezOffscreenRendererTest::Run()
 {
   EZ_PROFILE_SCOPE("Run");
 
@@ -123,7 +123,7 @@ ezApplication::Execution ezOffscreenRendererTest::Run()
   if (m_RequestedFrames.IsEmpty() && m_bExiting)
   {
     SetReturnCode(0);
-    RequestQuit();
+    RequestApplicationQuit();
   }
 
   // needs to be called once per frame
@@ -133,8 +133,6 @@ ezApplication::Execution ezOffscreenRendererTest::Run()
   // this has to be done at the very end, so that the task system will only use up the time that is left in this frame for
   // uploading GPU data etc.
   ezTaskSystem::FinishFrameTasks();
-
-  return WasQuitRequested() ? ezApplication::Execution::Quit : ezApplication::Execution::Continue;
 }
 
 void ezOffscreenRendererTest::OnPresent(ezUInt32 uiCurrentTexture, ezUInt64 uiCurrentSemaphoreValue)
@@ -169,7 +167,7 @@ void ezOffscreenRendererTest::AfterCoreSystemsStartup()
   {
     EZ_REPORT_FAILURE("Command Line does not contain -IPC parameter");
     SetReturnCode(-1);
-    RequestQuit();
+    RequestApplicationQuit();
     return;
   }
 
@@ -177,7 +175,7 @@ void ezOffscreenRendererTest::AfterCoreSystemsStartup()
   {
     EZ_REPORT_FAILURE("Command Line does not contain -PID parameter");
     SetReturnCode(-2);
-    RequestQuit();
+    RequestApplicationQuit();
     return;
   }
 
@@ -186,7 +184,7 @@ void ezOffscreenRendererTest::AfterCoreSystemsStartup()
   {
     EZ_REPORT_FAILURE("Command Line -PID parameter could not be converted to int");
     SetReturnCode(-3);
-    RequestQuit();
+    RequestApplicationQuit();
     return;
   }
 
@@ -259,7 +257,7 @@ void ezOffscreenRendererTest::MessageFunc(const ezProcessMessage* pMsg)
     {
       EZ_REPORT_FAILURE("Failed to create shared texture swapchain");
       SetReturnCode(-4);
-      RequestQuit();
+      RequestApplicationQuit();
     }
   }
   else if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_CloseMsg*>(pMsg))

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.h
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.h
@@ -61,7 +61,7 @@ public:
   ezOffscreenRendererTest();
   ~ezOffscreenRendererTest();
 
-  virtual ezApplication::Execution Run() override;
+  virtual void Run() override;
   void OnPresent(ezUInt32 uiCurrentTexture, ezUInt64 uiCurrentSemaphoreValue);
 
   virtual void AfterCoreSystemsStartup() override;


### PR DESCRIPTION
* There's now only a single application entry point macro: EZ_APPLICATION_ENTRY_POINT
* ezApplication doesn't have two ways to determine when to quite anymore. The return value from the Run() method was removed.