### PR TITLE
DebugRenderer: Allow to use Mat4 as transform

### DIFF
--- a/Code/Engine/Foundation/Math/Transform.h
+++ b/Code/Engine/Foundation/Math/Transform.h
@@ -44,7 +44,7 @@ public:
 
 
   /// \brief Initializes the transform from the given position, rotation and scale.
-  ezTransformTemplate(const ezVec3Template<Type>& vPosition,
+  explicit ezTransformTemplate(const ezVec3Template<Type>& vPosition,
     const ezQuatTemplate<Type>& qRotation = ezQuatTemplate<Type>::MakeIdentity(),
     const ezVec3Template<Type>& vScale = ezVec3Template<Type>(1)); // [tested]
 

--- a/Code/Engine/RendererCore/Debug/DebugRenderer.h
+++ b/Code/Engine/RendererCore/Debug/DebugRenderer.h
@@ -109,15 +109,15 @@ struct EZ_RENDERERCORE_DLL ezDebugRendererTexturedTriangle
 /// \brief Enables a function to take an ezMat3, ezMat4 or ezTransfrom.
 struct ezMatOrTransform
 {
-  ezMatOrTransform(const ezMat4& mat4)
-    : m_Mat4(mat4)
+  ezMatOrTransform(const ezMat4& mMat4)
+    : m_Mat4(mMat4)
   {
   }
 
-  ezMatOrTransform(const ezMat3& mat3)
+  ezMatOrTransform(const ezMat3& mMat3)
   {
     m_Mat4.SetIdentity();
-    m_Mat4.SetRotationalPart(mat3);
+    m_Mat4.SetRotationalPart(mMat3);
   }
 
   ezMatOrTransform(const ezTransform& transform)
@@ -139,34 +139,34 @@ class EZ_RENDERERCORE_DLL ezDebugRenderer
 {
 public:
   /// \brief Renders the given set of lines for one frame.
-  static void DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders the given set of lines in 2D (screen-space) for one frame.
   static void Draw2DLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color);
 
   /// \brief Renders a cross for one frame.
-  static void DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders a wireframe box for one frame.
-  static void DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders the corners of a wireframe box for one frame.
-  static void DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders a wireframe sphere for one frame.
-  static void DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders an upright wireframe capsule for one frame.
-  static void DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders an upright wireframe cylinder for one frame.
-  static void DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders a wireframe frustum for one frame.
   static void DrawLineFrustum(const ezDebugRendererContext& context, const ezFrustum& frustum, const ezColor& color, bool bDrawPlaneNormals = false);
 
   /// \brief Renders a solid box for one frame.
-  static void DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
+  static void DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
   /// \brief Renders the set of filled triangles for one frame.
   static void DrawSolidTriangles(const ezDebugRendererContext& context, ezArrayPtr<ezDebugRendererTriangle> triangles, const ezColor& color, bool bTwoSided = false);
@@ -218,41 +218,41 @@ public:
   static ezUInt32 Draw3DText(const ezDebugRendererContext& context, const ezFormatString& text, const ezVec3& vGlobalPosition, const ezColor& color, ezUInt32 uiSizeInPixel = 16, ezDebugTextHAlign::Enum horizontalAlignment = ezDebugTextHAlign::Center, ezDebugTextVAlign::Enum verticalAlignment = ezDebugTextVAlign::Bottom);
 
   /// \brief Renders a cross at the given location for as many frames until \a duration has passed.
-  static void AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezTime duration);
+  static void AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform mTransform, ezTime duration);
 
   /// \brief Renders a wireframe sphere at the given location for as many frames until \a duration has passed.
-  static void AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, ezMatOrTransform transform, ezTime duration);
+  static void AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, ezMatOrTransform mTransform, ezTime duration);
 
   /// \brief Renders a wireframe box at the given location for as many frames until \a duration has passed.
-  static void AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, ezMatOrTransform transform, ezTime duration);
+  static void AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, ezMatOrTransform mTransform, ezTime duration);
 
   /// \brief Renders lines at the given location for as many frames until \a duration has passed.
-  static void AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform, ezTime duration);
+  static void AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform, ezTime duration);
 
   /// \brief Renders a solid 2D cone in a plane with a given angle.
   ///
   /// The rotation goes around the given \a rotationAxis.
   /// An angle of zero is pointing into forwardAxis direction.
   /// Both angles may be negative.
-  static void DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX(), ezVec3 vRotationAxis = ezVec3::MakeAxisZ());
+  static void DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform mTransform, ezVec3 vForwardAxis = ezVec3::MakeAxisX(), ezVec3 vRotationAxis = ezVec3::MakeAxisZ());
 
   /// \brief Renders a cone with the tip at the center position, opening up with the given angle.
-  static void DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, ezMatOrTransform transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
+  static void DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, ezMatOrTransform mTransform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
 
   /// \brief Renders a bent cone with the tip at the center position, pointing into the +X direction opening up with halfAngle1 and halfAngle2 along the Y and Z axis.
   ///
   /// If solidColor.a > 0, the cone is rendered with as solid triangles.
   /// If lineColor.a > 0, the cone is rendered as lines.
   /// Both can be combined.
-  static void DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform);
+  static void DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform mTransform);
 
   /// \brief Renders a cylinder starting at the center position, along the +X axis.
   ///
   /// If the start and end radius are different, a cone or arrow can be created.
-  static void DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform, bool bCapStart = false, bool bCapEnd = false, ezBasisAxis::Enum cylinderAxis = ezBasisAxis::PositiveX);
+  static void DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform mTransform, bool bCapStart = false, bool bCapEnd = false, ezBasisAxis::Enum cylinderAxis = ezBasisAxis::PositiveX);
 
   /// \brief Renders a line arrow.
-  static void DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
+  static void DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform mTransform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
 
   /// \brief Returns the width of single glyph in pixels for the given text size
   static float GetTextGlyphWidth(ezUInt32 uiSizeInPixel = 16);

--- a/Code/Engine/RendererCore/Debug/DebugRenderer.h
+++ b/Code/Engine/RendererCore/Debug/DebugRenderer.h
@@ -106,6 +106,28 @@ struct EZ_RENDERERCORE_DLL ezDebugRendererTexturedTriangle
   ezColor m_color = ezColor::White;
 };
 
+/// \brief Enables a function to take an ezMat3, ezMat4 or ezTransfrom.
+struct ezMatOrTransform
+{
+  ezMatOrTransform(const ezMat4& mat4)
+    : m_Mat4(mat4)
+  {
+  }
+
+  ezMatOrTransform(const ezMat3& mat3)
+  {
+    m_Mat4.SetIdentity();
+    m_Mat4.SetRotationalPart(mat3);
+  }
+
+  ezMatOrTransform(const ezTransform& transform)
+  {
+    m_Mat4 = transform.GetAsMat4();
+  }
+
+  ezMat4 m_Mat4;
+};
+
 
 /// \brief Draws simple shapes into the scene or view.
 ///
@@ -117,34 +139,34 @@ class EZ_RENDERERCORE_DLL ezDebugRenderer
 {
 public:
   /// \brief Renders the given set of lines for one frame.
-  static void DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders the given set of lines in 2D (screen-space) for one frame.
   static void Draw2DLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color);
 
   /// \brief Renders a cross for one frame.
-  static void DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders a wireframe box for one frame.
-  static void DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders the corners of a wireframe box for one frame.
-  static void DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders a wireframe sphere for one frame.
-  static void DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders an upright wireframe capsule for one frame.
-  static void DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders an upright wireframe cylinder for one frame.
-  static void DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders a wireframe frustum for one frame.
   static void DrawLineFrustum(const ezDebugRendererContext& context, const ezFrustum& frustum, const ezColor& color, bool bDrawPlaneNormals = false);
 
   /// \brief Renders a solid box for one frame.
-  static void DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, const ezTransform& transform = ezTransform::MakeIdentity());
+  static void DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform = ezMat4::MakeIdentity());
 
   /// \brief Renders the set of filled triangles for one frame.
   static void DrawSolidTriangles(const ezDebugRendererContext& context, ezArrayPtr<ezDebugRendererTriangle> triangles, const ezColor& color, bool bTwoSided = false);
@@ -196,41 +218,41 @@ public:
   static ezUInt32 Draw3DText(const ezDebugRendererContext& context, const ezFormatString& text, const ezVec3& vGlobalPosition, const ezColor& color, ezUInt32 uiSizeInPixel = 16, ezDebugTextHAlign::Enum horizontalAlignment = ezDebugTextHAlign::Center, ezDebugTextVAlign::Enum verticalAlignment = ezDebugTextVAlign::Bottom);
 
   /// \brief Renders a cross at the given location for as many frames until \a duration has passed.
-  static void AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, const ezTransform& transform, ezTime duration);
+  static void AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezTime duration);
 
   /// \brief Renders a wireframe sphere at the given location for as many frames until \a duration has passed.
-  static void AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, const ezTransform& transform, ezTime duration);
+  static void AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, ezMatOrTransform transform, ezTime duration);
 
   /// \brief Renders a wireframe box at the given location for as many frames until \a duration has passed.
-  static void AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, const ezTransform& transform, ezTime duration);
+  static void AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, ezMatOrTransform transform, ezTime duration);
 
   /// \brief Renders lines at the given location for as many frames until \a duration has passed.
-  static void AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, const ezTransform& transform, ezTime duration);
+  static void AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform, ezTime duration);
 
   /// \brief Renders a solid 2D cone in a plane with a given angle.
   ///
   /// The rotation goes around the given \a rotationAxis.
   /// An angle of zero is pointing into forwardAxis direction.
   /// Both angles may be negative.
-  static void DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, const ezTransform& transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX(), ezVec3 vRotationAxis = ezVec3::MakeAxisZ());
+  static void DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX(), ezVec3 vRotationAxis = ezVec3::MakeAxisZ());
 
   /// \brief Renders a cone with the tip at the center position, opening up with the given angle.
-  static void DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, const ezTransform& transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
+  static void DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, ezMatOrTransform transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
 
   /// \brief Renders a bent cone with the tip at the center position, pointing into the +X direction opening up with halfAngle1 and halfAngle2 along the Y and Z axis.
   ///
   /// If solidColor.a > 0, the cone is rendered with as solid triangles.
   /// If lineColor.a > 0, the cone is rendered as lines.
   /// Both can be combined.
-  static void DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, const ezTransform& transform);
+  static void DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform);
 
   /// \brief Renders a cylinder starting at the center position, along the +X axis.
   ///
   /// If the start and end radius are different, a cone or arrow can be created.
-  static void DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, const ezTransform& transform, bool bCapStart = false, bool bCapEnd = false, ezBasisAxis::Enum cylinderAxis = ezBasisAxis::PositiveX);
+  static void DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform, bool bCapStart = false, bool bCapEnd = false, ezBasisAxis::Enum cylinderAxis = ezBasisAxis::PositiveX);
 
   /// \brief Renders a line arrow.
-  static void DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, const ezTransform& transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
+  static void DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezVec3 vForwardAxis = ezVec3::MakeAxisX());
 
   /// \brief Returns the width of single glyph in pixels for the given text size
   static float GetTextGlyphWidth(ezUInt32 uiSizeInPixel = 16);

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -414,7 +414,7 @@ namespace
   {
     float m_fSize;
     ezColor m_Color;
-    ezTransform m_Transform;
+    ezMat4 m_Transform;
     ezTime m_Timeout;
   };
 
@@ -422,7 +422,7 @@ namespace
   {
     float m_fRadius;
     ezColor m_Color;
-    ezTransform m_Transform;
+    ezMat4 m_Transform;
     ezTime m_Timeout;
   };
 
@@ -430,7 +430,7 @@ namespace
   {
     ezVec3 m_vHalfSize;
     ezColor m_Color;
-    ezTransform m_Transform;
+    ezMat4 m_Transform;
     ezTime m_Timeout;
   };
 
@@ -438,7 +438,7 @@ namespace
   {
     ezHybridArray<ezDebugRendererLine, 32> m_Lines;
     ezColor m_Color;
-    ezTransform m_Transform;
+    ezMat4 m_Transform;
     ezTime m_Timeout;
   };
 
@@ -486,7 +486,7 @@ EZ_END_SUBSYSTEM_DECLARATION;
 // clang-format on
 
 // static
-void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, const ezTransform& transform /*= ezTransform::MakeIdentity()*/)
+void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform /*= ezMat4::MakeIdentity()*/)
 {
   if (lines.IsEmpty())
     return;
@@ -503,7 +503,7 @@ void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPt
     for (ezUInt32 i = 0; i < 2; ++i)
     {
       auto& vertex = data.m_lineVertices.ExpandAndGetRef();
-      vertex.m_position = transform.TransformPosition(pPositions[i]);
+      vertex.m_position = transform.m_Mat4.TransformPosition(pPositions[i]);
       vertex.m_color = pColors[i] * color;
     }
   }
@@ -532,10 +532,12 @@ void ezDebugRenderer::Draw2DLines(const ezDebugRendererContext& context, ezArray
 }
 
 // static
-void ezDebugRenderer::DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, const ezTransform& transform /*= ezTransform::MakeIdentity()*/)
+void ezDebugRenderer::DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
 {
   if (fLineLength <= 0.0f)
     return;
+
+  const ezMat4& transform = transform0.m_Mat4;
 
   const float fHalfLineLength = fLineLength * 0.5f;
   const ezVec3 xAxis = ezVec3::MakeAxisX() * fHalfLineLength;
@@ -557,9 +559,11 @@ void ezDebugRenderer::DrawCross(const ezDebugRendererContext& context, const ezV
 }
 
 // static
-void ezDebugRenderer::DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, const ezTransform& transform)
+void ezDebugRenderer::DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform0)
 {
   EZ_LOCK(s_Mutex);
+
+  const ezMat4& transform = transform0.m_Mat4;
 
   auto& data = GetDataForExtraction(context);
 
@@ -567,13 +571,15 @@ void ezDebugRenderer::DrawLineBox(const ezDebugRendererContext& context, const e
 
   ezTransform boxTransform(box.GetCenter(), ezQuat::MakeIdentity(), box.GetHalfExtents());
 
-  boxData.m_transform = transform * boxTransform;
+  boxData.m_transform = transform * boxTransform.GetAsMat4();
   boxData.m_color = color;
 }
 
 // static
-void ezDebugRenderer::DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, const ezTransform& transform)
+void ezDebugRenderer::DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, ezMatOrTransform transform0)
 {
+  const ezMat4& transform = transform0.m_Mat4;
+
   fCornerFraction = ezMath::Clamp(fCornerFraction, 0.0f, 1.0f) * 0.5f;
 
   ezVec3 corners[8];
@@ -616,7 +622,7 @@ void ezDebugRenderer::DrawLineBoxCorners(const ezDebugRendererContext& context, 
 }
 
 // static
-void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, const ezTransform& transform /*= ezTransform::MakeIdentity()*/)
+void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
 {
   enum
   {
@@ -626,6 +632,8 @@ void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, cons
   const ezVec3 vCenter = sphere.m_vCenter;
   const float fRadius = sphere.m_fRadius;
   const ezAngle stepAngle = ezAngle::MakeFromDegree(360.0f / (float)NUM_SEGMENTS);
+
+  const ezMat4& transform = transform0.m_Mat4;
 
   EZ_LOCK(s_Mutex);
 
@@ -654,7 +662,7 @@ void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, cons
 }
 
 
-void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, const ezTransform& transform /*= ezTransform::MakeIdentity()*/)
+void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
 {
   enum
   {
@@ -662,6 +670,8 @@ void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, fl
     NUM_HALF_SEGMENTS = 16,
     NUM_LINES = NUM_SEGMENTS + NUM_SEGMENTS + NUM_SEGMENTS + NUM_SEGMENTS + 4,
   };
+
+  const ezMat4& transform = transform0.m_Mat4;
 
   const ezAngle stepAngle = ezAngle::MakeFromDegree(360.0f / (float)NUM_SEGMENTS);
 
@@ -744,7 +754,7 @@ void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, fl
   DrawLines(context, lines, color);
 }
 
-void ezDebugRenderer::DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, const ezTransform& transform /*= ezTransform::MakeIdentity()*/)
+void ezDebugRenderer::DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
 {
   enum
   {
@@ -752,6 +762,8 @@ void ezDebugRenderer::DrawLineCylinderZ(const ezDebugRendererContext& context, f
     NUM_HALF_SEGMENTS = 16,
     NUM_LINES = NUM_SEGMENTS + NUM_SEGMENTS + 4,
   };
+
+  const ezMat4& transform = transform0.m_Mat4;
 
   const ezAngle stepAngle = ezAngle::MakeFromDegree(360.0f / (float)NUM_SEGMENTS);
 
@@ -878,8 +890,10 @@ void ezDebugRenderer::DrawLineFrustum(const ezDebugRendererContext& context, con
 }
 
 // static
-void ezDebugRenderer::DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, const ezTransform& transform)
+void ezDebugRenderer::DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform0)
 {
+  const ezMat4& transform = transform0.m_Mat4;
+
   EZ_LOCK(s_Mutex);
 
   auto& data = GetDataForExtraction(context);
@@ -888,7 +902,7 @@ void ezDebugRenderer::DrawSolidBox(const ezDebugRendererContext& context, const 
 
   ezTransform boxTransform(box.GetCenter(), ezQuat::MakeIdentity(), box.GetHalfExtents());
 
-  boxData.m_transform = transform * boxTransform;
+  boxData.m_transform = transform * boxTransform.GetAsMat4();
   boxData.m_color = color;
 }
 
@@ -1099,49 +1113,49 @@ ezUInt32 ezDebugRenderer::Draw3DText(const ezDebugRendererContext& context, cons
     textLine.m_position = vGlobalPosition; });
 }
 
-void ezDebugRenderer::AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, const ezTransform& transform, ezTime duration)
+void ezDebugRenderer::AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Crosses.ExpandAndGetRef();
-  item.m_Transform = transform;
+  item.m_Transform = transform.m_Mat4;
   item.m_Color = color;
   item.m_fSize = fSize;
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, const ezTransform& transform, ezTime duration)
+void ezDebugRenderer::AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, ezMatOrTransform transform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Spheres.ExpandAndGetRef();
-  item.m_Transform = transform;
+  item.m_Transform = transform.m_Mat4;
   item.m_Color = color;
   item.m_fRadius = fRadius;
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, const ezTransform& transform, ezTime duration)
+void ezDebugRenderer::AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, ezMatOrTransform transform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Boxes.ExpandAndGetRef();
-  item.m_Transform = transform;
+  item.m_Transform = transform.m_Mat4;
   item.m_Color = color;
   item.m_vHalfSize = vHalfSize;
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, const ezTransform& transform, ezTime duration)
+void ezDebugRenderer::AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Lines.ExpandAndGetRef();
-  item.m_Transform = transform;
+  item.m_Transform = transform.m_Mat4;
   item.m_Color = color;
   item.m_Lines = lines;
   item.m_Timeout = data.m_Now + duration;
@@ -1162,8 +1176,10 @@ void ezDebugRenderer::AddPersistentInfoText(const ezDebugRendererContext& contex
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, const ezTransform& transform, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/, ezVec3 vRotationAxis /*= ezVec3::MakeAxisZ()*/)
+void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform0, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/, ezVec3 vRotationAxis /*= ezVec3::MakeAxisZ()*/)
 {
+  const ezMat4& transform = transform0.m_Mat4;
+
   ezHybridArray<ezDebugRendererTriangle, 64> tris;
   ezHybridArray<ezDebugRendererLine, 64> lines;
 
@@ -1197,12 +1213,12 @@ void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle s
     if (solidColor.a > 0)
     {
       ezDebugRendererTriangle& tri1 = tris.ExpandAndGetRef();
-      tri1.m_position[0] = transform.m_vPosition;
+      tri1.m_position[0] = transform.GetTranslationVector();
       tri1.m_position[1] = transform.TransformPosition(vNextDir);
       tri1.m_position[2] = transform.TransformPosition(vCurDir);
 
       ezDebugRendererTriangle& tri2 = tris.ExpandAndGetRef();
-      tri2.m_position[0] = transform.m_vPosition;
+      tri2.m_position[0] = transform.GetTranslationVector();
       tri2.m_position[1] = transform.TransformPosition(vCurDir);
       tri2.m_position[2] = transform.TransformPosition(vNextDir);
     }
@@ -1225,8 +1241,10 @@ void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle s
   DrawLines(context, lines, lineColor, transform);
 }
 
-void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, const ezTransform& transform, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
+void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, ezMatOrTransform transform0, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
 {
+  const ezMat4& transform = transform0.m_Mat4;
+
   ezHybridArray<ezDebugRendererTriangle, 64> trisInside;
   ezHybridArray<ezDebugRendererTriangle, 64> trisOutside;
 
@@ -1250,7 +1268,7 @@ void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezA
     if (colorInside.a > 0)
     {
       ezDebugRendererTriangle& tri = trisInside.ExpandAndGetRef();
-      tri.m_position[0] = transform.m_vPosition;
+      tri.m_position[0] = transform.GetTranslationVector();
       tri.m_position[1] = transform.TransformPosition(vCurDir);
       tri.m_position[2] = transform.TransformPosition(vNextDir);
     }
@@ -1258,7 +1276,7 @@ void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezA
     if (colorOutside.a > 0)
     {
       ezDebugRendererTriangle& tri = trisOutside.ExpandAndGetRef();
-      tri.m_position[0] = transform.m_vPosition;
+      tri.m_position[0] = transform.GetTranslationVector();
       tri.m_position[1] = transform.TransformPosition(vNextDir);
       tri.m_position[2] = transform.TransformPosition(vCurDir);
     }
@@ -1271,8 +1289,10 @@ void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezA
   DrawSolidTriangles(context, trisOutside, colorOutside);
 }
 
-void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, const ezTransform& transform)
+void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform0)
 {
+  const ezMat4& transform = transform0.m_Mat4;
+
   constexpr ezUInt32 NUM_LINES = 32;
   ezHybridArray<ezDebugRendererLine, NUM_LINES * 2> lines;
   ezHybridArray<ezDebugRendererTriangle, NUM_LINES * 2> tris;
@@ -1310,12 +1330,12 @@ void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAng
       if (solidColor.a > 0)
       {
         auto& t1 = tris.ExpandAndGetRef();
-        t1.m_position[0] = transform.m_vPosition;
+        t1.m_position[0] = transform.GetTranslationVector();
         t1.m_position[1] = transform.TransformPosition(prev);
         t1.m_position[2] = transform.TransformPosition(a);
 
         auto& t2 = tris.ExpandAndGetRef();
-        t2.m_position[0] = transform.m_vPosition;
+        t2.m_position[0] = transform.GetTranslationVector();
         t2.m_position[1] = transform.TransformPosition(a);
         t2.m_position[2] = transform.TransformPosition(prev);
       }
@@ -1328,10 +1348,10 @@ void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAng
   DrawLines(context, lines, lineColor, transform);
 }
 
-void ezDebugRenderer::DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, const ezTransform& transform0, bool bCapStart /*= false*/, bool bCapEnd /*= false*/, ezBasisAxis::Enum cylinderAxis /*= ezBasisAxis::PositiveX*/)
+void ezDebugRenderer::DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform0, bool bCapStart /*= false*/, bool bCapEnd /*= false*/, ezBasisAxis::Enum cylinderAxis /*= ezBasisAxis::PositiveX*/)
 {
   const ezQuat tilt = ezBasisAxis::GetBasisRotation(ezBasisAxis::PositiveX, cylinderAxis);
-  const ezTransform transform = transform0 * tilt;
+  const ezMat4 transform = transform0.m_Mat4 * tilt.GetAsMat4();
 
   constexpr ezUInt32 NUM_SEGMENTS = 16;
   ezHybridArray<ezDebugRendererLine, NUM_SEGMENTS * 3> lines;
@@ -1391,11 +1411,11 @@ void ezDebugRenderer::DrawCylinder(const ezDebugRendererContext& context, float 
   DrawLines(context, lines, lineColor, transform);
 }
 
-void ezDebugRenderer::DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, const ezTransform& transform, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
+void ezDebugRenderer::DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
 {
   vForwardAxis.Normalize();
-  const ezVec3 right = vForwardAxis.GetOrthogonalVector();
-  const ezVec3 up = vForwardAxis.CrossRH(right);
+  const ezVec3 right = vForwardAxis.GetOrthogonalVector().GetNormalized();
+  const ezVec3 up = vForwardAxis.CrossRH(right).GetNormalized();
   const ezVec3 endPoint = vForwardAxis * fSize;
   const ezVec3 endPoint2 = vForwardAxis * fSize * 0.9f;
   const float tipSize = fSize * 0.1f;

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -486,7 +486,7 @@ EZ_END_SUBSYSTEM_DECLARATION;
 // clang-format on
 
 // static
-void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform /*= ezMat4::MakeIdentity()*/)
+void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform /*= ezMat4::MakeIdentity()*/)
 {
   if (lines.IsEmpty())
     return;
@@ -503,7 +503,7 @@ void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPt
     for (ezUInt32 i = 0; i < 2; ++i)
     {
       auto& vertex = data.m_lineVertices.ExpandAndGetRef();
-      vertex.m_position = transform.m_Mat4.TransformPosition(pPositions[i]);
+      vertex.m_position = mTransform.m_Mat4.TransformPosition(pPositions[i]);
       vertex.m_color = pColors[i] * color;
     }
   }
@@ -532,12 +532,12 @@ void ezDebugRenderer::Draw2DLines(const ezDebugRendererContext& context, ezArray
 }
 
 // static
-void ezDebugRenderer::DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
+void ezDebugRenderer::DrawCross(const ezDebugRendererContext& context, const ezVec3& vGlobalPosition, float fLineLength, const ezColor& color, ezMatOrTransform mTransform0 /*= ezMat4::MakeIdentity()*/)
 {
   if (fLineLength <= 0.0f)
     return;
 
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   const float fHalfLineLength = fLineLength * 0.5f;
   const ezVec3 xAxis = ezVec3::MakeAxisX() * fHalfLineLength;
@@ -559,11 +559,11 @@ void ezDebugRenderer::DrawCross(const ezDebugRendererContext& context, const ezV
 }
 
 // static
-void ezDebugRenderer::DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform0)
+void ezDebugRenderer::DrawLineBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform mTransform0)
 {
   EZ_LOCK(s_Mutex);
 
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   auto& data = GetDataForExtraction(context);
 
@@ -576,9 +576,9 @@ void ezDebugRenderer::DrawLineBox(const ezDebugRendererContext& context, const e
 }
 
 // static
-void ezDebugRenderer::DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, ezMatOrTransform transform0)
+void ezDebugRenderer::DrawLineBoxCorners(const ezDebugRendererContext& context, const ezBoundingBox& box, float fCornerFraction, const ezColor& color, ezMatOrTransform mTransform0)
 {
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   fCornerFraction = ezMath::Clamp(fCornerFraction, 0.0f, 1.0f) * 0.5f;
 
@@ -622,7 +622,7 @@ void ezDebugRenderer::DrawLineBoxCorners(const ezDebugRendererContext& context, 
 }
 
 // static
-void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
+void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, const ezBoundingSphere& sphere, const ezColor& color, ezMatOrTransform mTransform0 /*= ezMat4::MakeIdentity()*/)
 {
   enum
   {
@@ -633,7 +633,7 @@ void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, cons
   const float fRadius = sphere.m_fRadius;
   const ezAngle stepAngle = ezAngle::MakeFromDegree(360.0f / (float)NUM_SEGMENTS);
 
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   EZ_LOCK(s_Mutex);
 
@@ -662,7 +662,7 @@ void ezDebugRenderer::DrawLineSphere(const ezDebugRendererContext& context, cons
 }
 
 
-void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
+void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform mTransform0 /*= ezMat4::MakeIdentity()*/)
 {
   enum
   {
@@ -671,7 +671,7 @@ void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, fl
     NUM_LINES = NUM_SEGMENTS + NUM_SEGMENTS + NUM_SEGMENTS + NUM_SEGMENTS + 4,
   };
 
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   const ezAngle stepAngle = ezAngle::MakeFromDegree(360.0f / (float)NUM_SEGMENTS);
 
@@ -754,7 +754,7 @@ void ezDebugRenderer::DrawLineCapsuleZ(const ezDebugRendererContext& context, fl
   DrawLines(context, lines, color);
 }
 
-void ezDebugRenderer::DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform transform0 /*= ezMat4::MakeIdentity()*/)
+void ezDebugRenderer::DrawLineCylinderZ(const ezDebugRendererContext& context, float fLength, float fRadius, const ezColor& color, ezMatOrTransform mTransform0 /*= ezMat4::MakeIdentity()*/)
 {
   enum
   {
@@ -763,7 +763,7 @@ void ezDebugRenderer::DrawLineCylinderZ(const ezDebugRendererContext& context, f
     NUM_LINES = NUM_SEGMENTS + NUM_SEGMENTS + 4,
   };
 
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   const ezAngle stepAngle = ezAngle::MakeFromDegree(360.0f / (float)NUM_SEGMENTS);
 
@@ -890,9 +890,9 @@ void ezDebugRenderer::DrawLineFrustum(const ezDebugRendererContext& context, con
 }
 
 // static
-void ezDebugRenderer::DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform transform0)
+void ezDebugRenderer::DrawSolidBox(const ezDebugRendererContext& context, const ezBoundingBox& box, const ezColor& color, ezMatOrTransform mTransform0)
 {
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   EZ_LOCK(s_Mutex);
 
@@ -1113,49 +1113,49 @@ ezUInt32 ezDebugRenderer::Draw3DText(const ezDebugRendererContext& context, cons
     textLine.m_position = vGlobalPosition; });
 }
 
-void ezDebugRenderer::AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezTime duration)
+void ezDebugRenderer::AddPersistentCross(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform mTransform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Crosses.ExpandAndGetRef();
-  item.m_Transform = transform.m_Mat4;
+  item.m_Transform = mTransform.m_Mat4;
   item.m_Color = color;
   item.m_fSize = fSize;
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, ezMatOrTransform transform, ezTime duration)
+void ezDebugRenderer::AddPersistentLineSphere(const ezDebugRendererContext& context, float fRadius, const ezColor& color, ezMatOrTransform mTransform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Spheres.ExpandAndGetRef();
-  item.m_Transform = transform.m_Mat4;
+  item.m_Transform = mTransform.m_Mat4;
   item.m_Color = color;
   item.m_fRadius = fRadius;
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, ezMatOrTransform transform, ezTime duration)
+void ezDebugRenderer::AddPersistentLineBox(const ezDebugRendererContext& context, const ezVec3& vHalfSize, const ezColor& color, ezMatOrTransform mTransform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Boxes.ExpandAndGetRef();
-  item.m_Transform = transform.m_Mat4;
+  item.m_Transform = mTransform.m_Mat4;
   item.m_Color = color;
   item.m_vHalfSize = vHalfSize;
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform transform, ezTime duration)
+void ezDebugRenderer::AddPersistentLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform, ezTime duration)
 {
   EZ_LOCK(s_Mutex);
 
   auto& data = s_PersistentPerContextData[context];
   auto& item = data.m_Lines.ExpandAndGetRef();
-  item.m_Transform = transform.m_Mat4;
+  item.m_Transform = mTransform.m_Mat4;
   item.m_Color = color;
   item.m_Lines = lines;
   item.m_Timeout = data.m_Now + duration;
@@ -1176,9 +1176,9 @@ void ezDebugRenderer::AddPersistentInfoText(const ezDebugRendererContext& contex
   item.m_Timeout = data.m_Now + duration;
 }
 
-void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform0, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/, ezVec3 vRotationAxis /*= ezVec3::MakeAxisZ()*/)
+void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle startAngle, ezAngle endAngle, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform mTransform0, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/, ezVec3 vRotationAxis /*= ezVec3::MakeAxisZ()*/)
 {
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   ezHybridArray<ezDebugRendererTriangle, 64> tris;
   ezHybridArray<ezDebugRendererLine, 64> lines;
@@ -1241,9 +1241,9 @@ void ezDebugRenderer::DrawAngle(const ezDebugRendererContext& context, ezAngle s
   DrawLines(context, lines, lineColor, transform);
 }
 
-void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, ezMatOrTransform transform0, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
+void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezAngle halfAngle, const ezColor& colorInside, const ezColor& colorOutside, ezMatOrTransform mTransform0, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
 {
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   ezHybridArray<ezDebugRendererTriangle, 64> trisInside;
   ezHybridArray<ezDebugRendererTriangle, 64> trisOutside;
@@ -1289,9 +1289,9 @@ void ezDebugRenderer::DrawOpeningCone(const ezDebugRendererContext& context, ezA
   DrawSolidTriangles(context, trisOutside, colorOutside);
 }
 
-void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform0)
+void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAngle halfAngle1, ezAngle halfAngle2, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform mTransform0)
 {
-  const ezMat4& transform = transform0.m_Mat4;
+  const ezMat4& transform = mTransform0.m_Mat4;
 
   constexpr ezUInt32 NUM_LINES = 32;
   ezHybridArray<ezDebugRendererLine, NUM_LINES * 2> lines;
@@ -1348,10 +1348,10 @@ void ezDebugRenderer::DrawLimitCone(const ezDebugRendererContext& context, ezAng
   DrawLines(context, lines, lineColor, transform);
 }
 
-void ezDebugRenderer::DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform transform0, bool bCapStart /*= false*/, bool bCapEnd /*= false*/, ezBasisAxis::Enum cylinderAxis /*= ezBasisAxis::PositiveX*/)
+void ezDebugRenderer::DrawCylinder(const ezDebugRendererContext& context, float fRadiusStart, float fRadiusEnd, float fLength, const ezColor& solidColor, const ezColor& lineColor, ezMatOrTransform mTransform0, bool bCapStart /*= false*/, bool bCapEnd /*= false*/, ezBasisAxis::Enum cylinderAxis /*= ezBasisAxis::PositiveX*/)
 {
   const ezQuat tilt = ezBasisAxis::GetBasisRotation(ezBasisAxis::PositiveX, cylinderAxis);
-  const ezMat4 transform = transform0.m_Mat4 * tilt.GetAsMat4();
+  const ezMat4 transform = mTransform0.m_Mat4 * tilt.GetAsMat4();
 
   constexpr ezUInt32 NUM_SEGMENTS = 16;
   ezHybridArray<ezDebugRendererLine, NUM_SEGMENTS * 3> lines;
@@ -1411,7 +1411,7 @@ void ezDebugRenderer::DrawCylinder(const ezDebugRendererContext& context, float 
   DrawLines(context, lines, lineColor, transform);
 }
 
-void ezDebugRenderer::DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform transform, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
+void ezDebugRenderer::DrawArrow(const ezDebugRendererContext& context, float fSize, const ezColor& color, ezMatOrTransform mTransform, ezVec3 vForwardAxis /*= ezVec3::MakeAxisX()*/)
 {
   vForwardAxis.Normalize();
   const ezVec3 right = vForwardAxis.GetOrthogonalVector().GetNormalized();
@@ -1431,7 +1431,7 @@ void ezDebugRenderer::DrawArrow(const ezDebugRendererContext& context, float fSi
   lines[7] = ezDebugRendererLine(lines[3].m_end, lines[4].m_end);
   lines[8] = ezDebugRendererLine(lines[4].m_end, lines[1].m_end);
 
-  DrawLines(context, lines, color, transform);
+  DrawLines(context, lines, color, mTransform);
 }
 
 // static

--- a/Code/EnginePlugins/AiPlugin/Navigation/Components/NavigationComponent.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Components/NavigationComponent.cpp
@@ -195,7 +195,7 @@ void ezAiNavigationComponent::Update()
 
     if (m_DebugFlags.IsSet(ezAiNavigationDebugFlags::VisTarget))
     {
-      ezDebugRenderer::DrawArrow(GetWorld(), 1.0f, ezColor::Lime, m_Navigation.GetTargetPosition() + ezVec3(0, 0, 1.5f), -ezVec3::MakeAxisZ());
+      ezDebugRenderer::DrawArrow(GetWorld(), 1.0f, ezColor::Lime, ezTransform(m_Navigation.GetTargetPosition() + ezVec3(0, 0, 1.5f)), -ezVec3::MakeAxisZ());
     }
   }
 }


### PR DESCRIPTION
Generally nothing speaks against using non-uniform scale, shearing and mirroring with the debug renderer. Additionally, some code paths give you transform matrices that include mirroring and non-uniform scaling (for example everything around animations). In these cases it is difficult to get the debug renderer to output the desired result, with just ezTransform.

The helper struct ezMatOrTransform now makes it possible to pass an ezTransform, ezMat3 or ezMat4 to the debug renderer.