### PR TITLE
Clang-Tidy Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,9 +358,8 @@ MigrationBackup/
 /Workspace
 /Output
 AssetCache
-/build/
-/buildUWP/
 Code/Engine/ezBuildInfo.h
+/llvm/
 
 # NOTE: Allows Live++ API to be used in the project without being ignored by git.
 !Code/ThirdParty/LivePP/**

--- a/Code/BuildSystem/AzurePipelines/clang-tidy.yml
+++ b/Code/BuildSystem/AzurePipelines/clang-tidy.yml
@@ -21,34 +21,23 @@ jobs:
     submodules: recursive
     fetchDepth: 1
     lfs: true
-  - task: CmdLine@2
-    displayName: Free Disk Space
-    inputs:
-      script: dir C:\
   - pwsh: |
       git fetch --no-recurse-submodules --depth=100 origin $(system.pullRequest.targetBranch)
       $curCommit = $(git rev-parse HEAD)
       git fetch --no-recurse-submodules --depth=100 origin $curCommit
-      Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/LLVM-16.0.6-win64.exe -OutFile "LLVM-16.0.6-win64.exe"
-      Invoke-WebRequest https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip -OutFile ninja-win.zip
-      ./Data/Tools/Precompiled/7z x -ollvm LLVM-16.0.6-win64.exe
-      ./Data/Tools/Precompiled/7z x -oninja ninja-win.zip
-      $WindowsSdkVersion = ((Get-ChildItem -Directory "C:\Program Files (x86)\Windows Kits\10\bin").Name | ? { $_ -match "^10\.0\." } | sort -Descending)[0]
-      Write-Host "Windows SDK Found" $WindowsSdkVersion
-      Get-CimInstance -ClassName Win32_LogicalDisk
-      $rcExe = "C:\Program Files (x86)\Windows Kits\10\bin\$WindowsSdkVersion\x64\rc.exe" -replace "\\","/"
-      $clangCppExe = "$pwd\llvm\bin\clang++.exe" -replace "\\","/"
-      $clangExe = "$pwd\llvm\bin\clang.exe" -replace "\\","/"
-      $ninjaExe = "$pwd\ninja\ninja.exe" -replace "\\","/"
-      .\Data\Tools\Precompiled\cmake\bin\cmake.exe -G Ninja -B workspace-clang -S . "-DCMAKE_MAKE_PROGRAM=$ninjaExe" "-DCMAKE_CXX_COMPILER=$clangCppExe" "-DCMAKE_C_COMPILER=$clangExe" "-DCMAKE_RC_COMPILER=$rcExe" -DCMAKE_RC_COMPILER_INIT=rc -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DEZ_USE_PCH=OFF -DEZ_ENABLE_FOLDER_UNITY_FILES=OFF
-    displayName: 'Download LLVM & CMake'
+      ./Utilities/clang-tidy/SetupWorkspace.ps1
+    displayName: 'Download LLVM & Run CMake'
+  - task: CmdLine@2
+    displayName: Free Disk Space
+    inputs:
+      script: dir C:\
   - task: PowerShell@2
     displayName: 'Run clang-tidy'
     inputs:
       pwsh: true
       targetType: filePath
-      filePath: './Utilities/RunClangTidy.ps1'
-      arguments: '-DiffTo "origin/$(system.pullRequest.targetBranch)" -LlvmInstallDir "$pwd\llvm" -Workspace "workspace-clang" -Vso'
+      filePath: './Utilities/clang-tidy/RunClangTidy.ps1'
+      arguments: '-DiffTo "origin/$(system.pullRequest.targetBranch)" -LlvmInstallDir "$pwd\llvm" -Workspace "Workspace/clang-tidy" -Vso'
   - task: PowerShell@2
     displayName: 'Fetch suggested changes'
     condition: always()

--- a/Code/Engine/Foundation/Communication/Implementation/IpcChannel.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcChannel.cpp
@@ -125,7 +125,7 @@ ezResult ezIpcChannel::WaitForMessages(ezTime timeout)
 
 void ezIpcChannel::SetConnectionState(ezEnum<ezIpcChannel::ConnectionState> state)
 {
-  const ezEnum<ezIpcChannel::ConnectionState> oldValue = m_iConnectionState.Set(state);
+  const ezEnum<ezIpcChannel::ConnectionState> oldValue = m_ConnectionState.Set(state);
 
   if (state != oldValue)
   {

--- a/Code/Engine/Foundation/Communication/IpcChannel.h
+++ b/Code/Engine/Foundation/Communication/IpcChannel.h
@@ -81,9 +81,9 @@ public:
   /// \brief Disconnect async. On completion, m_Events will be broadcasted.
   void Disconnect();
   /// \brief Returns whether we have a connection.
-  bool IsConnected() const { return m_iConnectionState == ConnectionState::Connected; }
+  bool IsConnected() const { return m_ConnectionState == ConnectionState::Connected; }
   /// \brief Returns the current state of the connection.
-  ezEnum<ConnectionState> GetConnectionState() const { return ezEnum<ConnectionState>(m_iConnectionState); }
+  ezEnum<ConnectionState> GetConnectionState() const { return ezEnum<ConnectionState>(m_ConnectionState); }
 
   /// \brief Sends a message. pMsg can be destroyed after the call.
   bool Send(ezArrayPtr<const ezUInt8> data);
@@ -132,7 +132,7 @@ protected:
   friend class ezMessageLoop;
   ezThreadID m_ThreadId = 0;
 
-  ezAtomicInteger<ConnectionState::Enum> m_iConnectionState = ConnectionState::Disconnected;
+  ezAtomicInteger<ConnectionState::Enum> m_ConnectionState = ConnectionState::Disconnected;
 
   // Setup in ctor
   ezString m_sAddress;

--- a/Utilities/clang-tidy/BuildInstructions.md
+++ b/Utilities/clang-tidy/BuildInstructions.md
@@ -4,7 +4,7 @@ All commands given should be executed in a powershell.
 
  * get the llvm source: `git clone https://github.com/llvm/llvm-project`
  * `cd llvm-project`
- * checkout the latest release version (for the current build llvm-16.0.6 is used): `git checkout llvmorg-16.0.6`
+ * checkout the latest release version (for the current build llvm-18.1.7 is used): `git checkout llvmorg-18.1.7`
  * Apply the llvm.patch: `git apply llvm.patch`
  * Copy the ez folder to `llvm-project/clang-tools-extra/clang-tidy/ez`
  * create a build folder `mkdir build`
@@ -13,6 +13,24 @@ All commands given should be executed in a powershell.
  * Open the generated solution and build the clang-tidy executable (Clang executables folder) in Release.
  * Copy the resulting executable from `build/Release/bin/clang-tidy.exe` to `ezEngine/Data/Tools/Precompiled/clang-tidy/clang-tidy.exe` when done
 
-## Known Pitfalls
- 
- * When running clang-tidy.exe out of the directory it was build into, it will pick up a different set of header files and compile errors might appear. So copy the exectable out of the build directory before attempting to run it on the ezEngine source code. For local minimal test cases the clang-tidy.exe can remain in the build output directory.
+# How to run clang-tidy locally
+
+* Run `Utilities\clang-tidy\SetupWorkspace.ps1`. This will download llvm and create a compatible cmake project that clang-tidy can work on. It is not advised to compile the entirety of llvm yourself, so it is best only compile clang-tidy and download pre-built binaries for everything else.
+* If you have made modifications to `clang-tidy.exe` copy it into the `Data\Tools\Precompiled\clang-tidy` folder.
+  * If you just want to check a single file, run `Utilities\clang-tidy\RunClangTidy.ps1 -SingleFile ABS_PATH_TO_FILE`.
+  * If you want to check all your changes against `dev`, first commit them, then run:\
+  `Utilities\clang-tidy\RunClangTidy.ps1`
+
+## Debugging clang-tidy
+
+⚠️When running clang-tidy.exe out of the directory it was build into, it will pick up a different set of header files and compile errors might appear. So copy the executable out of the build directory before attempting to run it on the ezEngine source code. For local minimal test cases the clang-tidy.exe can remain in the build output directory.\
+If you need to run and debug on EZ code, open the clang-tidy VS properties and do the following.
+  * Change the paths in the steps below as follows:
+    * **C:\Code\llvm-project**: The root directory of your llvm-project clone.
+    * **C:\Code\ezEngine**: The root directory of your EZ clone.
+    * **C:\Code\ezEngine\Code\Engine\Core\ResourceManager\Implementation\Resource.cpp**: The file you want to check.
+  * Build Events -> Post-Build-Event: `copy C:\Code\llvm-project\build\Debug\bin\clang-tidy.exe "C:\Code\ezEngine\Data\Tools\Precompiled\clang-tidy\clang-tidy.exe" /Y`
+  * Debugging:
+    * Command: `C:\Code\ezEngine\Data\Tools\Precompiled\clang-tidy\clang-tidy.exe`
+    * Command Arguments: `-p C:\Code\ezEngine\Workspace\clang-tidy --checks=-*,ez-name-check,modernize-use-default-member-init,modernize-use-equals-default,modernize-use-using,clang-analyzer-core.* "--header-filter=^((?!ThirdParty|DirectXTex|ogt_vox|ui_).)*$" --extra-arg=-DBUILDSYSTEM_CLANG_TIDY=1 "--extra-arg=-isystemC:\Code\ezEngine\llvm\lib\clang\16\include" C:\Code\ezEngine\Code\Engine\Core\ResourceManager\Implementation\Resource.cpp`
+    * Working Directory: `C:\Code\ezEngine\Data\Tools\Precompiled\clang-tidy`

--- a/Utilities/clang-tidy/SetupWorkspace.ps1
+++ b/Utilities/clang-tidy/SetupWorkspace.ps1
@@ -1,0 +1,28 @@
+      
+      $originalDir = Get-Location
+      Set-Location (Join-Path -Path $PSScriptRoot -ChildPath "..\..")
+      try {
+            if (-Not (Test-Path -Path "$pwd\llvm")) {
+                  Write-Host "LLVM not found, downloading LLVM and Ninja..."
+                  Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.7/LLVM-18.1.7-win64.exe -OutFile "LLVM-18.1.7-win64.exe"
+                  Invoke-WebRequest https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip -OutFile ninja-win.zip
+                  ./Data/Tools/Precompiled/7z x -ollvm LLVM-18.1.7-win64.exe
+                  ./Data/Tools/Precompiled/7z x -ollvm ninja-win.zip
+            }
+      
+            $WindowsSdkVersion = ((Get-ChildItem -Directory "C:\Program Files (x86)\Windows Kits\10\bin").Name | ? { $_ -match "^10\.0\." } | sort -Descending)[0]
+            Write-Host "Windows SDK Found" $WindowsSdkVersion
+            $rcExe = "C:\Program Files (x86)\Windows Kits\10\bin\$WindowsSdkVersion\x64\rc.exe" -replace "\\","/"
+            $clangCppExe = "$pwd\llvm\bin\clang++.exe" -replace "\\","/"
+            $clangExe = "$pwd\llvm\bin\clang.exe" -replace "\\","/"
+            $ninjaExe = "$pwd\llvm\ninja.exe" -replace "\\","/"
+            $cmakeCommand = ".\Data\Tools\Precompiled\cmake\bin\cmake.exe -G Ninja -B Workspace/clang-tidy -S . '-DCMAKE_MAKE_PROGRAM=$ninjaExe' '-DCMAKE_CXX_COMPILER=$clangCppExe' '-DCMAKE_C_COMPILER=$clangExe' '-DCMAKE_RC_COMPILER=$rcExe' -DCMAKE_RC_COMPILER_INIT=rc -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DEZ_USE_PCH=OFF -DEZ_ENABLE_FOLDER_UNITY_FILES=OFF '-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion'"
+            Write-Host "////////////////////////////////////////////////////////////////////////////////////////////////////////////"
+            Write-Host "// CMake Command: $cmakeCommand"
+            Write-Host "////////////////////////////////////////////////////////////////////////////////////////////////////////////"
+            Invoke-Expression $cmakeCommand
+      } finally {
+            Set-Location $originalDir
+      }
+ 
+    

--- a/Utilities/clang-tidy/ez/NameCheck.cpp
+++ b/Utilities/clang-tidy/ez/NameCheck.cpp
@@ -95,7 +95,8 @@ namespace clang
           if (prefixAdded)
             *prefixAdded = true;
           return newName.insert(0, "b");
-        } else if (typeName == "ezAtomicInteger32" || typeName == "ezAtomicInteger64")
+        }
+        else if (typeName == "ezAtomicInteger32" || typeName == "ezAtomicInteger64")
         {
           if (prefixAdded)
             *prefixAdded = true;

--- a/Utilities/clang-tidy/ez/NameCheck.cpp
+++ b/Utilities/clang-tidy/ez/NameCheck.cpp
@@ -95,8 +95,7 @@ namespace clang
           if (prefixAdded)
             *prefixAdded = true;
           return newName.insert(0, "b");
-        }
-        else if (typeName == "ezAtomicInteger")
+        } else if (typeName == "ezAtomicInteger32" || typeName == "ezAtomicInteger64")
         {
           if (prefixAdded)
             *prefixAdded = true;
@@ -223,7 +222,7 @@ namespace clang
             {
               return newName;
             }
-            else if (auto declTemplate = dyn_cast<ClassTemplateSpecializationDecl>(recordDecl); declTemplate && recordName == "atomic")
+            else if (auto declTemplate = dyn_cast<ClassTemplateSpecializationDecl>(recordDecl); declTemplate && (recordName == "atomic" || recordName == "ezAtomicInteger"))
             {
               auto& templateArgs = declTemplate->getTemplateArgs();
               if (templateArgs.size() == 1)

--- a/Utilities/clang-tidy/llvm.patch
+++ b/Utilities/clang-tidy/llvm.patch
@@ -1,20 +1,27 @@
-diff --git forkSrcPrefix/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.h forkDstPrefix/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.h
-index 38228fb59bf62487674a5ba28bbe8449956d37e2..a75ee3c87822304991835c6adba76df299849948 100644
---- forkSrcPrefix/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.h
-+++ forkDstPrefix/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.h
-@@ -50,7 +50,7 @@ public:
-     ShouldFix,
- 
-     /// The fixup will conflict with a language keyword,
--    /// so we can't fix it automatically.
-+    /// so we can't fix it automaticallyt.
-     ConflictsWithKeyword,
- 
-     /// The fixup will conflict with a macro
-diff --git forkSrcPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp forkDstPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
-index 0a80c996aaaade5fdb7e523ea231354d0cbb0e2f..045cb8961d1de610e7e20071a5901efafb340117 100644
---- forkSrcPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
-+++ forkDstPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+diff --git a/clang-tools-extra/clang-tidy/CMakeLists.txt b/clang-tools-extra/clang-tidy/CMakeLists.txt
+index 7e1905aa897b..b2fb1291ef52 100644
+--- a/clang-tools-extra/clang-tidy/CMakeLists.txt
++++ b/clang-tools-extra/clang-tidy/CMakeLists.txt
+@@ -67,6 +67,7 @@ add_subdirectory(linuxkernel)
+ add_subdirectory(llvm)
+ add_subdirectory(llvmlibc)
+ add_subdirectory(misc)
++add_subdirectory(ez)
+ add_subdirectory(modernize)
+ if(CLANG_TIDY_ENABLE_STATIC_ANALYZER)
+   add_subdirectory(mpi)
+@@ -87,6 +88,7 @@ set(ALL_CLANG_TIDY_CHECKS
+   clangTidyConcurrencyModule
+   clangTidyCppCoreGuidelinesModule
+   clangTidyDarwinModule
++  clangTidyEzModule
+   clangTidyFuchsiaModule
+   clangTidyGoogleModule
+   clangTidyHICPPModule
+diff --git a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+index 0a80c996aaaa..045cb8961d1d 100644
+--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
++++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
 @@ -565,17 +565,17 @@ void ClangTidyDiagnosticConsumer::checkFilters(SourceLocation Location,
    StringRef FileName(File->getName());
    LastErrorRelatesToUserCode = LastErrorRelatesToUserCode ||
@@ -36,10 +43,10 @@ index 0a80c996aaaade5fdb7e523ea231354d0cbb0e2f..045cb8961d1de610e7e20071a5901efa
    return HeaderFilter.get();
  }
  
-diff --git forkSrcPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h forkDstPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
-index 9280eb1e1f218dfb22c3fb8e6025db9d882733bd..45b4fec125907e95416ff04dc93c8143f6862308 100644
---- forkSrcPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
-+++ forkDstPrefix/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
+diff --git a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
+index 9280eb1e1f21..45b4fec12590 100644
+--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
++++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.h
 @@ -20,6 +20,8 @@
  #include "llvm/Support/Regex.h"
  #include <optional>
@@ -67,10 +74,10 @@ index 9280eb1e1f218dfb22c3fb8e6025db9d882733bd..45b4fec125907e95416ff04dc93c8143
    bool LastErrorRelatesToUserCode = false;
    bool LastErrorPassesLineFilter = false;
    bool LastErrorWasIgnored = false;
-diff --git forkSrcPrefix/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h forkDstPrefix/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
-index adde9136ff1dd5de54a3f7eb976cf2d2494d344b..4c8eef0533c2230217da356c23a4050c8ca3c298 100644
---- forkSrcPrefix/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
-+++ forkDstPrefix/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+diff --git a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
+index adde9136ff1d..4c8eef0533c2 100644
+--- a/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
++++ b/clang-tools-extra/clang-tidy/ClangTidyForceLinker.h
 @@ -94,6 +94,11 @@ extern volatile int MiscModuleAnchorSource;
  static int LLVM_ATTRIBUTE_UNUSED MiscModuleAnchorDestination =
      MiscModuleAnchorSource;
@@ -83,23 +90,3 @@ index adde9136ff1dd5de54a3f7eb976cf2d2494d344b..4c8eef0533c2230217da356c23a4050c
  // This anchor is used to force the linker to link the ModernizeModule.
  extern volatile int ModernizeModuleAnchorSource;
  static int LLVM_ATTRIBUTE_UNUSED ModernizeModuleAnchorDestination =
-diff --git forkSrcPrefix/clang-tools-extra/clang-tidy/CMakeLists.txt forkDstPrefix/clang-tools-extra/clang-tidy/CMakeLists.txt
-index 7e1905aa897b7e7a7362f9d023ec178e4d730f4f..b2fb1291ef525e510fcfcc22e888a68ce080e060 100644
---- forkSrcPrefix/clang-tools-extra/clang-tidy/CMakeLists.txt
-+++ forkDstPrefix/clang-tools-extra/clang-tidy/CMakeLists.txt
-@@ -67,6 +67,7 @@ add_subdirectory(linuxkernel)
- add_subdirectory(llvm)
- add_subdirectory(llvmlibc)
- add_subdirectory(misc)
-+add_subdirectory(ez)
- add_subdirectory(modernize)
- if(CLANG_TIDY_ENABLE_STATIC_ANALYZER)
-   add_subdirectory(mpi)
-@@ -87,6 +88,7 @@ set(ALL_CLANG_TIDY_CHECKS
-   clangTidyConcurrencyModule
-   clangTidyCppCoreGuidelinesModule
-   clangTidyDarwinModule
-+  clangTidyEzModule
-   clangTidyFuchsiaModule
-   clangTidyGoogleModule
-   clangTidyHICPPModule


### PR DESCRIPTION
* Project generation has been moved into `Utilities\clang-tidy\SetupWorkspace.ps1`. This will now create the CMake workspace `Workspace/clang-tidy` so it's where all the other workspaces are located.
* Updated LLVM download to `LLVM-18.1.7-win64.exe`.
* Added `llvm` folder to the gitignore list.
* Updated patch to work on LLVM-18.1.7.
* Extended `BuildInstructions.md` with how to run locally and VS debugging guides.
* `RunClangTidy.ps1` changes:
  * Moved to the `Utilities/clang-tidy` folder.
  * `$Workspace` parameter set to "Workspace/clang-tidy" by default.
  * Removed `$LlvmInstallDir` parameter default value. It's now searched for if not set by testing the local `llvm` folder and the `C:\Program Files\LLVM` folder.
  * `$DiffTo` parameter set to "origin/dev" by default so you can run the script without needing to provide parameters.
  * If `$SingleFile` is set, the script will skip the diff analysis.
* Clang-Tidy changes:
  * The templated `ezAtomicInteger<T>` will now use the template argument as the baseline for the prefix, just like `std::atomic<T>` so it is not trying to add `i` before everything like this:
```sh
D:/a/1/s/Code/Engine\Core/ResourceManager/Resource.h:175:36: warning: class / struct member 'm_LoadingState' does not follow the naming convention [ez-name-check]
   70 |   ezAtomicInteger<ezResourceState> m_LoadingState = ezResourceState::Unloaded;
      |                                    ^~~~~~~~~~~~~~
      |                                    m_iLoadingState
D:/a/1/s/Code/Engine\Core/ResourceManager/Resource.h:176:28: warning: class / struct member 'm_uiQualityLevelsDiscardable' does not follow the naming convention [ez-name-check]
   87 |   ezAtomicInteger<ezUInt8> m_uiQualityLevelsDiscardable = 0;
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                            m_iQualityLevelsDiscardable
D:/a/1/s/Code/Engine\Core/ResourceManager/Resource.h:177:28: warning: class / struct member 'm_uiQualityLevelsLoadable' does not follow the naming convention [ez-name-check]
   90 |   ezAtomicInteger<ezUInt8> m_uiQualityLevelsLoadable = 0;
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                            m_iQualityLevelsLoadable
```