### PR TITLE
Wait for layers to be loaded before export

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -114,9 +114,17 @@ ezResult ezProcessCommunicationChannel::WaitForMessage(const ezRTTI* pMessageTyp
 
       if (tTimeLeft < ezTime::MakeZero())
       {
-        m_pWaitForMessageType = nullptr;
-        ezLog::Dev("Reached time-out of {0} seconds while waiting for {1}", ezArgF(timeout.GetSeconds(), 1), pMessageType->GetTypeName());
-        return EZ_FAILURE;
+        // Don't time out if a debugger is attached to make stepping easier.
+        if (ezSystemInformation::IsDebuggerAttached())
+        {
+          tTimeLeft = ezTime::MakeFromSeconds(1);
+        }
+        else
+        {
+          m_pWaitForMessageType = nullptr;
+          ezLog::Dev("Reached time-out of {0} seconds while waiting for {1}", ezArgF(timeout.GetSeconds(), 1), pMessageType->GetTypeName());
+          return EZ_FAILURE;
+        }
       }
 
       m_pProtocol->WaitForMessages(tTimeLeft).IgnoreResult();

--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -117,6 +117,8 @@ public:
 
   /// \brief Returns the current state of the engine process side of this document.
   EngineStatus GetEngineStatus() const { return m_EngineStatus; }
+  /// \brief Waits for GetEngineStatus to return Loaded or returns a failure reason.
+  ezStatus WaitForEngineStatusLoaded() const;
 
   /// \brief Passed into ezEngineProcessDocumentContext::Initialize on the engine process side. Allows the document to provide additional data to the engine process during context creation.
   virtual ezVariant GetCreateEngineMetaData() const { return ezVariant(); }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -699,9 +699,7 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
 
   ezLog::Info("Exporting {0} to \"{1}\"", GetDocumentTypeName(), szOutputTarget);
 
-  ezStatus loadResult = WaitForEngineStatusLoaded();
-  if (loadResult.Failed())
-    return loadResult;
+  EZ_SUCCEED_OR_RETURN(WaitForEngineStatusLoaded());
 
   range.BeginNextStep(szOutputTarget);
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -699,18 +699,9 @@ ezStatus ezAssetDocument::RemoteExport(const ezAssetFileHeader& header, const ch
 
   ezLog::Info("Exporting {0} to \"{1}\"", GetDocumentTypeName(), szOutputTarget);
 
-  if (GetEngineStatus() == ezAssetDocument::EngineStatus::Disconnected)
-  {
-    return ezStatus(ezFmt("Exporting {0} to \"{1}\" failed, engine not started or crashed.", GetDocumentTypeName(), szOutputTarget));
-  }
-  else if (GetEngineStatus() == ezAssetDocument::EngineStatus::Initializing)
-  {
-    if (ezEditorEngineProcessConnection::GetSingleton()->WaitForDocumentMessage(GetGuid(), ezDocumentOpenResponseMsgToEditor::GetStaticRTTI(), ezTime::MakeFromSeconds(10)).Failed())
-    {
-      return ezStatus(ezFmt("Exporting {0} to \"{1}\" failed, document initialization timed out.", GetDocumentTypeName(), szOutputTarget));
-    }
-    EZ_ASSERT_DEV(GetEngineStatus() == ezAssetDocument::EngineStatus::Loaded, "After receiving ezDocumentOpenResponseMsgToEditor, the document should be in loaded state.");
-  }
+  ezStatus loadResult = WaitForEngineStatusLoaded();
+  if (loadResult.Failed())
+    return loadResult;
 
   range.BeginNextStep(szOutputTarget);
 
@@ -824,6 +815,24 @@ ezStatus ezAssetDocument::RemoteCreateThumbnail(const ThumbnailInfo& thumbnailIn
 ezUInt16 ezAssetDocument::GetAssetTypeVersion() const
 {
   return (ezUInt16)GetDynamicRTTI()->GetTypeVersion();
+}
+
+
+ezStatus ezAssetDocument::WaitForEngineStatusLoaded() const
+{
+  if (GetEngineStatus() == ezAssetDocument::EngineStatus::Disconnected)
+  {
+    return ezStatus(ezFmt("Loading {0} document '{1}' failed, engine not started or crashed.", GetDocumentTypeName(), GetDocumentPath()));
+  }
+  else if (GetEngineStatus() == ezAssetDocument::EngineStatus::Initializing)
+  {
+    if (ezEditorEngineProcessConnection::GetSingleton()->WaitForDocumentMessage(GetGuid(), ezDocumentOpenResponseMsgToEditor::GetStaticRTTI(), {}).Failed())
+    {
+      return ezStatus(ezFmt("Loading {0} document '{1}' failed, document initialization timed out or engine crashed.", GetDocumentTypeName(), GetDocumentPath()));
+    }
+    EZ_ASSERT_DEV(GetEngineStatus() == ezAssetDocument::EngineStatus::Loaded, "After receiving ezDocumentOpenResponseMsgToEditor, the document should be in loaded state.");
+  }
+  return ezStatus(EZ_SUCCESS);
 }
 
 bool ezAssetDocument::SendMessageToEngine(ezEditorEngineDocumentMsg* pMessage /*= false*/) const

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.cpp
@@ -22,11 +22,6 @@ void ezLayerDocument::InitializeAfterLoading(bool bFirstTimeCreation)
   SUPER::InitializeAfterLoading(bFirstTimeCreation);
 }
 
-void ezLayerDocument::InitializeAfterLoadingAndSaving()
-{
-  SUPER::InitializeAfterLoadingAndSaving();
-}
-
 ezVariant ezLayerDocument::GetCreateEngineMetaData() const
 {
   return m_pHostDocument->GetGuid();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/LayerDocument.h
@@ -13,7 +13,5 @@ public:
   ~ezLayerDocument();
 
   virtual void InitializeAfterLoading(bool bFirstTimeCreation) override;
-  virtual void InitializeAfterLoadingAndSaving() override;
-
   virtual ezVariant GetCreateEngineMetaData() const override;
 };

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -236,7 +236,7 @@ void ezScene2Document::SendGameWorldToEngine()
   }
 }
 
-ezTransformStatus ezScene2Document::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+ezTransformStatus ezScene2Document::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& assetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   // We need to wait for layers to be fully loaded before we can transform, i.e. export, a scene.
   ezStatus sceneRes = WaitForEngineStatusLoaded();
@@ -252,7 +252,7 @@ ezTransformStatus ezScene2Document::InternalTransformAsset(const char* szTargetF
     if (layerRes.Failed())
       return layerRes;
   }
-  return SUPER::InternalTransformAsset(szTargetFile, sOutputTag, pAssetProfile, AssetHeader, transformFlags);
+  return SUPER::InternalTransformAsset(szTargetFile, sOutputTag, pAssetProfile, assetHeader, transformFlags);
 }
 
 void ezScene2Document::PreventDoubleSelectionChange(bool b)

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -236,6 +236,25 @@ void ezScene2Document::SendGameWorldToEngine()
   }
 }
 
+ezTransformStatus ezScene2Document::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags)
+{
+  // We need to wait for layers to be fully loaded before we can transform, i.e. export, a scene.
+  ezStatus sceneRes = WaitForEngineStatusLoaded();
+  if (sceneRes.Failed())
+    return sceneRes;
+
+  ezHybridArray<ezSceneDocument*, 4> layers;
+  GetLoadedLayers(layers);
+
+  for (ezSceneDocument* pLayer : layers)
+  {
+    ezStatus layerRes = pLayer->WaitForEngineStatusLoaded();
+    if (layerRes.Failed())
+      return layerRes;
+  }
+  return SUPER::InternalTransformAsset(szTargetFile, sOutputTag, pAssetProfile, AssetHeader, transformFlags);
+}
+
 void ezScene2Document::PreventDoubleSelectionChange(bool b)
 {
   m_iAllowSelectionChanges = b ? 1 : -1;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -239,18 +239,14 @@ void ezScene2Document::SendGameWorldToEngine()
 ezTransformStatus ezScene2Document::InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& assetHeader, ezBitflags<ezTransformFlags> transformFlags)
 {
   // We need to wait for layers to be fully loaded before we can transform, i.e. export, a scene.
-  ezStatus sceneRes = WaitForEngineStatusLoaded();
-  if (sceneRes.Failed())
-    return sceneRes;
+  EZ_SUCCEED_OR_RETURN(WaitForEngineStatusLoaded());
 
   ezHybridArray<ezSceneDocument*, 4> layers;
   GetLoadedLayers(layers);
 
   for (ezSceneDocument* pLayer : layers)
   {
-    ezStatus layerRes = pLayer->WaitForEngineStatusLoaded();
-    if (layerRes.Failed())
-      return layerRes;
+    EZ_SUCCEED_OR_RETURN(pLayer->WaitForEngineStatusLoaded());
   }
   return SUPER::InternalTransformAsset(szTargetFile, sOutputTag, pAssetProfile, assetHeader, transformFlags);
 }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
@@ -120,6 +120,8 @@ public:
   virtual void HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg) override;
   virtual ezTaskGroupID InternalSaveDocument(AfterSaveCallback callback) override;
   virtual void SendGameWorldToEngine() override;
+  virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
+    const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ///@}
   /// \name Selection Specific Functions

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
@@ -121,7 +121,7 @@ public:
   virtual ezTaskGroupID InternalSaveDocument(AfterSaveCallback callback) override;
   virtual void SendGameWorldToEngine() override;
   virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
-    const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+    const ezAssetFileHeader& assetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   ///@}
   /// \name Selection Specific Functions


### PR DESCRIPTION
* Overloaded `ezScene2Document::InternalTransformAsset` to wait for layers and scene to be fully loaded before exporting. Fixes #1507.
* Don't timeout in `ezProcessCommunicationChannel::WaitForMessage` if a debugger is attached.