### PR TITLE
Removed AO Fresnel

### DIFF
--- a/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/SpotLightComponent.cpp
@@ -58,6 +58,8 @@ void ezSpotLightComponent::OnActivated()
 void ezSpotLightComponent::OnDeactivated()
 {
   DeleteCookie();
+
+  SUPER::OnDeactivated();
 }
 
 void ezSpotLightComponent::SerializeComponent(ezWorldWriter& inout_stream) const

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltVisColMeshComponent.cpp
@@ -148,6 +148,8 @@ void ezJoltVisColMeshComponent::OnDeactivated()
 {
   ezRenderDataManager* pRenderDataManager = GetWorld()->GetModule<ezRenderDataManager>();
   pRenderDataManager->DeleteInstanceData(m_InstanceDataOffset);
+
+  SUPER::OnDeactivated();
 }
 
 void ezJoltVisColMeshComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const

--- a/Data/Base/Shaders/Materials/MaterialHelper.h
+++ b/Data/Base/Shaders/Materials/MaterialHelper.h
@@ -214,13 +214,7 @@ ezMaterialData FillMaterialData()
   matData.roughness = RoughnessFromPerceptualRoughness(matData.perceptualRoughness);
 
 #if defined(USE_MATERIAL_OCCLUSION)
-#  if defined(USE_NORMAL)
-  float3 viewVector = normalize(GetCameraPosition() - matData.worldPosition);
-  float occlusionFade = saturate(dot(matData.vertexNormal, viewVector));
-#  else
-  float occlusionFade = 1.0f;
-#  endif
-  matData.occlusion = lerp(1.0f, GetOcclusion(), occlusionFade);
+  matData.occlusion = GetOcclusion();
 #else
   matData.occlusion = 1.0f;
 #endif
@@ -294,4 +288,12 @@ float4 SampleColorPalette(Texture2D paletteTex, uint row, float column)
 
   float2 uv = float2(column, (row + 0.5f) / height);
   return paletteTex.SampleLevel(LinearClampSampler, uv, 0);
+}
+
+float AOFresnel(float3 worldPosition, float3 vertexNormal, float ao, float fresnelStrength)
+{
+  float3 viewVector = normalize(GetCameraPosition() - worldPosition);
+  float occlusionFade = saturate(saturate(dot(vertexNormal, viewVector)) - fresnelStrength + 1);
+
+  return lerp(1.0f, ao, occlusionFade);
 }


### PR DESCRIPTION
Decided to remove the AO Fresnel by default. It is not that important and can lead to weird results. 
It is still available as a helper function so it can be used in the GetOcclusion function of a custom material shader.

Fixes #1715 