### PR TITLE
Fix monitors in testing chambers main scene

### DIFF
--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
@@ -20,7 +20,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTonemapPass, 1, ezRTTIDefaultAllocator<ezTonem
     EZ_MEMBER_PROPERTY("Color", m_PinColorInput),
     EZ_MEMBER_PROPERTY("Bloom", m_PinBloomInput),
     EZ_MEMBER_PROPERTY("Output", m_PinOutput),
-    EZ_RESOURCE_MEMBER_PROPERTY("VignettingTexture", m_hVignettingTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D")),
+    EZ_RESOURCE_MEMBER_PROPERTY("VignettingTexture", m_hVignettingTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D"), new ezDefaultValueAttribute("White.color")),
     EZ_MEMBER_PROPERTY("MoodColor", m_MoodColor)->AddAttributes(new ezDefaultValueAttribute(ezColor::Orange)),
     EZ_MEMBER_PROPERTY("MoodStrength", m_fMoodStrength)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_MEMBER_PROPERTY("Saturation", m_fSaturation)->AddAttributes(new ezClampValueAttribute(0.0f, 2.0f), new ezDefaultValueAttribute(1.0f)),

--- a/Data/Base/RenderPipelines/RenderTargetLDR.ezRenderPipelineAsset
+++ b/Data/Base/RenderPipelines/RenderTargetLDR.ezRenderPipelineAsset
@@ -11,11 +11,17 @@ o
 		s %AssetType{"RenderPipeline"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{9340082855766888863,4792825339744186213}}
-		u4 %Hash{13816272085590592866}
+		u4 %Hash{10182853041871438110}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
-		VarArray %PackageDeps{}
-		VarArray %References{}
+		VarArray %PackageDeps
+		{
+			s{"White.color"}
+		}
+		VarArray %References
+		{
+			s{"White.color"}
+		}
 		s %Tags{""}
 	}
 }
@@ -117,13 +123,14 @@ o
 {
 	Uuid %id{u4{14015861933268748453,4832101727536707722}}
 	s %t{"ezDepthOnlyPass"}
-	u3 %v{1}
+	u3 %v{2}
 	p
 	{
 		b %Active{1}
 		Uuid %DepthStencil{u4{14034198369995003864,10700101904229972968}}
 		s %Name{"DepthPrePass"}
 		Vec2 %Node::Pos{f{0xE5700B44,0xE7B1ED43}}
+		b %RenderTransparentObjects{0}
 	}
 }
 o
@@ -241,7 +248,7 @@ o
 		Vec2 %Node::Pos{f{0x1636A444,0xE638E343}}
 		Uuid %Output{u4{7642371703623570691,6852461079880770907}}
 		f %Saturation{0x0000803F}
-		s %VignettingTexture{""}
+		s %VignettingTexture{"White.color"}
 	}
 }
 o
@@ -634,7 +641,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezDepthOnlyPass"}
-		u3 %TypeVersion{1}
+		u3 %TypeVersion{2}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Scenes/Main_data/Corridor.ezTypeScriptAsset
+++ b/Data/Samples/Testing Chambers/Scenes/Main_data/Corridor.ezTypeScriptAsset
@@ -21,10 +21,10 @@ o
 		s %AssetType{"TypeScript"}
 		VarArray %Dependencies
 		{
-			s{"Scenes/Corridor_data/Corridor.ts"}
+			s{"Scenes/Main_data/Corridor.ts"}
 		}
 		Uuid %DocumentID{u4{10704327468068905896,5280056722113657732}}
-		u4 %Hash{15961413987223120780}
+		u4 %Hash{16241725351445451133}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{6310228099224176475,4922193385981354705}}
@@ -33,7 +33,7 @@ o
 		VarArray %PackageDeps{}
 		VarArray %References
 		{
-			s{"Scenes/Corridor_data/Corridor.ts"}
+			s{"Scenes/Main_data/Corridor.ts"}
 		}
 		s %Tags{""}
 	}
@@ -51,7 +51,7 @@ o
 		VarArray %BoolParameters{}
 		VarArray %ColorParameters{}
 		VarArray %NumberParameters{}
-		s %ScriptFile{"Scenes/Corridor_data/Corridor.ts"}
+		s %ScriptFile{"Scenes/Main_data/Corridor.ts"}
 		VarArray %StringParameters{}
 		VarArray %Vec3Parameters{}
 	}


### PR DESCRIPTION
Fixes #1410
The vignette texture was not set, which is also the default for the tonemap pass. With the fallback resources the fallback color was changed to black instead of white (which is what DX11 produces when sampling unbound texture slots). I've changed the render pass / pipeline instead of messing with the fallback resources as these are not supposed to be sampled in any case.

Also fixed a wrong pass after the scene was renamed.