### PR TITLE
Sped up BreakableSlab setup in editor

### DIFF
--- a/Code/Engine/Core/ResourceManager/Implementation/Resource.cpp
+++ b/Code/Engine/Core/ResourceManager/Implementation/Resource.cpp
@@ -294,7 +294,7 @@ void ezResource::VerifyAfterCreateResource(const ezResourceLoadDesc& ld)
   e.m_Type = ezResourceEvent::Type::ResourceContentUpdated;
   ezResourceManager::BroadcastResourceEvent(e);
 
-  ezLog::Debug("Created {0} - '{1}' ", GetDynamicRTTI()->GetTypeName(), ezArgSensitive(GetResourceDescription(), "ResourceDesc"));
+  ezLog::Debug("Created {0} - '{1}' ", GetDynamicRTTI()->GetTypeName(), ezArgSensitive(GetResourceIdOrDescription(), "ResourceDesc"));
 }
 
 EZ_STATICLINK_FILE(Core, Core_ResourceManager_Implementation_Resource);

--- a/Code/Engine/Core/World/Implementation/ComponentManager_inl.h
+++ b/Code/Engine/Core/World/Implementation/ComponentManager_inl.h
@@ -147,9 +147,10 @@ template <typename T, ezBlockStorageType::Enum StorageType>
 EZ_FORCE_INLINE void ezComponentManager<T, StorageType>::RegisterUpdateFunction(UpdateFunctionDesc& desc)
 {
   // round up to multiple of data block capacity so tasks only have to deal with complete data blocks
-  if (desc.m_uiGranularity != 0)
-    desc.m_uiGranularity = static_cast<ezUInt16>(
-      ezMath::RoundUp(static_cast<ezInt32>(desc.m_uiGranularity), ezDataBlock<ComponentType, ezInternal::DEFAULT_BLOCK_SIZE>::CAPACITY));
+  if (desc.m_uiAsyncPhaseBatchSize != 0)
+  {
+    desc.m_uiAsyncPhaseBatchSize = static_cast<ezUInt16>(ezMath::RoundUp(static_cast<ezInt32>(desc.m_uiAsyncPhaseBatchSize), ezDataBlock<ComponentType, ezInternal::DEFAULT_BLOCK_SIZE>::CAPACITY));
+  }
 
   ezComponentManagerBase::RegisterUpdateFunction(desc);
 }

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -1045,7 +1045,6 @@ void ezWorld::RegisterUpdateFunction(const ezComponentManagerBase::UpdateFunctio
 {
   CheckForWriteAccess();
 
-  EZ_ASSERT_DEV(desc.m_Phase == ezWorldUpdatePhase::Async || desc.m_uiGranularity == 0, "Granularity must be 0 for synchronous update functions");
   EZ_ASSERT_DEV(desc.m_Phase != ezWorldUpdatePhase::Async || desc.m_DependsOn.GetCount() == 0, "Asynchronous update functions must not have dependencies");
   EZ_ASSERT_DEV(desc.m_Function.IsComparable(), "Delegates with captures are not allowed as ezWorld update functions.");
 
@@ -1133,7 +1132,7 @@ void ezWorld::UpdateAsynchronous()
 
     // a world module can also register functions in the async phase so we want at least one task
     const ezUInt32 uiTotalCount = pManager != nullptr ? pManager->GetComponentCount() : 1;
-    const ezUInt32 uiGranularity = (updateFunction.m_uiGranularity != 0) ? updateFunction.m_uiGranularity : uiTotalCount;
+    const ezUInt32 uiGranularity = (updateFunction.m_uiAsyncPhaseBatchSize != 0) ? updateFunction.m_uiAsyncPhaseBatchSize : uiTotalCount;
 
     ezUInt32 uiStartIndex = 0;
     while (uiStartIndex < uiTotalCount)

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -179,7 +179,7 @@ namespace ezInternal
       ezWorldModule::UpdateFunction m_Function;
       ezHashedString m_sFunctionName;
       float m_fPriority;
-      ezUInt16 m_uiGranularity;
+      ezUInt16 m_uiAsyncPhaseBatchSize;
       bool m_bOnlyUpdateWhenSimulating;
 
       void FillFromDesc(const ezWorldModule::UpdateFunctionDesc& desc);

--- a/Code/Engine/Core/World/Implementation/WorldData_inl.h
+++ b/Code/Engine/Core/World/Implementation/WorldData_inl.h
@@ -197,7 +197,7 @@ namespace ezInternal
     m_Function = desc.m_Function;
     m_sFunctionName = desc.m_sFunctionName;
     m_fPriority = desc.m_fPriority;
-    m_uiGranularity = desc.m_uiGranularity;
+    m_uiAsyncPhaseBatchSize = desc.m_uiAsyncPhaseBatchSize;
     m_bOnlyUpdateWhenSimulating = desc.m_bOnlyUpdateWhenSimulating;
   }
 

--- a/Code/Engine/Core/World/WorldModule.h
+++ b/Code/Engine/Core/World/WorldModule.h
@@ -70,8 +70,8 @@ protected:
                                                   ///< called after all its dependencies have been called.
     ezEnum<ezWorldUpdatePhase> m_Phase;           ///< The update phase in which this update function should be called. See ezWorld for a description on the different phases.
     bool m_bOnlyUpdateWhenSimulating = false;     ///< The update function is only called when the world simulation is enabled.
-    ezUInt16 m_uiAsyncPhaseBatchSize = 0;         ///< 0 means all components are updated one after another, but still in parallel with other component managers.
-                                                  ///< >0 means m_Function will be called multiple times with batches of roughly this size.
+    ezUInt16 m_uiAsyncPhaseBatchSize = 0;         ///< 0 means m_Function is called once per frame, to update all components, but still in parallel with other world modules.
+                                                  ///< >0 means m_Function is called multiple times (in parallel) with batches of roughly this size.
     float m_fPriority = 0.0f;                     ///< Higher priority (higher number) means that this function is called earlier than a function with lower priority.
   };
 

--- a/Code/Engine/Core/World/WorldModule.h
+++ b/Code/Engine/Core/World/WorldModule.h
@@ -70,8 +70,8 @@ protected:
                                                   ///< called after all its dependencies have been called.
     ezEnum<ezWorldUpdatePhase> m_Phase;           ///< The update phase in which this update function should be called. See ezWorld for a description on the different phases.
     bool m_bOnlyUpdateWhenSimulating = false;     ///< The update function is only called when the world simulation is enabled.
-    ezUInt16 m_uiGranularity = 0;                 ///< The granularity in which batch updates should happen during the asynchronous phase. Has to be 0 for
-                                                  ///< synchronous functions.
+    ezUInt16 m_uiAsyncPhaseBatchSize = 0;         ///< 0 means all components are updated one after another, but still in parallel with other component managers.
+                                                  ///< >0 means m_Function will be called multiple times with batches of roughly this size.
     float m_fPriority = 0.0f;                     ///< Higher priority (higher number) means that this function is called earlier than a function with lower priority.
   };
 

--- a/Code/Engine/GameEngine/AI/Implementation/SensorComponent.cpp
+++ b/Code/Engine/GameEngine/AI/Implementation/SensorComponent.cpp
@@ -621,18 +621,19 @@ void ezSensorWorldModule::Initialize()
   SUPER::Initialize();
 
   {
-    auto updateDesc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezSensorWorldModule::UpdateSensors, this);
-    updateDesc.m_Phase = ezWorldUpdatePhase::Async;
-    updateDesc.m_bOnlyUpdateWhenSimulating = true;
+    auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezSensorWorldModule::UpdateSensors, this);
+    desc.m_Phase = ezWorldUpdatePhase::Async;
+    desc.m_bOnlyUpdateWhenSimulating = true;
+    desc.m_uiAsyncPhaseBatchSize = 16;
 
-    RegisterUpdateFunction(updateDesc);
+    RegisterUpdateFunction(desc);
   }
 
   {
-    auto updateDesc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezSensorWorldModule::DebugDrawSensors, this);
-    updateDesc.m_Phase = ezWorldUpdatePhase::PostTransform;
+    auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezSensorWorldModule::DebugDrawSensors, this);
+    desc.m_Phase = ezWorldUpdatePhase::PostTransform;
 
-    RegisterUpdateFunction(updateDesc);
+    RegisterUpdateFunction(desc);
   }
 
   m_pPhysicsWorldModule = GetWorld()->GetOrCreateModule<ezPhysicsWorldModuleInterface>();

--- a/Code/Engine/GameEngine/AI/Implementation/SensorComponent.cpp
+++ b/Code/Engine/GameEngine/AI/Implementation/SensorComponent.cpp
@@ -624,7 +624,6 @@ void ezSensorWorldModule::Initialize()
     auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezSensorWorldModule::UpdateSensors, this);
     desc.m_Phase = ezWorldUpdatePhase::Async;
     desc.m_bOnlyUpdateWhenSimulating = true;
-    desc.m_uiAsyncPhaseBatchSize = 16;
 
     RegisterUpdateFunction(desc);
   }

--- a/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
+++ b/Code/EnginePlugins/FmodPlugin/Components/FmodEventComponent.cpp
@@ -77,6 +77,7 @@ void ezFmodEventComponentManager::Initialize()
     auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezFmodEventComponentManager::UpdateOcclusion, this);
     desc.m_Phase = ezWorldUpdatePhase::Async;
     desc.m_bOnlyUpdateWhenSimulating = true;
+    desc.m_uiAsyncPhaseBatchSize = 8;
 
     this->RegisterUpdateFunction(desc);
   }

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/ClothSheetComponent.cpp
@@ -610,6 +610,7 @@ void ezClothSheetComponentManager::Initialize()
     auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezClothSheetComponentManager::Update, this);
     desc.m_Phase = ezWorldUpdatePhase::Async;
     desc.m_bOnlyUpdateWhenSimulating = true;
+    desc.m_uiAsyncPhaseBatchSize = 2;
 
     this->RegisterUpdateFunction(desc);
   }

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
@@ -463,6 +463,7 @@ void ezFakeRopeComponentManager::Initialize()
     auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezFakeRopeComponentManager::Update, this);
     desc.m_Phase = ezWorldUpdatePhase::Async;
     desc.m_bOnlyUpdateWhenSimulating = false;
+    desc.m_uiAsyncPhaseBatchSize = 4;
 
     this->RegisterUpdateFunction(desc);
   }

--- a/Code/EnginePlugins/JoltPlugin/Components/JoltBreakableSlabComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Components/JoltBreakableSlabComponent.h
@@ -80,10 +80,15 @@ private:
   friend class ezJoltWorldModule;
   friend class ezJoltBreakableSlabComponent;
 
+  void PreAsyncUpdate(const ezWorldModule::UpdateContext& context);
+  void ReinitSlabs(const ezWorldModule::UpdateContext& context);
   void Update(const ezWorldModule::UpdateContext& context);
 
   ezSet<ezComponentHandle> m_RequireBreakage;
   ezSet<ezComponentHandle> m_RequireBreakUpdate;
+
+  ezAtomicInteger32 m_iTriggerBoundsUpdateSlot;
+  ezDynamicArray<ezJoltBreakableSlabComponent*> m_TriggerBoundsUpdate;
 };
 
 /// \brief Represents a point in world space, where the breakable slab should be shattered.
@@ -236,6 +241,7 @@ private:
   ezMaterialResourceHandle m_hMaterial;
   ezSurfaceResourceHandle m_hSurface;
 
+  bool m_bReinitMeshes = true;
   ezInt8 m_iSwitchToSkinningState = -1;
   mutable ezInt8 m_iSkinningStateToUse = -1;
   mutable ezMeshResourceHandle m_hSwitchToMesh;

--- a/Code/UnitTests/CoreTest/World/ComponentTest.cpp
+++ b/Code/UnitTests/CoreTest/World/ComponentTest.cpp
@@ -29,7 +29,7 @@ namespace
 
       auto descAsync = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(TestComponentManager::UpdateAsync, this);
       descAsync.m_Phase = ezWorldUpdatePhase::Async;
-      descAsync.m_uiGranularity = 20;
+      descAsync.m_uiAsyncPhaseBatchSize = 20;
 
       // Update functions are now registered in reverse order, so we can test whether dependencies work.
       this->RegisterUpdateFunction(descAsync);


### PR DESCRIPTION
It was recreating meshes many times during scene setup. Now this is done only once and potentially on a separate thread. Also optimized the rectangle shape creation.
Clarified and renamed the component update function description.