### PR TITLE
Fixed race condition in ezImageFormat registration

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsRenderer.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsRenderer.cmake
@@ -49,6 +49,13 @@ function(ez_add_renderers TARGET_NAME)
 		endif()
 	endif()
 
+	if(EZ_BUILD_EXPERIMENTAL_WEBGPU)
+		target_link_libraries(${TARGET_NAME}
+			PRIVATE
+			RendererWebGPU
+		)
+	endif()
+
 	if(EZ_CMAKE_PLATFORM_WINDOWS)
 		target_link_libraries(${TARGET_NAME}
 			PRIVATE

--- a/Code/Engine/Core/ActorSystem/ActorManager.h
+++ b/Code/Engine/Core/ActorSystem/ActorManager.h
@@ -62,7 +62,7 @@ public:
   void DestroyAllActors(const void* pCreatedBy, DestructionMode mode = DestructionMode::Immediate);
 
   /// \brief Returns all actors currently in the system, including ones that are queued for destruction.
-  void GetAllActors(ezHybridArray<ezActor*, 8>& out_allActors);
+  void GetAllActors(ezDynamicArray<ezActor*>& out_allActors);
 
   /// \brief Destroys all actors that are queued for destruction.
   /// This is already executed by Update(), calling it directly only makes sense if one needs to clean up actors without also updating the others.

--- a/Code/Engine/Core/ActorSystem/Implementation/ActorManager.cpp
+++ b/Code/Engine/Core/ActorSystem/Implementation/ActorManager.cpp
@@ -139,7 +139,7 @@ void ezActorManager::DestroyAllActors(const void* pCreatedBy, DestructionMode mo
   }
 }
 
-void ezActorManager::GetAllActors(ezHybridArray<ezActor*, 8>& out_allActors)
+void ezActorManager::GetAllActors(ezDynamicArray<ezActor*>& out_allActors)
 {
   EZ_LOCK(m_pImpl->m_Mutex);
 

--- a/Code/Engine/Core/Input/DeviceTypes/Controller.h
+++ b/Code/Engine/Core/Input/DeviceTypes/Controller.h
@@ -68,7 +68,11 @@ public:
 
   /// \brief Returns from which physical controller the given virtual controller takes its input. May be negative, which means
   /// the virtual controller is deactivated.
-  ezInt8 GetControllerMapping(ezUInt8 uiVirtual) const;
+  ezInt8 GetPhysicalControllerMapping(ezUInt8 uiVirtual) const;
+
+  /// \brief Returns to which virtual controller the given physical controller pushes its input. May be negative, which means
+  /// the physical controller is not used.
+  ezInt8 GetVirtualControllerMapping(ezUInt8 uiPhysical) const;
 
   /// \brief Queries whether the controller with the given physical index is connected to the computer.
   /// This may change at any time.
@@ -108,6 +112,7 @@ private:
   ezUInt32 m_uiVibrationTrackPos;
   float m_fVibrationTracks[MaxControllers][Motor::ENUM_COUNT][MaxVibrationSamples];
   bool m_bVibrationEnabled[MaxControllers];
-  ezInt8 m_iControllerMapping[MaxControllers];
+  ezInt8 m_iVirtualToPhysicalControllerMapping[MaxControllers]; // maps from virtual controller index to physical device index
+  ezInt8 m_iPhysicalToVirtualControllerMapping[MaxControllers]; // maps from physical device index to virtual controller index
   float m_fVibrationStrength[MaxControllers][Motor::ENUM_COUNT];
 };

--- a/Code/Engine/Core/Platform/GLFW/ControllerInput_GLFW.cpp
+++ b/Code/Engine/Core/Platform/GLFW/ControllerInput_GLFW.cpp
@@ -157,7 +157,7 @@ void ezControllerInputGlfw::UpdateInputSlotValues()
   for (ezUInt8 uiVirtual = 0; uiVirtual < MaxControllers; ++uiVirtual)
   {
     // check from which physical device to take the input data
-    const ezInt8 iPhysical = GetControllerMapping(uiVirtual);
+    const ezInt8 iPhysical = GetPhysicalControllerMapping(uiVirtual);
 
     // if the mapping is negative (which means 'deactivated'), ignore this controller
     if ((iPhysical < 0) || (iPhysical >= MaxControllers))

--- a/Code/Engine/Foundation/Basics/Platform/Common.h
+++ b/Code/Engine/Foundation/Basics/Platform/Common.h
@@ -32,7 +32,7 @@ EZ_WARNING_POP()
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
 /// \brief Macro helper to check alignment
-#  define EZ_CHECK_ALIGNMENT(ptr, alignment) EZ_ASSERT_DEV(((size_t)ptr & ((alignment)-1)) == 0, "Wrong alignment.")
+#  define EZ_CHECK_ALIGNMENT(ptr, alignment) EZ_ASSERT_DEV(((size_t)ptr & ((alignment) - 1)) == 0, "Wrong alignment.")
 #else
 /// \brief Macro helper to check alignment
 #  define EZ_CHECK_ALIGNMENT(ptr, alignment)

--- a/Code/Engine/Foundation/Basics/Platform/Common.h
+++ b/Code/Engine/Foundation/Basics/Platform/Common.h
@@ -32,7 +32,7 @@ EZ_WARNING_POP()
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
 /// \brief Macro helper to check alignment
-#  define EZ_CHECK_ALIGNMENT(ptr, alignment) EZ_ASSERT_DEV(((size_t)ptr & ((alignment) - 1)) == 0, "Wrong alignment.")
+#  define EZ_CHECK_ALIGNMENT(ptr, alignment) EZ_ASSERT_DEV(((size_t)ptr & ((alignment)-1)) == 0, "Wrong alignment.")
 #else
 /// \brief Macro helper to check alignment
 #  define EZ_CHECK_ALIGNMENT(ptr, alignment)
@@ -78,6 +78,12 @@ EZ_WARNING_POP()
 ///
 /// When dynamic linking is used, this macro has no effect, at all.
 #  define EZ_STATICLINK_PLUGIN(PluginName)
+
+/// \brief A marker that can be placed in CPP files to enforce that the StaticLinkUtil doesn't skip this file.
+///
+/// Needed when a CPP file contains a global variable that's used for registering something (for example an ezEnumerable),
+/// and there is no other indication for the StaticLinkUtil to consider the file.
+#  define EZ_STATICLINK_FORCE
 
 #else
 
@@ -134,6 +140,12 @@ struct EZ_FOUNDATION_DLL ezPluginRegister
 #  define EZ_STATICLINK_PLUGIN(PluginName)                                               \
     extern "C" void EZ_PP_CONCAT(ezReferenceFunction_, PluginName)(bool bReturn = true); \
     ezStaticLinkHelper EZ_PP_CONCAT(ezStaticLinkHelper_, PluginName)(EZ_PP_CONCAT(ezReferenceFunction_, PluginName));
+
+/// \brief A marker that can be placed in CPP files to enforce that the StaticLinkUtil doesn't skip this file.
+///
+/// Needed when a CPP file contains a global variable that's used for registering something (for example an ezEnumerable),
+/// and there is no other indication for the StaticLinkUtil to consider the file.
+#  define EZ_STATICLINK_FORCE
 
 #endif
 

--- a/Code/Engine/GameEngine/Input/XBoxController/InputDeviceXBox.cpp
+++ b/Code/Engine/GameEngine/Input/XBoxController/InputDeviceXBox.cpp
@@ -87,23 +87,23 @@ void ezInputDeviceXBox360::RegisterInputSlots()
   ezLog::Success("Initialized XBox 360 Controller.");
 }
 
-const char* szControllerName[] = {
-  "controller0_",
-  "controller1_",
-  "controller2_",
-  "controller3_",
+const ezStringView sControllerName[] = {
+  "controller0_"_ezsv,
+  "controller1_"_ezsv,
+  "controller2_"_ezsv,
+  "controller3_"_ezsv,
 
-  "controller4_",
-  "controller5_",
-  "controller6_",
-  "controller7_",
+  "controller4_"_ezsv,
+  "controller5_"_ezsv,
+  "controller6_"_ezsv,
+  "controller7_"_ezsv,
 };
 
-static_assert(EZ_ARRAY_SIZE(szControllerName) >= ezInputDeviceXBox360::MaxControllers);
+static_assert(EZ_ARRAY_SIZE(sControllerName) >= ezInputDeviceController::MaxControllers);
 
 void ezInputDeviceXBox360::SetValue(ezInt32 iController, const char* szButton, float fValue)
 {
-  ezStringBuilder s = szControllerName[iController];
+  ezStringBuilder s = sControllerName[iController];
   s.Append(szButton);
   float& fVal = m_InputSlotValues[s];
   fVal = ezMath::Max(fVal, fValue);
@@ -160,7 +160,7 @@ void ezInputDeviceXBox360::UpdateInputSlotValues()
   for (ezUInt8 uiVirtual = 0; uiVirtual < MaxControllers; ++uiVirtual)
   {
     // check from which physical device to take the input data
-    const ezInt8 iPhysical = GetControllerMapping(uiVirtual);
+    const ezInt8 iPhysical = GetPhysicalControllerMapping(uiVirtual);
 
     // if the mapping is negative (which means 'deactivated'), ignore this controller
     if ((iPhysical < 0) || (iPhysical >= MaxControllers))

--- a/Code/Engine/GameEngine/Input/XBoxController/InputDeviceXBox.h
+++ b/Code/Engine/GameEngine/Input/XBoxController/InputDeviceXBox.h
@@ -27,7 +27,7 @@ public:
 private:
   virtual void ApplyVibration(ezUInt8 uiPhysicalController, Motor::Enum eMotor, float fStrength) override;
 
-  bool m_bControllerConnected[4];
+  bool m_bControllerConnected[MaxControllers];
 
   virtual void InitializeDevice() override {}
   virtual void UpdateInputSlotValues() override;

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -276,8 +276,7 @@ void ezGALCommandEncoderImplVulkan::CopyBufferRegionPlatform(const ezGALBuffer* 
   m_pPipelineBarrier->AccessBuffer(pDestinationVulkan, 0, bufferCopy.size, vk::PipelineStageFlagBits::eTransfer, vk::AccessFlagBits::eTransferWrite, pDestinationVulkan->GetUsedByPipelineStage(), pDestinationVulkan->GetAccessMask());
 }
 
-void ezGALCommandEncoderImplVulkan::UpdateBufferPlatform(const ezGALBuffer* pDestination, ezUInt32 uiDestOffset, ezArrayPtr<const ezUInt8> pSourceData,
-  ezGALUpdateMode::Enum updateMode)
+void ezGALCommandEncoderImplVulkan::UpdateBufferPlatform(const ezGALBuffer* pDestination, ezUInt32 uiDestOffset, ezArrayPtr<const ezUInt8> pSourceData, ezGALUpdateMode::Enum updateMode)
 {
   EZ_CHECK_ALIGNMENT(pSourceData.GetPtr(), 16);
 

--- a/Code/Engine/Texture/Image/Conversions/BC7EncConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/BC7EncConversions.cpp
@@ -76,8 +76,7 @@ public:
   }
 };
 
-// EZ_STATICLINK_FORCE
-static ezImageConversion_CompressBC7Enc s_conversion_compressBC7Enc;
+EZ_STATICLINK_FORCE static ezImageConversion_CompressBC7Enc s_conversion_compressBC7Enc;
 
 #endif
 

--- a/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTConversions.cpp
@@ -3061,7 +3061,7 @@ static ezImageConversion_CompressBC5 s_conversion_compressBC5;
 
 #endif
 
-// EZ_STATICLINK_FORCE
+EZ_STATICLINK_FORCE
 static ezImageConversion_BC1_RGBA s_conversion_BC1_RGBA;
 static ezImageConversion_BC2_RGBA s_conversion_BC2_RGBA;
 static ezImageConversion_BC3_RGBA s_conversion_BC3_RGBA;

--- a/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
@@ -387,8 +387,7 @@ public:
   }
 };
 
-// EZ_STATICLINK_FORCE
-static ezImageConversion_CompressDxTex s_conversion_compressDxTex;
+EZ_STATICLINK_FORCE static ezImageConversion_CompressDxTex s_conversion_compressDxTex;
 
 #endif
 

--- a/Code/Engine/Texture/Image/Conversions/DXTexCpuConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTexCpuConversions.cpp
@@ -133,8 +133,7 @@ public:
   }
 };
 
-// EZ_STATICLINK_FORCE
-static ezImageConversion_CompressDxTexCpu s_conversion_compressDxTexCpu;
+EZ_STATICLINK_FORCE static ezImageConversion_CompressDxTexCpu s_conversion_compressDxTexCpu;
 
 #endif
 

--- a/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/PixelConversions.cpp
@@ -1585,7 +1585,7 @@ ADD_16BPP_CONVERSION(B5G5R5A1);
 ADD_16BPP_CONVERSION(X1B5G5R5);
 ADD_16BPP_CONVERSION(A1B5G5R5);
 
-// EZ_STATICLINK_FORCE
+EZ_STATICLINK_FORCE
 static ezImageSwizzleConversion32_2103 s_conversion_swizzle2103;
 static ezImageConversion_BGRX_BGRA s_conversion_BGRX_BGRA;
 static ezImageConversion_F32_U8 s_conversion_F32_U8;

--- a/Code/Engine/Texture/Image/Conversions/PlanarConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/PlanarConversions.cpp
@@ -145,9 +145,8 @@ struct ezImageConversion_sRGB_NV12 : public ezImageConversionStepPlanarize
   }
 };
 
-// EZ_STATICLINK_FORCE
-static ezImageConversion_NV12_sRGB s_conversion_NV12_sRGB;
-static ezImageConversion_sRGB_NV12 s_conversion_sRGB_NV12;
+EZ_STATICLINK_FORCE static ezImageConversion_NV12_sRGB s_conversion_NV12_sRGB;
+EZ_STATICLINK_FORCE static ezImageConversion_sRGB_NV12 s_conversion_sRGB_NV12;
 
 
 

--- a/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
@@ -6,8 +6,7 @@
 #include <Texture/Image/Formats/BmpFileFormat.h>
 #include <Texture/Image/ImageConversion.h>
 
-// EZ_STATICLINK_FORCE
-ezImageFileFormatRegistrator<ezBmpFileFormat> g_bmpFormat;
+EZ_STATICLINK_FORCE static ezImageFileFormatRegistrator<ezBmpFileFormat> g_bmpFormat;
 
 enum ezBmpCompression
 {

--- a/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/BmpFileFormat.cpp
@@ -7,7 +7,7 @@
 #include <Texture/Image/ImageConversion.h>
 
 // EZ_STATICLINK_FORCE
-ezBmpFileFormat g_bmpFormat;
+ezImageFileFormatRegistrator<ezBmpFileFormat> g_bmpFormat;
 
 enum ezBmpCompression
 {

--- a/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
@@ -6,8 +6,7 @@
 #include <Texture/Image/Formats/ImageFormatMappings.h>
 #include <Texture/Image/Image.h>
 
-// EZ_STATICLINK_FORCE
-ezImageFileFormatRegistrator<ezDdsFileFormat> g_ddsFormat;
+EZ_STATICLINK_FORCE static ezImageFileFormatRegistrator<ezDdsFileFormat> g_ddsFormat;
 
 struct ezDdsPixelFormat
 {

--- a/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
@@ -7,7 +7,7 @@
 #include <Texture/Image/Image.h>
 
 // EZ_STATICLINK_FORCE
-ezDdsFileFormat g_ddsFormat;
+ezImageFileFormatRegistrator<ezDdsFileFormat> g_ddsFormat;
 
 struct ezDdsPixelFormat
 {

--- a/Code/Engine/Texture/Image/Formats/ExrFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/ExrFileFormat.cpp
@@ -11,8 +11,7 @@
 
 #  include <tinyexr/tinyexr.h>
 
-// EZ_STATICLINK_FORCE
-ezImageFileFormatRegistrator<ezExrFileFormat> g_ExrFileFormat;
+EZ_STATICLINK_FORCE static ezImageFileFormatRegistrator<ezExrFileFormat> g_ExrFileFormat;
 
 ezResult ReadImageData(ezStreamReader& ref_stream, ezDynamicArray<ezUInt8>& ref_fileBuffer, ezImageHeader& ref_header, EXRHeader& ref_exrHeader, EXRImage& ref_exrImage)
 {

--- a/Code/Engine/Texture/Image/Formats/ExrFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/ExrFileFormat.cpp
@@ -12,7 +12,7 @@
 #  include <tinyexr/tinyexr.h>
 
 // EZ_STATICLINK_FORCE
-ezExrFileFormat g_ExrFileFormat;
+ezImageFileFormatRegistrator<ezExrFileFormat> g_ExrFileFormat;
 
 ezResult ReadImageData(ezStreamReader& ref_stream, ezDynamicArray<ezUInt8>& ref_fileBuffer, ezImageHeader& ref_header, EXRHeader& ref_exrHeader, EXRImage& ref_exrImage)
 {

--- a/Code/Engine/Texture/Image/Formats/ImageFileFormat.h
+++ b/Code/Engine/Texture/Image/Formats/ImageFileFormat.h
@@ -61,6 +61,13 @@ public:
 };
 
 /// \brief Template used to automatically register an ezImageFileFormat globally.
+///
+/// Place a global variable of the desired type in some CPP file to register the type:
+///
+///   ezImageFileFormatRegistrator<ezDdsFileFormat> g_ddsFormat;
+///
+/// For the format to be available on platforms that use static linking, you may also need to add
+///   EZ_STATICLINK_FORCE
 template <class TYPE>
 class ezImageFileFormatRegistrator : public ezRegisteredImageFileFormat
 {

--- a/Code/Engine/Texture/Image/Formats/ImageFileFormat.h
+++ b/Code/Engine/Texture/Image/Formats/ImageFileFormat.h
@@ -13,7 +13,7 @@ class ezImageView;
 class ezStringBuilder;
 class ezImageHeader;
 
-class EZ_TEXTURE_DLL ezImageFileFormat : public ezEnumerable<ezImageFileFormat>
+class EZ_TEXTURE_DLL ezImageFileFormat
 {
 public:
   /// \brief Reads only the header information for an image and ignores the data. Much faster than reading the entire image, if the pixel data is not needed.
@@ -32,12 +32,44 @@ public:
   virtual bool CanWriteFileType(ezStringView sExtension) const = 0;
 
   /// \brief Returns an ezImageFileFormat that can read the given extension. Returns nullptr if there is no appropriate ezImageFileFormat.
-  static ezImageFileFormat* GetReaderFormat(ezStringView sExtension);
+  static const ezImageFileFormat* GetReaderFormat(ezStringView sExtension);
 
   /// \brief Returns an ezImageFileFormat that can write the given extension. Returns nullptr if there is no appropriate ezImageFileFormat.
-  static ezImageFileFormat* GetWriterFormat(ezStringView sExtension);
+  static const ezImageFileFormat* GetWriterFormat(ezStringView sExtension);
 
   static ezResult ReadImageHeader(ezStringView sFileName, ezImageHeader& ref_header);
+};
 
-  EZ_DECLARE_ENUMERABLE_CLASS(ezImageFileFormat);
+/// \brief Base class for a registered (globally known) ezImageFileFormat.
+///
+/// This is an enumerable class, so all known formats can be retrieved through the ezEnumerable interface.
+/// For example:
+///
+///   for (auto format = ezRegisteredImageFileFormat::GetFirstInstance(); format != nullptr; format = format->GetNextInstance())
+///   {
+///     auto& type = format->GetFormatType();
+///   }
+class EZ_TEXTURE_DLL ezRegisteredImageFileFormat : public ezEnumerable<ezRegisteredImageFileFormat>
+{
+  EZ_DECLARE_ENUMERABLE_CLASS(ezRegisteredImageFileFormat);
+
+public:
+  ezRegisteredImageFileFormat();
+  ~ezRegisteredImageFileFormat();
+
+  virtual const ezImageFileFormat& GetFormatType() const = 0;
+};
+
+/// \brief Template used to automatically register an ezImageFileFormat globally.
+template <class TYPE>
+class ezImageFileFormatRegistrator : public ezRegisteredImageFileFormat
+{
+public:
+  virtual const ezImageFileFormat& GetFormatType() const override
+  {
+    return m_Format;
+  }
+
+private:
+  TYPE m_Format;
 };

--- a/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
+++ b/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
@@ -11,7 +11,7 @@
 #include <stb/stb_image_write.h>
 
 // EZ_STATICLINK_FORCE
-ezStbImageFileFormats g_StbImageFormats;
+ezImageFileFormatRegistrator<ezStbImageFileFormats> g_StbImageFormats;
 
 // stb_image callbacks would be better than loading the entire file into memory.
 // However, it turned out that it does not map well to ezStreamReader

--- a/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
+++ b/Code/Engine/Texture/Image/Formats/StbImageFileFormats.cpp
@@ -10,8 +10,7 @@
 #include <stb/stb_image.h>
 #include <stb/stb_image_write.h>
 
-// EZ_STATICLINK_FORCE
-ezImageFileFormatRegistrator<ezStbImageFileFormats> g_StbImageFormats;
+EZ_STATICLINK_FORCE static ezImageFileFormatRegistrator<ezStbImageFileFormats> g_StbImageFormats;
 
 // stb_image callbacks would be better than loading the entire file into memory.
 // However, it turned out that it does not map well to ezStreamReader

--- a/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
@@ -6,8 +6,7 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <Texture/Image/ImageConversion.h>
 
-// EZ_STATICLINK_FORCE
-ezImageFileFormatRegistrator<ezTgaFileFormat> g_TgaFormat;
+EZ_STATICLINK_FORCE static ezImageFileFormatRegistrator<ezTgaFileFormat> g_TgaFormat;
 
 struct TgaImageDescriptor
 {

--- a/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/TgaFileFormat.cpp
@@ -7,7 +7,7 @@
 #include <Texture/Image/ImageConversion.h>
 
 // EZ_STATICLINK_FORCE
-ezTgaFileFormat g_TgaFormat;
+ezImageFileFormatRegistrator<ezTgaFileFormat> g_TgaFormat;
 
 struct TgaImageDescriptor
 {

--- a/Code/Engine/Texture/Image/Formats/WicFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/WicFileFormat.cpp
@@ -18,8 +18,7 @@ using namespace DirectX;
 
 EZ_DEFINE_AS_POD_TYPE(DirectX::Image); // Allow for storing this struct in ez containers
 
-// EZ_STATICLINK_FORCE
-ezImageFileFormatRegistrator<ezWicFileFormat> g_wicFormat;
+EZ_STATICLINK_FORCE static ezImageFileFormatRegistrator<ezWicFileFormat> g_wicFormat;
 
 namespace
 {

--- a/Code/Engine/Texture/Image/Formats/WicFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/WicFileFormat.cpp
@@ -19,7 +19,7 @@ using namespace DirectX;
 EZ_DEFINE_AS_POD_TYPE(DirectX::Image); // Allow for storing this struct in ez containers
 
 // EZ_STATICLINK_FORCE
-ezWicFileFormat g_wicFormat;
+ezImageFileFormatRegistrator<ezWicFileFormat> g_wicFormat;
 
 namespace
 {

--- a/Code/Engine/Texture/Image/Implementation/Image.cpp
+++ b/Code/Engine/Texture/Image/Implementation/Image.cpp
@@ -62,7 +62,7 @@ ezResult ezImageView::SaveTo(ezStringView sFileName) const
 
   ezStringView it = ezPathUtils::GetFileExtension(sFileName);
 
-  if (ezImageFileFormat* pFormat = ezImageFileFormat::GetWriterFormat(it.GetStartPointer()))
+  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetWriterFormat(it.GetStartPointer()))
   {
     if (pFormat->WriteImage(writer, *this, it.GetStartPointer()) != EZ_SUCCESS)
     {
@@ -272,7 +272,7 @@ ezResult ezImage::LoadFrom(ezStringView sFileName)
 
   ezStringView it = ezPathUtils::GetFileExtension(sFileName);
 
-  if (ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it.GetStartPointer()))
+  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it.GetStartPointer()))
   {
     if (pFormat->ReadImage(reader, *this, it.GetStartPointer()) != EZ_SUCCESS)
     {

--- a/Code/Engine/Texture/Image/Implementation/ImageFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageFileFormat.cpp
@@ -4,28 +4,26 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <Texture/Image/Formats/ImageFileFormat.h>
 
-EZ_ENUMERABLE_CLASS_IMPLEMENTATION(ezImageFileFormat);
-
-ezImageFileFormat* ezImageFileFormat::GetReaderFormat(ezStringView sExtension)
+const ezImageFileFormat* ezImageFileFormat::GetReaderFormat(ezStringView sExtension)
 {
-  for (ezImageFileFormat* pFormat = ezImageFileFormat::GetFirstInstance(); pFormat; pFormat = pFormat->GetNextInstance())
+  for (auto format = ezRegisteredImageFileFormat::GetFirstInstance(); format != nullptr; format = format->GetNextInstance())
   {
-    if (pFormat->CanReadFileType(sExtension))
+    if (format->GetFormatType().CanReadFileType(sExtension))
     {
-      return pFormat;
+      return &format->GetFormatType();
     }
   }
 
   return nullptr;
 }
 
-ezImageFileFormat* ezImageFileFormat::GetWriterFormat(ezStringView sExtension)
+const ezImageFileFormat* ezImageFileFormat::GetWriterFormat(ezStringView sExtension)
 {
-  for (ezImageFileFormat* pFormat = ezImageFileFormat::GetFirstInstance(); pFormat; pFormat = pFormat->GetNextInstance())
+  for (auto format = ezRegisteredImageFileFormat::GetFirstInstance(); format != nullptr; format = format->GetNextInstance())
   {
-    if (pFormat->CanWriteFileType(sExtension))
+    if (format->GetFormatType().CanWriteFileType(sExtension))
     {
-      return pFormat;
+      return &format->GetFormatType();
     }
   }
 
@@ -47,7 +45,7 @@ ezResult ezImageFileFormat::ReadImageHeader(ezStringView sFileName, ezImageHeade
 
   ezStringView it = ezPathUtils::GetFileExtension(sFileName);
 
-  if (ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it.GetStartPointer()))
+  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it.GetStartPointer()))
   {
     if (pFormat->ReadImageHeader(reader, ref_header, it.GetStartPointer()) != EZ_SUCCESS)
     {
@@ -61,3 +59,10 @@ ezResult ezImageFileFormat::ReadImageHeader(ezStringView sFileName, ezImageHeade
   ezLog::Warning("No known image file format for extension '{0}'", it);
   return EZ_FAILURE;
 }
+
+//////////////////////////////////////////////////////////////////////////
+
+EZ_ENUMERABLE_CLASS_IMPLEMENTATION(ezRegisteredImageFileFormat);
+
+ezRegisteredImageFileFormat::ezRegisteredImageFileFormat() = default;
+ezRegisteredImageFileFormat::~ezRegisteredImageFileFormat() = default;

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -1862,7 +1862,7 @@ static ezDynamicArray<char> ArrayToBase64(ezArrayPtr<const ezUInt8> in, bool bIn
 
 void ezImageUtils::EmbedImageData(ezStringBuilder& out_sHtml, const ezImage& image)
 {
-  ezImageFileFormat* format = ezImageFileFormat::GetWriterFormat("png");
+  const ezImageFileFormat* format = ezImageFileFormat::GetWriterFormat("png");
   EZ_ASSERT_DEV(format != nullptr, "No PNG writer found");
 
   ezDynamicArray<ezUInt8> imgData;

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
@@ -319,6 +319,8 @@ void ezJoltDynamicActorComponent::OnSimulationStarted()
   }
 
   JPH::Body* pBody = pBodies->CreateBody(bodyCfg);
+  EZ_ASSERT_DEV(pBody != nullptr, "Jolt body creation failed. You need to increase the maximum number of bodies.");
+
   m_uiJoltBodyID = pBody->GetID().GetIndexAndSequenceNumber();
 
   pModule->QueueBodyToAdd(pBody, !m_bStartAsleep);

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -110,6 +110,8 @@ void ezJoltQueryShapeActorComponent::OnSimulationStarted()
   bodyCfg.mUserData = reinterpret_cast<ezUInt64>(pUserData);
 
   JPH::Body* pBody = pBodies->CreateBody(bodyCfg);
+  EZ_ASSERT_DEV(pBody != nullptr, "Jolt body creation failed. You need to increase the maximum number of bodies.");
+
   m_uiJoltBodyID = pBody->GetID().GetIndexAndSequenceNumber();
 
   pModule->QueueBodyToAdd(pBody, true);

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
@@ -114,6 +114,8 @@ void ezJoltStaticActorComponent::OnSimulationStarted()
   bodyCfg.mUserData = reinterpret_cast<ezUInt64>(pUserData);
 
   JPH::Body* pBody = pBodies->CreateBody(bodyCfg);
+  EZ_ASSERT_DEV(pBody != nullptr, "Jolt body creation failed. You need to increase the maximum number of bodies.");
+
   m_uiJoltBodyID = pBody->GetID().GetIndexAndSequenceNumber();
 
   pModule->QueueBodyToAdd(pBody, true);

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltTriggerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltTriggerComponent.cpp
@@ -106,6 +106,8 @@ void ezJoltTriggerComponent::OnSimulationStarted()
   bodyCfg.mUserData = reinterpret_cast<ezUInt64>(pUserData);
 
   JPH::Body* pBody = pBodies->CreateBody(bodyCfg);
+  EZ_ASSERT_DEV(pBody != nullptr, "Jolt body creation failed. You need to increase the maximum number of bodies.");
+
   m_uiJoltBodyID = pBody->GetID().GetIndexAndSequenceNumber();
 
   pModule->QueueBodyToAdd(pBody, true);

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -428,6 +428,8 @@ void ezJoltCharacterControllerComponent::CreatePresenceBody()
   bodyCfg.mUserData = reinterpret_cast<ezUInt64>(pUserData);
 
   JPH::Body* pBody = pBodies->CreateBody(bodyCfg);
+  EZ_ASSERT_DEV(pBody != nullptr, "Jolt body creation failed. You need to increase the maximum number of bodies.");
+
   m_uiPresenceBodyID = pBody->GetID().GetIndexAndSequenceNumber();
 
   m_uiPresenceBodyAddCounter = pModule->QueueBodyToAdd(pBody, true);


### PR DESCRIPTION
The ezImageFormat class was used both as an ezEnumerable, as well as a local class. This creates a race condition and can result in a crash. Therefore the format type registration has been moved into a separate class.

Also added a couple of useful asserts to Jolt and improved the controller base class.