### PR TITLE
GAL Statistics and Logging Improvements

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -232,8 +232,15 @@ bool ezEngineProcessGameApplication::ProcessIPCMessages(bool bPendingOpInProgres
     else
     {
       EZ_PROFILE_SCOPE("WaitForMessages");
+      const ezUInt32 uiPreviousRedrawRequests = m_uiRedrawCountReceived;
       // Only suspend and wait if no more pending ops need to be done.
       m_IPC.WaitForMessages();
+      // We need to tick the render loop after receiving messages to allow for GAL resources to be freed. Otherwise, an ezEditorProcessor process might never free memory unless it gets a job to render a thumbnail.
+      if (uiPreviousRedrawRequests == m_uiRedrawCountReceived && ezGALDevice::HasDefaultDevice())
+      {
+        RunOneFrame();
+        ezGALDevice::GetDefaultDevice()->WaitIdle();
+      }
     }
     return true;
   }

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -8,14 +8,14 @@
 #include <Foundation/System/CrashHandler.h>
 #include <Foundation/System/SystemInformation.h>
 
-#include <Foundation/System/StackTracer.h>
-#include <Foundation/Utilities/CommandLineOptions.h>
 #include <Core/Console/QuakeConsole.h>
 #include <EditorEngineProcess/EngineProcGameApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessDocumentContext.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h>
 #include <EditorEngineProcessFramework/Gizmos/GizmoRenderer.h>
+#include <Foundation/System/StackTracer.h>
+#include <Foundation/Utilities/CommandLineOptions.h>
 #include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/RenderContext/RenderContext.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>

--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -8,6 +8,8 @@
 #include <Foundation/System/CrashHandler.h>
 #include <Foundation/System/SystemInformation.h>
 
+#include <Foundation/System/StackTracer.h>
+#include <Foundation/Utilities/CommandLineOptions.h>
 #include <Core/Console/QuakeConsole.h>
 #include <EditorEngineProcess/EngineProcGameApp.h>
 #include <EditorEngineProcessFramework/EngineProcess/EngineProcessApp.h>
@@ -22,12 +24,16 @@
 #  include <shellscalingapi.h>
 #endif
 
+ezCommandLineOptionPath opt_OutputDir("_EditorEngineProcess", "-outputDir", "Output directory", "");
+ezCommandLineOptionString opt_LogName("_EditorEngineProcess", "-logName", "Log File Prefix", "LogEngine");
 
 // Will forward assert messages and crash handler messages to the log system and then to the editor.
 // Note that this is unsafe as in some crash situation allocating memory will not be possible but it's better to have some logs compared to none.
 void EditorPrintFunction(const char* szText)
 {
-  ezLog::Info("{}", szText);
+  ezStringBuilder sError = szText;
+  sError.Trim();
+  ezLog::Error("{}", sError.GetData());
 }
 
 static ezAssertHandler g_PreviousAssertHandler = nullptr;
@@ -121,6 +127,13 @@ void ezEngineProcessGameApplication::WaitForDebugger()
 bool ezEngineProcessGameApplication::EditorAssertHandler(const char* szSourceFile, ezUInt32 uiLine, const char* szFunction, const char* szExpression, const char* szAssertMsg)
 {
   ezLog::Error("*** Assertion ***:\nFile: \"{}\",\nLine: \"{}\",\nFunction: \"{}\",\nExpression: \"{}\",\nMessage: \"{}\"", szSourceFile, uiLine, szFunction, szExpression, szAssertMsg);
+
+  void* pBuffer[64];
+  ezArrayPtr<void*> tempTrace(pBuffer);
+  const ezUInt32 uiNumTraces = ezStackTracer::GetStackTrace(tempTrace, nullptr);
+  ezStackTracer::ResolveStackTrace(tempTrace.GetSubArray(0, uiNumTraces), &ezLog::Print);
+  ezLog::Flush();
+
   // Wait for flush of IPC messages
   ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(500));
 
@@ -232,15 +245,8 @@ bool ezEngineProcessGameApplication::ProcessIPCMessages(bool bPendingOpInProgres
     else
     {
       EZ_PROFILE_SCOPE("WaitForMessages");
-      const ezUInt32 uiPreviousRedrawRequests = m_uiRedrawCountReceived;
       // Only suspend and wait if no more pending ops need to be done.
       m_IPC.WaitForMessages();
-      // We need to tick the render loop after receiving messages to allow for GAL resources to be freed. Otherwise, an ezEditorProcessor process might never free memory unless it gets a job to render a thumbnail.
-      if (uiPreviousRedrawRequests == m_uiRedrawCountReceived && ezGALDevice::HasDefaultDevice())
-      {
-        RunOneFrame();
-        ezGALDevice::GetDefaultDevice()->WaitIdle();
-      }
     }
     return true;
   }
@@ -386,6 +392,19 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
     else if (pMsg1->m_sWhatToDo == "ReloadAssetLUT")
     {
       ezFileSystem::ReloadAllExternalDataDirectoryConfigs();
+    }
+    else if (pMsg1->m_sWhatToDo == "FreeGalResources")
+    {
+      ezRenderWorld::ClearMainViews();
+      RunOneFrame();
+      ezGALDevice::GetDefaultDevice()->WaitIdle();
+    }
+    else if (pMsg1->m_sWhatToDo == "FreeAllResources")
+    {
+      ezResourceManager::FreeAllUnusedResources();
+      ezRenderWorld::ClearMainViews();
+      RunOneFrame();
+      ezGALDevice::GetDefaultDevice()->WaitIdle();
     }
     else if (pMsg1->m_sWhatToDo == "ReloadResources")
     {
@@ -608,6 +627,11 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
 {
   ezStringBuilder sAppDir = ">sdk/Data/Tools/EditorEngineProcess";
   ezStringBuilder sUserData = ">user/ezEngine Project/EditorEngineProcess";
+  if (opt_OutputDir.IsOptionSpecified(nullptr))
+  {
+    sUserData = opt_OutputDir.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified);
+  }
+
 
   // make sure these directories exist
   ezFileSystem::CreateDirectoryStructure(sAppDir).AssertSuccess();
@@ -624,9 +648,14 @@ void ezEngineProcessGameApplication::Init_FileSystem_ConfigureDataDirs()
 
   {
     // We need the file system before we can start the html logger.
+    ezStringBuilder sLogName = "LogEngine";
+    if (opt_LogName.IsOptionSpecified(nullptr))
+    {
+      sLogName = opt_LogName.GetOptionValue(ezCommandLineOption::LogMode::Never);
+    }
     ezOsProcessID uiProcessID = ezProcess::GetCurrentProcessID();
     ezStringBuilder sLogFile;
-    sLogFile.SetFormat(":appdata/Log_{0}.htm", uiProcessID);
+    sLogFile.SetFormat(":appdata/Logs/{0}_{1}.htm", sLogName, uiProcessID);
     m_LogHTML.BeginLog(sLogFile, "EditorEngineProcess");
   }
 }

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -28,3 +28,8 @@ public:
   ezTransformStatus m_Status;
   mutable ezDynamicArray<ezLogEntry> m_LogEntries;
 };
+
+class EZ_EDITORFRAMEWORK_DLL ezFreeAllResourcesMsg : public ezProcessMessage
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezFreeAllResourcesMsg, ezProcessMessage);
+};

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
@@ -29,4 +29,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcessAssetResponseMsg, 1, ezRTTIDefaultAlloc
   EZ_END_PROPERTIES;
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezFreeAllResourcesMsg, 1, ezRTTIDefaultAllocator<ezFreeAllResourcesMsg>)
+{
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -353,7 +353,11 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
     EZ_PROFILE_SCOPE("Logging");
     ezInt32 iApplicationID = pCmd->GetIntOption("-appid", 0);
     ezStringBuilder sLogFile;
-    sLogFile.SetFormat(":appdata/Log_{0}.htm", iApplicationID);
+    if (m_StartupFlags.IsSet(StartupFlags::Background))
+      sLogFile.SetFormat(":appdata/Logs/LogEditorProcessor_{0}.htm", iApplicationID);
+    else
+      sLogFile.SetFormat(":appdata/Logs/LogEditor_{0}.htm", iApplicationID);
+
     m_LogHTML.BeginLog(sLogFile, sApplicationName);
 
     ezGlobalLog::AddLogWriter(ezLogWriter::Console::LogMessageHandler);

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -136,6 +136,30 @@ void ezEditorEngineProcessConnection::Initialize(const ezRTTI* pFirstAllowedMess
     args << ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-TelemetryPort", 0, "1050").GetData(tmp);
   }
 
+  {
+    ezStringBuilder sRelativeData;
+    sRelativeData = ":APPDATA";
+
+    ezStringBuilder sAbsoluteData;
+    ezFileSystem::ResolvePath(sRelativeData, &sAbsoluteData, nullptr).AssertSuccess("Failed to resolve APPDATA dir!");
+
+    args << "-outputDir";
+    args << sAbsoluteData.GetData();
+    args << "-logName";
+
+    if (ezQtEditorApp::GetSingleton()->IsInHeadlessMode())
+    {
+      tmp.SetFormat("LogEditorProcessor_{}_Engine", ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-appid", 0));
+      args << tmp.GetData();
+    }
+    else
+    {
+      tmp.SetFormat("LogEditor_{}_Engine", ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-appid", 0));
+      args << tmp.GetData();
+    }
+  }
+
+
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
   const char* EditorEngineProcessExecutableName = "ezEditorEngineProcess.exe";
 #elif EZ_ENABLED(EZ_PLATFORM_LINUX)

--- a/Code/Engine/Foundation/Platform/Posix/StackTracer_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/StackTracer_Posix.h
@@ -41,7 +41,7 @@ void ezStackTracer::ResolveStackTrace(const ezArrayPtr<void*>& trace, PrintFunc 
   {
     for (ezUInt32 i = 0; i < trace.GetCount(); i++)
     {
-#if HAS_DLFCN
+#  if HAS_DLFCN
       Dl_info info{0};
       if (dladdr(trace[i], &info))
       {
@@ -56,11 +56,11 @@ void ezStackTracer::ResolveStackTrace(const ezArrayPtr<void*>& trace, PrintFunc 
           continue;
         }
       }
-#endif
+#  endif
       ezStringUtils::snprintf(szBuffer, EZ_ARRAY_SIZE(szBuffer), "%s\n", ppSymbols[i]);
       printFunc(szBuffer);
     }
-#if HAS_DLFCN
+#  if HAS_DLFCN
     // Addr2line commands:
     printFunc("*** Run in terminal to resolve file and line callstack: ***");
     for (ezUInt32 i = 0; i < trace.GetCount(); i++)
@@ -74,7 +74,7 @@ void ezStackTracer::ResolveStackTrace(const ezArrayPtr<void*>& trace, PrintFunc 
       }
     }
   }
-#endif
+#  endif
   free(ppSymbols);
 
 #else

--- a/Code/Engine/Foundation/Platform/Posix/StackTracer_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/StackTracer_Posix.h
@@ -10,6 +10,10 @@ EZ_FOUNDATION_INTERNAL_HEADER
 #  define HAS_EXECINFO 1
 #endif
 
+#if __has_include(<dlfcn.h>)
+#  include <dlfcn.h>
+#  define HAS_DLFCN 1
+#endif
 void ezStackTracer::OnPluginEvent(const ezPluginEvent& e)
 {
 }
@@ -28,24 +32,51 @@ ezUInt32 ezStackTracer::GetStackTrace(ezArrayPtr<void*>& trace, void* pContext)
 void ezStackTracer::ResolveStackTrace(const ezArrayPtr<void*>& trace, PrintFunc printFunc)
 {
 #if HAS_EXECINFO
-  char szBuffer[512];
+  char szBuffer[512] = {0};
 
   char** ppSymbols = backtrace_symbols(trace.GetPtr(), trace.GetCount());
 
+  // Demangle if possible, otherwise fallback to backtrace_symbols output.
   if (ppSymbols != nullptr)
   {
     for (ezUInt32 i = 0; i < trace.GetCount(); i++)
     {
-      size_t uiLen = ezMath::Min(strlen(ppSymbols[i]), static_cast<size_t>(EZ_ARRAY_SIZE(szBuffer)) - 2);
-      memcpy(szBuffer, ppSymbols[i], uiLen);
-      szBuffer[uiLen] = '\n';
-      szBuffer[uiLen + 1] = '\0';
-
+#if HAS_DLFCN
+      Dl_info info{0};
+      if (dladdr(trace[i], &info))
+      {
+        int iStatus = 0;
+        char* szDemangled = abi::__cxa_demangle(info.dli_sname, NULL, 0, &iStatus);
+        EZ_SCOPE_EXIT(free(szDemangled));
+        if (szDemangled != nullptr)
+        {
+          ezUInt32 uiOffset = static_cast<ezUInt32>((char*)trace[i] - (char*)info.dli_saddr);
+          ezStringUtils::snprintf(szBuffer, EZ_ARRAY_SIZE(szBuffer), "%s(%s+0x%x) [0x%llx]\n", info.dli_fname, szDemangled, uiOffset, (ezUInt64)trace[i]);
+          printFunc(szBuffer);
+          continue;
+        }
+      }
+#endif
+      ezStringUtils::snprintf(szBuffer, EZ_ARRAY_SIZE(szBuffer), "%s\n", ppSymbols[i]);
       printFunc(szBuffer);
     }
-
-    free(ppSymbols);
+#if HAS_DLFCN
+    // Addr2line commands:
+    printFunc("*** Run in terminal to resolve file and line callstack: ***");
+    for (ezUInt32 i = 0; i < trace.GetCount(); i++)
+    {
+      Dl_info info{0};
+      if (dladdr(trace[i], &info))
+      {
+        ptrdiff_t offset = (char*)trace[i] - (char*)info.dli_fbase;
+        ezStringUtils::snprintf(szBuffer, EZ_ARRAY_SIZE(szBuffer), "addr2line -e %s -C -f -s -p 0x%llx\n", info.dli_fname, (ezUInt64)offset);
+        printFunc(szBuffer);
+      }
+    }
   }
+#endif
+  free(ppSymbols);
+
 #else
   printFunc("Could not record stack trace on this Linux system, because execinfo.h is not available.");
 #endif

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -135,6 +135,9 @@ public:
   // Don't use light hearted ;)
   void InvalidateState();
 
+  const ezGALCommandEncoderStats& GetStats() const { return m_Stats; }
+  void ResetStats();
+
 protected:
   friend class ezGALDevice;
 
@@ -151,16 +154,7 @@ protected:
   }
 
 private:
-  void ClearStatisticsCounters();
-  void CountDispatchCall() { m_uiDispatchCalls++; }
-  void CountDrawCall() { m_uiDrawCalls++; }
-
-private:
   friend class ezMemoryUtils;
-
-  // Statistic variables
-  ezUInt32 m_uiDispatchCalls = 0;
-  ezUInt32 m_uiDrawCalls = 0;
 
   enum class CommandEncoderType
   {
@@ -191,6 +185,7 @@ private:
   ezGALDevice& m_Device;
   ezGALCommandEncoderRenderState m_State;
   ezGALCommandEncoderCommonPlatformInterface& m_CommonImpl;
+  ezGALCommandEncoderStats m_Stats;
 
   ezGALOcclusionHandle m_hPendingOcclusionQuery = {};
 };

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderState.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderState.h
@@ -22,3 +22,39 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderRenderState final
   float m_fViewPortMinDepth = ezMath::MaxValue<float>();
   float m_fViewPortMaxDepth = -ezMath::MaxValue<float>();
 };
+
+struct EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderStats
+{
+  void Reset();
+  void SetStatistics();
+  void operator+=(const ezGALCommandEncoderStats& rhs);
+
+  // Operations
+  ezUInt32 m_uiInsertTimestamp = 0;
+  ezUInt32 m_uiBeginOcclusionQuery = 0;
+  ezUInt32 m_uiInsertFence = 0;
+  ezUInt32 m_uiCopyBuffer = 0;
+  ezUInt32 m_uiUpdateBuffer = 0;
+  ezUInt32 m_uiCopyTexture = 0;
+  ezUInt32 m_uiUpdateTexture = 0;
+  ezUInt32 m_uiResolveTexture = 0;
+  ezUInt32 m_uiReadbackTexture = 0;
+  ezUInt32 m_uiReadbackBuffer = 0;
+  ezUInt32 m_uiFlush = 0;
+  // Compute
+  ezUInt32 m_uiBeginCompute = 0;
+  ezUInt32 m_uiDispatch = 0;
+  // Rendering
+  ezUInt32 m_uiBeginRendering = 0;
+  ezUInt32 m_uiClear = 0;
+  ezUInt32 m_uiDraw = 0;
+  // State Changes
+  ezUInt32 m_uiSetIndexBuffer = 0;
+  ezUInt32 m_uiSetVertexBuffer = 0;
+  ezUInt32 m_uiSetGraphicsPipeline = 0;
+  ezUInt32 m_uiSetComputePipeline = 0;
+  // Dynamic State Changes
+  ezUInt32 m_uiSetViewport = 0;
+  ezUInt32 m_uiSetScissorRect = 0;
+  ezUInt32 m_uiSetStencilReference = 0;
+};

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -1,7 +1,6 @@
 #include <RendererFoundation/RendererFoundationPCH.h>
 
 #include <Foundation/Logging/Log.h>
-#include <Foundation/Utilities/Stats.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Buffer.h>

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -1,6 +1,7 @@
 #include <RendererFoundation/RendererFoundationPCH.h>
 
 #include <Foundation/Logging/Log.h>
+#include <Foundation/Utilities/Stats.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Resources/Buffer.h>
@@ -138,6 +139,7 @@ void ezGALCommandEncoder::SetPushConstants(ezArrayPtr<const ezUInt8> data)
 ezGALTimestampHandle ezGALCommandEncoder::InsertTimestamp()
 {
   AssertRenderingThread();
+  m_Stats.m_uiInsertTimestamp++;
   return m_CommonImpl.InsertTimestampPlatform();
 }
 
@@ -145,6 +147,7 @@ ezGALOcclusionHandle ezGALCommandEncoder::BeginOcclusionQuery(ezEnum<ezGALQueryT
 {
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType == CommandEncoderType::Render, "Occlusion queries can only be started within a render scope");
   AssertRenderingThread();
+  m_Stats.m_uiBeginOcclusionQuery++;
   ezGALOcclusionHandle hOcclusion = m_CommonImpl.BeginOcclusionQueryPlatform(type);
 
   EZ_ASSERT_DEBUG(m_hPendingOcclusionQuery.IsInvalidated(), "Only one occusion query can be active at any give time.");
@@ -164,6 +167,7 @@ void ezGALCommandEncoder::EndOcclusionQuery(ezGALOcclusionHandle hOcclusion)
 
 ezGALFenceHandle ezGALCommandEncoder::InsertFence()
 {
+  m_Stats.m_uiInsertFence++;
   return m_CommonImpl.InsertFencePlatform();
 }
 
@@ -233,6 +237,7 @@ void ezGALCommandEncoder::CopyBuffer(ezGALBufferHandle hDest, ezGALBufferHandle 
 
   if (pDest != nullptr && pSource != nullptr)
   {
+    m_Stats.m_uiCopyBuffer++;
     m_CommonImpl.CopyBufferPlatform(pDest, pSource);
   }
   else
@@ -260,6 +265,7 @@ void ezGALCommandEncoder::CopyBufferRegion(
     EZ_IGNORE_UNUSED(uiSourceSize);
     EZ_ASSERT_DEV(uiSourceSize >= uiSourceOffset + uiByteCount, "Source buffer too small (or offset too big)");
 
+    m_Stats.m_uiCopyBuffer++;
     m_CommonImpl.CopyBufferRegionPlatform(pDest, uiDestOffset, pSource, uiSourceOffset, uiByteCount);
   }
   else
@@ -315,6 +321,7 @@ void ezGALCommandEncoder::UpdateBuffer(ezGALBufferHandle hDest, ezUInt32 uiDestO
       }
     }
 #endif
+    m_Stats.m_uiUpdateBuffer++;
     m_CommonImpl.UpdateBufferPlatform(pDest, uiDestOffset, sourceData, updateMode);
   }
   else
@@ -334,6 +341,16 @@ void ezGALCommandEncoder::CopyTexture(ezGALTextureHandle hDest, ezGALTextureHand
 
   if (pDest != nullptr && pSource != nullptr)
   {
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_Format == pSource->GetDescription().m_Format, "CopyTexture formats must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_SampleCount == pSource->GetDescription().m_SampleCount, "CopyTexture sample count must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_Type == pSource->GetDescription().m_Type, "CopyTexture type must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiHeight == pSource->GetDescription().m_uiHeight, "CopyTexture height must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiWidth == pSource->GetDescription().m_uiWidth, "CopyTexture width must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiDepth == pSource->GetDescription().m_uiDepth, "CopyTexture depth must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiMipLevelCount == pSource->GetDescription().m_uiMipLevelCount, "CopyTexture mip levels must match");
+    EZ_ASSERT_DEBUG(pDest->GetDescription().m_uiArraySize == pSource->GetDescription().m_uiArraySize, "CopyTexture array size must match");
+
+    m_Stats.m_uiCopyTexture++;
     m_CommonImpl.CopyTexturePlatform(pDest, pSource);
   }
   else
@@ -353,6 +370,7 @@ void ezGALCommandEncoder::CopyTextureRegion(ezGALTextureHandle hDest, const ezGA
 
   if (pDest != nullptr && pSource != nullptr)
   {
+    m_Stats.m_uiCopyTexture++;
     m_CommonImpl.CopyTextureRegionPlatform(pDest, destinationSubResource, vDestinationPoint, pSource, sourceSubResource, box);
   }
   else
@@ -371,6 +389,7 @@ void ezGALCommandEncoder::UpdateTexture(ezGALTextureHandle hDest, const ezGALTex
 
   if (pDest != nullptr)
   {
+    m_Stats.m_uiUpdateTexture++;
     m_CommonImpl.UpdateTexturePlatform(pDest, destinationSubResource, destinationBox, sourceData);
   }
   else
@@ -390,6 +409,7 @@ void ezGALCommandEncoder::ResolveTexture(ezGALTextureHandle hDest, const ezGALTe
 
   if (pDest != nullptr && pSource != nullptr)
   {
+    m_Stats.m_uiResolveTexture++;
     m_CommonImpl.ResolveTexturePlatform(pDest, destinationSubResource, pSource, sourceSubResource);
   }
   else
@@ -417,6 +437,7 @@ void ezGALCommandEncoder::ReadbackTexture(ezGALReadbackTextureHandle hDestinatio
 
   if (pDestination != nullptr && pSource != nullptr)
   {
+    m_Stats.m_uiReadbackTexture++;
     m_CommonImpl.ReadbackTexturePlatform(pDestination, pSource);
   }
 }
@@ -435,6 +456,7 @@ void ezGALCommandEncoder::ReadbackBuffer(ezGALReadbackBufferHandle hDestination,
 
   if (pDestination != nullptr && pSource != nullptr)
   {
+    m_Stats.m_uiReadbackBuffer++;
     m_CommonImpl.ReadbackBufferPlatform(pDestination, pSource);
   }
 }
@@ -462,6 +484,7 @@ void ezGALCommandEncoder::Flush()
   AssertRenderingThread();
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType != CommandEncoderType::Render, "Flush can't be called inside a rendering scope");
 
+  m_Stats.m_uiFlush++;
   m_CommonImpl.FlushPlatform();
 }
 
@@ -488,7 +511,6 @@ void ezGALCommandEncoder::InsertEventMarker(const char* szMarker)
   AssertRenderingThread();
 
   EZ_ASSERT_DEV(szMarker != nullptr, "Invalid marker!");
-
   m_CommonImpl.InsertEventMarkerPlatform(szMarker);
 }
 
@@ -516,7 +538,7 @@ ezResult ezGALCommandEncoder::Dispatch(ezUInt32 uiThreadGroupCountX, ezUInt32 ui
 
   EZ_ASSERT_DEBUG(uiThreadGroupCountX > 0 && uiThreadGroupCountY > 0 && uiThreadGroupCountZ > 0, "Thread group counts of zero are not meaningful. Did you mean 1?");
 
-  CountDispatchCall();
+  m_Stats.m_uiDispatch++;
   return m_CommonImpl.DispatchPlatform(uiThreadGroupCountX, uiThreadGroupCountY, uiThreadGroupCountZ);
 }
 
@@ -528,20 +550,15 @@ ezResult ezGALCommandEncoder::DispatchIndirect(ezGALBufferHandle hIndirectArgume
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hIndirectArgumentBuffer);
   EZ_ASSERT_DEV(pBuffer != nullptr, "Invalid buffer handle for indirect arguments!");
 
-  CountDispatchCall();
+  m_Stats.m_uiDispatch++;
   return m_CommonImpl.DispatchIndirectPlatform(pBuffer, uiArgumentOffsetInBytes);
-}
-
-void ezGALCommandEncoder::ClearStatisticsCounters()
-{
-  m_uiDrawCalls = 0;
-  m_uiDispatchCalls = 0;
 }
 
 void ezGALCommandEncoder::Clear(const ezColor& clearColor, ezUInt32 uiRenderTargetClearMask /*= 0xFFFFFFFFu*/, bool bClearDepth /*= true*/, bool bClearStencil /*= true*/, float fDepthClear /*= 1.0f*/, ezUInt8 uiStencilClear /*= 0x0u*/)
 {
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType == CommandEncoderType::Render, "Call BeginRendering first");
   AssertRenderingThread();
+  m_Stats.m_uiClear++;
   m_CommonImpl.ClearPlatform(clearColor, uiRenderTargetClearMask, bClearDepth, bClearStencil, fDepthClear, uiStencilClear);
 }
 
@@ -549,7 +566,7 @@ ezResult ezGALCommandEncoder::Draw(ezUInt32 uiVertexCount, ezUInt32 uiStartVerte
 {
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType == CommandEncoderType::Render, "Call BeginRendering first");
   AssertRenderingThread();
-  CountDrawCall();
+  m_Stats.m_uiDraw++;
   return m_CommonImpl.DrawPlatform(uiVertexCount, uiStartVertex);
 }
 
@@ -557,7 +574,7 @@ ezResult ezGALCommandEncoder::DrawIndexed(ezUInt32 uiIndexCount, ezUInt32 uiStar
 {
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType == CommandEncoderType::Render, "Call BeginRendering first");
   AssertRenderingThread();
-  CountDrawCall();
+  m_Stats.m_uiDraw++;
   return m_CommonImpl.DrawIndexedPlatform(uiIndexCount, uiStartIndex);
 }
 
@@ -565,7 +582,7 @@ ezResult ezGALCommandEncoder::DrawIndexedInstanced(ezUInt32 uiIndexCountPerInsta
 {
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType == CommandEncoderType::Render, "Call BeginRendering first");
   AssertRenderingThread();
-  CountDrawCall();
+  m_Stats.m_uiDraw++;
   return m_CommonImpl.DrawIndexedInstancedPlatform(uiIndexCountPerInstance, uiInstanceCount, uiStartIndex);
 }
 
@@ -575,7 +592,7 @@ ezResult ezGALCommandEncoder::DrawIndexedInstancedIndirect(ezGALBufferHandle hIn
   AssertRenderingThread();
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hIndirectArgumentBuffer);
   EZ_ASSERT_DEV(pBuffer != nullptr, "Invalid buffer handle for indirect arguments!");
-  CountDrawCall();
+  m_Stats.m_uiDraw++;
   return m_CommonImpl.DrawIndexedInstancedIndirectPlatform(pBuffer, uiArgumentOffsetInBytes);
 }
 
@@ -583,7 +600,7 @@ ezResult ezGALCommandEncoder::DrawInstanced(ezUInt32 uiVertexCountPerInstance, e
 {
   EZ_ASSERT_DEBUG(m_CurrentCommandEncoderType == CommandEncoderType::Render, "Call BeginRendering first");
   AssertRenderingThread();
-  CountDrawCall();
+  m_Stats.m_uiDraw++;
   return m_CommonImpl.DrawInstancedPlatform(uiVertexCountPerInstance, uiInstanceCount, uiStartVertex);
 }
 
@@ -593,7 +610,7 @@ ezResult ezGALCommandEncoder::DrawInstancedIndirect(ezGALBufferHandle hIndirectA
   AssertRenderingThread();
   const ezGALBuffer* pBuffer = GetDevice().GetBuffer(hIndirectArgumentBuffer);
   EZ_ASSERT_DEV(pBuffer != nullptr, "Invalid buffer handle for indirect arguments!");
-  CountDrawCall();
+  m_Stats.m_uiDraw++;
   return m_CommonImpl.DrawInstancedIndirectPlatform(pBuffer, uiArgumentOffsetInBytes);
 }
 
@@ -608,6 +625,7 @@ void ezGALCommandEncoder::SetIndexBuffer(ezGALBufferHandle hIndexBuffer)
   /// \todo Assert on index buffer type (if non nullptr)
   // Note that GL4 can bind arbitrary buffer to arbitrary binding points (index/vertex/transform-feedback/indirect-draw/...)
 
+  m_Stats.m_uiSetIndexBuffer++;
   m_CommonImpl.SetIndexBufferPlatform(pBuffer);
 
   m_State.m_hIndexBuffer = hIndexBuffer;
@@ -624,6 +642,7 @@ void ezGALCommandEncoder::SetVertexBuffer(ezUInt32 uiSlot, ezGALBufferHandle hVe
   // Assert on vertex buffer type (if non-zero)
   // Note that GL4 can bind arbitrary buffer to arbitrary binding points (index/vertex/transform-feedback/indirect-draw/...)
 
+  m_Stats.m_uiSetVertexBuffer++;
   m_CommonImpl.SetVertexBufferPlatform(uiSlot, pBuffer, uiOffset);
 
   m_State.m_hVertexBuffers[uiSlot] = hVertexBuffer;
@@ -638,6 +657,7 @@ void ezGALCommandEncoder::SetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraph
     return;
 
   const ezGALGraphicsPipeline* pGraphicsPipeline = GetDevice().GetGraphicsPipeline(hGraphicsPipeline);
+  m_Stats.m_uiSetGraphicsPipeline++;
   m_CommonImpl.SetGraphicsPipelinePlatform(pGraphicsPipeline);
   m_State.m_hGraphicsPipeline = hGraphicsPipeline;
 }
@@ -650,6 +670,7 @@ void ezGALCommandEncoder::SetComputePipeline(ezGALComputePipelineHandle hCompute
     return;
 
   const ezGALComputePipeline* pComputePipeline = GetDevice().GetComputePipeline(hComputePipeline);
+  m_Stats.m_uiSetComputePipeline++;
   m_CommonImpl.SetComputePipelinePlatform(pComputePipeline);
   m_State.m_hComputePipeline = hComputePipeline;
 }
@@ -663,6 +684,7 @@ void ezGALCommandEncoder::SetViewport(const ezRectFloat& rect, float fMinDepth, 
     return;
   }
 
+  m_Stats.m_uiSetViewport++;
   m_CommonImpl.SetViewportPlatform(rect, fMinDepth, fMaxDepth);
 
   m_State.m_ViewPortRect = rect;
@@ -679,6 +701,7 @@ void ezGALCommandEncoder::SetScissorRect(const ezRectU32& rect)
     return;
   }
 
+  m_Stats.m_uiSetScissorRect++;
   m_CommonImpl.SetScissorRectPlatform(rect);
 
   m_State.m_ScissorRect = rect;
@@ -691,6 +714,7 @@ void ezGALCommandEncoder::SetStencilReference(ezUInt8 uiStencilRefValue)
   if (m_State.m_uiStencilRefValue == uiStencilRefValue)
     return;
 
+  m_Stats.m_uiSetStencilReference++;
   m_CommonImpl.SetStencilReferencePlatform(uiStencilRefValue);
 
   m_State.m_uiStencilRefValue = uiStencilRefValue;
@@ -701,6 +725,7 @@ void ezGALCommandEncoder::BeginCompute(const char* szName)
   EZ_ASSERT_DEV(m_CurrentCommandEncoderType == CommandEncoderType::Invalid, "Nested Command Encoder are not allowed");
   m_CurrentCommandEncoderType = CommandEncoderType::Compute;
 
+  m_Stats.m_uiBeginCompute++;
   m_CommonImpl.BeginComputePlatform();
 
   m_bMarker = !ezStringUtils::IsNullOrEmpty(szName);
@@ -729,6 +754,7 @@ void ezGALCommandEncoder::BeginRendering(const ezGALRenderingSetup& renderingSet
   EZ_ASSERT_DEV(m_CurrentCommandEncoderType == CommandEncoderType::Invalid, "Nested Command Encoder are not allowed");
   m_CurrentCommandEncoderType = CommandEncoderType::Render;
 
+  m_Stats.m_uiBeginRendering++;
   m_CommonImpl.BeginRenderingPlatform(renderingSetup);
 
   m_bMarker = !ezStringUtils::IsNullOrEmpty(szName);
@@ -757,4 +783,9 @@ void ezGALCommandEncoder::EndRendering()
 bool ezGALCommandEncoder::IsInRenderingScope() const
 {
   return m_CurrentCommandEncoderType == CommandEncoderType::Render;
+}
+
+void ezGALCommandEncoder::ResetStats()
+{
+  m_Stats = ezGALCommandEncoderStats();
 }

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
@@ -20,3 +20,47 @@ void ezGALCommandEncoderRenderState::InvalidateState()
   m_fViewPortMinDepth = ezMath::MaxValue<float>();
   m_fViewPortMaxDepth = -ezMath::MaxValue<float>();
 }
+
+void ezGALCommandEncoderStats::Reset()
+{
+  ezMemoryUtils::ZeroFill<ezGALCommandEncoderStats>(static_cast<ezGALCommandEncoderStats*>(this), 1);
+}
+
+void ezGALCommandEncoderStats::SetStatistics()
+{
+  ezStats::SetStat("GalCommandEncoder/Operations/InsertTimestamp", m_uiInsertTimestamp);
+  ezStats::SetStat("GalCommandEncoder/Operations/BeginOcclusionQuery", m_uiBeginOcclusionQuery);
+  ezStats::SetStat("GalCommandEncoder/Operations/InsertFence", m_uiInsertFence);
+  ezStats::SetStat("GalCommandEncoder/Operations/CopyBuffer", m_uiCopyBuffer);
+  ezStats::SetStat("GalCommandEncoder/Operations/UpdateBuffer", m_uiUpdateBuffer);
+  ezStats::SetStat("GalCommandEncoder/Operations/CopyTexture", m_uiCopyTexture);
+  ezStats::SetStat("GalCommandEncoder/Operations/UpdateTexture", m_uiUpdateTexture);
+  ezStats::SetStat("GalCommandEncoder/Operations/ResolveTexture", m_uiResolveTexture);
+  ezStats::SetStat("GalCommandEncoder/Operations/ReadbackTexture", m_uiReadbackTexture);
+  ezStats::SetStat("GalCommandEncoder/Operations/ReadbackBuffer", m_uiReadbackBuffer);
+  ezStats::SetStat("GalCommandEncoder/Operations/Flush", m_uiFlush);
+  ezStats::SetStat("GalCommandEncoder/Compute/BeginCompute", m_uiBeginCompute);
+  ezStats::SetStat("GalCommandEncoder/Compute/Dispatch", m_uiDispatch);
+  ezStats::SetStat("GalCommandEncoder/Render/BeginRendering", m_uiBeginRendering);
+  ezStats::SetStat("GalCommandEncoder/Render/Clear", m_uiClear);
+  ezStats::SetStat("GalCommandEncoder/Render/Draw", m_uiDraw);
+  ezStats::SetStat("GalCommandEncoder/States/SetIndexBuffer", m_uiSetIndexBuffer);
+  ezStats::SetStat("GalCommandEncoder/States/SetVertexBuffer", m_uiSetVertexBuffer);
+  ezStats::SetStat("GalCommandEncoder/States/SetGraphicsPipeline", m_uiSetGraphicsPipeline);
+  ezStats::SetStat("GalCommandEncoder/States/SetComputePipeline", m_uiSetComputePipeline);
+  ezStats::SetStat("GalCommandEncoder/DynamicStates/SetViewport", m_uiSetViewport);
+  ezStats::SetStat("GalCommandEncoder/DynamicStates/SetScissorRect", m_uiSetScissorRect);
+  ezStats::SetStat("GalCommandEncoder/DynamicStates/SetStencilReference", m_uiSetStencilReference);
+}
+
+void ezGALCommandEncoderStats::operator+=(const ezGALCommandEncoderStats& rhs)
+{
+  const ezUInt32 uiCount = sizeof(ezGALCommandEncoderStats) / sizeof(ezUInt32);
+  ezUInt32* pDest = reinterpret_cast<ezUInt32*>(this);
+  const ezUInt32* pSource = reinterpret_cast<const ezUInt32*>(&rhs);
+  for (int i = 0; i < uiCount; ++i)
+  {
+    pDest[i] += pSource[i];
+  }
+}
+

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
@@ -63,4 +63,3 @@ void ezGALCommandEncoderStats::operator+=(const ezGALCommandEncoderStats& rhs)
     pDest[i] += pSource[i];
   }
 }
-

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoderState.cpp
@@ -1,5 +1,6 @@
 #include <RendererFoundation/RendererFoundationPCH.h>
 
+#include <Foundation/Utilities/Stats.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoderState.h>
 
 void ezGALCommandEncoderRenderState::InvalidateState()

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -9,6 +9,7 @@
 #include <RendererFoundation/Device/DeviceCapabilities.h>
 #include <RendererFoundation/Device/ReadbackLock.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/CommandEncoder/CommandEncoderState.h>
 
 class ezColor;
 
@@ -468,6 +469,16 @@ private:
   ezHybridArray<ezGALSwapChain*, 8> m_FrameSwapChains;
   bool m_bBeginPipelineCalled = false;
   ezGALCommandEncoder* m_pCommandEncoder = nullptr;
+
+  ezUInt32 m_uiShaders = 0;
+  ezUInt32 m_uiVertexDeclarations = 0;
+  ezUInt32 m_uiBlendStates = 0;
+  ezUInt32 m_uiDepthStencilStates = 0;
+  ezUInt32 m_uiRasterizerStates = 0;
+  ezUInt32 m_uiGraphicsPipelines = 0;
+  ezUInt32 m_uiComputePipelines = 0;
+  ezUInt32 m_uiSamplerStates = 0;
+  ezGALCommandEncoderStats m_EncoderStats;
 };
 
 #include <RendererFoundation/Device/Implementation/Device_inl.h>

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -5,11 +5,11 @@
 #include <Foundation/Containers/IdTable.h>
 #include <Foundation/Memory/CommonAllocators.h>
 #include <Foundation/Strings/HashedString.h>
+#include <RendererFoundation/CommandEncoder/CommandEncoderState.h>
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Device/DeviceCapabilities.h>
 #include <RendererFoundation/Device/ReadbackLock.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
-#include <RendererFoundation/CommandEncoder/CommandEncoderState.h>
 
 class ezColor;
 

--- a/Code/Engine/RendererFoundation/Resources/Implementation/RendererFallbackResources.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/RendererFallbackResources.cpp
@@ -186,8 +186,13 @@ void ezGALRendererFallbackResources::GALDeviceEventHandler(const ezGALDeviceEven
 
         ezGALTextureUnorderedAccessViewCreationDescription descUAV;
         descUAV.m_hTexture = hTexture;
+        descUAV.m_OverrideViewType = ezGALTextureType::Texture2D;
         auto hUAV = s_pDevice->CreateUnorderedAccessView(descUAV);
-        s_TextureUAVs[{ezGALShaderResourceType::TextureRW, ezGALShaderTextureType::Unknown, false}] = hUAV;
+        s_TextureUAVs[{ezGALShaderResourceType::TextureRW, ezGALShaderTextureType::Texture2D, false}] = hUAV;
+
+        descUAV.m_OverrideViewType = ezGALTextureType::Texture2DArray;
+        hUAV = s_pDevice->CreateUnorderedAccessView(descUAV);
+        s_TextureUAVs[{ezGALShaderResourceType::TextureRW, ezGALShaderTextureType::Texture2DArray, false}] = hUAV;
       }
       {
         ezGALBufferCreationDescription desc;

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -58,7 +58,7 @@ void ezEditorTestApplication::AfterCoreSystemsStartup()
   EZ_PROFILE_SCOPE("AfterCoreSystemsStartup");
   // We override the user data dir to not pollute the editor settings.
   ezStringBuilder userDataDir = ezTestFramework::GetInstance()->GetAbsOutputPath();
-    // ezOSFile::GetUserDataFolder();
+  // ezOSFile::GetUserDataFolder();
   userDataDir.AppendPath(m_sTestName);
   userDataDir.MakeCleanPath();
 

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -18,12 +18,13 @@
 #include <Texture/Image/ImageUtils.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
-ezEditorTestApplication::ezEditorTestApplication()
+ezEditorTestApplication::ezEditorTestApplication(ezStringView sTestName)
   : ezApplication("ezEditor")
 {
   EnableMemoryLeakReporting(true);
 
   m_pEditorApp = new ezQtEditorApp;
+  m_sTestName = sTestName;
 }
 
 ezResult ezEditorTestApplication::BeforeCoreSystemsStartup()
@@ -56,8 +57,9 @@ void ezEditorTestApplication::AfterCoreSystemsStartup()
 {
   EZ_PROFILE_SCOPE("AfterCoreSystemsStartup");
   // We override the user data dir to not pollute the editor settings.
-  ezStringBuilder userDataDir = ezOSFile::GetUserDataFolder();
-  userDataDir.AppendPath("ezEngine Project", "EditorTest");
+  ezStringBuilder userDataDir = ezTestFramework::GetInstance()->GetAbsOutputPath();
+    // ezOSFile::GetUserDataFolder();
+  userDataDir.AppendPath(m_sTestName);
   userDataDir.MakeCleanPath();
 
   ezQtEditorApp::GetSingleton()->StartupEditor(ezQtEditorApp::StartupFlags::SafeMode | ezQtEditorApp::StartupFlags::NoRecent | ezQtEditorApp::StartupFlags::UnitTest, userDataDir);
@@ -89,7 +91,7 @@ ezEditorTest::~ezEditorTest() = default;
 
 ezEditorTestApplication* ezEditorTest::CreateApplication()
 {
-  ezEditorTestApplication* pTestApplication = EZ_DEFAULT_NEW(ezEditorTestApplication);
+  ezEditorTestApplication* pTestApplication = EZ_DEFAULT_NEW(ezEditorTestApplication, GetTestName());
 
   m_CommandLineArguments = ezCommandLineUtils::GetGlobalInstance()->GetCommandLineArray();
   EZ_ASSERT_DEV(m_CommandLineArguments.GetCount() > 0, "There should always be at least 1 command line argument (the executable name)");

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.h
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.h
@@ -20,7 +20,7 @@ class ezEditorTestApplication : public ezApplication
 public:
   using SUPER = ezApplication;
 
-  ezEditorTestApplication();
+  ezEditorTestApplication(ezStringView sTestName);
   virtual ezResult BeforeCoreSystemsStartup() override;
   virtual void AfterCoreSystemsShutdown() override;
   virtual void Run() override;
@@ -33,6 +33,7 @@ public:
 
 public:
   ezQtEditorApp* m_pEditorApp = nullptr;
+  ezString m_sTestName;
 };
 
 class ezEditorTest : public ezTestBaseClass


### PR DESCRIPTION
## Statistics
* Adding statistics for `ezGALDevice` and `ezGALCommandEncoder`.
  * For the resources that are deduplicated (immutable states like shaders) the `ezGALDevice` now outputs stats for resource count and overall reference count to show how much deduplication saves for each type.

## Fixes
* Creating compute pipeline now increases reference count to the shader in the description.
* After transforming an asset in the EditorProcessor, a "FreeGalResources" message is sent to the engine process to deleted pending GAL resources.
* Once no more jobs are available to a processor, the editor sends a `ezFreeAllResourcesMsg` message over which the EditorProcessor forwards to the engine process as a "FreeAllResources" message which calls `ezResourceManager::FreeAllUnusedResources()` as this would otherwise never happen without ticking the game loop which is paused for the processors.
* Fixed some UAV fallback resources.

## Logging Improvements
* Linux stack tracer now demangles function names if possible and outputs commands for resolving file / line numbers.
* Editor logs are now written into a dedicated Logs folder which has a new naming convention which allows for easier correlation and collection of logs for test failures:
  * `LogEditor_{id}.htm` for the editor process.
  *  `LogEditor_{id}_Engine_{pid}` for the editor's engine process.
  * `LogEditorProcessor_{id}.htm` for an editor processor.
  * `LogEditorProcessor_{id}_Engine_{pid}.htm` for the editor processor's engine process.
