### PR TITLE
Update RmlUI assets when dependency (CSS file) changes

### DIFF
--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
@@ -4,7 +4,7 @@
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
 
-ezStringView FindRCSSReference(ezStringView& ref_sRml)
+ezStringView FindNextHREF(ezStringView& ref_sRml)
 {
   const char* szCurrent = ref_sRml.FindSubString("href");
   if (szCurrent == nullptr)
@@ -34,10 +34,14 @@ ezStringView FindRCSSReference(ezStringView& ref_sRml)
   {
     ref_sRml.SetStartPosition(szEnd);
 
-    ezStringView rcss = ezStringView(szStart, szEnd);
-    if (rcss.EndsWith_NoCase(".rcss"))
+    ezStringView href = ezStringView(szStart, szEnd);
+    if (href.HasExtension(".rcss"))
     {
-      return rcss;
+      return href;
+    }
+    if (href.HasExtension(".rml"))
+    {
+      return href;
     }
   }
 
@@ -93,7 +97,7 @@ ezTransformStatus ezRmlUiAssetDocument::InternalTransformAsset(ezStreamWriter& s
 
   desc.m_DependencyFile.AddFileDependency(pProp->m_sRmlFile);
 
-  EZ_SUCCEED_OR_RETURN(FindDependencies(desc.m_DependencyFile));
+  EZ_SUCCEED_OR_RETURN(FindDependencies(desc.m_DependencyFile, pProp->m_sRmlFile));
 
   EZ_SUCCEED_OR_RETURN(desc.Save(stream));
 
@@ -106,41 +110,41 @@ ezTransformStatus ezRmlUiAssetDocument::InternalCreateThumbnail(const ThumbnailI
   return status;
 }
 
-ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependencies) const
+ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependencies, ezStringView sFilePath) const
 {
-  const ezRmlUiAssetProperties* pProp = GetProperties();
-
   ezStringBuilder sContent;
   {
     ezFileReader reader;
-    if (reader.Open(pProp->m_sRmlFile).Failed())
-      return ezStatus("Failed to read RML file");
+    if (reader.Open(sFilePath).Failed())
+      return ezStatus(ezFmt("Failed to read file: '{}'", sFilePath));
 
     sContent.ReadAll(reader);
   }
 
-  ezStringBuilder sRmlFilePath = pProp->m_sRmlFile;
-  sRmlFilePath = sRmlFilePath.GetFileDirectory();
+  const ezStringView sFileDir = sFilePath.GetFileDirectory();
 
+  ezStringBuilder sTemp;
   ezStringView sContentView = sContent;
 
   while (true)
   {
-    ezStringView rcssReference = FindRCSSReference(sContentView);
-    if (rcssReference.IsEmpty())
+    ezStringView href = FindNextHREF(sContentView);
+    if (href.IsEmpty())
       break;
 
-    ezStringBuilder sRcssRef = rcssReference;
-    if (!ezFileSystem::ExistsFile(sRcssRef))
+    if (ezFileSystem::ExistsFile(href))
     {
-      ezStringBuilder sTemp;
-      sTemp.AppendPath(sRmlFilePath, sRcssRef);
-      sRcssRef = sTemp;
+      ref_Dependencies.AddFileDependency(href);
+      EZ_SUCCEED_OR_RETURN(FindDependencies(ref_Dependencies, href));
+      continue;
     }
 
-    if (ezFileSystem::ExistsFile(sRcssRef))
+    sTemp.SetPath(sFileDir, href);
+    if (ezFileSystem::ExistsFile(sTemp))
     {
-      ref_Dependencies.AddFileDependency(sRcssRef);
+      ref_Dependencies.AddFileDependency(sTemp);
+      EZ_SUCCEED_OR_RETURN(FindDependencies(ref_Dependencies, sTemp));
+      continue;
     }
   }
 
@@ -151,8 +155,10 @@ void ezRmlUiAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) c
 {
   SUPER::UpdateAssetDocumentInfo(pInfo);
 
+  const ezRmlUiAssetProperties* pProp = GetProperties();
+
   ezDependencyFile deps;
-  FindDependencies(deps).IgnoreResult();
+  FindDependencies(deps, pProp->m_sRmlFile).IgnoreResult();
 
   for (const auto& file : deps.GetFileDependencies())
   {

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.cpp
@@ -93,46 +93,7 @@ ezTransformStatus ezRmlUiAssetDocument::InternalTransformAsset(ezStreamWriter& s
 
   desc.m_DependencyFile.AddFileDependency(pProp->m_sRmlFile);
 
-  // Find rcss dependencies
-  {
-    ezStringBuilder sContent;
-    {
-      ezFileReader reader;
-      if (reader.Open(pProp->m_sRmlFile).Failed())
-        return ezStatus("Failed to read rml file");
-
-      sContent.ReadAll(reader);
-    }
-
-    ezStringBuilder sRmlFilePath = pProp->m_sRmlFile;
-    sRmlFilePath = sRmlFilePath.GetFileDirectory();
-
-    ezStringView sContentView = sContent;
-
-    while (true)
-    {
-      ezStringView rcssReference = FindRCSSReference(sContentView);
-      if (rcssReference.IsEmpty())
-        break;
-
-      ezStringBuilder sRcssRef = rcssReference;
-      if (!ezFileSystem::ExistsFile(sRcssRef))
-      {
-        ezStringBuilder sTemp;
-        sTemp.AppendPath(sRmlFilePath, sRcssRef);
-        sRcssRef = sTemp;
-      }
-
-      if (ezFileSystem::ExistsFile(sRcssRef))
-      {
-        desc.m_DependencyFile.AddFileDependency(sRcssRef);
-      }
-      else
-      {
-        ezLog::Warning("RCSS file '{}' was not added as dependency since it doesn't exist", sRcssRef);
-      }
-    }
-  }
+  EZ_SUCCEED_OR_RETURN(FindDependencies(desc.m_DependencyFile));
 
   EZ_SUCCEED_OR_RETURN(desc.Save(stream));
 
@@ -143,4 +104,58 @@ ezTransformStatus ezRmlUiAssetDocument::InternalCreateThumbnail(const ThumbnailI
 {
   ezStatus status = ezAssetDocument::RemoteCreateThumbnail(ThumbnailInfo);
   return status;
+}
+
+ezStatus ezRmlUiAssetDocument::FindDependencies(ezDependencyFile& ref_Dependencies) const
+{
+  const ezRmlUiAssetProperties* pProp = GetProperties();
+
+  ezStringBuilder sContent;
+  {
+    ezFileReader reader;
+    if (reader.Open(pProp->m_sRmlFile).Failed())
+      return ezStatus("Failed to read RML file");
+
+    sContent.ReadAll(reader);
+  }
+
+  ezStringBuilder sRmlFilePath = pProp->m_sRmlFile;
+  sRmlFilePath = sRmlFilePath.GetFileDirectory();
+
+  ezStringView sContentView = sContent;
+
+  while (true)
+  {
+    ezStringView rcssReference = FindRCSSReference(sContentView);
+    if (rcssReference.IsEmpty())
+      break;
+
+    ezStringBuilder sRcssRef = rcssReference;
+    if (!ezFileSystem::ExistsFile(sRcssRef))
+    {
+      ezStringBuilder sTemp;
+      sTemp.AppendPath(sRmlFilePath, sRcssRef);
+      sRcssRef = sTemp;
+    }
+
+    if (ezFileSystem::ExistsFile(sRcssRef))
+    {
+      ref_Dependencies.AddFileDependency(sRcssRef);
+    }
+  }
+
+  return EZ_SUCCESS;
+}
+
+void ezRmlUiAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
+{
+  SUPER::UpdateAssetDocumentInfo(pInfo);
+
+  ezDependencyFile deps;
+  FindDependencies(deps).IgnoreResult();
+
+  for (const auto& file : deps.GetFileDependencies())
+  {
+    pInfo->m_TransformDependencies.Insert(file);
+  }
 }

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
@@ -20,4 +20,8 @@ protected:
     const ezAssetFileHeader& AssetHeader, ezBitflags<ezTransformFlags> transformFlags) override;
 
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
+
+  ezStatus FindDependencies(ezDependencyFile& ref_Dependencies) const;
+
+  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 };

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAsset.h
@@ -21,7 +21,7 @@ protected:
 
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
 
-  ezStatus FindDependencies(ezDependencyFile& ref_Dependencies) const;
+  ezStatus FindDependencies(ezDependencyFile& ref_Dependencies, ezStringView sFilePath) const;
 
   virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 };

--- a/Data/Samples/RTS/UI/Edit.ezRmlUiAsset
+++ b/Data/Samples/RTS/UI/Edit.ezRmlUiAsset
@@ -12,6 +12,7 @@ o
 		VarArray %Dependencies
 		{
 			s{"UI/Edit.rml"}
+			s{"UI/UI.rcss"}
 		}
 		Uuid %DocumentID{u4{10922229380658380468,5439759434091703483}}
 		u4 %Hash{4733857253323256867}

--- a/Data/Samples/RTS/UI/SelectMode.ezRmlUiAsset
+++ b/Data/Samples/RTS/UI/SelectMode.ezRmlUiAsset
@@ -12,6 +12,7 @@ o
 		VarArray %Dependencies
 		{
 			s{"UI/SelectMode.rml"}
+			s{"UI/UI.rcss"}
 		}
 		Uuid %DocumentID{u4{1305255426561629067,5673149715115996774}}
 		u4 %Hash{6468534380519459840}


### PR DESCRIPTION
Makes it easier to see the effect of CSS changes. Should also work with RML templates.