### PR TITLE
ImGui crash fix

### DIFF
--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImgui.cpp
@@ -397,7 +397,11 @@ void ezImgui::GameApplicationEventHandler(const ezGameApplicationExecutionEvent&
 {
   if (e.m_Type == ezGameApplicationExecutionEvent::Type::AfterUpdatePlugins)
   {
-    ImGui::EndFrame();
+    ImGuiContext* pContext = ImGui::GetCurrentContext();
+    if (pContext && pContext->Initialized && pContext->WithinFrameScope)
+    {
+      ImGui::EndFrame();
+    }
   }
 }
 


### PR DESCRIPTION
The previous fix to call `ImGui::EndFrame()` in the `ezGameApplicationExecutionEvent::Type::AfterUpdatePlugins` event handler was meant to make sure that the imGui frame scope does not remain active across frames as it was leaking and then crashing later when the only imGui using editor window was closed but frame scope was never cleaned up.
This introduced the bug that ImGui could be loaded but unused in which case we can't call `ImGui::EndFrame()` unconditionally. The code now checks for ImGui being initialized and a frame scope being active.