### PR TITLE
Assert that component deserialization is correct

### DIFF
--- a/Code/Engine/Core/WorldSerializer/WorldReader.h
+++ b/Code/Engine/Core/WorldSerializer/WorldReader.h
@@ -182,6 +182,7 @@ private:
   {
     const ezRTTI* m_pRtti = nullptr;
     ezUInt32 m_uiNumComponents = 0;
+    ezUInt32 m_uiComponentDataSize = 0;
   };
 
   ezDynamicArray<ComponentTypeInfo> m_ComponentTypes;
@@ -227,6 +228,7 @@ private:
 
     struct ComponentTypeState
     {
+      ezUInt64 m_uiDataReadOffset = 0;
       ezDynamicArray<ezComponentHandle> m_ComponentIndexToHandle;
     };
 


### PR DESCRIPTION
When component serialization and deserialization are out of sync, the world reader now detects this and asserts with information about the problematic component:

![image](https://github.com/user-attachments/assets/d01d998a-8499-45d6-aa1a-da8d56acfa84)
