### PR TITLE
Simpler way to update buffers and textures from game code

### DIFF
--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -357,7 +357,7 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
     msg.m_FileSystemConfig = m_FileSystemConfig;
     msg.m_PluginConfig = m_PluginConfig;
     msg.m_sAssetProfile = ezAssetCurator::GetSingleton()->GetActiveAssetProfile()->GetConfigName();
-    msg.m_fDevicePixelRatio = QApplication::activeWindow() != nullptr ? QApplication::activeWindow()->devicePixelRatio() : 1.0f;
+    msg.m_fDevicePixelRatio = QApplication::activeWindow() != nullptr ? QApplication::activeWindow()->devicePixelRatio() : QGuiApplication::primaryScreen()->devicePixelRatio();
 
     SendMessage(&msg);
   }

--- a/Code/Engine/Foundation/Platform/Win/Time_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/Time_Win.cpp
@@ -15,7 +15,7 @@ void ezTime::Initialize()
   g_fInvQpcFrequency = 1.0 / double(frequency.QuadPart);
 }
 
-#  if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+#  if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
 thread_local ezInt64 s_LastTime;
 #  endif
 
@@ -24,11 +24,11 @@ ezTime ezTime::Now()
   LARGE_INTEGER temp;
   QueryPerformanceCounter(&temp);
 
-#  if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
-  EZ_ASSERT_DEV(s_LastTime <= temp.QuadPart, "Serious problem, Steve. This is like \"Houston, forget that other thing\".\n\n\n"
-                                             "When this happens the PC timer is unreliable. It was probably called from different threads "
-                                             "and the clocks on different CPU cores seem to return different results.\n"
-                                             "Under these conditions the engine cannot run reliably, it might crash or act weird.");
+#  if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+  EZ_ASSERT_DEBUG(s_LastTime <= temp.QuadPart, "Serious problem, Steve. This is like \"Houston, forget that other thing\".\n\n\n"
+                                               "When this happens the PC timer is unreliable. It was probably called from different threads "
+                                               "and the clocks on different CPU cores seem to return different results.\n"
+                                               "Under these conditions the engine cannot run reliably, it might crash or act weird.");
   s_LastTime = temp.QuadPart;
 #  endif
 

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
@@ -164,7 +164,7 @@ ezMeshRenderData* ezAnimatedMeshComponent::CreateRenderData() const
   auto pRenderData = ezCreateRenderDataForThisFrame<ezSkinnedMeshRenderData>(GetOwner());
   pRenderData->m_GlobalTransform = m_RootTransform;
 
-  m_SkinningState.FillSkinnedMeshRenderData(*pRenderData);
+  pRenderData->m_hSkinningTransforms = m_SkinningState.m_hGpuBuffer;
 
   return pRenderData;
 }

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -324,7 +324,7 @@ ezMeshRenderData* ezLodAnimatedMeshComponent::CreateRenderData() const
   auto pRenderData = ezCreateRenderDataForThisFrame<ezSkinnedMeshRenderData>(GetOwner());
   pRenderData->m_GlobalTransform = m_RootTransform;
 
-  m_SkinningState.FillSkinnedMeshRenderData(*pRenderData);
+  pRenderData->m_hSkinningTransforms = m_SkinningState.m_hGpuBuffer;
 
   return pRenderData;
 }

--- a/Code/Engine/RendererCore/BakedProbes/BakedProbesComponent.h
+++ b/Code/Engine/RendererCore/BakedProbes/BakedProbesComponent.h
@@ -19,14 +19,12 @@ public:
   ~ezBakedProbesComponentManager();
 
   virtual void Initialize() override;
-  virtual void Deinitialize() override;
 
   ezMeshResourceHandle m_hDebugSphere;
   ezMaterialResourceHandle m_hDebugMaterial;
 
 private:
   void RenderDebug(const ezWorldModule::UpdateContext& updateContext);
-  void OnRenderEvent(const ezRenderWorldRenderEvent& e);
   void CreateDebugResources();
 };
 

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -121,7 +121,7 @@ void ezRopeRenderComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
 
     pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
 
-    m_SkinningState.FillSkinnedMeshRenderData(*pRenderData);
+    pRenderData->m_hSkinningTransforms = m_SkinningState.m_hGpuBuffer;
 
     pRenderData->FillBatchIdAndSortingKey();
   }

--- a/Code/Engine/RendererCore/Debug/DebugTextComponent.h
+++ b/Code/Engine/RendererCore/Debug/DebugTextComponent.h
@@ -32,7 +32,7 @@ public:
   float m_fValue2 = 0.0f;                                         // [ property ]
   float m_fValue3 = 0.0f;                                         // [ property ]
 
-  float m_fMaxDistance = 10.0f;                                  // [ property ]
+  float m_fMaxDistance = 10.0f;                                   // [ property ]
 
 protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const; // [ msg handler ]

--- a/Code/Engine/RendererCore/Debug/DebugTextComponent.h
+++ b/Code/Engine/RendererCore/Debug/DebugTextComponent.h
@@ -32,7 +32,7 @@ public:
   float m_fValue2 = 0.0f;                                         // [ property ]
   float m_fValue3 = 0.0f;                                         // [ property ]
 
-  float m_fMaxDistance = 100.0f;                                  // [ property ]
+  float m_fMaxDistance = 10.0f;                                  // [ property ]
 
 protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const; // [ msg handler ]

--- a/Code/Engine/RendererCore/Debug/DebugTextComponent.h
+++ b/Code/Engine/RendererCore/Debug/DebugTextComponent.h
@@ -32,6 +32,8 @@ public:
   float m_fValue2 = 0.0f;                                         // [ property ]
   float m_fValue3 = 0.0f;                                         // [ property ]
 
+  float m_fMaxDistance = 100.0f;                                  // [ property ]
+
 protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const; // [ msg handler ]
 };

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
@@ -95,7 +95,7 @@ void ezDebugTextComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   c.a *= fFade;
 
   ezStringBuilder sb;
-  sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);  
+  sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);
 
   ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, GetOwner()->GetGlobalPosition(), c);
 }

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
@@ -85,8 +85,8 @@ void ezDebugTextComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   if (m_sText.IsEmpty())
     return;
 
-  const float fDistance = msg.m_pView->GetCullingCamera()->GetCenterPosition().GetDistanceTo(GetOwner()->GetGlobalPosition());
-  if (fDistance > m_fMaxDistance)
+  const float fSquaredDistance = msg.m_pView->GetCullingCamera()->GetCenterPosition().GetSquaredDistanceTo(GetOwner()->GetGlobalPosition());
+  if (fSquaredDistance > m_fMaxDistance * m_fMaxDistance)
     return;
 
   ezStringBuilder sb;

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
@@ -18,7 +18,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezDebugTextComponent, 2, ezComponentMode::Static)
     EZ_MEMBER_PROPERTY("Value2", m_fValue2),
     EZ_MEMBER_PROPERTY("Value3", m_fValue3),
     EZ_MEMBER_PROPERTY("Color", m_Color),
-    EZ_MEMBER_PROPERTY("MaxDistance", m_fMaxDistance)->AddAttributes(new ezDefaultValueAttribute(100.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_MEMBER_PROPERTY("MaxDistance", m_fMaxDistance)->AddAttributes(new ezDefaultValueAttribute(10.0f), new ezClampValueAttribute(0.0f, ezVariant())),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS
@@ -89,10 +89,15 @@ void ezDebugTextComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   if (fSquaredDistance > m_fMaxDistance * m_fMaxDistance)
     return;
 
-  ezStringBuilder sb;
-  sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);
+  const float fFade = ezMath::Saturate(ezMath::Sqrt(fSquaredDistance) / ezMath::Max(m_fMaxDistance, 0.0001f) * -5.0f + 5.0f);
 
-  ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, GetOwner()->GetGlobalPosition(), m_Color);
+  ezColor c = m_Color;
+  c.a *= fFade;
+
+  ezStringBuilder sb;
+  sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);  
+
+  ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, GetOwner()->GetGlobalPosition(), c);
 }
 
 

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugTextComponent.cpp
@@ -8,7 +8,7 @@
 #include <RendererCore/Pipeline/View.h>
 
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezDebugTextComponent, 1, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezDebugTextComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -18,6 +18,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezDebugTextComponent, 1, ezComponentMode::Static)
     EZ_MEMBER_PROPERTY("Value2", m_fValue2),
     EZ_MEMBER_PROPERTY("Value3", m_fValue3),
     EZ_MEMBER_PROPERTY("Color", m_Color),
+    EZ_MEMBER_PROPERTY("MaxDistance", m_fMaxDistance)->AddAttributes(new ezDefaultValueAttribute(100.0f), new ezClampValueAttribute(0.0f, ezVariant())),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS
@@ -53,12 +54,13 @@ void ezDebugTextComponent::SerializeComponent(ezWorldWriter& inout_stream) const
   s << m_fValue2;
   s << m_fValue3;
   s << m_Color;
+  s << m_fMaxDistance;
 }
 
 void ezDebugTextComponent::DeserializeComponent(ezWorldReader& inout_stream)
 {
   SUPER::DeserializeComponent(inout_stream);
-  // const ezUInt32 uiVersion = stream.GetComponentTypeVersion(GetStaticRTTI());
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
 
   auto& s = inout_stream.GetStream();
 
@@ -68,6 +70,11 @@ void ezDebugTextComponent::DeserializeComponent(ezWorldReader& inout_stream)
   s >> m_fValue2;
   s >> m_fValue3;
   s >> m_Color;
+
+  if (uiVersion >= 2)
+  {
+    s >> m_fMaxDistance;
+  }
 }
 
 void ezDebugTextComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
@@ -75,13 +82,17 @@ void ezDebugTextComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   if (msg.m_OverrideCategory != ezInvalidRenderDataCategory || msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::Shadow)
     return;
 
-  if (!m_sText.IsEmpty())
-  {
-    ezStringBuilder sb;
-    sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);
+  if (m_sText.IsEmpty())
+    return;
 
-    ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, GetOwner()->GetGlobalPosition(), m_Color);
-  }
+  const float fDistance = msg.m_pView->GetCullingCamera()->GetCenterPosition().GetDistanceTo(GetOwner()->GetGlobalPosition());
+  if (fDistance > m_fMaxDistance)
+    return;
+
+  ezStringBuilder sb;
+  sb.SetFormat(m_sText, m_fValue0, m_fValue1, m_fValue2, m_fValue3);
+
+  ezDebugRenderer::Draw3DText(msg.m_pView->GetHandle(), sb, GetOwner()->GetGlobalPosition(), m_Color);
 }
 
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
@@ -223,6 +223,7 @@ namespace
         break;
       case ezFillLightMode::ModulateIndirect:
         lightColor.a = LIGHT_TYPE_FILL_MODULATE_INDIRECT;
+        out_perLightData.intensity = ezMath::Saturate(out_perLightData.intensity);
         break;
     }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/FillLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/FillLightComponent.cpp
@@ -142,6 +142,8 @@ ezColorGammaUB ezFillLightComponent::GetEffectiveColor() const
 void ezFillLightComponent::SetIntensity(float fIntensity)
 {
   m_fIntensity = fIntensity;
+
+  InvalidateCachedRenderData();
 }
 
 void ezFillLightComponent::SetRange(float fRange)

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
@@ -236,9 +236,12 @@ ezMaterialResourceHandle ezMeshComponentBase::GetMaterial(ezUInt32 uiIndex) cons
 
 void ezMeshComponentBase::SetColor(const ezColor& color)
 {
-  m_Color = color;
+  if (m_Color != color)
+  {
+    m_Color = color;
 
-  InvalidateCachedRenderData();
+    InvalidateCachedRenderData();
+  }
 }
 
 const ezColor& ezMeshComponentBase::GetColor() const
@@ -277,9 +280,15 @@ void ezMeshComponentBase::OnMsgSetMeshMaterial(ezMsgSetMeshMaterial& ref_msg)
 
 void ezMeshComponentBase::OnMsgSetColor(ezMsgSetColor& ref_msg)
 {
-  ref_msg.ModifyColor(m_Color);
+  ezColor newColor = m_Color;
+  ref_msg.ModifyColor(newColor);
 
-  InvalidateCachedRenderData();
+  if (m_Color != newColor)
+  {
+    m_Color = newColor;
+
+    InvalidateCachedRenderData();
+  }
 }
 
 void ezMeshComponentBase::OnMsgSetCustomData(ezMsgSetCustomData& ref_msg)

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -33,8 +33,6 @@ void ezSkinningState::Clear()
     m_hGpuBuffer.Invalidate();
   }
 
-  m_bTransformsUpdated[0] = nullptr;
-  m_bTransformsUpdated[1] = nullptr;
   m_Transforms.Clear();
 }
 
@@ -54,30 +52,10 @@ void ezSkinningState::TransformsChanged()
     m_hGpuBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(BufferDesc, m_Transforms.GetArrayPtr().ToByteArray());
 
     ezGALDevice::GetDefaultDevice()->GetBuffer(m_hGpuBuffer)->SetDebugName("ezSkinningState");
-
-    m_bTransformsUpdated[0] = std::make_shared<bool>(true);
-    m_bTransformsUpdated[1] = std::make_shared<bool>(true);
   }
   else
   {
-    const ezUInt32 uiRenIdx = ezRenderWorld::GetDataIndexForExtraction();
-    *m_bTransformsUpdated[uiRenIdx] = false;
-  }
-}
-
-void ezSkinningState::FillSkinnedMeshRenderData(ezSkinnedMeshRenderData& ref_renderData) const
-{
-  ref_renderData.m_hSkinningTransforms = m_hGpuBuffer;
-
-  const ezUInt32 uiExIdx = ezRenderWorld::GetDataIndexForExtraction();
-
-  if (m_bTransformsUpdated[uiExIdx] && *m_bTransformsUpdated[uiExIdx] == false)
-  {
-    auto pSkinningMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezShaderTransform, m_Transforms.GetCount());
-    pSkinningMatrices.CopyFrom(m_Transforms);
-
-    ref_renderData.m_pNewSkinningTransformData = pSkinningMatrices.ToByteArray();
-    ref_renderData.m_bTransformsUpdated = m_bTransformsUpdated[uiExIdx];
+    ezGALDevice::GetDefaultDevice()->UpdateBufferForNextFrame(m_hGpuBuffer, m_Transforms.GetByteArrayPtr());
   }
 }
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
@@ -9,8 +9,6 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkinnedMeshRenderer, 1, ezRTTIDefaultAllocator
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-ezUInt32 ezSkinnedMeshRenderer::s_uiSkinningBufferUpdates = 0;
-
 ezSkinnedMeshRenderer::ezSkinnedMeshRenderer() = default;
 ezSkinnedMeshRenderer::~ezSkinnedMeshRenderer() = default;
 
@@ -35,16 +33,6 @@ void ezSkinnedMeshRenderer::SetAdditionalData(const ezRenderViewContext& renderV
   else
   {
     pContext->SetShaderPermutationVariable("VERTEX_SKINNING", "TRUE");
-
-    if (pSkinnedRenderData->m_bTransformsUpdated != nullptr && *pSkinnedRenderData->m_bTransformsUpdated == false)
-    {
-      // if this is the first renderer that is supposed to actually render the skinned mesh, upload the skinning matrices
-      *pSkinnedRenderData->m_bTransformsUpdated = true;
-      pContext->GetCommandEncoder()->UpdateBuffer(pSkinnedRenderData->m_hSkinningTransforms, 0, pSkinnedRenderData->m_pNewSkinningTransformData, ezGALUpdateMode::AheadOfTime);
-
-      // TODO: could expose this somewhere (ezStats?)
-      s_uiSkinningBufferUpdates++;
-    }
 
     pContext->BindBuffer("skinningTransforms", pDevice->GetDefaultResourceView(pSkinnedRenderData->m_hSkinningTransforms));
   }

--- a/Code/Engine/RendererCore/Meshes/SkinnedMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/SkinnedMeshComponent.h
@@ -13,8 +13,6 @@ class EZ_RENDERERCORE_DLL ezSkinnedMeshRenderData : public ezMeshRenderData
 public:
   virtual void FillBatchIdAndSortingKey() override;
   ezGALBufferHandle m_hSkinningTransforms;
-  ezArrayPtr<const ezUInt8> m_pNewSkinningTransformData;
-  std::shared_ptr<bool> m_bTransformsUpdated;
 };
 
 struct EZ_RENDERERCORE_DLL ezSkinningState
@@ -30,9 +28,5 @@ struct EZ_RENDERERCORE_DLL ezSkinningState
   /// \brief Call this, after modifying m_Transforms, to make the renderer apply the update.
   void TransformsChanged();
 
-  void FillSkinnedMeshRenderData(ezSkinnedMeshRenderData& ref_renderData) const;
-
-private:
   ezGALBufferHandle m_hGpuBuffer;
-  std::shared_ptr<bool> m_bTransformsUpdated[2];
 };

--- a/Code/Engine/RendererCore/Meshes/SkinnedMeshRenderer.h
+++ b/Code/Engine/RendererCore/Meshes/SkinnedMeshRenderer.h
@@ -17,6 +17,4 @@ public:
 
 protected:
   virtual void SetAdditionalData(const ezRenderViewContext& renderViewContext, const ezMeshRenderData* pRenderData) const override;
-
-  static ezUInt32 s_uiSkinningBufferUpdates;
 };

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -701,8 +701,13 @@ void ezGALDeviceDX11::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffe
   {
     if (copy.m_pDestResource == pBufferDX11->GetDXBuffer())
     {
-      ezLog::Error("Buffer is already updated for next frame.");
-      return;
+      const bool bWholeBuffer = copy.m_vSourceSize.x == ezInvalidIndex;
+      const bool bOverlapping = uiDestOffset < copy.m_vDestPoint.x + copy.m_vSourceSize.x && copy.m_vDestPoint.x < uiDestOffset + sourceData.GetCount();
+      if (bWholeBuffer || bOverlapping)
+      {
+        ezLog::Error("Buffer range is already updated for next frame.");
+        return;
+      }
     }
   }
 #endif
@@ -714,7 +719,7 @@ void ezGALDeviceDX11::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffe
   copy.m_pDestResource = pBufferDX11->GetDXBuffer();
   copy.m_vDestPoint.Set(uiDestOffset, 0, 0);
 
-  bool bWholeBuffer = uiDestOffset == 0 && copy.m_SourceResource.m_uiRowPitch == uiDestBufferSize;
+  const bool bWholeBuffer = uiDestOffset == 0 && copy.m_SourceResource.m_uiRowPitch == uiDestBufferSize;
   copy.m_vSourceSize = bWholeBuffer ? ezVec3U32(ezInvalidIndex) : ezVec3U32(sourceData.GetCount(), 1, 1);
 }
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/System/Window.h>
 #include <Foundation/Configuration/Startup.h>
+#include <Foundation/Memory/FrameAllocator.h>
 #include <Foundation/Platform/Win/Utils/IncludeWindows.h>
 #include <Foundation/System/SystemInformation.h>
 #include <RendererDX11/CommandEncoder/CommandEncoderImplDX11.h>
@@ -274,10 +275,10 @@ ezResult ezGALDeviceDX11::ShutdownPlatform()
   {
     for (auto it = m_FreeTempResources[type].GetIterator(); it.IsValid(); ++it)
     {
-      ezDynamicArray<ID3D11Resource*>& resources = it.Value();
-      for (auto pResource : resources)
+      ezDynamicArray<TempResource>& tempResources = it.Value();
+      for (auto tempResource : tempResources)
       {
-        EZ_GAL_DX11_RELEASE(pResource);
+        EZ_GAL_DX11_RELEASE(tempResource.m_pResource);
       }
     }
     m_FreeTempResources[type].Clear();
@@ -691,6 +692,62 @@ void ezGALDeviceDX11::DestroyVertexDeclarationPlatform(ezGALVertexDeclaration* p
   EZ_DELETE(&m_Allocator, pVertexDeclarationDX11);
 }
 
+void ezGALDeviceDX11::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset)
+{
+  const ezGALBufferDX11* pBufferDX11 = static_cast<const ezGALBufferDX11*>(pBuffer);
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+  for (auto& copy : m_PendingCopies)
+  {
+    if (copy.m_pDestResource == pBufferDX11->GetDXBuffer())
+    {
+      ezLog::Error("Buffer is already updated for next frame.");
+      return;
+    }
+  }
+#endif
+
+  const ezUInt32 uiDestBufferSize = pBuffer->GetDescription().m_uiTotalSize;
+  
+  auto& copy = m_PendingCopies.ExpandAndGetRef();
+  copy.m_SourceResource = CopyToTempBuffer(sourceData, m_uiFrameCounter + 1);
+  copy.m_pDestResource = pBufferDX11->GetDXBuffer();
+  copy.m_vDestPoint.Set(uiDestOffset, 0, 0);
+
+  bool bWholeBuffer = uiDestOffset == 0 && copy.m_SourceResource.m_uiRowPitch == uiDestBufferSize;
+  copy.m_vSourceSize = bWholeBuffer ? ezVec3U32(ezInvalidIndex) : ezVec3U32(sourceData.GetCount(), 1, 1);
+}
+
+void ezGALDeviceDX11::UpdateTextureForNextFramePlatform(const ezGALTexture* pTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox)
+{
+  const ezGALTextureDX11* pTextureDX11 = static_cast<const ezGALTextureDX11*>(pTexture);
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+  for (auto& copy : m_PendingCopies)
+  {
+    if (copy.m_pDestResource == pTextureDX11->GetDXTexture())
+    {
+      ezLog::Error("Texture is already updated for next frame.");
+      return;
+    }
+  }
+#endif
+
+  auto& desc = pTexture->GetDescription();
+
+  const ezUInt32 uiWidth = destinationBox.m_vMax.x - destinationBox.m_vMin.x;
+  const ezUInt32 uiHeight = destinationBox.m_vMax.y - destinationBox.m_vMin.y;
+  const ezUInt32 uiDepth = destinationBox.m_vMax.z - destinationBox.m_vMin.z;
+  bool bWholeTexture = destinationBox.m_vMin.IsZero() && destinationBox.m_vMax == ezVec3U32(desc.m_uiWidth, desc.m_uiHeight, desc.m_uiDepth);
+
+  auto& copy = m_PendingCopies.ExpandAndGetRef();
+  copy.m_SourceResource = CopyToTempTexture(sourceData, uiWidth, uiHeight, uiDepth, desc.m_Format, m_uiFrameCounter + 1);
+  copy.m_pDestResource = pTextureDX11->GetDXTexture();
+  copy.m_uiDestSubResource = D3D11CalcSubresource(destinationSubResource.m_uiMipLevel, destinationSubResource.m_uiArraySlice, desc.m_uiMipLevelCount);
+  copy.m_vDestPoint = destinationBox.m_vMin;
+  copy.m_vSourceSize = bWholeTexture ? ezVec3U32(ezInvalidIndex) : ezVec3U32(uiWidth, uiHeight, uiDepth);
+}
+
 ezEnum<ezGALAsyncResult> ezGALDeviceDX11::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& out_result)
 {
   return m_pQueryPool->GetTimestampResult(hTimestamp, out_result);
@@ -838,6 +895,8 @@ void ezGALDeviceDX11::BeginFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchains,
 #else
   EZ_IGNORE_UNUSED(uiAppFrame);
 #endif
+
+  ProcessPendingCopies();
 
   for (ezGALSwapChain* pSwapChain : swapchains)
   {
@@ -1044,11 +1103,11 @@ const ezGALSharedTexture* ezGALDeviceDX11::GetSharedTexture(ezGALTextureHandle h
   return static_cast<const ezGALSharedTextureDX11*>(pTexture->GetParentResource());
 }
 
-ID3D11Resource* ezGALDeviceDX11::FindTempBuffer(ezUInt32 uiSize)
+ezGALDeviceDX11::TempResource ezGALDeviceDX11::CopyToTempBuffer(ezConstByteArrayPtr sourceData, ezUInt64 uiLastUseFrame /*= ezUInt64(-1)*/)
 {
-  const ezUInt32 uiExpGrowthLimit = 16 * 1024 * 1024;
+  constexpr ezUInt32 uiExpGrowthLimit = 16 * 1024 * 1024;
 
-  uiSize = ezMath::Max(uiSize, 256U);
+  ezUInt32 uiSize = ezMath::Max(sourceData.GetCount(), 256U);
   if (uiSize < uiExpGrowthLimit)
   {
     uiSize = ezMath::PowerOfTwo_Ceil(uiSize);
@@ -1058,19 +1117,19 @@ ID3D11Resource* ezGALDeviceDX11::FindTempBuffer(ezUInt32 uiSize)
     uiSize = ezMemoryUtils::AlignSize(uiSize, uiExpGrowthLimit);
   }
 
-  ID3D11Resource* pResource = nullptr;
+  TempResource tempResource;
   auto it = m_FreeTempResources[TempResourceType::Buffer].Find(uiSize);
   if (it.IsValid())
   {
-    ezDynamicArray<ID3D11Resource*>& resources = it.Value();
+    ezDynamicArray<TempResource>& resources = it.Value();
     if (!resources.IsEmpty())
     {
-      pResource = resources[0];
+      tempResource = resources[0];
       resources.RemoveAtAndSwap(0);
     }
   }
 
-  if (pResource == nullptr)
+  if (tempResource.m_pResource == nullptr)
   {
     D3D11_BUFFER_DESC desc;
     desc.ByteWidth = uiSize;
@@ -1080,42 +1139,59 @@ ID3D11Resource* ezGALDeviceDX11::FindTempBuffer(ezUInt32 uiSize)
     desc.MiscFlags = 0;
     desc.StructureByteStride = 0;
 
-    ID3D11Buffer* pBuffer = nullptr;
-    if (!SUCCEEDED(m_pDevice->CreateBuffer(&desc, nullptr, &pBuffer)))
+    D3D11_SUBRESOURCE_DATA initData;
+    initData.pSysMem = sourceData.GetPtr();
+    initData.SysMemPitch = initData.SysMemSlicePitch = 0;
+
+    if (uiSize > sourceData.GetCount())
     {
-      return nullptr;
+      ezUInt8* dataCopy = EZ_NEW_RAW_BUFFER(ezFrameAllocator::GetCurrentAllocator(), ezUInt8, uiSize);
+      memcpy(dataCopy, sourceData.GetPtr(), sourceData.GetCount());
+      initData.pSysMem = dataCopy;
     }
 
-    pResource = pBuffer;
+    ID3D11Buffer* pBuffer = nullptr;
+    if (!SUCCEEDED(m_pDevice->CreateBuffer(&desc, &initData, &pBuffer)))
+    {
+      return {};
+    }
+
+    tempResource.m_pResource = pBuffer;
+    tempResource.m_uiRowPitch = uiSize;
+  }
+  else
+  {
+    EZ_ASSERT_DEBUG(tempResource.m_pData != nullptr, "Must be mapped at this point");
+    memcpy(tempResource.m_pData, sourceData.GetPtr(), sourceData.GetCount());
   }
 
-  auto& tempResource = m_UsedTempResources[TempResourceType::Buffer].ExpandAndGetRef();
-  tempResource.m_pResource = pResource;
-  tempResource.m_uiFrame = m_uiFrameCounter;
-  tempResource.m_uiHash = uiSize;
+  auto& usedTempResource = m_UsedTempResources[TempResourceType::Buffer].ExpandAndGetRef();
+  usedTempResource.m_pResource = tempResource.m_pResource;
+  usedTempResource.m_uiFrame = uiLastUseFrame != ezUInt64(-1) ? uiLastUseFrame : m_uiFrameCounter;
+  usedTempResource.m_uiHash = uiSize;
 
-  return pResource;
+  return tempResource;
 }
 
 
-ID3D11Resource* ezGALDeviceDX11::FindTempTexture(ezUInt32 uiWidth, ezUInt32 uiHeight, ezUInt32 uiDepth, ezGALResourceFormat::Enum format)
+ezGALDeviceDX11::TempResource ezGALDeviceDX11::CopyToTempTexture(const ezGALSystemMemoryDescription& sourceData, ezUInt32 uiWidth, ezUInt32 uiHeight, ezUInt32 uiDepth, ezGALResourceFormat::Enum format, ezUInt64 uiLastUseFrame /*= ezUInt64(-1)*/)
 {
-  ezUInt32 data[] = {uiWidth, uiHeight, uiDepth, (ezUInt32)format};
-  ezUInt32 uiHash = ezHashingUtils::xxHash32(data, sizeof(data));
+  ezUInt32 hashData[] = {uiWidth, uiHeight, uiDepth, (ezUInt32)format};
+  ezUInt32 uiHash = ezHashingUtils::xxHash32(hashData, sizeof(hashData));
 
-  ID3D11Resource* pResource = nullptr;
+  TempResource tempResource;
   auto it = m_FreeTempResources[TempResourceType::Texture].Find(uiHash);
   if (it.IsValid())
   {
-    ezDynamicArray<ID3D11Resource*>& resources = it.Value();
+    ezDynamicArray<TempResource>& resources = it.Value();
     if (!resources.IsEmpty())
     {
-      pResource = resources[0];
+      tempResource = resources[0];
       resources.RemoveAtAndSwap(0);
     }
   }
 
-  if (pResource == nullptr)
+  if (tempResource.m_pResource == nullptr)
   {
     if (uiDepth == 1)
     {
@@ -1132,27 +1208,68 @@ ID3D11Resource* ezGALDeviceDX11::FindTempTexture(ezUInt32 uiWidth, ezUInt32 uiHe
       desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
       desc.MiscFlags = 0;
 
+      D3D11_SUBRESOURCE_DATA initData;
+      initData.pSysMem = sourceData.m_pData.GetPtr();
+      initData.SysMemPitch = sourceData.m_uiRowPitch;
+      initData.SysMemSlicePitch = sourceData.m_uiSlicePitch;
+
       ID3D11Texture2D* pTexture = nullptr;
-      if (!SUCCEEDED(m_pDevice->CreateTexture2D(&desc, nullptr, &pTexture)))
+      if (!SUCCEEDED(m_pDevice->CreateTexture2D(&desc, &initData, &pTexture)))
       {
-        return nullptr;
+        return {};
       }
 
-      pResource = pTexture;
+      tempResource.m_pResource = pTexture;
     }
     else
     {
       EZ_ASSERT_NOT_IMPLEMENTED;
-      return nullptr;
+      return {};
+    }
+  }
+  else
+  {
+    EZ_ASSERT_DEBUG(tempResource.m_pData != nullptr, "Must be mapped at this point");
+    if (tempResource.m_uiRowPitch == sourceData.m_uiRowPitch && tempResource.m_uiDepthPitch == sourceData.m_uiSlicePitch)
+    {
+      memcpy(tempResource.m_pData, sourceData.m_pData.GetPtr(), sourceData.m_uiSlicePitch * uiDepth);
+    }
+    else
+    {
+      // Copy row by row
+      for (ezUInt32 z = 0; z < uiDepth; ++z)
+      {
+        const void* pSource = ezMemoryUtils::AddByteOffset(sourceData.m_pData.GetPtr(), z * sourceData.m_uiSlicePitch);
+        void* pDest = ezMemoryUtils::AddByteOffset(tempResource.m_pData, z * tempResource.m_uiDepthPitch);
+
+        for (ezUInt32 y = 0; y < uiHeight; ++y)
+        {
+          memcpy(pDest, pSource, sourceData.m_uiRowPitch);
+
+          pSource = ezMemoryUtils::AddByteOffset(pSource, sourceData.m_uiRowPitch);
+          pDest = ezMemoryUtils::AddByteOffset(pDest, tempResource.m_uiRowPitch);
+        }
+      }
     }
   }
 
-  auto& tempResource = m_UsedTempResources[TempResourceType::Texture].ExpandAndGetRef();
-  tempResource.m_pResource = pResource;
-  tempResource.m_uiFrame = m_uiFrameCounter;
-  tempResource.m_uiHash = uiHash;
+  auto& usedTempResource = m_UsedTempResources[TempResourceType::Buffer].ExpandAndGetRef();
+  usedTempResource.m_pResource = tempResource.m_pResource;
+  usedTempResource.m_uiFrame = uiLastUseFrame != ezUInt64(-1) ? uiLastUseFrame : m_uiFrameCounter;
+  usedTempResource.m_uiHash = uiHash;
 
-  return pResource;
+  return tempResource;
+}
+
+void ezGALDeviceDX11::UnmapTempResource(TempResource& tempResource)
+{
+  if (tempResource.m_pData != nullptr)
+  {
+    m_pImmediateContext->Unmap(tempResource.m_pResource, 0);
+    tempResource.m_pData = nullptr;
+    tempResource.m_uiRowPitch = 0;
+    tempResource.m_uiDepthPitch = 0;
+  }
 }
 
 void ezGALDeviceDX11::FreeTempResources(ezUInt64 uiFrame)
@@ -1167,10 +1284,20 @@ void ezGALDeviceDX11::FreeTempResources(ezUInt64 uiFrame)
         auto it = m_FreeTempResources[type].Find(usedTempResource.m_uiHash);
         if (!it.IsValid())
         {
-          it = m_FreeTempResources[type].Insert(usedTempResource.m_uiHash, ezDynamicArray<ID3D11Resource*>(&m_Allocator));
+          it = m_FreeTempResources[type].Insert(usedTempResource.m_uiHash, ezDynamicArray<TempResource>(&m_Allocator));
         }
 
-        it.Value().PushBack(usedTempResource.m_pResource);
+        D3D11_MAPPED_SUBRESOURCE mapped;
+        HRESULT hRes = m_pImmediateContext->Map(usedTempResource.m_pResource, 0, D3D11_MAP_WRITE, 0, &mapped);
+        EZ_ASSERT_DEV(SUCCEEDED(hRes), "Implementation error");
+        EZ_IGNORE_UNUSED(hRes);
+
+        auto& tempResources = it.Value().ExpandAndGetRef();
+        tempResources.m_pResource = usedTempResource.m_pResource;
+        tempResources.m_pData = mapped.pData;
+        tempResources.m_uiRowPitch = mapped.RowPitch;
+        tempResources.m_uiDepthPitch = mapped.DepthPitch;
+
         m_UsedTempResources[type].PopFront();
       }
       else
@@ -1179,6 +1306,27 @@ void ezGALDeviceDX11::FreeTempResources(ezUInt64 uiFrame)
       }
     }
   }
+}
+
+void ezGALDeviceDX11::ProcessPendingCopies()
+{
+  EZ_PROFILE_AND_MARKER(GetCommandEncoder(), "PendingCopies");
+
+  for (auto& copy : m_PendingCopies)
+  {
+    UnmapTempResource(copy.m_SourceResource);
+
+    if (copy.m_vSourceSize == ezVec3U32(ezInvalidIndex))
+    {
+      m_pImmediateContext->CopyResource(copy.m_pDestResource, copy.m_SourceResource.m_pResource);
+    }
+    else
+    {
+      D3D11_BOX srcBox = {0, 0, 0, copy.m_vSourceSize.x, copy.m_vSourceSize.y, copy.m_vSourceSize.z};
+      m_pImmediateContext->CopySubresourceRegion(copy.m_pDestResource, copy.m_uiDestSubResource, copy.m_vDestPoint.x, copy.m_vDestPoint.y, copy.m_vDestPoint.z, copy.m_SourceResource.m_pResource, 0, &srcBox);
+    }
+  }
+  m_PendingCopies.Clear();
 }
 
 void ezGALDeviceDX11::FillFormatLookupTable()

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -708,7 +708,7 @@ void ezGALDeviceDX11::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffe
 #endif
 
   const ezUInt32 uiDestBufferSize = pBuffer->GetDescription().m_uiTotalSize;
-  
+
   auto& copy = m_PendingCopies.ExpandAndGetRef();
   copy.m_SourceResource = CopyToTempBuffer(sourceData, m_uiFrameCounter + 1);
   copy.m_pDestResource = pBufferDX11->GetDXBuffer();

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -176,7 +176,7 @@ private:
   };
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
-  // This code ensures in debug build that a buffer is not updated twice per frame in the same location (without using CopyToTempStorage)
+  // This code ensures in debug build that a buffer is not updated twice per frame in the same location
   struct BufferRange
   {
     inline bool overlapRange(ezUInt32 uiOffset, ezUInt32 uiLength) const

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -317,7 +317,7 @@ void ezGALCommandEncoder::UpdateBuffer(ezGALBufferHandle hDest, ezUInt32 uiDestO
       ezHybridArray<BufferRange, 1>& ranges = it.Value();
       for (const BufferRange& range : ranges)
       {
-        EZ_ASSERT_DEBUG(!range.overlapRange(uiDestOffset, sourceData.GetCount()), "A buffer was updated twice in one frame on the same memory range. If this is needed, use CopyToTempStorage mode instead.");
+        EZ_ASSERT_DEBUG(!range.overlapRange(uiDestOffset, sourceData.GetCount()), "A buffer was updated twice in one frame on the same memory range.");
       }
       BufferRange* pLastElement = ranges.IsEmpty() ? nullptr : &ranges.PeekBack();
       if (pLastElement && pLastElement->m_uiOffset + pLastElement->m_uiLength == uiDestOffset)

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -79,6 +79,14 @@ public:
   ezGALReadbackTextureHandle CreateReadbackTexture(const ezGALTextureCreationDescription& description);
   void DestroyReadbackTexture(ezGALReadbackTextureHandle hTexture);
 
+  // Resource update functions
+
+  /// \brief Ensures that the given buffer is updated at the beginning of the next frame.
+  void UpdateBufferForNextFrame(ezGALBufferHandle hBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset = 0);
+
+  /// \brief Ensures that the given texture is updated at the beginning of the next frame.
+  void UpdateTextureForNextFrame(ezGALTextureHandle hTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource = {}, const ezBoundingBoxu32& destinationBox = ezBoundingBoxu32::MakeZero());
+
   // Resource views
   ezGALTextureResourceViewHandle GetDefaultResourceView(ezGALTextureHandle hTexture);
   ezGALBufferResourceViewHandle GetDefaultResourceView(ezGALBufferHandle hBuffer);
@@ -395,6 +403,11 @@ protected:
 
   virtual ezGALVertexDeclaration* CreateVertexDeclarationPlatform(const ezGALVertexDeclarationCreationDescription& Description) = 0;
   virtual void DestroyVertexDeclarationPlatform(ezGALVertexDeclaration* pVertexDeclaration) = 0;
+
+  // Resource update functions
+
+  virtual void UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset) = 0;
+  virtual void UpdateTextureForNextFramePlatform(const ezGALTexture* pTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox) = 0;
 
   // GPU -> CPU query functions
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -978,6 +978,12 @@ void ezGALDevice::UpdateTextureForNextFrame(ezGALTextureHandle hTexture, const e
     EZ_ASSERT_DEV(sourceData.m_uiSlicePitch == 0 || sourceData.m_uiSlicePitch == uiSlicePitch, "Invalid slice pitch. Expected {0} got {1}", uiSlicePitch, sourceData.m_uiSlicePitch);
     EZ_ASSERT_DEBUG(sourceData.m_pData.GetCount() >= uiSlicePitch * uiDepth, "Not enough data provided to update texture");
 
+    ezGALSystemMemoryDescription finalSourceData = sourceData;
+    if (finalSourceData.m_uiSlicePitch == 0)
+    {
+      finalSourceData.m_uiSlicePitch = uiSlicePitch;
+    }
+
     ezBoundingBoxu32 finalDestBox = destinationBox;
     if (bDestBoxIsValid)
     {
@@ -989,7 +995,7 @@ void ezGALDevice::UpdateTextureForNextFrame(ezGALTextureHandle hTexture, const e
       finalDestBox.m_vMax = ezVec3U32(desc.m_uiWidth, desc.m_uiHeight, desc.m_uiDepth);
     }
 
-    UpdateTextureForNextFramePlatform(pTexture, sourceData, destinationSubResource, finalDestBox);
+    UpdateTextureForNextFramePlatform(pTexture, finalSourceData, destinationSubResource, finalDestBox);
   }
   else
   {

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -974,9 +974,23 @@ void ezGALDevice::UpdateTextureForNextFrame(ezGALTextureHandle hTexture, const e
 
     const ezUInt32 uiRowPitch = uiWidth * ezGALResourceFormat::GetBitsPerElement(desc.m_Format) / 8;
     const ezUInt32 uiSlicePitch = uiRowPitch * uiHeight;
-    EZ_ASSERT_DEV(sourceData.m_uiRowPitch == uiRowPitch, "Invalid row pitch. Expected {0} got {1}", uiRowPitch, sourceData.m_uiRowPitch);
-    EZ_ASSERT_DEV(sourceData.m_uiSlicePitch == 0 || sourceData.m_uiSlicePitch == uiSlicePitch, "Invalid slice pitch. Expected {0} got {1}", uiSlicePitch, sourceData.m_uiSlicePitch);
-    EZ_ASSERT_DEBUG(sourceData.m_pData.GetCount() >= uiSlicePitch * uiDepth, "Not enough data provided to update texture");
+    if (sourceData.m_uiRowPitch != uiRowPitch)
+    {
+      ezLog::Error("Invalid row pitch. Expected {0} got {1}", uiRowPitch, sourceData.m_uiRowPitch);
+      return;
+    }
+
+    if (sourceData.m_uiSlicePitch != 0 && sourceData.m_uiSlicePitch != uiSlicePitch)
+    {
+      ezLog::Error("Invalid slice pitch. Expected {0} got {1}", uiSlicePitch, sourceData.m_uiSlicePitch);
+      return;
+    }
+
+    if (sourceData.m_pData.GetCount() < uiSlicePitch * uiDepth)
+    {
+      ezLog::Error("Not enough data provided to update texture");
+      return;
+    }
 
     ezGALSystemMemoryDescription finalSourceData = sourceData;
     if (finalSourceData.m_uiSlicePitch == 0)

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -570,6 +570,8 @@ ezGALBufferHandle ezGALDevice::CreateBuffer(const ezGALBufferCreationDescription
 
 ezGALBufferHandle ezGALDevice::FinalizeBufferInternal(const ezGALBufferCreationDescription& desc, ezGALBuffer* pBuffer)
 {
+  EZ_ASSERT_DEBUG(m_Mutex.IsLocked(), "");
+
   if (pBuffer != nullptr)
   {
     ezGALBufferHandle hBuffer(m_Buffers.Insert(pBuffer));
@@ -928,6 +930,70 @@ void ezGALDevice::DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer)
   else
   {
     ezLog::Warning("DestroyReadbackBuffer called on invalid handle (double free?)");
+  }
+}
+
+void ezGALDevice::UpdateBufferForNextFrame(ezGALBufferHandle hBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset /*= 0*/)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  if (const ezGALBuffer* pBuffer = GetBuffer(hBuffer))
+  {
+    if (uiDestOffset + sourceData.GetCount() > pBuffer->GetDescription().m_uiTotalSize)
+    {
+      ezLog::Error("Trying to update buffer outside of its bounds!");
+      return;
+    }
+
+    UpdateBufferForNextFramePlatform(pBuffer, sourceData, uiDestOffset);
+  }
+  else
+  {
+    ezLog::Error("No valid buffer handle given to update!");
+  }
+}
+
+void ezGALDevice::UpdateTextureForNextFrame(ezGALTextureHandle hTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource /*= {}*/, const ezBoundingBoxu32& destinationBox /*= ezBoundingBoxu32::MakeInvalid()*/)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  if (const ezGALTexture* pTexture = GetTexture(hTexture))
+  {
+    auto& desc = pTexture->GetDescription();
+
+    const bool bDestBoxIsValid = destinationBox.IsValid() && destinationBox.GetExtents().IsZero() == false;
+    if (bDestBoxIsValid && (destinationBox.m_vMax.x > desc.m_uiWidth || destinationBox.m_vMax.y > desc.m_uiHeight || destinationBox.m_vMax.z > desc.m_uiDepth))
+    {
+      ezLog::Error("Trying to update texture outside of its bounds!");
+      return;
+    }
+
+    const ezUInt32 uiWidth = bDestBoxIsValid ? ezMath::Max(destinationBox.m_vMax.x - destinationBox.m_vMin.x, 1u) : desc.m_uiWidth;
+    const ezUInt32 uiHeight = bDestBoxIsValid ? ezMath::Max(destinationBox.m_vMax.y - destinationBox.m_vMin.y, 1u) : desc.m_uiHeight;
+    const ezUInt32 uiDepth = bDestBoxIsValid ? ezMath::Max(destinationBox.m_vMax.z - destinationBox.m_vMin.z, 1u) : desc.m_uiDepth;
+
+    const ezUInt32 uiRowPitch = uiWidth * ezGALResourceFormat::GetBitsPerElement(desc.m_Format) / 8;
+    const ezUInt32 uiSlicePitch = uiRowPitch * uiHeight;
+    EZ_ASSERT_DEV(sourceData.m_uiRowPitch == uiRowPitch, "Invalid row pitch. Expected {0} got {1}", uiRowPitch, sourceData.m_uiRowPitch);
+    EZ_ASSERT_DEV(sourceData.m_uiSlicePitch == 0 || sourceData.m_uiSlicePitch == uiSlicePitch, "Invalid slice pitch. Expected {0} got {1}", uiSlicePitch, sourceData.m_uiSlicePitch);
+    EZ_ASSERT_DEBUG(sourceData.m_pData.GetCount() >= uiSlicePitch * uiDepth, "Not enough data provided to update texture");
+
+    ezBoundingBoxu32 finalDestBox = destinationBox;
+    if (bDestBoxIsValid)
+    {
+      finalDestBox.m_vMax = finalDestBox.m_vMin + ezVec3U32(uiWidth, uiHeight, uiDepth);
+    }
+    else
+    {
+      finalDestBox.m_vMin = ezVec3U32(0, 0, 0);
+      finalDestBox.m_vMax = ezVec3U32(desc.m_uiWidth, desc.m_uiHeight, desc.m_uiDepth);
+    }
+
+    UpdateTextureForNextFramePlatform(pTexture, sourceData, destinationSubResource, finalDestBox);
+  }
+  else
+  {
+    ezLog::Error("No valid texture handle given to update!");
   }
 }
 

--- a/Code/Engine/RendererFoundation/Profiling/Profiling.h
+++ b/Code/Engine/RendererFoundation/Profiling/Profiling.h
@@ -23,11 +23,11 @@ protected:
 
 #if EZ_ENABLED(EZ_USE_PROFILING) || defined(EZ_DOCS)
 
-/// \brief Profiles the current scope using the given name and also inserts a marker with the given GALContext.
-#  define EZ_PROFILE_AND_MARKER(GALContext, szName) ezProfilingScopeAndMarker EZ_PP_CONCAT(_ezProfilingScope, EZ_SOURCE_LINE)(GALContext, szName)
+/// \brief Profiles the current scope using the given name and also inserts a marker with the given command encoder.
+#  define EZ_PROFILE_AND_MARKER(GALCommandEncoder, szName) ezProfilingScopeAndMarker EZ_PP_CONCAT(_ezProfilingScope, EZ_SOURCE_LINE)(GALCommandEncoder, szName)
 
 #else
 
-#  define EZ_PROFILE_AND_MARKER(GALContext, szName) /*empty*/
+#  define EZ_PROFILE_AND_MARKER(GALCommandEncoder, szName) /*empty*/
 
 #endif

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -351,7 +351,6 @@ struct ezGALUpdateMode
   {
     TransientConstantBuffer, ///< Can be executed at any time in a command encoder. Buffer must be completely overwritten. Data will not persist across frames. Only allowed on transient constant buffers.
     AheadOfTime,             ///< Can be executed at any time in a command encoder. Copy is ensured to happen before the next command in the command encoder. The same memory location can't be updated twice in one frame. Note that no GPU access must have happened to the modified memory range in the current command encoder before this call or undefined behavior will occur.
-    CopyToTempStorage        ///< Only allowed outside a render pass. Upload to temp buffer, then buffer to buffer transfer at the current time in the command buffer.
   };
 };
 

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -306,9 +306,6 @@ void ezGALCommandEncoderImplVulkan::UpdateBufferPlatform(const ezGALBuffer* pDes
     case ezGALUpdateMode::AheadOfTime:
       m_GALDeviceVulkan.GetInitContext().UpdateBuffer(pVulkanDestination, uiDestOffset, pSourceData);
       break;
-    case ezGALUpdateMode::CopyToTempStorage:
-      m_GALDeviceVulkan.UploadBufferStaging(&m_GALDeviceVulkan.GetStagingBufferPool(), m_pPipelineBarrier, *m_pCommandBuffer, pVulkanDestination, pSourceData, uiDestOffset);
-      break;
   }
 }
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -259,7 +259,7 @@ public:
   void ReportLiveGpuObjects();
 
   static void UploadBufferStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> pInitialData, vk::DeviceSize dstOffset = 0);
-  static void UploadTextureStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALTextureVulkan* pTexture, const vk::ImageSubresourceLayers& subResource, const ezGALSystemMemoryDescription& data);
+  static void UploadTextureStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALTextureVulkan* pTexture, const vk::ImageSubresourceLayers& subResource, const vk::Offset3D& imageOffset, const vk::Extent3D& imageExtent, const ezGALSystemMemoryDescription& data);
 
   struct OnBeforeImageDestroyedData
   {
@@ -361,6 +361,11 @@ protected:
 
   virtual ezGALVertexDeclaration* CreateVertexDeclarationPlatform(const ezGALVertexDeclarationCreationDescription& Description) override;
   virtual void DestroyVertexDeclarationPlatform(ezGALVertexDeclaration* pVertexDeclaration) override;
+
+  // Resource update functions
+
+  virtual void UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset) override;
+  virtual void UpdateTextureForNextFramePlatform(const ezGALTexture* pTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox) override;
 
   // GPU -> CPU query functions
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -180,7 +180,7 @@ public:
 
   ezInt32 GetMemoryIndex(vk::MemoryPropertyFlags properties, const vk::MemoryRequirements& requirements) const;
 
-  vk::Fence Submit(bool bAddSignalSemaphore = true);
+  vk::Fence Submit(bool bAddSignalSemaphore = true, bool bAddUpdateForNextFrameCommands = false);
 
   void DeleteLaterImpl(const PendingDeletion& deletion);
 
@@ -440,6 +440,7 @@ private:
   ezUniquePtr<ezQueryPoolVulkan> m_pQueryPool;
   ezUniquePtr<ezFenceQueueVulkan> m_pFenceQueue;
   ezUniquePtr<ezInitContextVulkan> m_pInitContext;
+  ezUniquePtr<ezInitContextVulkan> m_pUpdateForNextFrameContext;
 
   // We daisy-chain all command buffers in a frame in sequential order via this semaphore for now.
   vk::Semaphore m_lastCommandBufferFinished;

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -391,6 +391,8 @@ protected:
   /// \endcond
 
 private:
+  void WaitIdleInternal(bool bAddUpdateForNextFrameCommands);
+
   struct PerFrameData
   {
     /// \brief These are all fences passed into submit calls. For some reason waiting for the fence of the last submit is not enough. At least I can't get it to work (neither semaphores nor barriers make it past the validation layer).

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -609,6 +609,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   m_pQueryPool->Initialize(queueFamilyProperties[m_graphicsQueue.m_uiQueueFamily].timestampValidBits);
   m_pFenceQueue = EZ_NEW(&m_Allocator, ezFenceQueueVulkan, this);
   m_pInitContext = EZ_NEW(&m_Allocator, ezInitContextVulkan, this);
+  m_pUpdateForNextFrameContext = EZ_NEW(&m_Allocator, ezInitContextVulkan, this);
 
   ezSemaphorePoolVulkan::Initialize(m_device);
   ezFencePoolVulkan::Initialize(m_device);
@@ -751,6 +752,7 @@ ezResult ezGALDeviceVulkan::ShutdownPlatform()
   m_pQueryPool = nullptr;
   m_pFenceQueue = nullptr;
   m_pInitContext = nullptr;
+  m_pUpdateForNextFrameContext = nullptr;
 
   ezSemaphorePoolVulkan::DeInitialize();
   ezFencePoolVulkan::DeInitialize();
@@ -848,14 +850,19 @@ ezGALBufferHandle ezGALDeviceVulkan::CreateBufferInternal(const ezGALBufferCreat
   return FinalizeBufferInternal(Description, pBuffer);
 }
 
-vk::Fence ezGALDeviceVulkan::Submit(bool bAddSignalSemaphore)
+vk::Fence ezGALDeviceVulkan::Submit(bool bAddSignalSemaphore, bool bAddUpdateForNextFrameCommands)
 {
   m_pCommandEncoderImpl->BeforeCommandBufferSubmit();
   m_pStagingBufferPool->BeforeCommandBufferSubmit();
   vk::CommandBuffer initCommandBuffer = m_pInitContext->GetFinishedCommandBuffer();
-  bool bHasCmdBuffer = initCommandBuffer || m_PerFrameData[m_uiCurrentPerFrameData].m_currentCommandBuffer;
+  vk::CommandBuffer updateForNextFrameCommandBuffer;
+  if (bAddUpdateForNextFrameCommands)
+  {
+    updateForNextFrameCommandBuffer = m_pUpdateForNextFrameContext->GetFinishedCommandBuffer();
+  }
+  bool bHasCmdBuffer = initCommandBuffer || updateForNextFrameCommandBuffer || m_PerFrameData[m_uiCurrentPerFrameData].m_currentCommandBuffer;
 
-  ezHybridArray<vk::CommandBuffer, 2> buffers;
+  ezHybridArray<vk::CommandBuffer, 3> buffers;
   vk::SubmitInfo submitInfo = {};
   if (bHasCmdBuffer)
   {
@@ -865,6 +872,11 @@ vk::Fence ezGALDeviceVulkan::Submit(bool bAddSignalSemaphore)
       // Any background loading that happened up to this point needs to be submitted first.
       // The main render command buffer assumes that all new resources are in their default state which is made sure by submitting this command buffer.
       buffers.PushBack(initCommandBuffer);
+    }
+    if (updateForNextFrameCommandBuffer)
+    {
+      // Update for next frame needs to be submitted after the resource init but before the main command buffer.
+      buffers.PushBack(updateForNextFrameCommandBuffer);
     }
     if (mainCommandBuffer)
     {
@@ -1144,6 +1156,7 @@ void ezGALDeviceVulkan::DestroyTexturePlatform(ezGALTexture* pTexture)
   ezGALTextureVulkan* pVulkanTexture = static_cast<ezGALTextureVulkan*>(pTexture);
   GetCurrentPipelineBarrier().TextureDestroyed(pVulkanTexture);
   m_pInitContext->TextureDestroyed(pVulkanTexture);
+  m_pUpdateForNextFrameContext->TextureDestroyed(pVulkanTexture);
 
   pVulkanTexture->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanTexture);
@@ -1167,6 +1180,7 @@ void ezGALDeviceVulkan::DestroySharedTexturePlatform(ezGALTexture* pTexture)
   ezGALSharedTextureVulkan* pVulkanTexture = static_cast<ezGALSharedTextureVulkan*>(pTexture);
   GetCurrentPipelineBarrier().TextureDestroyed(pVulkanTexture);
   m_pInitContext->TextureDestroyed(pVulkanTexture);
+  m_pUpdateForNextFrameContext->TextureDestroyed(pVulkanTexture);
 
   pVulkanTexture->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanTexture);
@@ -1345,14 +1359,14 @@ void ezGALDeviceVulkan::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuf
 {
   const ezGALBufferVulkan* pBufferVulkan = static_cast<const ezGALBufferVulkan*>(pBuffer);
 
-  m_pInitContext->UpdateBuffer(pBufferVulkan, uiDestOffset, sourceData);
+  m_pUpdateForNextFrameContext->UpdateBuffer(pBufferVulkan, uiDestOffset, sourceData);
 }
 
 void ezGALDeviceVulkan::UpdateTextureForNextFramePlatform(const ezGALTexture* pTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox)
 {
   const ezGALTextureVulkan* pTextureVulkan = static_cast<const ezGALTextureVulkan*>(pTexture);
 
-  m_pInitContext->UpdateTexture(pTextureVulkan, destinationSubResource, destinationBox, sourceData);
+  m_pUpdateForNextFrameContext->UpdateTexture(pTextureVulkan, destinationSubResource, destinationBox, sourceData);
 }
 
 ezEnum<ezGALAsyncResult> ezGALDeviceVulkan::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& result)
@@ -1502,6 +1516,7 @@ void ezGALDeviceVulkan::BeginFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchain
 
   m_pStagingBufferPool->AfterBeginFrame();
   m_pInitContext->AfterBeginFrame();
+  m_pUpdateForNextFrameContext->AfterBeginFrame();
   {
     EZ_PROFILE_SCOPE("QueryPool");
     m_pQueryPool->AfterBeginFrame(GetCurrentCommandBuffer());
@@ -1513,6 +1528,8 @@ void ezGALDeviceVulkan::BeginFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchain
   sb.SetFormat("RENDER FRAME {}", uiAppFrame);
   m_pFrameTimingScope = ezProfilingScopeAndMarker::Start(m_pCommandEncoder.Borrow(), sb);
 #endif
+
+  Submit(false, true);
 
   EZ_PROFILE_SCOPE("AcquireNextRenderTargets");
   for (ezGALSwapChain* pSwapChain : swapchains)

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1352,7 +1352,7 @@ void ezGALDeviceVulkan::UpdateTextureForNextFramePlatform(const ezGALTexture* pT
 {
   const ezGALTextureVulkan* pTextureVulkan = static_cast<const ezGALTextureVulkan*>(pTexture);
 
-  //m_pInitContext->UpdateTexture(pTextureVulkan, sourceData, destinationSubResource, destinationBox);
+  // m_pInitContext->UpdateTexture(pTextureVulkan, sourceData, destinationSubResource, destinationBox);
 }
 
 ezEnum<ezGALAsyncResult> ezGALDeviceVulkan::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& result)

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -666,11 +666,8 @@ void ezGALDeviceVulkan::UploadBufferStaging(ezStagingBufferPoolVulkan* pStagingB
   pPipelineBarrier->AccessBuffer(pBuffer, region.dstOffset, region.size, vk::PipelineStageFlagBits::eTransfer, vk::AccessFlagBits::eTransferWrite, pBuffer->GetUsedByPipelineStage(), pBuffer->GetAccessMask());
 }
 
-void ezGALDeviceVulkan::UploadTextureStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALTextureVulkan* pTexture, const vk::ImageSubresourceLayers& subResource, const ezGALSystemMemoryDescription& data)
+void ezGALDeviceVulkan::UploadTextureStaging(ezStagingBufferPoolVulkan* pStagingBufferPool, ezPipelineBarrierVulkan* pPipelineBarrier, vk::CommandBuffer commandBuffer, const ezGALTextureVulkan* pTexture, const vk::ImageSubresourceLayers& subResource, const vk::Offset3D& imageOffset, const vk::Extent3D& imageExtent, const ezGALSystemMemoryDescription& data)
 {
-  const vk::Offset3D imageOffset = {0, 0, 0};
-  const vk::Extent3D imageExtent = pTexture->GetMipLevelSize(subResource.mipLevel);
-
   auto getRange = [](const vk::ImageSubresourceLayers& layers) -> vk::ImageSubresourceRange
   {
     vk::ImageSubresourceRange range;
@@ -1342,6 +1339,20 @@ void ezGALDeviceVulkan::DestroyVertexDeclarationPlatform(ezGALVertexDeclaration*
   ezResourceCacheVulkan::ResourceDeleted(pVertexDeclarationVulkan);
   pVertexDeclarationVulkan->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVertexDeclarationVulkan);
+}
+
+void ezGALDeviceVulkan::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset)
+{
+  const ezGALBufferVulkan* pBufferVulkan = static_cast<const ezGALBufferVulkan*>(pBuffer);
+
+  m_pInitContext->UpdateBuffer(pBufferVulkan, uiDestOffset, sourceData);
+}
+
+void ezGALDeviceVulkan::UpdateTextureForNextFramePlatform(const ezGALTexture* pTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox)
+{
+  const ezGALTextureVulkan* pTextureVulkan = static_cast<const ezGALTextureVulkan*>(pTexture);
+
+  //m_pInitContext->UpdateTexture(pTextureVulkan, sourceData, destinationSubResource, destinationBox);
 }
 
 ezEnum<ezGALAsyncResult> ezGALDeviceVulkan::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& result)

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1352,7 +1352,7 @@ void ezGALDeviceVulkan::UpdateTextureForNextFramePlatform(const ezGALTexture* pT
 {
   const ezGALTextureVulkan* pTextureVulkan = static_cast<const ezGALTextureVulkan*>(pTexture);
 
-  // m_pInitContext->UpdateTexture(pTextureVulkan, sourceData, destinationSubResource, destinationBox);
+  m_pInitContext->UpdateTexture(pTextureVulkan, destinationSubResource, destinationBox, sourceData);
 }
 
 ezEnum<ezGALAsyncResult> ezGALDeviceVulkan::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& result)

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -738,7 +738,7 @@ ezResult ezGALDeviceVulkan::ShutdownPlatform()
     return EZ_SUCCESS;
   }
 
-  WaitIdlePlatform();
+  WaitIdleInternal(true);
 
   m_pStagingBufferPool->DeInitialize();
   m_pStagingBufferPool = nullptr;
@@ -1688,8 +1688,13 @@ void ezGALDeviceVulkan::FlushPlatform()
 
 void ezGALDeviceVulkan::WaitIdlePlatform()
 {
+  WaitIdleInternal(false);
+}
+
+void ezGALDeviceVulkan::WaitIdleInternal(bool bAddUpdateForNextFrameCommands)
+{
   // Make sure command buffers get flushed. Also, no need to add a wait semaphore if we flush anyway, all commands will be done.
-  Submit(false);
+  Submit(false, bAddUpdateForNextFrameCommands);
   m_device.waitIdle();
   DestroyDeadObjects();
   for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_PerFrameData); ++i)

--- a/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
@@ -7,7 +7,7 @@
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
-
+#include <RendererVulkan/Resources/BufferVulkan.h>
 
 ezInitContextVulkan::ezInitContextVulkan(ezGALDeviceVulkan* pDevice)
   : m_pDevice(pDevice)

--- a/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
@@ -4,10 +4,10 @@
 #include <RendererVulkan/Device/InitContext.h>
 #include <RendererVulkan/Pools/CommandBufferPoolVulkan.h>
 #include <RendererVulkan/Pools/StagingBufferPoolVulkan.h>
+#include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
-#include <RendererVulkan/Resources/BufferVulkan.h>
 
 ezInitContextVulkan::ezInitContextVulkan(ezGALDeviceVulkan* pDevice)
   : m_pDevice(pDevice)

--- a/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
@@ -144,7 +144,10 @@ void ezInitContextVulkan::InitTexture(const ezGALTextureVulkan* pTexture, vk::Im
         subresourceLayers.baseArrayLayer = uiLayer;
         subresourceLayers.layerCount = 1;
 
-        m_pDevice->UploadTextureStaging(m_pStagingBufferPool.Borrow(), m_pPipelineBarrier.Borrow(), m_currentCommandBuffer, pTexture, subresourceLayers, subResourceData);
+        const vk::Offset3D imageOffset = {0, 0, 0};
+        const vk::Extent3D imageExtent = pTexture->GetMipLevelSize(uiMipLevel);
+
+        m_pDevice->UploadTextureStaging(m_pStagingBufferPool.Borrow(), m_pPipelineBarrier.Borrow(), m_currentCommandBuffer, pTexture, subresourceLayers, imageOffset, imageExtent, subResourceData);
       }
     }
   }
@@ -162,7 +165,7 @@ void ezInitContextVulkan::TextureDestroyed(const ezGALTextureVulkan* pTexture)
   m_pPipelineBarrier->TextureDestroyed(pTexture);
 }
 
-void ezInitContextVulkan::InitBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> pInitialData)
+void ezInitContextVulkan::InitBuffer(const ezGALBufferVulkan* pBuffer, ezConstByteArrayPtr pInitialData)
 {
   EZ_LOCK(m_Lock);
 
@@ -182,7 +185,26 @@ void ezInitContextVulkan::InitBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPt
   }
 }
 
-void ezInitContextVulkan::UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezUInt32 uiOffset, ezArrayPtr<const ezUInt8> pSourceData)
+void ezInitContextVulkan::UpdateTexture(const ezGALTextureVulkan* pTexture, const ezGALTextureSubresource& subresource, const ezBoundingBoxu32& box, const ezGALSystemMemoryDescription& sourceData)
+{
+  EZ_LOCK(m_Lock);
+
+  EnsureCommandBufferExists();
+
+  const ezVec3U32 boxExtents = box.GetExtents();
+  const vk::Offset3D imageOffset = {(ezInt32)box.m_vMin.x, (ezInt32)box.m_vMin.y, (ezInt32)box.m_vMin.z};
+  const vk::Extent3D imageExtent = {boxExtents.x, boxExtents.y, boxExtents.z};
+
+  vk::ImageSubresourceLayers subresourceLayers;
+  subresourceLayers.aspectMask = ezConversionUtilsVulkan::IsDepthFormat(pTexture->GetImageFormat()) ? vk::ImageAspectFlagBits::eDepth : vk::ImageAspectFlagBits::eColor;
+  subresourceLayers.mipLevel = subresource.m_uiMipLevel;
+  subresourceLayers.baseArrayLayer = subresource.m_uiArraySlice;
+  subresourceLayers.layerCount = 1;
+
+  m_pDevice->UploadTextureStaging(m_pStagingBufferPool.Borrow(), m_pPipelineBarrier.Borrow(), m_currentCommandBuffer, pTexture, subresourceLayers, imageOffset, imageExtent, sourceData);
+}
+
+void ezInitContextVulkan::UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezUInt32 uiOffset, ezConstByteArrayPtr pSourceData)
 {
   EZ_LOCK(m_Lock);
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -396,6 +396,8 @@ void ezGALSwapChainVulkan::DestroySwapChainInternal(ezGALDeviceVulkan* pVulkanDe
   ezUInt32 uiSwapChainImages = m_swapChainTextures.GetCount();
   for (ezUInt32 i = 0; i < uiSwapChainImages; i++)
   {
+    pVulkanDevice->GetInitContext().TextureDestroyed(static_cast<const ezGALTextureVulkan*>(pVulkanDevice->GetTexture(m_swapChainTextures[i])));
+
     pVulkanDevice->DestroyTexture(m_swapChainTextures[i]);
   }
   m_swapChainTextures.Clear();

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -11,6 +11,7 @@
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
+#include <RendererVulkan/Device/InitContext.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -6,12 +6,12 @@
 #include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Device/InitContext.h>
 #include <RendererVulkan/Device/SwapChainVulkan.h>
 #include <RendererVulkan/Pools/SemaphorePoolVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
-#include <RendererVulkan/Device/InitContext.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>

--- a/Code/Engine/RendererVulkan/Device/InitContext.h
+++ b/Code/Engine/RendererVulkan/Device/InitContext.h
@@ -35,13 +35,16 @@ public:
   /// \brief Initializes a buffer with the given data.
   /// \param pBuffer The buffer to initialize.
   /// \param pInitialData The initial data that the buffer should be filled with.
-  void InitBuffer(const ezGALBufferVulkan* pBuffer, ezArrayPtr<const ezUInt8> pInitialData);
+  void InitBuffer(const ezGALBufferVulkan* pBuffer, ezConstByteArrayPtr pInitialData);
+
+  /// \brief Updates a texture region
+  void UpdateTexture(const ezGALTextureVulkan* pTexture, const ezGALTextureSubresource& subresource, const ezBoundingBoxu32& box, const ezGALSystemMemoryDescription& sourceData);
 
   /// \brief Updates a buffer range
   /// \param pBuffer The buffer to update.
   /// \param uiOffset The offset inside the buffer where the new data should be placed.
   /// \param pSourceData The new data to update the buffer with.
-  void UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezUInt32 uiOffset, ezArrayPtr<const ezUInt8> pSourceData);
+  void UpdateBuffer(const ezGALBufferVulkan* pBuffer, ezUInt32 uiOffset, ezConstByteArrayPtr pSourceData);
 
   /// \brief Used by ezUniformBufferPoolVulkan to write the entire uniform scratch pool to the GPU
   /// \param gpuBuffer The device local buffer to update.

--- a/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
@@ -3,6 +3,7 @@
 #include <RendererVulkan/Pools/QueryPoolVulkan.h>
 
 #include <RendererVulkan/Device/DeviceVulkan.h>
+#include <Foundation/Profiling/Profiling.h>
 
 ezQueryPoolVulkan::ezQueryPoolVulkan(ezGALDeviceVulkan* pDevice)
   : m_pDevice(pDevice)

--- a/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
@@ -2,8 +2,8 @@
 
 #include <RendererVulkan/Pools/QueryPoolVulkan.h>
 
-#include <RendererVulkan/Device/DeviceVulkan.h>
 #include <Foundation/Profiling/Profiling.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
 
 ezQueryPoolVulkan::ezQueryPoolVulkan(ezGALDeviceVulkan* pDevice)
   : m_pDevice(pDevice)

--- a/Code/EnginePlugins/ParticlePlugin/Type/Point/PointRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Point/PointRenderer.cpp
@@ -49,7 +49,7 @@ void ezParticlePointRenderer::RenderBatch(const ezRenderViewContext& renderViewC
 
   // Bind mesh buffer
   {
-    pRenderContext->BindMeshBuffer(ezGALBufferHandle(), ezGALBufferHandle(), nullptr, ezGALPrimitiveTopology::Points, s_uiParticlesPerBatch);
+    pRenderContext->BindNullMeshBuffer(ezGALPrimitiveTopology::Points, s_uiParticlesPerBatch);
   }
 
   // now render all particle effects of type Point

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiConversionUtils.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiConversionUtils.cpp
@@ -95,6 +95,9 @@ namespace ezRmlUiConversionUtils
       case ezVariant::Type::String:
         return Rml::Variant(value.Get<ezString>());
 
+      case ezVariant::Type::HashedString:
+        return Rml::Variant(value.Get<ezHashedString>().GetString());
+
       default:
         EZ_ASSERT_NOT_IMPLEMENTED;
         return Rml::Variant();

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.h
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.h
@@ -30,8 +30,8 @@ private:
   {
     DefaultCapture = 5,
     StructuredBuffer_InitialData = 5,
-    StructuredBuffer_CopyToTempStorage = 6,
-    StructuredBuffer_CopyToTempStorage2 = 7,
+    StructuredBuffer_UpdateForNextFrame = 6,
+    StructuredBuffer_UpdateForNextFrame2 = 7,
     StructuredBuffer_Transient1 = 8,
     StructuredBuffer_Transient2 = 9,
     Timestamps_MaxWaitTime = ezMath::MaxValue<ezUInt32>(),
@@ -65,6 +65,7 @@ private:
   void VertexBufferTest();
   void IndexBufferTest();
   void ConstantBufferTest();
+  void StructuredBufferTestUpload();
   void StructuredBufferTest();
   void Texture2D();
   void Texture2DArray();

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -513,15 +513,16 @@ void EvaluateFillLight(float3 worldPosition, float3 worldNormal, float3 diffuseC
   directionality = min(directionality, fillParams.y);
   float NdotL = dot(worldNormal, lightVector);
   attenuation *= saturate(lerp(1.0, NdotL, directionality));
+  attenuation *= lightData.intensity;
 
   float3 lightColor = RGB8ToFloat3(lightData.colorAndType);
   if (type == LIGHT_TYPE_FILL_ADDITIVE)
   {
-    diffuseLight += diffuseColor * lightColor * (lightData.intensity * attenuation);
+    diffuseLight += diffuseColor * lightColor * attenuation;
   }
   else if (type == LIGHT_TYPE_FILL_MODULATE_INDIRECT)
   {
-    indirectLightModulation *= max(lerp(1.0, lightColor * lightData.intensity, attenuation), 0.0);
+    indirectLightModulation *= max(lerp(1.0, lightColor, attenuation), 0.0);
   }
 }
 


### PR DESCRIPTION
* Added two new methods to GALDevice: UpdateBufferForNextFrame and UpdateTextureForNextFrame. These can be directly called from game code or during extraction to update a buffer or texture for the next render frame. E.g. this is now used for skinning buffer update or for the occlusion debug texture.
* Removed CopyToTempBuffer update mode for buffers since this is now basically replaced with the new methods above and was not used in our code anyways.
* Added a max draw distance to the debug text component which can be used to prevent clutter from too much debug text on screen.
* Various other smaller fixes and optimizations.