### PR TITLE
Editor camera and selection improvements

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoRenderer.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoRenderer.cpp
@@ -9,6 +9,8 @@
 
 #include <RendererCore/../../../Data/Base/Shaders/Editor/GizmoConstants.h>
 
+#include <Foundation/Platform/Win/Utils/IncludeWindows.h>
+
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezGizmoRenderer, 1, ezRTTIDefaultAllocator<ezGizmoRenderer>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
@@ -32,6 +34,18 @@ void ezGizmoRenderer::GetSupportedRenderDataCategories(ezHybridArray<ezRenderDat
 
 void ezGizmoRenderer::RenderBatch(const ezRenderViewContext& renderViewContext, const ezRenderPipelinePass* pPass, const ezRenderDataBatch& batch) const
 {
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+  // special Windows specific hack:
+  // When ALT is down, the editor shouldn't show any gizmos, because this is used for the orbit camera mode
+  // in general the ALT key is problematic and shouldn't be used as a modifier in gizmos
+  // so to indicate to users that ALT has a very different effect, and to discourage programmers from using ALT as a modifier,
+  // we just hide all gizmos when ALT is down
+  // however, detecting the ALT key is only possible with a direct OS check, since Qt doesn't report this as an individual key press
+  // and the ez input system is not active at all times
+  if (GetKeyState(VK_MENU) & 0x8000)
+    return;
+#endif
+
   bool bOnlyPickable = false;
 
   if (auto pPickingRenderPass = ezDynamicCast<const ezPickingRenderPass*>(pPass))

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -151,7 +151,7 @@ void ezQtEngineViewWidget::UpdateCameraInterpolation()
   const ezTime tDiff = tNow - m_LastCameraUpdate;
   m_LastCameraUpdate = tNow;
 
-  m_fCameraLerp += tDiff.GetSeconds() * 2.0f;
+  m_fCameraLerp += tDiff.GetSeconds() * 3.0f;
 
   if (m_fCameraLerp >= 1.0f)
     m_fCameraLerp = 1.0f;

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/GameObjectDocumentWindow.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/GameObjectDocumentWindow.cpp
@@ -238,7 +238,7 @@ void ezQtGameObjectDocumentWindow::HandleFocusOnSelection(const ezQuerySelection
     }
   }
 
-  pSceneView->m_pCameraMoveContext->SetOrbitPoint(vPivotPoint);
+  pSceneView->m_pCameraMoveContext->SetOrbitDistance(vPivotPoint.GetDistanceTo(vNewCameraPosition));
   pSceneView->InterpolateCameraTo(vNewCameraPosition, vNewCameraDirection, fNewFovOrDim);
 }
 

--- a/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
+++ b/Code/Editor/EditorFramework/InputContexts/CameraMoveContext.h
@@ -15,8 +15,8 @@ public:
 
   void SetCamera(ezCamera* pCamera);
 
-  const ezVec3& GetOrbitPoint() const;
-  void SetOrbitPoint(const ezVec3& vPos);
+  ezVec3 GetOrbitPoint() const;
+  void SetOrbitDistance(float fDistance);
 
   static float ConvertCameraSpeed(ezUInt32 uiSpeedIdx);
 
@@ -43,20 +43,21 @@ private:
   void SetCurrentMouseMode();
   void DeactivateIfLast();
 
-  ezVec3 m_vOrbitPoint;
+  float m_fOrbitPointDistance = 1.0f;
 
-  ezVec2I32 m_vLastMousePos;
+  ezVec2I32 m_vLastMousePos = ezVec2I32::MakeZero();
+  ezVec2I32 m_vMouseClickPos = ezVec2I32::MakeZero();
 
-  bool m_bRotateCamera;
-  bool m_bMoveCamera;
-  bool m_bMoveCameraInPlane;
-  bool m_bOrbitCamera;
-  bool m_bSlideForwards;
-  bool m_bPanOrbitPoint;
-  float m_fSlideForwardsDistance;
-  bool m_bOpenMenuOnMouseUp;
+  bool m_bRotateCamera = false;
+  bool m_bMoveCamera = false;
+  bool m_bMoveCameraInPlane = false;
+  bool m_bOrbitCamera = false;
+  bool m_bSlideForwards = false;
+  bool m_bPanOrbitPoint = false;
+  bool m_bPanCamera = false;
+  bool m_bOpenMenuOnMouseUp = false;
 
-  ezCamera* m_pCamera;
+  ezCamera* m_pCamera = nullptr;
 
   bool m_bRun = false;
   bool m_bSlowDown = false;
@@ -68,7 +69,7 @@ private:
   bool m_bMoveDown = false;
   bool m_bMoveForwardsInPlane = false;
   bool m_bMoveBackwardsInPlane = false;
-  bool m_bDidMoveMouse[3] = {false, false, false}; // Left Click, Right Click, Middle Click
+  ezInt32 m_iDidMoveMouse[3] = {0, 0, 0}; // Left Click, Right Click, Middle Click
 
   bool m_bRotateLeft = false;
   bool m_bRotateRight = false;

--- a/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
@@ -27,7 +27,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSkyLightComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ENUM_ACCESSOR_PROPERTY("ReflectionProbeMode", ezReflectionProbeMode, GetReflectionProbeMode, SetReflectionProbeMode)->AddAttributes(new ezDefaultValueAttribute(ezReflectionProbeMode::Dynamic), new ezGroupAttribute("Capture Description")),
+    EZ_ENUM_ACCESSOR_PROPERTY("ReflectionProbeMode", ezReflectionProbeMode, GetReflectionProbeMode, SetReflectionProbeMode)->AddAttributes(new ezGroupAttribute("Capture Description")),
     EZ_ACCESSOR_PROPERTY("CubeMap", GetCubeMapFile, SetCubeMapFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Cube")),
     EZ_ACCESSOR_PROPERTY("Intensity", GetIntensity, SetIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.4f)),
     EZ_ACCESSOR_PROPERTY("Saturation", GetSaturation, SetSaturation)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.3f)),


### PR DESCRIPTION
NOTE: This change may break your muscle-memory for how to move around a scene in the editor!

This PR introduces the major change that holding the left mouse button (LMB) and moving the mouse does NOT move the camera any longer. Unfortunately this did not work well with gizmos. If you slightly missed a gizmo handle and clicked next to it, it was easy to move the camera far away, interrupting your workflow. With this change, in such a situation nothing happens anymore .

To move the camera the way LMB did before, instead hold CTRL and use the middle mouse button (MMB) to drag. This is analogous to MMB which already moved the camera in the ground plane, now CTRL+MMB is just a variation of that.

Additionally, the orbit camera was changed, so that the orbit reference point is always right in front of the camera, just at varying distance. Thus using orbit mode (hold ALT) never makes the camera jump to some other point anymore, which was often very annoying. Instead the orbit reference point moves with the camera when it rotates or moves.

Other changes:
* When holding the ALT key, all gizmos now disappear, to indicate that ALT activates the orbit camera.
* Made left-click to select a bit more lenient. If you slightly move the mouse, it still counts as a selection click.
* The SkyLight component is now by default set to 'Static', to not waste performance in cases where all you want is prettier ambient lighting.