### PR TITLE
DynamicEnums can show option to execute action to edit values

### DIFF
--- a/Code/Editor/EditorFramework/PropertyGrid/DynamicEnumPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/DynamicEnumPropertyWidget.moc.h
@@ -5,6 +5,7 @@
 
 class QHBoxLayout;
 class QComboBox;
+class ezDynamicEnum;
 
 /// *** Asset Browser ***
 
@@ -26,4 +27,6 @@ protected:
 protected:
   QComboBox* m_pWidget;
   QHBoxLayout* m_pLayout;
+  ezDynamicEnum* m_pEnum = nullptr;
+  ezInt32 m_iLastIndex = -1;
 };

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/DynamicStringEnumPropertyWidget.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/Dialogs/EditDynamicEnumsDlg.moc.h>
 #include <EditorFramework/PropertyGrid/DynamicStringEnumPropertyWidget.moc.h>
+#include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/UIServices/DynamicStringEnum.h>
 
 ezQtDynamicStringEnumPropertyWidget::ezQtDynamicStringEnumPropertyWidget()
@@ -43,7 +44,11 @@ void ezQtDynamicStringEnumPropertyWidget::OnInit()
     m_pWidget->addItem(QString::fromUtf8(val.GetData()));
   }
 
-  if (!m_pEnum->GetStorageFile().IsEmpty())
+  if (!m_pEnum->GetEditCommand().IsEmpty())
+  {
+    m_pWidget->addItem("< Edit Values... >", QString("<cmd>"));
+  }
+  else if (!m_pEnum->GetStorageFile().IsEmpty())
   {
     m_pWidget->addItem("< Edit Values... >", QString("<edit>"));
   }
@@ -67,6 +72,16 @@ void ezQtDynamicStringEnumPropertyWidget::InternalSetValue(const ezVariant& valu
 
 void ezQtDynamicStringEnumPropertyWidget::on_CurrentEnum_changed(int iEnum)
 {
+  if (m_pWidget->currentData() == QString("<cmd>"))
+  {
+    iEnum = m_iLastIndex;
+    m_pWidget->setCurrentIndex(iEnum);
+
+    ezActionManager::ExecuteAction({}, m_pEnum->GetEditCommand(), ezActionContext(const_cast<ezDocument*>(m_pGrid->GetDocument())), m_pEnum->GetEditCommandValue()).AssertSuccess();
+
+    return;
+  }
+
   if (m_pWidget->currentData() == QString("<edit>"))
   {
     ezQtEditDynamicEnumsDlg dlg(m_pEnum, this);

--- a/Code/Tools/Libs/GuiFoundation/Action/ActionManager.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/ActionManager.h
@@ -62,11 +62,11 @@ public:
   static ezActionDescriptorHandle RegisterAction(const ezActionDescriptor& desc);
   static bool UnregisterAction(ezActionDescriptorHandle& ref_hAction);
   static const ezActionDescriptor* GetActionDescriptor(ezActionDescriptorHandle hAction);
-  static ezActionDescriptorHandle GetActionHandle(const char* szCategory, const char* szActionName);
+  static ezActionDescriptorHandle GetActionHandle(ezStringView sCategory, ezStringView sActionName);
 
   /// \brief Searches all action categories for the given action name. Returns the category name in which the action name was found, or an empty
   /// string.
-  static ezString FindActionCategory(const char* szActionName);
+  static ezString FindActionCategory(ezStringView sActionName);
 
   /// \brief Quick way to execute an action from code
   ///
@@ -82,7 +82,7 @@ public:
   ///        some members are optional. E.g. for document actions, only the m_pDocument member must be specified.
   /// \param value Optional value passed through to the ezAction::Execute() call. Some actions use it, most don't.
   /// \return Returns failure in case the action could not be found.
-  static ezResult ExecuteAction(const char* szCategory, const char* szActionName, const ezActionContext& context, const ezVariant& value = ezVariant());
+  static ezResult ExecuteAction(ezStringView sCategory, ezStringView sActionName, const ezActionContext& context, const ezVariant& value = ezVariant());
 
   static void SaveShortcutAssignment();
   static void LoadShortcutAssignment();
@@ -115,7 +115,7 @@ private:
   struct CategoryData
   {
     ezSet<ezActionDescriptorHandle> m_Actions;
-    ezHashTable<const char*, ezActionDescriptorHandle> m_ActionNameToHandle;
+    ezHashTable<ezStringView, ezActionDescriptorHandle> m_ActionNameToHandle;
   };
 
 private:

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionManager.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/ActionManager.cpp
@@ -62,7 +62,7 @@ ezActionDescriptorHandle ezActionManager::RegisterAction(const ezActionDescripto
 
   auto it = s_CategoryPathToActions.FindOrAdd(pDesc->m_sCategoryPath);
   it.Value().m_Actions.Insert(hType);
-  it.Value().m_ActionNameToHandle[pDesc->m_sActionName.GetData()] = hType;
+  it.Value().m_ActionNameToHandle[pDesc->m_sActionName] = hType;
 
   {
     Event msg;
@@ -112,39 +112,39 @@ const ezIdTable<ezActionId, ezActionDescriptor*>::ConstIterator ezActionManager:
   return s_ActionTable.GetIterator();
 }
 
-ezActionDescriptorHandle ezActionManager::GetActionHandle(const char* szCategoryPath, const char* szActionName)
+ezActionDescriptorHandle ezActionManager::GetActionHandle(ezStringView sCategoryPath, ezStringView sActionName)
 {
   ezActionDescriptorHandle hAction;
-  auto it = s_CategoryPathToActions.Find(szCategoryPath);
+  auto it = s_CategoryPathToActions.Find(sCategoryPath);
   if (!it.IsValid())
     return hAction;
 
-  it.Value().m_ActionNameToHandle.TryGetValue(szActionName, hAction);
+  it.Value().m_ActionNameToHandle.TryGetValue(sActionName, hAction);
 
   return hAction;
 }
 
-ezString ezActionManager::FindActionCategory(const char* szActionName)
+ezString ezActionManager::FindActionCategory(ezStringView sActionName)
 {
   for (auto itCat : s_CategoryPathToActions)
   {
-    if (itCat.Value().m_ActionNameToHandle.Contains(szActionName))
+    if (itCat.Value().m_ActionNameToHandle.Contains(sActionName))
       return itCat.Key();
   }
 
   return ezString();
 }
 
-ezResult ezActionManager::ExecuteAction(const char* szCategory, const char* szActionName, const ezActionContext& context, const ezVariant& value /*= ezVariant()*/)
+ezResult ezActionManager::ExecuteAction(ezStringView sCategory0, ezStringView sActionName, const ezActionContext& context, const ezVariant& value /*= ezVariant()*/)
 {
-  ezString sCategory = szCategory;
+  ezStringBuilder sCategory = sCategory0;
 
-  if (szCategory == nullptr)
+  if (sCategory.IsEmpty())
   {
-    sCategory = FindActionCategory(szActionName);
+    sCategory = FindActionCategory(sActionName);
   }
 
-  auto hAction = ezActionManager::GetActionHandle(sCategory, szActionName);
+  auto hAction = ezActionManager::GetActionHandle(sCategory, sActionName);
 
   if (hAction.IsInvalidated())
     return EZ_FAILURE;

--- a/Code/Tools/Libs/GuiFoundation/UIServices/DynamicEnums.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/DynamicEnums.h
@@ -2,6 +2,7 @@
 
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Strings/String.h>
+#include <Foundation/Types/Variant.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
 
 /// \brief Stores the valid values and names for 'dynamic' enums.
@@ -34,8 +35,19 @@ public:
   /// \brief Returns the name for the given value. Returns "<invalid value>" if the value is not in use.
   ezStringView GetValueName(ezInt32 iValue) const;
 
+  /// \brief If specified, the widget shows an "edit" option, which will run ezActionManager::ExecuteAction(sCmd, value)
+  ///
+  /// This is meant to be used to open existing config dialogs.
+  /// There is currently no way to report back a selection, so after making changes, the user has to make another selection.
+  void SetEditCommand(ezStringView sCmd, const ezVariant& value);
+  ezStringView GetEditCommand() const { return m_sEditCommand; }
+  const ezVariant& GetEditCommandValue() const { return m_EditCommandValue; }
+
+
 private:
   ezMap<ezInt32, ezString> m_ValidValues;
+  ezString m_sEditCommand;
+  ezVariant m_EditCommandValue;
 
   static ezMap<ezString, ezDynamicEnum> s_DynamicEnums;
 };

--- a/Code/Tools/Libs/GuiFoundation/UIServices/DynamicStringEnum.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/DynamicStringEnum.h
@@ -52,6 +52,14 @@ public:
   /// \brief The file where values will be stored.
   ezStringView GetStorageFile() const { return m_sStorageFile; }
 
+  /// \brief If specified, the widget shows an "edit" option, which will run ezActionManager::ExecuteAction(sCmd, value)
+  ///
+  /// This is meant to be used to open existing config dialogs.
+  /// There is currently no way to report back a selection, so after making changes, the user has to make another selection.
+  void SetEditCommand(ezStringView sCmd, const ezVariant& value);
+  ezStringView GetEditCommand() const { return m_sEditCommand; }
+  const ezVariant& GetEditCommandValue() const { return m_EditCommandValue; }
+
   void ReadFromStorage();
 
   void SaveToStorage();
@@ -64,6 +72,8 @@ public:
 private:
   ezHybridArray<ezString, 16> m_ValidValues;
   ezString m_sStorageFile;
+  ezString m_sEditCommand;
+  ezVariant m_EditCommandValue;
 
   static ezMap<ezString, ezDynamicStringEnum> s_DynamicEnums;
 };

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/DynamicEnums.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/DynamicEnums.cpp
@@ -34,6 +34,12 @@ ezStringView ezDynamicEnum::GetValueName(ezInt32 iValue) const
   return it.Value();
 }
 
+void ezDynamicEnum::SetEditCommand(ezStringView sCmd, const ezVariant& value)
+{
+  m_sEditCommand = sCmd;
+  m_EditCommandValue = value;
+}
+
 ezDynamicEnum& ezDynamicEnum::GetDynamicEnum(const char* szEnumName)
 {
   return s_DynamicEnums[szEnumName];

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/DynamicStringEnum.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/DynamicStringEnum.cpp
@@ -71,6 +71,12 @@ void ezDynamicStringEnum::SortValues()
   m_ValidValues.Sort();
 }
 
+void ezDynamicStringEnum::SetEditCommand(ezStringView sCmd, const ezVariant& value)
+{
+  m_sEditCommand = sCmd;
+  m_EditCommandValue = value;
+}
+
 void ezDynamicStringEnum::ReadFromStorage()
 {
   Clear();


### PR DESCRIPTION
Code can now register an action that shall be executed when the user wants to edit dynamic enum values. This is used to show configuration dialogs.