### PR TITLE
Simplified gpu resource destruction

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -239,17 +239,8 @@ void ezPickingRenderPass::DestroyTarget()
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
   m_RenderTargetSetup.DestroyAllAttachedViews();
-  if (!m_hPickingIdRT.IsInvalidated())
-  {
-    pDevice->DestroyTexture(m_hPickingIdRT);
-    m_hPickingIdRT.Invalidate();
-  }
-
-  if (!m_hPickingDepthRT.IsInvalidated())
-  {
-    pDevice->DestroyTexture(m_hPickingDepthRT);
-    m_hPickingDepthRT.Invalidate();
-  }
+  pDevice->DestroyTexture(m_hPickingIdRT);
+  pDevice->DestroyTexture(m_hPickingDepthRT);
 }
 
 void ezPickingRenderPass::ReadBackPropertiesSinglePick(ezView* pView)

--- a/Code/Engine/GameEngine/XR/Implementation/DummyXR.cpp
+++ b/Code/Engine/GameEngine/XR/Implementation/DummyXR.cpp
@@ -140,17 +140,9 @@ void ezDummyXR::OnActorDestroyed()
 
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
-  if (!m_hColorRT.IsInvalidated())
-  {
-    pDevice->DestroyTexture(m_hColorRT);
-    m_hColorRT.Invalidate();
-  }
-  if (!m_hDepthRT.IsInvalidated())
-  {
-    pDevice->DestroyTexture(m_hDepthRT);
-    m_hDepthRT.Invalidate();
-  }
-
+  pDevice->DestroyTexture(m_hColorRT);
+  pDevice->DestroyTexture(m_hDepthRT);
+  
   ezRenderWorld::RemoveMainView(m_hView);
   m_hView.Invalidate();
 }

--- a/Code/Engine/GameEngine/XR/Implementation/DummyXR.cpp
+++ b/Code/Engine/GameEngine/XR/Implementation/DummyXR.cpp
@@ -142,7 +142,7 @@ void ezDummyXR::OnActorDestroyed()
 
   pDevice->DestroyTexture(m_hColorRT);
   pDevice->DestroyTexture(m_hDepthRT);
-  
+
   ezRenderWorld::RemoveMainView(m_hView);
   m_hView.Invalidate();
 }

--- a/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
+++ b/Code/Engine/GameEngine/XR/Implementation/XRWindow.cpp
@@ -74,7 +74,6 @@ ezWindowOutputTargetXR::~ezWindowOutputTargetXR()
 {
   // Delete companion resources.
   ezRenderContext::DeleteConstantBufferStorage(m_hCompanionConstantBuffer);
-  m_hCompanionConstantBuffer.Invalidate();
 }
 
 void ezWindowOutputTargetXR::PresentImage(bool bEnableVSync)

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
@@ -404,7 +404,7 @@ void ezBakedProbesComponent::RenderDebugOverlay()
   if (uiTextureWidth != uiWidth || uiTextureHeight != uiHeight)
   {
     pDevice->DestroyTexture(m_hDebugViewTexture);
-    
+
     ezGALTextureCreationDescription desc;
     desc.m_uiWidth = uiWidth;
     desc.m_uiHeight = uiHeight;

--- a/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
+++ b/Code/Engine/RendererCore/BakedProbes/Implementation/BakedProbesComponent.cpp
@@ -403,11 +403,8 @@ void ezBakedProbesComponent::RenderDebugOverlay()
 
   if (uiTextureWidth != uiWidth || uiTextureHeight != uiHeight)
   {
-    if (!m_hDebugViewTexture.IsInvalidated())
-    {
-      pDevice->DestroyTexture(m_hDebugViewTexture);
-    }
-
+    pDevice->DestroyTexture(m_hDebugViewTexture);
+    
     ezGALTextureCreationDescription desc;
     desc.m_uiWidth = uiWidth;
     desc.m_uiHeight = uiHeight;

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
@@ -23,7 +23,7 @@ ezReflectionPool::Data::Data()
 ezReflectionPool::Data::~Data()
 {
   ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hFallbackReflectionSpecularTexture);
-  
+
   ezUInt32 uiWorldReflectionCount = m_WorldReflectionData.GetCount();
   for (ezUInt32 i = 0; i < uiWorldReflectionCount; ++i)
   {

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
@@ -22,12 +22,8 @@ ezReflectionPool::Data::Data()
 
 ezReflectionPool::Data::~Data()
 {
-  if (!m_hFallbackReflectionSpecularTexture.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hFallbackReflectionSpecularTexture);
-    m_hFallbackReflectionSpecularTexture.Invalidate();
-  }
-
+  ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hFallbackReflectionSpecularTexture);
+  
   ezUInt32 uiWorldReflectionCount = m_WorldReflectionData.GetCount();
   for (ezUInt32 i = 0; i < uiWorldReflectionCount; ++i)
   {
@@ -36,11 +32,7 @@ ezReflectionPool::Data::~Data()
   }
   m_WorldReflectionData.Clear();
 
-  if (!m_hSkyIrradianceTexture.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hSkyIrradianceTexture);
-    m_hSkyIrradianceTexture.Invalidate();
-  }
+  ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hSkyIrradianceTexture);
 }
 
 ezReflectionProbeId ezReflectionPool::Data::AddProbe(const ezWorld* pWorld, ProbeData&& probeData)

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
@@ -53,10 +53,7 @@ ezReflectionProbeUpdater::ProbeUpdateInfo::~ProbeUpdateInfo()
 {
   for (ezUInt32 i = 0; i < EZ_ARRAY_SIZE(m_hCubemapProxies); ++i)
   {
-    if (!m_hCubemapProxies[i].IsInvalidated())
-    {
-      ezGALDevice::GetDefaultDevice()->DestroyProxyTexture(m_hCubemapProxies[i]);
-    }
+    ezGALDevice::GetDefaultDevice()->DestroyProxyTexture(m_hCubemapProxies[i]);
   }
 
   if (!m_hCubemap.IsInvalidated())

--- a/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ShadowPool.cpp
@@ -160,11 +160,7 @@ struct ezShadowPool::Data
 
     m_TextureAtlas.Deinitialize();
 
-    if (!m_hShadowDataBuffer.IsInvalidated())
-    {
-      ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hShadowDataBuffer);
-      m_hShadowDataBuffer.Invalidate();
-    }
+    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hShadowDataBuffer);
   }
 
   enum

--- a/Code/Engine/RendererCore/Material/Implementation/MaterialManager.cpp
+++ b/Code/Engine/RendererCore/Material/Implementation/MaterialManager.cpp
@@ -116,7 +116,8 @@ ezGALBindGroupHandle ezMaterialManager::GetMaterialBindGroup(const ezMaterialRes
       EZ_ASSERT_DEBUG(pBindGroup != nullptr, "Bind group should be owned by the material manager but it no longer exists.");
       if (pBindGroup->IsInvalidated())
       {
-        pDevice->DestroyBindGroup(bindGroupCache.m_hGroup);
+        auto hBindGroup = bindGroupCache.m_hGroup;
+        pDevice->DestroyBindGroup(hBindGroup);
         data.m_BindGroups.RemoveAtAndSwap(i);
         break;
       }
@@ -562,8 +563,7 @@ void ezMaterialManager::MaterialShaderConstants::UpdateConstantBuffers()
         break;
       case ezMaterialManager::MaterialStorageMode::SingleStructuredBuffer:
       {
-        if (!m_hStructuredBuffer.IsInvalidated())
-          pDevice->DestroyBuffer(m_hStructuredBuffer);
+        pDevice->DestroyBuffer(m_hStructuredBuffer);
 
         ezGALBufferCreationDescription bufferDesc;
         bufferDesc.m_uiStructSize = m_pLayout->m_uiTotalSize;
@@ -614,13 +614,11 @@ void ezMaterialManager::MaterialShaderConstants::DestroyGpuResources()
 {
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
-  if (!m_hStructuredBuffer.IsInvalidated())
-    pDevice->DestroyBuffer(m_hStructuredBuffer);
+  pDevice->DestroyBuffer(m_hStructuredBuffer);
 
   for (ezGALBufferHandle hBuffer : m_MaterialBuffers)
   {
-    if (!hBuffer.IsInvalidated())
-      pDevice->DestroyBuffer(hBuffer);
+    pDevice->DestroyBuffer(hBuffer);
   }
   m_MaterialBuffers.Clear();
 }

--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshBufferResource.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshBufferResource.cpp
@@ -871,18 +871,10 @@ ezResourceLoadDesc ezMeshBufferResource::UnloadData(Unload WhatToUnload)
 {
   for (auto& hVertexBuffer : m_hVertexBuffers)
   {
-    if (!hVertexBuffer.IsInvalidated())
-    {
-      ezGALDevice::GetDefaultDevice()->DestroyBuffer(hVertexBuffer);
-      hVertexBuffer.Invalidate();
-    }
+    ezGALDevice::GetDefaultDevice()->DestroyBuffer(hVertexBuffer);
   }
 
-  if (!m_hIndexBuffer.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hIndexBuffer);
-    m_hIndexBuffer.Invalidate();
-  }
+  ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hIndexBuffer);
 
   m_uiPrimitiveCount = 0;
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -22,12 +22,8 @@ ezSkinningState::~ezSkinningState()
 
 void ezSkinningState::Clear()
 {
-  if (!m_hGpuBuffer.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hGpuBuffer);
-    m_hGpuBuffer.Invalidate();
-  }
-
+  ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hGpuBuffer);
+  
   m_Transforms.Clear();
 }
 

--- a/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SkinnedMeshComponent.cpp
@@ -23,7 +23,7 @@ ezSkinningState::~ezSkinningState()
 void ezSkinningState::Clear()
 {
   ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hGpuBuffer);
-  
+
   m_Transforms.Clear();
 }
 

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
@@ -345,11 +345,7 @@ void ezAOPass::SetFadeOutEnd(float fEnd)
 
   m_fFadeOutEnd = ezMath::Max(fEnd, m_fFadeOutStart);
 
-  if (!m_hSSAOSamplerState.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSSAOSamplerState);
-    m_hSSAOSamplerState.Invalidate();
-  }
+  ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSSAOSamplerState);
 }
 
 float ezAOPass::GetFadeOutEnd() const

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
@@ -60,7 +60,7 @@ ezAOPass::ezAOPass()
 ezAOPass::~ezAOPass()
 {
   ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSSAOSamplerState);
-  
+
   ezRenderContext::DeleteConstantBufferStorage(m_hDownscaleConstantBuffer);
   ezRenderContext::DeleteConstantBufferStorage(m_hSSAOConstantBuffer);
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/AOPass.cpp
@@ -59,17 +59,10 @@ ezAOPass::ezAOPass()
 
 ezAOPass::~ezAOPass()
 {
-  if (!m_hSSAOSamplerState.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSSAOSamplerState);
-    m_hSSAOSamplerState.Invalidate();
-  }
-
+  ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSSAOSamplerState);
+  
   ezRenderContext::DeleteConstantBufferStorage(m_hDownscaleConstantBuffer);
-  m_hDownscaleConstantBuffer.Invalidate();
-
   ezRenderContext::DeleteConstantBufferStorage(m_hSSAOConstantBuffer);
-  m_hSSAOConstantBuffer.Invalidate();
 }
 
 bool ezAOPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BloomPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BloomPass.cpp
@@ -50,7 +50,6 @@ ezBloomPass::ezBloomPass()
 ezBloomPass::~ezBloomPass()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hConstantBuffer);
-  m_hConstantBuffer.Invalidate();
 }
 
 bool ezBloomPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlurPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/BlurPass.cpp
@@ -45,7 +45,6 @@ ezBlurPass::ezBlurPass()
 ezBlurPass::~ezBlurPass()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hBlurCB);
-  m_hBlurCB.Invalidate();
 }
 
 bool ezBlurPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -87,7 +87,6 @@ ezLSAOPass::~ezLSAOPass()
   DestroyLineSweepData();
 
   ezRenderContext::DeleteConstantBufferStorage(m_hLineSweepCB);
-  m_hLineSweepCB.Invalidate();
 }
 
 bool ezLSAOPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LSAOPass.cpp
@@ -325,13 +325,8 @@ void ezLSAOPass::DestroyLineSweepData()
 {
   ezGALDevice* device = ezGALDevice::GetDefaultDevice();
 
-  if (!m_hLineSweepOutputBuffer.IsInvalidated())
-    device->DestroyBuffer(m_hLineSweepOutputBuffer);
-  m_hLineSweepOutputBuffer.Invalidate();
-
-  if (!m_hLineInfoBuffer.IsInvalidated())
-    device->DestroyBuffer(m_hLineInfoBuffer);
-  m_hLineInfoBuffer.Invalidate();
+  device->DestroyBuffer(m_hLineSweepOutputBuffer);
+  device->DestroyBuffer(m_hLineInfoBuffer);
 }
 
 void ezLSAOPass::SetupLineSweepData(const ezVec3I32& imageResolution)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
@@ -53,7 +53,6 @@ ezReflectionFilterPass::ezReflectionFilterPass()
 ezReflectionFilterPass::~ezReflectionFilterPass()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hIrradianceConstantBuffer);
-  m_hIrradianceConstantBuffer.Invalidate();
 }
 
 bool ezReflectionFilterPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SelectionHighlightPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SelectionHighlightPass.cpp
@@ -47,7 +47,6 @@ ezSelectionHighlightPass::ezSelectionHighlightPass(const char* szName)
 ezSelectionHighlightPass::~ezSelectionHighlightPass()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hConstantBuffer);
-  m_hConstantBuffer.Invalidate();
 }
 
 bool ezSelectionHighlightPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SeparatedBilateralBlur.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/SeparatedBilateralBlur.cpp
@@ -51,7 +51,6 @@ ezSeparatedBilateralBlurPass::ezSeparatedBilateralBlurPass()
 ezSeparatedBilateralBlurPass::~ezSeparatedBilateralBlurPass()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hBilateralBlurCB);
-  m_hBilateralBlurCB.Invalidate();
 }
 
 bool ezSeparatedBilateralBlurPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TonemapPass.cpp
@@ -64,7 +64,6 @@ ezTonemapPass::ezTonemapPass()
 ezTonemapPass::~ezTonemapPass()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hConstantBuffer);
-  m_hConstantBuffer.Invalidate();
 }
 
 bool ezTonemapPass::GetRenderTargetDescriptions(const ezView& view, const ezArrayPtr<ezGALTextureCreationDescription* const> inputs, ezArrayPtr<ezGALTextureCreationDescription> outputs)

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
@@ -23,11 +23,7 @@ ezTransparentForwardRenderPass::ezTransparentForwardRenderPass(const char* szNam
 
 ezTransparentForwardRenderPass::~ezTransparentForwardRenderPass()
 {
-  if (!m_hSceneColorSamplerState.IsInvalidated())
-  {
-    ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSceneColorSamplerState);
-    m_hSceneColorSamplerState.Invalidate();
-  }
+  ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSceneColorSamplerState);
 }
 
 void ezTransparentForwardRenderPass::Execute(const ezRenderViewContext& renderViewContext,

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderPipeline.cpp
@@ -51,12 +51,7 @@ ezRenderPipeline::ezRenderPipeline()
 
 ezRenderPipeline::~ezRenderPipeline()
 {
-  if (!m_hOcclusionDebugViewTexture.IsInvalidated())
-  {
-    ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
-    pDevice->DestroyTexture(m_hOcclusionDebugViewTexture);
-    m_hOcclusionDebugViewTexture.Invalidate();
-  }
+  ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hOcclusionDebugViewTexture);
 
   m_Data[0].Clear();
   m_Data[1].Clear();
@@ -1447,7 +1442,6 @@ void ezRenderPipeline::PreviewOcclusionBuffer(const ezRasterizerView& rasterizer
         pTexture->GetDescription().m_uiHeight != uiImgHeight)
     {
       pDevice->DestroyTexture(m_hOcclusionDebugViewTexture);
-      m_hOcclusionDebugViewTexture.Invalidate();
     }
   }
 

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -149,11 +149,8 @@ ezRenderContext::ezRenderContext(ezGALCommandEncoder* pCommandEncoder)
 ezRenderContext::~ezRenderContext()
 {
   DeleteConstantBufferStorage(m_hGlobalConstantBufferStorage);
-  if (!m_hPushConstantsStorage.IsInvalidated())
-  {
-    DeleteConstantBufferStorage(m_hPushConstantsStorage);
-  }
-
+  DeleteConstantBufferStorage(m_hPushConstantsStorage);
+  
   if (s_pDefaultInstance == this)
     s_pDefaultInstance = nullptr;
 
@@ -689,28 +686,28 @@ ezConstantBufferStorageHandle ezRenderContext::CreateConstantBufferStorage(ezUIn
 }
 
 // static
-void ezRenderContext::DeleteConstantBufferStorage(ezConstantBufferStorageHandle hStorage)
+void ezRenderContext::DeleteConstantBufferStorage(ezConstantBufferStorageHandle& inout_hStorage)
 {
   EZ_LOCK(s_ConstantBufferStorageMutex);
 
   ezConstantBufferStorageBase* pStorage = nullptr;
-  if (!s_ConstantBufferStorageTable.Remove(hStorage.m_InternalId, &pStorage))
+  if (s_ConstantBufferStorageTable.Remove(inout_hStorage.m_InternalId, &pStorage))
   {
-    // already deleted
-    return;
+    pStorage->BeforeBeginFrame();
+    s_DirtyConstantBuffers.Remove(pStorage);
+
+    ezUInt32 uiSizeInBytes = pStorage->m_Data.GetCount();
+
+    auto it = s_FreeConstantBufferStorage.Find(uiSizeInBytes);
+    if (!it.IsValid())
+    {
+      it = s_FreeConstantBufferStorage.Insert(uiSizeInBytes, ezDynamicArray<ezConstantBufferStorageBase*>());
+    }
+
+    it.Value().PushBack(pStorage);
   }
-  pStorage->BeforeBeginFrame();
-  s_DirtyConstantBuffers.Remove(pStorage);
 
-  ezUInt32 uiSizeInBytes = pStorage->m_Data.GetCount();
-
-  auto it = s_FreeConstantBufferStorage.Find(uiSizeInBytes);
-  if (!it.IsValid())
-  {
-    it = s_FreeConstantBufferStorage.Insert(uiSizeInBytes, ezDynamicArray<ezConstantBufferStorageBase*>());
-  }
-
-  it.Value().PushBack(pStorage);
+  inout_hStorage.Invalidate();
 }
 
 // static

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -150,7 +150,7 @@ ezRenderContext::~ezRenderContext()
 {
   DeleteConstantBufferStorage(m_hGlobalConstantBufferStorage);
   DeleteConstantBufferStorage(m_hPushConstantsStorage);
-  
+
   if (s_pDefaultInstance == this)
     s_pDefaultInstance = nullptr;
 

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -232,7 +232,7 @@ public:
   }
 
   static ezConstantBufferStorageHandle CreateConstantBufferStorage(ezUInt32 uiSizeInBytes, ezConstantBufferStorageBase*& out_pStorage);
-  static void DeleteConstantBufferStorage(ezConstantBufferStorageHandle hStorage);
+  static void DeleteConstantBufferStorage(ezConstantBufferStorageHandle& inout_hStorage);
 
   template <typename T>
   EZ_FORCE_INLINE static bool TryGetConstantBufferStorage(ezConstantBufferStorageHandle hStorage, ezConstantBufferStorage<T>*& out_pStorage)

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
@@ -34,30 +34,10 @@ ezResourceLoadDesc ezShaderPermutationResource::UnloadData(Unload WhatToUnload)
 
   auto pDevice = ezGALDevice::GetDefaultDevice();
 
-  if (!m_hShader.IsInvalidated())
-  {
-    pDevice->DestroyShader(m_hShader);
-    m_hShader.Invalidate();
-  }
-
-  if (!m_hBlendState.IsInvalidated())
-  {
-    pDevice->DestroyBlendState(m_hBlendState);
-    m_hBlendState.Invalidate();
-  }
-
-  if (!m_hDepthStencilState.IsInvalidated())
-  {
-    pDevice->DestroyDepthStencilState(m_hDepthStencilState);
-    m_hDepthStencilState.Invalidate();
-  }
-
-  if (!m_hRasterizerState.IsInvalidated())
-  {
-    pDevice->DestroyRasterizerState(m_hRasterizerState);
-    m_hRasterizerState.Invalidate();
-  }
-
+  pDevice->DestroyShader(m_hShader);
+  pDevice->DestroyBlendState(m_hBlendState);
+  pDevice->DestroyDepthStencilState(m_hDepthStencilState);
+  pDevice->DestroyRasterizerState(m_hRasterizerState);
 
   ezResourceLoadDesc res;
   res.m_State = ezResourceState::Unloaded;

--- a/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.cpp
+++ b/Code/Engine/RendererCore/Textures/DynamicTextureAtlas.cpp
@@ -37,11 +37,10 @@ ezResult ezDynamicTextureAtlas::Initialize(const ezGALTextureCreationDescription
 
 void ezDynamicTextureAtlas::Deinitialize()
 {
+  // Check is needed since GetDefaultDevice will assert if there is no more device set.
   if (!m_hTexture.IsInvalidated())
   {
-    ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
-    pDevice->DestroyTexture(m_hTexture);
-    m_hTexture.Invalidate();
+    ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hTexture);
   }
 
   m_uiAlignment = 0;

--- a/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
@@ -39,12 +39,8 @@ ezResourceLoadDesc ezTexture2DResource::UnloadData(Unload WhatToUnload)
     {
       --m_uiLoadedTextures;
 
-      if (!m_hGALTexture[m_uiLoadedTextures].IsInvalidated())
-      {
-        ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
-        m_hGALTexture[m_uiLoadedTextures].Invalidate();
-      }
-
+      ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
+      
       m_uiMemoryGPU[m_uiLoadedTextures] = 0;
 
       if (WhatToUnload == Unload::OneQualityLevel || m_uiLoadedTextures == 0)
@@ -54,11 +50,7 @@ ezResourceLoadDesc ezTexture2DResource::UnloadData(Unload WhatToUnload)
 
   if (WhatToUnload == Unload::AllQualityLevels)
   {
-    if (!m_hSamplerState.IsInvalidated())
-    {
-      ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSamplerState);
-      m_hSamplerState.Invalidate();
-    }
+    ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSamplerState);
   }
 
   ezResourceLoadDesc res;

--- a/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture2DResource.cpp
@@ -40,7 +40,7 @@ ezResourceLoadDesc ezTexture2DResource::UnloadData(Unload WhatToUnload)
       --m_uiLoadedTextures;
 
       ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
-      
+
       m_uiMemoryGPU[m_uiLoadedTextures] = 0;
 
       if (WhatToUnload == Unload::OneQualityLevel || m_uiLoadedTextures == 0)

--- a/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
@@ -40,7 +40,7 @@ ezResourceLoadDesc ezTexture3DResource::UnloadData(Unload WhatToUnload)
       --m_uiLoadedTextures;
 
       ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
-      
+
       m_uiMemoryGPU[m_uiLoadedTextures] = 0;
 
       if (WhatToUnload == Unload::OneQualityLevel || m_uiLoadedTextures == 0)

--- a/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
+++ b/Code/Engine/RendererCore/Textures/Texture3DResource.cpp
@@ -39,12 +39,8 @@ ezResourceLoadDesc ezTexture3DResource::UnloadData(Unload WhatToUnload)
     {
       --m_uiLoadedTextures;
 
-      if (!m_hGALTexture[m_uiLoadedTextures].IsInvalidated())
-      {
-        ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
-        m_hGALTexture[m_uiLoadedTextures].Invalidate();
-      }
-
+      ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
+      
       m_uiMemoryGPU[m_uiLoadedTextures] = 0;
 
       if (WhatToUnload == Unload::OneQualityLevel || m_uiLoadedTextures == 0)
@@ -54,11 +50,7 @@ ezResourceLoadDesc ezTexture3DResource::UnloadData(Unload WhatToUnload)
 
   if (WhatToUnload == Unload::AllQualityLevels)
   {
-    if (!m_hSamplerState.IsInvalidated())
-    {
-      ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSamplerState);
-      m_hSamplerState.Invalidate();
-    }
+    ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSamplerState);
   }
 
   ezResourceLoadDesc res;

--- a/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
+++ b/Code/Engine/RendererCore/Textures/TextureCubeResource.cpp
@@ -33,11 +33,7 @@ ezResourceLoadDesc ezTextureCubeResource::UnloadData(Unload WhatToUnload)
     {
       --m_uiLoadedTextures;
 
-      if (!m_hGALTexture[m_uiLoadedTextures].IsInvalidated())
-      {
-        ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
-        m_hGALTexture[m_uiLoadedTextures].Invalidate();
-      }
+      ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hGALTexture[m_uiLoadedTextures]);
 
       m_uiMemoryGPU[m_uiLoadedTextures] = 0;
 
@@ -48,11 +44,7 @@ ezResourceLoadDesc ezTextureCubeResource::UnloadData(Unload WhatToUnload)
 
   if (WhatToUnload == Unload::AllQualityLevels)
   {
-    if (!m_hSamplerState.IsInvalidated())
-    {
-      ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSamplerState);
-      m_hSamplerState.Invalidate();
-    }
+    ezGALDevice::GetDefaultDevice()->DestroySamplerState(m_hSamplerState);
   }
 
   ezResourceLoadDesc res;

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -39,7 +39,7 @@ struct ezGALPushConstant
 struct ezGALPipelineLayoutCreationDescription : public ezHashableStruct<ezGALPipelineLayoutCreationDescription>
 {
   ezGALBindGroupLayoutHandle m_BindGroups[EZ_GAL_MAX_BIND_GROUPS]; ///< One for each bind group used in the shader. BG_FRAME, BG_RENDER_PASS, BG_MATERIAL, BG_DRAW_CALL.
-  ezGALPushConstant m_PushConstants;                        ///< Only one push constant block is supported right now.
+  ezGALPushConstant m_PushConstants;                               ///< Only one push constant block is supported right now.
 };
 
 /// \brief Defines the complete state of a graphics pipeline, excluding bound resources (e.g. textures, buffers) and dynamic states (e.g. viewport).

--- a/Code/Engine/RendererFoundation/Device/Device.h
+++ b/Code/Engine/RendererFoundation/Device/Device.h
@@ -41,40 +41,40 @@ public:
   // State creation functions
 
   ezGALBlendStateHandle CreateBlendState(const ezGALBlendStateCreationDescription& description);
-  void DestroyBlendState(ezGALBlendStateHandle hBlendState);
+  void DestroyBlendState(ezGALBlendStateHandle& inout_hBlendState);
 
   ezGALDepthStencilStateHandle CreateDepthStencilState(const ezGALDepthStencilStateCreationDescription& description);
-  void DestroyDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState);
+  void DestroyDepthStencilState(ezGALDepthStencilStateHandle& inout_hDepthStencilState);
 
   ezGALRasterizerStateHandle CreateRasterizerState(const ezGALRasterizerStateCreationDescription& description);
-  void DestroyRasterizerState(ezGALRasterizerStateHandle hRasterizerState);
+  void DestroyRasterizerState(ezGALRasterizerStateHandle& inout_hRasterizerState);
 
   ezGALSamplerStateHandle CreateSamplerState(const ezGALSamplerStateCreationDescription& description);
-  void DestroySamplerState(ezGALSamplerStateHandle hSamplerState);
+  void DestroySamplerState(ezGALSamplerStateHandle& inout_hSamplerState);
 
   ezGALBindGroupLayoutHandle CreateBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& description);
-  void DestroyBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout);
+  void DestroyBindGroupLayout(ezGALBindGroupLayoutHandle& inout_hBindGroupLayout);
 
   // Bind group functions
   ezGALBindGroupHandle CreateBindGroup(const ezGALBindGroupCreationDescription& description);
-  void DestroyBindGroup(ezGALBindGroupHandle hBindGroup);
+  void DestroyBindGroup(ezGALBindGroupHandle& inout_hBindGroup);
 
   ezGALPipelineLayoutHandle CreatePipelineLayout(const ezGALPipelineLayoutCreationDescription& description);
-  void DestroyPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout);
+  void DestroyPipelineLayout(ezGALPipelineLayoutHandle& inout_hPipelineLayout);
 
   ezGALGraphicsPipelineHandle CreateGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& description);
-  void DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline);
+  void DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle& inout_hGraphicsPipeline);
 
   ezGALComputePipelineHandle CreateComputePipeline(const ezGALComputePipelineCreationDescription& description);
-  void DestroyComputePipeline(ezGALComputePipelineHandle hComputePipeline);
+  void DestroyComputePipeline(ezGALComputePipelineHandle& inout_hComputePipeline);
 
   // Resource creation functions
 
   ezGALShaderHandle CreateShader(const ezGALShaderCreationDescription& description);
-  void DestroyShader(ezGALShaderHandle hShader);
+  void DestroyShader(ezGALShaderHandle& inout_hShader);
 
   ezGALBufferHandle CreateBuffer(const ezGALBufferCreationDescription& description, ezArrayPtr<const ezUInt8> initialData = ezArrayPtr<const ezUInt8>());
-  void DestroyBuffer(ezGALBufferHandle hBuffer);
+  void DestroyBuffer(ezGALBufferHandle& inout_hBuffer);
 
   ezGALDynamicBufferHandle CreateDynamicBuffer(const ezGALBufferCreationDescription& description, ezStringView sDebugName);
   void DestroyDynamicBuffer(ezGALDynamicBufferHandle& inout_hBuffer);
@@ -86,20 +86,20 @@ public:
   ezGALBufferHandle CreateConstantBuffer(ezUInt32 uiBufferSize);
 
   ezGALTextureHandle CreateTexture(const ezGALTextureCreationDescription& description, ezArrayPtr<ezGALSystemMemoryDescription> initialData = ezArrayPtr<ezGALSystemMemoryDescription>());
-  void DestroyTexture(ezGALTextureHandle hTexture);
+  void DestroyTexture(ezGALTextureHandle& inout_hTexture);
 
   ezGALTextureHandle CreateProxyTexture(ezGALTextureHandle hParentTexture, ezUInt32 uiSlice);
-  void DestroyProxyTexture(ezGALTextureHandle hProxyTexture);
+  void DestroyProxyTexture(ezGALTextureHandle& inout_hProxyTexture);
 
   ezGALTextureHandle CreateSharedTexture(const ezGALTextureCreationDescription& description, ezArrayPtr<ezGALSystemMemoryDescription> initialData = {});
   ezGALTextureHandle OpenSharedTexture(const ezGALTextureCreationDescription& description, ezGALPlatformSharedHandle hSharedHandle);
-  void DestroySharedTexture(ezGALTextureHandle hTexture);
+  void DestroySharedTexture(ezGALTextureHandle& inout_hTexture);
 
   ezGALReadbackBufferHandle CreateReadbackBuffer(const ezGALBufferCreationDescription& description);
-  void DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer);
+  void DestroyReadbackBuffer(ezGALReadbackBufferHandle& inout_hBuffer);
 
   ezGALReadbackTextureHandle CreateReadbackTexture(const ezGALTextureCreationDescription& description);
-  void DestroyReadbackTexture(ezGALReadbackTextureHandle hTexture);
+  void DestroyReadbackTexture(ezGALReadbackTextureHandle& inout_hTexture);
 
   // Resource update functions
 
@@ -113,17 +113,17 @@ public:
   ezGALRenderTargetViewHandle GetDefaultRenderTargetView(ezGALTextureHandle hTexture);
 
   ezGALRenderTargetViewHandle CreateRenderTargetView(const ezGALRenderTargetViewCreationDescription& description);
-  void DestroyRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView);
+  void DestroyRenderTargetView(ezGALRenderTargetViewHandle& inout_hRenderTargetView);
 
   // Other rendering creation functions
 
   using SwapChainFactoryFunction = ezDelegate<ezGALSwapChain*(ezAllocator*)>;
   ezGALSwapChainHandle CreateSwapChain(const SwapChainFactoryFunction& func);
   ezResult UpdateSwapChain(ezGALSwapChainHandle hSwapChain, ezEnum<ezGALPresentMode> newPresentMode);
-  void DestroySwapChain(ezGALSwapChainHandle hSwapChain);
+  void DestroySwapChain(ezGALSwapChainHandle& inout_hSwapChain);
 
   ezGALVertexDeclarationHandle CreateVertexDeclaration(const ezGALVertexDeclarationCreationDescription& description);
-  void DestroyVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration);
+  void DestroyVertexDeclaration(ezGALVertexDeclarationHandle& inout_hVertexDeclaration);
 
   // GPU -> CPU query functions
 
@@ -280,14 +280,14 @@ protected:
   template <typename Handle, typename View, typename ViewTable, typename CacheTable>
   Handle InsertView(ezUInt32 uiHash, View* pView, ViewTable& viewTable, CacheTable& cacheTable);
   template <typename View, typename Handle, typename ViewTable>
-  void DestroyView(Handle hView, ViewTable& table, ezUInt32 galObjectType);
+  void DestroyView(Handle& inout_hView, ViewTable& table, ezUInt32 galObjectType);
 
   template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
   Handle TryGetHashedResource(HashType uiHash, Table& table, CacheTable& cacheTable, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
   template <typename Handle, typename Resource, typename Table, typename CacheTable, typename HashType>
   Handle InsertHashedResource(HashType uiHash, Resource* pResource, Table& table, CacheTable& cacheTable, ezUInt32& ref_uiCounter);
   template <typename Resource, typename Handle, typename Table>
-  void DestroyHashedResource(Handle hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
+  void DestroyHashedResource(Handle& inout_hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter);
 
   ezProxyAllocator m_Allocator;
   ezLocalAllocatorWrapper m_AllocatorWrapper;

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -302,26 +302,23 @@ Handle ezGALDevice::InsertHashedResource(HashType uiHash, Resource* pResource, T
 }
 
 template <typename Resource, typename Handle, typename Table>
-void ezGALDevice::DestroyHashedResource(Handle hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter)
+void ezGALDevice::DestroyHashedResource(Handle& inout_hResource, Table& table, ezUInt32 galObjectType, ezUInt32& ref_uiCounter)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   Resource* pResource = nullptr;
-
-  if (table.TryGetValue(hResource, pResource))
+  if (table.TryGetValue(inout_hResource, pResource))
   {
     pResource->ReleaseRef();
     ref_uiCounter--;
 
     if (pResource->GetRefCount() == 0)
     {
-      AddDeadObject(galObjectType, hResource);
+      AddDeadObject(galObjectType, inout_hResource);
     }
   }
-  else
-  {
-    ezLog::Warning("DestroyHashedResource called on invalid handle (double free?)");
-  }
+
+  inout_hResource.Invalidate();
 }
 
 ezGALBlendStateHandle ezGALDevice::CreateBlendState(const ezGALBlendStateCreationDescription& desc)
@@ -337,9 +334,9 @@ ezGALBlendStateHandle ezGALDevice::CreateBlendState(const ezGALBlendStateCreatio
   return InsertHashedResource<ezGALBlendStateHandle>(uiHash, pBlendState, m_BlendStates, m_BlendStateTable, m_uiBlendStates);
 }
 
-void ezGALDevice::DestroyBlendState(ezGALBlendStateHandle hBlendState)
+void ezGALDevice::DestroyBlendState(ezGALBlendStateHandle& inout_hBlendState)
 {
-  DestroyHashedResource<ezGALBlendState>(hBlendState, m_BlendStates, GALObjectType::BlendState, m_uiBlendStates);
+  DestroyHashedResource<ezGALBlendState>(inout_hBlendState, m_BlendStates, GALObjectType::BlendState, m_uiBlendStates);
 }
 
 ezGALDepthStencilStateHandle ezGALDevice::CreateDepthStencilState(const ezGALDepthStencilStateCreationDescription& desc)
@@ -355,9 +352,9 @@ ezGALDepthStencilStateHandle ezGALDevice::CreateDepthStencilState(const ezGALDep
   return InsertHashedResource<ezGALDepthStencilStateHandle>(uiHash, pDepthStencilState, m_DepthStencilStates, m_DepthStencilStateTable, m_uiDepthStencilStates);
 }
 
-void ezGALDevice::DestroyDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState)
+void ezGALDevice::DestroyDepthStencilState(ezGALDepthStencilStateHandle& inout_hDepthStencilState)
 {
-  DestroyHashedResource<ezGALDepthStencilState>(hDepthStencilState, m_DepthStencilStates, GALObjectType::DepthStencilState, m_uiDepthStencilStates);
+  DestroyHashedResource<ezGALDepthStencilState>(inout_hDepthStencilState, m_DepthStencilStates, GALObjectType::DepthStencilState, m_uiDepthStencilStates);
 }
 
 ezGALRasterizerStateHandle ezGALDevice::CreateRasterizerState(const ezGALRasterizerStateCreationDescription& desc)
@@ -373,9 +370,9 @@ ezGALRasterizerStateHandle ezGALDevice::CreateRasterizerState(const ezGALRasteri
   return InsertHashedResource<ezGALRasterizerStateHandle>(uiHash, pRasterizerState, m_RasterizerStates, m_RasterizerStateTable, m_uiRasterizerStates);
 }
 
-void ezGALDevice::DestroyRasterizerState(ezGALRasterizerStateHandle hRasterizerState)
+void ezGALDevice::DestroyRasterizerState(ezGALRasterizerStateHandle& inout_hRasterizerState)
 {
-  DestroyHashedResource<ezGALRasterizerState>(hRasterizerState, m_RasterizerStates, GALObjectType::RasterizerState, m_uiRasterizerStates);
+  DestroyHashedResource<ezGALRasterizerState>(inout_hRasterizerState, m_RasterizerStates, GALObjectType::RasterizerState, m_uiRasterizerStates);
 }
 
 ezGALSamplerStateHandle ezGALDevice::CreateSamplerState(const ezGALSamplerStateCreationDescription& desc)
@@ -391,9 +388,9 @@ ezGALSamplerStateHandle ezGALDevice::CreateSamplerState(const ezGALSamplerStateC
   return InsertHashedResource<ezGALSamplerStateHandle>(uiHash, pSamplerState, m_SamplerStates, m_SamplerStateTable, m_uiSamplerStates);
 }
 
-void ezGALDevice::DestroySamplerState(ezGALSamplerStateHandle hSamplerState)
+void ezGALDevice::DestroySamplerState(ezGALSamplerStateHandle& inout_hSamplerState)
 {
-  DestroyHashedResource<ezGALSamplerState>(hSamplerState, m_SamplerStates, GALObjectType::SamplerState, m_uiSamplerStates);
+  DestroyHashedResource<ezGALSamplerState>(inout_hSamplerState, m_SamplerStates, GALObjectType::SamplerState, m_uiSamplerStates);
 }
 
 ezGALBindGroupLayoutHandle ezGALDevice::CreateBindGroupLayout(const ezGALBindGroupLayoutCreationDescription& desc)
@@ -409,9 +406,9 @@ ezGALBindGroupLayoutHandle ezGALDevice::CreateBindGroupLayout(const ezGALBindGro
   return InsertHashedResource<ezGALBindGroupLayoutHandle>(uiHash, pBindGroupLayout, m_BindGroupLayouts, m_BindGroupLayoutTable, m_uiBindGroupLayouts);
 }
 
-void ezGALDevice::DestroyBindGroupLayout(ezGALBindGroupLayoutHandle hBindGroupLayout)
+void ezGALDevice::DestroyBindGroupLayout(ezGALBindGroupLayoutHandle& inout_hBindGroupLayout)
 {
-  DestroyHashedResource<ezGALBindGroupLayout>(hBindGroupLayout, m_BindGroupLayouts, GALObjectType::BindGroupLayout, m_uiBindGroupLayouts);
+  DestroyHashedResource<ezGALBindGroupLayout>(inout_hBindGroupLayout, m_BindGroupLayouts, GALObjectType::BindGroupLayout, m_uiBindGroupLayouts);
 }
 
 ezGALBindGroupHandle ezGALDevice::CreateBindGroup(const ezGALBindGroupCreationDescription& desc)
@@ -500,9 +497,9 @@ ezGALBindGroupHandle ezGALDevice::CreateBindGroup(const ezGALBindGroupCreationDe
   return InsertHashedResource<ezGALBindGroupHandle>(uiHash, pBindGroup, m_BindGroups, m_BindGroupTable, m_uiBindGroups);
 }
 
-void ezGALDevice::DestroyBindGroup(ezGALBindGroupHandle hBindGroup)
+void ezGALDevice::DestroyBindGroup(ezGALBindGroupHandle& inout_hBindGroup)
 {
-  DestroyHashedResource<ezGALBindGroup>(hBindGroup, m_BindGroups, GALObjectType::BindGroup, m_uiBindGroups);
+  DestroyHashedResource<ezGALBindGroup>(inout_hBindGroup, m_BindGroups, GALObjectType::BindGroup, m_uiBindGroups);
 }
 
 ezGALPipelineLayoutHandle ezGALDevice::CreatePipelineLayout(const ezGALPipelineLayoutCreationDescription& desc)
@@ -518,9 +515,9 @@ ezGALPipelineLayoutHandle ezGALDevice::CreatePipelineLayout(const ezGALPipelineL
   return InsertHashedResource<ezGALPipelineLayoutHandle>(uiHash, pPipelineLayout, m_PipelineLayouts, m_PipelineLayoutTable, m_uiPipelineLayouts);
 }
 
-void ezGALDevice::DestroyPipelineLayout(ezGALPipelineLayoutHandle hPipelineLayout)
+void ezGALDevice::DestroyPipelineLayout(ezGALPipelineLayoutHandle& inout_hPipelineLayout)
 {
-  DestroyHashedResource<ezGALPipelineLayout>(hPipelineLayout, m_PipelineLayouts, GALObjectType::PipelineLayout, m_uiPipelineLayouts);
+  DestroyHashedResource<ezGALPipelineLayout>(inout_hPipelineLayout, m_PipelineLayouts, GALObjectType::PipelineLayout, m_uiPipelineLayouts);
 }
 
 ezGALGraphicsPipelineHandle ezGALDevice::CreateGraphicsPipeline(const ezGALGraphicsPipelineCreationDescription& desc)
@@ -597,36 +594,36 @@ ezGALGraphicsPipelineHandle ezGALDevice::CreateGraphicsPipeline(const ezGALGraph
   return ezGALGraphicsPipelineHandle();
 }
 
-void ezGALDevice::DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle hGraphicsPipeline)
+void ezGALDevice::DestroyGraphicsPipeline(ezGALGraphicsPipelineHandle& inout_hGraphicsPipeline)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALGraphicsPipeline* pGraphicsPipeline = nullptr;
-
-  if (m_GraphicsPipelines.TryGetValue(hGraphicsPipeline, pGraphicsPipeline))
+  if (m_GraphicsPipelines.TryGetValue(inout_hGraphicsPipeline, pGraphicsPipeline))
   {
     pGraphicsPipeline->ReleaseRef();
     m_uiGraphicsPipelines--;
 
     if (pGraphicsPipeline->GetRefCount() == 0)
     {
-      AddDeadObject(GALObjectType::GraphicsPipeline, hGraphicsPipeline);
+      AddDeadObject(GALObjectType::GraphicsPipeline, inout_hGraphicsPipeline);
       const ezGALGraphicsPipelineCreationDescription& desc = pGraphicsPipeline->GetDescription();
 
-      DestroyShader(desc.m_hShader);
-      DestroyRasterizerState(desc.m_hRasterizerState);
-      DestroyBlendState(desc.m_hBlendState);
-      DestroyDepthStencilState(desc.m_hDepthStencilState);
-      if (!desc.m_hVertexDeclaration.IsInvalidated())
-      {
-        DestroyVertexDeclaration(desc.m_hVertexDeclaration);
-      }
+      auto hShader = desc.m_hShader;
+      auto hRasterizerState = desc.m_hRasterizerState;
+      auto hBlendState = desc.m_hBlendState;
+      auto hDepthStencilState = desc.m_hDepthStencilState;
+      auto hVertexDeclaration = desc.m_hVertexDeclaration;
+
+      DestroyShader(hShader);
+      DestroyRasterizerState(hRasterizerState);
+      DestroyBlendState(hBlendState);
+      DestroyDepthStencilState(hDepthStencilState);
+      DestroyVertexDeclaration(hVertexDeclaration);
     }
   }
-  else
-  {
-    ezLog::Warning("DestroyGraphicsPipeline called on invalid handle (double free?)");
-  }
+
+  inout_hGraphicsPipeline.Invalidate();
 }
 
 
@@ -689,22 +686,23 @@ ezGALComputePipelineHandle ezGALDevice::CreateComputePipeline(const ezGALCompute
   return ezGALComputePipelineHandle();
 }
 
-void ezGALDevice::DestroyComputePipeline(ezGALComputePipelineHandle hComputePipeline)
+void ezGALDevice::DestroyComputePipeline(ezGALComputePipelineHandle& inout_hComputePipeline)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALComputePipeline* pComputePipeline = nullptr;
-
-  if (m_ComputePipelines.TryGetValue(hComputePipeline, pComputePipeline))
+  if (m_ComputePipelines.TryGetValue(inout_hComputePipeline, pComputePipeline))
   {
     pComputePipeline->ReleaseRef();
     m_uiComputePipelines--;
 
     if (pComputePipeline->GetRefCount() == 0)
     {
-      AddDeadObject(GALObjectType::ComputePipeline, hComputePipeline);
+      AddDeadObject(GALObjectType::ComputePipeline, inout_hComputePipeline);
       const ezGALComputePipelineCreationDescription& desc = pComputePipeline->GetDescription();
-      DestroyShader(desc.m_hShader);
+
+      auto hShader = desc.m_hShader;
+      DestroyShader(hShader);
     }
   }
   else
@@ -771,26 +769,23 @@ ezGALShaderHandle ezGALDevice::CreateShader(const ezGALShaderCreationDescription
   return ezGALShaderHandle();
 }
 
-void ezGALDevice::DestroyShader(ezGALShaderHandle hShader)
+void ezGALDevice::DestroyShader(ezGALShaderHandle& inout_hShader)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALShader* pShader = nullptr;
-
-  if (m_Shaders.TryGetValue(hShader, pShader))
+  if (m_Shaders.TryGetValue(inout_hShader, pShader))
   {
     pShader->ReleaseRef();
     m_uiShaders--;
 
     if (pShader->GetRefCount() == 0)
     {
-      AddDeadObject(GALObjectType::Shader, hShader);
+      AddDeadObject(GALObjectType::Shader, inout_hShader);
     }
   }
-  else
-  {
-    ezLog::Warning("DestroyShader called on invalid handle (double free?)");
-  }
+
+  inout_hShader.Invalidate();
 }
 
 
@@ -866,20 +861,17 @@ ezGALBufferHandle ezGALDevice::CreateBuffer(const ezGALBufferCreationDescription
   return hBuffer;
 }
 
-void ezGALDevice::DestroyBuffer(ezGALBufferHandle hBuffer)
+void ezGALDevice::DestroyBuffer(ezGALBufferHandle& inout_hBuffer)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALBuffer* pBuffer = nullptr;
+  if (m_Buffers.TryGetValue(inout_hBuffer, pBuffer))
+  {
+    AddDeadObject(GALObjectType::Buffer, inout_hBuffer);
+  }
 
-  if (m_Buffers.TryGetValue(hBuffer, pBuffer))
-  {
-    AddDeadObject(GALObjectType::Buffer, hBuffer);
-  }
-  else
-  {
-    ezLog::Warning("DestroyBuffer called on invalid handle (double free?)");
-  }
+  inout_hBuffer.Invalidate();
 }
 
 ezGALDynamicBufferHandle ezGALDevice::CreateDynamicBuffer(const ezGALBufferCreationDescription& description, ezStringView sDebugName)
@@ -900,8 +892,9 @@ void ezGALDevice::DestroyDynamicBuffer(ezGALDynamicBufferHandle& inout_hBuffer)
   if (m_DynamicBuffers.TryGetValue(inout_hBuffer, pBuffer))
   {
     AddDeadObject(GALObjectType::DynamicBuffer, inout_hBuffer);
-    inout_hBuffer.Invalidate();
   }
+
+  inout_hBuffer.Invalidate();
 }
 
 // Helper functions for buffers (for common, simple use cases)
@@ -998,19 +991,17 @@ ezGALTextureHandle ezGALDevice::FinalizeTextureInternal(const ezGALTextureCreati
   return ezGALTextureHandle();
 }
 
-void ezGALDevice::DestroyTexture(ezGALTextureHandle hTexture)
+void ezGALDevice::DestroyTexture(ezGALTextureHandle& inout_hTexture)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALTexture* pTexture = nullptr;
-  if (m_Textures.TryGetValue(hTexture, pTexture))
+  if (m_Textures.TryGetValue(inout_hTexture, pTexture))
   {
-    AddDeadObject(GALObjectType::Texture, hTexture);
+    AddDeadObject(GALObjectType::Texture, inout_hTexture);
   }
-  else
-  {
-    ezLog::Warning("DestroyTexture called on invalid handle (double free?)");
-  }
+
+  inout_hTexture.Invalidate();
 }
 
 ezGALTextureHandle ezGALDevice::CreateProxyTexture(ezGALTextureHandle hParentTexture, ezUInt32 uiSlice)
@@ -1051,21 +1042,19 @@ ezGALTextureHandle ezGALDevice::CreateProxyTexture(ezGALTextureHandle hParentTex
   return hProxyTexture;
 }
 
-void ezGALDevice::DestroyProxyTexture(ezGALTextureHandle hProxyTexture)
+void ezGALDevice::DestroyProxyTexture(ezGALTextureHandle& inout_hProxyTexture)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALTexture* pTexture = nullptr;
-  if (m_Textures.TryGetValue(hProxyTexture, pTexture))
+  if (m_Textures.TryGetValue(inout_hProxyTexture, pTexture))
   {
     EZ_ASSERT_DEV(pTexture->GetDescription().m_Type == ezGALTextureType::Texture2DProxy, "Given texture is not a proxy texture");
 
-    AddDeadObject(GALObjectType::Texture, hProxyTexture);
+    AddDeadObject(GALObjectType::Texture, inout_hProxyTexture);
   }
-  else
-  {
-    ezLog::Warning("DestroyProxyTexture called on invalid handle (double free?)");
-  }
+
+  inout_hProxyTexture.Invalidate();
 }
 
 ezGALTextureHandle ezGALDevice::CreateSharedTexture(const ezGALTextureCreationDescription& desc, ezArrayPtr<ezGALSystemMemoryDescription> initialData)
@@ -1131,21 +1120,19 @@ ezGALTextureHandle ezGALDevice::OpenSharedTexture(const ezGALTextureCreationDesc
   return FinalizeTextureInternal(desc, pTexture);
 }
 
-void ezGALDevice::DestroySharedTexture(ezGALTextureHandle hSharedTexture)
+void ezGALDevice::DestroySharedTexture(ezGALTextureHandle& inout_hSharedTexture)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALTexture* pTexture = nullptr;
-  if (m_Textures.TryGetValue(hSharedTexture, pTexture))
+  if (m_Textures.TryGetValue(inout_hSharedTexture, pTexture))
   {
     EZ_ASSERT_DEV(pTexture->GetDescription().m_Type == ezGALTextureType::Texture2DShared, "Given texture is not a shared texture texture");
 
-    AddDeadObject(GALObjectType::Texture, hSharedTexture);
+    AddDeadObject(GALObjectType::Texture, inout_hSharedTexture);
   }
-  else
-  {
-    ezLog::Warning("DestroySharedTexture called on invalid handle (double free?)");
-  }
+
+  inout_hSharedTexture.Invalidate();
 }
 
 ezGALReadbackTextureHandle ezGALDevice::CreateReadbackTexture(const ezGALTextureCreationDescription& description)
@@ -1163,19 +1150,17 @@ ezGALReadbackTextureHandle ezGALDevice::CreateReadbackTexture(const ezGALTexture
   return hTexture;
 }
 
-void ezGALDevice::DestroyReadbackTexture(ezGALReadbackTextureHandle hTexture)
+void ezGALDevice::DestroyReadbackTexture(ezGALReadbackTextureHandle& inout_hTexture)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALReadbackTexture* pTexture = nullptr;
-  if (m_ReadbackTextures.TryGetValue(hTexture, pTexture))
+  if (m_ReadbackTextures.TryGetValue(inout_hTexture, pTexture))
   {
-    AddDeadObject(GALObjectType::ReadbackTexture, hTexture);
+    AddDeadObject(GALObjectType::ReadbackTexture, inout_hTexture);
   }
-  else
-  {
-    ezLog::Warning("DestroyReadbackTexture called on invalid handle (double free?)");
-  }
+
+  inout_hTexture.Invalidate();
 }
 
 ezGALReadbackBufferHandle ezGALDevice::CreateReadbackBuffer(const ezGALBufferCreationDescription& description)
@@ -1187,19 +1172,17 @@ ezGALReadbackBufferHandle ezGALDevice::CreateReadbackBuffer(const ezGALBufferCre
   return hBuffer;
 }
 
-void ezGALDevice::DestroyReadbackBuffer(ezGALReadbackBufferHandle hBuffer)
+void ezGALDevice::DestroyReadbackBuffer(ezGALReadbackBufferHandle& inout_hBuffer)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALReadbackBuffer* pBuffer = nullptr;
-  if (m_ReadbackBuffers.TryGetValue(hBuffer, pBuffer))
+  if (m_ReadbackBuffers.TryGetValue(inout_hBuffer, pBuffer))
   {
-    AddDeadObject(GALObjectType::ReadbackBuffer, hBuffer);
+    AddDeadObject(GALObjectType::ReadbackBuffer, inout_hBuffer);
   }
-  else
-  {
-    ezLog::Warning("DestroyReadbackBuffer called on invalid handle (double free?)");
-  }
+
+  inout_hBuffer.Invalidate();
 }
 
 void ezGALDevice::UpdateBufferForNextFrame(ezGALBufferHandle hBuffer, ezConstByteArrayPtr sourceData, ezUInt32 uiDestOffset /*= 0*/)
@@ -1315,21 +1298,20 @@ Handle ezGALDevice::InsertView(ezUInt32 uiHash, View* pView, ViewTable& viewTabl
 }
 
 template <typename View, typename Handle, typename ViewTable>
-void ezGALDevice::DestroyView(Handle hView, ViewTable& table, ezUInt32 galObjectType)
+void ezGALDevice::DestroyView(Handle& inout_hView, ViewTable& table, ezUInt32 galObjectType)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
+
   View* pView = nullptr;
-  if (table.TryGetValue(hView, pView))
+  if (table.TryGetValue(inout_hView, pView))
   {
     if (pView->ReleaseRef() == 0)
     {
-      AddDeadObject((GALObjectType::Enum)galObjectType, hView);
+      AddDeadObject((GALObjectType::Enum)galObjectType, inout_hView);
     }
   }
-  else
-  {
-    ezLog::Warning("DestroyView called on invalid handle (double free?)");
-  }
+
+  inout_hView.Invalidate();
 }
 
 ezGALRenderTargetViewHandle ezGALDevice::GetDefaultRenderTargetView(ezGALTextureHandle hTexture)
@@ -1381,9 +1363,9 @@ ezGALRenderTargetViewHandle ezGALDevice::CreateRenderTargetView(const ezGALRende
   return InsertView<ezGALRenderTargetViewHandle, ezGALRenderTargetView>(uiHash, pRenderTargetView, m_RenderTargetViews, pTexture->m_RenderTargetViews);
 }
 
-void ezGALDevice::DestroyRenderTargetView(ezGALRenderTargetViewHandle hRenderTargetView)
+void ezGALDevice::DestroyRenderTargetView(ezGALRenderTargetViewHandle& inout_hRenderTargetView)
 {
-  DestroyView<ezGALRenderTargetView>(hRenderTargetView, m_RenderTargetViews, GALObjectType::RenderTargetView);
+  DestroyView<ezGALRenderTargetView>(inout_hRenderTargetView, m_RenderTargetViews, GALObjectType::RenderTargetView);
 }
 
 ezGALSwapChainHandle ezGALDevice::CreateSwapChain(const SwapChainFactoryFunction& func)
@@ -1426,20 +1408,17 @@ ezResult ezGALDevice::UpdateSwapChain(ezGALSwapChainHandle hSwapChain, ezEnum<ez
   }
 }
 
-void ezGALDevice::DestroySwapChain(ezGALSwapChainHandle hSwapChain)
+void ezGALDevice::DestroySwapChain(ezGALSwapChainHandle& inout_hSwapChain)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALSwapChain* pSwapChain = nullptr;
+  if (m_SwapChains.TryGetValue(inout_hSwapChain, pSwapChain))
+  {
+    AddDeadObject(GALObjectType::SwapChain, inout_hSwapChain);
+  }
 
-  if (m_SwapChains.TryGetValue(hSwapChain, pSwapChain))
-  {
-    AddDeadObject(GALObjectType::SwapChain, hSwapChain);
-  }
-  else
-  {
-    ezLog::Warning("DestroySwapChain called on invalid handle (double free?)");
-  }
+  inout_hSwapChain.Invalidate();
 }
 
 ezGALVertexDeclarationHandle ezGALDevice::CreateVertexDeclaration(const ezGALVertexDeclarationCreationDescription& desc)
@@ -1499,26 +1478,23 @@ ezGALVertexDeclarationHandle ezGALDevice::CreateVertexDeclaration(const ezGALVer
   return ezGALVertexDeclarationHandle();
 }
 
-void ezGALDevice::DestroyVertexDeclaration(ezGALVertexDeclarationHandle hVertexDeclaration)
+void ezGALDevice::DestroyVertexDeclaration(ezGALVertexDeclarationHandle& inout_hVertexDeclaration)
 {
   EZ_GALDEVICE_LOCK_AND_CHECK();
 
   ezGALVertexDeclaration* pVertexDeclaration = nullptr;
-
-  if (m_VertexDeclarations.TryGetValue(hVertexDeclaration, pVertexDeclaration))
+  if (m_VertexDeclarations.TryGetValue(inout_hVertexDeclaration, pVertexDeclaration))
   {
     pVertexDeclaration->ReleaseRef();
     m_uiVertexDeclarations--;
 
     if (pVertexDeclaration->GetRefCount() == 0)
     {
-      AddDeadObject(GALObjectType::VertexDeclaration, hVertexDeclaration);
+      AddDeadObject(GALObjectType::VertexDeclaration, inout_hVertexDeclaration);
     }
   }
-  else
-  {
-    ezLog::Warning("DestroyVertexDeclaration called on invalid handle (double free?)");
-  }
+
+  inout_hVertexDeclaration.Invalidate();
 }
 
 ezEnum<ezGALAsyncResult> ezGALDevice::GetFenceResult(ezGALFenceHandle hFence, ezTime timeout)

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device_inl.h
@@ -163,9 +163,9 @@ EZ_ALWAYS_INLINE bool ezGALDevice::HasDefaultDevice()
 template <typename HandleType>
 EZ_FORCE_INLINE void ezGALDevice::AddDeadObject(ezUInt32 uiType, HandleType handle)
 {
-  auto& deadObject = m_DeadObjects.ExpandAndGetRef();
-  deadObject.m_uiType = uiType;
-  deadObject.m_uiHandle = handle.GetInternalID().m_Data;
+  DeadObject deadObject = {uiType, handle.GetInternalID().m_Data};
+  EZ_ASSERT_DEBUG(!m_DeadObjects.Contains(deadObject), "The same object is being destroyed multiple times.");
+  m_DeadObjects.PushBack(deadObject);
 }
 
 template <typename HandleType>

--- a/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/DynamicBuffer.cpp
@@ -55,18 +55,12 @@ void ezGALDynamicBuffer::Deinitialize()
 {
   Clear();
 
-  if (m_hBufferForUpload.IsInvalidated() == false)
-  {
-    ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hBufferForUpload);
-  }
-
-  if (m_hBufferForRendering.IsInvalidated() == false && m_hBufferForRendering != m_hBufferForUpload)
+  if (m_hBufferForRendering != m_hBufferForUpload)
   {
     ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hBufferForRendering);
   }
 
-  m_hBufferForUpload.Invalidate();
-  m_hBufferForRendering.Invalidate();
+  ezGALDevice::GetDefaultDevice()->DestroyBuffer(m_hBufferForUpload);
 }
 
 void ezGALDynamicBuffer::Clear()

--- a/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackHelper.cpp
+++ b/Code/Engine/RendererFoundation/Resources/Implementation/ReadbackHelper.cpp
@@ -23,11 +23,11 @@ ezGALReadbackBufferHelper::~ezGALReadbackBufferHelper()
 
 void ezGALReadbackBufferHelper::Reset()
 {
-  if (!m_hReadbackBuffer.IsInvalidated())
+  if (m_pDevice)
   {
     m_pDevice->DestroyReadbackBuffer(m_hReadbackBuffer);
-    m_hReadbackBuffer.Invalidate();
   }
+
   m_hFence = 0;
   m_pDevice = nullptr;
 }
@@ -81,11 +81,11 @@ ezGALReadbackTextureHelper::~ezGALReadbackTextureHelper()
 
 void ezGALReadbackTextureHelper::Reset()
 {
-  if (!m_hReadbackTexture.IsInvalidated())
+  if (m_pDevice)
   {
     m_pDevice->DestroyReadbackTexture(m_hReadbackTexture);
-    m_hReadbackTexture.Invalidate();
   }
+
   m_hFence = 0;
   m_pDevice = nullptr;
 }

--- a/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
@@ -61,7 +61,7 @@ void ezRmlUiCanvas2DComponent::Deinitialize()
   SUPER::Deinitialize();
 
   ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hTexture);
-  
+
   if (m_pContext != nullptr)
   {
     ezRmlUi::GetSingleton()->DeleteContext(m_pContext);

--- a/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Components/Implementation/RmlUiCanvas2DComponent.cpp
@@ -60,12 +60,8 @@ void ezRmlUiCanvas2DComponent::Deinitialize()
 {
   SUPER::Deinitialize();
 
-  if (m_hTexture.IsInvalidated() == false)
-  {
-    ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hTexture);
-    m_hTexture.Invalidate();
-  }
-
+  ezGALDevice::GetDefaultDevice()->DestroyTexture(m_hTexture);
+  
   if (m_pContext != nullptr)
   {
     ezRmlUi::GetSingleton()->DeleteContext(m_pContext);

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiRenderer.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiRenderer.cpp
@@ -28,7 +28,6 @@ ezRmlUiRenderer::ezRmlUiRenderer()
 ezRmlUiRenderer::~ezRmlUiRenderer()
 {
   ezRenderContext::DeleteConstantBufferStorage(m_hConstantBuffer);
-  m_hConstantBuffer.Invalidate();
 }
 
 void ezRmlUiRenderer::GetSupportedRenderDataTypes(ezHybridArray<const ezRTTI*, 8>& ref_types) const

--- a/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
+++ b/Code/Samples/MeshRenderSample/MeshRenderSample.cpp
@@ -253,10 +253,8 @@ public:
     ezResourceManager::EngineAboutToShutdown();
 
     ezRenderContext::DeleteConstantBufferStorage(m_hSampleConstants);
-    m_hSampleConstants.Invalidate();
 
     m_pDevice->DestroyTexture(m_hDepthStencilTexture);
-    m_hDepthStencilTexture.Invalidate();
 
     m_hMaterial1.Invalidate();
     m_hMaterial2.Invalidate();

--- a/Code/Samples/TextureSample/TextureSample.cpp
+++ b/Code/Samples/TextureSample/TextureSample.cpp
@@ -367,10 +367,8 @@ public:
     ezResourceManager::EngineAboutToShutdown();
 
     ezRenderContext::DeleteConstantBufferStorage(m_hSampleConstants);
-    m_hSampleConstants.Invalidate();
 
     m_pDevice->DestroyTexture(m_hDepthStencilTexture);
-    m_hDepthStencilTexture.Invalidate();
 
     m_hMaterial.Invalidate();
     m_hQuadMeshBuffer.Invalidate();

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -152,7 +152,9 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, StateDeduplication)
     EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
     VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 2);
 
-    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    // The destroy function below will invalidate the handle, so we need to copy it for later use.
+    auto hGraphicsPipelineCopy = hGraphicsPipeline;
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipelineCopy);
     VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 1);
     DestroyDependencies(pDevice, graphicsPipelineDesc);
 
@@ -174,7 +176,9 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, StateDeduplication)
     CreateDependencies(graphicsPipelineDesc);
     hGraphicsPipeline = pDevice->CreateGraphicsPipeline(graphicsPipelineDesc);
 
-    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    // The destroy function below will invalidate the handle, so we need to copy it for later use.
+    auto hGraphicsPipelineCopy = hGraphicsPipeline;
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipelineCopy);
     DestroyDependencies(pDevice, graphicsPipelineDesc);
 
     EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
@@ -207,7 +211,10 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, StateDeduplication)
 
     // Destroy dependencies first this time
     DestroyDependencies(pDevice, graphicsPipelineDesc);
-    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+
+    // The destroy function below will invalidate the handle, so we need to copy it for later use.
+    auto hGraphicsPipelineCopy = hGraphicsPipeline;
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipelineCopy);
 
     EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
     VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 0);
@@ -254,7 +261,9 @@ EZ_CREATE_SIMPLE_RENDERER_TEST(DataStructures, StateDeduplication)
     EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 1);
     VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 1);
 
-    pDevice->DestroyGraphicsPipeline(hGraphicsPipeline);
+    // The destroy function below will invalidate the handle, so we need to copy it for later use.
+    auto hGraphicsPipelineCopy = hGraphicsPipeline;
+    pDevice->DestroyGraphicsPipeline(hGraphicsPipelineCopy);
 
     EZ_TEST_INT(pDevice->GetGraphicsPipeline(hGraphicsPipeline)->GetRefCount(), 0);
     VerifyDependenciesRefCount(pDevice, graphicsPipelineDesc, 0);

--- a/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
+++ b/Code/UnitTests/RendererTest/DataStructures/StateDeduplication.cpp
@@ -37,10 +37,16 @@ namespace
 
   void DestroyDependencies(ezGALDevice* pDevice, const ezGALGraphicsPipelineCreationDescription& graphicsPipelineDesc)
   {
-    pDevice->DestroyShader(graphicsPipelineDesc.m_hShader);
-    pDevice->DestroyBlendState(graphicsPipelineDesc.m_hBlendState);
-    pDevice->DestroyDepthStencilState(graphicsPipelineDesc.m_hDepthStencilState);
-    pDevice->DestroyRasterizerState(graphicsPipelineDesc.m_hRasterizerState);
+    // the destroy functions want a mutable reference but we don't want to modify the original description
+    auto hShader = graphicsPipelineDesc.m_hShader;
+    auto hRasterizerState = graphicsPipelineDesc.m_hRasterizerState;
+    auto hBlendState = graphicsPipelineDesc.m_hBlendState;
+    auto hDepthStencilState = graphicsPipelineDesc.m_hDepthStencilState;
+
+    pDevice->DestroyShader(hShader);
+    pDevice->DestroyRasterizerState(hRasterizerState);
+    pDevice->DestroyBlendState(hBlendState);
+    pDevice->DestroyDepthStencilState(hDepthStencilState);
   }
 } // namespace
 

--- a/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/RendererTest/TestClass/TestClass.cpp
@@ -199,7 +199,6 @@ void ezGraphicsTest::ShutdownRenderer()
   m_hCubeUV.Invalidate();
 
   ezRenderContext::DeleteConstantBufferStorage(m_hObjectTransformCB);
-  m_hObjectTransformCB.Invalidate();
 
   ezStartup::ShutdownHighLevelSystems();
 


### PR DESCRIPTION
All destroy functions in GALDevice now take the handle as a reference and invalidate it automatically. Also calling destroy on an invalid handle will no longer emit a warning. This simplifies the user code and is more in line with other code like e.g. EZ_DELETE.