### PR TITLE
Added fog start distance parameter

### DIFF
--- a/Code/Engine/RendererCore/Components/FogComponent.h
+++ b/Code/Engine/RendererCore/Components/FogComponent.h
@@ -18,6 +18,7 @@ public:
   float m_fDensity;
   float m_fHeightFalloff;
   float m_fInvSkyDistance;
+  float m_fFogStartDistance;
 };
 
 class EZ_RENDERERCORE_DLL ezFogComponent : public ezSettingsComponent
@@ -59,6 +60,9 @@ public:
   void SetSkyDistance(float fDistance);         // [ property ]
   float GetSkyDistance() const;                 // [ property ]
 
+  void SetStartDistance(float fDistance);       // [ property ]
+  float GetStartDistance() const;               // [ property ]
+
 protected:
   void OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg);
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
@@ -67,5 +71,6 @@ protected:
   float m_fDensity = 1.0f;
   float m_fHeightFalloff = 10.0f;
   float m_fSkyDistance = 1000.0f;
+  float m_fStartDistance = 0.0f;
   bool m_bModulateWithSkyColor = false;
 };

--- a/Code/Engine/RendererCore/Components/Implementation/FogComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/FogComponent.cpp
@@ -10,12 +10,13 @@
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezFogRenderData, 1, ezRTTIDefaultAllocator<ezFogRenderData>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_COMPONENT_TYPE(ezFogComponent, 2, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezFogComponent, 3, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezDefaultValueAttribute(ezColorGammaUB(ezColor(0.2f, 0.2f, 0.3f)))),
     EZ_ACCESSOR_PROPERTY("Density", GetDensity, SetDensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),
+    EZ_ACCESSOR_PROPERTY("StartDistance", GetStartDistance, SetStartDistance)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_ACCESSOR_PROPERTY("HeightFalloff", GetHeightFalloff, SetHeightFalloff)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
     EZ_ACCESSOR_PROPERTY("ModulateWithSkyColor", GetModulateWithSkyColor, SetModulateWithSkyColor),
     EZ_ACCESSOR_PROPERTY("SkyDistance", GetSkyDistance, SetSkyDistance)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1000.0f)),
@@ -131,6 +132,21 @@ float ezFogComponent::GetSkyDistance() const
   return m_fSkyDistance;
 }
 
+void ezFogComponent::SetStartDistance(float fDistance)
+{
+  m_fStartDistance = fDistance;
+
+  if (IsActiveAndInitialized())
+  {
+    ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
+  }
+}
+
+float ezFogComponent::GetStartDistance() const
+{
+  return m_fStartDistance;
+}
+
 void ezFogComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
 {
   msg.SetAlwaysVisible(GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
@@ -148,6 +164,7 @@ void ezFogComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
   pRenderData->m_fDensity = m_fDensity / 100.0f;
   pRenderData->m_fHeightFalloff = m_fHeightFalloff;
   pRenderData->m_fInvSkyDistance = m_bModulateWithSkyColor ? 1.0f / m_fSkyDistance : 0.0f;
+  pRenderData->m_fFogStartDistance = m_fStartDistance;
 
   msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::Light, ezRenderData::Caching::IfStatic);
 }
@@ -163,6 +180,7 @@ void ezFogComponent::SerializeComponent(ezWorldWriter& inout_stream) const
   s << m_fHeightFalloff;
   s << m_fSkyDistance;
   s << m_bModulateWithSkyColor;
+  s << m_fStartDistance;
 }
 
 void ezFogComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -179,6 +197,11 @@ void ezFogComponent::DeserializeComponent(ezWorldReader& inout_stream)
   {
     s >> m_fSkyDistance;
     s >> m_bModulateWithSkyColor;
+  }
+
+  if (uiVersion >= 3)
+  {
+    s >> m_fStartDistance;
   }
 }
 

--- a/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
+++ b/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
@@ -38,6 +38,7 @@ public:
   float m_fFogHeightFalloff = 0.0f;
   float m_fFogDensityAtCameraPos = 0.0f;
   float m_fFogDensity = 0.0f;
+  float m_fFogStartDistance = 0.0f;
   float m_fFogInvSkyDistance = 0.0f;
   ezColor m_FogColor = ezColor::Black;
 };

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -314,6 +314,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
           pData->m_fFogDensityAtCameraPos = ezMath::Exp(ezMath::Clamp(fogAtCameraPos, -80.0f, 80.0f)); // Prevent infs
           pData->m_fFogDensity = pFogRenderData->m_fDensity;
           pData->m_fFogInvSkyDistance = pFogRenderData->m_fInvSkyDistance;
+          pData->m_fFogStartDistance = pFogRenderData->m_fFogStartDistance;
 
           pData->m_FogColor = pFogRenderData->m_Color;
         }

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataProvider.cpp
@@ -197,6 +197,7 @@ void* ezClusteredDataProvider::UpdateData(const ezRenderViewContext& renderViewC
     pConstants->FogDensity = pData->m_fFogDensity;
     pConstants->FogColor = pData->m_FogColor;
     pConstants->FogInvSkyDistance = pData->m_fFogInvSkyDistance;
+    pConstants->FogStartDistance = pData->m_fFogStartDistance;
   }
 
   return &m_Data;

--- a/Data/Base/Shaders/Common/LightData.h
+++ b/Data/Base/Shaders/Common/LightData.h
@@ -178,6 +178,7 @@ struct ezPerDecalAtlasData
     FLOAT1(FogDensity);
     COLOR4F(FogColor);
     FLOAT1(FogInvSkyDistance);
+    FLOAT1(FogStartDistance);
 };
 
 #define NUM_CLUSTERS_X 16

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -834,7 +834,7 @@ float GetFogAmount(float3 worldPosition)
     fogDensity *= saturate((exp(FogHeightFalloff * worldPosition.z + FogHeight) - FogDensityAtCameraPos) / range);
   }
 
-  return saturate(exp(-fogDensity * length(cameraToWorldPos)));
+  return saturate(exp(-fogDensity * max(0, length(cameraToWorldPos) - FogStartDistance)));
 }
 
 float3 ApplyFog(float3 color, float3 worldPosition, float fogAmount)


### PR DESCRIPTION
This parameter allows to push out the distance at which fog starts to appear.
This makes it possible to have dense fog, without it affecting everything right in front of the camera.