### PR TITLE
Make it easier to navigate asset references

### DIFF
--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -27,8 +27,9 @@ ezQtAssetPropertyWidget::ezQtAssetPropertyWidget()
   setFocusProxy(m_pWidget);
 
   EZ_VERIFY(connect(m_pWidget, SIGNAL(editingFinished()), this, SLOT(on_TextFinished_triggered())) != nullptr, "signal/slot connection failed");
-  EZ_VERIFY(connect(m_pWidget, SIGNAL(textChanged(const QString&)), this, SLOT(on_TextChanged_triggered(const QString&))) != nullptr,
-    "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pWidget, SIGNAL(textChanged(const QString&)), this, SLOT(on_TextChanged_triggered(const QString&))) != nullptr, "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pWidget, SIGNAL(OpenAsset()), this, SLOT(OnOpenAssetDocument())) != nullptr, "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pWidget, SIGNAL(SelectAsset()), this, SLOT(on_BrowseFile_clicked())) != nullptr, "signal/slot connection failed");
 
   m_pButton = new QToolButton(this);
   m_pButton->setText(QStringLiteral("... "));
@@ -214,9 +215,9 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
       m_pWidget->setPalette(m_Pal);
 
       if (m_AssetGuid.IsValid())
-        m_pWidget->setToolTip(QStringLiteral("The selected file resolved to a valid asset GUID"));
+        m_pWidget->setToolTip(QStringLiteral("Valid asset selected.\n\nCTRL+LMB or MMB to open the asset document.\nSHIFT+LMB to select a different asset."));
       else
-        m_pWidget->setToolTip(QStringLiteral("The selected file is not a valid asset"));
+        m_pWidget->setToolTip(QStringLiteral("The selected file is not a valid asset."));
     }
 
     m_pWidget->setPlaceholderText(QString());

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/QtAssetLineEdit.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/QtAssetLineEdit.cpp
@@ -126,3 +126,21 @@ void ezQtAssetLineEdit::paintEvent(QPaintEvent* e)
     p.drawText(r, ezMakeQString(sFinalText), opt);
   }
 }
+
+void ezQtAssetLineEdit::mousePressEvent(QMouseEvent* e)
+{
+  QLineEdit::mousePressEvent(e);
+
+  if ((e->button() == Qt::MouseButton::LeftButton && e->modifiers().testFlag(Qt::ControlModifier)) ||
+      (e->button() == Qt::MouseButton::MiddleButton))
+  {
+    Q_EMIT OpenAsset();
+    return;
+  }
+
+  if ((e->button() == Qt::MouseButton::LeftButton && e->modifiers().testFlag(Qt::ShiftModifier)))
+  {
+    Q_EMIT SelectAsset();
+    return;
+  }
+}

--- a/Code/Editor/EditorFramework/PropertyGrid/QtAssetLineEdit.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/QtAssetLineEdit.moc.h
@@ -12,12 +12,17 @@ class EZ_EDITORFRAMEWORK_DLL ezQtAssetLineEdit : public QLineEdit
 {
   Q_OBJECT
 
+Q_SIGNALS:
+  void OpenAsset();
+  void SelectAsset();
+
 public:
   explicit ezQtAssetLineEdit(QWidget* pParent = nullptr);
   virtual void dragMoveEvent(QDragMoveEvent* e) override;
   virtual void dragEnterEvent(QDragEnterEvent* e) override;
   virtual void dropEvent(QDropEvent* e) override;
   virtual void paintEvent(QPaintEvent* e) override;
+  virtual void mousePressEvent(QMouseEvent* e) override;
 
   ezQtAssetPropertyWidget* m_pOwner = nullptr;
 };


### PR DESCRIPTION
CTRL+LMB or MMB on an asset property now opens the asset document. SHIFT+LMB on an asset property immediately opens the asset selection dialog.

https://github.com/user-attachments/assets/4f5f39b5-feef-4b8e-a02e-6e5a717f7aac

