### PR TITLE
Readback refactor

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
@@ -4,8 +4,8 @@
 #include <EditorEngineProcessFramework/EngineProcess/WorldRttiConverterContext.h>
 #include <Foundation/Types/Uuid.h>
 #include <RendererFoundation/Device/SwapChain.h>
-#include <RendererFoundation/Resources/RenderTargetSetup.h>
 #include <RendererFoundation/Resources/ReadbackHelper.h>
+#include <RendererFoundation/Resources/RenderTargetSetup.h>
 
 class ezEditorEngineSyncObjectMsg;
 class ezEditorEngineSyncObject;

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h
@@ -5,6 +5,7 @@
 #include <Foundation/Types/Uuid.h>
 #include <RendererFoundation/Device/SwapChain.h>
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
+#include <RendererFoundation/Resources/ReadbackHelper.h>
 
 class ezEditorEngineSyncObjectMsg;
 class ezEditorEngineSyncObject;
@@ -185,6 +186,8 @@ private:
   ezGALRenderTargets m_ThumbnailRenderTargets;
   ezGALTextureHandle m_hThumbnailColorRT;
   ezGALTextureHandle m_hThumbnailDepthRT;
+  ezGALReadbackTextureHelper m_ThumbnailReadback;
+
   bool m_bWorldSimStateBeforeThumbnail = false;
   ezString m_sDocumentType;
 

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessApp.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessApp.cpp
@@ -107,7 +107,6 @@ ezViewHandle ezEditorEngineProcessApp::CreateRemoteWindowAndView(ezCamera* pCame
       ezGALWindowSwapChainCreationDescription desc;
       desc.m_pWindow = pWindowPlugin->m_pWindow.Borrow();
       desc.m_BackBufferFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
-      desc.m_bAllowScreenshots = true;
 
       pOutput->CreateSwapchain(desc);
 

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -458,7 +458,7 @@ void ezEngineProcessDocumentContext::UpdateDocumentContext()
         EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
 
         ezImage tmp;
-        ezImageView imageView = ezTextureUtils::CreateSubResourceView(pThumbnailColor->GetDescription(), sourceSubResource, memory[0], tmp, true);
+        ezImageView imageView = ezTextureUtils::MakeImageViewFromSubResource(pThumbnailColor->GetDescription(), sourceSubResource, memory[0], tmp, true);
 
         ezImage imageSwap;
         ezImage* pImage = &tmp;

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -435,49 +435,40 @@ void ezEngineProcessDocumentContext::UpdateDocumentContext()
       ezCreateThumbnailMsgToEditor ret;
       ret.m_DocumentGuid = GetDocumentGuid();
 
-      // Download image
+      // Start readback image
       {
         auto pCommandEncoder = ezGALDevice::GetDefaultDevice()->BeginCommands("Thumbnail Readback");
         EZ_SCOPE_EXIT(ezGALDevice::GetDefaultDevice()->EndCommands(pCommandEncoder));
 
-        pCommandEncoder->BeginRendering(ezGALRenderingSetup());
-        EZ_SCOPE_EXIT(pCommandEncoder->EndRendering());
+        m_ThumbnailReadback.ReadbackTexture(*pCommandEncoder, m_hThumbnailColorRT);
+        pCommandEncoder->Flush();
+      }
+      // Wait for results
+      {
+        ezEnum<ezGALAsyncResult> res = m_ThumbnailReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+        EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
 
-        pCommandEncoder->ReadbackTexture(m_hThumbnailColorRT);
         const ezGALTexture* pThumbnailColor = ezGALDevice::GetDefaultDevice()->GetTexture(m_hThumbnailColorRT);
-        const ezEnum<ezGALResourceFormat> format = pThumbnailColor->GetDescription().m_Format;
-
-        ezGALSystemMemoryDescription MemDesc;
-        {
-          MemDesc.m_uiRowPitch = 4 * m_uiThumbnailWidth;
-          MemDesc.m_uiSlicePitch = 4 * m_uiThumbnailWidth * m_uiThumbnailHeight;
-        }
-
-        ezImageHeader header;
-        header.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(format, true));
-        header.SetWidth(m_uiThumbnailWidth);
-        header.SetHeight(m_uiThumbnailHeight);
-        ezImage image;
-        image.ResetAndAlloc(header);
-        EZ_ASSERT_DEV(static_cast<ezUInt64>(m_uiThumbnailWidth) * static_cast<ezUInt64>(m_uiThumbnailHeight) * 4 == header.ComputeDataSize(), "Thumbnail ezImage has different size than data buffer!");
-
-        MemDesc.m_pData = image.GetPixelPointer<ezUInt8>();
-        ezArrayPtr<ezGALSystemMemoryDescription> SysMemDescs(&MemDesc, 1);
 
         ezGALTextureSubresource sourceSubResource;
         ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
+        ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
 
-        pCommandEncoder->CopyTextureReadbackResult(m_hThumbnailColorRT, sourceSubResources, SysMemDescs);
+        ezReadbackTextureLock lock = m_ThumbnailReadback.LockTexture(sourceSubResources, memory);
+        EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+
+        ezImage tmp;
+        ezImageView imageView = ezTextureUtils::CreateSubResourceView(pThumbnailColor->GetDescription(), sourceSubResource, memory[0], tmp, true);
 
         ezImage imageSwap;
-        ezImage* pImage = &image;
+        ezImage* pImage = &tmp;
         ezImage* pImageSwap = &imageSwap;
         for (ezUInt32 uiSuperscaleFactor = ThumbnailSuperscaleFactor; uiSuperscaleFactor > 1; uiSuperscaleFactor /= 2)
         {
-          ezImageUtils::Scale(*pImage, *pImageSwap, pImage->GetWidth() / 2, pImage->GetHeight() / 2).IgnoreResult();
+          ezImageView& sourceView = uiSuperscaleFactor == ThumbnailSuperscaleFactor ? imageView : *pImage;
+          ezImageUtils::Scale(sourceView, *pImageSwap, sourceView.GetWidth() / 2, sourceView.GetHeight() / 2).IgnoreResult();
           ezMath::Swap(pImage, pImageSwap);
         }
-
 
         ret.m_ThumbnailData.SetCountUninitialized((m_uiThumbnailWidth / ThumbnailSuperscaleFactor) * (m_uiThumbnailHeight / ThumbnailSuperscaleFactor) * 4);
         ezMemoryUtils::Copy(ret.m_ThumbnailData.GetData(), pImage->GetPixelPointer<ezUInt8>(), ret.m_ThumbnailData.GetCount());
@@ -527,7 +518,6 @@ void ezEngineProcessDocumentContext::CreateThumbnailViewContext(const ezCreateTh
   tcd.m_bAllowUAV = false;
   tcd.m_bCreateRenderTarget = true;
   tcd.m_Format = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
-  tcd.m_ResourceAccess.m_bReadBack = true;
   tcd.m_Type = ezGALTextureType::Texture2D;
   tcd.m_uiWidth = m_uiThumbnailWidth;
   tcd.m_uiHeight = m_uiThumbnailHeight;
@@ -535,7 +525,6 @@ void ezEngineProcessDocumentContext::CreateThumbnailViewContext(const ezCreateTh
   m_hThumbnailColorRT = pDevice->CreateTexture(tcd);
 
   tcd.m_Format = ezGALResourceFormat::DFloat;
-  tcd.m_ResourceAccess.m_bReadBack = false;
 
   m_hThumbnailDepthRT = pDevice->CreateTexture(tcd);
 

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessViewContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessViewContext.cpp
@@ -134,7 +134,6 @@ void ezEngineProcessViewContext::HandleWindowUpdate(ezWindowHandle hWnd, ezUInt1
       ezGALWindowSwapChainCreationDescription desc;
       desc.m_pWindow = pWindowPlugin->m_pWindow.Borrow();
       desc.m_BackBufferFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
-      desc.m_bAllowScreenshots = true;
 
       pOutput->CreateSwapchain(desc);
 

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -4,8 +4,8 @@
 #include <RendererCore/Lights/ClusteredDataProvider.h>
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderContext/RenderContext.h>
-#include <RendererFoundation/Resources/Texture.h>
 #include <RendererCore/Textures/TextureUtils.h>
+#include <RendererFoundation/Resources/Texture.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPickingRenderPass, 1, ezRTTIDefaultAllocator<ezPickingRenderPass>)

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -5,6 +5,7 @@
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererFoundation/Resources/Texture.h>
+#include <RendererCore/Textures/TextureUtils.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPickingRenderPass, 1, ezRTTIDefaultAllocator<ezPickingRenderPass>)
@@ -77,75 +78,78 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
   renderingSetup.m_bClearDepth = true;
   renderingSetup.m_bClearStencil = true;
 
-  auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName());
-
-  ezViewRenderMode::Enum viewRenderMode = renderViewContext.m_pViewData->m_ViewRenderMode;
-  if (viewRenderMode == ezViewRenderMode::WireframeColor || viewRenderMode == ezViewRenderMode::WireframeMonochrome)
-    renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_PICKING_WIREFRAME");
-  else
-    renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_PICKING");
-
-  // Setup clustered data
-  auto pClusteredData = GetPipeline()->GetFrameDataProvider<ezClusteredDataProvider>()->GetData(renderViewContext);
-  pClusteredData->BindResources(renderViewContext.m_pRenderContext);
-
-  // copy selection to set for faster checks
-  m_SelectionSet.Clear();
-
-  auto batchList = GetPipeline()->GetRenderDataBatchesWithCategory(ezDefaultRenderDataCategories::Selection);
-  const ezUInt32 uiBatchCount = batchList.GetBatchCount();
-  for (ezUInt32 i = 0; i < uiBatchCount; ++i)
   {
-    const ezRenderDataBatch& batch = batchList.GetBatch(i);
-    for (auto it = batch.GetIterator<ezRenderData>(); it.IsValid(); ++it)
+    auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName());
+
+    ezViewRenderMode::Enum viewRenderMode = renderViewContext.m_pViewData->m_ViewRenderMode;
+    if (viewRenderMode == ezViewRenderMode::WireframeColor || viewRenderMode == ezViewRenderMode::WireframeMonochrome)
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_PICKING_WIREFRAME");
+    else
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_PICKING");
+
+    // Setup clustered data
+    auto pClusteredData = GetPipeline()->GetFrameDataProvider<ezClusteredDataProvider>()->GetData(renderViewContext);
+    pClusteredData->BindResources(renderViewContext.m_pRenderContext);
+
+    // copy selection to set for faster checks
+    m_SelectionSet.Clear();
+
+    auto batchList = GetPipeline()->GetRenderDataBatchesWithCategory(ezDefaultRenderDataCategories::Selection);
+    const ezUInt32 uiBatchCount = batchList.GetBatchCount();
+    for (ezUInt32 i = 0; i < uiBatchCount; ++i)
     {
-      m_SelectionSet.Insert(it->m_hOwner);
+      const ezRenderDataBatch& batch = batchList.GetBatch(i);
+      for (auto it = batch.GetIterator<ezRenderData>(); it.IsValid(); ++it)
+      {
+        m_SelectionSet.Insert(it->m_hOwner);
+      }
     }
-  }
 
-  // filter out all selected objects
-  ezRenderDataBatch::Filter filter([&](const ezRenderData* pRenderData)
-    { return m_SelectionSet.Contains(pRenderData->m_hOwner); });
+    // filter out all selected objects
+    ezRenderDataBatch::Filter filter([&](const ezRenderData* pRenderData)
+      { return m_SelectionSet.Contains(pRenderData->m_hOwner); });
 
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaque, filter);
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMasked, filter);
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaque, filter);
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMasked, filter);
 
-  if (m_bPickTransparent)
-  {
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitTransparent, filter);
+    if (m_bPickTransparent)
+    {
+      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitTransparent, filter);
+
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "TRUE");
+      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitForeground);
+
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "FALSE");
+      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitForeground);
+    }
+
+    if (m_bPickSelected)
+    {
+      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::Selection);
+    }
+
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleOpaque);
+
+    if (m_bPickTransparent)
+    {
+      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleTransparent, filter);
+    }
 
     renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "TRUE");
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitForeground);
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleForeground);
 
     renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "FALSE");
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitForeground);
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleForeground);
+
+    renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_FORWARD");
   }
-
-  if (m_bPickSelected)
-  {
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::Selection);
-  }
-
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleOpaque);
-
-  if (m_bPickTransparent)
-  {
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleTransparent, filter);
-  }
-
-  renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "TRUE");
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleForeground);
-
-  renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "FALSE");
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleForeground);
-
-  renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_FORWARD");
 
   // download the picking information from the GPU
   if (m_uiWindowWidth != 0 && m_uiWindowHeight != 0)
   {
-    pCommandEncoder->ReadbackTexture(GetPickingDepthRT());
-    pCommandEncoder->ReadbackTexture(GetPickingIdRT());
+    m_PickingReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingIdRT());
+    m_PickingDepthReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingDepthRT());
+    renderViewContext.m_pRenderContext->GetCommandEncoder()->Flush();
 
     ezMat4 mProj;
     renderViewContext.m_pCamera->GetProjectionMatrix((float)m_uiWindowWidth / m_uiWindowHeight, mProj);
@@ -163,28 +167,35 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
 
     m_mPickingInverseViewProjectionMatrix = inv;
 
-    ezGALSystemMemoryDescription MemDesc;
-    MemDesc.m_uiRowPitch = 4 * m_uiWindowWidth;
-    MemDesc.m_uiSlicePitch = 4 * m_uiWindowWidth * m_uiWindowHeight;
-    ezArrayPtr<ezGALSystemMemoryDescription> SysMemDescs(&MemDesc, 1);
+    // Wait for results
+    {
+      ezEnum<ezGALAsyncResult> res = m_PickingReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+      res = m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+    }
 
     ezGALTextureSubresource sourceSubResource;
     ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
+    ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
 
     {
       m_PickingResultsDepth.Clear();
       m_PickingResultsDepth.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
 
-      MemDesc.m_pData = m_PickingResultsDepth.GetData();
-      pCommandEncoder->CopyTextureReadbackResult(GetPickingDepthRT(), sourceSubResources, SysMemDescs);
+      ezReadbackTextureLock lock = m_PickingDepthReadback.LockTexture(sourceSubResources, memory);
+      EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+      const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingDepthRT());
+      ezTextureUtils::CopySubResource(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsDepth.GetByteArrayPtr(), m_uiWindowWidth * sizeof(float));
     }
-
     {
       m_PickingResultsID.Clear();
       m_PickingResultsID.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
 
-      MemDesc.m_pData = m_PickingResultsID.GetData();
-      pCommandEncoder->CopyTextureReadbackResult(GetPickingIdRT(), sourceSubResources, SysMemDescs);
+      ezReadbackTextureLock lock = m_PickingReadback.LockTexture(sourceSubResources, memory);
+      EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+      const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingIdRT());
+      ezTextureUtils::CopySubResource(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsID.GetByteArrayPtr(), m_uiWindowWidth * sizeof(ezUInt32));
     }
   }
 }
@@ -206,7 +217,6 @@ void ezPickingRenderPass::CreateTarget()
   tcd.m_bAllowUAV = false;
   tcd.m_bCreateRenderTarget = true;
   tcd.m_Format = ezGALResourceFormat::RGBAUByteNormalized;
-  tcd.m_ResourceAccess.m_bReadBack = true;
   tcd.m_Type = ezGALTextureType::Texture2D;
   tcd.m_uiWidth = (ezUInt32)m_TargetRect.width;
   tcd.m_uiHeight = (ezUInt32)m_TargetRect.height;
@@ -214,7 +224,6 @@ void ezPickingRenderPass::CreateTarget()
   m_hPickingIdRT = pDevice->CreateTexture(tcd);
 
   tcd.m_Format = ezGALResourceFormat::DFloat;
-  tcd.m_ResourceAccess.m_bReadBack = true;
 
   m_hPickingDepthRT = pDevice->CreateTexture(tcd);
 

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -186,7 +186,7 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
       ezReadbackTextureLock lock = m_PickingDepthReadback.LockTexture(sourceSubResources, memory);
       EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
       const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingDepthRT());
-      ezTextureUtils::CopySubResource(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsDepth.GetByteArrayPtr(), m_uiWindowWidth * sizeof(float));
+      ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsDepth.GetByteArrayPtr(), m_uiWindowWidth * sizeof(float));
     }
     {
       m_PickingResultsID.Clear();
@@ -195,7 +195,7 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
       ezReadbackTextureLock lock = m_PickingReadback.LockTexture(sourceSubResources, memory);
       EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
       const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingIdRT());
-      ezTextureUtils::CopySubResource(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsID.GetByteArrayPtr(), m_uiWindowWidth * sizeof(ezUInt32));
+      ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsID.GetByteArrayPtr(), m_uiWindowWidth * sizeof(ezUInt32));
     }
   }
 }

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
@@ -2,6 +2,7 @@
 
 #include <EditorEngineProcessFramework/EngineProcess/ViewRenderSettings.h>
 #include <RendererCore/Pipeline/RenderPipelinePass.h>
+#include <RendererFoundation/Resources/ReadbackHelper.h>
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
 
 class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezPickingRenderPass : public ezRenderPipelinePass
@@ -49,6 +50,8 @@ private:
   ezGALTextureHandle m_hPickingIdRT;
   ezGALTextureHandle m_hPickingDepthRT;
   ezGALRenderTargetSetup m_RenderTargetSetup;
+  ezGALReadbackTextureHelper m_PickingReadback;
+  ezGALReadbackTextureHelper m_PickingDepthReadback;
 
   ezHashSet<ezGameObjectHandle> m_SelectionSet;
 

--- a/Code/Engine/Core/Platform/Win/InputDevice_Win.cpp
+++ b/Code/Engine/Core/Platform/Win/InputDevice_Win.cpp
@@ -390,7 +390,7 @@ void ezStandardInputDevice::WindowMessage(ezMinWindows::HWND hWnd, ezMinWindows:
   static ezInt32 s_iMouseCaptureCount = 0;
 #  endif
 
-  if (m_bFirstWndMsg)
+  if (m_bFirstWndMsg && m_ClipCursorMode != ezMouseCursorClipMode::NoClip)
   {
     // hack fix to make sure the mouse is in the window center and gets clipped to the window, on startup
 

--- a/Code/Engine/Foundation/Containers/Blob.h
+++ b/Code/Engine/Foundation/Containers/Blob.h
@@ -53,6 +53,13 @@ public:
   {
   }
 
+  /// \brief Initializes the ezBlobPtr to be a copy of \a other. No memory is allocated or copied.
+  EZ_ALWAYS_INLINE ezBlobPtr(const ezArrayPtr<T>& other)
+    : m_pPtr(other.GetPtr())
+    , m_uiCount(other.GetCount())
+  {
+  }
+
   /// \brief Convert to const version.
   operator ezBlobPtr<const T>() const { return ezBlobPtr<const T>(static_cast<const T*>(GetPtr()), GetCount()); }
 
@@ -61,6 +68,13 @@ public:
   {
     m_pPtr = other.m_pPtr;
     m_uiCount = other.m_uiCount;
+  }
+
+  /// \brief Copies the pointer and size of /a other. Does not allocate any data.
+  EZ_ALWAYS_INLINE void operator=(const ezArrayPtr<T>& other)
+  {
+    m_pPtr = other.GetPtr();
+    m_uiCount = other.GetCount();
   }
 
   /// \brief Clears the array

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
@@ -240,7 +240,7 @@ void ezImgui::Startup(ezImguiConfigFontCallback configFontCallback)
   if (!hFont.IsValid())
   {
     ezGALSystemMemoryDescription memoryDesc;
-    memoryDesc.m_pData = pixels;
+    memoryDesc.m_pData = ezMakeByteBlobPtr(pixels, ezUInt64(width) * height * 4ull);
     memoryDesc.m_uiRowPitch = width * 4;
     memoryDesc.m_uiSlicePitch = width * height * 4;
 

--- a/Code/Engine/GameEngine/GameApplication/Implementation/WindowOutputTargetGAL.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/WindowOutputTargetGAL.cpp
@@ -75,45 +75,28 @@ void ezWindowOutputTargetGAL::AcquireImage()
 ezResult ezWindowOutputTargetGAL::CaptureImage(ezImage& out_image)
 {
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
+  ezGALTextureHandle hBackbuffer;
+  // Start readback image
+  {
+    auto pCommandEncoder = pDevice->BeginCommands("CaptureImage");
+    EZ_SCOPE_EXIT(pDevice->EndCommands(pCommandEncoder));
 
-  auto pCommandEncoder = pDevice->BeginCommands("CaptureImage");
-  EZ_SCOPE_EXIT(pDevice->EndCommands(pCommandEncoder));
+    const ezGALSwapChain* pSwapChain = pDevice->GetSwapChain(m_hSwapChain);
+    hBackbuffer = pSwapChain ? pSwapChain->GetRenderTargets().m_hRTs[0] : ezGALTextureHandle();
+    m_Readback.ReadbackTexture(*pCommandEncoder, hBackbuffer);
+  }
+  // Wait for results
+  {
+    ezEnum<ezGALAsyncResult> res = m_Readback.GetReadbackResult(ezTime::MakeFromHours(1));
+    EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+  }
 
-  pCommandEncoder->BeginRendering(ezGALRenderingSetup());
-  EZ_SCOPE_EXIT(pCommandEncoder->EndRendering());
-
-  const ezGALSwapChain* pSwapChain = pDevice->GetSwapChain(m_hSwapChain);
-  ezGALTextureHandle hBackbuffer = pSwapChain ? pSwapChain->GetRenderTargets().m_hRTs[0] : ezGALTextureHandle();
-
-  pCommandEncoder->ReadbackTexture(hBackbuffer);
-
-  const ezGALTexture* pBackbuffer = ezGALDevice::GetDefaultDevice()->GetTexture(hBackbuffer);
-  const ezUInt32 uiWidth = pBackbuffer->GetDescription().m_uiWidth;
-  const ezUInt32 uiHeight = pBackbuffer->GetDescription().m_uiHeight;
-  const ezEnum<ezGALResourceFormat> format = pBackbuffer->GetDescription().m_Format;
-
-  ezDynamicArray<ezUInt8> backbufferData;
-  backbufferData.SetCountUninitialized(uiWidth * uiHeight * 4);
-
-  ezGALSystemMemoryDescription MemDesc;
-  MemDesc.m_uiRowPitch = 4 * uiWidth;
-  MemDesc.m_uiSlicePitch = 4 * uiWidth * uiHeight;
-
-  /// \todo Make this more efficient
-  MemDesc.m_pData = backbufferData.GetData();
-  ezArrayPtr<ezGALSystemMemoryDescription> SysMemDescsDepth(&MemDesc, 1);
   ezGALTextureSubresource sourceSubResource;
   ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
-  pCommandEncoder->CopyTextureReadbackResult(hBackbuffer, sourceSubResources, SysMemDescsDepth);
-
-  ezImageHeader header;
-  header.SetWidth(uiWidth);
-  header.SetHeight(uiHeight);
-  header.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(format, true));
-  out_image.ResetAndAlloc(header);
-  ezUInt8* pData = out_image.GetPixelPointer<ezUInt8>();
-
-  ezMemoryUtils::Copy(pData, backbufferData.GetData(), backbufferData.GetCount());
-
+  ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
+  ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
+  EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+  const ezGALTexture* pBackbuffer = ezGALDevice::GetDefaultDevice()->GetTexture(hBackbuffer);
+  ezTextureUtils::CreateSubResourceImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], out_image, true);
   return EZ_SUCCESS;
 }

--- a/Code/Engine/GameEngine/GameApplication/Implementation/WindowOutputTargetGAL.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/WindowOutputTargetGAL.cpp
@@ -97,6 +97,6 @@ ezResult ezWindowOutputTargetGAL::CaptureImage(ezImage& out_image)
   ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
   EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
   const ezGALTexture* pBackbuffer = ezGALDevice::GetDefaultDevice()->GetTexture(hBackbuffer);
-  ezTextureUtils::CreateSubResourceImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], out_image, true);
+  ezTextureUtils::CopySubResourceToImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], out_image, true);
   return EZ_SUCCESS;
 }

--- a/Code/Engine/GameEngine/GameApplication/WindowOutputTarget.h
+++ b/Code/Engine/GameEngine/GameApplication/WindowOutputTarget.h
@@ -6,6 +6,7 @@
 #include <Foundation/Math/Size.h>
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Resources/ReadbackHelper.h>
 
 struct ezGALDeviceEvent;
 
@@ -30,4 +31,5 @@ public:
   ezSizeU32 m_Size = ezSizeU32(0, 0);
   ezGALWindowSwapChainCreationDescription m_currentDesc;
   ezGALSwapChainHandle m_hSwapChain;
+  ezGALReadbackTextureHelper m_Readback;
 };

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -487,7 +487,6 @@ ezUniquePtr<ezWindowOutputTargetGAL> ezGameState::CreateMainOutputTarget(ezWindo
   ezGALWindowSwapChainCreationDescription desc;
   desc.m_pWindow = pMainWindow;
   desc.m_BackBufferFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
-  desc.m_bAllowScreenshots = true;
 
   pOutput->CreateSwapchain(desc);
 

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
@@ -118,7 +118,7 @@ void ezBakedProbesComponentManager::OnRenderEvent(const ezRenderWorldRenderEvent
       destBox.m_vMax = ezVec3U32(task->m_uiWidth, task->m_uiHeight, 1);
 
       ezGALSystemMemoryDescription sourceData;
-      sourceData.m_pData = task->m_PixelData.GetData();
+      sourceData.m_pData = task->m_PixelData.GetByteArrayPtr();
       sourceData.m_uiRowPitch = task->m_uiWidth * sizeof(ezColorGammaUB);
 
       pCommandEncoder->UpdateTexture(pComponent->m_hDebugViewTexture, ezGALTextureSubresource(), destBox, sourceData);

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -1967,7 +1967,7 @@ void ezDebugRenderer::OnEngineStartup()
     ezGraphicsUtils::CreateSimpleASCIIFontTexture(debugFontImage);
 
     ezGALSystemMemoryDescription memoryDesc;
-    memoryDesc.m_pData = debugFontImage.GetPixelPointer<ezUInt8>();
+    memoryDesc.m_pData = debugFontImage.GetByteBlobPtr();
     memoryDesc.m_uiRowPitch = static_cast<ezUInt32>(debugFontImage.GetRowPitch());
     memoryDesc.m_uiSlicePitch = static_cast<ezUInt32>(debugFontImage.GetDepthPitch());
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -197,6 +197,7 @@ void ezReflectionPool::UpdateSkyLight(const ezWorld* pWorld, ezReflectionProbeId
 // static
 void ezReflectionPool::SetConstantSkyIrradiance(const ezWorld* pWorld, const ezAmbientCube<ezColor>& skyIrradiance)
 {
+  EZ_LOCK(s_pData->m_Mutex);
   ezUInt32 uiWorldIndex = pWorld->GetIndex();
   ezAmbientCube<ezColorLinear16f> skyIrradiance16f = skyIrradiance;
 
@@ -211,6 +212,7 @@ void ezReflectionPool::SetConstantSkyIrradiance(const ezWorld* pWorld, const ezA
 
 void ezReflectionPool::ResetConstantSkyIrradiance(const ezWorld* pWorld)
 {
+  EZ_LOCK(s_pData->m_Mutex);
   ezUInt32 uiWorldIndex = pWorld->GetIndex();
 
   auto& skyIrradianceStorage = s_pData->m_SkyIrradianceStorage;
@@ -316,8 +318,8 @@ void ezReflectionPool::OnRenderEvent(const ezRenderWorldRenderEvent& e)
       destBox.m_vMin.Set(0, i, 0);
       destBox.m_vMax.Set(6, i + 1, 1);
       ezGALSystemMemoryDescription memDesc;
-      memDesc.m_pData = &skyIrradianceStorage[i].m_Values[0];
       memDesc.m_uiRowPitch = sizeof(ezAmbientCube<ezColorLinear16f>);
+      memDesc.m_pData = ezMakeByteBlobPtr(&skyIrradianceStorage[i].m_Values[0], memDesc.m_uiRowPitch * 1);
       pCommandEncoder->UpdateTexture(s_pData->m_hSkyIrradianceTexture, ezGALTextureSubresource(), destBox, memDesc);
 
       uiSkyIrradianceChanged &= ~EZ_BIT(i);

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
@@ -307,7 +307,6 @@ void ezReflectionPool::Data::CreateReflectionViewsAndResources()
     desc.m_Type = ezGALTextureType::TextureCubeArray;
     desc.m_bCreateRenderTarget = true;
     desc.m_bAllowUAV = true;
-    desc.m_ResourceAccess.m_bReadBack = true;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hFallbackReflectionSpecularTexture = pDevice->CreateTexture(desc);

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeMapping.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeMapping.cpp
@@ -24,7 +24,6 @@ ezReflectionProbeMapping::ezReflectionProbeMapping(ezUInt32 uiAtlasSize)
   desc.m_Type = ezGALTextureType::TextureCubeArray;
   desc.m_bCreateRenderTarget = true;
   desc.m_bAllowUAV = true;
-  desc.m_ResourceAccess.m_bReadBack = true;
   desc.m_ResourceAccess.m_bImmutable = false;
 
   m_hReflectionSpecularTexture = pDevice->CreateTexture(desc);

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
@@ -33,7 +33,6 @@ ezReflectionProbeUpdater::ProbeUpdateInfo::ProbeUpdateInfo()
     desc.m_Type = ezGALTextureType::TextureCube;
     desc.m_bCreateRenderTarget = true;
     desc.m_bAllowDynamicMipGeneration = true;
-    desc.m_ResourceAccess.m_bReadBack = true;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     m_hCubemap = ezGPUResourcePool::GetDefaultInstance()->GetRenderTarget(desc);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -409,7 +409,6 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       bufferDesc.m_uiStructSize = 4;
       bufferDesc.m_uiTotalSize = imageResolution.z * 2 * totalNumberOfSamples;
       bufferDesc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource | ezGALBufferUsageFlags::UnorderedAccess;
-      bufferDesc.m_ResourceAccess.m_bReadBack = false;
       bufferDesc.m_ResourceAccess.m_bImmutable = false;
 
       m_hLineSweepOutputBuffer = device->CreateBuffer(bufferDesc);
@@ -435,7 +434,6 @@ void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)
       bufferDesc.m_uiStructSize = sizeof(LineInstruction);
       bufferDesc.m_uiTotalSize = sizeof(LineInstruction) * m_uiNumSweepLines;
       bufferDesc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
-      bufferDesc.m_ResourceAccess.m_bReadBack = false;
       bufferDesc.m_ResourceAccess.m_bImmutable = true;
 
       m_hLineInfoBuffer = device->CreateBuffer(bufferDesc, ezArrayPtr<const ezUInt8>(reinterpret_cast<const ezUInt8*>(lineInstructions.GetData()), lineInstructions.GetCount() * sizeof(LineInstruction)));

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SimpleRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SimpleRenderPass.cpp
@@ -56,7 +56,6 @@ bool ezSimpleRenderPass::GetRenderTargetDescriptions(
       outputs[m_PinColor.m_uiOutputIndex] = pTexture->GetDescription();
       outputs[m_PinColor.m_uiOutputIndex].m_bCreateRenderTarget = true;
       outputs[m_PinColor.m_uiOutputIndex].m_bAllowShaderResourceView = true;
-      outputs[m_PinColor.m_uiOutputIndex].m_ResourceAccess.m_bReadBack = false;
       outputs[m_PinColor.m_uiOutputIndex].m_ResourceAccess.m_bImmutable = true;
       outputs[m_PinColor.m_uiOutputIndex].m_pExisitingNativeObject = nullptr;
     }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1465,7 +1465,7 @@ void ezRenderPipeline::PreviewOcclusionBuffer(const ezRasterizerView& rasterizer
       destBox.m_vMax = ezVec3U32(uiImgWidth, uiImgHeight, 1);
 
       ezGALSystemMemoryDescription sourceData;
-      sourceData.m_pData = fb.GetData();
+      sourceData.m_pData = fb.GetByteArrayPtr();
       sourceData.m_uiRowPitch = uiImgWidth * sizeof(ezColorLinearUB);
 
       pCommandEncoder->UpdateTexture(m_hOcclusionDebugViewTexture, ezGALTextureSubresource(), destBox, sourceData);
@@ -1484,7 +1484,7 @@ void ezRenderPipeline::PreviewOcclusionBuffer(const ezRasterizerView& rasterizer
     d.m_DescGAL.m_Format = ezGALResourceFormat::RGBAByteNormalized;
 
     ezGALSystemMemoryDescription content[1];
-    content[0].m_pData = fb.GetData();
+    content[0].m_pData = fb.GetByteArrayPtr();
     content[0].m_uiRowPitch = sizeof(ezColorLinearUB) * d.m_DescGAL.m_uiWidth;
     content[0].m_uiSlicePitch = content[0].m_uiRowPitch * d.m_DescGAL.m_uiHeight;
     d.m_InitialContent = content;

--- a/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
@@ -124,7 +124,7 @@ void ezTexture2DResource::FillOutDescriptor(ezTexture2DResourceDescriptor& ref_t
       {
         ezGALSystemMemoryDescription& id = ref_initData.ExpandAndGetRef();
 
-        id.m_pData = const_cast<ezUInt8*>(pImage->GetPixelPointer<ezUInt8>(mip, face, array_index));
+        id.m_pData = pImage->GetSubImageView(mip, face, array_index).GetByteBlobPtr();
 
         if (ezImageFormat::GetType(pImage->GetImageFormat()) == ezImageFormatType::BLOCK_COMPRESSED)
         {

--- a/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
@@ -97,7 +97,7 @@ void ezTexture3DResource::FillOutDescriptor(ezTexture3DResourceDescriptor& ref_t
       {
         ezGALSystemMemoryDescription& id = ref_initData.ExpandAndGetRef();
 
-        id.m_pData = const_cast<ezUInt8*>(pImage->GetPixelPointer<ezUInt8>(mip, face, array_index));
+        id.m_pData = pImage->GetSubImageView(mip, face, array_index).GetByteBlobPtr();
 
         if (ezImageFormat::GetType(pImage->GetImageFormat()) == ezImageFormatType::BLOCK_COMPRESSED)
         {

--- a/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
@@ -148,7 +148,7 @@ ezResourceLoadDesc ezTextureCubeResource::UpdateContent(ezStreamReader* Stream)
       {
         ezGALSystemMemoryDescription& id = InitData.ExpandAndGetRef();
 
-        id.m_pData = pImage->GetPixelPointer<ezUInt8>(mip, face, array_index);
+        id.m_pData = pImage->GetSubImageView(mip, face, array_index).GetByteBlobPtr();
 
         EZ_ASSERT_DEV(pImage->GetDepthPitch(mip) < ezMath::MaxValue<ezUInt32>(), "Depth pitch exceeds ezGAL limits.");
 

--- a/Code/Engine/RendererCore/Textures/TextureUtils.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.cpp
@@ -7,6 +7,18 @@
 
 bool ezTextureUtils::s_bForceFullQualityAlways = false;
 
+namespace
+{
+  ezUInt32 GetMipSize(ezUInt32 uiSize, ezUInt32 uiMipLevel)
+  {
+    for (ezUInt32 i = 0; i < uiMipLevel; i++)
+    {
+      uiSize = uiSize / 2;
+    }
+    return ezMath::Max(1u, uiSize);
+  }
+} // namespace
+
 ezGALResourceFormat::Enum ezTextureUtils::ImageFormatToGalFormat(ezImageFormat::Enum format, bool bSRGB)
 {
   switch (format)
@@ -415,15 +427,6 @@ ezImageView ezTextureUtils::MakeImageViewFromSubResource(const ezGALTextureCreat
     view = ref_Temp.GetSubImageView();
   }
   return view;
-}
-
-ezUInt32 GetMipSize(ezUInt32 uiSize, ezUInt32 uiMipLevel)
-{
-  for (ezUInt32 i = 0; i < uiMipLevel; i++)
-  {
-    uiSize = uiSize / 2;
-  }
-  return ezMath::Max(1u, uiSize);
 }
 
 void ezTextureUtils::CopySubResourceToMemory(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch)

--- a/Code/Engine/RendererCore/Textures/TextureUtils.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.cpp
@@ -357,7 +357,7 @@ void ezTextureUtils::ConfigureSampler(ezTextureFilterSetting::Enum filter, ezGAL
   }
 }
 
-void ezTextureUtils::CreateSubResourceImage(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& out_Image, bool bRemoveSRGB)
+void ezTextureUtils::CopySubResourceToImage(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& out_Image, bool bRemoveSRGB)
 {
   ezImageHeader headerTemp;
   headerTemp.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(desc.m_Format, bRemoveSRGB));
@@ -392,7 +392,7 @@ void ezTextureUtils::CreateSubResourceImage(const ezGALTextureCreationDescriptio
   }
 }
 
-ezImageView ezTextureUtils::CreateSubResourceView(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& ref_Temp, bool bRemoveSRGB)
+ezImageView ezTextureUtils::MakeImageViewFromSubResource(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& ref_Temp, bool bRemoveSRGB)
 {
   ezImageView view;
   ezImageHeader headerTemp;
@@ -411,7 +411,7 @@ ezImageView ezTextureUtils::CreateSubResourceView(const ezGALTextureCreationDesc
   }
   else
   {
-    CreateSubResourceImage(desc, subResource, memory, ref_Temp, bRemoveSRGB);
+    CopySubResourceToImage(desc, subResource, memory, ref_Temp, bRemoveSRGB);
     view = ref_Temp.GetSubImageView();
   }
   return view;
@@ -426,7 +426,7 @@ ezUInt32 GetMipSize(ezUInt32 uiSize, ezUInt32 uiMipLevel)
   return ezMath::Max(1u, uiSize);
 }
 
-void ezTextureUtils::CopySubResource(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch)
+void ezTextureUtils::CopySubResourceToMemory(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch)
 {
   if (sourceMemory.m_uiRowPitch == uiTargetRowPitch)
   {

--- a/Code/Engine/RendererCore/Textures/TextureUtils.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.cpp
@@ -3,6 +3,7 @@
 #include <Foundation/Reflection/ReflectionUtils.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/Textures/TextureUtils.h>
+#include <Foundation/Memory/MemoryUtils.h>
 
 bool ezTextureUtils::s_bForceFullQualityAlways = false;
 
@@ -353,5 +354,102 @@ void ezTextureUtils::ConfigureSampler(ezTextureFilterSetting::Enum filter, ezGAL
       break;
     default:
       break;
+  }
+}
+
+void ezTextureUtils::CreateSubResourceImage(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& out_Image, bool bRemoveSRGB)
+{
+  ezImageHeader headerTemp;
+  headerTemp.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(desc.m_Format, bRemoveSRGB));
+  headerTemp.SetWidth(desc.m_uiWidth);
+  headerTemp.SetHeight(desc.m_uiHeight);
+
+  ezImageHeader header;
+  header.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(desc.m_Format, bRemoveSRGB));
+  header.SetWidth(headerTemp.GetWidth(subResource.m_uiMipLevel));
+  header.SetHeight(headerTemp.GetHeight(subResource.m_uiMipLevel));
+
+  out_Image.ResetAndAlloc(header);
+
+  if (headerTemp.GetRowPitch() == memory.m_uiRowPitch)
+  {
+    const void* pSource = memory.m_pData.GetPtr();
+    ezUInt8* pDest = out_Image.GetPixelPointer<ezUInt8>();
+    ezUInt32 uiSize = header.GetHeight() * ezGALResourceFormat::GetBitsPerElement(desc.m_Format) * header.GetWidth() / 8;
+    EZ_ASSERT_DEBUG(uiSize <= memory.m_pData.GetCount(), "Not enough data in the buffer to create image");
+    memcpy(pDest, pSource, uiSize);
+  }
+  else
+  {
+    // Copy row by row
+    const ezUInt32 uiHeight = header.GetHeight();
+    for (ezUInt32 y = 0; y < uiHeight; ++y)
+    {
+      const void* pSource = ezMemoryUtils::AddByteOffset(memory.m_pData.GetPtr(), y * memory.m_uiRowPitch);
+      ezUInt8* pDest = out_Image.GetPixelPointer<ezUInt8>(0, 0, 0, 0, y);
+      memcpy(pDest, pSource, ezGALResourceFormat::GetBitsPerElement(desc.m_Format) * header.GetWidth() / 8);
+    }
+  }
+}
+
+ezImageView ezTextureUtils::CreateSubResourceView(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& ref_Temp, bool bRemoveSRGB)
+{
+  ezImageView view;
+  ezImageHeader headerTemp;
+  headerTemp.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(desc.m_Format, bRemoveSRGB));
+  headerTemp.SetWidth(desc.m_uiWidth);
+  headerTemp.SetHeight(desc.m_uiHeight);
+
+  ezImageHeader header;
+  header.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(desc.m_Format, bRemoveSRGB));
+  header.SetWidth(headerTemp.GetWidth(subResource.m_uiMipLevel));
+  header.SetHeight(headerTemp.GetHeight(subResource.m_uiMipLevel));
+
+  if (headerTemp.GetRowPitch() == memory.m_uiRowPitch)
+  {
+    view.ResetAndViewExternalStorage(header, ezConstByteBlobPtr(memory.m_pData.GetPtr(), memory.m_pData.GetCount()));
+  }
+  else
+  {
+    CreateSubResourceImage(desc, subResource, memory, ref_Temp, bRemoveSRGB);
+    view = ref_Temp.GetSubImageView();
+  }
+  return view;
+}
+
+ezUInt32 GetMipSize(ezUInt32 uiSize, ezUInt32 uiMipLevel)
+{
+  for (ezUInt32 i = 0; i < uiMipLevel; i++)
+  {
+    uiSize = uiSize / 2;
+  }
+  return ezMath::Max(1u, uiSize);
+}
+
+void ezTextureUtils::CopySubResource(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch)
+{
+  if (sourceMemory.m_uiRowPitch == uiTargetRowPitch)
+  {
+    const ezUInt32 uiMemorySize = ezGALResourceFormat::GetBitsPerElement(desc.m_Format) *
+                                  GetMipSize(desc.m_uiWidth, subResource.m_uiMipLevel) *
+                                  GetMipSize(desc.m_uiHeight, subResource.m_uiMipLevel) / 8;
+    EZ_ASSERT_DEBUG(uiMemorySize <= sourceMemory.m_pData.GetCount(), "");
+    EZ_ASSERT_DEBUG(uiMemorySize <= targetData.GetCount(), "");
+    memcpy(targetData.GetPtr(), sourceMemory.m_pData.GetPtr(), uiMemorySize);
+  }
+  else
+  {
+    // Copy row by row
+    const ezUInt32 uiHeight = GetMipSize(desc.m_uiHeight, subResource.m_uiMipLevel);
+    for (ezUInt32 y = 0; y < uiHeight; ++y)
+    {
+      const ezUInt8* pSource = ezMemoryUtils::AddByteOffset(sourceMemory.m_pData.GetPtr(), y * sourceMemory.m_uiRowPitch);
+      ezUInt8* pDest = ezMemoryUtils::AddByteOffset(targetData.GetPtr(), y * uiTargetRowPitch);
+
+      const ezUInt32 uiCopySize = ezGALResourceFormat::GetBitsPerElement(desc.m_Format) * GetMipSize(desc.m_uiWidth, subResource.m_uiMipLevel) / 8;
+      EZ_ASSERT_DEBUG(pDest + uiCopySize <= targetData.GetEndPtr(), "");
+      EZ_ASSERT_DEBUG(pSource + uiCopySize <= sourceMemory.m_pData.GetEndPtr(), "");
+      memcpy(pDest, pSource, uiCopySize);
+    }
   }
 }

--- a/Code/Engine/RendererCore/Textures/TextureUtils.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.cpp
@@ -1,9 +1,9 @@
 #include <RendererCore/RendererCorePCH.h>
 
+#include <Foundation/Memory/MemoryUtils.h>
 #include <Foundation/Reflection/ReflectionUtils.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/Textures/TextureUtils.h>
-#include <Foundation/Memory/MemoryUtils.h>
 
 bool ezTextureUtils::s_bForceFullQualityAlways = false;
 

--- a/Code/Engine/RendererCore/Textures/TextureUtils.h
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.h
@@ -14,6 +14,13 @@ struct EZ_RENDERERCORE_DLL ezTextureUtils
 
   static void ConfigureSampler(ezTextureFilterSetting::Enum filter, ezGALSamplerStateCreationDescription& out_sampler);
 
+  /// \brief Copies the given texture subresource from `memory` into `out_Image` according to the texture description.
+  static void CreateSubResourceImage(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& out_Image, bool bRemoveSRGB);
+  /// \brief Returns an image view of the texture subresource in `memory`. If the format allows for it, the memory will be aliased, removing the need to copy the data but the view becomes invalid once the memory does. If this is not possible, the function reverts to calling CreateSubResourceImage with `ref_Temp` used as the data storage. You can check if `ref_Temp` is valid to figure out which code path was taken.
+  static ezImageView CreateSubResourceView(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& ref_Temp, bool bRemoveSRGB);
+  /// \brief Copies a texture subresource memory to a new location with a different row pitch.
+  static void CopySubResource(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch);
+
   /// \brief If enabled, textures are always loaded to full quality immediately. Mostly necessary for image comparison unit tests.
   static bool s_bForceFullQualityAlways;
 };

--- a/Code/Engine/RendererCore/Textures/TextureUtils.h
+++ b/Code/Engine/RendererCore/Textures/TextureUtils.h
@@ -15,11 +15,11 @@ struct EZ_RENDERERCORE_DLL ezTextureUtils
   static void ConfigureSampler(ezTextureFilterSetting::Enum filter, ezGALSamplerStateCreationDescription& out_sampler);
 
   /// \brief Copies the given texture subresource from `memory` into `out_Image` according to the texture description.
-  static void CreateSubResourceImage(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& out_Image, bool bRemoveSRGB);
-  /// \brief Returns an image view of the texture subresource in `memory`. If the format allows for it, the memory will be aliased, removing the need to copy the data but the view becomes invalid once the memory does. If this is not possible, the function reverts to calling CreateSubResourceImage with `ref_Temp` used as the data storage. You can check if `ref_Temp` is valid to figure out which code path was taken.
-  static ezImageView CreateSubResourceView(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& ref_Temp, bool bRemoveSRGB);
+  static void CopySubResourceToImage(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& out_Image, bool bRemoveSRGB);
+  /// \brief Returns an image view of the texture subresource in `memory`. If the format allows for it, the memory will be aliased, removing the need to copy the data but the view becomes invalid once the memory does. If this is not possible, the function reverts to calling CopySubResourceToImage with `ref_Temp` used as the data storage. You can check if `ref_Temp` is valid to figure out which code path was taken.
+  static ezImageView MakeImageViewFromSubResource(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, ezGALSystemMemoryDescription& memory, ezImage& ref_Temp, bool bRemoveSRGB);
   /// \brief Copies a texture subresource memory to a new location with a different row pitch.
-  static void CopySubResource(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch);
+  static void CopySubResourceToMemory(const ezGALTextureCreationDescription& desc, const ezGALTextureSubresource& subResource, const ezGALSystemMemoryDescription& sourceMemory, ezArrayPtr<ezUInt8> targetData, ezUInt32 uiTargetRowPitch);
 
   /// \brief If enabled, textures are always loaded to full quality immediately. Mostly necessary for image comparison unit tests.
   static bool s_bForceFullQualityAlways;

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -68,9 +68,8 @@ public:
   virtual void ResolveTexturePlatform(const ezGALTexture* pDestination, const ezGALTextureSubresource& destinationSubResource,
     const ezGALTexture* pSource, const ezGALTextureSubresource& sourceSubResource) override;
 
-  virtual void ReadbackTexturePlatform(const ezGALTexture* pTexture) override;
-
-  virtual void CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData) override;
+  virtual void ReadbackTexturePlatform(const ezGALReadbackTexture* pDestination, const ezGALTexture* pSource) override;
+  virtual void ReadbackBufferPlatform(const ezGALReadbackBuffer* pDestination, const ezGALBuffer* pSource) override;
 
   virtual void GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView) override;
 

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -6,11 +6,11 @@
 #include <RendererDX11/Pools/FencePoolDX11.h>
 #include <RendererDX11/Pools/QueryPoolDX11.h>
 #include <RendererDX11/Resources/BufferDX11.h>
+#include <RendererDX11/Resources/ReadbackBufferDX11.h>
+#include <RendererDX11/Resources/ReadbackTextureDX11.h>
 #include <RendererDX11/Resources/RenderTargetViewDX11.h>
 #include <RendererDX11/Resources/ResourceViewDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
-#include <RendererDX11/Resources/ReadbackTextureDX11.h>
-#include <RendererDX11/Resources/ReadbackBufferDX11.h>
 #include <RendererDX11/Resources/UnorderedAccessViewDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -9,6 +9,8 @@
 #include <RendererDX11/Resources/RenderTargetViewDX11.h>
 #include <RendererDX11/Resources/ResourceViewDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
+#include <RendererDX11/Resources/ReadbackTextureDX11.h>
+#include <RendererDX11/Resources/ReadbackBufferDX11.h>
 #include <RendererDX11/Resources/UnorderedAccessViewDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
@@ -388,14 +390,15 @@ void ezGALCommandEncoderImplDX11::UpdateTexturePlatform(const ezGALTexture* pDes
 
     if (MapResult.RowPitch == uiRowPitch && MapResult.DepthPitch == uiSlicePitch)
     {
-      memcpy(MapResult.pData, sourceData.m_pData, uiSlicePitch * uiDepth);
+      EZ_ASSERT_DEBUG(sourceData.m_pData.GetCount() >= uiSlicePitch * uiDepth, "Not enough data provided to update texture");
+      memcpy(MapResult.pData, sourceData.m_pData.GetPtr(), uiSlicePitch * uiDepth);
     }
     else
     {
       // Copy row by row
       for (ezUInt32 z = 0; z < uiDepth; ++z)
       {
-        const void* pSource = ezMemoryUtils::AddByteOffset(sourceData.m_pData, z * uiSlicePitch);
+        const void* pSource = ezMemoryUtils::AddByteOffset(sourceData.m_pData.GetPtr(), z * uiSlicePitch);
         void* pDest = ezMemoryUtils::AddByteOffset(MapResult.pData, z * MapResult.DepthPitch);
 
         for (ezUInt32 y = 0; y < uiHeight; ++y)
@@ -435,25 +438,23 @@ void ezGALCommandEncoderImplDX11::ResolveTexturePlatform(const ezGALTexture* pDe
   m_pDXContext->ResolveSubresource(pDXDestination, dstSubResource, pDXSource, srcSubResource, DXFormat);
 }
 
-void ezGALCommandEncoderImplDX11::ReadbackTexturePlatform(const ezGALTexture* pTexture)
+void ezGALCommandEncoderImplDX11::ReadbackTexturePlatform(const ezGALReadbackTexture* pDestination, const ezGALTexture* pSource)
 {
-  const ezGALTextureDX11* pDXTexture = static_cast<const ezGALTextureDX11*>(pTexture);
+  const ezGALReadbackTextureDX11* pDXDestination = static_cast<const ezGALReadbackTextureDX11*>(pDestination);
+  const ezGALTextureDX11* pDXTexture = static_cast<const ezGALTextureDX11*>(pSource);
 
   // MSAA textures (e.g. backbuffers) need to be converted to non MSAA versions
   const bool bMSAASourceTexture = pDXTexture->GetDescription().m_SampleCount != ezGALMSAASampleCount::None;
+  EZ_ASSERT_DEV(!bMSAASourceTexture, "MSAA readback is now supported");
+  m_pDXContext->CopyResource(pDXDestination->GetDXTexture(), pDXTexture->GetDXTexture());
+}
 
-  EZ_ASSERT_DEV(pDXTexture->GetDXStagingTexture() != nullptr, "No staging resource available for read-back");
-  EZ_ASSERT_DEV(pDXTexture->GetDXTexture() != nullptr, "Texture object is invalid");
 
-  if (bMSAASourceTexture)
-  {
-    /// \todo Other mip levels etc?
-    m_pDXContext->ResolveSubresource(pDXTexture->GetDXStagingTexture(), 0, pDXTexture->GetDXTexture(), 0, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB);
-  }
-  else
-  {
-    m_pDXContext->CopyResource(pDXTexture->GetDXStagingTexture(), pDXTexture->GetDXTexture());
-  }
+void ezGALCommandEncoderImplDX11::ReadbackBufferPlatform(const ezGALReadbackBuffer* pDestination, const ezGALBuffer* pSource)
+{
+  const ezGALReadbackBufferDX11* pDXDestination = static_cast<const ezGALReadbackBufferDX11*>(pDestination);
+  const ezGALBufferDX11* pDXBuffer = static_cast<const ezGALBufferDX11*>(pSource);
+  m_pDXContext->CopyResource(pDXDestination->GetDXBuffer(), pDXBuffer->GetDXBuffer());
 }
 
 ezUInt32 GetMipSize(ezUInt32 uiSize, ezUInt32 uiMipLevel)
@@ -463,50 +464,6 @@ ezUInt32 GetMipSize(ezUInt32 uiSize, ezUInt32 uiMipLevel)
     uiSize = uiSize / 2;
   }
   return ezMath::Max(1u, uiSize);
-}
-
-void ezGALCommandEncoderImplDX11::CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData)
-{
-  const ezGALTextureDX11* pDXTexture = static_cast<const ezGALTextureDX11*>(pTexture);
-
-  EZ_ASSERT_DEV(pDXTexture->GetDXStagingTexture() != nullptr, "No staging resource available for read-back");
-  EZ_ASSERT_DEV(sourceSubResource.GetCount() == targetData.GetCount(), "Source and target arrays must be of the same size.");
-
-  const ezUInt32 uiSubResources = sourceSubResource.GetCount();
-  for (ezUInt32 i = 0; i < uiSubResources; i++)
-  {
-    const ezGALTextureSubresource& subRes = sourceSubResource[i];
-    const ezGALSystemMemoryDescription& memDesc = targetData[i];
-    const ezUInt32 uiSubResourceIndex = D3D11CalcSubresource(subRes.m_uiMipLevel, subRes.m_uiArraySlice, pTexture->GetDescription().m_uiMipLevelCount);
-
-    D3D11_MAPPED_SUBRESOURCE Mapped;
-    if (SUCCEEDED(m_pDXContext->Map(pDXTexture->GetDXStagingTexture(), uiSubResourceIndex, D3D11_MAP_READ, 0, &Mapped)))
-    {
-      // TODO: Depth pitch
-      if (Mapped.RowPitch == memDesc.m_uiRowPitch)
-      {
-        const ezUInt32 uiMemorySize = ezGALResourceFormat::GetBitsPerElement(pDXTexture->GetDescription().m_Format) *
-                                      GetMipSize(pDXTexture->GetDescription().m_uiWidth, subRes.m_uiMipLevel) *
-                                      GetMipSize(pDXTexture->GetDescription().m_uiHeight, subRes.m_uiMipLevel) / 8;
-        memcpy(memDesc.m_pData, Mapped.pData, uiMemorySize);
-      }
-      else
-      {
-        // Copy row by row
-        const ezUInt32 uiHeight = GetMipSize(pDXTexture->GetDescription().m_uiHeight, subRes.m_uiMipLevel);
-        for (ezUInt32 y = 0; y < uiHeight; ++y)
-        {
-          const void* pSource = ezMemoryUtils::AddByteOffset(Mapped.pData, y * Mapped.RowPitch);
-          void* pDest = ezMemoryUtils::AddByteOffset(memDesc.m_pData, y * memDesc.m_uiRowPitch);
-
-          memcpy(
-            pDest, pSource, ezGALResourceFormat::GetBitsPerElement(pDXTexture->GetDescription().m_Format) * GetMipSize(pDXTexture->GetDescription().m_uiWidth, subRes.m_uiMipLevel) / 8);
-        }
-      }
-
-      m_pDXContext->Unmap(pDXTexture->GetDXStagingTexture(), uiSubResourceIndex);
-    }
-  }
 }
 
 void ezGALCommandEncoderImplDX11::GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView)

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -105,6 +105,12 @@ protected:
   virtual ezGALTexture* CreateSharedTexturePlatform(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle handle) override;
   virtual void DestroySharedTexturePlatform(ezGALTexture* pTexture) override;
 
+  virtual ezGALReadbackBuffer* CreateReadbackBufferPlatform(const ezGALBufferCreationDescription& Description) override;
+  virtual void DestroyReadbackBufferPlatform(ezGALReadbackBuffer* pReadbackBuffer) override;
+
+  virtual ezGALReadbackTexture* CreateReadbackTexturePlatform(const ezGALTextureCreationDescription& Description) override;
+  virtual void DestroyReadbackTexturePlatform(ezGALReadbackTexture* pReadbackTexture) override;
+
   virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) override;
   virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) override;
 
@@ -130,7 +136,10 @@ protected:
   virtual ezEnum<ezGALAsyncResult> GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& out_result) override;
   virtual ezEnum<ezGALAsyncResult> GetOcclusionResultPlatform(ezGALOcclusionHandle hOcclusion, ezUInt64& out_uiResult) override;
   virtual ezEnum<ezGALAsyncResult> GetFenceResultPlatform(ezGALFenceHandle hFence, ezTime timeout) override;
-
+  virtual ezResult LockBufferPlatform(const ezGALReadbackBuffer* pBuffer, ezArrayPtr<const ezUInt8>& out_Memory) const override;
+  virtual void UnlockBufferPlatform(const ezGALReadbackBuffer* pBuffer) const override;
+  virtual ezResult LockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory) const override;
+  virtual void UnlockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources) const override;
   // Swap chain functions
 
   void PresentPlatform(const ezGALSwapChain* pSwapChain, bool bVSync);

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -10,6 +10,8 @@
 #include <RendererDX11/Pools/FencePoolDX11.h>
 #include <RendererDX11/Pools/QueryPoolDX11.h>
 #include <RendererDX11/Resources/BufferDX11.h>
+#include <RendererDX11/Resources/ReadbackBufferDX11.h>
+#include <RendererDX11/Resources/ReadbackTextureDX11.h>
 #include <RendererDX11/Resources/RenderTargetViewDX11.h>
 #include <RendererDX11/Resources/ResourceViewDX11.h>
 #include <RendererDX11/Resources/SharedTextureDX11.h>
@@ -523,6 +525,48 @@ void ezGALDeviceDX11::DestroySharedTexturePlatform(ezGALTexture* pTexture)
   EZ_DELETE(&m_Allocator, pDX11Texture);
 }
 
+ezGALReadbackBuffer* ezGALDeviceDX11::CreateReadbackBufferPlatform(const ezGALBufferCreationDescription& Description)
+{
+  ezGALReadbackBufferDX11* pReadbackBuffer = EZ_NEW(&m_Allocator, ezGALReadbackBufferDX11, Description);
+  
+  if (!pReadbackBuffer->InitPlatform(this).Succeeded())
+  {
+    EZ_DELETE(&m_Allocator, pReadbackBuffer);
+    return nullptr;
+  }
+
+  return pReadbackBuffer;
+}
+
+void ezGALDeviceDX11::DestroyReadbackBufferPlatform(ezGALReadbackBuffer* pReadbackBuffer)
+{
+  ezGALReadbackBufferDX11* pDX11ReadbackBuffer = static_cast<ezGALReadbackBufferDX11*>(pReadbackBuffer);
+
+  pDX11ReadbackBuffer->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pDX11ReadbackBuffer);
+}
+
+ezGALReadbackTexture* ezGALDeviceDX11::CreateReadbackTexturePlatform(const ezGALTextureCreationDescription& Description)
+{
+  ezGALReadbackTextureDX11* pReadbackTexture = EZ_NEW(&m_Allocator, ezGALReadbackTextureDX11, Description);
+  
+  if (!pReadbackTexture->InitPlatform(this).Succeeded())
+  {
+    EZ_DELETE(&m_Allocator, pReadbackTexture);
+    return nullptr;
+  }
+
+  return pReadbackTexture;
+}
+
+void ezGALDeviceDX11::DestroyReadbackTexturePlatform(ezGALReadbackTexture* pReadbackTexture)
+{
+  ezGALReadbackTextureDX11* pDX11ReadbackTexture = static_cast<ezGALReadbackTextureDX11*>(pReadbackTexture);
+  
+  pDX11ReadbackTexture->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pDX11ReadbackTexture);
+}
+
 ezGALTextureResourceView* ezGALDeviceDX11::CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description)
 {
   ezGALTextureResourceViewDX11* pResourceView = EZ_NEW(&m_Allocator, ezGALTextureResourceViewDX11, pResource, Description);
@@ -659,7 +703,89 @@ ezEnum<ezGALAsyncResult> ezGALDeviceDX11::GetOcclusionResultPlatform(ezGALOcclus
 
 ezEnum<ezGALAsyncResult> ezGALDeviceDX11::GetFenceResultPlatform(ezGALFenceHandle hFence, ezTime timeout)
 {
+  if (m_pFenceQueue->GetCurrentFenceHandle() == hFence && timeout.IsPositive())
+  {
+    // Fence has not been submitted yet, force submit of the command buffer or we would deadlock here.
+    Flush();
+  }
+
   return m_pFenceQueue->GetFenceResult(hFence, timeout);
+}
+
+ezResult ezGALDeviceDX11::LockBufferPlatform(const ezGALReadbackBuffer* pBuffer, ezArrayPtr<const ezUInt8>& out_Memory) const
+{
+  const ezGALReadbackBufferDX11* pDXBuffer = static_cast<const ezGALReadbackBufferDX11*>(pBuffer);
+
+  D3D11_MAPPED_SUBRESOURCE Mapped;
+  HRESULT hr = GetDXImmediateContext()->Map(pDXBuffer->GetDXBuffer(), 0, D3D11_MAP_READ, 0, &Mapped);
+  if (FAILED(hr))
+  {
+    return EZ_FAILURE;
+  }
+  out_Memory = ezArrayPtr<const ezUInt8>(reinterpret_cast<const ezUInt8*>(Mapped.pData), pBuffer->GetDescription().m_uiTotalSize);
+  return EZ_SUCCESS;
+}
+
+void ezGALDeviceDX11::UnlockBufferPlatform(const ezGALReadbackBuffer* pBuffer) const
+{
+  const ezGALReadbackBufferDX11* pDXBuffer = static_cast<const ezGALReadbackBufferDX11*>(pBuffer);
+  GetDXImmediateContext()->Unmap(pDXBuffer->GetDXBuffer(), 0);
+}
+
+ezResult ezGALDeviceDX11::LockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory) const
+{
+  out_Memory.Clear();
+  const ezGALReadbackTextureDX11* pDXTexture = static_cast<const ezGALReadbackTextureDX11*>(pTexture);
+
+  const ezUInt32 uiSubResources = subResources.GetCount();
+  for (ezUInt32 i = 0; i < uiSubResources; i++)
+  {
+    const ezGALTextureSubresource& subRes = subResources[i];
+    ezGALSystemMemoryDescription& memDesc = out_Memory.ExpandAndGetRef();
+    const ezUInt32 uiSubResourceIndex = D3D11CalcSubresource(subRes.m_uiMipLevel, subRes.m_uiArraySlice, pTexture->GetDescription().m_uiMipLevelCount);
+
+    D3D11_MAPPED_SUBRESOURCE Mapped;
+    if (FAILED(GetDXImmediateContext()->Map(pDXTexture->GetDXTexture(), uiSubResourceIndex, D3D11_MAP_READ, 0, &Mapped)))
+    {
+      ezLog::Error("Failed to map sub resource with miplevel {} and array slice {}.", subRes.m_uiMipLevel, subRes.m_uiArraySlice);
+    }
+    else
+    {
+      switch (pTexture->GetDescription().m_Type)
+      {
+        case ezGALTextureType::Texture2D:
+        case ezGALTextureType::Texture2DProxy:
+        case ezGALTextureType::Texture2DShared:
+        case ezGALTextureType::TextureCube:
+          memDesc.m_pData = ezMakeByteBlobPtr(Mapped.pData, Mapped.RowPitch * pTexture->GetDescription().m_uiHeight);
+          memDesc.m_uiRowPitch = Mapped.RowPitch;
+          memDesc.m_uiSlicePitch = 0;
+        case ezGALTextureType::Texture3D:
+          memDesc.m_pData = ezMakeByteBlobPtr(Mapped.pData, Mapped.DepthPitch * pTexture->GetDescription().m_uiDepth);
+          memDesc.m_uiRowPitch = Mapped.RowPitch;
+          memDesc.m_uiSlicePitch = Mapped.DepthPitch;
+          break;
+        default:
+          break;
+      }
+
+    }
+  }
+  return EZ_SUCCESS;
+}
+
+void ezGALDeviceDX11::UnlockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources) const
+{
+  const ezGALReadbackTextureDX11* pDXTexture = static_cast<const ezGALReadbackTextureDX11*>(pTexture);
+
+  const ezUInt32 uiSubResources = subResources.GetCount();
+  for (ezUInt32 i = 0; i < uiSubResources; i++)
+  {
+    const ezGALTextureSubresource& subRes = subResources[i];
+    const ezUInt32 uiSubResourceIndex = D3D11CalcSubresource(subRes.m_uiMipLevel, subRes.m_uiArraySlice, pTexture->GetDescription().m_uiMipLevelCount);
+
+    GetDXImmediateContext()->Unmap(pDXTexture->GetDXTexture(), uiSubResourceIndex);
+  }
 }
 
 // Swap chain functions

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -528,7 +528,7 @@ void ezGALDeviceDX11::DestroySharedTexturePlatform(ezGALTexture* pTexture)
 ezGALReadbackBuffer* ezGALDeviceDX11::CreateReadbackBufferPlatform(const ezGALBufferCreationDescription& Description)
 {
   ezGALReadbackBufferDX11* pReadbackBuffer = EZ_NEW(&m_Allocator, ezGALReadbackBufferDX11, Description);
-  
+
   if (!pReadbackBuffer->InitPlatform(this).Succeeded())
   {
     EZ_DELETE(&m_Allocator, pReadbackBuffer);
@@ -549,7 +549,7 @@ void ezGALDeviceDX11::DestroyReadbackBufferPlatform(ezGALReadbackBuffer* pReadba
 ezGALReadbackTexture* ezGALDeviceDX11::CreateReadbackTexturePlatform(const ezGALTextureCreationDescription& Description)
 {
   ezGALReadbackTextureDX11* pReadbackTexture = EZ_NEW(&m_Allocator, ezGALReadbackTextureDX11, Description);
-  
+
   if (!pReadbackTexture->InitPlatform(this).Succeeded())
   {
     EZ_DELETE(&m_Allocator, pReadbackTexture);
@@ -562,7 +562,7 @@ ezGALReadbackTexture* ezGALDeviceDX11::CreateReadbackTexturePlatform(const ezGAL
 void ezGALDeviceDX11::DestroyReadbackTexturePlatform(ezGALReadbackTexture* pReadbackTexture)
 {
   ezGALReadbackTextureDX11* pDX11ReadbackTexture = static_cast<ezGALReadbackTextureDX11*>(pReadbackTexture);
-  
+
   pDX11ReadbackTexture->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pDX11ReadbackTexture);
 }
@@ -768,7 +768,6 @@ ezResult ezGALDeviceDX11::LockTexturePlatform(const ezGALReadbackTexture* pTextu
         default:
           break;
       }
-
     }
   }
   return EZ_SUCCESS;

--- a/Code/Engine/RendererDX11/Device/Implementation/SwapChainDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/SwapChainDX11.cpp
@@ -238,19 +238,14 @@ ezResult ezGALSwapChainDX11::CreateBackBufferInternal(ezGALDeviceDX11* pDXDevice
 
   TexDesc.m_ResourceAccess.m_bImmutable = true;
 
-
-
-  TexDesc.m_ResourceAccess.m_bReadBack = m_WindowDesc.m_bAllowScreenshots && m_bCanMakeDirectScreenshots;
-
   // And create the ez texture object wrapping the backbuffer texture
   m_hBackBufferTexture = pDXDevice->CreateTexture(TexDesc);
   EZ_ASSERT_RELEASE(!m_hBackBufferTexture.IsInvalidated(), "Couldn't create native backbuffer texture object!");
 
   // Create extra texture to be used as "practical backbuffer" if we can't do the screenshots the user wants.
-  if (!m_bCanMakeDirectScreenshots && m_WindowDesc.m_bAllowScreenshots)
+  if (!m_bCanMakeDirectScreenshots)
   {
     TexDesc.m_pExisitingNativeObject = nullptr;
-    TexDesc.m_ResourceAccess.m_bReadBack = true;
 
     m_hActualBackBufferTexture = m_hBackBufferTexture;
     m_hBackBufferTexture = pDXDevice->CreateTexture(TexDesc);

--- a/Code/Engine/RendererDX11/Resources/BufferDX11.h
+++ b/Code/Engine/RendererDX11/Resources/BufferDX11.h
@@ -5,12 +5,15 @@
 #include <dxgi.h>
 
 struct ID3D11Buffer;
+struct D3D11_BUFFER_DESC;
 
 class EZ_RENDERERDX11_DLL ezGALBufferDX11 : public ezGALBuffer
 {
 public:
-  ID3D11Buffer* GetDXBuffer() const;
+  static ezResult CreateBufferDesc(const ezGALBufferCreationDescription& description, D3D11_BUFFER_DESC& out_BufferDesc, DXGI_FORMAT& out_IndexFormat);
 
+public:
+  ID3D11Buffer* GetDXBuffer() const;
   DXGI_FORMAT GetIndexFormat() const;
 
 protected:
@@ -18,16 +21,14 @@ protected:
   friend class ezMemoryUtils;
 
   ezGALBufferDX11(const ezGALBufferCreationDescription& Description);
-
   virtual ~ezGALBufferDX11();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ezUInt8> pInitialData) override;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
-
   virtual void SetDebugNamePlatform(const char* szName) const override;
 
+protected:
   ID3D11Buffer* m_pDXBuffer = nullptr;
-
   DXGI_FORMAT m_IndexFormat = DXGI_FORMAT_UNKNOWN; // Only applicable for index buffers
 };
 

--- a/Code/Engine/RendererDX11/Resources/Implementation/ReadbackBufferDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ReadbackBufferDX11.cpp
@@ -1,0 +1,49 @@
+#include <RendererDX11/RendererDX11PCH.h>
+
+#include <RendererDX11/Device/DeviceDX11.h>
+#include <RendererDX11/Resources/ReadbackBufferDX11.h>
+#include <RendererDX11/Resources/BufferDX11.h>
+
+ezGALReadbackBufferDX11::ezGALReadbackBufferDX11(const ezGALBufferCreationDescription& Description)
+  : ezGALReadbackBuffer(Description)
+{
+}
+
+ezGALReadbackBufferDX11::~ezGALReadbackBufferDX11() = default;
+
+ezResult ezGALReadbackBufferDX11::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
+
+  D3D11_BUFFER_DESC BufferDesc = {};
+  EZ_SUCCEED_OR_RETURN(ezGALBufferDX11::CreateBufferDesc(m_Description, BufferDesc, m_IndexFormat));
+  BufferDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+  BufferDesc.Usage = D3D11_USAGE_STAGING;
+
+  if (SUCCEEDED(pDXDevice->GetDXDevice()->CreateBuffer(&BufferDesc, nullptr, &m_pDXBuffer)))
+  {
+    return EZ_SUCCESS;
+  }
+  else
+  {
+    ezLog::Error("Creation of native DirectX buffer failed!");
+    return EZ_FAILURE;
+  }
+}
+
+ezResult ezGALReadbackBufferDX11::DeInitPlatform(ezGALDevice* pDevice)
+{
+  EZ_IGNORE_UNUSED(pDevice);
+  EZ_GAL_DX11_RELEASE(m_pDXBuffer);
+  return EZ_SUCCESS;
+}
+
+void ezGALReadbackBufferDX11::SetDebugNamePlatform(const char* szName) const
+{
+  ezUInt32 uiLength = ezStringUtils::GetStringElementCount(szName);
+
+  if (m_pDXBuffer != nullptr)
+  {
+    m_pDXBuffer->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
+  }
+}

--- a/Code/Engine/RendererDX11/Resources/Implementation/ReadbackBufferDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ReadbackBufferDX11.cpp
@@ -4,6 +4,8 @@
 #include <RendererDX11/Resources/BufferDX11.h>
 #include <RendererDX11/Resources/ReadbackBufferDX11.h>
 
+#include <d3d11.h>
+
 ezGALReadbackBufferDX11::ezGALReadbackBufferDX11(const ezGALBufferCreationDescription& Description)
   : ezGALReadbackBuffer(Description)
 {

--- a/Code/Engine/RendererDX11/Resources/Implementation/ReadbackBufferDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ReadbackBufferDX11.cpp
@@ -1,8 +1,8 @@
 #include <RendererDX11/RendererDX11PCH.h>
 
 #include <RendererDX11/Device/DeviceDX11.h>
-#include <RendererDX11/Resources/ReadbackBufferDX11.h>
 #include <RendererDX11/Resources/BufferDX11.h>
+#include <RendererDX11/Resources/ReadbackBufferDX11.h>
 
 ezGALReadbackBufferDX11::ezGALReadbackBufferDX11(const ezGALBufferCreationDescription& Description)
   : ezGALReadbackBuffer(Description)

--- a/Code/Engine/RendererDX11/Resources/Implementation/ReadbackTextureDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ReadbackTextureDX11.cpp
@@ -1,0 +1,81 @@
+#include <RendererDX11/RendererDX11PCH.h>
+
+#include <RendererDX11/Device/DeviceDX11.h>
+#include <RendererDX11/Resources/ReadbackTextureDX11.h>
+#include <RendererDX11/Resources/TextureDX11.h>
+
+ezGALReadbackTextureDX11::ezGALReadbackTextureDX11(const ezGALTextureCreationDescription& Description)
+  : ezGALReadbackTexture(Description)
+{
+}
+
+ezGALReadbackTextureDX11::~ezGALReadbackTextureDX11() = default;
+
+ezResult ezGALReadbackTextureDX11::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
+
+  switch (m_Description.m_Type)
+  {
+    case ezGALTextureType::Texture2D:
+    case ezGALTextureType::Texture2DArray:
+    case ezGALTextureType::TextureCube:
+    case ezGALTextureType::TextureCubeArray:
+    {
+      D3D11_TEXTURE2D_DESC Tex2DDesc = {};
+      EZ_SUCCEED_OR_RETURN(ezGALTextureDX11::Create2DDesc(m_Description, pDXDevice, Tex2DDesc));
+      Tex2DDesc.BindFlags = 0;
+      Tex2DDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+      // Need to remove this flag on the staging resource or texture readback no longer works.
+      Tex2DDesc.MiscFlags &= ~D3D11_RESOURCE_MISC_GENERATE_MIPS;
+      Tex2DDesc.Usage = D3D11_USAGE_STAGING;
+
+      if (FAILED(pDXDevice->GetDXDevice()->CreateTexture2D(&Tex2DDesc, nullptr, reinterpret_cast<ID3D11Texture2D**>(&m_pDXTexture))))
+      {
+        return EZ_FAILURE;
+      }
+    }
+    break;
+
+    case ezGALTextureType::Texture3D:
+    {
+      D3D11_TEXTURE3D_DESC Tex3DDesc = {};
+      EZ_SUCCEED_OR_RETURN(ezGALTextureDX11::Create3DDesc(m_Description, pDXDevice, Tex3DDesc));
+      Tex3DDesc.BindFlags = 0;
+      Tex3DDesc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;
+      // Need to remove this flag on the staging resource or texture readback no longer works.
+      Tex3DDesc.MiscFlags &= ~D3D11_RESOURCE_MISC_GENERATE_MIPS;
+      Tex3DDesc.Usage = D3D11_USAGE_STAGING;
+
+      if (FAILED(pDXDevice->GetDXDevice()->CreateTexture3D(&Tex3DDesc, nullptr, reinterpret_cast<ID3D11Texture3D**>(&m_pDXTexture))))
+      {
+        return EZ_FAILURE;
+      }
+    }
+    break;
+
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+      return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALReadbackTextureDX11::DeInitPlatform(ezGALDevice* pDevice)
+{
+  EZ_IGNORE_UNUSED(pDevice);
+
+  EZ_GAL_DX11_RELEASE(m_pDXTexture);
+  return EZ_SUCCESS;
+}
+
+void ezGALReadbackTextureDX11::SetDebugNamePlatform(const char* szName) const
+{
+  ezUInt32 uiLength = ezStringUtils::GetStringElementCount(szName);
+
+  if (m_pDXTexture != nullptr)
+  {
+    m_pDXTexture->SetPrivateData(WKPDID_D3DDebugObjectName, uiLength, szName);
+  }
+}

--- a/Code/Engine/RendererDX11/Resources/Implementation/ReadbackTextureDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/ReadbackTextureDX11.cpp
@@ -4,6 +4,8 @@
 #include <RendererDX11/Resources/ReadbackTextureDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
 
+#include <d3d11.h>
+
 ezGALReadbackTextureDX11::ezGALReadbackTextureDX11(const ezGALTextureCreationDescription& Description)
   : ezGALReadbackTexture(Description)
 {

--- a/Code/Engine/RendererDX11/Resources/Implementation/SharedTextureDX11.cpp
+++ b/Code/Engine/RendererDX11/Resources/Implementation/SharedTextureDX11.cpp
@@ -53,7 +53,7 @@ ezResult ezGALSharedTextureDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<e
     return EZ_SUCCESS;
   }
 
-  D3D11_TEXTURE2D_DESC Tex2DDesc;
+  D3D11_TEXTURE2D_DESC Tex2DDesc = {};
   EZ_SUCCEED_OR_RETURN(Create2DDesc(m_Description, pDXDevice, Tex2DDesc));
 
   if (m_SharedType == ezGALSharedTextureType::Exported)
@@ -91,9 +91,6 @@ ezResult ezGALSharedTextureDX11::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<e
     }
     m_hSharedHandle.m_hSharedTexture = (ezUInt64)hTexture;
   }
-
-  if (!m_Description.m_ResourceAccess.IsImmutable() || m_Description.m_ResourceAccess.m_bReadBack)
-    return CreateStagingTexture(pDXDevice);
 
   return EZ_SUCCESS;
 }

--- a/Code/Engine/RendererDX11/Resources/Implementation/TextureDX11_inl.h
+++ b/Code/Engine/RendererDX11/Resources/Implementation/TextureDX11_inl.h
@@ -4,8 +4,3 @@ ID3D11Resource* ezGALTextureDX11::GetDXTexture() const
 {
   return m_pDXTexture;
 }
-
-ID3D11Resource* ezGALTextureDX11::GetDXStagingTexture() const
-{
-  return m_pDXStagingTexture;
-}

--- a/Code/Engine/RendererDX11/Resources/ReadbackBufferDX11.h
+++ b/Code/Engine/RendererDX11/Resources/ReadbackBufferDX11.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <RendererFoundation/Resources/ReadbackBuffer.h>
+
+struct ID3D11Buffer;
+
+class ezGALReadbackBufferDX11 : public ezGALReadbackBuffer
+{
+public:
+  EZ_ALWAYS_INLINE ID3D11Buffer* GetDXBuffer() const { return m_pDXBuffer; }
+
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  ezGALReadbackBufferDX11(const ezGALBufferCreationDescription& Description);
+  ~ezGALReadbackBufferDX11();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void SetDebugNamePlatform(const char* szName) const override;
+
+protected:
+  ID3D11Buffer* m_pDXBuffer = nullptr;
+  DXGI_FORMAT m_IndexFormat = DXGI_FORMAT_UNKNOWN; // Only applicable for index buffers
+};

--- a/Code/Engine/RendererDX11/Resources/ReadbackTextureDX11.h
+++ b/Code/Engine/RendererDX11/Resources/ReadbackTextureDX11.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <RendererFoundation/Resources/ReadbackTexture.h>
+
+struct ID3D11Resource;
+struct D3D11_TEXTURE2D_DESC;
+struct D3D11_TEXTURE3D_DESC;
+struct D3D11_SUBRESOURCE_DATA;
+class ezGALDeviceDX11;
+
+class ezGALReadbackTextureDX11 : public ezGALReadbackTexture
+{
+public:
+  EZ_ALWAYS_INLINE ID3D11Resource* GetDXTexture() const { return m_pDXTexture;}
+
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  ezGALReadbackTextureDX11(const ezGALTextureCreationDescription& Description);
+  ~ezGALReadbackTextureDX11();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void SetDebugNamePlatform(const char* szName) const override;
+
+protected:
+  ID3D11Resource* m_pDXTexture = nullptr;
+};

--- a/Code/Engine/RendererDX11/Resources/ReadbackTextureDX11.h
+++ b/Code/Engine/RendererDX11/Resources/ReadbackTextureDX11.h
@@ -11,7 +11,7 @@ class ezGALDeviceDX11;
 class ezGALReadbackTextureDX11 : public ezGALReadbackTexture
 {
 public:
-  EZ_ALWAYS_INLINE ID3D11Resource* GetDXTexture() const { return m_pDXTexture;}
+  EZ_ALWAYS_INLINE ID3D11Resource* GetDXTexture() const { return m_pDXTexture; }
 
 protected:
   friend class ezGALDeviceDX11;

--- a/Code/Engine/RendererDX11/Resources/TextureDX11.h
+++ b/Code/Engine/RendererDX11/Resources/TextureDX11.h
@@ -13,9 +13,12 @@ EZ_DEFINE_AS_POD_TYPE(D3D11_SUBRESOURCE_DATA);
 class ezGALTextureDX11 : public ezGALTexture
 {
 public:
-  EZ_ALWAYS_INLINE ID3D11Resource* GetDXTexture() const;
+  static ezResult Create2DDesc(const ezGALTextureCreationDescription& description, ezGALDeviceDX11* pDXDevice, D3D11_TEXTURE2D_DESC& out_Tex2DDesc);
+  static ezResult Create3DDesc(const ezGALTextureCreationDescription& description, ezGALDeviceDX11* pDXDevice, D3D11_TEXTURE3D_DESC& out_Tex3DDesc);
+  static void ConvertInitialData(const ezGALTextureCreationDescription& description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezHybridArray<D3D11_SUBRESOURCE_DATA, 16>& out_InitialData);
 
-  EZ_ALWAYS_INLINE ID3D11Resource* GetDXStagingTexture() const;
+public:
+  EZ_ALWAYS_INLINE ID3D11Resource* GetDXTexture() const;
 
 protected:
   friend class ezGALDeviceDX11;
@@ -30,14 +33,9 @@ protected:
   virtual void SetDebugNamePlatform(const char* szName) const override;
 
   ezResult InitFromNativeObject(ezGALDeviceDX11* pDXDevice);
-  static ezResult Create2DDesc(const ezGALTextureCreationDescription& description, ezGALDeviceDX11* pDXDevice, D3D11_TEXTURE2D_DESC& out_Tex2DDesc);
-  static ezResult Create3DDesc(const ezGALTextureCreationDescription& description, ezGALDeviceDX11* pDXDevice, D3D11_TEXTURE3D_DESC& out_Tex3DDesc);
-  static void ConvertInitialData(const ezGALTextureCreationDescription& description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezHybridArray<D3D11_SUBRESOURCE_DATA, 16>& out_InitialData);
-  ezResult CreateStagingTexture(ezGALDeviceDX11* pDevice);
 
 protected:
   ID3D11Resource* m_pDXTexture = nullptr;
-  ID3D11Resource* m_pDXStagingTexture = nullptr;
 };
 
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -73,8 +73,8 @@ public:
 
   void ResolveTexture(ezGALTextureHandle hDest, const ezGALTextureSubresource& destinationSubResource, ezGALTextureHandle hSource, const ezGALTextureSubresource& sourceSubResource);
 
-  void ReadbackTexture(ezGALTextureHandle hTexture);
-  void CopyTextureReadbackResult(ezGALTextureHandle hTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData);
+  void ReadbackTexture(ezGALReadbackTextureHandle hDestination, ezGALTextureHandle hSource);
+  void ReadbackBuffer(ezGALReadbackBufferHandle hDestination, ezGALBufferHandle hSource);
 
   void GenerateMipMaps(ezGALTextureResourceViewHandle hResourceView);
 
@@ -102,6 +102,7 @@ public:
 
   void BeginRendering(const ezGALRenderingSetup& renderingSetup, const char* szName = "");
   void EndRendering();
+  bool IsInRenderingScope() const;
 
   /// \brief Clears active rendertargets.
   ///

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
@@ -51,9 +51,8 @@ public:
 
   virtual void ResolveTexturePlatform(const ezGALTexture* pDestination, const ezGALTextureSubresource& destinationSubResource, const ezGALTexture* pSource, const ezGALTextureSubresource& sourceSubResource) = 0;
 
-  virtual void ReadbackTexturePlatform(const ezGALTexture* pTexture) = 0;
-
-  virtual void CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData) = 0;
+  virtual void ReadbackTexturePlatform(const ezGALReadbackTexture* pDestination, const ezGALTexture* pSource) = 0;
+  virtual void ReadbackBufferPlatform(const ezGALReadbackBuffer* pDestination, const ezGALBuffer* pSource) = 0;
 
   virtual void GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView) = 0;
 

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -4,6 +4,8 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Buffer.h>
+#include <RendererFoundation/Resources/ReadbackBuffer.h>
+#include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Resources/Texture.h>
@@ -310,33 +312,46 @@ void ezGALCommandEncoder::ResolveTexture(ezGALTextureHandle hDest, const ezGALTe
   }
 }
 
-void ezGALCommandEncoder::ReadbackTexture(ezGALTextureHandle hTexture)
+void ezGALCommandEncoder::ReadbackTexture(ezGALReadbackTextureHandle hDestination, ezGALTextureHandle hSource)
 {
   AssertRenderingThread();
 
-  const ezGALTexture* pTexture = m_Device.GetTexture(hTexture);
+  const ezGALReadbackTexture* pDestination = m_Device.GetReadbackTexture(hDestination);
+  const ezGALTexture* pSource = m_Device.GetTexture(hSource);
 
-  if (pTexture != nullptr)
+  EZ_ASSERT_DEBUG(pDestination != nullptr && pSource != nullptr, "Invalid handle provided");
+
+  const ezGALTextureCreationDescription& sourceDesc = pSource->GetDescription();
+  const ezGALTextureCreationDescription& destinationDesc = pDestination->GetDescription();
+
+  bool bMissmatch = sourceDesc.m_uiWidth != destinationDesc.m_uiWidth || sourceDesc.m_uiHeight != destinationDesc.m_uiHeight || sourceDesc.m_uiDepth != destinationDesc.m_uiDepth || sourceDesc.m_uiMipLevelCount != destinationDesc.m_uiMipLevelCount || sourceDesc.m_uiArraySize != destinationDesc.m_uiArraySize || sourceDesc.m_Format != destinationDesc.m_Format || sourceDesc.m_Type != destinationDesc.m_Type || sourceDesc.m_Format != destinationDesc.m_Format || sourceDesc.m_SampleCount != destinationDesc.m_SampleCount;
+  EZ_IGNORE_UNUSED(bMissmatch);
+  EZ_ASSERT_DEBUG(!bMissmatch, "Source and destination formats do not match");
+
+  if (pDestination != nullptr && pSource != nullptr)
   {
-    EZ_ASSERT_RELEASE(pTexture->GetDescription().m_ResourceAccess.m_bReadBack,
-      "A texture supplied to read-back needs to be created with the correct resource usage (m_bReadBack = true)!");
-
-    m_CommonImpl.ReadbackTexturePlatform(pTexture);
+    m_CommonImpl.ReadbackTexturePlatform(pDestination, pSource);
   }
 }
 
-void ezGALCommandEncoder::CopyTextureReadbackResult(ezGALTextureHandle hTexture, ezArrayPtr<ezGALTextureSubresource> sourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> targetData)
+
+void ezGALCommandEncoder::ReadbackBuffer(ezGALReadbackBufferHandle hDestination, ezGALBufferHandle hSource)
 {
   AssertRenderingThread();
 
-  const ezGALTexture* pTexture = m_Device.GetTexture(hTexture);
+  const ezGALReadbackBuffer* pDestination = m_Device.GetReadbackBuffer(hDestination);
+  const ezGALBuffer* pSource = m_Device.GetBuffer(hSource);
 
-  if (pTexture != nullptr)
+  EZ_ASSERT_DEBUG(pDestination != nullptr && pSource != nullptr, "Invalid handle provided");
+
+  const ezGALBufferCreationDescription& sourceDesc = pSource->GetDescription();
+  const ezGALBufferCreationDescription& destinationDesc = pDestination->GetDescription();
+
+  EZ_ASSERT_DEBUG(sourceDesc.m_uiTotalSize == destinationDesc.m_uiTotalSize, "Source and destination size do not match");
+
+  if (pDestination != nullptr && pSource != nullptr)
   {
-    EZ_ASSERT_RELEASE(pTexture->GetDescription().m_ResourceAccess.m_bReadBack,
-      "A texture supplied to read-back needs to be created with the correct resource usage (m_bReadBack = true)!");
-
-    m_CommonImpl.CopyTextureReadbackResultPlatform(pTexture, sourceSubResource, targetData);
+    m_CommonImpl.ReadbackBufferPlatform(pDestination, pSource);
   }
 }
 
@@ -694,4 +709,9 @@ void ezGALCommandEncoder::EndRendering()
   EZ_ASSERT_DEBUG(m_hPendingOcclusionQuery.IsInvalidated(), "An occlusion query was started and not stopped within this render scope.");
 
   m_CommonImpl.EndRenderingPlatform();
+}
+
+bool ezGALCommandEncoder::IsInRenderingScope() const
+{
+  return m_CurrentCommandEncoderType == CommandEncoderType::Render;
 }

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -343,11 +343,7 @@ void ezGALCommandEncoder::ReadbackBuffer(ezGALReadbackBufferHandle hDestination,
   const ezGALBuffer* pSource = m_Device.GetBuffer(hSource);
 
   EZ_ASSERT_DEBUG(pDestination != nullptr && pSource != nullptr, "Invalid handle provided");
-
-  const ezGALBufferCreationDescription& sourceDesc = pSource->GetDescription();
-  const ezGALBufferCreationDescription& destinationDesc = pDestination->GetDescription();
-
-  EZ_ASSERT_DEBUG(sourceDesc.m_uiTotalSize == destinationDesc.m_uiTotalSize, "Source and destination size do not match");
+  EZ_ASSERT_DEBUG(pSource->GetDescription().m_uiTotalSize == pDestination->GetDescription().m_uiTotalSize, "Source and destination size do not match");
 
   if (pDestination != nullptr && pSource != nullptr)
   {

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -27,7 +27,6 @@ struct ezGALWindowSwapChainCreationDescription : public ezHashableStruct<ezGALWi
   ezEnum<ezGALPresentMode> m_InitialPresentMode = ezGALPresentMode::VSync;
 
   bool m_bDoubleBuffered = true;
-  bool m_bAllowScreenshots = false;
 };
 
 struct ezGALSwapChainCreationDescription : public ezHashableStruct<ezGALSwapChainCreationDescription>
@@ -153,23 +152,20 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALVertexDeclarationCreationDescription : pub
   ezStaticArray<ezGALVertexAttribute, 16> m_VertexAttributes;
 };
 
-// Need to add: immutable (GPU only), default(GPU only, but allows CopyToTempStorage updates), transient (allows ezGALUpdateMode::Discard), staging: read(back), staging: write (constantly mapped), unified memory (mobile, onboard GPU, allows all ops)
-// Or use VmaMemoryUsage  + read write flags?
 struct ezGALResourceAccess
 {
   EZ_ALWAYS_INLINE bool IsImmutable() const { return m_bImmutable; }
 
-  bool m_bReadBack = false;
   bool m_bImmutable = true;
 };
 
 struct ezGALBufferCreationDescription : public ezHashableStruct<ezGALBufferCreationDescription>
 {
-  ezUInt32 m_uiTotalSize = 0;
-  ezUInt32 m_uiStructSize = 0;                                         // Struct or texel size
+  ezUInt32 m_uiTotalSize = 0; // Total size in bytes
+  ezUInt32 m_uiStructSize = 0;                                         // Struct or texel size in bytes
   ezBitflags<ezGALBufferUsageFlags> m_BufferFlags;
   ezGALResourceAccess m_ResourceAccess;
-  ezEnum<ezGALResourceFormat> m_Format = ezGALResourceFormat::Invalid; // Only relevant for TexelBuffer
+  ezEnum<ezGALResourceFormat> m_Format = ezGALResourceFormat::Invalid; // Only relevant for TexelBuffer to create default views
 };
 
 struct ezGALTextureCreationDescription : public ezHashableStruct<ezGALTextureCreationDescription>

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -161,7 +161,7 @@ struct ezGALResourceAccess
 
 struct ezGALBufferCreationDescription : public ezHashableStruct<ezGALBufferCreationDescription>
 {
-  ezUInt32 m_uiTotalSize = 0; // Total size in bytes
+  ezUInt32 m_uiTotalSize = 0;                                          // Total size in bytes
   ezUInt32 m_uiStructSize = 0;                                         // Struct or texel size in bytes
   ezBitflags<ezGALBufferUsageFlags> m_BufferFlags;
   ezGALResourceAccess m_ResourceAccess;

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors_inl.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors_inl.h
@@ -32,8 +32,7 @@ inline void ezGALTextureCreationDescription::SetAsRenderTarget(ezUInt32 uiWidth,
   m_bAllowUAV = false;
   m_bCreateRenderTarget = true;
   m_bAllowDynamicMipGeneration = false;
-  m_ResourceAccess.m_bReadBack = false;
-  m_ResourceAccess.m_bImmutable = true;
+  m_ResourceAccess.m_bImmutable = false;
   m_pExisitingNativeObject = nullptr;
 }
 

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -8,6 +8,7 @@
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Device/DeviceCapabilities.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Device/ReadbackLock.h>
 
 class ezColor;
 
@@ -72,6 +73,12 @@ public:
   ezGALTextureHandle OpenSharedTexture(const ezGALTextureCreationDescription& description, ezGALPlatformSharedHandle hSharedHandle);
   void DestroySharedTexture(ezGALTextureHandle hTexture);
 
+  ezGALReadbackBufferHandle CreateReadbackBuffer(const ezGALBufferCreationDescription& description);
+  void DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer);
+  
+  ezGALReadbackTextureHandle CreateReadbackTexture(const ezGALTextureCreationDescription& description);
+  void DestroyReadbackTexture(ezGALReadbackTextureHandle hTexture);
+    
   // Resource views
   ezGALTextureResourceViewHandle GetDefaultResourceView(ezGALTextureHandle hTexture);
   ezGALBufferResourceViewHandle GetDefaultResourceView(ezGALBufferHandle hBuffer);
@@ -115,7 +122,7 @@ public:
   /// \sa ezCommandEncoder::InsertTimestamp
   ezEnum<ezGALAsyncResult> GetTimestampResult(ezGALTimestampHandle hTimestamp, ezTime& out_result);
 
-  /// \briefQueries the result of an occlusion query.
+  /// \brief Queries the result of an occlusion query.
   /// Should be called every frame until ezGALAsyncResult::Ready is returned.
   /// \param hOcclusion The occlusion query handle to query.
   /// \param out_uiResult If ezGALAsyncResult::Ready is returned, this will be the number of pixels of the occlusion query.
@@ -123,7 +130,7 @@ public:
   /// \sa ezCommandEncoder::BeginOcclusionQuery, ezCommandEncoder::EndOcclusionQuery
   ezEnum<ezGALAsyncResult> GetOcclusionQueryResult(ezGALOcclusionHandle hOcclusion, ezUInt64& out_uiResult);
 
-  /// \briefQueries the result of a fence.
+  /// \brief Queries the result of a fence.
   /// Fences can never expire as they are just monotonically increasing numbers over time.
   /// \param hFence The fence handle to query.
   /// \param timeout If set to > 0, the function will block until the fence is ready or the timeout is reached.
@@ -131,7 +138,19 @@ public:
   /// \sa ezCommandEncoder::InsertFence
   ezEnum<ezGALAsyncResult> GetFenceResult(ezGALFenceHandle hFence, ezTime timeout = ezTime::MakeZero());
 
-  /// \todo Map functions to save on memcpys
+  /// \brief Tries to lock a readback buffer for reading. Only fails if the handle is invalid.
+  /// \param hReadbackBuffer The buffer to lock.
+  /// \param out_Memory If successful, contains the memory of the buffer. Only allowed to be accessed within the lifetime of the returns lock object.
+  /// \return Returns the lock. ezReadbackBufferLock::IsValid needs to be called to ensure the locking was successful.
+  ezReadbackBufferLock LockBuffer(ezGALReadbackBufferHandle hReadbackBuffer, ezArrayPtr<const ezUInt8>& out_Memory);
+
+  /// \brief Tries to lock a readback texture for reading. Only fails if the handle is invalid.
+  /// \param hReadbackTexture The texture to lock.
+  /// \param subResources The sub-resources that should to be locked.
+  /// \param out_Memory If successful, contains the memory locations of each sub-resource. Only allowed to be accessed within the lifetime of the returns lock object.
+  /// \return Returns the lock. ezReadbackTextureLock::IsValid needs to be called to ensure the locking was successful.
+  ezReadbackTextureLock LockTexture(ezGALReadbackTextureHandle hReadbackTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory);
+
 
   // Swap chain functions
 
@@ -175,6 +194,8 @@ public:
   const ezGALTexture* GetTexture(ezGALTextureHandle hTexture) const;
   virtual const ezGALSharedTexture* GetSharedTexture(ezGALTextureHandle hTexture) const = 0;
   const ezGALBuffer* GetBuffer(ezGALBufferHandle hBuffer) const;
+  const ezGALReadbackBuffer* GetReadbackBuffer(ezGALReadbackBufferHandle hBuffer) const;
+  const ezGALReadbackTexture* GetReadbackTexture(ezGALReadbackTextureHandle hTexture) const;
   const ezGALDepthStencilState* GetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState) const;
   const ezGALBlendState* GetBlendState(ezGALBlendStateHandle hBlendState) const;
   const ezGALRasterizerState* GetRasterizerState(ezGALRasterizerStateHandle hRasterizerState) const;
@@ -247,6 +268,8 @@ protected:
   using RasterizerStateTable = ezIdTable<ezGALRasterizerStateHandle::IdType, ezGALRasterizerState*, ezLocalAllocatorWrapper>;
   using BufferTable = ezIdTable<ezGALBufferHandle::IdType, ezGALBuffer*, ezLocalAllocatorWrapper>;
   using TextureTable = ezIdTable<ezGALTextureHandle::IdType, ezGALTexture*, ezLocalAllocatorWrapper>;
+  using ReadbackBufferTable = ezIdTable<ezGALReadbackBufferHandle::IdType, ezGALReadbackBuffer*, ezLocalAllocatorWrapper>;
+  using ReadbackTextureTable = ezIdTable<ezGALReadbackTextureHandle::IdType, ezGALReadbackTexture*, ezLocalAllocatorWrapper>;
   using TextureResourceViewTable = ezIdTable<ezGALTextureResourceViewHandle::IdType, ezGALTextureResourceView*, ezLocalAllocatorWrapper>;
   using BufferResourceViewTable = ezIdTable<ezGALBufferResourceViewHandle::IdType, ezGALBufferResourceView*, ezLocalAllocatorWrapper>;
   using SamplerStateTable = ezIdTable<ezGALSamplerStateHandle::IdType, ezGALSamplerState*, ezLocalAllocatorWrapper>;
@@ -262,6 +285,8 @@ protected:
   RasterizerStateTable m_RasterizerStates;
   BufferTable m_Buffers;
   TextureTable m_Textures;
+  ReadbackBufferTable m_ReadbackBuffers;
+  ReadbackTextureTable m_ReadbackTextures;
   TextureResourceViewTable m_TextureResourceViews;
   BufferResourceViewTable m_BufferResourceViews;
   SamplerStateTable m_SamplerStates;
@@ -299,6 +324,8 @@ protected:
   // These functions need to be implemented by a render API abstraction
 protected:
   friend class ezMemoryUtils;
+  friend class ezReadbackBufferLock;
+  friend class ezReadbackTextureLock;
 
   // Init & shutdown functions
 
@@ -343,6 +370,12 @@ protected:
   virtual ezGALTexture* CreateSharedTexturePlatform(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle handle) = 0;
   virtual void DestroySharedTexturePlatform(ezGALTexture* pTexture) = 0;
 
+  virtual ezGALReadbackBuffer* CreateReadbackBufferPlatform(const ezGALBufferCreationDescription& Description) = 0;
+  virtual void DestroyReadbackBufferPlatform(ezGALReadbackBuffer* pReadbackBuffer) = 0;
+  
+  virtual ezGALReadbackTexture* CreateReadbackTexturePlatform(const ezGALTextureCreationDescription& Description) = 0;
+  virtual void DestroyReadbackTexturePlatform(ezGALReadbackTexture* pReadbackTexture) = 0;
+  
   virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) = 0;
   virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) = 0;
 
@@ -368,6 +401,10 @@ protected:
   virtual ezEnum<ezGALAsyncResult> GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& out_result) = 0;
   virtual ezEnum<ezGALAsyncResult> GetOcclusionResultPlatform(ezGALOcclusionHandle hOcclusion, ezUInt64& out_uiResult) = 0;
   virtual ezEnum<ezGALAsyncResult> GetFenceResultPlatform(ezGALFenceHandle hFence, ezTime timeout) = 0;
+  virtual ezResult LockBufferPlatform(const ezGALReadbackBuffer* pBuffer, ezArrayPtr<const ezUInt8>& out_Memory) const = 0;
+  virtual void UnlockBufferPlatform(const ezGALReadbackBuffer* pBuffer) const = 0;
+  virtual ezResult LockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory) const = 0;
+  virtual void UnlockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources) const = 0;
 
   // Misc functions
 
@@ -389,7 +426,7 @@ private:
   bool m_bBeginFrameCalled = false;
   ezHybridArray<ezGALSwapChain*, 8> m_FrameSwapChains;
   bool m_bBeginPipelineCalled = false;
-  bool m_bBeginCommandsCalled = false;
+  ezGALCommandEncoder* m_pCommandEncoder = nullptr;
 };
 
 #include <RendererFoundation/Device/Implementation/Device_inl.h>

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -7,8 +7,8 @@
 #include <Foundation/Strings/HashedString.h>
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Device/DeviceCapabilities.h>
-#include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Device/ReadbackLock.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
 
 class ezColor;
 
@@ -75,10 +75,10 @@ public:
 
   ezGALReadbackBufferHandle CreateReadbackBuffer(const ezGALBufferCreationDescription& description);
   void DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer);
-  
+
   ezGALReadbackTextureHandle CreateReadbackTexture(const ezGALTextureCreationDescription& description);
   void DestroyReadbackTexture(ezGALReadbackTextureHandle hTexture);
-    
+
   // Resource views
   ezGALTextureResourceViewHandle GetDefaultResourceView(ezGALTextureHandle hTexture);
   ezGALBufferResourceViewHandle GetDefaultResourceView(ezGALBufferHandle hBuffer);
@@ -372,10 +372,10 @@ protected:
 
   virtual ezGALReadbackBuffer* CreateReadbackBufferPlatform(const ezGALBufferCreationDescription& Description) = 0;
   virtual void DestroyReadbackBufferPlatform(ezGALReadbackBuffer* pReadbackBuffer) = 0;
-  
+
   virtual ezGALReadbackTexture* CreateReadbackTexturePlatform(const ezGALTextureCreationDescription& Description) = 0;
   virtual void DestroyReadbackTexturePlatform(ezGALReadbackTexture* pReadbackTexture) = 0;
-  
+
   virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) = 0;
   virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) = 0;
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -5,13 +5,16 @@
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Device/SharedTextureSwapChain.h>
 #include <RendererFoundation/Device/SwapChain.h>
+#include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Resources/Buffer.h>
 #include <RendererFoundation/Resources/ProxyTexture.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
+#include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Shader/VertexDeclaration.h>
 #include <RendererFoundation/State/State.h>
+#include <Foundation/Time/Stopwatch.h>
 
 namespace
 {
@@ -26,6 +29,8 @@ namespace
       Shader,
       Buffer,
       Texture,
+      ReadbackTexture,
+      ReadbackBuffer,
       TextureResourceView,
       BufferResourceView,
       RenderTargetView,
@@ -189,24 +194,21 @@ ezGALCommandEncoder* ezGALDevice::BeginCommands(const char* szName)
     e.m_Type = ezGALDeviceEvent::BeforeBeginCommands;
     s_Events.Broadcast(e, 1);
   }
-  ezGALCommandEncoder* pCommandEncoder = nullptr;
   {
     EZ_GALDEVICE_LOCK_AND_CHECK();
 
-    EZ_ASSERT_DEV(!m_bBeginCommandsCalled, "Nested Passes are not allowed: You must call ezGALDevice::EndCommands before you can call ezGALDevice::BeginCommands again");
-    m_bBeginCommandsCalled = true;
-
-    pCommandEncoder = BeginCommandsPlatform(szName);
+    EZ_ASSERT_DEV(m_pCommandEncoder == nullptr, "Nested Passes are not allowed: You must call ezGALDevice::EndCommands before you can call ezGALDevice::BeginCommands again");
+    m_pCommandEncoder = BeginCommandsPlatform(szName);
   }
   {
     EZ_PROFILE_SCOPE("AfterBeginCommands");
     ezGALDeviceEvent e;
     e.m_pDevice = this;
     e.m_Type = ezGALDeviceEvent::AfterBeginCommands;
-    e.m_pCommandEncoder = pCommandEncoder;
+    e.m_pCommandEncoder = m_pCommandEncoder;
     s_Events.Broadcast(e, 1);
   }
-  return pCommandEncoder;
+  return m_pCommandEncoder;
 }
 
 void ezGALDevice::EndCommands(ezGALCommandEncoder* pCommandEncoder)
@@ -221,8 +223,8 @@ void ezGALDevice::EndCommands(ezGALCommandEncoder* pCommandEncoder)
   }
   {
     EZ_GALDEVICE_LOCK_AND_CHECK();
-    EZ_ASSERT_DEV(m_bBeginCommandsCalled, "You must have called ezGALDevice::BeginCommands before you can call ezGALDevice::EndCommands");
-    m_bBeginCommandsCalled = false;
+    EZ_ASSERT_DEV(m_pCommandEncoder != nullptr, "You must have called ezGALDevice::BeginCommands before you can call ezGALDevice::EndCommands");
+    m_pCommandEncoder = nullptr;
     EndCommandsPlatform(pCommandEncoder);
   }
   {
@@ -857,6 +859,60 @@ void ezGALDevice::DestroySharedTexture(ezGALTextureHandle hSharedTexture)
   }
 }
 
+ezGALReadbackTextureHandle ezGALDevice::CreateReadbackTexture(const ezGALTextureCreationDescription& description)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  if (description.m_uiWidth == 0 || description.m_uiHeight == 0)
+  {
+    ezLog::Error("Trying to create a texture with width or height == 0 is not possible!");
+    return ezGALReadbackTextureHandle();
+  }
+
+  ezGALReadbackTexture* pReadbackTexture = CreateReadbackTexturePlatform(description);
+  ezGALReadbackTextureHandle hTexture(m_ReadbackTextures.Insert(pReadbackTexture));
+  return hTexture;
+}
+
+void ezGALDevice::DestroyReadbackTexture(ezGALReadbackTextureHandle hTexture)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  ezGALReadbackTexture* pTexture = nullptr;
+  if (m_ReadbackTextures.TryGetValue(hTexture, pTexture))
+  {
+    AddDeadObject(GALObjectType::ReadbackTexture, hTexture);
+  }
+  else
+  {
+    ezLog::Warning("DestroyReadbackTexture called on invalid handle (double free?)");
+  }
+}
+
+ezGALReadbackBufferHandle ezGALDevice::CreateReadbackBuffer(const ezGALBufferCreationDescription& description)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  ezGALReadbackBuffer* pReadbackBuffer = CreateReadbackBufferPlatform(description);
+  ezGALReadbackBufferHandle hBuffer(m_ReadbackBuffers.Insert(pReadbackBuffer));
+  return hBuffer;
+}
+
+void ezGALDevice::DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+  
+  ezGALReadbackBuffer* pBuffer = nullptr;
+  if (m_ReadbackBuffers.TryGetValue(hBuffer, pBuffer))
+  {
+    AddDeadObject(GALObjectType::ReadbackBuffer, hBuffer);
+  }
+  else
+  {
+    ezLog::Warning("DestroyReadbackBuffer called on invalid handle (double free?)");
+  }
+}
+
 ezGALTextureResourceViewHandle ezGALDevice::GetDefaultResourceView(ezGALTextureHandle hTexture)
 {
   if (const ezGALTexture* pTexture = GetTexture(hTexture))
@@ -1309,6 +1365,40 @@ void ezGALDevice::DestroyVertexDeclaration(ezGALVertexDeclarationHandle hVertexD
   }
 }
 
+ezEnum<ezGALAsyncResult> ezGALDevice::GetFenceResult(ezGALFenceHandle hFence, ezTime timeout)
+{
+  if (hFence == 0)
+    return ezGALAsyncResult::Expired;
+
+  EZ_ASSERT_DEBUG(timeout.IsZero() || m_pCommandEncoder == nullptr || !m_pCommandEncoder->IsInRenderingScope(), "Waiting for a fence is only allowed outside of a rendering scope");
+
+  ezEnum<ezGALAsyncResult> res = GetFenceResultPlatform(hFence, timeout);
+
+  return res;
+}
+
+ezReadbackBufferLock ezGALDevice::LockBuffer(ezGALReadbackBufferHandle hReadbackBuffer, ezArrayPtr<const ezUInt8>& out_Memory)
+{
+  if (hReadbackBuffer.IsInvalidated())
+    return {};
+  const ezGALReadbackBuffer* pReadbackBuffer = GetReadbackBuffer(hReadbackBuffer);
+  if (pReadbackBuffer == nullptr)
+    return {};
+
+  return ezReadbackBufferLock(this, pReadbackBuffer, out_Memory);
+}
+
+ezReadbackTextureLock ezGALDevice::LockTexture(ezGALReadbackTextureHandle hReadbackTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory)
+{
+  if (hReadbackTexture.IsInvalidated())
+    return {};
+  const ezGALReadbackTexture* pReadbackTexture = GetReadbackTexture(hReadbackTexture);
+  if (pReadbackTexture == nullptr)
+    return {};
+
+  return ezReadbackTextureLock(this, pReadbackTexture, subResources, out_Memory);
+}
+
 ezGALTextureHandle ezGALDevice::GetBackBufferTextureFromSwapChain(ezGALSwapChainHandle hSwapChain)
 {
   ezGALSwapChain* pSwapChain = nullptr;
@@ -1605,6 +1695,22 @@ void ezGALDevice::DestroyDeadObjects()
             DestroyTexturePlatform(pTexture);
             break;
         }
+        break;
+      }
+      case GALObjectType::ReadbackBuffer:
+      {
+        ezGALReadbackBufferHandle hBuffer(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALReadbackBuffer* pBuffer = nullptr;
+        EZ_VERIFY(m_ReadbackBuffers.Remove(hBuffer, &pBuffer), "");
+        DestroyReadbackBufferPlatform(pBuffer);
+        break;
+      }
+      case GALObjectType::ReadbackTexture:
+      {
+        ezGALReadbackTextureHandle hTexture(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALReadbackTexture* pTexture = nullptr;
+        EZ_VERIFY(m_ReadbackTextures.Remove(hTexture, &pTexture), "");
+        DestroyReadbackTexturePlatform(pTexture);
         break;
       }
       case GALObjectType::TextureResourceView:

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -2,19 +2,19 @@
 
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Profiling/Profiling.h>
+#include <Foundation/Time/Stopwatch.h>
+#include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Device/SharedTextureSwapChain.h>
 #include <RendererFoundation/Device/SwapChain.h>
-#include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Resources/Buffer.h>
 #include <RendererFoundation/Resources/ProxyTexture.h>
+#include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
-#include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Shader/VertexDeclaration.h>
 #include <RendererFoundation/State/State.h>
-#include <Foundation/Time/Stopwatch.h>
 
 namespace
 {
@@ -901,7 +901,7 @@ ezGALReadbackBufferHandle ezGALDevice::CreateReadbackBuffer(const ezGALBufferCre
 void ezGALDevice::DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   ezGALReadbackBuffer* pBuffer = nullptr;
   if (m_ReadbackBuffers.TryGetValue(hBuffer, pBuffer))
   {

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -35,14 +35,6 @@ EZ_ALWAYS_INLINE ezEnum<ezGALAsyncResult> ezGALDevice::GetOcclusionQueryResult(e
   return GetOcclusionResultPlatform(hOcclusion, out_uiResult);
 }
 
-EZ_ALWAYS_INLINE ezEnum<ezGALAsyncResult> ezGALDevice::GetFenceResult(ezGALFenceHandle hFence, ezTime timeout)
-{
-  if (hFence == 0)
-    return ezGALAsyncResult::Ready;
-
-  return GetFenceResultPlatform(hFence, timeout);
-}
-
 template <typename IdTableType, typename ReturnType>
 EZ_ALWAYS_INLINE ReturnType* ezGALDevice::Get(typename IdTableType::TypeOfId hHandle, const IdTableType& IdTable) const
 {
@@ -71,6 +63,16 @@ inline const ezGALTexture* ezGALDevice::GetTexture(ezGALTextureHandle hTexture) 
 inline const ezGALBuffer* ezGALDevice::GetBuffer(ezGALBufferHandle hBuffer) const
 {
   return Get<BufferTable, ezGALBuffer>(hBuffer, m_Buffers);
+}
+
+inline const ezGALReadbackBuffer* ezGALDevice::GetReadbackBuffer(ezGALReadbackBufferHandle hBuffer) const
+{
+  return Get<ReadbackBufferTable, ezGALReadbackBuffer>(hBuffer, m_ReadbackBuffers);
+}
+
+inline const ezGALReadbackTexture* ezGALDevice::GetReadbackTexture(ezGALReadbackTextureHandle hTexture) const
+{
+  return Get<ReadbackTextureTable, ezGALReadbackTexture>(hTexture, m_ReadbackTextures);
 }
 
 inline const ezGALDepthStencilState* ezGALDevice::GetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState) const

--- a/Code/Engine/RendererFoundation/Device/Implementation/ReadbackLock.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/ReadbackLock.cpp
@@ -1,0 +1,76 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Device/ReadbackLock.h>
+
+
+ezReadbackBufferLock::ezReadbackBufferLock(ezGALDevice* pDevice, const ezGALReadbackBuffer* pBuffer, ezArrayPtr<const ezUInt8>& out_Memory)
+  : m_pDevice(pDevice)
+  , m_pBuffer(pBuffer)
+{
+  if (m_pDevice->LockBufferPlatform(m_pBuffer, out_Memory).Failed())
+  {
+    m_pDevice = nullptr;
+    m_pBuffer = nullptr;
+  }
+}
+
+
+ezReadbackBufferLock::~ezReadbackBufferLock()
+{
+  if (m_pDevice)
+  {
+    m_pDevice->UnlockBufferPlatform(m_pBuffer);
+  }
+}
+
+void ezReadbackBufferLock::operator=(ezReadbackBufferLock&& rhs)
+{
+  if (m_pDevice)
+  {
+    m_pDevice->UnlockBufferPlatform(m_pBuffer);
+  }
+
+  m_pDevice = rhs.m_pDevice;
+  rhs.m_pDevice = nullptr;
+  m_pBuffer = rhs.m_pBuffer;
+  rhs.m_pBuffer = nullptr;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+ezReadbackTextureLock::ezReadbackTextureLock(ezGALDevice* pDevice, const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory)
+  : m_pDevice(pDevice)
+  , m_pTexture(pTexture)
+  , m_subResources(subResources)
+{
+  if (m_pDevice->LockTexturePlatform(m_pTexture, subResources, out_Memory).Failed())
+  {
+    m_pDevice = nullptr;
+    m_pTexture = nullptr;
+    m_subResources = {};
+  }
+}
+
+ezReadbackTextureLock::~ezReadbackTextureLock()
+{
+  if (m_pDevice)
+  {
+    m_pDevice->UnlockTexturePlatform(m_pTexture, m_subResources);
+  }
+}
+
+void ezReadbackTextureLock::operator=(ezReadbackTextureLock&& rhs)
+{
+  if (m_pDevice)
+  {
+    m_pDevice->UnlockTexturePlatform(m_pTexture, m_subResources);
+  }
+
+  m_pDevice = rhs.m_pDevice;
+  rhs.m_pDevice = nullptr;
+  m_pTexture = rhs.m_pTexture;
+  rhs.m_pTexture = nullptr;
+  m_subResources = rhs.m_subResources;
+  rhs.m_subResources = {};
+}

--- a/Code/Engine/RendererFoundation/Device/ReadbackLock.h
+++ b/Code/Engine/RendererFoundation/Device/ReadbackLock.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+class EZ_RENDERERFOUNDATION_DLL ezReadbackBufferLock
+{
+public:
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezReadbackBufferLock);
+
+  ezReadbackBufferLock() = default;
+  ezReadbackBufferLock(ezGALDevice* pDevice, const ezGALReadbackBuffer* pBuffer, ezArrayPtr<const ezUInt8>& out_Memory);
+  EZ_ALWAYS_INLINE ezReadbackBufferLock(ezReadbackBufferLock&& rhs) { *this = std::move(rhs); }
+  ~ezReadbackBufferLock();
+
+  void operator=(ezReadbackBufferLock&& rhs);
+
+  EZ_ALWAYS_INLINE bool IsValid() const { return m_pDevice != nullptr; }
+  EZ_ALWAYS_INLINE bool operator!() const { return m_pDevice == nullptr; }
+  EZ_ALWAYS_INLINE operator bool() const { return m_pDevice != nullptr; }
+
+private:
+  const ezGALDevice* m_pDevice = nullptr;
+  const ezGALReadbackBuffer* m_pBuffer = nullptr;
+};
+
+class EZ_RENDERERFOUNDATION_DLL ezReadbackTextureLock
+{
+public:
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezReadbackTextureLock);
+
+  ezReadbackTextureLock() = default;
+  ezReadbackTextureLock(ezGALDevice* pDevice, const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory);
+  EZ_ALWAYS_INLINE ezReadbackTextureLock(ezReadbackTextureLock&& rhs) { *this = std::move(rhs); }
+  ~ezReadbackTextureLock();
+
+  void operator=(ezReadbackTextureLock&& rhs);
+
+  EZ_ALWAYS_INLINE bool IsValid() const { return m_pDevice != nullptr; }
+  EZ_ALWAYS_INLINE bool operator!() const { return m_pDevice == nullptr; }
+  EZ_ALWAYS_INLINE operator bool() const { return m_pDevice != nullptr; }
+
+private:
+  const ezGALDevice* m_pDevice = nullptr;
+  const ezGALReadbackTexture* m_pTexture = nullptr;
+  ezArrayPtr<const ezGALTextureSubresource> m_subResources;
+};

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <Foundation/Basics.h>
+#include <Foundation/Containers/Blob.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/Id.h>
 #include <Foundation/Types/RefCounted.h>
-#include <Foundation/Containers/Blob.h>
 
 // Configure the DLL Import/Export Define
 #if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -4,6 +4,7 @@
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/Id.h>
 #include <Foundation/Types/RefCounted.h>
+#include <Foundation/Containers/Blob.h>
 
 // Configure the DLL Import/Export Define
 #if EZ_ENABLED(EZ_COMPILE_ENGINE_AS_DLL)
@@ -49,6 +50,8 @@ class ezGALResourceBase;
 class ezGALTexture;
 class ezGALSharedTexture;
 class ezGALBuffer;
+class ezGALReadbackBuffer;
+class ezGALReadbackTexture;
 class ezGALDepthStencilState;
 class ezGALBlendState;
 class ezGALRasterizerState;
@@ -365,7 +368,7 @@ struct ezGALTextureSubresource
 
 struct ezGALSystemMemoryDescription
 {
-  void* m_pData = nullptr;
+  ezConstByteBlobPtr m_pData;
   ezUInt32 m_uiRowPitch = 0;
   ezUInt32 m_uiSlicePitch = 0;
 };
@@ -416,9 +419,23 @@ class ezGALTextureHandle
   friend class ezGALDevice;
 };
 
+class ezGALReadbackTextureHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALReadbackTextureHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
 class ezGALBufferHandle
 {
   EZ_DECLARE_HANDLE_TYPE(ezGALBufferHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALReadbackBufferHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALReadbackBufferHandle, ezGAL::ez18_14Id);
 
   friend class ezGALDevice;
 };

--- a/Code/Engine/RendererFoundation/RendererReflection.cpp
+++ b/Code/Engine/RendererFoundation/RendererReflection.cpp
@@ -81,7 +81,6 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezGALResourceAccess, ezNoBase, 1, ezRTTIDefaultAl
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("ReadBack", m_bReadBack),
     EZ_MEMBER_PROPERTY("Immutable", m_bImmutable),
   }
   EZ_END_PROPERTIES;

--- a/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackBuffer.cpp
@@ -1,0 +1,10 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Resources/ReadbackBuffer.h>
+
+ezGALReadbackBuffer::ezGALReadbackBuffer(const ezGALBufferCreationDescription& Description)
+  : ezGALResource(Description)
+{
+}
+
+ezGALReadbackBuffer::~ezGALReadbackBuffer() = default;

--- a/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackHelper.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackHelper.cpp
@@ -3,9 +3,9 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Buffer.h>
-#include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/ReadbackBuffer.h>
 #include <RendererFoundation/Resources/ReadbackHelper.h>
+#include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/Texture.h>
 
 ezEnum<ezGALAsyncResult> ezGALReadbackHelper::GetReadbackResult(ezTime timeout) const

--- a/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackHelper.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackHelper.cpp
@@ -1,0 +1,136 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/CommandEncoder/CommandEncoder.h>
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Resources/Buffer.h>
+#include <RendererFoundation/Resources/ReadbackTexture.h>
+#include <RendererFoundation/Resources/ReadbackBuffer.h>
+#include <RendererFoundation/Resources/ReadbackHelper.h>
+#include <RendererFoundation/Resources/Texture.h>
+
+ezEnum<ezGALAsyncResult> ezGALReadbackHelper::GetReadbackResult(ezTime timeout) const
+{
+  if (m_hFence == 0 || m_pDevice == nullptr)
+    return ezGALAsyncResult::Expired;
+
+  return m_pDevice->GetFenceResult(m_hFence, timeout);
+}
+
+ezGALReadbackBufferHelper::~ezGALReadbackBufferHelper()
+{
+  Reset();
+}
+
+void ezGALReadbackBufferHelper::Reset()
+{
+  if (!m_hReadbackBuffer.IsInvalidated())
+  {
+    m_pDevice->DestroyReadbackBuffer(m_hReadbackBuffer);
+    m_hReadbackBuffer.Invalidate();
+  }
+  m_hFence = 0;
+  m_pDevice = nullptr;
+}
+
+ezGALFenceHandle ezGALReadbackBufferHelper::ReadbackBuffer(ezGALCommandEncoder& encoder, ezGALBufferHandle hBuffer)
+{
+  EZ_ASSERT_DEV(!encoder.IsInRenderingScope(), "Readback is only supported outside rendering scope");
+  m_pDevice = &encoder.GetDevice();
+  const ezGALBuffer* pBuffer = m_pDevice->GetBuffer(hBuffer);
+  EZ_ASSERT_DEV(pBuffer != nullptr, "Invalid buffer handle passed in for readback");
+  const ezGALBufferCreationDescription& desc = pBuffer->GetDescription();
+
+  if (!m_hReadbackBuffer.IsInvalidated())
+  {
+    const ezGALReadbackBuffer* pReadbackBuffer = m_pDevice->GetReadbackBuffer(m_hReadbackBuffer);
+    const ezGALBufferCreationDescription& readbackDesc = pReadbackBuffer->GetDescription();
+    if (desc.m_uiTotalSize != readbackDesc.m_uiTotalSize)
+    {
+      m_pDevice->DestroyReadbackBuffer(m_hReadbackBuffer);
+      m_hReadbackBuffer = {};
+    }
+  }
+
+  if (m_hReadbackBuffer.IsInvalidated())
+  {
+    ezGALBufferCreationDescription readbackDesc;
+    readbackDesc.m_uiTotalSize = desc.m_uiTotalSize;
+    readbackDesc.m_ResourceAccess.m_bImmutable = false;
+    m_hReadbackBuffer = m_pDevice->CreateReadbackBuffer(readbackDesc);
+  }
+
+  encoder.ReadbackBuffer(m_hReadbackBuffer, hBuffer);
+  m_hFence = encoder.InsertFence();
+  return m_hFence;
+}
+
+ezReadbackBufferLock ezGALReadbackBufferHelper::LockBuffer(ezArrayPtr<const ezUInt8>& out_Memory)
+{
+  if (m_pDevice == nullptr || m_hFence == 0 || m_pDevice->GetFenceResult(m_hFence) != ezGALAsyncResult::Ready)
+    return {};
+
+  return m_pDevice->LockBuffer(m_hReadbackBuffer, out_Memory);
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+ezGALReadbackTextureHelper::~ezGALReadbackTextureHelper()
+{
+  Reset();
+}
+
+void ezGALReadbackTextureHelper::Reset()
+{
+  if (!m_hReadbackTexture.IsInvalidated())
+  {
+    m_pDevice->DestroyReadbackTexture(m_hReadbackTexture);
+    m_hReadbackTexture.Invalidate();
+  }
+  m_hFence = 0;
+  m_pDevice = nullptr;
+}
+
+ezGALFenceHandle ezGALReadbackTextureHelper::ReadbackTexture(ezGALCommandEncoder& encoder, ezGALTextureHandle hTexture)
+{
+  EZ_ASSERT_DEV(!encoder.IsInRenderingScope(), "Readback is only supported outside rendering scope");
+  m_pDevice = &encoder.GetDevice();
+  const ezGALTexture* pTexture = m_pDevice->GetTexture(hTexture);
+  EZ_ASSERT_DEV(pTexture != nullptr, "Invalid texture handle passed in for readback");
+  ezGALTextureCreationDescription desc = pTexture->GetDescription();
+  // Reset properties that have no influence on the readback texture.
+  desc.m_pExisitingNativeObject = nullptr;
+  desc.m_ResourceAccess.m_bImmutable = false;
+  desc.m_bAllowShaderResourceView = false;
+  desc.m_bAllowUAV = false;
+  desc.m_bCreateRenderTarget = false;
+  desc.m_bAllowDynamicMipGeneration = false;
+
+
+  if (!m_hReadbackTexture.IsInvalidated())
+  {
+    const ezGALReadbackTexture* pReadbackTexture = m_pDevice->GetReadbackTexture(m_hReadbackTexture);
+    const ezGALTextureCreationDescription& readbackDesc = pReadbackTexture->GetDescription();
+    if (desc.CalculateHash() != readbackDesc.CalculateHash())
+    {
+      m_pDevice->DestroyReadbackTexture(m_hReadbackTexture);
+      m_hReadbackTexture = {};
+    }
+  }
+
+  if (m_hReadbackTexture.IsInvalidated())
+  {
+    EZ_ASSERT_DEV(desc.m_SampleCount == ezGALMSAASampleCount::None, "Readback of Multi-sampled images is unsupported");
+    m_hReadbackTexture = m_pDevice->CreateReadbackTexture(desc);
+  }
+  encoder.ReadbackTexture(m_hReadbackTexture, hTexture);
+  m_hFence = encoder.InsertFence();
+  return m_hFence;
+}
+
+ezReadbackTextureLock ezGALReadbackTextureHelper::LockTexture(const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory)
+{
+  if (m_pDevice == nullptr || m_hFence == 0 || m_pDevice->GetFenceResult(m_hFence) != ezGALAsyncResult::Ready)
+    return {};
+
+  return m_pDevice->LockTexture(m_hReadbackTexture, subResources, out_Memory);
+}

--- a/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackTexture.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackTexture.cpp
@@ -1,0 +1,10 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Resources/ReadbackTexture.h>
+
+ezGALReadbackTexture::ezGALReadbackTexture(const ezGALTextureCreationDescription& Description)
+  : ezGALResource(Description)
+{
+}
+
+ezGALReadbackTexture::~ezGALReadbackTexture() = default;

--- a/Code/Engine/RendererFoundation/Resources/ReadbackBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/ReadbackBuffer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/Resources/Resource.h>
+
+class ezGALDevice;
+
+/// \brief Allows for a GPU buffer to be read back to the CPU.
+/// Uses the same ezGALBufferCreationDescription as a normal buffer for convenience. While most of the properties may be irrelevant for this purpose, the user should not have to care about that and just request a readback buffer that can read back a buffer of the given description.
+class EZ_RENDERERFOUNDATION_DLL ezGALReadbackBuffer : public ezGALResource<ezGALBufferCreationDescription>
+{
+public:
+  EZ_ALWAYS_INLINE ezUInt32 GetSize() const { return m_Description.m_uiTotalSize; }
+
+protected:
+  friend class ezGALDevice;
+
+  ezGALReadbackBuffer(const ezGALBufferCreationDescription& Description);
+  virtual ~ezGALReadbackBuffer();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+};

--- a/Code/Engine/RendererFoundation/Resources/ReadbackHelper.h
+++ b/Code/Engine/RendererFoundation/Resources/ReadbackHelper.h
@@ -38,7 +38,7 @@ private:
 };
 
 /// \brief Helper class that automatically creates a readback texture and controls it's lifetime.
-class  EZ_RENDERERFOUNDATION_DLL ezGALReadbackTextureHelper : public ezGALReadbackHelper
+class EZ_RENDERERFOUNDATION_DLL ezGALReadbackTextureHelper : public ezGALReadbackHelper
 {
 public:
   ezGALReadbackTextureHelper() = default;
@@ -55,6 +55,3 @@ private:
   EZ_DISALLOW_COPY_AND_ASSIGN(ezGALReadbackTextureHelper);
   ezGALReadbackTextureHandle m_hReadbackTexture;
 };
-
-
-

--- a/Code/Engine/RendererFoundation/Resources/ReadbackHelper.h
+++ b/Code/Engine/RendererFoundation/Resources/ReadbackHelper.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <RendererFoundation/Device/ReadbackLock.h>
+
+class ezGALDevice;
+
+/// \brief Base-class for ezGALReadbackBufferHelper and ezGALReadbackTextureHelper.
+class EZ_RENDERERFOUNDATION_DLL ezGALReadbackHelper
+{
+public:
+  /// \brief Returns the fence of the last readback operation.
+  EZ_FORCE_INLINE ezGALFenceHandle GetCurrentFence() const { return m_hFence; }
+  /// \brief Returns the current status of the readback.
+  [[nodiscard]] ezEnum<ezGALAsyncResult> GetReadbackResult(ezTime timeout) const;
+
+protected:
+  ezGALDevice* m_pDevice = nullptr;
+  ezGALFenceHandle m_hFence = 0;
+};
+
+/// \brief Helper class that automatically creates a readback buffer and controls it's lifetime.
+class EZ_RENDERERFOUNDATION_DLL ezGALReadbackBufferHelper : public ezGALReadbackHelper
+{
+public:
+  ezGALReadbackBufferHelper() = default;
+  ~ezGALReadbackBufferHelper();
+
+  /// \brief Free the memory of the readback buffer.
+  void Reset();
+  /// \brief Starts a readback of a buffer. A new readback buffer will be created if the current one does not match the new buffer.
+  ezGALFenceHandle ReadbackBuffer(ezGALCommandEncoder& encoder, ezGALBufferHandle hBuffer);
+  /// \brief Same as ezGALDevice::LockBuffer, but checks that the fence has been reached. If not, returns an invalid lock object.
+  ezReadbackBufferLock LockBuffer(ezArrayPtr<const ezUInt8>& out_Memory);
+
+private:
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezGALReadbackBufferHelper);
+  ezGALReadbackBufferHandle m_hReadbackBuffer;
+};
+
+/// \brief Helper class that automatically creates a readback texture and controls it's lifetime.
+class  EZ_RENDERERFOUNDATION_DLL ezGALReadbackTextureHelper : public ezGALReadbackHelper
+{
+public:
+  ezGALReadbackTextureHelper() = default;
+  ~ezGALReadbackTextureHelper();
+
+  /// \brief Free the memory of the readback texture.
+  void Reset();
+  /// \brief Starts a readback of a texture. A new readback texture will be created if the current one does not match the new texture.
+  ezGALFenceHandle ReadbackTexture(ezGALCommandEncoder& encoder, ezGALTextureHandle hTexture);
+  /// \brief Same as ezGALDevice::LockTexture, but checks that the fence has been reached. If not, returns an invalid lock object.
+  ezReadbackTextureLock LockTexture(const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory);
+
+private:
+  EZ_DISALLOW_COPY_AND_ASSIGN(ezGALReadbackTextureHelper);
+  ezGALReadbackTextureHandle m_hReadbackTexture;
+};
+
+
+

--- a/Code/Engine/RendererFoundation/Resources/ReadbackTexture.h
+++ b/Code/Engine/RendererFoundation/Resources/ReadbackTexture.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/Resources/Resource.h>
+
+class ezGALDevice;
+
+/// \brief Allows for a GPU texture to be read back to the CPU.
+/// Uses the same ezGALTextureCreationDescription as a normal texture for convenience. While most of the properties may be irrelevant for this purpose, the user should not have to care about that and just request a readback texture that can read back a texture of the given description.
+class EZ_RENDERERFOUNDATION_DLL ezGALReadbackTexture : public ezGALResource<ezGALTextureCreationDescription>
+{
+protected:
+  friend class ezGALDevice;
+
+  ezGALReadbackTexture(const ezGALTextureCreationDescription& Description);
+  virtual ~ezGALReadbackTexture();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+};

--- a/Code/Engine/RendererFoundation/Resources/Texture.h
+++ b/Code/Engine/RendererFoundation/Resources/Texture.h
@@ -6,16 +6,13 @@
 
 class EZ_RENDERERFOUNDATION_DLL ezGALTexture : public ezGALResource<ezGALTextureCreationDescription>
 {
-public:
 protected:
   friend class ezGALDevice;
 
   ezGALTexture(const ezGALTextureCreationDescription& Description);
-
   virtual ~ezGALTexture();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData) = 0;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 
 protected:

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -76,13 +76,13 @@ public:
 
   virtual void ResolveTexturePlatform(const ezGALTexture* pDestination, const ezGALTextureSubresource& DestinationSubResource, const ezGALTexture* pSource, const ezGALTextureSubresource& SourceSubResource) override;
 
-  virtual void ReadbackTexturePlatform(const ezGALTexture* pTexture) override;
-
-  virtual void CopyTextureReadbackResultPlatform(const ezGALTexture* pTexture, ezArrayPtr<ezGALTextureSubresource> SourceSubResource, ezArrayPtr<ezGALSystemMemoryDescription> TargetData) override;
+  virtual void ReadbackTexturePlatform(const ezGALReadbackTexture* pDestination, const ezGALTexture* pSource) override;
+  virtual void ReadbackBufferPlatform(const ezGALReadbackBuffer* pDestination, const ezGALBuffer* pSource) override;
 
   virtual void GenerateMipMapsPlatform(const ezGALTextureResourceView* pResourceView) override;
 
   void CopyImageToBuffer(const ezGALTextureVulkan* pSource, const ezGALBufferVulkan* pDestination);
+  void CopyImageToBuffer(const ezGALTextureVulkan* pSource, vk::Buffer destination);
 
   // Misc
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -173,7 +173,7 @@ public:
   ezStagingBufferPoolVulkan& GetStagingBufferPool() const;
   ezInitContextVulkan& GetInitContext() const;
 
-  ezGALTextureHandle CreateTextureInternal(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, bool bLinearCPU = false, bool bStaging = false);
+  ezGALTextureHandle CreateTextureInternal(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData);
   ezGALBufferHandle CreateBufferInternal(const ezGALBufferCreationDescription& Description, ezArrayPtr<const ezUInt8> pInitialData, bool bCPU = false);
 
   const ezGALFormatLookupTableVulkan& GetFormatLookupTable() const;
@@ -338,6 +338,12 @@ protected:
   virtual ezGALTexture* CreateSharedTexturePlatform(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle handle) override;
   virtual void DestroySharedTexturePlatform(ezGALTexture* pTexture) override;
 
+  virtual ezGALReadbackBuffer* CreateReadbackBufferPlatform(const ezGALBufferCreationDescription& Description) override;
+  virtual void DestroyReadbackBufferPlatform(ezGALReadbackBuffer* pReadbackBuffer) override;
+
+  virtual ezGALReadbackTexture* CreateReadbackTexturePlatform(const ezGALTextureCreationDescription& Description) override;
+  virtual void DestroyReadbackTexturePlatform(ezGALReadbackTexture* pReadbackTexture) override;
+
   virtual ezGALTextureResourceView* CreateResourceViewPlatform(ezGALTexture* pResource, const ezGALTextureResourceViewCreationDescription& Description) override;
   virtual void DestroyResourceViewPlatform(ezGALTextureResourceView* pResourceView) override;
 
@@ -361,6 +367,10 @@ protected:
   virtual ezEnum<ezGALAsyncResult> GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& out_result) override;
   virtual ezEnum<ezGALAsyncResult> GetOcclusionResultPlatform(ezGALOcclusionHandle hOcclusion, ezUInt64& out_uiResult) override;
   virtual ezEnum<ezGALAsyncResult> GetFenceResultPlatform(ezGALFenceHandle hFence, ezTime timeout) override;
+  virtual ezResult LockBufferPlatform(const ezGALReadbackBuffer* pBuffer, ezArrayPtr<const ezUInt8>& out_Memory) const override;
+  virtual void UnlockBufferPlatform(const ezGALReadbackBuffer* pBuffer) const override;
+  virtual ezResult LockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources, ezDynamicArray<ezGALSystemMemoryDescription>& out_Memory) const override;
+  virtual void UnlockTexturePlatform(const ezGALReadbackTexture* pTexture, const ezArrayPtr<const ezGALTextureSubresource>& subResources) const override;
 
   // Misc functions
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
@@ -111,7 +111,7 @@ void ezInitContextVulkan::InitTexture(const ezGALTextureVulkan* pTexture, vk::Im
             (imageExtent.depth + blockExtent[2] - 1) / blockExtent[2]};
 
           ezGALSystemMemoryDescription data;
-          data.m_pData = tempData.GetData();
+          data.m_pData = tempData.GetByteArrayPtr();
           data.m_uiRowPitch = uiBlockSize * blockCount.width;
           data.m_uiSlicePitch = data.m_uiRowPitch * blockCount.height;
           initialData.PushBack(data);

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -335,9 +335,10 @@ ezResult ezGALSwapChainVulkan::CreateSwapChainInternal()
   swapChainCreateInfo.imageExtent.height = ezMath::Clamp(swapChainCreateInfo.imageExtent.height, surfaceCapabilities.minImageExtent.height, surfaceCapabilities.maxImageExtent.height);
   swapChainCreateInfo.imageFormat = desiredFormat;
 
-  swapChainCreateInfo.imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransferDst; // We need eTransferDst to be able to resolve msaa textures into the backbuffer.
-  if (m_WindowDesc.m_bAllowScreenshots)
-    swapChainCreateInfo.imageUsage |= vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled;
+  // We need eTransferDst to be able to resolve msaa textures into the backbuffer.
+  swapChainCreateInfo.imageUsage = vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eTransferDst;
+  // eTransferSrc is needed for debugging and screenshot purposes.
+  swapChainCreateInfo.imageUsage |= vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled;
 
   // #TODO_VULKAN Using only 2 images in the swapchain may trigger the following validation error when resizing the window. To prevent this we use 3 images instead. Technically m_bDoubleBuffered now means triple buffering - a problem for another time and creating a swapchain with only 1 texture is impossible anyways on most platforms.
   // https://vulkan.lunarg.com/doc/view/1.3.239.0/windows/1.3-extensions/vkspec.html#VUID-vkAcquireNextImageKHR-surface-07783
@@ -383,7 +384,6 @@ ezResult ezGALSwapChainVulkan::CreateSwapChainInternal()
     TexDesc.m_bAllowShaderResourceView = false;
     TexDesc.m_bCreateRenderTarget = true;
     TexDesc.m_ResourceAccess.m_bImmutable = true;
-    TexDesc.m_ResourceAccess.m_bReadBack = m_WindowDesc.m_bAllowScreenshots;
     m_swapChainTextures.PushBack(m_pVulkanDevice->CreateTextureInternal(TexDesc, ezArrayPtr<ezGALSystemMemoryDescription>()));
   }
   m_CurrentSize = ezSizeU32(swapChainCreateInfo.imageExtent.width, swapChainCreateInfo.imageExtent.height);

--- a/Code/Engine/RendererVulkan/Pools/Implementation/FencePoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/FencePoolVulkan.cpp
@@ -129,7 +129,7 @@ ezEnum<ezGALAsyncResult> ezFenceQueueVulkan::WaitForNextFence(ezTime timeout /*=
   }
 
   EZ_ASSERT_DEBUG(fenceStatus == vk::Result::eNotReady, "getFenceStatus returned {}", vk::to_string(fenceStatus).c_str());
-  if (fenceStatus == vk::Result::eNotReady && timeout > ezTime::MakeZero())
+  if (fenceStatus == vk::Result::eNotReady && !timeout.IsZero())
   {
     fenceStatus = m_device.waitForFences(1, &m_PendingFences[0].m_vkFence, true, static_cast<ezUInt64>(timeout.GetNanoseconds()));
     if (fenceStatus == vk::Result::eTimeout)
@@ -139,6 +139,7 @@ ezEnum<ezGALAsyncResult> ezFenceQueueVulkan::WaitForNextFence(ezTime timeout /*=
 
     m_uiReachedFenceCounter = m_PendingFences[0].m_hFence;
     m_PendingFences.PopFront();
+    return ezGALAsyncResult::Ready;
   }
   return ezGALAsyncResult::Pending;
 }

--- a/Code/Engine/RendererVulkan/Pools/Implementation/StagingBufferPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/StagingBufferPoolVulkan.cpp
@@ -17,7 +17,10 @@ void ezStagingBufferPoolVulkan::DeInitialize()
 
 ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize alignment, vk::DeviceSize size)
 {
-  // #TODO_VULKAN alignment
+  const vk::PhysicalDeviceProperties& properties = m_pDevice->GetPhysicalDeviceProperties();
+  alignment = ezMath::Max<vk::DeviceSize>(16, alignment, properties.limits.nonCoherentAtomSize);
+  size = ezMemoryUtils::AlignSize(size, alignment);
+
   ezStagingBufferVulkan buffer;
 
   EZ_ASSERT_DEBUG(m_device, "ezStagingBufferPoolVulkan::Initialize not called");
@@ -28,7 +31,6 @@ ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize a
   bufferCreateInfo.pQueueFamilyIndices = nullptr;
   bufferCreateInfo.queueFamilyIndexCount = 0;
   bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
-
 
   ezVulkanAllocationCreateInfo allocInfo;
   allocInfo.m_usage = ezVulkanMemoryUsage::Auto;

--- a/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
@@ -20,6 +20,9 @@ public:
   /// \brief Needs to be called every frame so the pool can figure out which queries have finished and reuse old data.
   void BeginFrame(vk::CommandBuffer commandBuffer);
 
+  /// \brief We have to call this before each begin rendering call as if we run out of queries inside a render pass, we can't recover given that resetQueryPool can only be called outside a render pass which is necessary to be called on every new pool.
+  void EnsureFreeQueryPoolSize(vk::CommandBuffer commandBuffer);
+
   /// \brief Inserts a timestamp into the given command buffer.
   /// \param commandBuffer Target command buffer to insert the timestamp into.
   /// \param hTimestamp Timestamp to insert. After insertion the only valid option is to call GetTimestampResult.
@@ -78,7 +81,9 @@ private:
     void DeInitialize();
 
     QueryPool* GetFreePool();
+    QueryPool* CreatePool();
     void BeginFrame(vk::CommandBuffer commandBuffer, ezUInt64 uiCurrentFrame, ezUInt64 uiSafeFrame);
+    void EnsureFreeQueryPoolSize(vk::CommandBuffer commandBuffer, ezUInt32 uiFreePools);
     ezGALPoolHandle CreateQuery(vk::CommandBuffer commandBuffer);
     Query GetQuery(ezGALPoolHandle hPool);
     ezEnum<ezGALAsyncResult> GetResult(ezGALPoolHandle hPool, ezUInt64& out_uiResult, bool bForce);

--- a/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <RendererVulkan/RendererVulkanDLL.h>
 #include <RendererFoundation/Descriptors/Enumerations.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
 
 #include <vulkan/vulkan.hpp>
 

--- a/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RendererVulkan/RendererVulkanDLL.h>
+#include <RendererFoundation/Descriptors/Enumerations.h>
 
 #include <vulkan/vulkan.hpp>
 

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
@@ -1,6 +1,8 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
 #include <RendererVulkan/Resources/ReadbackBufferVulkan.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Resources/BufferVulkan.h>
 
 ezGALReadbackBufferVulkan::ezGALReadbackBufferVulkan(const ezGALBufferCreationDescription& Description)
   : ezGALReadbackBuffer(Description)

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
@@ -1,8 +1,8 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
-#include <RendererVulkan/Resources/ReadbackBufferVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
+#include <RendererVulkan/Resources/ReadbackBufferVulkan.h>
 
 ezGALReadbackBufferVulkan::ezGALReadbackBufferVulkan(const ezGALBufferCreationDescription& Description)
   : ezGALReadbackBuffer(Description)

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
@@ -1,0 +1,51 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Resources/ReadbackBufferVulkan.h>
+
+ezGALReadbackBufferVulkan::ezGALReadbackBufferVulkan(const ezGALBufferCreationDescription& Description)
+  : ezGALReadbackBuffer(Description)
+{
+}
+
+ezGALReadbackBufferVulkan::~ezGALReadbackBufferVulkan() = default;
+
+ezResult ezGALReadbackBufferVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  m_pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  vk::DeviceSize alignment = ezGALBufferVulkan::GetAlignment(m_pDeviceVulkan, vk::BufferUsageFlagBits::eTransferDst);
+  m_size = ezMemoryUtils::AlignSize((vk::DeviceSize)m_Description.m_uiTotalSize, alignment);
+
+  vk::BufferCreateInfo bufferCreateInfo;
+  bufferCreateInfo.usage = vk::BufferUsageFlagBits::eTransferDst;
+  bufferCreateInfo.pQueueFamilyIndices = nullptr;
+  bufferCreateInfo.queueFamilyIndexCount = 0;
+  bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
+  bufferCreateInfo.size = m_size;
+
+  ezVulkanAllocationCreateInfo allocCreateInfo;
+  allocCreateInfo.m_usage = ezVulkanMemoryUsage::Auto;
+  allocCreateInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessRandom | ezVulkanAllocationCreateFlags::Mapped;
+
+  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_buffer, m_alloc, &m_allocInfo));
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALReadbackBufferVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  if (m_buffer)
+  {
+    m_pDeviceVulkan->DeleteLater(m_buffer, m_alloc);
+    m_allocInfo = {};
+  }
+  m_size = 0;
+  m_pDeviceVulkan = nullptr;
+  return EZ_SUCCESS;
+}
+
+void ezGALReadbackBufferVulkan::SetDebugNamePlatform(const char* szName) const
+{
+  m_pDeviceVulkan->SetDebugName(szName, m_buffer, m_alloc);
+}
+

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackBufferVulkan.cpp
@@ -48,4 +48,3 @@ void ezGALReadbackBufferVulkan::SetDebugNamePlatform(const char* szName) const
 {
   m_pDeviceVulkan->SetDebugName(szName, m_buffer, m_alloc);
 }
-

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
@@ -1,7 +1,7 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
-#include <RendererVulkan/Resources/ReadbackTextureVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Resources/ReadbackTextureVulkan.h>
 
 ezGALReadbackTextureVulkan::ezGALReadbackTextureVulkan(const ezGALTextureCreationDescription& Description)
   : ezGALReadbackTexture(Description)

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
@@ -1,0 +1,49 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Resources/ReadbackTextureVulkan.h>
+
+ezGALReadbackTextureVulkan::ezGALReadbackTextureVulkan(const ezGALTextureCreationDescription& Description)
+: ezGALReadbackTexture(Description)
+{
+}
+
+ezGALReadbackTextureVulkan::~ezGALReadbackTextureVulkan() = default;
+
+ezResult ezGALReadbackTextureVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  m_pDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  vk::BufferCreateInfo bufferCreateInfo;
+  bufferCreateInfo.usage = vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst | vk::BufferUsageFlagBits::eStorageBuffer;
+  bufferCreateInfo.pQueueFamilyIndices = nullptr;
+  bufferCreateInfo.queueFamilyIndexCount = 0;
+  bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
+
+  ezHybridArray<ezGALTextureVulkan::SubResourceOffset, 8> subResourceSizes;
+  bufferCreateInfo.size = ezGALTextureVulkan::ComputeSubResourceOffsets(m_pDevice, m_Description, subResourceSizes);
+
+  ezVulkanAllocationCreateInfo allocCreateInfo;
+  allocCreateInfo.m_usage = ezVulkanMemoryUsage::Auto;
+  allocCreateInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessRandom /*| ezVulkanAllocationCreateFlags::Mapped*/;
+
+  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_buffer, m_bufferAlloc, &m_bufferAllocInfo));
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALReadbackTextureVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  if (m_buffer)
+  {
+    ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+    pVulkanDevice->DeleteLater(m_buffer, m_bufferAlloc);
+    m_bufferAllocInfo = {};
+    m_buffer = nullptr;
+  }
+
+  return EZ_SUCCESS;
+}
+
+void ezGALReadbackTextureVulkan::SetDebugNamePlatform(const char* szName) const
+{
+  m_pDevice->SetDebugName(szName, m_buffer, m_bufferAlloc);
+}

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
@@ -3,7 +3,7 @@
 #include <RendererVulkan/Resources/ReadbackTextureVulkan.h>
 
 ezGALReadbackTextureVulkan::ezGALReadbackTextureVulkan(const ezGALTextureCreationDescription& Description)
-: ezGALReadbackTexture(Description)
+  : ezGALReadbackTexture(Description)
 {
 }
 

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ReadbackTextureVulkan.cpp
@@ -1,6 +1,7 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
 #include <RendererVulkan/Resources/ReadbackTextureVulkan.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
 
 ezGALReadbackTextureVulkan::ezGALReadbackTextureVulkan(const ezGALTextureCreationDescription& Description)
   : ezGALReadbackTexture(Description)

--- a/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/ResourceViewVulkan.cpp
@@ -155,7 +155,7 @@ ezResult ezGALBufferResourceViewVulkan::InitPlatform(ezGALDevice* pDevice)
   }
 
   auto pParentBuffer = static_cast<const ezGALBufferVulkan*>(pBuffer);
-  if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer))
+  if (pBuffer->GetDescription().m_BufferFlags.IsAnySet(ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ByteAddressBuffer))
   {
     m_resourceBufferInfo.offset = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiFirstElement;
     m_resourceBufferInfo.range = pBuffer->GetDescription().m_uiStructSize * m_Description.m_uiNumElements;

--- a/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
@@ -14,7 +14,7 @@
 #endif
 
 ezGALSharedTextureVulkan::ezGALSharedTextureVulkan(const ezGALTextureCreationDescription& Description, ezEnum<ezGALSharedTextureType> sharedType, ezGALPlatformSharedHandle hSharedHandle)
-  : ezGALTextureVulkan(Description, false, false)
+  : ezGALTextureVulkan(Description)
   , m_SharedType(sharedType)
   , m_hSharedHandle(hSharedHandle)
 {
@@ -31,13 +31,9 @@ ezResult ezGALSharedTextureVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr
   vk::ImageFormatListCreateInfo imageFormats;
   vk::ImageCreateInfo createInfo = {};
 
-  m_imageFormat = ComputeImageFormat(m_pDevice, m_Description.m_Format, createInfo, imageFormats, m_bStaging);
+  m_imageFormat = ComputeImageFormat(m_pDevice, m_Description.m_Format, createInfo, imageFormats);
 
   ComputeCreateInfo(m_pDevice, m_Description, createInfo, m_stages, m_access, m_preferredLayout);
-  if (m_bLinearCPU)
-  {
-    ComputeCreateInfoLinear(createInfo, m_stages, m_access);
-  }
 
   if (m_Description.m_pExisitingNativeObject == nullptr)
   {
@@ -59,7 +55,7 @@ ezResult ezGALSharedTextureVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr
     {
 
       ezVulkanAllocationCreateInfo allocInfo;
-      ComputeAllocInfo(m_bLinearCPU, allocInfo);
+      ComputeAllocInfo(allocInfo);
 
       if (m_SharedType == ezGALSharedTextureType::Exported)
       {
@@ -314,6 +310,9 @@ ezResult ezGALSharedTextureVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr
       vk::ImportMemoryWin32HandleInfoKHR fdInfo{vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32, reinterpret_cast<HANDLE>(m_hSharedHandle.m_hSharedTexture)};
       vk::MemoryAllocateInfo allocateInfo{imageMemoryRequirements.memoryRequirements.size, m_hSharedHandle.m_uiMemoryTypeIndex, &fdInfo};
 
+     //vk::MemoryWin32HandlePropertiesKHR handleProperties;
+     // device.getMemoryWin32HandlePropertiesKHR(vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32, reinterpret_cast<HANDLE>(m_hSharedHandle.m_hSharedTexture), m_pDevice->GetDispatchContext());
+
       m_allocInfo = {};
       VK_SUCCEED_OR_RETURN_EZ_FAILURE(device.allocateMemory(&allocateInfo, nullptr, &m_allocInfo.m_deviceMemory));
       m_allocInfo.m_offset = 0;
@@ -331,11 +330,6 @@ ezResult ezGALSharedTextureVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr
     m_image = static_cast<VkImage>(m_Description.m_pExisitingNativeObject);
   }
   m_pDevice->GetInitContext().InitTexture(this, createInfo, pInitialData);
-
-  if (m_Description.m_ResourceAccess.m_bReadBack)
-  {
-    return CreateStagingBuffer(createInfo);
-  }
 
   return EZ_SUCCESS;
 }

--- a/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/SharedTextureVulkan.cpp
@@ -310,8 +310,8 @@ ezResult ezGALSharedTextureVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr
       vk::ImportMemoryWin32HandleInfoKHR fdInfo{vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32, reinterpret_cast<HANDLE>(m_hSharedHandle.m_hSharedTexture)};
       vk::MemoryAllocateInfo allocateInfo{imageMemoryRequirements.memoryRequirements.size, m_hSharedHandle.m_uiMemoryTypeIndex, &fdInfo};
 
-     //vk::MemoryWin32HandlePropertiesKHR handleProperties;
-     // device.getMemoryWin32HandlePropertiesKHR(vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32, reinterpret_cast<HANDLE>(m_hSharedHandle.m_hSharedTexture), m_pDevice->GetDispatchContext());
+      // vk::MemoryWin32HandlePropertiesKHR handleProperties;
+      //  device.getMemoryWin32HandlePropertiesKHR(vk::ExternalMemoryHandleTypeFlagBits::eOpaqueWin32, reinterpret_cast<HANDLE>(m_hSharedHandle.m_hSharedTexture), m_pDevice->GetDispatchContext());
 
       m_allocInfo = {};
       VK_SUCCEED_OR_RETURN_EZ_FAILURE(device.allocateMemory(&allocateInfo, nullptr, &m_allocInfo.m_deviceMemory));

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan.cpp
@@ -9,9 +9,9 @@
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
 
-vk::Extent3D ezGALTextureVulkan::GetMipLevelSize(ezUInt32 uiMipLevel) const
+vk::Extent3D ezGALTextureVulkan::GetMipLevelSize(const ezGALTextureCreationDescription& description, ezUInt32 uiMipLevel)
 {
-  vk::Extent3D size = {m_Description.m_uiWidth, m_Description.m_uiHeight, m_Description.m_uiDepth};
+  vk::Extent3D size = {description.m_uiWidth, description.m_uiHeight, description.m_uiDepth};
   size.width = ezMath::Max(1u, size.width >> uiMipLevel);
   size.height = ezMath::Max(1u, size.height >> uiMipLevel);
   size.depth = ezMath::Max(1u, size.depth >> uiMipLevel);
@@ -43,11 +43,8 @@ vk::ImageAspectFlags ezGALTextureVulkan::GetAspectMask() const
   return mask;
 }
 
-ezGALTextureVulkan::ezGALTextureVulkan(const ezGALTextureCreationDescription& Description, bool bLinearCPU, bool bStaging)
+ezGALTextureVulkan::ezGALTextureVulkan(const ezGALTextureCreationDescription& Description)
   : ezGALTexture(Description)
-  , m_image(nullptr)
-  , m_bLinearCPU(bLinearCPU)
-  , m_bStaging(bStaging)
 {
 }
 
@@ -60,38 +57,29 @@ ezResult ezGALTextureVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<ezGAL
   vk::ImageFormatListCreateInfo imageFormats;
   vk::ImageCreateInfo createInfo = {};
 
-  m_imageFormat = ComputeImageFormat(m_pDevice, m_Description.m_Format, createInfo, imageFormats, m_bStaging);
+  m_imageFormat = ComputeImageFormat(m_pDevice, m_Description.m_Format, createInfo, imageFormats);
   ComputeCreateInfo(m_pDevice, m_Description, createInfo, m_stages, m_access, m_preferredLayout);
-  if (m_bLinearCPU)
-  {
-    ComputeCreateInfoLinear(createInfo, m_stages, m_access);
-  }
 
-  if (m_Description.m_pExisitingNativeObject == nullptr)
+  if (m_Description.m_pExisitingNativeObject != nullptr)
+  {
+    m_image = static_cast<VkImage>(m_Description.m_pExisitingNativeObject);
+    m_pDevice->GetInitContext().InitTexture(this, createInfo, pInitialData);
+  }
+  else
   {
     ezVulkanAllocationCreateInfo allocInfo;
-    ComputeAllocInfo(m_bLinearCPU, allocInfo);
+    ComputeAllocInfo(allocInfo);
 
     vk::ImageFormatProperties props2;
     VK_ASSERT_DEBUG(m_pDevice->GetVulkanPhysicalDevice().getImageFormatProperties(createInfo.format, createInfo.imageType, createInfo.tiling, createInfo.usage, createInfo.flags, &props2));
     VK_SUCCEED_OR_RETURN_EZ_FAILURE(ezMemoryAllocatorVulkan::CreateImage(createInfo, allocInfo, m_image, m_alloc, &m_allocInfo));
+    m_pDevice->GetInitContext().InitTexture(this, createInfo, pInitialData);
   }
-  else
-  {
-    m_image = static_cast<VkImage>(m_Description.m_pExisitingNativeObject);
-  }
-  m_pDevice->GetInitContext().InitTexture(this, createInfo, pInitialData);
-
-  if (m_Description.m_ResourceAccess.m_bReadBack)
-  {
-    return CreateStagingBuffer(createInfo);
-  }
-
   return EZ_SUCCESS;
 }
 
 
-vk::Format ezGALTextureVulkan::ComputeImageFormat(ezGALDeviceVulkan* pDevice, ezEnum<ezGALResourceFormat> galFormat, vk::ImageCreateInfo& ref_createInfo, vk::ImageFormatListCreateInfo& ref_imageFormats, bool bStaging)
+vk::Format ezGALTextureVulkan::ComputeImageFormat(const ezGALDeviceVulkan* pDevice, ezEnum<ezGALResourceFormat> galFormat, vk::ImageCreateInfo& ref_createInfo, vk::ImageFormatListCreateInfo& ref_imageFormats)
 {
   const ezGALFormatLookupEntryVulkan& format = pDevice->GetFormatLookupTable().GetFormatInfo(galFormat);
 
@@ -104,11 +92,11 @@ vk::Format ezGALTextureVulkan::ComputeImageFormat(ezGALDeviceVulkan* pDevice, ez
     ref_imageFormats.pViewFormats = format.m_mutableFormats.GetData();
   }
 
-  ref_createInfo.format = bStaging ? format.m_readback : format.m_format;
+  ref_createInfo.format = format.m_format;
   return ref_createInfo.format;
 }
 
-void ezGALTextureVulkan::ComputeCreateInfo(ezGALDeviceVulkan* m_pDevice, const ezGALTextureCreationDescription& m_Description, vk::ImageCreateInfo& createInfo, vk::PipelineStageFlags& m_stages, vk::AccessFlags& m_access, vk::ImageLayout& m_preferredLayout)
+void ezGALTextureVulkan::ComputeCreateInfo(const ezGALDeviceVulkan* m_pDevice, const ezGALTextureCreationDescription& m_Description, vk::ImageCreateInfo& createInfo, vk::PipelineStageFlags& m_stages, vk::AccessFlags& m_access, vk::ImageLayout& m_preferredLayout)
 {
   EZ_ASSERT_DEBUG(createInfo.format != vk::Format::eUndefined, "No storage format available for given format: {0}", m_Description.m_Format);
 
@@ -124,8 +112,9 @@ void ezGALTextureVulkan::ComputeCreateInfo(ezGALDeviceVulkan* m_pDevice, const e
   createInfo.queueFamilyIndexCount = 0;
   createInfo.tiling = vk::ImageTiling::eOptimal;
   createInfo.usage |= vk::ImageUsageFlagBits::eTransferDst;
-  if (m_Description.m_ResourceAccess.m_bReadBack)
-    createInfo.usage |= vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled;
+  // eTransferSrc can be set on everything without any negative effects.
+  // #TODO_VULKAN eSampled not needed if we only allow buffer readback or is it necessary for depth?
+  createInfo.usage |= vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled;
 
   createInfo.extent.width = m_Description.m_uiWidth;
   createInfo.extent.height = m_Description.m_uiHeight;
@@ -213,64 +202,19 @@ void ezGALTextureVulkan::ComputeCreateInfo(ezGALDeviceVulkan* m_pDevice, const e
   }
 }
 
-void ezGALTextureVulkan::ComputeCreateInfoLinear(vk::ImageCreateInfo& createInfo, vk::PipelineStageFlags& m_stages, vk::AccessFlags& m_access)
-{
-  createInfo.tiling = vk::ImageTiling::eLinear;
-  createInfo.usage |= vk::ImageUsageFlagBits::eTransferSrc;
-  m_stages |= vk::PipelineStageFlagBits::eHost;
-  m_access |= vk::AccessFlagBits::eHostRead;
-  createInfo.flags = {}; // Clear all flags as we don't need them and they usually are not supported on NVidia in linear mode.
-}
-
-void ezGALTextureVulkan::ComputeAllocInfo(bool m_bLinearCPU, ezVulkanAllocationCreateInfo& allocInfo)
+void ezGALTextureVulkan::ComputeAllocInfo(ezVulkanAllocationCreateInfo& allocInfo)
 {
   allocInfo.m_usage = ezVulkanMemoryUsage::Auto;
-  if (m_bLinearCPU)
-  {
-    allocInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessRandom;
-  }
 }
 
-ezGALTextureVulkan::StagingMode ezGALTextureVulkan::ComputeStagingMode(ezGALDeviceVulkan* m_pDevice, const ezGALTextureCreationDescription& m_Description, const vk::ImageCreateInfo& createInfo)
+ezUInt32 ezGALTextureVulkan::ComputeSubResourceOffsets(const ezGALDeviceVulkan* pDevice, const ezGALTextureCreationDescription& description, ezDynamicArray<SubResourceOffset>& subResourceSizes)
 {
-  if (!m_Description.m_ResourceAccess.m_bReadBack)
-    return StagingMode::None;
-
-  // We want the staging texture to always have the intended format and not the override format given by the parent texture.
-  vk::Format stagingFormat = m_pDevice->GetFormatLookupTable().GetFormatInfo(m_Description.m_Format).m_readback;
-
-  EZ_ASSERT_DEV(!ezConversionUtilsVulkan::IsStencilFormat(createInfo.format), "Stencil read-back not implemented.");
-  EZ_ASSERT_DEV(!ezConversionUtilsVulkan::IsDepthFormat(stagingFormat), "Depth read-back should use a color format for CPU staging.");
-
-  const vk::FormatProperties srcFormatProps = m_pDevice->GetVulkanPhysicalDevice().getFormatProperties(createInfo.format);
-  const vk::FormatProperties dstFormatProps = m_pDevice->GetVulkanPhysicalDevice().getFormatProperties(stagingFormat);
-
-  const bool bFormatsEqual = createInfo.format == stagingFormat && createInfo.samples == vk::SampleCountFlagBits::e1;
-  const bool bSupportsCopy = bFormatsEqual && (srcFormatProps.optimalTilingFeatures & vk::FormatFeatureFlagBits::eTransferSrc) && (dstFormatProps.linearTilingFeatures & vk::FormatFeatureFlagBits::eTransferDst);
-  if (bFormatsEqual)
-  {
-    EZ_ASSERT_DEV(srcFormatProps.optimalTilingFeatures & vk::FormatFeatureFlagBits::eTransferSrc, "Source format can't be read, readback impossible.");
-    return StagingMode::Buffer;
-  }
-  else
-  {
-    vk::ImageFormatProperties props;
-    vk::Result res = m_pDevice->GetVulkanPhysicalDevice().getImageFormatProperties(stagingFormat, createInfo.imageType, vk::ImageTiling::eLinear, vk::ImageUsageFlagBits::eColorAttachment, {}, &props);
-
-    // #TODO_VULKAN Note that on Nvidia driver 531.68 the above call succeeds even though linear rendering is not supported by the driver. Thus, we need to check explicitly here that vk::FormatFeatureFlagBits::eColorAttachment is supported again via the vk::FormatProperties.
-    const bool bCanUseDirectTexture = (dstFormatProps.linearTilingFeatures & vk::FormatFeatureFlagBits::eColorAttachment) && (res == vk::Result::eSuccess) && createInfo.arrayLayers <= props.maxArrayLayers && createInfo.mipLevels <= props.maxMipLevels && createInfo.extent.depth <= props.maxExtent.depth && createInfo.extent.width <= props.maxExtent.width && createInfo.extent.height <= props.maxExtent.height && (createInfo.samples & props.sampleCounts);
-    return bCanUseDirectTexture ? StagingMode::Texture : StagingMode::TextureAndBuffer;
-  }
-}
-
-ezUInt32 ezGALTextureVulkan::ComputeSubResourceOffsets(ezDynamicArray<SubResourceOffset>& subResourceSizes) const
-{
-  const ezUInt32 alignment = (ezUInt32)ezGALBufferVulkan::GetAlignment(m_pDevice, vk::BufferUsageFlagBits::eTransferDst);
-  const vk::Format stagingFormat = m_pDevice->GetFormatLookupTable().GetFormatInfo(m_Description.m_Format).m_readback;
+  const ezUInt32 alignment = (ezUInt32)ezGALBufferVulkan::GetAlignment(pDevice, vk::BufferUsageFlagBits::eTransferDst);
+  const vk::Format stagingFormat = pDevice->GetFormatLookupTable().GetFormatInfo(description.m_Format).m_readback;
   const ezUInt8 uiBlockSize = vk::blockSize(stagingFormat);
   const auto blockExtent = vk::blockExtent(stagingFormat);
-  const ezUInt32 arrayLayers = (m_Description.m_Type == ezGALTextureType::TextureCube || m_Description.m_Type == ezGALTextureType::TextureCubeArray) ? (m_Description.m_uiArraySize * 6) : m_Description.m_uiArraySize;
-  const ezUInt32 mipLevels = m_Description.m_uiMipLevelCount;
+  const ezUInt32 arrayLayers = (description.m_Type == ezGALTextureType::TextureCube || description.m_Type == ezGALTextureType::TextureCubeArray) ? (description.m_uiArraySize * 6) : description.m_uiArraySize;
+  const ezUInt32 mipLevels = description.m_uiMipLevelCount;
 
   subResourceSizes.Reserve(arrayLayers * mipLevels);
   ezUInt32 uiOffset = 0;
@@ -281,7 +225,7 @@ ezUInt32 ezGALTextureVulkan::ComputeSubResourceOffsets(ezDynamicArray<SubResourc
       const ezUInt32 uiSubresourceIndex = uiMipLevel + uiLayer * mipLevels;
       EZ_ASSERT_DEBUG(subResourceSizes.GetCount() == uiSubresourceIndex, "");
 
-      const vk::Extent3D imageExtent = GetMipLevelSize(uiMipLevel);
+      const vk::Extent3D imageExtent = GetMipLevelSize(description, uiMipLevel);
       const VkExtent3D blockCount = {
         (imageExtent.width + blockExtent[0] - 1) / blockExtent[0],
         (imageExtent.height + blockExtent[1] - 1) / blockExtent[1],
@@ -295,69 +239,15 @@ ezUInt32 ezGALTextureVulkan::ComputeSubResourceOffsets(ezDynamicArray<SubResourc
   return uiOffset;
 }
 
-ezResult ezGALTextureVulkan::CreateStagingBuffer(const vk::ImageCreateInfo& createInfo)
-{
-  m_stagingMode = ezGALTextureVulkan::ComputeStagingMode(m_pDevice, m_Description, createInfo);
-  if (m_stagingMode == StagingMode::Texture || m_stagingMode == StagingMode::TextureAndBuffer)
-  {
-    ezGALTextureCreationDescription stagingDesc = m_Description;
-    stagingDesc.m_SampleCount = ezGALMSAASampleCount::None;
-    stagingDesc.m_bAllowShaderResourceView = false;
-    stagingDesc.m_bAllowUAV = false;
-    stagingDesc.m_bCreateRenderTarget = true;
-    stagingDesc.m_bAllowDynamicMipGeneration = false;
-    stagingDesc.m_ResourceAccess.m_bReadBack = false;
-    stagingDesc.m_ResourceAccess.m_bImmutable = false;
-    stagingDesc.m_pExisitingNativeObject = nullptr;
-
-    const bool bLinearCPU = m_stagingMode == StagingMode::Texture;
-
-    m_hStagingTexture = m_pDevice->CreateTextureInternal(stagingDesc, {}, bLinearCPU, true);
-    if (m_hStagingTexture.IsInvalidated())
-    {
-      ezLog::Error("Failed to create staging texture for read-back");
-      return EZ_FAILURE;
-    }
-  }
-  if (m_stagingMode == StagingMode::Buffer || m_stagingMode == StagingMode::TextureAndBuffer)
-  {
-    ezGALBufferCreationDescription stagingBuffer;
-    stagingBuffer.m_BufferFlags = ezGALBufferUsageFlags::ByteAddressBuffer;
-    ezHybridArray<SubResourceOffset, 8> subResourceSizes;
-    stagingBuffer.m_uiTotalSize = ComputeSubResourceOffsets(subResourceSizes);
-    stagingBuffer.m_uiStructSize = 1;
-
-    stagingBuffer.m_ResourceAccess.m_bImmutable = false;
-
-    m_hStagingBuffer = m_pDevice->CreateBufferInternal(stagingBuffer, {}, true);
-    if (m_hStagingBuffer.IsInvalidated())
-    {
-      ezLog::Error("Failed to create staging buffer for read-back");
-      return EZ_FAILURE;
-    }
-  }
-
-  return EZ_SUCCESS;
-}
 ezResult ezGALTextureVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
   ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   if (m_image && !m_Description.m_pExisitingNativeObject)
   {
     pVulkanDevice->DeleteLater(m_image, m_alloc);
+    m_allocInfo = {};
   }
   m_image = nullptr;
-
-  if (!m_hStagingTexture.IsInvalidated())
-  {
-    pDevice->DestroyTexture(m_hStagingTexture);
-    m_hStagingTexture.Invalidate();
-  }
-  if (!m_hStagingBuffer.IsInvalidated())
-  {
-    pDevice->DestroyBuffer(m_hStagingBuffer);
-    m_hStagingBuffer.Invalidate();
-  }
 
   return EZ_SUCCESS;
 }
@@ -365,14 +255,4 @@ ezResult ezGALTextureVulkan::DeInitPlatform(ezGALDevice* pDevice)
 void ezGALTextureVulkan::SetDebugNamePlatform(const char* szName) const
 {
   m_pDevice->SetDebugName(szName, m_image, m_alloc);
-  if (!m_hStagingTexture.IsInvalidated())
-  {
-    auto pStagingTexture = static_cast<const ezGALTextureVulkan*>(m_pDevice->GetTexture(m_hStagingTexture));
-    pStagingTexture->SetDebugName(szName);
-  }
-  if (!m_hStagingBuffer.IsInvalidated())
-  {
-    auto pStagingBuffer = static_cast<const ezGALBufferVulkan*>(m_pDevice->GetBuffer(m_hStagingBuffer));
-    pStagingBuffer->SetDebugName(szName);
-  }
 }

--- a/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/TextureVulkan_inl.h
@@ -34,23 +34,3 @@ const ezVulkanAllocationInfo& ezGALTextureVulkan::GetAllocationInfo() const
 {
   return m_allocInfo;
 }
-
-bool ezGALTextureVulkan::IsLinearLayout() const
-{
-  return m_bLinearCPU;
-}
-
-ezGALTextureVulkan::StagingMode ezGALTextureVulkan::GetStagingMode() const
-{
-  return m_stagingMode;
-}
-
-ezGALTextureHandle ezGALTextureVulkan::GetStagingTexture() const
-{
-  return m_hStagingTexture;
-}
-
-ezGALBufferHandle ezGALTextureVulkan::GetStagingBuffer() const
-{
-  return m_hStagingBuffer;
-}

--- a/Code/Engine/RendererVulkan/Resources/ReadbackBufferVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/ReadbackBufferVulkan.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <RendererFoundation/Resources/ReadbackBuffer.h>
+
+#include <vulkan/vulkan.hpp>
+
+class ezGALDeviceVulkan;
+
+class ezGALReadbackBufferVulkan : public ezGALReadbackBuffer
+{
+public:
+  EZ_ALWAYS_INLINE vk::Buffer GetVkBuffer() const { return m_buffer; }
+  EZ_ALWAYS_INLINE ezVulkanAllocation GetAllocation() const { return m_alloc; }
+  EZ_ALWAYS_INLINE const ezVulkanAllocationInfo& GetAllocationInfo() const { return m_allocInfo; }
+
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  ezGALReadbackBufferVulkan(const ezGALBufferCreationDescription& Description);
+  virtual ~ezGALReadbackBufferVulkan();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void SetDebugNamePlatform(const char* szName) const override;
+
+protected:
+  vk::Buffer m_buffer = {};
+  vk::DeviceSize m_size = 0;
+  ezVulkanAllocation m_alloc = {};
+  ezVulkanAllocationInfo m_allocInfo = {};
+
+  ezGALDeviceVulkan* m_pDeviceVulkan = nullptr;
+};

--- a/Code/Engine/RendererVulkan/Resources/ReadbackTextureVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/ReadbackTextureVulkan.h
@@ -13,7 +13,7 @@ class ezGALReadbackTextureVulkan : public ezGALReadbackTexture
 {
 public:
   EZ_ALWAYS_INLINE vk::Buffer GetVkBuffer() const { return m_buffer; }
-  EZ_ALWAYS_INLINE ezVulkanAllocation GetBufferAllocation() const { return m_bufferAlloc;}
+  EZ_ALWAYS_INLINE ezVulkanAllocation GetBufferAllocation() const { return m_bufferAlloc; }
 
 protected:
   friend class ezGALDeviceVulkan;

--- a/Code/Engine/RendererVulkan/Resources/ReadbackTextureVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/ReadbackTextureVulkan.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <RendererFoundation/Resources/ReadbackTexture.h>
+
+#include <RendererVulkan/Resources/TextureVulkan.h>
+
+#include <vulkan/vulkan.hpp>
+
+class ezGALBufferVulkan;
+class ezGALDeviceVulkan;
+
+class ezGALReadbackTextureVulkan : public ezGALReadbackTexture
+{
+public:
+  EZ_ALWAYS_INLINE vk::Buffer GetVkBuffer() const { return m_buffer; }
+  EZ_ALWAYS_INLINE ezVulkanAllocation GetBufferAllocation() const { return m_bufferAlloc;}
+
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  ezGALReadbackTextureVulkan(const ezGALTextureCreationDescription& Description);
+  ~ezGALReadbackTextureVulkan();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void SetDebugNamePlatform(const char* szName) const override;
+
+protected:
+  vk::Buffer m_buffer = {};
+  ezVulkanAllocation m_bufferAlloc;
+  ezVulkanAllocationInfo m_bufferAllocInfo;
+
+  ezGALDeviceVulkan* m_pDevice = nullptr;
+};

--- a/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/PipelineBarrierVulkan.h
@@ -75,6 +75,10 @@ public:
   bool IsDirty(vk::Image image, const vk::ImageSubresourceRange& subResources) const;
   ///@}
 
+  bool AddBufferBarrierInternal(vk::Buffer buffer, vk::DeviceSize offset, vk::DeviceSize length,
+    vk::PipelineStageFlags srcStages, vk::AccessFlags srcAccess,
+    vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess);
+
 private:
   struct SubElementState
   {
@@ -110,9 +114,6 @@ private:
     ezHybridArray<SubBufferState, 1> m_subBufferState;
   };
 
-  bool AddBufferBarrierInternal(vk::Buffer buffer, vk::DeviceSize offset, vk::DeviceSize length,
-    vk::PipelineStageFlags srcStages, vk::AccessFlags srcAccess,
-    vk::PipelineStageFlags dstStages, vk::AccessFlags dstAccess);
   bool IsDirtyInternal(const BufferState& state, const SubBufferState& subState) const;
 
   bool AddImageBarrierInternal(vk::Image image, const vk::ImageSubresourceRange& subResources,

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/Extractor.cpp
@@ -153,7 +153,7 @@ namespace ezRmlUiInternal
     if (!hTexture.IsValid())
     {
       ezGALSystemMemoryDescription memoryDesc;
-      memoryDesc.m_pData = const_cast<Rml::byte*>(pSource);
+      memoryDesc.m_pData = ezMakeByteBlobPtr(pSource, uiSizeInBytes);
       memoryDesc.m_uiRowPitch = uiWidth * 4;
       memoryDesc.m_uiSlicePitch = uiSizeInBytes;
 

--- a/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
+++ b/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
@@ -112,7 +112,6 @@ public:
       ezGALWindowSwapChainCreationDescription swapChainDesc;
       swapChainDesc.m_pWindow = m_pWindow;
       swapChainDesc.m_SampleCount = ezGALMSAASampleCount::None;
-      swapChainDesc.m_bAllowScreenshots = true;
       m_hSwapChain = ezGALWindowSwapChain::Create(swapChainDesc);
 
       const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -446,7 +446,6 @@ void ezShaderExplorerApp::UpdateSwapChain()
     ezGALWindowSwapChainCreationDescription swapChainDesc;
     swapChainDesc.m_pWindow = m_pWindow;
     swapChainDesc.m_SampleCount = ezGALMSAASampleCount::None;
-    swapChainDesc.m_bAllowScreenshots = true;
     swapChainDesc.m_InitialPresentMode = ezGALPresentMode::VSync;
     m_hSwapChain = ezGALWindowSwapChain::Create(swapChainDesc);
   }

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -184,7 +184,6 @@ public:
       ezGALWindowSwapChainCreationDescription swapChainDesc;
       swapChainDesc.m_pWindow = m_pWindow;
       swapChainDesc.m_SampleCount = ezGALMSAASampleCount::None;
-      swapChainDesc.m_bAllowScreenshots = true;
       m_hSwapChain = ezGALWindowSwapChain::Create(swapChainDesc);
 
       const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);

--- a/Code/ThirdParty/ozz/animation/runtime/local_to_model_job.cc
+++ b/Code/ThirdParty/ozz/animation/runtime/local_to_model_job.cc
@@ -104,7 +104,10 @@ bool LocalToModelJob::Run() const {
       const int parent = parents[i];
       const math::Float4x4* parent_matrix =
           parent == Skeleton::kNoParent ? root_matrix : &output[parent];
-      output[i] = *parent_matrix * local_aos_matrices[i & 3];
+
+      // EZ Workaround for Visual Studio debug build compiler bug.
+      auto parent_matrix_cpy = *parent_matrix;
+      output[i] = parent_matrix_cpy * local_aos_matrices[i & 3];
     }
   }
   return true;

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -510,11 +510,11 @@ void ezRendererTestAdvancedFeatures::FloatSampling()
     {
       ezGALCommandEncoder* pCommandEncoder = BeginRendering(ezColor::RebeccaPurple, 0xFFFFFFFF, &viewport);
       RenderObject(m_hCubeUV, mMVP, ezColor(1, 1, 1, 1), ezShaderBindFlags::None);
+      EndRendering();
       if (m_ImgCompFrames.Contains(m_iFrame))
       {
         EZ_TEST_IMAGE(m_iFrame, 100);
       }
-      EndRendering();
     }
   }
   EndCommands();
@@ -608,12 +608,11 @@ void ezRendererTestAdvancedFeatures::VertexShaderRenderTargetArrayIndex()
     ezRenderContext::GetDefaultInstance()->BindMeshBuffer(ezGALBufferHandle(), ezGALBufferHandle(), nullptr, ezGALPrimitiveTopology::Triangles, 1);
     ezRenderContext::GetDefaultInstance()->DrawMeshBuffer().AssertSuccess();
 
+    EndRendering();
     if (m_bCaptureImage && m_ImgCompFrames.Contains(m_iFrame))
     {
       EZ_TEST_IMAGE(m_iFrame, 100);
     }
-
-    EndRendering();
   }
   EndCommands();
 }
@@ -628,11 +627,12 @@ void ezRendererTestAdvancedFeatures::Tessellation()
     ezRectFloat viewport = ezRectFloat(0, 0, fWidth, fHeight);
     ezGALCommandEncoder* pCommandEncoder = BeginRendering(ezColor::RebeccaPurple, 0xFFFFFFFF, &viewport);
     RenderObject(m_hSphereMesh, mMVP, ezColor(1, 1, 1, 1), ezShaderBindFlags::None);
+
+    EndRendering();
     if (m_ImgCompFrames.Contains(m_iFrame))
     {
       EZ_TEST_IMAGE(m_iFrame, 100);
     }
-    EndRendering();
   }
   EndCommands();
 }
@@ -731,7 +731,7 @@ ezTestAppRun ezRendererTestAdvancedFeatures::SharedTexture()
       ezRenderContext::GetDefaultInstance()->BindTexture2D("DiffuseTexture", m_pDevice->GetDefaultResourceView(m_hSharedTextures[texture.m_uiCurrentTextureIndex]));
       RenderObject(m_hCubeUV, mMVP, ezColor(1, 1, 1, 1), ezShaderBindFlags::None);
 
-
+      EndRendering();
       if (!m_bExiting && m_uiReceivedTextures > 10)
       {
         EZ_TEST_IMAGE(0, 10);
@@ -740,7 +740,6 @@ ezTestAppRun ezRendererTestAdvancedFeatures::SharedTexture()
         EZ_TEST_BOOL(m_pProtocol->Send(&msg));
         m_bExiting = true;
       }
-      EndRendering();
     }
     EndCommands();
 

--- a/Code/UnitTests/RendererTest/Basics/Basics.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Basics.cpp
@@ -68,8 +68,8 @@ ezTestAppRun ezRendererTestBasics::SubtestClearScreen()
       break;
   }
 
-  EZ_TEST_IMAGE(m_iFrame, 1);
   EndRendering();
+  EZ_TEST_IMAGE(m_iFrame, 1);
   EndCommands();
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/Basics/BlendStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/BlendStates.cpp
@@ -41,8 +41,8 @@ ezTestAppRun ezRendererTestBasics::SubtestBlendStates()
 
   RenderObjects(ezShaderBindFlags::NoBlendState);
 
-  EZ_TEST_IMAGE(m_iFrame, 150);
   EndRendering();
+  EZ_TEST_IMAGE(m_iFrame, 150);
   EndCommands();
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/Basics/LineRendering.cpp
+++ b/Code/UnitTests/RendererTest/Basics/LineRendering.cpp
@@ -12,8 +12,8 @@ ezTestAppRun ezRendererTestBasics::SubtestLineRendering()
 
   RenderLineObjects(ezShaderBindFlags::Default);
 
-  EZ_TEST_LINE_IMAGE(0, 150);
   EndRendering();
+  EZ_TEST_LINE_IMAGE(0, 150);
   EndCommands();
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -208,7 +208,7 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
     for (ezUInt32 m = 0; m < desc.m_uiMipLevelCount; m++)
     {
       ezGALSystemMemoryDescription& memoryDesc = initialData[m];
-      memoryDesc.m_pData = coloredMips.GetPixelPointer<ezUInt8>(m);
+      memoryDesc.m_pData = coloredMips.GetSubImageView(m).GetByteBlobPtr();
       memoryDesc.m_uiRowPitch = static_cast<ezUInt32>(coloredMips.GetRowPitch(m));
       memoryDesc.m_uiSlicePitch = static_cast<ezUInt32>(coloredMips.GetDepthPitch(m));
     }
@@ -248,7 +248,8 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
       for (ezUInt32 m = 0; m < desc.m_uiMipLevelCount; m++)
       {
         ezGALSystemMemoryDescription& memoryDesc = initialData[m + l * desc.m_uiMipLevelCount];
-        memoryDesc.m_pData = coloredMips[l].GetPixelPointer<ezUInt8>(m);
+
+        memoryDesc.m_pData = coloredMips[l].GetSubImageView(m).GetByteBlobPtr();
         memoryDesc.m_uiRowPitch = static_cast<ezUInt32>(coloredMips[l].GetRowPitch(m));
         memoryDesc.m_uiSlicePitch = static_cast<ezUInt32>(coloredMips[l].GetDepthPitch(m));
       }
@@ -465,11 +466,11 @@ void ezRendererTestPipelineStates::RenderBlock(ezMeshBufferResourceHandle mesh, 
       }
     }
 
+    EndRendering();
     if (m_bCaptureImage && m_ImgCompFrames.Contains(m_iFrame))
     {
       EZ_TEST_IMAGE(m_iFrame, 100);
     }
-    EndRendering();
   }
 
   EndCommands();
@@ -549,11 +550,11 @@ void ezRendererTestPipelineStates::PushConstantsTest()
         }
       }
     }
+    EndRendering();
     if (m_ImgCompFrames.Contains(m_iFrame))
     {
       EZ_TEST_IMAGE(m_iFrame, 100);
     }
-    EndRendering();
   }
   EndCommands();
 }
@@ -623,11 +624,11 @@ void ezRendererTestPipelineStates::ConstantBufferTest()
         }
       }
     }
+    EndRendering();
     if (m_ImgCompFrames.Contains(m_iFrame))
     {
       EZ_TEST_IMAGE(m_iFrame, 100);
     }
-    EndRendering();
   }
   EndCommands();
 }
@@ -681,11 +682,11 @@ void ezRendererTestPipelineStates::StructuredBufferTest()
         pContext->DrawMeshBuffer(1, 0, 4).AssertSuccess();
       }
     }
-    if (m_ImgCompFrames.Contains(m_iFrame))
-    {
-      EZ_TEST_IMAGE(m_iFrame, 100);
-    }
-    EndRendering();
+  }
+  EndRendering();
+  if (m_ImgCompFrames.Contains(m_iFrame))
+  {
+    EZ_TEST_IMAGE(m_iFrame, 100);
   }
   EndCommands();
 }

--- a/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
@@ -126,6 +126,7 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
 
   RenderObjects(ezShaderBindFlags::NoRasterizerState);
 
+  EndRendering();
   if (RasterStateDesc.m_bWireFrame)
   {
     ezStringView sRendererName = m_pDevice->GetRenderer();
@@ -135,7 +136,6 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
   }
   else
     EZ_TEST_IMAGE(m_iFrame, 200);
-  EndRendering();
   EndCommands();
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -257,7 +257,7 @@ ezTestAppRun ezRendererTestReadback::Readback(ezUInt32 uiInvocationCount)
         ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
         ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
         EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
-        ezTextureUtils::CreateSubResourceImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], readBackResult, false);
+        ezTextureUtils::CopySubResourceToImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], readBackResult, false);
       }
 
       {

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -71,9 +71,7 @@ ezResult ezRendererTestReadback::InitializeSubTest(ezInt32 iIdentifier)
   {
     m_Format = (ezGALResourceFormat::Enum)iIdentifier;
     ezGALTextureCreationDescription desc;
-    desc.SetAsRenderTarget(8, 8, m_Format,
-      ezGALMSAASampleCount::None);
-    desc.m_ResourceAccess.m_bReadBack = true;
+    desc.SetAsRenderTarget(8, 8, m_Format, ezGALMSAASampleCount::None);
     m_hTexture2DReadback = m_pDevice->CreateTexture(desc);
 
     EZ_ASSERT_DEBUG(!m_hTexture2DReadback.IsInvalidated(), "Failed to create readback texture");
@@ -84,6 +82,7 @@ ezResult ezRendererTestReadback::InitializeSubTest(ezInt32 iIdentifier)
 
 ezResult ezRendererTestReadback::DeInitializeSubTest(ezInt32 iIdentifier)
 {
+  m_Readback.Reset();
   m_ReadBackResult.Clear();
   if (!m_hTexture2DReadback.IsInvalidated())
   {
@@ -237,37 +236,37 @@ ezTestAppRun ezRendererTestReadback::Readback(ezUInt32 uiInvocationCount)
 
     // Queue readback
     {
-      m_pEncoder->BeginRendering(ezGALRenderingSetup());
-      m_pEncoder->ReadbackTexture(m_hTexture2DReadback);
-      m_pEncoder->EndRendering();
+      m_Readback.ReadbackTexture(*m_pEncoder, m_hTexture2DReadback);
+    }
+
+    // Wait for results
+    {
+      ezEnum<ezGALAsyncResult> res = m_Readback.GetReadbackResult(ezTime::MakeFromHours(1));
+      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
     }
 
     // Readback result
     {
       m_bReadbackInProgress = false;
-      m_pEncoder->BeginRendering(ezGALRenderingSetup());
 
       const ezGALTexture* pBackbuffer = ezGALDevice::GetDefaultDevice()->GetTexture(m_hTexture2DReadback);
-      const ezEnum<ezGALResourceFormat> format = pBackbuffer->GetDescription().m_Format;
-
-      ezImageHeader header;
-      header.SetWidth(pBackbuffer->GetDescription().m_uiWidth);
-      header.SetHeight(pBackbuffer->GetDescription().m_uiHeight);
-      header.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(format, false));
       ezImage readBackResult;
-      readBackResult.ResetAndAlloc(header);
-
-      ezGALSystemMemoryDescription MemDesc;
-      MemDesc.m_pData = readBackResult.GetPixelPointer<ezUInt8>();
-      MemDesc.m_uiRowPitch = static_cast<ezUInt32>(readBackResult.GetRowPitch());
-      MemDesc.m_uiSlicePitch = static_cast<ezUInt32>(readBackResult.GetDepthPitch());
-
-      ezArrayPtr<ezGALSystemMemoryDescription> SysMemDescs(&MemDesc, 1);
-      ezGALTextureSubresource sourceSubResource;
-      ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
-      m_pEncoder->CopyTextureReadbackResult(m_hTexture2DReadback, sourceSubResources, SysMemDescs);
+      {
+        ezGALTextureSubresource sourceSubResource;
+        ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
+        ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
+        ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
+        EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+        ezTextureUtils::CreateSubResourceImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], readBackResult, false);
+      }
 
       {
+        ezGALSystemMemoryDescription MemDesc;
+        MemDesc.m_pData = readBackResult.GetByteBlobPtr();
+        MemDesc.m_uiRowPitch = static_cast<ezUInt32>(readBackResult.GetRowPitch());
+        MemDesc.m_uiSlicePitch = static_cast<ezUInt32>(readBackResult.GetDepthPitch());
+        ezArrayPtr<ezGALSystemMemoryDescription> SysMemDescs(&MemDesc, 1);
+
         ezGALTextureCreationDescription desc;
         desc.m_uiWidth = 8;
         desc.m_uiHeight = 8;
@@ -310,10 +309,6 @@ ezTestAppRun ezRendererTestReadback::Readback(ezUInt32 uiInvocationCount)
         }
       }
       CompareReadbackImage(std::move(readBackResult));
-
-
-
-      m_pEncoder->EndRendering();
     }
     EndCommands();
   }
@@ -340,8 +335,8 @@ ezTestAppRun ezRendererTestReadback::Readback(ezUInt32 uiInvocationCount)
       ezGALCommandEncoder* pCommandEncoder = BeginRendering(ezColor::RebeccaPurple, 0, &viewport);
       ezRenderContext::GetDefaultInstance()->BindTexture2D("DiffuseTexture", m_pDevice->GetDefaultResourceView(m_hTexture2DUpload));
       RenderObject(m_hCubeUV, mMVP, ezColor(1, 1, 1, 1), ezShaderBindFlags::None);
-      CompareUploadImage();
       EndRendering();
+      CompareUploadImage();
     }
   }
   EndCommands();

--- a/Code/UnitTests/RendererTest/Basics/Readback.h
+++ b/Code/UnitTests/RendererTest/Basics/Readback.h
@@ -49,4 +49,5 @@ private:
   mutable ezImage m_ReadBackResult;
   mutable ezString m_sReadBackReferenceImage;
   bool m_bReadbackInProgress = true;
+  ezGALReadbackTextureHelper m_Readback;
 };

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
@@ -1,0 +1,185 @@
+#include <RendererTest/RendererTestPCH.h>
+
+#include <Core/GameState/GameStateWindow.h>
+#include <Core/Graphics/Camera.h>
+#include <Foundation/Configuration/Startup.h>
+#include <Foundation/Reflection/ReflectionUtils.h>
+#include <RendererCore/Textures/TextureUtils.h>
+#include <RendererFoundation/RendererReflection.h>
+#include <RendererFoundation/Resources/Texture.h>
+#include <RendererTest/Basics/ReadbackBuffer.h>
+
+void ezRendererTestReadbackBuffer::SetupSubTests()
+{
+  ezStartup::StartupCoreSystems();
+  SetupRenderer().AssertSuccess();
+
+  const ezGALDeviceCapabilities& caps = ezGALDevice::GetDefaultDevice()->GetCapabilities();
+
+  AddSubTest("VertexBuffer", SubTests::ST_VertexBuffer);
+  AddSubTest("IndexBuffer", SubTests::ST_IndexBuffer);
+  if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bSupportsTexelBuffer)
+  {
+    AddSubTest("TexelBuffer", SubTests::ST_TexelBuffer);
+  }
+  AddSubTest("StructuredBuffer", SubTests::ST_StructuredBuffer);
+
+  ShutdownRenderer();
+  ezStartup::ShutdownCoreSystems();
+}
+
+ezResult ezRendererTestReadbackBuffer::InitializeSubTest(ezInt32 iIdentifier)
+{
+  m_iFrame = -1;
+  m_bReadbackInProgress = true;
+
+  EZ_SUCCEED_OR_RETURN(ezGraphicsTest::InitializeSubTest(iIdentifier));
+  EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
+
+  // m_hUVColorShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackFloat.ezShader");
+
+  switch (iIdentifier)
+  {
+    case ST_VertexBuffer:
+    {
+      ezDynamicArray<float> data;
+      data.SetCountUninitialized(128);
+      for (ezUInt32 i = 0; i < 128; i++)
+      {
+        data[i] = (float)i;
+      }
+      m_BufferData = data.GetByteArrayPtr();
+
+      m_hBufferReadback = m_pDevice->CreateVertexBuffer(4 * sizeof(float), 32, m_BufferData.GetByteArrayPtr());
+      EZ_ASSERT_DEBUG(!m_hBufferReadback.IsInvalidated(), "Failed to create buffer");
+    }
+    break;
+    case ST_IndexBuffer:
+    {
+      ezDynamicArray<ezUInt32> data;
+      data.SetCountUninitialized(128);
+      for (ezUInt32 i = 0; i < 128; i++)
+      {
+        data[i] = i;
+      }
+      m_BufferData = data.GetByteArrayPtr();
+
+      m_hBufferReadback = m_pDevice->CreateIndexBuffer(ezGALIndexType::UInt, 128, m_BufferData.GetByteArrayPtr());
+      EZ_ASSERT_DEBUG(!m_hBufferReadback.IsInvalidated(), "Failed to create buffer");
+    }
+    break;
+    case ST_TexelBuffer:
+    {
+      ezDynamicArray<ezUInt32> data;
+      data.SetCountUninitialized(128);
+      for (ezUInt32 i = 0; i < 128; i++)
+      {
+        data[i] = i;
+      }
+      m_BufferData = data.GetByteArrayPtr();
+
+      ezGALBufferCreationDescription desc;
+      desc.m_uiStructSize = sizeof(ezUInt32);
+      desc.m_uiTotalSize = 128 * desc.m_uiStructSize;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::TexelBuffer | ezGALBufferUsageFlags::ShaderResource;
+      desc.m_Format = ezGALResourceFormat::RGBAUByteNormalized;
+      desc.m_ResourceAccess.m_bImmutable = false;
+      m_hBufferReadback = m_pDevice->CreateBuffer(desc, m_BufferData.GetByteArrayPtr());
+      EZ_ASSERT_DEBUG(!m_hBufferReadback.IsInvalidated(), "Failed to create buffer");
+    }
+    break;
+    case ST_StructuredBuffer:
+    {
+      ezDynamicArray<ezColor> data;
+      data.SetCountUninitialized(128);
+      for (ezUInt32 i = 0; i < 128; i++)
+      {
+        data[i] = ezColor::MakeFromKelvin(1000 + 10 * i);
+      }
+      m_BufferData = data.GetByteArrayPtr();
+
+      ezGALBufferCreationDescription desc;
+      desc.m_uiStructSize = sizeof(ezColor);
+      desc.m_uiTotalSize = 128 * desc.m_uiStructSize;
+      desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
+      desc.m_ResourceAccess.m_bImmutable = false;
+      m_hBufferReadback = m_pDevice->CreateBuffer(desc, m_BufferData.GetByteArrayPtr());
+      EZ_ASSERT_DEBUG(!m_hBufferReadback.IsInvalidated(), "Failed to create buffer");
+    }
+    break;
+    default:
+      break;
+  }
+  
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestReadbackBuffer::DeInitializeSubTest(ezInt32 iIdentifier)
+{
+  m_Readback.Reset();
+  if (!m_hBufferReadback.IsInvalidated())
+  {
+    m_pDevice->DestroyBuffer(m_hBufferReadback);
+    m_hBufferReadback.Invalidate();
+  }
+ 
+  m_hComputeShader.Invalidate();
+ 
+  DestroyWindow();
+
+  if (ezGraphicsTest::DeInitializeSubTest(iIdentifier).Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+ezTestAppRun ezRendererTestReadbackBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+{
+  m_iFrame = uiInvocationCount;
+  m_bCaptureImage = false;
+  BeginFrame();
+  ezTestAppRun res = ReadbackBuffer(uiInvocationCount);
+  EndFrame();
+  return res;
+}
+
+
+ezTestAppRun ezRendererTestReadbackBuffer::ReadbackBuffer(ezUInt32 uiInvocationCount)
+{
+  if (m_iFrame == 1)
+  {
+    BeginCommands("Readback Buffer");
+    // Queue readback
+    {
+      m_bReadbackInProgress = true;
+      m_Readback.ReadbackBuffer(*m_pEncoder, m_hBufferReadback);
+    }
+
+    // Wait for results
+    {
+      ezEnum<ezGALAsyncResult> res = m_Readback.GetReadbackResult(ezTime::MakeFromHours(1));
+      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+    }
+
+    // Readback result
+    {
+      m_bReadbackInProgress = false;
+      {
+        ezArrayPtr<const ezUInt8> memory;
+        ezReadbackBufferLock lock = m_Readback.LockBuffer(memory);
+        EZ_ASSERT_ALWAYS(lock, "Failed to lock readback buffer");
+
+        if (EZ_TEST_INT(memory.GetCount(), m_BufferData.GetCount()))
+        {
+          EZ_TEST_INT(ezMemoryUtils::Compare(memory.GetPtr(), m_BufferData.GetData(), memory.GetCount()), 0);
+        }
+      }
+
+    }
+    EndCommands();
+  }
+
+  return m_bReadbackInProgress ? ezTestAppRun::Continue : ezTestAppRun::Quit;
+}
+
+static ezRendererTestReadbackBuffer g_ReadbackTest;

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
@@ -181,4 +181,4 @@ ezTestAppRun ezRendererTestReadbackBuffer::ReadbackBuffer(ezUInt32 uiInvocationC
   return m_bReadbackInProgress ? ezTestAppRun::Continue : ezTestAppRun::Quit;
 }
 
-static ezRendererTestReadbackBuffer g_ReadbackTest;
+static ezRendererTestReadbackBuffer g_ReadbackBufferTest;

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
@@ -110,7 +110,7 @@ ezResult ezRendererTestReadbackBuffer::InitializeSubTest(ezInt32 iIdentifier)
     default:
       break;
   }
-  
+
   return EZ_SUCCESS;
 }
 
@@ -122,9 +122,9 @@ ezResult ezRendererTestReadbackBuffer::DeInitializeSubTest(ezInt32 iIdentifier)
     m_pDevice->DestroyBuffer(m_hBufferReadback);
     m_hBufferReadback.Invalidate();
   }
- 
+
   m_hComputeShader.Invalidate();
- 
+
   DestroyWindow();
 
   if (ezGraphicsTest::DeInitializeSubTest(iIdentifier).Failed())
@@ -174,7 +174,6 @@ ezTestAppRun ezRendererTestReadbackBuffer::ReadbackBuffer(ezUInt32 uiInvocationC
           EZ_TEST_INT(ezMemoryUtils::Compare(memory.GetPtr(), m_BufferData.GetData(), memory.GetCount()), 0);
         }
       }
-
     }
     EndCommands();
   }

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.h
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "../TestClass/TestClass.h"
+#include <RendererCore/Textures/Texture2DResource.h>
+
+/// \brief Tests texture readback from the GPU
+///
+/// Only renderable textures are tested.
+/// The test first renders a pattern into the 8x8 texture.
+/// Then the texture is read back and uploaded again to another texture.
+/// The readback result is converted to RGBA32float and compared to a reference image. As these only change depending on channel count the MapImageNumberToString function is overwritten to always point to the same images.
+/// Finally the original an re-uploaded texture is rendered to the screen and the result is again compared to a reference image.
+///
+/// The subtest list is dynamic, only formats that support render and sample are tested.
+class ezRendererTestReadbackBuffer : public ezGraphicsTest
+{
+  using SUPER = ezGraphicsTest;
+
+public:
+  virtual const char* GetTestName() const override { return "Readback Buffer"; }
+
+private:
+  enum SubTests
+  {
+    ST_VertexBuffer,
+    ST_IndexBuffer,
+    ST_TexelBuffer,
+    ST_StructuredBuffer,
+  };
+
+  virtual void SetupSubTests() override;
+
+  virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
+  virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
+  virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+  ezTestAppRun ReadbackBuffer(ezUInt32 uiInvocationCount);
+
+private:
+  ezShaderResourceHandle m_hComputeShader;
+
+  ezDynamicArray<ezUInt8> m_BufferData;
+  ezGALBufferHandle m_hBufferReadback;
+  bool m_bReadbackInProgress = true;
+  ezGALReadbackBufferHelper m_Readback;
+};

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
@@ -28,7 +28,6 @@ ezResult ezRendererTestSwapChain::InitializeSubTest(ezInt32 iIdentifier)
     ezGALWindowSwapChainCreationDescription swapChainDesc;
     swapChainDesc.m_pWindow = m_pWindow;
     swapChainDesc.m_SampleCount = ezGALMSAASampleCount::None;
-    swapChainDesc.m_bAllowScreenshots = true;
     swapChainDesc.m_InitialPresentMode = (iIdentifier == SubTests::ST_NoVSync) ? ezGALPresentMode::Immediate : ezGALPresentMode::VSync;
     m_hSwapChain = ezGALWindowSwapChain::Create(swapChainDesc);
   }

--- a/Code/UnitTests/RendererTest/Basics/Textures.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Textures.cpp
@@ -114,10 +114,9 @@ ezTestAppRun ezRendererTestBasics::SubtestTextures2D()
   if (bSupported)
   {
     RenderObjects(ezShaderBindFlags::Default);
-
-    EZ_TEST_IMAGE(m_iFrame, 300);
   }
   EndRendering();
+  EZ_TEST_IMAGE(m_iFrame, 300);
   EndCommands();
   EndFrame();
 
@@ -232,9 +231,8 @@ ezTestAppRun ezRendererTestBasics::SubtestTexturesCube()
 
   RenderObjects(ezShaderBindFlags::Default);
 
-  EZ_TEST_IMAGE(m_iFrame, 200);
-
   EndRendering();
+  EZ_TEST_IMAGE(m_iFrame, 200);
   EndCommands();
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -48,6 +48,7 @@ ezResult ezGraphicsTest::InitializeSubTest(ezInt32 iIdentifier)
 
 ezResult ezGraphicsTest::DeInitializeSubTest(ezInt32 iIdentifier)
 {
+  m_Readback.Reset();
   ShutdownRenderer();
   // shut down completely
   ezStartup::ShutdownCoreSystems();
@@ -177,6 +178,7 @@ ezResult ezGraphicsTest::SetupRenderer()
 
 void ezGraphicsTest::ShutdownRenderer()
 {
+  m_Readback.Reset();
   EZ_ASSERT_DEV(m_pWindow == nullptr, "DestroyWindow needs to be called before ShutdownRenderer");
   m_hShader.Invalidate();
   m_hCubeUV.Invalidate();
@@ -205,6 +207,9 @@ ezResult ezGraphicsTest::CreateWindow(ezUInt32 uiResolutionX, ezUInt32 uiResolut
     WindowCreationDesc.m_Resolution.width = uiResolutionX;
     WindowCreationDesc.m_Resolution.height = uiResolutionY;
     WindowCreationDesc.m_bShowMouseCursor = true;
+    WindowCreationDesc.m_bClipMouseCursor = false;
+    WindowCreationDesc.m_bSetForegroundOnInit = false;
+
     m_pWindow = EZ_DEFAULT_NEW(ezWindow);
     if (m_pWindow->Initialize(WindowCreationDesc).Failed())
       return EZ_FAILURE;
@@ -215,7 +220,6 @@ ezResult ezGraphicsTest::CreateWindow(ezUInt32 uiResolutionX, ezUInt32 uiResolut
     ezGALWindowSwapChainCreationDescription swapChainDesc;
     swapChainDesc.m_pWindow = m_pWindow;
     swapChainDesc.m_SampleCount = ezGALMSAASampleCount::None;
-    swapChainDesc.m_bAllowScreenshots = true;
     m_hSwapChain = ezGALWindowSwapChain::Create(swapChainDesc);
     if (m_hSwapChain.IsInvalidated())
     {
@@ -353,11 +357,11 @@ void ezGraphicsTest::RenderCube(ezRectFloat viewport, ezMat4 mMVP, ezUInt32 uiRe
 
   ezRenderContext::GetDefaultInstance()->BindTexture2D("DiffuseTexture", hSRV);
   RenderObject(m_hCubeUV, mMVP, ezColor(1, 1, 1, 1), ezShaderBindFlags::None);
+  EndRendering();
   if (m_bCaptureImage && m_ImgCompFrames.Contains(m_iFrame))
   {
     EZ_TEST_IMAGE(m_iFrame, 100);
   }
-  EndRendering();
 };
 
 
@@ -380,24 +384,20 @@ ezResult ezGraphicsTest::GetImage(ezImage& ref_img, const ezSubTestEntry& subTes
 
   ezGALTextureHandle hBBTexture = m_pDevice->GetSwapChain(m_hSwapChain)->GetBackBufferTexture();
   const ezGALTexture* pBackbuffer = ezGALDevice::GetDefaultDevice()->GetTexture(hBBTexture);
-  pCommandEncoder->ReadbackTexture(hBBTexture);
-  const ezEnum<ezGALResourceFormat> format = pBackbuffer->GetDescription().m_Format;
+  m_Readback.ReadbackTexture(*pCommandEncoder, hBBTexture);
+  pCommandEncoder->Flush();
+  // Wait for results
+  {
+    ezEnum<ezGALAsyncResult> res = m_Readback.GetReadbackResult(ezTime::MakeFromHours(1));
+    EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+  }
 
-  ezImageHeader header;
-  header.SetWidth(m_pWindow->GetClientAreaSize().width);
-  header.SetHeight(m_pWindow->GetClientAreaSize().height);
-  header.SetImageFormat(ezTextureUtils::GalFormatToImageFormat(format, true));
-  ref_img.ResetAndAlloc(header);
-
-  ezGALSystemMemoryDescription MemDesc;
-  MemDesc.m_pData = ref_img.GetPixelPointer<ezUInt8>();
-  MemDesc.m_uiRowPitch = 4 * m_pWindow->GetClientAreaSize().width;
-  MemDesc.m_uiSlicePitch = 4 * m_pWindow->GetClientAreaSize().width * m_pWindow->GetClientAreaSize().height;
-
-  ezArrayPtr<ezGALSystemMemoryDescription> SysMemDescs(&MemDesc, 1);
   ezGALTextureSubresource sourceSubResource;
   ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
-  pCommandEncoder->CopyTextureReadbackResult(hBBTexture, sourceSubResources, SysMemDescs);
+  ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
+  ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
+  EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+  ezTextureUtils::CreateSubResourceImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], ref_img, true);
 
   return EZ_SUCCESS;
 }

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -397,7 +397,7 @@ ezResult ezGraphicsTest::GetImage(ezImage& ref_img, const ezSubTestEntry& subTes
   ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
   ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
   EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
-  ezTextureUtils::CreateSubResourceImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], ref_img, true);
+  ezTextureUtils::CopySubResourceToImage(pBackbuffer->GetDescription(), sourceSubResource, memory[0], ref_img, true);
 
   return EZ_SUCCESS;
 }

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.h
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.h
@@ -7,6 +7,7 @@
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/ShaderCompiler/ShaderCompiler.h>
 #include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Resources/ReadbackHelper.h>
 #include <TestFramework/Framework/TestBaseClass.h>
 
 #undef CreateWindow
@@ -88,4 +89,5 @@ protected:
   ezInt32 m_iFrame = 0;
   bool m_bCaptureImage = false;
   ezHybridArray<ezUInt32, 8> m_ImgCompFrames;
+  ezGALReadbackTextureHelper m_Readback;
 };

--- a/Data/Base/Shaders/Particles/Point.ezShader
+++ b/Data/Base/Shaders/Particles/Point.ezShader
@@ -15,7 +15,12 @@ DepthWrite = true
 
 [SHADER]
 
+#include <Shaders/Common/Common.h>
+
 #define USE_COLOR0
+#if EZ_ENABLED(PLATFORM_VULKAN)
+  #define CUSTOM_INTERPOLATOR [[vk::builtin("PointSize")]] float PointSize : PSIZE;
+#endif
 
 [VERTEXSHADER]
 
@@ -46,11 +51,17 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
 
   ret.Position = screenPosition;
   ret.Color0 = UNPACKCOLOR4H(baseParticle.Color);
-
+#if EZ_ENABLED(PLATFORM_VULKAN)
+  ret.PointSize = 1.0;
+#endif
   return ret;
 }
 
 [GEOMETRYSHADER]
+
+#if EZ_ENABLED(PLATFORM_VULKAN)
+  #define CopyCustomInterpolators(output, input) output.PointSize = input.PointSize;
+#endif 
 
 #include <Shaders/Materials/MaterialStereoGeometryShader.h>
 


### PR DESCRIPTION
## Readback Changes

* The readback logic has been extracted from the `ezGALTexture` code and placed into its own resource: `ezGALReadbackTexture`. This has the benefit of not wasting memory on every potential texture you may want to readback at some point. An equivalent `ezGALReadbackBuffer` was created as well.
* Removed `ezGALWindowSwapChainCreationDescription::m_bAllowScreenshots` and `ezGALResourceAccess::m_bReadBack` as the texture resource itself no longer hold the readback staging resources. It is safe to potentially readback any resource, setting e.g. `vk::BufferUsageFlagBits::eTransferSrc` has no impact on performance.
* Readback of any kind is no longer allowed inside a rendering scope.
* A texture readback looks like this now:
```C++
ezGALTextureHandle hTexture = ...;
const ezGALTexture* pTexture = m_pDevice->GetTexture(hTexture);
// Create readback texture using the description of the texture you intent to read back:
ezGALReadbackTextureHandle hReadbackTexture = m_pDevice->CreateReadbackTexture(pTexture->GetDescription());
// Start the readback async operation
encoder.ReadbackTexture(m_hReadbackTexture, hTexture);
ezGALFenceHandle hFence = encoder.InsertFence();
...
// Once the fence has been reached, it is safe to lock the memory of the readback texture:
ezEnum<ezGALAsyncResult> res = pDevice->GetFenceResult(hFence);
if (res == ezGALAsyncResult::Ready)
{
    ezGALTextureSubresource sourceSubResource;
    ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
    ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
    ezReadbackTextureLock lock = m_Readback.LockTexture(sourceSubResources, memory);
    EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
    // Do something with the locked memory, e.g. create an ezImage:
    ezImage image;
    ezTextureUtils::CreateSubResourceImage(pTexture->GetDescription(), sourceSubResource, memory[0], image, true);
}
```
* A few helper functions have been added to make this easier:
  * `ezGALReadbackTextureHelper` and `ezGALReadbackBufferHelper` automate creation / destruction of the readback texture / buffer resource. They also ensure that you are not locking memory that still has a readback pending. The class allows repeated readbacks of resources of different formats - the underlying readback resource will be re-created if it is not suitable for the newly requested readback operation.
  * `ezTextureUtils::CreateSubResourceImage`: Copies the given texture subresource from a locked memory `ezGALSystemMemoryDescription`.
  * `ezTextureUtils::CreateSubResourceView`: Tries to create a texture view by aliasing the given locked memory `ezGALSystemMemoryDescription`. Falls back to `CreateSubResourceImage` if not possible.
  * `ezTextureUtils::CopySubResource`: Copies a texture subresource memory to a new location with a different row pitch.

## Misc

* `ezGALSystemMemoryDescription::m_pData` is now an `ezBlobPtr` instead of a raw ptr. This allows for sanity checks to prevent running out of the buffer memory.
* `ezBlobPtr` can now be initialized from an `ezArrayPtr<T>`.
* Fixed bug that moved the cursor even if `ezMouseCursorClipMode::NoClip` was set.
* Fixed data race in `ezReflectionPool::SetConstantSkyIrradiance`.
* Better barriers on vulkan buffer readback / upload.
* Fixed a bug in the Vulkan fence implementation that caused the wrong result to be returned when querying the fence status.
* Fixed a crash in Vulkan in case the timestamp pools runs out in the middle of a rendering scope. Turns out, you can't reset pools inside a rendering scope so for now we just ensure 3 free pools before entering any rendering scope.
* Worked around a Visual Studio compiler bug in ozz that caused an access violation reading 0xFFFFFFFFFFFF.
* Fixed `Point.ezShader` on Vulkan. Turns out, DX9 supported PSIZE vertex interpolator attribute, DX11 removed it and Vulkan requires it. So had to add an ifdef to the shader.