### PR TITLE
Stutter fix in editor play the game

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -53,8 +53,9 @@ void ezProcessCommunicationChannel::WaitForMessages()
   m_pProtocol->WaitForMessages().IgnoreResult();
 }
 
-void ezProcessCommunicationChannel::MessageFunc(const ezProcessMessage* pMsg)
+void ezProcessCommunicationChannel::MessageFunc(ezIpcProcessMessageProtocol::Event& msg)
 {
+  const ezProcessMessage* pMsg = msg.m_pMessage;
   const ezRTTI* pRtti = pMsg->GetDynamicRTTI();
 
   if (m_pWaitForMessageType != nullptr && pMsg->GetDynamicRTTI()->IsDerivedFrom(m_pWaitForMessageType))
@@ -79,7 +80,9 @@ void ezProcessCommunicationChannel::MessageFunc(const ezProcessMessage* pMsg)
 
   Event e;
   e.m_pMessage = pMsg;
+  e.m_bInterruptMessageProcessing = msg.m_bInterruptMessageProcessing;
   m_Events.Broadcast(e);
+  msg.m_bInterruptMessageProcessing = e.m_bInterruptMessageProcessing;
 }
 
 ezResult ezProcessCommunicationChannel::WaitForMessage(const ezRTTI* pMessageType, ezTime timeout, WaitForMessageCallback* pMessageCallack)

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -53,7 +53,7 @@ void ezProcessCommunicationChannel::WaitForMessages()
   m_pProtocol->WaitForMessages().IgnoreResult();
 }
 
-void ezProcessCommunicationChannel::MessageFunc(ezIpcProcessMessageProtocol::Event& msg)
+void ezProcessCommunicationChannel::MessageFunc(const ezIpcProcessMessageProtocol::Event& msg)
 {
   const ezProcessMessage* pMsg = msg.m_pMessage;
   const ezRTTI* pRtti = pMsg->GetDynamicRTTI();

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
@@ -2,10 +2,10 @@
 
 #include <EditorEngineProcessFramework/EditorEngineProcessFrameworkDLL.h>
 #include <Foundation/Communication/Event.h>
+#include <Foundation/Communication/IpcProcessMessageProtocol.h>
 #include <Foundation/Time/Time.h>
 #include <Foundation/Types/Delegate.h>
 #include <Foundation/Types/UniquePtr.h>
-#include <Foundation/Communication/IpcProcessMessageProtocol.h>
 
 class ezIpcChannel;
 class ezProcessMessage;

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
@@ -5,6 +5,7 @@
 #include <Foundation/Time/Time.h>
 #include <Foundation/Types/Delegate.h>
 #include <Foundation/Types/UniquePtr.h>
+#include <Foundation/Communication/IpcProcessMessageProtocol.h>
 
 class ezIpcChannel;
 class ezProcessMessage;
@@ -32,11 +33,13 @@ public:
   struct Event
   {
     const ezProcessMessage* m_pMessage;
+    // Set to true in a message handler to cancel the ProcessMessages function and return to the caller before all messages have been processed.
+    mutable bool m_bInterruptMessageProcessing = false;
   };
 
   ezEvent<const Event&> m_Events;
 
-  void MessageFunc(const ezProcessMessage* pMsg);
+  void MessageFunc(ezIpcProcessMessageProtocol::Event& msg);
 
 protected:
   ezUniquePtr<ezIpcProcessMessageProtocol> m_pProtocol;

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
@@ -39,7 +39,7 @@ public:
 
   ezEvent<const Event&> m_Events;
 
-  void MessageFunc(ezIpcProcessMessageProtocol::Event& msg);
+  void MessageFunc(const ezIpcProcessMessageProtocol::Event& msg);
 
 protected:
   ezUniquePtr<ezIpcProcessMessageProtocol> m_pProtocol;

--- a/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
+++ b/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
@@ -34,7 +34,7 @@ public:
   {
     const ezProcessMessage* m_pMessage;
     // Set to true in a message handler to cancel the ProcessMessages function and return to the caller before all messages have been processed.
-    bool m_bInterruptMessageProcessing = false;
+    mutable bool m_bInterruptMessageProcessing = false;
   };
   ezEvent<Event&> m_MessageEvent; ///< Will be sent from thread calling ProcessMessages or WaitForMessages.
 

--- a/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
+++ b/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
@@ -30,11 +30,17 @@ public:
   ezResult WaitForMessages(ezTime timeout = ezTime::MakeZero());
 
 public:
-  ezEvent<const ezProcessMessage*> m_MessageEvent; ///< Will be sent from thread calling ProcessMessages or WaitForMessages.
+  struct Event
+  {
+    const ezProcessMessage* m_pMessage;
+    // Set to true in a message handler to cancel the ProcessMessages function and return to the caller before all messages have been processed.
+    bool m_bInterruptMessageProcessing = false;
+  };
+  ezEvent<Event&> m_MessageEvent; ///< Will be sent from thread calling ProcessMessages or WaitForMessages.
 
 private:
   void EnqueueMessage(ezUniquePtr<ezProcessMessage>&& msg);
-  void SwapWorkQueue(ezDeque<ezUniquePtr<ezProcessMessage>>& messages);
+  ezUniquePtr<ezProcessMessage> PopMessage();
   void ReceiveMessageData(ezArrayPtr<const ezUInt8> data);
 
 private:

--- a/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
+++ b/Code/Engine/Foundation/Communication/IpcProcessMessageProtocol.h
@@ -36,7 +36,7 @@ public:
     // Set to true in a message handler to cancel the ProcessMessages function and return to the caller before all messages have been processed.
     mutable bool m_bInterruptMessageProcessing = false;
   };
-  ezEvent<Event&> m_MessageEvent; ///< Will be sent from thread calling ProcessMessages or WaitForMessages.
+  ezEvent<const Event&> m_MessageEvent; ///< Will be sent from thread calling ProcessMessages or WaitForMessages.
 
 private:
   void EnqueueMessage(ezUniquePtr<ezProcessMessage>&& msg);

--- a/Code/Engine/GameEngine/DearImgui/DearImgui.h
+++ b/Code/Engine/GameEngine/DearImgui/DearImgui.h
@@ -15,6 +15,7 @@
 using ezTexture2DResourceHandle = ezTypedResourceHandle<class ezTexture2DResource>;
 
 struct ImGuiContext;
+struct ezGameApplicationExecutionEvent;
 
 using ezImguiConfigFontCallback = ezDelegate<void(ImFontAtlas&)>;
 using ezImguiConfigStyleCallback = ezDelegate<void(ImGuiStyle&)>;
@@ -85,6 +86,7 @@ private:
 
   ImGuiContext* CreateContext();
   void BeginFrame(const ezViewHandle& hView);
+  void GameApplicationEventHandler(const ezGameApplicationExecutionEvent& e);
 
   ezProxyAllocator m_Allocator;
 

--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
@@ -257,10 +257,13 @@ void ezImgui::Startup(ezImguiConfigFontCallback configFontCallback)
 
   const size_t id = (size_t)m_Textures.GetCount() - 1;
   m_pSharedFontAtlas->TexID = reinterpret_cast<void*>(id);
+
+  ezGameApplicationBase::GetGameApplicationBaseInstance()->m_ExecutionEvents.AddEventHandler(ezMakeDelegate(&ezImgui::GameApplicationEventHandler, this));
 }
 
 void ezImgui::Shutdown()
 {
+  ezGameApplicationBase::GetGameApplicationBaseInstance()->m_ExecutionEvents.RemoveEventHandler(ezMakeDelegate(&ezImgui::GameApplicationEventHandler, this));
   m_Textures.Clear();
 
   m_pSharedFontAtlas = nullptr;
@@ -388,6 +391,14 @@ void ezImgui::BeginFrame(const ezViewHandle& hView)
   ImGui::NewFrame();
 
   m_bImguiWantsInput = cfg.WantCaptureKeyboard || cfg.WantCaptureMouse;
+}
+
+void ezImgui::GameApplicationEventHandler(const ezGameApplicationExecutionEvent& e)
+{
+  if (e.m_Type == ezGameApplicationExecutionEvent::Type::AfterUpdatePlugins)
+  {
+    ImGui::EndFrame();
+  }
 }
 
 #endif

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -898,9 +898,9 @@ ezTestAppRun ezRendererTestAdvancedFeatures::SharedTexture()
   return ezTestAppRun::Continue;
 }
 
-void ezRendererTestAdvancedFeatures::OffscreenProcessMessageFunc(const ezProcessMessage* pMsg)
+void ezRendererTestAdvancedFeatures::OffscreenProcessMessageFunc(ezIpcProcessMessageProtocol::Event& msg)
 {
-  if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_RenderResponseMsg*>(pMsg))
+  if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_RenderResponseMsg*>(msg.m_pMessage))
   {
     m_uiReceivedTextures++;
     ezStringBuilder sTemp;

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.cpp
@@ -898,7 +898,7 @@ ezTestAppRun ezRendererTestAdvancedFeatures::SharedTexture()
   return ezTestAppRun::Continue;
 }
 
-void ezRendererTestAdvancedFeatures::OffscreenProcessMessageFunc(ezIpcProcessMessageProtocol::Event& msg)
+void ezRendererTestAdvancedFeatures::OffscreenProcessMessageFunc(const ezIpcProcessMessageProtocol::Event& msg)
 {
   if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_RenderResponseMsg*>(msg.m_pMessage))
   {

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
@@ -45,7 +45,7 @@ private:
   void Compute();
   ezTestAppRun Material();
   ezTestAppRun SharedTexture();
-  void OffscreenProcessMessageFunc(ezIpcProcessMessageProtocol::Event& msg);
+  void OffscreenProcessMessageFunc(const ezIpcProcessMessageProtocol::Event& msg);
 
 private:
   ezShaderResourceHandle m_hShader2;

--- a/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
+++ b/Code/UnitTests/RendererTest/Advanced/AdvancedFeatures.h
@@ -45,8 +45,7 @@ private:
   void Compute();
   ezTestAppRun Material();
   ezTestAppRun SharedTexture();
-  void OffscreenProcessMessageFunc(const ezProcessMessage* pMsg);
-
+  void OffscreenProcessMessageFunc(ezIpcProcessMessageProtocol::Event& msg);
 
 private:
   ezShaderResourceHandle m_hShader2;

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -238,9 +238,9 @@ void ezOffscreenRendererTest::BeforeCoreSystemsShutdown()
   SUPER::BeforeCoreSystemsShutdown();
 }
 
-void ezOffscreenRendererTest::MessageFunc(const ezProcessMessage* pMsg)
+void ezOffscreenRendererTest::MessageFunc(ezIpcProcessMessageProtocol::Event& msg)
 {
-  if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_OpenMsg*>(pMsg))
+  if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_OpenMsg*>(msg.m_pMessage))
   {
     ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
     EZ_ASSERT_DEBUG(m_hSwapChain.IsInvalidated(), "SwapChain creation should only happen once");
@@ -258,11 +258,11 @@ void ezOffscreenRendererTest::MessageFunc(const ezProcessMessage* pMsg)
       RequestApplicationQuit();
     }
   }
-  else if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_CloseMsg*>(pMsg))
+  else if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_CloseMsg*>(msg.m_pMessage))
   {
     m_bExiting = true;
   }
-  else if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_RenderMsg*>(pMsg))
+  else if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_RenderMsg*>(msg.m_pMessage))
   {
     EZ_ASSERT_DEBUG(m_bExiting == false, "No new frame requests should come in at this point.");
     m_RequestedFrames.PushBack(*pAction);

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.cpp
@@ -238,7 +238,7 @@ void ezOffscreenRendererTest::BeforeCoreSystemsShutdown()
   SUPER::BeforeCoreSystemsShutdown();
 }
 
-void ezOffscreenRendererTest::MessageFunc(ezIpcProcessMessageProtocol::Event& msg)
+void ezOffscreenRendererTest::MessageFunc(const ezIpcProcessMessageProtocol::Event& msg)
 {
   if (const auto* pAction = ezDynamicCast<const ezOffscreenTest_OpenMsg*>(msg.m_pMessage))
   {

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.h
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.h
@@ -68,7 +68,7 @@ public:
   virtual void BeforeHighLevelSystemsShutdown() override;
   virtual void BeforeCoreSystemsShutdown() override;
 
-  void MessageFunc(const ezProcessMessage* pMsg);
+  void MessageFunc(ezIpcProcessMessageProtocol::Event& msg);
 
 
 private:

--- a/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.h
+++ b/Code/UnitTests/RendererTest/Advanced/OffscreenRenderer.h
@@ -68,7 +68,7 @@ public:
   virtual void BeforeHighLevelSystemsShutdown() override;
   virtual void BeforeCoreSystemsShutdown() override;
 
-  void MessageFunc(ezIpcProcessMessageProtocol::Event& msg);
+  void MessageFunc(const ezIpcProcessMessageProtocol::Event& msg);
 
 
 private:


### PR DESCRIPTION
Previously the editor rendered in two places:
1. `ezEngineProcessGameApplication::EventHandlerIPC` if a `ezSyncWithProcessMsgToEngine` message was received.
2. At the end of `ezEngineProcessGameApplication::Run`. This meant that in one frame loop multiple calls to `ezGameApplicationBase::RunOneFrame` could happen depending on what the editor wanted to render and what the running play the game loop wanted to render. This caused stuttering as the frames were very unbalanced in terms of workload.

To fix the stutter rendering in the first instance was removed. But to  still ensure that for each `ezSyncWithProcessMsgToEngine` message a frame is rendered, a new feature was added to cancel out of message processing via the new event message field `m_bInterruptMessageProcessing`. For each `ezSyncWithProcessMsgToEngine` message, we set `m_bInterruptMessageProcessing` to true so the message processing is interrupted and we end up at `ezEngineProcessGameApplication::Run` where  all the rendering now takes place. This ensures that rendering does not happen outside of the normal game loop.

## Misc
Fixed a crash in ImGui when closing the play the game window of the sample game project. There was no code path to ensure that at the end of the frame the ImGui frame was ended. So when the play the game window was closed, ImGui was shut down but the destructor asserted that a frame is still in progress.