### PR TITLE
Removed batch id from render data

### DIFF
--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
@@ -154,7 +154,7 @@ void ezEditorShapeIconsExtractor::ExtractShapeIcon(const ezGameObject* pObject, 
 
       pRenderData->m_color.a = 1.0f;
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     extractedRenderData.AddRenderData(pRenderData, category);

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -16,8 +16,6 @@ void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHig
   if (s_pState->m_bShutdown)
     return;
 
-  EZ_PROFILE_SCOPE("InternalPreloadResource");
-
   EZ_LOCK(s_ResourceMutex);
 
   // if there is nothing else that could be loaded, just return right away
@@ -28,6 +26,8 @@ void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHig
     // pResource->GetDynamicRTTI()->GetTypeName());
     return;
   }
+
+  EZ_PROFILE_SCOPE("InternalPreloadResource");
 
   EZ_ASSERT_DEV(!s_pState->m_bExportMode, "Resources should not be loaded in export mode");
 

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager_inl.h
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager_inl.h
@@ -3,13 +3,13 @@
 #include <Foundation/Logging/Log.h>
 
 template <typename ResourceType>
-ResourceType* ezResourceManager::GetResource(ezStringView sResourceID, bool bIsReloadable)
+EZ_FORCE_INLINE ResourceType* ezResourceManager::GetResource(ezStringView sResourceID, bool bIsReloadable)
 {
   return static_cast<ResourceType*>(GetResource(ezGetStaticRTTI<ResourceType>(), sResourceID, bIsReloadable));
 }
 
 template <typename ResourceType>
-ezTypedResourceHandle<ResourceType> ezResourceManager::LoadResource(ezStringView sResourceID)
+EZ_FORCE_INLINE ezTypedResourceHandle<ResourceType> ezResourceManager::LoadResource(ezStringView sResourceID)
 {
   // the mutex here is necessary to prevent a race between resource unloading and storing the pointer in the handle
   EZ_LOCK(s_ResourceMutex);

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -191,7 +191,7 @@ void ezLodAnimatedMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& 
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     // Determine render data category.

--- a/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/GreyBoxComponent.cpp
@@ -214,7 +214,7 @@ void ezGreyBoxComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) con
 
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     bool bDontCacheYet = false;

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
@@ -277,7 +277,7 @@ void ezBakedProbesComponent::OnExtractRenderData(ezMsgExtractRenderData& ref_msg
       pRenderData->m_uiSubMeshIndex = 0;
       pRenderData->m_uiUniqueID = ezRenderComponent::GetUniqueIdForRendering(*this, 0);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     ref_msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::SimpleOpaque, caching);

--- a/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/BeamComponent.cpp
@@ -157,7 +157,7 @@ void ezBeamComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
     pRenderData->m_uiSubMeshIndex = 0;
     pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
 
-    pRenderData->FillBatchIdAndSortingKey();
+    pRenderData->FillSortingKey();
   }
 
   // Determine render data category.

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
@@ -15,14 +15,20 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezLensFlareRenderData, 1, ezRTTIDefaultAllocator
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezLensFlareRenderData::FillBatchIdAndSortingKey()
+void ezLensFlareRenderData::FillSortingKey()
 {
   // ignore upper 32 bit of the resource ID hash
   const ezUInt32 uiTextureIDHash = static_cast<ezUInt32>(m_hTexture.GetResourceIDHash());
 
-  // Batch and sort by texture
-  m_uiBatchId = uiTextureIDHash;
+  // Sort by texture
   m_uiSortingKey = uiTextureIDHash;
+}
+
+bool ezLensFlareRenderData::CanBatch(const ezRenderData& other0) const
+{
+  const auto& other = ezStaticCast<const ezLensFlareRenderData&>(other0);
+
+  return m_hTexture == other.m_hTexture;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -307,7 +313,7 @@ void ezLensFlareComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
       pRenderData->m_bGreyscaleTexture = element.m_bGreyscaleTexture;
       pRenderData->m_bApplyFog = m_bApplyFog;
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::LitTransparent,

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -123,7 +123,7 @@ void ezRopeRenderComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
 
     pRenderData->m_hSkinningTransforms = m_SkinningState.m_hGpuBuffer;
 
-    pRenderData->FillBatchIdAndSortingKey();
+    pRenderData->FillSortingKey();
   }
 
   // Determine render data category.

--- a/Code/Engine/RendererCore/Components/Implementation/SkyBoxComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SkyBoxComponent.cpp
@@ -103,7 +103,7 @@ void ezSkyBoxComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) cons
     pRenderData->m_uiSubMeshIndex = 0;
     pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
 
-    pRenderData->FillBatchIdAndSortingKey();
+    pRenderData->FillSortingKey();
   }
 
   msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::Sky, ezRenderData::Caching::Never);

--- a/Code/Engine/RendererCore/Components/LensFlareComponent.h
+++ b/Code/Engine/RendererCore/Components/LensFlareComponent.h
@@ -14,7 +14,8 @@ class EZ_RENDERERCORE_DLL ezLensFlareRenderData : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezLensFlareRenderData, ezRenderData);
 
 public:
-  void FillBatchIdAndSortingKey();
+  void FillSortingKey();
+  virtual bool CanBatch(const ezRenderData& other) const override;
 
   ezTexture2DResourceHandle m_hTexture;
   ezFloat16Vec4 m_Color;

--- a/Code/Engine/RendererCore/Components/SpriteComponent.h
+++ b/Code/Engine/RendererCore/Components/SpriteComponent.h
@@ -32,7 +32,8 @@ class EZ_RENDERERCORE_DLL ezSpriteRenderData : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezSpriteRenderData, ezRenderData);
 
 public:
-  void FillBatchIdAndSortingKey();
+  void FillSortingKey();
+  virtual bool CanBatch(const ezRenderData& other) const override;
 
   ezTexture2DResourceHandle m_hTexture;
 

--- a/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
+++ b/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
@@ -75,4 +75,5 @@ private:
   ezDynamicArray<ezUInt32> m_TempClusterItemList;
 
   ezDynamicArray<ezSimdBSphere, ezAlignedAllocatorWrapper> m_ClusterBoundingSpheres;
+  ezMat4 m_ProjectionMatrix = ezMat4::MakeZero();
 };

--- a/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
+++ b/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
@@ -75,5 +75,5 @@ private:
   ezDynamicArray<ezUInt32> m_TempClusterItemList;
 
   ezDynamicArray<ezSimdBSphere, ezAlignedAllocatorWrapper> m_ClusterBoundingSpheres;
-  ezMat4 m_ProjectionMatrix = ezMat4::MakeZero();
+  ezMat4 m_mProjection = ezMat4::MakeZero();
 };

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -33,6 +33,8 @@ namespace
     ezMat4 mProj;
     pCamera->GetProjectionMatrix(fAspectRatio, mProj);
 
+    const ezMat4& mInvView = pCamera->GetViewMatrix().GetInverse();
+
     ezAngle fFovLeft;
     ezAngle fFovRight;
     ezAngle fFovBottom;
@@ -46,11 +48,13 @@ namespace
 
     ezColor lineColor = ezColor(1.0f, 1.0f, 1.0f, 0.1f);
 
-    ezInt32 debugSlice = cvar_RenderingLightingVisClusterDepthSlice;
-    ezUInt32 maxSlice = debugSlice < 0 ? NUM_CLUSTERS_Z : debugSlice + 1;
-    ezUInt32 minSlice = debugSlice < 0 ? 0 : debugSlice;
+    const ezInt32 debugSlice = cvar_RenderingLightingVisClusterDepthSlice;
+    const bool bOnlyOneSlice = debugSlice >= 0;
+    const ezUInt32 maxSlice = bOnlyOneSlice ? debugSlice + 1 : NUM_CLUSTERS_Z;
+    const ezUInt32 minSlice = bOnlyOneSlice ? debugSlice : 0;
 
     bool bDrawBoundingSphere = false;
+    ezStringBuilder sb;
 
     for (ezUInt32 z = maxSlice; z-- > minSlice;)
     {
@@ -68,56 +72,69 @@ namespace
             if (bDrawBoundingSphere)
             {
               ezBoundingSphere s = ezSimdConversion::ToBSphere(boundingSpheres[clusterIndex]);
+              s.TransformFromOrigin(mInvView);
               ezDebugRenderer::DrawLineSphere(view.GetHandle(), s, lineColor);
             }
+            else
+            {
+              ezVec3 cc[8];
+              GetClusterCornerPoints(*pCamera, fZf, fZn, fTanLeft, fTanRight, fTanBottom, fTanTop, x, y, z, cc);
 
-            ezVec3 cc[8];
-            GetClusterCornerPoints(*pCamera, fZf, fZn, fTanLeft, fTanRight, fTanBottom, fTanTop, x, y, z, cc);
+              const float lightCount = (float)GET_LIGHT_INDEX(clusterData.counts);
+              const float decalCount = (float)GET_DECAL_INDEX(clusterData.counts);
+              const float probeCount = (float)GET_PROBE_INDEX(clusterData.counts);
+              const float r = ezMath::Clamp(lightCount / 16.0f, 0.0f, 1.0f);
+              const float g = ezMath::Clamp(decalCount / 16.0f, 0.0f, 1.0f);
+              const float b = ezMath::Clamp(probeCount / 16.0f, 0.0f, 1.0f);
+              const ezColor color(r, g, b);
 
-            float lightCount = (float)GET_LIGHT_INDEX(clusterData.counts);
-            float decalCount = (float)GET_DECAL_INDEX(clusterData.counts);
-            float r = ezMath::Clamp(lightCount / 16.0f, 0.0f, 1.0f);
-            float g = ezMath::Clamp(decalCount / 16.0f, 0.0f, 1.0f);
+              ezDebugRendererTriangle tris[12];
+              // back
+              tris[0] = ezDebugRendererTriangle(cc[0], cc[2], cc[1]);
+              tris[1] = ezDebugRendererTriangle(cc[2], cc[3], cc[1]);
+              // front
+              tris[2] = ezDebugRendererTriangle(cc[4], cc[5], cc[6]);
+              tris[3] = ezDebugRendererTriangle(cc[6], cc[5], cc[7]);
+              // top
+              tris[4] = ezDebugRendererTriangle(cc[4], cc[0], cc[5]);
+              tris[5] = ezDebugRendererTriangle(cc[0], cc[1], cc[5]);
+              // bottom
+              tris[6] = ezDebugRendererTriangle(cc[6], cc[7], cc[2]);
+              tris[7] = ezDebugRendererTriangle(cc[2], cc[7], cc[3]);
+              // left
+              tris[8] = ezDebugRendererTriangle(cc[4], cc[6], cc[0]);
+              tris[9] = ezDebugRendererTriangle(cc[0], cc[6], cc[2]);
+              // right
+              tris[10] = ezDebugRendererTriangle(cc[5], cc[1], cc[7]);
+              tris[11] = ezDebugRendererTriangle(cc[1], cc[3], cc[7]);
 
-            ezDebugRendererTriangle tris[12];
-            // back
-            tris[0] = ezDebugRendererTriangle(cc[0], cc[2], cc[1]);
-            tris[1] = ezDebugRendererTriangle(cc[2], cc[3], cc[1]);
-            // front
-            tris[2] = ezDebugRendererTriangle(cc[4], cc[5], cc[6]);
-            tris[3] = ezDebugRendererTriangle(cc[6], cc[5], cc[7]);
-            // top
-            tris[4] = ezDebugRendererTriangle(cc[4], cc[0], cc[5]);
-            tris[5] = ezDebugRendererTriangle(cc[0], cc[1], cc[5]);
-            // bottom
-            tris[6] = ezDebugRendererTriangle(cc[6], cc[7], cc[2]);
-            tris[7] = ezDebugRendererTriangle(cc[2], cc[7], cc[3]);
-            // left
-            tris[8] = ezDebugRendererTriangle(cc[4], cc[6], cc[0]);
-            tris[9] = ezDebugRendererTriangle(cc[0], cc[6], cc[2]);
-            // right
-            tris[10] = ezDebugRendererTriangle(cc[5], cc[1], cc[7]);
-            tris[11] = ezDebugRendererTriangle(cc[1], cc[3], cc[7]);
+              ezDebugRenderer::DrawSolidTriangles(view.GetHandle(), tris, color.WithAlpha(0.1f));
 
-            ezDebugRenderer::DrawSolidTriangles(view.GetHandle(), tris, ezColor(r, g, 0.0f, 0.1f));
+              ezDebugRendererLine lines[12];
+              lines[0] = ezDebugRendererLine(cc[4], cc[5]);
+              lines[1] = ezDebugRendererLine(cc[5], cc[7]);
+              lines[2] = ezDebugRendererLine(cc[7], cc[6]);
+              lines[3] = ezDebugRendererLine(cc[6], cc[4]);
 
-            ezDebugRendererLine lines[12];
-            lines[0] = ezDebugRendererLine(cc[4], cc[5]);
-            lines[1] = ezDebugRendererLine(cc[5], cc[7]);
-            lines[2] = ezDebugRendererLine(cc[7], cc[6]);
-            lines[3] = ezDebugRendererLine(cc[6], cc[4]);
+              lines[4] = ezDebugRendererLine(cc[0], cc[1]);
+              lines[5] = ezDebugRendererLine(cc[1], cc[3]);
+              lines[6] = ezDebugRendererLine(cc[3], cc[2]);
+              lines[7] = ezDebugRendererLine(cc[2], cc[0]);
 
-            lines[4] = ezDebugRendererLine(cc[0], cc[1]);
-            lines[5] = ezDebugRendererLine(cc[1], cc[3]);
-            lines[6] = ezDebugRendererLine(cc[3], cc[2]);
-            lines[7] = ezDebugRendererLine(cc[2], cc[0]);
+              lines[8] = ezDebugRendererLine(cc[4], cc[0]);
+              lines[9] = ezDebugRendererLine(cc[5], cc[1]);
+              lines[10] = ezDebugRendererLine(cc[7], cc[3]);
+              lines[11] = ezDebugRendererLine(cc[6], cc[2]);
 
-            lines[8] = ezDebugRendererLine(cc[4], cc[0]);
-            lines[9] = ezDebugRendererLine(cc[5], cc[1]);
-            lines[10] = ezDebugRendererLine(cc[7], cc[3]);
-            lines[11] = ezDebugRendererLine(cc[6], cc[2]);
+              ezDebugRenderer::DrawLines(view.GetHandle(), lines, color);
 
-            ezDebugRenderer::DrawLines(view.GetHandle(), lines, ezColor(r, g, 0.0f));
+              if (bOnlyOneSlice)
+              {
+                sb.SetFormat("L:{}\nD:{}\nR:{}", (ezUInt32)lightCount, (ezUInt32)decalCount, (ezUInt32)probeCount);
+                ezVec3 textPos = (cc[0] + cc[1] + cc[2] + cc[3] + cc[4] + cc[5] + cc[6] + cc[7]) / 8.0f;
+                ezDebugRenderer::Draw3DText(view.GetHandle(), sb, textPos, color * 4.0f, 16u, ezDebugTextHAlign::Center, ezDebugTextVAlign::Center);
+              }
+            }
           }
         }
       }
@@ -168,6 +185,11 @@ ezClusteredDataExtractor::ezClusteredDataExtractor(const char* szName)
   m_TempLightsClusters.SetCountUninitialized(NUM_CLUSTERS);
   m_TempDecalsClusters.SetCountUninitialized(NUM_CLUSTERS);
   m_TempReflectionProbeClusters.SetCountUninitialized(NUM_CLUSTERS);
+
+  ezMemoryUtils::ZeroFill(m_TempLightsClusters.GetData(), NUM_CLUSTERS);
+  ezMemoryUtils::ZeroFill(m_TempDecalsClusters.GetData(), NUM_CLUSTERS);
+  ezMemoryUtils::ZeroFill(m_TempReflectionProbeClusters.GetData(), NUM_CLUSTERS);
+
   m_ClusterBoundingSpheres.SetCountUninitialized(NUM_CLUSTERS);
 }
 
@@ -180,7 +202,15 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
   const ezCamera* pCamera = view.GetCullingCamera();
   const float fAspectRatio = view.GetViewport().width / view.GetViewport().height;
 
-  FillClusterBoundingSpheres(*pCamera, fAspectRatio, m_ClusterBoundingSpheres);
+  ezMat4 mProj;
+  pCamera->GetProjectionMatrix(fAspectRatio, mProj);
+  if (m_ProjectionMatrix != mProj)
+  {
+    m_ProjectionMatrix = mProj;
+
+    FillClusterBoundingSpheres(*pCamera, mProj, m_ClusterBoundingSpheres);
+  }
+
   ezClusteredDataCPU* pData = EZ_NEW(ezFrameAllocator::GetCurrentAllocator(), ezClusteredDataCPU);
   pData->m_ClusterData = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezPerClusterData, NUM_CLUSTERS);
 
@@ -190,13 +220,13 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
   pCamera->GetProjectionMatrix(fAspectRatio, tmp);
   ezSimdMat4f projectionMatrix = ezSimdConversion::ToMat4(tmp);
 
+  ezSimdMat4f invViewMatrix = viewMatrix.GetInverse();
   ezSimdMat4f viewProjectionMatrix = projectionMatrix * viewMatrix;
 
   // Lights
   {
     EZ_PROFILE_SCOPE("Lights");
     m_TempLightData.Clear();
-    ezMemoryUtils::ZeroFill(m_TempLightsClusters.GetData(), NUM_CLUSTERS);
 
     auto batchList = ref_extractedRenderData.GetRenderDataBatchesWithCategory(ezDefaultRenderDataCategories::Light);
     const ezUInt32 uiBatchCount = batchList.GetBatchCount();
@@ -223,7 +253,8 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
 
           if (false)
           {
-            ezSimdBBox ssb = GetScreenSpaceBounds(pointLightSphere, viewMatrix, projectionMatrix);
+            ezSimdBSphere viewSpaceSphere(viewMatrix.TransformPosition(pointLightSphere.GetCenter()), pointLightSphere.GetRadius());    
+            ezSimdBBox ssb = GetScreenSpaceBounds(viewSpaceSphere, projectionMatrix);
             float minX = ((float)ssb.m_Min.x() * 0.5f + 0.5f) * view.GetViewport().width;
             float maxX = ((float)ssb.m_Max.x() * 0.5f + 0.5f) * view.GetViewport().width;
             float minY = ((float)ssb.m_Max.y() * -0.5f + 0.5f) * view.GetViewport().height;
@@ -296,7 +327,6 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
   {
     EZ_PROFILE_SCOPE("Decals");
     m_TempDecalData.Clear();
-    ezMemoryUtils::ZeroFill(m_TempDecalsClusters.GetData(), NUM_CLUSTERS);
 
     auto batchList = ref_extractedRenderData.GetRenderDataBatchesWithCategory(ezDefaultRenderDataCategories::Decal);
     const ezUInt32 uiBatchCount = batchList.GetBatchCount();
@@ -318,7 +348,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
         {
           FillDecalData(m_TempDecalData.ExpandAndGetRef(), pDecalRenderData);
 
-          RasterizeBox(pDecalRenderData->m_GlobalTransform, uiDecalIndex, viewProjectionMatrix, m_TempDecalsClusters.GetData(), m_ClusterBoundingSpheres.GetData());
+          RasterizeBox(pDecalRenderData->m_GlobalTransform, uiDecalIndex, invViewMatrix, viewProjectionMatrix, m_TempDecalsClusters.GetData(), m_ClusterBoundingSpheres.GetData());
         }
         else
         {
@@ -335,7 +365,6 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
   {
     EZ_PROFILE_SCOPE("Probes");
     m_TempReflectionProbeData.Clear();
-    ezMemoryUtils::ZeroFill(m_TempReflectionProbeClusters.GetData(), NUM_CLUSTERS);
 
     auto batchList = ref_extractedRenderData.GetRenderDataBatchesWithCategory(ezDefaultRenderDataCategories::ReflectionProbe);
     const ezUInt32 uiBatchCount = batchList.GetBatchCount();
@@ -390,7 +419,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
             // const ezBoundingBox aabb(ezVec3(-1.0f), ezVec3(1.0f));
             // ezDebugRenderer::DrawLineBox(view.GetHandle(), aabb, ezColor::DarkBlue, transform);
 
-            RasterizeBox(transform, uiProbeIndex, viewProjectionMatrix, m_TempReflectionProbeClusters.GetData(), m_ClusterBoundingSpheres.GetData());
+            RasterizeBox(transform, uiProbeIndex, invViewMatrix, viewProjectionMatrix, m_TempReflectionProbeClusters.GetData(), m_ClusterBoundingSpheres.GetData());
           }
         }
         else
@@ -475,12 +504,14 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
         while (mask > 0)
         {
           ezUInt32 uiLightIndex = ezMath::FirstBitLow(mask);
-          mask &= ~(1 << uiLightIndex);
+          mask &= mask - 1;
 
           uiLightIndex += uiBlockIndex * 32;
           pTempClusterItemListRange[uiLightCount] = uiLightIndex;
           ++uiLightCount;
         }
+
+        tempCluster.m_BitMask[uiBlockIndex] = 0;
       }
     }
 
@@ -496,7 +527,7 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
         while (mask > 0)
         {
           ezUInt32 uiDecalIndex = ezMath::FirstBitLow(mask);
-          mask &= ~(1 << uiDecalIndex);
+          mask &= mask - 1;
 
           uiDecalIndex += uiBlockIndex * 32;
 
@@ -512,6 +543,8 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
 
           ++uiDecalCount;
         }
+
+        tempCluster.m_BitMask[uiBlockIndex] = 0;
       }
     }
 
@@ -527,7 +560,7 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
         while (mask > 0)
         {
           ezUInt32 uiReflectionProbeIndex = ezMath::FirstBitLow(mask);
-          mask &= ~(1 << uiReflectionProbeIndex);
+          mask &= mask - 1;
 
           uiReflectionProbeIndex += uiBlockIndex * 32;
 
@@ -543,6 +576,8 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
 
           ++uiReflectionProbeCount;
         }
+
+        tempCluster.m_BitMask[uiBlockIndex] = 0;
       }
     }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -533,7 +533,7 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
 
           const ezUInt32 item = pTempClusterItemListRange[uiDecalCount];
           pTempClusterItemListRange[uiDecalCount] = (uiDecalCount < uiLightCount ? item : 0) | MakeDecalIndex(uiDecalIndex);
-          
+
           ++uiDecalCount;
         }
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -459,14 +459,14 @@ ezResult ezClusteredDataExtractor::Deserialize(ezStreamReader& inout_stream)
 
 namespace
 {
-  ezUInt32 PackIndex(ezUInt32 uiLightIndex, ezUInt32 uiDecalIndex)
+  EZ_FORCE_INLINE ezUInt32 MakeDecalIndex(ezUInt32 uiDecalIndex)
   {
-    return uiDecalIndex << 10 | uiLightIndex;
+    return uiDecalIndex << DECAL_SHIFT;
   }
 
-  ezUInt32 PackReflectionProbeIndex(ezUInt32 uiData, ezUInt32 uiReflectionProbeIndex)
+  EZ_FORCE_INLINE ezUInt32 MakeProbeIndex(ezUInt32 uiReflectionProbeIndex)
   {
-    return uiReflectionProbeIndex << 20 | uiData;
+    return uiReflectionProbeIndex << PROBE_SHIFT;
   }
 } // namespace
 
@@ -531,16 +531,9 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
 
           uiDecalIndex += uiBlockIndex * 32;
 
-          if (uiDecalCount < uiLightCount)
-          {
-            auto& item = pTempClusterItemListRange[uiDecalCount];
-            item = PackIndex(item, uiDecalIndex);
-          }
-          else
-          {
-            pTempClusterItemListRange[uiDecalCount] = PackIndex(0, uiDecalIndex);
-          }
-
+          const ezUInt32 item = pTempClusterItemListRange[uiDecalCount];
+          pTempClusterItemListRange[uiDecalCount] = (uiDecalCount < uiLightCount ? item : 0) | MakeDecalIndex(uiDecalIndex);
+          
           ++uiDecalCount;
         }
 
@@ -564,15 +557,8 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
 
           uiReflectionProbeIndex += uiBlockIndex * 32;
 
-          if (uiReflectionProbeCount < uiMaxUsed)
-          {
-            auto& item = pTempClusterItemListRange[uiReflectionProbeCount];
-            item = PackReflectionProbeIndex(item, uiReflectionProbeIndex);
-          }
-          else
-          {
-            pTempClusterItemListRange[uiReflectionProbeCount] = PackReflectionProbeIndex(0, uiReflectionProbeIndex);
-          }
+          const ezUInt32 item = pTempClusterItemListRange[uiReflectionProbeCount];
+          pTempClusterItemListRange[uiReflectionProbeCount] = (uiReflectionProbeCount < uiMaxUsed ? item : 0) | MakeProbeIndex(uiReflectionProbeIndex);
 
           ++uiReflectionProbeCount;
         }
@@ -587,7 +573,7 @@ void ezClusteredDataExtractor::FillItemListAndClusterData(ezClusteredDataCPU* pD
 
     auto& clusterData = pData->m_ClusterData[i];
     clusterData.offset = uiOffset;
-    clusterData.counts = PackReflectionProbeIndex(PackIndex(uiLightCount, uiDecalCount), uiReflectionProbeCount);
+    clusterData.counts = uiLightCount | MakeDecalIndex(uiDecalCount) | MakeProbeIndex(uiReflectionProbeCount);
   }
 
   pData->m_ClusterItemList = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt32, m_TempClusterItemList.GetCount());

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -253,7 +253,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
 
           if (false)
           {
-            ezSimdBSphere viewSpaceSphere(viewMatrix.TransformPosition(pointLightSphere.GetCenter()), pointLightSphere.GetRadius());    
+            ezSimdBSphere viewSpaceSphere(viewMatrix.TransformPosition(pointLightSphere.GetCenter()), pointLightSphere.GetRadius());
             ezSimdBBox ssb = GetScreenSpaceBounds(viewSpaceSphere, projectionMatrix);
             float minX = ((float)ssb.m_Min.x() * 0.5f + 0.5f) * view.GetViewport().width;
             float maxX = ((float)ssb.m_Max.x() * 0.5f + 0.5f) * view.GetViewport().width;

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -204,9 +204,9 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
 
   ezMat4 mProj;
   pCamera->GetProjectionMatrix(fAspectRatio, mProj);
-  if (m_ProjectionMatrix != mProj)
+  if (m_mProjection != mProj)
   {
-    m_ProjectionMatrix = mProj;
+    m_mProjection = mProj;
 
     FillClusterBoundingSpheres(*pCamera, mProj, m_ClusterBoundingSpheres);
   }

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
@@ -85,16 +85,13 @@ namespace
     out_pCorners[7] = out_pCorners[6] + dirRight * fStepXn;
   }
 
-  void FillClusterBoundingSpheres(const ezCamera& camera, float fAspectRatio, ezArrayPtr<ezSimdBSphere> clusterBoundingSpheres)
+  void FillClusterBoundingSpheres(const ezCamera& camera, ezMat4& mProj, ezArrayPtr<ezSimdBSphere> clusterBoundingSpheres)
   {
     EZ_PROFILE_SCOPE("FillClusterBoundingSpheres");
 
     ///\todo proper implementation for orthographic views
     if (camera.IsOrthographic())
       return;
-
-    ezMat4 mProj;
-    camera.GetProjectionMatrix(fAspectRatio, mProj);
 
     ezSimdVec4f stepScale;
     ezSimdVec4f tanLBLB;
@@ -117,10 +114,9 @@ namespace
       tanLBLB = ezSimdVec4f(fTanLeft, fTanBottom, fTanLeft, fTanBottom);
     }
 
-    ezSimdVec4f pos = ezSimdConversion::ToVec3(camera.GetPosition());
-    ezSimdVec4f dirForward = ezSimdConversion::ToVec3(camera.GetDirForwards());
-    ezSimdVec4f dirRight = ezSimdConversion::ToVec3(camera.GetDirRight());
-    ezSimdVec4f dirUp = ezSimdConversion::ToVec3(camera.GetDirUp());
+    const ezSimdVec4f dirForward = ezSimdVec4f(0, 0, 1, 0);
+    const ezSimdVec4f dirRight = ezSimdVec4f(1, 0, 0, 0);
+    const ezSimdVec4f dirUp = ezSimdVec4f(0, 1, 0, 0);
 
 
     ezSimdVec4f fZn = ezSimdVec4f::MakeZero();
@@ -132,8 +128,8 @@ namespace
       ezSimdVec4f zff_znn = fZf.GetCombined<ezSwizzle::XXXX>(fZn);
       ezSimdVec4f steps = zff_znn.CompMul(stepScale);
 
-      ezSimdVec4f depthF = pos + dirForward * fZf.x();
-      ezSimdVec4f depthN = pos + dirForward * fZn.x();
+      ezSimdVec4f depthF = dirForward * fZf.x();
+      ezSimdVec4f depthN = dirForward * fZn.x();
 
       ezSimdVec4f startLBLB = zff_znn.CompMul(tanLBLB);
 
@@ -293,11 +289,11 @@ namespace
   }
 
 
-  EZ_FORCE_INLINE ezSimdBBox GetScreenSpaceBounds(const ezSimdBSphere& sphere, const ezSimdMat4f& mViewMatrix, const ezSimdMat4f& mProjectionMatrix)
+  EZ_FORCE_INLINE ezSimdBBox GetScreenSpaceBounds(const ezSimdBSphere& viewSpaceSphere, const ezSimdMat4f& mProjectionMatrix)
   {
-    ezSimdVec4f viewSpaceCenter = mViewMatrix.TransformPosition(sphere.GetCenter());
+    ezSimdVec4f viewSpaceCenter = viewSpaceSphere.GetCenter();
     ezSimdFloat depth = viewSpaceCenter.z();
-    ezSimdFloat radius = sphere.GetRadius();
+    ezSimdFloat radius = viewSpaceSphere.GetRadius();
 
     ezSimdVec4f mi;
     ezSimdVec4f ma;
@@ -377,14 +373,16 @@ namespace
   void RasterizeSphere(const ezSimdBSphere& pointLightSphere, ezUInt32 uiLightIndex, const ezSimdMat4f& mViewMatrix,
     const ezSimdMat4f& mProjectionMatrix, Cluster* pClusters, ezSimdBSphere* pClusterBoundingSpheres)
   {
-    ezSimdBBox screenSpaceBounds = GetScreenSpaceBounds(pointLightSphere, mViewMatrix, mProjectionMatrix);
+    ezSimdBSphere viewSpaceSphere(mViewMatrix.TransformPosition(pointLightSphere.GetCenter()), pointLightSphere.GetRadius());
+
+    ezSimdBBox screenSpaceBounds = GetScreenSpaceBounds(viewSpaceSphere, mProjectionMatrix);
 
     const ezUInt32 uiBlockIndex = uiLightIndex / 32;
     const ezUInt32 uiMask = 1 << (uiLightIndex - uiBlockIndex * 32);
 
     FillCluster(screenSpaceBounds, uiBlockIndex, uiMask, pClusters,
       [&](ezUInt32 uiClusterIndex)
-      { return pointLightSphere.Overlaps(pClusterBoundingSpheres[uiClusterIndex]); });
+      { return viewSpaceSphere.Overlaps(pClusterBoundingSpheres[uiClusterIndex]); });
   }
 
   struct BoundingCone
@@ -399,9 +397,9 @@ namespace
   void RasterizeSpotLight(const BoundingCone& spotLightCone, ezUInt32 uiLightIndex, const ezSimdMat4f& mViewMatrix,
     const ezSimdMat4f& mProjectionMatrix, Cluster* pClusters, ezSimdBSphere* pClusterBoundingSpheres)
   {
-    ezSimdVec4f position = spotLightCone.m_PositionAndRange;
+    ezSimdVec4f position = mViewMatrix.TransformPosition(spotLightCone.m_PositionAndRange);
     ezSimdFloat range = spotLightCone.m_PositionAndRange.w();
-    ezSimdVec4f forwardDir = spotLightCone.m_ForwardDir;
+    ezSimdVec4f forwardDir = mViewMatrix.TransformDirection(spotLightCone.m_ForwardDir);
     ezSimdFloat sinAngle = spotLightCone.m_SinCosAngle.x();
     ezSimdFloat cosAngle = spotLightCone.m_SinCosAngle.y();
 
@@ -420,7 +418,7 @@ namespace
     }
 
     ezSimdBSphere spotLightSphere(bSphereCenter, bSphereRadius);
-    ezSimdBBox screenSpaceBounds = GetScreenSpaceBounds(spotLightSphere, mViewMatrix, mProjectionMatrix);
+    ezSimdBBox screenSpaceBounds = GetScreenSpaceBounds(spotLightSphere, mProjectionMatrix);
 
     const ezUInt32 uiBlockIndex = uiLightIndex / 32;
     const ezUInt32 uiMask = 1 << (uiLightIndex - uiBlockIndex * 32);
@@ -455,16 +453,16 @@ namespace
   }
 
   template <typename Cluster>
-  void RasterizeBox(const ezTransform& transform, ezUInt32 uiDecalIndex, const ezSimdMat4f& mViewProjectionMatrix, Cluster* pClusters,
+  void RasterizeBox(const ezTransform& transform, ezUInt32 uiDecalIndex, const ezSimdMat4f& mInvView, const ezSimdMat4f& mViewProjection, Cluster* pClusters,
     ezSimdBSphere* pClusterBoundingSpheres)
   {
-    ezSimdMat4f decalToWorld = ezSimdConversion::ToTransform(transform).GetAsMat4();
-    ezSimdMat4f worldToDecal = decalToWorld.GetInverse();
+    ezSimdMat4f boxToWorld = ezSimdConversion::ToTransform(transform).GetAsMat4();
+    ezSimdMat4f viewToBox = boxToWorld.GetInverse() * mInvView;
 
     ezVec3 corners[8];
     ezBoundingBox::MakeFromMinMax(ezVec3(-1), ezVec3(1)).GetCorners(corners);
 
-    ezSimdMat4f decalToScreen = mViewProjectionMatrix * decalToWorld;
+    ezSimdMat4f decalToScreen = mViewProjection * boxToWorld;
     ezSimdBBox screenSpaceBounds = ezSimdBBox::MakeInvalid();
     bool bInsideBox = false;
     for (ezUInt32 i = 0; i < 8; ++i)
@@ -496,7 +494,7 @@ namespace
     FillCluster(screenSpaceBounds, uiBlockIndex, uiMask, pClusters, [&](ezUInt32 uiClusterIndex)
       {
       ezSimdBSphere clusterSphere = pClusterBoundingSpheres[uiClusterIndex];
-      clusterSphere.Transform(worldToDecal);
+      clusterSphere.Transform(viewToBox);
 
       return localDecalBounds.Overlaps(clusterSphere); });
   }

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
@@ -85,7 +85,7 @@ namespace
     out_pCorners[7] = out_pCorners[6] + dirRight * fStepXn;
   }
 
-  void FillClusterBoundingSpheres(const ezCamera& camera, ezMat4& mProj, ezArrayPtr<ezSimdBSphere> clusterBoundingSpheres)
+  void FillClusterBoundingSpheres(const ezCamera& camera, const ezMat4& mProj, ezArrayPtr<ezSimdBSphere> clusterBoundingSpheres)
   {
     EZ_PROFILE_SCOPE("FillClusterBoundingSpheres");
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -144,7 +144,7 @@ void ezReflectionPool::ExtractReflectionProbe(const ezComponent* pComponent, ezM
       pRenderData->m_uiSubMeshIndex = 0;
       pRenderData->m_uiUniqueID = ezRenderComponent::GetUniqueIdForRendering(*pComponent, 0);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
       ref_msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::LitOpaque, ezRenderData::Caching::Never);
     }
   }

--- a/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/CustomMeshComponent.h
@@ -103,7 +103,8 @@ class EZ_RENDERERCORE_DLL ezCustomMeshRenderData : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezCustomMeshRenderData, ezRenderData);
 
 public:
-  virtual void FillBatchIdAndSortingKey();
+  void FillSortingKey();
+  virtual bool CanBatch(const ezRenderData& other) const override;
 
   ezDynamicMeshBufferResourceHandle m_hMesh;
   ezMaterialResourceHandle m_hMaterial;

--- a/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/InstancedMeshComponent.cpp
@@ -90,12 +90,6 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezInstancedMeshRenderData, 1, ezRTTIDefaultAlloc
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezInstancedMeshRenderData::FillBatchIdAndSortingKey()
-{
-  void* pData = &m_pExplicitInstanceData->m_InstanceDataBuffer;
-  FillBatchIdAndSortingKeyInternal(ezHashingUtils::xxHash32(pData, sizeof(pData)));
-}
-
 //////////////////////////////////////////////////////////////////////////////////////
 
 ezInstancedMeshComponentManager::ezInstancedMeshComponentManager(ezWorld* pWorld)

--- a/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/LodMeshComponent.cpp
@@ -183,7 +183,7 @@ void ezLodMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) con
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     // Determine render data category.

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
@@ -63,7 +63,7 @@ bool ezMeshRenderData::CanBatch(const ezRenderData& other0) const
   const auto& other = ezStaticCast<const ezMeshRenderData&>(other0);
 
   return m_hMesh == other.m_hMesh && m_uiSubMeshIndex == other.m_uiSubMeshIndex &&
-    m_hMaterial == other.m_hMaterial && m_uiFlipWinding == other.m_uiFlipWinding;
+         m_hMaterial == other.m_hMaterial && m_uiFlipWinding == other.m_uiFlipWinding;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshComponentBase.cpp
@@ -46,9 +46,24 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshRenderData, 1, ezRTTIDefaultAllocator<ezMe
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezMeshRenderData::FillBatchIdAndSortingKey()
+void ezMeshRenderData::FillSortingKey()
 {
-  FillBatchIdAndSortingKeyInternal(0);
+  m_uiFlipWinding = m_GlobalTransform.HasMirrorScaling() ? 1 : 0;
+  m_uiUniformScale = m_GlobalTransform.ContainsUniformScale() ? 1 : 0;
+
+  const ezUInt32 uiMeshIDHash = ezHashingUtils::StringHashTo32(m_hMesh.GetResourceIDHash());
+  const ezUInt32 uiMaterialIDHash = m_hMaterial.IsValid() ? ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash()) : 0;
+
+  // Sort by material and then by mesh
+  m_uiSortingKey = (uiMaterialIDHash << 16) | ((uiMeshIDHash + m_uiSubMeshIndex) & 0xFFFE) | m_uiFlipWinding;
+}
+
+bool ezMeshRenderData::CanBatch(const ezRenderData& other0) const
+{
+  const auto& other = ezStaticCast<const ezMeshRenderData&>(other0);
+
+  return m_hMesh == other.m_hMesh && m_uiSubMeshIndex == other.m_uiSubMeshIndex &&
+    m_hMaterial == other.m_hMaterial && m_uiFlipWinding == other.m_uiFlipWinding;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -176,7 +191,7 @@ void ezMeshComponentBase::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) co
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     bool bDontCacheYet = false;

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -13,11 +13,6 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSkinnedMeshRenderData, 1, ezRTTIDefaultAllocat
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezSkinnedMeshRenderData::FillBatchIdAndSortingKey()
-{
-  FillBatchIdAndSortingKeyInternal(m_hSkinningTransforms.GetInternalID().m_Data);
-}
-
 ezSkinningState::ezSkinningState() = default;
 
 ezSkinningState::~ezSkinningState()

--- a/Code/Engine/RendererCore/Meshes/InstancedMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/InstancedMeshComponent.h
@@ -38,7 +38,7 @@ class EZ_RENDERERCORE_DLL ezInstancedMeshRenderData : public ezMeshRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezInstancedMeshRenderData, ezMeshRenderData);
 
 public:
-  virtual void FillBatchIdAndSortingKey() override;
+  virtual bool CanBatch(const ezRenderData& other) const override { return false; }
 
   ezInstanceData* m_pExplicitInstanceData = nullptr;
   ezUInt32 m_uiExplicitInstanceCount = 0;

--- a/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
+++ b/Code/Engine/RendererCore/Meshes/MeshComponentBase.h
@@ -15,7 +15,8 @@ class EZ_RENDERERCORE_DLL ezMeshRenderData : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezMeshRenderData, ezRenderData);
 
 public:
-  virtual void FillBatchIdAndSortingKey();
+  void FillSortingKey();
+  virtual bool CanBatch(const ezRenderData& other) const override;
 
   ezMeshResourceHandle m_hMesh;
   ezMaterialResourceHandle m_hMaterial;
@@ -27,23 +28,6 @@ public:
   ezUInt32 m_uiUniformScale : 1;
 
   ezUInt32 m_uiUniqueID = 0;
-
-protected:
-  EZ_FORCE_INLINE void FillBatchIdAndSortingKeyInternal(ezUInt32 uiAdditionalBatchData)
-  {
-    m_uiFlipWinding = m_GlobalTransform.HasMirrorScaling() ? 1 : 0;
-    m_uiUniformScale = m_GlobalTransform.ContainsUniformScale() ? 1 : 0;
-
-    const ezUInt32 uiMeshIDHash = ezHashingUtils::StringHashTo32(m_hMesh.GetResourceIDHash());
-    const ezUInt32 uiMaterialIDHash = m_hMaterial.IsValid() ? ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash()) : 0;
-
-    // Generate batch id from mesh, material and part index.
-    ezUInt32 data[] = {uiMeshIDHash, uiMaterialIDHash, m_uiSubMeshIndex, m_uiFlipWinding, uiAdditionalBatchData};
-    m_uiBatchId = ezHashingUtils::xxHash32(data, sizeof(data));
-
-    // Sort by material and then by mesh
-    m_uiSortingKey = (uiMaterialIDHash << 16) | ((uiMeshIDHash + m_uiSubMeshIndex) & 0xFFFE) | m_uiFlipWinding;
-  }
 };
 
 /// \brief This message is used to replace the material on a mesh.

--- a/Code/Engine/RendererCore/Meshes/SkinnedMeshComponent.h
+++ b/Code/Engine/RendererCore/Meshes/SkinnedMeshComponent.h
@@ -11,7 +11,8 @@ class EZ_RENDERERCORE_DLL ezSkinnedMeshRenderData : public ezMeshRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezSkinnedMeshRenderData, ezMeshRenderData);
 
 public:
-  virtual void FillBatchIdAndSortingKey() override;
+  virtual bool CanBatch(const ezRenderData& other) const override { return false; }
+
   ezGALBufferHandle m_hSkinningTransforms;
 };
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData_inl.h
@@ -20,6 +20,17 @@ EZ_ALWAYS_INLINE bool ezRenderData::Category::operator!=(const Category& other) 
 //////////////////////////////////////////////////////////////////////////
 
 // static
+EZ_FORCE_INLINE ezHashedString ezRenderData::GetCategoryName(Category category)
+{
+  if (category.m_uiValue < s_CategoryData.GetCount())
+  {
+    return s_CategoryData[category.m_uiValue].m_sName;
+  }
+
+  return ezHashedString();
+}
+
+// static
 EZ_FORCE_INLINE const ezRenderer* ezRenderData::GetCategoryRenderer(Category category, const ezRTTI* pRenderDataType)
 {
   if (s_bRendererInstancesDirty)
@@ -38,18 +49,9 @@ EZ_FORCE_INLINE const ezRenderer* ezRenderData::GetCategoryRenderer(Category cat
   return nullptr;
 }
 
-// static
-EZ_FORCE_INLINE ezHashedString ezRenderData::GetCategoryName(Category category)
-{
-  if (category.m_uiValue < s_CategoryData.GetCount())
-  {
-    return s_CategoryData[category.m_uiValue].m_sName;
-  }
+//////////////////////////////////////////////////////////////////////////
 
-  return ezHashedString();
-}
-
-EZ_FORCE_INLINE ezUInt64 ezRenderData::GetCategorySortingKey(Category category, const ezCamera& camera) const
+EZ_FORCE_INLINE ezUInt64 ezRenderData::GetFinalSortingKey(Category category, const ezCamera& camera) const
 {
   return s_CategoryData[category.m_uiValue].m_sortingKeyFunc(this, camera);
 }

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -27,6 +27,18 @@ public:
     ezUInt16 m_uiValue = 0xFFFF;
   };
 
+  /// \brief This function generates a 64bit sorting key for the given render data. Data with lower sorting key is rendered first.
+  using SortingKeyFunc = ezUInt64 (*)(const ezRenderData*, const ezCamera&);
+
+  static Category RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc);
+  static Category FindCategory(ezTempHashedString sCategoryName);
+
+  static ezHashedString GetCategoryName(Category category);
+  static void GetAllCategoryNames(ezDynamicArray<ezHashedString>& out_categoryNames);
+
+  static const ezRenderer* GetCategoryRenderer(Category category, const ezRTTI* pRenderDataType);
+
+public:
   struct Caching
   {
     enum Enum
@@ -36,24 +48,16 @@ public:
     };
   };
 
-  /// \brief This function generates a 64bit sorting key for the given render data. Data with lower sorting key is rendered first.
-  using SortingKeyFunc = ezUInt64 (*)(const ezRenderData*, const ezCamera&);
+  /// \brief Returns the final sorting for this render data with the given category and camera.
+  ezUInt64 GetFinalSortingKey(Category category, const ezCamera& camera) const;
 
-  static Category RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc);
-  static Category FindCategory(ezTempHashedString sCategoryName);
-
-  static void GetAllCategoryNames(ezDynamicArray<ezHashedString>& out_categoryNames);
-
-  static const ezRenderer* GetCategoryRenderer(Category category, const ezRTTI* pRenderDataType);
-
-  static ezHashedString GetCategoryName(Category category);
-
-  ezUInt64 GetCategorySortingKey(Category category, const ezCamera& camera) const;
+  /// \brief Returns whether this render data and the other render data can be batched together, e.g. rendered in one draw call.
+  /// An implementation can assume that the other render data is of the same type as this render data.
+  virtual bool CanBatch(const ezRenderData& other) const { return false; }
 
   ezTransform m_GlobalTransform = ezTransform::MakeIdentity();
   ezBoundingBoxSphere m_GlobalBounds;
 
-  ezUInt32 m_uiBatchId = 0; ///< BatchId is used to group render data in batches.
   ezUInt32 m_uiSortingKey = 0;
   float m_fSortingDepthOffset = 0.0f;
 

--- a/Code/Engine/RendererCore/Rasterizer/Implementation/RasterizerView.cpp
+++ b/Code/Engine/RendererCore/Rasterizer/Implementation/RasterizerView.cpp
@@ -36,7 +36,7 @@ void ezRasterizerView::BeginScene()
 {
   EZ_ASSERT_DEV(m_pRasterizer != nullptr, "Call SetResolution() first.");
 
-  EZ_PROFILE_SCOPE("Occlusion::Clear");
+  EZ_PROFILE_SCOPE("Clear");
 
   m_pRasterizer->clear();
   m_bAnyOccludersRasterized = false;
@@ -57,7 +57,7 @@ void ezRasterizerView::EndScene()
   if (m_Instances.IsEmpty())
     return;
 
-  EZ_PROFILE_SCOPE("Occlusion::RasterizeScene");
+  EZ_PROFILE_SCOPE("RasterizeScene");
 
   SortObjectsFrontToBack();
 
@@ -75,7 +75,7 @@ void ezRasterizerView::RasterizeObjects(ezUInt32 uiMaxObjects)
 {
 #if EZ_ENABLED(EZ_RASTERIZER_SUPPORTED)
 
-  EZ_PROFILE_SCOPE("Occlusion::RasterizeObjects");
+  EZ_PROFILE_SCOPE("RasterizeObjects");
 
   for (const Instance& inst : m_Instances)
   {
@@ -123,7 +123,7 @@ void ezRasterizerView::ApplyModelViewProjectionMatrix(const ezTransform& modelTr
 void ezRasterizerView::SortObjectsFrontToBack()
 {
 #if EZ_ENABLED(EZ_RASTERIZER_SUPPORTED)
-  EZ_PROFILE_SCOPE("Occlusion::SortObjects");
+  EZ_PROFILE_SCOPE("SortObjects");
 
   const ezVec3 camPos = m_pCamera->GetCenterPosition();
 
@@ -141,8 +141,6 @@ bool ezRasterizerView::IsVisible(const ezSimdBBox& aabb) const
 #if EZ_ENABLED(EZ_RASTERIZER_SUPPORTED)
   if (!m_bAnyOccludersRasterized)
     return true; // assume that people already do frustum culling anyway
-
-  EZ_PROFILE_SCOPE("Occlusion::IsVisible");
 
   ezSimdVec4f vmin = aabb.m_Min;
   ezSimdVec4f vmax = aabb.m_Max;

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
@@ -105,7 +105,7 @@ namespace
     return false;
   }
 
-  static ezHashTable<ezUInt64, ezString> s_PermutationPaths;
+  static ezHashTable<ezUInt64, ezUntrackedString> s_PermutationPaths;
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -330,8 +330,8 @@ ezShaderPermutationResourceHandle ezShaderManager::PreloadSinglePermutationInter
 {
   const ezUInt64 uiPermutationKey = (ezUInt64)ezHashingUtils::StringHashTo32(uiResourceIdHash) << 32 | uiPermutationHash;
 
-  ezString* pPermutationPath = &s_PermutationPaths[uiPermutationKey];
-  if (pPermutationPath->IsEmpty())
+  ezUntrackedString& permutationPath = s_PermutationPaths[uiPermutationKey];
+  if (permutationPath.IsEmpty())
   {
     ezStringBuilder sShaderFile = GetCacheDirectory();
     sShaderFile.AppendPath(GetActivePlatform().GetData());
@@ -341,10 +341,10 @@ ezShaderPermutationResourceHandle ezShaderManager::PreloadSinglePermutationInter
       sShaderFile.Shrink(0, 1);
     sShaderFile.AppendFormat("_{0}.ezPermutation", ezArgU(uiPermutationHash, 8, true, 16, true));
 
-    *pPermutationPath = sShaderFile;
+    permutationPath = sShaderFile;
   }
 
-  ezShaderPermutationResourceHandle hShaderPermutation = ezResourceManager::LoadResource<ezShaderPermutationResource>(pPermutationPath->GetData());
+  ezShaderPermutationResourceHandle hShaderPermutation = ezResourceManager::LoadResource<ezShaderPermutationResource>(permutationPath);
 
   {
     ezResourceLock<ezShaderPermutationResource> pShaderPermutation(hShaderPermutation, ezResourceAcquireMode::PointerOnly);

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -263,8 +263,7 @@ void ezClothSheetComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
   pRenderData->m_Color = m_Color;
   pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform();
-  pRenderData->m_uiBatchId = ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash());
-  pRenderData->m_uiSortingKey = pRenderData->m_uiBatchId;
+  pRenderData->m_uiSortingKey = ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash());
   pRenderData->m_GlobalBounds = GetOwner()->GetGlobalBounds();
   pRenderData->m_hMaterial = m_hMaterial;
 
@@ -332,7 +331,6 @@ void ezClothSheetComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
     }
   }
 
-  // TODO: render pass category (plus cache this)
   ezRenderData::Category category = ezDefaultRenderDataCategories::LitOpaque;
 
   if (m_hMaterial.IsValid())
@@ -431,6 +429,8 @@ void ezClothSheetComponent::Update()
     }
   }
 }
+
+////////////////////////////////////////////////////////////////////////
 
 ezClothSheetRenderer::ezClothSheetRenderer()
 {

--- a/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Terrain/Implementation/HeightfieldComponent.cpp
@@ -162,7 +162,7 @@ void ezHeightfieldComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg)
 
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     bool bDontCacheYet = false;

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltClothSheetComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltClothSheetComponent.cpp
@@ -410,8 +410,7 @@ void ezJoltClothSheetComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& m
   pRenderData->m_uiUniqueID = GetUniqueIdForRendering();
   pRenderData->m_Color = m_Color;
   pRenderData->m_GlobalTransform = GetOwner()->GetGlobalTransform();
-  pRenderData->m_uiBatchId = ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash());
-  pRenderData->m_uiSortingKey = pRenderData->m_uiBatchId;
+  pRenderData->m_uiSortingKey = ezHashingUtils::StringHashTo32(m_hMaterial.GetResourceIDHash());
   pRenderData->m_GlobalBounds = GetOwner()->GetGlobalBounds();
   pRenderData->m_hMaterial = m_hMaterial;
   pRenderData->m_vTextureScale = m_vTextureScale;

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
@@ -174,7 +174,7 @@ void ezJoltVisColMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& m
       pRenderData->m_uiSubMeshIndex = uiPartIndex;
       pRenderData->m_uiUniqueID = GetUniqueIdForRendering(uiMaterialIndex);
 
-      pRenderData->FillBatchIdAndSortingKey();
+      pRenderData->FillSortingKey();
     }
 
     msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::LitOpaque, caching);

--- a/Code/EnginePlugins/KrautPlugin/Renderer/KrautRenderData.h
+++ b/Code/EnginePlugins/KrautPlugin/Renderer/KrautRenderData.h
@@ -13,6 +13,8 @@ class EZ_KRAUTPLUGIN_DLL ezKrautRenderData : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezKrautRenderData, ezRenderData);
 
 public:
+  virtual bool CanBatch(const ezRenderData& other) const override;
+
   ezMeshResourceHandle m_hMesh;
   ezUInt32 m_uiUniqueID = 0;
   float m_fLodDistanceMinSQR;

--- a/Code/EnginePlugins/KrautPlugin/Renderer/KrautRenderer.cpp
+++ b/Code/EnginePlugins/KrautPlugin/Renderer/KrautRenderer.cpp
@@ -22,6 +22,15 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezKrautRenderer, 1, ezRTTIDefaultAllocator<ezKra
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
+bool ezKrautRenderData::CanBatch(const ezRenderData& other0) const
+{
+  const auto& other = ezStaticCast<const ezKrautRenderData&>(other0);
+
+  return m_hMesh == other.m_hMesh && m_uiSubMeshIndex == other.m_uiSubMeshIndex;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
 ezKrautRenderer::ezKrautRenderer() = default;
 ezKrautRenderer::~ezKrautRenderer() = default;
 

--- a/Code/EnginePlugins/ParticlePlugin/ParticlePluginPCH.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/ParticlePluginPCH.cpp
@@ -12,8 +12,6 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezParticleTypeRenderMode, 1)
   EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::Opaque),
   EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::Additive),
   EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::Blended),
-  EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::BlendedForeground),
-  EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::BlendedBackground),
   EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::Distortion),
   EZ_ENUM_CONSTANT(ezParticleTypeRenderMode::BlendAdd),
 EZ_END_STATIC_REFLECTED_ENUM;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.cpp
@@ -208,7 +208,7 @@ void ezParticleTypeMesh::ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, 
         pRenderData->m_uiSubMeshIndex = 0;
         pRenderData->m_uiUniqueID = 0xFFFFFFFF;
 
-        pRenderData->FillBatchIdAndSortingKey();
+        pRenderData->FillSortingKey();
       }
 
       ref_msg.AddRenderData(pRenderData, m_RenderCategory, ezRenderData::Caching::Never);

--- a/Code/EnginePlugins/ParticlePlugin/Type/ParticleType.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/ParticleType.cpp
@@ -31,7 +31,7 @@ ezParticleType::ezParticleType()
   m_fPriority = +1000.0f;
 }
 
-ezUInt32 ezParticleType::ComputeSortingKey(ezParticleTypeRenderMode::Enum mode, ezUInt32 uiTextureHash)
+ezUInt32 ezParticleType::ComputeSortingKey(ezParticleTypeRenderMode::Enum mode, ezUInt64 uiTextureHash)
 {
   ezUInt32 key = 0;
 
@@ -69,7 +69,7 @@ ezUInt32 ezParticleType::ComputeSortingKey(ezParticleTypeRenderMode::Enum mode, 
   }
 
   key <<= 32 - 3; // require 3 bits for the values above
-  key |= uiTextureHash & 0x1FFFFFFFu;
+  key |= ezHashingUtils::StringHashTo32(uiTextureHash) & 0x1FFFFFFFu;
 
   return key;
 }

--- a/Code/EnginePlugins/ParticlePlugin/Type/ParticleType.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/ParticleType.h
@@ -51,7 +51,7 @@ protected:
   virtual void InitializeElements(ezUInt64 uiStartIndex, ezUInt64 uiNumElements) override {}
   virtual void StepParticleSystem(const ezTime& tDiff, ezUInt32 uiNumNewParticles) { m_TimeDiff = tDiff; }
 
-  static ezUInt32 ComputeSortingKey(ezParticleTypeRenderMode::Enum mode, ezUInt32 uiTextureHash);
+  static ezUInt32 ComputeSortingKey(ezParticleTypeRenderMode::Enum mode, ezUInt64 uiTextureHash);
 
   ezTime m_TimeDiff;
   mutable ezUInt64 m_uiLastExtractedFrame;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
@@ -215,8 +215,6 @@ struct sodComparer
 
 void ezParticleTypeQuad::ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& instanceTransform) const
 {
-  EZ_PROFILE_SCOPE("PFX: Quad");
-
   const ezUInt32 numParticles = (ezUInt32)GetOwnerSystem()->GetNumActiveParticles();
   if (!m_hTexture.IsValid() || numParticles == 0)
     return;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.cpp
@@ -432,8 +432,7 @@ void ezParticleTypeQuad::AddParticleRenderData(ezMsgExtractRenderData& msg, cons
 {
   auto pRenderData = ezCreateRenderDataForThisFrame<ezParticleQuadRenderData>(nullptr);
 
-  pRenderData->m_uiBatchId = ezHashingUtils::StringHashTo32(m_hTexture.GetResourceIDHash());
-  pRenderData->m_uiSortingKey = ComputeSortingKey(m_RenderMode, pRenderData->m_uiBatchId);
+  pRenderData->m_uiSortingKey = ComputeSortingKey(m_RenderMode, m_hTexture.GetResourceIDHash());
 
   pRenderData->m_bApplyObjectTransform = GetOwnerEffect()->NeedsToApplyTransform();
   pRenderData->m_GlobalTransform = instanceTransform;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.cpp
@@ -13,6 +13,15 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleQuadRenderer, 1, ezRTTIDefaultAllocato
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
+bool ezParticleQuadRenderData::CanBatch(const ezRenderData& other0) const
+{
+  const auto& other = ezStaticCast<const ezParticleQuadRenderData&>(other0);
+
+  return m_RenderMode == other.m_RenderMode && m_hTexture == other.m_hTexture;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
 ezParticleQuadRenderer::ezParticleQuadRenderer()
 {
   CreateParticleDataBuffer(m_BaseDataBuffer, sizeof(ezBaseParticleShaderData), s_uiParticlesPerBatch);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.h
@@ -14,6 +14,8 @@ class EZ_PARTICLEPLUGIN_DLL ezParticleQuadRenderData final : public ezRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleQuadRenderData, ezRenderData);
 
 public:
+  virtual bool CanBatch(const ezRenderData& other) const override;
+
   ezEnum<ezParticleTypeRenderMode> m_RenderMode;
   ezTexture2DResourceHandle m_hTexture;
   ezArrayPtr<ezBaseParticleShaderData> m_BaseParticleData;

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.cpp
@@ -265,8 +265,7 @@ void ezParticleTypeTrail::ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg,
 
   auto pRenderData = ezCreateRenderDataForThisFrame<ezParticleTrailRenderData>(nullptr);
 
-  pRenderData->m_uiBatchId = ezHashingUtils::StringHashTo32(m_hTexture.GetResourceIDHash()) + m_uiMaxPoints;
-  pRenderData->m_uiSortingKey = ComputeSortingKey(m_RenderMode, pRenderData->m_uiBatchId);
+  pRenderData->m_uiSortingKey = ComputeSortingKey(m_RenderMode, m_hTexture.GetResourceIDHash());
 
   pRenderData->m_bApplyObjectTransform = GetOwnerEffect()->NeedsToApplyTransform();
   pRenderData->m_TotalEffectLifeTime = GetOwnerEffect()->GetTotalEffectLifeTime();

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.cpp
@@ -18,6 +18,15 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleTrailRenderer, 1, ezRTTIDefaultAllocat
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
+bool ezParticleTrailRenderData::CanBatch(const ezRenderData& other0) const
+{
+  const auto& other = ezStaticCast<const ezParticleTrailRenderData&>(other0);
+
+  return m_RenderMode == other.m_RenderMode && m_hTexture == other.m_hTexture && m_uiMaxTrailPoints == other.m_uiMaxTrailPoints;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
 ezParticleTrailRenderer::ezParticleTrailRenderer()
 {
   CreateParticleDataBuffer(m_BaseDataBuffer, sizeof(ezBaseParticleShaderData), s_uiParticlesPerBatch);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.h
@@ -14,6 +14,8 @@ class EZ_PARTICLEPLUGIN_DLL ezParticleTrailRenderData final : public ezRenderDat
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTrailRenderData, ezRenderData);
 
 public:
+  virtual bool CanBatch(const ezRenderData& other) const override;
+
   ezTexture2DResourceHandle m_hTexture;
   ezUInt16 m_uiMaxTrailPoints;
   float m_fSnapshotFraction;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -17,11 +17,6 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcVertexColorRenderData, 1, ezRTTIDefaultAll
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-void ezProcVertexColorRenderData::FillBatchIdAndSortingKey()
-{
-  FillBatchIdAndSortingKeyInternal(m_hVertexColorBuffer.GetInternalID().m_Data);
-}
-
 //////////////////////////////////////////////////////////////////////////
 
 using namespace ezProcGenInternal;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVertexColorComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVertexColorComponent.h
@@ -10,8 +10,6 @@ class EZ_PROCGENPLUGIN_DLL ezProcVertexColorRenderData : public ezMeshRenderData
   EZ_ADD_DYNAMIC_REFLECTION(ezProcVertexColorRenderData, ezMeshRenderData);
 
 public:
-  virtual void FillBatchIdAndSortingKey() override;
-
   ezGALDynamicBufferHandle m_hVertexColorBuffer;
   ezUInt32 m_uiBufferAccessData = 0;
 };


### PR DESCRIPTION
* The batch id has been removed from render data. It was weird to work with and had no checks for potential collisions. A new virtual CanBatch method has been added to render data which can just do good old comparisons of all relevant members to determine whether two render data can be batched together.
* Optimized clustered data extraction. The bounding spheres around the cluster cells are now in viewspace and don't need to be recomputed every frame. Cluster bitmasks are directly cleared after use so the expensive zerofill calls could be removed.
* Cleaned up some profiling scopes and other smaller optimizations.