### PR TITLE
Added option to extract root motion of animation clips from feet joints

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessDocumentContext.cpp
@@ -149,6 +149,15 @@ void ezEngineProcessDocumentContext::Deinitialize()
 
 void ezEngineProcessDocumentContext::SendProcessMessage(ezProcessMessage* pMsg)
 {
+  if (ezEditorEngineDocumentMsg* pEngineMsg = ezDynamicCast<ezEditorEngineDocumentMsg*>(pMsg))
+  {
+    if (!pEngineMsg->m_DocumentGuid.IsValid())
+    {
+      // automatically fill this out, if it wasn't done by the calling code
+      pEngineMsg->m_DocumentGuid = GetDocumentGuid();
+    }
+  }
+
   m_pIPC->SendMessage(pMsg);
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipActions.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipActions.cpp
@@ -1,0 +1,67 @@
+#include <EditorPluginAssets/EditorPluginAssetsPCH.h>
+
+#include <EditorPluginAssets/AnimationClipAsset/AnimationClipActions.h>
+#include <EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h>
+#include <EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAction, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+ezActionDescriptorHandle ezAnimationClipActions::s_hCategory;
+ezActionDescriptorHandle ezAnimationClipActions::s_hRootMotionFromFeet;
+
+void ezAnimationClipActions::RegisterActions()
+{
+  s_hCategory = EZ_REGISTER_CATEGORY("AnimationClipAssetCategory");
+  s_hRootMotionFromFeet = EZ_REGISTER_ACTION_1("AnimationClip.RootMotionFromFeet", ezActionScope::Document, "Animation Clip", "", ezAnimationClipAction, ezAnimationClipAction::ActionType::RootMotionFromFeet);
+}
+
+void ezAnimationClipActions::UnregisterActions()
+{
+  ezActionManager::UnregisterAction(s_hCategory);
+  ezActionManager::UnregisterAction(s_hRootMotionFromFeet);
+}
+
+void ezAnimationClipActions::MapActions(ezStringView sActionMapName, ezStringView sSubPath)
+{
+  ezActionMap* pMap = ezActionMapManager::GetActionMap(sActionMapName);
+  EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sActionMapName);
+
+  pMap->MapAction(s_hCategory, sSubPath, 20.0f);
+
+  ezStringBuilder sPath;
+  sPath.SetPath(sSubPath, "AnimationClipAssetCategory");
+
+  pMap->MapAction(s_hRootMotionFromFeet, sPath, 1.0f);
+}
+
+ezAnimationClipAction::ezAnimationClipAction(const ezActionContext& context, const char* szName, ezAnimationClipAction::ActionType type)
+  : ezButtonAction(context, szName, false, "")
+{
+  m_Type = type;
+
+  m_pAssetWindow = static_cast<ezQtAnimationClipAssetDocumentWindow*>(ezQtDocumentWindow::FindWindowByDocument(context.m_pDocument));
+
+  switch (m_Type)
+  {
+    case ActionType::RootMotionFromFeet:
+      SetIconPath(":/EditorPluginAssets/Foot.svg");
+      break;
+
+    default:
+      break;
+  }
+}
+
+ezAnimationClipAction::~ezAnimationClipAction() = default;
+
+void ezAnimationClipAction::Execute(const ezVariant& value)
+{
+  switch (m_Type)
+  {
+    case ActionType::RootMotionFromFeet:
+      m_pAssetWindow->ExtractRootMotionFromFeet();
+      return;
+  }
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipActions.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipActions.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <GuiFoundation/Action/BaseActions.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
+
+class ezQtAnimationClipAssetDocumentWindow;
+
+class ezAnimationClipActions
+{
+public:
+  static void RegisterActions();
+  static void UnregisterActions();
+
+  static void MapActions(ezStringView sActionMap, ezStringView sSubPath);
+
+  static ezActionDescriptorHandle s_hCategory;
+  static ezActionDescriptorHandle s_hRootMotionFromFeet;
+};
+
+class ezAnimationClipAction : public ezButtonAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezAnimationClipAction, ezButtonAction);
+
+public:
+  enum class ActionType
+  {
+    RootMotionFromFeet,
+  };
+
+  ezAnimationClipAction(const ezActionContext& context, const char* szName, ActionType type);
+  ~ezAnimationClipAction();
+
+  virtual void Execute(const ezVariant& value) override;
+
+private:
+  ezQtAnimationClipAssetDocumentWindow* m_pAssetWindow = nullptr;
+  ActionType m_Type;
+};

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.cpp
@@ -29,6 +29,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimationClipAssetProperties, 3, ezRTTIDefault
     EZ_MEMBER_PROPERTY("Additive", m_bAdditive),
     EZ_ENUM_MEMBER_PROPERTY("RootMotion", ezRootMotionSource, m_RootMotionMode),
     EZ_MEMBER_PROPERTY("ConstantRootMotion", m_vConstantRootMotion),
+    EZ_MEMBER_PROPERTY("RootMotionDistance", m_fConstantRootMotionLength),
     EZ_MEMBER_PROPERTY("EventTrack", m_EventTrack)->AddAttributes(new ezHiddenAttribute()),
   }
   EZ_END_PROPERTIES;
@@ -51,14 +52,17 @@ void ezAnimationClipAssetProperties::PropertyMetaStateEventHandler(ezPropertyMet
 
   const ezInt64 motionType = e.m_pObject->GetTypeAccessor().GetValue("RootMotion").ConvertTo<ezInt64>();
 
+  props["ConstantRootMotion"].m_Visibility = ezPropertyUiState::Invisible;
+  props["RootMotionDistance"].m_Visibility = ezPropertyUiState::Invisible;
+
   switch (motionType)
   {
     case ezRootMotionSource::Constant:
       props["ConstantRootMotion"].m_Visibility = ezPropertyUiState::Default;
+      props["RootMotionDistance"].m_Visibility = ezPropertyUiState::Default;
       break;
 
     default:
-      props["ConstantRootMotion"].m_Visibility = ezPropertyUiState::Invisible;
       break;
   }
 }
@@ -134,6 +138,11 @@ ezTransformStatus ezAnimationClipAssetDocument::InternalTransformAsset(ezStreamW
     if (pProp->m_RootMotionMode == ezRootMotionSource::Constant)
     {
       desc.m_vConstantRootMotion = pProp->m_vConstantRootMotion;
+
+      if (pProp->m_fConstantRootMotionLength > 0.0f)
+      {
+        desc.m_vConstantRootMotion.SetLength(pProp->m_fConstantRootMotionLength, 0.01f).IgnoreResult();
+      }
     }
 
     range.BeginNextStep("Writing Result");
@@ -198,156 +207,6 @@ ezUuid ezAnimationClipAssetDocument::InsertEventTrackCpAt(ezInt64 iTickX, const 
 
   return newObjectGuid;
 }
-
-// void ezAnimationClipAssetDocument::ApplyCustomRootMotion(ezAnimationClipResourceDescriptor& anim) const
-//{
-//  const ezAnimationClipAssetProperties* pProp = GetProperties();
-//  const ezUInt16 uiRootMotionJointIdx = anim.GetRootMotionJoint();
-//  ezArrayPtr<ezTransform> pRootTransforms = anim.GetJointKeyframes(uiRootMotionJointIdx);
-//
-//  const ezVec3 vKeyframeMotion = pProp->m_vCustomRootMotion / (float)anim.GetFramesPerSecond();
-//  const ezTransform rootTransform(vKeyframeMotion);
-//
-//  for (ezUInt32 kf = 0; kf < anim.GetNumFrames(); ++kf)
-//  {
-//    pRootTransforms[kf] = rootTransform;
-//  }
-//}
-//
-// void ezAnimationClipAssetDocument::ExtractRootMotionFromFeet(ezAnimationClipResourceDescriptor& anim, const ezSkeleton& skeleton) const
-//{
-//  const ezAnimationClipAssetProperties* pProp = GetProperties();
-//  const ezUInt16 uiRootMotionJointIdx = anim.GetRootMotionJoint();
-//  ezArrayPtr<ezTransform> pRootTransforms = anim.GetJointKeyframes(uiRootMotionJointIdx);
-//
-//  const ezUInt16 uiFoot1 = skeleton.FindJointByName(ezTempHashedString(pProp->m_sJoint1.GetData()));
-//  const ezUInt16 uiFoot2 = skeleton.FindJointByName(ezTempHashedString(pProp->m_sJoint2.GetData()));
-//
-//  if (uiFoot1 == ezInvalidJointIndex || uiFoot2 == ezInvalidJointIndex)
-//  {
-//    ezLog::Error("Joints '{0}' and '{1}' could not be found in animation clip", pProp->m_sJoint1, pProp->m_sJoint2);
-//    return;
-//  }
-//
-//  ezAnimationPose pose;
-//  pose.Configure(skeleton);
-//
-//  ezVec3 lastFootPos1(0), lastFootPos2(0);
-//
-//  // init last foot position with very last frame data
-//  {
-//    pose.SetToBindPoseInLocalSpace(skeleton);
-//    anim.SetPoseToKeyframe(pose, skeleton, anim.GetNumFrames() - 1);
-//    pose.ConvertFromLocalSpaceToObjectSpace(skeleton);
-//
-//    lastFootPos1 = pose.GetTransform(uiFoot1).GetTranslationVector();
-//    lastFootPos2 = pose.GetTransform(uiFoot2).GetTranslationVector();
-//  }
-//
-//  ezInt32 lastFootDown = (lastFootPos1.z < lastFootPos2.z) ? 1 : 2;
-//
-//  ezHybridArray<ezUInt16, 32> unknownMotion;
-//
-//  for (ezUInt16 frame = 0; frame < anim.GetNumFrames(); ++frame)
-//  {
-//    pose.SetToBindPoseInLocalSpace(skeleton);
-//    anim.SetPoseToKeyframe(pose, skeleton, frame);
-//    pose.ConvertFromLocalSpaceToObjectSpace(skeleton);
-//
-//    const ezVec3 footPos1 = pose.GetTransform(uiFoot1).GetTranslationVector();
-//    const ezVec3 footPos2 = pose.GetTransform(uiFoot2).GetTranslationVector();
-//
-//    const ezVec3 footDir1 = footPos1 - lastFootPos1;
-//    const ezVec3 footDir2 = footPos2 - lastFootPos2;
-//
-//    ezVec3 rootMotion(0);
-//
-//    const ezInt32 curFootDown = (footPos1.z < footPos2.z) ? 1 : 2;
-//
-//    if (lastFootDown == curFootDown)
-//    {
-//      if (curFootDown == 1)
-//        rootMotion = -footDir1;
-//      else
-//        rootMotion = -footDir2;
-//
-//      rootMotion.z = 0;
-//      pRootTransforms[frame] = ezTransform(rootMotion);
-//    }
-//    else
-//    {
-//      // set them via average later on
-//      unknownMotion.PushBack(frame);
-//      pRootTransforms[frame].SetIdentity();
-//    }
-//
-//    lastFootDown = curFootDown;
-//    lastFootPos1 = footPos1;
-//    lastFootPos2 = footPos2;
-//  }
-//
-//  // fix unknown motion frames
-//  for (ezUInt16 crossedFeet : unknownMotion)
-//  {
-//    const ezUInt16 prevFrame = (crossedFeet > 0) ? (crossedFeet - 1) : anim.GetNumFrames() - 1;
-//    const ezUInt16 nextFrame = (crossedFeet + 1) % anim.GetNumFrames();
-//
-//    const ezVec3 avgTranslation = ezMath::Lerp(pRootTransforms[prevFrame].m_vPosition, pRootTransforms[nextFrame].m_vPosition, 0.5f);
-//
-//    pRootTransforms[crossedFeet] = ezTransform(avgTranslation);
-//  }
-//
-//  const ezUInt16 numFrames = anim.GetNumFrames();
-//
-//  ezHybridArray<ezVec3, 32> translations;
-//  translations.SetCount(numFrames);
-//
-//  for (ezUInt16 thisFrame = 0; thisFrame < numFrames; ++thisFrame)
-//  {
-//    translations[thisFrame] = pRootTransforms[thisFrame].m_vPosition;
-//  }
-//
-//  // do some smoothing
-//  for (ezUInt16 thisFrame = 0; thisFrame < numFrames; ++thisFrame)
-//  {
-//    const ezUInt16 prevFrame2 = (numFrames + thisFrame - 2) % numFrames;
-//    const ezUInt16 prevFrame = (numFrames + thisFrame - 1) % numFrames;
-//    const ezUInt16 nextFrame = (thisFrame + 1) % numFrames;
-//    const ezUInt16 nextFrame2 = (thisFrame + 2) % numFrames;
-//
-//    const ezVec3 smoothedTranslation =
-//      (translations[prevFrame2] + translations[prevFrame] + translations[thisFrame] + translations[nextFrame] + translations[nextFrame2]) * 0.2f;
-//
-//    pRootTransforms[thisFrame].m_vPosition = smoothedTranslation;
-//  }
-//
-//  // for (ezUInt32 i = 0; i < anim.GetNumFrames(); ++i)
-//  //{
-//  //  ezLog::Info("Motion {0}: {1} | {2}", ezArgI(i, 3), ezArgF(pRootTransforms[i].m_vPosition.x, 1),
-//  //              ezArgF(pRootTransforms[i].m_vPosition.y, 1));
-//  //}
-//}
-//
-// void ezAnimationClipAssetDocument::MakeRootMotionConstantAverage(ezAnimationClipResourceDescriptor& anim) const
-//{
-//  const ezUInt16 uiRootMotionJointIdx = anim.GetRootMotionJoint();
-//  ezArrayPtr<ezTransform> pRootTransforms = anim.GetJointKeyframes(uiRootMotionJointIdx);
-//  const ezUInt16 numFrames = anim.GetNumFrames();
-//
-//  ezVec3 avgFootTranslation(0);
-//
-//  for (ezUInt16 thisFrame = 0; thisFrame < numFrames; ++thisFrame)
-//  {
-//    avgFootTranslation += pRootTransforms[thisFrame].m_vPosition;
-//  }
-//
-//  avgFootTranslation /= numFrames;
-//
-//  for (ezUInt16 thisFrame = 0; thisFrame < numFrames; ++thisFrame)
-//  {
-//    pRootTransforms[thisFrame].m_vPosition = avgFootTranslation;
-//  }
-//}
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h
@@ -15,8 +15,6 @@ struct ezRootMotionSource
   {
     None,
     Constant,
-    // FromFeet,
-    // AvgFromFeet,
 
     Default = None
   };
@@ -41,6 +39,7 @@ public:
   ezString m_sPreviewMesh;
   ezEnum<ezRootMotionSource> m_RootMotionMode;
   ezVec3 m_vConstantRootMotion;
+  float m_fConstantRootMotionLength = 0.0f;
 
   ezEventTrackData m_EventTrack;
 
@@ -64,10 +63,6 @@ public:
 protected:
   virtual ezTransformStatus InternalTransformAsset(ezStreamWriter& stream, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile, const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
-
-  // void ApplyCustomRootMotion(ezAnimationClipResourceDescriptor& anim) const;
-  // void ExtractRootMotionFromFeet(ezAnimationClipResourceDescriptor& anim, const ezSkeleton& skeleton) const;
-  // void MakeRootMotionConstantAverage(ezAnimationClipResourceDescriptor& anim) const;
 
 private:
   float m_fSimulationSpeed = 1.0f;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h
@@ -23,6 +23,8 @@ public:
   ezAnimationClipAssetDocument* GetAnimationClipDocument();
   virtual const char* GetWindowLayoutGroupName() const override { return "AnimationClipAsset"; }
 
+  void ExtractRootMotionFromFeet();
+
 protected:
   virtual void InternalRedraw() override;
   virtual void ProcessMessageEventHandler(const ezEditorEngineDocumentMsg* pMsg) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -11,6 +11,7 @@
 #include <EditorFramework/Actions/ViewActions.h>
 #include <EditorFramework/Actions/ViewLightActions.h>
 #include <EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.h>
+#include <EditorPluginAssets/AnimationClipAsset/AnimationClipActions.h>
 #include <EditorPluginAssets/AnimationClipAsset/AnimationClipAsset.h>
 #include <EditorPluginAssets/DecalAsset/DecalAsset.h>
 #include <EditorPluginAssets/Dialogs/ShaderTemplateDlg.moc.h>
@@ -275,16 +276,23 @@ static void ConfigureDecalAsset()
 
 static void ConfigureAnimationClipAsset()
 {
+  ezAnimationClipActions::RegisterActions();
+
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezAnimationClipAssetProperties::PropertyMetaStateEventHandler);
 
   // Menu Bar
   {
     ezActionMapManager::RegisterActionMap("AnimationClipAssetMenuBar", "AssetMenuBar");
+
+    // additionally to the standard menus, also map the 'Assets' menu for asset specific actions
+    ezStandardMenus::MapActions("AnimationClipAssetMenuBar", ezStandardMenuTypes::Asset);
+    ezAnimationClipActions::MapActions("AnimationClipAssetMenuBar", "G.Asset");
   }
 
   // Tool Bar
   {
     ezActionMapManager::RegisterActionMap("AnimationClipAssetToolBar", "AssetToolbar");
+    ezAnimationClipActions::MapActions("AnimationClipAssetToolBar", "");
     ezCommonAssetActions::MapToolbarActions("AnimationClipAssetToolBar", ezCommonAssetUiState::Loop | ezCommonAssetUiState::Pause | ezCommonAssetUiState::Restart | ezCommonAssetUiState::SimulationSpeed | ezCommonAssetUiState::Grid);
   }
 
@@ -452,6 +460,7 @@ void OnUnloadPlugin()
   ezVisualShaderActions::UnregisterActions();
   ezMaterialAssetActions::UnregisterActions();
   ezSkeletonActions::UnregisterActions();
+  ezAnimationClipActions::UnregisterActions();
 
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezAnimatedMeshAssetProperties::PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezMeshAssetProperties::PropertyMetaStateEventHandler);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/QtResources/Foot.svg
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/QtResources/Foot.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ffffff" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800px" height="800px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <g> <circle cx="28.549" cy="35.885" r="4.342"/> <circle cx="65.794" cy="15.531" r="8.767"/> <circle cx="47.712" cy="18.329" r="5.469"/> <path d="M72.903,74.043c-1.387-2.237-2.202-4.867-2.202-7.693c0-2.464,0.616-4.782,1.692-6.82l-0.034-0.051 c2.168-3.252,3.436-7.155,3.436-11.356c0-11.326-9.182-20.507-20.507-20.507c-11.326,0-20.507,9.181-20.507,20.507 c0,2.212,0.36,4.338,1.009,6.335c0.436,1.792,1.139,3.475,2.068,5.011l-0.096,0.055l14.854,25.729 c1.568,4.64,5.947,7.984,11.115,7.984c6.484,0,11.743-5.256,11.743-11.741c0-2.813-0.992-5.394-2.643-7.416L72.903,74.043z"/> <circle cx="36.161" cy="26.693" r="4.342"/> </g> </g>
+</svg>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/QtResources/resources.qrc
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/QtResources/resources.qrc
@@ -42,6 +42,7 @@
     <file>JointSwingLimits.svg</file>
     <file>JointTwistLimits.svg</file>
     <file>PreviewMesh.svg</file>
+    <file>Foot.svg</file>    
   </qresource>
 </RCC>
 

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/AnimationClipAsset/AnimationClipContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/AnimationClipAsset/AnimationClipContext.cpp
@@ -3,6 +3,7 @@
 #include <EnginePluginAssets/AnimationClipAsset/AnimationClipContext.h>
 #include <EnginePluginAssets/AnimationClipAsset/AnimationClipView.h>
 
+#include <Core/ResourceManager/ResourceManager.h>
 #include <GameEngine/Animation/Skeletal/SimpleAnimationComponent.h>
 #include <RendererCore/AnimationSystem/AnimationClipResource.h>
 
@@ -76,6 +77,10 @@ void ezAnimationClipContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg
     else if (pMsg->m_sWhatToDo == "PlaybackPos")
     {
       SetPlaybackPosition(pMsg->m_PayloadValue.Get<double>());
+    }
+    else if (pMsg->m_sWhatToDo == "ExtractRootMotionFromFeet")
+    {
+      ExtractRootMotionFromFeet();
     }
 
     return;
@@ -198,5 +203,211 @@ void ezAnimationClipContext::SetPlaybackPosition(double pos)
   {
     pAnimController->SetNormalizedPlaybackPosition(static_cast<float>(pos));
     pAnimController->m_fSpeed = 0.0f;
+  }
+}
+
+void ezAnimationClipContext::ExtractRootMotionFromFeet()
+{
+  auto ReturnFailure = [this](ezStringView str)
+  {
+    ezSimpleDocumentConfigMsgToEditor msg;
+    msg.m_sWhatToDo = "ReportError";
+    msg.m_sPayload = str;
+    SendProcessMessage(&msg);
+  };
+
+  if (m_sAnimatedMeshToUse.IsEmpty())
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nPreview mesh is not set.");
+    return;
+  }
+
+  ezStringBuilder sAnimClipGuid;
+  ezConversionUtils::ToString(GetDocumentGuid(), sAnimClipGuid);
+  ezAnimationClipResourceHandle hAnimation = ezResourceManager::LoadResource<ezAnimationClipResource>(sAnimClipGuid);
+
+  ezResourceLock<ezAnimationClipResource> pAnimation(hAnimation, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
+  if (pAnimation.GetAcquireResult() != ezResourceAcquireResult::Final)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nCouldn't load animation.");
+    return;
+  }
+
+  ezMeshResourceHandle hAnimMesh = ezResourceManager::LoadResource<ezMeshResource>(m_sAnimatedMeshToUse);
+  ezResourceLock<ezMeshResource> pAnimMesh(hAnimMesh, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
+
+  if (pAnimMesh.GetAcquireResult() != ezResourceAcquireResult::Final)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nCouldn't load preview mesh.");
+    return;
+  }
+
+  if (!pAnimMesh->m_hDefaultSkeleton.IsValid())
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nPreview mesh has no skeleton.");
+    return;
+  }
+
+  ezResourceLock<ezSkeletonResource> pSkeleton(pAnimMesh->m_hDefaultSkeleton, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
+  if (pSkeleton.GetAcquireResult() != ezResourceAcquireResult::Final)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nSkeleton of preview mesh could not be loaded.");
+    return;
+  }
+
+  ezAnimPoseGenerator pg;
+
+  const auto& skel = pSkeleton->GetDescriptor().m_Skeleton;
+
+  const ezUInt16 uiFoot1 = pSkeleton->GetDescriptor().m_uiLeftFootJoint;
+  const ezUInt16 uiFoot2 = pSkeleton->GetDescriptor().m_uiRightFootJoint;
+
+  if (uiFoot1 == ezInvalidJointIndex)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nLeft foot joint is not correctly defined in skeleton asset.");
+    return;
+  }
+
+  if (uiFoot2 == ezInvalidJointIndex)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nRight foot joint is not correctly defined in skeleton asset.");
+    return;
+  }
+
+  if (uiFoot1 == uiFoot2)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nLeft and right foot joint must differ.");
+    return;
+  }
+
+  ezUInt16 uiSharedParentJoint = ezInvalidJointIndex;
+
+  // find shared parent bone
+  {
+    ezHybridArray<ezUInt16, 32> parents;
+
+    auto* pJoint = &skel.GetJointByIndex(uiFoot1);
+
+    // collect all parent joint indices
+    while (pJoint->GetParentIndex() != ezInvalidJointIndex)
+    {
+      parents.PushBack(pJoint->GetParentIndex());
+      pJoint = &skel.GetJointByIndex(pJoint->GetParentIndex());
+    }
+
+    pJoint = &skel.GetJointByIndex(uiFoot2);
+
+    // collect all parent joint indices
+    while (pJoint->GetParentIndex() != ezInvalidJointIndex)
+    {
+      if (parents.Contains(pJoint->GetParentIndex()))
+      {
+        uiSharedParentJoint = pJoint->GetParentIndex();
+        break;
+      }
+
+      pJoint = &skel.GetJointByIndex(pJoint->GetParentIndex());
+    }
+  }
+
+  if (uiSharedParentJoint == ezInvalidJointIndex)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nCouldn't find shared parent bone of feet bones.");
+    return;
+  }
+
+  // TODO: don't hard-code num samples ?
+  const ezUInt32 uiNumSamples = 32;
+  float fPrevPos = 0.0f;
+
+  int iFootDown = -1;
+  int iFootUp = -1;
+  ezVec3 vLastHipDist(0);
+
+  ezVec3 vMovement(0);
+  int iSamplesTaken = 0;
+
+
+  for (ezUInt32 uiSample = 0; uiSample < uiNumSamples; ++uiSample)
+  {
+    pg.Reset(pSkeleton.GetPointer(), nullptr);
+
+    auto& cmd = pg.AllocCommandSampleTrack(0);
+    cmd.m_EventSampling = ezAnimPoseEventTrackSampleMode::None;
+    cmd.m_fPreviousNormalizedSamplePos = fPrevPos;
+    cmd.m_fNormalizedSamplePos = (float)uiSample / (float)(uiNumSamples - 1);
+    cmd.m_hAnimationClip = hAnimation;
+    fPrevPos = cmd.m_fNormalizedSamplePos;
+
+    auto& cmdMP = pg.AllocCommandLocalToModelPose();
+    cmdMP.m_Inputs.PushBack(cmd.GetCommandID());
+
+    pg.SetFinalCommand(cmdMP.GetCommandID());
+
+    pg.UpdatePose(false);
+
+    const ezVec3 p[3] =
+      {
+        pg.GetCurrentPose()[uiSharedParentJoint].GetTranslationVector(),
+        pg.GetCurrentPose()[uiFoot1].GetTranslationVector(),
+        pg.GetCurrentPose()[uiFoot2].GetTranslationVector()
+        //
+      };
+
+    if (iFootDown == -1)
+    {
+      if (p[1].y < p[2].y)
+      {
+        iFootDown = 1;
+        iFootUp = 2;
+      }
+      else
+      {
+        iFootDown = 2;
+        iFootUp = 1;
+      }
+
+      vLastHipDist = p[0] - p[iFootDown];
+    }
+    else if (p[iFootDown].y > p[iFootUp].y)
+    {
+      ezMath::Swap(iFootDown, iFootUp);
+
+      vLastHipDist = p[0] - p[iFootDown];
+    }
+    else
+    {
+      const ezVec3 vHipDist = p[0] - p[iFootDown];
+
+      vMovement += vHipDist - vLastHipDist;
+      iSamplesTaken++;
+      vLastHipDist = vHipDist;
+    }
+  }
+
+  if (iSamplesTaken == 0)
+  {
+    ReturnFailure("Failed to extract root motion from feet.\n\nNo valid animation samples found.");
+    return;
+  }
+
+  ezVec3 avg = vMovement / (float)iSamplesTaken;
+  avg *= (uiNumSamples - 1);                                           // calculate the average movement over the entire clip
+  avg /= pAnimation->GetDescriptor().GetDuration().AsFloatInSeconds(); // scale it to the movement per second
+
+  // transform the motion into the desired space
+  avg = pSkeleton->GetDescriptor().m_RootTransform.GetAsMat4().TransformDirection(avg);
+
+  const float len = avg.GetLengthAndNormalize();
+
+  ezVec4 res;
+  res.Set(avg.x, avg.y, avg.z, len);
+
+  {
+    ezSimpleDocumentConfigMsgToEditor msg;
+    msg.m_sWhatToDo = "ExtractRootMotionFromFeet";
+    msg.m_PayloadValue = res;
+
+    SendProcessMessage(&msg);
   }
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/AnimationClipAsset/AnimationClipContext.h
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/AnimationClipAsset/AnimationClipContext.h
@@ -25,6 +25,7 @@ protected:
 private:
   void QuerySelectionBBox(const ezEditorEngineDocumentMsg* pMsg);
   void SetPlaybackPosition(double pos);
+  void ExtractRootMotionFromFeet();
 
   ezGameObject* m_pGameObject = nullptr;
   ezString m_sAnimatedMeshToUse;

--- a/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
+++ b/Code/Engine/GameEngine/Gameplay/Implementation/BlackboardComponent.cpp
@@ -332,6 +332,13 @@ void ezLocalBlackboardComponent::OnSimulationStarted()
   // and we then press play, to have the new entries in the BB
   // this would NOT update the initial values, though, if they changed
   InitializeFromTemplate();
+
+  // override with the component specific initial entries
+  for (auto& entry : m_InitialEntries)
+  {
+    m_pBoard->SetEntryValue(entry.m_sName, entry.m_InitialValue);
+    m_pBoard->SetEntryFlags(entry.m_sName, entry.m_Flags).AssertSuccess();
+  }
 }
 
 void ezLocalBlackboardComponent::SerializeComponent(ezWorldWriter& inout_stream) const

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BlackboardAnimNodes.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes/BlackboardAnimNodes.cpp
@@ -74,7 +74,7 @@ const char* ezSetBlackboardNumberAnimNode::GetBlackboardEntry() const
 
 void ezSetBlackboardNumberAnimNode::Step(ezAnimController& ref_controller, ezAnimGraphInstance& ref_graph, ezTime tDiff, const ezSkeletonResource* pSkeleton, ezGameObject* pTarget) const
 {
-  if (!m_InActivate.IsTriggered(ref_graph))
+  if (m_InActivate.IsConnected() && !m_InActivate.IsTriggered(ref_graph))
     return;
 
   auto pBlackboard = ref_controller.GetBlackboard();

--- a/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace2DAnimNode.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimGraph/AnimNodes2/SampleBlendSpace2DAnimNode.h
@@ -46,6 +46,7 @@ private:
   ezTime m_InputResponse = ezTime::MakeFromMilliseconds(100); // [ property ]
   bool m_bLoop = true;                                        // [ property ]
   bool m_bApplyRootMotion = false;                            // [ property ]
+  float m_fRootMotionAmount = 1.0f;                           // [ property ]
   float m_fPlaybackSpeed = 1.0f;                              // [ property ]
 
   ezAnimGraphTriggerInputPin m_InStart;                       // [ property ]

--- a/Code/Engine/RendererCore/AnimationSystem/AnimationClipResource.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimationClipResource.h
@@ -34,7 +34,7 @@ public:
   ezTime GetDuration() const;
   void SetDuration(ezTime duration);
 
-  void CreateMappedOzzAnimation(ozz::unique_ptr<ozz::animation::Animation>& ozzAnim, const ezSkeleton& skeleton) const;
+  void CreateMappedOzzAnimation(ozz::unique_ptr<ozz::animation::Animation>& out_pOzzAnim, const ezSkeleton& skeleton) const;
   const ozz::animation::Animation& GetMappedOzzAnimation(const ezSkeletonResource& skeleton) const;
 
   struct JointInfo

--- a/Code/Engine/RendererCore/AnimationSystem/AnimationClipResource.h
+++ b/Code/Engine/RendererCore/AnimationSystem/AnimationClipResource.h
@@ -6,8 +6,10 @@
 #include <Foundation/Containers/ArrayMap.h>
 #include <Foundation/Strings/HashedString.h>
 #include <Foundation/Tracks/EventTrack.h>
+#include <ozz/base/memory/unique_ptr.h>
 
 class ezSkeletonResource;
+class ezSkeleton;
 
 namespace ozz::animation
 {
@@ -32,6 +34,7 @@ public:
   ezTime GetDuration() const;
   void SetDuration(ezTime duration);
 
+  void CreateMappedOzzAnimation(ozz::unique_ptr<ozz::animation::Animation>& ozzAnim, const ezSkeleton& skeleton) const;
   const ozz::animation::Animation& GetMappedOzzAnimation(const ezSkeletonResource& skeleton) const;
 
   struct JointInfo

--- a/Code/Engine/RendererCore/AnimationSystem/EditableSkeleton.h
+++ b/Code/Engine/RendererCore/AnimationSystem/EditableSkeleton.h
@@ -120,6 +120,10 @@ public:
   ezEnum<ezBasisAxis> m_BoneDirection;
 
   ezHybridArray<ezEditableSkeletonJoint*, 4> m_Children;
+
+  // used for motion extraction
+  ezString m_sLeftFootJoint;
+  ezString m_sRightFootJoint;
 };
 
 struct EZ_RENDERERCORE_DLL ezExposedBone

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
@@ -254,18 +254,9 @@ EZ_FORCE_INLINE void ez2ozz(const ezQuat& qIn, ozz::math::Quaternion& ref_out)
   ref_out.w = qIn.w;
 }
 
-const ozz::animation::Animation& ezAnimationClipResourceDescriptor::GetMappedOzzAnimation(const ezSkeletonResource& skeleton) const
+void ezAnimationClipResourceDescriptor::CreateMappedOzzAnimation(ozz::unique_ptr<ozz::animation::Animation>& ozzAnim, const ezSkeleton& skeleton) const
 {
-  auto it = m_pOzzImpl->m_MappedOzzAnimations.Find(&skeleton);
-  if (it.IsValid())
-  {
-    if (it.Value().m_uiResourceChangeCounter == skeleton.GetCurrentResourceChangeCounter())
-    {
-      return *it.Value().m_pAnim.get();
-    }
-  }
-
-  auto pOzzSkeleton = &skeleton.GetDescriptor().m_Skeleton.GetOzzSkeleton();
+  auto pOzzSkeleton = &skeleton.GetOzzSkeleton();
   const ezUInt32 uiNumJoints = pOzzSkeleton->num_joints();
 
   ozz::animation::offline::RawAnimation rawAnim;
@@ -286,11 +277,11 @@ const ozz::animation::Animation& ezAnimationClipResourceDescriptor::GetMappedOzz
       dstTrack.rotations.resize(1);
       dstTrack.scales.resize(1);
 
-      const ezUInt16 uiFallbackIdx = skeleton.GetDescriptor().m_Skeleton.FindJointByName(sJointName);
+      const ezUInt16 uiFallbackIdx = skeleton.FindJointByName(sJointName);
 
       EZ_ASSERT_DEV(uiFallbackIdx != ezInvalidJointIndex, "");
 
-      const auto& fallbackJoint = skeleton.GetDescriptor().m_Skeleton.GetJointByIndex(uiFallbackIdx);
+      const auto& fallbackJoint = skeleton.GetJointByIndex(uiFallbackIdx);
 
       const ezTransform& fallbackTransform = m_bAdditive ? ezTransform::MakeIdentity() : fallbackJoint.GetRestPoseLocalTransform();
 
@@ -356,8 +347,22 @@ const ozz::animation::Animation& ezAnimationClipResourceDescriptor::GetMappedOzz
 
   EZ_ASSERT_DEBUG(rawAnim.Validate(), "Invalid animation data");
 
+  ozzAnim = std::move(animBuilder(rawAnim));
+}
+
+const ozz::animation::Animation& ezAnimationClipResourceDescriptor::GetMappedOzzAnimation(const ezSkeletonResource& skeleton) const
+{
+  auto it = m_pOzzImpl->m_MappedOzzAnimations.Find(&skeleton);
+  if (it.IsValid())
+  {
+    if (it.Value().m_uiResourceChangeCounter == skeleton.GetCurrentResourceChangeCounter())
+    {
+      return *it.Value().m_pAnim.get();
+    }
+  }
+
   auto& cached = m_pOzzImpl->m_MappedOzzAnimations[&skeleton];
-  cached.m_pAnim = std::move(animBuilder(rawAnim));
+  CreateMappedOzzAnimation(cached.m_pAnim, skeleton.GetDescriptor().m_Skeleton);
   cached.m_uiResourceChangeCounter = skeleton.GetCurrentResourceChangeCounter();
 
   return *cached.m_pAnim.get();

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/AnimationClipResource.cpp
@@ -254,7 +254,7 @@ EZ_FORCE_INLINE void ez2ozz(const ezQuat& qIn, ozz::math::Quaternion& ref_out)
   ref_out.w = qIn.w;
 }
 
-void ezAnimationClipResourceDescriptor::CreateMappedOzzAnimation(ozz::unique_ptr<ozz::animation::Animation>& ozzAnim, const ezSkeleton& skeleton) const
+void ezAnimationClipResourceDescriptor::CreateMappedOzzAnimation(ozz::unique_ptr<ozz::animation::Animation>& out_pOzzAnim, const ezSkeleton& skeleton) const
 {
   auto pOzzSkeleton = &skeleton.GetOzzSkeleton();
   const ezUInt32 uiNumJoints = pOzzSkeleton->num_joints();
@@ -347,7 +347,7 @@ void ezAnimationClipResourceDescriptor::CreateMappedOzzAnimation(ozz::unique_ptr
 
   EZ_ASSERT_DEBUG(rawAnim.Validate(), "Invalid animation data");
 
-  ozzAnim = std::move(animBuilder(rawAnim));
+  out_pOzzAnim = std::move(animBuilder(rawAnim));
 }
 
 const ozz::animation::Animation& ezAnimationClipResourceDescriptor::GetMappedOzzAnimation(const ezSkeletonResource& skeleton) const

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/EditableSkeleton.cpp
@@ -94,6 +94,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditableSkeleton, 2, ezRTTIDefaultAllocator<ez
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("Surface", m_sSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("MaxImpulse", m_fMaxImpulse)->AddAttributes(new ezDefaultValueAttribute(100.f)),
+    EZ_MEMBER_PROPERTY("LeftFootJoint", m_sLeftFootJoint),
+    EZ_MEMBER_PROPERTY("RightFootJoint", m_sRightFootJoint),
 
     EZ_ARRAY_MEMBER_PROPERTY("Children", m_Children)->AddFlags(ezPropertyFlags::PointerOwner | ezPropertyFlags::Hidden),
   }
@@ -228,6 +230,9 @@ void ezEditableSkeleton::FillResourceDescriptor(ezSkeletonResourceDescriptor& re
 
   sb.BuildSkeleton(ref_desc.m_Skeleton);
   ref_desc.m_Skeleton.m_BoneDirection = m_BoneDirection;
+
+  ref_desc.m_uiLeftFootJoint = ref_desc.m_Skeleton.FindJointByName(ezTempHashedString(m_sLeftFootJoint));
+  ref_desc.m_uiRightFootJoint = ref_desc.m_Skeleton.FindJointByName(ezTempHashedString(m_sRightFootJoint));
 }
 
 static void BuildOzzRawSkeleton(const ezEditableSkeletonJoint& srcJoint, ozz::animation::offline::RawSkeleton::Joint& ref_dstJoint)

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonResource.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonResource.cpp
@@ -104,7 +104,7 @@ ezUInt64 ezSkeletonResourceDescriptor::GetHeapMemoryUsage() const
 
 ezResult ezSkeletonResourceDescriptor::Serialize(ezStreamWriter& inout_stream) const
 {
-  inout_stream.WriteVersion(7);
+  inout_stream.WriteVersion(8);
 
   m_Skeleton.Save(inout_stream);
   inout_stream << m_RootTransform;
@@ -125,12 +125,16 @@ ezResult ezSkeletonResourceDescriptor::Serialize(ezStreamWriter& inout_stream) c
     EZ_SUCCEED_OR_RETURN(inout_stream.WriteArray(geo.m_TriangleIndices));
   }
 
+  // version 8
+  inout_stream << m_uiLeftFootJoint;
+  inout_stream << m_uiRightFootJoint;
+
   return EZ_SUCCESS;
 }
 
 ezResult ezSkeletonResourceDescriptor::Deserialize(ezStreamReader& inout_stream)
 {
-  const ezTypeVersion version = inout_stream.ReadVersion(7);
+  const ezTypeVersion version = inout_stream.ReadVersion(8);
 
   if (version < 6)
     return EZ_FAILURE;
@@ -174,6 +178,12 @@ ezResult ezSkeletonResourceDescriptor::Deserialize(ezStreamReader& inout_stream)
       EZ_SUCCEED_OR_RETURN(inout_stream.ReadArray(geo.m_VertexPositions));
       EZ_SUCCEED_OR_RETURN(inout_stream.ReadArray(geo.m_TriangleIndices));
     }
+  }
+
+  if (version >= 8)
+  {
+    inout_stream >> m_uiLeftFootJoint;
+    inout_stream >> m_uiRightFootJoint;
   }
 
   // make sure the geometry is sorted by bones

--- a/Code/Engine/RendererCore/AnimationSystem/SkeletonResource.h
+++ b/Code/Engine/RendererCore/AnimationSystem/SkeletonResource.h
@@ -38,6 +38,10 @@ struct EZ_RENDERERCORE_DLL ezSkeletonResourceDescriptor
   ezSkeleton m_Skeleton;
   float m_fMaxImpulse = ezMath::HighValue<float>();
 
+  // used for motion extraction
+  ezUInt16 m_uiLeftFootJoint = ezInvalidJointIndex;
+  ezUInt16 m_uiRightFootJoint = ezInvalidJointIndex;
+
   ezDynamicArray<ezSkeletonResourceGeometry> m_Geometry;
 };
 

--- a/Code/Tools/Libs/GuiFoundation/Action/ActionMapManager.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/ActionMapManager.h
@@ -10,13 +10,13 @@ public:
   /// \brief Adds a new action map with the given name and an optional inherited parent mapping. Asserts if the name was already used before.
   /// \param sMapping Name of the new mapping. This string has to be used when adding actions to the map.
   /// \param sParentMapping If set, the new mapping will inherit all actions of this mapping. The name must exist and resolve to a valid mapping once ezActionMap::BuildActionTree is called to generate the action tree.
-  static void RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping = {});
+  static void RegisterActionMap(ezStringView sActionMapName, ezStringView sParentActionMapName = {});
 
   /// \brief Deletes the action map with the given name. Asserts, if no such map exists.
-  static void UnregisterActionMap(ezStringView sMapping);
+  static void UnregisterActionMap(ezStringView sActionMapName);
 
   /// \brief Returns the action map with the given name, or nullptr, if it doesn't exist.
-  static ezActionMap* GetActionMap(ezStringView sMapping);
+  static ezActionMap* GetActionMap(ezStringView sActionMapName);
 
 private:
   EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(GuiFoundation, ActionMapManager);

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMapManager.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionMapManager.cpp
@@ -30,24 +30,24 @@ EZ_END_SUBSYSTEM_DECLARATION;
 // ezActionMapManager public functions
 ////////////////////////////////////////////////////////////////////////
 
-void ezActionMapManager::RegisterActionMap(ezStringView sMapping, ezStringView sParentMapping)
+void ezActionMapManager::RegisterActionMap(ezStringView sActionMapName, ezStringView sParentActionMapName)
 {
-  auto it = s_Mappings.Find(sMapping);
-  EZ_ASSERT_ALWAYS(!it.IsValid(), "Mapping '{}' already exists", sMapping);
-  s_Mappings.Insert(sMapping, EZ_DEFAULT_NEW(ezActionMap, sParentMapping));
+  auto it = s_Mappings.Find(sActionMapName);
+  EZ_ASSERT_ALWAYS(!it.IsValid(), "Mapping '{}' already exists", sActionMapName);
+  s_Mappings.Insert(sActionMapName, EZ_DEFAULT_NEW(ezActionMap, sParentActionMapName));
 }
 
-void ezActionMapManager::UnregisterActionMap(ezStringView sMapping)
+void ezActionMapManager::UnregisterActionMap(ezStringView sActionMapName)
 {
-  auto it = s_Mappings.Find(sMapping);
-  EZ_ASSERT_ALWAYS(it.IsValid(), "Mapping '{}' not found", sMapping);
+  auto it = s_Mappings.Find(sActionMapName);
+  EZ_ASSERT_ALWAYS(it.IsValid(), "Mapping '{}' not found", sActionMapName);
   EZ_DEFAULT_DELETE(it.Value());
   s_Mappings.Remove(it);
 }
 
-ezActionMap* ezActionMapManager::GetActionMap(ezStringView sMapping)
+ezActionMap* ezActionMapManager::GetActionMap(ezStringView sActionMapName)
 {
-  auto it = s_Mappings.Find(sMapping);
+  auto it = s_Mappings.Find(sActionMapName);
   if (!it.IsValid())
     return nullptr;
 

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
@@ -74,6 +74,7 @@ public:
 
   static const ezDynamicArray<ezQtDocumentWindow*>& GetAllDocumentWindows() { return s_AllDocumentWindows; }
 
+  /// \brief Returns the document window for the given document, if there is any. nullptr otherwise.
   static ezQtDocumentWindow* FindWindowByDocument(const ezDocument* pDocument);
   ezQtContainerWindow* GetContainerWindow() const;
 

--- a/Data/Tools/ezEditor/Localization/en/AnimationClipAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/AnimationClipAsset.txt
@@ -9,6 +9,8 @@ Animation Clip;Animation Clip
 AnimationClipImport_Single;Animation Clip (Single)
 AnimationClipImport_All;Animation Clips (All)
 
+AnimationClip.RootMotionFromFeet;Extract Root Motion From Feet
+
 # Properties
 
 ezRootMotionSource::None;No Root Motion

--- a/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/AllDeclarations.txt
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Editor/AngelScript/AllDeclarations.txt
@@ -220,7 +220,7 @@ bool ezStringView::StartsWith(ezStringView) const
 bool ezStringView::StartsWith_NoCase(ezStringView) const
 bool ezStringView::TrimWordEnd(ezStringView sWord)
 bool ezStringView::TrimWordStart(ezStringView sWord)
-bool ezStringView::opEquals(const ezStringView&in)
+bool ezStringView::opEquals(const ezStringView&in) const
 bool ezTempHashedString::IsEmpty() const
 bool ezTempHashedString::opEquals(ezTempHashedString) const
 bool ezTime::IsNegative() const
@@ -2551,7 +2551,7 @@ void ezSliderComponent::set_Axis(ezBasisAxis)
 void ezSliderComponent::set_Deceleration(float)
 void ezSliderComponent::set_Distance(float)
 void ezSliderComponent::set_RandomStart(ezTime)
-void ezSound::PlaySound(ezStringView Resource, ezVec3 GlobalPosition, ezQuat GlobalRotation, float Pitch = 1, float Volume = 1, bool BlockToLoad = 1)
+void ezSound::PlaySound(ezStringView Resource, ezVec3 GlobalPosition, ezQuat GlobalRotation = 1, float Pitch = 1, float Volume = 1, bool BlockToLoad = false)
 void ezSpatial::FindObjectsInSphere(ezStringView sCategory, const ezVec3&in vCenter, float fRadius, ReportObjectCB@ callback)
 void ezSpawnBoxComponent::StartSpawning()
 void ezSpawnBoxComponent::set_Duration(ezTime)

--- a/Data/UnitTests/GameEngineTest/AngelScript/as.predefined
+++ b/Data/UnitTests/GameEngineTest/AngelScript/as.predefined
@@ -796,7 +796,7 @@ class ezStringView
   void ChopAwayFirstCharacterAscii();
   bool TrimWordStart(ezStringView sWord);
   bool TrimWordEnd(ezStringView sWord);
-  bool opEquals(const ezStringView&in);
+  bool opEquals(const ezStringView&in) const;
   int opCmp(const ezStringView&in) const;
   void opAssign(const ezString&in);
   void opAssign(const ezHashedString&in);
@@ -2878,7 +2878,7 @@ namespace ezClock
 
 namespace ezSound
 {
-  void PlaySound(ezStringView Resource, ezVec3 GlobalPosition, ezQuat GlobalRotation, float Pitch = 1, float Volume = 1, bool BlockToLoad = 1);
+  void PlaySound(ezStringView Resource, ezVec3 GlobalPosition, ezQuat GlobalRotation = 1, float Pitch = 1, float Volume = 1, bool BlockToLoad = false);
 }
 
 namespace ezCVar


### PR DESCRIPTION
* A button in the animation clip asset allows users to let the engine attempt to compute the root motion and fill out the constant root motion values. The user can then tweak the values.
* Root motion is now also separated into direction and distance, which makes it easier to tweak. Also the automatically calculated direction sometimes needs fixing (zero out up/down axis).
* Fixed that local blackboards didn't properly set the initial values.
* Changed ezSetBlackboardNumberAnimNode to always set the value, if the trigger pin is not connected.
* ezSampleBlendSpace2DAnimNode now has a float value to tweak how much root motion gets applied.
* The skeleton asset now has an option to specify the names of the joints to use as the left and right foot. This is used by the root motion extraction, so that users don't need to specify this value in the animation clip.