### PR TITLE
Run clang tidy on self-hosted VM

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Android-arm64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-arm64.yml
@@ -17,6 +17,7 @@ jobs:
     name: Default
     demands:
     - Agent.OS -equals Linux
+    - GPU
 
   steps:
   - checkout: self

--- a/Code/BuildSystem/AzurePipelines/Android-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x64.yml
@@ -17,6 +17,7 @@ jobs:
     demands:
     - Agent.OS -equals Windows_NT
     - EMULATOR
+    - GPU
   steps:
   - checkout: self
     submodules: true

--- a/Code/BuildSystem/AzurePipelines/Linux-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Linux-x64.yml
@@ -49,6 +49,7 @@ jobs:
     name: Default
     demands:
     - Agent.OS -equals Linux
+    - GPU
   steps:
   - checkout: self
     submodules: true

--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -39,6 +39,7 @@ jobs:
     name: Default
     demands:
     - Agent.OS -equals Windows_NT
+    - GPU
   steps:
   - checkout: self
     submodules: true

--- a/Code/BuildSystem/AzurePipelines/clang-tidy.yml
+++ b/Code/BuildSystem/AzurePipelines/clang-tidy.yml
@@ -1,5 +1,11 @@
 name: ezEngine_ClangTidyVerification_$(Date:yyyyMMdd)$(Rev:.r)
 
+parameters:
+  - name: cleanWorkspace
+    displayName: 'Clean Workspace'
+    type: boolean
+    default: false
+
 trigger:
   branches:
     include:
@@ -8,36 +14,78 @@ trigger:
     - release
 
 jobs:
+- job: StartVM
+  displayName: StartVM
+  pool:
+    vmImage: 'windows-2022'
+  steps:
+  - checkout: none
+  - task: AzureKeyVault@2
+    displayName: 'Azure Key Vault: ezKeys'
+    inputs:
+      ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
+      KeyVaultName: ezKeys
+      SecretsFilter: AzureFunctionKey
+  - task: PowerShell@2
+    displayName: StartVM
+    continueOnError: true
+    inputs:
+      targetType: inline
+      script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartVM?code=$(AzureFunctionKey)&vmname=Windows10-1809"
+
 - job: ClangTidyVerification
   timeoutInMinutes: 120
   pool:
-    vmImage: 'windows-2022'
+    name: Default
+    demands:
+    - Agent.OS -equals Windows_NT
+    - VM
   steps:
   - task: CmdLine@2
     displayName: Free Disk Space
     inputs:
       script: dir C:\
+  
   - checkout: self
     submodules: recursive
-    fetchDepth: 1
     lfs: true
+    clean: ${{ parameters.cleanWorkspace }}
+
+  - task: PowerShell@2
+    displayName: 'Set targetBranch variable'
+    inputs:
+      pwsh: true
+      targetType: 'inline'
+      script: |
+        $targetBranch = if ($env:SYSTEM_PULLREQUEST_TARGETBRANCH) {
+          "$(system.pullRequest.targetBranch)"
+          Write-Host "This is a pull request"
+        } else {
+          "dev"
+        }
+        Write-Host "##vso[task.setvariable variable=targetBranch]$targetBranch"
+        Write-Host "Target branch set to: $targetBranch"
+
   - pwsh: |
-      git fetch --no-recurse-submodules --depth=100 origin $(system.pullRequest.targetBranch)
+      git fetch --no-recurse-submodules --depth=100 origin $(targetBranch)
       $curCommit = $(git rev-parse HEAD)
       git fetch --no-recurse-submodules --depth=100 origin $curCommit
       ./Utilities/clang-tidy/SetupWorkspace.ps1
     displayName: 'Download LLVM & Run CMake'
+  
   - task: CmdLine@2
     displayName: Free Disk Space
     inputs:
       script: dir C:\
+  
   - task: PowerShell@2
     displayName: 'Run clang-tidy'
     inputs:
       pwsh: true
       targetType: filePath
       filePath: './Utilities/clang-tidy/RunClangTidy.ps1'
-      arguments: '-DiffTo "origin/$(system.pullRequest.targetBranch)" -LlvmInstallDir "$pwd\llvm" -Workspace "Workspace/clang-tidy" -Vso'
+      arguments: '-DiffTo "origin/$(targetBranch)" -LlvmInstallDir "$pwd\llvm" -Workspace "Workspace/clang-tidy" -Vso'
+  
   - task: PowerShell@2
     displayName: 'Fetch suggested changes'
     condition: always()
@@ -52,6 +100,7 @@ jobs:
           Write-Host "##vso[task.logissue type=error]clang-tidy suggested changes. Clang tidy check failed! See artifact 'clang-tidy.patch' for suggested changes. Apply patch with: git apply clang-tidy.patch" -foreground red
           git diff | Out-File -Encoding utf8NoBOM -FilePath "$(Build.ArtifactStagingDirectory)\clang-tidy.patch"
         }
+  
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Suggested Changes'
     inputs:


### PR DESCRIPTION
The 2 vcores of free VMs took forever to compile clang tidy. This moves the clang tidy job to the self-hosted 8 vcore VM and forces the other jobs to be pinned on the physical machines so the VM is practically only used for clang tidy. This makes it easier to maintain as we don't have to create custom line rendering images for the software reasterizers and should speed up things overall. The physical machines now have a tag `GPU` and the VMs have the tag `VM` to allow jobs to be properly scheduled. Also added support for running the clang-tidy pipeline on a user branch without needing to create a PR.