### PR TITLE
Proc gen: High quality placement mode

### DIFF
--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -82,7 +82,7 @@ struct ezProcGenGraphAssetDocument::GenerateContext
 
 ////////////////////////////////////////////////////////////////
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenGraphAssetDocument, 7, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenGraphAssetDocument, 8, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezProcGenGraphAssetDocument::ezProcGenGraphAssetDocument(ezStringView sDocumentPath)
@@ -166,7 +166,7 @@ ezStatus ezProcGenGraphAssetDocument::WriteAsset(ezStreamWriter& inout_stream, c
   };
 
   {
-    chunk.BeginChunk("PlacementOutputs", 7);
+    chunk.BeginChunk("PlacementOutputs", 8);
 
     if (!bDebug)
     {

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -147,6 +147,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_PlacementOutput, 1, ezRTTIDefaultAlloc
     EZ_MEMBER_PROPERTY("ColorGradient", m_sColorGradient)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Data_Gradient")),
     EZ_MEMBER_PROPERTY("CullDistance", m_fCullDistance)->AddAttributes(new ezDefaultValueAttribute(30.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_ENUM_MEMBER_PROPERTY("PlacementMode", ezProcPlacementMode, m_PlacementMode),
+    EZ_MEMBER_PROPERTY("NumAdditionalRays", m_uiNumAdditionalRays)->AddAttributes(new ezDefaultValueAttribute(4), new ezClampValueAttribute(3, 20)),
+    EZ_MEMBER_PROPERTY("RaySpread", m_fRaySpread)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.0f, 10.0f)),
     EZ_ENUM_MEMBER_PROPERTY("PlacementPattern", ezProcPlacementPattern, m_PlacementPattern),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("Surface", m_sSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
@@ -261,6 +263,10 @@ void ezProcGen_PlacementOutput::Save(ezStreamWriter& inout_stream)
 
   // chunk version 5
   inout_stream << m_PlacementMode;
+
+  // chunk version 8
+  inout_stream << m_uiNumAdditionalRays;
+  inout_stream << m_fRaySpread;
 
   // chunk version 7
   inout_stream << m_PlacementPattern;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
@@ -76,6 +76,9 @@ public:
   ezString m_sColorGradient;
 
   ezEnum<ezProcPlacementMode> m_PlacementMode;
+  ezUInt8 m_uiNumAdditionalRays = 4;
+  float m_fRaySpread = 1.0f;
+
   ezEnum<ezProcPlacementPattern> m_PlacementPattern;
 
   ezRenderPipelineNodeInputPin m_DensityPin;

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshRenderer.cpp
@@ -25,8 +25,9 @@ void ezSkinnedMeshRenderer::SetAdditionalData(const ezRenderViewContext& renderV
   ezRenderContext* pContext = renderViewContext.m_pRenderContext;
 
   auto pSkinnedRenderData = static_cast<const ezSkinnedMeshRenderData*>(pRenderData);
+  auto pSkinningBuffer = pDevice->GetBuffer(pSkinnedRenderData->m_hSkinningTransforms);
 
-  if (pSkinnedRenderData->m_hSkinningTransforms.IsInvalidated())
+  if (pSkinningBuffer == nullptr)
   {
     pContext->SetShaderPermutationVariable("VERTEX_SKINNING", "FALSE");
   }

--- a/Code/EnginePlugins/ProcGenPlugin/Declarations.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Declarations.cpp
@@ -34,7 +34,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProcVertexColorMapping, ezNoBase, 1, ezRTTIDefa
 EZ_END_STATIC_REFLECTED_TYPE;
 
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezProcPlacementMode, 1)
-  EZ_ENUM_CONSTANTS(ezProcPlacementMode::Raycast, ezProcPlacementMode::Fixed)
+  EZ_ENUM_CONSTANTS(ezProcPlacementMode::Raycast, ezProcPlacementMode::RaycastHighQuality, ezProcPlacementMode::Fixed)
 EZ_END_STATIC_REFLECTED_ENUM;
 
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezProcPlacementPattern, 1)

--- a/Code/EnginePlugins/ProcGenPlugin/Declarations.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Declarations.h
@@ -91,6 +91,7 @@ struct ezProcPlacementMode
   enum Enum
   {
     Raycast,
+    RaycastHighQuality,
     Fixed,
 
     Default = Raycast
@@ -214,6 +215,8 @@ namespace ezProcGenInternal
     ezSurfaceResourceHandle m_hSurface;
 
     ezEnum<ezProcPlacementMode> m_Mode;
+    ezUInt8 m_uiNumAdditionalRays = 4;
+    float m_fRaySpread = 1.0f;
   };
 
   struct VertexColorOutput : public Output

--- a/Code/EnginePlugins/ProcGenPlugin/Resources/Implementation/ProcGenGraphResource.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Resources/Implementation/ProcGenGraphResource.cpp
@@ -173,6 +173,12 @@ ezResourceLoadDesc ezProcGenGraphResource::UpdateContent(ezStreamReader* Stream)
             chunk >> pOutput->m_Mode;
           }
 
+          if (chunk.GetCurrentChunk().m_uiChunkVersion >= 8)
+          {
+            chunk >> pOutput->m_uiNumAdditionalRays;
+            chunk >> pOutput->m_fRaySpread;
+          }
+
           ezEnum<ezProcPlacementPattern> pattern = ezProcPlacementPattern::RegularGrid;
           if (chunk.GetCurrentChunk().m_uiChunkVersion >= 7)
           {

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
@@ -119,7 +119,7 @@ void PlacementTask::FindPlacementPoints()
         bool bAllValid = true;
         for (ezUInt32 i = 0; i < uiNumAdditionalRays; ++i)
         {
-          const ezAngle angle = angleStep * i;
+          const ezAngle angle = angleStep * float(i);
           const ezSimdVec4f offset = ezSimdVec4f(ezMath::Cos(angle), ezMath::Sin(angle), 0.0f) * fSpread;
           const ezSimdVec4f rayStartOffset = rayStart + offset;
 

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
@@ -9,6 +9,7 @@
 #include <ProcGenPlugin/Tasks/PlacementData.h>
 #include <ProcGenPlugin/Tasks/PlacementTask.h>
 #include <ProcGenPlugin/Tasks/Utils.h>
+#include <RendererCore/Debug/DebugRenderer.h>
 
 using namespace ezProcGenInternal;
 
@@ -44,6 +45,24 @@ void PlacementTask::Execute()
   }
 }
 
+bool IsRequestedSurface(ezSurfaceResourceHandle hRequestedSurface, ezSurfaceResourceHandle hHitSurface)
+{
+  if (hRequestedSurface.IsValid())
+  {
+    if (!hHitSurface.IsValid())
+      return false;
+
+    ezResourceLock<ezSurfaceResource> hitSurface(hHitSurface, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
+    if (hitSurface.GetAcquireResult() == ezResourceAcquireResult::MissingFallback)
+      return false;
+
+    if (!hitSurface->IsBasedOn(hRequestedSurface))
+      return false;
+  }
+
+  return true;
+}
+
 void PlacementTask::FindPlacementPoints()
 {
   EZ_PROFILE_SCOPE("FindPlacementPoints");
@@ -73,29 +92,70 @@ void PlacementTask::FindPlacementPoints()
 
     ezPhysicsCastResult hitResult;
 
-    if (m_pData->m_pPhysicsModule != nullptr && m_pData->m_pOutput->m_Mode == ezProcPlacementMode::Raycast)
+    if (m_pData->m_pPhysicsModule != nullptr &&
+        (pOutput->m_Mode == ezProcPlacementMode::Raycast ||
+          pOutput->m_Mode == ezProcPlacementMode::RaycastHighQuality))
     {
       ezSimdVec4f rayStart = (vXY + patternCoords * pOutput->m_fFootprint);
       rayStart += ezSimdRandom::FloatMinMax(ezSimdVec4i(i), vMinOffset, vMaxOffset, seed);
       rayStart.SetZ(fZStart);
 
-      if (!m_pData->m_pPhysicsModule->Raycast(hitResult, ezSimdConversion::ToVec3(rayStart), rayDir, fZRange, ezPhysicsQueryParameters(uiCollisionLayer, ezPhysicsShapeType::Static)))
+      ezPhysicsQueryParameters queryParams(uiCollisionLayer, ezPhysicsShapeType::Static);
+
+      if (!m_pData->m_pPhysicsModule->Raycast(hitResult, ezSimdConversion::ToVec3(rayStart), rayDir, fZRange, queryParams))
         continue;
 
-      if (pOutput->m_hSurface.IsValid())
+      if (!IsRequestedSurface(pOutput->m_hSurface, hitResult.m_hSurface))
+        continue;
+
+      if (pOutput->m_Mode == ezProcPlacementMode::RaycastHighQuality)
       {
-        if (!hitResult.m_hSurface.IsValid())
+        ezUInt32 uiNumAdditionalRays = ezMath::Max<ezUInt32>(pOutput->m_uiNumAdditionalRays, 3);
+        const ezAngle angleStep = ezAngle::MakeFromDegree(360.0f / uiNumAdditionalRays);
+
+        ezHybridArray<ezVec3, 32> hitPositions;
+
+        bool bAllValid = true;
+        for (ezUInt32 i = 0; i < uiNumAdditionalRays; ++i)
+        {
+          const ezAngle angle = angleStep * i;
+          const ezSimdVec4f offset = ezSimdVec4f(ezMath::Cos(angle), ezMath::Sin(angle), 0.0f) * pOutput->m_fRaySpread;
+          const ezSimdVec4f rayStartOffset = rayStart + offset * pOutput->m_fFootprint;
+
+          ezPhysicsCastResult offsetHitResult;
+          if (!m_pData->m_pPhysicsModule->Raycast(offsetHitResult, ezSimdConversion::ToVec3(rayStartOffset), rayDir, fZRange, queryParams))
+          {
+            bAllValid = false;
+            break;
+          }
+
+          if (!IsRequestedSurface(pOutput->m_hSurface, offsetHitResult.m_hSurface))
+          {
+            bAllValid = false;
+            break;
+          }
+
+          hitPositions.PushBack(offsetHitResult.m_vPosition);
+        }
+
+        if (!bAllValid)
           continue;
 
-        ezResourceLock<ezSurfaceResource> hitSurface(hitResult.m_hSurface, ezResourceAcquireMode::BlockTillLoaded_NeverFail);
-        if (hitSurface.GetAcquireResult() == ezResourceAcquireResult::MissingFallback)
-          continue;
+        const ezSimdVec4f up = ezSimdVec4f(0, 0, 1);
+        ezSimdVec4f avgNormal = ezSimdVec4f::MakeZero();
+        for (auto& pos : hitPositions)
+        {
+          // Do not normalize dirToP, so that points that are further away contribute more to the normal
+          const ezSimdVec4f dirToP = (ezSimdConversion::ToVec3(hitResult.m_vPosition) - ezSimdConversion::ToVec3(pos));
+          const ezSimdVec4f rightDir = up.CrossRH(dirToP);
+          const ezSimdVec4f normal = dirToP.CrossRH(rightDir);
+          avgNormal += normal;
+        }
 
-        if (!hitSurface->IsBasedOn(pOutput->m_hSurface))
-          continue;
+        hitResult.m_vNormal = ezSimdConversion::ToVec3(avgNormal.GetNormalized<3>());
       }
     }
-    else if (m_pData->m_pOutput->m_Mode == ezProcPlacementMode::Fixed)
+    else if (pOutput->m_Mode == ezProcPlacementMode::Fixed)
     {
       ezSimdVec4f rayStart = (vXY + patternCoords * pOutput->m_fFootprint);
       rayStart += ezSimdRandom::FloatMinMax(ezSimdVec4i(i), vMinOffset, vMaxOffset, seed);

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
@@ -110,8 +110,9 @@ void PlacementTask::FindPlacementPoints()
 
       if (pOutput->m_Mode == ezProcPlacementMode::RaycastHighQuality)
       {
-        ezUInt32 uiNumAdditionalRays = ezMath::Max<ezUInt32>(pOutput->m_uiNumAdditionalRays, 3);
+        const ezUInt32 uiNumAdditionalRays = ezMath::Max<ezUInt32>(pOutput->m_uiNumAdditionalRays, 3);
         const ezAngle angleStep = ezAngle::MakeFromDegree(360.0f / uiNumAdditionalRays);
+        const float fSpread = ezMath::Max(pOutput->m_fRaySpread * pOutput->m_fFootprint, 0.01f);
 
         ezHybridArray<ezVec3, 32> hitPositions;
 
@@ -119,8 +120,8 @@ void PlacementTask::FindPlacementPoints()
         for (ezUInt32 i = 0; i < uiNumAdditionalRays; ++i)
         {
           const ezAngle angle = angleStep * i;
-          const ezSimdVec4f offset = ezSimdVec4f(ezMath::Cos(angle), ezMath::Sin(angle), 0.0f) * pOutput->m_fRaySpread;
-          const ezSimdVec4f rayStartOffset = rayStart + offset * pOutput->m_fFootprint;
+          const ezSimdVec4f offset = ezSimdVec4f(ezMath::Cos(angle), ezMath::Sin(angle), 0.0f) * fSpread;
+          const ezSimdVec4f rayStartOffset = rayStart + offset;
 
           ezPhysicsCastResult offsetHitResult;
           if (!m_pData->m_pPhysicsModule->Raycast(offsetHitResult, ezSimdConversion::ToVec3(rayStartOffset), rayDir, fZRange, queryParams))


### PR DESCRIPTION
Added a new placement mode that shoots additional raycasts around the initial hit position to verify that the position is good, e.g. not too close to a overhang etc. It also uses the additional raycasts to calculate a smoother normal.