### PR TITLE
ezVariant array and dictionary tooling support

### DIFF
--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersDefaultStateProvider.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersDefaultStateProvider.cpp
@@ -48,10 +48,13 @@ ezVariant ezExposedParametersDefaultStateProvider::GetDefaultValue(SuperArray su
   ezExposedParameterCommandAccessor accessor(pAccessor, pProp, m_pParameterSourceProp);
   if (index.IsValid())
   {
-    const ezExposedParameter* pParam = accessor.GetExposedParam(pObject, index.Get<ezString>());
-    if (pParam)
+    if (index.IsA<ezString>())
     {
-      return pParam->m_DefaultValue;
+      const ezExposedParameter* pParam = accessor.GetExposedParam(pObject, index.Get<ezString>());
+      if (pParam)
+      {
+        return pParam->m_DefaultValue;
+      }
     }
     return superPtr[0]->GetDefaultValue(superPtr.GetSubArray(1), pAccessor, pObject, pProp, index);
   }

--- a/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
@@ -12,6 +12,7 @@ class QAction;
 class EZ_EDITORFRAMEWORK_DLL ezExposedParameterCommandAccessor : public ezObjectProxyAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezExposedParameterCommandAccessor, ezObjectProxyAccessor);
+
 public:
   ezExposedParameterCommandAccessor(ezObjectAccessorBase* pSource, const ezAbstractProperty* pParameterProp, const ezAbstractProperty* pM_pParameterSourceProp);
 

--- a/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
@@ -11,6 +11,7 @@ class QAction;
 
 class EZ_EDITORFRAMEWORK_DLL ezExposedParameterCommandAccessor : public ezObjectProxyAccessor
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezExposedParameterCommandAccessor, ezObjectProxyAccessor);
 public:
   ezExposedParameterCommandAccessor(ezObjectAccessorBase* pSource, const ezAbstractProperty* pParameterProp, const ezAbstractProperty* pM_pParameterSourceProp);
 

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
@@ -7,6 +7,11 @@
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <GuiFoundation/Widgets/GroupBoxBase.moc.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezExposedParameterCommandAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 ezExposedParameterCommandAccessor::ezExposedParameterCommandAccessor(
   ezObjectAccessorBase* pSource, const ezAbstractProperty* pParameterProp, const ezAbstractProperty* pParameterSourceProp)
   : ezObjectProxyAccessor(pSource)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.cpp
@@ -4,6 +4,11 @@
 #include <EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.h>
 #include <EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectManager.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezPropertyAnimObjectAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 ezPropertyAnimObjectAccessor::ezPropertyAnimObjectAccessor(ezPropertyAnimAssetDocument* pDoc, ezCommandHistory* pHistory)
   : ezObjectCommandAccessor(pHistory)
   , m_pDocument(pDoc)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.h
@@ -6,6 +6,7 @@ class ezPropertyAnimObjectManager;
 
 class ezPropertyAnimObjectAccessor : public ezObjectCommandAccessor
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezPropertyAnimObjectAccessor, ezObjectCommandAccessor);
 public:
   ezPropertyAnimObjectAccessor(ezPropertyAnimAssetDocument* pDoc, ezCommandHistory* pHistory);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimObjectAccessor.h
@@ -7,6 +7,7 @@ class ezPropertyAnimObjectManager;
 class ezPropertyAnimObjectAccessor : public ezObjectCommandAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezPropertyAnimObjectAccessor, ezObjectCommandAccessor);
+
 public:
   ezPropertyAnimObjectAccessor(ezPropertyAnimAssetDocument* pDoc, ezCommandHistory* pHistory);
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
@@ -14,9 +14,10 @@
 #include <QPushButton>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
-ezQtAddSubElementButton::ezQtAddSubElementButton()
+ezQtAddSubElementButton::ezQtAddSubElementButton(ezEnum<ezPropertyCategory> containerCategory)
   : ezQtPropertyWidget()
 {
+  m_ContainerCategory = containerCategory;
   // Reset base class size policy as we are put in a layout that would cause us to vanish instead.
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
   m_pLayout = new QHBoxLayout(this);
@@ -171,7 +172,7 @@ void ezQtAddSubElementButton::OnAction(const ezRTTI* pRtti)
   EZ_ASSERT_DEV(pRtti != nullptr, "user data retrieval failed");
   ezVariant index = (ezInt32)-1;
 
-  if (m_pProp->GetCategory() == ezPropertyCategory::Map)
+  if (m_ContainerCategory == ezPropertyCategory::Map)
   {
     QString text;
     bool bOk = false;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.moc.h
@@ -8,12 +8,15 @@ class QHBoxLayout;
 class QPushButton;
 class QMenu;
 
+/// \brief Used by container widgets to add new elements to the container.
 class EZ_GUIFOUNDATION_DLL ezQtAddSubElementButton : public ezQtPropertyWidget
 {
   Q_OBJECT
 
 public:
-  ezQtAddSubElementButton();
+  /// Constructor
+  /// \param containerCategory The type of container. Only Map, Set and Array are supported.
+  ezQtAddSubElementButton(ezEnum<ezPropertyCategory> containerCategory);
 
 protected:
   virtual void DoPrepareToDie() override {}
@@ -32,6 +35,7 @@ private:
 
   ezQtTypeMenu m_TypeMenu;
 
+  ezEnum<ezPropertyCategory> m_ContainerCategory;
   bool m_bNoMoreElementsAllowed = false;
   QMenu* m_pMenu = nullptr;
   ezUInt32 m_uiMaxElements = 0; // 0 means unlimited

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/DefaultState.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/DefaultState.cpp
@@ -5,6 +5,7 @@
 #include <GuiFoundation/PropertyGrid/AttributeDefaultStateProvider.h>
 #include <GuiFoundation/PropertyGrid/DefaultState.h>
 #include <GuiFoundation/PropertyGrid/PrefabDefaultStateProvider.h>
+#include <GuiFoundation/PropertyGrid/VariantSubDefaultStateProvider.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 #include <ToolsFoundation/Serialization/DocumentObjectConverter.h>
 
@@ -14,12 +15,14 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(GuiFoundation, DefaultState)
   {
     ezDefaultState::RegisterDefaultStateProvider(ezAttributeDefaultStateProvider::CreateProvider);
     ezDefaultState::RegisterDefaultStateProvider(ezPrefabDefaultStateProvider::CreateProvider);
+    ezDefaultState::RegisterDefaultStateProvider(ezVariantSubDefaultStateProvider::CreateProvider);
   }
 
   ON_CORESYSTEMS_SHUTDOWN
   {
     ezDefaultState::UnregisterDefaultStateProvider(ezAttributeDefaultStateProvider::CreateProvider);
     ezDefaultState::UnregisterDefaultStateProvider(ezPrefabDefaultStateProvider::CreateProvider);
+    ezDefaultState::UnregisterDefaultStateProvider(ezVariantSubDefaultStateProvider::CreateProvider);
   }
 EZ_END_SUBSYSTEM_DECLARATION;
 // clang-format on

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -609,7 +609,7 @@ ezQtPropertyPointerWidget::ezQtPropertyPointerWidget()
 
   m_pLayout->addWidget(m_pGroup);
 
-  m_pAddButton = new ezQtAddSubElementButton(m_pProp->GetCategory());
+  m_pAddButton = new ezQtAddSubElementButton(ezPropertyCategory::Member);
   m_pGroup->GetHeader()->layout()->addWidget(m_pAddButton);
 
   m_pDeleteButton = new ezQtElementGroupButton(m_pGroup->GetHeader(), ezQtElementGroupButton::ElementAction::DeleteElement, this);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -609,7 +609,7 @@ ezQtPropertyPointerWidget::ezQtPropertyPointerWidget()
 
   m_pLayout->addWidget(m_pGroup);
 
-  m_pAddButton = new ezQtAddSubElementButton();
+  m_pAddButton = new ezQtAddSubElementButton(m_pProp->GetCategory());
   m_pGroup->GetHeader()->layout()->addWidget(m_pAddButton);
 
   m_pDeleteButton = new ezQtElementGroupButton(m_pGroup->GetHeader(), ezQtElementGroupButton::ElementAction::DeleteElement, this);
@@ -1261,7 +1261,7 @@ ezQtPropertyContainerWidget::Element& ezQtPropertyContainerWidget::AddElement(ez
 
   // Add Buttons
   auto pAttr = m_pProp->GetAttributeByType<ezContainerAttribute>();
-  if ((!pAttr || pAttr->CanMove()) && m_pProp->GetCategory() != ezPropertyCategory::Map)
+  if ((!pAttr || pAttr->CanMove()) && GetContainerCategory() != ezPropertyCategory::Map)
   {
     pSubGroup->SetDraggable(true);
     connect(pSubGroup, &ezQtGroupBoxBase::DragStarted, this, &ezQtPropertyContainerWidget::OnDragStarted);
@@ -1325,7 +1325,7 @@ void ezQtPropertyContainerWidget::UpdateElements()
 
 ezUInt32 ezQtPropertyContainerWidget::GetRequiredElementCount() const
 {
-  if (m_pProp->GetCategory() == ezPropertyCategory::Map)
+  if (GetContainerCategory() == ezPropertyCategory::Map)
   {
     m_Keys.Clear();
     EZ_VERIFY(m_pObjectAccessor->GetKeys(m_Items[0].m_pObject, m_pProp, m_Keys).Succeeded(), "GetKeys should always succeed.");
@@ -1414,6 +1414,11 @@ void ezQtPropertyContainerWidget::UpdatePropertyMetaState()
   }
 }
 
+ezPropertyCategory::Enum ezQtPropertyContainerWidget::GetContainerCategory() const
+{
+  return m_pProp->GetCategory();
+}
+
 void ezQtPropertyContainerWidget::Clear()
 {
   while (m_Elements.GetCount() > 0)
@@ -1433,7 +1438,7 @@ void ezQtPropertyContainerWidget::OnInit()
   const ezContainerAttribute* pArrayAttr = m_pProp->GetAttributeByType<ezContainerAttribute>();
   if (!pArrayAttr || pArrayAttr->CanAdd())
   {
-    m_pAddButton = new ezQtAddSubElementButton();
+    m_pAddButton = new ezQtAddSubElementButton(GetContainerCategory());
     m_pAddButton->Init(m_pGrid, m_pObjectAccessor, m_pType, m_pProp);
     m_pGroup->GetHeader()->layout()->addWidget(m_pAddButton);
   }
@@ -1482,7 +1487,7 @@ void ezQtPropertyContainerWidget::DeleteItems(ezHybridArray<ezPropertySelection,
 
 void ezQtPropertyContainerWidget::MoveItems(ezHybridArray<ezPropertySelection, 8>& items, ezInt32 iMove)
 {
-  EZ_ASSERT_DEV(m_pProp->GetCategory() != ezPropertyCategory::Map, "Map entries can't be moved.");
+  EZ_ASSERT_DEV(GetContainerCategory() != ezPropertyCategory::Map, "Map entries can't be moved.");
 
   m_pObjectAccessor->StartTransaction("Reparent Object");
 
@@ -1578,7 +1583,7 @@ void ezQtPropertyStandardTypeContainerWidget::UpdateElement(ezUInt32 index)
   }
 
   ezStringBuilder sTitle;
-  if (m_pProp->GetCategory() == ezPropertyCategory::Map)
+  if (GetContainerCategory() == ezPropertyCategory::Map)
     sTitle.SetFormat("{0}", m_Keys[index].ConvertTo<ezString>());
   else
     sTitle.SetFormat("[{0}]", m_Keys[index].ConvertTo<ezString>());
@@ -1805,7 +1810,12 @@ void ezQtVariantPropertyWidget::InternalSetValue(const ezVariant& value)
     m_pCurrentSubType = pNewtSubType;
     if (pNewtSubType)
     {
-      m_pWidget = ezQtPropertyGridWidget::GetFactory().CreateObject(pNewtSubType);
+      if (commonType == ezVariantType::VariantArray || commonType == ezVariantType::VariantDictionary)
+      {
+        m_pWidget = new ezQtVariantContainerWidget(commonType);
+      }
+      else
+        m_pWidget = ezQtPropertyGridWidget::GetFactory().CreateObject(pNewtSubType);
 
       if (!m_pWidget)
       {
@@ -1864,8 +1874,7 @@ void ezQtVariantPropertyWidget::ChangeVariantType(ezVariantType::Enum type)
     }
     else
     {
-      EZ_VERIFY(
-        m_pObjectAccessor->SetValue(item.m_pObject, m_pProp, ezReflectionUtils::GetDefaultVariantFromType(type), item.m_Index).Succeeded(), "");
+      EZ_VERIFY(m_pObjectAccessor->SetValue(item.m_pObject, m_pProp, ezReflectionUtils::GetDefaultVariantFromType(type), item.m_Index).Succeeded(), "");
     }
   }
   m_pObjectAccessor->FinishTransaction();
@@ -1873,13 +1882,57 @@ void ezQtVariantPropertyWidget::ChangeVariantType(ezVariantType::Enum type)
 
 ezResult ezQtVariantPropertyWidget::GetVariantTypeDisplayName(ezVariantType::Enum type, ezStringBuilder& out_sName) const
 {
-  if (type == ezVariantType::FirstStandardType || type >= ezVariantType::LastStandardType ||
-      type == ezVariantType::StringView || type == ezVariantType::DataBuffer || type == ezVariantType::TempHashedString)
-    return EZ_FAILURE;
-
+  if (type != ezVariantType::VariantArray && type != ezVariantType::VariantDictionary)
+  {
+    if (type == ezVariantType::FirstStandardType || type >= ezVariantType::LastStandardType ||
+        type == ezVariantType::StringView || type == ezVariantType::DataBuffer || type == ezVariantType::TempHashedString)
+      return EZ_FAILURE;
+  }
   const ezRTTI* pVariantEnum = ezGetStaticRTTI<ezVariantType>();
   if (ezReflectionUtils::EnumerationToString(pVariantEnum, type, out_sName) == false)
     return EZ_FAILURE;
 
   return EZ_SUCCESS;
+}
+
+/// *** ezQtVariantContainerWidget ***
+
+ezQtVariantContainerWidget::ezQtVariantContainerWidget(ezVariantType::Enum variantType)
+{
+  switch (variantType)
+  {
+    case ezVariantType::VariantArray:
+      m_ContainerCategory = ezPropertyCategory::Array;
+      break;
+    case ezVariantType::VariantDictionary:
+      m_ContainerCategory = ezPropertyCategory::Map;
+      break;
+    default:
+      EZ_REPORT_FAILURE("Only VariantArray and VariantDictionary are supported by ezQtVariantContainerWidget.");
+  }
+}
+
+void ezQtVariantContainerWidget::OnInit()
+{
+  // Init is only called once at creation time so it is safe to replace the object accessor here.
+  // As each ezVariantSubAccessor manages only one depth level into the ezVariant we need to wrap the object accessor for each level again which requires creating a unique accessor for each container and maintaining ownership to it.
+  m_pVariantSubAccessor = EZ_DEFAULT_NEW(ezVariantSubAccessor, m_pObjectAccessor, m_pProp);
+  m_pObjectAccessor = m_pVariantSubAccessor.Borrow();
+  ezQtPropertyContainerWidget::OnInit();
+}
+
+void ezQtVariantContainerWidget::SetSelection(const ezHybridArray<ezPropertySelection, 8>& items)
+{
+  ezMap<const ezDocumentObject*, ezVariant> subItems;
+  for (auto it : items)
+  {
+    subItems.Insert(it.m_pObject, it.m_Index);
+  }
+  m_pVariantSubAccessor->SetSubItems(subItems);
+  ezQtPropertyContainerWidget::SetSelection(items);
+}
+
+ezPropertyCategory::Enum ezQtVariantContainerWidget::GetContainerCategory() const
+{
+  return m_ContainerCategory;
 }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/VariantSubDefaultStateProvider.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/VariantSubDefaultStateProvider.cpp
@@ -1,0 +1,98 @@
+#include <GuiFoundation/GuiFoundationPCH.h>
+
+#include <GuiFoundation/PropertyGrid/VariantSubDefaultStateProvider.h>
+
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+#include <ToolsFoundation/Object/VariantSubAccessor.h>
+#include <ToolsFoundation/Reflection/VariantStorageAccessor.h>
+#include <ToolsFoundation/Serialization/DocumentObjectConverter.h>
+
+ezSharedPtr<ezDefaultStateProvider> ezVariantSubDefaultStateProvider::CreateProvider(ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp)
+{
+  if (auto variantSubAccessor = ezDynamicCast<ezVariantSubAccessor*>(pAccessor))
+  {
+    if (variantSubAccessor->GetRootProperty() == pProp)
+      return EZ_DEFAULT_NEW(ezVariantSubDefaultStateProvider, variantSubAccessor, pObject, pProp);
+  }
+  return nullptr;
+}
+
+ezVariantSubDefaultStateProvider::ezVariantSubDefaultStateProvider(ezVariantSubAccessor* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp)
+  : m_pAccessor(pAccessor)
+  , m_pObject(pObject)
+  , m_pProp(pProp)
+{
+  m_pRootAccessor = m_pAccessor->GetSourceAccessor();
+  while (auto variantSubAccessor = ezDynamicCast<ezVariantSubAccessor*>(m_pRootAccessor))
+  {
+    m_pRootAccessor = variantSubAccessor->GetSourceAccessor();
+  }
+}
+
+ezInt32 ezVariantSubDefaultStateProvider::GetRootDepth() const
+{
+  // As this default provider dives into the contents of a variable it has to always be executed first as all the other providers work on property granularity.
+  return 1000;
+}
+
+ezColorGammaUB ezVariantSubDefaultStateProvider::GetBackgroundColor() const
+{
+  // Set alpha to 0 -> color will be ignored.
+  return ezColorGammaUB(0, 0, 0, 0);
+}
+
+ezVariant ezVariantSubDefaultStateProvider::GetDefaultValue(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index)
+{
+  ezVariant defaultValue;
+  if (GetDefaultValueInternal(superPtr, pAccessor, pObject, pProp, index, defaultValue).Succeeded())
+    return defaultValue;
+
+  return {};
+}
+
+ezStatus ezVariantSubDefaultStateProvider::CreateRevertContainerDiff(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDeque<ezAbstractGraphDiffOperation>& out_diff)
+{
+  EZ_REPORT_FAILURE("Unreachable code");
+  return ezStatus(EZ_SUCCESS);
+}
+
+bool ezVariantSubDefaultStateProvider::IsDefaultValue(ezDefaultStateProvider::SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index)
+{
+  ezVariant defaultValue;
+  if (GetDefaultValueInternal(superPtr, pAccessor, pObject, pProp, index, defaultValue).Failed())
+    return true;
+
+  ezVariant value;
+  pAccessor->GetValue(pObject, pProp, value, index).LogFailure();
+  return defaultValue == value;
+}
+
+ezStatus ezVariantSubDefaultStateProvider::RevertProperty(ezDefaultStateProvider::SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index)
+{
+  ezVariant defaultValue;
+  if (GetDefaultValueInternal(superPtr, pAccessor, pObject, pProp, index, defaultValue).Failed())
+    return ezStatus(ezFmt("Failed to retrieve default value for variant sub tree."));
+
+  return pAccessor->SetValue(pObject, pProp, defaultValue, index);
+}
+
+ezResult ezVariantSubDefaultStateProvider::GetDefaultValueInternal(ezDefaultStateProvider::SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index, ezVariant& out_DefaultValue)
+{
+  EZ_ASSERT_DEBUG(pObject == m_pObject && pProp == m_pProp, "ezVariantSubDefaultStateProvider is only valid on the object and variant property it was created on.");
+  // As m_pAccessor is a view into an ezVariant we first need to take the same steps into the defaultValue retrieved from the root accessor to have the same view so we can compare the same subset of both ezVariants.
+  out_DefaultValue = superPtr[0]->GetDefaultValue(superPtr.GetSubArray(1), m_pRootAccessor, pObject, pProp);
+
+  ezHybridArray<ezVariant, 4> path;
+  EZ_SUCCEED_OR_RETURN(m_pAccessor->GetPath(pObject, path));
+  if (index.IsValid())
+    path.PushBack(index);
+
+  for (const ezVariant& step : path)
+  {
+    ezStatus res(EZ_SUCCESS);
+    out_DefaultValue = ezVariantStorageAccessor(pProp->GetPropertyName(), out_DefaultValue).GetValue(step, &res);
+    if (res.Failed())
+      return EZ_FAILURE;
+  }
+  return EZ_SUCCESS;
+}

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
@@ -6,8 +6,8 @@
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyEventHandler.h>
 #include <QWidget>
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
-#include <ToolsFoundation/Reflection/ReflectedType.h>
 #include <ToolsFoundation/Object/VariantSubAccessor.h>
+#include <ToolsFoundation/Reflection/ReflectedType.h>
 
 class ezDocumentObject;
 class ezQtTypeWidget;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
@@ -7,6 +7,7 @@
 #include <QWidget>
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
 #include <ToolsFoundation/Reflection/ReflectedType.h>
+#include <ToolsFoundation/Object/VariantSubAccessor.h>
 
 class ezDocumentObject;
 class ezQtTypeWidget;
@@ -270,6 +271,8 @@ protected:
   void UpdateElements();
   virtual ezUInt32 GetRequiredElementCount() const;
   virtual void UpdatePropertyMetaState();
+  /// \brief Some containers like ezVariant can be both a map or an array so we can't reply on the property type alone. For these containers, this method can be overwritten to retrieve the category from something other than `m_pProp->GetCategory()`.
+  virtual ezPropertyCategory::Enum GetContainerCategory() const;
 
   void Clear();
   virtual void OnInit() override;
@@ -358,4 +361,23 @@ protected:
   QComboBox* m_pTypeList = nullptr;
   ezQtPropertyWidget* m_pWidget = nullptr;
   const ezRTTI* m_pCurrentSubType = nullptr;
+};
+
+// Used for sub-containers of an ezVariant, e.g. an ezVariantArray or ezVariantDictionary stored inside an ezVariant. ezVariantSubAccessor is used to create a view into a sub-tree container of the ezVariant.
+class EZ_GUIFOUNDATION_DLL ezQtVariantContainerWidget : public ezQtPropertyStandardTypeContainerWidget
+{
+  Q_OBJECT;
+
+public:
+  ezQtVariantContainerWidget(ezVariantType::Enum variantType);
+  virtual ~ezQtVariantContainerWidget() = default;
+
+protected:
+  virtual void OnInit() override;
+  virtual void SetSelection(const ezHybridArray<ezPropertySelection, 8>& items) override;
+  virtual ezPropertyCategory::Enum GetContainerCategory() const override;
+
+private:
+  ezUniquePtr<ezVariantSubAccessor> m_pVariantSubAccessor;
+  ezEnum<ezPropertyCategory> m_ContainerCategory;
 };

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/VariantSubDefaultStateProvider.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/VariantSubDefaultStateProvider.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <GuiFoundation/GuiFoundationDLL.h>
+
+#include <GuiFoundation/PropertyGrid/DefaultState.h>
+
+class ezVariantSubAccessor;
+
+// \brief Default value provider for ezVariantSubAccessor.
+class EZ_GUIFOUNDATION_DLL ezVariantSubDefaultStateProvider : public ezDefaultStateProvider
+{
+public:
+  static ezSharedPtr<ezDefaultStateProvider> CreateProvider(ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp);
+
+  ezVariantSubDefaultStateProvider(ezVariantSubAccessor* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp);
+
+  virtual ezInt32 GetRootDepth() const override;
+  virtual ezColorGammaUB GetBackgroundColor() const override;
+  virtual ezString GetStateProviderName() const override { return "Variant"; }
+
+  virtual ezVariant GetDefaultValue(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+  virtual ezStatus CreateRevertContainerDiff(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDeque<ezAbstractGraphDiffOperation>& out_diff) override;
+  virtual bool IsDefaultValue(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+  virtual ezStatus RevertProperty(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+
+private:
+  ezResult GetDefaultValueInternal(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index, ezVariant& out_DefaultValue);
+
+private:
+  ezVariantSubAccessor* m_pAccessor = nullptr;
+  const ezDocumentObject* m_pObject = nullptr;
+  const ezAbstractProperty* m_pProp = nullptr;
+  ezObjectAccessorBase* m_pRootAccessor = nullptr;
+};

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/NodeCommandAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/Implementation/NodeCommandAccessor.cpp
@@ -4,6 +4,11 @@
 #include <ToolsFoundation/NodeObject/DocumentNodeManager.h>
 #include <ToolsFoundation/NodeObject/NodeCommandAccessor.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezNodeCommandAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 ezNodeCommandAccessor::ezNodeCommandAccessor(ezCommandHistory* pHistory)
   : ezObjectCommandAccessor(pHistory)
 {

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/NodeCommandAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/NodeCommandAccessor.h
@@ -4,6 +4,7 @@
 class EZ_TOOLSFOUNDATION_DLL ezNodeCommandAccessor : public ezObjectCommandAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezNodeCommandAccessor, ezObjectCommandAccessor);
+
 public:
   ezNodeCommandAccessor(ezCommandHistory* pHistory);
   ~ezNodeCommandAccessor();

--- a/Code/Tools/Libs/ToolsFoundation/NodeObject/NodeCommandAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/NodeObject/NodeCommandAccessor.h
@@ -3,6 +3,7 @@
 
 class EZ_TOOLSFOUNDATION_DLL ezNodeCommandAccessor : public ezObjectCommandAccessor
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezNodeCommandAccessor, ezObjectCommandAccessor);
 public:
   ezNodeCommandAccessor(ezCommandHistory* pHistory);
   ~ezNodeCommandAccessor();

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectAccessorBase.cpp
@@ -2,6 +2,11 @@
 
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezObjectAccessorBase, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 void ezObjectAccessorBase::StartTransaction(ezStringView sDisplayString) {}
 
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectCommandAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectCommandAccessor.cpp
@@ -5,6 +5,11 @@
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
 #include <ToolsFoundation/Object/ObjectCommandAccessor.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezObjectCommandAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 ezObjectCommandAccessor::ezObjectCommandAccessor(ezCommandHistory* pHistory)
   : ezObjectDirectAccessor(const_cast<ezDocumentObjectManager*>(pHistory->GetDocument()->GetObjectManager()))
   , m_pHistory(pHistory)

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectDirectAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectDirectAccessor.cpp
@@ -3,6 +3,11 @@
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
 #include <ToolsFoundation/Object/ObjectDirectAccessor.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezObjectDirectAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 ezObjectDirectAccessor::ezObjectDirectAccessor(ezDocumentObjectManager* pManager)
   : ezObjectAccessorBase(pManager)
   , m_pManager(pManager)

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectProxyAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/ObjectProxyAccessor.cpp
@@ -2,6 +2,11 @@
 
 #include <ToolsFoundation/Object/ObjectProxyAccessor.h>
 
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezObjectProxyAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
 ezObjectProxyAccessor::ezObjectProxyAccessor(ezObjectAccessorBase* pSource)
   : ezObjectAccessorBase(pSource->GetObjectManager())
   , m_pSource(pSource)

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/VariantSubAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/VariantSubAccessor.cpp
@@ -1,0 +1,136 @@
+#include <ToolsFoundation/ToolsFoundationPCH.h>
+
+#include <ToolsFoundation/Object/VariantSubAccessor.h>
+#include <ToolsFoundation/Reflection/VariantStorageAccessor.h>
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVariantSubAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezVariantSubAccessor::ezVariantSubAccessor(ezObjectAccessorBase* pSource, const ezAbstractProperty* pProp)
+  : ezObjectProxyAccessor(pSource)
+  , m_pProp(pProp)
+{
+}
+
+void ezVariantSubAccessor::SetSubItems(const ezMap<const ezDocumentObject*, ezVariant>& subItemMap)
+{
+  m_SubItemMap = subItemMap;
+}
+
+ezInt32 ezVariantSubAccessor::GetDepth() const
+{
+  if (auto variantSubAccessor = ezDynamicCast<ezVariantSubAccessor*>(GetSourceAccessor()))
+  {
+    return variantSubAccessor->GetDepth() + 1;
+  }
+  return 1;
+}
+
+ezResult ezVariantSubAccessor::GetPath(const ezDocumentObject* pObject, ezDynamicArray<ezVariant>& out_path) const
+{
+    out_path.Clear();
+    if (auto variantSubAccessor = ezDynamicCast<ezVariantSubAccessor*>(GetSourceAccessor()))
+    {
+      EZ_SUCCEED_OR_RETURN(variantSubAccessor->GetPath(pObject, out_path));
+    }
+    ezVariant subItem;
+    if (!m_SubItemMap.TryGetValue(pObject, subItem))
+      return EZ_FAILURE;
+
+    out_path.PushBack(subItem);
+    return EZ_SUCCESS;
+}
+
+ezStatus ezVariantSubAccessor::GetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value, ezVariant index)
+{
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, out_value));
+
+  ezStatus result(EZ_SUCCESS);
+  out_value = ezVariantStorageAccessor(pProp->GetPropertyName(), out_value).GetValue(index, &result);
+  return result;
+}
+
+ezStatus ezVariantSubAccessor::SetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).SetValue(newValue, index); });
+}
+
+ezStatus ezVariantSubAccessor::InsertValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).InsertValue(index, newValue); });
+}
+
+ezStatus ezVariantSubAccessor::RemoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).RemoveValue(index); });
+}
+
+ezStatus ezVariantSubAccessor::MoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& oldIndex, const ezVariant& newIndex)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).MoveValue(oldIndex, newIndex); });
+}
+
+ezStatus ezVariantSubAccessor::GetCount(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezInt32& out_iCount)
+{
+  ezVariant subValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, subValue));
+  out_iCount = ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).GetCount();
+  return EZ_SUCCESS;
+}
+
+ezStatus ezVariantSubAccessor::GetKeys(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_keys)
+{
+  ezVariant subValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, subValue));
+  return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).GetKeys(out_keys);
+}
+
+ezStatus ezVariantSubAccessor::GetValues(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_values)
+{
+  ezVariant subValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, subValue));
+  ezHybridArray<ezVariant, 16> keys;
+  ezVariantStorageAccessor accessor(pProp->GetPropertyName(), subValue);
+  EZ_SUCCEED_OR_RETURN(accessor.GetKeys(keys));
+  out_values.Clear();
+  out_values.Reserve(keys.GetCount());
+  for (const ezVariant& key : keys)
+  {
+    out_values.PushBack(accessor.GetValue(key));
+  }
+  return EZ_SUCCESS;
+}
+
+ezStatus ezVariantSubAccessor::GetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value)
+{
+  // EZ_ASSERT_DEBUG(m_pProp == pProp, "ezVariantSubAccessor should only be used to access a single variant property");
+  ezStatus result = ezObjectProxyAccessor::GetValue(pObject, pProp, out_value);
+  if (result.Failed())
+    return result;
+
+  ezVariant subItem;
+  if (!m_SubItemMap.TryGetValue(pObject, subItem))
+    return ezStatus(ezFmt("Sub-item '{0}' not found in variant property '{1}'", subItem, pProp->GetPropertyName()));
+
+  out_value = ezVariantStorageAccessor(pProp->GetPropertyName(), out_value).GetValue(subItem, &result);
+  return result;
+}
+
+ezStatus ezVariantSubAccessor::SetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezStatus(ezVariant&)>& func)
+{
+  EZ_ASSERT_DEBUG(m_pProp == pProp, "ezVariantSubAccessor should only be used to access a single variant property");
+  ezVariant subItem;
+  if (!m_SubItemMap.TryGetValue(pObject, subItem))
+    return ezStatus(ezFmt("Sub-item '{0}' not found in variant property '{1}'", subItem, pProp->GetPropertyName()));
+
+  ezVariant currentValue;
+  EZ_SUCCEED_OR_RETURN(ezObjectProxyAccessor::GetValue(pObject, pProp, currentValue, subItem));
+  EZ_SUCCEED_OR_RETURN(func(currentValue));
+  return ezObjectProxyAccessor::SetValue(pObject, pProp, currentValue, subItem);
+}

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/VariantSubAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/VariantSubAccessor.cpp
@@ -30,17 +30,17 @@ ezInt32 ezVariantSubAccessor::GetDepth() const
 
 ezResult ezVariantSubAccessor::GetPath(const ezDocumentObject* pObject, ezDynamicArray<ezVariant>& out_path) const
 {
-    out_path.Clear();
-    if (auto variantSubAccessor = ezDynamicCast<ezVariantSubAccessor*>(GetSourceAccessor()))
-    {
-      EZ_SUCCEED_OR_RETURN(variantSubAccessor->GetPath(pObject, out_path));
-    }
-    ezVariant subItem;
-    if (!m_SubItemMap.TryGetValue(pObject, subItem))
-      return EZ_FAILURE;
+  out_path.Clear();
+  if (auto variantSubAccessor = ezDynamicCast<ezVariantSubAccessor*>(GetSourceAccessor()))
+  {
+    EZ_SUCCEED_OR_RETURN(variantSubAccessor->GetPath(pObject, out_path));
+  }
+  ezVariant subItem;
+  if (!m_SubItemMap.TryGetValue(pObject, subItem))
+    return EZ_FAILURE;
 
-    out_path.PushBack(subItem);
-    return EZ_SUCCESS;
+  out_path.PushBack(subItem);
+  return EZ_SUCCESS;
 }
 
 ezStatus ezVariantSubAccessor::GetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value, ezVariant index)

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
@@ -7,6 +7,7 @@ class ezDocumentObject;
 class EZ_TOOLSFOUNDATION_DLL ezObjectAccessorBase : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezObjectAccessorBase, ezReflectedClass);
+
 public:
   virtual ~ezObjectAccessorBase();
   const ezDocumentObjectManager* GetObjectManager() const;

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectAccessorBase.h
@@ -4,8 +4,9 @@
 
 class ezDocumentObject;
 
-class EZ_TOOLSFOUNDATION_DLL ezObjectAccessorBase
+class EZ_TOOLSFOUNDATION_DLL ezObjectAccessorBase : public ezReflectedClass
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezObjectAccessorBase, ezReflectedClass);
 public:
   virtual ~ezObjectAccessorBase();
   const ezDocumentObjectManager* GetObjectManager() const;

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectCommandAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectCommandAccessor.h
@@ -8,6 +8,7 @@ class ezCommandHistory;
 class EZ_TOOLSFOUNDATION_DLL ezObjectCommandAccessor : public ezObjectDirectAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezObjectCommandAccessor, ezObjectDirectAccessor);
+
 public:
   ezObjectCommandAccessor(ezCommandHistory* pHistory);
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectCommandAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectCommandAccessor.h
@@ -7,6 +7,7 @@ class ezCommandHistory;
 
 class EZ_TOOLSFOUNDATION_DLL ezObjectCommandAccessor : public ezObjectDirectAccessor
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezObjectCommandAccessor, ezObjectDirectAccessor);
 public:
   ezObjectCommandAccessor(ezCommandHistory* pHistory);
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectDirectAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectDirectAccessor.h
@@ -6,6 +6,7 @@ class ezDocumentObjectManager;
 
 class EZ_TOOLSFOUNDATION_DLL ezObjectDirectAccessor : public ezObjectAccessorBase
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezObjectDirectAccessor, ezObjectAccessorBase);
 public:
   ezObjectDirectAccessor(ezDocumentObjectManager* pManager);
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectDirectAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectDirectAccessor.h
@@ -7,6 +7,7 @@ class ezDocumentObjectManager;
 class EZ_TOOLSFOUNDATION_DLL ezObjectDirectAccessor : public ezObjectAccessorBase
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezObjectDirectAccessor, ezObjectAccessorBase);
+
 public:
   ezObjectDirectAccessor(ezDocumentObjectManager* pManager);
 

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
@@ -7,6 +7,7 @@ class ezDocumentObject;
 class EZ_TOOLSFOUNDATION_DLL ezObjectProxyAccessor : public ezObjectAccessorBase
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezObjectProxyAccessor, ezReflectedClass);
+
 public:
   ezObjectProxyAccessor(ezObjectAccessorBase* pSource);
   virtual ~ezObjectProxyAccessor();

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
@@ -6,9 +6,11 @@ class ezDocumentObject;
 
 class EZ_TOOLSFOUNDATION_DLL ezObjectProxyAccessor : public ezObjectAccessorBase
 {
+  EZ_ADD_DYNAMIC_REFLECTION(ezObjectProxyAccessor, ezReflectedClass);
 public:
   ezObjectProxyAccessor(ezObjectAccessorBase* pSource);
   virtual ~ezObjectProxyAccessor();
+  ezObjectAccessorBase* GetSourceAccessor() const { return m_pSource; }
 
   /// \name Transaction Operations
   ///@{

--- a/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/ObjectProxyAccessor.h
@@ -6,7 +6,7 @@ class ezDocumentObject;
 
 class EZ_TOOLSFOUNDATION_DLL ezObjectProxyAccessor : public ezObjectAccessorBase
 {
-  EZ_ADD_DYNAMIC_REFLECTION(ezObjectProxyAccessor, ezReflectedClass);
+  EZ_ADD_DYNAMIC_REFLECTION(ezObjectProxyAccessor, ezObjectAccessorBase);
 
 public:
   ezObjectProxyAccessor(ezObjectAccessorBase* pSource);

--- a/Code/Tools/Libs/ToolsFoundation/Object/VariantSubAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/VariantSubAccessor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <ToolsFoundation/Object/ObjectProxyAccessor.h>
+
+class ezDocumentObject;
+
+/// \brief Accessor for a sub-tree on an ezVariant property.
+/// The tools foundation code uses an ezDocumentObject, one of its ezAbstractProperty and an optional ezVariant index to reference to properties. Any deeper hierarchies must be built from additional objects. This principle prevents the GUI to reference anything inside an ezVariant that stores an VariantArray or VariantDictionary as ezVariant is a pure value type and cannot store additional objects on the tool side. To work around this, this class creates a view one level deeper into an ezVariant. This is done by calling SetSubItems which for each object in the map moves the view into the sub-tree referenced by the given value of the map.
+class EZ_TOOLSFOUNDATION_DLL ezVariantSubAccessor : public ezObjectProxyAccessor
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezVariantSubAccessor, ezObjectProxyAccessor);
+public:
+  /// \brief Constructor
+  /// \param pSource The original accessor that is going to be proxied. By chaining this class an ezVariant can be explored deeper and deeper.
+  /// \param pProp The ezVariant property that is going to be proxied. Only this property is allowed to be accessed by the accessor functions.
+  ezVariantSubAccessor(ezObjectAccessorBase* pSource, const ezAbstractProperty* pProp);
+  /// \brief Sets the sub-tree indices for the selected objects.
+  /// \param subItemMap Object to index map. Note that as this is in the ToolsFoundation it cannot use the ezPropertySelection class.
+  void SetSubItems(const ezMap<const ezDocumentObject*, ezVariant>& subItemMap);
+  /// \brief Returns the property this accessor wraps.
+  const ezAbstractProperty* GetRootProperty() const { return m_pProp; }
+  /// \brief How many level deep the view is inside the property.
+  ezInt32 GetDepth() const;
+  /// Builds a path up the hierarchy of wrapped ezVariantSubAccessor objects to determine the path to the current sub-tree of the ezVariant.
+  /// \param pObject The object for which the path should be computed
+  /// \param out_path An array of indices that has to be followed from the root of the ezVariant to each the current sub-tree view.
+  /// \return Returns EZ_FAILURE if pObject is not known.
+  ezResult GetPath(const ezDocumentObject* pObject, ezDynamicArray<ezVariant>& out_path) const;
+
+  virtual ezStatus GetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value, ezVariant index = ezVariant()) override;
+  virtual ezStatus SetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index = ezVariant()) override;
+  virtual ezStatus InsertValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index = ezVariant()) override;
+  virtual ezStatus RemoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+  virtual ezStatus MoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& oldIndex, const ezVariant& newIndex) override;
+  virtual ezStatus GetCount(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezInt32& out_iCount) override;
+  virtual ezStatus GetKeys(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_keys) override;
+  virtual ezStatus GetValues(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_values) override;
+
+private:
+  ezStatus GetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value);
+  ezStatus SetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezStatus(ezVariant& subValue)>& func);
+
+private:
+  const ezAbstractProperty* m_pProp = nullptr;
+  ezMap<const ezDocumentObject*, ezVariant> m_SubItemMap;
+};

--- a/Code/Tools/Libs/ToolsFoundation/Object/VariantSubAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Object/VariantSubAccessor.h
@@ -9,6 +9,7 @@ class ezDocumentObject;
 class EZ_TOOLSFOUNDATION_DLL ezVariantSubAccessor : public ezObjectProxyAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezVariantSubAccessor, ezObjectProxyAccessor);
+
 public:
   /// \brief Constructor
   /// \param pSource The original accessor that is going to be proxied. By chaining this class an ezVariant can be explored deeper and deeper.

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/IReflectedTypeAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/IReflectedTypeAccessor.cpp
@@ -10,7 +10,7 @@ bool ezIReflectedTypeAccessor::GetValues(ezStringView sProperty, ezDynamicArray<
 
   out_values.Clear();
   out_values.Reserve(keys.GetCount());
-  for (ezVariant key : keys)
+  for (const ezVariant& key : keys)
   {
     out_values.PushBack(GetValue(sProperty, key));
   }

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/VariantStorageAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/Implementation/VariantStorageAccessor.cpp
@@ -1,0 +1,220 @@
+#include <ToolsFoundation/ToolsFoundationPCH.h>
+
+#include <Foundation/Types/Status.h>
+#include <ToolsFoundation/Reflection/VariantStorageAccessor.h>
+
+ezVariantStorageAccessor::ezVariantStorageAccessor(ezStringView sProperty, ezVariant& value)
+  : m_sProperty(sProperty)
+  , m_Value(value)
+{
+}
+
+ezVariantStorageAccessor::ezVariantStorageAccessor(ezStringView sProperty, const ezVariant& value)
+  : m_sProperty(sProperty)
+  , m_Value(const_cast<ezVariant&>(value))
+{
+}
+
+ezVariant ezVariantStorageAccessor::GetValue(ezVariant index, ezStatus* pRes) const
+{
+  if (!index.IsValid())
+    return m_Value;
+
+  if (index.IsNumber())
+  {
+    if (!m_Value.IsA<ezVariantArray>())
+    {
+      if (pRes)
+        *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid as the property is not an array.", index, m_sProperty));
+      return ezVariant();
+    }
+    const ezVariantArray& values = m_Value.Get<ezVariantArray>();
+    ezUInt32 uiIndex = index.ConvertTo<ezUInt32>();
+    if (uiIndex < values.GetCount())
+    {
+      return values[uiIndex];
+    }
+  }
+  else if (index.IsA<ezString>())
+  {
+    if (!m_Value.IsA<ezVariantDictionary>())
+    {
+      if (pRes)
+        *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid as the property is not a dictionary.", index, m_sProperty));
+      return ezVariant();
+    }
+    const ezVariantDictionary& values = m_Value.Get<ezVariantDictionary>();
+    const ezString& sIndex = index.Get<ezString>();
+    if (const ezVariant* pValue = values.GetValue(sIndex))
+    {
+      return *pValue;
+    }
+  }
+
+  if (pRes)
+    *pRes = ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid or out of bounds.", index, m_sProperty));
+  return ezVariant();
+}
+
+ezStatus ezVariantStorageAccessor::SetValue(const ezVariant& value, ezVariant index)
+{
+  if (!index.IsValid())
+  {
+    m_Value = value;
+    return EZ_SUCCESS;
+  }
+
+  if (index.IsNumber() && m_Value.IsA<ezVariantArray>())
+  {
+    ezVariantArray& values = m_Value.GetWritable<ezVariantArray>();
+    ezUInt32 uiIndex = index.ConvertTo<ezUInt32>();
+    if (uiIndex >= values.GetCount())
+    {
+      return ezStatus(ezFmt("Index '{0}' for property '{1}' is out of bounds.", uiIndex, m_sProperty));
+    }
+    values[uiIndex] = value;
+    return EZ_SUCCESS;
+  }
+  else if (index.IsA<ezString>() && m_Value.IsA<ezVariantDictionary>())
+  {
+    ezVariantDictionary& values = m_Value.GetWritable<ezVariantDictionary>();
+    const ezString& sIndex = index.Get<ezString>();
+    if (!values.Contains(sIndex))
+    {
+      return ezStatus(ezFmt("Index '{0}' for property '{1}' is out of bounds.", sIndex, m_sProperty));
+    }
+    values[sIndex] = value;
+    return EZ_SUCCESS;
+  }
+  return ezStatus(ezFmt("Index '{0}' for property '{1}' is invalid.", index, m_sProperty));
+}
+
+ezInt32 ezVariantStorageAccessor::GetCount() const
+{
+  if (m_Value.IsA<ezVariantArray>())
+    return m_Value.Get<ezVariantArray>().GetCount();
+  else if (m_Value.IsA<ezVariantDictionary>())
+    return m_Value.Get<ezVariantDictionary>().GetCount();
+  return 0;
+}
+
+ezStatus ezVariantStorageAccessor::GetKeys(ezDynamicArray<ezVariant>& out_keys) const
+{
+  if (m_Value.IsA<ezVariantArray>())
+  {
+    const ezVariantArray& values = m_Value.Get<ezVariantArray>();
+    out_keys.Reserve(values.GetCount());
+    for (ezUInt32 i = 0; i < values.GetCount(); ++i)
+    {
+      out_keys.PushBack(i);
+    }
+    return EZ_SUCCESS;
+  }
+  else if (m_Value.IsA<ezVariantDictionary>())
+  {
+    const ezVariantDictionary& values = m_Value.Get<ezVariantDictionary>();
+    out_keys.Reserve(values.GetCount());
+    for (auto it = values.GetIterator(); it.IsValid(); ++it)
+    {
+      out_keys.PushBack(ezVariant(it.Key()));
+    }
+    return EZ_SUCCESS;
+  }
+  return ezStatus(ezFmt("Property '{0}' is not a container.", m_sProperty));
+}
+
+ezStatus ezVariantStorageAccessor::InsertValue(const ezVariant& index, const ezVariant& value)
+{
+  if (index.IsNumber() && m_Value.IsA<ezVariantArray>())
+  {
+    ezVariantArray& values = m_Value.GetWritable<ezVariantArray>();
+    ezInt32 iIndex = index.ConvertTo<ezInt32>();
+    const ezInt32 iCount = (ezInt32)values.GetCount();
+    if (iIndex == -1)
+    {
+      iIndex = iCount;
+    }
+    if (iIndex > iCount)
+      return ezStatus(ezFmt("InsertValue: index '{0}' for property '{1}' is out of bounds.", iIndex, m_sProperty));
+
+    values.InsertAt(iIndex, value);
+    return EZ_SUCCESS;
+  }
+  else if (index.IsA<ezString>() && m_Value.IsA<ezVariantDictionary>())
+  {
+    ezVariantDictionary& values = m_Value.GetWritable<ezVariantDictionary>();
+    const ezString& sIndex = index.Get<ezString>();
+    if (values.Contains(index.Get<ezString>()))
+      return ezStatus(ezFmt("InsertValue: index '{0}' for property '{1}' already exists.", sIndex, m_sProperty));
+
+    values.Insert(sIndex, value);
+    return EZ_SUCCESS;
+  }
+  return ezStatus(ezFmt("InsertValue: Property '{0}' is not a container or index {1} is invalid.", m_sProperty, index));
+}
+
+ezStatus ezVariantStorageAccessor::RemoveValue(const ezVariant& index)
+{
+  if (index.IsNumber() && m_Value.IsA<ezVariantArray>())
+  {
+    ezVariantArray& values = m_Value.GetWritable<ezVariantArray>();
+    const ezUInt32 uiIndex = index.ConvertTo<ezUInt32>();
+    if (uiIndex > values.GetCount())
+      return ezStatus(ezFmt("RemoveValue: index '{0}' for property '{1}' is out of bounds.", uiIndex, m_sProperty));
+
+    values.RemoveAtAndCopy(uiIndex);
+    return EZ_SUCCESS;
+  }
+  else if (index.IsA<ezString>() && m_Value.IsA<ezVariantDictionary>())
+  {
+    ezVariantDictionary& values = m_Value.GetWritable<ezVariantDictionary>();
+    const ezString& sIndex = index.Get<ezString>();
+    if (!values.Contains(index.Get<ezString>()))
+      return ezStatus(ezFmt("RemoveValue: index '{0}' for property '{1}' does not exists.", sIndex, m_sProperty));
+
+    values.Remove(sIndex);
+    return EZ_SUCCESS;
+  }
+  return ezStatus(ezFmt("RemoveValue: Property '{0}' is not a container or index '{1}' is invalid.", m_sProperty, index));
+}
+
+ezStatus ezVariantStorageAccessor::MoveValue(const ezVariant& oldIndex, const ezVariant& newIndex)
+{
+  if (m_Value.IsA<ezVariantArray>() && oldIndex.IsNumber() && newIndex.IsNumber())
+  {
+    ezVariantArray& values = m_Value.GetWritable<ezVariantArray>();
+    ezUInt32 uiOldIndex = oldIndex.ConvertTo<ezUInt32>();
+    ezUInt32 uiNewIndex = newIndex.ConvertTo<ezUInt32>();
+    if (uiOldIndex < values.GetCount() && uiNewIndex <= values.GetCount())
+    {
+      ezVariant value = values[uiOldIndex];
+      values.RemoveAtAndCopy(uiOldIndex);
+      if (uiNewIndex > uiOldIndex)
+      {
+        uiNewIndex -= 1;
+      }
+      values.InsertAt(uiNewIndex, value);
+      return EZ_SUCCESS;
+    }
+    else
+    {
+      return ezStatus(ezFmt("MoveValue: index '{0}' or '{1}' for property '{2}' is out of bounds.", uiOldIndex, uiNewIndex, m_sProperty));
+    }
+  }
+  else if (m_Value.IsA<ezVariantDictionary>() && oldIndex.IsA<ezString>() && newIndex.IsA<ezString>())
+  {
+    ezVariantDictionary& values = m_Value.GetWritable<ezVariantDictionary>();
+    const ezString& sOldIndex = oldIndex.Get<ezString>();
+    const ezString& sNewIndex = newIndex.Get<ezString>();
+
+    if (!values.Contains(sOldIndex))
+      return ezStatus(ezFmt("MoveValue: old index '{0}' for property '{2}' does not exist.", sOldIndex, m_sProperty));
+    else if (values.Contains(sNewIndex))
+      return ezStatus(ezFmt("MoveValue: new index '{0}' for property '{2}' already exists.", sNewIndex, m_sProperty));
+
+    values.Insert(sNewIndex, values[sOldIndex]);
+    values.Remove(sOldIndex);
+    return EZ_SUCCESS;
+  }
+  return ezStatus(ezFmt("MoveValue: Property '{0}' is not a container or index '{1}' or '{2}' is invalid.", m_sProperty, oldIndex, newIndex));
+}

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/VariantStorageAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/VariantStorageAccessor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <ToolsFoundation/ToolsFoundationDLL.h>
 #include <Foundation/Types/Variant.h>
+#include <ToolsFoundation/ToolsFoundationDLL.h>
 
 class ezStatus;
 

--- a/Code/Tools/Libs/ToolsFoundation/Reflection/VariantStorageAccessor.h
+++ b/Code/Tools/Libs/ToolsFoundation/Reflection/VariantStorageAccessor.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <ToolsFoundation/ToolsFoundationDLL.h>
+#include <Foundation/Types/Variant.h>
+
+class ezStatus;
+
+/// \brief Helper class to modify an ezVariant as if it was a container.
+/// GetValue and SetValue are valid for all variant types.
+/// The remaining accessor functions require an VariantArray or VariantDictionary type.
+class EZ_TOOLSFOUNDATION_DLL ezVariantStorageAccessor
+{
+public:
+  ezVariantStorageAccessor(ezStringView sProperty, ezVariant& value);
+  ezVariantStorageAccessor(ezStringView sProperty, const ezVariant& value);
+
+  ezVariant GetValue(ezVariant index = ezVariant(), ezStatus* pRes = nullptr) const;
+  ezStatus SetValue(const ezVariant& value, ezVariant index = ezVariant());
+
+  ezInt32 GetCount() const;
+  ezStatus GetKeys(ezDynamicArray<ezVariant>& out_keys) const;
+  ezStatus InsertValue(const ezVariant& index, const ezVariant& value);
+  ezStatus RemoveValue(const ezVariant& index);
+  ezStatus MoveValue(const ezVariant& oldIndex, const ezVariant& newIndex);
+
+private:
+  ezStringView m_sProperty;
+  ezVariant& m_Value;
+};

--- a/Code/UnitTests/ToolsFoundationTest/Object/VariantPropertyTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Object/VariantPropertyTest.cpp
@@ -10,7 +10,7 @@ void TestPropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
   s_Changes.PushBack(e);
 }
 
-void TestArray(ezVariantSubAccessor& accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
+void TestArray(ezVariantSubAccessor& ref_accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
 {
   auto VerifyChange = [&]()
   {
@@ -23,57 +23,57 @@ void TestArray(ezVariantSubAccessor& accessor, const ezDocumentObject* pObject, 
   };
 
   s_Changes.Clear();
-  accessor.StartTransaction("Insert Element");
+  ref_accessor.StartTransaction("Insert Element");
   ezInt32 iCount = 0;
   ezVariant value = ezColor(1, 2, 3);
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 0);
-  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value, 0));
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.InsertValue(pObject, pProp, value, 0));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 1);
   EZ_TEST_BOOL(getNativeValue()[0] == value);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
   s_Changes.Clear();
 
   ezVariant outValue;
-  EZ_TEST_STATUS(accessor.GetValue(pObject, pProp, outValue, 0));
+  EZ_TEST_STATUS(ref_accessor.GetValue(pObject, pProp, outValue, 0));
   EZ_TEST_BOOL(value == outValue);
 
-  accessor.StartTransaction("Set Element");
+  ref_accessor.StartTransaction("Set Element");
   value = ezVariantDictionary();
-  EZ_TEST_STATUS(accessor.SetValue(pObject, pProp, value, 0));
+  EZ_TEST_STATUS(ref_accessor.SetValue(pObject, pProp, value, 0));
   EZ_TEST_BOOL(getNativeValue()[0] == value);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 
-  accessor.StartTransaction("Insert Element");
+  ref_accessor.StartTransaction("Insert Element");
   ezVariant value2 = "Test";
-  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value2, 1));
+  EZ_TEST_STATUS(ref_accessor.InsertValue(pObject, pProp, value2, 1));
   EZ_TEST_BOOL(getNativeValue()[0] == value);
   EZ_TEST_BOOL(getNativeValue()[1] == value2);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 
-  accessor.StartTransaction("Move Element");
-  EZ_TEST_STATUS(accessor.MoveValue(pObject, pProp, 1, 0));
+  ref_accessor.StartTransaction("Move Element");
+  EZ_TEST_STATUS(ref_accessor.MoveValue(pObject, pProp, 1, 0));
   EZ_TEST_BOOL(getNativeValue()[0] == value2);
   EZ_TEST_BOOL(getNativeValue()[1] == value);
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 2);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 
-  accessor.StartTransaction("Remove Element");
-  EZ_TEST_STATUS(accessor.RemoveValue(pObject, pProp, 0));
+  ref_accessor.StartTransaction("Remove Element");
+  EZ_TEST_STATUS(ref_accessor.RemoveValue(pObject, pProp, 0));
   EZ_TEST_BOOL(getNativeValue()[0] == value);
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 1);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 }
 
-void TestDictionary(ezVariantSubAccessor& accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
+void TestDictionary(ezVariantSubAccessor& ref_accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
 {
   auto VerifyChange = [&]()
   {
@@ -86,44 +86,44 @@ void TestDictionary(ezVariantSubAccessor& accessor, const ezDocumentObject* pObj
   };
 
   s_Changes.Clear();
-  accessor.StartTransaction("Insert Element");
+  ref_accessor.StartTransaction("Insert Element");
   ezInt32 iCount = 0;
   ezVariant value = ezColor(1, 2, 3);
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 0);
-  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value, "A"));
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.InsertValue(pObject, pProp, value, "A"));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 1);
   EZ_TEST_BOOL(getNativeValue()["A"] == value);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
   s_Changes.Clear();
 
   ezVariant outValue;
-  EZ_TEST_STATUS(accessor.GetValue(pObject, pProp, outValue, "A"));
+  EZ_TEST_STATUS(ref_accessor.GetValue(pObject, pProp, outValue, "A"));
   EZ_TEST_BOOL(value == outValue);
 
-  accessor.StartTransaction("Set Element");
+  ref_accessor.StartTransaction("Set Element");
   value = 42u;
-  EZ_TEST_STATUS(accessor.SetValue(pObject, pProp, value, "A"));
+  EZ_TEST_STATUS(ref_accessor.SetValue(pObject, pProp, value, "A"));
   EZ_TEST_BOOL(getNativeValue()["A"] == value);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 
-  accessor.StartTransaction("Insert Element");
+  ref_accessor.StartTransaction("Insert Element");
   ezVariant value2 = ezVariantArray();
-  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value2, "B"));
+  EZ_TEST_STATUS(ref_accessor.InsertValue(pObject, pProp, value2, "B"));
   EZ_TEST_BOOL(getNativeValue()["A"] == value);
   EZ_TEST_BOOL(getNativeValue()["B"] == value2);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 
-  accessor.StartTransaction("Remove Element");
-  EZ_TEST_STATUS(accessor.RemoveValue(pObject, pProp, "A"));
+  ref_accessor.StartTransaction("Remove Element");
+  EZ_TEST_STATUS(ref_accessor.RemoveValue(pObject, pProp, "A"));
   EZ_TEST_BOOL(getNativeValue()["B"] == value2);
-  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_STATUS(ref_accessor.GetCount(pObject, pProp, iCount));
   EZ_TEST_INT(iCount, 1);
-  accessor.FinishTransaction();
+  ref_accessor.FinishTransaction();
   VerifyChange();
 }
 

--- a/Code/UnitTests/ToolsFoundationTest/Object/VariantPropertyTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Object/VariantPropertyTest.cpp
@@ -12,7 +12,8 @@ void TestPropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
 
 void TestArray(ezVariantSubAccessor& accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
 {
-  auto VerifyChange = [&](){
+  auto VerifyChange = [&]()
+  {
     // Any operation should collapse to the ezVariant being set as a whole.
     EZ_TEST_INT(s_Changes.GetCount(), 1);
     EZ_TEST_BOOL(s_Changes[0].m_EventType == ezDocumentObjectPropertyEvent::Type::PropertySet);
@@ -162,27 +163,31 @@ EZ_CREATE_SIMPLE_TEST(DocumentObject, VariantPropertyTest)
     ezMap<const ezDocumentObject*, ezVariant> subItemMap;
     subItemMap.Insert(pObject, ezVariant());
     accessor.SetSubItems(subItemMap);
-    TestArray(accessor, pObject, pProp, [&](){return pNative->m_Variant;});
+    TestArray(accessor, pObject, pProp, [&]()
+      { return pNative->m_Variant; });
     // What remains is an ezVariantDictionary at index 0 that we can recurse into.
     {
       ezVariantSubAccessor accessor2(&accessor, pProp);
       ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
       subItemMap2.Insert(pObject, 0);
       accessor2.SetSubItems(subItemMap2);
-      TestDictionary(accessor2, pObject, pProp, [&](){return pNative->m_Variant[0];});
+      TestDictionary(accessor2, pObject, pProp, [&]()
+        { return pNative->m_Variant[0]; });
     }
     pAccessor->StartTransaction("Set as Dict");
     EZ_TEST_STATUS(pAccessor->SetValue(pObject, pProp, ezVariantDictionary()));
     pAccessor->FinishTransaction();
     s_Changes.Clear();
-    TestDictionary(accessor, pObject, pProp, [&](){return pNative->m_Variant;});
+    TestDictionary(accessor, pObject, pProp, [&]()
+      { return pNative->m_Variant; });
     // What remains is an ezVariantArray at index "B" that we can recurse into.
     {
       ezVariantSubAccessor accessor2(&accessor, pProp);
       ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
       subItemMap2.Insert(pObject, "B");
       accessor2.SetSubItems(subItemMap2);
-      TestArray(accessor2, pObject, pProp, [&](){return pNative->m_Variant["B"];});
+      TestArray(accessor2, pObject, pProp, [&]()
+        { return pNative->m_Variant["B"]; });
     }
   }
 
@@ -196,14 +201,16 @@ EZ_CREATE_SIMPLE_TEST(DocumentObject, VariantPropertyTest)
     ezMap<const ezDocumentObject*, ezVariant> subItemMap;
     subItemMap.Insert(pObject, 0);
     accessor.SetSubItems(subItemMap);
-    TestArray(accessor, pObject, pPropArray, [&](){return pNative->m_VariantArray[0];});
+    TestArray(accessor, pObject, pPropArray, [&]()
+      { return pNative->m_VariantArray[0]; });
     // What remains is an ezVariantDictionary at index 0 that we can recurse into.
     {
       ezVariantSubAccessor accessor2(&accessor, pPropArray);
       ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
       subItemMap2.Insert(pObject, 0);
       accessor2.SetSubItems(subItemMap2);
-      TestDictionary(accessor2, pObject, pPropArray, [&](){return pNative->m_VariantArray[0][0];});
+      TestDictionary(accessor2, pObject, pPropArray, [&]()
+        { return pNative->m_VariantArray[0][0]; });
     }
     pAccessor->StartTransaction("Insert Dictionary");
     EZ_TEST_STATUS(pAccessor->InsertValue(pObject, pPropArray, ezVariantDictionary(), 1));
@@ -211,14 +218,16 @@ EZ_CREATE_SIMPLE_TEST(DocumentObject, VariantPropertyTest)
     s_Changes.Clear();
     subItemMap.Insert(pObject, 1);
     accessor.SetSubItems(subItemMap);
-    TestDictionary(accessor, pObject, pPropArray, [&](){return pNative->m_VariantArray[1];});
+    TestDictionary(accessor, pObject, pPropArray, [&]()
+      { return pNative->m_VariantArray[1]; });
     // What remains is an ezVariantArray at index "B" that we can recurse into.
     {
       ezVariantSubAccessor accessor2(&accessor, pPropArray);
       ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
       subItemMap2.Insert(pObject, "B");
       accessor2.SetSubItems(subItemMap2);
-      TestArray(accessor2, pObject, pPropArray, [&](){return pNative->m_VariantArray[1]["B"];});
+      TestArray(accessor2, pObject, pPropArray, [&]()
+        { return pNative->m_VariantArray[1]["B"]; });
     }
   }
 
@@ -232,14 +241,16 @@ EZ_CREATE_SIMPLE_TEST(DocumentObject, VariantPropertyTest)
     ezMap<const ezDocumentObject*, ezVariant> subItemMap;
     subItemMap.Insert(pObject, "AAA");
     accessor.SetSubItems(subItemMap);
-    TestArray(accessor, pObject, pPropDict, [&](){return *pNative->m_VariantDictionary.GetValue("AAA");});
+    TestArray(accessor, pObject, pPropDict, [&]()
+      { return *pNative->m_VariantDictionary.GetValue("AAA"); });
     // What remains is an ezVariantDictionary at index 0 that we can recurse into.
     {
       ezVariantSubAccessor accessor2(&accessor, pPropDict);
       ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
       subItemMap2.Insert(pObject, 0);
       accessor2.SetSubItems(subItemMap2);
-      TestDictionary(accessor2, pObject, pPropDict, [&](){return (*pNative->m_VariantDictionary.GetValue("AAA"))[0];});
+      TestDictionary(accessor2, pObject, pPropDict, [&]()
+        { return (*pNative->m_VariantDictionary.GetValue("AAA"))[0]; });
     }
     pAccessor->StartTransaction("Insert Dictionary");
     EZ_TEST_STATUS(pAccessor->InsertValue(pObject, pPropDict, ezVariantDictionary(), "BBB"));
@@ -247,14 +258,16 @@ EZ_CREATE_SIMPLE_TEST(DocumentObject, VariantPropertyTest)
     s_Changes.Clear();
     subItemMap.Insert(pObject, "BBB");
     accessor.SetSubItems(subItemMap);
-    TestDictionary(accessor, pObject, pPropDict, [&](){return *pNative->m_VariantDictionary.GetValue("BBB");});
+    TestDictionary(accessor, pObject, pPropDict, [&]()
+      { return *pNative->m_VariantDictionary.GetValue("BBB"); });
     // What remains is an ezVariantArray at index "B" that we can recurse into.
     {
       ezVariantSubAccessor accessor2(&accessor, pPropDict);
       ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
       subItemMap2.Insert(pObject, "B");
       accessor2.SetSubItems(subItemMap2);
-      TestArray(accessor2, pObject, pPropDict, [&](){return (*pNative->m_VariantDictionary.GetValue("BBB"))["B"];});
+      TestArray(accessor2, pObject, pPropDict, [&]()
+        { return (*pNative->m_VariantDictionary.GetValue("BBB"))["B"]; });
     }
   }
 }

--- a/Code/UnitTests/ToolsFoundationTest/Object/VariantPropertyTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Object/VariantPropertyTest.cpp
@@ -1,0 +1,260 @@
+#include <ToolsFoundationTest/ToolsFoundationTestPCH.h>
+
+#include <ToolsFoundation/Object/VariantSubAccessor.h>
+#include <ToolsFoundationTest/Object/TestObjectManager.h>
+#include <ToolsFoundationTest/Reflection/ReflectionTestClasses.h>
+
+static ezHybridArray<ezDocumentObjectPropertyEvent, 2> s_Changes;
+void TestPropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
+{
+  s_Changes.PushBack(e);
+}
+
+void TestArray(ezVariantSubAccessor& accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
+{
+  auto VerifyChange = [&](){
+    // Any operation should collapse to the ezVariant being set as a whole.
+    EZ_TEST_INT(s_Changes.GetCount(), 1);
+    EZ_TEST_BOOL(s_Changes[0].m_EventType == ezDocumentObjectPropertyEvent::Type::PropertySet);
+    EZ_TEST_BOOL(s_Changes[0].m_pObject == pObject);
+    EZ_TEST_BOOL(s_Changes[0].m_sProperty == pProp->GetPropertyName());
+    s_Changes.Clear();
+  };
+
+  s_Changes.Clear();
+  accessor.StartTransaction("Insert Element");
+  ezInt32 iCount = 0;
+  ezVariant value = ezColor(1, 2, 3);
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 0);
+  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value, 0));
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 1);
+  EZ_TEST_BOOL(getNativeValue()[0] == value);
+  accessor.FinishTransaction();
+  VerifyChange();
+  s_Changes.Clear();
+
+  ezVariant outValue;
+  EZ_TEST_STATUS(accessor.GetValue(pObject, pProp, outValue, 0));
+  EZ_TEST_BOOL(value == outValue);
+
+  accessor.StartTransaction("Set Element");
+  value = ezVariantDictionary();
+  EZ_TEST_STATUS(accessor.SetValue(pObject, pProp, value, 0));
+  EZ_TEST_BOOL(getNativeValue()[0] == value);
+  accessor.FinishTransaction();
+  VerifyChange();
+
+  accessor.StartTransaction("Insert Element");
+  ezVariant value2 = "Test";
+  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value2, 1));
+  EZ_TEST_BOOL(getNativeValue()[0] == value);
+  EZ_TEST_BOOL(getNativeValue()[1] == value2);
+  accessor.FinishTransaction();
+  VerifyChange();
+
+  accessor.StartTransaction("Move Element");
+  EZ_TEST_STATUS(accessor.MoveValue(pObject, pProp, 1, 0));
+  EZ_TEST_BOOL(getNativeValue()[0] == value2);
+  EZ_TEST_BOOL(getNativeValue()[1] == value);
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 2);
+  accessor.FinishTransaction();
+  VerifyChange();
+
+  accessor.StartTransaction("Remove Element");
+  EZ_TEST_STATUS(accessor.RemoveValue(pObject, pProp, 0));
+  EZ_TEST_BOOL(getNativeValue()[0] == value);
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 1);
+  accessor.FinishTransaction();
+  VerifyChange();
+}
+
+void TestDictionary(ezVariantSubAccessor& accessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezVariant()>& getNativeValue)
+{
+  auto VerifyChange = [&]()
+  {
+    // Any operation should collapse to the ezVariant being set as a whole.
+    EZ_TEST_INT(s_Changes.GetCount(), 1);
+    EZ_TEST_BOOL(s_Changes[0].m_EventType == ezDocumentObjectPropertyEvent::Type::PropertySet);
+    EZ_TEST_BOOL(s_Changes[0].m_pObject == pObject);
+    EZ_TEST_BOOL(s_Changes[0].m_sProperty == pProp->GetPropertyName());
+    s_Changes.Clear();
+  };
+
+  s_Changes.Clear();
+  accessor.StartTransaction("Insert Element");
+  ezInt32 iCount = 0;
+  ezVariant value = ezColor(1, 2, 3);
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 0);
+  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value, "A"));
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 1);
+  EZ_TEST_BOOL(getNativeValue()["A"] == value);
+  accessor.FinishTransaction();
+  VerifyChange();
+  s_Changes.Clear();
+
+  ezVariant outValue;
+  EZ_TEST_STATUS(accessor.GetValue(pObject, pProp, outValue, "A"));
+  EZ_TEST_BOOL(value == outValue);
+
+  accessor.StartTransaction("Set Element");
+  value = 42u;
+  EZ_TEST_STATUS(accessor.SetValue(pObject, pProp, value, "A"));
+  EZ_TEST_BOOL(getNativeValue()["A"] == value);
+  accessor.FinishTransaction();
+  VerifyChange();
+
+  accessor.StartTransaction("Insert Element");
+  ezVariant value2 = ezVariantArray();
+  EZ_TEST_STATUS(accessor.InsertValue(pObject, pProp, value2, "B"));
+  EZ_TEST_BOOL(getNativeValue()["A"] == value);
+  EZ_TEST_BOOL(getNativeValue()["B"] == value2);
+  accessor.FinishTransaction();
+  VerifyChange();
+
+  accessor.StartTransaction("Remove Element");
+  EZ_TEST_STATUS(accessor.RemoveValue(pObject, pProp, "A"));
+  EZ_TEST_BOOL(getNativeValue()["B"] == value2);
+  EZ_TEST_STATUS(accessor.GetCount(pObject, pProp, iCount));
+  EZ_TEST_INT(iCount, 1);
+  accessor.FinishTransaction();
+  VerifyChange();
+}
+
+EZ_CREATE_SIMPLE_TEST(DocumentObject, VariantPropertyTest)
+{
+  EZ_SCOPE_EXIT(s_Changes.Clear(); s_Changes.Compact(););
+  ezTestDocument doc("Test", true);
+  doc.InitializeAfterLoading(false);
+  ezObjectAccessorBase* pAccessor = doc.GetObjectAccessor();
+  const ezDocumentObject* pObject = nullptr;
+  const ezVariantTestStruct* pNative = nullptr;
+  doc.GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&TestPropertyEventHandler));
+  EZ_SCOPE_EXIT(doc.GetObjectManager()->m_PropertyEvents.RemoveEventHandler(ezMakeDelegate(&TestPropertyEventHandler)));
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "CreateObject")
+  {
+    ezUuid objGuid;
+    pAccessor->StartTransaction("Add Object");
+    EZ_TEST_STATUS(pAccessor->AddObject(nullptr, (const ezAbstractProperty*)nullptr, -1, ezGetStaticRTTI<ezVariantTestStruct>(), objGuid));
+    pAccessor->FinishTransaction();
+    pObject = pAccessor->GetObject(objGuid);
+    pNative = static_cast<ezVariantTestStruct*>(doc.m_ObjectMirror.GetNativeObjectPointer(pObject));
+  }
+
+  const ezAbstractProperty* pProp = pObject->GetType()->FindPropertyByName("Variant");
+  const ezAbstractProperty* pPropArray = pObject->GetType()->FindPropertyByName("VariantArray");
+  const ezAbstractProperty* pPropDict = pObject->GetType()->FindPropertyByName("VariantDictionary");
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "TestVariant")
+  {
+    pAccessor->StartTransaction("Set as Array");
+    EZ_TEST_STATUS(pAccessor->SetValue(pObject, pProp, ezVariantArray()));
+    pAccessor->FinishTransaction();
+    s_Changes.Clear();
+
+    ezVariantSubAccessor accessor(pAccessor, pProp);
+    ezMap<const ezDocumentObject*, ezVariant> subItemMap;
+    subItemMap.Insert(pObject, ezVariant());
+    accessor.SetSubItems(subItemMap);
+    TestArray(accessor, pObject, pProp, [&](){return pNative->m_Variant;});
+    // What remains is an ezVariantDictionary at index 0 that we can recurse into.
+    {
+      ezVariantSubAccessor accessor2(&accessor, pProp);
+      ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
+      subItemMap2.Insert(pObject, 0);
+      accessor2.SetSubItems(subItemMap2);
+      TestDictionary(accessor2, pObject, pProp, [&](){return pNative->m_Variant[0];});
+    }
+    pAccessor->StartTransaction("Set as Dict");
+    EZ_TEST_STATUS(pAccessor->SetValue(pObject, pProp, ezVariantDictionary()));
+    pAccessor->FinishTransaction();
+    s_Changes.Clear();
+    TestDictionary(accessor, pObject, pProp, [&](){return pNative->m_Variant;});
+    // What remains is an ezVariantArray at index "B" that we can recurse into.
+    {
+      ezVariantSubAccessor accessor2(&accessor, pProp);
+      ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
+      subItemMap2.Insert(pObject, "B");
+      accessor2.SetSubItems(subItemMap2);
+      TestArray(accessor2, pObject, pProp, [&](){return pNative->m_Variant["B"];});
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "TestVariantArray")
+  {
+    pAccessor->StartTransaction("Insert Array");
+    EZ_TEST_STATUS(pAccessor->InsertValue(pObject, pPropArray, ezVariantArray(), 0));
+    pAccessor->FinishTransaction();
+
+    ezVariantSubAccessor accessor(pAccessor, pPropArray);
+    ezMap<const ezDocumentObject*, ezVariant> subItemMap;
+    subItemMap.Insert(pObject, 0);
+    accessor.SetSubItems(subItemMap);
+    TestArray(accessor, pObject, pPropArray, [&](){return pNative->m_VariantArray[0];});
+    // What remains is an ezVariantDictionary at index 0 that we can recurse into.
+    {
+      ezVariantSubAccessor accessor2(&accessor, pPropArray);
+      ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
+      subItemMap2.Insert(pObject, 0);
+      accessor2.SetSubItems(subItemMap2);
+      TestDictionary(accessor2, pObject, pPropArray, [&](){return pNative->m_VariantArray[0][0];});
+    }
+    pAccessor->StartTransaction("Insert Dictionary");
+    EZ_TEST_STATUS(pAccessor->InsertValue(pObject, pPropArray, ezVariantDictionary(), 1));
+    pAccessor->FinishTransaction();
+    s_Changes.Clear();
+    subItemMap.Insert(pObject, 1);
+    accessor.SetSubItems(subItemMap);
+    TestDictionary(accessor, pObject, pPropArray, [&](){return pNative->m_VariantArray[1];});
+    // What remains is an ezVariantArray at index "B" that we can recurse into.
+    {
+      ezVariantSubAccessor accessor2(&accessor, pPropArray);
+      ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
+      subItemMap2.Insert(pObject, "B");
+      accessor2.SetSubItems(subItemMap2);
+      TestArray(accessor2, pObject, pPropArray, [&](){return pNative->m_VariantArray[1]["B"];});
+    }
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "TestVariantDictionary")
+  {
+    pAccessor->StartTransaction("Insert Array");
+    EZ_TEST_STATUS(pAccessor->InsertValue(pObject, pPropDict, ezVariantArray(), "AAA"));
+    pAccessor->FinishTransaction();
+
+    ezVariantSubAccessor accessor(pAccessor, pPropDict);
+    ezMap<const ezDocumentObject*, ezVariant> subItemMap;
+    subItemMap.Insert(pObject, "AAA");
+    accessor.SetSubItems(subItemMap);
+    TestArray(accessor, pObject, pPropDict, [&](){return *pNative->m_VariantDictionary.GetValue("AAA");});
+    // What remains is an ezVariantDictionary at index 0 that we can recurse into.
+    {
+      ezVariantSubAccessor accessor2(&accessor, pPropDict);
+      ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
+      subItemMap2.Insert(pObject, 0);
+      accessor2.SetSubItems(subItemMap2);
+      TestDictionary(accessor2, pObject, pPropDict, [&](){return (*pNative->m_VariantDictionary.GetValue("AAA"))[0];});
+    }
+    pAccessor->StartTransaction("Insert Dictionary");
+    EZ_TEST_STATUS(pAccessor->InsertValue(pObject, pPropDict, ezVariantDictionary(), "BBB"));
+    pAccessor->FinishTransaction();
+    s_Changes.Clear();
+    subItemMap.Insert(pObject, "BBB");
+    accessor.SetSubItems(subItemMap);
+    TestDictionary(accessor, pObject, pPropDict, [&](){return *pNative->m_VariantDictionary.GetValue("BBB");});
+    // What remains is an ezVariantArray at index "B" that we can recurse into.
+    {
+      ezVariantSubAccessor accessor2(&accessor, pPropDict);
+      ezMap<const ezDocumentObject*, ezVariant> subItemMap2;
+      subItemMap2.Insert(pObject, "B");
+      accessor2.SetSubItems(subItemMap2);
+      TestArray(accessor2, pObject, pPropDict, [&](){return (*pNative->m_VariantDictionary.GetValue("BBB"))["B"];});
+    }
+  }
+}

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.cpp
@@ -4,6 +4,18 @@
 #include <ToolsFoundationTest/Reflection/ReflectionTestClasses.h>
 
 // clang-format off
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezVariantTestStruct, ezNoBase, 1, ezRTTIDefaultAllocator<ezVariantTestStruct>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Variant", m_Variant),
+    EZ_ARRAY_MEMBER_PROPERTY("VariantArray", m_VariantArray),
+    EZ_MAP_MEMBER_PROPERTY("VariantDictionary", m_VariantDictionary)
+  }
+  EZ_END_PROPERTIES;
+}
+EZ_END_STATIC_REFLECTED_TYPE;
+
 EZ_BEGIN_STATIC_REFLECTED_TYPE(ezIntegerStruct, ezNoBase, 1, ezRTTIDefaultAllocator<ezIntegerStruct>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.h
+++ b/Code/UnitTests/ToolsFoundationTest/Reflection/ReflectionTestClasses.h
@@ -4,6 +4,15 @@
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/VarianceTypes.h>
 
+struct ezVariantTestStruct
+{
+public:
+  ezVariant m_Variant;
+  ezVariantArray m_VariantArray;
+  ezVariantDictionary m_VariantDictionary;
+};
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_NO_LINKAGE, ezVariantTestStruct);
+
 struct ezIntegerStruct
 {
 public:


### PR DESCRIPTION
This change allows arbitrary hierarchies of ezVariant arrays and dictionaries to be constructed in the editor. As in the tooling code, any property is uniquely identified by object, property and index, only one level of hierarchies is supported. To work around this, the ezVariant's hierarchy is explored like this:
1. Whenever the `ezQtVariantPropertyWidget` encounters an `ezVariantType::VariantArray` or `ezVariantType::VariantDictionary` it creates an `ezQtVariantContainerWidget`.
2. The `ezQtVariantContainerWidget` creates an `ezVariantSubAccessor` and wraps the `ezObjectAccessorBase` passed in by the parent widget in it.
3. The `ezVariantSubAccessor` is assigned the selection of the parent widget (object to index map) and uses this to narrow the view for each object into the part of the ezVariant referenced by the index. The `ezVariantSubAccessor` now pretends this is the root of the ezVariant containing an array or dictionary. Any write operations consists of reading from the wrapped accessor the parent value container, modifying it and then writing the entire container back via the setter from the wrapped accessor. Due to this, and change always ripples up the chain and modifies the root property ezVariant as a whole so the tooling code only sees property changes to the entire ezVariant.  
4. Each time another container is found in the ezVariant hierarchy the process repeats and so `ezObjectAccessorBase` is wrapped again and again the narrow the view into the ezVariant further and further.

<img width="535" height="806" alt="image" src="https://github.com/user-attachments/assets/815ef481-9d4a-4b02-b32b-14b31231d1c1" />


## Implementation Details
* `ezObjectAccessorBase` is now reflected to allow code like default state providers to reason about the level of depths we have drilled down into an ezVariant's hierarchy.
* `ezQtAddSubElementButton` now has a new ctor argument `containerCategory` as the type of container is no longer static per property as an ezVariant can hold both arrays and maps. For the same reason, `ezQtPropertyContainerWidget` now has a virtual function `GetContainerCategory` which defaults to the property category type.
* `ezVariantStorageAccessor` added which contains various helper functions to work on an ezVariant as if it was an array or dictionary. The code was extracted from `ezReflectedTypeStorageAccessor` which already had to do these tasks to manage object storage.
* `ezVariantSubDefaultStateProvider` added to manage the default state inside an ezVariant. It is only created if the accessor is an `ezVariantSubAccessor`. The provider has an arbitrary depth of 1000 so it is always chosen first. The logic it executes is as follows:
  1. Get the value of the sub-tree element from the `ezVariantSubAccessor`.
  2. Compute the path from the root of the ezVariant to the current `ezVariantSubAccessor` sub-tree element.
  2. Get the default value of the property from the root of the ezVariant from the next default value provider in line.
  3. Follow the path from step 2 into the default value retrieved at root level.
  4. Compare both the sub-tree view for equality.