### PR TITLE
Trivial fix for #1624

### DIFF
--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -1348,9 +1348,6 @@ void ezWorld::ProcessUpdateFunctionsToDeregister()
 {
   CheckForWriteAccess();
 
-  if (m_Data.m_UpdateFunctionsToDeregister.IsEmpty())
-    return;
-
   for (const ezWorldModule::UpdateFunctionDesc& updateFunction : m_Data.m_UpdateFunctionsToDeregister)
   {
     DeregisterUpdateFunctionInternal(updateFunction);

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -512,6 +512,7 @@ void ezWorld::Update()
   {
     EZ_PROFILE_SCOPE("Initialize Phase");
     ProcessComponentsToInitialize();
+    ProcessUpdateFunctionsToDeregister();
     ProcessUpdateFunctionsToRegister();
 
     ProcessQueuedMessages(ezObjectMsgQueueType::AfterInitialized);
@@ -548,7 +549,6 @@ void ezWorld::Update()
     EZ_PROFILE_SCOPE("Delete Dead Objects");
     DeleteDeadObjects();
     DeleteDeadComponents();
-    ProcessUpdateFunctionsToDeregister();
   }
 
   // update transforms

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -548,6 +548,7 @@ void ezWorld::Update()
     EZ_PROFILE_SCOPE("Delete Dead Objects");
     DeleteDeadObjects();
     DeleteDeadComponents();
+    ProcessUpdateFunctionsToDeregister();
   }
 
   // update transforms
@@ -624,7 +625,7 @@ void ezWorld::DeleteModule(const ezRTTI* pRtti)
       m_Data.m_Modules[uiTypeId] = nullptr;
 
       pModule->Deinitialize();
-      DeregisterUpdateFunctions(pModule);
+      DeregisterUpdateFunctionsInternal(pModule);
       EZ_DELETE(&m_Data.m_Allocator, pModule);
     }
   }
@@ -1055,33 +1056,7 @@ void ezWorld::DeregisterUpdateFunction(const ezComponentManagerBase::UpdateFunct
 {
   CheckForWriteAccess();
 
-  ezDynamicArrayBase<ezInternal::WorldData::RegisteredUpdateFunction>& updateFunctions = m_Data.m_UpdateFunctions[desc.m_Phase.GetValue()];
-
-  for (ezUInt32 i = updateFunctions.GetCount(); i-- > 0;)
-  {
-    if (updateFunctions[i].m_Function.IsEqualIfComparable(desc.m_Function))
-    {
-      updateFunctions.RemoveAtAndCopy(i);
-    }
-  }
-}
-
-void ezWorld::DeregisterUpdateFunctions(ezWorldModule* pModule)
-{
-  CheckForWriteAccess();
-
-  for (ezUInt32 phase = ezWorldUpdatePhase::PreAsync; phase < ezWorldUpdatePhase::COUNT; ++phase)
-  {
-    ezDynamicArrayBase<ezInternal::WorldData::RegisteredUpdateFunction>& updateFunctions = m_Data.m_UpdateFunctions[phase];
-
-    for (ezUInt32 i = updateFunctions.GetCount(); i-- > 0;)
-    {
-      if (updateFunctions[i].m_Function.GetClassInstance() == pModule)
-      {
-        updateFunctions.RemoveAtAndCopy(i);
-      }
-    }
-  }
+  m_Data.m_UpdateFunctionsToDeregister.PushBack(desc);
 }
 
 void ezWorld::AddComponentToInitialize(ezComponentHandle hComponent)
@@ -1367,6 +1342,52 @@ ezResult ezWorld::RegisterUpdateFunctionInternal(const ezWorldModule::UpdateFunc
   updateFunctions.InsertAt(uiInsertionIndex, newFunction);
 
   return EZ_SUCCESS;
+}
+
+void ezWorld::ProcessUpdateFunctionsToDeregister()
+{
+  CheckForWriteAccess();
+
+  if (m_Data.m_UpdateFunctionsToDeregister.IsEmpty())
+    return;
+
+  for (const ezWorldModule::UpdateFunctionDesc& updateFunction : m_Data.m_UpdateFunctionsToDeregister)
+  {
+    DeregisterUpdateFunctionInternal(updateFunction);
+  }
+
+  m_Data.m_UpdateFunctionsToDeregister.Clear();
+}
+
+void ezWorld::DeregisterUpdateFunctionInternal(const ezWorldModule::UpdateFunctionDesc& desc)
+{
+  ezDynamicArrayBase<ezInternal::WorldData::RegisteredUpdateFunction>& updateFunctions = m_Data.m_UpdateFunctions[desc.m_Phase.GetValue()];
+
+  for (ezUInt32 i = updateFunctions.GetCount(); i-- > 0;)
+  {
+    if (updateFunctions[i].m_Function.IsEqualIfComparable(desc.m_Function))
+    {
+      updateFunctions.RemoveAtAndCopy(i);
+    }
+  }
+}
+
+void ezWorld::DeregisterUpdateFunctionsInternal(ezWorldModule* pModule)
+{
+  CheckForWriteAccess();
+
+  for (ezUInt32 phase = ezWorldUpdatePhase::PreAsync; phase < ezWorldUpdatePhase::COUNT; ++phase)
+  {
+    ezDynamicArrayBase<ezInternal::WorldData::RegisteredUpdateFunction>& updateFunctions = m_Data.m_UpdateFunctions[phase];
+
+    for (ezUInt32 i = updateFunctions.GetCount(); i-- > 0;)
+    {
+      if (updateFunctions[i].m_Function.GetClassInstance() == pModule)
+      {
+        updateFunctions.RemoveAtAndCopy(i);
+      }
+    }
+  }
 }
 
 void ezWorld::DeleteDeadObjects()

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -197,6 +197,7 @@ namespace ezInternal
 
     ezDynamicArray<RegisteredUpdateFunction, ezLocalAllocatorWrapper> m_UpdateFunctions[ezWorldUpdatePhase::COUNT];
     ezDynamicArray<ezWorldModule::UpdateFunctionDesc, ezLocalAllocatorWrapper> m_UpdateFunctionsToRegister;
+    ezDynamicArray<ezWorldModule::UpdateFunctionDesc, ezLocalAllocatorWrapper> m_UpdateFunctionsToDeregister;
 
     ezDynamicArray<ezSharedPtr<UpdateTask>, ezLocalAllocatorWrapper> m_UpdateTasks;
 

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -192,7 +192,7 @@ void ezWorld::DeleteComponentManager()
       m_Data.m_Modules[uiTypeId] = nullptr;
 
       static_cast<ezWorldModule*>(pModule)->Deinitialize();
-      DeregisterUpdateFunctions(pModule);
+      DeregisterUpdateFunctionsInternal(pModule);
       EZ_DELETE(&m_Data.m_Allocator, pModule);
     }
   }

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -428,7 +428,6 @@ private:
 
   void RegisterUpdateFunction(const ezWorldModule::UpdateFunctionDesc& desc);
   void DeregisterUpdateFunction(const ezWorldModule::UpdateFunctionDesc& desc);
-  void DeregisterUpdateFunctions(ezWorldModule* pModule);
 
   /// \brief Used by component managers to queue a new component for initialization during the next update
   void AddComponentToInitialize(ezComponentHandle hComponent);
@@ -442,6 +441,9 @@ private:
   void ProcessComponentsToInitialize();
   void ProcessUpdateFunctionsToRegister();
   ezResult RegisterUpdateFunctionInternal(const ezWorldModule::UpdateFunctionDesc& desc);
+  void ProcessUpdateFunctionsToDeregister();
+  void DeregisterUpdateFunctionInternal(const ezWorldModule::UpdateFunctionDesc& desc);
+  void DeregisterUpdateFunctionsInternal(ezWorldModule* pModule);
 
   void DeleteDeadObjects();
   void DeleteDeadComponents();


### PR DESCRIPTION
Here is a trivial solution for #1624. 

But there is one consideration I would like to highlight: 
Most importantly it doesn't take dependencies (`UpdateFunctionDesc::m_DependsOn`) into account  before deletion. Perhaps a better approach is to mark all the deletion methods for internal usage only.

Current changes:

1. Added `WorldData::m_UpdateFunctionsToDeregister` to store update functions marked for deletion
2. `WorldData::DeregisterUpdateFunction` is renamed to `DeregisterUpdateFunctionInternal`
3. `WorldData::DeregisterUpdateFunctions` is renamed to `DeregisterUpdateFunctionsInternal` for constistency
4. Now `WorldData::DeregisterUpdateFunction` appends functiond description to  `WorldData::m_UpdateFunctionsToDeregister` array
5. All marked for deletion update functions are deleted by `ezWorld::ProcessUpdateFunctionsToDeregister` by the end of `ezWorld::Update()`