### PR TITLE
Bind Group Resource

### DIFF
--- a/Code/Engine/RendererCore/Material/MaterialManager.h
+++ b/Code/Engine/RendererCore/Material/MaterialManager.h
@@ -3,8 +3,8 @@
 #include <Foundation/Configuration/Singleton.h>
 #include <Foundation/Memory/FrameAllocator.h>
 #include <RendererCore/Material/MaterialResource.h>
-#include <RendererCore/RenderWorld/RenderWorld.h>
 #include <RendererCore/RenderContext/BindGroupBuilder.h>
+#include <RendererCore/RenderWorld/RenderWorld.h>
 
 class ezGALCommandEncoder;
 struct ezGALDeviceEvent;

--- a/Code/Engine/RendererCore/Material/MaterialManager.h
+++ b/Code/Engine/RendererCore/Material/MaterialManager.h
@@ -4,6 +4,7 @@
 #include <Foundation/Memory/FrameAllocator.h>
 #include <RendererCore/Material/MaterialResource.h>
 #include <RendererCore/RenderWorld/RenderWorld.h>
+#include <RendererCore/RenderContext/BindGroupBuilder.h>
 
 class ezGALCommandEncoder;
 struct ezGALDeviceEvent;
@@ -26,6 +27,9 @@ public:
   /// \brief The material's render data. Accessed via ezMaterialManager::GetMaterialData.
   struct EZ_RENDERERCORE_DLL MaterialData
   {
+    ~MaterialData();
+    void DeleteBindGroups();
+
     ezShaderResourceHandle m_hShader;
     ezMaterialResource::ezMaterialId m_MaterialId; ///< Index into m_hStructuredBufferView
 
@@ -38,6 +42,13 @@ public:
     ezDynamicArray<ezMaterialResourceDescriptor::Parameter> m_Parameters; // Builds constant buffer
     ezDynamicArray<ezMaterialResourceDescriptor::Texture2DBinding> m_Texture2DBindings;
     ezDynamicArray<ezMaterialResourceDescriptor::TextureCubeBinding> m_TextureCubeBindings;
+
+    struct BindGroupCache
+    {
+      ezGALBindGroupLayoutHandle m_hLayout;
+      ezGALBindGroupHandle m_hGroup;
+    };
+    ezHybridArray<BindGroupCache, 2> m_BindGroups;
   };
 
 public:
@@ -50,6 +61,8 @@ public:
   static void MaterialRemoved(ezMaterialResource* pMaterial);
   /// \brief Returns the render data for a material resource. Can be nullptr if the material is not loaded yet or extraction + update was not executed yet.
   static const MaterialData* GetMaterialData(const ezMaterialResource* pMaterial);
+  /// Returns the bind group for the given material resource and layout.
+  static ezGALBindGroupHandle GetMaterialBindGroup(const ezMaterialResource* pMaterial, ezGALBindGroupLayoutHandle hBindGroupLayout);
   /// \brief Fired in case a material is reloaded and now occupies another index / shader.
   static ezEvent<const ezMaterialShaderChanged&, ezMutex> s_MaterialShaderChangedEvent;
 

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -250,7 +250,8 @@ void ezRenderContext::BindMaterial(const ezMaterialResourceHandle& hMaterial)
 {
   // Don't set m_hMaterial directly since we first need to check whether the material has been modified in the mean time.
   m_hNewMaterial = hMaterial;
-  m_StateFlags.Add(ezRenderContextFlags::MaterialBindingChanged);
+  m_StateFlags.Add(ezRenderContextFlags::MaterialBindingChanged | ezRenderContextFlags::BindGroupChanged);
+  m_bDirtyBindGroups[EZ_GAL_BIND_GROUP_MATERIAL] = true;
 }
 
 ezBindGroupBuilder& ezRenderContext::GetBindGroup(ezUInt32 uiBindGroup)
@@ -285,7 +286,11 @@ void ezRenderContext::SetPushConstants(ezTempHashedString sSlotName, ezArrayPtr<
 void ezRenderContext::BindShader(const ezShaderResourceHandle& hShader, ezBitflags<ezShaderBindFlags> flags)
 {
   m_hMaterial.Invalidate();
+  m_pMaterial = nullptr;
+  m_pMaterialBindGroup = nullptr;
+  m_bDirtyBindGroups[EZ_GAL_BIND_GROUP_MATERIAL] = true;
   m_StateFlags.Remove(ezRenderContextFlags::MaterialBindingChanged);
+  m_StateFlags.Add(ezRenderContextFlags::BindGroupChanged);
 
   BindShaderInternal(hShader, flags);
 }
@@ -471,6 +476,7 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
   {
     ApplyMaterialState();
     m_StateFlags.Remove(ezRenderContextFlags::MaterialBindingChanged);
+    m_StateFlags.Add(ezRenderContextFlags::BindGroupChanged);
   }
 
   for (ezUInt32 i = 0; i < EZ_GAL_MAX_BIND_GROUPS; ++i)
@@ -502,7 +508,8 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
       for (ezUInt32 uiBindGroup = 0; uiBindGroup < uiBindGroups; uiBindGroup++)
       {
         const bool bForceBindGroupUpdate = bForce || m_bDirtyBindGroups[uiBindGroup];
-        const bool bBindGroupModified = m_BindGroupBuilders[uiBindGroup].IsModified();
+        const bool bHasMaterialBindGroupResource = uiBindGroup == EZ_GAL_BIND_GROUP_MATERIAL && m_hMaterial.IsValid();
+        const bool bBindGroupModified = m_BindGroupBuilders[uiBindGroup].IsModified() && !bHasMaterialBindGroupResource;
         if (bBindGroupModified)
           m_Statistics.m_uiModifiedBindGroup[uiBindGroup]++;
 
@@ -562,7 +569,15 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
   {
     for (ezUInt32 i = 0; i < m_pActiveGALShader->GetBindGroupCount(); ++i)
     {
-      EZ_ASSERT_DEV(m_pActiveGALShader->GetBindGroupLayout(i) == m_BindGroups[i].m_hBindGroupLayout, "Invalid Bind Group Layout");
+      const bool bHasMaterialBindGroupResource = i == EZ_GAL_BIND_GROUP_MATERIAL && m_hMaterial.IsValid();
+      if (!bHasMaterialBindGroupResource)
+      {
+        EZ_ASSERT_DEV(m_pActiveGALShader->GetBindGroupLayout(i) == m_BindGroups[i].m_hBindGroupLayout, "Invalid Bind Group Layout");
+      }
+      else
+      {
+        EZ_ASSERT_DEV(m_pActiveGALShader->GetBindGroupLayout(i) == m_pMaterialBindGroup->GetDescription().m_hBindGroupLayout, "Invalid Bind Group Resource Layout");
+      }
     }
   }
   return EZ_SUCCESS;
@@ -576,6 +591,8 @@ void ezRenderContext::ResetContextState()
 
   m_hMaterial.Invalidate();
   m_hNewMaterial.Invalidate();
+  m_pMaterial = nullptr;
+  m_pMaterialBindGroup = nullptr;
 
   m_hActiveShader.Invalidate();
   m_PermutationVariables.Clear();
@@ -1072,14 +1089,16 @@ void ezRenderContext::ApplyMaterialState()
   if (!m_hNewMaterial.IsValid())
   {
     BindShaderInternal(ezShaderResourceHandle(), ezShaderBindFlags::Default);
+    m_pMaterial = nullptr;
+    m_pMaterialBindGroup = nullptr;
     return;
   }
 
-  // check whether material has been modified
-  ezResourceLock<ezMaterialResource> pMaterial(m_hNewMaterial, ezResourceAcquireMode::AllowLoadingFallback);
-
   if (m_hNewMaterial != m_hMaterial)
   {
+    // check whether material has been modified
+    ezResourceLock<ezMaterialResource> pMaterial(m_hNewMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+
     const ezMaterialManager::MaterialData* data = ezMaterialManager::GetMaterialData(pMaterial.GetPointer());
     if (data == nullptr)
     {
@@ -1088,33 +1107,14 @@ void ezRenderContext::ApplyMaterialState()
     }
 
     BindShaderInternal(data->m_hShader, ezShaderBindFlags::Default);
-
-    ezBindGroupBuilder& bindGroupMaterial = GetBindGroup(EZ_GAL_BIND_GROUP_MATERIAL);
-    if (!data->m_hStructuredBuffer.IsInvalidated())
-    {
-      bindGroupMaterial.BindBuffer("materialData", data->m_hStructuredBuffer);
-    }
-    else if (!data->m_hConstantBuffer.IsInvalidated())
-    {
-      bindGroupMaterial.BindBuffer("materialData", data->m_hConstantBuffer);
-    }
-
     for (const ezPermutationVar& perm : data->m_PermutationVars)
     {
       SetShaderPermutationVariableInternal(perm.m_sName, perm.m_sValue);
     }
 
-    for (const ezMaterialResourceDescriptor::Texture2DBinding& binding : data->m_Texture2DBindings)
-    {
-      bindGroupMaterial.BindTexture(binding.m_Name, binding.m_Value);
-    }
-
-    for (const ezMaterialResourceDescriptor::TextureCubeBinding& binding : data->m_TextureCubeBindings)
-    {
-      bindGroupMaterial.BindTexture(binding.m_Name, binding.m_Value);
-    }
-
     m_hMaterial = m_hNewMaterial;
+    // We don't know the permutation to use yet and thus also not the correct bind group layout. Therefore, we store the raw address of the material to be able to look up the correct bind group in ApplyBindGroup. We can't acquire the resource lock again as that might result in a different address (fallback vs real) and we would missmatch the material data and bind group from two different materials.
+    m_pMaterial = pMaterial.GetPointer();
   }
 }
 
@@ -1124,6 +1124,18 @@ ezResult ezRenderContext::ApplyBindGroup(const ezGALShader* pShader, ezUInt32 ui
   if (hLayout.IsInvalidated())
     return EZ_FAILURE;
 
+  const bool bHasMaterialBindGroupResource = uiBindGroup == EZ_GAL_BIND_GROUP_MATERIAL && m_hMaterial.IsValid();
+  if (bHasMaterialBindGroupResource)
+  {
+    ezGALBindGroupHandle hBindGroup = ezMaterialManager::GetMaterialBindGroup(m_pMaterial, hLayout);
+    if (hBindGroup.IsInvalidated())
+      return EZ_FAILURE;
+
+    m_pMaterialBindGroup = m_pGALCommandEncoder->GetDevice().GetBindGroup(hBindGroup);
+
+    m_pGALCommandEncoder->SetBindGroup(uiBindGroup, hBindGroup);
+    return EZ_SUCCESS;
+  }
   m_BindGroupBuilders[uiBindGroup].CreateBindGroup(hLayout, m_BindGroups[uiBindGroup]);
   m_pGALCommandEncoder->SetBindGroup(uiBindGroup, m_BindGroups[uiBindGroup]);
   return EZ_SUCCESS;

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -277,7 +277,7 @@ private:
   // Material
   ezMaterialResourceHandle m_hNewMaterial;
   ezMaterialResourceHandle m_hMaterial;
-  const ezMaterialResource* m_pMaterial = nullptr; ///< Must never be accessed, just used as key to ezMaterialManager::GetMaterialBindGroup
+  const ezMaterialResource* m_pMaterial = nullptr;      ///< Must never be accessed, just used as key to ezMaterialManager::GetMaterialBindGroup
   const ezGALBindGroup* m_pMaterialBindGroup = nullptr; ///< Only stored here to assert is we generate a layout missmatch.
 
   // Shader Resource

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -277,6 +277,8 @@ private:
   // Material
   ezMaterialResourceHandle m_hNewMaterial;
   ezMaterialResourceHandle m_hMaterial;
+  const ezMaterialResource* m_pMaterial = nullptr; ///< Must never be accessed, just used as key to ezMaterialManager::GetMaterialBindGroup
+  const ezGALBindGroup* m_pMaterialBindGroup = nullptr; ///< Only stored here to assert is we generate a layout missmatch.
 
   // Shader Resource
   ezShaderResourceHandle m_hActiveShader;

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -32,6 +32,7 @@ public:
   // ezGALCommandEncoderCommonPlatformInterface
   // State setting functions
   virtual void SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroupCreationDescription& bindGroup) override;
+  virtual void SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroup* pBindGroup) override;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) override;
 
   // GPU -> CPU query functions

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -214,6 +214,12 @@ void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, con
   }
 }
 
+void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroup* pBindGroup)
+{
+  // There is no way to persist bind groups in DX11, so this just redirects to the transient bind group code path.
+  SetBindGroupPlatform(uiBindGroup, pBindGroup->GetDescription());
+}
+
 void ezGALCommandEncoderImplDX11::SetConstantBuffer(const ezShaderResourceBinding& binding, const ezGALBuffer* pBuffer)
 {
   EZ_ASSERT_RELEASE(binding.m_iSlot < EZ_GAL_MAX_CONSTANT_BUFFER_COUNT, "Constant buffer slot index too big!");

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -92,6 +92,9 @@ protected:
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) override;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) override;
 
+  virtual ezGALBindGroup* CreateBindGroupPlatform(const ezGALBindGroupCreationDescription& Description) override;
+  virtual void DestroyBindGroupPlatform(ezGALBindGroup* pBindGroup) override;
+
   virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) override;
   virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) override;
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -16,8 +16,8 @@
 #include <RendererDX11/Resources/RenderTargetViewDX11.h>
 #include <RendererDX11/Resources/SharedTextureDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
-#include <RendererDX11/Shader/BindGroupLayoutDX11.h>
 #include <RendererDX11/Shader/BindGroupDX11.h>
+#include <RendererDX11/Shader/BindGroupLayoutDX11.h>
 #include <RendererDX11/Shader/PipelineLayoutDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -17,6 +17,7 @@
 #include <RendererDX11/Resources/SharedTextureDX11.h>
 #include <RendererDX11/Resources/TextureDX11.h>
 #include <RendererDX11/Shader/BindGroupLayoutDX11.h>
+#include <RendererDX11/Shader/BindGroupDX11.h>
 #include <RendererDX11/Shader/PipelineLayoutDX11.h>
 #include <RendererDX11/Shader/ShaderDX11.h>
 #include <RendererDX11/Shader/VertexDeclarationDX11.h>
@@ -469,6 +470,29 @@ void ezGALDeviceDX11::DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBind
   pDX11BindGroupLayout->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pDX11BindGroupLayout);
 }
+
+ezGALBindGroup* ezGALDeviceDX11::CreateBindGroupPlatform(const ezGALBindGroupCreationDescription& Description)
+{
+  ezGALBindGroupDX11* pDX11BindGroup = EZ_NEW(&m_Allocator, ezGALBindGroupDX11, Description);
+
+  if (pDX11BindGroup->InitPlatform(this).Succeeded())
+  {
+    return pDX11BindGroup;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pDX11BindGroup);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceDX11::DestroyBindGroupPlatform(ezGALBindGroup* pBindGroup)
+{
+  ezGALBindGroupDX11* pDX11BindGroup = static_cast<ezGALBindGroupDX11*>(pBindGroup);
+  pDX11BindGroup->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pDX11BindGroup);
+}
+
 
 ezGALPipelineLayout* ezGALDeviceDX11::CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description)
 {

--- a/Code/Engine/RendererDX11/Shader/BindGroupDX11.h
+++ b/Code/Engine/RendererDX11/Shader/BindGroupDX11.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <RendererDX11/RendererDX11DLL.h>
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/BindGroup.h>
+
+class ezGALBindGroupDX11 : public ezGALBindGroup
+{
+public:
+protected:
+  friend class ezGALDeviceDX11;
+  friend class ezMemoryUtils;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void Invalidate(ezGALDevice* pDevice) override;
+  virtual bool IsInvalidated() const override;
+  virtual void SetDebugNamePlatform(const char* szName) const override;
+
+  ezGALBindGroupDX11(const ezGALBindGroupCreationDescription& Description);
+
+  virtual ~ezGALBindGroupDX11();
+
+private:
+  bool m_bInvalidated = false;
+};

--- a/Code/Engine/RendererDX11/Shader/Implementation/BindGroupDX11.cpp
+++ b/Code/Engine/RendererDX11/Shader/Implementation/BindGroupDX11.cpp
@@ -7,17 +7,17 @@ ezGALBindGroupDX11::ezGALBindGroupDX11(const ezGALBindGroupCreationDescription& 
 
 ezGALBindGroupDX11::~ezGALBindGroupDX11() = default;
 
-ezResult ezGALBindGroupDX11::InitPlatform(ezGALDevice* pDevice)
+ezResult ezGALBindGroupDX11::InitPlatform(ezGALDevice*)
 {
   return EZ_SUCCESS;
 }
 
-ezResult ezGALBindGroupDX11::DeInitPlatform(ezGALDevice* pDevice)
+ezResult ezGALBindGroupDX11::DeInitPlatform(ezGALDevice*)
 {
   return EZ_SUCCESS;
 }
 
-void ezGALBindGroupDX11::Invalidate(ezGALDevice* pDevice)
+void ezGALBindGroupDX11::Invalidate(ezGALDevice*)
 {
   m_bInvalidated = true;
 }
@@ -27,6 +27,6 @@ bool ezGALBindGroupDX11::IsInvalidated() const
   return m_bInvalidated;
 }
 
-void ezGALBindGroupDX11::SetDebugNamePlatform(const char* szName) const
+void ezGALBindGroupDX11::SetDebugNamePlatform(const char*) const
 {
 }

--- a/Code/Engine/RendererDX11/Shader/Implementation/BindGroupDX11.cpp
+++ b/Code/Engine/RendererDX11/Shader/Implementation/BindGroupDX11.cpp
@@ -1,0 +1,32 @@
+#include <RendererDX11/Shader/BindGroupDX11.h>
+
+ezGALBindGroupDX11::ezGALBindGroupDX11(const ezGALBindGroupCreationDescription& Description)
+  : ezGALBindGroup(Description)
+{
+}
+
+ezGALBindGroupDX11::~ezGALBindGroupDX11() = default;
+
+ezResult ezGALBindGroupDX11::InitPlatform(ezGALDevice* pDevice)
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALBindGroupDX11::DeInitPlatform(ezGALDevice* pDevice)
+{
+  return EZ_SUCCESS;
+}
+
+void ezGALBindGroupDX11::Invalidate(ezGALDevice* pDevice)
+{
+  m_bInvalidated = true;
+}
+
+bool ezGALBindGroupDX11::IsInvalidated() const
+{
+  return m_bInvalidated;
+}
+
+void ezGALBindGroupDX11::SetDebugNamePlatform(const char* szName) const
+{
+}

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoder.h
@@ -42,9 +42,16 @@ public:
   /// - Texture ranges: Mip levels and array slices within bounds
   /// - Make sure no proxy texture is present
   ///
-  /// \param uiBindGroup The bind group slot index to set
+  /// \param uiBindGroup The bind group set index to set
   /// \param bindGroup Description containing the layout and resource items to bind
   void SetBindGroup(ezUInt32 uiBindGroup, const ezGALBindGroupCreationDescription& bindGroup);
+
+  /// \brief Sets a bind group resource to the given bind group index.
+  /// As there are two functions to set bind groups (this one and the overload for transient bind groups) the last call takes precedence if both functions are called for the same index.
+  /// \param uiBindGroup The bind group set index to set
+  /// \param hBindGroup Handle to the bind group that is to be used.
+  void SetBindGroup(ezUInt32 uiBindGroup, ezGALBindGroupHandle hBindGroup);
+
   void SetPushConstants(ezArrayPtr<const ezUInt8> data);
 
   // GPU -> CPU query functions

--- a/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
+++ b/Code/Engine/RendererFoundation/CommandEncoder/CommandEncoderPlatformInterface.h
@@ -15,6 +15,7 @@ class EZ_RENDERERFOUNDATION_DLL ezGALCommandEncoderCommonPlatformInterface
 public:
   // Resource binding functions
   virtual void SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroupCreationDescription& bindGroup) = 0;
+  virtual void SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroup* pBindGroup) = 0;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) = 0;
 
   // GPU -> CPU query functions

--- a/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
+++ b/Code/Engine/RendererFoundation/CommandEncoder/Implementation/CommandEncoder.cpp
@@ -1,6 +1,3 @@
-#include "RendererFoundation/Shader/BindGroup.h"
-
-
 #include <RendererFoundation/RendererFoundationPCH.h>
 
 #include <Foundation/Logging/Log.h>
@@ -9,9 +6,8 @@
 #include <RendererFoundation/Resources/Buffer.h>
 #include <RendererFoundation/Resources/ReadbackBuffer.h>
 #include <RendererFoundation/Resources/ReadbackTexture.h>
-
 #include <RendererFoundation/Resources/Texture.h>
-
+#include <RendererFoundation/Shader/BindGroup.h>
 #include <RendererFoundation/Shader/BindGroupLayout.h>
 
 void ezGALCommandEncoder::SetBindGroup(ezUInt32 uiBindGroup, const ezGALBindGroupCreationDescription& bindGroup)
@@ -22,167 +18,20 @@ void ezGALCommandEncoder::SetBindGroup(ezUInt32 uiBindGroup, const ezGALBindGrou
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
   {
     EZ_LOG_BLOCK("SetBindGroup");
-    const ezGALBindGroupLayout* pLayout = m_Device.GetBindGroupLayout(bindGroup.m_hBindGroupLayout);
-    ezArrayPtr<const ezShaderResourceBinding> bindings = pLayout->GetDescription().m_ResourceBindings;
-    ezArrayPtr<const ezGALBindGroupItem> items = bindGroup.m_BindGroupItems;
-    EZ_ASSERT_ALWAYS(bindings.GetCount() == items.GetCount(), "Missmatch between bindings and item count");
-    const ezUInt32 uiBindings = bindings.GetCount();
-    for (ezUInt32 i = 0; i < uiBindings; ++i)
-    {
-      const ezShaderResourceBinding& binding = bindings[i];
-      const ezGALBindGroupItem& item = items[i];
-      const ezBitflags<ezGALShaderResourceCategory> category = ezGALShaderResourceCategory::MakeFromShaderDescriptorType(binding.m_ResourceType);
-
-      switch (binding.m_ResourceType)
-      {
-        case ezGALShaderResourceType::Sampler:
-        {
-          EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Sampler), "Item type does not match binding");
-          const ezGALSamplerState* pSampler = m_Device.GetSamplerState(item.m_Sampler.m_hSampler);
-          EZ_ASSERT_ALWAYS(pSampler != nullptr, "Invalid sampler state");
-        }
-        break;
-
-        case ezGALShaderResourceType::ConstantBuffer:
-        {
-          EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Buffer), "Item type does not match binding");
-          const ezGALBuffer* pBuffer = m_Device.GetBuffer(item.m_Buffer.m_hBuffer);
-          EZ_ASSERT_ALWAYS(pBuffer != nullptr, "Invalid buffer");
-          EZ_ASSERT_ALWAYS(item.m_Buffer.m_OverrideTexelBufferFormat == ezGALResourceFormat::Invalid, "m_OverrideTexelBufferFormat must be Invalid for constant buffers");
-          EZ_ASSERT_ALWAYS(item.m_Buffer.m_BufferRange.m_uiByteOffset == 0, "Byte offset for constant buffers not supported yet");
-          EZ_ASSERT_ALWAYS(item.m_Buffer.m_BufferRange.m_uiByteCount == pBuffer->GetDescription().m_uiTotalSize, "Byte count for constant buffers not supported yet");
-        }
-        break;
-        case ezGALShaderResourceType::TexelBuffer:
-        case ezGALShaderResourceType::StructuredBuffer:
-        case ezGALShaderResourceType::ByteAddressBuffer:
-        case ezGALShaderResourceType::TexelBufferRW:
-        case ezGALShaderResourceType::StructuredBufferRW:
-        case ezGALShaderResourceType::ByteAddressBufferRW:
-        {
-
-          EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Buffer), "Item type does not match binding");
-          const ezGALBuffer* pBuffer = m_Device.GetBuffer(item.m_Buffer.m_hBuffer);
-          EZ_ASSERT_ALWAYS(pBuffer != nullptr, "Invalid buffer");
-          const ezGALBufferCreationDescription& bufferDesc = pBuffer->GetDescription();
-          EZ_ASSERT_ALWAYS((binding.m_ResourceType == ezGALShaderResourceType::TexelBuffer || binding.m_ResourceType == ezGALShaderResourceType::TexelBufferRW) || item.m_Buffer.m_OverrideTexelBufferFormat == ezGALResourceFormat::Invalid, "m_OverrideTexelBufferFormat must be Invalid for non-texel buffers");
-          EZ_ASSERT_ALWAYS((binding.m_ResourceType != ezGALShaderResourceType::TexelBuffer && binding.m_ResourceType != ezGALShaderResourceType::TexelBufferRW) || bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::TexelBuffer), "TexelBuffer bindings are only supported on texel buffers");
-          EZ_ASSERT_ALWAYS((binding.m_ResourceType != ezGALShaderResourceType::StructuredBuffer && binding.m_ResourceType != ezGALShaderResourceType::StructuredBufferRW) || bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer), "StructuredBuffer bindings are only supported on structured buffers");
-          EZ_ASSERT_ALWAYS((binding.m_ResourceType != ezGALShaderResourceType::ByteAddressBuffer && binding.m_ResourceType != ezGALShaderResourceType::ByteAddressBufferRW) || bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ByteAddressBuffer), "ByteAddressBuffer bindings are only supported on byte address buffers");
-
-          if (category.IsSet(ezGALShaderResourceCategory::BufferSRV))
-          {
-            EZ_ASSERT_ALWAYS(bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ShaderResource), "Buffer must have the ShaderResource flag set to be used as an SRV");
-          }
-          if (category.IsSet(ezGALShaderResourceCategory::BufferUAV))
-          {
-            EZ_ASSERT_ALWAYS(bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::UnorderedAccess), "Buffer must have the UnorderedAccess flag set to be used as an UAV");
-          }
-
-          ezUInt32 uiBytesPerElement = 4; // ByteAddress must be multiple of 4
-          if (binding.m_ResourceType == ezGALShaderResourceType::StructuredBuffer || binding.m_ResourceType == ezGALShaderResourceType::StructuredBufferRW)
-          {
-            uiBytesPerElement = bufferDesc.m_uiStructSize;
-          }
-          else if (binding.m_ResourceType == ezGALShaderResourceType::TexelBuffer || binding.m_ResourceType == ezGALShaderResourceType::TexelBufferRW)
-          {
-            const ezGALResourceFormat::Enum viewFormat = item.m_Buffer.m_OverrideTexelBufferFormat == ezGALResourceFormat::Invalid ? bufferDesc.m_Format : item.m_Buffer.m_OverrideTexelBufferFormat;
-            uiBytesPerElement = ezGALResourceFormat::GetBitsPerElement(viewFormat) / 8;
-          }
-
-          ezGALBufferRange range = item.m_Buffer.m_BufferRange;
-          if ((range.m_uiByteOffset % uiBytesPerElement) != 0)
-          {
-            EZ_REPORT_FAILURE("m_uiByteOffset {} is not a multiple of the element size {}", range.m_uiByteOffset, uiBytesPerElement);
-          }
-          if (range.m_uiByteOffset >= bufferDesc.m_uiTotalSize)
-          {
-            EZ_REPORT_FAILURE("m_uiByteOffset {} is too big for the buffer of size {}", range.m_uiByteOffset, bufferDesc.m_uiTotalSize);
-          }
-
-          if (range.m_uiByteCount != EZ_GAL_WHOLE_SIZE)
-          {
-            if ((range.m_uiByteCount % uiBytesPerElement) != 0)
-            {
-              EZ_REPORT_FAILURE("m_uiByteCount {} is not a multiple of the element size {}", range.m_uiByteCount, uiBytesPerElement);
-            }
-            if (range.m_uiByteOffset + range.m_uiByteCount > bufferDesc.m_uiTotalSize)
-            {
-              EZ_REPORT_FAILURE("m_uiByteOffset {} + m_uiByteCount {} = {} is too big for the buffer of size {}", range.m_uiByteOffset, range.m_uiByteCount, range.m_uiByteOffset + range.m_uiByteCount, bufferDesc.m_uiTotalSize);
-            }
-          }
-        }
-        break;
-        case ezGALShaderResourceType::Texture:
-        case ezGALShaderResourceType::TextureRW:
-        case ezGALShaderResourceType::TextureAndSampler:
-        {
-          EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Texture), "Item type does not match binding");
-          const ezGALTexture* pTexture = m_Device.GetTexture(item.m_Texture.m_hTexture);
-          EZ_ASSERT_ALWAYS(pTexture != nullptr, "Invalid texture");
-          const auto& textureDesc = pTexture->GetDescription();
-
-          if (item.m_Texture.m_OverrideViewFormat != ezGALResourceFormat::Invalid)
-          {
-            const ezEnum<ezGALResourceFormat> format = pTexture->GetDescription().m_Format;
-            const ezEnum<ezGALResourceFormat> overrideFormat = item.m_Texture.m_OverrideViewFormat;
-            EZ_ASSERT_ALWAYS(ezGALResourceFormat::GetBitsPerElement(format) == ezGALResourceFormat::GetBitsPerElement(overrideFormat), "Format override bits per element ({}) must match the same on the original format ({})", ezGALResourceFormat::GetBitsPerElement(overrideFormat), ezGALResourceFormat::GetBitsPerElement(format));
-            EZ_ASSERT_ALWAYS(ezGALResourceFormat::GetChannelCount(format) == ezGALResourceFormat::GetChannelCount(overrideFormat), "Format override channel count ({}) must match the same on the original format ({})", ezGALResourceFormat::GetChannelCount(overrideFormat), ezGALResourceFormat::GetChannelCount(format));
-          }
-          // TODO item.m_Texture.m_OverrideTexelBufferFormat
-          if (binding.m_ResourceType == ezGALShaderResourceType::TextureAndSampler)
-          {
-            const ezGALSamplerState* pSampler = m_Device.GetSamplerState(item.m_Texture.m_hSampler);
-            EZ_ASSERT_ALWAYS(pSampler != nullptr, "Invalid sampler state");
-          }
-
-          const ezGALTextureRange range = item.m_Texture.m_TextureRange;
-
-          if (!ezGALShaderTextureType::IsArray(binding.m_TextureType))
-          {
-            if (binding.m_TextureType == ezGALShaderTextureType::TextureCube)
-            {
-              EZ_ASSERT_ALWAYS(range.m_uiArraySlices == 6, "m_uiArraySlices must be 6 for a cube texture binding");
-            }
-            else
-            {
-              EZ_ASSERT_ALWAYS(range.m_uiArraySlices == 1, "m_uiArraySlices must be 1 for non array bindings");
-            }
-          }
-
-          EZ_ASSERT_ALWAYS(ezGALShaderTextureType::IsMSAA(binding.m_TextureType) == (textureDesc.m_SampleCount != ezGALMSAASampleCount::None), "MSAA missmatch between texture and binding");
-
-          if (category.IsSet(ezGALShaderResourceCategory::TextureSRV))
-          {
-            EZ_ASSERT_ALWAYS(textureDesc.m_bAllowShaderResourceView, "Texture must have the m_bAllowShaderResourceView bool set to be used as an SRV");
-          }
-          if (category.IsSet(ezGALShaderResourceCategory::TextureUAV))
-          {
-            EZ_ASSERT_ALWAYS(textureDesc.m_bAllowUAV, "Texture must have the m_bAllowUAV bool set to be used as an UAV");
-          }
-          const ezUInt32 uiSlices = (textureDesc.m_Type == ezGALTextureType::TextureCube || textureDesc.m_Type == ezGALTextureType::TextureCubeArray) ? textureDesc.m_uiArraySize * 6 : textureDesc.m_uiArraySize;
-          EZ_ASSERT_ALWAYS(textureDesc.m_Type != ezGALTextureType::Texture2DProxy, "Proxy textures must be resolved to their base texture before binding");
-          EZ_ASSERT_ALWAYS(range.m_uiBaseArraySlice < uiSlices, "Base array slice is out of bounds");
-          EZ_ASSERT_ALWAYS(range.m_uiBaseMipLevel < textureDesc.m_uiMipLevelCount, "Base array slice is out of bounds");
-          EZ_ASSERT_ALWAYS(range.m_uiMipLevels > 0, "Mip level count must be greater than 0");
-          EZ_ASSERT_ALWAYS(range.m_uiArraySlices > 0, "Array slices must be greater than 0");
-          EZ_ASSERT_ALWAYS(range.m_uiMipLevels == EZ_GAL_ALL_MIP_LEVELS || static_cast<ezUInt32>(range.m_uiBaseMipLevel) + range.m_uiMipLevels <= textureDesc.m_uiMipLevelCount, "Mip level range is out of bounds");
-
-          EZ_ASSERT_ALWAYS(range.m_uiArraySlices == EZ_GAL_ALL_ARRAY_SLICES || static_cast<ezUInt32>(range.m_uiBaseArraySlice) + range.m_uiArraySlices <= uiSlices, "Array slice range is out of bounds");
-          EZ_ASSERT_ALWAYS(binding.m_TextureType != ezGALShaderTextureType::TextureCube || range.m_uiArraySlices == 6, "Cube textures must have 6 as array slices");
-          EZ_ASSERT_ALWAYS(binding.m_TextureType != ezGALShaderTextureType::TextureCubeArray || (range.m_uiArraySlices % 6) == 0, "Cube array textures must have array slices that are multiple of 6");
-        }
-        break;
-        case ezGALShaderResourceType::Unknown:
-        case ezGALShaderResourceType::PushConstants:
-        default:
-          EZ_REPORT_FAILURE("Unsupported Shader Resource Type: {}", binding.m_ResourceType.GetValue());
-          break;
-      }
-    }
+    bindGroup.AssertValidDescription(m_Device);
   }
 #endif
   m_CommonImpl.SetBindGroupPlatform(uiBindGroup, bindGroup);
+}
+
+void ezGALCommandEncoder::SetBindGroup(ezUInt32 uiBindGroup, ezGALBindGroupHandle hBindGroup)
+{
+  AssertRenderingThread();
+
+  const ezGALBindGroup* pBindGroup = m_Device.GetBindGroup(hBindGroup);
+  EZ_ASSERT_DEBUG(pBindGroup != nullptr, "Bind group does not exist");
+  EZ_ASSERT_DEBUG(!pBindGroup->IsInvalidated(), "Bind group is invalidated. One of its dependencies was destroyed.");
+  m_CommonImpl.SetBindGroupPlatform(uiBindGroup, pBindGroup);
 }
 
 void ezGALCommandEncoder::SetPushConstants(ezArrayPtr<const ezUInt8> data)

--- a/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Enumerations.h
@@ -54,7 +54,7 @@ struct ezGALShaderResourceType
     // Not supported: (Vulkan) VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, frame-buffer local read-only image view. Required for render passes on mobile.
     // Not supported: (Vulkan) VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK,Vulkan 1.3 addition, surpasses push-constants but not widely supported yet. May be able to abstract this via PushConstants and custom shader compiler / GAL implementations.
     // Not supported: (Vulkan) VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, Vulkan extension for raytracing.
-
+    COUNT = ByteAddressBufferRW + 1,
     Default = Unknown
   };
 };

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <RendererFoundation/RendererFoundationDLL.h>
+
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Containers/IdTable.h>
 #include <Foundation/Memory/CommonAllocators.h>
@@ -8,7 +10,8 @@
 #include <RendererFoundation/Descriptors/Descriptors.h>
 #include <RendererFoundation/Device/DeviceCapabilities.h>
 #include <RendererFoundation/Device/ReadbackLock.h>
-#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Utils/DependencyTracker.h>
+
 
 class ezColor;
 
@@ -51,6 +54,10 @@ public:
 
   ezGALBindGroupLayoutHandle CreateBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& description);
   void DestroyBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout);
+
+  // Bind group functions
+  ezGALBindGroupHandle CreateBindGroup(const ezGALBindGroupCreationDescription& description);
+  void DestroyBindGroup(ezGALBindGroupHandle hBindGroup);
 
   ezGALPipelineLayoutHandle CreatePipelineLayout(const ezGALPipelineLayoutCreationDescription& description);
   void DestroyPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout);
@@ -210,6 +217,7 @@ public:
   const ezGALVertexDeclaration* GetVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration) const;
   const ezGALSamplerState* GetSamplerState(ezGALSamplerStateHandle hSamplerState) const;
   const ezGALBindGroupLayout* GetBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout) const;
+  const ezGALBindGroup* GetBindGroup(ezGALBindGroupHandle hBindGroup) const;
   const ezGALPipelineLayout* GetPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout) const;
   const ezGALGraphicsPipeline* GetGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline) const;
   const ezGALComputePipeline* GetComputePipeline(ezGALComputePipelineHandle hComputePipeline) const;
@@ -258,6 +266,8 @@ protected:
 
   void DestroyDeadObjects();
 
+  void OnBindGroupInvalidatedEventHandler(ezGALBindGroup* pBindGroup);
+
   /// \brief Asserts that either this device supports multi-threaded resource creation, or that this function is executed on the main thread.
   void VerifyMultithreadedAccess() const;
 
@@ -274,8 +284,8 @@ protected:
 
   template <typename Handle, typename Resource, typename Table, typename CacheTable>
   Handle TryGetHashedResource(ezUInt32 uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
-  template <typename Handle, typename Resource, typename Table, typename CacheTable>
-  Handle InsertHashedResource(ezUInt32 uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter);
+  template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
+  Handle InsertHashedResource(HashType uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter);
   template <typename Resource, typename Handle, typename Table>
   void DestroyHashedResource(Handle hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
 
@@ -296,6 +306,7 @@ protected:
   using SwapChainTable = ezIdTable<ezGALSwapChainHandle::IdType, ezGALSwapChain*, ezLocalAllocatorWrapper>;
   using VertexDeclarationTable = ezIdTable<ezGALVertexDeclarationHandle::IdType, ezGALVertexDeclaration*, ezLocalAllocatorWrapper>;
   using BindGroupLayoutTable = ezIdTable<ezGALBindGroupLayoutHandle::IdType, ezGALBindGroupLayout*, ezLocalAllocatorWrapper>;
+  using BindGroupTable = ezIdTable<ezGALBindGroupHandle::IdType, ezGALBindGroup*, ezLocalAllocatorWrapper>;
   using PipelineLayoutTable = ezIdTable<ezGALPipelineLayoutHandle::IdType, ezGALPipelineLayout*, ezLocalAllocatorWrapper>;
   using GraphicsPipelineTable = ezIdTable<ezGALGraphicsPipelineHandle::IdType, ezGALGraphicsPipeline*, ezLocalAllocatorWrapper>;
   using ComputePipelineTable = ezIdTable<ezGALComputePipelineHandle::IdType, ezGALComputePipeline*, ezLocalAllocatorWrapper>;
@@ -307,6 +318,8 @@ protected:
   RasterizerStateTable m_RasterizerStates;
   SamplerStateTable m_SamplerStates;
   BindGroupLayoutTable m_BindGroupLayouts;
+  BindGroupTable m_BindGroups;
+  ezDependencyTracker<ezGALBindGroup, ezGALResourceBase> m_BindGroupTracker;
   PipelineLayoutTable m_PipelineLayouts;
   GraphicsPipelineTable m_GraphicsPipelines;
   ComputePipelineTable m_ComputePipelines;
@@ -327,6 +340,7 @@ protected:
   ezHashTable<ezUInt32, ezGALRasterizerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_RasterizerStateTable;
   ezHashTable<ezUInt32, ezGALSamplerStateHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_SamplerStateTable;
   ezHashTable<ezUInt32, ezGALBindGroupLayoutHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_BindGroupLayoutTable;
+  ezHashTable<ezUInt64, ezGALBindGroupHandle, ezHashHelper<ezUInt64>, ezLocalAllocatorWrapper> m_BindGroupTable;
   ezHashTable<ezUInt32, ezGALPipelineLayoutHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_PipelineLayoutTable;
   ezHashTable<ezUInt32, ezGALGraphicsPipelineHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_GraphicsPipelineTable;
   ezHashTable<ezUInt32, ezGALComputePipelineHandle, ezHashHelper<ezUInt32>, ezLocalAllocatorWrapper> m_ComputePipelineTable;
@@ -385,6 +399,10 @@ protected:
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) = 0;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) = 0;
+
+  // Bind group platform functions
+  virtual ezGALBindGroup* CreateBindGroupPlatform(const ezGALBindGroupCreationDescription& Description) = 0;
+  virtual void DestroyBindGroupPlatform(ezGALBindGroup* pBindGroup) = 0;
 
   virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) = 0;
   virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) = 0;
@@ -467,6 +485,7 @@ private:
   ezUInt32 m_uiRasterizerStates = 0;
   ezUInt32 m_uiSamplerStates = 0;
   ezUInt32 m_uiBindGroupLayouts = 0;
+  ezUInt32 m_uiBindGroups = 0;
   ezUInt32 m_uiPipelineLayouts = 0;
   ezUInt32 m_uiGraphicsPipelines = 0;
   ezUInt32 m_uiComputePipelines = 0;

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -282,8 +282,8 @@ protected:
   template <typename View, typename Handle, typename ViewTable>
   void DestroyView(Handle hView, ViewTable& table, ezUInt32 galObjectType);
 
-  template <typename Handle, typename Resource, typename Table, typename CacheTable>
-  Handle TryGetHashedResource(ezUInt32 uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
+  template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
+  Handle TryGetHashedResource(HashType uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
   template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
   Handle InsertHashedResource(HashType uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter);
   template <typename Resource, typename Handle, typename Table>

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1666,7 +1666,7 @@ void ezGALDevice::EndFrame()
     ezStats::SetStat("GalDevice/RasterizerStates", m_RasterizerStates.GetCount());
     ezStats::SetStat("GalDevice/SamplerStates", m_SamplerStates.GetCount());
     ezStats::SetStat("GalDevice/BindGroupLayouts", m_BindGroupLayouts.GetCount());
-    ezStats::SetStat("GalDevice/BindGroup", m_BindGroups.GetCount());
+    ezStats::SetStat("GalDevice/BindGroups", m_BindGroups.GetCount());
     ezStats::SetStat("GalDevice/PipelineLayouts", m_PipelineLayouts.GetCount());
     ezStats::SetStat("GalDevice/GraphicsPipelines", m_GraphicsPipelines.GetCount());
     ezStats::SetStat("GalDevice/ComputePipelines", m_ComputePipelines.GetCount());

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -13,6 +13,7 @@
 #include <RendererFoundation/Resources/ProxyTexture.h>
 #include <RendererFoundation/Resources/ReadbackTexture.h>
 #include <RendererFoundation/Resources/RenderTargetView.h>
+#include <RendererFoundation/Shader/BindGroup.h>
 #include <RendererFoundation/Shader/BindGroupLayout.h>
 #include <RendererFoundation/Shader/PipelineLayout.h>
 #include <RendererFoundation/Shader/Shader.h>
@@ -41,6 +42,7 @@ namespace
       SwapChain,
       VertexDeclaration,
       BindGroupLayout,
+      BindGroup,
       PipelineLayout,
       GraphicsPipeline,
       ComputePipeline,
@@ -58,6 +60,7 @@ namespace
   static_assert(sizeof(ezGALSwapChainHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALVertexDeclarationHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALBindGroupLayoutHandle) == sizeof(ezUInt32));
+  static_assert(sizeof(ezGALBindGroupHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALPipelineLayoutHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALGraphicsPipelineHandle) == sizeof(ezUInt32));
   static_assert(sizeof(ezGALComputePipelineHandle) == sizeof(ezUInt32));
@@ -71,10 +74,12 @@ ezGALDevice::ezGALDevice(const ezGALDeviceCreationDescription& desc)
   , m_AllocatorWrapper(&m_Allocator)
   , m_Description(desc)
 {
+  m_BindGroupTracker.m_ResourceInvalidatedEvent.AddEventHandler(ezMakeDelegate(&ezGALDevice::OnBindGroupInvalidatedEventHandler, this));
 }
 
 ezGALDevice::~ezGALDevice()
 {
+  m_BindGroupTracker.m_ResourceInvalidatedEvent.RemoveEventHandler(ezMakeDelegate(&ezGALDevice::OnBindGroupInvalidatedEventHandler, this));
   // Check for object leaks
   {
     EZ_LOG_BLOCK("ezGALDevice object leak report");
@@ -108,6 +113,9 @@ ezGALDevice::~ezGALDevice()
 
     if (!m_BindGroupLayouts.IsEmpty())
       ezLog::Warning("{0} bind group layouts have not been cleaned up", m_BindGroupLayouts.GetCount());
+
+    if (!m_BindGroups.IsEmpty())
+      ezLog::Warning("{0} bind groups have not been cleaned up", m_BindGroups.GetCount());
 
     if (!m_PipelineLayouts.IsEmpty())
       ezLog::Warning("{0} pipeline layouts have not been cleaned up", m_PipelineLayouts.GetCount());
@@ -188,6 +196,7 @@ ezResult ezGALDevice::Shutdown()
   EZ_ASSERT_DEBUG(m_uiRasterizerStates == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiSamplerStates == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiBindGroupLayouts == 0, "Error in counting deduplicated GAL resources");
+  EZ_ASSERT_DEBUG(m_uiBindGroups == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiPipelineLayouts == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiGraphicsPipelines == 0, "Error in counting deduplicated GAL resources");
   EZ_ASSERT_DEBUG(m_uiComputePipelines == 0, "Error in counting deduplicated GAL resources");
@@ -273,8 +282,8 @@ Handle ezGALDevice::TryGetHashedResource(ezUInt32 uiHash, Table& table, CacheTab
   return {};
 }
 
-template <typename Handle, typename Resource, typename Table, typename CacheTable>
-Handle ezGALDevice::InsertHashedResource(ezUInt32 uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter)
+template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
+Handle ezGALDevice::InsertHashedResource(HashType uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter)
 {
   if (pResource != nullptr)
   {
@@ -403,6 +412,97 @@ ezGALBindGroupLayoutHandle ezGALDevice::CreateBindGroupLayout(const ezGALBindGro
 void ezGALDevice::DestroyBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout)
 {
   DestroyHashedResource<ezGALBindGroupLayout>(hBindGroupLayout, m_BindGroupLayouts, GALObjectType::BindGroupLayout, m_uiBindGroupLayouts);
+}
+
+ezGALBindGroupHandle ezGALDevice::CreateBindGroup(const ezGALBindGroupCreationDescription& desc)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+  // Hash desc and return potential existing one (including inc. refcount)
+  const ezUInt64 uiHash = desc.CalculateHash();
+
+  if (ezGALBindGroupHandle hBindGroup = TryGetHashedResource<ezGALBindGroupHandle, ezGALBindGroup>(uiHash, m_BindGroups, m_BindGroupTable, GALObjectType::BindGroup, m_uiBindGroups); !hBindGroup.IsInvalidated())
+    return hBindGroup;
+
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+  {
+    EZ_LOG_BLOCK("CreateBindGroup");
+    desc.AssertValidDescription(*this);
+  }
+#endif
+
+  ezGALBindGroup* pBindGroup = CreateBindGroupPlatform(desc);
+
+  const ezGALBindGroupCreationDescription& desc2 = pBindGroup->GetDescription();
+  EZ_ASSERT_DEBUG(desc.m_hBindGroupLayout == desc2.m_hBindGroupLayout, "");
+  EZ_ASSERT_DEBUG(desc.m_BindGroupItems.GetCount() == desc2.m_BindGroupItems.GetCount(), "");
+
+  EZ_ASSERT_DEBUG(desc.CalculateHash() == desc2.CalculateHash(), "");
+  for (ezUInt32 i = 0; i < desc2.m_BindGroupItems.GetCount(); ++i)
+  {
+    EZ_ASSERT_DEBUG(desc.m_BindGroupItems[i] == desc2.m_BindGroupItems[i], "");
+  }
+
+
+  {
+    ezSet<const ezGALResourceBase*> dependencies;
+    const ezGALBindGroupLayout* pLayout = GetBindGroupLayout(desc.m_hBindGroupLayout);
+    ezArrayPtr<const ezShaderResourceBinding> bindings = pLayout->GetDescription().m_ResourceBindings;
+    ezArrayPtr<const ezGALBindGroupItem> items = desc.m_BindGroupItems;
+    const ezUInt32 uiBindings = bindings.GetCount();
+    for (ezUInt32 i = 0; i < uiBindings; ++i)
+    {
+      const ezShaderResourceBinding& binding = bindings[i];
+      const ezGALBindGroupItem& item = items[i];
+      switch (binding.m_ResourceType)
+      {
+        case ezGALShaderResourceType::Sampler:
+        {
+          const ezGALSamplerState* pSampler = GetSamplerState(item.m_Sampler.m_hSampler);
+          dependencies.Insert(pSampler);
+        }
+        break;
+        case ezGALShaderResourceType::ConstantBuffer:
+        case ezGALShaderResourceType::TexelBuffer:
+        case ezGALShaderResourceType::StructuredBuffer:
+        case ezGALShaderResourceType::ByteAddressBuffer:
+        case ezGALShaderResourceType::TexelBufferRW:
+        case ezGALShaderResourceType::StructuredBufferRW:
+        case ezGALShaderResourceType::ByteAddressBufferRW:
+        {
+          const ezGALBuffer* pBuffer = GetBuffer(item.m_Buffer.m_hBuffer);
+          dependencies.Insert(pBuffer);
+        }
+        break;
+        case ezGALShaderResourceType::TextureAndSampler:
+        {
+          const ezGALSamplerState* pSampler = GetSamplerState(item.m_Texture.m_hSampler);
+          dependencies.Insert(pSampler);
+        }
+          [[fallthrough]];
+        case ezGALShaderResourceType::Texture:
+        case ezGALShaderResourceType::TextureRW:
+        {
+          const ezGALTexture* pTexture = GetTexture(item.m_Texture.m_hTexture);
+          dependencies.Insert(pTexture);
+        }
+        break;
+
+        default:
+          EZ_REPORT_FAILURE("Unsupported shader resource type in bind group");
+          break;
+      }
+    }
+
+    m_BindGroupTracker.AddResource(pBindGroup, dependencies);
+  }
+
+
+  return InsertHashedResource<ezGALBindGroupHandle>(uiHash, pBindGroup, m_BindGroups, m_BindGroupTable, m_uiBindGroups);
+}
+
+void ezGALDevice::DestroyBindGroup(ezGALBindGroupHandle hBindGroup)
+{
+  DestroyHashedResource<ezGALBindGroup>(hBindGroup, m_BindGroups, GALObjectType::BindGroup, m_uiBindGroups);
 }
 
 ezGALPipelineLayoutHandle ezGALDevice::CreatePipelineLayout(const ezGALPipelineLayoutCreationDescription& desc)
@@ -1554,6 +1654,7 @@ void ezGALDevice::EndFrame()
     ezStats::SetStat("GalDevice/RasterizerStateReferences", m_uiRasterizerStates);
     ezStats::SetStat("GalDevice/SamplerStateReferences", m_uiSamplerStates);
     ezStats::SetStat("GalDevice/BindGroupLayoutReferences", m_uiBindGroupLayouts);
+    ezStats::SetStat("GalDevice/BindGroupReferences", m_uiBindGroups);
     ezStats::SetStat("GalDevice/PipelineLayoutReferences", m_uiPipelineLayouts);
     ezStats::SetStat("GalDevice/GraphicsPipelineReferences", m_uiGraphicsPipelines);
     ezStats::SetStat("GalDevice/ComputePipelineReferences", m_uiComputePipelines);
@@ -1565,6 +1666,7 @@ void ezGALDevice::EndFrame()
     ezStats::SetStat("GalDevice/RasterizerStates", m_RasterizerStates.GetCount());
     ezStats::SetStat("GalDevice/SamplerStates", m_SamplerStates.GetCount());
     ezStats::SetStat("GalDevice/BindGroupLayouts", m_BindGroupLayouts.GetCount());
+    ezStats::SetStat("GalDevice/BindGroup", m_BindGroups.GetCount());
     ezStats::SetStat("GalDevice/PipelineLayouts", m_PipelineLayouts.GetCount());
     ezStats::SetStat("GalDevice/GraphicsPipelines", m_GraphicsPipelines.GetCount());
     ezStats::SetStat("GalDevice/ComputePipelines", m_ComputePipelines.GetCount());
@@ -1695,6 +1797,7 @@ void ezGALDevice::DestroyDeadObjects()
         EZ_VERIFY(m_SamplerStates.Remove(hSamplerState, &pSamplerState), "SamplerState not found in idTable");
         EZ_VERIFY(m_SamplerStateTable.Remove(pSamplerState->GetDescription().CalculateHash()), "SamplerState not found in de-duplication table");
 
+        m_BindGroupTracker.DependencyDestroyed(pSamplerState);
         DestroySamplerStatePlatform(pSamplerState);
 
         break;
@@ -1717,7 +1820,7 @@ void ezGALDevice::DestroyDeadObjects()
         ezGALBuffer* pBuffer = nullptr;
 
         EZ_VERIFY(m_Buffers.Remove(hBuffer, &pBuffer), "");
-
+        m_BindGroupTracker.DependencyDestroyed(pBuffer);
         DestroyBufferPlatform(pBuffer);
 
         break;
@@ -1742,6 +1845,7 @@ void ezGALDevice::DestroyDeadObjects()
 
         DestroyViews(pTexture);
 
+        m_BindGroupTracker.DependencyDestroyed(pTexture);
         switch (pTexture->GetDescription().m_Type)
         {
           case ezGALTextureType::Texture2DShared:
@@ -1823,6 +1927,18 @@ void ezGALDevice::DestroyDeadObjects()
         DestroyBindGroupLayoutPlatform(pBindGroupLayout);
         break;
       }
+      case GALObjectType::BindGroup:
+      {
+        ezGALBindGroupHandle hBindGroup(ezGAL::ez18_14Id(deadObject.m_uiHandle));
+        ezGALBindGroup* pBindGroup = nullptr;
+
+        EZ_VERIFY(m_BindGroups.Remove(hBindGroup, &pBindGroup), "Unexpected invalid handle");
+        m_BindGroupTable.Remove(pBindGroup->GetDescription().CalculateHash());
+
+        m_BindGroupTracker.RemoveResource(pBindGroup);
+        DestroyBindGroupPlatform(pBindGroup);
+        break;
+      }
       case GALObjectType::PipelineLayout:
       {
         ezGALPipelineLayoutHandle hPipelineLayout(ezGAL::ez18_14Id(deadObject.m_uiHandle));
@@ -1862,6 +1978,12 @@ void ezGALDevice::DestroyDeadObjects()
   }
 
   m_DeadObjects.Clear();
+}
+
+void ezGALDevice::OnBindGroupInvalidatedEventHandler(ezGALBindGroup* pBindGroup)
+{
+  EZ_GALDEVICE_LOCK_AND_CHECK();
+  pBindGroup->Invalidate(this);
 }
 
 const ezGALSwapChain* ezGALDevice::GetSwapChainInternal(ezGALSwapChainHandle hSwapChain, const ezRTTI* pRequestedType) const

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -263,8 +263,8 @@ void ezGALDevice::EndCommands(ezGALCommandEncoder* pCommandEncoder)
   }
 }
 
-template <typename Handle, typename Resource, typename Table, typename CacheTable>
-Handle ezGALDevice::TryGetHashedResource(ezUInt32 uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter)
+template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
+Handle ezGALDevice::TryGetHashedResource(HashType uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter)
 {
   Handle hResource;
   if (cacheTable.TryGetValue(uiHash, hResource))

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -116,6 +116,11 @@ inline const ezGALBindGroupLayout* ezGALDevice::GetBindGroupLayout(ezGALBindGrou
   return Get<BindGroupLayoutTable, ezGALBindGroupLayout>(hBindGroupLayout, m_BindGroupLayouts);
 }
 
+inline const ezGALBindGroup* ezGALDevice::GetBindGroup(ezGALBindGroupHandle hBindGroup) const
+{
+  return Get<BindGroupTable, ezGALBindGroup>(hBindGroup, m_BindGroups);
+}
+
 inline const ezGALPipelineLayout* ezGALDevice::GetPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout) const
 {
   return Get<PipelineLayoutTable, ezGALPipelineLayout>(hPipelineLayout, m_PipelineLayouts);

--- a/Code/Engine/RendererFoundation/RendererFoundationDLL.h
+++ b/Code/Engine/RendererFoundation/RendererFoundationDLL.h
@@ -51,6 +51,7 @@ struct ezGALVertexDeclarationCreationDescription;
 struct ezGALSamplerStateCreationDescription;
 struct ezGALRenderTargetViewCreationDescription;
 struct ezGALBindGroupLayoutCreationDescription;
+struct ezGALBindGroupCreationDescription;
 struct ezGALPipelineLayoutCreationDescription;
 struct ezGALGraphicsPipelineCreationDescription;
 struct ezGALComputePipelineCreationDescription;
@@ -73,6 +74,7 @@ class ezGALSamplerState;
 class ezGALRenderTargetView;
 class ezGALDevice;
 class ezGALCommandEncoder;
+class ezGALBindGroup;
 class ezGALBindGroupLayout;
 class ezGALPipelineLayout;
 class ezGALGraphicsPipeline;
@@ -571,6 +573,30 @@ class ezGALVertexDeclarationHandle
   friend class ezGALDevice;
 };
 
+/// \brief Handle to ezGALBindGroupLayout, created via ezGALDevice::CreateBindGroupLayout
+class ezGALBindGroupLayoutHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALBindGroupLayoutHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+/// \brief Handle to ezGALBindGroup, created via ezGALDevice::CreateBindGroup
+class ezGALBindGroupHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALBindGroupHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
+/// \brief Handle to ezGALPipelineLayout, created via ezGALDevice::CreatePipelineLayout
+class ezGALPipelineLayoutHandle
+{
+  EZ_DECLARE_HANDLE_TYPE(ezGALPipelineLayoutHandle, ezGAL::ez18_14Id);
+
+  friend class ezGALDevice;
+};
+
 class ezGALGraphicsPipelineHandle
 {
   EZ_DECLARE_HANDLE_TYPE(ezGALGraphicsPipelineHandle, ezGAL::ez18_14Id);
@@ -581,30 +607,6 @@ class ezGALGraphicsPipelineHandle
 class ezGALComputePipelineHandle
 {
   EZ_DECLARE_HANDLE_TYPE(ezGALComputePipelineHandle, ezGAL::ez18_14Id);
-
-  friend class ezGALDevice;
-};
-
-/// \brief Handle to ezGALBindGroupLayout, created ia ezGALDevice::CreateBindGroupLayout
-class ezGALBindGroupLayoutHandle
-{
-  EZ_DECLARE_HANDLE_TYPE(ezGALBindGroupLayoutHandle, ezGAL::ez18_14Id);
-
-  friend class ezGALDevice;
-};
-
-/// \brief Handle to ezGALPipelineLayout, created ia ezGALDevice::CreatePipelineLayout
-class ezGALPipelineLayoutHandle
-{
-  EZ_DECLARE_HANDLE_TYPE(ezGALPipelineLayoutHandle, ezGAL::ez18_14Id);
-
-  friend class ezGALDevice;
-};
-
-/// \brief Handle to ezGALBindGroup, created ia ezGALDevice::CreateBindGroup
-class ezGALBindGroupHandle
-{
-  EZ_DECLARE_HANDLE_TYPE(ezGALBindGroupHandle, ezGAL::ez18_14Id);
 
   friend class ezGALDevice;
 };

--- a/Code/Engine/RendererFoundation/Shader/BindGroup.h
+++ b/Code/Engine/RendererFoundation/Shader/BindGroup.h
@@ -3,8 +3,8 @@
 #include <RendererFoundation/RendererFoundationDLL.h>
 
 #include <Foundation/Algorithm/HashableStruct.h>
-#include <RendererFoundation/Resources/ResourceFormats.h>
 #include <RendererFoundation/Resources/Resource.h>
+#include <RendererFoundation/Resources/ResourceFormats.h>
 
 
 /// \file

--- a/Code/Engine/RendererFoundation/Shader/BindGroup.h
+++ b/Code/Engine/RendererFoundation/Shader/BindGroup.h
@@ -4,6 +4,8 @@
 
 #include <Foundation/Algorithm/HashableStruct.h>
 #include <RendererFoundation/Resources/ResourceFormats.h>
+#include <RendererFoundation/Resources/Resource.h>
+
 
 /// \file
 
@@ -80,10 +82,29 @@ struct ezGALBindGroupItem : public ezHashableStruct<ezGALBindGroupItem>
 
 /// \brief Defines a bind group.
 /// Can be set to the renderer via ezGALCommandEncoder::SetBindGroup.
-struct ezGALBindGroupCreationDescription
+struct EZ_RENDERERFOUNDATION_DLL ezGALBindGroupCreationDescription
 {
+  ezUInt64 CalculateHash() const;
+  void AssertValidDescription(const ezGALDevice& galDevice) const;
+
   ezGALBindGroupLayoutHandle m_hBindGroupLayout;       ///< The layout that this bind group was created for.
   ezDynamicArray<ezGALBindGroupItem> m_BindGroupItems; ///< Contains one item for every ezShaderResourceBinding in the ezGALBindGroupLayout at matching indices in the arrays.
+};
+
+class EZ_RENDERERFOUNDATION_DLL ezGALBindGroup : public ezGALResource<ezGALBindGroupCreationDescription>
+{
+public:
+  virtual bool IsInvalidated() const = 0;
+
+protected:
+  friend class ezGALDevice;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
+  virtual void Invalidate(ezGALDevice* pDevice) = 0;
+
+  inline ezGALBindGroup(const ezGALBindGroupCreationDescription& Description);
+  inline virtual ~ezGALBindGroup();
 };
 
 #include <RendererFoundation/Shader/Implementation/BindGroup_inl.h>

--- a/Code/Engine/RendererFoundation/Shader/Implementation/BindGroup.cpp
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/BindGroup.cpp
@@ -1,0 +1,181 @@
+#include <RendererFoundation/RendererFoundationPCH.h>
+
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Resources/Buffer.h>
+#include <RendererFoundation/Shader/BindGroup.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
+
+#include <Foundation/Algorithm/HashStream.h>
+
+ezUInt64 ezGALBindGroupCreationDescription::CalculateHash() const
+{
+  ezHashStreamWriter64 writer;
+  writer << m_hBindGroupLayout.GetInternalID().m_Data;
+  if (!m_BindGroupItems.IsEmpty())
+  {
+    auto data = m_BindGroupItems.GetByteArrayPtr();
+    writer.WriteBytes(data.GetPtr(), data.GetCount()).IgnoreResult();
+  }
+  return writer.GetHashValue();
+}
+void ezGALBindGroupCreationDescription::AssertValidDescription(const ezGALDevice& m_Device) const
+{
+  const ezGALBindGroupLayout* pLayout = m_Device.GetBindGroupLayout(m_hBindGroupLayout);
+  ezArrayPtr<const ezShaderResourceBinding> bindings = pLayout->GetDescription().m_ResourceBindings;
+  ezArrayPtr<const ezGALBindGroupItem> items = m_BindGroupItems;
+  EZ_ASSERT_ALWAYS(bindings.GetCount() == items.GetCount(), "Missmatch between bindings and item count");
+  const ezUInt32 uiBindings = bindings.GetCount();
+  for (ezUInt32 i = 0; i < uiBindings; ++i)
+  {
+    const ezShaderResourceBinding& binding = bindings[i];
+    const ezGALBindGroupItem& item = items[i];
+    const ezBitflags<ezGALShaderResourceCategory> category = ezGALShaderResourceCategory::MakeFromShaderDescriptorType(binding.m_ResourceType);
+
+    switch (binding.m_ResourceType)
+    {
+      case ezGALShaderResourceType::Sampler:
+      {
+        EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Sampler), "Item type does not match binding");
+        const ezGALSamplerState* pSampler = m_Device.GetSamplerState(item.m_Sampler.m_hSampler);
+        EZ_ASSERT_ALWAYS(pSampler != nullptr, "Invalid sampler state");
+      }
+      break;
+
+      case ezGALShaderResourceType::ConstantBuffer:
+      {
+        EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Buffer), "Item type does not match binding");
+        const ezGALBuffer* pBuffer = m_Device.GetBuffer(item.m_Buffer.m_hBuffer);
+        EZ_ASSERT_ALWAYS(pBuffer != nullptr, "Invalid buffer");
+        EZ_ASSERT_ALWAYS(item.m_Buffer.m_OverrideTexelBufferFormat == ezGALResourceFormat::Invalid, "m_OverrideTexelBufferFormat must be Invalid for constant buffers");
+        EZ_ASSERT_ALWAYS(item.m_Buffer.m_BufferRange.m_uiByteOffset == 0, "Byte offset for constant buffers not supported yet");
+        EZ_ASSERT_ALWAYS(item.m_Buffer.m_BufferRange.m_uiByteCount == pBuffer->GetDescription().m_uiTotalSize, "Byte count for constant buffers not supported yet");
+      }
+      break;
+      case ezGALShaderResourceType::TexelBuffer:
+      case ezGALShaderResourceType::StructuredBuffer:
+      case ezGALShaderResourceType::ByteAddressBuffer:
+      case ezGALShaderResourceType::TexelBufferRW:
+      case ezGALShaderResourceType::StructuredBufferRW:
+      case ezGALShaderResourceType::ByteAddressBufferRW:
+      {
+
+        EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Buffer), "Item type does not match binding");
+        const ezGALBuffer* pBuffer = m_Device.GetBuffer(item.m_Buffer.m_hBuffer);
+        EZ_ASSERT_ALWAYS(pBuffer != nullptr, "Invalid buffer");
+        const ezGALBufferCreationDescription& bufferDesc = pBuffer->GetDescription();
+        EZ_ASSERT_ALWAYS((binding.m_ResourceType == ezGALShaderResourceType::TexelBuffer || binding.m_ResourceType == ezGALShaderResourceType::TexelBufferRW) || item.m_Buffer.m_OverrideTexelBufferFormat == ezGALResourceFormat::Invalid, "m_OverrideTexelBufferFormat must be Invalid for non-texel buffers");
+        EZ_ASSERT_ALWAYS((binding.m_ResourceType != ezGALShaderResourceType::TexelBuffer && binding.m_ResourceType != ezGALShaderResourceType::TexelBufferRW) || bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::TexelBuffer), "TexelBuffer bindings are only supported on texel buffers");
+        EZ_ASSERT_ALWAYS((binding.m_ResourceType != ezGALShaderResourceType::StructuredBuffer && binding.m_ResourceType != ezGALShaderResourceType::StructuredBufferRW) || bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::StructuredBuffer), "StructuredBuffer bindings are only supported on structured buffers");
+        EZ_ASSERT_ALWAYS((binding.m_ResourceType != ezGALShaderResourceType::ByteAddressBuffer && binding.m_ResourceType != ezGALShaderResourceType::ByteAddressBufferRW) || bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ByteAddressBuffer), "ByteAddressBuffer bindings are only supported on byte address buffers");
+
+        if (category.IsSet(ezGALShaderResourceCategory::BufferSRV))
+        {
+          EZ_ASSERT_ALWAYS(bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::ShaderResource), "Buffer must have the ShaderResource flag set to be used as an SRV");
+        }
+        if (category.IsSet(ezGALShaderResourceCategory::BufferUAV))
+        {
+          EZ_ASSERT_ALWAYS(bufferDesc.m_BufferFlags.IsSet(ezGALBufferUsageFlags::UnorderedAccess), "Buffer must have the UnorderedAccess flag set to be used as an UAV");
+        }
+
+        ezUInt32 uiBytesPerElement = 4; // ByteAddress must be multiple of 4
+        if (binding.m_ResourceType == ezGALShaderResourceType::StructuredBuffer || binding.m_ResourceType == ezGALShaderResourceType::StructuredBufferRW)
+        {
+          uiBytesPerElement = bufferDesc.m_uiStructSize;
+        }
+        else if (binding.m_ResourceType == ezGALShaderResourceType::TexelBuffer || binding.m_ResourceType == ezGALShaderResourceType::TexelBufferRW)
+        {
+          const ezGALResourceFormat::Enum viewFormat = item.m_Buffer.m_OverrideTexelBufferFormat == ezGALResourceFormat::Invalid ? bufferDesc.m_Format : item.m_Buffer.m_OverrideTexelBufferFormat;
+          uiBytesPerElement = ezGALResourceFormat::GetBitsPerElement(viewFormat) / 8;
+        }
+
+        ezGALBufferRange range = item.m_Buffer.m_BufferRange;
+        if ((range.m_uiByteOffset % uiBytesPerElement) != 0)
+        {
+          EZ_REPORT_FAILURE("m_uiByteOffset {} is not a multiple of the element size {}", range.m_uiByteOffset, uiBytesPerElement);
+        }
+        if (range.m_uiByteOffset >= bufferDesc.m_uiTotalSize)
+        {
+          EZ_REPORT_FAILURE("m_uiByteOffset {} is too big for the buffer of size {}", range.m_uiByteOffset, bufferDesc.m_uiTotalSize);
+        }
+
+        if (range.m_uiByteCount != EZ_GAL_WHOLE_SIZE)
+        {
+          if ((range.m_uiByteCount % uiBytesPerElement) != 0)
+          {
+            EZ_REPORT_FAILURE("m_uiByteCount {} is not a multiple of the element size {}", range.m_uiByteCount, uiBytesPerElement);
+          }
+          if (range.m_uiByteOffset + range.m_uiByteCount > bufferDesc.m_uiTotalSize)
+          {
+            EZ_REPORT_FAILURE("m_uiByteOffset {} + m_uiByteCount {} = {} is too big for the buffer of size {}", range.m_uiByteOffset, range.m_uiByteCount, range.m_uiByteOffset + range.m_uiByteCount, bufferDesc.m_uiTotalSize);
+          }
+        }
+      }
+      break;
+      case ezGALShaderResourceType::Texture:
+      case ezGALShaderResourceType::TextureRW:
+      case ezGALShaderResourceType::TextureAndSampler:
+      {
+        EZ_ASSERT_ALWAYS(item.m_Flags.IsSet(ezGALBindGroupItemFlags::Texture), "Item type does not match binding");
+        const ezGALTexture* pTexture = m_Device.GetTexture(item.m_Texture.m_hTexture);
+        EZ_ASSERT_ALWAYS(pTexture != nullptr, "Invalid texture");
+        const auto& textureDesc = pTexture->GetDescription();
+
+        if (item.m_Texture.m_OverrideViewFormat != ezGALResourceFormat::Invalid)
+        {
+          const ezEnum<ezGALResourceFormat> format = pTexture->GetDescription().m_Format;
+          const ezEnum<ezGALResourceFormat> overrideFormat = item.m_Texture.m_OverrideViewFormat;
+          EZ_ASSERT_ALWAYS(ezGALResourceFormat::GetBitsPerElement(format) == ezGALResourceFormat::GetBitsPerElement(overrideFormat), "Format override bits per element ({}) must match the same on the original format ({})", ezGALResourceFormat::GetBitsPerElement(overrideFormat), ezGALResourceFormat::GetBitsPerElement(format));
+          EZ_ASSERT_ALWAYS(ezGALResourceFormat::GetChannelCount(format) == ezGALResourceFormat::GetChannelCount(overrideFormat), "Format override channel count ({}) must match the same on the original format ({})", ezGALResourceFormat::GetChannelCount(overrideFormat), ezGALResourceFormat::GetChannelCount(format));
+        }
+        // TODO item.m_Texture.m_OverrideTexelBufferFormat
+        if (binding.m_ResourceType == ezGALShaderResourceType::TextureAndSampler)
+        {
+          const ezGALSamplerState* pSampler = m_Device.GetSamplerState(item.m_Texture.m_hSampler);
+          EZ_ASSERT_ALWAYS(pSampler != nullptr, "Invalid sampler state");
+        }
+
+        const ezGALTextureRange range = item.m_Texture.m_TextureRange;
+
+        if (!ezGALShaderTextureType::IsArray(binding.m_TextureType))
+        {
+          if (binding.m_TextureType == ezGALShaderTextureType::TextureCube)
+          {
+            EZ_ASSERT_ALWAYS(range.m_uiArraySlices == 6, "m_uiArraySlices must be 6 for a cube texture binding");
+          }
+          else
+          {
+            EZ_ASSERT_ALWAYS(range.m_uiArraySlices == 1, "m_uiArraySlices must be 1 for non array bindings");
+          }
+        }
+
+        EZ_ASSERT_ALWAYS(ezGALShaderTextureType::IsMSAA(binding.m_TextureType) == (textureDesc.m_SampleCount != ezGALMSAASampleCount::None), "MSAA missmatch between texture and binding");
+
+        if (category.IsSet(ezGALShaderResourceCategory::TextureSRV))
+        {
+          EZ_ASSERT_ALWAYS(textureDesc.m_bAllowShaderResourceView, "Texture must have the m_bAllowShaderResourceView bool set to be used as an SRV");
+        }
+        if (category.IsSet(ezGALShaderResourceCategory::TextureUAV))
+        {
+          EZ_ASSERT_ALWAYS(textureDesc.m_bAllowUAV, "Texture must have the m_bAllowUAV bool set to be used as an UAV");
+        }
+        const ezUInt32 uiSlices = (textureDesc.m_Type == ezGALTextureType::TextureCube || textureDesc.m_Type == ezGALTextureType::TextureCubeArray) ? textureDesc.m_uiArraySize * 6 : textureDesc.m_uiArraySize;
+        EZ_ASSERT_ALWAYS(textureDesc.m_Type != ezGALTextureType::Texture2DProxy, "Proxy textures must be resolved to their base texture before binding");
+        EZ_ASSERT_ALWAYS(range.m_uiBaseArraySlice < uiSlices, "Base array slice is out of bounds");
+        EZ_ASSERT_ALWAYS(range.m_uiBaseMipLevel < textureDesc.m_uiMipLevelCount, "Base array slice is out of bounds");
+        EZ_ASSERT_ALWAYS(range.m_uiMipLevels > 0, "Mip level count must be greater than 0");
+        EZ_ASSERT_ALWAYS(range.m_uiArraySlices > 0, "Array slices must be greater than 0");
+        EZ_ASSERT_ALWAYS(range.m_uiMipLevels == EZ_GAL_ALL_MIP_LEVELS || static_cast<ezUInt32>(range.m_uiBaseMipLevel) + range.m_uiMipLevels <= textureDesc.m_uiMipLevelCount, "Mip level range is out of bounds");
+
+        EZ_ASSERT_ALWAYS(range.m_uiArraySlices == EZ_GAL_ALL_ARRAY_SLICES || static_cast<ezUInt32>(range.m_uiBaseArraySlice) + range.m_uiArraySlices <= uiSlices, "Array slice range is out of bounds");
+        EZ_ASSERT_ALWAYS(binding.m_TextureType != ezGALShaderTextureType::TextureCube || range.m_uiArraySlices == 6, "Cube textures must have 6 as array slices");
+        EZ_ASSERT_ALWAYS(binding.m_TextureType != ezGALShaderTextureType::TextureCubeArray || (range.m_uiArraySlices % 6) == 0, "Cube array textures must have array slices that are multiple of 6");
+      }
+      break;
+      case ezGALShaderResourceType::Unknown:
+      case ezGALShaderResourceType::PushConstants:
+      default:
+        EZ_REPORT_FAILURE("Unsupported Shader Resource Type: {}", binding.m_ResourceType.GetValue());
+        break;
+    }
+  }
+}

--- a/Code/Engine/RendererFoundation/Shader/Implementation/BindGroup_inl.h
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/BindGroup_inl.h
@@ -15,7 +15,9 @@ void ezGALBindGroupItem::operator=(const ezGALBindGroupItem& rhs)
   thisBase = rhsBase;
 }
 
-ezGALBindGroup::ezGALBindGroup(const ezGALBindGroupCreationDescription& Description) : ezGALResource(Description)
-{}
+ezGALBindGroup::ezGALBindGroup(const ezGALBindGroupCreationDescription& Description)
+  : ezGALResource(Description)
+{
+}
 
 ezGALBindGroup::~ezGALBindGroup() = default;

--- a/Code/Engine/RendererFoundation/Shader/Implementation/BindGroup_inl.h
+++ b/Code/Engine/RendererFoundation/Shader/Implementation/BindGroup_inl.h
@@ -14,3 +14,8 @@ void ezGALBindGroupItem::operator=(const ezGALBindGroupItem& rhs)
   const ezHashableStruct<ezGALBindGroupItem>& rhsBase = rhs;
   thisBase = rhsBase;
 }
+
+ezGALBindGroup::ezGALBindGroup(const ezGALBindGroupCreationDescription& Description) : ezGALResource(Description)
+{}
+
+ezGALBindGroup::~ezGALBindGroup() = default;

--- a/Code/Engine/RendererFoundation/State/Implementation/State.cpp
+++ b/Code/Engine/RendererFoundation/State/Implementation/State.cpp
@@ -29,7 +29,7 @@ ezGALRasterizerState::~ezGALRasterizerState() = default;
 
 
 ezGALSamplerState::ezGALSamplerState(const ezGALSamplerStateCreationDescription& Description)
-  : ezGALObject(Description)
+  : ezGALResource(Description)
 {
 }
 

--- a/Code/Engine/RendererFoundation/State/State.h
+++ b/Code/Engine/RendererFoundation/State/State.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <RendererFoundation/Descriptors/Descriptors.h>
+#include <RendererFoundation/Resources/Resource.h>
 
 class EZ_RENDERERFOUNDATION_DLL ezGALBlendState : public ezGALObject<ezGALBlendStateCreationDescription>
 {
@@ -25,7 +26,6 @@ protected:
   virtual ~ezGALDepthStencilState();
 
   virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 };
 
@@ -42,7 +42,7 @@ protected:
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 };
 
-class EZ_RENDERERFOUNDATION_DLL ezGALSamplerState : public ezGALObject<ezGALSamplerStateCreationDescription>
+class EZ_RENDERERFOUNDATION_DLL ezGALSamplerState : public ezGALResource<ezGALSamplerStateCreationDescription>
 {
 public:
 protected:
@@ -50,7 +50,7 @@ protected:
 
   virtual ~ezGALSamplerState();
 
+  virtual void SetDebugNamePlatform(const char* szName) const override {};
   virtual ezResult InitPlatform(ezGALDevice* pDevice) = 0;
-
   virtual ezResult DeInitPlatform(ezGALDevice* pDevice) = 0;
 };

--- a/Code/Engine/RendererFoundation/Utils/DependencyTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/DependencyTracker.h
@@ -10,7 +10,7 @@
 /// \tparam Resource The type of resource being tracked (e.g. bind groups)
 /// \tparam Dependency The base type of the dependencies (e.g., ezGALResource)
 template <typename Resource, typename Dependency>
-class EZ_RENDERERFOUNDATION_DLL ezDependencyTracker
+class ezDependencyTracker
 {
 public:
   ezDependencyTracker();

--- a/Code/Engine/RendererFoundation/Utils/DependencyTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/DependencyTracker.h
@@ -13,9 +13,6 @@ template <typename Resource, typename Dependency>
 class ezDependencyTracker
 {
 public:
-  ezDependencyTracker();
-  ~ezDependencyTracker();
-
   /// \brief Adds a resource and its dependencies to the tracking system.
   ///
   /// This method registers a resource along with all of its dependencies. The resource will be automatically invalidated if any of its dependencies are destroyed. Each resource can only be added once - attempting to add the same resource again will trigger an assertion in debug builds.

--- a/Code/Engine/RendererFoundation/Utils/DependencyTracker.h
+++ b/Code/Engine/RendererFoundation/Utils/DependencyTracker.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+
+/// \brief A thread-safe dependency tracking system for managing resource invalidation.
+///
+/// This template class tracks dependencies between resources and their dependencies to allow invalidating resources when their dependencies are destroyed.
+/// When a dependency is destroyed, all resources that depend on it are automatically identified and an invalidation event is broadcast for each affected resource.
+///
+/// \tparam Resource The type of resource being tracked (e.g. bind groups)
+/// \tparam Dependency The base type of the dependencies (e.g., ezGALResource)
+template <typename Resource, typename Dependency>
+class EZ_RENDERERFOUNDATION_DLL ezDependencyTracker
+{
+public:
+  ezDependencyTracker();
+  ~ezDependencyTracker();
+
+  /// \brief Adds a resource and its dependencies to the tracking system.
+  ///
+  /// This method registers a resource along with all of its dependencies. The resource will be automatically invalidated if any of its dependencies are destroyed. Each resource can only be added once - attempting to add the same resource again will trigger an assertion in debug builds.
+  ///
+  /// \param pResource Pointer to the resource to track
+  /// \param dependencies Set of dependencies that this resource depends on
+  void AddResource(Resource* pResource, const ezSet<const Dependency*>& dependencies);
+
+  /// \brief Removes a resource from the tracking system.
+  ///
+  /// This method removes the resource and all of its dependency relationships from the tracker. The resource will no longer receive invalidation events even if its former dependencies are destroyed.
+  ///
+  /// \param pResource Pointer to the resource to remove from tracking
+  void RemoveResource(Resource* pResource);
+
+  /// \brief Notifies the tracker that a dependency has been destroyed.
+  ///
+  /// This method should be called when a dependency object is about to be destroyed. It will identify all resources that depend on this dependency, remove the dependency relationships, and broadcast invalidation events for each affected resource.
+  ///
+  /// \param pDependency Pointer to the dependency that is being destroyed
+  void DependencyDestroyed(Dependency* pDependency);
+
+public:
+  /// \brief Event that is broadcast when a resource becomes invalid due to dependency destruction.
+  ezEvent<Resource*> m_ResourceInvalidatedEvent;
+
+private:
+  struct Item
+  {
+    EZ_DECLARE_POD_TYPE();
+    Item* m_pPreviousResource = nullptr;
+    Item* m_pNextResource = nullptr;
+    Item* m_pPreviousDependency = nullptr;
+    Item* m_pNextDependency = nullptr;
+    Resource* m_pResource = nullptr;
+    const Dependency* m_pDependency = nullptr;
+  };
+  using ResourceHeadMap = ezMap<Resource*, Item*>;
+  using DependencyHeadMap = ezMap<const Dependency*, Item*>;
+
+private:
+  void InsertItem(typename ResourceHeadMap::Iterator resourceHead, Resource* pResource, const Dependency* pDependency);
+  void RemoveResourceItem(typename ResourceHeadMap::ConstIterator resourceHead, Item* pItem);
+  void RemoveDependencyItem(typename DependencyHeadMap::ConstIterator dependencyHead, Item* pItem);
+
+private:
+  ezMutex m_Mutex;
+  ezDeque<Item> m_Dependencies;
+  Item* m_pFreeList = nullptr;
+  ResourceHeadMap m_ResourceHead;
+  DependencyHeadMap m_DependencyHead;
+};
+
+#include <RendererFoundation/Utils/Implementation/DependencyTracker_inl.h>

--- a/Code/Engine/RendererFoundation/Utils/Implementation/DependencyTracker_inl.h
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/DependencyTracker_inl.h
@@ -1,14 +1,3 @@
-
-template <typename Resource, typename Dependency>
-ezDependencyTracker<Resource, Dependency>::ezDependencyTracker()
-{
-}
-
-template <typename Resource, typename Dependency>
-ezDependencyTracker<Resource, Dependency>::~ezDependencyTracker()
-{
-}
-
 template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::AddResource(Resource* pResource, const ezSet<const Dependency*>& dependencies)
 {

--- a/Code/Engine/RendererFoundation/Utils/Implementation/DependencyTracker_inl.h
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/DependencyTracker_inl.h
@@ -1,0 +1,177 @@
+
+template<typename Resource, typename Dependency>
+ezDependencyTracker<Resource, Dependency>::ezDependencyTracker()
+{
+}
+
+template<typename Resource, typename Dependency>
+ezDependencyTracker<Resource, Dependency>::~ezDependencyTracker()
+{
+}
+
+template<typename Resource, typename Dependency>
+void ezDependencyTracker<Resource, Dependency>::AddResource(Resource* pResource, const ezSet<const Dependency*>& dependencies)
+{
+  EZ_LOCK(m_Mutex);
+  bool bExisted = false;
+  auto resourceHead = m_ResourceHead.FindOrAdd(pResource, &bExisted);
+  EZ_IGNORE_UNUSED(bExisted);
+  EZ_ASSERT_DEBUG(!bExisted, "Resource already tracked");
+
+  for (const Dependency* pDependency : dependencies)
+  {
+    InsertItem(resourceHead, pResource, pDependency);
+  }
+
+}
+
+template<typename Resource, typename Dependency>
+void ezDependencyTracker<Resource, Dependency>::RemoveResource(Resource* pResource)
+{
+  EZ_LOCK(m_Mutex);
+
+  auto resourceHead = m_ResourceHead.Find(pResource);
+  EZ_ASSERT_DEBUG(resourceHead.IsValid(), "Resource not tracked");
+
+  Item* pItem = resourceHead.Value();
+  while (pItem != nullptr)
+  {
+    Item* pCurrentItem = pItem;
+    pItem = pItem->m_pNextDependency;
+    RemoveResourceItem(resourceHead, pCurrentItem);
+  }
+
+  m_ResourceHead.Remove(resourceHead);
+}
+
+template<typename Resource, typename Dependency>
+void ezDependencyTracker<Resource, Dependency>::DependencyDestroyed(Dependency* pDependency)
+{
+  ezSet<Resource*> invalidResources;
+  {
+    EZ_LOCK(m_Mutex);
+    auto dependencyHead = m_DependencyHead.Find(pDependency);
+    if (!dependencyHead.IsValid())
+      return;
+
+    Item* pItem = dependencyHead.Value();
+    while (pItem != nullptr)
+    {
+      Item* pCurrentItem = pItem;
+      pItem = pItem->m_pNextResource;
+      invalidResources.Insert(pCurrentItem->m_pResource);
+      // This will destroy pCurrentItem so we must move pItem forward before this.
+      RemoveDependencyItem(dependencyHead, pCurrentItem);
+    }
+    m_DependencyHead.Remove(dependencyHead);
+  }
+
+  for (Resource* pResource : invalidResources)
+  {
+    m_ResourceInvalidatedEvent.Broadcast(pResource);
+  }
+}
+
+template<typename Resource, typename Dependency>
+void ezDependencyTracker<Resource, Dependency>::InsertItem(typename ResourceHeadMap::Iterator resourceHead, Resource* pResource, const Dependency* pDependency)
+{
+  Item* pItem = nullptr;
+  if (m_pFreeList != nullptr)
+  {
+    pItem = m_pFreeList;
+    m_pFreeList = m_pFreeList->m_pNextDependency;
+    *pItem = {};
+  }
+  else
+  {
+    m_Dependencies.PushBack();
+    pItem = &m_Dependencies.PeekBack();
+  }
+  pItem->m_pResource = pResource;
+  pItem->m_pDependency = pDependency;
+
+  auto dependencyHead = m_DependencyHead.FindOrAdd(pDependency);
+
+  if (dependencyHead.Value() != nullptr)
+  {
+    dependencyHead.Value()->m_pPreviousResource = pItem;
+    pItem->m_pNextResource = dependencyHead.Value();
+  }
+
+  if (resourceHead.Value() != nullptr)
+  {
+    resourceHead.Value()->m_pPreviousDependency = pItem;
+    pItem->m_pNextDependency = resourceHead.Value();
+  }
+
+  dependencyHead.Value() = pItem;
+  resourceHead.Value() = pItem;
+}
+
+template<typename Resource, typename Dependency>
+void ezDependencyTracker<Resource, Dependency>::RemoveResourceItem(typename ResourceHeadMap::ConstIterator resourceHead, Item* pItem)
+{
+  if (pItem->m_pNextResource != nullptr)
+  {
+    Item* pNextItem = pItem->m_pNextResource;
+    pNextItem->m_pPreviousResource = pItem->m_pPreviousResource;
+  }
+
+  if (pItem->m_pPreviousResource != nullptr)
+  {
+    Item* pPreviousItem = pItem->m_pPreviousResource;
+    pPreviousItem->m_pNextResource = pItem->m_pNextResource;
+  }
+  else
+  {
+    // We delete a dependency head
+    if (pItem->m_pNextResource == nullptr)
+    {
+      // Last instance of this dependency, remove key.
+      m_DependencyHead.Remove(pItem->m_pDependency);
+    }
+    else
+    {
+      // Update head to next item in list.
+      m_DependencyHead.Insert(pItem->m_pDependency, pItem->m_pNextResource);
+    }
+  }
+
+  *pItem = {};
+  pItem->m_pNextDependency = m_pFreeList;
+  m_pFreeList = pItem;
+}
+
+template<typename Resource, typename Dependency>
+void ezDependencyTracker<Resource, Dependency>::RemoveDependencyItem(typename DependencyHeadMap::ConstIterator dependencyHead, Item* pItem)
+{
+  if (pItem->m_pNextDependency != nullptr)
+  {
+    Item* pNextItem = pItem->m_pNextDependency;
+    pNextItem->m_pPreviousDependency = pItem->m_pPreviousDependency;
+  }
+
+  if (pItem->m_pPreviousDependency != nullptr)
+  {
+    Item* pPreviousItem = pItem->m_pPreviousDependency;
+    pPreviousItem->m_pNextDependency = pItem->m_pNextDependency;
+  }
+  else
+  {
+    // We delete a resource head
+    if (pItem->m_pNextDependency == nullptr)
+    {
+      // Last instance of this resource, set to nullptr
+      m_ResourceHead.Insert(pItem->m_pResource, nullptr);
+    }
+    else
+    {
+      // Update head to next item in list.
+      m_ResourceHead.Insert(pItem->m_pResource, pItem->m_pNextDependency);
+    }
+  }
+
+  *pItem = {};
+  pItem->m_pNextDependency = m_pFreeList;
+  m_pFreeList = pItem;
+}

--- a/Code/Engine/RendererFoundation/Utils/Implementation/DependencyTracker_inl.h
+++ b/Code/Engine/RendererFoundation/Utils/Implementation/DependencyTracker_inl.h
@@ -1,15 +1,15 @@
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 ezDependencyTracker<Resource, Dependency>::ezDependencyTracker()
 {
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 ezDependencyTracker<Resource, Dependency>::~ezDependencyTracker()
 {
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::AddResource(Resource* pResource, const ezSet<const Dependency*>& dependencies)
 {
   EZ_LOCK(m_Mutex);
@@ -22,10 +22,9 @@ void ezDependencyTracker<Resource, Dependency>::AddResource(Resource* pResource,
   {
     InsertItem(resourceHead, pResource, pDependency);
   }
-
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::RemoveResource(Resource* pResource)
 {
   EZ_LOCK(m_Mutex);
@@ -44,7 +43,7 @@ void ezDependencyTracker<Resource, Dependency>::RemoveResource(Resource* pResour
   m_ResourceHead.Remove(resourceHead);
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::DependencyDestroyed(Dependency* pDependency)
 {
   ezSet<Resource*> invalidResources;
@@ -72,7 +71,7 @@ void ezDependencyTracker<Resource, Dependency>::DependencyDestroyed(Dependency* 
   }
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::InsertItem(typename ResourceHeadMap::Iterator resourceHead, Resource* pResource, const Dependency* pDependency)
 {
   Item* pItem = nullptr;
@@ -108,7 +107,7 @@ void ezDependencyTracker<Resource, Dependency>::InsertItem(typename ResourceHead
   resourceHead.Value() = pItem;
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::RemoveResourceItem(typename ResourceHeadMap::ConstIterator resourceHead, Item* pItem)
 {
   if (pItem->m_pNextResource != nullptr)
@@ -142,7 +141,7 @@ void ezDependencyTracker<Resource, Dependency>::RemoveResourceItem(typename Reso
   m_pFreeList = pItem;
 }
 
-template<typename Resource, typename Dependency>
+template <typename Resource, typename Dependency>
 void ezDependencyTracker<Resource, Dependency>::RemoveDependencyItem(typename DependencyHeadMap::ConstIterator dependencyHead, Item* pItem)
 {
   if (pItem->m_pNextDependency != nullptr)

--- a/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
+++ b/Code/Engine/RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h
@@ -22,6 +22,8 @@ class ezFenceQueueVulkan;
 class ezGALGraphicsPipelineVulkan;
 class ezGALComputePipelineVulkan;
 struct ezGALBindGroupCreationDescription;
+class ezDescriptorWritePoolVulkan;
+class ezGALBindGroupVulkan;
 
 class EZ_RENDERERVULKAN_DLL ezGALCommandEncoderImplVulkan : public ezGALCommandEncoderCommonPlatformInterface
 {
@@ -35,10 +37,12 @@ public:
   void SetCurrentCommandBuffer(vk::CommandBuffer* commandBuffer, ezPipelineBarrierVulkan* pipelineBarrier);
   void BeforeCommandBufferSubmit();
   void AfterCommandBufferSubmit(vk::Fence submitFence);
+  ezDescriptorWritePoolVulkan& GetDescriptorWritePool() const;
 
   // ezGALCommandEncoderCommonPlatformInterface
   // State setting functions
   virtual void SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroupCreationDescription& bindGroup) override;
+  virtual void SetBindGroupPlatform(ezUInt32 uiBindGroup, const ezGALBindGroup* pBindGroup) override;
   virtual void SetPushConstantsPlatform(ezArrayPtr<const ezUInt8> data) override;
 
   // GPU -> CPU query functions
@@ -197,13 +201,11 @@ private:
 
   // Bind Groups
   ezGALBindGroupCreationDescription m_BindGroups[EZ_GAL_MAX_BIND_GROUPS];
+  const ezGALBindGroupVulkan* m_pBindGroups[EZ_GAL_MAX_BIND_GROUPS] = {};
   DynamicOffsets m_DynamicOffsets[EZ_GAL_MAX_BIND_GROUPS];
 
   // Descriptor Writes
-  ezDynamicArray<vk::WriteDescriptorSet> m_DescriptorWrites;
-  ezDeque<vk::DescriptorImageInfo> m_DescriptorImageInfos;
-  ezDeque<vk::DescriptorBufferInfo> m_DescriptorBufferInfos;
-  ezDeque<vk::BufferView> m_DescriptorBufferViews;
+  mutable ezUniquePtr<ezDescriptorWritePoolVulkan> m_pWritePool;
 
   // Actual bound descriptor sets
   ezHashTable<ezUInt64, vk::DescriptorSet> m_DescriptorCache;

--- a/Code/Engine/RendererVulkan/Device/DeclarationsVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeclarationsVulkan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
+#include <RendererFoundation/Descriptors/Enumerations.h>
 
 VK_DEFINE_HANDLE(ezVulkanAllocation)
 
@@ -28,4 +29,10 @@ struct ezPendingTextureCopyVulkan
   const ezGALTextureVulkan* m_pDstTexture = nullptr;
   vk::BufferImageCopy m_Region;
   vk::DeviceSize m_uiTotalSize;
+};
+
+/// \brief Used as a key to descriptor allocators. Defines the resource usage of each type inside a bind group layout.
+struct ezBindGroupLayoutResourceUsageVulkan
+{
+  ezUInt8 m_Usage[ezGALShaderResourceType::COUNT] = {0};
 };

--- a/Code/Engine/RendererVulkan/Device/DeclarationsVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeclarationsVulkan.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <vulkan/vulkan.hpp>
 #include <RendererFoundation/Descriptors/Enumerations.h>
+#include <vulkan/vulkan.hpp>
 
 VK_DEFINE_HANDLE(ezVulkanAllocation)
 

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -83,24 +83,23 @@ public:
   struct PendingDeletion
   {
     EZ_DECLARE_POD_TYPE();
-    vk::ObjectType m_type; ///< What type to cast m_pObject to.
+    vk::ObjectType m_type;                    ///< What type to cast m_pObject to.
     ezBitflags<PendingDeletionFlags> m_flags; ///< In case m_type == eUnknown, defines the custom deletion to be performed.
-    void* m_pObject; ///< The object to be deleted, usually cast to a vk::* type.
+    void* m_pObject;                          ///< The object to be deleted, usually cast to a vk::* type.
     union
     {
-      ezVulkanAllocation m_allocation; ///< For convenience to omit casting of m_pContext.
-      void* m_pContext; ///< 64bit of context data.
+      ezVulkanAllocation m_allocation;        ///< For convenience to omit casting of m_pContext.
+      void* m_pContext;                       ///< 64bit of context data.
     };
   };
 
   struct ReclaimResource
   {
     EZ_DECLARE_POD_TYPE();
-    vk::ObjectType m_type; ///< What type to cast m_pObject to.
-    ezUInt32 m_Data; ///< 32bit of context data.
-    void* m_pObject = nullptr; ///< The object to be reclaimed, usually cast to a vk::* type.
+    vk::ObjectType m_type;      ///< What type to cast m_pObject to.
+    ezUInt32 m_Data;            ///< 32bit of context data.
+    void* m_pObject = nullptr;  ///< The object to be reclaimed, usually cast to a vk::* type.
     void* m_pContext = nullptr; ///< 64bit of context data. Usually the object that reclaims the resource.
-
   };
 
   struct Extensions

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -49,6 +49,7 @@ class ezCommandBufferPoolVulkan;
 class ezStagingBufferPoolVulkan;
 class ezQueryPoolVulkan;
 class ezInitContextVulkan;
+class ezDescriptorWritePoolVulkan;
 
 /// \brief The Vulkan device implementation of the graphics abstraction layer.
 class EZ_RENDERERVULKAN_DLL ezGALDeviceVulkan : public ezGALDevice
@@ -82,22 +83,24 @@ public:
   struct PendingDeletion
   {
     EZ_DECLARE_POD_TYPE();
-    vk::ObjectType m_type;
-    ezBitflags<PendingDeletionFlags> m_flags;
-    void* m_pObject;
+    vk::ObjectType m_type; ///< What type to cast m_pObject to.
+    ezBitflags<PendingDeletionFlags> m_flags; ///< In case m_type == eUnknown, defines the custom deletion to be performed.
+    void* m_pObject; ///< The object to be deleted, usually cast to a vk::* type.
     union
     {
-      ezVulkanAllocation m_allocation;
-      void* m_pContext;
+      ezVulkanAllocation m_allocation; ///< For convenience to omit casting of m_pContext.
+      void* m_pContext; ///< 64bit of context data.
     };
   };
 
   struct ReclaimResource
   {
     EZ_DECLARE_POD_TYPE();
-    vk::ObjectType m_type;
-    void* m_pObject;
-    void* m_pContext = nullptr;
+    vk::ObjectType m_type; ///< What type to cast m_pObject to.
+    ezUInt32 m_Data; ///< 32bit of context data.
+    void* m_pObject = nullptr; ///< The object to be reclaimed, usually cast to a vk::* type.
+    void* m_pContext = nullptr; ///< 64bit of context data. Usually the object that reclaims the resource.
+
   };
 
   struct Extensions
@@ -169,6 +172,8 @@ public:
   ezFenceQueueVulkan& GetFenceQueue() const;
   ezStagingBufferPoolVulkan& GetStagingBufferPool() const;
   ezInitContextVulkan& GetInitContext() const;
+  ezDescriptorWritePoolVulkan& GetDescriptorWritePool() const;
+
 
   ezGALTextureHandle CreateTextureInternal(const ezGALTextureCreationDescription& Description, ezArrayPtr<ezGALSystemMemoryDescription> pInitialData);
   ezGALBufferHandle CreateBufferInternal(const ezGALBufferCreationDescription& Description, ezArrayPtr<const ezUInt8> pInitialData);
@@ -229,9 +234,9 @@ public:
   void ReclaimLater(const ReclaimResource& reclaim);
 
   template <typename T>
-  void ReclaimLater(T& object, void* pContext = nullptr)
+  void ReclaimLater(T& object, void* pContext = nullptr, ezUInt32 data = 0)
   {
-    ReclaimLater({object.objectType, (void*)object, pContext});
+    ReclaimLater({object.objectType, data, (void*)object, pContext});
     object = nullptr;
   }
 
@@ -322,6 +327,9 @@ protected:
 
   virtual ezGALBindGroupLayout* CreateBindGroupLayoutPlatform(const ezGALBindGroupLayoutCreationDescription& Description) override;
   virtual void DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBindGroupLayout) override;
+
+  virtual ezGALBindGroup* CreateBindGroupPlatform(const ezGALBindGroupCreationDescription& Description) override;
+  virtual void DestroyBindGroupPlatform(ezGALBindGroup* pBindGroup) override;
 
   virtual ezGALPipelineLayout* CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description) override;
   virtual void DestroyPipelineLayoutPlatform(ezGALPipelineLayout* pPipelineLayout) override;

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -19,12 +19,12 @@
 #include <RendererVulkan/Device/InitContext.h>
 #include <RendererVulkan/Device/SwapChainVulkan.h>
 #include <RendererVulkan/Pools/CommandBufferPoolVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Pools/FencePoolVulkan.h>
 #include <RendererVulkan/Pools/QueryPoolVulkan.h>
 #include <RendererVulkan/Pools/SemaphorePoolVulkan.h>
 #include <RendererVulkan/Pools/StagingBufferPoolVulkan.h>
 #include <RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h>
-#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/ReadbackBufferVulkan.h>
 #include <RendererVulkan/Resources/ReadbackTextureVulkan.h>

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -1633,6 +1633,7 @@ void ezGALDeviceVulkan::EndFramePlatform(ezArrayPtr<ezGALSwapChain*> swapchains)
     ezStats::SetStat("Vulkan/DescriptorSetsReused", encoderStats.m_uiDescriptorSetsReused);
     ezStats::SetStat("Vulkan/DescriptorWrites", encoderStats.m_uiDescriptorWrites);
     ezStats::SetStat("Vulkan/DynamicUniformBufferChanged", encoderStats.m_uiDynamicUniformBufferChanged);
+    ezStats::SetStat("Vulkan/DescriptorSetPools", ezDescriptorSetPoolVulkan::GetPoolCount());
   }
 }
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -13,19 +13,18 @@
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Device/SwapChain.h>
 #include <RendererFoundation/Profiling/Profiling.h>
-#include <RendererFoundation/RendererReflection.h>
-#include <RendererFoundation/Resources/RendererFallbackResources.h>
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
 #include <RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Device/InitContext.h>
 #include <RendererVulkan/Device/SwapChainVulkan.h>
 #include <RendererVulkan/Pools/CommandBufferPoolVulkan.h>
-#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Pools/FencePoolVulkan.h>
 #include <RendererVulkan/Pools/QueryPoolVulkan.h>
 #include <RendererVulkan/Pools/SemaphorePoolVulkan.h>
 #include <RendererVulkan/Pools/StagingBufferPoolVulkan.h>
+#include <RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/ReadbackBufferVulkan.h>
 #include <RendererVulkan/Resources/ReadbackTextureVulkan.h>
@@ -33,6 +32,7 @@
 #include <RendererVulkan/Resources/SharedTextureVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
 #include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Shader/BindGroupVulkan.h>
 #include <RendererVulkan/Shader/PipelineLayoutVulkan.h>
 #include <RendererVulkan/Shader/ShaderVulkan.h>
 #include <RendererVulkan/Shader/VertexDeclarationVulkan.h>
@@ -617,7 +617,8 @@ ezResult ezGALDeviceVulkan::InitPlatform()
   ezSemaphorePoolVulkan::Initialize(m_device);
   ezFencePoolVulkan::Initialize(m_device);
   ezResourceCacheVulkan::Initialize(this, m_device);
-  ezDescriptorSetPoolVulkan::Initialize(m_device);
+  ezTransientDescriptorSetPoolVulkan::Initialize(m_device);
+  ezDescriptorSetPoolVulkan::Initialize(this);
   ezImageCopyVulkan::Initialize(*this);
 
   m_pCommandEncoderImpl = EZ_NEW(&m_Allocator, ezGALCommandEncoderImplVulkan, *this);
@@ -760,6 +761,7 @@ ezResult ezGALDeviceVulkan::ShutdownPlatform()
   ezFencePoolVulkan::DeInitialize();
   ezResourceCacheVulkan::DeInitialize();
   ezDescriptorSetPoolVulkan::DeInitialize();
+  ezTransientDescriptorSetPoolVulkan::DeInitialize();
   ezMemoryAllocatorVulkan::DeInitialize();
 
   m_device.waitIdle();
@@ -1107,6 +1109,28 @@ void ezGALDeviceVulkan::DestroyBindGroupLayoutPlatform(ezGALBindGroupLayout* pBi
   ezGALBindGroupLayoutVulkan* pVulkanBindGroupLayout = static_cast<ezGALBindGroupLayoutVulkan*>(pBindGroupLayout);
   pVulkanBindGroupLayout->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pVulkanBindGroupLayout);
+}
+
+ezGALBindGroup* ezGALDeviceVulkan::CreateBindGroupPlatform(const ezGALBindGroupCreationDescription& Description)
+{
+  ezGALBindGroupVulkan* pVulkanBindGroup = EZ_NEW(&m_Allocator, ezGALBindGroupVulkan, Description);
+
+  if (pVulkanBindGroup->InitPlatform(this).Succeeded())
+  {
+    return pVulkanBindGroup;
+  }
+  else
+  {
+    EZ_DELETE(&m_Allocator, pVulkanBindGroup);
+    return nullptr;
+  }
+}
+
+void ezGALDeviceVulkan::DestroyBindGroupPlatform(ezGALBindGroup* pBindGroup)
+{
+  ezGALBindGroupVulkan* pVulkanBindGroup = static_cast<ezGALBindGroupVulkan*>(pBindGroup);
+  pVulkanBindGroup->DeInitPlatform(this).IgnoreResult();
+  EZ_DELETE(&m_Allocator, pVulkanBindGroup);
 }
 
 ezGALPipelineLayout* ezGALDeviceVulkan::CreatePipelineLayoutPlatform(const ezGALPipelineLayoutCreationDescription& Description)
@@ -1879,6 +1903,9 @@ void ezGALDeviceVulkan::DeletePendingResources(ezDeque<PendingDeletion>& pending
       case vk::ObjectType::ePipelineLayout:
         m_device.destroyPipelineLayout(reinterpret_cast<vk::PipelineLayout&>(deletion.m_pObject));
         break;
+      case vk::ObjectType::eDescriptorPool:
+        m_device.destroyDescriptorPool(reinterpret_cast<vk::DescriptorPool&>(deletion.m_pObject));
+        break;
       default:
         EZ_REPORT_FAILURE("This object type is not implemented");
         break;
@@ -1903,7 +1930,10 @@ void ezGALDeviceVulkan::ReclaimResources(ezDeque<ReclaimResource>& resources)
         static_cast<ezCommandBufferPoolVulkan*>(resource.m_pContext)->ReclaimCommandBuffer(reinterpret_cast<vk::CommandBuffer&>(resource.m_pObject));
         break;
       case vk::ObjectType::eDescriptorPool:
-        ezDescriptorSetPoolVulkan::ReclaimPool(reinterpret_cast<vk::DescriptorPool&>(resource.m_pObject));
+        ezTransientDescriptorSetPoolVulkan::ReclaimPool(reinterpret_cast<vk::DescriptorPool&>(resource.m_pObject));
+        break;
+      case vk::ObjectType::eDescriptorSet:
+        static_cast<ezDescriptorSetPoolVulkan*>(resource.m_pContext)->ReclaimDescriptorSet(reinterpret_cast<vk::DescriptorSet&>(resource.m_pObject), {resource.m_Data});
         break;
       default:
         EZ_REPORT_FAILURE("This object type is not implemented");
@@ -2162,6 +2192,11 @@ void ezGALDeviceVulkan::DestroyComputePipelinePlatform(ezGALComputePipeline* pCo
   ezGALComputePipelineVulkan* pComputePipelineVulkan = static_cast<ezGALComputePipelineVulkan*>(pComputePipeline);
   pComputePipelineVulkan->DeInitPlatform(this).IgnoreResult();
   EZ_DELETE(&m_Allocator, pComputePipelineVulkan);
+}
+
+ezDescriptorWritePoolVulkan& ezGALDeviceVulkan::GetDescriptorWritePool() const
+{
+  return m_pCommandEncoderImpl->GetDescriptorWritePool();
 }
 
 EZ_STATICLINK_FILE(RendererVulkan, RendererVulkan_Device_Implementation_DeviceVulkan);

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <RendererVulkan/RendererVulkanDLL.h>
 #include <RendererVulkan/Device/DeclarationsVulkan.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
 
 class ezGALDeviceVulkan;
 
@@ -44,7 +44,7 @@ private:
   static ezGALDeviceVulkan* s_pDevice;
   static ezMutex s_Mutex;
   static ezHashTable<ezBindGroupLayoutResourceUsageVulkan, ezSharedPtr<ezDescriptorSetPoolVulkan>, ResourceUsageHash> s_Pools; ///< Cache of all pools
-  static ezHashSet<ezDescriptorSetPoolVulkan*> s_DirtyPools;                                                    ///< Pools that need to free resources and can potentially be destroyed.
+  static ezHashSet<ezDescriptorSetPoolVulkan*> s_DirtyPools;                                                                   ///< Pools that need to free resources and can potentially be destroyed.
 
 private:
   struct DescriptorSubPool
@@ -65,11 +65,11 @@ private:
 private:
   ezMutex m_Mutex;
   ezGALDeviceVulkan* m_pDevice = nullptr;
-  ezBindGroupLayoutResourceUsageVulkan m_ResourceUsage;                       ///< How many resources of each type each descriptor set uses.
+  ezBindGroupLayoutResourceUsageVulkan m_ResourceUsage;        ///< How many resources of each type each descriptor set uses.
   ezUInt32 m_uiNextPoolSize = 64;                              ///< When the current pool runs out of data, allocate next pool with this size and double the value.
   ezUInt32 m_uiTotalAllocations = 0;                           ///< Total allocations across all sub-pools.
 
-  ezUInt32 m_uiActivePool = ezInvalidIndex;                  ///< The current pool with free allocations.
+  ezUInt32 m_uiActivePool = ezInvalidIndex;                    ///< The current pool with free allocations.
   ezHybridArray<ezUniquePtr<DescriptorSubPool>, 1> m_SubPools; ///< Available descriptor sub-pools.
   ezHashSet<DescriptorSubPool*> m_DirtySubPools;               ///< Descriptor sub-pools that have sets that need to be freed.
 };

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -14,6 +14,7 @@ public:
   static void Initialize(ezGALDeviceVulkan* pDevice);
   static void DeInitialize();
   static ezSharedPtr<ezDescriptorSetPoolVulkan> GetPool(const ezBindGroupLayoutResourceUsageVulkan& resourceUsage);
+  static ezUInt32 GetPoolCount();
   static void MarkPoolDirty(ezDescriptorSetPoolVulkan* pPool);
   static void BeginFrame();
 

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -1,36 +1,75 @@
 #pragma once
 
 #include <RendererVulkan/RendererVulkanDLL.h>
+#include <RendererVulkan/Device/DeclarationsVulkan.h>
 
-#include <vulkan/vulkan.hpp>
+class ezGALDeviceVulkan;
 
-EZ_DEFINE_AS_POD_TYPE(vk::DescriptorType);
-
-template <>
-struct ezHashHelper<vk::DescriptorType>
-{
-  EZ_ALWAYS_INLINE static ezUInt32 Hash(vk::DescriptorType value) { return ezHashHelper<ezUInt32>::Hash(ezUInt32(value)); }
-  EZ_ALWAYS_INLINE static bool Equal(vk::DescriptorType a, vk::DescriptorType b) { return a == b; }
-};
-
-class EZ_RENDERERVULKAN_DLL ezDescriptorSetPoolVulkan
+/// \brief Creates persistent descriptor sets.
+/// Each bind group layout requests a pool via GetPool. There is one pool for each resource usage distribution. This is efficient because the spec says: "Additionally, if all sets allocated from the pool since it was created or most recently reset use the same number of descriptors (of each type) and the requested allocation also uses that same number of descriptors (of each type), then fragmentation must not cause an allocation failure."
+/// Each pool will create sub-pools in increasing size once all current pools are full.
+class EZ_RENDERERVULKAN_DLL ezDescriptorSetPoolVulkan : public ezRefCounted
 {
 public:
-  static void Initialize(vk::Device device);
+  static void Initialize(ezGALDeviceVulkan* pDevice);
   static void DeInitialize();
-  static ezHashTable<vk::DescriptorType, float>& AccessDescriptorPoolWeights();
+  static ezSharedPtr<ezDescriptorSetPoolVulkan> GetPool(const ezBindGroupLayoutResourceUsageVulkan& resourceUsage);
+  static void MarkPoolDirty(ezDescriptorSetPoolVulkan* pPool);
+  static void BeginFrame();
 
-  static vk::DescriptorSet CreateDescriptorSet(vk::DescriptorSetLayout layout);
-  static void UpdateDescriptorSet(vk::DescriptorSet descriptorSet, ezArrayPtr<vk::WriteDescriptorSet> update);
-  static void ReclaimPool(vk::DescriptorPool& descriptorPool);
+public:
+  ~ezDescriptorSetPoolVulkan();
+
+  struct Allocation
+  {
+    ezUInt32 m_uiPoolIndex = 0;
+  };
+
+  /// \brief Creates a descriptor set for the given layout.
+  /// \param hBindGroupLayout The layout for which to create the descriptor set.
+  /// \param out_Allocation Filled out by the call. Needs to be passed in ReclaimDescriptorSet once the descriptor set is no longer used by the GPU.
+  vk::DescriptorSet CreateDescriptorSet(ezGALBindGroupLayoutHandle hBindGroupLayout, Allocation& out_Allocation);
+
+  /// \brief Reclaims a descriptor set for reuse.
+  /// This function should only be called by ezGALDeviceVulkan when it is safe to reuse the descriptor set. To reclaim a descriptor set created via CreateDescriptorSet, call ezGALDeviceVulkan->ReclaimLater(vk::DescriptorSet, ezDescriptorSetPoolVulkan*, Allocation::m_uiPoolIndex);
+  void ReclaimDescriptorSet(vk::DescriptorSet descriptorSet, Allocation allocation);
 
 private:
-  static constexpr ezUInt32 s_uiPoolBaseSize = 1024;
+  struct ResourceUsageHash
+  {
+    EZ_ALWAYS_INLINE static ezUInt32 Hash(const ezBindGroupLayoutResourceUsageVulkan& a);
+    EZ_ALWAYS_INLINE static bool Equal(const ezBindGroupLayoutResourceUsageVulkan& a, const ezBindGroupLayoutResourceUsageVulkan& b);
+  };
 
-  static vk::DescriptorPool GetNewPool();
+  static ezGALDeviceVulkan* s_pDevice;
+  static ezMutex s_Mutex;
+  static ezHashTable<ezBindGroupLayoutResourceUsageVulkan, ezSharedPtr<ezDescriptorSetPoolVulkan>, ResourceUsageHash> s_Pools; ///< Cache of all pools
+  static ezHashSet<ezDescriptorSetPoolVulkan*> s_DirtyPools;                                                    ///< Pools that need to free resources and can potentially be destroyed.
 
-  static vk::DescriptorPool s_currentPool;
-  static ezHybridArray<vk::DescriptorPool, 4> s_freePools;
-  static vk::Device s_device;
-  static ezHashTable<vk::DescriptorType, float> s_descriptorWeights;
+private:
+  struct DescriptorSubPool
+  {
+    vk::DescriptorPool m_DescriptorPool;
+    ezUInt32 m_uiPoolSize = 0;
+    ezUInt32 m_uiAllocatedSets = 0;
+    ezDynamicArray<vk::DescriptorSet> m_Reclaim;
+  };
+
+  ezDescriptorSetPoolVulkan(ezGALDeviceVulkan* pDevice, const ezBindGroupLayoutResourceUsageVulkan& resourceUsage);
+  ezUInt32 GetFreePoolIndex();
+
+  /// \brief Reclaims resources previously added via ReclaimDescriptorSet.
+  /// \return Returns true if the pool no longer holds any descriptor sets and can thus be safely deleted.
+  bool ReclaimResources();
+
+private:
+  ezMutex m_Mutex;
+  ezGALDeviceVulkan* m_pDevice = nullptr;
+  ezBindGroupLayoutResourceUsageVulkan m_ResourceUsage;                       ///< How many resources of each type each descriptor set uses.
+  ezUInt32 m_uiNextPoolSize = 64;                              ///< When the current pool runs out of data, allocate next pool with this size and double the value.
+  ezUInt32 m_uiTotalAllocations = 0;                           ///< Total allocations across all sub-pools.
+
+  ezUInt32 m_uiActivePool = ezInvalidIndex;                  ///< The current pool with free allocations.
+  ezHybridArray<ezUniquePtr<DescriptorSubPool>, 1> m_SubPools; ///< Available descriptor sub-pools.
+  ezHashSet<DescriptorSubPool*> m_DirtySubPools;               ///< Descriptor sub-pools that have sets that need to be freed.
 };

--- a/Code/Engine/RendererVulkan/Pools/DescriptorWritePoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorWritePoolVulkan.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <RendererVulkan/RendererVulkanDLL.h>
+#include <vulkan/vulkan.hpp>
+
+class ezGALDeviceVulkan;
+class ezUniformBufferPoolVulkan;
+struct ezShaderResourceBinding;
+struct ezGALBindGroupItem;
+
+/// \brief A thread-safe pool for batching Vulkan descriptor sets writes.
+///
+/// This class manages the creation and batching of Vulkan descriptor set writes, supporting both transient and persistent descriptor set updates.
+/// All writes are batched and flushed together to minimize API calls before the next bindDescriptorSets call.
+class EZ_RENDERERVULKAN_DLL ezDescriptorWritePoolVulkan
+{
+public:
+  ezDescriptorWritePoolVulkan(ezGALDeviceVulkan* pDevice);
+
+  /// \brief Writes a transient descriptor set with resources that may include dynamic uniform buffers.
+  ///
+  /// This method is used for transient descriptor sets that contain resources which may be allocated from a uniform buffer pool. Transient constant buffers are handled specially by using the uniform buffer pool to obtain their actual buffer info. Offsets are handled separately in ezGALCommandEncoderImplVulkan::UpdateDynamicUniformBufferOffsets.
+  ///
+  /// \param descriptorSet The Vulkan descriptor set to write to.
+  /// \param desc The bind group creation description containing the resources to write.
+  /// \param pUniformBufferPool Pointer to the uniform buffer pool for resolving transient buffers.
+  void WriteTransientDescriptor(vk::DescriptorSet descriptorSet, const ezGALBindGroupCreationDescription& desc, ezUniformBufferPoolVulkan* pUniformBufferPool);
+
+  /// \brief Writes a persistent descriptor set and extracts dynamic buffer offsets.
+  ///
+  /// This method is used for persistent descriptor sets used by bind group resources. We tag every constant buffer as dynamic in the layout, so we need to extract the offsets for each constant buffer here. The offsets are extracted and stored in the output array for later use during command buffer recording.
+  ///
+  /// \param descriptorSet The Vulkan descriptor set to write to.
+  /// \param desc The bind group creation description containing the resources to write.
+  /// \param out_Offsets Output array that will be filled with dynamic buffer offsets for constant buffers. See ezGALBindGroupVulkan::GetOffsets.
+  void WriteDescriptor(vk::DescriptorSet descriptorSet, const ezGALBindGroupCreationDescription& desc, ezDynamicArray<ezUInt32>& out_Offsets);
+
+  /// \brief Flushes all pending descriptor writes to the GPU.
+  ///
+  /// Right now, this method must be executed before each call to bindDescriptorSets until VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT is used (Vulkan 1.2). https://registry.khronos.org/vulkan/specs/latest/man/html/VkDescriptorSetLayoutBindingFlagsCreateInfo.html. As we can't guarantee that the API is available, only the inefficient version is implemented for now.
+  ///
+  /// \return The number of descriptor writes that were flushed
+  ezUInt32 FlushWrites();
+
+private:
+  vk::WriteDescriptorSet& WriteBindGroupItem(vk::DescriptorSet descriptorSet, const ezShaderResourceBinding& binding, const ezGALBindGroupItem& item, ezUniformBufferPoolVulkan* pUniformBufferPool);
+
+private:
+  ezGALDeviceVulkan* m_pDevice = nullptr;
+  ezMutex m_Mutex;
+  ezDynamicArray<vk::WriteDescriptorSet> m_DescriptorWrites;
+  ezDeque<vk::DescriptorImageInfo> m_DescriptorImageInfos;
+  ezDeque<vk::DescriptorBufferInfo> m_DescriptorBufferInfos;
+  ezDeque<vk::BufferView> m_DescriptorBufferViews;
+};

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -2,140 +2,201 @@
 
 #include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
+#include <RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 
+//////////////////////////////////////////////////////////////////////
 
-vk::DescriptorPool ezDescriptorSetPoolVulkan::s_currentPool;
-ezHybridArray<vk::DescriptorPool, 4> ezDescriptorSetPoolVulkan::s_freePools;
-vk::Device ezDescriptorSetPoolVulkan::s_device;
-ezHashTable<vk::DescriptorType, float> ezDescriptorSetPoolVulkan::s_descriptorWeights;
+ezGALDeviceVulkan* ezDescriptorSetPoolVulkan::s_pDevice = nullptr;
+ezMutex ezDescriptorSetPoolVulkan::s_Mutex;
+ezHashTable<ezBindGroupLayoutResourceUsageVulkan, ezSharedPtr<ezDescriptorSetPoolVulkan>, ezDescriptorSetPoolVulkan::ResourceUsageHash> ezDescriptorSetPoolVulkan::s_Pools;
+ezHashSet<ezDescriptorSetPoolVulkan*> ezDescriptorSetPoolVulkan::s_DirtyPools;
 
-void ezDescriptorSetPoolVulkan::Initialize(vk::Device device)
+ezUInt32 ezDescriptorSetPoolVulkan::ResourceUsageHash::Hash(const ezBindGroupLayoutResourceUsageVulkan& a)
 {
-  s_device = device;
-  s_descriptorWeights[vk::DescriptorType::eSampler] = 0.5f;              // Image sampler.
-  s_descriptorWeights[vk::DescriptorType::eSampledImage] = 2.0f;         // Read-only image view.
-  s_descriptorWeights[vk::DescriptorType::eStorageImage] = 1.0f;         // Read / write image view.
-  s_descriptorWeights[vk::DescriptorType::eUniformBuffer] = 1.0f;        // Read-only struct (constant buffer)
-  s_descriptorWeights[vk::DescriptorType::eStorageBuffer] = 1.0f;        // Read / write struct (UAV).
-  s_descriptorWeights[vk::DescriptorType::eUniformTexelBuffer] = 0.5f;   // Read-only linear texel buffer with view.
-  s_descriptorWeights[vk::DescriptorType::eCombinedImageSampler] = 2.0f; // Read-only image view with image sampler.
+  return ezHashingUtils::xxHash32(&a.m_Usage[0], ezGALShaderResourceType::COUNT);
+}
 
-  // Not used by EZ so far.
-  s_descriptorWeights[vk::DescriptorType::eStorageTexelBuffer] = 0.5f;   // Read / write linear texel buffer with view.
-  s_descriptorWeights[vk::DescriptorType::eUniformBufferDynamic] = 1.0f; // Same as eUniformBuffer but allows updating the memory offset into the buffer dynamically.
-  s_descriptorWeights[vk::DescriptorType::eStorageBufferDynamic] = 0.0f; // Same as eStorageBuffer but allows updating the memory offset into the buffer dynamically.
+bool ezDescriptorSetPoolVulkan::ResourceUsageHash::Equal(const ezBindGroupLayoutResourceUsageVulkan& a, const ezBindGroupLayoutResourceUsageVulkan& b)
+{
+  for (ezUInt32 i = 0; i < ezGALShaderResourceType::COUNT; ++i)
+  {
+    if (a.m_Usage[i] != b.m_Usage[i])
+      return false;
+  }
 
-  // Not supported by EZ so far.
-  s_descriptorWeights[vk::DescriptorType::eInputAttachment] = 0.0f; // frame-buffer local read-only image view.
+  return true;
+}
 
-  s_descriptorWeights[vk::DescriptorType::eInlineUniformBlock] = 0.0f;
-  s_descriptorWeights[vk::DescriptorType::eAccelerationStructureKHR] = 0.0f;
-  s_descriptorWeights[vk::DescriptorType::eAccelerationStructureNV] = 0.0f;
-  s_descriptorWeights[vk::DescriptorType::eMutableVALVE] = 0.0f;
+void ezDescriptorSetPoolVulkan::Initialize(ezGALDeviceVulkan* pDevice)
+{
+  s_pDevice = pDevice;
 }
 
 void ezDescriptorSetPoolVulkan::DeInitialize()
 {
-  s_descriptorWeights.Clear();
-  s_descriptorWeights.Compact();
-
-  for (vk::DescriptorPool& pool : s_freePools)
+  // Destroy all pools, make sure ref count is zero.
+  for (auto it : s_Pools)
   {
-    s_device.destroyDescriptorPool(pool, nullptr);
+    EZ_ASSERT_DEBUG(it.Value()->GetRefCount() == 1, "Pool still referenced. A bind group layout probably leaked");
   }
-  s_freePools.Clear();
-  s_freePools.Compact();
-  if (s_currentPool)
-  {
-    s_device.resetDescriptorPool(s_currentPool);
-    s_device.destroyDescriptorPool(s_currentPool, nullptr);
-    s_currentPool = nullptr;
-  }
-
-  s_device = nullptr;
+  s_Pools.Clear();
+  s_Pools.Compact();
+  s_DirtyPools.Clear();
+  s_DirtyPools.Compact();
+  s_pDevice = nullptr;
 }
 
-ezHashTable<vk::DescriptorType, float>& ezDescriptorSetPoolVulkan::AccessDescriptorPoolWeights()
+ezSharedPtr<ezDescriptorSetPoolVulkan> ezDescriptorSetPoolVulkan::GetPool(const ezBindGroupLayoutResourceUsageVulkan& resourceUsage)
 {
-  return s_descriptorWeights;
+  EZ_LOCK(s_Mutex);
+  auto it = s_Pools.Find(resourceUsage);
+  if (it.IsValid())
+  {
+    return it.Value();
+  }
+
+  ezSharedPtr<ezDescriptorSetPoolVulkan> pPool = EZ_DEFAULT_NEW(ezDescriptorSetPoolVulkan, s_pDevice, resourceUsage);
+  s_Pools[resourceUsage] = pPool;
+
+  return pPool;
 }
 
-vk::DescriptorSet ezDescriptorSetPoolVulkan::CreateDescriptorSet(vk::DescriptorSetLayout layout)
+void ezDescriptorSetPoolVulkan::MarkPoolDirty(ezDescriptorSetPoolVulkan* pPool)
 {
+  EZ_LOCK(s_Mutex);
+  s_DirtyPools.Insert(pPool);
+}
+
+void ezDescriptorSetPoolVulkan::BeginFrame()
+{
+  EZ_LOCK(s_Mutex);
+  for (ezDescriptorSetPoolVulkan* pPool : s_DirtyPools)
+  {
+    if (pPool->ReclaimResources())
+    {
+      // #TODO_VULKAN: We should delete the pool to free resources.
+    }
+  }
+  s_DirtyPools.Clear();
+}
+
+ezDescriptorSetPoolVulkan::ezDescriptorSetPoolVulkan(ezGALDeviceVulkan* pDevice, const ezBindGroupLayoutResourceUsageVulkan& resourceUsage)
+  : m_pDevice(pDevice)
+  , m_ResourceUsage(resourceUsage)
+{
+}
+
+ezDescriptorSetPoolVulkan::~ezDescriptorSetPoolVulkan()
+{
+  ReclaimResources();
+  EZ_ASSERT_DEBUG(m_uiTotalAllocations == 0, "A descriptor set has leaked, probably caused by a bind group not being freed before shutting down the GAL device");
+  for (ezUniquePtr<DescriptorSubPool>& pool : m_SubPools)
+  {
+    m_pDevice->GetVulkanDevice().destroyDescriptorPool(pool->m_DescriptorPool);
+  }
+  m_SubPools.Clear();
+}
+
+vk::DescriptorSet ezDescriptorSetPoolVulkan::CreateDescriptorSet(ezGALBindGroupLayoutHandle hBindGroupLayout, ezDescriptorSetPoolVulkan::Allocation& out_Allocation)
+{
+  EZ_LOCK(m_Mutex);
+  ezUInt32 uiPoolIndex = GetFreePoolIndex();
+  DescriptorSubPool* pSubPool = m_SubPools[uiPoolIndex].Borrow();
+
+  const ezGALBindGroupLayoutVulkan* pLayout = static_cast<const ezGALBindGroupLayoutVulkan*>(m_pDevice->GetBindGroupLayout(hBindGroupLayout));
+
   vk::DescriptorSet set;
-  if (!s_currentPool)
-  {
-    s_currentPool = GetNewPool();
-  }
-
   vk::DescriptorSetAllocateInfo allocateInfo;
-  allocateInfo.pSetLayouts = &layout;
-  allocateInfo.descriptorPool = s_currentPool;
+  allocateInfo.pSetLayouts = &pLayout->GetDescriptorSetLayout();
+  allocateInfo.descriptorPool = pSubPool->m_DescriptorPool;
   allocateInfo.descriptorSetCount = 1;
 
-  vk::Result res = s_device.allocateDescriptorSets(&allocateInfo, &set);
-  bool bPoolExhausted = false;
+  VK_ASSERT_DEV(m_pDevice->GetVulkanDevice().allocateDescriptorSets(&allocateInfo, &set));
 
-  switch (res)
-  {
-    case vk::Result::eSuccess:
-      break;
-    case vk::Result::eErrorFragmentedPool:
-    case vk::Result::eErrorOutOfPoolMemory:
-      bPoolExhausted = true;
-      break;
-    default:
-      VK_ASSERT_DEV(res);
-      break;
-  }
+  ++m_uiTotalAllocations;
+  ++pSubPool->m_uiAllocatedSets;
 
-  if (bPoolExhausted)
-  {
-    ezGALDeviceVulkan* pDevice = static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice());
-    pDevice->ReclaimLater(s_currentPool);
-    s_currentPool = GetNewPool();
-    allocateInfo.descriptorPool = s_currentPool;
-    VK_ASSERT_DEV(s_device.allocateDescriptorSets(&allocateInfo, &set));
-  }
+  out_Allocation.m_uiPoolIndex = uiPoolIndex;
 
   return set;
 }
 
-void ezDescriptorSetPoolVulkan::UpdateDescriptorSet(vk::DescriptorSet descriptorSet, ezArrayPtr<vk::WriteDescriptorSet> update)
+void ezDescriptorSetPoolVulkan::ReclaimDescriptorSet(vk::DescriptorSet descriptorSet, Allocation allocation)
 {
-  s_device.updateDescriptorSets(update.GetCount(), update.GetPtr(), 0, nullptr);
-}
-
-void ezDescriptorSetPoolVulkan::ReclaimPool(vk::DescriptorPool& descriptorPool)
-{
-  s_device.resetDescriptorPool(descriptorPool);
-  s_freePools.PushBack(descriptorPool);
-}
-
-vk::DescriptorPool ezDescriptorSetPoolVulkan::GetNewPool()
-{
-  if (s_freePools.IsEmpty())
+  bool bMarkPoolDirty = false;
   {
-    ezHybridArray<vk::DescriptorPoolSize, 20> poolSizes;
-    for (auto weight : s_descriptorWeights)
+    EZ_LOCK(m_Mutex);
+    DescriptorSubPool* pPool = m_SubPools[allocation.m_uiPoolIndex].Borrow();
+    pPool->m_Reclaim.PushBack(descriptorSet);
+    if (!m_DirtySubPools.Contains(pPool))
     {
-      if (static_cast<ezUInt32>(weight.Value() * s_uiPoolBaseSize) > 0)
-        poolSizes.PushBack(vk::DescriptorPoolSize(weight.Key(), static_cast<ezUInt32>(weight.Value() * s_uiPoolBaseSize)));
+      m_DirtySubPools.Insert(pPool);
+      bMarkPoolDirty = true;
     }
+  }
+
+  if (bMarkPoolDirty)
+  {
+    ezDescriptorSetPoolVulkan::MarkPoolDirty(this);
+  }
+}
+
+ezUInt32 ezDescriptorSetPoolVulkan::GetFreePoolIndex()
+{
+  if (m_uiActivePool != ezInvalidIndex && m_SubPools[m_uiActivePool]->m_uiAllocatedSets < m_SubPools[m_uiActivePool]->m_uiPoolSize)
+  {
+    return m_uiActivePool;
+  }
+
+  for (ezInt32 poolIndex = (ezInt32)m_SubPools.GetCount() - 1; poolIndex >= 0; --poolIndex)
+  {
+    if (m_SubPools[poolIndex]->m_uiAllocatedSets < m_SubPools[poolIndex]->m_uiPoolSize)
+    {
+      m_uiActivePool = poolIndex;
+      return m_uiActivePool;
+    }
+  }
+
+  ezUniquePtr<DescriptorSubPool> pSubPool = EZ_DEFAULT_NEW(DescriptorSubPool);
+  pSubPool->m_uiPoolSize = m_uiNextPoolSize;
+  {
+    // Create Vulkan descriptor pool
+    ezHybridArray<vk::DescriptorPoolSize, ezGALShaderResourceType::COUNT> poolSizes;
     vk::DescriptorPoolCreateInfo poolCreateInfo;
-    poolCreateInfo.flags = {};
-    poolCreateInfo.maxSets = s_uiPoolBaseSize;
+    poolCreateInfo.flags = vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet;
+    poolCreateInfo.maxSets = m_uiNextPoolSize;
     poolCreateInfo.poolSizeCount = poolSizes.GetCount();
     poolCreateInfo.pPoolSizes = poolSizes.GetData();
+    for (ezUInt32 i = 0; i < ezGALShaderResourceType::COUNT; ++i)
+    {
+      if (m_ResourceUsage.m_Usage[i] > 0)
+        poolSizes.PushBack(vk::DescriptorPoolSize(ezConversionUtilsVulkan::GetDescriptorType((ezGALShaderResourceType::Enum)i), m_ResourceUsage.m_Usage[i] * m_uiNextPoolSize));
+    }
+    VK_ASSERT_DEV(m_pDevice->GetVulkanDevice().createDescriptorPool(&poolCreateInfo, nullptr, &pSubPool->m_DescriptorPool));
+  }
+  m_SubPools.PushBack(std::move(pSubPool));
+  m_uiActivePool = m_SubPools.GetCount() - 1;
 
-    vk::DescriptorPool descriptorPool;
-    VK_ASSERT_DEV(s_device.createDescriptorPool(&poolCreateInfo, nullptr, &descriptorPool));
-    return descriptorPool;
-  }
-  else
+  m_uiNextPoolSize *= 2;
+
+  return m_uiActivePool;
+}
+
+bool ezDescriptorSetPoolVulkan::ReclaimResources()
+{
+  EZ_LOCK(m_Mutex);
+
+  for (DescriptorSubPool* pSubPool : m_DirtySubPools)
   {
-    vk::DescriptorPool pool = s_freePools.PeekBack();
-    s_freePools.PopBack();
-    return pool;
+    const ezUInt32 uiReclaimCount = pSubPool->m_Reclaim.GetCount();
+    m_pDevice->GetVulkanDevice().freeDescriptorSets(pSubPool->m_DescriptorPool, uiReclaimCount, pSubPool->m_Reclaim.GetData());
+    pSubPool->m_uiAllocatedSets -= uiReclaimCount;
+    m_uiTotalAllocations -= uiReclaimCount;
+    pSubPool->m_Reclaim.Clear();
   }
+  m_DirtySubPools.Clear();
+
+  return m_uiTotalAllocations == 0;
 }

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -169,7 +169,7 @@ ezUInt32 ezDescriptorSetPoolVulkan::GetFreePoolIndex()
       if (m_ResourceUsage.m_Usage[i] > 0)
         poolSizes.PushBack(vk::DescriptorPoolSize(ezConversionUtilsVulkan::GetDescriptorType((ezGALShaderResourceType::Enum)i), m_ResourceUsage.m_Usage[i] * m_uiNextPoolSize));
     }
-    
+
     vk::DescriptorPoolCreateInfo poolCreateInfo;
     poolCreateInfo.flags = vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet;
     poolCreateInfo.maxSets = m_uiNextPoolSize;

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -63,6 +63,11 @@ ezSharedPtr<ezDescriptorSetPoolVulkan> ezDescriptorSetPoolVulkan::GetPool(const 
   return pPool;
 }
 
+ezUInt32 ezDescriptorSetPoolVulkan::GetPoolCount()
+{
+  return s_Pools.GetCount();
+}
+
 void ezDescriptorSetPoolVulkan::MarkPoolDirty(ezDescriptorSetPoolVulkan* pPool)
 {
   EZ_LOCK(s_Mutex);

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorSetPoolVulkan.cpp
@@ -164,16 +164,18 @@ ezUInt32 ezDescriptorSetPoolVulkan::GetFreePoolIndex()
   {
     // Create Vulkan descriptor pool
     ezHybridArray<vk::DescriptorPoolSize, ezGALShaderResourceType::COUNT> poolSizes;
-    vk::DescriptorPoolCreateInfo poolCreateInfo;
-    poolCreateInfo.flags = vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet;
-    poolCreateInfo.maxSets = m_uiNextPoolSize;
-    poolCreateInfo.poolSizeCount = poolSizes.GetCount();
-    poolCreateInfo.pPoolSizes = poolSizes.GetData();
     for (ezUInt32 i = 0; i < ezGALShaderResourceType::COUNT; ++i)
     {
       if (m_ResourceUsage.m_Usage[i] > 0)
         poolSizes.PushBack(vk::DescriptorPoolSize(ezConversionUtilsVulkan::GetDescriptorType((ezGALShaderResourceType::Enum)i), m_ResourceUsage.m_Usage[i] * m_uiNextPoolSize));
     }
+    
+    vk::DescriptorPoolCreateInfo poolCreateInfo;
+    poolCreateInfo.flags = vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet;
+    poolCreateInfo.maxSets = m_uiNextPoolSize;
+    poolCreateInfo.poolSizeCount = poolSizes.GetCount();
+    poolCreateInfo.pPoolSizes = poolSizes.GetData();
+
     VK_ASSERT_DEV(m_pDevice->GetVulkanDevice().createDescriptorPool(&poolCreateInfo, nullptr, &pSubPool->m_DescriptorPool));
   }
   m_SubPools.PushBack(std::move(pSubPool));

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorWritePoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorWritePoolVulkan.cpp
@@ -1,0 +1,153 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Pools/DescriptorWritePoolVulkan.h>
+
+#include <RendererFoundation/Shader/BindGroup.h>
+#include <RendererVulkan/Pools/UniformBufferPoolVulkan.h>
+#include <RendererVulkan/Resources/BufferVulkan.h>
+#include <RendererVulkan/Resources/TextureVulkan.h>
+#include <RendererVulkan/State/StateVulkan.h>
+
+ezDescriptorWritePoolVulkan::ezDescriptorWritePoolVulkan(ezGALDeviceVulkan* pDevice)
+: m_pDevice(pDevice)
+{
+}
+
+void ezDescriptorWritePoolVulkan::WriteTransientDescriptor(vk::DescriptorSet descriptorSet, const ezGALBindGroupCreationDescription& desc, ezUniformBufferPoolVulkan* pUniformBufferPool)
+{
+  const ezGALBindGroupLayoutVulkan* pLayout = static_cast<const ezGALBindGroupLayoutVulkan*>(m_pDevice->GetBindGroupLayout(desc.m_hBindGroupLayout));
+  ezArrayPtr<const ezShaderResourceBinding> bindings = pLayout->GetDescription().m_ResourceBindings;
+  const ezUInt32 uiBindings = bindings.GetCount();
+
+  EZ_LOCK(m_Mutex);
+  for (ezUInt32 i = 0; i < uiBindings; ++i)
+  {
+    const ezShaderResourceBinding& binding = bindings[i];
+    const ezGALBindGroupItem& item = desc.m_BindGroupItems[i];
+    vk::WriteDescriptorSet& write = WriteBindGroupItem(descriptorSet, binding, item, pUniformBufferPool);
+    if (binding.m_ResourceType == ezGALShaderResourceType::ConstantBuffer)
+    {
+      // Offsets are moved into separate offset array so leave at 0. Dynamic uniform buffers need to be tagged in the layout, so we can't decide whether we use them or not depending on what buffer we have bound. Thus, everything is a dynamic uniform buffer and the offset must be provided via the bindDescriptorSets call for normal constant buffers too.
+      // Offset does not need to be stored, as it is handled in ezGALCommandEncoderImplVulkan::FindDynamicUniformBuffers.
+      const_cast<vk::DescriptorBufferInfo*>(write.pBufferInfo)->offset = 0;
+    }
+  }
+}
+
+void ezDescriptorWritePoolVulkan::WriteDescriptor(vk::DescriptorSet descriptorSet, const ezGALBindGroupCreationDescription& desc, ezDynamicArray<ezUInt32>& out_Offsets)
+{
+  out_Offsets.Clear();
+  const ezGALBindGroupLayoutVulkan* pLayout = static_cast<const ezGALBindGroupLayoutVulkan*>(m_pDevice->GetBindGroupLayout(desc.m_hBindGroupLayout));
+  ezArrayPtr<const ezShaderResourceBinding> bindings = pLayout->GetDescription().m_ResourceBindings;
+  const ezUInt32 uiBindings = bindings.GetCount();
+
+  EZ_LOCK(m_Mutex);
+  for (ezUInt32 i = 0; i < uiBindings; ++i)
+  {
+    const ezShaderResourceBinding& binding = bindings[i];
+    const ezGALBindGroupItem& item = desc.m_BindGroupItems[i];
+    vk::WriteDescriptorSet& write = WriteBindGroupItem(descriptorSet, binding, item, nullptr);
+    if (binding.m_ResourceType == ezGALShaderResourceType::ConstantBuffer)
+    {
+      out_Offsets.PushBack(write.pBufferInfo->offset);
+      const_cast<vk::DescriptorBufferInfo*>(write.pBufferInfo)->offset = 0;
+    }
+  }
+}
+
+ezUInt32 ezDescriptorWritePoolVulkan::FlushWrites()
+{
+  EZ_LOCK(m_Mutex);
+  ezUInt32 uiDescriptorWrites = 0;
+  if (!m_DescriptorWrites.IsEmpty())
+  {
+    uiDescriptorWrites = m_DescriptorWrites.GetCount();
+    m_pDevice->GetVulkanDevice().updateDescriptorSets(m_DescriptorWrites.GetCount(), m_DescriptorWrites.GetData(), 0, nullptr);
+    m_DescriptorWrites.Clear();
+    m_DescriptorImageInfos.Clear();
+    m_DescriptorBufferInfos.Clear();
+    m_DescriptorBufferViews.Clear();
+  }
+  return uiDescriptorWrites;
+}
+
+vk::WriteDescriptorSet& ezDescriptorWritePoolVulkan::WriteBindGroupItem(vk::DescriptorSet descriptorSet, const ezShaderResourceBinding& binding,
+  const ezGALBindGroupItem& item, ezUniformBufferPoolVulkan* pUniformBufferPool)
+{
+  vk::WriteDescriptorSet& write = m_DescriptorWrites.ExpandAndGetRef();
+  write.dstArrayElement = 0;
+  write.descriptorType = ezConversionUtilsVulkan::GetDescriptorType(binding.m_ResourceType);
+  write.dstBinding = binding.m_iSlot;
+  write.dstSet = descriptorSet;
+  write.descriptorCount = binding.m_uiArraySize;
+  switch (binding.m_ResourceType)
+  {
+    case ezGALShaderResourceType::ConstantBuffer:
+    {
+      vk::DescriptorBufferInfo& bufferInfo = m_DescriptorBufferInfos.ExpandAndGetRef();
+      write.pBufferInfo = &bufferInfo;
+      const ezGALBufferVulkan* pBuffer = static_cast<const ezGALBufferVulkan*>(m_pDevice->GetBuffer(item.m_Buffer.m_hBuffer));
+      if (pBuffer->GetDescription().m_BufferFlags.IsSet(ezGALBufferUsageFlags::Transient))
+      {
+        EZ_ASSERT_DEV(pUniformBufferPool != nullptr, "Bind group resources must not contain transient constant buffer references");
+        bufferInfo = *pUniformBufferPool->GetBuffer(pBuffer);
+      }
+      else
+      {
+        bufferInfo = pBuffer->GetBufferInfo();
+        bufferInfo.range = item.m_Buffer.m_BufferRange.m_uiByteCount;
+      }
+    }
+    break;
+    case ezGALShaderResourceType::Texture:
+    case ezGALShaderResourceType::TextureRW:
+    case ezGALShaderResourceType::TextureAndSampler:
+    {
+      vk::DescriptorImageInfo& imageInfo = m_DescriptorImageInfos.ExpandAndGetRef();
+      write.pImageInfo = &imageInfo;
+      const ezGALTextureVulkan* pTexture = static_cast<const ezGALTextureVulkan*>(m_pDevice->GetTexture(item.m_Texture.m_hTexture));
+      imageInfo = pTexture->GetDescriptorImageInfo(item.m_Texture.m_TextureRange, binding.m_ResourceType, binding.m_TextureType, item.m_Texture.m_OverrideViewFormat);
+      imageInfo.imageLayout = binding.m_ResourceType == ezGALShaderResourceType::TextureRW ? vk::ImageLayout::eGeneral : pTexture->GetPreferredLayout(ezConversionUtilsVulkan::GetDefaultLayout(pTexture->GetImageFormat()));
+
+      if (binding.m_ResourceType == ezGALShaderResourceType::TextureAndSampler)
+      {
+        const ezGALSamplerStateVulkan* pSampler = static_cast<const ezGALSamplerStateVulkan*>(m_pDevice->GetSamplerState(item.m_Texture.m_hSampler));
+        imageInfo.sampler = pSampler->GetImageInfo().sampler;
+      }
+    }
+    break;
+    case ezGALShaderResourceType::TexelBuffer:
+    case ezGALShaderResourceType::TexelBufferRW:
+    {
+      vk::BufferView& bufferView = m_DescriptorBufferViews.ExpandAndGetRef();
+      write.pTexelBufferView = &bufferView;
+      const ezGALBufferVulkan* pBuffer = static_cast<const ezGALBufferVulkan*>(m_pDevice->GetBuffer(item.m_Buffer.m_hBuffer));
+      bufferView = pBuffer->GetTexelBufferView(item.m_Buffer.m_BufferRange, item.m_Buffer.m_OverrideTexelBufferFormat);
+    }
+    break;
+    case ezGALShaderResourceType::StructuredBuffer:
+    case ezGALShaderResourceType::ByteAddressBuffer:
+    case ezGALShaderResourceType::StructuredBufferRW:
+    case ezGALShaderResourceType::ByteAddressBufferRW:
+    {
+      vk::DescriptorBufferInfo& bufferInfo = m_DescriptorBufferInfos.ExpandAndGetRef();
+      write.pBufferInfo = &bufferInfo;
+      const ezGALBufferVulkan* pBuffer = static_cast<const ezGALBufferVulkan*>(m_pDevice->GetBuffer(item.m_Buffer.m_hBuffer));
+      bufferInfo.buffer = pBuffer->GetBufferInfo().buffer;
+      bufferInfo.offset = item.m_Buffer.m_BufferRange.m_uiByteOffset;
+      bufferInfo.range = item.m_Buffer.m_BufferRange.m_uiByteCount;
+    }
+    break;
+    case ezGALShaderResourceType::Sampler:
+    {
+      vk::DescriptorImageInfo& imageInfo = m_DescriptorImageInfos.ExpandAndGetRef();
+      write.pImageInfo = &imageInfo;
+      const ezGALSamplerStateVulkan* pSampler = static_cast<const ezGALSamplerStateVulkan*>(m_pDevice->GetSamplerState(item.m_Sampler.m_hSampler));
+      imageInfo.sampler = pSampler->GetImageInfo().sampler;
+    }
+    break;
+    default:
+      break;
+  }
+  return write;
+}

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorWritePoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorWritePoolVulkan.cpp
@@ -9,7 +9,7 @@
 #include <RendererVulkan/State/StateVulkan.h>
 
 ezDescriptorWritePoolVulkan::ezDescriptorWritePoolVulkan(ezGALDeviceVulkan* pDevice)
-: m_pDevice(pDevice)
+  : m_pDevice(pDevice)
 {
 }
 

--- a/Code/Engine/RendererVulkan/Pools/Implementation/TransientDescriptorSetPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/TransientDescriptorSetPoolVulkan.cpp
@@ -1,0 +1,140 @@
+#include <RendererVulkan/RendererVulkanPCH.h>
+
+#include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h>
+
+vk::DescriptorPool ezTransientDescriptorSetPoolVulkan::s_currentTransientPool;
+ezHybridArray<vk::DescriptorPool, 4> ezTransientDescriptorSetPoolVulkan::s_freeTransientPools;
+vk::Device ezTransientDescriptorSetPoolVulkan::s_device;
+ezHashTable<vk::DescriptorType, float> ezTransientDescriptorSetPoolVulkan::s_descriptorWeights;
+
+void ezTransientDescriptorSetPoolVulkan::Initialize(vk::Device device)
+{
+  s_device = device;
+  s_descriptorWeights[vk::DescriptorType::eSampler] = 0.5f;              // Image sampler.
+  s_descriptorWeights[vk::DescriptorType::eSampledImage] = 2.0f;         // Read-only image view.
+  s_descriptorWeights[vk::DescriptorType::eStorageImage] = 1.0f;         // Read / write image view.
+  s_descriptorWeights[vk::DescriptorType::eUniformBuffer] = 1.0f;        // Read-only struct (constant buffer)
+  s_descriptorWeights[vk::DescriptorType::eStorageBuffer] = 1.0f;        // Read / write struct (UAV).
+  s_descriptorWeights[vk::DescriptorType::eUniformTexelBuffer] = 0.5f;   // Read-only linear texel buffer with view.
+  s_descriptorWeights[vk::DescriptorType::eCombinedImageSampler] = 2.0f; // Read-only image view with image sampler.
+
+  // Not used by EZ so far.
+  s_descriptorWeights[vk::DescriptorType::eStorageTexelBuffer] = 0.5f;   // Read / write linear texel buffer with view.
+  s_descriptorWeights[vk::DescriptorType::eUniformBufferDynamic] = 1.0f; // Same as eUniformBuffer but allows updating the memory offset into the buffer dynamically.
+  s_descriptorWeights[vk::DescriptorType::eStorageBufferDynamic] = 0.0f; // Same as eStorageBuffer but allows updating the memory offset into the buffer dynamically.
+
+  // Not supported by EZ so far.
+  s_descriptorWeights[vk::DescriptorType::eInputAttachment] = 0.0f; // frame-buffer local read-only image view.
+
+  s_descriptorWeights[vk::DescriptorType::eInlineUniformBlock] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eAccelerationStructureKHR] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eAccelerationStructureNV] = 0.0f;
+  s_descriptorWeights[vk::DescriptorType::eMutableVALVE] = 0.0f;
+}
+
+void ezTransientDescriptorSetPoolVulkan::DeInitialize()
+{
+  s_descriptorWeights.Clear();
+  s_descriptorWeights.Compact();
+
+  for (vk::DescriptorPool& pool : s_freeTransientPools)
+  {
+    s_device.destroyDescriptorPool(pool, nullptr);
+  }
+  s_freeTransientPools.Clear();
+  s_freeTransientPools.Compact();
+  if (s_currentTransientPool)
+  {
+    s_device.resetDescriptorPool(s_currentTransientPool);
+    s_device.destroyDescriptorPool(s_currentTransientPool, nullptr);
+    s_currentTransientPool = nullptr;
+  }
+
+  s_device = nullptr;
+}
+
+ezHashTable<vk::DescriptorType, float>& ezTransientDescriptorSetPoolVulkan::AccessDescriptorPoolWeights()
+{
+  return s_descriptorWeights;
+}
+
+vk::DescriptorSet ezTransientDescriptorSetPoolVulkan::CreateTransientDescriptorSet(vk::DescriptorSetLayout layout)
+{
+  vk::DescriptorSet set;
+  if (!s_currentTransientPool)
+  {
+    s_currentTransientPool = GetNewTransientPool();
+  }
+
+  vk::DescriptorSetAllocateInfo allocateInfo;
+  allocateInfo.pSetLayouts = &layout;
+  allocateInfo.descriptorPool = s_currentTransientPool;
+  allocateInfo.descriptorSetCount = 1;
+
+  vk::Result res = s_device.allocateDescriptorSets(&allocateInfo, &set);
+  bool bPoolExhausted = false;
+
+  switch (res)
+  {
+    case vk::Result::eSuccess:
+      break;
+    case vk::Result::eErrorFragmentedPool:
+    case vk::Result::eErrorOutOfPoolMemory:
+      bPoolExhausted = true;
+      break;
+    default:
+      VK_ASSERT_DEV(res);
+      break;
+  }
+
+  if (bPoolExhausted)
+  {
+    ezGALDeviceVulkan* pDevice = static_cast<ezGALDeviceVulkan*>(ezGALDevice::GetDefaultDevice());
+    pDevice->ReclaimLater(s_currentTransientPool);
+    s_currentTransientPool = GetNewTransientPool();
+    allocateInfo.descriptorPool = s_currentTransientPool;
+    VK_ASSERT_DEV(s_device.allocateDescriptorSets(&allocateInfo, &set));
+  }
+
+  return set;
+}
+
+void ezTransientDescriptorSetPoolVulkan::UpdateDescriptorSet(vk::DescriptorSet descriptorSet, ezArrayPtr<vk::WriteDescriptorSet> update)
+{
+  s_device.updateDescriptorSets(update.GetCount(), update.GetPtr(), 0, nullptr);
+}
+
+void ezTransientDescriptorSetPoolVulkan::ReclaimPool(vk::DescriptorPool& descriptorPool)
+{
+  s_device.resetDescriptorPool(descriptorPool);
+  s_freeTransientPools.PushBack(descriptorPool);
+}
+
+vk::DescriptorPool ezTransientDescriptorSetPoolVulkan::GetNewTransientPool()
+{
+  if (s_freeTransientPools.IsEmpty())
+  {
+    ezHybridArray<vk::DescriptorPoolSize, 20> poolSizes;
+    for (auto weight : s_descriptorWeights)
+    {
+      if (static_cast<ezUInt32>(weight.Value() * s_uiPoolBaseSize) > 0)
+        poolSizes.PushBack(vk::DescriptorPoolSize(weight.Key(), static_cast<ezUInt32>(weight.Value() * s_uiPoolBaseSize)));
+    }
+    vk::DescriptorPoolCreateInfo poolCreateInfo;
+    poolCreateInfo.flags = {};
+    poolCreateInfo.maxSets = s_uiPoolBaseSize;
+    poolCreateInfo.poolSizeCount = poolSizes.GetCount();
+    poolCreateInfo.pPoolSizes = poolSizes.GetData();
+
+    vk::DescriptorPool descriptorPool;
+    VK_ASSERT_DEV(s_device.createDescriptorPool(&poolCreateInfo, nullptr, &descriptorPool));
+    return descriptorPool;
+  }
+  else
+  {
+    vk::DescriptorPool pool = s_freeTransientPools.PeekBack();
+    s_freeTransientPools.PopBack();
+    return pool;
+  }
+}

--- a/Code/Engine/RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <RendererVulkan/RendererVulkanDLL.h>
 #include <RendererVulkan/Device/DeclarationsVulkan.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
 
 EZ_DEFINE_AS_POD_TYPE(vk::DescriptorType);
 

--- a/Code/Engine/RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <RendererVulkan/RendererVulkanDLL.h>
+#include <RendererVulkan/Device/DeclarationsVulkan.h>
+
+EZ_DEFINE_AS_POD_TYPE(vk::DescriptorType);
+
+template <>
+struct ezHashHelper<vk::DescriptorType>
+{
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(vk::DescriptorType value) { return ezHashHelper<ezUInt32>::Hash(ezUInt32(value)); }
+  EZ_ALWAYS_INLINE static bool Equal(vk::DescriptorType a, vk::DescriptorType b) { return a == b; }
+};
+
+/// \brief Creates descriptor sets that are only valid for a single frame.
+/// Descriptors are created from pools that are put in the frame deletion queue once full. The frame deletion queue on the device will then call ReclaimPool and the entire pool is reset and reused. Pools are only destroyed on shutdown.
+class EZ_RENDERERVULKAN_DLL ezTransientDescriptorSetPoolVulkan
+{
+public:
+  static void Initialize(vk::Device device);
+  static void DeInitialize();
+  static ezHashTable<vk::DescriptorType, float>& AccessDescriptorPoolWeights();
+
+  static vk::DescriptorSet CreateTransientDescriptorSet(vk::DescriptorSetLayout layout);
+  static void UpdateDescriptorSet(vk::DescriptorSet descriptorSet, ezArrayPtr<vk::WriteDescriptorSet> update);
+  static void ReclaimPool(vk::DescriptorPool& descriptorPool);
+
+private:
+  static constexpr ezUInt32 s_uiPoolBaseSize = 1024;
+
+  static vk::DescriptorPool GetNewTransientPool();
+
+  static vk::DescriptorPool s_currentTransientPool;
+  static ezHybridArray<vk::DescriptorPool, 4> s_freeTransientPools;
+
+  static vk::Device s_device;
+  static ezHashTable<vk::DescriptorType, float> s_descriptorWeights;
+};

--- a/Code/Engine/RendererVulkan/Shader/BindGroupLayoutVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/BindGroupLayoutVulkan.h
@@ -1,16 +1,19 @@
 
 #pragma once
 
-#include <RendererFoundation/RendererFoundationDLL.h>
-#include <RendererFoundation/Shader/BindGroupLayout.h>
 #include <RendererVulkan/RendererVulkanDLL.h>
 
-#include <vulkan/vulkan.hpp>
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/BindGroupLayout.h>
+#include <RendererVulkan/Device/DeclarationsVulkan.h>
+
+class ezDescriptorSetPoolVulkan;
 
 class ezGALBindGroupLayoutVulkan : public ezGALBindGroupLayout
 {
 public:
-  inline vk::DescriptorSetLayout GetDescriptorSetLayout() const { return m_DescriptorSetLayout; }
+  inline const vk::DescriptorSetLayout& GetDescriptorSetLayout() const { return m_DescriptorSetLayout; }
+  ezDescriptorSetPoolVulkan* GetDescriptorSetPool() const;
 
 protected:
   friend class ezGALDeviceVulkan;
@@ -25,4 +28,6 @@ protected:
 
 private:
   vk::DescriptorSetLayout m_DescriptorSetLayout;
+  ezBindGroupLayoutResourceUsageVulkan m_ResourceUsage; // How many resources of each type each descriptor set uses.
+  ezSharedPtr<ezDescriptorSetPoolVulkan> m_DescriptorSetPool;
 };

--- a/Code/Engine/RendererVulkan/Shader/BindGroupVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/BindGroupVulkan.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <RendererFoundation/RendererFoundationDLL.h>
+#include <RendererFoundation/Shader/BindGroup.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
+#include <vulkan/vulkan.hpp>
+
+class ezGALBindGroupVulkan : public ezGALBindGroup
+{
+public:
+  inline vk::DescriptorSet GetDescriptorSet() const { return m_DescriptorSet; }
+  inline ezArrayPtr<const ezUInt32> GetOffsets() const { return m_Offsets.GetArrayPtr(); }
+
+protected:
+  friend class ezGALDeviceVulkan;
+  friend class ezMemoryUtils;
+
+  virtual ezResult InitPlatform(ezGALDevice* pDevice) override;
+  virtual ezResult DeInitPlatform(ezGALDevice* pDevice) override;
+  virtual void Invalidate(ezGALDevice* pDevice) override;
+  virtual bool IsInvalidated() const override;
+  virtual void SetDebugNamePlatform(const char* szName) const override;
+
+  ezGALBindGroupVulkan(const ezGALBindGroupCreationDescription& Description);
+
+  virtual ~ezGALBindGroupVulkan();
+
+private:
+  vk::DescriptorSet m_DescriptorSet;
+  ezHybridArray<ezUInt32, 1> m_Offsets;
+  ezDescriptorSetPoolVulkan::Allocation m_Allocation;
+};

--- a/Code/Engine/RendererVulkan/Shader/BindGroupVulkan.h
+++ b/Code/Engine/RendererVulkan/Shader/BindGroupVulkan.h
@@ -2,8 +2,8 @@
 
 #include <RendererFoundation/RendererFoundationDLL.h>
 #include <RendererFoundation/Shader/BindGroup.h>
-#include <RendererVulkan/RendererVulkanDLL.h>
 #include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
+#include <RendererVulkan/RendererVulkanDLL.h>
 #include <vulkan/vulkan.hpp>
 
 class ezGALBindGroupVulkan : public ezGALBindGroup

--- a/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupLayoutVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupLayoutVulkan.cpp
@@ -4,10 +4,10 @@
 
 #include <RendererFoundation/Device/ImmutableSamplers.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
-#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 
 ezGALBindGroupLayoutVulkan::ezGALBindGroupLayoutVulkan(const ezGALBindGroupLayoutCreationDescription& Description)
   : ezGALBindGroupLayout(Description)

--- a/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupLayoutVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupLayoutVulkan.cpp
@@ -7,6 +7,7 @@
 #include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
 #include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
+#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
 
 ezGALBindGroupLayoutVulkan::ezGALBindGroupLayoutVulkan(const ezGALBindGroupLayoutCreationDescription& Description)
   : ezGALBindGroupLayout(Description)
@@ -38,6 +39,13 @@ ezResult ezGALBindGroupLayoutVulkan::InitPlatform(ezGALDevice* pDevice)
     ConvertBinding(ezBinding, binding);
   }
 
+  // Build m_ResourceUsage
+  for (ezUInt32 i = 0; i < m_Description.m_ResourceBindings.GetCount(); i++)
+  {
+    const ezShaderResourceBinding& ezBinding = m_Description.m_ResourceBindings[i];
+    m_ResourceUsage.m_Usage[ezBinding.m_ResourceType.GetValue()]++;
+  }
+
   const ezGALImmutableSamplers::ImmutableSamplers& immutableSamplers = ezGALImmutableSamplers::GetImmutableSamplers();
 
   for (ezUInt32 i = 0; i < m_Description.m_ImmutableSamplers.GetCount(); i++)
@@ -62,12 +70,20 @@ ezResult ezGALBindGroupLayoutVulkan::InitPlatform(ezGALDevice* pDevice)
   descriptorSetLayout.pBindings = bindings.GetData();
   VK_ASSERT_DEBUG(pVulkanDevice->GetVulkanDevice().createDescriptorSetLayout(&descriptorSetLayout, nullptr, &m_DescriptorSetLayout));
 
+  m_DescriptorSetPool = ezDescriptorSetPoolVulkan::GetPool(m_ResourceUsage);
+
   return EZ_SUCCESS;
 }
 
 ezResult ezGALBindGroupLayoutVulkan::DeInitPlatform(ezGALDevice* pDevice)
 {
+  m_DescriptorSetPool = nullptr;
   auto* pVulkanDevice = static_cast<ezGALDeviceVulkan*>(pDevice);
   pVulkanDevice->DeleteLater(m_DescriptorSetLayout);
   return EZ_SUCCESS;
+}
+
+ezDescriptorSetPoolVulkan* ezGALBindGroupLayoutVulkan::GetDescriptorSetPool() const
+{
+  return m_DescriptorSetPool.Borrow();
 }

--- a/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupVulkan.cpp
@@ -1,0 +1,52 @@
+#include <RendererVulkan/Shader/BindGroupVulkan.h>
+
+#include <RendererVulkan/Pools/DescriptorWritePoolVulkan.h>
+
+ezGALBindGroupVulkan::ezGALBindGroupVulkan(const ezGALBindGroupCreationDescription& Description)
+  : ezGALBindGroup(Description)
+{
+}
+
+ezGALBindGroupVulkan::~ezGALBindGroupVulkan() = default;
+
+ezResult ezGALBindGroupVulkan::InitPlatform(ezGALDevice* pDevice)
+{
+  ezGALDeviceVulkan* pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+  const ezGALBindGroupLayoutVulkan* pLayout = static_cast<const ezGALBindGroupLayoutVulkan*>(pDeviceVulkan->GetBindGroupLayout(m_Description.m_hBindGroupLayout));
+  if (pLayout == nullptr)
+  {
+    ezLog::Error("Invalid bind group layout handle passed into bind group");
+    return EZ_FAILURE;
+  }
+
+  m_DescriptorSet = pLayout->GetDescriptorSetPool()->CreateDescriptorSet(m_Description.m_hBindGroupLayout, m_Allocation);
+  pDeviceVulkan->GetDescriptorWritePool().WriteDescriptor(m_DescriptorSet, m_Description, m_Offsets);
+  return EZ_SUCCESS;
+}
+
+ezResult ezGALBindGroupVulkan::DeInitPlatform(ezGALDevice* pDevice)
+{
+  Invalidate(pDevice);
+  return EZ_SUCCESS;
+}
+
+void ezGALBindGroupVulkan::Invalidate(ezGALDevice* pDevice)
+{
+  if (m_DescriptorSet != nullptr)
+  {
+    ezGALDeviceVulkan* pDeviceVulkan = static_cast<ezGALDeviceVulkan*>(pDevice);
+    const ezGALBindGroupLayoutVulkan* pLayout = static_cast<const ezGALBindGroupLayoutVulkan*>(pDeviceVulkan->GetBindGroupLayout(m_Description.m_hBindGroupLayout));
+    pDeviceVulkan->ReclaimLater(m_DescriptorSet, pLayout->GetDescriptorSetPool(), m_Allocation.m_uiPoolIndex);
+    m_DescriptorSet = nullptr;
+    m_Allocation = {};
+  }
+}
+
+bool ezGALBindGroupVulkan::IsInvalidated() const
+{
+  return m_DescriptorSet == nullptr;
+}
+
+void ezGALBindGroupVulkan::SetDebugNamePlatform(const char* szName) const
+{
+}

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ConversionUtilsVulkan.inl.h
@@ -338,6 +338,9 @@ EZ_ALWAYS_INLINE vk::DescriptorType ezConversionUtilsVulkan::GetDescriptorType(e
       return vk::DescriptorType::eStorageBuffer;
     case ezGALShaderResourceType::ByteAddressBufferRW:
       return vk::DescriptorType::eStorageBuffer;
+    case ezGALShaderResourceType::COUNT:
+      EZ_REPORT_FAILURE("COUNT is not a valid resource type");
+      break;
   }
   EZ_REPORT_FAILURE("Unknown resource type: {}", (int)type);
   return vk::DescriptorType::eMutableVALVE;

--- a/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/ImageCopyVulkan.cpp
@@ -4,7 +4,7 @@
 #include <RendererFoundation/Resources/RenderTargetView.h>
 #include <RendererFoundation/Shader/ShaderUtils.h>
 #include <RendererFoundation/State/PipelineCache.h>
-#include <RendererVulkan/Pools/DescriptorSetPoolVulkan.h>
+#include <RendererVulkan/Pools/TransientDescriptorSetPoolVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/RenderTargetViewVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
@@ -385,7 +385,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
   }
 
   // Descriptor Set
-  vk::DescriptorSet descriptorSet = ezDescriptorSetPoolVulkan::CreateDescriptorSet(m_pShader->GetDescriptorSetLayout(0));
+  vk::DescriptorSet descriptorSet = ezTransientDescriptorSetPoolVulkan::CreateTransientDescriptorSet(m_pShader->GetDescriptorSetLayout(0));
   {
     ezHybridArray<vk::WriteDescriptorSet, 16> descriptorWrites;
 
@@ -424,7 +424,7 @@ void ezImageCopyVulkan::RenderInternal(const ezVec3U32& sourceOffset, const vk::
           break;
       }
     }
-    ezDescriptorSetPoolVulkan::UpdateDescriptorSet(descriptorSet, descriptorWrites);
+    ezTransientDescriptorSetPoolVulkan::UpdateDescriptorSet(descriptorSet, descriptorWrites);
     commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, m_pShader->GetVkPipelineLayout(), 0, 1, &descriptorSet, 0, nullptr);
   }
 

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: A7F2587B-843F-4A9E-8940-C055DAD3A021
+Change me: A7F2587B-843F-4A9E-8940-C055DAD3A021AAA


### PR DESCRIPTION
# Bind Group Resource

* Material Manager creates bind groups on demand. These get invalidated if textures or permutations change.
* RenderContext will acquire bind group from material manager for materials.
* `ezGALCommandEncoder::SetBindGroup` now has two overloads: binding transient bind groups via description and binding bind group resources via handle.
* Moved bind group validation into the bind group resource to allow sharing it between resource and transient code.
* Added `ezDependencyTracker` which is used to track the resource dependencies of a bind group and invalidate the bind group if one of its dependent resources dies. The renderer asserts if an invalidated bind group gets bound. We could also make bind groups hold references to the dependent resources but that seems to be excessive? The tracker could be removed in release builds.
* Made `ezGALSamplerState` derive from `ezGALResource` instead of `ezGALObject` as that was the only dependency of a bind group with a different base class.
* This roughly halves the number of reads / writes to the the bind group builders and descriptor writes.


## Vulkan
* Added `ezDescriptorWritePoolVulkan` and moved logic there from `ezGALCommandEncoderImplVulkan` to be reusable between transient and resource bind groups.
* Renamed `ezDescriptorSetPoolVulkan` to `ezTransientDescriptorSetPoolVulkan` as we want to use its name for something more descriptive.
* Added new `ezDescriptorSetPoolVulkan` which is a ref-counted class that is held by every bind group layout and is used as an allocator for descriptors. Multiple bind group layouts can share the same pool as long as they have the same number of resources of each type, which is tracked via the `ezBindGroupLayoutResourceUsageVulkan` struct.