### PR TITLE
Added GAL dynamic buffer

### DIFF
--- a/Code/Engine/RendererCore/Shader/ConstantBufferStorage.h
+++ b/Code/Engine/RendererCore/Shader/ConstantBufferStorage.h
@@ -5,7 +5,7 @@
 #include <RendererFoundation/RendererFoundationDLL.h>
 
 /// \brief Wrapper around ezGALBufferHandle that automates buffer updates.
-/// Created via ezRenderContext::CreateConstantBufferStorage. Retried via ezRenderContext::TryGetConstantBufferStorage, updated lazily via ezRenderContext::UploadConstants.
+/// Created via ezRenderContext::CreateConstantBufferStorage. Retrived via ezRenderContext::TryGetConstantBufferStorage, updated lazily via ezRenderContext::UploadConstants.
 ///
 class EZ_RENDERERCORE_DLL ezConstantBufferStorageBase
 {

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -57,6 +57,9 @@ public:
   ezGALBufferHandle CreateBuffer(const ezGALBufferCreationDescription& description, ezArrayPtr<const ezUInt8> initialData = ezArrayPtr<const ezUInt8>());
   void DestroyBuffer(ezGALBufferHandle hBuffer);
 
+  ezGALDynamicBufferHandle CreateDynamicBuffer(const ezGALBufferCreationDescription& description, ezStringView sDebugName);
+  void DestroyDynamicBuffer(ezGALDynamicBufferHandle& inout_hBuffer);
+
   // Helper functions for buffers (for common, simple use cases)
 
   ezGALBufferHandle CreateVertexBuffer(ezUInt32 uiVertexSize, ezUInt32 uiVertexCount, ezArrayPtr<const ezUInt8> initialData = ezArrayPtr<const ezUInt8>(), bool bDataIsMutable = false);
@@ -202,6 +205,8 @@ public:
   const ezGALTexture* GetTexture(ezGALTextureHandle hTexture) const;
   virtual const ezGALSharedTexture* GetSharedTexture(ezGALTextureHandle hTexture) const = 0;
   const ezGALBuffer* GetBuffer(ezGALBufferHandle hBuffer) const;
+  const ezGALDynamicBuffer* GetDynamicBuffer(ezGALDynamicBufferHandle hBuffer) const;
+  ezGALDynamicBuffer* GetDynamicBuffer(ezGALDynamicBufferHandle hBuffer);
   const ezGALReadbackBuffer* GetReadbackBuffer(ezGALReadbackBufferHandle hBuffer) const;
   const ezGALReadbackTexture* GetReadbackTexture(ezGALReadbackTextureHandle hTexture) const;
   const ezGALDepthStencilState* GetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState) const;
@@ -275,6 +280,7 @@ protected:
   using DepthStencilStateTable = ezIdTable<ezGALDepthStencilStateHandle::IdType, ezGALDepthStencilState*, ezLocalAllocatorWrapper>;
   using RasterizerStateTable = ezIdTable<ezGALRasterizerStateHandle::IdType, ezGALRasterizerState*, ezLocalAllocatorWrapper>;
   using BufferTable = ezIdTable<ezGALBufferHandle::IdType, ezGALBuffer*, ezLocalAllocatorWrapper>;
+  using DynamicBufferTable = ezIdTable<ezGALDynamicBufferHandle::IdType, ezGALDynamicBuffer*, ezLocalAllocatorWrapper>;
   using TextureTable = ezIdTable<ezGALTextureHandle::IdType, ezGALTexture*, ezLocalAllocatorWrapper>;
   using ReadbackBufferTable = ezIdTable<ezGALReadbackBufferHandle::IdType, ezGALReadbackBuffer*, ezLocalAllocatorWrapper>;
   using ReadbackTextureTable = ezIdTable<ezGALReadbackTextureHandle::IdType, ezGALReadbackTexture*, ezLocalAllocatorWrapper>;
@@ -292,6 +298,7 @@ protected:
   DepthStencilStateTable m_DepthStencilStates;
   RasterizerStateTable m_RasterizerStates;
   BufferTable m_Buffers;
+  DynamicBufferTable m_DynamicBuffers;
   TextureTable m_Textures;
   ReadbackBufferTable m_ReadbackBuffers;
   ReadbackTextureTable m_ReadbackTextures;

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -540,20 +540,17 @@ ezGALBufferHandle ezGALDevice::CreateBuffer(const ezGALBufferCreationDescription
     return ezGALBufferHandle();
   }
 
-  if (desc.m_ResourceAccess.IsImmutable())
+  if (desc.m_ResourceAccess.IsImmutable() && initialData.IsEmpty())
   {
-    if (initialData.IsEmpty())
-    {
-      ezLog::Error("Trying to create an immutable buffer but not supplying initial data is not possible!");
-      return ezGALBufferHandle();
-    }
+    ezLog::Error("Trying to create an immutable buffer but not supplying initial data is not possible!");
+    return ezGALBufferHandle();
+  }
 
-    ezUInt32 uiBufferSize = desc.m_uiTotalSize;
-    if (uiBufferSize != initialData.GetCount())
-    {
-      ezLog::Error("Trying to create a buffer with invalid initial data!");
-      return ezGALBufferHandle();
-    }
+  ezUInt32 uiBufferSize = desc.m_uiTotalSize;
+  if (initialData.GetCount() > 0 && uiBufferSize != initialData.GetCount())
+  {
+    ezLog::Error("Trying to create a buffer with invalid initial data!");
+    return ezGALBufferHandle();
   }
 
   if (desc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::Transient))

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -8,6 +8,7 @@
 #include <RendererFoundation/Device/SharedTextureSwapChain.h>
 #include <RendererFoundation/Device/SwapChain.h>
 #include <RendererFoundation/Resources/Buffer.h>
+#include <RendererFoundation/Resources/DynamicBuffer.h>
 #include <RendererFoundation/Resources/ProxyTexture.h>
 #include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
@@ -28,6 +29,7 @@ namespace
       SamplerState,
       Shader,
       Buffer,
+      DynamicBuffer,
       Texture,
       ReadbackTexture,
       ReadbackBuffer,
@@ -606,6 +608,28 @@ void ezGALDevice::DestroyBuffer(ezGALBufferHandle hBuffer)
   else
   {
     ezLog::Warning("DestroyBuffer called on invalid handle (double free?)");
+  }
+}
+
+ezGALDynamicBufferHandle ezGALDevice::CreateDynamicBuffer(const ezGALBufferCreationDescription& description, ezStringView sDebugName)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  auto pBuffer = EZ_NEW(&m_Allocator, ezGALDynamicBuffer);
+  pBuffer->Initialize(description, sDebugName);
+
+  return ezGALDynamicBufferHandle(m_DynamicBuffers.Insert(pBuffer));
+}
+
+void ezGALDevice::DestroyDynamicBuffer(ezGALDynamicBufferHandle& inout_hBuffer)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  ezGALDynamicBuffer* pBuffer = nullptr;
+  if (m_DynamicBuffers.TryGetValue(inout_hBuffer, pBuffer))
+  {
+    AddDeadObject(GALObjectType::DynamicBuffer, inout_hBuffer);
+    inout_hBuffer.Invalidate();
   }
 }
 
@@ -1587,6 +1611,11 @@ void ezGALDevice::BeginFrame(const ezUInt64 uiAppFrame)
     BeginFramePlatform(m_FrameSwapChains, uiAppFrame);
   }
 
+  for (auto it = m_DynamicBuffers.GetIterator(); it.IsValid(); ++it)
+  {
+    it.Value()->SwapBuffers();
+  }
+
   {
     ezGALDeviceEvent e;
     e.m_pDevice = this;
@@ -1816,6 +1845,17 @@ void ezGALDevice::DestroyDeadObjects()
 
         DestroyViews(pBuffer);
         DestroyBufferPlatform(pBuffer);
+
+        break;
+      }
+      case GALObjectType::DynamicBuffer:
+      {
+        ezGALDynamicBufferHandle hDynamicBuffer(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALDynamicBuffer* pDynamicBuffer = nullptr;
+
+        EZ_VERIFY(m_DynamicBuffers.Remove(hDynamicBuffer, &pDynamicBuffer), "");
+
+        EZ_DELETE(&m_Allocator, pDynamicBuffer);
 
         break;
       }

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -65,6 +65,16 @@ inline const ezGALBuffer* ezGALDevice::GetBuffer(ezGALBufferHandle hBuffer) cons
   return Get<BufferTable, ezGALBuffer>(hBuffer, m_Buffers);
 }
 
+inline const ezGALDynamicBuffer* ezGALDevice::GetDynamicBuffer(ezGALDynamicBufferHandle hBuffer) const
+{
+  return Get<DynamicBufferTable, ezGALDynamicBuffer>(hBuffer, m_DynamicBuffers);
+}
+
+inline ezGALDynamicBuffer* ezGALDevice::GetDynamicBuffer(ezGALDynamicBufferHandle hBuffer)
+{
+  return Get<DynamicBufferTable, ezGALDynamicBuffer>(hBuffer, m_DynamicBuffers);
+}
+
 inline const ezGALReadbackBuffer* ezGALDevice::GetReadbackBuffer(ezGALReadbackBufferHandle hBuffer) const
 {
   return Get<ReadbackBufferTable, ezGALReadbackBuffer>(hBuffer, m_ReadbackBuffers);

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -50,6 +50,7 @@ class ezGALResourceBase;
 class ezGALTexture;
 class ezGALSharedTexture;
 class ezGALBuffer;
+class ezGALDynamicBuffer;
 class ezGALReadbackBuffer;
 class ezGALReadbackTexture;
 class ezGALDepthStencilState;
@@ -438,6 +439,13 @@ class ezGALReadbackTextureHandle
 class ezGALBufferHandle
 {
   EZ_DECLARE_HANDLE_TYPE(ezGALBufferHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALDynamicBufferHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALDynamicBufferHandle, ezGAL::ez18_14Id);
 
   friend class ezGALDevice;
 };

--- a/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
@@ -70,6 +70,7 @@ private:
   void Resize(ezUInt32 uiNewSize);
 
   ezDynamicArray<ezUInt8, ezAlignedAllocatorWrapper> m_Data;
+  ezUInt32 m_uiNextOffset = 0;
 
   struct Allocation
   {

--- a/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
@@ -50,13 +50,13 @@ public:
   };
 
   /// \brief Tries to compact the buffer by moving allocations to free ranges. All moved allocations are returned in out_changedAllocations.
-  /// 
+  ///
   /// The user data can be used to update the owner of the allocation.
   /// To prevent too many changes per frame only uiMaxSteps are executed which corresponds to the number of allocations which can be moved.
   void RunCompactionSteps(ezDynamicArray<ChangedAllocation>& out_changedAllocations, ezUInt32 uiMaxSteps = 16);
 
   /// \brief This should be called inside the rendering code to retrieve the underlying buffer for rendering.
-  /// 
+  ///
   /// It is ensured that it will always return the same buffer until the next time BeginFrame is called on the GALDevice even if the buffer
   /// has been resized due to more allocations on the game play or extraction side.
   const ezGALBufferHandle& GetBufferForRendering() const

--- a/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
@@ -2,11 +2,22 @@
 
 #include <RendererFoundation/Descriptors/Descriptors.h>
 
+/// \brief A dynamic buffer can be used when a lot of data needs to be stored in a single large buffer with dynamic size.
+///
+/// This class supports allocation and deallocation of single elements or ranges of multiple elements.
+/// An allocation is identified by an offset and can have additional user data attached.
+/// The indented usage patterns is that data is allocated and written to the buffer during game play or extraction code.
+/// After all data has been written UploadChangesForNextFrame needs to be called to upload changed data to the GPU buffer.
+/// The renderer would then call GetBufferForRendering to get the correct buffer for rendering.
 class EZ_RENDERERFOUNDATION_DLL ezGALDynamicBuffer
 {
 public:
+  /// \brief Allocates a single or multiple elements and returns the offset to the first element.
+  /// This offset is used to identify the allocation and should also be used in a shader to read the data from the buffer.
+  ///
+  /// The user data can be used to store additional information, typically the owner of the allocation, like e.g. a component handle.
   template <typename U>
-  ezUInt32 Allocate(const U& userData, ezUInt32 uiCount)
+  ezUInt32 Allocate(const U& userData, ezUInt32 uiCount = 1)
   {
     static_assert(sizeof(U) <= sizeof(ezUInt64), "userData is too large");
     ezUInt64 uiUserData = 0;
@@ -15,8 +26,11 @@ public:
     return Allocate(uiUserData, uiCount);
   }
 
+  /// \brief Removes an allocation at the given offset. The offset must have been returned by Allocate.
+  /// This will create unused space in the buffer that can be filled by subsequent allocations or closed later by compaction.
   void Deallocate(ezUInt32 uiOffset);
 
+  /// \brief Maps a range of elements for writing.
   template <typename T>
   ezArrayPtr<T> MapForWriting(ezUInt32 uiOffset)
   {
@@ -26,7 +40,8 @@ public:
     return ezArrayPtr<T>(reinterpret_cast<T*>(byteData.GetPtr()), uiCount);
   }
 
-  void UploadChanges();
+  /// \brief Upload all changed data to the GPU buffer for the next rendering frame, aka the next time BeginFrame is called on the GALDevice.
+  void UploadChangesForNextFrame();
 
   struct ChangedAllocation
   {
@@ -34,8 +49,16 @@ public:
     ezUInt32 m_uiNewOffset = 0;
   };
 
+  /// \brief Tries to compact the buffer by moving allocations to free ranges. All moved allocations are returned in out_changedAllocations.
+  /// 
+  /// The user data can be used to update the owner of the allocation.
+  /// To prevent too many changes per frame only uiMaxSteps are executed which corresponds to the number of allocations which can be moved.
   void RunCompactionSteps(ezDynamicArray<ChangedAllocation>& out_changedAllocations, ezUInt32 uiMaxSteps = 16);
 
+  /// \brief This should be called inside the rendering code to retrieve the underlying buffer for rendering.
+  /// 
+  /// It is ensured that it will always return the same buffer until the next time BeginFrame is called on the GALDevice even if the buffer
+  /// has been resized due to more allocations on the game play or extraction side.
   const ezGALBufferHandle& GetBufferForRendering() const
   {
     return m_hBufferForRendering;

--- a/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
@@ -2,22 +2,9 @@
 
 #include <RendererFoundation/Descriptors/Descriptors.h>
 
-class ezGALDynamicBufferHandle
-{
-  EZ_DECLARE_HANDLE_TYPE(ezGALDynamicBufferHandle, ezGAL::ez18_14Id);
-
-  friend class ezGALDynamicBuffer;
-};
-
-
 class EZ_RENDERERFOUNDATION_DLL ezGALDynamicBuffer
 {
 public:
-  static ezGALDynamicBufferHandle Create(const ezGALBufferCreationDescription& desc, ezStringView sDebugName);
-  static void Destroy(ezGALDynamicBufferHandle& inout_hBuffer);
-  static ezGALDynamicBuffer* Get(ezGALDynamicBufferHandle hBuffer);
-
-
   template <typename U>
   ezUInt32 Allocate(const U& userData, ezUInt32 uiCount)
   {
@@ -69,6 +56,13 @@ private:
 
   void Resize(ezUInt32 uiNewSize);
 
+  void SwapBuffers()
+  {
+    m_hBufferForRendering = m_hBufferForUpload;
+  }
+
+  ezMutex m_Mutex;
+
   ezDynamicArray<ezUInt8, ezAlignedAllocatorWrapper> m_Data;
   ezUInt32 m_uiNextOffset = 0;
 
@@ -91,7 +85,4 @@ private:
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   ezString m_sDebugName;
 #endif
-
-  static void DeviceEventHandler(const ezGALDeviceEvent& e);
-  static ezIdTable<ezGALDynamicBufferHandle::IdType, ezGALDynamicBuffer*> s_Buffers;
 };

--- a/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <RendererFoundation/Descriptors/Descriptors.h>
+
+class ezGALDynamicBufferHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALDynamicBufferHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDynamicBuffer;
+};
+
+
+class EZ_RENDERERFOUNDATION_DLL ezGALDynamicBuffer
+{
+public:
+  static ezGALDynamicBufferHandle Create(const ezGALBufferCreationDescription& desc, ezStringView sDebugName);
+  static void Destroy(ezGALDynamicBufferHandle& inout_hBuffer);
+  static ezGALDynamicBuffer* Get(ezGALDynamicBufferHandle hBuffer);
+
+
+  template <typename U>
+  ezUInt32 Allocate(const U& userData, ezUInt32 uiCount)
+  {
+    static_assert(sizeof(U) <= sizeof(ezUInt64), "userData is too large");
+    ezUInt64 uiUserData = 0;
+    *reinterpret_cast<U*>(&uiUserData) = userData;
+
+    return Allocate(uiUserData, uiCount);
+  }
+
+  void Deallocate(ezUInt32 uiOffset);
+
+  template <typename T>
+  ezArrayPtr<T> MapForWriting(ezUInt32 uiOffset)
+  {
+    ezUInt32 uiCount = 0;
+    ezByteArrayPtr byteData = MapForWriting(uiOffset, uiCount);
+    EZ_ASSERT_DEBUG(uiCount * m_Desc.m_uiStructSize == byteData.GetCount(), "Invalid Type");
+    return ezArrayPtr<T>(reinterpret_cast<T*>(byteData.GetPtr()), uiCount);
+  }
+
+  void UploadChanges();
+
+  struct ChangedAllocation
+  {
+    ezUInt64 m_uiUserData = 0;
+    ezUInt32 m_uiNewOffset = 0;
+  };
+
+  void RunCompactionSteps(ezDynamicArray<ChangedAllocation>& out_changedAllocations, ezUInt32 uiMaxSteps = 16);
+
+  const ezGALBufferHandle& GetBufferForRendering() const
+  {
+    return m_hBufferForRendering;
+  }
+
+private:
+  friend class ezMemoryUtils;
+  friend class ezGALDevice;
+
+  ezGALDynamicBuffer() = default;
+  ~ezGALDynamicBuffer();
+
+  void Initialize(const ezGALBufferCreationDescription& desc, ezStringView sDebugName);
+  void Deinitialize();
+
+  ezUInt32 Allocate(ezUInt64 uiUserData, ezUInt32 uiCount);
+  ezByteArrayPtr MapForWriting(ezUInt32 uiOffset, ezUInt32& out_uiCount);
+
+  void Resize(ezUInt32 uiNewSize);
+
+  ezDynamicArray<ezUInt8, ezAlignedAllocatorWrapper> m_Data;
+
+  struct Allocation
+  {
+    ezUInt64 m_uiUserData = 0;
+    ezUInt32 m_uiCount = 0;
+  };
+
+  ezMap<ezUInt32, Allocation> m_Allocations;
+
+  ezDynamicArray<ezGAL::ModifiedRange> m_FreeRanges;
+  ezGAL::ModifiedRange m_DirtyRange;
+
+  ezGALBufferCreationDescription m_Desc;
+
+  ezGALBufferHandle m_hBufferForUpload;
+  ezGALBufferHandle m_hBufferForRendering;
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+  ezString m_sDebugName;
+#endif
+
+  static void DeviceEventHandler(const ezGALDeviceEvent& e);
+  static ezIdTable<ezGALDynamicBufferHandle::IdType, ezGALDynamicBuffer*> s_Buffers;
+};

--- a/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
+++ b/Code/Engine/RendererFoundation/Resources/DynamicBuffer.h
@@ -22,7 +22,7 @@ public:
   {
     ezUInt32 uiCount = 0;
     ezByteArrayPtr byteData = MapForWriting(uiOffset, uiCount);
-    EZ_ASSERT_DEBUG(uiCount * m_Desc.m_uiStructSize == byteData.GetCount(), "Invalid Type");
+    EZ_ASSERT_DEBUG(sizeof(T) == m_Desc.m_uiStructSize, "Invalid Type");
     return ezArrayPtr<T>(reinterpret_cast<T*>(byteData.GetPtr()), uiCount);
   }
 

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -12,6 +12,14 @@ namespace
     }
   };
 
+  struct CompareRangesByStartReverse
+  {
+    bool Less(const ezGAL::ModifiedRange& a, const ezGAL::ModifiedRange& b) const
+    {
+      return a.m_uiMin > b.m_uiMin;
+    }
+  };
+
   struct CompareRangesByCount
   {
     bool Less(const ezGAL::ModifiedRange& a, const ezGAL::ModifiedRange& b) const
@@ -113,27 +121,35 @@ void ezGALDynamicBuffer::Deallocate(ezUInt32 uiOffset)
   EZ_ASSERT_DEV(it.IsValid(), "Invalid offset");
 
   const ezUInt32 uiCount = it.Value().m_uiCount;
-  m_Allocations.Remove(it);
 
-  m_FreeRanges.PushBack(ezGAL::ModifiedRange{uiOffset, uiOffset + uiCount - 1});
-
-  // Merge adjacent free ranges
-  m_FreeRanges.Sort(CompareRangesByStart());
-  for (ezUInt32 i = 0; i < m_FreeRanges.GetCount() - 1; ++i)
+  if (it.Key() == m_Allocations.GetReverseIterator().Key())
   {
-    auto& currentFreeRange = m_FreeRanges[i];
-    auto& nextFreeRange = m_FreeRanges[i + 1];
+    m_uiNextOffset = uiOffset;
+  }
+  else
+  {
+    m_FreeRanges.PushBack(ezGAL::ModifiedRange{uiOffset, uiOffset + uiCount - 1});
 
-    if (currentFreeRange.m_uiMax + 1 == nextFreeRange.m_uiMin)
+    // Merge adjacent free ranges
+    m_FreeRanges.Sort(CompareRangesByStart());
+    for (ezUInt32 i = 0; i < m_FreeRanges.GetCount() - 1; ++i)
     {
-      currentFreeRange.m_uiMax = nextFreeRange.m_uiMax;
-      m_FreeRanges.RemoveAtAndCopy(i + 1);
-      --i;
+      auto& currentFreeRange = m_FreeRanges[i];
+      auto& nextFreeRange = m_FreeRanges[i + 1];
+
+      if (currentFreeRange.m_uiMax + 1 == nextFreeRange.m_uiMin)
+      {
+        currentFreeRange.m_uiMax = nextFreeRange.m_uiMax;
+        m_FreeRanges.RemoveAtAndCopy(i + 1);
+        --i;
+      }
     }
+
+    // Sort by count to make sure that the smaller holes are filled first
+    m_FreeRanges.Sort(CompareRangesByCount());
   }
 
-  // Sort by count to make sure that the smaller holes are filled first
-  m_FreeRanges.Sort(CompareRangesByCount());
+  m_Allocations.Remove(it);
 }
 
 ezByteArrayPtr ezGALDynamicBuffer::MapForWriting(ezUInt32 uiOffset, ezUInt32& out_uiCount)
@@ -189,8 +205,82 @@ void ezGALDynamicBuffer::RunCompactionSteps(ezDynamicArray<ChangedAllocation>& o
 
   out_changedAllocations.Clear();
 
-  // EZ_ASSERT_NOT_IMPLEMENTED;
-  EZ_IGNORE_UNUSED(uiMaxSteps);
+  if (m_FreeRanges.IsEmpty() || m_Allocations.IsEmpty())
+    return;
+
+  m_FreeRanges.Sort(CompareRangesByStartReverse());
+  EZ_SCOPE_EXIT(m_FreeRanges.Sort(CompareRangesByCount()));
+
+  auto MoveAllocation = [&](const Allocation& allocation, ezUInt32 uiOldOffset, ezUInt32 uiNewOffset)
+  {
+    out_changedAllocations.PushBack(ChangedAllocation{allocation.m_uiUserData, uiNewOffset});
+
+    const ezUInt32 uiOldByteOffset = uiOldOffset * m_Desc.m_uiStructSize;
+    const ezUInt32 uiNewByteOffset = uiNewOffset * m_Desc.m_uiStructSize;
+    const ezUInt32 uiByteSize = allocation.m_uiCount * m_Desc.m_uiStructSize;
+    ezMemoryUtils::Copy(&m_Data[uiNewByteOffset], &m_Data[uiOldByteOffset], uiByteSize);
+
+    m_DirtyRange.SetToIncludeRange(uiNewOffset, uiNewOffset + allocation.m_uiCount - 1);
+
+    m_Allocations.Insert(uiNewOffset, allocation);
+    m_Allocations.Remove(uiOldOffset);
+  };
+
+  for (ezUInt32 i = 0; i < uiMaxSteps; ++i)
+  {
+    if (m_FreeRanges.IsEmpty())
+      return;
+
+    auto& freeRange = m_FreeRanges.PeekBack();
+    const ezUInt32 uiFreeCount = freeRange.GetCount();
+    const ezUInt32 uiNewOffset = freeRange.m_uiMin;
+
+    // first check whether the last allocation fits into the hole
+    auto revIt = m_Allocations.GetReverseIterator();
+    if (revIt.IsValid())
+    {
+      if (revIt.Value().m_uiCount == uiFreeCount)
+      {
+        m_FreeRanges.PopBack();
+
+        MoveAllocation(revIt.Value(), revIt.Key(), uiNewOffset);
+        continue;
+      }
+    }
+
+    // if not start to move the allocations forward
+    auto it = m_Allocations.Find(freeRange.m_uiMax + 1);
+    EZ_ASSERT_DEV(it.IsValid(), "Implementation error");
+    {
+      const ezUInt32 uiNewFreeRangeMin = uiNewOffset + it.Value().m_uiCount;
+
+      if (it.Key() == revIt.Key())
+      {
+        // This was the last allocation
+        m_uiNextOffset = uiNewFreeRangeMin;
+        m_FreeRanges.PopBack();
+      }
+      else
+      {
+        freeRange.m_uiMin = uiNewFreeRangeMin;
+        freeRange.m_uiMax = freeRange.m_uiMin + uiFreeCount - 1;
+
+        // merge adjacent free ranges
+        if (m_FreeRanges.GetCount() > 1)
+        {
+          const ezUInt32 uiSecondIndex = m_FreeRanges.GetCount() - 2;
+          auto& secondFreeRange = m_FreeRanges[uiSecondIndex];
+          if (freeRange.m_uiMax + 1 == secondFreeRange.m_uiMin)
+          {
+            freeRange.m_uiMax = secondFreeRange.m_uiMax;
+            m_FreeRanges.RemoveAtAndCopy(uiSecondIndex);
+          }
+        }
+      }
+
+      MoveAllocation(it.Value(), it.Key(), uiNewOffset);
+    }
+  }
 }
 
 void ezGALDynamicBuffer::Resize(ezUInt32 uiNewSize)

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -2,6 +2,27 @@
 
 #include <RendererFoundation/Resources/DynamicBuffer.h>
 
+namespace
+{
+  struct CompareRangesByStart
+  {
+    bool Less(const ezGAL::ModifiedRange& a, const ezGAL::ModifiedRange& b) const
+    {
+      return a.m_uiMin < b.m_uiMin;
+    }
+  };
+
+  struct CompareRangesByCount
+  {
+    bool Less(const ezGAL::ModifiedRange& a, const ezGAL::ModifiedRange& b) const
+    {
+      return a.GetCount() < b.GetCount();
+    }
+  };
+} // namespace
+
+////////////////////////////////////////////////////////////////////////
+
 ezGALDynamicBuffer::~ezGALDynamicBuffer()
 {
   Deinitialize();
@@ -53,6 +74,8 @@ ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
 
     if (uiFreeCount >= uiCount)
     {
+      uiOffset = freeRange.m_uiMin;
+
       if (uiFreeCount == uiCount)
       {
         m_FreeRanges.RemoveAtAndCopy(i);
@@ -62,7 +85,6 @@ ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
         freeRange.m_uiMin += uiCount;
       }
 
-      uiOffset = freeRange.m_uiMin;
       break;
     }
   }
@@ -72,7 +94,7 @@ ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
     uiOffset = m_uiNextOffset;
     m_uiNextOffset += uiCount;
 
-    const ezUInt32 uiTotalByteSize = m_Data.GetCount() + (uiCount * m_Desc.m_uiStructSize);
+    const ezUInt32 uiTotalByteSize = m_uiNextOffset * m_Desc.m_uiStructSize;
     if (uiTotalByteSize > m_Desc.m_uiTotalSize)
     {
       Resize(uiTotalByteSize);
@@ -90,11 +112,28 @@ void ezGALDynamicBuffer::Deallocate(ezUInt32 uiOffset)
   auto it = m_Allocations.Find(uiOffset);
   EZ_ASSERT_DEV(it.IsValid(), "Invalid offset");
 
-  // const ezUInt32 uiCount = it.Value().m_uiCount;
+  const ezUInt32 uiCount = it.Value().m_uiCount;
   m_Allocations.Remove(it);
 
-  // First check for adjacent free ranges
-  EZ_ASSERT_NOT_IMPLEMENTED;
+  m_FreeRanges.PushBack(ezGAL::ModifiedRange{uiOffset, uiOffset + uiCount - 1});
+
+  // Merge adjacent free ranges
+  m_FreeRanges.Sort(CompareRangesByStart());
+  for (ezUInt32 i = 0; i < m_FreeRanges.GetCount() - 1; ++i)
+  {
+    auto& currentFreeRange = m_FreeRanges[i];
+    auto& nextFreeRange = m_FreeRanges[i + 1];
+
+    if (currentFreeRange.m_uiMax + 1 == nextFreeRange.m_uiMin)
+    {
+      currentFreeRange.m_uiMax = nextFreeRange.m_uiMax;
+      m_FreeRanges.RemoveAtAndCopy(i + 1);
+      --i;
+    }
+  }
+
+  // Sort by count to make sure that the smaller holes are filled first
+  m_FreeRanges.Sort(CompareRangesByCount());
 }
 
 ezByteArrayPtr ezGALDynamicBuffer::MapForWriting(ezUInt32 uiOffset, ezUInt32& out_uiCount)
@@ -150,7 +189,7 @@ void ezGALDynamicBuffer::RunCompactionSteps(ezDynamicArray<ChangedAllocation>& o
 
   out_changedAllocations.Clear();
 
-  //EZ_ASSERT_NOT_IMPLEMENTED;
+  // EZ_ASSERT_NOT_IMPLEMENTED;
   EZ_IGNORE_UNUSED(uiMaxSteps);
 }
 

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -1,5 +1,7 @@
 #include <RendererFoundation/RendererFoundationPCH.h>
 
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Resources/Buffer.h>
 #include <RendererFoundation/Resources/DynamicBuffer.h>
 
 namespace
@@ -167,7 +169,7 @@ ezByteArrayPtr ezGALDynamicBuffer::MapForWriting(ezUInt32 uiOffset, ezUInt32& ou
   return m_Data.GetByteArrayPtr().GetSubArray(uiByteOffset, uiByteSize);
 }
 
-void ezGALDynamicBuffer::UploadChanges()
+void ezGALDynamicBuffer::UploadChangesForNextFrame()
 {
   EZ_LOCK(m_Mutex);
 

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -59,7 +59,7 @@ void ezGALDynamicBuffer::Initialize(const ezGALBufferCreationDescription& desc, 
   EZ_ASSERT_DEV(desc.m_uiStructSize > 0, "Struct size must be greater than 0");
 
   m_Desc = desc;
-  m_Data.Reserve(desc.m_uiTotalSize);
+  m_Data.SetCountUninitialized(desc.m_uiTotalSize);
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
   m_sDebugName = sDebugName;
@@ -114,15 +114,14 @@ ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
 
   if (uiOffset == ezInvalidIndex)
   {
-    uiOffset = m_Data.GetCount() / m_Desc.m_uiStructSize;
+    uiOffset = m_uiNextOffset;
+    m_uiNextOffset += uiCount;
 
     const ezUInt32 uiTotalByteSize = m_Data.GetCount() + (uiCount * m_Desc.m_uiStructSize);
     if (uiTotalByteSize > m_Desc.m_uiTotalSize)
     {
       Resize(uiTotalByteSize);
     }
-
-    m_Data.SetCountUninitialized(uiTotalByteSize);
   }
 
   m_Allocations.Insert(uiOffset, Allocation{uiUserData, uiCount});
@@ -164,6 +163,7 @@ void ezGALDynamicBuffer::UploadChanges()
   if (m_hBufferForUpload.IsInvalidated() == false && pDevice->GetBuffer(m_hBufferForUpload)->GetDescription().m_uiTotalSize != m_Desc.m_uiTotalSize)
   {
     pDevice->DestroyBuffer(m_hBufferForUpload);
+    m_hBufferForUpload.Invalidate();
   }
 
   if (m_hBufferForUpload.IsInvalidated())
@@ -206,7 +206,7 @@ void ezGALDynamicBuffer::Resize(ezUInt32 uiNewSize)
   }
 
   m_Desc.m_uiTotalSize = uiSize;
-  m_Data.Reserve(uiSize);
+  m_Data.SetCountUninitialized(uiSize);
 
   m_DirtyRange.SetToIncludeRange(0, (uiSize / m_Desc.m_uiStructSize) - 1);
 }

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -2,53 +2,6 @@
 
 #include <RendererFoundation/Resources/DynamicBuffer.h>
 
-ezIdTable<ezGALDynamicBufferHandle::IdType, ezGALDynamicBuffer*> ezGALDynamicBuffer::s_Buffers;
-static bool s_bInitialized = false;
-static ezMutex s_Mutex;
-
-// static
-ezGALDynamicBufferHandle ezGALDynamicBuffer::Create(const ezGALBufferCreationDescription& desc, ezStringView sDebugName)
-{
-  EZ_LOCK(s_Mutex);
-
-  if (!s_bInitialized)
-  {
-    ezGALDevice::s_Events.AddEventHandler(ezMakeDelegate(&ezGALDynamicBuffer::DeviceEventHandler));
-    s_bInitialized = true;
-  }
-
-  auto pBuffer = EZ_DEFAULT_NEW(ezGALDynamicBuffer);
-  pBuffer->Initialize(desc, sDebugName);
-
-  return ezGALDynamicBufferHandle(s_Buffers.Insert(pBuffer));
-}
-
-// static
-void ezGALDynamicBuffer::Destroy(ezGALDynamicBufferHandle& inout_hBuffer)
-{
-  if (inout_hBuffer.IsInvalidated())
-    return;
-
-  EZ_LOCK(s_Mutex);
-
-  ezGALDynamicBuffer* pOldBuffer = nullptr;
-  s_Buffers.Remove(inout_hBuffer, &pOldBuffer);
-
-  EZ_DEFAULT_DELETE(pOldBuffer);
-
-  inout_hBuffer.Invalidate();
-}
-
-// static
-ezGALDynamicBuffer* ezGALDynamicBuffer::Get(ezGALDynamicBufferHandle hBuffer)
-{
-  EZ_LOCK(s_Mutex);
-
-  ezGALDynamicBuffer* pBuffer = nullptr;
-  s_Buffers.TryGetValue(hBuffer, pBuffer);
-  return pBuffer;
-}
-
 ezGALDynamicBuffer::~ezGALDynamicBuffer()
 {
   Deinitialize();
@@ -89,6 +42,8 @@ void ezGALDynamicBuffer::Deinitialize()
 
 ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
 {
+  EZ_LOCK(m_Mutex);
+
   ezUInt32 uiOffset = ezInvalidIndex;
 
   for (ezUInt32 i = 0; i < m_FreeRanges.GetCount(); ++i)
@@ -130,6 +85,8 @@ ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
 
 void ezGALDynamicBuffer::Deallocate(ezUInt32 uiOffset)
 {
+  EZ_LOCK(m_Mutex);
+
   auto it = m_Allocations.Find(uiOffset);
   EZ_ASSERT_DEV(it.IsValid(), "Invalid offset");
 
@@ -142,6 +99,8 @@ void ezGALDynamicBuffer::Deallocate(ezUInt32 uiOffset)
 
 ezByteArrayPtr ezGALDynamicBuffer::MapForWriting(ezUInt32 uiOffset, ezUInt32& out_uiCount)
 {
+  EZ_LOCK(m_Mutex);
+
   auto it = m_Allocations.Find(uiOffset);
   EZ_ASSERT_DEV(it.IsValid(), "Invalid offset");
 
@@ -155,6 +114,8 @@ ezByteArrayPtr ezGALDynamicBuffer::MapForWriting(ezUInt32 uiOffset, ezUInt32& ou
 
 void ezGALDynamicBuffer::UploadChanges()
 {
+  EZ_LOCK(m_Mutex);
+
   if (m_DirtyRange.IsValid() == false)
     return;
 
@@ -185,6 +146,8 @@ void ezGALDynamicBuffer::UploadChanges()
 
 void ezGALDynamicBuffer::RunCompactionSteps(ezDynamicArray<ChangedAllocation>& out_changedAllocations, ezUInt32 uiMaxSteps)
 {
+  EZ_LOCK(m_Mutex);
+
   out_changedAllocations.Clear();
 
   //EZ_ASSERT_NOT_IMPLEMENTED;
@@ -209,18 +172,4 @@ void ezGALDynamicBuffer::Resize(ezUInt32 uiNewSize)
   m_Data.SetCountUninitialized(uiSize);
 
   m_DirtyRange.SetToIncludeRange(0, (uiSize / m_Desc.m_uiStructSize) - 1);
-}
-
-void ezGALDynamicBuffer::DeviceEventHandler(const ezGALDeviceEvent& e)
-{
-  if (e.m_Type != ezGALDeviceEvent::AfterBeginFrame)
-    return;
-
-  EZ_LOCK(s_Mutex);
-
-  for (auto it = s_Buffers.GetIterator(); it.IsValid(); ++it)
-  {
-    auto pBuffer = it.Value();
-    pBuffer->m_hBufferForRendering = pBuffer->m_hBufferForUpload;
-  }
 }

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -1,0 +1,226 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Resources/DynamicBuffer.h>
+
+ezIdTable<ezGALDynamicBufferHandle::IdType, ezGALDynamicBuffer*> ezGALDynamicBuffer::s_Buffers;
+static bool s_bInitialized = false;
+static ezMutex s_Mutex;
+
+// static
+ezGALDynamicBufferHandle ezGALDynamicBuffer::Create(const ezGALBufferCreationDescription& desc, ezStringView sDebugName)
+{
+  EZ_LOCK(s_Mutex);
+
+  if (!s_bInitialized)
+  {
+    ezGALDevice::s_Events.AddEventHandler(ezMakeDelegate(&ezGALDynamicBuffer::DeviceEventHandler));
+    s_bInitialized = true;
+  }
+
+  auto pBuffer = EZ_DEFAULT_NEW(ezGALDynamicBuffer);
+  pBuffer->Initialize(desc, sDebugName);
+
+  return ezGALDynamicBufferHandle(s_Buffers.Insert(pBuffer));
+}
+
+// static
+void ezGALDynamicBuffer::Destroy(ezGALDynamicBufferHandle& inout_hBuffer)
+{
+  if (inout_hBuffer.IsInvalidated())
+    return;
+
+  EZ_LOCK(s_Mutex);
+
+  ezGALDynamicBuffer* pOldBuffer = nullptr;
+  s_Buffers.Remove(inout_hBuffer, &pOldBuffer);
+
+  EZ_DEFAULT_DELETE(pOldBuffer);
+
+  inout_hBuffer.Invalidate();
+}
+
+// static
+ezGALDynamicBuffer* ezGALDynamicBuffer::Get(ezGALDynamicBufferHandle hBuffer)
+{
+  EZ_LOCK(s_Mutex);
+
+  ezGALDynamicBuffer* pBuffer = nullptr;
+  s_Buffers.TryGetValue(hBuffer, pBuffer);
+  return pBuffer;
+}
+
+ezGALDynamicBuffer::~ezGALDynamicBuffer()
+{
+  Deinitialize();
+}
+
+void ezGALDynamicBuffer::Initialize(const ezGALBufferCreationDescription& desc, ezStringView sDebugName)
+{
+  EZ_ASSERT_DEV(desc.m_uiStructSize > 0, "Struct size must be greater than 0");
+
+  m_Desc = desc;
+  m_Data.Reserve(desc.m_uiTotalSize);
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+  m_sDebugName = sDebugName;
+#endif
+}
+
+void ezGALDynamicBuffer::Deinitialize()
+{
+  m_Data.Clear();
+  m_Allocations.Clear();
+  m_FreeRanges.Clear();
+  m_DirtyRange.Reset();
+
+  if (m_hBufferForUpload.IsInvalidated() == false)
+  {
+    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hBufferForUpload);
+  }
+
+  if (m_hBufferForRendering.IsInvalidated() == false && m_hBufferForRendering != m_hBufferForUpload)
+  {
+    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hBufferForRendering);
+  }
+
+  m_hBufferForUpload.Invalidate();
+  m_hBufferForRendering.Invalidate();
+}
+
+ezUInt32 ezGALDynamicBuffer::Allocate(ezUInt64 uiUserData, ezUInt32 uiCount)
+{
+  ezUInt32 uiOffset = ezInvalidIndex;
+
+  for (ezUInt32 i = 0; i < m_FreeRanges.GetCount(); ++i)
+  {
+    auto& freeRange = m_FreeRanges[i];
+    const ezUInt32 uiFreeCount = freeRange.GetCount();
+
+    if (uiFreeCount >= uiCount)
+    {
+      if (uiFreeCount == uiCount)
+      {
+        m_FreeRanges.RemoveAtAndCopy(i);
+      }
+      else
+      {
+        freeRange.m_uiMin += uiCount;
+      }
+
+      uiOffset = freeRange.m_uiMin;
+      break;
+    }
+  }
+
+  if (uiOffset == ezInvalidIndex)
+  {
+    uiOffset = m_Data.GetCount() / m_Desc.m_uiStructSize;
+
+    const ezUInt32 uiTotalByteSize = m_Data.GetCount() + (uiCount * m_Desc.m_uiStructSize);
+    if (uiTotalByteSize > m_Desc.m_uiTotalSize)
+    {
+      Resize(uiTotalByteSize);
+    }
+
+    m_Data.SetCountUninitialized(uiTotalByteSize);
+  }
+
+  m_Allocations.Insert(uiOffset, Allocation{uiUserData, uiCount});
+  return uiOffset;
+}
+
+void ezGALDynamicBuffer::Deallocate(ezUInt32 uiOffset)
+{
+  auto it = m_Allocations.Find(uiOffset);
+  EZ_ASSERT_DEV(it.IsValid(), "Invalid offset");
+
+  // const ezUInt32 uiCount = it.Value().m_uiCount;
+  m_Allocations.Remove(it);
+
+  // First check for adjacent free ranges
+  EZ_ASSERT_NOT_IMPLEMENTED;
+}
+
+ezByteArrayPtr ezGALDynamicBuffer::MapForWriting(ezUInt32 uiOffset, ezUInt32& out_uiCount)
+{
+  auto it = m_Allocations.Find(uiOffset);
+  EZ_ASSERT_DEV(it.IsValid(), "Invalid offset");
+
+  out_uiCount = it.Value().m_uiCount;
+  m_DirtyRange.SetToIncludeRange(uiOffset, uiOffset + out_uiCount - 1);
+
+  const ezUInt32 uiByteOffset = uiOffset * m_Desc.m_uiStructSize;
+  const ezUInt32 uiByteSize = out_uiCount * m_Desc.m_uiStructSize;
+  return m_Data.GetByteArrayPtr().GetSubArray(uiByteOffset, uiByteSize);
+}
+
+void ezGALDynamicBuffer::UploadChanges()
+{
+  if (m_DirtyRange.IsValid() == false)
+    return;
+
+  auto pDevice = ezGALDevice::GetDefaultDevice();
+
+  if (m_hBufferForUpload.IsInvalidated() == false && pDevice->GetBuffer(m_hBufferForUpload)->GetDescription().m_uiTotalSize != m_Desc.m_uiTotalSize)
+  {
+    pDevice->DestroyBuffer(m_hBufferForUpload);
+  }
+
+  if (m_hBufferForUpload.IsInvalidated())
+  {
+    m_hBufferForUpload = pDevice->CreateBuffer(m_Desc, m_Data);
+    pDevice->GetBuffer(m_hBufferForUpload)->SetDebugName(m_sDebugName);
+  }
+  else
+  {
+    const ezUInt32 uiByteOffset = m_DirtyRange.m_uiMin * m_Desc.m_uiStructSize;
+    const ezUInt32 uiByteSize = m_DirtyRange.GetCount() * m_Desc.m_uiStructSize;
+    auto data = m_Data.GetArrayPtr().GetSubArray(uiByteOffset, uiByteSize);
+
+    pDevice->UpdateBufferForNextFrame(m_hBufferForUpload, data, uiByteOffset);
+  }
+
+  m_DirtyRange.Reset();
+}
+
+void ezGALDynamicBuffer::RunCompactionSteps(ezDynamicArray<ChangedAllocation>& out_changedAllocations, ezUInt32 uiMaxSteps)
+{
+  out_changedAllocations.Clear();
+
+  //EZ_ASSERT_NOT_IMPLEMENTED;
+  EZ_IGNORE_UNUSED(uiMaxSteps);
+}
+
+void ezGALDynamicBuffer::Resize(ezUInt32 uiNewSize)
+{
+  constexpr ezUInt32 uiExpGrowthLimit = 16 * 1024 * 1024;
+
+  ezUInt32 uiSize = ezMath::Max(uiNewSize, 256U);
+  if (uiSize < uiExpGrowthLimit)
+  {
+    uiSize = ezMath::PowerOfTwo_Ceil(uiSize);
+  }
+  else
+  {
+    uiSize = ezMemoryUtils::AlignSize(uiSize, uiExpGrowthLimit);
+  }
+
+  m_Desc.m_uiTotalSize = uiSize;
+  m_Data.Reserve(uiSize);
+
+  m_DirtyRange.SetToIncludeRange(0, (uiSize / m_Desc.m_uiStructSize) - 1);
+}
+
+void ezGALDynamicBuffer::DeviceEventHandler(const ezGALDeviceEvent& e)
+{
+  if (e.m_Type != ezGALDeviceEvent::AfterBeginFrame)
+    return;
+
+  EZ_LOCK(s_Mutex);
+
+  for (auto it = s_Buffers.GetIterator(); it.IsValid(); ++it)
+  {
+    auto pBuffer = it.Value();
+    pBuffer->m_hBufferForRendering = pBuffer->m_hBufferForUpload;
+  }
+}

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -157,7 +157,7 @@ void ezProcVertexColorComponentManager::UpdateVertexColors(const ezWorldModule::
 bool ezProcVertexColorComponentManager::UpdateComponentOutputs(ezProcVertexColorComponent* pComponent)
 {
   pComponent->m_Outputs.Clear();
-  
+
   {
     ezResourceLock<ezProcGenGraphResource> pResource(pComponent->m_hResource, ezResourceAcquireMode::BlockTillLoaded);
     auto outputs = pResource->GetVertexColorOutputs();

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -557,6 +557,9 @@ void ezProcVertexColorComponent::SetBufferOffset(ezUInt32 uiOffset)
 {
   const ezUInt32 uiNumOutputs = m_Outputs.GetCount();
   m_uiBufferAccessData = uiNumOutputs << BUFFER_ACCESS_OFFSET_BITS | (uiOffset & ezProcVertexColorComponent::BUFFER_ACCESS_OFFSET_MASK);
+
+  // Invalidate all cached render data so the new offset is propagated to the render data
+  ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
 }
 
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -24,14 +24,6 @@ void ezProcVertexColorRenderData::FillBatchIdAndSortingKey()
 
 //////////////////////////////////////////////////////////////////////////
 
-enum
-{
-  BUFFER_ACCESS_OFFSET_BITS = 28,
-  BUFFER_ACCESS_OFFSET_MASK = (1 << BUFFER_ACCESS_OFFSET_BITS) - 1,
-
-  VERTEX_COLOR_BUFFER_SIZE = 1024 * 1024
-};
-
 using namespace ezProcGenInternal;
 
 ezProcVertexColorComponentManager::ezProcVertexColorComponentManager(ezWorld* pWorld)
@@ -46,9 +38,11 @@ void ezProcVertexColorComponentManager::Initialize()
   SUPER::Initialize();
 
   {
+    constexpr ezUInt32 uiInitialBufferSize = 1024 * 16;
+
     ezGALBufferCreationDescription desc;
     desc.m_uiStructSize = sizeof(ezUInt32);
-    desc.m_uiTotalSize = desc.m_uiStructSize * VERTEX_COLOR_BUFFER_SIZE;
+    desc.m_uiTotalSize = uiInitialBufferSize;
     desc.m_ResourceAccess.m_bImmutable = false;
 
     if (ezGALDevice::GetDefaultDevice()->GetCapabilities().m_bSupportsTexelBuffer)
@@ -60,9 +54,7 @@ void ezProcVertexColorComponentManager::Initialize()
     {
       desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
     }
-    m_hVertexColorBuffer = ezGALDevice::GetDefaultDevice()->CreateBuffer(desc);
-
-    m_VertexColorData.SetCountUninitialized(VERTEX_COLOR_BUFFER_SIZE);
+    m_hVertexColorBuffer = ezGALDynamicBuffer::Create(desc, "ProcVertexColor");
   }
 
   {
@@ -73,7 +65,6 @@ void ezProcVertexColorComponentManager::Initialize()
     this->RegisterUpdateFunction(desc);
   }
 
-  ezRenderWorld::GetRenderEvent().AddEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnRenderEvent, this));
   ezRenderWorld::GetExtractionEvent().AddEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnExtractionEvent, this));
 
   ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnResourceEvent, this));
@@ -84,10 +75,8 @@ void ezProcVertexColorComponentManager::Initialize()
 
 void ezProcVertexColorComponentManager::Deinitialize()
 {
-  ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hVertexColorBuffer);
-  m_hVertexColorBuffer.Invalidate();
+  ezGALDynamicBuffer::Destroy(m_hVertexColorBuffer);
 
-  ezRenderWorld::GetRenderEvent().RemoveEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnRenderEvent, this));
   ezRenderWorld::GetExtractionEvent().RemoveEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnExtractionEvent, this));
 
   ezResourceManager::GetResourceEvents().RemoveEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnResourceEvent, this));
@@ -99,30 +88,76 @@ void ezProcVertexColorComponentManager::Deinitialize()
 
 void ezProcVertexColorComponentManager::UpdateVertexColors(const ezWorldModule::UpdateContext& context)
 {
-  m_UpdateTaskGroupID = ezTaskSystem::CreateTaskGroup(ezTaskPriority::EarlyThisFrame);
+  auto pBuffer = ezGALDynamicBuffer::Get(m_hVertexColorBuffer);
 
-  for (const auto& componentToUpdate : m_ComponentsToUpdate)
+  // Buffer compaction
   {
-    ezProcVertexColorComponent* pComponent = nullptr;
-    if (!TryGetComponent(componentToUpdate, pComponent))
-      continue;
+    constexpr ezUInt32 uiMaxSteps = 16;
 
-    UpdateComponentVertexColors(pComponent);
+    ezHybridArray<ezGALDynamicBuffer::ChangedAllocation, uiMaxSteps> changedAllocations;
+    pBuffer->RunCompactionSteps(changedAllocations, uiMaxSteps);
 
-    // Invalidate all cached render data so the new buffer handle and offset are propagated to the render data
-    ezRenderWorld::DeleteCachedRenderData(pComponent->GetOwner()->GetHandle(), pComponent->GetHandle());
+    for (const auto& changedAllocation : changedAllocations)
+    {
+      ezComponentHandle hComponent(ezComponentId(changedAllocation.m_uiUserData));
+      ezProcVertexColorComponent* pComponent = nullptr;
+      EZ_VERIFY(TryGetComponent(hComponent, pComponent), "Invalid component handle");
+
+      pComponent->SetBufferOffset(changedAllocation.m_uiNewOffset);
+    }
   }
 
-  m_ComponentsToUpdate.Clear();
+  // New allocations first to ensure that the buffer is large enough and the memory is not invalidated by reallocations
+  {
+    for (const auto& componentToUpdate : m_ComponentsToUpdate)
+    {
+      ezProcVertexColorComponent* pComponent = nullptr;
+      if (!TryGetComponent(componentToUpdate, pComponent))
+        continue;
 
-  ezTaskSystem::StartTaskGroup(m_UpdateTaskGroupID);
+      if (!UpdateComponentOutputs(pComponent))
+        continue;
+
+      if (pComponent->m_uiBufferAccessData != 0)
+        continue;
+
+      auto pCpuMesh = pComponent->GetCpuMeshResource();
+      if (pCpuMesh == nullptr)
+        continue;
+
+      const auto& meshBufferDescriptor = pCpuMesh->GetDescriptor().MeshBufferDesc();
+      const ezUInt32 uiNumOutputs = pComponent->m_Outputs.GetCount();
+      const ezUInt32 uiVertexColorCount = meshBufferDescriptor.GetVertexCount() * uiNumOutputs;
+
+      const ezUInt32 uiOffset = pBuffer->Allocate(pComponent->GetHandle(), uiVertexColorCount);
+      pComponent->SetBufferOffset(uiOffset);
+      pComponent->m_hVertexColorBuffer = m_hVertexColorBuffer;
+    }
+  }
+
+  // Update
+  {
+    m_UpdateTaskGroupID = ezTaskSystem::CreateTaskGroup(ezTaskPriority::EarlyThisFrame);
+
+    for (const auto& componentToUpdate : m_ComponentsToUpdate)
+    {
+      ezProcVertexColorComponent* pComponent = nullptr;
+      if (!TryGetComponent(componentToUpdate, pComponent))
+        continue;
+
+      UpdateComponentVertexColors(pComponent, pBuffer);
+    }
+
+    m_ComponentsToUpdate.Clear();
+
+    ezTaskSystem::StartTaskGroup(m_UpdateTaskGroupID);
+  }
 }
 
-void ezProcVertexColorComponentManager::UpdateComponentVertexColors(ezProcVertexColorComponent* pComponent)
+bool ezProcVertexColorComponentManager::UpdateComponentOutputs(ezProcVertexColorComponent* pComponent)
 {
   pComponent->m_Outputs.Clear();
-  ezHybridArray<ezProcVertexColorMapping, 2> outputMappings;
-
+  
   {
     ezResourceLock<ezProcGenGraphResource> pResource(pComponent->m_hResource, ezResourceAcquireMode::BlockTillLoaded);
     auto outputs = pResource->GetVertexColorOutputs();
@@ -152,40 +187,20 @@ void ezProcVertexColorComponentManager::UpdateComponentVertexColors(ezProcVertex
       {
         pComponent->m_Outputs.PushBack(nullptr);
       }
-
-      outputMappings.PushBack(outputDesc.m_Mapping);
     }
   }
 
-  if (!pComponent->HasValidOutputs())
+  return pComponent->HasValidOutputs();
+}
+
+void ezProcVertexColorComponentManager::UpdateComponentVertexColors(ezProcVertexColorComponent* pComponent, ezGALDynamicBuffer* pBuffer)
+{
+  if (pComponent->m_uiBufferAccessData == 0 || !pComponent->HasValidOutputs())
     return;
 
-  const ezStringView sMesh = pComponent->GetMesh().GetResourceID();
-  if (sMesh.IsEmpty())
+  auto pCpuMesh = pComponent->GetCpuMeshResource();
+  if (pCpuMesh == nullptr)
     return;
-
-  ezCpuMeshResourceHandle hCpuMesh = ezResourceManager::LoadResource<ezCpuMeshResource>(sMesh);
-  ezResourceLock<ezCpuMeshResource> pCpuMesh(hCpuMesh, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
-  if (pCpuMesh.GetAcquireResult() != ezResourceAcquireResult::Final)
-  {
-    ezLog::Warning("Failed to retrieve CPU mesh '{}'", sMesh);
-    return;
-  }
-
-  const auto& mbDesc = pCpuMesh->GetDescriptor().MeshBufferDesc();
-  const ezUInt32 uiNumOutputs = pComponent->m_Outputs.GetCount();
-  const ezUInt32 uiVertexColorCount = mbDesc.GetVertexCount() * uiNumOutputs;
-
-  pComponent->m_hVertexColorBuffer = m_hVertexColorBuffer;
-
-  if (pComponent->m_uiBufferAccessData == 0)
-  {
-    pComponent->m_uiBufferAccessData = (uiNumOutputs << BUFFER_ACCESS_OFFSET_BITS) | m_uiCurrentBufferOffset;
-    m_uiCurrentBufferOffset += uiVertexColorCount;
-  }
-
-  const ezUInt32 uiBufferOffset = pComponent->m_uiBufferAccessData & BUFFER_ACCESS_OFFSET_MASK;
-  m_ModifiedDataRange.SetToIncludeRange(uiBufferOffset, uiBufferOffset + uiVertexColorCount - 1);
 
   if (m_uiNextTaskIndex >= m_UpdateTasks.GetCount())
   {
@@ -195,10 +210,19 @@ void ezProcVertexColorComponentManager::UpdateComponentVertexColors(ezProcVertex
   auto& pUpdateTask = m_UpdateTasks[m_uiNextTaskIndex];
 
   ezStringBuilder taskName = "VertexColor ";
-  taskName.Append(pCpuMesh->GetResourceDescription().GetView());
+  taskName.Append(pCpuMesh->GetResourceIdOrDescription());
   pUpdateTask->ConfigureTask(taskName, ezTaskNesting::Never);
 
-  pUpdateTask->Prepare(*GetWorld(), mbDesc, pComponent->GetOwner()->GetGlobalTransform(), pComponent->m_Outputs, outputMappings, m_VertexColorData.GetArrayPtr().GetSubArray(uiBufferOffset, uiVertexColorCount));
+  const auto& meshBufferDescriptor = pCpuMesh->GetDescriptor().MeshBufferDesc();
+  auto vertexColorData = pBuffer->MapForWriting<ezUInt32>(pComponent->GetBufferOffset());
+
+  ezHybridArray<ezProcVertexColorMapping, 2> outputMappings;
+  for (auto& outputDesc : pComponent->m_OutputDescs)
+  {
+    outputMappings.PushBack(outputDesc.m_Mapping);
+  }
+
+  pUpdateTask->Prepare(*GetWorld(), meshBufferDescriptor, pComponent->GetOwner()->GetGlobalTransform(), pComponent->m_Outputs, outputMappings, vertexColorData);
 
   ezTaskSystem::AddTaskToGroup(m_UpdateTaskGroupID, pUpdateTask);
 
@@ -214,35 +238,7 @@ void ezProcVertexColorComponentManager::OnExtractionEvent(const ezRenderWorldExt
   m_UpdateTaskGroupID.Invalidate();
   m_uiNextTaskIndex = 0;
 
-  if (m_ModifiedDataRange.IsValid())
-  {
-    auto& dataCopy = m_DataCopy[ezRenderWorld::GetDataIndexForExtraction()];
-    dataCopy.m_Data = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt32, m_ModifiedDataRange.GetCount());
-    dataCopy.m_Data.CopyFrom(m_VertexColorData.GetArrayPtr().GetSubArray(m_ModifiedDataRange.m_uiMin, m_ModifiedDataRange.GetCount()));
-    dataCopy.m_uiStart = m_ModifiedDataRange.m_uiMin;
-
-    m_ModifiedDataRange.Reset();
-  }
-}
-
-void ezProcVertexColorComponentManager::OnRenderEvent(const ezRenderWorldRenderEvent& e)
-{
-  if (e.m_Type != ezRenderWorldRenderEvent::Type::BeginRender)
-    return;
-
-  auto& dataCopy = m_DataCopy[ezRenderWorld::GetDataIndexForRendering()];
-  if (!dataCopy.m_Data.IsEmpty())
-  {
-    ezGALDevice* pGALDevice = ezGALDevice::GetDefaultDevice();
-    ezGALCommandEncoder* pCommandEncoder = pGALDevice->BeginCommands("ProcVertexUpdate");
-
-    ezUInt32 uiByteOffset = dataCopy.m_uiStart * sizeof(ezUInt32);
-    pCommandEncoder->UpdateBuffer(m_hVertexColorBuffer, uiByteOffset, dataCopy.m_Data.ToByteArray(), ezGALUpdateMode::AheadOfTime);
-
-    dataCopy = DataCopy();
-
-    pGALDevice->EndCommands(pCommandEncoder);
-  }
+  ezGALDynamicBuffer::Get(m_hVertexColorBuffer)->UploadChanges();
 }
 
 void ezProcVertexColorComponentManager::EnqueueUpdate(ezProcVertexColorComponent* pComponent)
@@ -265,8 +261,7 @@ void ezProcVertexColorComponentManager::RemoveComponent(ezProcVertexColorCompone
 
   if (pComponent->m_uiBufferAccessData != 0)
   {
-    /// \todo compact buffer somehow?
-
+    ezGALDynamicBuffer::Get(m_hVertexColorBuffer)->Deallocate(pComponent->m_uiBufferAccessData);
     pComponent->m_uiBufferAccessData = 0;
   }
 }
@@ -385,7 +380,10 @@ void ezProcVertexColorComponent::OnActivated()
   auto pManager = static_cast<ezProcVertexColorComponentManager*>(GetOwningManager());
   pManager->EnqueueUpdate(this);
 
-  GetOwner()->EnableStaticTransformChangesNotifications();
+  if (GetUniqueID() != ezInvalidIndex)
+  {
+    GetOwner()->EnableStaticTransformChangesNotifications();
+  }
 }
 
 void ezProcVertexColorComponent::OnDeactivated()
@@ -536,6 +534,29 @@ bool ezProcVertexColorComponent::HasValidOutputs() const
   }
 
   return false;
+}
+
+const ezCpuMeshResource* ezProcVertexColorComponent::GetCpuMeshResource() const
+{
+  const ezStringView sMesh = GetMesh().GetResourceID();
+  if (sMesh.IsEmpty())
+    return nullptr;
+
+  ezCpuMeshResourceHandle hCpuMesh = ezResourceManager::LoadResource<ezCpuMeshResource>(sMesh);
+  ezResourceLock<ezCpuMeshResource> pCpuMesh(hCpuMesh, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
+  if (pCpuMesh.GetAcquireResult() != ezResourceAcquireResult::Final)
+  {
+    ezLog::Warning("Failed to retrieve CPU mesh '{}'", sMesh);
+    return nullptr;
+  }
+
+  return pCpuMesh.GetPointer();
+}
+
+void ezProcVertexColorComponent::SetBufferOffset(ezUInt32 uiOffset)
+{
+  const ezUInt32 uiNumOutputs = m_Outputs.GetCount();
+  m_uiBufferAccessData = uiNumOutputs << BUFFER_ACCESS_OFFSET_BITS | (uiOffset & ezProcVertexColorComponent::BUFFER_ACCESS_OFFSET_MASK);
 }
 
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -238,7 +238,7 @@ void ezProcVertexColorComponentManager::OnExtractionEvent(const ezRenderWorldExt
   m_UpdateTaskGroupID.Invalidate();
   m_uiNextTaskIndex = 0;
 
-  ezGALDevice::GetDefaultDevice()->GetDynamicBuffer(m_hVertexColorBuffer)->UploadChanges();
+  ezGALDevice::GetDefaultDevice()->GetDynamicBuffer(m_hVertexColorBuffer)->UploadChangesForNextFrame();
 }
 
 void ezProcVertexColorComponentManager::EnqueueUpdate(ezProcVertexColorComponent* pComponent)

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -261,7 +261,7 @@ void ezProcVertexColorComponentManager::RemoveComponent(ezProcVertexColorCompone
 
   if (pComponent->m_uiBufferAccessData != 0)
   {
-    ezGALDynamicBuffer::Get(m_hVertexColorBuffer)->Deallocate(pComponent->m_uiBufferAccessData);
+    ezGALDynamicBuffer::Get(m_hVertexColorBuffer)->Deallocate(pComponent->GetBufferOffset());
     pComponent->m_uiBufferAccessData = 0;
   }
 }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -54,7 +54,7 @@ void ezProcVertexColorComponentManager::Initialize()
     {
       desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
     }
-    m_hVertexColorBuffer = ezGALDynamicBuffer::Create(desc, "ProcVertexColor");
+    m_hVertexColorBuffer = ezGALDevice::GetDefaultDevice()->CreateDynamicBuffer(desc, "ProcVertexColor");
   }
 
   {
@@ -75,7 +75,7 @@ void ezProcVertexColorComponentManager::Initialize()
 
 void ezProcVertexColorComponentManager::Deinitialize()
 {
-  ezGALDynamicBuffer::Destroy(m_hVertexColorBuffer);
+  ezGALDevice::GetDefaultDevice()->DestroyDynamicBuffer(m_hVertexColorBuffer);
 
   ezRenderWorld::GetExtractionEvent().RemoveEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnExtractionEvent, this));
 
@@ -88,7 +88,7 @@ void ezProcVertexColorComponentManager::Deinitialize()
 
 void ezProcVertexColorComponentManager::UpdateVertexColors(const ezWorldModule::UpdateContext& context)
 {
-  auto pBuffer = ezGALDynamicBuffer::Get(m_hVertexColorBuffer);
+  auto pBuffer = ezGALDevice::GetDefaultDevice()->GetDynamicBuffer(m_hVertexColorBuffer);
 
   // Buffer compaction
   {
@@ -238,7 +238,7 @@ void ezProcVertexColorComponentManager::OnExtractionEvent(const ezRenderWorldExt
   m_UpdateTaskGroupID.Invalidate();
   m_uiNextTaskIndex = 0;
 
-  ezGALDynamicBuffer::Get(m_hVertexColorBuffer)->UploadChanges();
+  ezGALDevice::GetDefaultDevice()->GetDynamicBuffer(m_hVertexColorBuffer)->UploadChanges();
 }
 
 void ezProcVertexColorComponentManager::EnqueueUpdate(ezProcVertexColorComponent* pComponent)
@@ -261,7 +261,7 @@ void ezProcVertexColorComponentManager::RemoveComponent(ezProcVertexColorCompone
 
   if (pComponent->m_uiBufferAccessData != 0)
   {
-    ezGALDynamicBuffer::Get(m_hVertexColorBuffer)->Deallocate(pComponent->GetBufferOffset());
+    ezGALDevice::GetDefaultDevice()->GetDynamicBuffer(m_hVertexColorBuffer)->Deallocate(pComponent->GetBufferOffset());
     pComponent->m_uiBufferAccessData = 0;
   }
 }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorRenderer.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorRenderer.cpp
@@ -27,7 +27,7 @@ void ezProcVertexColorRenderer::SetAdditionalData(const ezRenderViewContext& ren
   ezRenderContext* pContext = renderViewContext.m_pRenderContext;
 
   auto pProcVertexColorRenderData = static_cast<const ezProcVertexColorRenderData*>(pRenderData);
-  if (auto pVertexColorBuffer = ezGALDynamicBuffer::Get(pProcVertexColorRenderData->m_hVertexColorBuffer))
+  if (auto pVertexColorBuffer = pDevice->GetDynamicBuffer(pProcVertexColorRenderData->m_hVertexColorBuffer))
   {
     pContext->BindBuffer("perInstanceVertexColors", pDevice->GetDefaultResourceView(pVertexColorBuffer->GetBufferForRendering()));
   }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorRenderer.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorRenderer.cpp
@@ -27,8 +27,10 @@ void ezProcVertexColorRenderer::SetAdditionalData(const ezRenderViewContext& ren
   ezRenderContext* pContext = renderViewContext.m_pRenderContext;
 
   auto pProcVertexColorRenderData = static_cast<const ezProcVertexColorRenderData*>(pRenderData);
-
-  pContext->BindBuffer("perInstanceVertexColors", pDevice->GetDefaultResourceView(pProcVertexColorRenderData->m_hVertexColorBuffer));
+  if (auto pVertexColorBuffer = ezGALDynamicBuffer::Get(pProcVertexColorRenderData->m_hVertexColorBuffer))
+  {
+    pContext->BindBuffer("perInstanceVertexColors", pDevice->GetDefaultResourceView(pVertexColorBuffer->GetBufferForRendering()));
+  }
 }
 
 void ezProcVertexColorRenderer::FillPerInstanceData(

--- a/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.cpp
+++ b/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.cpp
@@ -1,0 +1,139 @@
+#include <RendererTest/RendererTestPCH.h>
+
+#include <RendererTest/Basics/DynamicBufferTest.h>
+
+#include <RendererFoundation/Resources/DynamicBuffer.h>
+
+void ezRendererTestDynamicBuffer::SetupSubTests()
+{
+  AddSubTest("Allocations", SubTests::ST_Allocations);
+  AddSubTest("Deallocations", SubTests::ST_Deallocations);
+}
+
+ezResult ezRendererTestDynamicBuffer::InitializeSubTest(ezInt32 iIdentifier)
+{
+  EZ_SUCCEED_OR_RETURN(ezGraphicsTest::InitializeSubTest(iIdentifier));
+
+  m_iFrame = -1;
+
+  ezGALBufferCreationDescription desc;
+  desc.m_uiStructSize = sizeof(ezUInt64);
+  desc.m_uiTotalSize = desc.m_uiStructSize * 16;
+  desc.m_BufferFlags = ezGALBufferUsageFlags::StructuredBuffer | ezGALBufferUsageFlags::ShaderResource;
+
+  m_hDynamicBuffer = ezGALDevice::GetDefaultDevice()->CreateDynamicBuffer(desc, "Test buffer");
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestDynamicBuffer::DeInitializeSubTest(ezInt32 iIdentifier)
+{
+  ezGALDevice::GetDefaultDevice()->DestroyDynamicBuffer(m_hDynamicBuffer);
+
+  if (ezGraphicsTest::DeInitializeSubTest(iIdentifier).Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+{
+  if (iIdentifier == SubTests::ST_Allocations)
+  {
+    constexpr ezUInt32 uiAllocationSizes[] = {11, 23, 4, 5, 6};
+
+    auto pDevice = ezGALDevice::GetDefaultDevice();
+    auto pDynamicBuffer = pDevice->GetDynamicBuffer(m_hDynamicBuffer);
+
+    ezUInt32 uiTotalOffset = 0;
+    auto AllocateAndMap = [&](ezUInt32 uiIndex)
+    {
+      ezUInt32 uiOffset = pDynamicBuffer->Allocate(uiIndex, uiAllocationSizes[uiIndex]);
+      EZ_TEST_INT(uiOffset, uiTotalOffset);
+
+      auto pMappedData = pDynamicBuffer->MapForWriting<ezUInt64>(uiOffset);
+      EZ_TEST_INT(pMappedData.GetCount(), uiAllocationSizes[uiIndex]);
+
+      uiTotalOffset += uiAllocationSizes[uiIndex];
+    };
+
+    AllocateAndMap(0);
+
+    pDynamicBuffer->UploadChanges();
+
+    // Internal buffer should be have been created after upload but GetBufferForRendering should still return the old handle until the next frame.
+    ezGALBufferHandle hBuffer = pDynamicBuffer->GetBufferForRendering();
+    EZ_TEST_BOOL(hBuffer.IsInvalidated());
+
+    {
+      BeginFrame();
+
+      // After the one frame the buffer should be created
+      ezGALBufferHandle hNewBuffer = pDynamicBuffer->GetBufferForRendering();
+      EZ_TEST_BOOL(hNewBuffer.IsInvalidated() == false);
+      hBuffer = hNewBuffer;
+
+      EndFrame();
+    }
+
+    for (ezUInt32 i = 1; i < EZ_ARRAY_SIZE(uiAllocationSizes); ++i)
+    {
+      AllocateAndMap(i);
+    }
+
+    pDynamicBuffer->UploadChanges();
+
+    ezGALBufferHandle hNewBuffer = pDynamicBuffer->GetBufferForRendering();
+    EZ_TEST_BOOL(hNewBuffer.IsInvalidated() == false);
+
+    // The internal buffer has been re-allocated but GetBufferForRendering should still return the old handle until the next frame.
+    EZ_TEST_BOOL(hNewBuffer == hBuffer);
+
+    BeginFrame();
+    EZ_SCOPE_EXIT(EndFrame());
+
+    // Now the new buffer should be returned
+    hNewBuffer = pDynamicBuffer->GetBufferForRendering();
+    EZ_TEST_BOOL(hNewBuffer != hBuffer);
+
+    return ezTestAppRun::Quit;
+  }
+  else if (iIdentifier == SubTests::ST_Deallocations)
+  {
+    constexpr ezUInt32 uiAllocationSizes[] = {3, 4, 5, 6, 7, 9, 11};
+
+    auto pDevice = ezGALDevice::GetDefaultDevice();
+    auto pDynamicBuffer = pDevice->GetDynamicBuffer(m_hDynamicBuffer);
+
+    ezHybridArray<ezUInt32, 16> offsets;
+    for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(uiAllocationSizes); ++i)
+    {
+      offsets.PushBack(pDynamicBuffer->Allocate(i, uiAllocationSizes[i]));
+    }
+
+    // Create some holes out of order
+    pDynamicBuffer->Deallocate(offsets[1]);
+    pDynamicBuffer->Deallocate(offsets[5]);
+    pDynamicBuffer->Deallocate(offsets[3]);
+
+    // Should try to waste as little space as possible so this allocation should go into the middle hole with size 6. 
+    ezUInt32 uiNewOffset = pDynamicBuffer->Allocate(100, 5);
+    EZ_TEST_INT(uiNewOffset, offsets[3]);
+
+    pDynamicBuffer->Deallocate(uiNewOffset);
+
+    // Should merge all the holes into one big hole
+    pDynamicBuffer->Deallocate(offsets[4]);
+    pDynamicBuffer->Deallocate(offsets[2]);
+
+    // Test whether the merging was done correctly by allocation something almost as big as the hole
+    uiNewOffset = pDynamicBuffer->Allocate(101, 30);
+    EZ_TEST_INT(uiNewOffset, offsets[1]);
+
+    return ezTestAppRun::Quit;
+  }
+
+  return ezTestAppRun::Quit;
+}
+
+static ezRendererTestDynamicBuffer g_DynamicBufferTest;

--- a/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.cpp
+++ b/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.cpp
@@ -60,16 +60,16 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
 
     AllocateAndMap(0);
 
-    pDynamicBuffer->UploadChanges();
+    pDynamicBuffer->UploadChangesForNextFrame();
 
-    // Internal buffer should be have been created after upload but GetBufferForRendering should still return the old handle until the next frame.
+    // Internal buffer should have been created after upload but GetBufferForRendering should still return the old handle until the next frame.
     ezGALBufferHandle hBuffer = pDynamicBuffer->GetBufferForRendering();
     EZ_TEST_BOOL(hBuffer.IsInvalidated());
 
     {
       BeginFrame();
 
-      // After the one frame the buffer should be created
+      // After one frame the buffer should be created
       ezGALBufferHandle hNewBuffer = pDynamicBuffer->GetBufferForRendering();
       EZ_TEST_BOOL(hNewBuffer.IsInvalidated() == false);
       hBuffer = hNewBuffer;
@@ -82,7 +82,7 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
       AllocateAndMap(i);
     }
 
-    pDynamicBuffer->UploadChanges();
+    pDynamicBuffer->UploadChangesForNextFrame();
 
     ezGALBufferHandle hNewBuffer = pDynamicBuffer->GetBufferForRendering();
     EZ_TEST_BOOL(hNewBuffer.IsInvalidated() == false);
@@ -90,12 +90,15 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
     // The internal buffer has been re-allocated but GetBufferForRendering should still return the old handle until the next frame.
     EZ_TEST_BOOL(hNewBuffer == hBuffer);
 
-    BeginFrame();
-    EZ_SCOPE_EXIT(EndFrame());
+    {
+      BeginFrame();
 
-    // Now the new buffer should be returned
-    hNewBuffer = pDynamicBuffer->GetBufferForRendering();
-    EZ_TEST_BOOL(hNewBuffer != hBuffer);
+      // Now the new buffer should be returned
+      hNewBuffer = pDynamicBuffer->GetBufferForRendering();
+      EZ_TEST_BOOL(hNewBuffer != hBuffer);
+
+      EndFrame();
+    }
   }
   else if (iIdentifier == SubTests::ST_Deallocations)
   {
@@ -121,7 +124,7 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
 
     pDynamicBuffer->Deallocate(uiNewOffset);
 
-    // Should merge all the holes into one big hole
+    // Should merge all holes into one big hole
     pDynamicBuffer->Deallocate(offsets[4]);
     pDynamicBuffer->Deallocate(offsets[2]);
 

--- a/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.cpp
+++ b/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.cpp
@@ -8,6 +8,7 @@ void ezRendererTestDynamicBuffer::SetupSubTests()
 {
   AddSubTest("Allocations", SubTests::ST_Allocations);
   AddSubTest("Deallocations", SubTests::ST_Deallocations);
+  AddSubTest("Compaction", SubTests::ST_Compaction);
 }
 
 ezResult ezRendererTestDynamicBuffer::InitializeSubTest(ezInt32 iIdentifier)
@@ -40,7 +41,7 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
 {
   if (iIdentifier == SubTests::ST_Allocations)
   {
-    constexpr ezUInt32 uiAllocationSizes[] = {11, 23, 4, 5, 6};
+    constexpr ezUInt32 uiAllocationSizes[] = {11, 23, 4, 5, 6, 7, 8, 9};
 
     auto pDevice = ezGALDevice::GetDefaultDevice();
     auto pDynamicBuffer = pDevice->GetDynamicBuffer(m_hDynamicBuffer);
@@ -95,12 +96,10 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
     // Now the new buffer should be returned
     hNewBuffer = pDynamicBuffer->GetBufferForRendering();
     EZ_TEST_BOOL(hNewBuffer != hBuffer);
-
-    return ezTestAppRun::Quit;
   }
   else if (iIdentifier == SubTests::ST_Deallocations)
   {
-    constexpr ezUInt32 uiAllocationSizes[] = {3, 4, 5, 6, 7, 9, 11};
+    constexpr ezUInt32 uiAllocationSizes[] = {3, 4, 5, 6, 7, 9, 11, 13};
 
     auto pDevice = ezGALDevice::GetDefaultDevice();
     auto pDynamicBuffer = pDevice->GetDynamicBuffer(m_hDynamicBuffer);
@@ -116,7 +115,7 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
     pDynamicBuffer->Deallocate(offsets[5]);
     pDynamicBuffer->Deallocate(offsets[3]);
 
-    // Should try to waste as little space as possible so this allocation should go into the middle hole with size 6. 
+    // Should try to waste as little space as possible so this allocation should go into the middle hole with size 6.
     ezUInt32 uiNewOffset = pDynamicBuffer->Allocate(100, 5);
     EZ_TEST_INT(uiNewOffset, offsets[3]);
 
@@ -130,7 +129,51 @@ ezTestAppRun ezRendererTestDynamicBuffer::RunSubTest(ezInt32 iIdentifier, ezUInt
     uiNewOffset = pDynamicBuffer->Allocate(101, 30);
     EZ_TEST_INT(uiNewOffset, offsets[1]);
 
-    return ezTestAppRun::Quit;
+    // Deallocate the last allocation
+    pDynamicBuffer->Deallocate(offsets[7]);
+
+    uiNewOffset = pDynamicBuffer->Allocate(102, 100);
+    EZ_TEST_INT(uiNewOffset, offsets[7]);
+  }
+  else if (iIdentifier == SubTests::ST_Compaction)
+  {
+    constexpr ezUInt32 uiAllocationSizes[] = {15, 14, 13, 11, 7, 9, 15, 14};
+
+    auto pDevice = ezGALDevice::GetDefaultDevice();
+    auto pDynamicBuffer = pDevice->GetDynamicBuffer(m_hDynamicBuffer);
+
+    ezHybridArray<ezUInt32, 16> offsets;
+    for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(uiAllocationSizes); ++i)
+    {
+      offsets.PushBack(pDynamicBuffer->Allocate(i, uiAllocationSizes[i]));
+    }
+
+    // Create some holes out of order
+    pDynamicBuffer->Deallocate(offsets[5]);
+    pDynamicBuffer->Deallocate(offsets[1]);
+    pDynamicBuffer->Deallocate(offsets[3]);
+
+    ezHybridArray<ezGALDynamicBuffer::ChangedAllocation, 16> changedAllocations;
+
+    // The first compaction step should move the last allocation into the first hole
+    {
+      pDynamicBuffer->RunCompactionSteps(changedAllocations, 1);
+
+      EZ_TEST_INT(changedAllocations.GetCount(), 1);
+      EZ_TEST_INT(changedAllocations[0].m_uiUserData, 7);
+      EZ_TEST_INT(changedAllocations[0].m_uiNewOffset, offsets[1]);
+    }
+
+    // For the next steps the last allocation does not match the hole size so it should start to move allocations forward to close the hole
+    {
+      pDynamicBuffer->RunCompactionSteps(changedAllocations, 16);
+
+      EZ_TEST_INT(changedAllocations.GetCount(), 2);
+      EZ_TEST_INT(changedAllocations[0].m_uiUserData, 4);
+      EZ_TEST_INT(changedAllocations[0].m_uiNewOffset, offsets[3]);
+      EZ_TEST_INT(changedAllocations[1].m_uiUserData, 6);
+      EZ_TEST_INT(changedAllocations[1].m_uiNewOffset, offsets[3] + uiAllocationSizes[4]);
+    }
   }
 
   return ezTestAppRun::Quit;

--- a/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.h
+++ b/Code/UnitTests/RendererTest/Basics/DynamicBufferTest.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "../TestClass/TestClass.h"
+
+class ezRendererTestDynamicBuffer : public ezGraphicsTest
+{
+  using SUPER = ezGraphicsTest;
+
+public:
+  virtual const char* GetTestName() const override { return "Dynamic Buffer"; }
+
+private:
+  enum SubTests
+  {
+    ST_Allocations,
+    ST_Deallocations,
+    ST_Compaction,
+  };
+
+  virtual void SetupSubTests() override;
+
+  virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
+  virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
+  virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+
+private:
+  ezGALDynamicBufferHandle m_hDynamicBuffer;
+};

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -278,7 +278,10 @@ void ezGraphicsTest::BeginFrame()
 
 void ezGraphicsTest::EndFrame()
 {
-  m_pWindow->ProcessWindowMessages();
+  if (m_pWindow)
+  {
+    m_pWindow->ProcessWindowMessages();
+  }
 
   ezRenderContext::GetDefaultInstance()->ResetContextState();
 


### PR DESCRIPTION
* Added a new "buffer" type called GAL dynamic buffer which can be used when a lot of data should be stored in a single large buffer with a dynamic size. It supports allocation/deallocation of single elements or ranges of multiple elements. There is also a compaction step which can move allocations around to reduce fragmentation over time. Only a dirty range of changed elements is then uploaded to the GPU buffer.
* In this PR a dynamic buffer is only used for procedural vertex colors but the plan is to use it for much more in the future, e.g. instance data, skinning data etc.