### PR TITLE
Various Fixes

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserModel.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserModel.moc.h
@@ -54,7 +54,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezAssetBrowserItemFlags
 EZ_DECLARE_FLAGS_OPERATORS(ezAssetBrowserItemFlags);
 
 /// \brief Model of the item view in the asset browser.
-class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserModel : public QAbstractItemModel
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserModel : public QAbstractItemModel, public QEnableSharedFromThis<ezQtAssetBrowserModel>
 {
   Q_OBJECT
 public:
@@ -72,6 +72,7 @@ public:
 
   ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* pFilter);
   ~ezQtAssetBrowserModel();
+  void Initialize();
 
   void resetModel();
 
@@ -138,6 +139,8 @@ private:
   ezQtAssetFilter* m_pFilter = nullptr;
   bool m_bIconMode = true;
   ezSet<ezString> m_ImportExtensions;
+  ezEventSubscriptionID m_FileChangedSubscription = 0;
+  ezEventSubscriptionID m_FolderChangedSubscription = 0;
 
   ezMutex m_Mutex;
   ezDynamicArray<FsEvent> m_QueuedFileSystemEvents;

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -13,7 +13,7 @@ class ezQtAssetBrowserModel;
 struct ezAssetCuratorEvent;
 class ezQtAssetBrowserModel;
 
-class ezQtAssetBrowserWidget : public QWidget, public Ui_AssetBrowserWidget
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetBrowserWidget : public QWidget, public Ui_AssetBrowserWidget
 {
   Q_OBJECT
 public:
@@ -42,8 +42,8 @@ public:
   void dragLeaveEvent(QDragLeaveEvent* pEvent) override;
   void dropEvent(QDropEvent* pEvent) override;
 
-  ezQtAssetBrowserModel* GetAssetBrowserModel() { return m_pModel; }
-  const ezQtAssetBrowserModel* GetAssetBrowserModel() const { return m_pModel; }
+  ezQtAssetBrowserModel* GetAssetBrowserModel() { return m_pModel.data(); }
+  const ezQtAssetBrowserModel* GetAssetBrowserModel() const { return m_pModel.data(); }
   ezQtAssetBrowserFilter* GetAssetBrowserFilter() { return m_pFilter; }
   const ezQtAssetBrowserFilter* GetAssetBrowserFilter() const { return m_pFilter; }
 
@@ -111,7 +111,7 @@ private:
   Mode m_Mode = Mode::Browser;
   ezQtToolBarActionMapView* m_pToolbar = nullptr;
   ezString m_sAllTypesFilter;
-  ezQtAssetBrowserModel* m_pModel = nullptr;
+  QSharedPointer<ezQtAssetBrowserModel> m_pModel = nullptr;
   ezQtAssetBrowserFilter* m_pFilter = nullptr;
 
   /// \brief After creating a new asset and renaming it, we want to open it as well.

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -108,8 +108,19 @@ ezQtAssetBrowserModel::ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* 
   : QAbstractItemModel(pParent)
   , m_pFilter(pFilter)
 {
-  EZ_ASSERT_DEBUG(pFilter != nullptr, "ezQtAssetBrowserModel requires a valid filter.");
-  connect(pFilter, &ezQtAssetFilter::FilterChanged, this, [this]()
+}
+
+ezQtAssetBrowserModel::~ezQtAssetBrowserModel()
+{
+  ezFileSystemModel::GetSingleton()->m_FileChangedEvents.RemoveEventHandler(m_FileChangedSubscription);
+  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.RemoveEventHandler(m_FolderChangedSubscription);
+  ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::AssetCuratorEventHandler, this));
+}
+
+void ezQtAssetBrowserModel::Initialize()
+{
+  EZ_ASSERT_DEBUG(m_pFilter != nullptr, "ezQtAssetBrowserModel requires a valid filter.");
+  connect(m_pFilter, &ezQtAssetFilter::FilterChanged, this, [this]()
     { resetModel(); });
 
   ezAssetCurator::GetSingleton()->m_Events.AddEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::AssetCuratorEventHandler, this));
@@ -122,15 +133,22 @@ ezQtAssetBrowserModel::ezQtAssetBrowserModel(QObject* pParent, ezQtAssetFilter* 
   EZ_VERIFY(connect(ezQtImageCache::GetSingleton(), &ezQtImageCache::ImageInvalidated, this, &ezQtAssetBrowserModel::ThumbnailInvalidated) != nullptr,
     "signal/slot connection failed");
 
-  ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::FileSystemFileEventHandler, this));
-  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.AddEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::FileSystemFolderEventHandler, this));
-}
-
-ezQtAssetBrowserModel::~ezQtAssetBrowserModel()
-{
-  ezFileSystemModel::GetSingleton()->m_FileChangedEvents.RemoveEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::FileSystemFileEventHandler, this));
-  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.RemoveEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::FileSystemFolderEventHandler, this));
-  ezAssetCurator::GetSingleton()->m_Events.RemoveEventHandler(ezMakeDelegate(&ezQtAssetBrowserModel::AssetCuratorEventHandler, this));
+  QWeakPointer<ezQtAssetBrowserModel> pWeak = sharedFromThis();
+  m_FileChangedSubscription = ezFileSystemModel::GetSingleton()->m_FileChangedEvents.AddEventHandler([pWeak](const ezFileChangedEvent& e)
+    {
+      if (QSharedPointer<ezQtAssetBrowserModel> strong = pWeak.toStrongRef())
+      {
+        strong->FileSystemFileEventHandler(e);
+      }
+    });
+  m_FolderChangedSubscription = ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.AddEventHandler([pWeak](const ezFolderChangedEvent& e)
+    {
+      if (QSharedPointer<ezQtAssetBrowserModel> strong = pWeak.toStrongRef())
+      {
+        strong->FileSystemFolderEventHandler(e);
+      }
+    });
+  ezAssetDocumentGenerator::GetSupportsFileTypes(m_ImportExtensions);
 }
 
 void ezQtAssetBrowserModel::AssetCuratorEventHandler(const ezAssetCuratorEvent& e)
@@ -142,7 +160,11 @@ void ezQtAssetBrowserModel::AssetCuratorEventHandler(const ezAssetCuratorEvent& 
       VisibleEntry ve;
       ve.m_Guid = e.m_AssetGuid;
       ve.m_sAbsFilePath = e.m_pInfo->m_pAssetInfo->m_Path;
-
+      ve.m_Flags = ezAssetBrowserItemFlags::File;
+      if (ve.m_Guid.IsValid())
+      {
+        ve.m_Flags |= ezAssetBrowserItemFlags::Asset;
+      }
       HandleEntry(ve, AssetOp::Updated);
       break;
     }
@@ -321,25 +343,29 @@ void ezQtAssetBrowserModel::HandleEntry(const VisibleEntry& entry, AssetOp op)
       endRemoveRows();
     }
   }
-  else
+  else // Updated
   {
-    // Equal?
+    // Updated entries can cause the filter function `IsAssetFiltered` to change its result, e.g. the transform issues list in the curator panel shows assets that were updated from a healthy state to an error state. Thus, updated entries could be missing in the list at this point, so we need to first check if the item already exists:
     if (uiInsertIndex < m_EntriesToDisplay.GetCount() && !cmp.Less(*pLB, entry) && !cmp.Less(entry, *pLB))
     {
+      // Already exists
       QModelIndex idx = index(uiInsertIndex, 0);
       Q_EMIT dataChanged(idx, idx);
     }
     else
     {
+      // Item not found. Do an exhaustive search in case the name was changed in which the order is no longer the same.
       ezInt32 oldIndex = FindAssetIndex(entry.m_Guid);
       if (oldIndex != -1)
       {
-        // Name has changed, remove old entry
+        // Order (most likely name) has changed, remove old entry and insert new one
         beginRemoveRows(QModelIndex(), oldIndex, oldIndex);
         m_EntriesToDisplay.RemoveAtAndCopy(oldIndex);
         m_DisplayedEntries.Remove(entry.m_Guid);
         endRemoveRows();
       }
+      // Reinsert the updated entry.
+      HandleEntry(entry, AssetOp::Add);
     }
   }
 }
@@ -621,6 +647,9 @@ bool ezQtAssetBrowserModel::setData(const QModelIndex& index, const QVariant& va
   if (!index.isValid())
     return false;
 
+  if (iRole != Qt::EditRole)
+    return false;
+
   const ezInt32 iRow = index.row();
   if (iRow < 0 || iRow >= (ezInt32)m_EntriesToDisplay.GetCount())
     return false;
@@ -770,6 +799,8 @@ void ezQtAssetBrowserModel::FileSystemFileEventHandler(const ezFileChangedEvent&
 
   if (bFire)
   {
+    //QTimer::singleShot(500, [this]()
+    //  { QMetaObject::invokeMethod(this, "OnFileSystemUpdate", //Qt::ConnectionType::QueuedConnection); });
     QMetaObject::invokeMethod(this, "OnFileSystemUpdate", Qt::ConnectionType::QueuedConnection);
   }
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -797,8 +797,6 @@ void ezQtAssetBrowserModel::FileSystemFileEventHandler(const ezFileChangedEvent&
 
   if (bFire)
   {
-    // QTimer::singleShot(500, [this]()
-    //   { QMetaObject::invokeMethod(this, "OnFileSystemUpdate", //Qt::ConnectionType::QueuedConnection); });
     QMetaObject::invokeMethod(this, "OnFileSystemUpdate", Qt::ConnectionType::QueuedConnection);
   }
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserModel.cpp
@@ -139,15 +139,13 @@ void ezQtAssetBrowserModel::Initialize()
       if (QSharedPointer<ezQtAssetBrowserModel> strong = pWeak.toStrongRef())
       {
         strong->FileSystemFileEventHandler(e);
-      }
-    });
+      } });
   m_FolderChangedSubscription = ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.AddEventHandler([pWeak](const ezFolderChangedEvent& e)
     {
       if (QSharedPointer<ezQtAssetBrowserModel> strong = pWeak.toStrongRef())
       {
         strong->FileSystemFolderEventHandler(e);
-      }
-    });
+      } });
   ezAssetDocumentGenerator::GetSupportsFileTypes(m_ImportExtensions);
 }
 
@@ -799,8 +797,8 @@ void ezQtAssetBrowserModel::FileSystemFileEventHandler(const ezFileChangedEvent&
 
   if (bFire)
   {
-    //QTimer::singleShot(500, [this]()
-    //  { QMetaObject::invokeMethod(this, "OnFileSystemUpdate", //Qt::ConnectionType::QueuedConnection); });
+    // QTimer::singleShot(500, [this]()
+    //   { QMetaObject::invokeMethod(this, "OnFileSystemUpdate", //Qt::ConnectionType::QueuedConnection); });
     QMetaObject::invokeMethod(this, "OnFileSystemUpdate", Qt::ConnectionType::QueuedConnection);
   }
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -32,12 +32,13 @@ ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* pParent)
 
   TreeFolderFilter->SetFilter(m_pFilter);
 
-  m_pModel = new ezQtAssetBrowserModel(this, m_pFilter);
+  m_pModel = QSharedPointer<ezQtAssetBrowserModel>(new ezQtAssetBrowserModel(this, m_pFilter));
+  m_pModel->Initialize();
   SearchWidget->setPlaceholderText("Search Assets");
 
   IconSizeSlider->setValue(50);
 
-  ListAssets->setModel(m_pModel);
+  ListAssets->setModel(m_pModel.data());
   ListAssets->SetIconScale(IconSizeSlider->value());
   ListAssets->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
   ListAssets->setDragEnabled(true);
@@ -67,8 +68,8 @@ ezQtAssetBrowserWidget::ezQtAssetBrowserWidget(QWidget* pParent)
   EZ_VERIFY(connect(m_pFilter, SIGNAL(TypeFilterChanged()), this, SLOT(OnTypeFilterChanged())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pFilter, SIGNAL(PathFilterChanged()), this, SLOT(OnPathFilterChanged())) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(m_pFilter, SIGNAL(FilterChanged()), this, SLOT(OnFilterChanged())) != nullptr, "signal/slot connection failed");
-  EZ_VERIFY(connect(m_pModel, SIGNAL(modelReset()), this, SLOT(OnModelReset())) != nullptr, "signal/slot connection failed");
-  EZ_VERIFY(connect(m_pModel, &ezQtAssetBrowserModel::editingFinished, this, &ezQtAssetBrowserWidget::OnFileEditingFinished, Qt::QueuedConnection), "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pModel.data(), SIGNAL(modelReset()), this, SLOT(OnModelReset())) != nullptr, "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pModel.data(), &ezQtAssetBrowserModel::editingFinished, this, &ezQtAssetBrowserWidget::OnFileEditingFinished, Qt::QueuedConnection), "signal/slot connection failed");
 
   EZ_VERIFY(connect(ListAssets->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)), this, SLOT(OnAssetSelectionChanged(const QItemSelection&, const QItemSelection&))) != nullptr, "signal/slot connection failed");
   EZ_VERIFY(connect(ListAssets->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this, SLOT(OnAssetSelectionCurrentChanged(const QModelIndex&, const QModelIndex&))) != nullptr, "signal/slot connection failed");

--- a/Code/Editor/EditorFramework/EditorApp/Qt.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Qt.cpp
@@ -191,9 +191,14 @@ void ezQtEditorApp::InitQt(int iArgc, char** pArgv)
     m_iArgc = iArgc;
     m_pQtApplication = new QApplication(m_iArgc, pArgv);
     m_pQtApplication->setProperty("Shared", QVariant::fromValue((int)1));
-    QFont font = m_pQtApplication->font();
-    // font.setPixelSize(11);
-    m_pQtApplication->setFont(font);
+    // Locale fixes required by various third party libraries like RmlGui.
+    QLocale::setDefault(QLocale::C);
+    const char* locales[] = {"C.UTF-8", "C.utf8", "UTF-8"};
+    for (const char* szLocale : locales)
+    {
+      if (setlocale(LC_ALL, szLocale) != nullptr)
+        break;
+    }
   }
 }
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h
@@ -45,7 +45,7 @@ private:
   void LogWriter(const ezLoggingEventData& e);
   void UpdateIssueInfo();
 
-  ezQtAssetBrowserModel* m_pModel;
+  QSharedPointer<ezQtAssetBrowserModel> m_pModel;
   ezQtAssetCuratorFilter* m_pFilter;
   QPersistentModelIndex m_SelectedIndex;
 };

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -82,18 +82,19 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
 
   ezAssetProcessor::GetSingleton()->AddLogWriter(ezMakeDelegate(&ezQtAssetCuratorPanel::LogWriter, this));
 
-  m_pFilter = new ezQtAssetCuratorFilter(this);
-  m_pModel = new ezQtAssetBrowserModel(this, m_pFilter);
+  m_pFilter =  new ezQtAssetCuratorFilter(this);
+  m_pModel = QSharedPointer<ezQtAssetBrowserModel>(new ezQtAssetBrowserModel(this, m_pFilter));
+  m_pModel->Initialize();
   m_pModel->SetIconMode(false);
 
   TransformLog->ShowControls(false);
 
-  ListAssets->setModel(m_pModel);
+  ListAssets->setModel(m_pModel.data());
   ListAssets->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
   EZ_VERIFY(
     connect(ListAssets->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ezQtAssetCuratorPanel::OnAssetSelectionChanged) != nullptr,
     "signal/slot connection failed");
-  EZ_VERIFY(connect(m_pModel, &QAbstractItemModel::dataChanged, this,
+  EZ_VERIFY(connect(m_pModel.data(), &QAbstractItemModel::dataChanged, this,
               [this](const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles)
               {
                 if (m_SelectedIndex.isValid() && topLeft.row() <= m_SelectedIndex.row() && m_SelectedIndex.row() <= bottomRight.row())
@@ -103,7 +104,7 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
               }),
     "signal/slot connection failed");
 
-  EZ_VERIFY(connect(m_pModel, &QAbstractItemModel::modelReset, this,
+  EZ_VERIFY(connect(m_pModel.data(), &QAbstractItemModel::modelReset, this,
               [this]()
               {
                 m_SelectedIndex = QPersistentModelIndex();

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -82,7 +82,7 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
 
   ezAssetProcessor::GetSingleton()->AddLogWriter(ezMakeDelegate(&ezQtAssetCuratorPanel::LogWriter, this));
 
-  m_pFilter =  new ezQtAssetCuratorFilter(this);
+  m_pFilter = new ezQtAssetCuratorFilter(this);
   m_pModel = QSharedPointer<ezQtAssetBrowserModel>(new ezQtAssetBrowserModel(this, m_pFilter));
   m_pModel->Initialize();
   m_pModel->SetIconMode(false);

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -336,7 +336,7 @@ ezTestAppRun ezEditorTestMisc::AssetBrowerModelTest()
     QString relativePath = index2.data(ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
     EZ_TEST_STRING(relativePath.toUtf8().data(), "EditorTest/Meshes/mesh.ezMeshAsset");
     const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index2.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
-    EZ_TEST_BOOL(itemType == ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset);
+    EZ_TEST_BOOL(itemType == (ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset));
     const bool bImportable = index2.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
     EZ_TEST_BOOL(!bImportable);
   }
@@ -384,7 +384,7 @@ ezTestAppRun ezEditorTestMisc::AssetBrowerModelTest()
     QString relativePath = index.data(ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
     EZ_TEST_STRING(relativePath.toUtf8().data(), "EditorTest/Meshes/mesh.ezMeshAsset");
     const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
-    EZ_TEST_BOOL(itemType == ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset);
+    EZ_TEST_BOOL(itemType == (ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset));
     const bool bImportable = index.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
     EZ_TEST_BOOL(!bImportable);
   }

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -1,6 +1,8 @@
 #include <EditorTest/EditorTestPCH.h>
 
+#include "EditorFramework/Assets/AssetBrowserWidget.moc.h"
 #include "Misc.h"
+#include <EditorFramework/Assets/AssetBrowserFilter.moc.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/DocumentWindow/EngineDocumentWindow.moc.h>
 #include <EditorFramework/DocumentWindow/EngineViewWidget.moc.h>
@@ -22,6 +24,7 @@ void ezEditorTestMisc::SetupSubTests()
 {
   AddSubTest("GameObject References", SubTests::GameObjectReferences);
   AddSubTest("Default Values", SubTests::DefaultValues);
+  AddSubTest("Asset Browser Model", SubTests::AssetBrowerModel);
 }
 
 ezResult ezEditorTestMisc::InitializeTest()
@@ -60,6 +63,9 @@ ezTestAppRun ezEditorTestMisc::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvoca
 
     case SubTests::DefaultValues:
       return DefaultValuesTest();
+
+    case SubTests::AssetBrowerModel:
+      return AssetBrowerModelTest();
   }
 
   // const auto& allDesc = ezDocumentManager::GetAllDocumentDescriptors();
@@ -264,5 +270,141 @@ ezTestAppRun ezEditorTestMisc::DefaultValuesTest()
         }
       } });
 
+  return ezTestAppRun::Quit;
+}
+
+ezTestAppRun ezEditorTestMisc::AssetBrowerModelTest()
+{
+  ezQtAssetBrowserWidget* pDialog = new ezQtAssetBrowserWidget(QApplication::activeWindow());
+  pDialog->SetMode(ezQtAssetBrowserWidget::Mode::Browser);
+  pDialog->show();
+  ProcessEvents();
+  ezQtAssetBrowserFilter* pFilter = pDialog->GetAssetBrowserFilter();
+  ezQtAssetBrowserModel* pModel = pDialog->GetAssetBrowserModel();
+  pFilter->SetPathFilter("EditorTest/Meshes");
+  pFilter->SetShowNonImportableFiles(false);
+  pFilter->SetShowFiles(true);
+  ProcessEvents();
+
+  // Importable asset found:
+  {
+    EZ_TEST_INT(pModel->rowCount(), 1);
+    QModelIndex index = pModel->index(0, 0);
+    QString relativePath = pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
+    EZ_TEST_STRING(relativePath.toUtf8().data(), "EditorTest/Meshes/Cube.obj");
+    const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)pModel->data(index, ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+    EZ_TEST_INT(itemType.GetValue(), ezAssetBrowserItemFlags::File);
+    const bool bImportable = index.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+    EZ_TEST_BOOL(bImportable);
+  }
+
+  // Import (manually) into mesh.ezMeshAsset
+  ezUuid guid;
+  {
+    ezStringBuilder sName = m_sProjectPath;
+    sName.AppendPath("Meshes", "mesh.ezMeshAsset");
+    ezAssetDocument* pDoc = static_cast<ezAssetDocument*>(m_pApplication->m_pEditorApp->CreateDocument(sName, ezDocumentFlags::Default));
+    ezDocumentObject* pMeshAsset = pDoc->GetObjectManager()->GetRootObject()->GetChildren()[0];
+    ezObjectAccessorBase* pAcc = pDoc->GetObjectAccessor();
+    pAcc->StartTransaction("Edit Mesh");
+    EZ_TEST_BOOL(pAcc->SetValueByName(pMeshAsset, "MeshFile", "Meshes/Cube.obj").Succeeded());
+    pAcc->FinishTransaction();
+    EZ_TEST_STATUS(pDoc->SaveDocument());
+    guid = pDoc->GetGuid();
+    pDoc->GetDocumentManager()->CloseDocument(pDoc);
+  }
+
+  // Wait for changes
+  for (ezUInt32 i = 0; i < 10; ++i)
+  {
+    ProcessEvents();
+    if (pModel->rowCount() == 2)
+    {
+      QModelIndex index2 = pModel->index(1, 0);
+      ezUuid guid2 = pModel->data(index2, ezQtAssetBrowserModel::UserRoles::AssetGuid).value<ezUuid>();
+      if (guid2 == guid)
+        break;
+    }
+    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+  }
+  // Check new asset
+  if (EZ_TEST_INT(pModel->rowCount(), 2))
+  {
+    QModelIndex index2 = pModel->index(1, 0);
+    ezUuid guid2 = index2.data(ezQtAssetBrowserModel::UserRoles::AssetGuid).value<ezUuid>();
+    EZ_TEST_BOOL(guid2 == guid);
+    QString relativePath = index2.data(ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
+    EZ_TEST_STRING(relativePath.toUtf8().data(), "EditorTest/Meshes/mesh.ezMeshAsset");
+    const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index2.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+    EZ_TEST_BOOL(itemType == ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset);
+    const bool bImportable = index2.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+    EZ_TEST_BOOL(!bImportable);
+  }
+
+  // Rename Cobe.obj to zzz.obj, moving it to the back of the list and making the asset invalid
+  {
+    QModelIndex index = pModel->index(0, 0);
+    QString absolutePath = index.data(ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+
+    EZ_TEST_BOOL(pModel->setData(index, QString("zzz"), Qt::EditRole));
+  }
+
+  // Wait for changes
+  for (ezUInt32 i = 0; i < 10; ++i)
+  {
+    ProcessEvents();
+    if (pModel->rowCount() == 2)
+    {
+      QModelIndex index2 = pModel->index(1, 0);
+      QString sName = index2.data(Qt::EditRole).toString();
+
+      if (sName.toUtf8().data() == "zzz"_ezsv)
+        break;
+    }
+    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+  }
+
+  // Check renamed file
+  {
+    QModelIndex index = pModel->index(1, 0);
+    QString relativePath = pModel->data(index, ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
+
+    EZ_TEST_STRING(relativePath.toUtf8().data(), "EditorTest/Meshes/zzz.obj");
+    const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)pModel->data(index, ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+    EZ_TEST_INT(itemType.GetValue(), ezAssetBrowserItemFlags::File);
+    const bool bImportable = index.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+    EZ_TEST_BOOL(bImportable);
+  }
+
+  // Check asset
+  {
+    QModelIndex index = pModel->index(0, 0);
+    ezUuid guid2 = index.data(ezQtAssetBrowserModel::UserRoles::AssetGuid).value<ezUuid>();
+    EZ_TEST_BOOL(guid2 == guid);
+    QString relativePath = index.data(ezQtAssetBrowserModel::UserRoles::RelativePath).toString();
+    EZ_TEST_STRING(relativePath.toUtf8().data(), "EditorTest/Meshes/mesh.ezMeshAsset");
+    const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+    EZ_TEST_BOOL(itemType == ezAssetBrowserItemFlags::File | ezAssetBrowserItemFlags::Asset);
+    const bool bImportable = index.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
+    EZ_TEST_BOOL(!bImportable);
+  }
+
+  // Wait for transform state of asset to change
+  ezAssetInfo::TransformState state = ezAssetInfo::Unknown;
+  for (ezUInt32 i = 0; i < 10; ++i)
+  {
+    ProcessEvents();
+
+    QModelIndex index = pModel->index(0, 0);
+    state = (ezAssetInfo::TransformState)index.data(ezQtAssetBrowserModel::UserRoles::TransformState).toInt();
+    if (state == ezAssetInfo::TransformState::MissingTransformDependency)
+        break;
+
+    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+  }
+  EZ_TEST_BOOL(state == ezAssetInfo::TransformState::MissingTransformDependency);
+  pDialog->hide();
+  delete pDialog;
+  ProcessEvents();
   return ezTestAppRun::Quit;
 }

--- a/Code/UnitTests/EditorTest/Misc/Misc.cpp
+++ b/Code/UnitTests/EditorTest/Misc/Misc.cpp
@@ -398,7 +398,7 @@ ezTestAppRun ezEditorTestMisc::AssetBrowerModelTest()
     QModelIndex index = pModel->index(0, 0);
     state = (ezAssetInfo::TransformState)index.data(ezQtAssetBrowserModel::UserRoles::TransformState).toInt();
     if (state == ezAssetInfo::TransformState::MissingTransformDependency)
-        break;
+      break;
 
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
   }

--- a/Code/UnitTests/EditorTest/Misc/Misc.h
+++ b/Code/UnitTests/EditorTest/Misc/Misc.h
@@ -18,6 +18,7 @@ private:
   {
     GameObjectReferences,
     DefaultValues,
+    AssetBrowerModel,
   };
 
   virtual void SetupSubTests() override;
@@ -27,6 +28,7 @@ private:
 
   ezTestAppRun GameObjectReferencesTest();
   ezTestAppRun DefaultValuesTest();
+  ezTestAppRun AssetBrowerModelTest();
 
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;

--- a/Code/UnitTests/TestFramework/Utilities/TestSetup.cpp
+++ b/Code/UnitTests/TestFramework/Utilities/TestSetup.cpp
@@ -84,6 +84,14 @@ ezTestAppRun ezTestSetup::RunTests()
     qApp->setProperty("Shared", QVariant::fromValue((int)1));
     qApp->setApplicationName(pTestFramework->GetTestName());
     ezQtTestGUI::SetDarkTheme();
+    // Locale fixes required by various third party libraries like RmlGui.
+    QLocale::setDefault(QLocale::C);
+    const char* locales[] = {"C.UTF-8", "C.utf8", "UTF-8"};
+    for (const char* szLocale : locales)
+    {
+      if (setlocale(LC_ALL, szLocale) != nullptr)
+        break;
+    }
   }
 
   // Create main window

--- a/Data/Base/Shaders/Editor/TextureCubePreview.ezShader
+++ b/Data/Base/Shaders/Editor/TextureCubePreview.ezShader
@@ -36,7 +36,7 @@ VS_OUT main(VS_IN Input)
 [PIXELSHADER]
 
 #include <Shaders/Materials/MaterialInterpolator.h>
-
+#include <Shaders/Common/GlobalConstants.h>
 TextureCube BaseTexture;
 SamplerState BaseTexture_AutoSampler;
 


### PR DESCRIPTION
* Fix Asset Curator Panel not showing newly added transform failures. 
  * Added unit test for some basic model changes affected by this change.
* Fixed a broken preview shader.
* Fix race conditions in ezQtAssetBrowserModel. As ezFileSystemModel events can be fired at any time, event handlers must use weak pointers for the event handler to safely allows for ezQtAssetBrowserModel destruction.
* Fix RmlGui tests in case locale is changed.