### PR TITLE
Better foot normal detection

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -248,6 +248,7 @@ void ezJoltCharacterControllerComponent::CollectCastContacts(ezDynamicArray<Cont
       contact.m_vContactNormal = ezJoltConversionUtils::ToVec3(-result.mPenetrationAxis.Normalized());
       contact.m_BodyID = result.mBodyID2;
       contact.m_fCastFraction = result.mFraction;
+      contact.m_fPenetrationDepth = result.mPenetrationDepth;
       contact.m_SubShapeID = result.mSubShapeID2;
 
       JPH::BodyLockRead lock(*m_pLockInterface, contact.m_BodyID);
@@ -273,7 +274,7 @@ void ezJoltCharacterControllerComponent::CollectCastContacts(ezDynamicArray<Cont
   pJoltSystem->GetNarrowPhaseQuery().CastShape(castOpt, settings, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, m_BodyFilter);
 }
 
-void ezJoltCharacterControllerComponent::CollectContacts(ezDynamicArray<ContactPoint>& out_Contacts, const JPH::Shape* pShape, const ezVec3& vQueryPosition, const ezQuat& qQueryRotation, float fCollisionTolerance) const
+void ezJoltCharacterControllerComponent::CollectContacts(ezDynamicArray<ContactPoint>& out_Contacts, const JPH::Shape* pShape, const ezVec3& vQueryPosition, const ezQuat& qQueryRotation, float fMaxSeparationDistance) const
 {
   out_Contacts.Clear();
 
@@ -286,6 +287,7 @@ void ezJoltCharacterControllerComponent::CollectContacts(ezDynamicArray<ContactP
     virtual void AddHit(const JPH::CollideShapeResult& result) override
     {
       auto& contact = m_pContacts->ExpandAndGetRef();
+      contact.m_fPenetrationDepth = result.mPenetrationDepth;
       contact.m_vPosition = ezJoltConversionUtils::ToVec3(result.mContactPointOn2);
       contact.m_vContactNormal = ezJoltConversionUtils::ToVec3(-result.mPenetrationAxis.Normalized());
       contact.m_BodyID = result.mBodyID2;
@@ -309,7 +311,7 @@ void ezJoltCharacterControllerComponent::CollectContacts(ezDynamicArray<ContactP
   const JPH::Mat44 trans = JPH::Mat44::sRotationTranslation(ezJoltConversionUtils::ToQuat(qQueryRotation), ezJoltConversionUtils::ToVec3(vQueryPosition));
 
   JPH::CollideShapeSettings settings;
-  settings.mCollisionTolerance = fCollisionTolerance;
+  settings.mMaxSeparationDistance = fMaxSeparationDistance;
   settings.mBackFaceMode = JPH::EBackFaceMode::CollideWithBackFaces;
 
   pJoltSystem->GetNarrowPhaseQuery().CollideShape(pShape, JPH::Vec3::sReplicate(1.0f), trans, settings, JPH::RVec3::sZero(), collector, broadphaseFilter, objectFilter, m_BodyFilter);

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -542,7 +542,6 @@ void ezJoltDefaultCharacterComponent::CheckFeet()
 
   ezHybridArray<ContactPoint, 32> contacts;
   CollectContacts(contacts, &shape, shapeTrans.m_vPosition, shapeRot, m_fMaxStepDown);
-  //CollectContacts(contacts, &shape, shapeTrans.m_vPosition, shapeRot, 0.01f);
 
   for (const auto& contact : contacts)
   {

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -538,14 +538,21 @@ void ezJoltDefaultCharacterComponent::CheckFeet()
   const float halfHeight = ezMath::Max(0.01f, m_fMaxStepDown - radius);
 
   JPH::CapsuleShape shape(halfHeight, radius);
+  shapeTrans.m_vPosition.z += halfHeight;
 
   ezHybridArray<ContactPoint, 32> contacts;
-  CollectContacts(contacts, &shape, shapeTrans.m_vPosition, shapeRot, 0.01f);
+  CollectContacts(contacts, &shape, shapeTrans.m_vPosition, shapeRot, m_fMaxStepDown);
+  //CollectContacts(contacts, &shape, shapeTrans.m_vPosition, shapeRot, 0.01f);
 
   for (const auto& contact : contacts)
   {
     ezVec3 gpos = contact.m_vPosition;
     ezVec3 gnom = contact.m_vSurfaceNormal;
+
+    // if the object is not penetrated and stands further than foot radius then skip this object
+    float fXYDistanceSquared = contact.m_fPenetrationDepth < 0 ? (contact.m_fPenetrationDepth * gnom).GetAsVec2().GetLengthSquared() : 0.f;
+    if (fXYDistanceSquared > radius * radius)
+      continue;
 
     ezColor color = ezColor::LightYellow;
     ezQuat rot;

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltDefaultCharacterComponent.cpp
@@ -538,7 +538,7 @@ void ezJoltDefaultCharacterComponent::CheckFeet()
   const float halfHeight = ezMath::Max(0.01f, m_fMaxStepDown - radius);
 
   JPH::CapsuleShape shape(halfHeight, radius);
-  shapeTrans.m_vPosition.z += halfHeight;
+  shapeTrans.m_vPosition.z += halfHeight + radius;
 
   ezHybridArray<ContactPoint, 32> contacts;
   CollectContacts(contacts, &shape, shapeTrans.m_vPosition, shapeRot, m_fMaxStepDown);

--- a/Code/EnginePlugins/JoltPlugin/Character/JoltCharacterControllerComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Character/JoltCharacterControllerComponent.h
@@ -48,6 +48,7 @@ public:
   struct ContactPoint
   {
     float m_fCastFraction = 0.0f;
+    float m_fPenetrationDepth = 0.0f;
     ezVec3 m_vPosition;
     ezVec3 m_vSurfaceNormal;
     ezVec3 m_vContactNormal;
@@ -152,8 +153,8 @@ protected:
 
   /// \brief Gathers all contact points of the shape at the target position.
   ///
-  /// Use fCollisionTolerance > 0 (e.g. 0.02f) to find contacts with walls/ground that the shape is touching but not penetrating.
-  void CollectContacts(ezDynamicArray<ContactPoint>& out_Contacts, const JPH::Shape* pShape, const ezVec3& vQueryPosition, const ezQuat& qQueryRotation, float fCollisionTolerance) const;
+  /// Use fMaxSeparationDistance > 0 (e.g. 0.02f) to find contacts with walls/ground that the shape is touching but not penetrating.
+  void CollectContacts(ezDynamicArray<ContactPoint>& out_Contacts, const JPH::Shape* pShape, const ezVec3& vQueryPosition, const ezQuat& qQueryRotation, float fMaxSeparationDistance) const;
 
   /// \brief Detects the velocity at the contact point. If it is a dynamic body, a force pushing it away is applied.
   ///


### PR DESCRIPTION
Resolves #1636


**Main idea**
1. Keep a foot shape collider on the same height as the character.
2. For collision detection use `mMaxSeparationDistance = m_fMaxStepDown` which is described in Jolt as 
```cpp
/// When > 0 contacts in the vicinity of the query shape can be found. All nearest contacts that are not further away than this distance will be found.
/// Note that in this case CollideShapeResult::mPenetrationDepth can become negative to indicate that objects are not overlapping. (unit: meter)"
```
3. Therefore we can detect shapes which are below our character by m_fMaxStepDown. Also we can use mPenetrationDepth to filter out false collisions (outside capsule radius)

**Screenshots**
Before changes: 
<img width="516" height="528" alt="image" src="https://github.com/user-attachments/assets/8f4c8cc2-1a41-4301-a414-1d6448b3350c" />
After changes:
<img width="467" height="588" alt="image" src="https://github.com/user-attachments/assets/57ec6039-4a73-4717-8c2c-5c1b2f6e7461" />


**Other changes**:
I have replaced `fCollisionTolerance` with `fMaxSeparationDistance`. The later seems to be more suitable choice for most of the cases + it provides additional info via `mPenetrationDepth`


I haven't found any Jolt's CC features to implement custom foot size. Actually, since #753 most of the stair stepping logic is handled by Jolt. 

Additionally, I would be thankful if someone could run some tests. I will do some more tests on my own, but I don't have any experience developing CC and might miss something important