### PR TITLE
Added option to generate a collision mesh from multiple convex parts

### DIFF
--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.cpp
@@ -26,6 +26,7 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezJoltConvexCollisionMeshType, 1)
   EZ_ENUM_CONSTANT(ezJoltConvexCollisionMeshType::ConvexHull),
   EZ_ENUM_CONSTANT(ezJoltConvexCollisionMeshType::Cylinder),
   EZ_ENUM_CONSTANT(ezJoltConvexCollisionMeshType::ConvexDecomposition),
+  EZ_ENUM_CONSTANT(ezJoltConvexCollisionMeshType::ConvexHullGroup),
 EZ_END_STATIC_REFLECTED_ENUM;
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezJoltCollisionMeshAssetProperties, 2, ezRTTIDefaultAllocator<ezJoltCollisionMeshAssetProperties>)
@@ -83,12 +84,13 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
   props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Invisible;
   props["ConvexMeshType"].m_Visibility = ezPropertyUiState::Invisible;
   props["MaxConvexPieces"].m_Visibility = ezPropertyUiState::Invisible;
-  props["Surfaces"].m_Visibility = isConvex ? ezPropertyUiState::Invisible : ezPropertyUiState::Default;
-  props["Surface"].m_Visibility = isConvex ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
-
-  props["MeshSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
-  props["MaxSimplificationError"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
-  props["AggressiveSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+  props["MaxConvexPieces"].m_Visibility = ezPropertyUiState::Invisible;
+  props["Surfaces"].m_Visibility = ezPropertyUiState::Invisible;
+  props["SimplifyMesh"].m_Visibility = ezPropertyUiState::Invisible;
+  props["MeshSimplification"].m_Visibility = ezPropertyUiState::Invisible;
+  props["MaxSimplificationError"].m_Visibility = ezPropertyUiState::Invisible;
+  props["AggressiveSimplification"].m_Visibility = ezPropertyUiState::Invisible;
+  props["Surface"].m_Visibility = ezPropertyUiState::Invisible;
 
   const ezInt64 importTransform = e.m_pObject->GetTypeAccessor().GetValue("ImportTransform").ConvertTo<ezInt64>();
   const bool bCustomTransform = importTransform == 127;
@@ -101,6 +103,12 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
     props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
     props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
     props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
+    props["Surfaces"].m_Visibility = ezPropertyUiState::Default;
+    props["SimplifyMesh"].m_Visibility = ezPropertyUiState::Default;
+
+    props["MeshSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+    props["MaxSimplificationError"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
+    props["AggressiveSimplification"].m_Visibility = bSimplify ? ezPropertyUiState::Default : ezPropertyUiState::Invisible;
   }
   else
   {
@@ -108,14 +116,26 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
 
     switch (meshType)
     {
-      case ezJoltConvexCollisionMeshType::ConvexDecomposition:
-        props["MaxConvexPieces"].m_Visibility = ezPropertyUiState::Default;
-        [[fallthrough]];
-
       case ezJoltConvexCollisionMeshType::ConvexHull:
         props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
         props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
         props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["Surface"].m_Visibility = ezPropertyUiState::Default;
+        break;
+
+      case ezJoltConvexCollisionMeshType::ConvexDecomposition:
+        props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["Surface"].m_Visibility = ezPropertyUiState::Default;
+        props["MaxConvexPieces"].m_Visibility = ezPropertyUiState::Default;
+        break;
+
+      case ezJoltConvexCollisionMeshType::ConvexHullGroup:
+        props["MeshFile"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshIncludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["MeshExcludeTags"].m_Visibility = ezPropertyUiState::Default;
+        props["Surfaces"].m_Visibility = ezPropertyUiState::Default;
         break;
 
       case ezJoltConvexCollisionMeshType::Cylinder:
@@ -123,6 +143,7 @@ void ezJoltCollisionMeshAssetProperties::PropertyMetaStateEventHandler(ezPropert
         props["Radius2"].m_Visibility = ezPropertyUiState::Default;
         props["Height"].m_Visibility = ezPropertyUiState::Default;
         props["Detail"].m_Visibility = ezPropertyUiState::Default;
+        props["Surface"].m_Visibility = ezPropertyUiState::Default;
         break;
     }
   }

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetObjects.h
@@ -38,6 +38,7 @@ struct ezJoltConvexCollisionMeshType
     ConvexHull,
     Cylinder,
     ConvexDecomposition,
+    ConvexHullGroup,
 
     Default = ConvexHull
   };

--- a/Code/EnginePlugins/JoltCooking/JoltCooking.h
+++ b/Code/EnginePlugins/JoltCooking/JoltCooking.h
@@ -22,7 +22,8 @@ public:
   {
     Triangle,
     ConvexHull,
-    ConvexDecomposition
+    ConvexDecomposition,
+    ConvexHullGroup,
   };
 
   static ezResult CookTriangleMesh(const ezJoltCookingMesh& mesh, ezStreamWriter& ref_outputStream);
@@ -30,6 +31,7 @@ public:
   static ezResult ComputeConvexHull(const ezJoltCookingMesh& mesh, ezJoltCookingMesh& out_mesh);
   static ezStatus WriteResourceToStream(ezChunkStreamWriter& inout_stream, const ezJoltCookingMesh& mesh, const ezArrayPtr<ezString>& surfaces, MeshType meshType, ezUInt32 uiMaxConvexPieces = 1);
   static ezResult CookDecomposedConvexMesh(const ezJoltCookingMesh& mesh, ezStreamWriter& ref_outputStream, ezUInt32 uiMaxConvexPieces);
+  static ezResult CookConvexHullGroup(const ezJoltCookingMesh& mesh, ezStreamWriter& ref_outputStream);
 
 private:
   static ezResult CookSingleConvexJoltMesh(const ezJoltCookingMesh& mesh, ezStreamWriter& OutputStream);

--- a/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResource.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Resources/JoltMeshResource.cpp
@@ -508,6 +508,17 @@ JPH::Shape* ezJoltMeshResource::InstantiateConvexPart(ezUInt32 uiPartIdx, ezUInt
       }
     }
 
+    if (materials.GetCount() > 1)
+    {
+      if (materials.GetCount() > uiPartIdx)
+      {
+        JPH::PhysicsMaterialRefC pMat = materials[uiPartIdx];
+        materials.SetCount(1);
+        materials[0] = pMat;
+      }
+
+      materials.SetCount(1);
+    }
 
     EZ_ASSERT_DEBUG(materials.GetCount() <= 1, "Convex meshes should only have a single material. '{}' has {}", GetResourceIdOrDescription(), materials.GetCount());
     shapeRes.Get()->RestoreMaterialState(materials.GetData(), materials.GetCount());


### PR DESCRIPTION
This allows to import complex meshes as convex meshes, which are made up of multiple convex pieces. In contrast to the convex decomposition, it doesn't try to get close to the original shape, instead it just builds one convex hull for each material group.

So for example this triangle mesh which has two different materials:

![grafik](https://github.com/user-attachments/assets/d9b85b92-b460-43e9-989f-011cc09dfa85)

Ends up like this:

![grafik](https://github.com/user-attachments/assets/25544e33-3d40-4c08-9204-a42a40fffcb4)

That can then be used for dynamic rigid bodies.

Of course this is even more interesting, when each material group is already built as a good collider mesh, then the result can actually represent the real shape quite well.

Each material can get it's own surface, as well.
