### PR TITLE
Make Jolt cloth interactions one-sided

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
@@ -85,8 +85,6 @@ void ezJoltContactListener::OnContact(const JPH::Body& body0, const JPH::Body& b
     ezBitflags<ezOnJoltContact> CombinedContactFlags;
     CombinedContactFlags.SetValue(ContactFlags0.GetValue() | ContactFlags1.GetValue());
 
-    // bSendContactReport = bSendContactReport || CombinedContactFlags.IsSet(ezOnJoltContact::SendReportMsg);
-
     if (CombinedContactFlags.IsAnySet(ezOnJoltContact::AllReactions))
     {
       ezVec3 vAvgPos(0);
@@ -120,11 +118,6 @@ void ezJoltContactListener::OnContact(const JPH::Body& body0, const JPH::Body& b
       }
     }
   }
-
-  //   if (bSendContactReport)
-  //   {
-  //     SendContactReport(pairHeader, pairs, nbPairs);
-  //   }
 }
 
 bool ezJoltContactListener::ActivateTrigger(const JPH::Body& body1, const JPH::Body& body2, ezUInt64 uiBody1id, ezUInt64 uiBody2id)
@@ -604,5 +597,14 @@ void ezJoltContactEvents::OnContact_SlideAndRollReaction(const JPH::Body& body0,
   }
 }
 
+JPH::SoftBodyValidateResult ezJoltSoftBodyContactListener::OnSoftBodyContactValidate(const JPH::Body& inSoftBody, const JPH::Body& inOtherBody, JPH::SoftBodyContactSettings& ioSettings)
+{
+  // give the rigid body "infinite mass" -> soft bodies can't push them
+  // so the interaction is always one sided
+  ioSettings.mInvMassScale2 = 0.0f;
+  ioSettings.mInvInertiaScale2 = 0.0f;
+
+  return JPH::SoftBodyValidateResult::AcceptContact;
+}
 
 EZ_STATICLINK_FILE(JoltPlugin, JoltPlugin_System_JoltContacts);

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
@@ -597,12 +597,12 @@ void ezJoltContactEvents::OnContact_SlideAndRollReaction(const JPH::Body& body0,
   }
 }
 
-JPH::SoftBodyValidateResult ezJoltSoftBodyContactListener::OnSoftBodyContactValidate(const JPH::Body& softBody, const JPH::Body& otherBody, JPH::SoftBodyContactSettings& settings)
+JPH::SoftBodyValidateResult ezJoltSoftBodyContactListener::OnSoftBodyContactValidate(const JPH::Body& softBody, const JPH::Body& otherBody, JPH::SoftBodyContactSettings& ref_settings)
 {
   // give the rigid body "infinite mass" -> soft bodies can't push them
   // so the interaction is always one sided
-  settings.mInvMassScale2 = 0.0f;
-  settings.mInvInertiaScale2 = 0.0f;
+  ref_settings.mInvMassScale2 = 0.0f;
+  ref_settings.mInvInertiaScale2 = 0.0f;
 
   return JPH::SoftBodyValidateResult::AcceptContact;
 }

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
@@ -597,12 +597,12 @@ void ezJoltContactEvents::OnContact_SlideAndRollReaction(const JPH::Body& body0,
   }
 }
 
-JPH::SoftBodyValidateResult ezJoltSoftBodyContactListener::OnSoftBodyContactValidate(const JPH::Body& inSoftBody, const JPH::Body& inOtherBody, JPH::SoftBodyContactSettings& ioSettings)
+JPH::SoftBodyValidateResult ezJoltSoftBodyContactListener::OnSoftBodyContactValidate(const JPH::Body& softBody, const JPH::Body& otherBody, JPH::SoftBodyContactSettings& settings)
 {
   // give the rigid body "infinite mass" -> soft bodies can't push them
   // so the interaction is always one sided
-  ioSettings.mInvMassScale2 = 0.0f;
-  ioSettings.mInvInertiaScale2 = 0.0f;
+  settings.mInvMassScale2 = 0.0f;
+  settings.mInvInertiaScale2 = 0.0f;
 
   return JPH::SoftBodyValidateResult::AcceptContact;
 }

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
@@ -95,5 +95,5 @@ public:
 class ezJoltSoftBodyContactListener : public JPH::SoftBodyContactListener
 {
 public:
-  virtual JPH::SoftBodyValidateResult OnSoftBodyContactValidate(const JPH::Body& softBody, const JPH::Body& otherBody, JPH::SoftBodyContactSettings& settings) override;
+  virtual JPH::SoftBodyValidateResult OnSoftBodyContactValidate(const JPH::Body& softBody, const JPH::Body& otherBody, JPH::SoftBodyContactSettings& ref_settings) override;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
@@ -2,6 +2,7 @@
 
 #include <Core/World/Declarations.h>
 #include <Physics/Collision/ContactListener.h>
+#include <Physics/SoftBody/SoftBodyContactListener.h>
 
 class ezWorld;
 class ezJoltTriggerComponent;
@@ -89,4 +90,10 @@ public:
   bool ActivateTrigger(const JPH::Body& body1, const JPH::Body& body2, ezUInt64 uiBody1id, ezUInt64 uiBody2id);
 
   void DeactivateTrigger(ezUInt64 uiBody1id, ezUInt64 uiBody2id);
+};
+
+class ezJoltSoftBodyContactListener : public JPH::SoftBodyContactListener
+{
+public:
+  virtual JPH::SoftBodyValidateResult OnSoftBodyContactValidate(const JPH::Body& inSoftBody, const JPH::Body& inOtherBody, JPH::SoftBodyContactSettings& ioSettings) override;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
@@ -95,5 +95,5 @@ public:
 class ezJoltSoftBodyContactListener : public JPH::SoftBodyContactListener
 {
 public:
-  virtual JPH::SoftBodyValidateResult OnSoftBodyContactValidate(const JPH::Body& inSoftBody, const JPH::Body& inOtherBody, JPH::SoftBodyContactSettings& ioSettings) override;
+  virtual JPH::SoftBodyValidateResult OnSoftBodyContactValidate(const JPH::Body& softBody, const JPH::Body& otherBody, JPH::SoftBodyContactSettings& settings) override;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.cpp
@@ -140,6 +140,10 @@ void ezJoltWorldModule::Deinitialize()
   EZ_DEFAULT_DELETE(pContactListener);
   m_pContactListener = nullptr;
 
+  ezJoltSoftBodyContactListener* pSoftBodyContactListener = reinterpret_cast<ezJoltSoftBodyContactListener*>(m_pSoftBodyContactListener);
+  EZ_DEFAULT_DELETE(pSoftBodyContactListener);
+  m_pSoftBodyContactListener = nullptr;
+
   m_pGroupFilter->Release();
   m_pGroupFilter = nullptr;
 
@@ -278,6 +282,12 @@ void ezJoltWorldModule::Initialize()
     pListener->m_pWorld = GetWorld();
     m_pContactListener = pListener;
     m_pSystem->SetContactListener(pListener);
+  }
+
+  {
+    ezJoltSoftBodyContactListener* pListener = EZ_DEFAULT_NEW(ezJoltSoftBodyContactListener);
+    m_pSoftBodyContactListener = pListener;
+    m_pSystem->SetSoftBodyContactListener(pListener);
   }
 
   {

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -14,6 +14,7 @@
 
 class ezJoltCharacterControllerComponent;
 class ezJoltContactListener;
+class ezJoltSoftBodyContactListener;
 class ezJoltRagdollComponent;
 class ezJoltRopeComponent;
 class ezView;
@@ -147,6 +148,11 @@ public:
     return reinterpret_cast<ezJoltContactListener*>(m_pContactListener);
   }
 
+  ezJoltSoftBodyContactListener* GetSoftBodyContactListener()
+  {
+    return reinterpret_cast<ezJoltSoftBodyContactListener*>(m_pSoftBodyContactListener);
+  }
+
   void CheckBreakableConstraints();
 
   ezSet<ezComponentHandle> m_BreakableConstraints;
@@ -244,6 +250,7 @@ private:
   ezJoltObjectLayerPairFilter m_ObjectLayerPairFilter;
 
   void* m_pContactListener = nullptr;
+  void* m_pSoftBodyContactListener = nullptr;
   void* m_pActivationListener = nullptr;
   ezSet<ezJoltDynamicActorComponent*> m_ActiveActors;
   ezMap<ezJoltRagdollComponent*, ezInt32> m_ActiveRagdolls;


### PR DESCRIPTION
Cloth should be purely decorative, to not be able to break gameplay. Thus it now cannot push rigid bodies anymore.
Also removed the cloth mass property, since there's no point to it, when cloth doesn't push anything.