### PR TITLE
Linux build fixes

### DIFF
--- a/Code/Engine/Foundation/Strings/HashedString.h
+++ b/Code/Engine/Foundation/Strings/HashedString.h
@@ -98,7 +98,7 @@ public:
   /// \brief Compares this string object to an ezTempHashedString object. This should be used whenever some object needs to be found
   /// and the string to compare against is not yet an ezHashedString object.
   bool operator==(const ezTempHashedString& rhs) const; // [tested]
-  EZ_ADD_DEFAULT_OPERATOR_NOTEQUAL(const ezTempHashedString&);
+  bool operator!=(const ezTempHashedString& rhs) const; // [tested]
 
   /// \brief This operator allows sorting objects by hash value, not by alphabetical order.
   bool operator<(const ezHashedString& rhs) const; // [tested]

--- a/Code/Engine/Foundation/Strings/Implementation/HashedString_inl.h
+++ b/Code/Engine/Foundation/Strings/Implementation/HashedString_inl.h
@@ -92,6 +92,11 @@ inline bool ezHashedString::operator==(const ezTempHashedString& rhs) const
   return m_Data.Key() == rhs.m_uiHash;
 }
 
+inline bool ezHashedString::operator!=(const ezTempHashedString& rhs) const
+{
+  return m_Data.Key() != rhs.m_uiHash;
+}
+
 inline bool ezHashedString::operator<(const ezHashedString& rhs) const
 {
   return m_Data.Key() < rhs.m_Data.Key();

--- a/RunCMake.sh
+++ b/RunCMake.sh
@@ -92,8 +92,14 @@ verlt() {
 }
 
 if [ "$Distribution" = "Ubuntu" -a "$Version" = "22" ] || [ "$Distribution" = "Ubuntu" -a "$Version" = "24" ] || [ "$Distribution" = "Mint" -a "$Version" = "21" ]; then
-  packages=(cmake build-essential ninja-build libxrandr-dev libxinerama-dev libomp-dev libxcursor-dev libxi-dev uuid-dev mold libfreetype-dev libtinfo5 libomp-dev)
+  packages=(cmake build-essential ninja-build libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev uuid-dev mold libfreetype-dev libxkbcommon-dev)
 
+  if [ "$Distribution" = "Ubuntu" -a "$Version" = "24" ]; then
+    packages+=(libtinfo6)
+  else  
+    packages+=(libtinfo5)
+  fi
+  
   if [ "$UseClang" = true ]; then
     packages+=(clang-14 libomp-14-dev libstdc++-12-dev)
   else


### PR DESCRIPTION
* Fixes for `RunCmake.sh` on a clean Ubuntu 24.04 install.
* Build fix: Newer gcc versions do not like our `EZ_ADD_DEFAULT_OPERATOR_NOTEQUAL` macro when used on a forward declared type.