### PR TITLE
Deactivate deprecated Recast plugin

### DIFF
--- a/Code/EditorPlugins/Recast/EditorPluginRecast/CMakeLists.txt
+++ b/Code/EditorPlugins/Recast/EditorPluginRecast/CMakeLists.txt
@@ -3,6 +3,7 @@ ez_cmake_init()
 ez_requires_editor()
 
 ez_requires(EZ_3RDPARTY_RECAST_SUPPORT)
+ez_requires(EZ_BUILD_DEPRECATED_RECAST_PLUGIN)
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)

--- a/Code/EditorPlugins/Recast/EnginePluginRecast/CMakeLists.txt
+++ b/Code/EditorPlugins/Recast/EnginePluginRecast/CMakeLists.txt
@@ -3,6 +3,7 @@ ez_cmake_init()
 ez_requires_editor()
 
 ez_requires(EZ_3RDPARTY_RECAST_SUPPORT)
+ez_requires(EZ_BUILD_DEPRECATED_RECAST_PLUGIN)
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)

--- a/Code/EnginePlugins/RecastPlugin/CMakeLists.txt
+++ b/Code/EnginePlugins/RecastPlugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 ez_cmake_init()
 
-
 ez_requires(EZ_3RDPARTY_RECAST_SUPPORT)
+ez_requires(EZ_BUILD_DEPRECATED_RECAST_PLUGIN)
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)

--- a/Code/EnginePlugins/RecastPlugin/init.cmake
+++ b/Code/EnginePlugins/RecastPlugin/init.cmake
@@ -1,0 +1,2 @@
+set (EZ_BUILD_DEPRECATED_RECAST_PLUGIN OFF CACHE BOOL "Whether to build the old Recast plugin.")
+mark_as_advanced(FORCE EZ_BUILD_DEPRECATED_RECAST_PLUGIN)


### PR DESCRIPTION
Still available for some time, but needs to be manually activated in CMake.