### PR TITLE
Bind Group Layout and Pipeline Layout Resources

### DIFF
--- a/Code/BuildSystem/CMake/Platforms/Configure_Android.cmake
+++ b/Code/BuildSystem/CMake/Platforms/Configure_Android.cmake
@@ -68,19 +68,24 @@ macro(ez_platformhook_set_build_flags_clang TARGET_NAME)
 endmacro()
 
 macro(ez_platformhook_find_vulkan)
+
+	# As we are cross compiling, CMake assumes every path to be located under the Android NDK root. This is not the case for external libraries like the Vulkan SDK, so we need to clear the sysroot and find root path.
+	set(CMAKE_FIND_ROOT_PATH "")
+	set(CMAKE_SYSROOT "")
+
 	if(EZ_CMAKE_ARCHITECTURE_64BIT)
 		if((EZ_VULKAN_DIR STREQUAL "EZ_VULKAN_DIR-NOTFOUND") OR(EZ_VULKAN_DIR STREQUAL ""))
 			#set(CMAKE_FIND_DEBUG_MODE TRUE)
 			unset(EZ_VULKAN_DIR CACHE)
 			unset(EzVulkan_DIR CACHE)
 			set(EZ_SHARED_VULKAN_DIR "${EZ_ROOT}/Workspace/shared/vulkan-sdk/${EZ_CONFIG_VULKAN_SDK_LINUXX64_VERSION}")
-			# Have to add `NO_DEFAULT_PATH` here or CMake prefixes every path with the Android NDK root.
-			find_path(EZ_VULKAN_DIR config/vk_layer_settings.txt NO_DEFAULT_PATH
+			find_path(EZ_VULKAN_DIR config/vk_layer_settings.txt
 					PATHS
 					${EZ_SHARED_VULKAN_DIR}
 					${EZ_VULKAN_DIR}
 					$ENV{VULKAN_SDK}
 			)
+			#set(CMAKE_FIND_DEBUG_MODE FALSE)
 
 			if((EZ_VULKAN_DIR STREQUAL "EZ_VULKAN_DIR-NOTFOUND") OR (EZ_VULKAN_DIR STREQUAL ""))
 				# When cross-compiling on windows, we assume the env var VULKAN_SDK is set so the previous find_path call should have succeeded.
@@ -112,14 +117,30 @@ macro(ez_platformhook_find_vulkan)
 
 	# Download prebuilt VkLayer_khronos_validation for Android
 	if((EZ_VULKAN_VALIDATIONLAYERS_DIR STREQUAL "EZ_VULKAN_VALIDATIONLAYERS_DIR-NOTFOUND") OR (EZ_VULKAN_VALIDATIONLAYERS_DIR STREQUAL ""))
-		ez_download_and_extract("${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_ANDROID_URL}" "${CMAKE_BINARY_DIR}/vulkan-sdk" "vulkan-layers-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}")
-		ez_create_link("${CMAKE_BINARY_DIR}/vulkan-sdk/android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}" "${EZ_ROOT}/Workspace/shared/vulkan-sdk/" "android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}")
-		set(EZ_VULKAN_VALIDATIONLAYERS_DIR "${EZ_ROOT}/Workspace/shared/vulkan-sdk/android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}" CACHE PATH "Directory of the Vulkan Validation Layers" FORCE)
-
-		find_path(EZ_VULKAN_VALIDATIONLAYERS_DIR arm64-v8a/libVkLayer_khronos_validation.so NO_DEFAULT_PATH
-			PATHS
-			${EZ_VULKAN_VALIDATIONLAYERS_DIR}
+		
+		set(EZ_SHARED_VULKAN_VALIDATIONLAYERS_DIR "${EZ_ROOT}/Workspace/shared/vulkan-sdk/android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}")
+		
+		#set(CMAKE_FIND_DEBUG_MODE TRUE)
+		unset(EZ_VULKAN_VALIDATIONLAYERS_DIR CACHE)
+		find_path(EZ_VULKAN_VALIDATIONLAYERS_DIR
+				NAMES arm64-v8a/libVkLayer_khronos_validation.so
+				NO_DEFAULT_PATH
+				HINTS
+				${EZ_SHARED_VULKAN_VALIDATIONLAYERS_DIR}
+				${EZ_VULKAN_VALIDATIONLAYERS_DIR}
 		)
+		#set(CMAKE_FIND_DEBUG_MODE FALSE)
+		if((EZ_VULKAN_VALIDATIONLAYERS_DIR STREQUAL "EZ_VULKAN_VALIDATIONLAYERS_DIR-NOTFOUND") OR (EZ_VULKAN_VALIDATIONLAYERS_DIR STREQUAL ""))
+			ez_download_and_extract("${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_ANDROID_URL}" "${CMAKE_BINARY_DIR}/vulkan-sdk" "vulkan-layers-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}")
+			ez_create_link("${CMAKE_BINARY_DIR}/vulkan-sdk/android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}" "${EZ_ROOT}/Workspace/shared/vulkan-sdk/" "android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}")
+			set(EZ_VULKAN_VALIDATIONLAYERS_DIR "${EZ_ROOT}/Workspace/shared/vulkan-sdk/android-binaries-${EZ_CONFIG_VULKAN_VALIDATIONLAYERS_VERSION}" CACHE PATH "Directory of the Vulkan Validation Layers" FORCE)
+
+			find_path(EZ_VULKAN_VALIDATIONLAYERS_DIR arm64-v8a/libVkLayer_khronos_validation.so NO_DEFAULT_PATH
+				PATHS
+				${EZ_SHARED_VULKAN_VALIDATIONLAYERS_DIR}
+				${EZ_VULKAN_VALIDATIONLAYERS_DIR}
+			)
+		endif()
 	endif()
 
 	include(FindPackageHandleStandardArgs)

--- a/Code/BuildSystem/CMake/Platforms/Configure_Android.cmake
+++ b/Code/BuildSystem/CMake/Platforms/Configure_Android.cmake
@@ -70,6 +70,8 @@ endmacro()
 macro(ez_platformhook_find_vulkan)
 
 	# As we are cross compiling, CMake assumes every path to be located under the Android NDK root. This is not the case for external libraries like the Vulkan SDK, so we need to clear the sysroot and find root path.
+	set(backup_CMAKE_FIND_ROOT_PATH ${CMAKE_FIND_ROOT_PATH})
+	set(backup_CMAKE_SYSROOT ${CMAKE_SYSROOT})
 	set(CMAKE_FIND_ROOT_PATH "")
 	set(CMAKE_SYSROOT "")
 
@@ -142,6 +144,9 @@ macro(ez_platformhook_find_vulkan)
 			)
 		endif()
 	endif()
+
+	set(CMAKE_FIND_ROOT_PATH ${backup_CMAKE_FIND_ROOT_PATH})
+	set(CMAKE_SYSROOT ${backup_CMAKE_SYSROOT})
 
 	include(FindPackageHandleStandardArgs)
 	find_package_handle_standard_args(EzVulkan DEFAULT_MSG EZ_VULKAN_DIR)

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <Foundation/Types/Bitflags.h>
@@ -89,6 +88,12 @@ protected:
 
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) override;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
+
+  virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) override;
+  virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) override;
+
+  virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) override;
+  virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) override;
 
   virtual ezGALGraphicsPipeline* CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description) override;
   virtual void DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline) override;

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -26,6 +26,8 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Profiling/Profiling.h>
+#include <RendererDX11/Shader/BindGroupLayoutDX11.h>
+#include <RendererDX11/Shader/PipelineLayoutDX11.h>
 
 #include <d3d11.h>
 #include <d3d11_3.h>
@@ -445,6 +447,50 @@ void ezGALDeviceDX11::DestroySamplerStatePlatform(ezGALSamplerState* pSamplerSta
   ezGALSamplerStateDX11* pDX11SamplerState = static_cast<ezGALSamplerStateDX11*>(pSamplerState);
   pDX11SamplerState->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pDX11SamplerState);
+}
+
+ezGALBindGroupLayout* ezGALDeviceDX11::CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description)
+{
+  ezGALBindGroupLayoutDX11* pDX11BindGroupLayout = EZ_NEW(&m_Allocator, ezGALBindGroupLayoutDX11, Description);
+
+  if (pDX11BindGroupLayout->InitPlatform(this).Succeeded())
+  {
+    return pDX11BindGroupLayout;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pDX11BindGroupLayout);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceDX11::DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout)
+{
+  ezGALBindGroupLayoutDX11* pDX11BindGroupLayout = static_cast<ezGALBindGroupLayoutDX11*>(pBindGroupLayout);
+  pDX11BindGroupLayout->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pDX11BindGroupLayout);
+}
+
+ezGALPipelineLayout* ezGALDeviceDX11::CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description)
+{
+  ezGALPipelineLayoutDX11* pDX11PipelineLayout = EZ_NEW(&m_Allocator, ezGALPipelineLayoutDX11, Description);
+
+  if (pDX11PipelineLayout->InitPlatform(this).Succeeded())
+  {
+    return pDX11PipelineLayout;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pDX11PipelineLayout);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceDX11::DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout)
+{
+  ezGALPipelineLayoutDX11* pDX11PipelineLayout = static_cast<ezGALPipelineLayoutDX11*>(pPipelineLayout);
+  pDX11PipelineLayout->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pDX11PipelineLayout);
 }
 
 ezGALGraphicsPipeline* ezGALDeviceDX11::CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description)

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -18,6 +18,8 @@
 #include <RendererDX11/Resources/SharedTextureDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
 #include <RendererDX11/Resources/UnorderedAccessViewDX11.h>
+#include <RendererDX11/Shader/BindGroupLayoutDX11.h>
+#include <RendererDX11/Shader/PipelineLayoutDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
 #include <RendererDX11/State/ComputePipelineDX11.h>
@@ -26,8 +28,6 @@
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Profiling/Profiling.h>
-#include <RendererDX11/Shader/BindGroupLayoutDX11.h>
-#include <RendererDX11/Shader/PipelineLayoutDX11.h>
 
 #include <d3d11.h>
 #include <d3d11_3.h>

--- a/Code/Engine/RendererDX11/Shader/BindGroupLayoutDX11.h
+++ b/Code/Engine/RendererDX11/Shader/BindGroupLayoutDX11.h
@@ -1,0 +1,24 @@
+
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
+#include <RendererDX11/RendererDX11DLL.h>
+
+class ezGALBindGroupLayoutDX11 : public ezGALBindGroupLayout
+{
+public:
+
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  ezGALBindGroupLayoutDX11(const ezGALBindGroupLayoutCreationDescription& Description);
+
+  virtual ~ezGALBindGroupLayoutDX11();
+
+};
+

--- a/Code/Engine/RendererDX11/Shader/BindGroupLayoutDX11.h
+++ b/Code/Engine/RendererDX11/Shader/BindGroupLayoutDX11.h
@@ -1,14 +1,13 @@
 
 #pragma once
 
+#include <RendererDX11/RendererDX11DLL.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Shader/BindGroupLayout.h>
-#include <RendererDX11/RendererDX11DLL.h>
 
 class ezGALBindGroupLayoutDX11 : public ezGALBindGroupLayout
 {
 public:
-
 protected:
   friend class ezGALDeviceDX11;
   friend class ezMemoryUtils;
@@ -19,6 +18,4 @@ protected:
   ezGALBindGroupLayoutDX11(const ezGALBindGroupLayoutCreationDescription& Description);
 
   virtual ~ezGALBindGroupLayoutDX11();
-
 };
-

--- a/Code/Engine/RendererDX11/Shader/Implementation/BindGroupLayoutDX11.cpp
+++ b/Code/Engine/RendererDX11/Shader/Implementation/BindGroupLayoutDX11.cpp
@@ -1,0 +1,21 @@
+#include <RendererDX11/RendererDX11PCH.h>
+
+#include <RendererDX11/Device/DeviceDX11.h>
+#include <RendererDX11/Shader/BindGroupLayoutDX11.h>
+
+ezGALBindGroupLayoutDX11::ezGALBindGroupLayoutDX11(const ezGALBindGroupLayoutCreationDescription& Description)
+  : ezGALBindGroupLayout(Description)
+{
+}
+
+ezGALBindGroupLayoutDX11::~ezGALBindGroupLayoutDX11() = default;
+
+ezResult ezGALBindGroupLayoutDX11::InitPlatform(ezGALDevice*)
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALBindGroupLayoutDX11::DeInitPlatform(ezGALDevice*)
+{
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/RendererDX11/Shader/Implementation/PipelineLayoutDX11.cpp
+++ b/Code/Engine/RendererDX11/Shader/Implementation/PipelineLayoutDX11.cpp
@@ -1,0 +1,21 @@
+#include <RendererDX11/RendererDX11PCH.h>
+
+#include <RendererDX11/Device/DeviceDX11.h>
+#include <RendererDX11/Shader/PipelineLayoutDX11.h>
+
+ezGALPipelineLayoutDX11::ezGALPipelineLayoutDX11(const ezGALPipelineLayoutCreationDescription& Description)
+  : ezGALPipelineLayout(Description)
+{
+}
+
+ezGALPipelineLayoutDX11::~ezGALPipelineLayoutDX11() = default;
+
+ezResult ezGALPipelineLayoutDX11::InitPlatform(ezGALDevice*)
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALPipelineLayoutDX11::DeInitPlatform(ezGALDevice*)
+{
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/RendererDX11/Shader/Implementation/ShaderDX11.cpp
+++ b/Code/Engine/RendererDX11/Shader/Implementation/ShaderDX11.cpp
@@ -51,7 +51,9 @@ void ezGALShaderDX11::SetDebugName(ezStringView sName) const
 
 ezResult ezGALShaderDX11::InitPlatform(ezGALDevice* pDevice)
 {
+  m_pDevice = pDevice;
   EZ_SUCCEED_OR_RETURN(CreateBindingMapping(true));
+  EZ_SUCCEED_OR_RETURN(CreateLayouts(pDevice, false));
 
   ezGALDeviceDX11* pDXDevice = static_cast<ezGALDeviceDX11*>(pDevice);
   ID3D11Device* pD3D11Device = pDXDevice->GetDXDevice();
@@ -122,9 +124,9 @@ ezResult ezGALShaderDX11::InitPlatform(ezGALDevice* pDevice)
 
 ezResult ezGALShaderDX11::DeInitPlatform(ezGALDevice* pDevice)
 {
-  EZ_IGNORE_UNUSED(pDevice);
-
   DestroyBindingMapping();
+  DestroyLayouts(pDevice);
+
   EZ_GAL_DX11_RELEASE(m_pVertexShader);
   EZ_GAL_DX11_RELEASE(m_pHullShader);
   EZ_GAL_DX11_RELEASE(m_pDomainShader);

--- a/Code/Engine/RendererDX11/Shader/PipelineLayoutDX11.h
+++ b/Code/Engine/RendererDX11/Shader/PipelineLayoutDX11.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/PipelineLayout.h>
+#include <RendererDX11/RendererDX11DLL.h>
+
+class ezGALPipelineLayoutDX11 : public ezGALPipelineLayout
+{
+public:
+
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  ezGALPipelineLayoutDX11(const ezGALPipelineLayoutCreationDescription& Description);
+
+  virtual ~ezGALPipelineLayoutDX11();
+
+};

--- a/Code/Engine/RendererDX11/Shader/PipelineLayoutDX11.h
+++ b/Code/Engine/RendererDX11/Shader/PipelineLayoutDX11.h
@@ -1,13 +1,12 @@
 #pragma once
 
+#include <RendererDX11/RendererDX11DLL.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Shader/PipelineLayout.h>
-#include <RendererDX11/RendererDX11DLL.h>
 
 class ezGALPipelineLayoutDX11 : public ezGALPipelineLayout
 {
 public:
-
 protected:
   friend class ezGALDeviceDX11;
   friend class ezMemoryUtils;
@@ -18,5 +17,4 @@ protected:
   ezGALPipelineLayoutDX11(const ezGALPipelineLayoutCreationDescription& Description);
 
   virtual ~ezGALPipelineLayoutDX11();
-
 };

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -15,6 +15,33 @@
 
 class ezWindowBase;
 
+/// \brief Bind group layout for a single set.
+/// Auto created by shader resource. Mostly used to quickly determine if a bind group still matches after e.g. switching the shader.
+struct ezGALBindGroupLayoutCreationDescription
+{
+  ezUInt32 CalculateHash() const;
+
+  ezDynamicArray<ezShaderResourceBinding> m_ResourceBindings; ///< Must be sorted by m_iSlot. m_iSet must be the same for all bindings in this array.
+  ezHybridArray<ezShaderResourceBinding, 1> m_ImmutableSamplers; ///< If supported by the platform, contains immutable samplers. See ezGALImmutableSamplers.
+};
+
+/// \brief Push constant info
+/// Used by ezGALPipelineLayoutCreationDescription.
+struct ezGALPushConstant
+{
+  ezUInt16 m_uiSize = 0;
+  ezUInt16 m_uiOffset = 0;
+  ezBitflags<ezGALShaderStageFlags> m_Stages;
+};
+
+/// \brief Pipeline layout.
+/// Auto created by shader resource. Mostly used for de-duplication of native resources in case pipelines share the same layout.
+struct ezGALPipelineLayoutCreationDescription : public ezHashableStruct<ezGALPipelineLayoutCreationDescription>
+{
+  ezGALBindGroupLayoutHandle m_BindGroups[EZ_GAL_MAX_SETS]; ///< One for each set used in the shader. SET_FRAME, SET_RENDER_PASS, SET_MATERIAL, SET_DRAW_CALL.
+  ezGALPushConstant m_PushConstants; ///< Only one push constant block is supported right now.
+};
+
 /// \brief Defines the complete state of a graphics pipeline, excluding bound resources (e.g. textures, buffers) and dynamic states (e.g. viewport).
 /// All handles must be set except for m_hVertexDeclaration which is optional. Creating a graphics pipeline increases the reference count on all valid handles.
 struct ezGALGraphicsPipelineCreationDescription : public ezHashableStruct<ezGALGraphicsPipelineCreationDescription>

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -21,7 +21,7 @@ struct ezGALBindGroupLayoutCreationDescription
 {
   ezUInt32 CalculateHash() const;
 
-  ezDynamicArray<ezShaderResourceBinding> m_ResourceBindings; ///< Must be sorted by m_iSlot. m_iSet must be the same for all bindings in this array.
+  ezDynamicArray<ezShaderResourceBinding> m_ResourceBindings;    ///< Must be sorted by m_iSlot. m_iSet must be the same for all bindings in this array.
   ezHybridArray<ezShaderResourceBinding, 1> m_ImmutableSamplers; ///< If supported by the platform, contains immutable samplers. See ezGALImmutableSamplers.
 };
 
@@ -39,7 +39,7 @@ struct ezGALPushConstant
 struct ezGALPipelineLayoutCreationDescription : public ezHashableStruct<ezGALPipelineLayoutCreationDescription>
 {
   ezGALBindGroupLayoutHandle m_BindGroups[EZ_GAL_MAX_SETS]; ///< One for each set used in the shader. SET_FRAME, SET_RENDER_PASS, SET_MATERIAL, SET_DRAW_CALL.
-  ezGALPushConstant m_PushConstants; ///< Only one push constant block is supported right now.
+  ezGALPushConstant m_PushConstants;                        ///< Only one push constant block is supported right now.
 };
 
 /// \brief Defines the complete state of a graphics pipeline, excluding bound resources (e.g. textures, buffers) and dynamic states (e.g. viewport).

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
@@ -1,0 +1,32 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <Foundation/Algorithm/HashStream.h>
+#include <RendererFoundation/Descriptors/Descriptors.h>
+
+ezUInt32 ezGALBindGroupLayoutCreationDescription::CalculateHash() const
+{
+  ezHashStreamWriter32 writer;
+  for (const ezShaderResourceBinding& binding : m_ResourceBindings)
+  {
+    writer << binding.m_ResourceType.GetValue();
+    writer << binding.m_TextureType.GetValue();
+    writer << binding.m_Stages.GetValue();
+    writer << binding.m_iSet;
+    writer << binding.m_iSlot;
+    writer << binding.m_uiArraySize;
+    writer << binding.m_sName;
+    if (binding.m_pLayout != nullptr)
+    {
+      const ezShaderConstantBufferLayout* pLayout = binding.m_pLayout;
+      writer << pLayout->m_uiTotalSize;
+      for (const ezShaderConstant& constant : pLayout->m_Constants)
+      {
+        writer << constant.m_sName;
+        writer << constant.m_Type.GetValue();
+        writer << constant.m_uiArrayElements;
+        writer << constant.m_uiOffset;
+      }
+    }
+  }
+  return writer.GetHashValue();
+}

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -416,7 +416,7 @@ protected:
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) = 0;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) = 0;
-  
+
   virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) = 0;
   virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) = 0;
 

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <Foundation/Containers/HashTable.h>
@@ -49,6 +48,12 @@ public:
 
   ezGALSamplerStateHandle CreateSamplerState(const ezGALSamplerStateCreationDescription& description);
   void DestroySamplerState(ezGALSamplerStateHandle hSamplerState);
+
+  ezGALBindGroupLayoutHandle CreateBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& description);
+  void DestroyBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout);
+
+  ezGALPipelineLayoutHandle CreatePipelineLayout(const ezGALPipelineLayoutCreationDescription& description);
+  void DestroyPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout);
 
   ezGALGraphicsPipelineHandle CreateGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& description);
   void DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline);
@@ -221,6 +226,8 @@ public:
   const ezGALRasterizerState* GetRasterizerState(ezGALRasterizerStateHandle hRasterizerState) const;
   const ezGALVertexDeclaration* GetVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration) const;
   const ezGALSamplerState* GetSamplerState(ezGALSamplerStateHandle hSamplerState) const;
+  const ezGALBindGroupLayout* GetBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout) const;
+  const ezGALPipelineLayout* GetPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout) const;
   const ezGALGraphicsPipeline* GetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline) const;
   const ezGALComputePipeline* GetComputePipeline(ezGALComputePipelineHandle hComputePipeline) const;
   const ezGALTextureResourceView* GetResourceView(ezGALTextureResourceViewHandle hResourceView) const;
@@ -288,6 +295,13 @@ protected:
   template <typename View, typename Handle, typename ViewTable>
   void DestroyView(Handle hView, ViewTable& table, ezUInt32 galObjectType);
 
+  template <typename Handle, typename Resource, typename Table, typename CacheTable>
+  Handle TryGetHashedResource(ezUInt32 uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
+  template <typename Handle, typename Resource, typename Table, typename CacheTable>
+  Handle InsertHashedResource(ezUInt32 uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter);
+  template <typename Resource, typename Handle, typename Table>
+  void DestroyHashedResource(Handle hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
+
   ezProxyAllocator m_Allocator;
   ezLocalAllocatorWrapper m_AllocatorWrapper;
 
@@ -308,6 +322,8 @@ protected:
   using BufferUnorderedAccessViewTable = ezIdTable<ezGALBufferUnorderedAccessViewHandle::IdType, ezGALBufferUnorderedAccessView*, ezLocalAllocatorWrapper>;
   using SwapChainTable = ezIdTable<ezGALSwapChainHandle::IdType, ezGALSwapChain*, ezLocalAllocatorWrapper>;
   using VertexDeclarationTable = ezIdTable<ezGALVertexDeclarationHandle::IdType, ezGALVertexDeclaration*, ezLocalAllocatorWrapper>;
+  using BindGroupLayoutTable = ezIdTable<ezGALBindGroupLayoutHandle::IdType, ezGALBindGroupLayout*, ezLocalAllocatorWrapper>;
+  using PipelineLayoutTable = ezIdTable<ezGALPipelineLayoutHandle::IdType, ezGALPipelineLayout*, ezLocalAllocatorWrapper>;
   using GraphicsPipelineTable = ezIdTable<ezGALGraphicsPipelineHandle::IdType, ezGALGraphicsPipeline*, ezLocalAllocatorWrapper>;
   using ComputePipelineTable = ezIdTable<ezGALComputePipelineHandle::IdType, ezGALComputePipeline*, ezLocalAllocatorWrapper>;
 
@@ -316,9 +332,11 @@ protected:
   BlendStateTable m_BlendStates;
   DepthStencilStateTable m_DepthStencilStates;
   RasterizerStateTable m_RasterizerStates;
+  SamplerStateTable m_SamplerStates;
+  BindGroupLayoutTable m_BindGroupLayouts;
+  PipelineLayoutTable m_PipelineLayouts;
   GraphicsPipelineTable m_GraphicsPipelines;
   ComputePipelineTable m_ComputePipelines;
-  SamplerStateTable m_SamplerStates;
 
   BufferTable m_Buffers;
   DynamicBufferTable m_DynamicBuffers;
@@ -338,9 +356,11 @@ protected:
   ezHashTable<ezUInt32, ezGALBlendStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_BlendStateTable;
   ezHashTable<ezUInt32, ezGALDepthStencilStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_DepthStencilStateTable;
   ezHashTable<ezUInt32, ezGALRasterizerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_RasterizerStateTable;
+  ezHashTable<ezUInt32, ezGALSamplerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_SamplerStateTable;
+  ezHashTable<ezUInt32, ezGALBindGroupLayoutHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_BindGroupLayoutTable;
+  ezHashTable<ezUInt32, ezGALPipelineLayoutHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_PipelineLayoutTable;
   ezHashTable<ezUInt32, ezGALGraphicsPipelineHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_GraphicsPipelineTable;
   ezHashTable<ezUInt32, ezGALComputePipelineHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_ComputePipelineTable;
-  ezHashTable<ezUInt32, ezGALSamplerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_SamplerStateTable;
 
   struct DeadObject
   {
@@ -393,6 +413,12 @@ protected:
 
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) = 0;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) = 0;
+
+  virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) = 0;
+  virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) = 0;
+  
+  virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) = 0;
+  virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) = 0;
 
   virtual ezGALGraphicsPipeline* CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description) = 0;
   virtual void DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline) = 0;
@@ -482,9 +508,11 @@ private:
   ezUInt32 m_uiBlendStates = 0;
   ezUInt32 m_uiDepthStencilStates = 0;
   ezUInt32 m_uiRasterizerStates = 0;
+  ezUInt32 m_uiSamplerStates = 0;
+  ezUInt32 m_uiBindGroupLayouts = 0;
+  ezUInt32 m_uiPipelineLayouts = 0;
   ezUInt32 m_uiGraphicsPipelines = 0;
   ezUInt32 m_uiComputePipelines = 0;
-  ezUInt32 m_uiSamplerStates = 0;
   ezGALCommandEncoderStats m_EncoderStats;
 };
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -130,7 +130,7 @@ ezGALDevice::~ezGALDevice()
 
     if (!m_BindGroupLayouts.IsEmpty())
       ezLog::Warning("{0} bind group layouts have not been cleaned up", m_BindGroupLayouts.GetCount());
-    
+
     if (!m_PipelineLayouts.IsEmpty())
       ezLog::Warning("{0} pipeline layouts have not been cleaned up", m_PipelineLayouts.GetCount());
 

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -15,6 +15,8 @@
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Resources/ResourceView.h>
 #include <RendererFoundation/Resources/UnorderedAccesView.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
+#include <RendererFoundation/Shader/PipelineLayout.h>
 #include <RendererFoundation/Shader/Shader.h>
 #include <RendererFoundation/Shader/VertexDeclaration.h>
 #include <RendererFoundation/State/ComputePipeline.h>
@@ -44,8 +46,10 @@ namespace
       BufferUnorderedAccessView,
       SwapChain,
       VertexDeclaration,
+      BindGroupLayout,
+      PipelineLayout,
       GraphicsPipeline,
-      ComputePipeline
+      ComputePipeline,
     };
   };
 
@@ -63,6 +67,8 @@ namespace
   static_assert(sizeof(ezGALBufferUnorderedAccessViewHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALSwapChainHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALVertexDeclarationHandle) == sizeof(ezUInt32));
+  static_assert(sizeof(ezGALBindGroupLayoutHandle) == sizeof(ezUInt32));
+  static_assert(sizeof(ezGALPipelineLayoutHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALGraphicsPipelineHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALComputePipelineHandle) == sizeof(ezUInt32));
 } // namespace
@@ -121,6 +127,12 @@ ezGALDevice::~ezGALDevice()
 
     if (!m_VertexDeclarations.IsEmpty())
       ezLog::Warning("{0} vertex declarations have not been cleaned up", m_VertexDeclarations.GetCount());
+
+    if (!m_BindGroupLayouts.IsEmpty())
+      ezLog::Warning("{0} bind group layouts have not been cleaned up", m_BindGroupLayouts.GetCount());
+    
+    if (!m_PipelineLayouts.IsEmpty())
+      ezLog::Warning("{0} pipeline layouts have not been cleaned up", m_PipelineLayouts.GetCount());
 
     if (!m_GraphicsPipelines.IsEmpty())
       ezLog::Warning("{0} graphics pipelines have not been cleaned up", m_GraphicsPipelines.GetCount());
@@ -196,9 +208,11 @@ ezResult ezGALDevice::Shutdown()
   EZ_ASSERT_DEBUG(m_uiBlendStates == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiDepthStencilStates == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiRasterizerStates == 0, "Error in counting deduplicated GAL resources");
+  EZ_ASSERT_DEBUG(m_uiSamplerStates == 0, "Error in counting deduplicated GAL resources");
+  EZ_ASSERT_DEBUG(m_uiBindGroupLayouts == 0, "Error in counting deduplicated GAL resources");
+  EZ_ASSERT_DEBUG(m_uiPipelineLayouts == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiGraphicsPipelines == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiComputePipelines == 0, "Error in counting deduplicated GAL resources");
-  EZ_ASSERT_DEBUG(m_uiSamplerStates == 0, "Error in counting deduplicated GAL resources");
 
   return ShutdownPlatform();
 }
@@ -262,258 +276,173 @@ void ezGALDevice::EndCommands(ezGALCommandEncoder* pCommandEncoder)
   }
 }
 
-ezGALBlendStateHandle ezGALDevice::CreateBlendState(const ezGALBlendStateCreationDescription& desc)
+template <typename Handle, typename Resource, typename Table, typename CacheTable>
+Handle ezGALDevice::TryGetHashedResource(ezUInt32 uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter)
 {
-  EZ_GALDEVICE_LOCK_AND_CHECK();
-
-  // Hash desc and return potential existing one (including inc. refcount)
-  ezUInt32 uiHash = desc.CalculateHash();
-
+  Handle hResource;
+  if (cacheTable.TryGetValue(uiHash, hResource))
   {
-    ezGALBlendStateHandle hBlendState;
-    if (m_BlendStateTable.TryGetValue(uiHash, hBlendState))
+    Resource* pResource = table[hResource];
+    if (pResource->GetRefCount() == 0)
     {
-      ezGALBlendState* pBlendState = m_BlendStates[hBlendState];
-      if (pBlendState->GetRefCount() == 0)
-      {
-        ReviveDeadObject(GALObjectType::BlendState, hBlendState);
-      }
-
-      pBlendState->AddRef();
-      m_uiBlendStates++;
-      return hBlendState;
+      ReviveDeadObject(galObjectType, hResource);
     }
+
+    pResource->AddRef();
+    ref_uiCounter++;
+    return hResource;
   }
-
-  ezGALBlendState* pBlendState = CreateBlendStatePlatform(desc);
-
-  if (pBlendState != nullptr)
-  {
-    EZ_ASSERT_DEBUG(pBlendState->GetDescription().CalculateHash() == uiHash, "BlendState hash doesn't match");
-
-    pBlendState->AddRef();
-    m_uiBlendStates++;
-
-    ezGALBlendStateHandle hBlendState(m_BlendStates.Insert(pBlendState));
-    m_BlendStateTable.Insert(uiHash, hBlendState);
-
-    return hBlendState;
-  }
-
-  return ezGALBlendStateHandle();
+  return {};
 }
 
-void ezGALDevice::DestroyBlendState(ezGALBlendStateHandle hBlendState)
+template <typename Handle, typename Resource, typename Table, typename CacheTable>
+Handle ezGALDevice::InsertHashedResource(ezUInt32 uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter)
+{
+  if (pResource != nullptr)
+  {
+    EZ_ASSERT_DEBUG(pResource->GetDescription().CalculateHash() == uiHash, "Resource hash doesn't match");
+
+    pResource->AddRef();
+    ref_uiCounter++;
+
+    Handle hResource(table.Insert(pResource));
+    cacheTable.Insert(uiHash, hResource);
+
+    return hResource;
+  }
+
+  return Handle();
+}
+
+template <typename Resource, typename Handle, typename Table>
+void ezGALDevice::DestroyHashedResource(Handle hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
-  ezGALBlendState* pBlendState = nullptr;
+  Resource* pResource = nullptr;
 
-  if (m_BlendStates.TryGetValue(hBlendState, pBlendState))
+  if (table.TryGetValue(hResource, pResource))
   {
-    pBlendState->ReleaseRef();
-    m_uiBlendStates--;
+    pResource->ReleaseRef();
+    ref_uiCounter--;
 
-    if (pBlendState->GetRefCount() == 0)
+    if (pResource->GetRefCount() == 0)
     {
-      AddDeadObject(GALObjectType::BlendState, hBlendState);
+      AddDeadObject(galObjectType, hResource);
     }
   }
   else
   {
-    ezLog::Warning("DestroyBlendState called on invalid handle (double free?)");
+    ezLog::Warning("DestroyHashedResource called on invalid handle (double free?)");
   }
+}
+
+ezGALBlendStateHandle ezGALDevice::CreateBlendState(const ezGALBlendStateCreationDescription& desc)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+  // Hash desc and return potential existing one (including inc. refcount)
+  const ezUInt32 uiHash = desc.CalculateHash();
+
+  if (ezGALBlendStateHandle hBlendState = TryGetHashedResource<ezGALBlendStateHandle, ezGALBlendState>(uiHash, m_BlendStates, m_BlendStateTable, GALObjectType::BlendState, m_uiBlendStates); !hBlendState.IsInvalidated())
+    return hBlendState;
+
+  ezGALBlendState* pBlendState = CreateBlendStatePlatform(desc);
+  return InsertHashedResource<ezGALBlendStateHandle>(uiHash, pBlendState, m_BlendStates, m_BlendStateTable, m_uiBlendStates);
+}
+
+void ezGALDevice::DestroyBlendState(ezGALBlendStateHandle hBlendState)
+{
+  DestroyHashedResource<ezGALBlendState>(hBlendState, m_BlendStates, GALObjectType::BlendState, m_uiBlendStates);
 }
 
 ezGALDepthStencilStateHandle ezGALDevice::CreateDepthStencilState(const ezGALDepthStencilStateCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-
   // Hash desc and return potential existing one (including inc. refcount)
-  ezUInt32 uiHash = desc.CalculateHash();
+  const ezUInt32 uiHash = desc.CalculateHash();
 
-  {
-    ezGALDepthStencilStateHandle hDepthStencilState;
-    if (m_DepthStencilStateTable.TryGetValue(uiHash, hDepthStencilState))
-    {
-      ezGALDepthStencilState* pDepthStencilState = m_DepthStencilStates[hDepthStencilState];
-      if (pDepthStencilState->GetRefCount() == 0)
-      {
-        ReviveDeadObject(GALObjectType::DepthStencilState, hDepthStencilState);
-      }
-
-      pDepthStencilState->AddRef();
-      m_uiDepthStencilStates++;
-      return hDepthStencilState;
-    }
-  }
+  if (ezGALDepthStencilStateHandle hDepthStencilState = TryGetHashedResource<ezGALDepthStencilStateHandle, ezGALDepthStencilState>(uiHash, m_DepthStencilStates, m_DepthStencilStateTable, GALObjectType::DepthStencilState, m_uiDepthStencilStates); !hDepthStencilState.IsInvalidated())
+    return hDepthStencilState;
 
   ezGALDepthStencilState* pDepthStencilState = CreateDepthStencilStatePlatform(desc);
-
-  if (pDepthStencilState != nullptr)
-  {
-    EZ_ASSERT_DEBUG(pDepthStencilState->GetDescription().CalculateHash() == uiHash, "DepthStencilState hash doesn't match");
-
-    pDepthStencilState->AddRef();
-    m_uiDepthStencilStates++;
-
-    ezGALDepthStencilStateHandle hDepthStencilState(m_DepthStencilStates.Insert(pDepthStencilState));
-    m_DepthStencilStateTable.Insert(uiHash, hDepthStencilState);
-
-    return hDepthStencilState;
-  }
-
-  return ezGALDepthStencilStateHandle();
+  return InsertHashedResource<ezGALDepthStencilStateHandle>(uiHash, pDepthStencilState, m_DepthStencilStates, m_DepthStencilStateTable, m_uiDepthStencilStates);
 }
 
 void ezGALDevice::DestroyDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState)
 {
-  EZ_GALDEVICE_LOCK_AND_CHECK();
-
-  ezGALDepthStencilState* pDepthStencilState = nullptr;
-
-  if (m_DepthStencilStates.TryGetValue(hDepthStencilState, pDepthStencilState))
-  {
-    pDepthStencilState->ReleaseRef();
-    m_uiDepthStencilStates--;
-
-    if (pDepthStencilState->GetRefCount() == 0)
-    {
-      AddDeadObject(GALObjectType::DepthStencilState, hDepthStencilState);
-    }
-  }
-  else
-  {
-    ezLog::Warning("DestroyDepthStencilState called on invalid handle (double free?)");
-  }
+  DestroyHashedResource<ezGALDepthStencilState>(hDepthStencilState, m_DepthStencilStates, GALObjectType::DepthStencilState, m_uiDepthStencilStates);
 }
 
 ezGALRasterizerStateHandle ezGALDevice::CreateRasterizerState(const ezGALRasterizerStateCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-
   // Hash desc and return potential existing one (including inc. refcount)
-  ezUInt32 uiHash = desc.CalculateHash();
+  const ezUInt32 uiHash = desc.CalculateHash();
 
-  {
-    ezGALRasterizerStateHandle hRasterizerState;
-    if (m_RasterizerStateTable.TryGetValue(uiHash, hRasterizerState))
-    {
-      ezGALRasterizerState* pRasterizerState = m_RasterizerStates[hRasterizerState];
-      if (pRasterizerState->GetRefCount() == 0)
-      {
-        ReviveDeadObject(GALObjectType::RasterizerState, hRasterizerState);
-      }
-
-      pRasterizerState->AddRef();
-      m_uiRasterizerStates++;
-      return hRasterizerState;
-    }
-  }
+  if (ezGALRasterizerStateHandle hRasterizerState = TryGetHashedResource<ezGALRasterizerStateHandle, ezGALRasterizerState>(uiHash, m_RasterizerStates, m_RasterizerStateTable, GALObjectType::RasterizerState, m_uiRasterizerStates); !hRasterizerState.IsInvalidated())
+    return hRasterizerState;
 
   ezGALRasterizerState* pRasterizerState = CreateRasterizerStatePlatform(desc);
-
-  if (pRasterizerState != nullptr)
-  {
-    EZ_ASSERT_DEBUG(pRasterizerState->GetDescription().CalculateHash() == uiHash, "RasterizerState hash doesn't match");
-
-    pRasterizerState->AddRef();
-    m_uiRasterizerStates++;
-
-    ezGALRasterizerStateHandle hRasterizerState(m_RasterizerStates.Insert(pRasterizerState));
-    m_RasterizerStateTable.Insert(uiHash, hRasterizerState);
-
-    return hRasterizerState;
-  }
-
-  return ezGALRasterizerStateHandle();
+  return InsertHashedResource<ezGALRasterizerStateHandle>(uiHash, pRasterizerState, m_RasterizerStates, m_RasterizerStateTable, m_uiRasterizerStates);
 }
 
 void ezGALDevice::DestroyRasterizerState(ezGALRasterizerStateHandle hRasterizerState)
 {
-  EZ_GALDEVICE_LOCK_AND_CHECK();
-
-  ezGALRasterizerState* pRasterizerState = nullptr;
-
-  if (m_RasterizerStates.TryGetValue(hRasterizerState, pRasterizerState))
-  {
-    pRasterizerState->ReleaseRef();
-    m_uiRasterizerStates--;
-
-    if (pRasterizerState->GetRefCount() == 0)
-    {
-      AddDeadObject(GALObjectType::RasterizerState, hRasterizerState);
-    }
-  }
-  else
-  {
-    ezLog::Warning("DestroyRasterizerState called on invalid handle (double free?)");
-  }
+  DestroyHashedResource<ezGALRasterizerState>(hRasterizerState, m_RasterizerStates, GALObjectType::RasterizerState, m_uiRasterizerStates);
 }
 
 ezGALSamplerStateHandle ezGALDevice::CreateSamplerState(const ezGALSamplerStateCreationDescription& desc)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
-
-  /// \todo Platform independent validation
-
   // Hash desc and return potential existing one (including inc. refcount)
-  ezUInt32 uiHash = desc.CalculateHash();
+  const ezUInt32 uiHash = desc.CalculateHash();
 
-  {
-    ezGALSamplerStateHandle hSamplerState;
-    if (m_SamplerStateTable.TryGetValue(uiHash, hSamplerState))
-    {
-      ezGALSamplerState* pSamplerState = m_SamplerStates[hSamplerState];
-      if (pSamplerState->GetRefCount() == 0)
-      {
-        ReviveDeadObject(GALObjectType::SamplerState, hSamplerState);
-      }
-
-      pSamplerState->AddRef();
-      m_uiSamplerStates++;
-      return hSamplerState;
-    }
-  }
+  if (ezGALSamplerStateHandle hSamplerState = TryGetHashedResource<ezGALSamplerStateHandle, ezGALSamplerState>(uiHash, m_SamplerStates, m_SamplerStateTable, GALObjectType::SamplerState, m_uiSamplerStates); !hSamplerState.IsInvalidated())
+    return hSamplerState;
 
   ezGALSamplerState* pSamplerState = CreateSamplerStatePlatform(desc);
-
-  if (pSamplerState != nullptr)
-  {
-    EZ_ASSERT_DEBUG(pSamplerState->GetDescription().CalculateHash() == uiHash, "SamplerState hash doesn't match");
-
-    pSamplerState->AddRef();
-    m_uiSamplerStates++;
-
-    ezGALSamplerStateHandle hSamplerState(m_SamplerStates.Insert(pSamplerState));
-    m_SamplerStateTable.Insert(uiHash, hSamplerState);
-
-    return hSamplerState;
-  }
-
-  return ezGALSamplerStateHandle();
+  return InsertHashedResource<ezGALSamplerStateHandle>(uiHash, pSamplerState, m_SamplerStates, m_SamplerStateTable, m_uiSamplerStates);
 }
 
 void ezGALDevice::DestroySamplerState(ezGALSamplerStateHandle hSamplerState)
 {
+  DestroyHashedResource<ezGALSamplerState>(hSamplerState, m_SamplerStates, GALObjectType::SamplerState, m_uiSamplerStates);
+}
+
+ezGALBindGroupLayoutHandle ezGALDevice::CreateBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& desc)
+{
   EZ_GALDEVICE_LOCK_AND_CHECK();
+  // Hash desc and return potential existing one (including inc. refcount)
+  const ezUInt32 uiHash = desc.CalculateHash();
 
-  ezGALSamplerState* pSamplerState = nullptr;
+  if (ezGALBindGroupLayoutHandle hBindGroupLayout = TryGetHashedResource<ezGALBindGroupLayoutHandle, ezGALBindGroupLayout>(uiHash, m_BindGroupLayouts, m_BindGroupLayoutTable, GALObjectType::BindGroupLayout, m_uiBindGroupLayouts); !hBindGroupLayout.IsInvalidated())
+    return hBindGroupLayout;
 
-  if (m_SamplerStates.TryGetValue(hSamplerState, pSamplerState))
-  {
-    pSamplerState->ReleaseRef();
-    m_uiSamplerStates--;
+  ezGALBindGroupLayout* pBindGroupLayout = CreateBindGroupLayoutPlatform(desc);
+  return InsertHashedResource<ezGALBindGroupLayoutHandle>(uiHash, pBindGroupLayout, m_BindGroupLayouts, m_BindGroupLayoutTable, m_uiBindGroupLayouts);
+}
 
-    if (pSamplerState->GetRefCount() == 0)
-    {
-      AddDeadObject(GALObjectType::SamplerState, hSamplerState);
-    }
-  }
-  else
-  {
-    ezLog::Warning("DestroySamplerState called on invalid handle (double free?)");
-  }
+void ezGALDevice::DestroyBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout)
+{
+  DestroyHashedResource<ezGALBindGroupLayout>(hBindGroupLayout, m_BindGroupLayouts, GALObjectType::BindGroupLayout, m_uiBindGroupLayouts);
+}
+
+ezGALPipelineLayoutHandle ezGALDevice::CreatePipelineLayout(const ezGALPipelineLayoutCreationDescription& desc)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+  // Hash desc and return potential existing one (including inc. refcount)
+  const ezUInt32 uiHash = desc.CalculateHash();
+
+  if (ezGALPipelineLayoutHandle hPipelineLayout = TryGetHashedResource<ezGALPipelineLayoutHandle, ezGALPipelineLayout>(uiHash, m_PipelineLayouts, m_PipelineLayoutTable, GALObjectType::PipelineLayout, m_uiPipelineLayouts); !hPipelineLayout.IsInvalidated())
+    return hPipelineLayout;
+
+  ezGALPipelineLayout* pPipelineLayout = CreatePipelineLayoutPlatform(desc);
+  return InsertHashedResource<ezGALPipelineLayoutHandle>(uiHash, pPipelineLayout, m_PipelineLayouts, m_PipelineLayoutTable, m_uiPipelineLayouts);
+}
+
+void ezGALDevice::DestroyPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout)
+{
+  DestroyHashedResource<ezGALPipelineLayout>(hPipelineLayout, m_PipelineLayouts, GALObjectType::PipelineLayout, m_uiPipelineLayouts);
 }
 
 ezGALGraphicsPipelineHandle ezGALDevice::CreateGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& desc)
@@ -2083,18 +2012,22 @@ void ezGALDevice::EndFrame()
     ezStats::SetStat("GalDevice/BlendStateReferences", m_uiBlendStates);
     ezStats::SetStat("GalDevice/DepthStencilStateReferences", m_uiDepthStencilStates);
     ezStats::SetStat("GalDevice/RasterizerStateReferences", m_uiRasterizerStates);
+    ezStats::SetStat("GalDevice/SamplerStateReferences", m_uiSamplerStates);
+    ezStats::SetStat("GalDevice/BindGroupLayoutReferences", m_uiBindGroupLayouts);
+    ezStats::SetStat("GalDevice/PipelineLayoutReferences", m_uiPipelineLayouts);
     ezStats::SetStat("GalDevice/GraphicsPipelineReferences", m_uiGraphicsPipelines);
     ezStats::SetStat("GalDevice/ComputePipelineReferences", m_uiComputePipelines);
-    ezStats::SetStat("GalDevice/SamplerStateReferences", m_uiSamplerStates);
 
     ezStats::SetStat("GalDevice/Shaders", m_Shaders.GetCount());
     ezStats::SetStat("GalDevice/VertexDeclarations", m_VertexDeclarations.GetCount());
     ezStats::SetStat("GalDevice/BlendStates", m_BlendStates.GetCount());
     ezStats::SetStat("GalDevice/DepthStencilStates", m_DepthStencilStates.GetCount());
     ezStats::SetStat("GalDevice/RasterizerStates", m_RasterizerStates.GetCount());
+    ezStats::SetStat("GalDevice/SamplerStates", m_SamplerStates.GetCount());
+    ezStats::SetStat("GalDevice/BindGroupLayouts", m_BindGroupLayouts.GetCount());
+    ezStats::SetStat("GalDevice/PipelineLayouts", m_PipelineLayouts.GetCount());
     ezStats::SetStat("GalDevice/GraphicsPipelines", m_GraphicsPipelines.GetCount());
     ezStats::SetStat("GalDevice/ComputePipelines", m_ComputePipelines.GetCount());
-    ezStats::SetStat("GalDevice/SamplerStates", m_SamplerStates.GetCount());
 
     ezStats::SetStat("GalDevice/Buffers", m_Buffers.GetCount());
     ezStats::SetStat("GalDevice/DynamicBuffers", m_DynamicBuffers.GetCount());
@@ -2464,6 +2397,28 @@ void ezGALDevice::DestroyDeadObjects()
 
         DestroyVertexDeclarationPlatform(pVertexDeclaration);
 
+        break;
+      }
+      case GALObjectType::BindGroupLayout:
+      {
+        ezGALBindGroupLayoutHandle hBindGroupLayout(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALBindGroupLayout* pBindGroupLayout = nullptr;
+
+        EZ_VERIFY(m_BindGroupLayouts.Remove(hBindGroupLayout, &pBindGroupLayout), "Unexpected invalid handle");
+        m_BindGroupLayoutTable.Remove(pBindGroupLayout->GetDescription().CalculateHash());
+
+        DestroyBindGroupLayoutPlatform(pBindGroupLayout);
+        break;
+      }
+      case GALObjectType::PipelineLayout:
+      {
+        ezGALPipelineLayoutHandle hPipelineLayout(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALPipelineLayout* pPipelineLayout = nullptr;
+
+        EZ_VERIFY(m_PipelineLayouts.Remove(hPipelineLayout, &pPipelineLayout), "Unexpected invalid handle");
+        m_PipelineLayoutTable.Remove(pPipelineLayout->GetDescription().CalculateHash());
+
+        DestroyPipelineLayoutPlatform(pPipelineLayout);
         break;
       }
       case GALObjectType::GraphicsPipeline:

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -111,6 +111,16 @@ inline const ezGALSamplerState* ezGALDevice::GetSamplerState(ezGALSamplerStateHa
   return Get<SamplerStateTable, ezGALSamplerState>(hSamplerState, m_SamplerStates);
 }
 
+inline const ezGALBindGroupLayout* ezGALDevice::GetBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout) const
+{
+  return Get<BindGroupLayoutTable, ezGALBindGroupLayout>(hBindGroupLayout, m_BindGroupLayouts);
+}
+
+inline const ezGALPipelineLayout* ezGALDevice::GetPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout) const
+{
+  return Get<PipelineLayoutTable, ezGALPipelineLayout>(hPipelineLayout, m_PipelineLayouts);
+}
+
 inline const ezGALGraphicsPipeline* ezGALDevice::GetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline) const
 {
   return Get<GraphicsPipelineTable, ezGALGraphicsPipeline>(hGraphicsPipeline, m_GraphicsPipelines);

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -25,8 +25,9 @@
 #define EZ_GAL_MAX_VERTEX_BUFFER_COUNT 16
 #define EZ_GAL_MAX_VERTEX_ATTRIBUTE_COUNT 16
 #define EZ_GAL_MAX_RENDERTARGET_COUNT 8
+#define EZ_GAL_MAX_SETS 4
 
-#define EZ_GAL_WHOLE_SIZE 0xFFFFFFFF
+#define EZ_GAL_WHOLE_SIZE 0xFFFFFFFFu
 
 // Forward declarations
 
@@ -46,7 +47,11 @@ struct ezGALBufferResourceViewCreationDescription;
 struct ezGALRenderTargetViewCreationDescription;
 struct ezGALTextureUnorderedAccessViewCreationDescription;
 struct ezGALBufferUnorderedAccessViewCreationDescription;
+struct ezGALBindGroupLayoutCreationDescription;
+struct ezGALPipelineLayoutCreationDescription;
 struct ezGALGraphicsPipelineCreationDescription;
+struct ezGALComputePipelineCreationDescription;
+
 
 class ezGALSwapChain;
 class ezGALShader;
@@ -69,6 +74,8 @@ class ezGALTextureUnorderedAccessView;
 class ezGALBufferUnorderedAccessView;
 class ezGALDevice;
 class ezGALCommandEncoder;
+class ezGALBindGroupLayout;
+class ezGALPipelineLayout;
 class ezGALGraphicsPipeline;
 class ezGALComputePipeline;
 
@@ -582,6 +589,21 @@ class ezGALComputePipelineHandle
 
   friend class ezGALDevice;
 };
+
+class ezGALBindGroupLayoutHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALBindGroupLayoutHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+class ezGALPipelineLayoutHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALPipelineLayoutHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
 
 using ezGALPoolHandle = ezGAL::ez20_44Id;
 using ezGALTimestampHandle = ezGALPoolHandle;

--- a/Code/Engine/RendererFoundation/Shader/BindGroupLayout.h
+++ b/Code/Engine/RendererFoundation/Shader/BindGroupLayout.h
@@ -1,0 +1,17 @@
+
+#pragma once
+
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+class EZ_RENDERERFOUNDATION_DLL ezGALBindGroupLayout : public ezGALObject<ezGALBindGroupLayoutCreationDescription>
+{
+protected:
+  friend class ezGALDevice;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+
+  ezGALBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& Description);
+  virtual ~ezGALBindGroupLayout();
+};

--- a/Code/Engine/RendererFoundation/Shader/Implementation/BindGroupLayout.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/BindGroupLayout.cpp
@@ -1,0 +1,10 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Shader/BindGroupLayout.h>
+
+ezGALBindGroupLayout::ezGALBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& Description)
+  : ezGALObject(Description)
+{
+}
+
+ezGALBindGroupLayout::~ezGALBindGroupLayout() = default;

--- a/Code/Engine/RendererFoundation/Shader/Implementation/PipelineLayout.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/PipelineLayout.cpp
@@ -1,0 +1,9 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+#include <RendererFoundation/Shader/PipelineLayout.h>
+
+ezGALPipelineLayout::ezGALPipelineLayout(const ezGALPipelineLayoutCreationDescription& Description)
+  : ezGALObject(Description)
+{
+}
+
+ezGALPipelineLayout::~ezGALPipelineLayout() = default;

--- a/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
@@ -1,8 +1,14 @@
+
+
 #include <RendererFoundation/RendererFoundationPCH.h>
 
+#include <Foundation/Logging/Log.h>
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Device/ImmutableSamplers.h>
 #include <RendererFoundation/Shader/Shader.h>
 #include <RendererFoundation/Shader/ShaderUtils.h>
 #include <RendererFoundation/Shader/Types.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
 
 bool ezShaderMat3::TransposeShaderMatrices = false;
 
@@ -53,6 +59,87 @@ ezResult ezGALShader::CreateBindingMapping(bool bAllowMultipleBindingPerName)
 void ezGALShader::DestroyBindingMapping()
 {
   m_BindingMapping.Clear();
+}
+
+ezResult ezGALShader::CreateLayouts(ezGALDevice* pDevice, bool bSupportsImmutableSamplers)
+{
+  ezGALBindGroupLayoutCreationDescription BindGroupLayoutDesc[EZ_GAL_MAX_SETS];
+  ezGALPipelineLayoutCreationDescription PipelineLayoutDesc;
+
+  const ezGALImmutableSamplers::ImmutableSamplers& immutableSamplers = ezGALImmutableSamplers::GetImmutableSamplers();
+  for (const ezShaderResourceBinding& binding : m_BindingMapping)
+  {
+    if (binding.m_ResourceType == ezGALShaderResourceType::PushConstants)
+    {
+      if (PipelineLayoutDesc.m_PushConstants.m_uiSize != 0)
+      {
+        ezLog::Error("Only one push constants block is supported per shader.");
+        return EZ_FAILURE;
+      }
+      PipelineLayoutDesc.m_PushConstants.m_Stages = binding.m_Stages;
+      PipelineLayoutDesc.m_PushConstants.m_uiOffset = 0;
+      PipelineLayoutDesc.m_PushConstants.m_uiSize = binding.m_pLayout->m_uiTotalSize;
+      continue;
+    }
+
+    if (binding.m_iSet >= EZ_GAL_MAX_SETS)
+    {
+      ezLog::Error("Binding set {} for shader resource '{}' is bigger than EZ_GAL_MAX_SETS.", binding.m_sName.GetData(), binding.m_iSet);
+      return EZ_FAILURE;
+    }
+
+    if (bSupportsImmutableSamplers && binding.m_ResourceType == ezGALShaderResourceType::Sampler && immutableSamplers.Contains(binding.m_sName))
+    {
+      BindGroupLayoutDesc[binding.m_iSet].m_ImmutableSamplers.PushBack(binding);
+    }
+    else
+    {
+      BindGroupLayoutDesc[binding.m_iSet].m_ResourceBindings.PushBack(binding);
+    }
+  }
+
+  // There must always be at least one empty set.
+  ezUInt32 uiMaxSets = 1;
+  for (ezUInt32 uiSetIndex = 1; uiSetIndex < EZ_GAL_MAX_SETS; ++uiSetIndex)
+  {
+    if (!BindGroupLayoutDesc[uiSetIndex].m_ResourceBindings.IsEmpty())
+    {
+      uiMaxSets = uiSetIndex + 1;
+    }
+  }
+
+  m_BindGroupLayouts.SetCount(uiMaxSets);
+  for (ezUInt32 uiSetIndex = 0; uiSetIndex < uiMaxSets; ++uiSetIndex)
+  {
+    m_BindGroupLayouts[uiSetIndex] = pDevice->CreateBindGroupLayout(BindGroupLayoutDesc[uiSetIndex]);
+    if (m_BindGroupLayouts[uiSetIndex].IsInvalidated())
+    {
+      return EZ_FAILURE;
+    }
+    PipelineLayoutDesc.m_BindGroups[uiSetIndex] = m_BindGroupLayouts[uiSetIndex];
+  }
+  m_hPipelineLayout = pDevice->CreatePipelineLayout(PipelineLayoutDesc);
+  if (m_hPipelineLayout.IsInvalidated())
+  {
+    return EZ_FAILURE;
+  }
+  return EZ_SUCCESS;
+}
+
+void ezGALShader::DestroyLayouts(ezGALDevice* pDevice)
+{
+  pDevice->DestroyPipelineLayout(m_hPipelineLayout);
+  for (ezUInt32 uiSetIndex = 0; uiSetIndex < m_BindGroupLayouts.GetCount(); ++uiSetIndex)
+  {
+    pDevice->DestroyBindGroupLayout(m_BindGroupLayouts[uiSetIndex]);
+  }
+  m_BindGroupLayouts.Clear();
+}
+
+ezArrayPtr<const ezShaderResourceBinding> ezGALShader::GetBindings(ezUInt32 uiSet) const
+{
+  EZ_ASSERT_DEBUG(uiSet < GetSetCount(), "Set index out of range.");
+  return m_pDevice->GetBindGroupLayout(m_BindGroupLayouts[uiSet])->GetDescription().m_ResourceBindings;
 }
 
 ezGALShader::~ezGALShader() = default;

--- a/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
@@ -5,10 +5,10 @@
 #include <Foundation/Logging/Log.h>
 #include <RendererFoundation/Device/Device.h>
 #include <RendererFoundation/Device/ImmutableSamplers.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
 #include <RendererFoundation/Shader/Shader.h>
 #include <RendererFoundation/Shader/ShaderUtils.h>
 #include <RendererFoundation/Shader/Types.h>
-#include <RendererFoundation/Shader/BindGroupLayout.h>
 
 bool ezShaderMat3::TransposeShaderMatrices = false;
 

--- a/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/Shader.cpp
@@ -78,7 +78,7 @@ ezResult ezGALShader::CreateLayouts(ezGALDevice* pDevice, bool bSupportsImmutabl
       }
       PipelineLayoutDesc.m_PushConstants.m_Stages = binding.m_Stages;
       PipelineLayoutDesc.m_PushConstants.m_uiOffset = 0;
-      PipelineLayoutDesc.m_PushConstants.m_uiSize = binding.m_pLayout->m_uiTotalSize;
+      PipelineLayoutDesc.m_PushConstants.m_uiSize = (ezUInt16)binding.m_pLayout->m_uiTotalSize;
       continue;
     }
 

--- a/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
@@ -187,20 +187,7 @@ ezResult ezShaderResourceBinding::CreateMergedShaderResourceBinding(const ezArra
 
 ezGALShaderByteCode::ezGALShaderByteCode() = default;
 
-ezGALShaderByteCode::~ezGALShaderByteCode()
-{
-  for (auto& binding : m_ShaderResourceBindings)
-  {
-    if (binding.m_pLayout != nullptr)
-    {
-      ezShaderConstantBufferLayout* pLayout = binding.m_pLayout;
-      binding.m_pLayout = nullptr;
-
-      if (pLayout->GetRefCount() == 0)
-        EZ_DEFAULT_DELETE(pLayout);
-    }
-  }
-}
+ezGALShaderByteCode::~ezGALShaderByteCode() = default;
 
 bool ezShaderConstantBufferLayout::operator==(const ezShaderConstantBufferLayout& rhs) const
 {

--- a/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
@@ -177,12 +177,11 @@ ezResult ezShaderResourceBinding::CreateMergedShaderResourceBinding(const ezArra
     }
   }
   out_bindings.Sort([](const ezShaderResourceBinding& lhs, const ezShaderResourceBinding& rhs)
-  {
+    {
     if (lhs.m_iSet != rhs.m_iSet)
       return lhs.m_iSet < rhs.m_iSet;
 
-    return lhs.m_iSlot < rhs.m_iSlot;
-  });
+    return lhs.m_iSlot < rhs.m_iSlot; });
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
@@ -176,6 +176,13 @@ ezResult ezShaderResourceBinding::CreateMergedShaderResourceBinding(const ezArra
       }
     }
   }
+  out_bindings.Sort([](const ezShaderResourceBinding& lhs, const ezShaderResourceBinding& rhs)
+  {
+    if (lhs.m_iSet != rhs.m_iSet)
+      return lhs.m_iSet < rhs.m_iSet;
+
+    return lhs.m_iSlot < rhs.m_iSlot;
+  });
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/RendererFoundation/Shader/PipelineLayout.h
+++ b/Code/Engine/RendererFoundation/Shader/PipelineLayout.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+class EZ_RENDERERFOUNDATION_DLL ezGALPipelineLayout : public ezGALObject<ezGALPipelineLayoutCreationDescription>
+{
+public:
+protected:
+  friend class ezGALDevice;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+
+  ezGALPipelineLayout(const ezGALPipelineLayoutCreationDescription& Description);
+  virtual ~ezGALPipelineLayout();
+
+private:
+};

--- a/Code/Engine/RendererFoundation/Shader/Shader.h
+++ b/Code/Engine/RendererFoundation/Shader/Shader.h
@@ -9,9 +9,16 @@ public:
   virtual void SetDebugName(ezStringView sName) const = 0;
 
   /// Returns the list of shader resources and their binding information. These must be bound before the shader can be used.
+  /// TODO: This list across all sets will be removed once bind groups are implemented.
   ezArrayPtr<const ezShaderResourceBinding> GetBindingMapping() const;
   /// Convenience function that finds 'sName' in GetBindingMapping and returns it if present.
   const ezShaderResourceBinding* GetShaderResourceBinding(const ezTempHashedString& sName) const;
+
+  EZ_ALWAYS_INLINE ezUInt32 GetSetCount() const { return m_BindGroupLayouts.GetCount(); }
+  EZ_ALWAYS_INLINE ezGALBindGroupLayoutHandle GetBindGroupLayout(ezUInt32 uiSet = 0) const { return m_BindGroupLayouts[uiSet]; }
+  EZ_ALWAYS_INLINE ezGALPipelineLayoutHandle GetPipelineLayout() const { return m_hPipelineLayout; }
+  /// Convenience function that returns ezGALBindGroupLayoutCreationDescription::m_ResourceBindings of the given bind group layout.
+  ezArrayPtr<const ezShaderResourceBinding> GetBindings(ezUInt32 uiSet = 0) const;
 
   /// Returns the list of vertex input attributes. Compute shaders return an empty array.
   ezArrayPtr<const ezShaderVertexInputAttribute> GetVertexInputAttributes() const;
@@ -24,10 +31,16 @@ protected:
 
   ezResult CreateBindingMapping(bool bAllowMultipleBindingPerName);
   void DestroyBindingMapping();
+  ezResult CreateLayouts(ezGALDevice* pDevice, bool bSupportsImmutableSamplers);
+  void DestroyLayouts(ezGALDevice* pDevice);
 
   ezGALShader(const ezGALShaderCreationDescription& Description);
   virtual ~ezGALShader();
 
 protected:
+  ezGALDevice* m_pDevice = nullptr;
   ezDynamicArray<ezShaderResourceBinding> m_BindingMapping;
+
+  ezHybridArray<ezGALBindGroupLayoutHandle, EZ_GAL_MAX_SETS> m_BindGroupLayouts;
+  ezGALPipelineLayoutHandle m_hPipelineLayout;
 };

--- a/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
+++ b/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
@@ -85,7 +85,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezShaderResourceBinding
   ezInt16 m_iSlot = -1;                                       //< The slot under which the resource needs to be bound in the set.
   ezUInt32 m_uiArraySize = 1;                                 //< Number of array elements. Only 1 is currently supported. 0 if bindless.
   ezHashedString m_sName;                                     //< Name under which a resource must be bound to fulfill this resource binding.
-  ezSharedPtr<ezShaderConstantBufferLayout> m_pLayout; //< Only valid if ezGALShaderResourceType is ConstantBuffer, PushConstants, StructuredBuffer, StructuredBufferRW.
+  ezSharedPtr<ezShaderConstantBufferLayout> m_pLayout;        //< Only valid if ezGALShaderResourceType is ConstantBuffer, PushConstants, StructuredBuffer, StructuredBufferRW.
 
   static ezResult CreateMergedShaderResourceBinding(const ezArrayPtr<ezArrayPtr<const ezShaderResourceBinding>>& resourcesPerStage, ezDynamicArray<ezShaderResourceBinding>& out_bindings, bool bAllowMultipleBindingPerName);
 };

--- a/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
+++ b/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
@@ -85,7 +85,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezShaderResourceBinding
   ezInt16 m_iSlot = -1;                                       //< The slot under which the resource needs to be bound in the set.
   ezUInt32 m_uiArraySize = 1;                                 //< Number of array elements. Only 1 is currently supported. 0 if bindless.
   ezHashedString m_sName;                                     //< Name under which a resource must be bound to fulfill this resource binding.
-  ezScopedRefPointer<ezShaderConstantBufferLayout> m_pLayout; //< Only valid if ezGALShaderResourceType is ConstantBuffer, PushConstants, StructuredBuffer, StructuredBufferRW.
+  ezSharedPtr<ezShaderConstantBufferLayout> m_pLayout; //< Only valid if ezGALShaderResourceType is ConstantBuffer, PushConstants, StructuredBuffer, StructuredBufferRW.
 
   static ezResult CreateMergedShaderResourceBinding(const ezArrayPtr<ezArrayPtr<const ezShaderResourceBinding>>& resourcesPerStage, ezDynamicArray<ezShaderResourceBinding>& out_bindings, bool bAllowMultipleBindingPerName);
 };

--- a/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
+++ b/Code/Engine/RendererVulkan/Cache/ResourceCacheVulkan.h
@@ -31,28 +31,12 @@ public:
   static vk::RenderPass RequestRenderPass(const ezGALRenderPassDescriptor& renderPass);
   static vk::Framebuffer RequestFrameBuffer(vk::RenderPass vkRenderPass, const ezGALFrameBufferDescriptor& frameBuffer);
 
-  struct PipelineLayoutDesc
-  {
-    ezHybridArray<vk::DescriptorSetLayout, 4> m_layout;
-    vk::PushConstantRange m_pushConstants;
-  };
-
-  static vk::PipelineLayout RequestPipelineLayout(const PipelineLayoutDesc& desc);
-
-  struct DescriptorSetLayoutDesc
-  {
-    mutable ezUInt32 m_uiHash = 0;
-    ezHybridArray<vk::DescriptorSetLayoutBinding, 6> m_bindings;
-  };
-  static vk::DescriptorSetLayout RequestDescriptorSetLayout(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc);
-
 private:
   struct FramebufferKey
   {
     vk::RenderPass m_renderPass;
     ezGALFrameBufferDescriptor m_frameBuffer;
   };
-
 
   struct ResourceCacheHash
   {
@@ -61,12 +45,6 @@ private:
 
     static ezUInt32 Hash(const FramebufferKey& renderTargetSetup);
     static bool Equal(const FramebufferKey& a, const FramebufferKey& b);
-
-    static ezUInt32 Hash(const PipelineLayoutDesc& desc);
-    static bool Equal(const PipelineLayoutDesc& a, const PipelineLayoutDesc& b);
-
-    static ezUInt32 Hash(const ezGALShaderVulkan::DescriptorSetLayoutDesc& desc) { return desc.m_uiHash; }
-    static bool Equal(const ezGALShaderVulkan::DescriptorSetLayoutDesc& a, const ezGALShaderVulkan::DescriptorSetLayoutDesc& b);
   };
 
 private:
@@ -80,8 +58,4 @@ private:
   // We have a N to 1 mapping for ezGALRenderingSetup to vk::RenderPass as multiple ezGALRenderingSetup can share the same RenderPassDesc.
   static ezHashTable<ezGALRenderPassDescriptor, vk::RenderPass, ResourceCacheHash> s_renderPasses;
   static ezHashTable<FramebufferKey, vk::Framebuffer, ResourceCacheHash> s_frameBuffers; // #TODO_VULKAN cache invalidation
-
-  static ezHashTable<PipelineLayoutDesc, vk::PipelineLayout, ResourceCacheHash> s_pipelineLayouts;
-
-  static ezHashTable<ezGALShaderVulkan::DescriptorSetLayoutDesc, vk::DescriptorSetLayout, ResourceCacheHash> s_descriptorSetLayouts;
 };

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1296,14 +1296,14 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
 
       ezDescriptorSetPoolVulkan::UpdateDescriptorSet(m_DescriptorSets[uiSet], m_DescriptorWrites);
     }
-    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_pShader->GetPipelineLayout(), 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), m_DynamicUniformBufferOffsets.GetCount(), m_DynamicUniformBufferOffsets.GetData());
+    m_pCommandBuffer->bindDescriptorSets(m_bInsideCompute ? vk::PipelineBindPoint::eCompute : vk::PipelineBindPoint::eGraphics, m_pShader->GetVkPipelineLayout(), 0, m_DescriptorSets.GetCount(), m_DescriptorSets.GetData(), m_DynamicUniformBufferOffsets.GetCount(), m_DynamicUniformBufferOffsets.GetData());
   }
 
   if (m_bPushConstantsDirty && m_pShader->GetPushConstantRange().size > 0)
   {
     EZ_ASSERT_DEBUG(m_pShader->GetPushConstantRange().size == m_PushConstants.GetCount(), "");
 
-    m_pCommandBuffer->pushConstants(m_pShader->GetPipelineLayout(), m_pShader->GetPushConstantRange().stageFlags, m_pShader->GetPushConstantRange().offset, m_PushConstants.GetCount(), m_PushConstants.GetData());
+    m_pCommandBuffer->pushConstants(m_pShader->GetVkPipelineLayout(), m_pShader->GetPushConstantRange().stageFlags, m_pShader->GetPushConstantRange().offset, m_PushConstants.GetCount(), m_PushConstants.GetData());
   }
 
   if (m_bRenderPassActive && m_pPipelineBarrier->IsDirty())

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -320,6 +320,12 @@ protected:
   virtual ezGALSamplerState* CreateSamplerStatePlatform(const ezGALSamplerStateCreationDescription& Description) override;
   virtual void DestroySamplerStatePlatform(ezGALSamplerState* pSamplerState) override;
 
+  virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) override;
+  virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) override;
+
+  virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) override;
+  virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) override;
+
   virtual ezGALGraphicsPipeline* CreateGraphicsPipelinePlatform(const ezGALGraphicsPipelineCreationDescription& Description) override;
   virtual void DestroyGraphicsPipelinePlatform(ezGALGraphicsPipeline* pGraphicsPipeline) override;
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -34,6 +34,8 @@
 #include <RendererVulkan/Resources/SharedTextureVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Resources/UnorderedAccessViewVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
 #include <RendererVulkan/State/ComputePipelineVulkan.h>
@@ -42,8 +44,6 @@
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
-#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
-#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -42,6 +42,8 @@
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 #include <RendererVulkan/Utils/ImageCopyVulkan.h>
 #include <RendererVulkan/Utils/PipelineBarrierVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
 
 #if EZ_ENABLED(EZ_SUPPORTS_GLFW)
 #  include <GLFW/glfw3.h>
@@ -1088,6 +1090,49 @@ void ezGALDeviceVulkan::DestroySamplerStatePlatform(ezGALSamplerState* pSamplerS
   EZ_DELETE(&m_Allocator, pVulkanSamplerState);
 }
 
+ezGALBindGroupLayout* ezGALDeviceVulkan::CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description)
+{
+  ezGALBindGroupLayoutVulkan* pVulkanBindGroupLayout = EZ_NEW(&m_Allocator, ezGALBindGroupLayoutVulkan, Description);
+
+  if (pVulkanBindGroupLayout->InitPlatform(this).Succeeded())
+  {
+    return pVulkanBindGroupLayout;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pVulkanBindGroupLayout);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceVulkan::DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout)
+{
+  ezGALBindGroupLayoutVulkan* pVulkanBindGroupLayout = static_cast<ezGALBindGroupLayoutVulkan*>(pBindGroupLayout);
+  pVulkanBindGroupLayout->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pVulkanBindGroupLayout);
+}
+
+ezGALPipelineLayout* ezGALDeviceVulkan::CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description)
+{
+  ezGALPipelineLayoutVulkan* pVulkanPipelineLayout = EZ_NEW(&m_Allocator, ezGALPipelineLayoutVulkan, Description);
+
+  if (pVulkanPipelineLayout->InitPlatform(this).Succeeded())
+  {
+    return pVulkanPipelineLayout;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pVulkanPipelineLayout);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceVulkan::DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout)
+{
+  ezGALPipelineLayoutVulkan* pVulkanPipelineLayout = static_cast<ezGALPipelineLayoutVulkan*>(pPipelineLayout);
+  pVulkanPipelineLayout->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pVulkanPipelineLayout);
+}
 
 // Resource creation functions
 
@@ -1905,6 +1950,12 @@ void ezGALDeviceVulkan::DeletePendingResources(ezDeque<PendingDeletion>& pending
         break;
       case vk::ObjectType::ePipeline:
         m_device.destroyPipeline(reinterpret_cast<vk::Pipeline&>(deletion.m_pObject));
+        break;
+      case vk::ObjectType::eDescriptorSetLayout:
+        m_device.destroyDescriptorSetLayout(reinterpret_cast<vk::DescriptorSetLayout&>(deletion.m_pObject));
+        break;
+      case vk::ObjectType::ePipelineLayout:
+        m_device.destroyPipelineLayout(reinterpret_cast<vk::PipelineLayout&>(deletion.m_pObject));
         break;
       default:
         EZ_REPORT_FAILURE("This object type is not implemented");

--- a/Code/Engine/RendererVulkan/Shader/BindGroupLayoutVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/BindGroupLayoutVulkan.h
@@ -11,6 +11,7 @@ class ezGALBindGroupLayoutVulkan : public ezGALBindGroupLayout
 {
 public:
   inline vk::DescriptorSetLayout GetDescriptorSetLayout() const { return m_DescriptorSetLayout; }
+
 protected:
   friend class ezGALDeviceVulkan;
   friend class ezMemoryUtils;
@@ -24,6 +25,4 @@ protected:
 
 private:
   vk::DescriptorSetLayout m_DescriptorSetLayout;
-
 };
-

--- a/Code/Engine/RendererVulkan/Shader/BindGroupLayoutVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/BindGroupLayoutVulkan.h
@@ -1,0 +1,29 @@
+
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
+
+#include <vulkan/vulkan.hpp>
+
+class ezGALBindGroupLayoutVulkan : public ezGALBindGroupLayout
+{
+public:
+  inline vk::DescriptorSetLayout GetDescriptorSetLayout() const { return m_DescriptorSetLayout; }
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  ezGALBindGroupLayoutVulkan(const ezGALBindGroupLayoutCreationDescription& Description);
+
+  virtual ~ezGALBindGroupLayoutVulkan();
+
+private:
+  vk::DescriptorSetLayout m_DescriptorSetLayout;
+
+};
+

--- a/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupLayoutVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupLayoutVulkan.cpp
@@ -1,0 +1,73 @@
+
+
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererFoundation/Device/ImmutableSamplers.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/State/StateVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
+
+ezGALBindGroupLayoutVulkan::ezGALBindGroupLayoutVulkan(const ezGALBindGroupLayoutCreationDescription& Description)
+  : ezGALBindGroupLayout(Description)
+{
+}
+
+ezGALBindGroupLayoutVulkan::~ezGALBindGroupLayoutVulkan() = default;
+
+ezResult ezGALBindGroupLayoutVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  ezHybridArray<vk::DescriptorSetLayoutBinding, 6> bindings;
+  bindings.Reserve(m_Description.m_ResourceBindings.GetCount() + m_Description.m_ImmutableSamplers.GetCount());
+
+  auto ConvertBinding = [](const ezShaderResourceBinding& ezBinding, vk::DescriptorSetLayoutBinding& out_Binding)
+  {
+    out_Binding.binding = ezBinding.m_iSlot;
+    out_Binding.descriptorType = ezConversionUtilsVulkan::GetDescriptorType(ezBinding.m_ResourceType);
+    out_Binding.descriptorCount = ezBinding.m_uiArraySize;
+    out_Binding.stageFlags = ezConversionUtilsVulkan::GetShaderStages(ezBinding.m_Stages);
+  };
+
+  // Build Vulkan descriptor set layout
+  for (ezUInt32 i = 0; i < m_Description.m_ResourceBindings.GetCount(); i++)
+  {
+    const ezShaderResourceBinding& ezBinding = m_Description.m_ResourceBindings[i];
+    vk::DescriptorSetLayoutBinding& binding = bindings.ExpandAndGetRef();
+    ConvertBinding(ezBinding, binding);
+  }
+
+  const ezGALImmutableSamplers::ImmutableSamplers& immutableSamplers = ezGALImmutableSamplers::GetImmutableSamplers();
+
+  for (ezUInt32 i = 0; i < m_Description.m_ImmutableSamplers.GetCount(); i++)
+  {
+    const ezShaderResourceBinding& ezBinding = m_Description.m_ImmutableSamplers[i];
+    vk::DescriptorSetLayoutBinding& binding = bindings.ExpandAndGetRef();
+    ConvertBinding(ezBinding, binding);
+    if (const ezGALSamplerStateHandle* hSampler = immutableSamplers.GetValue(ezBinding.m_sName))
+    {
+      const auto* pSampler = static_cast<const ezGALSamplerStateVulkan*>(pVulkanDevice->GetSamplerState(*hSampler));
+      binding.pImmutableSamplers = &pSampler->GetImageInfo().sampler;
+    }
+    else
+    {
+      ezLog::Error("Immutable sampler '{}' not found, failed to create bind group layout", ezBinding.m_sName.GetData());
+      return EZ_FAILURE;
+    }
+  }
+
+  vk::DescriptorSetLayoutCreateInfo descriptorSetLayout;
+  descriptorSetLayout.bindingCount = bindings.GetCount();
+  descriptorSetLayout.pBindings = bindings.GetData();
+  VK_ASSERT_DEBUG(pVulkanDevice->GetVulkanDevice().createDescriptorSetLayout(&descriptorSetLayout, nullptr, &m_DescriptorSetLayout));
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALBindGroupLayoutVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  auto* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+  pVulkanDevice->DeleteLater(m_DescriptorSetLayout);
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/RendererVulkan/Shader/Implementation/PipelineLayoutVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/PipelineLayoutVulkan.cpp
@@ -1,0 +1,59 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
+
+ezGALPipelineLayoutVulkan::ezGALPipelineLayoutVulkan(const ezGALPipelineLayoutCreationDescription& Description)
+  : ezGALPipelineLayout(Description)
+{
+}
+
+ezGALPipelineLayoutVulkan::~ezGALPipelineLayoutVulkan() = default;
+
+ezResult ezGALPipelineLayoutVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+
+  // There must always be at least one empty set.
+  ezUInt32 uiMaxSets = 1;
+  for (ezUInt32 i = 1; i < EZ_GAL_MAX_SETS; ++i)
+  {
+    if (!m_Description.m_BindGroups[i].IsInvalidated())
+    {
+      uiMaxSets = i + 1;
+    }
+  }
+
+  ezHybridArray<vk::DescriptorSetLayout, EZ_GAL_MAX_SETS> descriptorSetLayouts;
+  descriptorSetLayouts.SetCount(uiMaxSets);
+  for (ezUInt32 i = 0; i < uiMaxSets; ++i)
+  {
+    const ezGALBindGroupLayout* pBindGroupLayout = pVulkanDevice->GetBindGroupLayout(m_Description.m_BindGroups[i]);
+    descriptorSetLayouts[i] = static_cast<const ezGALBindGroupLayoutVulkan*>(pBindGroupLayout)->GetDescriptorSetLayout();
+  }
+
+  m_pushConstants.size = m_Description.m_PushConstants.m_uiSize;
+  m_pushConstants.offset = m_Description.m_PushConstants.m_uiOffset;
+  m_pushConstants.stageFlags = ezConversionUtilsVulkan::GetShaderStages(m_Description.m_PushConstants.m_Stages);
+
+  vk::PipelineLayoutCreateInfo layoutInfo;
+  layoutInfo.setLayoutCount = descriptorSetLayouts.GetCount();
+  layoutInfo.pSetLayouts = descriptorSetLayouts.GetData();
+  if (m_pushConstants.size != 0)
+  {
+    layoutInfo.pushConstantRangeCount = 1;
+    layoutInfo.pPushConstantRanges = &m_pushConstants;
+  }
+
+  VK_ASSERT_DEBUG(pVulkanDevice->GetVulkanDevice().createPipelineLayout(&layoutInfo, nullptr, &m_PipelineLayout));
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALPipelineLayoutVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  auto* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
+  pVulkanDevice->DeleteLater(m_PipelineLayout);
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -2,9 +2,9 @@
 
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
-#include <RendererVulkan/Shader/ShaderVulkan.h>
-#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
 #include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
+#include <RendererVulkan/Shader/ShaderVulkan.h>
 
 ezGALShaderVulkan::ezGALShaderVulkan(const ezGALShaderCreationDescription& Description)
   : ezGALShader(Description)

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan.cpp
@@ -1,28 +1,10 @@
 #include <RendererVulkan/RendererVulkanPCH.h>
 
-#include <Foundation/Algorithm/HashStream.h>
-#include <RendererFoundation/Device/ImmutableSamplers.h>
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Shader/ShaderVulkan.h>
-#include <RendererVulkan/State/StateVulkan.h>
-#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
-
-void ezGALShaderVulkan::DescriptorSetLayoutDesc::ComputeHash()
-{
-  ezHashStreamWriter32 writer;
-  const ezUInt32 uiSize = m_bindings.GetCount();
-  for (ezUInt32 i = 0; i < uiSize; i++)
-  {
-    const auto& binding = m_bindings[i];
-    writer << binding.binding;
-    writer << ezConversionUtilsVulkan::GetUnderlyingValue(binding.descriptorType);
-    writer << binding.descriptorCount;
-    writer << ezConversionUtilsVulkan::GetUnderlyingFlagsValue(binding.stageFlags);
-    writer << binding.pImmutableSamplers;
-  }
-  m_uiHash = writer.GetHashValue();
-}
+#include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
 
 ezGALShaderVulkan::ezGALShaderVulkan(const ezGALShaderCreationDescription& Description)
   : ezGALShader(Description)
@@ -34,108 +16,19 @@ ezGALShaderVulkan::~ezGALShaderVulkan() {}
 void ezGALShaderVulkan::SetDebugName(ezStringView sName) const
 {
   ezStringBuilder tmp;
-
-  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice());
   for (ezUInt32 i = 0; i < ezGALShaderStage::ENUM_COUNT; i++)
   {
-    pVulkanDevice->SetDebugName(sName.GetData(tmp), m_Shaders[i]);
+    static_cast<ezGALDeviceVulkan*>(m_pDevice)->SetDebugName(sName.GetData(tmp), m_Shaders[i]);
   }
 }
 
 ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
 {
+  m_pDevice = pDevice;
   EZ_SUCCEED_OR_RETURN(CreateBindingMapping(false));
+  EZ_SUCCEED_OR_RETURN(CreateLayouts(pDevice, true));
 
-  ezGALDeviceVulkan* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
-
-  m_SetBindings.Clear();
-
-  for (const ezShaderResourceBinding& binding : GetBindingMapping())
-  {
-    if (binding.m_ResourceType == ezGALShaderResourceType::PushConstants)
-      continue;
-
-    ezUInt32 iMaxSets = ezMath::Max((ezUInt32)m_SetBindings.GetCount(), static_cast<ezUInt32>(binding.m_iSet + 1));
-    m_SetBindings.SetCount(iMaxSets);
-    m_SetBindings[binding.m_iSet].PushBack(binding);
-  }
-
-  const ezGALImmutableSamplers::ImmutableSamplers& immutableSamplers = ezGALImmutableSamplers::GetImmutableSamplers();
-  auto GetImmutableSampler = [&](const ezHashedString& sName) -> const vk::Sampler*
-  {
-    if (const ezGALSamplerStateHandle* hSampler = immutableSamplers.GetValue(sName))
-    {
-      const auto* pSampler = static_cast<const ezGALSamplerStateVulkan*>(pVulkanDevice->GetSamplerState(*hSampler));
-      return &pSampler->GetImageInfo().sampler;
-    }
-    return nullptr;
-  };
-
-  // If no descriptor set is needed, we still need to create an empty one to fulfil the Vulkan spec :-/
-  if (m_SetBindings.IsEmpty())
-  {
-    m_SetBindings.SetCount(1);
-  }
-
-  // Sort mappings and build descriptor set layout
-  ezHybridArray<DescriptorSetLayoutDesc, 4> descriptorSetLayoutDesc;
-  descriptorSetLayoutDesc.SetCount(m_SetBindings.GetCount());
-  m_descriptorSetLayout.SetCount(m_SetBindings.GetCount());
-  for (ezUInt32 iSet = 0; iSet < m_SetBindings.GetCount(); ++iSet)
-  {
-    m_SetBindings[iSet].Sort([](const ezShaderResourceBinding& lhs, const ezShaderResourceBinding& rhs)
-      { return lhs.m_iSlot < rhs.m_iSlot; });
-
-    // Build Vulkan descriptor set layout
-    for (ezUInt32 i = 0; i < m_SetBindings[iSet].GetCount(); i++)
-    {
-      const ezShaderResourceBinding& ezBinding = m_SetBindings[iSet][i];
-      vk::DescriptorSetLayoutBinding& binding = descriptorSetLayoutDesc[ezBinding.m_iSet].m_bindings.ExpandAndGetRef();
-
-      binding.binding = ezBinding.m_iSlot;
-      binding.descriptorType = ezConversionUtilsVulkan::GetDescriptorType(ezBinding.m_ResourceType);
-      binding.descriptorCount = ezBinding.m_uiArraySize;
-      binding.stageFlags = ezConversionUtilsVulkan::GetShaderStages(ezBinding.m_Stages);
-      binding.pImmutableSamplers = ezBinding.m_ResourceType == ezGALShaderResourceType::Sampler ? GetImmutableSampler(ezBinding.m_sName) : nullptr;
-    }
-
-    descriptorSetLayoutDesc[iSet].ComputeHash();
-    m_descriptorSetLayout[iSet] = ezResourceCacheVulkan::RequestDescriptorSetLayout(descriptorSetLayoutDesc[iSet]);
-  }
-
-  // Remove immutable samplers and push constants from binding info
-  {
-    for (ezUInt32 uiSet = 0; uiSet < m_SetBindings.GetCount(); ++uiSet)
-    {
-      for (ezInt32 iIndex = (ezInt32)m_SetBindings[uiSet].GetCount() - 1; iIndex >= 0; --iIndex)
-      {
-        const bool bIsImmutableSample = m_SetBindings[uiSet][iIndex].m_ResourceType == ezGALShaderResourceType::Sampler && immutableSamplers.Contains(m_SetBindings[uiSet][iIndex].m_sName);
-
-        if (bIsImmutableSample)
-        {
-          m_SetBindings[uiSet].RemoveAtAndCopy(iIndex);
-        }
-      }
-    }
-    for (ezInt32 iIndex = (ezInt32)m_BindingMapping.GetCount() - 1; iIndex >= 0; --iIndex)
-    {
-      const bool bIsImmutableSample = m_BindingMapping[iIndex].m_ResourceType == ezGALShaderResourceType::Sampler && immutableSamplers.Contains(m_BindingMapping[iIndex].m_sName);
-      const bool bIsPushConstant = m_BindingMapping[iIndex].m_ResourceType == ezGALShaderResourceType::PushConstants;
-
-      if (bIsPushConstant)
-      {
-        const auto& pushConstant = m_BindingMapping[iIndex];
-        m_pushConstants.size = pushConstant.m_pLayout->m_uiTotalSize;
-        m_pushConstants.offset = 0;
-        m_pushConstants.stageFlags = ezConversionUtilsVulkan::GetShaderStages(pushConstant.m_Stages);
-      }
-
-      if (bIsImmutableSample || bIsPushConstant)
-      {
-        m_BindingMapping.RemoveAtAndCopy(iIndex);
-      }
-    }
-  }
+  auto pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
 
   // Build shaders
   vk::ShaderModuleCreateInfo createInfo;
@@ -146,33 +39,17 @@ ezResult ezGALShaderVulkan::InitPlatform(ezGALDevice* pDevice)
       createInfo.codeSize = m_Description.m_ByteCodes[i]->m_ByteCode.GetCount();
       EZ_ASSERT_DEV(createInfo.codeSize % 4 == 0, "Spirv shader code should be a multiple of 4.");
       createInfo.pCode = reinterpret_cast<const ezUInt32*>(m_Description.m_ByteCodes[i]->m_ByteCode.GetData());
-      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pVulkanDevice->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_Shaders[i]));
+      VK_SUCCEED_OR_RETURN_EZ_FAILURE(pDeviceVulkan->GetVulkanDevice().createShaderModule(&createInfo, nullptr, &m_Shaders[i]));
     }
   }
 
-  // Build pipeline Layout
-  {
-    ezResourceCacheVulkan::PipelineLayoutDesc m_LayoutDesc;
-    const ezUInt32 uiSets = GetSetCount();
-    m_LayoutDesc.m_layout.SetCount(uiSets);
-    m_LayoutDesc.m_pushConstants = GetPushConstantRange();
-    for (ezUInt32 uiSet = 0; uiSet < uiSets; ++uiSet)
-    {
-      m_LayoutDesc.m_layout[uiSet] = GetDescriptorSetLayout(uiSet);
-    }
-
-    m_PipelineLayout = ezResourceCacheVulkan::RequestPipelineLayout(m_LayoutDesc);
-  }
   return EZ_SUCCESS;
 }
 
 ezResult ezGALShaderVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
   DestroyBindingMapping();
-
-  // Right now, we do not destroy descriptor set layouts as they are shared among many shaders.
-  m_descriptorSetLayout.Clear();
-  m_SetBindings.Clear();
+  DestroyLayouts(pDevice);
 
   auto* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   for (auto& m_Shader : m_Shaders)
@@ -180,4 +57,20 @@ ezResult ezGALShaderVulkan::DeInitPlatform(ezGALDevice* pDevice)
     pVulkanDevice->DeleteLater(m_Shader);
   }
   return EZ_SUCCESS;
+}
+
+vk::PipelineLayout ezGALShaderVulkan::GetVkPipelineLayout() const
+{
+  return static_cast<const ezGALPipelineLayoutVulkan*>(m_pDevice->GetPipelineLayout(m_hPipelineLayout))->GetVkPipelineLayout();
+}
+
+vk::DescriptorSetLayout ezGALShaderVulkan::GetDescriptorSetLayout(ezUInt32 uiSet) const
+{
+  EZ_ASSERT_DEBUG(uiSet < GetSetCount(), "Set index out of range.");
+  return static_cast<const ezGALBindGroupLayoutVulkan*>(m_pDevice->GetBindGroupLayout(m_BindGroupLayouts[uiSet]))->GetDescriptorSetLayout();
+}
+
+vk::PushConstantRange ezGALShaderVulkan::GetPushConstantRange() const
+{
+  return static_cast<const ezGALPipelineLayoutVulkan*>(m_pDevice->GetPipelineLayout(m_hPipelineLayout))->GetPushConstantRange();
 }

--- a/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h
@@ -3,30 +3,3 @@ vk::ShaderModule ezGALShaderVulkan::GetShader(ezGALShaderStage::Enum stage) cons
 {
   return m_Shaders[stage];
 }
-
-vk::PipelineLayout ezGALShaderVulkan::GetPipelineLayout() const
-{
-  return m_PipelineLayout;
-}
-
-ezUInt32 ezGALShaderVulkan::GetSetCount() const
-{
-  return m_SetBindings.GetCount();
-}
-
-vk::DescriptorSetLayout ezGALShaderVulkan::GetDescriptorSetLayout(ezUInt32 uiSet) const
-{
-  EZ_ASSERT_DEBUG(uiSet < m_descriptorSetLayout.GetCount(), "Set index out of range.");
-  return m_descriptorSetLayout[uiSet];
-}
-
-ezArrayPtr<const ezShaderResourceBinding> ezGALShaderVulkan::GetBindings(ezUInt32 uiSet) const
-{
-  EZ_ASSERT_DEBUG(uiSet < m_SetBindings.GetCount(), "Set index out of range.");
-  return m_SetBindings[uiSet].GetArrayPtr();
-}
-
-vk::PushConstantRange ezGALShaderVulkan::GetPushConstantRange() const
-{
-  return m_pushConstants;
-}

--- a/Code/Engine/RendererVulkan/Shader/PipelineLayoutVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/PipelineLayoutVulkan.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/PipelineLayout.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
+
+#include <vulkan/vulkan.hpp>
+
+class ezGALPipelineLayoutVulkan : public ezGALPipelineLayout
+{
+public:
+  inline vk::PushConstantRange GetPushConstantRange() const { return m_pushConstants; }
+  inline vk::PipelineLayout GetVkPipelineLayout() const { return m_PipelineLayout; }
+
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+
+  ezGALPipelineLayoutVulkan(const ezGALPipelineLayoutCreationDescription& Description);
+
+  virtual ~ezGALPipelineLayoutVulkan();
+
+private:
+  vk::PushConstantRange m_pushConstants;
+  vk::PipelineLayout m_PipelineLayout;
+};

--- a/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
@@ -30,7 +30,6 @@ protected:
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
 private:
-
   vk::ShaderModule m_Shaders[ezGALShaderStage::ENUM_COUNT];
 };
 

--- a/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/ShaderVulkan.h
@@ -12,22 +12,12 @@
 class EZ_RENDERERVULKAN_DLL ezGALShaderVulkan : public ezGALShader
 {
 public:
-  /// \brief Used as input to ezResourceCacheVulkan::RequestDescriptorSetLayout to create a vk::DescriptorSetLayout.
-  struct DescriptorSetLayoutDesc
-  {
-    mutable ezUInt32 m_uiHash = 0;
-    ezHybridArray<vk::DescriptorSetLayoutBinding, 6> m_bindings;
-    void ComputeHash();
-  };
-
   virtual void SetDebugName(ezStringView sName) const override;
 
   EZ_ALWAYS_INLINE vk::ShaderModule GetShader(ezGALShaderStage::Enum stage) const;
-  EZ_ALWAYS_INLINE vk::PipelineLayout GetPipelineLayout() const;
-  EZ_ALWAYS_INLINE ezUInt32 GetSetCount() const;
-  EZ_ALWAYS_INLINE vk::DescriptorSetLayout GetDescriptorSetLayout(ezUInt32 uiSet = 0) const;
-  EZ_ALWAYS_INLINE ezArrayPtr<const ezShaderResourceBinding> GetBindings(ezUInt32 uiSet = 0) const;
-  EZ_ALWAYS_INLINE vk::PushConstantRange GetPushConstantRange() const;
+  vk::PipelineLayout GetVkPipelineLayout() const;
+  vk::DescriptorSetLayout GetDescriptorSetLayout(ezUInt32 uiSet = 0) const;
+  vk::PushConstantRange GetPushConstantRange() const;
 
 protected:
   friend class ezGALDeviceVulkan;
@@ -40,11 +30,8 @@ protected:
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
 
 private:
-  vk::PushConstantRange m_pushConstants;
-  ezHybridArray<vk::DescriptorSetLayout, 4> m_descriptorSetLayout;
-  ezHybridArray<ezHybridArray<ezShaderResourceBinding, 16>, 4> m_SetBindings;
+
   vk::ShaderModule m_Shaders[ezGALShaderStage::ENUM_COUNT];
-  vk::PipelineLayout m_PipelineLayout;
 };
 
 #include <RendererVulkan/Shader/Implementation/ShaderVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/State/Implementation/ComputePipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/ComputePipelineVulkan.cpp
@@ -29,7 +29,7 @@ ezResult ezGALComputePipelineVulkan::InitPlatform(ezGALDevice* pDevice)
   }
 
   vk::ComputePipelineCreateInfo pipe;
-  pipe.layout = pShader->GetPipelineLayout();
+  pipe.layout = pShader->GetVkPipelineLayout();
   {
     vk::ShaderModule shader = pShader->GetShader(ezGALShaderStage::ComputeShader);
     EZ_ASSERT_DEV(shader != nullptr, "No compute shader stage present in the bound shader");

--- a/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
@@ -108,7 +108,7 @@ ezResult ezGALGraphicsPipelineVulkan::InitPlatform(ezGALDevice* pDevice)
 
   vk::GraphicsPipelineCreateInfo pipe;
   pipe.renderPass = ezResourceCacheVulkan::RequestRenderPass(m_Description.m_RenderPass);
-  pipe.layout = pShader->GetPipelineLayout();
+  pipe.layout = pShader->GetVkPipelineLayout();
   pipe.stageCount = shader_stages.GetCount();
   pipe.pStages = shader_stages.GetData();
   pipe.pVertexInputState = pVertexCreateInfo;

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -428,7 +428,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
       }
     }
     ezDescriptorSetPoolVulkan::UpdateDescriptorSet(descriptorSet, descriptorWrites);
-    commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_pShader->GetPipelineLayout(), 0, 1, &descriptorSet, 0, nullptr);
+    commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_pShader->GetVkPipelineLayout(), 0, 1, &descriptorSet, 0, nullptr);
   }
 
   // Render

--- a/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
+++ b/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.cpp
@@ -879,7 +879,7 @@ ezResult ezShaderCompilerDXC::ReflectShaderStage(ezShaderProgramData& inout_Data
   return EZ_SUCCESS;
 }
 
-ezShaderConstantBufferLayout* ezShaderCompilerDXC::ReflectStructuredBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block)
+ezSharedPtr<ezShaderConstantBufferLayout> ezShaderCompilerDXC::ReflectStructuredBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block)
 {
   EZ_LOG_BLOCK("Structured Buffer Layout", sName);
   SpvReflectBlockVariable& innerBlock = block.members[0];
@@ -887,16 +887,16 @@ ezShaderConstantBufferLayout* ezShaderCompilerDXC::ReflectStructuredBufferLayout
   return ReflectBufferLayout(innerBlock);
 }
 
-ezShaderConstantBufferLayout* ezShaderCompilerDXC::ReflectConstantBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block)
+ezSharedPtr<ezShaderConstantBufferLayout> ezShaderCompilerDXC::ReflectConstantBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block)
 {
   EZ_LOG_BLOCK("Constant Buffer Layout", sName);
   ezLog::Debug("Constant Buffer has {} variables, Size is {}", block.member_count, block.padded_size);
   return ReflectBufferLayout(block);
 }
 
-ezShaderConstantBufferLayout* ezShaderCompilerDXC::ReflectBufferLayout(const SpvReflectBlockVariable& block)
+ezSharedPtr<ezShaderConstantBufferLayout> ezShaderCompilerDXC::ReflectBufferLayout(const SpvReflectBlockVariable& block)
 {
-  ezShaderConstantBufferLayout* pLayout = EZ_DEFAULT_NEW(ezShaderConstantBufferLayout);
+  ezSharedPtr<ezShaderConstantBufferLayout> pLayout = EZ_DEFAULT_NEW(ezShaderConstantBufferLayout);
 
   pLayout->m_uiTotalSize = block.padded_size;
 

--- a/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.h
+++ b/Code/Engine/ShaderCompilerDXC/ShaderCompilerDXC.h
@@ -29,9 +29,9 @@ private:
   void CreateNewShaderResourceDeclaration(ezStringView sPlatform, ezStringView sDeclaration, const ezShaderResourceBinding& binding, ezStringBuilder& out_sDeclaration);
 
   ezResult ReflectShaderStage(ezShaderProgramData& inout_Data, ezGALShaderStage::Enum Stage);
-  ezShaderConstantBufferLayout* ReflectStructuredBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block);
-  ezShaderConstantBufferLayout* ReflectConstantBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block);
-  ezShaderConstantBufferLayout* ReflectBufferLayout(const SpvReflectBlockVariable& block);
+  ezSharedPtr<ezShaderConstantBufferLayout> ReflectStructuredBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block);
+  ezSharedPtr<ezShaderConstantBufferLayout> ReflectConstantBufferLayout(ezStringView sName, const SpvReflectBlockVariable& block);
+  ezSharedPtr<ezShaderConstantBufferLayout> ReflectBufferLayout(const SpvReflectBlockVariable& block);
   ezResult FillResourceBinding(ezShaderResourceBinding& binding, const SpvReflectDescriptorBinding& info);
   ezResult FillSRVResourceBinding(ezShaderResourceBinding& binding, const SpvReflectDescriptorBinding& info);
   ezResult FillUAVResourceBinding(ezShaderResourceBinding& binding, const SpvReflectDescriptorBinding& info);

--- a/Code/Engine/ShaderCompilerHLSL/ShaderCompilerHLSL.cpp
+++ b/Code/Engine/ShaderCompilerHLSL/ShaderCompilerHLSL.cpp
@@ -235,7 +235,7 @@ void ezShaderCompilerHLSL::ReflectShaderStage(ezShaderProgramData& inout_Data, e
   pReflector->Release();
 }
 
-ezShaderConstantBufferLayout* ezShaderCompilerHLSL::ReflectConstantBufferLayout(ezGALShaderByteCode& pStageBinary, ID3D11ShaderReflectionConstantBuffer* pConstantBufferReflection)
+ezSharedPtr<ezShaderConstantBufferLayout> ezShaderCompilerHLSL::ReflectConstantBufferLayout(ezGALShaderByteCode& pStageBinary, ID3D11ShaderReflectionConstantBuffer* pConstantBufferReflection)
 {
   D3D11_SHADER_BUFFER_DESC shaderBufferDesc;
 
@@ -247,7 +247,7 @@ ezShaderConstantBufferLayout* ezShaderCompilerHLSL::ReflectConstantBufferLayout(
   EZ_LOG_BLOCK("Constant Buffer Layout", shaderBufferDesc.Name);
   ezLog::Debug("Constant Buffer has {0} variables, Size is {1}", shaderBufferDesc.Variables, shaderBufferDesc.Size);
 
-  ezShaderConstantBufferLayout* pLayout = EZ_DEFAULT_NEW(ezShaderConstantBufferLayout);
+  ezSharedPtr<ezShaderConstantBufferLayout> pLayout = EZ_DEFAULT_NEW(ezShaderConstantBufferLayout);
 
   pLayout->m_uiTotalSize = shaderBufferDesc.Size;
 

--- a/Code/Engine/ShaderCompilerHLSL/ShaderCompilerHLSL.h
+++ b/Code/Engine/ShaderCompilerHLSL/ShaderCompilerHLSL.h
@@ -33,7 +33,7 @@ private:
   void CreateNewShaderResourceDeclaration(ezStringView sPlatform, ezStringView sDeclaration, const ezShaderResourceBinding& binding, ezStringBuilder& out_sDeclaration);
 
   void ReflectShaderStage(ezShaderProgramData& inout_Data, ezGALShaderStage::Enum Stage);
-  ezShaderConstantBufferLayout* ReflectConstantBufferLayout(ezGALShaderByteCode& pStageBinary, ID3D11ShaderReflectionConstantBuffer* pConstantBufferReflection);
+  ezSharedPtr<ezShaderConstantBufferLayout> ReflectConstantBufferLayout(ezGALShaderByteCode& pStageBinary, ID3D11ShaderReflectionConstantBuffer* pConstantBufferReflection);
   void Initialize();
   static ezGALResourceFormat::Enum GetEZFormat(const _D3D11_SIGNATURE_PARAMETER_DESC& paramDesc);
 

--- a/Code/UnitTests/EditorTest/GenerateCompile/GenerateCompile.cpp
+++ b/Code/UnitTests/EditorTest/GenerateCompile/GenerateCompile.cpp
@@ -87,7 +87,7 @@ ezString ezEditorTestGenerateCompile::GetEditorProcessorPath() const
   path.AppendPath("ezEditorProcessor.exe");
 #else
   path.AppendPath("ezEditorProcessor");
-#endif;
+#endif
   return path;
 }
 


### PR DESCRIPTION
Adds `ezGALBindGroupLayoutCreationDescription` and `ezGALPipelineLayoutCreationDescription` which moves what was previously scattered in the Vulkan code into the renderer foundation. This will make it easier to support other platforms as some of the logic can be reused. Also this allows for quick comparisions to make sure two bindings share the same layout later on. No logical changes, just moved code around and split Vulkan code from general code.

## Misc Changes
* Building Android on Windows no longer requires admin priviledges to create the junction to share the SDKs with multiple builds. This is done by manually calling `mklink`.
* Fixed a potential memory leak as `ezShaderConstantBufferLayout` was stored as a `ezScopedRefPointer` instead of a `ezSharedPtr` in one place.