### PR TITLE
Added toolbar menus to select snapping options

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/TransformGizmoActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/TransformGizmoActions.cpp
@@ -3,6 +3,7 @@
 #include <EditorFramework/Actions/TransformGizmoActions.h>
 #include <EditorFramework/Dialogs/SnapSettingsDlg.moc.h>
 #include <EditorFramework/EditTools/StandardGizmoEditTools.h>
+#include <EditorFramework/Gizmos/SnapProvider.h>
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezGizmoAction, 0, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
@@ -72,6 +73,380 @@ void ezToggleWorldSpaceGizmo::Execute(const ezVariant& value)
 
 //////////////////////////////////////////////////////////////////////////
 
+class ezSnapTranslationMenuAction : public ezDynamicMenuAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSnapTranslationMenuAction, ezDynamicMenuAction);
+
+public:
+  ezSnapTranslationMenuAction(const ezActionContext& context, const char* szName, const char* szIconPath)
+    : ezDynamicMenuAction(context, szName, szIconPath)
+  {
+    UpdateIcon();
+
+    ezSnapProvider::s_Events.AddEventHandler(ezMakeDelegate(&ezSnapTranslationMenuAction::SnapEvent, this));
+  }
+
+  ~ezSnapTranslationMenuAction()
+  {
+    ezSnapProvider::s_Events.RemoveEventHandler(ezMakeDelegate(&ezSnapTranslationMenuAction::SnapEvent, this));
+  }
+
+  void SnapEvent(const ezSnapProviderEvent& e)
+  {
+    UpdateIcon();
+  }
+
+  virtual void GetEntries(ezDynamicArray<Item>& out_entries) override
+  {
+    out_entries.Clear();
+
+    const float fValue = ezSnapProvider::GetTranslationSnapValue();
+
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0";
+      e.m_UserValue = 0.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.01f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0_01";
+      e.m_UserValue = 0.01f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.05f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0_05";
+      e.m_UserValue = 0.05f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0_1";
+      e.m_UserValue = 0.1f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.2f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0_2";
+      e.m_UserValue = 0.2f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.25f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0_25";
+      e.m_UserValue = 0.25f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 0.5f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.0_5";
+      e.m_UserValue = 0.5f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 1.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.1";
+      e.m_UserValue = 1.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 2.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.2";
+      e.m_UserValue = 2.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 4.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.4";
+      e.m_UserValue = 4.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 5.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.5";
+      e.m_UserValue = 5.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 8.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.8";
+      e.m_UserValue = 8.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = (fValue == 10.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Translate.Snap.10";
+      e.m_UserValue = 10.0f;
+    }
+  }
+
+  virtual void Execute(const ezVariant& value) override
+  {
+    ezSnapProvider::SetTranslationSnapValue(value.Get<float>());
+  };
+
+  void UpdateIcon()
+  {
+    const float fValue = ezSnapProvider::GetTranslationSnapValue();
+
+    if (fValue == 0.0f)
+      SetIconPath(":EditorFramework/Icons/Snap0cm.svg");
+    else if (fValue == 0.01f)
+      SetIconPath(":EditorFramework/Icons/Snap1cm.svg");
+    else if (fValue == 0.05f)
+      SetIconPath(":EditorFramework/Icons/Snap5cm.svg");
+    else if (fValue == 0.1f)
+      SetIconPath(":EditorFramework/Icons/Snap10cm.svg");
+    else if (fValue == 0.2f)
+      SetIconPath(":EditorFramework/Icons/Snap20cm.svg");
+    else if (fValue == 0.25f)
+      SetIconPath(":EditorFramework/Icons/Snap25cm.svg");
+    else if (fValue == 0.5f)
+      SetIconPath(":EditorFramework/Icons/Snap50cm.svg");
+    else if (fValue == 1.0f)
+      SetIconPath(":EditorFramework/Icons/Snap100cm.svg");
+    else if (fValue == 2.0f)
+      SetIconPath(":EditorFramework/Icons/Snap200cm.svg");
+    else if (fValue == 4.0f)
+      SetIconPath(":EditorFramework/Icons/Snap400cm.svg");
+    else if (fValue == 5.0f)
+      SetIconPath(":EditorFramework/Icons/Snap500cm.svg");
+    else if (fValue == 8.0f)
+      SetIconPath(":EditorFramework/Icons/Snap800cm.svg");
+    else if (fValue == 10.0f)
+      SetIconPath(":EditorFramework/Icons/Snap1000cm.svg");
+
+    TriggerUpdate();
+  }
+};
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSnapTranslationMenuAction, 0, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+//////////////////////////////////////////////////////////////////////////
+
+class ezSnapRotationMenuAction : public ezDynamicMenuAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSnapRotationMenuAction, ezDynamicMenuAction);
+
+public:
+  ezSnapRotationMenuAction(const ezActionContext& context, const char* szName, const char* szIconPath)
+    : ezDynamicMenuAction(context, szName, szIconPath)
+  {
+    UpdateIcon();
+
+    ezSnapProvider::s_Events.AddEventHandler(ezMakeDelegate(&ezSnapRotationMenuAction::SnapEvent, this));
+  }
+
+  ~ezSnapRotationMenuAction()
+  {
+    ezSnapProvider::s_Events.RemoveEventHandler(ezMakeDelegate(&ezSnapRotationMenuAction::SnapEvent, this));
+  }
+
+  void SnapEvent(const ezSnapProviderEvent& e)
+  {
+    UpdateIcon();
+  }
+
+  virtual void GetEntries(ezDynamicArray<Item>& out_entries) override
+  {
+    out_entries.Clear();
+
+    const float fValue = ezSnapProvider::GetRotationSnapValue().GetDegree();
+
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 0.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.0_Degree";
+      e.m_UserValue = 0.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 1.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.1_Degree";
+      e.m_UserValue = 1.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 5.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.5_Degree";
+      e.m_UserValue = 5.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 10.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.10_Degree";
+      e.m_UserValue = 10.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 15.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.15_Degree";
+      e.m_UserValue = 15.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 22.5f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.22_5_Degree";
+      e.m_UserValue = 22.5f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 30.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.30_Degree";
+      e.m_UserValue = 30.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 45.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Rotation.Snap.45_Degree";
+      e.m_UserValue = 45.0f;
+    }
+  }
+
+  virtual void Execute(const ezVariant& value) override
+  {
+    ezSnapProvider::SetRotationSnapValue(ezAngle::MakeFromDegree(value.Get<float>()));
+  };
+
+  void UpdateIcon()
+  {
+    const float fValue = ezSnapProvider::GetRotationSnapValue().GetDegree();
+
+    if (ezMath::IsEqual(fValue, 0.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap0deg.svg");
+    else if (ezMath::IsEqual(fValue, 1.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap1deg.svg");
+    else if (ezMath::IsEqual(fValue, 5.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap5deg.svg");
+    else if (ezMath::IsEqual(fValue, 10.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap10deg.svg");
+    else if (ezMath::IsEqual(fValue, 15.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap15deg.svg");
+    else if (ezMath::IsEqual(fValue, 22.5f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap22deg.svg");
+    else if (ezMath::IsEqual(fValue, 30.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap30deg.svg");
+    else if (ezMath::IsEqual(fValue, 45.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap45deg.svg");
+
+    TriggerUpdate();
+  }
+};
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSnapRotationMenuAction, 0, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+//////////////////////////////////////////////////////////////////////////
+
+class ezSnapScaleMenuAction : public ezDynamicMenuAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSnapScaleMenuAction, ezDynamicMenuAction);
+
+public:
+  ezSnapScaleMenuAction(const ezActionContext& context, const char* szName, const char* szIconPath)
+    : ezDynamicMenuAction(context, szName, szIconPath)
+  {
+    UpdateIcon();
+
+    ezSnapProvider::s_Events.AddEventHandler(ezMakeDelegate(&ezSnapScaleMenuAction::SnapEvent, this));
+  }
+
+  ~ezSnapScaleMenuAction()
+  {
+    ezSnapProvider::s_Events.RemoveEventHandler(ezMakeDelegate(&ezSnapScaleMenuAction::SnapEvent, this));
+  }
+
+  void SnapEvent(const ezSnapProviderEvent& e)
+  {
+    UpdateIcon();
+  }
+
+  virtual void GetEntries(ezDynamicArray<Item>& out_entries) override
+  {
+    out_entries.Clear();
+
+    const float fValue = ezSnapProvider::GetScaleSnapValue();
+
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 0.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.0";
+      e.m_UserValue = 0.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 0.125f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.0_125";
+      e.m_UserValue = 0.125f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 0.25f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.0_25";
+      e.m_UserValue = 0.25f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 0.5f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.0_5";
+      e.m_UserValue = 0.5f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 1.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.1";
+      e.m_UserValue = 1.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 2.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.2";
+      e.m_UserValue = 2.0f;
+    }
+    {
+      auto& e = out_entries.ExpandAndGetRef();
+      e.m_CheckState = ezMath::IsEqual(fValue, 4.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
+      e.m_sDisplay = "Gizmo.Scale.Snap.4";
+      e.m_UserValue = 4.0f;
+    }
+  }
+
+  virtual void Execute(const ezVariant& value) override
+  {
+    ezSnapProvider::SetScaleSnapValue(value.Get<float>());
+  };
+
+  void UpdateIcon()
+  {
+    const float fValue = ezSnapProvider::GetScaleSnapValue();
+
+    if (ezMath::IsEqual(fValue, 0.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap0x.svg");
+    else if (ezMath::IsEqual(fValue, 0.125f, 0.05f))
+      SetIconPath(":EditorFramework/Icons/Snap0125x.svg");
+    else if (ezMath::IsEqual(fValue, 0.25f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap025x.svg");
+    else if (ezMath::IsEqual(fValue, 0.5f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap05x.svg");
+    else if (ezMath::IsEqual(fValue, 1.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap1x.svg");
+    else if (ezMath::IsEqual(fValue, 2.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap2x.svg");
+    else if (ezMath::IsEqual(fValue, 4.0f, 0.1f))
+      SetIconPath(":EditorFramework/Icons/Snap4x.svg");
+
+    TriggerUpdate();
+  }
+};
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSnapScaleMenuAction, 0, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+//////////////////////////////////////////////////////////////////////////
+
 ezActionDescriptorHandle ezTransformGizmoActions::s_hGizmoCategory;
 ezActionDescriptorHandle ezTransformGizmoActions::s_hGizmoMenu;
 ezActionDescriptorHandle ezTransformGizmoActions::s_hNoGizmo;
@@ -82,6 +457,9 @@ ezActionDescriptorHandle ezTransformGizmoActions::s_hDragToPositionGizmo;
 ezActionDescriptorHandle ezTransformGizmoActions::s_hWorldSpace;
 ezActionDescriptorHandle ezTransformGizmoActions::s_hMoveParentOnly;
 ezActionDescriptorHandle ezTransformGizmoActions::s_SnapSettings;
+ezActionDescriptorHandle ezTransformGizmoActions::s_SnapTranslationMenu;
+ezActionDescriptorHandle ezTransformGizmoActions::s_SnapRotationMenu;
+ezActionDescriptorHandle ezTransformGizmoActions::s_SnapScaleMenu;
 
 void ezTransformGizmoActions::RegisterActions()
 {
@@ -102,6 +480,10 @@ void ezTransformGizmoActions::RegisterActions()
     ezTransformGizmoAction::ActionType::GizmoToggleMoveParentOnly);
   s_SnapSettings = EZ_REGISTER_ACTION_1(
     "Gizmo.SnapSettings", ezActionScope::Document, "Gizmo", "End", ezTransformGizmoAction, ezTransformGizmoAction::ActionType::GizmoSnapSettings);
+
+  s_SnapTranslationMenu = EZ_REGISTER_DYNAMIC_MENU("Gizmo.Translation.Snap.Dropdown", ezSnapTranslationMenuAction, ":/EditorFramework/Icons/SnapSettings.svg");
+  s_SnapRotationMenu = EZ_REGISTER_DYNAMIC_MENU("Gizmo.Rotation.Snap.Dropdown", ezSnapRotationMenuAction, ":/EditorFramework/Icons/SnapSettings.svg");
+  s_SnapScaleMenu = EZ_REGISTER_DYNAMIC_MENU("Gizmo.Scale.Snap.Dropdown", ezSnapScaleMenuAction, ":/EditorFramework/Icons/SnapSettings.svg");
 }
 
 void ezTransformGizmoActions::UnregisterActions()
@@ -116,6 +498,9 @@ void ezTransformGizmoActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hWorldSpace);
   ezActionManager::UnregisterAction(s_hMoveParentOnly);
   ezActionManager::UnregisterAction(s_SnapSettings);
+  ezActionManager::UnregisterAction(s_SnapTranslationMenu);
+  ezActionManager::UnregisterAction(s_SnapRotationMenu);
+  ezActionManager::UnregisterAction(s_SnapScaleMenu);
 }
 
 void ezTransformGizmoActions::MapMenuActions(ezStringView sMapping)
@@ -150,7 +535,9 @@ void ezTransformGizmoActions::MapToolbarActions(ezStringView sMapping)
   pMap->MapAction(s_hScaleGizmo, sSubPath, 3.0f);
   pMap->MapAction(s_hDragToPositionGizmo, sSubPath, 4.0f);
   pMap->MapAction(s_hWorldSpace, sSubPath, 6.0f);
-  pMap->MapAction(s_SnapSettings, sSubPath, 7.0f);
+  pMap->MapAction(s_SnapTranslationMenu, sSubPath, 7.0f);
+  pMap->MapAction(s_SnapRotationMenu, sSubPath, 8.0f);
+  pMap->MapAction(s_SnapScaleMenu, sSubPath, 9.0f);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/EditorFramework/Actions/TransformGizmoActions.h
+++ b/Code/Editor/EditorFramework/Actions/TransformGizmoActions.h
@@ -29,6 +29,9 @@ public:
   static ezActionDescriptorHandle s_hWorldSpace;
   static ezActionDescriptorHandle s_hMoveParentOnly;
   static ezActionDescriptorHandle s_SnapSettings;
+  static ezActionDescriptorHandle s_SnapTranslationMenu;
+  static ezActionDescriptorHandle s_SnapRotationMenu;
+  static ezActionDescriptorHandle s_SnapScaleMenu;
 };
 
 ///

--- a/Code/Editor/EditorFramework/Dialogs/SnapSettingsDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/SnapSettingsDlg.cpp
@@ -9,6 +9,7 @@ ezQtSnapSettingsDlg::ezQtSnapSettingsDlg(QWidget* pParent)
   setupUi(this);
 
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.0", 0.0f});
+  m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.0_01", 0.01f});
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.0_05", 0.05f});
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.0_1", 0.1f});
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.0_125", 0.125f});
@@ -21,28 +22,23 @@ ezQtSnapSettingsDlg::ezQtSnapSettingsDlg(QWidget* pParent)
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.5", 5.0f});
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.8", 8.0f});
   m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.10", 10.0f});
-  m_Translation.PushBack(KeyValue{"Gizmo.Translate.Snap.16", 16.0f});
 
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.0_Degree", 0.0f});
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.1_Degree", 1.0f});
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.5_Degree", 5.0f});
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.10_Degree", 10.0f});
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.15_Degree", 15.0f});
-  m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.30_Degree", 30.0f});
-  m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.2_8125_Degree", 2.8125f});
-  m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.5_625_Degree", 5.625f});
-  m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.11_25_Degree", 11.25f});
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.22_5_Degree", 22.5f});
+  m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.30_Degree", 30.0f});
   m_Rotation.PushBack(KeyValue{"Gizmo.Rotation.Snap.45_Degree", 45.0f});
 
   m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.0", 0.0f});
-  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.8", 8.0f});
-  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.4", 4.0f});
-  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.2", 2.0f});
-  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.1", 1.0f});
-  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.0_5", 0.5f});
-  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.0_25", 0.25f});
   m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.0_125", 0.125f});
+  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.0_25", 0.25f});
+  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.0_5", 0.5f});
+  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.1", 1.0f});
+  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.2", 2.0f});
+  m_Scale.PushBack(KeyValue{"Gizmo.Scale.Snap.4", 4.0f});
 
   ezUInt32 uiSelectedT = 0;
   ezUInt32 uiSelectedR = 0;

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap0125x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap0125x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap0125x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:138.468px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.721187"
+       x="95.451599"
+       y="95.108955"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.721187"
+         x="95.451599"
+         y="95.108955"
+         id="tspan4">1/8</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap025x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap025x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap025x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:138.468px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.721187"
+       x="95.451599"
+       y="95.108955"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.721187"
+         x="95.451599"
+         y="95.108955"
+         id="tspan4">1/4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap05x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap05x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap05x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:138.468px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.721187"
+       x="95.451599"
+       y="95.108955"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.721187"
+         x="95.451599"
+         y="95.108955"
+         id="tspan4">1/2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap0cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap0cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap0cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap0deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap0deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap0deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap0x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap0x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap0x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap1000cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap1000cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap1000cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">10</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+         x="73.077057"
+         y="196.01088">m</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap100cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap100cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap100cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+         x="73.077057"
+         y="196.01088">m</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap10cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap10cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap10cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">10</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap10deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap10deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap10deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">10</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap15deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap15deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap15deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">15</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap1cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap1cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap1cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap1deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap1deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap1deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap1x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap1x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap1x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap200cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap200cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap200cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+         x="73.077057"
+         y="196.01088">m</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap20cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap20cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap20cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">20</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap22deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap22deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap22deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">22</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap25cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap25cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap25cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">25</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap2x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap2x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap2x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap30deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap30deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap30deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">30</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap400cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap400cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap400cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+         x="73.077057"
+         y="196.01088">m</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap45deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap45deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap45deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">45</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap4x.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap4x.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="Snap4x.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="377.45545"
+     inkscape:cy="365.63945"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">X</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap500cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap500cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap500cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">5</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+         x="73.077057"
+         y="196.01088">m</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap50cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap50cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap50cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">50</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap5cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap5cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap5cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">5</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.646886"
+         x="73.077049"
+         y="196.01088">cm</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap5deg.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap5deg.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap5deg.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32657"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">5</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:98.8649px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+       x="75.704124"
+       y="197.96928"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#f40000;fill-opacity:1;stroke-width:0.514923"
+         x="75.704124"
+         y="197.96928">DEG</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/Icons/Snap800cm.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/Snap800cm.svg
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="200mm"
+   height="200mm"
+   viewBox="0 0 200 200"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="Snap800cm.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.76167929"
+     inkscape:cx="376.79901"
+     inkscape:cy="364.32656"
+     inkscape:window-width="1920"
+     inkscape:window-height="1111"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1">
+    <rect
+       x="60.392872"
+       y="70.89598"
+       width="588.17406"
+       height="337.41235"
+       id="rect1" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="SVGRepo_bgCarrier"
+       stroke-width="0"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <g
+       id="SVGRepo_tracerCarrier"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       transform="matrix(3.246923,0,0,3.246923,4.7101032,121.22714)"
+       style="fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text1"
+       style="font-size:29.3333px;white-space:pre;shape-inside:url(#rect1);display:inline;fill:#ffffff;fill-opacity:1" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.823356"
+       x="99.341103"
+       y="81.993713"
+       id="text2"><tspan
+         sodipodi:role="line"
+         id="tspan2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:93.2549px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;stroke-width:0.823356"
+         x="99.341103"
+         y="81.993713" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:187.127px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke-width:0.974618"
+       x="100.53296"
+       y="128.03918"
+       id="text3"><tspan
+         sodipodi:role="line"
+         style="stroke-width:0.974618"
+         x="100.53296"
+         y="128.03918"
+         id="tspan4">8</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:124.202px;font-family:'Franklin Gothic Demi Cond';-inkscape-font-specification:'Franklin Gothic Demi Cond';text-align:center;text-anchor:middle;fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+       x="73.077057"
+       y="196.01088"
+       id="text5"><tspan
+         sodipodi:role="line"
+         id="tspan5"
+         style="fill:#481bff;fill-opacity:1;stroke-width:0.646886"
+         x="73.077057"
+         y="196.01088">m</tspan></text>
+  </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/resources.qrc
+++ b/Code/Editor/EditorFramework/QtResources/resources.qrc
@@ -65,6 +65,34 @@
     <file>Icons/MoveCameraHere.svg</file>
     <file>Icons/id.svg</file>
     <file>Icons/ActiveParent.svg</file>
+    <file>Icons/Snap0cm.svg</file>
+    <file>Icons/Snap1cm.svg</file>
+    <file>Icons/Snap5cm.svg</file>
+    <file>Icons/Snap10cm.svg</file>
+    <file>Icons/Snap20cm.svg</file>
+    <file>Icons/Snap25cm.svg</file>
+    <file>Icons/Snap50cm.svg</file>
+    <file>Icons/Snap100cm.svg</file>
+    <file>Icons/Snap200cm.svg</file>
+    <file>Icons/Snap400cm.svg</file>
+    <file>Icons/Snap500cm.svg</file>
+    <file>Icons/Snap800cm.svg</file>
+    <file>Icons/Snap1000cm.svg</file>
+    <file>Icons/Snap0deg.svg</file>
+    <file>Icons/Snap1deg.svg</file>
+    <file>Icons/Snap5deg.svg</file>
+    <file>Icons/Snap10deg.svg</file>
+    <file>Icons/Snap15deg.svg</file>
+    <file>Icons/Snap22deg.svg</file>
+    <file>Icons/Snap30deg.svg</file>
+    <file>Icons/Snap45deg.svg</file>
+    <file>Icons/Snap0x.svg</file>
+    <file>Icons/Snap0125x.svg</file>
+    <file>Icons/Snap025x.svg</file>
+    <file>Icons/Snap05x.svg</file>
+    <file>Icons/Snap1x.svg</file>
+    <file>Icons/Snap2x.svg</file>
+    <file>Icons/Snap4x.svg</file>
   </qresource>
   <qresource prefix="TypeIcons">
     <file>ezDragToPositionGizmoEditTool.svg</file>

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/Actions/AngelScriptActions.cpp
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/Actions/AngelScriptActions.cpp
@@ -28,7 +28,20 @@ void ezAngelScriptActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hSyncExposedParams);
 }
 
-void ezAngelScriptActions::MapActions(ezStringView sMapping)
+void ezAngelScriptActions::MapActionsMenu(ezStringView sMapping)
+{
+  ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
+  EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);
+
+  pMap->MapAction(s_hCategory, "G.Asset", 1.0f);
+
+  const char* szSubPath = "AngelScriptCategory";
+
+  pMap->MapAction(s_hOpenInVSC, szSubPath, 1.0f);
+  pMap->MapAction(s_hSyncExposedParams, szSubPath, 2.0f);
+}
+
+void ezAngelScriptActions::MapActionsToolbar(ezStringView sMapping)
 {
   ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
   EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/Actions/AngelScriptActions.h
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/Actions/AngelScriptActions.h
@@ -14,7 +14,8 @@ public:
   static void RegisterActions();
   static void UnregisterActions();
 
-  static void MapActions(ezStringView sMapping);
+  static void MapActionsMenu(ezStringView sMapping);
+  static void MapActionsToolbar(ezStringView sMapping);
 
   static ezActionDescriptorHandle s_hCategory;
   static ezActionDescriptorHandle s_hOpenInVSC;

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/EditorPluginAngelScript.cpp
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/EditorPluginAngelScript.cpp
@@ -25,7 +25,6 @@ void OnLoadPlugin()
 
       ezEditActions::MapActions("AngelScriptAssetMenuBar", false, false);
       ezAngelScriptActions::MapActionsMenu("AngelScriptAssetMenuBar");
-
     }
 
     // Tool Bar

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/EditorPluginAngelScript.cpp
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/EditorPluginAngelScript.cpp
@@ -20,13 +20,18 @@ void OnLoadPlugin()
     // Menu Bar
     {
       ezActionMapManager::RegisterActionMap("AngelScriptAssetMenuBar", "AssetMenuBar");
+
+      ezStandardMenus::MapActions("AngelScriptAssetMenuBar", ezStandardMenuTypes::Asset);
+
       ezEditActions::MapActions("AngelScriptAssetMenuBar", false, false);
+      ezAngelScriptActions::MapActionsMenu("AngelScriptAssetMenuBar");
+
     }
 
     // Tool Bar
     {
       ezActionMapManager::RegisterActionMap("AngelScriptAssetToolBar", "AssetToolbar");
-      ezAngelScriptActions::MapActions("AngelScriptAssetToolBar");
+      ezAngelScriptActions::MapActionsToolbar("AngelScriptAssetToolBar");
     }
 
     ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezAngelScriptAssetDocument::PropertyMetaStateEventHandler);

--- a/Code/Tools/Libs/GuiFoundation/Action/BaseActions.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/BaseActions.h
@@ -50,7 +50,10 @@ public:
   virtual void Execute(const ezVariant& value) override {};
 };
 
+/// An action that represents a sub-menu. Can be within a menu bar, or the menu of a tool button).
 ///
+/// This class can be used directly, but then every menu entry has to be mapped individually into the menu.
+/// It is often more convenient to use derived types which already set up the content of the menu.
 class EZ_GUIFOUNDATION_DLL ezMenuAction : public ezNamedAction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezMenuAction, ezNamedAction);
@@ -64,7 +67,14 @@ public:
   virtual void Execute(const ezVariant& value) override {};
 };
 
+/// A menu action whose content is determined when opening the menu.
 ///
+/// Every time this menu gets opened, GetEntries() is executed,
+/// with the state of the previous menu items.
+/// It can then return the same result, or adjust the entries (update check marks or show entirely different entries).
+///
+/// Derive from this, to create your own dynamic menu.
+/// Or use something like ezEnumerationMenuAction to get a menu for an enum type.
 class EZ_GUIFOUNDATION_DLL ezDynamicMenuAction : public ezMenuAction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezDynamicMenuAction, ezMenuAction);
@@ -110,7 +120,7 @@ public:
   virtual void GetEntries(ezDynamicArray<Item>& out_entries) = 0;
 };
 
-///
+/// An action that is displayed as a tool button that is clickable but also has a sub-menu that can be opened for selecting a different action.
 class EZ_GUIFOUNDATION_DLL ezDynamicActionAndMenuAction : public ezDynamicMenuAction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezDynamicActionAndMenuAction, ezDynamicMenuAction);
@@ -139,7 +149,7 @@ protected:
   bool m_bVisible;
 };
 
-///
+/// A menu that lists all values of an enum type.
 class EZ_GUIFOUNDATION_DLL ezEnumerationMenuAction : public ezDynamicMenuAction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezEnumerationMenuAction, ezDynamicMenuAction);
@@ -154,7 +164,7 @@ protected:
   const ezRTTI* m_pEnumerationType;
 };
 
-///
+/// The standard button action.
 class EZ_GUIFOUNDATION_DLL ezButtonAction : public ezNamedAction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezButtonAction, ezNamedAction);
@@ -201,7 +211,7 @@ protected:
   bool m_bVisible;
 };
 
-
+/// An action that represents an integer value within a fixed range, and gets displayed as a slider.
 class EZ_GUIFOUNDATION_DLL ezSliderAction : public ezNamedAction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezSliderAction, ezNamedAction);

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/StandardMenus.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/StandardMenus.cpp
@@ -11,6 +11,7 @@ ezActionDescriptorHandle ezStandardMenus::s_hMenuFile;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuEdit;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuPanels;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuScene;
+ezActionDescriptorHandle ezStandardMenus::s_hMenuAsset;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuView;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuTools;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuHelp;
@@ -24,6 +25,7 @@ void ezStandardMenus::RegisterActions()
   s_hMenuEdit = EZ_REGISTER_MENU("G.Edit");
   s_hMenuPanels = EZ_REGISTER_DYNAMIC_MENU("G.Panels", ezApplicationPanelsMenuAction, "");
   s_hMenuScene = EZ_REGISTER_MENU("G.Scene");
+  s_hMenuAsset = EZ_REGISTER_MENU("G.Asset");
   s_hMenuView = EZ_REGISTER_MENU("G.View");
   s_hMenuTools = EZ_REGISTER_MENU("G.Tools");
   s_hMenuHelp = EZ_REGISTER_MENU("G.Help");
@@ -38,6 +40,7 @@ void ezStandardMenus::UnregisterActions()
   ezActionManager::UnregisterAction(s_hMenuEdit);
   ezActionManager::UnregisterAction(s_hMenuPanels);
   ezActionManager::UnregisterAction(s_hMenuScene);
+  ezActionManager::UnregisterAction(s_hMenuAsset);
   ezActionManager::UnregisterAction(s_hMenuView);
   ezActionManager::UnregisterAction(s_hMenuTools);
   ezActionManager::UnregisterAction(s_hMenuHelp);
@@ -64,18 +67,21 @@ void ezStandardMenus::MapActions(ezStringView sMapping, const ezBitflags<ezStand
   if (menus.IsAnySet(ezStandardMenuTypes::Scene))
     pMap->MapAction(s_hMenuScene, "", 3.0f);
 
+  if (menus.IsAnySet(ezStandardMenuTypes::Asset))
+    pMap->MapAction(s_hMenuAsset, "", 4.0f);
+
   if (menus.IsAnySet(ezStandardMenuTypes::View))
-    pMap->MapAction(s_hMenuView, "", 4.0f);
+    pMap->MapAction(s_hMenuView, "", 5.0f);
 
   if (menus.IsAnySet(ezStandardMenuTypes::Tools))
-    pMap->MapAction(s_hMenuTools, "", 5.0f);
+    pMap->MapAction(s_hMenuTools, "", 6.0f);
 
   if (menus.IsAnySet(ezStandardMenuTypes::Panels))
-    pMap->MapAction(s_hMenuPanels, "", 6.0f);
+    pMap->MapAction(s_hMenuPanels, "", 7.0f);
 
   if (menus.IsAnySet(ezStandardMenuTypes::Help))
   {
-    pMap->MapAction(s_hMenuHelp, "", 7.0f);
+    pMap->MapAction(s_hMenuHelp, "", 8.0f);
     pMap->MapAction(s_hReportProblem, "G.Help", 3.0f);
     pMap->MapAction(s_hCheckForUpdates, "G.Help", 10.0f);
   }

--- a/Code/Tools/Libs/GuiFoundation/Action/StandardMenus.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/StandardMenus.h
@@ -14,9 +14,10 @@ struct ezStandardMenuTypes
     Edit = EZ_BIT(2),
     Panels = EZ_BIT(3),
     Scene = EZ_BIT(4),
-    View = EZ_BIT(5),
-    Tools = EZ_BIT(6),
-    Help = EZ_BIT(7),
+    Asset = EZ_BIT(5),
+    View = EZ_BIT(6),
+    Tools = EZ_BIT(7),
+    Help = EZ_BIT(8),
 
     Default = Project | File | Panels | Tools | Help
   };
@@ -28,6 +29,7 @@ struct ezStandardMenuTypes
     StorageType Edit : 1;
     StorageType Panels : 1;
     StorageType Scene : 1;
+    StorageType Asset : 1;
     StorageType View : 1;
     StorageType Tools : 1;
     StorageType Help : 1;
@@ -50,6 +52,7 @@ public:
   static ezActionDescriptorHandle s_hMenuEdit;
   static ezActionDescriptorHandle s_hMenuPanels;
   static ezActionDescriptorHandle s_hMenuScene;
+  static ezActionDescriptorHandle s_hMenuAsset;
   static ezActionDescriptorHandle s_hMenuView;
   static ezActionDescriptorHandle s_hMenuTools;
   static ezActionDescriptorHandle s_hMenuHelp;

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/ToolBarActionMapView.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/ToolBarActionMapView.cpp
@@ -102,7 +102,10 @@ void ezQtToolBarActionMapView::CreateView(const ezActionMap::TreeNode* pObject)
         pButton->setPopupMode(QToolButton::ToolButtonPopupMode::InstantPopup);
         pButton->setText(pQtMenu->title());
         pButton->setIcon(ezQtUiServices::GetCachedIconResource(pNamed->GetIconPath()));
-        pButton->setToolTip(pQtMenu->title().toUtf8().data());
+        pButton->setToolTip(pQtMenu->toolTip());
+
+        pNamed->m_StatusUpdateEvent.AddEventHandler([=](ezAction* pAction)
+          { pButton->setIcon(ezQtUiServices::GetCachedIconResource(pNamed->GetIconPath())); });
 
         // TODO addWidget return value of QAction leaks!
         QAction* pToolButtonAction = addWidget(pButton);

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/QtProxy.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/QtProxy.moc.h
@@ -90,6 +90,9 @@ public:
 
   virtual QMenu* GetQMenu();
 
+private:
+  void StatusUpdateEventHandler(ezAction* pAction);
+
 protected:
   QMenu* m_pMenu;
 };
@@ -147,9 +150,6 @@ public:
 
 private Q_SLOTS:
   void OnTriggered();
-
-private:
-  void StatusUpdateEventHandler(ezAction* pAction);
 
 private:
   QPointer<QAction> m_pQtAction;

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -29,6 +29,7 @@ G.File;&File
 G.Edit;E&dit
 G.Panels;P&anels
 G.Scene;&Scene
+G.Asset;&Asset
 G.Tools;&Tools
 G.View;&View
 G.Help;&Help
@@ -182,6 +183,9 @@ ezCoreRenderProfileConfig;Rendering Options
 # Gizmo
 
 G.Gizmos;Edit Mode
+Gizmo.Translation.Snap.Dropdown;Position Snapping;Position Snapping: Hold SHIFT while dragging gizmo for no snapping.
+Gizmo.Rotation.Snap.Dropdown;Rotation Snapping;Rotation Snapping: Hold SHIFT while dragging gizmo for no snapping.
+Gizmo.Scale.Snap.Dropdown;Scale Snapping;Scale Snapping: Hold SHIFT while dragging gizmo for no snapping.
 Gizmo.Mode.Select;Select
 Gizmo.Mode.Translate;Translate
 Gizmo.Mode.Rotate;Rotate
@@ -190,21 +194,15 @@ Gizmo.Mode.DragToPosition;Drag To Position
 Gizmo.Mode.GreyBoxing;Grey-Boxing
 Gizmo.TransformSpace;Transform in World Space
 Gizmo.MoveParentOnly;Transform Parent Only
-Gizmo.Rotation.Snap.Menu;Rotation Snap
 Gizmo.Rotation.Snap.0_Degree;No Rotation Snap
 Gizmo.Rotation.Snap.1_Degree;1 Degree
 Gizmo.Rotation.Snap.5_Degree;5 Degree
 Gizmo.Rotation.Snap.10_Degree;10 Degree
 Gizmo.Rotation.Snap.15_Degree;15 Degree
 Gizmo.Rotation.Snap.30_Degree;30 Degree
-Gizmo.Rotation.Snap.2_8125_Degree;2.8125 Degree (1/128)
-Gizmo.Rotation.Snap.5_625_Degree;5.625 Degree (1/64)
-Gizmo.Rotation.Snap.11_25_Degree;11.25 Degree (1/32)
-Gizmo.Rotation.Snap.22_5_Degree;22.5 Degree (1/16)
-Gizmo.Rotation.Snap.45_Degree;45 Degree (1/8)
-Gizmo.Scale.Snap.Menu;Scaling Snap
+Gizmo.Rotation.Snap.22_5_Degree;22.5 Degree
+Gizmo.Rotation.Snap.45_Degree;45 Degree
 Gizmo.Scale.Snap.0;No Scale Snap
-Gizmo.Scale.Snap.8;8
 Gizmo.Scale.Snap.4;4
 Gizmo.Scale.Snap.2;2
 Gizmo.Scale.Snap.1;1
@@ -215,7 +213,6 @@ Gizmo.Translate.Snap.Menu;Position Snap
 Gizmo.Translate.Snap.PivotToGrid;Snap Pivot To Grid
 Gizmo.Translate.Snap.ObjectsToGrid;Snap Each Object To Grid
 Gizmo.Translate.Snap.0;No Position Snap
-Gizmo.Translate.Snap.16;16m
 Gizmo.Translate.Snap.10;10m
 Gizmo.Translate.Snap.8;8 m
 Gizmo.Translate.Snap.5;5 m
@@ -228,6 +225,7 @@ Gizmo.Translate.Snap.0_2;20 cm
 Gizmo.Translate.Snap.0_125;12.5 cm
 Gizmo.Translate.Snap.0_1;10 cm
 Gizmo.Translate.Snap.0_05;5 cm
+Gizmo.Translate.Snap.0_01;1 cm
 Gizmo.SnapSettings;Snap Settings
 
 # GameObjectContext


### PR DESCRIPTION
Also added an 'Asset' menu for asset specific actions.
Currently only used by the AngelScript asset.

Toolbar looks like this:
![image](https://github.com/user-attachments/assets/44179ada-8bd0-4c2a-a9a8-d139f8cba11b)

The selected value is shown as the icon:
![image](https://github.com/user-attachments/assets/6d85d613-0086-496f-ae5b-97a1243b59fe)