### PR TITLE
Fix assert in Vulkan when closing scenes and wrong ctor reflection for ezBoxManipulatorAttribute

### DIFF
--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -473,10 +473,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezBoxManipulatorAttribute, 1, ezRTTIDefaultAlloc
   EZ_END_PROPERTIES;
   EZ_BEGIN_FUNCTIONS
   {
-    EZ_CONSTRUCTOR_PROPERTY(const char*, bool, float),
-    EZ_CONSTRUCTOR_PROPERTY(const char*, bool, float),
-    EZ_CONSTRUCTOR_PROPERTY(const char*, bool, float, const char*),
-    EZ_CONSTRUCTOR_PROPERTY(const char*, bool, float, const char*, const char*),
+    EZ_CONSTRUCTOR_PROPERTY(const char*, float, bool),
+    EZ_CONSTRUCTOR_PROPERTY(const char*, float, bool, const char*),
+    EZ_CONSTRUCTOR_PROPERTY(const char*, float, bool, const char*, const char*),
   }
   EZ_END_FUNCTIONS;
 }
@@ -590,7 +589,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTransformManipulatorAttribute, 1, ezRTTIDefaul
 {
   EZ_BEGIN_FUNCTIONS
   {
-    EZ_CONSTRUCTOR_PROPERTY(const char*, const char*, const char*),
+    EZ_CONSTRUCTOR_PROPERTY(const char*, const char*, const char*, const char*, const char*),
   }
   EZ_END_FUNCTIONS;
 }

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1449,7 +1449,6 @@ void ezGALDeviceVulkan::BeginFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchain
       {
         EZ_ASSERT_DEBUG(uiFrame == perFrameData.m_uiFrame, "Frame data was likely overwritten and no longer matches the expected previous frame index. This should have been prevented by bForce above.");
         bool bFencesReached = true;
-        EZ_ASSERT_DEV(perFrameData.m_CommandBufferFences.GetCount() > 0, "");
         for (vk::Fence fence : perFrameData.m_CommandBufferFences)
         {
           vk::Result fenceStatus = m_device.getFenceStatus(fence);
@@ -1546,6 +1545,8 @@ void ezGALDeviceVulkan::EndFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchains)
       EZ_LOCK(currentFrameData.m_reclaimResourcesMutex);
       currentFrameData.m_reclaimResourcesPrevious.Swap(currentFrameData.m_reclaimResources);
     }
+
+    EZ_ASSERT_DEBUG(currentFrameData.m_CommandBufferFences.GetCount() > 0, "Each frame must have at least one fence to guard pending resource deletions");
   }
   m_uiFrameCounter.Increment();
   m_uiCurrentPerFrameData = (m_uiFrameCounter) % FRAMES;


### PR DESCRIPTION
It is unfortunately not possible to figure out the type of the Nth ctor parameter, so `EZ_CONSTRUCTOR_PROPERTY` relies on duck-typing to construct the object. This means that the `EZ_CONSTRUCTOR_PROPERTY` parameter type list can diverge from the actual types as long as the compiler can convert them. In this case, two ctor parameters were swapped but the reflection was not adapted which still worked because the compiler converted float to bool and vise versa to make it 'fit'.