### PR TITLE
Crash fixes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -603,7 +603,7 @@ void ezQtAssetBrowserWidget::OnTypeFilterChanged()
       }
     }
 
-    if (iNumChecked == (m_Mode != Mode::Browser) ? 1 : 3)
+    if (iNumChecked == ((m_Mode != Mode::Browser) ? 1 : 3))
       TypeFilter->setCurrentIndex(iCheckedFilter);
     else
       TypeFilter->setCurrentIndex((m_Mode != Mode::Browser) ? 0 : 2); // "<All Assets>"

--- a/Code/Engine/Core/Collection/Implementation/CollectionUtils.cpp
+++ b/Code/Engine/Core/Collection/Implementation/CollectionUtils.cpp
@@ -95,7 +95,7 @@ void ezCollectionUtils::AddResourceHandle(ezCollectionResourceDescriptor& ref_co
     ezStringView root, relFile;
     ezPathUtils::GetRootedPathParts(resID, root, relFile);
     absFilename = sAbsFolderpath;
-    absFilename.AppendPath(relFile.GetStartPointer());
+    absFilename.AppendPath(relFile);
     absFilename.MakeCleanPath();
 
     ezFileStats stats;

--- a/Code/Engine/Foundation/IO/Implementation/OpenDdlUtils.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/OpenDdlUtils.cpp
@@ -742,7 +742,7 @@ ezResult ezOpenDdlUtils::ConvertToVariant(const ezOpenDdlReaderElement* pElement
       const ezStringView* pValues = pString->GetPrimitivesString();
 
       value.SetCountUninitialized(pValues[0].GetElementCount() / 2);
-      ezConversionUtils::ConvertHexToBinary(pValues[0].GetStartPointer(), value.GetData(), value.GetCount());
+      ezConversionUtils::ConvertHexToBinary(pValues[0], value.GetData(), value.GetCount());
 
       out_result = value;
       return EZ_SUCCESS;

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
@@ -106,18 +106,18 @@ void ezAnimatedMeshComponent::InitializeAnimationPose()
     const ozz::animation::Skeleton* pOzzSkeleton = &pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
     const ezUInt32 uiNumSkeletonJoints = pOzzSkeleton->num_joints();
 
-    ezArrayPtr<ezMat4> pPoseMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezMat4, uiNumSkeletonJoints);
-
+    ezArrayPtr<ozz::math::Float4x4> pPoseMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, uiNumSkeletonJoints);
+    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pPoseMatrices.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
     {
       ozz::animation::LocalToModelJob job;
       job.input = pOzzSkeleton->joint_rest_poses();
-      job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(pPoseMatrices.GetPtr()), reinterpret_cast<ozz::math::Float4x4*>(pPoseMatrices.GetEndPtr()));
+      job.output = ozz::span<ozz::math::Float4x4>(pPoseMatrices.GetPtr(), pPoseMatrices.GetEndPtr());
       job.skeleton = pOzzSkeleton;
       job.Run();
     }
 
     ezMsgAnimationPoseUpdated msg;
-    msg.m_ModelTransforms = pPoseMatrices;
+    msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pPoseMatrices.GetPtr()), pPoseMatrices.GetCount());
     msg.m_pRootTransform = &pSkeleton->GetDescriptor().m_RootTransform;
     msg.m_pSkeleton = &pSkeleton->GetDescriptor().m_Skeleton;
 

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimPoseGenerator.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimPoseGenerator.cpp
@@ -472,7 +472,8 @@ void ezAnimPoseGenerator::ExecuteCmd(ezAnimPoseGeneratorCommandLocalToModelPose&
   }
 
   m_OutputPose = AcquireModelPoseTransforms(cmd.m_ModelPoseOutput);
-
+  // This cast is safe because m_OutputPose points to m_UsedModelTransforms which is 16 byte aligned.
+  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(m_OutputPose.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
   job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(m_OutputPose.GetPtr()), m_OutputPose.GetCount());
   job.skeleton = &m_pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
   EZ_ASSERT_DEBUG(job.Validate(), "");
@@ -569,6 +570,7 @@ void ezAnimPoseGenerator::ExecuteCmd(ezAnimPoseGeneratorCommandAimIK& cmd)
     job.from = (int)cmd.m_uiJointIdx;
     job.to = (int)cmd.m_uiRecalcModelPoseToJointIdx;
     job.input = ozz::span<const ozz::math::SoaTransform>(transform.GetPtr(), transform.GetCount());
+    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(m_OutputPose.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
     job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(m_OutputPose.GetPtr()), m_OutputPose.GetCount());
     job.skeleton = &m_pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
     EZ_ASSERT_DEBUG(job.Validate(), "");
@@ -653,6 +655,7 @@ void ezAnimPoseGenerator::ExecuteCmd(ezAnimPoseGeneratorCommandTwoBoneIK& cmd)
     job.from = (int)cmd.m_uiJointIdxStart;
     job.to = (int)cmd.m_uiRecalcModelPoseToJointIdx;
     job.input = ozz::span<const ozz::math::SoaTransform>(transform.GetPtr(), transform.GetCount());
+    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(m_OutputPose.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
     job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(m_OutputPose.GetPtr()), m_OutputPose.GetCount());
     job.skeleton = &m_pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
     EZ_ASSERT_DEBUG(job.Validate(), "");

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
@@ -237,7 +237,8 @@ void ezSkeletonPoseComponent::SendRestPose()
   ezMsgAnimationPoseUpdated msg;
   msg.m_pRootTransform = &desc.m_RootTransform;
   msg.m_pSkeleton = &skel;
-  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());;
+  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());
+  ;
 
   GetOwner()->SendMessage(msg);
 
@@ -311,7 +312,8 @@ void ezSkeletonPoseComponent::SendCustomPose()
   ezMsgAnimationPoseUpdated msg;
   msg.m_pRootTransform = &desc.m_RootTransform;
   msg.m_pSkeleton = &skel;
-  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());;
+  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());
+  ;
 
   GetOwner()->SendMessage(msg);
 

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
@@ -223,13 +223,13 @@ void ezSkeletonPoseComponent::SendRestPose()
   if (skel.GetJointCount() == 0)
     return;
 
-  ezHybridArray<ezMat4, 32> finalTransforms(ezFrameAllocator::GetCurrentAllocator());
-  finalTransforms.SetCountUninitialized(skel.GetJointCount());
+  ezArrayPtr<ozz::math::Float4x4> pFinalTransforms = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, skel.GetJointCount());
+  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pFinalTransforms.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
 
   {
     ozz::animation::LocalToModelJob job;
     job.input = skel.GetOzzSkeleton().joint_rest_poses();
-    job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(finalTransforms.GetData()), finalTransforms.GetCount());
+    job.output = ozz::span<ozz::math::Float4x4>(pFinalTransforms.GetPtr(), pFinalTransforms.GetEndPtr());
     job.skeleton = &skel.GetOzzSkeleton();
     job.Run();
   }
@@ -237,7 +237,7 @@ void ezSkeletonPoseComponent::SendRestPose()
   ezMsgAnimationPoseUpdated msg;
   msg.m_pRootTransform = &desc.m_RootTransform;
   msg.m_pSkeleton = &skel;
-  msg.m_ModelTransforms = finalTransforms;
+  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());;
 
   GetOwner()->SendMessage(msg);
 
@@ -254,12 +254,12 @@ void ezSkeletonPoseComponent::SendCustomPose()
   const auto& desc = pSkeleton->GetDescriptor();
   const auto& skel = desc.m_Skeleton;
 
-  ezHybridArray<ezMat4, 32> finalTransforms(ezFrameAllocator::GetCurrentAllocator());
-  finalTransforms.SetCountUninitialized(skel.GetJointCount());
+  ezArrayPtr<ozz::math::Float4x4> pFinalTransforms = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, skel.GetJointCount());
+  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pFinalTransforms.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
 
-  for (ezUInt32 i = 0; i < finalTransforms.GetCount(); ++i)
+  for (ezUInt32 i = 0; i < pFinalTransforms.GetCount(); ++i)
   {
-    finalTransforms[i].SetIdentity();
+    pFinalTransforms[i] = ozz::math::Float4x4::identity();
   }
 
   ozz::vector<ozz::math::SoaTransform> ozzLocalTransforms;
@@ -299,9 +299,10 @@ void ezSkeletonPoseComponent::SendCustomPose()
     reinterpret_cast<float*>(&q.w)[idx1] = boneRot.w;
   }
 
+  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pFinalTransforms.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
   ozz::animation::LocalToModelJob job;
   job.input = ozz::span<const ozz::math::SoaTransform>(ozzLocalTransforms.data(), ozzLocalTransforms.size());
-  job.output = ozz::span<ozz::math::Float4x4>(reinterpret_cast<ozz::math::Float4x4*>(finalTransforms.GetData()), finalTransforms.GetCount());
+  job.output = ozz::span<ozz::math::Float4x4>(pFinalTransforms.GetPtr(), pFinalTransforms.GetEndPtr());
   job.skeleton = &skel.GetOzzSkeleton();
   EZ_ASSERT_DEBUG(job.Validate(), "");
   job.Run();
@@ -310,7 +311,7 @@ void ezSkeletonPoseComponent::SendCustomPose()
   ezMsgAnimationPoseUpdated msg;
   msg.m_pRootTransform = &desc.m_RootTransform;
   msg.m_pSkeleton = &skel;
-  msg.m_ModelTransforms = finalTransforms;
+  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());;
 
   GetOwner()->SendMessage(msg);
 

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -323,7 +323,7 @@ namespace
         Accept(tokens, ref_uiCurToken, ezTokenType::Integer, &uiValueToken);
 
         ezInt32 iValue = 0;
-        if (ezConversionUtils::StringToInt(tokens[uiValueToken]->m_DataView.GetStartPointer(), iValue).Succeeded() && iValue >= 0)
+        if (ezConversionUtils::StringToInt(tokens[uiValueToken]->m_DataView, iValue).Succeeded() && iValue >= 0)
         {
           uiCurrentValue = iValue;
         }

--- a/Code/Engine/Texture/Image/Implementation/Image.cpp
+++ b/Code/Engine/Texture/Image/Implementation/Image.cpp
@@ -62,9 +62,9 @@ ezResult ezImageView::SaveTo(ezStringView sFileName) const
 
   ezStringView it = ezPathUtils::GetFileExtension(sFileName);
 
-  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetWriterFormat(it.GetStartPointer()))
+  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetWriterFormat(it))
   {
-    if (pFormat->WriteImage(writer, *this, it.GetStartPointer()) != EZ_SUCCESS)
+    if (pFormat->WriteImage(writer, *this, it) != EZ_SUCCESS)
     {
       ezLog::Error("Failed to write image file '{0}'", sFileName);
       return EZ_FAILURE;
@@ -260,8 +260,7 @@ void ezImage::ResetAndCopy(const ezImageView& other)
 ezResult ezImage::LoadFrom(ezStringView sFileName)
 {
   EZ_LOG_BLOCK("Loading Image", sFileName);
-
-  EZ_PROFILE_SCOPE(ezPathUtils::GetFileNameAndExtension(sFileName).GetStartPointer());
+  EZ_PROFILE_SCOPE(ezPathUtils::GetFileNameAndExtension(sFileName));
 
   ezFileReader reader;
   if (reader.Open(sFileName) == EZ_FAILURE)
@@ -272,9 +271,9 @@ ezResult ezImage::LoadFrom(ezStringView sFileName)
 
   ezStringView it = ezPathUtils::GetFileExtension(sFileName);
 
-  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it.GetStartPointer()))
+  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it))
   {
-    if (pFormat->ReadImage(reader, *this, it.GetStartPointer()) != EZ_SUCCESS)
+    if (pFormat->ReadImage(reader, *this, it) != EZ_SUCCESS)
     {
       ezLog::Warning("Failed to read image file '{0}'", ezArgSensitive(sFileName, "File"));
       return EZ_FAILURE;

--- a/Code/Engine/Texture/Image/Implementation/ImageFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageFileFormat.cpp
@@ -34,7 +34,7 @@ ezResult ezImageFileFormat::ReadImageHeader(ezStringView sFileName, ezImageHeade
 {
   EZ_LOG_BLOCK("Read Image Header", sFileName);
 
-  EZ_PROFILE_SCOPE(ezPathUtils::GetFileNameAndExtension(sFileName).GetStartPointer());
+  EZ_PROFILE_SCOPE(ezPathUtils::GetFileNameAndExtension(sFileName));
 
   ezFileReader reader;
   if (reader.Open(sFileName) == EZ_FAILURE)
@@ -45,9 +45,9 @@ ezResult ezImageFileFormat::ReadImageHeader(ezStringView sFileName, ezImageHeade
 
   ezStringView it = ezPathUtils::GetFileExtension(sFileName);
 
-  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it.GetStartPointer()))
+  if (const ezImageFileFormat* pFormat = ezImageFileFormat::GetReaderFormat(it))
   {
-    if (pFormat->ReadImageHeader(reader, ref_header, it.GetStartPointer()) != EZ_SUCCESS)
+    if (pFormat->ReadImageHeader(reader, ref_header, it) != EZ_SUCCESS)
     {
       ezLog::Warning("Failed to read image file '{0}'", ezArgSensitive(sFileName, "File"));
       return EZ_FAILURE;

--- a/Code/Engine/Utilities/FileFormats/Implementation/OBJLoader.cpp
+++ b/Code/Engine/Utilities/FileFormats/Implementation/OBJLoader.cpp
@@ -100,7 +100,7 @@ ezResult ezOBJLoader::LoadOBJ(const char* szFile, bool bIgnoreMaterials)
     if (sFirst.IsEqual_NoCase("v")) // line declares a vertex
     {
       ezVec3 v(0.0f);
-      ezConversionUtils::ExtractFloatsFromString(sLine.GetStartPointer(), 3, &v.x);
+      ezConversionUtils::ExtractFloatsFromString(sLine, 3, &v.x);
 
       m_Positions.PushBack(v);
     }
@@ -109,7 +109,7 @@ ezResult ezOBJLoader::LoadOBJ(const char* szFile, bool bIgnoreMaterials)
       bContainsTexCoords = true;
 
       ezVec3 v(0.0f);
-      ezConversionUtils::ExtractFloatsFromString(sLine.GetStartPointer(), 3, &v.x); // reads up to three texture-coordinates
+      ezConversionUtils::ExtractFloatsFromString(sLine, 3, &v.x); // reads up to three texture-coordinates
 
       m_TexCoords.PushBack(v);
     }
@@ -118,7 +118,7 @@ ezResult ezOBJLoader::LoadOBJ(const char* szFile, bool bIgnoreMaterials)
       bContainsNormals = true;
 
       ezVec3 v(0.0f);
-      ezConversionUtils::ExtractFloatsFromString(sLine.GetStartPointer(), 3, &v.x);
+      ezConversionUtils::ExtractFloatsFromString(sLine, 3, &v.x);
       v.Normalize(); // make sure normals are indeed normalized
 
       m_Normals.PushBack(v);
@@ -136,7 +136,7 @@ ezResult ezOBJLoader::LoadOBJ(const char* szFile, bool bIgnoreMaterials)
         ezInt32 id;
 
         // read the position index
-        if (ezConversionUtils::StringToInt(sLine.GetStartPointer(), id, &szCurPos).Failed())
+        if (ezConversionUtils::StringToInt(sLine, id, &szCurPos).Failed())
           break; // nothing found, face-declaration is finished
 
         sLine.SetStartPosition(szCurPos);
@@ -150,7 +150,7 @@ ezResult ezOBJLoader::LoadOBJ(const char* szFile, bool bIgnoreMaterials)
           if (!SkipSlash(sLine))
             break;
 
-          if (ezConversionUtils::StringToInt(sLine.GetStartPointer(), id, &szCurPos).Failed())
+          if (ezConversionUtils::StringToInt(sLine, id, &szCurPos).Failed())
             break;
 
           sLine.SetStartPosition(szCurPos);
@@ -164,7 +164,7 @@ ezResult ezOBJLoader::LoadOBJ(const char* szFile, bool bIgnoreMaterials)
           if (!SkipSlash(sLine))
             break;
 
-          if (ezConversionUtils::StringToInt(sLine.GetStartPointer(), id, &szCurPos).Failed())
+          if (ezConversionUtils::StringToInt(sLine, id, &szCurPos).Failed())
             break;
 
           sLine.SetStartPosition(szCurPos);
@@ -298,7 +298,7 @@ ezResult ezOBJLoader::LoadMTL(const char* szFile, const char* szMaterialBasePath
     else if (sFirst.IsEqual_NoCase("map_Kd"))
     {
       sTemp = szMaterialBasePath;
-      sTemp.AppendPath(sLine.GetStartPointer());
+      sTemp.AppendPath(sLine);
 
       m_Materials[sCurMatName].m_sDiffuseTexture = sTemp;
     }

--- a/Code/ThirdParty/ozz/animation/runtime/local_to_model_job.cc
+++ b/Code/ThirdParty/ozz/animation/runtime/local_to_model_job.cc
@@ -105,9 +105,7 @@ bool LocalToModelJob::Run() const {
       const math::Float4x4* parent_matrix =
           parent == Skeleton::kNoParent ? root_matrix : &output[parent];
 
-      // EZ Workaround for Visual Studio debug build compiler bug.
-      auto parent_matrix_cpy = *parent_matrix;
-      output[i] = parent_matrix_cpy * local_aos_matrices[i & 3];
+      output[i] = *parent_matrix * local_aos_matrices[i & 3];
     }
   }
   return true;

--- a/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
+++ b/Code/Tools/StaticLinkUtil/StaticLinkUtil.cpp
@@ -648,14 +648,14 @@ public:
     {
       if (sFile.HasExtension("h") || sFile.HasExtension("inl"))
       {
-        EZ_LOG_BLOCK("Header", sFile.GetFileNameAndExtension().GetStartPointer());
+        EZ_LOG_BLOCK("Header", sFile.GetFileNameAndExtension());
         FixFileContents(sFile);
         continue;
       }
 
       if (sFile.HasExtension("cpp"))
       {
-        EZ_LOG_BLOCK("Source", sFile.GetFileNameAndExtension().GetStartPointer());
+        EZ_LOG_BLOCK("Source", sFile.GetFileNameAndExtension());
         FixFileContents(sFile);
 
         InsertRefPoint(sFile);


### PR DESCRIPTION
* `ozz::math::Float4x4` needs to be aligned to 16 bytes so it is not safe to cast `ezMat4` to it as the later one is not 16 bytes aligned.
* Replaced all casts from `ezStringView` to `const char*` which ended up being put back into an `ezStringView`. Some of these produced invalid reads with a guarding allocator.
* Wrong brackets in AssetBrowerWidget.cpp. The old code was always true as `==` binds stronger than `?`.