### PR TITLE
Various small improvements (particles, curves)

### DIFF
--- a/Code/Editor/EditorFramework/Dialogs/EditDynamicEnumsDlg.ui
+++ b/Code/Editor/EditorFramework/Dialogs/EditDynamicEnumsDlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>291</width>
-    <height>315</height>
+    <width>297</width>
+    <height>331</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,7 +28,7 @@
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -41,7 +41,7 @@
        <item>
         <widget class="QPushButton" name="ButtonAdd">
          <property name="toolTip">
-          <string>Add another folder as a data directory</string>
+          <string>Add enum string</string>
          </property>
          <property name="text">
           <string/>
@@ -55,7 +55,7 @@
        <item>
         <widget class="QPushButton" name="ButtonRemove">
          <property name="toolTip">
-          <string>Remove the selected data directory</string>
+          <string>Remove selected string</string>
          </property>
          <property name="text">
           <string/>
@@ -69,7 +69,7 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -86,7 +86,7 @@
    <item>
     <widget class="QDialogButtonBox" name="Buttons">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.cpp
@@ -2,7 +2,7 @@
 
 #include <Core/Curves/ColorGradientResource.h>
 #include <EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezColorControlPoint, 2, ezRTTIDefaultAllocator<ezColorControlPoint>)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAsset.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <EditorFramework/Assets/SimpleAssetDocument.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 
 class ezCurve1D;
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
@@ -5,8 +5,8 @@
 #include <EditorFramework/Object/ObjectPropertyPath.h>
 #include <EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h>
 #include <Foundation/Communication/Event.h>
-#include <GameEngine/Animation/PropertyAnimResource.h>
 #include <Foundation/Tracks/CurveEditData.h>
+#include <GameEngine/Animation/PropertyAnimResource.h>
 #include <GuiFoundation/Widgets/EventTrackEditData.h>
 
 struct ezGameObjectContextEvent;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAsset.h
@@ -6,7 +6,7 @@
 #include <EditorPluginAssets/ColorGradientAsset/ColorGradientAsset.h>
 #include <Foundation/Communication/Event.h>
 #include <GameEngine/Animation/PropertyAnimResource.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 #include <GuiFoundation/Widgets/EventTrackEditData.h>
 
 struct ezGameObjectContextEvent;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetWindow.moc.h
@@ -3,7 +3,7 @@
 #include <EditorFramework/DocumentWindow/GameObjectDocumentWindow.moc.h>
 #include <EditorFramework/EditTools/EditTool.h>
 #include <Foundation/Basics.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 #include <QTreeView>
 #include <ToolsFoundation/Object/DocumentObjectManager.h>
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Foundation/CodeUtils/Expression/ExpressionAST.h>
-#include <Foundation/Types/TagSet.h>
 #include <Foundation/Tracks/CurveEditData.h>
+#include <Foundation/Types/TagSet.h>
 #include <ProcGenPlugin/Resources/ProcGenGraphSharedData.h>
 #include <RendererCore/Pipeline/RenderPipelineNode.h>
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.h
@@ -2,7 +2,7 @@
 
 #include <Foundation/CodeUtils/Expression/ExpressionAST.h>
 #include <Foundation/Types/TagSet.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 #include <ProcGenPlugin/Resources/ProcGenGraphSharedData.h>
 #include <RendererCore/Pipeline/RenderPipelineNode.h>
 

--- a/Code/Engine/Foundation/Tracks/CurveEditData.h
+++ b/Code/Engine/Foundation/Tracks/CurveEditData.h
@@ -5,11 +5,10 @@
 #include <Foundation/Math/Vec2.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Tracks/Curve1D.h>
-#include <GuiFoundation/GuiFoundationDLL.h>
 
 class ezCurve1D;
 
-EZ_DECLARE_REFLECTABLE_TYPE(EZ_GUIFOUNDATION_DLL, ezCurveTangentMode);
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_FOUNDATION_DLL, ezCurveTangentMode);
 
 template <typename T>
 void FindNearestControlPoints(ezArrayPtr<T> cps, ezInt64 iTick, T*& ref_pLlhs, T*& lhs, T*& rhs, T*& ref_pRrhs)
@@ -61,7 +60,7 @@ void FindNearestControlPoints(ezArrayPtr<T> cps, ezInt64 iTick, T*& ref_pLlhs, T
   }
 }
 
-class EZ_GUIFOUNDATION_DLL ezCurveControlPointData : public ezReflectedClass
+class EZ_FOUNDATION_DLL ezCurveControlPointData : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezCurveControlPointData, ezReflectedClass);
 
@@ -78,7 +77,7 @@ public:
   ezEnum<ezCurveTangentMode> m_RightTangentMode;
 };
 
-class EZ_GUIFOUNDATION_DLL ezSingleCurveData : public ezReflectedClass
+class EZ_FOUNDATION_DLL ezSingleCurveData : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezSingleCurveData, ezReflectedClass);
 
@@ -90,7 +89,7 @@ public:
   double Evaluate(ezInt64 iTick) const;
 };
 
-class EZ_GUIFOUNDATION_DLL ezCurveExtentsAttribute : public ezPropertyAttribute
+class EZ_FOUNDATION_DLL ezCurveExtentsAttribute : public ezPropertyAttribute
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezCurveExtentsAttribute, ezPropertyAttribute);
 
@@ -105,7 +104,7 @@ public:
 };
 
 
-class EZ_GUIFOUNDATION_DLL ezCurveGroupData : public ezReflectedClass
+class EZ_FOUNDATION_DLL ezCurveGroupData : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezCurveGroupData, ezReflectedClass);
 
@@ -131,7 +130,7 @@ public:
   void ConvertToRuntimeData(ezUInt32 uiCurveIdx, ezCurve1D& out_result) const;
 };
 
-struct EZ_GUIFOUNDATION_DLL ezSelectedCurveCP
+struct EZ_FOUNDATION_DLL ezSelectedCurveCP
 {
   EZ_DECLARE_POD_TYPE();
 

--- a/Code/Engine/Foundation/Tracks/Implementation/Curve1D.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/Curve1D.cpp
@@ -79,8 +79,7 @@ ezInt32 ezCurve1D::FindApproxControlPoint(double x) const
   {
     const ezUInt32 uiMidIdx = uiLowIdx + ((uiHighIdx - uiLowIdx) >> 1); // lerp
 
-    // doesn't matter whether to use > or >=
-    if (m_LinearApproximation[uiMidIdx].x > x)
+    if (m_LinearApproximation[uiMidIdx].x >= x)
       uiHighIdx = uiMidIdx;
     else
       uiLowIdx = uiMidIdx;

--- a/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
@@ -76,8 +76,8 @@ ezCurveExtentsAttribute::ezCurveExtentsAttribute(double fLowerExtent, bool bLowe
 
 void ezCurveControlPointData::SetTickFromTime(ezTime time, ezInt64 iFps)
 {
-  const ezUInt32 uiTicksPerStep = 4800 / iFps;
-  m_iTick = (ezInt64)ezMath::RoundToMultiple(time.GetSeconds() * 4800.0, (double)uiTicksPerStep);
+  const ezInt64 iTicksPerStep = 4800 / iFps;
+  m_iTick = (ezInt64)ezMath::RoundToMultiple(time.GetSeconds() * 4800.0, (double)iTicksPerStep);
 }
 
 ezCurveGroupData::~ezCurveGroupData()
@@ -186,7 +186,7 @@ public:
   {
   }
 
-  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  virtual void Patch(ezGraphPatchContext& /*ref_context*/, ezAbstractObjectGraph* /*pGraph*/, ezAbstractObjectNode* pNode) const override
   {
     auto* pPoint = pNode->FindProperty("Point");
     if (pPoint && pPoint->m_Value.IsA<ezVec2>())
@@ -212,7 +212,7 @@ public:
   {
   }
 
-  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  virtual void Patch(ezGraphPatchContext& /*ref_context*/, ezAbstractObjectGraph* /*pGraph*/, ezAbstractObjectNode* pNode) const override
   {
     auto* pPoint = pNode->FindProperty("Time");
     if (pPoint && pPoint->m_Value.IsA<double>())
@@ -235,7 +235,7 @@ public:
   {
   }
 
-  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* /*pGraph*/, ezAbstractObjectNode* /*pNode*/) const override
   {
     ref_context.RenameClass("ezCurveControlPointData");
   }
@@ -253,7 +253,7 @@ public:
   {
   }
 
-  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* /*pGraph*/, ezAbstractObjectNode* /*pNode*/) const override
   {
     ref_context.RenameClass("ezSingleCurveData");
   }
@@ -271,7 +271,7 @@ public:
   {
   }
 
-  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* pGraph, ezAbstractObjectNode* pNode) const override
+  virtual void Patch(ezGraphPatchContext& ref_context, ezAbstractObjectGraph* /*pGraph*/, ezAbstractObjectNode* /*pNode*/) const override
   {
     ref_context.RenameClass("ezCurveGroupData");
   }

--- a/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
@@ -1,8 +1,8 @@
-#include <GuiFoundation/GuiFoundationPCH.h>
+#include <Foundation/FoundationPCH.h>
 
 #include <Foundation/Math/Math.h>
 #include <Foundation/Tracks/Curve1D.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 
 // clang-format off
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezCurveTangentMode, 1)

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Bounds.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Bounds.h
@@ -4,6 +4,9 @@
 
 class ezPhysicsWorldModuleInterface;
 
+/// Behavior that restricts particles to a box volume
+///
+/// Particles can be killed, teleported or bounced when leaving the box bounds.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_Bounds final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_Bounds, ezParticleBehaviorFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_ColorGradient.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_ColorGradient.cpp
@@ -135,8 +135,8 @@ void ezParticleBehavior_ColorGradient::Process(ezUInt64 uiNumElements)
 {
   if (!GetOwnerEffect()->IsVisible())
   {
-    // set the update interval such that once the effect becomes visible,
-    // all particles get fully updated
+    // When invisible, don't update at all. Set the interval to 1 so that once
+    // the effect becomes visible, all particles get fully updated on the next frame.
     m_uiCurrentUpdateInterval = 1;
     m_uiFirstToUpdate = 0;
     return;

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_ColorGradient.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_ColorGradient.h
@@ -3,6 +3,10 @@
 #include <Core/Curves/ColorGradientResource.h>
 #include <ParticlePlugin/Behavior/ParticleBehavior.h>
 
+/// Behavior that applies a color gradient to particles
+///
+/// The gradient can be sampled based on particle lifetime or speed.
+/// The final color is multiplied by the tint color.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_ColorGradient final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_ColorGradient, ezParticleBehaviorFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_FadeOut.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_FadeOut.cpp
@@ -63,8 +63,8 @@ void ezParticleBehavior_FadeOut::Process(ezUInt64 uiNumElements)
 {
   if (!GetOwnerEffect()->IsVisible())
   {
-    // set the update interval such that once the effect becomes visible,
-    // all particles get fully updated
+    // When invisible, don't update at all. Set the interval to 1 so that once
+    // the effect becomes visible, all particles get fully updated on the next frame.
     m_uiCurrentUpdateInterval = 1;
     m_uiFirstToUpdate = 0;
     return;

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_FadeOut.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_FadeOut.h
@@ -2,6 +2,9 @@
 
 #include <ParticlePlugin/Behavior/ParticleBehavior.h>
 
+/// Behavior that fades particle alpha over their lifetime
+///
+/// Uses a power curve to control the fade speed.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_FadeOut final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_FadeOut, ezParticleBehaviorFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Flies.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Flies.h
@@ -2,6 +2,10 @@
 
 #include <ParticlePlugin/Behavior/ParticleBehavior.h>
 
+/// Behavior that makes particles move like flies or insects
+///
+/// Particles move at a constant speed with random direction changes.
+/// They tend to stay within a certain distance from the effect origin.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_Flies final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_Flies, ezParticleBehaviorFactory);
@@ -18,10 +22,10 @@ public:
   virtual void Save(ezStreamWriter& inout_stream) const override;
   virtual void Load(ezStreamReader& inout_stream) override;
 
-  float m_fSpeed = 0.2f;
-  float m_fPathLength = 0.2f;
-  float m_fMaxEmitterDistance = 0.5f;
-  ezAngle m_MaxSteeringAngle = ezAngle::MakeFromDegree(30);
+  float m_fSpeed = 0.2f;                                    ///< Movement speed in units per second
+  float m_fPathLength = 0.2f;                               ///< Distance traveled before changing direction
+  float m_fMaxEmitterDistance = 0.5f;                       ///< Maximum distance from effect origin before turning back
+  ezAngle m_MaxSteeringAngle = ezAngle::MakeFromDegree(30); ///< Maximum angle change per direction update
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Gravity.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Gravity.h
@@ -4,6 +4,10 @@
 
 class ezPhysicsWorldModuleInterface;
 
+/// Behavior that applies gravity to particles
+///
+/// Uses the world's gravity vector from the physics module.
+/// The gravity factor scales the applied gravity force.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_Gravity final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_Gravity, ezParticleBehaviorFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_PullAlong.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_PullAlong.h
@@ -4,6 +4,10 @@
 
 class ezPhysicsWorldModuleInterface;
 
+/// Behavior that pulls particles along when the effect moves
+///
+/// Useful for effects attached to moving objects where particles should
+/// follow the movement to some degree rather than staying in world space.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_PullAlong final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_PullAlong, ezParticleBehaviorFactory);
@@ -17,7 +21,7 @@ public:
   virtual void Save(ezStreamWriter& inout_stream) const override;
   virtual void Load(ezStreamReader& inout_stream) override;
 
-  float m_fStrength;
+  float m_fStrength; ///< How much particles follow the effect movement (0-1 range)
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Raycast.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Raycast.h
@@ -5,15 +5,16 @@
 
 class ezPhysicsWorldModuleInterface;
 
+/// How particles react when hitting a physics surface
 struct EZ_PARTICLEPLUGIN_DLL ezParticleRaycastHitReaction
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    Bounce,
-    Die,
-    Stop,
+    Bounce, ///< Particle bounces off the surface
+    Die,    ///< Particle is killed on impact
+    Stop,   ///< Particle stops moving
 
     Default = Bounce
   };
@@ -21,6 +22,11 @@ struct EZ_PARTICLEPLUGIN_DLL ezParticleRaycastHitReaction
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleRaycastHitReaction);
 
+/// Behavior that performs physics raycasts to detect collisions
+///
+/// Raycasts from the particle's last position to its current position.
+/// On collision, particles can bounce, die, or stop.
+/// Optionally triggers an event on collision.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_Raycast final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_Raycast, ezParticleBehaviorFactory);
@@ -37,12 +43,12 @@ public:
   virtual void Save(ezStreamWriter& inout_stream) const override;
   virtual void Load(ezStreamReader& inout_stream) override;
 
-  ezEnum<ezParticleRaycastHitReaction> m_Reaction;
-  ezUInt8 m_uiCollisionLayer = 0;
-  ezString m_sOnCollideEvent;
-  float m_fBounceFactor = 0.5f;
-  float m_fSlideFactor = 0.5f;
-  float m_fSizeFactor = 0.1f;
+  ezEnum<ezParticleRaycastHitReaction> m_Reaction; ///< How particles react to collisions
+  ezUInt8 m_uiCollisionLayer = 0;                  ///< Physics collision layer to raycast against
+  ezString m_sOnCollideEvent;                      ///< Optional event name to raise on collision
+  float m_fBounceFactor = 0.5f;                    ///< Velocity multiplier when bouncing (energy loss)
+  float m_fSlideFactor = 0.5f;                     ///< How much particles slide along the surface
+  float m_fSizeFactor = 0.1f;                      ///< Multiplier for particle size used in raycast length
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_SizeCurve.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_SizeCurve.h
@@ -3,6 +3,10 @@
 #include <Core/Curves/Curve1DResource.h>
 #include <ParticlePlugin/Behavior/ParticleBehavior.h>
 
+/// Behavior that modifies particle size over their lifetime using a curve
+///
+/// The curve is sampled based on the particle's normalized lifetime (0-1).
+/// The final size is: base size + (curve value * curve scale).
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_SizeCurve final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_SizeCurve, ezParticleBehaviorFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Velocity.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Velocity.h
@@ -5,6 +5,10 @@
 class ezPhysicsWorldModuleInterface;
 class ezWindWorldModuleInterface;
 
+/// Behavior that applies friction and rise/fall forces to particles
+///
+/// Friction reduces particle velocity over time.
+/// Rise speed makes particles move along the inverse gravity direction.
 class EZ_PARTICLEPLUGIN_DLL ezParticleBehaviorFactory_Velocity final : public ezParticleBehaviorFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleBehaviorFactory_Velocity, ezParticleBehaviorFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Declarations.h
+++ b/Code/EnginePlugins/ParticlePlugin/Declarations.h
@@ -34,21 +34,22 @@ using ezParticleEffectResourceHandle = ezTypedResourceHandle<class ezParticleEff
 
 using ezParticleEffectId = ezGenericId<22, 10>;
 
-/// \brief A handle to a particle effect
+/// Handle to a particle effect instance
 class EZ_PARTICLEPLUGIN_DLL ezParticleEffectHandle
 {
   EZ_DECLARE_HANDLE_TYPE(ezParticleEffectHandle, ezParticleEffectId);
 };
 
 
+/// Current state of a particle system
 struct EZ_PARTICLEPLUGIN_DLL ezParticleSystemState
 {
   enum Enum
   {
-    Active,
-    EmittersFinished,
-    OnlyReacting,
-    Inactive,
+    Active,           ///< System is actively emitting and processing particles
+    EmittersFinished, ///< Emitters stopped, particles still alive
+    OnlyReacting,     ///< Only reacting to events, otherwise finished
+    Inactive,         ///< System is inactive
   };
 };
 
@@ -72,6 +73,7 @@ private:
 
 //////////////////////////////////////////////////////////////////////////
 
+/// Blending mode for particle rendering
 struct EZ_PARTICLEPLUGIN_DLL ezParticleTypeRenderMode
 {
   using StorageType = ezUInt8;
@@ -93,14 +95,15 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleTypeRenderMode);
 
 //////////////////////////////////////////////////////////////////////////
 
+/// Lighting mode for particles
 struct EZ_PARTICLEPLUGIN_DLL ezParticleLightingMode
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    Fullbright,
-    VertexLit,
+    Fullbright, ///< No lighting applied
+    VertexLit,  ///< Simple vertex lighting
     Default = Fullbright
   };
 };
@@ -109,19 +112,19 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleLightingMode);
 
 //////////////////////////////////////////////////////////////////////////
 
-/// \brief What to do when an effect is not visible.
+/// Update rate for effects that are not visible
 struct EZ_PARTICLEPLUGIN_DLL ezEffectInvisibleUpdateRate
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    FullUpdate,
-    Max20fps,
-    Max10fps,
-    Max5fps,
-    Pause,
-    Discard,
+    FullUpdate, ///< Continue updating at full rate
+    Max20fps,   ///< Update at most 20 times per second
+    Max10fps,   ///< Update at most 10 times per second
+    Max5fps,    ///< Update at most 5 times per second
+    Pause,      ///< Pause simulation completely
+    Discard,    ///< Delete the effect
 
     Default = Max10fps
   };
@@ -131,17 +134,18 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezEffectInvisibleUpdateRate);
 
 //////////////////////////////////////////////////////////////////////////
 
+/// How to use texture atlas for particle sprites
 struct EZ_PARTICLEPLUGIN_DLL ezParticleTextureAtlasType
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    None,
+    None,              ///< No atlas, use full texture
 
-    RandomVariations,
-    FlipbookAnimation,
-    RandomYAnimatedX,
+    RandomVariations,  ///< Pick random tile for variation
+    FlipbookAnimation, ///< Animate through tiles over lifetime
+    RandomYAnimatedX,  ///< Random Y row, animate X over lifetime
 
     Default = None
   };
@@ -151,14 +155,15 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleTextureAtlasType);
 
 //////////////////////////////////////////////////////////////////////////
 
+/// How to sample color gradients for particles
 struct EZ_PARTICLEPLUGIN_DLL ezParticleColorGradientMode
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    Age,
-    Speed,
+    Age,   ///< Sample based on normalized particle lifetime (0-1)
+    Speed, ///< Sample based on particle speed
 
     Default = Age
   };
@@ -169,14 +174,15 @@ EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezParticleColorGradientMode);
 
 //////////////////////////////////////////////////////////////////////////
 
+/// Action when particles leave bounds
 struct EZ_PARTICLEPLUGIN_DLL ezParticleOutOfBoundsMode
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    Teleport,
-    Die,
+    Teleport, ///< Wrap particle to opposite side
+    Die,      ///< Kill the particle
 
     Default = Teleport
   };

--- a/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter.h
+++ b/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter.h
@@ -9,7 +9,7 @@ class ezParticleSystemInstance;
 class ezProcessingStream;
 class ezParticleEmitter;
 
-/// \brief Base class for all particle emitters
+/// Base class for all particle emitters
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitterFactory : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEmitterFactory, ezReflectedClass);
@@ -25,15 +25,17 @@ public:
   virtual void Load(ezStreamReader& inout_stream) = 0;
 };
 
+/// Current state of a particle emitter
 enum class ezParticleEmitterState
 {
-  Active,
-  Finished,
-  OnlyReacting, //< Doesn't do anything, unless there are events that trigger it. That means it is considered finished, when all other emitters are
-                // finished.
+  Active,       ///< Emitter is actively spawning particles
+  Finished,     ///< Emitter will not spawn more particles
+  OnlyReacting, ///< Only spawns on events, considered finished when other emitters finish
 };
 
-/// \brief Base class for stream spawners that are used by ezParticleEmitter's
+/// Base class for particle emitters
+///
+/// Emitters control when and how many particles are spawned.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitter : public ezParticleModule
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEmitter, ezParticleModule);
@@ -45,10 +47,10 @@ protected:
   virtual bool IsContinuous() const;
   virtual void Process(ezUInt64 uiNumElements) final override;
 
-  /// \brief Called once per update. Must return how many new particles are to be spawned.
+  /// Called once per update. Must return how many new particles to spawn.
   virtual ezUInt32 ComputeSpawnCount(const ezTime& tDiff) = 0;
 
-  /// \brief Called before ComputeSpawnCount(). Should return true, if the emitter will never spawn any more particles.
+  /// Called before ComputeSpawnCount(). Returns whether the emitter will spawn more particles.
   virtual ezParticleEmitterState IsFinished() = 0;
 
   virtual void ProcessEventQueue(ezParticleEventQueue queue);

--- a/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_Burst.h
+++ b/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_Burst.h
@@ -3,6 +3,10 @@
 #include <Foundation/Types/VarianceTypes.h>
 #include <ParticlePlugin/Emitter/ParticleEmitter.h>
 
+/// Emitter that spawns a burst of particles over a short duration
+///
+/// Spawns all particles distributed over the duration time.
+/// After the burst completes, the emitter becomes inactive.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitterFactory_Burst final : public ezParticleEmitterFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEmitterFactory_Burst, ezParticleEmitterFactory);
@@ -18,12 +22,12 @@ public:
   virtual void Load(ezStreamReader& inout_stream) override;
 
 public:
-  ezTime m_Duration;
-  ezTime m_StartDelay;
+  ezTime m_Duration;                    ///< Duration over which to distribute the burst (0 = single frame)
+  ezTime m_StartDelay;                  ///< Delay before burst starts
 
-  ezUInt32 m_uiSpawnCountMin;
-  ezUInt32 m_uiSpawnCountRange;
-  ezString m_sSpawnCountScaleParameter;
+  ezUInt32 m_uiSpawnCountMin;           ///< Minimum number of particles to spawn
+  ezUInt32 m_uiSpawnCountRange;         ///< Random range added to spawn count
+  ezString m_sSpawnCountScaleParameter; ///< Optional parameter to scale spawn count
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_Continuous.h
+++ b/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_Continuous.h
@@ -6,6 +6,10 @@
 
 using ezCurve1DResourceHandle = ezTypedResourceHandle<class ezCurve1DResource>;
 
+/// Emitter that continuously spawns particles over time
+///
+/// Spawn rate can be constant or modulated by a curve.
+/// Continues emitting until the effect is stopped.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitterFactory_Continuous final : public ezParticleEmitterFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEmitterFactory_Continuous, ezParticleEmitterFactory);
@@ -21,14 +25,14 @@ public:
   virtual void Load(ezStreamReader& inout_stream) override;
 
 public:
-  ezTime m_StartDelay;
+  ezTime m_StartDelay;                   ///< Delay before emission starts
 
-  ezUInt32 m_uiSpawnCountPerSec;
-  ezUInt32 m_uiSpawnCountPerSecRange;
-  ezString m_sSpawnCountScaleParameter;
+  ezUInt32 m_uiSpawnCountPerSec;         ///< Base spawn rate per second
+  ezUInt32 m_uiSpawnCountPerSecRange;    ///< Random range added to spawn rate
+  ezString m_sSpawnCountScaleParameter;  ///< Optional parameter to scale spawn rate
 
-  ezCurve1DResourceHandle m_hCountCurve;
-  ezTime m_CurveDuration;
+  ezCurve1DResourceHandle m_hCountCurve; ///< Optional curve to modulate spawn rate
+  ezTime m_CurveDuration;                ///< Duration for curve evaluation
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_Distance.h
+++ b/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_Distance.h
@@ -3,6 +3,10 @@
 #include <Foundation/Types/VarianceTypes.h>
 #include <ParticlePlugin/Emitter/ParticleEmitter.h>
 
+/// Emitter that spawns particles based on distance traveled
+///
+/// Spawns particles when the effect moves a certain distance from the last spawn position.
+/// Useful for creating trails or footstep effects.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitterFactory_Distance final : public ezParticleEmitterFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEmitterFactory_Distance, ezParticleEmitterFactory);
@@ -18,10 +22,10 @@ public:
   virtual void Load(ezStreamReader& inout_stream) override;
 
 public:
-  float m_fDistanceThreshold = 0.1f;
-  ezUInt32 m_uiSpawnCountMin = 1;
-  ezUInt32 m_uiSpawnCountRange = 0;
-  ezString m_sSpawnCountScaleParameter;
+  float m_fDistanceThreshold = 0.1f;    ///< Distance that must be traveled before spawning
+  ezUInt32 m_uiSpawnCountMin = 1;       ///< Minimum particles per spawn
+  ezUInt32 m_uiSpawnCountRange = 0;     ///< Random range added to spawn count
+  ezString m_sSpawnCountScaleParameter; ///< Optional parameter to scale spawn count
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_OnEvent.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_OnEvent.cpp
@@ -14,7 +14,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEmitterFactory_OnEvent, 1, ezRTTIDefau
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("EventName", m_sEventName),
+    EZ_MEMBER_PROPERTY("EventName", m_sEventName)->AddAttributes(new ezDynamicStringEnumAttribute("ParticleEventNamesEnum")),
     EZ_MEMBER_PROPERTY("MinSpawnCount", m_uiSpawnCountMin)->AddAttributes(new ezDefaultValueAttribute(1)),
     EZ_MEMBER_PROPERTY("SpawnCountRange", m_uiSpawnCountRange),
     EZ_MEMBER_PROPERTY("SpawnCountScaleParam", m_sSpawnCountScaleParameter),

--- a/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_OnEvent.h
+++ b/Code/EnginePlugins/ParticlePlugin/Emitter/ParticleEmitter_OnEvent.h
@@ -5,6 +5,10 @@
 #include <ParticlePlugin/Emitter/ParticleEmitter.h>
 #include <ParticlePlugin/Events/ParticleEvent.h>
 
+/// Emitter that spawns particles in response to events
+///
+/// Only spawns when the specified event is raised.
+/// Useful for creating impact effects or other event-driven particles.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitterFactory_OnEvent final : public ezParticleEmitterFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEmitterFactory_OnEvent, ezParticleEmitterFactory);
@@ -20,10 +24,10 @@ public:
   virtual void Save(ezStreamWriter& inout_stream) const override;
   virtual void Load(ezStreamReader& inout_stream) override;
 
-  ezString m_sEventName;
-  ezUInt32 m_uiSpawnCountMin = 1;
-  ezUInt32 m_uiSpawnCountRange = 0;
-  ezString m_sSpawnCountScaleParameter;
+  ezString m_sEventName;                ///< Name of the event that triggers emission
+  ezUInt32 m_uiSpawnCountMin = 1;       ///< Minimum particles per event
+  ezUInt32 m_uiSpawnCountRange = 0;     ///< Random range added to spawn count
+  ezString m_sSpawnCountScaleParameter; ///< Optional parameter to scale spawn count
 };
 
 class EZ_PARTICLEPLUGIN_DLL ezParticleEmitter_OnEvent final : public ezParticleEmitter

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEvent.h
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEvent.h
@@ -5,14 +5,19 @@
 #include <Foundation/Types/ArrayPtr.h>
 #include <ParticlePlugin/ParticlePluginDLL.h>
 
+/// Represents an event triggered by a particle system.
+///
+/// Particle events are raised during a particle's lifetime (e.g., on death, collision)
+/// and can trigger reactions like spawning effects or prefabs.
 struct EZ_PARTICLEPLUGIN_DLL ezParticleEvent
 {
   EZ_DECLARE_POD_TYPE();
 
-  ezTempHashedString m_EventType;
-  ezVec3 m_vPosition;
-  ezVec3 m_vDirection;
-  ezVec3 m_vNormal;
+  ezTempHashedString m_EventType; ///< The type identifier for this event (e.g., "death", "collision")
+  ezVec3 m_vPosition;             ///< World-space position where the event occurred
+  ezVec3 m_vDirection;            ///< Direction vector associated with the event (e.g., movement direction)
+  ezVec3 m_vNormal;               ///< Surface normal at the event location (relevant for collision events)
 };
 
+/// Queue of particle events to be processed.
 using ezParticleEventQueue = ezArrayPtr<ezParticleEvent>;

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction.cpp
@@ -7,7 +7,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleEventReactionFactory, 1, ezRTTINoAlloc
 {
   EZ_BEGIN_PROPERTIES
   {
-    EZ_MEMBER_PROPERTY("EventType", m_sEventType),
+    EZ_MEMBER_PROPERTY("EventType", m_sEventType)->AddAttributes(new ezDynamicStringEnumAttribute("ParticleEventNamesEnum")),
     EZ_MEMBER_PROPERTY("Probability", m_uiProbability)->AddAttributes(new ezDefaultValueAttribute(100), new ezClampValueAttribute(1, 100)),
   }
   EZ_END_PROPERTIES;

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction.h
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction.h
@@ -7,7 +7,10 @@
 class ezParticleEffectInstance;
 class ezParticleEventReaction;
 
-/// \brief Base class for all particle event reactions
+/// \brief Base class for all particle event reaction factories
+///
+/// Event reaction factories create and configure event reactions that respond to particle events.
+/// Each factory specifies which event type to respond to and the probability of triggering.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEventReactionFactory : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEventReactionFactory, ezReflectedClass);
@@ -16,15 +19,20 @@ public:
   virtual const ezRTTI* GetEventReactionType() const = 0;
   virtual void CopyReactionProperties(ezParticleEventReaction* pObject, bool bFirstTime) const = 0;
 
+  /// Creates and initializes a new event reaction instance for the given effect.
   ezParticleEventReaction* CreateEventReaction(ezParticleEffectInstance* pOwner) const;
 
   virtual void Save(ezStreamWriter& inout_stream) const;
   virtual void Load(ezStreamReader& inout_stream);
 
-  ezString m_sEventType;
-  ezUInt8 m_uiProbability = 100;
+  ezString m_sEventType;         ///< The type of particle event this reaction responds to
+  ezUInt8 m_uiProbability = 100; ///< Probability (1-100) that this reaction triggers when the event occurs
 };
 
+/// Base class for all particle event reactions.
+///
+/// Event reactions respond to particle events by performing actions like spawning effects or prefabs.
+/// Reactions are checked probabilistically - they may not trigger every time an event occurs.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEventReaction : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEventReaction, ezReflectedClass);
@@ -36,11 +44,15 @@ protected:
   ezParticleEventReaction();
   ~ezParticleEventReaction();
 
+  /// Initializes the reaction with a reference to the owning effect instance.
   void Reset(ezParticleEffectInstance* pOwner);
 
+  /// Called when a matching event occurs and the probability check passes.
+  ///
+  /// Derived classes implement the actual reaction behavior (e.g., spawning an effect).
   virtual void ProcessEvent(const ezParticleEvent& e) = 0;
 
-  ezTempHashedString m_sEventName;
-  ezUInt8 m_uiProbability;
-  ezParticleEffectInstance* m_pOwnerEffect = nullptr;
+  ezTempHashedString m_sEventName;                    ///< Hashed event type name for fast comparison
+  ezUInt8 m_uiProbability;                            ///< Probability value (1-100) for triggering this reaction
+  ezParticleEffectInstance* m_pOwnerEffect = nullptr; ///< The effect instance that owns this reaction
 };

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Effect.h
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Effect.h
@@ -5,6 +5,9 @@
 #include <Foundation/Types/SharedPtr.h>
 #include <ParticlePlugin/Events/ParticleEventReaction.h>
 
+/// Factory for creating effect spawn reactions.
+///
+/// Configures reactions that spawn a particle effect at the event location.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEventReactionFactory_Effect final : public ezParticleEventReactionFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEventReactionFactory_Effect, ezParticleEventReactionFactory);
@@ -33,6 +36,10 @@ private:
   ezSharedPtr<ezParticleEffectParameters> m_pParameters;
 };
 
+/// Event reaction that spawns a particle effect.
+///
+/// When triggered, spawns the configured effect at the event's position and orientation.
+/// The effect can be aligned according to the event's direction and normal vectors.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEventReaction_Effect final : public ezParticleEventReaction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEventReaction_Effect, ezParticleEventReaction);

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.h
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.h
@@ -6,6 +6,9 @@
 
 using ezPrefabResourceHandle = ezTypedResourceHandle<class ezPrefabResource>;
 
+/// Factory for creating prefab spawn reactions.
+///
+/// Configures reactions that instantiate a prefab at the event location.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEventReactionFactory_Prefab final : public ezParticleEventReactionFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEventReactionFactory_Prefab, ezParticleEventReactionFactory);
@@ -34,6 +37,10 @@ private:
   // ezSharedPtr<ezParticlePrefabParameters> m_Parameters;
 };
 
+/// Event reaction that instantiates a prefab.
+///
+/// When triggered, spawns the configured prefab at the event's position and orientation.
+/// The prefab can be aligned according to the event's direction and normal vectors.
 class EZ_PARTICLEPLUGIN_DLL ezParticleEventReaction_Prefab final : public ezParticleEventReaction
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleEventReaction_Prefab, ezParticleEventReaction);

--- a/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer.h
@@ -9,7 +9,10 @@ class ezProcessingStream;
 class ezParticleSystemInstance;
 class ezParticleFinalizer;
 
-/// \brief Base class for all particle Finalizers
+/// Factory class for creating particle finalizer instances.
+///
+/// Finalizer factories hold the configuration properties and create the corresponding
+/// finalizer instances when a particle system is instantiated.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizerFactory : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizerFactory, ezReflectedClass);
@@ -21,6 +24,12 @@ public:
   ezParticleFinalizer* CreateFinalizer(ezParticleSystemInstance* pOwner) const;
 };
 
+/// Base class for particle finalizers.
+///
+/// Finalizers run at the end of each simulation frame to update particle state or
+/// perform cleanup operations. They execute after all behaviors have been processed.
+/// Examples include updating particle age, applying velocity to position, or computing
+/// bounding volumes.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizer : public ezParticleModule
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizer, ezParticleModule);
@@ -32,5 +41,6 @@ protected:
   virtual void InitializeElements(ezUInt64 uiStartIndex, ezUInt64 uiNumElements) override {}
   virtual void StepParticleSystem(const ezTime& tDiff, ezUInt32 uiNumNewParticles) { m_TimeDiff = tDiff; }
 
+  /// Time delta for the current simulation step.
   ezTime m_TimeDiff;
 };

--- a/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_Age.h
+++ b/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_Age.h
@@ -5,6 +5,7 @@
 
 class ezPhysicsWorldModuleInterface;
 
+/// Factory for age finalizers.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizerFactory_Age final : public ezParticleFinalizerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizerFactory_Age, ezParticleFinalizerFactory);
@@ -21,6 +22,12 @@ public:
 };
 
 
+/// Updates particle age and removes particles that have exceeded their lifetime.
+///
+/// Each frame, the remaining lifetime is decreased by the time delta. When a particle's
+/// lifetime reaches zero, it is removed from the system. If an on-death event is configured,
+/// the event is triggered at the particle's position with its velocity as the direction.
+/// The lifetime is initialized with optional variance and can be scaled by an effect parameter.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizer_Age final : public ezParticleFinalizer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizer_Age, ezParticleFinalizer);

--- a/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_ApplyVelocity.h
+++ b/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_ApplyVelocity.h
@@ -2,6 +2,7 @@
 
 #include <ParticlePlugin/Finalizer/ParticleFinalizer.h>
 
+/// Factory for apply velocity finalizers.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizerFactory_ApplyVelocity final : public ezParticleFinalizerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizerFactory_ApplyVelocity, ezParticleFinalizerFactory);
@@ -14,6 +15,11 @@ public:
 };
 
 
+/// Integrates particle velocity into position each frame.
+///
+/// Updates particle positions by adding velocity * time_delta. The velocity is stored as
+/// a direction vector (xyz) and speed scalar (w). This finalizer has a slightly higher
+/// priority (525) to run after most other finalizers.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizer_ApplyVelocity final : public ezParticleFinalizer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizer_ApplyVelocity, ezParticleFinalizer);

--- a/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_LastPosition.h
+++ b/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_LastPosition.h
@@ -2,6 +2,7 @@
 
 #include <ParticlePlugin/Finalizer/ParticleFinalizer.h>
 
+/// Factory for last position finalizers.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizerFactory_LastPosition final : public ezParticleFinalizerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizerFactory_LastPosition, ezParticleFinalizerFactory);
@@ -14,6 +15,12 @@ public:
 };
 
 
+/// Records the previous frame's particle position for motion-based effects.
+///
+/// Copies the current position to the last position stream each frame. This data is used
+/// by renderers to create motion blur trails or stretched particles. The finalizer has a
+/// very low priority (-499) to run early in the frame, after initializers but before
+/// most other processing.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizer_LastPosition final : public ezParticleFinalizer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizer_LastPosition, ezParticleFinalizer);

--- a/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_Volume.h
+++ b/Code/EnginePlugins/ParticlePlugin/Finalizer/ParticleFinalizer_Volume.h
@@ -5,6 +5,7 @@
 
 class ezPhysicsWorldModuleInterface;
 
+/// Factory for volume finalizers.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizerFactory_Volume final : public ezParticleFinalizerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizerFactory_Volume, ezParticleFinalizerFactory);
@@ -18,6 +19,11 @@ public:
 };
 
 
+/// Computes the bounding volume for the entire particle system.
+///
+/// Calculates a bounding box-sphere from all particle positions and optionally considers
+/// particle sizes to determine the maximum extent. The computed volume is used for culling
+/// and rendering optimizations. If no particles exist, the process is skipped.
 class EZ_PARTICLEPLUGIN_DLL ezParticleFinalizer_Volume final : public ezParticleFinalizer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleFinalizer_Volume, ezParticleFinalizer);

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer.h
@@ -11,7 +11,7 @@ class ezProcessingStream;
 class ezParticleInitializer;
 class ezParticleEffectInstance;
 
-/// \brief Base class for all particle emitters
+/// Base class for all particle initializers
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory, ezReflectedClass);
@@ -29,7 +29,10 @@ public:
   virtual void QueryFinalizerDependencies(ezSet<const ezRTTI*>& inout_finalizerDeps) const {}
 };
 
-/// \brief Base class for stream spawners that are used by ezParticleEmitter's
+/// Base class for particle initializers
+///
+/// Initializers set the initial values of newly spawned particles.
+/// They are executed once per particle when it is created.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializer : public ezParticleModule
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializer, ezParticleModule);

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_BoxPosition.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_BoxPosition.h
@@ -2,6 +2,7 @@
 
 #include <ParticlePlugin/Initializer/ParticleInitializer.h>
 
+/// Initializer that spawns particles in a box volume
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_BoxPosition final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_BoxPosition, ezParticleInitializerFactory);
@@ -17,11 +18,11 @@ public:
   virtual void Load(ezStreamReader& inout_stream) override;
 
 public:
-  ezVec3 m_vPositionOffset;
-  ezVec3 m_vSize;
-  ezString m_sScaleXParameter;
-  ezString m_sScaleYParameter;
-  ezString m_sScaleZParameter;
+  ezVec3 m_vPositionOffset;    ///< Center of the spawn box
+  ezVec3 m_vSize;              ///< Size of the spawn box (full size, not half extents)
+  ezString m_sScaleXParameter; ///< Optional parameter name to scale box width
+  ezString m_sScaleYParameter; ///< Optional parameter name to scale box depth
+  ezString m_sScaleZParameter; ///< Optional parameter name to scale box height
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_CylinderPosition.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_CylinderPosition.h
@@ -3,6 +3,10 @@
 #include <Foundation/Types/VarianceTypes.h>
 #include <ParticlePlugin/Initializer/ParticleInitializer.h>
 
+/// Initializer that spawns particles in a cylinder volume
+///
+/// Can spawn throughout the volume or only on the surface.
+/// Optionally sets initial velocity pointing outward from the cylinder axis.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_CylinderPosition final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_CylinderPosition, ezParticleInitializerFactory);
@@ -20,14 +24,14 @@ public:
   virtual void QueryFinalizerDependencies(ezSet<const ezRTTI*>& inout_finalizerDeps) const override;
 
 public:
-  ezVec3 m_vPositionOffset;
-  float m_fRadius;
-  float m_fHeight;
-  bool m_bSpawnOnSurface;
-  bool m_bSetVelocity;
-  ezVarianceTypeFloat m_Speed;
-  ezString m_sScaleRadiusParameter;
-  ezString m_sScaleHeightParameter;
+  ezVec3 m_vPositionOffset;         ///< Center of the cylinder
+  float m_fRadius;                  ///< Cylinder radius
+  float m_fHeight;                  ///< Cylinder height
+  bool m_bSpawnOnSurface;           ///< If true, spawn only on cylinder surface
+  bool m_bSetVelocity;              ///< If true, set velocity pointing outward from axis
+  ezVarianceTypeFloat m_Speed;      ///< Speed value when setting velocity
+  ezString m_sScaleRadiusParameter; ///< Optional parameter name to scale radius
+  ezString m_sScaleHeightParameter; ///< Optional parameter name to scale height
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomColor.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomColor.h
@@ -5,6 +5,9 @@
 
 using ezColorGradientResourceHandle = ezTypedResourceHandle<class ezColorGradientResource>;
 
+/// Initializer that sets random particle colors
+///
+/// Colors are picked randomly between Color1 and Color2, or sampled from a gradient.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_RandomColor final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_RandomColor, ezParticleInitializerFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomRotationSpeed.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomRotationSpeed.h
@@ -6,6 +6,9 @@
 
 using ezCurve1DResourceHandle = ezTypedResourceHandle<class ezCurve1DResource>;
 
+/// Initializer that sets random particle rotation speeds
+///
+/// Optionally also sets a random starting rotation angle.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_RandomRotationSpeed final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_RandomRotationSpeed, ezParticleInitializerFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomSize.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_RandomSize.h
@@ -6,6 +6,9 @@
 
 using ezCurve1DResourceHandle = ezTypedResourceHandle<class ezCurve1DResource>;
 
+/// Initializer that sets random particle sizes
+///
+/// Sizes can be picked from a variance value or sampled from a curve.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_RandomSize final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_RandomSize, ezParticleInitializerFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_SpherePosition.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_SpherePosition.h
@@ -3,6 +3,10 @@
 #include <Foundation/Types/VarianceTypes.h>
 #include <ParticlePlugin/Initializer/ParticleInitializer.h>
 
+/// Initializer that spawns particles in a sphere volume
+///
+/// Can spawn throughout the volume or only on the surface.
+/// Optionally sets initial velocity pointing outward from the center.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_SpherePosition final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_SpherePosition, ezParticleInitializerFactory);
@@ -20,12 +24,12 @@ public:
   virtual void QueryFinalizerDependencies(ezSet<const ezRTTI*>& inout_finalizerDeps) const override;
 
 public:
-  ezVec3 m_vPositionOffset;
-  float m_fRadius;
-  bool m_bSpawnOnSurface;
-  bool m_bSetVelocity;
-  ezVarianceTypeFloat m_Speed;
-  ezString m_sScaleRadiusParameter;
+  ezVec3 m_vPositionOffset;         ///< Center of the sphere
+  float m_fRadius;                  ///< Sphere radius
+  bool m_bSpawnOnSurface;           ///< If true, spawn only on sphere surface
+  bool m_bSetVelocity;              ///< If true, set velocity pointing outward from center
+  ezVarianceTypeFloat m_Speed;      ///< Speed value when setting velocity
+  ezString m_sScaleRadiusParameter; ///< Optional parameter name to scale radius
 };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_VelocityCone.h
+++ b/Code/EnginePlugins/ParticlePlugin/Initializer/ParticleInitializer_VelocityCone.h
@@ -3,6 +3,9 @@
 #include <Foundation/Types/VarianceTypes.h>
 #include <ParticlePlugin/Initializer/ParticleInitializer.h>
 
+/// Initializer that sets particle velocity within a cone
+///
+/// Velocities point along the local Z-axis with random deviation within the cone angle.
 class EZ_PARTICLEPLUGIN_DLL ezParticleInitializerFactory_VelocityCone final : public ezParticleInitializerFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleInitializerFactory_VelocityCone, ezParticleInitializerFactory);

--- a/Code/EnginePlugins/ParticlePlugin/Module/ParticleModule.h
+++ b/Code/EnginePlugins/ParticlePlugin/Module/ParticleModule.h
@@ -8,6 +8,10 @@
 
 class ezProcessingStream;
 
+/// Base class for all particle system modules
+///
+/// Modules process particle data through streams.
+/// Derived types include emitters, initializers, behaviors, and finalizers.
 class EZ_PARTICLEPLUGIN_DLL ezParticleModule : public ezProcessingStreamProcessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleModule, ezProcessingStreamProcessor);
@@ -26,7 +30,7 @@ public:
     OnReset();
   }
 
-  /// \brief Called after everything is set up.
+  /// Called after everything is set up.
   virtual void OnFinalize() {}
 
   ezParticleSystemInstance* GetOwnerSystem() { return m_pOwnerSystem; }
@@ -35,11 +39,13 @@ public:
 
   ezParticleEffectInstance* GetOwnerEffect() const { return m_pOwnerSystem->GetOwnerEffect(); }
 
-  /// \brief Override this to cache world module pointers for later (through ezParticleWorldModule::GetCachedWorldModule()).
+  /// Override this to cache world module pointers for later access.
+  ///
+  /// Cached modules can be retrieved via ezParticleWorldModule::GetCachedWorldModule().
   virtual void RequestRequiredWorldModulesForCache(ezParticleWorldModule* pParticleModule) {}
 
 protected:
-  /// \brief Called by Reset()
+  /// Called by Reset() to perform custom cleanup
   virtual void OnReset() {}
 
   void CreateStream(const char* szName, ezProcessingStream::DataType Type, ezProcessingStream** ppStream, bool bWillInitializeStream)

--- a/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Renderer/ParticleRenderer.h
@@ -13,6 +13,9 @@ class ezGALBufferPool;
 class ezRenderContext;
 
 /// \brief Implements rendering of particle systems
+///
+/// Base class for all particle renderers. Provides common functionality for uploading
+/// particle data to the GPU and binding shaders with particle system constants.
 class EZ_PARTICLEPLUGIN_DLL ezParticleRenderer : public ezRenderer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleRenderer, ezRenderer);
@@ -25,20 +28,31 @@ public:
   virtual void GetSupportedRenderDataCategories(ezHybridArray<ezRenderData::Category, 8>& ref_categories) const override;
 
 protected:
+  /// Helper for managing per-particle-system constant buffer data during rendering.
+  ///
+  /// Automatically binds the constant buffer on construction and unbinds on destruction.
+  /// Provides methods to fill in system-specific rendering parameters.
   struct TempSystemCB
   {
     TempSystemCB(ezRenderContext* pRenderContext);
     ~TempSystemCB();
 
     void SetGenericData(const ezTransform& objectTransform, ezTime effectLifeTime, ezUInt8 uiNumVariationsX, ezUInt8 uiNumVariationsY, ezUInt8 uiNumFlipbookAnimsX, ezUInt8 uiNumFlipbookAnimsY, float fDistortionStrength = 0, float fNormalCurvature = 0, float fLightDirectionality = 0);
+
+    /// Sets trail-specific rendering parameters.
     void SetTrailData(float fSnapshotFraction, ezInt32 iNumUsedTrailPoints);
 
     ezConstantBufferStorage<ezParticleSystemConstants>* m_pConstants;
     ezConstantBufferStorageHandle m_hConstantBuffer;
   };
 
+  /// Allocates a GPU buffer from the pool for uploading particle data.
   void CreateParticleDataBuffer(ezGALBufferPool& inout_Buffer, ezUInt32 uiDataTypeSize, ezUInt32 uiNumParticlesPerBatch);
+
+  /// Returns a particle data buffer to the pool.
   void DestroyParticleDataBuffer(ezGALBufferPool& inout_Buffer);
+
+  /// Loads and binds the specified particle shader for rendering.
   void BindParticleShader(ezRenderContext* pRenderContext, const char* szShader) const;
 
 protected:

--- a/Code/EnginePlugins/ParticlePlugin/Resources/ParticleEffectResource.h
+++ b/Code/EnginePlugins/ParticlePlugin/Resources/ParticleEffectResource.h
@@ -6,6 +6,9 @@
 
 using ezParticleEffectResourceHandle = ezTypedResourceHandle<class ezParticleEffectResource>;
 
+/// Descriptor for particle effect resources
+///
+/// Contains the particle effect configuration data.
 struct EZ_PARTICLEPLUGIN_DLL ezParticleEffectResourceDescriptor
 {
   virtual void Save(ezStreamWriter& inout_stream) const;

--- a/Code/EnginePlugins/ParticlePlugin/Streams/DefaultParticleStreams.h
+++ b/Code/EnginePlugins/ParticlePlugin/Streams/DefaultParticleStreams.h
@@ -6,6 +6,10 @@
 // ZERO-INIT STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Stream that initializes particle data to zero.
+///
+/// Uses the base class implementation which zero-fills all elements.
+/// This stream type is used for data that should start at zero without custom initialization.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_ZeroInit final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_ZeroInit, ezParticleStream);
@@ -19,6 +23,7 @@ protected:
 // POSITION STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating position streams (Float4 data type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_Position final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_Position, ezParticleStreamFactory);
@@ -27,6 +32,10 @@ public:
   ezParticleStreamFactory_Position();
 };
 
+/// Stream storing particle positions.
+///
+/// Initializes new particles at the particle system's transform position.
+/// Stores positions as ezVec4 (Float4 stream type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_Position final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_Position, ezParticleStream);
@@ -42,6 +51,7 @@ protected:
 // SIZE STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating size streams (Half data type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_Size final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_Size, ezParticleStreamFactory);
@@ -50,6 +60,10 @@ public:
   ezParticleStreamFactory_Size();
 };
 
+/// Stream storing particle sizes.
+///
+/// Initializes new particles with size 1.0.
+/// Uses half-precision floats to reduce memory usage.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_Size final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_Size, ezParticleStream);
@@ -62,6 +76,7 @@ protected:
 // COLOR STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating color streams (Half4 data type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_Color final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_Color, ezParticleStreamFactory);
@@ -70,6 +85,10 @@ public:
   ezParticleStreamFactory_Color();
 };
 
+/// Stream storing particle colors.
+///
+/// Initializes new particles with white color (1, 1, 1, 1).
+/// Uses half-precision floats (ezColorLinear16f) to reduce memory usage.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_Color final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_Color, ezParticleStream);
@@ -82,6 +101,7 @@ protected:
 // VELOCITY STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating velocity streams (Half4 data type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_Velocity final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_Velocity, ezParticleStreamFactory);
@@ -90,6 +110,11 @@ public:
   ezParticleStreamFactory_Velocity();
 };
 
+/// Stream storing particle velocities.
+///
+/// Initializes new particles with the particle system's start velocity.
+/// Stores velocity as direction (xyz) and speed (w) in an ezVec4 using half-precision floats.
+/// If the start velocity is zero, defaults to direction (0, 0, 1) with speed 0.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_Velocity final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_Velocity, ezParticleStream);
@@ -111,6 +136,9 @@ protected:
 // LAST POSITION STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating last position streams (Float3 data type).
+///
+/// Used for trail rendering and motion blur effects to track the previous frame's particle positions.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_LastPosition final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_LastPosition, ezParticleStreamFactory);
@@ -123,6 +151,9 @@ public:
 // ROTATION SPEED STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating rotation speed streams (Half data type).
+///
+/// Stores the angular velocity for rotating billboard particles.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_RotationSpeed final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_RotationSpeed, ezParticleStreamFactory);
@@ -135,6 +166,9 @@ public:
 // ROTATION OFFSET STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating rotation offset streams (Half data type).
+///
+/// Stores the initial rotation angle offset for particles.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_RotationOffset final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_RotationOffset, ezParticleStreamFactory);
@@ -147,6 +181,9 @@ public:
 // EFFECT ID STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating effect ID streams (Int data type).
+///
+/// Used to track which effect instance spawned a particle, useful for event reactions and debugging.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_EffectID final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_EffectID, ezParticleStreamFactory);
@@ -159,6 +196,9 @@ public:
 // ON OFF STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating on/off streams (Byte data type).
+///
+/// Used to enable or disable individual particles without removing them from the system.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_OnOff final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_OnOff, ezParticleStreamFactory);
@@ -171,6 +211,7 @@ public:
 // AXIS STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating axis streams (Float3 data type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_Axis final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_Axis, ezParticleStreamFactory);
@@ -179,6 +220,10 @@ public:
   ezParticleStreamFactory_Axis();
 };
 
+/// Stream storing particle orientation axes.
+///
+/// Initializes new particles with axis (1, 0, 0).
+/// Used for oriented particle rendering where particles need a direction vector.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_Axis final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_Axis, ezParticleStream);
@@ -191,6 +236,9 @@ protected:
 // TRAIL DATA STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating trail data streams (Short2 data type).
+///
+/// Stores trail-specific data for trail renderers to connect particles into ribbons.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_TrailData final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_TrailData, ezParticleStreamFactory);
@@ -203,6 +251,7 @@ public:
 // VARIATION STREAM
 //////////////////////////////////////////////////////////////////////////
 
+/// Factory for creating variation streams (Int data type).
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory_Variation final : public ezParticleStreamFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory_Variation, ezParticleStreamFactory);
@@ -211,6 +260,10 @@ public:
   ezParticleStreamFactory_Variation();
 };
 
+/// Stream storing particle variation values.
+///
+/// Initializes new particles with random unsigned integers.
+/// Used for texture atlas variations, flipbook animations, or other per-particle randomization.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream_Variation final : public ezParticleStream
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream_Variation, ezParticleStream);

--- a/Code/EnginePlugins/ParticlePlugin/Streams/ParticleStream.h
+++ b/Code/EnginePlugins/ParticlePlugin/Streams/ParticleStream.h
@@ -10,6 +10,9 @@ class ezParticleStream;
 class ezParticleSystemInstance;
 
 /// \brief Base class for all particle stream factories
+///
+/// Stream factories are responsible for creating and configuring particle streams.
+/// Each factory specifies the stream name, data type, and the actual stream class to instantiate.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStreamFactory : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStreamFactory, ezReflectedClass);
@@ -21,8 +24,10 @@ public:
   ezProcessingStream::DataType GetStreamDataType() const;
   const char* GetStreamName() const;
 
+  /// Constructs a full stream name by appending the data type in parentheses (e.g., "Position(3)" for Float4).
   static void GetFullStreamName(const char* szName, ezProcessingStream::DataType type, ezStringBuilder& out_sResult);
 
+  /// Creates and initializes a new particle stream instance for the given particle system.
   ezParticleStream* CreateParticleStream(ezParticleSystemInstance* pOwner) const;
 
 private:
@@ -32,6 +37,10 @@ private:
 };
 
 /// \brief Base class for all particle streams
+///
+/// Particle streams store per-particle data like position, velocity, color, or size.
+/// Each stream type provides initialization logic for new particles.
+/// Streams run with high priority (-1000) to ensure they initialize data before other processors.
 class EZ_PARTICLEPLUGIN_DLL ezParticleStream : public ezProcessingStreamProcessor
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleStream, ezProcessingStreamProcessor);
@@ -41,14 +50,22 @@ class EZ_PARTICLEPLUGIN_DLL ezParticleStream : public ezProcessingStreamProcesso
 
 protected:
   ezParticleStream();
+
+  /// Called once during stream creation to set up any necessary references or state.
   virtual void Initialize(ezParticleSystemInstance* pOwner) {}
+
   virtual ezResult UpdateStreamBindings() final override;
+
+  /// Particle streams do not process existing elements, they only initialize new ones.
   virtual void Process(ezUInt64 uiNumElements) final override {}
 
   /// \brief The default implementation initializes all data with zero.
+  ///
+  /// Override this to provide custom initialization for new particles.
+  /// The implementation should initialize elements in the range [uiStartIndex, uiStartIndex + uiNumElements).
   virtual void InitializeElements(ezUInt64 uiStartIndex, ezUInt64 uiNumElements) override;
 
-  ezProcessingStream* m_pStream;
+  ezProcessingStream* m_pStream; ///< The underlying data stream managed by this particle stream
 
 private:
   ezParticleStreamBinding m_StreamBinding;

--- a/Code/EnginePlugins/ParticlePlugin/System/ParticleSystemDescriptor.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/System/ParticleSystemDescriptor.cpp
@@ -20,7 +20,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleSystemDescriptor, 2, ezRTTIDefaultAllo
     EZ_MEMBER_PROPERTY("Visible", m_bVisible)->AddAttributes(new ezDefaultValueAttribute(true)),
     EZ_MEMBER_PROPERTY("LifeTime", m_LifeTime)->AddAttributes(new ezDefaultValueAttribute(ezVarianceTypeTime(ezTime::MakeFromSeconds(2))), new ezClampValueAttribute(ezTime::MakeFromSeconds(0.0), ezVariant())),
     EZ_MEMBER_PROPERTY("LifeScaleParam", m_sLifeScaleParameter),
-    EZ_MEMBER_PROPERTY("OnDeathEvent", m_sOnDeathEvent),
+    EZ_MEMBER_PROPERTY("OnDeathEvent", m_sOnDeathEvent)->AddAttributes(new ezDynamicStringEnumAttribute("ParticleEventNamesEnum")),
     EZ_ARRAY_MEMBER_PROPERTY("Emitters", m_EmitterFactories)->AddFlags(ezPropertyFlags::PointerOwner)->AddAttributes(new ezMaxArraySizeAttribute(1)),
     EZ_SET_ACCESSOR_PROPERTY("Initializers", GetInitializerFactories, AddInitializerFactory, RemoveInitializerFactory)->AddFlags(ezPropertyFlags::PointerOwner)->AddAttributes(new ezPreventDuplicatesAttribute()),
     EZ_SET_ACCESSOR_PROPERTY("Behaviors", GetBehaviorFactories, AddBehaviorFactory, RemoveBehaviorFactory)->AddFlags(ezPropertyFlags::PointerOwner)->AddAttributes(new ezPreventDuplicatesAttribute()),
@@ -367,5 +367,6 @@ public:
 };
 
 ezParticleSystemDescriptor_1_2 g_ezParticleSystemDescriptor_1_2;
+
 
 EZ_STATICLINK_FILE(ParticlePlugin, ParticlePlugin_System_ParticleSystemDescriptor);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Effect/ParticleTypeEffect.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Effect/ParticleTypeEffect.h
@@ -5,6 +5,7 @@
 
 using ezParticleEffectResourceHandle = ezTypedResourceHandle<class ezParticleEffectResource>;
 
+/// Factory for creating effect particle types.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeEffectFactory final : public ezParticleTypeFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeEffectFactory, ezParticleTypeFactory);
@@ -23,6 +24,10 @@ public:
   ezString m_sSharedInstanceName; // to be removed
 };
 
+/// Spawns nested particle effects at each particle position.
+///
+/// Each particle spawns an independent particle effect instance at its position.
+/// The spawned effects are automatically cleaned up when the parent particle dies.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeEffect final : public ezParticleType
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeEffect, ezParticleType);
@@ -37,6 +42,9 @@ public:
   virtual void CreateRequiredStreams() override;
   virtual void ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& instanceTransform) const override;
 
+  /// Returns the maximum effect radius for culling.
+  ///
+  /// This is an approximation based on the spawned effect's bounding radius.
   virtual float GetMaxParticleRadius(float fParticleSize) const override { return m_fMaxEffectRadius; }
 
 protected:

--- a/Code/EnginePlugins/ParticlePlugin/Type/Light/ParticleTypeLight.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Light/ParticleTypeLight.h
@@ -6,6 +6,7 @@
 class ezView;
 class ezExtractedRenderData;
 
+/// Factory for creating light particle types.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeLightFactory final : public ezParticleTypeFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeLightFactory, ezParticleTypeFactory);
@@ -27,6 +28,11 @@ public:
   ezString m_sSizeScaleParameter;
 };
 
+/// Renders particles as dynamic point lights.
+///
+/// Each particle creates a point light with range based on particle size.
+/// Not all particles need to emit light - the percentage can be controlled
+/// to reduce performance cost. Light properties can be modulated by effect parameters.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeLight final : public ezParticleType
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeLight, ezParticleType);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Mesh/ParticleTypeMesh.h
@@ -8,6 +8,7 @@
 using ezMeshResourceHandle = ezTypedResourceHandle<class ezMeshResource>;
 using ezMaterialResourceHandle = ezTypedResourceHandle<class ezMaterialResource>;
 
+/// Factory for creating mesh particle types.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeMeshFactory final : public ezParticleTypeFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeMeshFactory, ezParticleTypeFactory);
@@ -25,6 +26,12 @@ public:
   ezString m_sTintColorParameter;
 };
 
+/// Renders particles as instanced 3D meshes.
+///
+/// Each particle renders a full 3D mesh at its position, oriented according to
+/// its rotation axis. Materials can be overridden globally or use the mesh's
+/// default materials. Uses instanced rendering for performance when many particles
+/// share the same mesh.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeMesh final : public ezParticleType
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeMesh, ezParticleType);
@@ -48,6 +55,7 @@ protected:
   virtual void InitializeElements(ezUInt64 uiStartIndex, ezUInt64 uiNumElements) override;
   virtual void Process(ezUInt64 uiNumElements) override {}
 
+  /// Queries and caches mesh and material information from resources.
   bool QueryMeshAndMaterialInfo() const;
 
   void RequestRequiredWorldModulesForCache(ezParticleWorldModule* pParticleModule) override;

--- a/Code/EnginePlugins/ParticlePlugin/Type/ParticleType.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/ParticleType.h
@@ -7,6 +7,7 @@
 
 struct ezMsgExtractRenderData;
 
+/// Sorting key values used to order particles during rendering.
 enum ezParticleTypeSortingKey
 {
   Distortion, // samples the back-buffer, so doing this later would overwrite their result
@@ -18,6 +19,10 @@ enum ezParticleTypeSortingKey
   BlendedForeground,
 };
 
+/// Factory for creating particle type instances.
+///
+/// Each particle type factory stores the configuration for a particle type
+/// and can create instances of that type for particle system instances.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeFactory : public ezReflectedClass
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeFactory, ezReflectedClass);
@@ -28,12 +33,18 @@ public:
 
   ezParticleType* CreateType(ezParticleSystemInstance* pOwner) const;
 
+  /// Allows the type to register any finalizers it depends on.
   virtual void QueryFinalizerDependencies(ezSet<const ezRTTI*>& inout_finalizerDeps) const {}
 
   virtual void Save(ezStreamWriter& inout_stream) const = 0;
   virtual void Load(ezStreamReader& inout_stream) = 0;
 };
 
+/// Base class for particle types that define how particles are rendered.
+///
+/// Each particle type handles a specific rendering method such as billboards,
+/// trails, meshes, or lights. Types process particle data each frame and
+/// generate render data for the renderer.
 class EZ_PARTICLEPLUGIN_DLL ezParticleType : public ezParticleModule
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleType, ezParticleModule);
@@ -41,8 +52,15 @@ class EZ_PARTICLEPLUGIN_DLL ezParticleType : public ezParticleModule
   friend class ezParticleSystemInstance;
 
 public:
+  /// Returns the maximum radius a particle can occupy for culling purposes.
+  ///
+  /// Used to compute bounding volumes for frustum culling. The default implementation
+  /// returns half the particle size, assuming spherical particles.
   virtual float GetMaxParticleRadius(float fParticleSize) const { return fParticleSize * 0.5f; }
 
+  /// Generates render data for all active particles.
+  ///
+  /// Called during render data extraction to create render objects for this particle type.
   virtual void ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& instanceTransform) const = 0;
 
 protected:

--- a/Code/EnginePlugins/ParticlePlugin/Type/Point/ParticleTypePoint.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Point/ParticleTypePoint.h
@@ -4,6 +4,7 @@
 #include <ParticlePlugin/Type/Point/PointRenderer.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
 
+/// Factory for creating point particle types.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypePointFactory final : public ezParticleTypeFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypePointFactory, ezParticleTypeFactory);
@@ -16,6 +17,7 @@ public:
   virtual void Load(ezStreamReader& inout_stream) override;
 };
 
+/// Renders particles as single-pixel points.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypePoint final : public ezParticleType
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypePoint, ezParticleType);
@@ -27,6 +29,7 @@ public:
 
   virtual void ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& instanceTransform) const override;
 
+  /// Point particles have no radius for culling purposes.
   virtual float GetMaxParticleRadius(float fParticleSize) const override { return 0.0f; }
 
 protected:

--- a/Code/EnginePlugins/ParticlePlugin/Type/Point/PointRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Point/PointRenderer.h
@@ -8,18 +8,19 @@
 #include <RendererCore/../../../Data/Base/Shaders/Particles/BillboardQuadParticleShaderData.h>
 #include <RendererFoundation/Resources/BufferPool.h>
 
+/// Render data for point particles.
 class EZ_PARTICLEPLUGIN_DLL ezParticlePointRenderData final : public ezRenderData
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticlePointRenderData, ezRenderData);
 
 public:
-  ezArrayPtr<ezBaseParticleShaderData> m_BaseParticleData;
-  ezArrayPtr<ezBillboardQuadParticleShaderData> m_BillboardParticleData;
-  ezTransform m_GlobalTransform;
-  ezTime m_TotalEffectLifeTime;
+  ezArrayPtr<ezBaseParticleShaderData> m_BaseParticleData;               ///< Base particle data
+  ezArrayPtr<ezBillboardQuadParticleShaderData> m_BillboardParticleData; ///< Billboard data
+  ezTransform m_GlobalTransform;                                         ///< World transform of the particle system
+  ezTime m_TotalEffectLifeTime;                                          ///< Total lifetime of the effect
 };
 
-/// \brief Implements rendering of particle systems
+/// Renderer for point particle systems.
 class EZ_PARTICLEPLUGIN_DLL ezParticlePointRenderer final : public ezParticleRenderer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticlePointRenderer, ezParticleRenderer);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/ParticleTypeQuad.h
@@ -6,23 +6,24 @@
 
 using ezTexture2DResourceHandle = ezTypedResourceHandle<class ezTexture2DResource>;
 
+/// Orientation modes for quad particles.
 struct EZ_PARTICLEPLUGIN_DLL ezQuadParticleOrientation
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    Billboard,
+    Billboard,                ///< Always faces the camera
 
-    Rotating_OrthoEmitterDir,
-    Rotating_EmitterDir,
+    Rotating_OrthoEmitterDir, ///< Rotates around axis orthogonal to emitter direction
+    Rotating_EmitterDir,      ///< Rotates around emitter direction
 
-    Fixed_EmitterDir,
-    Fixed_WorldUp,
-    Fixed_RandomDir,
+    Fixed_EmitterDir,         ///< Fixed orientation based on emitter direction
+    Fixed_WorldUp,            ///< Fixed orientation aligned with world up
+    Fixed_RandomDir,          ///< Fixed random orientation per particle
 
-    FixedAxis_EmitterDir,
-    FixedAxis_ParticleDir,
+    FixedAxis_EmitterDir,     ///< Fixed axis aligned with emitter direction
+    FixedAxis_ParticleDir,    ///< Fixed axis aligned with particle direction
 
     Default = Billboard
   };
@@ -30,6 +31,7 @@ struct EZ_PARTICLEPLUGIN_DLL ezQuadParticleOrientation
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_PARTICLEPLUGIN_DLL, ezQuadParticleOrientation);
 
+/// Factory for creating quad particle types.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeQuadFactory final : public ezParticleTypeFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeQuadFactory, ezParticleTypeFactory);
@@ -61,6 +63,13 @@ public:
   ezString m_sCustomMaterial;
 };
 
+/// Renders particles as camera-facing or oriented textured quads.
+///
+/// This is the most common particle type, rendering each particle as a textured
+/// quad. Quads can be billboarded to face the camera or oriented in various ways.
+/// Supports texture atlases for sprite animations and variations. Can be lit or
+/// fullbright. The stretch parameter allows elongating particles along their
+/// velocity direction for motion blur effects.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeQuad final : public ezParticleType
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeQuad, ezParticleType);
@@ -89,12 +98,13 @@ public:
 
   virtual void ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& instanceTransform) const override;
 
+  /// Helper struct for depth sorting particles.
   struct sod
   {
     EZ_DECLARE_POD_TYPE();
 
-    float dist;
-    ezUInt32 index;
+    float dist;     ///< Distance from camera
+    ezUInt32 index; ///< Particle index
   };
 
 

--- a/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Quad/QuadParticleRenderer.h
@@ -9,6 +9,7 @@
 #include <RendererCore/../../../Data/Base/Shaders/Particles/BillboardQuadParticleShaderData.h>
 #include <RendererCore/../../../Data/Base/Shaders/Particles/TangentQuadParticleShaderData.h>
 
+/// Render data for quad particles.
 class EZ_PARTICLEPLUGIN_DLL ezParticleQuadRenderData final : public ezRenderData
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleQuadRenderData, ezRenderData);
@@ -38,7 +39,7 @@ public:
   ezMaterialResourceHandle m_hCustomMaterial;
 };
 
-/// \brief Implements rendering of particle systems
+/// Renderer for quad particle systems.
 class EZ_PARTICLEPLUGIN_DLL ezParticleQuadRenderer final : public ezParticleRenderer
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleQuadRenderer, ezParticleRenderer);

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/ParticleTypeTrail.h
@@ -8,6 +8,7 @@
 using ezTexture2DResourceHandle = ezTypedResourceHandle<class ezTexture2DResource>;
 struct ezTrailParticleData;
 
+/// Factory for creating trail particle types.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeTrailFactory final : public ezParticleTypeFactory
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeTrailFactory, ezParticleTypeFactory);
@@ -36,6 +37,12 @@ public:
   ezString m_sCustomMaterial;
 };
 
+/// Renders particles as textured ribbons following their movement path.
+///
+/// Trails record particle positions over time and render a ribbon connecting
+/// the trail points. The trail length is determined by the maximum number of
+/// points and the update interval. Older trail points fade out automatically.
+/// Trails can be lit or fullbright and support texture atlases.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTypeTrail final : public ezParticleType
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTypeTrail, ezParticleType);
@@ -61,9 +68,14 @@ public:
 
   virtual void CreateRequiredStreams() override;
   virtual void ExtractTypeRenderData(ezMsgExtractRenderData& ref_msg, const ezTransform& instanceTransform) const override;
-  /// \todo This is a hacky guess, one would actually need to inspect the trail positions
+
+  /// Returns an approximation of the maximum trail radius.
+  ///
+  /// This is an estimate based on particle size and maximum trail length.
+  /// Inspecting actual trail positions would be more accurate but costly.
   virtual float GetMaxParticleRadius(float fParticleSize) const override { return fParticleSize + m_uiMaxPoints * 0.05f; }
 
+  /// Computes the memory bucket size needed for storing trail points.
   static ezUInt16 ComputeTrailPointBucketSize(ezUInt16 uiMaxTrailPoints);
 
 protected:
@@ -97,10 +109,7 @@ protected:
   const ezVec4* GetTrailPointsPositions(ezUInt32 index) const;
   ezVec4* GetTrailPointsPositions(ezUInt32 index);
 
-  /// \todo Use a shared freelist across effects instead
-  // ezDynamicArray<ezTrailParticlePointsData8> m_TrailPoints8;
-  // ezDynamicArray<ezTrailParticlePointsData16> m_TrailPoints16;
-  // ezDynamicArray<ezTrailParticlePointsData32> m_TrailPoints32;
-  ezDynamicArray<ezTrailParticlePointsData64, ezAlignedAllocatorWrapper> m_TrailPoints64;
-  ezDynamicArray<ezUInt16> m_FreeTrailData;
+  // Currently only 64-point trails are used. Smaller bucket sizes are reserved for future use.
+  ezDynamicArray<ezTrailParticlePointsData64, ezAlignedAllocatorWrapper> m_TrailPoints64; ///< Storage for trail points
+  ezDynamicArray<ezUInt16> m_FreeTrailData;                                               ///< Freelist for trail data allocation
 };

--- a/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.h
+++ b/Code/EnginePlugins/ParticlePlugin/Type/Trail/TrailRenderer.h
@@ -9,6 +9,7 @@
 
 #include <RendererCore/../../../Data/Base/Shaders/Particles/TrailShaderData.h>
 
+/// Render data for trail particles.
 class EZ_PARTICLEPLUGIN_DLL ezParticleTrailRenderData final : public ezRenderData
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezParticleTrailRenderData, ezRenderData);

--- a/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleEffects.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleEffects.cpp
@@ -202,5 +202,3 @@ void ezParticleWorldModule::ReconfigureEffects()
 
   m_EffectsToReconfigure.Clear();
 }
-
-

--- a/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleSystems.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/WorldModule/ParticleSystems.cpp
@@ -33,5 +33,3 @@ void ezParticleWorldModule::DestroySystemInstance(ezParticleSystemInstance* pIns
   pInstance->Destruct();
   m_ParticleSystemFreeList.PushBack(pInstance);
 }
-
-

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.cpp
@@ -1,20 +1,26 @@
 #include <GuiFoundation/GuiFoundationPCH.h>
 
+#include <Foundation/Tracks/CurveEditData.h>
 #include <GuiFoundation/Dialogs/CurveEditDlg.moc.h>
 #include <GuiFoundation/Widgets/Curve1DEditorWidget.moc.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
 #include <ToolsFoundation/Document/Document.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
 QByteArray ezQtCurveEditDlg::s_LastDialogGeometry;
 
-ezQtCurveEditDlg::ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, QWidget* pParent)
+ezQtCurveEditDlg::ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, QWidget* pParent, ezStringView sTitle)
   : QDialog(pParent)
 {
   m_pObjectAccessor = pObjectAccessor;
   m_pCurveObject = pCurveObject;
 
   setupUi(this);
+
+  if (!sTitle.IsEmpty())
+  {
+    ezStringBuilder tmp;
+    setWindowTitle(sTitle.GetData(tmp));
+  }
 
   ezQtCurve1DEditorWidget* pEdit = CurveEditor;
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <GuiFoundation/GuiFoundationDLL.h>
 #include <Foundation/Tracks/CurveEditData.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/ui_CurveEditDlg.h>
 #include <QDialog>
 

--- a/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Dialogs/CurveEditDlg.moc.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <GuiFoundation/GuiFoundationDLL.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 #include <GuiFoundation/ui_CurveEditDlg.h>
 #include <QDialog>
 
@@ -13,7 +13,7 @@ class EZ_GUIFOUNDATION_DLL ezQtCurveEditDlg : public QDialog, Ui_CurveEditDlg
 {
   Q_OBJECT
 public:
-  ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, QWidget* pParent);
+  ezQtCurveEditDlg(ezObjectAccessorBase* pObjectAccessor, const ezDocumentObject* pCurveObject, QWidget* pParent, ezStringView sTitle = {});
   ~ezQtCurveEditDlg();
 
   static QByteArray GetLastDialogGeometry() { return s_LastDialogGeometry; }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
@@ -1,5 +1,6 @@
 #include <GuiFoundation/GuiFoundationPCH.h>
 
+#include <Foundation/Tracks/CurveEditData.h>
 #include <GuiFoundation/PropertyGrid/Implementation/ExpressionPropertyWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.moc.h>
@@ -7,7 +8,6 @@
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/Widgets/CollapsibleGroupBox.moc.h>
-#include <Foundation/Tracks/CurveEditData.h>
 
 #include <ToolsFoundation/Document/Document.h>
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyGridWidget.cpp
@@ -7,7 +7,7 @@
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/PropertyMetaState.h>
 #include <GuiFoundation/Widgets/CollapsibleGroupBox.moc.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 
 #include <ToolsFoundation/Document/Document.h>
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -1,10 +1,10 @@
 #include <GuiFoundation/GuiFoundationPCH.h>
 
 #include <Foundation/Strings/TranslationLookup.h>
+#include <Foundation/Tracks/CurveEditData.h>
 #include <GuiFoundation/Dialogs/CurveEditDlg.moc.h>
 #include <GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
 #include <GuiFoundation/Widgets/DoubleSpinBox.moc.h>
 #include <QComboBox>
 #include <QLineEdit>
@@ -1992,12 +1992,12 @@ void ezQtPropertyEditorCurve1DWidget::SetSelection(const ezHybridArray<ezPropert
 
 void ezQtPropertyEditorCurve1DWidget::OnInit()
 {
-  m_pObjectAccessor->GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&ezQtPropertyEditorCurve1DWidget::PropertyEventHandler, this));
+  m_pObjectAccessor->GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&ezQtPropertyEditorCurve1DWidget::PropertyEventHandler, this), m_Unsub);
 }
 
 void ezQtPropertyEditorCurve1DWidget::DoPrepareToDie()
 {
-  m_pObjectAccessor->GetObjectManager()->m_PropertyEvents.RemoveEventHandler(ezMakeDelegate(&ezQtPropertyEditorCurve1DWidget::PropertyEventHandler, this));
+  m_Unsub.Unsubscribe();
 }
 
 void ezQtPropertyEditorCurve1DWidget::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
@@ -2056,7 +2056,8 @@ void ezQtPropertyEditorCurve1DWidget::on_Button_triggered()
   // but also be able to undo individual steps while editing
   // m_pObjectAccessor->GetObjectManager()->GetDocument()->GetCommandHistory()->StartTransaction("Edit Curve");
 
-  ezQtCurveEditDlg* pDlg = new ezQtCurveEditDlg(m_pObjectAccessor, pCurve, this);
+  ezStringBuilder sTitle = ezTranslate(m_pProp->GetPropertyName());
+  ezQtCurveEditDlg* pDlg = new ezQtCurveEditDlg(m_pObjectAccessor, pCurve, this, sTitle);
   pDlg->restoreGeometry(ezQtCurveEditDlg::GetLastDialogGeometry());
 
   if (pColorAttr)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.moc.h
@@ -429,4 +429,5 @@ protected:
 protected:
   QHBoxLayout* m_pLayout = nullptr;
   ezQtCurve1DButtonWidget* m_pButton = nullptr;
+  ezCopyOnBroadcastEvent<const ezDocumentObjectPropertyEvent&>::Unsubscriber m_Unsub;
 };

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/VarianceWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/VarianceWidget.cpp
@@ -21,7 +21,8 @@ ezQtVarianceTypeWidget::ezQtVarianceTypeWidget()
   m_pValueWidget->setMaximum(ezMath::Infinity<double>());
   m_pValueWidget->setSingleStep(0.1f);
   m_pValueWidget->setAccelerated(true);
-  m_pValueWidget->setDecimals(2);
+  m_pValueWidget->setDecimals(3);
+  m_pValueWidget->setMinimumWidth(60);
 
   m_pVarianceWidget = new QSlider(this);
   m_pVarianceWidget->setOrientation(Qt::Orientation::Horizontal);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditWidget.moc.h
@@ -4,7 +4,7 @@
 #include <Foundation/Math/Vec2.h>
 #include <Foundation/Tracks/Curve1D.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
-#include <GuiFoundation/Widgets/CurveEditData.h>
+#include <Foundation/Tracks/CurveEditData.h>
 
 #include <QBrush>
 #include <QPen>

--- a/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/CurveEditWidget.moc.h
@@ -3,8 +3,8 @@
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Math/Vec2.h>
 #include <Foundation/Tracks/Curve1D.h>
-#include <GuiFoundation/GuiFoundationDLL.h>
 #include <Foundation/Tracks/CurveEditData.h>
+#include <GuiFoundation/GuiFoundationDLL.h>
 
 #include <QBrush>
 #include <QPen>


### PR DESCRIPTION
* Added code comments to particle plugin
* Show custom title in curve edit dialog (uses curve name)
* Moved CurveEditData.h to Foundation, so that it can be used in runtime plugins
* Fixed a subtle bug in ezCurve1D lookup
* Event names in the particle system now use dynamic string enums for type safety
* Increased minimum size of the variance widget