### PR TITLE
Animation Controller fixes

### DIFF
--- a/Code/Engine/GameEngine/Animation/Skeletal/AnimationControllerComponent.h
+++ b/Code/Engine/GameEngine/Animation/Skeletal/AnimationControllerComponent.h
@@ -11,7 +11,20 @@
 using ezSkeletonResourceHandle = ezTypedResourceHandle<class ezSkeletonResource>;
 using ezAnimGraphResourceHandle = ezTypedResourceHandle<class ezAnimGraphResource>;
 
-using ezAnimationControllerComponentManager = ezComponentManagerSimple<class ezAnimationControllerComponent, ezComponentUpdateType::WhenSimulating, ezBlockStorageType::FreeList>;
+class ezAnimationControllerComponentManager : public ezComponentManager<class ezAnimationControllerComponent, ezBlockStorageType::FreeList>
+{
+public:
+  ezAnimationControllerComponentManager(ezWorld* pWorld);
+
+  virtual void Initialize() override;
+  virtual void Deinitialize() override;
+
+private:
+  void Update(const ezWorldModule::UpdateContext& context);
+  void ResourceEvent(const ezResourceEvent& e);
+
+  ezDeque<ezComponentHandle> m_ComponentsToReset;
+};
 
 /// \brief Evaluates an ezAnimGraphResource and provides the result through the ezMsgAnimationPoseUpdated.
 ///

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipAnimNode.cpp
@@ -96,6 +96,11 @@ void ezSampleAnimClipAnimNode::Step(ezAnimController& ref_controller, ezAnimGrap
 
   InstanceState* pState = ref_graph.GetAnimNodeInstanceData<InstanceState>(*this);
 
+  if (!m_InStart.IsConnected() && pState->m_PlaybackTime > ezTime::MakeFromHours(10))
+  {
+    pState->m_PlaybackTime = ezTime::MakeZero();
+  }
+
   if (m_InStart.IsTriggered(ref_graph))
   {
     pState->m_PlaybackTime = ezTime::MakeZero();

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipAnimNode.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipAnimNode.h
@@ -44,6 +44,6 @@ private:
 
   struct InstanceState
   {
-    ezTime m_PlaybackTime = ezTime::MakeZero();
+    ezTime m_PlaybackTime = ezTime::MakeFromHours(1000);
   };
 };

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipSequenceAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipSequenceAnimNode.cpp
@@ -130,6 +130,12 @@ void ezSampleAnimClipSequenceAnimNode::Step(ezAnimController& ref_controller, ez
 
   InstanceState* pState = ref_graph.GetAnimNodeInstanceData<InstanceState>(*this);
 
+  if (!m_InStart.IsConnected() && pState->m_PlaybackTime > ezTime::MakeFromHours(10))
+  {
+    pState->m_PlaybackTime = ezTime::MakeZero();
+    pState->m_State = State::Start;
+  }
+
   if (m_InStart.IsTriggered(ref_graph))
   {
     pState->m_PlaybackTime = ezTime::MakeZero();

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipSequenceAnimNode.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleAnimClipSequenceAnimNode.h
@@ -68,7 +68,7 @@ private:
 
   struct InstanceState
   {
-    ezTime m_PlaybackTime = ezTime::MakeZero();
+    ezTime m_PlaybackTime = ezTime::MakeFromHours(1000);
     State m_State = State::Start;
     ezUInt8 m_uiMiddleClipIdx = 0;
   };

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace1DAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace1DAnimNode.cpp
@@ -132,6 +132,11 @@ void ezSampleBlendSpace1DAnimNode::Step(ezAnimController& ref_controller, ezAnim
 
   InstanceState* pState = ref_graph.GetAnimNodeInstanceData<InstanceState>(*this);
 
+  if (!m_InStart.IsConnected() && pState->m_PlaybackTime > ezTime::MakeFromHours(10))
+  {
+    pState->m_PlaybackTime = ezTime::MakeZero();
+  }
+
   if (m_InStart.IsTriggered(ref_graph))
   {
     pState->m_PlaybackTime = ezTime::MakeZero();

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace1DAnimNode.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace1DAnimNode.h
@@ -54,6 +54,6 @@ private:
 
   struct InstanceState
   {
-    ezTime m_PlaybackTime = ezTime::MakeZero();
+    ezTime m_PlaybackTime = ezTime::MakeFromHours(1000);
   };
 };

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace2DAnimNode.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace2DAnimNode.cpp
@@ -151,6 +151,12 @@ void ezSampleBlendSpace2DAnimNode::Step(ezAnimController& ref_controller, ezAnim
 
   InstanceState* pState = ref_graph.GetAnimNodeInstanceData<InstanceState>(*this);
 
+  if (!m_InStart.IsConnected() && pState->m_CenterPlaybackTime > ezTime::MakeFromHours(10))
+  {
+    pState->m_CenterPlaybackTime = ezTime::MakeZero();
+    pState->m_fOtherPlaybackPosNorm = 0.0f;
+  }
+
   if (m_InStart.IsTriggered(ref_graph))
   {
     pState->m_CenterPlaybackTime = ezTime::MakeZero();

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace2DAnimNode.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace2DAnimNode.h
@@ -68,7 +68,7 @@ private:
 
   struct InstanceState
   {
-    ezTime m_CenterPlaybackTime = ezTime::MakeZero();
+    ezTime m_CenterPlaybackTime = ezTime::MakeFromHours(1000);
     float m_fOtherPlaybackPosNorm = 0.0f;
     float m_fLastValueX = 0.0f;
     float m_fLastValueY = 0.0f;

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimController.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/Implementation/AnimController.cpp
@@ -18,6 +18,22 @@ ezAnimController::~ezAnimController() = default;
 
 void ezAnimController::Initialize(const ezSkeletonResourceHandle& hSkeleton, ezAnimPoseGenerator& ref_poseGenerator, const ezSharedPtr<ezBlackboard>& pBlackboard /*= nullptr*/)
 {
+  m_Instances.Clear();
+  m_PinDataBoneWeights.Clear();
+  m_PinDataLocalTransforms.Clear();
+  m_PinDataModelTransforms.Clear();
+  m_AnimationClipMapping.Clear();
+  m_CurrentLocalTransformOutputs.Clear();
+  m_pBlackboard.Clear();
+  m_BlendMask.Clear();
+  m_pPoseGenerator = nullptr;
+  m_pCurrentModelTransforms = nullptr;
+  m_hSkeleton = {};
+  m_vRootMotion.SetZero();
+  m_RootRotationX = {};
+  m_RootRotationY = {};
+  m_RootRotationZ = {};
+
   m_hSkeleton = hSkeleton;
   m_pPoseGenerator = &ref_poseGenerator;
   m_pBlackboard = pBlackboard;


### PR DESCRIPTION
* Fixed crash when editing animation graph while a scene is simulating. It now properly hot reloads the animation graph.
* Fixed that triggered animation clip sample nodes would play once right at start.