### PR TITLE
# Rendering Setup Refactor

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessViewContext.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessViewContext.h
@@ -10,7 +10,6 @@ class ezEngineProcessDocumentContext;
 class ezEditorEngineDocumentMsg;
 class ezViewRedrawMsgToEngine;
 class ezEditorEngineViewMsg;
-class ezGALRenderTargetSetup;
 class ezActor;
 struct ezGALRenderTargets;
 

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -87,14 +87,8 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
   EZ_ASSERT_DEV(m_uiWindowWidth == pDepthTexture->GetDescription().m_uiWidth, "");
   EZ_ASSERT_DEV(m_uiWindowHeight == pDepthTexture->GetDescription().m_uiHeight, "");
 
-  ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup = m_RenderTargetSetup;
-  renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-  renderingSetup.m_bClearDepth = true;
-  renderingSetup.m_bClearStencil = true;
-
   {
-    auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName());
+    auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, m_RenderTargetSetup, GetName());
 
     ezViewRenderMode::Enum viewRenderMode = renderViewContext.m_pViewData->m_ViewRenderMode;
     if (viewRenderMode == ezViewRenderMode::WireframeColor || viewRenderMode == ezViewRenderMode::WireframeMonochrome)
@@ -235,7 +229,9 @@ void ezPickingRenderPass::CreateTarget()
 
   m_hPickingDepthRT = pDevice->CreateTexture(tcd);
 
-  m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(m_hPickingIdRT)).SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(m_hPickingDepthRT));
+  m_RenderTargetSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(m_hPickingIdRT)).SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(m_hPickingDepthRT));
+  m_RenderTargetSetup.SetClearColor(0);
+  m_RenderTargetSetup.SetClearDepth().SetClearStencil();
 }
 
 void ezPickingRenderPass::DestroyTarget()

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.h
@@ -52,7 +52,7 @@ private:
 
   ezGALTextureHandle m_hPickingIdRT;
   ezGALTextureHandle m_hPickingDepthRT;
-  ezGALRenderTargetSetup m_RenderTargetSetup;
+  ezGALRenderingSetup m_RenderTargetSetup;
 
   ezHashSet<ezGameObjectHandle> m_SelectionSet;
 

--- a/Code/Engine/Foundation/Algorithm/HashableStruct.h
+++ b/Code/Engine/Foundation/Algorithm/HashableStruct.h
@@ -20,6 +20,9 @@ public:
   ezHashableStruct(const ezHashableStruct<DERIVED>& other); // [tested]
 
   void operator=(const ezHashableStruct<DERIVED>& other);   // [tested]
+  bool operator==(const ezHashableStruct<DERIVED>& other) const;
+  bool operator!=(const ezHashableStruct<DERIVED>& other) const;
+  bool operator<(const ezHashableStruct<DERIVED>& other) const;
 
   /// \brief Calculates the 32 bit hash of the struct and returns it
   ezUInt32 CalculateHash() const; // [tested]

--- a/Code/Engine/Foundation/Algorithm/Implementation/HashableStruct_inl.h
+++ b/Code/Engine/Foundation/Algorithm/Implementation/HashableStruct_inl.h
@@ -21,6 +21,23 @@ EZ_ALWAYS_INLINE void ezHashableStruct<T>::operator=(const ezHashableStruct<T>& 
     ezMemoryUtils::RawByteCopy(this, &other, sizeof(T));
   }
 }
+template <typename T>
+bool ezHashableStruct<T>::operator==(const ezHashableStruct<T>& other) const
+{
+  return ezMemoryUtils::RawByteCompare(this, &other, sizeof(T)) == 0;
+}
+
+template <typename T>
+bool ezHashableStruct<T>::operator!=(const ezHashableStruct<T>& other) const
+{
+  return ezMemoryUtils::RawByteCompare(this, &other, sizeof(T)) != 0;
+}
+
+template <typename T>
+bool ezHashableStruct<T>::operator<(const ezHashableStruct<T>& other) const
+{
+  return ezMemoryUtils::RawByteCompare(this, &other, sizeof(T)) < 0;
+}
 
 template <typename T>
 EZ_ALWAYS_INLINE ezUInt32 ezHashableStruct<T>::CalculateHash() const

--- a/Code/Engine/Foundation/Math/Size.h
+++ b/Code/Engine/Foundation/Math/Size.h
@@ -41,3 +41,5 @@ bool operator!=(const ezSizeTemplate<Type>& v1, const ezSizeTemplate<Type>& v2);
 using ezSizeU32 = ezSizeTemplate<ezUInt32>;
 using ezSizeFloat = ezSizeTemplate<float>;
 using ezSizeDouble = ezSizeTemplate<double>;
+
+EZ_FOUNDATION_DLL ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezSizeU32& arg);

--- a/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
@@ -1,12 +1,12 @@
 #include <Foundation/FoundationPCH.h>
 
 #include <Foundation/Math/Rational.h>
+#include <Foundation/Math/Size.h>
 #include <Foundation/Strings/FormatString.h>
 #include <Foundation/Strings/HashedString.h>
 #include <Foundation/Strings/String.h>
 #include <Foundation/Strings/StringBuilder.h>
 #include <Foundation/Types/Variant.h>
-#include <Foundation/Math/Size.h>
 
 ezFormatString::ezFormatString(const ezStringBuilder& s)
 {

--- a/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/FormatString.cpp
@@ -6,6 +6,7 @@
 #include <Foundation/Strings/String.h>
 #include <Foundation/Strings/StringBuilder.h>
 #include <Foundation/Types/Variant.h>
+#include <Foundation/Math/Size.h>
 
 ezFormatString::ezFormatString(const ezStringBuilder& s)
 {
@@ -380,6 +381,17 @@ ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezArgSensitive& a
 
   return arg.m_sSensitiveInfo;
 }
+
+ezStringView BuildString(char* szTmp, ezUInt32 uiLength, const ezSizeU32& arg)
+{
+  ezUInt32 writepos = 0;
+  ezStringUtils::OutputFormattedInt(szTmp, uiLength, writepos, arg.width, 1, false, 10);
+  szTmp[writepos++] = 'x';
+  ezStringUtils::OutputFormattedInt(szTmp, uiLength, writepos, arg.height, 1, false, 10);
+  szTmp[writepos] = '\0';
+  return ezStringView(szTmp, szTmp + writepos);
+}
+
 
 ezStringView ezArgSensitive::BuildString_SensitiveUserData_Hash(char* szTmp, ezUInt32 uiLength, const ezArgSensitive& arg)
 {

--- a/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
+++ b/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
@@ -124,7 +124,7 @@ void ezWindowOutputTargetXR::CompanionViewEndFrame()
     ezVec2 targetSize = ezVec2((float)tex->GetDescription().m_uiWidth, (float)tex->GetDescription().m_uiHeight);
 
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, hRenderTargetView);
+    renderingSetup.SetColorTarget(0, hRenderTargetView);
 
     m_pRenderContext->BeginRendering(renderingSetup, ezRectFloat(targetSize.x, targetSize.y));
 

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPool.cpp
@@ -349,9 +349,8 @@ void ezReflectionPool::OnRenderEvent(const ezRenderWorldRenderEvent& e)
           desc.m_uiSliceCount = 1;
           desc.m_OverrideViewType = ezGALTextureType::Texture2DArray;
 
-          renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->CreateRenderTargetView(desc));
-          renderingSetup.m_ClearColor = ezColor(0, 0, 0, 1);
-          renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
+          renderingSetup.SetColorTarget(0, pDevice->CreateRenderTargetView(desc));
+          renderingSetup.SetClearColor(0, ezColor(0, 0, 0, 1));
 
           pCommandEncoder->BeginRendering(renderingSetup, "ClearSkySpecular");
           pCommandEncoder->EndRendering();

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -1101,8 +1101,8 @@ void ezShadowPool::OnRenderEvent(const ezRenderWorldRenderEvent& e)
   ezGALCommandEncoder* pCommandEncoder = pDevice->BeginCommands("Shadow Atlas");
 
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(s_pData->m_hShadowAtlasTexture));
-  renderingSetup.m_bClearDepth = true;
+  renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(s_pData->m_hShadowAtlasTexture));
+  renderingSetup.SetClearDepth();
 
   pCommandEncoder->BeginRendering(renderingSetup);
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
@@ -200,7 +200,7 @@ void ezAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezArr
       ezVec2 targetSize = hzbSizes[i];
 
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, hOutputView);
+      renderingSetup.SetColorTarget(0, hOutputView);
       renderViewContext.m_pRenderContext->BeginRendering(renderingSetup, ezRectFloat(targetSize.x, targetSize.y), "SSAOMipMaps", renderViewContext.m_pCamera->IsStereoscopic());
 
       ezDownscaleDepthConstants* constants = ezRenderContext::GetConstantBufferData<ezDownscaleDepthConstants>(m_hDownscaleConstantBuffer);
@@ -243,7 +243,7 @@ void ezAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezArr
   // SSAO pass
   {
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(tempSSAOTexture));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(tempSSAOTexture));
     auto pCommandEncoder = renderViewContext.m_pRenderContext->BeginRenderingScope(renderViewContext, renderingSetup, "SSAO", renderViewContext.m_pCamera->IsStereoscopic());
 
     renderViewContext.m_pRenderContext->BindConstantBuffer("ezSSAOConstants", m_hSSAOConstantBuffer);
@@ -263,7 +263,7 @@ void ezAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezArr
   // Blur pass
   {
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
     auto pCommandEncoder = renderViewContext.m_pRenderContext->BeginRenderingScope(renderViewContext, renderingSetup, "Blur", renderViewContext.m_pCamera->IsStereoscopic());
 
     renderViewContext.m_pRenderContext->BindConstantBuffer("ezSSAOConstants", m_hSSAOConstantBuffer);
@@ -299,9 +299,8 @@ void ezAOPass::ExecuteInactive(const ezRenderViewContext& renderViewContext, con
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
-  renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-  renderingSetup.m_ClearColor = ezColor::White;
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+  renderingSetup.SetClearColor(0, ezColor::White);
 
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName());
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AntialiasingPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AntialiasingPass.cpp
@@ -88,7 +88,7 @@ void ezAntialiasingPass::Execute(const ezRenderViewContext& renderViewContext, c
 
   // Setup render target
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
 
   // Bind render target and viewport
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlendPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlendPass.cpp
@@ -71,9 +71,8 @@ void ezBlendPass::Execute(const ezRenderViewContext& renderViewContext, const ez
 
     // Setup render target
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
-    renderingSetup.m_uiRenderTargetClearMask = ezInvalidIndex;
-    renderingSetup.m_ClearColor = ezColor(1.0f, 0.0f, 0.0f);
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
+    renderingSetup.SetClearColor(0, ezColor(1.0f, 0.0f, 0.0f));
 
     // Bind render target and viewport
     auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BloomPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BloomPass.cpp
@@ -157,7 +157,7 @@ void ezBloomPass::Execute(const ezRenderViewContext& renderViewContext, const ez
       ezVec2 targetSize = targetSizes[i];
 
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(hOutput));
+      renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(hOutput));
       renderViewContext.m_pRenderContext->BeginRendering(renderingSetup, ezRectFloat(targetSize.x, targetSize.y), "Downscale", renderViewContext.m_pCamera->IsStereoscopic());
 
       ezColor tintColor = (i == uiNumBlurPasses - 1) ? ezColor(m_OuterTintColor) : ezColor::White;
@@ -205,7 +205,7 @@ void ezBloomPass::Execute(const ezRenderViewContext& renderViewContext, const ez
       ezVec2 targetSize = targetSizes[i];
 
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(hOutput));
+      renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(hOutput));
       renderViewContext.m_pRenderContext->BeginRendering(renderingSetup, ezRectFloat(targetSize.x, targetSize.y), "Upscale", renderViewContext.m_pCamera->IsStereoscopic());
 
       ezColor tintColor;
@@ -258,9 +258,8 @@ void ezBloomPass::ExecuteInactive(const ezRenderViewContext& renderViewContext, 
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pColorOutput->m_TextureHandle));
-  renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-  renderingSetup.m_ClearColor = ezColor::Black;
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pColorOutput->m_TextureHandle));
+  renderingSetup.SetClearColor(0, ezColor::Black);
 
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, "Clear");
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlurPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlurPass.cpp
@@ -78,9 +78,8 @@ void ezBlurPass::Execute(const ezRenderViewContext& renderViewContext, const ezA
 
     // Setup render target
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
-    renderingSetup.m_uiRenderTargetClearMask = ezInvalidIndex;
-    renderingSetup.m_ClearColor = ezColor(1.0f, 0.0f, 0.0f);
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
+    renderingSetup.SetClearColor(0, ezColor(1.0f, 0.0f, 0.0f));
 
     // Bind render target and viewport
     auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/DepthOnlyPass.cpp
@@ -63,10 +63,10 @@ void ezDepthOnlyPass::Execute(const ezRenderViewContext& renderViewContext, cons
   ezGALRenderingSetup renderingSetup;
   if (inputs[m_PinDepthStencil.m_uiInputIndex])
   {
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(inputs[m_PinDepthStencil.m_uiInputIndex]->m_TextureHandle));
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(inputs[m_PinDepthStencil.m_uiInputIndex]->m_TextureHandle));
   }
 
-  auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());
+  auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());
 
   renderViewContext.m_pRenderContext->SetShaderPermutationVariable("RENDER_PASS", "RENDER_PASS_DEPTH_ONLY");
   renderViewContext.m_pRenderContext->SetShaderPermutationVariable("SHADING_QUALITY", "SHADING_QUALITY_NORMAL");

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ForwardRenderPass.cpp
@@ -104,12 +104,12 @@ void ezForwardRenderPass::SetupResources(ezGALCommandEncoder* pCommandEncoder, c
   ezGALRenderingSetup renderingSetup;
   if (inputs[m_PinColor.m_uiInputIndex])
   {
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(inputs[m_PinColor.m_uiInputIndex]->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(inputs[m_PinColor.m_uiInputIndex]->m_TextureHandle));
   }
 
   if (inputs[m_PinDepthStencil.m_uiInputIndex])
   {
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(inputs[m_PinDepthStencil.m_uiInputIndex]->m_TextureHandle));
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(inputs[m_PinDepthStencil.m_uiInputIndex]->m_TextureHandle));
   }
 
   renderViewContext.m_pRenderContext->BeginRendering(std::move(renderingSetup), renderViewContext.m_pViewData->m_ViewPortRect, "", renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/HistorySourcePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/HistorySourcePass.cpp
@@ -99,18 +99,15 @@ void ezHistorySourcePass::Execute(const ezRenderViewContext& renderViewContext, 
 
   // Setup render target
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_ClearColor = m_ClearColor;
-  renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-  renderingSetup.m_bClearDepth = true;
-  renderingSetup.m_bClearStencil = true;
-
   if (ezGALResourceFormat::IsDepthFormat(pOutput->m_Desc.m_Format))
   {
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetClearDepth().SetClearStencil();
   }
   else
   {
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetClearColor(0, m_ClearColor);
   }
 
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -152,11 +152,11 @@ void ezLSAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezA
     tempTextureDesc.m_bAllowShaderResourceView = true;
     tempTextureDesc.m_bAllowRenderTargetView = true;
     tempTexture = ezGPUResourcePool::GetDefaultInstance()->GetRenderTarget(tempTextureDesc);
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(tempTexture));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(tempTexture));
   }
   else
   {
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
   }
 
   // Line Sweep part (compute)
@@ -224,7 +224,8 @@ void ezLSAOPass::Execute(const ezRenderViewContext& renderViewContext, const ezA
         break;
     }
 
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
+    renderingSetup.Reset();
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
 
     auto pCommandEncoder = renderViewContext.m_pRenderContext->BeginRenderingScope(renderViewContext, renderingSetup, "Averaging", renderViewContext.m_pCamera->IsStereoscopic());
 
@@ -252,9 +253,8 @@ void ezLSAOPass::ExecuteInactive(const ezRenderViewContext& renderViewContext, c
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
-  renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-  renderingSetup.m_ClearColor = ezColor::White;
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+  renderingSetup.SetClearColor(0, ezColor::White);
 
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, "Clear");
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaResolvePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaResolvePass.cpp
@@ -81,10 +81,10 @@ void ezMsaaResolvePass::Execute(const ezRenderViewContext& renderViewContext, co
   {
     // Setup render target
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
 
     // Bind render target and viewport
-    auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());
+    auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());
 
     auto& globals = renderViewContext.m_pRenderContext->WriteGlobalConstants();
     globals.NumMsaaSamples = m_MsaaSampleCount;

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaUpscalePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/MsaaUpscalePass.cpp
@@ -78,10 +78,10 @@ void ezMsaaUpscalePass::Execute(const ezRenderViewContext& renderViewContext, co
 
   // Setup render target
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
 
   // Bind render target and viewport
-  auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());
+  auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());
 
   renderViewContext.m_pRenderContext->BindShader(m_hShader);
   renderViewContext.m_pRenderContext->BindMeshBuffer(ezGALBufferHandle(), ezGALBufferHandle(), nullptr, ezGALPrimitiveTopology::Triangles, 1);

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SelectionHighlightPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SelectionHighlightPass.cpp
@@ -96,9 +96,8 @@ void ezSelectionHighlightPass::Execute(const ezRenderViewContext& renderViewCont
     hDepthTexture = ezGPUResourcePool::GetDefaultInstance()->GetRenderTarget(uiWidth, uiHeight, ezGALResourceFormat::D24S8, sampleCount, uiSliceCount);
 
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(hDepthTexture));
-    renderingSetup.m_bClearDepth = true;
-    renderingSetup.m_bClearStencil = true;
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(hDepthTexture));
+    renderingSetup.SetClearDepth().SetClearStencil();
 
     auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());
 
@@ -114,7 +113,7 @@ void ezSelectionHighlightPass::Execute(const ezRenderViewContext& renderViewCont
     constants->OverlayOpacity = m_fOverlayOpacity;
 
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pColorOutput->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pColorOutput->m_TextureHandle));
 
     auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SeparatedBilateralBlur.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SeparatedBilateralBlur.cpp
@@ -125,7 +125,7 @@ void ezSeparatedBilateralBlurPass::Execute(const ezRenderViewContext& renderView
 
     // Horizontal
     {
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(tempTexture));
+      renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(tempTexture));
       ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, "", renderViewContext.m_pCamera->IsStereoscopic());
 
       renderViewContext.m_pRenderContext->SetShaderPermutationVariable("BLUR_DIRECTION", "BLUR_DIRECTION_HORIZONTAL");
@@ -135,7 +135,7 @@ void ezSeparatedBilateralBlurPass::Execute(const ezRenderViewContext& renderView
 
     // Vertical
     {
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
+      renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(outputs[m_PinOutput.m_uiOutputIndex]->m_TextureHandle));
       ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, "", renderViewContext.m_pCamera->IsStereoscopic());
 
       renderViewContext.m_pRenderContext->SetShaderPermutationVariable("BLUR_DIRECTION", "BLUR_DIRECTION_VERTICAL");

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SimpleRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SimpleRenderPass.cpp
@@ -88,12 +88,12 @@ void ezSimpleRenderPass::Execute(const ezRenderViewContext& renderViewContext, c
   ezGALRenderingSetup renderingSetup;
   if (inputs[m_PinColor.m_uiInputIndex])
   {
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(inputs[m_PinColor.m_uiInputIndex]->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(inputs[m_PinColor.m_uiInputIndex]->m_TextureHandle));
   }
 
   if (inputs[m_PinDepthStencil.m_uiInputIndex])
   {
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(inputs[m_PinDepthStencil.m_uiInputIndex]->m_TextureHandle));
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(inputs[m_PinDepthStencil.m_uiInputIndex]->m_TextureHandle));
   }
 
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, std::move(renderingSetup), GetName(), renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SourcePass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SourcePass.cpp
@@ -159,18 +159,15 @@ void ezSourcePass::Execute(const ezRenderViewContext& renderViewContext, const e
 
   // Setup render target
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_ClearColor = m_ClearColor;
-  renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-  renderingSetup.m_bClearDepth = true;
-  renderingSetup.m_bClearStencil = true;
-
   if (ezGALResourceFormat::IsDepthFormat(pOutput->m_Desc.m_Format))
   {
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetClearDepth().SetClearStencil();
   }
   else
   {
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+    renderingSetup.SetClearColor(0, m_ClearColor);
   }
 
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/StereoTestPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/StereoTestPass.cpp
@@ -71,7 +71,7 @@ void ezStereoTestPass::Execute(const ezRenderViewContext& renderViewContext, con
 
   // Setup render target
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pOutput->m_TextureHandle));
 
   // Bind render target and viewport
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
@@ -115,7 +115,7 @@ void ezTonemapPass::Execute(const ezRenderViewContext& renderViewContext, const 
 
   // Setup render target
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(pColorOutput->m_TextureHandle));
+  renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(pColorOutput->m_TextureHandle));
 
   // Bind render target and viewport
   auto pCommandEncoder = ezRenderContext::BeginRenderingScope(renderViewContext, renderingSetup, GetName(), renderViewContext.m_pCamera->IsStereoscopic());

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -166,23 +166,7 @@ void ezRenderContext::BeginRendering(const ezGALRenderingSetup& renderingSetup, 
 {
   EZ_ASSERT_DEBUG(m_bRendering == false && m_bCompute == false, "Already in a scope");
   m_bRendering = true;
-  ezGALMSAASampleCount::Enum msaaSampleCount = ezGALMSAASampleCount::None;
-
-  ezGALRenderTargetViewHandle hRTV;
-  if (renderingSetup.m_RenderTargetSetup.GetRenderTargetCount() > 0)
-  {
-    hRTV = renderingSetup.m_RenderTargetSetup.GetRenderTarget(0);
-  }
-  if (hRTV.IsInvalidated())
-  {
-    hRTV = renderingSetup.m_RenderTargetSetup.GetDepthStencilTarget();
-  }
-
-  if (const ezGALRenderTargetView* pRTV = ezGALDevice::GetDefaultDevice()->GetRenderTargetView(hRTV))
-  {
-    msaaSampleCount = pRTV->GetTexture()->GetDescription().m_SampleCount;
-  }
-
+  const ezGALMSAASampleCount::Enum msaaSampleCount = renderingSetup.GetRenderPass().m_Msaa;
   if (msaaSampleCount != ezGALMSAASampleCount::None)
   {
     SetShaderPermutationVariable("MSAA", "TRUE");
@@ -1071,8 +1055,8 @@ ezResult ezRenderContext::BuildVertexDeclaration(ezGALShaderHandle hShader, ezAr
   {
     iHighestUsedBinding = ezMath::Max(iHighestUsedBinding, static_cast<ezInt32>(customVertexDecl.m_VertexStreams[slot].m_uiVertexBufferSlot));
   }
-  EZ_ASSERT_DEBUG(iHighestUsedBinding < vertexBufferStrides.GetCount(), "Not enough vertex buffer strides");
-  EZ_ASSERT_DEBUG(iHighestUsedBinding < vertexBufferBindingRates.GetCount(), "Not enough vertex buffer binding rates");
+  EZ_ASSERT_DEBUG(iHighestUsedBinding < (ezInt32)vertexBufferStrides.GetCount(), "Not enough vertex buffer strides");
+  EZ_ASSERT_DEBUG(iHighestUsedBinding < (ezInt32)vertexBufferBindingRates.GetCount(), "Not enough vertex buffer binding rates");
 
   ShaderVertexDecl svd;
   {

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -154,7 +154,7 @@ private:
 
   ID3D11DeviceChild* m_pBoundShaders[ezGALShaderStage::ENUM_COUNT] = {};
 
-  ezGALRenderTargetSetup m_RenderTargetSetup;
+  ezGALRenderingSetup m_RenderTargetSetup;
   ID3D11RenderTargetView* m_pBoundRenderTargets[EZ_GAL_MAX_RENDERTARGET_COUNT] = {};
   ezUInt32 m_uiBoundRenderTargetCount = 0;
   ID3D11DepthStencilView* m_pBoundDepthStencilTarget = nullptr;

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -487,20 +487,20 @@ void ezGALCommandEncoderImplDX11::InsertEventMarkerPlatform(const char* szMarker
 
 void ezGALCommandEncoderImplDX11::BeginRenderingPlatform(const ezGALRenderingSetup& renderingSetup)
 {
-  if (m_RenderTargetSetup != renderingSetup.m_RenderTargetSetup)
+  if (m_RenderTargetSetup != renderingSetup)
   {
-    m_RenderTargetSetup = renderingSetup.m_RenderTargetSetup;
+    m_RenderTargetSetup = renderingSetup;
 
     const ezGALRenderTargetView* pRenderTargetViews[EZ_GAL_MAX_RENDERTARGET_COUNT] = {nullptr};
     const ezGALRenderTargetView* pDepthStencilView = nullptr;
 
-    const ezUInt32 uiRenderTargetCount = m_RenderTargetSetup.GetRenderTargetCount();
+    const ezUInt32 uiRenderTargetCount = m_RenderTargetSetup.GetColorTargetCount();
 
     bool bFlushNeeded = false;
 
     for (ezUInt8 uiIndex = 0; uiIndex < uiRenderTargetCount; ++uiIndex)
     {
-      const ezGALRenderTargetView* pRenderTargetView = m_GALDeviceDX11.GetRenderTargetView(m_RenderTargetSetup.GetRenderTarget(uiIndex));
+      const ezGALRenderTargetView* pRenderTargetView = m_GALDeviceDX11.GetRenderTargetView(m_RenderTargetSetup.GetFrameBuffer().m_hColorTarget[uiIndex]);
       if (pRenderTargetView != nullptr)
       {
         const ezGALResourceBase* pTexture = pRenderTargetView->GetTexture()->GetParentResource();
@@ -512,13 +512,16 @@ void ezGALCommandEncoderImplDX11::BeginRenderingPlatform(const ezGALRenderingSet
       pRenderTargetViews[uiIndex] = pRenderTargetView;
     }
 
-    pDepthStencilView = m_GALDeviceDX11.GetRenderTargetView(m_RenderTargetSetup.GetDepthStencilTarget());
-    if (pDepthStencilView != nullptr)
+    if (m_RenderTargetSetup.HasDepthStencilTarget())
     {
-      const ezGALResourceBase* pTexture = pDepthStencilView->GetTexture()->GetParentResource();
+      pDepthStencilView = m_GALDeviceDX11.GetRenderTargetView(m_RenderTargetSetup.GetFrameBuffer().m_hDepthTarget);
+      if (pDepthStencilView != nullptr)
+      {
+        const ezGALResourceBase* pTexture = pDepthStencilView->GetTexture()->GetParentResource();
 
-      bFlushNeeded |= UnsetResourceViews(pTexture);
-      bFlushNeeded |= UnsetUnorderedAccessViews(pTexture);
+        bFlushNeeded |= UnsetResourceViews(pTexture);
+        bFlushNeeded |= UnsetUnorderedAccessViews(pTexture);
+      }
     }
 
     if (bFlushNeeded)
@@ -560,7 +563,23 @@ void ezGALCommandEncoderImplDX11::BeginRenderingPlatform(const ezGALRenderingSet
     }
   }
 
-  ClearPlatform(renderingSetup.m_ClearColor, renderingSetup.m_uiRenderTargetClearMask, renderingSetup.m_bClearDepth, renderingSetup.m_bClearStencil, renderingSetup.m_fDepthClear, renderingSetup.m_uiStencilClear);
+  for (ezUInt32 i = 0; i < m_uiBoundRenderTargetCount; i++)
+  {
+    if (m_RenderTargetSetup.GetRenderPass().m_ColorLoadOp[i] == ezGALRenderTargetLoadOp::Clear && m_pBoundRenderTargets[i])
+    {
+      m_pDXContext->ClearRenderTargetView(m_pBoundRenderTargets[i], m_RenderTargetSetup.GetClearColor(i).GetData());
+    }
+  }
+
+  bool bClearDepth = m_RenderTargetSetup.GetRenderPass().m_DepthLoadOp == ezGALRenderTargetLoadOp::Clear;
+  bool bClearStencil = m_RenderTargetSetup.GetRenderPass().m_StencilLoadOp == ezGALRenderTargetLoadOp::Clear;
+  if ((bClearDepth || bClearStencil) && m_pBoundDepthStencilTarget)
+  {
+    ezUInt32 uiClearFlags = bClearDepth ? D3D11_CLEAR_DEPTH : 0;
+    uiClearFlags |= bClearStencil ? D3D11_CLEAR_STENCIL : 0;
+
+    m_pDXContext->ClearDepthStencilView(m_pBoundDepthStencilTarget, uiClearFlags, m_RenderTargetSetup.GetClearDepth(), m_RenderTargetSetup.GetClearStencil());
+  }
 }
 
 void ezGALCommandEncoderImplDX11::EndRenderingPlatform()
@@ -571,7 +590,7 @@ void ezGALCommandEncoderImplDX11::BeginComputePlatform()
 {
   // We need to unbind all render targets as otherwise using them in a compute shader as input will fail:
   // DEVICE_CSSETSHADERRESOURCES_HAZARD: Resource being set to CS shader resource slot 0 is still bound on output!
-  m_RenderTargetSetup = ezGALRenderTargetSetup();
+  m_RenderTargetSetup = ezGALRenderingSetup();
   m_pDXContext->OMSetRenderTargets(0, nullptr, nullptr);
 }
 void ezGALCommandEncoderImplDX11::EndComputePlatform()

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -567,7 +567,7 @@ void ezGALCommandEncoderImplDX11::BeginRenderingPlatform(const ezGALRenderingSet
   {
     if (m_RenderTargetSetup.GetRenderPass().m_ColorLoadOp[i] == ezGALRenderTargetLoadOp::Clear && m_pBoundRenderTargets[i])
     {
-      m_pDXContext->ClearRenderTargetView(m_pBoundRenderTargets[i], m_RenderTargetSetup.GetClearColor(i).GetData());
+      m_pDXContext->ClearRenderTargetView(m_pBoundRenderTargets[i], m_RenderTargetSetup.GetClearColor((ezUInt8)i).GetData());
     }
   }
 

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -57,7 +57,6 @@ class ezGALReadbackTexture;
 class ezGALDepthStencilState;
 class ezGALBlendState;
 class ezGALRasterizerState;
-class ezGALRenderTargetSetup;
 class ezGALVertexDeclaration;
 class ezGALSamplerState;
 class ezGALTextureResourceView;
@@ -365,6 +364,31 @@ struct ezGALVertexBindingRate
     Vertex,
     Instance,
     Default = Vertex,
+  };
+};
+
+/// \brief The initial state of a render target when starting to render to it.
+struct ezGALRenderTargetLoadOp
+{
+  using StorageType = ezUInt8;
+  enum Enum
+  {
+    Load, ///< The previous contents of the render target are preserved when starting to render to it.
+    Clear, ///< The render target is cleared before rendering.
+    DontCare, ///< The contents of the render target is undefined. Use if you intent to render to the entirety of the viewport.
+    Default = Load
+  };
+};
+
+/// \brief The state of a render target after finishing to render to it.
+struct ezGALRenderTargetStoreOp
+{
+  using StorageType = ezUInt8;
+  enum Enum
+  {
+    Store, ///< The render result is written back to the render target's memory.
+    Discard, ///< The end result is not needed. Use for transient render targets.
+    Default = Store
   };
 };
 

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -373,8 +373,8 @@ struct ezGALRenderTargetLoadOp
   using StorageType = ezUInt8;
   enum Enum
   {
-    Load, ///< The previous contents of the render target are preserved when starting to render to it.
-    Clear, ///< The render target is cleared before rendering.
+    Load,     ///< The previous contents of the render target are preserved when starting to render to it.
+    Clear,    ///< The render target is cleared before rendering.
     DontCare, ///< The contents of the render target is undefined. Use if you intent to render to the entirety of the viewport.
     Default = Load
   };
@@ -386,7 +386,7 @@ struct ezGALRenderTargetStoreOp
   using StorageType = ezUInt8;
   enum Enum
   {
-    Store, ///< The render result is written back to the render target's memory.
+    Store,   ///< The render result is written back to the render target's memory.
     Discard, ///< The end result is not needed. Use for transient render targets.
     Default = Store
   };

--- a/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
@@ -119,7 +119,7 @@ ezGALRenderingSetup& ezGALRenderingSetup::SetClearColor(ezUInt8 uiIndex, const e
   EZ_ASSERT_DEBUG(uiIndex < m_RenderPass.m_uiRTCount, "Render target not set, call SetRenderTarget first");
   m_ClearColor[uiIndex] = color;
   m_RenderPass.m_ColorLoadOp[uiIndex] = ezGALRenderTargetLoadOp::Clear;
-  return * this;
+  return *this;
 }
 
 ezGALRenderingSetup& ezGALRenderingSetup::SetClearDepth(float fDepthClear)
@@ -127,7 +127,7 @@ ezGALRenderingSetup& ezGALRenderingSetup::SetClearDepth(float fDepthClear)
   EZ_ASSERT_DEBUG(HasDepthStencilTarget(), "Depth target not set, call SetDepthStencilTarget first");
   m_fClearDepth = fDepthClear;
   m_RenderPass.m_DepthLoadOp = ezGALRenderTargetLoadOp::Clear;
-  return * this;
+  return *this;
 }
 
 ezGALRenderingSetup& ezGALRenderingSetup::SetClearStencil(ezUInt8 uiStencilClear)
@@ -135,7 +135,7 @@ ezGALRenderingSetup& ezGALRenderingSetup::SetClearStencil(ezUInt8 uiStencilClear
   EZ_ASSERT_DEBUG(HasDepthStencilTarget(), "Depth target not set, call SetDepthStencilTarget first");
   m_uiClearStencil = uiStencilClear;
   m_RenderPass.m_StencilLoadOp = ezGALRenderTargetLoadOp::Clear;
-  return * this;
+  return *this;
 }
 
 void ezGALRenderingSetup::Reset()

--- a/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
@@ -2,6 +2,35 @@
 
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/RenderTargetSetup.h>
+#include <RendererFoundation/Resources/RenderTargetView.h>
+
+namespace
+{
+  struct RenderTargetViewInfo
+  {
+    ezEnum<ezGALMSAASampleCount> m_MSAA;
+    ezSizeU32 m_Size = {0, 0};
+    ezUInt32 m_uiSliceCount = 0;
+  };
+
+  RenderTargetViewInfo getRenderTargetViewInfo(ezGALRenderTargetViewHandle hView, ezEnum<ezGALResourceFormat>& out_format)
+  {
+    RenderTargetViewInfo info;
+    const ezGALRenderTargetView* pRTV = ezGALDevice::GetDefaultDevice()->GetRenderTargetView(hView);
+    EZ_ASSERT_DEV(pRTV, "Render target view must be valid");
+    const ezGALRenderTargetViewCreationDescription& viewDesc = pRTV->GetDescription();
+    const ezGALTextureCreationDescription& texDesc = pRTV->GetTexture()->GetDescription();
+    out_format = viewDesc.m_OverrideViewFormat;
+    if (out_format == ezGALResourceFormat::Invalid)
+      out_format = texDesc.m_Format;
+
+    info.m_MSAA = texDesc.m_SampleCount;
+    ezVec3U32 size = pRTV->GetTexture()->GetMipMapSize(viewDesc.m_uiMipLevel);
+    info.m_Size = {size.x, size.y};
+    info.m_uiSliceCount = viewDesc.m_uiSliceCount;
+    return info;
+  }
+} // namespace
 
 bool ezGALRenderTargets::operator==(const ezGALRenderTargets& other) const
 {
@@ -21,53 +50,104 @@ bool ezGALRenderTargets::operator!=(const ezGALRenderTargets& other) const
   return !(*this == other);
 }
 
-ezGALRenderTargetSetup::ezGALRenderTargetSetup() = default;
-
-ezGALRenderTargetSetup& ezGALRenderTargetSetup::SetRenderTarget(ezUInt8 uiIndex, ezGALRenderTargetViewHandle hRenderTarget)
+ezGALRenderingSetup& ezGALRenderingSetup::SetColorTarget(ezUInt8 uiIndex, ezGALRenderTargetViewHandle hRenderTarget, ezEnum<ezGALRenderTargetLoadOp> loadOp, ezEnum<ezGALRenderTargetStoreOp> storeOp)
 {
-  EZ_ASSERT_DEV(uiIndex < EZ_GAL_MAX_RENDERTARGET_COUNT, "Render target index out of bounds - should be less than EZ_GAL_MAX_RENDERTARGET_COUNT");
+  EZ_ASSERT_DEBUG(uiIndex <= m_RenderPass.m_uiRTCount, "Render targets must be defined in order, starting at 0 and must not have gaps. The index {} should be less or equal to {}", uiIndex, m_RenderPass.m_uiRTCount);
 
-  m_hRTs[uiIndex] = hRenderTarget;
-
-  m_uiRTCount = ezMath::Max(m_uiRTCount, static_cast<ezUInt8>(uiIndex + 1u));
-
-  return *this;
-}
-
-ezGALRenderTargetSetup& ezGALRenderTargetSetup::SetDepthStencilTarget(ezGALRenderTargetViewHandle hDSTarget)
-{
-  m_hDSTarget = hDSTarget;
-
-  return *this;
-}
-
-bool ezGALRenderTargetSetup::operator==(const ezGALRenderTargetSetup& other) const
-{
-  if (m_hDSTarget != other.m_hDSTarget)
-    return false;
-
-  if (m_uiRTCount != other.m_uiRTCount)
-    return false;
-
-  for (ezUInt8 uiRTIndex = 0; uiRTIndex < m_uiRTCount; ++uiRTIndex)
+  RenderTargetViewInfo info = getRenderTargetViewInfo(hRenderTarget, m_RenderPass.m_ColorFormat[uiIndex]);
+  const bool bFirstRenderTarget = GetColorTargetCount() == 0 && m_FrameBuffer.m_hDepthTarget.IsInvalidated();
+  if (!bFirstRenderTarget)
   {
-    if (m_hRTs[uiRTIndex] != other.m_hRTs[uiRTIndex])
-      return false;
+    EZ_ASSERT_DEBUG(m_RenderPass.m_Msaa == info.m_MSAA, "Missmatch between this render target's MSAA mode ({}) and the previously set MSAA mode ({}).", info.m_MSAA, m_RenderPass.m_Msaa);
+    EZ_ASSERT_DEBUG(m_FrameBuffer.m_Size == info.m_Size, "Missmatch between this render target's size ({}) and the previously set size ({}).", info.m_Size, m_FrameBuffer.m_Size);
+    EZ_ASSERT_DEBUG(m_FrameBuffer.m_uiSliceCount == info.m_uiSliceCount, "Missmatch between this render target's slice count ({}) and the previously set slice count ({}).", info.m_uiSliceCount, m_FrameBuffer.m_uiSliceCount);
+  }
+  else
+  {
+    m_RenderPass.m_Msaa = info.m_MSAA;
+    m_FrameBuffer.m_Size = info.m_Size;
+    m_FrameBuffer.m_uiSliceCount = info.m_uiSliceCount;
   }
 
-  return true;
+  EZ_ASSERT_DEBUG(!ezGALResourceFormat::IsDepthFormat(m_RenderPass.m_ColorFormat[uiIndex]), "The format {} must be a color format", m_RenderPass.m_DepthFormat);
+
+  m_FrameBuffer.m_hColorTarget[uiIndex] = hRenderTarget;
+  m_RenderPass.m_uiRTCount = ezMath::Max(m_RenderPass.m_uiRTCount, static_cast<ezUInt8>(uiIndex + 1u));
+  m_RenderPass.m_ColorLoadOp[uiIndex] = loadOp;
+  m_RenderPass.m_ColorStoreOp[uiIndex] = storeOp;
+
+  return *this;
 }
 
-bool ezGALRenderTargetSetup::operator!=(const ezGALRenderTargetSetup& other) const
+ezGALRenderingSetup& ezGALRenderingSetup::SetDepthStencilTarget(ezGALRenderTargetViewHandle hDSTarget, ezEnum<ezGALRenderTargetLoadOp> depthLoadOp, ezEnum<ezGALRenderTargetStoreOp> depthStoreOp, ezEnum<ezGALRenderTargetLoadOp> stencilLoadOp, ezEnum<ezGALRenderTargetStoreOp> stencilStoreOp)
 {
-  return !(*this == other);
+  RenderTargetViewInfo info = getRenderTargetViewInfo(hDSTarget, m_RenderPass.m_DepthFormat);
+  const bool bFirstRenderTarget = GetColorTargetCount() == 0 && m_FrameBuffer.m_hDepthTarget.IsInvalidated();
+  if (!bFirstRenderTarget)
+  {
+    EZ_ASSERT_DEBUG(m_RenderPass.m_Msaa == info.m_MSAA, "Missmatch between this render target's MSAA mode ({}) and the previously set MSAA mode ({}).", info.m_MSAA, m_RenderPass.m_Msaa);
+    EZ_ASSERT_DEBUG(m_FrameBuffer.m_Size == info.m_Size, "Missmatch between this render target's size ({}) and the previously set size ({}).", info.m_Size, m_FrameBuffer.m_Size);
+    EZ_ASSERT_DEBUG(m_FrameBuffer.m_uiSliceCount == info.m_uiSliceCount, "Missmatch between this render target's slice count ({}) and the previously set slice count ({}).", info.m_uiSliceCount, m_FrameBuffer.m_uiSliceCount);
+  }
+  else
+  {
+    m_RenderPass.m_Msaa = info.m_MSAA;
+    m_FrameBuffer.m_Size = info.m_Size;
+    m_FrameBuffer.m_uiSliceCount = info.m_uiSliceCount;
+  }
+
+  m_FrameBuffer.m_hDepthTarget = hDSTarget;
+  m_RenderPass.m_DepthLoadOp = depthLoadOp;
+  m_RenderPass.m_DepthStoreOp = depthStoreOp;
+
+  EZ_ASSERT_DEBUG(ezGALResourceFormat::IsDepthFormat(m_RenderPass.m_DepthFormat), "The format {} is not a depth format", m_RenderPass.m_DepthFormat);
+  if (ezGALResourceFormat::IsStencilFormat(m_RenderPass.m_DepthFormat))
+  {
+    m_RenderPass.m_StencilLoadOp = stencilLoadOp;
+    m_RenderPass.m_StencilStoreOp = stencilStoreOp;
+  }
+  else
+  {
+    m_RenderPass.m_StencilLoadOp = ezGALRenderTargetLoadOp::DontCare;
+    m_RenderPass.m_StencilStoreOp = ezGALRenderTargetStoreOp::Discard;
+  }
+  return *this;
 }
 
-void ezGALRenderTargetSetup::DestroyAllAttachedViews()
+ezGALRenderingSetup& ezGALRenderingSetup::SetClearColor(ezUInt8 uiIndex, const ezColor& color)
+{
+  EZ_ASSERT_DEBUG(uiIndex < m_RenderPass.m_uiRTCount, "Render target not set, call SetRenderTarget first");
+  m_ClearColor[uiIndex] = color;
+  m_RenderPass.m_ColorLoadOp[uiIndex] = ezGALRenderTargetLoadOp::Clear;
+  return * this;
+}
+
+ezGALRenderingSetup& ezGALRenderingSetup::SetClearDepth(float fDepthClear)
+{
+  EZ_ASSERT_DEBUG(HasDepthStencilTarget(), "Depth target not set, call SetDepthStencilTarget first");
+  m_fClearDepth = fDepthClear;
+  m_RenderPass.m_DepthLoadOp = ezGALRenderTargetLoadOp::Clear;
+  return * this;
+}
+
+ezGALRenderingSetup& ezGALRenderingSetup::SetClearStencil(ezUInt8 uiStencilClear)
+{
+  EZ_ASSERT_DEBUG(HasDepthStencilTarget(), "Depth target not set, call SetDepthStencilTarget first");
+  m_uiClearStencil = uiStencilClear;
+  m_RenderPass.m_StencilLoadOp = ezGALRenderTargetLoadOp::Clear;
+  return * this;
+}
+
+void ezGALRenderingSetup::Reset()
+{
+  *this = ezGALRenderingSetup();
+}
+
+void ezGALRenderingSetup::DestroyAllAttachedViews()
 {
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
-  ezArrayPtr<ezGALRenderTargetViewHandle> colorViews(m_hRTs);
+  ezArrayPtr<ezGALRenderTargetViewHandle> colorViews(m_FrameBuffer.m_hColorTarget);
   for (ezGALRenderTargetViewHandle& hView : colorViews)
   {
     if (!hView.IsInvalidated())
@@ -77,20 +157,10 @@ void ezGALRenderTargetSetup::DestroyAllAttachedViews()
     }
   }
 
-  if (!m_hDSTarget.IsInvalidated())
+  if (!m_FrameBuffer.m_hDepthTarget.IsInvalidated())
   {
-    pDevice->DestroyRenderTargetView(m_hDSTarget);
-    m_hDSTarget.Invalidate();
+    pDevice->DestroyRenderTargetView(m_FrameBuffer.m_hDepthTarget);
+    m_FrameBuffer.m_hDepthTarget.Invalidate();
   }
-  m_uiRTCount = 0;
-}
-
-bool ezGALRenderingSetup::operator==(const ezGALRenderingSetup& other) const
-{
-  return m_RenderTargetSetup == other.m_RenderTargetSetup && m_ClearColor == other.m_ClearColor && m_uiRenderTargetClearMask == other.m_uiRenderTargetClearMask && m_fDepthClear == other.m_fDepthClear && m_uiStencilClear == other.m_uiStencilClear && m_bClearDepth == other.m_bClearDepth && m_bClearStencil == other.m_bClearStencil && m_bDiscardColor == other.m_bDiscardColor && m_bDiscardDepth == other.m_bDiscardDepth;
-}
-
-bool ezGALRenderingSetup::operator!=(const ezGALRenderingSetup& other) const
-{
-  return !(*this == other);
+  Reset();
 }

--- a/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup_inl.h
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup_inl.h
@@ -1,19 +1,39 @@
 
 #pragma once
 
-ezUInt8 ezGALRenderTargetSetup::GetRenderTargetCount() const
+ezUInt8 ezGALRenderingSetup::GetColorTargetCount() const
 {
-  return m_uiRTCount;
+  return m_RenderPass.m_uiRTCount;
 }
 
-ezGALRenderTargetViewHandle ezGALRenderTargetSetup::GetRenderTarget(ezUInt8 uiIndex) const
+const ezColor& ezGALRenderingSetup::GetClearColor(ezUInt8 uiIndex) const
 {
-  EZ_ASSERT_DEBUG(uiIndex < m_uiRTCount, "Render target index out of range");
-
-  return m_hRTs[uiIndex];
+  EZ_ASSERT_DEBUG(uiIndex < m_RenderPass.m_uiRTCount, "Render target at index {} does no exist, there are only {} render targets. Call GetRenderTargetCount first to determine max render targets.", uiIndex, m_RenderPass.m_uiRTCount);
+  return m_ClearColor[uiIndex];
 }
 
-ezGALRenderTargetViewHandle ezGALRenderTargetSetup::GetDepthStencilTarget() const
+bool ezGALRenderingSetup::HasDepthStencilTarget() const
 {
-  return m_hDSTarget;
+  return !m_FrameBuffer.m_hDepthTarget.IsInvalidated();
+}
+
+float ezGALRenderingSetup::GetClearDepth() const
+{
+  EZ_ASSERT_DEBUG(HasDepthStencilTarget(), "No depth target exists, check HasDepthStencilTarget() first.");
+  return m_fClearDepth;
+}
+
+ezUInt8 ezGALRenderingSetup::GetClearStencil() const
+{
+  EZ_ASSERT_DEBUG(HasDepthStencilTarget(), "No depth target exists, check HasDepthStencilTarget() first.");
+  return m_uiClearStencil;
+}
+
+const ezGALRenderPassDescriptor& ezGALRenderingSetup::GetRenderPass() const
+{
+  return m_RenderPass;
+}
+const ezGALFrameBufferDescriptor& ezGALRenderingSetup::GetFrameBuffer() const
+{
+  return m_FrameBuffer;
 }

--- a/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/Texture.cpp
@@ -16,3 +16,12 @@ ezGALTexture::~ezGALTexture()
   EZ_ASSERT_DEV(m_RenderTargetViews.IsEmpty(), "Dangling render target views");
   EZ_ASSERT_DEV(m_UnorderedAccessViews.IsEmpty(), "Dangling unordered access views");
 }
+
+ezVec3U32 ezGALTexture::GetMipMapSize(ezUInt32 uiMipLevel) const
+{
+  ezVec3U32 size = {m_Description.m_uiWidth, m_Description.m_uiHeight, m_Description.m_uiDepth};
+  size.x = ezMath::Max(1u, size.x >> uiMipLevel);
+  size.y = ezMath::Max(1u, size.y >> uiMipLevel);
+  size.z = ezMath::Max(1u, size.z >> uiMipLevel);
+  return size;
+}

--- a/Code/Engine/RendererFoundation/Resources/RenderTargetSetup.h
+++ b/Code/Engine/RendererFoundation/Resources/RenderTargetSetup.h
@@ -1,10 +1,12 @@
-
 #pragma once
 
+#include <Foundation/Math/Size.h>
+#include <Foundation/Algorithm/HashableStruct.h>
 #include <Foundation/Basics.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Resources/ResourceFormats.h>
 
-// \brief This class can be used to define the render targets to be used by an ezView.
+/// \brief This class can be used to define the render targets to be used by an ezView.
 struct EZ_RENDERERFOUNDATION_DLL ezGALRenderTargets
 {
   bool operator==(const ezGALRenderTargets& other) const;
@@ -14,46 +16,108 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALRenderTargets
   ezGALTextureHandle m_hDSTarget;
 };
 
-// \brief This class can be used to construct render target setups on the stack.
-class EZ_RENDERERFOUNDATION_DLL ezGALRenderTargetSetup
+/// \brief This class is used to describe the render pass setup of a graphics pipeline.
+/// This should not be filled out manually, but rather be created by the ezGALRenderingSetup.
+/// The render pass descriptor is eventually used by the renderer to generate both a render pass as well as compatible graphics pipeline state objects.
+/// \sa ezGALRenderingSetup
+struct ezGALRenderPassDescriptor : public ezHashableStruct<ezGALRenderPassDescriptor>
+{
+  ezUInt8 m_uiRTCount = 0;
+  ezEnum<ezGALMSAASampleCount> m_Msaa;
+  ezEnum<ezGALResourceFormat> m_DepthFormat = ezGALResourceFormat::Invalid;
+  ezEnum<ezGALRenderTargetLoadOp> m_DepthLoadOp;
+  ezEnum<ezGALRenderTargetStoreOp> m_DepthStoreOp;
+  ezEnum<ezGALRenderTargetLoadOp> m_StencilLoadOp;
+  ezEnum<ezGALRenderTargetStoreOp> m_StencilStoreOp;
+  ezEnum<ezGALResourceFormat> m_ColorFormat[EZ_GAL_MAX_RENDERTARGET_COUNT] = {ezGALResourceFormat::Invalid};
+  ezEnum<ezGALRenderTargetLoadOp> m_ColorLoadOp[EZ_GAL_MAX_RENDERTARGET_COUNT];
+  ezEnum<ezGALRenderTargetStoreOp> m_ColorStoreOp[EZ_GAL_MAX_RENDERTARGET_COUNT];
+};
+
+/// \brief This class is used to describe the frame buffer of a graphics pipeline.
+/// This should not be filled out manually, but rather be created by the ezGALRenderingSetup.
+/// The frame buffer descriptor is used by the renderer to set up render targets to render into.
+/// \sa ezGALRenderingSetup
+struct ezGALFrameBufferDescriptor : public ezHashableStruct<ezGALFrameBufferDescriptor>
+{
+  ezGALRenderTargetViewHandle m_hColorTarget[EZ_GAL_MAX_RENDERTARGET_COUNT];
+  ezGALRenderTargetViewHandle m_hDepthTarget;
+  ezSizeU32 m_Size = {0, 0};
+  ezUInt32 m_uiSliceCount = 0;
+};
+
+/// \brief This class sets up the render targets for a graphics pipeline, used by ezRenderContext::BeginRendering or ezGALCommandEncoder::BeginRendering.
+///
+/// The usage pattern is very strict to prevent creating invalid render target configs: SetColorTarget must be called starting at uiIndex 0 before you can call it with index 1 and so fourth. To call any of the SetClear* functions, you first must have called the corresponding SetColorTarget or SetDepthStencilTarget functions. All clear methods have reasonable default values (color: black, depth: 1.0, stencil: 0). SetColorTarget and SetDepthStencilTarget can be called multiple times as long as the format of the view remains identical to the previously assigned one. Thus, while not very expensive, it is still a good idea to cache these objects and only swap out the textures when they are not fixed, e.g. when using the ezGPUResourcePool.
+/// The class produces a ezGALRenderPassDescriptor and a ezGALFrameBufferDescriptor that can be retrieved via GetRenderPass and GetFrameBuffer respectively.
+///
+/// Example usage:
+/// \code{.cpp}
+/// renderTargetSetup.SetColorTarget(0, hRT)).SetClearColor(0, ezColor::White)
+/// renderTargetSetup.SetDepthStencilTarget(hDepth)).SetClearDepth().SetClearStencil();
+/// \endcode
+///
+/// \sa ezGALRenderPassDescriptor, ezGALFrameBufferDescriptor, ezRenderContext::BeginRendering, ezGALCommandEncoder::BeginRendering
+struct EZ_RENDERERFOUNDATION_DLL ezGALRenderingSetup : public ezHashableStruct<ezGALRenderingSetup>
 {
 public:
-  ezGALRenderTargetSetup();
+  /// \name Setup render targets
+  ///@{
 
-  ezGALRenderTargetSetup& SetRenderTarget(ezUInt8 uiIndex, ezGALRenderTargetViewHandle hRenderTarget);
-  ezGALRenderTargetSetup& SetDepthStencilTarget(ezGALRenderTargetViewHandle hDSTarget);
+  /// \brief Sets the color render target at the given index.
+  /// Note that you must set index 0 before you can call this with index 1 and so fourth. You can call the function for an already set index again as long as the format / size matches.
+  /// If not set, the load and store operations default to 'Load' and 'Store' respectively.
+  ezGALRenderingSetup& SetColorTarget(ezUInt8 uiIndex, ezGALRenderTargetViewHandle hRenderTarget, ezEnum<ezGALRenderTargetLoadOp> loadOp = {}, ezEnum<ezGALRenderTargetStoreOp> storeOp = {});
 
-  bool operator==(const ezGALRenderTargetSetup& other) const;
-  bool operator!=(const ezGALRenderTargetSetup& other) const;
+  /// \brief Sets the depth / stencil render target.
+  /// If not set, the load and store operations default to 'Load' and 'Store' respectively for both depth and stencil.
+  ezGALRenderingSetup& SetDepthStencilTarget(ezGALRenderTargetViewHandle hDSTarget, ezEnum<ezGALRenderTargetLoadOp> depthLoadOp = {},  ezEnum<ezGALRenderTargetStoreOp> depthStoreOp = {}, ezEnum<ezGALRenderTargetLoadOp> stencilLoadOp = {},  ezEnum<ezGALRenderTargetStoreOp> stencilStoreOp = {});
 
-  inline ezUInt8 GetRenderTargetCount() const;
+  /// \brief Sets the clear color of the given render target and switches the load op to clear.
+  /// Note that you first must have called SetColorTarget with the same uiIndex to be able to set the clear color.
+  ezGALRenderingSetup& SetClearColor(ezUInt8 uiIndex, const ezColor& color = ezColor(0, 0, 0, 0));
 
-  inline ezGALRenderTargetViewHandle GetRenderTarget(ezUInt8 uiIndex) const;
-  inline ezGALRenderTargetViewHandle GetDepthStencilTarget() const;
+  /// \brief Sets the clear depth value.
+  /// Note that you first must have called SetDepthStencilTarget to be able to set the clear depth value.
+  ezGALRenderingSetup& SetClearDepth(float fDepthClear = 1.0f);
 
+  /// \brief Sets the clear depth value.
+  /// Note that you first must have called SetDepthStencilTarget to be able to set the clear depth value.
+  ezGALRenderingSetup& SetClearStencil(ezUInt8 uiStencilClear = 0);
+
+  ///@}
+  /// \name Accessors
+  ///@{
+
+  inline ezUInt8 GetColorTargetCount() const;
+  /// \brief Returns the clear color of the render target at the given index. Note that uiIndex must be less than GetColorTargetCount().
+  inline const ezColor& GetClearColor(ezUInt8 uiIndex) const;
+
+  inline bool HasDepthStencilTarget() const;
+  /// \brief Returns the depth clear value. This call is only valid if HasDepthStencilTarget() returns true.
+  inline float GetClearDepth() const;
+  /// \brief Returns the stencil clear value. This call is only valid if HasDepthStencilTarget() returns true.
+  inline ezUInt8 GetClearStencil() const;
+
+  /// \brief Returns the render pass description. Used to create a render pass or feed into the creation of a graphics pipeline state object.
+  inline const ezGALRenderPassDescriptor& GetRenderPass() const;
+  /// \brief Returns the frame buffer description. Used by the renderer to setup render targets.
+  inline const ezGALFrameBufferDescriptor& GetFrameBuffer() const;
+
+  ///@}
+
+  /// \brief Same as creating a new instance.
+  void Reset();
+  /// \brief Same as Reset, but destroys all attached views first.
   void DestroyAllAttachedViews();
 
 protected:
-  ezGALRenderTargetViewHandle m_hRTs[EZ_GAL_MAX_RENDERTARGET_COUNT];
-  ezGALRenderTargetViewHandle m_hDSTarget;
+  ezUInt8 m_uiClearStencil = 0;
+  float m_fClearDepth = 1.0f;
+  ezColor m_ClearColor[EZ_GAL_MAX_RENDERTARGET_COUNT] = {ezColor(0, 0, 0, 0)};
 
-  ezUInt8 m_uiRTCount = 0;
-};
-
-struct EZ_RENDERERFOUNDATION_DLL ezGALRenderingSetup
-{
-  bool operator==(const ezGALRenderingSetup& other) const;
-  bool operator!=(const ezGALRenderingSetup& other) const;
-
-  ezGALRenderTargetSetup m_RenderTargetSetup;
-  ezColor m_ClearColor = ezColor(0, 0, 0, 0);
-  ezUInt32 m_uiRenderTargetClearMask = 0x0;
-  float m_fDepthClear = 1.0f;
-  ezUInt8 m_uiStencilClear = 0;
-  bool m_bClearDepth = false;
-  bool m_bClearStencil = false;
-  bool m_bDiscardColor = false;
-  bool m_bDiscardDepth = false;
+  ezGALRenderPassDescriptor m_RenderPass;
+  ezGALFrameBufferDescriptor m_FrameBuffer;
 };
 
 #include <RendererFoundation/Resources/Implementation/RenderTargetSetup_inl.h>

--- a/Code/Engine/RendererFoundation/Resources/RenderTargetSetup.h
+++ b/Code/Engine/RendererFoundation/Resources/RenderTargetSetup.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <Foundation/Math/Size.h>
 #include <Foundation/Algorithm/HashableStruct.h>
 #include <Foundation/Basics.h>
+#include <Foundation/Math/Size.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Resources/ResourceFormats.h>
 
@@ -71,7 +71,7 @@ public:
 
   /// \brief Sets the depth / stencil render target.
   /// If not set, the load and store operations default to 'Load' and 'Store' respectively for both depth and stencil.
-  ezGALRenderingSetup& SetDepthStencilTarget(ezGALRenderTargetViewHandle hDSTarget, ezEnum<ezGALRenderTargetLoadOp> depthLoadOp = {},  ezEnum<ezGALRenderTargetStoreOp> depthStoreOp = {}, ezEnum<ezGALRenderTargetLoadOp> stencilLoadOp = {},  ezEnum<ezGALRenderTargetStoreOp> stencilStoreOp = {});
+  ezGALRenderingSetup& SetDepthStencilTarget(ezGALRenderTargetViewHandle hDSTarget, ezEnum<ezGALRenderTargetLoadOp> depthLoadOp = {}, ezEnum<ezGALRenderTargetStoreOp> depthStoreOp = {}, ezEnum<ezGALRenderTargetLoadOp> stencilLoadOp = {}, ezEnum<ezGALRenderTargetStoreOp> stencilStoreOp = {});
 
   /// \brief Sets the clear color of the given render target and switches the load op to clear.
   /// Note that you first must have called SetColorTarget with the same uiIndex to be able to set the clear color.

--- a/Code/Engine/RendererFoundation/Resources/Texture.h
+++ b/Code/Engine/RendererFoundation/Resources/Texture.h
@@ -6,6 +6,9 @@
 
 class EZ_RENDERERFOUNDATION_DLL ezGALTexture : public ezGALResource<ezGALTextureCreationDescription>
 {
+public:
+  ezVec3U32 GetMipMapSize(ezUInt32 uiMipLevel) const;
+
 protected:
   friend class ezGALDevice;
 

--- a/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
+++ b/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
@@ -40,8 +40,8 @@ public:
   {
     EZ_DECLARE_POD_TYPE();
     ezGALRenderPassDescriptor m_renderPassDesc;
-    vk::RenderPass m_renderPass;     // Created from ezGALRenderPassDescriptor above
-    vk::PipelineLayout m_layout;     // Created from shader (descriptor sets)
+    vk::RenderPass m_renderPass; // Created from ezGALRenderPassDescriptor above
+    vk::PipelineLayout m_layout; // Created from shader (descriptor sets)
     ezEnum<ezGALPrimitiveTopology> m_topology;
     const ezGALRasterizerStateVulkan* m_pCurrentRasterizerState = nullptr;
     const ezGALBlendStateVulkan* m_pCurrentBlendState = nullptr;
@@ -81,7 +81,7 @@ private:
   };
 
 
-    struct ResourceCacheHash
+  struct ResourceCacheHash
   {
     static ezUInt32 Hash(const ezGALRenderPassDescriptor& renderingSetup);
     static bool Equal(const ezGALRenderPassDescriptor& a, const ezGALRenderPassDescriptor& b);
@@ -112,7 +112,7 @@ private:
   static ezGALDeviceVulkan* s_pDevice;
   static vk::Device s_device;
   static ezHashTable<ezGALRenderPassDescriptor, vk::RenderPass, ResourceCacheHash> s_renderPasses;
-  static ezHashTable<FramebufferKey, vk::Framebuffer, ResourceCacheHash> s_frameBuffers;           // #TODO_VULKAN cache invalidation
+  static ezHashTable<FramebufferKey, vk::Framebuffer, ResourceCacheHash> s_frameBuffers; // #TODO_VULKAN cache invalidation
 
   static ezHashTable<PipelineLayoutDesc, vk::PipelineLayout, ResourceCacheHash> s_pipelineLayouts;
   static GraphicsPipelineMap s_graphicsPipelines;

--- a/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
+++ b/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
@@ -27,8 +27,8 @@ public:
   static void Initialize(ezGALDeviceVulkan* pDevice, vk::Device device);
   static void DeInitialize();
 
-  static vk::RenderPass RequestRenderPass(const ezGALRenderingSetup& renderingSetup);
-  static vk::Framebuffer RequestFrameBuffer(vk::RenderPass renderPass, const ezGALRenderTargetSetup& renderTargetSetup, ezSizeU32& out_Size, ezEnum<ezGALMSAASampleCount>& out_msaa, ezUInt32& out_uiLayers);
+  static vk::RenderPass RequestRenderPass(const ezGALRenderPassDescriptor& renderPass);
+  static vk::Framebuffer RequestFrameBuffer(vk::RenderPass vkRenderPass, const ezGALFrameBufferDescriptor& frameBuffer);
 
   struct PipelineLayoutDesc
   {
@@ -39,11 +39,10 @@ public:
   struct GraphicsPipelineDesc
   {
     EZ_DECLARE_POD_TYPE();
-    vk::RenderPass m_renderPass;     // Created from ezGALRenderingSetup
-    vk::PipelineLayout m_layout;     // Created from shader
+    ezGALRenderPassDescriptor m_renderPassDesc;
+    vk::RenderPass m_renderPass;     // Created from ezGALRenderPassDescriptor above
+    vk::PipelineLayout m_layout;     // Created from shader (descriptor sets)
     ezEnum<ezGALPrimitiveTopology> m_topology;
-    ezEnum<ezGALMSAASampleCount> m_msaa;
-    ezUInt8 m_uiAttachmentCount = 0; // DX12 requires format list for RT and DT
     const ezGALRasterizerStateVulkan* m_pCurrentRasterizerState = nullptr;
     const ezGALBlendStateVulkan* m_pCurrentBlendState = nullptr;
     const ezGALDepthStencilStateVulkan* m_pCurrentDepthStencilState = nullptr;
@@ -78,49 +77,14 @@ private:
   struct FramebufferKey
   {
     vk::RenderPass m_renderPass;
-    ezGALRenderTargetSetup m_renderTargetSetup;
+    ezGALFrameBufferDescriptor m_frameBuffer;
   };
 
-  /// \brief Hashable version without pointers of vk::FramebufferCreateInfo
-  struct FramebufferDesc
-  {
-    VkRenderPass renderPass;
-    ezSizeU32 m_size = {0, 0};
-    uint32_t layers = 1;
-    ezHybridArray<vk::ImageView, EZ_GAL_MAX_RENDERTARGET_COUNT + 1> attachments;
-    ezEnum<ezGALMSAASampleCount> m_msaa;
-  };
 
-  /// \brief Hashable version without pointers or redundant data of vk::AttachmentDescription
-  struct AttachmentDesc
+    struct ResourceCacheHash
   {
-    EZ_DECLARE_POD_TYPE();
-    vk::Format format = vk::Format::eUndefined;
-    vk::SampleCountFlagBits samples = vk::SampleCountFlagBits::e1;
-    // Not set at all right now
-    vk::ImageUsageFlags usage = vk::ImageUsageFlagBits::eSampled;
-    // Not set at all right now
-    vk::ImageLayout initialLayout = vk::ImageLayout::eUndefined;
-    // No support for eDontCare in EZ right now
-    vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear;
-    vk::AttachmentStoreOp storeOp = vk::AttachmentStoreOp::eStore;
-    vk::AttachmentLoadOp stencilLoadOp = vk::AttachmentLoadOp::eClear;
-    vk::AttachmentStoreOp stencilStoreOp = vk::AttachmentStoreOp::eStore;
-  };
-
-  /// \brief Hashable version without pointers of vk::RenderPassCreateInfo
-  struct RenderPassDesc
-  {
-    ezHybridArray<AttachmentDesc, EZ_GAL_MAX_RENDERTARGET_COUNT> attachments;
-  };
-
-  struct ResourceCacheHash
-  {
-    static ezUInt32 Hash(const RenderPassDesc& renderingSetup);
-    static bool Equal(const RenderPassDesc& a, const RenderPassDesc& b);
-
-    static ezUInt32 Hash(const ezGALRenderingSetup& renderingSetup);
-    static bool Equal(const ezGALRenderingSetup& a, const ezGALRenderingSetup& b);
+    static ezUInt32 Hash(const ezGALRenderPassDescriptor& renderingSetup);
+    static bool Equal(const ezGALRenderPassDescriptor& a, const ezGALRenderPassDescriptor& b);
 
     static ezUInt32 Hash(const FramebufferKey& renderTargetSetup);
     static bool Equal(const FramebufferKey& a, const FramebufferKey& b);
@@ -139,19 +103,6 @@ private:
     static bool Equal(const ezGALShaderVulkan::DescriptorSetLayoutDesc& a, const ezGALShaderVulkan::DescriptorSetLayoutDesc& b);
   };
 
-  struct FrameBufferCache
-  {
-    vk::Framebuffer m_frameBuffer;
-    ezSizeU32 m_size;
-    ezEnum<ezGALMSAASampleCount> m_msaa;
-    ezUInt32 m_layers = 0;
-    EZ_DECLARE_POD_TYPE();
-  };
-
-  static vk::RenderPass RequestRenderPassInternal(const RenderPassDesc& desc);
-  static void GetRenderPassDesc(const ezGALRenderingSetup& renderingSetup, RenderPassDesc& out_desc);
-  static void GetFrameBufferDesc(vk::RenderPass renderPass, const ezGALRenderTargetSetup& renderTargetSetup, FramebufferDesc& out_desc);
-
 public:
   using GraphicsPipelineMap = ezMap<ezResourceCacheVulkan::GraphicsPipelineDesc, vk::Pipeline, ezResourceCacheVulkan::ResourceCacheHash>;
   using ComputePipelineMap = ezMap<ezResourceCacheVulkan::ComputePipelineDesc, vk::Pipeline, ezResourceCacheVulkan::ResourceCacheHash>;
@@ -160,11 +111,8 @@ public:
 private:
   static ezGALDeviceVulkan* s_pDevice;
   static vk::Device s_device;
-  // We have a N to 1 mapping for ezGALRenderingSetup to vk::RenderPass as multiple ezGALRenderingSetup can share the same RenderPassDesc.
-  // Thus, we have a two stage resolve to the vk::RenderPass. If a ezGALRenderingSetup is not present in s_shallowRenderPasses we create the RenderPassDesc which has a 1 to 1 relationship with vk::RenderPass and look that one up in s_renderPasses. Finally we add the entry to s_shallowRenderPasses to make sure a shallow lookup will work on the next query.
-  static ezHashTable<ezGALRenderingSetup, vk::RenderPass, ResourceCacheHash> s_shallowRenderPasses; // #TODO_VULKAN cache invalidation
-  static ezHashTable<RenderPassDesc, vk::RenderPass, ResourceCacheHash> s_renderPasses;
-  static ezHashTable<FramebufferKey, FrameBufferCache, ResourceCacheHash> s_frameBuffers;           // #TODO_VULKAN cache invalidation
+  static ezHashTable<ezGALRenderPassDescriptor, vk::RenderPass, ResourceCacheHash> s_renderPasses;
+  static ezHashTable<FramebufferKey, vk::Framebuffer, ResourceCacheHash> s_frameBuffers;           // #TODO_VULKAN cache invalidation
 
   static ezHashTable<PipelineLayoutDesc, vk::PipelineLayout, ResourceCacheHash> s_pipelineLayouts;
   static GraphicsPipelineMap s_graphicsPipelines;

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -44,7 +44,7 @@ namespace
 
     return false;
   }
-}
+} // namespace
 
 ezGALCommandEncoderImplVulkan::ezGALCommandEncoderImplVulkan(ezGALDeviceVulkan& device)
   : m_GALDeviceVulkan(device)

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -25,6 +25,27 @@
 
 #include <Foundation/Profiling/Profiling.h>
 
+namespace
+{
+  bool UsesClearOp(const ezGALRenderingSetup& renderingSetup)
+  {
+    if (renderingSetup.HasDepthStencilTarget())
+    {
+      if (renderingSetup.GetRenderPass().m_DepthLoadOp == ezGALRenderTargetLoadOp::Clear || renderingSetup.GetRenderPass().m_StencilLoadOp == ezGALRenderTargetLoadOp::Clear)
+        return true;
+    }
+
+    const ezUInt32 uiRTs = renderingSetup.GetRenderPass().m_uiRTCount;
+    for (ezUInt32 i = 0; i < uiRTs; ++i)
+    {
+      if (renderingSetup.GetRenderPass().m_ColorLoadOp[i] == ezGALRenderTargetLoadOp::Clear)
+        return true;
+    }
+
+    return false;
+  }
+}
+
 ezGALCommandEncoderImplVulkan::ezGALCommandEncoderImplVulkan(ezGALDeviceVulkan& device)
   : m_GALDeviceVulkan(device)
 {
@@ -50,7 +71,7 @@ void ezGALCommandEncoderImplVulkan::Reset()
   m_BoundVertexBuffersRange.Reset();
 
   m_LayoutDesc = {};
-  m_PipelineDesc = {};
+  m_PipelineDesc = ezResourceCacheVulkan::GraphicsPipelineDesc();
   m_frameBuffer = nullptr;
 
   m_viewport = vk::Viewport();
@@ -751,7 +772,7 @@ void ezGALCommandEncoderImplVulkan::PushMarkerPlatform(const char* szMarker)
 {
   if (m_GALDeviceVulkan.GetExtensions().m_bDebugUtilsMarkers)
   {
-    constexpr float markerColor[4] = {1, 1, 1, 1};
+    constexpr float markerColor[4] = {0, 0, 0, 0};
     vk::DebugUtilsLabelEXT markerInfo = {};
     ezMemoryUtils::Copy(markerInfo.color.data(), markerColor, EZ_ARRAY_SIZE(markerColor));
     markerInfo.pLabelName = szMarker;
@@ -789,11 +810,11 @@ void ezGALCommandEncoderImplVulkan::BeginRenderingPlatform(const ezGALRenderingS
   // We have to ensure we have enough queries before entering the render pass as we can't replenish pools while within.
   m_GALDeviceVulkan.GetQueryPool().EnsureFreeQueryPoolSize(*m_pCommandBuffer);
 
-  m_PipelineDesc.m_renderPass = ezResourceCacheVulkan::RequestRenderPass(renderingSetup);
-  m_PipelineDesc.m_uiAttachmentCount = renderingSetup.m_RenderTargetSetup.GetRenderTargetCount();
-  ezSizeU32 size;
-  m_frameBuffer = ezResourceCacheVulkan::RequestFrameBuffer(m_PipelineDesc.m_renderPass, renderingSetup.m_RenderTargetSetup, size, m_PipelineDesc.m_msaa, m_uiLayers);
-
+  m_PipelineDesc.m_renderPassDesc = renderingSetup.GetRenderPass();
+  m_PipelineDesc.m_renderPass = ezResourceCacheVulkan::RequestRenderPass(renderingSetup.GetRenderPass());
+  m_frameBuffer = ezResourceCacheVulkan::RequestFrameBuffer(m_PipelineDesc.m_renderPass, renderingSetup.GetFrameBuffer());
+  m_uiLayers = renderingSetup.GetFrameBuffer().m_uiSliceCount;
+  ezSizeU32 size = renderingSetup.GetFrameBuffer().m_Size;
   SetScissorRectPlatform(ezRectU32(size.width, size.height));
 
   {
@@ -804,26 +825,26 @@ void ezGALCommandEncoderImplVulkan::BeginRenderingPlatform(const ezGALRenderingS
 
     m_clearValues.Clear();
 
-    const bool m_bHasDepth = !renderingSetup.m_RenderTargetSetup.GetDepthStencilTarget().IsInvalidated();
-    const ezUInt32 uiColorCount = renderingSetup.m_RenderTargetSetup.GetRenderTargetCount();
-    m_bClearSubmitted = !(renderingSetup.m_bClearDepth || renderingSetup.m_bClearStencil || renderingSetup.m_uiRenderTargetClearMask);
+    const bool m_bHasDepth = renderingSetup.HasDepthStencilTarget();
+    const ezUInt32 uiColorCount = renderingSetup.GetColorTargetCount();
+    m_bClearSubmitted = !UsesClearOp(renderingSetup);
 
     if (m_bHasDepth)
     {
       vk::ClearValue& depthClear = m_clearValues.ExpandAndGetRef();
-      depthClear.depthStencil.setDepth(1.0f).setStencil(0);
+      depthClear.depthStencil.setDepth(renderingSetup.GetClearDepth()).setStencil(renderingSetup.GetClearStencil());
 
-      const ezGALRenderTargetViewVulkan* pRenderTargetView = static_cast<const ezGALRenderTargetViewVulkan*>(m_GALDeviceVulkan.GetRenderTargetView(renderingSetup.m_RenderTargetSetup.GetDepthStencilTarget()));
+      const ezGALRenderTargetViewVulkan* pRenderTargetView = static_cast<const ezGALRenderTargetViewVulkan*>(m_GALDeviceVulkan.GetRenderTargetView(renderingSetup.GetFrameBuffer().m_hDepthTarget));
       m_depthMask = pRenderTargetView->GetRange().aspectMask;
       m_pPipelineBarrier->EnsureImageLayout(pRenderTargetView, vk::ImageLayout::eDepthStencilAttachmentOptimal, vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests, vk::AccessFlagBits::eDepthStencilAttachmentWrite | vk::AccessFlagBits::eDepthStencilAttachmentRead);
     }
     for (ezUInt32 i = 0; i < uiColorCount; i++)
     {
       vk::ClearValue& colorClear = m_clearValues.ExpandAndGetRef();
-      ezColor col = renderingSetup.m_ClearColor;
+      ezColor col = renderingSetup.GetClearColor(i);
       colorClear.color.setFloat32({col.r, col.g, col.b, col.a});
 
-      const ezGALRenderTargetViewVulkan* pRenderTargetView = static_cast<const ezGALRenderTargetViewVulkan*>(m_GALDeviceVulkan.GetRenderTargetView(renderingSetup.m_RenderTargetSetup.GetRenderTarget(i)));
+      const ezGALRenderTargetViewVulkan* pRenderTargetView = static_cast<const ezGALRenderTargetViewVulkan*>(m_GALDeviceVulkan.GetRenderTargetView(renderingSetup.GetFrameBuffer().m_hColorTarget[i]));
       m_pPipelineBarrier->EnsureImageLayout(pRenderTargetView, vk::ImageLayout::eColorAttachmentOptimal, vk::PipelineStageFlagBits::eColorAttachmentOutput, vk::AccessFlagBits::eColorAttachmentWrite | vk::AccessFlagBits::eColorAttachmentRead);
     }
 
@@ -854,7 +875,7 @@ void ezGALCommandEncoderImplVulkan::EndRenderingPlatform()
 
   m_depthMask = {};
   m_uiLayers = 0;
-  m_PipelineDesc.m_msaa = ezGALMSAASampleCount::None;
+  m_PipelineDesc.m_renderPassDesc = ezGALRenderPassDescriptor();
   m_PipelineDesc.m_renderPass = nullptr;
   m_frameBuffer = nullptr;
 }
@@ -880,7 +901,7 @@ void ezGALCommandEncoderImplVulkan::ClearPlatform(const ezColor& ClearColor, ezU
   {
     for (ezUInt32 i = 0; i < EZ_GAL_MAX_RENDERTARGET_COUNT; i++)
     {
-      if (uiRenderTargetClearMask & (1u << i) && i < m_PipelineDesc.m_uiAttachmentCount)
+      if (uiRenderTargetClearMask & (1u << i) && i < m_PipelineDesc.m_renderPassDesc.m_uiRTCount)
       {
         vk::ClearAttachment& attachment = attachments.ExpandAndGetRef();
         attachment.aspectMask = vk::ImageAspectFlagBits::eColor;

--- a/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/InitContext.cpp
@@ -45,6 +45,10 @@ vk::CommandBuffer ezInitContextVulkan::GetFinishedCommandBuffer()
   {
     m_pStagingBufferPool->BeforeCommandBufferSubmit();
     m_pPipelineBarrier->Submit();
+    if (m_pDevice->GetExtensions().m_bDebugUtilsMarkers)
+    {
+      m_currentCommandBuffer.endDebugUtilsLabelEXT();
+    }
     vk::CommandBuffer res = m_currentCommandBuffer;
     res.end();
 
@@ -63,6 +67,15 @@ void ezInitContextVulkan::EnsureCommandBufferExists()
     vk::CommandBufferBeginInfo beginInfo;
     m_currentCommandBuffer.begin(&beginInfo);
     m_pPipelineBarrier->SetCommandBuffer(&m_currentCommandBuffer);
+    if (m_pDevice->GetExtensions().m_bDebugUtilsMarkers)
+    {
+      constexpr float markerColor[4] = {0, 0, 0, 0};
+      vk::DebugUtilsLabelEXT markerInfo = {};
+      ezMemoryUtils::Copy(markerInfo.color.data(), markerColor, EZ_ARRAY_SIZE(markerColor));
+      markerInfo.pLabelName = "InitContext";
+
+      m_currentCommandBuffer.beginDebugUtilsLabelEXT(markerInfo);
+    }
   }
 }
 

--- a/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ConversionUtilsVulkan.h
@@ -27,6 +27,8 @@ public:
     return static_cast<typename T::MaskType>(value);
   }
 
+  static vk::AttachmentLoadOp GetAttachmentLoadOp(ezEnum<ezGALRenderTargetLoadOp> op);
+  static vk::AttachmentStoreOp GetAttachmentStoreOp(ezEnum<ezGALRenderTargetStoreOp> op);
   static vk::VertexInputRate GetVertexBindingRate(ezEnum<ezGALVertexBindingRate> rate);
   static vk::SampleCountFlagBits GetSamples(ezEnum<ezGALMSAASampleCount> samples);
   static vk::PresentModeKHR GetPresentMode(ezEnum<ezGALPresentMode> presentMode, const ezDynamicArray<vk::PresentModeKHR>& supportedModes);

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -29,19 +29,11 @@ public:
   static void Initialize(ezGALDeviceVulkan& GALDeviceVulkan);
   static void DeInitialize(ezGALDeviceVulkan& GALDeviceVulkan);
 
-  struct RenderPassCacheKey
-  {
-    EZ_DECLARE_POD_TYPE();
-
-    vk::Format targetFormat;
-    vk::SampleCountFlagBits targetSamples;
-  };
-
   struct FramebufferCacheKey
   {
     EZ_DECLARE_POD_TYPE();
 
-    vk::RenderPass m_renderpass;
+    vk::RenderPass m_renderPass;
     vk::ImageView m_targetView;
     ezVec3U32 m_extends;
     uint32_t m_layerCount;
@@ -93,7 +85,6 @@ private:
     ~Cache();
 
     ezHashTable<ezGALShaderHandle, ezGALVertexDeclarationHandle> m_vertexDeclarations;
-    ezHashTable<RenderPassCacheKey, vk::RenderPass> m_renderPasses;
     ezHashTable<ImageViewCacheKey, vk::ImageView> m_sourceImageViews;
     ezHashTable<vk::Image, ImageViewCacheValue> m_imageToSourceImageViewCacheKey;
     ezHashTable<ImageViewCacheKey, vk::ImageView> m_targetImageViews;

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
@@ -1,6 +1,36 @@
 #include <RendererFoundation/Resources/ResourceFormats.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 
+EZ_ALWAYS_INLINE vk::AttachmentLoadOp ezConversionUtilsVulkan::GetAttachmentLoadOp(ezEnum<ezGALRenderTargetLoadOp> op)
+{
+  switch (op)
+  {
+    case ezGALRenderTargetLoadOp::Load:
+      return vk::AttachmentLoadOp::eLoad;
+    case ezGALRenderTargetLoadOp::Clear:
+      return vk::AttachmentLoadOp::eClear;
+    case ezGALRenderTargetLoadOp::DontCare:
+      return vk::AttachmentLoadOp::eDontCare;
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+      return vk::AttachmentLoadOp::eLoad;
+  }
+}
+
+EZ_ALWAYS_INLINE vk::AttachmentStoreOp ezConversionUtilsVulkan::GetAttachmentStoreOp(ezEnum<ezGALRenderTargetStoreOp> op)
+{
+  switch (op)
+  {
+    case ezGALRenderTargetStoreOp::Store:
+      return vk::AttachmentStoreOp::eStore;
+    case ezGALRenderTargetStoreOp::Discard:
+      return vk::AttachmentStoreOp::eDontCare;
+    default:
+      EZ_ASSERT_NOT_IMPLEMENTED;
+      return vk::AttachmentStoreOp::eStore;
+  }
+}
+
 EZ_ALWAYS_INLINE vk::VertexInputRate ezConversionUtilsVulkan::GetVertexBindingRate(ezEnum<ezGALVertexBindingRate> rate)
 {
   switch (rate)

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RenderInterface.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RenderInterface.cpp
@@ -401,11 +401,6 @@ namespace ezRmlUiInternal
     const ezGALResourceFormat::Enum tempStencilFormat = ezGALResourceFormat::D24S8;
     const ezGALMSAASampleCount::Enum msaaSampleCount = ezGALMSAASampleCount::FourSamples;
 
-    ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_uiRenderTargetClearMask = 0x1;
-    renderingSetup.m_bClearStencil = true;
-    renderingSetup.m_bDiscardDepth = true;
-
     pRenderContext->BindShader(m_hShader);
     pRenderContext->BindConstantBuffer("ezRmlUiConstants", m_hConstantBuffer);
 
@@ -421,8 +416,12 @@ namespace ezRmlUiInternal
 
       ezGALTextureHandle hTempTarget = pGpuResourcePool->GetRenderTarget(textureDesc.m_uiWidth, textureDesc.m_uiHeight, tempTargetFormat, msaaSampleCount);
       ezGALTextureHandle hTempStencil = pGpuResourcePool->GetRenderTarget(textureDesc.m_uiWidth, textureDesc.m_uiHeight, tempStencilFormat, msaaSampleCount);
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, pDevice->GetDefaultRenderTargetView(hTempTarget));
-      renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(hTempStencil));
+
+      ezGALRenderingSetup renderingSetup;
+      renderingSetup.SetColorTarget(0, pDevice->GetDefaultRenderTargetView(hTempTarget));
+      renderingSetup.SetClearColor(0);
+      renderingSetup.SetDepthStencilTarget(pDevice->GetDefaultRenderTargetView(hTempStencil), ezGALRenderTargetLoadOp::DontCare, ezGALRenderTargetStoreOp::Discard);
+      renderingSetup.SetClearStencil().SetClearDepth();
 
       pRenderContext->BeginRendering(renderingSetup, viewport, pCommandBuffer->m_sName, false);
       pRenderContext->SetShaderPermutationVariable("RMLUI_MODE", "RMLUI_MODE_NORMAL");

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
@@ -72,7 +72,7 @@ void ezComputeShaderHistogramApp::Run()
     // Draw background.
     {
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_hScreenRTV);
+      renderingSetup.SetColorTarget(0, m_hScreenRTV);
       renderContext.BeginRendering(renderingSetup, viewport, "Background");
 
       renderContext.BindShader(m_hScreenShader);
@@ -90,7 +90,7 @@ void ezComputeShaderHistogramApp::Run()
     // Switch to backbuffer (so that the screen texture is no longer bound)
     {
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, hBackbufferRTV);
+      renderingSetup.SetColorTarget(0, hBackbufferRTV);
       renderContext.BeginRendering(renderingSetup, viewport, "Dummy");
       renderContext.EndRendering();
     }
@@ -113,7 +113,7 @@ void ezComputeShaderHistogramApp::Run()
     // Draw histogram.
     {
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, hBackbufferRTV);
+      renderingSetup.SetColorTarget(0, hBackbufferRTV);
       renderContext.BeginRendering(renderingSetup, viewport, "DrawHistogram");
 
       renderContext.BindShader(m_hHistogramDisplayShader);

--- a/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
+++ b/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
@@ -176,9 +176,8 @@ public:
       m_hBBDSV = m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture);
 
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
-      renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-      renderingSetup.m_bClearDepth = true;
+      renderingSetup.SetColorTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
+      renderingSetup.SetClearColor(0).SetClearDepth();
 
       ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, ezRectFloat(0.0f, 0.0f, (float)g_uiWindowWidth, (float)g_uiWindowHeight));
 

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -177,10 +177,8 @@ void ezShaderExplorerApp::Run()
     ezGALRenderTargetViewHandle hBBDSV = m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture);
 
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, hBBRTV).SetDepthStencilTarget(hBBDSV);
-    renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-    renderingSetup.m_bClearDepth = true;
-    renderingSetup.m_bClearStencil = true;
+    renderingSetup.SetColorTarget(0, hBBRTV).SetDepthStencilTarget(hBBDSV);
+    renderingSetup.SetClearColor(0).SetClearDepth().SetClearStencil();
 
     ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, ezRectFloat(0.0f, 0.0f, (float)g_uiWindowWidth, (float)g_uiWindowHeight));
 

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -293,9 +293,8 @@ public:
       ezGALCommandEncoder* pCommandEncoder = m_pDevice->BeginCommands("ezTextureSampleMainPass");
 
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
-      renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
-      renderingSetup.m_bClearDepth = true;
+      renderingSetup.SetColorTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
+      renderingSetup.SetClearColor(0).SetClearDepth();
 
       ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, ezRectFloat(0.0f, 0.0f, (float)g_uiWindowWidth, (float)g_uiWindowHeight));
 

--- a/Code/UnitTests/FoundationTest/Algorithm/HashingTest.cpp
+++ b/Code/UnitTests/FoundationTest/Algorithm/HashingTest.cpp
@@ -351,4 +351,32 @@ EZ_CREATE_SIMPLE_TEST(Algorithm, HashableStruct)
   uiAutomaticHash = AutomaticInst.CalculateHash();
 
   EZ_TEST_BOOL(uiAutomaticHash != uiNonAutomaticHash);
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Compare")
+  {
+    SimpleHashableStruct LeftSide;
+    LeftSide.m_uiTestMember1 = 1;
+    LeftSide.m_uiTestMember2 = 2;
+    LeftSide.m_uiTestMember3 = 3;
+    SimpleHashableStruct RightSide = LeftSide;
+    EZ_TEST_BOOL(LeftSide == RightSide);
+    EZ_TEST_BOOL(!(LeftSide != RightSide));
+    EZ_TEST_BOOL(!(LeftSide < RightSide));
+    EZ_TEST_BOOL(!(RightSide < LeftSide));
+    EZ_TEST_BOOL(LeftSide.CalculateHash() == RightSide.CalculateHash());
+
+    LeftSide.m_uiTestMember3 = 2;
+    EZ_TEST_BOOL(!(LeftSide == RightSide));
+    EZ_TEST_BOOL(LeftSide != RightSide);
+    EZ_TEST_BOOL(LeftSide < RightSide);
+    EZ_TEST_BOOL(!(RightSide < LeftSide));
+    EZ_TEST_BOOL(LeftSide.CalculateHash() != RightSide.CalculateHash());
+
+    RightSide.m_uiTestMember1 = 0;
+    EZ_TEST_BOOL(!(LeftSide == RightSide));
+    EZ_TEST_BOOL(LeftSide != RightSide);
+    EZ_TEST_BOOL(!(LeftSide < RightSide));
+    EZ_TEST_BOOL(RightSide < LeftSide);
+    EZ_TEST_BOOL(LeftSide.CalculateHash() != RightSide.CalculateHash());
+  }
 }

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -512,9 +512,8 @@ void ezRendererTestAdvancedFeatures::ReadRenderTarget()
   BeginCommands("Offscreen");
   {
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hTexture2D));
-    renderingSetup.m_ClearColor = ezColor::RebeccaPurple;
-    renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
+    renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hTexture2D));
+    renderingSetup.SetClearColor(0, ezColor::RebeccaPurple);
 
     ezRectFloat viewport = ezRectFloat(0, 0, 8, 8);
     ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, viewport);
@@ -557,9 +556,8 @@ void ezRendererTestAdvancedFeatures::FloatSampling()
   BeginCommands("Offscreen");
   {
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_bDiscardDepth = true;
-    renderingSetup.m_bClearDepth = true;
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hTexture2DArray));
+    renderingSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hTexture2DArray));
+    renderingSetup.SetClearDepth();
 
     ezRectFloat viewport = ezRectFloat(0, 0, 8, 8);
     ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, viewport);
@@ -609,9 +607,8 @@ void ezRendererTestAdvancedFeatures::ProxyTexture()
   for (ezUInt32 i = 0; i < 2; i++)
   {
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hProxyTexture2D[i]));
-    renderingSetup.m_ClearColor = ezColor::RebeccaPurple;
-    renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
+    renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hProxyTexture2D[i]));
+    renderingSetup.SetClearColor(0, ezColor::RebeccaPurple);
 
     ezRectFloat viewport = ezRectFloat(0, 0, 8, 8);
     ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, viewport);
@@ -656,9 +653,8 @@ void ezRendererTestAdvancedFeatures::VertexShaderRenderTargetArrayIndex()
   BeginCommands("Offscreen Stereo");
   {
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hTexture2DArray));
-    renderingSetup.m_ClearColor = ezColor::RebeccaPurple;
-    renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
+    renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hTexture2DArray));
+    renderingSetup.SetClearColor(0, ezColor::RebeccaPurple);
 
     ezRectFloat viewport = ezRectFloat(0, 0, m_pWindow->GetClientAreaSize().width / 2.0f, (float)m_pWindow->GetClientAreaSize().height);
     ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, viewport);

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -100,9 +100,8 @@ void ezOffscreenRendererTest::Run()
 
     ezGALRenderingSetup renderingSetup;
     ezGALRenderTargetViewHandle hBackbufferRTV = device->GetDefaultRenderTargetView(pSwapChain->GetRenderTargets().m_hRTs[0]);
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, hBackbufferRTV);
-    renderingSetup.m_ClearColor = ezColor::Pink;
-    renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
+    renderingSetup.SetColorTarget(0, hBackbufferRTV);
+    renderingSetup.SetClearColor(0, ezColor::Pink);
 
     ezRectFloat viewport = ezRectFloat(0, 0, 8, 8);
     ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, viewport);

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -205,14 +205,14 @@ ezTestAppRun ezRendererTestReadback::Readback(ezUInt32 uiInvocationCount)
       ezShaderResourceHandle shader;
       if (bIsDepthTexture)
       {
-        renderingSetup.m_bDiscardDepth = true;
-        renderingSetup.m_bClearDepth = true;
-        renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hTexture2DReadback));
+        renderingSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hTexture2DReadback));
+        renderingSetup.SetClearDepth().SetClearStencil();
         shader = m_hUVColorDepthShader;
       }
       else
       {
-        renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hTexture2DReadback));
+        renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(m_hTexture2DReadback));
+        renderingSetup.SetClearColor(0, ezColor::RebeccaPurple);
         if (bIsIntTexture)
         {
           shader = bIsSigned ? m_hUVColorIntShader : m_hUVColorUIntShader;
@@ -222,8 +222,6 @@ ezTestAppRun ezRendererTestReadback::Readback(ezUInt32 uiInvocationCount)
           shader = m_hUVColorShader;
         }
       }
-      renderingSetup.m_ClearColor = ezColor::RebeccaPurple;
-      renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
 
       ezRectFloat viewport = ezRectFloat(0, 0, 8, 8);
       ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, viewport);

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
@@ -110,14 +110,12 @@ ezTestAppRun ezRendererTestSwapChain::BasicRenderLoop(ezInt32 iIdentifier, ezUIn
     const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);
 
     ezGALRenderingSetup renderingSetup;
-    renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture()));
-    renderingSetup.m_ClearColor = ezColor::CornflowerBlue;
-    renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
+    renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture()));
+    renderingSetup.SetClearColor(0, ezColor::CornflowerBlue);
     if (!m_hDepthStencilTexture.IsInvalidated())
     {
-      renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture));
-      renderingSetup.m_bClearDepth = true;
-      renderingSetup.m_bClearStencil = true;
+      renderingSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture));
+      renderingSetup.SetClearDepth().SetClearStencil();
     }
     ezRectFloat viewport = ezRectFloat(0.0f, 0.0f, (float)m_pWindow->GetClientAreaSize().width, (float)m_pWindow->GetClientAreaSize().height);
 

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -310,14 +310,15 @@ ezGALCommandEncoder* ezGraphicsTest::BeginRendering(ezColor clearColor, ezUInt32
   const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);
 
   ezGALRenderingSetup renderingSetup;
-  renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture()));
-  renderingSetup.m_ClearColor = clearColor;
-  renderingSetup.m_uiRenderTargetClearMask = uiRenderTargetClearMask;
+  renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture()));
+  if (uiRenderTargetClearMask & EZ_BIT(0))
+  {
+    renderingSetup.SetClearColor(0, clearColor);
+  }
   if (!m_hDepthStencilTexture.IsInvalidated())
   {
-    renderingSetup.m_RenderTargetSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture));
-    renderingSetup.m_bClearDepth = true;
-    renderingSetup.m_bClearStencil = true;
+    renderingSetup.SetDepthStencilTarget(m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture));
+    renderingSetup.SetClearDepth().SetClearStencil();
   }
   ezRectFloat viewport = ezRectFloat(0.0f, 0.0f, (float)m_pWindow->GetClientAreaSize().width, (float)m_pWindow->GetClientAreaSize().height);
   if (pViewport)


### PR DESCRIPTION
## ezGALRenderingSetup
* `ezGALRenderTargetSetup` has been merged into `ezGALRenderingSetup`.
* `ezGALRenderingSetup` is now very strict to prevent creating invalid render target configs: `SetColorTarget` must be called starting at index 0 before you can call it with index 1 and so fourth.
* `SetColorTarget` and `SetDepthStencilTarget` now support extended render target load / store behaviour using `ezGALRenderTargetLoadOp` and `ezGALRenderTargetStoreOp`.
* Each color render target can have its own clear color now.
* To call any of the `SetClearColor`, `SetClearDepth` or `SetClearStencil` functions, you first must have called the corresponding `SetColorTarget` or `SetDepthStencilTarget` functions.
* All clear methods have reasonable default values (color: black, depth: 1.0, stencil: 0).
* `SetColorTarget` and `SetDepthStencilTarget` can be called multiple times as long as the format of the view remains identical to the previously assigned one. Thus, while not very expensive, it is still a good idea to cache these objects and only swap out the textures when they are not fixed, e.g. when using the `ezGPUResourcePool`.
* The class produces a `ezGALRenderPassDescriptor` and a `ezGALFrameBufferDescriptor` that can be retrieved via `GetRenderPass` and `GetFrameBuffer` respectively. These are used by the renderer to build render passes, frame buffers and compatible graphics pipeline state objects.

## BREAKING CHANGES

The required code changes should be mostly self-explanatory. An example of the old interface:
```cpp
renderingSetup.m_uiRenderTargetClearMask = 0xFFFFFFFF;
renderingSetup.m_bClearDepth = true;
renderingSetup.m_RenderTargetSetup.SetRenderTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
```
The same code using the new interface. Notice that the clear values have to be moved after setting up the corresponding render target.
```cpp
renderingSetup.SetColorTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
renderingSetup.SetClearColor(0).SetClearDepth();
```

## Misc
* `ezHashableStruct` now has equal, not equal and less operators.
* Added format support for `ezSizeU32`.
* Added `ezGALTexture::GetMipMapSize` for convenience.
* Changed Vulkan debug utils marker color to black because I like the dark theme in RenderDoc.
* Added **InitContext** debug utils marker scope to each frame's `ezInitContextVulkan` workload.