### PR TITLE
Delay Editor picking readback by one frame

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -275,6 +275,10 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
 {
   if (const auto* pMsg = ezDynamicCast<const ezSyncWithProcessMsgToEngine*>(e.m_pMessage))
   {
+    ezStringBuilder sRedrawScope;
+    sRedrawScope.SetFormat("Redraw {}", pMsg->m_uiRedrawCount);
+    EZ_PROFILE_SCOPE(sRedrawScope.GetData());
+
     ezSyncWithProcessMsgToEditor msg;
     msg.m_uiRedrawCount = pMsg->m_uiRedrawCount;
     m_uiRedrawCountReceived = msg.m_uiRedrawCount;

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -32,6 +32,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezPickingRenderPass::ezPickingRenderPass()
   : ezRenderPipelinePass("EditorPickingRenderPass")
 {
+  m_PendingReadback = EZ_DEFAULT_NEW(PickingReadback);
 }
 
 ezPickingRenderPass::~ezPickingRenderPass()
@@ -144,11 +145,50 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
     renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_FORWARD");
   }
 
-  // download the picking information from the GPU
+  if (m_PendingReadback->m_bReadbackInProgress)
+  {
+    // Wait for results
+    {
+      ezEnum<ezGALAsyncResult> res = m_PendingReadback->m_PickingReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+      res = m_PendingReadback->m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+      m_PendingReadback->m_bReadbackInProgress = false;
+    }
+
+    ezGALTextureSubresource sourceSubResource;
+    ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
+    ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
+
+    m_PickingResultsDepth.Clear();
+    m_PickingResultsID.Clear();
+    m_mPickingInverseViewProjectionMatrix = ezMat4::MakeZero();
+    // If the resolution has changed, discard the readback result.
+    if (m_uiWindowHeight == m_PendingReadback->m_uiWindowHeight && m_uiWindowWidth == m_PendingReadback->m_uiWindowWidth)
+    {
+      {
+        m_PickingResultsDepth.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
+        ezReadbackTextureLock lock = m_PendingReadback->m_PickingDepthReadback.LockTexture(sourceSubResources, memory);
+        EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+        const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingDepthRT());
+        ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsDepth.GetByteArrayPtr(), m_uiWindowWidth * sizeof(float));
+      }
+      {
+        m_PickingResultsID.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
+        ezReadbackTextureLock lock = m_PendingReadback->m_PickingReadback.LockTexture(sourceSubResources, memory);
+        EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
+        const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingIdRT());
+        ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsID.GetByteArrayPtr(), m_uiWindowWidth * sizeof(ezUInt32));
+      }
+      m_mPickingInverseViewProjectionMatrix = m_PendingReadback->m_mPickingInverseViewProjectionMatrix;
+    }
+  }
+
+  // Start transferring the picking information from the GPU to the CPU
   if (m_uiWindowWidth != 0 && m_uiWindowHeight != 0)
   {
-    m_PickingReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingIdRT());
-    m_PickingDepthReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingDepthRT());
+    m_PendingReadback->m_PickingReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingIdRT());
+    m_PendingReadback->m_PickingDepthReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingDepthRT());
     renderViewContext.m_pRenderContext->GetCommandEncoder()->Flush();
 
     ezMat4 mProj;
@@ -165,38 +205,10 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
       return;
     }
 
-    m_mPickingInverseViewProjectionMatrix = inv;
-
-    // Wait for results
-    {
-      ezEnum<ezGALAsyncResult> res = m_PickingReadback.GetReadbackResult(ezTime::MakeFromHours(1));
-      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
-      res = m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromHours(1));
-      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
-    }
-
-    ezGALTextureSubresource sourceSubResource;
-    ezArrayPtr<ezGALTextureSubresource> sourceSubResources(&sourceSubResource, 1);
-    ezHybridArray<ezGALSystemMemoryDescription, 1> memory;
-
-    {
-      m_PickingResultsDepth.Clear();
-      m_PickingResultsDepth.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
-
-      ezReadbackTextureLock lock = m_PickingDepthReadback.LockTexture(sourceSubResources, memory);
-      EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
-      const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingDepthRT());
-      ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsDepth.GetByteArrayPtr(), m_uiWindowWidth * sizeof(float));
-    }
-    {
-      m_PickingResultsID.Clear();
-      m_PickingResultsID.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
-
-      ezReadbackTextureLock lock = m_PickingReadback.LockTexture(sourceSubResources, memory);
-      EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
-      const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingIdRT());
-      ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsID.GetByteArrayPtr(), m_uiWindowWidth * sizeof(ezUInt32));
-    }
+    m_PendingReadback->m_mPickingInverseViewProjectionMatrix = inv;
+    m_PendingReadback->m_uiWindowWidth = m_uiWindowWidth;
+    m_PendingReadback->m_uiWindowHeight = m_uiWindowHeight;
+    m_PendingReadback->m_bReadbackInProgress = true;
   }
 }
 

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -32,6 +32,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezPickingRenderPass::ezPickingRenderPass()
   : ezRenderPipelinePass("EditorPickingRenderPass")
 {
+  m_pGridRenderDataType = ezRTTI::FindTypeByName("ezGridRenderData");
+  EZ_ASSERT_DEV(m_pGridRenderDataType != nullptr, "ezGridRenderData type not found. Type renamed?");
 }
 
 ezPickingRenderPass::~ezPickingRenderPass()
@@ -107,7 +109,7 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
 
     // filter out all selected objects
     ezRenderDataBatch::Filter filter([&](const ezRenderData* pRenderData)
-      { return m_SelectionSet.Contains(pRenderData->m_hOwner); });
+      { return m_SelectionSet.Contains(pRenderData->m_hOwner) || pRenderData->IsInstanceOf(m_pGridRenderDataType); });
 
     RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaque, filter);
     RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMasked, filter);

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -32,7 +32,6 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezPickingRenderPass::ezPickingRenderPass()
   : ezRenderPipelinePass("EditorPickingRenderPass")
 {
-  m_PendingReadback = EZ_DEFAULT_NEW(PickingReadback);
 }
 
 ezPickingRenderPass::~ezPickingRenderPass()
@@ -145,15 +144,15 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
     renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_FORWARD");
   }
 
-  if (m_PendingReadback->m_bReadbackInProgress)
+  if (m_PendingReadback.m_bReadbackInProgress)
   {
     // Wait for results
     {
-      ezEnum<ezGALAsyncResult> res = m_PendingReadback->m_PickingReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+      ezEnum<ezGALAsyncResult> res = m_PendingReadback.m_PickingReadback.GetReadbackResult(ezTime::MakeFromHours(1));
       EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
-      res = m_PendingReadback->m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromHours(1));
+      res = m_PendingReadback.m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromHours(1));
       EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
-      m_PendingReadback->m_bReadbackInProgress = false;
+      m_PendingReadback.m_bReadbackInProgress = false;
     }
 
     ezGALTextureSubresource sourceSubResource;
@@ -164,31 +163,31 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
     m_PickingResultsID.Clear();
     m_mPickingInverseViewProjectionMatrix = ezMat4::MakeZero();
     // If the resolution has changed, discard the readback result.
-    if (m_uiWindowHeight == m_PendingReadback->m_uiWindowHeight && m_uiWindowWidth == m_PendingReadback->m_uiWindowWidth)
+    if (m_uiWindowHeight == m_PendingReadback.m_uiWindowHeight && m_uiWindowWidth == m_PendingReadback.m_uiWindowWidth)
     {
       {
         m_PickingResultsDepth.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
-        ezReadbackTextureLock lock = m_PendingReadback->m_PickingDepthReadback.LockTexture(sourceSubResources, memory);
+        ezReadbackTextureLock lock = m_PendingReadback.m_PickingDepthReadback.LockTexture(sourceSubResources, memory);
         EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
         const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingDepthRT());
         ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsDepth.GetByteArrayPtr(), m_uiWindowWidth * sizeof(float));
       }
       {
         m_PickingResultsID.SetCountUninitialized(m_uiWindowWidth * m_uiWindowHeight);
-        ezReadbackTextureLock lock = m_PendingReadback->m_PickingReadback.LockTexture(sourceSubResources, memory);
+        ezReadbackTextureLock lock = m_PendingReadback.m_PickingReadback.LockTexture(sourceSubResources, memory);
         EZ_ASSERT_ALWAYS(lock, "Failed to lock readback texture");
         const ezGALTexture* pReadbackTexture = ezGALDevice::GetDefaultDevice()->GetTexture(GetPickingIdRT());
         ezTextureUtils::CopySubResourceToMemory(pReadbackTexture->GetDescription(), sourceSubResource, memory[0], m_PickingResultsID.GetByteArrayPtr(), m_uiWindowWidth * sizeof(ezUInt32));
       }
-      m_mPickingInverseViewProjectionMatrix = m_PendingReadback->m_mPickingInverseViewProjectionMatrix;
+      m_mPickingInverseViewProjectionMatrix = m_PendingReadback.m_mPickingInverseViewProjectionMatrix;
     }
   }
 
   // Start transferring the picking information from the GPU to the CPU
   if (m_uiWindowWidth != 0 && m_uiWindowHeight != 0)
   {
-    m_PendingReadback->m_PickingReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingIdRT());
-    m_PendingReadback->m_PickingDepthReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingDepthRT());
+    m_PendingReadback.m_PickingReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingIdRT());
+    m_PendingReadback.m_PickingDepthReadback.ReadbackTexture(*renderViewContext.m_pRenderContext->GetCommandEncoder(), GetPickingDepthRT());
     renderViewContext.m_pRenderContext->GetCommandEncoder()->Flush();
 
     ezMat4 mProj;
@@ -205,10 +204,10 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
       return;
     }
 
-    m_PendingReadback->m_mPickingInverseViewProjectionMatrix = inv;
-    m_PendingReadback->m_uiWindowWidth = m_uiWindowWidth;
-    m_PendingReadback->m_uiWindowHeight = m_uiWindowHeight;
-    m_PendingReadback->m_bReadbackInProgress = true;
+    m_PendingReadback.m_mPickingInverseViewProjectionMatrix = inv;
+    m_PendingReadback.m_uiWindowWidth = m_uiWindowWidth;
+    m_PendingReadback.m_uiWindowHeight = m_uiWindowHeight;
+    m_PendingReadback.m_bReadbackInProgress = true;
   }
 }
 

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
@@ -46,6 +46,7 @@ private:
 
 private:
   ezRectFloat m_TargetRect;
+  const ezRTTI* m_pGridRenderDataType = nullptr;
 
   ezGALTextureHandle m_hPickingIdRT;
   ezGALTextureHandle m_hPickingDepthRT;

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
@@ -66,7 +66,7 @@ private:
     ezMat4 m_mPickingInverseViewProjectionMatrix = ezMat4::MakeZero();
   };
 
-  ezUniquePtr<PickingReadback> m_PendingReadback;
+  PickingReadback m_PendingReadback;
 
   // Picking Results
   ezMat4 m_mPickingInverseViewProjectionMatrix = ezMat4::MakeZero();

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
@@ -50,18 +50,28 @@ private:
   ezGALTextureHandle m_hPickingIdRT;
   ezGALTextureHandle m_hPickingDepthRT;
   ezGALRenderTargetSetup m_RenderTargetSetup;
-  ezGALReadbackTextureHelper m_PickingReadback;
-  ezGALReadbackTextureHelper m_PickingDepthReadback;
 
   ezHashSet<ezGameObjectHandle> m_SelectionSet;
 
+  // Readback
+  struct PickingReadback
+  {
+    ezGALReadbackTextureHelper m_PickingReadback;
+    ezGALReadbackTextureHelper m_PickingDepthReadback;
 
-  /// we need this matrix to compute the world space position of picked pixels
+    bool m_bReadbackInProgress = false;
+    ezUInt32 m_uiWindowWidth = 0;
+    ezUInt32 m_uiWindowHeight = 0;
+    /// we need this matrix to compute the world space position of picked pixels
+    ezMat4 m_mPickingInverseViewProjectionMatrix = ezMat4::MakeZero();
+  };
+
+  ezUniquePtr<PickingReadback> m_PendingReadback;
+
+  // Picking Results
   ezMat4 m_mPickingInverseViewProjectionMatrix = ezMat4::MakeZero();
-
   /// stores the 2D depth buffer image (32 Bit depth precision), to compute pixel positions from
   ezDynamicArray<float> m_PickingResultsDepth;
-
   /// Stores the 32 Bit picking ID values of each pixel. This can lead back to the ezComponent, etc. that rendered to that pixel
   ezDynamicArray<ezUInt32> m_PickingResultsID;
 };

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -68,6 +68,9 @@ void ezEditorEngineProcessConnection::UIServicesTickEventHandler(const ezQtUiSer
 
       if (m_uiRedrawCountSent > m_uiRedrawCountReceived)
       {
+        ezStringBuilder sRedrawScope;
+        sRedrawScope.SetFormat("Wait For Redraw {}", m_uiRedrawCountReceived + 1);
+        EZ_PROFILE_SCOPE(sRedrawScope.GetData());
         WaitForMessage(ezGetStaticRTTI<ezSyncWithProcessMsgToEditor>(), ezTime::MakeFromSeconds(2.0)).IgnoreResult();
       }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1215,7 +1215,6 @@ void ezRenderPipeline::Render(ezRenderContext* pRenderContext)
     for (ezUInt32 i = 0; i < m_Passes.GetCount(); ++i)
     {
       auto& pPass = m_Passes[i];
-      EZ_PROFILE_SCOPE(pPass->GetName());
       ezLogBlock passBlock("Render Pass", pPass->GetName());
 
       // Create pool textures

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -833,7 +833,7 @@ void ezGALDeviceDX11::BeginFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchains,
 
 #if EZ_ENABLED(EZ_USE_PROFILING)
   ezStringBuilder sb;
-  sb.SetFormat("GPU FRAME {}", uiAppFrame);
+  sb.SetFormat("RENDER FRAME {}", uiAppFrame);
   m_pFrameTimingScope = ezProfilingScopeAndMarker::Start(m_pCommandEncoder.Borrow(), sb);
 #else
   EZ_IGNORE_UNUSED(uiAppFrame);

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1508,7 +1508,7 @@ void ezGALDeviceVulkan::BeginFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchain
 
 #if EZ_ENABLED(EZ_USE_PROFILING)
   ezStringBuilder sb;
-  sb.SetFormat("Frame {}", uiAppFrame);
+  sb.SetFormat("RENDER FRAME {}", uiAppFrame);
   m_pFrameTimingScope = ezProfilingScopeAndMarker::Start(m_pCommandEncoder.Borrow(), sb);
 #endif
 


### PR DESCRIPTION
* Added various profiling scopes to make editor / engine / gpu corrrelation easier.
* Picking is now done with one frame delay, preventing blocking on the readback operation.
* Removed duplicate profiling scopes.