### PR TITLE
Visualizer Updates

### DIFF
--- a/Code/Engine/Foundation/ezEngine.natvis
+++ b/Code/Engine/Foundation/ezEngine.natvis
@@ -29,18 +29,17 @@
 
     <Type Name="ezStringIterator">
 		<AlternativeType Name="ezStringReverseIterator" />
-		<DisplayString Condition="m_pElement == 0">&lt;Invalid Iterator&gt;</DisplayString>
-		<DisplayString Condition="(m_pElement[1] &amp; 0xC0) != 0x80">{m_pElement,[1]s8}</DisplayString>
-		<DisplayString Condition="(m_pElement[1] &amp; 0xC0) == 0x80 &amp;&amp; (m_pElement[2] &amp; 0xC0) != 0x80">{m_pElement,[2]s8}</DisplayString>
-		<DisplayString Condition="(m_pElement[1] &amp; 0xC0) == 0x80 &amp;&amp; (m_pElement[2] &amp; 0xC0) == 0x80 &amp;&amp; (m_pElement[3] &amp; 0xC0) != 0x80">{m_pElement,[3]s8}</DisplayString>
-		<DisplayString Condition="(m_pElement[1] &amp; 0xC0) == 0x80 &amp;&amp; (m_pElement[2] &amp; 0xC0) == 0x80 &amp;&amp; (m_pElement[3] &amp; 0xC0) == 0x80 &amp;&amp; (m_pElement[4] &amp; 0xC0) != 0x80">{m_pElement,[4]s8}</DisplayString>
+		<DisplayString Condition="m_pCurPtr == 0">&lt;Invalid Iterator&gt;</DisplayString>
+		<DisplayString Condition="(m_pCurPtr[1] &amp; 0xC0) != 0x80">{m_pCurPtr,[1]s8}</DisplayString>
+		<DisplayString Condition="(m_pCurPtr[1] &amp; 0xC0) == 0x80 &amp;&amp; (m_pCurPtr[2] &amp; 0xC0) != 0x80">{m_pCurPtr,[2]s8}</DisplayString>
+		<DisplayString Condition="(m_pCurPtr[1] &amp; 0xC0) == 0x80 &amp;&amp; (m_pCurPtr[2] &amp; 0xC0) == 0x80 &amp;&amp; (m_pCurPtr[3] &amp; 0xC0) != 0x80">{m_pCurPtr,[3]s8}</DisplayString>
+		<DisplayString Condition="(m_pCurPtr[1] &amp; 0xC0) == 0x80 &amp;&amp; (m_pCurPtr[2] &amp; 0xC0) == 0x80 &amp;&amp; (m_pCurPtr[3] &amp; 0xC0) == 0x80 &amp;&amp; (m_pCurPtr[4] &amp; 0xC0) != 0x80">{m_pCurPtr,[4]s8}</DisplayString>
 	</Type>
 	
 	<Type Name="ezHashedString">
 		<DisplayString>{m_Data.m_pElement->m_Value.m_sString}</DisplayString>
 		<StringView>m_Data.m_pElement->m_Value.m_sString</StringView>
 		<Expand>
-			<!--<Item Name="ref">m_Data.m_pElement->m_Value.m_iRefCount</Item>-->
 			<Item Name="hash">m_Data.m_pElement->m_Key,x</Item>
 		</Expand>
 	</Type>
@@ -96,29 +95,29 @@
 	</Type>
 	
 	<Type Name="ezHashTableBase&lt;*&gt;">
+    <AlternativeType Name="ezHashSetBase&lt;*&gt;" />
 		<DisplayString>{{ count={m_uiCount} }}</DisplayString>
 		<Expand>
 			<Item Name="count">m_uiCount</Item>
 			<Item Name="capacity">m_uiCapacity</Item>
-			<ArrayItems>
-				<Size>m_uiCapacity</Size>
-				<ValuePointer>m_pEntries</ValuePointer>
-			</ArrayItems>
+      <CustomListItems MaxItemsPerView="1000">
+        <Variable Name="index" InitialValue="0" />
+        <Variable Name="flags" InitialValue="0" />
+        <Variable Name="count" InitialValue="0" />
+        <Size>m_uiCount</Size>
+        <Loop>
+          <Exec>flags = (m_pEntryFlags[index / 16] >> ((index &amp; 15) * 2)) &amp; 3</Exec>
+          <If Condition="(flags &amp; 0x01) == 0x01">
+            <Item>m_pEntries[index]</Item>
+            <Exec>count++</Exec>
+          </If>
+          <Exec>index++</Exec>
+          <Break Condition="count == m_uiCount" />
+        </Loop>
+      </CustomListItems>
 		</Expand>
 	</Type>
 	
-	<Type Name="ezHashSetBase&lt;*&gt;">
-		<DisplayString>{{ count={m_uiCount} }}</DisplayString>
-		<Expand>
-			<Item Name="count">m_uiCount</Item>
-			<Item Name="capacity">m_uiCapacity</Item>
-			<ArrayItems>
-				<Size>m_uiCapacity</Size>
-				<ValuePointer>m_pEntries</ValuePointer>
-			</ArrayItems>
-		</Expand>
-	</Type>
-
 	<Type Name="ezListBase&lt;*&gt;">
 		<DisplayString>{{ count={m_uiCount} }}</DisplayString>
 		<Expand>
@@ -162,11 +161,14 @@
 		<DisplayString>{{ count={m_uiCount} }}</DisplayString>
 		<Expand>
 			<Item Name="count">m_uiCount</Item>
-			<Item Name="start index">m_uiFirstElement</Item>
-			<ArrayItems>
-				<Size>m_uiCount</Size>
-				<ValuePointer>m_pElements</ValuePointer>
-			</ArrayItems>
+      <CustomListItems MaxItemsPerView="1000">
+        <Variable Name="index" InitialValue="m_uiFirstElement" />
+        <Size>m_uiCount</Size>
+        <Loop>
+          <Item>m_pElements[index]</Item>
+          <Exec>index = (index + 1) % $T2</Exec>
+        </Loop>
+      </CustomListItems>
 		</Expand>
 	</Type>
 
@@ -185,7 +187,8 @@
 	<Type Name="ezVariant">
 		<DisplayString Condition="m_uiType == Type::TypedObject &amp;&amp; m_bIsShared">({m_Data.shared->m_pType->m_sTypeName,sb}*) {reinterpret_cast&lt;void*&gt;(m_Data.shared->m_Ptr)}</DisplayString>
 		<DisplayString Condition="m_uiType == Type::TypedObject &amp;&amp; !m_bIsShared">({m_Data.inlined.m_pType->m_sTypeName,sb}*) {reinterpret_cast&lt;void*&gt;(&amp;m_Data)}</DisplayString>
-		<Expand>
+    <DisplayString Condition="m_uiType == Type::TypedPointer">({reinterpret_cast&lt;ezTypedPointer*&gt;(&amp;m_Data)->m_pType->m_sTypeName,sb}*) {reinterpret_cast&lt;ezTypedPointer*&gt;(&amp;m_Data)->m_pObject}</DisplayString>
+    <Expand>
 			<Item Name="Type">(Type::Enum) m_uiType</Item>
 			<Item Name="Value" Condition="m_uiType == Type::Bool">*reinterpret_cast&lt;bool*&gt;(&amp;m_Data)</Item>
 			<Item Name="Value" Condition="m_uiType == Type::Int8">*reinterpret_cast&lt;ezInt8*&gt;(&amp;m_Data)</Item>
@@ -257,7 +260,7 @@
 	</Type>
 
 	<Type Name="ezQuatTemplate&lt;*&gt;">
-		<DisplayString>{{ x={v.x}, y={v.y}, z={v.z}, w={w} }}</DisplayString>
+		<DisplayString>{{ x={x}, y={y}, z={z}, w={w} }}</DisplayString>
 	</Type>
 	
 	<Type Name="ezPlaneTemplate&lt;*&gt;">
@@ -265,6 +268,14 @@
 	</Type>
 	
 	<Type Name="ezColor">
+		<DisplayString>{{ r={r}, g={g}, b={b}, a={a} }}</DisplayString>
+	</Type>
+
+	<Type Name="ezColorBaseUB">
+		<DisplayString>{{ r={r}, g={g}, b={b}, a={a} }}</DisplayString>
+	</Type>
+
+	<Type Name="ezColorLinearUB">
 		<DisplayString>{{ r={r}, g={g}, b={b}, a={a} }}</DisplayString>
 	</Type>
 	
@@ -294,7 +305,11 @@
 			<Item Name="Column3">&amp;m_fElementsCM[12],4</Item>
 		</Expand>
 	</Type>
-
+  
+  <Type Name="ezUuid">
+    <DisplayString>{{ {*reinterpret_cast&lt;ezUInt32*&gt;(this),nvoXb}-{*(reinterpret_cast&lt;ezUInt16*&gt;(this) + 2),nvoXb}-{*(reinterpret_cast&lt;ezUInt16*&gt;(this) + 3),nvoXb}-{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 8),nvoXb}{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 9),nvoXb}-{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 10),nvoXb}{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 11),nvoXb}{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 12),nvoXb}{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 13),nvoXb}{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 14),nvoXb}{*(reinterpret_cast&lt;ezUInt8*&gt;(this) + 15),nvoXb} }}</DisplayString>
+  </Type>
+  
 	<Type Name="ezResource">
 		<DisplayString>{{ID = {m_sUniqueID} }}</DisplayString>
 		<Expand>

--- a/Code/Engine/Foundation/ezEngine.py
+++ b/Code/Engine/Foundation/ezEngine.py
@@ -1,24 +1,84 @@
 import lldb.formatters.Logger
 import lldb
+try:
+  import debugpy
+except ImportError:
+  print("debugpy module not found")
 
 def __lldb_init_module(debugger, internal_dict):
     # comment this in for debug output
-    # lldb.formatters.Logger._lldb_formatters_debug_level = 2
-    debugger.HandleCommand('type synthetic add -x "^ezDynamicArray<" --python-class ezEngine.ezDynamicArraySynthProvider')
-    debugger.HandleCommand('type synthetic add -x "^ezHybridArray<" --python-class ezEngine.ezHybridArraySynthProvider')
-    debugger.HandleCommand('type synthetic add -x "^ezHybridString<" --python-class ezEngine.ezHybridStringSynthProvider')
-    debugger.HandleCommand('type synthetic add ezStringBuilder --python-class ezEngine.ezHybridStringSynthProvider')
-    debugger.HandleCommand('type synthetic add ezStringView --python-class ezEngine.ezStringViewSynthProvider')
-    debugger.HandleCommand('type synthetic add -x "^ezEnum<" --python-class ezEngine.ezEnumSynthProvider')
-    debugger.HandleCommand('type synthetic add -x "^ezArrayPtr<" --python-class ezEngine.ezArrayPtrSynthProvider')
-    debugger.HandleCommand('type synthetic add ezByteArrayPtr --python-class ezEngine.ezArrayPtrSynthProvider')
-    debugger.HandleCommand('type synthetic add ezConstByteArrayPtr --python-class ezEngine.ezArrayPtrSynthProvider')
-    debugger.HandleCommand('type synthetic add -x "^ezMap<" --python-class ezEngine.ezMapSynthProvider')
+    lldb.formatters.Logger._lldb_formatters_debug_level = 2
 
-    debugger.HandleCommand('type summary add -x "^ezHybridString<" --python-function ezEngine.ezHybridString_SummaryProvider')
-    debugger.HandleCommand('type summary add ezStringBuilder --python-function ezEngine.ezHybridString_SummaryProvider')
-    debugger.HandleCommand('type summary add ezStringView --python-function ezEngine.ezStringView_SummaryProvider')
-    debugger.HandleCommand('type summary add -x "^ezEnum<" --python-function ezEngine.ezEnum_SummaryProvider')
+    try:
+        print("debugpy is listening...")
+        debugpy.listen(5678)
+    except NameError:
+        print("debugpy not installed.")
+
+    # Strings
+    debugger.HandleCommand('type synthetic add -x "^ezHybridString<.+>$" --python-class ezEngine.ezHybridStringSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezHybridString<.+>$" --python-function ezEngine.ezHybridString_SummaryProvider -w ezEngine')
+
+    debugger.HandleCommand('type synthetic add ezStringBuilder --python-class ezEngine.ezHybridStringSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add ezStringBuilder --python-function ezEngine.ezHybridString_SummaryProvider -w ezEngine')
+
+    debugger.HandleCommand('type synthetic add ezStringView --python-class ezEngine.ezStringViewSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add ezStringView --python-function ezEngine.ezStringView_SummaryProvider -w ezEngine')
+
+    debugger.HandleCommand('type synthetic add ezHashedString --python-class ezEngine.ezHashedStringSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add ezHashedString --python-function ezEngine.ezHashedString_SummaryProvider -w ezEngine')
+
+    debugger.HandleCommand('type summary add ezStringIterator --python-function ezEngine.ezStringIterator_SummaryProvider -w ezEngine')
+    debugger.HandleCommand('type summary add ezStringReverseIterator --python-function ezEngine.ezStringIterator_SummaryProvider -w ezEngine') 
+
+    # Containers
+    debugger.HandleCommand('type synthetic add -x "^ezDynamicArray<.+>$" --python-class ezEngine.ezDynamicArrayBaseSynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add -x "^ezHybridArray<.+>$" --python-class ezEngine.ezDynamicArrayBaseSynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add -x "^ezSmallArray<.+>$" --python-class ezEngine.ezSmallArraySynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add -x "^ezStaticArray<.+>$" --python-class ezEngine.ezStaticArraySynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add -x "^ezStaticRingBuffer<.+>$" --python-class ezEngine.ezStaticRingBufferSynthProvider -w ezEngine')
+
+    debugger.HandleCommand('type synthetic add -x "^ezArrayPtr<.+>$" --python-class ezEngine.ezArrayPtrSynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add ezByteArrayPtr --python-class ezEngine.ezArrayPtrSynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add ezConstByteArrayPtr --python-class ezEngine.ezArrayPtrSynthProvider -w ezEngine')
+
+    debugger.HandleCommand('type synthetic add -x "^ezHashTable<.+>$" --python-class ezEngine.ezHashTableBaseSynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add -x "^ezHashSet<.+>$" --python-class ezEngine.ezHashTableBaseSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezHashTableBase<.+>::Entry$" --summary-string "key = ${var.key}, value = ${var.value}" -w ezEngine')
+    
+    debugger.HandleCommand('type synthetic add -x "^ezMap<.+>$" --python-class ezEngine.ezMapSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezMapBase<.+>::Node$" --summary-string "key = ${var.m_Key}, value = ${var.m_Value}" -w ezEngine')
+    
+    debugger.HandleCommand('type synthetic add -x "^ezSet<.+>$" --python-class ezEngine.ezMapSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezSetBase<.+>::Node$" --summary-string "${var.m_Key}" -w ezEngine')
+    
+    debugger.HandleCommand('type synthetic add -x "^ezList<.+>$" --python-class ezEngine.ezListSynthProvider -w ezEngine')
+
+    debugger.HandleCommand('type synthetic add -x "^ezDeque<.+>$" --python-class ezEngine.ezDequeSynthProvider -w ezEngine')
+
+    # Basic Types
+    debugger.HandleCommand('type synthetic add -x "^ezEnum<.+>$" --python-class ezEngine.ezEnumSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezEnum<.+>$" --python-function ezEngine.ezEnum_SummaryProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezBitflags<.+>$" --python-function ezEngine.ezBitflags_SummaryProvider -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezVec2Template<.+>$" --summary-string "\{ x=${var.x}, y=${var.y} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezVec3Template<.+>$" --summary-string "\{ x=${var.x}, y=${var.y}, z=${var.z} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezVec4Template<.+>$" --summary-string "\{ x=${var.x}, y=${var.y}, z=${var.z}, w=${var.w} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezQuatTemplate<.+>$" --summary-string "\{ x=${var.x}, y=${var.y}, z=${var.z}, w=${var.w} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add -x "^ezPlaneTemplate<.+>$" --summary-string "\{ nx=${var.m_vNormal.x}, ny=${var.m_vNormal.y}, nz=${var.m_vNormal.z}, negDist=${var.m_fNegDistance} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add "ezColor" --summary-string "\{ r=${var.r}, g=${var.g}, b=${var.b}, a=${var.a} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add "ezColorGammaUB" --summary-string "\{ r=${var.r:d}, g=${var.g:d}, b=${var.b:d}, a=${var.a:d} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add "ezColorLinearUB" --summary-string "\{ r=${var.r:d}, g=${var.g:d}, b=${var.b:d}, a=${var.a:d} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add "ezTime" --summary-string "\{ seconds=${var.m_fTime} \}" -w ezEngine')
+    debugger.HandleCommand('type summary add "ezAngle" --python-function ezEngine.ezAngle_SummaryProvider -w ezEngine')
+    debugger.HandleCommand('type summary add "ezUuid" --python-function ezEngine.ezUuid_SummaryProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add "ezMat3" --python-class ezEngine.ezMat3SynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add "ezMat4" --python-class ezEngine.ezMat4SynthProvider -w ezEngine')
+    debugger.HandleCommand('type synthetic add "ezVariant" --python-class ezEngine.ezVariantSynthProvider -w ezEngine')
+    debugger.HandleCommand('type summary add "ezVariant" --python-function ezEngine.ezVariant_SummaryProvider -w ezEngine')
+
+    debugger.HandleCommand('type category enable ezEngine')
+
+#region Strings
 
 def make_string(F):
     data = bytearray(F.GetData().uint8)
@@ -26,111 +86,6 @@ def make_string(F):
         data = data[:-1]
     return data.decode("utf-8")
 
-class ezDynamicArraySynthProvider:
-    def __init__(self, valobj, dict):
-        logger = lldb.formatters.Logger.Logger()
-        self.valobj = valobj
-
-    def update(self):
-        try:
-            self.m_pElements = self.valobj.GetChildMemberWithName('m_pElements')
-            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
-            self.m_uiCapacity = self.valobj.GetChildMemberWithName('m_uiCapacity')
-            self.m_pAllocator = self.valobj.GetChildMemberWithName('m_pAllocator')
-            self.element_type = self.m_pElements.GetType().GetPointeeType()
-            self.element_size = self.element_type.GetByteSize()
-        except Exception as inst:
-            logger >> inst
-
-        return False
-
-    def num_children(self):
-        logger = lldb.formatters.Logger.Logger()
-        logger >> "num_children" + str(self.m_uiCount)
-        numElements = self.m_uiCount.GetValueAsUnsigned(0)
-        if numElements > 0xff000000:
-            return 3
-        numElements = min(numElements, 256)
-        return numElements + 3
-
-    def get_child_at_index(self, index):
-        logger = lldb.formatters.Logger.Logger()
-        logger >> "Getting child" + str(index)
-        if index < 3:
-            if index == 0:
-                return self.m_uiCount
-            if index == 1:
-                return self.m_uiCapacity
-            if index == 2:
-                return self.m_pAllocator
-        else:
-            index = index - 3
-
-        if index >= self.num_children() - 3:
-            return None
-        try:
-            offset = index * self.element_size
-            return self.m_pElements.CreateChildAtOffset('[' + str(index) + ']', offset, self.element_type)
-        except exception as inst:
-            logger >> inst
-            return None
-
-class ezHybridArraySynthProvider:
-    def __init__(self, valobj, dict):
-        logger = lldb.formatters.Logger.Logger()
-        self.valobj = valobj
-
-    def update(self):
-        logger = lldb.formatters.Logger.Logger()
-        try:
-            self.m_pElements = self.valobj.GetChildMemberWithName('m_pElements')
-            self.m_StaticData = self.valobj.GetChildAtIndex(1).GetChildAtIndex(0)
-            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
-            self.m_uiCapacity = self.valobj.GetChildMemberWithName('m_uiCapacity')
-            self.m_pAllocator = self.valobj.GetChildMemberWithName('m_pAllocator')
-            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
-            self.element_size = self.element_type.GetByteSize()
-            self.local_storage_size = self.m_StaticData.GetType().GetByteSize() // self.element_size
-            logger >> "m_StaticData " + str(self.m_StaticData.GetType().GetDisplayTypeName())
-            logger >> "local_storage_size " + str(self.local_storage_size)
-        except Exception as inst:
-            logger >> inst
-
-        return False
-
-    def num_children(self):
-        logger = lldb.formatters.Logger.Logger()
-        logger >> "num_children" + str(self.m_uiCount)
-        numElements = self.m_uiCount.GetValueAsUnsigned(0)
-        if numElements > 0x10000000:
-            return 3
-        numElements = min(numElements, 256)
-        return numElements + 3
-
-    def get_child_at_index(self, index):
-        logger = lldb.formatters.Logger.Logger()
-        logger >> "Getting child" + str(index)
-        if index < 3:
-            if index == 0:
-                return self.m_uiCount
-            if index == 1:
-                return self.m_uiCapacity
-            if index == 2:
-                return self.m_pAllocator
-        else:
-            index = index - 3
-
-        if index >= self.num_children() - 3:
-            return None
-        try:
-            offset = index * self.element_size
-            if self.m_uiCount.GetValueAsUnsigned(0) <= self.local_storage_size:
-                return self.m_StaticData.CreateChildAtOffset('[' + str(index) + ']', offset, self.element_type)
-            else:
-                return self.m_pElements.CreateChildAtOffset('[' + str(index) + ']', offset, self.element_type)
-        except exception as inst:
-            logger >> inst
-            return None
 
 class ezHybridStringSynthProvider:
     def __init__(self, valobj, dict):
@@ -141,29 +96,26 @@ class ezHybridStringSynthProvider:
         logger = lldb.formatters.Logger.Logger()
         try:
             m_Data = self.valobj.GetChildMemberWithName('m_Data')
-            self.m_uiCharacterCount = self.valobj.GetChildMemberWithName('m_uiCharacterCount')
             self.m_pElements = m_Data.GetChildMemberWithName('m_pElements')
             self.m_StaticData = m_Data.GetChildAtIndex(1).GetChildAtIndex(0)
             self.m_uiCount = m_Data.GetChildMemberWithName('m_uiCount')
             self.m_uiCapacity = m_Data.GetChildMemberWithName('m_uiCapacity')
             self.m_pAllocator = m_Data.GetChildMemberWithName('m_pAllocator')
             self.local_storage_size = self.m_StaticData.GetType().GetByteSize()
-            logger >> "local_storage_size " + str(self.local_storage_size)
         except Exception as inst:
-            logger >> inst
+            logger >> "ezHybridStringSynthProvider.update: " + str(inst)
 
         return False
 
     def num_children(self):
-        return 4
+        return 3
 
     def get_child_at_index(self, index):
         logger = lldb.formatters.Logger.Logger()
-        logger >> "Getting child" + str(index)
-
         try:
             if index == 0:
-                count = self.m_uiCount.GetValueAsUnsigned(0) 
+                count = self.m_uiCount.GetValueAsUnsigned(0)
+                # Detect if string is probably broken (uninitialized)
                 if count > 0x10000000:
                     count = 0
                 if count <= self.local_storage_size:
@@ -173,20 +125,17 @@ class ezHybridStringSynthProvider:
             elif index == 1:
                 return self.m_uiCount
             elif index == 2:
-                return self.m_uiCharacterCount
-            elif index == 3:
                 return self.m_pAllocator
         except Exception as inst:
-            logger >> str(inst)
+            logger >> "ezHybridStringSynthProvider.get_child_at_index: " + str(inst)
             return None
-
 
 def ezHybridString_SummaryProvider(valobj, dict):
     logger = lldb.formatters.Logger.Logger()
     try:
-        logger >> "ezHybridString_SummaryProvider"
         content = valobj.GetChildAtIndex(0)
         count = valobj.GetChildAtIndex(1).GetValueAsUnsigned(0)
+        # Detect if string is probably broken (uninitialized)
         if count > 0x10000000:
             count = 0
         if count == 0:
@@ -195,7 +144,7 @@ def ezHybridString_SummaryProvider(valobj, dict):
             count = 1024
         return '"' + make_string(content) + '"'
     except Exception as inst:
-        logger >> str(inst)
+        logger >> "ezHybridString_SummaryProvider: " + str(inst)
         return "<error>"
 
 class ezStringViewSynthProvider:
@@ -205,7 +154,6 @@ class ezStringViewSynthProvider:
 
     def update(self):
         logger = lldb.formatters.Logger.Logger()
-        logger >> "ezStringViewSynthProvider::update"
         self.valid = False
         try:
             self.m_pStart = self.valobj.GetChildMemberWithName('m_pStart')
@@ -213,16 +161,14 @@ class ezStringViewSynthProvider:
 
             start = self.m_pStart.GetValueAsUnsigned(0)
             count = self.m_uiElementCount.GetValueAsUnsigned(0)
-            logger >> str(start) + " " + str(count)
             if start == 0 or count == 0:
                 self.valid = False
             else:
                 self.valid = True
                 self.count = count
-                logger >> "count " + str(self.count)
             
         except Exception as inst:
-            logger >> inst
+            logger >> "ezStringViewSynthProvider.update: " + str(inst)
 
         return False
 
@@ -231,8 +177,6 @@ class ezStringViewSynthProvider:
 
     def get_child_at_index(self, index):
         logger = lldb.formatters.Logger.Logger()
-        logger >> "Getting child" + str(index)
-
         if not self.valid:
             return None
 
@@ -240,100 +184,487 @@ class ezStringViewSynthProvider:
             count = min(self.count, 256)
             return self.m_pStart.CreateValueFromData('contents', self.m_pStart.GetPointeeData(0, count), self.m_pStart.GetType().GetPointeeType().GetArrayType(count))
         except Exception as inst:
-            logger >> str(inst)
+            logger >> "ezStringViewSynthProvider.get_child_at_index: " + str(inst)
             return None
 
 def ezStringView_SummaryProvider(valobj, dict):
     logger = lldb.formatters.Logger.Logger()
     try:
-        logger >> "ezStringView_SummaryProvider"
         content = valobj.GetChildAtIndex(0)
+        # Check if content is empty
+        if content.IsValid() == False:
+            return "<empty>"
         return '"' + make_string(content) + '"'
     except Exception as inst:
-        logger >> str(inst)
+        logger >> "ezStringView_SummaryProvider: " + str(inst)
         return "<error>"
 
-class ezEnumSynthProvider:
+class ezHashedStringSynthProvider:
     def __init__(self, valobj, dict):
+        logger = lldb.formatters.Logger.Logger()
         self.valobj = valobj
 
-
     def update(self):
-        self.value = "?"
         logger = lldb.formatters.Logger.Logger()
-        logger >> "ezEnumSynthProvider::Update"
+        self.valid = False
         try:
-            enum_name = self.valobj.GetType().GetTemplateArgumentType(0).GetName() + "::Enum"
-            logger >> enum_name
-            enum_type = self.valobj.GetTarget().FindTypes(enum_name).GetTypeAtIndex(0)
-            logger >> str(enum_type)
-            value = self.valobj.GetChildMemberWithName("m_Value").GetValueAsUnsigned()
-            self.value = "? ({})".format(value)
-            for v in enum_type.GetEnumMembers():
-                if value == v.GetValueAsUnsigned():
-                    self.value = "{} ({})".format(v.GetName(), v.GetValueAsUnsigned())
-                    break
+            self.m_Data = self.valobj.GetChildMemberWithName('m_Data')
+            self.m_pElement = self.m_Data.GetChildMemberWithName('m_pElement')
+            self.m_Key = self.m_pElement.GetChildMemberWithName('m_Key')
+            self.m_Value = self.m_pElement.GetChildMemberWithName('m_Value')
+            self.m_sString = self.m_Value.GetChildMemberWithName('m_sString')
+            self.valid = True
+
         except Exception as inst:
-            logger >> str(inst)
+            logger >> "ezHashedStringSynthProvider.update: " + str(inst)
+
         return False
 
     def num_children(self):
-        return 1
+        return 2
 
     def get_child_at_index(self, index):
-        return self.valobj.CreateValueFromExpression('Value', '"' + self.value + '"')
+        logger = lldb.formatters.Logger.Logger()
 
-def ezEnum_SummaryProvider(valobj, dict):
+        if not self.valid:
+            return None
+
+        try:
+            if index == 0:
+                return self.m_sString
+            elif index == 1:
+                return self.m_Key
+        except Exception as inst:
+            logger >> "ezHashedStringSynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+def ezHashedString_SummaryProvider(valobj, dict):
     logger = lldb.formatters.Logger.Logger()
     try:
-        logger >> "ezEnum_SummaryProvider"
         content = valobj.GetChildAtIndex(0)
-        return make_string(content)
+        return ezHybridString_SummaryProvider(content, dict)
     except Exception as inst:
-        logger >> str(inst)
+        logger >> "ezHashedString_SummaryProvider: " + str(inst)
         return "<error>"
 
-class ezArrayPtrSynthProvider:
+def ezStringIterator_SummaryProvider(valobj, dict):
+    logger = lldb.formatters.Logger.Logger()
+    try:
+        m_pCurPtr = valobj.GetChildMemberWithName("m_pCurPtr")
+        m_pEndPtr = valobj.GetChildMemberWithName("m_pEndPtr")
+        curr = m_pCurPtr.GetValueAsUnsigned(0)
+        end = m_pEndPtr.GetValueAsUnsigned(0)
+        size = min(end - curr, 4) # We need up to 4 bytes to decode one utf8 character
+        bytes = m_pCurPtr.GetPointeeData(0, size)
+        if size == 0:
+            return "<empty>"
+        
+        for i in range(1, size):
+            # Check if the next byte marks the start of a new UTF-8 character
+            if (bytes.uint8s[i] & 0xC0) != 0x80:
+                size = i
+                break
+  
+        data = bytearray(bytes.uint8s[:size])
+        if size > 0:
+            char = data.decode('utf-8')[0]
+            return f"'{char}'"
+
+    except Exception as inst:
+        logger >> "ezStringIterator_SummaryProvider: " + str(inst)
+        return "<error>"
+    
+#endregion
+
+#region Containers
+class ArraySynthProvider:
     def __init__(self, valobj, dict):
-        logger = lldb.formatters.Logger.Logger()
         self.valobj = valobj
 
+    def set_fields(self, names):
+        self.names = names
+        self.fields = []
+        for name in self.names:
+            member = self.valobj.GetChildMemberWithName(name)
+            self.fields.append(member)
+        
+    def get_field_count(self):
+        return self.fields.__len__()
+
+    def get_field(self, index):
+        return self.fields[index]
+    
+    def get_array_size(self, countField):
+        count = countField.GetValueAsUnsigned(0)
+        # Clamp the count to a maximum of 256 elements for performance reasons
+        return min(count, 256)
+        
+    def get_array_element(self, elementsField, elementType, elementSize, index):
+        offset = index * elementSize
+        return elementsField.CreateChildAtOffset('[' + str(index) + ']', offset, elementType)
+        
+    def get_array_element_with_fake_index(self, elementsField, elementType, elementSize, index, fakeIndex):
+        offset = index * elementSize
+        return elementsField.CreateChildAtOffset('[' + str(fakeIndex) + ']', offset, elementType)
+
+        
+class ezDynamicArrayBaseSynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+         super().__init__(valobj, dict)
+
     def update(self):
+        logger = lldb.formatters.Logger.Logger()
         try:
-            self.m_ptr = self.valobj.GetChildMemberWithName('m_pPtr')
+            super().set_fields(['m_uiCount', 'm_uiCapacity', 'm_pAllocator'])
+            self.m_pElements = self.valobj.GetChildMemberWithName('m_pElements')
             self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
-            self.element_type = self.m_ptr.GetType().GetPointeeType()
+            self.element_type = self.m_pElements.GetType().GetPointeeType()
             self.element_size = self.element_type.GetByteSize()
         except Exception as inst:
-            logger >> inst
+            logger >> "ezDynamicArrayBaseSynthProvider.update: " + str(inst)
 
         return False
 
     def num_children(self):
         logger = lldb.formatters.Logger.Logger()
-        logger >> "num_children" + str(self.m_uiCount)
-        numElements = self.m_uiCount.GetValueAsUnsigned(0)
-        if numElements > 0xff000000:
-            return 1
-        numElements = min(numElements, 256)
-        return numElements + 1
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezDynamicArrayBaseSynthProvider.num_children: " + str(inst)
+            return 0
 
     def get_child_at_index(self, index):
         logger = lldb.formatters.Logger.Logger()
-        logger >> "Getting child" + str(index)
-        if index < 1:
-            if index == 0:
-                return self.m_uiCount
-        else:
-            index = index - 1
-
-        if index >= self.num_children() - 1:
-            return None
         try:
-            offset = index * self.element_size
-            return self.m_ptr.CreateChildAtOffset('[' + str(index) + ']', offset, self.element_type)
-        except exception as inst:
-            logger >> str(inst)
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+            
+            return super().get_array_element(self.m_pElements, self.element_type, self.element_size, index - fields)
+        except Exception as inst:
+            logger >> "ezDynamicArrayBaseSynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+class ezSmallArraySynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+        super().__init__(valobj, dict)
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            super().set_fields(['m_uiCount', 'm_uiCapacity', 'm_uiUserData'])
+            self.m_pElements = self.valobj.GetChildAtIndex(0).GetChildAtIndex(3).GetChildAtIndex(1)
+            self.m_StaticData = self.valobj.GetChildAtIndex(0).GetChildAtIndex(3).GetChildAtIndex(0).GetChildAtIndex(0)
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.m_uiCapacity = self.valobj.GetChildMemberWithName('m_uiCapacity')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+            self.local_storage_size = self.m_StaticData.GetType().GetByteSize() // self.element_size
+        except Exception as inst:
+            logger >> "ezSmallArraySynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezSmallArraySynthProvider.num_children: " + str(inst)
+            return 0
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+                
+            if self.m_uiCapacity.GetValueAsUnsigned(0) <= self.local_storage_size:
+                return super().get_array_element(self.m_StaticData, self.element_type, self.element_size, index - fields)
+            else:
+                return super().get_array_element(self.m_pElements, self.element_type, self.element_size, index - fields)
+        except Exception as inst:
+            logger >> "ezSmallArraySynthProvider.get_child_at_index: " + str(inst)
+            return None
+        
+class ezStaticArraySynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+        super().__init__(valobj, dict)
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            super().set_fields(['m_uiCount', 'm_uiCapacity'])
+            self.m_Data = self.valobj.GetChildAtIndex(1).GetChildAtIndex(0)
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+        except Exception as inst:
+            logger >> "ezStaticArraySynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezStaticArraySynthProvider.num_children: " + str(inst)
+            return 0
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+                
+            return super().get_array_element(self.m_Data, self.element_type, self.element_size, index - fields)
+        except Exception as inst:
+            logger >> "ezStaticArraySynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+class ezStaticRingBufferSynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+        super().__init__(valobj, dict)
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            super().set_fields(['m_uiCount', 'm_uiFirstElement'])
+            self.m_pElements = self.valobj.GetChildMemberWithName('m_pElements')
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.m_uiFirstElement = self.valobj.GetChildMemberWithName('m_uiFirstElement')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+
+            self.m_StaticData = self.valobj.GetChildAtIndex(0).GetChildAtIndex(0)
+            self.local_storage_size = self.m_StaticData.GetType().GetByteSize() // self.element_size
+        except Exception as inst:
+            logger >> "ezStaticRingBufferSynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezStaticRingBufferSynthProvider.update: " + str(inst)
+            return 0
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+            
+            index = index - fields
+            firstElement = self.m_uiFirstElement.GetValueAsUnsigned(0)
+            actualIndex = (firstElement + index) % self.local_storage_size
+            offset = actualIndex * self.element_size
+            return super().get_array_element_with_fake_index(self.m_pElements, self.element_type, self.element_size, actualIndex, index)
+        except Exception as inst:
+            logger >> "ezStaticRingBufferSynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+class ezArrayPtrSynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+        super().__init__(valobj, dict)
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            super().set_fields(['m_uiCount'])
+            self.m_pPtr = self.valobj.GetChildMemberWithName('m_pPtr')
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+        except Exception as inst:
+            logger >> "ezArrayPtrSynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezArrayPtrSynthProvider.num_children: " + str(inst)
+            return 0
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+                
+            return super().get_array_element(self.m_pPtr, self.element_type, self.element_size, index - fields)
+        except Exception as inst:
+            logger >> "ezArrayPtrSynthProvider.get_child_at_index: " + str(inst)
+            return None
+    
+class ezHashTableBaseSynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+        super().__init__(valobj, dict)
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            super().set_fields(['m_uiCount', 'm_uiCapacity', 'm_pAllocator'])
+            self.m_pEntries = self.valobj.GetChildMemberWithName('m_pEntries')
+            self.m_pEntryFlags = self.valobj.GetChildMemberWithName('m_pEntryFlags')
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.m_uiCapacity = self.valobj.GetChildMemberWithName('m_uiCapacity')
+            self.element_type = self.m_pEntries.GetType().GetPointeeType()
+            self.element_size = self.element_type.GetByteSize()
+            self.flags_type = self.m_pEntryFlags.GetType().GetPointeeType()
+            self.flags_size = self.flags_type.GetByteSize()
+            # reading the data through the debugger can take a long time
+            # Limit the loops to this number of iterations
+            self.maxSteps = 255 
+            self.compactedEntries = []
+            capacity = self.m_uiCapacity.GetValueAsUnsigned(0)
+            fakeIndex = 0
+            for index in range(0, capacity):
+                flags = super().get_array_element(self.m_pEntryFlags, self.flags_type, self.flags_size, index // 16)
+                flags_value = flags.GetValueAsUnsigned(0)
+                flags_value = flags_value >> ((index & 15) * 2) & 3
+                isvalid = (flags_value & 0x01) == 0x01
+                if isvalid:
+                    self.compactedEntries.append(super().get_array_element_with_fake_index(self.m_pEntries, self.element_type, self.element_size, index, fakeIndex))
+                    fakeIndex += 1
+                if fakeIndex >= self.maxSteps:
+                    break  # Limit the number of entries to avoid performance issues in the debugger
+
+        except Exception as inst:
+            logger >> "ezHashTableBaseSynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezHashTableBaseSynthProvider.num_children: " + str(inst)
+            return 0
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+                
+            index = index - fields
+            return self.compactedEntries[index]
+        except Exception as inst:
+            logger >> "ezHashTableBaseSynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+class ezListSynthProvider:
+    def __init__(self, valobj, dict):
+        logger = lldb.formatters.Logger.Logger()
+        self.valobj = valobj
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+
+            current = self.valobj.GetChildMemberWithName('m_First').GetChildMemberWithName('m_pNext')
+            count = self.m_uiCount.GetValueAsUnsigned(0)
+
+            self.compactedEntries = []
+            for index in range(0, count):
+                value = current.GetChildMemberWithName('m_Data')
+                self.compactedEntries.append(value)
+                current = current.GetChildMemberWithName('m_pNext')
+
+        except Exception as inst:
+            logger >> "ezListSynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            numElements = self.m_uiCount.GetValueAsUnsigned(0)
+            return numElements + 1
+        except Exception as inst:
+            logger >> "ezListSynthProvider.num_children: " + str(inst)
+            return 0
+    
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            if index < 1:
+                return self.m_uiCount
+
+            index = index - 1
+            return self.compactedEntries[index].CreateChildAtOffset('[' + str(index) + ']', 0, self.element_type)
+        except Exception as inst:
+            logger >> "ezListSynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+class ezDequeSynthProvider(ArraySynthProvider):
+    def __init__(self, valobj, dict):
+        super().__init__(valobj, dict)
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            super().set_fields(['m_uiCount', 'm_pAllocator'])
+            self.m_pChunks = self.valobj.GetChildMemberWithName('m_pChunks')
+            self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
+            self.first_element = self.valobj.GetChildMemberWithName('m_uiFirstElement').GetValueAsUnsigned(0)
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+
+            self.chunk_type = self.m_pChunks.GetType().GetPointeeType()
+            self.chunk_pointer_size = self.chunk_type.GetByteSize()
+
+            self.m_uiChunkSize = self.valobj.GetChildMemberWithName('m_uiChunkSize')
+            self.chunk_size = self.m_uiChunkSize.GetValueAsUnsigned(0)
+            if (4096 // self.element_size) < 32:
+                self.chunk_size = 32
+            else:
+                self.chunk_size = 4096 // self.element_size
+            
+        except Exception as inst:
+            logger >> "ezDequeSynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return super().get_array_size(self.m_uiCount) + super().get_field_count()
+        except Exception as inst:
+            logger >> "ezDequeSynthProvider.num_children: " + str(inst)
+            return 0
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            fields = super().get_field_count()
+            if index < fields:
+                return super().get_field(index)
+            
+            index = index - fields
+            realIndex = self.first_element + index
+            chunkIndex = realIndex // self.chunk_size
+            chunkOffset = realIndex % self.chunk_size
+            chunk = super().get_array_element(self.m_pChunks, self.chunk_type, self.chunk_pointer_size, chunkIndex)
+            element = super().get_array_element_with_fake_index(chunk, self.element_type, self.element_size, chunkOffset, index)
+            return element
+        except Exception as inst:
+            logger >> "ezDequeSynthProvider.get_child_at_index: " + str(inst)
             return None
 
 class ezMapSynthProvider:
@@ -347,25 +678,31 @@ class ezMapSynthProvider:
         self.lastNode = None
 
     def update(self):
+        logger = lldb.formatters.Logger.Logger()
         try:
             self.lastNodeIndex = -2
             self.lastNode = None
             self.m_uiCount = self.valobj.GetChildMemberWithName('m_uiCount')
             self.m_pRoot = self.valobj.GetChildMemberWithName('m_pRoot')
             self.m_NilNodeAddr = self.valobj.GetChildMemberWithName('m_NilNode').GetLoadAddress()
-            self.element_type = self.m_ptr.GetType().GetPointeeType()
+            self.element_type = self.m_pRoot.GetType().GetPointeeType()
             self.element_size = self.element_type.GetByteSize()
         except Exception as inst:
-            logger >> inst
+            logger >> "ezMapSynthProvider.update: " + str(inst)
 
         return False
 
     def num_children(self):
-        numElements = self.m_uiCount.GetValueAsUnsigned(0)
-        if numElements > 0xff000000:
-            return 1
-        numElements = min(numElements, 256)
-        return numElements + 1
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            numElements = self.m_uiCount.GetValueAsUnsigned(0)
+            if numElements > 0xff000000:
+                return 1
+            numElements = min(numElements, 256)
+            return numElements + 1
+        except Exception as inst:
+            logger >> "ezMapSynthProvider.num_children: " + str(inst)
+            return 0
 
     def GetLink(self, node, index):
         return node.Dereference().GetChildMemberWithName('m_pLink').GetChildAtIndex(index)
@@ -431,16 +768,15 @@ class ezMapSynthProvider:
 
     def get_child_at_index(self, index):
         logger = lldb.formatters.Logger.Logger()
-        logger >> "Getting child" + str(index)
-        if index < 1:
-            if index == 0:
-                return self.m_uiCount
-        else:
-            index = index - 1
-
-        if index >= self.num_children():
-            return None
         try:
+            if index < 1:
+                if index == 0:
+                    return self.m_uiCount
+            else:
+                index = index - 1
+
+            if index >= self.num_children():
+                return None
             node = self.GetLeftMost()
             stepsLeft = index
 
@@ -460,6 +796,341 @@ class ezMapSynthProvider:
 
             return None
 
-        except exception as inst:
-            logger >> str(inst)
+        except Exception as inst:
+            logger >> "ezMapSynthProvider.get_child_at_index: " + str(inst)
             return None
+
+#endregion
+
+#region Enums and Bitflags
+
+class ezEnumSynthProvider:
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+
+    def update(self):
+        self.value = "?"
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            enum_name = self.valobj.GetType().GetTemplateArgumentType(0).GetName() + "::Enum"
+            enum_type = self.valobj.GetTarget().FindTypes(enum_name).GetTypeAtIndex(0)
+            value = self.valobj.GetChildMemberWithName("m_Value").GetValueAsUnsigned()
+            self.value = "? ({})".format(value)
+            for v in enum_type.GetEnumMembers():
+                if value == v.GetValueAsUnsigned():
+                    self.value = "{} ({})".format(v.GetName(), v.GetValueAsUnsigned())
+                    break
+        except Exception as inst:
+            logger >> "ezEnumSynthProvider.update: " + str(inst)
+        return False
+
+    def num_children(self):
+        return 1
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            return self.valobj.CreateValueFromExpression('Value', '"' + self.value + '"')
+        except Exception as inst:
+            logger >> "ezEnumSynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+def ezEnum_SummaryProvider(valobj, dict):
+    logger = lldb.formatters.Logger.Logger()
+    try:
+        content = valobj.GetChildAtIndex(0)
+        return make_string(content)
+    except Exception as inst:
+        logger >> "ezEnum_SummaryProvider: " + str(inst)
+        return "<error>"
+
+def ezBitflags_SummaryProvider(valobj, dict):
+    logger = lldb.formatters.Logger.Logger()
+    try:
+        content = valobj.GetChildAtIndex(0).GetChildAtIndex(0)
+        type = valobj.GetType().GetTemplateArgumentType(0)
+        enum_name = type.GetName() + "::Enum"
+        enum_type = valobj.GetTarget().FindTypes(enum_name).GetTypeAtIndex(0)
+
+        value = content.GetValueAsUnsigned(0)
+        flags_list = []
+        for v in enum_type.GetEnumMembers():
+            bit_value = v.GetValueAsUnsigned()
+            # Skip if none or more than one bit is set (must be a power of 2 to have exactly one bit)
+            if bit_value == 0 or (bit_value & (bit_value - 1)) != 0:
+                continue
+            if value & bit_value:
+                flags_list.append(v.GetName())     
+
+        if not flags_list:
+            return "None (0)"
+        return " | ".join(flags_list) + f" ({value})"
+    except Exception as inst:
+        logger >> "ezBitflags_SummaryProvider: " + str(inst)
+        return "<error>"
+    
+#endregion
+
+#region Basic Types
+
+def ezAngle_SummaryProvider(valobj, dict):
+    logger = lldb.formatters.Logger.Logger()
+    try:
+        m_fRadian = valobj.GetChildAtIndex(0)
+        radian_value = float(m_fRadian.GetValue())
+
+        degree_value = radian_value * 180.0 / 3.14159265358979323846
+        return f"{{ Degree={degree_value:.2f}° }}"
+    except Exception as inst:
+        logger >> "ezAngle_SummaryProvider: " + str(inst)
+        return "<error>"
+    
+def ezUuid_SummaryProvider(valobj, dict):
+    logger = lldb.formatters.Logger.Logger()
+    try:
+        m_uiHigh = valobj.GetChildAtIndex(0)
+        m_uiLow = valobj.GetChildAtIndex(1)
+        m_uiHighValue = m_uiHigh.GetValueAsUnsigned(0)
+        m_uiLowValue = m_uiLow.GetValueAsUnsigned(0)
+
+        high_bytes = m_uiHighValue.to_bytes(8, byteorder='little')
+        low_bytes = m_uiLowValue.to_bytes(8, byteorder='little')
+        time_low = int.from_bytes(high_bytes[0:4], byteorder='little')
+        time_mid = int.from_bytes(high_bytes[4:6], byteorder='little')
+        time_hi_version = int.from_bytes(high_bytes[6:8], byteorder='little')
+        clock_seq = int.from_bytes(low_bytes[0:2], byteorder='big')
+        node = int.from_bytes(low_bytes[2:8], byteorder='big')
+
+        uuid_str = f"{time_low:08x}-{time_mid:04x}-{time_hi_version:04x}-{clock_seq:04x}-{node:012x}"
+        return uuid_str
+        
+    except Exception as inst:
+        logger >> "ezUuid_SummaryProvider: " + str(inst)
+        return "<error>"
+
+class ezMat3SynthProvider:
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            self.m_fElementsCM = self.valobj.GetChildMemberWithName('m_fElementsCM')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+            
+        except Exception as inst:
+            logger >> "ezMat3SynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        return 4
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            if index == 0:
+                expr = f"(ezVec3*)" +str(self.m_fElementsCM.GetAddress())
+                Column0 = self.valobj.CreateValueFromExpression('Column0', expr)
+                return Column0
+            if index == 1:
+                address = self.m_fElementsCM.GetAddress()
+                address.OffsetAddress(self.element_size * 3)
+                expr = f"(ezVec3*)" +str(address)
+                Column1 = self.valobj.CreateValueFromExpression('Column1', expr)
+                return Column1
+            if index == 2:
+                address = self.m_fElementsCM.GetAddress()
+                address.OffsetAddress(self.element_size * 6)
+                expr = f"(ezVec3*)" +str(address)
+                Column2 = self.valobj.CreateValueFromExpression('Column2', expr)
+                return Column2
+            if index == 3:
+                return self.m_fElementsCM
+        except Exception as inst:
+            logger >> "ezMat3SynthProvider.get_child_at_index: " + str(inst)
+            return None
+        
+class ezMat4SynthProvider:
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            self.m_fElementsCM = self.valobj.GetChildMemberWithName('m_fElementsCM')
+            self.element_type = self.valobj.GetType().GetTemplateArgumentType(0)
+            self.element_size = self.element_type.GetByteSize()
+            
+        except Exception as inst:
+            logger >> "ezMat4SynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        return 5
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            if index == 0:
+                expr = f"(ezVec4*)" +str(self.m_fElementsCM.GetAddress())
+                Column0 = self.valobj.CreateValueFromExpression('Column0', expr)
+                return Column0
+            if index == 1:
+                address = self.m_fElementsCM.GetAddress()
+                address.OffsetAddress(self.element_size * 4)
+                expr = f"(ezVec4*)" +str(address)
+                Column1 = self.valobj.CreateValueFromExpression('Column1', expr)
+                return Column1
+            if index == 2:
+                address = self.m_fElementsCM.GetAddress()
+                address.OffsetAddress(self.element_size * 8)
+                expr = f"(ezVec4*)" +str(address)
+                Column2 = self.valobj.CreateValueFromExpression('Column2', expr)
+                return Column2
+            if index == 3:
+                address = self.m_fElementsCM.GetAddress()
+                address.OffsetAddress(self.element_size * 12)
+                expr = f"(ezVec4*)" +str(address)
+                Column3 = self.valobj.CreateValueFromExpression('Column3', expr)
+                return Column3
+            if index == 4:
+                return self.m_fElementsCM
+        except Exception as inst:
+            logger >> "ezMat4SynthProvider.get_child_at_index: " + str(inst)
+            return None
+
+class ezVariantSynthProvider:
+
+    variantMap = {}
+    variantTargetTypeMap = {}
+
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
+        if not ezVariantSynthProvider.variantMap:
+            enum_type = self.valobj.GetTarget().FindTypes("ezVariantType::Enum").GetTypeAtIndex(0)
+            for v in enum_type.GetEnumMembers():
+                bit_value = v.GetValueAsUnsigned()
+                ezVariantSynthProvider.variantMap[bit_value] = v.GetName()
+            
+            ezVariantSynthProvider.variantTargetTypeMap["Bool"] = "bool"
+            ezVariantSynthProvider.variantTargetTypeMap["Int8"] = "ezInt8"
+            ezVariantSynthProvider.variantTargetTypeMap["UInt8"] = "ezUInt8"
+            ezVariantSynthProvider.variantTargetTypeMap["Int16"] = "ezInt16"
+            ezVariantSynthProvider.variantTargetTypeMap["UInt16"] = "ezUInt16"
+            ezVariantSynthProvider.variantTargetTypeMap["Int32"] = "ezInt32"
+            ezVariantSynthProvider.variantTargetTypeMap["UInt32"] = "ezUInt32"
+            ezVariantSynthProvider.variantTargetTypeMap["Int64"] = "ezInt64"
+            ezVariantSynthProvider.variantTargetTypeMap["UInt64"] = "ezUInt64"
+            ezVariantSynthProvider.variantTargetTypeMap["Float"] = "float"
+            ezVariantSynthProvider.variantTargetTypeMap["Double"] = "double"
+            ezVariantSynthProvider.variantTargetTypeMap["Color"] = "ezColor"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector2"] = "ezVec2"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector3"] = "ezVec3"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector4"] = "ezVec4"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector2I"] = "ezVec2I32"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector3I"] = "ezVec3I32"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector4I"] = "ezVec4I32"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector2U"] = "ezVec2U32"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector3U"] = "ezVec3U32"
+            ezVariantSynthProvider.variantTargetTypeMap["Vector4U"] = "ezVec4U32"
+            ezVariantSynthProvider.variantTargetTypeMap["Quaternion"] = "ezQuat"
+            ezVariantSynthProvider.variantTargetTypeMap["Matrix3"] = "ezMat3"
+            ezVariantSynthProvider.variantTargetTypeMap["Matrix4"] = "ezMat4"
+            ezVariantSynthProvider.variantTargetTypeMap["Transform"] = "ezTransform"
+            ezVariantSynthProvider.variantTargetTypeMap["String"] = "ezString"
+            ezVariantSynthProvider.variantTargetTypeMap["StringView"] = "ezStringView"
+            ezVariantSynthProvider.variantTargetTypeMap["DataBuffer"] = "ezDataBuffer"
+            ezVariantSynthProvider.variantTargetTypeMap["Time"] = "ezTime"
+            ezVariantSynthProvider.variantTargetTypeMap["Uuid"] = "ezUuid"
+            ezVariantSynthProvider.variantTargetTypeMap["Angle"] = "ezAngle"
+            ezVariantSynthProvider.variantTargetTypeMap["ColorGamma"] = "ezColorGammaUB"
+            ezVariantSynthProvider.variantTargetTypeMap["HashedString"] = "ezHashedString"
+            ezVariantSynthProvider.variantTargetTypeMap["TempHashedString"] = "ezTempHashedString"
+            ezVariantSynthProvider.variantTargetTypeMap["VariantArray"] = "ezVariantArray"
+            ezVariantSynthProvider.variantTargetTypeMap["VariantDictionary"] = "ezVariantDictionary"
+            ezVariantSynthProvider.variantTargetTypeMap["TypedPointer"] = "ezTypedPointer"
+
+    def update(self):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            self.m_Data = self.valobj.GetChildMemberWithName('m_Data')
+            self.m_Ptr = self.m_Data.EvaluateExpression('shared->m_Ptr')
+            self.m_sharedType = self.m_Data.EvaluateExpression('shared->m_pType')
+            self.m_inlineType = self.m_Data.EvaluateExpression('inlined.m_pType')
+            self.m_uiType = self.valobj.GetChildMemberWithName('m_uiType')
+            self.m_bIsShared = self.valobj.GetChildMemberWithName('m_bIsShared')
+            
+        except Exception as inst:
+            logger >> "ezMat4SynthProvider.update: " + str(inst)
+
+        return False
+
+    def num_children(self):
+        return 3
+
+    def get_child_at_index(self, index):
+        logger = lldb.formatters.Logger.Logger()
+        try:
+            if index == 0:
+                typeValue = self.m_uiType.GetValueAsUnsigned(0)
+                return self.valobj.CreateValueFromExpression('Type', f"(ezVariantType::Enum) {typeValue}")
+                return self.m_uiType
+            if index == 1:
+                typeValue = self.m_uiType.GetValueAsUnsigned(0)
+                isShared = self.m_bIsShared.GetValueAsUnsigned(0)
+                # Choose the correct data source based on isShared
+                if isShared != 0:
+                    address = self.m_Ptr.GetValueAsUnsigned()
+                else:
+                    address = self.m_Data.GetAddress()
+                # Check if we can map the typeValue to a type name
+                if typeValue in ezVariantSynthProvider.variantMap:
+                    typeName = ezVariantSynthProvider.variantMap[typeValue]
+                    if typeName in ezVariantSynthProvider.variantTargetTypeMap:
+                        targetType = ezVariantSynthProvider.variantTargetTypeMap[typeName]
+                        expr = f"*reinterpret_cast<{targetType}*>({address})"
+                        return self.valobj.CreateValueFromExpression('Value', expr)
+
+                if 'Invalid' == ezVariantSynthProvider.variantMap[typeValue]:
+                    return self.valobj.CreateValueFromExpression('Invalid', 'nullptr')
+                
+                if 'TypedObject' == ezVariantSynthProvider.variantMap[typeValue]:
+                    # For TypedObject, we extract the name of the RTTI type and build an expression to cast to it
+                    if isShared != 0:
+                        rtti = self.m_sharedType
+                    else:
+                        rtti = self.m_inlineType
+                    typeName = rtti.GetChildMemberWithName('m_sTypeName')
+                    typeNameStr = str(typeName.GetSummary()).replace('"', '') # A bit hacky, it depends on the ezStringView summary provider
+                    expr = f"({typeNameStr}*){address}"
+                    return self.valobj.CreateValueFromExpression('Value', expr)
+
+                return self.m_Data
+            if index == 2:
+                return self.m_bIsShared
+        except Exception as inst:
+            logger >> "ezVariantSynthProvider.get_child_at_index: " + str(inst)
+            return None
+        
+def ezVariant_SummaryProvider(valobj, dict):
+    logger = lldb.formatters.Logger.Logger()
+    try:
+        type = valobj.GetChildAtIndex(0).GetValue()
+        value = valobj.GetChildAtIndex(1)
+        valueSummary = value.GetSummary()
+        valueValue = value.GetValue()
+        summaryString = f"({type}) "
+        if valueSummary is not None and valueSummary != "":
+            summaryString += valueSummary
+        elif valueValue is not None and valueValue != "":
+            summaryString += valueValue
+        return summaryString
+    except Exception as inst:
+        logger >> "ezVariant_SummaryProvider: " + str(inst)
+        return "<error>"
+    
+#endregion

--- a/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
@@ -2,15 +2,15 @@
 
 #include <Foundation/CodeUtils/MathExpression.h>
 #include <Foundation/Containers/List.h>
+#include <Foundation/Containers/StaticRingBuffer.h>
 #include <Foundation/Types/RefCounted.h>
 #include <Foundation/Types/SharedPtr.h>
-#include <Foundation/Containers/StaticRingBuffer.h>
 #include <Foundation/Types/VarianceTypes.h>
 
 #include <string>
 
 #ifdef __clang__
-#pragma clang optimize off
+#  pragma clang optimize off
 #endif
 
 class TestRefCounted : public ezRefCounted

--- a/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
@@ -1,0 +1,288 @@
+#include <FoundationTest/FoundationTestPCH.h>
+
+#include <Foundation/CodeUtils/MathExpression.h>
+#include <Foundation/Containers/List.h>
+#include <Foundation/Types/RefCounted.h>
+#include <Foundation/Types/SharedPtr.h>
+
+#include <Foundation/Types/VarianceTypes.h>
+
+#include <string>
+
+#ifdef __clang__
+#pragma clang optimize off
+#endif
+
+class TestRefCounted : public ezRefCounted
+{
+public:
+  ezUInt32 m_uiDummyMember = 0x42u;
+};
+
+// declare bitflags using macro magic
+EZ_DECLARE_FLAGS(ezUInt32, TestFlags, Bit1, Bit2, Bit3, Bit4);
+
+EZ_DEFINE_AS_POD_TYPE(TestFlags::Enum);
+
+class ReflectedTest : public ezReflectedClass
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ReflectedTest, ezReflectedClass);
+
+public:
+  float u;
+  float v;
+};
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ReflectedTest, 1, ezRTTINoAllocator)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("u", u),
+    EZ_MEMBER_PROPERTY("v", v),
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+
+EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
+{
+  struct StuffStruct
+  {
+    int a;
+    float b;
+    ezString c;
+  };
+  EZ_TEST_BOOL(true);
+  // Strings
+  {
+    ezString stringEmpty;
+    ezString string = u8"こんにちは 世界";
+    ezString* stringPtr = &string;
+    ezString stringArray[4] = {"AAA", "BBB", "CCC", "DDD"};
+    ezStringBuilder stringBuilder = "Test";
+    ezStringView stringViewEmpty;
+    ezStringView stringView = string.GetSubString(0, 5);
+    ezStringIterator stringIteratorEmpty;
+    ezStringIterator stringIterator = stringView.GetIteratorFront();
+    stringIterator++;
+    ezStringReverseIterator stringReverseIteratorEmpty;
+    ezStringReverseIterator stringReverseIterator = stringView.GetIteratorBack();
+    stringReverseIterator++;
+
+    ezHashedString hashedStringEmpty;
+    ezHashedString hashedString = ezMakeHashedString("Test");
+    EZ_TEST_BOOL(true);
+  }
+
+  // Containers
+  {
+    ezDynamicArray<ezString> dynamicArray;
+    dynamicArray.PushBack("Item1");
+    dynamicArray.PushBack("Item2");
+
+    ezHybridArray<StuffStruct, 4> hybridArray;
+    hybridArray.PushBack({1, 2.0f, "Item3"});
+    hybridArray.PushBack({2, 3.0f, "Item4"});
+
+    ezHybridArray<StuffStruct, 1> hybridArray2;
+    hybridArray2.PushBack({1, 2.0f, "Item3"});
+    hybridArray2.PushBack({2, 3.0f, "Item4"});
+    hybridArray2.PushBack({3, 4.0f, "Item5"});
+
+    ezSmallArray<ezString, 66> smallArray;
+    smallArray.PushBack("SmallItem1");
+    smallArray.PushBack("SmallItem2");
+
+    ezSmallArray<ezString, 2> smallArray2;
+    smallArray2.PushBack("SmallItem1");
+    smallArray2.PushBack("SmallItem2");
+    smallArray2.PushBack("SmallItem3");
+    smallArray2.PushBack("SmallItem4");
+
+    ezStaticArray<float, 2> staticArray;
+    staticArray.SetCount(2);
+    staticArray[0] = 1.0f;
+    staticArray[1] = 2.0f;
+
+    ezHashTable<int, StuffStruct> hashTable;
+    hashTable.Insert(1, StuffStruct{3, 4.0f, "HashItem1"});
+    hashTable.Insert(99, StuffStruct{3, 4.0f, "HashItem1"});
+
+    ezHashSet<ezString> hashSet;
+    hashSet.Insert("HashSetItem1");
+    hashSet.Insert("HashSetItem2");
+
+    ezList<ezString> list;
+    list.PushBack("ListItem1");
+    list.PushBack("ListItem2");
+
+    ezDeque<ezString> deque;
+    deque.PushBack("DequeItem1");
+    deque.PushBack("DequeItem2");
+    deque.PushFront("DequeItem0");
+
+    ezMap<int, ezString> map;
+    map.Insert(1, "MapItem1");
+    map.Insert(2, "MapItem2");
+
+    ezSet<ezStringView> set;
+    set.Insert("SetItem1");
+    set.Insert("SetItem2");
+
+    ezStaticRingBuffer<StuffStruct, 4> staticRingBuffer;
+    staticRingBuffer.PushBack({5, 6.0f, "StaticRingItem1"});
+    staticRingBuffer.PushBack({7, 8.0f, "StaticRingItem2"});
+    staticRingBuffer.PushBack({9, 10.0f, "StaticRingItem3"});
+    staticRingBuffer.PushBack({11, 12.0f, "StaticRingItem4"});
+    staticRingBuffer.PopFront();
+    staticRingBuffer.PushBack({13, 14.0f, "StaticRingItem5"});
+
+    ezArrayPtr<ezString> arrayPtr = ezMakeArrayPtr(dynamicArray.GetData(), dynamicArray.GetCount());
+    ezArrayPtr<StuffStruct> hybridArrayPtr = ezMakeArrayPtr(hybridArray.GetData(), hybridArray.GetCount());
+    EZ_TEST_BOOL(true);
+  }
+
+  // ezVariant
+  {
+    ezVariant variantInvalid; // Default constructor creates Invalid type
+    ezVariant variantBool = ezVariant(true);
+    ezVariant variantInt8 = ezVariant(static_cast<ezInt8>(42));
+    ezVariant variantUInt8 = ezVariant(static_cast<ezUInt8>(42));
+    ezVariant variantInt16 = ezVariant(static_cast<ezInt16>(42));
+    ezVariant variantUInt16 = ezVariant(static_cast<ezUInt16>(42));
+    ezVariant variantInt32 = ezVariant(static_cast<ezInt32>(42));
+    ezVariant variantUInt32 = ezVariant(static_cast<ezUInt32>(42));
+    ezVariant variantInt64 = ezVariant(static_cast<ezInt64>(42));
+    ezVariant variantUInt64 = ezVariant(static_cast<ezUInt64>(42));
+    ezVariant variantFloat = ezVariant(42.0f);
+    ezVariant variantDouble = ezVariant(42.0);
+    ezVariant variantColor = ezVariant(ezColor(1.0f, 0.5f, 0.25f, 1.0f));
+    ezVariant variantVector2 = ezVariant(ezVec2(1.0f, 2.0f));
+    ezVariant variantVector3 = ezVariant(ezVec3(1.0f, 2.0f, 3.0f));
+    ezVariant variantVector4 = ezVariant(ezVec4(1.0f, 2.0f, 3.0f, 4.0f));
+    ezVariant variantVector2I = ezVariant(ezVec2I32(1, 2));
+    ezVariant variantVector3I = ezVariant(ezVec3I32(1, 2, 3));
+    ezVariant variantVector4I = ezVariant(ezVec4I32(1, 2, 3, 4));
+    ezVariant variantVector2U = ezVariant(ezVec2U32(1, 2));
+    ezVariant variantVector3U = ezVariant(ezVec3U32(1, 2, 3));
+    ezVariant variantVector4U = ezVariant(ezVec4U32(1, 2, 3, 4));
+    ezVariant variantQuaternion = ezVariant(ezQuat::MakeIdentity());
+    ezVariant variantMatrix3 = ezVariant(ezMat3::MakeIdentity());
+    ezVariant variantMatrix4 = ezVariant(ezMat4::MakeIdentity());
+    ezVariant variantTransform = ezVariant(ezTransform::MakeIdentity());
+    ezVariant variantString = ezVariant("SampleString");
+    ezVariant variantStringView = ezVariant(ezStringView("SampleStringView"));
+
+    ezDataBuffer dataBuffer;
+    dataBuffer.PushBack(1);
+    dataBuffer.PushBack(2);
+    dataBuffer.PushBack(3);
+    ezVariant variantDataBuffer = ezVariant(dataBuffer);
+
+    ezVariant variantTime = ezVariant(ezTime::Seconds(42.0));
+    ezVariant variantUuid = ezVariant(ezUuid::MakeStableUuidFromInt(42));
+    ezVariant variantAngle = ezVariant(ezAngle::MakeFromDegree(45.0f));
+    ezVariant variantColorGamma = ezVariant(ezColorGammaUB(128, 192, 255, 255));
+    ezVariant variantHashedString = ezVariant(ezMakeHashedString("HashedSample"));
+    ezVariant variantTempHashedString = ezVariant(ezTempHashedString("TempHashedSample"));
+
+    // Extended types
+    ezVariantArray varArray;
+    varArray.PushBack(ezVariant("Item1"));
+    varArray.PushBack(ezVariant(42));
+    ezVariant variantVariantArray = ezVariant(varArray);
+
+    ezVariantDictionary varDict;
+    varDict.Insert("Key1", ezVariant("Value1"));
+    varDict.Insert("Key2", ezVariant(42));
+    ezVariant variantVariantDictionary = ezVariant(varDict);
+
+    ReflectedTest test;
+    ezVariant variantTypedPointer(&test);
+    ezTypedPointer ptr = {nullptr, ezGetStaticRTTI<ReflectedTest>()};
+    ezVariant variantTypedPointerNull = ptr;
+
+    ezVarianceTypeAngle value2(ezAngle::MakeFromRadian(1.57079637f), 0.2f);
+    ezVariant variantTypedObject(value2);
+    EZ_TEST_BOOL(true);
+  }
+
+  // Enum
+  {
+    ezEnum<ezVariantType> enumTest = ezVariantType::Angle;
+    ezEnum<ezVariantType> enumArray[3] = {ezVariantType::Int32, ezVariantType::String, ezVariantType::Color};
+    ezHybridArray<ezEnum<ezVariantType>, 3> hybridEnumArray;
+    hybridEnumArray.PushBack(ezVariantType::Int32);
+    hybridEnumArray.PushBack(ezVariantType::String);
+    EZ_TEST_BOOL(true);
+  }
+
+  // Bitflags
+  {
+    ezBitflags<TestFlags> bitflags;
+    bitflags.Add(TestFlags::Bit1);
+    bitflags.Add(TestFlags::Bit2);
+
+    ezBitflags<TestFlags> bitflagsArray[2];
+    bitflagsArray[0].Add(TestFlags::Bit3);
+    bitflagsArray[1].Add(TestFlags::Bit4);
+
+    ezHybridArray<ezBitflags<TestFlags>, 2> hybridBitflagsArray;
+    hybridBitflagsArray.PushBack(TestFlags::Bit1 | TestFlags::Bit2);
+    hybridBitflagsArray.PushBack(TestFlags::Bit3 | TestFlags::Bit4);
+    EZ_TEST_BOOL(true);
+  }
+
+  // Math
+  {
+    ezVec2 vec2(1.0f, 2.0f);
+    ezVec3 vec3(1.0f, 2.0f, 3.0f);
+    ezVec4 vec4(1.0f, 2.0f, 3.0f, 4.0f);
+    ezVec2I32 vec2I(1, 2);
+    ezVec3I32 vec3I(1, 2, 3);
+    ezVec4I32 vec4I(1, 2, 3, 4);
+    ezVec2U32 vec2U(1, 2);
+    ezVec3U32 vec3U(1, 2, 3);
+    ezVec4U32 vec4U(1, 2, 3, 4);
+    ezQuat quat = ezQuat::MakeFromAxisAndAngle(ezVec3(0, 1, 0), ezAngle::MakeFromDegree(90.0f));
+    ezMat3 mat3 = ezMat3::MakeRotationZ(ezAngle::MakeFromDegree(45.0f));
+    ezMat4 mat4 = ezMat4::MakeRotationY(ezAngle::MakeFromDegree(30.0f));
+    ezTransform transform(ezVec3(1.0f, 2.0f, 3.0f), quat, ezVec3(1.0f, 1.0f, 1.0f));
+    ezAngle angle = ezAngle::MakeFromDegree(60.0f);
+    ezPlane plane = ezPlane::MakeFromNormalAndPoint(ezVec3(0, 1, 0), ezVec3(0, 0, 0));
+
+    ezColor color(1.0f, 0.5f, 0.25f, 1.0f);
+    ezColorGammaUB colorGamma(128, 192, 255, 255);
+    ezColorLinearUB colorLinear(128, 192, 255, 255);
+    ezTime time = ezTime::Seconds(42.0);
+
+    ezUuid uuid = ezConversionUtils::ConvertStringToUuid("{ 01234567-89AB-CDEF-0123-456789ABCDEF }");
+    ezStringBuilder uuidString;
+    ezConversionUtils::ToString(uuid, uuidString);
+    EZ_TEST_BOOL(true);
+  }
+
+  // UniquePtr
+  {
+    ezUniquePtr<ReflectedTest> uniquePtr = EZ_DEFAULT_NEW(ReflectedTest);
+    uniquePtr->u = 1.0f;
+    uniquePtr->v = 2.0f;
+
+    ezSharedPtr<TestRefCounted> sharedPtr = EZ_DEFAULT_NEW(TestRefCounted);
+    sharedPtr->m_uiDummyMember = 0x42u;
+
+    TestRefCounted testRef;
+    ezScopedRefPointer<TestRefCounted> scopedRefPointer(&testRef);
+    EZ_TEST_BOOL(true);
+  }
+
+  // Mutex
+  {
+    ezMutex mutex;
+    EZ_LOCK(mutex);
+    EZ_TEST_BOOL(true);
+  }
+}

--- a/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
@@ -4,7 +4,7 @@
 #include <Foundation/Containers/List.h>
 #include <Foundation/Types/RefCounted.h>
 #include <Foundation/Types/SharedPtr.h>
-
+#include <Foundation/Containers/StaticRingBuffer.h>
 #include <Foundation/Types/VarianceTypes.h>
 
 #include <string>
@@ -21,8 +21,32 @@ public:
 
 // declare bitflags using macro magic
 EZ_DECLARE_FLAGS(ezUInt32, TestFlags, Bit1, Bit2, Bit3, Bit4);
-
 EZ_DEFINE_AS_POD_TYPE(TestFlags::Enum);
+
+struct TestFlagsManual
+{
+  using StorageType = ezUInt32;
+
+  enum Enum
+  {
+    Bit1 = EZ_BIT(0),
+    Bit2 = EZ_BIT(1),
+    Bit3 = EZ_BIT(2),
+    Bit4 = EZ_BIT(3),
+    MultiBits = Bit1 | Bit3,
+    Default = 0
+  };
+
+  struct Bits
+  {
+    StorageType Bit1 : 1;
+    StorageType Bit2 : 1;
+    StorageType Bit3 : 1;
+    StorageType Bit4 : 1;
+  };
+};
+
+EZ_DECLARE_FLAGS_OPERATORS(TestFlagsManual);
 
 class ReflectedTest : public ezReflectedClass
 {
@@ -222,9 +246,13 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
 
   // Bitflags
   {
-    ezBitflags<TestFlags> bitflags;
-    bitflags.Add(TestFlags::Bit1);
-    bitflags.Add(TestFlags::Bit2);
+    TestFlags::Enum rawBitflags = TestFlags::Bit1;
+    TestFlags::Enum rawBitflags2 = (TestFlags::Enum)(TestFlags::Bit1 | TestFlags::Bit2).GetValue();
+
+    ezBitflags<TestFlagsManual> bitflagsEmpty;
+    ezBitflags<TestFlagsManual> bitflags;
+    bitflags.Add(TestFlagsManual::Bit1);
+    bitflags.Add(TestFlagsManual::Bit3);
 
     ezBitflags<TestFlags> bitflagsArray[2];
     bitflagsArray[0].Add(TestFlags::Bit3);


### PR DESCRIPTION
# Natvis
* Added proper hashtable / hashset visualizers.
* Added ezColorBaseUB and ezColorLinearUB visualizers.
* Added ezUuid visualizer that matches the EZ to string conversion.
* Fixed ezStringIterator visualizer.
* Correct ezStaticRingBuffer element order.

# LLDB
* Rewrote or added most visualizers to create parity with the natvis visualizers.

# Test
* Added a VisualizerZoo test that allows testing every visualizer in a convenient file.