### PR TITLE
Shader Fixes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocumentManager.h
@@ -71,6 +71,10 @@ public:
 
   /// \brief Relative to 'AssetCache' folder.
   virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const;
+
+  /// \brief Should return the document type of the given sOutputTag.
+  virtual ezStringView GetOutputDocumentType(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const { return pTypeDesc->m_sDocumentTypeName; }
+
   virtual bool GeneratesProfileSpecificAssets() const = 0;
 
   bool IsOutputUpToDate(ezStringView sDocumentPath, const ezDynamicArray<ezString>& outputs, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor);

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -112,6 +112,9 @@ public:
   //
   //
 
+  /// \brief Returns whether we are between StartupEditor and ShutdownEditor.
+  bool IsRunning() const { return m_bIsRunning; }
+
   /// \brief Can be set via the command line option '-safe'. In this mode the editor will not automatically load recent documents
   bool IsInSafeMode() const { return m_StartupFlags.IsSet(StartupFlags::SafeMode); }
 
@@ -276,6 +279,7 @@ private:
   bool m_bLoadingProjectInProgress = false;
   bool m_bAnyProjectOpened = false;
   bool m_bWroteCrashIndicatorFile = false;
+  bool m_bIsRunning = false;
 
   ezBitflags<StartupFlags> m_StartupFlags;
   ezDynamicArray<ezString> m_DocumentsToOpen;

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -401,11 +401,13 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
   LoadEditorPlugins();
   CloseSplashScreen();
 
+  m_bIsRunning = true;
   {
     ezEditorAppEvent e;
     e.m_Type = ezEditorAppEvent::Type::EditorStarted;
     m_Events.Broadcast(e);
   }
+
 
   ezEditorPreferencesUser* pPreferences = ezPreferences::QueryPreferences<ezEditorPreferencesUser>();
 
@@ -462,6 +464,7 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
 
 void ezQtEditorApp::ShutdownEditor()
 {
+  m_bIsRunning = false;
   ezStackTraceLogParser::Unregister();
 
   ezToolsProject::SaveProjectState();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.cpp
@@ -27,7 +27,7 @@ ezMaterialAssetDocumentManager::ezMaterialAssetDocumentManager()
   m_DocTypeDesc.m_CompatibleTypes.PushBack("CompatibleAsset_Material");
 
   m_DocTypeDesc.m_sResourceFileExtension = "ezBinMaterial";
-  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail;
+  m_DocTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::SupportsThumbnail | ezAssetDocumentFlags::AutoTransformOnSave;
 }
 
 ezMaterialAssetDocumentManager::~ezMaterialAssetDocumentManager()
@@ -76,6 +76,14 @@ bool ezMaterialAssetDocumentManager::IsOutputUpToDate(ezStringView sDocumentPath
   return ezAssetDocumentManager::IsOutputUpToDate(sDocumentPath, sOutputTag, uiHash, pTypeDescriptor);
 }
 
+ezStringView ezMaterialAssetDocumentManager::GetOutputDocumentType(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const
+{
+  if (sOutputTag == s_szShaderOutputTag)
+  {
+    return "Shader";
+  }
+  return SUPER::GetOutputDocumentType(pTypeDesc, sOutputTag, pAssetProfile);
+}
 
 void ezMaterialAssetDocumentManager::OnDocumentManagerEvent(const ezDocumentManager::Event& e)
 {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetManager.h
@@ -13,6 +13,7 @@ public:
 
   virtual ezString GetRelativeOutputFileName(const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezStringView sDataDirectory, ezStringView sDocumentPath, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile) const override;
   virtual bool IsOutputUpToDate(ezStringView sDocumentPath, ezStringView sOutputTag, ezUInt64 uiHash, const ezAssetDocumentTypeDescriptor* pTypeDescriptor) override;
+  virtual ezStringView GetOutputDocumentType(const ezAssetDocumentTypeDescriptor* pTypeDesc, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile = nullptr) const override;
 
   static const char* const s_szShaderOutputTag;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
@@ -69,6 +69,7 @@ class ezVisualShaderTypeRegistry
 
 public:
   ezVisualShaderTypeRegistry();
+  ~ezVisualShaderTypeRegistry();
 
   const ezVisualShaderNodeDescriptor* GetDescriptorForType(const ezRTTI* pRtti) const;
 
@@ -83,6 +84,7 @@ public:
 private:
   EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(EditorPluginAssets, VisualShader);
 
+  void EditorEventHandler(const ezEditorAppEvent& e);
   void LoadNodeData();
   const ezRTTI* GenerateTypeFromDesc(const ezVisualShaderNodeDescriptor& desc);
   void LoadConfigFile(const char* szFile);

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplicationInit.cpp
@@ -63,6 +63,7 @@ void ezGameApplication::Init_ConfigureAssetManagement()
   ezResourceManager::RegisterResourceForAssetType("PropertyAnim", ezGetStaticRTTI<ezPropertyAnimResource>());
   ezResourceManager::RegisterResourceForAssetType("RenderPipeline", ezGetStaticRTTI<ezRenderPipelineResource>());
   ezResourceManager::RegisterResourceForAssetType("Render Target", ezGetStaticRTTI<ezTexture2DResource>());
+  ezResourceManager::RegisterResourceForAssetType("Shader", ezGetStaticRTTI<ezShaderResource>());
   ezResourceManager::RegisterResourceForAssetType("Skeleton", ezGetStaticRTTI<ezSkeletonResource>());
   ezResourceManager::RegisterResourceForAssetType("StateMachine", ezGetStaticRTTI<ezStateMachineResource>());
   ezResourceManager::RegisterResourceForAssetType("Substance Texture", ezGetStaticRTTI<ezTexture2DResource>());

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -293,7 +293,7 @@ ezResult ezShaderCompiler::CompileShaderPermutationForPlatforms(ezStringView sFi
     m_IncludeFiles.Insert(sMaterialConstantsTemplateFile);
   }
 
-  ezStringView extensions[] {"vs", "hs", "ds", "gs", "ps", "cs"};
+  ezStringView extensions[]{"vs", "hs", "ds", "gs", "ps", "cs"};
   static_assert(EZ_ARRAY_SIZE(extensions) == ezGALShaderStage::ENUM_COUNT);
   ezStringBuilder tmp = sFile;
   tmp.MakeCleanPath();

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -293,8 +293,16 @@ ezResult ezShaderCompiler::CompileShaderPermutationForPlatforms(ezStringView sFi
     m_IncludeFiles.Insert(sMaterialConstantsTemplateFile);
   }
 
+  ezStringView extensions[] {"vs", "hs", "ds", "gs", "ps", "cs"};
+  static_assert(EZ_ARRAY_SIZE(extensions) == ezGALShaderStage::ENUM_COUNT);
+  ezStringBuilder tmp = sFile;
+  tmp.MakeCleanPath();
+
   for (ezUInt32 stage = ezGALShaderStage::VertexShader; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
   {
+    m_StageSourceFile[stage] = tmp;
+    m_StageSourceFile[stage].ChangeFileExtension(extensions[stage]);
+
     ezStringView sStageSource = Sections.GetSectionContent(ezShaderHelper::ezShaderSections::VERTEXSHADER + stage, uiFirstLine);
 
     // later code checks whether the string is empty, to see whether we have any shader source, so this has to be kept empty
@@ -305,7 +313,8 @@ ezResult ezShaderCompiler::CompileShaderPermutationForPlatforms(ezStringView sFi
       // prepend material constants section if there is any
       if (!sMaterialConstantsSource.IsEmpty())
       {
-        sTemp.AppendFormat(sMaterialConstantsTemplate, uiFirstMaterialConstantsLine, sMaterialConstantsSource);
+        // We need to fill teh template not only with the section content but also the starting line and filename to get correct line numbers for all compile failures.
+        sTemp.AppendFormat(sMaterialConstantsTemplate, uiFirstMaterialConstantsLine, m_StageSourceFile[stage], sMaterialConstantsSource);
       }
 
       // prepend common shader section if there is any
@@ -323,27 +332,6 @@ ezResult ezShaderCompiler::CompileShaderPermutationForPlatforms(ezStringView sFi
       m_ShaderData.m_ShaderStageSource[stage].Clear();
     }
   }
-
-  ezStringBuilder tmp = sFile;
-  tmp.MakeCleanPath();
-
-  m_StageSourceFile[ezGALShaderStage::VertexShader] = tmp;
-  m_StageSourceFile[ezGALShaderStage::VertexShader].ChangeFileExtension("vs");
-
-  m_StageSourceFile[ezGALShaderStage::HullShader] = tmp;
-  m_StageSourceFile[ezGALShaderStage::HullShader].ChangeFileExtension("hs");
-
-  m_StageSourceFile[ezGALShaderStage::DomainShader] = tmp;
-  m_StageSourceFile[ezGALShaderStage::DomainShader].ChangeFileExtension("ds");
-
-  m_StageSourceFile[ezGALShaderStage::GeometryShader] = tmp;
-  m_StageSourceFile[ezGALShaderStage::GeometryShader].ChangeFileExtension("gs");
-
-  m_StageSourceFile[ezGALShaderStage::PixelShader] = tmp;
-  m_StageSourceFile[ezGALShaderStage::PixelShader].ChangeFileExtension("ps");
-
-  m_StageSourceFile[ezGALShaderStage::ComputeShader] = tmp;
-  m_StageSourceFile[ezGALShaderStage::ComputeShader].ChangeFileExtension("cs");
 
   // try out every compiler that we can find
   ezResult result = EZ_SUCCESS;

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -692,10 +692,7 @@ ezStatus ParseShaderConstant(const TokenStream& tokens, ezUInt32& ref_uiCurToken
       return ezStatus(EZ_SUCCESS);
     }
 
-    const char* szStart = tokens[uiStartToken]->m_DataView.GetStartPointer();
-    const char* szEnd = tokens[ref_uiCurToken]->m_DataView.GetStartPointer();
-    ezStringView sConstant(szStart, static_cast<ezUInt32>(szEnd - szStart));
-    return ezStatus(ezFmt("Unknown shader constant: {}", sConstant));
+    return ezStatus(ezFmt("Unknown shader constant type: {}", tokens[uiTypeToken]->m_DataView));
   }
   else if (Accept(tokens, ref_uiCurToken, packedhalf2Pattern, &acceptedTokens))
   {
@@ -777,10 +774,13 @@ void AlignStructuredBufferStd430Relaxed(ezShaderConstantBufferLayout& ref_materi
 
 ezStatus ParseMaterialConstants(const TokenStream& tokens, ezUInt32& ref_uiCurToken, ezShaderConstantBufferLayout& ref_materialConstantBufferLayout)
 {
-  const bool bIsConstantBuffer = true;
-
-  while (ParseShaderConstant(tokens, ref_uiCurToken, ref_materialConstantBufferLayout).Succeeded())
+  while (!Accept(tokens, ref_uiCurToken, ezTokenType::EndOfFile))
   {
+    ezStatus parseResult = ParseShaderConstant(tokens, ref_uiCurToken, ref_materialConstantBufferLayout);
+    if (!parseResult.Succeeded())
+    {
+      return parseResult;
+    }
   }
 
   if (ref_materialConstantBufferLayout.m_Constants.IsEmpty())

--- a/Data/Base/Shaders/Materials/MaterialConstants.template
+++ b/Data/Base/Shaders/Materials/MaterialConstants.template
@@ -8,7 +8,8 @@
 
 BEGIN_MATERIAL_CONSTANTS
 {
-#line {0}
-{1}
+// The line below should be filled out with the starting line of the material constant section of the shader that is being compiled so that the "Shaders/Materials/MaterialConstants.template" line above does not propagate further through the rest of the code. E.g. #line 8 "RendererTest/Shaders/TestMaterial.vs", followed by the content of the section.
+#line {0} "{1}"
+{2}
 }
 END_MATERIAL_CONSTANTS


### PR DESCRIPTION
* Additional asset outputs are now reloaded in the engine on asset transform. To support this, the asset needs to do these things:
  * Implement `ezAssetDocumentManager::GetOutputDocumentType` to define the asset type of the additional output.
  * The output must be loaded via relative path at runtime.
* Fixed a bug where the `ezVisualShaderTypeRegistry` would not work if the assets plugin was linked statically.
* Fixed bug in which all shader compile errors where attributed to `MaterialConstants.template`.
* Errors in the material constants section will now correctly output errors and fail compilation.