### PR TITLE
Added ezWorld::SearchForObject()

### DIFF
--- a/Code/EnginePlugins/AngelScriptPlugin/TypeRegistration/AsRegisterTypes_World.cpp
+++ b/Code/EnginePlugins/AngelScriptPlugin/TypeRegistration/AsRegisterTypes_World.cpp
@@ -223,7 +223,6 @@ void ezAngelScriptEngineSingleton::Register_GameObject()
   AS_CHECK(m_pEngine->RegisterObjectMethod("ezGameObject", "ezGameObject@ FindChildByName(const ezTempHashedString& in sName, bool bRecursive = true)", asMETHOD(ezGameObject, FindChildByName), asCALL_THISCALL));
   AS_CHECK(m_pEngine->RegisterObjectMethod("ezGameObject", "ezGameObject@ FindChildByPath(ezStringView sPath)", asMETHOD(ezGameObject, FindChildByPath), asCALL_THISCALL));
   // AS_CHECK(m_pEngine->RegisterObjectMethod("ezGameObject", "ezGameObject@ SearchForChildByNameSequence(string)", asMETHOD(ezGameObject, SearchForChildByNameSequence), asCALL_THISCALL));
-  // AS_CHECK(m_pEngine->RegisterObjectMethod("ezGameObject", "ezGameObject@ SearchForChildrenByNameSequence(string)", asMETHOD(ezGameObject, SearchForChildrenByNameSequence), asCALL_THISCALL));
   AS_CHECK(m_pEngine->RegisterObjectMethod("ezGameObject", "ezWorld@ GetWorld()", asMETHODPR(ezGameObject, GetWorld, (), ezWorld*), asCALL_THISCALL));
   AS_CHECK(m_pEngine->RegisterObjectMethod("ezGameObject", "const ezWorld@ GetWorld() const", asMETHODPR(ezGameObject, GetWorld, () const, const ezWorld*), asCALL_THISCALL));
 
@@ -431,6 +430,8 @@ void ezAngelScriptEngineSingleton::Register_World()
 
   AS_CHECK(m_pEngine->RegisterObjectMethod("ezWorld", "bool TryGetObjectWithGlobalKey(const ezTempHashedString& in sGlobalKey, ezGameObject@& out pObject)", asMETHODPR(ezWorld, TryGetObjectWithGlobalKey, (const ezTempHashedString& sGlobalKey, ezGameObject*& out_pObject), bool), asCALL_THISCALL));
   AS_CHECK(m_pEngine->RegisterObjectMethod("ezWorld", "bool TryGetObjectWithGlobalKey(const ezTempHashedString& in sGlobalKey, const ezGameObject@& out pObject)", asMETHODPR(ezWorld, TryGetObjectWithGlobalKey, (const ezTempHashedString& sGlobalKey, const ezGameObject*& out_pObject) const, bool), asCALL_THISCALL));
+
+  AS_CHECK(m_pEngine->RegisterObjectMethod("ezWorld", "ezGameObject@ SearchForObject(ezStringView sSearchPath, ezGameObject@ pStartSearchObj = null, const ezRTTI@ pExpectedComponent = null)", asMETHOD(ezWorld, SearchForObject), asCALL_THISCALL));
 
   // GetOrCreateModule
 

--- a/Code/UnitTests/CoreTest/World/WorldTest.cpp
+++ b/Code/UnitTests/CoreTest/World/WorldTest.cpp
@@ -198,6 +198,23 @@ namespace
   EZ_END_DYNAMIC_REFLECTED_TYPE;
   EZ_IMPLEMENT_WORLD_MODULE(VelocityTestModule);
   // clang-format on
+
+  ezGameObject* CreateObj(ezWorld* pWorld, ezStringView name, ezGameObject* pParent = nullptr, ezStringView globalkey = {})
+  {
+    ezGameObjectDesc gd;
+    gd.m_sName.Assign(name);
+    gd.m_hParent = pParent ? pParent->GetHandle() : ezGameObjectHandle();
+
+    ezGameObject* go;
+    pWorld->CreateObject(gd, go);
+
+    if (!globalkey.IsEmpty())
+    {
+      go->SetGlobalKey(globalkey);
+    }
+
+    return go;
+  }
 } // namespace
 
 class ezGameObjectTest
@@ -595,6 +612,7 @@ EZ_CREATE_SIMPLE_TEST(World, World)
     EZ_TEST_BOOL(world2.IsValidObject(hObj2));
 
     ezGameObject* pObj1 = nullptr;
+    const ezGameObject* pObjConst = nullptr;
     EZ_TEST_BOOL(world1.TryGetObject(hObj1, pObj1));
     EZ_TEST_BOOL(pObj1 != nullptr);
 
@@ -603,6 +621,8 @@ EZ_CREATE_SIMPLE_TEST(World, World)
     EZ_TEST_BOOL(world1.TryGetObjectWithGlobalKey(ezTempHashedString("Obj1"), pObj1));
     EZ_TEST_BOOL(!world1.TryGetObjectWithGlobalKey(ezTempHashedString("Obj2"), pObj1));
     EZ_TEST_BOOL(pObj1 != nullptr);
+    EZ_TEST_BOOL(world1.TryGetObjectWithGlobalKey(ezTempHashedString("Obj1"), pObjConst));
+    EZ_TEST_BOOL(pObj1 == pObjConst);
 
     ezGameObject* pObj2 = nullptr;
     EZ_TEST_BOOL(world2.TryGetObject(hObj2, pObj2));
@@ -771,4 +791,58 @@ EZ_CREATE_SIMPLE_TEST(World, World)
     }
   }
 #endif
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SearchForObject")
+  {
+    ezWorldDesc worldDesc("Test");
+    ezWorld world(worldDesc);
+    EZ_LOCK(world.GetWriteMarker());
+
+    auto pKey1 = CreateObj(&world, "Key1", nullptr, "Key1");
+    auto pKey2 = CreateObj(&world, "Key2", nullptr, "Key2");
+    auto pKey3 = CreateObj(&world, "Key3", nullptr, "Key3");
+
+    auto pA1 = CreateObj(&world, "A", pKey1);
+    auto pB1 = CreateObj(&world, "B", pA1);
+    auto pC1 = CreateObj(&world, "C", pB1);
+
+    auto pA2 = CreateObj(&world, "A", pKey2, "A2");
+    auto pB2 = CreateObj(&world, "B", pA2, "B2");
+    auto pC2 = CreateObj(&world, "C", pB2, "C2");
+
+    EZ_TEST_BOOL(world.SearchForObject("G:Key1") == pKey1);
+    EZ_TEST_BOOL(world.SearchForObject("G:Key2") == pKey2);
+    EZ_TEST_BOOL(world.SearchForObject("G:Key3/") == pKey3);
+    EZ_TEST_BOOL(world.SearchForObject("G:key3/") == nullptr); // case sensitive
+    EZ_TEST_BOOL(world.SearchForObject("G:B2") == pB2);
+    EZ_TEST_BOOL(world.SearchForObject("G:none") == nullptr);
+
+    EZ_TEST_BOOL(world.SearchForObject("A", pKey1) == pA1);
+    EZ_TEST_BOOL(world.SearchForObject("B", pKey1) == pB1);
+    EZ_TEST_BOOL(world.SearchForObject("A/B", pKey1) == pB1);
+    EZ_TEST_BOOL(world.SearchForObject("A/C", pKey1) == pC1);
+    EZ_TEST_BOOL(world.SearchForObject("B/C", pA1) == pC1);
+    EZ_TEST_BOOL(world.SearchForObject("A", pA1) == nullptr); // A has to be a child
+
+    EZ_TEST_BOOL(world.SearchForObject("G:A2/C") == pC2);
+
+    EZ_TEST_BOOL(world.SearchForObject("P:A", pC2) == pA2);
+    EZ_TEST_BOOL(world.SearchForObject("P:D", pC2) == nullptr);
+    EZ_TEST_BOOL(world.SearchForObject("P:A/C", pC2) == pC2);
+
+    EZ_TEST_BOOL(world.SearchForObject("", pA1) == pA1);
+    EZ_TEST_BOOL(world.SearchForObject("") == nullptr);
+
+    EZ_TEST_BOOL(world.SearchForObject("G:C2/P:A/B", pKey3) == pB2);
+    EZ_TEST_BOOL(world.SearchForObject("G:C2/P:a/B", pKey3) == nullptr);  // case sensitive
+    EZ_TEST_BOOL(world.SearchForObject("G:C2/P:A//B", pKey3) == nullptr); // malformed path
+
+    EZ_TEST_BOOL(world.SearchForObject("..", pC1) == pB1);
+    EZ_TEST_BOOL(world.SearchForObject("../../", pC1) == pA1);
+    EZ_TEST_BOOL(world.SearchForObject("../..", pC1) == pA1);
+
+    EZ_TEST_BOOL(world.SearchForObject("G:C2/P:B/../../A", pKey3) == pA2);
+
+    EZ_TEST_BOOL(world.SearchForObject("G:B2/C/..") == nullptr); // malformed path
+  }
 }

--- a/Code/UnitTests/CoreTest/World/WorldTest.cpp
+++ b/Code/UnitTests/CoreTest/World/WorldTest.cpp
@@ -199,18 +199,18 @@ namespace
   EZ_IMPLEMENT_WORLD_MODULE(VelocityTestModule);
   // clang-format on
 
-  ezGameObject* CreateObj(ezWorld* pWorld, ezStringView name, ezGameObject* pParent = nullptr, ezStringView globalkey = {})
+  ezGameObject* CreateObj(ezWorld* pWorld, ezStringView sName, ezGameObject* pParent = nullptr, ezStringView sGlobalkey = {})
   {
     ezGameObjectDesc gd;
-    gd.m_sName.Assign(name);
+    gd.m_sName.Assign(sName);
     gd.m_hParent = pParent ? pParent->GetHandle() : ezGameObjectHandle();
 
     ezGameObject* go;
     pWorld->CreateObject(gd, go);
 
-    if (!globalkey.IsEmpty())
+    if (!sGlobalkey.IsEmpty())
     {
-      go->SetGlobalKey(globalkey);
+      go->SetGlobalKey(sGlobalkey);
     }
 
     return go;

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/AllDeclarations.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/AllDeclarations.txt
@@ -884,6 +884,7 @@ ezGameObject@ ezGameObject::FindChildByPath(ezStringView sPath)
 ezGameObject@ ezGameObject::GetParent()
 ezGameObject@ ezGameObject::GetParent() const
 ezGameObject@ ezSpatial::FindClosestObjectInSphere(ezStringView Category, ezVec3 Center, float Radius)
+ezGameObject@ ezWorld::SearchForObject(ezStringView sSearchPath, ezGameObject@ pStartSearchObj = null, const ezRTTI@ pExpectedComponent = null)
 ezGameObjectHandle ezBlackboardComponent::GetEntryValue_asGameObjectHandle(ezString Name) const
 ezGameObjectHandle ezCVar::GetValue_asGameObjectHandle(ezStringView Name)
 ezGameObjectHandle ezGameObject::GetHandle() const

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/Methods.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/Methods.txt
@@ -285,6 +285,7 @@ Rotate
 ScaleRGB
 ScaleRGBA
 ScheduleSpawn
+SearchForObject
 SendEventMessage
 SendMessage
 SendMessageRecursive

--- a/Data/Samples/Testing Chambers/as.predefined
+++ b/Data/Samples/Testing Chambers/as.predefined
@@ -1297,6 +1297,7 @@ class ezWorld
   bool TryGetObject(const ezGameObjectHandle&in, const ezGameObject@&out pObject) const;
   bool TryGetObjectWithGlobalKey(const ezTempHashedString&in sGlobalKey, ezGameObject@&out pObject);
   bool TryGetObjectWithGlobalKey(const ezTempHashedString&in sGlobalKey, const ezGameObject@&out pObject);
+  ezGameObject@ SearchForObject(ezStringView sSearchPath, ezGameObject@ pStartSearchObj = null, const ezRTTI@ pExpectedComponent = null);
   bool IsValidComponent(ezComponentHandle&in);
   bool TryGetComponent(const ezComponentHandle&in hComponent, ?&out component);
   void SendMessage(const ezGameObjectHandle&in hReceiverObject, ezMessage&inout msg);

--- a/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/AllDeclarations.txt
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/AllDeclarations.txt
@@ -74,7 +74,6 @@ bool ezGameObjectHandle::IsInvalidated() const
 bool ezGameObjectHandle::opEquals(ezGameObjectHandle) const
 bool ezGrabbableItemComponent::get_DebugShowPoints() const
 bool ezGreyBoxComponent::get_GenerateCollision() const
-bool ezGreyBoxComponent::get_IncludeInNavmesh() const
 bool ezGreyBoxComponent::get_SlopedBottom() const
 bool ezGreyBoxComponent::get_SlopedTop() const
 bool ezGreyBoxComponent::get_UseAsOccluder() const
@@ -102,7 +101,6 @@ bool ezJoltHitboxComponent::get_QueryShapeOnly() const
 bool ezJoltRagdollComponent::get_SelfCollision() const
 bool ezJoltRopeComponent::get_ContinuousCollisionDetection() const
 bool ezJoltRopeComponent::get_SelfCollision() const
-bool ezJoltStaticActorComponent::get_IncludeInNavmesh() const
 bool ezJoltStaticActorComponent::get_PullSurfacesFromGraphicsMesh() const
 bool ezLensFlareComponent::get_ApplyFog() const
 bool ezLensFlareComponent::get_LinkToLightShape() const
@@ -132,7 +130,7 @@ bool ezPathComponent::get_Closed() const
 bool ezPhysics::OverlapTestCapsule(float Radius, float Height, ezTransform Transform, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3))
 bool ezPhysics::OverlapTestLine(ezVec3 Start, ezVec3 End, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3), uint IgnoreObjectID = 4294967295)
 bool ezPhysics::OverlapTestSphere(float Radius, ezVec3 Position, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3))
-bool ezPhysics::Raycast(ezVec3&out HitPosition, ezVec3&out HitNormal, ezGameObjectHandle&out HitObject, ezVec3 Start, ezVec3 Direction, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes, uint IgnoreObjectID = 3)
+bool ezPhysics::Raycast(ezVec3&out HitPosition, ezVec3&out HitNormal, ezGameObjectHandle&out HitObject, ezVec3 Start, ezVec3 Direction, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3), uint IgnoreObjectID = 4294967295)
 bool ezPhysics::RaycastSurfaceInteraction(ezVec3 RayStart, ezVec3 RayDirection, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes, ezStringView FallbackSurface, ezTempHashedString Interaction, float Impulse = 0, uint IgnoreObjectID = 4294967295)
 bool ezPhysics::SweepTestCapsule(ezVec3&out HitPosition, ezVec3&out HitNormal, ezGameObjectHandle&out HitObject, float Radius, float Height, ezTransform Start, ezVec3 Direction, float Distance, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3))
 bool ezPhysics::SweepTestSphere(ezVec3&out HitPosition, ezVec3&out HitNormal, ezGameObjectHandle&out HitObject, float Radius, ezVec3 Start, ezVec3 Direction, float Distance, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3))
@@ -776,6 +774,7 @@ ezGameObject@ ezGameObject::FindChildByPath(ezStringView sPath)
 ezGameObject@ ezGameObject::GetParent()
 ezGameObject@ ezGameObject::GetParent() const
 ezGameObject@ ezSpatial::FindClosestObjectInSphere(ezStringView Category, ezVec3 Center, float Radius)
+ezGameObject@ ezWorld::SearchForObject(ezStringView sSearchPath, ezGameObject@ pStartSearchObj = null, const ezRTTI@ pExpectedComponent = null)
 ezGameObjectHandle ezBlackboardComponent::GetEntryValue_asGameObjectHandle(ezString Name) const
 ezGameObjectHandle ezCVar::GetValue_asGameObjectHandle(ezStringView Name)
 ezGameObjectHandle ezGameObject::GetHandle() const
@@ -2161,7 +2160,6 @@ void ezGreyBoxComponent::set_Curvature(ezAngle)
 void ezGreyBoxComponent::set_CustomData(ezVec4)
 void ezGreyBoxComponent::set_Detail(uint)
 void ezGreyBoxComponent::set_GenerateCollision(bool)
-void ezGreyBoxComponent::set_IncludeInNavmesh(bool)
 void ezGreyBoxComponent::set_Material(ezStringView)
 void ezGreyBoxComponent::set_Shape(ezGreyBoxShape)
 void ezGreyBoxComponent::set_SizeNegX(float)
@@ -2315,7 +2313,6 @@ void ezJoltSliderConstraintComponent::set_LimitMode(ezJoltConstraintLimitMode)
 void ezJoltSliderConstraintComponent::set_LowerLimit(float)
 void ezJoltSliderConstraintComponent::set_UpperLimit(float)
 void ezJoltStaticActorComponent::set_CollisionMesh(ezStringView)
-void ezJoltStaticActorComponent::set_IncludeInNavmesh(bool)
 void ezJoltStaticActorComponent::set_PullSurfacesFromGraphicsMesh(bool)
 void ezJoltStaticActorComponent::set_Surface(ezStringView)
 void ezJoltSwingTwistConstraintComponent::set_Friction(float)

--- a/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/Methods.txt
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/Methods.txt
@@ -271,6 +271,7 @@ Rotate
 ScaleRGB
 ScaleRGBA
 ScheduleSpawn
+SearchForObject
 SendEventMessage
 SendMessage
 SendMessageRecursive

--- a/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/Properties.txt
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/Properties.txt
@@ -187,7 +187,6 @@ HotPink
 ISO
 ImpactDirection
 Impulse
-IncludeInNavmesh
 IndianRed
 Indigo
 InfluenceScale

--- a/Data/UnitTests/GameEngineTest/AngelScript/Tests/GameObjectTest.as
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Tests/GameObjectTest.as
@@ -111,6 +111,9 @@ class ScriptObject : ezAngelScriptTestClass
             ezGameObject@ skybox;
             EZ_TEST_BOOL(GetWorld().TryGetObjectWithGlobalKey("Skybox", skybox));
 
+            ezGameObject@ skybox2 = GetWorld().SearchForObject("G:Skybox");
+            EZ_TEST_BOOL(@skybox == @skybox2);
+
             ezSkyBoxComponent@ skyboxComp;
             EZ_TEST_BOOL(skybox.TryGetComponentOfBaseType(@skyboxComp));
 

--- a/Data/UnitTests/GameEngineTest/AngelScript/as.predefined
+++ b/Data/UnitTests/GameEngineTest/AngelScript/as.predefined
@@ -1217,6 +1217,7 @@ class ezWorld
   bool TryGetObject(const ezGameObjectHandle&in, const ezGameObject@&out pObject) const;
   bool TryGetObjectWithGlobalKey(const ezTempHashedString&in sGlobalKey, ezGameObject@&out pObject);
   bool TryGetObjectWithGlobalKey(const ezTempHashedString&in sGlobalKey, const ezGameObject@&out pObject);
+  ezGameObject@ SearchForObject(ezStringView sSearchPath, ezGameObject@ pStartSearchObj = null, const ezRTTI@ pExpectedComponent = null);
   bool IsValidComponent(ezComponentHandle&in);
   bool TryGetComponent(const ezComponentHandle&in hComponent, ?&out component);
   void SendMessage(const ezGameObjectHandle&in hReceiverObject, ezMessage&inout msg);
@@ -2013,7 +2014,6 @@ class ezGreyBoxComponent : ezRenderComponent
   bool SlopedTop;
   bool SlopedBottom;
   bool GenerateCollision;
-  bool IncludeInNavmesh;
   bool UseAsOccluder;
 }
 
@@ -2209,7 +2209,6 @@ class ezJoltQueryShapeActorComponent : ezJoltActorComponent
 class ezJoltStaticActorComponent : ezJoltActorComponent
 {
   ezStringView CollisionMesh;
-  bool IncludeInNavmesh;
   bool PullSurfacesFromGraphicsMesh;
   ezStringView Surface;
 }
@@ -2941,7 +2940,7 @@ namespace ezPhysics
 {
   ezVec3 GetGravity();
   uint8 GetCollisionLayerByName(ezStringView Name);
-  bool Raycast(ezVec3&out HitPosition, ezVec3&out HitNormal, ezGameObjectHandle&out HitObject, ezVec3 Start, ezVec3 Direction, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes, uint IgnoreObjectID = 3);
+  bool Raycast(ezVec3&out HitPosition, ezVec3&out HitNormal, ezGameObjectHandle&out HitObject, ezVec3 Start, ezVec3 Direction, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3), uint IgnoreObjectID = 4294967295);
   bool OverlapTestLine(ezVec3 Start, ezVec3 End, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3), uint IgnoreObjectID = 4294967295);
   bool OverlapTestSphere(float Radius, ezVec3 Position, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3));
   bool OverlapTestCapsule(float Radius, float Height, ezTransform Transform, uint8 CollisionLayer, ezPhysicsShapeType ShapeTypes = ezPhysicsShapeType(3));


### PR DESCRIPTION
This is a feature for conveniently searching for objects, either relative to some reference object, or through a global key (and then relative to that).

The search path allows to search both upwards (towards a named parent) and downwards through a series of named children.

Optionally, it also only finds objects with a specific component type.

Documentation:
https://ezengine.net/pages/docs/concepts/object-paths.html