### PR TITLE
RML document input fix + monitor screen resolutions

### DIFF
--- a/Code/EditorPlugins/RmlUi/EnginePluginRmlUi/RmlUiAsset/RmlUiDocumentContext.cpp
+++ b/Code/EditorPlugins/RmlUi/EnginePluginRmlUi/RmlUiAsset/RmlUiDocumentContext.cpp
@@ -38,6 +38,10 @@ void ezRmlUiDocumentContext::OnInitialize()
     ezRmlUiCanvas2DComponent* pComponent = nullptr;
     ezRmlUiCanvas2DComponent::CreateComponent(m_pMainObject, pComponent);
 
+    pComponent->SetPassInput(false);
+    pComponent->SetOnDemandUpdate(false);
+    pComponent->SetAutobindBlackboards(false); // there is no blackboard that could be bound in this context
+
     ezStringBuilder sResourceGuid;
     ezConversionUtils::ToString(GetDocumentGuid(), sResourceGuid);
     m_hMainResource = ezResourceManager::LoadResource<ezRmlUiResource>(sResourceGuid);

--- a/Code/Engine/Foundation/Platform/Win/Screen_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/Screen_Win.cpp
@@ -5,6 +5,84 @@
 #  include <Foundation/Platform/Win/Utils/IncludeWindows.h>
 #  include <Foundation/System/Screen.h>
 
+EZ_DEFINE_AS_POD_TYPE(DISPLAYCONFIG_PATH_INFO);
+EZ_DEFINE_AS_POD_TYPE(DISPLAYCONFIG_MODE_INFO);
+
+static void QueryMonitorNames(ezMap<ezString, ezString>& out_DeviceIDtoName)
+{
+  out_DeviceIDtoName.Clear();
+
+  ezHybridArray<DISPLAYCONFIG_PATH_INFO, 4> paths;
+  ezHybridArray<DISPLAYCONFIG_MODE_INFO, 4> modes;
+  UINT32 flags = QDC_ONLY_ACTIVE_PATHS;
+  LONG isError = ERROR_INSUFFICIENT_BUFFER;
+
+  UINT32 pathCount, modeCount;
+  isError = GetDisplayConfigBufferSizes(flags, &pathCount, &modeCount);
+
+  if (isError)
+    return;
+
+  // Allocate the path and mode arrays
+  paths.SetCount(pathCount);
+  modes.SetCount(modeCount);
+
+  // Get all active paths and their modes
+  isError = QueryDisplayConfig(flags, &pathCount, paths.GetData(), &modeCount, modes.GetData(), nullptr);
+
+  // The function may have returned fewer paths/modes than estimated
+  paths.SetCount(pathCount);
+  modes.SetCount(modeCount);
+
+  if (isError)
+    return;
+
+  ezStringBuilder tmp;
+
+  // For each active path
+  for (ezUInt32 i = 0; i < paths.GetCount(); i++)
+  {
+    // Find the target (monitor) friendly name
+    DISPLAYCONFIG_TARGET_DEVICE_NAME targetName = {};
+    targetName.header.adapterId = paths[i].targetInfo.adapterId;
+    targetName.header.id = paths[i].targetInfo.id;
+    targetName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+    targetName.header.size = sizeof(targetName);
+    isError = DisplayConfigGetDeviceInfo(&targetName.header);
+
+    if (isError)
+      return;
+
+    if (targetName.flags.friendlyNameFromEdid)
+    {
+      tmp = targetName.monitorDevicePath;
+      out_DeviceIDtoName[tmp] = targetName.monitorFriendlyDeviceName;
+    }
+  }
+}
+
+static void EnumerateDisplayModes(ezStringView deviceName, ezDynamicArray<ezScreenResolution>& inout_Modes)
+{
+  inout_Modes.Clear();
+
+  const ezStringWChar wName(deviceName);
+
+  DEVMODEW devMode = {};
+  devMode.dmSize = sizeof(DEVMODEW);
+
+  int modeNum = 0;
+  while (EnumDisplaySettingsW(wName.GetData(), modeNum++, &devMode))
+  {
+    ezScreenResolution& mode = inout_Modes.ExpandAndGetRef();
+    mode.m_uiResolutionX = devMode.dmPelsWidth;
+    mode.m_uiResolutionY = devMode.dmPelsHeight;
+    mode.m_uiBitsPerPixel = devMode.dmBitsPerPel;
+    mode.m_uiRefreshRate = devMode.dmDisplayFrequency;
+  }
+
+  inout_Modes.Sort();
+}
+
 BOOL CALLBACK ezMonitorEnumProc(HMONITOR pMonitor, HDC pHdcMonitor, LPRECT pLprcMonitor, LPARAM data)
 {
   EZ_IGNORE_UNUSED(pHdcMonitor);
@@ -26,15 +104,31 @@ BOOL CALLBACK ezMonitorEnumProc(HMONITOR pMonitor, HDC pHdcMonitor, LPRECT pLprc
   mon.m_iOffsetY = info.rcMonitor.top;
   mon.m_iResolutionX = info.rcMonitor.right - info.rcMonitor.left;
   mon.m_iResolutionY = info.rcMonitor.bottom - info.rcMonitor.top;
+  mon.m_sDisplayID = info.szDevice;
   mon.m_sDisplayName = info.szDevice;
   mon.m_bIsPrimary = (info.dwFlags & MONITORINFOF_PRIMARY) != 0;
 
   DISPLAY_DEVICEW ddev;
   ddev.cb = sizeof(ddev);
 
+  ezMap<ezString, ezString> monitorNames;
+  QueryMonitorNames(monitorNames);
+
   if (EnumDisplayDevicesW(info.szDevice, 0, &ddev, 1) != FALSE)
   {
-    mon.m_sDisplayName = ddev.DeviceString;
+    ezStringBuilder tmp;
+    tmp = ddev.DeviceID;
+
+    if (auto it = monitorNames.Find(tmp); it.IsValid())
+    {
+      mon.m_sDisplayName = it.Value();
+    }
+    else
+    {
+      mon.m_sDisplayName = ddev.DeviceString;
+    }
+
+    EnumerateDisplayModes(mon.m_sDisplayID, mon.m_SupportedResolutions);
   }
 
   return TRUE;

--- a/Code/Engine/Foundation/Platform/Win/Screen_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/Screen_Win.cpp
@@ -8,9 +8,9 @@
 EZ_DEFINE_AS_POD_TYPE(DISPLAYCONFIG_PATH_INFO);
 EZ_DEFINE_AS_POD_TYPE(DISPLAYCONFIG_MODE_INFO);
 
-static void QueryMonitorNames(ezMap<ezString, ezString>& out_DeviceIDtoName)
+static void QueryMonitorNames(ezMap<ezString, ezString>& out_deviceIDtoName)
 {
-  out_DeviceIDtoName.Clear();
+  out_deviceIDtoName.Clear();
 
   ezHybridArray<DISPLAYCONFIG_PATH_INFO, 4> paths;
   ezHybridArray<DISPLAYCONFIG_MODE_INFO, 4> modes;
@@ -56,16 +56,16 @@ static void QueryMonitorNames(ezMap<ezString, ezString>& out_DeviceIDtoName)
     if (targetName.flags.friendlyNameFromEdid)
     {
       tmp = targetName.monitorDevicePath;
-      out_DeviceIDtoName[tmp] = targetName.monitorFriendlyDeviceName;
+      out_deviceIDtoName[tmp] = targetName.monitorFriendlyDeviceName;
     }
   }
 }
 
-static void EnumerateDisplayModes(ezStringView deviceName, ezDynamicArray<ezScreenResolution>& inout_Modes)
+static void EnumerateDisplayModes(ezStringView sDeviceName, ezDynamicArray<ezScreenResolution>& inout_modes)
 {
-  inout_Modes.Clear();
+  inout_modes.Clear();
 
-  const ezStringWChar wName(deviceName);
+  const ezStringWChar wName(sDeviceName);
 
   DEVMODEW devMode = {};
   devMode.dmSize = sizeof(DEVMODEW);
@@ -73,17 +73,17 @@ static void EnumerateDisplayModes(ezStringView deviceName, ezDynamicArray<ezScre
   int modeNum = 0;
   while (EnumDisplaySettingsW(wName.GetData(), modeNum++, &devMode))
   {
-    ezScreenResolution& mode = inout_Modes.ExpandAndGetRef();
+    ezScreenResolution& mode = inout_modes.ExpandAndGetRef();
     mode.m_uiResolutionX = devMode.dmPelsWidth;
     mode.m_uiResolutionY = devMode.dmPelsHeight;
     mode.m_uiBitsPerPixel = static_cast<ezUInt8>(devMode.dmBitsPerPel);
     mode.m_uiRefreshRate = static_cast<ezUInt16>(devMode.dmDisplayFrequency);
   }
 
-  inout_Modes.Sort();
+  inout_modes.Sort();
 }
 
-BOOL CALLBACK ezMonitorEnumProc(HMONITOR pMonitor, HDC pHdcMonitor, LPRECT pLprcMonitor, LPARAM data)
+static BOOL CALLBACK ezMonitorEnumProc(HMONITOR pMonitor, HDC pHdcMonitor, LPRECT pLprcMonitor, LPARAM data)
 {
   EZ_IGNORE_UNUSED(pHdcMonitor);
   EZ_IGNORE_UNUSED(pLprcMonitor);

--- a/Code/Engine/Foundation/Platform/Win/Screen_Win.cpp
+++ b/Code/Engine/Foundation/Platform/Win/Screen_Win.cpp
@@ -76,8 +76,8 @@ static void EnumerateDisplayModes(ezStringView deviceName, ezDynamicArray<ezScre
     ezScreenResolution& mode = inout_Modes.ExpandAndGetRef();
     mode.m_uiResolutionX = devMode.dmPelsWidth;
     mode.m_uiResolutionY = devMode.dmPelsHeight;
-    mode.m_uiBitsPerPixel = devMode.dmBitsPerPel;
-    mode.m_uiRefreshRate = devMode.dmDisplayFrequency;
+    mode.m_uiBitsPerPixel = static_cast<ezUInt8>(devMode.dmBitsPerPel);
+    mode.m_uiRefreshRate = static_cast<ezUInt16>(devMode.dmDisplayFrequency);
   }
 
   inout_Modes.Sort();

--- a/Code/Engine/Foundation/System/Screen.h
+++ b/Code/Engine/Foundation/System/Screen.h
@@ -5,9 +5,34 @@
 #include <Foundation/Math/Size.h>
 #include <Foundation/Strings/String.h>
 
+struct ezScreenResolution
+{
+  EZ_DECLARE_POD_TYPE();
+
+  ezUInt32 m_uiResolutionX = 0;
+  ezUInt32 m_uiResolutionY = 0;
+  ezUInt16 m_uiRefreshRate = 0;
+  ezUInt8 m_uiBitsPerPixel = 0;
+
+  inline bool operator<(const ezScreenResolution& rhs) const
+  {
+    if (m_uiBitsPerPixel != rhs.m_uiBitsPerPixel)
+      return m_uiBitsPerPixel < rhs.m_uiBitsPerPixel;
+
+    if (m_uiRefreshRate != rhs.m_uiRefreshRate)
+      return m_uiRefreshRate < rhs.m_uiRefreshRate;
+
+    if (m_uiResolutionX != rhs.m_uiResolutionX)
+      return m_uiResolutionX < rhs.m_uiResolutionX;
+
+    return m_uiResolutionY < rhs.m_uiResolutionY;
+  }
+};
+
 /// \brief Describes the properties of a screen
 struct EZ_FOUNDATION_DLL ezScreenInfo
 {
+  ezString m_sDisplayID;   ///< Internal name used by the OS to identify the monitor.
   ezString m_sDisplayName; ///< Some OS provided name for the screen, typically the manufacturer and model name.
 
   ezInt32 m_iOffsetX;      ///< The virtual position of the screen. Ie. a window created at this location will appear on this screen.
@@ -15,6 +40,8 @@ struct EZ_FOUNDATION_DLL ezScreenInfo
   ezInt32 m_iResolutionX;  ///< The virtual resolution. Ie. a window with this dimension will span the entire screen.
   ezInt32 m_iResolutionY;  ///< The virtual resolution. Ie. a window with this dimension will span the entire screen.
   bool m_bIsPrimary;       ///< Whether this is the primary/main screen.
+
+  ezDynamicArray<ezScreenResolution> m_SupportedResolutions;
 };
 
 /// \brief Provides functionality to detect available monitors

--- a/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
@@ -97,7 +97,7 @@ void ezRmlUiCanvas2DComponent::Update()
   if (m_pContext == nullptr)
     return;
 
-  ezTime tDiff = GetWorld()->GetClock().GetTimeDiff();
+  const ezTime tDiff = ezClock::GetGlobalClock()->GetTimeDiff();
   bool bNeedsUpdate = m_pContext->GetNextUpdateDelay() < ezMath::Max(tDiff.GetSeconds(), 1.0 / 240.0);
 
   ezVec2 viewSize = ezVec2::MakeZero();


### PR DESCRIPTION
Fixed that open RML documents would swallow input and thus break input pass-through in a running game.
Also added that ezScreen reports proper monitor names and the supported resolutions.