### PR TITLE
Fixed #859: Surface restitution changes are always immediately visible in editor

### DIFF
--- a/Code/Engine/Core/Physics/Implementation/SurfaceResource.cpp
+++ b/Code/Engine/Core/Physics/Implementation/SurfaceResource.cpp
@@ -22,6 +22,11 @@ ezSurfaceResource::ezSurfaceResource()
 
 ezSurfaceResource::~ezSurfaceResource()
 {
+  ezSurfaceResourceEvent e;
+  e.m_pSurface = this;
+  e.m_Type = ezSurfaceResourceEvent::Type::Destroyed;
+  s_Events.Broadcast(e);
+
   EZ_ASSERT_DEV(m_pPhysicsMaterialPhysX == nullptr, "Physics material has not been cleaned up properly");
   EZ_ASSERT_DEV(m_pPhysicsMaterialJolt == nullptr, "Physics material has not been cleaned up properly");
 }
@@ -34,11 +39,6 @@ ezResourceLoadDesc ezSurfaceResource::UnloadData(Unload WhatToUnload)
   res.m_uiQualityLevelsDiscardable = 0;
   res.m_uiQualityLevelsLoadable = 0;
   res.m_State = ezResourceState::Unloaded;
-
-  ezSurfaceResourceEvent e;
-  e.m_pSurface = this;
-  e.m_Type = ezSurfaceResourceEvent::Type::Destroyed;
-  s_Events.Broadcast(e);
 
   return res;
 }

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.cpp
@@ -62,14 +62,27 @@ void ezJoltContactListener::OnContact(const JPH::Body& body0, const JPH::Body& b
 {
   // compute per-material friction and restitution
   {
-    const ezJoltMaterial* pMat0 = static_cast<const ezJoltMaterial*>(body0.GetShape()->GetMaterial(manifold.mSubShapeID1));
-    const ezJoltMaterial* pMat1 = static_cast<const ezJoltMaterial*>(body1.GetShape()->GetMaterial(manifold.mSubShapeID2));
 
-    if (pMat0 && pMat1)
+    float fRes0 = 0.2f;
+    float fRes1 = 0.2f;
+
+    float fFri0 = 0.5f;
+    float fFri1 = 0.5f;
+
+    if (const ezJoltMaterial* pMat0 = static_cast<const ezJoltMaterial*>(body0.GetShape()->GetMaterial(manifold.mSubShapeID1)))
     {
-      ref_settings.mCombinedRestitution = ezMath::Max(pMat0->m_fRestitution, pMat1->m_fRestitution);
-      ref_settings.mCombinedFriction = ezMath::Sqrt(pMat0->m_fFriction * pMat1->m_fFriction);
+      fRes0 = pMat0->m_fRestitution;
+      fFri0 = pMat0->m_fFriction;
     }
+
+    if (const ezJoltMaterial* pMat1 = static_cast<const ezJoltMaterial*>(body1.GetShape()->GetMaterial(manifold.mSubShapeID2)))
+    {
+      fRes1 = pMat1->m_fRestitution;
+      fFri1 = pMat1->m_fFriction;
+    }
+
+    ref_settings.mCombinedRestitution = ezMath::Max(fRes0, fRes1);
+    ref_settings.mCombinedFriction = ezMath::Sqrt(fFri0 * fFri1);
   }
 
   m_ContactEvents.m_pWorld = m_pWorld;

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
@@ -239,13 +239,23 @@ void ezJoltCore::SurfaceResourceEventHandler(const ezSurfaceResourceEvent& e)
   {
     const auto& desc = e.m_pSurface->GetDescriptor();
 
-    auto pNewMaterial = new ezJoltMaterial;
-    pNewMaterial->AddRef();
-    pNewMaterial->m_pSurface = e.m_pSurface;
-    pNewMaterial->m_fRestitution = desc.m_fPhysicsRestitution;
-    pNewMaterial->m_fFriction = ezMath::Lerp(desc.m_fPhysicsFrictionStatic, desc.m_fPhysicsFrictionDynamic, 0.5f);
+    ezJoltMaterial* pJoltMat = static_cast<ezJoltMaterial*>(e.m_pSurface->m_pPhysicsMaterialJolt);
 
-    e.m_pSurface->m_pPhysicsMaterialJolt = pNewMaterial;
+    if (pJoltMat == nullptr)
+    {
+      pJoltMat = new ezJoltMaterial;
+      pJoltMat->AddRef();
+      pJoltMat->m_pSurface = e.m_pSurface;
+    }
+    else
+    {
+      EZ_ASSERT_DEV(pJoltMat->m_pSurface == e.m_pSurface, "Invalid surface");
+    }
+
+    pJoltMat->m_fRestitution = desc.m_fPhysicsRestitution;
+    pJoltMat->m_fFriction = ezMath::Lerp(desc.m_fPhysicsFrictionStatic, desc.m_fPhysicsFrictionDynamic, 0.5f);
+
+    e.m_pSurface->m_pPhysicsMaterialJolt = pJoltMat;
   }
   else if (e.m_Type == ezSurfaceResourceEvent::Type::Destroyed)
   {


### PR DESCRIPTION
When changing restitution (or friction) of surfaces, the Jolt materials (and thus the simulation) is now always updated immediately and doesn't require an editor restart anymore.

Also fixed that null materials would break the overall restitution/friction calculation.

Fixes #859.