### PR TITLE
Darken inactive game objects in the scene graph

### DIFF
--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectModel.cpp
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectModel.cpp
@@ -125,15 +125,24 @@ QVariant ezQtGameObjectAdapter::data(const ezDocumentObject* pObject, int iRow, 
       const bool bPrefab = pMeta->m_CreateFromPrefab.IsValid();
       m_pObjectMetaData->EndReadMetaData();
 
+      bool bActive = pObject->GetTypeAccessor().GetValue("Active").ConvertTo<bool>();
+
+      const QPalette palette = QApplication::palette();
+      const QColor qtDefaultColor = palette.color(QPalette::Text);
+
+      ezColor color = qtToEzColor(qtDefaultColor);
+
       if (bPrefab)
       {
-        return ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Blue));
+        color = ezColorScheme::LightUI(ezColorScheme::Blue);
       }
 
-      if (sName.IsEmpty())
+      if (!bActive)
       {
-        return QVariant();
+        return ezToQtColor(color.GetDarker(1.85f));
       }
+
+      return ezToQtColor(color);
     }
     break;
 


### PR DESCRIPTION
- if the object is not marked as "Active", its label in the scene graph gets darker

It can be useful in the large scenes, if a user prefers to activate/deactivate some of the objects for testing/prototyping/performance reason

The result: 
![image](https://github.com/user-attachments/assets/02e70d9e-662e-4601-aed5-59428e0c866a)
