### PR TITLE
Added support for custom value types to Angel Script arrays

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -251,6 +251,20 @@ ezTransformStatus ezScene2Document::InternalTransformAsset(const char* szTargetF
   return SUPER::InternalTransformAsset(szTargetFile, sOutputTag, pAssetProfile, assetHeader, transformFlags);
 }
 
+void ezScene2Document::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
+{
+  EZ_ASSERT_DEBUG(GetActiveLayer() == m_pDocumentInfo->m_DocumentID, "Ensure that the active layer is the scene itself before calling this function");
+  SUPER::UpdateAssetDocumentInfo(pInfo);
+
+  // Add layers as dependencies
+  ezStringBuilder sTemp;
+  for (auto it = m_Layers.GetIterator(); it.IsValid(); ++it)
+  {
+    if (it.Key() != this->GetDocumentInfo()->m_DocumentID)
+      pInfo->m_TransformDependencies.Insert(ezConversionUtils::ToString(it.Key(), sTemp));
+  }
+}
+
 void ezScene2Document::PreventDoubleSelectionChange(bool b)
 {
   m_iAllowSelectionChanges = b ? 1 : -1;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
@@ -122,6 +122,7 @@ public:
   virtual void SendGameWorldToEngine() override;
   virtual ezTransformStatus InternalTransformAsset(const char* szTargetFile, ezStringView sOutputTag, const ezPlatformProfile* pAssetProfile,
     const ezAssetFileHeader& assetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
+  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 
   ///@}
   /// \name Selection Specific Functions

--- a/Code/ThirdParty/AngelScript/source/add_on/scriptarray/scriptarray.cpp
+++ b/Code/ThirdParty/AngelScript/source/add_on/scriptarray/scriptarray.cpp
@@ -1826,7 +1826,7 @@ void CScriptArray::Precache()
 				if( !isCmp && !isEq )
 					continue;
 
-				// The parameter must either be a reference to the subtype or a handle to the subtype
+				// The parameter must either be a reference to the subtype, a handle to the subtype or passed by value for pod value types
 				int paramTypeId;
 				func->GetParam(0, &paramTypeId, &flags);
 
@@ -1842,6 +1842,10 @@ void CScriptArray::Precache()
 				{
 					if( mustBeConst && !(paramTypeId & asTYPEID_HANDLETOCONST) )
 						continue;
+				}
+				else if( subType->GetFlags() & asOBJ_VALUE && subType->GetFlags() & asOBJ_POD )
+				{
+					// Passing pod value types by value is allowed
 				}
 				else
 					continue;

--- a/Code/UnitTests/GameEngineTest/AngelScriptTest/AngelScriptTest.cpp
+++ b/Code/UnitTests/GameEngineTest/AngelScriptTest/AngelScriptTest.cpp
@@ -28,6 +28,7 @@ void ezGameEngineTestAngelScript::SetupSubTests()
 {
   AddSubTest("Types", SubTests::Types);
   AddSubTest("Strings", SubTests::Strings);
+  AddSubTest("Arrays", SubTests::Arrays);
   AddSubTest("EntryPoints", SubTests::EntryPoints);
   AddSubTest("World", SubTests::World);
   AddSubTest("Messaging", SubTests::Messaging);
@@ -51,6 +52,9 @@ ezTestAppRun ezGameEngineTestAngelScript::RunSubTest(ezInt32 iIdentifier, ezUInt
       return ezTestAppRun::Quit;
     case SubTests::Strings:
       m_pOwnApplication->RunTestScript("Tests/Types/StringsTest.as");
+      return ezTestAppRun::Quit;
+    case SubTests::Arrays:
+      m_pOwnApplication->RunTestScript("Tests/Types/ArraysTest.as");
       return ezTestAppRun::Quit;
     default:
       return m_pOwnApplication->SubTestBasisExec(GetSubTestName(iIdentifier));

--- a/Code/UnitTests/GameEngineTest/AngelScriptTest/AngelScriptTest.h
+++ b/Code/UnitTests/GameEngineTest/AngelScriptTest/AngelScriptTest.h
@@ -32,6 +32,7 @@ public:
   {
     Types,
     Strings,
+    Arrays,
     EntryPoints,
     World,
     Messaging,

--- a/Data/UnitTests/GameEngineTest/AngelScript/Tests/Types/ArraysTest.as
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Tests/Types/ArraysTest.as
@@ -36,7 +36,45 @@ void ExecuteTests()
         EZ_TEST_BOOL(elements[0] == test);
     }
 
-    // non pod value type
+    // Bigger pod value type
+    {
+        ezVec4 test(1.0f, 2.0f, 3.0f, 4.0f);
+        ezVec4 test2(5.0f, 6.0f, 7.0f, 8.0f);
+        array<ezVec4> elements;
+
+        EZ_TEST_BOOL(elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 0);
+        EZ_TEST_BOOL(!elements.Contains(test));
+        EZ_TEST_BOOL(!elements.Contains(test2));
+        EZ_TEST_INT(elements.IndexOf(test), -1);
+        EZ_TEST_INT(elements.IndexOf(test2), -1);
+
+        elements.PushBack(test);
+        EZ_TEST_BOOL(!elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 1);
+        EZ_TEST_BOOL(elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), 0);
+        EZ_TEST_BOOL(elements[0] == test);
+        EZ_TEST_BOOL(elements[0] != test2);
+
+        elements.PushBack(test2);
+        EZ_TEST_BOOL(!elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 2);
+        EZ_TEST_BOOL(elements.Contains(test));
+        EZ_TEST_BOOL(elements.Contains(test2));
+        EZ_TEST_INT(elements.IndexOf(test), 0);
+        EZ_TEST_INT(elements.IndexOf(test2), 1);
+        EZ_TEST_BOOL(elements[0] == test);
+        EZ_TEST_BOOL(elements[1] == test2);
+        EZ_TEST_BOOL(elements[0] != test2);
+        EZ_TEST_BOOL(elements[1] != test);
+
+        elements.PushBack(ezVec4(9.0f, 10.0f, 11.0f, 12.0f));
+        EZ_TEST_BOOL(elements.Contains(ezVec4(9.0f, 10.0f, 11.0f, 12.0f)));
+        EZ_TEST_BOOL(elements[2] == ezVec4(9.0f, 10.0f, 11.0f, 12.0f));
+    }
+
+    // non-pod value type
     {
         ezString test = "Test";
         array<ezString> elements;

--- a/Data/UnitTests/GameEngineTest/AngelScript/Tests/Types/ArraysTest.as
+++ b/Data/UnitTests/GameEngineTest/AngelScript/Tests/Types/ArraysTest.as
@@ -1,0 +1,72 @@
+#include "../TestFramework.as"
+
+void ExecuteTests()
+{
+    // typedef to basic type
+    {
+        ezUInt32 test = 5;
+        array<ezUInt32> elements;
+
+        EZ_TEST_BOOL(elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 0);
+        EZ_TEST_BOOL(!elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), -1);
+        elements.PushBack(test);
+        EZ_TEST_BOOL(!elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 1);
+        EZ_TEST_BOOL(elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), 0);
+        EZ_TEST_BOOL(elements[0] == test);
+    }
+
+    // pod value type
+    {
+        ezGameObjectHandle test;
+        array<ezGameObjectHandle> elements;
+
+        EZ_TEST_BOOL(elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 0);
+        EZ_TEST_BOOL(!elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), -1);
+        elements.PushBack(test);
+        EZ_TEST_BOOL(!elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 1);
+        EZ_TEST_BOOL(elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), 0);
+        EZ_TEST_BOOL(elements[0] == test);
+    }
+
+    // non pod value type
+    {
+        ezString test = "Test";
+        array<ezString> elements;
+
+        EZ_TEST_BOOL(elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 0);
+        EZ_TEST_BOOL(!elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), -1);
+        elements.PushBack(test);
+        EZ_TEST_BOOL(!elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 1);
+        EZ_TEST_BOOL(elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), 0);
+        EZ_TEST_BOOL(elements[0] == test);
+    }
+
+    // ezStringView
+    {
+        ezStringView test = "Test";
+        array<ezStringView> elements;
+
+        EZ_TEST_BOOL(elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 0);
+        EZ_TEST_BOOL(!elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), -1);
+        elements.PushBack(test);
+        EZ_TEST_BOOL(!elements.IsEmpty());
+        EZ_TEST_BOOL(elements.GetCount() == 1);
+        EZ_TEST_BOOL(elements.Contains(test));
+        EZ_TEST_INT(elements.IndexOf(test), 0);
+        EZ_TEST_BOOL(elements[0] == test);
+    }
+}


### PR DESCRIPTION
Fixes #1538
Needed to touch angel script itself for this change: the scriptarray class did only support references or handles to the type for operators - not passing the type by value, which is quite common for operators working on value types. Also fixed that scene layers were not tracked as dependencies of scenes.