### PR TITLE
Vulkan Ring Buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ Code/Engine/ezBuildInfo.h
 
 # NOTE: Allows Live++ API to be used in the project without being ignored by git.
 !Code/ThirdParty/LivePP/**
+cmake-build-debug-visual-studio

--- a/.gitignore
+++ b/.gitignore
@@ -364,4 +364,3 @@ Code/Engine/ezBuildInfo.h
 
 # NOTE: Allows Live++ API to be used in the project without being ignored by git.
 !Code/ThirdParty/LivePP/**
-cmake-build-debug-visual-studio

--- a/Code/Engine/Foundation/UserConfig.h
+++ b/Code/Engine/Foundation/UserConfig.h
@@ -40,7 +40,12 @@
 
 // Tracking of memory allocations.
 #  undef EZ_ALLOC_TRACKING_DEFAULT
-#  define EZ_ALLOC_TRACKING_DEFAULT ezAllocatorTrackingMode::AllocationStatsAndStacktraces
+
+#  if EZ_ENABLED(EZ_PLATFORM_ANDROID)
+#    define EZ_ALLOC_TRACKING_DEFAULT ezAllocatorTrackingMode::AllocationStatsIgnoreLeaks
+#  else
+#    define EZ_ALLOC_TRACKING_DEFAULT ezAllocatorTrackingMode::AllocationStatsAndStacktraces
+#  endif
 
 #endif
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
@@ -8,7 +8,6 @@
 #include <Shaders/Common/ObjectConstants.h>
 
 ezInstanceData::ezInstanceData(ezUInt32 uiMaxInstanceCount, bool bTransient)
-
 {
   CreateBuffer(uiMaxInstanceCount, bTransient);
 
@@ -96,7 +95,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezInstanceDataProvider, 1, ezRTTIDefaultAllocato
   }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezInstanceDataProvider::ezInstanceDataProvider() = default;
+ezInstanceDataProvider::ezInstanceDataProvider()
+{
+}
 
 ezInstanceDataProvider::~ezInstanceDataProvider() = default;
 

--- a/Code/Engine/RendererCore/Pipeline/InstanceDataProvider.h
+++ b/Code/Engine/RendererCore/Pipeline/InstanceDataProvider.h
@@ -18,7 +18,7 @@ public:
   /// Constructor.
   /// \param uiMaxInstanceCount How many instances this object can represent.
   /// \param bTransient If true, data will not be preserved across frames, requiring re-upload every frame.
-  ezInstanceData(ezUInt32 uiMaxInstanceCount = 1024, bool bTransient = false);
+  ezInstanceData(ezUInt32 uiMaxInstanceCount = 1024, bool bTransient = true);
   ~ezInstanceData();
 
   ezGALBufferPool m_InstanceDataBuffer;

--- a/Code/Engine/RendererFoundation/State/Implementation/State.cpp
+++ b/Code/Engine/RendererFoundation/State/Implementation/State.cpp
@@ -1,6 +1,5 @@
 #include <RendererFoundation/RendererFoundationPCH.h>
 
-#include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/State/State.h>
 
 ezGALBlendState::ezGALBlendState(const ezGALBlendStateCreationDescription& Description)

--- a/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
@@ -1,0 +1,77 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Utils/RingBufferTracker.h>
+
+ezRingBufferTracker::ezRingBufferTracker(ezUInt32 uiAlignment, ezUInt32 uiTotalSize)
+  : m_uiAlignment(uiAlignment)
+  , m_uiTotalSize(uiTotalSize)
+  , m_uiFree(uiTotalSize)
+{
+  EZ_ASSERT_DEBUG(ezMath::IsPowerOf2(m_uiAlignment), "Non-power of two alignment not supported");
+}
+
+ezResult ezRingBufferTracker::Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiAllocatedOffset)
+{
+  uiSize = ezMemoryUtils::AlignSize(uiSize, m_uiAlignment);
+
+  FrameData* pData = nullptr;
+  // We don't want to append data to an already submitted FrameData, so we explicitly don't remove the s_FrameDataSubmitted flag before comparing frames.
+  if (m_FrameData.IsEmpty() || m_FrameData.PeekBack().m_uiFrame != uiCurrentFrame)
+  {
+    pData = &m_FrameData.ExpandAndGetRef();
+    pData->m_uiFrame = uiCurrentFrame;
+    pData->m_uiStartOffset = m_uiCurrentOffset;
+  }
+  else
+  {
+    pData = &m_FrameData.PeekBack();
+  }
+
+  if (m_uiFree < uiSize)
+    return EZ_FAILURE;
+
+  if (m_uiCurrentOffset + uiSize > m_uiTotalSize)
+  {
+    const ezUInt32 uiSkip = m_uiTotalSize - m_uiCurrentOffset;
+    if (m_uiFree - uiSkip < uiSize)
+      return EZ_FAILURE;
+
+    pData->m_uiSize += uiSkip;
+    m_uiFree -= uiSkip;
+    // Creating a new frame data when going over the buffer boundary makes it easier to later upload the data.
+    pData = &m_FrameData.ExpandAndGetRef();
+    pData->m_uiFrame = uiCurrentFrame;
+    m_uiCurrentOffset = 0;
+  }
+
+  out_uiAllocatedOffset = m_uiCurrentOffset;
+  pData->m_uiSize += uiSize;
+  m_uiFree -= uiSize;
+  m_uiCurrentOffset = (m_uiCurrentOffset + uiSize) % m_uiTotalSize;
+
+  return EZ_SUCCESS;
+}
+
+void ezRingBufferTracker::Free(ezUInt64 uiUpToFrame)
+{
+  while (!m_FrameData.IsEmpty() && (m_FrameData[0].m_uiFrame & ~s_FrameDataSubmitted) <= uiUpToFrame)
+  {
+    m_uiFree += m_FrameData[0].m_uiSize;
+    m_FrameData.RemoveAtAndCopy(0);
+  }
+}
+
+ezResult ezRingBufferTracker::SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_FrameData)
+{
+  out_FrameData.Clear();
+  for (ezUInt32 i = 0; i < m_FrameData.GetCount(); i++)
+  {
+    if (m_FrameData[i].m_uiFrame == uiFrame)
+    {
+      FrameData& data = out_FrameData.ExpandAndGetRef();
+      data = m_FrameData[i];
+      m_FrameData[i].m_uiFrame |= s_FrameDataSubmitted;
+    }
+  }
+  return out_FrameData.IsEmpty() ? EZ_FAILURE : EZ_SUCCESS;
+}

--- a/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
@@ -15,8 +15,12 @@ ezResult ezRingBufferTracker::Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame,
   uiSize = ezMemoryUtils::AlignSize(uiSize, m_uiAlignment);
 
   FrameData* pData = nullptr;
-  // We don't want to append data to an already submitted FrameData, so we explicitly don't remove the s_FrameDataSubmitted flag before comparing frames.
-  if (m_FrameData.IsEmpty() || m_FrameData.PeekBack().m_uiFrame != uiCurrentFrame)
+  // New frame data blocks need to be created in these cases:
+  // 1: There is no block yet.
+  // 2: The last block is from a previous frame.
+  // 3: The block was already submitted. For this, we explicitly don't remove the s_FrameDataSubmitted flag before comparing frames.
+  // 4: We wrapped around in the last allocation, i.e. m_uiCurrentOffset is before the last blocks starting point.
+  if (m_FrameData.IsEmpty() || m_FrameData.PeekBack().m_uiFrame != uiCurrentFrame || m_uiCurrentOffset < m_FrameData.PeekBack().m_uiStartOffset)
   {
     pData = &m_FrameData.ExpandAndGetRef();
     pData->m_uiFrame = uiCurrentFrame;

--- a/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/RingBufferTracker.cpp
@@ -65,17 +65,17 @@ void ezRingBufferTracker::Free(ezUInt64 uiUpToFrame)
   }
 }
 
-ezResult ezRingBufferTracker::SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_FrameData)
+ezResult ezRingBufferTracker::SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_frameData)
 {
-  out_FrameData.Clear();
+  out_frameData.Clear();
   for (ezUInt32 i = 0; i < m_FrameData.GetCount(); i++)
   {
     if (m_FrameData[i].m_uiFrame == uiFrame)
     {
-      FrameData& data = out_FrameData.ExpandAndGetRef();
+      FrameData& data = out_frameData.ExpandAndGetRef();
       data = m_FrameData[i];
       m_FrameData[i].m_uiFrame |= s_FrameDataSubmitted;
     }
   }
-  return out_FrameData.IsEmpty() ? EZ_FAILURE : EZ_SUCCESS;
+  return out_frameData.IsEmpty() ? EZ_FAILURE : EZ_SUCCESS;
 }

--- a/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
@@ -14,9 +14,9 @@ public:
   // \brief A memory range starting at m_uiStartOffset of size m_uiSize that was modified in a frame.
   struct FrameData
   {
-    ezUInt64 m_uiFrame = 0; ///< The frame in which the memory was allocated.
+    ezUInt64 m_uiFrame = 0;       ///< The frame in which the memory was allocated.
     ezUInt32 m_uiStartOffset = 0; ///< The start offset of the memory that was modified in this frame.
-    ezUInt32 m_uiSize = 0; ///< The size of the memory modification.
+    ezUInt32 m_uiSize = 0;        ///< The size of the memory modification.
   };
 
 public:
@@ -41,11 +41,11 @@ public:
   /// \param uiFrame Frame index to submit dirty ranges.
   /// \param out_FrameData Will receive the FrameData objects containing the dirty ranges of the memory.
   /// \return Returns EZ_FAILURE if no allocations were made in uiFrame.
-  ezResult SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_FrameData); // [tested]
+  ezResult SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_FrameData);    // [tested]
 
-  EZ_ALWAYS_INLINE ezUInt32 GetTotalMemory() const { return m_uiTotalSize; } // [tested]
+  EZ_ALWAYS_INLINE ezUInt32 GetTotalMemory() const { return m_uiTotalSize; }           // [tested]
   EZ_ALWAYS_INLINE ezUInt32 GetUsedMemory() const { return m_uiTotalSize - m_uiFree; } // [tested]
-  EZ_ALWAYS_INLINE ezUInt32 GetFreeMemory() const { return m_uiFree; } // [tested]
+  EZ_ALWAYS_INLINE ezUInt32 GetFreeMemory() const { return m_uiFree; }                 // [tested]
 
 private:
   ezUInt32 m_uiAlignment = 0;

--- a/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
@@ -39,9 +39,9 @@ public:
   /// \brief Retrieves the dirty memory ranges of this frame.
   /// Note that this can be anything between zero and two. In case that the end of the buffer is reached and wraps around within a frame, the end part and the part at the start are split into two FrameData objects. Can be called multiple times per frame. Each dirty range will only be given out once.
   /// \param uiFrame Frame index to submit dirty ranges.
-  /// \param out_FrameData Will receive the FrameData objects containing the dirty ranges of the memory.
+  /// \param out_frameData Will receive the FrameData objects containing the dirty ranges of the memory.
   /// \return Returns EZ_FAILURE if no allocations were made in uiFrame.
-  ezResult SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_FrameData);    // [tested]
+  ezResult SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_frameData);    // [tested]
 
   EZ_ALWAYS_INLINE ezUInt32 GetTotalMemory() const { return m_uiTotalSize; }           // [tested]
   EZ_ALWAYS_INLINE ezUInt32 GetUsedMemory() const { return m_uiTotalSize - m_uiFree; } // [tested]

--- a/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/RingBufferTracker.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+/// \brief Tracks memory in a ring buffer on a frame by frame basis.
+/// The intended usage pattern is that for frame N, multiple allocations are called. This is followed by a call to SubmitFrame for frame N (optional) which allows the user to handle to memory ranges that were modified in this frame. Eventually at a later point in time Free is called for frame N to allow reuse of the memory.
+/// Note that the assumption is that N is always increasing and that free is called for each frame in order.
+class EZ_RENDERERFOUNDATION_DLL ezRingBufferTracker
+{
+public:
+  // Used to tag the frameData as submitted to make sure we create a new FrameData bucket and don't upload the same range twice.
+  constexpr static ezUInt64 s_FrameDataSubmitted = EZ_BIT(63);
+
+  // \brief A memory range starting at m_uiStartOffset of size m_uiSize that was modified in a frame.
+  struct FrameData
+  {
+    ezUInt64 m_uiFrame = 0; ///< The frame in which the memory was allocated.
+    ezUInt32 m_uiStartOffset = 0; ///< The start offset of the memory that was modified in this frame.
+    ezUInt32 m_uiSize = 0; ///< The size of the memory modification.
+  };
+
+public:
+  /// Crates a new tracker.
+  /// \param uiAlignment All allocations will be aligned to this. Must be power of two.
+  /// \param uiTotalSize The size of the memory.
+  ezRingBufferTracker(ezUInt32 uiAlignment, ezUInt32 uiTotalSize); // [tested]
+
+  /// Allocates memory of the given size.
+  /// \param uiSize Size requested.
+  /// \param uiCurrentFrame The current frame for which this allocation is tracked.
+  /// \param out_uiAllocatedOffset Will be filled by the start offset of the allocation inside the memory if successful.
+  /// \return Returns EZ_FAILURE if not enough memory remains to fulfil the allocation.
+  ezResult Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiAllocatedOffset); // [tested]
+
+  /// Makes all memory that was used up to uiUpToFrame available again for allocations.
+  /// \param uiUpToFrame All frames below this and this frame itself are safe to be reused.
+  void Free(ezUInt64 uiUpToFrame); // [tested]
+
+  /// \brief Retrieves the dirty memory ranges of this frame.
+  /// Note that this can be anything between zero and two. In case that the end of the buffer is reached and wraps around within a frame, the end part and the part at the start are split into two FrameData objects. Can be called multiple times per frame. Each dirty range will only be given out once.
+  /// \param uiFrame Frame index to submit dirty ranges.
+  /// \param out_FrameData Will receive the FrameData objects containing the dirty ranges of the memory.
+  /// \return Returns EZ_FAILURE if no allocations were made in uiFrame.
+  ezResult SubmitFrame(ezUInt64 uiFrame, ezDynamicArray<FrameData>& out_FrameData); // [tested]
+
+  EZ_ALWAYS_INLINE ezUInt32 GetTotalMemory() const { return m_uiTotalSize; } // [tested]
+  EZ_ALWAYS_INLINE ezUInt32 GetUsedMemory() const { return m_uiTotalSize - m_uiFree; } // [tested]
+  EZ_ALWAYS_INLINE ezUInt32 GetFreeMemory() const { return m_uiFree; } // [tested]
+
+private:
+  ezUInt32 m_uiAlignment = 0;
+  ezUInt32 m_uiTotalSize = 0;
+  ezUInt32 m_uiFree = 0;
+  ezUInt32 m_uiCurrentOffset = 0;
+  ezHybridArray<FrameData, 4> m_FrameData;
+};

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -206,4 +206,7 @@ private:
   ezHybridArray<vk::DescriptorSet, 4> m_DescriptorSets;
 
   ezDynamicArray<ezUInt8> m_PushConstants;
+
+  ezDeque<vk::DescriptorBufferInfo> m_DynamicUniformBuffers;
+  ezHybridArray<ezUInt32, 6> m_DynamicUniformBufferOffsets;
 };

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -7,6 +7,7 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h>
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
+#include <RendererVulkan/Pools/UniformBufferPoolVulkan.h>
 
 #include <vulkan/vulkan.hpp>
 
@@ -32,8 +33,10 @@ public:
 
   void Reset();
 
+  void EndFrame();
   void SetCurrentCommandBuffer(vk::CommandBuffer* commandBuffer, ezPipelineBarrierVulkan* pipelineBarrier);
-  void CommandBufferSubmitted(vk::Fence submitFence);
+  void BeforeCommandBufferSubmit();
+  void AfterCommandBufferSubmit(vk::Fence submitFence);
 
   // ezGALCommandEncoderCommonPlatformInterface
   // State setting functions
@@ -160,6 +163,8 @@ private:
 
   vk::CommandBuffer* m_pCommandBuffer = nullptr;
   ezPipelineBarrierVulkan* m_pPipelineBarrier = nullptr;
+
+  ezUniquePtr<ezUniformBufferPoolVulkan> m_pUniformBufferPool;
 
   // Cache flags.
   bool m_bPipelineStateDirty = true;

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1207,6 +1207,10 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
     m_TextureAndSampler.Clear();
     const ezUInt32 uiSets = m_PipelineDesc.m_pCurrentShader->GetSetCount();
     m_DescriptorSets.SetCount(uiSets);
+
+    ezDeque<vk::DescriptorBufferInfo> dynamicUniformBuffers;
+    ezHybridArray<ezUInt32, 6> dynamicUniformBufferOffsets;
+
     for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
     {
       m_DescriptorSets[uiSet] = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_LayoutDesc.m_layout[uiSet]);
@@ -1242,6 +1246,12 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
               write.pBufferInfo = &pBuffer->GetBufferInfo();
               EZ_ASSERT_DEBUG(write.pBufferInfo != nullptr, "Implementation error");
             }
+
+            auto& bufferInfo = dynamicUniformBuffers.ExpandAndGetRef();
+            bufferInfo = *m_pUniformBufferPool->GetBuffer(pBuffer);
+            dynamicUniformBufferOffsets.PushBack((ezUInt32)bufferInfo.offset);
+            bufferInfo.offset = 0;
+            write.pBufferInfo = &bufferInfo;
           }
           break;
           case ezGALShaderResourceType::Texture:
@@ -1317,7 +1327,7 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
 
       ezDescriptorSetPoolVulkan::UpdateDescriptorSet(m_DescriptorSets[uiSet], m_DescriptorWrites);
     }
-    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), 0, nullptr);
+    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), dynamicUniformBufferOffsets.GetCount(), dynamicUniformBufferOffsets.GetData());
   }
 
   if (m_bPushConstantsDirty && m_LayoutDesc.m_pushConstants.size > 0)

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1207,9 +1207,8 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
     m_TextureAndSampler.Clear();
     const ezUInt32 uiSets = m_PipelineDesc.m_pCurrentShader->GetSetCount();
     m_DescriptorSets.SetCount(uiSets);
-
-    ezDeque<vk::DescriptorBufferInfo> dynamicUniformBuffers;
-    ezHybridArray<ezUInt32, 6> dynamicUniformBufferOffsets;
+    m_DynamicUniformBuffers.Clear();
+    m_DynamicUniformBufferOffsets.Clear();
 
     for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
     {
@@ -1248,9 +1247,9 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
             }
 
             // Move offset out and into the separate offset array.
-            auto& bufferInfo = dynamicUniformBuffers.ExpandAndGetRef();
+            auto& bufferInfo = m_DynamicUniformBuffers.ExpandAndGetRef();
             bufferInfo = *write.pBufferInfo;
-            dynamicUniformBufferOffsets.PushBack((ezUInt32)bufferInfo.offset);
+            m_DynamicUniformBufferOffsets.PushBack((ezUInt32)bufferInfo.offset);
             bufferInfo.offset = 0;
             write.pBufferInfo = &bufferInfo;
           }
@@ -1328,7 +1327,7 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
 
       ezDescriptorSetPoolVulkan::UpdateDescriptorSet(m_DescriptorSets[uiSet], m_DescriptorWrites);
     }
-    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), dynamicUniformBufferOffsets.GetCount(), dynamicUniformBufferOffsets.GetData());
+    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), m_DynamicUniformBufferOffsets.GetCount(), m_DynamicUniformBufferOffsets.GetData());
   }
 
   if (m_bPushConstantsDirty && m_LayoutDesc.m_pushConstants.size > 0)

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -29,10 +29,14 @@ ezGALCommandEncoderImplVulkan::ezGALCommandEncoderImplVulkan(ezGALDeviceVulkan& 
   : m_GALDeviceVulkan(device)
 {
   m_vkDevice = device.GetVulkanDevice();
+  m_pUniformBufferPool = EZ_NEW(device.GetAllocator(), ezUniformBufferPoolVulkan, &device);
+  m_pUniformBufferPool->Initialize();
 }
 
 ezGALCommandEncoderImplVulkan::~ezGALCommandEncoderImplVulkan()
 {
+  m_pUniformBufferPool->DeInitialize();
+  m_pUniformBufferPool = nullptr;
 }
 
 void ezGALCommandEncoderImplVulkan::Reset()
@@ -81,7 +85,17 @@ void ezGALCommandEncoderImplVulkan::Reset()
   m_clearValues.Clear();
 }
 
-void ezGALCommandEncoderImplVulkan::CommandBufferSubmitted(vk::Fence submitFence)
+void ezGALCommandEncoderImplVulkan::EndFrame()
+{
+  m_pUniformBufferPool->EndFrame();
+}
+
+void ezGALCommandEncoderImplVulkan::BeforeCommandBufferSubmit()
+{
+  m_pUniformBufferPool->BeforeCommandBufferSubmit();
+}
+
+void ezGALCommandEncoderImplVulkan::AfterCommandBufferSubmit(vk::Fence submitFence)
 {
   m_pCommandBuffer = nullptr;
   m_pPipelineBarrier = nullptr;
@@ -284,9 +298,11 @@ void ezGALCommandEncoderImplVulkan::UpdateBufferPlatform(const ezGALBuffer* pDes
   switch (updateMode)
   {
     case ezGALUpdateMode::TransientConstantBuffer:
-      pVulkanDestination->DiscardBuffer();
-      [[fallthrough]];
-
+      EZ_ASSERT_DEBUG(pDestination->GetDescription().m_BufferFlags.AreAllSet(ezGALBufferUsageFlags::Transient | ezGALBufferUsageFlags::ConstantBuffer), "Only transient constant buffer can make use of TransientConstantBuffer update mode");
+      EZ_ASSERT_DEBUG(uiDestOffset == 0, "Offset not supported");
+      EZ_ASSERT_DEBUG(pVulkanDestination->GetDescription().m_uiTotalSize == pSourceData.GetCount(), "Transient buffers must be updated in their entirety");
+      m_pUniformBufferPool->UpdateBuffer(pVulkanDestination, pSourceData);
+      break;
     case ezGALUpdateMode::AheadOfTime:
       m_GALDeviceVulkan.GetInitContext().UpdateBuffer(pVulkanDestination, uiDestOffset, pSourceData);
       break;
@@ -407,17 +423,14 @@ void ezGALCommandEncoderImplVulkan::UpdateTexturePlatform(const ezGALTexture* pD
     (uiDepth + blockExtent[2] - 1) / blockExtent[2]};
 
   const vk::DeviceSize uiTotalSize = uiBlockSize * blockCount.width * blockCount.height * blockCount.depth;
-  ezStagingBufferVulkan stagingBuffer = m_GALDeviceVulkan.GetStagingBufferPool().AllocateBuffer(0, uiTotalSize);
+  ezStagingBufferVulkan stagingBuffer = m_GALDeviceVulkan.GetStagingBufferPool().AllocateBuffer(uiTotalSize);
 
   const ezUInt32 uiBufferRowPitch = uiBlockSize * blockCount.width;
   const ezUInt32 uiBufferSlicePitch = uiBufferRowPitch * blockCount.height;
   EZ_ASSERT_DEV(uiBufferRowPitch == data.m_uiRowPitch, "Row pitch with padding is not implemented yet.");
 
-  void* pData = nullptr;
-  ezMemoryAllocatorVulkan::MapMemory(stagingBuffer.m_alloc, &pData);
   EZ_ASSERT_DEBUG(data.m_pData.GetCount() >= uiTotalSize, "Not enough data provided to update texture");
-  ezMemoryUtils::RawByteCopy(pData, data.m_pData.GetPtr(), uiTotalSize);
-  ezMemoryAllocatorVulkan::UnmapMemory(stagingBuffer.m_alloc);
+  ezMemoryUtils::RawByteCopy(stagingBuffer.m_Data.GetPtr(), data.m_pData.GetPtr(), uiTotalSize);
 
   vk::BufferImageCopy region = {};
   region.imageSubresource.aspectMask = range.aspectMask;
@@ -428,12 +441,11 @@ void ezGALCommandEncoderImplVulkan::UpdateTexturePlatform(const ezGALTexture* pD
   region.imageOffset = vk::Offset3D(DestinationBox.m_vMin.x, DestinationBox.m_vMin.y, DestinationBox.m_vMin.z);
   region.imageExtent = vk::Extent3D(uiWidth, uiHeight, uiDepth);
 
-  region.bufferOffset = 0;
+  region.bufferOffset = stagingBuffer.m_uiOffset;
   region.bufferRowLength = blockExtent[0] * uiBufferRowPitch / uiBlockSize;
   region.bufferImageHeight = blockExtent[1] * uiBufferSlicePitch / uiBufferRowPitch;
 
   m_pCommandBuffer->copyBufferToImage(stagingBuffer.m_buffer, pDestVulkan->GetImage(), pDestVulkan->GetPreferredLayout(vk::ImageLayout::eTransferDstOptimal), 1, &region);
-  m_GALDeviceVulkan.GetStagingBufferPool().ReclaimBuffer(stagingBuffer);
 }
 
 void ezGALCommandEncoderImplVulkan::ResolveTexturePlatform(const ezGALTexture* pDestination, const ezGALTextureSubresource& DestinationSubResource,
@@ -1220,7 +1232,16 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
           {
             const ezGALBufferVulkan* pBuffer = ezUInt32(mapping.m_iSlot) < resources.m_pBoundConstantBuffers.GetCount() ? resources.m_pBoundConstantBuffers[mapping.m_iSlot] : nullptr;
             EZ_VULKAN_CHECK_STATE(pBuffer != nullptr, "No CB bound at '{}'", mapping.m_sName.GetView());
-            write.pBufferInfo = &pBuffer->GetBufferInfo();
+            if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::Transient))
+            {
+              write.pBufferInfo = m_pUniformBufferPool->GetBuffer(pBuffer);
+              EZ_ASSERT_DEBUG(write.pBufferInfo != nullptr, "Implementation error");
+            }
+            else
+            {
+              write.pBufferInfo = &pBuffer->GetBufferInfo();
+              EZ_ASSERT_DEBUG(write.pBufferInfo != nullptr, "Implementation error");
+            }
           }
           break;
           case ezGALShaderResourceType::Texture:

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1247,8 +1247,9 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
               EZ_ASSERT_DEBUG(write.pBufferInfo != nullptr, "Implementation error");
             }
 
+            // Move offset out and into the separate offset array.
             auto& bufferInfo = dynamicUniformBuffers.ExpandAndGetRef();
-            bufferInfo = *m_pUniformBufferPool->GetBuffer(pBuffer);
+            bufferInfo = *write.pBufferInfo;
             dynamicUniformBufferOffsets.PushBack((ezUInt32)bufferInfo.offset);
             bufferInfo.offset = 0;
             write.pBufferInfo = &bufferInfo;

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -410,8 +410,9 @@ private:
 
   static constexpr ezUInt32 FRAMES = 4;
 
-  ezUInt64 m_uiFrameCounter = 1; ///< We start at 1 so m_uiFrameCounter and m_uiSafeFrame are not equal at the start.
-  ezUInt64 m_uiSafeFrame = 0;
+  // These are atomic as the ezInitContextVulkan is accessing these on worker threads when uploading resources in the background.
+  ezAtomicInteger<ezUInt64> m_uiFrameCounter = 1; ///< We start at 1 so m_uiFrameCounter and m_uiSafeFrame are not equal at the start.
+  ezAtomicInteger<ezUInt64> m_uiSafeFrame = 0;
   ezUInt8 m_uiCurrentPerFrameData = m_uiFrameCounter % FRAMES;
 
   vk::Instance m_instance;

--- a/Code/Engine/RendererVulkan/Device/InitContext.h
+++ b/Code/Engine/RendererVulkan/Device/InitContext.h
@@ -18,7 +18,7 @@ public:
   void AfterBeginFrame();
 
   ezMutex& AccessLock() { return m_Lock; }
-  
+
   /// \brief Returns a finished command buffer of all background loading up to this point.
   ///    The command buffer is already ended and marked to be reclaimed so the only thing done on it should be to submit it.
   vk::CommandBuffer GetFinishedCommandBuffer();

--- a/Code/Engine/RendererVulkan/Device/InitContext.h
+++ b/Code/Engine/RendererVulkan/Device/InitContext.h
@@ -15,6 +15,10 @@ public:
   ezInitContextVulkan(ezGALDeviceVulkan* pDevice);
   ~ezInitContextVulkan();
 
+  void AfterBeginFrame();
+
+  ezMutex& AccessLock() { return m_Lock; }
+  
   /// \brief Returns a finished command buffer of all background loading up to this point.
   ///    The command buffer is already ended and marked to be reclaimed so the only thing done on it should be to submit it.
   vk::CommandBuffer GetFinishedCommandBuffer();
@@ -38,6 +42,13 @@ public:
   /// \param uiOffset The offset inside the buffer where the new data should be placed.
   /// \param pSourceData The new data to update the buffer with.
   void UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezUInt32 uiOffset, ezArrayPtr<const ezUInt8> pSourceData);
+
+  /// \brief Used by ezUniformBufferPoolVulkan to write the entire uniform scratch pool to the GPU
+  /// \param gpuBuffer The device local buffer to update.
+  /// \param stagingBuffer The staging buffer that contains the data to be copied to gpuBuffer. If null, buffer is CPU writable and already contains the data.
+  /// \param uiOffset Offset in the buffer.
+  /// \param uiSize The size of the data to be copied from stagingBuffer to gpuBuffer.
+  void UpdateDynamicUniformBuffer(vk::Buffer gpuBuffer, vk::Buffer stagingBuffer, ezUInt32 uiOffset, ezUInt32 uiSize);
 
 private:
   void EnsureCommandBufferExists();

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -22,7 +22,7 @@ void ezDescriptorSetPoolVulkan::Initialize(vk::Device device)
 
   // Not used by EZ so far.
   s_descriptorWeights[vk::DescriptorType::eStorageTexelBuffer] = 0.5f;   // Read / write linear texel buffer with view.
-  s_descriptorWeights[vk::DescriptorType::eUniformBufferDynamic] = 0.0f; // Same as eUniformBuffer but allows updating the memory offset into the buffer dynamically.
+  s_descriptorWeights[vk::DescriptorType::eUniformBufferDynamic] = 1.0f; // Same as eUniformBuffer but allows updating the memory offset into the buffer dynamically.
   s_descriptorWeights[vk::DescriptorType::eStorageBufferDynamic] = 0.0f; // Same as eStorageBuffer but allows updating the memory offset into the buffer dynamically.
 
   // Not supported by EZ so far.

--- a/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
@@ -90,7 +90,7 @@ void ezQueryPoolVulkan::Calibrate()
   m_TimestampPool.m_device.destroyEvent(event);
 }
 
-void ezQueryPoolVulkan::BeginFrame(vk::CommandBuffer commandBuffer)
+void ezQueryPoolVulkan::AfterBeginFrame(vk::CommandBuffer commandBuffer)
 {
   ezUInt64 uiCurrentFrame = m_pDevice->GetCurrentFrame();
   ezUInt64 uiSafeFrame = m_pDevice->GetSafeFrame();

--- a/Code/Engine/RendererVulkan/Pools/Implementation/StagingBufferPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/StagingBufferPoolVulkan.cpp
@@ -10,8 +10,8 @@ void ezStagingBufferPoolVulkan::Initialize(ezGALDeviceVulkan* pDevice, ezUInt64 
   m_device = pDevice->GetVulkanDevice();
 
   const vk::PhysicalDeviceProperties& properties = m_pDevice->GetPhysicalDeviceProperties();
-  m_uiAlignment = ezMath::Max<vk::DeviceSize>(16, m_uiAlignment, properties.limits.nonCoherentAtomSize);
-  m_uiAlignment = ezMath::Max(m_uiAlignment, properties.limits.optimalBufferCopyOffsetAlignment);
+  m_uiAlignment = ezMath::Max<ezUInt64>(16ull, m_uiAlignment, (ezUInt64)properties.limits.nonCoherentAtomSize);
+  m_uiAlignment = ezMath::Max(m_uiAlignment, (ezUInt64)properties.limits.optimalBufferCopyOffsetAlignment);
   EZ_ASSERT_DEBUG(ezMath::IsPowerOf2(m_uiAlignment), "Non-power of two alignment not supported");
   m_uiStartingPoolSize = ezMemoryUtils::AlignSize(uiStartingPoolSize, m_uiAlignment);
 }
@@ -38,7 +38,7 @@ void ezStagingBufferPoolVulkan::AfterBeginFrame()
     m_uiTotalAllocatedSize += pPool->m_Tracker.GetUsedMemory();
     pPool->Free(uiSafeFrame);
   }
-  m_uiHighWatermark = ezMath::Max(m_uiTotalAllocatedSize, m_uiHighWatermark);
+  m_uiHighWatermark = ezMath::Max<ezUInt64>(m_uiTotalAllocatedSize, m_uiHighWatermark);
 
   // Keep one pool around at all times.
   while (m_Pools.GetCount() > 1 && m_Pools.PeekBack()->m_uiFramesWithoutAllocations > s_uiNumberOfFramesToKeepUnusedPoolsAlive)
@@ -58,7 +58,7 @@ void ezStagingBufferPoolVulkan::BeforeCommandBufferSubmit()
   }
 }
 
-ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize size)
+ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(ezUInt64 size)
 {
   EZ_ASSERT_DEBUG(m_device, "ezStagingBufferPoolVulkan::Initialize not called");
   ezStagingBufferVulkan buffer;
@@ -88,9 +88,9 @@ ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize s
   return buffer;
 }
 
-ezStagingBufferPoolVulkan::StagingBufferPool* ezStagingBufferPoolVulkan::GetFreePool(vk::DeviceSize uiSize)
+ezStagingBufferPoolVulkan::StagingBufferPool* ezStagingBufferPoolVulkan::GetFreePool(ezUInt64 uiSize)
 {
-  vk::DeviceSize uiNewPoolSize = m_Pools.IsEmpty() ? m_uiStartingPoolSize : m_Pools.PeekBack()->m_Tracker.GetTotalMemory() * 2;
+  ezUInt64 uiNewPoolSize = m_Pools.IsEmpty() ? m_uiStartingPoolSize : m_Pools.PeekBack()->m_Tracker.GetTotalMemory() * 2;
 
   m_uiStartingPoolSize = ezMemoryUtils::AlignSize(ezMath::Max(uiNewPoolSize, uiSize), m_uiAlignment);
 

--- a/Code/Engine/RendererVulkan/Pools/Implementation/StagingBufferPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/StagingBufferPoolVulkan.cpp
@@ -4,28 +4,107 @@
 
 #include <RendererVulkan/Device/DeviceVulkan.h>
 
-void ezStagingBufferPoolVulkan::Initialize(ezGALDeviceVulkan* pDevice)
+void ezStagingBufferPoolVulkan::Initialize(ezGALDeviceVulkan* pDevice, ezUInt64 uiStartingPoolSize)
 {
   m_pDevice = pDevice;
   m_device = pDevice->GetVulkanDevice();
+
+  const vk::PhysicalDeviceProperties& properties = m_pDevice->GetPhysicalDeviceProperties();
+  m_uiAlignment = ezMath::Max<vk::DeviceSize>(16, m_uiAlignment, properties.limits.nonCoherentAtomSize);
+  m_uiAlignment = ezMath::Max(m_uiAlignment, properties.limits.optimalBufferCopyOffsetAlignment);
+  EZ_ASSERT_DEBUG(ezMath::IsPowerOf2(m_uiAlignment), "Non-power of two alignment not supported");
+  m_uiStartingPoolSize = ezMemoryUtils::AlignSize(uiStartingPoolSize, m_uiAlignment);
 }
 
 void ezStagingBufferPoolVulkan::DeInitialize()
 {
+  // We assume the device makes sure no buffers are still in use before calling this.
   m_device = nullptr;
+  for (StagingBufferPool* pPool : m_Pools)
+  {
+    EZ_DELETE(m_pDevice->GetAllocator(), pPool);
+  }
+  m_Pools.Clear();
+
+  ezLog::Info("StagingBufferPoolVulkan#{}: high water mark: {}", ezArgP(this), ezArgHumanReadable((ezInt64)m_uiHighWatermark));
 }
 
-ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize alignment, vk::DeviceSize size)
+void ezStagingBufferPoolVulkan::AfterBeginFrame()
 {
-  const vk::PhysicalDeviceProperties& properties = m_pDevice->GetPhysicalDeviceProperties();
-  alignment = ezMath::Max<vk::DeviceSize>(16, alignment, properties.limits.nonCoherentAtomSize);
-  size = ezMemoryUtils::AlignSize(size, alignment);
+  ezUInt64 m_uiTotalAllocatedSize = 0;
+  const ezUInt64 uiSafeFrame = m_pDevice->GetSafeFrame();
+  for (StagingBufferPool* pPool : m_Pools)
+  {
+    m_uiTotalAllocatedSize += pPool->m_Tracker.GetUsedMemory();
+    pPool->Free(uiSafeFrame);
+  }
+  m_uiHighWatermark = ezMath::Max(m_uiTotalAllocatedSize, m_uiHighWatermark);
 
+  // Keep one pool around at all times.
+  while (m_Pools.GetCount() > 1 && m_Pools.PeekBack()->m_uiFramesWithoutAllocations > s_uiNumberOfFramesToKeepUnusedPoolsAlive)
+  {
+    // It is safe to delete the pool here as there can't be any usage on the GPU of the buffer if the pool is unused.
+    StagingBufferPool* pPool = m_Pools.PeekBack();
+    m_Pools.PopBack();
+    EZ_DELETE(m_pDevice->GetAllocator(), pPool);
+  }
+}
+
+void ezStagingBufferPoolVulkan::BeforeCommandBufferSubmit()
+{
+  for (StagingBufferPool* pPool : m_Pools)
+  {
+    pPool->Submit(m_pDevice, m_pDevice->GetCurrentFrame());
+  }
+}
+
+ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize size)
+{
+  EZ_ASSERT_DEBUG(m_device, "ezStagingBufferPoolVulkan::Initialize not called");
   ezStagingBufferVulkan buffer;
 
-  EZ_ASSERT_DEBUG(m_device, "ezStagingBufferPoolVulkan::Initialize not called");
+  ezUInt32 uiOffset = 0;
+  ezByteArrayPtr allocation;
+  for (StagingBufferPool* pPool : m_Pools)
+  {
+    if (pPool->Allocate((ezUInt32)size, m_pDevice->GetCurrentFrame(), uiOffset, allocation).Succeeded())
+    {
+      buffer.m_alloc = pPool->m_Alloc;
+      buffer.m_buffer = pPool->m_Buffer;
+      break;
+    }
+  }
+
+  if (allocation.IsEmpty())
+  {
+    StagingBufferPool* pPool = GetFreePool(size);
+    pPool->Allocate((ezUInt32)size, m_pDevice->GetCurrentFrame(), uiOffset, allocation).AssertSuccess("Newly created pool should be able to allocate requested size");
+    buffer.m_alloc = pPool->m_Alloc;
+    buffer.m_buffer = pPool->m_Buffer;
+  }
+
+  buffer.m_Data = allocation;
+  buffer.m_uiOffset = uiOffset;
+  return buffer;
+}
+
+ezStagingBufferPoolVulkan::StagingBufferPool* ezStagingBufferPoolVulkan::GetFreePool(vk::DeviceSize uiSize)
+{
+  vk::DeviceSize uiNewPoolSize = m_Pools.IsEmpty() ? m_uiStartingPoolSize : m_Pools.PeekBack()->m_Tracker.GetTotalMemory() * 2;
+
+  m_uiStartingPoolSize = ezMemoryUtils::AlignSize(ezMath::Max(uiNewPoolSize, uiSize), m_uiAlignment);
+
+  StagingBufferPool* pPool = EZ_NEW(m_pDevice->GetAllocator(), StagingBufferPool, (ezUInt32)m_uiAlignment, (ezUInt32)m_uiStartingPoolSize);
+  m_Pools.PushBack(pPool);
+  return pPool;
+}
+
+
+ezStagingBufferPoolVulkan::StagingBufferPool::StagingBufferPool(ezUInt32 uiAlignment, ezUInt32 uiTotalSize)
+  : m_Tracker(uiAlignment, uiTotalSize)
+{
   vk::BufferCreateInfo bufferCreateInfo = {};
-  bufferCreateInfo.size = size;
+  bufferCreateInfo.size = uiTotalSize;
   bufferCreateInfo.usage = vk::BufferUsageFlagBits::eTransferSrc;
 
   bufferCreateInfo.pQueueFamilyIndices = nullptr;
@@ -34,17 +113,40 @@ ezStagingBufferVulkan ezStagingBufferPoolVulkan::AllocateBuffer(vk::DeviceSize a
 
   ezVulkanAllocationCreateInfo allocInfo;
   allocInfo.m_usage = ezVulkanMemoryUsage::Auto;
-  allocInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessSequentialWrite;
+  allocInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessSequentialWrite | ezVulkanAllocationCreateFlags::Mapped;
 
-  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocInfo, buffer.m_buffer, buffer.m_alloc, &buffer.m_allocInfo));
-
-  return buffer;
+  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocInfo, m_Buffer, m_Alloc, &m_AllocInfo));
+  m_Data = ezMakeArrayPtr(reinterpret_cast<ezUInt8*>(m_AllocInfo.m_pMappedData), uiTotalSize);
 }
 
-void ezStagingBufferPoolVulkan::ReclaimBuffer(ezStagingBufferVulkan& buffer)
+ezStagingBufferPoolVulkan::StagingBufferPool::~StagingBufferPool()
 {
-  m_pDevice->DeleteLater(buffer.m_buffer, buffer.m_alloc);
+  ezMemoryAllocatorVulkan::DestroyBuffer(m_Buffer, m_Alloc);
+}
 
-  // EZ_ASSERT_DEBUG(m_device, "ezStagingBufferPoolVulkan::Initialize not called");
-  // ezMemoryAllocatorVulkan::DestroyBuffer(buffer.m_buffer, buffer.m_alloc);
+ezResult ezStagingBufferPoolVulkan::StagingBufferPool::Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiStartOffset, ezByteArrayPtr& out_Allocation)
+{
+  if (m_Tracker.Allocate(uiSize, uiCurrentFrame, out_uiStartOffset).Failed())
+    return EZ_FAILURE;
+
+  out_Allocation = m_Data.GetSubArray(out_uiStartOffset, uiSize);
+  return EZ_SUCCESS;
+}
+
+void ezStagingBufferPoolVulkan::StagingBufferPool::Free(ezUInt64 uiUpToFrame)
+{
+  m_uiFramesWithoutAllocations = m_Tracker.GetUsedMemory() == 0 ? ++m_uiFramesWithoutAllocations : 0;
+  m_Tracker.Free(uiUpToFrame);
+}
+
+void ezStagingBufferPoolVulkan::StagingBufferPool::Submit(ezGALDeviceVulkan* pDevice, ezUInt64 uiFrame)
+{
+  ezHybridArray<ezRingBufferTracker::FrameData, 4> frameData;
+  if (m_Tracker.SubmitFrame(uiFrame, frameData).Failed())
+    return;
+
+  for (ezRingBufferTracker::FrameData& frame : frameData)
+  {
+    VK_ASSERT_DEBUG(ezMemoryAllocatorVulkan::FlushAllocation(m_Alloc, frame.m_uiStartOffset, frame.m_uiSize));
+  }
 }

--- a/Code/Engine/RendererVulkan/Pools/Implementation/UniformBufferPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/UniformBufferPoolVulkan.cpp
@@ -1,0 +1,231 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Device/InitContext.h>
+#include <RendererVulkan/Pools/UniformBufferPoolVulkan.h>
+#include <RendererVulkan/Resources/BufferVulkan.h>
+
+ezUniformBufferPoolVulkan::ezUniformBufferPoolVulkan(ezGALDeviceVulkan* pDevice)
+  : m_pDevice(pDevice)
+  , m_device(pDevice->GetVulkanDevice())
+  , m_Buffer(pDevice->GetAllocator())
+  , m_PendingPools(pDevice->GetAllocator())
+  , m_FreePools(pDevice->GetAllocator())
+{
+}
+
+void ezUniformBufferPoolVulkan::Initialize()
+{
+  m_uiAlignment = (ezUInt32)ezGALBufferVulkan::GetAlignment(m_pDevice, vk::BufferUsageFlagBits::eUniformBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst);
+  m_uiBufferSize = GetBufferSize(2u * 1024u * 1024u);
+}
+
+void ezUniformBufferPoolVulkan::DeInitialize()
+{
+  if (m_pCurrentPool)
+  {
+    m_FreePools.PushBack(m_pCurrentPool);
+    m_pCurrentPool = nullptr;
+  }
+
+  for (UniformBufferPool* pPool : m_PendingPools)
+  {
+    m_FreePools.PushBack(pPool);
+  }
+  m_PendingPools.Clear();
+
+  for (UniformBufferPool* pPool : m_FreePools)
+  {
+    EZ_DELETE(m_pDevice->GetAllocator(), pPool);
+  }
+  m_FreePools.Clear();
+}
+
+void ezUniformBufferPoolVulkan::EndFrame()
+{
+  m_Buffer.Clear();
+  ezUInt64 uiSafeFrame = m_pDevice->GetSafeFrame();
+
+  for (UniformBufferPool* pPool : m_PendingPools)
+  {
+    m_FreePools.PushBack(pPool);
+  }
+  m_PendingPools.Clear();
+
+  for (UniformBufferPool* pPool : m_FreePools)
+  {
+    pPool->Free(uiSafeFrame);
+  }
+
+  m_FreePools.Sort([](const UniformBufferPool* pLhs, const UniformBufferPool* pRhs) -> bool
+    { return pLhs->GetFreeMemory() < pRhs->GetFreeMemory(); });
+
+  // Don't switch the current pool as that would cause descriptor re-creation later on.
+  if (m_pCurrentPool)
+  {
+    m_pCurrentPool->Free(uiSafeFrame);
+  }
+}
+
+void ezUniformBufferPoolVulkan::BeforeCommandBufferSubmit()
+{
+  if (m_pCurrentPool)
+  {
+    m_pCurrentPool->Submit(m_pDevice, m_pDevice->GetCurrentFrame());
+  }
+}
+
+ezUniformBufferPoolVulkan::BufferUpdateResult ezUniformBufferPoolVulkan::UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> data)
+{
+  const ezUInt64 uiCurrentFrame = m_pDevice->GetCurrentFrame();
+  BufferUpdateResult res = BufferUpdateResult::OffsetChanged;
+  const ezUInt32 uiSize = ezMemoryUtils::AlignSize(data.GetCount(), (ezUInt32)m_uiAlignment);
+  if (!m_pCurrentPool)
+  {
+    m_pCurrentPool = GetFreePool(uiSize);
+    res = BufferUpdateResult::DynamicBufferChanged;
+  }
+
+  ezUInt32 uiOffset = 0;
+  ezByteArrayPtr allocation;
+  if (m_pCurrentPool->Allocate(uiSize, uiCurrentFrame, uiOffset, allocation).Failed())
+  {
+    m_pCurrentPool->Submit(m_pDevice, uiCurrentFrame);
+    m_PendingPools.PushBack(m_pCurrentPool);
+    m_pCurrentPool = GetFreePool(uiSize);
+    m_pCurrentPool->Allocate(uiSize, uiCurrentFrame, uiOffset, allocation).AssertSuccess("implementation error");
+    res = BufferUpdateResult::DynamicBufferChanged;
+  }
+
+  EZ_ASSERT_DEBUG(allocation.GetCount() >= data.GetCount(), "implementation error");
+  ezMemoryUtils::RawByteCopy(allocation.GetPtr(), data.GetPtr(), data.GetCount());
+
+  vk::DescriptorBufferInfo info;
+  info.buffer = m_pCurrentPool->m_Buffer;
+  info.range = uiSize;
+  info.offset = uiOffset;
+  m_Buffer.Insert(pBuffer, info);
+
+  return res;
+}
+
+const vk::DescriptorBufferInfo* ezUniformBufferPoolVulkan::GetBuffer(const ezGALBufferVulkan* pBuffer) const
+{
+  vk::DescriptorBufferInfo* info = nullptr;
+  bool bFound = m_Buffer.TryGetValue(pBuffer, info);
+  EZ_ASSERT_DEBUG(bFound, "Dynamic buffer not found. Dynamic buffers must be updated every frame before use.");
+  return info;
+}
+
+ezUniformBufferPoolVulkan::UniformBufferPool* ezUniformBufferPoolVulkan::GetFreePool(ezUInt32 uiSize)
+{
+  if (!m_FreePools.IsEmpty())
+  {
+    // The back has the pool with the highest available memory. If this fails there is no point in checking other pools.
+    ezUniformBufferPoolVulkan::UniformBufferPool* pPool = m_FreePools.PeekBack();
+    if (pPool->GetFreeMemory() >= uiSize)
+    {
+      m_FreePools.PopBack();
+      return pPool;
+    }
+  }
+
+  // Create new pool. This time larger in the hopes that it won't run out.
+  m_uiBufferSize = GetBufferSize(m_uiBufferSize * 2);
+  UniformBufferPool* pPool(EZ_NEW(m_pDevice->GetAllocator(), UniformBufferPool, m_uiAlignment, m_uiBufferSize));
+  return pPool;
+}
+
+
+ezUInt32 ezUniformBufferPoolVulkan::GetBufferSize(ezUInt32 uiSize)
+{
+  const ezUInt32 uiMaxBufferSize = m_pDevice->GetPhysicalDeviceProperties().limits.maxUniformBufferRange;
+  ezUInt32 uiBufferSize = ezMath::Min(uiSize, uiMaxBufferSize);
+  uiBufferSize = ezMemoryUtils::AlignSize(uiBufferSize, m_uiAlignment);
+  while (uiBufferSize >= uiMaxBufferSize)
+  {
+    uiBufferSize -= m_uiAlignment;
+  }
+  return uiBufferSize;
+}
+
+ezUniformBufferPoolVulkan::UniformBufferPool::UniformBufferPool(ezUInt32 uiAlignment, ezUInt32 uiBufferSize)
+  : m_Tracker(uiAlignment, uiBufferSize)
+{
+  {
+    vk::BufferCreateInfo bufferCreateInfo;
+    bufferCreateInfo.usage = vk::BufferUsageFlagBits::eUniformBuffer | vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst;
+    bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
+    bufferCreateInfo.size = uiBufferSize;
+
+    ezVulkanAllocationCreateInfo allocCreateInfo;
+    allocCreateInfo.m_usage = ezVulkanMemoryUsage::Auto;
+    allocCreateInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessSequentialWrite | ezVulkanAllocationCreateFlags::Mapped | ezVulkanAllocationCreateFlags::AllowTransferInstead;
+    VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_Buffer, m_Alloc, &m_AllocInfo));
+  }
+
+  vk::MemoryPropertyFlags memFlags = ezMemoryAllocatorVulkan::GetAllocationFlags(m_Alloc);
+  if (memFlags & vk::MemoryPropertyFlagBits::eHostVisible)
+  {
+    m_Data = ezMakeArrayPtr(reinterpret_cast<ezUInt8*>(m_AllocInfo.m_pMappedData), uiBufferSize);
+  }
+  else
+  {
+    vk::BufferCreateInfo bufferCreateInfo;
+    bufferCreateInfo.usage = vk::BufferUsageFlagBits::eTransferSrc;
+    bufferCreateInfo.sharingMode = vk::SharingMode::eExclusive;
+    bufferCreateInfo.size = uiBufferSize;
+
+    ezVulkanAllocationCreateInfo allocCreateInfo;
+    allocCreateInfo.m_usage = ezVulkanMemoryUsage::Auto;
+    allocCreateInfo.m_flags = ezVulkanAllocationCreateFlags::HostAccessSequentialWrite | ezVulkanAllocationCreateFlags::Mapped;
+    VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_StagingBuffer, m_StagingAlloc, &m_StagingAllocInfo));
+    m_Data = ezMakeArrayPtr(reinterpret_cast<ezUInt8*>(m_StagingAllocInfo.m_pMappedData), uiBufferSize);
+  }
+}
+
+
+ezUniformBufferPoolVulkan::UniformBufferPool::~UniformBufferPool()
+{
+  m_Data.Clear();
+  ezMemoryAllocatorVulkan::DestroyBuffer(m_Buffer, m_Alloc);
+  if (m_StagingBuffer)
+  {
+    ezMemoryAllocatorVulkan::DestroyBuffer(m_StagingBuffer, m_StagingAlloc);
+  }
+}
+
+ezResult ezUniformBufferPoolVulkan::UniformBufferPool::Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiStartOffset, ezByteArrayPtr& out_Allocation)
+{
+  if (m_Tracker.Allocate(uiSize, uiCurrentFrame, out_uiStartOffset).Failed())
+    return EZ_FAILURE;
+
+  out_Allocation = m_Data.GetSubArray(out_uiStartOffset, uiSize);
+  return EZ_SUCCESS;
+}
+
+void ezUniformBufferPoolVulkan::UniformBufferPool::Free(ezUInt64 uiUpToFrame)
+{
+  m_Tracker.Free(uiUpToFrame);
+}
+
+void ezUniformBufferPoolVulkan::UniformBufferPool::Submit(ezGALDeviceVulkan* pDevice, ezUInt64 uiFrame)
+{
+  ezHybridArray<ezRingBufferTracker::FrameData, 4> frameData;
+  if (m_Tracker.SubmitFrame(uiFrame, frameData).Failed())
+    return;
+
+  for (ezRingBufferTracker::FrameData& frame : frameData)
+  {
+    if (m_StagingBuffer)
+    {
+      VK_ASSERT_DEBUG(ezMemoryAllocatorVulkan::FlushAllocation(m_StagingAlloc, frame.m_uiStartOffset, frame.m_uiSize));
+      pDevice->GetInitContext().UpdateDynamicUniformBuffer(m_Buffer, m_StagingBuffer, frame.m_uiStartOffset, frame.m_uiSize);
+    }
+    else
+    {
+      VK_ASSERT_DEBUG(ezMemoryAllocatorVulkan::FlushAllocation(m_Alloc, frame.m_uiStartOffset, frame.m_uiSize));
+      pDevice->GetInitContext().UpdateDynamicUniformBuffer(m_Buffer, m_StagingBuffer, frame.m_uiStartOffset, frame.m_uiSize);
+    }
+  }
+}

--- a/Code/Engine/RendererVulkan/Pools/Implementation/UniformBufferPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/UniformBufferPoolVulkan.cpp
@@ -220,11 +220,13 @@ void ezUniformBufferPoolVulkan::UniformBufferPool::Submit(ezGALDeviceVulkan* pDe
     if (m_StagingBuffer)
     {
       VK_ASSERT_DEBUG(ezMemoryAllocatorVulkan::FlushAllocation(m_StagingAlloc, frame.m_uiStartOffset, frame.m_uiSize));
+      EZ_ASSERT_DEBUG(frame.m_uiStartOffset + frame.m_uiSize <= m_Tracker.GetTotalMemory(), "Buffer overrun");
       pDevice->GetInitContext().UpdateDynamicUniformBuffer(m_Buffer, m_StagingBuffer, frame.m_uiStartOffset, frame.m_uiSize);
     }
     else
     {
       VK_ASSERT_DEBUG(ezMemoryAllocatorVulkan::FlushAllocation(m_Alloc, frame.m_uiStartOffset, frame.m_uiSize));
+      EZ_ASSERT_DEBUG(frame.m_uiStartOffset + frame.m_uiSize <= m_Tracker.GetTotalMemory(), "Buffer overrun");
       pDevice->GetInitContext().UpdateDynamicUniformBuffer(m_Buffer, m_StagingBuffer, frame.m_uiStartOffset, frame.m_uiSize);
     }
   }

--- a/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/QueryPoolVulkan.h
@@ -19,7 +19,7 @@ public:
   void DeInitialize();
 
   /// \brief Needs to be called every frame so the pool can figure out which queries have finished and reuse old data.
-  void BeginFrame(vk::CommandBuffer commandBuffer);
+  void AfterBeginFrame(vk::CommandBuffer commandBuffer);
 
   /// \brief We have to call this before each begin rendering call as if we run out of queries inside a render pass, we can't recover given that resetQueryPool can only be called outside a render pass which is necessary to be called on every new pool.
   void EnsureFreeQueryPoolSize(vk::CommandBuffer commandBuffer);

--- a/Code/Engine/RendererVulkan/Pools/StagingBufferPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/StagingBufferPoolVulkan.h
@@ -36,7 +36,7 @@ public:
   /// \brief Allocates a temp buffer of the given size.
   /// \param size The size of the temp buffer.
   /// \return Allocated temp buffer.
-  ezStagingBufferVulkan AllocateBuffer(vk::DeviceSize size);
+  ezStagingBufferVulkan AllocateBuffer(ezUInt64 size);
 
 private:
   static constexpr ezUInt32 s_uiNumberOfFramesToKeepUnusedPoolsAlive = 600;
@@ -58,14 +58,14 @@ private:
   };
 
 private:
-  StagingBufferPool* GetFreePool(vk::DeviceSize uiSize);
+  StagingBufferPool* GetFreePool(ezUInt64 uiSize);
 
 private:
-  vk::DeviceSize m_uiAlignment = 0;
-  vk::DeviceSize m_uiStartingPoolSize = 10 * 1024u * 1024u;
+  ezUInt64 m_uiAlignment = 0;
+  ezUInt64 m_uiStartingPoolSize = 10 * 1024u * 1024u;
   ezGALDeviceVulkan* m_pDevice = nullptr;
   vk::Device m_device;
 
   ezHybridArray<StagingBufferPool*, 8> m_Pools;
-  vk::DeviceSize m_uiHighWatermark = 0;
+  ezUInt64 m_uiHighWatermark = 0;
 };

--- a/Code/Engine/RendererVulkan/Pools/StagingBufferPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/StagingBufferPoolVulkan.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <RendererFoundation/Utils/RingBufferTracker.h>
 #include <RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h>
 #include <RendererVulkan/RendererVulkanDLL.h>
-#include <RendererFoundation/Utils/RingBufferTracker.h>
 
 #include <vulkan/vulkan.hpp>
 

--- a/Code/Engine/RendererVulkan/Pools/StagingBufferPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/StagingBufferPoolVulkan.h
@@ -2,6 +2,7 @@
 
 #include <RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h>
 #include <RendererVulkan/RendererVulkanDLL.h>
+#include <RendererFoundation/Utils/RingBufferTracker.h>
 
 #include <vulkan/vulkan.hpp>
 
@@ -10,20 +11,61 @@ class ezGALDeviceVulkan;
 struct ezStagingBufferVulkan
 {
   vk::Buffer m_buffer;
+  vk::DeviceSize m_uiOffset = 0;
   ezVulkanAllocation m_alloc;
-  ezVulkanAllocationInfo m_allocInfo;
+  ezByteArrayPtr m_Data;
 };
 
+/// \brief Allocates temporary staging buffers from a large pool. Allocations will automatically be freed at the end of the frame.
+/// New (larger) pools will be created if the existing ones run out of space. Pools will be deleted after a certain time of no usage.
 class EZ_RENDERERVULKAN_DLL ezStagingBufferPoolVulkan
 {
 public:
-  void Initialize(ezGALDeviceVulkan* pDevice);
+  /// \brief Initializes the pool.
+  /// \param pDevice GAL device.
+  /// \param uiStartingPoolSize Size of the first pool. If depleted, a new one with twice the size of the previous one is created.
+  void Initialize(ezGALDeviceVulkan* pDevice, ezUInt64 uiStartingPoolSize);
+  /// \brief Needs to be called before destroying this instance. Ensure that the GPU is idle before calling.
   void DeInitialize();
 
-  ezStagingBufferVulkan AllocateBuffer(vk::DeviceSize alignment, vk::DeviceSize size);
-  void ReclaimBuffer(ezStagingBufferVulkan& buffer);
+  /// \brief Needs to be called after begin frame to free memory.
+  void AfterBeginFrame();
+  /// \brief Needs to be called before submitting work to the GPU to flush GPU caches.
+  void BeforeCommandBufferSubmit();
+
+  /// \brief Allocates a temp buffer of the given size.
+  /// \param size The size of the temp buffer.
+  /// \return Allocated temp buffer.
+  ezStagingBufferVulkan AllocateBuffer(vk::DeviceSize size);
 
 private:
+  static constexpr ezUInt32 s_uiNumberOfFramesToKeepUnusedPoolsAlive = 600;
+
+  struct StagingBufferPool
+  {
+    StagingBufferPool(ezUInt32 uiAlignment, ezUInt32 uiTotalSize);
+    ~StagingBufferPool();
+    ezResult Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiStartOffset, ezByteArrayPtr& out_Allocation);
+    void Free(ezUInt64 uiUpToFrame);
+    void Submit(ezGALDeviceVulkan* pDevice, ezUInt64 uiFrame);
+
+    ezRingBufferTracker m_Tracker;
+    ezArrayPtr<ezUInt8> m_Data;
+    vk::Buffer m_Buffer;
+    ezVulkanAllocation m_Alloc;
+    ezVulkanAllocationInfo m_AllocInfo;
+    ezUInt32 m_uiFramesWithoutAllocations = 0;
+  };
+
+private:
+  StagingBufferPool* GetFreePool(vk::DeviceSize uiSize);
+
+private:
+  vk::DeviceSize m_uiAlignment = 0;
+  vk::DeviceSize m_uiStartingPoolSize = 10 * 1024u * 1024u;
   ezGALDeviceVulkan* m_pDevice = nullptr;
   vk::Device m_device;
+
+  ezHybridArray<StagingBufferPool*, 8> m_Pools;
+  vk::DeviceSize m_uiHighWatermark = 0;
 };

--- a/Code/Engine/RendererVulkan/Pools/UniformBufferPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/UniformBufferPoolVulkan.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
+
+#include <RendererFoundation/Utils/RingBufferTracker.h>
+
+#include <vulkan/vulkan.hpp>
+
+class ezGALDeviceVulkan;
+class ezGALBufferVulkan;
+
+/// \brief `ezGALBufferVulkan` created with `ezGALBufferUsageFlags::Transient` will allocate scratch memory from this pool which will last until the end of the frame.
+class EZ_RENDERERVULKAN_DLL ezUniformBufferPoolVulkan
+{
+public:
+  enum class BufferUpdateResult
+  {
+    OffsetChanged, ///< The offset of the current buffer was moved forward.
+    DynamicBufferChanged, ///< The current buffer was depleted and a new buffer was started.
+  };
+
+  ezUniformBufferPoolVulkan(ezGALDeviceVulkan* pDevice);
+
+  void Initialize();
+  void DeInitialize();
+
+  void EndFrame();
+  void BeforeCommandBufferSubmit();
+
+  /// \brief Needs to be called each from for a buffer before it can be used.
+  /// Can be called multiple times per frame. GetBuffer will always return a reference to the last UpdateBuffer content.
+  /// \param pBuffer The buffer to allocate scratch memory for.
+  /// \param data The data of the buffer. Must be the size of the entire buffer.
+  /// \return Returns whether a new pool needed to be created.
+  BufferUpdateResult UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> data);
+
+  /// Access the descriptor info for the given buffer.
+  /// \param pBuffer The buffer for which previously scratch memory was allocated for.
+  /// \return Pointer to the descriptor info.
+  const vk::DescriptorBufferInfo* GetBuffer(const ezGALBufferVulkan* pBuffer) const;
+
+private:
+  struct UniformBufferPool
+  {
+    UniformBufferPool(ezUInt32 uiAlignment, ezUInt32 uiTotalSize);
+    ~UniformBufferPool();
+    ezResult Allocate(ezUInt32 uiSize, ezUInt64 uiCurrentFrame, ezUInt32& out_uiStartOffset, ezByteArrayPtr& out_Allocation);
+    void Free(ezUInt64 uiUpToFrame);
+    void Submit(ezGALDeviceVulkan* pDevice, ezUInt64 uiFrame);
+    ezUInt32 GetFreeMemory() const { return m_Tracker.GetFreeMemory(); }
+
+    ezRingBufferTracker m_Tracker;
+    ezArrayPtr<ezUInt8> m_Data;
+    vk::Buffer m_Buffer;
+    vk::Buffer m_StagingBuffer;
+    ezVulkanAllocation m_Alloc;
+    ezVulkanAllocation m_StagingAlloc;
+    ezVulkanAllocationInfo m_AllocInfo;
+    ezVulkanAllocationInfo m_StagingAllocInfo;
+  };
+
+private:
+  UniformBufferPool* GetFreePool(ezUInt32 uiSize);
+  ezUInt32 GetBufferSize(ezUInt32 uiSize);
+
+private:
+  ezGALDeviceVulkan* m_pDevice = nullptr;
+  vk::Device m_device;
+  ezUInt32 m_uiAlignment = 0;
+  ezUInt32 m_uiBufferSize = 0;
+
+  ezMap<const ezGALBufferVulkan*, vk::DescriptorBufferInfo> m_Buffer;
+
+  UniformBufferPool* m_pCurrentPool = nullptr;
+  ezDeque<UniformBufferPool*> m_PendingPools;
+  ezHybridArray<UniformBufferPool*, 8> m_FreePools;
+};

--- a/Code/Engine/RendererVulkan/Pools/UniformBufferPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/UniformBufferPoolVulkan.h
@@ -16,7 +16,7 @@ class EZ_RENDERERVULKAN_DLL ezUniformBufferPoolVulkan
 public:
   enum class BufferUpdateResult
   {
-    OffsetChanged, ///< The offset of the current buffer was moved forward.
+    OffsetChanged,        ///< The offset of the current buffer was moved forward.
     DynamicBufferChanged, ///< The current buffer was depleted and a new buffer was started.
   };
 

--- a/Code/Engine/RendererVulkan/Resources/BufferVulkan.h
+++ b/Code/Engine/RendererVulkan/Resources/BufferVulkan.h
@@ -10,7 +10,6 @@
 class EZ_RENDERERVULKAN_DLL ezGALBufferVulkan : public ezGALBuffer
 {
 public:
-  void DiscardBuffer() const;
   EZ_ALWAYS_INLINE vk::Buffer GetVkBuffer() const;
   const vk::DescriptorBufferInfo& GetBufferInfo() const;
 
@@ -22,13 +21,6 @@ public:
   static vk::DeviceSize GetAlignment(const ezGALDeviceVulkan* pDevice, vk::BufferUsageFlags usage);
 
 protected:
-  struct BufferVulkan
-  {
-    vk::Buffer m_buffer;
-    ezVulkanAllocation m_alloc;
-    mutable ezUInt64 m_currentFrame = 0;
-  };
-
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
 
@@ -39,12 +31,13 @@ protected:
   virtual ezResult InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const ezUInt8> pInitialData) override;
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
   virtual void SetDebugNamePlatform(const char* szName) const override;
-  void CreateBuffer() const;
+  void CreateBuffer();
 
-  mutable BufferVulkan m_currentBuffer;
-  mutable vk::DescriptorBufferInfo m_resourceBufferInfo;
-  mutable ezDeque<BufferVulkan> m_usedBuffers;
-  mutable ezVulkanAllocationInfo m_allocInfo;
+protected:
+  vk::Buffer m_buffer = {};
+  ezVulkanAllocation m_alloc = {};
+  ezVulkanAllocationInfo m_allocInfo = {};
+  vk::DescriptorBufferInfo m_resourceBufferInfo = {};
 
   // Data for memory barriers and access
   vk::PipelineStageFlags m_stages = {};
@@ -54,7 +47,7 @@ protected:
   vk::DeviceSize m_size = 0;
 
   ezGALDeviceVulkan* m_pDeviceVulkan = nullptr;
-  vk::Device m_device;
+  vk::Device m_device = {};
 
   mutable ezString m_sDebugName;
 };

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan.cpp
@@ -83,10 +83,14 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
   vk::DeviceSize alignment = GetAlignment(m_pDeviceVulkan, m_usage);
   m_size = ezMemoryUtils::AlignSize((vk::DeviceSize)m_Description.m_uiTotalSize, alignment);
 
-  CreateBuffer();
-
   m_resourceBufferInfo.offset = 0;
   m_resourceBufferInfo.range = m_size;
+
+  // No buffer needed if we use transient memory for constant buffers.
+  if (m_Description.m_BufferFlags.AreAllSet(ezGALBufferUsageFlags::Transient | ezGALBufferUsageFlags::ConstantBuffer))
+    return EZ_SUCCESS;
+
+  CreateBuffer();
 
   if (!pInitialData.IsEmpty())
   {
@@ -97,16 +101,12 @@ ezResult ezGALBufferVulkan::InitPlatform(ezGALDevice* pDevice, ezArrayPtr<const 
 
 ezResult ezGALBufferVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
-  if (m_currentBuffer.m_buffer)
+  if (m_buffer)
   {
-    m_pDeviceVulkan->DeleteLater(m_currentBuffer.m_buffer, m_currentBuffer.m_alloc);
+    m_pDeviceVulkan->DeleteLater(m_buffer, m_alloc);
     m_allocInfo = {};
   }
-  for (auto& bufferVulkan : m_usedBuffers)
-  {
-    m_pDeviceVulkan->DeleteLater(bufferVulkan.m_buffer, bufferVulkan.m_alloc);
-  }
-  m_usedBuffers.Clear();
+
   m_resourceBufferInfo = vk::DescriptorBufferInfo();
 
   m_stages = {};
@@ -121,35 +121,12 @@ ezResult ezGALBufferVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-void ezGALBufferVulkan::DiscardBuffer() const
-{
-  m_usedBuffers.PushBack(m_currentBuffer);
-  m_currentBuffer = {};
-
-  ezUInt64 uiSafeFrame = m_pDeviceVulkan->GetSafeFrame();
-  if (m_usedBuffers.PeekFront().m_currentFrame <= uiSafeFrame)
-  {
-    m_currentBuffer = m_usedBuffers.PeekFront();
-    m_usedBuffers.PopFront();
-    m_allocInfo = ezMemoryAllocatorVulkan::GetAllocationInfo(m_currentBuffer.m_alloc);
-  }
-  else
-  {
-    CreateBuffer();
-    SetDebugNamePlatform(m_sDebugName);
-  }
-}
-
 const vk::DescriptorBufferInfo& ezGALBufferVulkan::GetBufferInfo() const
 {
-  m_currentBuffer.m_currentFrame = m_pDeviceVulkan->GetCurrentFrame();
-  // Vulkan buffers get constantly swapped out for new ones so the vk::Buffer pointer is not persistent.
-  // We need to acquire the latest one on every request for rendering.
-  m_resourceBufferInfo.buffer = m_currentBuffer.m_buffer;
   return m_resourceBufferInfo;
 }
 
-void ezGALBufferVulkan::CreateBuffer() const
+void ezGALBufferVulkan::CreateBuffer()
 {
   vk::BufferCreateInfo bufferCreateInfo;
   bufferCreateInfo.usage = m_usage;
@@ -161,13 +138,13 @@ void ezGALBufferVulkan::CreateBuffer() const
   ezVulkanAllocationCreateInfo allocCreateInfo;
   allocCreateInfo.m_usage = ezVulkanMemoryUsage::Auto;
 
-  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_currentBuffer.m_buffer, m_currentBuffer.m_alloc, &m_allocInfo));
+  VK_ASSERT_DEV(ezMemoryAllocatorVulkan::CreateBuffer(bufferCreateInfo, allocCreateInfo, m_buffer, m_alloc, &m_allocInfo));
 }
 
 void ezGALBufferVulkan::SetDebugNamePlatform(const char* szName) const
 {
   m_sDebugName = szName;
-  m_pDeviceVulkan->SetDebugName(szName, m_currentBuffer.m_buffer, m_currentBuffer.m_alloc);
+  m_pDeviceVulkan->SetDebugName(szName, m_buffer, m_alloc);
 }
 
 vk::DeviceSize ezGALBufferVulkan::GetAlignment(const ezGALDeviceVulkan* pDevice, vk::BufferUsageFlags usage)

--- a/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Resources/Implementation/BufferVulkan_inl.h
@@ -1,7 +1,7 @@
 
 vk::Buffer ezGALBufferVulkan::GetVkBuffer() const
 {
-  return m_currentBuffer.m_buffer;
+  return m_buffer;
 }
 
 vk::IndexType ezGALBufferVulkan::GetIndexType() const
@@ -11,7 +11,7 @@ vk::IndexType ezGALBufferVulkan::GetIndexType() const
 
 ezVulkanAllocation ezGALBufferVulkan::GetAllocation() const
 {
-  return m_currentBuffer.m_alloc;
+  return m_alloc;
 }
 
 const ezVulkanAllocationInfo& ezGALBufferVulkan::GetAllocationInfo() const

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
@@ -310,7 +310,7 @@ EZ_ALWAYS_INLINE vk::DescriptorType ezConversionUtilsVulkan::GetDescriptorType(e
     case ezGALShaderResourceType::Sampler:
       return vk::DescriptorType::eSampler;
     case ezGALShaderResourceType::ConstantBuffer:
-      return vk::DescriptorType::eUniformBuffer;
+      return vk::DescriptorType::eUniformBufferDynamic;
     case ezGALShaderResourceType::Texture:
       return vk::DescriptorType::eSampledImage;
     case ezGALShaderResourceType::TextureAndSampler:

--- a/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
@@ -106,6 +106,5 @@ EZ_CREATE_SIMPLE_TEST(DataStructures, RingBufferTracker)
     EZ_TEST_INT(frames[1].m_uiFrame, 2);
     EZ_TEST_INT(frames[1].m_uiStartOffset, 0);
     EZ_TEST_INT(frames[1].m_uiSize, 200);
-
   }
 }

--- a/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
@@ -1,0 +1,111 @@
+#include <GameEngineTest/GameEngineTestPCH.h>
+
+
+#include <RendererFoundation/Utils/RingBufferTracker.h>
+
+EZ_CREATE_SIMPLE_TEST_GROUP(DataStructures);
+
+EZ_CREATE_SIMPLE_TEST(DataStructures, RingBufferTracker)
+{
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Allocate entire buffer")
+  {
+    ezRingBufferTracker tracker(64, 65472);
+    EZ_TEST_INT(tracker.GetTotalMemory(), 65472);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 0);
+    EZ_TEST_INT(tracker.GetFreeMemory(), 65472);
+
+    ezUInt32 uiOffset = 0;
+    EZ_TEST_RESULT(tracker.Allocate(65472, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_INT(tracker.GetTotalMemory(), 65472);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 65472);
+    EZ_TEST_INT(tracker.GetFreeMemory(), 0);
+  }
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Allocate, submit, free")
+  {
+    ezRingBufferTracker tracker(64, 1024);
+    ezUInt32 uiOffset = 0;
+    EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 256);
+    EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 512);
+    EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 768);
+    EZ_TEST_BOOL(tracker.Allocate(256, 1, uiOffset).Failed());
+    EZ_TEST_INT(tracker.GetFreeMemory(), 0);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 1024);
+
+    ezHybridArray<ezRingBufferTracker::FrameData, 2> frames;
+    EZ_TEST_RESULT(tracker.SubmitFrame(1, frames));
+    EZ_TEST_INT(frames.GetCount(), 1);
+    EZ_TEST_INT(frames[0].m_uiFrame, 1);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 0);
+    EZ_TEST_INT(frames[0].m_uiSize, 1024);
+
+    tracker.Free(1);
+    EZ_TEST_INT(tracker.GetFreeMemory(), 1024);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 0);
+    EZ_TEST_RESULT(tracker.Allocate(256, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Loop through the ringbuffer")
+  {
+    ezRingBufferTracker tracker(64, 1024);
+    ezUInt32 uiOffset = 0;
+    for (size_t i = 4; i < 20; i++)
+    {
+      EZ_TEST_INT(tracker.GetTotalMemory(), 1024);
+      tracker.Free(i - 4);
+      EZ_TEST_RESULT(tracker.Allocate(256, i, uiOffset));
+      EZ_TEST_INT(uiOffset, (i * 256) % 1024);
+      ezHybridArray<ezRingBufferTracker::FrameData, 2> frames;
+      EZ_TEST_RESULT(tracker.SubmitFrame(i, frames));
+      EZ_TEST_INT(frames.GetCount(), 1);
+      EZ_TEST_INT(frames[0].m_uiFrame, i);
+      EZ_TEST_INT(frames[0].m_uiStartOffset, (i * 256) % 1024);
+      EZ_TEST_INT(frames[0].m_uiSize, 256);
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Allocation skip due to reaching the end of the buffer")
+  {
+    ezRingBufferTracker tracker(2, 1000);
+    ezUInt32 uiOffset = 0;
+
+    EZ_TEST_RESULT(tracker.Allocate(800, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 800);
+    ezHybridArray<ezRingBufferTracker::FrameData, 2> frames;
+    EZ_TEST_RESULT(tracker.SubmitFrame(1, frames));
+    EZ_TEST_INT(frames.GetCount(), 1);
+    EZ_TEST_INT(frames[0].m_uiFrame, 1);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 0);
+    EZ_TEST_INT(frames[0].m_uiSize, 800);
+    tracker.Free(1);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 0);
+
+    EZ_TEST_RESULT(tracker.Allocate(100, 2, uiOffset));
+    EZ_TEST_INT(uiOffset, 800);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 100);
+
+    // We allocate at the end of the buffer but it doesn't fit so 100 bytes are wasted as we skip to the start again.
+    EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 400);
+
+    EZ_TEST_RESULT(tracker.SubmitFrame(2, frames));
+    EZ_TEST_INT(frames.GetCount(), 2);
+
+    EZ_TEST_INT(frames[0].m_uiFrame, 2);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 800);
+    EZ_TEST_INT(frames[0].m_uiSize, 200);
+
+    EZ_TEST_INT(frames[1].m_uiFrame, 2);
+    EZ_TEST_INT(frames[1].m_uiStartOffset, 0);
+    EZ_TEST_INT(frames[1].m_uiSize, 200);
+
+  }
+}

--- a/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/RingBufferTrackerTest.cpp
@@ -70,11 +70,12 @@ EZ_CREATE_SIMPLE_TEST(DataStructures, RingBufferTracker)
     }
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Allocation skip due to reaching the end of the buffer")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Buffer wrap around")
   {
     ezRingBufferTracker tracker(2, 1000);
     ezUInt32 uiOffset = 0;
 
+    // Frame 1: Move a bit forward so we are at the end of the buffer in the next frame.
     EZ_TEST_RESULT(tracker.Allocate(800, 1, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 800);
@@ -87,11 +88,52 @@ EZ_CREATE_SIMPLE_TEST(DataStructures, RingBufferTracker)
     tracker.Free(1);
     EZ_TEST_INT(tracker.GetUsedMemory(), 0);
 
+    // Frame 2: We allocate memory and hit the end point exactly and then do another allocation.
+    EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
+    EZ_TEST_INT(uiOffset, 800);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 200);
+
+    // This allocation wraps around now.
+    EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 400);
+
+    EZ_TEST_RESULT(tracker.SubmitFrame(2, frames));
+    EZ_TEST_INT(frames.GetCount(), 2);
+
+    EZ_TEST_INT(frames[0].m_uiFrame, 2);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 800);
+    EZ_TEST_INT(frames[0].m_uiSize, 200);
+
+    EZ_TEST_INT(frames[1].m_uiFrame, 2);
+    EZ_TEST_INT(frames[1].m_uiStartOffset, 0);
+    EZ_TEST_INT(frames[1].m_uiSize, 200);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Allocation skip due to reaching the end of the buffer")
+  {
+    ezRingBufferTracker tracker(2, 1000);
+    ezUInt32 uiOffset = 0;
+
+    // Frame 1: Move a bit forward so we are at the end of the buffer in the next frame.
+    EZ_TEST_RESULT(tracker.Allocate(800, 1, uiOffset));
+    EZ_TEST_INT(uiOffset, 0);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 800);
+    ezHybridArray<ezRingBufferTracker::FrameData, 2> frames;
+    EZ_TEST_RESULT(tracker.SubmitFrame(1, frames));
+    EZ_TEST_INT(frames.GetCount(), 1);
+    EZ_TEST_INT(frames[0].m_uiFrame, 1);
+    EZ_TEST_INT(frames[0].m_uiStartOffset, 0);
+    EZ_TEST_INT(frames[0].m_uiSize, 800);
+    tracker.Free(1);
+    EZ_TEST_INT(tracker.GetUsedMemory(), 0);
+
+    // Frame 2: We allocate memory but do not hit the end point yet.
     EZ_TEST_RESULT(tracker.Allocate(100, 2, uiOffset));
     EZ_TEST_INT(uiOffset, 800);
     EZ_TEST_INT(tracker.GetUsedMemory(), 100);
 
-    // We allocate at the end of the buffer but it doesn't fit so 100 bytes are wasted as we skip to the start again.
+    // We allocate near the end of the buffer but it doesn't fit so 100 bytes are wasted as we skip to the start again.
     EZ_TEST_RESULT(tracker.Allocate(200, 2, uiOffset));
     EZ_TEST_INT(uiOffset, 0);
     EZ_TEST_INT(tracker.GetUsedMemory(), 400);


### PR DESCRIPTION
## ezRingBufferTracker
* Tracks memory in a ring buffer on a frame by frame basis. The intended usage pattern is that for frame N, multiple allocations are called. This is followed by a call to `SubmitFrame` for frame N (optional) which allows the user to handle to memory ranges that were modified in this frame. Eventually at a later point in time `Free` is called for frame N to allow reuse of the memory. Note that the assumption is that N is always increasing and that `Free` is called for each frame in order.
* Added unit test.

## ezUniformBufferPoolVulkan
* `ezGALBufferVulkan` created with `ezGALBufferUsageFlags::Transient` no longer allocate any memory. Instead, allocations are handled by the new class `ezUniformBufferPoolVulkan`.
* Uses `ezRingBufferTracker` to track pools of memory. Each pool is a dynamic uniform ringbuffer.

## ezStagingBufferPoolVulkan
* Allocates temporary staging buffers from a large pool. Allocations will automatically be freed at the end of the frame. New (larger) pools will be created if the existing ones run out of space. Pools will be deleted after a certain time of no usage.
* Uses `ezRingBufferTracker` to track pools of memory. Each pool is a Vulkan buffer with `ezVulkanAllocationCreateFlags::HostAccessSequentialWrite` and `ezVulkanAllocationCreateFlags::Mapped` flags set and allocations will point directly into the permanently mapped buffer. Only memcpy operations should be used on the allocated buffers.