### PR TITLE
Fix for material bind groups not updating when new lod levels are loaded in

### DIFF
--- a/Code/Engine/RendererCore/Material/MaterialManager.h
+++ b/Code/Engine/RendererCore/Material/MaterialManager.h
@@ -179,4 +179,7 @@ private:
   // This container will hold dead pointers after material deletion until the next extraction phase + begin render loop.
   // This is better than locking this container on every material draw call.
   ezMap<const void*, MaterialData> m_Materials;
+
+  // Contains any materials that has bind groups with fallback or partially loaded resources. These will be deleted at the start of each frame.
+  ezSet<const void*> m_DirtyBindGroups;
 };

--- a/Code/Engine/RendererCore/RenderContext/BindGroupBuilder.h
+++ b/Code/Engine/RendererCore/RenderContext/BindGroupBuilder.h
@@ -25,21 +25,24 @@ public:
   /// Binds a sampler to this bind group
   /// @param sSlotName The slot under which the sampler is to be bound.
   /// @param hSampler If valid, it will be bound. If not, bind group item under this slot will be removed and replaced with a fallback resource if required.
-  void BindSampler(ezTempHashedString sSlotName, ezGALSamplerStateHandle hSampler);
+  /// @param metaFlags Optional subset of ezGALBindGroupItemFlags::MetaFlags to be added to the binding.
+  void BindSampler(ezTempHashedString sSlotName, ezGALSamplerStateHandle hSampler, ezBitflags<ezGALBindGroupItemFlags> metaFlags = {});
 
   /// Binds a buffer to this bind group
   /// @param sSlotName The slot under which the buffer is to be bound.
   /// @param hBuffer If valid, it will be bound. If not, bind group item under this slot will be removed and replaced with a fallback resource if required.
   /// @param bufferRange What part of the buffer should be bound. Default is entire buffer.
   /// @param overrideTexelBufferFormat Sets the format of the texel buffer. If invalid, default format of the buffer will be used.
-  void BindBuffer(ezTempHashedString sSlotName, ezGALBufferHandle hBuffer, ezGALBufferRange bufferRange = {}, ezEnum<ezGALResourceFormat> overrideTexelBufferFormat = ezGALResourceFormat::Invalid);
+  /// @param metaFlags Optional subset of ezGALBindGroupItemFlags::MetaFlags to be added to the binding.
+  void BindBuffer(ezTempHashedString sSlotName, ezGALBufferHandle hBuffer, ezGALBufferRange bufferRange = {}, ezEnum<ezGALResourceFormat> overrideTexelBufferFormat = ezGALResourceFormat::Invalid, ezBitflags<ezGALBindGroupItemFlags> metaFlags = {});
 
   /// Binds a texture to this bind group
   /// @param sSlotName The slot under which the texture is to be bound.
   /// @param hTexture If valid, it will be bound. If not, bind group item under this slot will be removed and replaced with a fallback resource if required.
   /// @param textureRange What part of the texture should be bound. Default is entire texture. Or as much as the target ezShaderResourceBinding allows for.
   /// @param overrideViewFormat If set, re-interprets the format of the texture. This can cause performance penalties. Only use it to e.g. read linear vs gamma space or other formats of same type and width.
-  void BindTexture(ezTempHashedString sSlotName, ezGALTextureHandle hTexture, ezGALTextureRange textureRange = {}, ezEnum<ezGALResourceFormat> overrideViewFormat = ezGALResourceFormat::Invalid);
+  /// @param metaFlags Optional subset of ezGALBindGroupItemFlags::MetaFlags to be added to the binding.
+  void BindTexture(ezTempHashedString sSlotName, ezGALTextureHandle hTexture, ezGALTextureRange textureRange = {}, ezEnum<ezGALResourceFormat> overrideViewFormat = ezGALResourceFormat::Invalid, ezBitflags<ezGALBindGroupItemFlags> metaFlags = {});
 
   // Convenience functions:
   void BindTexture(ezTempHashedString sSlotName, const ezTexture2DResourceHandle& hTexture, ezResourceAcquireMode acquireMode = ezResourceAcquireMode::AllowLoadingFallback, ezGALTextureRange textureRange = {}, ezEnum<ezGALResourceFormat> overrideViewFormat = ezGALResourceFormat::Invalid);
@@ -49,8 +52,9 @@ public:
 
   /// Create a new bind group for the given layout.
   /// @param hBindGroupLayout The bind group layout for which to create the bind group.
-  /// @param out_bindGroup The resulting bind group. Will be undefined if EZ_FAILURE is returned.
-  void CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLayout, ezGALBindGroupCreationDescription& out_bindGroup);
+  /// @param out_bindGroup The resulting bind group.
+  /// @param out_metaFlags Union of all meta flags across the bindings in the bind group. I.e. a bit will be set here if it is set for any binding.
+  void CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLayout, ezGALBindGroupCreationDescription& out_bindGroup, ezBitflags<ezGALBindGroupItemFlags>& out_metaFlags);
 
 public:
   /// \brief Number of modifications of the hash tables each frame. Used for stats.

--- a/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
@@ -34,7 +34,7 @@ namespace
       metaFlags.Add(ezGALBindGroupItemFlags::PartiallyLoaded);
     return metaFlags;
   }
-}
+} // namespace
 
 void ezBindGroupBuilder::ResetBoundResources(const ezGALDevice* pDevice)
 {

--- a/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
@@ -20,6 +20,21 @@ ezUInt32 ezBindGroupBuilder::s_uiReads = 0;
 
 ezBindGroupBuilder::ezBindGroupBuilder() = default;
 
+namespace
+{
+  template <typename T>
+  ezBitflags<ezGALBindGroupItemFlags> GetMetaFlags(ezResourceLock<T>& pResource)
+  {
+    ezBitflags<ezGALBindGroupItemFlags> metaFlags;
+    const bool isFallback = pResource.GetAcquireResult() != ezResourceAcquireResult::Final;
+    const bool isPartiallyLoaded = pResource->GetNumQualityLevelsLoadable() != 0;
+    if (isFallback)
+      metaFlags.Add(ezGALBindGroupItemFlags::FallbackResource);
+    if (isPartiallyLoaded)
+      metaFlags.Add(ezGALBindGroupItemFlags::PartiallyLoaded);
+    return metaFlags;
+  }
+}
 
 void ezBindGroupBuilder::ResetBoundResources(const ezGALDevice* pDevice)
 {
@@ -47,7 +62,7 @@ void ezBindGroupBuilder::ResetBoundResources(const ezGALDevice* pDevice)
   EZ_ASSERT_DEBUG(!m_hDefaultSampler.IsInvalidated(), "LinearSampler should have been registered at this point.");
 }
 
-void ezBindGroupBuilder::BindSampler(ezTempHashedString sSlotName, ezGALSamplerStateHandle hSampler)
+void ezBindGroupBuilder::BindSampler(ezTempHashedString sSlotName, ezGALSamplerStateHandle hSampler, ezBitflags<ezGALBindGroupItemFlags> metaFlags)
 {
   EZ_ASSERT_DEBUG(sSlotName != "LinearSampler", "'LinearSampler' is a reserved sampler name and must not be set manually.");
   EZ_ASSERT_DEBUG(sSlotName != "LinearClampSampler", "'LinearClampSampler' is a reserved sampler name and must not be set manually.");
@@ -61,14 +76,14 @@ void ezBindGroupBuilder::BindSampler(ezTempHashedString sSlotName, ezGALSamplerS
   }
 
   ezGALBindGroupItem item;
-  item.m_Flags = ezGALBindGroupItemFlags::Sampler;
+  item.m_Flags = (metaFlags & ezGALBindGroupItemFlags::MetaFlags) | ezGALBindGroupItemFlags::Sampler;
   item.m_Sampler.m_hSampler = hSampler;
   EZ_ASSERT_DEBUG(m_pDevice->GetSamplerState(item.m_Sampler.m_hSampler) != nullptr, "Invalid sampler handle bound.");
 
   InsertItem(sSlotName, item, m_BoundSamplers);
 }
 
-void ezBindGroupBuilder::BindBuffer(ezTempHashedString sSlotName, ezGALBufferHandle hBuffer, ezGALBufferRange bufferRange, ezEnum<ezGALResourceFormat> overrideTexelBufferFormat)
+void ezBindGroupBuilder::BindBuffer(ezTempHashedString sSlotName, ezGALBufferHandle hBuffer, ezGALBufferRange bufferRange, ezEnum<ezGALResourceFormat> overrideTexelBufferFormat, ezBitflags<ezGALBindGroupItemFlags> metaFlags)
 {
   if (hBuffer.IsInvalidated())
   {
@@ -79,7 +94,7 @@ void ezBindGroupBuilder::BindBuffer(ezTempHashedString sSlotName, ezGALBufferHan
   const ezGALBuffer* pBuffer = m_pDevice->GetBuffer(hBuffer);
   EZ_ASSERT_DEBUG(pBuffer != nullptr, "Invalid buffer handle bound.");
   ezGALBindGroupItem item;
-  item.m_Flags = ezGALBindGroupItemFlags::Buffer;
+  item.m_Flags = (metaFlags & ezGALBindGroupItemFlags::MetaFlags) | ezGALBindGroupItemFlags::Buffer;
   item.m_Buffer.m_hBuffer = hBuffer;
   item.m_Buffer.m_BufferRange = pBuffer->ClampRange(bufferRange);
   item.m_Buffer.m_OverrideTexelBufferFormat = overrideTexelBufferFormat;
@@ -87,7 +102,7 @@ void ezBindGroupBuilder::BindBuffer(ezTempHashedString sSlotName, ezGALBufferHan
   InsertItem(sSlotName, item, m_BoundBuffers);
 }
 
-void ezBindGroupBuilder::BindTexture(ezTempHashedString sSlotName, ezGALTextureHandle hTexture, ezGALTextureRange textureRange, ezEnum<ezGALResourceFormat> overrideViewFormat)
+void ezBindGroupBuilder::BindTexture(ezTempHashedString sSlotName, ezGALTextureHandle hTexture, ezGALTextureRange textureRange, ezEnum<ezGALResourceFormat> overrideViewFormat, ezBitflags<ezGALBindGroupItemFlags> metaFlags)
 {
   if (hTexture.IsInvalidated())
   {
@@ -107,7 +122,7 @@ void ezBindGroupBuilder::BindTexture(ezTempHashedString sSlotName, ezGALTextureH
   }
 
   ezGALBindGroupItem item;
-  item.m_Flags = ezGALBindGroupItemFlags::Texture;
+  item.m_Flags = (metaFlags & ezGALBindGroupItemFlags::MetaFlags) | ezGALBindGroupItemFlags::Texture;
   item.m_Texture.m_hTexture = hTexture;
   item.m_Texture.m_hSampler = {};
   item.m_Texture.m_TextureRange = pTexture->ClampRange(textureRange);
@@ -121,8 +136,9 @@ void ezBindGroupBuilder::BindTexture(ezTempHashedString sSlotName, const ezTextu
   if (hTexture.IsValid())
   {
     ezResourceLock<ezTexture2DResource> pTexture(hTexture, acquireMode);
-    BindTexture(sSlotName, pTexture->GetGALTexture(), textureRange, overrideViewFormat);
-    BindSampler(sSlotName, pTexture->GetGALSamplerState());
+    ezBitflags<ezGALBindGroupItemFlags> metaFlags = GetMetaFlags(pTexture);
+    BindTexture(sSlotName, pTexture->GetGALTexture(), textureRange, overrideViewFormat, metaFlags);
+    BindSampler(sSlotName, pTexture->GetGALSamplerState(), metaFlags);
   }
   else
   {
@@ -136,8 +152,9 @@ void ezBindGroupBuilder::BindTexture(ezTempHashedString sSlotName, const ezTextu
   if (hTexture.IsValid())
   {
     ezResourceLock<ezTexture3DResource> pTexture(hTexture, acquireMode);
-    BindTexture(sSlotName, pTexture->GetGALTexture(), textureRange, overrideViewFormat);
-    BindSampler(sSlotName, pTexture->GetGALSamplerState());
+    ezBitflags<ezGALBindGroupItemFlags> metaFlags = GetMetaFlags(pTexture);
+    BindTexture(sSlotName, pTexture->GetGALTexture(), textureRange, overrideViewFormat, metaFlags);
+    BindSampler(sSlotName, pTexture->GetGALSamplerState(), metaFlags);
   }
   else
   {
@@ -151,8 +168,9 @@ void ezBindGroupBuilder::BindTexture(ezTempHashedString sSlotName, const ezTextu
   if (hTexture.IsValid())
   {
     ezResourceLock<ezTextureCubeResource> pTexture(hTexture, acquireMode);
-    BindTexture(sSlotName, pTexture->GetGALTexture(), textureRange, overrideViewFormat);
-    BindSampler(sSlotName, pTexture->GetGALSamplerState());
+    ezBitflags<ezGALBindGroupItemFlags> metaFlags = GetMetaFlags(pTexture);
+    BindTexture(sSlotName, pTexture->GetGALTexture(), textureRange, overrideViewFormat, metaFlags);
+    BindSampler(sSlotName, pTexture->GetGALSamplerState(), metaFlags);
   }
   else
   {
@@ -174,8 +192,9 @@ void ezBindGroupBuilder::BindBuffer(ezTempHashedString sSlotName, ezConstantBuff
   }
 }
 
-void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLayout, ezGALBindGroupCreationDescription& out_bindGroup)
+void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLayout, ezGALBindGroupCreationDescription& out_bindGroup, ezBitflags<ezGALBindGroupItemFlags>& out_metaFlags)
 {
+  out_metaFlags = {};
   const ezGALBindGroupLayout* pLayout = m_pDevice->GetBindGroupLayout(hBindGroupLayout);
   EZ_ASSERT_DEBUG(pLayout != nullptr, "Bind group layout is null.");
 
@@ -197,7 +216,7 @@ void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLa
         s_uiReads++;
         if (!m_BoundSamplers.TryGetValue(binding.m_sName.GetHash(), item))
         {
-          item.m_Flags = ezGALBindGroupItemFlags::Sampler;
+          item.m_Flags = ezGALBindGroupItemFlags::Sampler | ezGALBindGroupItemFlags::EmptyBinding;
           item.m_Sampler.m_hSampler = m_hDefaultSampler;
         }
       }
@@ -216,7 +235,7 @@ void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLa
           ezGALBufferHandle hBuffer = ezGALRendererFallbackResources::GetFallbackBuffer(binding.m_ResourceType);
           EZ_ASSERT_DEBUG(!hBuffer.IsInvalidated(), "Missing fallback resource for binding resource type {}", binding.m_ResourceType.GetValue());
           const ezGALBuffer* pBuffer = m_pDevice->GetBuffer(hBuffer);
-          item.m_Flags = ezGALBindGroupItemFlags::Buffer | ezGALBindGroupItemFlags::Fallback;
+          item.m_Flags = ezGALBindGroupItemFlags::Buffer | ezGALBindGroupItemFlags::EmptyBinding;
           item.m_Buffer.m_hBuffer = hBuffer;
           item.m_Buffer.m_BufferRange = pBuffer->ClampRange({});
           item.m_Buffer.m_OverrideTexelBufferFormat = {};
@@ -235,7 +254,7 @@ void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLa
           ezGALTextureHandle hTexture = ezGALRendererFallbackResources::GetFallbackTexture(binding.m_ResourceType, binding.m_TextureType, bDepth);
           EZ_ASSERT_DEBUG(!hTexture.IsInvalidated(), "Missing fallback resource for binding resource type {}, texture type {}, depth {}", binding.m_ResourceType.GetValue(), binding.m_TextureType.GetValue(), bDepth);
           const ezGALTexture* pTexture = m_pDevice->GetTexture(hTexture);
-          item.m_Flags = ezGALBindGroupItemFlags::Texture | ezGALBindGroupItemFlags::Fallback;
+          item.m_Flags = ezGALBindGroupItemFlags::Texture | ezGALBindGroupItemFlags::EmptyBinding;
           item.m_Texture.m_hTexture = hTexture;
           item.m_Texture.m_hSampler = {};
           item.m_Texture.m_TextureRange = pTexture->ClampRange({});
@@ -248,6 +267,7 @@ void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLa
           const ezGALBindGroupItem* pSamplerItem = nullptr;
           if (!m_BoundSamplers.TryGetValue(binding.m_sName.GetHash(), pSamplerItem))
           {
+            item.m_Flags |= ezGALBindGroupItemFlags::EmptyBinding;
             item.m_Texture.m_hSampler = m_hDefaultSampler;
           }
           else
@@ -268,6 +288,7 @@ void ezBindGroupBuilder::CreateBindGroup(ezGALBindGroupLayoutHandle hBindGroupLa
         EZ_REPORT_FAILURE("Unsupported resource type for binding '{0}'", binding.m_sName, binding.m_ResourceType);
         break;
     }
+    out_metaFlags |= (item.m_Flags & ezGALBindGroupItemFlags::MetaFlags);
   }
   m_bModified = false;
 }

--- a/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
@@ -23,11 +23,11 @@ ezBindGroupBuilder::ezBindGroupBuilder() = default;
 namespace
 {
   template <typename T>
-  ezBitflags<ezGALBindGroupItemFlags> GetMetaFlags(const ezResourceLock<T>& pResource)
+  ezBitflags<ezGALBindGroupItemFlags> GetMetaFlags(const ezResourceLock<T>& resource)
   {
     ezBitflags<ezGALBindGroupItemFlags> metaFlags;
-    const bool isFallback = pResource.GetAcquireResult() != ezResourceAcquireResult::Final;
-    const bool isPartiallyLoaded = pResource->GetNumQualityLevelsLoadable() != 0;
+    const bool isFallback = resource.GetAcquireResult() != ezResourceAcquireResult::Final;
+    const bool isPartiallyLoaded = resource->GetNumQualityLevelsLoadable() != 0;
     if (isFallback)
       metaFlags.Add(ezGALBindGroupItemFlags::FallbackResource);
     if (isPartiallyLoaded)

--- a/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/BindGroupBuilder.cpp
@@ -23,7 +23,7 @@ ezBindGroupBuilder::ezBindGroupBuilder() = default;
 namespace
 {
   template <typename T>
-  ezBitflags<ezGALBindGroupItemFlags> GetMetaFlags(ezResourceLock<T>& pResource)
+  ezBitflags<ezGALBindGroupItemFlags> GetMetaFlags(const ezResourceLock<T>& pResource)
   {
     ezBitflags<ezGALBindGroupItemFlags> metaFlags;
     const bool isFallback = pResource.GetAcquireResult() != ezResourceAcquireResult::Final;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -1129,7 +1129,8 @@ ezResult ezRenderContext::ApplyBindGroup(const ezGALShader* pShader, ezUInt32 ui
     m_pGALCommandEncoder->SetBindGroup(uiBindGroup, hBindGroup);
     return EZ_SUCCESS;
   }
-  m_BindGroupBuilders[uiBindGroup].CreateBindGroup(hLayout, m_BindGroups[uiBindGroup]);
+  ezBitflags<ezGALBindGroupItemFlags> metaFlags;
+  m_BindGroupBuilders[uiBindGroup].CreateBindGroup(hLayout, m_BindGroups[uiBindGroup], metaFlags);
   m_pGALCommandEncoder->SetBindGroup(uiBindGroup, m_BindGroups[uiBindGroup]);
   return EZ_SUCCESS;
 }

--- a/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
+++ b/Code/Engine/RendererDX11/CommandEncoder/Implementation/CommandEncoderImplDX11.cpp
@@ -127,7 +127,7 @@ void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, con
       case ezGALShaderResourceType::ConstantBuffer:
       {
         const ezGALBufferDX11* pBuffer = static_cast<const ezGALBufferDX11*>(m_GALDeviceDX11.GetBuffer(item.m_Buffer.m_hBuffer));
-        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::Fallback))
+        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::EmptyBinding))
           pBuffer = nullptr;
 
         SetConstantBuffer(binding, pBuffer);
@@ -136,7 +136,7 @@ void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, con
       case ezGALShaderResourceType::Texture:
       {
         const ezGALTextureDX11* pTexture = static_cast<const ezGALTextureDX11*>(m_GALDeviceDX11.GetTexture(item.m_Texture.m_hTexture));
-        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::Fallback))
+        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::EmptyBinding))
           pTexture = nullptr;
 
         if (pTexture != nullptr && UnsetUnorderedAccessViews(pTexture))
@@ -152,7 +152,7 @@ void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, con
       case ezGALShaderResourceType::TextureRW:
       {
         const ezGALTextureDX11* pTexture = static_cast<const ezGALTextureDX11*>(m_GALDeviceDX11.GetTexture(item.m_Texture.m_hTexture));
-        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::Fallback))
+        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::EmptyBinding))
           pTexture = nullptr;
 
         if (pTexture != nullptr && UnsetResourceViews(pTexture))
@@ -170,7 +170,7 @@ void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, con
       case ezGALShaderResourceType::ByteAddressBuffer:
       {
         const ezGALBufferDX11* pBuffer = static_cast<const ezGALBufferDX11*>(m_GALDeviceDX11.GetBuffer(item.m_Buffer.m_hBuffer));
-        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::Fallback))
+        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::EmptyBinding))
           pBuffer = nullptr;
 
         if (pBuffer != nullptr && UnsetUnorderedAccessViews(pBuffer))
@@ -189,7 +189,7 @@ void ezGALCommandEncoderImplDX11::SetBindGroupPlatform(ezUInt32 uiBindGroup, con
       case ezGALShaderResourceType::ByteAddressBufferRW:
       {
         const ezGALBufferDX11* pBuffer = static_cast<const ezGALBufferDX11*>(m_GALDeviceDX11.GetBuffer(item.m_Buffer.m_hBuffer));
-        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::Fallback))
+        if (item.m_Flags.IsSet(ezGALBindGroupItemFlags::EmptyBinding))
           pBuffer = nullptr;
 
         if (pBuffer != nullptr && UnsetResourceViews(pBuffer))

--- a/Code/Engine/RendererFoundation/Shader/BindGroup.h
+++ b/Code/Engine/RendererFoundation/Shader/BindGroup.h
@@ -49,7 +49,11 @@ struct ezGALBindGroupItemFlags
     Sampler = EZ_BIT(0),  ///< ezGALBindGroupItem::m_Sampler is valid
     Texture = EZ_BIT(1),  ///< ezGALBindGroupItem::m_Texture is valid
     Buffer = EZ_BIT(2),   ///< ezGALBindGroupItem::m_Buffer is valid
-    Fallback = EZ_BIT(3), ///< The slot was filled with a fallback resource.
+    EmptyBinding = EZ_BIT(3), ///< The binding slot was empty and filled with a fallback resource from ezGALRendererFallbackResources.
+    FallbackResource = EZ_BIT(4), ///< The slot was filled with a fallback resource due to ezResourceAcquireMode::AllowLoadingFallback.
+    PartiallyLoaded = EZ_BIT(5),  ///< The resource is only partially loaded.
+    TypeFlags = Sampler | Texture | Buffer,
+    MetaFlags = EmptyBinding | FallbackResource | PartiallyLoaded,
     Default = 0
   };
 

--- a/Code/Engine/RendererFoundation/Shader/BindGroup.h
+++ b/Code/Engine/RendererFoundation/Shader/BindGroup.h
@@ -46,10 +46,10 @@ struct ezGALBindGroupItemFlags
 
   enum Enum : ezUInt8
   {
-    Sampler = EZ_BIT(0),  ///< ezGALBindGroupItem::m_Sampler is valid
-    Texture = EZ_BIT(1),  ///< ezGALBindGroupItem::m_Texture is valid
-    Buffer = EZ_BIT(2),   ///< ezGALBindGroupItem::m_Buffer is valid
-    EmptyBinding = EZ_BIT(3), ///< The binding slot was empty and filled with a fallback resource from ezGALRendererFallbackResources.
+    Sampler = EZ_BIT(0),          ///< ezGALBindGroupItem::m_Sampler is valid
+    Texture = EZ_BIT(1),          ///< ezGALBindGroupItem::m_Texture is valid
+    Buffer = EZ_BIT(2),           ///< ezGALBindGroupItem::m_Buffer is valid
+    EmptyBinding = EZ_BIT(3),     ///< The binding slot was empty and filled with a fallback resource from ezGALRendererFallbackResources.
     FallbackResource = EZ_BIT(4), ///< The slot was filled with a fallback resource due to ezResourceAcquireMode::AllowLoadingFallback.
     PartiallyLoaded = EZ_BIT(5),  ///< The resource is only partially loaded.
     TypeFlags = Sampler | Texture | Buffer,

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: A7F2587B-843F-4A9E-8940-C055DAD3A021AAA
+Change me: B7F2587B-843F-4A9E-8940-C055DAD3A021AAB


### PR DESCRIPTION
The code completely ignored when resources hit fallbacks or when a resource had additional lod levels. `ezBindGroupBuilder` will now tag each bound resource with meta data from `ezGALBindGroupItemFlags::MetaFlags`:
1. **EmptyBinding**: The binding slot was empty and filled with a fallback resource from ezGALRendererFallbackResources.
2. **FallbackResource**: The slot was filled with a fallback resource due to ezResourceAcquireMode::AllowLoadingFallback.
3. **PartiallyLoaded**: The resource is only partially loaded.
 
`ezBindGroupBuilder::CreateBindGroup` will return the union of all meta flags. 
If `ezMaterialManager::GetMaterialBindGroup` creates a bind group that contains `FallbackResource` or `PartiallyLoaded`, it will flag the material for bind group deletion in the next frame, forcing the bind groups to be re-created until a final state is reached without partial data.