### PR TITLE
Pipeline State Objects

### DIFF
--- a/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.inl
+++ b/Code/Engine/Foundation/Platform/Posix/OSFile_Posix.inl
@@ -374,10 +374,13 @@ ezString ezOSFile::GetUserDataFolder(ezStringView sSubFolder)
 {
   if (s_sUserDataPath.IsEmpty())
   {
-    s_sUserDataPath = getenv("HOME");
+    ezStringBuilder sTemp = getenv("HOME");
 
-    if (s_sUserDataPath.IsEmpty())
-      s_sUserDataPath = getpwuid(getuid())->pw_dir;
+    if (sTemp.IsEmpty())
+      sTemp = getpwuid(getuid())->pw_dir;
+
+    sTemp.AppendPath(".local", "share");
+    s_sUserDataPath = sTemp;
   }
 
   ezStringBuilder s = s_sUserDataPath;
@@ -394,7 +397,13 @@ ezString ezOSFile::GetTempDataFolder(ezStringView sSubFolder)
 {
   if (s_sTempDataPath.IsEmpty())
   {
-    s_sTempDataPath = GetUserDataFolder(".cache").GetData();
+    ezStringBuilder sTemp = getenv("HOME");
+
+    if (sTemp.IsEmpty())
+      sTemp = getpwuid(getuid())->pw_dir;
+
+    sTemp.AppendPath(".cache");
+    s_sTempDataPath = sTemp;
   }
 
   ezStringBuilder s = s_sTempDataPath;
@@ -411,10 +420,13 @@ ezString ezOSFile::GetUserDocumentsFolder(ezStringView sSubFolder)
 {
   if (s_sUserDocumentsPath.IsEmpty())
   {
-    s_sUserDataPath = getenv("HOME");
+    ezStringBuilder sTemp = getenv("HOME");
 
-    if (s_sUserDataPath.IsEmpty())
-      s_sUserDataPath = getpwuid(getuid())->pw_dir;
+    if (sTemp.IsEmpty())
+      sTemp = getpwuid(getuid())->pw_dir;
+
+    sTemp.AppendPath("Documents");
+    s_sUserDocumentsPath = sTemp;
   }
 
   ezStringBuilder s = s_sUserDocumentsPath;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -677,7 +677,7 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
   EZ_SCOPE_EXIT(if (pShaderPermutation != nullptr) { ezResourceManager::EndAcquireResource(pShaderPermutation); });
 
   bool bRebuildVertexDeclaration = m_StateFlags.IsAnySet(ezRenderContextFlags::ShaderStateChanged | ezRenderContextFlags::MeshBufferBindingChanged);
- 
+
   if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::ShaderStateChanged))
   {
     pShaderPermutation = ApplyShaderState();

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -18,6 +18,7 @@
 #include <RendererFoundation/Resources/Buffer.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/Texture.h>
+#include <RendererFoundation/State/PipelineCache.h>
 
 ezRenderContext* ezRenderContext::s_pDefaultInstance = nullptr;
 ezGALCommandEncoder* ezRenderContext::s_pCommandEncoder = nullptr;
@@ -125,7 +126,7 @@ ezRenderContext::ezRenderContext(ezGALCommandEncoder* pCommandEncoder)
   m_pGALCommandEncoder = pCommandEncoder;
 
   m_StateFlags = ezRenderContextFlags::AllStatesInvalid;
-  m_Topology = ezGALPrimitiveTopology::ENUM_COUNT; // Set to something invalid
+  m_GraphicsPipeline.m_Topology = ezGALPrimitiveTopology::ENUM_COUNT; // Set to something invalid
   m_uiMeshBufferPrimitiveCount = 0;
   m_DefaultTextureFilter = ezTextureFilterSetting::FixedAnisotropic4x;
   m_bAllowAsyncShaderLoading = false;
@@ -166,6 +167,8 @@ void ezRenderContext::BeginRendering(const ezGALRenderingSetup& renderingSetup, 
 {
   EZ_ASSERT_DEBUG(m_bRendering == false && m_bCompute == false, "Already in a scope");
   m_bRendering = true;
+  m_GraphicsPipeline.m_RenderPass = renderingSetup.GetRenderPass();
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
   const ezGALMSAASampleCount::Enum msaaSampleCount = renderingSetup.GetRenderPass().m_Msaa;
   if (msaaSampleCount != ezGALMSAASampleCount::None)
   {
@@ -204,12 +207,14 @@ void ezRenderContext::BeginCompute(const char* szName /*= ""*/)
   EZ_ASSERT_DEBUG(m_bRendering == false && m_bCompute == false, "Already in a scope");
   m_pGALCommandEncoder->BeginCompute(szName);
   m_bCompute = true;
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
 }
 
 void ezRenderContext::EndCompute()
 {
   m_pGALCommandEncoder->EndCompute();
   m_bCompute = false;
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
   // TODO: See EndRendering
   // ResetContextState();
 }
@@ -487,6 +492,24 @@ void ezRenderContext::BindShader(const ezShaderResourceHandle& hShader, ezBitfla
   BindShaderInternal(hShader, flags);
 }
 
+void ezRenderContext::SetBlendState(ezGALBlendStateHandle hBlendState)
+{
+  m_GraphicsPipeline.m_hBlendState = hBlendState;
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
+}
+
+void ezRenderContext::SetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState)
+{
+  m_GraphicsPipeline.m_hDepthStencilState = hDepthStencilState;
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
+}
+
+void ezRenderContext::SetRasterizerState(ezGALRasterizerStateHandle hRasterizerState)
+{
+  m_GraphicsPipeline.m_hRasterizerState = hRasterizerState;
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
+}
+
 void ezRenderContext::BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuffer)
 {
   ezResourceLock<ezMeshBufferResource> pMeshBuffer(hMeshBuffer, ezResourceAcquireMode::AllowLoadingFallback);
@@ -497,7 +520,7 @@ void ezRenderContext::BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuff
 void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBufferHandle hIndexBuffer,
   const ezVertexDeclarationInfo* pVertexDeclarationInfo, ezGALPrimitiveTopology::Enum topology, ezUInt32 uiPrimitiveCount, ezGALBufferHandle hVertexBuffer2, ezGALBufferHandle hVertexBuffer3, ezGALBufferHandle hVertexBuffer4)
 {
-  if (m_hVertexBuffers[0] == hVertexBuffer && m_hVertexBuffers[1] == hVertexBuffer2 && m_hVertexBuffers[2] == hVertexBuffer3 && m_hVertexBuffers[3] == hVertexBuffer4 && m_hIndexBuffer == hIndexBuffer && m_pVertexDeclarationInfo == pVertexDeclarationInfo && m_Topology == topology && m_uiMeshBufferPrimitiveCount == uiPrimitiveCount)
+  if (m_hVertexBuffers[0] == hVertexBuffer && m_hVertexBuffers[1] == hVertexBuffer2 && m_hVertexBuffers[2] == hVertexBuffer3 && m_hVertexBuffers[3] == hVertexBuffer4 && m_hIndexBuffer == hIndexBuffer && m_pVertexDeclarationInfo == pVertexDeclarationInfo && m_GraphicsPipeline.m_Topology == topology && m_uiMeshBufferPrimitiveCount == uiPrimitiveCount)
   {
     return;
   }
@@ -519,9 +542,10 @@ void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBuffe
   }
 #endif
 
-  if (m_Topology != topology)
+  if (m_GraphicsPipeline.m_Topology != topology)
   {
-    m_Topology = topology;
+    m_GraphicsPipeline.m_Topology = topology;
+    m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
 
     ezTempHashedString sTopologies[] = {
       ezTempHashedString("TOPOLOGY_POINTS"),
@@ -532,7 +556,7 @@ void ezRenderContext::BindMeshBuffer(ezGALBufferHandle hVertexBuffer, ezGALBuffe
 
     static_assert(EZ_ARRAY_SIZE(sTopologies) == ezGALPrimitiveTopology::ENUM_COUNT);
 
-    SetShaderPermutationVariable("TOPOLOGY", sTopologies[m_Topology]);
+    SetShaderPermutationVariable("TOPOLOGY", sTopologies[m_GraphicsPipeline.m_Topology]);
   }
 
   m_hVertexBuffers[0] = hVertexBuffer;
@@ -595,8 +619,8 @@ ezResult ezRenderContext::DrawMeshBuffer(ezUInt32 uiPrimitiveCount, ezUInt32 uiF
 
   auto pCommandEncoder = GetCommandEncoder();
 
-  const ezUInt32 uiIndexCount = ezGALPrimitiveTopology::GetIndexCount(pCommandEncoder->GetPrimitiveTopology(), uiPrimitiveCount);
-  const ezUInt32 uiFirstIndex = ezGALPrimitiveTopology::GetIndexCount(pCommandEncoder->GetPrimitiveTopology(), uiFirstPrimitive);
+  const ezUInt32 uiIndexCount = ezGALPrimitiveTopology::GetIndexCount(m_GraphicsPipeline.m_Topology, uiPrimitiveCount);
+  const ezUInt32 uiFirstIndex = ezGALPrimitiveTopology::GetIndexCount(m_GraphicsPipeline.m_Topology, uiFirstPrimitive);
 
   if (m_bStereoRendering)
   {
@@ -653,11 +677,10 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
   EZ_SCOPE_EXIT(if (pShaderPermutation != nullptr) { ezResourceManager::EndAcquireResource(pShaderPermutation); });
 
   bool bRebuildVertexDeclaration = m_StateFlags.IsAnySet(ezRenderContextFlags::ShaderStateChanged | ezRenderContextFlags::MeshBufferBindingChanged);
-
+ 
   if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::ShaderStateChanged))
   {
     pShaderPermutation = ApplyShaderState();
-
     if (pShaderPermutation == nullptr)
     {
       return EZ_FAILURE;
@@ -686,6 +709,7 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
       // #TODO_SHADER It's a bit unclean that we need to acquire the GAL shader on this level. Unfortunately, we need the resource binding on both the GAL and the high level renderer and the only alternative is some kind of duplication of the data.
       pShader = ezGALDevice::GetDefaultDevice()->GetShader(m_hActiveGALShader);
     }
+
 
     ezLogBlock applyBindingsBlock("Applying Shader Bindings", pShaderPermutation ? pShaderPermutation->GetResourceDescription().GetData() : "");
     UploadConstants();
@@ -732,8 +756,6 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
 
     if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::MeshBufferBindingChanged))
     {
-      pCommandEncoder->SetPrimitiveTopology(m_Topology);
-
       for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hVertexBuffers); ++i)
       {
         pCommandEncoder->SetVertexBuffer(i, m_hVertexBuffers[i], m_VertexBufferOffsets[i]);
@@ -752,9 +774,18 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
     if ((!m_hVertexBuffers[0].IsInvalidated() || !m_hVertexBuffers[1].IsInvalidated() || !m_hVertexBuffers[2].IsInvalidated() || !m_hVertexBuffers[3].IsInvalidated()) && hVertexDeclaration.IsInvalidated())
       return EZ_FAILURE;
 
-    pCommandEncoder->SetVertexDeclaration(hVertexDeclaration);
+    m_GraphicsPipeline.m_hVertexDeclaration = hVertexDeclaration;
+    m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
 
     m_StateFlags.Remove(ezRenderContextFlags::MeshBufferBindingChanged);
+  }
+
+  if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::PipelineChanged))
+  {
+    if (m_bRendering)
+      m_pGALCommandEncoder->SetGraphicsPipeline(ezGALPipelineCache::GetPipeline(m_GraphicsPipeline));
+    else if (m_bCompute)
+      m_pGALCommandEncoder->SetComputePipeline(ezGALPipelineCache::GetPipeline(m_ComputePipeline));
   }
 
   return EZ_SUCCESS;
@@ -785,7 +816,7 @@ void ezRenderContext::ResetContextState()
   m_CustomVertexStreams.m_uiHash = 0;
   m_hIndexBuffer.Invalidate();
   m_pVertexDeclarationInfo = nullptr;
-  m_Topology = ezGALPrimitiveTopology::ENUM_COUNT; // Set to something invalid
+  m_GraphicsPipeline.m_Topology = ezGALPrimitiveTopology::ENUM_COUNT; // Set to something invalid
   m_uiMeshBufferPrimitiveCount = 0;
 
   m_BoundTextures2D.Clear();
@@ -1167,8 +1198,7 @@ ezShaderPermutationResource* ezRenderContext::ApplyShaderState()
 {
   m_hActiveGALShader.Invalidate();
 
-  m_StateFlags.Add(ezRenderContextFlags::TextureBindingChanged | ezRenderContextFlags::SamplerBindingChanged |
-                   ezRenderContextFlags::BufferBindingChanged | ezRenderContextFlags::ConstantBufferBindingChanged);
+  m_StateFlags.Add(ezRenderContextFlags::TextureBindingChanged | ezRenderContextFlags::SamplerBindingChanged | ezRenderContextFlags::BufferBindingChanged | ezRenderContextFlags::ConstantBufferBindingChanged | ezRenderContextFlags::PipelineChanged);
 
   if (!m_hActiveShader.IsValid())
     return nullptr;
@@ -1188,23 +1218,21 @@ ezShaderPermutationResource* ezRenderContext::ApplyShaderState()
   }
 
   m_hActiveGALShader = pShaderPermutation->GetGALShader();
+  m_GraphicsPipeline.m_hShader = m_hActiveGALShader;
+  m_ComputePipeline.m_hShader = m_hActiveGALShader;
   EZ_ASSERT_DEV(!m_hActiveGALShader.IsInvalidated(), "Invalid GAL Shader handle.");
-
-  m_pGALCommandEncoder->SetShader(m_hActiveGALShader);
 
   // Set render state from shader
   if (!m_bCompute)
   {
-    auto pCommandEncoder = GetCommandEncoder();
-
     if (!m_ShaderBindFlags.IsSet(ezShaderBindFlags::NoBlendState))
-      pCommandEncoder->SetBlendState(pShaderPermutation->GetBlendState());
+      m_GraphicsPipeline.m_hBlendState = pShaderPermutation->GetBlendState();
 
     if (!m_ShaderBindFlags.IsSet(ezShaderBindFlags::NoRasterizerState))
-      pCommandEncoder->SetRasterizerState(pShaderPermutation->GetRasterizerState());
+      m_GraphicsPipeline.m_hRasterizerState = pShaderPermutation->GetRasterizerState();
 
     if (!m_ShaderBindFlags.IsSet(ezShaderBindFlags::NoDepthStencilState))
-      pCommandEncoder->SetDepthStencilState(pShaderPermutation->GetDepthStencilState());
+      m_GraphicsPipeline.m_hDepthStencilState = pShaderPermutation->GetDepthStencilState();
   }
 
   return pShaderPermutation;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
@@ -57,9 +57,9 @@ struct EZ_RENDERERCORE_DLL ezRenderContextFlags
     ConstantBufferBindingChanged = EZ_BIT(5),
     MeshBufferBindingChanged = EZ_BIT(6),
     MaterialBindingChanged = EZ_BIT(7),
+    PipelineChanged = EZ_BIT(8),
 
-    AllStatesInvalid = ShaderStateChanged | TextureBindingChanged | UAVBindingChanged | SamplerBindingChanged | BufferBindingChanged |
-                       ConstantBufferBindingChanged | MeshBufferBindingChanged,
+    AllStatesInvalid = ShaderStateChanged | TextureBindingChanged | UAVBindingChanged | SamplerBindingChanged | BufferBindingChanged | ConstantBufferBindingChanged | MeshBufferBindingChanged | PipelineChanged,
     Default = None
   };
 
@@ -73,6 +73,7 @@ struct EZ_RENDERERCORE_DLL ezRenderContextFlags
     StorageType ConstantBufferBindingChanged : 1;
     StorageType MeshBufferBindingChanged : 1;
     StorageType MaterialBindingChanged : 1;
+    StorageType PipelineChanged : 1;
   };
 };
 

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -178,6 +178,9 @@ public:
   ///
   /// This function has no effect until the next draw or dispatch call on the context.
   void BindShader(const ezShaderResourceHandle& hShader, ezBitflags<ezShaderBindFlags> flags = ezShaderBindFlags::Default);
+  void SetBlendState(ezGALBlendStateHandle hBlendState);
+  void SetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState);
+  void SetRasterizerState(ezGALRasterizerStateHandle hRasterizerState);
 
   void BindMeshBuffer(const ezDynamicMeshBufferResourceHandle& hDynamicMeshBuffer);
   void BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuffer);
@@ -306,11 +309,14 @@ private:
   ezVertexDeclarationInfo m_CustomVertexStreams;
   ezGALBufferHandle m_hIndexBuffer;
   const ezVertexDeclarationInfo* m_pVertexDeclarationInfo;
-  ezGALPrimitiveTopology::Enum m_Topology;
+
   ezUInt32 m_uiMeshBufferPrimitiveCount;
   ezEnum<ezTextureFilterSetting> m_DefaultTextureFilter;
   bool m_bAllowAsyncShaderLoading;
   bool m_bStereoRendering = false;
+
+  ezGALGraphicsPipelineCreationDescription m_GraphicsPipeline;
+  ezGALComputePipelineCreationDescription m_ComputePipeline;
 
   ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTextures2D;
   ezHashTable<ezUInt64, ezGALTextureResourceViewHandle> m_BoundTextures3D;

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderCompiler.cpp
@@ -315,12 +315,16 @@ ezResult ezShaderCompiler::CompileShaderPermutationForPlatforms(ezStringView sFi
       {
         // We need to fill teh template not only with the section content but also the starting line and filename to get correct line numbers for all compile failures.
         sTemp.AppendFormat(sMaterialConstantsTemplate, uiFirstMaterialConstantsLine, m_StageSourceFile[stage], sMaterialConstantsSource);
+        if (!sTemp.EndsWith_NoCase("\n"))
+          sTemp.Append("\n");
       }
 
       // prepend common shader section if there is any
       if (!sShaderSource.IsEmpty())
       {
         sTemp.AppendFormat("#line {0}\n{1}", uiFirstShaderLine, sShaderSource);
+        if (!sTemp.EndsWith_NoCase("\n"))
+          sTemp.Append("\n");
       }
 
       sTemp.AppendFormat("#line {0}\n{1}", uiFirstLine, sStageSource);

--- a/Code/Engine/RendererCore/Textures/Texture2DResource.h
+++ b/Code/Engine/RendererCore/Textures/Texture2DResource.h
@@ -81,7 +81,7 @@ struct EZ_RENDERERCORE_DLL ezRenderToTexture2DResourceDescriptor
   ezUInt32 m_uiWidth = 0;
   ezUInt32 m_uiHeight = 0;
   ezEnum<ezGALMSAASampleCount> m_SampleCount;
-  ezEnum<ezGALResourceFormat> m_Format;
+  ezEnum<ezGALResourceFormat> m_Format = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
   ezGALSamplerStateCreationDescription m_SamplerDesc;
   ezArrayPtr<ezGALSystemMemoryDescription> m_InitialContent;
 };

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -30,8 +30,6 @@ public:
   // ezGALCommandEncoderCommonPlatformInterface
   // State setting functions
 
-  void SetShaderPlatform(const ezGALShader* pShader);
-
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) override;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
   virtual void SetResourceViewPlatform(const ezShaderResourceBinding& binding, const ezGALTextureResourceView* pResourceView) override;
@@ -116,18 +114,18 @@ public:
   virtual void SetGraphicsPipelinePlatform(const ezGALGraphicsPipeline* pGraphicsPipeline) override;
   virtual void SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline) override;
 
-  void SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration);
-  void SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum topology);
-  void SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& blendFactor = ezColor::White, ezUInt32 uiSampleMask = 0xFFFFFFFFu);
-  void SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState);
-  void SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState);
-
   virtual void SetViewportPlatform(const ezRectFloat& rect, float fMinDepth, float fMaxDepth) override;
   virtual void SetScissorRectPlatform(const ezRectU32& rect) override;
   virtual void SetStencilReferencePlatform(ezUInt8 uiStencilRefValue) override;
 
 private:
   friend class ezGALDeviceDX11;
+  void SetShader(const ezGALShader* pShader);
+  void SetVertexDeclaration(const ezGALVertexDeclaration* pVertexDeclaration);
+  void SetPrimitiveTopology(ezGALPrimitiveTopology::Enum topology);
+  void SetBlendState(const ezGALBlendState* pBlendState, const ezColor& blendFactor = ezColor::White, ezUInt32 uiSampleMask = 0xFFFFFFFFu);
+  void SetDepthStencilState(const ezGALDepthStencilState* pDepthStencilState);
+  void SetRasterizerState(const ezGALRasterizerState* pRasterizerState);
 
   bool UnsetResourceViews(const ezGALResourceBase* pResource);
   bool UnsetUnorderedAccessViews(const ezGALResourceBase* pResource);

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -30,7 +30,7 @@ public:
   // ezGALCommandEncoderCommonPlatformInterface
   // State setting functions
 
-  virtual void SetShaderPlatform(const ezGALShader* pShader) override;
+  void SetShaderPlatform(const ezGALShader* pShader);
 
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) override;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
@@ -112,15 +112,19 @@ public:
 
   virtual void SetIndexBufferPlatform(const ezGALBuffer* pIndexBuffer) override;
   virtual void SetVertexBufferPlatform(ezUInt32 uiSlot, const ezGALBuffer* pVertexBuffer, ezUInt32 uiOffset) override;
-  virtual void SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration) override;
-  virtual void SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum topology) override;
 
-  virtual void SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& blendFactor, ezUInt32 uiSampleMask) override;
-  virtual void SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState, ezUInt8 uiStencilRefValue) override;
-  virtual void SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState) override;
+  virtual void SetGraphicsPipelinePlatform(const ezGALGraphicsPipeline* pGraphicsPipeline) override;
+  virtual void SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline) override;
+
+  void SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration);
+  void SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum topology);
+  void SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& blendFactor = ezColor::White, ezUInt32 uiSampleMask = 0xFFFFFFFFu);
+  void SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState);
+  void SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState);
 
   virtual void SetViewportPlatform(const ezRectFloat& rect, float fMinDepth, float fMaxDepth) override;
   virtual void SetScissorRectPlatform(const ezRectU32& rect) override;
+  virtual void SetStencilReferencePlatform(ezUInt8 uiStencilRefValue) override;
 
 private:
   friend class ezGALDeviceDX11;
@@ -153,6 +157,7 @@ private:
   ezGAL::ModifiedRange m_BoundSamplerStatesRange[ezGALShaderStage::ENUM_COUNT];
 
   ID3D11DeviceChild* m_pBoundShaders[ezGALShaderStage::ENUM_COUNT] = {};
+  ezUInt8 m_uiStencilRefValue = 0xFFu;
 
   ezGALRenderingSetup m_RenderTargetSetup;
   ID3D11RenderTargetView* m_pBoundRenderTargets[EZ_GAL_MAX_RENDERTARGET_COUNT] = {};

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -14,6 +14,8 @@
 #include <RendererDX11/Resources/UnorderedAccessViewDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
+#include <RendererDX11/State/ComputePipelineDX11.h>
+#include <RendererDX11/State/GraphicsPipelineDX11.h>
 #include <RendererDX11/State/StateDX11.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 
@@ -716,6 +718,47 @@ void ezGALCommandEncoderImplDX11::SetVertexBufferPlatform(ezUInt32 uiSlot, const
   m_BoundVertexBuffersRange.SetToIncludeValue(uiSlot);
 }
 
+void ezGALCommandEncoderImplDX11::SetGraphicsPipelinePlatform(const ezGALGraphicsPipeline* pGraphicsPipeline)
+{
+  const ezGALShader* pShader = nullptr;
+  const ezGALVertexDeclaration* pVertexDeclaration = nullptr;
+  const ezGALRasterizerState* pRasterizerState = nullptr;
+  const ezGALBlendState* pBlendState = nullptr;
+  const ezGALDepthStencilState* pDepthStencilState = nullptr;
+
+  if (pGraphicsPipeline)
+  {
+    const ezGALGraphicsPipelineCreationDescription& desc = pGraphicsPipeline->GetDescription();
+    pShader = m_GALDeviceDX11.GetShader(desc.m_hShader);
+    EZ_ASSERT_DEBUG(pShader->GetDescription().m_ByteCodes[ezGALShaderStage::ComputeShader] == nullptr, "");
+    pVertexDeclaration = m_GALDeviceDX11.GetVertexDeclaration(desc.m_hVertexDeclaration);
+    pRasterizerState = m_GALDeviceDX11.GetRasterizerState(desc.m_hRasterizerState);
+    pBlendState = m_GALDeviceDX11.GetBlendState(desc.m_hBlendState);
+    pDepthStencilState = m_GALDeviceDX11.GetDepthStencilState(desc.m_hDepthStencilState);
+    SetPrimitiveTopologyPlatform(desc.m_Topology);
+  }
+
+  SetShaderPlatform(pShader);
+  SetVertexDeclarationPlatform(pVertexDeclaration);
+  SetRasterizerStatePlatform(pRasterizerState);
+  SetBlendStatePlatform(pBlendState);
+  SetDepthStencilStatePlatform(pDepthStencilState);
+}
+
+void ezGALCommandEncoderImplDX11::SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline)
+{
+  const ezGALShader* pShader = nullptr;
+
+  if (pComputePipeline)
+  {
+    const ezGALComputePipelineCreationDescription& desc = pComputePipeline->GetDescription();
+    pShader = m_GALDeviceDX11.GetShader(desc.m_hShader);
+    EZ_ASSERT_DEBUG(pShader->GetDescription().m_ByteCodes[ezGALShaderStage::ComputeShader] != nullptr, "");
+  }
+
+  SetShaderPlatform(pShader);
+}
+
 void ezGALCommandEncoderImplDX11::SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration)
 {
   ezMemoryUtils::ZeroFill(m_VertexBufferStrides, EZ_ARRAY_SIZE(m_VertexBufferStrides));
@@ -759,11 +802,10 @@ void ezGALCommandEncoderImplDX11::SetBlendStatePlatform(const ezGALBlendState* p
     pBlendState != nullptr ? static_cast<const ezGALBlendStateDX11*>(pBlendState)->GetDXBlendState() : nullptr, BlendFactors, uiSampleMask);
 }
 
-void ezGALCommandEncoderImplDX11::SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState, ezUInt8 uiStencilRefValue)
+void ezGALCommandEncoderImplDX11::SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState)
 {
-  m_pDXContext->OMSetDepthStencilState(
-    pDepthStencilState != nullptr ? static_cast<const ezGALDepthStencilStateDX11*>(pDepthStencilState)->GetDXDepthStencilState() : nullptr,
-    uiStencilRefValue);
+  ID3D11DepthStencilState* pDepthStencilStateDX11 = pDepthStencilState != nullptr ? static_cast<const ezGALDepthStencilStateDX11*>(pDepthStencilState)->GetDXDepthStencilState() : nullptr;
+  m_pDXContext->OMSetDepthStencilState(pDepthStencilStateDX11, m_uiStencilRefValue);
 }
 
 void ezGALCommandEncoderImplDX11::SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState)
@@ -793,6 +835,17 @@ void ezGALCommandEncoderImplDX11::SetScissorRectPlatform(const ezRectU32& rect)
   ScissorRect.bottom = rect.y + rect.height;
 
   m_pDXContext->RSSetScissorRects(1, &ScissorRect);
+}
+
+void ezGALCommandEncoderImplDX11::SetStencilReferencePlatform(ezUInt8 uiStencilRefValue)
+{
+  if (m_uiStencilRefValue == uiStencilRefValue)
+    return;
+
+  m_uiStencilRefValue = uiStencilRefValue;
+  ID3D11DepthStencilState* pState = nullptr;
+  m_pDXContext->OMGetDepthStencilState(&pState, nullptr);
+  m_pDXContext->OMSetDepthStencilState(pState, m_uiStencilRefValue);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -45,7 +45,7 @@ void ezGALCommandEncoderImplDX11::EndFrame()
 
 // State setting functions
 
-void ezGALCommandEncoderImplDX11::SetShaderPlatform(const ezGALShader* pShader)
+void ezGALCommandEncoderImplDX11::SetShader(const ezGALShader* pShader)
 {
   m_uiTessellationPatchControlPoints = 0;
   ID3D11VertexShader* pVS = nullptr;
@@ -735,14 +735,14 @@ void ezGALCommandEncoderImplDX11::SetGraphicsPipelinePlatform(const ezGALGraphic
     pRasterizerState = m_GALDeviceDX11.GetRasterizerState(desc.m_hRasterizerState);
     pBlendState = m_GALDeviceDX11.GetBlendState(desc.m_hBlendState);
     pDepthStencilState = m_GALDeviceDX11.GetDepthStencilState(desc.m_hDepthStencilState);
-    SetPrimitiveTopologyPlatform(desc.m_Topology);
+    SetPrimitiveTopology(desc.m_Topology);
   }
 
-  SetShaderPlatform(pShader);
-  SetVertexDeclarationPlatform(pVertexDeclaration);
-  SetRasterizerStatePlatform(pRasterizerState);
-  SetBlendStatePlatform(pBlendState);
-  SetDepthStencilStatePlatform(pDepthStencilState);
+  SetShader(pShader);
+  SetVertexDeclaration(pVertexDeclaration);
+  SetRasterizerState(pRasterizerState);
+  SetBlendState(pBlendState);
+  SetDepthStencilState(pDepthStencilState);
 }
 
 void ezGALCommandEncoderImplDX11::SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline)
@@ -756,10 +756,10 @@ void ezGALCommandEncoderImplDX11::SetComputePipelinePlatform(const ezGALComputeP
     EZ_ASSERT_DEBUG(pShader->GetDescription().m_ByteCodes[ezGALShaderStage::ComputeShader] != nullptr, "");
   }
 
-  SetShaderPlatform(pShader);
+  SetShader(pShader);
 }
 
-void ezGALCommandEncoderImplDX11::SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration)
+void ezGALCommandEncoderImplDX11::SetVertexDeclaration(const ezGALVertexDeclaration* pVertexDeclaration)
 {
   ezMemoryUtils::ZeroFill(m_VertexBufferStrides, EZ_ARRAY_SIZE(m_VertexBufferStrides));
   auto pVertexDeclarationDX11 = static_cast<const ezGALVertexDeclarationDX11*>(pVertexDeclaration);
@@ -789,12 +789,12 @@ static const D3D11_PRIMITIVE_TOPOLOGY GALTopologyToDX11[] = {
 
 static_assert(EZ_ARRAY_SIZE(GALTopologyToDX11) == ezGALPrimitiveTopology::ENUM_COUNT);
 
-void ezGALCommandEncoderImplDX11::SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum topology)
+void ezGALCommandEncoderImplDX11::SetPrimitiveTopology(ezGALPrimitiveTopology::Enum topology)
 {
   m_Topology = topology;
 }
 
-void ezGALCommandEncoderImplDX11::SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& blendFactor, ezUInt32 uiSampleMask)
+void ezGALCommandEncoderImplDX11::SetBlendState(const ezGALBlendState* pBlendState, const ezColor& blendFactor, ezUInt32 uiSampleMask)
 {
   FLOAT BlendFactors[4] = {blendFactor.r, blendFactor.g, blendFactor.b, blendFactor.a};
 
@@ -802,13 +802,13 @@ void ezGALCommandEncoderImplDX11::SetBlendStatePlatform(const ezGALBlendState* p
     pBlendState != nullptr ? static_cast<const ezGALBlendStateDX11*>(pBlendState)->GetDXBlendState() : nullptr, BlendFactors, uiSampleMask);
 }
 
-void ezGALCommandEncoderImplDX11::SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState)
+void ezGALCommandEncoderImplDX11::SetDepthStencilState(const ezGALDepthStencilState* pDepthStencilState)
 {
   ID3D11DepthStencilState* pDepthStencilStateDX11 = pDepthStencilState != nullptr ? static_cast<const ezGALDepthStencilStateDX11*>(pDepthStencilState)->GetDXDepthStencilState() : nullptr;
   m_pDXContext->OMSetDepthStencilState(pDepthStencilStateDX11, m_uiStencilRefValue);
 }
 
-void ezGALCommandEncoderImplDX11::SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState)
+void ezGALCommandEncoderImplDX11::SetRasterizerState(const ezGALRasterizerState* pRasterizerState)
 {
   m_pDXContext->RSSetState(pRasterizerState != nullptr ? static_cast<const ezGALRasterizerStateDX11*>(pRasterizerState)->GetDXRasterizerState() : nullptr);
 }

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -90,6 +90,12 @@ protected:
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) override;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
 
+  virtual ezGALGraphicsPipeline* CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description) override;
+  virtual void DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline) override;
+
+  virtual ezGALComputePipeline* CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description) override;
+  virtual void DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline) override;
+  
 
   // Resource creation functions
 

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -95,7 +95,7 @@ protected:
 
   virtual ezGALComputePipeline* CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description) override;
   virtual void DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline) override;
-  
+
 
   // Resource creation functions
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -17,11 +17,11 @@
 #include <RendererDX11/Resources/ResourceViewDX11.h>
 #include <RendererDX11/Resources/SharedTextureDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
-#include <RendererDX11/State/GraphicsPipelineDX11.h>
-#include <RendererDX11/State/ComputePipelineDX11.h>
 #include <RendererDX11/Resources/UnorderedAccessViewDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
+#include <RendererDX11/State/ComputePipelineDX11.h>
+#include <RendererDX11/State/GraphicsPipelineDX11.h>
 #include <RendererDX11/State/StateDX11.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/DeviceFactory.h>

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -17,6 +17,8 @@
 #include <RendererDX11/Resources/ResourceViewDX11.h>
 #include <RendererDX11/Resources/SharedTextureDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
+#include <RendererDX11/State/GraphicsPipelineDX11.h>
+#include <RendererDX11/State/ComputePipelineDX11.h>
 #include <RendererDX11/Resources/UnorderedAccessViewDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
@@ -443,6 +445,49 @@ void ezGALDeviceDX11::DestroySamplerStatePlatform(ezGALSamplerState* pSamplerSta
   EZ_DELETE(&m_Allocator, pDX11SamplerState);
 }
 
+ezGALGraphicsPipeline* ezGALDeviceDX11::CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description)
+{
+  ezGALGraphicsPipelineDX11* pGraphicsPipeline = EZ_NEW(&m_Allocator, ezGALGraphicsPipelineDX11, Description);
+
+  if (pGraphicsPipeline->InitPlatform(this).Succeeded())
+  {
+    return pGraphicsPipeline;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pGraphicsPipeline);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceDX11::DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline)
+{
+  ezGALGraphicsPipelineDX11* pGraphicsPipelineDX11 = static_cast<ezGALGraphicsPipelineDX11*>(pGraphicsPipeline);
+  pGraphicsPipelineDX11->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pGraphicsPipelineDX11);
+}
+
+ezGALComputePipeline* ezGALDeviceDX11::CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description)
+{
+  ezGALComputePipelineDX11* pComputePipeline = EZ_NEW(&m_Allocator, ezGALComputePipelineDX11, Description);
+
+  if (pComputePipeline->InitPlatform(this).Succeeded())
+  {
+    return pComputePipeline;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pComputePipeline);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceDX11::DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline)
+{
+  ezGALComputePipelineDX11* pComputePipelineDX11 = static_cast<ezGALComputePipelineDX11*>(pComputePipeline);
+  pComputePipelineDX11->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pComputePipelineDX11);
+}
 
 // Resource creation functions
 

--- a/Code/Engine/RendererDX11/State/ComputePipelineDX11.h
+++ b/Code/Engine/RendererDX11/State/ComputePipelineDX11.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Foundation/Basics.h>
-#include <RendererFoundation/State/ComputePipeline.h>
 #include <RendererDX11/RendererDX11DLL.h>
+#include <RendererFoundation/State/ComputePipeline.h>
 
 class ezGALDeviceDX11;
 
@@ -17,5 +17,4 @@ public:
   virtual void SetDebugName(const char* szName) override;
 
 private:
-
 };

--- a/Code/Engine/RendererDX11/State/ComputePipelineDX11.h
+++ b/Code/Engine/RendererDX11/State/ComputePipelineDX11.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <RendererFoundation/State/ComputePipeline.h>
+#include <RendererDX11/RendererDX11DLL.h>
+
+class ezGALDeviceDX11;
+
+class EZ_RENDERERDX11_DLL ezGALComputePipelineDX11 : public ezGALComputePipeline
+{
+public:
+  ezGALComputePipelineDX11(const ezGALComputePipelineCreationDescription& description);
+  ~ezGALComputePipelineDX11();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void SetDebugName(const char* szName) override;
+
+private:
+
+};

--- a/Code/Engine/RendererDX11/State/GraphicsPipelineDX11.h
+++ b/Code/Engine/RendererDX11/State/GraphicsPipelineDX11.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererDX11/RendererDX11DLL.h>
+
+class ezGALDeviceDX11;
+
+class EZ_RENDERERDX11_DLL ezGALGraphicsPipelineDX11 : public ezGALGraphicsPipeline
+{
+public:
+  ezGALGraphicsPipelineDX11(const ezGALGraphicsPipelineCreationDescription& description);
+  ~ezGALGraphicsPipelineDX11();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void SetDebugName(const char* szName) override;
+
+private:
+
+};

--- a/Code/Engine/RendererDX11/State/GraphicsPipelineDX11.h
+++ b/Code/Engine/RendererDX11/State/GraphicsPipelineDX11.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Foundation/Basics.h>
-#include <RendererFoundation/State/GraphicsPipeline.h>
 #include <RendererDX11/RendererDX11DLL.h>
+#include <RendererFoundation/State/GraphicsPipeline.h>
 
 class ezGALDeviceDX11;
 
@@ -17,5 +17,4 @@ public:
   virtual void SetDebugName(const char* szName) override;
 
 private:
-
 };

--- a/Code/Engine/RendererDX11/State/Implementation/ComputePipelineDX11.cpp
+++ b/Code/Engine/RendererDX11/State/Implementation/ComputePipelineDX11.cpp
@@ -1,0 +1,28 @@
+#include <RendererDX11/RendererDX11PCH.h>
+
+#include <RendererDX11/Device/DeviceDX11.h>
+#include <RendererDX11/Shader/ShaderDX11.h>
+#include <RendererDX11/State/ComputePipelineDX11.h>
+
+ezGALComputePipelineDX11::ezGALComputePipelineDX11(const ezGALComputePipelineCreationDescription& description)
+  : ezGALComputePipeline(description)
+{
+}
+
+ezGALComputePipelineDX11::~ezGALComputePipelineDX11() = default;
+
+ezResult ezGALComputePipelineDX11::InitPlatform(ezGALDevice* pDevice)
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALComputePipelineDX11::DeInitPlatform(ezGALDevice* pDevice)
+{
+  EZ_IGNORE_UNUSED(pDevice);
+  return EZ_SUCCESS;
+}
+
+void ezGALComputePipelineDX11::SetDebugName(const char* szName)
+{
+  EZ_IGNORE_UNUSED(szName);
+}

--- a/Code/Engine/RendererDX11/State/Implementation/ComputePipelineDX11.cpp
+++ b/Code/Engine/RendererDX11/State/Implementation/ComputePipelineDX11.cpp
@@ -11,18 +11,16 @@ ezGALComputePipelineDX11::ezGALComputePipelineDX11(const ezGALComputePipelineCre
 
 ezGALComputePipelineDX11::~ezGALComputePipelineDX11() = default;
 
-ezResult ezGALComputePipelineDX11::InitPlatform(ezGALDevice* pDevice)
+ezResult ezGALComputePipelineDX11::InitPlatform(ezGALDevice*)
 {
   return EZ_SUCCESS;
 }
 
-ezResult ezGALComputePipelineDX11::DeInitPlatform(ezGALDevice* pDevice)
+ezResult ezGALComputePipelineDX11::DeInitPlatform(ezGALDevice*)
 {
-  EZ_IGNORE_UNUSED(pDevice);
   return EZ_SUCCESS;
 }
 
-void ezGALComputePipelineDX11::SetDebugName(const char* szName)
+void ezGALComputePipelineDX11::SetDebugName(const char*)
 {
-  EZ_IGNORE_UNUSED(szName);
 }

--- a/Code/Engine/RendererDX11/State/Implementation/GraphicsPipelineDX11.cpp
+++ b/Code/Engine/RendererDX11/State/Implementation/GraphicsPipelineDX11.cpp
@@ -1,0 +1,29 @@
+#include <RendererDX11/RendererDX11PCH.h>
+
+#include <RendererDX11/Device/DeviceDX11.h>
+#include <RendererDX11/Resources/RenderTargetViewDX11.h>
+#include <RendererDX11/Shader/ShaderDX11.h>
+#include <RendererDX11/Shader/VertexDeclarationDX11.h>
+#include <RendererDX11/State/GraphicsPipelineDX11.h>
+#include <RendererDX11/State/StateDX11.h>
+
+ezGALGraphicsPipelineDX11::ezGALGraphicsPipelineDX11(const ezGALGraphicsPipelineCreationDescription& description)
+  : ezGALGraphicsPipeline(description)
+{
+}
+
+ezGALGraphicsPipelineDX11::~ezGALGraphicsPipelineDX11() = default;
+
+ezResult ezGALGraphicsPipelineDX11::InitPlatform(ezGALDevice*)
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALGraphicsPipelineDX11::DeInitPlatform(ezGALDevice*)
+{
+  return EZ_SUCCESS;
+}
+
+void ezGALGraphicsPipelineDX11::SetDebugName(const char*)
+{
+}

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -18,8 +18,6 @@ public:
 
   // State setting functions
 
-  void SetShader(ezGALShaderHandle hShader);
-
   void SetConstantBuffer(const ezShaderResourceBinding& binding, ezGALBufferHandle hBuffer);
   void SetSamplerState(const ezShaderResourceBinding& binding, ezGALSamplerStateHandle hSamplerState);
   void SetResourceView(const ezShaderResourceBinding& binding, ezGALTextureResourceViewHandle hResourceView);
@@ -27,6 +25,7 @@ public:
   void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView);
   void SetUnorderedAccessView(const ezShaderResourceBinding& binding, ezGALBufferUnorderedAccessViewHandle hUnorderedAccessView);
   void SetPushConstants(ezArrayPtr<const ezUInt8> data);
+
 
   // GPU -> CPU query functions
 
@@ -53,7 +52,7 @@ public:
   /// \sa ezGALDevice::GetFenceResult
   ezGALFenceHandle InsertFence();
 
-  // Resource functions
+  // Update functions
 
   /// Clears an unordered access view with a float value.
   void ClearUnorderedAccessView(ezGALTextureUnorderedAccessViewHandle hUnorderedAccessView, ezVec4 vClearValues);
@@ -119,24 +118,19 @@ public:
   ezResult DrawInstanced(ezUInt32 uiVertexCountPerInstance, ezUInt32 uiInstanceCount, ezUInt32 uiStartVertex);
   ezResult DrawInstancedIndirect(ezGALBufferHandle hIndirectArgumentBuffer, ezUInt32 uiArgumentOffsetInBytes);
 
-  // State functions
-
+  // State Functions
   void SetIndexBuffer(ezGALBufferHandle hIndexBuffer);
   void SetVertexBuffer(ezUInt32 uiSlot, ezGALBufferHandle hVertexBuffer, ezUInt32 uiOffset = 0);
-  void SetVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration);
 
-  ezGALPrimitiveTopology::Enum GetPrimitiveTopology() const { return m_State.m_Topology; }
-  void SetPrimitiveTopology(ezGALPrimitiveTopology::Enum topology);
+  void SetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline);
+  void SetComputePipeline(ezGALComputePipelineHandle hComputePipeline);
 
-  void SetBlendState(ezGALBlendStateHandle hBlendState, const ezColor& blendFactor = ezColor::White, ezUInt32 uiSampleMask = 0xFFFFFFFFu);
-  void SetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState, ezUInt8 uiStencilRefValue = 0xFFu);
-  void SetRasterizerState(ezGALRasterizerStateHandle hRasterizerState);
-
+  // Dynamic State functions
   void SetViewport(const ezRectFloat& rect, float fMinDepth = 0.0f, float fMaxDepth = 1.0f);
   void SetScissorRect(const ezRectU32& rect);
+  void SetStencilReference(ezUInt8 uiStencilRefValue);
 
   // Internal
-
   EZ_ALWAYS_INLINE ezGALDevice& GetDevice() { return m_Device; }
   // Don't use light hearted ;)
   void InvalidateState();

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
@@ -12,9 +12,7 @@ struct ezGALRenderingSetup;
 class EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderCommonPlatformInterface
 {
 public:
-  // State setting functions
-
-  virtual void SetShaderPlatform(const ezGALShader* pShader) = 0;
+  // Resource binding functions
 
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) = 0;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) = 0;
@@ -71,6 +69,7 @@ public:
   virtual void BeginComputePlatform() = 0;
   virtual void EndComputePlatform() = 0;
 
+
   virtual ezResult DispatchPlatform(ezUInt32 uiThreadGroupCountX, ezUInt32 uiThreadGroupCountY, ezUInt32 uiThreadGroupCountZ) = 0;
   virtual ezResult DispatchIndirectPlatform(const ezGALBuffer* pIndirectArgumentBuffer, ezUInt32 uiArgumentOffsetInBytes) = 0;
 
@@ -92,13 +91,13 @@ public:
 
   virtual void SetIndexBufferPlatform(const ezGALBuffer* pIndexBuffer) = 0;
   virtual void SetVertexBufferPlatform(ezUInt32 uiSlot, const ezGALBuffer* pVertexBuffer, ezUInt32 uiOffset) = 0;
-  virtual void SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration) = 0;
-  virtual void SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum topology) = 0;
 
-  virtual void SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& blendFactor, ezUInt32 uiSampleMask) = 0;
-  virtual void SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState, ezUInt8 uiStencilRefValue) = 0;
-  virtual void SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState) = 0;
+  virtual void SetGraphicsPipelinePlatform(const ezGALGraphicsPipeline* pGraphicsPipeline) = 0;
+  virtual void SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline) = 0;
+
+  // Dynamic State Functions
 
   virtual void SetViewportPlatform(const ezRectFloat& rect, float fMinDepth, float fMaxDepth) = 0;
   virtual void SetScissorRectPlatform(const ezRectU32& rect) = 0;
+  virtual void SetStencilReferencePlatform(ezUInt8 uiStencilRefValue) = 0;
 };

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderState.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderState.h
@@ -9,22 +9,13 @@
 struct EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderRenderState final
 {
   void InvalidateState();
-  ezGALShaderHandle m_hShader;
   ezGALBufferHandle m_hVertexBuffers[EZ_GAL_MAX_VERTEX_BUFFER_COUNT];
   ezUInt32 m_hVertexBufferOffsets[EZ_GAL_MAX_VERTEX_BUFFER_COUNT] = {};
   ezGALBufferHandle m_hIndexBuffer;
 
-  ezGALVertexDeclarationHandle m_hVertexDeclaration;
-  ezGALPrimitiveTopology::Enum m_Topology = ezGALPrimitiveTopology::ENUM_COUNT;
-
-  ezGALBlendStateHandle m_hBlendState;
-  ezColor m_BlendFactor = ezColor(0, 0, 0, 0);
-  ezUInt32 m_uiSampleMask = 0;
-
-  ezGALDepthStencilStateHandle m_hDepthStencilState;
+  ezGALGraphicsPipelineHandle m_hGraphicsPipeline;
+  ezGALComputePipelineHandle m_hComputePipeline;
   ezUInt8 m_uiStencilRefValue = 0;
-
-  ezGALRasterizerStateHandle m_hRasterizerState;
 
   ezRectU32 m_ScissorRect = ezRectU32(0xFFFFFFFF, 0xFFFFFFFF, 0, 0);
   ezRectFloat m_ViewPortRect = ezRectFloat(ezMath::MaxValue<float>(), ezMath::MaxValue<float>(), 0.0f, 0.0f);

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -11,22 +11,6 @@
 #include <RendererFoundation/Resources/Texture.h>
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
 
-void ezGALCommandEncoder::SetShader(ezGALShaderHandle hShader)
-{
-  AssertRenderingThread();
-  /// \todo Assert for shader capabilities (supported shader stages etc.)
-
-  if (m_State.m_hShader == hShader)
-    return;
-
-  const ezGALShader* pShader = m_Device.GetShader(hShader);
-  EZ_ASSERT_DEV(pShader != nullptr, "The given shader handle isn't valid, this may be a use after destroy!");
-
-  m_CommonImpl.SetShaderPlatform(pShader);
-
-  m_State.m_hShader = hShader;
-}
-
 void ezGALCommandEncoder::SetConstantBuffer(const ezShaderResourceBinding& binding, ezGALBufferHandle hBuffer)
 {
   AssertRenderingThread();
@@ -646,86 +630,28 @@ void ezGALCommandEncoder::SetVertexBuffer(ezUInt32 uiSlot, ezGALBufferHandle hVe
   m_State.m_hVertexBufferOffsets[uiSlot] = uiOffset;
 }
 
-void ezGALCommandEncoder::SetPrimitiveTopology(ezGALPrimitiveTopology::Enum topology)
+void ezGALCommandEncoder::SetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline)
 {
   AssertRenderingThread();
-
-  if (m_State.m_Topology == topology)
-  {
+  m_State.m_hComputePipeline.Invalidate();
+  if (m_State.m_hGraphicsPipeline == hGraphicsPipeline)
     return;
-  }
 
-  m_CommonImpl.SetPrimitiveTopologyPlatform(topology);
-
-  m_State.m_Topology = topology;
+  const ezGALGraphicsPipeline* pGraphicsPipeline = GetDevice().GetGraphicsPipeline(hGraphicsPipeline);
+  m_CommonImpl.SetGraphicsPipelinePlatform(pGraphicsPipeline);
+  m_State.m_hGraphicsPipeline = hGraphicsPipeline;
 }
 
-void ezGALCommandEncoder::SetVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration)
+void ezGALCommandEncoder::SetComputePipeline(ezGALComputePipelineHandle hComputePipeline)
 {
   AssertRenderingThread();
-
-  if (m_State.m_hVertexDeclaration == hVertexDeclaration)
-  {
+  m_State.m_hGraphicsPipeline.Invalidate();
+  if (m_State.m_hComputePipeline == hComputePipeline)
     return;
-  }
-
-  const ezGALVertexDeclaration* pVertexDeclaration = GetDevice().GetVertexDeclaration(hVertexDeclaration);
-  // Assert on vertex buffer type (if non-zero)
-
-  m_CommonImpl.SetVertexDeclarationPlatform(pVertexDeclaration);
-
-  m_State.m_hVertexDeclaration = hVertexDeclaration;
-}
-
-void ezGALCommandEncoder::SetBlendState(ezGALBlendStateHandle hBlendState, const ezColor& blendFactor, ezUInt32 uiSampleMask)
-{
-  AssertRenderingThread();
-
-  if (m_State.m_hBlendState == hBlendState && m_State.m_BlendFactor.IsEqualRGBA(blendFactor, 0.001f) && m_State.m_uiSampleMask == uiSampleMask)
-  {
-    return;
-  }
-
-  const ezGALBlendState* pBlendState = GetDevice().GetBlendState(hBlendState);
-
-  m_CommonImpl.SetBlendStatePlatform(pBlendState, blendFactor, uiSampleMask);
-
-  m_State.m_hBlendState = hBlendState;
-  m_State.m_BlendFactor = blendFactor;
-  m_State.m_uiSampleMask = uiSampleMask;
-}
-
-void ezGALCommandEncoder::SetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState, ezUInt8 uiStencilRefValue /*= 0xFFu*/)
-{
-  AssertRenderingThread();
-
-  if (m_State.m_hDepthStencilState == hDepthStencilState && m_State.m_uiStencilRefValue == uiStencilRefValue)
-  {
-    return;
-  }
-
-  const ezGALDepthStencilState* pDepthStencilState = GetDevice().GetDepthStencilState(hDepthStencilState);
-
-  m_CommonImpl.SetDepthStencilStatePlatform(pDepthStencilState, uiStencilRefValue);
-
-  m_State.m_hDepthStencilState = hDepthStencilState;
-  m_State.m_uiStencilRefValue = uiStencilRefValue;
-}
-
-void ezGALCommandEncoder::SetRasterizerState(ezGALRasterizerStateHandle hRasterizerState)
-{
-  AssertRenderingThread();
-
-  if (m_State.m_hRasterizerState == hRasterizerState)
-  {
-    return;
-  }
-
-  const ezGALRasterizerState* pRasterizerState = GetDevice().GetRasterizerState(hRasterizerState);
-
-  m_CommonImpl.SetRasterizerStatePlatform(pRasterizerState);
-
-  m_State.m_hRasterizerState = hRasterizerState;
+  
+  const ezGALComputePipeline* pComputePipeline = GetDevice().GetComputePipeline(hComputePipeline);
+  m_CommonImpl.SetComputePipelinePlatform(pComputePipeline);
+  m_State.m_hComputePipeline = hComputePipeline;
 }
 
 void ezGALCommandEncoder::SetViewport(const ezRectFloat& rect, float fMinDepth, float fMaxDepth)
@@ -756,6 +682,18 @@ void ezGALCommandEncoder::SetScissorRect(const ezRectU32& rect)
   m_CommonImpl.SetScissorRectPlatform(rect);
 
   m_State.m_ScissorRect = rect;
+}
+
+void ezGALCommandEncoder::SetStencilReference(ezUInt8 uiStencilRefValue)
+{
+  AssertRenderingThread();
+
+  if (m_State.m_uiStencilRefValue == uiStencilRefValue)
+    return;
+
+  m_CommonImpl.SetStencilReferencePlatform(uiStencilRefValue);
+
+  m_State.m_uiStencilRefValue = uiStencilRefValue;
 }
 
 void ezGALCommandEncoder::BeginCompute(const char* szName)

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -648,7 +648,7 @@ void ezGALCommandEncoder::SetComputePipeline(ezGALComputePipelineHandle hCompute
   m_State.m_hGraphicsPipeline.Invalidate();
   if (m_State.m_hComputePipeline == hComputePipeline)
     return;
-  
+
   const ezGALComputePipeline* pComputePipeline = GetDevice().GetComputePipeline(hComputePipeline);
   m_CommonImpl.SetComputePipelinePlatform(pComputePipeline);
   m_State.m_hComputePipeline = hComputePipeline;

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
@@ -4,7 +4,6 @@
 
 void ezGALCommandEncoderRenderState::InvalidateState()
 {
-  m_hShader = ezGALShaderHandle();
   for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hVertexBuffers); ++i)
   {
     m_hVertexBuffers[i].Invalidate();
@@ -12,17 +11,9 @@ void ezGALCommandEncoderRenderState::InvalidateState()
   }
   m_hIndexBuffer.Invalidate();
 
-  m_hVertexDeclaration.Invalidate();
-  m_Topology = ezGALPrimitiveTopology::ENUM_COUNT;
-
-  m_hBlendState.Invalidate();
-  m_BlendFactor = ezColor(0, 0, 0, 0);
-  m_uiSampleMask = 0;
-
-  m_hDepthStencilState.Invalidate();
+  m_hGraphicsPipeline.Invalidate();
+  m_hComputePipeline.Invalidate();
   m_uiStencilRefValue = 0;
-
-  m_hRasterizerState.Invalidate();
 
   m_ScissorRect = ezRectU32(0xFFFFFFFF, 0xFFFFFFFF, 0, 0);
   m_ViewPortRect = ezRectFloat(ezMath::MaxValue<float>(), ezMath::MaxValue<float>(), 0.0f, 0.0f);

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -8,9 +8,9 @@
 #include <Foundation/Types/SharedPtr.h>
 #include <RendererFoundation/Descriptors/Enumerations.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Resources/RenderTargetSetup.h>
 #include <RendererFoundation/Resources/ResourceFormats.h>
 #include <RendererFoundation/Shader/ShaderByteCode.h>
-#include <RendererFoundation/Resources/RenderTargetSetup.h>
 #include <Texture/Image/ImageEnums.h>
 
 class ezWindowBase;
@@ -19,7 +19,7 @@ class ezWindowBase;
 /// All handles must be set except for m_hVertexDeclaration which is optional. Creating a graphics pipeline increases the reference count on all valid handles.
 struct ezGALGraphicsPipelineCreationDescription : public ezHashableStruct<ezGALGraphicsPipelineCreationDescription>
 {
-  ezGALShaderHandle m_hShader; ///< Also defines pipeline layout
+  ezGALShaderHandle m_hShader;                       ///< Also defines pipeline layout
   ezGALVertexDeclarationHandle m_hVertexDeclaration; ///< Optional
 
   ezGALRasterizerStateHandle m_hRasterizerState;

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -68,7 +68,7 @@ struct ezGALShaderCreationDescription : public ezHashableStruct<ezGALShaderCreat
   ezGALShaderCreationDescription(const ezGALShaderCreationDescription& other);
   ~ezGALShaderCreationDescription();
   /// \brief Needs to be overwritten as the base class impl can only handle pod types.
-  void operator=(const ezGALShaderCreationDescription& other); 
+  void operator=(const ezGALShaderCreationDescription& other);
 
   bool HasByteCodeForStage(ezGALShaderStage::Enum stage) const;
 

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -10,11 +10,33 @@
 #include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Resources/ResourceFormats.h>
 #include <RendererFoundation/Shader/ShaderByteCode.h>
+#include <RendererFoundation/Resources/RenderTargetSetup.h>
 #include <Texture/Image/ImageEnums.h>
 
 class ezWindowBase;
 
+/// \brief Defines the complete state of a graphics pipeline, excluding bound resources (e.g. textures, buffers) and dynamic states (e.g. viewport).
+/// All handles must be set except for m_hVertexDeclaration which is optional. Creating a graphics pipeline increases the reference count on all valid handles.
+struct ezGALGraphicsPipelineCreationDescription : public ezHashableStruct<ezGALGraphicsPipelineCreationDescription>
+{
+  ezGALShaderHandle m_hShader; ///< Also defines pipeline layout
+  ezGALVertexDeclarationHandle m_hVertexDeclaration; ///< Optional
 
+  ezGALRasterizerStateHandle m_hRasterizerState;
+  ezGALBlendStateHandle m_hBlendState;
+  ezGALDepthStencilStateHandle m_hDepthStencilState;
+
+  ezEnum<ezGALPrimitiveTopology> m_Topology;
+
+  ezGALRenderPassDescriptor m_RenderPass; ///< Use ezGALRenderingSetup::GetRenderPass to set this.
+};
+
+/// \brief Defines the complete state of a compute pipeline, excluding bound resources (e.g. textures, buffers).
+/// Creating a compute pipeline increases the reference count on the shader handle.
+struct ezGALComputePipelineCreationDescription : public ezHashableStruct<ezGALComputePipelineCreationDescription>
+{
+  ezGALShaderHandle m_hShader; ///< Also defines pipeline layout
+};
 
 struct ezGALWindowSwapChainCreationDescription : public ezHashableStruct<ezGALWindowSwapChainCreationDescription>
 {

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -64,7 +64,11 @@ struct ezGALDeviceCreationDescription
 struct ezGALShaderCreationDescription : public ezHashableStruct<ezGALShaderCreationDescription>
 {
   ezGALShaderCreationDescription();
+  /// \brief Needs to be overwritten as the base class impl can only handle pod types.
+  ezGALShaderCreationDescription(const ezGALShaderCreationDescription& other);
   ~ezGALShaderCreationDescription();
+  /// \brief Needs to be overwritten as the base class impl can only handle pod types.
+  void operator=(const ezGALShaderCreationDescription& other); 
 
   bool HasByteCodeForStage(ezGALShaderStage::Enum stage) const;
 

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors_inl.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors_inl.h
@@ -5,11 +5,27 @@ inline ezGALShaderCreationDescription::ezGALShaderCreationDescription()
 {
 }
 
+inline ezGALShaderCreationDescription::ezGALShaderCreationDescription(const ezGALShaderCreationDescription& other)
+{
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; ++i)
+  {
+    m_ByteCodes[i] = other.m_ByteCodes[i];
+  }
+}
+
 inline ezGALShaderCreationDescription::~ezGALShaderCreationDescription()
 {
   for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; ++i)
   {
     m_ByteCodes[i] = nullptr;
+  }
+}
+
+inline void ezGALShaderCreationDescription::operator=(const ezGALShaderCreationDescription& other)
+{
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; ++i)
+  {
+    m_ByteCodes[i] = other.m_ByteCodes[i];
   }
 }
 

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -49,6 +49,12 @@ public:
   ezGALSamplerStateHandle CreateSamplerState(const ezGALSamplerStateCreationDescription& description);
   void DestroySamplerState(ezGALSamplerStateHandle hSamplerState);
 
+  ezGALGraphicsPipelineHandle CreateGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& description);
+  void DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline);
+
+  ezGALComputePipelineHandle CreateComputePipeline(const ezGALComputePipelineCreationDescription& description);
+  void DestroyComputePipeline(ezGALComputePipelineHandle hComputePipeline);
+  
   // Resource creation functions
 
   ezGALShaderHandle CreateShader(const ezGALShaderCreationDescription& description);
@@ -214,6 +220,8 @@ public:
   const ezGALRasterizerState* GetRasterizerState(ezGALRasterizerStateHandle hRasterizerState) const;
   const ezGALVertexDeclaration* GetVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration) const;
   const ezGALSamplerState* GetSamplerState(ezGALSamplerStateHandle hSamplerState) const;
+  const ezGALGraphicsPipeline* GetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline) const;
+  const ezGALComputePipeline* GetComputePipeline(ezGALComputePipelineHandle hComputePipeline) const;
   const ezGALTextureResourceView* GetResourceView(ezGALTextureResourceViewHandle hResourceView) const;
   const ezGALBufferResourceView* GetResourceView(ezGALBufferResourceViewHandle hResourceView) const;
   const ezGALRenderTargetView* GetRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView) const;
@@ -292,11 +300,18 @@ protected:
   using BufferUnorderedAccessViewTable = ezIdTable<ezGALBufferUnorderedAccessViewHandle::IdType, ezGALBufferUnorderedAccessView*, ezLocalAllocatorWrapper>;
   using SwapChainTable = ezIdTable<ezGALSwapChainHandle::IdType, ezGALSwapChain*, ezLocalAllocatorWrapper>;
   using VertexDeclarationTable = ezIdTable<ezGALVertexDeclarationHandle::IdType, ezGALVertexDeclaration*, ezLocalAllocatorWrapper>;
+  using GraphicsPipelineTable = ezIdTable<ezGALGraphicsPipelineHandle::IdType, ezGALGraphicsPipeline*, ezLocalAllocatorWrapper>;
+  using ComputePipelineTable = ezIdTable<ezGALComputePipelineHandle::IdType, ezGALComputePipeline*, ezLocalAllocatorWrapper>;
 
   ShaderTable m_Shaders;
+  VertexDeclarationTable m_VertexDeclarations;
   BlendStateTable m_BlendStates;
   DepthStencilStateTable m_DepthStencilStates;
   RasterizerStateTable m_RasterizerStates;
+  GraphicsPipelineTable m_GraphicsPipelines;
+  ComputePipelineTable m_ComputePipelines;
+  SamplerStateTable m_SamplerStates;
+
   BufferTable m_Buffers;
   DynamicBufferTable m_DynamicBuffers;
   TextureTable m_Textures;
@@ -304,20 +319,20 @@ protected:
   ReadbackTextureTable m_ReadbackTextures;
   TextureResourceViewTable m_TextureResourceViews;
   BufferResourceViewTable m_BufferResourceViews;
-  SamplerStateTable m_SamplerStates;
   RenderTargetViewTable m_RenderTargetViews;
   TextureUnorderedAccessViewTable m_TextureUnorderedAccessViews;
   BufferUnorderedAccessViewTable m_BufferUnorderedAccessViews;
   SwapChainTable m_SwapChains;
-  VertexDeclarationTable m_VertexDeclarations;
-
 
   // Hash tables used to prevent state object duplication
+  ezHashTable<ezUInt32, ezGALShaderHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_ShaderTable;
+  ezHashTable<ezUInt32, ezGALVertexDeclarationHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_VertexDeclarationTable;
   ezHashTable<ezUInt32, ezGALBlendStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_BlendStateTable;
   ezHashTable<ezUInt32, ezGALDepthStencilStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_DepthStencilStateTable;
   ezHashTable<ezUInt32, ezGALRasterizerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_RasterizerStateTable;
+  ezHashTable<ezUInt32, ezGALGraphicsPipelineHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_GraphicsPipelineTable;
+  ezHashTable<ezUInt32, ezGALComputePipelineHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_ComputePipelineTable;
   ezHashTable<ezUInt32, ezGALSamplerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_SamplerStateTable;
-  ezHashTable<ezUInt32, ezGALVertexDeclarationHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_VertexDeclarationTable;
 
   struct DeadObject
   {
@@ -371,6 +386,12 @@ protected:
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) = 0;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) = 0;
 
+  virtual ezGALGraphicsPipeline* CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description) = 0;
+  virtual void DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline) = 0;
+
+  virtual ezGALComputePipeline* CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description) = 0;
+  virtual void DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline) = 0;
+  
   // Resource creation functions
 
   virtual ezGALShader* CreateShaderPlatform(const ezGALShaderCreationDescription& Description) = 0;

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -54,7 +54,7 @@ public:
 
   ezGALComputePipelineHandle CreateComputePipeline(const ezGALComputePipelineCreationDescription& description);
   void DestroyComputePipeline(ezGALComputePipelineHandle hComputePipeline);
-  
+
   // Resource creation functions
 
   ezGALShaderHandle CreateShader(const ezGALShaderCreationDescription& description);
@@ -391,7 +391,7 @@ protected:
 
   virtual ezGALComputePipeline* CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description) = 0;
   virtual void DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline) = 0;
-  
+
   // Resource creation functions
 
   virtual ezGALShader* CreateShaderPlatform(const ezGALShaderCreationDescription& Description) = 0;

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -15,7 +15,10 @@
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
 #include <RendererFoundation/Shader/VertexDeclaration.h>
+#include <RendererFoundation/Shader/Shader.h>
 #include <RendererFoundation/State/State.h>
+#include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererFoundation/State/ComputePipeline.h>
 
 namespace
 {
@@ -39,7 +42,9 @@ namespace
       TextureUnorderedAccessView,
       BufferUnorderedAccessView,
       SwapChain,
-      VertexDeclaration
+      VertexDeclaration,
+      GraphicsPipeline,
+      ComputePipeline
     };
   };
 
@@ -57,6 +62,8 @@ namespace
   static_assert(sizeof(ezGALBufferUnorderedAccessViewHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALSwapChainHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALVertexDeclarationHandle) == sizeof(ezUInt32));
+  static_assert(sizeof(ezGALGraphicsPipelineHandle) == sizeof(ezUInt32));
+  static_assert(sizeof(ezGALComputePipelineHandle) == sizeof(ezUInt32));
 } // namespace
 
 ezGALDevice* ezGALDevice::s_pDefaultDevice = nullptr;
@@ -113,6 +120,12 @@ ezGALDevice::~ezGALDevice()
 
     if (!m_VertexDeclarations.IsEmpty())
       ezLog::Warning("{0} vertex declarations have not been cleaned up", m_VertexDeclarations.GetCount());
+    
+    if (!m_GraphicsPipelines.IsEmpty())
+      ezLog::Warning("{0} graphics pipelines have not been cleaned up", m_GraphicsPipelines.GetCount());
+    
+    if (!m_ComputePipelines.IsEmpty())
+      ezLog::Warning("{0} Compute pipelines have not been cleaned up", m_ComputePipelines.GetCount());
   }
 }
 
@@ -145,8 +158,6 @@ ezResult ezGALDevice::Init()
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezProfilingSystem::InitializeGPUData();
-
-
 
   {
     ezGALDeviceEvent e;
@@ -480,7 +491,173 @@ void ezGALDevice::DestroySamplerState(ezGALSamplerStateHandle hSamplerState)
   }
 }
 
+ezGALGraphicsPipelineHandle ezGALDevice::CreateGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& desc)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
 
+  auto IncreaseReference = [&](const auto& idTable, auto handle, GALObjectType::Enum type)
+  {
+    auto pRes = idTable[handle];
+    if (pRes->GetRefCount() == 0)
+    {
+      ReviveDeadObject(type, handle);
+    }
+    pRes->AddRef();
+  };
+
+  // Hash desc and return potential existing one (including inc. refcount)
+  ezUInt32 uiHash = desc.CalculateHash();
+  {
+    ezGALGraphicsPipelineHandle hGraphicsPipeline;
+    if (m_GraphicsPipelineTable.TryGetValue(uiHash, hGraphicsPipeline))
+    {
+      ezGALGraphicsPipeline* pGraphicsPipeline = m_GraphicsPipelines[hGraphicsPipeline];
+      if (pGraphicsPipeline->GetRefCount() == 0)
+      {
+        ReviveDeadObject(GALObjectType::GraphicsPipeline, hGraphicsPipeline);
+        IncreaseReference(m_Shaders, desc.m_hShader, GALObjectType::Shader);
+        IncreaseReference(m_RasterizerStates, desc.m_hRasterizerState, GALObjectType::RasterizerState);
+        IncreaseReference(m_BlendStates, desc.m_hBlendState, GALObjectType::BlendState);
+        IncreaseReference(m_DepthStencilStates, desc.m_hDepthStencilState, GALObjectType::DepthStencilState);
+        if (!desc.m_hVertexDeclaration.IsInvalidated())
+        {
+          IncreaseReference(m_VertexDeclarations, desc.m_hVertexDeclaration, GALObjectType::VertexDeclaration);
+        }
+      }
+
+      pGraphicsPipeline->AddRef();
+      return hGraphicsPipeline;
+    }
+  }
+
+  if (desc.m_hBlendState.IsInvalidated() || desc.m_hDepthStencilState.IsInvalidated() || desc.m_hRasterizerState.IsInvalidated() || desc.m_hShader.IsInvalidated())
+  {
+    ezLog::Error("An essential handle was invalid. Only the m_hVertexDeclaration handle can be invalid.");
+    return {};
+  }
+
+  ezGALGraphicsPipeline* pGraphicsPipeline = CreateGraphicsPipelinePlatform(desc);
+
+  if (pGraphicsPipeline != nullptr)
+  {
+    EZ_ASSERT_DEBUG(pGraphicsPipeline->GetDescription().CalculateHash() == uiHash, "GraphicsPipeline hash doesn't match");
+
+    pGraphicsPipeline->AddRef();
+
+    ezGALGraphicsPipelineHandle hGraphicsPipeline(m_GraphicsPipelines.Insert(pGraphicsPipeline));
+    m_GraphicsPipelineTable.Insert(uiHash, hGraphicsPipeline);
+
+    IncreaseReference(m_Shaders, desc.m_hShader, GALObjectType::Shader);
+    IncreaseReference(m_RasterizerStates, desc.m_hRasterizerState, GALObjectType::RasterizerState);
+    IncreaseReference(m_BlendStates, desc.m_hBlendState, GALObjectType::BlendState);
+    IncreaseReference(m_DepthStencilStates, desc.m_hDepthStencilState, GALObjectType::DepthStencilState);
+    if (!desc.m_hVertexDeclaration.IsInvalidated())
+    {
+      IncreaseReference(m_VertexDeclarations, desc.m_hVertexDeclaration, GALObjectType::VertexDeclaration);
+    }
+
+    return hGraphicsPipeline;
+  }
+
+  return ezGALGraphicsPipelineHandle();
+}
+
+void ezGALDevice::DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  ezGALGraphicsPipeline* pGraphicsPipeline = nullptr;
+
+  if (m_GraphicsPipelines.TryGetValue(hGraphicsPipeline, pGraphicsPipeline))
+  {
+    pGraphicsPipeline->ReleaseRef();
+
+    if (pGraphicsPipeline->GetRefCount() == 0)
+    {
+      AddDeadObject(GALObjectType::GraphicsPipeline, hGraphicsPipeline);
+      const ezGALGraphicsPipelineCreationDescription& desc = pGraphicsPipeline->GetDescription();
+
+      DestroyShader(desc.m_hShader);
+      DestroyRasterizerState(desc.m_hRasterizerState);
+      DestroyBlendState(desc.m_hBlendState);
+      DestroyDepthStencilState(desc.m_hDepthStencilState);
+      if (!desc.m_hVertexDeclaration.IsInvalidated())
+      {
+        DestroyVertexDeclaration(desc.m_hVertexDeclaration);
+      }
+    }
+  }
+  else
+  {
+    ezLog::Warning("DestroyGraphicsPipeline called on invalid handle (double free?)");
+  }
+}
+
+
+ezGALComputePipelineHandle ezGALDevice::CreateComputePipeline(const ezGALComputePipelineCreationDescription& desc)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+  
+  // Hash desc and return potential existing one (including inc. refcount)
+  ezUInt32 uiHash = desc.CalculateHash();
+  {
+    ezGALComputePipelineHandle hComputePipeline;
+    if (m_ComputePipelineTable.TryGetValue(uiHash, hComputePipeline))
+    {
+      ezGALComputePipeline* pComputePipeline = m_ComputePipelines[hComputePipeline];
+      if (pComputePipeline->GetRefCount() == 0)
+      {
+        ReviveDeadObject(GALObjectType::ComputePipeline, hComputePipeline);
+      }
+
+      pComputePipeline->AddRef();
+      return hComputePipeline;
+    }
+  }
+
+  if (desc.m_hShader.IsInvalidated())
+  {
+    ezLog::Error("Shader handle must be valid.");
+    return {};
+  }
+
+  ezGALComputePipeline* pComputePipeline = CreateComputePipelinePlatform(desc);
+
+  if (pComputePipeline != nullptr)
+  {
+    EZ_ASSERT_DEBUG(pComputePipeline->GetDescription().CalculateHash() == uiHash, "ComputePipeline hash doesn't match");
+
+    pComputePipeline->AddRef();
+
+    ezGALComputePipelineHandle hComputePipeline(m_ComputePipelines.Insert(pComputePipeline));
+    m_ComputePipelineTable.Insert(uiHash, hComputePipeline);
+
+    return hComputePipeline;
+  }
+
+  return ezGALComputePipelineHandle();
+}
+
+void ezGALDevice::DestroyComputePipeline(ezGALComputePipelineHandle hComputePipeline)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+
+  ezGALComputePipeline* pComputePipeline = nullptr;
+
+  if (m_ComputePipelines.TryGetValue(hComputePipeline, pComputePipeline))
+  {
+    pComputePipeline->ReleaseRef();
+
+    if (pComputePipeline->GetRefCount() == 0)
+    {
+      AddDeadObject(GALObjectType::ComputePipeline, hComputePipeline);
+    }
+  }
+  else
+  {
+    ezLog::Warning("DestroyComputePipeline called on invalid handle (double free?)");
+  }
+}
 
 ezGALShaderHandle ezGALDevice::CreateShader(const ezGALShaderCreationDescription& desc)
 {
@@ -503,16 +680,39 @@ ezGALShaderHandle ezGALDevice::CreateShader(const ezGALShaderCreationDescription
     return ezGALShaderHandle();
   }
 
+  // Hash desc and return potential existing one (including inc. refcount)
+  ezUInt32 uiHash = desc.CalculateHash();
+
+  {
+    ezGALShaderHandle hShader;
+    if (m_ShaderTable.TryGetValue(uiHash, hShader))
+    {
+      ezGALShader* pShader = m_Shaders[hShader];
+      if (pShader->GetRefCount() == 0)
+      {
+        ReviveDeadObject(GALObjectType::Shader, hShader);
+      }
+
+      pShader->AddRef();
+      return hShader;
+    }
+  }
+
   ezGALShader* pShader = CreateShaderPlatform(desc);
 
-  if (pShader == nullptr)
+  if (pShader != nullptr)
   {
-    return ezGALShaderHandle();
+    EZ_ASSERT_DEBUG(pShader->GetDescription().CalculateHash() == uiHash, "Shader hash doesn't match");
+
+    pShader->AddRef();
+
+    ezGALShaderHandle hShader(m_Shaders.Insert(pShader));
+    m_ShaderTable.Insert(uiHash, hShader);
+
+    return hShader;
   }
-  else
-  {
-    return ezGALShaderHandle(m_Shaders.Insert(pShader));
-  }
+
+  return ezGALShaderHandle();
 }
 
 void ezGALDevice::DestroyShader(ezGALShaderHandle hShader)
@@ -523,7 +723,12 @@ void ezGALDevice::DestroyShader(ezGALShaderHandle hShader)
 
   if (m_Shaders.TryGetValue(hShader, pShader))
   {
-    AddDeadObject(GALObjectType::Shader, hShader);
+    pShader->ReleaseRef();
+
+    if (pShader->GetRefCount() == 0)
+    {
+      AddDeadObject(GALObjectType::Shader, hShader);
+    }
   }
   else
   {
@@ -1847,6 +2052,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALShader* pShader = nullptr;
 
         EZ_VERIFY(m_Shaders.Remove(hShader, &pShader), "");
+        m_ShaderTable.Remove(pShader->GetDescription().CalculateHash());
 
         DestroyShaderPlatform(pShader);
 
@@ -2018,6 +2224,28 @@ void ezGALDevice::DestroyDeadObjects()
 
         DestroyVertexDeclarationPlatform(pVertexDeclaration);
 
+        break;
+      }
+      case GALObjectType::GraphicsPipeline:
+      {
+        ezGALGraphicsPipelineHandle hGraphicsPipeline(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALGraphicsPipeline* pGraphicsPipeline = nullptr;
+
+        EZ_VERIFY(m_GraphicsPipelines.Remove(hGraphicsPipeline, &pGraphicsPipeline), "Unexpected invalid handle");
+        m_GraphicsPipelineTable.Remove(pGraphicsPipeline->GetDescription().CalculateHash());
+
+        DestroyGraphicsPipelinePlatform(pGraphicsPipeline);
+        break;
+      }
+      case GALObjectType::ComputePipeline:
+      {
+        ezGALComputePipelineHandle hComputePipeline(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALComputePipeline* pComputePipeline = nullptr;
+        
+        EZ_VERIFY(m_ComputePipelines.Remove(hComputePipeline, &pComputePipeline), "Unexpected invalid handle");
+        m_ComputePipelineTable.Remove(pComputePipeline->GetDescription().CalculateHash());
+
+        DestroyComputePipelinePlatform(pComputePipeline);
         break;
       }
       default:

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -14,11 +14,11 @@
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
-#include <RendererFoundation/Shader/VertexDeclaration.h>
 #include <RendererFoundation/Shader/Shader.h>
-#include <RendererFoundation/State/State.h>
-#include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererFoundation/Shader/VertexDeclaration.h>
 #include <RendererFoundation/State/ComputePipeline.h>
+#include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererFoundation/State/State.h>
 
 namespace
 {
@@ -120,10 +120,10 @@ ezGALDevice::~ezGALDevice()
 
     if (!m_VertexDeclarations.IsEmpty())
       ezLog::Warning("{0} vertex declarations have not been cleaned up", m_VertexDeclarations.GetCount());
-    
+
     if (!m_GraphicsPipelines.IsEmpty())
       ezLog::Warning("{0} graphics pipelines have not been cleaned up", m_GraphicsPipelines.GetCount());
-    
+
     if (!m_ComputePipelines.IsEmpty())
       ezLog::Warning("{0} Compute pipelines have not been cleaned up", m_ComputePipelines.GetCount());
   }
@@ -597,7 +597,7 @@ void ezGALDevice::DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsP
 ezGALComputePipelineHandle ezGALDevice::CreateComputePipeline(const ezGALComputePipelineCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-  
+
   // Hash desc and return potential existing one (including inc. refcount)
   ezUInt32 uiHash = desc.CalculateHash();
   {
@@ -2241,7 +2241,7 @@ void ezGALDevice::DestroyDeadObjects()
       {
         ezGALComputePipelineHandle hComputePipeline(ezGAL::ez18_14Id(deadObject.m_uiHandle));
         ezGALComputePipeline* pComputePipeline = nullptr;
-        
+
         EZ_VERIFY(m_ComputePipelines.Remove(hComputePipeline, &pComputePipeline), "Unexpected invalid handle");
         m_ComputePipelineTable.Remove(pComputePipeline->GetDescription().CalculateHash());
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -112,12 +112,12 @@ inline const ezGALSamplerState* ezGALDevice::GetSamplerState(ezGALSamplerStateHa
 
 inline const ezGALGraphicsPipeline* ezGALDevice::GetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline) const
 {
-  return Get<GraphicsPipelineTable , ezGALGraphicsPipeline>(hGraphicsPipeline, m_GraphicsPipelines);
+  return Get<GraphicsPipelineTable, ezGALGraphicsPipeline>(hGraphicsPipeline, m_GraphicsPipelines);
 }
 
 inline const ezGALComputePipeline* ezGALDevice::GetComputePipeline(ezGALComputePipelineHandle hComputePipeline) const
 {
-  return Get<ComputePipelineTable , ezGALComputePipeline>(hComputePipeline, m_ComputePipelines);
+  return Get<ComputePipelineTable, ezGALComputePipeline>(hComputePipeline, m_ComputePipelines);
 }
 
 inline const ezGALTextureResourceView* ezGALDevice::GetResourceView(ezGALTextureResourceViewHandle hResourceView) const

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -110,6 +110,16 @@ inline const ezGALSamplerState* ezGALDevice::GetSamplerState(ezGALSamplerStateHa
   return Get<SamplerStateTable, ezGALSamplerState>(hSamplerState, m_SamplerStates);
 }
 
+inline const ezGALGraphicsPipeline* ezGALDevice::GetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline) const
+{
+  return Get<GraphicsPipelineTable , ezGALGraphicsPipeline>(hGraphicsPipeline, m_GraphicsPipelines);
+}
+
+inline const ezGALComputePipeline* ezGALDevice::GetComputePipeline(ezGALComputePipelineHandle hComputePipeline) const
+{
+  return Get<ComputePipelineTable , ezGALComputePipeline>(hComputePipeline, m_ComputePipelines);
+}
+
 inline const ezGALTextureResourceView* ezGALDevice::GetResourceView(ezGALTextureResourceViewHandle hResourceView) const
 {
   return Get<TextureResourceViewTable, ezGALTextureResourceView>(hResourceView, m_TextureResourceViews);

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -44,6 +44,7 @@ struct ezGALBufferResourceViewCreationDescription;
 struct ezGALRenderTargetViewCreationDescription;
 struct ezGALTextureUnorderedAccessViewCreationDescription;
 struct ezGALBufferUnorderedAccessViewCreationDescription;
+struct ezGALGraphicsPipelineCreationDescription;
 
 class ezGALSwapChain;
 class ezGALShader;
@@ -66,6 +67,8 @@ class ezGALTextureUnorderedAccessView;
 class ezGALBufferUnorderedAccessView;
 class ezGALDevice;
 class ezGALCommandEncoder;
+class ezGALGraphicsPipeline;
+class ezGALComputePipeline;
 
 // Basic enums
 struct ezGALPrimitiveTopology
@@ -560,6 +563,20 @@ class ezGALSamplerStateHandle
 class ezGALVertexDeclarationHandle
 {
   EZ_DECLARE_HANDLE_TYPE(ezGALVertexDeclarationHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALGraphicsPipelineHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALGraphicsPipelineHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALComputePipelineHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALComputePipelineHandle, ezGAL::ez18_14Id);
 
   friend class ezGALDevice;
 };

--- a/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/RenderTargetSetup.cpp
@@ -86,7 +86,8 @@ ezGALRenderingSetup& ezGALRenderingSetup::SetDepthStencilTarget(ezGALRenderTarge
   if (!bFirstRenderTarget)
   {
     EZ_ASSERT_DEBUG(m_RenderPass.m_Msaa == info.m_MSAA, "Missmatch between this render target's MSAA mode ({}) and the previously set MSAA mode ({}).", info.m_MSAA, m_RenderPass.m_Msaa);
-    EZ_ASSERT_DEBUG(m_FrameBuffer.m_Size == info.m_Size, "Missmatch between this render target's size ({}) and the previously set size ({}).", info.m_Size, m_FrameBuffer.m_Size);
+    m_FrameBuffer.m_Size.height = ezMath::Min(m_FrameBuffer.m_Size.height, info.m_Size.height);
+    m_FrameBuffer.m_Size.width = ezMath::Min(m_FrameBuffer.m_Size.width, info.m_Size.width);
     EZ_ASSERT_DEBUG(m_FrameBuffer.m_uiSliceCount == info.m_uiSliceCount, "Missmatch between this render target's slice count ({}) and the previously set slice count ({}).", info.m_uiSliceCount, m_FrameBuffer.m_uiSliceCount);
   }
   else

--- a/Code/Engine/RendererFoundation/Resources/RenderTargetSetup.h
+++ b/Code/Engine/RendererFoundation/Resources/RenderTargetSetup.h
@@ -29,7 +29,7 @@ struct ezGALRenderPassDescriptor : public ezHashableStruct<ezGALRenderPassDescri
   ezEnum<ezGALRenderTargetStoreOp> m_DepthStoreOp;
   ezEnum<ezGALRenderTargetLoadOp> m_StencilLoadOp;
   ezEnum<ezGALRenderTargetStoreOp> m_StencilStoreOp;
-  ezEnum<ezGALResourceFormat> m_ColorFormat[EZ_GAL_MAX_RENDERTARGET_COUNT] = {ezGALResourceFormat::Invalid};
+  ezEnum<ezGALResourceFormat> m_ColorFormat[EZ_GAL_MAX_RENDERTARGET_COUNT];
   ezEnum<ezGALRenderTargetLoadOp> m_ColorLoadOp[EZ_GAL_MAX_RENDERTARGET_COUNT];
   ezEnum<ezGALRenderTargetStoreOp> m_ColorStoreOp[EZ_GAL_MAX_RENDERTARGET_COUNT];
 };

--- a/Code/Engine/RendererFoundation/Resources/ResourceFormats.h
+++ b/Code/Engine/RendererFoundation/Resources/ResourceFormats.h
@@ -100,7 +100,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALResourceFormat
 
     ENUM_COUNT,
 
-    Default = RGBAUByteNormalizedsRGB
+    Default = Invalid
   };
 
 

--- a/Code/Engine/RendererFoundation/State/ComputePipeline.h
+++ b/Code/Engine/RendererFoundation/State/ComputePipeline.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+class EZ_RENDERERFOUNDATION_DLL ezGALComputePipeline : public ezGALObject<ezGALComputePipelineCreationDescription>
+{
+public:
+  ezGALComputePipeline(const ezGALComputePipelineCreationDescription& description)
+    : ezGALObject<ezGALComputePipelineCreationDescription>(description)
+  {
+  }
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+  virtual void SetDebugName(const char* szName) = 0;
+};

--- a/Code/Engine/RendererFoundation/State/GraphicsPipeline.h
+++ b/Code/Engine/RendererFoundation/State/GraphicsPipeline.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+/// \brief Graphics pipeline state object combining shader, blend, depth-stencil, rasterizer state, and vertex declaration into a single object.
+class EZ_RENDERERFOUNDATION_DLL ezGALGraphicsPipeline : public ezGALObject<ezGALGraphicsPipelineCreationDescription>
+{
+public:
+  ezGALGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& description)
+    : ezGALObject<ezGALGraphicsPipelineCreationDescription>(description)
+  {
+  }
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+  virtual void SetDebugName(const char* szName) = 0;
+};

--- a/Code/Engine/RendererFoundation/State/Implementation/PipelineCache.cpp
+++ b/Code/Engine/RendererFoundation/State/Implementation/PipelineCache.cpp
@@ -1,0 +1,140 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <Foundation/Configuration/Startup.h>
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/State/PipelineCache.h>
+
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(RendererFoundation, PipelineCache)
+
+  BEGIN_SUBSYSTEM_DEPENDENCIES
+    "Foundation",
+    "Core"
+  END_SUBSYSTEM_DEPENDENCIES
+
+  ON_CORESYSTEMS_STARTUP
+  {
+    EZ_DEFAULT_NEW(ezGALPipelineCache);
+  }
+
+  ON_CORESYSTEMS_SHUTDOWN
+  {
+    ezGALPipelineCache* pDummy = ezGALPipelineCache::GetSingleton();
+    EZ_DEFAULT_DELETE(pDummy);
+  }
+
+EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
+
+EZ_IMPLEMENT_SINGLETON(ezGALPipelineCache);
+
+ezGALPipelineCache::ezGALPipelineCache()
+  : m_SingletonRegistrar(this)
+{
+  ezGALDevice::s_Events.AddEventHandler(ezMakeDelegate(&ezGALPipelineCache::GALDeviceEventHandler, this));
+}
+
+ezGALPipelineCache::~ezGALPipelineCache()
+{
+  ezGALDevice::s_Events.RemoveEventHandler(ezMakeDelegate(&ezGALPipelineCache::GALDeviceEventHandler, this));
+}
+
+void ezGALPipelineCache::GALDeviceEventHandler(const ezGALDeviceEvent& e)
+{
+  switch (e.m_Type)
+  {
+    case ezGALDeviceEvent::AfterInit:
+      m_pDevice = e.m_pDevice;
+      break;
+    case ezGALDeviceEvent::BeforeShutdown:
+      Clear();
+      break;
+    default:
+      break;
+  }
+}
+
+void ezGALPipelineCache::Clear()
+{
+  EZ_LOCK(m_Mutex);
+
+  for (auto it = m_GraphicsPipelines.GetIterator(); it.IsValid(); ++it)
+  {
+    m_pDevice->DestroyGraphicsPipeline(it.Value());
+  }
+  m_GraphicsPipelines.Clear();
+
+  for (auto it = m_ComputePipelines.GetIterator(); it.IsValid(); ++it)
+  {
+    m_pDevice->DestroyComputePipeline(it.Value());
+  }
+  m_ComputePipelines.Clear();
+}
+
+ezGALGraphicsPipelineHandle ezGALPipelineCache::GetPipeline(const ezGALGraphicsPipelineCreationDescription& description)
+{
+  ezGALPipelineCache* pCache = ezGALPipelineCache::GetSingleton();
+  
+  ezGALGraphicsPipelineHandle hGraphicsPipeline = pCache->TryGetPipeline<ezGALGraphicsPipelineHandle>(description, pCache->m_GraphicsPipelines);
+
+  if (hGraphicsPipeline.IsInvalidated())
+  {
+    hGraphicsPipeline = pCache->m_pDevice->CreateGraphicsPipeline(description);
+    if (hGraphicsPipeline.IsInvalidated())
+    {
+      return {};
+    }
+    
+    if (pCache->TryInsertPipeline<ezGALGraphicsPipelineHandle>(description, hGraphicsPipeline, pCache->m_GraphicsPipelines).Failed())
+    {
+      // Already created and inserted, reduce ref count again.
+      pCache->m_pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    }
+  }
+  
+  return hGraphicsPipeline;
+}
+
+ezGALComputePipelineHandle ezGALPipelineCache::GetPipeline(const ezGALComputePipelineCreationDescription& description)
+{
+  ezGALPipelineCache* pCache = ezGALPipelineCache::GetSingleton();
+  
+  ezGALComputePipelineHandle hComputePipeline = pCache->TryGetPipeline<ezGALComputePipelineHandle>(description, pCache->m_ComputePipelines);
+  
+  if (hComputePipeline.IsInvalidated())
+  {
+    hComputePipeline = pCache->m_pDevice->CreateComputePipeline(description);
+    if (hComputePipeline.IsInvalidated())
+    {
+      return {};
+    }
+    
+    if (pCache->TryInsertPipeline<ezGALComputePipelineHandle>(description, hComputePipeline, pCache->m_ComputePipelines).Failed())
+    {
+      // Already created and inserted, reduce ref count again.
+      pCache->m_pDevice->DestroyComputePipeline(hComputePipeline);
+    }
+  }
+  
+  return hComputePipeline;
+}
+
+ezUInt32 ezGALPipelineCache::CacheKeyHasher::Hash(const ezGALPipelineCache::GraphicsPipelineCacheKey& a)
+{
+  return a.m_uiHash;
+}
+
+bool ezGALPipelineCache::CacheKeyHasher::Equal(const ezGALPipelineCache::GraphicsPipelineCacheKey& a, const ezGALPipelineCache::GraphicsPipelineCacheKey& b)
+{
+  return a.m_uiHash == b.m_uiHash && a.m_Desc == b.m_Desc;
+}
+
+ezUInt32 ezGALPipelineCache::CacheKeyHasher::Hash(const ezGALPipelineCache::ComputePipelineCacheKey& a)
+{
+  return a.m_uiHash;
+}
+
+bool ezGALPipelineCache::CacheKeyHasher::Equal(const ezGALPipelineCache::ComputePipelineCacheKey& a, const ezGALPipelineCache::ComputePipelineCacheKey& b)
+{
+  return a.m_uiHash == b.m_uiHash && a.m_Desc == b.m_Desc;
+}

--- a/Code/Engine/RendererFoundation/State/Implementation/PipelineCache.cpp
+++ b/Code/Engine/RendererFoundation/State/Implementation/PipelineCache.cpp
@@ -74,7 +74,7 @@ void ezGALPipelineCache::Clear()
 ezGALGraphicsPipelineHandle ezGALPipelineCache::GetPipeline(const ezGALGraphicsPipelineCreationDescription& description)
 {
   ezGALPipelineCache* pCache = ezGALPipelineCache::GetSingleton();
-  
+
   ezGALGraphicsPipelineHandle hGraphicsPipeline = pCache->TryGetPipeline<ezGALGraphicsPipelineHandle>(description, pCache->m_GraphicsPipelines);
 
   if (hGraphicsPipeline.IsInvalidated())
@@ -84,23 +84,23 @@ ezGALGraphicsPipelineHandle ezGALPipelineCache::GetPipeline(const ezGALGraphicsP
     {
       return {};
     }
-    
+
     if (pCache->TryInsertPipeline<ezGALGraphicsPipelineHandle>(description, hGraphicsPipeline, pCache->m_GraphicsPipelines).Failed())
     {
       // Already created and inserted, reduce ref count again.
       pCache->m_pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
     }
   }
-  
+
   return hGraphicsPipeline;
 }
 
 ezGALComputePipelineHandle ezGALPipelineCache::GetPipeline(const ezGALComputePipelineCreationDescription& description)
 {
   ezGALPipelineCache* pCache = ezGALPipelineCache::GetSingleton();
-  
+
   ezGALComputePipelineHandle hComputePipeline = pCache->TryGetPipeline<ezGALComputePipelineHandle>(description, pCache->m_ComputePipelines);
-  
+
   if (hComputePipeline.IsInvalidated())
   {
     hComputePipeline = pCache->m_pDevice->CreateComputePipeline(description);
@@ -108,14 +108,14 @@ ezGALComputePipelineHandle ezGALPipelineCache::GetPipeline(const ezGALComputePip
     {
       return {};
     }
-    
+
     if (pCache->TryInsertPipeline<ezGALComputePipelineHandle>(description, hComputePipeline, pCache->m_ComputePipelines).Failed())
     {
       // Already created and inserted, reduce ref count again.
       pCache->m_pDevice->DestroyComputePipeline(hComputePipeline);
     }
   }
-  
+
   return hComputePipeline;
 }
 

--- a/Code/Engine/RendererFoundation/State/Implementation/PipelineCache_inl.h
+++ b/Code/Engine/RendererFoundation/State/Implementation/PipelineCache_inl.h
@@ -1,0 +1,42 @@
+
+template <typename HandleType,  typename DescType, typename KeyType>
+HandleType ezGALPipelineCache::TryGetPipeline(const DescType& description, ezHashTable<KeyType, HandleType, ezGALPipelineCache::CacheKeyHasher>& table)
+{
+  EZ_ASSERT_DEV(m_pDevice != nullptr, "GAL device not initialized");
+
+  KeyType key;
+  key.m_Desc = description;
+  key.m_uiHash = description.CalculateHash();
+
+  {
+    EZ_LOCK(m_Mutex);
+
+    HandleType* pExistingPipeline = table.GetValue(key);
+    if (pExistingPipeline != nullptr)
+    {
+      return *pExistingPipeline;
+    }
+  }
+  return {};
+}
+
+template <typename HandleType,  typename DescType, typename KeyType>
+EZ_ALWAYS_INLINE ezResult ezGALPipelineCache::TryInsertPipeline(const DescType& description, HandleType hNewPipeline, ezHashTable<KeyType, HandleType, ezGALPipelineCache::CacheKeyHasher>& table)
+{
+  KeyType key;
+  key.m_Desc = description;
+  key.m_uiHash = description.CalculateHash();
+
+  EZ_LOCK(m_Mutex);
+  HandleType* pExistingPipeline = table.GetValue(key);
+  if (pExistingPipeline == nullptr)
+  {
+    table.Insert(key, hNewPipeline);
+    return EZ_SUCCESS;
+  }
+  else
+  {
+    EZ_ASSERT_DEBUG(*pExistingPipeline == hNewPipeline, "On collision, both pipelines must be the same (create should have just increased the ref count)");
+    return EZ_FAILURE;
+  }
+}

--- a/Code/Engine/RendererFoundation/State/Implementation/PipelineCache_inl.h
+++ b/Code/Engine/RendererFoundation/State/Implementation/PipelineCache_inl.h
@@ -1,5 +1,5 @@
 
-template <typename HandleType,  typename DescType, typename KeyType>
+template <typename HandleType, typename DescType, typename KeyType>
 HandleType ezGALPipelineCache::TryGetPipeline(const DescType& description, ezHashTable<KeyType, HandleType, ezGALPipelineCache::CacheKeyHasher>& table)
 {
   EZ_ASSERT_DEV(m_pDevice != nullptr, "GAL device not initialized");
@@ -20,7 +20,7 @@ HandleType ezGALPipelineCache::TryGetPipeline(const DescType& description, ezHas
   return {};
 }
 
-template <typename HandleType,  typename DescType, typename KeyType>
+template <typename HandleType, typename DescType, typename KeyType>
 EZ_ALWAYS_INLINE ezResult ezGALPipelineCache::TryInsertPipeline(const DescType& description, HandleType hNewPipeline, ezHashTable<KeyType, HandleType, ezGALPipelineCache::CacheKeyHasher>& table)
 {
   KeyType key;

--- a/Code/Engine/RendererFoundation/State/Implementation/PipelineCache_inl.h
+++ b/Code/Engine/RendererFoundation/State/Implementation/PipelineCache_inl.h
@@ -28,15 +28,12 @@ EZ_ALWAYS_INLINE ezResult ezGALPipelineCache::TryInsertPipeline(const DescType& 
   key.m_uiHash = description.CalculateHash();
 
   EZ_LOCK(m_Mutex);
-  HandleType* pExistingPipeline = table.GetValue(key);
-  if (pExistingPipeline == nullptr)
+
+  HandleType existingPipeline;
+  if (table.Insert(key, hNewPipeline, &existingPipeline))
   {
-    table.Insert(key, hNewPipeline);
-    return EZ_SUCCESS;
-  }
-  else
-  {
-    EZ_ASSERT_DEBUG(*pExistingPipeline == hNewPipeline, "On collision, both pipelines must be the same (create should have just increased the ref count)");
+    EZ_ASSERT_DEBUG(existingPipeline == hNewPipeline, "On collision, both pipelines must be the same (create should have just increased the ref count)");
     return EZ_FAILURE;
   }
+  return EZ_SUCCESS;
 }

--- a/Code/Engine/RendererFoundation/State/PipelineCache.h
+++ b/Code/Engine/RendererFoundation/State/PipelineCache.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <Foundation/Configuration/Singleton.h>
+#include <Foundation/Containers/HashTable.h>
+#include <Foundation/Threading/Mutex.h>
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+class ezGALDevice;
+
+/// \brief A cache from pipeline descriptor to handle which holds a reference to each pipeline that is never freed until shutdown. This is just a stopgap solution until the high level interface changes and mostly used by `ezRenderContext` to provide the old interface until further refactoring.
+class EZ_RENDERERFOUNDATION_DLL ezGALPipelineCache
+{
+  EZ_DECLARE_SINGLETON(ezGALPipelineCache);
+public:
+  /// \brief Creates a pipeline or retrieves it from the cache. Ownership remains with the cache so do not call DestroyGraphicsPipeline on the handle.
+  static ezGALGraphicsPipelineHandle GetPipeline(const ezGALGraphicsPipelineCreationDescription& description);
+  /// \brief Creates a pipeline or retrieves it from the cache. Ownership remains with the cache so do not call DestroyComputePipeline on the handle.
+  static ezGALComputePipelineHandle GetPipeline(const ezGALComputePipelineCreationDescription& description);
+
+private:
+  EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(RendererFoundation, PipelineCache);
+  friend class ezMemoryUtils;
+
+  struct GraphicsPipelineCacheKey
+  {
+    EZ_DECLARE_POD_TYPE();
+    ezUInt32 m_uiHash = 0;
+    ezGALGraphicsPipelineCreationDescription m_Desc;
+  };
+  
+  struct ComputePipelineCacheKey
+  {
+    EZ_DECLARE_POD_TYPE();
+    ezUInt32 m_uiHash = 0;
+    ezGALComputePipelineCreationDescription m_Desc;
+  };
+
+  struct CacheKeyHasher
+  {
+    static ezUInt32 Hash(const GraphicsPipelineCacheKey& a);
+    static bool Equal(const GraphicsPipelineCacheKey& a, const GraphicsPipelineCacheKey& b);
+    
+    static ezUInt32 Hash(const ComputePipelineCacheKey& a);
+    static bool Equal(const ComputePipelineCacheKey& a, const ComputePipelineCacheKey& b);
+  };
+
+private:
+  ezGALPipelineCache();
+  ~ezGALPipelineCache();
+  void GALDeviceEventHandler(const ezGALDeviceEvent& e);
+  void Clear();
+
+  template <typename HandleType,  typename DescType, typename KeyType>
+  EZ_ALWAYS_INLINE HandleType TryGetPipeline(const DescType& description, ezHashTable<KeyType, HandleType, CacheKeyHasher>& table);
+
+  template <typename HandleType,  typename DescType, typename KeyType>
+  EZ_ALWAYS_INLINE ezResult TryInsertPipeline(const DescType& description, HandleType hNewPipeline, ezHashTable<KeyType, HandleType, CacheKeyHasher>& table);
+
+private:
+  ezMutex m_Mutex;
+  ezGALDevice* m_pDevice = nullptr;
+  ezHashTable<GraphicsPipelineCacheKey, ezGALGraphicsPipelineHandle, CacheKeyHasher> m_GraphicsPipelines;
+  ezHashTable<ComputePipelineCacheKey, ezGALComputePipelineHandle, CacheKeyHasher> m_ComputePipelines;
+};
+
+#include <RendererFoundation/State/Implementation/PipelineCache_inl.h>

--- a/Code/Engine/RendererFoundation/State/PipelineCache.h
+++ b/Code/Engine/RendererFoundation/State/PipelineCache.h
@@ -12,6 +12,7 @@ class ezGALDevice;
 class EZ_RENDERERFOUNDATION_DLL ezGALPipelineCache
 {
   EZ_DECLARE_SINGLETON(ezGALPipelineCache);
+
 public:
   /// \brief Creates a pipeline or retrieves it from the cache. Ownership remains with the cache so do not call DestroyGraphicsPipeline on the handle.
   static ezGALGraphicsPipelineHandle GetPipeline(const ezGALGraphicsPipelineCreationDescription& description);
@@ -28,7 +29,7 @@ private:
     ezUInt32 m_uiHash = 0;
     ezGALGraphicsPipelineCreationDescription m_Desc;
   };
-  
+
   struct ComputePipelineCacheKey
   {
     EZ_DECLARE_POD_TYPE();
@@ -40,7 +41,7 @@ private:
   {
     static ezUInt32 Hash(const GraphicsPipelineCacheKey& a);
     static bool Equal(const GraphicsPipelineCacheKey& a, const GraphicsPipelineCacheKey& b);
-    
+
     static ezUInt32 Hash(const ComputePipelineCacheKey& a);
     static bool Equal(const ComputePipelineCacheKey& a, const ComputePipelineCacheKey& b);
   };
@@ -51,10 +52,10 @@ private:
   void GALDeviceEventHandler(const ezGALDeviceEvent& e);
   void Clear();
 
-  template <typename HandleType,  typename DescType, typename KeyType>
+  template <typename HandleType, typename DescType, typename KeyType>
   EZ_ALWAYS_INLINE HandleType TryGetPipeline(const DescType& description, ezHashTable<KeyType, HandleType, CacheKeyHasher>& table);
 
-  template <typename HandleType,  typename DescType, typename KeyType>
+  template <typename HandleType, typename DescType, typename KeyType>
   EZ_ALWAYS_INLINE ezResult TryInsertPipeline(const DescType& description, HandleType hNewPipeline, ezHashTable<KeyType, HandleType, CacheKeyHasher>& table);
 
 private:

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -1,6 +1,10 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
+#include <Foundation/Application/Application.h>
 #include <Foundation/Basics.h>
+#include <Foundation/IO/FileSystem/FileReader.h>
+#include <Foundation/IO/FileSystem/FileWriter.h>
+#include <Foundation/IO/OSFile.h>
 #include <RendererFoundation/Resources/Texture.h>
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
@@ -11,14 +15,11 @@
 
 ezGALDeviceVulkan* ezResourceCacheVulkan::s_pDevice;
 vk::Device ezResourceCacheVulkan::s_device;
+vk::PipelineCache ezResourceCacheVulkan::s_pipelineCache;
 
 ezHashTable<ezGALRenderPassDescriptor, vk::RenderPass, ezResourceCacheVulkan::ResourceCacheHash> ezResourceCacheVulkan::s_renderPasses;
 ezHashTable<ezResourceCacheVulkan::FramebufferKey, vk::Framebuffer, ezResourceCacheVulkan::ResourceCacheHash> ezResourceCacheVulkan::s_frameBuffers;
 ezHashTable<ezResourceCacheVulkan::PipelineLayoutDesc, vk::PipelineLayout, ezResourceCacheVulkan::ResourceCacheHash> ezResourceCacheVulkan::s_pipelineLayouts;
-ezResourceCacheVulkan::GraphicsPipelineMap ezResourceCacheVulkan::s_graphicsPipelines;
-ezResourceCacheVulkan::ComputePipelineMap ezResourceCacheVulkan::s_computePipelines;
-ezMap<const ezRefCounted*, ezHybridArray<ezResourceCacheVulkan::GraphicsPipelineMap::Iterator, 1>> ezResourceCacheVulkan::s_graphicsPipelineUsedBy;
-ezMap<const ezRefCounted*, ezHybridArray<ezResourceCacheVulkan::ComputePipelineMap::Iterator, 1>> ezResourceCacheVulkan::s_computePipelineUsedBy;
 
 ezHashTable<ezGALShaderVulkan::DescriptorSetLayoutDesc, vk::DescriptorSetLayout, ezResourceCacheVulkan::ResourceCacheHash> ezResourceCacheVulkan::s_descriptorSetLayouts;
 
@@ -32,16 +33,75 @@ namespace
     Stream << reinterpret_cast<const ezUInt32&>(Value);
     return Stream;
   }
+
+  static constexpr ezUInt32 PIPELINE_CACHE_MAGIC = 0x45A9BCD7; // Arbitrary m_uiMagic number
+  // Header structure for Vulkan pipeline cache
+  struct PipelineCachePrefixHeader
+  {
+    EZ_DECLARE_POD_TYPE();
+
+    ezUInt32 m_uiMagic;             // An arbitrary m_uiMagic header to make sure this is actually our file
+    ezUInt32 m_uiDataSize;          // Equal to *pDataSize returned by vkGetPipelineCacheData
+    ezUInt64 m_uiDataHash;          // A hash of pipeline cache data, including the header
+    ezUInt32 m_uiVendorID;          // Equal to VkPhysicalDeviceProperties::vendorID
+    ezUInt32 m_uiDeviceID;          // Equal to VkPhysicalDeviceProperties::deviceID
+    ezUInt32 m_uiDriverVersion;     // Equal to VkPhysicalDeviceProperties::driverVersion
+    ezUInt32 m_uiDriverABI;         // Equal to sizeof(void*)
+    ezUInt8 m_uiUuid[VK_UUID_SIZE]; // Equal to VkPhysicalDeviceProperties::pipelineCacheUUID
+  };
+
+  ezString GetPipelineCacheFilename(const vk::PhysicalDeviceProperties& deviceProperties)
+  {
+    ezStringBuilder sCacheFilePath;
+    ezString sAppName = ezApplication::GetApplicationInstance() ? ezApplication::GetApplicationInstance()->GetApplicationName().GetView() : "ezEngine"_ezsv;
+#if EZ_ENABLED(EZ_PLATFORM_ANDROID)
+    // Be extra pedantic on Android and don't reuse caches on driver version changes, see https://zeux.io/2019/07/17/serializing-pipeline-cache/
+    sCacheFilePath.SetFormat("{}/PipelineCache_{}_{}_{}.bin",
+      ezOSFile::GetUserDataFolder(sAppName),
+      ezArgU(deviceProperties.vendorID, 8, true, 16, true),
+      ezArgU(deviceProperties.deviceID, 8, true, 16, true),
+      ezArgU(deviceProperties.driverVersion, 8, true, 16, true));
+#else
+    // On desktop, we assume that vendors can actually write proper code and caches can be reused after driver updates.
+    sCacheFilePath.SetFormat("{}/PipelineCache_{}_{}.bin",
+      ezOSFile::GetUserDataFolder(sAppName),
+      ezArgU(deviceProperties.vendorID, 8, true, 16, true),
+      ezArgU(deviceProperties.deviceID, 8, true, 16, true));
+#endif
+    return sCacheFilePath;
+  }
 } // namespace
+
+
 
 void ezResourceCacheVulkan::Initialize(ezGALDeviceVulkan* pDevice, vk::Device device)
 {
   s_pDevice = pDevice;
   s_device = device;
+
+  if (LoadPipelineCache(s_pipelineCache).Failed())
+  {
+    vk::PipelineCacheCreateInfo pipelineCacheInfo;
+    pipelineCacheInfo.initialDataSize = 0;
+    pipelineCacheInfo.pInitialData = nullptr;
+    VK_ASSERT_DEV(s_device.createPipelineCache(&pipelineCacheInfo, nullptr, &s_pipelineCache));
+  }
 }
 
 void ezResourceCacheVulkan::DeInitialize()
 {
+  if (s_pipelineCache)
+  {
+    if (SavePipelineCache().Failed())
+    {
+      ezLog::Error("Failed to save Vulkan pipeline cache");
+    }
+    // Destroy the pipeline cache
+    s_device.destroyPipelineCache(s_pipelineCache, nullptr);
+    s_pipelineCache = nullptr;
+  }
+
+  // Destroy other resources
   for (auto it : s_renderPasses)
   {
     s_device.destroyRenderPass(it.Value(), nullptr);
@@ -55,34 +115,6 @@ void ezResourceCacheVulkan::DeInitialize()
   }
   s_frameBuffers.Clear();
   s_frameBuffers.Compact();
-
-  // graphic
-  {
-    for (auto it : s_graphicsPipelines)
-    {
-      s_device.destroyPipeline(it.Value(), nullptr);
-    }
-    s_graphicsPipelines.Clear();
-    GraphicsPipelineMap tmp;
-    s_graphicsPipelines.Swap(tmp);
-    s_graphicsPipelineUsedBy.Clear();
-    ezMap<const ezRefCounted*, ezHybridArray<GraphicsPipelineMap::Iterator, 1>> tmp2;
-    s_graphicsPipelineUsedBy.Swap(tmp2);
-  }
-
-  // compute
-  {
-    for (auto it : s_computePipelines)
-    {
-      s_device.destroyPipeline(it.Value(), nullptr);
-    }
-    s_computePipelines.Clear();
-    ComputePipelineMap tmp;
-    s_computePipelines.Swap(tmp);
-    s_computePipelineUsedBy.Clear();
-    ezMap<const ezRefCounted*, ezHybridArray<ComputePipelineMap::Iterator, 1>> tmp2;
-    s_computePipelineUsedBy.Swap(tmp2);
-  }
 
   for (auto it : s_pipelineLayouts)
   {
@@ -268,147 +300,6 @@ vk::PipelineLayout ezResourceCacheVulkan::RequestPipelineLayout(const PipelineLa
   return layout;
 }
 
-vk::Pipeline ezResourceCacheVulkan::RequestGraphicsPipeline(const GraphicsPipelineDesc& desc)
-{
-  if (const vk::Pipeline* pPipeline = s_graphicsPipelines.GetValue(desc))
-  {
-    return *pPipeline;
-  }
-
-#ifdef EZ_LOG_VULKAN_RESOURCES
-  ezLog::Info("Creating Graphics Pipeline #{}", s_graphicsPipelines.GetCount());
-#endif // EZ_LOG_VULKAN_RESOURCES
-
-  vk::PipelineVertexInputStateCreateInfo dummy;
-  const vk::PipelineVertexInputStateCreateInfo* pVertexCreateInfo = nullptr;
-  ezHybridArray<vk::VertexInputBindingDescription, EZ_GAL_MAX_VERTEX_BUFFER_COUNT> bindings;
-  pVertexCreateInfo = desc.m_pCurrentVertexDecl ? &desc.m_pCurrentVertexDecl->GetCreateInfo() : &dummy;
-
-  vk::PipelineInputAssemblyStateCreateInfo input_assembly;
-  input_assembly.topology = ezConversionUtilsVulkan::GetPrimitiveTopology(desc.m_topology);
-  const bool bTessellation = desc.m_pCurrentShader->GetShader(ezGALShaderStage::HullShader) != nullptr;
-  if (bTessellation)
-  {
-    // Tessellation shaders always need to use patch list as the topology.
-    input_assembly.topology = vk::PrimitiveTopology::ePatchList;
-  }
-
-  // Specify rasterization state.
-  const vk::PipelineRasterizationStateCreateInfo* raster = desc.m_pCurrentRasterizerState->GetRasterizerState();
-
-  // Our attachment will write to all color channels
-  vk::PipelineColorBlendStateCreateInfo blend = *desc.m_pCurrentBlendState->GetBlendState();
-  blend.attachmentCount = desc.m_renderPassDesc.m_uiRTCount;
-
-  // We will have one viewport and scissor box.
-  vk::PipelineViewportStateCreateInfo viewport;
-  viewport.viewportCount = 1;
-  viewport.scissorCount = 1;
-
-  // Depth Testing
-  const vk::PipelineDepthStencilStateCreateInfo* depth_stencil = desc.m_pCurrentDepthStencilState->GetDepthStencilState();
-
-  // Multisampling.
-  vk::PipelineMultisampleStateCreateInfo multisample;
-  multisample.rasterizationSamples = ezConversionUtilsVulkan::GetSamples(desc.m_renderPassDesc.m_Msaa);
-  if (multisample.rasterizationSamples != vk::SampleCountFlagBits::e1 && desc.m_pCurrentBlendState->GetDescription().m_bAlphaToCoverage)
-  {
-    multisample.alphaToCoverageEnable = true;
-  }
-
-  // Specify that these states will be dynamic, i.e. not part of pipeline state object.
-  ezHybridArray<vk::DynamicState, 2> dynamics;
-  dynamics.PushBack(vk::DynamicState::eViewport);
-  dynamics.PushBack(vk::DynamicState::eScissor);
-
-  vk::PipelineDynamicStateCreateInfo dynamic;
-  dynamic.pDynamicStates = dynamics.GetData();
-  dynamic.dynamicStateCount = dynamics.GetCount();
-
-  // Load our SPIR-V shaders.
-  ezHybridArray<vk::PipelineShaderStageCreateInfo, 6> shader_stages;
-  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
-  {
-    if (vk::ShaderModule shader = desc.m_pCurrentShader->GetShader((ezGALShaderStage::Enum)i))
-    {
-      vk::PipelineShaderStageCreateInfo& stage = shader_stages.ExpandAndGetRef();
-      stage.stage = ezConversionUtilsVulkan::GetShaderStage((ezGALShaderStage::Enum)i);
-      stage.module = shader;
-      stage.pName = "main";
-    }
-  }
-
-  vk::PipelineTessellationStateCreateInfo tessellationInfo;
-  if (bTessellation)
-  {
-    tessellationInfo.patchControlPoints = desc.m_pCurrentShader->GetDescription().m_ByteCodes[ezGALShaderStage::HullShader]->m_uiTessellationPatchControlPoints;
-  }
-
-  vk::GraphicsPipelineCreateInfo pipe;
-  pipe.renderPass = desc.m_renderPass;
-  pipe.layout = desc.m_layout;
-  pipe.stageCount = shader_stages.GetCount();
-  pipe.pStages = shader_stages.GetData();
-  pipe.pVertexInputState = pVertexCreateInfo;
-  pipe.pInputAssemblyState = &input_assembly;
-  pipe.pRasterizationState = raster;
-  pipe.pColorBlendState = &blend;
-  pipe.pMultisampleState = &multisample;
-  pipe.pViewportState = &viewport;
-  pipe.pDepthStencilState = depth_stencil;
-  pipe.pDynamicState = &dynamic;
-  if (bTessellation)
-    pipe.pTessellationState = &tessellationInfo;
-
-  vk::Pipeline pipeline;
-  vk::PipelineCache cache;
-  VK_ASSERT_DEBUG(s_device.createGraphicsPipelines(cache, 1, &pipe, nullptr, &pipeline));
-
-  auto it = s_graphicsPipelines.Insert(desc, pipeline);
-  {
-    s_graphicsPipelineUsedBy[desc.m_pCurrentRasterizerState].PushBack(it);
-    s_graphicsPipelineUsedBy[desc.m_pCurrentBlendState].PushBack(it);
-    s_graphicsPipelineUsedBy[desc.m_pCurrentDepthStencilState].PushBack(it);
-    s_graphicsPipelineUsedBy[desc.m_pCurrentShader].PushBack(it);
-    s_graphicsPipelineUsedBy[desc.m_pCurrentVertexDecl].PushBack(it);
-  }
-
-  return pipeline;
-}
-
-vk::Pipeline ezResourceCacheVulkan::RequestComputePipeline(const ComputePipelineDesc& desc)
-{
-  if (const vk::Pipeline* pPipeline = s_computePipelines.GetValue(desc))
-  {
-    return *pPipeline;
-  }
-
-#ifdef EZ_LOG_VULKAN_RESOURCES
-  ezLog::Info("Creating Compute Pipeline #{}", s_computePipelines.GetCount());
-#endif // EZ_LOG_VULKAN_RESOURCES
-
-  vk::ComputePipelineCreateInfo pipe;
-  pipe.layout = desc.m_layout;
-  {
-    vk::ShaderModule shader = desc.m_pCurrentShader->GetShader(ezGALShaderStage::ComputeShader);
-    EZ_ASSERT_DEV(shader != nullptr, "No compute shader stage present in the bound shader");
-    pipe.stage.stage = ezConversionUtilsVulkan::GetShaderStage(ezGALShaderStage::ComputeShader);
-    pipe.stage.module = shader;
-    pipe.stage.pName = "main";
-  }
-
-  vk::Pipeline pipeline;
-  vk::PipelineCache cache;
-  VK_ASSERT_DEBUG(s_device.createComputePipelines(cache, 1, &pipe, nullptr, &pipeline));
-
-  auto it = s_computePipelines.Insert(desc, pipeline);
-  {
-    s_computePipelineUsedBy[desc.m_pCurrentShader].PushBack(it);
-  }
-
-  return pipeline;
-}
-
 vk::DescriptorSetLayout ezResourceCacheVulkan::RequestDescriptorSetLayout(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc)
 {
   if (const vk::DescriptorSetLayout* pLayout = s_descriptorSetLayouts.GetValue(desc))
@@ -431,54 +322,112 @@ vk::DescriptorSetLayout ezResourceCacheVulkan::RequestDescriptorSetLayout(const 
   return layout;
 }
 
-void ezResourceCacheVulkan::ResourceDeleted(const ezRefCounted* pResource)
+ezResult ezResourceCacheVulkan::SavePipelineCache()
 {
-  auto it = s_graphicsPipelineUsedBy.Find(pResource);
-  if (it.IsValid())
+  // Get physical device properties for cache validation
+  vk::PhysicalDeviceProperties deviceProperties = s_pDevice->GetVulkanPhysicalDevice().getProperties();
+
+  // Get the cache data
+  size_t dataSize = 0;
+  VK_SUCCEED_OR_RETURN_EZ_FAILURE(s_device.getPipelineCacheData(s_pipelineCache, &dataSize, nullptr));
+  if (dataSize == 0)
+    return EZ_SUCCESS;
+
+  ezDynamicArray<ezUInt8> pipelineCacheData;
+  pipelineCacheData.SetCountUninitialized(dataSize);
+  VK_SUCCEED_OR_RETURN_EZ_FAILURE(s_device.getPipelineCacheData(s_pipelineCache, &dataSize, pipelineCacheData.GetData()));
+
+  // Create our custom prefix header
+  PipelineCachePrefixHeader prefixHeader;
+  prefixHeader.m_uiMagic = PIPELINE_CACHE_MAGIC;
+  prefixHeader.m_uiDataSize = static_cast<ezUInt32>(dataSize);
+  prefixHeader.m_uiVendorID = deviceProperties.vendorID;
+  prefixHeader.m_uiDeviceID = deviceProperties.deviceID;
+  prefixHeader.m_uiDriverVersion = deviceProperties.driverVersion;
+  prefixHeader.m_uiDriverABI = sizeof(void*);
+  for (ezUInt32 i = 0; i < VK_UUID_SIZE; ++i)
   {
-    const auto& itArray = it.Value();
-    for (GraphicsPipelineMap::Iterator it2 : itArray)
-    {
-      s_pDevice->DeleteLater(it2.Value());
-
-      const GraphicsPipelineDesc& desc = it2.Key();
-      ezArrayPtr<const ezRefCounted*> resources((const ezRefCounted**)&desc.m_pCurrentRasterizerState, 5);
-      for (const ezRefCounted* pResource2 : resources)
-      {
-        if (pResource2 != pResource)
-        {
-          s_graphicsPipelineUsedBy[pResource2].RemoveAndSwap(it2);
-        }
-      }
-
-      s_graphicsPipelines.Remove(it2);
-    }
-
-    s_graphicsPipelineUsedBy.Remove(it);
+    prefixHeader.m_uiUuid[i] = deviceProperties.pipelineCacheUUID[i];
   }
+  prefixHeader.m_uiDataHash = ezHashingUtils::MurmurHash64(pipelineCacheData.GetData(), dataSize);
+
+  ezString sCacheFilePath = GetPipelineCacheFilename(deviceProperties);
+  ezStringBuilder sTempFilePath;
+  sTempFilePath.SetFormat("{}_temp", sCacheFilePath);
+  // Write to the temporary file first
+  {
+    ezOSFile file;
+    //ezFileWriter file;
+    EZ_SUCCEED_OR_RETURN(file.Open(sTempFilePath, ezFileOpenMode::Write, ezFileShareMode::Exclusive));
+    EZ_SUCCEED_OR_RETURN(file.Write(&prefixHeader, sizeof(PipelineCachePrefixHeader)));
+    EZ_SUCCEED_OR_RETURN(file.Write(pipelineCacheData.GetData(), dataSize));
+    file.Close();
+  }
+
+  // Now rename the temporary file to the final file
+  EZ_SUCCEED_OR_RETURN(ezOSFile::DeleteFile(sCacheFilePath));
+  EZ_SUCCEED_OR_RETURN(ezOSFile::MoveFileOrDirectory(sTempFilePath, sCacheFilePath));
+  return EZ_SUCCESS;
 }
 
-void ezResourceCacheVulkan::ShaderDeleted(const ezGALShaderVulkan* pShader)
+ezResult ezResourceCacheVulkan::LoadPipelineCache(vk::PipelineCache& out_pipelineCache)
 {
-  if (pShader->GetDescription().HasByteCodeForStage(ezGALShaderStage::ComputeShader))
-  {
-    auto it = s_computePipelineUsedBy.Find(pShader);
-    if (it.IsValid())
-    {
-      const auto& itArray = it.Value();
-      for (ComputePipelineMap::Iterator it2 : itArray)
-      {
-        s_pDevice->DeleteLater(it2.Value());
-        s_computePipelines.Remove(it2);
-      }
+  // Pipeline cache implementation following https://zeux.io/2019/07/17/serializing-pipeline-cache/
+  vk::PhysicalDeviceProperties deviceProperties = s_pDevice->GetVulkanPhysicalDevice().getProperties();
 
-      s_computePipelineUsedBy.Remove(it);
+  // Try to load the pipeline cache from file
+  ezString cacheFilePath = GetPipelineCacheFilename(deviceProperties);
+
+  ezOSFile file;
+  EZ_SUCCEED_OR_RETURN(file.Open(cacheFilePath, ezFileOpenMode::Read, ezFileShareMode::Default));
+
+  // Read our custom prefix header
+  PipelineCachePrefixHeader prefixHeader;
+  ezUInt64 uiReadSize = file.Read(&prefixHeader, sizeof(PipelineCachePrefixHeader));
+  if (uiReadSize != sizeof(PipelineCachePrefixHeader))
+    return EZ_FAILURE;
+
+  bool bCacheUuidValid = true;
+  for (ezUInt32 i = 0; i < VK_UUID_SIZE; ++i)
+  {
+    if (prefixHeader.m_uiUuid[i] != deviceProperties.pipelineCacheUUID[i])
+    {
+      bCacheUuidValid = false;
+      break;
     }
   }
-  else
-  {
-    ResourceDeleted(pShader);
-  }
+  const bool bIsValid =
+    bCacheUuidValid && prefixHeader.m_uiMagic == PIPELINE_CACHE_MAGIC && prefixHeader.m_uiVendorID == deviceProperties.vendorID && prefixHeader.m_uiDeviceID == deviceProperties.deviceID
+#if EZ_ENABLED(EZ_PLATFORM_ANDROID)
+    && prefixHeader.m_uiDriverVersion == deviceProperties.driverVersion && prefixHeader.m_uiDriverABI == sizeof(void*)
+#endif
+    ;
+
+  if (!bIsValid)
+    return EZ_FAILURE;
+
+  // Read the cache data into memory
+  ezDynamicArray<ezUInt8> initialData;
+  initialData.SetCountUninitialized(prefixHeader.m_uiDataSize);
+  uiReadSize = file.Read(initialData.GetData(), initialData.GetCount());
+  if (uiReadSize != prefixHeader.m_uiDataSize)
+    return EZ_FAILURE;
+
+  file.Close();
+
+  // Verify hash
+  const ezUInt64 computedHash = ezHashingUtils::MurmurHash64(initialData.GetData(), initialData.GetCount());
+  if (computedHash != prefixHeader.m_uiDataHash)
+    return EZ_FAILURE;
+
+  // Create the pipeline cache
+  vk::PipelineCacheCreateInfo pipelineCacheInfo;
+  pipelineCacheInfo.initialDataSize = initialData.GetCount();
+  pipelineCacheInfo.pInitialData = initialData.GetData();
+  if (s_device.createPipelineCache(&pipelineCacheInfo, nullptr, &s_pipelineCache) != vk::Result::eSuccess)
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
 }
 
 ezUInt32 ezResourceCacheVulkan::ResourceCacheHash::Hash(const ezGALRenderPassDescriptor& desc)
@@ -508,25 +457,6 @@ bool ezResourceCacheVulkan::ResourceCacheHash::Equal(const ezGALShaderVulkan::De
   return true;
 }
 
-bool ezResourceCacheVulkan::ResourceCacheHash::Less(const GraphicsPipelineDesc& a, const GraphicsPipelineDesc& b)
-{
-#define LESS_CHECK(member)  \
-  if (a.member != b.member) \
-    return a.member < b.member;
-
-  LESS_CHECK(m_renderPass);
-  LESS_CHECK(m_layout);
-  LESS_CHECK(m_topology);
-  LESS_CHECK(m_renderPassDesc);
-  LESS_CHECK(m_pCurrentRasterizerState);
-  LESS_CHECK(m_pCurrentBlendState);
-  LESS_CHECK(m_pCurrentDepthStencilState);
-  LESS_CHECK(m_pCurrentShader);
-  LESS_CHECK(m_pCurrentVertexDecl);
-  return false;
-
-#undef LESS_CHECK
-}
 
 ezUInt32 ezResourceCacheVulkan::ResourceCacheHash::Hash(const FramebufferKey& key)
 {
@@ -568,46 +498,4 @@ bool ezResourceCacheVulkan::ResourceCacheHash::Equal(const PipelineLayoutDesc& a
       return false;
   }
   return a.m_pushConstants == b.m_pushConstants;
-}
-
-ezUInt32 ezResourceCacheVulkan::ResourceCacheHash::Hash(const GraphicsPipelineDesc& desc)
-{
-  ezHashStreamWriter32 writer;
-  writer << desc.m_renderPass;
-  writer << desc.m_layout;
-  writer << desc.m_topology;
-  writer << desc.m_renderPassDesc.CalculateHash();
-  writer << desc.m_pCurrentRasterizerState;
-  writer << desc.m_pCurrentBlendState;
-  writer << desc.m_pCurrentDepthStencilState;
-  writer << desc.m_pCurrentShader;
-  writer << desc.m_pCurrentVertexDecl;
-  return writer.GetHashValue();
-}
-
-bool ArraysEqual(const ezUInt32 (&a)[EZ_GAL_MAX_VERTEX_BUFFER_COUNT], const ezUInt32 (&b)[EZ_GAL_MAX_VERTEX_BUFFER_COUNT])
-{
-  for (ezUInt32 i = 0; i < EZ_GAL_MAX_VERTEX_BUFFER_COUNT; i++)
-  {
-    if (a[i] != b[i])
-      return false;
-  }
-  return true;
-}
-
-bool ezResourceCacheVulkan::ResourceCacheHash::Equal(const GraphicsPipelineDesc& a, const GraphicsPipelineDesc& b)
-{
-  return a.m_renderPass == b.m_renderPass && a.m_layout == b.m_layout && a.m_topology == b.m_topology && a.m_renderPassDesc == b.m_renderPassDesc && a.m_pCurrentRasterizerState == b.m_pCurrentRasterizerState && a.m_pCurrentBlendState == b.m_pCurrentBlendState && a.m_pCurrentDepthStencilState == b.m_pCurrentDepthStencilState && a.m_pCurrentShader == b.m_pCurrentShader && a.m_pCurrentVertexDecl == b.m_pCurrentVertexDecl;
-}
-
-bool ezResourceCacheVulkan::ResourceCacheHash::Less(const ComputePipelineDesc& a, const ComputePipelineDesc& b)
-{
-  if (a.m_layout != b.m_layout)
-    return a.m_layout < b.m_layout;
-  return a.m_pCurrentShader < b.m_pCurrentShader;
-}
-
-bool ezResourceCacheVulkan::ResourceCacheHash::Equal(const ComputePipelineDesc& a, const ComputePipelineDesc& b)
-{
-  return a.m_layout == b.m_layout && a.m_pCurrentShader == b.m_pCurrentShader;
 }

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -334,7 +334,7 @@ ezResult ezResourceCacheVulkan::SavePipelineCache()
     return EZ_SUCCESS;
 
   ezDynamicArray<ezUInt8> pipelineCacheData;
-  pipelineCacheData.SetCountUninitialized(dataSize);
+  pipelineCacheData.SetCountUninitialized(static_cast<ezUInt32>(dataSize));
   VK_SUCCEED_OR_RETURN_EZ_FAILURE(s_device.getPipelineCacheData(s_pipelineCache, &dataSize, pipelineCacheData.GetData()));
 
   // Create our custom prefix header

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -357,7 +357,7 @@ ezResult ezResourceCacheVulkan::SavePipelineCache()
   // Write to the temporary file first
   {
     ezOSFile file;
-    //ezFileWriter file;
+    // ezFileWriter file;
     EZ_SUCCEED_OR_RETURN(file.Open(sTempFilePath, ezFileOpenMode::Write, ezFileShareMode::Exclusive));
     EZ_SUCCEED_OR_RETURN(file.Write(&prefixHeader, sizeof(PipelineCachePrefixHeader)));
     EZ_SUCCEED_OR_RETURN(file.Write(pipelineCacheData.GetData(), dataSize));

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -349,7 +349,7 @@ ezResult ezResourceCacheVulkan::SavePipelineCache()
   {
     prefixHeader.m_uiUuid[i] = deviceProperties.pipelineCacheUUID[i];
   }
-  prefixHeader.m_uiDataHash = ezHashingUtils::MurmurHash64(pipelineCacheData.GetData(), dataSize);
+  prefixHeader.m_uiDataHash = ezHashingUtils::xxHash64(pipelineCacheData.GetData(), dataSize);
 
   ezString sCacheFilePath = GetPipelineCacheFilename(deviceProperties);
   ezStringBuilder sTempFilePath;
@@ -416,7 +416,7 @@ ezResult ezResourceCacheVulkan::LoadPipelineCache(vk::PipelineCache& out_pipelin
   file.Close();
 
   // Verify hash
-  const ezUInt64 computedHash = ezHashingUtils::MurmurHash64(initialData.GetData(), initialData.GetCount());
+  const ezUInt64 computedHash = ezHashingUtils::xxHash64(initialData.GetData(), initialData.GetCount());
   if (computedHash != prefixHeader.m_uiDataHash)
     return EZ_FAILURE;
 

--- a/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Cache/Implementation/ResourceCacheVulkan.cpp
@@ -162,7 +162,7 @@ vk::RenderPass ezResourceCacheVulkan::RequestRenderPass(const ezGALRenderPassDes
     vkAttachment.storeOp = ezConversionUtilsVulkan::GetAttachmentStoreOp(renderPass.m_DepthStoreOp);
     vkAttachment.stencilLoadOp = ezConversionUtilsVulkan::GetAttachmentLoadOp(renderPass.m_StencilLoadOp);
     vkAttachment.stencilStoreOp = ezConversionUtilsVulkan::GetAttachmentStoreOp(renderPass.m_StencilStoreOp);
-    vkAttachment.initialLayout = vkAttachment.loadOp == vk::AttachmentLoadOp::eLoad ? vk::ImageLayout::eDepthStencilAttachmentOptimal : vk::ImageLayout::eUndefined;
+    vkAttachment.initialLayout = vkAttachment.loadOp == vk::AttachmentLoadOp::eLoad || vkAttachment.stencilLoadOp == vk::AttachmentLoadOp::eLoad ? vk::ImageLayout::eDepthStencilAttachmentOptimal : vk::ImageLayout::eUndefined;
     vkAttachment.finalLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 
     vk::AttachmentReference& depthAttachment = depthAttachmentRefs.ExpandAndGetRef();

--- a/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
+++ b/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
@@ -27,6 +27,7 @@ public:
   static void Initialize(ezGALDeviceVulkan* pDevice, vk::Device device);
   static void DeInitialize();
 
+  static vk::PipelineCache GetPipelineCache() { return s_pipelineCache; }
   static vk::RenderPass RequestRenderPass(const ezGALRenderPassDescriptor& renderPass);
   static vk::Framebuffer RequestFrameBuffer(vk::RenderPass vkRenderPass, const ezGALFrameBufferDescriptor& frameBuffer);
 
@@ -36,30 +37,7 @@ public:
     vk::PushConstantRange m_pushConstants;
   };
 
-  struct GraphicsPipelineDesc
-  {
-    EZ_DECLARE_POD_TYPE();
-    ezGALRenderPassDescriptor m_renderPassDesc;
-    vk::RenderPass m_renderPass; // Created from ezGALRenderPassDescriptor above
-    vk::PipelineLayout m_layout; // Created from shader (descriptor sets)
-    ezEnum<ezGALPrimitiveTopology> m_topology;
-    const ezGALRasterizerStateVulkan* m_pCurrentRasterizerState = nullptr;
-    const ezGALBlendStateVulkan* m_pCurrentBlendState = nullptr;
-    const ezGALDepthStencilStateVulkan* m_pCurrentDepthStencilState = nullptr;
-    const ezGALShaderVulkan* m_pCurrentShader = nullptr;
-    const ezGALVertexDeclarationVulkan* m_pCurrentVertexDecl = nullptr;
-  };
-
-  struct ComputePipelineDesc
-  {
-    EZ_DECLARE_POD_TYPE();
-    vk::PipelineLayout m_layout;
-    const ezGALShaderVulkan* m_pCurrentShader = nullptr;
-  };
-
   static vk::PipelineLayout RequestPipelineLayout(const PipelineLayoutDesc& desc);
-  static vk::Pipeline RequestGraphicsPipeline(const GraphicsPipelineDesc& desc);
-  static vk::Pipeline RequestComputePipeline(const ComputePipelineDesc& desc);
 
   struct DescriptorSetLayoutDesc
   {
@@ -67,11 +45,6 @@ public:
     ezHybridArray<vk::DescriptorSetLayoutBinding, 6> m_bindings;
   };
   static vk::DescriptorSetLayout RequestDescriptorSetLayout(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc);
-
-  /// \brief Invalidates any caches that use this resource. Basically all pointer types in GraphicsPipelineDesc except for ezGALShaderVulkan.
-  static void ResourceDeleted(const ezRefCounted* pResource);
-  /// \brief Invalidates any caches that use this shader resource.
-  static void ShaderDeleted(const ezGALShaderVulkan* pShader);
 
 private:
   struct FramebufferKey
@@ -92,33 +65,23 @@ private:
     static ezUInt32 Hash(const PipelineLayoutDesc& desc);
     static bool Equal(const PipelineLayoutDesc& a, const PipelineLayoutDesc& b);
 
-    static bool Less(const GraphicsPipelineDesc& a, const GraphicsPipelineDesc& b);
-    static ezUInt32 Hash(const GraphicsPipelineDesc& desc);
-    static bool Equal(const GraphicsPipelineDesc& a, const GraphicsPipelineDesc& b);
-
-    static bool Less(const ComputePipelineDesc& a, const ComputePipelineDesc& b);
-    static bool Equal(const ComputePipelineDesc& a, const ComputePipelineDesc& b);
-
     static ezUInt32 Hash(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc) { return desc.m_uiHash; }
     static bool Equal(const ezGALShaderVulkan::DescriptorSetLayoutDesc& a, const ezGALShaderVulkan::DescriptorSetLayoutDesc& b);
   };
 
-public:
-  using GraphicsPipelineMap = ezMap<ezResourceCacheVulkan::GraphicsPipelineDesc, vk::Pipeline, ezResourceCacheVulkan::ResourceCacheHash>;
-  using ComputePipelineMap = ezMap<ezResourceCacheVulkan::ComputePipelineDesc, vk::Pipeline, ezResourceCacheVulkan::ResourceCacheHash>;
-
+private:
+  static ezResult SavePipelineCache();
+  static ezResult LoadPipelineCache(vk::PipelineCache& out_pipelineCache);
 
 private:
   static ezGALDeviceVulkan* s_pDevice;
   static vk::Device s_device;
+  static vk::PipelineCache s_pipelineCache;
+  // We have a N to 1 mapping for ezGALRenderingSetup to vk::RenderPass as multiple ezGALRenderingSetup can share the same RenderPassDesc.
   static ezHashTable<ezGALRenderPassDescriptor, vk::RenderPass, ResourceCacheHash> s_renderPasses;
   static ezHashTable<FramebufferKey, vk::Framebuffer, ResourceCacheHash> s_frameBuffers; // #TODO_VULKAN cache invalidation
 
   static ezHashTable<PipelineLayoutDesc, vk::PipelineLayout, ResourceCacheHash> s_pipelineLayouts;
-  static GraphicsPipelineMap s_graphicsPipelines;
-  static ComputePipelineMap s_computePipelines;
-  static ezMap<const ezRefCounted*, ezHybridArray<GraphicsPipelineMap::Iterator, 1>> s_graphicsPipelineUsedBy;
-  static ezMap<const ezRefCounted*, ezHybridArray<ComputePipelineMap::Iterator, 1>> s_computePipelineUsedBy;
 
   static ezHashTable<ezGALShaderVulkan::DescriptorSetLayoutDesc, vk::DescriptorSetLayout, ResourceCacheHash> s_descriptorSetLayouts;
 };

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -23,7 +23,8 @@ class ezGALTextureUnorderedAccessViewVulkan;
 class ezGALBufferUnorderedAccessViewVulkan;
 class ezGALDeviceVulkan;
 class ezFenceQueueVulkan;
-
+class ezGALGraphicsPipelineVulkan;
+class ezGALComputePipelineVulkan;
 
 class EZ_RENDERERVULKAN_DLL ezGALCommandEncoderImplVulkan : public ezGALCommandEncoderCommonPlatformInterface
 {
@@ -40,8 +41,6 @@ public:
 
   // ezGALCommandEncoderCommonPlatformInterface
   // State setting functions
-
-  virtual void SetShaderPlatform(const ezGALShader* pShader) override;
 
   virtual void SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer) override;
   virtual void SetSamplerStatePlatform(const ezShaderResourceBinding& binding, const ezGALSamplerState* pSamplerState) override;
@@ -126,16 +125,13 @@ public:
 
   virtual void SetIndexBufferPlatform(const ezGALBuffer* pIndexBuffer) override;
   virtual void SetVertexBufferPlatform(ezUInt32 uiSlot, const ezGALBuffer* pVertexBuffer, ezUInt32 uiOffset) override;
-  virtual void SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration) override;
-  virtual void SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum Topology) override;
 
-  virtual void SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& BlendFactor, ezUInt32 uiSampleMask) override;
-  virtual void SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState, ezUInt8 uiStencilRefValue) override;
-  virtual void SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState) override;
+  virtual void SetGraphicsPipelinePlatform(const ezGALGraphicsPipeline* pGraphicsPipeline) override;
+  virtual void SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline) override;
 
   virtual void SetViewportPlatform(const ezRectFloat& rect, float fMinDepth, float fMaxDepth) override;
   virtual void SetScissorRectPlatform(const ezRectU32& rect) override;
-
+  virtual void SetStencilReferencePlatform(ezUInt8 uiStencilRefValue) override;
 
 
 private:
@@ -178,10 +174,10 @@ private:
   bool m_bPushConstantsDirty = false;
 
   // Bound objects for deferred state flushes
-  ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
-  ezResourceCacheVulkan::GraphicsPipelineDesc m_PipelineDesc;
-  ezResourceCacheVulkan::ComputePipelineDesc m_ComputeDesc;
-  vk::Framebuffer m_frameBuffer;
+  const ezGALShaderVulkan* m_pShader = nullptr;
+  const ezGALGraphicsPipelineVulkan* m_pGraphicsPipeline = nullptr;
+  const ezGALComputePipelineVulkan* m_pComputePipeline = nullptr;
+
   vk::RenderPassBeginInfo m_renderPass;
   ezHybridArray<vk::ClearValue, EZ_GAL_MAX_RENDERTARGET_COUNT + 1> m_clearValues;
   vk::ImageAspectFlags m_depthMask = {};

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -18,9 +18,9 @@
 #include <RendererVulkan/Resources/UnorderedAccessViewVulkan.h>
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
-#include <RendererVulkan/State/StateVulkan.h>
-#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
 #include <RendererVulkan/State/ComputePipelineVulkan.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
+#include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
@@ -803,7 +803,7 @@ void ezGALCommandEncoderImplVulkan::BeginRenderingPlatform(const ezGALRenderingS
   m_GALDeviceVulkan.GetQueryPool().EnsureFreeQueryPoolSize(*m_pCommandBuffer);
 
   m_renderPass.renderPass = ezResourceCacheVulkan::RequestRenderPass(renderingSetup.GetRenderPass());
-  m_renderPass.framebuffer  = ezResourceCacheVulkan::RequestFrameBuffer(m_renderPass.renderPass, renderingSetup.GetFrameBuffer());
+  m_renderPass.framebuffer = ezResourceCacheVulkan::RequestFrameBuffer(m_renderPass.renderPass, renderingSetup.GetFrameBuffer());
   m_uiLayers = renderingSetup.GetFrameBuffer().m_uiSliceCount;
   ezSizeU32 size = renderingSetup.GetFrameBuffer().m_Size;
   SetScissorRectPlatform(ezRectU32(size.width, size.height));
@@ -866,7 +866,7 @@ void ezGALCommandEncoderImplVulkan::EndRenderingPlatform()
   m_uiLayers = 0;
 
   m_renderPass.renderPass = nullptr;
-  m_renderPass.framebuffer  = nullptr;
+  m_renderPass.framebuffer = nullptr;
 }
 
 void ezGALCommandEncoderImplVulkan::ClearPlatform(const ezColor& ClearColor, ezUInt32 uiRenderTargetClearMask, bool bClearDepth, bool bClearStencil, float fDepthClear, ezUInt8 uiStencilClear)

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -19,6 +19,8 @@
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
+#include <RendererVulkan/State/ComputePipelineVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
@@ -70,9 +72,9 @@ void ezGALCommandEncoderImplVulkan::Reset()
   m_bDescriptorsDirty = true;
   m_BoundVertexBuffersRange.Reset();
 
-  m_LayoutDesc = {};
-  m_PipelineDesc = ezResourceCacheVulkan::GraphicsPipelineDesc();
-  m_frameBuffer = nullptr;
+  m_pShader = nullptr;
+  m_pGraphicsPipeline = nullptr;
+  m_pComputePipeline = nullptr;
 
   m_viewport = vk::Viewport();
   m_scissor = vk::Rect2D();
@@ -146,16 +148,6 @@ void ezGALCommandEncoderImplVulkan::SetCurrentCommandBuffer(vk::CommandBuffer* c
 }
 
 // State setting functions
-
-void ezGALCommandEncoderImplVulkan::SetShaderPlatform(const ezGALShader* pShader)
-{
-  if (pShader != nullptr)
-  {
-    m_PipelineDesc.m_pCurrentShader = static_cast<const ezGALShaderVulkan*>(pShader);
-    m_ComputeDesc.m_pCurrentShader = m_PipelineDesc.m_pCurrentShader;
-    m_bPipelineStateDirty = true;
-  }
-}
 
 void ezGALCommandEncoderImplVulkan::SetConstantBufferPlatform(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer)
 {
@@ -810,16 +802,13 @@ void ezGALCommandEncoderImplVulkan::BeginRenderingPlatform(const ezGALRenderingS
   // We have to ensure we have enough queries before entering the render pass as we can't replenish pools while within.
   m_GALDeviceVulkan.GetQueryPool().EnsureFreeQueryPoolSize(*m_pCommandBuffer);
 
-  m_PipelineDesc.m_renderPassDesc = renderingSetup.GetRenderPass();
-  m_PipelineDesc.m_renderPass = ezResourceCacheVulkan::RequestRenderPass(renderingSetup.GetRenderPass());
-  m_frameBuffer = ezResourceCacheVulkan::RequestFrameBuffer(m_PipelineDesc.m_renderPass, renderingSetup.GetFrameBuffer());
+  m_renderPass.renderPass = ezResourceCacheVulkan::RequestRenderPass(renderingSetup.GetRenderPass());
+  m_renderPass.framebuffer  = ezResourceCacheVulkan::RequestFrameBuffer(m_renderPass.renderPass, renderingSetup.GetFrameBuffer());
   m_uiLayers = renderingSetup.GetFrameBuffer().m_uiSliceCount;
   ezSizeU32 size = renderingSetup.GetFrameBuffer().m_Size;
   SetScissorRectPlatform(ezRectU32(size.width, size.height));
 
   {
-    m_renderPass.renderPass = m_PipelineDesc.m_renderPass;
-    m_renderPass.framebuffer = m_frameBuffer;
     m_renderPass.renderArea.offset.setX(0).setY(0);
     m_renderPass.renderArea.extent.setHeight(size.height).setWidth(size.width);
 
@@ -875,9 +864,9 @@ void ezGALCommandEncoderImplVulkan::EndRenderingPlatform()
 
   m_depthMask = {};
   m_uiLayers = 0;
-  m_PipelineDesc.m_renderPassDesc = ezGALRenderPassDescriptor();
-  m_PipelineDesc.m_renderPass = nullptr;
-  m_frameBuffer = nullptr;
+
+  m_renderPass.renderPass = nullptr;
+  m_renderPass.framebuffer  = nullptr;
 }
 
 void ezGALCommandEncoderImplVulkan::ClearPlatform(const ezColor& ClearColor, ezUInt32 uiRenderTargetClearMask, bool bClearDepth, bool bClearStencil, float fDepthClear, ezUInt8 uiStencilClear)
@@ -901,7 +890,7 @@ void ezGALCommandEncoderImplVulkan::ClearPlatform(const ezColor& ClearColor, ezU
   {
     for (ezUInt32 i = 0; i < EZ_GAL_MAX_RENDERTARGET_COUNT; i++)
     {
-      if (uiRenderTargetClearMask & (1u << i) && i < m_PipelineDesc.m_renderPassDesc.m_uiRTCount)
+      if (uiRenderTargetClearMask & (1u << i) && i < m_pGraphicsPipeline->GetDescription().m_RenderPass.m_uiRTCount)
       {
         vk::ClearAttachment& attachment = attachments.ExpandAndGetRef();
         attachment.aspectMask = vk::ImageAspectFlagBits::eColor;
@@ -1005,53 +994,32 @@ void ezGALCommandEncoderImplVulkan::SetVertexBufferPlatform(ezUInt32 uiSlot, con
   }
 }
 
-void ezGALCommandEncoderImplVulkan::SetVertexDeclarationPlatform(const ezGALVertexDeclaration* pVertexDeclaration)
+void ezGALCommandEncoderImplVulkan::SetGraphicsPipelinePlatform(const ezGALGraphicsPipeline* pGraphicsPipeline)
 {
-  if (m_PipelineDesc.m_pCurrentVertexDecl != pVertexDeclaration)
+  if (m_pGraphicsPipeline != pGraphicsPipeline)
   {
-    m_PipelineDesc.m_pCurrentVertexDecl = static_cast<const ezGALVertexDeclarationVulkan*>(pVertexDeclaration);
-    m_bPipelineStateDirty = true;
-  }
-}
-
-void ezGALCommandEncoderImplVulkan::SetPrimitiveTopologyPlatform(ezGALPrimitiveTopology::Enum Topology)
-{
-  if (m_PipelineDesc.m_topology != Topology)
-  {
-    m_PipelineDesc.m_topology = Topology;
-    m_bPipelineStateDirty = true;
-  }
-}
-
-void ezGALCommandEncoderImplVulkan::SetBlendStatePlatform(const ezGALBlendState* pBlendState, const ezColor& BlendFactor, ezUInt32 uiSampleMask)
-{
-  // #TODO_VULKAN BlendFactor / uiSampleMask ?
-  if (m_PipelineDesc.m_pCurrentBlendState != pBlendState)
-  {
-    m_PipelineDesc.m_pCurrentBlendState = pBlendState != nullptr ? static_cast<const ezGALBlendStateVulkan*>(pBlendState) : nullptr;
-    m_bPipelineStateDirty = true;
-  }
-}
-
-void ezGALCommandEncoderImplVulkan::SetDepthStencilStatePlatform(const ezGALDepthStencilState* pDepthStencilState, ezUInt8 uiStencilRefValue)
-{
-  // #TODO_VULKAN uiStencilRefValue ?
-  if (m_PipelineDesc.m_pCurrentDepthStencilState != pDepthStencilState)
-  {
-    m_PipelineDesc.m_pCurrentDepthStencilState = pDepthStencilState != nullptr ? static_cast<const ezGALDepthStencilStateVulkan*>(pDepthStencilState) : nullptr;
-    m_bPipelineStateDirty = true;
-  }
-}
-
-void ezGALCommandEncoderImplVulkan::SetRasterizerStatePlatform(const ezGALRasterizerState* pRasterizerState)
-{
-  if (m_PipelineDesc.m_pCurrentRasterizerState != pRasterizerState)
-  {
-    m_PipelineDesc.m_pCurrentRasterizerState = pRasterizerState != nullptr ? static_cast<const ezGALRasterizerStateVulkan*>(pRasterizerState) : nullptr;
-    if (m_PipelineDesc.m_pCurrentRasterizerState->GetDescription().m_bScissorTest != m_bScissorEnabled)
+    m_pGraphicsPipeline = static_cast<const ezGALGraphicsPipelineVulkan*>(pGraphicsPipeline);
+    if (m_pGraphicsPipeline)
     {
-      m_bScissorEnabled = m_PipelineDesc.m_pCurrentRasterizerState->GetDescription().m_bScissorTest;
-      m_bViewportDirty = true;
+      m_pShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_pGraphicsPipeline->GetDescription().m_hShader));
+      m_bScissorEnabled = m_GALDeviceVulkan.GetRasterizerState(m_pGraphicsPipeline->GetDescription().m_hRasterizerState)->GetDescription().m_bScissorTest;
+    }
+    else
+    {
+      m_bScissorEnabled = false;
+    }
+    m_bPipelineStateDirty = true;
+  }
+}
+
+void ezGALCommandEncoderImplVulkan::SetComputePipelinePlatform(const ezGALComputePipeline* pComputePipeline)
+{
+  if (m_pComputePipeline != pComputePipeline)
+  {
+    m_pComputePipeline = static_cast<const ezGALComputePipelineVulkan*>(pComputePipeline);
+    if (m_pComputePipeline)
+    {
+      m_pShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_pComputePipeline->GetDescription().m_hShader));
     }
     m_bPipelineStateDirty = true;
   }
@@ -1079,6 +1047,11 @@ void ezGALCommandEncoderImplVulkan::SetScissorRectPlatform(const ezRectU32& rect
     m_scissor = scissor;
     m_bViewportDirty = true;
   }
+}
+
+void ezGALCommandEncoderImplVulkan::SetStencilReferencePlatform(ezUInt8 uiStencilRefValue)
+{
+  m_pCommandBuffer->setStencilReference(vk::StencilFaceFlagBits::eFrontAndBack, uiStencilRefValue);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1130,31 +1103,14 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
   EZ_PROFILE_SCOPE("FlushDeferredStateChanges");
   if (m_bPipelineStateDirty)
   {
-    if (!m_PipelineDesc.m_pCurrentShader)
-    {
-      ezLog::Error("No shader set");
-      return EZ_FAILURE;
-    }
-
-    const ezUInt32 uiSets = m_PipelineDesc.m_pCurrentShader->GetSetCount();
-    m_LayoutDesc.m_layout.SetCount(uiSets);
-    m_LayoutDesc.m_pushConstants = m_PipelineDesc.m_pCurrentShader->GetPushConstantRange();
-    for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
-    {
-      m_LayoutDesc.m_layout[uiSet] = m_PipelineDesc.m_pCurrentShader->GetDescriptorSetLayout(uiSet);
-    }
-
-    m_PipelineDesc.m_layout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
-    m_ComputeDesc.m_layout = m_PipelineDesc.m_layout;
-
     vk::Pipeline pipeline;
     if (m_bInsideCompute)
     {
-      pipeline = ezResourceCacheVulkan::RequestComputePipeline(m_ComputeDesc);
+      pipeline = m_pComputePipeline->GetPipeline();
     }
     else
     {
-      pipeline = ezResourceCacheVulkan::RequestGraphicsPipeline(m_PipelineDesc);
+      pipeline = m_pGraphicsPipeline->GetPipeline();
     }
 
     m_pCommandBuffer->bindPipeline(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, pipeline);
@@ -1211,22 +1167,21 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
 
   if (true /*m_bDescriptorsDirty*/)
   {
-    // #TODO_VULKAN we always create a new descriptor set as we don't know if a buffer was modified since the last draw call (ezGALBufferVulkan::DiscardBuffer).
-    //  Need to figure out a fast check if any buffer or buffer of a resource view was discarded.
+    // #TODO_VULKAN we always create a new descriptor set
     m_bDescriptorsDirty = false;
 
     m_DescriptorWrites.Clear();
     m_TextureAndSampler.Clear();
-    const ezUInt32 uiSets = m_PipelineDesc.m_pCurrentShader->GetSetCount();
+    const ezUInt32 uiSets = m_pShader->GetSetCount();
     m_DescriptorSets.SetCount(uiSets);
     m_DynamicUniformBuffers.Clear();
     m_DynamicUniformBufferOffsets.Clear();
 
     for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
     {
-      m_DescriptorSets[uiSet] = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_LayoutDesc.m_layout[uiSet]);
+      m_DescriptorSets[uiSet] = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_pShader->GetDescriptorSetLayout(uiSet));
 
-      ezArrayPtr<const ezShaderResourceBinding> bindingMapping = m_PipelineDesc.m_pCurrentShader->GetBindings(uiSet);
+      ezArrayPtr<const ezShaderResourceBinding> bindingMapping = m_pShader->GetBindings(uiSet);
       const ezUInt32 uiCount = bindingMapping.GetCount();
 
       m_Resources.EnsureCount(uiSet + 1);
@@ -1339,14 +1294,14 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
 
       ezDescriptorSetPoolVulkan::UpdateDescriptorSet(m_DescriptorSets[uiSet], m_DescriptorWrites);
     }
-    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), m_DynamicUniformBufferOffsets.GetCount(), m_DynamicUniformBufferOffsets.GetData());
+    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_pShader->GetPipelineLayout(), 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), m_DynamicUniformBufferOffsets.GetCount(), m_DynamicUniformBufferOffsets.GetData());
   }
 
-  if (m_bPushConstantsDirty && m_LayoutDesc.m_pushConstants.size > 0)
+  if (m_bPushConstantsDirty && m_pShader->GetPushConstantRange().size > 0)
   {
-    EZ_ASSERT_DEBUG(m_LayoutDesc.m_pushConstants.size == m_PushConstants.GetCount(), "");
+    EZ_ASSERT_DEBUG(m_pShader->GetPushConstantRange().size == m_PushConstants.GetCount(), "");
 
-    m_pCommandBuffer->pushConstants(m_PipelineDesc.m_layout, m_LayoutDesc.m_pushConstants.stageFlags, m_LayoutDesc.m_pushConstants.offset, m_PushConstants.GetCount(), m_PushConstants.GetData());
+    m_pCommandBuffer->pushConstants(m_pShader->GetPipelineLayout(), m_pShader->GetPushConstantRange().stageFlags, m_pShader->GetPushConstantRange().offset, m_PushConstants.GetCount(), m_PushConstants.GetData());
   }
 
   if (m_bRenderPassActive && m_pPipelineBarrier->IsDirty())

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -325,7 +325,7 @@ protected:
 
   virtual ezGALComputePipeline* CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description) override;
   virtual void DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline) override;
-  
+
   // Resource creation functions
 
   virtual ezGALShader* CreateShaderPlatform(const ezGALShaderCreationDescription& Description) override;

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <Foundation/Types/Bitflags.h>
@@ -321,7 +320,12 @@ protected:
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) override;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
 
+  virtual ezGALGraphicsPipeline* CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description) override;
+  virtual void DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline) override;
 
+  virtual ezGALComputePipeline* CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description) override;
+  virtual void DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline) override;
+  
   // Resource creation functions
 
   virtual ezGALShader* CreateShaderPlatform(const ezGALShaderCreationDescription& Description) override;

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -8,6 +8,7 @@
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/Profiling/Profiling.h>
 #include <Foundation/Reflection/ReflectionUtils.h>
+#include <Foundation/Utilities/Stats.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Device/SwapChain.h>
@@ -1634,6 +1635,14 @@ void ezGALDeviceVulkan::EndFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchains)
   }
   m_uiFrameCounter.Increment();
   m_uiCurrentPerFrameData = (m_uiFrameCounter) % FRAMES;
+
+  {
+    ezVulkanMemoryStatistics stats = ezMemoryAllocatorVulkan::GetStats();
+    ezStats::SetStat("Vulkan/BlockCount", stats.m_uiBlockCount);
+    ezStats::SetStat("Vulkan/AllocationCount", stats.m_uiAllocationCount);
+    ezStats::SetStat("Vulkan/BlockBytes", stats.m_uiBlockBytes);
+    ezStats::SetStat("Vulkan/AllocationBytes", stats.m_uiAllocationBytes);
+  }
 }
 
 ezUInt64 ezGALDeviceVulkan::GetCurrentFramePlatform() const

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -36,6 +36,8 @@
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
+#include <RendererVulkan/State/ComputePipelineVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
@@ -1015,7 +1017,6 @@ ezGALBlendState* ezGALDeviceVulkan::CreateBlendStatePlatform(const ezGALBlendSta
 void ezGALDeviceVulkan::DestroyBlendStatePlatform(ezGALBlendState* pBlendState)
 {
   ezGALBlendStateVulkan* pState = static_cast<ezGALBlendStateVulkan*>(pBlendState);
-  ezResourceCacheVulkan::ResourceDeleted(pState);
   pState->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pState);
 }
@@ -1038,7 +1039,6 @@ ezGALDepthStencilState* ezGALDeviceVulkan::CreateDepthStencilStatePlatform(const
 void ezGALDeviceVulkan::DestroyDepthStencilStatePlatform(ezGALDepthStencilState* pDepthStencilState)
 {
   ezGALDepthStencilStateVulkan* pVulkanDepthStencilState = static_cast<ezGALDepthStencilStateVulkan*>(pDepthStencilState);
-  ezResourceCacheVulkan::ResourceDeleted(pVulkanDepthStencilState);
   pVulkanDepthStencilState->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanDepthStencilState);
 }
@@ -1061,7 +1061,6 @@ ezGALRasterizerState* ezGALDeviceVulkan::CreateRasterizerStatePlatform(const ezG
 void ezGALDeviceVulkan::DestroyRasterizerStatePlatform(ezGALRasterizerState* pRasterizerState)
 {
   ezGALRasterizerStateVulkan* pVulkanRasterizerState = static_cast<ezGALRasterizerStateVulkan*>(pRasterizerState);
-  ezResourceCacheVulkan::ResourceDeleted(pVulkanRasterizerState);
   pVulkanRasterizerState->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanRasterizerState);
 }
@@ -1107,7 +1106,6 @@ ezGALShader* ezGALDeviceVulkan::CreateShaderPlatform(const ezGALShaderCreationDe
 void ezGALDeviceVulkan::DestroyShaderPlatform(ezGALShader* pShader)
 {
   ezGALShaderVulkan* pVulkanShader = static_cast<ezGALShaderVulkan*>(pShader);
-  ezResourceCacheVulkan::ShaderDeleted(pVulkanShader);
   pVulkanShader->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanShader);
 }
@@ -1364,7 +1362,6 @@ ezGALVertexDeclaration* ezGALDeviceVulkan::CreateVertexDeclarationPlatform(const
 void ezGALDeviceVulkan::DestroyVertexDeclarationPlatform(ezGALVertexDeclaration* pVertexDeclaration)
 {
   ezGALVertexDeclarationVulkan* pVertexDeclarationVulkan = static_cast<ezGALVertexDeclarationVulkan*>(pVertexDeclaration);
-  ezResourceCacheVulkan::ResourceDeleted(pVertexDeclarationVulkan);
   pVertexDeclarationVulkan->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVertexDeclarationVulkan);
 }
@@ -2141,5 +2138,48 @@ void ezGALDeviceVulkan::AddSignalSemaphore(const SemaphoreInfo& signalSemaphore)
     m_signalSemaphores.PushBack(signalSemaphore);
 }
 
+ezGALGraphicsPipeline* ezGALDeviceVulkan::CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description)
+{
+  ezGALGraphicsPipelineVulkan* pGraphicsPipeline = EZ_NEW(&m_Allocator, ezGALGraphicsPipelineVulkan, Description);
+
+  if (pGraphicsPipeline->InitPlatform(this).Succeeded())
+  {
+    return pGraphicsPipeline;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pGraphicsPipeline);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceVulkan::DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline)
+{
+  ezGALGraphicsPipelineVulkan* pGraphicsPipelineVulkan = static_cast<ezGALGraphicsPipelineVulkan*>(pGraphicsPipeline);
+  pGraphicsPipelineVulkan->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pGraphicsPipelineVulkan);
+}
+
+ezGALComputePipeline* ezGALDeviceVulkan::CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description)
+{
+  ezGALComputePipelineVulkan* pComputePipeline = EZ_NEW(&m_Allocator, ezGALComputePipelineVulkan, Description);
+  
+  if (pComputePipeline->InitPlatform(this).Succeeded())
+  {
+    return pComputePipeline;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pComputePipeline);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceVulkan::DestroyComputePipelinePlatform(ezGALComputePipeline* pComputePipeline)
+{
+  ezGALComputePipelineVulkan* pComputePipelineVulkan = static_cast<ezGALComputePipelineVulkan*>(pComputePipeline);
+  pComputePipelineVulkan->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pComputePipelineVulkan);
+}
 
 EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Device_Implementation_DeviceVulkan);

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -35,9 +35,9 @@
 #include <RendererVulkan/Resources/UnorderedAccessViewVulkan.h>
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
-#include <RendererVulkan/State/StateVulkan.h>
-#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
 #include <RendererVulkan/State/ComputePipelineVulkan.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
+#include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
@@ -2163,7 +2163,7 @@ void ezGALDeviceVulkan::DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* p
 ezGALComputePipeline* ezGALDeviceVulkan::CreateComputePipelinePlatform(const ezGALComputePipelineCreationDescription& Description)
 {
   ezGALComputePipelineVulkan* pComputePipeline = EZ_NEW(&m_Allocator, ezGALComputePipelineVulkan, Description);
-  
+
   if (pComputePipeline->InitPlatform(this).Succeeded())
   {
     return pComputePipeline;

--- a/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
@@ -264,8 +264,8 @@ ezVulkanMemoryStatistics ezMemoryAllocatorVulkan::GetStats()
     const VmaBudget& budget = budgets[i];
     stats.m_uiBlockCount += budget.statistics.blockCount;
     stats.m_uiAllocationCount += budget.statistics.allocationCount;
-    stats.m_uiBlockBytes += budget.statistics.blockBytes;
-    stats.m_uiAllocationBytes += budget.statistics.allocationBytes;
+    stats.m_uiBlockBytes += (ezUInt64)budget.statistics.blockBytes;
+    stats.m_uiAllocationBytes += (ezUInt64)budget.statistics.allocationBytes;
   }
   return stats;
 }

--- a/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
@@ -249,3 +249,23 @@ vk::Result ezMemoryAllocatorVulkan::InvalidateAllocation(ezVulkanAllocation allo
 {
   return (vk::Result)vmaInvalidateAllocation(m_pImpl->m_allocator, reinterpret_cast<VmaAllocation&>(alloc), offset, size);
 }
+
+EZ_DEFINE_AS_POD_TYPE(VmaBudget);
+
+ezVulkanMemoryStatistics ezMemoryAllocatorVulkan::GetStats()
+{
+  ezVulkanMemoryStatistics stats;
+  const ezUInt32 uiHeapCount = m_pImpl->m_allocator->GetMemoryHeapCount();
+  ezHybridArray<VmaBudget, 4> budgets;
+  budgets.SetCount(uiHeapCount);
+  vmaGetHeapBudgets(m_pImpl->m_allocator, budgets.GetData());
+  for (ezUInt32 i = 0; i < uiHeapCount; ++i)
+  {
+    const VmaBudget& budget = budgets[i];
+    stats.m_uiBlockCount += budget.statistics.blockCount;
+    stats.m_uiAllocationCount += budget.statistics.allocationCount;
+    stats.m_uiBlockBytes += budget.statistics.blockBytes;
+    stats.m_uiAllocationBytes += budget.statistics.allocationBytes;
+  }
+  return stats;
+}

--- a/Code/Engine/RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h
@@ -86,6 +86,16 @@ struct ezVulkanAllocationInfo
   const char* m_pName;
 };
 
+/// \brief Copy of VmaStatistics. Duplicated for abstraction purposes.
+struct ezVulkanMemoryStatistics
+{
+  ezUInt32 m_uiBlockCount = 0;
+  ezUInt32 m_uiAllocationCount = 0;
+  ezUInt32 m_uiBlockBytes = 0;
+  ezUInt32 m_uiAllocationBytes = 0;
+};
+
+
 /// \brief Thin abstraction layer over VulkanMemoryAllocator to allow for abstraction and prevent pulling in its massive header into other files.
 /// Functions are a subset of VMA's. To be extended once a use-case comes up.
 class EZ_RENDERERVULKAN_DLL ezMemoryAllocatorVulkan
@@ -109,6 +119,7 @@ public:
   static vk::Result FlushAllocation(ezVulkanAllocation alloc, vk::DeviceSize offset = 0, vk::DeviceSize size = VK_WHOLE_SIZE);
   static vk::Result InvalidateAllocation(ezVulkanAllocation alloc, vk::DeviceSize offset = 0, vk::DeviceSize size = VK_WHOLE_SIZE);
 
+  static ezVulkanMemoryStatistics GetStats();
 
 private:
   struct Impl;

--- a/Code/Engine/RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/MemoryAllocatorVulkan.h
@@ -91,8 +91,8 @@ struct ezVulkanMemoryStatistics
 {
   ezUInt32 m_uiBlockCount = 0;
   ezUInt32 m_uiAllocationCount = 0;
-  ezUInt32 m_uiBlockBytes = 0;
-  ezUInt32 m_uiAllocationBytes = 0;
+  ezUInt64 m_uiBlockBytes = 0;
+  ezUInt64 m_uiAllocationBytes = 0;
 };
 
 

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -150,6 +150,19 @@ ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
     }
   }
 
+  // Build pipeline Layout
+  {
+    ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
+    const ezUInt32 uiSets = GetSetCount();
+    m_LayoutDesc.m_layout.SetCount(uiSets);
+    m_LayoutDesc.m_pushConstants = GetPushConstantRange();
+    for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
+    {
+      m_LayoutDesc.m_layout[uiSet] = GetDescriptorSetLayout(uiSet);
+    }
+
+    m_PipelineLayout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
+  }
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h
@@ -4,6 +4,11 @@ vk::ShaderModule ezGALShaderVulkan::GetShader(ezGALShaderStage::Enum stage) cons
   return m_Shaders[stage];
 }
 
+vk::PipelineLayout ezGALShaderVulkan::GetPipelineLayout() const
+{
+  return m_PipelineLayout;
+}
+
 ezUInt32 ezGALShaderVulkan::GetSetCount() const
 {
   return m_SetBindings.GetCount();

--- a/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
@@ -23,6 +23,7 @@ public:
   virtual void SetDebugName(ezStringView sName) const override;
 
   EZ_ALWAYS_INLINE vk::ShaderModule GetShader(ezGALShaderStage::Enum stage) const;
+  EZ_ALWAYS_INLINE vk::PipelineLayout GetPipelineLayout() const;
   EZ_ALWAYS_INLINE ezUInt32 GetSetCount() const;
   EZ_ALWAYS_INLINE vk::DescriptorSetLayout GetDescriptorSetLayout(ezUInt32 uiSet = 0) const;
   EZ_ALWAYS_INLINE ezArrayPtr<const ezShaderResourceBinding> GetBindings(ezUInt32 uiSet = 0) const;
@@ -43,6 +44,7 @@ private:
   ezHybridArray<vk::DescriptorSetLayout, 4> m_descriptorSetLayout;
   ezHybridArray<ezHybridArray<ezShaderResourceBinding, 16>, 4> m_SetBindings;
   vk::ShaderModule m_Shaders[ezGALShaderStage::ENUM_COUNT];
+  vk::PipelineLayout m_PipelineLayout;
 };
 
 #include <RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/State/ComputePipelineVulkan.h
+++ b/Code/Engine/RendererVulkan/State/ComputePipelineVulkan.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <RendererFoundation/State/ComputePipeline.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
+#include <vulkan/vulkan.hpp>
+
+class ezGALDeviceVulkan;
+
+class EZ_RENDERERVULKAN_DLL ezGALComputePipelineVulkan : public ezGALComputePipeline
+{
+public:
+  ezGALComputePipelineVulkan(const ezGALComputePipelineCreationDescription& description);
+  ~ezGALComputePipelineVulkan();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  const vk::Pipeline& GetPipeline() const { return m_pipeline; }
+
+  virtual void SetDebugName(const char* szName) override;
+
+private:
+  vk::Pipeline m_pipeline;
+};

--- a/Code/Engine/RendererVulkan/State/GraphicsPipelineVulkan.h
+++ b/Code/Engine/RendererVulkan/State/GraphicsPipelineVulkan.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Foundation/Basics.h>
+#include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
+#include <vulkan/vulkan.hpp>
+
+class ezGALDeviceVulkan;
+
+class EZ_RENDERERVULKAN_DLL ezGALGraphicsPipelineVulkan : public ezGALGraphicsPipeline
+{
+public:
+  ezGALGraphicsPipelineVulkan(const ezGALGraphicsPipelineCreationDescription& description);
+  ~ezGALGraphicsPipelineVulkan();
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  const vk::Pipeline& GetPipeline() const { return m_pipeline; }
+
+  virtual void SetDebugName(const char* szName) override;
+
+private:
+  vk::Pipeline m_pipeline;
+};

--- a/Code/Engine/RendererVulkan/State/Implementation/ComputePipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/ComputePipelineVulkan.cpp
@@ -1,0 +1,60 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Cache/ResourceCacheVulkan.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Shader/ShaderVulkan.h>
+#include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
+#include <RendererVulkan/State/ComputePipelineVulkan.h>
+#include <RendererVulkan/State/StateVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
+
+ezGALComputePipelineVulkan::ezGALComputePipelineVulkan(const ezGALComputePipelineCreationDescription& description)
+  : ezGALComputePipeline(description)
+{
+}
+
+ezGALComputePipelineVulkan::~ezGALComputePipelineVulkan()
+{
+}
+
+ezResult ezGALComputePipelineVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  const ezGALShaderVulkan* pShader = static_cast<const ezGALShaderVulkan*>(pDevice->GetShader(m_Description.m_hShader));
+  if (pShader == nullptr)
+  {
+    ezLog::Error("Failed to create Vulkan Compute pipeline: Invalid shader handle.");
+    return EZ_FAILURE;
+  }
+
+  vk::ComputePipelineCreateInfo pipe;
+  pipe.layout = pShader->GetPipelineLayout();
+  {
+    vk::ShaderModule shader = pShader->GetShader(ezGALShaderStage::ComputeShader);
+    EZ_ASSERT_DEV(shader != nullptr, "No compute shader stage present in the bound shader");
+    pipe.stage.stage = ezConversionUtilsVulkan::GetShaderStage(ezGALShaderStage::ComputeShader);
+    pipe.stage.module = shader;
+    pipe.stage.pName = "main";
+  }
+
+  VK_ASSERT_DEV(pDeviceVulkan->GetVulkanDevice().createComputePipelines(ezResourceCacheVulkan::GetPipelineCache(), 1, &pipe, nullptr, &m_pipeline));
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALComputePipelineVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  if (m_pipeline)
+  {
+    pDeviceVulkan->DeleteLater(m_pipeline);
+    m_pipeline = nullptr;
+  }
+  return EZ_SUCCESS;
+}
+
+void ezGALComputePipelineVulkan::SetDebugName(const char* szName)
+{
+}

--- a/Code/Engine/RendererVulkan/State/Implementation/ComputePipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/ComputePipelineVulkan.cpp
@@ -55,6 +55,6 @@ ezResult ezGALComputePipelineVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-void ezGALComputePipelineVulkan::SetDebugName(const char* szName)
+void ezGALComputePipelineVulkan::SetDebugName(const char*)
 {
 }

--- a/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
@@ -1,0 +1,144 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Cache/ResourceCacheVulkan.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Shader/ShaderVulkan.h>
+#include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
+#include <RendererVulkan/State/StateVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
+
+ezGALGraphicsPipelineVulkan::ezGALGraphicsPipelineVulkan(const ezGALGraphicsPipelineCreationDescription& description)
+  : ezGALGraphicsPipeline(description)
+{
+}
+
+ezGALGraphicsPipelineVulkan::~ezGALGraphicsPipelineVulkan()
+{
+}
+
+ezResult ezGALGraphicsPipelineVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  const ezGALShaderVulkan* pShader = static_cast<const ezGALShaderVulkan*>(pDevice->GetShader(m_Description.m_hShader));
+  if (pShader == nullptr)
+  {
+    ezLog::Error("Failed to create Vulkan graphics pipeline: Invalid shader handle.");
+    return EZ_FAILURE;
+  }
+
+  const ezGALBlendStateVulkan* pBlendState = static_cast<const ezGALBlendStateVulkan*>(pDevice->GetBlendState(m_Description.m_hBlendState));
+  const ezGALDepthStencilStateVulkan* pDepthStencilState = static_cast<const ezGALDepthStencilStateVulkan*>(pDevice->GetDepthStencilState(m_Description.m_hDepthStencilState));
+  const ezGALRasterizerStateVulkan* pRasterizerState = static_cast<const ezGALRasterizerStateVulkan*>(pDevice->GetRasterizerState(m_Description.m_hRasterizerState));
+  const ezGALVertexDeclarationVulkan* pVertexDeclaration = static_cast<const ezGALVertexDeclarationVulkan*>(pDevice->GetVertexDeclaration(m_Description.m_hVertexDeclaration));
+
+  if (pBlendState == nullptr || pDepthStencilState == nullptr || pRasterizerState == nullptr)
+  {
+    ezLog::Error("Failed to create Vulkan graphics pipeline: Invalid state handle(s).");
+    return EZ_FAILURE;
+  }
+
+  vk::PipelineVertexInputStateCreateInfo dummy;
+  const vk::PipelineVertexInputStateCreateInfo* pVertexCreateInfo = nullptr;
+  ezHybridArray<vk::VertexInputBindingDescription, EZ_GAL_MAX_VERTEX_BUFFER_COUNT> bindings;
+  pVertexCreateInfo = pVertexDeclaration ? &pVertexDeclaration->GetCreateInfo() : &dummy;
+
+  vk::PipelineInputAssemblyStateCreateInfo input_assembly;
+  input_assembly.topology = ezConversionUtilsVulkan::GetPrimitiveTopology(m_Description.m_Topology);
+  const bool bTessellation = pShader->GetShader(ezGALShaderStage::HullShader) != nullptr;
+  if (bTessellation)
+  {
+    // Tessellation shaders always need to use patch list as the topology.
+    input_assembly.topology = vk::PrimitiveTopology::ePatchList;
+  }
+
+  // Specify rasterization state.
+  const vk::PipelineRasterizationStateCreateInfo* raster = pRasterizerState->GetRasterizerState();
+
+  // Our attachment will write to all color channels
+  vk::PipelineColorBlendStateCreateInfo blend = *pBlendState->GetBlendState();
+  blend.attachmentCount = m_Description.m_RenderPass.m_uiRTCount;
+
+  // We will have one viewport and scissor box.
+  vk::PipelineViewportStateCreateInfo viewport;
+  viewport.viewportCount = 1;
+  viewport.scissorCount = 1;
+
+  // Depth Testing
+  const vk::PipelineDepthStencilStateCreateInfo* depth_stencil = pDepthStencilState->GetDepthStencilState();
+
+  // Multisampling.
+  vk::PipelineMultisampleStateCreateInfo multisample;
+  multisample.rasterizationSamples = ezConversionUtilsVulkan::GetSamples(m_Description.m_RenderPass.m_Msaa);
+  if (multisample.rasterizationSamples != vk::SampleCountFlagBits::e1 && pBlendState->GetDescription().m_bAlphaToCoverage)
+  {
+    multisample.alphaToCoverageEnable = true;
+  }
+
+  // Specify that these states will be dynamic, i.e. not part of pipeline state object.
+  ezHybridArray<vk::DynamicState, 3> dynamics;
+  dynamics.PushBack(vk::DynamicState::eViewport);
+  dynamics.PushBack(vk::DynamicState::eScissor);
+  if (pDepthStencilState->GetDescription().m_bStencilTest)
+    dynamics.PushBack(vk::DynamicState::eStencilReference);
+
+  vk::PipelineDynamicStateCreateInfo dynamic;
+  dynamic.pDynamicStates = dynamics.GetData();
+  dynamic.dynamicStateCount = dynamics.GetCount();
+
+  // Load our SPIR-V shaders.
+  ezHybridArray<vk::PipelineShaderStageCreateInfo, 6> shader_stages;
+  for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
+  {
+    if (vk::ShaderModule shader = pShader->GetShader((ezGALShaderStage::Enum)i))
+    {
+      vk::PipelineShaderStageCreateInfo& stage = shader_stages.ExpandAndGetRef();
+      stage.stage = ezConversionUtilsVulkan::GetShaderStage((ezGALShaderStage::Enum)i);
+      stage.module = shader;
+      stage.pName = "main";
+    }
+  }
+
+  vk::PipelineTessellationStateCreateInfo tessellationInfo;
+  if (bTessellation)
+  {
+    tessellationInfo.patchControlPoints = pShader->GetDescription().m_ByteCodes[ezGALShaderStage::HullShader]->m_uiTessellationPatchControlPoints;
+  }
+
+  vk::GraphicsPipelineCreateInfo pipe;
+  pipe.renderPass = ezResourceCacheVulkan::RequestRenderPass(m_Description.m_RenderPass);
+  pipe.layout = pShader->GetPipelineLayout();
+  pipe.stageCount = shader_stages.GetCount();
+  pipe.pStages = shader_stages.GetData();
+  pipe.pVertexInputState = pVertexCreateInfo;
+  pipe.pInputAssemblyState = &input_assembly;
+  pipe.pRasterizationState = raster;
+  pipe.pColorBlendState = &blend;
+  pipe.pMultisampleState = &multisample;
+  pipe.pViewportState = &viewport;
+  pipe.pDepthStencilState = depth_stencil;
+  pipe.pDynamicState = &dynamic;
+  if (bTessellation)
+    pipe.pTessellationState = &tessellationInfo;
+
+  VK_ASSERT_DEV(pDeviceVulkan->GetVulkanDevice().createGraphicsPipelines(ezResourceCacheVulkan::GetPipelineCache(), 1, &pipe, nullptr, &m_pipeline));
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALGraphicsPipelineVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  if (m_pipeline)
+  {
+    pDeviceVulkan->DeleteLater(m_pipeline);
+    m_pipeline = nullptr;
+  }
+  return EZ_SUCCESS;
+}
+
+void ezGALGraphicsPipelineVulkan::SetDebugName(const char* szName)
+{
+}

--- a/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
@@ -139,6 +139,6 @@ ezResult ezGALGraphicsPipelineVulkan::DeInitPlatform(ezGALDevice* pDevice)
   return EZ_SUCCESS;
 }
 
-void ezGALGraphicsPipelineVulkan::SetDebugName(const char* szName)
+void ezGALGraphicsPipelineVulkan::SetDebugName(const char*)
 {
 }

--- a/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
+++ b/Code/Engine/RendererVulkan/Utils/ImageCopyVulkan.h
@@ -73,9 +73,10 @@ private:
   vk::RenderPass m_renderPass;
   ezShaderUtils::ezBuiltinShader m_shader;
   ezGALVertexDeclarationHandle m_hVertexDecl;
-  ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
-  ezResourceCacheVulkan::GraphicsPipelineDesc m_PipelineDesc;
+  ezGALGraphicsPipelineCreationDescription m_PipelineDesc;
+  ezGALGraphicsPipelineHandle m_hGalPipeline;
   vk::Pipeline m_pipeline;
+  const ezGALShaderVulkan* m_pShader = nullptr;
 
   // Cache to keep important resources alive
   // This avoids recreating them every frame

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -4,6 +4,7 @@
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Shader/ShaderUtils.h>
+#include <RendererFoundation/State/PipelineCache.h>
 #include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/RenderTargetViewVulkan.h>
@@ -11,12 +12,11 @@
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Resources/UnorderedAccessViewVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
-#include <RendererFoundation/State/PipelineCache.h>
-#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
 
 template <>
 struct ezHashHelper<ezGALShaderHandle>

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -15,6 +15,8 @@
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
+#include <RendererFoundation/State/PipelineCache.h>
+#include <RendererVulkan/State/GraphicsPipelineVulkan.h>
 
 template <>
 struct ezHashHelper<ezGALShaderHandle>
@@ -193,11 +195,11 @@ void ezImageCopyVulkan::Init(const ezGALTextureVulkan* pSource, const ezGALTextu
 
   // Render pass
   {
-    m_PipelineDesc.m_renderPassDesc = ezGALRenderPassDescriptor();
-    m_PipelineDesc.m_renderPassDesc.m_Msaa = targetDesc.m_SampleCount;
-    m_PipelineDesc.m_renderPassDesc.m_uiRTCount = 1;
-    m_PipelineDesc.m_renderPassDesc.m_ColorFormat[0] = m_pTarget->GetDescription().m_Format;
-    m_renderPass = ezResourceCacheVulkan::RequestRenderPass(m_PipelineDesc.m_renderPassDesc);
+    m_PipelineDesc.m_RenderPass = ezGALRenderPassDescriptor();
+    m_PipelineDesc.m_RenderPass.m_Msaa = targetDesc.m_SampleCount;
+    m_PipelineDesc.m_RenderPass.m_uiRTCount = 1;
+    m_PipelineDesc.m_RenderPass.m_ColorFormat[0] = m_pTarget->GetDescription().m_Format;
+    m_renderPass = ezResourceCacheVulkan::RequestRenderPass(m_PipelineDesc.m_RenderPass);
   }
 
   // Pipeline
@@ -206,12 +208,12 @@ void ezImageCopyVulkan::Init(const ezGALTextureVulkan* pSource, const ezGALTextu
     if (auto it = s_cache->m_shaders.Find(type); it.IsValid())
     {
       m_shader = it.Value();
-      m_PipelineDesc.m_pCurrentRasterizerState = static_cast<const ezGALRasterizerStateVulkan*>(m_GALDeviceVulkan.GetRasterizerState(m_shader.m_hRasterizerState));
-      m_PipelineDesc.m_pCurrentBlendState = static_cast<const ezGALBlendStateVulkan*>(m_GALDeviceVulkan.GetBlendState(m_shader.m_hBlendState));
-      m_PipelineDesc.m_pCurrentDepthStencilState = static_cast<const ezGALDepthStencilStateVulkan*>(m_GALDeviceVulkan.GetDepthStencilState(m_shader.m_hDepthStencilState));
-      m_PipelineDesc.m_pCurrentShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_shader.m_hActiveGALShader));
+      m_PipelineDesc.m_hRasterizerState = m_shader.m_hRasterizerState;
+      m_PipelineDesc.m_hBlendState = m_shader.m_hBlendState;
+      m_PipelineDesc.m_hDepthStencilState = m_shader.m_hDepthStencilState;
+      m_PipelineDesc.m_hShader = m_shader.m_hActiveGALShader;
 
-      if (!m_PipelineDesc.m_pCurrentRasterizerState || !m_PipelineDesc.m_pCurrentBlendState || !m_PipelineDesc.m_pCurrentDepthStencilState || !m_PipelineDesc.m_pCurrentShader)
+      if (m_PipelineDesc.m_hRasterizerState.IsInvalidated() || m_PipelineDesc.m_hBlendState.IsInvalidated() || m_PipelineDesc.m_hDepthStencilState.IsInvalidated() || m_PipelineDesc.m_hShader.IsInvalidated())
       {
         s_cache->m_shaders.Clear();
         for (auto& kv : (s_cache->m_vertexDeclarations))
@@ -222,21 +224,20 @@ void ezImageCopyVulkan::Init(const ezGALTextureVulkan* pSource, const ezGALTextu
       }
     }
 
-    if (!m_PipelineDesc.m_pCurrentRasterizerState || !m_PipelineDesc.m_pCurrentBlendState || !m_PipelineDesc.m_pCurrentDepthStencilState || !m_PipelineDesc.m_pCurrentShader)
+    if (m_PipelineDesc.m_hRasterizerState.IsInvalidated() || m_PipelineDesc.m_hBlendState.IsInvalidated() || m_PipelineDesc.m_hDepthStencilState.IsInvalidated() || m_PipelineDesc.m_hShader.IsInvalidated())
     {
       ezShaderUtils::RequestBuiltinShader(type, m_shader);
       s_cache->m_shaders.Insert(type, m_shader);
 
-      m_PipelineDesc.m_pCurrentRasterizerState = static_cast<const ezGALRasterizerStateVulkan*>(m_GALDeviceVulkan.GetRasterizerState(m_shader.m_hRasterizerState));
-      m_PipelineDesc.m_pCurrentBlendState = static_cast<const ezGALBlendStateVulkan*>(m_GALDeviceVulkan.GetBlendState(m_shader.m_hBlendState));
-      m_PipelineDesc.m_pCurrentDepthStencilState = static_cast<const ezGALDepthStencilStateVulkan*>(m_GALDeviceVulkan.GetDepthStencilState(m_shader.m_hDepthStencilState));
-      m_PipelineDesc.m_pCurrentShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(m_shader.m_hActiveGALShader));
+      m_PipelineDesc.m_hRasterizerState = m_shader.m_hRasterizerState;
+      m_PipelineDesc.m_hBlendState = m_shader.m_hBlendState;
+      m_PipelineDesc.m_hDepthStencilState = m_shader.m_hDepthStencilState;
+      m_PipelineDesc.m_hShader = m_shader.m_hActiveGALShader;
 
-      EZ_ASSERT_DEV(m_PipelineDesc.m_pCurrentRasterizerState && m_PipelineDesc.m_pCurrentBlendState && m_PipelineDesc.m_pCurrentDepthStencilState && m_PipelineDesc.m_pCurrentShader, "");
+      EZ_ASSERT_DEV(!m_PipelineDesc.m_hRasterizerState.IsInvalidated() && !m_PipelineDesc.m_hBlendState.IsInvalidated() && !m_PipelineDesc.m_hDepthStencilState.IsInvalidated() && !m_PipelineDesc.m_hShader.IsInvalidated(), "");
     }
 
-    m_PipelineDesc.m_renderPass = m_renderPass;
-    m_PipelineDesc.m_topology = ezGALPrimitiveTopology::Triangles;
+    m_PipelineDesc.m_Topology = ezGALPrimitiveTopology::Triangles;
 
     // Vertex declaration
     {
@@ -251,17 +252,13 @@ void ezImageCopyVulkan::Init(const ezGALTextureVulkan* pSource, const ezGALTextu
         m_hVertexDecl = m_GALDeviceVulkan.CreateVertexDeclaration(desc);
         s_cache->m_vertexDeclarations.Insert(m_shader.m_hActiveGALShader, m_hVertexDecl);
       }
-      m_PipelineDesc.m_pCurrentVertexDecl = static_cast<const ezGALVertexDeclarationVulkan*>(m_GALDeviceVulkan.GetVertexDeclaration(m_hVertexDecl));
+      m_PipelineDesc.m_hVertexDeclaration = m_hVertexDecl;
     }
 
-    const ezUInt32 uiSets = m_PipelineDesc.m_pCurrentShader->GetSetCount();
-    m_LayoutDesc.m_layout.SetCount(uiSets);
-    for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
-    {
-      m_LayoutDesc.m_layout[uiSet] = m_PipelineDesc.m_pCurrentShader->GetDescriptorSetLayout(uiSet);
-    }
-    m_PipelineDesc.m_layout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
-    m_pipeline = ezResourceCacheVulkan::RequestGraphicsPipeline(m_PipelineDesc);
+    m_hGalPipeline = ezGALPipelineCache::GetPipeline(m_PipelineDesc);
+    const ezGALGraphicsPipelineVulkan* pGraphicsPipeline = static_cast<const ezGALGraphicsPipelineVulkan*>(m_GALDeviceVulkan.GetGraphicsPipeline(m_hGalPipeline));
+    m_pipeline = pGraphicsPipeline->GetPipeline();
+    m_pShader = static_cast<const ezGALShaderVulkan*>(m_GALDeviceVulkan.GetShader(pGraphicsPipeline->GetDescription().m_hShader));
   }
 }
 
@@ -391,7 +388,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
   }
 
   // Descriptor Set
-  vk::DescriptorSet descriptorSet = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_LayoutDesc.m_layout[0]);
+  vk::DescriptorSet descriptorSet = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_pShader->GetDescriptorSetLayout(0));
   {
     ezHybridArray<vk::WriteDescriptorSet, 16> descriptorWrites;
 
@@ -399,7 +396,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
     sourceInfo.imageLayout = ezConversionUtilsVulkan::GetDefaultLayout(m_pSource->GetImageFormat());
     sourceInfo.imageView = sourceView;
 
-    ezArrayPtr<const ezShaderResourceBinding> bindingMapping = m_PipelineDesc.m_pCurrentShader->GetBindings();
+    ezArrayPtr<const ezShaderResourceBinding> bindingMapping = m_pShader->GetBindings();
     const ezUInt32 uiCount = bindingMapping.GetCount();
     for (ezUInt32 i = 0; i < uiCount; i++)
     {
@@ -431,14 +428,14 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
       }
     }
     ezDescriptorSetPoolVulkan::UpdateDescriptorSet(descriptorSet, descriptorWrites);
-    commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_PipelineDesc.m_layout, 0, 1, &descriptorSet, 0, nullptr);
+    commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_pShader->GetPipelineLayout(), 0, 1, &descriptorSet, 0, nullptr);
   }
 
   // Render
   {
     {
       vk::RenderPassBeginInfo begin;
-      begin.renderPass = m_PipelineDesc.m_renderPass;
+      begin.renderPass = ezResourceCacheVulkan::RequestRenderPass(m_PipelineDesc.m_RenderPass);
       begin.framebuffer = frameBuffer;
       begin.renderArea.offset.setX(0).setY(0);
       begin.renderArea.extent.setWidth(extends.x).setHeight(extends.y);

--- a/Code/UnitTests/RendererTest/Basics/BlendStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/BlendStates.cpp
@@ -37,7 +37,7 @@ ezTestAppRun ezRendererTestBasics::SubtestBlendStates()
   hState = m_pDevice->CreateBlendState(StateDesc);
   EZ_ASSERT_DEV(!hState.IsInvalidated(), "Couldn't create blend state!");
 
-  ezRenderContext::GetDefaultInstance()->GetCommandEncoder()->SetBlendState(hState);
+  ezRenderContext::GetDefaultInstance()->SetBlendState(hState);
 
   RenderObjects(ezShaderBindFlags::NoBlendState);
 

--- a/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
@@ -120,7 +120,7 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
   hState = m_pDevice->CreateRasterizerState(RasterStateDesc);
   EZ_ASSERT_DEV(!hState.IsInvalidated(), "Couldn't create rasterizer state!");
 
-  ezRenderContext::GetDefaultInstance()->GetCommandEncoder()->SetRasterizerState(hState);
+  ezRenderContext::GetDefaultInstance()->SetRasterizerState(hState);
 
   ezRenderContext::GetDefaultInstance()->GetCommandEncoder()->SetScissorRect(ezRectU32(100, 50, GetResolution().width / 2, GetResolution().height / 2));
 

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
@@ -18,6 +18,8 @@ ezResult ezRendererTestSwapChain::InitializeSubTest(ezInt32 iIdentifier)
     ezWindowCreationDesc WindowCreationDesc;
     WindowCreationDesc.m_Resolution.width = m_CurrentWindowSize.width;
     WindowCreationDesc.m_Resolution.height = m_CurrentWindowSize.height;
+    WindowCreationDesc.m_bClipMouseCursor = false;
+    WindowCreationDesc.m_bShowMouseCursor = true;
     WindowCreationDesc.m_WindowMode = (iIdentifier == SubTests::ST_ResizeWindow) ? ezWindowMode::WindowResizable : ezWindowMode::WindowFixedResolution;
     // ezGameStateWindow will write any window size changes into the config.
     m_pWindow = EZ_DEFAULT_NEW(ezGameStateWindow, WindowCreationDesc);

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -100,10 +100,20 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, StateDeduplication)
       depthDesc = pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState)->GetDescription();
 
       hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
-      ezResourceManager::FreeAllUnusedResources();
     }
-    ezUInt32 uiDeleted = ezResourceManager::FreeAllUnusedResources();
-    EZ_TEST_INT_MSG(uiDeleted, 2, "This should have freed the ezShaderResource and the ezShaderPermutationResource");
+
+    ezUInt32 uiUnloaded = 0;
+    for (ezUInt32 tries = 0; tries < 3; ++tries)
+    {
+      // if a resource is in a loading queue, unloading it can actually 'fail' for a short time
+      uiUnloaded += ezResourceManager::FreeAllUnusedResources();
+
+      if (uiUnloaded == 2)
+        break;
+
+      ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+    }
+    EZ_TEST_INT_MSG(uiUnloaded, 2, "This should have freed the ezShaderResource and the ezShaderPermutationResource");
 
     pDevice->BeginFrame(1);
     pDevice->EndFrame();

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -1,12 +1,12 @@
 #include <RendererTest/RendererTestPCH.h>
 
+#include <RendererCore/Shader/ShaderPermutationResource.h>
+#include <RendererCore/ShaderCompiler/ShaderManager.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/State/GraphicsPipeline.h>
 #include <RendererFoundation/State/State.h>
 #include <RendererFoundation/Utils/RingBufferTracker.h>
 #include <RendererTest/TestClass/SimpleRendererTest.h>
-#include <RendererCore/ShaderCompiler/ShaderManager.h>
-#include <RendererCore/Shader/ShaderPermutationResource.h>
 
 namespace
 {

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -10,7 +10,7 @@
 
 namespace
 {
-  void VerifyDependenciesExist(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
+  void VerifyDependenciesExist(ezGALDevice* pDevice, const ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
   {
     EZ_TEST_BOOL(pDevice->GetShader(graphicsPipelineDesc.m_hShader) != nullptr);
     EZ_TEST_BOOL(pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState) != nullptr);
@@ -18,7 +18,7 @@ namespace
     EZ_TEST_BOOL(pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState) != nullptr);
   }
 
-  void VerifyDependenciesAreDestroyed(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
+  void VerifyDependenciesAreDestroyed(ezGALDevice* pDevice, const ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
   {
     EZ_TEST_BOOL(pDevice->GetShader(graphicsPipelineDesc.m_hShader) == nullptr);
     EZ_TEST_BOOL(pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState) == nullptr);
@@ -26,7 +26,7 @@ namespace
     EZ_TEST_BOOL(pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState) == nullptr);
   }
 
-  void VerifyDependenciesRefCount(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc, ezUInt32 uiRefCount)
+  void VerifyDependenciesRefCount(ezGALDevice* pDevice, const ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc, ezUInt32 uiRefCount)
   {
     EZ_TEST_INT(pDevice->GetShader(graphicsPipelineDesc.m_hShader)->GetRefCount(), uiRefCount);
     EZ_TEST_INT(pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState)->GetRefCount(), uiRefCount);
@@ -34,7 +34,7 @@ namespace
     EZ_TEST_INT(pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState)->GetRefCount(), uiRefCount);
   }
 
-  void DestroyDependencies(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
+  void DestroyDependencies(ezGALDevice* pDevice, const ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
   {
     pDevice->DestroyShader(graphicsPipelineDesc.m_hShader);
     pDevice->DestroyBlendState(graphicsPipelineDesc.m_hBlendState);

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -5,6 +5,8 @@
 #include <RendererFoundation/State/State.h>
 #include <RendererFoundation/Utils/RingBufferTracker.h>
 #include <RendererTest/TestClass/SimpleRendererTest.h>
+#include <RendererCore/ShaderCompiler/ShaderManager.h>
+#include <RendererCore/Shader/ShaderPermutationResource.h>
 
 namespace
 {

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -1,0 +1,249 @@
+#include <RendererTest/RendererTestPCH.h>
+
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/State/GraphicsPipeline.h>
+#include <RendererFoundation/State/State.h>
+#include <RendererFoundation/Utils/RingBufferTracker.h>
+#include <RendererTest/TestClass/SimpleRendererTest.h>
+
+namespace
+{
+  void VerifyDependenciesExist(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
+  {
+    EZ_TEST_BOOL(pDevice->GetShader(graphicsPipelineDesc.m_hShader) != nullptr);
+    EZ_TEST_BOOL(pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState) != nullptr);
+    EZ_TEST_BOOL(pDevice->GetRasterizerState(graphicsPipelineDesc.m_hRasterizerState) != nullptr);
+    EZ_TEST_BOOL(pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState) != nullptr);
+  }
+
+  void VerifyDependenciesAreDestroyed(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
+  {
+    EZ_TEST_BOOL(pDevice->GetShader(graphicsPipelineDesc.m_hShader) == nullptr);
+    EZ_TEST_BOOL(pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState) == nullptr);
+    EZ_TEST_BOOL(pDevice->GetRasterizerState(graphicsPipelineDesc.m_hRasterizerState) == nullptr);
+    EZ_TEST_BOOL(pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState) == nullptr);
+  }
+
+  void VerifyDependenciesRefCount(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc, ezUInt32 uiRefCount)
+  {
+    EZ_TEST_INT(pDevice->GetShader(graphicsPipelineDesc.m_hShader)->GetRefCount(), uiRefCount);
+    EZ_TEST_INT(pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState)->GetRefCount(), uiRefCount);
+    EZ_TEST_INT(pDevice->GetRasterizerState(graphicsPipelineDesc.m_hRasterizerState)->GetRefCount(), uiRefCount);
+    EZ_TEST_INT(pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState)->GetRefCount(), uiRefCount);
+  }
+
+  void DestroyDependencies(ezGALDevice* pDevice, ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
+  {
+    pDevice->DestroyShader(graphicsPipelineDesc.m_hShader);
+    pDevice->DestroyBlendState(graphicsPipelineDesc.m_hBlendState);
+    pDevice->DestroyDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState);
+    pDevice->DestroyRasterizerState(graphicsPipelineDesc.m_hRasterizerState);
+  }
+} // namespace
+
+EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, StateDeduplication)
+
+
+
+{
+  ezGALShaderCreationDescription shaderDesc;
+  ezGALBlendStateCreationDescription blendDesc;
+  ezGALRasterizerStateCreationDescription rasterDesc;
+  ezGALDepthStencilStateCreationDescription depthDesc;
+  ezGALRenderPassDescriptor renderPassDesc;
+
+  ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
+
+  auto CreateDependencies = [&](ezGALGraphicsPipelineCreationDescription& ref_graphicsPipelineDesc)
+  {
+    ref_graphicsPipelineDesc.m_hShader = pDevice->CreateShader(shaderDesc);
+    ref_graphicsPipelineDesc.m_hBlendState = pDevice->CreateBlendState(blendDesc);
+    ref_graphicsPipelineDesc.m_hDepthStencilState = pDevice->CreateDepthStencilState(depthDesc);
+    ref_graphicsPipelineDesc.m_hRasterizerState = pDevice->CreateRasterizerState(rasterDesc);
+    ref_graphicsPipelineDesc.m_RenderPass = renderPassDesc;
+  };
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "LoadAndFreeTestData")
+  {
+    renderPassDesc.m_uiRTCount = 1;
+    renderPassDesc.m_DepthFormat = ezGALResourceFormat::D24S8;
+    renderPassDesc.m_ColorFormat[0] = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
+    renderPassDesc.m_ColorLoadOp[0] = ezGALRenderTargetLoadOp::Clear;
+    renderPassDesc.m_ColorStoreOp[0] = ezGALRenderTargetStoreOp::Store;
+
+    ezGALGraphicsPipelineCreationDescription graphicsPipelineDesc;
+    ezGALGraphicsPipelineHandle hGraphicsPipeline;
+    {
+      ezShaderResourceHandle hShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/MostBasicTriangle.ezShader");
+
+      ezHashedString sFalse = ezMakeHashedString("FALSE");
+      ezHashTable<ezHashedString, ezHashedString> permutationVariables;
+      permutationVariables[ezMakeHashedString("CLIP_SPACE_FLIPPED")] = sFalse;
+      permutationVariables[ezMakeHashedString("MSAA")] = sFalse;
+      permutationVariables[ezMakeHashedString("TOPOLOGY")] = ezMakeHashedString("TOPOLOGY_TRIANGLES");
+
+      ezShaderPermutationResourceHandle hActiveShaderPermutation = ezShaderManager::PreloadSinglePermutation(hShader, permutationVariables, false);
+
+      ezResourceLock<ezShaderPermutationResource> pShaderPermutation(hActiveShaderPermutation, ezResourceAcquireMode::BlockTillLoaded);
+
+      graphicsPipelineDesc.m_hShader = pShaderPermutation->GetGALShader();
+      graphicsPipelineDesc.m_hBlendState = pShaderPermutation->GetBlendState();
+      graphicsPipelineDesc.m_hRasterizerState = pShaderPermutation->GetRasterizerState();
+      graphicsPipelineDesc.m_hDepthStencilState = pShaderPermutation->GetDepthStencilState();
+      graphicsPipelineDesc.m_RenderPass = renderPassDesc;
+
+      shaderDesc = pDevice->GetShader(graphicsPipelineDesc.m_hShader)->GetDescription();
+      blendDesc = pDevice->GetBlendState(graphicsPipelineDesc.m_hBlendState)->GetDescription();
+      rasterDesc = pDevice->GetRasterizerState(graphicsPipelineDesc.m_hRasterizerState)->GetDescription();
+      depthDesc = pDevice->GetDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState)->GetDescription();
+
+      hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+      ezResourceManager::FreeAllUnusedResources();
+    }
+    ezUInt32 uiDeleted = ezResourceManager::FreeAllUnusedResources();
+    EZ_TEST_INT_MSG(uiDeleted, 2, "This should have freed the ezShaderResource and the ezShaderPermutationResource");
+
+    pDevice->BeginFrame(1);
+    pDevice->EndFrame();
+
+    VerifyDependenciesExist(pDevice, graphicsPipelineDesc);
+
+    // This will mark the pipeline and its dependencies as dead objects which will be freed in the next frame loop.
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+
+    pDevice->BeginFrame(1);
+    pDevice->EndFrame();
+
+    EZ_TEST_BOOL(pDevice->GetGraphicsPipeline(hGraphicsPipeline) == nullptr);
+    VerifyDependenciesAreDestroyed(pDevice, graphicsPipelineDesc);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ReferenceCounting")
+  {
+    ezGALGraphicsPipelineCreationDescription graphicsPipelineDesc;
+    ezGALGraphicsPipelineHandle hGraphicsPipeline;
+
+    CreateDependencies(graphicsPipelineDesc);
+
+    VerifyDependenciesExist(pDevice, graphicsPipelineDesc);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 1);
+
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 2);
+
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 1);
+    DestroyDependencies(pDevice, graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 0);
+
+    pDevice->BeginFrame(1);
+    pDevice->EndFrame();
+
+    EZ_TEST_BOOL(pDevice->GetGraphicsPipeline(hGraphicsPipeline) == nullptr);
+    VerifyDependenciesAreDestroyed(pDevice, graphicsPipelineDesc);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ReviveDeadObjects")
+  {
+    ezGALGraphicsPipelineCreationDescription graphicsPipelineDesc;
+    ezGALGraphicsPipelineHandle hGraphicsPipeline;
+
+    CreateDependencies(graphicsPipelineDesc);
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    DestroyDependencies(pDevice, graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 0);
+
+    // This should revive the dead objects
+    CreateDependencies(graphicsPipelineDesc);
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 2);
+
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    DestroyDependencies(pDevice, graphicsPipelineDesc);
+
+    pDevice->BeginFrame(1);
+    pDevice->EndFrame();
+
+    EZ_TEST_BOOL(pDevice->GetGraphicsPipeline(hGraphicsPipeline) == nullptr);
+    VerifyDependenciesAreDestroyed(pDevice, graphicsPipelineDesc);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "OddDestructionOrder")
+  {
+    ezGALGraphicsPipelineCreationDescription graphicsPipelineDesc;
+    ezGALGraphicsPipelineHandle hGraphicsPipeline;
+
+    CreateDependencies(graphicsPipelineDesc);
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    // Destroy dependencies first this time
+    DestroyDependencies(pDevice, graphicsPipelineDesc);
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 0);
+
+    // This should revive the dead objects
+    CreateDependencies(graphicsPipelineDesc);
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 2);
+
+    // Destroy the dependencies only partially
+    pDevice->DestroyShader(graphicsPipelineDesc.m_hShader);
+    pDevice->DestroyBlendState(graphicsPipelineDesc.m_hBlendState);
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+
+    graphicsPipelineDesc.m_hShader = pDevice->CreateShader(shaderDesc);
+    graphicsPipelineDesc.m_hBlendState = pDevice->CreateBlendState(blendDesc);
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 2);
+
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    DestroyDependencies(pDevice, graphicsPipelineDesc);
+
+    pDevice->BeginFrame(1);
+    pDevice->EndFrame();
+
+    EZ_TEST_BOOL(pDevice->GetGraphicsPipeline(hGraphicsPipeline) == nullptr);
+    VerifyDependenciesAreDestroyed(pDevice, graphicsPipelineDesc);
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ReviveDeadDependencies")
+  {
+    ezGALGraphicsPipelineCreationDescription graphicsPipelineDesc;
+    ezGALGraphicsPipelineHandle hGraphicsPipeline;
+
+    CreateDependencies(graphicsPipelineDesc);
+    DestroyDependencies(pDevice, graphicsPipelineDesc);
+    // Now this is technically invalid code as we are creating a pipeline referencing dead handles. However, this works for all GAL state objects right now and is a side-effect of the fact that objects are deleted at the end of the frame.
+    hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 1);
+
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+
+    EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
+    VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 0);
+
+    pDevice->BeginFrame(1);
+    pDevice->EndFrame();
+
+    EZ_TEST_BOOL(pDevice->GetGraphicsPipeline(hGraphicsPipeline) == nullptr);
+    VerifyDependenciesAreDestroyed(pDevice, graphicsPipelineDesc);
+  }
+}

--- a/Data/UnitTests/GameEngineTest/RmlUi/RuntimeConfigs/Window.ddl
+++ b/Data/UnitTests/GameEngineTest/RmlUi/RuntimeConfigs/Window.ddl
@@ -3,8 +3,8 @@ WindowDesc
 	string %Title{"RmlUi"}
 	string %Mode{"Window"}
 	Vec2u %Resolution{uint32{640,360}}
-	bool %ClipMouseCursor{true}
-	bool %ShowMouseCursor{false}
+	bool %ClipMouseCursor{false}
+	bool %ShowMouseCursor{true}
 	bool %SetForegroundOnInit{true}
 	bool %CenterWindowOnDisplay{true}
 }


### PR DESCRIPTION
## Pipeline State Objects
* New GAL resource: `ezGALGraphicsPipelineCreationDescription` creates a `ezGALGraphicsPipeline`.
* New GAL resource: `ezGALComputePipelineCreationDescription` creates a `ezGALComputePipeline`.
* `ezGALCommandEncoder::SetGraphicsPipeline` and `SetComputePipeline` replaces these previous functions: `SetShader`, `SetVertexDeclaration`, `SetPrimitiveTopology`, `SetBlendState`, `SetDepthStencilState`, `SetRasterizerState`. Same is true for the `ezGALCommandEncoderCommonPlatformInterface`.
* Creating a pipeline increases the reference count on all valid handles in the descriptor.
* Added `ezGALPipelineCache` which is just a hashmap from descriptor to handle which holds a reference to each pipeline. These are never freed until shutdown. This is just a stopgap solution until the high level interface changes, as `ezRenderContext` interface remains the same for now.
* `SetBlendState`, `SetDepthStencilState`, `SetRasterizerState` have been moved from `ezGALCommandEncoder` to `ezRenderContext`.
  * `SetBlendState` parameter `blendFactor` has been removed as it was never implemented.
  * `SetBlendState` parameter `uiSampleMask` has been removed as it required created a new PSO when changed. Also unused so far.
  * `SetDepthStencilState` parameter `uiStencilRefValue` has been moved into a separate function `ezGALCommandEncoder::SetStencilReference`.

## Vulkan
* With the now existing pipeline resources, most of the code in `ezResourceCacheVulkan` has moved into the new resource types. The only changes are:
  * `vk::DynamicState::eScissor` is now dependent on the `ezGALRasterizerStateCreationDescription::m_bScissorTest` flag.
  * `vk::DynamicState::eStencilReference` was added and is dependent on `ezGALDepthStencilStateCreationDescription::m_bStencilTest`.
* `ezResourceCacheVulkan` now maintains a `vk::PipelineCache` on disk. This follows the best practices outlined here: https://zeux.io/2019/07/17/serializing-pipeline-cache/.
* The `ezGALShaderVulkan` now holds a `vk::PipelineLayout` instead of it being generated on the fly in the `ezGALCommandEncoderImplVulkan`.

## Misc
* Guard against shader compiler generating invalid code by appending code snippets that are not separated via new lines.
* Changed posix `GetUserDataFolder` to point to `~/.local/share` instead of just `~/`. Test output data now lands in here instead of cluttering the home directory. Only downside is that test result html files can't be opened by the snap version of Firefox. Use e.g. the dep version from the official webpage instead.
* Changed posix `GetUserDocumentsFolder` to point to `~/Documents` instead of just `~/`.
* Changed a few more tests to not grab the mouse cursor.
* Changed default value of `ezGALResourceFormat` to `Invalid` instead of `RGBAUByteNormalizedsRGB`.