### PR TITLE
Bind Group Fixes

### DIFF
--- a/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
+++ b/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
@@ -142,8 +142,6 @@ void ezWindowOutputTargetXR::CompanionViewEndFrame()
     m_pRenderContext->EndRendering();
 
     pDevice->EndCommands(pEncoder);
-
-    m_pRenderContext->ResetContextState();
   }
 }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
@@ -98,7 +98,7 @@ void ezReflectionFilterPass::Execute(const ezRenderViewContext& renderViewContex
 
   {
     auto pFilteredSpecularOutput = outputs[m_PinFilteredSpecular.m_uiOutputIndex];
-    if (pFilteredSpecularOutput != nullptr && !pFilteredSpecularOutput->m_TextureHandle.IsInvalidated())
+    if (pFilteredSpecularOutput != nullptr && !pFilteredSpecularOutput->m_TextureHandle.IsInvalidated() && pDevice->GetTexture(pFilteredSpecularOutput->m_TextureHandle) != nullptr)
     {
       ezUInt32 uiNumMipMaps = pFilteredSpecularOutput->m_Desc.m_uiMipLevelCount;
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -1290,8 +1290,6 @@ void ezRenderPipeline::Render(ezRenderContext* pRenderContext)
     ezRenderWorld::s_RenderEvent.Broadcast(renderEvent);
   }
 
-  pRenderContext->ResetContextState();
-
   data.Clear();
 
   m_CurrentRenderThread = (ezThreadID)0;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
@@ -295,4 +295,9 @@ void ezBindGroupBuilder::InsertItem(ezTempHashedString sSlotName, const ezGALBin
       s_uiWrites++;
     }
   }
+  else
+  {
+    m_bModified = true;
+    s_uiWrites++;
+  }
 }

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -562,9 +562,12 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
       m_pGALCommandEncoder->SetComputePipeline(ezGALPipelineCache::GetPipeline(m_ComputePipeline));
   }
 
-  for (ezUInt32 i = 0; i < m_pActiveGALShader->GetBindGroupCount(); ++i)
+  if (m_pActiveGALShader)
   {
-    EZ_ASSERT_DEV(m_pActiveGALShader->GetBindGroupLayout(i) == m_BindGroups[i].m_hBindGroupLayout, "Invalid Bind Group Layout");
+    for (ezUInt32 i = 0; i < m_pActiveGALShader->GetBindGroupCount(); ++i)
+    {
+      EZ_ASSERT_DEV(m_pActiveGALShader->GetBindGroupLayout(i) == m_BindGroups[i].m_hBindGroupLayout, "Invalid Bind Group Layout");
+    }
   }
   return EZ_SUCCESS;
 }

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -104,6 +104,11 @@ ezRenderContext::Statistics::Statistics()
 void ezRenderContext::Statistics::Reset()
 {
   m_uiFailedDrawcalls = 0;
+  for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; ++i)
+  {
+    m_uiModifiedBindGroup[i] = 0;
+    m_uiLayoutChanged[i] = 0;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -166,8 +171,7 @@ ezRenderContext::~ezRenderContext()
 ezRenderContext::Statistics ezRenderContext::GetAndResetStatistics()
 {
   ezRenderContext::Statistics ret = m_Statistics;
-  ret.Reset();
-
+  m_Statistics.Reset();
   return ret;
 }
 
@@ -204,10 +208,6 @@ void ezRenderContext::EndRendering()
 
   m_bStereoRendering = false;
   m_bRendering = false;
-  // TODO: The render context needs to reset its state after every encoding block if we want to record to separate command buffers.
-  // Although this is currently not possible since a lot of high level code binds stuff only once per frame on the render context.
-  // Resetting the state after every encoding block breaks those assumptions.
-  // ResetContextState();
 }
 
 void ezRenderContext::BeginCompute(const char* szName /*= ""*/)
@@ -223,8 +223,6 @@ void ezRenderContext::EndCompute()
   m_pGALCommandEncoder->EndCompute();
   m_bCompute = false;
   m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
-  // TODO: See EndRendering
-  // ResetContextState();
 }
 
 void ezRenderContext::SetShaderPermutationVariable(const char* szName, const ezTempHashedString& sTempValue)
@@ -472,6 +470,13 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
 {
   EZ_ASSERT_DEBUG(m_bRendering || m_bCompute, "Must be either in a rendering or compute scope");
 
+  // First apply material state since this can modify all other states.
+  if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::MaterialBindingChanged))
+  {
+    ApplyMaterialState();
+    m_StateFlags.Remove(ezRenderContextFlags::MaterialBindingChanged);
+  }
+
   for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; ++i)
   {
     if (m_BindGroupBuilders[i].IsModified())
@@ -481,61 +486,35 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
     }
   }
 
-  // First apply material state since this can modify all other states.
-  if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::MaterialBindingChanged))
-  {
-    ApplyMaterialState();
-    m_StateFlags.Remove(ezRenderContextFlags::MaterialBindingChanged);
-  }
-
-  ezShaderPermutationResource* pShaderPermutation = nullptr;
-  EZ_SCOPE_EXIT(if (pShaderPermutation != nullptr) { ezResourceManager::EndAcquireResource(pShaderPermutation); });
-
   bool bRebuildVertexDeclaration = m_StateFlags.IsAnySet(ezRenderContextFlags::ShaderStateChanged | ezRenderContextFlags::MeshBufferBindingChanged);
 
   if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::ShaderStateChanged))
   {
-    pShaderPermutation = ApplyShaderState();
-    if (pShaderPermutation == nullptr)
-    {
-      return EZ_FAILURE;
-    }
-
+    EZ_SUCCEED_OR_RETURN(ApplyShaderState());
     m_StateFlags.Remove(ezRenderContextFlags::ShaderStateChanged);
   }
 
-  if (m_hActiveShaderPermutation.IsValid())
+  if (m_pActiveGALShader)
   {
     const bool bDirty = (bForce || m_StateFlags.IsAnySet(ezRenderContextFlags::BindGroupLayoutChanged | ezRenderContextFlags::BindGroupChanged));
 
-    const ezGALShader* pShader = nullptr;
-    if (bDirty)
-    {
-      if (pShaderPermutation == nullptr)
-      {
-        pShaderPermutation = ezResourceManager::BeginAcquireResource(m_hActiveShaderPermutation, ezResourceAcquireMode::BlockTillLoaded);
-      }
-      if (pShaderPermutation == nullptr)
-      {
-        return EZ_FAILURE;
-      }
-      // #TODO_SHADER It's a bit unclean that we need to acquire the GAL shader on this level. Unfortunately, we need the resource binding on both the GAL and the high level renderer and the only alternative is some kind of duplication of the data.
-      pShader = ezGALDevice::GetDefaultDevice()->GetShader(m_hActiveGALShader);
-    }
-
-
-    ezLogBlock applyBindingsBlock("Applying Shader Bindings", pShaderPermutation ? pShaderPermutation->GetResourceDescription().GetData() : "");
+    ezLogBlock applyBindingsBlock("Applying Shader Bindings", m_sActiveShader);
     UploadConstants();
     if (bDirty)
     {
-      const ezUInt32 uiBindGroups = pShader->GetBindGroupCount();
-      const bool bForceBindGroupUpdate = bForce || m_StateFlags.IsSet(ezRenderContextFlags::BindGroupLayoutChanged);
+      const ezUInt32 uiBindGroups = m_pActiveGALShader->GetBindGroupCount();
       for (ezUInt32 uiBindGroup = 0; uiBindGroup < uiBindGroups; uiBindGroup++)
       {
-        if (bForceBindGroupUpdate || m_BindGroupBuilders[uiBindGroup].IsModified())
+        const bool bForceBindGroupUpdate = bForce || m_bDirtyBindGroups[uiBindGroup];
+        const bool bBindGroupModified = m_BindGroupBuilders[uiBindGroup].IsModified();
+        if (bBindGroupModified)
+          m_Statistics.m_uiModifiedBindGroup[uiBindGroup]++;
+
+        if (bForceBindGroupUpdate || bBindGroupModified)
         {
-          EZ_SUCCEED_OR_RETURN(ApplyBindGroup(pShader, uiBindGroup));
+          EZ_SUCCEED_OR_RETURN(ApplyBindGroup(m_pActiveGALShader, uiBindGroup));
         }
+        m_bDirtyBindGroups[uiBindGroup] = false;
       }
       m_StateFlags.Remove(ezRenderContextFlags::BindGroupLayoutChanged);
       m_StateFlags.Remove(ezRenderContextFlags::BindGroupChanged);
@@ -583,6 +562,10 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
       m_pGALCommandEncoder->SetComputePipeline(ezGALPipelineCache::GetPipeline(m_ComputePipeline));
   }
 
+  for (ezUInt32 i = 0; i < m_pActiveGALShader->GetBindGroupCount(); ++i)
+  {
+    EZ_ASSERT_DEV(m_pActiveGALShader->GetBindGroupLayout(i) == m_BindGroups[i].m_hBindGroupLayout, "Invalid Bind Group Layout");
+  }
   return EZ_SUCCESS;
 }
 
@@ -592,15 +575,16 @@ void ezRenderContext::ResetContextState()
 
   m_StateFlags = ezRenderContextFlags::AllStatesInvalid;
 
-  m_hActiveShader.Invalidate();
-  m_hActiveGALShader.Invalidate();
-
-  m_PermutationVariables.Clear();
-  m_hNewMaterial.Invalidate();
   m_hMaterial.Invalidate();
+  m_hNewMaterial.Invalidate();
 
+  m_hActiveShader.Invalidate();
+  m_PermutationVariables.Clear();
   m_hActiveShaderPermutation.Invalidate();
-
+  m_sActiveShader.Clear();
+  m_hActiveGALShader.Invalidate();
+  m_pActiveGALShader = nullptr;
+  
   static_assert(EZ_ARRAY_SIZE(m_hVertexBuffers) == EZ_GAL_MAX_VERTEX_BUFFER_COUNT);
   for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hVertexBuffers); ++i)
   {
@@ -619,6 +603,9 @@ void ezRenderContext::ResetContextState()
   for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; ++i)
   {
     m_BindGroupBuilders[i].ResetBoundResources(ezGALDevice::GetDefaultDevice());
+    m_BindGroups[i].m_hBindGroupLayout.Invalidate();
+    m_BindGroups[i].m_BindGroupItems.Clear();
+    m_bDirtyBindGroups[i] = false;
   }
 }
 
@@ -856,6 +843,10 @@ void ezRenderContext::GALStaticDeviceEventHandler(const ezGALDeviceEvent& e)
     if (s_pDefaultInstance)
     {
       s_pDefaultInstance->m_StateFlags = ezRenderContextFlags::AllStatesInvalid;
+      for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; ++i)
+      {
+        s_pDefaultInstance->m_bDirtyBindGroups[i] = true;
+      }
       s_pDefaultInstance->m_pGALCommandEncoder = e.m_pCommandEncoder;
     }
   }
@@ -867,6 +858,10 @@ void ezRenderContext::GALStaticDeviceEventHandler(const ezGALDeviceEvent& e)
   }
   else if (e.m_Type == ezGALDeviceEvent::Type::BeforeBeginFrame)
   {
+    if (s_pDefaultInstance)
+    {
+      s_pDefaultInstance->ResetContextState();
+    }
     for (auto it = s_ConstantBufferStorageTable.GetIterator(); it.IsValid(); ++it)
     {
       it.Value()->BeforeBeginFrame();
@@ -879,6 +874,19 @@ void ezRenderContext::GALStaticDeviceEventHandler(const ezGALDeviceEvent& e)
     ezBindGroupBuilder::s_uiWrites = 0;
     ezStats::SetStat("RenderContext/BindGroupReads", ezBindGroupBuilder::s_uiReads);
     ezBindGroupBuilder::s_uiReads = 0;
+
+    if (s_pDefaultInstance)
+    {
+      ezRenderContext::Statistics stats = s_pDefaultInstance->GetAndResetStatistics();
+      for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; ++i)
+      {
+        ezStringBuilder groupName;
+        groupName.SetFormat("RenderContext/BindGroup_{}_Modified", i);
+        ezStats::SetStat(groupName, stats.m_uiModifiedBindGroup[i]);
+        groupName.SetFormat("RenderContext/BindGroup_{}_LayoutChanged", i);
+        ezStats::SetStat(groupName, stats.m_uiLayoutChanged[i]);
+      }
+    }
   }
 }
 
@@ -999,33 +1007,44 @@ void ezRenderContext::BindShaderInternal(const ezShaderResourceHandle& hShader, 
   }
 }
 
-ezShaderPermutationResource* ezRenderContext::ApplyShaderState()
+ezResult ezRenderContext::ApplyShaderState()
 {
   m_hActiveGALShader.Invalidate();
 
-  m_StateFlags.Add(ezRenderContextFlags::BindGroupLayoutChanged | ezRenderContextFlags::PipelineChanged);
+  m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
 
   if (!m_hActiveShader.IsValid())
-    return nullptr;
+    return EZ_FAILURE;
 
   m_hActiveShaderPermutation = ezShaderManager::PreloadSinglePermutation(m_hActiveShader, m_PermutationVariables, m_bAllowAsyncShaderLoading);
 
   if (!m_hActiveShaderPermutation.IsValid())
-    return nullptr;
+    return EZ_FAILURE;
 
-  ezShaderPermutationResource* pShaderPermutation = ezResourceManager::BeginAcquireResource(
-    m_hActiveShaderPermutation, m_bAllowAsyncShaderLoading ? ezResourceAcquireMode::AllowLoadingFallback : ezResourceAcquireMode::BlockTillLoaded);
+  // Non-material shaders are always force-loaded so we don't accidentally miss to render important passes.
+  const bool bAsyncShaderLoading = m_bAllowAsyncShaderLoading && m_hMaterial.IsValid();
+  ezResourceLock<ezShaderPermutationResource> pShaderPermutation(m_hActiveShaderPermutation, bAsyncShaderLoading ? ezResourceAcquireMode::AllowLoadingFallback : ezResourceAcquireMode::BlockTillLoaded);
 
-  if (!pShaderPermutation->IsShaderValid())
-  {
-    ezResourceManager::EndAcquireResource(pShaderPermutation);
-    return nullptr;
-  }
+  if (!pShaderPermutation.IsValid() || !pShaderPermutation->IsShaderValid())
+    return EZ_FAILURE;
 
+  m_sActiveShader = pShaderPermutation->GetResourceDescription();
   m_hActiveGALShader = pShaderPermutation->GetGALShader();
   m_GraphicsPipeline.m_hShader = m_hActiveGALShader;
   m_ComputePipeline.m_hShader = m_hActiveGALShader;
   EZ_ASSERT_DEV(!m_hActiveGALShader.IsInvalidated(), "Invalid GAL Shader handle.");
+  m_pActiveGALShader = ezGALDevice::GetDefaultDevice()->GetShader(m_hActiveGALShader);
+  EZ_ASSERT_DEV(m_pActiveGALShader, "Invalid GAL Shader handle.");
+  const ezUInt32 uiBindGroups = m_pActiveGALShader->GetBindGroupCount();
+  for (ezUInt32 i = 0; i < uiBindGroups; ++i)
+  {
+    if (m_pActiveGALShader->GetBindGroupLayout(i) != m_BindGroups[i].m_hBindGroupLayout)
+    {
+      m_Statistics.m_uiLayoutChanged[i]++;
+      m_bDirtyBindGroups[i] = true;
+      m_StateFlags.Add(ezRenderContextFlags::BindGroupLayoutChanged);
+    }
+  }
 
   // Set render state from shader
   if (!m_bCompute)
@@ -1040,7 +1059,7 @@ ezShaderPermutationResource* ezRenderContext::ApplyShaderState()
       m_GraphicsPipeline.m_hDepthStencilState = pShaderPermutation->GetDepthStencilState();
   }
 
-  return pShaderPermutation;
+  return EZ_SUCCESS;
 }
 
 void ezRenderContext::ApplyMaterialState()

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -584,7 +584,7 @@ void ezRenderContext::ResetContextState()
   m_sActiveShader.Clear();
   m_hActiveGALShader.Invalidate();
   m_pActiveGALShader = nullptr;
-  
+
   static_assert(EZ_ARRAY_SIZE(m_hVertexBuffers) == EZ_GAL_MAX_VERTEX_BUFFER_COUNT);
   for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hVertexBuffers); ++i)
   {

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
@@ -52,9 +52,9 @@ struct EZ_RENDERERCORE_DLL ezRenderContextFlags
     ShaderStateChanged = EZ_BIT(0),
     BindGroupChanged = EZ_BIT(1),
     BindGroupLayoutChanged = EZ_BIT(2),
-    MeshBufferBindingChanged = EZ_BIT(6),
-    MaterialBindingChanged = EZ_BIT(7),
-    PipelineChanged = EZ_BIT(8),
+    MeshBufferBindingChanged = EZ_BIT(3),
+    MaterialBindingChanged = EZ_BIT(4),
+    PipelineChanged = EZ_BIT(5),
 
     AllStatesInvalid = ShaderStateChanged | BindGroupChanged | BindGroupLayoutChanged | MeshBufferBindingChanged | PipelineChanged,
     Default = None
@@ -63,11 +63,8 @@ struct EZ_RENDERERCORE_DLL ezRenderContextFlags
   struct Bits
   {
     StorageType ShaderStateChanged : 1;
-    StorageType TextureBindingChanged : 1;
-    StorageType UAVBindingChanged : 1;
-    StorageType SamplerBindingChanged : 1;
-    StorageType BufferBindingChanged : 1;
-    StorageType ConstantBufferBindingChanged : 1;
+    StorageType BindGroupChanged : 1;
+    StorageType BindGroupLayoutChanged : 1;
     StorageType MeshBufferBindingChanged : 1;
     StorageType MaterialBindingChanged : 1;
     StorageType PipelineChanged : 1;

--- a/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
+++ b/Code/Engine/RendererFoundation/Descriptors/Implementation/Descriptors.cpp
@@ -6,7 +6,7 @@
 ezUInt32 ezGALBindGroupLayoutCreationDescription::CalculateHash() const
 {
   ezHashStreamWriter32 writer;
-  for (const ezShaderResourceBinding& binding : m_ResourceBindings)
+  auto HashBinding = [](ezHashStreamWriter32& writer, const ezShaderResourceBinding& binding)
   {
     writer << binding.m_ResourceType.GetValue();
     writer << binding.m_TextureType.GetValue();
@@ -27,6 +27,15 @@ ezUInt32 ezGALBindGroupLayoutCreationDescription::CalculateHash() const
         writer << constant.m_uiOffset;
       }
     }
+  };
+
+  for (const ezShaderResourceBinding& binding : m_ResourceBindings)
+  {
+    HashBinding(writer, binding);
+  }
+  for (const ezShaderResourceBinding& binding : m_ImmutableSamplers)
+  {
+    HashBinding(writer, binding);
   }
   return writer.GetHashValue();
 }

--- a/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/ShaderByteCode.cpp
@@ -135,7 +135,7 @@ ezResult ezShaderResourceBinding::CreateMergedShaderResourceBinding(const ezArra
       ezUInt32 uiIndex = ezInvalidIndex;
       if (res.m_ResourceType == ezGALShaderResourceType::Sampler)
       {
-        // #TODO_SHADER Samplers are special! Since the shader compiler edits the reflection data and renames "*_AutoSampler" to just "*", we generate a naming collision between the texture and the sampler. See ezRenderContext::BindTexture2D for binding code. For now, we allow this collision, but it will probably bite us later on.
+        // #TODO_SHADER Samplers are special! Since the shader compiler edits the reflection data and renames "*_AutoSampler" to just "*", we generate a naming collision between the texture and the sampler. See ezBindGroupBuilder::BindTexture for binding code. For now, we allow this collision, but it will probably bite us later on.
         samplerToIndex.TryGetValue(res.m_sName, uiIndex);
       }
       else

--- a/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
+++ b/Code/Engine/RendererFoundation/Shader/ShaderByteCode.h
@@ -3,8 +3,10 @@
 
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Types/RefCounted.h>
+#include <Foundation/Types/SharedPtr.h>
 #include <RendererFoundation/Descriptors/Enumerations.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Resources/ResourceFormats.h>
 
 /// \brief The reflection data of a constant in a shader constant buffer.
 /// \sa ezShaderConstantBufferLayout

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -984,6 +984,8 @@ ezGALCommandEncoder* ezGALDeviceVulkan::BeginCommandsPlatform(const char* szName
 #if EZ_ENABLED(EZ_USE_PROFILING)
   m_pPassTimingScope = ezProfilingScopeAndMarker::Start(m_pCommandEncoder.Borrow(), szName);
 #endif
+  m_pCommandEncoderImpl->Reset();
+  m_pCommandEncoder->InvalidateState();
   return m_pCommandEncoder.Borrow();
 }
 
@@ -992,10 +994,6 @@ void ezGALDeviceVulkan::EndCommandsPlatform(ezGALCommandEncoder* pPass)
 #if EZ_ENABLED(EZ_USE_PROFILING)
   ezProfilingScopeAndMarker::Stop(m_pCommandEncoder.Borrow(), m_pPassTimingScope);
 #endif
-  // Submit();
-  //  Technically we don't need to do this here.
-  m_pCommandEncoderImpl->Reset();
-  m_pCommandEncoder->InvalidateState();
 }
 
 

--- a/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
+++ b/Code/Samples/ComputeShaderHistogram/ComputeShaderHistogram.cpp
@@ -142,7 +142,6 @@ void ezComputeShaderHistogramApp::Run()
     device->EndCommands(pCommandEncoder);
 
     device->EndFrame();
-    ezRenderContext::GetDefaultInstance()->ResetContextState();
   }
 
   // needs to be called once per frame

--- a/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
+++ b/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
@@ -216,7 +216,6 @@ public:
       m_pDevice->EndCommands(pCommandEncoder);
 
       m_pDevice->EndFrame();
-      ezRenderContext::GetDefaultInstance()->ResetContextState();
     }
 
     // needs to be called once per frame to finish resource loading

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -205,7 +205,6 @@ void ezShaderExplorerApp::Run()
     m_pDevice->EndCommands(pCommandEncoder);
 
     m_pDevice->EndFrame();
-    ezRenderContext::GetDefaultInstance()->ResetContextState();
   }
 
   // needs to be called once per frame

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -349,7 +349,6 @@ public:
       m_pDevice->EndCommands(pCommandEncoder);
 
       m_pDevice->EndFrame();
-      ezRenderContext::GetDefaultInstance()->ResetContextState();
     }
 
     // needs to be called once per frame

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -880,7 +880,6 @@ ezTestAppRun ezRendererTestAdvancedFeatures::SharedTexture()
 
     texture.m_uiCurrentSemaphoreValue++;
     pSharedTexture->SignalSemaphoreGPU(texture.m_uiCurrentSemaphoreValue);
-    ezRenderContext::GetDefaultInstance()->ResetContextState();
   }
   EndFrame();
 

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -116,7 +116,6 @@ void ezOffscreenRendererTest::Run()
     device->EndCommands(pCommandEncoder);
 
     device->EndFrame();
-    ezRenderContext::GetDefaultInstance()->ResetContextState();
   }
 
   if (m_RequestedFrames.IsEmpty() && m_bExiting)

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -299,8 +299,6 @@ void ezGraphicsTest::EndFrame()
     m_pWindow->ProcessWindowMessages();
   }
 
-  ezRenderContext::GetDefaultInstance()->ResetContextState();
-
   m_pDevice->EndFrame();
 
   ezTaskSystem::FinishFrameTasks();


### PR DESCRIPTION
# Bind Group Fixes
* `ezRenderContext::ResetContextState` is now private as it was misused in multiple places and de-synced with the renderer impl. Now both are reset at frame start.
* Workaround for reflection filter pass crash as it sets a dead GAL object. This previously just failed silently or caused other crashes but the `ezBindGroupBuilder` will always assert on this. This is the old problem of the recorded pass being played back when the view is already destroyed.
* Fixed a case where `ezBindGroupBuilder` was not marked modified.
* `ezGALBindGroupLayoutCreationDescription` did not hash the immutable samplers, causing hash collisions.
* `ezRenderContext` now tracks dirty flags for each bind group layout index.
* `ezRenderContext::ApplyShaderState` no longer returns a resource but just an `ezResult` as the code for removing the lock was error prone and unnecessary.
* Removed some odd code in `ezRenderContext::ApplyContextStates` where after `ApplyShaderState` the shader was force loaded again. This means there were two code paths that loaded the shader. The first one respected `m_bAllowAsyncShaderLoading` while the second one ignored it. To not break to much, non-material shaders will continue to force load.
* Some statistics for bind group modified / layout changed events over a frame. 