### PR TITLE
Moved render data filtering to extraction phase

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h>
 #include <RendererCore/Lights/ClusteredDataProvider.h>
+#include <RendererCore/Pipeline/SortingFunctions.h>
 #include <RendererCore/Pipeline/View.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/Textures/TextureUtils.h>
@@ -28,6 +29,11 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPickingRenderPass, 1, ezRTTIDefaultAllocator<e
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
+
+static ezRenderData::Category s_LitOpaqueWithoutSelection = ezRenderData::RegisterDerivedCategory("LitOpaqueWithoutSelection", ezDefaultRenderDataCategories::LitOpaque);
+static ezRenderData::Category s_LitMaskedWithoutSelection = ezRenderData::RegisterDerivedCategory("LitMaskedWithoutSelection", ezDefaultRenderDataCategories::LitMasked);
+static ezRenderData::Category s_LitTransparentWithoutSelection = ezRenderData::RegisterDerivedCategory("LitTransparentWithoutSelection", ezDefaultRenderDataCategories::LitTransparent);
+static ezRenderData::Category s_SimpleTransparentWithoutSelection = ezRenderData::RegisterDerivedCategory("SimpleTransparentWithoutSelection", ezDefaultRenderDataCategories::SimpleTransparent);
 
 ezPickingRenderPass::ezPickingRenderPass()
   : ezRenderPipelinePass("EditorPickingRenderPass")
@@ -62,6 +68,11 @@ void ezPickingRenderPass::InitRenderPipelinePass(const ezArrayPtr<ezRenderPipeli
 {
   DestroyTarget();
   CreateTarget();
+
+  if (m_uiProcessorId == ezInvalidIndex)
+  {
+    m_uiProcessorId = GetPipeline()->AddRenderDataProcessor(ezMakeDelegate(&ezPickingRenderPass::ProcessPickingRenderData, this));
+  }
 }
 
 void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, const ezArrayPtr<ezRenderPipelinePassConnection* const> inputs, const ezArrayPtr<ezRenderPipelinePassConnection* const> outputs)
@@ -93,30 +104,12 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
     auto pClusteredData = GetPipeline()->GetFrameDataProvider<ezClusteredDataProvider>()->GetData(renderViewContext);
     pClusteredData->BindResources(renderViewContext.m_pRenderContext);
 
-    // copy selection to set for faster checks
-    m_SelectionSet.Clear();
-
-    auto batchList = GetPipeline()->GetRenderDataBatchesWithCategory(ezDefaultRenderDataCategories::Selection);
-    const ezUInt32 uiBatchCount = batchList.GetBatchCount();
-    for (ezUInt32 i = 0; i < uiBatchCount; ++i)
-    {
-      const ezRenderDataBatch& batch = batchList.GetBatch(i);
-      for (auto it = batch.GetIterator<ezRenderData>(); it.IsValid(); ++it)
-      {
-        m_SelectionSet.Insert(it->m_hOwner);
-      }
-    }
-
-    // filter out all selected objects
-    ezRenderDataBatch::Filter filter([&](const ezRenderData* pRenderData)
-      { return m_SelectionSet.Contains(pRenderData->m_hOwner) || pRenderData->IsInstanceOf(m_pGridRenderDataType); });
-
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaque, filter);
-    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMasked, filter);
+    RenderDataWithCategory(renderViewContext, s_LitOpaqueWithoutSelection);
+    RenderDataWithCategory(renderViewContext, s_LitMaskedWithoutSelection);
 
     if (m_bPickTransparent)
     {
-      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitTransparent, filter);
+      RenderDataWithCategory(renderViewContext, s_LitTransparentWithoutSelection);
 
       renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "TRUE");
       RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitForeground);
@@ -134,7 +127,7 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
 
     if (m_bPickTransparent)
     {
-      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::SimpleTransparent, filter);
+      RenderDataWithCategory(renderViewContext, s_SimpleTransparentWithoutSelection);
     }
 
     renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PREPARE_DEPTH", "TRUE");
@@ -401,4 +394,39 @@ void ezPickingRenderPass::ReadBackPropertiesMarqueePick(ezView* pView)
   }
 
   pView->SetRenderPassReadBackProperty(GetName(), "MarqueeResult", resArray);
+}
+
+void ezPickingRenderPass::ProcessPickingRenderData(ezExtractedRenderData& extractedRenderData)
+{
+  // copy selection to set for faster checks
+  m_SelectionSet.Clear();
+  {
+    auto renderDataList = extractedRenderData.GetRawRenderDataWithCategory(ezDefaultRenderDataCategories::Selection);
+    for (auto& sortableRenderData : renderDataList)
+    {
+      m_SelectionSet.Insert(sortableRenderData.m_pRenderData->m_hOwner);
+    }
+  }
+
+  auto Filter = [&](ezRenderData::Category originalCategory, ezRenderData::Category filteredCategory)
+  {
+    auto renderDataList = extractedRenderData.GetRawRenderDataWithCategory(originalCategory);
+    for (auto& sortableRenderData : renderDataList)
+    {
+      auto pRenderData = sortableRenderData.m_pRenderData;
+      if (m_SelectionSet.Contains(pRenderData->m_hOwner) || pRenderData->IsInstanceOf(m_pGridRenderDataType))
+        continue;
+
+      extractedRenderData.AddRenderData(pRenderData, filteredCategory);
+    }
+  };
+
+  Filter(ezDefaultRenderDataCategories::LitOpaque, s_LitOpaqueWithoutSelection);
+  Filter(ezDefaultRenderDataCategories::LitMasked, s_LitMaskedWithoutSelection);
+
+  if (m_bPickTransparent)
+  {
+    Filter(ezDefaultRenderDataCategories::LitTransparent, s_LitTransparentWithoutSelection);
+    Filter(ezDefaultRenderDataCategories::SimpleTransparent, s_SimpleTransparentWithoutSelection);
+  }
 }

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -30,8 +30,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPickingRenderPass, 1, ezRTTIDefaultAllocator<e
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
-static ezRenderData::Category s_LitOpaqueWithoutSelection = ezRenderData::RegisterDerivedCategory("LitOpaqueWithoutSelection", ezDefaultRenderDataCategories::LitOpaque);
-static ezRenderData::Category s_LitMaskedWithoutSelection = ezRenderData::RegisterDerivedCategory("LitMaskedWithoutSelection", ezDefaultRenderDataCategories::LitMasked);
+static ezRenderData::Category s_LitOpaqueWithoutSelection = ezRenderData::RegisterDerivedCategory("LitOpaqueWithoutSelection", ezDefaultRenderDataCategories::LitOpaqueStatic);
+static ezRenderData::Category s_LitMaskedWithoutSelection = ezRenderData::RegisterDerivedCategory("LitMaskedWithoutSelection", ezDefaultRenderDataCategories::LitMaskedStatic);
+static ezRenderData::Category s_LitMaskedDynamicWithoutSelection = ezRenderData::RegisterDerivedCategory("LitMaskedDynamicWithoutSelection", ezDefaultRenderDataCategories::LitMaskedDynamic);
+
 static ezRenderData::Category s_LitTransparentWithoutSelection = ezRenderData::RegisterDerivedCategory("LitTransparentWithoutSelection", ezDefaultRenderDataCategories::LitTransparent);
 static ezRenderData::Category s_SimpleTransparentWithoutSelection = ezRenderData::RegisterDerivedCategory("SimpleTransparentWithoutSelection", ezDefaultRenderDataCategories::SimpleTransparent);
 
@@ -421,8 +423,11 @@ void ezPickingRenderPass::ProcessPickingRenderData(ezExtractedRenderData& extrac
     }
   };
 
-  Filter(ezDefaultRenderDataCategories::LitOpaque, s_LitOpaqueWithoutSelection);
-  Filter(ezDefaultRenderDataCategories::LitMasked, s_LitMaskedWithoutSelection);
+  Filter(ezDefaultRenderDataCategories::LitOpaqueStatic, s_LitOpaqueWithoutSelection);
+  Filter(ezDefaultRenderDataCategories::LitOpaqueDynamic, s_LitOpaqueWithoutSelection);
+
+  Filter(ezDefaultRenderDataCategories::LitMaskedStatic, s_LitMaskedWithoutSelection);
+  Filter(ezDefaultRenderDataCategories::LitMaskedDynamic, s_LitOpaqueWithoutSelection);
 
   if (m_bPickTransparent)
   {

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
@@ -44,6 +44,8 @@ private:
   void ReadBackPropertiesSinglePick(ezView* pView);
   void ReadBackPropertiesMarqueePick(ezView* pView);
 
+  void ProcessPickingRenderData(ezExtractedRenderData& extractedRenderData);
+
 private:
   ezRectFloat m_TargetRect;
   const ezRTTI* m_pGridRenderDataType = nullptr;
@@ -75,4 +77,6 @@ private:
   ezDynamicArray<float> m_PickingResultsDepth;
   /// Stores the 32 Bit picking ID values of each pixel. This can lead back to the ezComponent, etc. that rendered to that pixel
   ezDynamicArray<ezUInt32> m_PickingResultsID;
+
+  ezUInt32 m_uiProcessorId = ezInvalidIndex;
 };

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -114,7 +114,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenOutput, 1, ezRTTINoAllocator)
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Active", m_bActive)->AddAttributes(new ezDefaultValueAttribute(true)),
-    EZ_MEMBER_PROPERTY("Name", m_sName),
+    EZ_MEMBER_PROPERTY("Name", m_sName)->AddAttributes(new ezDynamicStringEnumAttribute("ProcGenOutputNameEnum")),
   }
   EZ_END_PROPERTIES;
 

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -715,8 +715,7 @@ void ezSubstancePackageAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInf
 
 ezTransformStatus ezSubstancePackageAssetDocument::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& assetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
-  ezSubstancePackageAssetProperties* pProp = GetProperties();
-  ezStringBuilder sAbsolutePackagePath = pProp->m_sSubstancePackage;
+  ezStringBuilder sAbsolutePackagePath = GetProperties()->m_sSubstancePackage;
   if (!ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sAbsolutePackagePath))
   {
     return ezStatus(ezFmt("Couldn't make path absolute: '{0};", sAbsolutePackagePath));
@@ -761,7 +760,7 @@ ezTransformStatus ezSubstancePackageAssetDocument::InternalTransformAsset(const 
 
   ezHybridArray<ezString, 8> pngPaths;
 
-  for (auto& graph : pProp->m_Graphs)
+  for (auto& graph : GetProperties()->m_Graphs)
   {
     if (graph.m_bEnabled == false)
       continue;

--- a/Code/Engine/RendererCore/Pipeline/ExtractedRenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/ExtractedRenderData.h
@@ -36,8 +36,9 @@ public:
 
   void Clear();
 
-  ezRenderDataBatchList GetRenderDataBatchesWithCategory(
-    ezRenderData::Category category, ezRenderDataBatch::Filter filter = ezRenderDataBatch::Filter()) const;
+  ezRenderDataBatchList GetRenderDataBatchesWithCategory(ezRenderData::Category category) const;
+
+  ezArrayPtr<const ezRenderDataBatch::SortableRenderData> GetRawRenderDataWithCategory(ezRenderData::Category category) const;
 
   template <typename T>
   EZ_ALWAYS_INLINE const T* GetFrameData() const
@@ -62,6 +63,6 @@ private:
   ezDebugRendererContext m_WorldDebugContext;
   ezDebugRendererContext m_ViewDebugContext;
 
-  ezHybridArray<DataPerCategory, 16> m_DataPerCategory;
+  ezHybridArray<DataPerCategory, 32> m_DataPerCategory;
   ezHybridArray<const ezRenderData*, 16> m_FrameData;
 };

--- a/Code/Engine/RendererCore/Pipeline/Implementation/ExtractedRenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/ExtractedRenderData.cpp
@@ -80,18 +80,27 @@ void ezExtractedRenderData::Clear()
   m_FrameData.Clear();
 }
 
-ezRenderDataBatchList ezExtractedRenderData::GetRenderDataBatchesWithCategory(ezRenderData::Category category, ezRenderDataBatch::Filter filter) const
+ezRenderDataBatchList ezExtractedRenderData::GetRenderDataBatchesWithCategory(ezRenderData::Category category) const
 {
   if (category.m_uiValue < m_DataPerCategory.GetCount())
   {
     ezRenderDataBatchList list;
     list.m_Batches = m_DataPerCategory[category.m_uiValue].m_Batches;
-    list.m_Filter = filter;
 
     return list;
   }
 
   return ezRenderDataBatchList();
+}
+
+ezArrayPtr<const ezRenderDataBatch::SortableRenderData> ezExtractedRenderData::GetRawRenderDataWithCategory(ezRenderData::Category category) const
+{
+  if (category.m_uiValue < m_DataPerCategory.GetCount())
+  {
+    return m_DataPerCategory[category.m_uiValue].m_SortableRenderData;
+  }
+
+  return {};
 }
 
 const ezRenderData* ezExtractedRenderData::GetFrameData(const ezRTTI* pRtti) const

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -156,7 +156,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
     {
       for (auto& data : msg.m_ExtractedRenderData)
       {
-        extractedRenderData.AddRenderData(data.m_pRenderData, ezRenderData::Category(data.m_uiCategory));
+        extractedRenderData.AddRenderData(data.m_pRenderData, data.m_Category);
       }
     }
 
@@ -226,7 +226,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
           {
             auto& newCacheEntry = newCacheEntries.ExpandAndGetRef();
             newCacheEntry.m_pRenderData = msg.m_ExtractedRenderData[uiPartIndex].m_pRenderData;
-            newCacheEntry.m_uiCategory = msg.m_ExtractedRenderData[uiPartIndex].m_uiCategory;
+            newCacheEntry.m_uiCategory = msg.m_ExtractedRenderData[uiPartIndex].m_Category.m_uiValue;
             newCacheEntry.m_uiComponentIndex = static_cast<ezUInt16>(uiComponentIndex);
             newCacheEntry.m_uiPartIndex = static_cast<ezUInt16>(uiPartIndex);
           }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
@@ -11,11 +11,13 @@
 #include <Foundation/IO/TypeVersionContext.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDepthOnlyPass, 2, ezRTTIDefaultAllocator<ezDepthOnlyPass>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezDepthOnlyPass, 3, ezRTTIDefaultAllocator<ezDepthOnlyPass>)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("DepthStencil", m_PinDepthStencil),
+    EZ_MEMBER_PROPERTY("RenderStaticObjects", m_bRenderStaticObjects),
+    EZ_MEMBER_PROPERTY("RenderDynamicObjects", m_bRenderDynamicObjects),
     EZ_MEMBER_PROPERTY("RenderTransparentObjects", m_bRenderTransparentObjects),
   }
   EZ_END_PROPERTIES;
@@ -69,10 +71,27 @@ void ezDepthOnlyPass::Execute(const ezRenderViewContext& renderViewContext, cons
   renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_DEPTH_ONLY");
   renderViewContext.m_pRenderContext->SetShaderPermutationVariable("SHADING_QUALITY", "SHADING_QUALITY_NORMAL");
 
-  // Render
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaque);
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMasked);
+  // Opaque
+  if (m_bRenderStaticObjects)
+  {
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaqueStatic);
+  }
+  if (m_bRenderDynamicObjects)
+  {
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaqueDynamic);
+  }
 
+  // Masked
+  if (m_bRenderStaticObjects)
+  {
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMaskedStatic);
+  }
+  if (m_bRenderDynamicObjects)
+  {
+    RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMaskedDynamic);
+  }  
+
+  // Transparent
   if (m_bRenderTransparentObjects)
   {
     RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitTransparent);
@@ -82,6 +101,8 @@ void ezDepthOnlyPass::Execute(const ezRenderViewContext& renderViewContext, cons
 ezResult ezDepthOnlyPass::Serialize(ezStreamWriter& inout_stream) const
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Serialize(inout_stream));
+  inout_stream << m_bRenderStaticObjects;
+  inout_stream << m_bRenderDynamicObjects;
   inout_stream << m_bRenderTransparentObjects;
   return EZ_SUCCESS;
 }
@@ -90,10 +111,18 @@ ezResult ezDepthOnlyPass::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
   const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
+
+  if (uiVersion >= 3)
+  {
+    inout_stream >> m_bRenderStaticObjects;
+    inout_stream >> m_bRenderDynamicObjects;
+  }
+
   if (uiVersion >= 2)
   {
     inout_stream >> m_bRenderTransparentObjects;
   }
+
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
@@ -89,7 +89,7 @@ void ezDepthOnlyPass::Execute(const ezRenderViewContext& renderViewContext, cons
   if (m_bRenderDynamicObjects)
   {
     RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMaskedDynamic);
-  }  
+  }
 
   // Transparent
   if (m_bRenderTransparentObjects)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/OpaqueForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/OpaqueForwardRenderPass.cpp
@@ -101,8 +101,10 @@ void ezOpaqueForwardRenderPass::SetupPermutationVars(const ezRenderViewContext& 
 
 void ezOpaqueForwardRenderPass::RenderObjects(const ezRenderViewContext& renderViewContext)
 {
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaque);
-  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMasked);
+  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaqueStatic);
+  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitOpaqueDynamic);
+  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMaskedStatic);
+  RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMaskedDynamic);
 }
 
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -84,6 +84,17 @@ ezRenderData::Category ezRenderData::RegisterCategory(const char* szCategoryName
 }
 
 // static
+ezRenderData::Category ezRenderData::RegisterDerivedCategory(const char* szCategoryName, Category baseCategory)
+{
+  auto& baseCategoryData = s_CategoryData[baseCategory.m_uiValue];
+
+  Category derivedCategory = RegisterCategory(szCategoryName, baseCategoryData.m_sortingKeyFunc);
+  s_CategoryData[derivedCategory.m_uiValue].m_baseCategory = baseCategory;
+
+  return derivedCategory;
+}
+
+// static
 ezRenderData::Category ezRenderData::FindCategory(ezTempHashedString sCategoryName)
 {
   for (ezUInt32 uiCategoryIndex = 0; uiCategoryIndex < s_CategoryData.GetCount(); ++uiCategoryIndex)
@@ -157,11 +168,20 @@ void ezRenderData::CreateRendererInstances()
     {
       auto& categoryData = s_CategoryData[category.m_uiValue];
 
-      for (ezUInt32 i = 0; i < supportedTypes.GetCount(); ++i)
+      for (auto pType : supportedTypes)
       {
-        categoryData.m_TypeToRendererIndex.Insert(supportedTypes[i], uiIndex);
+        categoryData.m_TypeToRendererIndex.Insert(pType, uiIndex);
       }
     }
+  }
+
+  // Copy the renderer types to derived categories
+  for (auto& categoryData : s_CategoryData)
+  {
+    if (categoryData.m_baseCategory == ezInvalidRenderDataCategory)
+      continue;
+
+    categoryData.m_TypeToRendererIndex = s_CategoryData[categoryData.m_baseCategory.m_uiValue].m_TypeToRendererIndex;
   }
 
   s_bRendererInstancesDirty = false;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -95,6 +95,16 @@ ezRenderData::Category ezRenderData::RegisterDerivedCategory(const char* szCateg
 }
 
 // static
+ezRenderData::Category ezRenderData::RegisterRedirectedCategory(const char* szCategoryName, Category staticCategory, Category dynamicCategory)
+{
+  Category newCategory = RegisterCategory(szCategoryName, nullptr);
+  s_CategoryData[newCategory.m_uiValue].m_staticCategory = staticCategory;
+  s_CategoryData[newCategory.m_uiValue].m_dynamicCategory = dynamicCategory;
+
+  return newCategory;
+}
+
+// static
 ezRenderData::Category ezRenderData::FindCategory(ezTempHashedString sCategoryName)
 {
   for (ezUInt32 uiCategoryIndex = 0; uiCategoryIndex < s_CategoryData.GetCount(); ++uiCategoryIndex)
@@ -104,6 +114,18 @@ ezRenderData::Category ezRenderData::FindCategory(ezTempHashedString sCategoryNa
   }
 
   return ezInvalidRenderDataCategory;
+}
+
+// static
+ezRenderData::Category ezRenderData::ResolveCategory(Category category, bool bDynamic)
+{
+  auto& categoryData = s_CategoryData[category.m_uiValue];
+  if (categoryData.m_staticCategory != ezInvalidRenderDataCategory)
+  {
+    return bDynamic ? categoryData.m_dynamicCategory : categoryData.m_staticCategory;
+  }
+
+  return category;
 }
 
 // static
@@ -164,13 +186,20 @@ void ezRenderData::CreateRendererInstances()
     ezHybridArray<const ezRTTI*, 8> supportedTypes;
     pRenderer->GetSupportedRenderDataTypes(supportedTypes);
 
-    for (Category category : supportedCategories)
+    for (auto pType : supportedTypes)
     {
-      auto& categoryData = s_CategoryData[category.m_uiValue];
-
-      for (auto pType : supportedTypes)
+      for (Category category : supportedCategories)
       {
-        categoryData.m_TypeToRendererIndex.Insert(pType, uiIndex);
+        auto& categoryData = s_CategoryData[category.m_uiValue];
+        if (categoryData.m_staticCategory != ezInvalidRenderDataCategory)
+        {
+          s_CategoryData[categoryData.m_staticCategory.m_uiValue].m_TypeToRendererIndex.Insert(pType, uiIndex);
+          s_CategoryData[categoryData.m_dynamicCategory.m_uiValue].m_TypeToRendererIndex.Insert(pType, uiIndex);
+        }
+        else
+        {
+          categoryData.m_TypeToRendererIndex.Insert(pType, uiIndex);
+        }
       }
     }
   }
@@ -204,14 +233,23 @@ ezRenderData::Category ezDefaultRenderDataCategories::Light = ezRenderData::Regi
 ezRenderData::Category ezDefaultRenderDataCategories::Decal = ezRenderData::RegisterCategory("Decal", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
 ezRenderData::Category ezDefaultRenderDataCategories::ReflectionProbe = ezRenderData::RegisterCategory("ReflectionProbe", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
 ezRenderData::Category ezDefaultRenderDataCategories::Sky = ezRenderData::RegisterCategory("Sky", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::LitOpaque = ezRenderData::RegisterCategory("LitOpaque", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
-ezRenderData::Category ezDefaultRenderDataCategories::LitMasked = ezRenderData::RegisterCategory("LitMasked", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+
+ezRenderData::Category ezDefaultRenderDataCategories::LitOpaqueStatic = ezRenderData::RegisterCategory("LitOpaqueStatic", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitOpaqueDynamic = ezRenderData::RegisterCategory("LitOpaqueDynamic", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitOpaque = ezRenderData::RegisterRedirectedCategory("LitOpaque", ezDefaultRenderDataCategories::LitOpaqueStatic, ezDefaultRenderDataCategories::LitOpaqueDynamic);
+
+ezRenderData::Category ezDefaultRenderDataCategories::LitMaskedStatic = ezRenderData::RegisterCategory("LitMaskedStatic", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitMaskedDynamic = ezRenderData::RegisterCategory("LitMaskedDynamic", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+ezRenderData::Category ezDefaultRenderDataCategories::LitMasked = ezRenderData::RegisterRedirectedCategory("LitMasked", ezDefaultRenderDataCategories::LitMaskedStatic, ezDefaultRenderDataCategories::LitMaskedDynamic);
+
 ezRenderData::Category ezDefaultRenderDataCategories::LitTransparent = ezRenderData::RegisterCategory("LitTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
 ezRenderData::Category ezDefaultRenderDataCategories::LitForeground = ezRenderData::RegisterCategory("LitForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
 ezRenderData::Category ezDefaultRenderDataCategories::LitScreenFX = ezRenderData::RegisterCategory("LitScreenFX", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
+
 ezRenderData::Category ezDefaultRenderDataCategories::SimpleOpaque = ezRenderData::RegisterCategory("SimpleOpaque", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
 ezRenderData::Category ezDefaultRenderDataCategories::SimpleTransparent = ezRenderData::RegisterCategory("SimpleTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
 ezRenderData::Category ezDefaultRenderDataCategories::SimpleForeground = ezRenderData::RegisterCategory("SimpleForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
+
 ezRenderData::Category ezDefaultRenderDataCategories::Selection = ezRenderData::RegisterCategory("Selection", &ezRenderSortingFunctions::ByRenderDataThenFrontToBack);
 ezRenderData::Category ezDefaultRenderDataCategories::GUI = ezRenderData::RegisterCategory("GUI", &ezRenderSortingFunctions::BackToFrontThenByRenderData);
 
@@ -221,7 +259,7 @@ void ezMsgExtractRenderData::AddRenderData(const ezRenderData* pRenderData, ezRe
 {
   auto& cached = m_ExtractedRenderData.ExpandAndGetRef();
   cached.m_pRenderData = pRenderData;
-  cached.m_uiCategory = category.m_uiValue;
+  cached.m_Category = ezRenderData::ResolveCategory(category, pRenderData->m_Flags.IsSet(ezRenderData::Flags::Dynamic));
 
   if (cachingBehavior == ezRenderData::Caching::IfStatic)
   {

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderDataBatch_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderDataBatch_inl.h
@@ -36,7 +36,7 @@ EZ_ALWAYS_INLINE void ezRenderDataBatch::Iterator<T>::operator++()
 }
 
 template <typename T>
-EZ_ALWAYS_INLINE ezRenderDataBatch::Iterator<T>::Iterator(const SortableRenderData* pStart, const SortableRenderData* pEnd)  
+EZ_ALWAYS_INLINE ezRenderDataBatch::Iterator<T>::Iterator(const SortableRenderData* pStart, const SortableRenderData* pEnd)
 {
   m_pCurrent = pStart;
   m_pEnd = pEnd;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderDataBatch_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderDataBatch_inl.h
@@ -18,17 +18,9 @@ EZ_ALWAYS_INLINE ezRenderDataBatch::Iterator<T>::operator const T*() const
 }
 
 template <typename T>
-EZ_FORCE_INLINE void ezRenderDataBatch::Iterator<T>::Next()
+EZ_ALWAYS_INLINE void ezRenderDataBatch::Iterator<T>::Next()
 {
   ++m_pCurrent;
-
-  if (m_Filter.IsValid())
-  {
-    while (m_pCurrent < m_pEnd && m_Filter(m_pCurrent->m_pRenderData))
-    {
-      ++m_pCurrent;
-    }
-  }
 }
 
 template <typename T>
@@ -44,19 +36,9 @@ EZ_ALWAYS_INLINE void ezRenderDataBatch::Iterator<T>::operator++()
 }
 
 template <typename T>
-EZ_FORCE_INLINE ezRenderDataBatch::Iterator<T>::Iterator(const SortableRenderData* pStart, const SortableRenderData* pEnd, Filter filter)
-  : m_Filter(filter)
+EZ_ALWAYS_INLINE ezRenderDataBatch::Iterator<T>::Iterator(const SortableRenderData* pStart, const SortableRenderData* pEnd)  
 {
-  const SortableRenderData* pCurrent = pStart;
-  if (m_Filter.IsValid())
-  {
-    while (pCurrent < pEnd && m_Filter(pCurrent->m_pRenderData))
-    {
-      ++pCurrent;
-    }
-  }
-
-  m_pCurrent = pCurrent;
+  m_pCurrent = pStart;
   m_pEnd = pEnd;
 }
 
@@ -67,17 +49,16 @@ EZ_ALWAYS_INLINE ezUInt32 ezRenderDataBatch::GetCount() const
 }
 
 template <typename T>
-EZ_FORCE_INLINE const T* ezRenderDataBatch::GetFirstData() const
+EZ_ALWAYS_INLINE const T* ezRenderDataBatch::GetFirstData() const
 {
-  auto it = Iterator<T>(m_Data.GetPtr(), m_Data.GetPtr() + m_Data.GetCount(), m_Filter);
-  return it.IsValid() ? (const T*)it : nullptr;
+  return m_Data.IsEmpty() == false ? ezStaticCast<const T*>(m_Data.GetPtr()->m_pRenderData) : nullptr;
 }
 
 template <typename T>
-EZ_FORCE_INLINE ezRenderDataBatch::Iterator<T> ezRenderDataBatch::GetIterator(ezUInt32 uiStartIndex, ezUInt32 uiCount) const
+EZ_ALWAYS_INLINE ezRenderDataBatch::Iterator<T> ezRenderDataBatch::GetIterator(ezUInt32 uiStartIndex, ezUInt32 uiCount) const
 {
   ezUInt32 uiEndIndex = ezMath::Min(uiStartIndex + uiCount, m_Data.GetCount());
-  return Iterator<T>(m_Data.GetPtr() + uiStartIndex, m_Data.GetPtr() + uiEndIndex, m_Filter);
+  return Iterator<T>(m_Data.GetPtr() + uiStartIndex, m_Data.GetPtr() + uiEndIndex);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -87,10 +68,7 @@ EZ_ALWAYS_INLINE ezUInt32 ezRenderDataBatchList::GetBatchCount() const
   return m_Batches.GetCount();
 }
 
-EZ_FORCE_INLINE ezRenderDataBatch ezRenderDataBatchList::GetBatch(ezUInt32 uiIndex) const
+EZ_ALWAYS_INLINE const ezRenderDataBatch& ezRenderDataBatchList::GetBatch(ezUInt32 uiIndex) const
 {
-  ezRenderDataBatch batch = m_Batches[uiIndex];
-  batch.m_Filter = m_Filter;
-
-  return batch;
+  return m_Batches[uiIndex];
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData_inl.h
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData_inl.h
@@ -67,6 +67,7 @@ static T* ezCreateRenderDataForThisFrame(const ezGameObject* pOwner)
 
   if (pOwner != nullptr)
   {
+    pRenderData->m_Flags.AddOrRemove(ezRenderData::Flags::Dynamic, pOwner->IsDynamic());
     pRenderData->m_hOwner = pOwner->GetHandle();
   }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -955,6 +955,11 @@ void ezRenderPipeline::ExtractData(const ezView& view)
     }
   }
 
+  for (auto& processor : m_RenderDataProcessors)
+  {
+    processor(data);
+  }
+
   data.SortAndBatch();
 
   for (auto& pExtractor : m_Extractors)
@@ -1296,10 +1301,17 @@ const ezExtractedRenderData& ezRenderPipeline::GetRenderData() const
   return m_Data[ezRenderWorld::GetDataIndexForRendering()];
 }
 
-ezRenderDataBatchList ezRenderPipeline::GetRenderDataBatchesWithCategory(ezRenderData::Category category, ezRenderDataBatch::Filter filter) const
+ezRenderDataBatchList ezRenderPipeline::GetRenderDataBatchesWithCategory(ezRenderData::Category category) const
 {
   auto& data = m_Data[ezRenderWorld::GetDataIndexForRendering()];
-  return data.GetRenderDataBatchesWithCategory(category, filter);
+  return data.GetRenderDataBatchesWithCategory(category);
+}
+
+ezUInt32 ezRenderPipeline::AddRenderDataProcessor(RenderDataProcessor processor)
+{
+  ezUInt32 uiIndex = m_RenderDataProcessors.GetCount();
+  m_RenderDataProcessors.PushBack(processor);
+  return uiIndex;
 }
 
 void ezRenderPipeline::CreateDgmlGraph(ezDGMLGraph& ref_graph)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelinePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipelinePass.cpp
@@ -72,11 +72,11 @@ ezResult ezRenderPipelinePass::Deserialize(ezStreamReader& inout_stream)
   return EZ_SUCCESS;
 }
 
-void ezRenderPipelinePass::RenderDataWithCategory(const ezRenderViewContext& renderViewContext, ezRenderData::Category category, ezRenderDataBatch::Filter filter)
+void ezRenderPipelinePass::RenderDataWithCategory(const ezRenderViewContext& renderViewContext, ezRenderData::Category category)
 {
   EZ_PROFILE_AND_MARKER(renderViewContext.m_pRenderContext->GetCommandEncoder(), ezRenderData::GetCategoryName(category));
 
-  auto batchList = m_pPipeline->GetRenderDataBatchesWithCategory(category, filter);
+  auto batchList = m_pPipeline->GetRenderDataBatchesWithCategory(category);
   const ezUInt32 uiBatchCount = batchList.GetBatchCount();
   for (ezUInt32 i = 0; i < uiBatchCount; ++i)
   {

--- a/Code/Engine/RendererCore/Pipeline/Passes/DepthOnlyPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/DepthOnlyPass.h
@@ -20,5 +20,7 @@ public:
 protected:
   ezRenderPipelineNodePassThroughPin m_PinDepthStencil;
 
+  bool m_bRenderStaticObjects = true;
+  bool m_bRenderDynamicObjects = true;
   bool m_bRenderTransparentObjects = false;
 };

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -31,6 +31,7 @@ public:
   using SortingKeyFunc = ezUInt64 (*)(const ezRenderData*, const ezCamera&);
 
   static Category RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc);
+  static Category RegisterDerivedCategory(const char* szCategoryName, Category baseCategory);
   static Category FindCategory(ezTempHashedString sCategoryName);
 
   static ezHashedString GetCategoryName(Category category);
@@ -78,6 +79,8 @@ private:
 
   struct CategoryData
   {
+    Category m_baseCategory;
+
     ezHashedString m_sName;
     SortingKeyFunc m_sortingKeyFunc;
 

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -32,7 +32,9 @@ public:
 
   static Category RegisterCategory(const char* szCategoryName, SortingKeyFunc sortingKeyFunc);
   static Category RegisterDerivedCategory(const char* szCategoryName, Category baseCategory);
+  static Category RegisterRedirectedCategory(const char* szCategoryName, Category staticCategory, Category dynamicCategory);
   static Category FindCategory(ezTempHashedString sCategoryName);
+  static Category ResolveCategory(Category category, bool bDynamic);
 
   static ezHashedString GetCategoryName(Category category);
   static void GetAllCategoryNames(ezDynamicArray<ezHashedString>& out_categoryNames);
@@ -49,12 +51,31 @@ public:
     };
   };
 
+  struct Flags
+  {
+    using StorageType = ezUInt32;
+
+    enum Enum
+    {
+      Dynamic = EZ_BIT(0),
+
+      Default = 0
+    };
+
+    struct Bits
+    {
+      StorageType Dynamic : 1;
+    };
+  };
+
   /// \brief Returns the final sorting for this render data with the given category and camera.
   ezUInt64 GetFinalSortingKey(Category category, const ezCamera& camera) const;
 
   /// \brief Returns whether this render data and the other render data can be batched together, e.g. rendered in one draw call.
   /// An implementation can assume that the other render data is of the same type as this render data.
   virtual bool CanBatch(const ezRenderData& other) const { return false; }
+
+  ezBitflags<Flags> m_Flags;
 
   ezTransform m_GlobalTransform = ezTransform::MakeIdentity();
   ezBoundingBoxSphere m_GlobalBounds;
@@ -80,6 +101,8 @@ private:
   struct CategoryData
   {
     Category m_baseCategory;
+    Category m_staticCategory;
+    Category m_dynamicCategory;
 
     ezHashedString m_sName;
     SortingKeyFunc m_sortingKeyFunc;
@@ -105,7 +128,11 @@ struct EZ_RENDERERCORE_DLL ezDefaultRenderDataCategories
   static ezRenderData::Category ReflectionProbe;
   static ezRenderData::Category Sky;
   static ezRenderData::Category LitOpaque;
+  static ezRenderData::Category LitOpaqueStatic;
+  static ezRenderData::Category LitOpaqueDynamic;
   static ezRenderData::Category LitMasked;
+  static ezRenderData::Category LitMaskedStatic;
+  static ezRenderData::Category LitMaskedDynamic;
   static ezRenderData::Category LitTransparent;
   static ezRenderData::Category LitForeground;
   static ezRenderData::Category LitScreenFX;
@@ -136,7 +163,7 @@ private:
   struct Data
   {
     const ezRenderData* m_pRenderData = nullptr;
-    ezUInt16 m_uiCategory = 0;
+    ezRenderData::Category m_Category;
   };
 
   ezHybridArray<Data, 16> m_ExtractedRenderData;

--- a/Code/Engine/RendererCore/Pipeline/RenderDataBatch.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderDataBatch.h
@@ -14,10 +14,7 @@ private:
   };
 
 public:
-  // EZ_DECLARE_POD_TYPE(); // ezDelegate has a destructor and therefore ezRenderDataBatch can't be POD
-
-  /// \brief This function should return true if the given render data should be filtered and not rendered.
-  using Filter = ezDelegate<bool(const ezRenderData*)>;
+  EZ_DECLARE_POD_TYPE();
 
   template <typename T>
   class Iterator
@@ -37,9 +34,8 @@ public:
   private:
     friend class ezRenderDataBatch;
 
-    Iterator(const SortableRenderData* pStart, const SortableRenderData* pEnd, Filter filter);
+    Iterator(const SortableRenderData* pStart, const SortableRenderData* pEnd);
 
-    Filter m_Filter;
     const SortableRenderData* m_pCurrent;
     const SortableRenderData* m_pEnd;
   };
@@ -56,7 +52,6 @@ private:
   friend class ezExtractedRenderData;
   friend class ezRenderDataBatchList;
 
-  Filter m_Filter;
   ezArrayPtr<SortableRenderData> m_Data;
 };
 
@@ -65,12 +60,11 @@ class ezRenderDataBatchList
 public:
   ezUInt32 GetBatchCount() const;
 
-  ezRenderDataBatch GetBatch(ezUInt32 uiIndex) const;
+  const ezRenderDataBatch& GetBatch(ezUInt32 uiIndex) const;
 
 private:
   friend class ezExtractedRenderData;
 
-  ezRenderDataBatch::Filter m_Filter;
   ezArrayPtr<const ezRenderDataBatch> m_Batches;
 };
 

--- a/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipeline.h
@@ -56,8 +56,10 @@ public:
   }
 
   const ezExtractedRenderData& GetRenderData() const;
-  ezRenderDataBatchList GetRenderDataBatchesWithCategory(
-    ezRenderData::Category category, ezRenderDataBatch::Filter filter = ezRenderDataBatch::Filter()) const;
+  ezRenderDataBatchList GetRenderDataBatchesWithCategory(ezRenderData::Category category) const;
+
+  using RenderDataProcessor = ezDelegate<void(ezExtractedRenderData&)>;
+  ezUInt32 AddRenderDataProcessor(RenderDataProcessor processor);
 
   /// \brief Creates a DGML graph of all passes and textures. Can be used to verify that no accidental temp textures are created due to poorly constructed pipelines or errors in code.
   void CreateDgmlGraph(ezDGMLGraph& ref_graph);
@@ -147,6 +149,8 @@ private: // Member data
   // Data Providers
   mutable ezDynamicArray<ezUniquePtr<ezFrameDataProviderBase>> m_DataProviders;
   mutable ezHashTable<const ezRTTI*, ezUInt32> m_TypeToDataProviderIndex;
+
+  ezDynamicArray<RenderDataProcessor> m_RenderDataProcessors;
 
   ezDynamicArray<ezPermutationVar> m_PermutationVars;
 

--- a/Code/Engine/RendererCore/Pipeline/RenderPipelinePass.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderPipelinePass.h
@@ -70,7 +70,7 @@ public:
   virtual ezResult Serialize(ezStreamWriter& inout_stream) const;
   virtual ezResult Deserialize(ezStreamReader& inout_stream);
 
-  void RenderDataWithCategory(const ezRenderViewContext& renderViewContext, ezRenderData::Category category, ezRenderDataBatch::Filter filter = ezRenderDataBatch::Filter());
+  void RenderDataWithCategory(const ezRenderViewContext& renderViewContext, ezRenderData::Category category);
 
   EZ_ALWAYS_INLINE ezRenderPipeline* GetPipeline() { return m_pPipeline; }
   EZ_ALWAYS_INLINE const ezRenderPipeline* GetPipeline() const { return m_pPipeline; }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -308,18 +308,13 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProcVertexColorOutputDesc, ezNoBase, 1, ezRTTID
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_ACCESSOR_PROPERTY("Name", GetName, SetName),
+    EZ_MEMBER_PROPERTY("Name", m_sName)->AddAttributes(new ezDynamicStringEnumAttribute("ProcGenOutputNameEnum")),
     EZ_MEMBER_PROPERTY("Mapping", m_Mapping),
   }
   EZ_END_PROPERTIES;
 }
 EZ_END_STATIC_REFLECTED_TYPE;
 // clang-format on
-
-void ezProcVertexColorOutputDesc::SetName(const char* szName)
-{
-  m_sName.Assign(szName);
-}
 
 static ezTypeVersion s_ProcVertexColorOutputDescVersion = 1;
 ezResult ezProcVertexColorOutputDesc::Serialize(ezStreamWriter& inout_stream) const

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVertexColorComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVertexColorComponent.h
@@ -62,9 +62,6 @@ struct ezProcVertexColorOutputDesc
   ezHashedString m_sName;
   ezProcVertexColorMapping m_Mapping;
 
-  void SetName(const char* szName);
-  const char* GetName() const { return m_sName; }
-
   ezResult Serialize(ezStreamWriter& inout_stream) const;
   ezResult Deserialize(ezStreamReader& inout_stream);
 };


### PR DESCRIPTION
* We had the ability to additionally filter render data during rendering, which was currently only used by the Editor picking pass. This however makes it difficult to prepare batches during extraction to a point where the render passes don't have to loop over individual render data anymore. Therefore the filtering has also been moved to the extraction phase where a render pass can hook into and create it a new render data category which already contains the filtered render data.
* LitOpaque and LitMasked render data are now split into a static and dynamic category. This is not used for anything yet, but could be used for e.g. shadow map caching or velocity buffers in the future.
* Other smaller fixes and additions