### PR TITLE
Make object creation with a desired component type easier

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SelectionActions.cpp
@@ -281,13 +281,13 @@ void ezSelectionAction::Execute(const ezVariant& value)
       return;
     case ActionType::CreateEmptyChildObject:
     {
-      auto res = m_pSceneDocument->CreateEmptyObject(true, false);
+      auto res = m_pSceneDocument->CreateEmptyObject(true, false, false);
       ezQtUiServices::MessageBoxStatus(res, "Object creation failed.");
       return;
     }
     case ActionType::CreateEmptyObjectAtPosition:
     {
-      auto res = m_pSceneDocument->CreateEmptyObject(false, true);
+      auto res = m_pSceneDocument->CreateEmptyObject(false, true, true);
       ezQtUiServices::MessageBoxStatus(res, "Object creation failed.");
       return;
     }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -15,6 +15,7 @@
 #include <Foundation/Serialization/DdlSerializer.h>
 #include <Foundation/Serialization/ReflectionSerializer.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
+#include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 #include <QClipboard>
 #include <RendererCore/Components/CameraComponent.h>
 #include <ToolsFoundation/Command/TreeCommands.h>
@@ -419,8 +420,27 @@ void ezSceneDocument::CopyReference()
   ezQtUiServices::GetSingleton()->ShowAllDocumentsTemporaryStatusBarMessage(ezFmt("Copied Object Reference: {}", sGuid), ezTime::MakeFromSeconds(5));
 }
 
-ezStatus ezSceneDocument::CreateEmptyObject(bool bAttachToParent, bool bAtPickedPosition)
+ezStatus ezSceneDocument::CreateEmptyObject(bool bAttachToParent, bool bAtPickedPosition, bool bComponentSelectionMenu)
 {
+  const ezRTTI* pComponentType = ezRTTI::FindTypeByName("ezShapeIconComponent");
+
+  if (bComponentSelectionMenu)
+  {
+    // show the context menu to select a component type
+
+    QMenu m;
+    ezQtTypeMenu tm;
+    tm.FillMenu(&m, ezGetStaticRTTI<ezComponent>(), true, false);
+
+    m.exec(QCursor::pos());
+
+    if (tm.m_pLastSelectedType)
+    {
+      pComponentType = tm.m_pLastSelectedType;
+      tm.m_pLastSelectedType = nullptr;
+    }
+  }
+
   auto history = GetCommandHistory();
 
   history->StartTransaction("Create Node");
@@ -503,7 +523,7 @@ ezStatus ezSceneDocument::CreateEmptyObject(bool bAttachToParent, bool bAtPicked
   // Add a dummy shape icon component, which enables picking
   {
     ezAddObjectCommand cmdAdd;
-    cmdAdd.m_pType = ezRTTI::FindTypeByName("ezShapeIconComponent");
+    cmdAdd.m_pType = pComponentType;
     cmdAdd.m_sParentProperty = "Components";
     cmdAdd.m_Index = -1;
     cmdAdd.m_Parent = NewNode;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -17,6 +17,7 @@
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/Widgets/SearchableTypeMenu.moc.h>
 #include <QClipboard>
+#include <QMenu>
 #include <RendererCore/Components/CameraComponent.h>
 #include <ToolsFoundation/Command/TreeCommands.h>
 #include <ToolsFoundation/Object/ObjectDirectAccessor.h>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.h
@@ -72,7 +72,7 @@ public:
   void CopyReference();
 
   /// \brief Creates a new empty object, either top-level (selection empty) or as a child of the selected item
-  ezStatus CreateEmptyObject(bool bAttachToParent, bool bAtPickedPosition);
+  ezStatus CreateEmptyObject(bool bAttachToParent, bool bAtPickedPosition, bool bComponentSelectionMenu);
 
   void DuplicateSelection();
   void ShowOrHideSelectedObjects(ShowOrHide action);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableMenu.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableMenu.cpp
@@ -235,6 +235,19 @@ void ezQtSearchableMenu::OnSearchChanged(const QString& text)
 
 void ezQtSearchableMenu::OnShow()
 {
+  if (m_pFilterModel->rowCount() > 0)
+  {
+    QModelIndex idx = m_pFilterModel->index(0, 0);
+
+    // hacky convention, if the first item name starts with a whitespace,
+    // that is to move it to the top of the list, which is currently used for the 'RECENT' section
+    // and we want that to always be expanded
+    if (m_pFilterModel->data(idx, Qt::DisplayRole).toString().startsWith(' '))
+    {
+      m_pTreeView->expandRecursively(idx);
+    }
+  }
+
   m_pSearch->setFocus();
   m_pSearch->selectAll();
 }

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/SearchableTypeMenu.cpp
@@ -77,6 +77,8 @@ void ezQtTypeMenu::OnMenuAction()
 
 void ezQtTypeMenu::OnMenuAction(const ezRTTI* pRtti)
 {
+  m_pLastSelectedType = pRtti;
+
   if (s_pRecentList && !s_pRecentList->Contains(pRtti->GetTypeName()))
   {
     if (s_pRecentList->GetCount() > 8)

--- a/Code/Tools/Libs/GuiFoundation/Widgets/SearchableTypeMenu.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/SearchableTypeMenu.moc.h
@@ -18,6 +18,8 @@ public:
   static ezDynamicArray<ezString>* s_pRecentList;
   static bool s_bShowInDevelopmentFeatures;
 
+  const ezRTTI* m_pLastSelectedType = nullptr;
+
 Q_SIGNALS:
   void TypeSelected(QString sTypeName);
 

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -160,7 +160,7 @@ Selection.HideItems;Hide Selected
 Selection.HideUnselectedItems;Hide Unselected
 Selection.ShowHidden;Show Hidden Objects
 Selection.CreateEmptyChildObject;Create Empty Child Object
-Selection.CreateEmptyObjectAtPosition;Create Empty Object Here
+Selection.CreateEmptyObjectAtPosition;Create Object Here
 Selection.DuplicateSpecial;Duplicate...
 Selection.DeltaTransform;Delta Transform...
 Selection.Attach;Attach to This

--- a/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
@@ -89,7 +89,6 @@ ezSceneTransitionComponent;Scene Transition;;https://ezengine.net/pages/docs/gam
 EditorShortcut;Editor Shortcut;Press ALT+Number to jump to this camera.
 Scene.CreateThumbnail;Create Scene Thumbnail
 Scene.GameMode.PlayFromHere;Play From Here
-Scene.GameObject.CreateEmptyHere;Create Empty Object Here
 Scene.Camera.Create.0;Create Level Camera 0;Creates a camera node at the current editor camera position and configures its shortcut
 Scene.Camera.Create.1;Create Level Camera 1;Creates a camera node at the current editor camera position and configures its shortcut
 Scene.Camera.Create.2;Create Level Camera 2;Creates a camera node at the current editor camera position and configures its shortcut


### PR DESCRIPTION
When creating an empty game object somewhere (CTRL+SHIFT+X in viewport), the editor now shows the component type menu. If the user choses a component type from it, the new game object uses that. If they click somewhere else to close the menu, it uses the default shape icon component, as before.

https://github.com/user-attachments/assets/d5e9c474-38e6-4c37-a510-2e86b662acf1

