### PR TITLE
Fixed #1368: Animations stopped when exclusively visualizing Jolt geometry

### DIFF
--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
@@ -25,7 +25,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSimpleAnimationComponent, 3, ezComponentMode::Static);
     EZ_ENUM_MEMBER_PROPERTY("AnimationMode", ezPropertyAnimMode, m_AnimationMode),
     EZ_MEMBER_PROPERTY("Speed", m_fSpeed)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_ENUM_MEMBER_PROPERTY("RootMotionMode", ezRootMotionMode, m_RootMotionMode),
-    EZ_ENUM_MEMBER_PROPERTY("InvisibleUpdateRate", ezAnimationInvisibleUpdateRate, m_InvisibleUpdateRate),
+    EZ_ENUM_MEMBER_PROPERTY("InvisibleUpdateRate", ezAnimationInvisibleUpdateRate, m_InvisibleUpdateRate)->AddAttributes(new ezDefaultValueAttribute(ezAnimationInvisibleUpdateRate::Pause)),
     EZ_MEMBER_PROPERTY("EnableIK", m_bEnableIK),
   }
   EZ_END_PROPERTIES;
@@ -119,7 +119,9 @@ void ezSimpleAnimationComponent::Update()
   if (m_ElapsedTimeSinceUpdate < tMinStep)
     return;
 
-  const bool bVisible = visType != ezVisibilityState::Invisible;
+  // if we did this, the animation would fully stop, when the component is really invisible (not even indirectly visible)
+  // this breaks the setting 'InvisibleUpdateRate', which is supposed to let the user override the update rate for this case
+  const bool bVisible = true; // visType != ezVisibilityState::Invisible;
 
   ezResourceLock<ezAnimationClipResource> pAnimation(m_hAnimationClip, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
   if (pAnimation.GetAcquireResult() != ezResourceAcquireResult::Final)

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -39,7 +39,14 @@ void ezJoltQueryShapeActorComponentManager::UpdateMovingQueryShapes()
     const ezSimdVec4f pos = pObject->GetGlobalPositionSimd();
     const ezSimdQuat rot = pObject->GetGlobalRotationSimd();
 
-    pBodies->SetPositionAndRotation(bodyId, ezJoltConversionUtils::ToVec3(pos), ezJoltConversionUtils::ToQuat(rot), JPH::EActivation::DontActivate);
+    JPH::Quat jRot = ezJoltConversionUtils::ToQuat(rot);
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+    // Jolt is overly strict about normalization
+    jRot.Normalized();
+#endif
+
+    pBodies->SetPositionAndRotation(bodyId, ezJoltConversionUtils::ToVec3(pos), jRot, JPH::EActivation::DontActivate);
   }
 }
 

--- a/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Actors/Implementation/JoltQueryShapeActorComponent.cpp
@@ -43,7 +43,7 @@ void ezJoltQueryShapeActorComponentManager::UpdateMovingQueryShapes()
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
     // Jolt is overly strict about normalization
-    jRot.Normalized();
+    jRot = jRot.Normalized();
 #endif
 
     pBodies->SetPositionAndRotation(bodyId, ezJoltConversionUtils::ToVec3(pos), jRot, JPH::EActivation::DontActivate);


### PR DESCRIPTION
The simple animation component had an extra optimization to do absolutely nothing under certain circumstances. However, this goes against the user setting to have a minimum update framerate.

Now it follows that setting correctly, so animations WILL stop when visualizing only physics geometry, but only if the user configured it to do so.

Also the default InvisibleUpdateRate option of the simple anim component was changed to "Pause".

Also fixed a bug in the breakable slab component, that would make it crash when it broke while not visible.