### PR TITLE
Added Layer panel toolbar, and option to not automatically switch the layer

### DIFF
--- a/Code/EditorPlugins/Scene/EditorPluginScene/Actions/LayerActions.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Actions/LayerActions.h
@@ -15,6 +15,7 @@ public:
   static void UnregisterActions();
 
   static void MapContextMenuActions(ezStringView sMapping);
+  static void MapToolbarActions(ezStringView sMapping);
 
   static ezActionDescriptorHandle s_hLayerCategory;
   static ezActionDescriptorHandle s_hCreateLayer;
@@ -23,6 +24,7 @@ public:
   static ezActionDescriptorHandle s_hSaveActiveLayer;
   static ezActionDescriptorHandle s_hLayerLoaded;
   static ezActionDescriptorHandle s_hLayerVisible;
+  static ezActionDescriptorHandle s_hSwitchOnSelection;
 };
 
 ///
@@ -39,6 +41,7 @@ public:
     SaveActiveLayer,
     LayerLoaded,
     LayerVisible,
+    SwitchOnSelection,
   };
 
   ezLayerAction(const ezActionContext& context, const char* szName, ActionType type);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/EditorPluginScene.cpp
@@ -222,6 +222,9 @@ void OnLoadPlugin()
   ezActionMapManager::RegisterActionMap("EditorPluginScene_LayerContextMenu");
   ezLayerActions::MapContextMenuActions("EditorPluginScene_LayerContextMenu");
 
+  ezActionMapManager::RegisterActionMap("EditorPluginScene_LayerToolbar");
+  ezLayerActions::MapToolbarActions("EditorPluginScene_LayerToolbar");
+
   // component property meta states
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezCameraComponent_PropertyMetaStateEventHandler);
   ezPropertyMetaState::GetSingleton()->m_Events.AddEventHandler(ezSkyLightComponent_PropertyMetaStateEventHandler);

--- a/Code/EditorPlugins/Scene/EditorPluginScene/InputContexts/SceneSelectionContext.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/InputContexts/SceneSelectionContext.cpp
@@ -39,8 +39,15 @@ void ezSceneSelectionContext::SelectPickedObject(const ezObjectPickingResult& re
 
         if (pSceneDocument->GetActiveLayer() != layerGuid)
         {
-          pSceneDocument->PreventDoubleSelectionChange(true);
-          pSceneDocument->SetActiveLayer(layerGuid).LogFailure();
+          if (pSceneDocument->GetSwitchLayerToSelection())
+          {
+            pSceneDocument->PreventDoubleSelectionChange(true);
+            pSceneDocument->SetActiveLayer(layerGuid).LogFailure();
+          }
+          else
+          {
+            pSceneDocument->ShowDocumentStatus(ezFmt("The clicked object is in layer '{}'. Switch layer or enable 'Auto Switch Layer to Selection'", pSceneDocument->GetLayerDocument(layerGuid)->GetDocumentPath().GetFileName()));
+          }
         }
       }
     }

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Panels/LayerPanel/LayerPanel.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Panels/LayerPanel/LayerPanel.cpp
@@ -6,8 +6,8 @@
 #include <EditorPluginScene/Panels/ScenegraphPanel/ScenegraphModel.moc.h>
 #include <EditorPluginScene/Scene/Scene2Document.h>
 #include <GuiFoundation/ActionViews/MenuActionMapView.moc.h>
-#include <QVBoxLayout>
 #include <GuiFoundation/ActionViews/ToolBarActionMapView.moc.h>
+#include <QVBoxLayout>
 
 ezQtLayerPanel::ezQtLayerPanel(ads::CDockManager* pDockManager, QWidget* pParent, ezScene2Document* pDocument)
   : ezQtDocumentPanel(pDockManager, pParent, pDocument)

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Panels/LayerPanel/LayerPanel.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Panels/LayerPanel/LayerPanel.cpp
@@ -7,6 +7,7 @@
 #include <EditorPluginScene/Scene/Scene2Document.h>
 #include <GuiFoundation/ActionViews/MenuActionMapView.moc.h>
 #include <QVBoxLayout>
+#include <GuiFoundation/ActionViews/ToolBarActionMapView.moc.h>
 
 ezQtLayerPanel::ezQtLayerPanel(ads::CDockManager* pDockManager, QWidget* pParent, ezScene2Document* pDocument)
   : ezQtDocumentPanel(pDockManager, pParent, pDocument)
@@ -31,6 +32,18 @@ ezQtLayerPanel::ezQtLayerPanel(ads::CDockManager* pDockManager, QWidget* pParent
     "signal/slot connection failed");
 
   setWidget(m_pTreeWidget);
+
+  {
+    // Tool Bar
+    ezQtToolBarActionMapView* pToolBar = new ezQtToolBarActionMapView("Toolbar", this);
+    ezActionContext context;
+    context.m_sMapping = "EditorPluginScene_LayerToolbar";
+    context.m_pDocument = pDocument;
+    context.m_pWindow = this;
+    pToolBar->SetActionContext(context);
+    pToolBar->setObjectName("LayerPanel_ToolBar");
+    setToolBar(pToolBar);
+  }
 }
 
 ezQtLayerPanel::~ezQtLayerPanel() = default;

--- a/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/Icons/SelectAllowed.svg
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/Icons/SelectAllowed.svg
@@ -1,0 +1,10 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#ffffff">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<path d="M13.172 5.717l2.71-1.297.432.902-2.865 1.372zm.203-4.301l-.943-.333-1.028 2.915.872.535zm-9.219 8.616l.432.902 2.865-1.37-.587-.829zM6.978 2.03L8.06 4.291l.902-.431L7.88 1.599zm-.342 4.25L3.72 5.252l-.332.943 3.117 1.1zM21.813 15H16.36l3.032 6.049-3.94 1.981-3.106-6.152L9 21.462V5.65zm-7.074-1h4.007L10 7.618v10.777l2.501-3.427 3.393 6.72 2.155-1.084z"/>
+<path fill="none" d="M0 0h24v24H0z"/>
+</g>
+</svg>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/Icons/SelectForbidden.svg
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/Icons/SelectForbidden.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="#ffffff"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="SelectForbidden.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="0.71948115"
+     inkscape:cx="395.42384"
+     inkscape:cy="276.58821"
+     inkscape:window-width="1920"
+     inkscape:window-height="1010"
+     inkscape:window-x="1913"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="SVGRepo_iconCarrier" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round" />
+  <g
+     id="SVGRepo_iconCarrier">
+    <path
+       fill="none"
+       d="M0 0h24v24H0z"
+       id="path2" />
+    <path
+       fill="none"
+       d="M 0,0 H 24 V 24 H 0 Z"
+       id="path2-1" />
+    <path
+       d="M 0.6424193,7.4811818 C 0.56940488,11.453347 3.730408,14.732734 7.7025729,14.805748 11.675882,14.878784 14.954126,11.717759 15.02714,7.7455948 15.100176,3.7722856 11.940317,0.4929191 7.967007,0.41988364 3.9948524,0.34629725 0.71546527,3.5072996 0.6424193,7.4811818 Z M 7.9268443,2.6048326 C 8.9128752,2.6229579 9.8272414,2.9271438 10.59417,3.4352831 L 3.5586898,10.215659 C 3.0790696,9.4311481 2.8075366,8.5067722 2.8256614,7.5207405 2.8758552,4.7589282 5.1638976,2.5540456 7.9268443,2.6048326 Z M 7.7427356,12.6208 C 6.7555603,12.602654 5.8423385,12.298489 5.0753899,11.791495 L 12.11089,5.0099729 c 0.477342,0.7838974 0.749988,1.7100118 0.731864,2.6960421 -0.05019,2.76124 -2.338788,4.965541 -5.1000184,4.914785 z"
+       id="path1-6"
+       style="fill:#ff8080;stroke-width:0.572372" />
+    <path
+       d="M 21.813,15 H 16.36 l 3.032,6.049 -3.94,1.981 L 12.346,16.878 9,21.462 V 5.65 Z m -7.074,-1 h 4.007 L 10,7.618 v 10.777 l 2.501,-3.427 3.393,6.72 2.155,-1.084 z"
+       id="path1"
+       sodipodi:nodetypes="cccccccccccccccc" />
+  </g>
+</svg>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/resources.qrc
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/QtResources/resources.qrc
@@ -22,6 +22,8 @@
     <file>Icons/LayerLoaded.svg</file>
     <file>Icons/LayerUnloaded.svg</file>
     <file>Icons/SelectParent.svg</file>
+    <file>Icons/SelectAllowed.svg</file>
+    <file>Icons/SelectForbidden.svg</file>
   </qresource>
   <qresource prefix="TypeIcons">
     <file>ezMeshComponent.svg</file>

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -121,6 +121,18 @@ ezScene2Document::~ezScene2Document()
   }
 }
 
+void ezScene2Document::SetSwitchLayerToSelection(bool bEnable)
+{
+  if (m_bSwitchLayerToSelection == bEnable)
+    return;
+
+  m_bSwitchLayerToSelection = bEnable;
+
+  ezScene2LayerEvent e;
+  e.m_Type = ezScene2LayerEvent::Type::SettingsChanged;
+  m_LayerEvents.Broadcast(e);
+}
+
 void ezScene2Document::InitializeAfterLoading(bool bFirstTimeCreation)
 {
   EnsureSettingsObjectExist();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.h
@@ -56,6 +56,7 @@ struct ezScene2LayerEvent
     LayerVisible,
     LayerInvisible,
     ActiveLayerChanged,
+    SettingsChanged,
   };
 
   Type m_Type;
@@ -109,6 +110,9 @@ public:
   virtual ezGameObjectDocument* GetRedirectedGameObjectDoc() override;
 
   bool IsAnyLayerModified() const;
+
+  bool GetSwitchLayerToSelection() const { return m_bSwitchLayerToSelection; }
+  void SetSwitchLayerToSelection(bool bEnable);
 
   ///@}
   /// \name Base Class Functions
@@ -176,6 +180,7 @@ private:
   mutable ezUniquePtr<ezSelectionManager> m_pLayerSelection;
   ezUuid m_ActiveLayerGuid;
   ezHashTable<ezUuid, LayerInfo> m_Layers;
+  bool m_bSwitchLayerToSelection = true;
 
   void ActiveLayerGameObjectEventHandler(const ezGameObjectEvent& e);
 

--- a/Data/Samples/Testing Chambers/Scenes/Hall_data/Level Geometry.ezSceneLayer
+++ b/Data/Samples/Testing Chambers/Scenes/Hall_data/Level Geometry.ezSceneLayer
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Layer"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{15189912638122679973,5056406926986055588}}
-		u4 %Hash{9526914939352092304}
+		u4 %Hash{15331904616301469977}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -1271,6 +1271,33 @@ o
 }
 o
 {
+	Uuid %id{u4{7164440475931150003,1458624191468737905}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11329112634305722748,2446169078329304689}}
+			Uuid{u4{4733686916463924891,1663172076644293923}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0xFFFF7FBF,0}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{11622399420657189983,1459415729505972521}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -1539,6 +1566,33 @@ o
 }
 o
 {
+	Uuid %id{u4{4880536918892937885,1614223537853834170}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{9045209077267510630,2601768424714400954}}
+			Uuid{u4{2449783359425712773,1818771423029390188}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0xF30435BF,0xF304353F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{7717502928476155505,1623191599008552656}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -1610,6 +1664,25 @@ o
 		{
 			s{"CastShadow"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{4733686916463924891,1663172076644293923}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -1848,6 +1921,25 @@ o
 		{
 			s{"CastShadow"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{2449783359425712773,1818771423029390188}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -3981,6 +4073,33 @@ o
 }
 o
 {
+	Uuid %id{u4{11329112634305722748,2446169078329304689}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
+	}
+}
+o
+{
 	Uuid %id{u4{11206021289771368016,2477338153524831145}}
 	s %t{"ezScriptComponent"}
 	u3 %v{2}
@@ -4240,6 +4359,33 @@ o
 		s %ScriptClass{"{ dba927c8-40a8-462e-92f8-d2100b060b17 }"}
 		Time %UpdateInterval{d{0}}
 		b %UpdateOnlyWhenSimulating{1}
+	}
+}
+o
+{
+	Uuid %id{u4{9045209077267510630,2601768424714400954}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
 	}
 }
 o
@@ -8629,6 +8775,35 @@ o
 }
 o
 {
+	Uuid %id{u4{13827637536853494172,5295900170704454027}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{7164440475931150003,1458624191468737905}}
+			Uuid{u4{13412726514552731137,14486870746783143022}}
+			Uuid{u4{2589980270102530406,6345308261126493506}}
+			Uuid{u4{3032209679170319202,9406068633797787797}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x000010C1,0x000010C1,0x9A995941}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{10852481138874002419,5314022370608166895}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -9591,6 +9766,33 @@ o
 }
 o
 {
+	Uuid %id{u4{2589980270102530406,6345308261126493506}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6754652428477103151,7332853147987060290}}
+			Uuid{u4{159226710635305294,6549856146302049524}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0xF20435BF,0xF20435BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{7910609632897142621,6356438122708232067}}
 	s %t{"ezJoltShapeConvexHullComponent"}
 	u3 %v{1}
@@ -9830,6 +10032,8 @@ o
 			Uuid{u4{8668056355962254804,16494755262900068839}}
 			Uuid{u4{1129358326224983869,11427844898843623272}}
 			Uuid{u4{1448734719282759689,15246739518875187335}}
+			Uuid{u4{13827637536853494172,5295900170704454027}}
+			Uuid{u4{5295447941193700920,10869997035484696791}}
 		}
 		Uuid %Settings{u4{3545585462772090823,5964016910079890489}}
 	}
@@ -10070,6 +10274,25 @@ o
 		{
 			s{"CastShadow"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{159226710635305294,6549856146302049524}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -11375,6 +11598,33 @@ o
 }
 o
 {
+	Uuid %id{u4{17078994953980908367,7032721056248980669}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2796923038645929496,8020265943109547453}}
+			Uuid{u4{14648241394513683255,7237268941424536687}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0xFFFF7FBF,0}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{7698989539607303934,7033650918906893406}}
 	s %t{"ezScriptComponent"}
 	u3 %v{2}
@@ -12075,6 +12325,25 @@ o
 }
 o
 {
+	Uuid %id{u4{14648241394513683255,7237268941424536687}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
+	}
+}
+o
+{
 	Uuid %id{u4{4501829057139255658,7242071879366310950}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -12373,6 +12642,33 @@ o
 		f %Thickness{0xCDCCCC3D}
 		Vec2 %UVScale{f{0x0000A040,0x9A99993F}}
 		f %Width{0x0000A040}
+	}
+}
+o
+{
+	Uuid %id{u4{6754652428477103151,7332853147987060290}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
 	}
 }
 o
@@ -13632,6 +13928,33 @@ o
 		f %StiffnessFactor{0x0000803F}
 		u1 %WeightCategory{17}
 		f %WeightScale{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{2796923038645929496,8020265943109547453}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
 	}
 }
 o
@@ -15429,6 +15752,33 @@ o
 }
 o
 {
+	Uuid %id{u4{3032209679170319202,9406068633797787797}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7196881837544891947,10393613520658354581}}
+			Uuid{u4{601456119703094090,9610616518973343815}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{6249282977794061642,9415115838431552548}}
 	s %t{"ezScriptComponent"}
 	u3 %v{2}
@@ -15653,6 +16003,25 @@ o
 		{
 			s{"CastShadow"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{601456119703094090,9610616518973343815}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -17978,6 +18347,33 @@ o
 }
 o
 {
+	Uuid %id{u4{7196881837544891947,10393613520658354581}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
+	}
+}
+o
+{
 	Uuid %id{u4{11868564454406751553,10421247223181792916}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -18738,6 +19134,35 @@ o
 		s %GlobalKey{""}
 		Vec3 %LocalPosition{f{0x9C9909C1,0x04002040,0}}
 		Quat %LocalRotation{f{0,0,0x0000803F,0x000000B3}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{5295447941193700920,10869997035484696791}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{17078994953980908367,7032721056248980669}}
+			Uuid{u4{4880536918892937885,1614223537853834170}}
+			Uuid{u4{12504534748152288770,11919405125906736270}}
+			Uuid{u4{12946764157220077566,14980165498578030561}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0000E841,0x000010C1,0x9A995941}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
@@ -20029,6 +20454,33 @@ o
 }
 o
 {
+	Uuid %id{u4{12504534748152288770,11919405125906736270}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16669206906526861515,12906950012767303054}}
+			Uuid{u4{10073781188685063658,12123953011082292288}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0xF20435BF,0xF20435BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{15223637333647398909,11926379792631522293}}
 	s %t{"ezJoltBreakableSlabComponent"}
 	u3 %v{1}
@@ -20687,6 +21139,25 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10073781188685063658,12123953011082292288}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -22216,6 +22687,33 @@ o
 }
 o
 {
+	Uuid %id{u4{16669206906526861515,12906950012767303054}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
+	}
+}
+o
+{
 	Uuid %id{u4{14382112591504779000,12919549532748781501}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -23719,6 +24217,33 @@ o
 }
 o
 {
+	Uuid %id{u4{13412726514552731137,14486870746783143022}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17577398672927303882,15474415633643709806}}
+			Uuid{u4{10981972955085506025,14691418631958699040}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0xF30435BF,0xF304353F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{290735877770923914,14496278772947041281}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -23892,6 +24417,25 @@ o
 		s %ScriptClass{"{ dba927c8-40a8-462e-92f8-d2100b060b17 }"}
 		Time %UpdateInterval{d{0}}
 		b %UpdateOnlyWhenSimulating{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10981972955085506025,14691418631958699040}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -24577,6 +25121,33 @@ o
 		s %GlobalKey{""}
 		Vec3 %LocalPosition{f{0x68668640,0x603009B4,0x7F7330B6}}
 		Quat %LocalRotation{f{0xEC04353F,0xE80435B3,0xEE0435B3,0xEC0435BF}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{12946764157220077566,14980165498578030561}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17111436315594650311,15967710385438597345}}
+			Uuid{u4{10516010597752852454,15184713383753586579}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0,0,0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
@@ -25494,6 +26065,25 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10516010597752852454,15184713383753586579}}
+	s %t{"ezRotorComponent"}
+	u3 %v{3}
+	p
+	{
+		f %Acceleration{0}
+		b %Active{1}
+		s %Axis{"ezBasisAxis::PositiveZ"}
+		Angle %AxisDeviation{f{0}}
+		f %Deceleration{0}
+		i3 %DegreesToRotate{0}
+		b %ReverseAtEnd{1}
+		b %ReverseAtStart{1}
+		b %Running{1}
+		f %Speed{0x00003443}
 	}
 }
 o
@@ -26576,6 +27166,33 @@ o
 }
 o
 {
+	Uuid %id{u4{17577398672927303882,15474415633643709806}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
+	}
+}
+o
+{
 	Uuid %id{u4{16179788427413515040,15503086239253662399}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -27491,6 +28108,33 @@ o
 		s %ScriptClass{"{ dba927c8-40a8-462e-92f8-d2100b060b17 }"}
 		Time %UpdateInterval{d{0}}
 		b %UpdateOnlyWhenSimulating{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17111436315594650311,15967710385438597345}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{16}
+		b %GenerateCollision{1}
+		s %Material{""}
+		s %Shape{"ezGreyBoxShape::Box"}
+		f %SizeNegX{0x00000041}
+		f %SizeNegY{0x0000003F}
+		f %SizeNegZ{0xCDCCCC3D}
+		f %SizePosX{0}
+		f %SizePosY{0x0000003F}
+		f %SizePosZ{0xCDCCCC3D}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Scenes/Hall_data/Scene Config.ezSceneLayer
+++ b/Data/Samples/Testing Chambers/Scenes/Hall_data/Scene Config.ezSceneLayer
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Layer"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{4025706763557391268,5561767617844493014}}
-		u4 %Hash{8974483691524073322}
+		u4 %Hash{12318718853050300255}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -67,7 +67,7 @@ o
 			Uuid{u4{14297796451663817887,2620174386669844025}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0xCDCCCC41,0x9A997940,0x31335340}}
+		Vec3 %LocalPosition{f{0xCDCCCC41,0x0000B040,0x6266E63F}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
@@ -163,7 +163,7 @@ o
 			Uuid{u4{15052979748227913434,5329957381823104229}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x343383C0,0x6966A6BF,0x31335340}}
+		Vec3 %LocalPosition{f{0x343383C0,0xCFCC8CBF,0xCBCC0C40}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
@@ -442,7 +442,7 @@ o
 			Uuid{u4{7906681225849977954,10122298778038626929}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x343383C0,0x34339BC1,0x31335340}}
+		Vec3 %LocalPosition{f{0x000090C0,0x67669AC1,0x9599D93F}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}

--- a/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
@@ -169,6 +169,7 @@ Layer.SaveLayer;Save Layer
 Layer.SaveActiveLayer;Save Active Layer
 Layer.LayerLoaded;Layer Loaded
 Layer.LayerVisible;Layer Visible
+Layer.SwitchOnSelection;Auto Switch Layer to Selection;Automatically switch to the layer that a selected object is in. If disabled, only objects in the active layer can be selected, to prevent accidentally editing a different layer.
 
 ezLogicOperator::Equal;=
 ezLogicOperator::Unequal;<>


### PR DESCRIPTION
Added an option that allows to disable automatically switching the active layer. If an object in a different layer is selected, the statusbar will show a message. This is supposed to help prevent accidentally editing a different layer.

![image](https://github.com/user-attachments/assets/e8260094-5ab8-4f63-986b-55ad88e63479)
