### PR TITLE
Fixed #1717: Editor auto-saves documents every couple of minutes

### DIFF
--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -3,6 +3,7 @@
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/EditorApp/CheckVersion.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorFramework/Preferences/EditorPreferences.h>
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/IO/OpenDdlReader.h>
@@ -26,12 +27,16 @@ ezQtEditorApp::ezQtEditorApp()
   m_pVersionChecker = EZ_DEFAULT_NEW(ezQtVersionChecker);
 
   m_pTimer = new QTimer(nullptr);
+  m_pAutoSaveTimer = new QTimer(nullptr);
 }
 
 ezQtEditorApp::~ezQtEditorApp()
 {
   delete m_pTimer;
   m_pTimer = nullptr;
+
+  delete m_pAutoSaveTimer;
+  m_pAutoSaveTimer = nullptr;
 
   CloseSplashScreen();
 }
@@ -66,6 +71,46 @@ void ezQtEditorApp::SlotTimedUpdate()
 void ezQtEditorApp::SlotSaveSettings()
 {
   SaveSettings();
+}
+
+void ezQtEditorApp::SlotAutoSave()
+{
+  const auto* pPreferences = ezPreferences::QueryPreferences<ezEditorPreferencesUser>();
+  if (!pPreferences || pPreferences->m_uiAutoSaveMinutes == 0)
+    return;
+
+  const ezTime tAutoSaveThreshold = ezTime::MakeFromMinutes(pPreferences->m_uiAutoSaveMinutes);
+  const ezTime tNow = ezTime::Now();
+
+  // Find the oldest modified document that exceeds the auto-save threshold.
+  ezDocument* pOldestDoc = nullptr;
+  ezTime tOldestTime = tNow;
+
+  for (auto pMan : ezDocumentManager::GetAllDocumentManagers())
+  {
+    for (auto pDoc : pMan->ezDocumentManager::GetAllOpenDocuments())
+    {
+      const ezTime tModified = pDoc->GetModifiedTime();
+      if (tModified.IsPositive() && (tNow - tModified) >= tAutoSaveThreshold && tModified < tOldestTime)
+      {
+        pOldestDoc = pDoc;
+        tOldestTime = tModified;
+      }
+    }
+  }
+
+  if (pOldestDoc == nullptr)
+    return;
+
+  ezQtDocumentWindow* pWnd = ezQtDocumentWindow::FindWindowByDocument(pOldestDoc);
+  if (pWnd && pWnd->GetDocument() == pOldestDoc)
+  {
+    pWnd->SaveDocument().IgnoreResult();
+  }
+  else
+  {
+    pOldestDoc->SaveDocument().IgnoreResult();
+  }
 }
 
 void ezQtEditorApp::SlotVersionCheckCompleted(bool bNewVersionReleased, bool bForced)

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -236,6 +236,7 @@ private:
 
 private Q_SLOTS:
   void SlotTimedUpdate();
+  void SlotAutoSave();
   void SlotQueuedCloseProject();
   void SlotQueuedOpenProject(QString sProject);
   void SlotQueuedOpenDocument(QString sProject, void* pOpenContext);
@@ -302,6 +303,7 @@ private:
   QTimer* m_pTimer = nullptr;
 
   QSplashScreen* m_pSplashScreen = nullptr;
+  QTimer* m_pAutoSaveTimer = nullptr;
 
   ezLogWriter::HTML m_LogHTML;
 

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -452,6 +452,10 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
   connect(m_pTimer, SIGNAL(timeout()), this, SLOT(SlotTimedUpdate()), Qt::QueuedConnection);
   m_pTimer->start(1);
 
+  // Setup auto-save timer - polls every 20 seconds and checks document modification age
+  connect(m_pAutoSaveTimer, SIGNAL(timeout()), this, SLOT(SlotAutoSave()), Qt::QueuedConnection);
+  m_pAutoSaveTimer->start(20 * 1000);
+
   if (m_bWroteCrashIndicatorFile)
   {
     QTimer::singleShot(1000, [this]()

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
@@ -33,6 +33,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorPreferencesUser, 1, ezRTTIDefaultAllocat
     EZ_MEMBER_PROPERTY("CombinedEditorAndEngineLogs", m_bCombinedEditorAndEngineLogs)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_ACCESSOR_PROPERTY("HighlightUntranslatedUI", GetHighlightUntranslatedUI, SetHighlightUntranslatedUI),
     EZ_MEMBER_PROPERTY("AssetBrowserShowItemsInSubFolders", m_bAssetBrowserShowItemsInSubFolders)->AddAttributes(new ezDefaultValueAttribute(true), new ezHiddenAttribute()),
+    EZ_MEMBER_PROPERTY("AutoSaveMinutes", m_uiAutoSaveMinutes)->AddAttributes(new ezDefaultValueAttribute(5), new ezClampValueAttribute(0, 24 * 60)),
 
     // START GROUP Engine View Light Settings
     EZ_MEMBER_PROPERTY("SkyBox", m_bSkyBox)->AddAttributes(new ezDefaultValueAttribute(true), new ezGroupAttribute("Engine View Light Settings")),

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
@@ -32,6 +32,9 @@ public:
   bool m_bHighlightUntranslatedUI = false;
   bool m_bAssetBrowserShowItemsInSubFolders = true;
 
+  // Auto-save interval in minutes. 0 = off.
+  ezUInt32 m_uiAutoSaveMinutes = 5;
+
   bool m_bSkyBox = true;
   bool m_bSkyLight = true;
   ezString m_sSkyLightCubeMap = "{ 0b202e08-a64f-465d-b38e-15b81d161822 }";

--- a/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
+++ b/Code/Engine/GameEngine/Console/Implementation/ImGuiConsole.cpp
@@ -215,7 +215,7 @@ void ezImGuiConsole::RenderCommandWindow(bool bSetFocus)
   ImGui::SetNextWindowSize(ImVec2(commandWidth, commandHeight), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowPos(ImVec2(commandPosX, commandPosY), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
 
-  if (!ImGui::Begin("Commands", nullptr, ImGuiWindowFlags_MenuBar))
+  if (!ImGui::Begin("Commands", nullptr, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoSavedSettings))
   {
     ImGui::End();
     return;
@@ -333,7 +333,7 @@ void ezImGuiConsole::RenderCVarWindow()
   ImGui::SetNextWindowSize(ImVec2(cvarWidth, cvarHeight), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowPos(ImVec2(cvarPosX, cvarPosY), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
 
-  if (!ImGui::Begin("CVars", &m_bCVarWindowOpen))
+  if (!ImGui::Begin("CVars", &m_bCVarWindowOpen, ImGuiWindowFlags_NoSavedSettings))
   {
     ImGui::End();
     return;
@@ -387,7 +387,7 @@ void ezImGuiConsole::RenderStatsWindow(bool bFull)
 
   ImGui::SetNextWindowPos(ImVec2(statsPosX, statsPosY), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
 
-  ImGuiWindowFlags flags = 0;
+  ImGuiWindowFlags flags = ImGuiWindowFlags_NoSavedSettings;
   if (!bFull)
   {
     flags |= ImGuiWindowFlags_NoDecoration;
@@ -871,7 +871,7 @@ void ezImGuiConsole::RenderLogWindow(bool bFull)
   ImGui::SetNextWindowSize(ImVec2(logWidth, logHeight), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowPos(ImVec2(logPosX, logPosY), (m_uiResetLayout > 0) ? ImGuiCond_Always : ImGuiCond_FirstUseEver);
 
-  ImGuiWindowFlags flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+  ImGuiWindowFlags flags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoSavedSettings;
   if (!bFull)
   {
     flags |= ImGuiWindowFlags_NoDecoration;

--- a/Code/Engine/GameEngine/Utils/Implementation/SceneLoadUtil.cpp
+++ b/Code/Engine/GameEngine/Utils/Implementation/SceneLoadUtil.cpp
@@ -11,52 +11,52 @@ constexpr float fCollectionPreloadPiece = 0.9f;
 ezSceneLoadUtility::ezSceneLoadUtility() = default;
 ezSceneLoadUtility::~ezSceneLoadUtility() = default;
 
-ezStatus ezSceneLoadUtility::FindRedirectedSceneFile(ezStringBuilder& sFinalSceneFile, ezStringView sSceneFile)
+ezStatus ezSceneLoadUtility::FindRedirectedSceneFile(ezStringBuilder& ref_sFinalPath, ezStringView sSceneFile)
 {
-  sFinalSceneFile = sSceneFile;
+  ref_sFinalPath = sSceneFile;
 
-  if (sFinalSceneFile.IsEmpty())
+  if (ref_sFinalPath.IsEmpty())
   {
     return ezStatus("No scene file specified.");
   }
 
-  if (sFinalSceneFile.IsAbsolutePath())
+  if (ref_sFinalPath.IsAbsolutePath())
   {
     // this can fail if the scene is in a different data directory than the project directory
     // shouldn't stop us from loading it anyway
-    sFinalSceneFile.MakeRelativeTo(ezGameApplication::GetGameApplicationInstance()->GetAppProjectPath()).IgnoreResult();
+    ref_sFinalPath.MakeRelativeTo(ezGameApplication::GetGameApplicationInstance()->GetAppProjectPath()).IgnoreResult();
   }
 
-  if (sFinalSceneFile.HasExtension("ezScene") || sFinalSceneFile.HasExtension("ezPrefab"))
+  if (ref_sFinalPath.HasExtension("ezScene") || ref_sFinalPath.HasExtension("ezPrefab"))
   {
-    if (sFinalSceneFile.IsAbsolutePath())
+    if (ref_sFinalPath.IsAbsolutePath())
     {
-      if (ezFileSystem::ResolvePath(sFinalSceneFile, nullptr, &sFinalSceneFile).Failed())
+      if (ezFileSystem::ResolvePath(ref_sFinalPath, nullptr, &ref_sFinalPath).Failed())
       {
-        return ezStatus(ezFmt("Scene path is not located in any data directory: '{}'", sFinalSceneFile));
+        return ezStatus(ezFmt("Scene path is not located in any data directory: '{}'", ref_sFinalPath));
       }
     }
 
     // if this is a path to the non-transformed source file, redirect it to the transformed file in the asset cache
-    sFinalSceneFile.Prepend("AssetCache/Common/");
+    ref_sFinalPath.Prepend("AssetCache/Common/");
 
-    if (sFinalSceneFile.HasExtension("ezScene"))
-      sFinalSceneFile.ChangeFileExtension("ezBinScene");
+    if (ref_sFinalPath.HasExtension("ezScene"))
+      ref_sFinalPath.ChangeFileExtension("ezBinScene");
     else
-      sFinalSceneFile.ChangeFileExtension("ezBinPrefab");
+      ref_sFinalPath.ChangeFileExtension("ezBinPrefab");
   }
 
   return EZ_SUCCESS;
 }
 
-ezStatus ezSceneLoadUtility::LoadSceneImmediate(ezWorld& targetWorld, ezStringView sSceneFile)
+ezStatus ezSceneLoadUtility::LoadSceneImmediate(ezWorld& inout_targetWorld, ezStringView sSceneFile)
 {
-  ezStringBuilder sFinalSceneFile;
-  EZ_SUCCEED_OR_RETURN(FindRedirectedSceneFile(sFinalSceneFile, sSceneFile));
+  ezStringBuilder ref_sFinalPath;
+  EZ_SUCCEED_OR_RETURN(FindRedirectedSceneFile(ref_sFinalPath, sSceneFile));
 
   ezFileReader fileReader;
 
-  if (fileReader.Open(sFinalSceneFile).Failed())
+  if (fileReader.Open(ref_sFinalPath).Failed())
     return ezStatus("Failed to open the file.");
 
   // Read and skip the asset file header
@@ -73,7 +73,7 @@ ezStatus ezSceneLoadUtility::LoadSceneImmediate(ezWorld& targetWorld, ezStringVi
   if (worldReader.ReadWorldDescription(fileReader).Failed())
     return ezStatus("Error reading world description.");
 
-  worldReader.InstantiateWorld(targetWorld, nullptr);
+  worldReader.InstantiateWorld(inout_targetWorld, nullptr);
 
   return EZ_SUCCESS;
 }
@@ -90,8 +90,8 @@ void ezSceneLoadUtility::StartSceneLoading(ezStringView sSceneFile, ezStringView
 
   m_sRequestedFile = sSceneFile;
 
-  ezStringBuilder sFinalSceneFile;
-  auto res = FindRedirectedSceneFile(sFinalSceneFile, sSceneFile);
+  ezStringBuilder ref_sFinalPath;
+  auto res = FindRedirectedSceneFile(ref_sFinalPath, sSceneFile);
 
   if (res.Failed())
   {
@@ -99,12 +99,12 @@ void ezSceneLoadUtility::StartSceneLoading(ezStringView sSceneFile, ezStringView
     return;
   }
 
-  if (sFinalSceneFile != sSceneFile)
+  if (ref_sFinalPath != sSceneFile)
   {
-    ezLog::Dev("Redirecting scene file from '{}' to '{}'", sSceneFile, sFinalSceneFile);
+    ezLog::Dev("Redirecting scene file from '{}' to '{}'", sSceneFile, ref_sFinalPath);
   }
 
-  m_sRedirectedFile = sFinalSceneFile;
+  m_sRedirectedFile = ref_sFinalPath;
 
   if (!sPreloadCollectionFile.IsEmpty())
   {

--- a/Code/Engine/GameEngine/Utils/SceneLoadUtil.h
+++ b/Code/Engine/GameEngine/Utils/SceneLoadUtil.h
@@ -20,13 +20,13 @@ public:
   ~ezSceneLoadUtility();
 
   /// Redirects a scene path to the actual binary scene file, if necessary.
-  static ezStatus FindRedirectedSceneFile(ezStringBuilder& sFinalPath, ezStringView sSceneFile);
+  static ezStatus FindRedirectedSceneFile(ezStringBuilder& ref_sFinalPath, ezStringView sSceneFile);
 
   /// Loads a scene immediately into the given target world.
   ///
   /// Doesn't clear the world beforehand.
   /// Does call FindRedirectedSceneFile() on the scene path first.
-  static ezStatus LoadSceneImmediate(ezWorld& targetWorld, ezStringView sSceneFile);
+  static ezStatus LoadSceneImmediate(ezWorld& inout_targetWorld, ezStringView sSceneFile);
 
   enum class LoadingState
   {

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -4,6 +4,7 @@
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Strings/String.h>
 #include <Foundation/Threading/Implementation/TaskSystemDeclarations.h>
+#include <Foundation/Time/Time.h>
 #include <Foundation/Types/Status.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <ToolsFoundation/CommandHistory/CommandHistory.h>
@@ -68,6 +69,10 @@ public:
 
   bool IsModified() const { return m_bModified; }
   bool IsReadOnly() const { return m_bReadOnly; }
+
+  /// Returns when the document was last marked as modified. Invalid if the document is not modified.
+  ezTime GetModifiedTime() const { return m_ModifiedTime; }
+
   const ezUuid GetGuid() const { return m_pDocumentInfo ? m_pDocumentInfo->m_DocumentID : ezUuid(); }
 
   const ezDocumentObjectManager* GetObjectManager() const { return m_pObjectManager.Borrow(); }
@@ -325,6 +330,7 @@ private:
   bool m_bReadOnly = false;
   bool m_bWindowRequested = false;
   bool m_bAddToRecentFilesList = true;
+  ezTime m_ModifiedTime;
 
   /// \brief Set of unknown object types encountered during loading.
   ezSet<ezString> m_UnknownObjectTypes;

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
@@ -101,6 +101,7 @@ void ezDocument::SetModified(bool b)
     return;
 
   m_bModified = b;
+  m_ModifiedTime = b ? ezTime::Now() : ezTime();
 
   ezDocumentEvent e;
   e.m_pDocument = this;

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: B7F2587B-843F-4A9E-8940-C055DAD3A021AAB123
+Change me: B7F2587B-843F-4A2E-8840-C055DAD3A021AAB123


### PR DESCRIPTION
By default documents are now auto-saved every 5 minutes.
This can be configured in the editor preferences. Set the value to 0 to disable auto-saving.