### PR TITLE
Several editor usability fixes

### DIFF
--- a/Code/Editor/EditorFramework/Actions/GameObjectSelectionActions.h
+++ b/Code/Editor/EditorFramework/Actions/GameObjectSelectionActions.h
@@ -23,7 +23,6 @@ public:
   static ezActionDescriptorHandle s_hFocusOnSelectionAllViews;
   static ezActionDescriptorHandle s_hSnapCameraToObject;
   static ezActionDescriptorHandle s_hMoveCameraHere;
-  static ezActionDescriptorHandle s_hCreateEmptyGameObjectHere;
 };
 
 ///
@@ -39,7 +38,6 @@ public:
     FocusOnSelectionAllViews,
     SnapCameraToObject,
     MoveCameraHere,
-    CreateGameObjectHere,
   };
 
   ezGameObjectSelectionAction(const ezActionContext& context, const char* szName, ActionType type);

--- a/Code/Editor/EditorFramework/Actions/Implementation/GameObjectSelectionActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/GameObjectSelectionActions.cpp
@@ -14,7 +14,6 @@ ezActionDescriptorHandle ezGameObjectSelectionActions::s_hFocusOnSelection;
 ezActionDescriptorHandle ezGameObjectSelectionActions::s_hFocusOnSelectionAllViews;
 ezActionDescriptorHandle ezGameObjectSelectionActions::s_hSnapCameraToObject;
 ezActionDescriptorHandle ezGameObjectSelectionActions::s_hMoveCameraHere;
-ezActionDescriptorHandle ezGameObjectSelectionActions::s_hCreateEmptyGameObjectHere;
 
 void ezGameObjectSelectionActions::RegisterActions()
 {
@@ -29,9 +28,6 @@ void ezGameObjectSelectionActions::RegisterActions()
     ezGameObjectSelectionAction::ActionType::SnapCameraToObject);
   s_hMoveCameraHere = EZ_REGISTER_ACTION_1("Scene.Camera.MoveCameraHere", ezActionScope::Document, "Camera", "C", ezGameObjectSelectionAction,
     ezGameObjectSelectionAction::ActionType::MoveCameraHere);
-
-  s_hCreateEmptyGameObjectHere = EZ_REGISTER_ACTION_1("Scene.GameObject.CreateEmptyHere", ezActionScope::Document, "Scene", "",
-    ezGameObjectSelectionAction, ezGameObjectSelectionAction::ActionType::CreateGameObjectHere);
 }
 
 void ezGameObjectSelectionActions::UnregisterActions()
@@ -42,7 +38,6 @@ void ezGameObjectSelectionActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hFocusOnSelectionAllViews);
   ezActionManager::UnregisterAction(s_hSnapCameraToObject);
   ezActionManager::UnregisterAction(s_hMoveCameraHere);
-  ezActionManager::UnregisterAction(s_hCreateEmptyGameObjectHere);
 }
 
 void ezGameObjectSelectionActions::MapActions(ezStringView sMapping)
@@ -66,7 +61,7 @@ void ezGameObjectSelectionActions::MapContextMenuActions(ezStringView sMapping)
 
   pMap->MapAction(s_hSelectionCategory, "", 5.0f);
 
-  pMap->MapAction(s_hFocusOnSelectionAllViews, "G.Selection", 1.0f);
+  pMap->MapAction(s_hFocusOnSelection, "G.Selection", 1.0f);
 }
 
 
@@ -77,10 +72,8 @@ void ezGameObjectSelectionActions::MapViewContextMenuActions(ezStringView sMappi
 
   pMap->MapAction(s_hSelectionCategory, "", 5.0f);
 
-  pMap->MapAction(s_hFocusOnSelectionAllViews, "G.Selection", 1.0f);
-  pMap->MapAction(s_hSnapCameraToObject, "G.Selection", 4.0f);
-  pMap->MapAction(s_hMoveCameraHere, "G.Selection", 6.0f);
-  pMap->MapAction(s_hCreateEmptyGameObjectHere, "G.Selection", 1.0f);
+  pMap->MapAction(s_hMoveCameraHere, "G.Selection", 1.5f);
+  pMap->MapAction(s_hSnapCameraToObject, "G.Selection", 8.0f);
 }
 
 ezGameObjectSelectionAction::ezGameObjectSelectionAction(
@@ -106,9 +99,6 @@ ezGameObjectSelectionAction::ezGameObjectSelectionAction(
       break;
     case ActionType::MoveCameraHere:
       SetIconPath(":/EditorFramework/Icons/MoveCameraHere.svg");
-      break;
-    case ActionType::CreateGameObjectHere:
-      SetIconPath(":/EditorFramework/Icons/CreateEmpty.svg");
       break;
   }
 
@@ -143,12 +133,6 @@ void ezGameObjectSelectionAction::Execute(const ezVariant& value)
     case ActionType::MoveCameraHere:
       m_pSceneDocument->MoveCameraHere();
       break;
-    case ActionType::CreateGameObjectHere:
-    {
-      auto res = m_pSceneDocument->CreateGameObjectHere();
-      ezQtUiServices::GetSingleton()->MessageBoxStatus(res, "Create empty object at picked position failed.");
-    }
-    break;
   }
 }
 

--- a/Code/Editor/EditorFramework/Document/GameObjectDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectDocument.h
@@ -96,10 +96,10 @@ class EZ_EDITORFRAMEWORK_DLL ezGameObjectDocument : public ezAssetDocument
   EZ_ADD_DYNAMIC_REFLECTION(ezGameObjectDocument, ezAssetDocument);
 
 public:
-  ezGameObjectDocument(ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager,
-    ezAssetDocEngineConnection engineConnectionType = ezAssetDocEngineConnection::FullObjectMirroring);
+  ezGameObjectDocument(ezStringView sDocumentPath, ezDocumentObjectManager* pObjectManager, ezAssetDocEngineConnection engineConnectionType = ezAssetDocEngineConnection::FullObjectMirroring);
   ~ezGameObjectDocument();
 
+  virtual ezGameObjectDocument* GetRedirectedGameObjectDoc() { return this; }
 
   virtual ezEditorInputContext* GetEditorInputContextOverride() override;
 
@@ -160,9 +160,6 @@ public:
   void SnapCameraToObject();
   /// \brief Moves the camera to the current picking position
   void MoveCameraHere();
-
-  /// \brief Creates an empty game object at the current picking position
-  ezStatus CreateGameObjectHere();
 
   void ScheduleSendObjectSelection();
 

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -40,6 +40,7 @@
 #include <EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h>
 #include <EditorFramework/PropertyGrid/FileBrowserPropertyWidget.moc.h>
 #include <EditorFramework/PropertyGrid/GameObjectReferencePropertyWidget.moc.h>
+#include <EditorFramework/PropertyGrid/RttiTypeStringPropertyWidget.moc.h>
 #include <EditorFramework/Visualizers/BoxVisualizerAdapter.h>
 #include <EditorFramework/Visualizers/CameraVisualizerAdapter.h>
 #include <EditorFramework/Visualizers/CapsuleVisualizerAdapter.h>
@@ -152,6 +153,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezCompilerPreferences>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtCompilerPreferencesWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezCodeEditorPreferences>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtCodeEditorPreferencesWidget(); });
     ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezImageSliderUiAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtPropertyEditorSliderWidget(); });
+    ezQtPropertyGridWidget::GetFactory().RegisterCreator(ezGetStaticRTTI<ezRttiTypeStringAttribute>(), [](const ezRTTI* pRtti)->ezQtPropertyWidget* { return new ezQtRttiTypeStringPropertyWidget(); });
 
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezSphereManipulatorAttribute>(), [](const ezRTTI* pRtti)->ezManipulatorAdapter* { return EZ_DEFAULT_NEW(ezSphereManipulatorAdapter); });
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezCapsuleManipulatorAttribute>(), [](const ezRTTI* pRtti)->ezManipulatorAdapter* { return EZ_DEFAULT_NEW(ezCapsuleManipulatorAdapter); });

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
@@ -431,7 +431,7 @@ ezEditorInput ezCameraMoveContext::DoMouseReleaseEvent(QMouseEvent* e)
 
       ResetCursor();
 
-      if (m_iDidMoveMouse[1] < 5 && m_bOpenMenuOnMouseUp)
+      if (m_iDidMoveMouse[1] < 3 && m_bOpenMenuOnMouseUp)
       {
         GetOwnerView()->OpenContextMenu(e->globalPosition().toPoint());
       }
@@ -458,7 +458,7 @@ ezEditorInput ezCameraMoveContext::DoMouseReleaseEvent(QMouseEvent* e)
 
       ResetCursor();
 
-      if (m_iDidMoveMouse[1] < 5 && m_bOpenMenuOnMouseUp)
+      if (m_iDidMoveMouse[1] < 3 && m_bOpenMenuOnMouseUp)
       {
         GetOwnerView()->OpenContextMenu(e->globalPosition().toPoint());
       }

--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/GameObjectPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/GameObjectPanel.moc.h
@@ -17,6 +17,8 @@ public:
   ezQtGameObjectWidget(QWidget* pParent, ezGameObjectDocument* pDocument, const char* szContextMenuMapping, std::unique_ptr<ezQtDocumentTreeModel> pCustomModel, ezSelectionManager* pSelection = nullptr);
   ~ezQtGameObjectWidget();
 
+  ezQtSearchWidget& GetFilterWidget() { return *m_pFilterWidget; }
+
 private Q_SLOTS:
   void OnItemDoubleClicked(const QModelIndex&);
   void OnRequestContextMenu(QPoint pos);

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
@@ -5,6 +5,7 @@
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h>
+#include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -84,7 +85,7 @@ void ezEditorPreferencesUser::SetShowInDevelopmentFeatures(bool b)
 {
   m_bShowInDevelopmentFeatures = b;
 
-  ezQtAddSubElementButton::s_bShowInDevelopmentFeatures = b;
+  ezQtTypeMenu::s_bShowInDevelopmentFeatures = b;
 }
 
 void ezEditorPreferencesUser::SetHighlightUntranslatedUI(bool b)

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/RttiTypeStringPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/RttiTypeStringPropertyWidget.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/PropertyGrid/RttiTypeStringPropertyWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <GuiFoundation/Widgets/SearchableMenu.moc.h>
 
 ezQtRttiTypeStringPropertyWidget::ezQtRttiTypeStringPropertyWidget()

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/RttiTypeStringPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/RttiTypeStringPropertyWidget.cpp
@@ -1,0 +1,80 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/PropertyGrid/RttiTypeStringPropertyWidget.moc.h>
+#include <GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h>
+#include <GuiFoundation/Widgets/SearchableMenu.moc.h>
+
+ezQtRttiTypeStringPropertyWidget::ezQtRttiTypeStringPropertyWidget()
+  : ezQtStandardPropertyWidget()
+{
+  m_pLayout = new QHBoxLayout(this);
+  m_pLayout->setContentsMargins(0, 0, 0, 0);
+  setLayout(m_pLayout);
+
+  m_pButton = new QPushButton(this);
+  m_pButton->setText("Select Type");
+  m_pButton->setObjectName("Button");
+
+  QSizePolicy policy = m_pButton->sizePolicy();
+  policy.setHorizontalStretch(0);
+  m_pButton->setSizePolicy(policy);
+
+  m_pLayout->addWidget(m_pButton);
+}
+
+void ezQtRttiTypeStringPropertyWidget::OnInit()
+{
+  m_pMenu = new QMenu(m_pButton);
+  m_pMenu->setToolTipsVisible(true);
+  connect(m_pMenu, &QMenu::aboutToShow, this, &ezQtRttiTypeStringPropertyWidget::onMenuAboutToShow);
+  m_pButton->setMenu(m_pMenu);
+  m_pButton->setObjectName("Button");
+
+  connect(&m_TypeMenu, &ezQtTypeMenu::TypeSelected, this, &ezQtRttiTypeStringPropertyWidget::OnTypeSelected);
+}
+
+void ezQtRttiTypeStringPropertyWidget::InternalSetValue(const ezVariant& value)
+{
+  const ezString sTypeName = value.ConvertTo<ezString>();
+
+  const ezRTTI* pRtti = ezRTTI::FindTypeByName(sTypeName);
+
+  const ezCategoryAttribute* pCatA = pRtti->GetAttributeByType<ezCategoryAttribute>();
+  const ezColorAttribute* pColA = pRtti->GetAttributeByType<ezColorAttribute>();
+
+  ezColor iconColor = ezColor::MakeZero();
+
+  if (pColA)
+  {
+    iconColor = pColA->GetColor();
+  }
+  else if (pCatA && iconColor == ezColor::MakeZero())
+  {
+    iconColor = ezColorScheme::GetCategoryColor(pCatA->GetCategory(), ezColorScheme::CategoryColorUsage::MenuEntryIcon);
+  }
+
+  ezStringBuilder sIconName;
+  sIconName.Set(":/TypeIcons/", sTypeName, ".svg");
+  const QIcon actionIcon = ezQtUiServices::GetCachedIconResource(sIconName.GetData(), iconColor);
+
+  m_pButton->setText(sTypeName.GetData());
+  m_pButton->setIcon(actionIcon);
+}
+
+void ezQtRttiTypeStringPropertyWidget::onMenuAboutToShow()
+{
+  if (m_pMenu->isEmpty())
+  {
+    const ezRttiTypeStringAttribute* pTypeAttr = m_pProp->GetAttributeByType<ezRttiTypeStringAttribute>();
+    const ezRTTI* pBaseType = ezRTTI::FindTypeByName(pTypeAttr->GetBaseType());
+
+    m_TypeMenu.FillMenu(m_pMenu, pBaseType, true, false);
+  }
+}
+
+void ezQtRttiTypeStringPropertyWidget::OnTypeSelected(QString sTypeName)
+{
+  const ezString typeName = sTypeName.toUtf8().data();
+
+  BroadcastValueChanged(typeName);
+}

--- a/Code/Editor/EditorFramework/PropertyGrid/RttiTypeStringPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/RttiTypeStringPropertyWidget.moc.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
+#include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
+
+class QHBoxLayout;
+
+class EZ_EDITORFRAMEWORK_DLL ezQtRttiTypeStringPropertyWidget : public ezQtStandardPropertyWidget
+{
+  Q_OBJECT
+
+public:
+  ezQtRttiTypeStringPropertyWidget();
+
+protected Q_SLOTS:
+  void onMenuAboutToShow();
+  void OnTypeSelected(QString sTypeName);
+
+protected:
+  virtual void OnInit() override;
+  virtual void InternalSetValue(const ezVariant& value) override;
+
+protected:
+  QPushButton* m_pButton = nullptr;
+  QHBoxLayout* m_pLayout = nullptr;
+  QMenu* m_pMenu = nullptr;
+
+  ezQtTypeMenu m_TypeMenu;
+};

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -184,7 +184,7 @@ void ezSceneActions::MapViewContextMenuActions(ezStringView sMapping)
   ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
   EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);
 
-  pMap->MapAction(s_hGameModePlayFromHere, "", 1.0f);
+  pMap->MapAction(s_hGameModePlayFromHere, "", 0.0f);
 }
 
 ezSceneAction::ezSceneAction(const ezActionContext& context, const char* szName, ezSceneAction::ActionType type)

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
@@ -174,15 +174,17 @@ void ezSelectionActions::MapViewContextMenuActions(ezStringView sMapping)
   ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
   EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);
 
+  pMap->MapAction(s_hCreateEmptyObjectAtPosition, "G.Selection", 1.0f);
   pMap->MapAction(s_hGroupSelectedItems, "G.Selection", 2.0f);
-  pMap->MapAction(s_hSelectParent, "G.Selection", 2.5f);
-  pMap->MapAction(s_hHideSelectedObjects, "G.Selection", 3.0f);
-  pMap->MapAction(s_hAttachToObject, "G.Selection", 3.1f);
-  pMap->MapAction(s_hDetachFromParent, "G.Selection", 3.2f);
-  pMap->MapAction(s_hSnapObjectToCamera, "G.Selection", 5.0f);
-  pMap->MapAction(s_hCopyReference, "G.Selection", 6.0f);
+  pMap->MapAction(s_hSelectParent, "G.Selection", 3.0f);
+  pMap->MapAction(s_hHideSelectedObjects, "G.Selection", 4.0f);
+  pMap->MapAction(s_hAttachToObject, "G.Selection", 5.0f);
+  pMap->MapAction(s_hDetachFromParent, "G.Selection", 6.0f);
+  pMap->MapAction(s_hSnapObjectToCamera, "G.Selection", 7.0f);
+  pMap->MapAction(s_hCopyReference, "G.Selection", 10.0f);
 
-  MapPrefabActions(sMapping, 7.0f);
+
+  MapPrefabActions(sMapping, 12.0f);
 }
 
 ezSelectionAction::ezSelectionAction(const ezActionContext& context, const char* szName, ezSelectionAction::ActionType type)

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Panels/ScenegraphPanel/ScenegraphPanel.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Panels/ScenegraphPanel/ScenegraphPanel.cpp
@@ -3,7 +3,7 @@
 #include <EditorPluginScene/Panels/ScenegraphPanel/ScenegraphModel.moc.h>
 #include <EditorPluginScene/Panels/ScenegraphPanel/ScenegraphPanel.moc.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
-
+#include <GuiFoundation/Widgets/SearchWidget.moc.h>
 #include <QLayout>
 #include <QStackedWidget>
 
@@ -120,5 +120,12 @@ void ezQtScenegraphPanel::LayerUnloaded(const ezUuid& layerGuid)
 
 void ezQtScenegraphPanel::ActiveLayerChanged(const ezUuid& layerGuid)
 {
+  // migrate the search filter text to the other layer
+  if (ezQtGameObjectWidget* pPrev = qobject_cast<ezQtGameObjectWidget*>(m_pStack->currentWidget()))
+  {
+    QString sText = pPrev->GetFilterWidget().text();
+    m_LayerWidgets[layerGuid]->GetFilterWidget().setText(sText);
+  }
+
   m_pStack->setCurrentWidget(m_LayerWidgets[layerGuid]);
 }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
@@ -106,6 +106,8 @@ public:
   const ezDocumentObject* GetLayerObject(const ezUuid& layerGuid) const;
   ezSceneDocument* GetLayerDocument(const ezUuid& layerGuid) const;
 
+  virtual ezGameObjectDocument* GetRedirectedGameObjectDoc() override;
+
   bool IsAnyLayerModified() const;
 
   ///@}
@@ -163,4 +165,8 @@ private:
   mutable ezUniquePtr<ezSelectionManager> m_pLayerSelection;
   ezUuid m_ActiveLayerGuid;
   ezHashTable<ezUuid, LayerInfo> m_Layers;
+
+  void ActiveLayerGameObjectEventHandler(const ezGameObjectEvent& e);
+
+  ezEvent<const ezGameObjectEvent&>::Unsubscriber m_ActiveLayerGoEvUnsubscriber;
 };

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -441,10 +441,12 @@ ezStatus ezSceneDocument::CreateEmptyObject(bool bAttachToParent, bool bAtPicked
 
     if (!bAttachToParent)
     {
+      const ezUuid activeParent = GetRedirectedGameObjectDoc()->GetActiveParent();
+
       // the object may not exist anymore
-      if (auto pParentObj = GetObjectManager()->GetObject(GetActiveParent()))
+      if (auto pParentObj = GetObjectManager()->GetObject(activeParent))
       {
-        cmdAdd.m_Parent = GetActiveParent();
+        cmdAdd.m_Parent = activeParent;
       }
     }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -94,8 +94,7 @@ public:
 
   virtual void GetSupportedMimeTypesForPasting(ezHybridArray<ezString, 4>& out_mimeTypes) const override;
   virtual bool CopySelectedObjects(ezAbstractObjectGraph& out_objectGraph, ezStringBuilder& out_sMimeType) const override;
-  virtual bool Paste(
-    const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
+  virtual bool Paste(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bAllowPickedPosition, ezStringView sMimeType) override;
   bool DuplicateSelectedObjects(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, bool bSetSelected);
   bool CopySelectedObjects(ezAbstractObjectGraph& ref_graph, ezMap<ezUuid, ezUuid>* out_pParents) const;
   bool PasteAt(const ezArrayPtr<PasteInfo>& info, const ezAbstractObjectGraph& objectGraph, const ezVec3& vPos);
@@ -129,8 +128,7 @@ public:
   bool StopGameMode();
 
   ezTransformStatus ExportScene(bool bCreateThumbnail);
-  void ExportSceneGeometry(
-    const char* szFile, bool bOnlySelection, int iExtractionMode /* ezWorldGeoExtractionUtil::ExtractionMode */, const ezMat3& mTransform);
+  void ExportSceneGeometry(const char* szFile, bool bOnlySelection, int iExtractionMode /* ezWorldGeoExtractionUtil::ExtractionMode */, const ezMat3& mTransform);
 
   virtual void HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg) override;
   void HandleGameModeMsg(const ezGameModeMsgToEditor* pMsg);
@@ -150,8 +148,7 @@ public:
     return ezDynamicCast<const T*>(GetSettingsBase());
   }
 
-  ezStatus CreateExposedProperty(
-    const ezDocumentObject* pObject, const ezAbstractProperty* pProperty, ezVariant index, ezExposedSceneProperty& out_key) const;
+  ezStatus CreateExposedProperty(const ezDocumentObject* pObject, const ezAbstractProperty* pProperty, ezVariant index, ezExposedSceneProperty& out_key) const;
   ezStatus AddExposedParameter(const char* szName, const ezDocumentObject* pObject, const ezAbstractProperty* pProperty, ezVariant index);
   ezInt32 FindExposedParameter(const ezDocumentObject* pObject, const ezAbstractProperty* pProperty, ezVariant index);
   ezStatus RemoveExposedParameter(ezInt32 iIndex);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneViewWidget.cpp
@@ -102,8 +102,9 @@ void ezQtSceneViewWidget::dragEnterEvent(QDragEnterEvent* e)
     info.m_bShiftKeyDown = e->modifiers() & Qt::ShiftModifier;
     info.m_bCtrlKeyDown = e->modifiers() & Qt::ControlModifier;
 
-    if (ezSceneDocument* pSceneDoc = ezDynamicCast<ezSceneDocument*>(m_pDocumentWindow->GetDocument()))
+    if (ezGameObjectDocument* pSceneDoc = ezDynamicCast<ezGameObjectDocument*>(m_pDocumentWindow->GetDocument()))
     {
+      pSceneDoc = pSceneDoc->GetRedirectedGameObjectDoc();
       const ezUuid guid = pSceneDoc->GetActiveParent();
 
       // the object may not exist anymore

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptGraphQt.cpp
@@ -160,9 +160,9 @@ void ezQtVisualScriptNode::UpdateState()
         sVal.ReplaceAll("\n", " ");
         sVal.ReplaceAll("\t", " ");
 
-        if (sVal.GetCharacterCount() > 16)
+        if (sVal.GetCharacterCount() > 23)
         {
-          sVal.Shrink(0, sVal.GetCharacterCount() - 13);
+          sVal.Shrink(0, sVal.GetCharacterCount() - 21);
           sVal.Append("...");
         }
         sVal.Prepend("\"");

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -307,7 +307,6 @@ void ezVisualScriptNodeRegistry::UpdateNodeTypes()
     m_bBuiltinTypesCreated = true;
   }
 
-  auto& componentTypesDynEnum = ezDynamicStringEnum::CreateDynamicEnum("ComponentTypes");
   auto& scriptBaseClassesDynEnum = ezDynamicStringEnum::CreateDynamicEnum("ScriptBaseClasses");
 
   ezRTTI::ForEachType([this](const ezRTTI* pRtti)
@@ -322,12 +321,6 @@ void ezVisualScriptNodeRegistry::UpdateNodeType(const ezRTTI* pRtti)
 
   if (pRtti->GetAttributeByType<ezHiddenAttribute>() != nullptr || pRtti->GetAttributeByType<ezExcludeFromScript>() != nullptr)
     return;
-
-  if (pRtti->IsDerivedFrom<ezComponent>())
-  {
-    auto& componentTypesDynEnum = ezDynamicStringEnum::GetDynamicEnum("ComponentTypes");
-    componentTypesDynEnum.AddValidValue(pRtti->GetTypeName(), true);
-  }
 
   if (pRtti->IsDerivedFrom<ezScriptCoroutine>())
   {
@@ -1302,11 +1295,11 @@ void ezVisualScriptNodeRegistry::CreateBuiltinTypes()
       propDesc.m_sType = ezGetStaticRTTI<ezString>()->GetTypeName();
       propDesc.m_Flags = ezPropertyFlags::StandardType;
 
-      auto pAttr = EZ_DEFAULT_NEW(ezDynamicStringEnumAttribute, "ComponentTypes");
+      auto pAttr = EZ_DEFAULT_NEW(ezRttiTypeStringAttribute, "ezComponent");
       propDesc.m_Attributes.PushBack(pAttr);
     }
 
-    auto pAttr = EZ_DEFAULT_NEW(ezTitleAttribute, "GameObject::TryGetComponentOfBaseType {TypeName}");
+    auto pAttr = EZ_DEFAULT_NEW(ezTitleAttribute, "Get {TypeName}");
     typeDesc.m_Attributes.PushBack(pAttr);
 
     NodeDesc nodeDesc;

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -1155,4 +1155,23 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 //////////////////////////////////////////////////////////////////////////
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRttiTypeStringAttribute, 1, ezRTTIDefaultAllocator<ezRttiTypeStringAttribute>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("BaseType", m_sBaseType),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_CONSTRUCTOR_PROPERTY(const char*),
+  }
+  EZ_END_FUNCTIONS;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+//////////////////////////////////////////////////////////////////////////
+
 EZ_STATICLINK_FILE(Foundation, Foundation_Reflection_Implementation_PropertyAttributes);

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -1098,3 +1098,26 @@ public:
 
   ezUntrackedString m_sImageGenerator;
 };
+
+//////////////////////////////////////////////////////////////////////////
+
+/// \brief Attribute that turns a string property into a selector for an RTTI type.
+///
+/// The base type defines what types to display.
+/// For example if "ezComponent" is passed in, only types derived from ezComponent are listed.
+class EZ_FOUNDATION_DLL ezRttiTypeStringAttribute : public ezTypeWidgetAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezRttiTypeStringAttribute, ezTypeWidgetAttribute);
+
+public:
+  ezRttiTypeStringAttribute() = default;
+  ezRttiTypeStringAttribute(const char* szBaseType)
+    : m_sBaseType(szBaseType)
+  {
+  }
+
+  const char* GetBaseType() const { return m_sBaseType; }
+
+private:
+  ezUntrackedString m_sBaseType;
+};

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -75,6 +75,9 @@ ezProjectileComponent::~ezProjectileComponent() = default;
 
 void ezProjectileComponent::Update()
 {
+  if (m_fGravityMultiplier == 0.0f && m_fMetersPerSecond == 0.0f)
+    return;
+
   ezPhysicsWorldModuleInterface* pPhysicsInterface = GetWorld()->GetModule<ezPhysicsWorldModuleInterface>();
 
   if (pPhysicsInterface)
@@ -221,6 +224,7 @@ void ezProjectileComponent::Update()
         else if (interaction.m_Reaction == ezProjectileReaction::Attach)
         {
           m_fMetersPerSecond = 0.0f;
+          m_fGravityMultiplier = 0.0f;
           vNewPosition = castResult.m_vPosition;
 
           ezGameObject* pObject;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
@@ -7,14 +7,12 @@
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <GuiFoundation/Widgets/SearchableMenu.moc.h>
+#include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 #include <QHBoxLayout>
 #include <QInputDialog>
 #include <QMenu>
 #include <QPushButton>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
-
-ezString ezQtAddSubElementButton::s_sLastMenuSearch;
-bool ezQtAddSubElementButton::s_bShowInDevelopmentFeatures = false;
 
 ezQtAddSubElementButton::ezQtAddSubElementButton()
   : ezQtPropertyWidget()
@@ -51,6 +49,8 @@ void ezQtAddSubElementButton::OnInit()
     connect(m_pMenu, &QMenu::aboutToShow, this, &ezQtAddSubElementButton::onMenuAboutToShow);
     m_pButton->setMenu(m_pMenu);
     m_pButton->setObjectName("Button");
+
+    connect(&m_TypeMenu, &ezQtTypeMenu::TypeSelected, this, &ezQtAddSubElementButton::OnTypeSelected);
   }
 
   if (const ezMaxArraySizeAttribute* pAttr = m_pProp->GetAttributeByType<ezMaxArraySizeAttribute>())
@@ -66,63 +66,6 @@ void ezQtAddSubElementButton::OnInit()
   QMetaObject::connectSlotsByName(this);
 }
 
-struct TypeComparer
-{
-  EZ_FORCE_INLINE bool Less(const ezRTTI* a, const ezRTTI* b) const
-  {
-    const ezCategoryAttribute* pCatA = a->GetAttributeByType<ezCategoryAttribute>();
-    const ezCategoryAttribute* pCatB = b->GetAttributeByType<ezCategoryAttribute>();
-    if (pCatA != nullptr && pCatB == nullptr)
-    {
-      return true;
-    }
-    else if (pCatA == nullptr && pCatB != nullptr)
-    {
-      return false;
-    }
-    else if (pCatA != nullptr && pCatB != nullptr)
-    {
-      ezInt32 iRes = ezStringUtils::Compare(pCatA->GetCategory(), pCatB->GetCategory());
-      if (iRes != 0)
-      {
-        return iRes < 0;
-      }
-    }
-
-    return a->GetTypeName().Compare(b->GetTypeName()) < 0;
-  }
-};
-
-QMenu* ezQtAddSubElementButton::CreateCategoryMenu(const char* szCategory, ezMap<ezString, QMenu*>& existingMenus)
-{
-  if (ezStringUtils::IsNullOrEmpty(szCategory))
-    return m_pMenu;
-
-
-  auto it = existingMenus.Find(szCategory);
-  if (it.IsValid())
-    return it.Value();
-
-  ezStringBuilder sPath = szCategory;
-  sPath.PathParentDirectory();
-  sPath.Trim("/");
-
-  QMenu* pParentMenu = m_pMenu;
-
-  if (!sPath.IsEmpty())
-  {
-    pParentMenu = CreateCategoryMenu(sPath, existingMenus);
-  }
-
-  sPath = szCategory;
-  sPath = sPath.GetFileName();
-
-  QMenu* pNewMenu = pParentMenu->addMenu(ezMakeQString(ezTranslate(sPath)));
-  existingMenus[szCategory] = pNewMenu;
-
-  return pNewMenu;
-}
-
 void ezQtAddSubElementButton::onMenuAboutToShow()
 {
   if (m_Items.IsEmpty())
@@ -132,137 +75,7 @@ void ezQtAddSubElementButton::onMenuAboutToShow()
   {
     auto pProp = GetProperty();
 
-    if (pProp->GetFlags().IsSet(ezPropertyFlags::Pointer))
-    {
-      m_SupportedTypes.Clear();
-      ezReflectionUtils::GatherTypesDerivedFromClass(pProp->GetSpecificType(), m_SupportedTypes);
-    }
-    m_SupportedTypes.Insert(pProp->GetSpecificType());
-
-    // Make category-sorted array of types and skip all abstract, hidden or in development types
-    ezDynamicArray<const ezRTTI*> supportedTypes;
-    for (const ezRTTI* pRtti : m_SupportedTypes)
-    {
-      if (pRtti->GetTypeFlags().IsAnySet(ezTypeFlags::Abstract))
-        continue;
-
-      if (pRtti->GetAttributeByType<ezHiddenAttribute>() != nullptr)
-        continue;
-
-      if (!s_bShowInDevelopmentFeatures && pRtti->GetAttributeByType<ezInDevelopmentAttribute>() != nullptr)
-        continue;
-
-      supportedTypes.PushBack(pRtti);
-    }
-    supportedTypes.Sort(TypeComparer());
-
-    if (!m_bPreventDuplicates && supportedTypes.GetCount() > 10)
-    {
-      // only show a searchable menu when it makes some sense
-      // also deactivating entries to prevent duplicates is currently not supported by the searchable menu
-      m_pSearchableMenu = new ezQtSearchableMenu(m_pMenu);
-    }
-
-    ezStringBuilder sIconName;
-    ezStringBuilder sCategory = "";
-
-    ezMap<ezString, QMenu*> existingMenus;
-
-    if (m_pSearchableMenu == nullptr)
-    {
-      // first round: create all sub menus
-      for (const ezRTTI* pRtti : supportedTypes)
-      {
-        // Determine current menu
-        const ezCategoryAttribute* pCatA = pRtti->GetAttributeByType<ezCategoryAttribute>();
-
-        if (pCatA)
-        {
-          CreateCategoryMenu(pCatA->GetCategory(), existingMenus);
-        }
-      }
-    }
-
-    ezStringBuilder tmp;
-
-    // second round: create the actions
-    for (const ezRTTI* pRtti : supportedTypes)
-    {
-      sIconName.Set(":/TypeIcons/", pRtti->GetTypeName(), ".svg");
-
-      // Determine current menu
-      const ezCategoryAttribute* pCatA = pRtti->GetAttributeByType<ezCategoryAttribute>();
-      const ezInDevelopmentAttribute* pInDev = pRtti->GetAttributeByType<ezInDevelopmentAttribute>();
-      const ezColorAttribute* pColA = pRtti->GetAttributeByType<ezColorAttribute>();
-
-      ezColor iconColor = ezColor::MakeZero();
-
-      if (pColA)
-      {
-        iconColor = pColA->GetColor();
-      }
-      else if (pCatA && iconColor == ezColor::MakeZero())
-      {
-        iconColor = ezColorScheme::GetCategoryColor(pCatA->GetCategory(), ezColorScheme::CategoryColorUsage::MenuEntryIcon);
-      }
-
-      const QIcon actionIcon = ezQtUiServices::GetCachedIconResource(sIconName.GetData(), iconColor);
-
-
-      if (m_pSearchableMenu != nullptr)
-      {
-        ezStringBuilder sFullPath;
-        sFullPath = pCatA ? pCatA->GetCategory() : "";
-        sFullPath.AppendPath(pRtti->GetTypeName());
-
-        ezStringBuilder sDisplayName = ezTranslate(pRtti->GetTypeName().GetData(tmp));
-        if (pInDev)
-        {
-          sDisplayName.AppendFormat(" [ {} ]", pInDev->GetString());
-        }
-
-        m_pSearchableMenu->AddItem(sDisplayName, sFullPath, QVariant::fromValue((void*)pRtti), actionIcon);
-      }
-      else
-      {
-        QMenu* pCat = CreateCategoryMenu(pCatA ? pCatA->GetCategory() : nullptr, existingMenus);
-
-        ezStringBuilder fullName = ezTranslate(pRtti->GetTypeName().GetData(tmp));
-
-        if (pInDev)
-        {
-          fullName.AppendFormat(" [ {} ]", pInDev->GetString());
-        }
-
-        // Add type action to current menu
-        QAction* pAction = new QAction(fullName.GetData(), m_pMenu);
-        pAction->setProperty("type", QVariant::fromValue((void*)pRtti));
-        EZ_VERIFY(connect(pAction, SIGNAL(triggered()), this, SLOT(OnMenuAction())) != nullptr, "connection failed");
-
-        pAction->setIcon(actionIcon);
-
-        pCat->addAction(pAction);
-      }
-    }
-
-    if (m_pSearchableMenu != nullptr)
-    {
-      connect(m_pSearchableMenu, &ezQtSearchableMenu::MenuItemTriggered, m_pMenu, [this](const QString& sName, const QVariant& variant)
-        {
-        const ezRTTI* pRtti = static_cast<const ezRTTI*>(variant.value<void*>());
-
-        OnAction(pRtti);
-        m_pMenu->close(); });
-
-      connect(m_pSearchableMenu, &ezQtSearchableMenu::SearchTextChanged, m_pMenu,
-        [this](const QString& sText)
-        { s_sLastMenuSearch = sText.toUtf8().data(); });
-
-      m_pMenu->addAction(m_pSearchableMenu);
-
-      // important to do this last to make sure the search bar gets focus
-      m_pSearchableMenu->Finalize(s_sLastMenuSearch.GetData());
-    }
+    m_TypeMenu.FillMenu(m_pMenu, pProp->GetSpecificType(), pProp->GetFlags().IsSet(ezPropertyFlags::Pointer), m_bPreventDuplicates);
   }
 
   if (m_uiMaxElements > 0) // 0 means unlimited
@@ -345,11 +158,11 @@ void ezQtAddSubElementButton::on_Button_clicked()
   }
 }
 
-void ezQtAddSubElementButton::OnMenuAction()
+void ezQtAddSubElementButton::OnTypeSelected(QString sTypeName)
 {
-  const ezRTTI* pRtti = static_cast<const ezRTTI*>(sender()->property("type").value<void*>());
+  const ezString typeName = sTypeName.toUtf8().data();
 
-  OnAction(pRtti);
+  OnAction(ezRTTI::FindTypeByName(typeName));
 }
 
 void ezQtAddSubElementButton::OnAction(const ezRTTI* pRtti)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h
@@ -2,11 +2,11 @@
 
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h>
+#include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 
 class QHBoxLayout;
 class QPushButton;
 class QMenu;
-class ezQtSearchableMenu;
 
 class EZ_GUIFOUNDATION_DLL ezQtAddSubElementButton : public ezQtPropertyWidget
 {
@@ -15,34 +15,25 @@ class EZ_GUIFOUNDATION_DLL ezQtAddSubElementButton : public ezQtPropertyWidget
 public:
   ezQtAddSubElementButton();
 
-  static bool s_bShowInDevelopmentFeatures;
-
 protected:
   virtual void DoPrepareToDie() override {}
 
 private Q_SLOTS:
   void onMenuAboutToShow();
   void on_Button_clicked();
-  void OnMenuAction();
+  void OnTypeSelected(QString sTypeName);
 
 private:
   virtual void OnInit() override;
   void OnAction(const ezRTTI* pRtti);
 
-  QMenu* CreateCategoryMenu(const char* szCategory, ezMap<ezString, QMenu*>& existingMenus);
-
   QHBoxLayout* m_pLayout;
   QPushButton* m_pButton;
 
-  ezSet<const ezRTTI*> m_SupportedTypes;
+  ezQtTypeMenu m_TypeMenu;
 
   bool m_bNoMoreElementsAllowed = false;
   QMenu* m_pMenu = nullptr;
-  ezQtSearchableMenu* m_pSearchableMenu = nullptr;
   ezUInt32 m_uiMaxElements = 0; // 0 means unlimited
   bool m_bPreventDuplicates = false;
-
-  // used to remember the last search term entered into the searchable menu
-  // this should probably be per 'distinguishable menu', but currently it is just global
-  static ezString s_sLastMenuSearch;
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CVarWidget.cpp
@@ -63,6 +63,11 @@ void ezQtCVarWidget::UpdateCVarUI(const ezMap<ezString, ezCVarWidgetData>& cvars
 {
   int row = 0;
 
+  if (CVarsView->isPersistentEditorOpen(CVarsView->currentIndex()))
+  {
+    CVarsView->closePersistentEditor(CVarsView->currentIndex());
+  }
+
   m_pItemModel->BeginResetModel();
 
   for (auto it = cvars.GetIterator(); it.IsValid(); ++it, ++row)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
@@ -1,3 +1,5 @@
+#include <Foundation/Reflection/Implementation/PropertyAttributes.h>
+#include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Strings/TranslationLookup.h>
 #include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
@@ -1,0 +1,211 @@
+#include <Foundation/Strings/TranslationLookup.h>
+#include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
+
+bool ezQtTypeMenu::s_bShowInDevelopmentFeatures = false;
+
+struct TypeComparer
+{
+  EZ_FORCE_INLINE bool Less(const ezRTTI* a, const ezRTTI* b) const
+  {
+    const ezCategoryAttribute* pCatA = a->GetAttributeByType<ezCategoryAttribute>();
+    const ezCategoryAttribute* pCatB = b->GetAttributeByType<ezCategoryAttribute>();
+    if (pCatA != nullptr && pCatB == nullptr)
+    {
+      return true;
+    }
+    else if (pCatA == nullptr && pCatB != nullptr)
+    {
+      return false;
+    }
+    else if (pCatA != nullptr && pCatB != nullptr)
+    {
+      ezInt32 iRes = ezStringUtils::Compare(pCatA->GetCategory(), pCatB->GetCategory());
+      if (iRes != 0)
+      {
+        return iRes < 0;
+      }
+    }
+
+    return a->GetTypeName().Compare(b->GetTypeName()) < 0;
+  }
+};
+
+ezString ezQtTypeMenu::s_sLastMenuSearch;
+
+QMenu* ezQtTypeMenu::CreateCategoryMenu(const char* szCategory, ezMap<ezString, QMenu*>& existingMenus)
+{
+  if (ezStringUtils::IsNullOrEmpty(szCategory))
+    return m_pMenu;
+
+
+  auto it = existingMenus.Find(szCategory);
+  if (it.IsValid())
+    return it.Value();
+
+  ezStringBuilder sPath = szCategory;
+  sPath.PathParentDirectory();
+  sPath.Trim("/");
+
+  QMenu* pParentMenu = m_pMenu;
+
+  if (!sPath.IsEmpty())
+  {
+    pParentMenu = CreateCategoryMenu(sPath, existingMenus);
+  }
+
+  sPath = szCategory;
+  sPath = sPath.GetFileName();
+
+  QMenu* pNewMenu = pParentMenu->addMenu(ezMakeQString(ezTranslate(sPath)));
+  existingMenus[szCategory] = pNewMenu;
+
+  return pNewMenu;
+}
+
+void ezQtTypeMenu::OnMenuAction()
+{
+  const ezRTTI* pRtti = static_cast<const ezRTTI*>(sender()->property("type").value<void*>());
+
+  Q_EMIT TypeSelected(ezMakeQString(pRtti->GetTypeName()));
+}
+
+void ezQtTypeMenu::FillMenu(QMenu* pMenu, const ezRTTI* pBaseType, bool bDerivedTypes, bool bSimpleMenu)
+{
+  m_pMenu = pMenu;
+
+  m_SupportedTypes.Clear();
+  m_SupportedTypes.Insert(pBaseType);
+
+  if (bDerivedTypes)
+  {
+    ezReflectionUtils::GatherTypesDerivedFromClass(pBaseType, m_SupportedTypes);
+  }
+
+  // Make category-sorted array of types and skip all abstract, hidden or in development types
+  ezDynamicArray<const ezRTTI*> supportedTypes;
+  for (const ezRTTI* pRtti : m_SupportedTypes)
+  {
+    if (pRtti->GetTypeFlags().IsAnySet(ezTypeFlags::Abstract))
+      continue;
+
+    if (pRtti->GetAttributeByType<ezHiddenAttribute>() != nullptr)
+      continue;
+
+    if (!s_bShowInDevelopmentFeatures && pRtti->GetAttributeByType<ezInDevelopmentAttribute>() != nullptr)
+      continue;
+
+    supportedTypes.PushBack(pRtti);
+  }
+  supportedTypes.Sort(TypeComparer());
+
+  if (!bSimpleMenu && supportedTypes.GetCount() > 10)
+  {
+    // only show a searchable menu when it makes some sense
+    // also deactivating entries to prevent duplicates is currently not supported by the searchable menu
+    m_pSearchableMenu = new ezQtSearchableMenu(m_pMenu);
+  }
+
+  ezStringBuilder sIconName;
+  ezStringBuilder sCategory = "";
+
+  ezMap<ezString, QMenu*> existingMenus;
+
+  if (m_pSearchableMenu == nullptr)
+  {
+    // first round: create all sub menus
+    for (const ezRTTI* pRtti : supportedTypes)
+    {
+      // Determine current menu
+      const ezCategoryAttribute* pCatA = pRtti->GetAttributeByType<ezCategoryAttribute>();
+
+      if (pCatA)
+      {
+        CreateCategoryMenu(pCatA->GetCategory(), existingMenus);
+      }
+    }
+  }
+
+  ezStringBuilder tmp;
+
+  // second round: create the actions
+  for (const ezRTTI* pRtti : supportedTypes)
+  {
+    sIconName.Set(":/TypeIcons/", pRtti->GetTypeName(), ".svg");
+
+    // Determine current menu
+    const ezCategoryAttribute* pCatA = pRtti->GetAttributeByType<ezCategoryAttribute>();
+    const ezInDevelopmentAttribute* pInDev = pRtti->GetAttributeByType<ezInDevelopmentAttribute>();
+    const ezColorAttribute* pColA = pRtti->GetAttributeByType<ezColorAttribute>();
+
+    ezColor iconColor = ezColor::MakeZero();
+
+    if (pColA)
+    {
+      iconColor = pColA->GetColor();
+    }
+    else if (pCatA && iconColor == ezColor::MakeZero())
+    {
+      iconColor = ezColorScheme::GetCategoryColor(pCatA->GetCategory(), ezColorScheme::CategoryColorUsage::MenuEntryIcon);
+    }
+
+    const QIcon actionIcon = ezQtUiServices::GetCachedIconResource(sIconName.GetData(), iconColor);
+
+
+    if (m_pSearchableMenu != nullptr)
+    {
+      ezStringBuilder sFullPath;
+      sFullPath = pCatA ? pCatA->GetCategory() : "";
+      sFullPath.AppendPath(pRtti->GetTypeName());
+
+      ezStringBuilder sDisplayName = ezTranslate(pRtti->GetTypeName().GetData(tmp));
+      if (pInDev)
+      {
+        sDisplayName.AppendFormat(" [ {} ]", pInDev->GetString());
+      }
+
+      m_pSearchableMenu->AddItem(sDisplayName, sFullPath, QVariant::fromValue((void*)pRtti), actionIcon);
+    }
+    else
+    {
+      QMenu* pCat = CreateCategoryMenu(pCatA ? pCatA->GetCategory() : nullptr, existingMenus);
+
+      ezStringBuilder fullName = ezTranslate(pRtti->GetTypeName().GetData(tmp));
+
+      if (pInDev)
+      {
+        fullName.AppendFormat(" [ {} ]", pInDev->GetString());
+      }
+
+      // Add type action to current menu
+      QAction* pAction = new QAction(fullName.GetData(), m_pMenu);
+      pAction->setProperty("type", QVariant::fromValue((void*)pRtti));
+      EZ_VERIFY(connect(pAction, SIGNAL(triggered()), this, SLOT(OnMenuAction())) != nullptr, "connection failed");
+
+      pAction->setIcon(actionIcon);
+
+      pCat->addAction(pAction);
+    }
+  }
+
+  if (m_pSearchableMenu != nullptr)
+  {
+    connect(m_pSearchableMenu, &ezQtSearchableMenu::MenuItemTriggered, m_pMenu, [this](const QString& sName, const QVariant& variant)
+      {
+        const ezRTTI* pRtti = static_cast<const ezRTTI*>(variant.value<void*>());
+
+        Q_EMIT TypeSelected(ezMakeQString(pRtti->GetTypeName()));
+
+        m_pMenu->close();
+        //
+      });
+
+    connect(m_pSearchableMenu, &ezQtSearchableMenu::SearchTextChanged, m_pMenu,
+      [this](const QString& sText)
+      { ezQtTypeMenu::s_sLastMenuSearch = sText.toUtf8().data(); });
+
+    m_pMenu->addAction(m_pSearchableMenu);
+
+    // important to do this last to make sure the search bar gets focus
+    m_pSearchableMenu->Finalize(ezQtTypeMenu::s_sLastMenuSearch.GetData());
+  }
+}

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
@@ -1,6 +1,9 @@
 #include <Foundation/Reflection/Implementation/PropertyAttributes.h>
 #include <Foundation/Reflection/Reflection.h>
+#include <Foundation/Reflection/ReflectionUtils.h>
 #include <Foundation/Strings/TranslationLookup.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
+#include <GuiFoundation/Widgets/SearchableMenu.moc.h>
 #include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 
 bool ezQtTypeMenu::s_bShowInDevelopmentFeatures = false;

--- a/Code/Tools/Libs/GuiFoundation/Widgets/SearchableTypeMenu.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/SearchableTypeMenu.moc.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <Foundation/Containers/Set.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
+#include <QObject>
+
+class ezQtSearchableMenu;
+class ezRTTI;
+class QMenu;
+
+class EZ_GUIFOUNDATION_DLL ezQtTypeMenu : public QObject
+{
+  Q_OBJECT
+
+public:
+  void FillMenu(QMenu* pMenu, const ezRTTI* pBaseType, bool bDerivedTypes, bool bSimpleMenu);
+
+  static bool s_bShowInDevelopmentFeatures;
+
+Q_SIGNALS:
+  void TypeSelected(QString sTypeName);
+
+protected Q_SLOTS:
+  void OnMenuAction();
+
+private:
+  QMenu* CreateCategoryMenu(const char* szCategory, ezMap<ezString, QMenu*>& existingMenus);
+
+  QMenu* m_pMenu = nullptr;
+  ezSet<const ezRTTI*> m_SupportedTypes;
+  ezQtSearchableMenu* m_pSearchableMenu = nullptr;
+
+  static ezString s_sLastMenuSearch;
+};

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -160,7 +160,7 @@ Selection.HideItems;Hide Selected
 Selection.HideUnselectedItems;Hide Unselected
 Selection.ShowHidden;Show Hidden Objects
 Selection.CreateEmptyChildObject;Create Empty Child Object
-Selection.CreateEmptyObjectAtPosition;Create Empty Object At Position
+Selection.CreateEmptyObjectAtPosition;Create Empty Object Here
 Selection.DuplicateSpecial;Duplicate...
 Selection.DeltaTransform;Delta Transform...
 Selection.Attach;Attach to This


### PR DESCRIPTION
* Fixed an annoying Qt warning in the CVars panel
* Fixed that the 'attach' mode of projectiles didn't work anymore
* When switching layers, the search text in the scenegraph is now kept
* Fixed that 'active parent' didn't work in other layers than the main layer
* Also fixed that some actions didn't consider the active parent setting
* Improved the shadow stats text overlay
* Added a type annotation for turning a string into an RTTI type selector. Implemented proper UI for it:
  ![image](https://github.com/user-attachments/assets/4f8b3c0b-03ac-4815-9efa-3373f4f807ba)
