### PR TITLE
AngelScript: #include dependencies, error line mapping

### DIFF
--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptAsset/AngelScriptAsset.h
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptAsset/AngelScriptAsset.h
@@ -42,6 +42,7 @@ class ezAngelScriptAssetProperties : public ezReflectedClass
   ezString m_sCode;
 
   ezDynamicArray<ezAngelScriptParameter> m_Parameters;
+  ezDynamicArray<ezString> m_Dependencies;
 };
 
 class ezAngelScriptAssetDocument : public ezSimpleAssetDocument<ezAngelScriptAssetProperties>

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptWindow/AngelScriptWindow.moc.h
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptWindow/AngelScriptWindow.moc.h
@@ -41,6 +41,7 @@ private:
   };
 
   ezDynamicArray<ExposedParam> m_ExposedParams;
+  ezDynamicArray<ezString> m_Dependencies;
 
   ezAngelScriptAssetDocument* m_pAssetDoc = nullptr;
 

--- a/Code/EditorPlugins/AngelScript/EnginePluginAngelScript/AngelScriptAsset/AngelScriptContext.h
+++ b/Code/EditorPlugins/AngelScript/EnginePluginAngelScript/AngelScriptAsset/AngelScriptContext.h
@@ -19,7 +19,7 @@ protected:
   void DestroyViewContext(ezEngineProcessViewContext* pContext) override;
 
   void SyncExposedParameters();
-  asIScriptModule* CompileModule(ezStringBuilder& out_sCode);
+  asIScriptModule* CompileModule(ezStringBuilder& out_sCode, ezSet<ezString>* out_pDependencies);
   void RetrieveScriptInfos(ezStringView sBasePath);
 
   ezString m_sInputFile;

--- a/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Implementation/TokenParseUtils.cpp
@@ -236,19 +236,22 @@ namespace ezTokenParseUtils
           sCurFile = Tokens[t]->m_File;
         }
 
-        if (Tokens[t]->m_iType == ezTokenType::Newline)
-        {
-          ++uiCurLine;
-        }
-
         if (t > 0 && Tokens[t - 1]->m_iType == ezTokenType::Newline)
         {
           if (Tokens[t]->m_uiLine != uiCurLine || Tokens[t]->m_File != sCurFile)
           {
-            ref_sResult.AppendFormat("\n#line {0} \"{1}\"\n", Tokens[t]->m_uiLine, Tokens[t]->m_File);
+            if (!ref_sResult.EndsWith("\n"))
+              ref_sResult.Append("\n");
+
+            ref_sResult.AppendFormat("#line {0} \"{1}\"\n", Tokens[t]->m_uiLine, Tokens[t]->m_File);
             uiCurLine = Tokens[t]->m_uiLine;
             sCurFile = Tokens[t]->m_File;
           }
+        }
+
+        if (Tokens[t]->m_iType == ezTokenType::Newline)
+        {
+          ++uiCurLine;
         }
       }
 

--- a/Code/EnginePlugins/AngelScriptPlugin/Resources/AngelScriptResource.cpp
+++ b/Code/EnginePlugins/AngelScriptPlugin/Resources/AngelScriptResource.cpp
@@ -11,9 +11,9 @@
 #include <Foundation/Communication/Message.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/IO/ChunkStream.h>
+#include <Foundation/IO/CompressedStreamZstd.h>
 #include <Foundation/IO/StringDeduplicationContext.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
-#include <Foundation/IO/CompressedStreamZstd.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAngelScriptResource, 1, ezRTTIDefaultAllocator<ezAngelScriptResource>)

--- a/Code/EnginePlugins/AngelScriptPlugin/Resources/AngelScriptResource.cpp
+++ b/Code/EnginePlugins/AngelScriptPlugin/Resources/AngelScriptResource.cpp
@@ -13,6 +13,7 @@
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/IO/StringDeduplicationContext.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
+#include <Foundation/IO/CompressedStreamZstd.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAngelScriptResource, 1, ezRTTIDefaultAllocator<ezAngelScriptResource>)
@@ -88,7 +89,43 @@ ezResourceLoadDesc ezAngelScriptResource::UpdateContent(ezStreamReader* pStream)
   ezUInt8 uiVersion = 1;
   (*pStream) >> uiVersion;
 
-  (*pStream) >> m_sClassName;
+  ezUInt8 uiCompressionMode = 0;
+
+  if (uiVersion >= 4)
+  {
+    (*pStream) >> uiCompressionMode;
+  }
+
+  ezStreamReader* pDeCompressor = pStream;
+
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+  ezCompressedStreamReaderZstd decompressorZstd;
+#endif
+
+  switch (uiCompressionMode)
+  {
+    case 0:
+      break;
+
+    case 1:
+#ifdef BUILDSYSTEM_ENABLE_ZSTD_SUPPORT
+      decompressorZstd.SetInputStream(pStream);
+      pDeCompressor = &decompressorZstd;
+      break;
+#else
+      ezLog::Error("AngelScript is compressed with zstandard, but support for this compressor is not compiled in.");
+      ld.m_State = ezResourceState::LoadedResourceMissing;
+      return res;
+#endif
+
+    default:
+      ezLog::Error("AngelScript is compressed with an unknown algorithm.");
+      ld.m_State = ezResourceState::LoadedResourceMissing;
+      return ld;
+  }
+
+  ezStreamReader& stream = *pDeCompressor;
+  stream >> m_sClassName;
 
   ezStringBuilder sModuleID;
   sModuleID.SetFormat("{}-{}", GetResourceID(), GetCurrentResourceChangeCounter());
@@ -97,19 +134,18 @@ ezResourceLoadDesc ezAngelScriptResource::UpdateContent(ezStreamReader* pStream)
 
   if (uiVersion == 1)
   {
-    (*pStream) >> m_sScriptContent;
-    // m_pModule = pAs->CompileModule(sModuleID, m_sClassName, m_sScriptContent);
-    return ld;
+    stream >> m_sScriptContent;
+    m_pModule = pAs->CompileModule(sModuleID, m_sClassName, "main", m_sScriptContent, nullptr, nullptr);
   }
   else
   {
     ezHybridArray<ezUInt8, 1024 * 8> bytecode;
-    (*pStream).ReadArray(bytecode).AssertSuccess();
+    stream.ReadArray(bytecode).AssertSuccess();
 
     if (uiVersion >= 3)
     {
-      (*pStream) >> m_sScriptContent;
-      m_pModule = pAs->CompileModule(sModuleID, m_sClassName, "main", m_sScriptContent, nullptr);
+      stream >> m_sScriptContent;
+      m_pModule = pAs->CompileModule(sModuleID, m_sClassName, "main", m_sScriptContent, nullptr, nullptr);
     }
     else
     {

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.cpp
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.cpp
@@ -49,6 +49,15 @@ static void ezAsFree(void* pPtr)
   g_pAsAllocator->Deallocate(pPtr);
 }
 
+static void AsThrow(ezStringView msg)
+{
+  if (asIScriptContext* ctx = asGetActiveContext())
+  {
+    ezStringBuilder tmp;
+    ctx->SetException(msg.GetData(tmp), false);
+  }
+}
+
 ezAngelScriptEngineSingleton::ezAngelScriptEngineSingleton()
   : m_SingletonRegistrar(this)
 {
@@ -64,7 +73,7 @@ ezAngelScriptEngineSingleton::ezAngelScriptEngineSingleton()
   m_pEngine->SetEngineProperty(asEP_REQUIRE_ENUM_SCOPE, 1);
   m_pEngine->SetEngineProperty(asEP_DISALLOW_GLOBAL_VARS, 1);
 
-  AS_CHECK(m_pEngine->SetMessageCallback(asFUNCTION(MessageCallback), 0, asCALL_CDECL));
+  AS_CHECK(m_pEngine->SetMessageCallback(asMETHOD(ezAngelScriptEngineSingleton, CompilerMessageCallback), this, asCALL_THISCALL));
   AS_CHECK(m_pEngine->SetTranslateAppExceptionCallback(asMETHOD(ezAngelScriptEngineSingleton, ExceptionCallback), this, asCALL_THISCALL));
 
   m_pStringFactory = EZ_DEFAULT_NEW(ezAsStringFactory);
@@ -72,6 +81,8 @@ ezAngelScriptEngineSingleton::ezAngelScriptEngineSingleton()
   AS_CHECK(m_pEngine->RegisterInterface("ezAngelScriptMessage"));
 
   RegisterStandardTypes();
+
+  AS_CHECK(m_pEngine->RegisterGlobalFunction("void throw(ezStringView)", asFUNCTION(AsThrow), asCALL_CDECL));
 
   m_pEngine->RegisterStringFactory("ezStringView", m_pStringFactory);
 
@@ -109,22 +120,6 @@ void ezAngelScriptEngineSingleton::AddForbiddenType(const char* szTypeName)
 bool ezAngelScriptEngineSingleton::IsTypeForbidden(const asITypeInfo* pType) const
 {
   return m_ForbiddenTypes.Contains(pType);
-}
-
-void ezAngelScriptEngineSingleton::MessageCallback(const asSMessageInfo* msg, void* param)
-{
-  switch (msg->type)
-  {
-    case asMSGTYPE_ERROR:
-      ezLog::Error("AngelScript: {} ({}, {}) : {}", msg->section, msg->row, msg->col, msg->message);
-      break;
-    case asMSGTYPE_WARNING:
-      ezLog::Warning("AngelScript: {} ({}, {}) : {}", msg->section, msg->row, msg->col, msg->message);
-      break;
-    case asMSGTYPE_INFORMATION:
-      ezLog::Info("AngelScript: {} ({}, {}) : {}", msg->section, msg->row, msg->col, msg->message);
-      break;
-  }
 }
 
 void ezAngelScriptEngineSingleton::ExceptionCallback(asIScriptContext* pContext)
@@ -619,6 +614,14 @@ void ezAngelScriptEngineSingleton::RegisterTypeProperties(const char* szTypeName
         const ezRTTI* pPropRtti = pMember->GetSpecificType();
 
         sVarTypeName = ezAngelScriptUtils::VariantTypeToString(pPropRtti->GetVariantType());
+
+        if (sVarTypeName.IsEmpty())
+        {
+          if (pPropRtti->GetTypeName() == "ezGameObjectHandle" || pPropRtti->GetTypeName() == "ezComponentHandle")
+          {
+            sVarTypeName = pPropRtti->GetTypeName();
+          }
+        }
       }
 
       if (!sVarTypeName.IsEmpty())

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.cpp
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.cpp
@@ -49,12 +49,12 @@ static void ezAsFree(void* pPtr)
   g_pAsAllocator->Deallocate(pPtr);
 }
 
-static void AsThrow(ezStringView msg)
+static void AsThrow(ezStringView sMsg)
 {
   if (asIScriptContext* ctx = asGetActiveContext())
   {
     ezStringBuilder tmp;
-    ctx->SetException(msg.GetData(tmp), false);
+    ctx->SetException(sMsg.GetData(tmp), false);
   }
 }
 

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.h
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.h
@@ -30,7 +30,7 @@ public:
   asIScriptEngine* GetEngine() const { return m_pEngine; }
 
   asIScriptModule* SetModuleCode(ezStringView sModuleName, ezStringView sCode, bool bAddExternalSection);
-  asIScriptModule* CompileModule(ezStringView sModuleName, ezStringView sMainClass, ezStringView sRefFilePath, ezStringView sCode, ezStringBuilder* out_pProcessedCode);
+  asIScriptModule* CompileModule(ezStringView sModuleName, ezStringView sMainClass, ezStringView sRefFilePath, ezStringView sCode, ezStringBuilder* out_pProcessedCode, ezSet<ezString>* out_pDependencies);
   ezResult ValidateModule(asIScriptModule* pModule) const;
 
   const ezSet<ezString>& GetNotRegistered() const { return m_NotRegistered; }
@@ -38,7 +38,7 @@ public:
 private:
   void AddForbiddenType(const char* szTypeName);
   bool IsTypeForbidden(const asITypeInfo* pType) const;
-  static void MessageCallback(const asSMessageInfo* msg, void* param);
+  void CompilerMessageCallback(const asSMessageInfo* msg);
   void ExceptionCallback(asIScriptContext* pContext);
 
   void RegisterStandardTypes();
@@ -123,4 +123,7 @@ private:
   ezAsStringFactory* m_pStringFactory = nullptr;
 
   ezSet<ezString> m_NotRegistered;
+
+  ezMutex m_CompilerMutex;
+  ezStringView m_sCodeInCompilation;
 };

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsInstance.cpp
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsInstance.cpp
@@ -86,5 +86,5 @@ ezVariant ezAngelScriptInstance::GetInstanceVariable(const ezHashedString& sName
 
 void ezAngelScriptInstance::ExceptionCallback(asIScriptContext* pContext)
 {
-  ezLog::Error("AS '{}': {}", m_pOwnerComponent->GetScriptClass().GetResourceIdOrDescription(), pContext->GetExceptionString());
+  ezLog::Error("AS Exception '{}' - in '{}'", pContext->GetExceptionString(), m_pOwnerComponent->GetScriptClass().GetResourceIdOrDescription());
 }

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltDynamicActorComponent.cpp
@@ -362,7 +362,12 @@ void ezJoltDynamicActorComponent::AddLinearForce(const ezVec3& vForce)
     return;
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-  pBodies->AddForce(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(vForce));
+  const JPH::BodyID bodyId(m_uiJoltBodyID);
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pBodies->AddForce(bodyId, ezJoltConversionUtils::ToVec3(vForce));
+  }
 }
 
 void ezJoltDynamicActorComponent::AddLinearImpulse(const ezVec3& vImpulse)
@@ -371,7 +376,12 @@ void ezJoltDynamicActorComponent::AddLinearImpulse(const ezVec3& vImpulse)
     return;
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-  pBodies->AddImpulse(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(vImpulse));
+  const JPH::BodyID bodyId(m_uiJoltBodyID);
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pBodies->AddImpulse(bodyId, ezJoltConversionUtils::ToVec3(vImpulse));
+  }
 }
 
 void ezJoltDynamicActorComponent::AddAngularForce(const ezVec3& vForce)
@@ -380,7 +390,12 @@ void ezJoltDynamicActorComponent::AddAngularForce(const ezVec3& vForce)
     return;
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-  pBodies->AddTorque(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(vForce));
+  const JPH::BodyID bodyId(m_uiJoltBodyID);
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pBodies->AddTorque(bodyId, ezJoltConversionUtils::ToVec3(vForce));
+  }
 }
 
 void ezJoltDynamicActorComponent::AddAngularImpulse(const ezVec3& vImpulse)
@@ -389,7 +404,12 @@ void ezJoltDynamicActorComponent::AddAngularImpulse(const ezVec3& vImpulse)
     return;
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-  pBodies->AddAngularImpulse(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(vImpulse));
+  const JPH::BodyID bodyId(m_uiJoltBodyID);
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pBodies->AddAngularImpulse(bodyId, ezJoltConversionUtils::ToVec3(vImpulse));
+  }
 }
 
 void ezJoltDynamicActorComponent::AddConstraint(ezComponentHandle hComponent)
@@ -408,7 +428,12 @@ void ezJoltDynamicActorComponent::AddForceAtPos(ezMsgPhysicsAddForce& ref_msg)
     return;
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-  pBodies->AddForce(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(ref_msg.m_vForce), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  const JPH::BodyID bodyId(m_uiJoltBodyID);
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pBodies->AddForce(bodyId, ezJoltConversionUtils::ToVec3(ref_msg.m_vForce), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  }
 }
 
 void ezJoltDynamicActorComponent::AddImpulseAtPos(ezMsgPhysicsAddImpulse& ref_msg)
@@ -417,7 +442,12 @@ void ezJoltDynamicActorComponent::AddImpulseAtPos(ezMsgPhysicsAddImpulse& ref_ms
     return;
 
   auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-  pBodies->AddImpulse(JPH::BodyID(m_uiJoltBodyID), ezJoltConversionUtils::ToVec3(ref_msg.m_vImpulse), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  const JPH::BodyID bodyId(m_uiJoltBodyID);
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pBodies->AddImpulse(bodyId, ezJoltConversionUtils::ToVec3(ref_msg.m_vImpulse), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  }
 }
 
 float ezJoltDynamicActorComponent::GetMass() const

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -432,7 +432,7 @@ void ezJoltCharacterControllerComponent::CreatePresenceBody()
 
   m_uiPresenceBodyID = pBody->GetID().GetIndexAndSequenceNumber();
 
-  m_uiPresenceBodyAddCounter = pModule->QueueBodyToAdd(pBody, true);
+  pModule->QueueBodyToAdd(pBody, true);
 }
 
 void ezJoltCharacterControllerComponent::RemovePresenceBody()
@@ -470,11 +470,11 @@ void ezJoltCharacterControllerComponent::MovePresenceBody(ezTime deltaTime)
 
   ezJoltWorldModule* pModule = GetWorld()->GetOrCreateModule<ezJoltWorldModule>();
 
-  if (pModule->IsBodyStillQueuedToAdd(m_uiPresenceBodyAddCounter))
-    return;
-
   auto* pSystem = pModule->GetJoltSystem();
   auto* pBodies = &pSystem->GetBodyInterface();
+
+  if (!pBodies->IsAdded(bodyId))
+    return;
 
   const ezSimdTransform trans = GetOwner()->GetGlobalTransformSimd();
 

--- a/Code/EnginePlugins/JoltPlugin/Character/JoltCharacterControllerComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Character/JoltCharacterControllerComponent.h
@@ -182,7 +182,6 @@ private:
   void MovePresenceBody(ezTime deltaTime);
 
   ezUInt32 m_uiPresenceBodyID = ezInvalidIndex;
-  ezUInt32 m_uiPresenceBodyAddCounter = 0;
 
   ezJoltBodyFilter m_BodyFilter;
   ezUInt32 m_uiUserDataIndex = ezInvalidIndex;

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
@@ -371,7 +371,11 @@ void ezJoltRagdollComponent::OnMsgPhysicsAddImpulse(ezMsgPhysicsAddImpulse& ref_
   if (!bodyId.IsInvalid())
   {
     auto pBodies = &GetWorld()->GetModule<ezJoltWorldModule>()->GetJoltSystem()->GetBodyInterface();
-    pBodies->AddImpulse(bodyId, ezJoltConversionUtils::ToVec3(ref_msg.m_vImpulse), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+
+    if (pBodies->IsAdded(bodyId))
+    {
+      pBodies->AddImpulse(bodyId, ezJoltConversionUtils::ToVec3(ref_msg.m_vImpulse), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+    }
   }
 }
 
@@ -725,7 +729,10 @@ void ezJoltRagdollComponent::ApplyInitialImpulse(ezJoltWorldModule& worldModule,
     }
   }
 
-  pJoltSystem->GetBodyInterface().AddImpulse(closestBody, ezJoltConversionUtils::ToVec3(m_vInitialImpulseDirection), vImpulsePosition);
+  if (pJoltSystem->GetBodyInterface().IsAdded(closestBody))
+  {
+    pJoltSystem->GetBodyInterface().AddImpulse(closestBody, ezJoltConversionUtils::ToVec3(m_vInitialImpulseDirection), vImpulsePosition);
+  }
 }
 
 

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
@@ -893,6 +893,7 @@ void ezJoltRopeComponent::AddForceAtPos(ezMsgPhysicsAddForce& ref_msg)
   else
     bodyId = m_pRagdoll->GetBodyID(0);
 
+
   ezVec3 vImp = ref_msg.m_vForce;
   const float fOrgImp = vImp.GetLength();
 
@@ -907,7 +908,12 @@ void ezJoltRopeComponent::AddForceAtPos(ezMsgPhysicsAddForce& ref_msg)
   }
 
   ezJoltWorldModule* pModule = GetWorld()->GetModule<ezJoltWorldModule>();
-  pModule->GetJoltSystem()->GetBodyInterface().AddForce(bodyId, ezJoltConversionUtils::ToVec3(vImp), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  auto pBodies = &pModule->GetJoltSystem()->GetBodyInterface();
+
+  if (pBodies->IsAdded(bodyId))
+  {
+    pModule->GetJoltSystem()->GetBodyInterface().AddForce(bodyId, ezJoltConversionUtils::ToVec3(vImp), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  }
 }
 
 void ezJoltRopeComponent::AddImpulseAtPos(ezMsgPhysicsAddImpulse& ref_msg)
@@ -936,7 +942,11 @@ void ezJoltRopeComponent::AddImpulseAtPos(ezMsgPhysicsAddImpulse& ref_msg)
   }
 
   ezJoltWorldModule* pModule = GetWorld()->GetModule<ezJoltWorldModule>();
-  pModule->GetJoltSystem()->GetBodyInterface().AddImpulse(bodyId, ezJoltConversionUtils::ToVec3(vImp), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+
+  if (pModule->GetJoltSystem()->GetBodyInterface().IsAdded(bodyId))
+  {
+    pModule->GetJoltSystem()->GetBodyInterface().AddImpulse(bodyId, ezJoltConversionUtils::ToVec3(vImp), ezJoltConversionUtils::ToVec3(ref_msg.m_vGlobalPosition));
+  }
 }
 
 void ezJoltRopeComponent::SetAnchor1ConstraintMode(ezEnum<ezJoltRopeAnchorConstraintMode> mode)

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -456,14 +456,12 @@ ezBoundingBoxSphere ezJoltWorldModule::GetWorldSpaceBounds(ezGameObject* pOwner,
   return result;
 }
 
-ezUInt32 ezJoltWorldModule::QueueBodyToAdd(JPH::Body* pBody, bool bAwake)
+void ezJoltWorldModule::QueueBodyToAdd(JPH::Body* pBody, bool bAwake)
 {
   if (bAwake)
     m_BodiesToAddAndActivate.PushBack(pBody->GetID().GetIndexAndSequenceNumber());
   else
     m_BodiesToAdd.PushBack(pBody->GetID().GetIndexAndSequenceNumber());
-
-  return m_uiBodiesAddCounter;
 }
 
 void ezJoltWorldModule::EnableJoinedBodiesCollisions(ezUInt32 uiObjectFilterID1, ezUInt32 uiObjectFilterID2, bool bEnable)
@@ -566,7 +564,6 @@ void ezJoltWorldModule::StartSimulation(const ezWorldModule::UpdateContext& cont
     }
 
     m_BodiesToAdd.Clear();
-    ++m_uiBodiesAddCounter;
   }
 
   if (!m_BodiesToAddAndActivate.IsEmpty())
@@ -590,7 +587,6 @@ void ezJoltWorldModule::StartSimulation(const ezWorldModule::UpdateContext& cont
     }
 
     m_BodiesToAddAndActivate.Clear();
-    ++m_uiBodiesAddCounter;
   }
 
   if (m_uiBodiesAddedSinceOptimize > 128)

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -87,14 +87,7 @@ public:
   const ezMap<ezJoltRopeComponent*, ezInt32>& GetActiveRopes() const { return m_ActiveRopes; }
   ezArrayPtr<ezJoltRagdollComponent*> GetRagdollsPutToSleep() { return m_RagdollsPutToSleep.GetArrayPtr(); }
 
-  /// \brief Returns a uint32 that can be queried for completion with IsBodyStillQueuedToAdd().
-  ezUInt32 QueueBodyToAdd(JPH::Body* pBody, bool bAwake);
-
-  /// \brief Checks whether the last QueueBodyToAdd() has been processed already, or not.
-  ///
-  /// Bodies that aren't added to Jolt yet, may not get locked (they are not in the broadphase).
-  /// If this is still the case, skip operations that wouldn't have an effect anyway.
-  bool IsBodyStillQueuedToAdd(ezUInt32 uiBodiesAddCounter) const { return uiBodiesAddCounter == m_uiBodiesAddCounter; }
+  void QueueBodyToAdd(JPH::Body* pBody, bool bAwake);
 
   JPH::GroupFilter* GetGroupFilter() const { return m_pGroupFilter; }
   JPH::GroupFilter* GetGroupFilterIgnoreSame() const { return m_pGroupFilterIgnoreSame; }
@@ -213,7 +206,6 @@ private:
   JPH::GroupFilter* m_pGroupFilterIgnoreSame = nullptr;
 
   ezUInt32 m_uiBodiesAddedSinceOptimize = 100;
-  ezUInt32 m_uiBodiesAddCounter = 1; // increased every time bodies get added, can be used to check whether a queued body is still queued
   ezDeque<ezUInt32> m_BodiesToAdd;
   ezDeque<ezUInt32> m_BodiesToAddAndActivate;
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase.cpp
@@ -138,6 +138,11 @@ ezStatus ezObjectAccessorBase::ClearByName(const ezDocumentObject* pObject, ezSt
   return ezStatus(EZ_SUCCESS);
 }
 
+const ezAbstractProperty* ezObjectAccessorBase::FindPropertyByName(const ezDocumentObject* pObject, ezStringView sProp)
+{
+  return pObject->GetType()->FindPropertyByName(sProp);
+}
+
 ezObjectAccessorBase::ezObjectAccessorBase(const ezDocumentObjectManager* pManager)
   : m_pConstManager(pManager)
 {

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
@@ -60,6 +60,8 @@ public:
 
   ezStatus ClearByName(const ezDocumentObject* pObject, ezStringView sProp);
 
+  const ezAbstractProperty* FindPropertyByName(const ezDocumentObject* pObject, ezStringView sProp);
+
   template <typename T>
   T Get(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant());
   template <typename T>

--- a/Data/Samples/SampleGame/TypeScript/ez/AllComponents.ts
+++ b/Data/Samples/SampleGame/TypeScript/ez/AllComponents.ts
@@ -324,6 +324,8 @@ export class DebugTextComponent extends Component
   set Value3(value: number) { __CPP_ComponentProperty_set(this, 1816166542, value); }
   get Color(): Color { return __CPP_ComponentProperty_get(this, 1881354469); }
   set Color(value: Color) { __CPP_ComponentProperty_set(this, 1881354469, value); }
+  get MaxDistance(): number { return __CPP_ComponentProperty_get(this, 1272349630); }
+  set MaxDistance(value: number) { __CPP_ComponentProperty_set(this, 1272349630, value); }
 }
 
 export class DecalComponent extends RenderComponent
@@ -949,6 +951,7 @@ export class ScriptComponent extends EventMessageHandlerComponent
   public static GetTypeNameHash(): number { return 1614462437; }
   SetScriptVariable(Name: string, Value: any): void { __CPP_ComponentFunction_Call(this, 1554318557, Name, Value); }
   GetScriptVariable(Name: string): any { return __CPP_ComponentFunction_Call(this, 4178349120, Name); }
+  SetUpdateInterval(interval: number): void { __CPP_ComponentFunction_Call(this, 2103510945, interval); }
   get UpdateInterval(): number { return __CPP_ComponentProperty_get(this, 3597189607); }
   set UpdateInterval(value: number) { __CPP_ComponentProperty_set(this, 3597189607, value); }
   get ScriptClass(): string { return __CPP_ComponentProperty_get(this, 1184048898); }

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/AllDeclarations.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/AllDeclarations.txt
@@ -1303,6 +1303,11 @@ ezGameObject@ ezGameObject::FindChildByPath(ezStringView sPath)
 ezGameObject@ ezGameObject::GetParent()
 ezGameObject@ ezGameObject::GetParent() const
 ezGameObjectHandle ezGameObject::GetHandle() const
+ezGameObjectHandle ezMsgObjectGrabbed::get_GrabbedBy() const
+ezGameObjectHandle ezMsgOnlyApplyToObject::get_Object() const
+ezGameObjectHandle ezMsgPhysicsJointBroke::get_JointObject() const
+ezGameObjectHandle ezMsgReleaseObjectGrab::get_GrabbedObjectToRelease() const
+ezGameObjectHandle ezMsgTriggerTriggered::get_GameObject() const
 ezGameObjectHandle ezWorld::CreateObject(const ezGameObjectDesc&in desc)
 ezGameObjectHandle ezWorld::CreateObject(const ezGameObjectDesc&in desc, ezGameObject@&out object)
 ezGizmoComponent@ ezComponent::opCast()
@@ -3216,11 +3221,15 @@ void ezMsgMoveCharacterController::set_Run(bool)
 void ezMsgMoveCharacterController::set_StrafeLeft(double)
 void ezMsgMoveCharacterController::set_StrafeRight(double)
 void ezMsgObjectGrabbed::set_GotGrabbed(bool)
+void ezMsgObjectGrabbed::set_GrabbedBy(ezGameObjectHandle)
+void ezMsgOnlyApplyToObject::set_Object(ezGameObjectHandle)
 void ezMsgPhysicsAddForce::set_Force(ezVec3)
 void ezMsgPhysicsAddForce::set_GlobalPosition(ezVec3)
 void ezMsgPhysicsAddImpulse::set_GlobalPosition(ezVec3)
 void ezMsgPhysicsAddImpulse::set_Impulse(ezVec3)
 void ezMsgPhysicsAddImpulse::set_ObjectFilterID(uint)
+void ezMsgPhysicsJointBroke::set_JointObject(ezGameObjectHandle)
+void ezMsgReleaseObjectGrab::set_GrabbedObjectToRelease(ezGameObjectHandle)
 void ezMsgSetColor::set_Color(ezColor)
 void ezMsgSetColor::set_Mode(ezSetColorMode)
 void ezMsgSetCustomData::set_Data0(float)
@@ -3232,6 +3241,7 @@ void ezMsgSetFloatParameter::set_Value(float)
 void ezMsgSetMeshMaterial::set_Material(ezStringView)
 void ezMsgSetMeshMaterial::set_MaterialSlot(uint)
 void ezMsgSetPlaying::set_Play(bool)
+void ezMsgTriggerTriggered::set_GameObject(ezGameObjectHandle)
 void ezMsgTriggerTriggered::set_Message(ezHashedString)
 void ezMsgTriggerTriggered::set_TriggerState(ezTriggerState)
 void ezNavMeshObstacleComponent::InvalidateSectors()
@@ -3639,8 +3649,13 @@ void ezWindVolumeSphereComponent::PostMessage(const ezMessage&in msg, ezTime del
 void ezWindVolumeSphereComponent::set_Radius(float)
 void ezWorld::DeleteObjectDelayed(const ezGameObjectHandle&in hObject, bool bAlsoDeleteEmptyParents = true)
 void ezWorld::PostMessage(const ezComponentHandle&in hReceiverObject, const ezMessage&in msg, ezTime delay, ezObjectMsgQueueType queueType = ezObjectMsgQueueType::NextFrame) const
+void ezWorld::PostMessage(const ezGameObjectHandle&in hReceiverObject, const ezAngelScriptMessage&in, ezTime delay, ezObjectMsgQueueType delivery = ezObjectMsgQueueType::NextFrame)
 void ezWorld::PostMessage(const ezGameObjectHandle&in hReceiverObject, const ezMessage&in msg, ezTime delay, ezObjectMsgQueueType queueType = ezObjectMsgQueueType::NextFrame) const
+void ezWorld::PostMessageRecursive(const ezGameObjectHandle&in hReceiverObject, const ezAngelScriptMessage&in, ezTime delay, ezObjectMsgQueueType delivery = ezObjectMsgQueueType::NextFrame)
 void ezWorld::PostMessageRecursive(const ezGameObjectHandle&in hReceiverObject, const ezMessage&in msg, ezTime delay, ezObjectMsgQueueType queueType = ezObjectMsgQueueType::NextFrame) const
 void ezWorld::SendMessage(const ezComponentHandle&in hReceiverObject, ezMessage&inout msg)
+void ezWorld::SendMessage(const ezGameObjectHandle&in hReceiverObject, ezAngelScriptMessage&inout)
 void ezWorld::SendMessage(const ezGameObjectHandle&in hReceiverObject, ezMessage&inout msg)
+void ezWorld::SendMessageRecursive(const ezGameObjectHandle&in hReceiverObject, ezAngelScriptMessage&inout)
 void ezWorld::SendMessageRecursive(const ezGameObjectHandle&in hReceiverObject, ezMessage&inout msg)
+void throw(ezStringView)

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/GlobalFunctions.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/GlobalFunctions.txt
@@ -110,3 +110,4 @@ SweepTestSphere
 Tan
 Unlerp
 Warning
+throw

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/Properties.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/Properties.txt
@@ -178,6 +178,7 @@ Frequency
 Friction
 Fuchsia
 Gainsboro
+GameObject
 GenerateCollision
 GhostWhite
 GlobalPosition
@@ -185,6 +186,8 @@ Gold
 GoldenRod
 GotGrabbed
 GrabAnyObjectWithSize
+GrabbedBy
+GrabbedObjectToRelease
 Gradient
 Granularity
 GravityFactor
@@ -226,6 +229,7 @@ Ivory
 JointEnd
 JointMiddle
 JointName
+JointObject
 JointStart
 Jump
 JumpImpulse
@@ -336,6 +340,7 @@ NewStateName
 NewValue
 NoGlobalPitch
 NumCascades
+Object
 ObjectFilterID
 ObjectGravity
 OcclusionCollisionLayer

--- a/Data/Samples/Testing Chambers/Prefabs/BallMine_data/BallMine.as
+++ b/Data/Samples/Testing Chambers/Prefabs/BallMine_data/BallMine.as
@@ -26,7 +26,7 @@ class ScriptObject : ezAngelScriptClass
             _player = obj.GetHandle();
         }
 
-        Update();
+        Update(ezTime::MakeZero());
     }
 
     bool QueryForNPC(ezGameObject@ go)
@@ -36,7 +36,7 @@ class ScriptObject : ezAngelScriptClass
          return false;
     }
 
-    void Update()
+    void Update(ezTime deltaTime)
     {
         auto oldState = _state;
         auto owner = GetOwner();

--- a/Data/Samples/Testing Chambers/Prefabs/ConsumablePickup_data/ConsumablePickup.as
+++ b/Data/Samples/Testing Chambers/Prefabs/ConsumablePickup_data/ConsumablePickup.as
@@ -9,16 +9,11 @@ class ConsumablePickup : ezAngelScriptClass
     {
         if (msg.TriggerState == ezTriggerState::Activated && msg.Message == "Pickup")
         {
-            // TODO: need GO handles in messages to identify who entered the trigger
-            ezGameObject@ player;
-            if (!GetWorld().TryGetObjectWithGlobalKey("Player", player))
-                return;
-
             MsgAddConsumable hm;
             hm.consumableType = ConsumableType(ObjectType);
             hm.amount = Amount;
 
-            player.SendMessageRecursive(hm);
+            GetWorld().SendMessageRecursive(msg.GameObject, hm);
 
             if (hm.return_consumed == false)
                 return;

--- a/Data/Samples/Testing Chambers/Prefabs/ConsumablePickup_data/ConsumablePickup.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/ConsumablePickup_data/ConsumablePickup.ezAngelScriptAsset
@@ -12,9 +12,10 @@ o
 		VarArray %Dependencies
 		{
 			s{"Prefabs/ConsumablePickup_data/ConsumablePickup.as"}
+			s{"Scripting/GameDecls.as"}
 		}
 		Uuid %DocumentID{u4{15093952775324887440,4755446790216139985}}
-		u4 %Hash{6837973678878459689}
+		u4 %Hash{17193738463330394903}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{3849098155197325966,14027127256261368063}}
@@ -80,10 +81,14 @@ o
 	{
 		s %ClassName{"ConsumablePickup"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters
 		{
-			Uuid{u4{4314210376975429564,5764037692530829574}}
-			Uuid{u4{9937236735064536477,5085449825073821705}}
+			Uuid{u4{5658861719800082359,4902781441944077681}}
+			Uuid{u4{13215161804877139843,5682523784638819288}}
 		}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/ConsumablePickup_data/ConsumablePickup.as"}
@@ -91,20 +96,7 @@ o
 }
 o
 {
-	Uuid %id{u4{9937236735064536477,5085449825073821705}}
-	s %t{"ezAngelScriptParameter"}
-	u3 %v{1}
-	p
-	{
-		s %Declaration{"int32 Amount = 0"}
-		i3 %DefaultValue{0}
-		b %Expose{1}
-		s %Name{"Amount"}
-	}
-}
-o
-{
-	Uuid %id{u4{4314210376975429564,5764037692530829574}}
+	Uuid %id{u4{5658861719800082359,4902781441944077681}}
 	s %t{"ezAngelScriptParameter"}
 	u3 %v{1}
 	p
@@ -113,6 +105,19 @@ o
 		i3 %DefaultValue{0}
 		b %Expose{1}
 		s %Name{"ObjectType"}
+	}
+}
+o
+{
+	Uuid %id{u4{13215161804877139843,5682523784638819288}}
+	s %t{"ezAngelScriptParameter"}
+	u3 %v{1}
+	p
+	{
+		s %Declaration{"int32 Amount = 0"}
+		i3 %DefaultValue{0}
+		b %Expose{1}
+		s %Name{"Amount"}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Prefabs/GasCylinder_data/GasCylinder.as
+++ b/Data/Samples/Testing Chambers/Prefabs/GasCylinder_data/GasCylinder.as
@@ -9,7 +9,7 @@ class ScriptObject :  ezAngelScriptClass
         SetUpdateInterval(ezTime::MakeFromSeconds(10));
     }
 
-    void Update()
+    void Update(ezTime deltaTime)
     {
         if (capHealth <= 0) 
         {

--- a/Data/Samples/Testing Chambers/Prefabs/Guns/MachineGun_data/MachineGun.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/Guns/MachineGun_data/MachineGun.ezAngelScriptAsset
@@ -12,9 +12,11 @@ o
 		VarArray %Dependencies
 		{
 			s{"Prefabs/Guns/MachineGun_data/MachineGun.as"}
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
 		}
 		Uuid %DocumentID{u4{14890957447412390053,5189418597059215815}}
-		u4 %Hash{13370771605183565046}
+		u4 %Hash{14229091161430665088}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{13814229466196597394,6113561388189469666}}
@@ -50,6 +52,11 @@ o
 	{
 		s %ClassName{"MachineGun"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters{}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/Guns/MachineGun_data/MachineGun.as"}

--- a/Data/Samples/Testing Chambers/Prefabs/Guns/Pistol_data/Pistol.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/Guns/Pistol_data/Pistol.ezAngelScriptAsset
@@ -22,9 +22,11 @@ o
 		VarArray %Dependencies
 		{
 			s{"Prefabs/Guns/Pistol_data/Pistol.as"}
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
 		}
 		Uuid %DocumentID{u4{5966609228509665681,5361859106406761452}}
-		u4 %Hash{4405938720927153507}
+		u4 %Hash{47204891290238127}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{7481354196455915945,3362469960979315015}}
@@ -50,6 +52,11 @@ o
 	{
 		s %ClassName{"Pistol"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters{}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/Guns/Pistol_data/Pistol.as"}

--- a/Data/Samples/Testing Chambers/Prefabs/Guns/PlasmaRifle_data/PlasmaRifle.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/Guns/PlasmaRifle_data/PlasmaRifle.ezAngelScriptAsset
@@ -12,9 +12,11 @@ o
 		VarArray %Dependencies
 		{
 			s{"Prefabs/Guns/PlasmaRifle_data/PlasmaRifle.as"}
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
 		}
 		Uuid %DocumentID{u4{12712196599291816839,5266986229344438210}}
-		u4 %Hash{12485662029005573017}
+		u4 %Hash{5874244306660053868}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{13700463139157668186,9902105918934074528}}
@@ -50,6 +52,11 @@ o
 	{
 		s %ClassName{"PlasmaRifle"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters{}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/Guns/PlasmaRifle_data/PlasmaRifle.as"}

--- a/Data/Samples/Testing Chambers/Prefabs/Guns/RocketLauncher_data/RocketLauncher.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/Guns/RocketLauncher_data/RocketLauncher.ezAngelScriptAsset
@@ -22,9 +22,11 @@ o
 		VarArray %Dependencies
 		{
 			s{"Prefabs/Guns/RocketLauncher_data/RocketLauncher.as"}
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
 		}
 		Uuid %DocumentID{u4{2126202199220389306,4929291486868465546}}
-		u4 %Hash{7465761332366830939}
+		u4 %Hash{2669246774345395559}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{14526129409328794426,3093375623949258268}}
@@ -50,6 +52,11 @@ o
 	{
 		s %ClassName{"RocketLauncher"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters{}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/Guns/RocketLauncher_data/RocketLauncher.as"}

--- a/Data/Samples/Testing Chambers/Prefabs/Guns/Shotgun_data/Shotgun.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/Guns/Shotgun_data/Shotgun.ezAngelScriptAsset
@@ -12,9 +12,11 @@ o
 		VarArray %Dependencies
 		{
 			s{"Prefabs/Guns/Shotgun_data/Shotgun.as"}
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
 		}
 		Uuid %DocumentID{u4{5127540915118614438,5008085743819691028}}
-		u4 %Hash{13202157220404117301}
+		u4 %Hash{3375761175202835362}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{11022518350425411134,13871513922187234223}}
@@ -50,6 +52,11 @@ o
 	{
 		s %ClassName{"Shotgun"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters{}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/Guns/Shotgun_data/Shotgun.as"}

--- a/Data/Samples/Testing Chambers/Prefabs/Player_data/Player.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Prefabs/Player_data/Player.ezAngelScriptAsset
@@ -14,7 +14,7 @@ o
 			s{"Prefabs/Player_data/Player.as"}
 		}
 		Uuid %DocumentID{u4{5967608025336921517,5557651060148712635}}
-		u4 %Hash{9973714235819001047}
+		u4 %Hash{11355554131486594524}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{5188246925958840120,17028944065193808758}}
@@ -80,10 +80,15 @@ o
 	{
 		s %ClassName{"Player"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Prefabs/Guns/Weapon.as"}
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters
 		{
-			Uuid{u4{15864886478433129653,5168665553977808296}}
-			Uuid{u4{13241372975068593801,5420549005398797090}}
+			Uuid{u4{11087143322895431846,4761117206212665443}}
+			Uuid{u4{7846732528233788843,5095627809616113803}}
 		}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Prefabs/Player_data/Player.as"}
@@ -91,7 +96,7 @@ o
 }
 o
 {
-	Uuid %id{u4{15864886478433129653,5168665553977808296}}
+	Uuid %id{u4{11087143322895431846,4761117206212665443}}
 	s %t{"ezAngelScriptParameter"}
 	u3 %v{1}
 	p
@@ -104,7 +109,7 @@ o
 }
 o
 {
-	Uuid %id{u4{13241372975068593801,5420549005398797090}}
+	Uuid %id{u4{7846732528233788843,5095627809616113803}}
 	s %t{"ezAngelScriptParameter"}
 	u3 %v{1}
 	p

--- a/Data/Samples/Testing Chambers/Prefabs/Turret_data/Turret.as
+++ b/Data/Samples/Testing Chambers/Prefabs/Turret_data/Turret.as
@@ -53,7 +53,7 @@ class ScriptObject : ezAngelScriptClass
         return false;
     }
 
-    void Update()
+    void Update(ezTime deltaTime)
     {
         if (Health <= 0)
             return;

--- a/Data/Samples/Testing Chambers/Scenes/Main_data/Corridor.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Scenes/Main_data/Corridor.ezAngelScriptAsset
@@ -21,10 +21,11 @@ o
 		s %AssetType{"AngelScript"}
 		VarArray %Dependencies
 		{
+			s{"Features/RenderToTexture/Monitor_data/Monitor.as"}
 			s{"Scenes/Main_data/Corridor.as"}
 		}
 		Uuid %DocumentID{u4{16450976138972234425,4687106429097080588}}
-		u4 %Hash{443077794545903753}
+		u4 %Hash{18337396432930092362}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{16616245777925676785,940473987124105707}}
@@ -50,6 +51,10 @@ o
 	{
 		s %ClassName{"Corridor"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Features/RenderToTexture/Monitor_data/Monitor.as"}
+		}
 		VarArray %Parameters{}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Scenes/Main_data/Corridor.as"}

--- a/Data/Samples/Testing Chambers/Scripting/GameDecls.as
+++ b/Data/Samples/Testing Chambers/Scripting/GameDecls.as
@@ -47,7 +47,7 @@ class AmmoPouch
             return AmmoRocketLauncher;
         }
 
-        // TODO: assert ?
+        throw("Missing Case");
         return AmmoPistol;
     }
 }

--- a/Data/Samples/Testing Chambers/Scripting/UnlockWeapon.as
+++ b/Data/Samples/Testing Chambers/Scripting/UnlockWeapon.as
@@ -8,15 +8,10 @@ class UnlockWeapon : ezAngelScriptClass
     {
         if (msg.TriggerState == ezTriggerState::Activated && msg.Message == "Pickup")
         {
-            // TODO: need GO handles in messages to identify who entered the trigger
-            ezGameObject@ player;
-            if (!GetWorld().TryGetObjectWithGlobalKey("Player", @player))
-                return;
-
             MsgUnlockWeapon hm;
             hm.weaponType = WeaponType(weaponType);
 
-            player.SendMessageRecursive(hm);
+            GetWorld().SendMessageRecursive(msg.GameObject, hm);
 
             if (!hm.return_consumed)
                 return;

--- a/Data/Samples/Testing Chambers/Scripting/UnlockWeapon.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Scripting/UnlockWeapon.ezAngelScriptAsset
@@ -11,10 +11,11 @@ o
 		s %AssetType{"AngelScript"}
 		VarArray %Dependencies
 		{
+			s{"Scripting/GameDecls.as"}
 			s{"Scripting/UnlockWeapon.as"}
 		}
 		Uuid %DocumentID{u4{18353314003251839166,5725247999247466157}}
-		u4 %Hash{5385216487346731579}
+		u4 %Hash{683992239689923063}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{7670945929406840423,7059934551145565828}}
@@ -66,9 +67,13 @@ o
 	{
 		s %ClassName{"UnlockWeapon"}
 		s %Code{"class ScriptObject : ezAngelScriptClass\n{\n\t// int PublicIntVar = 0;\n\n\tvoid OnSimulationStarted()\n\t{\n\t\t// ezLog::Info(\"Simulation Started\");\n\t}\n\n\t// void Update() { }\n\n\t// void OnMsgTriggerTriggered(ezMsgTriggerTriggered@ msg) { }\n}"}
+		VarArray %Dependencies
+		{
+			s{"Scripting/GameDecls.as"}
+		}
 		VarArray %Parameters
 		{
-			Uuid{u4{3873946572314018203,5413922000228535960}}
+			Uuid{u4{7637037525266942869,5756583826343957143}}
 		}
 		s %Source{"ezAngelScriptCodeMode::FromFile"}
 		s %SourceFile{"Scripting/UnlockWeapon.as"}
@@ -76,7 +81,7 @@ o
 }
 o
 {
-	Uuid %id{u4{3873946572314018203,5413922000228535960}}
+	Uuid %id{u4{7637037525266942869,5756583826343957143}}
 	s %t{"ezAngelScriptParameter"}
 	u3 %v{1}
 	p

--- a/Data/Samples/Testing Chambers/Scripts/JointBroke.ezAngelScriptAsset
+++ b/Data/Samples/Testing Chambers/Scripts/JointBroke.ezAngelScriptAsset
@@ -73,6 +73,7 @@ o
 	{
 		s %ClassName{"ScriptObject"}
 		s %Code{"class ScriptObject :  ezAngelScriptClass\n{\n    ezString Text = \"Joint Broke\";\n\n    void OnMsgPhysicsJointBroke(ezMsgPhysicsJointBroke@ msg)\n    {\n        ezLog::Info(Text);\n    }\n}\n"}
+		VarArray %Dependencies{}
 		VarArray %Parameters
 		{
 			Uuid{u4{10740826615265613734,4942408714307029089}}

--- a/Data/Samples/Testing Chambers/as.predefined
+++ b/Data/Samples/Testing Chambers/as.predefined
@@ -1272,6 +1272,10 @@ class ezWorld
   ezClock@ GetClock();
   const ezClock@ GetClock() const;
   ezRandom@ GetRandomNumberGenerator();
+  void SendMessage(const ezGameObjectHandle&in hReceiverObject, ezAngelScriptMessage&inout);
+  void SendMessageRecursive(const ezGameObjectHandle&in hReceiverObject, ezAngelScriptMessage&inout);
+  void PostMessage(const ezGameObjectHandle&in hReceiverObject, const ezAngelScriptMessage&in, ezTime delay, ezObjectMsgQueueType delivery = ezObjectMsgQueueType::NextFrame);
+  void PostMessageRecursive(const ezGameObjectHandle&in hReceiverObject, const ezAngelScriptMessage&in, ezTime delay, ezObjectMsgQueueType delivery = ezObjectMsgQueueType::NextFrame);
 }
 
 class ezMessage
@@ -3388,15 +3392,18 @@ class ezEventMessage : ezMessage
 
 class ezMsgPhysicsJointBroke : ezEventMessage
 {
+  ezGameObjectHandle JointObject;
 }
 
 class ezMsgObjectGrabbed : ezMessage
 {
+  ezGameObjectHandle GrabbedBy;
   bool GotGrabbed;
 }
 
 class ezMsgReleaseObjectGrab : ezMessage
 {
+  ezGameObjectHandle GrabbedObjectToRelease;
 }
 
 class ezMsgBuildStaticMesh : ezMessage
@@ -3405,6 +3412,7 @@ class ezMsgBuildStaticMesh : ezMessage
 
 class ezMsgOnlyApplyToObject : ezMessage
 {
+  ezGameObjectHandle Object;
 }
 
 class ezMsgCollision : ezMessage
@@ -3469,6 +3477,7 @@ class ezMsgTriggerTriggered : ezEventMessage
 {
   ezHashedString Message;
   ezTriggerState TriggerState;
+  ezGameObjectHandle GameObject;
 }
 
 class ezMsgSetColor : ezMessage
@@ -3774,6 +3783,7 @@ namespace ezSpatial
   void FindObjectsInSphere(ezWorld@ world, ezStringView sType, const ezVec3&in vCenter, float fRadius, ReportObjectCB@ callback);
 }
 
+void throw(ezStringView);
 namespace ezQuat
 {
   ezQuat MakeFromAxisAndAngle(ezVec3 Axis, ezAngle Angle);


### PR DESCRIPTION
* Asset now tracks #include dependencies and recompiles script on demand
* Asset output now uses compression
* Compiler errors are now correctly translated to the file and line where they occurred
* Update function now gets the time delta
* Added "throw" for critical errors
* Added support for game object and component handles in properties
* fixed an issue that made Jolt crash when applying a force to a just created object