### PR TITLE
Sample shader and component for mesh decals aka floaters

### DIFF
--- a/Code/Engine/Foundation/IO/Implementation/StreamOperationsMath_inl.h
+++ b/Code/Engine/Foundation/IO/Implementation/StreamOperationsMath_inl.h
@@ -16,15 +16,15 @@
 
 // ezFloat16
 
-inline ezStreamWriter& operator<<(ezStreamWriter& inout_stream, ezFloat16 fValue)
+inline ezStreamWriter& operator<<(ezStreamWriter& inout_stream, ezFloat16 value)
 {
-  inout_stream.WriteWordValue(&fValue).AssertSuccess();
+  inout_stream.WriteWordValue(&value).AssertSuccess();
   return inout_stream;
 }
 
-inline ezStreamReader& operator>>(ezStreamReader& inout_stream, ezFloat16& ref_fValue)
+inline ezStreamReader& operator>>(ezStreamReader& inout_stream, ezFloat16& ref_value)
 {
-  inout_stream.ReadWordValue(&ref_fValue).AssertSuccess();
+  inout_stream.ReadWordValue(&ref_value).AssertSuccess();
   return inout_stream;
 }
 

--- a/Code/Engine/Foundation/IO/Implementation/StreamOperationsMath_inl.h
+++ b/Code/Engine/Foundation/IO/Implementation/StreamOperationsMath_inl.h
@@ -4,6 +4,7 @@
 #include <Foundation/Math/BoundingSphere.h>
 #include <Foundation/Math/Color.h>
 #include <Foundation/Math/Color8UNorm.h>
+#include <Foundation/Math/Float16.h>
 #include <Foundation/Math/Mat3.h>
 #include <Foundation/Math/Mat4.h>
 #include <Foundation/Math/Plane.h>
@@ -12,6 +13,20 @@
 #include <Foundation/Math/Vec2.h>
 #include <Foundation/Math/Vec3.h>
 #include <Foundation/Math/Vec4.h>
+
+// ezFloat16
+
+inline ezStreamWriter& operator<<(ezStreamWriter& inout_stream, ezFloat16 fValue)
+{
+  inout_stream.WriteWordValue(&fValue).AssertSuccess();
+  return inout_stream;
+}
+
+inline ezStreamReader& operator>>(ezStreamReader& inout_stream, ezFloat16& ref_fValue)
+{
+  inout_stream.ReadWordValue(&ref_fValue).AssertSuccess();
+  return inout_stream;
+}
 
 // ezVec2Template
 

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
@@ -67,8 +67,10 @@ ezPerDecalAtlasData MakeAtlasData(const ezRectU16& rect, const ezVec2& vTextureS
 
 struct DecalInfo
 {
+  ezUInt32 m_uiRefCount = 0;
+
   ezUInt8 m_uiGeneration = 1;
-  ezUInt32 m_uiAtlasDataOffset = ezInvalidIndex; // Also used as index into s_pData->m_DecalInfos
+  ezUInt16 m_uiAtlasDataOffset = ezSmallInvalidIndex; // Also used as index into s_pData->m_DecalInfos
   ezDynamicTextureAtlas::AllocationId m_atlasAllocationId;
 
   float m_fMaxScreenSpaceSize = 0.0f;
@@ -81,6 +83,8 @@ struct DecalInfo
 
   ezTime m_NextUpdateTime = ezTime::MakeFromHours(-1);
   ezTime m_WorldTime;
+
+  ezHashedString m_sName;
 
   EZ_ALWAYS_INLINE bool IsStatic() const { return m_hTexture.IsValid(); }
   EZ_ALWAYS_INLINE bool IsDynamic() const { return !IsStatic(); }
@@ -116,12 +120,15 @@ struct DecalInfo
     return 0;
   }
 
-  EZ_FORCE_INLINE void Update(float fScreenSpaceSize, const ezView* pReferenceView, ezTime updateInterval)
+  EZ_FORCE_INLINE void SetUpdateInterval(ezTime updateInterval)
   {
-    m_fMaxScreenSpaceSize = ezMath::Max(m_fMaxScreenSpaceSize, fScreenSpaceSize);
-
     m_fUpdateInterval = ezMath::Min(m_fUpdateInterval, updateInterval.AsFloatInSeconds());
     m_NextUpdateTime = ezMath::Min(m_NextUpdateTime, ezTime::Now() + ezTime::MakeFromSeconds(m_fUpdateInterval));
+  }
+
+  EZ_FORCE_INLINE void MarkUsage(float fScreenSpaceSize, const ezView* pReferenceView)
+  {
+    m_fMaxScreenSpaceSize = ezMath::Max(m_fMaxScreenSpaceSize, fScreenSpaceSize);
 
     if (pReferenceView != nullptr && pReferenceView->GetWorld() != nullptr)
     {
@@ -131,20 +138,38 @@ struct DecalInfo
         m_WorldTime = pReferenceView->GetWorld()->GetClock().GetAccumulatedTime();
       }
     }
+
+    if (m_sName.IsEmpty())
+    {
+      if (m_hTexture.IsValid())
+      {
+        ezResourceLock<ezTexture2DResource> pTexture(m_hTexture, ezResourceAcquireMode::AllowLoadingFallback);
+        if (pTexture.GetAcquireResult() != ezResourceAcquireResult::Final || pTexture->GetNumQualityLevelsLoadable() > 0)
+          return;
+
+        m_uiMaxWidth = ezMath::Min(pTexture->GetWidth(), s_uiMaxDecalSize);
+        m_uiMaxHeight = ezMath::Min(pTexture->GetHeight(), s_uiMaxDecalSize);
+        m_sName.Assign(GetNameFromResource(*pTexture.GetPointer()));
+      }
+      else
+      {
+        EZ_ASSERT_DEV(m_hMaterial.IsValid(), "DecalInfo must have either a texture or a material assigned.");
+
+        ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+        if (pMaterial.GetAcquireResult() != ezResourceAcquireResult::Final)
+          return;
+
+        m_sName.Assign(DecalInfo::GetNameFromResource(*pMaterial.GetPointer()));
+      }
+    }
   }
 
   EZ_FORCE_INLINE void ResetAfterUpdate()
   {
-    m_NextUpdateTime = ezTime::Now() + ezTime::MakeFromSeconds(m_fUpdateInterval);
     m_fMaxScreenSpaceSize = 0.0f;
 
-    if (IsDynamic())
-    {
-      m_uiMaxWidth = 0;
-      m_uiMaxHeight = 0;
-      m_fUpdateInterval = ezTime::MakeFromHours(3600).AsFloatInSeconds();
-      m_WorldTime = ezTime::MakeZero();
-    }
+    m_NextUpdateTime = ezTime::Now() + ezTime::MakeFromSeconds(m_fUpdateInterval);
+    m_WorldTime = ezTime::MakeZero();
   }
 
   EZ_ALWAYS_INLINE static ezUInt64 GetKey(const ezTexture2DResourceHandle& hTexture)
@@ -289,7 +314,7 @@ struct ezDecalManager::Data
 ezDecalManager::Data* ezDecalManager::s_pData = nullptr;
 
 // static
-ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView)
+ezDecalId ezDecalManager::GetOrCreateRuntimeDecal(const ezTexture2DResourceHandle& hTexture)
 {
   s_pData->EnsureResourceCreated();
 
@@ -309,6 +334,7 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& 
     auto& decalInfo = s_pData->m_DecalInfos[uiIndex];
     decalInfo.m_uiAtlasDataOffset = uiIndex;
     decalInfo.m_hTexture = hTexture;
+    decalInfo.SetUpdateInterval(ezTime::MakeFromSeconds(0.1));
 
     ezStringBuilder decalMaterialName;
     decalMaterialName.AppendFormat("DecalMaterial_{0}", hTexture.GetResourceID());
@@ -326,12 +352,12 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& 
 
   auto& decalInfo = s_pData->m_DecalInfos[uiIndex];
   EZ_ASSERT_DEBUG(decalInfo.m_uiAtlasDataOffset == uiIndex, "Implementation error");
-  decalInfo.Update(fScreenSpaceSize, pReferenceView, ezTime::MakeFromSeconds(0.1));
+  ++decalInfo.m_uiRefCount;
 
   return ezDecalId(uiIndex, decalInfo.m_uiGeneration);
 }
 
-ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView)
+ezDecalId ezDecalManager::GetOrCreateRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval)
 {
   s_pData->EnsureResourceCreated();
 
@@ -355,7 +381,8 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& h
 
   auto& decalInfo = s_pData->m_DecalInfos[uiIndex];
   EZ_ASSERT_DEBUG(decalInfo.m_uiAtlasDataOffset == uiIndex, "Implementation error");
-  decalInfo.Update(fScreenSpaceSize, pReferenceView, updateInterval);
+  decalInfo.SetUpdateInterval(updateInterval);
+  ++decalInfo.m_uiRefCount;
 
   decalInfo.m_uiMaxWidth = ezMath::Clamp<ezUInt16>(decalInfo.m_uiMaxWidth, uiResolution, s_uiMaxDecalSize);
   decalInfo.m_uiMaxHeight = decalInfo.m_uiMaxWidth;
@@ -364,15 +391,20 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& h
 }
 
 // static
-void ezDecalManager::RemoveRuntimeDecal(ezDecalId decalId)
+void ezDecalManager::DeleteRuntimeDecal(ezDecalId& ref_decalId)
 {
-  EZ_LOCK(s_pData->m_Mutex);
-
-  if (decalId.m_InstanceIndex >= s_pData->m_DecalInfos.GetCount())
+  if (ref_decalId.IsInvalidated())
     return;
 
-  auto& decalInfo = s_pData->m_DecalInfos[decalId.m_InstanceIndex];
-  if (decalInfo.m_uiGeneration != decalId.m_Generation)
+  EZ_SCOPE_EXIT(ref_decalId.Invalidate());
+
+  EZ_LOCK(s_pData->m_Mutex);
+
+  auto& decalInfo = s_pData->m_DecalInfos[ref_decalId.m_InstanceIndex];
+  EZ_ASSERT_DEV(decalInfo.m_uiGeneration == ref_decalId.m_Generation, "Invalid decal id");
+
+  --decalInfo.m_uiRefCount;
+  if (decalInfo.m_uiRefCount > 0)
     return;
 
   if (decalInfo.m_atlasAllocationId.IsInvalidated() == false)
@@ -391,6 +423,20 @@ void ezDecalManager::RemoveRuntimeDecal(ezDecalId decalId)
   decalInfo.m_uiGeneration = generation + 1;
   if (decalInfo.m_uiGeneration == 0)
     decalInfo.m_uiGeneration = 1;
+}
+
+// static
+void ezDecalManager::MarkRuntimeDecalAsUsed(ezDecalId decalId, float fScreenSpaceSize, const ezView* pReferenceView)
+{
+  if (decalId.IsInvalidated())
+    return;
+
+  EZ_LOCK(s_pData->m_Mutex);
+
+  auto& decalInfo = s_pData->m_DecalInfos[decalId.m_InstanceIndex];
+  EZ_ASSERT_DEV(decalInfo.m_uiGeneration == decalId.m_Generation && decalInfo.m_uiRefCount > 0, "Invalid decal");
+
+  decalInfo.MarkUsage(fScreenSpaceSize, pReferenceView);
 }
 
 ezDecalAtlasResourceHandle ezDecalManager::GetBakedDecalAtlas()
@@ -471,21 +517,11 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 
     for (auto& decalInfo : s_pData->m_DecalInfos)
     {
-      if (decalInfo.m_uiAtlasDataOffset == ezInvalidIndex)
+      if (decalInfo.m_uiAtlasDataOffset == ezInvalidIndex || decalInfo.m_sName.IsEmpty())
         continue;
 
       if (decalInfo.m_NextUpdateTime > now)
         continue;
-
-      if (decalInfo.IsStatic())
-      {
-        ezResourceLock<ezTexture2DResource> pTexture(decalInfo.m_hTexture, ezResourceAcquireMode::AllowLoadingFallback);
-        if (pTexture.GetAcquireResult() != ezResourceAcquireResult::Final || pTexture->GetNumQualityLevelsLoadable() > 0)
-          continue;
-
-        decalInfo.m_uiMaxWidth = ezMath::Min(pTexture->GetWidth(), s_uiMaxDecalSize);
-        decalInfo.m_uiMaxHeight = ezMath::Min(pTexture->GetHeight(), s_uiMaxDecalSize);
-      }
 
       const ezRectU16 currentRect = s_pData->m_RuntimeAtlas.GetAllocationRect(decalInfo.m_atlasAllocationId);
       const ezVec2U32 newSize = decalInfo.CalculateScaledSize();
@@ -519,29 +555,8 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 
     if (decalInfo.m_atlasAllocationId.IsInvalidated())
     {
-      ezStringView sName;
-
-      if (decalInfo.m_hTexture.IsValid())
-      {
-        ezResourceLock<ezTexture2DResource> pTexture(decalInfo.m_hTexture, ezResourceAcquireMode::AllowLoadingFallback);
-        if (pTexture.GetAcquireResult() != ezResourceAcquireResult::Final || pTexture->GetNumQualityLevelsLoadable() > 0)
-          continue;
-
-        sName = DecalInfo::GetNameFromResource(*pTexture.GetPointer());
-      }
-      else
-      {
-        EZ_ASSERT_DEV(decalInfo.m_hMaterial.IsValid(), "DecalInfo must have either a texture or a material assigned.");
-
-        ezResourceLock<ezMaterialResource> pMaterial(decalInfo.m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-        if (pMaterial.GetAcquireResult() != ezResourceAcquireResult::Final)
-          continue;
-
-        sName = DecalInfo::GetNameFromResource(*pMaterial.GetPointer());
-      }
-
       ezRectU16 rect;
-      decalInfo.m_atlasAllocationId = s_pData->m_RuntimeAtlas.Allocate(decalToUpdate.m_vNewSize.x, decalToUpdate.m_vNewSize.y, sName, &rect);
+      decalInfo.m_atlasAllocationId = s_pData->m_RuntimeAtlas.Allocate(decalToUpdate.m_vNewSize.x, decalToUpdate.m_vNewSize.y, decalInfo.m_sName, &rect);
 
       auto data = pAtlasDataBuffer->MapForWriting<ezPerDecalAtlasData>(decalInfo.m_uiAtlasDataOffset);
       data[0] = MakeAtlasData(rect, vAtlasSize);

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
@@ -45,7 +45,6 @@ ezCVarBool cvar_RenderingDecalsShowAtlasTexture("Rendering.Decals.ShowAtlasTextu
 ///       but they can also be overwritten in custom game states at startup.
 EZ_RENDERERCORE_DLL ezCVarInt cvar_RenderingDecalsDynamicAtlasSize("Rendering.Decals.DynamicAtlasSize", 3072, ezCVarFlags::RequiresDelayedSync, "The size of the dynamic decal atlas texture.");
 
-constexpr ezUInt32 s_uiMinDecalSize = 16;
 constexpr ezUInt32 s_uiMaxDecalSize = 1024;
 
 static ezUInt32 s_uiLastConfigModification = 0;
@@ -80,9 +79,11 @@ struct DecalInfo
   ezUInt16 m_uiMaxHeight = 0;
   float m_fUpdateInterval = ezTime::MakeFromHours(3600).AsFloatInSeconds();
 
-  ezTime m_AutoRemoveTime;
-  ezTime m_NextUpdateTime;
+  ezTime m_NextUpdateTime = ezTime::MakeFromHours(-1);
   ezTime m_WorldTime;
+
+  EZ_ALWAYS_INLINE bool IsStatic() const { return m_hTexture.IsValid(); }
+  EZ_ALWAYS_INLINE bool IsDynamic() const { return !IsStatic(); }
 
   float CalculateScore(ezTime now) const
   {
@@ -94,9 +95,9 @@ struct DecalInfo
 
   ezVec2U32 CalculateScaledSize() const
   {
-    const float fScreenSpaceSize = ezMath::Clamp(ezMath::Pow(m_fMaxScreenSpaceSize, 1.2f), 0.01f, 1.0f);
-    const ezUInt32 uiWidth = ezMath::Clamp(static_cast<ezUInt32>(m_uiMaxWidth * fScreenSpaceSize), s_uiMinDecalSize, s_uiMaxDecalSize);
-    const ezUInt32 uiHeight = ezMath::Clamp(static_cast<ezUInt32>(m_uiMaxHeight * fScreenSpaceSize), s_uiMinDecalSize, s_uiMaxDecalSize);
+    const float fScreenSpaceSize = ezMath::Saturate(ezMath::Pow(m_fMaxScreenSpaceSize, 1.2f));
+    const ezUInt32 uiWidth = ezMath::Min(static_cast<ezUInt32>(m_uiMaxWidth * fScreenSpaceSize), s_uiMaxDecalSize);
+    const ezUInt32 uiHeight = ezMath::Min(static_cast<ezUInt32>(m_uiMaxHeight * fScreenSpaceSize), s_uiMaxDecalSize);
 
     const ezUInt32 uiWidthAlign = uiWidth < 64 ? 16 : 64;
     const ezUInt32 uiHeightAlign = uiHeight < 64 ? 16 : 64;
@@ -115,10 +116,12 @@ struct DecalInfo
     return 0;
   }
 
-  EZ_FORCE_INLINE void Update(float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove)
+  EZ_FORCE_INLINE void Update(float fScreenSpaceSize, const ezView* pReferenceView, ezTime updateInterval)
   {
     m_fMaxScreenSpaceSize = ezMath::Max(m_fMaxScreenSpaceSize, fScreenSpaceSize);
-    m_AutoRemoveTime = ezTime::Now() + inactiveTimeBeforeAutoRemove;
+
+    m_fUpdateInterval = ezMath::Min(m_fUpdateInterval, updateInterval.AsFloatInSeconds());
+    m_NextUpdateTime = ezMath::Min(m_NextUpdateTime, ezTime::Now() + ezTime::MakeFromSeconds(m_fUpdateInterval));
 
     if (pReferenceView != nullptr && pReferenceView->GetWorld() != nullptr)
     {
@@ -127,6 +130,20 @@ struct DecalInfo
       {
         m_WorldTime = pReferenceView->GetWorld()->GetClock().GetAccumulatedTime();
       }
+    }
+  }
+
+  EZ_FORCE_INLINE void ResetAfterUpdate()
+  {
+    m_NextUpdateTime = ezTime::Now() + ezTime::MakeFromSeconds(m_fUpdateInterval);
+    m_fMaxScreenSpaceSize = 0.0f;
+
+    if (IsDynamic())
+    {
+      m_uiMaxWidth = 0;
+      m_uiMaxHeight = 0;
+      m_fUpdateInterval = ezTime::MakeFromHours(3600).AsFloatInSeconds();
+      m_WorldTime = ezTime::MakeZero();
     }
   }
 
@@ -159,6 +176,8 @@ struct SortedDecal
 
   ezUInt32 m_uiIndex;
   float m_fScore;
+
+  ezVec2U32 m_vNewSize;
 
   bool operator<(const SortedDecal& other) const
   {
@@ -270,7 +289,7 @@ struct ezDecalManager::Data
 ezDecalManager::Data* ezDecalManager::s_pData = nullptr;
 
 // static
-ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove /*= ezTime::MakeFromSeconds(1)*/)
+ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView)
 {
   s_pData->EnsureResourceCreated();
 
@@ -307,12 +326,12 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& 
 
   auto& decalInfo = s_pData->m_DecalInfos[uiIndex];
   EZ_ASSERT_DEBUG(decalInfo.m_uiAtlasDataOffset == uiIndex, "Implementation error");
-  decalInfo.Update(fScreenSpaceSize, pReferenceView, inactiveTimeBeforeAutoRemove);
+  decalInfo.Update(fScreenSpaceSize, pReferenceView, ezTime::MakeFromSeconds(0.1));
 
   return ezDecalId(uiIndex, decalInfo.m_uiGeneration);
 }
 
-ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove)
+ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView)
 {
   s_pData->EnsureResourceCreated();
 
@@ -336,10 +355,7 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& h
 
   auto& decalInfo = s_pData->m_DecalInfos[uiIndex];
   EZ_ASSERT_DEBUG(decalInfo.m_uiAtlasDataOffset == uiIndex, "Implementation error");
-  decalInfo.Update(fScreenSpaceSize, pReferenceView, inactiveTimeBeforeAutoRemove);
-
-  decalInfo.m_fUpdateInterval = ezMath::Min(decalInfo.m_fUpdateInterval, updateInterval.AsFloatInSeconds());
-  decalInfo.m_NextUpdateTime = ezMath::Min(decalInfo.m_NextUpdateTime, ezTime::Now() + ezTime::MakeFromSeconds(decalInfo.m_fUpdateInterval));
+  decalInfo.Update(fScreenSpaceSize, pReferenceView, updateInterval);
 
   decalInfo.m_uiMaxWidth = ezMath::Clamp<ezUInt16>(decalInfo.m_uiMaxWidth, uiResolution, s_uiMaxDecalSize);
   decalInfo.m_uiMaxHeight = decalInfo.m_uiMaxWidth;
@@ -458,42 +474,36 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
       if (decalInfo.m_uiAtlasDataOffset == ezInvalidIndex)
         continue;
 
-      if (now > decalInfo.m_AutoRemoveTime)
-      {
-        if (decalInfo.m_atlasAllocationId.IsInvalidated() == false)
-        {
-          s_pData->m_RuntimeAtlas.Deallocate(decalInfo.m_atlasAllocationId);
-        }
-      }
-      else
-      {
-        bool bShouldUpdate = now >= decalInfo.m_NextUpdateTime;
-        if (decalInfo.m_atlasAllocationId.IsInvalidated())
-        {
-          bShouldUpdate = true;
-        }
-        else
-        {
-          const ezRectU16 currentRect = s_pData->m_RuntimeAtlas.GetAllocationRect(decalInfo.m_atlasAllocationId);
-          const ezVec2U32 newSize = decalInfo.CalculateScaledSize();
+      if (decalInfo.m_NextUpdateTime > now)
+        continue;
 
-          if (currentRect.width != newSize.x || currentRect.height != newSize.y)
-          {
-            s_pData->m_RuntimeAtlas.Deallocate(decalInfo.m_atlasAllocationId);
-            bShouldUpdate = true;
-          }
-        }
+      if (decalInfo.IsStatic())
+      {
+        ezResourceLock<ezTexture2DResource> pTexture(decalInfo.m_hTexture, ezResourceAcquireMode::AllowLoadingFallback);
+        if (pTexture.GetAcquireResult() != ezResourceAcquireResult::Final || pTexture->GetNumQualityLevelsLoadable() > 0)
+          continue;
 
-        if (bShouldUpdate)
-        {
-          s_pData->m_SortedDecals.PushBack({decalInfo.m_uiAtlasDataOffset, decalInfo.CalculateScore(now)});
-        }
-        else
-        {
-          // Reset screen space size so it can be recalculated next frame
-          decalInfo.m_fMaxScreenSpaceSize = 0.0f;
-        }
+        decalInfo.m_uiMaxWidth = ezMath::Min(pTexture->GetWidth(), s_uiMaxDecalSize);
+        decalInfo.m_uiMaxHeight = ezMath::Min(pTexture->GetHeight(), s_uiMaxDecalSize);
       }
+
+      const ezRectU16 currentRect = s_pData->m_RuntimeAtlas.GetAllocationRect(decalInfo.m_atlasAllocationId);
+      const ezVec2U32 newSize = decalInfo.CalculateScaledSize();
+      const bool bSizeChanged = currentRect.width != newSize.x || currentRect.height != newSize.y;
+      if (bSizeChanged)
+      {
+        s_pData->m_RuntimeAtlas.Deallocate(decalInfo.m_atlasAllocationId);
+      }
+
+      if ((decalInfo.IsDynamic() || bSizeChanged) && newSize.IsZero() == false)
+      {
+        auto& sortedDecal = s_pData->m_SortedDecals.ExpandAndGetRef();
+        sortedDecal.m_uiIndex = decalInfo.m_uiAtlasDataOffset;
+        sortedDecal.m_fScore = decalInfo.CalculateScore(now);
+        sortedDecal.m_vNewSize = newSize;
+      }
+
+      decalInfo.ResetAfterUpdate();
     }
   }
 
@@ -517,8 +527,6 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
         if (pTexture.GetAcquireResult() != ezResourceAcquireResult::Final || pTexture->GetNumQualityLevelsLoadable() > 0)
           continue;
 
-        decalInfo.m_uiMaxWidth = ezMath::Clamp(pTexture->GetWidth(), s_uiMinDecalSize, s_uiMaxDecalSize);
-        decalInfo.m_uiMaxHeight = ezMath::Clamp(pTexture->GetHeight(), s_uiMinDecalSize, s_uiMaxDecalSize);
         sName = DecalInfo::GetNameFromResource(*pTexture.GetPointer());
       }
       else
@@ -532,10 +540,8 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
         sName = DecalInfo::GetNameFromResource(*pMaterial.GetPointer());
       }
 
-      ezVec2U32 uiSize = decalInfo.CalculateScaledSize();
-
       ezRectU16 rect;
-      decalInfo.m_atlasAllocationId = s_pData->m_RuntimeAtlas.Allocate(uiSize.x, uiSize.y, sName, &rect);
+      decalInfo.m_atlasAllocationId = s_pData->m_RuntimeAtlas.Allocate(decalToUpdate.m_vNewSize.x, decalToUpdate.m_vNewSize.y, sName, &rect);
 
       auto data = pAtlasDataBuffer->MapForWriting<ezPerDecalAtlasData>(decalInfo.m_uiAtlasDataOffset);
       data[0] = MakeAtlasData(rect, vAtlasSize);
@@ -545,18 +551,6 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
     updateInfo.m_hMaterial = decalInfo.m_hMaterial;
     updateInfo.m_TargetRect = s_pData->m_RuntimeAtlas.GetAllocationRect(decalInfo.m_atlasAllocationId);
     updateInfo.m_WorldTime = decalInfo.m_WorldTime;
-
-    // Reset data
-    decalInfo.m_NextUpdateTime = ezTime::Now() + ezTime::MakeFromSeconds(decalInfo.m_fUpdateInterval);
-    decalInfo.m_fUpdateInterval = ezTime::MakeFromHours(3600).AsFloatInSeconds();
-    decalInfo.m_fMaxScreenSpaceSize = 0.0f;
-
-    if (decalInfo.m_hTexture.IsValid() == false)
-    {
-      decalInfo.m_uiMaxWidth = 0;
-      decalInfo.m_uiMaxHeight = 0;
-      decalInfo.m_WorldTime = ezTime::MakeZero();
-    }
   }
 
   s_pData->m_SortedDecals.Clear();
@@ -622,7 +616,7 @@ void ezDecalManager::OnRenderEvent(const ezRenderWorldRenderEvent& e)
       pRenderContext->SetGlobalAndWorldTimeConstants(updateInfo.m_WorldTime);
       pRenderContext->BindMaterial(updateInfo.m_hMaterial);
 
-      pRenderContext->DrawMeshBuffer().IgnoreResult();
+      pRenderContext->DrawMeshBuffer().AssertSuccess();
     }
 
     pRenderContext->EndRendering();

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
@@ -94,12 +94,12 @@ struct DecalInfo
 
   ezVec2U32 CalculateScaledSize() const
   {
-    const float fScreenSpaceSize = ezMath::Clamp(ezMath::Pow(m_fMaxScreenSpaceSize, 1.5f), 0.01f, 1.0f);
+    const float fScreenSpaceSize = ezMath::Clamp(ezMath::Pow(m_fMaxScreenSpaceSize, 1.2f), 0.01f, 1.0f);
     const ezUInt32 uiWidth = ezMath::Clamp(static_cast<ezUInt32>(m_uiMaxWidth * fScreenSpaceSize), s_uiMinDecalSize, s_uiMaxDecalSize);
     const ezUInt32 uiHeight = ezMath::Clamp(static_cast<ezUInt32>(m_uiMaxHeight * fScreenSpaceSize), s_uiMinDecalSize, s_uiMaxDecalSize);
 
-    const ezUInt32 uiWidthAlign = uiWidth < 32 ? 16 : 32;
-    const ezUInt32 uiHeightAlign = uiHeight < 32 ? 16 : 32;
+    const ezUInt32 uiWidthAlign = uiWidth < 64 ? 16 : 64;
+    const ezUInt32 uiHeightAlign = uiHeight < 64 ? 16 : 64;
     return ezVec2U32(ezMemoryUtils::AlignSize(uiWidth, uiWidthAlign), ezMemoryUtils::AlignSize(uiHeight, uiHeightAlign));
   }
 
@@ -120,21 +120,22 @@ struct DecalInfo
     m_fMaxScreenSpaceSize = ezMath::Max(m_fMaxScreenSpaceSize, fScreenSpaceSize);
     m_AutoRemoveTime = ezTime::Now() + inactiveTimeBeforeAutoRemove;
 
-    if (pReferenceView->GetCameraUsageHint() == ezCameraUsageHint::MainView || pReferenceView->GetCameraUsageHint() == ezCameraUsageHint::EditorView || m_WorldTime.IsZero())
+    if (pReferenceView != nullptr && pReferenceView->GetWorld() != nullptr)
     {
-      if (const ezWorld* pWorld = pReferenceView->GetWorld())
+      const bool bIsMainView = pReferenceView->GetCameraUsageHint() == ezCameraUsageHint::MainView || pReferenceView->GetCameraUsageHint() == ezCameraUsageHint::EditorView;
+      if (bIsMainView || m_WorldTime.IsZero())
       {
-        m_WorldTime = pWorld->GetClock().GetAccumulatedTime();
+        m_WorldTime = pReferenceView->GetWorld()->GetClock().GetAccumulatedTime();
       }
     }
   }
 
-  EZ_ALWAYS_INLINE static ezUInt64 GetKey(ezTexture2DResourceHandle hTexture)
+  EZ_ALWAYS_INLINE static ezUInt64 GetKey(const ezTexture2DResourceHandle& hTexture)
   {
     return hTexture.GetResourceIDHash();
   }
 
-  EZ_ALWAYS_INLINE static ezUInt64 GetKey(ezMaterialResourceHandle hMaterial)
+  EZ_ALWAYS_INLINE static ezUInt64 GetKey(const ezMaterialResourceHandle& hMaterial)
   {
     return hMaterial.GetResourceIDHash();
   }
@@ -269,13 +270,13 @@ struct ezDecalManager::Data
 ezDecalManager::Data* ezDecalManager::s_pData = nullptr;
 
 // static
-ezDecalId ezDecalManager::GetOrAddRuntimeDecal(ezTexture2DResourceHandle hTexture, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove /*= ezTime::MakeFromSeconds(1)*/)
+ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove /*= ezTime::MakeFromSeconds(1)*/)
 {
   s_pData->EnsureResourceCreated();
 
-  EZ_LOCK(s_pData->m_Mutex);
+  const ezUInt64 uiKey = DecalInfo::GetKey(hTexture);
 
-  ezUInt64 uiKey = DecalInfo::GetKey(hTexture);
+  EZ_LOCK(s_pData->m_Mutex);
 
   bool bExisted = false;
   ezUInt32& uiIndex = s_pData->m_DecalKeyToInfoIndex.FindOrAdd(uiKey, &bExisted);
@@ -311,13 +312,13 @@ ezDecalId ezDecalManager::GetOrAddRuntimeDecal(ezTexture2DResourceHandle hTextur
   return ezDecalId(uiIndex, decalInfo.m_uiGeneration);
 }
 
-ezDecalId ezDecalManager::GetOrAddRuntimeDecal(ezMaterialResourceHandle hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove)
+ezDecalId ezDecalManager::GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove)
 {
   s_pData->EnsureResourceCreated();
 
-  EZ_LOCK(s_pData->m_Mutex);
+  const ezUInt64 uiKey = DecalInfo::GetKey(hMaterial);
 
-  ezUInt64 uiKey = DecalInfo::GetKey(hMaterial);
+  EZ_LOCK(s_pData->m_Mutex);
 
   bool bExisted = false;
   ezUInt32& uiIndex = s_pData->m_DecalKeyToInfoIndex.FindOrAdd(uiKey, &bExisted);
@@ -459,7 +460,10 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 
       if (now > decalInfo.m_AutoRemoveTime)
       {
-        RemoveRuntimeDecal(ezDecalId(decalInfo.m_uiAtlasDataOffset, decalInfo.m_uiGeneration));
+        if (decalInfo.m_atlasAllocationId.IsInvalidated() == false)
+        {
+          s_pData->m_RuntimeAtlas.Deallocate(decalInfo.m_atlasAllocationId);
+        }
       }
       else
       {
@@ -483,6 +487,11 @@ void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
         if (bShouldUpdate)
         {
           s_pData->m_SortedDecals.PushBack({decalInfo.m_uiAtlasDataOffset, decalInfo.CalculateScore(now)});
+        }
+        else
+        {
+          // Reset screen space size so it can be recalculated next frame
+          decalInfo.m_fMaxScreenSpaceSize = 0.0f;
         }
       }
     }

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.h
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.h
@@ -10,9 +10,13 @@ class ezView;
 class EZ_RENDERERCORE_DLL ezDecalManager
 {
 public:
-  static ezDecalId GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView);
-  static ezDecalId GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView);
-  static void RemoveRuntimeDecal(ezDecalId decalId);
+  static ezDecalId GetOrCreateRuntimeDecal(const ezTexture2DResourceHandle& hTexture);
+  static ezDecalId GetOrCreateRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval);
+  static void DeleteRuntimeDecal(ezDecalId& ref_decalId);
+
+  /// \brief Marks the runtime decal as in use with the given screen space size by the given reference view. Should be called every frame.
+  /// This is used to calculate how much space the decal needs in the atlas.
+  static void MarkRuntimeDecalAsUsed(ezDecalId decalId, float fScreenSpaceSize, const ezView* pReferenceView);
 
   static ezDecalAtlasResourceHandle GetBakedDecalAtlas();
   static ezGALTextureHandle GetRuntimeDecalAtlasTexture();

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.h
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <RendererCore/Declarations.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
 
 struct ezRenderWorldExtractionEvent;
 struct ezRenderWorldRenderEvent;
@@ -9,8 +10,8 @@ class ezView;
 class EZ_RENDERERCORE_DLL ezDecalManager
 {
 public:
-  static ezDecalId GetOrAddRuntimeDecal(ezTexture2DResourceHandle hTexture, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove = ezTime::MakeFromSeconds(1));
-  static ezDecalId GetOrAddRuntimeDecal(ezMaterialResourceHandle hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove = ezTime::MakeFromSeconds(1));
+  static ezDecalId GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove = ezTime::MakeFromSeconds(1));
+  static ezDecalId GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove = ezTime::MakeFromSeconds(1));
   static void RemoveRuntimeDecal(ezDecalId decalId);
 
   static ezDecalAtlasResourceHandle GetBakedDecalAtlas();

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.h
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.h
@@ -10,8 +10,8 @@ class ezView;
 class EZ_RENDERERCORE_DLL ezDecalManager
 {
 public:
-  static ezDecalId GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove = ezTime::MakeFromSeconds(1));
-  static ezDecalId GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView, ezTime inactiveTimeBeforeAutoRemove = ezTime::MakeFromSeconds(1));
+  static ezDecalId GetOrAddRuntimeDecal(const ezTexture2DResourceHandle& hTexture, float fScreenSpaceSize, const ezView* pReferenceView);
+  static ezDecalId GetOrAddRuntimeDecal(const ezMaterialResourceHandle& hMaterial, ezUInt32 uiResolution, ezTime updateInterval, float fScreenSpaceSize, const ezView* pReferenceView);
   static void RemoveRuntimeDecal(ezDecalId decalId);
 
   static ezDecalAtlasResourceHandle GetBakedDecalAtlas();

--- a/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
@@ -244,7 +244,7 @@ void ezSpotLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
 
     ezDecalManager::MarkRuntimeDecalAsUsed(m_CookieId, fScreenSpaceSizeForCookie, msg.m_pView);
   }
-  
+
   if (m_bCastShadows && fShadowFadeOut > 0.0f)
   {
     pRenderData->FillShadowDataOffsetAndFadeOut(ezShadowPool::AddSpotLight(this, fScreenSpaceSize, msg.m_pView), fShadowFadeOut);

--- a/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
@@ -13,7 +13,7 @@ constexpr ezAngle c_MaxSpotAngle = ezAngle::MakeFromDegree(160.0f);
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSpotLightRenderData, 1, ezRTTIDefaultAllocator<ezSpotLightRenderData>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_COMPONENT_TYPE(ezSpotLightComponent, 3, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezSpotLightComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -46,6 +46,65 @@ EZ_END_COMPONENT_TYPE
 
 ezSpotLightComponent::ezSpotLightComponent() = default;
 ezSpotLightComponent::~ezSpotLightComponent() = default;
+
+void ezSpotLightComponent::OnActivated()
+{
+  SUPER::OnActivated();
+
+  UpdateCookie();
+}
+
+void ezSpotLightComponent::OnDeactivated()
+{
+  DeleteCookie();
+}
+
+void ezSpotLightComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+
+  ezStreamWriter& s = inout_stream.GetStream();
+
+  s << m_fRange;
+  s << m_fShadowFadeOutRange;
+  s << m_InnerSpotAngle;
+  s << m_OuterSpotAngle;
+  s << m_uiMaterialResolution;
+  s << m_MaterialUpdateInterval;
+  s << m_hMaterial;
+  s << m_hCookie;
+}
+
+void ezSpotLightComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  ezStreamReader& s = inout_stream.GetStream();
+
+  ezTexture2DResourceHandle m_hProjectedTexture;
+
+  s >> m_fRange;
+  if (uiVersion >= 3)
+  {
+    s >> m_fShadowFadeOutRange;
+  }
+  s >> m_InnerSpotAngle;
+  s >> m_OuterSpotAngle;
+
+  if (uiVersion >= 4)
+  {
+    s >> m_uiMaterialResolution;
+    s >> m_MaterialUpdateInterval;
+    s >> m_hMaterial;
+    s >> m_hCookie;
+  }
+  else
+  {
+    ezStringBuilder temp;
+    s >> temp;
+    SetCookieFile(temp);
+  }
+}
 
 ezResult ezSpotLightComponent::GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg)
 {
@@ -114,6 +173,7 @@ void ezSpotLightComponent::SetCookie(const ezTexture2DResourceHandle& hCookie)
   {
     m_hCookie = hCookie;
 
+    UpdateCookie();
     InvalidateCachedRenderData();
   }
 }
@@ -124,6 +184,7 @@ void ezSpotLightComponent::SetMaterial(const ezMaterialResourceHandle& hMaterial
   {
     m_hMaterial = hMaterial;
 
+    UpdateCookie();
     InvalidateCachedRenderData();
   }
 }
@@ -132,6 +193,7 @@ void ezSpotLightComponent::SetMaterialResolution(ezUInt32 uiResolution)
 {
   m_uiMaterialResolution = ezMath::Clamp(uiResolution, 16u, 1024u);
 
+  UpdateCookie();
   // No need to invalidate cached render data, render data is not cached if a material is used.
 }
 
@@ -139,6 +201,7 @@ void ezSpotLightComponent::SetMaterialUpdateInterval(ezTime updateInterval)
 {
   m_MaterialUpdateInterval = ezMath::Clamp(updateInterval.AsFloatInSeconds(), 0.0f, 10.0f);
 
+  UpdateCookie();
   // No need to invalidate cached render data, render data is not cached if a material is used.
 }
 
@@ -172,18 +235,16 @@ void ezSpotLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
   pRenderData->m_fRange = m_fEffectiveRange;
   pRenderData->m_InnerSpotAngle = m_InnerSpotAngle;
   pRenderData->m_OuterSpotAngle = m_OuterSpotAngle;
+  pRenderData->m_CookieId = m_CookieId;
 
-  // Spotlight bounds tend to be way larger than the projected area thus times 0.5
-  const float fScreenSpaceSizeForCookie = fScreenSpaceSize * 0.5f;
-  if (m_hMaterial.IsValid())
+  if (m_CookieId.IsInvalidated() == false)
   {
-    pRenderData->m_CookieId = ezDecalManager::GetOrAddRuntimeDecal(m_hMaterial, m_uiMaterialResolution, ezTime::MakeFromSeconds(m_MaterialUpdateInterval), fScreenSpaceSizeForCookie, msg.m_pView);
-  }
-  else if (m_hCookie.IsValid())
-  {
-    pRenderData->m_CookieId = ezDecalManager::GetOrAddRuntimeDecal(m_hCookie, fScreenSpaceSizeForCookie, msg.m_pView);
-  }
+    // Spotlight bounds tend to be way larger than the projected area thus times 0.5
+    const float fScreenSpaceSizeForCookie = fScreenSpaceSize * 0.5f;
 
+    ezDecalManager::MarkRuntimeDecalAsUsed(m_CookieId, fScreenSpaceSizeForCookie, msg.m_pView);
+  }
+  
   if (m_bCastShadows && fShadowFadeOut > 0.0f)
   {
     pRenderData->FillShadowDataOffsetAndFadeOut(ezShadowPool::AddSpotLight(this, fScreenSpaceSize, msg.m_pView), fShadowFadeOut);
@@ -195,42 +256,8 @@ void ezSpotLightComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
 
   pRenderData->FillBatchIdAndSortingKey(fScreenSpaceSize);
 
-  ezRenderData::Caching::Enum caching = (m_bCastShadows || m_hCookie.IsValid() || m_hMaterial.IsValid()) ? ezRenderData::Caching::Never : ezRenderData::Caching::IfStatic;
+  ezRenderData::Caching::Enum caching = (m_bCastShadows || m_CookieId.IsInvalidated() == false) ? ezRenderData::Caching::Never : ezRenderData::Caching::IfStatic;
   msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::Light, caching);
-}
-
-void ezSpotLightComponent::SerializeComponent(ezWorldWriter& inout_stream) const
-{
-  SUPER::SerializeComponent(inout_stream);
-
-  ezStreamWriter& s = inout_stream.GetStream();
-
-  s << m_fRange;
-  s << m_fShadowFadeOutRange;
-  s << m_InnerSpotAngle;
-  s << m_OuterSpotAngle;
-  s << GetCookieFile();
-}
-
-void ezSpotLightComponent::DeserializeComponent(ezWorldReader& inout_stream)
-{
-  SUPER::DeserializeComponent(inout_stream);
-  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
-  ezStreamReader& s = inout_stream.GetStream();
-
-  ezTexture2DResourceHandle m_hProjectedTexture;
-
-  s >> m_fRange;
-  if (uiVersion >= 3)
-  {
-    s >> m_fShadowFadeOutRange;
-  }
-  s >> m_InnerSpotAngle;
-  s >> m_OuterSpotAngle;
-
-  ezStringBuilder temp;
-  s >> temp;
-  SetCookieFile(temp);
 }
 
 ezBoundingSphere ezSpotLightComponent::CalculateBoundingSphere(const ezTransform& t, float fRange) const
@@ -252,6 +279,28 @@ ezBoundingSphere ezSpotLightComponent::CalculateBoundingSphere(const ezTransform
   }
 
   return res;
+}
+
+void ezSpotLightComponent::UpdateCookie()
+{
+  if (!IsActiveAndInitialized())
+    return;
+
+  DeleteCookie();
+
+  if (m_hMaterial.IsValid())
+  {
+    m_CookieId = ezDecalManager::GetOrCreateRuntimeDecal(m_hMaterial, m_uiMaterialResolution, ezTime::MakeFromSeconds(m_MaterialUpdateInterval));
+  }
+  else if (m_hCookie.IsValid())
+  {
+    m_CookieId = ezDecalManager::GetOrCreateRuntimeDecal(m_hCookie);
+  }
+}
+
+void ezSpotLightComponent::DeleteCookie()
+{
+  ezDecalManager::DeleteRuntimeDecal(m_CookieId);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/RendererCore/Lights/SpotLightComponent.h
+++ b/Code/Engine/RendererCore/Lights/SpotLightComponent.h
@@ -28,6 +28,9 @@ class EZ_RENDERERCORE_DLL ezSpotLightComponent : public ezLightComponent
   // ezComponent
 
 public:
+  virtual void OnActivated() override;
+  virtual void OnDeactivated() override;
+
   virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
   virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
 
@@ -87,6 +90,9 @@ protected:
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
   ezBoundingSphere CalculateBoundingSphere(const ezTransform& t, float fRange) const;
 
+  void UpdateCookie();
+  void DeleteCookie();
+
   float m_fRange = 0.0f;
   float m_fEffectiveRange = 0.0f;
   float m_fShadowFadeOutRange = 0.0f;
@@ -99,6 +105,8 @@ protected:
   ezMaterialResourceHandle m_hMaterial;
 
   ezTexture2DResourceHandle m_hCookie;
+
+  ezDecalId m_CookieId;
 };
 
 /// \brief A special visualizer attribute for spot lights

--- a/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.cpp
+++ b/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.cpp
@@ -3,6 +3,7 @@
 #include <Core/ResourceManager/ResourceManager.h>
 #include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/Textures/DynamicTextureAtlas.h>
+#include <RendererCore/Textures/Texture2DResource.h>
 #include <RendererFoundation/Device/Device.h>
 
 ezDynamicTextureAtlas::ezDynamicTextureAtlas() = default;

--- a/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.cpp
+++ b/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.cpp
@@ -1,5 +1,6 @@
 #include <RendererCore/RendererCorePCH.h>
 
+#include <Core/ResourceManager/ResourceManager.h>
 #include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/Textures/DynamicTextureAtlas.h>
 #include <RendererFoundation/Device/Device.h>
@@ -263,7 +264,7 @@ ezRectU16 ezDynamicTextureAtlas::GetAllocationRect(AllocationId id) const
   return ezRectU16();
 }
 
-void ezDynamicTextureAtlas::DebugDraw(const ezDebugRendererContext& debugContext, float fViewWidth, float fViewHeight) const
+void ezDynamicTextureAtlas::DebugDraw(const ezDebugRendererContext& debugContext, float fViewWidth, float fViewHeight, bool bBlackOutFreeAreas /*= true*/) const
 {
   if (m_hTexture.IsInvalidated())
     return;
@@ -292,6 +293,11 @@ void ezDynamicTextureAtlas::DebugDraw(const ezDebugRendererContext& debugContext
       ezMath::Round(node.m_Rect.width * fScale) - 1.0f,
       ezMath::Round(node.m_Rect.height * fScale) - 1.0f);
     ezDebugRenderer::Draw2DLineRectangle(debugContext, nodeRect, 0.0f, color);
+
+    if (bBlackOutFreeAreas && node.GetType() == NodeType::Free)
+    {
+      ezDebugRenderer::Draw2DRectangle(debugContext, nodeRect, 0.0f, ezColor::Black, ezResourceManager::LoadResource<ezTexture2DResource>("White.color"));
+    }
 
     if (node.GetType() == NodeType::Allocation)
     {

--- a/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.h
+++ b/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.h
@@ -24,7 +24,7 @@ public:
   ezGALTextureHandle GetTexture() const { return m_hTexture; }
   ezRectU16 GetAllocationRect(AllocationId id) const;
 
-  void DebugDraw(const ezDebugRendererContext& debugContext, float fViewWidth, float fViewHeight) const;
+  void DebugDraw(const ezDebugRendererContext& debugContext, float fViewWidth, float fViewHeight, bool bBlackOutFreeAreas = true) const;
 
 private:
   struct NodeType
@@ -65,7 +65,6 @@ private:
 
   ezGALTextureHandle m_hTexture;
   ezUInt32 m_uiAlignment = 0;
-
 
   struct Node
   {

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
@@ -3,8 +3,6 @@
 #include <GameComponentsPlugin/Effects/MeshDecalComponent.h>
 
 #include <Core/Messages/SetColorMessage.h>
-#include <Core/Messages/TriggerMessage.h>
-#include <Core/ResourceManager/ResourceManager.h>
 #include <Core/WorldSerializer/WorldReader.h>
 #include <Core/WorldSerializer/WorldWriter.h>
 #include <Foundation/Containers/ArrayMap.h>
@@ -12,7 +10,6 @@
 #include <RendererCore/Decals/Implementation/DecalManager.h>
 #include <RendererCore/Lights/LightComponent.h>
 #include <RendererCore/Pipeline/View.h>
-#include <RendererCore/RenderWorld/RenderWorld.h>
 #include <RendererCore/Textures/Texture2DResource.h>
 
 //////////////////////////////////////////////////////////////////////////
@@ -44,70 +41,6 @@ ezResult ezMeshDecalDescription::Deserialize(ezStreamReader& inout_stream)
   inout_stream >> m_hBaseColorTexture;
 
   return EZ_SUCCESS;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-ezMeshDecalComponentManager::ezMeshDecalComponentManager(ezWorld* pWorld)
-  : ezComponentManager<ezMeshDecalComponent, ezBlockStorageType::Compact>(pWorld)
-{
-}
-
-ezMeshDecalComponentManager::~ezMeshDecalComponentManager() = default;
-
-void ezMeshDecalComponentManager::Initialize()
-{
-  auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezMeshDecalComponentManager::UpdateDecalVisibility, this);
-  desc.m_Phase = ezWorldUpdatePhase::Async;
-
-  this->RegisterUpdateFunction(desc);
-}
-
-void ezMeshDecalComponentManager::UpdateDecalVisibility(const ezWorldModule::UpdateContext& context)
-{
-  for (auto it = m_DecalUsageInfos.GetIterator(); it.IsValid(); ++it)
-  {
-    auto& usageInfo = it.Value();
-
-    const float fScreenSpaceSize = ezMath::ColorShortToFloat(usageInfo.m_iMaxScreenSpaceSize);
-    ezDecalManager::GetOrAddRuntimeDecal(it.Key(), fScreenSpaceSize, nullptr);
-
-    usageInfo.m_iMaxScreenSpaceSize = 0;
-  }
-}
-
-void ezMeshDecalComponentManager::RegisterDecalUsage(const ezTexture2DResourceHandle& hDecal)
-{
-  if (hDecal.IsValid())
-  {
-    DecalUsageInfo& usageInfo = m_DecalUsageInfos[hDecal];
-    usageInfo.m_iRefCount.Increment();
-  }
-}
-
-void ezMeshDecalComponentManager::UnregisterDecalUsage(const ezTexture2DResourceHandle& hDecal)
-{
-  if (hDecal.IsValid())
-  {
-    DecalUsageInfo& usageInfo = m_DecalUsageInfos[hDecal];
-    EZ_ASSERT_DEBUG(usageInfo.m_iRefCount > 0, "Unregistering a decal usage that was never registered.");
-    if (usageInfo.m_iRefCount.Decrement() == 0)
-    {
-      m_DecalUsageInfos.Remove(hDecal);
-    }
-  }
-}
-
-void ezMeshDecalComponentManager::UpdateMaxScreenSpaceSize(const ezTexture2DResourceHandle& hDecal, float fMaxScreenSpaceSize) const
-{
-  if (hDecal.IsValid())
-  {
-    if (const DecalUsageInfo* pUsageInfo = m_DecalUsageInfos.GetValue(hDecal))
-    {
-      int iMaxScreenSpaceSize = ezMath::ColorFloatToShort(fMaxScreenSpaceSize);
-      pUsageInfo->m_iMaxScreenSpaceSize.Max(iMaxScreenSpaceSize);
-    }
-  }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -156,26 +89,14 @@ void ezMeshDecalComponent::OnActivated()
 {
   SUPER::OnActivated();
 
-  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
-  for (auto& desc : m_DecalDescs)
-  {
-    pManager->RegisterDecalUsage(desc.m_hBaseColorTexture);
-  }
-
-  UpdateDecalIds();
+  UpdateDecals();
 }
 
 void ezMeshDecalComponent::OnDeactivated()
 {
   SUPER::OnDeactivated();
 
-  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
-  for (auto& desc : m_DecalDescs)
-  {
-    pManager->UnregisterDecalUsage(desc.m_hBaseColorTexture);
-  }
-
-  m_ActiveRuntimeDecals.Clear();
+  DeleteDecals();
 }
 
 void ezMeshDecalComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
@@ -185,10 +106,9 @@ void ezMeshDecalComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) c
 
   const float fScreenSpaceSize = ezLightComponent::CalculateScreenSpaceSize(GetOwner()->GetGlobalBounds().GetSphere(), *msg.m_pView->GetCullingCamera());
 
-  auto pManager = static_cast<const ezMeshDecalComponentManager*>(GetOwningManager());
-  for (auto& hTexture : m_ActiveRuntimeDecals)
+  for (ezDecalId decalId : m_DecalIds)
   {
-    pManager->UpdateMaxScreenSpaceSize(hTexture, fScreenSpaceSize);
+    ezDecalManager::MarkRuntimeDecalAsUsed(decalId, fScreenSpaceSize, msg.m_pView);
   }
 }
 
@@ -204,42 +124,31 @@ const ezMeshDecalDescription& ezMeshDecalComponent::Decals_Get(ezUInt32 uiIndex)
 
 void ezMeshDecalComponent::Decals_Set(ezUInt32 uiIndex, const ezMeshDecalDescription& desc)
 {
-  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
-  pManager->UnregisterDecalUsage(m_DecalDescs[uiIndex].m_hBaseColorTexture);
-
   m_DecalDescs[uiIndex] = desc;
 
-  pManager->RegisterDecalUsage(desc.m_hBaseColorTexture);
-
-  UpdateDecalIds();
+  UpdateDecals();
 }
 
 void ezMeshDecalComponent::Decals_Insert(ezUInt32 uiIndex, const ezMeshDecalDescription& desc)
 {
-  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
-  pManager->RegisterDecalUsage(desc.m_hBaseColorTexture);
-
   m_DecalDescs.InsertAt(uiIndex, desc);
 
-  UpdateDecalIds();
+  UpdateDecals();
 }
 
 void ezMeshDecalComponent::Decals_Remove(ezUInt32 uiIndex)
 {
-  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
-  pManager->UnregisterDecalUsage(m_DecalDescs[uiIndex].m_hBaseColorTexture);
-
   m_DecalDescs.RemoveAtAndCopy(uiIndex);
 
-  UpdateDecalIds();
+  UpdateDecals();
 }
 
-void ezMeshDecalComponent::UpdateDecalIds()
+void ezMeshDecalComponent::UpdateDecals()
 {
   if (!IsActiveAndInitialized())
     return;
 
-  m_ActiveRuntimeDecals.Clear();
+  DeleteDecals();
 
   ezArrayMap<ezUInt32, ezTexture2DResourceHandle> indexToTexture(ezFrameAllocator::GetCurrentAllocator());
   indexToTexture.Reserve(m_DecalDescs.GetCount());
@@ -265,18 +174,18 @@ void ezMeshDecalComponent::UpdateDecalIds()
 
     const ezUInt32 uiLowerBound = indexToTexture.LowerBound(i);
     const ezUInt32 uiUpperBound = ezMath::Min(indexToTexture.UpperBound(i), indexToTexture.GetCount());
-    
+
     if (uiLowerBound != ezInvalidIndex && uiUpperBound > uiLowerBound)
     {
       const ezUInt32 uiIndex = RandomIndex(uiLowerBound, uiUpperBound);
       auto& hTexture = indexToTexture.GetValue(uiIndex);
       if (hTexture.IsValid())
       {
-        ezDecalId decalId = ezDecalManager::GetOrAddRuntimeDecal(hTexture, 0.0f, nullptr);
+        ezDecalId decalId = ezDecalManager::GetOrCreateRuntimeDecal(hTexture);
         decalIndices[i] = decalId.m_InstanceIndex;
 
-        if (!m_ActiveRuntimeDecals.Contains(hTexture))
-          m_ActiveRuntimeDecals.PushBack(hTexture);
+        if (!m_DecalIds.Contains(decalId))
+          m_DecalIds.PushBack(decalId);
       }
     }
   }
@@ -289,4 +198,14 @@ void ezMeshDecalComponent::UpdateDecalIds()
   msg.m_fData3 = pDecalIndicesAsFloat[3];
 
   GetOwner()->PostMessage(msg, ezTime::MakeZero(), ezObjectMsgQueueType::AfterInitialized);
+}
+
+void ezMeshDecalComponent::DeleteDecals()
+{
+  for (ezDecalId decalId : m_DecalIds)
+  {
+    ezDecalManager::DeleteRuntimeDecal(decalId);
+  }
+
+  m_DecalIds.Clear();
 }

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
@@ -72,7 +72,7 @@ void ezMeshDecalComponentManager::UpdateDecalVisibility(const ezWorldModule::Upd
     const float fScreenSpaceSize = ezMath::ColorShortToFloat(usageInfo.m_iMaxScreenSpaceSize);
     ezDecalManager::GetOrAddRuntimeDecal(it.Key(), fScreenSpaceSize, nullptr);
 
-    usageInfo.m_iMaxScreenSpaceSize = ezMath::ColorFloatToShort(0.01f);
+    usageInfo.m_iMaxScreenSpaceSize = 0;
   }
 }
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
@@ -1,0 +1,292 @@
+#include <GameComponentsPlugin/GameComponentsPCH.h>
+
+#include <GameComponentsPlugin/Effects/MeshDecalComponent.h>
+
+#include <Core/Messages/SetColorMessage.h>
+#include <Core/Messages/TriggerMessage.h>
+#include <Core/ResourceManager/ResourceManager.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <Foundation/Containers/ArrayMap.h>
+#include <Foundation/SimdMath/SimdRandom.h>
+#include <RendererCore/Decals/Implementation/DecalManager.h>
+#include <RendererCore/Lights/LightComponent.h>
+#include <RendererCore/Pipeline/View.h>
+#include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererCore/Textures/Texture2DResource.h>
+
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezMeshDecalDescription, ezNoBase, 1, ezRTTIDefaultAllocator<ezMeshDecalDescription>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Index", m_uiIndex)->AddAttributes(new ezClampValueAttribute(0, 7)),
+    EZ_RESOURCE_MEMBER_PROPERTY("BaseColorTexture", m_hBaseColorTexture)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_2D")),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_STATIC_REFLECTED_TYPE;
+// clang-format on
+
+ezResult ezMeshDecalDescription::Serialize(ezStreamWriter& inout_stream) const
+{
+  inout_stream << m_uiIndex;
+  inout_stream << m_hBaseColorTexture;
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezMeshDecalDescription::Deserialize(ezStreamReader& inout_stream)
+{
+  inout_stream >> m_uiIndex;
+  inout_stream >> m_hBaseColorTexture;
+
+  return EZ_SUCCESS;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+ezMeshDecalComponentManager::ezMeshDecalComponentManager(ezWorld* pWorld)
+  : ezComponentManager<ezMeshDecalComponent, ezBlockStorageType::Compact>(pWorld)
+{
+}
+
+ezMeshDecalComponentManager::~ezMeshDecalComponentManager() = default;
+
+void ezMeshDecalComponentManager::Initialize()
+{
+  auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezMeshDecalComponentManager::UpdateDecalVisibility, this);
+  desc.m_Phase = ezWorldUpdatePhase::Async;
+
+  this->RegisterUpdateFunction(desc);
+}
+
+void ezMeshDecalComponentManager::UpdateDecalVisibility(const ezWorldModule::UpdateContext& context)
+{
+  for (auto it = m_DecalUsageInfos.GetIterator(); it.IsValid(); ++it)
+  {
+    auto& usageInfo = it.Value();
+
+    const float fScreenSpaceSize = ezMath::ColorShortToFloat(usageInfo.m_iMaxScreenSpaceSize);
+    ezDecalManager::GetOrAddRuntimeDecal(it.Key(), fScreenSpaceSize, nullptr);
+
+    usageInfo.m_iMaxScreenSpaceSize = ezMath::ColorFloatToShort(0.01f);
+  }
+}
+
+void ezMeshDecalComponentManager::RegisterDecalUsage(const ezTexture2DResourceHandle& hDecal)
+{
+  if (hDecal.IsValid())
+  {
+    DecalUsageInfo& usageInfo = m_DecalUsageInfos[hDecal];
+    usageInfo.m_iRefCount.Increment();
+  }
+}
+
+void ezMeshDecalComponentManager::UnregisterDecalUsage(const ezTexture2DResourceHandle& hDecal)
+{
+  if (hDecal.IsValid())
+  {
+    DecalUsageInfo& usageInfo = m_DecalUsageInfos[hDecal];
+    EZ_ASSERT_DEBUG(usageInfo.m_iRefCount > 0, "Unregistering a decal usage that was never registered.");
+    if (usageInfo.m_iRefCount.Decrement() == 0)
+    {
+      m_DecalUsageInfos.Remove(hDecal);
+    }
+  }
+}
+
+void ezMeshDecalComponentManager::UpdateMaxScreenSpaceSize(const ezTexture2DResourceHandle& hDecal, float fMaxScreenSpaceSize) const
+{
+  if (hDecal.IsValid())
+  {
+    if (const DecalUsageInfo* pUsageInfo = m_DecalUsageInfos.GetValue(hDecal))
+    {
+      int iMaxScreenSpaceSize = ezMath::ColorFloatToShort(fMaxScreenSpaceSize);
+      pUsageInfo->m_iMaxScreenSpaceSize.Max(iMaxScreenSpaceSize);
+    }
+  }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_COMPONENT_TYPE(ezMeshDecalComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ARRAY_ACCESSOR_PROPERTY("Decals", Decals_GetCount, Decals_Get, Decals_Set, Decals_Insert, Decals_Remove),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezCategoryAttribute("Effects"),
+  }
+  EZ_END_ATTRIBUTES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+  }
+  EZ_END_MESSAGEHANDLERS;
+}
+EZ_END_COMPONENT_TYPE
+// clang-format on
+
+void ezMeshDecalComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+  ezStreamWriter& s = inout_stream.GetStream();
+
+  s.WriteArray(m_DecalDescs).AssertSuccess();
+}
+
+void ezMeshDecalComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+
+  ezStreamReader& s = inout_stream.GetStream();
+
+  s.ReadArray(m_DecalDescs).AssertSuccess();
+}
+
+void ezMeshDecalComponent::OnActivated()
+{
+  SUPER::OnActivated();
+
+  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
+  for (auto& desc : m_DecalDescs)
+  {
+    pManager->RegisterDecalUsage(desc.m_hBaseColorTexture);
+  }
+
+  UpdateDecalIds();
+}
+
+void ezMeshDecalComponent::OnDeactivated()
+{
+  SUPER::OnDeactivated();
+
+  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
+  for (auto& desc : m_DecalDescs)
+  {
+    pManager->UnregisterDecalUsage(desc.m_hBaseColorTexture);
+  }
+
+  m_ActiveRuntimeDecals.Clear();
+}
+
+void ezMeshDecalComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
+{
+  if (msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::Shadow)
+    return;
+
+  const float fScreenSpaceSize = ezLightComponent::CalculateScreenSpaceSize(GetOwner()->GetGlobalBounds().GetSphere(), *msg.m_pView->GetCullingCamera());
+
+  auto pManager = static_cast<const ezMeshDecalComponentManager*>(GetOwningManager());
+  for (auto& hTexture : m_ActiveRuntimeDecals)
+  {
+    pManager->UpdateMaxScreenSpaceSize(hTexture, fScreenSpaceSize);
+  }
+}
+
+ezUInt32 ezMeshDecalComponent::Decals_GetCount() const
+{
+  return m_DecalDescs.GetCount();
+}
+
+const ezMeshDecalDescription& ezMeshDecalComponent::Decals_Get(ezUInt32 uiIndex) const
+{
+  return m_DecalDescs[uiIndex];
+}
+
+void ezMeshDecalComponent::Decals_Set(ezUInt32 uiIndex, const ezMeshDecalDescription& desc)
+{
+  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
+  pManager->UnregisterDecalUsage(m_DecalDescs[uiIndex].m_hBaseColorTexture);
+
+  m_DecalDescs[uiIndex] = desc;
+
+  pManager->RegisterDecalUsage(desc.m_hBaseColorTexture);
+
+  UpdateDecalIds();
+}
+
+void ezMeshDecalComponent::Decals_Insert(ezUInt32 uiIndex, const ezMeshDecalDescription& desc)
+{
+  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
+  pManager->RegisterDecalUsage(desc.m_hBaseColorTexture);
+
+  m_DecalDescs.InsertAt(uiIndex, desc);
+
+  UpdateDecalIds();
+}
+
+void ezMeshDecalComponent::Decals_Remove(ezUInt32 uiIndex)
+{
+  auto pManager = static_cast<ezMeshDecalComponentManager*>(GetOwningManager());
+  pManager->UnregisterDecalUsage(m_DecalDescs[uiIndex].m_hBaseColorTexture);
+
+  m_DecalDescs.RemoveAtAndCopy(uiIndex);
+
+  UpdateDecalIds();
+}
+
+void ezMeshDecalComponent::UpdateDecalIds()
+{
+  if (!IsActiveAndInitialized())
+    return;
+
+  m_ActiveRuntimeDecals.Clear();
+
+  ezArrayMap<ezUInt32, ezTexture2DResourceHandle> indexToTexture(ezFrameAllocator::GetCurrentAllocator());
+  indexToTexture.Reserve(m_DecalDescs.GetCount());
+
+  for (auto& desc : m_DecalDescs)
+  {
+    indexToTexture.Insert(desc.m_uiIndex, desc.m_hBaseColorTexture);
+  }
+
+  ezUInt32 uiRandomSeed = GetOwner()->GetStableRandomSeed();
+  int iRandomPos = 0;
+  auto RandomIndex = [uiRandomSeed, &iRandomPos](ezUInt32 uiMin, ezUInt32 uiMax)
+  {
+    ezUInt32 uiIndex = static_cast<ezUInt32>(ezSimdRandom::FloatMinMax(ezSimdVec4i(iRandomPos), ezSimdVec4f(float(uiMin)), ezSimdVec4f(float(uiMax)), ezSimdVec4u(uiRandomSeed)).x());
+    iRandomPos++;
+    return uiIndex;
+  };
+
+  ezUInt16 decalIndices[8] = {};
+  for (ezUInt32 i = 0; i < 8; ++i)
+  {
+    decalIndices[i] = ezSmallInvalidIndex;
+
+    const ezUInt32 uiLowerBound = indexToTexture.LowerBound(i);
+    const ezUInt32 uiUpperBound = ezMath::Min(indexToTexture.UpperBound(i), indexToTexture.GetCount());
+    
+    if (uiLowerBound != ezInvalidIndex && uiUpperBound > uiLowerBound)
+    {
+      const ezUInt32 uiIndex = RandomIndex(uiLowerBound, uiUpperBound);
+      auto& hTexture = indexToTexture.GetValue(uiIndex);
+      if (hTexture.IsValid())
+      {
+        ezDecalId decalId = ezDecalManager::GetOrAddRuntimeDecal(hTexture, 0.0f, nullptr);
+        decalIndices[i] = decalId.m_InstanceIndex;
+
+        if (!m_ActiveRuntimeDecals.Contains(hTexture))
+          m_ActiveRuntimeDecals.PushBack(hTexture);
+      }
+    }
+  }
+
+  const float* pDecalIndicesAsFloat = reinterpret_cast<const float*>(decalIndices);
+  ezMsgSetCustomData msg;
+  msg.m_fData0 = pDecalIndicesAsFloat[0];
+  msg.m_fData1 = pDecalIndicesAsFloat[1];
+  msg.m_fData2 = pDecalIndicesAsFloat[2];
+  msg.m_fData3 = pDecalIndicesAsFloat[3];
+
+  GetOwner()->PostMessage(msg, ezTime::MakeZero(), ezObjectMsgQueueType::AfterInitialized);
+}

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
@@ -21,6 +21,12 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMECOMPONENTS_DLL, ezMeshDecalDescription);
 
 using ezMeshDecalComponentManager = ezComponentManager<class ezMeshDecalComponent, ezBlockStorageType::Compact>;
 
+/// \brief A component that takes a couple of decal textures, picks a random one for each slot,
+/// adds them to runtime decal atlas and sends a custom data message with the corresponding decal indices.
+///
+/// The decals in this case are not regular projected decals, but rather mesh decals aka floaters.
+/// This requires a special shader to be used which uses the custom data in the instance data to map the UV coordinates to the decal atlas.
+/// See "Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader" for an example shader.
 class EZ_GAMECOMPONENTS_DLL ezMeshDecalComponent final : public ezComponent
 {
   EZ_DECLARE_COMPONENT_TYPE(ezMeshDecalComponent, ezComponent, ezMeshDecalComponentManager);

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <Core/World/World.h>
+#include <GameComponentsPlugin/GameComponentsDLL.h>
+#include <RendererCore/Declarations.h>
+
+struct ezMsgExtractRenderData;
+
+struct EZ_GAMECOMPONENTS_DLL ezMeshDecalDescription
+{
+  ezUInt16 m_uiIndex = 0;
+  ezTexture2DResourceHandle m_hBaseColorTexture;
+
+  ezResult Serialize(ezStreamWriter& inout_stream) const;
+  ezResult Deserialize(ezStreamReader& inout_stream);
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMECOMPONENTS_DLL, ezMeshDecalDescription);
+
+////////////////////////////////////////////////////////////////////////////
+
+class EZ_GAMECOMPONENTS_DLL ezMeshDecalComponentManager final : public ezComponentManager<class ezMeshDecalComponent, ezBlockStorageType::Compact>
+{
+public:
+  ezMeshDecalComponentManager(ezWorld* pWorld);
+  ~ezMeshDecalComponentManager();
+
+  void Initialize() override;
+
+private:
+  void UpdateDecalVisibility(const ezWorldModule::UpdateContext& context);
+
+  friend class ezMeshDecalComponent;
+  void RegisterDecalUsage(const ezTexture2DResourceHandle& hDecal);
+  void UnregisterDecalUsage(const ezTexture2DResourceHandle& hDecal);
+  void UpdateMaxScreenSpaceSize(const ezTexture2DResourceHandle& hDecal, float fMaxScreenSpaceSize) const;
+
+  struct DecalUsageInfo
+  {
+    ezAtomicInteger32 m_iRefCount = 0;
+    mutable ezAtomicInteger32 m_iMaxScreenSpaceSize = 0;
+  };
+
+  ezHashTable<ezTexture2DResourceHandle, DecalUsageInfo> m_DecalUsageInfos;
+};
+
+class EZ_GAMECOMPONENTS_DLL ezMeshDecalComponent final : public ezComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezMeshDecalComponent, ezComponent, ezMeshDecalComponentManager);
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezComponent
+
+public:
+  virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+protected:
+  virtual void OnActivated() override;
+  virtual void OnDeactivated() override;
+
+  void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
+
+private:
+  ezUInt32 Decals_GetCount() const;
+  const ezMeshDecalDescription& Decals_Get(ezUInt32 uiIndex) const;
+  void Decals_Set(ezUInt32 uiIndex, const ezMeshDecalDescription& desc);
+  void Decals_Insert(ezUInt32 uiIndex, const ezMeshDecalDescription& desc);
+  void Decals_Remove(ezUInt32 uiIndex);
+
+  void UpdateDecalIds();
+  
+  ezSmallArray<ezMeshDecalDescription, 2> m_DecalDescs;
+  ezSmallArray<ezTexture2DResourceHandle, 2> m_ActiveRuntimeDecals;
+};

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
@@ -19,30 +19,7 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMECOMPONENTS_DLL, ezMeshDecalDescription);
 
 ////////////////////////////////////////////////////////////////////////////
 
-class EZ_GAMECOMPONENTS_DLL ezMeshDecalComponentManager final : public ezComponentManager<class ezMeshDecalComponent, ezBlockStorageType::Compact>
-{
-public:
-  ezMeshDecalComponentManager(ezWorld* pWorld);
-  ~ezMeshDecalComponentManager();
-
-  void Initialize() override;
-
-private:
-  void UpdateDecalVisibility(const ezWorldModule::UpdateContext& context);
-
-  friend class ezMeshDecalComponent;
-  void RegisterDecalUsage(const ezTexture2DResourceHandle& hDecal);
-  void UnregisterDecalUsage(const ezTexture2DResourceHandle& hDecal);
-  void UpdateMaxScreenSpaceSize(const ezTexture2DResourceHandle& hDecal, float fMaxScreenSpaceSize) const;
-
-  struct DecalUsageInfo
-  {
-    ezAtomicInteger32 m_iRefCount = 0;
-    mutable ezAtomicInteger32 m_iMaxScreenSpaceSize = 0;
-  };
-
-  ezHashTable<ezTexture2DResourceHandle, DecalUsageInfo> m_DecalUsageInfos;
-};
+using ezMeshDecalComponentManager = ezComponentManager<class ezMeshDecalComponent, ezBlockStorageType::Compact>;
 
 class EZ_GAMECOMPONENTS_DLL ezMeshDecalComponent final : public ezComponent
 {
@@ -68,8 +45,9 @@ private:
   void Decals_Insert(ezUInt32 uiIndex, const ezMeshDecalDescription& desc);
   void Decals_Remove(ezUInt32 uiIndex);
 
-  void UpdateDecalIds();
+  void UpdateDecals();
+  void DeleteDecals();
   
   ezSmallArray<ezMeshDecalDescription, 2> m_DecalDescs;
-  ezSmallArray<ezTexture2DResourceHandle, 2> m_ActiveRuntimeDecals;
+  ezSmallArray<ezDecalId, 2> m_DecalIds;
 };

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/MeshDecalComponent.h
@@ -53,7 +53,7 @@ private:
 
   void UpdateDecals();
   void DeleteDecals();
-  
+
   ezSmallArray<ezMeshDecalDescription, 2> m_DecalDescs;
   ezSmallArray<ezDecalId, 2> m_DecalIds;
 };

--- a/Data/Samples/Testing Chambers/Materials/MeshDecal.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecal.ezMaterialAsset
@@ -1,0 +1,562 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{13372529112349640576,5516946423271476972}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Material"}
+		VarArray %Dependencies
+		{
+			s{"Materials/MeshDecalMaterial.ezShader"}
+		}
+		Uuid %DocumentID{u4{13372529112349640576,5516946423271476972}}
+		u4 %Hash{7011489966184224663}
+		VarArray %MetaInfo{}
+		VarArray %Outputs{}
+		VarArray %PackageDeps
+		{
+			s{"{ bac42aa1-3f34-43ff-a2ef-0347758a705a }"}
+		}
+		VarArray %References
+		{
+			s{"Materials/MeshDecalMaterial.ezShader"}
+			s{"{ bac42aa1-3f34-43ff-a2ef-0347758a705a }"}
+		}
+		s %Tags{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{9792377281523314140,5096662692245937437}}
+	s %t{"Materials/MeshDecalMaterial.ezShader"}
+	u3 %v{2}
+	p
+	{
+		f %AlphaContrast{0x00000040}
+		s %AlphaTexture{"{ bac42aa1-3f34-43ff-a2ef-0347758a705a }"}
+		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		Color %BaseColor{f{0xBD5EE53E,0x424BCA3E,0x349AB53E,0x9796163F}}
+		f %DepthBias{0x0000803F}
+		f %MaskThreshold{0x0000803E}
+	}
+}
+o
+{
+	Uuid %id{u4{4404545538082810508,5463627017144094608}}
+	s %t{"ezMaterialAssetProperties"}
+	u3 %v{4}
+	p
+	{
+		s %AssetFilterTags{""}
+		s %BaseMaterial{""}
+		s %Shader{"Materials/MeshDecalMaterial.ezShader"}
+		s %ShaderMode{"ezMaterialShaderMode::File"}
+		Uuid %ShaderProperties{u4{9792377281523314140,5096662692245937437}}
+		s %Surface{""}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{4404545538082810508,5463627017144094608}}
+		}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{18311245008988910186,1895067994934075466}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{773668148553828920,15966949596821666881}}
+			Uuid{u4{540429536914844576,8213819539779215949}}
+			Uuid{u4{15543418230834458689,5548684801941186544}}
+			Uuid{u4{16393153594407016602,3744118329769567614}}
+			Uuid{u4{7757084663128585029,8011669779036733373}}
+			Uuid{u4{5650026407490086663,5768478847879086899}}
+			Uuid{u4{3687164412847300807,16605290275319987562}}
+		}
+		s %TypeName{"BLEND_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6545170155912199324,3496733780329560390}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Texture 2D"}
+	}
+}
+o
+{
+	Uuid %id{u4{16393153594407016602,3744118329769567614}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{2}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_DITHERED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{10515076537420242153,5154199315482791699}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6037004379202407639,9885671958675958295}}
+			Uuid{u4{11842346326124098784,16694928834844283675}}
+			Uuid{u4{6605222836758472296,18177811796540042103}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseColor"}
+		s %Type{"ezColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{6106305860844615146,5244968148170921337}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{3918337419931038321,5285315593630290188}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{960152750114028346,11185416691160657918}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"AlphaContrast"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{16970819890733740309,5520799648492120155}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6106305860844615146,5244968148170921337}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"BLEND_MODE"}
+		s %Type{"BLEND_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{15543418230834458689,5548684801941186544}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{5650026407490086663,5768478847879086899}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{4}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{5272874553530736781,6184227311035647419}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x000000000000F03F}
+	}
+}
+o
+{
+	Uuid %id{u4{615678103686273916,7151176275606449298}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{13737951011035379018,8399609771049402693}}
+			Uuid{u4{5272874553530736781,6184227311035647419}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"DepthBias"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{16248150205802219639,7955600646926129371}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{7757084663128585029,8011669779036733373}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{3}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{540429536914844576,8213819539779215949}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{13737951011035379018,8399609771049402693}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17717897218099796308,9033184167245688007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezShaderTypeBase"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{6037004379202407639,9885671958675958295}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{15123761430731827776,10780950473423758110}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezShaderTypeBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{16970819890733740309,5520799648492120155}}
+			Uuid{u4{12763922396590077063,16519011468733818509}}
+			Uuid{u4{615678103686273916,7151176275606449298}}
+			Uuid{u4{10515076537420242153,5154199315482791699}}
+			Uuid{u4{15524087554425894888,14811120508237665148}}
+			Uuid{u4{3918337419931038321,5285315593630290188}}
+		}
+		s %TypeName{"Materials/MeshDecalMaterial.ezShader"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{960152750114028346,11185416691160657918}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{13908932274245174406,12097783386698681285}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x000000000000D03F}
+	}
+}
+o
+{
+	Uuid %id{u4{10380105039408580433,12329897656400741403}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
+	}
+}
+o
+{
+	Uuid %id{u4{15524087554425894888,14811120508237665148}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6545170155912199324,3496733780329560390}}
+			Uuid{u4{10380105039408580433,12329897656400741403}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"AlphaTexture"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{773668148553828920,15966949596821666881}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{12763922396590077063,16519011468733818509}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{16248150205802219639,7955600646926129371}}
+			Uuid{u4{13908932274245174406,12097783386698681285}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"MaskThreshold"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{3687164412847300807,16605290275319987562}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{5}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{11842346326124098784,16694928834844283675}}
+	s %t{"ezExposeColorAlphaAttribute"}
+	u3 %v{1}
+	p{}
+}
+o
+{
+	Uuid %id{u4{8721322561248882817,17579066505604714242}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialShaderMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6605222836758472296,18177811796540042103}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Color %Value{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{5030680158680079231,18410952876772242771}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialAssetProperties"}
+		u3 %TypeVersion{4}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
@@ -1,0 +1,147 @@
+[PLATFORMS]
+ALL
+
+[PERMUTATIONS]
+
+BLEND_MODE
+RENDER_PASS
+SHADING_MODE = SHADING_MODE_LIT
+SHADING_QUALITY = SHADING_QUALITY_NORMAL
+TWO_SIDED = FALSE
+FLIP_WINDING
+FORWARD_PASS_WRITE_DEPTH
+MSAA
+CAMERA_MODE
+
+[MATERIALPARAMETER]
+
+Permutation BLEND_MODE;
+float MaskThreshold @Default(0.25);
+float DepthBias @Default(1.0);
+
+Color BaseColor @Default(Color(1, 1, 1));
+
+Texture2D AlphaTexture;
+float AlphaContrast;
+
+[MATERIALCONSTANTS]
+
+COLOR4F(BaseColor);
+FLOAT1(MaskThreshold);
+FLOAT1(DepthBias);
+FLOAT1(AlphaContrast);
+
+[MATERIALCONFIG]
+
+#include <Shaders/Materials/MaterialConfig.h>
+
+[RENDERSTATE]
+
+#include <Shaders/Materials/MaterialState.h>
+
+[SHADER]
+
+#define USE_NORMAL
+#define USE_TANGENT
+#define USE_TEXCOORD0
+//#define USE_COLOR0
+
+[VERTEXSHADER]
+
+#define USE_VERTEX_DEPTH_BIAS
+#define CUSTOM_INTERPOLATOR float2 TexCoordAlpha : TEXCOORD_ALPHA;
+
+#include <Shaders/Materials/MaterialVertexShader.h>
+#include <Shaders/Common/LightData.h>
+
+float GetVertexDepthBias()
+{
+  return -DepthBias;
+}
+
+VS_OUT main(VS_IN Input)
+{
+  VS_OUT Output = FillVertexData(Input);
+
+  Output.TexCoordAlpha = Output.TexCoord0;
+
+  uint innerIndex = clamp(uint(Input.TexCoord0.x), 0, 1);
+  uint outerIndex = clamp(uint(Input.TexCoord0.y), 0, 3);
+
+  uint customData = asuint(GetInstanceData().CustomData[outerIndex]);
+  uint decalIndex = (customData >> (innerIndex * 16)) & 0xFFFF;
+
+  ezPerDecalAtlasData atlasData = perDecalAtlasDataBuffer[decalIndex];
+  if (decalIndex == 0xFFFF || atlasData.scale == 0)
+  {
+    // Invalid decal -> cull
+    Output.Position.z = 2 * Output.Position.w;
+  }
+  else
+  {
+    // The decal atlas assumes input uvs to be in [-1, 1] range but mesh uvs are in [0, 1] range.
+    float2 uvs = frac(Input.TexCoord0.xy) * 2.0 - 1.0;
+    Output.TexCoord0 = uvs * RG16FToFloat2(atlasData.scale) + RG16FToFloat2(atlasData.offset);
+  }
+
+  return Output;
+}
+
+[PIXELSHADER]
+
+#define USE_SIMPLE_MATERIAL_MODEL
+#define USE_MATERIAL_OCCLUSION
+#define USE_FOG
+#define CUSTOM_INTERPOLATOR float2 TexCoordAlpha : TEXCOORD_ALPHA;
+
+#include <Shaders/Materials/MaterialPixelShader.h>
+
+Texture2D AlphaTexture;
+SamplerState AlphaTexture_AutoSampler;
+
+float3 GetNormal()
+{
+  return G.Input.Normal;
+}
+
+float3 GetBaseColor()
+{
+  float3 color = DecalRuntimeAtlasTexture.SampleLevel(DecalAtlasSampler, G.Input.TexCoord0.xy, 0).rgb;
+  color *= BaseColor.rgb * GetInstanceData().Color.rgb;
+  return color;
+}
+
+float GetMetallic()
+{
+  return 0.0;
+}
+
+float GetReflectance()
+{
+  return 0.5;
+}
+
+float GetRoughness()
+{
+  return 0.9;
+}
+
+float GetOpacity()
+{
+  float alpha = AlphaTexture.Sample(AlphaTexture_AutoSampler, G.Input.TexCoordAlpha.xy).r;
+  alpha = AdjustContrast(alpha, AlphaContrast);
+
+  float opacity = DecalRuntimeAtlasTexture.SampleLevel(DecalAtlasSampler, G.Input.TexCoord0.xy, 0).a;
+  opacity *= alpha * BaseColor.a * GetInstanceData().Color.a;
+  
+  #if BLEND_MODE == BLEND_MODE_MASKED
+    return opacity - MaskThreshold;
+  #else
+    return opacity;
+  #endif
+}
+
+float GetOcclusion()
+{
+  return 1.0;
+}

--- a/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
@@ -54,6 +54,7 @@ FLOAT1(AlphaContrast);
 #include <Shaders/Materials/MaterialVertexShader.h>
 #include <Shaders/Common/LightData.h>
 
+// Use the depth bias to ensure decals are always rendered on top the surface.
 float GetVertexDepthBias()
 {
   return -DepthBias;
@@ -65,12 +66,15 @@ VS_OUT main(VS_IN Input)
 
   Output.TexCoordAlpha = Output.TexCoord0;
 
+  // First determine the slot index based on the integer part of the UVs. 
   uint innerIndex = clamp(uint(Input.TexCoord0.x), 0, 1);
   uint outerIndex = clamp(uint(Input.TexCoord0.y), 0, 3);
 
+  // Then fetch the decal index from the custom data of the instance.
   uint customData = asuint(GetInstanceData().CustomData[outerIndex]);
   uint decalIndex = (customData >> (innerIndex * 16)) & 0xFFFF;
 
+  // Finally fetch the atlas data for the decal index.
   ezPerDecalAtlasData atlasData = perDecalAtlasDataBuffer[decalIndex];
   if (decalIndex == 0xFFFF || atlasData.scale == 0)
   {

--- a/Data/Samples/Testing Chambers/Objects/Box.ezMeshAsset
+++ b/Data/Samples/Testing Chambers/Objects/Box.ezMeshAsset
@@ -14,17 +14,19 @@ o
 			s{"Objects/Box_data/Box.FBX"}
 		}
 		Uuid %DocumentID{u4{9222742976553252257,5711196105140488960}}
-		u4 %Hash{15957109085748343053}
+		u4 %Hash{1861363711553415745}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
 		{
 			s{"{ 6050f082-3194-428a-8aa7-e64d21cf0a67 }"}
+			s{"{ bbf54eec-218a-4c90-8087-2b8260c494b9 }"}
 		}
 		VarArray %References
 		{
 			s{"Objects/Box_data/Box.FBX"}
 			s{"{ 6050f082-3194-428a-8aa7-e64d21cf0a67 }"}
+			s{"{ bbf54eec-218a-4c90-8087-2b8260c494b9 }"}
 		}
 		s %Tags{""}
 	}
@@ -39,7 +41,7 @@ o
 	u3 %v{1}
 	p
 	{
-		s %Label{"Material"}
+		s %Label{"Box"}
 		s %Resource{"{ 6050f082-3194-428a-8aa7-e64d21cf0a67 }"}
 	}
 }
@@ -47,7 +49,7 @@ o
 {
 	Uuid %id{u4{12158029488866988735,4749202168660676795}}
 	s %t{"ezMeshAssetProperties"}
-	u3 %v{3}
+	u3 %v{4}
 	p
 	{
 		b %AggressiveSimplification{0}
@@ -59,12 +61,16 @@ o
 		b %FlipForwardDir{0}
 		f %Height{0x0000803F}
 		b %ImportMaterials{0}
+		s %ImportTransform{"ezMeshImportTransform::Custom"}
 		VarArray %Materials
 		{
 			Uuid{u4{6688943519444525002,2510057602504650768}}
+			Uuid{u4{10555614618223731331,4900557965869365196}}
 		}
 		u1 %MaxSimplificationError{5}
+		s %MeshExcludeTags{"$;UCX_"}
 		s %MeshFile{"Objects/Box_data/Box.FBX"}
+		s %MeshIncludeTags{""}
 		u1 %MeshSimplification{50}
 		s %NormalPrecision{"ezMeshNormalPrecision::_10Bit"}
 		s %PrimitiveType{"ezMeshPrimitive::File"}
@@ -77,6 +83,18 @@ o
 		s %TexCoordPrecision{"ezMeshTexCoordPrecision::_16Bit"}
 		f %UniformScaling{0x0000803F}
 		s %UpDir{"ezBasisAxis::PositiveY"}
+		s %VertexColorConversion{"ezMeshVertexColorConversion::None"}
+	}
+}
+o
+{
+	Uuid %id{u4{10555614618223731331,4900557965869365196}}
+	s %t{"ezMaterialResourceSlot"}
+	u3 %v{1}
+	p
+	{
+		s %Label{"Decals"}
+		s %Resource{"{ bbf54eec-218a-4c90-8087-2b8260c494b9 }"}
 	}
 }
 o
@@ -127,7 +145,7 @@ o
 		s %PluginName{"ezEditorPluginAssets"}
 		VarArray %Properties{}
 		s %TypeName{"ezMeshAssetProperties"}
-		u3 %TypeVersion{3}
+		u3 %TypeVersion{4}
 	}
 }
 o
@@ -144,6 +162,23 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16959510582460493866,8962221111705621108}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshImportTransform"}
 		u3 %TypeVersion{1}
 	}
 }
@@ -178,6 +213,23 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezMeshTexCoordPrecision"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1149684950174857976,12897203947091760514}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezMeshVertexColorConversion"}
 		u3 %TypeVersion{1}
 	}
 }

--- a/Data/Samples/Testing Chambers/Objects/Box.ezPrefab
+++ b/Data/Samples/Testing Chambers/Objects/Box.ezPrefab
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{2653273945935889549,5408382608569466657}}
-		u4 %Hash{9594900639687534043}
+		u4 %Hash{5139991441615508442}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{11971242699897598154,12838358576299228189}}
@@ -19,12 +19,20 @@ o
 		VarArray %Outputs{}
 		VarArray %PackageDeps
 		{
+			s{"{ 01efb260-0e6a-4f6e-93ca-4dfa9897bfab }"}
 			s{"{ 317e4b00-3e99-4f42-a175-2f7cdfc3fd7f }"}
 			s{"{ 58d44330-37a1-4c9d-9fa2-0540a1d8ee90 }"}
+			s{"{ 7dd20d89-0919-4868-9ab1-6fe2b6aa9bbc }"}
+			s{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
+			s{"{ c9157316-8756-4771-a162-327b4c479b64 }"}
 		}
 		VarArray %References
 		{
+			s{"{ 01efb260-0e6a-4f6e-93ca-4dfa9897bfab }"}
 			s{"{ 317e4b00-3e99-4f42-a175-2f7cdfc3fd7f }"}
+			s{"{ 7dd20d89-0919-4868-9ab1-6fe2b6aa9bbc }"}
+			s{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
+			s{"{ c9157316-8756-4771-a162-327b4c479b64 }"}
 		}
 		s %Tags{""}
 	}
@@ -54,6 +62,7 @@ o
 		VarArray %Components
 		{
 			Uuid{u4{7906224441069663639,2673834784278647053}}
+			Uuid{u4{13201624610604425397,4715912255827769827}}
 			Uuid{u4{12785786955112432779,5252008499447130408}}
 			Uuid{u4{10173565788422716322,4634033198773031944}}
 			Uuid{u4{11794192176365346495,4727709182479083056}}
@@ -100,6 +109,27 @@ o
 }
 o
 {
+	Uuid %id{u4{13201624610604425397,4715912255827769827}}
+	s %t{"ezMeshDecalComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Decals
+		{
+			Uuid{u4{3493413085135186304,5175310218666337932}}
+			Uuid{u4{1068454773302186369,5362303458600349992}}
+			Uuid{u4{10698091178655869106,5322430356251310379}}
+			Uuid{u4{4771643241309783992,5363599449085161640}}
+			Uuid{u4{4680452154622173107,5319877401472059690}}
+			Uuid{u4{8623272079402435206,4832122395535742918}}
+			Uuid{u4{13909610169123786933,5384091965877922906}}
+			Uuid{u4{2042984088539366785,5612708916301296339}}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{11794192176365346495,4727709182479083056}}
 	s %t{"ezGrabbableItemComponent"}
 	u3 %v{1}
@@ -114,6 +144,17 @@ o
 			Uuid{u4{14229167397029895573,5501943711183693288}}
 			Uuid{u4{16472688989518818689,5139949315865586510}}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{8623272079402435206,4832122395535742918}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{""}
+		u2 %Index{1}
 	}
 }
 o
@@ -155,9 +196,20 @@ o
 }
 o
 {
+	Uuid %id{u4{3493413085135186304,5175310218666337932}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ 7dd20d89-0919-4868-9ab1-6fe2b6aa9bbc }"}
+		u2 %Index{0}
+	}
+}
+o
+{
 	Uuid %id{u4{12785786955112432779,5252008499447130408}}
 	s %t{"ezJoltDynamicActorComponent"}
-	u3 %v{6}
+	u3 %v{7}
 	p
 	{
 		b %Active{1}
@@ -181,6 +233,61 @@ o
 }
 o
 {
+	Uuid %id{u4{4680452154622173107,5319877401472059690}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ 01efb260-0e6a-4f6e-93ca-4dfa9897bfab }"}
+		u2 %Index{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10698091178655869106,5322430356251310379}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ c9157316-8756-4771-a162-327b4c479b64 }"}
+		u2 %Index{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1068454773302186369,5362303458600349992}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
+		u2 %Index{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4771643241309783992,5363599449085161640}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{""}
+		u2 %Index{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13909610169123786933,5384091965877922906}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
+		u2 %Index{2}
+	}
+}
+o
+{
 	Uuid %id{u4{14229167397029895573,5501943711183693288}}
 	s %t{"ezGrabbableItemGrabPoint"}
 	u3 %v{1}
@@ -199,6 +306,17 @@ o
 	{
 		Vec3 %LocalPosition{f{0x000000BF,0,0}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{2042984088539366785,5612708916301296339}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ c9157316-8756-4771-a162-327b4c479b64 }"}
+		u2 %Index{2}
 	}
 }
 o
@@ -304,9 +422,11 @@ o
 		VarArray %ArgNames
 		{
 			s{"vImpulse"}
+			s{"uiImpulseType"}
 		}
 		VarArray %ArgTypes
 		{
+			u1{0}
 			u1{0}
 		}
 	}
@@ -326,6 +446,16 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezManipulatorAttribute"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14958217006258665035,690358072931221741}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Value{0}
 	}
 }
 o
@@ -361,6 +491,24 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezComponent"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6967669394581444225,1261545456310377889}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{7832908673972767009,8582614506276643933}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseColorTexture"}
+		s %Type{"ezStringView"}
 	}
 }
 o
@@ -450,9 +598,11 @@ o
 		VarArray %ArgNames
 		{
 			s{"vImpulse"}
+			s{"uiImpulseType"}
 		}
 		VarArray %ArgTypes
 		{
+			u1{0}
 			u1{0}
 		}
 	}
@@ -529,6 +679,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezExposedSceneProperty"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4480277756701344755,3122750415656630425}}
+	s %t{"ezFunctionArgumentDescriptor"}
+	u3 %v{1}
+	p
+	{
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Type{"ezUInt8"}
 	}
 }
 o
@@ -626,6 +787,68 @@ o
 }
 o
 {
+	Uuid %id{u4{3774587384740579185,3695365945540523376}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{16042029265769598148,11405978919055105991}}
+		}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezGameComponentsPlugin"}
+		VarArray %Properties
+		{
+			Uuid{u4{6902132715477760199,14929062528364786245}}
+		}
+		s %TypeName{"ezMeshDecalComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5336344449290661074,4383793934612844372}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{4396885050006836836,11373936384696251049}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Index"}
+		s %Type{"ezUInt16"}
+	}
+}
+o
+{
+	Uuid %id{u4{9064688606274517541,4514156333772235209}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"ezGameComponentsPlugin"}
+		VarArray %Properties
+		{
+			Uuid{u4{5336344449290661074,4383793934612844372}}
+			Uuid{u4{6967669394581444225,1261545456310377889}}
+		}
+		s %TypeName{"ezMeshDecalDescription"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{9085939981889508946,4612025930380880638}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
@@ -662,6 +885,20 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Kinematic"}
 		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{16337583193817562798,4686003285916175886}}
+	s %t{"ezFunctionArgumentAttributes"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ArgAttributes
+		{
+			Uuid{u4{11000941240856164325,15082151704469256447}}
+		}
+		u3 %ArgIndex{1}
 	}
 }
 o
@@ -734,9 +971,9 @@ o
 	{
 		VarArray %ArgNames
 		{
-			s{"forceID"}
+			s{"uiForceID"}
 			s{"duration"}
-			s{"force"}
+			s{"vForce"}
 		}
 		VarArray %ArgTypes
 		{
@@ -863,7 +1100,7 @@ o
 	{
 		VarArray %ArgNames
 		{
-			s{"forceID"}
+			s{"uiForceID"}
 		}
 		VarArray %ArgTypes
 		{
@@ -928,7 +1165,7 @@ o
 			Uuid{u4{3225422539751733703,15467635098152158757}}
 		}
 		s %TypeName{"ezJoltDynamicActorComponent"}
-		u3 %TypeVersion{6}
+		u3 %TypeVersion{7}
 	}
 }
 o
@@ -958,6 +1195,18 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"WeightCategory"}
 		s %Type{"ezUInt8"}
+	}
+}
+o
+{
+	Uuid %id{u4{7832908673972767009,8582614506276643933}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
 	}
 }
 o
@@ -1020,10 +1269,12 @@ o
 		VarArray %Arguments
 		{
 			Uuid{u4{6336723317049884733,6579878144043010185}}
+			Uuid{u4{4480277756701344755,3122750415656630425}}
 		}
 		VarArray %Attributes
 		{
 			Uuid{u4{5683086205581634420,2448255893199881040}}
+			Uuid{u4{12993606658877674130,12900577086516897735}}
 		}
 		s %Flags{"ezPropertyFlags::Phantom"}
 		s %Name{"AddAngularImpulse"}
@@ -1046,6 +1297,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezSceneDocumentRoot"}
 		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{266995518533564983,9230344921036805643}}
+	s %t{"ezFunctionArgumentDescriptor"}
+	u3 %v{1}
+	p
+	{
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Type{"ezUInt8"}
 	}
 }
 o
@@ -1257,6 +1519,27 @@ o
 }
 o
 {
+	Uuid %id{u4{4396885050006836836,11373936384696251049}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Max{7}
+		i3 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16042029265769598148,11405978919055105991}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Effects"}
+	}
+}
+o
+{
 	Uuid %id{u4{14700230518358869173,11472901527618371423}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -1454,6 +1737,20 @@ o
 }
 o
 {
+	Uuid %id{u4{12993606658877674130,12900577086516897735}}
+	s %t{"ezFunctionArgumentAttributes"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ArgAttributes
+		{
+			Uuid{u4{14958217006258665035,690358072931221741}}
+		}
+		u3 %ArgIndex{1}
+	}
+}
+o
+{
 	Uuid %id{u4{4903960154749262079,14218359138397949918}}
 	s %t{"ezFunctionArgumentDescriptor"}
 	u3 %v{1}
@@ -1473,15 +1770,32 @@ o
 		VarArray %Arguments
 		{
 			Uuid{u4{14656959313833216783,11974093621308024724}}
+			Uuid{u4{266995518533564983,9230344921036805643}}
 		}
 		VarArray %Attributes
 		{
 			Uuid{u4{8848366910655626142,348363795862216714}}
+			Uuid{u4{16337583193817562798,4686003285916175886}}
 		}
 		s %Flags{"ezPropertyFlags::Phantom"}
 		s %Name{"AddLinearImpulse"}
 		Uuid %ReturnValue{u4{10916935353549710630,2962763290225888874}}
 		s %Type{"ezFunctionType::Member"}
+	}
+}
+o
+{
+	Uuid %id{u4{6902132715477760199,14929062528364786245}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Array"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::Class|ezPropertyFlags::Const|ezPropertyFlags::Reference|ezPropertyFlags::Phantom"}
+		s %Name{"Decals"}
+		s %Type{"ezMeshDecalDescription"}
 	}
 }
 o
@@ -1499,6 +1813,16 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezEnumBase"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11000941240856164325,15082151704469256447}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Value{0}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Objects/MetalBox.ezPrefab
+++ b/Data/Samples/Testing Chambers/Objects/MetalBox.ezPrefab
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{16417845693445938855,5426315883368663920}}
-		u4 %Hash{8440169772449682644}
+		u4 %Hash{2122267541737184554}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{1685474806231586891,11999636717318555766}}
@@ -21,12 +21,16 @@ o
 		{
 			s{"{ 317e4b00-3e99-4f42-a175-2f7cdfc3fd7f }"}
 			s{"{ 72115f7a-5947-4a21-899f-868368bd41d7 }"}
+			s{"{ 7dd20d89-0919-4868-9ab1-6fe2b6aa9bbc }"}
 			s{"{ 873e3738-dc4d-40b0-93e8-236c2dd3165d }"}
+			s{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
 		}
 		VarArray %References
 		{
 			s{"{ 317e4b00-3e99-4f42-a175-2f7cdfc3fd7f }"}
+			s{"{ 7dd20d89-0919-4868-9ab1-6fe2b6aa9bbc }"}
 			s{"{ 873e3738-dc4d-40b0-93e8-236c2dd3165d }"}
+			s{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
 		}
 		s %Tags{""}
 	}
@@ -46,9 +50,20 @@ Objects
 {
 o
 {
+	Uuid %id{u4{17105776962027170956,4729121220752714842}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ 7dd20d89-0919-4868-9ab1-6fe2b6aa9bbc }"}
+		u2 %Index{0}
+	}
+}
+o
+{
 	Uuid %id{u4{4637723655534580669,4815798633864556694}}
 	s %t{"ezJoltDynamicActorComponent"}
-	u3 %v{6}
+	u3 %v{7}
 	p
 	{
 		b %Active{1}
@@ -79,6 +94,32 @@ o
 	{
 		b %Active{1}
 		Vec3 %HalfExtents{f{0x0000003F,0x0000003F,0x0000003F}}
+	}
+}
+o
+{
+	Uuid %id{u4{452041346853144733,5201957890537463928}}
+	s %t{"ezMeshDecalDescription"}
+	u3 %v{1}
+	p
+	{
+		s %BaseColorTexture{"{ c449cbce-ae68-4bf6-b409-61732de93547 }"}
+		u2 %Index{2}
+	}
+}
+o
+{
+	Uuid %id{u4{17961247903747087792,5625017769071589474}}
+	s %t{"ezMeshDecalComponent"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Decals
+		{
+			Uuid{u4{17105776962027170956,4729121220752714842}}
+			Uuid{u4{452041346853144733,5201957890537463928}}
+		}
 	}
 }
 o
@@ -118,6 +159,7 @@ o
 		VarArray %Components
 		{
 			Uuid{u4{9431151716676181810,7604723771899900927}}
+			Uuid{u4{17961247903747087792,5625017769071589474}}
 			Uuid{u4{9000452612287570606,4918991027585166852}}
 			Uuid{u4{4637723655534580669,4815798633864556694}}
 		}
@@ -220,9 +262,11 @@ o
 		VarArray %ArgNames
 		{
 			s{"vImpulse"}
+			s{"uiImpulseType"}
 		}
 		VarArray %ArgTypes
 		{
+			u1{0}
 			u1{0}
 		}
 	}
@@ -242,6 +286,16 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezManipulatorAttribute"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{14958217006258665035,690358072931221741}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Value{0}
 	}
 }
 o
@@ -277,6 +331,24 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezComponent"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{6967669394581444225,1261545456310377889}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{7832908673972767009,8582614506276643933}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseColorTexture"}
+		s %Type{"ezStringView"}
 	}
 }
 o
@@ -366,9 +438,11 @@ o
 		VarArray %ArgNames
 		{
 			s{"vImpulse"}
+			s{"uiImpulseType"}
 		}
 		VarArray %ArgTypes
 		{
+			u1{0}
 			u1{0}
 		}
 	}
@@ -411,6 +485,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezExposedSceneProperty"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4480277756701344755,3122750415656630425}}
+	s %t{"ezFunctionArgumentDescriptor"}
+	u3 %v{1}
+	p
+	{
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Type{"ezUInt8"}
 	}
 }
 o
@@ -508,6 +593,68 @@ o
 }
 o
 {
+	Uuid %id{u4{3774587384740579185,3695365945540523376}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{16042029265769598148,11405978919055105991}}
+		}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"ezGameComponentsPlugin"}
+		VarArray %Properties
+		{
+			Uuid{u4{6902132715477760199,14929062528364786245}}
+		}
+		s %TypeName{"ezMeshDecalComponent"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5336344449290661074,4383793934612844372}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{4396885050006836836,11373936384696251049}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Index"}
+		s %Type{"ezUInt16"}
+	}
+}
+o
+{
+	Uuid %id{u4{9064688606274517541,4514156333772235209}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"ezGameComponentsPlugin"}
+		VarArray %Properties
+		{
+			Uuid{u4{5336344449290661074,4383793934612844372}}
+			Uuid{u4{6967669394581444225,1261545456310377889}}
+		}
+		s %TypeName{"ezMeshDecalDescription"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{9085939981889508946,4612025930380880638}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
@@ -544,6 +691,20 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Kinematic"}
 		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{16337583193817562798,4686003285916175886}}
+	s %t{"ezFunctionArgumentAttributes"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ArgAttributes
+		{
+			Uuid{u4{11000941240856164325,15082151704469256447}}
+		}
+		u3 %ArgIndex{1}
 	}
 }
 o
@@ -616,9 +777,9 @@ o
 	{
 		VarArray %ArgNames
 		{
-			s{"forceID"}
+			s{"uiForceID"}
 			s{"duration"}
-			s{"force"}
+			s{"vForce"}
 		}
 		VarArray %ArgTypes
 		{
@@ -745,7 +906,7 @@ o
 	{
 		VarArray %ArgNames
 		{
-			s{"forceID"}
+			s{"uiForceID"}
 		}
 		VarArray %ArgTypes
 		{
@@ -810,7 +971,7 @@ o
 			Uuid{u4{3225422539751733703,15467635098152158757}}
 		}
 		s %TypeName{"ezJoltDynamicActorComponent"}
-		u3 %TypeVersion{6}
+		u3 %TypeVersion{7}
 	}
 }
 o
@@ -840,6 +1001,18 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"WeightCategory"}
 		s %Type{"ezUInt8"}
+	}
+}
+o
+{
+	Uuid %id{u4{7832908673972767009,8582614506276643933}}
+	s %t{"ezAssetBrowserAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %DependencyFlags{"ezDependencyFlags::Package|ezDependencyFlags::Thumbnail"}
+		s %Filter{";CompatibleAsset_Texture_2D;"}
+		s %RequiredTag{""}
 	}
 }
 o
@@ -902,10 +1075,12 @@ o
 		VarArray %Arguments
 		{
 			Uuid{u4{6336723317049884733,6579878144043010185}}
+			Uuid{u4{4480277756701344755,3122750415656630425}}
 		}
 		VarArray %Attributes
 		{
 			Uuid{u4{5683086205581634420,2448255893199881040}}
+			Uuid{u4{12993606658877674130,12900577086516897735}}
 		}
 		s %Flags{"ezPropertyFlags::Phantom"}
 		s %Name{"AddAngularImpulse"}
@@ -928,6 +1103,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezSceneDocumentRoot"}
 		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{266995518533564983,9230344921036805643}}
+	s %t{"ezFunctionArgumentDescriptor"}
+	u3 %v{1}
+	p
+	{
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Type{"ezUInt8"}
 	}
 }
 o
@@ -1139,6 +1325,27 @@ o
 }
 o
 {
+	Uuid %id{u4{4396885050006836836,11373936384696251049}}
+	s %t{"ezClampValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Max{7}
+		i3 %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{16042029265769598148,11405978919055105991}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Effects"}
+	}
+}
+o
+{
 	Uuid %id{u4{14700230518358869173,11472901527618371423}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -1336,6 +1543,20 @@ o
 }
 o
 {
+	Uuid %id{u4{12993606658877674130,12900577086516897735}}
+	s %t{"ezFunctionArgumentAttributes"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ArgAttributes
+		{
+			Uuid{u4{14958217006258665035,690358072931221741}}
+		}
+		u3 %ArgIndex{1}
+	}
+}
+o
+{
 	Uuid %id{u4{4903960154749262079,14218359138397949918}}
 	s %t{"ezFunctionArgumentDescriptor"}
 	u3 %v{1}
@@ -1355,15 +1576,32 @@ o
 		VarArray %Arguments
 		{
 			Uuid{u4{14656959313833216783,11974093621308024724}}
+			Uuid{u4{266995518533564983,9230344921036805643}}
 		}
 		VarArray %Attributes
 		{
 			Uuid{u4{8848366910655626142,348363795862216714}}
+			Uuid{u4{16337583193817562798,4686003285916175886}}
 		}
 		s %Flags{"ezPropertyFlags::Phantom"}
 		s %Name{"AddLinearImpulse"}
 		Uuid %ReturnValue{u4{10916935353549710630,2962763290225888874}}
 		s %Type{"ezFunctionType::Member"}
+	}
+}
+o
+{
+	Uuid %id{u4{6902132715477760199,14929062528364786245}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Array"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::Class|ezPropertyFlags::Const|ezPropertyFlags::Reference|ezPropertyFlags::Phantom"}
+		s %Name{"Decals"}
+		s %Type{"ezMeshDecalDescription"}
 	}
 }
 o
@@ -1381,6 +1619,16 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezEnumBase"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11000941240856164325,15082151704469256447}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Value{0}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Scenes/Main.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Main.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{16544919359503455170}
+		u4 %Hash{11619025250165794949}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -2967,6 +2967,33 @@ o
 }
 o
 {
+	Uuid %id{u4{12453119127391467173,2646193055572563648}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17897274458903344021,2768165758929210051}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0000CC41,0x00008E41,0x0000B040}}
+		Quat %LocalRotation{f{0,0,0x9BBA4F3D,0xACAB7F3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{9006609991873646630,2654292609029922312}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -3141,6 +3168,19 @@ o
 		b %Active{1}
 		VarDict %Parameters{}
 		s %Prefab{"{ 41a909e4-0dbd-48ef-b6f3-a445bed9f62c }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{17897274458903344021,2768165758929210051}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ e12eff21-6f53-4b0e-8dc4-4e9f9852d224 }"}
 		b %ShowShapeIcons{0}
 	}
 }
@@ -8960,7 +9000,7 @@ o
 {
 	Uuid %id{u4{4419099002648726716,5164655309980221281}}
 	s %t{"ezJoltDynamicActorComponent"}
-	u3 %v{6}
+	u3 %v{7}
 	p
 	{
 		b %Active{1}
@@ -13542,7 +13582,7 @@ o
 {
 	Uuid %id{u4{7302054564858891172,5675878667142954405}}
 	s %t{"ezJoltRopeComponent"}
-	u3 %v{3}
+	u3 %v{4}
 	p
 	{
 		b %Active{1}
@@ -14657,7 +14697,6 @@ o
 			Uuid{u4{12438665485029124527,5129201294300623802}}
 			Uuid{u4{2181015070720445781,10192421347808571758}}
 			Uuid{u4{5163055760231073090,10383216202617316746}}
-			Uuid{u4{5893317176824952668,10294331358867511033}}
 			Uuid{u4{7859809441090412352,10003456440436560737}}
 			Uuid{u4{2852265507519394527,14776534576366115763}}
 			Uuid{u4{14440524914201477847,15586429732161026229}}
@@ -14860,6 +14899,7 @@ o
 			Uuid{u4{4656057195403548042,5480615887265037466}}
 			Uuid{u4{1549936818781279289,9940792065740930554}}
 			Uuid{u4{12171801923888789859,10002228581407278372}}
+			Uuid{u4{12453119127391467173,2646193055572563648}}
 		}
 		Uuid %Settings{u4{11204937990389899402,5417500911553874876}}
 	}
@@ -20020,33 +20060,6 @@ o
 }
 o
 {
-	Uuid %id{u4{5893317176824952668,10294331358867511033}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{11337472508336829516,10416304062224157436}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x0000CA41,0x00008E41,0x0000B040}}
-		Quat %LocalRotation{f{0,0,0x9BBA4F3D,0xACAB7F3F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"CastShadow"}
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{5953209187039697417,10298106454267859306}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -20796,19 +20809,6 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
-	}
-}
-o
-{
-	Uuid %id{u4{11337472508336829516,10416304062224157436}}
-	s %t{"ezPrefabReferenceComponent"}
-	u3 %v{4}
-	p
-	{
-		b %Active{1}
-		VarDict %Parameters{}
-		s %Prefab{"{ e12eff21-6f53-4b0e-8dc4-4e9f9852d224 }"}
-		b %ShowShapeIcons{0}
 	}
 }
 o
@@ -34164,9 +34164,11 @@ o
 		VarArray %ArgNames
 		{
 			s{"vImpulse"}
+			s{"uiImpulseType"}
 		}
 		VarArray %ArgTypes
 		{
+			u1{0}
 			u1{0}
 		}
 	}
@@ -34206,6 +34208,16 @@ o
 	p
 	{
 		f %Value{0x0000A040}
+	}
+}
+o
+{
+	Uuid %id{u4{14958217006258665035,690358072931221741}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Value{0}
 	}
 }
 o
@@ -34592,9 +34604,11 @@ o
 		VarArray %ArgNames
 		{
 			s{"vImpulse"}
+			s{"uiImpulseType"}
 		}
 		VarArray %ArgTypes
 		{
+			u1{0}
 			u1{0}
 		}
 	}
@@ -34705,6 +34719,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezVolumeComponent"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4480277756701344755,3122750415656630425}}
+	s %t{"ezFunctionArgumentDescriptor"}
+	u3 %v{1}
+	p
+	{
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Type{"ezUInt8"}
 	}
 }
 o
@@ -34935,6 +34960,20 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Kinematic"}
 		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{16337583193817562798,4686003285916175886}}
+	s %t{"ezFunctionArgumentAttributes"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ArgAttributes
+		{
+			Uuid{u4{11000941240856164325,15082151704469256447}}
+		}
+		u3 %ArgIndex{1}
 	}
 }
 o
@@ -35276,9 +35315,9 @@ o
 	{
 		VarArray %ArgNames
 		{
-			s{"forceID"}
+			s{"uiForceID"}
 			s{"duration"}
-			s{"force"}
+			s{"vForce"}
 		}
 		VarArray %ArgTypes
 		{
@@ -35596,7 +35635,7 @@ o
 	{
 		VarArray %ArgNames
 		{
-			s{"forceID"}
+			s{"uiForceID"}
 		}
 		VarArray %ArgTypes
 		{
@@ -35676,7 +35715,7 @@ o
 			Uuid{u4{3225422539751733703,15467635098152158757}}
 		}
 		s %TypeName{"ezJoltDynamicActorComponent"}
-		u3 %TypeVersion{6}
+		u3 %TypeVersion{7}
 	}
 }
 o
@@ -35964,10 +36003,12 @@ o
 		VarArray %Arguments
 		{
 			Uuid{u4{6336723317049884733,6579878144043010185}}
+			Uuid{u4{4480277756701344755,3122750415656630425}}
 		}
 		VarArray %Attributes
 		{
 			Uuid{u4{5683086205581634420,2448255893199881040}}
+			Uuid{u4{12993606658877674130,12900577086516897735}}
 		}
 		s %Flags{"ezPropertyFlags::Phantom"}
 		s %Name{"AddAngularImpulse"}
@@ -36034,6 +36075,17 @@ o
 		VarArray %Properties{}
 		s %TypeName{"ezLensFlareComponent"}
 		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{266995518533564983,9230344921036805643}}
+	s %t{"ezFunctionArgumentDescriptor"}
+	u3 %v{1}
+	p
+	{
+		s %Flags{"ezPropertyFlags::StandardType"}
+		s %Type{"ezUInt8"}
 	}
 }
 o
@@ -36525,7 +36577,7 @@ o
 			Uuid{u4{7676408644121109562,7468477203766939121}}
 		}
 		s %TypeName{"ezJoltRopeComponent"}
-		u3 %TypeVersion{3}
+		u3 %TypeVersion{4}
 	}
 }
 o
@@ -37173,6 +37225,20 @@ o
 }
 o
 {
+	Uuid %id{u4{12993606658877674130,12900577086516897735}}
+	s %t{"ezFunctionArgumentAttributes"}
+	u3 %v{1}
+	p
+	{
+		VarArray %ArgAttributes
+		{
+			Uuid{u4{14958217006258665035,690358072931221741}}
+		}
+		u3 %ArgIndex{1}
+	}
+}
+o
+{
 	Uuid %id{u4{8133212801983337177,13151094094623123205}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -37451,10 +37517,12 @@ o
 		VarArray %Arguments
 		{
 			Uuid{u4{14656959313833216783,11974093621308024724}}
+			Uuid{u4{266995518533564983,9230344921036805643}}
 		}
 		VarArray %Attributes
 		{
 			Uuid{u4{8848366910655626142,348363795862216714}}
+			Uuid{u4{16337583193817562798,4686003285916175886}}
 		}
 		s %Flags{"ezPropertyFlags::Phantom"}
 		s %Name{"AddLinearImpulse"}
@@ -37547,6 +37615,16 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
 		s %Name{"ezClothSheetFlags::FixedCornerTopRight"}
 		s %Type{"ezUInt16"}
+	}
+}
+o
+{
+	Uuid %id{u4{11000941240856164325,15082151704469256447}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		i3 %Value{0}
 	}
 }
 o

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: 173AC3EB-90F3-23D5-874C-D71Fd4CAFB0A69C9ABC
+Change me: 6AD776C0-E2B6-4A6B-910A-8D23FD19E26F


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/95f9614b-7cc2-48d7-ac32-bf663a49c451)

Mesh decals aka floaters or floating geometry is often used to add details to meshes without complicating the underlying geometry and uv mapping. 
This PR adds a sample shader that uses a depth offset to ensure floaters are always rendered on top of the underlying geometry. The depth offset is in depth units so there won't be any z-fighting even when viewed from far away. 
Furthermore the sample shader utilizes the runtime decal atlas to allow variation between mesh instances with increasing the number of draw calls. The shader works in tandem with the mesh decal component which allows the user to select arbitrary textures that will then be put into the runtime decal atlas. The component feeds the runtime decal indices as custom data per instance to the shader.
The shader uses the integer part of the UV coordinates to identify which decal slot should be used. There can be up to 8 slots per mesh:

![image](https://github.com/user-attachments/assets/0a58544f-71ca-46ab-85c7-9580f38bf44f)

The sample shader only supports base color from the runtime decal atlas and an additional alpha texture per material. The shader and also the component is meant as a starting point and can be customized to the individual needs of the user.
