### PR TITLE
CreateResource is no longer run under the resource manager lock

### DIFF
--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -16,8 +16,8 @@ void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHig
   if (s_pState->m_bShutdown)
     return;
 
-  // Runtime created resources are not loaded via tasks but created on the stack directly.
-  if (pResource->GetBaseResourceFlags().IsSet(ezResourceFlags::IsCreatedResource))
+  // Runtime created resources without loaders are not loaded via tasks but created on the stack directly.
+  if (pResource->GetBaseResourceFlags().IsSet(ezResourceFlags::IsCreatedResource) && !pResource->GetBaseResourceFlags().IsSet(ezResourceFlags::HasCustomDataLoader))
     return;
 
   EZ_LOCK(s_ResourceMutex);

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -27,6 +27,10 @@ void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHig
     return;
   }
 
+  // Runtime created resources are not loaded via tasks but created on the stack directly.
+  if (pResource->GetBaseResourceFlags().IsSet(ezResourceFlags::IsCreatedResource))
+    return;
+
   EZ_PROFILE_SCOPE("InternalPreloadResource");
 
   EZ_ASSERT_DEV(!s_pState->m_bExportMode, "Resources should not be loaded in export mode");

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceLoading.cpp
@@ -16,6 +16,10 @@ void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHig
   if (s_pState->m_bShutdown)
     return;
 
+  // Runtime created resources are not loaded via tasks but created on the stack directly.
+  if (pResource->GetBaseResourceFlags().IsSet(ezResourceFlags::IsCreatedResource))
+    return;
+
   EZ_LOCK(s_ResourceMutex);
 
   // if there is nothing else that could be loaded, just return right away
@@ -26,10 +30,6 @@ void ezResourceManager::InternalPreloadResource(ezResource* pResource, bool bHig
     // pResource->GetDynamicRTTI()->GetTypeName());
     return;
   }
-
-  // Runtime created resources are not loaded via tasks but created on the stack directly.
-  if (pResource->GetBaseResourceFlags().IsSet(ezResourceFlags::IsCreatedResource))
-    return;
 
   EZ_PROFILE_SCOPE("InternalPreloadResource");
 

--- a/Code/Engine/Core/ResourceManager/ResourceManager.h
+++ b/Code/Engine/Core/ResourceManager/ResourceManager.h
@@ -38,8 +38,7 @@ public:
   ///@{
 
 public:
-  /// \brief Returns a handle to the requested resource. szResourceID must uniquely identify the resource, different spellings / casing
-  /// will result in different resources.
+  /// \brief Returns a handle to the requested resource. szResourceID must uniquely identify the resource, different spellings / casing will result in different resources.
   ///
   /// After the call to this function the resource definitely exists in memory. Upon access through BeginAcquireResource / ezResourceLock
   /// the resource will be loaded. If it is not possible to load the resource it will change to a 'missing' state. If the code accessing the
@@ -47,13 +46,10 @@ public:
   template <typename ResourceType>
   static ezTypedResourceHandle<ResourceType> LoadResource(ezStringView sResourceID);
 
-  /// \brief Same as LoadResource(), but additionally allows to set a priority on the resource and a custom fallback resource for this
+  /// \brief Same as LoadResource(), but additionally allows to set a custom fallback resource for this
   /// instance.
   ///
-  /// Pass in ezResourcePriority::Unchanged, if you only want to specify a custom fallback resource.
-  /// If a resource priority is specified, the target resource will get that priority.
-  /// If a valid fallback resource is specified, the resource will store that as its instance specific fallback resource. This will be used
-  /// when trying to acquire the resource later.
+  /// If a valid fallback resource is specified, the resource will store that as its instance specific fallback resource. This will be used when trying to acquire the resource later.
   template <typename ResourceType>
   static ezTypedResourceHandle<ResourceType> LoadResource(ezStringView sResourceID, ezTypedResourceHandle<ResourceType> hLoadingFallback);
 
@@ -115,8 +111,7 @@ public:
 
   static ezTypelessResourceHandle GetExistingResourceOrCreateAsync(const ezRTTI* pResourceType, ezStringView sResourceID, ezUniquePtr<ezResourceTypeLoader>&& pLoader);
 
-  /// \brief Triggers loading of the given resource. tShouldBeAvailableIn specifies how long the resource is not yet needed, thus allowing
-  /// other resources to be loaded first. This is only a hint and there are no guarantees when the resource is available.
+  /// \brief Triggers loading of the given resource.
   static void PreloadResource(const ezTypelessResourceHandle& hResource);
 
   /// \brief Similar to locking a resource with 'BlockTillLoaded' acquire mode, but can be done with a typeless handle and does not return a result.
@@ -465,6 +460,9 @@ private:
   static void EnsureResourceLoadingState(ezResource* pResource, const ezResourceState RequestedState);
   static void PreloadResource(ezResource* pResource);
   static void InternalPreloadResource(ezResource* pResource, bool bHighestPriority);
+
+  template <typename ResourceType, typename DescriptorType>
+  static ezTypedResourceHandle<ResourceType> CreateResourceInternal(ezStringView sResourceID, DescriptorType&& descriptor, ezStringView sResourceDescription, bool bAllowGetFallback);
 
   template <typename ResourceType>
   static ResourceType* GetResource(ezStringView sResourceID, bool bIsReloadable);

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -105,7 +105,10 @@ namespace ezInternal
 
     m_Clock.SetTimeStepSmoothing(m_pTimeStepSmoothing.Borrow());
 
+    // BEGIN-DOCS-CODE-SNIPPET: resource-management-listen-all
+    // Listening to all resource events
     ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&WorldData::ResourceEventHandler, this));
+    // END-DOCS-CODE-SNIPPET
   }
 
   WorldData::~WorldData()

--- a/Code/Engine/Foundation/Containers/IdTable.h
+++ b/Code/Engine/Foundation/Containers/IdTable.h
@@ -91,6 +91,9 @@ public:
   /// \brief Returns the number of active entries in the table.
   IndexType GetCount() const; // [tested]
 
+  /// \brief Returns the capacity of the table.
+  IndexType GetCapacity() const; // [tested]
+
   /// \brief Returns true, if the table does not contain any elements.
   bool IsEmpty() const; // [tested]
 

--- a/Code/Engine/Foundation/Containers/Implementation/IdTable_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/IdTable_inl.h
@@ -171,6 +171,12 @@ EZ_ALWAYS_INLINE typename ezIdTableBase<IdType, ValueType>::IndexType ezIdTableB
 }
 
 template <typename IdType, typename ValueType>
+EZ_ALWAYS_INLINE typename ezIdTableBase<IdType, ValueType>::IndexType ezIdTableBase<IdType, ValueType>::GetCapacity() const
+{
+  return m_Capacity;
+}
+
+template <typename IdType, typename ValueType>
 EZ_ALWAYS_INLINE bool ezIdTableBase<IdType, ValueType>::IsEmpty() const
 {
   return m_Count == 0;

--- a/Code/Engine/Foundation/ezEngine.py
+++ b/Code/Engine/Foundation/ezEngine.py
@@ -300,7 +300,7 @@ class ezArrayPtrSynthProvider:
 
     def update(self):
         try:
-            self.m_ptr = self.valobj.GetChildMemberWithName('m_ptr')
+            self.m_ptr = self.valobj.GetChildMemberWithName('m_pPtr')
             self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
             self.element_type = self.m_ptr.GetType().GetPointeeType()
             self.element_size = self.element_type.GetByteSize()

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -2016,6 +2016,7 @@ void ezDebugRenderer::OnEngineStartup()
   }
 
   {
+    // BEGIN-DOCS-CODE-SNIPPET: resource-management-create
     ezGeometry geom;
     geom.AddBox(ezVec3(2.0f), false);
 
@@ -2024,6 +2025,7 @@ void ezDebugRenderer::OnEngineStartup()
     desc.AllocateStreamsFromGeometry(geom, ezGALPrimitiveTopology::Triangles);
 
     s_hSolidBoxMeshBuffer = ezResourceManager::CreateResource<ezMeshBufferResource>("DebugSolidBox", std::move(desc), "Mesh for Rendering Debug Solid Boxes");
+    // END-DOCS-CODE-SNIPPET
   }
 
   {

--- a/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
+++ b/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Foundation/Types/ScopeExit.h>
+#include <Foundation/Threading/Thread.h>
 
 EZ_CREATE_SIMPLE_TEST_GROUP(ResourceManager);
 
@@ -9,10 +10,16 @@ namespace
 {
   using TestResourceHandle = ezTypedResourceHandle<class TestResource>;
 
+  struct TestResourceDescriptor
+  {
+    ezUInt32 m_uiData = 0;
+  };
+
   class TestResource : public ezResource
   {
     EZ_ADD_DYNAMIC_REFLECTION(TestResource, ezResource);
     EZ_RESOURCE_DECLARE_COMMON_CODE(TestResource);
+    EZ_RESOURCE_DECLARE_CREATEABLE(TestResource, TestResourceDescriptor);
 
   public:
     TestResource()
@@ -81,6 +88,21 @@ namespace
     ezDynamicArray<ezUInt32> m_Data;
   };
 
+  EZ_RESOURCE_IMPLEMENT_CREATEABLE(TestResource, TestResourceDescriptor)
+  {
+    ezResourceLoadDesc res;
+    res.m_State = ezResourceState::Loaded;
+    res.m_uiQualityLevelsDiscardable = 0;
+    res.m_uiQualityLevelsLoadable = 0;
+
+    EZ_TEST_INT(m_Data.GetCount(), 0);
+    m_Data.PushBack(descriptor.m_uiData);
+    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(50));
+    EZ_TEST_INT(m_Data.GetCount(), 1);
+
+    return res;
+  }
+
   class TestResourceTypeLoader : public ezResourceTypeLoader
   {
   public:
@@ -126,6 +148,26 @@ namespace
   EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(TestResource, 1, ezRTTIDefaultAllocator<TestResource>)
   EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+
+  class ResourceTestThread : public ezThread
+  {
+  public:
+    ezDelegate<int()> m_Lambda;
+
+    ResourceTestThread()
+      : ezThread("Resource Test Thread")
+    {
+    }
+
+    virtual ezUInt32 Run()
+    {
+      if (m_Lambda.IsValid())
+      {
+        return m_Lambda();
+      }
+      return 0;
+    }
+  };
 } // namespace
 
 EZ_CREATE_SIMPLE_TEST(ResourceManager, Basics)
@@ -189,6 +231,54 @@ EZ_CREATE_SIMPLE_TEST(ResourceManager, Basics)
     EZ_TEST_INT(ezResourceManager::GetAllResourcesOfType<TestResource>()->GetCount(), 0);
   }
 }
+
+
+EZ_CREATE_SIMPLE_TEST(ResourceManager, ThreadedCreateResource)
+{
+  TestResourceTypeLoader TypeLoader;
+  ezResourceManager::AllowResourceTypeAcquireDuringUpdateContent<TestResource, TestResource>();
+  ezResourceManager::SetResourceTypeLoader<TestResource>(&TypeLoader);
+  EZ_SCOPE_EXIT(ezResourceManager::SetResourceTypeLoader<TestResource>(nullptr));
+
+  auto testLambda = []() -> int
+  {
+    TestResourceDescriptor desc;
+    TestResourceHandle hTest = ezResourceManager::GetOrCreateResource<TestResource>("test1", std::move(desc));
+    {
+      ezResourceLock<TestResource> pTest(hTest, ezResourceAcquireMode::PointerOnly);
+      EZ_TEST_INT((int)pTest.GetAcquireResult(), (int)ezResourceAcquireResult::Final);
+    }
+    EZ_TEST_INT(ezResourceManager::GetAllResourcesOfType<TestResource>()->GetCount(), 1);
+    return 0;
+  };
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ThreadedCreateResource")
+  {
+    ezHybridArray<ezUniquePtr<ResourceTestThread>, 8> threads;
+    for (ezUInt32 i = 0; i < 8; ++i)
+    {
+      ezUniquePtr<ResourceTestThread> thread = EZ_DEFAULT_NEW(ResourceTestThread);
+      thread->m_Lambda = testLambda;
+      threads.PushBack(std::move(thread));
+    }
+
+    EZ_TEST_INT(ezResourceManager::GetAllResourcesOfType<TestResource>()->GetCount(), 0);
+
+    for (ezUInt32 i = 0; i < 8; ++i)
+    {
+      threads[i]->Start();
+    }
+
+    for (ezUInt32 i = 0; i < 8; ++i)
+    {
+      threads[i]->Join();
+    }
+    EZ_TEST_INT(ezResourceManager::GetAllResourcesOfType<TestResource>()->GetCount(), 1);
+
+    threads.Clear();
+  }
+}
+
 
 EZ_CREATE_SIMPLE_TEST(ResourceManager, NestedLoading)
 {

--- a/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
+++ b/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
@@ -1,8 +1,8 @@
 #include <CoreTest/CoreTestPCH.h>
 
 #include <Core/ResourceManager/ResourceManager.h>
-#include <Foundation/Types/ScopeExit.h>
 #include <Foundation/Threading/Thread.h>
+#include <Foundation/Types/ScopeExit.h>
 
 EZ_CREATE_SIMPLE_TEST_GROUP(ResourceManager);
 

--- a/Code/UnitTests/FoundationTest/Containers/IdTableTest.cpp
+++ b/Code/UnitTests/FoundationTest/Containers/IdTableTest.cpp
@@ -23,6 +23,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, IdTable)
     ezIdTable<Id, ezInt32> table;
 
     EZ_TEST_BOOL(table.GetCount() == 0);
+    EZ_TEST_BOOL(table.GetCapacity() == 0);
     EZ_TEST_BOOL(table.IsEmpty());
 
     ezUInt32 counter = 0;
@@ -69,6 +70,10 @@ EZ_CREATE_SIMPLE_TEST(Containers, IdTable)
       EZ_TEST_INT(table1.GetCount(), 100);
       EZ_TEST_INT(table2.GetCount(), 100);
       EZ_TEST_INT(table3.GetCount(), 100);
+
+      EZ_TEST_BOOL(table1.GetCapacity() >= 100);
+      EZ_TEST_BOOL(table2.GetCapacity() >= 100);
+      EZ_TEST_BOOL(table3.GetCapacity() >= 100);
 
       ezUInt32 uiCounter = 0;
       for (ezIdTable<Id, st>::ConstIterator it = table1.GetIterator(); it.IsValid(); ++it)
@@ -162,7 +167,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, IdTable)
       EZ_TEST_BOOL(x.s == y.s);
     }
     EZ_TEST_INT(table.GetCount(), 100);
-
+    ezUInt32 uiCapacity = table.GetCapacity();
     Id ids[10] = {Id(13, 1), Id(0, 1), Id(16, 1), Id(34, 1), Id(56, 1), Id(57, 1), Id(79, 1), Id(85, 1), Id(91, 1), Id(97, 1)};
 
 
@@ -173,7 +178,7 @@ EZ_CREATE_SIMPLE_TEST(Containers, IdTable)
       EZ_TEST_BOOL(!table.Contains(ids[i]));
     }
     EZ_TEST_INT(table.GetCount(), 90);
-
+    EZ_TEST_INT_MSG(table.GetCapacity(), uiCapacity, "Removing items should not decrease capacity");
     for (int i = 0; i < 40; i++)
     {
       TestObject x = {1000, "Bla. This is a very long string which does not fit into 32 byte and will cause memory allocations."};

--- a/Code/UnitTests/TestFramework/Framework/SimpleTest.cpp
+++ b/Code/UnitTests/TestFramework/Framework/SimpleTest.cpp
@@ -3,7 +3,7 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <TestFramework/Framework/TestFramework.h>
 
-EZ_ENUMERABLE_CLASS_IMPLEMENTATION(ezRegisterSimpleTestHelper);
+EZ_ENUMERABLE_CLASS_IMPLEMENTATION(ezRegisterTestHelper);
 
 void ezSimpleTestGroup::AddSimpleTest(const char* szName, SimpleTestFunc testFunc)
 {

--- a/Code/UnitTests/TestFramework/Framework/SimpleTest.h
+++ b/Code/UnitTests/TestFramework/Framework/SimpleTest.h
@@ -36,10 +36,17 @@ private:
   std::deque<SimpleTestEntry> m_SimpleTests;
 };
 
-class EZ_TEST_DLL ezRegisterSimpleTestHelper : public ezEnumerable<ezRegisterSimpleTestHelper>
+class EZ_TEST_DLL ezRegisterTestHelper : public ezEnumerable<ezRegisterTestHelper>
 {
-  EZ_DECLARE_ENUMERABLE_CLASS(ezRegisterSimpleTestHelper);
+  EZ_DECLARE_ENUMERABLE_CLASS(ezRegisterTestHelper);
+public:
+  ezRegisterTestHelper() = default;
+  virtual ~ezRegisterTestHelper() = default;
+  virtual void RegisterTest() = 0;
+};
 
+class EZ_TEST_DLL ezRegisterSimpleTestHelper : public ezRegisterTestHelper
+{
 public:
   ezRegisterSimpleTestHelper(ezSimpleTestGroup* pTestGroup, const char* szTestName, ezSimpleTestGroup::SimpleTestFunc func)
   {
@@ -48,7 +55,7 @@ public:
     m_Func = func;
   }
 
-  void RegisterTest() { m_pTestGroup->AddSimpleTest(m_szTestName, m_Func); }
+  virtual void RegisterTest() override { m_pTestGroup->AddSimpleTest(m_szTestName, m_Func); }
 
 private:
   ezSimpleTestGroup* m_pTestGroup;

--- a/Code/UnitTests/TestFramework/Framework/SimpleTest.h
+++ b/Code/UnitTests/TestFramework/Framework/SimpleTest.h
@@ -39,6 +39,7 @@ private:
 class EZ_TEST_DLL ezRegisterTestHelper : public ezEnumerable<ezRegisterTestHelper>
 {
   EZ_DECLARE_ENUMERABLE_CLASS(ezRegisterTestHelper);
+
 public:
   ezRegisterTestHelper() = default;
   virtual ~ezRegisterTestHelper() = default;

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -249,7 +249,7 @@ void ezTestFramework::GatherAllTests()
 
   // first let all simple tests register themselves
   {
-    ezRegisterSimpleTestHelper* pHelper = ezRegisterSimpleTestHelper::GetFirstInstance();
+    ezRegisterTestHelper* pHelper = ezRegisterTestHelper::GetFirstInstance();
 
     while (pHelper)
     {


### PR DESCRIPTION
This allows for the resource's `CreateResource` function to load other resources without creating a deadlock. As the resource creation calls `ezResourceManager::GetOrCreateResource` and `ezResourceManager::CreateResource` are no longer executed in their entirely under the resource manager lock, special care needs to be taken that other threads that acquire the lock in the meantime don't interfere with the resource creation. The most important part is that `ezResourceManager::LoadResourceByType` ignores resources that have the `ezResourceFlags::IsCreatedResource` flag set.

# Misc changes
* Fixed various comments in the `ResourceManager.h`.
* Expose `GetCapacity()` on the `ezIdTable`.
* Fix `ezArrayPtr` lldb custom visualizer.
* Created a base class to `ezRegisterSimpleTestHelper` called `ezRegisterTestHelper`which allow it to be derived from to write custom simple tests like simple renderer tests etc. without needing to rewrite the registration infrastructure.