### PR TITLE
Transform scenes only during "Transform All"

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
@@ -140,7 +140,7 @@ void ezAssetAction::Execute(const ezVariant& value)
     case ezAssetAction::ButtonType::TransformAllAssets:
     {
       ezAssetCurator::GetSingleton()->CheckFileSystem();
-      ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::None).IgnoreResult();
+      ezAssetCurator::GetSingleton()->TransformAllAssets().IgnoreResult();
     }
     break;
 

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -220,7 +220,10 @@ public:
   void StoreFullTransformDate();
 
   /// \brief Transforms all assets and writes the lookup tables. If the given platform is empty, the active platform is used.
-  ezStatus TransformAllAssets(ezBitflags<ezTransformFlags> transformFlags, const ezPlatformProfile* pAssetProfile = nullptr);
+  ///
+  /// Pass ezTransformFlags::TriggeredManually to make sure that all assets get transformed,
+  /// even the ones that should not be transformed by background processors (mainly scenes).
+  ezStatus TransformAllAssets(ezBitflags<ezTransformFlags> transformFlags = ezTransformFlags::TriggeredManually, const ezPlatformProfile* pAssetProfile = nullptr);
   ezTransformStatus TransformAsset(const ezUuid& assetGuid, ezBitflags<ezTransformFlags> transformFlags, const ezPlatformProfile* pAssetProfile = nullptr);
   ezTransformStatus CreateThumbnail(const ezUuid& assetGuid);
 

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -50,6 +50,8 @@ struct ezAssetDocumentFlags
     StorageType OnlyTransformManually : 1;
     StorageType SupportsThumbnail : 1;
     StorageType AutoThumbnailOnTransform : 1;
+    StorageType SubAssetsSupportThumbnail : 1;
+    StorageType SubAssetsAutoThumbnailOnTransform : 1;
   };
 };
 

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -73,7 +73,7 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
 
   if (TransformAll->isChecked())
   {
-    ezStatus stat = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually);
+    ezStatus stat = ezAssetCurator::GetSingleton()->TransformAllAssets();
 
     if (stat.Failed())
     {

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -357,7 +357,7 @@ Explanation: For assets to work properly, they must be <a href='https://ezengine
 
           // check whether the project needs to be transformed
           QTimer::singleShot(2000, this, [this]()
-            { ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::Default).IgnoreResult(); });
+            { ezAssetCurator::GetSingleton()->TransformAllAssets().IgnoreResult(); });
         }
       }
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/SceneActions.cpp
@@ -289,7 +289,7 @@ void ezSceneAction::Execute(const ezVariant& value)
       range.BeginNextStep("Transform Assets");
       if (dlg.s_bTransformAll)
       {
-        if (ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::None).Succeeded())
+        if (ezAssetCurator::GetSingleton()->TransformAllAssets().Succeeded())
         {
           // once all assets have been transformed, disable it for the next export
           dlg.s_bTransformAll = false;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocument.cpp
@@ -1750,7 +1750,9 @@ ezTransformStatus ezSceneDocument::ExportScene(bool bCreateThumbnail)
     res = ezAssetCurator::GetSingleton()->TransformAsset(GetGuid(), ezTransformFlags::ForceTransform | ezTransformFlags::TriggeredManually);
   }
   else
+  {
     res = TransformAsset(ezTransformFlags::ForceTransform | ezTransformFlags::TriggeredManually);
+  }
 
   if (res.Failed())
     ezLog::Error(res.m_sMessage);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentManager.cpp
@@ -27,7 +27,7 @@ ezSceneDocumentManager::ezSceneDocumentManager()
     docTypeDesc.m_CompatibleTypes.PushBack("CompatibleAsset_Scene");
 
     docTypeDesc.m_sResourceFileExtension = "ezBinScene";
-    docTypeDesc.m_AssetDocumentFlags = /*ezAssetDocumentFlags::AutoTransformOnSave |*/ ezAssetDocumentFlags::SupportsThumbnail;
+    docTypeDesc.m_AssetDocumentFlags = ezAssetDocumentFlags::OnlyTransformManually | ezAssetDocumentFlags::SupportsThumbnail;
   }
 
   // Document type descriptor for a prefab

--- a/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
@@ -47,7 +47,7 @@ ezResult ezMaterialDocumentTest::InitializeTest()
   if (SUPER::CreateAndLoadProject("SceneTestProject").Failed())
     return EZ_FAILURE;
 
-  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::None); res.Failed())
+  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(); res.Failed())
   {
     ezLog::Error("Asset transform failed: {}", res.m_sMessage);
     return EZ_FAILURE;

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -32,7 +32,7 @@ ezResult ezEditorTestMisc::InitializeTest()
   if (SUPER::OpenProject("Data/UnitTests/EditorTest").Failed())
     return EZ_FAILURE;
 
-  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::None); res.Failed())
+  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(); res.Failed())
   {
     ezLog::Error("Asset transform failed: {}", res.m_sMessage);
     return EZ_FAILURE;
@@ -81,7 +81,7 @@ ezTestAppRun ezEditorTestMisc::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvoca
   ////TODO: Newly created assets actually do not transform cleanly.
   // if (false)
   //{
-  //  ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually);
+  //  ezAssetCurator::GetSingleton()->TransformAllAssets();
 
   //  ezUInt32 uiNumAssets;
   //  ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT> sections;

--- a/Code/UnitTests/EditorTest/Project/Project.cpp
+++ b/Code/UnitTests/EditorTest/Project/Project.cpp
@@ -82,7 +82,7 @@ ezTestAppRun ezEditorTestProject::CreateDocuments()
   // TODO: Newly created assets actually do not transform cleanly.
   if (false)
   {
-    ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::TriggeredManually).IgnoreResult();
+    ezAssetCurator::GetSingleton()->TransformAllAssets().IgnoreResult();
 
     ezUInt32 uiNumAssets;
     ezHybridArray<ezUInt32, ezAssetInfo::TransformState::COUNT> sections;

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -41,7 +41,7 @@ ezResult ezEditorSceneDocumentTest::InitializeTest()
   if (SUPER::CreateAndLoadProject("SceneTestProject").Failed())
     return EZ_FAILURE;
 
-  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(ezTransformFlags::None); res.Failed())
+  if (ezStatus res = ezAssetCurator::GetSingleton()->TransformAllAssets(); res.Failed())
   {
     ezLog::Error("Asset transform failed: {}", res.m_sMessage);
     return EZ_FAILURE;


### PR DESCRIPTION
Reverts scene transform behavior to not transform scenes in the background anymore, and also not on save.
The first can otherwise block background processors too much, the second results in very slow saving times for some scenes.

Instead, when "transform all" is done, scenes now also get transformed.