### PR TITLE
Fix for Background Asset Transformation does not start

### DIFF
--- a/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
+++ b/Code/Engine/Foundation/Communication/Implementation/IpcProcessMessageProtocol.cpp
@@ -50,6 +50,12 @@ bool ezIpcProcessMessageProtocol::ProcessMessages()
 
 ezResult ezIpcProcessMessageProtocol::WaitForMessages(ezTime timeout)
 {
+  // Message processing can be interrupted via the m_bInterruptMessageProcessing flag. Thus, there is no guarantee that the queue is empty at this point. Only wait if the queue is empty.
+  if (ProcessMessages())
+  {
+    return EZ_SUCCESS;
+  }
+
   ezResult res = m_pChannel->WaitForMessages(timeout);
   if (res.Succeeded())
   {


### PR DESCRIPTION
This regression was introduced with #1638 which added the option to interrupt message processing in the queue. This broke the assumption that if `WaitForMessages` was called all messages up to that point would be processed and the `m_IncomingMessages` would only be triggered if new messages arrived. However, as `ezIpcProcessMessageProtocol::WaitForMessages` did not check if there are still messages in the incoming buffer, it would wait for mew messages to arrive before processing the already arrived messages. Due to bad timing when the other side was waiting for a message, this could cause a deadlock between the two sides.   Fixes #1656.