### PR TITLE
Couple of follow up fixes after the bind group changes

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -76,8 +76,15 @@ namespace
       }
     }
 
+    ezString sContent;
+    sContent.ReadAll(file);
+    ezShaderHelper::ezTextSectionizer sections;
+    ezShaderHelper::GetShaderSections(sContent, sections);
+    ezUInt32 uiFirstLine = 0;
+    ezStringView sSectionContent = sections.GetSectionContent(ezShaderHelper::ezShaderSections::MATERIALCONFIG, uiFirstLine);
+
     ezStringBuilder sOutput;
-    EZ_SUCCEED_OR_RETURN(ezShaderParser::PreprocessSection(file, ezShaderHelper::ezShaderSections::MATERIALCONFIG, defines, sOutput));
+    EZ_SUCCEED_OR_RETURN(ezShaderParser::PreprocessSection(sSectionContent, defines, sOutput));
 
     ezHybridArray<ezStringView, 32> allAssignments;
     sOutput.Split(false, allAssignments, "\n", ";", "\r");

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -451,17 +451,8 @@ namespace
   }
 } // namespace
 
-ezResult ezShaderParser::PreprocessSection(ezStreamReader& inout_stream, ezShaderHelper::ezShaderSections::Enum section, ezArrayPtr<ezString> customDefines, ezStringBuilder& out_sResult)
+ezResult ezShaderParser::PreprocessSection(ezStringView sSectionContent, ezArrayPtr<ezString> customDefines, ezStringBuilder& out_sResult)
 {
-  ezString sContent;
-  sContent.ReadAll(inout_stream);
-
-  ezShaderHelper::ezTextSectionizer sections;
-  ezShaderHelper::GetShaderSections(sContent, sections);
-
-  ezUInt32 uiFirstLine = 0;
-  ezStringView sSectionContent = sections.GetSectionContent(section, uiFirstLine);
-
   ezPreprocessor pp;
   pp.SetPassThroughPragma(false);
   pp.SetPassThroughLine(false);
@@ -530,9 +521,15 @@ ezResult ezShaderParser::PreprocessSection(ezStreamReader& inout_stream, ezShade
 // static
 void ezShaderParser::ParseMaterialParameterSection(ezStringView sSection, ezDynamicArray<ParameterDefinition>& out_parameter, ezDynamicArray<EnumDefinition>& out_enumDefinitions)
 {
+  ezStringBuilder sPreprocessedSection;
+  if (ezShaderParser::PreprocessSection(sSection, ezArrayPtr<ezString>(), sPreprocessedSection).Failed())
+  {
+    ezLog::Error("Preprocessing material parameter section failed.");
+    return;
+  }
 
   ezTokenizer tokenizer;
-  tokenizer.Tokenize(ezMakeArrayPtr((const ezUInt8*)sSection.GetStartPointer(), sSection.GetElementCount()), ezLog::GetThreadLocalLogSystem(), false);
+  tokenizer.Tokenize(ezMakeArrayPtr((const ezUInt8*)sPreprocessedSection.GetData(), sPreprocessedSection.GetElementCount()), ezLog::GetThreadLocalLogSystem(), false);
 
   TokenStream tokens;
   tokenizer.GetAllLines(tokens);

--- a/Code/Engine/RendererCore/ShaderCompiler/ShaderParser.h
+++ b/Code/Engine/RendererCore/ShaderCompiler/ShaderParser.h
@@ -39,7 +39,7 @@ public:
     ezHybridArray<EnumValue, 16> m_Values;
   };
 
-  static ezResult PreprocessSection(ezStreamReader& inout_stream, ezShaderHelper::ezShaderSections::Enum section, ezArrayPtr<ezString> customDefines, ezStringBuilder& out_sResult);
+  static ezResult PreprocessSection(ezStringView sSectionContent, ezArrayPtr<ezString> customDefines, ezStringBuilder& out_sResult);
 
   static void ParseMaterialParameterSection(ezStringView sSection, ezDynamicArray<ParameterDefinition>& out_parameter, ezDynamicArray<EnumDefinition>& out_enumDefinitions);
 

--- a/Data/Base/Shaders/Editor/TextureCubePreview.ezShader
+++ b/Data/Base/Shaders/Editor/TextureCubePreview.ezShader
@@ -37,8 +37,9 @@ VS_OUT main(VS_IN Input)
 
 #include <Shaders/Materials/MaterialInterpolator.h>
 #include <Shaders/Common/GlobalConstants.h>
-TextureCube BaseTexture;
-SamplerState BaseTexture_AutoSampler;
+
+TextureCube BaseTexture BIND_GROUP(BG_MATERIAL);
+SamplerState BaseTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
 
 float4 SampleTexture(PS_IN Input)
 {

--- a/Data/Base/Shaders/Editor/TexturePreview.ezShader
+++ b/Data/Base/Shaders/Editor/TexturePreview.ezShader
@@ -42,7 +42,7 @@ VS_OUT main(VS_IN Input)
 #include <Shaders/Materials/MaterialInterpolator.h>
 
 Texture2D BaseTexture BIND_GROUP(BG_MATERIAL);
-SamplerState BaseTexture_AutoSampler;
+SamplerState BaseTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
 
 float4 SampleTexture(PS_IN Input)
 {

--- a/Data/Base/Shaders/Editor/TexturePreview.ezShader
+++ b/Data/Base/Shaders/Editor/TexturePreview.ezShader
@@ -41,7 +41,7 @@ VS_OUT main(VS_IN Input)
 
 #include <Shaders/Materials/MaterialInterpolator.h>
 
-Texture2D BaseTexture;
+Texture2D BaseTexture BIND_GROUP(BG_MATERIAL);
 SamplerState BaseTexture_AutoSampler;
 
 float4 SampleTexture(PS_IN Input)

--- a/Data/Samples/ComputeShaderHistogram/Shaders/ComputeHistogram.ezShader
+++ b/Data/Samples/ComputeShaderHistogram/Shaders/ComputeHistogram.ezShader
@@ -3,10 +3,6 @@ ALL
 
 [PERMUTATIONS]
 
-[MATERIALPARAMETER]
-RWTexture2D HistogramOutput;
-Texture2D ScreenTexture;
-
 [COMPUTESHADER]
 
 #include <Shaders/Common/GlobalConstants.h>

--- a/Data/Samples/ComputeShaderHistogram/Shaders/DisplayHistogram.ezShader
+++ b/Data/Samples/ComputeShaderHistogram/Shaders/DisplayHistogram.ezShader
@@ -3,9 +3,6 @@ ALL
 
 [PERMUTATIONS]
 
-[MATERIALPARAMETER]
-Texture2D HistogramTexture;
-
 [RENDERSTATE]
 DepthTest = false
 CullMode = CullMode_None

--- a/Data/Samples/MeshRenderSample/Shaders/Sample1.ezShader
+++ b/Data/Samples/MeshRenderSample/Shaders/Sample1.ezShader
@@ -25,8 +25,8 @@ VS_OUT main(VS_IN Input)
 
 #include "Common.h"
 
-Texture2D DiffuseTexture;
-SamplerState DiffuseTexture_AutoSampler;
+Texture2D DiffuseTexture BIND_GROUP(BG_MATERIAL);
+SamplerState DiffuseTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
 
 float4 main(PS_IN Input) : SV_Target
 {


### PR DESCRIPTION
* Restored preprocessing of material parameter section.
* Ensure that the preprocessed shader source code is different if only the bind groups have changed: Since DX11 has no concept of bind groups (sets, spaces etc) the shader source code was always identical but only the metadata changed. We use a hash of the preprocessed shader source code to determine whether a shader should be re-compiled which didn't work in that case. Now the bind group is added as a comment after the resource declaration to prevent this issue.
* Fixed some bind group issues in the compute histogram and the mesh render sample. Fixes #1603 Fixes #1605 