### PR TITLE
Added fog plane example material

### DIFF
--- a/Data/Plugins/RmlUI/rmlui-default/assets.rcss
+++ b/Data/Plugins/RmlUI/rmlui-default/assets.rcss
@@ -133,9 +133,9 @@
 	progress-l: 103px 267px 13px 34px;
 	progress-c: 116px 267px 54px 34px;
 	progress-r: 170px 267px 13px 34px;
-	progress-fill-l: 110px 302px 6px 34px;
-	progress-fill-c: 140px 302px 6px 34px;
-	progress-fill-r: 170px 302px 6px 34px;
+	progress-fill-l: 103px 302px 13px 34px;
+	progress-fill-c: 140px 302px 13px 34px;
+	progress-fill-r: 170px 302px 13px 34px;
 	gauge: 0px 271px 100px 86px;
 	gauge-fill: 0px 356px 100px 86px;
 }

--- a/Data/Samples/Testing Chambers/Materials/FogPlane.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/FogPlane.ezMaterialAsset
@@ -1,0 +1,1506 @@
+HeaderV2
+{
+o
+{
+	Uuid %id{u4{2473129551536206237,5132110376782968790}}
+	s %t{"ezAssetDocumentInfo"}
+	u3 %v{2}
+	s %n{"Header"}
+	p
+	{
+		s %AssetType{"Material"}
+		VarArray %Dependencies
+		{
+			s{":app/VisualShader/Conversions.ddl"}
+			s{":app/VisualShader/Inputs.ddl"}
+			s{":app/VisualShader/Math_Basic.ddl"}
+			s{":app/VisualShader/Math_Clamping.ddl"}
+			s{":app/VisualShader/Output_Material.ddl"}
+			s{":app/VisualShader/Parameters.ddl"}
+			s{":app/VisualShader/Utils.ddl"}
+		}
+		Uuid %DocumentID{u4{2473129551536206237,5132110376782968790}}
+		u4 %Hash{12457818409278214319}
+		VarArray %MetaInfo{}
+		VarArray %Outputs
+		{
+			s{"VISUAL_SHADER"}
+		}
+		VarArray %PackageDeps{}
+		VarArray %References{}
+		s %Tags{""}
+	}
+}
+}
+Objects
+{
+o
+{
+	Uuid %id{u4{5862493043119968756,4437803930983611913}}
+	s %t{"AssetCache/Common/Materials/FogPlane.autogen.ezShader"}
+	u3 %v{2}
+	p
+	{
+		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		Color %Color{f{0x7B0AF63D,0xC25A113F,0xC6747B3F,0x0000803F}}
+		f %Density{0x0000803F}
+		f %MaskThreshold{0x0000803E}
+		s %SHADING_MODE{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		b %TWO_SIDED{0}
+	}
+}
+o
+{
+	Uuid %id{u4{1010881670684323987,4733441794864929290}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{11689326455357925050,5261552034667375917}}
+		s %SourcePin{"Position"}
+		Uuid %Target{u4{4581775783983871129,5208641831384202529}}
+		s %TargetPin{"a"}
+	}
+}
+o
+{
+	Uuid %id{u4{474661299679465124,4804768255881769084}}
+	s %t{"ezMaterialAssetProperties"}
+	u3 %v{4}
+	p
+	{
+		s %AssetFilterTags{""}
+		s %BaseMaterial{""}
+		s %Shader{"{ 543eb7d6-eb32-4738-9d31-d65239525222 }"}
+		s %ShaderMode{"ezMaterialShaderMode::Custom"}
+		Uuid %ShaderProperties{u4{5862493043119968756,4437803930983611913}}
+		s %Surface{""}
+	}
+}
+o
+{
+	Uuid %id{u4{14159293442408206515,4843861645720582657}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{8420297378562516126,5760016065871893163}}
+		s %SourcePin{"result"}
+		Uuid %Target{u4{3187636646355155356,5556835071859796733}}
+		s %TargetPin{"Opacity"}
+	}
+}
+o
+{
+	Uuid %id{u4{764754589330526856,5012566013189191150}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{18149825580820494014,5054589457580171423}}
+		s %SourcePin{"result"}
+		Uuid %Target{u4{8420297378562516126,5760016065871893163}}
+		s %TargetPin{"a"}
+	}
+}
+o
+{
+	Uuid %id{u4{1675853918036776330,5045227964952141464}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{6703703986529109169,5348012701815438837}}
+		s %SourcePin{"result"}
+		Uuid %Target{u4{18149825580820494014,5054589457580171423}}
+		s %TargetPin{"a"}
+	}
+}
+o
+{
+	Uuid %id{u4{18149825580820494014,5054589457580171423}}
+	s %t{"ShaderNode::Multiply"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0x3ED06044,0x13659143}}
+		f %a{0x0000803F}
+		f %b{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{1175734345818709379,5056513271275137905}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{4581775783983871129,5208641831384202529}}
+		s %SourcePin{"z"}
+		Uuid %Target{u4{6703703986529109169,5348012701815438837}}
+		s %TargetPin{"b"}
+	}
+}
+o
+{
+	Uuid %id{u4{17502315913803642524,5076917116982291855}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{11182337331263097488,5479886193515300937}}
+		s %SourcePin{"Value"}
+		Uuid %Target{u4{18149825580820494014,5054589457580171423}}
+		s %TargetPin{"b"}
+	}
+}
+o
+{
+	Uuid %id{u4{12756842103276853146,5122870276429375610}}
+	s %t{"ShaderNode::ParameterColor"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0x86717F44,0x723CD242}}
+		s %ParamName{"Color"}
+	}
+}
+o
+{
+	Uuid %id{u4{4581775783983871129,5208641831384202529}}
+	s %t{"ShaderNode::Split"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0x76C91444,0x0AFB3443}}
+	}
+}
+o
+{
+	Uuid %id{u4{12959991360121775038,5212379586451689233}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{12756842103276853146,5122870276429375610}}
+		s %SourcePin{"Value"}
+		Uuid %Target{u4{3187636646355155356,5556835071859796733}}
+		s %TargetPin{"BaseColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{11689326455357925050,5261552034667375917}}
+	s %t{"ShaderNode::ScenePosition"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0x018ABE43,0x72B03B43}}
+	}
+}
+o
+{
+	Uuid %id{u4{6703703986529109169,5348012701815438837}}
+	s %t{"ShaderNode::Subtract"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0x6B5F3844,0x14674E43}}
+		f %a{0}
+		f %b{0}
+	}
+}
+o
+{
+	Uuid %id{u4{11182337331263097488,5479886193515300937}}
+	s %t{"ShaderNode::Parameter1f"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0xD2BA2D44,0x8C3DB343}}
+		s %ParamName{"Density"}
+	}
+}
+o
+{
+	Uuid %id{u4{3187636646355155356,5556835071859796733}}
+	s %t{"ShaderNode::MaterialOutput"}
+	u3 %v{1}
+	p
+	{
+		b %ApplyFog{1}
+		Vec3 %BaseColor{f{0x0000803F,0x0000803F,0x0000803F}}
+		Vec3 %Emissive{f{0,0,0}}
+		f %MaskThreshold{0x0000803E}
+		f %Metallic{0}
+		Vec2 %Node::Pos{f{0x1AD39E44,0x5D3A2943}}
+		f %Occlusion{0x0000803F}
+		f %Opacity{0x0000803F}
+		f %Reflectance{0}
+		Vec4 %RefractionColor{f{0,0,0,0x0000803F}}
+		f %Roughness{0}
+		Vec3 %SubsurfaceColor{f{0,0,0}}
+	}
+}
+o
+{
+	Uuid %id{u4{5163221385814180499,5748136413718593492}}
+	s %t{"ezDocumentObject_ConnectionBase"}
+	u3 %v{1}
+	p
+	{
+		Uuid %Source{u4{14150850705887030316,10121243293421574974}}
+		s %SourcePin{"Z"}
+		Uuid %Target{u4{6703703986529109169,5348012701815438837}}
+		s %TargetPin{"a"}
+	}
+}
+o
+{
+	Uuid %id{u4{8420297378562516126,5760016065871893163}}
+	s %t{"ShaderNode::Saturate"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0xFCA68444,0xA7159343}}
+	}
+}
+o
+{
+	Uuid %id{u4{18096612296587978288,6449934965513159559}}
+	s %t{"ezDocumentRoot"}
+	u3 %v{1}
+	s %n{"ObjectTree"}
+	p
+	{
+		VarArray %Children
+		{
+			Uuid{u4{474661299679465124,4804768255881769084}}
+			Uuid{u4{3187636646355155356,5556835071859796733}}
+			Uuid{u4{6703703986529109169,5348012701815438837}}
+			Uuid{u4{18149825580820494014,5054589457580171423}}
+			Uuid{u4{8420297378562516126,5760016065871893163}}
+			Uuid{u4{12756842103276853146,5122870276429375610}}
+			Uuid{u4{11689326455357925050,5261552034667375917}}
+			Uuid{u4{14150850705887030316,10121243293421574974}}
+			Uuid{u4{764754589330526856,5012566013189191150}}
+			Uuid{u4{14159293442408206515,4843861645720582657}}
+			Uuid{u4{11182337331263097488,5479886193515300937}}
+			Uuid{u4{17502315913803642524,5076917116982291855}}
+			Uuid{u4{4581775783983871129,5208641831384202529}}
+			Uuid{u4{1010881670684323987,4733441794864929290}}
+			Uuid{u4{5163221385814180499,5748136413718593492}}
+			Uuid{u4{1175734345818709379,5056513271275137905}}
+			Uuid{u4{1675853918036776330,5045227964952141464}}
+			Uuid{u4{12959991360121775038,5212379586451689233}}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14150850705887030316,10121243293421574974}}
+	s %t{"ShaderNode::VertexWorldPosition"}
+	u3 %v{1}
+	p
+	{
+		Vec2 %Node::Pos{f{0x46E50844,0x292319C2}}
+	}
+}
+}
+Types
+{
+o
+{
+	Uuid %id{u4{8435977591727481336,164499438610169273}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Value{"CustomColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{7337062898864118968,917633431844621644}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{18437073470067871457,1625598021779406384}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{11040065101175624628,1662539785884692449}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{2589033904860476140,2941600109649901427}}
+			Uuid{u4{16804715233058764794,16291563085247070494}}
+			Uuid{u4{18411837506060015951,13397631608945770603}}
+			Uuid{u4{8531456234757106898,9843359760009772741}}
+			Uuid{u4{10978509386339080603,6055180187630064684}}
+			Uuid{u4{2493142764329470971,4237250110264931902}}
+			Uuid{u4{11381554768749103056,5747586724112780390}}
+			Uuid{u4{15388913065968328453,11188089115316402371}}
+			Uuid{u4{13652862081152275637,1931931446829192038}}
+			Uuid{u4{4737060376990519197,5534452074735684677}}
+			Uuid{u4{17888293823252574217,5278584362329602531}}
+		}
+		s %TypeName{"ShaderNode::MaterialOutput"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18311245008988910186,1895067994934075466}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{773668148553828920,15966949596821666881}}
+			Uuid{u4{540429536914844576,8213819539779215949}}
+			Uuid{u4{15543418230834458689,5548684801941186544}}
+			Uuid{u4{16393153594407016602,3744118329769567614}}
+			Uuid{u4{7757084663128585029,8011669779036733373}}
+			Uuid{u4{5650026407490086663,5768478847879086899}}
+			Uuid{u4{3687164412847300807,16605290275319987562}}
+		}
+		s %TypeName{"BLEND_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{2524718926845712419,1904526312384132727}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezVisualShaderNodeBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{13652862081152275637,1931931446829192038}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{8648126710299805379,15926322808980556731}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Occlusion"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{9182498974977327514,2041274447054354959}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_LIT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{9304690124962626883,2167934239923339245}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ShaderNode::ScenePosition"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{7999768391447710917,2784851377566841839}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{2589033904860476140,2941600109649901427}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{107023027798387058,15125524156854853544}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"MaskThreshold"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{7663342708106228735,3264391877378751372}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{10278369354623115403,16656751965644272535}}
+		}
+		s %TypeName{"ShaderNode::Parameter1f"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11103799278586492299,3397139525945711413}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{10546328178433928928,3538178021212683011}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		b %Value{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16393153594407016602,3744118329769567614}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{2}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_DITHERED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{7150528602981716380,3812190886568867668}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{5968167099646843483,4160956034734702909}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Density"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{11992629484154905888,3993029317059678037}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{8877328514147020979,11814959309858965089}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"a"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{5968167099646843483,4160956034734702909}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Constant"}
+	}
+}
+o
+{
+	Uuid %id{u4{2493142764329470971,4237250110264931902}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12975893279928312590,7112828226212987324}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Roughness"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{4085023801481947262,4424431816763648179}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8550075590461460286,4490880025266928341}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{1630575026503368177,5056594911948926398}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ShaderNode::VertexWorldPosition"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{4858951768529187673,5136142318512320422}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		d %Value{0x000000000000D03F}
+	}
+}
+o
+{
+	Uuid %id{u4{17888293823252574217,5278584362329602531}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{13542406804441022416,9548951225033578222}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"SubsurfaceColor"}
+		s %Type{"ezVec3"}
+	}
+}
+o
+{
+	Uuid %id{u4{4737060376990519197,5534452074735684677}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12496807453269888305,16412205064812982056}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"RefractionColor"}
+		s %Type{"ezVec4"}
+	}
+}
+o
+{
+	Uuid %id{u4{15543418230834458689,5548684801941186544}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MASKED"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{11381554768749103056,5747586724112780390}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{1263665986699366714,7795821215980672176}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Opacity"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{5650026407490086663,5768478847879086899}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{4}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_ADDITIVE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{10978509386339080603,6055180187630064684}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11154057802738083180,8940345913792219569}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Reflectance"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{11695727463527673381,6549777581474058039}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{1155205217496153151,16062411953539633064}}
+			Uuid{u4{9182498974977327514,2041274447054354959}}
+			Uuid{u4{14201946371216656691,8983156218640221597}}
+		}
+		s %TypeName{"SHADING_MODE"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{12878069495871467418,6604460216013732060}}
+	s %t{"ezCategoryAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Category{"Permutation"}
+	}
+}
+o
+{
+	Uuid %id{u4{11425776353448344375,7050208629762217394}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{18437073470067871457,1625598021779406384}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"SHADING_MODE"}
+		s %Type{"SHADING_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{12975893279928312590,7112828226212987324}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000003F}
+	}
+}
+o
+{
+	Uuid %id{u4{15857399435423166171,7430766950459069189}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{10954214981482726729,17111196752340869338}}
+			Uuid{u4{12609603033176210513,7964630687986868603}}
+		}
+		s %TypeName{"ShaderNode::Subtract"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1263665986699366714,7795821215980672176}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{12609603033176210513,7964630687986868603}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{9774780989707894273,9848653915852827572}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"b"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{7757084663128585029,8011669779036733373}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{3}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{540429536914844576,8213819539779215949}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_OPAQUE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{6089094783765586323,8705960867921430659}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentRoot"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11154057802738083180,8940345913792219569}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000003F}
+	}
+}
+o
+{
+	Uuid %id{u4{14201946371216656691,8983156218640221597}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{1}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::SHADING_MODE_FULLBRIGHT"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{17717897218099796308,9033184167245688007}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Abstract|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ezShaderTypeBase"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{13542406804441022416,9548951225033578222}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Vec3 %Value{f{0,0,0}}
+	}
+}
+o
+{
+	Uuid %id{u4{8531456234757106898,9843359760009772741}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{4085023801481947262,4424431816763648179}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Metallic"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{9774780989707894273,9848653915852827572}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15388913065968328453,11188089115316402371}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{6649753934969554305,13791166057793731169}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Emissive"}
+		s %Type{"ezVec3"}
+	}
+}
+o
+{
+	Uuid %id{u4{8216874154989125036,11573100282353988519}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezShaderTypeBase"}
+		s %PluginName{"ShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{1583810902704431137,17643656401097186625}}
+			Uuid{u4{7150528602981716380,3812190886568867668}}
+			Uuid{u4{14445316286408677272,16039416866095024820}}
+			Uuid{u4{11425776353448344375,7050208629762217394}}
+			Uuid{u4{7008203069590114017,15391729685078694181}}
+			Uuid{u4{16089325949572418848,15098457187719602857}}
+		}
+		s %TypeName{"AssetCache/Common/Materials/FogPlane.autogen.ezShader"}
+		u3 %TypeVersion{2}
+	}
+}
+o
+{
+	Uuid %id{u4{8877328514147020979,11814959309858965089}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{10097442269101671049,12017415575322047640}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12689300849278625136,16388205898017076391}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"b"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{4440304378651420221,12575431605907932885}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{11992629484154905888,3993029317059678037}}
+			Uuid{u4{10097442269101671049,12017415575322047640}}
+		}
+		s %TypeName{"ShaderNode::Multiply"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{18411837506060015951,13397631608945770603}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{2531204913114908651,14636118749865147444}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"BaseColor"}
+		s %Type{"ezVec3"}
+	}
+}
+o
+{
+	Uuid %id{u4{6649753934969554305,13791166057793731169}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Vec3 %Value{f{0,0,0}}
+	}
+}
+o
+{
+	Uuid %id{u4{16422282166416556709,14502256122642309324}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{8435977591727481336,164499438610169273}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"ParamName"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{2531204913114908651,14636118749865147444}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Vec3 %Value{f{0x0000803F,0x0000803F,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{2947336711354777548,15013008608905564043}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezEnumBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16089325949572418848,15098457187719602857}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{11103799278586492299,3397139525945711413}}
+			Uuid{u4{4858951768529187673,5136142318512320422}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"MaskThreshold"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{107023027798387058,15125524156854853544}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000803E}
+	}
+}
+o
+{
+	Uuid %id{u4{7008203069590114017,15391729685078694181}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{8550075590461460286,4490880025266928341}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"TWO_SIDED"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{574185834121239378,15422088015066052787}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ShaderNode::Split"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8648126710299805379,15926322808980556731}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{773668148553828920,15966949596821666881}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{14445316286408677272,16039416866095024820}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12878069495871467418,6604460216013732060}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::IsEnum|ezPropertyFlags::Phantom"}
+		s %Name{"BLEND_MODE"}
+		s %Type{"BLEND_MODE"}
+	}
+}
+o
+{
+	Uuid %id{u4{1155205217496153151,16062411953539633064}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		u3 %ConstantValue{0}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"SHADING_MODE::Default"}
+		s %Type{"ezUInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{18349806816312788076,16229247027635378395}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties{}
+		s %TypeName{"ShaderNode::Saturate"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16804715233058764794,16291563085247070494}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{10546328178433928928,3538178021212683011}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"ApplyFog"}
+		s %Type{"bool"}
+	}
+}
+o
+{
+	Uuid %id{u4{12689300849278625136,16388205898017076391}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		f %Value{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{12496807453269888305,16412205064812982056}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Vec4 %Value{f{0,0,0,0x0000803F}}
+	}
+}
+o
+{
+	Uuid %id{u4{9055380125307899845,16548159432520566774}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Phantom"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezVisualShaderNodeBase"}
+		s %PluginName{"VisualShaderTypes"}
+		VarArray %Properties
+		{
+			Uuid{u4{16422282166416556709,14502256122642309324}}
+		}
+		s %TypeName{"ShaderNode::ParameterColor"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{3687164412847300807,16605290275319987562}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes{}
+		s %Category{"ezPropertyCategory::Constant"}
+		i3 %ConstantValue{5}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
+		s %Name{"BLEND_MODE::BLEND_MODE_MODULATE"}
+		s %Type{"ezInt32"}
+	}
+}
+o
+{
+	Uuid %id{u4{10278369354623115403,16656751965644272535}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{12660487385210335935,17927281519322274274}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"ParamName"}
+		s %Type{"ezString"}
+	}
+}
+o
+{
+	Uuid %id{u4{10954214981482726729,17111196752340869338}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{7999768391447710917,2784851377566841839}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"a"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{13983305718315019434,17572363554072221229}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezDocumentObject_ConnectionBase"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{8721322561248882817,17579066505604714242}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::IsEnum|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezEnumBase"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialShaderMode"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{1583810902704431137,17643656401097186625}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{7337062898864118968,917633431844621644}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"Color"}
+		s %Type{"ezColor"}
+	}
+}
+o
+{
+	Uuid %id{u4{12660487385210335935,17927281519322274274}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		s %Value{"CustomValue1f"}
+	}
+}
+o
+{
+	Uuid %id{u4{983387834180907111,17935407260904399048}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{""}
+		s %PluginName{"Static"}
+		VarArray %Properties{}
+		s %TypeName{"ezReflectedClass"}
+		u3 %TypeVersion{1}
+	}
+}
+o
+{
+	Uuid %id{u4{5030680158680079231,18410952876772242771}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezReflectedClass"}
+		s %PluginName{"ezEditorPluginAssets"}
+		VarArray %Properties{}
+		s %TypeName{"ezMaterialAssetProperties"}
+		u3 %TypeVersion{4}
+	}
+}
+}

--- a/Data/Samples/Testing Chambers/Materials/FogPlane.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/FogPlane.ezMaterialAsset
@@ -20,7 +20,7 @@ o
 			s{":app/VisualShader/Utils.ddl"}
 		}
 		Uuid %DocumentID{u4{2473129551536206237,5132110376782968790}}
-		u4 %Hash{12457818409278214319}
+		u4 %Hash{8127576532061071894}
 		VarArray %MetaInfo{}
 		VarArray %Outputs
 		{
@@ -228,6 +228,7 @@ o
 	u3 %v{1}
 	p
 	{
+		b %ApplyDecals{0}
 		b %ApplyFog{1}
 		Vec3 %BaseColor{f{0x0000803F,0x0000803F,0x0000803F}}
 		Vec3 %Emissive{f{0,0,0}}
@@ -364,6 +365,7 @@ o
 			Uuid{u4{13652862081152275637,1931931446829192038}}
 			Uuid{u4{4737060376990519197,5534452074735684677}}
 			Uuid{u4{17888293823252574217,5278584362329602531}}
+			Uuid{u4{5182949022402297138,11502908056830025687}}
 		}
 		s %TypeName{"ShaderNode::MaterialOutput"}
 		u3 %TypeVersion{1}
@@ -426,8 +428,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"Occlusion"}
-		s %Type{"float"}
+		s %Name{"Emissive"}
+		s %Type{"ezVec3"}
 	}
 }
 o
@@ -605,7 +607,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"Roughness"}
+		s %Name{"Reflectance"}
 		s %Type{"float"}
 	}
 }
@@ -616,7 +618,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0}
+		Vec3 %Value{f{0x0000803F,0x0000803F,0x0000803F}}
 	}
 }
 o
@@ -670,8 +672,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"SubsurfaceColor"}
-		s %Type{"ezVec3"}
+		s %Name{"RefractionColor"}
+		s %Type{"ezVec4"}
 	}
 }
 o
@@ -688,8 +690,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"RefractionColor"}
-		s %Type{"ezVec4"}
+		s %Name{"Occlusion"}
+		s %Type{"float"}
 	}
 }
 o
@@ -721,7 +723,7 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"Opacity"}
+		s %Name{"Roughness"}
 		s %Type{"float"}
 	}
 }
@@ -754,8 +756,18 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"Reflectance"}
+		s %Name{"Metallic"}
 		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{168057228374501286,6251753556952912477}}
+	s %t{"ezDefaultValueAttribute"}
+	u3 %v{1}
+	p
+	{
+		Vec3 %Value{f{0,0,0}}
 	}
 }
 o
@@ -846,7 +858,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x0000803F}
+		f %Value{0x0000003F}
 	}
 }
 o
@@ -921,7 +933,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x0000003F}
+		f %Value{0}
 	}
 }
 o
@@ -963,7 +975,7 @@ o
 	u3 %v{1}
 	p
 	{
-		Vec3 %Value{f{0,0,0}}
+		Vec4 %Value{f{0,0,0,0x0000803F}}
 	}
 }
 o
@@ -980,8 +992,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"Metallic"}
-		s %Type{"float"}
+		s %Name{"BaseColor"}
+		s %Type{"ezVec3"}
 	}
 }
 o
@@ -1008,7 +1020,25 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"Emissive"}
+		s %Name{"Opacity"}
+		s %Type{"float"}
+	}
+}
+o
+{
+	Uuid %id{u4{5182949022402297138,11502908056830025687}}
+	s %t{"ezReflectedPropertyDescriptor"}
+	u3 %v{2}
+	p
+	{
+		VarArray %Attributes
+		{
+			Uuid{u4{168057228374501286,6251753556952912477}}
+		}
+		s %Category{"ezPropertyCategory::Member"}
+		Invalid %ConstantValue{}
+		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
+		s %Name{"SubsurfaceColor"}
 		s %Type{"ezVec3"}
 	}
 }
@@ -1100,8 +1130,8 @@ o
 		s %Category{"ezPropertyCategory::Member"}
 		Invalid %ConstantValue{}
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::Phantom"}
-		s %Name{"BaseColor"}
-		s %Type{"ezVec3"}
+		s %Name{"ApplyDecals"}
+		s %Type{"bool"}
 	}
 }
 o
@@ -1111,7 +1141,7 @@ o
 	u3 %v{1}
 	p
 	{
-		Vec3 %Value{f{0,0,0}}
+		f %Value{0x0000803F}
 	}
 }
 o
@@ -1139,7 +1169,7 @@ o
 	u3 %v{1}
 	p
 	{
-		Vec3 %Value{f{0x0000803F,0x0000803F,0x0000803F}}
+		b %Value{1}
 	}
 }
 o
@@ -1230,7 +1260,7 @@ o
 	u3 %v{1}
 	p
 	{
-		f %Value{0x0000803F}
+		Vec3 %Value{f{0,0,0}}
 	}
 }
 o
@@ -1333,7 +1363,7 @@ o
 	u3 %v{1}
 	p
 	{
-		Vec4 %Value{f{0,0,0,0x0000803F}}
+		f %Value{0x0000803F}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Scenes/Main.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Main.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{12721122281920259769}
+		u4 %Hash{15506299023615416033}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -38,6 +38,7 @@ o
 			s{"{ 51b6f98e-5474-4a6b-b638-beec9565f502 }"}
 			s{"{ 522c7e02-3e76-4d5d-ba3e-1936544bbdff }"}
 			s{"{ 526ebdd3-265d-4bbb-93a3-6389cec9d729 }"}
+			s{"{ 543eb7d6-eb32-4738-9d31-d65239525222 }"}
 			s{"{ 580aefec-1a70-4442-9c88-d213519f8b8f }"}
 			s{"{ 5f7e8998-fe23-4a33-aa84-d10d4dfcf2a6 }"}
 			s{"{ 6082de35-c174-4c40-a5a5-17fd67b11ce5 }"}
@@ -117,6 +118,7 @@ o
 			s{"{ 4f850b7b-e53d-4f0c-9efd-15b35ffa6962 }"}
 			s{"{ 51b6f98e-5474-4a6b-b638-beec9565f502 }"}
 			s{"{ 522c7e02-3e76-4d5d-ba3e-1936544bbdff }"}
+			s{"{ 543eb7d6-eb32-4738-9d31-d65239525222 }"}
 			s{"{ 580aefec-1a70-4442-9c88-d213519f8b8f }"}
 			s{"{ 5f7e8998-fe23-4a33-aa84-d10d4dfcf2a6 }"}
 			s{"{ 6082de35-c174-4c40-a5a5-17fd67b11ce5 }"}
@@ -1589,32 +1591,6 @@ o
 }
 o
 {
-	Uuid %id{u4{926741693450784634,1976556240644026349}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{16649201847367863911,2459840242960010788}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x0000AE40,0x00C0B0C1,0x00000035}}
-		Quat %LocalRotation{f{0,0,0x16EFC3BE,0x5E836C3F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{3036348538428995198,1978574117014545728}}
 	s %t{"ezParticleComponent"}
 	u3 %v{5}
@@ -2390,25 +2366,6 @@ o
 }
 o
 {
-	Uuid %id{u4{16649201847367863911,2459840242960010788}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{13550982391782579258,2466606769076845071}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -2732,6 +2689,32 @@ o
 		s %SharedInstanceName{""}
 		b %SpawnAtStart{1}
 		s %SpawnDirection{"ezBasisAxis::PositiveZ"}
+	}
+}
+o
+{
+	Uuid %id{u4{6442685378968481410,2619875815398175256}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{3718401459176009071,3103159817714159695}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x541565C1,0x7F3F44C1,0x0800003F}}
+		Quat %LocalRotation{f{0,0,0x16EFC3BE,0x5E836C3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"AutoColMesh"}
+		}
 	}
 }
 o
@@ -3538,6 +3521,25 @@ o
 }
 o
 {
+	Uuid %id{u4{3718401459176009071,3103159817714159695}}
+	s %t{"ezHeightfieldComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec2u %ColMeshTesselation{u3{16,16}}
+		b %GenerateCollision{1}
+		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
+		f %Height{0x0000A040}
+		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
+		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
+		Vec2u %Tesselation{u3{32,32}}
+		Vec2 %TexCoordOffset{f{0,0}}
+		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
+	}
+}
+o
+{
 	Uuid %id{u4{10361909016710503512,3193876396421700986}}
 	s %t{"ezFakeRopeComponent"}
 	u3 %v{3}
@@ -3936,6 +3938,32 @@ o
 }
 o
 {
+	Uuid %id{u4{707962529034654242,4142563897004265381}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16430422682951733519,4625847899320249820}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xA09DA440,0xF0ECB841,0x00000035}}
+		Quat %LocalRotation{f{0,0,0xCBD71BBF,0x34194B3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{11322252982643972853,4179265412389056509}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -4326,6 +4354,25 @@ o
 		s %SharedInstanceName{""}
 		b %SpawnAtStart{1}
 		s %SpawnDirection{"ezBasisAxis::PositiveZ"}
+	}
+}
+o
+{
+	Uuid %id{u4{16430422682951733519,4625847899320249820}}
+	s %t{"ezHeightfieldComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec2u %ColMeshTesselation{u3{16,16}}
+		b %GenerateCollision{1}
+		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
+		f %Height{0x0000A040}
+		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
+		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
+		Vec2u %Tesselation{u3{32,32}}
+		Vec2 %TexCoordOffset{f{0,0}}
+		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
 	}
 }
 o
@@ -10004,32 +10051,6 @@ o
 }
 o
 {
-	Uuid %id{u4{9570406273182852268,5251745451230879567}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{6846122353390379929,5735029453546864006}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x00008E40,0x0000CBC0,0x00000035}}
-		Quat %LocalRotation{f{0,0,0,0x0000803F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{15571647124614831757,5263395047586077476}}
 	s %t{"ezPrefabReferenceComponent"}
 	u3 %v{4}
@@ -12402,40 +12423,6 @@ o
 }
 o
 {
-	Uuid %id{u4{603381307494182539,5518260189028378895}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children
-		{
-			Uuid{u4{9570406273182852268,5251745451230879567}}
-			Uuid{u4{17761976448077637177,10015479726080041145}}
-			Uuid{u4{11301035487477496019,15661488977724350294}}
-			Uuid{u4{926741693450784634,1976556240644026349}}
-			Uuid{u4{15183705890337747250,7223220241647355491}}
-			Uuid{u4{15184413879162990691,10992175113753623113}}
-			Uuid{u4{11780562831746814646,11948047087862524357}}
-			Uuid{u4{5566312637543668851,17184177059330440419}}
-		}
-		VarArray %Components{}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x00C025C2,0x00C09241,0xD1349940}}
-		Quat %LocalRotation{f{0,0,0,0x0000803F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{"Terrain"}
-		VarArray %Tags
-		{
-			s{"CastShadow"}
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{85272366116542135,5518975260102559105}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -14425,25 +14412,6 @@ o
 }
 o
 {
-	Uuid %id{u4{6846122353390379929,5735029453546864006}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x00002041,0x00002041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{15639044592868290449,5743055630991095592}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -15210,7 +15178,6 @@ o
 			Uuid{u4{1614171555409169821,5437998280226109731}}
 			Uuid{u4{3947003308069612624,10637121186424612541}}
 			Uuid{u4{11172347283609373525,1176797310416435819}}
-			Uuid{u4{603381307494182539,5518260189028378895}}
 			Uuid{u4{4977511570756208798,12939163566617067275}}
 			Uuid{u4{9295392638145697467,4813552625071262577}}
 			Uuid{u4{6274990214136178021,3070574863935728770}}
@@ -15266,6 +15233,7 @@ o
 			Uuid{u4{15536528723240958112,5118218595794246475}}
 			Uuid{u4{4012970955276113321,5241426715688777744}}
 			Uuid{u4{1778919280459753151,4840405745262177921}}
+			Uuid{u4{14191775272694719546,10923391100411755473}}
 		}
 		Uuid %Settings{u4{11204937990389899402,5417500911553874876}}
 	}
@@ -15810,32 +15778,6 @@ o
 }
 o
 {
-	Uuid %id{u4{15183705890337747250,7223220241647355491}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{12459421970545274911,7706504243963339930}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x000021C1,0x0040B341,0x00000035}}
-		Quat %LocalRotation{f{0,0,0xD8B35DBF,0xFEFFFF3E}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{18268630161957445675,7224763018323184089}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -15923,6 +15865,32 @@ o
 		VarArray %Tags
 		{
 			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{14515135658651321641,7381687152027402927}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11790851738858849302,7864971154343387366}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x0000AE40,0x00C0B0C1,0xC099193E}}
+		Quat %LocalRotation{f{0,0,0x16EFC3BE,0x5E836C3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
 			s{"AutoColMesh"}
 		}
 	}
@@ -16424,25 +16392,6 @@ o
 }
 o
 {
-	Uuid %id{u4{12459421970545274911,7706504243963339930}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{11736052350132180003,7732508100600035575}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -16626,6 +16575,25 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{11790851738858849302,7864971154343387366}}
+	s %t{"ezHeightfieldComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec2u %ColMeshTesselation{u3{16,16}}
+		b %GenerateCollision{1}
+		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
+		f %Height{0x0000A040}
+		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
+		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
+		Vec2u %Tesselation{u3{32,32}}
+		Vec2 %TexCoordOffset{f{0,0}}
+		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
 	}
 }
 o
@@ -19431,32 +19399,6 @@ o
 }
 o
 {
-	Uuid %id{u4{17761976448077637177,10015479726080041145}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{15037692528285164838,10498763728396025584}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x0000BAC0,0x008005C1,0x00000035}}
-		Quat %LocalRotation{f{0,0,0,0x0000803F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{15874228700132223608,10024025888939685378}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -19993,6 +19935,32 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16485958582333063014,10182852596148097998}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{17655760554861543771,10594382171276402100}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xC0CCBA40,0x3433CEC0,0x98734EC0}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
 	}
 }
 o
@@ -21624,25 +21592,6 @@ o
 }
 o
 {
-	Uuid %id{u4{15037692528285164838,10498763728396025584}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x00002041,0x00002041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{13953849811979832626,10499310123304626417}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -22181,6 +22130,33 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{17655760554861543771,10594382171276402100}}
+	s %t{"ezGreyBoxComponent"}
+	u3 %v{7}
+	p
+	{
+		b %Active{1}
+		Color %Color{f{0x0000803F,0x0000803F,0x0000803F,0x0000803F}}
+		Angle %Curvature{f{0}}
+		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
+		u3 %Detail{32}
+		b %GenerateCollision{1}
+		s %Material{"{ 543eb7d6-eb32-4738-9d31-d65239525222 }"}
+		s %Shape{"ezGreyBoxShape::Column"}
+		f %SizeNegX{0x66669E41}
+		f %SizeNegY{0x00008841}
+		f %SizeNegZ{0x66665640}
+		f %SizePosX{0x6866EE40}
+		f %SizePosY{0x9A997941}
+		f %SizePosZ{0}
+		b %SlopedBottom{0}
+		b %SlopedTop{0}
+		f %Thickness{0x0000003F}
+		b %UseAsOccluder{1}
 	}
 }
 o
@@ -23507,6 +23483,38 @@ o
 }
 o
 {
+	Uuid %id{u4{14191775272694719546,10923391100411755473}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children
+		{
+			Uuid{u4{6442685378968481410,2619875815398175256}}
+			Uuid{u4{14515135658651321641,7381687152027402927}}
+			Uuid{u4{10325355781828732641,12628351153030732069}}
+			Uuid{u4{6922212723237800037,17353177999245900935}}
+			Uuid{u4{707962529034654242,4142563897004265381}}
+			Uuid{u4{16485958582333063014,10182852596148097998}}
+		}
+		VarArray %Components{}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x00C025C2,0x00C09241,0xD1349940}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{"Terrain"}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{7142310433455296102,10925688729525564658}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -23648,32 +23656,6 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
-	}
-}
-o
-{
-	Uuid %id{u4{15184413879162990691,10992175113753623113}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{12460129959370518352,11475459116069607552}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x0080B2C1,0x00008BC0,0x00000035}}
-		Quat %LocalRotation{f{0,0,0,0x0000803F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
 	}
 }
 o
@@ -24764,25 +24746,6 @@ o
 }
 o
 {
-	Uuid %id{u4{12460129959370518352,11475459116069607552}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x00002041,0x00002041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{2035173738460620150,11528906696731166649}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -24982,32 +24945,6 @@ o
 		s %Mode{"ezObjectMode::Automatic"}
 		s %Name{""}
 		VarArray %Tags{}
-	}
-}
-o
-{
-	Uuid %id{u4{11780562831746814646,11948047087862524357}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{9056278911954342307,12431331090178508796}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x00004341,0x00006A40,0x00000035}}
-		Quat %LocalRotation{f{0,0,0xCBD71BBF,0x34194B3F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
 	}
 }
 o
@@ -25262,25 +25199,6 @@ o
 }
 o
 {
-	Uuid %id{u4{9056278911954342307,12431331090178508796}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{10478248890730334832,12440072588013365095}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -25531,6 +25449,32 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
+	}
+}
+o
+{
+	Uuid %id{u4{10325355781828732641,12628351153030732069}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{7601071862036260302,13111635155346716508}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xCCCC5DC1,0xFC307D41,0x80CC4CBD}}
+		Quat %LocalRotation{f{0,0,0xD8B35DBF,0xFEFFFF3E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"AutoColMesh"}
+		}
 	}
 }
 o
@@ -26205,6 +26149,25 @@ o
 		s %SharedInstanceName{""}
 		b %SpawnAtStart{1}
 		s %SpawnDirection{"ezBasisAxis::PositiveZ"}
+	}
+}
+o
+{
+	Uuid %id{u4{7601071862036260302,13111635155346716508}}
+	s %t{"ezHeightfieldComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec2u %ColMeshTesselation{u3{16,16}}
+		b %GenerateCollision{1}
+		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
+		f %Height{0x0000A040}
+		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
+		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
+		Vec2u %Tesselation{u3{32,32}}
+		Vec2 %TexCoordOffset{f{0,0}}
+		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
 	}
 }
 o
@@ -30408,32 +30371,6 @@ o
 }
 o
 {
-	Uuid %id{u4{11301035487477496019,15661488977724350294}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{8576751567685023680,16144772980040334733}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x000035C1,0x008039C1,0x00000035}}
-		Quat %LocalRotation{f{0,0,0x16EFC3BE,0x5E836C3F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{11969685683401567197,15663338383299141306}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -32063,25 +32000,6 @@ o
 }
 o
 {
-	Uuid %id{u4{8576751567685023680,16144772980040334733}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{1337394534892566739,16151171786344485584}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -33390,32 +33308,6 @@ o
 }
 o
 {
-	Uuid %id{u4{5566312637543668851,17184177059330440419}}
-	s %t{"ezGameObject"}
-	u3 %v{1}
-	p
-	{
-		b %Active{1}
-		VarArray %Children{}
-		VarArray %Components
-		{
-			Uuid{u4{2842028717751196512,17667461061646424858}}
-		}
-		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x0080DB41,0x0040D541,0x00000035}}
-		Quat %LocalRotation{f{0,0,0xCBD71BBF,0x34194B3F}}
-		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
-		f %LocalUniformScaling{0x0000803F}
-		s %Mode{"ezObjectMode::Automatic"}
-		s %Name{""}
-		VarArray %Tags
-		{
-			s{"AutoColMesh"}
-		}
-	}
-}
-o
-{
 	Uuid %id{u4{14534098682451307405,17223585064829349867}}
 	s %t{"ezSliderComponent"}
 	u3 %v{3}
@@ -33431,6 +33323,32 @@ o
 		b %ReverseAtStart{1}
 		b %Running{1}
 		f %Speed{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{6922212723237800037,17353177999245900935}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{4197928803445327698,17836462001561885374}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x2A737341,0x301B4B40,0x626686BF}}
+		Quat %LocalRotation{f{0,0,0xA4A8053E,0x55CF7D3F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"AutoColMesh"}
+		}
 	}
 }
 o
@@ -33710,25 +33628,6 @@ o
 }
 o
 {
-	Uuid %id{u4{2842028717751196512,17667461061646424858}}
-	s %t{"ezHeightfieldComponent"}
-	u3 %v{2}
-	p
-	{
-		b %Active{1}
-		Vec2u %ColMeshTesselation{u3{16,16}}
-		b %GenerateCollision{1}
-		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
-		f %Height{0x0000A040}
-		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
-		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
-		Vec2u %Tesselation{u3{32,32}}
-		Vec2 %TexCoordOffset{f{0,0}}
-		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
-	}
-}
-o
-{
 	Uuid %id{u4{10994456798952350532,17721022814617676320}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -33859,6 +33758,25 @@ o
 		u3 %Temperature{6550}
 		b %TransparentShadows{0}
 		b %UseColorTemperature{0}
+	}
+}
+o
+{
+	Uuid %id{u4{4197928803445327698,17836462001561885374}}
+	s %t{"ezHeightfieldComponent"}
+	u3 %v{2}
+	p
+	{
+		b %Active{1}
+		Vec2u %ColMeshTesselation{u3{16,16}}
+		b %GenerateCollision{1}
+		Vec2 %HalfExtents{f{0x0000A041,0x0000A041}}
+		f %Height{0x0000A040}
+		s %HeightfieldImage{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
+		s %Material{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
+		Vec2u %Tesselation{u3{32,32}}
+		Vec2 %TexCoordOffset{f{0,0}}
+		Vec2 %TexCoordScale{f{0x00008040,0x00008040}}
 	}
 }
 o

--- a/Data/Samples/Testing Chambers/Scenes/Main.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Main.ezScene
@@ -11,11 +11,12 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{7297922959506964864,5177324930371449723}}
-		u4 %Hash{15506299023615416033}
+		u4 %Hash{9360711512524413630}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
 		{
+			s{"{ 0425bf65-7a42-4f20-adfc-56f09ea2cae9 }"}
 			s{"{ 0b202e08-a64f-465d-b38e-15b81d161822 }"}
 			s{"{ 0b975f05-9508-4ea4-9c1e-750f1f3386ba }"}
 			s{"{ 0c8dd872-9e75-4ea9-955e-442f9e2c2323 }"}
@@ -81,6 +82,7 @@ o
 			s{"{ cb429221-40ae-4e6d-842b-b37b3709cd58 }"}
 			s{"{ cdcc5813-2f08-4542-b310-fdcc84dc134e }"}
 			s{"{ d037502d-21e1-4123-a7e4-3bfd5877c2e8 }"}
+			s{"{ d16f8af4-ee4f-41f7-b0ef-c4d7e3c5f36d }"}
 			s{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
 			s{"{ d615cd66-0904-00ca-81f9-768ff4fc24ee }"}
 			s{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
@@ -99,6 +101,7 @@ o
 		}
 		VarArray %References
 		{
+			s{"{ 0425bf65-7a42-4f20-adfc-56f09ea2cae9 }"}
 			s{"{ 0b202e08-a64f-465d-b38e-15b81d161822 }"}
 			s{"{ 0b975f05-9508-4ea4-9c1e-750f1f3386ba }"}
 			s{"{ 0c8dd872-9e75-4ea9-955e-442f9e2c2323 }"}
@@ -149,6 +152,7 @@ o
 			s{"{ cb3fcb70-258b-4b4e-a79e-0537ace7d7e3 }"}
 			s{"{ cb429221-40ae-4e6d-842b-b37b3709cd58 }"}
 			s{"{ cdcc5813-2f08-4542-b310-fdcc84dc134e }"}
+			s{"{ d16f8af4-ee4f-41f7-b0ef-c4d7e3c5f36d }"}
 			s{"{ d2a92ebd-fd90-4214-9455-ca14b38571f5 }"}
 			s{"{ d615cd66-0904-00ca-81f9-768ff4fc24ee }"}
 			s{"{ d63193e0-3e77-4960-a51a-9c8a45393450 }"}
@@ -2705,8 +2709,8 @@ o
 			Uuid{u4{3718401459176009071,3103159817714159695}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x541565C1,0x7F3F44C1,0x0800003F}}
-		Quat %LocalRotation{f{0,0,0x16EFC3BE,0x5E836C3F}}
+		Vec3 %LocalPosition{f{0x541565C1,0x37F73AC1,0x0800003F}}
+		Quat %LocalRotation{f{0,0,0x0A0C7ABF,0x4E8B5B3E}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
@@ -3950,8 +3954,8 @@ o
 			Uuid{u4{16430422682951733519,4625847899320249820}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0xA09DA440,0xF0ECB841,0x00000035}}
-		Quat %LocalRotation{f{0,0,0xCBD71BBF,0x34194B3F}}
+		Vec3 %LocalPosition{f{0x206EDE40,0x4464B041,0x00000035}}
+		Quat %LocalRotation{f{0,0,0x42665BBF,0x9CE8033F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
 		s %Mode{"ezObjectMode::Automatic"}
@@ -5095,6 +5099,19 @@ o
 }
 o
 {
+	Uuid %id{u4{6711197402938653865,4725547275123352337}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ 6d2f2203-1c29-417b-bb1b-b434080e8fed }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
 	Uuid %id{u4{6901218708791995038,4726714664285598441}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -5271,6 +5288,18 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
+	}
+}
+o
+{
+	Uuid %id{u4{16406060068849329306,4738256361394742847}}
+	s %t{"ezKrautTreeComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		s %KrautTree{"{ d16f8af4-ee4f-41f7-b0ef-c4d7e3c5f36d }"}
+		u2 %VariationIndex{65535}
 	}
 }
 o
@@ -5533,6 +5562,18 @@ o
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
 		b %UseAsOccluder{1}
+	}
+}
+o
+{
+	Uuid %id{u4{11173347516372346767,4772383541940059945}}
+	s %t{"ezKrautTreeComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		s %KrautTree{"{ 0425bf65-7a42-4f20-adfc-56f09ea2cae9 }"}
+		u2 %VariationIndex{65535}
 	}
 }
 o
@@ -6288,6 +6329,32 @@ o
 		s %RmlFile{"{ 85b1daee-d583-4146-ae88-c628e3ead476 }"}
 		Vec2u %TextureSize{u3{512,512}}
 		s %TextureSlotName{"BaseTexture"}
+	}
+}
+o
+{
+	Uuid %id{u4{14021975442848134551,4860818590376751854}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{11173347516372346767,4772383541940059945}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x8BA638C2,0x60B90B41,0x6E5B1540}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
 	}
 }
 o
@@ -7395,6 +7462,32 @@ o
 		{
 			s{"CastShadow"}
 			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{15009546707440310400,4987524778241897388}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6711197402938653865,4725547275123352337}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7A9029C2,0x8EAD9F41,0xBC201E3F}}
+		Quat %LocalRotation{f{0x74B1113F,0x44DCD63E,0x6B8B343F,0xB5C7513D}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
 		}
 	}
 }
@@ -9165,6 +9258,32 @@ o
 		s %Surface{"{ ac49f52b-70b6-468e-b934-af2373a806bc }"}
 		u1 %WeightCategory{2}
 		f %WeightScale{0x0000803F}
+	}
+}
+o
+{
+	Uuid %id{u4{6264946971220094853,5165923059926355198}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{16406060068849329306,4738256361394742847}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x9A9937C2,0x9A99E741,0xCDCC0C40}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
 	}
 }
 o
@@ -15234,6 +15353,17 @@ o
 			Uuid{u4{4012970955276113321,5241426715688777744}}
 			Uuid{u4{1778919280459753151,4840405745262177921}}
 			Uuid{u4{14191775272694719546,10923391100411755473}}
+			Uuid{u4{6264946971220094853,5165923059926355198}}
+			Uuid{u4{14021975442848134551,4860818590376751854}}
+			Uuid{u4{3577042866992837435,10907631146374871901}}
+			Uuid{u4{8149442525150924313,10854542622937188271}}
+			Uuid{u4{11499988508053047581,10519575668142310857}}
+			Uuid{u4{15009546707440310400,4987524778241897388}}
+			Uuid{u4{11128884249503544327,9814815956380681117}}
+			Uuid{u4{4854142102055198720,10532081631862947037}}
+			Uuid{u4{14886586461681879812,10135626432374473579}}
+			Uuid{u4{13864437451735791011,14459054319455821462}}
+			Uuid{u4{587110551127789462,15543922883889352114}}
 		}
 		Uuid %Settings{u4{11204937990389899402,5417500911553874876}}
 	}
@@ -17842,6 +17972,19 @@ o
 }
 o
 {
+	Uuid %id{u4{2830534945001887792,9552838453262136066}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ 6d2f2203-1c29-417b-bb1b-b434080e8fed }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
 	Uuid %id{u4{10277689818698545761,9562048869646445838}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -18398,6 +18541,32 @@ o
 }
 o
 {
+	Uuid %id{u4{11128884249503544327,9814815956380681117}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{2830534945001887792,9552838453262136066}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xE9D124C2,0x2FB1A541,0xDA191E3F}}
+		Quat %LocalRotation{f{0x91040CBF,0x1579E53E,0x35D4053F,0xF8C5F33E}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{6385124540062664837,9819713809479447823}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -18558,6 +18727,19 @@ o
 			s{"CastShadow"}
 			s{"AutoColMesh"}
 		}
+	}
+}
+o
+{
+	Uuid %id{u4{6588237157180223277,9873648929255928528}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ 6d2f2203-1c29-417b-bb1b-b434080e8fed }"}
+		b %ShowShapeIcons{0}
 	}
 }
 o
@@ -19691,6 +19873,32 @@ o
 }
 o
 {
+	Uuid %id{u4{14886586461681879812,10135626432374473579}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{6588237157180223277,9873648929255928528}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x10DE26C2,0xE83CAA41,0x51211E3F}}
+		Quat %LocalRotation{f{0x173BC23E,0x82C318BF,0x418B02BE,0x7B0D323F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{8958313302936811607,10136289721537297313}}
 	s %t{"ezPrefabReferenceComponent"}
 	u3 %v{4}
@@ -19951,7 +20159,7 @@ o
 			Uuid{u4{17655760554861543771,10594382171276402100}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0xC0CCBA40,0x3433CEC0,0x98734EC0}}
+		Vec3 %LocalPosition{f{0xC0648A40,0x3433CEC0,0xFEA853C0}}
 		Quat %LocalRotation{f{0,0,0,0x0000803F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
@@ -20152,6 +20360,19 @@ o
 		b %Active{1}
 		VarDict %Parameters{}
 		s %Prefab{"{ 4f850b7b-e53d-4f0c-9efd-15b35ffa6962 }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{15002536871263093801,10270104128744401986}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ 6d2f2203-1c29-417b-bb1b-b434080e8fed }"}
 		b %ShowShapeIcons{0}
 	}
 }
@@ -21215,6 +21436,18 @@ o
 }
 o
 {
+	Uuid %id{u4{18290555622780158766,10426875924405575920}}
+	s %t{"ezKrautTreeComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		s %KrautTree{"{ d16f8af4-ee4f-41f7-b0ef-c4d7e3c5f36d }"}
+		u2 %VariationIndex{65535}
+	}
+}
+o
+{
 	Uuid %id{u4{2147398474610728779,10429579530174423996}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -21251,6 +21484,18 @@ o
 		VarDict %Parameters{}
 		s %Prefab{"{ 580aefec-1a70-4442-9c88-d213519f8b8f }"}
 		b %ShowShapeIcons{0}
+	}
+}
+o
+{
+	Uuid %id{u4{8651360581577259797,10431140619705618948}}
+	s %t{"ezKrautTreeComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		s %KrautTree{"{ 0425bf65-7a42-4f20-adfc-56f09ea2cae9 }"}
+		u2 %VariationIndex{65535}
 	}
 }
 o
@@ -21556,6 +21801,18 @@ o
 }
 o
 {
+	Uuid %id{u4{13718155964622071888,10479964447843259550}}
+	s %t{"ezKrautTreeComponent"}
+	u3 %v{3}
+	p
+	{
+		b %Active{1}
+		s %KrautTree{"{ d16f8af4-ee4f-41f7-b0ef-c4d7e3c5f36d }"}
+		u2 %VariationIndex{65535}
+	}
+}
+o
+{
 	Uuid %id{u4{4908264646402161246,10482963789985639801}}
 	s %t{"ezPrefabReferenceComponent"}
 	u3 %v{4}
@@ -21659,6 +21916,32 @@ o
 }
 o
 {
+	Uuid %id{u4{11499988508053047581,10519575668142310857}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{8651360581577259797,10431140619705618948}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x666640C2,0x9A999341,0xED368E3F}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{5018848927503455499,10525381803639232570}}
 	s %t{"ezGameObject"}
 	u3 %v{1}
@@ -21708,6 +21991,32 @@ o
 		{
 			s{"CastShadow"}
 			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{4854142102055198720,10532081631862947037}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{15002536871263093801,10270104128744401986}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0xDD5221C2,0x5EB0AC41,0x6B4BA63E}}
+		Quat %LocalRotation{f{0x2F59B3BE,0x848002BF,0xE0533FBF,0x606F78BE}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
 		}
 	}
 }
@@ -22144,19 +22453,19 @@ o
 		Angle %Curvature{f{0}}
 		Vec4 %CustomData{f{0,0x0000803F,0,0x0000803F}}
 		u3 %Detail{32}
-		b %GenerateCollision{1}
+		b %GenerateCollision{0}
 		s %Material{"{ 543eb7d6-eb32-4738-9d31-d65239525222 }"}
 		s %Shape{"ezGreyBoxShape::Column"}
 		f %SizeNegX{0x66669E41}
 		f %SizeNegY{0x00008841}
 		f %SizeNegZ{0x66665640}
-		f %SizePosX{0x6866EE40}
-		f %SizePosY{0x9A997941}
+		f %SizePosX{0x9B99F140}
+		f %SizePosY{0x34339F41}
 		f %SizePosZ{0}
 		b %SlopedBottom{0}
 		b %SlopedTop{0}
 		f %Thickness{0x0000003F}
-		b %UseAsOccluder{1}
+		b %UseAsOccluder{0}
 	}
 }
 o
@@ -23140,6 +23449,32 @@ o
 }
 o
 {
+	Uuid %id{u4{8149442525150924313,10854542622937188271}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{18290555622780158766,10426875924405575920}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x00000BC2,0x6666B841,0x7363BA3F}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
+	}
+}
+o
+{
 	Uuid %id{u4{10526263586602435914,10856172074028864907}}
 	s %t{"ezShapeIconComponent"}
 	u3 %v{1}
@@ -23397,6 +23732,32 @@ o
 		{
 			s{"CastShadow"}
 			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{3577042866992837435,10907631146374871901}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{13718155964622071888,10479964447843259550}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x33331BC2,0x6766A640,0x33332340}}
+		Quat %LocalRotation{f{0,0,0,0x0000803F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
 		}
 	}
 }
@@ -27207,6 +27568,19 @@ o
 }
 o
 {
+	Uuid %id{u4{5566088147234134476,14197076816337276411}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ 6d2f2203-1c29-417b-bb1b-b434080e8fed }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
 	Uuid %id{u4{12561045803166298055,14202016149960612534}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -27329,6 +27703,32 @@ o
 		{
 			s{"CastShadow"}
 			s{"AutoColMesh"}
+		}
+	}
+}
+o
+{
+	Uuid %id{u4{13864437451735791011,14459054319455821462}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{5566088147234134476,14197076816337276411}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x72260FC2,0x9D4E4541,0x8708293F}}
+		Quat %LocalRotation{f{0x61313FBF,0x944B6B3E,0x6C0FA13E,0x86F8093F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
 		}
 	}
 }
@@ -29047,6 +29447,19 @@ o
 }
 o
 {
+	Uuid %id{u4{10735505320335684543,15281945380770807063}}
+	s %t{"ezPrefabReferenceComponent"}
+	u3 %v{4}
+	p
+	{
+		b %Active{1}
+		VarDict %Parameters{}
+		s %Prefab{"{ 6d2f2203-1c29-417b-bb1b-b434080e8fed }"}
+		b %ShowShapeIcons{0}
+	}
+}
+o
+{
 	Uuid %id{u4{3976225222128118005,15297265400526264592}}
 	s %t{"ezGreyBoxComponent"}
 	u3 %v{7}
@@ -29988,6 +30401,32 @@ o
 		s %Spline{"{ db886e00-1fef-40e2-b507-92504af40a93 }"}
 		f %StartDistance{0x00002041}
 		f %TiltAmount{0x0000A040}
+	}
+}
+o
+{
+	Uuid %id{u4{587110551127789462,15543922883889352114}}
+	s %t{"ezGameObject"}
+	u3 %v{1}
+	p
+	{
+		b %Active{1}
+		VarArray %Children{}
+		VarArray %Components
+		{
+			Uuid{u4{10735505320335684543,15281945380770807063}}
+		}
+		s %GlobalKey{""}
+		Vec3 %LocalPosition{f{0x7C6D28C2,0xB9E89A41,0xA211A03E}}
+		Quat %LocalRotation{f{0x3D92593B,0x342FA83C,0x8FCEDC3E,0x93E8663F}}
+		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
+		f %LocalUniformScaling{0x0000803F}
+		s %Mode{"ezObjectMode::Automatic"}
+		s %Name{""}
+		VarArray %Tags
+		{
+			s{"CastShadow"}
+		}
 	}
 }
 o
@@ -33339,7 +33778,7 @@ o
 			Uuid{u4{4197928803445327698,17836462001561885374}}
 		}
 		s %GlobalKey{""}
-		Vec3 %LocalPosition{f{0x2A737341,0x301B4B40,0x626686BF}}
+		Vec3 %LocalPosition{f{0x2A737341,0x301B4B40,0x682A59BF}}
 		Quat %LocalRotation{f{0,0,0xA4A8053E,0x55CF7D3F}}
 		Vec3 %LocalScaling{f{0x0000803F,0x0000803F,0x0000803F}}
 		f %LocalUniformScaling{0x0000803F}
@@ -38139,6 +38578,23 @@ o
 		s %Flags{"ezPropertyFlags::StandardType|ezPropertyFlags::ReadOnly"}
 		s %Name{"ezJoltRopeAnchorConstraintMode::Point"}
 		s %Type{"ezInt8"}
+	}
+}
+o
+{
+	Uuid %id{u4{9882684502593738813,12242697362626301325}}
+	s %t{"ezReflectedTypeDescriptor"}
+	u3 %v{1}
+	p
+	{
+		VarArray %Attributes{}
+		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
+		VarArray %Functions{}
+		s %ParentTypeName{"ezRenderComponent"}
+		s %PluginName{"ezEditorPluginKraut"}
+		VarArray %Properties{}
+		s %TypeName{"ezKrautTreeComponent"}
+		u3 %TypeVersion{3}
 	}
 }
 o

--- a/Data/Tools/ezEditor/VisualShader/Inputs.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Inputs.ddl
@@ -161,21 +161,21 @@ Node %VertexWorldPosition
   {
     string %Type { "float" }
     string %Color { "Red" }
-    string %Inline { "G.Input.Position.x" }
+    string %Inline { "G.Input.WorldPosition.x" }
   }
 
   OutputPin %Y
   {
     string %Type { "float" }
     string %Color { "Green" }
-    string %Inline { "G.Input.Position.y" }
+    string %Inline { "G.Input.WorldPosition.y" }
   }
 
   OutputPin %Z
   {
     string %Type { "float" }
     string %Color { "Blue" }
-    string %Inline { "G.Input.Position.z" }
+    string %Inline { "G.Input.WorldPosition.z" }
   }
 }
 

--- a/Data/Tools/ezEditor/VisualShader/Output_Material.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Output_Material.ddl
@@ -96,7 +96,6 @@ float MaskThreshold @Default($prop0);
 #define USE_MATERIAL_EMISSIVE
 #define USE_MATERIAL_OCCLUSION
 #define USE_TWO_SIDED_LIGHTING
-#define USE_DECALS
 
 #if VERTEX_SKINNING
   #define USE_SKINNING
@@ -108,6 +107,10 @@ float MaskThreshold @Default($prop0);
 
 #if $prop1
   #define USE_FOG
+#endif
+
+#if $prop2
+  #define USE_DECALS
 #endif
 
 #if INPUT_PIN_1_CONNECTED
@@ -215,6 +218,12 @@ float3 GetSubsurfaceColor()
   }
   
   Property %ApplyFog
+  {
+    string %Type { "bool" }
+    string %DefaultValue { "true" }
+  }
+
+  Property %ApplyDecals
   {
     string %Type { "bool" }
     string %DefaultValue { "true" }

--- a/Data/Tools/ezEditor/VisualShader/Utils.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Utils.ddl
@@ -85,6 +85,19 @@ Node %DepthFade
   }
 }
 
+Node %PixelDepth
+{
+  string %Category { "Utils" }
+  string %Color { "Green" }
+  string %Docs { "Returns the depth at the current pixel." }
+ 
+  OutputPin %Depth
+  {
+    string %Type { "float" }
+    string %Inline { "G.Input.Position.w" }
+  }
+}
+
 Node %Fresnel
 {
   string %Category { "Utils" }

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: B7F2587B-843F-4A2E-8840-C055DAD3A021AAB123
+Change me: A7920CB7-B6E0-4555-B76C-FF53BDD6D330


### PR DESCRIPTION
The 'Main' scene in the Testing Chamber example contains a basic example material for how to make a ground fog effect.

<img width="1599" height="1252" alt="image" src="https://github.com/user-attachments/assets/b66d3a17-3a4e-4c5c-9303-ac438f2b56b4" />

Also fixed a bug in a visual shader node and added a 'pixel depth' node (though not used for this example).