### PR TITLE
Shader Compiler Multi-Treading Support and Renderer Fixes

### DIFF
--- a/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/CreateProjectDlg.cpp
@@ -331,6 +331,9 @@ void ezQtCreateProjectDlg::CreateProject()
     // make sure, that in case we copied an AssetCache, it gets deleted
     // so that the project definitely starts fresh
     ezStringBuilder sAssetCache(sFullPath, "/AssetCache");
-    ezOSFile::DeleteFolder(sAssetCache);
+    if (ezOSFile::DeleteFolder(sAssetCache).Failed())
+    {
+      // TODO
+    }
   }
 }

--- a/Code/Engine/Foundation/IO/DependencyFile.h
+++ b/Code/Engine/Foundation/IO/DependencyFile.h
@@ -62,5 +62,6 @@ private:
     ezTime m_LastCheck;
   };
 
+  static ezMutex s_FileTimestampsLock;
   static ezMap<ezString, FileCheckCache> s_FileTimestamps;
 };

--- a/Code/Engine/Foundation/IO/Implementation/DependencyFile.cpp
+++ b/Code/Engine/Foundation/IO/Implementation/DependencyFile.cpp
@@ -16,6 +16,7 @@ enum class ezDependencyFileVersion : ezUInt8
   Current = ENUM_COUNT - 1,
 };
 
+ezMutex ezDependencyFile::s_FileTimestampsLock;
 ezMap<ezString, ezDependencyFile::FileCheckCache> ezDependencyFile::s_FileTimestamps;
 
 ezDependencyFile::ezDependencyFile()
@@ -145,7 +146,7 @@ ezResult ezDependencyFile::ReadDependencyFile(ezStreamReader& inout_stream)
 ezResult ezDependencyFile::RetrieveFileTimeStamp(ezStringView sFile, ezTimestamp& out_Result)
 {
 #if EZ_ENABLED(EZ_SUPPORTS_FILE_STATS)
-
+  EZ_LOCK(s_FileTimestampsLock);
   bool bExisted = false;
   auto it = s_FileTimestamps.FindOrAdd(sFile, &bExisted);
 

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -99,7 +99,7 @@ ezString ezGameApplication::FindProjectDirectory() const
 
 bool ezGameApplication::IsGameUpdateEnabled() const
 {
-  return ezRenderWorld::GetMainViews().GetCount() > 0;
+  return ezRenderWorld::IsRenderingScheduled();
 }
 
 void ezGameApplication::Run_WorldUpdateAndRender()

--- a/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
@@ -219,7 +219,6 @@ void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLa
           item.m_Flags = ezGALBindGroupItemFlags::Buffer | ezGALBindGroupItemFlags::Fallback;
           item.m_Buffer.m_hBuffer = hBuffer;
           item.m_Buffer.m_BufferRange = pBuffer->ClampRange({});
-          ;
           item.m_Buffer.m_OverrideTexelBufferFormat = {};
         }
       }

--- a/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
+++ b/Code/Engine/RendererCore/RenderWorld/Implementation/RenderWorld.cpp
@@ -255,6 +255,11 @@ ezArrayPtr<ezViewHandle> ezRenderWorld::GetMainViews()
   return s_MainViews;
 }
 
+bool ezRenderWorld::IsRenderingScheduled()
+{
+  return !s_MainViews.IsEmpty() || !s_FilteredRenderPipelines[GetDataIndexForRendering()].IsEmpty();
+}
+
 void ezRenderWorld::CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries)
 {
   if (cvar_RenderingCachingStaticObjects)

--- a/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
+++ b/Code/Engine/RendererCore/RenderWorld/RenderWorld.h
@@ -51,6 +51,7 @@ public:
   static void RemoveMainView(const ezViewHandle& hView);
   static void ClearMainViews();
   static ezArrayPtr<ezViewHandle> GetMainViews();
+  static bool IsRenderingScheduled();
 
   static void CacheRenderData(const ezView& view, const ezGameObjectHandle& hOwnerObject, const ezComponentHandle& hOwnerComponent, ezUInt16 uiComponentVersion, ezArrayPtr<ezInternal::RenderDataCacheEntry> cacheEntries);
 

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStageBinary.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStageBinary.cpp
@@ -262,6 +262,7 @@ ezShaderStageBinary* ezShaderStageBinary::LoadStageBinary(ezGALShaderStage::Enum
 // static
 void ezShaderStageBinary::OnEngineShutdown()
 {
+  EZ_LOCK(s_ShaderStageBinariesLock);
   for (ezUInt32 stage = 0; stage < ezGALShaderStage::ENUM_COUNT; ++stage)
   {
     s_ShaderStageBinaries[stage].Clear();

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStageBinary.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStageBinary.cpp
@@ -10,6 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 ezMap<ezUInt32, ezShaderStageBinary> ezShaderStageBinary::s_ShaderStageBinaries[ezGALShaderStage::ENUM_COUNT];
+ezMutex ezShaderStageBinary::s_ShaderStageBinariesLock;
 
 ezShaderStageBinary::ezShaderStageBinary() = default;
 
@@ -227,6 +228,7 @@ ezResult ezShaderStageBinary::WriteStageBinary(ezLogInterface* pLog, ezStringVie
 // static
 ezShaderStageBinary* ezShaderStageBinary::LoadStageBinary(ezGALShaderStage::Enum Stage, ezUInt32 uiHash, ezStringView sPlatform)
 {
+  EZ_LOCK(s_ShaderStageBinariesLock);
   auto itStage = s_ShaderStageBinaries[Stage].Find(uiHash);
 
   if (!itStage.IsValid())

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
@@ -277,6 +277,7 @@ static ezInt32 GetIntStateVariable(const ezMap<ezString, ezString>& variables, c
 }
 
 // Global variables don't use memory tracking, so these won't reported as memory leaks.
+static ezMutex StateValuesLock;
 static ezMap<ezString, ezInt32> StateValuesBlend;
 static ezMap<ezString, ezInt32> StateValuesBlendOp;
 static ezMap<ezString, ezInt32> StateValuesCullMode;
@@ -315,63 +316,66 @@ ezResult ezShaderStateResourceDescriptor::Parse(const char* szSource)
     }
   }
 
-  if (StateValuesBlend.IsEmpty())
   {
-    // ezGALBlend
+    EZ_LOCK(StateValuesLock);
+    if (StateValuesBlend.IsEmpty())
     {
-      StateValuesBlend["Blend_Zero"] = ezGALBlend::Zero;
-      StateValuesBlend["Blend_One"] = ezGALBlend::One;
-      StateValuesBlend["Blend_SrcColor"] = ezGALBlend::SrcColor;
-      StateValuesBlend["Blend_InvSrcColor"] = ezGALBlend::InvSrcColor;
-      StateValuesBlend["Blend_SrcAlpha"] = ezGALBlend::SrcAlpha;
-      StateValuesBlend["Blend_InvSrcAlpha"] = ezGALBlend::InvSrcAlpha;
-      StateValuesBlend["Blend_DestAlpha"] = ezGALBlend::DestAlpha;
-      StateValuesBlend["Blend_InvDestAlpha"] = ezGALBlend::InvDestAlpha;
-      StateValuesBlend["Blend_DestColor"] = ezGALBlend::DestColor;
-      StateValuesBlend["Blend_InvDestColor"] = ezGALBlend::InvDestColor;
-      StateValuesBlend["Blend_SrcAlphaSaturated"] = ezGALBlend::SrcAlphaSaturated;
-      StateValuesBlend["Blend_BlendFactor"] = ezGALBlend::BlendFactor;
-      StateValuesBlend["Blend_InvBlendFactor"] = ezGALBlend::InvBlendFactor;
-    }
+      // ezGALBlend
+      {
+        StateValuesBlend["Blend_Zero"] = ezGALBlend::Zero;
+        StateValuesBlend["Blend_One"] = ezGALBlend::One;
+        StateValuesBlend["Blend_SrcColor"] = ezGALBlend::SrcColor;
+        StateValuesBlend["Blend_InvSrcColor"] = ezGALBlend::InvSrcColor;
+        StateValuesBlend["Blend_SrcAlpha"] = ezGALBlend::SrcAlpha;
+        StateValuesBlend["Blend_InvSrcAlpha"] = ezGALBlend::InvSrcAlpha;
+        StateValuesBlend["Blend_DestAlpha"] = ezGALBlend::DestAlpha;
+        StateValuesBlend["Blend_InvDestAlpha"] = ezGALBlend::InvDestAlpha;
+        StateValuesBlend["Blend_DestColor"] = ezGALBlend::DestColor;
+        StateValuesBlend["Blend_InvDestColor"] = ezGALBlend::InvDestColor;
+        StateValuesBlend["Blend_SrcAlphaSaturated"] = ezGALBlend::SrcAlphaSaturated;
+        StateValuesBlend["Blend_BlendFactor"] = ezGALBlend::BlendFactor;
+        StateValuesBlend["Blend_InvBlendFactor"] = ezGALBlend::InvBlendFactor;
+      }
 
-    // ezGALBlendOp
-    {
-      StateValuesBlendOp["BlendOp_Add"] = ezGALBlendOp::Add;
-      StateValuesBlendOp["BlendOp_Subtract"] = ezGALBlendOp::Subtract;
-      StateValuesBlendOp["BlendOp_RevSubtract"] = ezGALBlendOp::RevSubtract;
-      StateValuesBlendOp["BlendOp_Min"] = ezGALBlendOp::Min;
-      StateValuesBlendOp["BlendOp_Max"] = ezGALBlendOp::Max;
-    }
+      // ezGALBlendOp
+      {
+        StateValuesBlendOp["BlendOp_Add"] = ezGALBlendOp::Add;
+        StateValuesBlendOp["BlendOp_Subtract"] = ezGALBlendOp::Subtract;
+        StateValuesBlendOp["BlendOp_RevSubtract"] = ezGALBlendOp::RevSubtract;
+        StateValuesBlendOp["BlendOp_Min"] = ezGALBlendOp::Min;
+        StateValuesBlendOp["BlendOp_Max"] = ezGALBlendOp::Max;
+      }
 
-    // ezGALCullMode
-    {
-      StateValuesCullMode["CullMode_None"] = ezGALCullMode::None;
-      StateValuesCullMode["CullMode_Front"] = ezGALCullMode::Front;
-      StateValuesCullMode["CullMode_Back"] = ezGALCullMode::Back;
-    }
+      // ezGALCullMode
+      {
+        StateValuesCullMode["CullMode_None"] = ezGALCullMode::None;
+        StateValuesCullMode["CullMode_Front"] = ezGALCullMode::Front;
+        StateValuesCullMode["CullMode_Back"] = ezGALCullMode::Back;
+      }
 
-    // ezGALCompareFunc
-    {
-      StateValuesCompareFunc["CompareFunc_Never"] = ezGALCompareFunc::Never;
-      StateValuesCompareFunc["CompareFunc_Less"] = ezGALCompareFunc::Less;
-      StateValuesCompareFunc["CompareFunc_Equal"] = ezGALCompareFunc::Equal;
-      StateValuesCompareFunc["CompareFunc_LessEqual"] = ezGALCompareFunc::LessEqual;
-      StateValuesCompareFunc["CompareFunc_Greater"] = ezGALCompareFunc::Greater;
-      StateValuesCompareFunc["CompareFunc_NotEqual"] = ezGALCompareFunc::NotEqual;
-      StateValuesCompareFunc["CompareFunc_GreaterEqual"] = ezGALCompareFunc::GreaterEqual;
-      StateValuesCompareFunc["CompareFunc_Always"] = ezGALCompareFunc::Always;
-    }
+      // ezGALCompareFunc
+      {
+        StateValuesCompareFunc["CompareFunc_Never"] = ezGALCompareFunc::Never;
+        StateValuesCompareFunc["CompareFunc_Less"] = ezGALCompareFunc::Less;
+        StateValuesCompareFunc["CompareFunc_Equal"] = ezGALCompareFunc::Equal;
+        StateValuesCompareFunc["CompareFunc_LessEqual"] = ezGALCompareFunc::LessEqual;
+        StateValuesCompareFunc["CompareFunc_Greater"] = ezGALCompareFunc::Greater;
+        StateValuesCompareFunc["CompareFunc_NotEqual"] = ezGALCompareFunc::NotEqual;
+        StateValuesCompareFunc["CompareFunc_GreaterEqual"] = ezGALCompareFunc::GreaterEqual;
+        StateValuesCompareFunc["CompareFunc_Always"] = ezGALCompareFunc::Always;
+      }
 
-    // ezGALStencilOp
-    {
-      StateValuesStencilOp["StencilOp_Keep"] = ezGALStencilOp::Keep;
-      StateValuesStencilOp["StencilOp_Zero"] = ezGALStencilOp::Zero;
-      StateValuesStencilOp["StencilOp_Replace"] = ezGALStencilOp::Replace;
-      StateValuesStencilOp["StencilOp_IncrementSaturated"] = ezGALStencilOp::IncrementSaturated;
-      StateValuesStencilOp["StencilOp_DecrementSaturated"] = ezGALStencilOp::DecrementSaturated;
-      StateValuesStencilOp["StencilOp_Invert"] = ezGALStencilOp::Invert;
-      StateValuesStencilOp["StencilOp_Increment"] = ezGALStencilOp::Increment;
-      StateValuesStencilOp["StencilOp_Decrement"] = ezGALStencilOp::Decrement;
+      // ezGALStencilOp
+      {
+        StateValuesStencilOp["StencilOp_Keep"] = ezGALStencilOp::Keep;
+        StateValuesStencilOp["StencilOp_Zero"] = ezGALStencilOp::Zero;
+        StateValuesStencilOp["StencilOp_Replace"] = ezGALStencilOp::Replace;
+        StateValuesStencilOp["StencilOp_IncrementSaturated"] = ezGALStencilOp::IncrementSaturated;
+        StateValuesStencilOp["StencilOp_DecrementSaturated"] = ezGALStencilOp::DecrementSaturated;
+        StateValuesStencilOp["StencilOp_Invert"] = ezGALStencilOp::Invert;
+        StateValuesStencilOp["StencilOp_Increment"] = ezGALStencilOp::Increment;
+        StateValuesStencilOp["StencilOp_Decrement"] = ezGALStencilOp::Decrement;
+      }
     }
   }
 

--- a/Code/Engine/RendererCore/Shader/ShaderStageBinary.h
+++ b/Code/Engine/RendererCore/Shader/ShaderStageBinary.h
@@ -55,5 +55,6 @@ private: // statics
 
   static void OnEngineShutdown();
 
+  static ezMutex s_ShaderStageBinariesLock;
   static ezMap<ezUInt32, ezShaderStageBinary> s_ShaderStageBinaries[ezGALShaderStage::ENUM_COUNT];
 };

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -12,6 +12,7 @@ using namespace ezTokenParseUtils;
 
 namespace
 {
+  static ezMutex s_TableLock;
   static ezHashTable<ezStringView, const ezRTTI*> s_NameToTypeTable;
   static ezHashTable<ezStringView, ezEnum<ezGALShaderResourceType>> s_NameToDescriptorTable;
   static ezHashTable<ezStringView, ezEnum<ezGALShaderTextureType>> s_NameToTextureTable;
@@ -21,6 +22,8 @@ namespace
 
   void InitializeTables()
   {
+    EZ_LOCK(s_TableLock);
+
     if (!s_NameToTypeTable.IsEmpty())
       return;
 

--- a/Code/Engine/RendererCore/ShaderCompiler/ShaderCompiler.h
+++ b/Code/Engine/RendererCore/ShaderCompiler/ShaderCompiler.h
@@ -44,10 +44,10 @@ public:
 class EZ_RENDERERCORE_DLL ezShaderCompiler
 {
 public:
-  ezResult CompileShaderPermutationForPlatforms(ezStringView sFile, const ezArrayPtr<const ezPermutationVar>& permutationVars, ezLogInterface* pLog, ezStringView sPlatform = "ALL");
+  ezResult CompileShaderPermutationForPlatforms(ezStringView sFile, const ezArrayPtr<const ezPermutationVar>& permutationVars, ezLogInterface* pLog, ezStringView sPlatform = "ALL", ezTokenizedFileCache* pFileCache = nullptr);
 
 private:
-  ezResult RunShaderCompiler(ezStringView sFile, ezStringView sPlatform, ezShaderProgramCompiler* pCompiler, ezLogInterface* pLog);
+  ezResult RunShaderCompiler(ezStringView sFile, ezStringView sPlatform, ezShaderProgramCompiler* pCompiler, ezLogInterface* pLog, ezTokenizedFileCache* pFileCache = nullptr);
 
   void WriteFailedShaderSource(ezShaderProgramData& spd, ezLogInterface* pLog);
 

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -142,6 +142,7 @@ private:
   void FindDynamicUniformBuffers(const ezGALBindGroupCreationDescription& desc, DynamicOffsets& out_offsets);
   static ezUInt64 HashBindGroup(const ezGALBindGroupCreationDescription& desc, const DynamicOffsets& offsets);
   vk::DescriptorSet CreateDescriptorSet(const ezGALBindGroupCreationDescription& desc, const DynamicOffsets& offsets);
+  void EnsureBindGroupTextureLayout(const ezGALBindGroupCreationDescription& desc);
 
   enum class DynamicUniformBufferChanges
   {

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1331,6 +1331,8 @@ void ezGALCommandEncoderImplVulkan::EnsureBindGroupTextureLayout(const ezGALBind
         m_pPipelineBarrier->EnsureImageLayout(pTexture, item.m_Texture.m_TextureRange, imageLayout, ezConversionUtilsVulkan::GetPipelineStages(binding.m_Stages), vk::AccessFlagBits::eShaderRead);
       }
       break;
+      default:
+        break;
     }
   }
 }

--- a/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
+++ b/Code/Engine/RendererVulkan/CommandEncoder/Implementation/CommandEncoderImplVulkan.cpp
@@ -1122,6 +1122,7 @@ ezResult ezGALCommandEncoderImplVulkan::FlushDeferredStateChanges()
         // Need to call FindDynamicUniformBuffers first to generate the m_DynamicUniformVkBuffers list which is needed for the hash lookup inside CreateDescriptorSet.
         FindDynamicUniformBuffers(m_BindGroups[uiBindGroup], m_DynamicOffsets[uiBindGroup]);
         m_DescriptorSets[uiBindGroup] = CreateDescriptorSet(m_BindGroups[uiBindGroup], m_DynamicOffsets[uiBindGroup]);
+        EnsureBindGroupTextureLayout(m_BindGroups[uiBindGroup]);
         continue;
       }
 
@@ -1261,7 +1262,6 @@ vk::DescriptorSet ezGALCommandEncoderImplVulkan::CreateDescriptorSet(const ezGAL
         const ezGALTextureVulkan* pTexture = static_cast<const ezGALTextureVulkan*>(m_GALDeviceVulkan.GetTexture(item.m_Texture.m_hTexture));
         imageInfo = pTexture->GetDescriptorImageInfo(item.m_Texture.m_TextureRange, binding.m_ResourceType, binding.m_TextureType, item.m_Texture.m_OverrideViewFormat);
         imageInfo.imageLayout = binding.m_ResourceType == ezGALShaderResourceType::TextureRW ? vk::ImageLayout::eGeneral : pTexture->GetPreferredLayout(ezConversionUtilsVulkan::GetDefaultLayout(pTexture->GetImageFormat()));
-        m_pPipelineBarrier->EnsureImageLayout(pTexture, item.m_Texture.m_TextureRange, imageInfo.imageLayout, ezConversionUtilsVulkan::GetPipelineStages(binding.m_Stages), vk::AccessFlagBits::eShaderRead);
 
         if (binding.m_ResourceType == ezGALShaderResourceType::TextureAndSampler)
         {
@@ -1308,6 +1308,31 @@ vk::DescriptorSet ezGALCommandEncoderImplVulkan::CreateDescriptorSet(const ezGAL
 
   m_DescriptorCache.Insert(uiHash, descriptorSet);
   return descriptorSet;
+}
+
+void ezGALCommandEncoderImplVulkan::EnsureBindGroupTextureLayout(const ezGALBindGroupCreationDescription& desc)
+{
+  const ezGALBindGroupLayoutVulkan* pLayout = static_cast<const ezGALBindGroupLayoutVulkan*>(m_GALDeviceVulkan.GetBindGroupLayout(desc.m_hBindGroupLayout));
+  ezArrayPtr<const ezShaderResourceBinding> bindings = pLayout->GetDescription().m_ResourceBindings;
+  const ezUInt32 uiBindings = bindings.GetCount();
+  for (ezUInt32 i = 0; i < uiBindings; ++i)
+  {
+    const ezShaderResourceBinding& binding = bindings[i];
+    const ezGALBindGroupItem& item = desc.m_BindGroupItems[i];
+
+    switch (binding.m_ResourceType)
+    {
+      case ezGALShaderResourceType::Texture:
+      case ezGALShaderResourceType::TextureRW:
+      case ezGALShaderResourceType::TextureAndSampler:
+      {
+        const ezGALTextureVulkan* pTexture = static_cast<const ezGALTextureVulkan*>(m_GALDeviceVulkan.GetTexture(item.m_Texture.m_hTexture));
+        vk::ImageLayout imageLayout = binding.m_ResourceType == ezGALShaderResourceType::TextureRW ? vk::ImageLayout::eGeneral : pTexture->GetPreferredLayout(ezConversionUtilsVulkan::GetDefaultLayout(pTexture->GetImageFormat()));
+        m_pPipelineBarrier->EnsureImageLayout(pTexture, item.m_Texture.m_TextureRange, imageLayout, ezConversionUtilsVulkan::GetPipelineStages(binding.m_Stages), vk::AccessFlagBits::eShaderRead);
+      }
+      break;
+    }
+  }
 }
 
 void ezGALCommandEncoderImplVulkan::FindDynamicUniformBuffers(const ezGALBindGroupCreationDescription& desc, ezGALCommandEncoderImplVulkan::DynamicOffsets& out_offsets)
@@ -1381,7 +1406,6 @@ ezGALCommandEncoderImplVulkan::DynamicUniformBufferChanges ezGALCommandEncoderIm
     if (pBuffer == nullptr)
     {
       // Non-transient buffers are not tracked here and will always have an offset of zero.
-      ref_offsets.m_DynamicUniformBufferOffsets.PushBack(0);
       continue;
     }
     const vk::DescriptorBufferInfo* pBufferInfo = m_pUniformBufferPool->GetBuffer(pBuffer);

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -196,7 +196,6 @@ public:
 
       m_hDepthStencilTexture = m_pDevice->CreateTexture(texDesc);
 
-      m_hBBRTV = m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture());
       m_hBBDSV = m_pDevice->GetDefaultRenderTargetView(m_hDepthStencilTexture);
     }
 
@@ -293,7 +292,8 @@ public:
       ezGALCommandEncoder* pCommandEncoder = m_pDevice->BeginCommands("ezTextureSampleMainPass");
 
       ezGALRenderingSetup renderingSetup;
-      renderingSetup.SetColorTarget(0, m_hBBRTV).SetDepthStencilTarget(m_hBBDSV);
+      const ezGALSwapChain* pPrimarySwapChain = m_pDevice->GetSwapChain(m_hSwapChain);
+      renderingSetup.SetColorTarget(0, m_pDevice->GetDefaultRenderTargetView(pPrimarySwapChain->GetBackBufferTexture())).SetDepthStencilTarget(m_hBBDSV);
       renderingSetup.SetClearColor(0).SetClearDepth();
 
       ezRenderContext::GetDefaultInstance()->BeginRendering(renderingSetup, ezRectFloat(0.0f, 0.0f, (float)g_uiWindowWidth, (float)g_uiWindowHeight));
@@ -448,7 +448,6 @@ private:
   ezGALDevice* m_pDevice;
 
   ezGALSwapChainHandle m_hSwapChain;
-  ezGALRenderTargetViewHandle m_hBBRTV;
   ezGALRenderTargetViewHandle m_hBBDSV;
   ezGALTextureHandle m_hDepthStencilTexture;
 

--- a/Data/Base/Shaders/Debug/DebugPrimitive.ezShader
+++ b/Data/Base/Shaders/Debug/DebugPrimitive.ezShader
@@ -31,11 +31,13 @@ DepthTest = true
 
 VS_OUT main(VS_IN Input)
 {
-#if CAMERA_MODE == CAMERA_MODE_STEREO
-  s_ActiveCameraEyeIndex = Input.InstanceID % 2;
-#endif
-
   VS_OUT RetVal;
+  #if defined(CAMERA_MODE) && CAMERA_MODE == CAMERA_MODE_STEREO
+    s_ActiveCameraEyeIndex = Input.InstanceID % 2;
+    #if VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX == TRUE
+      RetVal.RenderTargetArrayIndex = Input.InstanceID % 2;
+    #endif
+  #endif
 
   #if PRE_TRANSFORMED_VERTICES
     float2 screenPosition = (Input.Position.xy * ViewportSize.zw) * float2(2.0, -2.0) + float2(-1.0, 1.0);

--- a/Data/Base/Shaders/Debug/DebugTexturedPrimitive.ezShader
+++ b/Data/Base/Shaders/Debug/DebugTexturedPrimitive.ezShader
@@ -33,11 +33,13 @@ DepthTest = true
 
 VS_OUT main(VS_IN Input)
 {
-#if CAMERA_MODE == CAMERA_MODE_STEREO
-  s_ActiveCameraEyeIndex = Input.InstanceID % 2;
-#endif
-
   VS_OUT RetVal;
+  #if defined(CAMERA_MODE) && CAMERA_MODE == CAMERA_MODE_STEREO
+    s_ActiveCameraEyeIndex = Input.InstanceID % 2;
+    #if VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX == TRUE
+      RetVal.RenderTargetArrayIndex = Input.InstanceID % 2;
+    #endif
+  #endif
 
   #if PRE_TRANSFORMED_VERTICES
     float2 screenPosition = (Input.Position.xy * ViewportSize.zw) * float2(2.0, -2.0) + float2(-1.0, 1.0);

--- a/Data/Base/Shaders/Editor/GizmoHandle.ezShader
+++ b/Data/Base/Shaders/Editor/GizmoHandle.ezShader
@@ -53,6 +53,9 @@ RenderDataCategory = SimpleForeground
 
 VS_OUT main(VS_IN Input)
 {
+#if CAMERA_MODE == CAMERA_MODE_STEREO
+    s_ActiveCameraEyeIndex = Input.InstanceID % 2;
+#endif
 	float3 centerPosition = mul(ObjectToWorldMatrix, float4(0, 0, 0, 1)).xyz;
 
 	#if GIZMO_CONSTANT_SIZE == 1
@@ -87,6 +90,13 @@ VS_OUT main(VS_IN Input)
 	float4 worldSpacePos = mul(ObjectToWorldMatrix, float4(inpos * scale, 1.0f));
 
 	VS_OUT RetVal;
+#if defined(CAMERA_MODE)
+#  if CAMERA_MODE == CAMERA_MODE_STEREO
+#    if VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX == TRUE
+    RetVal.RenderTargetArrayIndex = Input.InstanceID % 2;
+#    endif
+#  endif
+#endif
 	RetVal.Position = mul(GetWorldToScreenMatrix(), worldSpacePos);
 	RetVal.Color0 = GizmoColor;
 	RetVal.Normal = float3(0, 1, 0);

--- a/Data/Base/Shaders/Materials/MaterialPixelShader.h
+++ b/Data/Base/Shaders/Materials/MaterialPixelShader.h
@@ -293,7 +293,7 @@ PS_OUT main(PS_IN Input)
     Output.Color = float4(matData.diffuseColor, 1.0f);
   }
 
-#elif (RENDER_PASS == RENDER_PASS_PICKING || RENDER_PASS == RENDER_PASS_PICKING_WIREFRAME )
+#elif (RENDER_PASS == RENDER_PASS_PICKING || RENDER_PASS == RENDER_PASS_PICKING_WIREFRAME)
   Output.Color = RGBA8ToFloat4(gameObjectId);
 
 #elif RENDER_PASS == RENDER_PASS_DEPTH_ONLY

--- a/Data/Base/Shaders/Materials/MaterialPixelShader.h
+++ b/Data/Base/Shaders/Materials/MaterialPixelShader.h
@@ -89,10 +89,9 @@ PS_OUT main(PS_IN Input)
 
   ezMaterialData matData = FillMaterialData();
 
+  uint gameObjectId = GetInstanceData().GameObjectID;
 #if SHADING_QUALITY == SHADING_QUALITY_NORMAL
   ezPerClusterData clusterData = GetClusterData(Input.Position.xyw);
-  uint gameObjectId = GetInstanceData().GameObjectID;
-
 #  if defined(USE_DECALS)
   ApplyDecals(matData, clusterData, gameObjectId);
 #  endif
@@ -294,7 +293,7 @@ PS_OUT main(PS_IN Input)
     Output.Color = float4(matData.diffuseColor, 1.0f);
   }
 
-#elif (RENDER_PASS == RENDER_PASS_PICKING || RENDER_PASS == RENDER_PASS_PICKING_WIREFRAME)
+#elif (RENDER_PASS == RENDER_PASS_PICKING || RENDER_PASS == RENDER_PASS_PICKING_WIREFRAME )
   Output.Color = RGBA8ToFloat4(gameObjectId);
 
 #elif RENDER_PASS == RENDER_PASS_DEPTH_ONLY

--- a/Data/Plugins/Kraut/Kraut.ezShader
+++ b/Data/Plugins/Kraut/Kraut.ezShader
@@ -241,10 +241,7 @@ VS_OUT main(VS_IN Input)
 
 [GEOMETRYSHADER]
 
-void CopyCustomInterpolators(GS_OUT output, VS_OUT input)
-{
-  output.LeafNormal = input.LeafNormal;
-}
+#define CopyCustomInterpolators(output, input) output.LeafNormal = input.LeafNormal;
 
 #include <Shaders/Materials/MaterialStereoGeometryShader.h>
 

--- a/Data/Plugins/Shaders/RmlUi.ezShader
+++ b/Data/Plugins/Shaders/RmlUi.ezShader
@@ -46,16 +46,14 @@ struct PS_IN
 
 #include "RmlUiConstants.h"
 
-#if RMLUI_MODE != RMLUI_MODE_STENCIL_SET
-  struct VS_IN
-  {
-    float2 Position : POSITION;
-    float2 TexCoord0 : TEXCOORD0;
-    float4 Color0 : COLOR0;
-  };
+struct VS_IN
+{
+  float2 Position : POSITION;
+  float2 TexCoord0 : TEXCOORD0;
+  float4 Color0 : COLOR0;
+};
 
-  typedef PS_IN VS_OUT;
-#endif
+typedef PS_IN VS_OUT;
 
 float4 GetScreenPosition(float4 inputPos)
 {

--- a/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
@@ -10,6 +10,7 @@ SHADING_QUALITY = SHADING_QUALITY_NORMAL
 TWO_SIDED = FALSE
 FLIP_WINDING
 FORWARD_PASS_WRITE_DEPTH
+VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX
 MSAA
 CAMERA_MODE
 
@@ -62,8 +63,17 @@ float GetVertexDepthBias()
 
 VS_OUT main(VS_IN Input)
 {
+#if CAMERA_MODE == CAMERA_MODE_STEREO
+  s_ActiveCameraEyeIndex = Input.InstanceID % 2;
+#endif
   VS_OUT Output = FillVertexData(Input);
-
+#if defined(CAMERA_MODE)
+#  if CAMERA_MODE == CAMERA_MODE_STEREO
+#    if VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX == TRUE
+    Output.RenderTargetArrayIndex = Input.InstanceID % 2;
+#    endif
+#  endif
+#endif
   Output.TexCoordAlpha = Output.TexCoord0;
 
   // First determine the slot index based on the integer part of the UVs.

--- a/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
@@ -63,17 +63,7 @@ float GetVertexDepthBias()
 
 VS_OUT main(VS_IN Input)
 {
-#if CAMERA_MODE == CAMERA_MODE_STEREO
-  s_ActiveCameraEyeIndex = Input.InstanceID % 2;
-#endif
   VS_OUT Output = FillVertexData(Input);
-#if defined(CAMERA_MODE)
-#  if CAMERA_MODE == CAMERA_MODE_STEREO
-#    if VERTEX_SHADER_RENDER_TARGET_ARRAY_INDEX == TRUE
-    Output.RenderTargetArrayIndex = Input.InstanceID % 2;
-#    endif
-#  endif
-#endif
   Output.TexCoordAlpha = Output.TexCoord0;
 
   // First determine the slot index based on the integer part of the UVs.

--- a/Data/Tools/ezEditor/VisualShader/Output_Material.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Output_Material.ddl
@@ -97,7 +97,6 @@ float3 GetWorldPositionOffset(ezPerInstanceData data, float3 worldPosition)
 Permutation BLEND_MODE;
 Permutation SHADING_MODE;
 Permutation TWO_SIDED;
-Permutation VERTEX_SKINNING;
 float MaskThreshold @Default($prop0);
 " }
 


### PR DESCRIPTION
# Shader Compiler
* Various static caches have been extended with locks.
* Added a `ezTokenizedFileCache` as a parameter to `ezShaderCompiler::CompileShaderPermutationForPlatforms`. This allows to drastically cut down on parsing cost.
* `ezRTTI::ForEachDerivedType` hold a lock, so the shader compiler was never using more than one thread as all compile calls were under the `ezRTTI` lock. Separated the RTTI discovery loop from the actual shader compile loop so the compilation happens outside the `ezRTTI` lock.
* Fixed shader compiler tool to handle both relative as well as absolute files and directories. The problem was that a relative folder can't be made absolute via `ezFileSystem::ResolvePath` as that relies and file readers which don't apply to folders.
* Fixed all shaders that failed compilation. Fixes #1573.

# Renderer Fixes
* `ezGameApplication::IsGameUpdateEnabled` will now call `ezRenderWorld::IsRenderingScheduled` which in turns checks for active views and submitted render pipelines. The old code was not checking for render pipelines which caused extracted render pipelines to be rendered much later than planned, e.g. when resources they extracted where already destroyed.
* Separated layout change code from the `ezGALCommandEncoderImplVulkan::CreateDescriptorSet`into a new function `EnsureBindGroupTextureLayout`. If a descriptor was cached before, the layout change code would be skipped, causing Vulkan validation issues.
* The texture sample was caching the render target view to a single texture in the swap chain and reusing it every frame, causing flicker. Fixes #1604.
* Fixed a bug that caused VSE materials to not work reliably on skinned meshes. The material output node was exposing `Permutation VERTEX_SKINNING;` as a material property which overwrote the global state of the skinned mesh renderer.