### PR TITLE
Make standard app input configurable through ezGameState

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -677,7 +677,7 @@ bool ezEngineProcessGameApplication::Run_ProcessApplicationInput()
   {
     if (m_pGameState)
     {
-      m_pGameState->RequestQuit();
+      m_pGameState->RequestQuit("editor-esc");
     }
   }
   else

--- a/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/SceneContext/SceneContext.cpp
@@ -468,8 +468,6 @@ void ezSceneContext::OnSimulationEnabled()
 
   ezResourceManager::ReloadAllResources(false);
 
-  ezGameApplication::GetGameApplicationInstance()->ReinitializeInputConfig();
-
   if (ezSoundInterface* pSoundInterface = ezSingletonRegistry::GetSingletonInstance<ezSoundInterface>())
   {
     pSoundInterface->SetListenerOverrideMode(true);
@@ -644,8 +642,6 @@ void ezSceneContext::OnPlayTheGameModeStarted(ezStringView sStartPosition, const
   m_pWorld->GetClock().SetSpeed(1.0f);
   m_pWorld->SetWorldSimulationEnabled(true);
 
-  ezGameApplication::GetGameApplicationInstance()->ReinitializeInputConfig();
-
   s_pWorldLinkedWithGameState = m_pWorld;
   ezGameApplicationBase::GetGameApplicationBaseInstance()->ActivateGameState(m_pWorld, sStartPosition, startPositionOffset);
 
@@ -741,7 +737,7 @@ void ezSceneContext::HandleGameModeMsg(const ezGameModeMsgToEngine* pMsg)
       return;
 
     ezLog::Info("Attempting to stop Play-the-Game mode");
-    pState->RequestQuit();
+    pState->RequestQuit("editor-force");
   }
 }
 

--- a/Code/Engine/Core/GameApplication/GameApplicationBase.h
+++ b/Code/Engine/Core/GameApplication/GameApplicationBase.h
@@ -223,7 +223,6 @@ protected:
   virtual void Init_LoadWorldModuleConfig();
   virtual void Init_LoadProjectPlugins();
   virtual void Init_PlatformProfile_LoadForRuntime();
-  virtual void Init_ConfigureInput();
   virtual void Init_ConfigureTags();
   virtual void Init_ConfigureCVars();
   virtual void Init_SetupGraphicsDevice() = 0;

--- a/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
+++ b/Code/Engine/Core/GameApplication/Implementation/GameApplicationBaseInit.cpp
@@ -43,7 +43,6 @@ void ezGameApplicationBase::ExecuteInitFunctions()
   Init_LoadWorldModuleConfig();
   Init_LoadProjectPlugins();
   Init_PlatformProfile_LoadForRuntime();
-  Init_ConfigureInput();
   Init_ConfigureTags();
   Init_ConfigureCVars();
   Init_SetupGraphicsDevice();
@@ -204,8 +203,6 @@ void ezGameApplicationBase::Init_PlatformProfile_LoadForRuntime()
 
   m_PlatformProfile.LoadForRuntime(sRuntimeProfileFile).IgnoreResult();
 }
-
-void ezGameApplicationBase::Init_ConfigureInput() {}
 
 void ezGameApplicationBase::Init_ConfigureTags()
 {

--- a/Code/Engine/Core/GameState/GameStateBase.h
+++ b/Code/Engine/Core/GameState/GameStateBase.h
@@ -67,9 +67,16 @@ public:
   /// \brief Call this to signal that a game state requested the application to quit.
   ///
   /// ezGameApplication will shut down when this happens. ezEditor will stop play-the-game mode when it is running.
-  virtual void RequestQuit() = 0;
+  /// When calling this, pass a string to identify where the request comes from, e.g. "window" for when clicking
+  /// the window close button, "game" when game logic (UI) decided to quite, etc.
+  /// ezEditor will pass in "editor-esc" and "editor-force" when a game-state should be shut down due to
+  /// the user pressing Escape or clicking the "stop" button.
+  virtual void RequestQuit(ezStringView sRequestedBy) = 0;
 
   /// \brief Returns whether the game state wants to quit the application.
+  ///
+  /// ezGameApplication will shut down when this function returns true.
+  /// Logic for whether to shut down should typically be handled in RequestQuit().
   virtual bool WasQuitRequested() const = 0;
 
   /// \brief Should be overridden by game states that are only meant as a fallback solution.

--- a/Code/Engine/GameEngine/GameState/GameState.h
+++ b/Code/Engine/GameEngine/GameState/GameState.h
@@ -86,9 +86,9 @@ public:
   /// \brief Simply stores that the game should stop.
   ///
   /// Override this to add more elaborate logic, if necessary.
-  virtual void RequestQuit() override;
+  virtual void RequestQuit(ezStringView sRequestedBy) override;
 
-  /// \brief Whether WasQuitRequested() was called before.
+  /// \brief Whether RequestQuit() was called before.
   virtual bool WasQuitRequested() const override;
 
   /// \brief The ezGameState doesn't implement any input logic, but it forwards to UpdateBackgroundSceneLoading().

--- a/Code/Engine/GameEngine/GameState/Implementation/FallbackGameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/FallbackGameState.cpp
@@ -105,6 +105,8 @@ static void RegisterInputAction(const char* szInputSet, const char* szInputActio
 
 void ezFallbackGameState::ConfigureInputActions()
 {
+  SUPER::ConfigureInputActions();
+
   g_AllInput.Clear();
 
   RegisterInputAction("Game", "MoveForwards", ezInputSlot_KeyW);

--- a/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
+++ b/Code/Engine/GameEngine/GameState/Implementation/GameState.cpp
@@ -111,7 +111,7 @@ void ezGameState::AddMainViewsToRender()
   }
 }
 
-void ezGameState::RequestQuit()
+void ezGameState::RequestQuit(ezStringView sRequestedBy)
 {
   m_bStateWantsToQuit = true;
 }
@@ -275,7 +275,17 @@ void ezGameState::CreateActors()
 
 void ezGameState::ConfigureMainWindowInputDevices(ezWindow* pWindow) {}
 
-void ezGameState::ConfigureInputActions() {}
+void ezGameState::ConfigureInputActions()
+{
+  if (auto pApp = ezGameApplication::GetGameApplicationInstance())
+  {
+    // shipped games should have their own game state
+    // they should probably only use ezGameApplicationInputFlags::LoadInputConfig
+    // if you've come to the point where you want to use the ESC key (for instance to show a menu)
+    // you also need to have your own game-state and remove the flag ezGameApplicationInputFlags::Dev_EscapeToClose
+    pApp->RegisterGameApplicationInputActions(ezGameApplicationInputFlags::All);
+  }
+}
 
 void ezGameState::SetupMainView(ezGALSwapChainHandle hSwapChain, ezSizeU32 viewportSize)
 {
@@ -494,7 +504,7 @@ ezUniquePtr<ezWindow> ezGameState::CreateMainWindow()
 
   ezUniquePtr<ezGameStateWindow> pWindow = EZ_DEFAULT_NEW(ezGameStateWindow, wndDesc, [] {});
   pWindow->ResetOnClickClose([this]()
-    { this->RequestQuit(); });
+    { this->RequestQuit("window"); });
   if (pWindow->GetInputDevice())
     pWindow->GetInputDevice()->SetMouseSpeed(ezVec2(0.02f));
 

--- a/Code/Tools/ShaderCompiler/ShaderCompiler.h
+++ b/Code/Tools/ShaderCompiler/ShaderCompiler.h
@@ -21,7 +21,6 @@ private:
   virtual void AfterCoreSystemsStartup() override;
   virtual void Init_LoadProjectPlugins() override {}
   virtual void Init_SetupDefaultResources() override {}
-  virtual void Init_ConfigureInput() override {}
   virtual void Init_ConfigureTags() override {}
   virtual bool Run_ProcessApplicationInput() override { return true; }
 

--- a/Data/Samples/RTS/CppSource/RTSPlugin/GameState/Input.cpp
+++ b/Data/Samples/RTS/CppSource/RTSPlugin/GameState/Input.cpp
@@ -15,7 +15,17 @@ void RTSGameState::ConfigureMainWindowInputDevices(ezWindow* pWindow)
 
 void RTSGameState::ConfigureInputActions()
 {
-  SUPER::ConfigureInputActions();
+  // do NOT call the base implementation, because we don't want the default setup
+  // instead, go to ezGameApplication directly and only set up what we want
+  // SUPER::ConfigureInputActions();
+
+  if (auto pApp = ezGameApplication::GetGameApplicationInstance())
+  {
+    ezBitflags<ezGameApplicationInputFlags> flags = ezGameApplicationInputFlags::All;
+    flags.Remove(ezGameApplicationInputFlags::Dev_EscapeToClose); // remove the "ESC to quit" functionality
+    pApp->RegisterGameApplicationInputActions(flags);
+  }
+
 
   ezInputActionConfig cfg;
 

--- a/Data/Samples/RTS/CppSource/RTSPlugin/GameState/RTSGameState.cpp
+++ b/Data/Samples/RTS/CppSource/RTSPlugin/GameState/RTSGameState.cpp
@@ -21,6 +21,25 @@ RTSGameState::RTSGameState()
 
 RTSGameState::~RTSGameState() = default;
 
+void RTSGameState::RequestQuit(ezStringView sRequestedBy)
+{
+  if (sRequestedBy == "window")
+  {
+    // we could do something when the window close button gets pressed
+    // for example show the main menu with the option to quit the game
+  }
+
+  if (sRequestedBy == "editor-esc")
+  {
+    // sent when the ESC key was pressed while playing in the editor
+    // but only when ezGameApplicationInputFlags::Dev_EscapeToClose is used
+    // by default this is on, but deactivated in this sample in RTSGameState::ConfigureInputActions()
+  }
+
+  // by default, just quit, but we could filter this out in certain cases
+  SUPER::RequestQuit(sRequestedBy);
+}
+
 ezString RTSGameState::GetStartupSceneFile()
 {
   // replace this to load a certain scene at startup

--- a/Data/Samples/RTS/CppSource/RTSPlugin/GameState/RTSGameState.h
+++ b/Data/Samples/RTS/CppSource/RTSPlugin/GameState/RTSGameState.h
@@ -36,6 +36,8 @@ public:
 
   static RTSGameState* GetSingleton() { return s_pSingleton; }
 
+  virtual void RequestQuit(ezStringView sRequestedBy) override;
+
 protected:
   virtual void ConfigureMainCamera() override;
   virtual void OnChangedMainWorld(ezWorld* pPrevWorld, ezWorld* pNewWorld, ezStringView sStartPosition, const ezTransform& startPositionOffset) override;


### PR DESCRIPTION
ezGameApplication has some standard input setup.
For example this implements that ESC always closes the application, and F5 shows the FPS counter, etc.
This is now configurable. The ezGameState makes the call to set this up, and custom game states can this decide not to do this. The RTS sample now uses this to deactivate the ESC key. In the future it may then show an ingame menu instead.