### PR TITLE
Cleanup of Rendering Device Capabilities

### DIFF
--- a/Code/Engine/Foundation/Platform/Posix/SystemInformation_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/SystemInformation_Posix.h
@@ -8,10 +8,6 @@ EZ_FOUNDATION_INTERNAL_HEADER
 
 bool ezSystemInformation::IsDebuggerAttached()
 {
-#if EZ_ENABLED(EZ_PLATFORM_WEB)
-  return false;
-#else
-
   ezOSFile status;
   if (status.Open("/proc/self/status", ezFileOpenMode::Read).Failed())
   {
@@ -39,7 +35,6 @@ bool ezSystemInformation::IsDebuggerAttached()
   }
 
   return *tracerPid == '0' ? false : true;
-#endif
 }
 
 void ezSystemInformation::Initialize()

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1170,7 +1170,7 @@ void ezRenderPipeline::Render(ezRenderContext* pRenderContext)
   else
     pRenderContext->SetShaderPermutationVariable(sCameraMode, sPerspective);
 
-  if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bVertexShaderRenderTargetArrayIndex)
+  if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bSupportsVSRenderTargetArrayIndex)
     pRenderContext->SetShaderPermutationVariable(sVSRTAI, sTrue);
   else
     pRenderContext->SetShaderPermutationVariable(sVSRTAI, sFalse);

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -904,7 +904,7 @@ void ezRenderContext::LoadBuiltinShader(ezShaderUtils::ezBuiltinShaderType type,
   static ezHashedString sStereo = ezMakeHashedString("CAMERA_MODE_STEREO");
 
   permutationVariables.Insert(sCameraMode, bStereo ? sStereo : sPerspective);
-  if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bVertexShaderRenderTargetArrayIndex)
+  if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bSupportsVSRenderTargetArrayIndex)
     permutationVariables.Insert(sVSRTAI, sTrue);
   else
     permutationVariables.Insert(sVSRTAI, sFalse);

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -761,14 +761,15 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
     m_Capabilities.m_uiDedicatedSystemRAM = static_cast<ezUInt64>(adapterDesc.DedicatedSystemMemory);
     m_Capabilities.m_uiSharedSystemRAM = static_cast<ezUInt64>(adapterDesc.SharedSystemMemory);
     m_Capabilities.m_bHardwareAccelerated = (adapterDesc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0;
+    m_Capabilities.m_bSupportsTexelBuffer = true;
   }
 
-  m_Capabilities.m_bMultithreadedResourceCreation = true;
+  m_Capabilities.m_bSupportsMultithreadedResourceCreation = true;
 
   switch (m_uiFeatureLevel)
   {
     case D3D_FEATURE_LEVEL_11_1:
-      m_Capabilities.m_bNoOverwriteBufferUpdate = true;
+      m_Capabilities.m_bSupportsNoOverwriteBufferUpdate = true;
       [[fallthrough]];
 
     case D3D_FEATURE_LEVEL_11_0:
@@ -778,66 +779,36 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
       m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = true;
       m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
       m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = true;
-      m_Capabilities.m_bInstancing = true;
-      m_Capabilities.m_b32BitIndices = true;
-      m_Capabilities.m_bIndirectDraw = true;
-      m_Capabilities.m_uiMaxConstantBuffers = D3D11_COMMONSHADER_CONSTANT_BUFFER_HW_SLOT_COUNT;
-      m_Capabilities.m_bTextureArrays = true;
-      m_Capabilities.m_bCubemapArrays = true;
-      m_Capabilities.m_bSharedTextures = true;
-      m_Capabilities.m_uiMaxTextureDimension = D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION;
-      m_Capabilities.m_uiMaxCubemapDimension = D3D11_REQ_TEXTURECUBE_DIMENSION;
-      m_Capabilities.m_uiMax3DTextureDimension = D3D11_REQ_TEXTURE3D_U_V_OR_W_DIMENSION;
-      m_Capabilities.m_uiMaxAnisotropy = D3D11_REQ_MAXANISOTROPY;
-      m_Capabilities.m_uiMaxRendertargets = D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT;
-      m_Capabilities.m_uiUAVCount = (m_uiFeatureLevel == D3D_FEATURE_LEVEL_11_1 ? 64 : 8);
-      m_Capabilities.m_bAlphaToCoverage = true;
+      m_Capabilities.m_bSupportsIndirectDraw = true;
+      m_Capabilities.m_bSupportsSharedTextures = true;
       break;
 
-    case D3D_FEATURE_LEVEL_10_1:
-    case D3D_FEATURE_LEVEL_10_0:
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::VertexShader] = true;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = false;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::DomainShader] = false;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = true;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = false;
-      m_Capabilities.m_bInstancing = true;
-      m_Capabilities.m_b32BitIndices = true;
-      m_Capabilities.m_bIndirectDraw = false;
-      m_Capabilities.m_uiMaxConstantBuffers = D3D11_COMMONSHADER_CONSTANT_BUFFER_HW_SLOT_COUNT;
-      m_Capabilities.m_bTextureArrays = true;
-      m_Capabilities.m_bCubemapArrays = (m_uiFeatureLevel == D3D_FEATURE_LEVEL_10_1 ? true : false);
-      m_Capabilities.m_uiMaxTextureDimension = D3D10_REQ_TEXTURE2D_U_OR_V_DIMENSION;
-      m_Capabilities.m_uiMaxCubemapDimension = D3D10_REQ_TEXTURECUBE_DIMENSION;
-      m_Capabilities.m_uiMax3DTextureDimension = D3D10_REQ_TEXTURE3D_U_V_OR_W_DIMENSION;
-      m_Capabilities.m_uiMaxAnisotropy = D3D10_REQ_MAXANISOTROPY;
-      m_Capabilities.m_uiMaxRendertargets = D3D10_SIMULTANEOUS_RENDER_TARGET_COUNT;
-      m_Capabilities.m_uiUAVCount = 0;
-      m_Capabilities.m_bAlphaToCoverage = true;
-      break;
+      // not supported any longer
 
-    case D3D_FEATURE_LEVEL_9_3:
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::VertexShader] = true;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = false;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::DomainShader] = false;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = false;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
-      m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = false;
-      m_Capabilities.m_bInstancing = true;
-      m_Capabilities.m_b32BitIndices = true;
-      m_Capabilities.m_bIndirectDraw = false;
-      m_Capabilities.m_uiMaxConstantBuffers = D3D11_COMMONSHADER_CONSTANT_BUFFER_HW_SLOT_COUNT;
-      m_Capabilities.m_bTextureArrays = false;
-      m_Capabilities.m_bCubemapArrays = false;
-      m_Capabilities.m_uiMaxTextureDimension = D3D_FL9_3_REQ_TEXTURE1D_U_DIMENSION;
-      m_Capabilities.m_uiMaxCubemapDimension = D3D_FL9_3_REQ_TEXTURECUBE_DIMENSION;
-      m_Capabilities.m_uiMax3DTextureDimension = 0;
-      m_Capabilities.m_uiMaxAnisotropy = 16;
-      m_Capabilities.m_uiMaxRendertargets = D3D_FL9_3_SIMULTANEOUS_RENDER_TARGET_COUNT;
-      m_Capabilities.m_uiUAVCount = 0;
-      m_Capabilities.m_bAlphaToCoverage = false;
-      break;
+      // case D3D_FEATURE_LEVEL_10_1:
+      // case D3D_FEATURE_LEVEL_10_0:
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::VertexShader] = true;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = false;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::DomainShader] = false;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = true;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = false;
+      //   m_Capabilities.m_bSupportsIndirectDraw = false;
+      //   m_Capabilities.m_bTextureArrays = true;
+      //   m_Capabilities.m_bCubemapArrays = (m_uiFeatureLevel == D3D_FEATURE_LEVEL_10_1 ? true : false);
+      //   break;
+
+      // case D3D_FEATURE_LEVEL_9_3:
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::VertexShader] = true;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = false;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::DomainShader] = false;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = false;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
+      //   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = false;
+      //   m_Capabilities.m_bSupportsIndirectDraw = false;
+      //   m_Capabilities.m_bTextureArrays = false;
+      //   m_Capabilities.m_bCubemapArrays = false;
+      //   break;
 
     default:
       EZ_ASSERT_NOT_IMPLEMENTED;
@@ -849,13 +820,13 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
     D3D11_FEATURE_DATA_D3D11_OPTIONS2 featureOpts2;
     if (SUCCEEDED(m_pDevice3->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS2, &featureOpts2, sizeof(featureOpts2))))
     {
-      m_Capabilities.m_bConservativeRasterization = (featureOpts2.ConservativeRasterizationTier != D3D11_CONSERVATIVE_RASTERIZATION_NOT_SUPPORTED);
+      m_Capabilities.m_bSupportsConservativeRasterization = (featureOpts2.ConservativeRasterizationTier != D3D11_CONSERVATIVE_RASTERIZATION_NOT_SUPPORTED);
     }
 
     D3D11_FEATURE_DATA_D3D11_OPTIONS3 featureOpts3;
     if (SUCCEEDED(m_pDevice3->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS3, &featureOpts3, sizeof(featureOpts3))))
     {
-      m_Capabilities.m_bVertexShaderRenderTargetArrayIndex = featureOpts3.VPAndRTArrayIndexFromAnyShaderFeedingRasterizer != 0;
+      m_Capabilities.m_bSupportsVSRenderTargetArrayIndex = featureOpts3.VPAndRTArrayIndexFromAnyShaderFeedingRasterizer != 0;
     }
   }
 

--- a/Code/Engine/RendererDX11/State/Implementation/StateDX11.cpp
+++ b/Code/Engine/RendererDX11/State/Implementation/StateDX11.cpp
@@ -204,7 +204,7 @@ ezResult ezGALRasterizerStateDX11::InitPlatform(ezGALDevice* pDevice)
       m_Description.m_bConservativeRasterization ? D3D11_CONSERVATIVE_RASTERIZATION_MODE_ON : D3D11_CONSERVATIVE_RASTERIZATION_MODE_OFF;
     DXDesc2.ForcedSampleCount = 0;
 
-    if (!pDevice->GetCapabilities().m_bConservativeRasterization && m_Description.m_bConservativeRasterization)
+    if (!pDevice->GetCapabilities().m_bSupportsConservativeRasterization && m_Description.m_bConservativeRasterization)
     {
       ezLog::Error("Rasterizer state description enables conservative rasterization which is not available!");
       return EZ_FAILURE;

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -225,7 +225,7 @@ void ezGALCommandEncoder::UpdateBuffer(ezGALBufferHandle hDest, ezUInt32 uiDestO
 
   if (pDest != nullptr)
   {
-    if (updateMode == ezGALUpdateMode::NoOverwrite && !(GetDevice().GetCapabilities().m_bNoOverwriteBufferUpdate))
+    if (updateMode == ezGALUpdateMode::NoOverwrite && !(GetDevice().GetCapabilities().m_bSupportsNoOverwriteBufferUpdate))
     {
       updateMode = ezGALUpdateMode::CopyToTempStorage;
     }

--- a/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
+++ b/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
@@ -48,33 +48,19 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALDeviceCapabilities
   bool m_bHardwareAccelerated = false;
 
   // General capabilities
-  bool m_bMultithreadedResourceCreation = false; ///< whether creating resources is allowed on other threads than the main thread
-  bool m_bNoOverwriteBufferUpdate = false;
+  bool m_bSupportsMultithreadedResourceCreation = false; ///< whether creating resources is allowed on other threads than the main thread
+  bool m_bSupportsNoOverwriteBufferUpdate = false;
 
   // Draw related capabilities
   bool m_bShaderStageSupported[ezGALShaderStage::ENUM_COUNT] = {};
-  bool m_bInstancing = false;
-  bool m_b32BitIndices = false;
-  bool m_bIndirectDraw = false;
-  bool m_bConservativeRasterization = false;
-  bool m_bVertexShaderRenderTargetArrayIndex = false;
-  bool m_bTexelBuffer = true; ///< Whether ezGALBufferUsageFlags::TexelBuffer is supported. Hardcoded per platform as it must match SUPPORTS_TEXEL_BUFFER shader define.
-  ezUInt16 m_uiMaxConstantBuffers = 0;
+  bool m_bSupportsIndirectDraw = false;
+  bool m_bSupportsConservativeRasterization = false;
+  bool m_bSupportsVSRenderTargetArrayIndex = false;
+  bool m_bSupportsTexelBuffer = false; ///< Whether ezGALBufferUsageFlags::TexelBuffer is supported. Hardcoded per platform as it must match SUPPORTS_TEXEL_BUFFER shader define.
   ezUInt16 m_uiMaxPushConstantsSize = 0;
 
 
   // Texture related capabilities
-  bool m_bTextureArrays = false;
-  bool m_bCubemapArrays = false;
-  bool m_bSharedTextures = false;
-  ezUInt16 m_uiMaxTextureDimension = 0;
-  ezUInt16 m_uiMaxCubemapDimension = 0;
-  ezUInt16 m_uiMax3DTextureDimension = 0;
-  ezUInt16 m_uiMaxAnisotropy = 0;
+  bool m_bSupportsSharedTextures = false;
   ezDynamicArray<ezBitflags<ezGALResourceFormatSupport>> m_FormatSupport;
-
-  // Output related capabilities
-  ezUInt16 m_uiMaxRendertargets = 0;
-  ezUInt16 m_uiUAVCount = 0;
-  bool m_bAlphaToCoverage = false;
 };

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -170,7 +170,7 @@ void ezGALDevice::ReviveDeadObject(ezUInt32 uiType, HandleType handle)
 EZ_ALWAYS_INLINE void ezGALDevice::VerifyMultithreadedAccess() const
 {
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-  EZ_ASSERT_DEV(m_Capabilities.m_bMultithreadedResourceCreation || ezThreadUtils::IsMainThread(),
+  EZ_ASSERT_DEV(m_Capabilities.m_bSupportsMultithreadedResourceCreation || ezThreadUtils::IsMainThread(),
     "This device does not support multi-threaded resource creation, therefore this function can only be executed on the main thread.");
 #endif
 }

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -594,7 +594,7 @@ void ezGALCommandEncoderImplVulkan::ReadbackTexturePlatform(const ezGALTexture* 
 
     const ezUInt32 arraySize = (textureDesc.m_Type == ezGALTextureType::TextureCube || textureDesc.m_Type == ezGALTextureType::TextureCubeArray) ? textureDesc.m_uiArraySize * 6 : textureDesc.m_uiArraySize;
     const ezUInt32 mipLevels = textureDesc.m_uiMipLevelCount;
-    const bool bStereoSupport = m_GALDeviceVulkan.GetCapabilities().m_bVertexShaderRenderTargetArrayIndex || m_GALDeviceVulkan.GetCapabilities().m_bShaderStageSupported[ezGALShaderStage::GeometryShader];
+    const bool bStereoSupport = m_GALDeviceVulkan.GetCapabilities().m_bSupportsVSRenderTargetArrayIndex || m_GALDeviceVulkan.GetCapabilities().m_bShaderStageSupported[ezGALShaderStage::GeometryShader];
     if (arraySize > 1 && bStereoSupport)
     {
       copy.Init(pVulkanTexture, pStagingTexture, ezShaderUtils::ezBuiltinShaderType::CopyImageArray);
@@ -862,7 +862,7 @@ void ezGALCommandEncoderImplVulkan::GenerateMipMapsPlatform(const ezGALTextureRe
       }
 
       ezImageCopyVulkan copy(m_GALDeviceVulkan);
-      const bool bStereoSupport = m_GALDeviceVulkan.GetCapabilities().m_bVertexShaderRenderTargetArrayIndex || m_GALDeviceVulkan.GetCapabilities().m_bShaderStageSupported[ezGALShaderStage::GeometryShader];
+      const bool bStereoSupport = m_GALDeviceVulkan.GetCapabilities().m_bSupportsVSRenderTargetArrayIndex || m_GALDeviceVulkan.GetCapabilities().m_bShaderStageSupported[ezGALShaderStage::GeometryShader];
       if (bStereoSupport)
       {
         copy.Init(pVulkanTexture, pVulkanTexture, ezShaderUtils::ezBuiltinShaderType::DownscaleImageArray);

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1463,11 +1463,12 @@ void ezGALDeviceVulkan::FillCapabilitiesPlatform()
     m_Capabilities.m_uiDedicatedSystemRAM = static_cast<ezUInt64>(systemMemory);
     m_Capabilities.m_uiSharedSystemRAM = static_cast<ezUInt64>(0); // TODO
     m_Capabilities.m_bHardwareAccelerated = m_properties.deviceType == vk::PhysicalDeviceType::eDiscreteGpu;
+    m_Capabilities.m_bSupportsTexelBuffer = true;
   }
 
-  m_Capabilities.m_bMultithreadedResourceCreation = true;
+  m_Capabilities.m_bSupportsMultithreadedResourceCreation = true;
 
-  m_Capabilities.m_bNoOverwriteBufferUpdate = true; // TODO how to check
+  m_Capabilities.m_bSupportsNoOverwriteBufferUpdate = true; // TODO how to check
 
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::VertexShader] = true;
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = features.tessellationShader;
@@ -1475,31 +1476,19 @@ void ezGALDeviceVulkan::FillCapabilitiesPlatform()
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = features.geometryShader;
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = true; // we check this when creating the queue, always has to be supported
-  m_Capabilities.m_bInstancing = true;
-  m_Capabilities.m_b32BitIndices = true;
-  m_Capabilities.m_bIndirectDraw = true;
-  m_Capabilities.m_uiMaxConstantBuffers = ezMath::Min(m_properties.limits.maxDescriptorSetUniformBuffers, (ezUInt32)ezMath::MaxValue<ezUInt16>());
+  m_Capabilities.m_bSupportsIndirectDraw = true;
   m_Capabilities.m_uiMaxPushConstantsSize = ezMath::Min(m_properties.limits.maxPushConstantsSize, (ezUInt32)ezMath::MaxValue<ezUInt16>());
   ;
-  m_Capabilities.m_bTextureArrays = true;
-  m_Capabilities.m_bCubemapArrays = true;
 #if EZ_ENABLED(EZ_PLATFORM_LINUX) || EZ_ENABLED(EZ_PLATFORM_ANDROID)
-  m_Capabilities.m_bSharedTextures = m_extensions.m_bTimelineSemaphore && m_extensions.m_bExternalMemoryFd && m_extensions.m_bExternalSemaphoreFd;
+  m_Capabilities.m_bSupportsSharedTextures = m_extensions.m_bTimelineSemaphore && m_extensions.m_bExternalMemoryFd && m_extensions.m_bExternalSemaphoreFd;
 #elif EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-  m_Capabilities.m_bSharedTextures = m_extensions.m_bTimelineSemaphore && m_extensions.m_bExternalMemoryWin32 && m_extensions.m_bExternalSemaphoreWin32;
+  m_Capabilities.m_bSupportsSharedTextures = m_extensions.m_bTimelineSemaphore && m_extensions.m_bExternalMemoryWin32 && m_extensions.m_bExternalSemaphoreWin32;
 #else
   EZ_ASSERT_NOT_IMPLEMENTED;
 #endif
-  m_Capabilities.m_uiMaxTextureDimension = m_properties.limits.maxImageDimension1D;
-  m_Capabilities.m_uiMaxCubemapDimension = m_properties.limits.maxImageDimensionCube;
-  m_Capabilities.m_uiMax3DTextureDimension = m_properties.limits.maxImageDimension3D;
-  m_Capabilities.m_uiMaxAnisotropy = static_cast<ezUInt16>(m_properties.limits.maxSamplerAnisotropy);
-  m_Capabilities.m_uiMaxRendertargets = m_properties.limits.maxColorAttachments;
-  m_Capabilities.m_uiUAVCount = ezMath::Min(ezMath::Min(m_properties.limits.maxDescriptorSetStorageBuffers, m_properties.limits.maxDescriptorSetStorageImages), (ezUInt32)ezMath::MaxValue<ezUInt16>());
-  m_Capabilities.m_bAlphaToCoverage = true;
-  m_Capabilities.m_bVertexShaderRenderTargetArrayIndex = m_extensions.m_bShaderViewportIndexLayer;
+  m_Capabilities.m_bSupportsVSRenderTargetArrayIndex = m_extensions.m_bShaderViewportIndexLayer;
 
-  m_Capabilities.m_bConservativeRasterization = false; // need to query for VK_EXT_CONSERVATIVE_RASTERIZATION
+  m_Capabilities.m_bSupportsConservativeRasterization = false; // need to query for VK_EXT_CONSERVATIVE_RASTERIZATION
 
   m_Capabilities.m_FormatSupport.SetCount(ezGALResourceFormat::ENUM_COUNT);
   for (ezUInt32 i = 0; i < ezGALResourceFormat::ENUM_COUNT; i++)

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -51,7 +51,7 @@ void ezProcVertexColorComponentManager::Initialize()
     desc.m_uiTotalSize = desc.m_uiStructSize * VERTEX_COLOR_BUFFER_SIZE;
     desc.m_ResourceAccess.m_bImmutable = false;
 
-    if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bTexelBuffer)
+    if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bSupportsTexelBuffer)
     {
       desc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource;
       desc.m_Format = ezGALResourceFormat::RGBAUByteNormalized;

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -20,12 +20,12 @@ void ezRendererTestAdvancedFeatures::SetupSubTests()
   const ezGALDeviceCapabilities& caps = ezGALDevice::GetDefaultDevice()->GetCapabilities();
 
   AddSubTest("01 - ReadRenderTarget", SubTests::ST_ReadRenderTarget);
-  if (caps.m_bVertexShaderRenderTargetArrayIndex)
+  if (caps.m_bSupportsVSRenderTargetArrayIndex)
   {
     AddSubTest("02 - VertexShaderRenderTargetArrayIndex", SubTests::ST_VertexShaderRenderTargetArrayIndex);
   }
 #if EZ_ENABLED(EZ_SUPPORTS_PROCESSES)
-  if (caps.m_bSharedTextures)
+  if (caps.m_bSupportsSharedTextures)
   {
     AddSubTest("03 - SharedTexture", SubTests::ST_SharedTexture);
   }
@@ -396,7 +396,7 @@ ezTestAppRun ezRendererTestAdvancedFeatures::RunSubTest(ezInt32 iIdentifier, ezU
       ReadRenderTarget();
       break;
     case SubTests::ST_VertexShaderRenderTargetArrayIndex:
-      if (!m_pDevice->GetCapabilities().m_bVertexShaderRenderTargetArrayIndex)
+      if (!m_pDevice->GetCapabilities().m_bSupportsVSRenderTargetArrayIndex)
         return ezTestAppRun::Quit;
       VertexShaderRenderTargetArrayIndex();
       break;


### PR DESCRIPTION
* Removed DX11 downlevel support.
* Removed capabilities that we don't use. No point in maintaining values just for fun.