### PR TITLE
Input fix for PTG regression

### DIFF
--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -45,6 +45,13 @@ struct ezGameApplicationExecutionEvent
   Type m_Type;
 };
 
+enum class ezGameUpdateMode
+{
+  Skip, ///< Dont update or render anything
+  Render, ///< Only render, no input update
+  UpdateInputAndRender, ///< Update input and render
+};
+
 // TODO: document this and update ezGameApplication comments
 
 class EZ_CORE_DLL ezGameApplicationBase : public ezApplication
@@ -249,7 +256,7 @@ public:
   ezTime GetFrameTime() const { return m_FrameTime; }
 
 protected:
-  virtual bool IsGameUpdateEnabled() const { return true; }
+  virtual ezGameUpdateMode GetGameUpdateMode() const { return ezGameUpdateMode::UpdateInputAndRender; }
 
   virtual void Run_InputUpdate();
   virtual bool Run_ProcessApplicationInput();

--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -47,8 +47,8 @@ struct ezGameApplicationExecutionEvent
 
 enum class ezGameUpdateMode
 {
-  Skip, ///< Dont update or render anything
-  Render, ///< Only render, no input update
+  Skip,                 ///< Dont update or render anything
+  Render,               ///< Only render, no input update
   UpdateInputAndRender, ///< Update input and render
 };
 

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -420,7 +420,7 @@ void ezGameApplicationBase::RunOneFrame()
     Run_InputUpdate();
 
   Run_AcquireImage();
-  
+
   Run_WorldUpdateAndRender();
 
   if (!s_bUpdatePluginsExecuted)

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBase.cpp
@@ -403,7 +403,8 @@ void ezGameApplicationBase::RunOneFrame()
 
   ezActorManager::GetSingleton()->Update();
 
-  if (!IsGameUpdateEnabled())
+  const ezGameUpdateMode state = GetGameUpdateMode();
+  if (state == ezGameUpdateMode::Skip)
     return;
 
   {
@@ -415,10 +416,11 @@ void ezGameApplicationBase::RunOneFrame()
     m_ExecutionEvents.Broadcast(e);
   }
 
-  Run_InputUpdate();
+  if (state == ezGameUpdateMode::UpdateInputAndRender)
+    Run_InputUpdate();
 
   Run_AcquireImage();
-
+  
   Run_WorldUpdateAndRender();
 
   if (!s_bUpdatePluginsExecuted)

--- a/Code/Engine/GameEngine/GameApplication/GameApplication.h
+++ b/Code/Engine/GameEngine/GameApplication/GameApplication.h
@@ -78,7 +78,7 @@ protected:
   virtual void Init_SetupGraphicsDevice() override;
   virtual void Deinit_ShutdownGraphicsDevice() override;
 
-  virtual bool IsGameUpdateEnabled() const override;
+  virtual ezGameUpdateMode GetGameUpdateMode() const override;
 
   virtual bool Run_ProcessApplicationInput() override;
   virtual void Run_AcquireImage() override;

--- a/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
+++ b/Code/Engine/GameEngine/GameApplication/Implementation/GameApplication.cpp
@@ -97,9 +97,15 @@ ezString ezGameApplication::FindProjectDirectory() const
   return result;
 }
 
-bool ezGameApplication::IsGameUpdateEnabled() const
+ezGameUpdateMode ezGameApplication::GetGameUpdateMode() const
 {
-  return ezRenderWorld::IsRenderingScheduled();
+  const bool bViewsScheduled = !ezRenderWorld::GetMainViews().IsEmpty();
+  const bool bRenderingScheduled = ezRenderWorld::IsRenderingScheduled();
+  if (bViewsScheduled)
+  {
+    return ezGameUpdateMode::UpdateInputAndRender;
+  }
+  return bRenderingScheduled ? ezGameUpdateMode::Render : ezGameUpdateMode::Skip;
 }
 
 void ezGameApplication::Run_WorldUpdateAndRender()


### PR DESCRIPTION
A bit ugly, just s stop gap fix until a proper solution is found. Ideally we would track dependencies between render pipelines what what spawned them and remove those automatically if e.g. a view is destroyed. The entire resource lifetime of extracted views also needs to be revisited.

The basic problem is: If we extract something, it must be rendered the next frame as we can't guarantee the extracted resource lifetime longer than that. So we can't skip frames if rendering is scheduled. On the other hand, updating input events will be lost if there is no view -> world that consumes the changed input state so we can't update input if we are not updating views in a frame. This problem only exists in the editor which schedules rendering without views as it destroys view when closing documents but does not remove the extracted view pipeline for the next frame upon view closure.