### PR TITLE
Visualize exposed parameters as phantom types in the GUI

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -249,7 +249,7 @@ void ezAssetDocument::AddReferences(const ezDocumentObject* pObject, ezAssetDocu
             {
               ezHybridArray<ezPropertySelection, 1> selection;
               selection.PushBack({pObject, ezVariant()});
-              ezDefaultObjectState defaultState(GetObjectAccessor(), selection.GetArrayPtr());
+              ezDefaultObjectState defaultState(pType, GetObjectAccessor(), selection.GetArrayPtr());
               if (defaultState.GetStateProviderName() == "Prefab" && defaultState.IsDefaultValue(pProp))
                 continue;
             }
@@ -279,7 +279,7 @@ void ezAssetDocument::AddReferences(const ezDocumentObject* pObject, ezAssetDocu
             {
               ezHybridArray<ezPropertySelection, 1> selection;
               selection.PushBack({pObject, ezVariant()});
-              ezDefaultContainerState defaultState(GetObjectAccessor(), selection.GetArrayPtr(), pProp->GetPropertyName());
+              ezDefaultContainerState defaultState(pType, GetObjectAccessor(), selection.GetArrayPtr(), pProp->GetPropertyName());
               for (ezInt32 i = 0; i < iCount; ++i)
               {
                 ezVariant value = pObject->GetTypeAccessor().GetValue(pProp->GetPropertyName(), i);
@@ -327,7 +327,7 @@ void ezAssetDocument::AddReferences(const ezDocumentObject* pObject, ezAssetDocu
             {
               ezHybridArray<ezPropertySelection, 1> selection;
               selection.PushBack({pObject, ezVariant()});
-              ezDefaultContainerState defaultState(GetObjectAccessor(), selection.GetArrayPtr(), pProp->GetPropertyName());
+              ezDefaultContainerState defaultState(pType, GetObjectAccessor(), selection.GetArrayPtr(), pProp->GetPropertyName());
               for (auto it : varDict)
               {
                 if (defaultState.GetStateProviderName() == "Prefab" && defaultState.IsDefaultElement(it.Key()))

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -87,6 +87,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
 
   ON_CORESYSTEMS_STARTUP
   {
+    ezDefaultState::RegisterDefaultStateProvider(ezExposedParametersAsTypeDefaultStateProvider::CreateProvider);
     ezDefaultState::RegisterDefaultStateProvider(ezExposedParametersDefaultStateProvider::CreateProvider);
     ezDefaultState::RegisterDefaultStateProvider(ezDynamicDefaultStateProvider::CreateProvider);
     ezProjectActions::RegisterActions();
@@ -178,6 +179,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
 
   ON_CORESYSTEMS_SHUTDOWN
   {
+    ezDefaultState::UnregisterDefaultStateProvider(ezExposedParametersAsTypeDefaultStateProvider::CreateProvider);
     ezDefaultState::UnregisterDefaultStateProvider(ezExposedParametersDefaultStateProvider::CreateProvider);
     ezDefaultState::UnregisterDefaultStateProvider(ezDynamicDefaultStateProvider::CreateProvider);
     ezProjectActions::UnregisterActions();

--- a/Code/Editor/EditorFramework/GUI/ExposedParameters.h
+++ b/Code/Editor/EditorFramework/GUI/ExposedParameters.h
@@ -11,6 +11,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezExposedParameter
   ezString m_sName;
   ezString m_sType;
   ezVariant m_DefaultValue;
+  ezEnum<ezPropertyCategory> m_Category;
   ezHybridArray<ezPropertyAttribute*, 2> m_Attributes;
 };
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_EDITORFRAMEWORK_DLL, ezExposedParameter)

--- a/Code/Editor/EditorFramework/GUI/ExposedParametersDefaultStateProvider.h
+++ b/Code/Editor/EditorFramework/GUI/ExposedParametersDefaultStateProvider.h
@@ -6,6 +6,7 @@
 
 class ezExposedParametersAttribute;
 class ezExposedParameterCommandAccessor;
+class ezExposedParametersAsTypeCommandAccessor;
 
 /// \brief Default state provider handling variant maps with the ezExposedParametersAttribute set. Reflects the default value defined in the ezExposedParameter.
 class EZ_EDITORFRAMEWORK_DLL ezExposedParametersDefaultStateProvider : public ezDefaultStateProvider
@@ -24,9 +25,31 @@ public:
   virtual bool IsDefaultValue(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
   virtual ezStatus RevertProperty(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
 
-private:
+protected:
   const ezDocumentObject* m_pObject = nullptr;
   const ezAbstractProperty* m_pProp = nullptr;
   const ezExposedParametersAttribute* m_pAttrib = nullptr;
   const ezAbstractProperty* m_pParameterSourceProp = nullptr;
+};
+
+/// \brief Default state provider handling variant maps with the ezExposedParametersAttribute set that are visualized as their respective phantom type.
+/// This class builds on top of ezExposedParametersDefaultStateProvider and only adds the logic to redirect the phantom type + phantom property requested into the actual underlying variant map of the exposed parameters.
+/// The provider is only valid if the target accessor is of type ezExposedParametersAsTypeCommandAccessor.
+class EZ_EDITORFRAMEWORK_DLL ezExposedParametersAsTypeDefaultStateProvider : public ezExposedParametersDefaultStateProvider
+{
+public:
+  static ezSharedPtr<ezDefaultStateProvider> CreateProvider(ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp);
+
+  ezExposedParametersAsTypeDefaultStateProvider(ezExposedParametersAsTypeCommandAccessor* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp);
+
+  virtual ezVariant GetDefaultValue(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+  virtual ezStatus CreateRevertContainerDiff(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDeque<ezAbstractGraphDiffOperation>& out_diff) override;
+  virtual bool IsDefaultValue(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+  virtual ezStatus RevertProperty(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+
+private:
+  ezResult GetDefaultValueInternal(SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index, ezVariant& out_DefaultValue);
+
+private:
+  ezExposedParametersAsTypeCommandAccessor* m_pAccessor = nullptr;
 };

--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParameters.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParameters.cpp
@@ -3,13 +3,14 @@
 #include <EditorFramework/GUI/ExposedParameters.h>
 
 // clang-format off
-EZ_BEGIN_STATIC_REFLECTED_TYPE(ezExposedParameter, ezNoBase, 2, ezRTTIDefaultAllocator<ezExposedParameter>)
+EZ_BEGIN_STATIC_REFLECTED_TYPE(ezExposedParameter, ezNoBase, 3, ezRTTIDefaultAllocator<ezExposedParameter>)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("Name", m_sName),
     EZ_MEMBER_PROPERTY("Type", m_sType),
     EZ_MEMBER_PROPERTY("DefaultValue", m_DefaultValue),
+    EZ_ENUM_MEMBER_PROPERTY("Category", ezPropertyCategory, m_Category)->AddAttributes(new ezDefaultValueAttribute(ezPropertyCategory::Member)),
     EZ_ARRAY_MEMBER_PROPERTY("Attributes", m_Attributes)->AddFlags(ezPropertyFlags::PointerOwner),
   }
   EZ_END_PROPERTIES;

--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersTypeRegistry.cpp
@@ -112,8 +112,10 @@ void ezExposedParametersTypeRegistry::UpdateExposedParametersType(ParamData& dat
         pType = pType2;
     }
     if (pType == nullptr)
+    {
+      ezLog::Warning("The exposed parameter '{}' on type '{}' does not have a type defined as is skipped.", parameter->m_sName, name);
       continue;
-
+    }
     ezBitflags<ezPropertyFlags> flags = ezPropertyFlags::Phantom;
     if (pType->IsDerivedFrom<ezEnumBase>())
       flags |= ezPropertyFlags::IsEnum;
@@ -124,10 +126,14 @@ void ezExposedParametersTypeRegistry::UpdateExposedParametersType(ParamData& dat
     else
       flags |= ezPropertyFlags::Class;
 
-    ezReflectedPropertyDescriptor propDesc(ezPropertyCategory::Member, parameter->m_sName, pType->GetTypeName(), flags);
+    ezReflectedPropertyDescriptor propDesc(parameter->m_Category, parameter->m_sName, pType->GetTypeName(), flags);
     for (auto attrib : parameter->m_Attributes)
     {
       propDesc.m_Attributes.PushBack(ezReflectionSerializer::Clone(attrib));
+    }
+    if (parameter->m_DefaultValue.IsValid())
+    {
+      propDesc.m_Attributes.PushBack(EZ_DEFAULT_NEW(ezDefaultValueAttribute, parameter->m_DefaultValue));
     }
     desc.m_Properties.PushBack(propDesc);
   }

--- a/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
@@ -43,9 +43,10 @@ public:
 class EZ_EDITORFRAMEWORK_DLL ezExposedParametersAsTypeCommandAccessor : public ezObjectProxyAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezExposedParametersAsTypeCommandAccessor, ezObjectProxyAccessor);
+
 public:
   ezExposedParametersAsTypeCommandAccessor(ezExposedParameterCommandAccessor* pSource);
-  ezExposedParameterCommandAccessor* GetSourceAccessor() const { return static_cast<ezExposedParameterCommandAccessor*>(m_pSource);}
+  ezExposedParameterCommandAccessor* GetSourceAccessor() const { return static_cast<ezExposedParameterCommandAccessor*>(m_pSource); }
 
   virtual ezStatus GetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value, ezVariant index = ezVariant()) override;
   virtual ezStatus SetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index = ezVariant()) override;

--- a/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
+++ b/Code/Editor/EditorFramework/PropertyGrid/ExposedParametersPropertyWidget.moc.h
@@ -8,7 +8,10 @@
 
 class QToolButton;
 class QAction;
+struct ezPhantomRttiManagerEvent;
 
+/// \brief Helper accessor to pretend all exposed parameters always have a value defined.
+/// The exposed parameters are stored as just a sparse map. Only the elements that are overwritten from their defaults are actually stored in the component. Thus, requesting the value of an exposed parameter that has not been overwritten results in failure. To fix this, this class will automatically return the default value of an exposed parameter. This allows the tooling code to always show every exposed parameter's value independent on whether it was overwritten or remains at the default value.
 class EZ_EDITORFRAMEWORK_DLL ezExposedParameterCommandAccessor : public ezObjectProxyAccessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezExposedParameterCommandAccessor, ezObjectProxyAccessor);
@@ -35,14 +38,34 @@ public:
   const ezAbstractProperty* m_pParameterSourceProp = nullptr;
 };
 
-class EZ_EDITORFRAMEWORK_DLL ezQtExposedParameterPropertyWidget : public ezQtVariantPropertyWidget
+/// \brief Accessor to pretend the exposed parameters map property is an object of the generated phantom type.
+/// This fake type accessor is created by taking the property name and redirecting to the exposed parameter map's element under that name. As long as no code path is looking at the actual type of the object this works with any property widget. An ezQtTypeWidget constructed with the exposed parameter type and this accessor will produce a normal type widget that looks like the exposed parameter type but redirects all read / writes into the exposed parameter map property. Additionally, this class ensures the value stored in the map is converted to match the property type exactly.
+class EZ_EDITORFRAMEWORK_DLL ezExposedParametersAsTypeCommandAccessor : public ezObjectProxyAccessor
 {
-  Q_OBJECT;
+  EZ_ADD_DYNAMIC_REFLECTION(ezExposedParametersAsTypeCommandAccessor, ezObjectProxyAccessor);
+public:
+  ezExposedParametersAsTypeCommandAccessor(ezExposedParameterCommandAccessor* pSource);
+  ezExposedParameterCommandAccessor* GetSourceAccessor() const { return static_cast<ezExposedParameterCommandAccessor*>(m_pSource);}
+
+  virtual ezStatus GetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value, ezVariant index = ezVariant()) override;
+  virtual ezStatus SetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index = ezVariant()) override;
+  virtual ezStatus InsertValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index = ezVariant()) override;
+  virtual ezStatus RemoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index = ezVariant()) override;
+  virtual ezStatus MoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& oldIndex, const ezVariant& newIndex) override;
+  virtual ezStatus GetCount(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezInt32& out_iCount) override;
+  virtual ezStatus GetKeys(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_keys) override;
+  virtual ezStatus GetValues(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_values) override;
 
 protected:
-  virtual void InternalSetValue(const ezVariant& value);
+  ezStatus GetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value);
+  ezStatus SetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezStatus(ezVariant& subValue)>& func);
+
+  /// \brief Make sure that any property retrieved via this accessor matches the expected property type to make sure no invalid data is passed into one of the property widgets generated under the type widget.
+  void PatchPropertyType(ezVariant& ref_value, const ezAbstractProperty* pProp);
 };
 
+/// \brief Custom widget for properties annotated with the ezExposedParametersAttribute attribute.
+/// Technically exposed parameters are stored as an ezVariantDictionary but that leaves much to be desired for usability. This class uses ezExposedParameterCommandAccessor to always show all exposed parameters in the dictionary even if none were overwritten. Additionally, ezExposedParametersAsTypeCommandAccessor is used to project the exposed parameters into a phantom type widget to make editing exposed parameters indistinguishable from editing a normal type object. A button can be used to switch between the two representations.
 class EZ_EDITORFRAMEWORK_DLL ezQtExposedParametersPropertyWidget : public ezQtPropertyStandardTypeContainerWidget
 {
   Q_OBJECT
@@ -54,27 +77,35 @@ public:
 
 protected:
   virtual void OnInit() override;
-  virtual ezQtPropertyWidget* CreateWidget(ezUInt32 index) override;
   virtual void UpdateElement(ezUInt32 index) override;
   virtual void UpdatePropertyMetaState() override;
+  virtual void GetRequiredElements(ezDynamicArray<ezVariant>& out_keys) const override;
 
 private:
   void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);
   void CommandHistoryEventHandler(const ezCommandHistoryEvent& e);
-  void FlushQueuedChanges();
+  void PhantomTypeRegistryEventHandler(const ezPhantomRttiManagerEvent& e);
+  void FlushOrQueueChanges(bool bNeedsUpdate, bool bNeedsMetaDataUpdate);
   bool RemoveUnusedKeys(bool bTestOnly);
   bool FixKeyTypes(bool bTestOnly);
   void UpdateActionState();
 
 private:
+  static bool s_bRawMode;
+
+private:
   ezUniquePtr<ezExposedParameterCommandAccessor> m_pProxy;
+  ezUniquePtr<ezExposedParametersAsTypeCommandAccessor> m_pTypeProxy;
   ezObjectAccessorBase* m_pSourceObjectAccessor = nullptr;
   ezString m_sExposedParamProperty;
   mutable ezDynamicArray<ezExposedParameter> m_Parameters;
   bool m_bNeedsUpdate = false;
   bool m_bNeedsMetaDataUpdate = false;
 
+  ezQtTypeWidget* m_pTypeWidget = nullptr;
+  QVBoxLayout* m_pTypeViewLayout = nullptr;
   QToolButton* m_pFixMeButton = nullptr;
+  QToolButton* m_pToggleRawModeButton = nullptr;
   QAction* m_pRemoveUnusedAction = nullptr;
   QAction* m_pFixTypesAction = nullptr;
 };

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
@@ -465,7 +465,7 @@ void ezQtExposedParametersPropertyWidget::OnInit()
   m_pProxy = EZ_DEFAULT_NEW(ezExposedParameterCommandAccessor, m_pSourceObjectAccessor, m_pProp, pParameterSourceProp);
   m_pTypeProxy = EZ_DEFAULT_NEW(ezExposedParametersAsTypeCommandAccessor, m_pProxy.Borrow());
   // Overwriting this will display the exposed parameter map as before, i.e. each property will be shown in the map even if not present. As this is now obsolete given the phantom type widget, this is probably no longer needed?
-  //m_pObjectAccessor = m_pProxy.Borrow();
+  // m_pObjectAccessor = m_pProxy.Borrow();
 
   ezQtPropertyStandardTypeContainerWidget::OnInit();
 
@@ -509,11 +509,11 @@ void ezQtExposedParametersPropertyWidget::OnInit()
     m_pToggleRawModeButton->setSizePolicy(sp);
     m_pToggleRawModeButton->setToolTip("Toggle between Type or RAW dictionary view");
 
-    connect(m_pToggleRawModeButton, &QToolButton::toggled, this, [this](bool checked){
+    connect(m_pToggleRawModeButton, &QToolButton::toggled, this, [this](bool checked)
+      {
         s_bRawMode = checked;
         ezQtScopedUpdatesDisabled _(this);
-        SetSelection(m_Items);
-      });
+        SetSelection(m_Items); });
 
     auto layout = qobject_cast<QHBoxLayout*>(m_pGroup->GetHeader()->layout());
     layout->insertWidget(layout->count() - 1, m_pToggleRawModeButton);

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
@@ -6,11 +6,17 @@
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <GuiFoundation/Widgets/GroupBoxBase.moc.h>
+#include <ToolsFoundation/Reflection/VariantStorageAccessor.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezExposedParameterCommandAccessor, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezExposedParametersAsTypeCommandAccessor, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
+
+bool ezQtExposedParametersPropertyWidget::s_bRawMode = false;
 
 ezExposedParameterCommandAccessor::ezExposedParameterCommandAccessor(
   ezObjectAccessorBase* pSource, const ezAbstractProperty* pParameterProp, const ezAbstractProperty* pParameterSourceProp)
@@ -67,7 +73,7 @@ ezStatus ezExposedParameterCommandAccessor::SetValue(
   // so we redirect to insert to make it true.
   if (res.Failed() && m_pParameterProp == pProp && index.IsA<ezString>())
   {
-    return InsertValue(pObject, pProp, newValue, index);
+    return ezExposedParameterCommandAccessor::InsertValue(pObject, pProp, newValue, index);
   }
   return res;
 }
@@ -199,6 +205,7 @@ const ezRTTI* ezExposedParameterCommandAccessor::GetCommonExposedParamsType(cons
     if (bFirst)
     {
       type = GetExposedParamsType(item.m_pObject);
+      bFirst = false;
     }
     else
     {
@@ -225,60 +232,219 @@ bool ezExposedParameterCommandAccessor::IsExposedProperty(const ezDocumentObject
 
 //////////////////////////////////////////////////////////////////////////
 
-void ezQtExposedParameterPropertyWidget::InternalSetValue(const ezVariant& value)
+ezExposedParametersAsTypeCommandAccessor::ezExposedParametersAsTypeCommandAccessor(ezExposedParameterCommandAccessor* pSource)
+  : ezObjectProxyAccessor(pSource)
 {
-  ezVariantType::Enum commonType = ezVariantType::Invalid;
-  GetCommonVariantSubType(m_Items, m_pProp, commonType);
-  const ezRTTI* pNewtSubType = commonType != ezVariantType::Invalid ? ezReflectionUtils::GetTypeFromVariant(commonType) : nullptr;
+}
 
-  ezExposedParameterCommandAccessor* proxy = static_cast<ezExposedParameterCommandAccessor*>(m_pObjectAccessor);
-  if (auto type = proxy->GetCommonExposedParamsType(m_Items))
+ezStatus ezExposedParametersAsTypeCommandAccessor::GetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value, ezVariant index)
+{
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, out_value));
+
+  ezStatus result(EZ_SUCCESS);
+  out_value = ezVariantStorageAccessor(pProp->GetPropertyName(), out_value).GetValue(index, &result);
+  return result;
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::SetValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).SetValue(newValue, index); });
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::InsertValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& newValue, ezVariant index)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).InsertValue(index, newValue); });
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::RemoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).RemoveValue(index); });
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::MoveValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezVariant& oldIndex, const ezVariant& newIndex)
+{
+  return SetSubValue(pObject, pProp, [&](ezVariant& subValue) -> ezStatus
+    { return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).MoveValue(oldIndex, newIndex); });
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::GetCount(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezInt32& out_iCount)
+{
+  ezVariant subValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, subValue));
+  out_iCount = ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).GetCount();
+  return EZ_SUCCESS;
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::GetKeys(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_keys)
+{
+  ezVariant subValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, subValue));
+  return ezVariantStorageAccessor(pProp->GetPropertyName(), subValue).GetKeys(out_keys);
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::GetValues(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezDynamicArray<ezVariant>& out_values)
+{
+  ezVariant subValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, subValue));
+  ezHybridArray<ezVariant, 16> keys;
+  ezVariantStorageAccessor accessor(pProp->GetPropertyName(), subValue);
+  EZ_SUCCEED_OR_RETURN(accessor.GetKeys(keys));
+  out_values.Clear();
+  out_values.Reserve(keys.GetCount());
+  for (const ezVariant& key : keys)
   {
-    if (auto prop = type->FindPropertyByName(m_Items[0].m_Index.Get<ezString>()))
+    out_values.PushBack(accessor.GetValue(key));
+  }
+  return EZ_SUCCESS;
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::GetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value)
+{
+  const ezRTTI* pType = GetSourceAccessor()->GetExposedParamsType(pObject);
+  EZ_ASSERT_DEBUG(pType && pType->FindPropertyByName(pProp->GetPropertyName()) == pProp, "");
+
+  ezStatus result = GetSourceAccessor()->GetValue(pObject, GetSourceAccessor()->m_pParameterProp, out_value, pProp->GetPropertyName());
+  if (result.Failed())
+    return result;
+
+  PatchPropertyType(out_value, pProp);
+
+  return result;
+}
+
+ezStatus ezExposedParametersAsTypeCommandAccessor::SetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, const ezDelegate<ezStatus(ezVariant&)>& func)
+{
+  ezVariant currentValue;
+  EZ_SUCCEED_OR_RETURN(GetSubValue(pObject, pProp, currentValue));
+  EZ_SUCCEED_OR_RETURN(func(currentValue));
+  return GetSourceAccessor()->SetValue(pObject, pProp, currentValue, pProp->GetPropertyName());
+}
+
+void ezExposedParametersAsTypeCommandAccessor::PatchPropertyType(ezVariant& ref_value, const ezAbstractProperty* pProp)
+{
+  const ezVariantType::Enum propType = ezToolsReflectionUtils::GetStorageType(pProp);
+  const ezVariantType::Enum valueType = ref_value.GetType();
+  if (propType != valueType)
+  {
+    if (ref_value.CanConvertTo(propType))
     {
-      auto paramDefault = ezToolsReflectionUtils::GetStorageDefault(prop);
-      if (paramDefault.GetType() == commonType)
-      {
-        if (prop->GetSpecificType() != m_pCurrentSubType || m_pWidget == nullptr)
-        {
-          if (m_pWidget)
-          {
-            m_pWidget->PrepareToDie();
-            m_pWidget->deleteLater();
-            m_pWidget = nullptr;
-          }
-          m_pCurrentSubType = pNewtSubType;
-          m_pWidget = ezQtPropertyGridWidget::CreateMemberPropertyWidget(prop);
-          if (!m_pWidget)
-            m_pWidget = new ezQtUnsupportedPropertyWidget("Unsupported Type");
-
-          m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-          m_pWidget->setParent(this);
-          m_pLayout->addWidget(m_pWidget);
-          m_pWidget->Init(m_pGrid, m_pObjectAccessor, type, prop);
-
-          UpdateTypeListSelection(commonType);
-        }
-        m_pWidget->SetSelection(m_Items);
-        return;
-      }
+      ref_value = ref_value.ConvertTo(propType);
+    }
+    else
+    {
+      ref_value = ezToolsReflectionUtils::GetStorageDefault(pProp);
     }
   }
-  ezQtVariantPropertyWidget::InternalSetValue(value);
+
+  switch (pProp->GetCategory())
+  {
+    case ezPropertyCategory::Array:
+      if (const ezVariantType::Enum propElementType = pProp->GetSpecificType()->GetVariantType(); propElementType != ezVariantType::Invalid)
+      {
+        const ezVariantArray& array = ref_value.Get<ezVariantArray>();
+        for (int i = 0; i < array.GetCount(); ++i)
+        {
+          const ezVariant& element = array[i];
+          const ezVariantType::Enum valueElementType = element.GetType();
+          if (propElementType != valueElementType)
+          {
+            ezVariantArray& arrayWritable = ref_value.GetWritable<ezVariantArray>();
+            ezVariant& elementWritable = arrayWritable[i];
+            if (elementWritable.CanConvertTo(propElementType))
+            {
+              elementWritable = elementWritable.ConvertTo(propType);
+            }
+            else
+            {
+              elementWritable = ezReflectionUtils::GetDefaultVariantFromType(propElementType);
+            }
+          }
+        }
+      }
+      break;
+    case ezPropertyCategory::Map:
+      if (const ezVariantType::Enum propElementType = pProp->GetSpecificType()->GetVariantType(); propElementType != ezVariantType::Invalid)
+      {
+        const ezVariantDictionary& map = ref_value.Get<ezVariantDictionary>();
+        for (auto it : map)
+        {
+          const ezVariant& element = it.Value();
+          const ezVariantType::Enum valueElementType = element.GetType();
+          if (propElementType != valueElementType)
+          {
+            ezVariantDictionary& mapWritable = ref_value.GetWritable<ezVariantDictionary>();
+            ezVariant* pElementWritable = nullptr;
+            mapWritable.TryGetValue(it.Key(), pElementWritable);
+            if (pElementWritable->CanConvertTo(propElementType))
+            {
+              *pElementWritable = pElementWritable->ConvertTo(propType);
+            }
+            else
+            {
+              *pElementWritable = ezReflectionUtils::GetDefaultVariantFromType(propElementType);
+            }
+          }
+        }
+      }
+      break;
+
+    default:
+      break;
+  }
 }
 
 //////////////////////////////////////////////////////////////////////////
 
-ezQtExposedParametersPropertyWidget::ezQtExposedParametersPropertyWidget() = default;
+ezQtExposedParametersPropertyWidget::ezQtExposedParametersPropertyWidget()
+  : ezQtPropertyStandardTypeContainerWidget()
+{
+  // Replace the container layout so we can prepend the type widget before all container elements
+  delete m_pGroupLayout;
+  m_pGroupLayout = new QVBoxLayout(nullptr);
+  m_pGroupLayout->setSpacing(1);
+  m_pGroupLayout->setContentsMargins(5, 0, 0, 0);
+
+  m_pTypeViewLayout = new QVBoxLayout(nullptr);
+  m_pTypeViewLayout->addLayout(m_pGroupLayout);
+  m_pTypeViewLayout->setSpacing(0);
+  m_pTypeViewLayout->setContentsMargins(0, 0, 0, 0);
+
+  m_pGroup->GetContent()->setLayout(m_pTypeViewLayout);
+}
 
 ezQtExposedParametersPropertyWidget::~ezQtExposedParametersPropertyWidget()
 {
   m_pGrid->GetObjectManager()->m_PropertyEvents.RemoveEventHandler(ezMakeDelegate(&ezQtExposedParametersPropertyWidget::PropertyEventHandler, this));
   m_pGrid->GetCommandHistory()->m_Events.RemoveEventHandler(ezMakeDelegate(&ezQtExposedParametersPropertyWidget::CommandHistoryEventHandler, this));
+  ezPhantomRttiManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezQtExposedParametersPropertyWidget::PhantomTypeRegistryEventHandler, this));
 }
 
 void ezQtExposedParametersPropertyWidget::SetSelection(const ezHybridArray<ezPropertySelection, 8>& items)
 {
+  const ezRTTI* pCommonType = m_pProxy->GetCommonExposedParamsType(items);
+  if (m_pTypeWidget && m_pTypeWidget->GetType() != pCommonType)
+  {
+    m_pTypeWidget->PrepareToDie();
+    m_pTypeWidget->deleteLater();
+    m_pTypeWidget = nullptr;
+  }
+
+  if (m_pTypeWidget == nullptr && pCommonType != nullptr)
+  {
+    m_pTypeWidget = new ezQtTypeWidget(m_pGroup->GetContent(), m_pGrid, m_pTypeProxy.Borrow(), pCommonType, nullptr, nullptr);
+    m_pTypeViewLayout->insertWidget(0, m_pTypeWidget);
+  }
+
+  if (m_pTypeWidget)
+  {
+    m_pTypeWidget->setVisible(!s_bRawMode);
+    m_pTypeWidget->SetSelection(items);
+  }
+
+
   ezQtPropertyStandardTypeContainerWidget::SetSelection(items);
   UpdateActionState();
 }
@@ -287,6 +453,7 @@ void ezQtExposedParametersPropertyWidget::OnInit()
 {
   m_pGrid->GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&ezQtExposedParametersPropertyWidget::PropertyEventHandler, this));
   m_pGrid->GetCommandHistory()->m_Events.AddEventHandler(ezMakeDelegate(&ezQtExposedParametersPropertyWidget::CommandHistoryEventHandler, this));
+  ezPhantomRttiManager::s_Events.AddEventHandler(ezMakeDelegate(&ezQtExposedParametersPropertyWidget::PhantomTypeRegistryEventHandler, this));
 
   const auto* pAttrib = m_pProp->GetAttributeByType<ezExposedParametersAttribute>();
   EZ_ASSERT_DEV(pAttrib, "ezQtExposedParametersPropertyWidget was created for a property that does not have the ezExposedParametersAttribute.");
@@ -296,7 +463,9 @@ void ezQtExposedParametersPropertyWidget::OnInit()
     pParameterSourceProp, "The exposed parameter source '{0}' does not exist on type '{1}'", m_sExposedParamProperty, m_pType->GetTypeName());
   m_pSourceObjectAccessor = m_pObjectAccessor;
   m_pProxy = EZ_DEFAULT_NEW(ezExposedParameterCommandAccessor, m_pSourceObjectAccessor, m_pProp, pParameterSourceProp);
-  m_pObjectAccessor = m_pProxy.Borrow();
+  m_pTypeProxy = EZ_DEFAULT_NEW(ezExposedParametersAsTypeCommandAccessor, m_pProxy.Borrow());
+  // Overwriting this will display the exposed parameter map as before, i.e. each property will be shown in the map even if not present. As this is now obsolete given the phantom type widget, this is probably no longer needed?
+  //m_pObjectAccessor = m_pProxy.Borrow();
 
   ezQtPropertyStandardTypeContainerWidget::OnInit();
 
@@ -327,13 +496,29 @@ void ezQtExposedParametersPropertyWidget::OnInit()
     auto layout = qobject_cast<QHBoxLayout*>(m_pGroup->GetHeader()->layout());
     layout->insertWidget(layout->count() - 1, m_pFixMeButton);
   }
-}
 
-ezQtPropertyWidget* ezQtExposedParametersPropertyWidget::CreateWidget(ezUInt32 index)
-{
-  return new ezQtExposedParameterPropertyWidget();
-}
+  {
+    // Button to toggle between type-based view and the raw dictionary-based view of the exposed parameters.
+    m_pToggleRawModeButton = new QToolButton();
+    m_pToggleRawModeButton->setAutoRaise(true);
+    m_pToggleRawModeButton->setCheckable(true);
+    m_pToggleRawModeButton->setChecked(s_bRawMode);
+    m_pToggleRawModeButton->setIcon(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/ExposedParameterViewToggle.svg"));
+    auto sp = m_pToggleRawModeButton->sizePolicy();
+    sp.setVerticalPolicy(QSizePolicy::Ignored);
+    m_pToggleRawModeButton->setSizePolicy(sp);
+    m_pToggleRawModeButton->setToolTip("Toggle between Type or RAW dictionary view");
 
+    connect(m_pToggleRawModeButton, &QToolButton::toggled, this, [this](bool checked){
+        s_bRawMode = checked;
+        ezQtScopedUpdatesDisabled _(this);
+        SetSelection(m_Items);
+      });
+
+    auto layout = qobject_cast<QHBoxLayout*>(m_pGroup->GetHeader()->layout());
+    layout->insertWidget(layout->count() - 1, m_pToggleRawModeButton);
+  }
+}
 
 void ezQtExposedParametersPropertyWidget::UpdateElement(ezUInt32 index)
 {
@@ -343,27 +528,17 @@ void ezQtExposedParametersPropertyWidget::UpdateElement(ezUInt32 index)
 void ezQtExposedParametersPropertyWidget::UpdatePropertyMetaState()
 {
   ezQtPropertyStandardTypeContainerWidget::UpdatePropertyMetaState();
-  return;
+}
 
-  for (ezUInt32 i = 0; i < m_Elements.GetCount(); i++)
+void ezQtExposedParametersPropertyWidget::GetRequiredElements(ezDynamicArray<ezVariant>& out_keys) const
+{
+  if (!s_bRawMode)
   {
-    Element& elem = m_Elements[i];
-    const auto& selection = elem.m_pWidget->GetSelection();
-    bool isDefault = true;
-    for (const auto& item : selection)
-    {
-      ezVariant value;
-      ezStatus res = m_pSourceObjectAccessor->GetValue(item.m_pObject, m_pProp, value, item.m_Index);
-      if (res.Succeeded())
-      {
-        // In case we successfully read the value from the source accessor (not the proxy that pretends all exposed params exist)
-        // we now the value is overwritten as in the default case the map index would not exist.
-        isDefault = false;
-        break;
-      }
-    }
-    elem.m_pWidget->SetIsDefault(isDefault);
-    elem.m_pSubGroup->SetBoldTitle(!isDefault);
+    out_keys.Clear();
+  }
+  else
+  {
+    ezQtPropertyContainerWidget::GetRequiredElements(out_keys);
   }
 }
 
@@ -378,16 +553,11 @@ void ezQtExposedParametersPropertyWidget::PropertyEventHandler(const ezDocumentO
 
   if (!m_bNeedsUpdate && m_sExposedParamProperty == e.m_sProperty)
   {
-    m_bNeedsUpdate = true;
-    // In case the change happened outside the command history we have to update at once.
-    if (!m_pGrid->GetCommandHistory()->IsInTransaction() && !m_pGrid->GetCommandHistory()->IsInUndoRedo())
-      FlushQueuedChanges();
+    FlushOrQueueChanges(true, false);
   }
   if (!m_bNeedsMetaDataUpdate && m_pProp->GetPropertyName() == e.m_sProperty)
   {
-    m_bNeedsMetaDataUpdate = true;
-    if (!m_pGrid->GetCommandHistory()->IsInTransaction() && !m_pGrid->GetCommandHistory()->IsInUndoRedo())
-      FlushQueuedChanges();
+    FlushOrQueueChanges(false, true);
   }
 }
 
@@ -403,7 +573,7 @@ void ezQtExposedParametersPropertyWidget::CommandHistoryEventHandler(const ezCom
     case ezCommandHistoryEvent::Type::TransactionEnded:
     case ezCommandHistoryEvent::Type::TransactionCanceled:
     {
-      FlushQueuedChanges();
+      FlushOrQueueChanges(false, false);
     }
     break;
 
@@ -412,8 +582,29 @@ void ezQtExposedParametersPropertyWidget::CommandHistoryEventHandler(const ezCom
   }
 }
 
-void ezQtExposedParametersPropertyWidget::FlushQueuedChanges()
+void ezQtExposedParametersPropertyWidget::PhantomTypeRegistryEventHandler(const ezPhantomRttiManagerEvent& e)
 {
+  if (const ezRTTI* pCommonType = m_pProxy->GetCommonExposedParamsType(m_Items))
+  {
+    if (e.m_pChangedType->IsDerivedFrom(pCommonType))
+    {
+      // The type widget stores pointer to properties which have been destroyed by the phantom type update so we need to destroy it and recreate it.
+      m_pTypeWidget->PrepareToDie();
+      m_pTypeWidget->deleteLater();
+      m_pTypeWidget = nullptr;
+      FlushOrQueueChanges(true, true);
+    }
+  }
+}
+
+void ezQtExposedParametersPropertyWidget::FlushOrQueueChanges(bool bNeedsUpdate, bool bNeedsMetaDataUpdate)
+{
+  m_bNeedsUpdate |= bNeedsUpdate;
+  m_bNeedsMetaDataUpdate |= bNeedsMetaDataUpdate;
+  // Wait until the transaction is done and this function will be called again inside CommandHistoryEventHandler.
+  if (m_pGrid->GetCommandHistory()->IsInTransaction() || m_pGrid->GetCommandHistory()->IsInUndoRedo())
+    return;
+
   if (m_bNeedsUpdate)
   {
     m_bNeedsUpdate = false;
@@ -421,6 +612,7 @@ void ezQtExposedParametersPropertyWidget::FlushQueuedChanges()
   }
   if (m_bNeedsMetaDataUpdate)
   {
+    // m_bNeedsMetaDataUpdate is reset inside UpdateActionState as it can be called from other places.
     UpdateActionState();
   }
 }
@@ -484,11 +676,11 @@ bool ezQtExposedParametersPropertyWidget::FixKeyTypes(bool bTestOnly)
               ezVariantType::Enum type = pParam->m_DefaultValue.GetType();
               if (value.CanConvertTo(type))
               {
-                m_pObjectAccessor->SetValue(item.m_pObject, m_pProp, value.ConvertTo(type), key).LogFailure();
+                m_pProxy->SetValue(item.m_pObject, m_pProp, value.ConvertTo(type), key).LogFailure();
               }
               else
               {
-                m_pObjectAccessor->SetValue(item.m_pObject, m_pProp, pParam->m_DefaultValue, key).LogFailure();
+                m_pProxy->SetValue(item.m_pObject, m_pProp, pParam->m_DefaultValue, key).LogFailure();
               }
             }
             else

--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/ExposedParametersPropertyWidget.cpp
@@ -345,7 +345,7 @@ void ezExposedParametersAsTypeCommandAccessor::PatchPropertyType(ezVariant& ref_
       if (const ezVariantType::Enum propElementType = pProp->GetSpecificType()->GetVariantType(); propElementType != ezVariantType::Invalid)
       {
         const ezVariantArray& array = ref_value.Get<ezVariantArray>();
-        for (int i = 0; i < array.GetCount(); ++i)
+        for (ezUInt32 i = 0; i < array.GetCount(); ++i)
         {
           const ezVariant& element = array[i];
           const ezVariantType::Enum valueElementType = element.GetType();

--- a/Code/Editor/EditorFramework/QtResources/Icons/ExposedParameterViewToggle.svg
+++ b/Code/Editor/EditorFramework/QtResources/Icons/ExposedParameterViewToggle.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#ffffff">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <g> <path fill="none" d="M0 0H24V24H0z"/> <path d="M10 2c.552 0 1 .448 1 1v4c0 .552-.448 1-1 1H8v2h5V9c0-.552.448-1 1-1h6c.552 0 1 .448 1 1v4c0 .552-.448 1-1 1h-6c-.552 0-1-.448-1-1v-1H8v6h5v-1c0-.552.448-1 1-1h6c.552 0 1 .448 1 1v4c0 .552-.448 1-1 1h-6c-.552 0-1-.448-1-1v-1H7c-.552 0-1-.448-1-1V8H4c-.552 0-1-.448-1-1V3c0-.552.448-1 1-1h6zm9 16h-4v2h4v-2zm0-8h-4v2h4v-2zM9 4H5v2h4V4z"/> </g> </g>
+</svg>

--- a/Code/Editor/EditorFramework/QtResources/resources.qrc
+++ b/Code/Editor/EditorFramework/QtResources/resources.qrc
@@ -39,6 +39,7 @@
     <file>Icons/AssetFailedTransform.svg</file>
     <file>Icons/WindowConfig.svg</file>
     <file>Icons/SwitchToRemoteProcess.svg</file>
+    <file>Icons/ExposedParameterViewToggle.svg</file>
     <file>Icons/Fileserve.svg</file>
     <file>Icons/Inspector.svg</file>
     <file>Icons/Tracy.svg</file>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -957,7 +957,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
 
       ezHybridArray<ezPropertySelection, 1> selection;
       selection.PushBack({pObject, ezVariant()});
-      ezDefaultObjectState defaultState(GetObjectAccessor(), selection.GetArrayPtr());
+      ezDefaultObjectState defaultState(pType, GetObjectAccessor(), selection.GetArrayPtr());
 
       for (auto pProp : properties)
       {

--- a/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/AbstractProperty.h
@@ -89,6 +89,11 @@ struct ezPropertyFlags
     StorageType ReadOnly : 1;
     StorageType Hidden : 1;
     StorageType Phantom : 1;
+
+    StorageType VarOut : 1;
+    StorageType VarInOut : 1;
+
+    StorageType PureFunction : 1;
   };
 
   template <class Type>

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/DefaultState.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/DefaultState.h
@@ -44,9 +44,10 @@ class EZ_GUIFOUNDATION_DLL ezDefaultObjectState
 
 public:
   /// \brief Constructor. Will collect the appropriate ezDefaultStateProviders to query the states.
+  /// \param pType The common base type of the selection.
   /// \param pAccessor Used to revert properties and query their current value.
   /// \param selection For which objects the default state should be queried. The ezPropertySelection::m_Index should be invalid.
-  ezDefaultObjectState(ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection);
+  ezDefaultObjectState(const ezRTTI* pType, ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection);
 
   /// \brief Returns the color of the top-most ezDefaultStateProvider of the first element of the selection.
   ezColorGammaUB GetBackgroundColor() const;
@@ -63,6 +64,7 @@ public:
 
 
 private:
+  const ezRTTI* m_pType = nullptr;
   ezObjectAccessorBase* m_pAccessor = nullptr;
   ezArrayPtr<ezPropertySelection> m_Selection;
   ezHybridArray<ezHybridArray<ezSharedPtr<ezDefaultStateProvider>, 4>, 1> m_Providers;
@@ -77,10 +79,11 @@ class EZ_GUIFOUNDATION_DLL ezDefaultContainerState
 
 public:
   /// \brief Constructor. Will collect the appropriate ezDefaultStateProviders to query the states.
+  /// \param pType The common base type of the selection.
   /// \param pAccessor Used to revert properties and query their current value.
   /// \param selection For which objects the default state should be queried. If ezPropertySelection::m_Index is set, IsDefaultElement and RevertElement will query the value under that index if the passed in index is invalid.
   /// \param szProperty The name of the container for which default states should be queried.
-  ezDefaultContainerState(ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection, const char* szProperty);
+  ezDefaultContainerState(const ezRTTI* pType, ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection, const char* szProperty);
 
   /// \brief Returns the color of the top-most ezDefaultStateProvider of the first element of the selection.
   /// \sa ezDefaultStateProvider::GetBackgroundColor
@@ -97,6 +100,7 @@ public:
   ezVariant GetDefaultContainer(ezUInt32 uiSelectionIndex = 0) const;
 
 private:
+  const ezRTTI* m_pType = nullptr;
   ezObjectAccessorBase* m_pAccessor = nullptr;
   const ezAbstractProperty* m_pProp = nullptr;
   ezArrayPtr<ezPropertySelection> m_Selection;

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/AddSubElementButton.cpp
@@ -239,7 +239,7 @@ void ezQtAddSubElementButton::OnAction(const ezRTTI* pRtti)
 
         ezHybridArray<ezPropertySelection, 1> selection;
         selection.PushBack({m_pObjectAccessor->GetObject(guid), ezVariant()});
-        ezDefaultObjectState defaultState(m_pObjectAccessor, selection);
+        ezDefaultObjectState defaultState(m_pType, m_pObjectAccessor, selection);
         defaultState.RevertObject().AssertSuccess();
       }
     }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/DefaultState.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/DefaultState.cpp
@@ -42,8 +42,9 @@ void ezDefaultState::UnregisterDefaultStateProvider(CreateStateProviderFunc func
 
 //////////////////////////////////////////////////////////////////////////
 
-ezDefaultObjectState::ezDefaultObjectState(ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection)
+ezDefaultObjectState::ezDefaultObjectState(const ezRTTI* pType, ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection)
 {
+  m_pType = pType;
   m_pAccessor = pAccessor;
   m_Selection = selection;
   m_Providers.Reserve(m_Selection.GetCount());
@@ -75,7 +76,7 @@ ezString ezDefaultObjectState::GetStateProviderName() const
 
 bool ezDefaultObjectState::IsDefaultValue(const char* szProperty) const
 {
-  const ezAbstractProperty* pProp = m_Selection[0].m_pObject->GetTypeAccessor().GetType()->FindPropertyByName(szProperty);
+  const ezAbstractProperty* pProp = m_pType->FindPropertyByName(szProperty);
   return IsDefaultValue(pProp);
 }
 
@@ -94,7 +95,7 @@ bool ezDefaultObjectState::IsDefaultValue(const ezAbstractProperty* pProp) const
 
 ezStatus ezDefaultObjectState::RevertProperty(const char* szProperty)
 {
-  const ezAbstractProperty* pProp = m_Selection[0].m_pObject->GetTypeAccessor().GetType()->FindPropertyByName(szProperty);
+  const ezAbstractProperty* pProp = m_pType->FindPropertyByName(szProperty);
   return RevertProperty(pProp);
 }
 
@@ -134,7 +135,7 @@ ezStatus ezDefaultObjectState::RevertObject()
 
 ezVariant ezDefaultObjectState::GetDefaultValue(const char* szProperty, ezUInt32 uiSelectionIndex) const
 {
-  const ezAbstractProperty* pProp = m_Selection[0].m_pObject->GetTypeAccessor().GetType()->FindPropertyByName(szProperty);
+  const ezAbstractProperty* pProp = m_pType->FindPropertyByName(szProperty);
   return GetDefaultValue(pProp, uiSelectionIndex);
 }
 
@@ -147,12 +148,13 @@ ezVariant ezDefaultObjectState::GetDefaultValue(const ezAbstractProperty* pProp,
 
 //////////////////////////////////////////////////////////////////////////
 
-ezDefaultContainerState::ezDefaultContainerState(ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection, const char* szProperty)
+ezDefaultContainerState::ezDefaultContainerState(const ezRTTI* pType, ezObjectAccessorBase* pAccessor, const ezArrayPtr<ezPropertySelection> selection, const char* szProperty)
 {
+  m_pType = pType;
   m_pAccessor = pAccessor;
   m_Selection = selection;
   // We assume selections can only contain objects of the same (base) type.
-  m_pProp = szProperty ? selection[0].m_pObject->GetTypeAccessor().GetType()->FindPropertyByName(szProperty) : nullptr;
+  m_pProp = szProperty ? m_pType->FindPropertyByName(szProperty) : nullptr;
   m_Providers.Reserve(m_Selection.GetCount());
   for (const ezPropertySelection& sel : m_Selection)
   {

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TypeWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TypeWidget.cpp
@@ -410,7 +410,7 @@ void ezQtTypeWidget::UpdatePropertyMetaState()
   ezMap<ezString, ezPropertyUiState> PropertyStates;
   pMeta->GetTypePropertiesState(m_Items, PropertyStates);
 
-  ezDefaultObjectState defaultState(m_pObjectAccessor, m_Items);
+  ezDefaultObjectState defaultState(m_pType, m_pObjectAccessor, m_Items);
 
   ezQtPropertyWidget::SetPaletteBackgroundColor(defaultState.GetBackgroundColor(), m_Pal);
   setPalette(m_Pal);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h
@@ -269,7 +269,7 @@ protected:
   virtual void RemoveElement(ezUInt32 index);
   virtual void UpdateElement(ezUInt32 index) = 0;
   void UpdateElements();
-  virtual ezUInt32 GetRequiredElementCount() const;
+  virtual void GetRequiredElements(ezDynamicArray<ezVariant>& out_keys) const;
   virtual void UpdatePropertyMetaState();
   /// \brief Some containers like ezVariant can be both a map or an array so we can't reply on the property type alone. For these containers, this method can be overwritten to retrieve the category from something other than `m_pProp->GetCategory()`.
   virtual ezPropertyCategory::Enum GetContainerCategory() const;
@@ -297,7 +297,7 @@ protected:
   ezQtAddSubElementButton* m_pAddButton = nullptr;
   QPalette m_Pal;
 
-  mutable ezHybridArray<ezVariant, 16> m_Keys;
+  ezHybridArray<ezVariant, 16> m_Keys;
   ezDynamicArray<Element> m_Elements;
   ezInt32 m_iDropSource = -1;
   ezInt32 m_iDropTarget = -1;

--- a/Code/Tools/Libs/ToolsFoundation/Object/Implementation/VariantSubAccessor.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Object/Implementation/VariantSubAccessor.cpp
@@ -109,7 +109,6 @@ ezStatus ezVariantSubAccessor::GetValues(const ezDocumentObject* pObject, const 
 
 ezStatus ezVariantSubAccessor::GetSubValue(const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant& out_value)
 {
-  // EZ_ASSERT_DEBUG(m_pProp == pProp, "ezVariantSubAccessor should only be used to access a single variant property");
   ezStatus result = ezObjectProxyAccessor::GetValue(pObject, pProp, out_value);
   if (result.Failed())
     return result;

--- a/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/SceneDocument/SceneDocumentTest.cpp
@@ -367,7 +367,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       // Check that modifications above changed properties from their default state.
       ezHybridArray<ezPropertySelection, 1> selection;
       selection.PushBack({pSphere1, ezVariant()});
-      ezDefaultObjectState defaultState(pAccessor, selection);
+      ezDefaultObjectState defaultState(pSphere1->GetType(), pAccessor, selection);
       EZ_TEST_STRING(defaultState.GetStateProviderName(), "Attribute");
 
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("Name"));
@@ -397,7 +397,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       // pSphere2 should be unmodified except for the component array.
       ezHybridArray<ezPropertySelection, 1> selection;
       selection.PushBack({pSphere2, ezVariant()});
-      ezDefaultObjectState defaultState(pAccessor, selection);
+      ezDefaultObjectState defaultState(pSphere2->GetType(), pAccessor, selection);
       EZ_TEST_BOOL(defaultState.IsDefaultValue("Name"));
       EZ_TEST_BOOL(defaultState.IsDefaultValue("LocalPosition"));
       EZ_TEST_BOOL(defaultState.IsDefaultValue("LocalRotation"));
@@ -411,7 +411,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       ezHybridArray<ezPropertySelection, 1> selection;
       selection.PushBack({pSphere1, ezVariant()});
       selection.PushBack({pSphere2, ezVariant()});
-      ezDefaultObjectState defaultState(pAccessor, selection);
+      ezDefaultObjectState defaultState(pSphere1->GetType(), pAccessor, selection);
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("Name"));
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("LocalPosition"));
       EZ_TEST_BOOL(!defaultState.IsDefaultValue("LocalRotation"));
@@ -424,7 +424,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       // Default state object array
       ezHybridArray<ezPropertySelection, 1> selection;
       selection.PushBack({pSphere1, ezVariant()});
-      ezDefaultContainerState defaultState(pAccessor, selection, "Components");
+      ezDefaultContainerState defaultState(pSphere1->GetType(), pAccessor, selection, "Components");
       EZ_TEST_STRING(defaultState.GetStateProviderName(), "Attribute");
       EZ_TEST_BOOL(defaultState.GetDefaultContainer() == ezVariantArray());
       EZ_TEST_BOOL(defaultState.GetDefaultElement(0) == ezUuid());
@@ -438,14 +438,14 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       // Default state value array
       ezHybridArray<ezPropertySelection, 1> selection;
       selection.PushBack({pMeshComponent, ezVariant()});
-      ezDefaultContainerState defaultState(pAccessor, selection, "Materials");
+      ezDefaultContainerState defaultState(pMeshComponent->GetType(), pAccessor, selection, "Materials");
       EZ_TEST_STRING(defaultState.GetStateProviderName(), "Attribute");
       EZ_TEST_BOOL(defaultState.GetDefaultContainer() == ezVariantArray());
       EZ_TEST_BOOL(defaultState.GetDefaultElement(0) == "");
       EZ_TEST_BOOL(!defaultState.IsDefaultContainer());
       EZ_TEST_BOOL(!defaultState.IsDefaultElement(0));
 
-      ezDefaultObjectState defaultObjectState(pAccessor, selection);
+      ezDefaultObjectState defaultObjectState(pMeshComponent->GetType(), pAccessor, selection);
       EZ_TEST_STRING(defaultObjectState.GetStateProviderName(), "Attribute");
       EZ_TEST_BOOL(defaultObjectState.GetDefaultValue("Materials") == ezVariantArray());
       EZ_TEST_BOOL(!defaultObjectState.IsDefaultValue("Materials"));
@@ -556,7 +556,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
   {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
-    ezDefaultObjectState defaultState(pAccessor, selection);
+    ezDefaultObjectState defaultState(pChild->GetType(), pAccessor, selection);
     // The root node of the prefab is not actually part of the prefab in the sense that it is just the container and does not actually exist in the prefab itself.
     const char* szExpectedProvider = pChild == pPrefab3 ? "Attribute" : "Prefab";
     EZ_TEST_STRING(defaultState.GetStateProviderName(), szExpectedProvider);
@@ -646,7 +646,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       {
         ezHybridArray<ezPropertySelection, 1> selection;
         selection.PushBack({pChild0, ezVariant()});
-        ezDefaultContainerState defaultObjectState(pAccessor, selection, "Components");
+        ezDefaultContainerState defaultObjectState(pChild0->GetType(), pAccessor, selection, "Components");
         EZ_TEST_STRING(defaultObjectState.GetStateProviderName(), "Prefab");
         EZ_TEST_BOOL(!defaultObjectState.IsDefaultContainer());
       }
@@ -654,7 +654,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       {
         ezHybridArray<ezPropertySelection, 1> selection;
         selection.PushBack({pChild1, ezVariant()});
-        ezDefaultContainerState defaultObjectState(pAccessor, selection, "Components");
+        ezDefaultContainerState defaultObjectState(pChild1->GetType(), pAccessor, selection, "Components");
         EZ_TEST_STRING(defaultObjectState.GetStateProviderName(), "Prefab");
         EZ_TEST_BOOL(!defaultObjectState.IsDefaultContainer());
       }
@@ -662,7 +662,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
       {
         ezHybridArray<ezPropertySelection, 1> selection;
         selection.PushBack({pComp, ezVariant()});
-        ezDefaultObjectState defaultObjectState(pAccessor, selection);
+        ezDefaultObjectState defaultObjectState(pComp->GetType(), pAccessor, selection);
         EZ_TEST_STRING(defaultObjectState.GetStateProviderName(), "Attribute");
       }
     }
@@ -680,7 +680,7 @@ void ezEditorSceneDocumentTest::PrefabOperations()
         ezHybridArray<ezPropertySelection, 1> selection;
         selection.PushBack({pChild1, ezVariant()});
         selection.PushBack({pChild2, ezVariant()});
-        ezDefaultContainerState defaultState(pAccessor, selection, "Components");
+        ezDefaultContainerState defaultState(pChild1->GetType(), pAccessor, selection, "Components");
 
         pAccessor->StartTransaction("Revert children");
         defaultState.RevertContainer().AssertSuccess();
@@ -735,7 +735,7 @@ void ezEditorSceneDocumentTest::ComponentOperations()
   {
     ezHybridArray<ezPropertySelection, 1> selection;
     selection.PushBack({pChild, ezVariant()});
-    ezDefaultObjectState defaultState(pAccessor, selection);
+    ezDefaultObjectState defaultState(pChild->GetType(), pAccessor, selection);
 
     ezHybridArray<const ezAbstractProperty*, 32> properties;
     pChild->GetType()->GetAllProperties(properties);


### PR DESCRIPTION
## Visualize exposed parameters as phantom types in the GUI

Exposed parameters already generated phantom types before but they were not used for visualization in the property grid. As exposed parameters are stored as a sparse `ezVariantDictionary` that overrides the default state, they don't map directly to an object of the corresponding phantom type. To visualize these as if they are objects, the following steps are taken:
1. `ezQtExposedParametersPropertyWidget` generates a `ezQtTypeWidget` that is filled with the phantom type matching the exposed parameters, the object that holds the exposed parameters map and a `ezExposedParametersAsTypeCommandAccessor`.
2. As the object doesn't hold any of the phantom type's properties, read / write operations are redirected on the `ezExposedParametersAsTypeCommandAccessor` to the exposed parameters map with the property name used as a key to the map. The accessor also ensures the type of the value in the map is converted to match the phantom property exactly.
3. If there is no value in the map for a given key, the default value of the property is returned which is done by the `ezExposedParameterCommandAccessor`.

The result looks like this:
<img width="447" height="382" alt="image" src="https://github.com/user-attachments/assets/857c5ec4-cfb2-4c74-a335-78f20030f8e1" />

There is now a button to toggle to the raw display of the underlying exposed parameter map. This will show the exposed parameters as is without any decorations via the phantom type:
<img width="447" height="541" alt="image" src="https://github.com/user-attachments/assets/3dfd248a-637f-4115-bc8b-54e7295394c4" />


## Implementation details:
* `ezQtExposedParametersPropertyWidget` is still a container for the exposed parameter map but as long as raw mode is not toggled, it will not show any elements and only show the phantom type widget. 
* Added `ezExposedParametersAsTypeCommandAccessor` class to redirects phantom type + phantom property accesses into the property map.
* Added `ezExposedParametersAsTypeDefaultStateProvider` provides default state logic for exposed properties visualized as phantom types in the property grid.
* Added `ezEnum<ezPropertyCategory> m_Category` to the `ezExposedParameter` struct. This allows for exposing arrays, sets and maps as exposed parameters. In case a container is exposed, `m_sType` should be the element's type and `m_DefaultValue` an `ezVariantDictionary` for maps and a `ezVariantArray` for arrays and sets.
* If `m_DefaultValue` is set on an exposed parameter, the phantom type will now be extended with the `ezDefaultValueAttribute`.
* `ezDefaultObjectState` now requires an `ezRTTI` type to be passed in to support exposed properties phantom types.
* `ezQtPropertyContainerWidget::GetRequiredElementCount()` has been replaced with `GetRequiredElements(ezDynamicArray<ezVariant>& out_keys)` as the former function had side-effects. The out parameter now serves both purposes of generating the keys as well as providing the total element count.


## To Do:

Note that this just adds the infrastructure for exposed parameter container support. Here is currently no way of exposing arrays in the visual script or angel script assets. This is a future work item.