### PR TITLE
Easy access to sun light data in shader

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/TransformGizmoActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/TransformGizmoActions.cpp
@@ -105,79 +105,79 @@ public:
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0");
       e.m_UserValue = 0.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.01f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0_01";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0_01");
       e.m_UserValue = 0.01f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.05f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0_05";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0_05");
       e.m_UserValue = 0.05f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0_1";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0_1");
       e.m_UserValue = 0.1f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.2f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0_2";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0_2");
       e.m_UserValue = 0.2f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.25f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0_25";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0_25");
       e.m_UserValue = 0.25f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 0.5f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.0_5";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.0_5");
       e.m_UserValue = 0.5f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 1.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.1";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.1");
       e.m_UserValue = 1.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 2.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.2";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.2");
       e.m_UserValue = 2.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 4.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.4";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.4");
       e.m_UserValue = 4.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 5.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.5";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.5");
       e.m_UserValue = 5.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 8.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.8";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.8");
       e.m_UserValue = 8.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = (fValue == 10.0f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Translate.Snap.10";
+      e.m_sDisplay = ezTranslate("Gizmo.Translate.Snap.10");
       e.m_UserValue = 10.0f;
     }
   }
@@ -259,49 +259,49 @@ public:
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 0.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.0_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.0_Degree");
       e.m_UserValue = 0.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 1.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.1_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.1_Degree");
       e.m_UserValue = 1.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 5.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.5_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.5_Degree");
       e.m_UserValue = 5.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 10.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.10_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.10_Degree");
       e.m_UserValue = 10.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 15.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.15_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.15_Degree");
       e.m_UserValue = 15.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 22.5f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.22_5_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.22_5_Degree");
       e.m_UserValue = 22.5f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 30.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.30_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.30_Degree");
       e.m_UserValue = 30.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 45.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Rotation.Snap.45_Degree";
+      e.m_sDisplay = ezTranslate("Gizmo.Rotation.Snap.45_Degree");
       e.m_UserValue = 45.0f;
     }
   }
@@ -373,43 +373,43 @@ public:
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 0.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.0";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.0");
       e.m_UserValue = 0.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 0.125f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.0_125";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.0_125");
       e.m_UserValue = 0.125f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 0.25f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.0_25";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.0_25");
       e.m_UserValue = 0.25f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 0.5f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.0_5";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.0_5");
       e.m_UserValue = 0.5f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 1.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.1";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.1");
       e.m_UserValue = 1.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 2.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.2";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.2");
       e.m_UserValue = 2.0f;
     }
     {
       auto& e = out_entries.ExpandAndGetRef();
       e.m_CheckState = ezMath::IsEqual(fValue, 4.0f, 0.1f) ? ezDynamicMenuAction::Item::CheckMark::Checked : ezDynamicMenuAction::Item::CheckMark::Unchecked;
-      e.m_sDisplay = "Gizmo.Scale.Snap.4";
+      e.m_sDisplay = ezTranslate("Gizmo.Scale.Snap.4");
       e.m_UserValue = 4.0f;
     }
   }

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -417,10 +417,13 @@ namespace
 
     auto CheckPath = [&](ezStringView sPath)
     {
+      if (sPath.IsEmpty())
+        return false;
+
       ezStringBuilder path = sPath;
       path.AppendPath("sbscooker.exe");
 
-      if (ezOSFile::ExistsFile(path))
+      if (path.IsAbsolutePath() && ezOSFile::ExistsFile(path))
       {
         s_CachedPath = sPath;
         out_sPath = sPath;

--- a/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
+++ b/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
@@ -30,6 +30,7 @@ public:
   ezArrayPtr<ezPerClusterData> m_ClusterData;
   ezArrayPtr<ezUInt32> m_ClusterItemList;
 
+  ezUInt32 m_uiBrightestDirectionalLightIndex = 0;
   ezUInt32 m_uiSkyIrradianceIndex = 0;
   ezEnum<ezCameraUsageHint> m_cameraUsageHint = ezCameraUsageHint::Default;
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
@@ -190,6 +190,7 @@ void* ezClusteredDataProvider::UpdateData(const ezRenderViewContext& renderViewC
     pConstants->NumLights = pData->m_LightData.GetCount();
     pConstants->NumDecals = pData->m_DecalData.GetCount();
 
+    pConstants->BrightestDirectionalLightIndex = pData->m_uiBrightestDirectionalLightIndex;
     pConstants->SkyIrradianceIndex = pData->m_uiSkyIrradianceIndex;
 
     pConstants->FogHeight = pData->m_fFogHeight;

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
@@ -459,7 +459,7 @@ void ezQtDynamicMenuProxy::SlotMenuAboutToShow()
       }
       else
       {
-        auto pAction = m_pMenu->addAction(ezMakeQString(ezTranslate(p.m_sDisplay)));
+        auto pAction = m_pMenu->addAction(ezMakeQString(p.m_sDisplay));
         pAction->setData(i);
         pAction->setIcon(p.m_Icon);
         pAction->setCheckable(p.m_CheckState != ezDynamicMenuAction::Item::CheckMark::NotCheckable);

--- a/Data/Base/Shaders/Common/LightData.h
+++ b/Data/Base/Shaders/Common/LightData.h
@@ -33,6 +33,21 @@ struct EZ_SHADER_STRUCT ezPerLightData
 
 #if EZ_ENABLED(PLATFORM_SHADER)
   StructuredBuffer<ezPerLightData> perLightDataBuffer;
+
+  uint GetLightType(ezPerLightData data)
+  {
+    return (data.colorAndType >> 24) & 0xFF;
+  }
+
+  float3 GetLightColor(ezPerLightData data)
+  {
+    return RGB8ToFloat3(data.colorAndType);
+  }
+
+  float3 GetLightDirection(ezPerLightData data)
+  {
+    return normalize(RGB10ToFloat3(data.direction) * 2.0 - 1.0);
+  }
 #else
   static_assert(sizeof(ezPerLightData) == 48);
 #endif
@@ -141,8 +156,8 @@ struct EZ_SHADER_STRUCT ezPerDecalData
 
     UINT1(NumLights);
     UINT1(NumDecals);
-    UINT1(Padding);
 
+    UINT1(BrightestDirectionalLightIndex); // aka sun
     UINT1(SkyIrradianceIndex);
 
     FLOAT1(FogHeight);

--- a/Data/Base/Shaders/Common/LightData.h
+++ b/Data/Base/Shaders/Common/LightData.h
@@ -193,6 +193,16 @@ struct ezPerClusterData
 #if EZ_ENABLED(PLATFORM_SHADER)
   StructuredBuffer<ezPerClusterData> perClusterDataBuffer;
   StructuredBuffer<uint> clusterItemBuffer;
+
+  ezPerLightData GetBrightestDirectionalLightData()
+  {
+    if (BrightestDirectionalLightIndex != 0xFFFFFFFF)
+    {
+      return perLightDataBuffer[BrightestDirectionalLightIndex];
+    }
+    
+    return (ezPerLightData)0;
+  }
 #endif
 
 // clang-format on

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -474,7 +474,7 @@ float3 ComputeReflection(inout ezMaterialData matData, float3 viewVector, ezPerC
 // Returns unsaturated NdotL
 float EvaluatePBRLight(float3 worldPosition, float3 worldNormal, ezPerLightData lightData, uint type, out float3 lightVector, out float attenuation, out float distanceToLight)
 {
-  float3 lightDir = normalize(RGB10ToFloat3(lightData.direction) * 2.0 - 1.0);
+  float3 lightDir = GetLightDirection(lightData);
   lightVector = lightDir;
   attenuation = 1.0;
   distanceToLight = 1.0;
@@ -515,7 +515,7 @@ void EvaluateFillLight(float3 worldPosition, float3 worldNormal, float3 diffuseC
   attenuation *= saturate(lerp(1.0, NdotL, directionality));
   attenuation *= lightData.intensity;
 
-  float3 lightColor = RGB8ToFloat3(lightData.colorAndType);
+  float3 lightColor = GetLightColor(lightData);
   if (type == LIGHT_TYPE_FILL_ADDITIVE)
   {
     diffuseLight += diffuseColor * lightColor * attenuation;
@@ -547,7 +547,7 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
     uint lightIndex = GET_LIGHT_INDEX(itemIndex);
 
     ezPerLightData lightData = perLightDataBuffer[lightIndex];
-    uint type = (lightData.colorAndType >> 24) & 0xFF;
+    uint type = GetLightType(lightData);
 
     [branch] if (type <= LIGHT_TYPE_DIR)
     {
@@ -574,7 +574,7 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
         }
 
         attenuation *= lightData.intensity;
-        float3 lightColor = RGB8ToFloat3(lightData.colorAndType);
+        float3 lightColor = GetLightColor(lightData);
 
         // debug cascade or point face selection
 #if 0


### PR DESCRIPTION
EZ does not have the concept of a "sun" light but often you need this information in custom shaders. With this change ez exposes the "brightest" directional light, which is typically the sun, and allows you to access its data in any shader like so:

```
ezPerLightData sunData = GetBrightestDirectionalLightData();
float3 sunDir = GetLightDirection(sunData);
float3 sunColor = GetLightColor(sunData);
float sunIntensity = sunData.intensity;
```

Note that some data like e.g. direction and color is accessed with helper functions because the data is stored compressed and requires custom unpacking. Other data like itensity can be just accessed as is.