### PR TITLE
Fixed world reader to be able to instantiate prefabs from multiple threads

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/Documents.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Documents.cpp
@@ -50,10 +50,10 @@ ezDocument* ezQtEditorApp::OpenDocument(ezStringView sDocument, ezBitflags<ezDoc
     if (pDocument->GetUnknownObjectTypeInstances() > 0)
     {
       ezStringBuilder s;
-      s.SetFormat("The document contained {0} objects of an unknown type. Necessary plugins may be missing.\n\n\
+      s.SetFormat("The document '{}' contained {} objects of an unknown type. Necessary plugins may be missing.\n\n\
 If you save this document, all data for these objects is lost permanently!\n\n\
 The following types are missing:\n",
-        pDocument->GetUnknownObjectTypeInstances());
+        sDocument, pDocument->GetUnknownObjectTypeInstances());
 
       for (auto it = pDocument->GetUnknownObjectTypes().GetIterator(); it.IsValid(); ++it)
       {

--- a/Code/Engine/Core/World/GameObject.h
+++ b/Code/Engine/Core/World/GameObject.h
@@ -350,17 +350,17 @@ public:
 
   /// \brief Tries to find a component of the given base type in the objects components list and returns the first match.
   template <typename T>
-  bool TryGetComponentOfBaseType(T*& out_pComponent);
+  [[nodiscard]] bool TryGetComponentOfBaseType(T*& out_pComponent);
 
   /// \brief Tries to find a component of the given base type in the objects components list and returns the first match.
   template <typename T>
-  bool TryGetComponentOfBaseType(const T*& out_pComponent) const;
+  [[nodiscard]] bool TryGetComponentOfBaseType(const T*& out_pComponent) const;
 
   /// \brief Tries to find a component of the given base type in the objects components list and returns the first match.
-  bool TryGetComponentOfBaseType(const ezRTTI* pType, ezComponent*& out_pComponent);
+  [[nodiscard]] bool TryGetComponentOfBaseType(const ezRTTI* pType, ezComponent*& out_pComponent);
 
   /// \brief Tries to find a component of the given base type in the objects components list and returns the first match.
-  bool TryGetComponentOfBaseType(const ezRTTI* pType, const ezComponent*& out_pComponent) const;
+  [[nodiscard]] bool TryGetComponentOfBaseType(const ezRTTI* pType, const ezComponent*& out_pComponent) const;
 
   /// \brief Tries to find components of the given base type in the objects components list and returns all matches.
   template <typename T>

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -19,7 +19,7 @@ class ezColor;
 class EZ_RENDERERFOUNDATION_DLL ezGALDevice
 {
 public:
-  static ezEvent<const ezGALDeviceEvent&> s_Events;
+  static ezEvent<const ezGALDeviceEvent&, ezMutex> s_Events;
 
   // Init & shutdown functions
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -58,7 +58,7 @@ namespace
 } // namespace
 
 ezGALDevice* ezGALDevice::s_pDefaultDevice = nullptr;
-ezEvent<const ezGALDeviceEvent&> ezGALDevice::s_Events;
+ezEvent<const ezGALDeviceEvent&, ezMutex> ezGALDevice::s_Events;
 
 ezGALDevice::ezGALDevice(const ezGALDeviceCreationDescription& desc)
   : m_Allocator("GALDevice", ezFoundation::GetDefaultAllocator())

--- a/Code/Engine/RendererFoundation/Shader/Types.h
+++ b/Code/Engine/RendererFoundation/Shader/Types.h
@@ -2,6 +2,7 @@
 
 #include <RendererFoundation/RendererFoundationDLL.h>
 
+#include <Foundation/Math/Float16.h>
 #include <Foundation/Math/Mat3.h>
 #include <Foundation/Math/Transform.h>
 

--- a/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/VertexDeclarationVulkan.cpp
@@ -48,7 +48,7 @@ ezResult ezGALVertexDeclarationVulkan::InitPlatform(ezGALDevice* pDevice)
     const ezUInt32 uiLocation = FindLocation(Current.m_eSemantic, Current.m_eFormat);
     if (uiLocation == ezMath::MaxValue<ezUInt32>())
     {
-      ezLog::Warning("Vertex buffer semantic {} not used by shader", Current.m_eSemantic);
+      // ezLog::Warning("Vertex buffer semantic {} not used by shader", Current.m_eSemantic);
       continue;
     }
     vk::VertexInputAttributeDescription& attrib = m_attributes.ExpandAndGetRef();
@@ -93,5 +93,3 @@ ezResult ezGALVertexDeclarationVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
   return EZ_SUCCESS;
 }
-
-

--- a/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltConstraintComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Constraints/Implementation/JoltConstraintComponent.cpp
@@ -430,7 +430,10 @@ ezResult ezJoltConstraintComponent::FindChildBody(ezUInt32& out_uiJoltBodyID, ez
       return EZ_FAILURE;
     }
 
-    pObject->TryGetComponentOfBaseType(pRbComp);
+    if (!pObject->TryGetComponentOfBaseType(pRbComp))
+    {
+      EZ_REPORT_FAILURE("Component should exist.");
+    }
   }
 
   pRbComp->EnsureSimulationStarted();

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -1317,8 +1317,10 @@ namespace
     }
 
     ezComponent* pComponent = nullptr;
-    static_cast<ezGameObject*>(p.m_pObject)->TryGetComponentOfBaseType(userData.m_pType, pComponent);
-    inout_context.SetPointerData(node.GetOutputDataOffset(0), pComponent);
+    if (static_cast<ezGameObject*>(p.m_pObject)->TryGetComponentOfBaseType(userData.m_pType, pComponent))
+    {
+      inout_context.SetPointerData(node.GetOutputDataOffset(0), pComponent);
+    }
 
     return ExecResult::RunNext(0);
   }

--- a/Code/UnitTests/CoreTest/World/MessageTest.cpp
+++ b/Code/UnitTests/CoreTest/World/MessageTest.cpp
@@ -152,22 +152,22 @@ EZ_CREATE_SIMPLE_TEST(World, Messaging)
     pParents[0]->SendMessage(msg2);
 
     TestComponentMsg* pComponent2 = nullptr;
-    pParents[0]->TryGetComponentOfBaseType(pComponent2);
+    EZ_TEST_BOOL(pParents[0]->TryGetComponentOfBaseType(pComponent2));
     EZ_TEST_INT(pComponent2->m_iSomeData, 5);
     EZ_TEST_INT(pComponent2->m_iSomeData2, 10);
 
     // siblings, parent and children should not be affected
-    pParents[1]->TryGetComponentOfBaseType(pComponent2);
+    EZ_TEST_BOOL(pParents[1]->TryGetComponentOfBaseType(pComponent2));
     EZ_TEST_INT(pComponent2->m_iSomeData, 1);
     EZ_TEST_INT(pComponent2->m_iSomeData2, 2);
 
-    pRoot->TryGetComponentOfBaseType(pComponent2);
+    EZ_TEST_BOOL(pRoot->TryGetComponentOfBaseType(pComponent2));
     EZ_TEST_INT(pComponent2->m_iSomeData, 1);
     EZ_TEST_INT(pComponent2->m_iSomeData2, 2);
 
     for (auto it = pParents[0]->GetChildren(); it.IsValid(); ++it)
     {
-      it->TryGetComponentOfBaseType(pComponent2);
+      EZ_TEST_BOOL(it->TryGetComponentOfBaseType(pComponent2));
       EZ_TEST_INT(pComponent2->m_iSomeData, 1);
       EZ_TEST_INT(pComponent2->m_iSomeData2, 2);
     }
@@ -191,7 +191,7 @@ EZ_CREATE_SIMPLE_TEST(World, Messaging)
     world.Update();
 
     TestComponentMsg* pComponent2 = nullptr;
-    pRoot->TryGetComponentOfBaseType(pComponent2);
+    EZ_TEST_BOOL(pRoot->TryGetComponentOfBaseType(pComponent2));
     EZ_TEST_INT(pComponent2->m_iSomeData, 46);
     EZ_TEST_INT(pComponent2->m_iSomeData2, 92);
 
@@ -226,7 +226,7 @@ EZ_CREATE_SIMPLE_TEST(World, Messaging)
       world.Update();
 
       TestComponentMsg* pComponent2 = nullptr;
-      pRoot->TryGetComponentOfBaseType(pComponent2);
+      EZ_TEST_BOOL(pRoot->TryGetComponentOfBaseType(pComponent2));
       EZ_TEST_INT(pComponent2->m_iSomeData, iDesiredValue);
       EZ_TEST_INT(pComponent2->m_iSomeData2, iDesiredValue2);
     }


### PR DESCRIPTION
The ezPrefabResource uses a single ezWorldReader to instantiate prefabs, no matter from which thread it is called.

Unfortunately, parts of its internal state are modified during instantiation, which means that if the same prefab gets instantiated in parallel (into different worlds), it would crash.

This can happen when you have two scenes open in the editor and then transform an asset that is used in both of them. Both scenes will update their prefab instances, which can happen on different threads which then use the same world reader.

The fix moves all mutable state into the instantiation context. I did not want to change the interface of ezWorldReader, which would have affected a lot of the code base. Therefore I had to use a thread_local to track the active instantiation context. ezWorldReader is already using thread_locals for the string deduplication context, so this doesn't change how it can be used. 