### PR TITLE
Occlusion rasterizer: check for FMA instructions set

### DIFF
--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1366,7 +1366,8 @@ ezRasterizerView* ezRenderPipeline::PrepareOcclusionCulling(const ezFrustum& fru
   if (!cvar_SpatialCullingOcclusionEnable)
     return nullptr;
 
-  if (!ezSystemInformation::Get().GetCpuFeatures().IsAvx1Available())
+  auto& cpuFeatures = ezSystemInformation::Get().GetCpuFeatures();
+  if (!cpuFeatures.IsAvx1Available() || !cpuFeatures.HW_FMA3)
     return nullptr;
 
   ezRasterizerView* pRasterizer = nullptr;


### PR DESCRIPTION
The occlusion rasterizer uses fma instructions besides avx so we need to check for those as well before using it otherwise we would crash.