### PR TITLE
Fixed #722: Use ezTaskSystem for Jolt jobs

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
@@ -12,6 +12,7 @@
 #include <JoltPlugin/Shapes/Implementation/JoltCustomShapeInfo.h>
 #include <JoltPlugin/System/JoltCore.h>
 #include <JoltPlugin/System/JoltDebugRenderer.h>
+#include <JoltPlugin/System/JoltJobSystem.h>
 #include <RendererCore/Debug/DebugRenderer.h>
 #include <stdarg.h>
 
@@ -35,7 +36,7 @@ EZ_END_STATIC_REFLECTED_BITFLAGS;
 // clang-format on
 
 ezJoltMaterial* ezJoltCore::s_pDefaultMaterial = nullptr;
-std::unique_ptr<JPH::JobSystem> ezJoltCore::s_pJobSystem;
+ezUniquePtr<JPH::JobSystem> ezJoltCore::s_pJobSystem;
 ezUniquePtr<ezProxyAllocator> ezJoltCore::s_pAllocator;
 ezUniquePtr<ezProxyAllocator> ezJoltCore::s_pAllocatorAligned;
 ezCollisionFilterConfig ezJoltCore::s_CollisionFilterConfig;
@@ -171,8 +172,7 @@ void ezJoltCore::Startup()
 
   ezJoltCustomShapeInfo::sRegister();
 
-  // TODO: custom job system
-  s_pJobSystem = std::make_unique<JPH::JobSystemThreadPool>(JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsBarriers, std::thread::hardware_concurrency() - 1);
+  s_pJobSystem = EZ_NEW(ezFoundation::GetAlignedAllocator(), ezJoltJobSystem, JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsBarriers);
 
   s_pDefaultMaterial = new ezJoltMaterial;
   s_pDefaultMaterial->AddRef();

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
@@ -20,7 +20,7 @@ namespace JPH
 class EZ_JOLTPLUGIN_DLL ezJoltCore
 {
 public:
-  static JPH::JobSystem* GetJoltJobSystem() { return s_pJobSystem.get(); }
+  static JPH::JobSystem* GetJoltJobSystem() { return s_pJobSystem.Borrow(); }
   static const ezJoltMaterial* GetDefaultMaterial() { return s_pDefaultMaterial; }
 
   static void DebugDraw(ezWorld* pWorld);
@@ -52,7 +52,7 @@ private:
   static void LoadWeightCategories();
 
   static ezJoltMaterial* s_pDefaultMaterial;
-  static std::unique_ptr<JPH::JobSystem> s_pJobSystem;
+  static ezUniquePtr<JPH::JobSystem> s_pJobSystem;
 
   static ezUniquePtr<ezProxyAllocator> s_pAllocator;
   static ezUniquePtr<ezProxyAllocator> s_pAllocatorAligned;

--- a/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.cpp
@@ -1,0 +1,97 @@
+#include <JoltPlugin/JoltPluginPCH.h>
+
+#include <Foundation/Types/SharedPtr.h>
+#include <JoltPlugin/System/JoltJobSystem.h>
+
+ezJoltJobSystem::ezJoltJobSystem(ezUInt32 uiMaxJobs, ezUInt32 uiMaxBarriers)
+{
+  JobSystemWithBarrier::Init(uiMaxBarriers);
+
+  m_Jobs.Init(uiMaxJobs, uiMaxJobs);
+
+  m_Tasks.SetCount(uiMaxJobs);
+  for (ezUInt32 i = 0; i < m_Tasks.GetCount(); ++i)
+  {
+    m_Tasks[i] = EZ_DEFAULT_NEW(ezJoltTask);
+    m_Tasks[i]->ConfigureTask("Jolt", ezTaskNesting::Never);
+  }
+}
+
+int ezJoltJobSystem::GetMaxConcurrency() const
+{
+  return ezTaskSystem::GetWorkerThreadCount(ezWorkerThreadType::ShortTasks);
+}
+
+JPH::JobHandle ezJoltJobSystem::CreateJob(const char* szName, JPH::ColorArg color, const JobFunction& jobFunction, ezUInt32 uiNumDependencies)
+{
+  // Loop until we can get a job from the free list
+  ezUInt32 index;
+  for (;;)
+  {
+    index = m_Jobs.ConstructObject(szName, color, this, jobFunction, uiNumDependencies);
+    if (index != AvailableJobs::cInvalidObjectIndex)
+      break;
+
+    EZ_ASSERT_DEBUG(false, "No jobs available!");
+    ezThreadUtils::YieldTimeSlice();
+  }
+
+  CustomJob* job = &m_Jobs.Get(index);
+  job->m_uiJobIndex = index;
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
+  {
+    ezStringBuilder name("Jolt-", szName);
+    m_Tasks[index]->ConfigureTask(name, ezTaskNesting::Never);
+  }
+#endif
+
+  // Construct handle to keep a reference, the job is queued below and may immediately complete
+  JobHandle handle(job);
+
+  // If there are no dependencies, queue the job now
+  if (uiNumDependencies == 0)
+    QueueJob(job);
+
+  // Return the handle
+  return handle;
+}
+
+void ezJoltJobSystem::FreeJob(Job* pJob)
+{
+  m_Jobs.DestructObject(static_cast<CustomJob*>(pJob));
+}
+
+void ezJoltJobSystem::Execute(void* pJob)
+{
+  auto* pJoltJob = static_cast<JPH::JobSystem::Job*>(pJob);
+
+  pJoltJob->Execute();
+  pJoltJob->Release();
+}
+
+void ezJoltJobSystem::QueueJob(Job* pJob)
+{
+  auto* pMyJob = static_cast<CustomJob*>(pJob);
+  pMyJob->AddRef();
+
+  const auto& pTask = m_Tasks[pMyJob->m_uiJobIndex];
+
+  pTask->m_pJob = pJob;
+
+  ezTaskSystem::StartSingleTask(pTask, ezTaskPriority::EarlyThisFrame);
+}
+
+void ezJoltJobSystem::QueueJobs(Job** pJob, ezUInt32 uiNum_Jobs)
+{
+  for (ezUInt32 i = 0; i < uiNum_Jobs; ++i)
+  {
+    QueueJob(pJob[i]);
+  }
+}
+
+void ezJoltTask::Execute()
+{
+  ezJoltJobSystem::Execute(m_pJob);
+  m_pJob = nullptr;
+}

--- a/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Foundation/Threading/TaskSystem.h>
 #include <Jolt/Core/FixedSizeFreeList.h>
 #include <Jolt/Core/JobSystemWithBarrier.h>
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <Jolt/Core/FixedSizeFreeList.h>
+#include <Jolt/Core/JobSystemWithBarrier.h>
+
+class ezJoltJobSystem;
+
+class ezJoltTask : public ezTask
+{
+public:
+  void* m_pJob = nullptr;
+
+  virtual void Execute() override;
+};
+
+class ezJoltJobSystem final : public JPH::JobSystemWithBarrier
+{
+public:
+  ezJoltJobSystem(ezUInt32 uiMaxJobs, ezUInt32 uiMaxBarriers);
+
+  virtual int GetMaxConcurrency() const override;
+  virtual JPH::JobHandle CreateJob(const char* szName, JPH::ColorArg color, const JobFunction& jobFunction, ezUInt32 uiNumDependencies = 0) override;
+
+  virtual void QueueJob(Job* pJob) override;
+  virtual void QueueJobs(Job** pJobs, ezUInt32 uiNumJobs) override;
+  virtual void FreeJob(Job* pJob) override;
+
+  static void Execute(void* pJob);
+
+private:
+  class CustomJob : public JPH::JobSystem::Job
+  {
+  public:
+    CustomJob(const char* szJobName, JPH::ColorArg color, JPH::JobSystem* pJobSystem, const JobFunction& jobFunction, ezUInt32 uiNumDependencies)
+      : Job(szJobName, color, pJobSystem, jobFunction, uiNumDependencies)
+    {
+    }
+
+    ezUInt32 m_uiJobIndex = ezInvalidIndex;
+  };
+
+  using AvailableJobs = JPH::FixedSizeFreeList<CustomJob>;
+  AvailableJobs m_Jobs;
+
+  ezDynamicArray<ezSharedPtr<ezJoltTask>> m_Tasks;
+};


### PR DESCRIPTION
Now Jolt jobs show up in EZ profiling traces and we don't spawn additional threads just for Jolt.