### PR TITLE
Added presets for mesh import transform settings

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -603,7 +603,7 @@ void ezQtAssetBrowserWidget::OnTypeFilterChanged()
       }
     }
 
-    if (iNumChecked == 3)
+    if (iNumChecked == (m_Mode != Mode::Browser) ? 1 : 3)
       TypeFilter->setCurrentIndex(iCheckedFilter);
     else
       TypeFilter->setCurrentIndex((m_Mode != Mode::Browser) ? 0 : 2); // "<All Assets>"

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -16,9 +16,13 @@ static ezMat3 CalculateTransformationMatrix(const ezMeshAssetProperties* pProp)
 {
   const float us = ezMath::Clamp(pProp->m_fUniformScaling, 0.0001f, 10000.0f);
 
-  const ezBasisAxis::Enum forwardDir = ezBasisAxis::GetOrthogonalAxis(pProp->m_RightDir, pProp->m_UpDir, !pProp->m_bFlipForwardDir);
+  auto rightDir = ezMeshImportTransform::GetRightDir(pProp->m_ImportTransform, pProp->m_RightDir);
+  auto upDir = ezMeshImportTransform::GetUpDir(pProp->m_ImportTransform, pProp->m_UpDir);
+  auto flipFwd = ezMeshImportTransform::GetFlipForward(pProp->m_ImportTransform, pProp->m_bFlipForwardDir);
 
-  return ezBasisAxis::CalculateTransformationMatrix(forwardDir, pProp->m_RightDir, pProp->m_UpDir, us);
+  const ezBasisAxis::Enum forwardDir = ezBasisAxis::GetOrthogonalAxis(rightDir, upDir, !flipFwd);
+
+  return ezBasisAxis::CalculateTransformationMatrix(forwardDir, rightDir, upDir, us);
 }
 
 ezMeshAssetDocument::ezMeshAssetDocument(ezStringView sDocumentPath)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
@@ -5,7 +5,7 @@
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetProperties, 3, ezRTTIDefaultAllocator<ezMeshAssetProperties>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetProperties, 4, ezRTTIDefaultAllocator<ezMeshAssetProperties>)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -251,3 +251,21 @@ public:
 };
 
 ezMeshAssetPropertiesPatch_2_3 g_ezMeshAssetPropertiesPatch_2_3;
+
+//////////////////////////////////////////////////////////////////////////
+
+class ezMeshAssetPropertiesPatch_3_4 : public ezGraphPatch
+{
+public:
+  ezMeshAssetPropertiesPatch_3_4()
+    : ezGraphPatch("ezMeshAssetProperties", 4)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    pNode->AddProperty("ImportTransform", 127);
+  }
+};
+
+ezMeshAssetPropertiesPatch_3_4 g_ezMeshAssetPropertiesPatch_3_4;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
@@ -11,9 +11,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetProperties, 3, ezRTTIDefaultAllocator
   {
     EZ_ENUM_MEMBER_PROPERTY("PrimitiveType", ezMeshPrimitive, m_PrimitiveType),
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes)),
+    EZ_ENUM_MEMBER_PROPERTY("ImportTransform", ezMeshImportTransform, m_ImportTransform),
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
-    EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir),
+    EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("UniformScaling", m_fUniformScaling)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0001f, 10000.0f)),
     EZ_MEMBER_PROPERTY("RecalculateNormals", m_bRecalculateNormals),
     EZ_MEMBER_PROPERTY("RecalculateTangents", m_bRecalculateTrangents)->AddAttributes(new ezDefaultValueAttribute(true)),
@@ -66,9 +67,21 @@ public:
 
 ezMeshAssetPropertiesPatch_1_2 g_MeshAssetPropertiesPatch_1_2;
 
+// clang-format off
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezMeshPrimitive, 1)
-  EZ_ENUM_CONSTANT(ezMeshPrimitive::File), EZ_ENUM_CONSTANT(ezMeshPrimitive::Box), EZ_ENUM_CONSTANT(ezMeshPrimitive::Rect), EZ_ENUM_CONSTANT(ezMeshPrimitive::Cylinder), EZ_ENUM_CONSTANT(ezMeshPrimitive::Cone), EZ_ENUM_CONSTANT(ezMeshPrimitive::Pyramid), EZ_ENUM_CONSTANT(ezMeshPrimitive::Sphere), EZ_ENUM_CONSTANT(ezMeshPrimitive::HalfSphere), EZ_ENUM_CONSTANT(ezMeshPrimitive::GeodesicSphere), EZ_ENUM_CONSTANT(ezMeshPrimitive::Capsule), EZ_ENUM_CONSTANT(ezMeshPrimitive::Torus),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::File),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Box),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Rect),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Cylinder),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Cone),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Pyramid),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Sphere),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::HalfSphere),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::GeodesicSphere),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Capsule),
+  EZ_ENUM_CONSTANT(ezMeshPrimitive::Torus),
 EZ_END_STATIC_REFLECTED_ENUM;
+// clang-format on
 
 ezMeshAssetProperties::ezMeshAssetProperties() = default;
 ezMeshAssetProperties::~ezMeshAssetProperties() = default;
@@ -102,6 +115,12 @@ void ezMeshAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaStateEve
     props["MeshSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
     props["MaxSimplificationError"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
     props["AggressiveSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+
+    const ezInt64 importTransform = e.m_pObject->GetTypeAccessor().GetValue("ImportTransform").ConvertTo<ezInt64>();
+    const bool bCustomTransform = importTransform == 127;
+    props["RightDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+    props["UpDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+    props["FlipForwardDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
 
     switch (primType)
     {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/Assets/SimpleAssetDocument.h>
 #include <EditorPluginAssets/Util/AssetUtils.h>
+#include <RendererCore/Declarations.h>
 #include <RendererCore/Meshes/MeshBufferUtils.h>
 #include <ToolsFoundation/Object/DocumentObjectBase.h>
 
@@ -53,9 +54,10 @@ public:
   bool m_bCap = true;
   bool m_bCap2 = true;
 
-  ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::PositiveY;
-  ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveZ;
-  bool m_bFlipForwardDir = false;
+  ezEnum<ezMeshImportTransform> m_ImportTransform;
+  ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::PositiveX;
+  ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveY;
+  bool m_bFlipForwardDir = true;
 
   ezMeshPrimitive::Enum m_PrimitiveType = ezMeshPrimitive::Default;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -18,16 +18,18 @@ static ezTransform CalculateTransformationMatrix(const ezEditableSkeleton* pProp
 {
   const float us = ezMath::Clamp(pProp->m_fUniformScaling, 0.0001f, 10000.0f);
 
-  const ezBasisAxis::Enum rightDir = pProp->m_RightDir;
-  const ezBasisAxis::Enum upDir = pProp->m_UpDir;
-  ezBasisAxis::Enum forwardDir = ezBasisAxis::GetOrthogonalAxis(rightDir, upDir, !pProp->m_bFlipForwardDir);
+  auto rightDir = ezMeshImportTransform::GetRightDir(pProp->m_ImportTransform, pProp->m_RightDir);
+  auto upDir = ezMeshImportTransform::GetUpDir(pProp->m_ImportTransform, pProp->m_UpDir);
+  auto flipFwd = ezMeshImportTransform::GetFlipForward(pProp->m_ImportTransform, pProp->m_bFlipForwardDir);
+
+  ezBasisAxis::Enum forwardDir = ezBasisAxis::GetOrthogonalAxis(rightDir, upDir, !flipFwd);
 
   ezTransform t;
   t.SetIdentity();
   t.m_vScale.Set(us);
 
   // prevent mirroring in the rotation matrix, because we can't generate a quaternion from that
-  if (!pProp->m_bFlipForwardDir)
+  if (!flipFwd)
   {
     switch (forwardDir)
     {
@@ -73,6 +75,17 @@ ezSkeletonAssetDocument::~ezSkeletonAssetDocument() = default;
 
 void ezSkeletonAssetDocument::PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e)
 {
+  if (e.m_pObject->GetTypeAccessor().GetType() == ezGetStaticRTTI<ezEditableSkeleton>())
+  {
+    auto& props = *e.m_pPropertyStates;
+
+    const ezInt64 importTransform = e.m_pObject->GetTypeAccessor().GetValue("ImportTransform").ConvertTo<ezInt64>();
+    const bool bCustomTransform = importTransform == 127;
+    props["RightDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+    props["UpDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+    props["FlipForwardDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  }
+
   if (e.m_pObject->GetTypeAccessor().GetType() == ezGetStaticRTTI<ezEditableSkeletonJoint>())
   {
     auto& props = *e.m_pPropertyStates;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAsset.cpp
@@ -485,3 +485,24 @@ ezStatus ezSkeletonAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, 
 
   return ezStatus(EZ_SUCCESS);
 }
+
+
+//////////////////////////////////////////////////////////////////////////
+
+#include <Foundation/Serialization/GraphPatch.h>
+
+class ezEditableSkeleton_1_2 : public ezGraphPatch
+{
+public:
+  ezEditableSkeleton_1_2()
+    : ezGraphPatch("ezEditableSkeleton", 2)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    pNode->AddProperty("ImportTransform", 127);
+  }
+};
+
+ezEditableSkeleton_1_2 g_ezEditableSkeleton_1_2;

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -22,9 +22,13 @@ static ezMat3 CalculateTransformationMatrix(const ezJoltCollisionMeshAssetProper
 {
   const float us = ezMath::Clamp(pProp->m_fUniformScaling, 0.0001f, 10000.0f);
 
-  const ezBasisAxis::Enum forwardDir = ezBasisAxis::GetOrthogonalAxis(pProp->m_RightDir, pProp->m_UpDir, !pProp->m_bFlipForwardDir);
+  auto rightDir = ezMeshImportTransform::GetRightDir(pProp->m_ImportTransform, pProp->m_RightDir);
+  auto upDir = ezMeshImportTransform::GetUpDir(pProp->m_ImportTransform, pProp->m_UpDir);
+  auto flipFwd = ezMeshImportTransform::GetFlipForward(pProp->m_ImportTransform, pProp->m_bFlipForwardDir);
 
-  return ezBasisAxis::CalculateTransformationMatrix(forwardDir, pProp->m_RightDir, pProp->m_UpDir, us);
+  const ezBasisAxis::Enum forwardDir = ezBasisAxis::GetOrthogonalAxis(rightDir, upDir, !flipFwd);
+
+  return ezBasisAxis::CalculateTransformationMatrix(forwardDir, rightDir, upDir, us);
 }
 
 ezJoltCollisionMeshAssetDocument::ezJoltCollisionMeshAssetDocument(ezStringView sDocumentPath, bool bConvexMesh)

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -32,9 +32,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 1, ezRTTIDef
 {
   EZ_BEGIN_PROPERTIES
   {
+    EZ_ENUM_MEMBER_PROPERTY("ImportTransform", ezMeshImportTransform, m_ImportTransform),
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
-    EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir),
+    EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("UniformScaling", m_fUniformScaling)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("IsConvexMesh", m_bIsConvexMesh)->AddAttributes(new ezHiddenAttribute()),
     EZ_ENUM_MEMBER_PROPERTY("ConvexMeshType", ezJoltConvexCollisionMeshType, m_ConvexMeshType),
@@ -84,6 +85,12 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
   props["MeshSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
   props["MaxSimplificationError"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
   props["AggressiveSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+
+  const ezInt64 importTransform = e.m_pObject->GetTypeAccessor().GetValue("ImportTransform").ConvertTo<ezInt64>();
+  const bool bCustomTransform = importTransform == 127;
+  props["RightDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  props["UpDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  props["FlipForwardDir"].m_Visibility = bCustomTransform ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
 
   if (!isConvex)
   {

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -28,7 +28,7 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezJoltConvexCollisionMeshType, 1)
   EZ_ENUM_CONSTANT(ezJoltConvexCollisionMeshType::ConvexDecomposition),
 EZ_END_STATIC_REFLECTED_ENUM;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 1, ezRTTIDefaultAllocator<ezJoltCollisionMeshAssetProperties>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 2, ezRTTIDefaultAllocator<ezJoltCollisionMeshAssetProperties>)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -119,3 +119,23 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
     }
   }
 }
+
+//////////////////////////////////////////////////////////////////////////
+
+#include <Foundation/Serialization/GraphPatch.h>
+
+class ezJoltCollisionMeshAssetProperties_1_2 : public ezGraphPatch
+{
+public:
+  ezJoltCollisionMeshAssetProperties_1_2()
+    : ezGraphPatch("ezJoltCollisionMeshAssetProperties", 2)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    pNode->AddProperty("ImportTransform", 127);
+  }
+};
+
+ezJoltCollisionMeshAssetProperties_1_2 g_ezJoltCollisionMeshAssetProperties_1_2;

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <EditorFramework/Assets/SimpleAssetDocument.h>
+#include <RendererCore/Declarations.h>
 #include <ToolsFoundation/Object/DocumentObjectBase.h>
 
 struct ezPropertyMetaStateEvent;
@@ -60,9 +61,10 @@ public:
   float m_fUniformScaling = 1.0f;
   ezString m_sConvexMeshSurface;
 
+  ezEnum<ezMeshImportTransform> m_ImportTransform;
   ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::PositiveX;
   ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveY;
-  bool m_bFlipForwardDir = false;
+  bool m_bFlipForwardDir = true;
   bool m_bIsConvexMesh = false;
   ezEnum<ezJoltConvexCollisionMeshType> m_ConvexMeshType;
   ezUInt16 m_uiMaxConvexPieces = 2;

--- a/Code/Engine/RendererCore/AnimationSystem/EditableSkeleton.h
+++ b/Code/Engine/RendererCore/AnimationSystem/EditableSkeleton.h
@@ -6,6 +6,7 @@
 #include <Foundation/Strings/HashedString.h>
 #include <Foundation/Types/VariantTypeRegistry.h>
 #include <RendererCore/AnimationSystem/Declarations.h>
+#include <RendererCore/Declarations.h>
 
 class ezSkeletonBuilder;
 class ezSkeleton;
@@ -112,9 +113,10 @@ public:
   float m_fUniformScaling = 1.0f;
   float m_fMaxImpulse = 100.0f;
 
-  ezEnum<ezBasisAxis> m_RightDir;
-  ezEnum<ezBasisAxis> m_UpDir;
-  bool m_bFlipForwardDir = false;
+  ezEnum<ezMeshImportTransform> m_ImportTransform;
+  ezEnum<ezBasisAxis> m_RightDir = ezBasisAxis::PositiveX;
+  ezEnum<ezBasisAxis> m_UpDir = ezBasisAxis::PositiveY;
+  bool m_bFlipForwardDir = true;
   ezEnum<ezBasisAxis> m_BoneDirection;
 
   ezHybridArray<ezEditableSkeletonJoint*, 4> m_Children;

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
@@ -84,9 +84,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeleton, 1, ezRTTIDefaultAllocator<ez
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("File", m_sSourceFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations)),
+    EZ_ENUM_MEMBER_PROPERTY("ImportTransform", ezMeshImportTransform, m_ImportTransform),
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
-    EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir),
+    EZ_MEMBER_PROPERTY("FlipForwardDir", m_bFlipForwardDir)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("UniformScaling", m_fUniformScaling)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0001f, 10000.0f)),
     EZ_ENUM_MEMBER_PROPERTY("BoneDirection", ezBasisAxis, m_BoneDirection)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
     EZ_MEMBER_PROPERTY("PreviewMesh", m_sPreviewMesh)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skinned", ezDependencyFlags::None)),

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
@@ -79,7 +79,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeletonJoint, 2, ezRTTIDefaultAllocat
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeleton, 1, ezRTTIDefaultAllocator<ezEditableSkeleton>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeleton, 2, ezRTTIDefaultAllocator<ezEditableSkeleton>)
 {
   EZ_BEGIN_PROPERTIES
   {

--- a/Code/Engine/RendererCore/Declarations.h
+++ b/Code/Engine/RendererCore/Declarations.h
@@ -46,7 +46,7 @@ struct EZ_RENDERERCORE_DLL ezMeshImportTransform
 
   static ezBasisAxis::Enum GetRightDir(ezMeshImportTransform::Enum transform, ezBasisAxis::Enum dir);
   static ezBasisAxis::Enum GetUpDir(ezMeshImportTransform::Enum transform, ezBasisAxis::Enum dir);
-  static bool GetFlipForward(ezMeshImportTransform::Enum transform, bool flip);
+  static bool GetFlipForward(ezMeshImportTransform::Enum transform, bool bFlip);
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_RENDERERCORE_DLL, ezMeshImportTransform);

--- a/Code/Engine/RendererCore/Declarations.h
+++ b/Code/Engine/RendererCore/Declarations.h
@@ -29,3 +29,24 @@ struct EZ_RENDERERCORE_DLL ezPermutationVar
 
   EZ_ALWAYS_INLINE bool operator==(const ezPermutationVar& other) const { return m_sName == other.m_sName && m_sValue == other.m_sValue; }
 };
+
+struct EZ_RENDERERCORE_DLL ezMeshImportTransform
+{
+  using StorageType = ezInt8;
+
+  enum Enum
+  {
+    Blender_YUp,
+    Blender_ZUp,
+
+    Custom = 127,
+
+    Default = Blender_YUp
+  };
+
+  static ezBasisAxis::Enum GetRightDir(ezMeshImportTransform::Enum transform, ezBasisAxis::Enum dir);
+  static ezBasisAxis::Enum GetUpDir(ezMeshImportTransform::Enum transform, ezBasisAxis::Enum dir);
+  static bool GetFlipForward(ezMeshImportTransform::Enum transform, bool flip);
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_RENDERERCORE_DLL, ezMeshImportTransform);

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponent.cpp
@@ -48,4 +48,65 @@ void ezMeshComponent::OnMsgExtractGeometry(ezMsgExtractGeometry& ref_msg) const
   ref_msg.AddMeshObject(GetOwner()->GetGlobalTransform(), ezResourceManager::LoadResource<ezCpuMeshResource>(GetMesh().GetResourceID()));
 }
 
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_ENUM(ezMeshImportTransform, 1)
+  EZ_ENUM_CONSTANT(ezMeshImportTransform::Blender_YUp),
+    EZ_ENUM_CONSTANT(ezMeshImportTransform::Blender_ZUp),
+    EZ_ENUM_CONSTANT(ezMeshImportTransform::Custom),
+EZ_END_STATIC_REFLECTED_ENUM;
+// clang-format on
+
+ezBasisAxis::Enum ezMeshImportTransform::GetRightDir(ezMeshImportTransform::Enum transform, ezBasisAxis::Enum dir)
+{
+  switch (transform)
+  {
+    case ezMeshImportTransform::Blender_YUp:
+      return ezBasisAxis::PositiveX;
+    case ezMeshImportTransform::Blender_ZUp:
+      return ezBasisAxis::PositiveX;
+    case ezMeshImportTransform::Custom:
+      return dir;
+
+      EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
+  }
+
+  return dir;
+}
+
+ezBasisAxis::Enum ezMeshImportTransform::GetUpDir(ezMeshImportTransform::Enum transform, ezBasisAxis::Enum dir)
+{
+  switch (transform)
+  {
+    case ezMeshImportTransform::Blender_YUp:
+      return ezBasisAxis::PositiveY;
+    case ezMeshImportTransform::Blender_ZUp:
+      return ezBasisAxis::PositiveZ;
+    case ezMeshImportTransform::Custom:
+      return dir;
+
+      EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
+  }
+
+  return dir;
+}
+
+bool ezMeshImportTransform::GetFlipForward(ezMeshImportTransform::Enum transform, bool flip)
+{
+  switch (transform)
+  {
+    case ezMeshImportTransform::Blender_YUp:
+      return true;
+    case ezMeshImportTransform::Blender_ZUp:
+      return true;
+    case ezMeshImportTransform::Custom:
+      return flip;
+
+      EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
+  }
+
+  return flip;
+}
+
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Meshes_Implementation_MeshComponent);

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponent.cpp
@@ -92,7 +92,7 @@ ezBasisAxis::Enum ezMeshImportTransform::GetUpDir(ezMeshImportTransform::Enum tr
   return dir;
 }
 
-bool ezMeshImportTransform::GetFlipForward(ezMeshImportTransform::Enum transform, bool flip)
+bool ezMeshImportTransform::GetFlipForward(ezMeshImportTransform::Enum transform, bool bFlip)
 {
   switch (transform)
   {
@@ -101,12 +101,12 @@ bool ezMeshImportTransform::GetFlipForward(ezMeshImportTransform::Enum transform
     case ezMeshImportTransform::Blender_ZUp:
       return true;
     case ezMeshImportTransform::Custom:
-      return flip;
+      return bFlip;
 
       EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
   }
 
-  return flip;
+  return bFlip;
 }
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Meshes_Implementation_MeshComponent);


### PR DESCRIPTION
This makes it easier to import meshes with the correct forward and right vectors.
Current presets are for the typical Blender conventions of Y up and Z up.
In Blender it is common to orient meshes to look down the -Y direction. But during export it is also common to switch from Z up to Y up. So these presets were added. Can be expanded in the future.

Existing assets will use the 'Custom' setting, which behaves the same as before.

Before:

![image](https://github.com/user-attachments/assets/e700a4cf-5190-40c3-9987-107caecf09c5)

After:

![image](https://github.com/user-attachments/assets/d7e10492-cf13-4695-8b4d-0696044ae309)
