### PR TITLE
Editor UI tweaks + ezGraphicsUtils fixes

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -281,8 +281,8 @@ void ezPickingRenderPass::ReadBackPropertiesSinglePick(ezView* pView)
   ezVec3 vPickedPosition(0);
   {
     const float fDepth = m_PickingResultsDepth[uiIndex];
-    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)(m_uiWindowHeight - y), fDepth), vPickedPosition).IgnoreResult();
-    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)(m_uiWindowHeight - y), 0), vPickingRayStartPosition).IgnoreResult();
+    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)y, fDepth), vPickedPosition).IgnoreResult();
+    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)y, 0), vPickingRayStartPosition).IgnoreResult();
 
     float fOtherDepths[4] = {fDepth, fDepth, fDepth, fDepth};
     ezVec3 vOtherPos[4];
@@ -297,10 +297,10 @@ void ezPickingRenderPass::ReadBackPropertiesSinglePick(ezView* pView)
     if (y > 0)
       fOtherDepths[3] = m_PickingResultsDepth[((y - 1) * m_uiWindowWidth) + x];
 
-    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)(x + 1), (float)(m_uiWindowHeight - y), fOtherDepths[0]), vOtherPos[0]).IgnoreResult();
-    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)(x - 1), (float)(m_uiWindowHeight - y), fOtherDepths[1]), vOtherPos[1]).IgnoreResult();
-    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)(m_uiWindowHeight - (y + 1)), fOtherDepths[2]), vOtherPos[2]).IgnoreResult();
-    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)(m_uiWindowHeight - (y - 1)), fOtherDepths[3]), vOtherPos[3]).IgnoreResult();
+    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)(x + 1), (float)y, fOtherDepths[0]), vOtherPos[0]).IgnoreResult();
+    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)(x - 1), (float)y, fOtherDepths[1]), vOtherPos[1]).IgnoreResult();
+    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)(y + 1), fOtherDepths[2]), vOtherPos[2]).IgnoreResult();
+    ezGraphicsUtils::ConvertScreenPosToWorldPos(m_mPickingInverseViewProjectionMatrix, 0, 0, m_uiWindowWidth, m_uiWindowHeight, ezVec3((float)x, (float)(y - 1), fOtherDepths[3]), vOtherPos[3]).IgnoreResult();
 
     vNormals[0].CalculateNormal(vPickedPosition, vOtherPos[0], vOtherPos[2]).IgnoreResult();
     vNormals[1].CalculateNormal(vPickedPosition, vOtherPos[2], vOtherPos[1]).IgnoreResult();

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -266,7 +266,7 @@ ezResult ezQtEngineViewWidget::PickPlane(ezUInt16 uiScreenPosX, ezUInt16 uiScree
   ezMat4 mViewProj = mProj * mView;
   ezMat4 mInvViewProj = mViewProj.GetInverse();
 
-  ezVec3 vScreenPos(uiScreenPosX, height() - uiScreenPosY, 0);
+  ezVec3 vScreenPos(uiScreenPosX, uiScreenPosY, 0);
   ezVec3 vResPos, vResRay;
 
   if (ezGraphicsUtils::ConvertScreenPosToWorldPos(mInvViewProj, 0, 0, width(), height(), vScreenPos, vResPos, &vResRay).Failed())

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -69,7 +69,7 @@ ezResult ezQtEditorApp::CreateOrOpenProject(bool bCreate, ezStringView sFile0)
   }
 
   // check that we don't attempt to open a project from a different repository, due to code changes this often doesn't work too well
-  if (!IsInHeadlessMode())
+  if (!IsInHeadlessMode() && !m_bAnyProjectOpened)
   {
     ezStringBuilder sdkDirFromProject;
     if (ezFileSystem::FindFolderWithSubPath(sdkDirFromProject, sFile, "Data/Base", "ezSdkRoot.txt").Succeeded())

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/NonUniformBoxGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/NonUniformBoxGizmo.cpp
@@ -163,7 +163,7 @@ modify:
   m_vStartNegSize = m_vNegSize;
   m_vStartPosSize = m_vPosSize;
 
-  GetPointOnAxis(e->pos().x(), m_vViewport.y - e->pos().y(), m_vInteractionPivot).IgnoreResult();
+  GetPointOnAxis(e->pos().x(), e->pos().y(), m_vInteractionPivot).IgnoreResult();
 
   ezViewHighlightMsgToEngine msg;
   msg.m_HighlightObject = m_pInteractionGizmoHandle->GetGuid();
@@ -217,7 +217,7 @@ ezEditorInput ezNonUniformBoxGizmo::DoMouseMoveEvent(QMouseEvent* e)
   {
     ezVec3 vCurrentInteractionPoint;
 
-    if (GetPointOnAxis(e->pos().x(), m_vViewport.y - e->pos().y(), vCurrentInteractionPoint).Failed())
+    if (GetPointOnAxis(e->pos().x(), e->pos().y(), vCurrentInteractionPoint).Failed())
     {
       m_vLastMousePos = UpdateMouseMode(e);
       return ezEditorInput::WasExclusivelyHandled;

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/RotateGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/RotateGizmo.cpp
@@ -110,7 +110,7 @@ ezEditorInput ezRotateGizmo::DoMousePressEvent(QMouseEvent* e)
   // compute screen space tangent for rotation
   {
     const ezVec3 vAxisWS = m_vRotationAxis.GetNormalized();
-    const ezVec3 vMousePos(e->pos().x(), m_vViewport.y - e->pos().y(), 0);
+    const ezVec3 vMousePos(e->pos().x(), e->pos().y(), 0);
     const ezVec3 vGizmoPosWS = GetTransformation().m_vPosition;
 
     ezVec3 vPosOnNearPlane, vRayDir;

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/TranslateGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/TranslateGizmo.cpp
@@ -181,11 +181,11 @@ ezEditorInput ezTranslateGizmo::DoMousePressEvent(QMouseEvent* e)
 
   if (m_Mode == TranslateMode::Axis)
   {
-    GetPointOnAxis(e->pos().x(), m_vViewport.y - e->pos().y(), m_vInteractionPivot).IgnoreResult();
+    GetPointOnAxis(e->pos().x(), e->pos().y(), m_vInteractionPivot).IgnoreResult();
   }
   else if (m_Mode == TranslateMode::Plane)
   {
-    GetPointOnPlane(e->pos().x(), m_vViewport.y - e->pos().y(), m_vInteractionPivot).IgnoreResult();
+    GetPointOnPlane(e->pos().x(), e->pos().y(), m_vInteractionPivot).IgnoreResult();
   }
 
   m_fStartScale = (m_vInteractionPivot - m_pCamera->GetPosition()).GetLength() * 0.125;
@@ -281,7 +281,7 @@ ezEditorInput ezTranslateGizmo::DoMouseMoveEvent(QMouseEvent* e)
 
     if (m_Mode == TranslateMode::Axis)
     {
-      if (GetPointOnAxis(e->pos().x(), m_vViewport.y - e->pos().y(), vCurrentInteractionPoint).Failed())
+      if (GetPointOnAxis(e->pos().x(), e->pos().y(), vCurrentInteractionPoint).Failed())
       {
         m_vLastMousePos = UpdateMouseMode(e);
         return ezEditorInput::WasExclusivelyHandled;
@@ -289,7 +289,7 @@ ezEditorInput ezTranslateGizmo::DoMouseMoveEvent(QMouseEvent* e)
     }
     else if (m_Mode == TranslateMode::Plane)
     {
-      if (GetPointOnPlane(e->pos().x(), m_vViewport.y - e->pos().y(), vCurrentInteractionPoint).Failed())
+      if (GetPointOnPlane(e->pos().x(), e->pos().y(), vCurrentInteractionPoint).Failed())
       {
         m_vLastMousePos = UpdateMouseMode(e);
         return ezEditorInput::WasExclusivelyHandled;

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
@@ -696,7 +696,7 @@ ezEditorInput ezCameraMoveContext::DoMouseMoveEvent(QMouseEvent* e)
         ezMat4 invMvp = mvp.GetInverse();
 
         vScreenPos.x -= diff.x;
-        vScreenPos.y += diff.y;
+        vScreenPos.y -= diff.y;
 
         ezVec3 vNewPoint(0);
         if (ezGraphicsUtils::ConvertScreenPosToWorldPos(invMvp, 0, 0, GetOwnerView()->width(), GetOwnerView()->height(), vScreenPos, vNewPoint).Succeeded())

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/SelectionContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/SelectionContext.cpp
@@ -202,8 +202,8 @@ void ezSelectionContext::SendMarqueeMsg(QMouseEvent* e, ezUInt8 uiWhatToDo)
 
   const ezVec3 vMousePos(e->pos().x(), e->pos().y(), 0.01f);
 
-  const ezVec3 vScreenSpacePos0(vMousePos.x, m_vViewport.y - vMousePos.y, vMousePos.z);
-  const ezVec3 vScreenSpacePos1(m_vMarqueeStartPos.x, m_vViewport.y - m_vMarqueeStartPos.y, m_vMarqueeStartPos.z);
+  const ezVec3 vScreenSpacePos0(vMousePos.x, vMousePos.y, vMousePos.z);
+  const ezVec3 vScreenSpacePos1(m_vMarqueeStartPos.x, m_vMarqueeStartPos.y, m_vMarqueeStartPos.z);
 
   ezVec3 vPosOnNearPlane0, vRayDir0;
   ezVec3 vPosOnNearPlane1, vRayDir1;

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/RttiTypeStringPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/RttiTypeStringPropertyWidget.cpp
@@ -40,6 +40,13 @@ void ezQtRttiTypeStringPropertyWidget::InternalSetValue(const ezVariant& value)
 
   const ezRTTI* pRtti = ezRTTI::FindTypeByName(sTypeName);
 
+  if (pRtti == nullptr)
+  {
+    m_pButton->setText("Select Type");
+    m_pButton->setIcon(QIcon());
+    return;
+  }
+
   const ezCategoryAttribute* pCatA = pRtti->GetAttributeByType<ezCategoryAttribute>();
   const ezColorAttribute* pColA = pRtti->GetAttributeByType<ezColorAttribute>();
 

--- a/Code/Engine/Foundation/Utilities/GraphicsUtils.h
+++ b/Code/Engine/Foundation/Utilities/GraphicsUtils.h
@@ -21,6 +21,10 @@ namespace ezGraphicsUtils
     const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vPoint, ezVec3& out_vScreenPos,
     ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
 
+  /// \brief Overload of ConvertWorldPosToScreenPos() that returns the screen position in normalized space ([0; 1] range) and therefore doesn't require the viewport dimensions.
+  EZ_FOUNDATION_DLL ezResult ConvertWorldPosToScreenPos(const ezMat4& mModelViewProjection, const ezVec3& vPoint, ezVec3& out_vScreenPosNormalized,
+    ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
+
   /// \brief Takes the screen space position (including depth in [0;1] range) and converts it into a world space position.
   ///
   /// \param InverseModelViewProjection
@@ -36,27 +40,35 @@ namespace ezGraphicsUtils
   /// but for orthographic cameras it is not (it's simply the forward vector of the camera).
   /// This function handles both cases properly.
   ///
-  /// The z value of vScreenPos is always expected to be in [0; 1] range (meaning 0 is at the near plane, 1 at the far plane),
+  /// The z value of vScreenPixelPos is always expected to be in [0; 1] range (meaning 0 is at the near plane, 1 at the far plane),
   /// even on platforms that use [-1; +1] range for clip-space z values. The DepthRange parameter needs to be correct to handle this case
   /// properly.
+  ///
+  /// vScreenPixelPos is expected to be in range [viewport x/y; viewport width/height]. There is an overload below that takes just a normalized value
+  /// in range [0; 1].
   EZ_FOUNDATION_DLL ezResult ConvertScreenPosToWorldPos(const ezMat4& mInverseModelViewProjection, const ezUInt32 uiViewportX,
-    const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPos, ezVec3& out_vPoint,
-    ezVec3* out_pDirection = nullptr,
-    ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
+    const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPixelPos, ezVec3& out_vPoint,
+    ezVec3* out_pDirection = nullptr, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
+
+  /// \brief Overload of ConvertScreenPosToWorldPos() that takes the coordinate in normalized space ([0; 1]) and therefore doesn't require the viewport dimensions.
+  EZ_FOUNDATION_DLL ezResult ConvertScreenPosToWorldPos(const ezMat4& mInverseModelViewProjection, const ezVec3& vNormalizedScreenPos, ezVec3& out_vPoint,
+    ezVec3* out_pDirection = nullptr, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
 
   /// \brief A double-precision version of ConvertScreenPosToWorldPos()
   EZ_FOUNDATION_DLL ezResult ConvertScreenPosToWorldPos(const ezMat4d& mInverseModelViewProjection, const ezUInt32 uiViewportX,
-    const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPos, ezVec3& out_vPoint,
-    ezVec3* out_pDirection = nullptr,
-    ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
+    const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPixelPos, ezVec3& out_vPoint,
+    ezVec3* out_pDirection = nullptr, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
+
+  /// \brief Double-precision overload of ConvertScreenPosToWorldPos() that takes the coordinate in normalized space ([0; 1]) and therefore doesn't require the viewport dimensions.
+  EZ_FOUNDATION_DLL ezResult ConvertScreenPosToWorldPos(const ezMat4d& mInverseModelViewProjection, const ezVec3& vNormalizedScreenPos,
+    ezVec3& out_vPoint, ezVec3* out_pDirection = nullptr, ezClipSpaceDepthRange::Enum depthRange = ezClipSpaceDepthRange::Default); // [tested]
 
   /// \brief Checks whether the given transformation matrix would change the winding order of a triangle's vertices and thus requires that
   /// the vertex order gets reversed to compensate.
   EZ_FOUNDATION_DLL bool IsTriangleFlipRequired(const ezMat3& mTransformation);
 
   /// \brief Converts a projection or view-projection matrix from one depth-range convention to another
-  EZ_FOUNDATION_DLL void ConvertProjectionMatrixDepthRange(
-    ezMat4& inout_mMatrix, ezClipSpaceDepthRange::Enum srcDepthRange, ezClipSpaceDepthRange::Enum dstDepthRange); // [tested]
+  EZ_FOUNDATION_DLL void ConvertProjectionMatrixDepthRange(ezMat4& inout_mMatrix, ezClipSpaceDepthRange::Enum srcDepthRange, ezClipSpaceDepthRange::Enum dstDepthRange); // [tested]
 
   /// \brief Retrieves the horizontal and vertical field-of-view angles from the perspective matrix.
   ///

--- a/Code/Engine/Foundation/Utilities/GraphicsUtils.h
+++ b/Code/Engine/Foundation/Utilities/GraphicsUtils.h
@@ -4,6 +4,12 @@
 
 namespace ezGraphicsUtils
 {
+  /// \brief Converts a screen-space position from pixel coordinates to normalized coordinates.
+  EZ_FOUNDATION_DLL void ConvertScreenPixelPosToNormalizedPos(const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, ezVec3& inout_vPixelPos);
+
+  /// \brief Converts a screen-space position from normalized coordinates to pixel coordinates.
+  EZ_FOUNDATION_DLL void ConvertScreenNormalizedPosToPixelPos(const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, ezVec3& inout_vNormalizedPos);
+
   /// \brief Projects the given point from 3D world space into screen space, if possible.
   ///
   /// \param ModelViewProjection

--- a/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
@@ -4,6 +4,16 @@
 
 ezResult ezGraphicsUtils::ConvertWorldPosToScreenPos(const ezMat4& mModelViewProjection, const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vPoint, ezVec3& out_vScreenPos, ezClipSpaceDepthRange::Enum depthRange)
 {
+  EZ_SUCCEED_OR_RETURN(ConvertWorldPosToScreenPos(mModelViewProjection, vPoint, out_vScreenPos, depthRange));
+
+  out_vScreenPos.x = uiViewportX + uiViewportWidth * out_vScreenPos.x;
+  out_vScreenPos.y = uiViewportY + uiViewportHeight * out_vScreenPos.y;
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGraphicsUtils::ConvertWorldPosToScreenPos(const ezMat4& mModelViewProjection, const ezVec3& vPoint, ezVec3& out_vScreenPosNormalized, ezClipSpaceDepthRange::Enum depthRange /*= ezClipSpaceDepthRange::Default*/)
+{
   const ezVec4 vToProject = vPoint.GetAsVec4(1.0f);
 
   ezVec4 vClipSpace = mModelViewProjection * vToProject;
@@ -15,27 +25,34 @@ ezResult ezGraphicsUtils::ConvertWorldPosToScreenPos(const ezMat4& mModelViewPro
   if (vClipSpace.w < 0.0f)
     vProjected.z = -vProjected.z;
 
-  out_vScreenPos.x = uiViewportX + uiViewportWidth * ((vProjected.x * 0.5f) + 0.5f);
-  out_vScreenPos.y = uiViewportY + uiViewportHeight * ((vProjected.y * 0.5f) + 0.5f);
+  // move into [0; 1] range
+  out_vScreenPosNormalized.x = (vProjected.x * 0.5f) + 0.5f;
+  out_vScreenPosNormalized.y = (vProjected.y * 0.5f) + 0.5f;
 
   // normalize the output z value to always be in [0; 1] range
   // That means when the projection matrix spits out values between -1 and +1, rescale those values
   if (depthRange == ezClipSpaceDepthRange::MinusOneToOne)
-    out_vScreenPos.z = vProjected.z * 0.5f + 0.5f;
+    out_vScreenPosNormalized.z = vProjected.z * 0.5f + 0.5f;
   else
-    out_vScreenPos.z = vProjected.z;
+    out_vScreenPosNormalized.z = vProjected.z;
 
   return EZ_SUCCESS;
 }
 
-ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(
-  const ezMat4& mInverseModelViewProjection, const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPos, ezVec3& out_vPoint, ezVec3* out_pDirection, ezClipSpaceDepthRange::Enum depthRange)
+ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4& mInverseModelViewProjection, const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPixelPos, ezVec3& out_vPoint, ezVec3* out_pDirection, ezClipSpaceDepthRange::Enum depthRange)
 {
-  ezVec3 vClipSpace = vScreenPos;
+  ezVec3 vNormalizedScreenPos = vScreenPixelPos;
 
   // From window coordinates to [0; 1] range
-  vClipSpace.x = (vClipSpace.x - uiViewportX) / uiViewportWidth;
-  vClipSpace.y = (vClipSpace.y - uiViewportY) / uiViewportHeight;
+  vNormalizedScreenPos.x = (vNormalizedScreenPos.x - uiViewportX) / uiViewportWidth;
+  vNormalizedScreenPos.y = (vNormalizedScreenPos.y - uiViewportY) / uiViewportHeight;
+
+  return ezGraphicsUtils::ConvertScreenPosToWorldPos(mInverseModelViewProjection, vNormalizedScreenPos, out_vPoint, out_pDirection, depthRange);
+}
+
+ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4& mInverseModelViewProjection, const ezVec3& vNormalizedScreenPos, ezVec3& out_vPoint, ezVec3* out_pDirection /*= nullptr*/, ezClipSpaceDepthRange::Enum depthRange /*= ezClipSpaceDepthRange::Default*/)
+{
+  ezVec3 vClipSpace = vNormalizedScreenPos;
 
   // Map to range [-1; 1]
   vClipSpace.x = vClipSpace.x * 2.0f - 1.0f;
@@ -70,14 +87,22 @@ ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(
   return EZ_SUCCESS;
 }
 
-ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4d& mInverseModelViewProjection, const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPos, ezVec3& out_vPoint, ezVec3* out_pDirection /*= nullptr*/,
+
+ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4d& mInverseModelViewProjection, const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vScreenPixelPos, ezVec3& out_vPoint, ezVec3* out_pDirection /*= nullptr*/,
   ezClipSpaceDepthRange::Enum depthRange /*= ezClipSpaceDepthRange::Default*/)
 {
-  ezVec3 vClipSpace = vScreenPos;
+  ezVec3 vNormalizedScreenPos = vScreenPixelPos;
 
   // From window coordinates to [0; 1] range
-  vClipSpace.x = (vClipSpace.x - uiViewportX) / uiViewportWidth;
-  vClipSpace.y = (vClipSpace.y - uiViewportY) / uiViewportHeight;
+  vNormalizedScreenPos.x = (vNormalizedScreenPos.x - uiViewportX) / uiViewportWidth;
+  vNormalizedScreenPos.y = (vNormalizedScreenPos.y - uiViewportY) / uiViewportHeight;
+
+  return ezGraphicsUtils::ConvertScreenPosToWorldPos(mInverseModelViewProjection, vNormalizedScreenPos, out_vPoint, out_pDirection, depthRange);
+}
+
+ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4d& mInverseModelViewProjection, const ezVec3& vNormalizedScreenPos, ezVec3& out_vPoint, ezVec3* out_pDirection /*= nullptr*/, ezClipSpaceDepthRange::Enum depthRange /*= ezClipSpaceDepthRange::Default*/)
+{
+  ezVec3 vClipSpace = vNormalizedScreenPos;
 
   // Map to range [-1; 1]
   vClipSpace.x = vClipSpace.x * 2.0f - 1.0f;

--- a/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
@@ -2,6 +2,18 @@
 
 #include <Foundation/Utilities/GraphicsUtils.h>
 
+void ezGraphicsUtils::ConvertScreenPixelPosToNormalizedPos(const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, ezVec3& inout_vPixelPos)
+{
+  inout_vPixelPos.x = (inout_vPixelPos.x - uiViewportX) / uiViewportWidth;
+  inout_vPixelPos.y = (inout_vPixelPos.y - uiViewportY) / uiViewportHeight;
+}
+
+void ezGraphicsUtils::ConvertScreenNormalizedPosToPixelPos(const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, ezVec3& inout_vNormalizedPos)
+{
+  inout_vNormalizedPos.x = uiViewportX + uiViewportWidth * inout_vNormalizedPos.x;
+  inout_vNormalizedPos.y = uiViewportY + uiViewportHeight * inout_vNormalizedPos.y;
+}
+
 ezResult ezGraphicsUtils::ConvertWorldPosToScreenPos(const ezMat4& mModelViewProjection, const ezUInt32 uiViewportX, const ezUInt32 uiViewportY, const ezUInt32 uiViewportWidth, const ezUInt32 uiViewportHeight, const ezVec3& vPoint, ezVec3& out_vScreenPos, ezClipSpaceDepthRange::Enum depthRange)
 {
   EZ_SUCCEED_OR_RETURN(ConvertWorldPosToScreenPos(mModelViewProjection, vPoint, out_vScreenPos, depthRange));

--- a/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/GraphicsUtils.cpp
@@ -27,7 +27,7 @@ ezResult ezGraphicsUtils::ConvertWorldPosToScreenPos(const ezMat4& mModelViewPro
 
   // move into [0; 1] range
   out_vScreenPosNormalized.x = (vProjected.x * 0.5f) + 0.5f;
-  out_vScreenPosNormalized.y = (vProjected.y * 0.5f) + 0.5f;
+  out_vScreenPosNormalized.y = (1.0f - ((vProjected.y * 0.5f) + 0.5f));
 
   // normalize the output z value to always be in [0; 1] range
   // That means when the projection matrix spits out values between -1 and +1, rescale those values
@@ -56,7 +56,7 @@ ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4& mInverseModel
 
   // Map to range [-1; 1]
   vClipSpace.x = vClipSpace.x * 2.0f - 1.0f;
-  vClipSpace.y = vClipSpace.y * 2.0f - 1.0f;
+  vClipSpace.y = -(vClipSpace.y * 2.0f - 1.0f);
 
   // The OpenGL matrix expects the z values to be between -1 and +1, so rescale the incoming value to that range
   if (depthRange == ezClipSpaceDepthRange::MinusOneToOne)
@@ -106,7 +106,7 @@ ezResult ezGraphicsUtils::ConvertScreenPosToWorldPos(const ezMat4d& mInverseMode
 
   // Map to range [-1; 1]
   vClipSpace.x = vClipSpace.x * 2.0f - 1.0f;
-  vClipSpace.y = vClipSpace.y * 2.0f - 1.0f;
+  vClipSpace.y = -(vClipSpace.y * 2.0f - 1.0f);
 
   // The OpenGL matrix expects the z values to be between -1 and +1, so rescale the incoming value to that range
   if (depthRange == ezClipSpaceDepthRange::MinusOneToOne)

--- a/Code/Engine/GameEngine/GameState/GameState.h
+++ b/Code/Engine/GameEngine/GameState/GameState.h
@@ -50,6 +50,9 @@ protected:
 public:
   virtual ~ezGameState();
 
+  /// \brief Returns the active ezGameState. Only one ezGameState is allowed to exist.
+  static ezGameState* GetActiveGameState();
+
   /// \brief Returns the ezWorld that is currently the active one.
   ezWorld* GetMainWorld() { return m_pMainWorld; }
 
@@ -209,6 +212,8 @@ protected:
 
   /// \brief Called by `CancelBackgroundSceneLoading()` when scene loading gets canceled.
   virtual void OnBackgroundSceneLoadingCanceled();
+
+  static ezGameState* s_pActiveGameState;
 
   ezViewHandle m_hMainView;
 

--- a/Code/Engine/GameEngine/GameState/GameState.h
+++ b/Code/Engine/GameEngine/GameState/GameState.h
@@ -50,8 +50,14 @@ protected:
 public:
   virtual ~ezGameState();
 
+  /// \brief Returns the ezWorld that is currently the active one.
+  ezWorld* GetMainWorld() { return m_pMainWorld; }
+
   /// \brief Gives access to the game state's main camera object.
   ezCamera* GetMainCamera() { return &m_MainCamera; }
+
+  /// \brief Returns the ezView that is currently the one used for rendering the main output.
+  ezView* GetMainView();
 
   /// \brief Whether a scene is currently being loaded.
   bool IsLoadingSceneInBackground(float* out_pProgress = nullptr) const;

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -116,6 +116,17 @@ void ezGameState::ProcessInput()
   UpdateBackgroundSceneLoading();
 }
 
+ezView* ezGameState::GetMainView()
+{
+  ezView* pView = nullptr;
+  if (ezRenderWorld::TryGetView(m_hMainView, pView))
+  {
+    return pView;
+  }
+
+  return nullptr;
+}
+
 bool ezGameState::IsLoadingSceneInBackground(float* out_pProgress) const
 {
   if (out_pProgress)

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -37,6 +37,8 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 EZ_STATICLINK_FILE(GameEngine, GameEngine_GameState_Implementation_GameState);
 // clang-format on
 
+ezGameState* ezGameState::s_pActiveGameState = nullptr;
+
 ezGameState::ezGameState()
 {
   // initialize camera to default values
@@ -46,8 +48,15 @@ ezGameState::ezGameState()
 
 ezGameState::~ezGameState() = default;
 
+ezGameState* ezGameState::GetActiveGameState()
+{
+  return s_pActiveGameState;
+}
+
 void ezGameState::OnActivation(ezWorld* pWorld, ezStringView sStartPosition, const ezTransform& startPositionOffset)
 {
+  s_pActiveGameState = this;
+
   CreateActors();
   ConfigureInputActions();
 
@@ -90,6 +99,8 @@ void ezGameState::OnDeactivation()
   }
 
   ezRenderWorld::DeleteView(m_hMainView);
+
+  s_pActiveGameState = nullptr;
 }
 
 void ezGameState::AddMainViewsToRender()

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -1678,6 +1678,8 @@ void ezDebugRenderer::RenderInternalWorldSpace(const ezDebugRendererContext& con
       ezVec3 screenPos;
       if (renderViewContext.m_pViewData->ComputeScreenSpacePos(textLine.m_position, screenPos).Succeeded() && screenPos.z > 0.0f)
       {
+        renderViewContext.m_pViewData->ConvertScreenNormalizedPosToPixelPos(screenPos);
+
         textLine.m_topLeftCorner.x += ezMath::Round(screenPos.x);
         textLine.m_topLeftCorner.y += ezMath::Round(screenPos.y);
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/InstanceDataProvider.cpp
@@ -91,14 +91,9 @@ void ezInstanceData::Reset()
 //////////////////////////////////////////////////////////////////////////
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezInstanceDataProvider, 1, ezRTTIDefaultAllocator<ezInstanceDataProvider>)
-  {
-  }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-ezInstanceDataProvider::ezInstanceDataProvider()
-{
-}
-
+ezInstanceDataProvider::ezInstanceDataProvider() = default;
 ezInstanceDataProvider::~ezInstanceDataProvider() = default;
 
 void* ezInstanceDataProvider::UpdateData(const ezRenderViewContext& renderViewContext, const ezExtractedRenderData& extractedData)
@@ -107,7 +102,6 @@ void* ezInstanceDataProvider::UpdateData(const ezRenderViewContext& renderViewCo
 
   return &m_Data;
 }
-
 
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Pipeline_Implementation_InstanceDataProvider);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/View_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/View_inl.h
@@ -107,6 +107,22 @@ EZ_FORCE_INLINE ezResult ezView::ComputeScreenSpacePos(const ezVec3& vPoint, ezV
   return m_Data.ComputeScreenSpacePos(vPoint, out_vScreenPos);
 }
 
+EZ_FORCE_INLINE ezResult ezView::ComputeWorldSpacePos(float fNormalizedScreenPosX, float fNormalizedScreenPosY, ezVec3& out_vWorldPos) const
+{
+  UpdateCachedMatrices();
+  return m_Data.ComputeWorldSpacePos(fNormalizedScreenPosX, fNormalizedScreenPosY, out_vWorldPos);
+}
+
+EZ_FORCE_INLINE void ezView::ConvertScreenPixelPosToNormalizedPos(ezVec3& inout_vPixelPos)
+{
+  m_Data.ConvertScreenPixelPosToNormalizedPos(inout_vPixelPos);
+}
+
+EZ_FORCE_INLINE void ezView::ConvertScreenNormalizedPosToPixelPos(ezVec3& inout_vNormalizedPos)
+{
+  m_Data.ConvertScreenNormalizedPosToPixelPos(inout_vNormalizedPos);
+}
+
 EZ_ALWAYS_INLINE const ezMat4& ezView::GetProjectionMatrix(ezCameraEye eye) const
 {
   UpdateCachedMatrices();

--- a/Code/Engine/RendererCore/Pipeline/View.h
+++ b/Code/Engine/RendererCore/Pipeline/View.h
@@ -89,13 +89,26 @@ public:
   const ezSharedPtr<ezTask>& GetExtractTask();
 
 
-  /// \brief Returns the start position and direction (in world space) of the picking ray through the screen position in this view.
+  /// \brief Calculates the start position and direction (in world space) of the picking ray through the screen position in this view.
   ///
-  /// fScreenPosX and fScreenPosY are expected to be in [0; 1] range (normalized pixel coordinates).
+  /// fNormalizedScreenPosX and fNormalizedScreenPosY are expected to be in [0; 1] range (normalized screen coordinates).
   /// If no ray can be computed, EZ_FAILURE is returned.
-  ezResult ComputePickingRay(float fScreenPosX, float fScreenPosY, ezVec3& out_vRayStartPos, ezVec3& out_vRayDir) const;
+  ezResult ComputePickingRay(float fNormalizedScreenPosX, float fNormalizedScreenPosY, ezVec3& out_vRayStartPos, ezVec3& out_vRayDir) const;
 
-  ezResult ComputeScreenSpacePos(const ezVec3& vPoint, ezVec3& out_vScreenPos) const;
+  /// \brief Calculates the normalized screen-space coordinate ([0; 1] range) that the given world-space point projects to.
+  ///
+  /// Returns EZ_FAILURE, if the point could not be projected into screen-space.
+  ezResult ComputeScreenSpacePos(const ezVec3& vWorldPos, ezVec3& out_vScreenPosNormalized) const;
+
+  /// \brief Calculates the world-space position that the given normalized screen-space coordinate maps to
+  ezResult ComputeWorldSpacePos(float fNormalizedScreenPosX, float fNormalizedScreenPosY, ezVec3& out_vWorldPos) const;
+
+  /// \brief Converts a screen-space position from pixel coordinates to normalized coordinates.
+  void ConvertScreenPixelPosToNormalizedPos(ezVec3& inout_vPixelPos);
+
+  /// \brief Converts a screen-space position from normalized coordinates to pixel coordinates.
+  void ConvertScreenNormalizedPosToPixelPos(ezVec3& inout_vNormalizedPos);
+
 
   /// \brief Returns the current projection matrix.
   const ezMat4& GetProjectionMatrix(ezCameraEye eye) const;

--- a/Code/Engine/RendererCore/Pipeline/ViewData.h
+++ b/Code/Engine/RendererCore/Pipeline/ViewData.h
@@ -43,16 +43,14 @@ struct EZ_RENDERERCORE_DLL ezViewData
   ///
   /// fScreenPosX and fScreenPosY are expected to be in [0; 1] range (normalized pixel coordinates).
   /// If no ray can be computed, EZ_FAILURE is returned.
-  ezResult ComputePickingRay(
-    float fScreenPosX, float fScreenPosY, ezVec3& out_vRayStartPos, ezVec3& out_vRayDir, ezCameraEye eye = ezCameraEye::Left) const
+  ezResult ComputePickingRay(float fScreenPosX, float fScreenPosY, ezVec3& out_vRayStartPos, ezVec3& out_vRayDir, ezCameraEye eye = ezCameraEye::Left) const
   {
     ezVec3 vScreenPos;
     vScreenPos.x = fScreenPosX;
-    vScreenPos.y = 1.0f - fScreenPosY;
+    vScreenPos.y = fScreenPosY;
     vScreenPos.z = 0.0f;
 
-    return ezGraphicsUtils::ConvertScreenPosToWorldPos(
-      m_InverseViewProjectionMatrix[static_cast<int>(eye)], 0, 0, 1, 1, vScreenPos, out_vRayStartPos, &out_vRayDir);
+    return ezGraphicsUtils::ConvertScreenPosToWorldPos(m_InverseViewProjectionMatrix[static_cast<int>(eye)], 0, 0, 1, 1, vScreenPos, out_vRayStartPos, &out_vRayDir);
   }
 
   ezResult ComputeScreenSpacePos(const ezVec3& vPoint, ezVec3& out_vScreenPos, ezCameraEye eye = ezCameraEye::Left) const
@@ -64,8 +62,6 @@ struct EZ_RENDERERCORE_DLL ezViewData
 
     if (ezGraphicsUtils::ConvertWorldPosToScreenPos(m_ViewProjectionMatrix[static_cast<int>(eye)], x, y, w, h, vPoint, out_vScreenPos).Succeeded())
     {
-      out_vScreenPos.y = m_ViewPortRect.height - out_vScreenPos.y;
-
       return EZ_SUCCESS;
     }
 

--- a/Code/Engine/RendererCore/Pipeline/ViewData.h
+++ b/Code/Engine/RendererCore/Pipeline/ViewData.h
@@ -68,7 +68,7 @@ struct EZ_RENDERERCORE_DLL ezViewData
   }
 
   /// \brief Converts a screen-space position from pixel coordinates to normalized coordinates.
-  EZ_ALWAYS_INLINE void ConvertScreenPixelPosToNormalizedPos(ezVec3& inout_vPixelPos)
+  EZ_ALWAYS_INLINE void ConvertScreenPixelPosToNormalizedPos(ezVec3& inout_vPixelPos) const
   {
     ezUInt32 x = (ezUInt32)m_ViewPortRect.x;
     ezUInt32 y = (ezUInt32)m_ViewPortRect.y;
@@ -78,7 +78,7 @@ struct EZ_RENDERERCORE_DLL ezViewData
   }
 
   /// \brief Converts a screen-space position from normalized coordinates to pixel coordinates.
-  EZ_ALWAYS_INLINE void ConvertScreenNormalizedPosToPixelPos(ezVec3& inout_vNormalizedPos)
+  EZ_ALWAYS_INLINE void ConvertScreenNormalizedPosToPixelPos(ezVec3& inout_vNormalizedPos) const
   {
     {
       ezUInt32 x = (ezUInt32)m_ViewPortRect.x;

--- a/Code/Engine/RendererCore/Pipeline/ViewData.h
+++ b/Code/Engine/RendererCore/Pipeline/ViewData.h
@@ -39,32 +39,53 @@ struct EZ_RENDERERCORE_DLL ezViewData
   ezMat4 m_ViewProjectionMatrix[2];
   ezMat4 m_InverseViewProjectionMatrix[2];
 
-  /// \brief Returns the start position and direction (in world space) of the picking ray through the screen position in this view.
+  /// \brief Calculates the start position and direction (in world space) of the picking ray through the screen position in this view.
   ///
-  /// fScreenPosX and fScreenPosY are expected to be in [0; 1] range (normalized pixel coordinates).
+  /// fNormalizedScreenPosX and fNormalizedScreenPosY are expected to be in [0; 1] range (normalized screen coordinates).
   /// If no ray can be computed, EZ_FAILURE is returned.
-  ezResult ComputePickingRay(float fScreenPosX, float fScreenPosY, ezVec3& out_vRayStartPos, ezVec3& out_vRayDir, ezCameraEye eye = ezCameraEye::Left) const
+  EZ_ALWAYS_INLINE ezResult ComputePickingRay(float fNormalizedScreenPosX, float fNormalizedScreenPosY, ezVec3& out_vRayStartPos, ezVec3& out_vRayDir, ezCameraEye eye = ezCameraEye::Left) const
   {
     ezVec3 vScreenPos;
-    vScreenPos.x = fScreenPosX;
-    vScreenPos.y = fScreenPosY;
+    vScreenPos.x = fNormalizedScreenPosX;
+    vScreenPos.y = fNormalizedScreenPosY;
     vScreenPos.z = 0.0f;
 
-    return ezGraphicsUtils::ConvertScreenPosToWorldPos(m_InverseViewProjectionMatrix[static_cast<int>(eye)], 0, 0, 1, 1, vScreenPos, out_vRayStartPos, &out_vRayDir);
+    return ezGraphicsUtils::ConvertScreenPosToWorldPos(m_InverseViewProjectionMatrix[static_cast<int>(eye)], vScreenPos, out_vRayStartPos, &out_vRayDir);
   }
 
-  ezResult ComputeScreenSpacePos(const ezVec3& vPoint, ezVec3& out_vScreenPos, ezCameraEye eye = ezCameraEye::Left) const
+  /// \brief Calculates the normalized screen-space coordinate ([0; 1] range) that the given world-space point projects to.
+  ///
+  /// Returns EZ_FAILURE, if the point could not be projected into screen-space.
+  EZ_ALWAYS_INLINE ezResult ComputeScreenSpacePos(const ezVec3& vWorldPos, ezVec3& out_vScreenPosNormalized, ezCameraEye eye = ezCameraEye::Left) const
+  {
+    return ezGraphicsUtils::ConvertWorldPosToScreenPos(m_ViewProjectionMatrix[static_cast<int>(eye)], vWorldPos, out_vScreenPosNormalized);
+  }
+
+  /// \brief Calculates the world-space position that the given normalized screen-space coordinate maps to
+  EZ_ALWAYS_INLINE ezResult ComputeWorldSpacePos(float fNormalizedScreenPosX, float fNormalizedScreenPosY, ezVec3& out_vWorldPos, ezCameraEye eye = ezCameraEye::Left) const
+  {
+    return ezGraphicsUtils::ConvertScreenPosToWorldPos(m_InverseViewProjectionMatrix[static_cast<int>(eye)], ezVec3(fNormalizedScreenPosX, fNormalizedScreenPosY, 0.0f), out_vWorldPos);
+  }
+
+  /// \brief Converts a screen-space position from pixel coordinates to normalized coordinates.
+  EZ_ALWAYS_INLINE void ConvertScreenPixelPosToNormalizedPos(ezVec3& inout_vPixelPos)
   {
     ezUInt32 x = (ezUInt32)m_ViewPortRect.x;
     ezUInt32 y = (ezUInt32)m_ViewPortRect.y;
     ezUInt32 w = (ezUInt32)m_ViewPortRect.width;
     ezUInt32 h = (ezUInt32)m_ViewPortRect.height;
+    ezGraphicsUtils::ConvertScreenPixelPosToNormalizedPos(x, y, w, h, inout_vPixelPos);
+  }
 
-    if (ezGraphicsUtils::ConvertWorldPosToScreenPos(m_ViewProjectionMatrix[static_cast<int>(eye)], x, y, w, h, vPoint, out_vScreenPos).Succeeded())
+  /// \brief Converts a screen-space position from normalized coordinates to pixel coordinates.
+  EZ_ALWAYS_INLINE void ConvertScreenNormalizedPosToPixelPos(ezVec3& inout_vNormalizedPos)
+  {
     {
-      return EZ_SUCCESS;
+      ezUInt32 x = (ezUInt32)m_ViewPortRect.x;
+      ezUInt32 y = (ezUInt32)m_ViewPortRect.y;
+      ezUInt32 w = (ezUInt32)m_ViewPortRect.width;
+      ezUInt32 h = (ezUInt32)m_ViewPortRect.height;
+      ezGraphicsUtils::ConvertScreenNormalizedPosToPixelPos(x, y, w, h, inout_vNormalizedPos);
     }
-
-    return EZ_FAILURE;
   }
 };

--- a/Code/Samples/RtsGamePlugin/GameState/Input.cpp
+++ b/Code/Samples/RtsGamePlugin/GameState/Input.cpp
@@ -71,7 +71,7 @@ void RtsGameState::UpdateMousePosition()
   m_MouseInputState.m_RightClickState = ezInputManager::GetInputActionState("Game", "MouseRightClick");
 
   m_MouseInputState.m_MousePos.x = (ezUInt32)(valueX * vp.width);
-  m_MouseInputState.m_MousePos.y = (ezUInt32)((1.0f - valueY) * vp.height);
+  m_MouseInputState.m_MousePos.y = (ezUInt32)(valueY * vp.height);
 
   if (m_MouseInputState.m_LeftClickState == ezKeyState::Pressed)
   {

--- a/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
+++ b/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
@@ -307,8 +307,7 @@ ezResult RtsGameState::ComputePickingRay()
 
   const auto& vp = pView->GetViewport();
 
-  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(
-        pView->GetInverseViewProjectionMatrix(ezCameraEye::Left), (ezUInt32)vp.x, (ezUInt32)vp.y, (ezUInt32)vp.width, (ezUInt32)vp.height, ezVec3((float)m_MouseInputState.m_MousePos.x, (float)m_MouseInputState.m_MousePos.y, 0), m_vCurrentPickingRayStart, &m_vCurrentPickingRayDir)
+  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(pView->GetInverseViewProjectionMatrix(ezCameraEye::Left), (ezUInt32)vp.x, (ezUInt32)vp.y, (ezUInt32)vp.width, (ezUInt32)vp.height, ezVec3((float)m_MouseInputState.m_MousePos.x, (float)m_MouseInputState.m_MousePos.y, 0), m_vCurrentPickingRayStart, &m_vCurrentPickingRayDir)
         .Failed())
     return EZ_FAILURE;
 

--- a/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
+++ b/Code/Samples/RtsGamePlugin/GameState/RtsGameState.cpp
@@ -305,13 +305,11 @@ ezResult RtsGameState::ComputePickingRay()
   if (!ezRenderWorld::TryGetView(m_hMainView, pView))
     return EZ_FAILURE;
 
-  const auto& vp = pView->GetViewport();
+  ezVec3 vMousePos((float)m_MouseInputState.m_MousePos.x, (float)m_MouseInputState.m_MousePos.y, 0);
 
-  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(pView->GetInverseViewProjectionMatrix(ezCameraEye::Left), (ezUInt32)vp.x, (ezUInt32)vp.y, (ezUInt32)vp.width, (ezUInt32)vp.height, ezVec3((float)m_MouseInputState.m_MousePos.x, (float)m_MouseInputState.m_MousePos.y, 0), m_vCurrentPickingRayStart, &m_vCurrentPickingRayDir)
-        .Failed())
-    return EZ_FAILURE;
+  pView->ConvertScreenPixelPosToNormalizedPos(vMousePos);
 
-  return EZ_SUCCESS;
+  return pView->ComputePickingRay(vMousePos.x, vMousePos.y, m_vCurrentPickingRayStart, m_vCurrentPickingRayDir);
 }
 
 ezResult RtsGameState::PickGroundPlanePosition(ezVec3& out_vPositon) const

--- a/Code/ThirdParty/ads/DockOverlay.cpp
+++ b/Code/ThirdParty/ads/DockOverlay.cpp
@@ -128,8 +128,9 @@ struct DockOverlayCrossPrivate
 			 }
 			 break;
 
-		case CDockOverlayCross::ArrowColor: return pal.color(QPalette::Active, QPalette::Base);
-		case CDockOverlayCross::ShadowColor: return QColor(0, 0, 0, 64);
+    // EZ-SPECIFIC colors
+		case CDockOverlayCross::ArrowColor: return QColor(255, 255, 255, 200);
+		case CDockOverlayCross::ShadowColor: return QColor(255, 255, 255, 255);
 		default:
 			return QColor();
 		}

--- a/Code/ThirdParty/ads/stylesheets/default.css
+++ b/Code/ThirdParty/ads/stylesheets/default.css
@@ -35,7 +35,7 @@ ads--CTitleBarButton {
 
 
 #tabsMenuButton::menu-indicator {
-        image: none;
+    image: url(:/ads/images/tabs-menu-button.svg);
 }
 
 #tabsMenuButton {

--- a/Code/ThirdParty/ads/stylesheets/focus_highlighting.css
+++ b/Code/ThirdParty/ads/stylesheets/focus_highlighting.css
@@ -51,7 +51,7 @@ ads--CTitleBarButton {
 
 
 #tabsMenuButton::menu-indicator {
-	image: none;
+	image: url(:/ads/images/tabs-menu-button.svg);
 }
 
 

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -400,6 +400,7 @@ void ezQtContainerWindow::AddDocumentWindow(ezQtDocumentWindow* pDocWindow)
   ezString displayName = pDocWindow->GetDisplayNameShort();
   ads::CDockWidget* dock = new ads::CDockWidget(QString::fromUtf8(displayName.GetData(), displayName.GetElementCount()));
   dock->installEventFilter(pDocWindow);
+  dock->setFeature(ads::CDockWidget::CustomCloseHandling, true);
 
   dock->setObjectName(pDocWindow->GetUniqueName());
   EZ_ASSERT_DEV(!dock->objectName().isEmpty(), "Dock name must not be empty.");
@@ -417,7 +418,7 @@ void ezQtContainerWindow::AddDocumentWindow(ezQtDocumentWindow* pDocWindow)
     m_pDockManager->addDockWidgetTab(ads::LeftDockWidgetArea, dock);
   }
   m_DocumentDocks.PushBack(dock);
-  connect(dock, &ads::CDockWidget::closed, this, &ezQtContainerWindow::SlotDocumentTabCloseRequested);
+  connect(dock, &ads::CDockWidget::closeRequested, this, &ezQtContainerWindow::SlotDocumentTabCloseRequested);
   connect(dock->tabWidget(), &QWidget::customContextMenuRequested, this, &ezQtContainerWindow::SlotTabsContextMenuRequested);
   connect(dock, &ads::CDockWidget::topLevelChanged, this, &ezQtContainerWindow::SlotDockWidgetFloatingChanged);
 
@@ -564,11 +565,9 @@ void ezQtContainerWindow::SlotDocumentTabCloseRequested()
 
   if (!pDocWindow->CanCloseWindow())
   {
-    // TODO: There is no CloseRequested event so we just reopen on a timer.
-    QTimer::singleShot(1, [dock]()
-      { dock->toggleView(); });
     return;
   }
+
   pDocWindow->CloseDocumentWindow();
 }
 

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -74,15 +74,18 @@ ezQtContainerWindow::ezQtContainerWindow()
     ads::CDockManager::ActiveTabHasCloseButton |
     ads::CDockManager::XmlCompressionEnabled |
     ads::CDockManager::FloatingContainerHasWidgetTitle |
+    ads::CDockManager::HideSingleCentralWidgetTitleBar |
     ads::CDockManager::DragPreviewShowsContentPixmap |
     ads::CDockManager::FocusHighlighting |
     ads::CDockManager::AlwaysShowTabs |
-    ads::CDockManager::DockAreaHasCloseButton |
+    // ads::CDockManager::DockAreaHasCloseButton |
     ads::CDockManager::DockAreaCloseButtonClosesTab |
     ads::CDockManager::MiddleMouseButtonClosesTab |
     ads::CDockManager::DockAreaHasTabsMenuButton |
     ads::CDockManager::FloatingContainerHasWidgetIcon |
-    ads::CDockManager::AllTabsHaveCloseButton |
+    // ads::CDockManager::AllTabsHaveCloseButton |
+    ads::CDockManager::RetainTabSizeWhenCloseButtonHidden |
+    ads::CDockManager::DockAreaHideDisabledButtons |
     ads::CDockManager::OpaqueSplitterResize;
   ads::CDockManager::setConfigFlags(flags);
 

--- a/Code/UnitTests/FoundationTest/Utility/GraphicsUtilsTest.cpp
+++ b/Code/UnitTests/FoundationTest/Utility/GraphicsUtilsTest.cpp
@@ -8,8 +8,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
   {
     ezMat4 mProj, mProjInv;
 
-    mProj = ezGraphicsUtils::CreatePerspectiveProjectionMatrixFromFovX(
-      ezAngle::MakeFromDegree(85.0f), 2.0f, 1.0f, 1000.0f, ezClipSpaceDepthRange::MinusOneToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
+    mProj = ezGraphicsUtils::CreatePerspectiveProjectionMatrixFromFovX(ezAngle::MakeFromDegree(85.0f), 2.0f, 1.0f, 1000.0f, ezClipSpaceDepthRange::MinusOneToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
     mProjInv = mProj.GetInverse();
 
     for (ezUInt32 y = 0; y < 25; ++y)
@@ -17,15 +16,12 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
       for (ezUInt32 x = 0; x < 50; ++x)
       {
         ezVec3 vPoint, vDir;
-        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(
-          mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::MinusOneToOne)
-                       .Succeeded());
+        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::MinusOneToOne).Succeeded());
 
         EZ_TEST_VEC3(vDir, vPoint.GetNormalized(), 0.01f);
 
         ezVec3 vScreen;
-        EZ_TEST_BOOL(
-          ezGraphicsUtils::ConvertWorldPosToScreenPos(mProj, 0, 0, 50, 25, vPoint, vScreen, ezClipSpaceDepthRange::MinusOneToOne).Succeeded());
+        EZ_TEST_BOOL(ezGraphicsUtils::ConvertWorldPosToScreenPos(mProj, 0, 0, 50, 25, vPoint, vScreen, ezClipSpaceDepthRange::MinusOneToOne).Succeeded());
 
         EZ_TEST_VEC3(vScreen, ezVec3((float)x, (float)y, 0.5f), 0.01f);
       }
@@ -35,8 +31,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Perspective (0/1): ConvertWorldPosToScreenPos / ConvertScreenPosToWorldPos")
   {
     ezMat4 mProj, mProjInv;
-    mProj = ezGraphicsUtils::CreatePerspectiveProjectionMatrixFromFovX(
-      ezAngle::MakeFromDegree(85.0f), 2.0f, 1.0f, 1000.0f, ezClipSpaceDepthRange::ZeroToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
+    mProj = ezGraphicsUtils::CreatePerspectiveProjectionMatrixFromFovX(ezAngle::MakeFromDegree(85.0f), 2.0f, 1.0f, 1000.0f, ezClipSpaceDepthRange::ZeroToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
     mProjInv = mProj.GetInverse();
 
     for (ezUInt32 y = 0; y < 25; ++y)
@@ -44,9 +39,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
       for (ezUInt32 x = 0; x < 50; ++x)
       {
         ezVec3 vPoint, vDir;
-        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(
-          mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::ZeroToOne)
-                       .Succeeded());
+        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::ZeroToOne).Succeeded());
 
         EZ_TEST_VEC3(vDir, vPoint.GetNormalized(), 0.01f);
 
@@ -61,8 +54,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Ortho (-1/1): ConvertWorldPosToScreenPos / ConvertScreenPosToWorldPos")
   {
     ezMat4 mProj, mProjInv;
-    mProj = ezGraphicsUtils::CreateOrthographicProjectionMatrix(
-      50, 25, 1.0f, 1000.0f, ezClipSpaceDepthRange::MinusOneToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
+    mProj = ezGraphicsUtils::CreateOrthographicProjectionMatrix(50, 25, 1.0f, 1000.0f, ezClipSpaceDepthRange::MinusOneToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
 
     mProjInv = mProj.GetInverse();
 
@@ -71,9 +63,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
       for (ezUInt32 x = 0; x < 50; ++x)
       {
         ezVec3 vPoint, vDir;
-        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(
-          mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::MinusOneToOne)
-                       .Succeeded());
+        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::MinusOneToOne).Succeeded());
 
         EZ_TEST_VEC3(vDir, ezVec3(0, 0, 1.0f), 0.01f);
 
@@ -89,8 +79,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Ortho (0/1): ConvertWorldPosToScreenPos / ConvertScreenPosToWorldPos")
   {
     ezMat4 mProj, mProjInv;
-    mProj = ezGraphicsUtils::CreateOrthographicProjectionMatrix(
-      50, 25, 1.0f, 1000.0f, ezClipSpaceDepthRange::ZeroToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
+    mProj = ezGraphicsUtils::CreateOrthographicProjectionMatrix(50, 25, 1.0f, 1000.0f, ezClipSpaceDepthRange::ZeroToOne, ezClipSpaceYMode::Regular, ezHandedness::LeftHanded);
     mProjInv = mProj.GetInverse();
 
     for (ezUInt32 y = 0; y < 25; ++y)
@@ -98,9 +87,7 @@ EZ_CREATE_SIMPLE_TEST(Utility, GraphicsUtils)
       for (ezUInt32 x = 0; x < 50; ++x)
       {
         ezVec3 vPoint, vDir;
-        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(
-          mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::ZeroToOne)
-                       .Succeeded());
+        EZ_TEST_BOOL(ezGraphicsUtils::ConvertScreenPosToWorldPos(mProjInv, 0, 0, 50, 25, ezVec3((float)x, (float)y, 0.5f), vPoint, &vDir, ezClipSpaceDepthRange::ZeroToOne).Succeeded());
 
         EZ_TEST_VEC3(vDir, ezVec3(0, 0, 1.0f), 0.01f);
 


### PR DESCRIPTION
* When closing a document, we now first ask to save it, before hiding the tab.
* Fixed that ezGraphicsUtils was using the Y screen coordinate inverted compared to other code, such as the OS mouse coordinates. Now you don't need to invert the coordinates anymore. This is a breaking change.
* Added some overloads to ezGraphicsUtils for convenience.
* Added some utility functions to ezView for converting coordinates and mapping to and from screen and world coordinates.
* Made it easier to acces the one ezGameState that could be in use.