### PR TITLE
Linux Unit Test Fixes

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,6 +30,10 @@
         "EZ_ENABLE_FOLDER_UNITY_FILES" : "ON",
         "EZ_COMPILE_ENGINE_AS_DLL" : "ON",
         "CMAKE_EXPORT_COMPILE_COMMANDS" : "ON"
+      },
+      "environment": {
+        "VK_LAYER_PATH" : "${sourceDir}/Workspace/shared/vulkan-sdk/1.3.275.0/x86_64/share/vulkan/explicit_layer.d",
+        "LD_LIBRARY_PATH" : "${sourceDir}/Workspace/shared/vulkan-sdk/1.3.275.0/x86_64/lib"
       }
     },
     {

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -237,7 +237,8 @@ endfunction()
 # #####################################
 function(ez_set_build_flags_gcc TARGET_NAME)
 	# Wno-enum-compare removes all annoying enum cast warnings
-	target_compile_options(${TARGET_NAME} PRIVATE -fPIC -Wno-enum-compare -gdwarf-3 -pthread)
+	# -fno-gnu-unique prevents symbols like static inline or static templates to be marked with STB_GNU_UNIQUE, preventing the owning dll from being unloaded.
+	target_compile_options(${TARGET_NAME} PRIVATE -fPIC -Wno-enum-compare -gdwarf-3 -pthread -fno-gnu-unique)
 
 	if(EZ_CMAKE_ARCHITECTURE_X86)
 		target_compile_options(${TARGET_NAME} PRIVATE -mssse3 -mfpmath=sse)

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -194,6 +194,11 @@ void ezQtAssetBrowserModel::resetModel()
   m_EntriesToDisplay.Clear();
   m_DisplayedEntries.Clear();
 
+  // Get Curator Mutex first to prevent deadlocks
+  ezAssetCurator::ezLockedSubAssetTable AllAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
+  const ezHashTable<ezUuid, ezSubAsset>& AllAssets = *(AllAssetsLocked.operator->());
+
+  auto allFiles = ezFileSystemModel::GetSingleton()->GetFiles();
   auto allFolders = ezFileSystemModel::GetSingleton()->GetFolders();
 
   for (const auto& folder : *allFolders)
@@ -205,8 +210,6 @@ void ezQtAssetBrowserModel::resetModel()
     entry.m_Flags = folder.Key().GetDataDirRelativePath().IsEmpty() ? ezAssetBrowserItemFlags::DataDirectory : ezAssetBrowserItemFlags::Folder;
     entry.m_sAbsFilePath = folder.Key();
   }
-
-  auto allFiles = ezFileSystemModel::GetSingleton()->GetFiles();
 
   for (const auto& file : *allFiles)
   {
@@ -251,8 +254,6 @@ void ezQtAssetBrowserModel::resetModel()
     }
   }
 
-  ezAssetCurator::ezLockedSubAssetTable AllAssetsLocked = ezAssetCurator::GetSingleton()->GetKnownSubAssets();
-  const ezHashTable<ezUuid, ezSubAsset>& AllAssets = *(AllAssetsLocked.operator->());
 
   FileComparer cmp(this, AllAssets);
   m_EntriesToDisplay.Sort(cmp);

--- a/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
+++ b/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
@@ -129,6 +129,7 @@ protected:
 protected:
   void EngineViewProcessEventHandler(const ezEditorEngineProcessConnection::Event& e);
   void ShowRestartButton(bool bShow);
+  void RecreateEngineViewport();
   virtual void OnOpenContextMenu(QPoint globalPos) {}
   virtual void HandleMarqueePickingResult(const ezViewMarqueePickingResultMsgToEditor* pMsg) {}
 
@@ -140,7 +141,7 @@ protected:
   bool m_bPickTransparent = true;
   bool m_bInDragAndDropOperation;
   ezUInt32 m_uiViewID;
-  ezQtEngineDocumentWindow* m_pDocumentWindow;
+  ezQtEngineDocumentWindow* m_pDocumentWindow = nullptr;
 
   static ezUInt32 s_uiNextViewID;
 
@@ -155,8 +156,9 @@ protected:
   ezVec3 m_vCameraUp;
   ezTime m_LastCameraUpdate;
 
-  QHBoxLayout* m_pRestartButtonLayout;
-  QPushButton* m_pRestartButton;
+  QHBoxLayout* m_pMainLayout = nullptr;
+  QPushButton* m_pRestartButton = nullptr;
+  QWidget* m_pViewportWidget = nullptr;
 
   mutable ezObjectPickingResult m_LastPickingResult;
 

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -27,8 +27,8 @@ void ezObjectPickingResult::Reset()
 class ezQtNativeSurfaceWidget : public QWidget
 {
 public:
-  ezQtNativeSurfaceWidget(QWidget* parent = nullptr)
-    : QWidget(parent)
+  ezQtNativeSurfaceWidget(QWidget* pParent = nullptr)
+    : QWidget(pParent)
   {
     // setAttribute(Qt::WA_OpaquePaintEvent);
     setAutoFillBackground(false);

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -40,7 +40,7 @@ public:
     setAttribute(Qt::WA_NoSystemBackground);
   }
 
-  virtual void paintEvent(QPaintEvent* event) override {}
+  virtual void paintEvent(QPaintEvent* pEvent) override {}
   virtual QPaintEngine* paintEngine() const override { return nullptr; }
 };
 

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -23,6 +23,27 @@ void ezObjectPickingResult::Reset()
   m_vPickingRayStart.SetZero();
 }
 
+/// \brief Small helper class which exposes the native surface that the renderer can render into.
+class ezQtNativeSurfaceWidget : public QWidget
+{
+public:
+  ezQtNativeSurfaceWidget(QWidget* parent = nullptr)
+  : QWidget(parent)
+  {
+    // setAttribute(Qt::WA_OpaquePaintEvent);
+    setAutoFillBackground(false);
+    setMouseTracking(true);
+    setMinimumSize(64, 64); // prevent the window from becoming zero sized, otherwise the rendering code may crash
+
+    setAttribute(Qt::WA_PaintOnScreen, true);
+    setAttribute(Qt::WA_NativeWindow, true);
+    setAttribute(Qt::WA_NoSystemBackground);
+  }
+
+  virtual void paintEvent(QPaintEvent* event) override  {}
+  virtual QPaintEngine* paintEngine() const override { return nullptr; }
+};
+
 ////////////////////////////////////////////////////////////////////////
 // ezQtEngineViewWidget public functions
 ////////////////////////////////////////////////////////////////////////
@@ -34,20 +55,16 @@ ezQtEngineViewWidget::ezQtEngineViewWidget(QWidget* pParent, ezQtEngineDocumentW
   , m_pDocumentWindow(pDocumentWindow)
   , m_pViewConfig(pViewConfig)
 {
-  m_pRestartButtonLayout = nullptr;
-  m_pRestartButton = nullptr;
-
-  setFocusPolicy(Qt::FocusPolicy::StrongFocus);
-  // setAttribute(Qt::WA_OpaquePaintEvent);
   setAutoFillBackground(false);
   setMouseTracking(true);
-  setMinimumSize(64, 64); // prevent the window from becoming zero sized, otherwise the rendering code may crash
+  setMinimumSize(64, 64);
+  setFocusPolicy(Qt::FocusPolicy::StrongFocus);
 
-  setAttribute(Qt::WA_PaintOnScreen, true);
-  setAttribute(Qt::WA_NativeWindow, true);
-  setAttribute(Qt::WA_NoSystemBackground);
+  m_pMainLayout = new QHBoxLayout(this);
+  m_pMainLayout->setContentsMargins(0, 0, 0, 0);
+  setLayout(m_pMainLayout);
 
-  installEventFilter(this);
+  RecreateEngineViewport();
 
   m_bUpdatePickingData = false;
   m_bInDragAndDropOperation = false;
@@ -117,11 +134,11 @@ void ezQtEngineViewWidget::SyncToEngine()
   cam.m_vDirRight = m_pViewConfig->m_Camera.GetCenterDirRight();
   cam.m_vPosition = m_pViewConfig->m_Camera.GetCenterPosition();
   cam.m_ViewMatrix = m_pViewConfig->m_Camera.GetViewMatrix();
-  m_pViewConfig->m_Camera.GetProjectionMatrix((float)width() / (float)height(), cam.m_ProjMatrix);
+  m_pViewConfig->m_Camera.GetProjectionMatrix((float)m_pViewportWidget->width() / (float)m_pViewportWidget->height(), cam.m_ProjMatrix);
 
-  cam.m_uiHWND = (ezUInt64)(winId());
-  cam.m_uiWindowWidth = width() * this->devicePixelRatio();
-  cam.m_uiWindowHeight = height() * this->devicePixelRatio();
+  cam.m_uiHWND = (ezUInt64)(m_pViewportWidget->winId());
+  cam.m_uiWindowWidth = m_pViewportWidget->width() * this->devicePixelRatio();
+  cam.m_uiWindowHeight = m_pViewportWidget->height() * this->devicePixelRatio();
   cam.m_bUpdatePickingData = m_bUpdatePickingData;
   cam.m_bEnablePickingSelected = IsPickingAgainstSelectionAllowed() && (!ezEditorInputContext::IsAnyInputContextActive() || ezEditorInputContext::GetActiveInputContext()->IsPickingSelectedAllowed());
   cam.m_bEnablePickTransparent = m_bPickTransparent;
@@ -139,7 +156,7 @@ void ezQtEngineViewWidget::SyncToEngine()
 void ezQtEngineViewWidget::GetCameraMatrices(ezMat4& out_mViewMatrix, ezMat4& out_mProjectionMatrix) const
 {
   out_mViewMatrix = m_pViewConfig->m_Camera.GetViewMatrix();
-  m_pViewConfig->m_Camera.GetProjectionMatrix((float)width() / (float)height(), out_mProjectionMatrix);
+  m_pViewConfig->m_Camera.GetProjectionMatrix((float)m_pViewportWidget->width() / (float)m_pViewportWidget->height(), out_mProjectionMatrix);
 }
 
 void ezQtEngineViewWidget::UpdateCameraInterpolation()
@@ -262,14 +279,14 @@ ezResult ezQtEngineViewWidget::PickPlane(ezUInt16 uiScreenPosX, ezUInt16 uiScree
 
   ezMat4 mView = cam.GetViewMatrix();
   ezMat4 mProj;
-  cam.GetProjectionMatrix((float)width() / (float)height(), mProj);
+  cam.GetProjectionMatrix((float)m_pViewportWidget->width() / (float)m_pViewportWidget->height(), mProj);
   ezMat4 mViewProj = mProj * mView;
   ezMat4 mInvViewProj = mViewProj.GetInverse();
 
   ezVec3 vScreenPos(uiScreenPosX, uiScreenPosY, 0);
   ezVec3 vResPos, vResRay;
 
-  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(mInvViewProj, 0, 0, width(), height(), vScreenPos, vResPos, &vResRay).Failed())
+  if (ezGraphicsUtils::ConvertScreenPosToWorldPos(mInvViewProj, 0, 0, m_pViewportWidget->width(), m_pViewportWidget->height(), vScreenPos, vResPos, &vResRay).Failed())
     return EZ_FAILURE;
 
   if (plane.GetRayIntersection(vResPos, vResRay, nullptr, &out_vPosition))
@@ -628,6 +645,7 @@ void ezQtEngineViewWidget::EngineViewProcessEventHandler(const ezEditorEnginePro
 
     case ezEditorEngineProcessConnection::Event::Type::ProcessStarted:
     {
+      RecreateEngineViewport();
       ShowRestartButton(false);
     }
     break;
@@ -651,20 +669,15 @@ void ezQtEngineViewWidget::ShowRestartButton(bool bShow)
 {
   ezQtScopedUpdatesDisabled _(this);
 
-  if (m_pRestartButtonLayout == nullptr && bShow == true)
+  if (m_pRestartButton == nullptr && bShow == true)
   {
-    m_pRestartButtonLayout = new QHBoxLayout(this);
-    m_pRestartButtonLayout->setContentsMargins(0, 0, 0, 0);
-
-    setLayout(m_pRestartButtonLayout);
-
     m_pRestartButton = new QPushButton(this);
     m_pRestartButton->setText("Restart Engine View Process");
     m_pRestartButton->setVisible(ezEditorEngineProcessConnection::GetSingleton()->IsProcessCrashed());
     m_pRestartButton->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
     m_pRestartButton->connect(m_pRestartButton, &QPushButton::clicked, this, &ezQtEngineViewWidget::SlotRestartEngineProcess);
 
-    m_pRestartButtonLayout->addWidget(m_pRestartButton);
+    m_pMainLayout->addWidget(m_pRestartButton);
   }
 
   if (m_pRestartButton)
@@ -674,8 +687,36 @@ void ezQtEngineViewWidget::ShowRestartButton(bool bShow)
     if (bShow)
       m_pRestartButton->update();
   }
+
+  m_pViewportWidget->setVisible(!bShow);
 }
 
+void ezQtEngineViewWidget::RecreateEngineViewport()
+{
+  if (m_pViewportWidget)
+  {
+    m_pViewportWidget->removeEventFilter(this);
+    m_pViewportWidget->hide();
+    m_pViewportWidget->setParent(nullptr);
+    m_pViewportWidget->deleteLater();
+  }
+
+  m_pViewportWidget = new ezQtNativeSurfaceWidget(this);
+  m_pViewportWidget->installEventFilter(this);
+  m_pViewportWidget->setFocusProxy(this);
+  if (s_FixedResolution.HasNonZeroArea())
+  {
+    qreal pixelRatio = devicePixelRatio();
+    // When using DPI scaling, this could actually not be possible to achieve so we use the ceiling of the logical size. This is fine, as the editor tests crop the resulting image if not of the proper size.
+    m_pViewportWidget->setFixedSize(
+      static_cast<ezInt32>(ezMath::Ceil(s_FixedResolution.width / pixelRatio)),
+      static_cast<ezInt32>(ezMath::Ceil(s_FixedResolution.height / pixelRatio)));
+  }
+  else
+  {
+    m_pMainLayout->addWidget(m_pViewportWidget);
+  }
+}
 
 ////////////////////////////////////////////////////////////////////////
 // ezQtEngineViewWidget private slots

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -28,7 +28,7 @@ class ezQtNativeSurfaceWidget : public QWidget
 {
 public:
   ezQtNativeSurfaceWidget(QWidget* parent = nullptr)
-  : QWidget(parent)
+    : QWidget(parent)
   {
     // setAttribute(Qt::WA_OpaquePaintEvent);
     setAutoFillBackground(false);
@@ -40,7 +40,7 @@ public:
     setAttribute(Qt::WA_NoSystemBackground);
   }
 
-  virtual void paintEvent(QPaintEvent* event) override  {}
+  virtual void paintEvent(QPaintEvent* event) override {}
   virtual QPaintEngine* paintEngine() const override { return nullptr; }
 };
 

--- a/Code/Engine/Foundation/Platform/Posix/FileIterator_Posix.inl
+++ b/Code/Engine/Foundation/Platform/Posix/FileIterator_Posix.inl
@@ -62,7 +62,11 @@ namespace
     curFile.m_bIsDirectory = hCurrentFile->d_type == DT_DIR;
     curFile.m_sParentPath = curPath;
     curFile.m_sName = hCurrentFile->d_name;
+#    ifdef __USE_XOPEN2K8
+    curFile.m_LastModificationTime = ezTimestamp::MakeFromInt(fileStat.st_mtim.tv_sec * 1000000000ull + fileStat.st_mtim.tv_nsec, ezSIUnitOfTime::Nanosecond);
+#    else
     curFile.m_LastModificationTime = ezTimestamp::MakeFromInt(fileStat.st_mtime, ezSIUnitOfTime::Second);
+#    endif
 
     return EZ_SUCCESS;
   }

--- a/Code/Engine/Foundation/Platform/Posix/FileIterator_Posix.inl
+++ b/Code/Engine/Foundation/Platform/Posix/FileIterator_Posix.inl
@@ -62,11 +62,11 @@ namespace
     curFile.m_bIsDirectory = hCurrentFile->d_type == DT_DIR;
     curFile.m_sParentPath = curPath;
     curFile.m_sName = hCurrentFile->d_name;
-#    ifdef __USE_XOPEN2K8
+#ifdef __USE_XOPEN2K8
     curFile.m_LastModificationTime = ezTimestamp::MakeFromInt(fileStat.st_mtim.tv_sec * 1000000000ull + fileStat.st_mtim.tv_nsec, ezSIUnitOfTime::Nanosecond);
-#    else
+#else
     curFile.m_LastModificationTime = ezTimestamp::MakeFromInt(fileStat.st_mtime, ezSIUnitOfTime::Second);
-#    endif
+#endif
 
     return EZ_SUCCESS;
   }

--- a/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.inl
+++ b/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.inl
@@ -340,11 +340,11 @@ ezResult ezOSFile::InternalGetFileStats(ezStringView sFileOrFolder, ezFileStats&
   out_Stats.m_sParentPath = sFileOrFolder;
   out_Stats.m_sParentPath.PathParentDirectory();
   out_Stats.m_sName = ezPathUtils::GetFileNameAndExtension(sFileOrFolder); // no OS support, so just pass it through
-#ifdef __USE_XOPEN2K8
+#    ifdef __USE_XOPEN2K8
   out_Stats.m_LastModificationTime = ezTimestamp::MakeFromInt(tempStat.st_mtim.tv_sec * 1000000000ull + tempStat.st_mtim.tv_nsec, ezSIUnitOfTime::Nanosecond);
-#else
+#    else
   out_Stats.m_LastModificationTime = ezTimestamp::MakeFromInt(tempStat.st_mtime, ezSIUnitOfTime::Second);
-#endif
+#    endif
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.inl
+++ b/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.inl
@@ -340,8 +340,11 @@ ezResult ezOSFile::InternalGetFileStats(ezStringView sFileOrFolder, ezFileStats&
   out_Stats.m_sParentPath = sFileOrFolder;
   out_Stats.m_sParentPath.PathParentDirectory();
   out_Stats.m_sName = ezPathUtils::GetFileNameAndExtension(sFileOrFolder); // no OS support, so just pass it through
+#ifdef __USE_XOPEN2K8
+  out_Stats.m_LastModificationTime = ezTimestamp::MakeFromInt(tempStat.st_mtim.tv_sec * 1000000000ull + tempStat.st_mtim.tv_nsec, ezSIUnitOfTime::Nanosecond);
+#else
   out_Stats.m_LastModificationTime = ezTimestamp::MakeFromInt(tempStat.st_mtime, ezSIUnitOfTime::Second);
-
+#endif
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -89,7 +89,7 @@ void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
       {
         ezLog::Warning("Automatic swap-chain re-creation didn't have an effect, retrying");
       }
-      
+
       if (retryCount >= 4)
       {
         EZ_REPORT_FAILURE("Automatic swap-chain re-creation didn't have an effect 4 times in a row, application can't be recovered.");

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -65,7 +65,7 @@ namespace
 void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
 {
   EZ_PROFILE_SCOPE("AcquireNextRenderTarget");
-
+  auto pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   EZ_ASSERT_DEV(!m_currentPipelineImageAvailableSemaphore, "Pipeline semaphores leaked");
   m_currentPipelineImageAvailableSemaphore = ezSemaphorePoolVulkan::RequestSemaphore();
 
@@ -74,35 +74,36 @@ void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
   {
     // #TODO_VULKAN We leave the fence parameter blank as we do not care on the CPU whether a swap chain image is still in use or not. Currently, we daisy-chain each frame to the previous frame's semaphore. Not sure if this won't break if we stop doing that. If we call acquireNextImageKHR, can we be sure that the image is no longer in use?
     vk::Result result = m_pVulkanDevice->GetVulkanDevice().acquireNextImageKHR(m_vulkanSwapChain, std::numeric_limits<uint64_t>::max(), m_currentPipelineImageAvailableSemaphore, nullptr, &m_uiCurrentSwapChainImage);
-    if (result == vk::Result::eErrorOutOfDateKHR || result == vk::Result::eSuboptimalKHR)
+    if (result == vk::Result::eSuboptimalKHR)
     {
       const vk::SurfaceCapabilitiesKHR surfaceCapabilities = m_pVulkanDevice->GetVulkanPhysicalDevice().getSurfaceCapabilitiesKHR(m_vulkanSurface);
-      if (result == vk::Result::eSuboptimalKHR && (surfaceCapabilities.currentExtent.width != m_CurrentSize.width || surfaceCapabilities.currentExtent.height != m_CurrentSize.height))
+      if ((surfaceCapabilities.currentExtent.width != m_CurrentSize.width || surfaceCapabilities.currentExtent.height != m_CurrentSize.height))
       {
         ezLog::Warning("Swap-chain does not match the target window size and should be recreated. Expected size {0}x{1}, current size {2}x{3}.", surfaceCapabilities.currentExtent.width, surfaceCapabilities.currentExtent.height, m_CurrentSize.width, m_CurrentSize.height);
-        break;
+      }
+      break;
+    }
+    else if (result == vk::Result::eErrorOutOfDateKHR)
+    {
+      if (retryCount > 0)
+      {
+        ezLog::Warning("Automatic swap-chain re-creation didn't have an effect, retrying");
+      }
+      
+      if (retryCount >= 4)
+      {
+        EZ_REPORT_FAILURE("Automatic swap-chain re-creation didn't have an effect 4 times in a row, application can't be recovered.");
+      }
+      // It is not a size issue, re-create automatically
+      if (CreateSwapChainInternal().Failed())
+      {
+        ezLog::Error("Failed automatic swapchain re-creation");
       }
       else
       {
-        if (retryCount > 0)
-        {
-          ezLog::Error("Automatic swap-chain re-creation didn't have an effect");
-          break;
-        }
-        else
-        {
-          // It is not a size issue, re-create automatically
-          if (CreateSwapChainInternal().Failed())
-          {
-            ezLog::Error("Failed automatic swapchain re-creation");
-          }
-          else
-          {
-            ezLog::Info("Automatic swapchain re-creation succeeded");
-          }
-          retryCount++;
-        }
+        ezLog::Debug("Automatic swapchain re-creation succeeded");
       }
+      retryCount++;
     }
     else
     {
@@ -115,9 +116,6 @@ void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
 #endif
 
   m_RenderTargets.m_hRTs[0] = m_swapChainTextures[m_uiCurrentSwapChainImage];
-
-  auto pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
-  // pVulkanDevice->Submit();
   pVulkanDevice->AddWaitSemaphore(ezGALDeviceVulkan::SemaphoreInfo::MakeWaitSemaphore(m_currentPipelineImageAvailableSemaphore, vk::PipelineStageFlagBits::eColorAttachmentOutput));
   pVulkanDevice->ReclaimLater(m_currentPipelineImageAvailableSemaphore);
 }
@@ -125,6 +123,9 @@ void ezGALSwapChainVulkan::AcquireNextRenderTarget(ezGALDevice* pDevice)
 void ezGALSwapChainVulkan::PresentRenderTarget(ezGALDevice* pDevice)
 {
   EZ_PROFILE_SCOPE("PresentRenderTarget");
+  if (m_RenderTargets.m_hRTs[0].IsInvalidated())
+    return;
+
 
   auto pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   {

--- a/Code/EnginePlugins/AiPlugin/Navigation/Components/NavigationComponent.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Components/NavigationComponent.cpp
@@ -298,8 +298,6 @@ void ezAiNavigationComponent::Turn(ezTransform& transform, float tDiff)
   if (m_State != ezAiNavigationComponentState::Turning)
     return;
 
-  m_vTurnTowardsPos;
-
   ezAngle turnSpeed = ezAngle::MakeFromDegree(360);
 
   const ezVec3 vTargetDir = (m_vTurnTowardsPos.GetAsVec3(0) - GetOwner()->GetGlobalPosition()).GetNormalized();

--- a/Code/ThirdParty/ads/stylesheets/default_linux.css
+++ b/Code/ThirdParty/ads/stylesheets/default_linux.css
@@ -79,7 +79,7 @@ ads--CDockWidgetTab[activeTab="true"] {
 
 
 ads--CDockWidgetTab QLabel {
-	color: palette(dark);
+	color: palette(foreground);
 }
 
 

--- a/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/AssetDocument/AssetDocumentTest.cpp
@@ -347,7 +347,7 @@ void ezEditorAssetDocumentTest::FileOperations()
   sAbsAssetCopyPath.ChangeFileName("meshCopy");
   ezUuid copyGuid;
 
-  // Tests that copy gets a unique ID to resolev conflict.
+  // Tests that copy gets a unique ID to resolve conflict.
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Copy Asset")
   {
     const ezUuid mod = ezUuid::MakeStableUuidFromString(sAbsAssetCopyPath);

--- a/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
@@ -139,8 +139,6 @@ void ezMaterialDocumentTest::CaptureMaterialImage()
   if (!EZ_TEST_BOOL(pWindow != nullptr))
     return;
 
-  pWindow->backingStore()->window()->showMaximized();
-
   EZ_ANALYSIS_ASSUME(pWindow != nullptr);
   auto viewWidgets = pWindow->GetViewWidgets();
 

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -15,6 +15,7 @@
 #include <QMimeData>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
+#include <Texture/Image/ImageUtils.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 ezEditorTestApplication::ezEditorTestApplication()
@@ -109,7 +110,16 @@ ezResult ezEditorTest::GetImage(ezImage& ref_img, const ezSubTestEntry& subTest,
   if (!m_CapturedImage.IsValid())
     return EZ_FAILURE;
 
-  ref_img.ResetAndMove(std::move(m_CapturedImage));
+  if (m_CapturedImage.GetWidth() == 512 && m_CapturedImage.GetHeight() == 512)
+  {
+    ref_img.ResetAndMove(std::move(m_CapturedImage));
+  }
+  else
+  {
+    // Due to DPI scaling, we can't guarantee that the swapchain is exactly 512x512. The viewport still is though, so as long as we have something bigger the resulting image is correct if we crop off the remaining pixels.
+    ezImageUtils::CropImage(m_CapturedImage, {0, 0}, {512, 512}, ref_img);
+    m_CapturedImage.Clear();
+  }
   return EZ_SUCCESS;
 }
 

--- a/Data/UnitTests/GameEngineTest/Animations/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/Animations/RuntimeConfigs/Window.ddl
@@ -1,6 +1,6 @@
 WindowDesc
 {
-	string %Title{"AngelScript"}
+	string %Title{"ezEngine"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{1280,720}}
 	bool %ClipMouseCursor{false}

--- a/Data/UnitTests/GameEngineTest/Basics/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/Basics/RuntimeConfigs/Window.ddl
@@ -3,6 +3,8 @@ WindowDesc
 	string %Title{"GameEngineTest - Basics"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
+	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/Effects/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/Effects/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"GameEngineTest - Effects"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/Particles/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/Particles/RuntimeConfigs/Window.ddl
@@ -3,6 +3,8 @@ WindowDesc
 	string %Title{"GameEngineTest - Basics"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
+	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/PlatformWin/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/PlatformWin/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"Kraut"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{640,360}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/ProcGen/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/ProcGen/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"Procedural Generation"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/RmlUi/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/RmlUi/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"RmlUi"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{640,360}}
-	bool %ClipMouseCursor{false}
-	bool %ShowMouseCursor{true}
+	bool %ClipMouseCursor{true}
+	bool %ShowMouseCursor{false}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/StateMachine/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/StateMachine/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"State Machine"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/Substance/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/Substance/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"Substance"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/VisualScript/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/VisualScript/RuntimeConfigs/Window.ddl
@@ -3,7 +3,8 @@ WindowDesc
 	string %Title{"Visual Script"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
+	bool %CenterWindowOnDisplay{true}
 }

--- a/Data/UnitTests/GameEngineTest/XR/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/XR/RuntimeConfigs/Window.ddl
@@ -3,8 +3,8 @@ WindowDesc
 	string %Title{"GameEngineTest - XR"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{320,240}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
 	bool %CenterWindowOnDisplay{true}
 }


### PR DESCRIPTION
These changes will allow Linux to run all editor and gameengine tests successfully.
* Allow unloading of GCC compiled plugins by adding `-fno-gnu-unique` to the compiler flags. This allows DLLs to be unloaded even if they can contain symbols that are marked as `STB_GNU_UNIQUE`, which would prevent unloading in Linux.
* Always enable validation layer by setting up Vulkan layer paths for each Linux build preset.
* Fixed deadlock in AssetBrowser by always locking ezAssetCurator first when in need to hold both ezAssetCurator and ezFileSystemModel locks.
* EngineViewWidget is now re-created on every engine reload to ensure leaked Vulkan surfaces in the driver don't block viewport from being created. Also changed how the editor tests setup the fixed viewport which allows Linux to run the tests. In the test case, the widget is now no longer in a layout and has a fixed size. Special care needs to be taken for DPI scaling though.
* Posix OS file stat calls now actually reads the nanosecond part. Previously, file time stamps only had second precision.
* Fixed engine process freeze when resizing the editor windows a lot. This was caused by the Vulkan swapchain code. The code now will in a loop try to recreate the swapchain if it can't acquire an image. Previously, it gave up after one try. After 5 failed attempts we will hard crash now. The bug waas caused because the editor could resize the viewport while we are recreating the swapchain, making the new swapchain already out of date when we tried to acquire the first image from it.
* Fixed text being black on gray for inactive tabs in the editor UI on Linux via the `dafault_linux.css` file. Windows already has this fix.
* In case DPI scaling creates a too big backbuffer during editor tests, the captured image will be cropped to compensate. This is fine as the viewport was always correct so we are just cutting away black borders.
* Set all game engine test projects to not clip / hide the cursor.
* Fixed a few typos here and there.