### PR TITLE
Particle editor default value fixes

### DIFF
--- a/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
@@ -84,7 +84,7 @@ void ezQtCreateProjectDlg::UpdateUI()
     Next->setEnabled(!sFullPath.IsEmpty());
   }
 
-  switch (m_state)
+  switch (m_State)
   {
     case State::Basics:
       StackedPages->setCurrentIndex(0);
@@ -222,21 +222,21 @@ void ezQtCreateProjectDlg::on_ProjectName_textChanged(QString text)
 
 void ezQtCreateProjectDlg::on_Prev_clicked()
 {
-  switch (m_state)
+  switch (m_State)
   {
     case State::Templates:
-      m_state = State::Basics;
+      m_State = State::Basics;
       break;
 
     case State::Plugins:
-      m_state = State::Templates;
+      m_State = State::Templates;
       break;
 
     case State::Summary:
       if (m_sProjectTemplate.IsEmpty())
-        m_state = State::Plugins;
+        m_State = State::Plugins;
       else
-        m_state = State::Templates;
+        m_State = State::Templates;
       break;
 
     default:
@@ -248,10 +248,10 @@ void ezQtCreateProjectDlg::on_Prev_clicked()
 
 void ezQtCreateProjectDlg::on_Next_clicked()
 {
-  switch (m_state)
+  switch (m_State)
   {
     case State::Basics:
-      m_state = State::Templates;
+      m_State = State::Templates;
       break;
 
     case State::Templates:
@@ -259,20 +259,20 @@ void ezQtCreateProjectDlg::on_Next_clicked()
       m_sProjectTemplate = ProjectTemplates->currentItem()->data(Qt::UserRole).toString().toUtf8().data();
 
       if (m_sProjectTemplate.IsEmpty())
-        m_state = State::Plugins;
+        m_State = State::Plugins;
       else
-        m_state = State::Summary;
+        m_State = State::Summary;
 
       break;
     }
 
     case State::Plugins:
       Plugins->SyncStateToSet();
-      m_state = State::Summary;
+      m_State = State::Summary;
       break;
 
     case State::Summary:
-      m_state = State::Create;
+      m_State = State::Create;
       break;
     case State::Create:
       break;
@@ -280,7 +280,7 @@ void ezQtCreateProjectDlg::on_Next_clicked()
 
   UpdateUI();
 
-  if (m_state == State::Create)
+  if (m_State == State::Create)
   {
     CreateProject();
 

--- a/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
@@ -109,6 +109,9 @@ void ezQtCreateProjectDlg::UpdateUI()
       Prev->setVisible(true);
       Next->setText("Create");
       break;
+
+    case State::Create:
+      break;
   }
 }
 
@@ -230,12 +233,13 @@ void ezQtCreateProjectDlg::on_Prev_clicked()
       break;
 
     case State::Summary:
-
       if (m_sProjectTemplate.IsEmpty())
         m_state = State::Plugins;
       else
         m_state = State::Templates;
+      break;
 
+    default:
       break;
   }
 
@@ -269,6 +273,8 @@ void ezQtCreateProjectDlg::on_Next_clicked()
 
     case State::Summary:
       m_state = State::Create;
+      break;
+    case State::Create:
       break;
   }
 

--- a/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.moc.h
@@ -41,7 +41,7 @@ private:
     Create,
   };
 
-  State m_state = State::Basics;
+  State m_State = State::Basics;
   ezString m_sProjectTemplate;
   ezPluginBundleSet m_LocalPluginSet;
 };

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -203,6 +203,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezCompilerPreferences>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezCodeEditorPreferences>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezImageSliderUiAttribute>());
+    ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezRttiTypeStringAttribute>());
 
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezSphereManipulatorAttribute>());
     ezManipulatorAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezCapsuleManipulatorAttribute>());

--- a/Code/Engine/Core/Scripting/Implementation/ScriptCoroutine.cpp
+++ b/Code/Engine/Core/Scripting/Implementation/ScriptCoroutine.cpp
@@ -115,6 +115,11 @@ ezScriptCoroutineRTTI::~ezScriptCoroutineRTTI()
 {
   UnregisterType();
   m_sTypeName = nullptr;
+
+  // RTTI base class will try to delete the contents of these arrays under the assumption that they were created during static init. Dynamically created types must ensure that these arrays are cleared out before the base class is executed.
+  m_Properties.Clear();
+  m_Functions.Clear();
+  m_Attributes.Clear();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/Core/Scripting/Implementation/ScriptRTTI.cpp
+++ b/Code/Engine/Core/Scripting/Implementation/ScriptRTTI.cpp
@@ -42,6 +42,11 @@ ezScriptRTTI::~ezScriptRTTI()
 {
   UnregisterType();
   m_sTypeName = nullptr;
+
+  // RTTI base class will try to delete the contents of these arrays under the assumption that they were created during static init. Dynamically created types must ensure that these arrays are cleared out before the base class is executed.
+  m_Properties.Clear();
+  m_Functions.Clear();
+  m_Attributes.Clear();
 }
 
 const ezAbstractFunctionProperty* ezScriptRTTI::GetFunctionByIndex(ezUInt32 uiIndex) const

--- a/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.cpp
@@ -11,4 +11,3 @@ ezAbstractProperty ::~ezAbstractProperty()
     delete pAttrib;
   }
 }
-

--- a/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.cpp
@@ -1,0 +1,14 @@
+#include <Foundation/FoundationPCH.h>
+
+#include <Foundation/Reflection/Implementation/AbstractProperty.h>
+#include <Foundation/Reflection/Implementation/PropertyAttributes.h>
+
+ezAbstractProperty ::~ezAbstractProperty()
+{
+  // To ensure unloading plugins does not leak any heap allocated attributes etc, we need to properly clean up attributes. The assumption is that anything that is deleted here was created using global 'new' when declaring the reflection information inside EZ_BEGIN_PROPERTIES. Thus, any phantom property must ensure this array is cleared before this destructor is called.
+  for (auto pAttrib : m_Attributes)
+  {
+    delete pAttrib;
+  }
+}
+

--- a/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.h
@@ -152,7 +152,7 @@ public:
   /// \brief The constructor must get the name of the property. The string must be a compile-time constant.
   ezAbstractProperty(const char* szPropertyName) { m_szPropertyName = szPropertyName; }
 
-  virtual ~ezAbstractProperty() = default;
+  virtual ~ezAbstractProperty();
 
   /// \brief Returns the name of the property.
   const char* GetPropertyName() const { return m_szPropertyName; }

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -1072,6 +1072,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 ezFunctionArgumentAttributes::ezFunctionArgumentAttributes(ezUInt32 uiArgIndex, const ezPropertyAttribute* pAttribute1, const ezPropertyAttribute* pAttribute2 /*= nullptr*/, const ezPropertyAttribute* pAttribute3 /*= nullptr*/, const ezPropertyAttribute* pAttribute4 /*= nullptr*/)
   : m_uiArgIndex(uiArgIndex)
 {
+  m_bUsesGlobalNew = true;
   {
     if (pAttribute1 == nullptr)
       return;
@@ -1103,7 +1104,14 @@ ezFunctionArgumentAttributes::~ezFunctionArgumentAttributes()
   for (auto pAttribute : m_ArgAttributes)
   {
     auto pAttributeNonConst = const_cast<ezPropertyAttribute*>(pAttribute);
-    EZ_DEFAULT_DELETE(pAttributeNonConst);
+    if (m_bUsesGlobalNew)
+    {
+      delete pAttributeNonConst;
+    }
+    else
+    {
+      EZ_DEFAULT_DELETE(pAttributeNonConst);
+    }
   }
 }
 

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -1024,6 +1024,8 @@ class EZ_FOUNDATION_DLL ezFunctionArgumentAttributes : public ezPropertyAttribut
 
 private:
   ezUInt32 m_uiArgIndex = 0;
+  // Not pretty, but the values in the array are either created using 'new' when using this class as a reflection decoration, or created using 'EZ_DEFAULT_NEW' when serialized and sent to the editor so in the dtor we need to know where these came from.
+  bool m_bUsesGlobalNew = false;
   ezHybridArray<const ezPropertyAttribute*, 4> m_ArgAttributes;
 };
 

--- a/Code/Engine/Foundation/Types/VarianceTypes.h
+++ b/Code/Engine/Foundation/Types/VarianceTypes.h
@@ -31,10 +31,10 @@ struct EZ_FOUNDATION_DLL ezVarianceTypeFloat : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
   ezVarianceTypeFloat() = default;
-  ezVarianceTypeFloat(float value, float variance = 0.0f)
+  ezVarianceTypeFloat(float value, float fVariance = 0.0f)
     : m_Value(value)
   {
-    m_fVariance = variance;
+    m_fVariance = fVariance;
   }
 
   bool operator==(const ezVarianceTypeFloat& rhs) const
@@ -56,10 +56,10 @@ struct EZ_FOUNDATION_DLL ezVarianceTypeTime : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
   ezVarianceTypeTime() = default;
-  ezVarianceTypeTime(ezTime value, float variance = 0.0f)
+  ezVarianceTypeTime(ezTime value, float fVariance = 0.0f)
     : m_Value(value)
   {
-    m_fVariance = variance;
+    m_fVariance = fVariance;
   }
 
   bool operator==(const ezVarianceTypeTime& rhs) const
@@ -81,10 +81,10 @@ struct EZ_FOUNDATION_DLL ezVarianceTypeAngle : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
   ezVarianceTypeAngle() = default;
-  ezVarianceTypeAngle(ezAngle value, float variance = 0.0f)
+  ezVarianceTypeAngle(ezAngle value, float fVariance = 0.0f)
     : m_Value(value)
   {
-    m_fVariance = variance;
+    m_fVariance = fVariance;
   }
 
   bool operator==(const ezVarianceTypeAngle& rhs) const

--- a/Code/Engine/Foundation/Types/VarianceTypes.h
+++ b/Code/Engine/Foundation/Types/VarianceTypes.h
@@ -30,6 +30,9 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_FOUNDATION_DLL, ezVarianceTypeBase);
 struct EZ_FOUNDATION_DLL ezVarianceTypeFloat : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
+  ezVarianceTypeFloat() = default;
+  ezVarianceTypeFloat(float value, float variance = 0.0f) : m_Value(value) {m_fVariance = variance; }
+
   bool operator==(const ezVarianceTypeFloat& rhs) const
   {
     return m_fVariance == rhs.m_fVariance && m_Value == rhs.m_Value;
@@ -48,6 +51,9 @@ EZ_DECLARE_CUSTOM_VARIANT_TYPE(ezVarianceTypeFloat);
 struct EZ_FOUNDATION_DLL ezVarianceTypeTime : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
+  ezVarianceTypeTime() = default;
+  ezVarianceTypeTime(ezTime value, float variance = 0.0f) : m_Value(value) {m_fVariance = variance; }
+
   bool operator==(const ezVarianceTypeTime& rhs) const
   {
     return m_fVariance == rhs.m_fVariance && m_Value == rhs.m_Value;
@@ -66,6 +72,9 @@ EZ_DECLARE_CUSTOM_VARIANT_TYPE(ezVarianceTypeTime);
 struct EZ_FOUNDATION_DLL ezVarianceTypeAngle : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
+  ezVarianceTypeAngle() = default;
+  ezVarianceTypeAngle(ezAngle value, float variance = 0.0f) : m_Value(value) {m_fVariance = variance; }
+
   bool operator==(const ezVarianceTypeAngle& rhs) const
   {
     return m_fVariance == rhs.m_fVariance && m_Value == rhs.m_Value;

--- a/Code/Engine/Foundation/Types/VarianceTypes.h
+++ b/Code/Engine/Foundation/Types/VarianceTypes.h
@@ -31,7 +31,11 @@ struct EZ_FOUNDATION_DLL ezVarianceTypeFloat : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
   ezVarianceTypeFloat() = default;
-  ezVarianceTypeFloat(float value, float variance = 0.0f) : m_Value(value) {m_fVariance = variance; }
+  ezVarianceTypeFloat(float value, float variance = 0.0f)
+    : m_Value(value)
+  {
+    m_fVariance = variance;
+  }
 
   bool operator==(const ezVarianceTypeFloat& rhs) const
   {
@@ -52,7 +56,11 @@ struct EZ_FOUNDATION_DLL ezVarianceTypeTime : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
   ezVarianceTypeTime() = default;
-  ezVarianceTypeTime(ezTime value, float variance = 0.0f) : m_Value(value) {m_fVariance = variance; }
+  ezVarianceTypeTime(ezTime value, float variance = 0.0f)
+    : m_Value(value)
+  {
+    m_fVariance = variance;
+  }
 
   bool operator==(const ezVarianceTypeTime& rhs) const
   {
@@ -73,7 +81,11 @@ struct EZ_FOUNDATION_DLL ezVarianceTypeAngle : public ezVarianceTypeBase
 {
   EZ_DECLARE_POD_TYPE();
   ezVarianceTypeAngle() = default;
-  ezVarianceTypeAngle(ezAngle value, float variance = 0.0f) : m_Value(value) {m_fVariance = variance; }
+  ezVarianceTypeAngle(ezAngle value, float variance = 0.0f)
+    : m_Value(value)
+  {
+    m_fVariance = variance;
+  }
 
   bool operator==(const ezVarianceTypeAngle& rhs) const
   {

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomSize.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomSize.cpp
@@ -15,7 +15,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleInitializerFactory_RandomSize, 2, ezRT
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("Size", m_Size)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_MEMBER_PROPERTY("Size", m_Size)->AddAttributes(new ezDefaultValueAttribute(ezVarianceTypeFloat(1.0f)), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_RESOURCE_MEMBER_PROPERTY("SizeCurve", m_hCurve)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_Curve")),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/ParticlePlugin/System/ParticleSystemDescriptor.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/System/ParticleSystemDescriptor.cpp
@@ -18,7 +18,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleSystemDescriptor, 2, ezRTTIDefaultAllo
   {
     EZ_MEMBER_PROPERTY("Name", m_sName),
     EZ_MEMBER_PROPERTY("Visible", m_bVisible)->AddAttributes(new ezDefaultValueAttribute(true)),
-    EZ_MEMBER_PROPERTY("LifeTime", m_LifeTime)->AddAttributes(new ezDefaultValueAttribute(ezTime::MakeFromSeconds(2)), new ezClampValueAttribute(ezTime::MakeFromSeconds(0.0), ezVariant())),
+    EZ_MEMBER_PROPERTY("LifeTime", m_LifeTime)->AddAttributes(new ezDefaultValueAttribute(ezVarianceTypeTime(ezTime::MakeFromSeconds(2))), new ezClampValueAttribute(ezTime::MakeFromSeconds(0.0), ezVariant())),
     EZ_MEMBER_PROPERTY("LifeScaleParam", m_sLifeScaleParameter),
     EZ_MEMBER_PROPERTY("OnDeathEvent", m_sOnDeathEvent),
     EZ_ARRAY_MEMBER_PROPERTY("Emitters", m_EmitterFactories)->AddFlags(ezPropertyFlags::PointerOwner)->AddAttributes(new ezMaxArraySizeAttribute(1)),

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomProperty.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomProperty.cpp
@@ -23,6 +23,7 @@ ezPhantomConstantProperty::~ezPhantomConstantProperty()
   {
     pAttr->GetDynamicRTTI()->GetAllocator()->Deallocate(const_cast<ezPropertyAttribute*>(pAttr));
   }
+  m_Attributes.Clear();
 }
 
 const ezRTTI* ezPhantomConstantProperty::GetSpecificType() const
@@ -56,6 +57,7 @@ ezPhantomMemberProperty::~ezPhantomMemberProperty()
   {
     pAttr->GetDynamicRTTI()->GetAllocator()->Deallocate(const_cast<ezPropertyAttribute*>(pAttr));
   }
+  m_Attributes.Clear();
 }
 
 const ezRTTI* ezPhantomMemberProperty::GetSpecificType() const
@@ -88,6 +90,7 @@ ezPhantomFunctionProperty::~ezPhantomFunctionProperty()
   {
     pAttr->GetDynamicRTTI()->GetAllocator()->Deallocate(const_cast<ezPropertyAttribute*>(pAttr));
   }
+  m_Attributes.Clear();
 }
 
 ezFunctionType::Enum ezPhantomFunctionProperty::GetFunctionType() const
@@ -144,6 +147,7 @@ ezPhantomArrayProperty::~ezPhantomArrayProperty()
   {
     pAttr->GetDynamicRTTI()->GetAllocator()->Deallocate(const_cast<ezPropertyAttribute*>(pAttr));
   }
+  m_Attributes.Clear();
 }
 
 const ezRTTI* ezPhantomArrayProperty::GetSpecificType() const
@@ -170,6 +174,7 @@ ezPhantomSetProperty::~ezPhantomSetProperty()
   {
     pAttr->GetDynamicRTTI()->GetAllocator()->Deallocate(const_cast<ezPropertyAttribute*>(pAttr));
   }
+  m_Attributes.Clear();
 }
 
 const ezRTTI* ezPhantomSetProperty::GetSpecificType() const
@@ -196,6 +201,7 @@ ezPhantomMapProperty::~ezPhantomMapProperty()
   {
     pAttr->GetDynamicRTTI()->GetAllocator()->Deallocate(const_cast<ezPropertyAttribute*>(pAttr));
   }
+  m_Attributes.Clear();
 }
 
 const ezRTTI* ezPhantomMapProperty::GetSpecificType() const

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/PhantomRtti.cpp
@@ -28,15 +28,23 @@ ezPhantomRTTI::~ezPhantomRTTI()
   {
     EZ_DEFAULT_DELETE(pProp);
   }
+  m_PropertiesStorage.Clear();
+  m_Properties.Clear();
+
   for (auto pFunc : m_FunctionsStorage)
   {
     EZ_DEFAULT_DELETE(pFunc);
   }
+  m_FunctionsStorage.Clear();
+  m_Functions.Clear();
+
   for (auto pAttrib : m_AttributesStorage)
   {
     auto pAttribNonConst = const_cast<ezPropertyAttribute*>(pAttrib);
     EZ_DEFAULT_DELETE(pAttribNonConst);
   }
+  m_AttributesStorage.Clear();
+  m_Attributes.Clear();
 }
 
 void ezPhantomRTTI::SetProperties(ezDynamicArray<ezReflectedPropertyDescriptor>& properties)

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageManager.cpp
@@ -360,7 +360,7 @@ void ezReflectedTypeStorageManager::PluginEventHandler(const ezPluginEvent& Even
   {
     case ezPluginEvent::BeforeUnloading:
     {
-      for (auto it = s_ReflectedTypeToStorageMapping.GetIterator(); it.IsValid(); )
+      for (auto it = s_ReflectedTypeToStorageMapping.GetIterator(); it.IsValid();)
       {
         if (it.Key()->GetPluginName() == EventData.m_sPluginBinary)
         {

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/ReflectedTypeStorageManager.cpp
@@ -243,12 +243,14 @@ void ezReflectedTypeStorageManager::ReflectedTypeStorageMapping::AddPropertyToIn
 
 void ezReflectedTypeStorageManager::Startup()
 {
+  ezPlugin::Events().AddEventHandler(ezReflectedTypeStorageManager::PluginEventHandler);
   ezPhantomRttiManager::s_Events.AddEventHandler(TypeEventHandler);
 }
 
 void ezReflectedTypeStorageManager::Shutdown()
 {
   ezPhantomRttiManager::s_Events.RemoveEventHandler(TypeEventHandler);
+  ezPlugin::Events().RemoveEventHandler(ezReflectedTypeStorageManager::PluginEventHandler);
 
   for (auto it = s_ReflectedTypeToStorageMapping.GetIterator(); it.IsValid(); ++it)
   {
@@ -349,5 +351,33 @@ void ezReflectedTypeStorageManager::TypeEventHandler(const ezPhantomRttiManagerE
       EZ_DEFAULT_DELETE(pMapping);
     }
     break;
+  }
+}
+
+void ezReflectedTypeStorageManager::PluginEventHandler(const ezPluginEvent& EventData)
+{
+  switch (EventData.m_EventType)
+  {
+    case ezPluginEvent::BeforeUnloading:
+    {
+      for (auto it = s_ReflectedTypeToStorageMapping.GetIterator(); it.IsValid(); )
+      {
+        if (it.Key()->GetPluginName() == EventData.m_sPluginBinary)
+        {
+          ReflectedTypeStorageMapping* pMapping = it.Value();
+          EZ_ASSERT_DEV(pMapping->m_Instances.IsEmpty(), "A type was removed which still has instances using the type!");
+          it = s_ReflectedTypeToStorageMapping.Remove(it);
+          EZ_DEFAULT_DELETE(pMapping);
+        }
+        else
+        {
+          ++it;
+        }
+      }
+    }
+    break;
+
+    default:
+      break;
   }
 }

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageManager.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/ReflectedTypeStorageManager.h
@@ -63,6 +63,7 @@ private:
 
   static ReflectedTypeStorageMapping* GetTypeStorageMapping(const ezRTTI* pType);
   static void TypeEventHandler(const ezPhantomRttiManagerEvent& e);
+  static void PluginEventHandler(const ezPluginEvent& EventData);
 
 private:
   static ezMap<const ezRTTI*, ReflectedTypeStorageMapping*> s_ReflectedTypeToStorageMapping;

--- a/Code/UnitTests/EditorTest/CMakeLists.txt
+++ b/Code/UnitTests/EditorTest/CMakeLists.txt
@@ -1,7 +1,6 @@
 ez_cmake_init()
 
 ez_requires_editor()
-ez_requires(EZ_CMAKE_PLATFORM_WINDOWS)
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
@@ -17,7 +16,6 @@ target_link_libraries(${PROJECT_NAME}
   TestFramework
   EditorFramework
   EditorEngineProcessFramework
-  RendererDX11
   EditorPluginScene
 )
 

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -21,6 +21,7 @@ const char* ezEditorTestMisc::GetTestName() const
 void ezEditorTestMisc::SetupSubTests()
 {
   AddSubTest("GameObject References", SubTests::GameObjectReferences);
+  AddSubTest("Default Values", SubTests::DefaultValues);
 }
 
 ezResult ezEditorTestMisc::InitializeTest()
@@ -50,72 +51,14 @@ ezResult ezEditorTestMisc::DeInitializeTest()
 
 ezTestAppRun ezEditorTestMisc::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
 {
-  if (iIdentifier == SubTests::GameObjectReferences)
+  switch (iIdentifier)
   {
-    m_pDocument = SUPER::OpenDocument("Scenes/GameObjectReferences.ezScene");
+    case SubTests::GameObjectReferences:
+      return GameObjectReferencesTest();
 
-    if (!EZ_TEST_BOOL(m_pDocument != nullptr))
-      return ezTestAppRun::Quit;
-
-    EZ_ANALYSIS_ASSUME(m_pDocument != nullptr);
-    ezAssetCurator::GetSingleton()->TransformAsset(m_pDocument->GetGuid(), ezTransformFlags::Default);
-
-    ezQtEngineDocumentWindow* pWindow = qobject_cast<ezQtEngineDocumentWindow*>(ezQtDocumentWindow::FindWindowByDocument(m_pDocument));
-
-    if (!EZ_TEST_BOOL(pWindow != nullptr))
-      return ezTestAppRun::Quit;
-
-    EZ_ANALYSIS_ASSUME(pWindow != nullptr);
-    auto viewWidgets = pWindow->GetViewWidgets();
-
-    if (!EZ_TEST_BOOL(!viewWidgets.IsEmpty()))
-      return ezTestAppRun::Quit;
-
-    ezQtEngineViewWidget::InteractionContext ctxt;
-    ctxt.m_pLastHoveredViewWidget = viewWidgets[0];
-    ezQtEngineViewWidget::SetInteractionContext(ctxt);
-
-    viewWidgets[0]->m_pViewConfig->m_RenderMode = ezViewRenderMode::Default;
-    viewWidgets[0]->m_pViewConfig->m_Perspective = ezSceneViewPerspective::Perspective;
-    viewWidgets[0]->m_pViewConfig->ApplyPerspectiveSetting(90.0f);
-
-    ExecuteDocumentAction("Scene.Camera.JumpTo.0", m_pDocument, true);
-
-    for (int i = 0; i < 10; ++i)
-    {
-      ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
-      ProcessEvents();
-    }
-
-    EZ_TEST_BOOL(CaptureImage(pWindow, "GoRef").Succeeded());
-
-    EZ_TEST_IMAGE(1, 100);
-
-    // Move everything to the layer and repeat the test.
-    ezScene2Document* pScene = ezDynamicCast<ezScene2Document*>(m_pDocument);
-    ezHybridArray<ezUuid, 2> layerGuids;
-    pScene->GetAllLayers(layerGuids);
-    EZ_TEST_INT(layerGuids.GetCount(), 2);
-    ezUuid layerGuid = layerGuids[0] == pScene->GetGuid() ? layerGuids[1] : layerGuids[0];
-
-    auto pAccessor = pScene->GetObjectAccessor();
-    auto pRoot = pScene->GetObjectManager()->GetRootObject();
-    ezHybridArray<ezVariant, 16> values;
-    pAccessor->GetValues(pRoot, "Children", values).AssertSuccess();
-
-    ezDeque<const ezDocumentObject*> assets;
-    for (auto& value : values)
-    {
-      assets.PushBack(pAccessor->GetObject(value.Get<ezUuid>()));
-    }
-    ezDeque<const ezDocumentObject*> newObjects;
-    MoveObjectsToLayer(pScene, assets, layerGuid, newObjects);
-
-    EZ_TEST_BOOL(CaptureImage(pWindow, "GoRef").Succeeded());
-
-    EZ_TEST_IMAGE(1, 100);
+    case SubTests::DefaultValues:
+      return DefaultValuesTest();
   }
-
 
   // const auto& allDesc = ezDocumentManager::GetAllDocumentDescriptors();
   // for (auto* pDesc : allDesc)
@@ -158,4 +101,166 @@ ezResult ezEditorTestMisc::DeInitializeSubTest(ezInt32 iIdentifier)
 {
   ezDocumentManager::CloseAllDocuments();
   return EZ_SUCCESS;
+}
+
+ezTestAppRun ezEditorTestMisc::GameObjectReferencesTest()
+{
+  m_pDocument = SUPER::OpenDocument("Scenes/GameObjectReferences.ezScene");
+
+  if (!EZ_TEST_BOOL(m_pDocument != nullptr))
+    return ezTestAppRun::Quit;
+
+  EZ_ANALYSIS_ASSUME(m_pDocument != nullptr);
+  ezAssetCurator::GetSingleton()->TransformAsset(m_pDocument->GetGuid(), ezTransformFlags::Default);
+
+  ezQtEngineDocumentWindow* pWindow = qobject_cast<ezQtEngineDocumentWindow*>(ezQtDocumentWindow::FindWindowByDocument(m_pDocument));
+
+  if (!EZ_TEST_BOOL(pWindow != nullptr))
+    return ezTestAppRun::Quit;
+
+  EZ_ANALYSIS_ASSUME(pWindow != nullptr);
+  auto viewWidgets = pWindow->GetViewWidgets();
+
+  if (!EZ_TEST_BOOL(!viewWidgets.IsEmpty()))
+    return ezTestAppRun::Quit;
+
+  ezQtEngineViewWidget::InteractionContext ctxt;
+  ctxt.m_pLastHoveredViewWidget = viewWidgets[0];
+  ezQtEngineViewWidget::SetInteractionContext(ctxt);
+
+  viewWidgets[0]->m_pViewConfig->m_RenderMode = ezViewRenderMode::Default;
+  viewWidgets[0]->m_pViewConfig->m_Perspective = ezSceneViewPerspective::Perspective;
+  viewWidgets[0]->m_pViewConfig->ApplyPerspectiveSetting(90.0f);
+
+  ExecuteDocumentAction("Scene.Camera.JumpTo.0", m_pDocument, true);
+
+  for (int i = 0; i < 10; ++i)
+  {
+    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+    ProcessEvents();
+  }
+
+  EZ_TEST_BOOL(CaptureImage(pWindow, "GoRef").Succeeded());
+
+  EZ_TEST_IMAGE(1, 100);
+
+  // Move everything to the layer and repeat the test.
+  ezScene2Document* pScene = ezDynamicCast<ezScene2Document*>(m_pDocument);
+  ezHybridArray<ezUuid, 2> layerGuids;
+  pScene->GetAllLayers(layerGuids);
+  EZ_TEST_INT(layerGuids.GetCount(), 2);
+  ezUuid layerGuid = layerGuids[0] == pScene->GetGuid() ? layerGuids[1] : layerGuids[0];
+
+  auto pAccessor = pScene->GetObjectAccessor();
+  auto pRoot = pScene->GetObjectManager()->GetRootObject();
+  ezHybridArray<ezVariant, 16> values;
+  pAccessor->GetValues(pRoot, "Children", values).AssertSuccess();
+
+  ezDeque<const ezDocumentObject*> assets;
+  for (auto& value : values)
+  {
+    assets.PushBack(pAccessor->GetObject(value.Get<ezUuid>()));
+  }
+  ezDeque<const ezDocumentObject*> newObjects;
+  MoveObjectsToLayer(pScene, assets, layerGuid, newObjects);
+
+  EZ_TEST_BOOL(CaptureImage(pWindow, "GoRef").Succeeded());
+
+  EZ_TEST_IMAGE(1, 100);
+
+  return ezTestAppRun::Quit;
+}
+
+bool CheckDefaultValue(const ezAbstractProperty* pProperty, const ezDefaultValueAttribute* pAttrib)
+{
+  ezVariant defaultValue = pAttrib->GetValue();
+
+  const bool isValueType = ezReflectionUtils::IsValueType(pProperty);
+  const ezVariantType::Enum type = pProperty->GetFlags().IsSet(ezPropertyFlags::Pointer) || (pProperty->GetFlags().IsSet(ezPropertyFlags::Class) && !isValueType) ? ezVariantType::Uuid : pProperty->GetSpecificType()->GetVariantType();
+
+  switch (pProperty->GetCategory())
+  {
+    case ezPropertyCategory::Member:
+    {
+      if (isValueType)
+      {
+        if (pProperty->GetSpecificType() == ezGetStaticRTTI<ezVariant>())
+          return true;
+        return pAttrib->GetValue().CanConvertTo(type);
+      }
+      else if (pProperty->GetSpecificType()->GetTypeFlags().IsAnySet(ezTypeFlags::IsEnum | ezTypeFlags::Bitflags))
+      {
+        return pAttrib->GetValue().CanConvertTo(ezVariantType::Int64);
+      }
+      else // Class
+      {
+        return false;
+      }
+    }
+    break;
+    case ezPropertyCategory::Array:
+    case ezPropertyCategory::Set:
+    {
+      if (!isValueType)
+        return true;
+
+      if (!pAttrib->GetValue().IsA<ezVariantArray>())
+        return false;
+
+      const auto& defaultArray = pAttrib->GetValue().Get<ezVariantArray>();
+      for (ezUInt32 i = 0; i < defaultArray.GetCount(); ++i)
+      {
+        const ezVariant& defaultSubValue = defaultArray[i];
+        if (pProperty->GetSpecificType() == ezGetStaticRTTI<ezVariant>())
+          continue;
+        if (!defaultSubValue.CanConvertTo(type))
+          return false;
+      }
+      return true;
+    }
+    break;
+    case ezPropertyCategory::Map:
+    {
+      if (isValueType)
+        return true;
+
+      if (pAttrib->GetValue().IsA<ezVariantDictionary>())
+        return false;
+
+      const auto& defaultDict = pAttrib->GetValue().Get<ezVariantDictionary>();
+      for (auto it = defaultDict.GetIterator(); it.IsValid(); ++it)
+      {
+        const ezVariant& defaultSubValue = it.Value();
+        if (pProperty->GetSpecificType() == ezGetStaticRTTI<ezVariant>())
+          continue;
+        if (!defaultSubValue.CanConvertTo(type))
+          return false;
+      }
+      return true;
+    }
+    break;
+    default:
+      break;
+  }
+  return true;
+}
+
+ezTestAppRun ezEditorTestMisc::DefaultValuesTest()
+{
+  ezRTTI::ForEachType([&](const ezRTTI* pRtti)
+    {
+      ezArrayPtr<const ezAbstractProperty* const> props = pRtti->GetProperties();
+      for (const ezAbstractProperty* pProperty : props)
+      {
+        const ezDefaultValueAttribute* pAttrib = pProperty->GetAttributeByType<ezDefaultValueAttribute>();
+        if (!pAttrib)
+          return;
+
+        if (!CheckDefaultValue(pProperty, pAttrib))
+        {
+          ezLog::Error("Invalid default value property! Type: {}, Property: {}, PropertyType: {}, DefaultValueType: {}", pRtti->GetTypeName(), pProperty->GetPropertyName(), pProperty->GetSpecificType()->GetTypeName(), pAttrib->GetValue().GetReflectedType()->GetTypeName());
+        }
+      } });
+
+  return ezTestAppRun::Quit;
 }

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -46,6 +46,8 @@ ezResult ezEditorTestMisc::DeInitializeTest()
   if (SUPER::DeInitializeTest().Failed())
     return EZ_FAILURE;
 
+  ezMemoryTracker::DumpMemoryLeaks();
+
   return EZ_SUCCESS;
 }
 
@@ -142,7 +144,7 @@ ezTestAppRun ezEditorTestMisc::GameObjectReferencesTest()
 
   EZ_TEST_BOOL(CaptureImage(pWindow, "GoRef").Succeeded());
 
-  EZ_TEST_IMAGE(1, 100);
+  EZ_TEST_LINE_IMAGE(1, 100);
 
   // Move everything to the layer and repeat the test.
   ezScene2Document* pScene = ezDynamicCast<ezScene2Document*>(m_pDocument);
@@ -166,7 +168,7 @@ ezTestAppRun ezEditorTestMisc::GameObjectReferencesTest()
 
   EZ_TEST_BOOL(CaptureImage(pWindow, "GoRef").Succeeded());
 
-  EZ_TEST_IMAGE(1, 100);
+  EZ_TEST_LINE_IMAGE(1, 100);
 
   return ezTestAppRun::Quit;
 }

--- a/Code/UnitTests/EditorTest/Misc/Misc.h
+++ b/Code/UnitTests/EditorTest/Misc/Misc.h
@@ -17,12 +17,16 @@ private:
   enum SubTests
   {
     GameObjectReferences,
+    DefaultValues,
   };
 
   virtual void SetupSubTests() override;
   virtual ezResult InitializeTest() override;
   virtual ezResult DeInitializeTest() override;
   virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+
+  ezTestAppRun GameObjectReferencesTest();
+  ezTestAppRun DefaultValuesTest();
 
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;

--- a/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
@@ -1140,7 +1140,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
     ezUInt64 uiHash = v.ComputeHash(0);
     EZ_TEST_INT(uiHash, 8527525522777555267ul);
 
-    ezVarianceTypeAngle* pTypedAngle = EZ_DEFAULT_NEW(ezVarianceTypeAngle, ezAngle::MakeFromRadian(1.57079637f), 0.1);
+    ezVarianceTypeAngle* pTypedAngle = EZ_DEFAULT_NEW(ezVarianceTypeAngle, ezAngle::MakeFromRadian(1.57079637f), 0.1f);
     ezVariant copy;
     copy.CopyTypedObject(pTypedAngle, ezGetStaticRTTI<ezVarianceTypeAngle>());
     ezVariant move;

--- a/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
+++ b/Code/UnitTests/FoundationTest/Basics/Types/VariantTest.cpp
@@ -1116,8 +1116,8 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezTypedObject inline")
   {
     // ezAngle::MakeFromDegree(90.0f) was replaced with radian as release builds generate a different float then debug.
-    ezVarianceTypeAngle value = {0.1f, ezAngle::MakeFromRadian(1.57079637f)};
-    ezVarianceTypeAngle value2 = {0.2f, ezAngle::MakeFromRadian(1.57079637f)};
+    ezVarianceTypeAngle value(ezAngle::MakeFromRadian(1.57079637f), 0.1f);
+    ezVarianceTypeAngle value2(ezAngle::MakeFromRadian(1.57079637f), 0.2f);
 
     ezVariant v(value);
     TestVariant<ezVarianceTypeAngle>(v, ezVariantType::TypedObject);
@@ -1140,7 +1140,7 @@ EZ_CREATE_SIMPLE_TEST(Basics, Variant)
     ezUInt64 uiHash = v.ComputeHash(0);
     EZ_TEST_INT(uiHash, 8527525522777555267ul);
 
-    ezVarianceTypeAngle* pTypedAngle = EZ_DEFAULT_NEW(ezVarianceTypeAngle, {0.1f, ezAngle::MakeFromRadian(1.57079637f)});
+    ezVarianceTypeAngle* pTypedAngle = EZ_DEFAULT_NEW(ezVarianceTypeAngle, ezAngle::MakeFromRadian(1.57079637f), 0.1);
     ezVariant copy;
     copy.CopyTypedObject(pTypedAngle, ezGetStaticRTTI<ezVarianceTypeAngle>());
     ezVariant move;

--- a/Code/UnitTests/FoundationTest/Reflection/FunctionReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/FunctionReflectionTest.cpp
@@ -45,12 +45,12 @@ struct FunctionTest
       EZ_TEST_BOOL(m_values[4] == *pPv);
       EZ_TEST_BOOL(m_values[5] == *pCpv);
     }
-    ref_rv = {2.0f, ezAngle::MakeFromDegree(200.0f)};
+    ref_rv = ezVarianceTypeAngle(ezAngle::MakeFromDegree(200.0f), 2.0f);
     if (pPv)
     {
-      *pPv = {4.0f, ezAngle::MakeFromDegree(400.0f)};
+      *pPv = ezVarianceTypeAngle(ezAngle::MakeFromDegree(400.0f), 4.0f);
     }
-    return {0.6f, ezAngle::MakeFromDegree(60.0f)};
+    return ezVarianceTypeAngle(ezAngle::MakeFromDegree(60.0f), 0.6f);
   }
 
   ezVarianceTypeAngle CustomTypeFunction2(ezVarianceTypeAngle v, const ezVarianceTypeAngle cv, ezVarianceTypeAngle& ref_rv, const ezVarianceTypeAngle& crv, ezVarianceTypeAngle* pPv, const ezVarianceTypeAngle* pCpv)
@@ -69,12 +69,12 @@ struct FunctionTest
       EZ_TEST_BOOL(*m_values[4].Get<ezVarianceTypeAngle*>() == *pPv);
       EZ_TEST_BOOL(*m_values[5].Get<ezVarianceTypeAngle*>() == *pCpv);
     }
-    ref_rv = {2.0f, ezAngle::MakeFromDegree(200.0f)};
+    ref_rv = ezVarianceTypeAngle(ezAngle::MakeFromDegree(200.0f), 2.0f);
     if (pPv)
     {
-      *pPv = {4.0f, ezAngle::MakeFromDegree(400.0f)};
+      *pPv = ezVarianceTypeAngle(ezAngle::MakeFromDegree(400.0f), 4.0f);
     }
-    return {0.6f, ezAngle::MakeFromDegree(60.0f)};
+    return ezVarianceTypeAngle(ezAngle::MakeFromDegree(60.0f), 0.6f);
   }
 
   const char* StringTypeFunction(const char* szString, ezString& ref_sString, ezStringView sView)
@@ -362,19 +362,19 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Functions)
 
     {
       FunctionTest test;
-      test.m_values.PushBack(ezVarianceTypeAngle{0.0f, ezAngle::MakeFromDegree(0.0f)});
-      test.m_values.PushBack(ezVarianceTypeAngle{0.1f, ezAngle::MakeFromDegree(10.0f)});
-      test.m_values.PushBack(ezVarianceTypeAngle{0.2f, ezAngle::MakeFromDegree(20.0f)});
-      test.m_values.PushBack(ezVarianceTypeAngle{0.3f, ezAngle::MakeFromDegree(30.0f)});
-      test.m_values.PushBack(ezVarianceTypeAngle{0.4f, ezAngle::MakeFromDegree(40.0f)});
-      test.m_values.PushBack(ezVarianceTypeAngle{0.5f, ezAngle::MakeFromDegree(50.0f)});
+      test.m_values.PushBack(ezVarianceTypeAngle(ezAngle::MakeFromDegree(0.0f), 0.0f));
+      test.m_values.PushBack(ezVarianceTypeAngle(ezAngle::MakeFromDegree(10.0f), 0.1f));
+      test.m_values.PushBack(ezVarianceTypeAngle(ezAngle::MakeFromDegree(20.0f), 0.2f));
+      test.m_values.PushBack(ezVarianceTypeAngle(ezAngle::MakeFromDegree(30.0f), 0.3f));
+      test.m_values.PushBack(ezVarianceTypeAngle(ezAngle::MakeFromDegree(40.0f), 0.4f));
+      test.m_values.PushBack(ezVarianceTypeAngle(ezAngle::MakeFromDegree(50.0f), 0.5f));
 
       ezVariant ret;
       funccall.Execute(&test, test.m_values, ret);
       EZ_TEST_BOOL(ret.GetType() == ezVariantType::TypedObject);
-      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle{0.6f, ezAngle::MakeFromDegree(60.0f)}));
-      EZ_TEST_BOOL(test.m_values[2] == ezVariant(ezVarianceTypeAngle{2.0f, ezAngle::MakeFromDegree(200.0f)}));
-      EZ_TEST_BOOL(test.m_values[4] == ezVariant(ezVarianceTypeAngle{4.0f, ezAngle::MakeFromDegree(400.0f)}));
+      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle(ezAngle::MakeFromDegree(60.0f), 0.6f)));
+      EZ_TEST_BOOL(test.m_values[2] == ezVariant(ezVarianceTypeAngle(ezAngle::MakeFromDegree(200.0f), 2.0f)));
+      EZ_TEST_BOOL(test.m_values[4] == ezVariant(ezVarianceTypeAngle(ezAngle::MakeFromDegree(400.0f), 4.0f)));
 
       test.m_bPtrAreNull = true;
       test.m_values[4] = ezVariant();
@@ -382,19 +382,19 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Functions)
       ret = ezVariant();
       funccall.Execute(&test, test.m_values, ret);
       EZ_TEST_BOOL(ret.GetType() == ezVariantType::TypedObject);
-      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle{0.6f, ezAngle::MakeFromDegree(60.0f)}));
+      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle(ezAngle::MakeFromDegree(60.0f), 0.6f)));
     }
 
     {
       ezFunctionProperty<decltype(&FunctionTest::CustomTypeFunction2)> funccall2("", &FunctionTest::CustomTypeFunction2);
 
       FunctionTest test;
-      ezVarianceTypeAngle v0{0.0f, ezAngle::MakeFromDegree(0.0f)};
-      ezVarianceTypeAngle v1{0.1f, ezAngle::MakeFromDegree(10.0f)};
-      ezVarianceTypeAngle v2{0.2f, ezAngle::MakeFromDegree(20.0f)};
-      ezVarianceTypeAngle v3{0.3f, ezAngle::MakeFromDegree(30.0f)};
-      ezVarianceTypeAngle v4{0.4f, ezAngle::MakeFromDegree(40.0f)};
-      ezVarianceTypeAngle v5{0.5f, ezAngle::MakeFromDegree(50.0f)};
+      ezVarianceTypeAngle v0(ezAngle::MakeFromDegree(0.0f), 0.0f);
+      ezVarianceTypeAngle v1(ezAngle::MakeFromDegree(10.0f), 0.1f);
+      ezVarianceTypeAngle v2(ezAngle::MakeFromDegree(20.0f), 0.2f);
+      ezVarianceTypeAngle v3(ezAngle::MakeFromDegree(30.0f), 0.3f);
+      ezVarianceTypeAngle v4(ezAngle::MakeFromDegree(40.0f), 0.4f);
+      ezVarianceTypeAngle v5(ezAngle::MakeFromDegree(50.0f), 0.5f);
       test.m_values.PushBack(&v0);
       test.m_values.PushBack(&v1);
       test.m_values.PushBack(&v2);
@@ -405,9 +405,9 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Functions)
       ezVariant ret;
       funccall2.Execute(&test, test.m_values, ret);
       EZ_TEST_BOOL(ret.GetType() == ezVariantType::TypedObject);
-      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle{0.6f, ezAngle::MakeFromDegree(60.0f)}));
-      EZ_TEST_BOOL((*test.m_values[2].Get<ezVarianceTypeAngle*>() == ezVarianceTypeAngle{2.0f, ezAngle::MakeFromDegree(200.0f)}));
-      EZ_TEST_BOOL((*test.m_values[4].Get<ezVarianceTypeAngle*>() == ezVarianceTypeAngle{4.0f, ezAngle::MakeFromDegree(400.0f)}));
+      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle(ezAngle::MakeFromDegree(60.0f), 0.6f)));
+      EZ_TEST_BOOL((*test.m_values[2].Get<ezVarianceTypeAngle*>() == ezVarianceTypeAngle(ezAngle::MakeFromDegree(200.0f), 2.0f)));
+      EZ_TEST_BOOL((*test.m_values[4].Get<ezVarianceTypeAngle*>() == ezVarianceTypeAngle(ezAngle::MakeFromDegree(400.0f), 4.0f)));
 
       test.m_bPtrAreNull = true;
       test.m_values[4] = ezVariant();
@@ -415,7 +415,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Functions)
       ret = ezVariant();
       funccall2.Execute(&test, test.m_values, ret);
       EZ_TEST_BOOL(ret.GetType() == ezVariantType::TypedObject);
-      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle{0.6f, ezAngle::MakeFromDegree(60.0f)}));
+      EZ_TEST_BOOL(ret == ezVariant(ezVarianceTypeAngle(ezAngle::MakeFromDegree(60.0f), 0.6f)));
     }
   }
 

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTest.cpp
@@ -529,8 +529,8 @@ EZ_CREATE_SIMPLE_TEST(Reflection, MemberProperties)
     TestMemberProperty<ezVariant>("Variant", &data, pRtti, ezPropertyFlags::StandardType, ezVariant("Test"),
       ezVariant(ezVec3(0, -1.0f, 3.14f)));
     TestMemberProperty<ezAngle>("Angle", &data, pRtti, ezPropertyFlags::StandardType, ezAngle::MakeFromDegree(0.5f), ezAngle::MakeFromDegree(1.0f));
-    ezVarianceTypeAngle expectedVA = {0.5f, ezAngle::MakeFromDegree(90.0f)};
-    ezVarianceTypeAngle testVA = {0.1f, ezAngle::MakeFromDegree(45.0f)};
+    ezVarianceTypeAngle expectedVA(ezAngle::MakeFromDegree(90.0f), 0.5f);
+    ezVarianceTypeAngle testVA(ezAngle::MakeFromDegree(45.0f), 0.1f);
     TestMemberProperty<ezVarianceTypeAngle>("VarianceAngle", &data, pRtti, ezPropertyFlags::Class, expectedVA, testVA);
 
     ezDataBuffer expected;
@@ -1002,7 +1002,7 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Arrays)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Custom Variant Array")
   {
-    ezVarianceTypeAngle data{0.1f, ezAngle::MakeFromDegree(45.0f)};
+    ezVarianceTypeAngle data(ezAngle::MakeFromDegree(45.0f), 0.1f);
 
     TestArrayProperty<ezVarianceTypeAngle>("Custom", &containers, pRtti, data);
     TestArrayProperty<ezVarianceTypeAngle>("CustomRO", &containers, pRtti, data);
@@ -1140,14 +1140,14 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Sets)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Custom Variant HashSet")
   {
-    ezVarianceTypeAngle value1{-0.1f, ezAngle::MakeFromDegree(-45.0f)};
-    ezVarianceTypeAngle value2{0.1f, ezAngle::MakeFromDegree(45.0f)};
+    ezVarianceTypeAngle value1(ezAngle::MakeFromDegree(-45.0f), -0.1f);
+    ezVarianceTypeAngle value2(ezAngle::MakeFromDegree(45.0f), 0.1f);
 
     TestSetProperty<ezVarianceTypeAngle>("CustomHashSet", &containers, pRtti, value1, value2);
     TestSetProperty<ezVarianceTypeAngle>("CustomHashSetRO", &containers, pRtti, value1, value2);
 
-    ezVarianceTypeAngle value3{-0.2f, ezAngle::MakeFromDegree(-90.0f)};
-    ezVarianceTypeAngle value4{0.2f, ezAngle::MakeFromDegree(90.0f)};
+    ezVarianceTypeAngle value3(ezAngle::MakeFromDegree(-90.0f), -0.2f);
+    ezVarianceTypeAngle value4(ezAngle::MakeFromDegree(90.0f), 0.2f);
     TestSetProperty<ezVarianceTypeAngle>("CustomHashAcSet", &containers, pRtti, value3, value4);
     TestSetProperty<ezVarianceTypeAngle>("CustomHashAcSetRO", &containers, pRtti, value3, value4);
   }
@@ -1249,8 +1249,8 @@ EZ_CREATE_SIMPLE_TEST(Reflection, Maps)
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "CustomVariant")
   {
-    ezVarianceTypeAngle value1{-0.1f, ezAngle::MakeFromDegree(-45.0f)};
-    ezVarianceTypeAngle value2{0.1f, ezAngle::MakeFromDegree(45.0f)};
+    ezVarianceTypeAngle value1(ezAngle::MakeFromDegree(-45.0f), -0.1f);
+    ezVarianceTypeAngle value2(ezAngle::MakeFromDegree(45.0f), 0.1f);
 
     TestMapProperty<ezVarianceTypeAngle>("CustomVariant", &containers, pRtti, value1, value2);
     TestMapProperty<ezVarianceTypeAngle>("CustomVariantRO", &containers, pRtti, value1, value2);

--- a/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.cpp
+++ b/Code/UnitTests/FoundationTest/Reflection/ReflectionTestClasses.cpp
@@ -34,7 +34,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezTestStruct, ezNoBase, 7, ezRTTIDefaultAllocator
     EZ_MEMBER_PROPERTY("Angle", m_Angle)->AddAttributes(new ezDefaultValueAttribute(ezAngle::MakeFromDegree(0.5))),
     EZ_MEMBER_PROPERTY("DataBuffer", m_DataBuffer)->AddAttributes(new ezDefaultValueAttribute(ezTestStruct::GetDefaultDataBuffer())),
     EZ_MEMBER_PROPERTY("vVec3I", m_vVec3I)->AddAttributes(new ezDefaultValueAttribute(ezVec3I32(1,2,3))),
-    EZ_MEMBER_PROPERTY("VarianceAngle", m_VarianceAngle)->AddAttributes(new ezDefaultValueAttribute(ezVarianceTypeAngle{0.5f, ezAngle::MakeFromDegree(90.0f)})),
+    EZ_MEMBER_PROPERTY("VarianceAngle", m_VarianceAngle)->AddAttributes(new ezDefaultValueAttribute(ezVarianceTypeAngle(ezAngle::MakeFromDegree(90.0f), 0.5f))),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.h
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.h
@@ -87,7 +87,7 @@ public:
     m_Buffer.PushBack(0xFF);
     m_Buffer.PushBack(0x0);
     m_Buffer.PushBack(0xCD);
-    m_VarianceAngle = {0.1f, ezAngle::MakeFromDegree(90.0f)};
+    m_VarianceAngle = ezVarianceTypeAngle(ezAngle::MakeFromDegree(90.0f), 0.1f);
   }
 
   ezIntegerStruct m_IntegerStruct;

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: FQ34216A-17A3-4AFE-BD86-ABF7F8ddA1K3
+Change me: FQ3421DA-17A3-4AFE-BD8Q-ABF7F8ddA1K3


### PR DESCRIPTION
fixes #1455
* Added ctor to `ezVarianceTypeFloat` and others.
* Replaced default values of wrong type with the correct type.
* Added unit test  that makes sure all default value attributes are correctly typed.
* Some Linux build fixes.