### PR TITLE
Added search by component type in scene tree

### DIFF
--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeModel.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeModel.cpp
@@ -588,6 +588,11 @@ bool ezQtDocumentTreeModel::MoveObjects(const ezDragDropInfo& info)
   return false;
 }
 
+const ezDocumentObject* ezQtDocumentTreeModel::GetObject(const QModelIndex index) const
+{
+  return (const ezDocumentObject*)index.internalPointer();
+}
+
 QStringList ezQtDocumentTreeModel::mimeTypes() const
 {
   QStringList types;

--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
@@ -18,6 +18,29 @@ ezQtDocumentTreeView::ezQtDocumentTreeView(QWidget* pParent, ezDocument* pDocume
   Initialize(pDocument, std::move(pModel), pSelection);
 }
 
+static bool GameObjectFilterFunc(QModelIndex index, const ezSearchPatternFilter& filter)
+{
+  if (const ezQtDocumentTreeModel* pModel = qobject_cast<const ezQtDocumentTreeModel*>(index.model()))
+  {
+    auto pObj = pModel->GetObject(index);
+    auto pAcc = pModel->GetDocumentTree()->GetDocument()->GetObjectAccessor();
+
+    ezVariant comp;
+
+    const ezInt32 iNum = pAcc->GetCountByName(pObj, "Components");
+    for (ezInt32 i = 0; i < iNum; ++i)
+    {
+      if (pAcc->GetValueByName(pObj, "Components", comp, i).Succeeded())
+      {
+        if (filter.PassesFilters(pAcc->GetObject(comp.Get<ezUuid>())->GetType()->GetTypeName()))
+          return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 void ezQtDocumentTreeView::Initialize(ezDocument* pDocument, std::unique_ptr<ezQtDocumentTreeModel> pModel, ezSelectionManager* pSelection)
 {
   m_pDocument = pDocument;
@@ -31,6 +54,7 @@ void ezQtDocumentTreeView::Initialize(ezDocument* pDocument, std::unique_ptr<ezQ
 
   m_pFilterModel.reset(new ezQtTreeSearchFilterModel(this));
   m_pFilterModel->setSourceModel(m_pModel.get());
+  m_pFilterModel->SetCustomFilterFunc(GameObjectFilterFunc);
 
   setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
   setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);

--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
@@ -3,6 +3,7 @@
 #include <EditorFramework/GUI/RawDocumentTreeWidget.moc.h>
 #include <GuiFoundation/ActionViews/QtProxy.moc.h>
 #include <GuiFoundation/Models/TreeSearchFilterModel.moc.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
 ezQtDocumentTreeView::ezQtDocumentTreeView(QWidget* pParent)
   : ezQtItemView<QTreeView>(pParent)

--- a/Code/Editor/EditorFramework/GUI/RawDocumentTreeModel.moc.h
+++ b/Code/Editor/EditorFramework/GUI/RawDocumentTreeModel.moc.h
@@ -84,6 +84,8 @@ public:
 /// Hierarchy is defined by ezQtDocumentTreeModelAdapter that have to be added via AddAdapter.
 class EZ_EDITORFRAMEWORK_DLL ezQtDocumentTreeModel : public QAbstractItemModel
 {
+  Q_OBJECT
+
 public:
   ezQtDocumentTreeModel(const ezDocumentObjectManager* pTree, const ezUuid& root = ezUuid());
   ~ezQtDocumentTreeModel();
@@ -100,6 +102,9 @@ public:
   void SetAllowDragDrop(bool bAllow);
 
   static bool MoveObjects(const ezDragDropInfo& info);
+
+  /// \brief Returns the ezDocumentObject that the index points to.
+  const ezDocumentObject* GetObject(const QModelIndex index) const;
 
 public: // QAbstractItemModel
   virtual QModelIndex index(int iRow, int iColumn, const QModelIndex& parent = QModelIndex()) const override;

--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectPanel.cpp
@@ -22,6 +22,7 @@ ezQtGameObjectWidget::ezQtGameObjectWidget(QWidget* pParent, ezGameObjectDocumen
 
   m_pFilterWidget = new ezQtSearchWidget(this);
   m_pFilterWidget->setObjectName("ezQtSearchWidget");
+  m_pFilterWidget->setPlaceholderText("Search by name or component type");
   connect(m_pFilterWidget, &ezQtSearchWidget::textChanged, this, &ezQtGameObjectWidget::OnFilterTextChanged);
 
   layout()->addWidget(m_pFilterWidget);

--- a/Code/Tools/Libs/GuiFoundation/Models/Implementation/TreeSearchFilterModel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Models/Implementation/TreeSearchFilterModel.cpp
@@ -26,7 +26,6 @@ void ezQtTreeSearchFilterModel::SetFilterText(const QString& sText)
   invalidateFilter();
 }
 
-
 void ezQtTreeSearchFilterModel::SetIncludeChildren(bool bInclude)
 {
   m_bIncludeChildren = true;
@@ -36,6 +35,11 @@ void ezQtTreeSearchFilterModel::SetIncludeChildren(bool bInclude)
     RecomputeVisibleItems();
     invalidateFilter();
   }
+}
+
+void ezQtTreeSearchFilterModel::SetCustomFilterFunc(CustomFilterFunc func)
+{
+  m_CustomFilterFunc = func;
 }
 
 void ezQtTreeSearchFilterModel::RecomputeVisibleItems()
@@ -67,7 +71,7 @@ bool ezQtTreeSearchFilterModel::UpdateVisibility(const QModelIndex& idx, bool bP
   bool bSubTreeAnyVisible = false;
 
   if (m_Filter.PassesFilters(displayName.toUtf8().data()) ||
-      (internalNameVar.canConvert<QString>() && m_Filter.PassesFilters(internalNameVar.toString().toUtf8().data())))
+      (internalNameVar.canConvert<QString>() && m_Filter.PassesFilters(internalNameVar.toString().toUtf8().data())) || (m_CustomFilterFunc.IsValid() && m_CustomFilterFunc(idx, m_Filter)))
   {
     bParentIsVisible = true;
     bSubTreeAnyVisible = true;

--- a/Code/Tools/Libs/GuiFoundation/Models/TreeSearchFilterModel.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Models/TreeSearchFilterModel.moc.h
@@ -13,6 +13,9 @@ class EZ_GUIFOUNDATION_DLL ezQtTreeSearchFilterModel : public QSortFilterProxyMo
   Q_OBJECT
 
 public:
+  /// Return true to indicate that the model index shall be visible.
+  using CustomFilterFunc = ezDelegate<bool(QModelIndex, const ezSearchPatternFilter&)>;
+
   ezQtTreeSearchFilterModel(QWidget* pParent);
 
   void SetFilterText(const QString& sText);
@@ -20,6 +23,9 @@ public:
   /// \brief By default only nodes (and their parents) are shown that fit the search criterion.
   /// If this is enabled, all child nodes of nodes that fit the criterion are included as well.
   void SetIncludeChildren(bool bInclude);
+
+  /// The custom function is executed when when visibility is updated. Return false to hide an element.
+  void SetCustomFilterFunc(CustomFilterFunc func);
 
 protected:
   void RecomputeVisibleItems();
@@ -30,4 +36,5 @@ protected:
   QAbstractItemModel* m_pSourceModel;
   ezSearchPatternFilter m_Filter;
   ezMap<QModelIndex, bool> m_Visible;
+  CustomFilterFunc m_CustomFilterFunc;
 };

--- a/Data/Samples/Testing Chambers/Scenes/Main.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Main.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{5663861999519337560}
+		u4 %Hash{13835143483548054507}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -927,6 +927,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -5941,6 +5942,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -10096,7 +10098,7 @@ o
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::ForceDynamic"}
-		s %Name{"asdf"}
+		s %Name{""}
 		VarArray %Tags
 		{
 			s{"CastShadow"}
@@ -14510,6 +14512,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -18197,6 +18200,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -24597,6 +24601,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -27233,6 +27238,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -33084,6 +33090,7 @@ o
 		b %Active{1}
 		Vec3 %CustomTangentIn{f{0,0,0}}
 		Vec3 %CustomTangentOut{f{0,0,0}}
+		b %LinkCustomTangents{0}
 		Angle %Roll{f{0}}
 		s %TangentModeIn{"ezSplineTangentMode::Auto"}
 		s %TangentModeOut{"ezSplineTangentMode::Auto"}
@@ -35172,6 +35179,23 @@ o
 }
 o
 {
+	Uuid %id{u4{8654430645282539645,3990045288992136643}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSplineComponentSpace"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
 	Uuid %id{u4{10436287537458291866,4104850229502638426}}
 	s %t{"ezDefaultValueAttribute"}
 	u3 %v{1}
@@ -36253,6 +36277,23 @@ o
 			Uuid{u4{175585461870260746,5885483319571961131}}
 		}
 		s %TypeName{"ezJoltBreakableSlabFlags"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4655660492459501943,8090873753673120907}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezManipulatorAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSplineTangentManipulatorAttribute"}
 		u3 %TypeVersion{1}
 	}
 }
@@ -38049,23 +38090,6 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
 		s %Name{"Size"}
 		s %Type{"ezVec2"}
-	}
-}
-o
-{
-	Uuid %id{u4{3477397724192825265,13467442718353903955}}
-	s %t{"ezReflectedTypeDescriptor"}
-	u3 %v{1}
-	p
-	{
-		VarArray %Attributes{}
-		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
-		VarArray %Functions{}
-		s %ParentTypeName{"ezManipulatorAttribute"}
-		s %PluginName{"Static"}
-		VarArray %Properties{}
-		s %TypeName{"ezSplineNodeManipulatorAttribute"}
-		u3 %TypeVersion{1}
 	}
 }
 o


### PR DESCRIPTION
The scene tree search now also considers the attached component types. Ie you can now search for "light" and find all objects that have any kind of light component attached.