### PR TITLE
Procedural spline volumes

### DIFF
--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
@@ -129,6 +129,7 @@ void ezQtProcGenNode::UpdateState()
     {
       sTitle.Shrink(9, 0);
     }
+    sTitle.TrimLeft("_");
   }
 
   m_pTitleLabel->setPlainText(sTitle.GetData());

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -484,6 +484,48 @@ ezExpressionAST::Node* ezProcGen_Blend::GenerateExpressionASTNode(ezTempHashedSt
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_Contrast, 1, ezRTTIDefaultAllocator<ezProcGen_Contrast>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("Input", m_fInputValue)->AddAttributes(new ezDefaultValueAttribute(0.5f)),
+    EZ_MEMBER_PROPERTY("Contrast", m_fContrast)->AddAttributes(new ezClampValueAttribute(-10.0f, 10.0f)),
+
+    EZ_MEMBER_PROPERTY("X", m_InputValuePin),
+    EZ_MEMBER_PROPERTY("Value", m_OutputValuePin)
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_ATTRIBUTES
+  {
+    new ezTitleAttribute("Contrast: {Contrast}"),
+    new ezCategoryAttribute("Math"),
+  }
+  EZ_END_ATTRIBUTES;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezExpressionAST::Node* ezProcGen_Contrast::GenerateExpressionASTNode(ezTempHashedString sOutputName, ezArrayPtr<ezExpressionAST::Node*> inputs, ezExpressionAST& out_ast, GraphContext& ref_context)
+{
+  EZ_ASSERT_DEBUG(sOutputName == "Value", "Implementation error");
+
+  auto pInput = inputs[0];
+  if (pInput == nullptr)
+  {
+    pInput = out_ast.CreateConstant(m_fInputValue);
+  }
+
+  auto pA = out_ast.CreateConstant(-m_fContrast);
+  auto pB = out_ast.CreateConstant(1.0f + m_fContrast);
+  auto pLerp = out_ast.CreateTernaryOperator(ezExpressionAST::NodeType::Lerp, pA, pB, pInput);
+  auto pSaturate = out_ast.CreateUnaryOperator(ezExpressionAST::NodeType::Saturate, pLerp);
+
+  return pSaturate;
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGen_Height, 1, ezRTTIDefaultAllocator<ezProcGen_Height>)
 {
   EZ_BEGIN_PROPERTIES

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
@@ -166,6 +166,22 @@ public:
 
 //////////////////////////////////////////////////////////////////////////
 
+class ezProcGen_Contrast : public ezProcGenNodeBase
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezProcGen_Contrast, ezProcGenNodeBase);
+
+public:
+  virtual ezExpressionAST::Node* GenerateExpressionASTNode(ezTempHashedString sOutputName, ezArrayPtr<ezExpressionAST::Node*> inputs, ezExpressionAST& out_ast, GraphContext& ref_context) override;
+
+  float m_fInputValue = 0.5f;
+  float m_fContrast = 0.0f;
+
+  ezRenderPipelineNodeInputPin m_InputValuePin;
+  ezRenderPipelineNodeOutputPin m_OutputValuePin;
+};
+
+//////////////////////////////////////////////////////////////////////////
+
 class ezProcGen_Height : public ezProcGenNodeBase
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezProcGen_Height, ezProcGenNodeBase);

--- a/Code/Engine/Core/Graphics/Implementation/Spline.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Spline.cpp
@@ -331,5 +331,174 @@ ezSimdTransform ezSpline::EvaluateTransform(float fT) const
   return transform;
 }
 
+ezResult ezSpline::CalculateSegmentBounds(ezUInt32 uiSegmentIndex, ezSimdBBoxSphere& out_bounds) const
+{
+  EZ_ASSERT_DEBUG(uiSegmentIndex < m_ControlPoints.GetCount(), "Invalid segment index");
+
+  auto& cp0 = m_ControlPoints[uiSegmentIndex];
+  auto& cp1 = m_ControlPoints[GetCp1Index(uiSegmentIndex)];
+
+  const ezSimdVec4f points[] = {
+    cp0.m_vPos,
+    cp0.m_vPos + cp0.m_vPosTangentOut,
+    cp1.m_vPos + cp1.m_vPosTangentIn,
+    cp1.m_vPos
+  };
+
+  out_bounds.SetFromPoints(points, EZ_ARRAY_SIZE(points));
+  return EZ_SUCCESS;
+}
+
+ezResult ezSpline::CalculateBounds(ezSimdBBoxSphere& out_bounds) const
+{
+  if (m_ControlPoints.GetCount() < 2)
+  {
+    out_bounds = ezSimdBBoxSphere::MakeInvalid();
+    return EZ_FAILURE;
+  }
+
+  const ezUInt32 uiNumSegments = GetNumSegments();
+
+  out_bounds = ezSimdBBoxSphere::MakeInvalid();
+  for (ezUInt32 i = 0; i < uiNumSegments; ++i)
+  {
+    ezSimdBBoxSphere segmentBounds;
+    EZ_SUCCEED_OR_RETURN(CalculateSegmentBounds(i, segmentBounds));
+    out_bounds.ExpandToInclude(segmentBounds);
+  }
+
+  return EZ_SUCCESS;
+}
+
+EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& p0, const ezSimdVec4f& p1, const ezSimdVec4f& p2, const ezSimdVec4f& p3, const ezSimdFloat& fMinT, const ezSimdFloat& fMaxT, const ezSimdVec4f& vPoint, ezSimdVec4f& out_closestDistSqr, ezSimdVec4f& out_closestT, ezSimdFloat& out_fStep)
+{
+  ezSimdVec4f vClosestPoint = ezMath::EvaluateBezierCurve(fMinT, p0, p1, p2, p3);
+  ezSimdVec4f vClosestDistSqr = ezSimdVec4f((vClosestPoint - vPoint).GetLengthSquared<3>());
+  ezSimdVec4f vClosestT = ezSimdVec4f(fMinT);
+
+  const ezUInt32 numSteps = 8;
+  ezSimdFloat fStep = (fMaxT - fMinT) / ezSimdFloat(static_cast<float>(numSteps));
+  for (ezSimdFloat fT = fStep; fT <= fMaxT; fT += fStep)
+  {
+    const ezSimdVec4f vCandidate = ezMath::EvaluateBezierCurve(fT, p0, p1, p2, p3);
+    const ezSimdVec4f vDistSqr = ezSimdVec4f((vCandidate - vPoint).GetLengthSquared<3>());
+    const ezSimdVec4b bIsCloser = (vDistSqr < vClosestDistSqr);
+
+    vClosestPoint = ezSimdVec4f::Select(bIsCloser, vCandidate, vClosestPoint);
+    vClosestDistSqr = ezSimdVec4f::Select(bIsCloser, vDistSqr, vClosestDistSqr);
+    vClosestT = ezSimdVec4f::Select(bIsCloser, ezSimdVec4f(fT), vClosestT);
+  }
+
+  out_closestDistSqr = vClosestDistSqr;
+  out_closestT = vClosestT;
+  out_fStep = fStep;
+  return vClosestPoint;
+}
+
+ezSimdVec4f ezSpline::FindClosestPointOnSegment(ezUInt32 uiSegmentIndex, const ezSimdVec4f& vPoint, float& out_fT, float& out_fDistanceSquared, float fMaxError /*= 0.1f*/) const
+{
+  EZ_ASSERT_DEBUG(uiSegmentIndex < m_ControlPoints.GetCount(), "Invalid segment index");
+
+  auto& cp0 = m_ControlPoints[uiSegmentIndex];
+  auto& cp1 = m_ControlPoints[GetCp1Index(uiSegmentIndex)];
+  const ezSimdVec4f p0 = cp0.m_vPos;
+  const ezSimdVec4f p1 = cp0.m_vPos + cp0.m_vPosTangentOut;
+  const ezSimdVec4f p2 = cp1.m_vPos + cp1.m_vPosTangentIn;
+  const ezSimdVec4f p3 = cp1.m_vPos;
+  const ezSimdFloat one(1.0f);
+  const ezSimdFloat maxErrorSqr(fMaxError * fMaxError);
+
+  ezSimdVec4f vClosestDistSqr;
+  ezSimdVec4f vClosestT;
+  ezSimdFloat fStep;
+  ezSimdVec4f vClosestPoint = FindIteration(p0, p1, p2, p2, ezSimdFloat::MakeZero(), one, vPoint, vClosestDistSqr, vClosestT, fStep);
+
+  constexpr ezUInt32 maxIterations = 4;
+  for (ezUInt32 i = 0; i < maxIterations; ++i)
+  {
+    const ezSimdFloat fClosestT = vClosestT.x();
+    const ezSimdFloat fMinT = (fClosestT - fStep).Max(ezSimdFloat::MakeZero());
+    const ezSimdFloat fMaxT = (fClosestT + fStep).Min(one);
+
+    const ezSimdFloat fClosestTToMinT = (fClosestT - fMinT).Abs();
+    const ezSimdFloat fClosestTToMaxT = (fClosestT - fMaxT).Abs();
+    const ezSimdFloat fTestT = fClosestTToMaxT > fClosestTToMinT ? fMaxT : fMinT;    
+    const ezSimdVec4f vTestP = ezMath::EvaluateBezierCurve(fTestT, p0, p1, p2, p3);
+    const ezSimdFloat vTestDistSqr = (vTestP - vClosestPoint).GetLengthSquared<3>();
+    if (vTestDistSqr < maxErrorSqr)
+      break;
+
+    vClosestPoint = FindIteration(p0, p1, p2, p3, fMinT, fMaxT, vPoint, vClosestDistSqr, vClosestT, fStep);
+  }
+
+  out_fT = vClosestT.x();
+  out_fDistanceSquared = vClosestDistSqr.x();
+  return vClosestPoint;
+}
+
+ezSimdVec4f ezSpline::FindClosestPoint(const ezSimdVec4f& vPoint, float& out_fT, float& out_fDistanceSquared, float fMaxError /*= 0.1f*/) const
+{
+  if (m_ControlPoints.GetCount() < 2)
+  {
+    out_fT = -1.0f;
+    return ezSimdVec4f::MakeNaN();
+  }
+
+  const ezUInt32 uiNumSegments = GetNumSegments();
+  ezHybridArray<ezSimdBBox, 32, ezAlignedAllocatorWrapper> segmentBounds;
+  segmentBounds.SetCountUninitialized(uiNumSegments);
+
+  ezUInt32 uiClosestSegment = 0;
+  float fClosestDistSqr = ezMath::MaxValue<float>();
+  for (ezUInt32 i = 0; i < uiNumSegments; ++i)
+  {
+    auto& cp0 = m_ControlPoints[i];
+    auto& cp1 = m_ControlPoints[GetCp1Index(i)];
+
+    auto& bounds = segmentBounds[i];
+    bounds.m_Min = cp0.m_vPos;
+    bounds.m_Max = cp0.m_vPos;
+    bounds.ExpandToInclude(cp0.m_vPos + cp0.m_vPosTangentOut);
+    bounds.ExpandToInclude(cp1.m_vPos + cp1.m_vPosTangentIn);
+    bounds.ExpandToInclude(cp1.m_vPos);
+
+    const float fDistSqr = bounds.GetDistanceSquaredTo(vPoint);
+    if (fDistSqr < fClosestDistSqr)
+    {
+      fClosestDistSqr = fDistSqr;
+      uiClosestSegment = i;
+    }
+  }
+
+  fClosestDistSqr = ezMath::MaxValue<float>();
+  float fClosestT = 0.0f;
+  ezSimdVec4f vClosestPoint;
+  
+  for (ezUInt32 i = 0; i < uiNumSegments; ++i)
+  {
+    ezUInt32 uiSegment = (uiClosestSegment + i);
+    if (uiSegment >= uiNumSegments)
+      uiSegment -= uiNumSegments;
+
+    const float fDistToBoundsSqr = segmentBounds[uiSegment].GetDistanceSquaredTo(vPoint);
+    if (fDistToBoundsSqr > fClosestDistSqr)
+      continue;
+
+    float fCandidateT = 0.0f;
+    float fCandidateDistSqr = 0.0f;
+    const ezSimdVec4f vCandidate = FindClosestPointOnSegment(uiSegment, vPoint, fCandidateT, fCandidateDistSqr, fMaxError);
+    if (fCandidateDistSqr < fClosestDistSqr)
+    {
+      vClosestPoint = vCandidate;
+      fClosestDistSqr = fCandidateDistSqr;
+      fClosestT = static_cast<float>(uiSegment) + fCandidateT;
+    }
+  }
+
+  out_fT = fClosestT;
+  out_fDistanceSquared = fClosestDistSqr;
+  return vClosestPoint;
+}
+
 
 EZ_STATICLINK_FILE(Core, Core_Graphics_Implementation_Spline);

--- a/Code/Engine/Core/Graphics/Implementation/Spline.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Spline.cpp
@@ -342,8 +342,7 @@ ezResult ezSpline::CalculateSegmentBounds(ezUInt32 uiSegmentIndex, ezSimdBBoxSph
     cp0.m_vPos,
     cp0.m_vPos + cp0.m_vPosTangentOut,
     cp1.m_vPos + cp1.m_vPosTangentIn,
-    cp1.m_vPos
-  };
+    cp1.m_vPos};
 
   out_bounds.SetFromPoints(points, EZ_ARRAY_SIZE(points));
   return EZ_SUCCESS;
@@ -422,7 +421,7 @@ ezSimdVec4f ezSpline::FindClosestPointOnSegment(ezUInt32 uiSegmentIndex, const e
 
     const ezSimdFloat fClosestTToMinT = (fClosestT - fMinT).Abs();
     const ezSimdFloat fClosestTToMaxT = (fClosestT - fMaxT).Abs();
-    const ezSimdFloat fTestT = fClosestTToMaxT > fClosestTToMinT ? fMaxT : fMinT;    
+    const ezSimdFloat fTestT = fClosestTToMaxT > fClosestTToMinT ? fMaxT : fMinT;
     const ezSimdVec4f vTestP = ezMath::EvaluateBezierCurve(fTestT, p0, p1, p2, p3);
     const ezSimdFloat vTestDistSqr = (vTestP - vClosestPoint).GetLengthSquared<3>();
     if (vTestDistSqr < maxErrorSqr)
@@ -473,7 +472,7 @@ ezSimdVec4f ezSpline::FindClosestPoint(const ezSimdVec4f& vPoint, float& out_fT,
   fClosestDistSqr = ezMath::MaxValue<float>();
   float fClosestT = 0.0f;
   ezSimdVec4f vClosestPoint;
-  
+
   for (ezUInt32 i = 0; i < uiNumSegments; ++i)
   {
     ezUInt32 uiSegment = (uiClosestSegment + i);

--- a/Code/Engine/Core/Graphics/Implementation/Spline.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Spline.cpp
@@ -342,9 +342,10 @@ ezResult ezSpline::CalculateSegmentBounds(ezUInt32 uiSegmentIndex, ezSimdBBoxSph
     cp0.m_vPos,
     cp0.m_vPos + cp0.m_vPosTangentOut,
     cp1.m_vPos + cp1.m_vPosTangentIn,
-    cp1.m_vPos};
+    cp1.m_vPos,
+  };
 
-  out_bounds.SetFromPoints(points, EZ_ARRAY_SIZE(points));
+  out_bounds = ezSimdBBoxSphere::MakeFromPoints(points, EZ_ARRAY_SIZE(points));
   return EZ_SUCCESS;
 }
 

--- a/Code/Engine/Core/Graphics/Implementation/Spline.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Spline.cpp
@@ -370,7 +370,7 @@ ezResult ezSpline::CalculateBounds(ezSimdBBoxSphere& out_bounds) const
   return EZ_SUCCESS;
 }
 
-EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& vP0, const ezSimdVec4f& vP1, const ezSimdVec4f& vP2, const ezSimdVec4f& vP3, const ezSimdFloat& fMinT, const ezSimdFloat& fMaxT, const ezSimdVec4f& vPoint, ezSimdVec4f& out_closestDistSqr, ezSimdVec4f& out_closestT, ezSimdFloat& out_fStep)
+EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& vP0, const ezSimdVec4f& vP1, const ezSimdVec4f& vP2, const ezSimdVec4f& vP3, const ezSimdFloat& fMinT, const ezSimdFloat& fMaxT, const ezSimdVec4f& vPoint, ezSimdVec4f& out_vClosestDistSqr, ezSimdVec4f& out_vClosestT, ezSimdFloat& out_fStep)
 {
   ezSimdVec4f vClosestPoint = ezMath::EvaluateBezierCurve(fMinT, vP0, vP1, vP2, vP3);
   ezSimdVec4f vClosestDistSqr = ezSimdVec4f((vClosestPoint - vPoint).GetLengthSquared<3>());
@@ -389,8 +389,8 @@ EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& vP0, const ezSimdV
     vClosestT = ezSimdVec4f::Select(bIsCloser, ezSimdVec4f(fT), vClosestT);
   }
 
-  out_closestDistSqr = vClosestDistSqr;
-  out_closestT = vClosestT;
+  out_vClosestDistSqr = vClosestDistSqr;
+  out_vClosestT = vClosestT;
   out_fStep = fStep;
   return vClosestPoint;
 }

--- a/Code/Engine/Core/Graphics/Implementation/Spline.cpp
+++ b/Code/Engine/Core/Graphics/Implementation/Spline.cpp
@@ -370,9 +370,9 @@ ezResult ezSpline::CalculateBounds(ezSimdBBoxSphere& out_bounds) const
   return EZ_SUCCESS;
 }
 
-EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& p0, const ezSimdVec4f& p1, const ezSimdVec4f& p2, const ezSimdVec4f& p3, const ezSimdFloat& fMinT, const ezSimdFloat& fMaxT, const ezSimdVec4f& vPoint, ezSimdVec4f& out_closestDistSqr, ezSimdVec4f& out_closestT, ezSimdFloat& out_fStep)
+EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& vP0, const ezSimdVec4f& vP1, const ezSimdVec4f& vP2, const ezSimdVec4f& vP3, const ezSimdFloat& fMinT, const ezSimdFloat& fMaxT, const ezSimdVec4f& vPoint, ezSimdVec4f& out_closestDistSqr, ezSimdVec4f& out_closestT, ezSimdFloat& out_fStep)
 {
-  ezSimdVec4f vClosestPoint = ezMath::EvaluateBezierCurve(fMinT, p0, p1, p2, p3);
+  ezSimdVec4f vClosestPoint = ezMath::EvaluateBezierCurve(fMinT, vP0, vP1, vP2, vP3);
   ezSimdVec4f vClosestDistSqr = ezSimdVec4f((vClosestPoint - vPoint).GetLengthSquared<3>());
   ezSimdVec4f vClosestT = ezSimdVec4f(fMinT);
 
@@ -380,7 +380,7 @@ EZ_ALWAYS_INLINE ezSimdVec4f FindIteration(const ezSimdVec4f& p0, const ezSimdVe
   ezSimdFloat fStep = (fMaxT - fMinT) / ezSimdFloat(static_cast<float>(numSteps));
   for (ezSimdFloat fT = fStep; fT <= fMaxT; fT += fStep)
   {
-    const ezSimdVec4f vCandidate = ezMath::EvaluateBezierCurve(fT, p0, p1, p2, p3);
+    const ezSimdVec4f vCandidate = ezMath::EvaluateBezierCurve(fT, vP0, vP1, vP2, vP3);
     const ezSimdVec4f vDistSqr = ezSimdVec4f((vCandidate - vPoint).GetLengthSquared<3>());
     const ezSimdVec4b bIsCloser = (vDistSqr < vClosestDistSqr);
 

--- a/Code/Engine/Core/Graphics/Implementation/Spline_inl.h
+++ b/Code/Engine/Core/Graphics/Implementation/Spline_inl.h
@@ -59,6 +59,17 @@ EZ_ALWAYS_INLINE void ezSpline::ControlPoint::SetScale(const ezSimdVec4f& vScale
 
 //////////////////////////////////////////////////////////////////////////
 
+EZ_ALWAYS_INLINE ezUInt32 ezSpline::GetNumControlPoints() const
+{
+  return m_ControlPoints.GetCount();
+}
+
+EZ_ALWAYS_INLINE ezUInt32 ezSpline::GetNumSegments() const
+{
+  const ezUInt32 uiNumPoints = m_ControlPoints.GetCount();
+  return m_bClosed ? uiNumPoints : (ezMath::Max(uiNumPoints, 1u) - 1);
+}
+
 EZ_FORCE_INLINE ezSimdVec4f ezSpline::EvaluatePosition(float fT) const
 {
   ezUInt32 uiCp0;

--- a/Code/Engine/Core/Graphics/Spline.h
+++ b/Code/Engine/Core/Graphics/Spline.h
@@ -3,7 +3,7 @@
 #include <Core/CoreDLL.h>
 
 #include <Foundation/Reflection/Reflection.h>
-#include <Foundation/SimdMath/SimdTransform.h>
+#include <Foundation/SimdMath/SimdBBoxSphere.h>
 
 class ezStreamReader;
 class ezStreamWriter;
@@ -73,8 +73,14 @@ struct EZ_CORE_DLL ezSpline
   ezResult Serialize(ezStreamWriter& ref_writer) const;
   ezResult Deserialize(ezStreamReader& ref_reader);
 
+
+  ezUInt32 GetNumControlPoints() const;
+  ezUInt32 GetNumSegments() const;
+
+
   /// \brief Calculates tangents for all control points with a tangent mode other than 'Custom'.
   void CalculateUpDirAndAutoTangents(const ezSimdVec4f& vGlobalUpDir = ezSimdVec4f(0, 0, 1), const ezSimdVec4f& vGlobalForwardDir = ezSimdVec4f(1, 0, 0));
+
 
   /// \brief Returns the position of the spline at the given parameter fT.
   ezSimdVec4f EvaluatePosition(float fT) const;
@@ -92,6 +98,20 @@ struct EZ_CORE_DLL ezSpline
 
   /// \brief Returns the full transform (consisting of position, scale, and orientation) of the spline at the given parameter fT.
   ezSimdTransform EvaluateTransform(float fT) const;
+
+
+  /// \brief Calculates the bounding volume of a single segment of the spline.
+  ezResult CalculateSegmentBounds(ezUInt32 uiSegmentIndex, ezSimdBBoxSphere& out_bounds) const;
+
+  /// \brief Calculates the bounding volume of the entire spline.
+  ezResult CalculateBounds(ezSimdBBoxSphere& out_bounds) const;
+
+
+  /// \brief Finds the closest point on a single segment of the spline to the given point. Returns the position on the spline, the parameter fT, and the squared distance.
+  ezSimdVec4f FindClosestPointOnSegment(ezUInt32 uiSegmentIndex, const ezSimdVec4f& vPoint, float& out_fT, float& out_fDistanceSquared, float fMaxError = 0.1f) const;
+
+  /// \brief Finds the closest point on the entire spline to the given point. Returns the position on the spline, the parameter fT, and the squared distance.
+  ezSimdVec4f FindClosestPoint(const ezSimdVec4f& vPoint, float& out_fT, float& out_fDistanceSquared, float fMaxError = 0.1f) const;
 
 private:
   float ClampAndSplitT(float fT, ezUInt32& out_uiIndex) const;

--- a/Code/Engine/Foundation/Math/Implementation/Math_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Math_inl.h
@@ -445,7 +445,7 @@ namespace ezMath
   }
 
   template <typename T, typename T2>
-  T EvaluateBezierCurve(T2 t, const T& startPoint, const T& controlPoint1, const T& controlPoint2, const T& endPoint)
+  EZ_FORCE_INLINE T EvaluateBezierCurve(T2 t, const T& startPoint, const T& controlPoint1, const T& controlPoint2, const T& endPoint)
   {
     const T2 mt = 1 - t;
     const T2 mt2 = mt * mt;
@@ -460,7 +460,7 @@ namespace ezMath
   }
 
   template <typename T, typename T2>
-  T EvaluateBezierCurveDerivative(T2 t, const T& startPoint, const T& controlPoint1, const T& controlPoint2, const T& endPoint)
+  EZ_FORCE_INLINE T EvaluateBezierCurveDerivative(T2 t, const T& startPoint, const T& controlPoint1, const T& controlPoint2, const T& endPoint)
   {
     const T2 mt = 1 - t;
 

--- a/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
@@ -13,11 +13,20 @@
 EZ_BEGIN_STATIC_REFLECTED_BITFLAGS(ezSplineComponentFlags, 1)
   EZ_BITFLAGS_CONSTANTS(ezSplineComponentFlags::VisualizeSpline, ezSplineComponentFlags::VisualizeUpDir, ezSplineComponentFlags::VisualizeTangents)
 EZ_END_STATIC_REFLECTED_BITFLAGS;
-// clang-format on
 
-// clang-format off
+EZ_BEGIN_STATIC_REFLECTED_ENUM(ezSplineComponentSpace, 1)
+  EZ_ENUM_CONSTANTS(ezSplineComponentSpace::Local, ezSplineComponentSpace::Global)
+EZ_END_STATIC_REFLECTED_ENUM;
+
 EZ_IMPLEMENT_MESSAGE_TYPE(ezMsgSplineChanged);
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMsgSplineChanged, 1, ezRTTIDefaultAllocator<ezMsgSplineChanged>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("ChangeCounter", m_uiChangeCounter),
+  }
+  EZ_END_PROPERTIES;
+}
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
@@ -82,19 +91,22 @@ EZ_BEGIN_COMPONENT_TYPE(ezSplineComponent, 1, ezComponentMode::Static)
   EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_FUNCTIONS
   {
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetPositionAtKey, In, "Key"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetForwardDirAtKey, In, "Key"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetUpDirAtKey, In, "Key"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetScaleAtKey, In, "Key"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetTransformAtKey, In, "Key"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetPositionAtKey, In, "Key", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetForwardDirAtKey, In, "Key", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetUpDirAtKey, In, "Key", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetScaleAtKey, In, "Key", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetTransformAtKey, In, "Key", In, "Space"),
 
     EZ_SCRIPT_FUNCTION_PROPERTY(GetTotalLength),
     EZ_SCRIPT_FUNCTION_PROPERTY(GetKeyAtDistance, In, "Distance"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetPositionAtDistance, In, "Distance"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetForwardDirAtDistance, In, "Distance"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetUpDirAtDistance, In, "Distance"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetScaleAtDistance, In, "Distance"),
-    EZ_SCRIPT_FUNCTION_PROPERTY(GetTransformAtDistance, In, "Distance"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetPositionAtDistance, In, "Distance", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetForwardDirAtDistance, In, "Distance", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetUpDirAtDistance, In, "Distance", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetScaleAtDistance, In, "Distance", In, "Space"),
+    EZ_SCRIPT_FUNCTION_PROPERTY(GetTransformAtDistance, In, "Distance", In, "Space"),
+
+    EZ_SCRIPT_FUNCTION_PROPERTY(FindKeyClosestToPoint, In, "Point", Out, "DistanceToPoint", In, "Space", In, "MaxError")->AddAttributes(
+      new ezFunctionArgumentAttributes(3, new ezDefaultValueAttribute(0.1))),
 
     EZ_SCRIPT_FUNCTION_PROPERTY(GetChangeCounter),
   }
@@ -162,11 +174,6 @@ void ezSplineComponent::OnDeactivated()
   }
 }
 
-void ezSplineComponent::OnMsgSplineChanged(ezMsgSplineChanged& ref_msg)
-{
-  UpdateSpline();
-}
-
 void ezSplineComponent::SetClosed(bool bClosed)
 {
   if (m_Spline.m_bClosed == bClosed)
@@ -190,29 +197,64 @@ void ezSplineComponent::SetSplineFlags(ezBitflags<ezSplineComponentFlags> flags)
   }
 }
 
-ezVec3 ezSplineComponent::GetPositionAtKey(float fKey) const
+ezVec3 ezSplineComponent::GetPositionAtKey(float fKey, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
-  return ezSimdConversion::ToVec3(m_Spline.EvaluatePosition(fKey));
+  ezVec3 pos = ezSimdConversion::ToVec3(m_Spline.EvaluatePosition(fKey));
+
+  if (space == ezSplineComponentSpace::Global)
+  {
+    pos = GetOwner()->GetGlobalTransform().TransformPosition(pos);
+  }
+
+  return pos;
 }
 
-ezVec3 ezSplineComponent::GetForwardDirAtKey(float fKey) const
+ezVec3 ezSplineComponent::GetForwardDirAtKey(float fKey, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
-  return ezSimdConversion::ToVec3(m_Spline.EvaluateDerivative(fKey).GetNormalized<3>());
+  ezVec3 dir = ezSimdConversion::ToVec3(m_Spline.EvaluateDerivative(fKey).GetNormalized<3>());
+
+  if (space == ezSplineComponentSpace::Global)
+  {
+    dir = GetOwner()->GetGlobalTransform().TransformDirection(dir);
+  }
+
+  return dir;
 }
 
-ezVec3 ezSplineComponent::GetUpDirAtKey(float fKey) const
+ezVec3 ezSplineComponent::GetUpDirAtKey(float fKey, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
-  return ezSimdConversion::ToVec3(m_Spline.EvaluateUpDirection(fKey));
+  ezVec3 dir = ezSimdConversion::ToVec3(m_Spline.EvaluateUpDirection(fKey));
+
+  if (space == ezSplineComponentSpace::Global)
+  {
+    dir = GetOwner()->GetGlobalTransform().TransformDirection(dir);
+  }
+
+  return dir;
 }
 
-ezVec3 ezSplineComponent::GetScaleAtKey(float fKey) const
+ezVec3 ezSplineComponent::GetScaleAtKey(float fKey, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
-  return ezSimdConversion::ToVec3(m_Spline.EvaluateScale(fKey));
+  ezVec3 scale = ezSimdConversion::ToVec3(m_Spline.EvaluateScale(fKey));
+
+  if (space == ezSplineComponentSpace::Global)
+  {
+    scale = scale.CompMul(GetOwner()->GetGlobalTransform().m_vScale);
+  }
+
+  return scale;
 }
 
-ezTransform ezSplineComponent::GetTransformAtKey(float fKey) const
+ezTransform ezSplineComponent::GetTransformAtKey(float fKey, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
-  return ezSimdConversion::ToTransform(m_Spline.EvaluateTransform(fKey));
+  ezTransform t = ezSimdConversion::ToTransform(m_Spline.EvaluateTransform(fKey));
+
+  if (space == ezSplineComponentSpace::Global)
+  {
+    t = ezTransform::MakeGlobalTransform(GetOwner()->GetGlobalTransform(), t);
+  }
+
+  return t;
 }
 
 float ezSplineComponent::GetKeyAtDistance(float fDistance) const
@@ -231,34 +273,51 @@ float ezSplineComponent::GetKeyAtDistance(float fDistance) const
   return ezMath::Lerp(fLowerKey, fUpperKey, ezMath::Saturate(ezMath::Unlerp(fLowerDistance, fUpperDistance, fDistance)));
 }
 
-ezVec3 ezSplineComponent::GetPositionAtDistance(float fDistance) const
+ezVec3 ezSplineComponent::GetPositionAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
   const float fKey = GetKeyAtDistance(fDistance);
-  return GetPositionAtKey(fKey);
+  return GetPositionAtKey(fKey, space);
 }
 
-ezVec3 ezSplineComponent::GetForwardDirAtDistance(float fDistance) const
+ezVec3 ezSplineComponent::GetForwardDirAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
   const float fKey = GetKeyAtDistance(fDistance);
-  return GetForwardDirAtKey(fKey);
+  return GetForwardDirAtKey(fKey, space);
 }
 
-ezVec3 ezSplineComponent::GetUpDirAtDistance(float fDistance) const
+ezVec3 ezSplineComponent::GetUpDirAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
   const float fKey = GetKeyAtDistance(fDistance);
-  return GetUpDirAtKey(fKey);
+  return GetUpDirAtKey(fKey, space);
 }
 
-ezVec3 ezSplineComponent::GetScaleAtDistance(float fDistance) const
+ezVec3 ezSplineComponent::GetScaleAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
   const float fKey = GetKeyAtDistance(fDistance);
-  return GetScaleAtKey(fKey);
+  return GetScaleAtKey(fKey, space);
 }
 
-ezTransform ezSplineComponent::GetTransformAtDistance(float fDistance) const
+ezTransform ezSplineComponent::GetTransformAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/) const
 {
   const float fKey = GetKeyAtDistance(fDistance);
-  return GetTransformAtKey(fKey);
+  return GetTransformAtKey(fKey, space);
+}
+
+float ezSplineComponent::FindKeyClosestToPoint(const ezVec3& vPoint, float& out_fDistance, ezEnum<ezSplineComponentSpace> space /* = ezSplineComponentSpace::Default*/, float fMaxError /*= 0.1f*/) const
+{
+  ezSimdVec4f p = ezSimdConversion::ToVec3(vPoint);
+
+  if (space == ezSplineComponentSpace::Global)
+  {
+    p = GetOwner()->GetGlobalTransformSimd().GetInverse().TransformPosition(p);
+  }
+
+  float fClosestKey = 0.0f;
+  float fClosestDistSqr = 0.0f;
+  m_Spline.FindClosestPoint(p, fClosestKey, fClosestDistSqr, fMaxError);
+
+  out_fDistance = ezMath::Sqrt(fClosestDistSqr);
+  return fClosestKey;
 }
 
 void ezSplineComponent::SetSpline(ezSpline&& spline)
@@ -268,6 +327,28 @@ void ezSplineComponent::SetSpline(ezSpline&& spline)
   m_Spline.m_uiChangeCounter = uiOldChangeCounter + 1;
 
   CreateDistanceToKeyRemapping();
+
+  ForwardSplineChangedEvent();
+}
+
+void ezSplineComponent::OnMsgSplineChanged(ezMsgSplineChanged& ref_msg)
+{
+  UpdateSpline();
+}
+
+void ezSplineComponent::ForwardSplineChangedEvent()
+{
+  ezMsgSplineChanged msg;
+  msg.FillFromSenderComponent(this);
+  msg.m_uiChangeCounter = m_Spline.m_uiChangeCounter;
+
+  for (ezComponent* pComp : GetOwner()->GetComponents())
+  {
+    if (pComp != this)
+    {
+      pComp->SendMessage(msg);
+    }
+  }
 }
 
 void ezSplineComponent::Nodes_SetNode(ezUInt32 uiIndex, const ezHashedString& sNodeName)
@@ -297,7 +378,7 @@ void ezSplineComponent::Nodes_Remove(ezUInt32 uiIndex)
   UpdateSpline();
 }
 
-void ezSplineComponent::UpdateSpline()
+void ezSplineComponent::UpdateSpline(bool bForwardChangedEvent /* = true*/)
 {
   if (!IsActiveAndInitialized())
     return;
@@ -309,6 +390,11 @@ void ezSplineComponent::UpdateSpline()
   }
 
   CreateDistanceToKeyRemapping();
+
+  if (bForwardChangedEvent)
+  {
+    ForwardSplineChangedEvent();
+  }
 }
 
 ezSplineNodeComponent* ezSplineComponent::FindNodeComponent(const ezHashedString& sNodeName)
@@ -371,6 +457,8 @@ void ezSplineComponent::UpdateFromNodeObjects()
   m_Spline.CalculateUpDirAndAutoTangents(ezSimdConversion::ToVec3(coordinateSystem.m_vUpDir), ezSimdConversion::ToVec3(coordinateSystem.m_vForwardDir));
 
   ++m_Spline.m_uiChangeCounter;
+  if (m_Spline.m_uiChangeCounter == ezInvalidIndex)
+    m_Spline.m_uiChangeCounter = 0;
 }
 
 void ezSplineComponent::InsertHalfPoint(ezDynamicArray<float>& ref_Ts, ezUInt32 uiCp0, float fLowerT, float fUpperT, const ezSimdVec4f& vLowerPos, const ezSimdVec4f& vUpperPos, float fDistSqr, ezInt32 iMinSteps, ezInt32 iMaxSteps) const

--- a/Code/Engine/RendererCore/Components/SplineComponent.h
+++ b/Code/Engine/RendererCore/Components/SplineComponent.h
@@ -156,7 +156,7 @@ protected:
   friend class ezSplineNodeComponent;
 
   /// \brief Informs the spline component, that its shape has changed. Sent by spline nodes when they are modified.
-  void OnMsgSplineChanged(ezMsgSplineChanged& ref_msg);                                    // [ message handler ]
+  void OnMsgSplineChanged(ezMsgSplineChanged& ref_msg); // [ message handler ]
 
   void ForwardSplineChangedEvent();
 
@@ -169,7 +169,7 @@ protected:
   void UpdateSpline(bool bForwardChangedEvent = true);
 
   ezSplineNodeComponent* FindNodeComponent(const ezHashedString& sNodeName);
-  void UpdateFromNodeObjects();  
+  void UpdateFromNodeObjects();
 
   void InsertHalfPoint(ezDynamicArray<float>& ref_Ts, ezUInt32 uiCp0, float fLowerT, float fUpperT, const ezSimdVec4f& vLowerPos, const ezSimdVec4f& vUpperPos, float fDistSqr, ezInt32 iMinSteps, ezInt32 iMaxSteps) const;
 

--- a/Code/Engine/RendererCore/Components/SplineComponent.h
+++ b/Code/Engine/RendererCore/Components/SplineComponent.h
@@ -21,9 +21,28 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_RENDERERCORE_DLL, ezSplineComponentFlags);
 
 //////////////////////////////////////////////////////////////////////////
 
+struct ezSplineComponentSpace
+{
+  using StorageType = ezUInt8;
+
+  enum Enum
+  {
+    Local,
+    Global,
+
+    Default = Local
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_RENDERERCORE_DLL, ezSplineComponentSpace);
+
+//////////////////////////////////////////////////////////////////////////
+
 struct EZ_RENDERERCORE_DLL ezMsgSplineChanged : public ezEventMessage
 {
   EZ_DECLARE_MESSAGE_TYPE(ezMsgSplineChanged, ezEventMessage);
+
+  ezUInt32 m_uiChangeCounter = ezInvalidIndex;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -49,7 +68,7 @@ protected:
 /// This can be used for moving things along the spline (see ezFollowSplineComponent) or to describe the (complex) shape of an object, for example a rope.
 ///
 /// The ezSplineComponent stores the shape as nodes with positions and tangents.
-/// Remapping XXXX
+/// It additionally creates a remapping from distance along the spline to spline key (segment index + t) for easier evaluation by distance.
 ///
 /// To set up the shape, attach child objects and attach an ezSplineNodeComponent to each. Also give each child object a distinct name.
 /// Then reference these child objects by name through the "Nodes" property on the spline shape.
@@ -78,9 +97,6 @@ public:
   ezSplineComponent();
   ~ezSplineComponent();
 
-  /// \brief Informs the spline component, that its shape has changed. Sent by spline nodes when they are modified.
-  void OnMsgSplineChanged(ezMsgSplineChanged& ref_msg); // [ message handler ]
-
   /// \brief Whether the spline end connects to the beginning.
   void SetClosed(bool bClosed);                                                       // [ property ]
   bool GetClosed() const { return m_Spline.m_bClosed; }                               // [ property ]
@@ -89,19 +105,19 @@ public:
   ezBitflags<ezSplineComponentFlags> GetSplineFlags() const { return m_SplineFlags; } // [ property ]
 
   /// \brief Returns the position of the spline at the given key (segment index + t).
-  ezVec3 GetPositionAtKey(float fKey) const; // [ scriptable ]
+  ezVec3 GetPositionAtKey(float fKey, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the forward direction of the spline at the given key (segment index + t).
-  ezVec3 GetForwardDirAtKey(float fKey) const; // [ scriptable ]
+  ezVec3 GetForwardDirAtKey(float fKey, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the up direction of the spline at the given key (segment index + t).
-  ezVec3 GetUpDirAtKey(float fKey) const; // [ scriptable ]
+  ezVec3 GetUpDirAtKey(float fKey, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the scale of the spline at the given key (segment index + t).
-  ezVec3 GetScaleAtKey(float fKey) const; // [ scriptable ]
+  ezVec3 GetScaleAtKey(float fKey, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the transform of the spline at the given key (segment index + t).
-  ezTransform GetTransformAtKey(float fKey) const; // [ scriptable ]
+  ezTransform GetTransformAtKey(float fKey, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
 
   /// \brief Returns the total length of the spline (in local space)
@@ -111,19 +127,23 @@ public:
   float GetKeyAtDistance(float fDistance) const; // [ scriptable ]
 
   /// \brief Returns the position of the spline at the given distance along the spline.
-  ezVec3 GetPositionAtDistance(float fDistance) const; // [ scriptable ]
+  ezVec3 GetPositionAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the forward direction of the spline at the given distance along the spline.
-  ezVec3 GetForwardDirAtDistance(float fDistance) const; // [ scriptable ]
+  ezVec3 GetForwardDirAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the up direction of the spline at the given distance along the spline.
-  ezVec3 GetUpDirAtDistance(float fDistance) const; // [ scriptable ]
+  ezVec3 GetUpDirAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the scale of the spline at the given distance along the spline.
-  ezVec3 GetScaleAtDistance(float fDistance) const; // [ scriptable ]
+  ezVec3 GetScaleAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
 
   /// \brief Returns the full transform of the spline at the given distance along the spline.
-  ezTransform GetTransformAtDistance(float fDistance) const; // [ scriptable ]
+  ezTransform GetTransformAtDistance(float fDistance, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default) const; // [ scriptable ]
+
+
+  /// \brief Finds the closest point on the spline to the given point in space.
+  float FindKeyClosestToPoint(const ezVec3& vPoint, float& out_fDistanceToPoint, ezEnum<ezSplineComponentSpace> space = ezSplineComponentSpace::Default, float fMaxError = 0.1f) const; // [ scriptable ]
 
 
   /// \brief Access to the underlying spline object
@@ -135,16 +155,21 @@ public:
 protected:
   friend class ezSplineNodeComponent;
 
+  /// \brief Informs the spline component, that its shape has changed. Sent by spline nodes when they are modified.
+  void OnMsgSplineChanged(ezMsgSplineChanged& ref_msg);                                    // [ message handler ]
+
+  void ForwardSplineChangedEvent();
+
   ezUInt32 Nodes_GetCount() const { return m_Nodes.GetCount(); }                           // [ property ]
   const ezHashedString& Nodes_GetNode(ezUInt32 uiIndex) const { return m_Nodes[uiIndex]; } // [ property ]
   void Nodes_SetNode(ezUInt32 uiIndex, const ezHashedString& sNodeName);                   // [ property ]
   void Nodes_Insert(ezUInt32 uiIndex, const ezHashedString& sNodeName);                    // [ property ]
   void Nodes_Remove(ezUInt32 uiIndex);                                                     // [ property ]
 
-  void UpdateSpline();
+  void UpdateSpline(bool bForwardChangedEvent = true);
 
   ezSplineNodeComponent* FindNodeComponent(const ezHashedString& sNodeName);
-  void UpdateFromNodeObjects();
+  void UpdateFromNodeObjects();  
 
   void InsertHalfPoint(ezDynamicArray<float>& ref_Ts, ezUInt32 uiCp0, float fLowerT, float fUpperT, const ezSimdVec4f& vLowerPos, const ezSimdVec4f& vUpperPos, float fDistSqr, ezInt32 iMinSteps, ezInt32 iMaxSteps) const;
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -8,6 +8,7 @@
 #include <Foundation/Profiling/Profiling.h>
 #include <ProcGenPlugin/Components/Implementation/PlacementTile.h>
 #include <ProcGenPlugin/Components/ProcPlacementComponent.h>
+#include <ProcGenPlugin/Components/ProcVolumeComponent.h>
 #include <ProcGenPlugin/Tasks/FindPlacementTilesTask.h>
 #include <ProcGenPlugin/Tasks/PlacementData.h>
 #include <ProcGenPlugin/Tasks/PlacementTask.h>
@@ -59,11 +60,15 @@ void ezProcPlacementComponentManager::Initialize()
   }
 
   ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&ezProcPlacementComponentManager::OnResourceEvent, this));
+
+  ezProcVolumeComponent::GetAreaInvalidatedEvent().AddEventHandler(ezMakeDelegate(&ezProcPlacementComponentManager::OnAreaInvalidated, this));
 }
 
 void ezProcPlacementComponentManager::Deinitialize()
 {
   ezResourceManager::GetResourceEvents().RemoveEventHandler(ezMakeDelegate(&ezProcPlacementComponentManager::OnResourceEvent, this));
+
+  ezProcVolumeComponent::GetAreaInvalidatedEvent().RemoveEventHandler(ezMakeDelegate(&ezProcPlacementComponentManager::OnAreaInvalidated, this));
 
   for (auto& activeTile : m_ActiveTiles)
   {
@@ -547,6 +552,32 @@ void ezProcPlacementComponentManager::OnResourceEvent(const ezResourceEvent& res
       {
         m_ComponentsToUpdate.PushBack(it->GetHandle());
       }
+    }
+  }
+}
+
+void ezProcPlacementComponentManager::OnAreaInvalidated(const ezProcGenInternal::InvalidatedArea& area)
+{
+  if (area.m_pWorld != GetWorld())
+    return;
+
+  ezSimdBBox areaBox = ezSimdConversion::ToBBox(area.m_Box);
+
+  for (auto it = GetComponents(); it.IsValid(); it.Next())
+  {
+    bool bIntersects = false;
+    for (auto& bounds : it->m_Bounds)
+    {
+      if (areaBox.Overlaps(bounds.m_GlobalBoundingBox))
+      {
+        bIntersects = true;
+        break;
+      }
+    }
+
+    if (bIntersects && !m_ComponentsToUpdate.Contains(it->GetHandle()))
+    {
+      m_ComponentsToUpdate.PushBack(it->GetHandle());
     }
   }
 }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -64,7 +64,6 @@ void ezProcVertexColorComponentManager::Initialize()
 
   ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnResourceEvent, this));
 
-  // TODO: also do this in ezProcPlacementComponentManager
   ezProcVolumeComponent::GetAreaInvalidatedEvent().AddEventHandler(ezMakeDelegate(&ezProcVertexColorComponentManager::OnAreaInvalidated, this));
 }
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
@@ -11,13 +11,6 @@
 #include <ProcGenPlugin/Components/ProcVolumeComponent.h>
 #include <ProcGenPlugin/Components/VolumeCollection.h>
 
-namespace
-{
-  ezSpatialData::Category s_ProcVolumeCategory = ezSpatialData::RegisterCategory("ProcVolume", ezSpatialData::Flags::None);
-}
-
-//////////////////////////////////////////////////////////////////////////
-
 // clang-format off
 EZ_BEGIN_ABSTRACT_COMPONENT_TYPE(ezProcVolumeComponent, 1)
 {
@@ -43,6 +36,7 @@ EZ_END_COMPONENT_TYPE
 // clang-format on
 
 ezProcVolumeComponent::AreaInvalidatedEvent ezProcVolumeComponent::s_AreaInvalidatedEvent;
+ezSpatialData::Category ezProcVolumeComponent::s_SpatialCategory = ezSpatialData::RegisterCategory("ProcVolume", ezSpatialData::Flags::None);
 
 ezProcVolumeComponent::ezProcVolumeComponent() = default;
 ezProcVolumeComponent::~ezProcVolumeComponent() = default;
@@ -249,7 +243,7 @@ void ezProcVolumeSphereComponent::DeserializeComponent(ezWorldReader& inout_stre
 
 void ezProcVolumeSphereComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& ref_msg) const
 {
-  ref_msg.AddBounds(ezBoundingSphere::MakeFromCenterAndRadius(ezVec3::MakeZero(), m_fRadius), s_ProcVolumeCategory);
+  ref_msg.AddBounds(ezBoundingSphere::MakeFromCenterAndRadius(ezVec3::MakeZero(), m_fRadius), s_SpatialCategory);
 }
 
 void ezProcVolumeSphereComponent::OnExtractVolumes(ezMsgExtractVolumes& ref_msg) const
@@ -360,7 +354,7 @@ void ezProcVolumeBoxComponent::DeserializeComponent(ezWorldReader& inout_stream)
 
 void ezProcVolumeBoxComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& ref_msg) const
 {
-  ref_msg.AddBounds(ezBoundingBoxSphere::MakeFromBox(ezBoundingBox::MakeFromMinMax(-m_vExtents * 0.5f, m_vExtents * 0.5f)), s_ProcVolumeCategory);
+  ref_msg.AddBounds(ezBoundingBoxSphere::MakeFromBox(ezBoundingBox::MakeFromMinMax(-m_vExtents * 0.5f, m_vExtents * 0.5f)), s_SpatialCategory);
 }
 
 void ezProcVolumeBoxComponent::OnExtractVolumes(ezMsgExtractVolumes& ref_msg) const

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
@@ -260,12 +260,13 @@ void ezProcVolumeSphereComponent::OnExtractVolumes(ezMsgExtractVolumes& ref_msg)
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeBoxComponent, 2, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeBoxComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("Extents", GetExtents, SetExtents)->AddAttributes(new ezDefaultValueAttribute(ezVec3(10.0f)), new ezClampValueAttribute(ezVec3(0), ezVariant())),
-    EZ_ACCESSOR_PROPERTY("Falloff", GetFalloff, SetFalloff)->AddAttributes(new ezDefaultValueAttribute(ezVec3(0.5f)), new ezClampValueAttribute(ezVec3(0.0f), ezVec3(1.0f))),
+    EZ_ACCESSOR_PROPERTY("PositiveFalloff", GetPositiveFalloff, SetPositiveFalloff)->AddAttributes(new ezDefaultValueAttribute(ezVec3(0.5f)), new ezClampValueAttribute(ezVec3(0.0f), ezVec3(1.0f))),
+    EZ_ACCESSOR_PROPERTY("NegativeFalloff", GetNegativeFalloff, SetNegativeFalloff)->AddAttributes(new ezDefaultValueAttribute(ezVec3(0.5f)), new ezClampValueAttribute(ezVec3(0.0f), ezVec3(1.0f))),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS
@@ -302,11 +303,21 @@ void ezProcVolumeBoxComponent::SetExtents(const ezVec3& vExtents)
   }
 }
 
-void ezProcVolumeBoxComponent::SetFalloff(const ezVec3& vFalloff)
+void ezProcVolumeBoxComponent::SetPositiveFalloff(const ezVec3& vFalloff)
 {
-  if (m_vFalloff != vFalloff)
+  if (m_vPositiveFalloff != vFalloff)
   {
-    m_vFalloff = vFalloff;
+    m_vPositiveFalloff = vFalloff;
+
+    InvalidateArea();
+  }
+}
+
+void ezProcVolumeBoxComponent::SetNegativeFalloff(const ezVec3& vFalloff)
+{
+  if (m_vNegativeFalloff != vFalloff)
+  {
+    m_vNegativeFalloff = vFalloff;
 
     InvalidateArea();
   }
@@ -319,7 +330,8 @@ void ezProcVolumeBoxComponent::SerializeComponent(ezWorldWriter& inout_stream) c
   ezStreamWriter& s = inout_stream.GetStream();
 
   s << m_vExtents;
-  s << m_vFalloff;
+  s << m_vPositiveFalloff;
+  s << m_vNegativeFalloff;
 }
 
 void ezProcVolumeBoxComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -329,11 +341,20 @@ void ezProcVolumeBoxComponent::DeserializeComponent(ezWorldReader& inout_stream)
   ezStreamReader& s = inout_stream.GetStream();
 
   s >> m_vExtents;
-  s >> m_vFalloff;
+  s >> m_vPositiveFalloff;
+  if (uiVersion >= 3)
+  {
+    s >> m_vNegativeFalloff;
+  }
+  else
+  {
+    m_vNegativeFalloff = m_vPositiveFalloff;
+  }
 
   if (uiVersion < 2)
   {
-    m_vFalloff = ezVec3(1.0f) - m_vFalloff;
+    m_vPositiveFalloff = ezVec3(1.0f) - m_vPositiveFalloff;
+    m_vNegativeFalloff = ezVec3(1.0f) - m_vNegativeFalloff;
   }
 }
 
@@ -344,7 +365,7 @@ void ezProcVolumeBoxComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& ref_m
 
 void ezProcVolumeBoxComponent::OnExtractVolumes(ezMsgExtractVolumes& ref_msg) const
 {
-  ref_msg.m_pCollection->AddBox(GetOwner()->GetGlobalTransformSimd(), m_vExtents, m_BlendMode, m_fSortOrder, m_fValue, m_vFalloff);
+  ref_msg.m_pCollection->AddBox(GetOwner()->GetGlobalTransformSimd(), m_vExtents, m_BlendMode, m_fSortOrder, m_fValue, m_vPositiveFalloff, m_vNegativeFalloff);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -389,7 +410,7 @@ void ezProcVolumeImageComponent::DeserializeComponent(ezWorldReader& inout_strea
 
 void ezProcVolumeImageComponent::OnExtractVolumes(ezMsgExtractVolumes& ref_msg) const
 {
-  ref_msg.m_pCollection->AddImage(GetOwner()->GetGlobalTransformSimd(), m_vExtents, m_BlendMode, m_fSortOrder, m_fValue, m_vFalloff, m_hImage);
+  ref_msg.m_pCollection->AddBox(GetOwner()->GetGlobalTransformSimd(), m_vExtents, m_BlendMode, m_fSortOrder, m_fValue, m_vPositiveFalloff, m_vNegativeFalloff, m_hImage);
 }
 
 void ezProcVolumeImageComponent::SetImage(const ezImageDataResourceHandle& hResource)
@@ -442,6 +463,27 @@ public:
 };
 
 ezProcVolumeBoxComponent_1_2 g_ezProcVolumeBoxComponent_1_2;
+
+class ezProcVolumeBoxComponent_2_3 : public ezGraphPatch
+{
+public:
+  ezProcVolumeBoxComponent_2_3()
+    : ezGraphPatch("ezProcVolumeBoxComponent", 3)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    auto* pFalloff = pNode->FindProperty("Falloff");
+    if (pFalloff && pFalloff->m_Value.IsA<ezVec3>())
+    {
+      pNode->AddProperty("PositiveFalloff", pFalloff->m_Value.Get<ezVec3>());
+      pNode->AddProperty("NegativeFalloff", pFalloff->m_Value.Get<ezVec3>());
+    }
+  }
+};
+
+ezProcVolumeBoxComponent_2_3 g_ezProcVolumeBoxComponent_2_3;
 
 
 EZ_STATICLINK_FILE(ProcGenPlugin, ProcGenPlugin_Components_Implementation_ProcVolumeComponent);

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeComponent.cpp
@@ -187,7 +187,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeSphereComponent, 2, ezComponentMode::Static)
   EZ_BEGIN_ATTRIBUTES
   {
     new ezSphereManipulatorAttribute("Radius"),
-    new ezSphereVisualizerAttribute("Radius", ezColor::LimeGreen),
+    new ezSphereVisualizerAttribute("Radius", ezColorScheme::GetCategoryColor("Construction", ezColorScheme::CategoryColorUsage::ViewportIcon)),
   }
   EZ_END_ATTRIBUTES;
 }
@@ -278,7 +278,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeBoxComponent, 3, ezComponentMode::Static)
   EZ_BEGIN_ATTRIBUTES
   {
     new ezBoxManipulatorAttribute("Extents", 1.0f, true),
-    new ezBoxVisualizerAttribute("Extents", 1.0f, ezColor::LimeGreen),
+    new ezBoxVisualizerAttribute("Extents", 1.0f, ezColorScheme::GetCategoryColor("Construction", ezColorScheme::CategoryColorUsage::ViewportIcon)),
   }
   EZ_END_ATTRIBUTES;
 }

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
@@ -7,6 +7,8 @@
 #include <ProcGenPlugin/Components/ProcVolumeSplineComponent.h>
 #include <ProcGenPlugin/Components/VolumeCollection.h>
 #include <RendererCore/Components/SplineComponent.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+#include <RendererCore/Pipeline/RenderData.h>
 
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeSplineComponent, 1, ezComponentMode::Static)
@@ -106,7 +108,7 @@ void ezProcVolumeSplineComponent::OnMsgUpdateLocalBounds(ezMsgUpdateLocalBounds&
   bounds.m_BoxHalfExtents += ezSimdVec4f(m_fRadius);
   bounds.m_CenterAndRadius.SetW(bounds.m_CenterAndRadius.w() + ezSimdFloat(m_fRadius));
 
-  ref_msg.AddBounds(ezSimdConversion::ToBBoxSphere(bounds), s_ProcVolumeCategory);
+  ref_msg.AddBounds(ezSimdConversion::ToBBoxSphere(bounds), s_SpatialCategory);
 }
 
 void ezProcVolumeSplineComponent::OnMsgExtractVolumes(ezMsgExtractVolumes& ref_msg) const
@@ -177,7 +179,7 @@ void ezProcVolumeSplineComponent::OnMsgExtractRenderData(ezMsgExtractRenderData&
     const float fStep = 1.0f / static_cast<float>(uiSteps);
     for (ezUInt32 i = 0; i < uiNumSegments; ++i)
     {
-      ezSimdTransform t0 = spline.EvaluateTransform(i);
+      ezSimdTransform t0 = spline.EvaluateTransform(static_cast<float>(i));
 
       AddRing(t0, ezBasisAxis::PositiveY, ezBasisAxis::PositiveZ, uiRingSteps);
       if (i == 0 && !spline.m_bClosed)

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
@@ -81,12 +81,12 @@ void ezProcVolumeSplineComponent::DeserializeComponent(ezWorldReader& inout_stre
   s >> m_fFalloff;
 }
 
-void ezProcVolumeSplineComponent::OnMsgSplineChanged(ezMsgSplineChanged& msg)
+void ezProcVolumeSplineComponent::OnMsgSplineChanged(ezMsgSplineChanged& ref_msg)
 {
-  if (msg.m_uiChangeCounter == ezInvalidIndex || msg.m_uiChangeCounter == m_uiLastChangeCounter)
+  if (ref_msg.m_uiChangeCounter == ezInvalidIndex || ref_msg.m_uiChangeCounter == m_uiLastChangeCounter)
     return;
 
-  m_uiLastChangeCounter = msg.m_uiChangeCounter;
+  m_uiLastChangeCounter = ref_msg.m_uiChangeCounter;
 
   GetOwner()->UpdateLocalBounds();
 
@@ -123,9 +123,9 @@ void ezProcVolumeSplineComponent::OnMsgExtractVolumes(ezMsgExtractVolumes& ref_m
   ref_msg.m_pCollection->AddSpline(GetOwner()->GetGlobalTransformSimd(), pSplineComponent->GetSpline(), m_fRadius, m_BlendMode, m_fSortOrder, m_fValue, m_fFalloff);
 }
 
-void ezProcVolumeSplineComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
+void ezProcVolumeSplineComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& ref_msg) const
 {
-  if (msg.m_OverrideCategory != ezDefaultRenderDataCategories::Selection)
+  if (ref_msg.m_OverrideCategory != ezDefaultRenderDataCategories::Selection)
     return;
 
   const ezSplineComponent* pSplineComponent = nullptr;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
@@ -1,0 +1,221 @@
+#include <ProcGenPlugin/ProcGenPluginPCH.h>
+
+#include <Core/Messages/TransformChangedMessage.h>
+#include <Core/Messages/UpdateLocalBoundsMessage.h>
+#include <Core/WorldSerializer/WorldReader.h>
+#include <Core/WorldSerializer/WorldWriter.h>
+#include <ProcGenPlugin/Components/ProcVolumeSplineComponent.h>
+#include <ProcGenPlugin/Components/VolumeCollection.h>
+#include <RendererCore/Components/SplineComponent.h>
+
+// clang-format off
+EZ_BEGIN_COMPONENT_TYPE(ezProcVolumeSplineComponent, 1, ezComponentMode::Static)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_ACCESSOR_PROPERTY("Radius", GetRadius, SetRadius)->AddAttributes(new ezDefaultValueAttribute(5.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_ACCESSOR_PROPERTY("Falloff", GetFalloff, SetFalloff)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgSplineChanged, OnMsgSplineChanged),
+    EZ_MESSAGE_HANDLER(ezMsgUpdateLocalBounds, OnMsgUpdateLocalBounds),
+    EZ_MESSAGE_HANDLER(ezMsgExtractVolumes, OnMsgExtractVolumes),
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+  }
+  EZ_END_MESSAGEHANDLERS;
+}
+EZ_END_COMPONENT_TYPE
+// clang-format on
+
+ezProcVolumeSplineComponent::ezProcVolumeSplineComponent() = default;
+ezProcVolumeSplineComponent::~ezProcVolumeSplineComponent() = default;
+
+void ezProcVolumeSplineComponent::SetRadius(float fRadius)
+{
+  if (m_fRadius != fRadius)
+  {
+    m_fRadius = fRadius;
+
+    if (IsActiveAndInitialized())
+    {
+      GetOwner()->UpdateLocalBounds();
+    }
+
+    InvalidateArea();
+
+    m_DebugLines.Clear();
+  }
+}
+
+void ezProcVolumeSplineComponent::SetFalloff(float fFalloff)
+{
+  if (m_fFalloff != fFalloff)
+  {
+    m_fFalloff = fFalloff;
+
+    InvalidateArea();
+  }
+}
+
+void ezProcVolumeSplineComponent::SerializeComponent(ezWorldWriter& inout_stream) const
+{
+  SUPER::SerializeComponent(inout_stream);
+
+  ezStreamWriter& s = inout_stream.GetStream();
+
+  s << m_fRadius;
+  s << m_fFalloff;
+}
+
+void ezProcVolumeSplineComponent::DeserializeComponent(ezWorldReader& inout_stream)
+{
+  SUPER::DeserializeComponent(inout_stream);
+  const ezUInt32 uiVersion = inout_stream.GetComponentTypeVersion(GetStaticRTTI());
+  ezStreamReader& s = inout_stream.GetStream();
+
+  s >> m_fRadius;
+  s >> m_fFalloff;
+}
+
+void ezProcVolumeSplineComponent::OnMsgSplineChanged(ezMsgSplineChanged& msg)
+{
+  if (msg.m_uiChangeCounter == ezInvalidIndex || msg.m_uiChangeCounter == m_uiLastChangeCounter)
+    return;
+
+  m_uiLastChangeCounter = msg.m_uiChangeCounter;
+
+  GetOwner()->UpdateLocalBounds();
+
+  InvalidateArea();
+
+  m_DebugLines.Clear();
+}
+
+void ezProcVolumeSplineComponent::OnMsgUpdateLocalBounds(ezMsgUpdateLocalBounds& ref_msg) const
+{
+  const ezSplineComponent* pSplineComponent = nullptr;
+  if (!GetOwner()->TryGetComponentOfBaseType(pSplineComponent))
+    return;
+
+  ezSimdBBoxSphere bounds;
+  if (pSplineComponent->GetSpline().CalculateBounds(bounds).Failed())
+    return;
+
+  bounds.m_BoxHalfExtents += ezSimdVec4f(m_fRadius);
+  bounds.m_CenterAndRadius.SetW(bounds.m_CenterAndRadius.w() + ezSimdFloat(m_fRadius));
+
+  ref_msg.AddBounds(ezSimdConversion::ToBBoxSphere(bounds), s_ProcVolumeCategory);
+}
+
+void ezProcVolumeSplineComponent::OnMsgExtractVolumes(ezMsgExtractVolumes& ref_msg) const
+{
+  const ezSplineComponent* pSplineComponent = nullptr;
+  if (!GetOwner()->TryGetComponentOfBaseType(pSplineComponent))
+    return;
+
+  if (pSplineComponent->GetSpline().m_ControlPoints.GetCount() < 2)
+    return;
+
+  ref_msg.m_pCollection->AddSpline(GetOwner()->GetGlobalTransformSimd(), pSplineComponent->GetSpline(), m_fRadius, m_BlendMode, m_fSortOrder, m_fValue, m_fFalloff);
+}
+
+void ezProcVolumeSplineComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
+{
+  if (msg.m_OverrideCategory != ezDefaultRenderDataCategories::Selection)
+    return;
+
+  const ezSplineComponent* pSplineComponent = nullptr;
+  if (!GetOwner()->TryGetComponentOfBaseType(pSplineComponent))
+    return;
+
+  auto& spline = pSplineComponent->GetSpline();
+  if (spline.GetNumControlPoints() < 2)
+    return;
+
+  if (m_DebugLines.IsEmpty())
+  {
+    constexpr ezUInt32 uiSteps = 8;
+    constexpr ezUInt32 uiRingSteps = 16;
+    constexpr ezAngle ringStepAngle = ezAngle::MakeFromDegree(360.0f / (float)uiRingSteps);
+    const ezUInt32 uiNumSegments = spline.GetNumSegments();
+
+    const ezUInt32 uiNumRings = uiNumSegments * 2 + (spline.m_bClosed ? 0 : 3);
+    const ezUInt32 uiNumLines = uiNumSegments * uiSteps * 4 + uiNumRings * uiRingSteps;
+    m_DebugLines.Reserve(uiNumLines);
+
+    auto AddRing = [&](const ezSimdTransform& t, ezBasisAxis::Enum rightAxis, ezBasisAxis::Enum upAxis, ezUInt32 uiNumSteps)
+    {
+      const ezSimdVec4f vRight = ezSimdConversion::ToVec3(ezBasisAxis::GetBasisVector(rightAxis)) * m_fRadius;
+      const ezSimdVec4f vUp = ezSimdConversion::ToVec3(ezBasisAxis::GetBasisVector(upAxis)) * m_fRadius;
+
+      for (ezUInt32 s = 0; s < uiNumSteps; ++s)
+      {
+        const float fS1 = static_cast<float>(s);
+        const float fS2 = static_cast<float>(s + 1);
+
+        const float fCos1 = ezMath::Cos(fS1 * ringStepAngle);
+        const float fCos2 = ezMath::Cos(fS2 * ringStepAngle);
+
+        const float fSin1 = ezMath::Sin(fS1 * ringStepAngle);
+        const float fSin2 = ezMath::Sin(fS2 * ringStepAngle);
+
+        auto& line = m_DebugLines.ExpandAndGetRef();
+        line.m_start = ezSimdConversion::ToVec3(t.TransformPosition(vRight * fSin1 + vUp * fCos1));
+        line.m_end = ezSimdConversion::ToVec3(t.TransformPosition(vRight * fSin2 + vUp * fCos2));
+      }      
+    };
+
+    const ezSimdVec4f vOffsets[] = {
+      ezSimdVec4f(0, m_fRadius, 0),
+      ezSimdVec4f(0, -m_fRadius, 0),
+      ezSimdVec4f(0, 0, m_fRadius),
+      ezSimdVec4f(0, 0, -m_fRadius),
+    };
+
+    const float fStep = 1.0f / static_cast<float>(uiSteps);
+    for (ezUInt32 i = 0; i < uiNumSegments; ++i)
+    {
+      ezSimdTransform t0 = spline.EvaluateTransform(i);
+
+      AddRing(t0, ezBasisAxis::PositiveY, ezBasisAxis::PositiveZ, uiRingSteps);
+      if (i == 0 && !spline.m_bClosed)
+      {
+        AddRing(t0, ezBasisAxis::NegativeX, ezBasisAxis::PositiveY, uiRingSteps / 2);
+        AddRing(t0, ezBasisAxis::NegativeX, ezBasisAxis::PositiveZ, uiRingSteps / 2);
+      }
+
+      for (ezUInt32 uiStep = 1; uiStep <= uiSteps; ++uiStep)
+      {
+        const float fT = fStep * static_cast<float>(uiStep);
+        const ezSimdTransform t1 = spline.EvaluateTransform(fT + i);
+        for (const auto& offset : vOffsets)
+        {
+          auto& line = m_DebugLines.ExpandAndGetRef();
+          line.m_start = ezSimdConversion::ToVec3(t0.TransformPosition(offset));
+          line.m_end = ezSimdConversion::ToVec3(t1.TransformPosition(offset));
+        }
+
+        if (uiStep == uiSteps / 2)
+        {
+          AddRing(t1, ezBasisAxis::PositiveY, ezBasisAxis::PositiveZ, uiRingSteps);
+        }
+
+        t0 = t1;
+      }
+
+      if (i == uiNumSegments - 1 && !spline.m_bClosed)
+      {
+        AddRing(t0, ezBasisAxis::PositiveX, ezBasisAxis::PositiveY, uiRingSteps / 2);
+        AddRing(t0, ezBasisAxis::PositiveX, ezBasisAxis::PositiveZ, uiRingSteps / 2);
+        AddRing(t0, ezBasisAxis::PositiveY, ezBasisAxis::PositiveZ, uiRingSteps);
+      }
+    }
+
+    EZ_ASSERT_DEBUG(m_DebugLines.GetCount() == uiNumLines, "Implementation error");
+  }  
+
+  ezColor c = ezColorScheme::GetCategoryColor("Construction", ezColorScheme::CategoryColorUsage::ViewportIcon);
+  ezDebugRenderer::DrawLines(GetWorld(), m_DebugLines, c, GetOwner()->GetGlobalTransform());
+}

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVolumeSplineComponent.cpp
@@ -164,7 +164,7 @@ void ezProcVolumeSplineComponent::OnMsgExtractRenderData(ezMsgExtractRenderData&
         auto& line = m_DebugLines.ExpandAndGetRef();
         line.m_start = ezSimdConversion::ToVec3(t.TransformPosition(vRight * fSin1 + vUp * fCos1));
         line.m_end = ezSimdConversion::ToVec3(t.TransformPosition(vRight * fSin2 + vUp * fCos2));
-      }      
+      }
     };
 
     const ezSimdVec4f vOffsets[] = {
@@ -214,7 +214,7 @@ void ezProcVolumeSplineComponent::OnMsgExtractRenderData(ezMsgExtractRenderData&
     }
 
     EZ_ASSERT_DEBUG(m_DebugLines.GetCount() == uiNumLines, "Implementation error");
-  }  
+  }
 
   ezColor c = ezColorScheme::GetCategoryColor("Construction", ezColorScheme::CategoryColorUsage::ViewportIcon);
   ezDebugRenderer::DrawLines(GetWorld(), m_DebugLines, c, GetOwner()->GetGlobalTransform());

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/VolumeCollection.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/VolumeCollection.cpp
@@ -31,7 +31,7 @@ namespace
   }
 } // namespace
 
-static_assert(sizeof(ezVolumeCollection::Sphere) == 64);
+static_assert(sizeof(ezVolumeCollection::Sphere) == 60);
 static_assert(sizeof(ezVolumeCollection::Box) == 80);
 
 void ezVolumeCollection::Shape::SetGlobalToLocalTransform(const ezSimdMat4f& t)
@@ -58,6 +58,13 @@ ezSimdMat4f ezVolumeCollection::Shape::GetGlobalToLocalTransform() const
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVolumeCollection, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
+ezVolumeCollection::ezVolumeCollection()
+  : m_Allocator("VolumeCollection", ezFoundation::GetAlignedAllocator())
+{
+}
+
+ezVolumeCollection::~ezVolumeCollection() = default;
+
 float ezVolumeCollection::EvaluateAtGlobalPosition(const ezSimdVec4f& vPosition, float fInitialValue, ezProcVolumeImageMode::Enum imgMode, const ezColor& refColor) const
 {
   float fValue = fInitialValue;
@@ -72,20 +79,23 @@ float ezVolumeCollection::EvaluateAtGlobalPosition(const ezSimdVec4f& vPosition,
       if (distSquared <= 1.0f)
       {
         const float fNewValue = ApplyValue(sphere.m_BlendMode, fValue, sphere.m_fValue);
-        const float fAlpha = ezMath::Saturate(ezMath::Sqrt(distSquared) * sphere.m_fFadeOutScale + sphere.m_fFadeOutBias);
+        const float fAlpha = ezMath::Saturate(ezMath::Sqrt(distSquared) * sphere.m_fFadeOut - sphere.m_fFadeOut);
         fValue = ezMath::Lerp(fValue, fNewValue, fAlpha);
       }
     }
     else if (pShape->m_Type == ShapeType::Box)
     {
       auto& box = *static_cast<const Box*>(pShape);
-      const ezSimdVec4f absLocalPos = box.GetGlobalToLocalTransform().TransformPosition(vPosition).Abs();
+      const ezSimdVec4f localPos = box.GetGlobalToLocalTransform().TransformPosition(vPosition);
+      const ezSimdVec4f absLocalPos = localPos.Abs();
       if ((absLocalPos <= ezSimdVec4f(1.0f)).AllSet<3>())
       {
-        const float fNewValue = ApplyValue(box.m_BlendMode, fValue, box.m_fValue);
-        ezSimdVec4f vAlpha = absLocalPos.CompMul(ezSimdConversion::ToVec3(box.m_vFadeOutScale)) + ezSimdConversion::ToVec3(box.m_vFadeOutBias);
+        const ezSimdVec4f fadeOut = ezSimdVec4f::Select(localPos > ezSimdVec4f::MakeZero(), ezSimdConversion::ToVec3(box.m_vPositiveFadeOut), ezSimdConversion::ToVec3(box.m_vNegativeFadeOut));
+        ezSimdVec4f vAlpha = absLocalPos.CompMul(fadeOut) - fadeOut;
         vAlpha = vAlpha.CompMin(ezSimdVec4f(1.0f)).CompMax(ezSimdVec4f::MakeZero());
         const float fAlpha = vAlpha.x() * vAlpha.y() * vAlpha.z();
+
+        const float fNewValue = ApplyValue(box.m_BlendMode, fValue, box.m_fValue);
         fValue = ezMath::Lerp(fValue, fNewValue, fAlpha);
       }
     }
@@ -128,10 +138,12 @@ float ezVolumeCollection::EvaluateAtGlobalPosition(const ezSimdVec4f& vPosition,
 
         if (imgMode != ezProcVolumeImageMode::ReferenceColor || col.IsEqualRGBA(refColor, 0.1f))
         {
-          const float fNewValue = ApplyValue(image.m_BlendMode, fValue, fValueToUse);
-          ezSimdVec4f vAlpha = absLocalPos.CompMul(ezSimdConversion::ToVec3(image.m_vFadeOutScale)) + ezSimdConversion::ToVec3(image.m_vFadeOutBias);
+          const ezSimdVec4f fadeOut = ezSimdVec4f::Select(localPos > ezSimdVec4f::MakeZero(), ezSimdConversion::ToVec3(image.m_vPositiveFadeOut), ezSimdConversion::ToVec3(image.m_vNegativeFadeOut));
+          ezSimdVec4f vAlpha = absLocalPos.CompMul(fadeOut) - fadeOut;
           vAlpha = vAlpha.CompMin(ezSimdVec4f(1.0f)).CompMax(ezSimdVec4f::MakeZero());
           const float fAlpha = vAlpha.x() * vAlpha.y() * vAlpha.z();
+
+          const float fNewValue = ApplyValue(image.m_BlendMode, fValue, image.m_fValue);
           fValue = ezMath::Lerp(fValue, fNewValue, fAlpha);
         }
       }
@@ -152,84 +164,36 @@ void ezVolumeCollection::ExtractVolumesInBox(const ezWorld& world, const ezBound
   queryParams.m_uiCategoryBitmask = spatialCategory.GetBitmask();
   queryParams.m_pIncludeTags = &includeTags;
 
-  world.GetSpatialSystem()->FindObjectsInBox(box, queryParams, [&](ezGameObject* pObject)
+  world.GetSpatialSystem()->FindObjectsInBox(box, queryParams,
+    [&](ezGameObject* pObject)
     {
-    if (pComponentBaseType != nullptr)
-    {
-      ezHybridArray<const ezComponent*, 8> components;
-      pObject->TryGetComponentsOfBaseType(pComponentBaseType, components);
-
-      for (auto pComponent : components)
+      if (pComponentBaseType != nullptr)
       {
-        pComponent->SendMessage(msg);
+        ezHybridArray<const ezComponent*, 8> components;
+        pObject->TryGetComponentsOfBaseType(pComponentBaseType, components);
+
+        for (auto pComponent : components)
+        {
+          pComponent->SendMessage(msg);
+        }
       }
-    }
-    else
-    {
-      pObject->SendMessage(msg);
-    }
+      else
+      {
+        pObject->SendMessage(msg);
+      }
 
-    return ezVisitorExecution::Continue; });
+      return ezVisitorExecution::Continue;
+    });
 
-  out_collection.m_Spheres.Sort();
-  out_collection.m_Boxes.Sort();
-  out_collection.m_Images.Sort();
-
-  const ezUInt32 uiNumSpheres = out_collection.m_Spheres.GetCount();
-  const ezUInt32 uiNumBoxes = out_collection.m_Boxes.GetCount();
-  const ezUInt32 uiNumImages = out_collection.m_Images.GetCount();
-
-  out_collection.m_SortedShapes.Reserve(uiNumSpheres + uiNumBoxes + uiNumImages);
-
-  ezUInt32 uiCurrentSphere = 0;
-  ezUInt32 uiCurrentBox = 0;
-  ezUInt32 uiCurrentImage = 0;
-
-  while (uiCurrentSphere < uiNumSpheres || uiCurrentBox < uiNumBoxes || uiCurrentImage < uiNumImages)
+  struct Sorter
   {
-    Sphere* pSphere = uiCurrentSphere < uiNumSpheres ? &out_collection.m_Spheres[uiCurrentSphere] : nullptr;
-    Box* pBox = uiCurrentBox < uiNumBoxes ? &out_collection.m_Boxes[uiCurrentBox] : nullptr;
-    Image* pImage = uiCurrentImage < uiNumImages ? &out_collection.m_Images[uiCurrentImage] : nullptr;
-
-    Shape* pSmallestShape = nullptr;
-    ezUInt32 uiSmallestKey = 0xFFFFFFFF;
-
-    if (pSphere && pSphere->m_uiSortingKey < uiSmallestKey)
+    bool Less(const Shape* lhs, const Shape* rhs) const
     {
-      pSmallestShape = pSphere;
-      uiSmallestKey = pSmallestShape->m_uiSortingKey;
+      return *lhs < *rhs;
     }
+  };
 
-    if (pBox && pBox->m_uiSortingKey < uiSmallestKey)
-    {
-      pSmallestShape = pBox;
-      uiSmallestKey = pSmallestShape->m_uiSortingKey;
-    }
-
-    if (pImage && pImage->m_uiSortingKey < uiSmallestKey)
-    {
-      pSmallestShape = pImage;
-      uiSmallestKey = pSmallestShape->m_uiSortingKey;
-    }
-
-    EZ_IGNORE_UNUSED(uiSmallestKey);
-    EZ_ASSERT_DEBUG(pSmallestShape != nullptr, "Error sorting proc-gen volumes.");
-
-    out_collection.m_SortedShapes.PushBack(pSmallestShape);
-
-    if (pSmallestShape == pSphere)
-    {
-      ++uiCurrentSphere;
-    }
-    else if (pSmallestShape == pBox)
-    {
-      ++uiCurrentBox;
-    }
-    else if (pSmallestShape == pImage)
-    {
-      ++uiCurrentImage;
-    }
-  }
+  out_collection.m_SortedShapes.Sort(Sorter());
 }
 
 void ezVolumeCollection::AddSphere(const ezSimdTransform& transform, float fRadius, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, float fFalloff)
@@ -237,55 +201,53 @@ void ezVolumeCollection::AddSphere(const ezSimdTransform& transform, float fRadi
   ezSimdTransform scaledTransform = transform;
   scaledTransform.m_Scale *= fRadius;
 
-  auto& sphere = m_Spheres.ExpandAndGetRef();
-  sphere.SetGlobalToLocalTransform(scaledTransform.GetAsMat4().GetInverse());
-  sphere.m_Type = ShapeType::Sphere;
-  sphere.m_BlendMode = blendMode;
-  sphere.m_fValue = fValue;
-  sphere.m_uiSortingKey = ezVolumeSampler::ComputeSortingKey(fSortOrder, scaledTransform.GetMaxScale());
-  sphere.m_fFadeOutScale = -1.0f / ezMath::Max(fFalloff, 0.0001f);
-  sphere.m_fFadeOutBias = -sphere.m_fFadeOutScale;
+  Sphere* pSphere = EZ_NEW(&m_Allocator, Sphere);
+  pSphere->SetGlobalToLocalTransform(scaledTransform.GetAsMat4().GetInverse());
+  pSphere->m_Type = ShapeType::Sphere;
+  pSphere->m_BlendMode = blendMode;
+  pSphere->m_fValue = fValue;
+  pSphere->m_uiSortingKey = ezVolumeSampler::ComputeSortingKey(fSortOrder, scaledTransform.GetMaxScale());
+  pSphere->m_fFadeOut = -1.0f / ezMath::Max(fFalloff, 0.0001f);
+
+  m_SortedShapes.PushBack(pSphere);
 }
 
-void ezVolumeCollection::AddBox(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder,
-  float fValue, const ezVec3& vFalloff)
+void ezVolumeCollection::AddBox(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, const ezVec3& vPositiveFalloff, const ezVec3& vNegativeFalloff, const ezImageDataResourceHandle& hImage)
 {
+  const bool bHasImage = hImage.IsValid();
+
   ezSimdTransform scaledTransform = transform;
   scaledTransform.m_Scale = scaledTransform.m_Scale.CompMul(ezSimdConversion::ToVec3(vExtents)) * 0.5f;
 
-  auto& box = m_Boxes.ExpandAndGetRef();
-  box.SetGlobalToLocalTransform(scaledTransform.GetAsMat4().GetInverse());
-  box.m_Type = ShapeType::Box;
-  box.m_BlendMode = blendMode;
-  box.m_fValue = fValue;
-  box.m_uiSortingKey = ezVolumeSampler::ComputeSortingKey(fSortOrder, scaledTransform.GetMaxScale());
-  box.m_vFadeOutScale = ezVec3(-1.0f).CompDiv(vFalloff.CompMax(ezVec3(0.0001f)));
-  box.m_vFadeOutBias = -box.m_vFadeOutScale;
-}
-
-void ezVolumeCollection::AddImage(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, const ezVec3& vFadeOutStart, const ezImageDataResourceHandle& hImage)
-{
-  ezSimdTransform scaledTransform = transform;
-  scaledTransform.m_Scale = scaledTransform.m_Scale.CompMul(ezSimdConversion::ToVec3(vExtents)) * 0.5f;
-
-  auto& shape = m_Images.ExpandAndGetRef();
-  shape.SetGlobalToLocalTransform(scaledTransform.GetAsMat4().GetInverse());
-  shape.m_Type = ShapeType::Image;
-  shape.m_BlendMode = blendMode;
-  shape.m_fValue = fValue;
-  shape.m_uiSortingKey = ezVolumeSampler::ComputeSortingKey(fSortOrder, scaledTransform.GetMaxScale());
-  shape.m_vFadeOutScale = ezVec3(-1.0f).CompDiv((ezVec3(1.0f) - vFadeOutStart).CompMax(ezVec3(0.0001f)));
-  shape.m_vFadeOutBias = -shape.m_vFadeOutScale;
-
-  shape.m_Image = hImage;
-
-  if (shape.m_Image.IsValid())
+  Box* pBox = nullptr;
+  if (bHasImage)
   {
-    ezResourceLock<ezImageDataResource> pImage(shape.m_Image, ezResourceAcquireMode::BlockTillLoaded);
-    shape.m_pPixelData = pImage->GetDescriptor().m_Image.GetPixelPointer<ezColor>();
-    shape.m_uiImageWidth = pImage->GetDescriptor().m_Image.GetWidth();
-    shape.m_uiImageHeight = pImage->GetDescriptor().m_Image.GetHeight();
+    Image* pImage = EZ_NEW(&m_Allocator, Image);
+    pImage->m_Type = ShapeType::Image;
+    pImage->m_hImage = hImage;
+
+    ezResourceLock<ezImageDataResource> pImageData(hImage, ezResourceAcquireMode::BlockTillLoaded);
+    auto& image = pImageData->GetDescriptor().m_Image;
+    pImage->m_pPixelData = image.GetPixelPointer<ezColor>();
+    pImage->m_uiImageWidth = image.GetWidth();
+    pImage->m_uiImageHeight = image.GetHeight();
+
+    pBox = pImage;
   }
+  else
+  {
+    pBox = EZ_NEW(&m_Allocator, Box);
+    pBox->m_Type = ShapeType::Box;
+  }
+
+  pBox->SetGlobalToLocalTransform(scaledTransform.GetAsMat4().GetInverse());
+  pBox->m_BlendMode = blendMode;
+  pBox->m_fValue = fValue;
+  pBox->m_uiSortingKey = ezVolumeSampler::ComputeSortingKey(fSortOrder, scaledTransform.GetMaxScale());
+  pBox->m_vPositiveFadeOut = ezVec3(-1.0f).CompDiv(vPositiveFalloff.CompMax(ezVec3(0.0001f)));
+  pBox->m_vNegativeFadeOut = ezVec3(-1.0f).CompDiv(vNegativeFalloff.CompMax(ezVec3(0.0001f)));
+
+  m_SortedShapes.PushBack(pBox);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/VolumeCollection.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/VolumeCollection.cpp
@@ -148,6 +148,30 @@ float ezVolumeCollection::EvaluateAtGlobalPosition(const ezSimdVec4f& vPosition,
         }
       }
     }
+    else if (pShape->m_Type == ShapeType::Spline)
+    {
+      auto& spline = *static_cast<const Spline*>(pShape);
+      const ezSimdVec4f localPos = spline.GetGlobalToLocalTransform().TransformPosition(vPosition);
+      const ezSimdBBox localBox = ezSimdConversion::ToBBox(spline.m_BoundingBox);
+      if (!localBox.Contains(localPos))
+        continue;
+
+      float fT = 0.0f;
+      float fDistanceSquared = 0.0f;
+      const ezSimdVec4f pointOnSpline = spline.m_Spline.FindClosestPoint(localPos, fT, fDistanceSquared, spline.m_fMaxError);
+      const ezSimdMat4f t = spline.m_Spline.EvaluateTransform(fT).GetAsMat4().GetInverse();
+      const float fNormalizedDistance = float(t.TransformPosition(localPos).GetLength<3>()) * spline.m_fInvRadius;
+      if (fNormalizedDistance <= 1.0f)
+      {
+        const float fNewValue = ApplyValue(spline.m_BlendMode, fValue, spline.m_fValue);
+        const float fAlpha = ezMath::Saturate(fNormalizedDistance * spline.m_fFadeOut - spline.m_fFadeOut);
+        fValue = ezMath::Lerp(fValue, fNewValue, fAlpha);
+      }
+    }
+    else
+    {
+      EZ_ASSERT_NOT_IMPLEMENTED;
+    }
   }
 
   return fValue;
@@ -248,6 +272,30 @@ void ezVolumeCollection::AddBox(const ezSimdTransform& transform, const ezVec3& 
   pBox->m_vNegativeFadeOut = ezVec3(-1.0f).CompDiv(vNegativeFalloff.CompMax(ezVec3(0.0001f)));
 
   m_SortedShapes.PushBack(pBox);
+}
+
+void ezVolumeCollection::AddSpline(const ezSimdTransform& transform, const ezSpline& spline, float fRadius, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, float fFalloff)
+{
+  Spline* pSpline = EZ_NEW(&m_Allocator, Spline);
+  pSpline->SetGlobalToLocalTransform(transform.GetAsMat4().GetInverse());
+  pSpline->m_Type = ShapeType::Spline;
+  pSpline->m_BlendMode = blendMode;
+  pSpline->m_fValue = fValue;
+  pSpline->m_uiSortingKey = ezVolumeSampler::ComputeSortingKey(fSortOrder, transform.GetMaxScale());
+
+  ezSimdBBoxSphere bounds;
+  spline.CalculateBounds(bounds).IgnoreResult();
+  ezSimdBBox box = bounds.GetBox();
+  box.m_Min -= ezSimdVec4f(fRadius);
+  box.m_Max += ezSimdVec4f(fRadius);
+
+  pSpline->m_Spline = spline;
+  pSpline->m_BoundingBox = ezSimdConversion::ToBBox(box);
+  pSpline->m_fInvRadius = 1.0f / ezMath::Max(fRadius, 0.0001f);
+  pSpline->m_fFadeOut = -1.0f / ezMath::Max(fFalloff, 0.0001f);
+  pSpline->m_fMaxError = ezMath::Max(fRadius / 5.0f, 0.1f);
+
+  m_SortedShapes.PushBack(pSpline);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcPlacementComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcPlacementComponent.h
@@ -41,6 +41,7 @@ private:
 
   void RemoveTilesForComponent(ezProcPlacementComponent* pComponent, bool* out_bAnyObjectsRemoved = nullptr);
   void OnResourceEvent(const ezResourceEvent& resourceEvent);
+  void OnAreaInvalidated(const ezProcGenInternal::InvalidatedArea& area);
 
   void AddVisibleComponent(const ezComponentHandle& hComponent, const ezVec3& cameraPosition, const ezVec3& cameraDirection) const;
   void ClearVisibleComponents();

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeComponent.h
@@ -47,6 +47,7 @@ protected:
   void InvalidateArea(const ezBoundingBox& area);
 
   static AreaInvalidatedEvent s_AreaInvalidatedEvent;
+  static ezSpatialData::Category s_SpatialCategory;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeComponent.h
@@ -93,8 +93,10 @@ public:
   const ezVec3& GetExtents() const { return m_vExtents; }
   void SetExtents(const ezVec3& vExtents);
 
-  const ezVec3& GetFalloff() const { return m_vFalloff; }
-  void SetFalloff(const ezVec3& vFalloff);
+  const ezVec3& GetPositiveFalloff() const { return m_vPositiveFalloff; }
+  void SetPositiveFalloff(const ezVec3& vFalloff);
+  const ezVec3& GetNegativeFalloff() const { return m_vNegativeFalloff; }
+  void SetNegativeFalloff(const ezVec3& vFalloff);
 
   virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
   virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
@@ -104,7 +106,8 @@ public:
 
 protected:
   ezVec3 m_vExtents = ezVec3(10.0f);
-  ezVec3 m_vFalloff = ezVec3(0.5f);
+  ezVec3 m_vPositiveFalloff = ezVec3(0.5f);
+  ezVec3 m_vNegativeFalloff = ezVec3(0.5f);
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeSplineComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeSplineComponent.h
@@ -25,10 +25,10 @@ public:
   virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
   virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
 
-  void OnMsgSplineChanged(ezMsgSplineChanged& msg);
+  void OnMsgSplineChanged(ezMsgSplineChanged& ref_msg);
   void OnMsgUpdateLocalBounds(ezMsgUpdateLocalBounds& ref_msg) const;
   void OnMsgExtractVolumes(ezMsgExtractVolumes& ref_msg) const;
-  void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
+  void OnMsgExtractRenderData(ezMsgExtractRenderData& ref_msg) const;
 
 protected:
   float m_fRadius = 5.0f;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeSplineComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeSplineComponent.h
@@ -3,6 +3,8 @@
 #include <ProcGenPlugin/Components/ProcVolumeComponent.h>
 
 struct ezMsgSplineChanged;
+struct ezMsgExtractRenderData;
+struct ezDebugRendererLine;
 
 using ezProcVolumeSplineComponentManager = ezComponentManager<class ezProcVolumeSplineComponent, ezBlockStorageType::Compact>;
 

--- a/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeSplineComponent.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/ProcVolumeSplineComponent.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <ProcGenPlugin/Components/ProcVolumeComponent.h>
+
+struct ezMsgSplineChanged;
+
+using ezProcVolumeSplineComponentManager = ezComponentManager<class ezProcVolumeSplineComponent, ezBlockStorageType::Compact>;
+
+class EZ_PROCGENPLUGIN_DLL ezProcVolumeSplineComponent : public ezProcVolumeComponent
+{
+  EZ_DECLARE_COMPONENT_TYPE(ezProcVolumeSplineComponent, ezProcVolumeComponent, ezProcVolumeSplineComponentManager);
+
+public:
+  ezProcVolumeSplineComponent();
+  ~ezProcVolumeSplineComponent();
+
+  float GetRadius() const { return m_fRadius; }
+  void SetRadius(float fRadius);
+
+  float GetFalloff() const { return m_fFalloff; }
+  void SetFalloff(float fFalloff);
+
+  virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
+  virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+  void OnMsgSplineChanged(ezMsgSplineChanged& msg);
+  void OnMsgUpdateLocalBounds(ezMsgUpdateLocalBounds& ref_msg) const;
+  void OnMsgExtractVolumes(ezMsgExtractVolumes& ref_msg) const;
+  void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
+
+protected:
+  float m_fRadius = 5.0f;
+  float m_fFalloff = 0.5f;
+
+  ezUInt32 m_uiLastChangeCounter = 0;
+
+  mutable ezDynamicArray<ezDebugRendererLine> m_DebugLines;
+};

--- a/Code/EnginePlugins/ProcGenPlugin/Components/VolumeCollection.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/VolumeCollection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Graphics/Spline.h>
 #include <Core/World/World.h>
 #include <Foundation/Math/Float16.h>
 #include <Foundation/Types/TagSet.h>
@@ -24,6 +25,7 @@ public:
       Sphere,
       Box,
       Image,
+      Spline,
 
       Default = Sphere
     };
@@ -68,15 +70,26 @@ public:
     ezUInt32 m_uiImageHeight = 0;
   };
 
+  struct Spline : public Shape
+  {
+    ezSpline m_Spline;
+    ezBoundingBox m_BoundingBox;
+    float m_fInvRadius;
+    float m_fFadeOut;
+    float m_fMaxError;
+  };
+
   bool IsEmpty() { return m_SortedShapes.IsEmpty(); }
 
   float EvaluateAtGlobalPosition(const ezSimdVec4f& vPosition, float fInitialValue, ezProcVolumeImageMode::Enum imgMode, const ezColor& refColor) const;
 
   static void ExtractVolumesInBox(const ezWorld& world, const ezBoundingBox& box, ezSpatialData::Category spatialCategory, const ezTagSet& includeTags, ezVolumeCollection& out_collection, const ezRTTI* pComponentBaseType = nullptr);
 
-  void AddSphere(const ezSimdTransform& transform, float fRadius, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, float fFadeOutStart);
+  void AddSphere(const ezSimdTransform& transform, float fRadius, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, float fFalloff);
 
   void AddBox(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, const ezVec3& vPositiveFalloff, const ezVec3& vNegativeFalloff, const ezImageDataResourceHandle& hImage = {});
+
+  void AddSpline(const ezSimdTransform& transform, const ezSpline& spline, float fRadius, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, float fFalloff);
 
 private:
   ezLinearAllocator<ezAllocatorTrackingMode::Basics> m_Allocator;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/VolumeCollection.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/VolumeCollection.h
@@ -12,6 +12,9 @@ class EZ_PROCGENPLUGIN_DLL ezVolumeCollection : public ezReflectedClass
   EZ_ADD_DYNAMIC_REFLECTION(ezVolumeCollection, ezReflectedClass);
 
 public:
+  ezVolumeCollection();
+  ~ezVolumeCollection();
+
   struct ShapeType
   {
     using StorageType = ezUInt8;
@@ -44,25 +47,28 @@ public:
 
   struct Sphere : public Shape
   {
-    float m_fFadeOutScale;
-    float m_fFadeOutBias;
+    EZ_DECLARE_POD_TYPE();
+
+    float m_fFadeOut;
   };
 
   struct Box : public Shape
   {
-    ezVec3 m_vFadeOutScale;
-    ezVec3 m_vFadeOutBias;
+    EZ_DECLARE_POD_TYPE();
+
+    ezVec3 m_vPositiveFadeOut;
+    ezVec3 m_vNegativeFadeOut;
   };
 
   struct Image : public Box
   {
-    ezImageDataResourceHandle m_Image;
+    ezImageDataResourceHandle m_hImage;
     const ezColor* m_pPixelData = nullptr;
     ezUInt32 m_uiImageWidth = 0;
     ezUInt32 m_uiImageHeight = 0;
   };
 
-  bool IsEmpty() { return m_Spheres.IsEmpty() && m_Boxes.IsEmpty(); }
+  bool IsEmpty() { return m_SortedShapes.IsEmpty(); }
 
   float EvaluateAtGlobalPosition(const ezSimdVec4f& vPosition, float fInitialValue, ezProcVolumeImageMode::Enum imgMode, const ezColor& refColor) const;
 
@@ -70,14 +76,10 @@ public:
 
   void AddSphere(const ezSimdTransform& transform, float fRadius, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, float fFadeOutStart);
 
-  void AddBox(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, const ezVec3& vFadeOutStart);
-
-  void AddImage(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, const ezVec3& vFadeOutStart, const ezImageDataResourceHandle& hImage);
+  void AddBox(const ezSimdTransform& transform, const ezVec3& vExtents, ezEnum<ezProcGenBlendMode> blendMode, float fSortOrder, float fValue, const ezVec3& vPositiveFalloff, const ezVec3& vNegativeFalloff, const ezImageDataResourceHandle& hImage = {});
 
 private:
-  ezDynamicArray<Sphere, ezAlignedAllocatorWrapper> m_Spheres;
-  ezDynamicArray<Box, ezAlignedAllocatorWrapper> m_Boxes;
-  ezDynamicArray<Image, ezAlignedAllocatorWrapper> m_Images;
+  ezLinearAllocator<ezAllocatorTrackingMode::Basics> m_Allocator;
 
   ezDynamicArray<const Shape*> m_SortedShapes;
 };

--- a/Data/Base/Shaders/Common/Common.h
+++ b/Data/Base/Shaders/Common/Common.h
@@ -81,11 +81,16 @@ float3 CubeMapDirection(float3 inDirection)
   return float3(inDirection.x, inDirection.z, -inDirection.y);
 }
 
-float3 DecodeNormalTexture(float4 normalTex)
+float3 DecodeNormalTexture(float2 normalTex)
 {
   float2 xy = normalTex.xy * 2.0f - 1.0f;
   float z = sqrt(max(1.0f - dot(xy, xy), 0.0));
   return float3(xy, z);
+}
+
+float3 DecodeNormalTexture(float4 normalTex)
+{
+  return DecodeNormalTexture(normalTex.xy);
 }
 
 float InterleavedGradientNoise(float2 screenSpacePosition)


### PR DESCRIPTION
* Can be used for procedural vertex colors or placement just like the existing box and sphere volumes:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d00f6b28-1ca8-4c31-b4ad-64fdce2c2de0" />

* Procedural box volumes now have separate falloff values for positive and negative sides
* New script function on spline component to get the closest point on spline
* Added an option to retrieve pos, scale, transform etc. in local or global space to all corresponding spline component script functions