### PR TITLE
Force Loading of Highest Quality Levels during Tests

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -490,12 +490,16 @@ void ezSceneAction::LaunchPlayer(const char* szPlayerApp)
 {
   ezStringBuilder sCmd;
   QStringList arguments = GetPlayerCommandLine(sCmd);
-
   ezLog::Info("Running: {} {}", szPlayerApp, sCmd);
   m_pSceneDocument->ShowDocumentStatus(ezFmt("Running: {} {}", szPlayerApp, sCmd));
 
-  QProcess proc;
-  proc.startDetached(QString::fromUtf8(szPlayerApp), arguments);
+  ezStringBuilder sPlayerApp = szPlayerApp;
+  if (sPlayerApp.IsRelativePath())
+  {
+    sPlayerApp.Prepend("./");
+  }
+
+  QProcess::startDetached(QString::fromUtf8(sPlayerApp.GetData()), arguments, QCoreApplication::applicationDirPath());
 }
 
 QStringList ezSceneAction::GetPlayerCommandLine(ezStringBuilder& out_sSingleLine) const

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -494,11 +494,12 @@ void ezSceneAction::LaunchPlayer(const char* szPlayerApp)
   m_pSceneDocument->ShowDocumentStatus(ezFmt("Running: {} {}", szPlayerApp, sCmd));
 
   ezStringBuilder sPlayerApp = szPlayerApp;
+#if EZ_ENABLED(EZ_PLATFORM_LINUX)
   if (sPlayerApp.IsRelativePath())
   {
     sPlayerApp.Prepend("./");
   }
-
+#endif()
   QProcess::startDetached(QString::fromUtf8(sPlayerApp.GetData()), arguments, QCoreApplication::applicationDirPath());
 }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Dialogs/ExportAndRunDlg.cpp
@@ -99,7 +99,12 @@ void ezQtExportAndRunDlg::on_AddToolButton_clicked()
   appDir.MakeCleanPath();
   static QString sLastPath = appDir.GetData();
 
-  const QString sFile = QFileDialog::getOpenFileName(this, "Select Program", sLastPath, "Applicaation (*.exe)", nullptr, QFileDialog::Option::DontResolveSymlinks);
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
+  const QString sFile = QFileDialog::getOpenFileName(this, "Select Program", sLastPath, "Application (*.exe)", nullptr, QFileDialog::Option::DontResolveSymlinks);
+#else
+  const QString sFile = QFileDialog::getOpenFileName(this, "Select Program", sLastPath, "Executable (*)", nullptr, QFileDialog::Option::DontResolveSymlinks);
+#endif
+
 
   if (sFile.isEmpty())
     return;

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager.cpp
@@ -500,6 +500,11 @@ void ezResourceManager::PerFrameUpdate()
   {
     FreeUnusedResources(s_pState->m_AutoFreeUnusedTimeout, s_pState->m_AutoFreeUnusedThreshold);
   }
+
+  if (s_pState->m_uiForceNoFallbackAcquisition > 0)
+  {
+    s_pState->m_uiForceNoFallbackAcquisition--;
+  }
 }
 
 const ezEvent<const ezResourceEvent&, ezMutex>& ezResourceManager::GetResourceEvents()

--- a/Code/Engine/Core/ResourceManager/Implementation/ResourceManager_inl.h
+++ b/Code/Engine/Core/ResourceManager/Implementation/ResourceManager_inl.h
@@ -207,7 +207,16 @@ ResourceType* ezResourceManager::BeginAcquireResource(const ezTypedResourceHandl
       // accessing IsQueuedForLoading without a lock here is save because InternalPreloadResource() will lock and early out if necessary
       // and accidentally skipping InternalPreloadResource() is no problem
       if (IsQueuedForLoading(pResource) == false && pResource->GetNumQualityLevelsLoadable() > 0)
+      {
         InternalPreloadResource(pResource, false);
+
+        if (GetForceNoFallbackAcquisition() > 0)
+        {
+          EnsureResourceCondition(pResource, [=]() -> bool
+            { return ((ezInt32)pResource->GetLoadingState() >= (ezInt32)ezResourceState::Loaded && pResource->GetNumQualityLevelsLoadable() == 0) ||
+                     (pResource->GetLoadingState() == ezResourceState::LoadedResourceMissing); });
+        }
+      }
     }
   }
 

--- a/Code/Engine/Core/ResourceManager/ResourceManager.h
+++ b/Code/Engine/Core/ResourceManager/ResourceManager.h
@@ -458,6 +458,7 @@ private:
     EZ_ALWAYS_INLINE bool operator<(const LoadingInfo& rhs) const { return m_fPriority < rhs.m_fPriority; }
   };
   static void EnsureResourceLoadingState(ezResource* pResource, const ezResourceState RequestedState);
+  static void EnsureResourceCondition(ezResource* pResource, const ezDelegate<bool()>& condition);
   static void PreloadResource(ezResource* pResource);
   static void InternalPreloadResource(ezResource* pResource, bool bHighestPriority);
 

--- a/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
+++ b/Code/UnitTests/CoreTest/ResourceManager/ResourceManagerTest.cpp
@@ -323,6 +323,11 @@ EZ_CREATE_SIMPLE_TEST(ResourceManager, NestedLoading)
 
     hResources.Clear();
 
+    while (ezResourceManager::IsAnyLoadingInProgress())
+    {
+      ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+    }
+
     ezResourceManager::FreeAllUnusedResources();
     EZ_TEST_INT(ezResourceManager::GetAllResourcesOfType<TestResource>()->GetCount(), 0);
   }


### PR DESCRIPTION
Decal tests are failing spuriously due to some mipmaps not being loaded yet.
* Added `EnsureResourceCondition` which is a generalized version of `EnsureResourceLoadingState`.
* If `GetForceNoFallbackAcquisition` is > 0, wait for higher quality levels to load during resource acquisition. Should be the same logic as for the first quality level just with the added check `pResource->GetNumQualityLevelsLoadable() == 0`.
* `m_uiForceNoFallbackAcquisition` is now actually counted down during the frame tick. Previously, this state persisted indefinitely.
* Random change: Fixed starting the ezPlayer under Linux and the alternative player executable browser dialog.