### PR TITLE
Visual script improvements

### DIFF
--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
@@ -245,7 +245,7 @@ void ezQtExposedParameterPropertyWidget::InternalSetValue(const ezVariant& value
           m_pCurrentSubType = pNewtSubType;
           m_pWidget = ezQtPropertyGridWidget::CreateMemberPropertyWidget(prop);
           if (!m_pWidget)
-            m_pWidget = new ezQtUnsupportedPropertyWidget("Unsupported type");
+            m_pWidget = new ezQtUnsupportedPropertyWidget("Unsupported Type");
 
           m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
           m_pWidget->setParent(this);

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptClassAsset/VisualScriptClassAsset.cpp
@@ -20,7 +20,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptClassAssetProperties, 1, ezRTTIDef
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptClassAssetDocument, 6, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVisualScriptClassAssetDocument, 7, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
@@ -246,6 +246,7 @@ namespace
     &FillUserData_VariableName,                      // Builtin_SetVariable,
     &FillUserData_VariableName,                      // Builtin_IncVariable,
     &FillUserData_VariableName,                      // Builtin_DecVariable,
+    nullptr,                                         // Builtin_TempVariable,
 
     nullptr,                                         // Builtin_Branch,
     &FillUserData_Switch,                            // Builtin_Switch,

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -633,6 +633,21 @@ void ezVisualScriptNodeRegistry::CreateBuiltinTypes()
     }
   }
 
+  // Builtin_TempVariable
+  {
+    FillDesc(typeDesc, "Builtin_TempVariable", logicColor);
+
+    NodeDesc nodeDesc;
+    nodeDesc.m_Type = ezVisualScriptNodeDescription::Type::Builtin_TempVariable;
+    nodeDesc.m_DeductTypeFunc = &ezVisualScriptTypeDeduction::DeductFromAllInputPins;
+    nodeDesc.AddInputExecutionPin("");
+    nodeDesc.AddOutputExecutionPin("");
+    AddInputDataPin_Any(typeDesc, nodeDesc, "Value", false, true);
+    nodeDesc.AddOutputDataPin("Value", nullptr, ezVisualScriptDataType::Any);
+
+    RegisterNodeType(typeDesc, std::move(nodeDesc), sVariablesCategory);
+  }
+
   // Builtin_Branch
   {
     FillDesc(typeDesc, "Builtin_Branch", logicColor);

--- a/Code/Engine/Core/Scripting/ScriptClasses/Implementation/ScriptExtensionClass_CVar.cpp
+++ b/Code/Engine/Core/Scripting/ScriptClasses/Implementation/ScriptExtensionClass_CVar.cpp
@@ -1,0 +1,238 @@
+#include <Core/CorePCH.h>
+
+#include <Core/Scripting/ScriptAttributes.h>
+#include <Core/Scripting/ScriptClasses/ScriptExtensionClass_CVar.h>
+
+#include <Foundation/Configuration/CVar.h>
+
+// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezScriptExtensionClass_CVar, ezNoBase, 1, ezRTTINoAllocator)
+{
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetValue, In, "Name")->AddFlags(ezPropertyFlags::Const),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetBoolValue, In, "Name")->AddFlags(ezPropertyFlags::Const),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetIntValue, In, "Name")->AddFlags(ezPropertyFlags::Const),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetFloatValue, In, "Name")->AddFlags(ezPropertyFlags::Const),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetStringValue, In, "Name")->AddFlags(ezPropertyFlags::Const),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetValue, In, "Name", In, "Value"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetBoolValue, In, "Name", In, "Value"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetIntValue, In, "Name", In, "Value"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetFloatValue, In, "Name", In, "Value"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(SetStringValue, In, "Name", In, "Value"),
+  }
+  EZ_END_FUNCTIONS;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezScriptExtensionAttribute("CVar"),
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_STATIC_REFLECTED_TYPE;
+// clang-format on
+
+static ezHashTable<ezTempHashedString, ezCVar*> s_CachedCVars;
+
+static ezCVar* FindCVarByNameCached(ezStringView sName)
+{
+  ezTempHashedString sNameHashed(sName);
+
+  ezCVar* pCVar = nullptr;
+  if (!s_CachedCVars.TryGetValue(sNameHashed, pCVar))
+  {
+    pCVar = ezCVar::FindCVarByName(sName);
+
+    s_CachedCVars.Insert(sNameHashed, pCVar);
+  }
+
+  ezCVar::s_AllCVarEvents.AddEventHandler(
+    [&](const ezCVarEvent& e)
+    {
+      if (e.m_EventType == ezCVarEvent::Type::ListOfVarsChanged)
+      {
+        s_CachedCVars.Clear();
+      }
+    });
+
+  return pCVar;
+}
+
+// static
+ezVariant ezScriptExtensionClass_CVar::GetValue(ezStringView sName)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr)
+  {
+    return {};
+  }
+
+  switch (pCVar->GetType())
+  {
+    case ezCVarType::Bool:
+      return static_cast<ezCVarBool*>(pCVar)->GetValue();
+    case ezCVarType::Int:
+      return static_cast<ezCVarInt*>(pCVar)->GetValue();
+    case ezCVarType::Float:
+      return static_cast<ezCVarFloat*>(pCVar)->GetValue();
+    case ezCVarType::String:
+      return static_cast<ezCVarString*>(pCVar)->GetValue();
+
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+  }
+
+  return {};
+}
+
+// static
+bool ezScriptExtensionClass_CVar::GetBoolValue(ezStringView sName)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::Bool)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type bool.", sName);
+    return false;
+  }
+
+  return static_cast<ezCVarBool*>(pCVar)->GetValue();
+}
+
+// static
+int ezScriptExtensionClass_CVar::GetIntValue(ezStringView sName)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::Int)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type int.", sName);
+    return 0;
+  }
+
+  return static_cast<ezCVarInt*>(pCVar)->GetValue();
+}
+
+// static
+float ezScriptExtensionClass_CVar::GetFloatValue(ezStringView sName)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::Float)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type float.", sName);
+    return 0;
+  }
+
+  return static_cast<ezCVarFloat*>(pCVar)->GetValue();
+}
+
+// static
+ezString ezScriptExtensionClass_CVar::GetStringValue(ezStringView sName)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::String)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type string.", sName);
+    return "";
+  }
+
+  return static_cast<ezCVarString*>(pCVar)->GetValue();
+}
+
+// static
+void ezScriptExtensionClass_CVar::SetValue(ezStringView sName, const ezVariant& value)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr)
+  {
+    ezLog::Error("CVar '{}' does not exist.", sName);
+    return;
+  }
+
+  switch (pCVar->GetType())
+  {
+    case ezCVarType::Bool:
+    {
+      ezCVarBool* pVar = static_cast<ezCVarBool*>(pCVar);
+      *pVar = value.ConvertTo<bool>();
+      break;
+    }
+
+    case ezCVarType::Int:
+    {
+      ezCVarInt* pVar = static_cast<ezCVarInt*>(pCVar);
+      *pVar = value.ConvertTo<int>();
+      break;
+    }
+
+    case ezCVarType::Float:
+    {
+      ezCVarFloat* pVar = static_cast<ezCVarFloat*>(pCVar);
+      *pVar = value.ConvertTo<float>();
+      break;
+    }
+
+    case ezCVarType::String:
+    {
+      ezCVarString* pVar = static_cast<ezCVarString*>(pCVar);
+      *pVar = value.ConvertTo<ezString>();
+      break;
+    }
+
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+  }
+}
+
+// static
+void ezScriptExtensionClass_CVar::SetBoolValue(ezStringView sName, bool bValue)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::Bool)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type bool.", sName);
+    return;
+  }
+
+  ezCVarBool* pVar = static_cast<ezCVarBool*>(pCVar);
+  *pVar = bValue;
+}
+
+// static
+void ezScriptExtensionClass_CVar::SetIntValue(ezStringView sName, int iValue)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::Int)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type int.", sName);
+    return;
+  }
+
+  ezCVarInt* pVar = static_cast<ezCVarInt*>(pCVar);
+  *pVar = iValue;
+}
+
+// static
+void ezScriptExtensionClass_CVar::SetFloatValue(ezStringView sName, float fValue)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::Float)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type float.", sName);
+    return;
+  }
+
+  ezCVarFloat* pVar = static_cast<ezCVarFloat*>(pCVar);
+  *pVar = fValue;
+}
+
+// static
+void ezScriptExtensionClass_CVar::SetStringValue(ezStringView sName, const ezString& sValue)
+{
+  ezCVar* pCVar = FindCVarByNameCached(sName);
+  if (pCVar == nullptr || pCVar->GetType() != ezCVarType::String)
+  {
+    ezLog::Error("CVar '{}' does not exist or is not of type string.", sName);
+    return;
+  }
+
+  ezCVarString* pVar = static_cast<ezCVarString*>(pCVar);
+  *pVar = sValue;
+}

--- a/Code/Engine/Core/Scripting/ScriptClasses/ScriptExtensionClass_CVar.h
+++ b/Code/Engine/Core/Scripting/ScriptClasses/ScriptExtensionClass_CVar.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Core/CoreDLL.h>
+#include <Foundation/Reflection/Reflection.h>
+
+class EZ_CORE_DLL ezScriptExtensionClass_CVar
+{
+public:
+  static ezVariant GetValue(ezStringView sName);
+  static bool GetBoolValue(ezStringView sName);
+  static int GetIntValue(ezStringView sName);
+  static float GetFloatValue(ezStringView sName);
+  static ezString GetStringValue(ezStringView sName);
+
+  static void SetValue(ezStringView sName, const ezVariant& value);
+  static void SetBoolValue(ezStringView sName, bool bValue);
+  static void SetIntValue(ezStringView sName, int iValue);
+  static void SetFloatValue(ezStringView sName, float fValue);
+  static void SetStringValue(ezStringView sName, const ezString& sValue);
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_CORE_DLL, ezScriptExtensionClass_CVar);

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BlackboardAnimNodes.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BlackboardAnimNodes.cpp
@@ -14,7 +14,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSetBlackboardNumberAnimNode, 1, ezRTTIDefaultA
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
     EZ_MEMBER_PROPERTY("Number", m_fNumber),
 
     EZ_MEMBER_PROPERTY("InActivate", m_InActivate)->AddAttributes(new ezHiddenAttribute()),
@@ -93,7 +93,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezGetBlackboardNumberAnimNode, 1, ezRTTIDefaultA
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
 
     EZ_MEMBER_PROPERTY("OutNumber", m_OutNumber)->AddAttributes(new ezHiddenAttribute()),
   }
@@ -174,7 +174,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCompareBlackboardNumberAnimNode, 1, ezRTTIDefa
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
     EZ_MEMBER_PROPERTY("ReferenceValue", m_fReferenceValue),
     EZ_ENUM_MEMBER_PROPERTY("Comparison", ezComparisonOperator, m_Comparison),
 
@@ -295,7 +295,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCheckBlackboardBoolAnimNode, 1, ezRTTIDefaultA
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
 
     EZ_MEMBER_PROPERTY("OutOnTrue", m_OutOnTrue)->AddAttributes(new ezHiddenAttribute()),
     EZ_MEMBER_PROPERTY("OutOnFalse", m_OutOnFalse)->AddAttributes(new ezHiddenAttribute()),
@@ -409,7 +409,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSetBlackboardBoolAnimNode, 1, ezRTTIDefaultAll
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
     EZ_MEMBER_PROPERTY("Bool", m_bBool),
 
     EZ_MEMBER_PROPERTY("InActivate", m_InActivate)->AddAttributes(new ezHiddenAttribute()),
@@ -488,7 +488,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezGetBlackboardBoolAnimNode, 1, ezRTTIDefaultAll
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
 
     EZ_MEMBER_PROPERTY("OutBool", m_OutBool)->AddAttributes(new ezHiddenAttribute()),
   }
@@ -570,7 +570,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezOnBlackboardValueChangedAnimNode, 1, ezRTTIDef
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry),
+    EZ_ACCESSOR_PROPERTY("BlackboardEntry", GetBlackboardEntry, SetBlackboardEntry)->AddAttributes(new ezDynamicStringEnumAttribute("BlackboardKeysEnum")),
 
     EZ_MEMBER_PROPERTY("OutOnValueChanged", m_OutOnValueChanged)->AddAttributes(new ezHiddenAttribute()),
   }

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.cpp
@@ -30,6 +30,7 @@ namespace
     "Builtin_SetVariable",
     "Builtin_IncVariable",
     "Builtin_DecVariable",
+    "Builtin_TempVariable",
 
     "Builtin_Branch",
     "Builtin_Switch",
@@ -155,7 +156,7 @@ ezVisualScriptGraphDescription::ezVisualScriptGraphDescription()
 
 ezVisualScriptGraphDescription::~ezVisualScriptGraphDescription() = default;
 
-static const ezTypeVersion s_uiVisualScriptGraphDescriptionVersion = 4;
+static const ezTypeVersion s_uiVisualScriptGraphDescriptionVersion = 5;
 
 // static
 ezResult ezVisualScriptGraphDescription::Serialize(ezArrayPtr<const ezVisualScriptNodeDescription> nodes, const ezVisualScriptDataDescription& localDataDesc, ezStreamWriter& inout_stream)
@@ -203,9 +204,9 @@ ezResult ezVisualScriptGraphDescription::Serialize(ezArrayPtr<const ezVisualScri
 ezResult ezVisualScriptGraphDescription::Deserialize(ezStreamReader& inout_stream, const ezVisualScriptDataDescription& instanceDataDesc, const ezVisualScriptDataDescription& constantDataDesc)
 {
   ezTypeVersion uiVersion = inout_stream.ReadVersion(s_uiVisualScriptGraphDescriptionVersion);
-  if (uiVersion < 4)
+  if (uiVersion < s_uiVisualScriptGraphDescriptionVersion)
   {
-    ezLog::Error("Invalid visual script desc version. Expected >= 4 but got {}. Visual Script needs re-export", uiVersion);
+    ezLog::Error("Invalid visual script desc version. Expected >= {} but got {}. Visual Script needs re-export", s_uiVisualScriptGraphDescriptionVersion, uiVersion);
     return EZ_FAILURE;
   }
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.h
@@ -35,6 +35,7 @@ struct EZ_VISUALSCRIPTPLUGIN_DLL ezVisualScriptNodeDescription
       Builtin_SetVariable,
       Builtin_IncVariable,
       Builtin_DecVariable,
+      Builtin_TempVariable,
 
       Builtin_Branch,
       Builtin_Switch,

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -1456,6 +1456,7 @@ namespace
     {nullptr, &NodeFunction_Builtin_SetVariable_Getter},       // Builtin_SetVariable,
     {nullptr, &NodeFunction_Builtin_IncVariable_Getter},       // Builtin_IncVariable,
     {nullptr, &NodeFunction_Builtin_DecVariable_Getter},       // Builtin_DecVariable,
+    {nullptr, &NodeFunction_Builtin_SetVariable_Getter},       // Builtin_TempVariable,
 
     {&NodeFunction_Builtin_Branch},                            // Builtin_Branch,
     {nullptr, &NodeFunction_Builtin_Switch_Getter},            // Builtin_Switch,

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeUserData.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeUserData.h
@@ -464,6 +464,7 @@ namespace
     {},                                           // Builtin_SetVariable,
     {},                                           // Builtin_IncVariable,
     {},                                           // Builtin_DecVariable,
+    {},                                           // Builtin_TempVariable,
 
     {},                                           // Builtin_Branch,
     {&NodeUserData_Switch::Serialize,

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -544,10 +544,17 @@ void ezQtUnsupportedPropertyWidget::OnInit()
 {
   ezQtScopedBlockSignals bs(m_pWidget);
 
-  ezStringBuilder tmp;
-  QString sMessage = QStringLiteral("Unsupported Type: ") % QString::fromUtf8(m_pProp->GetSpecificType()->GetTypeName().GetData(tmp));
+  QString sMessage;
   if (!m_sMessage.IsEmpty())
-    sMessage += QStringLiteral(" (") % QString::fromUtf8(m_sMessage, m_sMessage.GetElementCount()) % QStringLiteral(")");
+  {
+    sMessage = m_sMessage;
+  }
+  else
+  {
+    ezStringBuilder tmp;
+    sMessage = QStringLiteral("Unsupported Type: ") % QString::fromUtf8(m_pProp->GetSpecificType()->GetTypeName().GetData(tmp));
+  }
+
   m_pWidget->setText(sMessage);
   m_pWidget->setToolTip(sMessage);
 }
@@ -1798,8 +1805,11 @@ void ezQtVariantPropertyWidget::InternalSetValue(const ezVariant& value)
     if (pNewtSubType)
     {
       m_pWidget = ezQtPropertyGridWidget::GetFactory().CreateObject(pNewtSubType);
+
       if (!m_pWidget)
-        m_pWidget = new ezQtUnsupportedPropertyWidget("Unsupported type");
+      {
+        m_pWidget = new ezQtUnsupportedPropertyWidget("<Unsupported Type>");
+      }
     }
     else if (!sameType)
     {
@@ -1807,8 +1817,9 @@ void ezQtVariantPropertyWidget::InternalSetValue(const ezVariant& value)
     }
     else
     {
-      m_pWidget = new ezQtUnsupportedPropertyWidget("<Invalid>");
+      m_pWidget = new ezQtUnsupportedPropertyWidget("<Invalid Type>");
     }
+
     m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     m_pWidget->setParent(this);
     m_pLayout->addWidget(m_pWidget);

--- a/Code/Tools/StaticLinkUtil/CMakeLists.txt
+++ b/Code/Tools/StaticLinkUtil/CMakeLists.txt
@@ -11,5 +11,5 @@ ez_add_output_ez_prefix(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-  Core
+  Foundation
 )


### PR DESCRIPTION
* Exposed CVars to visual script
* Added a temp variable node: This node can be used to ensure that certain calculations are only executed once and the result is cached in a temp variable.
* Small usability fixes: Use blackboard entry enum in anim graph nodes and nicer display text when invalid variant type is selected.