### PR TITLE
Editor usability fixes

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/ViewRenderSettings.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/ViewRenderSettings.h
@@ -24,21 +24,13 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_EDITORENGINEPROCESSFRAMEWORK_DLL, ezSceneViewPers
 
 struct EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezEngineViewConfig
 {
-  ezEngineViewConfig()
-  {
-    m_RenderMode = ezViewRenderMode::Default;
-    m_Perspective = ezSceneViewPerspective::Default;
-    m_CameraUsageHint = ezCameraUsageHint::EditorView;
-    m_pLinkedViewConfig = nullptr;
-  }
-
-  ezViewRenderMode::Enum m_RenderMode;
-  ezSceneViewPerspective::Enum m_Perspective;
-  ezCameraUsageHint::Enum m_CameraUsageHint;
+  ezViewRenderMode::Enum m_RenderMode = ezViewRenderMode::Default;
+  ezSceneViewPerspective::Enum m_Perspective = ezSceneViewPerspective::Default;
+  ezCameraUsageHint::Enum m_CameraUsageHint = ezCameraUsageHint::EditorView;
   bool m_bUseCameraTransformOnDevice = true;
 
   ezCamera m_Camera;
-  ezEngineViewConfig* m_pLinkedViewConfig; // used to store which other view config this is linked to, for resetting values when switching views
+  ezEngineViewConfig* m_pLinkedViewConfig = nullptr; // used to store which other view config this is linked to, for resetting values when switching views
 
   void ApplyPerspectiveSetting(float fFov = 0.0f, float fNearPlane = 0.1f, float fFarPlane = 1000.0f);
 };

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserView.moc.h
@@ -25,6 +25,7 @@ public:
   void dragMoveEvent(QDragMoveEvent* pEvent) override;
   void dragLeaveEvent(QDragLeaveEvent* pEvent) override;
   void dropEvent(QDropEvent* pEvent) override;
+  void startDrag(Qt::DropActions supportedActions) override;
 
 Q_SIGNALS:
   void ViewZoomed(ezInt32 iIconSizePercentage);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
@@ -28,9 +28,13 @@ QValidator::State ezFileNameValidator::validate(QString& ref_sInput, int& ref_iP
 
   if (!m_sCurrentName.IsEmpty() && sTemp == m_sCurrentName)
     return QValidator::State::Acceptable;
+  if (!m_sCurrentName.IsEmpty() && sTemp == m_sCurrentName.GetFileName())
+    return QValidator::State::Acceptable;
 
   ezStringBuilder sAbsPath = m_sParentFolder;
   sAbsPath.AppendPath(sTemp);
+  sAbsPath.Append(".", m_sCurrentName.GetFileExtension());
+
   if (ezOSFile::ExistsDirectory(sAbsPath) || ezOSFile::ExistsFile(sAbsPath))
     return QValidator::State::Intermediate;
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -479,7 +479,7 @@ QVariant ezQtAssetBrowserModel::data(const QModelIndex& index, int iRole) const
 
       case Qt::EditRole:
       {
-        ezStringView sFilename = entry.m_sAbsFilePath.GetAbsolutePath().GetFileNameAndExtension();
+        ezStringView sFilename = entry.m_sAbsFilePath.GetAbsolutePath().GetFileName(); // remove the file extension
         return ezMakeQString(sFilename);
       }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserView.cpp
@@ -24,6 +24,26 @@ ezQtAssetBrowserView::ezQtAssetBrowserView(QWidget* pParent)
   SetIconScale(m_iIconSizePercentage);
 }
 
+void ezQtAssetBrowserView::startDrag(Qt::DropActions supportedActions)
+{
+  // overridden so that we can get rid of the preview image
+
+  QModelIndexList indexes = selectedIndexes();
+  if (indexes.count() > 0)
+  {
+    QMimeData* data = model()->mimeData(indexes);
+    if (!data)
+    {
+      return;
+    }
+
+    QDrag* drag = new QDrag(this);
+    drag->setMimeData(data);
+
+    drag->exec(supportedActions, Qt::MoveAction);
+  }
+}
+
 void ezQtAssetBrowserView::SetDialogMode(bool bDialogMode)
 {
   m_bDialogMode = bDialogMode;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -1317,10 +1317,7 @@ void ezQtAssetBrowserWidget::OnFileEditingFinished(const QString& sAbsPath, cons
 {
   ezStringBuilder sOldPath = qtToEzString(sAbsPath);
   ezStringBuilder sNewPath = sOldPath;
-  if (bIsAsset)
-    sNewPath.ChangeFileName(qtToEzString(sNewName));
-  else
-    sNewPath.ChangeFileNameAndExtension(qtToEzString(sNewName));
+  sNewPath.ChangeFileName(qtToEzString(sNewName));
 
   if (sOldPath != sNewPath)
   {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -695,7 +695,7 @@ void ezQtAssetBrowserWidget::DeleteSelection()
     }
   }
 
-  QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Do you want to delete the selected items?"), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
+  QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Delete the selected file?\n\nThis operation cannot be undone."), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
   if (choice == QMessageBox::StandardButton::Cancel)
     return;
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -1275,7 +1275,7 @@ void ezQtAssetBrowserWidget::NewAsset()
   ezPathUtils::MakeValidFilename(sTranslateAssetType, ' ', sBaseFileName);
   sNewAsset.AppendFormat("/{}.{}", sBaseFileName, sExtension);
 
-  for (ezUInt32 i = 0; ezOSFile::ExistsFile(sNewAsset); i++)
+  for (ezUInt32 i = 2; ezOSFile::ExistsFile(sNewAsset); i++)
   {
     sNewAsset = qtToEzString(sStartDir);
     sNewAsset.AppendFormat("/{}{}.{}", sBaseFileName, i, sExtension);

--- a/Code/Editor/EditorFramework/Preferences/QuadViewPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/QuadViewPreferences.cpp
@@ -61,10 +61,10 @@ ezQuadViewPreferencesUser::ezQuadViewPreferencesUser()
 {
   m_bQuadView = false;
 
-  m_ViewSingle.m_vCamPos.Set(-3, 0, 2);
-  m_ViewSingle.m_vCamDir.Set(1, 0, -0.5f);
-  m_ViewSingle.m_vCamDir.Normalize();
-  m_ViewSingle.m_vCamUp = m_ViewSingle.m_vCamDir.CrossRH(ezVec3(0, 1, 0)).GetNormalized();
+  m_ViewSingle.m_vCamPos.Set(3, 0.5f, 1);
+  m_ViewSingle.m_vCamDir = -m_ViewSingle.m_vCamPos.GetNormalized();
+  ezVec3 vRight = m_ViewSingle.m_vCamDir.CrossRH(ezVec3(0, 0, 1));
+  m_ViewSingle.m_vCamUp = vRight.CrossRH(m_ViewSingle.m_vCamDir).GetNormalized();
   m_ViewSingle.m_PerspectiveMode = ezSceneViewPerspective::Perspective;
   m_ViewSingle.m_RenderMode = ezViewRenderMode::Default;
   m_ViewSingle.m_fFov = 70.0f;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -118,7 +118,6 @@ void ezSceneDocument::GroupSelection()
   if (numSel <= 1)
     return;
 
-  ezVec3 vCenter(0.0f);
   const ezDocumentObject* pCommonParent = sel[0]->GetParent();
 
   // this happens for top-level objects, their parent object is an ezDocumentRootObject
@@ -127,17 +126,15 @@ void ezSceneDocument::GroupSelection()
     pCommonParent = nullptr;
   }
 
+  const ezTransform tGroup = GetGlobalTransform(GetSelectionManager()->GetCurrentObject());
+
   for (const auto& item : sel)
   {
-    vCenter += GetGlobalTransform(item).m_vPosition;
-
     if (pCommonParent != item->GetParent())
     {
       pCommonParent = nullptr;
     }
   }
-
-  vCenter /= numSel;
 
   auto pHistory = GetCommandHistory();
 
@@ -166,7 +163,7 @@ void ezSceneDocument::GroupSelection()
   }
 
   auto pGroupObject = GetObjectManager()->GetObject(cmdAdd.m_NewObjectGuid);
-  SetGlobalTransform(pGroupObject, ezTransform(vCenter), TransformationChanges::Translation);
+  SetGlobalTransform(pGroupObject, tGroup, TransformationChanges::All);
 
   ezMoveObjectCommand cmdMove;
   cmdMove.m_NewParent = cmdAdd.m_NewObjectGuid;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
@@ -185,6 +185,8 @@ void ezQtSceneViewWidget::dropEvent(QDropEvent* e)
     info.m_bCtrlKeyDown = e->modifiers() & Qt::ControlModifier;
 
     ezDragDropHandler::FinishDragDrop(&info);
+
+    setFocus();
   }
 
   ezQtEngineViewWidget::dropEvent(e);

--- a/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OSFile.cpp
@@ -326,7 +326,7 @@ void ezOSFile::FindFreeFilename(ezStringBuilder& inout_sPath, ezStringView sSuff
 
   ezStringBuilder newName;
 
-  for (ezUInt32 i = 1; i < 100000; ++i)
+  for (ezUInt32 i = 2; i < 100000; ++i)
   {
     newName.SetFormat("{}{}{}", orgName, sSuffix, i);
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
@@ -278,9 +278,6 @@ void ezJoltDynamicActorComponent::OnSimulationStarted()
     return;
   }
 
-  if (pMaterial == nullptr)
-    pMaterial = ezJoltCore::GetDefaultMaterial();
-
   ezJoltUserData* pUserData = nullptr;
   m_uiUserDataIndex = pModule->AllocateUserData(pUserData);
   pUserData->Init(this);
@@ -444,7 +441,7 @@ const ezJoltMaterial* ezJoltDynamicActorComponent::GetJoltMaterial() const
     }
   }
 
-  return nullptr;
+  return ezJoltCore::GetDefaultMaterial();
 }
 
 void ezJoltDynamicActorComponent::SetSurfaceFile(ezStringView sFile)

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -164,7 +164,7 @@ const ezJoltMaterial* ezJoltQueryShapeActorComponent::GetJoltMaterial() const
     }
   }
 
-  return nullptr;
+  return ezJoltCore::GetDefaultMaterial();
 }
 
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -7,6 +7,7 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <JoltPlugin/Actors/JoltQueryShapeActorComponent.h>
 #include <JoltPlugin/Shapes/JoltShapeComponent.h>
+#include <JoltPlugin/System/JoltCore.h>
 #include <JoltPlugin/System/JoltWorldModule.h>
 #include <JoltPlugin/Utilities/JoltConversionUtils.h>
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltStaticActorComponent.cpp
@@ -100,9 +100,6 @@ void ezJoltStaticActorComponent::OnSimulationStarted()
   auto* pSystem = pModule->GetJoltSystem();
   auto* pBodies = &pSystem->GetBodyInterface();
 
-  if (pMaterial == nullptr)
-    pMaterial = ezJoltCore::GetDefaultMaterial();
-
   bodyCfg.mPosition = ezJoltConversionUtils::ToVec3(trans.m_Position);
   bodyCfg.mRotation = ezJoltConversionUtils::ToQuat(trans.m_Rotation).Normalized();
   bodyCfg.mMotionType = JPH::EMotionType::Static;
@@ -251,7 +248,7 @@ const ezJoltMaterial* ezJoltStaticActorComponent::GetJoltMaterial() const
     }
   }
 
-  return nullptr;
+  return ezJoltCore::GetDefaultMaterial();
 }
 
 void ezJoltStaticActorComponent::SetSurfaceFile(ezStringView sFile)

--- a/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltShapeSphereComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Shapes/Implementation/JoltShapeSphereComponent.cpp
@@ -7,6 +7,7 @@
 #include <JoltPlugin/Resources/JoltMaterial.h>
 #include <JoltPlugin/Shapes/JoltShapeSphereComponent.h>
 #include <JoltPlugin/Utilities/JoltConversionUtils.h>
+#include <Physics/Collision/Shape/EmptyShape.h>
 
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ezJoltShapeSphereComponent, 1, ezComponentMode::Static)
@@ -69,15 +70,24 @@ void ezJoltShapeSphereComponent::SetRadius(float f)
 
 void ezJoltShapeSphereComponent::CreateShapes(ezDynamicArray<ezJoltSubShape>& out_Shapes, const ezTransform& rootTransform, float fDensity, const ezJoltMaterial* pMaterial)
 {
-  auto pNewShape = new JPH::SphereShape(m_fRadius);
-  pNewShape->AddRef();
-  pNewShape->SetDensity(fDensity);
-  pNewShape->SetUserData(reinterpret_cast<ezUInt64>(GetUserData()));
-  pNewShape->SetMaterial(pMaterial);
-
   ezJoltSubShape& sub = out_Shapes.ExpandAndGetRef();
-  sub.m_pShape = pNewShape;
   sub.m_Transform = ezTransform::MakeLocalTransform(rootTransform, GetOwner()->GetGlobalTransform());
+
+  if (m_fRadius > 0.0f)
+  {
+    auto pNewShape = new JPH::SphereShape(m_fRadius);
+    pNewShape->SetDensity(fDensity);
+    pNewShape->SetMaterial(pMaterial);
+
+    sub.m_pShape = pNewShape;
+  }
+  else
+  {
+    sub.m_pShape = new JPH::EmptyShape();
+  }
+
+  sub.m_pShape->AddRef();
+  sub.m_pShape->SetUserData(reinterpret_cast<ezUInt64>(GetUserData()));
 }
 
 


### PR DESCRIPTION
* After dropping an asset into a scene, the target window now gets focus. This fixes some issues, like "Delete" removing the asset in the browser, instead of removing the dropped object.
* Dragging assets into a scene doesn't show a distracting preview image overlay anymore.
* Default camera position in prefabs is now along -X, so that it points at the front of prefabs.
* Fixed a couple of issues when trying to rename assets in the asset browser.
* When grouping objects via CTRL+G, the group object now uses the same transform as the 'current' (last selected) object.
* It is now valid to add a Jolt sphere shape with radius 0 as an empty dummy shape.