### PR TITLE
Selective mesh import and automatic LOD setup

### DIFF
--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsRenderer.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsRenderer.cmake
@@ -4,16 +4,19 @@
 
 macro(ez_requires_renderer)
 	# PLATFORM-TODO
+
+	# if we know which backend the user wants, require that
+	# otherwise require the platform specific renderer
+	# if nothing else is known, this platform doesn't support renderers
 	if(EZ_BUILD_EXPERIMENTAL_WEBGPU)
 		ez_requires_webgpu()
-	endif()
-
-	if(EZ_BUILD_EXPERIMENTAL_VULKAN)
+	elseif(EZ_BUILD_EXPERIMENTAL_VULKAN)
 		ez_requires_vulkan()
-	endif()
-
-	if(EZ_CMAKE_PLATFORM_WINDOWS)
+	elseif(EZ_CMAKE_PLATFORM_WINDOWS)
 		ez_requires_d3d()
+	else()
+		message(STATUS "No renderer available on this platform.")
+		return()
 	endif()
 endmacro()
 

--- a/Code/BuildSystem/CMake/Platforms/Configure_OSX.cmake
+++ b/Code/BuildSystem/CMake/Platforms/Configure_OSX.cmake
@@ -33,6 +33,13 @@ macro(ez_platform_detect_generator)
 		set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_PREFIX "Make")
 		set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_CONFIGURATION ${CMAKE_BUILD_TYPE})
 
+	elseif(CMAKE_GENERATOR MATCHES "Ninja") # Ninja
+		message(STATUS "Buildsystem is Ninja (EZ_CMAKE_GENERATOR_MAKE)")
+
+		set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_NINJA ON)
+		set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_PREFIX "Ninja")
+		set_property(GLOBAL PROPERTY EZ_CMAKE_GENERATOR_CONFIGURATION ${CMAKE_BUILD_TYPE})
+
 	else()
 		message(FATAL_ERROR "Generator '${CMAKE_GENERATOR}' is not supported on OS X! Please extend ez_platform_detect_generator()")
 	endif()

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -701,7 +701,7 @@ void ezQtAssetBrowserWidget::DeleteSelection()
     }
   }
 
-  QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Delete the selected file?\n\nThis operation cannot be undone."), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Yes);
+  QMessageBox::StandardButton choice = ezQtUiServices::MessageBoxQuestion(ezFmt("Delete the selected file?\n\nThis operation cannot be undone."), QMessageBox::StandardButton::Cancel | QMessageBox::StandardButton::Yes, QMessageBox::StandardButton::Cancel);
   if (choice == QMessageBox::StandardButton::Cancel)
     return;
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.ui
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.ui
@@ -100,6 +100,9 @@
              <bool>false</bool>
             </property>
             <widget class="QTreeView" name="ListAssets">
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
              <property name="uniformRowHeights">
               <bool>true</bool>
              </property>

--- a/Code/Editor/EditorFramework/Preferences/ProjectPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/ProjectPreferences.cpp
@@ -12,6 +12,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProjectPreferencesUser, 1, ezRTTIDefaultAlloca
     EZ_ARRAY_MEMBER_PROPERTY("Players", m_PlayerApps)->AddAttributes(new ezHiddenAttribute()),
     EZ_MEMBER_PROPERTY("ExportFolder", m_sExportFolder)->AddAttributes(new ezHiddenAttribute()),
     EZ_MEMBER_PROPERTY("SharedMaterialFolder", m_sSharedMaterialFolder)->AddAttributes(new ezHiddenAttribute()),
+    EZ_MEMBER_PROPERTY("MeshLodPrefix", m_sMeshLodPrefix)->AddAttributes(new ezHiddenAttribute(), new ezDefaultValueAttribute("$LOD")),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorFramework/Preferences/ProjectPreferences.h
+++ b/Code/Editor/EditorFramework/Preferences/ProjectPreferences.h
@@ -19,4 +19,7 @@ public:
 
   // path to a folder where shared materials should be stored
   ezString m_sSharedMaterialFolder;
+
+  // the default mesh include tag used to indicate that a sub-mesh is an LOD
+  ezString m_sMeshLodPrefix;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -79,6 +79,28 @@ ezStatus ezAnimatedMeshAssetDocument::CreateMeshFromFile(ezAnimatedMeshAssetProp
   opt.m_bNormalizeWeights = pProp->m_bNormalizeWeights;
   // opt.m_RootTransform = CalculateTransformationMatrix(pProp);
 
+  // include tags
+  {
+    ezHybridArray<ezStringView, 8> tags;
+    pProp->m_sMeshIncludeTags.Split(false, tags, ";");
+    for (ezStringView tag : tags)
+    {
+      tag.Trim();
+      opt.m_MeshIncludeTags.PushBack(tag);
+    }
+  }
+
+  // exclude tags
+  {
+    ezHybridArray<ezStringView, 8> tags;
+    pProp->m_sMeshExcludeTags.Split(false, tags, ";");
+    for (ezStringView tag : tags)
+    {
+      tag.Trim();
+      opt.m_MeshExcludeTags.PushBack(tag);
+    }
+  }
+
   if (pProp->m_bSimplifyMesh)
   {
     opt.m_uiMeshSimplification = pProp->m_uiMeshSimplification;
@@ -88,6 +110,17 @@ ezStatus ezAnimatedMeshAssetDocument::CreateMeshFromFile(ezAnimatedMeshAssetProp
 
   if (pImporter->Import(opt).Failed())
     return ezStatus("Model importer was unable to read this asset.");
+
+  if (desc.GetSubMeshes().IsEmpty() || !desc.GetBounds().IsValid())
+    return ezStatus("Imported mesh is empty.");
+
+  for (auto& sm : desc.GetSubMeshes())
+  {
+    if (sm.m_uiPrimitiveCount == 0)
+    {
+      return ezStatus("Imported mesh is empty.");
+    }
+  }
 
   range.BeginNextStep("Importing Materials");
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.cpp
@@ -9,6 +9,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezAnimatedMeshAssetProperties, 2, ezRTTIDefaultA
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::MeshesWithAnimations)),
+    EZ_MEMBER_PROPERTY("MeshIncludeTags", m_sMeshIncludeTags),
+    EZ_MEMBER_PROPERTY("MeshExcludeTags", m_sMeshExcludeTags)->AddAttributes(new ezDefaultValueAttribute("$;UCX_")),
     EZ_MEMBER_PROPERTY("DefaultSkeleton", m_sDefaultSkeleton)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Mesh_Skeleton")),
     EZ_MEMBER_PROPERTY("RecalculateNormals", m_bRecalculateNormals),
     EZ_MEMBER_PROPERTY("RecalculateTangents", m_bRecalculateTrangents)->AddAttributes(new ezDefaultValueAttribute(true)),

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetObjects.h
@@ -16,6 +16,8 @@ public:
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
   ezString m_sMeshFile;
+  ezString m_sMeshIncludeTags;
+  ezString m_sMeshExcludeTags;
   ezString m_sDefaultSkeleton;
 
   bool m_bRecalculateNormals = false;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.cpp
@@ -22,6 +22,9 @@ void ezMeshImportDlg::showEvent(QShowEvent* e)
   ImportAnimClips->setChecked(m_bImportAnimationClips);
   ReuseSkeleton->setChecked(m_bReuseExistingSkeleton);
   UseSharedMaterials->setChecked(m_bUseSharedMaterials);
+  Lod->setChecked(m_bAddLODs);
+  NumLODs->setValue(m_uiNumLODs);
+  LodIncludeTag->setText(ezMakeQString(m_sMeshLodPrefix));
 
   UpdateUI();
 }
@@ -106,6 +109,9 @@ void ezMeshImportDlg::on_Buttons_accepted()
   m_bCreateMaterials = Materials->isChecked();
   m_bImportAnimationClips = ImportAnimClips->isChecked();
   m_bApplyToAll = ApplyToAll->isChecked();
+  m_bAddLODs = Lod->isChecked();
+  m_uiNumLODs = NumLODs->value();
+  m_sMeshLodPrefix = LodIncludeTag->text().toUtf8().data();
 
   accept();
 }
@@ -180,4 +186,9 @@ void ezMeshImportDlg::on_ReuseSkeleton_clicked(bool)
   m_bReuseExistingSkeleton = ReuseSkeleton->isChecked();
 
   UpdateUI();
+}
+
+void ezMeshImportDlg::on_Help_clicked(bool)
+{
+  QDesktopServices::openUrl(QUrl("https://ezengine.net/pages/docs/assets/import-assets.html"));
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.moc.h
@@ -19,7 +19,10 @@ public:
   bool m_bShowAnimMeshOptions = false;
   bool m_bReuseExistingSkeleton = false;
   bool m_bImportAnimationClips = false;
+  bool m_bAddLODs = false;
+  ezUInt8 m_uiNumLODs = 1;
   ezUuid m_SharedSkeleton;
+  ezString m_sMeshLodPrefix;
 
 private Q_SLOTS:
   void on_Buttons_accepted();
@@ -29,6 +32,7 @@ private Q_SLOTS:
   void on_UseSharedMaterials_clicked(bool);
   void on_Materials_clicked(bool);
   void on_ReuseSkeleton_clicked(bool);
+  void on_Help_clicked(bool);
 
 private:
   virtual void showEvent(QShowEvent*) override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.ui
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Dialogs/MeshImportDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>391</width>
-    <height>342</height>
+    <width>333</width>
+    <height>446</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -31,14 +31,29 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="CurrentAsset">
-     <property name="text">
-      <string>Asset:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="CurrentAsset">
+       <property name="text">
+        <string>Asset:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="Help">
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+         <normaloff>:/GuiFoundation/Icons/Help.svg</normaloff>:/GuiFoundation/Icons/Help.svg</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <spacer name="verticalSpacer_2">
@@ -131,6 +146,62 @@
          <string>Import all animation clips</string>
         </property>
        </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="Lod">
+     <property name="title">
+      <string>Add Levels of Detail</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Mesh LOD Prefix:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="LodIncludeTag"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Auto Generate Num LODs:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="NumLODs">
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>4</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>29</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -233,6 +233,28 @@ ezTransformStatus ezMeshAssetDocument::CreateMeshFromFile(ezMeshAssetProperties*
   opt.m_MeshVertexColorConversion = pProp->m_VertexColorConversion;
   opt.m_RootTransform = CalculateTransformationMatrix(pProp);
 
+  // include tags
+  {
+    ezHybridArray<ezStringView, 8> tags;
+    pProp->m_sMeshIncludeTags.Split(false, tags, ";");
+    for (ezStringView tag : tags)
+    {
+      tag.Trim();
+      opt.m_MeshIncludeTags.PushBack(tag);
+    }
+  }
+
+  // exclude tags
+  {
+    ezHybridArray<ezStringView, 8> tags;
+    pProp->m_sMeshExcludeTags.Split(false, tags, ";");
+    for (ezStringView tag : tags)
+    {
+      tag.Trim();
+      opt.m_MeshExcludeTags.PushBack(tag);
+    }
+  }
+
   if (pProp->m_bSimplifyMesh)
   {
     opt.m_uiMeshSimplification = pProp->m_uiMeshSimplification;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.h
@@ -48,7 +48,7 @@ public:
 
 protected:
   ezMeshAssetDocumentGenerator(bool bAnimMesh);
-  virtual ezStatus ConfigureMeshDocument(ezDocument* pDoc, ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments);
+  virtual ezStatus ConfigureMeshDocument(ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments);
 
   bool m_bAnimatedMesh = false;
   bool m_bShowImportDlg = true;
@@ -56,6 +56,8 @@ protected:
   static bool s_bImportAllClips;
   static bool s_bUseSharedMaterials;
   static bool s_bCreateMaterials;
+  static bool s_bAddLODs;
+  static ezUInt8 s_uiNumLODs;
   static ezUuid s_SharedSkeleton;
 };
 
@@ -71,5 +73,5 @@ public:
   virtual ezStringView GetDocumentExtension() const override { return "ezAnimatedMeshAsset"; }
 
 protected:
-  virtual ezStatus ConfigureMeshDocument(ezDocument* pDoc, ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
+  virtual ezStatus ConfigureMeshDocument(ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments) override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetImport.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetImport.cpp
@@ -164,9 +164,9 @@ ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezSt
   return ConfigureMeshDocument(sInputFileRel, sOutFile, pImporter.Borrow(), materials, out_generatedDocuments);
 }
 
-static void FindLODs(ezArrayMap<ezUInt32, ezString>& out_FoundLods, ezModelImporter2::Importer* pImporter)
+static void FindLODs(ezArrayMap<ezUInt32, ezString>& out_foundLods, ezModelImporter2::Importer* pImporter)
 {
-  out_FoundLods.Clear();
+  out_foundLods.Clear();
 
   ezProjectPreferencesUser* pPref = ezPreferences::QueryPreferences<ezProjectPreferencesUser>();
 
@@ -183,36 +183,36 @@ static void FindLODs(ezArrayMap<ezUInt32, ezString>& out_FoundLods, ezModelImpor
       {
         if (meshName.StartsWith_NoCase(lod) || meshName.EndsWith_NoCase(lod))
         {
-          out_FoundLods[i] = lod;
+          out_foundLods[i] = lod;
         }
       }
     }
   }
 
-  out_FoundLods.Sort();
+  out_foundLods.Sort();
 }
 
-static void SetMeshLod(ezUInt32 uiLod, ezArrayMap<ezUInt32, ezString>& foundLods, ezDocumentObject* pPropObj, ezObjectCommandAccessor& ca)
+static void SetMeshLod(ezUInt32 uiLod, ezArrayMap<ezUInt32, ezString>& ref_foundLods, ezDocumentObject* pPropObj, ezObjectCommandAccessor& ref_accessor)
 {
   if (uiLod > 0)
   {
-    if (foundLods.IsEmpty())
+    if (ref_foundLods.IsEmpty())
     {
-      ca.SetValueByName(pPropObj, "SimplifyMesh", true).AssertSuccess();
+      ref_accessor.SetValueByName(pPropObj, "SimplifyMesh", true).AssertSuccess();
 
       const ezInt32 uiSimp[5] = {0, 50, 75, 90, 95};
       const ezInt32 uiErro[5] = {0, 5, 5, 10, 15};
-      ca.SetValueByName(pPropObj, "MeshSimplification", uiSimp[uiLod]).AssertSuccess();
-      ca.SetValueByName(pPropObj, "MaxSimplificationError", uiErro[uiLod]).AssertSuccess();
+      ref_accessor.SetValueByName(pPropObj, "MeshSimplification", uiSimp[uiLod]).AssertSuccess();
+      ref_accessor.SetValueByName(pPropObj, "MaxSimplificationError", uiErro[uiLod]).AssertSuccess();
     }
     else
     {
       // always use the smallest next LOD that was found
-      const ezString& sLodToUse = foundLods.GetValue(0);
+      const ezString& sLodToUse = ref_foundLods.GetValue(0);
 
-      ca.SetValueByName(pPropObj, "MeshIncludeTags", sLodToUse).AssertSuccess();
+      ref_accessor.SetValueByName(pPropObj, "MeshIncludeTags", sLodToUse).AssertSuccess();
 
-      foundLods.RemoveAtAndCopy(0);
+      ref_foundLods.RemoveAtAndCopy(0);
     }
   }
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetImport.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetImport.cpp
@@ -8,6 +8,7 @@
 #include <EditorPluginAssets/MeshAsset/MeshAsset.h>
 #include <EditorPluginAssets/SkeletonAsset/SkeletonAsset.h>
 #include <EditorPluginAssets/Util/MeshImportUtils.h>
+#include <Foundation/Containers/ArrayMap.h>
 #include <Foundation/Utilities/Progress.h>
 #include <ModelImporter2/ModelImporter.h>
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
@@ -20,6 +21,8 @@ bool ezMeshAssetDocumentGenerator::s_bCreateMaterials = true;
 bool ezMeshAssetDocumentGenerator::s_bUseSharedMaterials = false;
 bool ezMeshAssetDocumentGenerator::s_bReuseSkeleton = false;
 bool ezMeshAssetDocumentGenerator::s_bImportAllClips = false;
+bool ezMeshAssetDocumentGenerator::s_bAddLODs = false;
+ezUInt8 ezMeshAssetDocumentGenerator::s_uiNumLODs = 1;
 ezUuid ezMeshAssetDocumentGenerator::s_SharedSkeleton;
 
 ezMeshAssetDocumentGenerator::ezMeshAssetDocumentGenerator()
@@ -87,6 +90,9 @@ ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezSt
     dlg.m_bReuseExistingSkeleton = s_bReuseSkeleton;
     dlg.m_SharedSkeleton = s_SharedSkeleton;
     dlg.m_bImportAnimationClips = s_bImportAllClips;
+    dlg.m_bAddLODs = s_bAddLODs;
+    dlg.m_uiNumLODs = s_uiNumLODs;
+    dlg.m_sMeshLodPrefix = pPref->m_sMeshLodPrefix.IsEmpty() ? ezString("$LOD") : pPref->m_sMeshLodPrefix;
 
     if (dlg.exec() != QDialog::Accepted)
     {
@@ -104,6 +110,13 @@ ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezSt
         sSharedMaterialsFolderAbs = dlg.m_sSharedMaterialsFolderAbs;
         pPref->m_sSharedMaterialFolder = dlg.m_sSharedMaterialsFolderAbs;
       }
+    }
+
+    s_bAddLODs = dlg.m_bAddLODs;
+    if (s_bAddLODs)
+    {
+      s_uiNumLODs = ezMath::Clamp<ezUInt8>(dlg.m_uiNumLODs, 0, 4);
+      pPref->m_sMeshLodPrefix = dlg.m_sMeshLodPrefix;
     }
 
     if (m_bAnimatedMesh)
@@ -148,39 +161,119 @@ ezStatus ezMeshAssetDocumentGenerator::Generate(ezStringView sInputFileAbs, ezSt
     ezMeshImportUtils::ImportMeshAssetMaterials(materials, sMaterialFolder, pImporter.Borrow());
   }
 
-  ezDocument* pDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
-  if (pDoc == nullptr)
-    return ezStatus("Could not create target document");
-
-  out_generatedDocuments.PushBack(pDoc);
-
-  return ConfigureMeshDocument(pDoc, sInputFileRel, sOutFile, pImporter.Borrow(), materials, out_generatedDocuments);
+  return ConfigureMeshDocument(sInputFileRel, sOutFile, pImporter.Borrow(), materials, out_generatedDocuments);
 }
 
-ezStatus ezMeshAssetDocumentGenerator::ConfigureMeshDocument(ezDocument* pDoc, ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments)
+static void FindLODs(ezArrayMap<ezUInt32, ezString>& out_FoundLods, ezModelImporter2::Importer* pImporter)
 {
-  ezMeshAssetDocument* pAssetDoc = ezDynamicCast<ezMeshAssetDocument*>(pDoc);
+  out_FoundLods.Clear();
 
-  auto pPropObj = pAssetDoc->GetPropertyObject();
+  ezProjectPreferencesUser* pPref = ezPreferences::QueryPreferences<ezProjectPreferencesUser>();
 
-  ezObjectCommandAccessor ca(pAssetDoc->GetCommandHistory());
-  ca.StartTransaction("Init Values");
-  ca.SetValueByName(pPropObj, "MeshFile", sInputFile).AssertSuccess();
-  ca.SetValueByName(pPropObj, "ImportMaterials", false).AssertSuccess();
-
-  for (ezUInt32 i = 0; i < materials.GetCount(); ++i)
+  if (!pPref->m_sMeshLodPrefix.IsEmpty())
   {
-    ezUuid guid = ezUuid::MakeUuid();
-    ca.AddObjectByName(pPropObj, "Materials", i, ezGetStaticRTTI<ezMaterialResourceSlot>(), guid).AssertSuccess();
+    ezStringBuilder lod;
 
-    auto* pChildMatObj = ca.GetObject(guid);
-    ca.SetValueByName(pChildMatObj, "Label", materials[i].m_sLabel).AssertSuccess();
-    ca.SetValueByName(pChildMatObj, "Resource", materials[i].m_sResource).AssertSuccess();
+    for (ezUInt32 i = 0; i < 4; ++i)
+    {
+      lod = pPref->m_sMeshLodPrefix;
+      lod.AppendFormat("{}", i);
+
+      for (const auto& meshName : pImporter->m_OutputMeshNames)
+      {
+        if (meshName.StartsWith_NoCase(lod) || meshName.EndsWith_NoCase(lod))
+        {
+          out_FoundLods[i] = lod;
+        }
+      }
+    }
   }
 
-  ca.FinishTransaction();
+  out_FoundLods.Sort();
+}
 
-  ezLog::Success("Imported mesh: '{}'", sOutFile);
+static void SetMeshLod(ezUInt32 uiLod, ezArrayMap<ezUInt32, ezString>& foundLods, ezDocumentObject* pPropObj, ezObjectCommandAccessor& ca)
+{
+  if (uiLod > 0)
+  {
+    if (foundLods.IsEmpty())
+    {
+      ca.SetValueByName(pPropObj, "SimplifyMesh", true).AssertSuccess();
+
+      const ezInt32 uiSimp[5] = {0, 50, 75, 90, 95};
+      const ezInt32 uiErro[5] = {0, 5, 5, 10, 15};
+      ca.SetValueByName(pPropObj, "MeshSimplification", uiSimp[uiLod]).AssertSuccess();
+      ca.SetValueByName(pPropObj, "MaxSimplificationError", uiErro[uiLod]).AssertSuccess();
+    }
+    else
+    {
+      // always use the smallest next LOD that was found
+      const ezString& sLodToUse = foundLods.GetValue(0);
+
+      ca.SetValueByName(pPropObj, "MeshIncludeTags", sLodToUse).AssertSuccess();
+
+      foundLods.RemoveAtAndCopy(0);
+    }
+  }
+}
+
+ezStatus ezMeshAssetDocumentGenerator::ConfigureMeshDocument(ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments)
+{
+  auto pApp = ezQtEditorApp::GetSingleton();
+
+  ezUInt32 uiNumLODs = 1;
+
+  ezArrayMap<ezUInt32, ezString> foundLods;
+  if (s_bAddLODs)
+  {
+    FindLODs(foundLods, pImporter);
+    uiNumLODs += (!foundLods.IsEmpty()) ? foundLods.GetCount() : s_uiNumLODs;
+  }
+
+  ezStringBuilder sFinalName, sFinalPath;
+
+  for (ezUInt32 uiLod = 0; uiLod < uiNumLODs; ++uiLod)
+  {
+    sFinalPath = sOutFile;
+
+    if (uiLod > 0)
+    {
+      // sFinalName.SetFormat("{}_lod{}", sOutFile.GetFileName(), uiLod);
+      sFinalName.SetFormat("{}_data/LOD-{}", sOutFile.GetFileName(), uiLod);
+      sFinalPath.ChangeFileName(sFinalName);
+    }
+
+    ezDocument* pDoc = pApp->CreateDocument(sFinalPath, ezDocumentFlags::None);
+    if (pDoc == nullptr)
+      return ezStatus(ezFmt("Could not create document '{}'", sFinalPath));
+
+    out_generatedDocuments.PushBack(pDoc);
+
+    ezMeshAssetDocument* pAssetDoc = ezDynamicCast<ezMeshAssetDocument*>(pDoc);
+
+    auto pPropObj = pAssetDoc->GetPropertyObject();
+
+    ezObjectCommandAccessor ca(pAssetDoc->GetCommandHistory());
+    ca.StartTransaction("Init Values");
+    ca.SetValueByName(pPropObj, "MeshFile", sInputFile).AssertSuccess();
+    ca.SetValueByName(pPropObj, "ImportMaterials", false).AssertSuccess();
+
+    for (ezUInt32 i = 0; i < materials.GetCount(); ++i)
+    {
+      ezUuid guid = ezUuid::MakeUuid();
+      ca.AddObjectByName(pPropObj, "Materials", i, ezGetStaticRTTI<ezMaterialResourceSlot>(), guid).AssertSuccess();
+
+      auto* pChildMatObj = ca.GetObject(guid);
+      ca.SetValueByName(pChildMatObj, "Label", materials[i].m_sLabel).AssertSuccess();
+      ca.SetValueByName(pChildMatObj, "Resource", materials[i].m_sResource).AssertSuccess();
+    }
+
+    SetMeshLod(uiLod, foundLods, pPropObj, ca);
+
+    ca.FinishTransaction();
+
+    ezLog::Success("Imported mesh: '{}'", sFinalPath);
+  }
 
   return ezStatus(EZ_SUCCESS);
 }
@@ -211,9 +304,15 @@ void ezAnimatedMeshAssetDocumentGenerator::GetImportModes(ezStringView sAbsInput
   }
 }
 
-ezStatus ezAnimatedMeshAssetDocumentGenerator::ConfigureMeshDocument(ezDocument* pMainDoc, ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments)
+ezStatus ezAnimatedMeshAssetDocumentGenerator::ConfigureMeshDocument(ezStringView sInputFile, ezStringView sOutFile, ezModelImporter2::Importer* pImporter, ezArrayPtr<ezMaterialResourceSlot> materials, ezDynamicArray<ezDocument*>& out_generatedDocuments)
 {
   auto pApp = ezQtEditorApp::GetSingleton();
+
+  ezDocument* pMainDoc = pApp->CreateDocument(sOutFile, ezDocumentFlags::None);
+  if (pMainDoc == nullptr)
+    return ezStatus(ezFmt("Could not create document '{}'", sOutFile));
+
+  out_generatedDocuments.PushBack(pMainDoc);
 
   ezUuid skeletonGuid = s_SharedSkeleton;
 
@@ -261,32 +360,70 @@ ezStatus ezAnimatedMeshAssetDocumentGenerator::ConfigureMeshDocument(ezDocument*
 
   // configure animated mesh asset
   {
-    ezAnimatedMeshAssetDocument* pAnimMeshDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(pMainDoc);
+    ezStringBuilder sFinalName, sFinalPath;
 
-    auto pPropObj = pAnimMeshDoc->GetPropertyObject();
+    ezUInt32 uiNumLODs = 1;
 
-    ezStringBuilder sSkeletonGuid;
-    ezConversionUtils::ToString(skeletonGuid, sSkeletonGuid);
-
-    ezObjectCommandAccessor ca(pAnimMeshDoc->GetCommandHistory());
-    ca.StartTransaction("Init Values");
-    ca.SetValueByName(pPropObj, "MeshFile", sInputFile).AssertSuccess();
-    ca.SetValueByName(pPropObj, "ImportMaterials", false).AssertSuccess();
-    ca.SetValueByName(pPropObj, "DefaultSkeleton", sSkeletonGuid.GetView()).AssertSuccess();
-
-    for (ezUInt32 i = 0; i < materials.GetCount(); ++i)
+    ezArrayMap<ezUInt32, ezString> foundLods;
+    if (s_bAddLODs)
     {
-      ezUuid guid = ezUuid::MakeUuid();
-      ca.AddObjectByName(pPropObj, "Materials", i, ezGetStaticRTTI<ezMaterialResourceSlot>(), guid).AssertSuccess();
-
-      auto* pChildMatObj = ca.GetObject(guid);
-      ca.SetValueByName(pChildMatObj, "Label", materials[i].m_sLabel).AssertSuccess();
-      ca.SetValueByName(pChildMatObj, "Resource", materials[i].m_sResource).AssertSuccess();
+      FindLODs(foundLods, pImporter);
+      uiNumLODs += (!foundLods.IsEmpty()) ? foundLods.GetCount() : s_uiNumLODs;
     }
 
-    ca.FinishTransaction();
+    for (ezUInt32 uiLod = 0; uiLod < uiNumLODs; ++uiLod)
+    {
+      sFinalPath = sOutFile;
 
-    ezLog::Success("Imported animated mesh: '{}'", sOutFile);
+      ezAnimatedMeshAssetDocument* pAnimMeshDoc;
+
+      if (uiLod == 0)
+      {
+        pAnimMeshDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(pMainDoc);
+      }
+      else
+      {
+        if (uiLod > 0)
+        {
+          // sFinalName.SetFormat("{}_lod{}", sOutFile.GetFileName(), uiLod);
+          sFinalName.SetFormat("{}_data/LOD-{}", sOutFile.GetFileName(), uiLod);
+          sFinalPath.ChangeFileName(sFinalName);
+        }
+
+        pAnimMeshDoc = ezDynamicCast<ezAnimatedMeshAssetDocument*>(pApp->CreateDocument(sFinalPath, ezDocumentFlags::None));
+        if (pAnimMeshDoc == nullptr)
+          return ezStatus(ezFmt("Could not create document '{}'", sFinalPath));
+
+        out_generatedDocuments.PushBack(pAnimMeshDoc);
+      }
+
+      auto pPropObj = pAnimMeshDoc->GetPropertyObject();
+
+      ezStringBuilder sSkeletonGuid;
+      ezConversionUtils::ToString(skeletonGuid, sSkeletonGuid);
+
+      ezObjectCommandAccessor ca(pAnimMeshDoc->GetCommandHistory());
+      ca.StartTransaction("Init Values");
+      ca.SetValueByName(pPropObj, "MeshFile", sInputFile).AssertSuccess();
+      ca.SetValueByName(pPropObj, "ImportMaterials", false).AssertSuccess();
+      ca.SetValueByName(pPropObj, "DefaultSkeleton", sSkeletonGuid.GetView()).AssertSuccess();
+
+      for (ezUInt32 i = 0; i < materials.GetCount(); ++i)
+      {
+        ezUuid guid = ezUuid::MakeUuid();
+        ca.AddObjectByName(pPropObj, "Materials", i, ezGetStaticRTTI<ezMaterialResourceSlot>(), guid).AssertSuccess();
+
+        auto* pChildMatObj = ca.GetObject(guid);
+        ca.SetValueByName(pChildMatObj, "Label", materials[i].m_sLabel).AssertSuccess();
+        ca.SetValueByName(pChildMatObj, "Resource", materials[i].m_sResource).AssertSuccess();
+      }
+
+      SetMeshLod(uiLod, foundLods, pPropObj, ca);
+
+      ca.FinishTransaction();
+
+      ezLog::Success("Imported animated mesh: '{}'", sFinalPath);
+    }
   }
 
   // create animation clip assets

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.cpp
@@ -11,6 +11,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMeshAssetProperties, 4, ezRTTIDefaultAllocator
   {
     EZ_ENUM_MEMBER_PROPERTY("PrimitiveType", ezMeshPrimitive, m_PrimitiveType),
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes)),
+    EZ_MEMBER_PROPERTY("MeshIncludeTags", m_sMeshIncludeTags),
+    EZ_MEMBER_PROPERTY("MeshExcludeTags", m_sMeshExcludeTags)->AddAttributes(new ezDefaultValueAttribute("$;UCX_")),
     EZ_ENUM_MEMBER_PROPERTY("ImportTransform", ezMeshImportTransform, m_ImportTransform),
     EZ_ENUM_MEMBER_PROPERTY("RightDir", ezBasisAxis, m_RightDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::NegativeX)),
     EZ_ENUM_MEMBER_PROPERTY("UpDir", ezBasisAxis, m_UpDir)->AddAttributes(new ezDefaultValueAttribute((int)ezBasisAxis::PositiveY)),
@@ -97,6 +99,8 @@ void ezMeshAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaStateEve
     auto& props = *e.m_pPropertyStates;
 
     props["MeshFile"].m_Visibility = ezPropertyUiState::Invisible;
+    props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Invisible;
+    props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Invisible;
     props["Radius"].m_Visibility = ezPropertyUiState::Invisible;
     props["Radius2"].m_Visibility = ezPropertyUiState::Invisible;
     props["Height"].m_Visibility = ezPropertyUiState::Invisible;
@@ -126,6 +130,8 @@ void ezMeshAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaStateEve
     {
       case ezMeshPrimitive::File:
         props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
         props["ImportMaterials"].m_Visibility = ezPropertyUiState::Default;
         props["RecalculateNormals"].m_Visibility = ezPropertyUiState::Default;
         props["RecalculateTangents"].m_Visibility = ezPropertyUiState::Default;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetObjects.h
@@ -43,6 +43,8 @@ public:
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
   ezString m_sMeshFile;
+  ezString m_sMeshIncludeTags;
+  ezString m_sMeshExcludeTags;
   float m_fUniformScaling = 1.0f;
 
   float m_fRadius = 0.5f;

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/AnimatedMeshAsset/AnimatedMeshView.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/AnimatedMeshAsset/AnimatedMeshView.cpp
@@ -57,7 +57,16 @@ void ezAnimatedMeshViewContext::SetCamera(const ezViewRedrawMsgToEngine* pMsg)
 
     ezUInt32 uiNumVertices = bufferDesc.m_uiTotalSize / bufferDesc.m_uiStructSize;
     ezUInt32 uiNumTriangles = pAnimatedMeshBuffer->GetPrimitiveCount();
-    const ezBoundingBox& bbox = pAnimatedMeshBuffer->GetBounds().GetBox();
+
+    ezBoundingBox bbox;
+    if (pAnimatedMeshBuffer->GetBounds().IsValid())
+    {
+      bbox = pAnimatedMeshBuffer->GetBounds().GetBox();
+    }
+    else
+    {
+      bbox = ezBoundingBox::MakeFromCenterAndHalfExtents(ezVec3::MakeZero(), ezVec3(0.5f));
+    }
 
     ezUInt32 uiNumUVs = 0;
     ezUInt32 uiNumColors = 0;

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -149,6 +149,28 @@ ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltCookingMesh&
   opt.m_pMeshOutput = &meshDesc;
   opt.m_RootTransform = CalculateTransformationMatrix(pProp);
 
+  // include tags
+  {
+    ezHybridArray<ezStringView, 8> tags;
+    pProp->m_sMeshIncludeTags.Split(false, tags, ";");
+    for (ezStringView tag : tags)
+    {
+      tag.Trim();
+      opt.m_MeshIncludeTags.PushBack(tag);
+    }
+  }
+
+  // exclude tags
+  {
+    ezHybridArray<ezStringView, 8> tags;
+    pProp->m_sMeshExcludeTags.Split(false, tags, ";");
+    for (ezStringView tag : tags)
+    {
+      tag.Trim();
+      opt.m_MeshExcludeTags.PushBack(tag);
+    }
+  }
+
   if (pProp->m_bSimplifyMesh)
   {
     opt.m_uiMeshSimplification = pProp->m_uiMeshSimplification;

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -186,6 +186,9 @@ ezStatus ezJoltCollisionMeshAssetDocument::CreateMeshFromFile(ezJoltCookingMesh&
   const ezUInt32 uiNumTriangles = meshBuffer.GetPrimitiveCount();
   const ezUInt32 uiNumVertices = meshBuffer.GetVertexCount();
 
+  if (uiNumTriangles < 3 || uiNumVertices < 3)
+    return ezStatus("Invalid collision mesh.");
+
   outMesh.m_PolygonSurfaceID.SetCountUninitialized(uiNumTriangles);
   outMesh.m_VerticesInPolygon.SetCountUninitialized(uiNumTriangles);
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -45,6 +45,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 2, ezRTTIDef
     EZ_MEMBER_PROPERTY("Height", m_fHeight)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_MEMBER_PROPERTY("Detail", m_uiDetail)->AddAttributes(new ezDefaultValueAttribute(1), new ezClampValueAttribute(0, 32)),
     EZ_MEMBER_PROPERTY("MeshFile", m_sMeshFile)->AddAttributes(new ezFileBrowserAttribute("Select Mesh", ezFileBrowserAttribute::Meshes)),
+    EZ_MEMBER_PROPERTY("MeshIncludeTags", m_sMeshIncludeTags),
+    EZ_MEMBER_PROPERTY("MeshExcludeTags", m_sMeshExcludeTags),
     EZ_ARRAY_MEMBER_PROPERTY("Surfaces", m_Slots)->AddAttributes(new ezContainerAttribute(false, false, true)),
     EZ_MEMBER_PROPERTY("Surface", m_sConvexMeshSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
 
@@ -77,6 +79,8 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
   props["Height"].m_Visibility = ezPropertyUiState::Invisible;
   props["Detail"].m_Visibility = ezPropertyUiState::Invisible;
   props["MeshFile"].m_Visibility = ezPropertyUiState::Invisible;
+  props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Invisible;
+  props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Invisible;
   props["ConvexMeshType"].m_Visibility = ezPropertyUiState::Invisible;
   props["MaxConvexPieces"].m_Visibility = ezPropertyUiState::Invisible;
   props["Surfaces"].m_Visibility = isConvex ? ezPropertyUiState::Invisible : ezPropertyUiState::Default;
@@ -95,6 +99,8 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
   if (!isConvex)
   {
     props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
+    props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
+    props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
   }
   else
   {
@@ -108,6 +114,8 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
 
       case ezJoltConvexCollisionMeshType::ConvexHull:
         props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
         break;
 
       case ezJoltConvexCollisionMeshType::Cylinder:

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
@@ -58,6 +58,8 @@ public:
   static void PropertyMetaStateEventHandler(ezPropertyMetaStateEvent& e);
 
   ezString m_sMeshFile;
+  ezString m_sMeshIncludeTags;
+  ezString m_sMeshExcludeTags;
   float m_fUniformScaling = 1.0f;
   ezString m_sConvexMeshSurface;
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeUserData.h
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeUserData.h
@@ -265,7 +265,7 @@ namespace
 
       auto pScriptableFunctionAttribute = pFunction->GetAttributeByType<ezScriptableFunctionAttribute>();
       if (pScriptableFunctionAttribute == nullptr)
-        EZ_FAILURE;
+        return EZ_FAILURE;
 
       ezUInt32 uiInputArgsMask = 0;
       ezUInt32 uiOutputArgsMask = 0;

--- a/Code/Tools/Libs/ModelImporter2/Importer/Importer.h
+++ b/Code/Tools/Libs/ModelImporter2/Importer/Importer.h
@@ -28,6 +28,11 @@ namespace ezModelImporter2
     bool m_bNormalizeWeights = false;
     ezMat3 m_RootTransform = ezMat3::MakeIdentity();
 
+    // if non-empty, only import meshes whose names start or end with any of these strings
+    ezDynamicArray<ezString> m_MeshIncludeTags;
+    // if non-empty, do not import meshes whose names start or end with any of these strings (unless already explicitly included)
+    ezDynamicArray<ezString> m_MeshExcludeTags;
+
     ezMeshResourceDescriptor* m_pMeshOutput = nullptr;
     ezEnum<ezMeshNormalPrecision> m_MeshNormalsPrecision = ezMeshNormalPrecision::Default;
     ezEnum<ezMeshTexCoordPrecision> m_MeshTexCoordsPrecision = ezMeshTexCoordPrecision::Default;
@@ -105,6 +110,7 @@ namespace ezModelImporter2
     ezMap<ezString, OutputTexture> m_OutputTextures; // path -> additional data
     ezDeque<OutputMaterial> m_OutputMaterials;
     ezDynamicArray<ezString> m_OutputAnimationNames;
+    ezDynamicArray<ezString> m_OutputMeshNames;
 
   protected:
     virtual ezResult DoImport() = 0;

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/AssimpMeshImport.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/AssimpMeshImport.cpp
@@ -148,6 +148,40 @@ namespace ezModelImporter2
     if ((pMesh->mPrimitiveTypes & aiPrimitiveType::aiPrimitiveType_TRIANGLE) == 0) // no triangles in there ?
       return EZ_SUCCESS;
 
+    m_OutputMeshNames.PushBack(pMesh->mName.C_Str());
+
+    if (!m_Options.m_MeshIncludeTags.IsEmpty() || !m_Options.m_MeshExcludeTags.IsEmpty())
+    {
+      ezLog::Dev("Found mesh with name: '{}'", pMesh->mName.C_Str());
+    }
+
+    if (!m_Options.m_MeshIncludeTags.IsEmpty())
+    {
+      for (const auto& str : m_Options.m_MeshIncludeTags)
+      {
+        if (ezStringUtils::StartsWith_NoCase(pMesh->mName.C_Str(), str) || ezStringUtils::EndsWith_NoCase(pMesh->mName.C_Str(), str))
+        {
+          ezLog::Dev("Including mesh '{}' because of include-tag '{}'", pMesh->mName.C_Str(), str);
+          goto do_import;
+        }
+      }
+
+      ezLog::Dev("Skipping mesh '{}', because it doesn't match any include-tag.", pMesh->mName.C_Str());
+      return EZ_SUCCESS; // not a failure case
+    }
+
+    for (const auto& str : m_Options.m_MeshExcludeTags)
+    {
+      if (ezStringUtils::StartsWith_NoCase(pMesh->mName.C_Str(), str) || ezStringUtils::EndsWith_NoCase(pMesh->mName.C_Str(), str))
+      {
+        ezLog::Dev("Skipping mesh '{}' because of exclude-tag '{}'", pMesh->mName.C_Str(), str);
+        return EZ_SUCCESS; // not a failure case
+      }
+    }
+
+
+  do_import:
+
     if (m_Options.m_bImportSkinningData && !pMesh->HasBones())
     {
       ezLog::Warning("Mesh contains an unskinned part ('{}' - {} triangles)", pMesh->mName.C_Str(), pMesh->mNumFaces);

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
@@ -31,7 +31,7 @@ namespace ezModelImporter2
   class aiLogStreamInfo : public Assimp::LogStream
   {
   public:
-    void write(const char* szMessage) { ezLog::Dev("AssImp: {0}", szMessage); }
+    void write(const char* szMessage) { ezLog::Debug("AssImp: {0}", szMessage); }
   };
 
   ezResult ImporterAssimp::DoImport()


### PR DESCRIPTION
* Static meshes, animated meshes and collision meshes now support "include tags" and "exclude tags", which are semicolon separated lists of strings. If used, a mesh inside a GLTF / FBX file can be selectively chosen or ignored during import. This means you can pack LODs and colliders in one file and import them where needed.
* The mesh import dialog now has an option to automatically set up LODs by either taking the LOD sub-meshes from a file, or automatically generating them.

This is the new dialog:

![image](https://github.com/user-attachments/assets/90dca68d-c1b5-4fbe-aab6-ebc7d3cb823a)

If an asset contains a mesh named "$LOD1_xyz" then that will be used. If there are additional LODs ("$LOD2_xyz", "$LOD3_xyz", etc) they will also be configured for use.
If there are no such named meshes, the import will add 2 LODs by configuring the mesh simplification option. If that's not desired, just set this to 0.