### PR TITLE
Tesselation and recreate engine view fix

### DIFF
--- a/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
+++ b/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
@@ -129,6 +129,7 @@ protected:
 protected:
   void EngineViewProcessEventHandler(const ezEditorEngineProcessConnection::Event& e);
   void ShowRestartButton(bool bShow);
+  void RecreateEngineViewport();
   virtual void OnOpenContextMenu(QPoint globalPos) {}
   virtual void HandleMarqueePickingResult(const ezViewMarqueePickingResultMsgToEditor* pMsg) {}
 
@@ -140,7 +141,7 @@ protected:
   bool m_bPickTransparent = true;
   bool m_bInDragAndDropOperation;
   ezUInt32 m_uiViewID;
-  ezQtEngineDocumentWindow* m_pDocumentWindow;
+  ezQtEngineDocumentWindow* m_pDocumentWindow = nullptr;
 
   static ezUInt32 s_uiNextViewID;
 
@@ -155,8 +156,9 @@ protected:
   ezVec3 m_vCameraUp;
   ezTime m_LastCameraUpdate;
 
-  QHBoxLayout* m_pRestartButtonLayout;
-  QPushButton* m_pRestartButton;
+  QHBoxLayout* m_pMainLayout = nullptr;
+  QPushButton* m_pRestartButton = nullptr;
+  QWidget* m_pViewportWidget = nullptr;
 
   mutable ezObjectPickingResult m_LastPickingResult;
 

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -34,20 +34,11 @@ ezQtEngineViewWidget::ezQtEngineViewWidget(QWidget* pParent, ezQtEngineDocumentW
   , m_pDocumentWindow(pDocumentWindow)
   , m_pViewConfig(pViewConfig)
 {
-  m_pRestartButtonLayout = nullptr;
-  m_pRestartButton = nullptr;
+  m_pMainLayout = new QHBoxLayout(this);
+  m_pMainLayout->setContentsMargins(0, 0, 0, 0);
+  setLayout(m_pMainLayout);
 
-  setFocusPolicy(Qt::FocusPolicy::StrongFocus);
-  // setAttribute(Qt::WA_OpaquePaintEvent);
-  setAutoFillBackground(false);
-  setMouseTracking(true);
-  setMinimumSize(64, 64); // prevent the window from becoming zero sized, otherwise the rendering code may crash
-
-  setAttribute(Qt::WA_PaintOnScreen, true);
-  setAttribute(Qt::WA_NativeWindow, true);
-  setAttribute(Qt::WA_NoSystemBackground);
-
-  installEventFilter(this);
+  RecreateEngineViewport();
 
   m_bUpdatePickingData = false;
   m_bInDragAndDropOperation = false;
@@ -119,7 +110,7 @@ void ezQtEngineViewWidget::SyncToEngine()
   cam.m_ViewMatrix = m_pViewConfig->m_Camera.GetViewMatrix();
   m_pViewConfig->m_Camera.GetProjectionMatrix((float)width() / (float)height(), cam.m_ProjMatrix);
 
-  cam.m_uiHWND = (ezUInt64)(winId());
+  cam.m_uiHWND = (ezUInt64)(m_pViewportWidget->winId());
   cam.m_uiWindowWidth = width() * this->devicePixelRatio();
   cam.m_uiWindowHeight = height() * this->devicePixelRatio();
   cam.m_bUpdatePickingData = m_bUpdatePickingData;
@@ -628,6 +619,7 @@ void ezQtEngineViewWidget::EngineViewProcessEventHandler(const ezEditorEnginePro
 
     case ezEditorEngineProcessConnection::Event::Type::ProcessStarted:
     {
+      RecreateEngineViewport();
       ShowRestartButton(false);
     }
     break;
@@ -651,20 +643,15 @@ void ezQtEngineViewWidget::ShowRestartButton(bool bShow)
 {
   ezQtScopedUpdatesDisabled _(this);
 
-  if (m_pRestartButtonLayout == nullptr && bShow == true)
+  if (m_pRestartButton == nullptr && bShow == true)
   {
-    m_pRestartButtonLayout = new QHBoxLayout(this);
-    m_pRestartButtonLayout->setContentsMargins(0, 0, 0, 0);
-
-    setLayout(m_pRestartButtonLayout);
-
     m_pRestartButton = new QPushButton(this);
     m_pRestartButton->setText("Restart Engine View Process");
     m_pRestartButton->setVisible(ezEditorEngineProcessConnection::GetSingleton()->IsProcessCrashed());
     m_pRestartButton->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
     m_pRestartButton->connect(m_pRestartButton, &QPushButton::clicked, this, &ezQtEngineViewWidget::SlotRestartEngineProcess);
 
-    m_pRestartButtonLayout->addWidget(m_pRestartButton);
+    m_pMainLayout->addWidget(m_pRestartButton);
   }
 
   if (m_pRestartButton)
@@ -674,6 +661,32 @@ void ezQtEngineViewWidget::ShowRestartButton(bool bShow)
     if (bShow)
       m_pRestartButton->update();
   }
+
+  m_pViewportWidget->setVisible(!bShow);
+}
+
+void ezQtEngineViewWidget::RecreateEngineViewport()
+{
+  if (m_pViewportWidget)
+  {
+    m_pViewportWidget->hide();
+    m_pViewportWidget->setParent(nullptr);
+    m_pViewportWidget->deleteLater();
+  }
+
+  m_pViewportWidget = new QWidget(this);
+  m_pMainLayout->addWidget(m_pViewportWidget);
+  m_pViewportWidget->setFocusPolicy(Qt::FocusPolicy::StrongFocus);
+  // setAttribute(Qt::WA_OpaquePaintEvent);
+  m_pViewportWidget->setAutoFillBackground(false);
+  m_pViewportWidget->setMouseTracking(true);
+  m_pViewportWidget->setMinimumSize(64, 64); // prevent the window from becoming zero sized, otherwise the rendering code may crash
+
+  m_pViewportWidget->setAttribute(Qt::WA_PaintOnScreen, true);
+  m_pViewportWidget->setAttribute(Qt::WA_NativeWindow, true);
+  m_pViewportWidget->setAttribute(Qt::WA_NoSystemBackground);
+
+  m_pViewportWidget->installEventFilter(this);
 }
 
 

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -75,7 +75,7 @@ void ezGALCommandEncoderImplDX11::SetShaderPlatform(const ezGALShader* pShader)
   {
     m_pDXContext->HSSetShader(pHS, nullptr, 0);
     m_pBoundShaders[ezGALShaderStage::HullShader] = pHS;
-    if (pShader)
+    if (pHS)
     {
       m_uiTessellationPatchControlPoints = pShader->GetDescription().m_ByteCodes[ezGALShaderStage::HullShader]->m_uiTessellationPatchControlPoints;
     }

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -359,7 +359,7 @@ ezResult ezGALSwapChainVulkan::CreateSwapChainInternal()
   swapChainCreateInfo.oldSwapchain = m_vulkanSwapChain;
   DestroySwapChainInternal(m_pVulkanDevice);
 
-  m_vulkanSwapChain = m_pVulkanDevice->GetVulkanDevice().createSwapchainKHR(swapChainCreateInfo);
+  VK_SUCCEED_OR_RETURN_EZ_FAILURE(m_pVulkanDevice->GetVulkanDevice().createSwapchainKHR(&swapChainCreateInfo, nullptr, &m_vulkanSwapChain));
 
   if (!m_vulkanSwapChain)
   {

--- a/Data/Base/Shaders/Materials/MaterialInterpolator.h
+++ b/Data/Base/Shaders/Materials/MaterialInterpolator.h
@@ -52,7 +52,7 @@ struct VS_IN
   uint VertexID : SV_VertexID;
 };
 
-#if defined(VERTEX_SHADER)
+#if defined(VERTEX_SHADER) || defined(HULL_SHADER) || defined(DOMAIN_SHADER)
 #  if defined(CAMERA_MODE)
 #    if CAMERA_MODE == CAMERA_MODE_STEREO
 #      if VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX == TRUE


### PR DESCRIPTION
* Fix crash when switching between tesselated and non-tesselated rendering.
* Allow tesselation to work with material interpolator code.
* Don't throw in swapchain creation.
* Re-create widgets used as window surface for the engine as latest AMD drivers leak the Vulkan surface on an engine crash, making the native surface unusable as it will throw `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`.