### PR TITLE
Fix imgGui rendering breaking console

### DIFF
--- a/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
+++ b/Code/Engine/GameEngine/DearImgui/Implementation/DearImguiRenderer.cpp
@@ -196,6 +196,10 @@ void ezImguiRenderer::RenderBatch(const ezRenderViewContext& renderContext, cons
       uiFirstIndex += imGuiBatch.m_uiVertexCount;
     }
   }
+
+  // Reset scissor to default.
+  ezRectFloat rect = renderContext.m_pViewData->m_ViewPortRect;
+  pCommandEncoder->SetScissorRect(ezRectU32((ezUInt32)rect.x, (ezUInt32)rect.y, (ezUInt32)rect.width, (ezUInt32)rect.height));
 }
 
 void ezImguiRenderer::SetupRenderer()


### PR DESCRIPTION
Renderer was changing the scissor rect but never reverting it to the default, causing rendering in the same render pass afterwards to be cropped.