### PR TITLE
Rider Cpp support

### DIFF
--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -22,7 +22,9 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezIDE, 1)
   EZ_ENUM_CONSTANT(ezIDE::VisualStudioCode),
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
   EZ_ENUM_CONSTANT(ezIDE::VisualStudio),
+  EZ_ENUM_CONSTANT(ezIDE::SolutionDefault),
 #endif
+  EZ_ENUM_CONSTANT(ezIDE::Rider),
 EZ_END_STATIC_REFLECTED_ENUM;
 
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezCompiler, 1)
@@ -275,12 +277,24 @@ ezStatus ezCppProject::OpenSolution(const ezCppSettings& cfg)
   {
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     case ezIDE::VisualStudio:
-      if (!ezQtUiServices::OpenFileInDefaultProgram(ezCppProject::GetSolutionPath(cfg)))
+      if (!ezQtUiServices::OpenInVisualStudio(ezCppProject::GetSolutionPath(cfg)))
       {
         return ezStatus("Opening the solution in Visual Studio failed.");
       }
       break;
+    case ezIDE::SolutionDefault:
+      if (!ezQtUiServices::OpenFileInDefaultProgram(ezCppProject::GetSolutionPath(cfg)))
+      {
+        return ezStatus("Failed to open solution.");
+      }
+      break;
 #endif
+    case ezIDE::Rider:
+      if (!ezQtUiServices::OpenInRider(ezCppProject::GetSolutionPath(cfg)))
+      {
+        return ezStatus("Opening the solution in Rider failed");
+      }
+      break;
     case ezIDE::VisualStudioCode:
     {
       auto solutionPath = ezCppProject::GetTargetSourceDir();

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -19,11 +19,11 @@
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezIDE, 1)
-  EZ_ENUM_CONSTANT(ezIDE::VisualStudioCode),
+  EZ_ENUM_CONSTANT(ezIDE::DefaultProgram),
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
   EZ_ENUM_CONSTANT(ezIDE::VisualStudio),
-  EZ_ENUM_CONSTANT(ezIDE::SolutionDefault),
 #endif
+  EZ_ENUM_CONSTANT(ezIDE::VisualStudioCode),
   EZ_ENUM_CONSTANT(ezIDE::Rider),
 EZ_END_STATIC_REFLECTED_ENUM;
 
@@ -275,33 +275,44 @@ ezStatus ezCppProject::OpenSolution(const ezCppSettings& cfg)
 
   switch (preferences->m_Ide.GetValue())
   {
+    case ezIDE::DefaultProgram:
+    {
+      if (ezQtUiServices::OpenFileInDefaultProgram(ezCppProject::GetSolutionPath(cfg)).Failed())
+      {
+        return ezStatus("Failed to open solution with default program.\n\nGo to 'Tools > Preferences > C++ Projects' to select another option.");
+      }
+
+      return ezStatus(EZ_SUCCESS);
+    }
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     case ezIDE::VisualStudio:
-      if (!ezQtUiServices::OpenInVisualStudio(ezCppProject::GetSolutionPath(cfg)))
+    {
+      if (ezQtUiServices::OpenInVisualStudio(ezCppProject::GetSolutionPath(cfg)).Failed())
       {
-        return ezStatus("Opening the solution in Visual Studio failed.");
+        return ezStatus("Failed to open solution with Visual Studio.\n\nGo to 'Tools > Preferences > C++ Projects' to select another option.");
       }
-      break;
-    case ezIDE::SolutionDefault:
-      if (!ezQtUiServices::OpenFileInDefaultProgram(ezCppProject::GetSolutionPath(cfg)))
-      {
-        return ezStatus("Failed to open solution.");
-      }
-      break;
-#endif
-    case ezIDE::Rider:
 
+      return ezStatus(EZ_SUCCESS);
+    }
+#endif
+
+    case ezIDE::Rider:
+    {
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
       auto solutionPath = ezCppProject::GetSolutionPath(cfg);
 #else
       auto solutionPath = ezCppProject::GetTargetSourceDir();
 #endif
 
-      if (!ezQtUiServices::OpenInRider(solutionPath))
+      if (ezQtUiServices::OpenInRider(solutionPath).Failed())
       {
-        return ezStatus("Opening the solution in Rider failed");
+        return ezStatus("Failed to open solution with Rider.\n\nGo to 'Tools > Preferences > C++ Projects' to select another option.");
       }
-      break;
+
+      return ezStatus(EZ_SUCCESS);
+    }
+
     case ezIDE::VisualStudioCode:
     {
       auto solutionPath = ezCppProject::GetTargetSourceDir();
@@ -309,13 +320,14 @@ ezStatus ezCppProject::OpenSolution(const ezCppSettings& cfg)
       args.push_back(QString::fromUtf8(solutionPath.GetData(), solutionPath.GetElementCount()));
       if (ezStatus status = ezQtUiServices::OpenInVsCode(args); status.Failed())
       {
-        return ezStatus(ezFmt("Opening Visual Studio Code failed: {}", status.m_sMessage));
+        return ezStatus(ezFmt("Failed to open solution with Visual Studio Code: {}\n\nGo to 'Tools > Preferences > C++ Projects' to select another option.", status.m_sMessage));
       }
+
+      return ezStatus(EZ_SUCCESS);
     }
-    break;
   }
 
-  return ezStatus(EZ_SUCCESS);
+  return ezStatus("Failed to open solution: Unknown error");
 }
 
 ezStatus ezCppProject::OpenInCodeEditor(const ezStringView& sFileName, ezInt32 iLineNumber)

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -290,7 +290,14 @@ ezStatus ezCppProject::OpenSolution(const ezCppSettings& cfg)
       break;
 #endif
     case ezIDE::Rider:
-      if (!ezQtUiServices::OpenInRider(ezCppProject::GetSolutionPath(cfg)))
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+      auto solutionPath = ezCppProject::GetSolutionPath(cfg);
+#else
+      auto solutionPath = ezCppProject::GetTargetSourceDir();
+#endif
+
+      if (!ezQtUiServices::OpenInRider(solutionPath))
       {
         return ezStatus("Opening the solution in Rider failed");
       }

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.h
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.h
@@ -17,8 +17,9 @@ struct EZ_EDITORFRAMEWORK_DLL ezIDE
     VisualStudioCode,
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     VisualStudio,
+    SolutionDefault, // Uses the system default way of opening an sln file
 #endif
-
+    Rider,
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     Default = VisualStudio
 #else

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.h
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.h
@@ -14,17 +14,13 @@ struct EZ_EDITORFRAMEWORK_DLL ezIDE
 
   enum Enum
   {
-    VisualStudioCode,
+    DefaultProgram, // Uses the system default way of opening an sln file
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
     VisualStudio,
-    SolutionDefault, // Uses the system default way of opening an sln file
 #endif
+    VisualStudioCode,
     Rider,
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-    Default = VisualStudio
-#else
-    Default = VisualStudioCode
-#endif
+    Default = DefaultProgram
   };
 };
 

--- a/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.cpp
@@ -54,7 +54,7 @@ void ezQtAssetBrowserPanel::SlotAssetChosen(ezUuid guid, QString sAssetPathRelat
   }
   else
   {
-    ezQtUiServices::OpenFileInDefaultProgram(qtToEzString(sAssetPathAbsolute));
+    ezQtUiServices::OpenFileInDefaultProgram(qtToEzString(sAssetPathAbsolute)).IgnoreResult();
   }
 }
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/FileBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/FileBrowserPropertyWidget.cpp
@@ -156,10 +156,12 @@ void ezQtFilePropertyWidget::OnOpenFile()
   if (!ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sPath))
     return;
 
-  if (!ezQtUiServices::OpenFileInDefaultProgram(sPath))
+  if (ezQtUiServices::OpenFileInDefaultProgram(sPath).Failed())
+  {
     ezQtUiServices::MessageBoxInformation(ezFmt("File could not be opened:\n{0}\nCheck that the file exists, that a program is associated "
                                                 "with this file type and that access to this file is not denied.",
       sPath));
+  }
 }
 
 void ezQtFilePropertyWidget::OnOpenFileWith()
@@ -360,10 +362,12 @@ void ezQtExternalFilePropertyWidget::OnOpenFile()
   if (!ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sPath))
     return;
 
-  if (!ezQtUiServices::OpenFileInDefaultProgram(sPath))
+  if (ezQtUiServices::OpenFileInDefaultProgram(sPath).Failed())
+  {
     ezQtUiServices::MessageBoxInformation(ezFmt("File could not be opened:\n{0}\nCheck that the file exists, that a program is associated "
                                                 "with this file type and that access to this file is not denied.",
       sPath));
+  }
 }
 
 void ezQtExternalFilePropertyWidget::OnOpenFileWith()

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptAsset/AngelScriptAsset.cpp
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptAsset/AngelScriptAsset.cpp
@@ -270,7 +270,7 @@ void ezAngelScriptAssetDocument::OpenExternalEditor()
     if (ezQtUiServices::OpenInVsCode(args).Failed())
     {
       // try again with a different program
-      ezQtUiServices::OpenFileInDefaultProgram(sScriptFileAbs);
+      ezQtUiServices::OpenFileInDefaultProgram(sScriptFileAbs).IgnoreResult();
     }
   }
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/EditorPluginAssets.cpp
@@ -415,7 +415,7 @@ ezVariant CustomAction_CreateShaderFromTemplate(const ezDocument* pDoc)
     ezStringBuilder abs;
     if (ezFileSystem::ResolvePath(dlg.m_sResult, &abs, nullptr).Succeeded())
     {
-      if (!ezQtUiServices::GetSingleton()->OpenFileInDefaultProgram(abs))
+      if (ezQtUiServices::GetSingleton()->OpenFileInDefaultProgram(abs).Failed())
       {
         ezQtUiServices::GetSingleton()->MessageBoxInformation(ezFmt("There is no default program set to open shader files:\n\n{}", abs));
       }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -278,7 +278,7 @@ void ezQtMaterialAssetDocumentWindow::OnOpenShaderClicked(bool)
 
   if (ezOSFile::ExistsFile(sAutoGenShader))
   {
-    ezQtUiServices::OpenFileInDefaultProgram(sAutoGenShader);
+    ezQtUiServices::OpenFileInDefaultProgram(sAutoGenShader).IgnoreResult();
   }
   else
   {

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -356,12 +356,12 @@ void ezQtUiServices::ShowGlobalStatusBarMessage(const ezFormatString& msg)
 }
 
 
-bool ezQtUiServices::OpenFileInDefaultProgram(const char* szPath)
+ezResult ezQtUiServices::OpenFileInDefaultProgram(const char* szPath)
 {
-  return QDesktopServices::openUrl(QUrl::fromLocalFile(szPath));
+  return QDesktopServices::openUrl(QUrl::fromLocalFile(szPath)) ? EZ_SUCCESS : EZ_FAILURE;
 }
 
-bool ezQtUiServices::OpenInVisualStudio(const char* szPath)
+ezResult ezQtUiServices::OpenInVisualStudio(const char* szPath)
 {
   QString sVSExe;
   QSettings settings("\\HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\Applications\\VSLauncher.exe\\Shell\\Open\\Command", QSettings::NativeFormat);
@@ -379,13 +379,13 @@ bool ezQtUiServices::OpenInVisualStudio(const char* szPath)
   QProcess proc;
   if (proc.startDetached(sVSExe, arguments) == false)
   {
-    return false;
+    return EZ_FAILURE;
   }
 
-  return true;
+  return EZ_SUCCESS;
 }
 
-bool ezQtUiServices::OpenInRider(const char* szPath)
+ezResult ezQtUiServices::OpenInRider(const char* szPath)
 {
   QString sRiderPath;
 
@@ -423,7 +423,7 @@ bool ezQtUiServices::OpenInRider(const char* szPath)
     sRiderPath = "rider.sh";
   }
 #else
-  return false;
+  return EZ_FAILURE;
 #endif
 
   QStringList arguments;
@@ -431,8 +431,8 @@ bool ezQtUiServices::OpenInRider(const char* szPath)
 
   if (!QProcess::startDetached(sRiderPath, arguments))
   {
-    return false;
+    return EZ_FAILURE;
   }
 
-  return true;
+  return EZ_SUCCESS;
 }

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -360,3 +360,79 @@ bool ezQtUiServices::OpenFileInDefaultProgram(const char* szPath)
 {
   return QDesktopServices::openUrl(QUrl::fromLocalFile(szPath));
 }
+
+bool ezQtUiServices::OpenInVisualStudio(const char* szPath)
+{
+  QString sVSExe;
+  QSettings settings("\\HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\Applications\\VSLauncher.exe\\Shell\\Open\\Command", QSettings::NativeFormat);
+  QString sVSKey = settings.value(".", "").value<QString>();
+
+  if (sVSKey.length() > 5)
+  {
+    // Remove shell parameter and normalize QT Compatible path, QFile expects the file separator to be '/' regardless of operating system
+    sVSExe = sVSKey.left(sVSKey.length() - 5).replace("\\", "/").replace("\"", "");
+  }
+
+  QStringList arguments;
+  arguments.push_back(szPath);
+
+  QProcess proc;
+  if (proc.startDetached(sVSExe, arguments) == false)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+bool ezQtUiServices::OpenInRider(const char* szPath)
+{
+  QString sRiderPath;
+
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+  QSettings settings("\\HKEY_CURRENT_USER\\SOFTWARE\\JetBrains\\Toolbox\\", QSettings::NativeFormat);
+  QString sToolboxKey = settings.value(".", "").value<QString>();
+
+  QString sToolboxPath = sToolboxKey.replace("\\", "/").replace("\"", "");
+  sToolboxPath.append("/../.settings.json");
+
+  if (QFile::exists(sToolboxPath))
+  {
+
+    QFile file(sToolboxPath);
+    file.open(QIODevice::ReadOnly);
+
+    QByteArray rawData = file.readAll();
+    QJsonDocument doc = QJsonDocument::fromJson(rawData);
+
+    QJsonObject rootObject = doc.object();
+    QJsonValue shellPathValue = rootObject.value("shell_scripts");
+    QJsonObject shellPathObject = shellPathValue.toObject();
+    sRiderPath = shellPathObject.value("location").toString().replace("\\", "/").replace("\"", "");
+    sRiderPath.append("/rider.cmd");
+    file.close();
+  }
+#elif EZ_ENABLED(EZ_PLATFORM_LINUX)
+  if (QFile::exists("/opt/rider/bin/rider.sh"))
+  {
+    sRiderPath = "/opt/clion/bin/rider.sh";
+  }
+  else
+  {
+    // Maybe its in path????
+    sRiderPath = "rider.sh";
+  }
+#else
+  return false;
+#endif
+
+  QStringList arguments;
+  arguments.push_back(szPath);
+
+  if (!QProcess::startDetached(sRiderPath, arguments))
+  {
+    return false;
+  }
+
+  return true;
+}

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -98,13 +98,13 @@ public:
   static void ShowGlobalStatusBarMessage(const ezFormatString& msg);
 
   /// \brief Opens the given file in the program that is registered in the OS to handle that file type.
-  static bool OpenFileInDefaultProgram(const char* szPath);
+  static ezResult OpenFileInDefaultProgram(const char* szPath);
 
   /// \brief Open the given file in Visual Studio
-  static bool OpenInVisualStudio(const char* szPath);
+  static ezResult OpenInVisualStudio(const char* szPath);
 
   /// \brief Open the given file in Jetbrains Rider
-  static bool OpenInRider(const char* szPath);
+  static ezResult OpenInRider(const char* szPath);
 
   /// \brief Opens the given file or folder in the Explorer
   static void OpenInExplorer(const char* szPath, bool bIsFile);

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -100,6 +100,12 @@ public:
   /// \brief Opens the given file in the program that is registered in the OS to handle that file type.
   static bool OpenFileInDefaultProgram(const char* szPath);
 
+  /// \brief Open the given file in Visual Studio
+  static bool OpenInVisualStudio(const char* szPath);
+
+  /// \brief Open the given file in Jetbrains Rider
+  static bool OpenInRider(const char* szPath);
+
   /// \brief Opens the given file or folder in the Explorer
   static void OpenInExplorer(const char* szPath, bool bIsFile);
 


### PR DESCRIPTION
Adds support for Rider to open cpp solution files. 
Changes VS handling to ensure it always opens in visual studio. 
Also Adds Option to open solution with system default application (same behavior vs used prior)
Fixes part of https://github.com/ezEngine/ezEngine/issues/1520