### PR TITLE
Fixed several public header includes

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -433,6 +433,32 @@ ezTransformStatus ezTextureAssetDocument::InternalTransformAsset(const char* szT
       case ezRenderTargetFormat::RGBA16:
         format = ezGALResourceFormat::RGBAHalf;
         break;
+
+      case ezRenderTargetFormat::R8:
+        format = ezGALResourceFormat::RUByteNormalized;
+        break;
+
+      case ezRenderTargetFormat::R16:
+        format = ezGALResourceFormat::RHalf;
+        break;
+
+      case ezRenderTargetFormat::R32:
+        format = ezGALResourceFormat::RFloat;
+        break;
+
+      case ezRenderTargetFormat::RG8:
+        format = ezGALResourceFormat::RGUByteNormalized;
+        break;
+
+      case ezRenderTargetFormat::RG16:
+        format = ezGALResourceFormat::RGHalf;
+        break;
+
+      case ezRenderTargetFormat::RG32:
+        format = ezGALResourceFormat::RGFloat;
+        break;
+
+        EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
     }
 
     file << bIsSRGB;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
@@ -18,6 +18,8 @@ EZ_END_STATIC_REFLECTED_ENUM;
 
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezRenderTargetFormat, 1)
   EZ_ENUM_CONSTANTS(ezRenderTargetFormat::RGBA8sRgb, ezRenderTargetFormat::RGBA8, ezRenderTargetFormat::RGB10, ezRenderTargetFormat::RGBA16)
+  EZ_ENUM_CONSTANTS(ezRenderTargetFormat::R8, ezRenderTargetFormat::R16, ezRenderTargetFormat::R32)
+  EZ_ENUM_CONSTANTS(ezRenderTargetFormat::RG8, ezRenderTargetFormat::RG16, ezRenderTargetFormat::RG32)
 EZ_END_STATIC_REFLECTED_ENUM;
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureAssetProperties, 5, ezRTTIDefaultAllocator<ezTextureAssetProperties>)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.h
@@ -63,6 +63,12 @@ struct ezRenderTargetFormat
     RGBA8,
     RGB10,
     RGBA16,
+    R8,
+    R16,
+    R32,
+    RG8,
+    RG16,
+    RG32,
 
     Default = RGBA8sRgb
   };

--- a/Code/Engine/RendererCore/Debug/DebugRendererContext.h
+++ b/Code/Engine/RendererCore/Debug/DebugRendererContext.h
@@ -6,6 +6,11 @@
 class ezWorld;
 class ezViewHandle;
 
+/// \brief Value used by containers for indices to indicate an invalid index.
+#ifndef ezInvalidIndex
+#  define ezInvalidIndex 0xFFFFFFFF
+#endif
+
 /// \brief Used in ezDebugRenderer to determine where debug geometry should be rendered
 class EZ_RENDERERCORE_DLL ezDebugRendererContext
 {

--- a/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
+++ b/Code/Engine/RendererDX11/CommandEncoder/CommandEncoderImplDX11.h
@@ -151,7 +151,7 @@ private:
   ezGAL::ModifiedRange m_BoundSamplerStatesRange[ezGALShaderStage::ENUM_COUNT];
 
   ID3D11DeviceChild* m_pBoundShaders[ezGALShaderStage::ENUM_COUNT] = {};
-  ezUInt8 m_uiStencilRefValue = 0xFFu;
+  ezUInt8 m_uiStencilRefValue = 0;
 
   ezGALRenderingSetup m_RenderTargetSetup;
   ID3D11RenderTargetView* m_pBoundRenderTargets[EZ_GAL_MAX_RENDERTARGET_COUNT] = {};

--- a/Code/EnginePlugins/AiPlugin/Navigation/NavMesh.h
+++ b/Code/EnginePlugins/AiPlugin/Navigation/NavMesh.h
@@ -7,6 +7,7 @@
 #include <Foundation/Containers/DynamicArray.h>
 #include <Foundation/Containers/Map.h>
 #include <Foundation/Math/Vec2.h>
+#include <Foundation/Threading/Mutex.h>
 #include <Foundation/Types/RefCounted.h>
 #include <Foundation/Types/SharedPtr.h>
 #include <Recast.h>

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.h
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <AngelScript/include/angelscript.h>
 #include <AngelScriptPlugin/AngelScriptPluginDLL.h>
 #include <Foundation/Configuration/Singleton.h>
 #include <Foundation/Memory/CommonAllocators.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/UniquePtr.h>
-#include <AngelScript/include/angelscript.h>
 
 class asIScriptEngine;
 class asIScriptModule;

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.h
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsEngineSingleton.h
@@ -5,12 +5,14 @@
 #include <Foundation/Memory/CommonAllocators.h>
 #include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/UniquePtr.h>
+#include <AngelScript/include/angelscript.h>
 
 class asIScriptEngine;
 class asIScriptModule;
 class asIStringFactory;
 struct asSMessageInfo;
 class ezAsStringFactory;
+class asITypeInfo;
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
 using ezAsAllocatorType = ezAllocatorWithPolicy<ezAllocPolicyHeap, ezAllocatorTrackingMode::AllocationStats>;

--- a/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsStringFactory.h
+++ b/Code/EnginePlugins/AngelScriptPlugin/Runtime/AsStringFactory.h
@@ -4,7 +4,7 @@
 
 #include <AngelScript/include/angelscript.h>
 #include <Foundation/Containers/Set.h>
-#include <Foundation/Strings/StringView.h>
+#include <Foundation/Strings/String.h>
 #include <Foundation/Threading/Mutex.h>
 
 class ezAsStringFactory : public asIStringFactory

--- a/Code/EnginePlugins/AngelScriptPlugin/Utils/AngelScriptUtils.h
+++ b/Code/EnginePlugins/AngelScriptPlugin/Utils/AngelScriptUtils.h
@@ -11,6 +11,7 @@ class asIScriptGeneric;
 class ezAbstractFunctionProperty;
 class asIScriptModule;
 class asIScriptFunction;
+class ezWorld;
 
 struct EZ_ANGELSCRIPTPLUGIN_DLL ezAsInfos
 {

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/HeadBoneComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/HeadBoneComponent.h
@@ -2,6 +2,8 @@
 
 #include <GameComponentsPlugin/GameComponentsDLL.h>
 
+#include <Core/World/ComponentManager.h>
+
 using ezHeadBoneComponentManager = ezComponentManagerSimple<class ezHeadBoneComponent, ezComponentUpdateType::WhenSimulating>;
 
 /// \brief Applies a vertical rotation in local space (local Y axis) to the owner game object.

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Interfaces/PhysicsQuery.h>
 #include <Core/Physics/SurfaceResource.h>
 #include <Core/World/Component.h>
 #include <Core/World/World.h>

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/RaycastComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/RaycastComponent.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include <Core/Interfaces/PhysicsQuery.h>
 #include <Core/Messages/TriggerMessage.h>
 #include <Core/World/Component.h>
 #include <Core/World/World.h>

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/ClothSheetComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/ClothSheetComponent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <GameComponentsPlugin/GameComponentsDLL.h>
 #include <GameEngine/Physics/ClothSheetSimulator.h>
 #include <RendererCore/Components/RenderComponent.h>
 #include <RendererCore/Pipeline/RenderData.h>

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/FakeRopeComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/FakeRopeComponent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <GameComponentsPlugin/GameComponentsDLL.h>
+
 #include <Core/World/ComponentManager.h>
 #include <GameEngine/Physics/RopeSimulator.h>
 

--- a/Code/EnginePlugins/JoltPlugin/Character/JoltDefaultCharacterComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Character/JoltDefaultCharacterComponent.h
@@ -4,6 +4,11 @@
 
 struct ezMsgApplyRootMotion;
 
+namespace JPH
+{
+  class CharacterContactListener;
+}
+
 using ezJoltDefaultCharacterComponentManager = ezComponentManager<class ezJoltDefaultCharacterComponent, ezBlockStorageType::FreeList>;
 
 /// \brief An example character controller (CC) implementation build upon ezJoltCharacterControllerComponent

--- a/Code/EnginePlugins/JoltPlugin/Components/JoltBreakableSlabComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Components/JoltBreakableSlabComponent.h
@@ -8,11 +8,17 @@
 #include <RendererCore/Components/RenderComponent.h>
 #include <RendererCore/Meshes/SkinnedMeshRenderData.h>
 
+#include <Jolt/Jolt.h>
+
+#include <Jolt/Core/Reference.h>
+
 using ezMaterialResourceHandle = ezTypedResourceHandle<class ezMaterialResource>;
 using ezMeshResourceHandle = ezTypedResourceHandle<class ezMeshResource>;
 
 struct ezMsgPhysicsAddImpulse;
 struct ezMsgExtractRenderData;
+struct ezMsgPhysicContact;
+struct ezMsgPhysicCharacterContact;
 class ezGeometry;
 class ezMeshResourceDescriptor;
 class ezJoltMaterial;
@@ -20,7 +26,8 @@ class ezJoltMaterial;
 namespace JPH
 {
   class BodyInterface;
-}
+  class ConvexShape;
+} // namespace JPH
 
 /// \brief Flags that define which edges of a breakable slab are fixed/anchored in the world.
 /// A fixed edge means that shards adjacent to that edge will remain stationary and not fall under gravity.

--- a/Code/EnginePlugins/JoltPlugin/Components/JoltRopeComponent.h
+++ b/Code/EnginePlugins/JoltPlugin/Components/JoltRopeComponent.h
@@ -1,13 +1,17 @@
 #pragma once
 
 #include <Core/ResourceManager/ResourceHandle.h>
+#include <Core/World/ComponentManager.h>
 #include <JoltPlugin/JoltPluginDLL.h>
 
 struct ezMsgPhysicsAddImpulse;
+struct ezJoltMsgDisconnectConstraints;
+class ezJoltMaterial;
 
 namespace JPH
 {
   class Constraint;
+  class Ragdoll;
 }
 
 using ezSurfaceResourceHandle = ezTypedResourceHandle<class ezSurfaceResource>;

--- a/Code/EnginePlugins/JoltPlugin/Resources/JoltMaterial.h
+++ b/Code/EnginePlugins/JoltPlugin/Resources/JoltMaterial.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Core/Physics/SurfaceResource.h>
+
+#include <Jolt/Jolt.h>
 #include <Jolt/Physics/Collision/PhysicsMaterial.h>
 
 class ezJoltMaterial : public JPH::PhysicsMaterial

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCollisionFiltering.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCollisionFiltering.h
@@ -2,9 +2,11 @@
 
 #include <Core/Interfaces/PhysicsWorldModule.h>
 #include <Foundation/Basics.h>
+#include <Jolt/Jolt.h>
+#include <Jolt/Physics/Body/Body.h>
+#include <Jolt/Physics/Body/BodyFilter.h>
 #include <Jolt/Physics/Collision/BroadPhase/BroadPhaseLayer.h>
 #include <JoltPlugin/JoltPluginDLL.h>
-#include <Physics/Body/BodyFilter.h>
 
 class ezCollisionFilterConfig;
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltContacts.h
@@ -1,12 +1,15 @@
 #pragma once
 
 #include <Core/World/Declarations.h>
-#include <Physics/Collision/ContactListener.h>
-#include <Physics/SoftBody/SoftBodyContactListener.h>
+#include <Jolt/Jolt.h>
+#include <Jolt/Physics/Collision/ContactListener.h>
+#include <Jolt/Physics/SoftBody/SoftBodyContactListener.h>
 
 class ezWorld;
 class ezJoltTriggerComponent;
 class ezJoltContactEvents;
+class ezSurfaceResource;
+struct ezOnJoltContact;
 
 namespace JPH
 {

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
@@ -7,6 +7,7 @@
 #include <GameEngine/Physics/ImpulseType.h>
 #include <GameEngine/Physics/WeightCategory.h>
 #include <JoltPlugin/JoltPluginDLL.h>
+#include <memory>
 
 class ezJoltMaterial;
 struct ezSurfaceResourceEvent;

--- a/Code/EnginePlugins/JoltPlugin/System/JoltDebugRenderer.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltDebugRenderer.h
@@ -4,6 +4,9 @@
 
 #  include <RendererCore/Debug/DebugRenderer.h>
 
+#  include <Jolt/Jolt.h>
+#  include <Jolt/Renderer/DebugRenderer.h>
+
 class ezJoltDebugRenderer : public JPH::DebugRenderer
 {
 public:

--- a/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltJobSystem.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <Foundation/Threading/TaskSystem.h>
+#include <Jolt/Jolt.h>
+
 #include <Jolt/Core/FixedSizeFreeList.h>
 #include <Jolt/Core/JobSystemWithBarrier.h>
 

--- a/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltWorldModule.h
@@ -12,6 +12,9 @@
 #include <JoltPlugin/Utilities/JoltUserData.h>
 #include <RendererCore/Meshes/DynamicMeshBufferResource.h>
 
+#include <Jolt/Jolt.h>
+#include <Jolt/Physics/PhysicsSystem.h>
+
 class ezJoltCharacterControllerComponent;
 class ezJoltContactListener;
 class ezJoltSoftBodyContactListener;

--- a/Code/EnginePlugins/JoltPlugin/Utilities/JoltConversionUtils.h
+++ b/Code/EnginePlugins/JoltPlugin/Utilities/JoltConversionUtils.h
@@ -5,6 +5,9 @@
 #include <Foundation/Math/Color.h>
 #include <Foundation/Math/Transform.h>
 #include <Foundation/SimdMath/SimdTransform.h>
+
+#include <Jolt/Jolt.h>
+
 #include <Jolt/Core/Color.h>
 #include <Jolt/Math/Float3.h>
 #include <Jolt/Math/Vec3.h>

--- a/Code/EnginePlugins/JoltPlugin/Utilities/JoltUserData.h
+++ b/Code/EnginePlugins/JoltPlugin/Utilities/JoltUserData.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <JoltPlugin/JoltPluginDLL.h>
+#include <JoltPlugin/Declarations.h>
+
+#include <Foundation/Types/Bitflags.h>
 
 class ezComponent;
 class ezJoltDynamicActorComponent;

--- a/Code/EnginePlugins/MiniAudioPlugin/Components/MiniAudioSoundComponent.h
+++ b/Code/EnginePlugins/MiniAudioPlugin/Components/MiniAudioSoundComponent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/ResourceManager/ResourceHandle.h>
 #include <Core/World/Component.h>
 #include <Core/World/ComponentManager.h>
 #include <MiniAudioPlugin/MiniAudioPluginDLL.h>
@@ -115,5 +116,4 @@ protected:
   bool m_bPaused = false;
 
   ezMiniAudioSoundInstance* m_pInstance = nullptr;
-
 };

--- a/Code/EnginePlugins/MiniAudioPlugin/Resources/MiniAudioSoundResource.cpp
+++ b/Code/EnginePlugins/MiniAudioPlugin/Resources/MiniAudioSoundResource.cpp
@@ -44,7 +44,7 @@ float ezMiniAudioSoundResource::GetPitch(ezRandom& ref_rng) const
   return m_fMinPitch;
 }
 
-ezMiniAudioSoundInstance* ezMiniAudioSoundResource::InstantiateSound(ezRandom* pRng, ezWorld* pWorld, ezComponentHandle hComponent)
+ezMiniAudioSoundInstance* ezMiniAudioSoundResource::InstantiateSound(ezRandom* pRng, ezWorld* pWorld, const ezComponentHandle& hComponent)
 {
   ezMiniAudioSingleton* pMA = ezMiniAudioSingleton::GetSingleton();
 

--- a/Code/EnginePlugins/MiniAudioPlugin/Resources/MiniAudioSoundResource.h
+++ b/Code/EnginePlugins/MiniAudioPlugin/Resources/MiniAudioSoundResource.h
@@ -4,6 +4,9 @@
 #include <MiniAudioPlugin/MiniAudioPluginDLL.h>
 
 class ezRandom;
+class ezWorld;
+struct ezMiniAudioSoundInstance;
+struct ezComponentHandle;
 
 using ezMiniAudioSoundResourceHandle = ezTypedResourceHandle<class ezMiniAudioSoundResource>;
 
@@ -34,7 +37,7 @@ public:
   float GetRolloff() const { return m_fRolloff; }
 
   /// \brief Instantiates the sound, all arguments are optional.
-  ezMiniAudioSoundInstance* InstantiateSound(ezRandom* pRng, ezWorld* pWorld, ezComponentHandle hComponent);
+  ezMiniAudioSoundInstance* InstantiateSound(ezRandom* pRng, ezWorld* pWorld, const ezComponentHandle& hComponent);
 
 private:
   virtual ezResourceLoadDesc UnloadData(Unload WhatToUnload) override;

--- a/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.h
+++ b/Code/EnginePlugins/ParticlePlugin/Events/ParticleEventReaction_Prefab.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Physics/SurfaceResourceDescriptor.h>
 #include <Foundation/Types/RangeView.h>
 #include <Foundation/Types/SharedPtr.h>
 #include <ParticlePlugin/Events/ParticleEventReaction.h>

--- a/Code/EnginePlugins/ParticlePlugin/System/ParticleSystemDescriptor.h
+++ b/Code/EnginePlugins/ParticlePlugin/System/ParticleSystemDescriptor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Core/Physics/SurfaceResourceDescriptor.h>
 #include <Foundation/DataProcessing/Stream/ProcessingStream.h>
 #include <Foundation/DataProcessing/Stream/ProcessingStreamGroup.h>
 #include <Foundation/Reflection/Reflection.h>
@@ -10,6 +11,7 @@ class ezParticleEmitterFactory;
 class ezParticleBehaviorFactory;
 class ezParticleInitializerFactory;
 class ezParticleTypeFactory;
+class ezParticleFinalizerFactory;
 
 class EZ_PARTICLEPLUGIN_DLL ezParticleSystemDescriptor final : public ezReflectedClass
 {

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Utils.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Utils.h
@@ -1,8 +1,16 @@
 #pragma once
 
+#include <ProcGenPlugin/ProcGenPluginDLL.h>
+
 #include <Foundation/CodeUtils/Expression/ExpressionDeclarations.h>
 
 class ezVolumeCollection;
+class ezWorld;
+
+namespace ezProcGenInternal
+{
+  struct Output;
+}
 
 struct EZ_PROCGENPLUGIN_DLL ezProcGenExpressionFunctions
 {

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUiConversionUtils.h
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUiConversionUtils.h
@@ -2,6 +2,7 @@
 
 #include <RmlUiPlugin/RmlUiPluginDLL.h>
 
+#include <Foundation/Types/Variant.h>
 #include <RmlUi/Include/RmlUi/Core.h>
 
 namespace ezRmlUiConversionUtils

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUiDataBinding.h
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUiDataBinding.h
@@ -4,6 +4,13 @@
 
 #include <RmlUi/Include/RmlUi/Core.h>
 
+#include <Foundation/Basics.h>
+
+namespace Rml
+{
+  class Context;
+}
+
 class EZ_RMLUIPLUGIN_DLL ezRmlUiDataBinding
 {
 public:

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUiSingleton.h
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUiSingleton.h
@@ -2,10 +2,10 @@
 
 #include <RmlUiPlugin/RmlUiPluginDLL.h>
 
+#include <Core/ResourceManager/ResourceHandle.h>
 #include <Foundation/Configuration/Singleton.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
-#include <Core/ResourceManager/ResourceHandle.h>
 
 class ezRmlUiContext;
 struct ezMsgExtractRenderData;

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUiSingleton.h
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUiSingleton.h
@@ -5,9 +5,12 @@
 #include <Foundation/Configuration/Singleton.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <RendererFoundation/RendererFoundationDLL.h>
+#include <Core/ResourceManager/ResourceHandle.h>
 
 class ezRmlUiContext;
 struct ezMsgExtractRenderData;
+
+using ezRmlUiResourceHandle = ezTypedResourceHandle<class ezRmlUiResource>;
 
 /// \brief The RML configuration to be used on a specific platform
 struct EZ_RMLUIPLUGIN_DLL ezRmlUiConfiguration

--- a/Data/Tools/ezEditor/Localization/en/TextureAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/TextureAsset.txt
@@ -33,6 +33,12 @@ ezRenderTargetFormat::RGBA8;RGBA8 (linear)
 ezRenderTargetFormat::RGBA8sRgb;RGBA8 (sRGB)
 ezRenderTargetFormat::RGB10;RGB10
 ezRenderTargetFormat::RGBA16;RGBA16
+ezRenderTargetFormat::R8;R8 (normalized)
+ezRenderTargetFormat::R16;R16 (half float)
+ezRenderTargetFormat::R32;R32 (full float)
+ezRenderTargetFormat::RG8;RG8 (normalized)
+ezRenderTargetFormat::RG16;RG16 (half float)
+ezRenderTargetFormat::RG32;RG32 (full float)
 
 ezTextureFilterSetting::FixedNearest;Fixed: Nearest
 ezTextureFilterSetting::FixedBilinear;Fixed: Bilinear

--- a/Utilities/Scripts/generateHeaderCheckProject.ps1
+++ b/Utilities/Scripts/generateHeaderCheckProject.ps1
@@ -1,0 +1,97 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$SourceFolder
+)
+
+# Normalize the path
+$SourceFolder = $SourceFolder.TrimEnd('\', '/')
+$SourceFolder = Resolve-Path $SourceFolder -ErrorAction Stop
+
+# Determine the test project folder name
+$sourceFolderName = Split-Path -Leaf $SourceFolder
+$parentFolder = Split-Path -Parent $SourceFolder
+$testProjectName = "${sourceFolderName}HeaderCheck"
+$testProjectFolder = Join-Path -Path $parentFolder -ChildPath $testProjectName
+
+Write-Host "Source folder: $SourceFolder"
+Write-Host "Test project folder: $testProjectFolder"
+Write-Host ""
+
+# Create the test project folder
+if (Test-Path -Path $testProjectFolder) {
+    Write-Host "Removing existing test project folder..."
+    Remove-Item -Path $testProjectFolder -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $testProjectFolder | Out-Null
+Write-Host "Created test project folder: $testProjectFolder"
+Write-Host ""
+
+# Find all .h files, excluding those with "implementation" in the path
+Write-Host "Scanning for header files..."
+$headerFiles = Get-ChildItem -Path $SourceFolder -Filter *.h -Recurse -File | Where-Object {
+    $_.FullName -inotmatch "\\implementation\\" -and $_.FullName -inotmatch "/implementation/" -and $_.Name -inotlike "*_inl.h"
+}
+
+Write-Host "Found $($headerFiles.Count) header files (excluding implementation folders)"
+Write-Host ""
+
+# Generate a .cpp file for each header
+$cppFiles = @()
+$index = 1
+foreach ($header in $headerFiles) {
+    # Calculate the relative path from source folder to the header
+    $relativePath = $header.FullName.Substring($SourceFolder.Length + 1)
+    $relativePath = $relativePath -replace '\\', '/'
+
+    # Prepend the source folder name to create the full include path
+    $includePathWithFolder = "$sourceFolderName/$relativePath"
+
+    # Create a unique cpp filename based on the header path
+    # Replace path separators with underscores to create a flat structure
+    $cppFileName = $relativePath -replace '/', '_' -replace '\.h$', '.cpp'
+    $cppFilePath = Join-Path -Path $testProjectFolder -ChildPath $cppFileName
+
+    # Generate the cpp file content
+    $cppContent = "// Auto-generated test file for: $includePathWithFolder`n`n#include <$includePathWithFolder>`n"
+
+    # Write the cpp file
+    Set-Content -Path $cppFilePath -Value $cppContent -NoNewline
+    $cppFiles += $cppFileName
+
+    Write-Host "[$index/$($headerFiles.Count)] Generated: $cppFileName"
+    $index++
+}
+
+Write-Host ""
+Write-Host "Generated $($cppFiles.Count) .cpp test files"
+Write-Host ""
+
+# Generate CMakeLists.txt
+Write-Host "Generating CMakeLists.txt..."
+
+$cmakeContent = @"
+ez_cmake_init()
+
+# Get the name of this folder as the project name
+get_filename_component(PROJECT_NAME `${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
+
+ez_create_target(LIBRARY `${PROJECT_NAME} NO_UNITY NO_PCH)
+
+target_link_libraries(`${PROJECT_NAME}
+  PRIVATE
+  $sourceFolderName
+)
+"@
+
+$cmakeFilePath = Join-Path -Path $testProjectFolder -ChildPath "CMakeLists.txt"
+Set-Content -Path $cmakeFilePath -Value $cmakeContent
+
+Write-Host "Created CMakeLists.txt"
+Write-Host ""
+Write-Host "Header check project generation complete!"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "1. Add 'add_subdirectory($testProjectName)' to $parentFolder\CMakeLists.txt"
+Write-Host "2. Re-run CMake to include the new test project"
+Write-Host "3. Build the '$testProjectName' target to verify all headers compile independently"


### PR DESCRIPTION
This should fix #1752.

Wrote a script to temporarily create a project that includes every public header directly, so that one can find missing dependencies.

Fixed many headers of the engine plugins. Though this should be done for many more projects at some point.

Also added a few more render target formats and fixed an inconsistency in the default value of the stencil reference value.