### PR TITLE
Added a 'RECENT' section to the type selection menu

### DIFF
--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
@@ -41,6 +41,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorPreferencesUser, 1, ezRTTIDefaultAllocat
     EZ_MEMBER_PROPERTY("DirectionalLightShadows", m_bDirectionalLightShadows),
     EZ_MEMBER_PROPERTY("DirectionalLightIntensity", m_fDirectionalLightIntensity)->AddAttributes(new ezDefaultValueAttribute(10.0f)),
     EZ_MEMBER_PROPERTY("Fog", m_bFog),
+    EZ_ARRAY_MEMBER_PROPERTY("RecentTypes", m_RecentlyCreatedTypes)->AddAttributes(new ezHiddenAttribute()),
   }
   EZ_END_PROPERTIES;
 }
@@ -50,9 +51,13 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezEditorPreferencesUser::ezEditorPreferencesUser()
   : ezPreferences(Domain::Application, "General")
 {
+  ezQtTypeMenu::s_pRecentList = &m_RecentlyCreatedTypes;
 }
 
-ezEditorPreferencesUser::~ezEditorPreferencesUser() = default;
+ezEditorPreferencesUser::~ezEditorPreferencesUser()
+{
+  ezQtTypeMenu::s_pRecentList = nullptr;
+}
 
 void ezEditorPreferencesUser::ApplyDefaultValues(ezEngineViewLightSettings& ref_settings)
 {

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
@@ -59,6 +59,8 @@ public:
   void SetMaxFramerate(ezUInt16 uiFPS);
   ezUInt16 GetMaxFramerate() const { return m_uiMaxFramerate; }
 
+  ezHybridArray<ezString, 8> m_RecentlyCreatedTypes;
+
 private:
   void SyncGlobalSettings();
 

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptNodeRegistry.cpp
@@ -1299,7 +1299,7 @@ void ezVisualScriptNodeRegistry::CreateBuiltinTypes()
       propDesc.m_Attributes.PushBack(pAttr);
     }
 
-    auto pAttr = EZ_DEFAULT_NEW(ezTitleAttribute, "Get {TypeName}");
+    auto pAttr = EZ_DEFAULT_NEW(ezTitleAttribute, "GameObject::TryGet {TypeName}");
     typeDesc.m_Attributes.PushBack(pAttr);
 
     NodeDesc nodeDesc;

--- a/Code/Tools/Libs/GuiFoundation/Widgets/SearchableTypeMenu.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/SearchableTypeMenu.moc.h
@@ -15,6 +15,7 @@ class EZ_GUIFOUNDATION_DLL ezQtTypeMenu : public QObject
 public:
   void FillMenu(QMenu* pMenu, const ezRTTI* pBaseType, bool bDerivedTypes, bool bSimpleMenu);
 
+  static ezDynamicArray<ezString>* s_pRecentList;
   static bool s_bShowInDevelopmentFeatures;
 
 Q_SIGNALS:
@@ -25,6 +26,7 @@ protected Q_SLOTS:
 
 private:
   QMenu* CreateCategoryMenu(const char* szCategory, ezMap<ezString, QMenu*>& existingMenus);
+  void OnMenuAction(const ezRTTI* pRtti);
 
   QMenu* m_pMenu = nullptr;
   ezSet<const ezRTTI*> m_SupportedTypes;


### PR DESCRIPTION
Recently used types are stored and also saved across editor runs.

![image](https://github.com/user-attachments/assets/c867f543-3114-4e0a-83c3-7e38e94d3e18)
