### PR TITLE
Fixed #1687: Support different keyboard layouts in editor

### DIFF
--- a/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/CameraMoveContext.cpp
@@ -7,6 +7,7 @@
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <EditorFramework/Preferences/ScenePreferences.h>
 #include <Foundation/Utilities/GraphicsUtils.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
 
 static constexpr float s_fMoveSpeed[25] = {
   0.5f,
@@ -177,26 +178,44 @@ ezEditorInput ezCameraMoveContext::DoKeyReleaseEvent(QKeyEvent* e)
 
   m_bRun = (e->modifiers() & Qt::KeyboardModifier::ShiftModifier) != 0;
 
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_W))
+  {
+    m_bMoveForwards = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_S))
+  {
+    m_bMoveBackwards = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_A))
+  {
+    m_bMoveLeft = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_D))
+  {
+    m_bMoveRight = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_Q))
+  {
+    m_bMoveDown = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_E))
+  {
+    m_bMoveUp = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
   switch (e->key())
   {
-    case Qt::Key_W:
-      m_bMoveForwards = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_S:
-      m_bMoveBackwards = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_A:
-      m_bMoveLeft = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_D:
-      m_bMoveRight = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_Q:
-      m_bMoveDown = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_E:
-      m_bMoveUp = false;
-      return ezEditorInput::WasExclusivelyHandled;
     case Qt::Key_Left:
       m_bMoveLeft = false;
       m_bRotateLeft = false;
@@ -267,26 +286,40 @@ ezEditorInput ezCameraMoveContext::DoKeyPressEvent(QKeyEvent* e)
   if (!m_bRotateCamera)
     return ezEditorInput::MayBeHandledByOthers;
 
-  switch (e->key())
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_W))
   {
-    case Qt::Key_W:
-      m_bMoveForwards = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_S:
-      m_bMoveBackwards = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_A:
-      m_bMoveLeft = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_D:
-      m_bMoveRight = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_Q:
-      m_bMoveDown = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_E:
-      m_bMoveUp = true;
-      return ezEditorInput::WasExclusivelyHandled;
+    m_bMoveForwards = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_S))
+  {
+    m_bMoveBackwards = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_A))
+  {
+    m_bMoveLeft = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_D))
+  {
+    m_bMoveRight = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_Q))
+  {
+    m_bMoveDown = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_E))
+  {
+    m_bMoveUp = true;
+    return ezEditorInput::WasExclusivelyHandled;
   }
 
   return ezEditorInput::MayBeHandledByOthers;

--- a/Code/Editor/EditorFramework/InputContexts/Implementation/OrbitCameraContext.cpp
+++ b/Code/Editor/EditorFramework/InputContexts/Implementation/OrbitCameraContext.cpp
@@ -342,7 +342,7 @@ ezEditorInput ezOrbitCameraContext::DoWheelEvent(QWheelEvent* e)
 
 ezEditorInput ezOrbitCameraContext::DoKeyPressEvent(QKeyEvent* e)
 {
-  if (e->key() == Qt::Key_F)
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_F))
   {
     MoveCameraToDefaultPosition();
     return ezEditorInput::WasExclusivelyHandled;
@@ -353,26 +353,40 @@ ezEditorInput ezOrbitCameraContext::DoKeyPressEvent(QKeyEvent* e)
 
   m_bRun = (e->modifiers() & Qt::KeyboardModifier::ShiftModifier) != 0;
 
-  switch (e->key())
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_W))
   {
-    case Qt::Key_W:
-      m_bMoveForwards = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_S:
-      m_bMoveBackwards = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_A:
-      m_bMoveLeft = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_D:
-      m_bMoveRight = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_Q:
-      m_bMoveDown = true;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_E:
-      m_bMoveUp = true;
-      return ezEditorInput::WasExclusivelyHandled;
+    m_bMoveForwards = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_S))
+  {
+    m_bMoveBackwards = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_A))
+  {
+    m_bMoveLeft = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_D))
+  {
+    m_bMoveRight = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_Q))
+  {
+    m_bMoveDown = true;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_E))
+  {
+    m_bMoveUp = true;
+    return ezEditorInput::WasExclusivelyHandled;
   }
 
   return ezEditorInput::MayBeHandledByOthers;
@@ -388,26 +402,40 @@ ezEditorInput ezOrbitCameraContext::DoKeyReleaseEvent(QKeyEvent* e)
 
   m_bRun = (e->modifiers() & Qt::KeyboardModifier::ShiftModifier) != 0;
 
-  switch (e->key())
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_W))
   {
-    case Qt::Key_W:
-      m_bMoveForwards = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_S:
-      m_bMoveBackwards = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_A:
-      m_bMoveLeft = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_D:
-      m_bMoveRight = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_Q:
-      m_bMoveDown = false;
-      return ezEditorInput::WasExclusivelyHandled;
-    case Qt::Key_E:
-      m_bMoveUp = false;
-      return ezEditorInput::WasExclusivelyHandled;
+    m_bMoveForwards = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_S))
+  {
+    m_bMoveBackwards = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_A))
+  {
+    m_bMoveLeft = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_D))
+  {
+    m_bMoveRight = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_Q))
+  {
+    m_bMoveDown = false;
+    return ezEditorInput::WasExclusivelyHandled;
+  }
+
+  if (ezQtUtils::IsEquivalentQtKey(e, Qt::Key_E))
+  {
+    m_bMoveUp = false;
+    return ezEditorInput::WasExclusivelyHandled;
   }
 
   return ezEditorInput::MayBeHandledByOthers;

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphQt.cpp
@@ -153,7 +153,7 @@ void ezQtProcGenPin::ExtendContextMenu(QMenu& ref_menu)
 
 void ezQtProcGenPin::keyPressEvent(QKeyEvent* pEvent)
 {
-  if (pEvent->key() == Qt::Key_D || pEvent->key() == Qt::Key_F9)
+  if (ezQtUtils::IsEquivalentQtKey(pEvent, Qt::Key_D) || pEvent->key() == Qt::Key_F9)
   {
     SetDebug(!m_bDebug);
   }

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.cpp
@@ -6,6 +6,7 @@
 #include <QKeySequenceEdit>
 #include <QTableWidget>
 #include <QTreeWidget>
+#include <ToolsFoundation/Utilities/SearchPatternFilter.h>
 
 ezQtShortcutEditorDlg::ezQtShortcutEditorDlg(QWidget* pParent)
   : QDialog(pParent)
@@ -203,4 +204,35 @@ void ezQtShortcutEditorDlg::on_ButtonReset_clicked()
   m_ActionDescs[m_iSelectedAction]->UpdateExistingActions();
 
   UpdateTable();
+}
+
+void ezQtShortcutEditorDlg::on_Search_textChanged(const QString& sText)
+{
+  ezSearchPatternFilter filter;
+  filter.SetSearchText(sText.toUtf8().data());
+
+  ezQtScopedUpdatesDisabled ud(Shortcuts);
+
+  for (ezInt32 iTop = 0; iTop < Shortcuts->topLevelItemCount(); ++iTop)
+  {
+    auto pTopItem = Shortcuts->topLevelItem(iTop);
+    bool bAnyCategoryChildVisible = false;
+
+    for (ezInt32 iChild = 0; iChild < pTopItem->childCount(); ++iChild)
+    {
+      auto pChild = pTopItem->child(iChild);
+      const ezString sActionName = pChild->data(0, Qt::DisplayRole).toString().toUtf8().data();
+      const ezString sShortcut = pChild->data(2, Qt::DisplayRole).toString().toUtf8().data();
+
+      const bool bVisible = filter.PassesFilters(sActionName) || filter.PassesFilters(sShortcut);
+      pChild->setHidden(!bVisible);
+
+      if (bVisible)
+      {
+        bAnyCategoryChildVisible = true;
+      }
+    }
+
+    pTopItem->setHidden(!bAnyCategoryChildVisible);
+  }
 }

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.moc.h
@@ -31,6 +31,7 @@ private Q_SLOTS:
   void on_ButtonAssign_clicked();
   void on_ButtonRemove_clicked();
   void on_ButtonReset_clicked();
+  void on_Search_textChanged(const QString& sText);
 
 private:
   ezInt32 m_iSelectedAction;

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.ui
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.ui
@@ -85,7 +85,7 @@
   <customwidget>
    <class>ezQtSearchWidget</class>
    <extends>QWidget</extends>
-   <header location="global">GuiFoundation\Widgets\SearchWidget.moc.h</header>
+   <header location="global">GuiFoundation/Widgets/SearchWidget.moc.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.ui
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/ShortcutEditorDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>582</width>
-    <height>596</height>
+    <width>588</width>
+    <height>612</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,6 +18,9 @@
     <normaloff>:/GuiFoundation/Icons/Shortcuts.svg</normaloff>:/GuiFoundation/Icons/Shortcuts.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="ezQtSearchWidget" name="Search" native="true"/>
+   </item>
    <item>
     <widget class="QTreeWidget" name="Shortcuts">
      <property name="uniformRowHeights">
@@ -78,9 +81,16 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ezQtSearchWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">GuiFoundation\Widgets\SearchWidget.moc.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../QtResources/resources.qrc"/>
  </resources>
  <connections/>
-</ui> 
-
+</ui>

--- a/Code/Tools/Libs/GuiFoundation/GuiFoundationDLL.h
+++ b/Code/Tools/Libs/GuiFoundation/GuiFoundationDLL.h
@@ -22,6 +22,7 @@
 
 class QWidget;
 class QObject;
+class QKeyEvent;
 
 
 Q_DECLARE_METATYPE(ezUuid);
@@ -115,3 +116,15 @@ void operator<<(QDataStream& inout_stream, ezDynamicArray<T>& rhs)
     inout_stream << rhs[i];
   }
 }
+
+namespace ezQtUtils
+{
+  /// Uses keyboard layout independent scan-codes to check whether the key of the QKeyEvent represents the desired key.
+  ///
+  /// Use this when the position of the key on the keyboard is the desired aspect, not the actual character.
+  /// For example for navigation (WSAD) in a viewport.
+  ///
+  /// Assumes the standard US keyboard layout for the reference keys.
+  EZ_GUIFOUNDATION_DLL bool IsEquivalentQtKey(const QKeyEvent* e, Qt::Key reference);
+
+} // namespace ezQtUtils

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -508,9 +508,12 @@ namespace ezQtUtils
         return e->nativeScanCode() == 21;
       case Qt::Key_Z:
         return e->nativeScanCode() == 44;
+
+      default:
+        ezLog::Dev("IsEquivalentQtKey: Undefined scancode mapping for key: {} (pressed: {})", (int)reference, e->nativeScanCode());
+        break;
     }
 
-    ezLog::Dev("IsEquivalentQtKey: Undefined scancode mapping for key: {} (pressed: {})", (int)reference, e->nativeScanCode());
     return e->key() == reference;
   }
 } // namespace ezQtUtils

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -396,7 +396,7 @@ ezResult ezQtUiServices::OpenInRider(const char* szPath)
   QString sToolboxPath = sToolboxKey.replace("\\", "/").replace("\"", "");
   if (sToolboxPath.isEmpty())
   {
-    sToolboxPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).split("Local/",Qt::KeepEmptyParts,Qt::CaseInsensitive).first();
+    sToolboxPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation).split("Local/", Qt::KeepEmptyParts, Qt::CaseInsensitive).first();
     sToolboxPath += "Local/JetBrains/Toolbox/.settings.json";
   }
   else
@@ -449,3 +449,68 @@ ezResult ezQtUiServices::OpenInRider(const char* szPath)
 
   return EZ_SUCCESS;
 }
+
+namespace ezQtUtils
+{
+  bool IsEquivalentQtKey(const QKeyEvent* e, Qt::Key reference)
+  {
+    switch (reference)
+    {
+      case Qt::Key_A:
+        return e->nativeScanCode() == 30;
+      case Qt::Key_B:
+        return e->nativeScanCode() == 48;
+      case Qt::Key_C:
+        return e->nativeScanCode() == 46;
+      case Qt::Key_D:
+        return e->nativeScanCode() == 32;
+      case Qt::Key_E:
+        return e->nativeScanCode() == 18;
+      case Qt::Key_F:
+        return e->nativeScanCode() == 33;
+      case Qt::Key_G:
+        return e->nativeScanCode() == 34;
+      case Qt::Key_H:
+        return e->nativeScanCode() == 35;
+      case Qt::Key_I:
+        return e->nativeScanCode() == 23;
+      case Qt::Key_J:
+        return e->nativeScanCode() == 36;
+      case Qt::Key_K:
+        return e->nativeScanCode() == 37;
+      case Qt::Key_L:
+        return e->nativeScanCode() == 38;
+      case Qt::Key_M:
+        return e->nativeScanCode() == 50;
+      case Qt::Key_N:
+        return e->nativeScanCode() == 49;
+      case Qt::Key_O:
+        return e->nativeScanCode() == 24;
+      case Qt::Key_P:
+        return e->nativeScanCode() == 25;
+      case Qt::Key_Q:
+        return e->nativeScanCode() == 16;
+      case Qt::Key_R:
+        return e->nativeScanCode() == 19;
+      case Qt::Key_S:
+        return e->nativeScanCode() == 31;
+      case Qt::Key_T:
+        return e->nativeScanCode() == 20;
+      case Qt::Key_U:
+        return e->nativeScanCode() == 22;
+      case Qt::Key_V:
+        return e->nativeScanCode() == 47;
+      case Qt::Key_W:
+        return e->nativeScanCode() == 17;
+      case Qt::Key_X:
+        return e->nativeScanCode() == 45;
+      case Qt::Key_Y:
+        return e->nativeScanCode() == 21;
+      case Qt::Key_Z:
+        return e->nativeScanCode() == 44;
+    }
+
+    ezLog::Dev("IsEquivalentQtKey: Undefined scancode mapping for key: {} (pressed: {})", (int)reference, e->nativeScanCode());
+    return e->key() == reference;
+  }
+} // namespace ezQtUtils

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/CurveEditWidget.cpp
@@ -795,17 +795,17 @@ void ezQtCurveEditWidget::keyPressEvent(QKeyEvent* e)
 {
   QWidget::keyPressEvent(e);
 
-  if (e->modifiers() == Qt::ControlModifier && e->key() == Qt::Key_F)
+  if (e->modifiers() == Qt::ControlModifier && ezQtUtils::IsEquivalentQtKey(e, Qt::Key_F))
   {
     e->accept();
     FrameCurve();
   }
-  else if (e->modifiers() == Qt::ShiftModifier && e->key() == Qt::Key_F)
+  else if (e->modifiers() == Qt::ShiftModifier && ezQtUtils::IsEquivalentQtKey(e, Qt::Key_F))
   {
     e->accept();
     FrameSelection();
   }
-  else if (e->modifiers() == Qt::ControlModifier && e->key() == Qt::Key_A)
+  else if (e->modifiers() == Qt::ControlModifier && ezQtUtils::IsEquivalentQtKey(e, Qt::Key_A))
   {
     e->accept();
     SelectAll();

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/EventTrackWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/EventTrackWidget.cpp
@@ -673,7 +673,7 @@ void ezQtEventTrackWidget::keyPressEvent(QKeyEvent* e)
 {
   QWidget::keyPressEvent(e);
 
-  if (e->modifiers() == Qt::ControlModifier && e->key() == Qt::Key_F)
+  if (e->modifiers() == Qt::ControlModifier && ezQtUtils::IsEquivalentQtKey(e, Qt::Key_F))
   {
     FrameCurve();
   }


### PR DESCRIPTION
Actions like moving the camera are supposed to work with keys that are in specific positions on the keyboard. With different keyboard layouts, this didn't work.

This change switches to scancodes for querying these specific keys, so now camera movement should work as desired on all non-US QWERTY keyboard layouts.

Also added a search box to the "Shortcuts" dialog, to make it easier to remap shortcuts.

Unfortunately, while all shortcuts that use a modifier (CTRL, ALT) automatically work with all layouts (although the position of the key may change), single character shortcuts only work on systems that actually have this character.

So the shortcut 'G' that toggles the grid, doesn't work on a Cyrillic keyboard, where the latin 'G' doesn't exist.
A shortcut 'CTRL+G', however, would work, and get activated by the П key, which is in the location of the G.
I am currently not sure whether there is a workaround for this behavior. The only option is for people to remap those problematic shortcuts to their native layout (mapping П to grid toggle does make it work).

<img width="1127" height="557" alt="image" src="https://github.com/user-attachments/assets/1b15094f-f5ba-40e7-a14e-43bda7cee177" />
