### PR TITLE
Add box and capsule shape queries

### DIFF
--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -35,17 +35,23 @@ public:
 
   virtual bool SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 
+  virtual bool SweepTestCylinder(ezPhysicsCastResult& out_result, float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
+
   virtual bool OverlapTestSphere(float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const = 0;
 
   virtual bool OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& vPosition, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
 
   virtual bool OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
 
+  virtual bool OverlapTestCylinder(float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
+
   virtual void QueryShapesInSphere(ezPhysicsOverlapResultArray& out_results, float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const = 0;
 
   virtual void QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
 
   virtual void QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
+
+  virtual void QueryShapesInCylinder(ezPhysicsOverlapResultArray& out_results, float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
 
   virtual ezVec3 GetGravity() const = 0;
 

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -31,7 +31,7 @@ public:
 
   virtual bool SweepTestSphere(ezPhysicsCastResult& out_result, float fSphereRadius, const ezVec3& vStart, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 
-  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtends, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
+  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 
   virtual bool SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -41,6 +41,10 @@ public:
 
   virtual void QueryShapesInSphere(ezPhysicsOverlapResultArray& out_results, float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const = 0;
 
+  virtual void QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
+
+  virtual void QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
+
   virtual ezVec3 GetGravity() const = 0;
 
   //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
+++ b/Code/Engine/Core/Interfaces/PhysicsWorldModule.h
@@ -31,11 +31,13 @@ public:
 
   virtual bool SweepTestSphere(ezPhysicsCastResult& out_result, float fSphereRadius, const ezVec3& vStart, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 
-  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
+  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, const ezVec3& vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 
   virtual bool SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const = 0;
 
   virtual bool OverlapTestSphere(float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const = 0;
+
+  virtual bool OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& vPosition, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
 
   virtual bool OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const = 0;
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -191,7 +191,7 @@ bool ezJoltWorldModule::SweepTestSphere(ezPhysicsCastResult& out_result, float f
 
   const JPH::SphereShape shape(fSphereRadius);
 
-  return SweepTest(out_result, shape, JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vStart)), vDir, fDistance, params, collection);
+  return SweepTest(out_result, shape, JPH::Vec3(1., 1., 1.), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vStart)), vDir, fDistance, params, collection);
 }
 
 bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
@@ -199,8 +199,9 @@ bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBo
   const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  return SweepTest(out_result, shape, trans, vDir, fDistance, params, collection);
+  return SweepTest(out_result, shape, scale, trans, vDir, fDistance, params, collection);
 }
 
 bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
@@ -208,7 +209,11 @@ bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float 
   if (fCapsuleRadius <= 0.0f)
     return false;
 
-  const JPH::CapsuleShape shape(fCapsuleHeight * 0.5f, fCapsuleRadius);
+  const ezVec3 vScaleAbs = transform.m_vScale.Abs();
+  const float fHeightTransformed = fCapsuleHeight * vScaleAbs.z;
+  const float fRadiusTransformed = fCapsuleRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  const JPH::CapsuleShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
 
   ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
 
@@ -217,11 +222,12 @@ bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float 
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  return SweepTest(out_result, shape, trans, vDir, fDistance, params, collection);
+  return SweepTest(out_result, shape, scale, trans, vDir, fDistance, params, collection);
 }
 
-bool ezJoltWorldModule::SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
+bool ezJoltWorldModule::SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
 {
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
@@ -229,7 +235,7 @@ bool ezJoltWorldModule::SweepTest(ezPhysicsCastResult& out_Result, const JPH::Sh
   ezJoltBodyFilter bodyFilter(params.m_uiIgnoreObjectFilterID);
   ezJoltObjectLayerFilter objectFilter(params.m_uiCollisionLayer);
 
-  JPH::RShapeCast cast(&shape, JPH::Vec3(1, 1, 1), transform, ezJoltConversionUtils::ToVec3(vDir * fDistance));
+  JPH::RShapeCast cast(&shape, scale, transform, ezJoltConversionUtils::ToVec3(vDir * fDistance));
 
   ezJoltShapeCastCollector collector;
   collector.m_bAnyHit = collection == ezPhysicsHitCollection::Any;
@@ -284,15 +290,15 @@ bool ezJoltWorldModule::OverlapTestSphere(float fSphereRadius, const ezVec3& vPo
 
   const JPH::SphereShape shape(fSphereRadius);
 
-  return OverlapTest(shape, JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition)), params);
+  return OverlapTest(shape, JPH::Vec3(1, 1, 1), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition)), params);
 }
 
 bool ezJoltWorldModule::OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
 {
-  if (fCapsuleRadius <= 0.0f)
+  if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
     return false;
 
-  const JPH::CapsuleShape shape(fCapsuleHeight * 0.5f, fCapsuleRadius);
+  const JPH::CapsuleShape shape(fCapsuleRadius * 0.5f, fCapsuleHeight);
 
   ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
 
@@ -301,11 +307,12 @@ bool ezJoltWorldModule::OverlapTestCapsule(float fCapsuleRadius, float fCapsuleH
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  return OverlapTest(shape, trans, params);
+  return OverlapTest(shape, scale, trans, params);
 }
 
-bool ezJoltWorldModule::OverlapTest(const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
+bool ezJoltWorldModule::OverlapTest(const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
 {
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
@@ -314,7 +321,7 @@ bool ezJoltWorldModule::OverlapTest(const JPH::Shape& shape, const JPH::Mat44& t
   ezJoltObjectLayerFilter objectFilter(params.m_uiCollisionLayer);
 
   ezJoltShapeCollectorAny collector;
-  query.CollideShape(&shape, JPH::Vec3(1, 1, 1), transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
+  query.CollideShape(&shape, scale, transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
 
   return collector.m_bFoundAny;
 }
@@ -329,7 +336,7 @@ void ezJoltWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_res
   const JPH::SphereShape shape(fSphereRadius);
   const JPH::Mat44 trans = JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition));
 
-  QueryShapes(out_results, shape, trans, params);
+  QueryShapes(out_results, shape, JPH::Vec3(1, 1, 1), trans, params);
 }
 
 void ezJoltWorldModule::QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
@@ -342,8 +349,9 @@ void ezJoltWorldModule::QueryShapesInBox(ezPhysicsOverlapResultArray& out_result
   const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation),
                                                             ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  QueryShapes(out_results, shape, trans, params);
+  QueryShapes(out_results, shape, scale, trans, params);
 }
 
 void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
@@ -353,7 +361,11 @@ void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_re
   if (fCapsuleRadius <= 0.0f)
     return;
 
-  const JPH::CapsuleShape shape(fCapsuleHeight * 0.5f, fCapsuleRadius);
+  const ezVec3 vScaleAbs = transform.m_vScale.Abs();
+  const float fHeightTransformed = fCapsuleHeight * vScaleAbs.z;
+  const float fRadiusTransformed = fCapsuleRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  const JPH::CapsuleShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
 
   ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
 
@@ -362,11 +374,12 @@ void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_re
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  QueryShapes(out_results, shape, trans, params);
+  QueryShapes(out_results, shape, scale, trans, params);
 }
 
-void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
+void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
 {
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
@@ -376,7 +389,7 @@ void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, co
 
   ezJoltShapeCollectorAll collector;
 
-  query.CollideShape(&shape, JPH::RVec3(1, 1, 1), transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
+  query.CollideShape(&shape, scale, transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
 
   out_results.m_Results.SetCount(collector.m_Results.GetCount());
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -194,8 +194,11 @@ bool ezJoltWorldModule::SweepTestSphere(ezPhysicsCastResult& out_result, float f
   return SweepTest(out_result, shape, JPH::Vec3(1., 1., 1.), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vStart)), vDir, fDistance, params, collection);
 }
 
-bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
+bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, const ezVec3& vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
 {
+  if (vBoxExtents.x <= 0.0f || vBoxExtents.y <= 0.0f || vBoxExtents.z <= 0.0f)
+    return false;
+
   const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
@@ -206,7 +209,7 @@ bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBo
 
 bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
 {
-  if (fCapsuleRadius <= 0.0f)
+  if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
     return false;
 
   const ezVec3 vScaleAbs = transform.m_vScale.Abs();
@@ -295,6 +298,20 @@ bool ezJoltWorldModule::OverlapTestSphere(float fSphereRadius, const ezVec3& vPo
   return OverlapTest(shape, JPH::Vec3(1, 1, 1), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition)), params);
 }
 
+bool ezJoltWorldModule::OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& vPosition, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
+{
+  if (vBoxExtents.x <= 0.0f || vBoxExtents.y <= 0.0f || vBoxExtents.z <= 0.0f)
+    return false;
+
+  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
+
+  const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation),
+                                                            ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
+
+  return OverlapTest(shape, scale, trans, params);
+}
+
 bool ezJoltWorldModule::OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
 {
   if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
@@ -362,7 +379,7 @@ void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_re
 {
   out_results.m_Results.Clear();
 
-  if (fCapsuleRadius <= 0.0f)
+  if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
     return;
 
   const ezVec3 vScaleAbs = transform.m_vScale.Abs();

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -191,7 +191,7 @@ bool ezJoltWorldModule::SweepTestSphere(ezPhysicsCastResult& out_result, float f
 
   const JPH::SphereShape shape(fSphereRadius);
 
-  return SweepTest(out_result, shape, JPH::Vec3(1., 1., 1.), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vStart)), vDir, fDistance, params, collection);
+  return SweepTest(out_result, shape, JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vStart)), vDir, fDistance, params, collection);
 }
 
 bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, const ezVec3& vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
@@ -199,22 +199,21 @@ bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, const ezVe
   if (vBoxExtents.x <= 0.0f || vBoxExtents.y <= 0.0f || vBoxExtents.z <= 0.0f)
     return false;
 
-  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
+  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents.CompMul(transform.m_vScale.Abs()) * 0.5f));
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  return SweepTest(out_result, shape, scale, trans, vDir, fDistance, params, collection);
+  return SweepTest(out_result, shape, trans, vDir, fDistance, params, collection);
 }
 
 bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
 {
-  if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
-    return false;
-
   const ezVec3 vScaleAbs = transform.m_vScale.Abs();
   const float fHeightTransformed = fCapsuleHeight * vScaleAbs.z;
   const float fRadiusTransformed = fCapsuleRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  if (fRadiusTransformed <= 0.0f || fHeightTransformed <= 0.0f)
+    return false;
 
   const JPH::CapsuleShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
 
@@ -225,14 +224,33 @@ bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float 
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale(transform.m_vScale.x,
-                        transform.m_vScale.z,
-                        transform.m_vScale.y);
 
-  return SweepTest(out_result, shape, scale, trans, vDir, fDistance, params, collection);
+  return SweepTest(out_result, shape, trans, vDir, fDistance, params, collection);
 }
 
-bool ezJoltWorldModule::SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
+bool ezJoltWorldModule::SweepTestCylinder(ezPhysicsCastResult& out_result, float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
+{
+  const ezVec3 vScaleAbs = transform.m_vScale.Abs();
+  const float fHeightTransformed = fCylinderHeight * vScaleAbs.z;
+  const float fRadiusTransformed = fCylinderRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  if (fRadiusTransformed <= 0.0f || fHeightTransformed <= 0.0f)
+    return false;
+
+  const JPH::CylinderShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
+
+  ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
+
+  ezQuat qRot;
+  qRot = transform.m_qRotation;
+  qRot = qRot * qFixRot;
+
+  const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+
+  return SweepTest(out_result, shape, trans, vDir, fDistance, params, collection);
+}
+
+bool ezJoltWorldModule::SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
 {
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
@@ -240,7 +258,7 @@ bool ezJoltWorldModule::SweepTest(ezPhysicsCastResult& out_Result, const JPH::Sh
   ezJoltBodyFilter bodyFilter(params.m_uiIgnoreObjectFilterID);
   ezJoltObjectLayerFilter objectFilter(params.m_uiCollisionLayer);
 
-  JPH::RShapeCast cast(&shape, scale, transform, ezJoltConversionUtils::ToVec3(vDir * fDistance));
+  JPH::RShapeCast cast(&shape, JPH::RVec3::sOne(), transform, ezJoltConversionUtils::ToVec3(vDir * fDistance));
 
   ezJoltShapeCastCollector collector;
   collector.m_bAnyHit = collection == ezPhysicsHitCollection::Any;
@@ -295,7 +313,7 @@ bool ezJoltWorldModule::OverlapTestSphere(float fSphereRadius, const ezVec3& vPo
 
   const JPH::SphereShape shape(fSphereRadius);
 
-  return OverlapTest(shape, JPH::Vec3(1, 1, 1), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition)), params);
+  return OverlapTest(shape, JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition)), params);
 }
 
 bool ezJoltWorldModule::OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& vPosition, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
@@ -303,21 +321,24 @@ bool ezJoltWorldModule::OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& 
   if (vBoxExtents.x <= 0.0f || vBoxExtents.y <= 0.0f || vBoxExtents.z <= 0.0f)
     return false;
 
-  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
+  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents.CompMul(transform.m_vScale.Abs()) * 0.5f));
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation),
                                                             ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  return OverlapTest(shape, scale, trans, params);
+  return OverlapTest(shape, trans, params);
 }
 
 bool ezJoltWorldModule::OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
 {
-  if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
+  const ezVec3 vScaleAbs = transform.m_vScale.Abs();
+  const float fHeightTransformed = fCapsuleHeight * vScaleAbs.z;
+  const float fRadiusTransformed = fCapsuleRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  if (fRadiusTransformed <= 0.0f || fHeightTransformed <= 0.0f)
     return false;
 
-  const JPH::CapsuleShape shape(fCapsuleRadius * 0.5f, fCapsuleHeight);
+  const JPH::CapsuleShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
 
   ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
 
@@ -326,14 +347,33 @@ bool ezJoltWorldModule::OverlapTestCapsule(float fCapsuleRadius, float fCapsuleH
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale(transform.m_vScale.x,
-                        transform.m_vScale.z,
-                        transform.m_vScale.y);
 
-  return OverlapTest(shape, scale, trans, params);
+  return OverlapTest(shape, trans, params);
 }
 
-bool ezJoltWorldModule::OverlapTest(const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
+bool ezJoltWorldModule::OverlapTestCylinder(float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
+{
+  const ezVec3 vScaleAbs = transform.m_vScale.Abs();
+  const float fHeightTransformed = fCylinderHeight * vScaleAbs.z;
+  const float fRadiusTransformed = fCylinderRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  if (fRadiusTransformed <= 0.0f || fHeightTransformed <= 0.0f)
+    return false;
+
+  const JPH::CylinderShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
+
+  ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
+
+  ezQuat qRot;
+  qRot = transform.m_qRotation;
+  qRot = qRot * qFixRot;
+
+  const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+
+  return OverlapTest(shape, trans, params);
+}
+
+bool ezJoltWorldModule::OverlapTest(const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
 {
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
@@ -342,7 +382,7 @@ bool ezJoltWorldModule::OverlapTest(const JPH::Shape& shape, const JPH::Vec3& sc
   ezJoltObjectLayerFilter objectFilter(params.m_uiCollisionLayer);
 
   ezJoltShapeCollectorAny collector;
-  query.CollideShape(&shape, scale, transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
+  query.CollideShape(&shape, JPH::RVec3::sOne(), transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
 
   return collector.m_bFoundAny;
 }
@@ -357,7 +397,7 @@ void ezJoltWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_res
   const JPH::SphereShape shape(fSphereRadius);
   const JPH::Mat44 trans = JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition));
 
-  QueryShapes(out_results, shape, JPH::Vec3(1, 1, 1), trans, params);
+  QueryShapes(out_results, shape, trans, params);
 }
 
 void ezJoltWorldModule::QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
@@ -367,24 +407,23 @@ void ezJoltWorldModule::QueryShapesInBox(ezPhysicsOverlapResultArray& out_result
   if (vBoxExtents.x <= 0.0f || vBoxExtents.y <= 0.0f || vBoxExtents.z <= 0.0f)
     return;
 
-  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
+  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents.CompMul(transform.m_vScale.Abs()) * 0.5f));
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation),
                                                             ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
 
-  QueryShapes(out_results, shape, scale, trans, params);
+  QueryShapes(out_results, shape, trans, params);
 }
 
 void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
 {
   out_results.m_Results.Clear();
 
-  if (fCapsuleRadius <= 0.0f || fCapsuleHeight <= 0.0f)
-    return;
-
   const ezVec3 vScaleAbs = transform.m_vScale.Abs();
   const float fHeightTransformed = fCapsuleHeight * vScaleAbs.z;
   const float fRadiusTransformed = fCapsuleRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  if (fRadiusTransformed <= 0.0f || fHeightTransformed <= 0.0f)
+    return;
 
   const JPH::CapsuleShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
 
@@ -395,14 +434,35 @@ void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_re
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale(transform.m_vScale.x,
-                        transform.m_vScale.z,
-                        transform.m_vScale.y);
 
-  QueryShapes(out_results, shape, scale, trans, params);
+  QueryShapes(out_results, shape, trans, params);
 }
 
-void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
+void ezJoltWorldModule::QueryShapesInCylinder(ezPhysicsOverlapResultArray& out_results, float fCylinderRadius, float fCylindereHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
+{
+  out_results.m_Results.Clear();
+
+  const ezVec3 vScaleAbs = transform.m_vScale.Abs();
+  const float fHeightTransformed = fCylindereHeight * vScaleAbs.z;
+  const float fRadiusTransformed = fCylinderRadius * ezMath::Max(vScaleAbs.x, vScaleAbs.y);
+
+  if (fRadiusTransformed <= 0.0f || fHeightTransformed <= 0.0f)
+    return;
+
+  const JPH::CylinderShape shape(fHeightTransformed * 0.5f, fRadiusTransformed);
+
+  ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
+
+  ezQuat qRot;
+  qRot = transform.m_qRotation;
+  qRot = qRot * qFixRot;
+
+  const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+
+  QueryShapes(out_results, shape, trans, params);
+}
+
+void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
 {
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
@@ -412,7 +472,7 @@ void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, co
 
   ezJoltShapeCollectorAll collector;
 
-  query.CollideShape(&shape, scale, transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
+  query.CollideShape(&shape, JPH::RVec3::sOne(), transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
 
   out_results.m_Results.SetCount(collector.m_Results.GetCount());
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -222,7 +222,9 @@ bool ezJoltWorldModule::SweepTestCapsule(ezPhysicsCastResult& out_result, float 
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
+  const JPH::Vec3 scale(transform.m_vScale.x,
+                        transform.m_vScale.z,
+                        transform.m_vScale.y);
 
   return SweepTest(out_result, shape, scale, trans, vDir, fDistance, params, collection);
 }
@@ -307,7 +309,9 @@ bool ezJoltWorldModule::OverlapTestCapsule(float fCapsuleRadius, float fCapsuleH
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
+  const JPH::Vec3 scale(transform.m_vScale.x,
+                        transform.m_vScale.z,
+                        transform.m_vScale.y);
 
   return OverlapTest(shape, scale, trans, params);
 }
@@ -374,7 +378,9 @@ void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_re
   qRot = qRot * qFixRot;
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
-  const JPH::Vec3 scale = ezJoltConversionUtils::ToVec3(transform.m_vScale);
+  const JPH::Vec3 scale(transform.m_vScale.x,
+                        transform.m_vScale.z,
+                        transform.m_vScale.y);
 
   QueryShapes(out_results, shape, scale, trans, params);
 }

--- a/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltQueries.cpp
@@ -194,9 +194,9 @@ bool ezJoltWorldModule::SweepTestSphere(ezPhysicsCastResult& out_result, float f
   return SweepTest(out_result, shape, JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vStart)), vDir, fDistance, params, collection);
 }
 
-bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtends, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
+bool ezJoltWorldModule::SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const
 {
-  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtends * 0.5f));
+  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
 
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
 
@@ -327,6 +327,47 @@ void ezJoltWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_res
     return;
 
   const JPH::SphereShape shape(fSphereRadius);
+  const JPH::Mat44 trans = JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition));
+
+  QueryShapes(out_results, shape, trans, params);
+}
+
+void ezJoltWorldModule::QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
+{
+  out_results.m_Results.Clear();
+
+  if (vBoxExtents.x <= 0.0f || vBoxExtents.y <= 0.0f || vBoxExtents.z <= 0.0f)
+    return;
+
+  const JPH::BoxShape shape(ezJoltConversionUtils::ToVec3(vBoxExtents * 0.5f));
+  const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(transform.m_qRotation),
+                                                            ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+
+  QueryShapes(out_results, shape, trans, params);
+}
+
+void ezJoltWorldModule::QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const
+{
+  out_results.m_Results.Clear();
+
+  if (fCapsuleRadius <= 0.0f)
+    return;
+
+  const JPH::CapsuleShape shape(fCapsuleHeight * 0.5f, fCapsuleRadius);
+
+  ezQuat qFixRot = ezQuat::MakeFromAxisAndAngle(ezVec3(1, 0, 0), ezAngle::MakeFromDegree(90.0f));
+
+  ezQuat qRot;
+  qRot = transform.m_qRotation;
+  qRot = qRot * qFixRot;
+
+  const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qRot), ezJoltConversionUtils::ToVec3(transform.m_vPosition));
+
+  QueryShapes(out_results, shape, trans, params);
+}
+
+void ezJoltWorldModule::QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const
+{
   const JPH::NarrowPhaseQuery& query = m_pSystem->GetNarrowPhaseQuery();
 
   ezJoltBroadPhaseLayerFilter broadphaseFilter(params.m_ShapeTypes);
@@ -334,7 +375,8 @@ void ezJoltWorldModule::QueryShapesInSphere(ezPhysicsOverlapResultArray& out_res
   ezJoltBodyFilter bodyFilter(params.m_uiIgnoreObjectFilterID);
 
   ezJoltShapeCollectorAll collector;
-  query.CollideShape(&shape, JPH::RVec3(1, 1, 1), JPH::Mat44::sTranslation(ezJoltConversionUtils::ToVec3(vPosition)), {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
+
+  query.CollideShape(&shape, JPH::RVec3(1, 1, 1), transform, {}, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, bodyFilter);
 
   out_results.m_Results.SetCount(collector.m_Results.GetCount());
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -68,17 +68,23 @@ public:
 
   virtual bool SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
+  virtual bool SweepTestCylinder(ezPhysicsCastResult& out_result, float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
+
   virtual bool OverlapTestSphere(float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const override;
 
   virtual bool OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& vPosition, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
   virtual bool OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
+  virtual bool OverlapTestCylinder(float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
+
   virtual void QueryShapesInSphere(ezPhysicsOverlapResultArray& out_results, float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const override;
 
   virtual void QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
   virtual void QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
+
+  virtual void QueryShapesInCylinder(ezPhysicsOverlapResultArray& out_results, float fCylinderRadius, float fCylinderHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
   virtual void AddStaticCollisionBox(ezGameObject* pObject, ezVec3 vBoxSize) override;
 
@@ -120,9 +126,9 @@ public:
   ezUInt64 GetJoltUpdateCounter() const { return m_uiJoltUpdateCounter; }
 
 private:
-  bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
-  bool OverlapTest(const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
-  void QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
+  bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
+  bool OverlapTest(const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
+  void QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
 
   void FreeUserDataAfterSimulationStep();
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -118,9 +118,9 @@ public:
   ezUInt64 GetJoltUpdateCounter() const { return m_uiJoltUpdateCounter; }
 
 private:
-  bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
-  bool OverlapTest(const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
-  void QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
+  bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
+  bool OverlapTest(const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
+  void QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Vec3& scale, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
 
   void FreeUserDataAfterSimulationStep();
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -64,7 +64,7 @@ public:
 
   virtual bool SweepTestSphere(ezPhysicsCastResult& out_result, float fSphereRadius, const ezVec3& vStart, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
-  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtends, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
+  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
   virtual bool SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
@@ -73,6 +73,10 @@ public:
   virtual bool OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
   virtual void QueryShapesInSphere(ezPhysicsOverlapResultArray& out_results, float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const override;
+
+  virtual void QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const;
+
+  virtual void QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const;
 
   virtual void AddStaticCollisionBox(ezGameObject* pObject, ezVec3 vBoxSize) override;
 
@@ -116,6 +120,7 @@ public:
 private:
   bool SweepTest(ezPhysicsCastResult& out_Result, const JPH::Shape& shape, const JPH::Mat44& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection) const;
   bool OverlapTest(const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
+  void QueryShapes(ezPhysicsOverlapResultArray& out_results, const JPH::Shape& shape, const JPH::Mat44& transform, const ezPhysicsQueryParameters& params) const;
 
   void FreeUserDataAfterSimulationStep();
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -64,11 +64,13 @@ public:
 
   virtual bool SweepTestSphere(ezPhysicsCastResult& out_result, float fSphereRadius, const ezVec3& vStart, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
-  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, ezVec3 vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
+  virtual bool SweepTestBox(ezPhysicsCastResult& out_result, const ezVec3& vBoxExtents, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
   virtual bool SweepTestCapsule(ezPhysicsCastResult& out_result, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezVec3& vDir, float fDistance, const ezPhysicsQueryParameters& params, ezPhysicsHitCollection collection = ezPhysicsHitCollection::Closest) const override;
 
   virtual bool OverlapTestSphere(float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const override;
+
+  virtual bool OverlapTestBox(const ezVec3& vBoxExtents, const ezVec3& vPosition, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
   virtual bool OverlapTestCapsule(float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -74,9 +74,9 @@ public:
 
   virtual void QueryShapesInSphere(ezPhysicsOverlapResultArray& out_results, float fSphereRadius, const ezVec3& vPosition, const ezPhysicsQueryParameters& params) const override;
 
-  virtual void QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const;
+  virtual void QueryShapesInBox(ezPhysicsOverlapResultArray& out_results, const ezVec3& vBoxExtents, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
-  virtual void QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const;
+  virtual void QueryShapesInCapsule(ezPhysicsOverlapResultArray& out_results, float fCapsuleRadius, float fCapsuleHeight, const ezTransform& transform, const ezPhysicsQueryParameters& params) const override;
 
   virtual void AddStaticCollisionBox(ezGameObject* pObject, ezVec3 vBoxSize) override;
 


### PR DESCRIPTION
We discussed this topic in Discord channel. Opening PR in case these changes might be helpful.

Some additional considerations:
- Fixed "BoxExtends" -> "BoxExtents"
- `transform` parameter in `SweepTestBox` and `QueryShapesInBox` is ambiguous. Implementation uses only position and rotation parts. Perhaps it's better to split transform into two params.