### PR TITLE
Visual script fix

### DIFF
--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptCompiler.cpp
@@ -1772,7 +1772,7 @@ ezResult ezVisualScriptCompiler::TraverseAllConnections(AstNode* pEntryAstNode, 
 ezResult ezVisualScriptCompiler::FinalizeConstantData()
 {
   m_Module.m_ConstantDataDesc.CalculatePerTypeStartOffsets();
-  m_Module.m_ConstantDataStorage.AllocateStorage();
+  m_Module.m_ConstantDataStorage.AllocateStorage(ezFoundation::GetDefaultAllocator());
 
   for (auto& it : m_ConstantDataToIndex)
   {

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
@@ -42,7 +42,7 @@ EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezProcVolumeComponent, 1)
 EZ_END_COMPONENT_TYPE
 // clang-format on
 
-ezEvent<const ezProcGenInternal::InvalidatedArea&> ezProcVolumeComponent::s_AreaInvalidatedEvent;
+ezProcVolumeComponent::AreaInvalidatedEvent ezProcVolumeComponent::s_AreaInvalidatedEvent;
 
 ezProcVolumeComponent::ezProcVolumeComponent() = default;
 ezProcVolumeComponent::~ezProcVolumeComponent() = default;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeComponent.h
@@ -35,7 +35,8 @@ public:
 
   void OnTransformChanged(ezMsgTransformChanged& ref_msg);
 
-  static const ezEvent<const ezProcGenInternal::InvalidatedArea&>& GetAreaInvalidatedEvent() { return s_AreaInvalidatedEvent; }
+  using AreaInvalidatedEvent = ezEvent<const ezProcGenInternal::InvalidatedArea&, ezMutex>;
+  static const AreaInvalidatedEvent& GetAreaInvalidatedEvent() { return s_AreaInvalidatedEvent; }
 
 protected:
   float m_fValue = 1.0f;
@@ -45,7 +46,7 @@ protected:
   void InvalidateArea();
   void InvalidateArea(const ezBoundingBox& area);
 
-  static ezEvent<const ezProcGenInternal::InvalidatedArea&> s_AreaInvalidatedEvent;
+  static AreaInvalidatedEvent s_AreaInvalidatedEvent;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EnginePlugins/VisualScriptPlugin/Resources/VisualScriptClassResource.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Resources/VisualScriptClassResource.cpp
@@ -108,7 +108,7 @@ ezResourceLoadDesc ezVisualScriptClassResource::UpdateContent(ezStreamReader* pS
         }
 
         ezSharedPtr<ezVisualScriptDataStorage> pConstantDataStorage = EZ_SCRIPT_NEW(ezVisualScriptDataStorage, pConstantDataDesc);
-        if (pConstantDataStorage->Deserialize(chunk).Succeeded())
+        if (pConstantDataStorage->Deserialize(chunk, ezScriptAllocator::GetAllocator()).Succeeded())
         {
           m_pConstantDataStorage = pConstantDataStorage;
         }

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.cpp
@@ -305,9 +305,12 @@ ezScriptMessageDesc ezVisualScriptGraphDescription::GetMessageDesc() const
 
 ezCVarInt cvar_MaxNodeExecutions("VisualScript.MaxNodeExecutions", 100000, ezCVarFlags::Default, "The maximum number of nodes executed within a script invocation");
 
-ezVisualScriptExecutionContext::ezVisualScriptExecutionContext(const ezSharedPtr<const ezVisualScriptGraphDescription>& pDesc)
+ezVisualScriptExecutionContext::ezVisualScriptExecutionContext(const ezSharedPtr<const ezVisualScriptGraphDescription>& pDesc, ezAllocator* pAllocator)
   : m_pDesc(pDesc)
+  , m_LocalDataStorage(pDesc->GetLocalDataDesc())
 {
+  m_LocalDataStorage.AllocateStorage(pAllocator);
+  m_DataStorage[DataOffset::Source::Local] = &m_LocalDataStorage;
 }
 
 ezVisualScriptExecutionContext::~ezVisualScriptExecutionContext()
@@ -315,11 +318,10 @@ ezVisualScriptExecutionContext::~ezVisualScriptExecutionContext()
   Deinitialize();
 }
 
-void ezVisualScriptExecutionContext::Initialize(ezVisualScriptInstance& inout_instance, ezVisualScriptDataStorage& inout_localDataStorage, ezArrayPtr<ezVariant> arguments)
+void ezVisualScriptExecutionContext::Initialize(ezVisualScriptInstance& inout_instance, ezArrayPtr<ezVariant> arguments)
 {
   m_pInstance = &inout_instance;
 
-  m_DataStorage[DataOffset::Source::Local] = &inout_localDataStorage;
   m_DataStorage[DataOffset::Source::Instance] = inout_instance.GetInstanceDataStorage();
   m_DataStorage[DataOffset::Source::Constant] = inout_instance.GetConstantDataStorage();
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScript.h
@@ -240,10 +240,10 @@ private:
 class EZ_VISUALSCRIPTPLUGIN_DLL ezVisualScriptExecutionContext
 {
 public:
-  ezVisualScriptExecutionContext(const ezSharedPtr<const ezVisualScriptGraphDescription>& pDesc);
+  ezVisualScriptExecutionContext(const ezSharedPtr<const ezVisualScriptGraphDescription>& pDesc, ezAllocator* pAllocator);
   ~ezVisualScriptExecutionContext();
 
-  void Initialize(ezVisualScriptInstance& inout_instance, ezVisualScriptDataStorage& inout_localDataStorage, ezArrayPtr<ezVariant> arguments);
+  void Initialize(ezVisualScriptInstance& inout_instance, ezArrayPtr<ezVariant> arguments);
   void Deinitialize();
 
   using ExecResult = ezVisualScriptGraphDescription::ExecResult;
@@ -282,6 +282,7 @@ private:
   ezUInt32 m_uiExecutionCounter = 0;
   ezTime m_DeltaTimeSinceLastExecution;
 
+  ezVisualScriptDataStorage m_LocalDataStorage;
   ezVisualScriptDataStorage* m_DataStorage[DataOffset::Source::Count] = {};
 
   ezScriptCoroutine* m_pCurrentCoroutine = nullptr;

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.cpp
@@ -4,8 +4,7 @@
 #include <VisualScriptPlugin/Runtime/VisualScriptInstance.h>
 
 ezVisualScriptCoroutine::ezVisualScriptCoroutine(const ezSharedPtr<const ezVisualScriptGraphDescription>& pDesc)
-  : m_LocalDataStorage(pDesc->GetLocalDataDesc())
-  , m_Context(pDesc)
+  : m_Context(pDesc, ezScriptAllocator::GetAllocator())
 {
 }
 
@@ -13,10 +12,8 @@ ezVisualScriptCoroutine::~ezVisualScriptCoroutine() = default;
 
 void ezVisualScriptCoroutine::StartWithVarargs(ezArrayPtr<ezVariant> arguments)
 {
-  m_LocalDataStorage.AllocateStorage();
-
   auto pVisualScriptInstance = static_cast<ezVisualScriptInstance*>(GetScriptInstance());
-  m_Context.Initialize(*pVisualScriptInstance, m_LocalDataStorage, arguments);
+  m_Context.Initialize(*pVisualScriptInstance, arguments);
 }
 
 void ezVisualScriptCoroutine::Stop()

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptCoroutine.h
@@ -14,7 +14,6 @@ public:
   virtual Result Update(ezTime deltaTimeSinceLastUpdate) override;
 
 private:
-  ezVisualScriptDataStorage m_LocalDataStorage;
   ezVisualScriptExecutionContext m_Context;
 };
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptData.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptData.h
@@ -96,11 +96,11 @@ public:
   const ezVisualScriptDataDescription& GetDesc() const;
 
   bool IsAllocated() const;
-  void AllocateStorage();
+  void AllocateStorage(ezAllocator* pAllocator);
   void DeallocateStorage();
 
   ezResult Serialize(ezStreamWriter& inout_stream) const;
-  ezResult Deserialize(ezStreamReader& inout_stream);
+  ezResult Deserialize(ezStreamReader& inout_stream, ezAllocator* pAllocator);
 
   using DataOffset = ezVisualScriptDataDescription::DataOffset;
 
@@ -123,7 +123,8 @@ public:
 
 private:
   ezSharedPtr<const ezVisualScriptDataDescription> m_pDesc;
-  ezBlob m_Storage;
+  ezByteArrayPtr m_Storage;
+  ezAllocator* m_pAllocator = nullptr;
 };
 
 struct ezVisualScriptInstanceData

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptData_inl.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptData_inl.h
@@ -37,7 +37,7 @@ EZ_ALWAYS_INLINE const ezVisualScriptDataDescription& ezVisualScriptDataStorage:
 
 EZ_ALWAYS_INLINE bool ezVisualScriptDataStorage::IsAllocated() const
 {
-  return m_Storage.GetByteBlobPtr().IsEmpty() == false;
+  return m_Storage.IsEmpty() == false;
 }
 
 template <typename T>
@@ -47,7 +47,7 @@ const T& ezVisualScriptDataStorage::GetData(DataOffset dataOffset) const
 
   m_pDesc->CheckOffset(dataOffset, ezGetStaticRTTI<T>());
 
-  return *reinterpret_cast<const T*>(m_Storage.GetByteBlobPtr().GetPtr() + dataOffset.m_uiByteOffset);
+  return *reinterpret_cast<const T*>(m_Storage.GetPtr() + dataOffset.m_uiByteOffset);
 }
 
 template <typename T>
@@ -57,7 +57,7 @@ T& ezVisualScriptDataStorage::GetWritableData(DataOffset dataOffset)
 
   m_pDesc->CheckOffset(dataOffset, ezGetStaticRTTI<T>());
 
-  return *reinterpret_cast<T*>(m_Storage.GetByteBlobPtr().GetPtr() + dataOffset.m_uiByteOffset);
+  return *reinterpret_cast<T*>(m_Storage.GetPtr() + dataOffset.m_uiByteOffset);
 }
 
 template <typename T>
@@ -65,11 +65,11 @@ void ezVisualScriptDataStorage::SetData(DataOffset dataOffset, const T& value)
 {
   static_assert(!std::is_pointer<T>::value, "Use SetPointerData instead");
 
-  if (dataOffset.m_uiByteOffset < m_Storage.GetByteBlobPtr().GetCount())
+  if (dataOffset.m_uiByteOffset < m_Storage.GetCount())
   {
     m_pDesc->CheckOffset(dataOffset, ezGetStaticRTTI<T>());
 
-    auto pData = m_Storage.GetByteBlobPtr().GetPtr() + dataOffset.m_uiByteOffset;
+    auto pData = m_Storage.GetPtr() + dataOffset.m_uiByteOffset;
 
     if constexpr (std::is_same<T, ezGameObjectHandle>::value)
     {
@@ -97,9 +97,9 @@ void ezVisualScriptDataStorage::SetPointerData(DataOffset dataOffset, T ptr, con
 {
   static_assert(std::is_pointer<T>::value);
 
-  if (dataOffset.m_uiByteOffset < m_Storage.GetByteBlobPtr().GetCount())
+  if (dataOffset.m_uiByteOffset < m_Storage.GetCount())
   {
-    auto pData = m_Storage.GetByteBlobPtr().GetPtr() + dataOffset.m_uiByteOffset;
+    auto pData = m_Storage.GetPtr() + dataOffset.m_uiByteOffset;
 
     if constexpr (std::is_same<T, ezGameObject*>::value)
     {

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptFunctionProperty.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptFunctionProperty.h
@@ -19,7 +19,6 @@ public:
 
 private:
   ezSharedPtr<const ezVisualScriptGraphDescription> m_pDesc;
-  mutable ezVisualScriptDataStorage m_LocalDataStorage;
 };
 
 class EZ_VISUALSCRIPTPLUGIN_DLL ezVisualScriptMessageHandler : public ezScriptMessageHandler
@@ -32,5 +31,4 @@ public:
 
 private:
   ezSharedPtr<const ezVisualScriptGraphDescription> m_pDesc;
-  mutable ezVisualScriptDataStorage m_LocalDataStorage;
 };

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptInstance.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptInstance.cpp
@@ -6,16 +6,16 @@ ezVisualScriptInstance::ezVisualScriptInstance(ezReflectedClass& inout_owner, ez
   : ezScriptInstance(inout_owner, pWorld)
   , m_pConstantDataStorage(pConstantDataStorage)
   , m_pInstanceDataMapping(pInstanceDataMapping)
+  , m_InstanceDataStorage(pInstanceDataDesc)
 {
   if (pInstanceDataDesc != nullptr)
   {
-    m_pInstanceDataStorage = EZ_SCRIPT_NEW(ezVisualScriptDataStorage, pInstanceDataDesc);
-    m_pInstanceDataStorage->AllocateStorage();
+    m_InstanceDataStorage.AllocateStorage(ezScriptAllocator::GetAllocator());
 
     for (auto& it : m_pInstanceDataMapping->m_Content)
     {
       auto& instanceData = it.Value();
-      m_pInstanceDataStorage->SetDataFromVariant(instanceData.m_DataOffset, instanceData.m_DefaultValue, 0);
+      m_InstanceDataStorage.SetDataFromVariant(instanceData.m_DataOffset, instanceData.m_DefaultValue, 0);
     }
   }
 }
@@ -39,7 +39,7 @@ void ezVisualScriptInstance::SetInstanceVariable(const ezHashedString& sName, co
     return;
   }
 
-  m_pInstanceDataStorage->SetDataFromVariant(pInstanceData->m_DataOffset, convertedValue, 0);
+  m_InstanceDataStorage.SetDataFromVariant(pInstanceData->m_DataOffset, convertedValue, 0);
 }
 
 ezVariant ezVisualScriptInstance::GetInstanceVariable(const ezHashedString& sName)
@@ -51,5 +51,5 @@ ezVariant ezVisualScriptInstance::GetInstanceVariable(const ezHashedString& sNam
   if (m_pInstanceDataMapping->m_Content.TryGetValue(sName, pInstanceData) == false)
     return ezVariant();
 
-  return m_pInstanceDataStorage->GetDataAsVariant(pInstanceData->m_DataOffset, nullptr, 0);
+  return m_InstanceDataStorage.GetDataAsVariant(pInstanceData->m_DataOffset, nullptr, 0);
 }

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptInstance.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptInstance.h
@@ -13,10 +13,11 @@ public:
   virtual ezVariant GetInstanceVariable(const ezHashedString& sName) override;
 
   ezVisualScriptDataStorage* GetConstantDataStorage() { return m_pConstantDataStorage.Borrow(); }
-  ezVisualScriptDataStorage* GetInstanceDataStorage() { return m_pInstanceDataStorage.Borrow(); }
+  ezVisualScriptDataStorage* GetInstanceDataStorage() { return &m_InstanceDataStorage; }
 
 private:
   ezSharedPtr<ezVisualScriptDataStorage> m_pConstantDataStorage;
-  ezUniquePtr<ezVisualScriptDataStorage> m_pInstanceDataStorage;
   ezSharedPtr<ezVisualScriptInstanceDataMapping> m_pInstanceDataMapping;
+
+  ezVisualScriptDataStorage m_InstanceDataStorage;
 };


### PR DESCRIPTION
* Fixed a crash in visual scripts when executing the same visual script functions in different worlds at the same time. Each world is updated in its own task and the visual script functions kept local state around which led to race conditions.
* Also made the proc gen area invalidated event thread safe since it also can be called from multiple threads at the same time.