### PR TITLE
Removed unused options from testframework

### DIFF
--- a/Code/UnitTests/TestFramework/Framework/Declarations.h
+++ b/Code/UnitTests/TestFramework/Framework/Declarations.h
@@ -36,14 +36,12 @@ enum class AssertOnTestFail
   AssertIfDebuggerAttached,
   AlwaysAssert,
 };
+
 struct TestSettings
 {
   // The following settings are stored in the settings file.
   AssertOnTestFail m_AssertOnTestFail = AssertOnTestFail::DoNotAssert;
-  bool m_bOpenHtmlOutputOnError = false;
-  bool m_bKeepConsoleOpen = false;
   bool m_bShowTimestampsInLog = false;
-  bool m_bShowMessageBox = false;
   bool m_bAutoDisableSuccessfulTests = false;
 
   // The following settings are only set via command-line.
@@ -55,5 +53,4 @@ struct TestSettings
   std::string m_sJsonOutput;         /// Absolute path to the json file the results should be written to.
   bool m_bEnableAllTests = false;    /// Enables all test.
   std::string m_sTestFilter;         /// Filter that does a 'contains' test on each test name.
-  ezUInt8 m_uiFullPasses = 1;        /// All tests are done this often, to check whether some tests fail only when executed multiple times.
 };

--- a/Code/UnitTests/TestFramework/Framework/Qt/qtTestGUI.cpp
+++ b/Code/UnitTests/TestFramework/Framework/Qt/qtTestGUI.cpp
@@ -66,8 +66,6 @@ ezQtTestGUI::ezQtTestGUI(ezQtTestFramework& ref_testFramework)
   // Sync actions with test framework settings
   TestSettings settings = m_pTestFramework->GetSettings();
   this->actionAssertOnTestFail->setChecked(settings.m_AssertOnTestFail != AssertOnTestFail::DoNotAssert);
-  this->actionOpenHTMLOutput->setChecked(settings.m_bOpenHtmlOutputOnError);
-  this->actionShowMessageBox->setChecked(settings.m_bShowMessageBox);
   this->actionDisableSuccessfulTests->setChecked(settings.m_bAutoDisableSuccessfulTests);
 
   connect(m_pTestFramework, SIGNAL(TestResultReceived(qint32, qint32)), this, SLOT(onTestFrameworkTestResultReceived(qint32, qint32)));
@@ -110,20 +108,6 @@ void ezQtTestGUI::on_actionAssertOnTestFail_triggered(bool bChecked)
 {
   TestSettings settings = m_pTestFramework->GetSettings();
   settings.m_AssertOnTestFail = bChecked ? AssertOnTestFail::AssertIfDebuggerAttached : AssertOnTestFail::DoNotAssert;
-  m_pTestFramework->SetSettings(settings);
-}
-
-void ezQtTestGUI::on_actionOpenHTMLOutput_triggered(bool bChecked)
-{
-  TestSettings settings = m_pTestFramework->GetSettings();
-  settings.m_bOpenHtmlOutputOnError = bChecked;
-  m_pTestFramework->SetSettings(settings);
-}
-
-void ezQtTestGUI::on_actionShowMessageBox_triggered(bool bChecked)
-{
-  TestSettings settings = m_pTestFramework->GetSettings();
-  settings.m_bShowMessageBox = bChecked;
   m_pTestFramework->SetSettings(settings);
 }
 
@@ -221,9 +205,6 @@ void ezQtTestGUI::on_actionRunTests_triggered()
   {
     m_pStatusTextWorkState->setText("<p><span style=\"font-weight:600; color:#ff0000;\">  [Tests Aborted]</span></p>");
 
-    if (m_pTestFramework->GetSettings().m_bShowMessageBox)
-      QMessageBox::information(this, "Tests Aborted", "The tests were aborted by the user.", QMessageBox::Ok, QMessageBox::Ok);
-
     m_bAbort = false;
   }
   else
@@ -231,16 +212,10 @@ void ezQtTestGUI::on_actionRunTests_triggered()
     if (m_pTestFramework->GetTotalErrorCount() > 0)
     {
       m_pStatusTextWorkState->setText("<p><span style=\"font-weight:600; color:#ff0000;\">  [Tests Failed]</span></p>");
-
-      if (m_pTestFramework->GetSettings().m_bShowMessageBox)
-        QMessageBox::critical(this, "Tests Failed", "Some tests have failed.", QMessageBox::Ok, QMessageBox::Ok);
     }
     else
     {
       m_pStatusTextWorkState->setText("<p><span style=\"font-weight:600; color:#00aa00;\">  [All Tests Passed]</span></p>");
-
-      if (m_pTestFramework->GetSettings().m_bShowMessageBox)
-        QMessageBox::information(this, "Tests Succeeded", "All tests succeeded.", QMessageBox::Ok, QMessageBox::Ok);
 
       if (m_pTestFramework->GetSettings().m_bCloseOnSuccess)
         QTimer::singleShot(100, this, SLOT(on_actionQuit_triggered()));

--- a/Code/UnitTests/TestFramework/Framework/Qt/qtTestGUI.h
+++ b/Code/UnitTests/TestFramework/Framework/Qt/qtTestGUI.h
@@ -37,8 +37,6 @@ private:
 
 private Q_SLOTS:
   void on_actionAssertOnTestFail_triggered(bool bChecked);
-  void on_actionOpenHTMLOutput_triggered(bool bChecked);
-  void on_actionShowMessageBox_triggered(bool bChecked);
   void on_actionDisableSuccessfulTests_triggered(bool bChecked);
   void on_actionSaveTestSettingsAs_triggered();
   void on_actionSaveTestOrderAs_triggered();

--- a/Code/UnitTests/TestFramework/Framework/Qt/qtTestGUI.ui
+++ b/Code/UnitTests/TestFramework/Framework/Qt/qtTestGUI.ui
@@ -60,7 +60,7 @@
       <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -94,7 +94,7 @@
      <x>0</x>
      <y>0</y>
      <width>951</width>
-     <height>21</height>
+     <height>33</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuRun">
@@ -111,8 +111,6 @@
      <string>Settings</string>
     </property>
     <addaction name="actionAssertOnTestFail"/>
-    <addaction name="actionOpenHTMLOutput"/>
-    <addaction name="actionShowMessageBox"/>
     <addaction name="actionDisableSuccessfulTests"/>
     <addaction name="separator"/>
     <addaction name="actionSaveTestSettingsAs"/>
@@ -137,14 +135,6 @@
    </property>
    <property name="text">
     <string>Break on Test Failure</string>
-   </property>
-  </action>
-  <action name="actionOpenHTMLOutput">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Open HTML on Error</string>
    </property>
   </action>
   <action name="actionRunTests">
@@ -220,14 +210,6 @@
    </property>
    <property name="toolTip">
     <string>Enables all children of the selected test.</string>
-   </property>
-  </action>
-  <action name="actionShowMessageBox">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Show MessageBoxes</string>
    </property>
   </action>
   <action name="actionSaveTestSettingsAs">

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -1,25 +1,17 @@
 #include <TestFramework/TestFrameworkPCH.h>
 
-#include <Texture/Image/Formats/ImageFileFormat.h>
-
 #include <Foundation/IO/FileSystem/FileReader.h>
-#include <Foundation/IO/MemoryStream.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Logging/Log.h>
-#include <Foundation/Logging/VisualStudioWriter.h>
-#include <Foundation/Platform/Win/Utils/IncludeWindows.h>
-#include <Foundation/System/CrashHandler.h>
 #include <Foundation/System/EnvironmentVariableUtils.h>
 #include <Foundation/System/Process.h>
 #include <Foundation/System/StackTracer.h>
-#include <Foundation/Threading/ThreadUtils.h>
 #include <Foundation/Types/ScopeExit.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
 #include <TestFramework/Utilities/TestOrder.h>
-
+#include <Texture/Image/Formats/ImageFileFormat.h>
 #include <cstdlib>
 #include <stdexcept>
-#include <stdlib.h>
 
 #ifdef EZ_TESTFRAMEWORK_USE_FILESERVE
 #  include <FileservePlugin/Client/FileserveClient.h>
@@ -39,15 +31,11 @@ ezCommandLineOptionPath opt_SettingsFile("_TestFramework", "-settings", "Path to
 ezCommandLineOptionBool opt_Run("_TestFramework", "-run", "Makes the tests execute right away.", false);
 ezCommandLineOptionBool opt_Close("_TestFramework", "-close", "Makes the application close automatically after the tests are finished.", false);
 ezCommandLineOptionBool opt_NoGui("_TestFramework", "-noGui", "Never show a GUI.", false);
-ezCommandLineOptionBool opt_HTML("_TestFramework", "-html", "Open summary HTML on error.", false);
-ezCommandLineOptionBool opt_Console("_TestFramework", "-console", "Keep the console open.", false);
 ezCommandLineOptionBool opt_Timestamps("_TestFramework", "-timestamps", "Show timestamps in logs.", false);
-ezCommandLineOptionBool opt_MsgBox("_TestFramework", "-msgbox", "Show message box after tests.", false);
 ezCommandLineOptionBool opt_DisableSuccessful("_TestFramework", "-disableSuccessful", "Disable tests that ran successfully.", false);
 ezCommandLineOptionBool opt_EnableAllTests("_TestFramework", "-all", "Enable all tests.", false);
 ezCommandLineOptionBool opt_NoSave("_TestFramework", "-noSave", "Disables saving of any state.", false);
 ezCommandLineOptionInt opt_Revision("_TestFramework", "-rev", "Revision number to pass through to JSON output.", -1);
-ezCommandLineOptionInt opt_Passes("_TestFramework", "-passes", "Number of passes to execute.", 1);
 ezCommandLineOptionInt opt_Assert("_TestFramework", "-assert", "Whether to assert when a test fails.", (int)AssertOnTestFail::AssertIfDebuggerAttached);
 ezCommandLineOptionString opt_Filter("_TestFramework", "-filter", "Filter to execute only certain tests.", "");
 ezCommandLineOptionPath opt_Json("_TestFramework", "-json", "JSON file to write.", "");
@@ -319,24 +307,14 @@ void ezTestFramework::GetTestSettingsFromCommandLine(const ezCommandLineUtils& c
 
   ezStringBuilder tmp;
 
-  opt_HTML.SetDefaultValue(m_Settings.m_bOpenHtmlOutputOnError);
-  m_Settings.m_bOpenHtmlOutputOnError = opt_HTML.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
-
-  opt_Console.SetDefaultValue(m_Settings.m_bKeepConsoleOpen);
-  m_Settings.m_bKeepConsoleOpen = opt_Console.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
-
   opt_Timestamps.SetDefaultValue(m_Settings.m_bShowTimestampsInLog);
   m_Settings.m_bShowTimestampsInLog = opt_Timestamps.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
-
-  opt_MsgBox.SetDefaultValue(m_Settings.m_bShowMessageBox);
-  m_Settings.m_bShowMessageBox = opt_MsgBox.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
 
   opt_DisableSuccessful.SetDefaultValue(m_Settings.m_bAutoDisableSuccessfulTests);
   m_Settings.m_bAutoDisableSuccessfulTests = opt_DisableSuccessful.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
 
   m_Settings.m_iRevision = opt_Revision.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
   m_Settings.m_bEnableAllTests = opt_EnableAllTests.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
-  m_Settings.m_uiFullPasses = static_cast<ezUInt8>(opt_Passes.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd));
   m_Settings.m_sTestFilter = opt_Filter.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd).GetData(tmp);
 
   if (opt_Json.IsOptionSpecified(nullptr, &cmd))
@@ -375,8 +353,6 @@ void ezTestFramework::GetTestSettingsFromCommandLine(const ezCommandLineUtils& c
   }
   opt_NoSave.SetDefaultValue(bNoAutoSave);
   m_Settings.m_bNoAutomaticSaving = opt_NoSave.GetOptionValue(ezCommandLineOption::LogMode::AlwaysIfSpecified, &cmd);
-
-  m_uiPassesLeft = m_Settings.m_uiFullPasses;
 }
 
 void ezTestFramework::LoadTestOrder()
@@ -669,16 +645,6 @@ ezTestAppRun ezTestFramework::RunTestExecutionLoop()
   if (m_uiExecutingTest >= (ezUInt32)m_TestEntries.size())
   {
     EndTests();
-
-    if (m_uiPassesLeft > 1 && !m_bAbortTests)
-    {
-      --m_uiPassesLeft;
-
-      m_uiExecutingTest = ezInvalidIndex;
-      m_uiExecutingSubTest = ezInvalidIndex;
-
-      return ezTestAppRun::Continue;
-    }
 
 #ifdef EZ_TESTFRAMEWORK_USE_FILESERVE
     if (ezFileserveClient* pClient = ezFileserveClient::GetSingleton())

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.h
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.h
@@ -201,7 +201,6 @@ private:
   ezUInt32 m_uiExecutingSubTest = 0;
   bool m_bSubTestInitialized = false;
   bool m_bAbortTests = false;
-  ezUInt8 m_uiPassesLeft = 0;
   double m_fTotalTestDuration = 0.0;
   double m_fTotalSubTestDuration = 0.0;
   ezInt32 m_iErrorCountBeforeTest = 0;

--- a/Code/UnitTests/TestFramework/Utilities/HTMLOutput.h
+++ b/Code/UnitTests/TestFramework/Utilities/HTMLOutput.h
@@ -175,15 +175,6 @@ struct ezOutputToHTML
         htmlFile.close();
 
         std::string sOutputFile = std::string(ezTestFramework::GetInstance()->GetAbsOutputPath()) + "/UnitTestsLog.htm";
-
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
-        TestSettings settings = ezTestFramework::GetInstance()->GetSettings();
-        if (settings.m_bOpenHtmlOutputOnError && bError)
-        {
-          // opens the html file in a browser
-          ShellExecuteA(nullptr, "open", sOutputFile.c_str(), nullptr, nullptr, SW_SHOW);
-        }
-#endif
       }
       break;
       default:

--- a/Code/UnitTests/TestFramework/Utilities/TestOrder.cpp
+++ b/Code/UnitTests/TestFramework/Utilities/TestOrder.cpp
@@ -210,12 +210,6 @@ void SaveTestSettings(const char* szFile, TestSettings& ref_testSettings)
   {
     ezStringUtils::snprintf(szTemp, 256, "  AssertOnTestFail = %s\n", ref_testSettings.m_AssertOnTestFail != AssertOnTestFail::DoNotAssert ? "on" : "off");
     fwrite(szTemp, sizeof(char), strlen(szTemp), pFile);
-    ezStringUtils::snprintf(szTemp, 256, "  OpenHtmlOutputOnError = %s\n", ref_testSettings.m_bOpenHtmlOutputOnError ? "on" : "off");
-    fwrite(szTemp, sizeof(char), strlen(szTemp), pFile);
-    ezStringUtils::snprintf(szTemp, 256, "  KeepConsoleOpen = %s\n", ref_testSettings.m_bKeepConsoleOpen ? "on" : "off");
-    fwrite(szTemp, sizeof(char), strlen(szTemp), pFile);
-    ezStringUtils::snprintf(szTemp, 256, "  ShowMessageBox = %s\n", ref_testSettings.m_bShowMessageBox ? "on" : "off");
-    fwrite(szTemp, sizeof(char), strlen(szTemp), pFile);
     ezStringUtils::snprintf(szTemp, 256, "  DisableSuccessfulTests = %s\n", ref_testSettings.m_bAutoDisableSuccessfulTests ? "on" : "off");
     fwrite(szTemp, sizeof(char), strlen(szTemp), pFile);
   }
@@ -262,18 +256,6 @@ void LoadTestSettings(const char* szFile, TestSettings& ref_testSettings)
           if (ezStringUtils::IsEqual_NoCase("AssertOnTestFail", szTestName))
           {
             ref_testSettings.m_AssertOnTestFail = bIsOff ? AssertOnTestFail::DoNotAssert : AssertOnTestFail::AssertIfDebuggerAttached;
-          }
-          else if (ezStringUtils::IsEqual_NoCase("OpenHtmlOutputOnError", szTestName))
-          {
-            ref_testSettings.m_bOpenHtmlOutputOnError = !bIsOff;
-          }
-          else if (ezStringUtils::IsEqual_NoCase("KeepConsoleOpen", szTestName))
-          {
-            ref_testSettings.m_bKeepConsoleOpen = !bIsOff;
-          }
-          else if (ezStringUtils::IsEqual_NoCase("ShowMessageBox", szTestName))
-          {
-            ref_testSettings.m_bShowMessageBox = !bIsOff;
           }
           else if (ezStringUtils::IsEqual_NoCase("DisableSuccessfulTests", szTestName))
           {

--- a/Code/UnitTests/TestFramework/Utilities/TestSetup.cpp
+++ b/Code/UnitTests/TestFramework/Utilities/TestSetup.cpp
@@ -123,7 +123,7 @@ void ezTestSetup::DeInitTestFramework(bool bSilent /*= false*/)
   ezStartup::ShutdownCoreSystems();
 
   TestSettings settings = pTestFramework->GetSettings();
-  if (settings.m_bKeepConsoleOpen && !bSilent)
+  if (!bSilent)
   {
     if (ezSystemInformation::IsDebuggerAttached())
     {


### PR DESCRIPTION
These were useful in the beginning, but with better UI they aren't needed anymore.