### PR TITLE
Added specular intensity value to skylight component

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/ViewRenderSettings.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/ViewRenderSettings.cpp
@@ -272,7 +272,8 @@ void ezEngineViewLightSettings::UpdateForEngine(ezWorld* pWorld)
 
     if (ezSkyLightComponent* pSkyLight = SyncComponent<ezSkyLightComponent>(m_pWorld, pParent, m_hSkyLight, m_bSkyLight))
     {
-      pSkyLight->SetIntensity(m_fSkyLightIntensity);
+      pSkyLight->SetDiffuseIntensity(m_fSkyLightIntensity);
+      pSkyLight->SetSpecularIntensity(m_fSkyLightIntensity);
       pSkyLight->SetReflectionProbeMode(ezReflectionProbeMode::Static);
       pSkyLight->SetCubeMapFile(m_sSkyLightCubeMap);
     }

--- a/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LensFlareComponent.cpp
@@ -228,8 +228,8 @@ void ezLensFlareComponent::FindLightComponent()
 
 void ezLensFlareComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
 {
-  // Don't render in shadow views
-  if (msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::Shadow)
+  // Don't render in shadow and reflection views
+  if (msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::Shadow || msg.m_pView->GetCameraUsageHint() == ezCameraUsageHint::Reflection)
     return;
 
   // Don't extract render data for selection.

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionPoolData.cpp
@@ -132,10 +132,10 @@ bool ezReflectionPool::Data::UpdateSkyLightData(ProbeData& ref_probeData, const 
   ref_probeData.m_desc = desc;
   ref_probeData.m_GlobalTransform = pComponent->GetOwner()->GetGlobalTransform();
 
-  if (auto pSkyLight = ezDynamicCast<const ezSkyLightComponent*>(pComponent))
+  if (pComponent != nullptr)
   {
     ref_probeData.m_Flags = ezProbeFlags::SkyLight;
-    ref_probeData.m_hCubeMap = pSkyLight->GetCubeMap();
+    ref_probeData.m_hCubeMap = pComponent->GetCubeMap();
     if (ref_probeData.m_desc.m_Mode == ezReflectionProbeMode::Dynamic)
     {
       ref_probeData.m_Flags |= ezProbeFlags::Dynamic;

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeData.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeData.h
@@ -32,8 +32,9 @@ struct EZ_RENDERERCORE_DLL ezReflectionProbeDesc
   bool m_bShowDebugInfo = false;
   bool m_bShowMipMaps = false;
 
-  float m_fIntensity = 0.4f;
-  float m_fSaturation = 0.3f;
+  float m_fDiffuseIntensity = 0.4f;
+  float m_fDiffuseSaturation = 0.3f;
+  float m_fSpecularIntensity = 1.0f;
   float m_fNearPlane = 0.0f;
   float m_fFarPlane = 100.0f;
   ezVec3 m_vCaptureOffset = ezVec3::MakeZero();

--- a/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ReflectionProbeUpdater.cpp
@@ -399,8 +399,9 @@ void ezReflectionProbeUpdater::AddViewToRender(const ProbeUpdateInfo::Step& step
       {
         renderTargets.m_hRTs[2] = updateInfo.m_TargetSlot.m_hIrradianceOutputTexture;
       }
-      pView->SetRenderPassProperty("ReflectionFilterPass", "Intensity", updateInfo.m_desc.m_fIntensity);
-      pView->SetRenderPassProperty("ReflectionFilterPass", "Saturation", updateInfo.m_desc.m_fSaturation);
+      pView->SetRenderPassProperty("ReflectionFilterPass", "DiffuseIntensity", updateInfo.m_desc.m_fDiffuseIntensity);
+      pView->SetRenderPassProperty("ReflectionFilterPass", "DiffuseSaturation", updateInfo.m_desc.m_fDiffuseSaturation);
+      pView->SetRenderPassProperty("ReflectionFilterPass", "SpecularIntensity", updateInfo.m_desc.m_fSpecularIntensity);
       pView->SetRenderPassProperty("ReflectionFilterPass", "SpecularOutputIndex", updateInfo.m_TargetSlot.m_iSpecularOutputIndex);
       pView->SetRenderPassProperty("ReflectionFilterPass", "IrradianceOutputIndex", updateInfo.m_TargetSlot.m_iIrradianceOutputIndex);
 

--- a/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SkyLightComponent.cpp
@@ -23,14 +23,15 @@ namespace
 } // namespace
 
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezSkyLightComponent, 3, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezSkyLightComponent, 4, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_ENUM_ACCESSOR_PROPERTY("ReflectionProbeMode", ezReflectionProbeMode, GetReflectionProbeMode, SetReflectionProbeMode)->AddAttributes(new ezGroupAttribute("Capture Description")),
     EZ_ACCESSOR_PROPERTY("CubeMap", GetCubeMapFile, SetCubeMapFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Texture_Cube")),
-    EZ_ACCESSOR_PROPERTY("Intensity", GetIntensity, SetIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.4f)),
-    EZ_ACCESSOR_PROPERTY("Saturation", GetSaturation, SetSaturation)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.3f)),
+    EZ_ACCESSOR_PROPERTY("DiffuseIntensity", GetDiffuseIntensity, SetDiffuseIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.4f)),
+    EZ_ACCESSOR_PROPERTY("DiffuseSaturation", GetDiffuseSaturation, SetDiffuseSaturation)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.3f)),
+    EZ_ACCESSOR_PROPERTY("SpecularIntensity", GetSpecularIntensity, SetSpecularIntensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),
     EZ_SET_ACCESSOR_PROPERTY("IncludeTags", GetIncludeTags, InsertIncludeTag, RemoveIncludeTag)->AddAttributes(new ezTagSetWidgetAttribute("Default"), new ezDefaultValueAttribute(GetDefaultTags())),
     EZ_SET_ACCESSOR_PROPERTY("ExcludeTags", GetExcludeTags, InsertExcludeTag, RemoveExcludeTag)->AddAttributes(new ezTagSetWidgetAttribute("Default")),
     EZ_ACCESSOR_PROPERTY("NearPlane", GetNearPlane, SetNearPlane)->AddAttributes(new ezDefaultValueAttribute(0.0f), new ezClampValueAttribute(0.0f, {}), new ezMinValueTextAttribute("Auto")),
@@ -89,26 +90,37 @@ ezEnum<ezReflectionProbeMode> ezSkyLightComponent::GetReflectionProbeMode() cons
   return m_Desc.m_Mode;
 }
 
-void ezSkyLightComponent::SetIntensity(float fIntensity)
+void ezSkyLightComponent::SetDiffuseIntensity(float fIntensity)
 {
-  m_Desc.m_fIntensity = fIntensity;
+  m_Desc.m_fDiffuseIntensity = fIntensity;
   m_bStatesDirty = true;
 }
 
-float ezSkyLightComponent::GetIntensity() const
+float ezSkyLightComponent::GetDiffuseIntensity() const
 {
-  return m_Desc.m_fIntensity;
+  return m_Desc.m_fDiffuseIntensity;
 }
 
-void ezSkyLightComponent::SetSaturation(float fSaturation)
+void ezSkyLightComponent::SetDiffuseSaturation(float fSaturation)
 {
-  m_Desc.m_fSaturation = fSaturation;
+  m_Desc.m_fDiffuseSaturation = fSaturation;
   m_bStatesDirty = true;
 }
 
-float ezSkyLightComponent::GetSaturation() const
+float ezSkyLightComponent::GetDiffuseSaturation() const
 {
-  return m_Desc.m_fSaturation;
+  return m_Desc.m_fDiffuseSaturation;
+}
+
+void ezSkyLightComponent::SetSpecularIntensity(float fIntensity)
+{
+  m_Desc.m_fSpecularIntensity = fIntensity;
+  m_bStatesDirty = true;
+}
+
+float ezSkyLightComponent::GetSpecularIntensity() const
+{
+  return m_Desc.m_fSpecularIntensity;
 }
 
 const ezTagSet& ezSkyLightComponent::GetIncludeTags() const
@@ -232,8 +244,9 @@ void ezSkyLightComponent::SerializeComponent(ezWorldWriter& inout_stream) const
   m_Desc.m_ExcludeTags.Save(s);
   s << m_Desc.m_Mode;
   s << m_Desc.m_bShowDebugInfo;
-  s << m_Desc.m_fIntensity;
-  s << m_Desc.m_fSaturation;
+  s << m_Desc.m_fDiffuseIntensity;
+  s << m_Desc.m_fDiffuseSaturation;
+  s << m_Desc.m_fSpecularIntensity;
   s << m_hCubeMap;
   s << m_Desc.m_fNearPlane;
   s << m_Desc.m_fFarPlane;
@@ -249,8 +262,13 @@ void ezSkyLightComponent::DeserializeComponent(ezWorldReader& inout_stream)
   m_Desc.m_ExcludeTags.Load(s, ezTagRegistry::GetGlobalRegistry());
   s >> m_Desc.m_Mode;
   s >> m_Desc.m_bShowDebugInfo;
-  s >> m_Desc.m_fIntensity;
-  s >> m_Desc.m_fSaturation;
+  s >> m_Desc.m_fDiffuseIntensity;
+  s >> m_Desc.m_fDiffuseSaturation;
+  if (uiVersion >= 4)
+  {
+    s >> m_Desc.m_fSpecularIntensity;
+  }
+
   if (uiVersion >= 2)
   {
     s >> m_hCubeMap;
@@ -296,5 +314,24 @@ public:
 };
 
 ezSkyLightComponentPatch_2_3 g_ezSkyLightComponentPatch_2_3;
+
+///////////////////////////////////////////////////////////////////////////
+
+class ezSkyLightComponentPatch_3_4 : public ezGraphPatch
+{
+public:
+  ezSkyLightComponentPatch_3_4()
+    : ezGraphPatch("ezSkyLightComponent", 4)
+  {
+  }
+
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  {
+    pNode->RenameProperty("Intensity", "DiffuseIntensity");
+    pNode->RenameProperty("Saturation", "DiffuseSaturation");
+  }
+};
+
+ezSkyLightComponentPatch_3_4 g_ezSkyLightComponentPatch_3_4;
 
 EZ_STATICLINK_FILE(RendererCore, RendererCore_Lights_Implementation_SkyLightComponent);

--- a/Code/Engine/RendererCore/Lights/SkyLightComponent.h
+++ b/Code/Engine/RendererCore/Lights/SkyLightComponent.h
@@ -37,11 +37,14 @@ public:
   void SetReflectionProbeMode(ezEnum<ezReflectionProbeMode> mode); // [ property ]
   ezEnum<ezReflectionProbeMode> GetReflectionProbeMode() const;    // [ property ]
 
-  void SetIntensity(float fIntensity);                             // [ property ]
-  float GetIntensity() const;                                      // [ property ]
+  void SetDiffuseIntensity(float fIntensity);                      // [ property ]
+  float GetDiffuseIntensity() const;                               // [ property ]
 
-  void SetSaturation(float fSaturation);                           // [ property ]
-  float GetSaturation() const;                                     // [ property ]
+  void SetDiffuseSaturation(float fSaturation);                    // [ property ]
+  float GetDiffuseSaturation() const;                              // [ property ]
+
+  void SetSpecularIntensity(float fIntensity);                     // [ property ]
+  float GetSpecularIntensity() const;                              // [ property ]
 
   const ezTagSet& GetIncludeTags() const;                          // [ property ]
   void InsertIncludeTag(const char* szTag);                        // [ property ]

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/ReflectionFilterPass.cpp
@@ -12,15 +12,16 @@
 #include <RendererCore/../../../Data/Base/Shaders/Pipeline/ReflectionIrradianceConstants.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezReflectionFilterPass, 1, ezRTTIDefaultAllocator<ezReflectionFilterPass>)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezReflectionFilterPass, 2, ezRTTIDefaultAllocator<ezReflectionFilterPass>)
 {
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("FilteredSpecular", m_PinFilteredSpecular),
     EZ_MEMBER_PROPERTY("AvgLuminance", m_PinAvgLuminance),
     EZ_MEMBER_PROPERTY("IrradianceData", m_PinIrradianceData),
-    EZ_MEMBER_PROPERTY("Intensity", m_fIntensity)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
-    EZ_MEMBER_PROPERTY("Saturation", m_fSaturation)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
+    EZ_MEMBER_PROPERTY("DiffuseIntensity", m_fDiffuseIntensity)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
+    EZ_MEMBER_PROPERTY("DiffuseSaturation", m_fDiffuseSaturation)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
+    EZ_MEMBER_PROPERTY("SpecularIntensity", m_fSpecularIntensity)->AddAttributes(new ezDefaultValueAttribute(1.0f)),
     EZ_MEMBER_PROPERTY("SpecularOutputIndex", m_uiSpecularOutputIndex),
     EZ_MEMBER_PROPERTY("IrradianceOutputIndex", m_uiIrradianceOutputIndex),
     EZ_ACCESSOR_PROPERTY("InputCubemap", GetInputCubemap, SetInputCubemap)
@@ -153,8 +154,9 @@ void ezReflectionFilterPass::Execute(const ezRenderViewContext& renderViewContex
 ezResult ezReflectionFilterPass::Serialize(ezStreamWriter& inout_stream) const
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Serialize(inout_stream));
-  inout_stream << m_fIntensity;
-  inout_stream << m_fSaturation;
+  inout_stream << m_fDiffuseIntensity;
+  inout_stream << m_fDiffuseSaturation;
+  inout_stream << m_fSpecularIntensity;
   inout_stream << m_uiSpecularOutputIndex;
   inout_stream << m_uiIrradianceOutputIndex;
   // inout_stream << m_hInputCubemap; Runtime only property
@@ -165,9 +167,13 @@ ezResult ezReflectionFilterPass::Deserialize(ezStreamReader& inout_stream)
 {
   EZ_SUCCEED_OR_RETURN(SUPER::Deserialize(inout_stream));
   const ezUInt32 uiVersion = ezTypeVersionReadContext::GetContext()->GetTypeVersion(GetStaticRTTI());
-  EZ_IGNORE_UNUSED(uiVersion);
-  inout_stream >> m_fIntensity;
-  inout_stream >> m_fSaturation;
+
+  inout_stream >> m_fDiffuseIntensity;
+  inout_stream >> m_fDiffuseSaturation;
+  if (uiVersion >= 2)
+  {
+    inout_stream >> m_fSpecularIntensity;
+  }
   inout_stream >> m_uiSpecularOutputIndex;
   inout_stream >> m_uiIrradianceOutputIndex;
   return EZ_SUCCESS;
@@ -189,16 +195,15 @@ void ezReflectionFilterPass::UpdateFilteredSpecularConstantBuffer(ezUInt32 uiMip
   constants->MipLevel = uiMipMapIndex;
   constants->OutputWidth = uiWidth;
   constants->OutputHeight = uiHeight;
-  constants->Intensity = m_fIntensity;
-  constants->Saturation = m_fSaturation;
+  constants->Intensity = m_fSpecularIntensity;
 }
 
 void ezReflectionFilterPass::UpdateIrradianceConstantBuffer()
 {
   auto constants = ezRenderContext::GetConstantBufferData<ezReflectionIrradianceConstants>(m_hIrradianceConstantBuffer);
   constants->LodLevel = 6; // TODO: calculate from cubemap size and number of samples
-  constants->Intensity = m_fIntensity;
-  constants->Saturation = m_fSaturation;
+  constants->Intensity = m_fDiffuseIntensity;
+  constants->Saturation = m_fDiffuseSaturation;
   constants->OutputIndex = m_uiIrradianceOutputIndex;
 }
 

--- a/Code/Engine/RendererCore/Pipeline/Passes/ReflectionFilterPass.h
+++ b/Code/Engine/RendererCore/Pipeline/Passes/ReflectionFilterPass.h
@@ -35,8 +35,9 @@ protected:
   ezRenderPipelineNodeOutputPin m_PinAvgLuminance;
   ezRenderPipelineNodeOutputPin m_PinIrradianceData;
 
-  float m_fIntensity = 1.0f;
-  float m_fSaturation = 1.0f;
+  float m_fDiffuseIntensity = 1.0f;
+  float m_fDiffuseSaturation = 1.0f;
+  float m_fSpecularIntensity = 1.0f;
   ezUInt32 m_uiSpecularOutputIndex = 0;
   ezUInt32 m_uiIrradianceOutputIndex = 0;
 

--- a/Data/Base/Shaders/Pipeline/ReflectionFilteredSpecular.ezShader
+++ b/Data/Base/Shaders/Pipeline/ReflectionFilteredSpecular.ezShader
@@ -207,5 +207,7 @@ void main(uint3 groupID : SV_GroupID, uint3 groupThreadID : SV_GroupThreadID)
     inputColor = integrateCubeLDOnly(CubeMapDirection(dir), CubeMapDirection(dir), roughness);
   }
 
+  inputColor.rgb *= Intensity;
+
   ReflectionOutput[uint3(pixelIndex, faceIndex)] = inputColor;
 }

--- a/Data/Base/Shaders/Pipeline/ReflectionFilteredSpecularConstants.h
+++ b/Data/Base/Shaders/Pipeline/ReflectionFilteredSpecularConstants.h
@@ -9,8 +9,4 @@ CONSTANT_BUFFER(ezReflectionFilteredSpecularConstants, 3)
   UINT1(OutputWidth);
   UINT1(OutputHeight);
   FLOAT1(Intensity);
-  FLOAT1(Saturation);
-  FLOAT1(DUMMY1);
-  FLOAT1(DUMMY2);
-  FLOAT1(DUMMY3);
 };

--- a/Data/Samples/Testing Chambers/Scenes/Main.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Main.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{13835143483548054507}
+		u4 %Hash{18095887016695046552}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -5188,23 +5188,24 @@ o
 {
 	Uuid %id{u4{3930349619982266804,4739713657226695897}}
 	s %t{"ezSkyLightComponent"}
-	u3 %v{3}
+	u3 %v{4}
 	p
 	{
 		b %Active{1}
 		s %CubeMap{""}
+		f %DiffuseIntensity{0x0000803E}
+		f %DiffuseSaturation{0xCDCC4C3F}
 		VarArray %ExcludeTags{}
 		f %FarPlane{0x0000C842}
 		VarArray %IncludeTags
 		{
 			s{"SkyLight"}
 		}
-		f %Intensity{0x0000803E}
 		f %NearPlane{0}
 		s %ReflectionProbeMode{"ezReflectionProbeMode::Dynamic"}
-		f %Saturation{0xCDCC4C3F}
 		b %ShowDebugInfo{0}
 		b %ShowMipMaps{0}
+		f %SpecularIntensity{0x0000803F}
 	}
 }
 o
@@ -6842,6 +6843,33 @@ o
 		u3 %Temperature{6550}
 		b %TransparentShadows{0}
 		b %UseColorTemperature{0}
+	}
+}
+o
+{
+	Uuid %id{u4{13734508199580147859,4933046863669298674}}
+	s %t{"ezBoxReflectionProbeComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		b %BoxProjection{1}
+		Vec3 %CaptureOffset{f{0,0,0}}
+		VarArray %ExcludeTags
+		{
+			s{"SkyLight"}
+		}
+		Vec3 %Extents{f{0x9A99E541,0x00006841,0x9A991941}}
+		f %FarPlane{0x0000C842}
+		VarArray %IncludeTags{}
+		Vec3 %InfluenceScale{f{0x0000803F,0x0000803F,0x0000803F}}
+		Vec3 %InfluenceShift{f{0,0,0}}
+		f %NearPlane{0}
+		Vec3 %NegativeFalloff{f{0xCDCCCC3D,0xCDCCCC3D,0}}
+		Vec3 %PositiveFalloff{f{0xCDCCCC3D,0xCDCCCC3D,0}}
+		s %ReflectionProbeMode{"ezReflectionProbeMode::Static"}
+		b %ShowDebugInfo{0}
+		b %ShowMipMaps{0}
 	}
 }
 o
@@ -8567,6 +8595,32 @@ o
 }
 o
 {
+	Uuid %id{u4{15536528723240958112,5118218595794246475}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13734508199580147859,4933046863669298674}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9A990541,0x0000803F,0x6666A640}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{7076981106638042302,5118677211503179128}}
 	s %t{"ezDecalComponent"}
 	u3 %v{8}
@@ -9378,6 +9432,32 @@ o
 			Uuid{u4{11068466961908290238,4903866592875722828}}
 		}
 		s %Resource{"{ 5f7e8998-fe23-4a33-aa84-d10d4dfcf2a6 }"}
+	}
+}
+o
+{
+	Uuid %id{u4{9466076154862504583,5216630948189107896}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16901855781810201004,5370339387906238151}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x3333F341,0x6766663F,0xCDCC2C40}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
 	}
 }
 o
@@ -10712,6 +10792,30 @@ o
 			HashedString{s{"6"}}
 			HashedString{s{"7"}}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{16901855781810201004,5370339387906238151}}
+	s %t{"ezSphereReflectionProbeComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec3 %CaptureOffset{f{0,0,0}}
+		VarArray %ExcludeTags
+		{
+			s{"SkyLight"}
+		}
+		f %Falloff{0xCDCCCC3D}
+		f %FarPlane{0x0000C842}
+		VarArray %IncludeTags{}
+		f %NearPlane{0}
+		f %Radius{0x00004041}
+		s %ReflectionProbeMode{"ezReflectionProbeMode::Static"}
+		b %ShowDebugInfo{0}
+		b %ShowMipMaps{0}
+		b %SphereProjection{0}
 	}
 }
 o
@@ -15001,6 +15105,8 @@ o
 			Uuid{u4{7430185196328706443,5202510460933968501}}
 			Uuid{u4{6784801398737644675,5532476487104095687}}
 			Uuid{u4{13196395880004401327,4654021650958973376}}
+			Uuid{u4{9466076154862504583,5216630948189107896}}
+			Uuid{u4{15536528723240958112,5118218595794246475}}
 		}
 		Uuid %Settings{u4{11204937990389899402,5417500911553874876}}
 	}
@@ -34590,6 +34696,23 @@ o
 }
 o
 {
+	Uuid %id{u4{7156867284130120138,2127711369401232967}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezComponent"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectionProbeComponentBase"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
 	Uuid %id{u4{953262915051745881,2141373605625162620}}
 	s %t{"ezReflectedTypeDescriptor"}
 	u3 %v{1}
@@ -34657,6 +34780,23 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezDirectionVisualizerAttribute"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{17022679703366345737,2362589303538873091}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezAbstractObjectNode"}
 		u3 %TypeVersion{1}
 	}
 }
@@ -34868,6 +35008,23 @@ o
 	{
 		Invalid %Max{}
 		f %Min{0}
+	}
+}
+o
+{
+	Uuid %id{u4{5009753258260405712,2877066798947251804}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectionProbeComponentBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBoxReflectionProbeComponent"}
+		u3 %TypeVersion{2}
 	}
 }
 o
@@ -35133,6 +35290,23 @@ o
 	p
 	{
 		f %Value{0x0AD7A33C}
+	}
+}
+o
+{
+	Uuid %id{u4{3768493600839864773,3777667521719406409}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualizerAttribute"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezBoxReflectionProbeVisualizerAttribute"}
+		u3 %TypeVersion{1}
 	}
 }
 o
@@ -37781,6 +37955,23 @@ o
 }
 o
 {
+	Uuid %id{u4{7223601987112261230,12139124130745219210}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectionProbeComponentBase"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezSphereReflectionProbeComponent"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
 	Uuid %id{u4{5780283942903250625,12235373275010886406}}
 	s %t{"ezReflectedPropertyDescriptor"}
 	u3 %v{2}
@@ -38380,7 +38571,7 @@ o
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezSkyLightComponent"}
-		u3 %TypeVersion{3}
+		u3 %TypeVersion{4}
 	}
 }
 o


### PR DESCRIPTION
* Can be useful to tweak the skylight reflection if it is too bright. Though it should only be used in very rare cases. The better solution is proper reflection probe placement to "mask" the skylight.
* Fixes #581