### PR TITLE
Streamlining Android dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 .claude/
+.idea/
 
 # ez specific
 /Workspace
@@ -7,5 +8,4 @@
 AssetCache
 Code/Engine/ezBuildInfo.h
 /llvm/
-
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@
 
 ```shell
 # Generate and build Debug configuration
-powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target Win64vs2022 -SolutionName "ClaudeBuild" -WorkspaceDir "claude-build"
+powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target vs2022x64 -SolutionName "ClaudeBuild" -WorkspaceDir "claude-build"
 cmake --build Workspace/claude-build --config Debug
 
 # Generate and build Dev configuration
-powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target Win64vs2022 -SolutionName "ClaudeBuild" -WorkspaceDir "claude-build"
+powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target vs2022x64 -SolutionName "ClaudeBuild" -WorkspaceDir "claude-build"
 cmake --build Workspace/claude-build --config Dev
 
 # Clean build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,6 +20,19 @@
       "environment": {}
     },
     {
+      "name": "vs2026x64",
+      "hidden": false,
+      "generator": "Visual Studio 18 2026",
+      "architecture": "x64",
+      "binaryDir": "${sourceDir}/Workspace/${presetName}",
+      "cacheVariables": {
+        "EZ_BUILD_EXPERIMENTAL_VULKAN": "ON",
+        "EZ_ENABLE_FOLDER_UNITY_FILES" : "ON",
+        "EZ_COMPILE_ENGINE_AS_DLL" : "ON"
+      },
+      "environment": {}
+    },
+    {
       "name": "linux-base",
       "hidden": true,
       "generator": "Ninja",
@@ -66,7 +79,11 @@
         "ANDROID_PLATFORM" : "29",
         "CMAKE_TOOLCHAIN_FILE" : "$env{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake"
       },
-      "environment": {}
+      "environment": {
+        "ANDROID_HOME" : "${sourceDir}/Workspace/shared/android",
+        "ANDROID_NDK_HOME" : "${sourceDir}/Workspace/shared/android/ndk/26.1.10909125",
+        "JAVA_HOME" : "${sourceDir}/Workspace/shared/android/jdk17"
+      }
     },
 
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,7 +13,6 @@
       "architecture": "x64",
       "binaryDir": "${sourceDir}/Workspace/${presetName}",
       "cacheVariables": {
-        "EZ_BUILD_EXPERIMENTAL_VULKAN": "ON",
         "EZ_ENABLE_FOLDER_UNITY_FILES" : "ON",
         "EZ_COMPILE_ENGINE_AS_DLL" : "ON"
       },
@@ -26,7 +25,6 @@
       "architecture": "x64",
       "binaryDir": "${sourceDir}/Workspace/${presetName}",
       "cacheVariables": {
-        "EZ_BUILD_EXPERIMENTAL_VULKAN": "ON",
         "EZ_ENABLE_FOLDER_UNITY_FILES" : "ON",
         "EZ_COMPILE_ENGINE_AS_DLL" : "ON"
       },

--- a/Code/BuildSystem/AzurePipelines/Android-arm64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-arm64.yml
@@ -39,7 +39,7 @@ jobs:
             git clean -dfx
             Copy-Item -Path $pathA -Destination $pathB
         }
-        
+
   - task: CMake@1
     displayName: CMake linux-clang-dev
     inputs:
@@ -55,18 +55,18 @@ jobs:
   - task: PowerShell@2
     displayName: Compile Shaders
     inputs:
-      targetType: inline
-      errorActionPreference: 'stop'
-      failOnStderr: true
-      script: |
-        Set-StrictMode -Version Latest   
-        cd $(System.DefaultWorkingDirectory)/Output/Bin/LinuxNinjaClangDev64
-        ./ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/Base -shader Shaders/Pipeline
-        if ($LASTEXITCODE -ne 0) { throw "Error compiling Base shaders" }
-        ./ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/UnitTests -shader RendererTest/Shaders
-        if ($LASTEXITCODE -ne 0) { throw "Error compiling UnitTests shaders" }
-        ./ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/Samples/ShaderExplorer -shader Shaders
-        if ($LASTEXITCODE -ne 0) { throw "Error compiling ShaderExplorer shaders" }
+      targetType: filepath
+      pwsh: true
+      filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/CompileShaders.ps1
+      arguments: "-BinariesDir $(System.DefaultWorkingDirectory)/Output/Bin/LinuxNinjaClangDev64"
+
+  - task: PowerShell@2
+    displayName: Install Android Dependencies
+    inputs:
+      targetType: filepath
+      pwsh: true
+      filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/InstallAndroidDependencies.ps1
+      arguments: "-acceptLicence"
 
   - task: CMake@1
     displayName: CMake android-arm64-dev

--- a/Code/BuildSystem/AzurePipelines/Android-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x64.yml
@@ -1,4 +1,9 @@
-# Variable 'task.MSBuild.status' was defined in the Variables tab
+parameters:
+  - name: compileShaderCompiler
+    displayName: 'Compile Shader Compiler'
+    type: boolean
+    default: false # For now, we use the precompiled ShaderCompiler for Windows to speed up testing.
+
 trigger:
   branches:
     include:
@@ -8,6 +13,10 @@ resources:
   - repository: self
     type: git
     ref: dev
+variables:
+  androidHome: '$(System.DefaultWorkingDirectory)/Workspace/shared/android'
+  androidNdkHome: '$(System.DefaultWorkingDirectory)/Workspace/shared/android/ndk/26.1.10909125'
+  javaHome: '$(System.DefaultWorkingDirectory)/Workspace/shared/android/jdk17'
 jobs:
 - job: Job_1
   displayName: Android-x64
@@ -27,6 +36,7 @@ jobs:
   - task: PowerShell@2
     displayName: Check force clean
     inputs:
+      pwsh: true
       targetType: inline
       script: |
         $pathA = Join-Path $(System.DefaultWorkingDirectory) "gitClean.txt"
@@ -46,29 +56,27 @@ jobs:
       KeyVaultName: ezKeys
       SecretsFilter: AzureBlobPW
 
-  - task: CMake@1
-    displayName: CMake vs2022x64
-    inputs:
-      cwd: $(System.DefaultWorkingDirectory)
-      cmakeArgs: --preset vs2022x64
+  - ${{ if eq(parameters.compileShaderCompiler, true) }}:
+    - task: CMake@1
+      displayName: CMake vs2022x64
+      inputs:
+        cwd: $(System.DefaultWorkingDirectory)
+        cmakeArgs: --preset vs2022x64 -DEZ_BUILD_EXPERIMENTAL_VULKAN:BOOL=ON
 
-  - task: CMake@1
-    displayName: CMake build vs2022x64
-    inputs:
-      cwd: $(System.DefaultWorkingDirectory)/Workspace/vs2022x64
-      cmakeArgs: --build . --target ShaderCompiler --config dev
+    - task: CMake@1
+      displayName: CMake build vs2022x64
+      inputs:
+        cwd: $(System.DefaultWorkingDirectory)/Workspace/vs2022x64
+        cmakeArgs: --build . --target ShaderCompiler --config dev
 
-  - task: CmdLine@2
+  - task: PowerShell@2
     displayName: Compile Shaders
     inputs:
-      script: |
-        cd $(System.DefaultWorkingDirectory)/Output/Bin/WinVs2022Dev64
-        ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/Base -shader Shaders/Pipeline
-        if %ERRORLEVEL% NEQ 0 exit 1
-        ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/UnitTests -shader RendererTest/Shaders
-        if %ERRORLEVEL% NEQ 0 exit 1
-        ezShaderCompiler -renderer Vulkan -platform VULKAN -project $(System.DefaultWorkingDirectory)/Data/Samples/ShaderExplorer -shader Shaders
-        if %ERRORLEVEL% NEQ 0 exit 1
+      targetType: filepath
+      pwsh: true
+      filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/CompileShaders.ps1
+      ${{ if eq(parameters.compileShaderCompiler, true) }}:
+        arguments: "-BinariesDir $(System.DefaultWorkingDirectory)/Output/Bin/WinVs2022Dev64"
 
   - task: CMake@1
     displayName: CMake android-x64-dev
@@ -79,10 +87,9 @@ jobs:
   - task: CmdLine@2
     displayName: Build
     inputs:
-      script: |
-        cd $(System.DefaultWorkingDirectory)/Workspace/android-x64-dev
-        ninja
-
+      targetType: inline
+      script: ninja -C Workspace/android-x64-dev
+        
   - task: PowerShell@2
     displayName: Install Emulator
     inputs:
@@ -90,6 +97,10 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidEmulator.ps1
       arguments: "-installEmulator"
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
 
   - task: PowerShell@2
     displayName: Start Emulator
@@ -98,6 +109,10 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidEmulator.ps1
       arguments: "-startEmulator"
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
 
   - task: PowerShell@2
     displayName: Check Ready for Testing
@@ -113,6 +128,10 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
       arguments: "-deviceAdb emulator-5555 -packageName com.ezengine.FoundationTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/FoundationTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDev64/FoundationTest.apk"
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
 
   - task: PowerShell@2
     displayName: CoreTest
@@ -122,6 +141,10 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
       arguments: "-deviceAdb emulator-5555 -packageName com.ezengine.CoreTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/CoreTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDev64/CoreTest.apk"
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
 
   - task: PowerShell@2
     displayName: RendererTest
@@ -131,6 +154,10 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
       arguments: "-deviceAdb emulator-5555 -packageName com.ezengine.RendererTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/RendererTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDev64/RendererTest.apk"
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
 
   - task: PowerShell@2
     displayName: ToolsFoundationTest
@@ -140,6 +167,10 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
       arguments: "-deviceAdb emulator-5555 -packageName com.ezengine.ToolsFoundationTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/ToolsFoundationTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDev64/ToolsFoundationTest.apk"
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
 
   - task: PowerShell@2
     displayName: Stop Emulator
@@ -149,7 +180,11 @@ jobs:
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidEmulator.ps1
       arguments: "-stopEmulator"
-
+    env:
+      ANDROID_HOME: '$(androidHome)'
+      ANDROID_NDK_HOME: '$(androidNdkHome)'
+      JAVA_HOME: '$(javaHome)'
+      
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: TestResults'
     condition: eq(variables['task.MSBuild.status'], 'success')

--- a/Code/BuildSystem/AzurePipelines/Android-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x64.yml
@@ -2,7 +2,7 @@ parameters:
   - name: compileShaderCompiler
     displayName: 'Compile Shader Compiler'
     type: boolean
-    default: false # For now, we use the precompiled ShaderCompiler for Windows to speed up testing.
+    default: true # For now, we use the precompiled ShaderCompiler for Windows to speed up testing.
 
 trigger:
   branches:

--- a/Code/BuildSystem/AzurePipelines/Android-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x64.yml
@@ -84,8 +84,8 @@ jobs:
       targetType: filepath
       pwsh: true
       filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/InstallAndroidDependencies.ps1
-      arguments: "-acceptLicence"
-      
+      arguments: "-acceptLicence -installEmulator"
+
   - task: CMake@1
     displayName: CMake android-x64-dev
     inputs:

--- a/Code/BuildSystem/AzurePipelines/Android-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x64.yml
@@ -78,6 +78,14 @@ jobs:
       ${{ if eq(parameters.compileShaderCompiler, true) }}:
         arguments: "-BinariesDir $(System.DefaultWorkingDirectory)/Output/Bin/WinVs2022Dev64"
 
+  - task: PowerShell@2
+    displayName: Install Android Dependencies
+    inputs:
+      targetType: filepath
+      pwsh: true
+      filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/InstallAndroidDependencies.ps1
+      arguments: "-acceptLicence"
+      
   - task: CMake@1
     displayName: CMake android-x64-dev
     inputs:

--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -3,6 +3,10 @@ parameters:
     displayName: 'Upload Caches'
     type: boolean
     default: false
+  - name: useVM
+    displayName: 'Start VM before build'
+    type: boolean
+    default: false
 
 trigger:
   branches:
@@ -14,25 +18,26 @@ resources:
     type: git
     ref: dev
 jobs:
-- job: Job_3
-  displayName: StartVM
-  pool:
-    vmImage: 'windows-2022'
-  steps:
-  - checkout: none
-  - task: AzureKeyVault@2
-    displayName: 'Azure Key Vault: ezKeys'
-    inputs:
-      ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
-      KeyVaultName: ezKeys
-      SecretsFilter: AzureFunctionKey
-  - task: PowerShell@2
+- ${{ if eq(parameters.useVM, true) }}:
+  - job: StartVM
     displayName: StartVM
-    continueOnError: true
-    inputs:
-      targetType: inline
-      script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartVM?code=$(AzureFunctionKey)&vmname=Windows10-1809"
-- job: Job_1
+    pool:
+      vmImage: 'windows-2022'
+    steps:
+    - checkout: none
+    - task: AzureKeyVault@2
+      displayName: 'Azure Key Vault: ezKeys'
+      inputs:
+        ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
+        KeyVaultName: ezKeys
+        SecretsFilter: AzureFunctionKey
+    - task: PowerShell@2
+      displayName: StartVM
+      continueOnError: true
+      inputs:
+        targetType: inline
+        script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartVM?code=$(AzureFunctionKey)&vmname=Windows10-1809"
+- job: Windows_x64
   displayName: Windows-x64
   timeoutInMinutes: 180
   pool:
@@ -95,7 +100,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: "$(System.DefaultWorkingDirectory)/RunCMake.ps1"
-      arguments: "-Target Win64vs2022 -NoUnityBuild -NoSubmoduleUpdate -SolutionName solution"
+      arguments: "-Target vs2022x64 -NoUnityBuild -NoSubmoduleUpdate -SolutionName solution"
   - task: MSBuild@1
     displayName: Build Solution
     inputs:

--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -100,7 +100,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: "$(System.DefaultWorkingDirectory)/RunCMake.ps1"
-      arguments: "-Target vs2022x64 -NoUnityBuild -NoSubmoduleUpdate -SolutionName solution"
+      arguments: "-Target vs2022x64 -NoUnityBuild -NoSubmoduleUpdate -VulkanSupport 0 -SolutionName solution"
   - task: MSBuild@1
     displayName: Build Solution
     inputs:

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsAndroid.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsAndroid.cmake
@@ -65,6 +65,15 @@ function(ez_android_add_default_content TARGET_NAME)
 		set(ANDROID_SDK $ENV{ANDROID_HOME})
 	endif()
 
+	if(NOT JAVA_HOME)
+		if(NOT EXISTS "$ENV{JAVA_HOME}")
+			message(FATAL_ERROR "JAVA_HOME environment variable not set. Please ensure it points to the JDK folder.")
+		else()
+			set(JAVA_HOME $ENV{JAVA_HOME})
+		endif()
+	endif()
+
+
 	get_filename_component(ANDROID_BUILD_TOOLS_ROOT "${ANDROID_SDK}/build-tools" ABSOLUTE)
 	ez_list_subdirs(AVAILABLE_BUILD_TOOLS ${ANDROID_BUILD_TOOLS_ROOT})
 	list(LENGTH AVAILABLE_BUILD_TOOLS NUM_AVAILABLE_BUILD_TOOLS)
@@ -105,7 +114,7 @@ function(ez_android_add_default_content TARGET_NAME)
 		BYPRODUCTS "${APK_OUTPUT_DIR}/${TARGET_NAME}.apk" "${APK_OUTPUT_DIR}/${TARGET_NAME}.unaligned.apk"
 		COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${TARGET_NAME}> ${CONTENT_DIRECTORY_DST}/lib/${ANDROID_ABI}/lib${TARGET_NAME}.so
 		COMMAND ${CMAKE_COMMAND} -E copy "${EZ_VULKAN_VALIDATIONLAYERS_DIR}/${ANDROID_ABI}/libVkLayer_khronos_validation.so" ${CONTENT_DIRECTORY_DST}/lib/${ANDROID_ABI}/libVkLayer_khronos_validation.so
-		COMMAND pwsh -NoLogo -NoProfile -File ${EZ_ROOT}/Utilities/Android/BuildApk.ps1 -BuildToolsPath "${ANDROID_BUILD_TOOLS}" -ContentDirectory "${CONTENT_DIRECTORY_DST}" -Manifest "${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml" -AndroidPlatformRoot "${ANDROID_PLATFORM_ROOT}" -TargetName "${TARGET_NAME}" -OutDir "${APK_OUTPUT_DIR}" -SignKey "${CONTENT_DIRECTORY_SRC}/debug.keystore" -SignPassword "pass:android"
+		COMMAND pwsh -NoLogo -NoProfile -File ${EZ_ROOT}/Utilities/Android/BuildApk.ps1 -BuildToolsPath "${ANDROID_BUILD_TOOLS}" -JavaHome "${JAVA_HOME}" -ContentDirectory "${CONTENT_DIRECTORY_DST}" -Manifest "${CMAKE_CURRENT_BINARY_DIR}/AndroidManifest.xml" -AndroidPlatformRoot "${ANDROID_PLATFORM_ROOT}" -TargetName "${TARGET_NAME}" -OutDir "${APK_OUTPUT_DIR}" -SignKey "${CONTENT_DIRECTORY_SRC}/debug.keystore" -SignPassword "pass:android"
 		USES_TERMINAL
 	)
 endfunction()

--- a/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
+++ b/Code/BuildSystem/CMake/CMakeUtils/ezUtilsCppFlags.cmake
@@ -206,6 +206,9 @@ endfunction()
 # ## ez_set_build_flags_clang(<target>)
 # #####################################
 function(ez_set_build_flags_clang TARGET_NAME)
+	# Enable debug info
+	target_compile_options(${TARGET_NAME} PRIVATE -g)
+
 	if(EZ_CMAKE_ARCHITECTURE_X86)
 
 		if(${EZ_MIN_REQUIRED_SSE_LEVEL} STREQUAL "SSE41")
@@ -219,7 +222,6 @@ function(ez_set_build_flags_clang TARGET_NAME)
 	endif()
 	if(EZ_3RDPARTY_LIVEPP_SUPPORT)
 		target_compile_options(${TARGET_NAME} PRIVATE 
-		"-g"
 		"-gcodeview"
 		"-fms-hotpatch"
 		"-ffunction-sections"

--- a/Code/EditorPlugins/Fileserve/EditorPluginFileserve/CMakeLists.txt
+++ b/Code/EditorPlugins/Fileserve/EditorPluginFileserve/CMakeLists.txt
@@ -1,8 +1,8 @@
 ez_cmake_init()
 
 ez_requires_qt()
+ez_requires_desktop()
 
-ez_requires(EZ_CMAKE_PLATFORM_WINDOWS)
 ez_requires(EZ_3RDPARTY_ENET_SUPPORT)
 
 # Get the name of this folder as the project name

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -10,6 +10,7 @@
 #include <Foundation/Reflection/ReflectionUtils.h>
 #include <Foundation/Utilities/Stats.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
+#include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Device/SwapChain.h>
 #include <RendererFoundation/Profiling/Profiling.h>

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -10,10 +10,10 @@
 #include <Foundation/Reflection/ReflectionUtils.h>
 #include <Foundation/Utilities/Stats.h>
 #include <RendererFoundation/CommandEncoder/CommandEncoder.h>
-#include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Device/DeviceFactory.h>
 #include <RendererFoundation/Device/SwapChain.h>
 #include <RendererFoundation/Profiling/Profiling.h>
+#include <RendererFoundation/RendererReflection.h>
 #include <RendererVulkan/Cache/ResourceCacheVulkan.h>
 #include <RendererVulkan/CommandEncoder/CommandEncoderImplVulkan.h>
 #include <RendererVulkan/Device/DeviceVulkan.h>

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -2,6 +2,7 @@
 
 #include <RendererVulkan/Device/DeclarationsVulkan.h>
 #include <RendererVulkan/RendererVulkanDLL.h>
+#include <Foundation/Types/SharedPtr.h>
 
 class ezGALDeviceVulkan;
 

--- a/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
+++ b/Code/Engine/RendererVulkan/Pools/DescriptorSetPoolVulkan.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <Foundation/Types/SharedPtr.h>
 #include <RendererVulkan/Device/DeclarationsVulkan.h>
 #include <RendererVulkan/RendererVulkanDLL.h>
-#include <Foundation/Types/SharedPtr.h>
 
 class ezGALDeviceVulkan;
 

--- a/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorWritePoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/DescriptorWritePoolVulkan.cpp
@@ -6,7 +6,9 @@
 #include <RendererVulkan/Pools/UniformBufferPoolVulkan.h>
 #include <RendererVulkan/Resources/BufferVulkan.h>
 #include <RendererVulkan/Resources/TextureVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
 #include <RendererVulkan/State/StateVulkan.h>
+#include <RendererVulkan/Utils/ConversionUtilsVulkan.h>
 
 ezDescriptorWritePoolVulkan::ezDescriptorWritePoolVulkan(ezGALDeviceVulkan* pDevice)
   : m_pDevice(pDevice)

--- a/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupVulkan.cpp
@@ -1,8 +1,8 @@
 #include <RendererVulkan/Shader/BindGroupVulkan.h>
 
+#include <RendererVulkan/Device/DeviceVulkan.h>
 #include <RendererVulkan/Pools/DescriptorWritePoolVulkan.h>
 #include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
-#include <RendererVulkan/Device/DeviceVulkan.h>
 
 ezGALBindGroupVulkan::ezGALBindGroupVulkan(const ezGALBindGroupCreationDescription& Description)
   : ezGALBindGroup(Description)

--- a/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Shader/Implementation/BindGroupVulkan.cpp
@@ -1,6 +1,8 @@
 #include <RendererVulkan/Shader/BindGroupVulkan.h>
 
 #include <RendererVulkan/Pools/DescriptorWritePoolVulkan.h>
+#include <RendererVulkan/Shader/BindGroupLayoutVulkan.h>
+#include <RendererVulkan/Device/DeviceVulkan.h>
 
 ezGALBindGroupVulkan::ezGALBindGroupVulkan(const ezGALBindGroupCreationDescription& Description)
   : ezGALBindGroup(Description)

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiInput.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RmlUiInput.cpp
@@ -59,7 +59,7 @@ bool ezRmlUiInputProvider::Update(ezRmlUiInputSnapshot input)
   return bHasChanged;
 }
 
-EZ_ALWAYS_INLINE ezKeyState::Enum ezRmlUiInputProvider::GetButtonState(ezRmlUiInputButtons::Enum button) const
+ezKeyState::Enum ezRmlUiInputProvider::GetButtonState(ezRmlUiInputButtons::Enum button) const
 {
   if (m_Buttons.IsSet(button))
   {

--- a/Code/Samples/ShaderExplorer/CMakeLists.txt
+++ b/Code/Samples/ShaderExplorer/CMakeLists.txt
@@ -1,7 +1,6 @@
 ez_cmake_init()
 
 ez_requires_renderer()
-ez_requires_desktop()
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
@@ -22,6 +21,9 @@ if(EZ_CMAKE_PLATFORM_ANDROID)
     target_link_libraries(${PROJECT_NAME}
         PUBLIC
         InspectorPlugin
+        # To support Fileserve we need to link against the plugin which does unfortunately force loading of it so Fileserve can't be disabled at runtime.
+        # See comments in ShaderExplorer.h for details.
+        # FileservePlugin
     )
 endif()
 
@@ -30,8 +32,4 @@ ez_add_renderers(${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
   RendererCore
-)
-
-add_dependencies(${PROJECT_NAME}
-  InspectorPlugin
 )

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -2,8 +2,8 @@
 
 #include <Core/Graphics/Camera.h>
 #include <Core/Graphics/Geometry.h>
-#include <Core/Input/InputManager.h>
 #include <Core/Input/DeviceTypes/MouseKeyboard.h>
+#include <Core/Input/InputManager.h>
 #include <Core/Input/VirtualThumbStick.h>
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Core/System/Window.h>

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.cpp
@@ -3,6 +3,7 @@
 #include <Core/Graphics/Camera.h>
 #include <Core/Graphics/Geometry.h>
 #include <Core/Input/InputManager.h>
+#include <Core/Input/DeviceTypes/MouseKeyboard.h>
 #include <Core/Input/VirtualThumbStick.h>
 #include <Core/ResourceManager/ResourceManager.h>
 #include <Core/System/Window.h>

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.h
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.h
@@ -20,7 +20,7 @@
 #  if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)
 // on sandboxed platforms, we can only load data through fileserve, so enforce use of this plugin
 // Right now, the only platform that hits this code path is Android, but right now, port forwarding for enet does not seem to work in the emulator so for now this is disabled until this can be debugged further.
-//#    define USE_FILESERVE EZ_ON
+// #    define USE_FILESERVE EZ_ON
 #    define USE_FILESERVE EZ_OFF
 #  else
 #    define USE_FILESERVE EZ_OFF

--- a/Code/Samples/ShaderExplorer/ShaderExplorer.h
+++ b/Code/Samples/ShaderExplorer/ShaderExplorer.h
@@ -19,7 +19,9 @@
 
 #  if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT) && EZ_DISABLED(EZ_SUPPORTS_UNRESTRICTED_FILE_ACCESS)
 // on sandboxed platforms, we can only load data through fileserve, so enforce use of this plugin
-#    define USE_FILESERVE EZ_ON
+// Right now, the only platform that hits this code path is Android, but right now, port forwarding for enet does not seem to work in the emulator so for now this is disabled until this can be debugged further.
+//#    define USE_FILESERVE EZ_ON
+#    define USE_FILESERVE EZ_OFF
 #  else
 #    define USE_FILESERVE EZ_OFF
 #  endif

--- a/Code/Tools/Fileserve/CMakeLists.txt
+++ b/Code/Tools/Fileserve/CMakeLists.txt
@@ -1,7 +1,7 @@
 ez_cmake_init()
 
 ez_requires_qt()
-ez_requires(EZ_CMAKE_PLATFORM_WINDOWS)
+ez_requires_desktop()
 
 ez_requires(EZ_3RDPARTY_ENET_SUPPORT)
 

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef EZ_USE_QT
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
 #else
 int main(int argc, const char** argv)
@@ -25,11 +25,11 @@ int main(int argc, const char** argv)
   ezFileserverApp* pApp = new ezFileserverApp();
 
 #ifdef EZ_USE_QT
-#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+#  if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   ezCommandLineUtils::GetGlobalInstance()->SetCommandLine();
-#else
+#  else
   ezCommandLineUtils::GetGlobalInstance()->SetCommandLine(argc, argv);
-#endif
+#  endif
   int dummyArgc = 0;
   char** dummyArgv = nullptr;
   QApplication* pQtApplication = new QApplication(dummyArgc, const_cast<char**>(dummyArgv));

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -16,7 +16,7 @@
 #endif
 
 #ifdef EZ_USE_QT
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int iCmdShow)
+int main(int argc, char **argv)
 {
 #else
 int main(int argc, const char** argv)
@@ -25,11 +25,14 @@ int main(int argc, const char** argv)
   ezFileserverApp* pApp = new ezFileserverApp();
 
 #ifdef EZ_USE_QT
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   ezCommandLineUtils::GetGlobalInstance()->SetCommandLine();
-
-  int argc = 0;
-  char** argv = nullptr;
-  QApplication* pQtApplication = new QApplication(argc, const_cast<char**>(argv));
+#else
+  ezCommandLineUtils::GetGlobalInstance()->SetCommandLine(argc, argv);
+#endif
+  int dummyArgc = 0;
+  char** dummyArgv = nullptr;
+  QApplication* pQtApplication = new QApplication(dummyArgc, const_cast<char**>(dummyArgv));
   pQtApplication->setApplicationName("ezFileserve");
   pQtApplication->setOrganizationDomain("www.ezEngine.net");
   pQtApplication->setOrganizationName("ezEngine Project");

--- a/Code/UnitTests/TestFramework/Utilities/ConsoleOutput.cpp
+++ b/Code/UnitTests/TestFramework/Utilities/ConsoleOutput.cpp
@@ -1,4 +1,3 @@
-#pragma once
 
 #include <TestFramework/Framework/TestFramework.h>
 

--- a/GenerateWin64vs2022.bat
+++ b/GenerateWin64vs2022.bat
@@ -1,1 +1,1 @@
-@powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target Win64vs2022 %*
+@powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target vs2022x64 %*

--- a/GenerateWin64vs2026.bat
+++ b/GenerateWin64vs2026.bat
@@ -1,1 +1,1 @@
-@powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target Win64vs2026 %*
+@powershell -NoProfile -ExecutionPolicy ByPass ./RunCMake.ps1 -Target vs2026x64 %*

--- a/RunCMake.ps1
+++ b/RunCMake.ps1
@@ -1,14 +1,16 @@
 param
 (
-    [Parameter(Mandatory = $True)] [ValidateSet('Win64vs2022', 'Win64vs2026')][string] $Target,
-    [switch]$NoUnityBuild,
+    [Parameter(Mandatory = $True)] [ValidateSet('vs2022x64', 'vs2026x64', 'android-arm64-debug', 'android-arm64-dev', 'android-arm64-shipping', 'android-x64-debug', 'android-x64-dev', 'android-x64-shipping')][string] $Target,
     [switch]$NoSubmoduleUpdate,
+    [switch]$NoUnityBuild,
+    [Nullable[bool]]$VulkanSupport,
     [string]$SolutionName,
     [string]$WorkspaceDir
 )
 
 Set-Location $PSScriptRoot
 
+#region Submodule Update
 if ($NoSubmoduleUpdate -eq $False) {
     $CURRENT_COMMIT = git log -n 1 --format=%H
 
@@ -30,7 +32,7 @@ if ($NoSubmoduleUpdate -eq $False) {
     }
 
     if ($UPDATE_SUBMODULES) {
-        Write-Host "Updating submodules"
+        Write-Host "Updating submodules..." -ForegroundColor Green
 
         git submodule init
         git submodule update
@@ -38,9 +40,18 @@ if ($NoSubmoduleUpdate -eq $False) {
         Out-File ( New-Item -Path $LAST_UPDATE_FILE -Force) -InputObject $CURRENT_COMMIT
     }
 }
+#endregion
 
-$CMAKE_ARGS = @("-S", "$PSScriptRoot")
+#region Android Dependencies
+if ($Target -like "android*") {
+    Write-Host "Installing Android Dependencies..." -ForegroundColor Green
+    . "$PSScriptRoot/Utilities/Android/InstallAndroidDependencies.ps1"
+    . "$PSScriptRoot/Utilities/Android/CompileShaders.ps1"
+}
+#endregion
 
+#region CMake
+$CMAKE_ARGS = @("-S", "$PSScriptRoot", "--preset", "$Target")
 if ($NoUnityBuild) {
     $CMAKE_ARGS += "-DEZ_ENABLE_FOLDER_UNITY_FILES:BOOL=OFF"
 }
@@ -48,66 +59,38 @@ else {
     $CMAKE_ARGS += "-DEZ_ENABLE_FOLDER_UNITY_FILES:BOOL=ON"
 }
 
+if ($PSBoundParameters.ContainsKey('VulkanSupport') -and $Target -like "android*" -eq $False) {
+    if ($VulkanSupport) {
+        $CMAKE_ARGS += "-DEZ_BUILD_EXPERIMENTAL_VULKAN:BOOL=ON"
+    }
+    else {
+        $CMAKE_ARGS += "-DEZ_BUILD_EXPERIMENTAL_VULKAN:BOOL=OFF"
+    }
+}
+
 if ($SolutionName -ne "") {
     $CMAKE_ARGS += "-DEZ_SOLUTION_NAME:STRING='${SolutionName}'"
 }
 
-$CMAKE_ARGS += "-G"
-
 Write-Host ""
 
-$CustomWorkspace = $False
-
-if ($WorkspaceDir -ne "") {
-    $CustomWorkspace = $True
-}
-
-if ($Target -eq "Win64vs2022") {
-
-    Write-Host "=== Generating Solution for Visual Studio 2022 x64 ==="
-
-    $CMAKE_ARGS += "Visual Studio 17 2022"
-    $CMAKE_ARGS += "-A"
-    $CMAKE_ARGS += "x64"
-
-    if (-not $CustomWorkspace) {
-        $WorkspaceDir = "vs2022x64"
-    }
-}
-elseif ($Target -eq "Win64vs2026") {
-
-    Write-Host "=== Generating Solution for Visual Studio 2026 x64 ==="
-
-    $CMAKE_ARGS += "Visual Studio 18 2026"
-    $CMAKE_ARGS += "-A"
-    $CMAKE_ARGS += "x64"
-
-    if (-not $CustomWorkspace) {
-        $WorkspaceDir = "vs2026x64"
-    }
-}
-else {
-    throw "Unknown target '$Target'."
-}
-
-# Add build directory to CMAKE_ARGS
-$CMAKE_ARGS += "-B"
-$CMAKE_ARGS += "$PSScriptRoot\Workspace\$WorkspaceDir"
-
-Write-Host "Using workspace directory: Workspace\$WorkspaceDir"
-
 # Set custom output directories to avoid conflicts between different workspaces
-if ($CustomWorkspace) {
+if ($WorkspaceDir -ne "") {
+    Write-Host "Using custom workspace directory: Workspace\$WorkspaceDir"
+    $CMAKE_ARGS += "-B"
+    $CMAKE_ARGS += "$PSScriptRoot\Workspace\$WorkspaceDir"
     $CMAKE_ARGS += "-DEZ_OUTPUT_DIRECTORY_DLL:PATH=$PSScriptRoot\Workspace\$WorkspaceDir-output\Bin"
     $CMAKE_ARGS += "-DEZ_OUTPUT_DIRECTORY_LIB:PATH=$PSScriptRoot\Workspace\$WorkspaceDir-output\Lib"
     Write-Host "Custom output directories: Workspace\$WorkspaceDir-output\"
 }
 
 Write-Host ""
-Write-Host "Running cmake.exe $CMAKE_ARGS"
+Write-Host "Running cmake.exe $CMAKE_ARGS" -ForegroundColor Green
 Write-Host ""
 &Data\Tools\Precompiled\cmake\bin\cmake.exe $CMAKE_ARGS
 
 if (!$?) {
     throw "CMake failed with exit code '$LASTEXITCODE'."
 }
+#endregion
+

--- a/Utilities/Android/AndroidEmulator.ps1
+++ b/Utilities/Android/AndroidEmulator.ps1
@@ -90,6 +90,7 @@ if ($startEmulator) {
 
 # Stop Emulator
 if ($stopEmulator) {
+    $adb = Get-Adb
     & $adb -s $deviceAdb emu kill
     return 0
 }

--- a/Utilities/Android/AndroidEmulator.ps1
+++ b/Utilities/Android/AndroidEmulator.ps1
@@ -17,25 +17,12 @@ $devicePackage = "system-images;android-29;google_apis;x86_64"
 $deviceType = "pixel_7"
 
 if ($installBuildDependencies) {
-    $sdkTools = Get-LatestSdkTools
-    $sdkManager = Join-Path -Path $sdkTools -ChildPath "bin/sdkmanager"
-    if ($IsWindows) {
-        $sdkManager = "$sdkManager.bat"
+    $sdkManager = Get-SdkManager
+    for ($i = 0; $i -lt 8; $i++) {
+        "y`ny`ny`n" | & $sdkManager --licenses | Out-Null
     }
-    if (-not (Test-Path $sdkManager)) {
-        RaiseError "Failed to locate sdkmanager in $sdkManager. Please ensure that the ANDROID_HOME environment variable is correctly set"
-    }
-
-    # build dependencies
-    & $sdkManager "build-tools;34.0.0"
-    & $sdkManager "cmdline-tools;latest"
-    & $sdkManager "ndk;26.1.10909125"
-    & $sdkManager "platform-tools"
-    & $sdkManager "platforms;android-29"
-    # Emulator packages
-    & $sdkManager "emulator"
-    & $sdkManager "extras;google;Android_Emulator_Hypervisor_Driver"
-    & $sdkManager "system-images;android-29;google_apis;x86_64"
+    Install-SdkBuildDependencies -SdkManager $sdkManager
+    Install-SdkEmulatorPackages -SdkManager $sdkManager
 
     for ($i = 0; $i -lt 8; $i++) {
         "y`ny`ny`n" | & $sdkManager --licenses | Out-Null

--- a/Utilities/Android/AndroidUtils.ps1
+++ b/Utilities/Android/AndroidUtils.ps1
@@ -1,22 +1,6 @@
-
-# Find ADB and JDB
-$adb = "$env:ANDROID_HOME/platform-tools/adb"
-if ($IsWindows) {
-	$adb = "$adb.exe"
-}
-if (-not (Test-Path $adb)) {
-	RaiseError "Failed to find adb executable in $adb. Please ensure that the ANDROID_HOME environment variable is correctly set"
-}
-$adb = Resolve-Path $adb
-
-$jdb = "$env:JAVA_HOME/bin/jdb"
-if ($IsWindows) {
-	$jdb = "$jdb.exe"
-}
-if (-not (Test-Path $jdb)) {
-	RaiseError "Failed to find jdb executable in $jdb. Please ensure that the JAVA_HOME environment variable is correctly set."
-}
-$jdb = Resolve-Path $jdb
+## ADB/JDB paths are resolved lazily on first use to avoid module-load failures
+## when ANDROID_HOME or JAVA_HOME are not set.
+## Use Get-Adb and Get-Jdb to retrieve the resolved paths.
 
 $ErrorActionPreference = "Stop"
 if ($MessageBoxOnError -and $IsWindows) {
@@ -56,6 +40,18 @@ function Get-LatestSdkTools {
 	return $highestFloatFolder.FullName
 }
 
+function Get-SdkManager {
+	$sdkTools = Get-LatestSdkTools
+	$sdkManager = Join-Path -Path $sdkTools -ChildPath "bin/sdkmanager"
+	if ($IsWindows) {
+		$sdkManager = "$sdkManager.bat"
+	}
+	if (-not (Test-Path $sdkManager)) {
+		RaiseError "Failed to locate sdkmanager in $sdkManager. Please ensure that the ANDROID_HOME environment variable is correctly set"
+	}
+	return $sdkManager
+}
+
 function RaiseError {
 	param(
 		[string]$msg
@@ -75,6 +71,40 @@ function RaiseError {
 	}
 }
 
+function Get-Adb {
+	# Returns the resolved adb path, resolving once and caching the result.
+	if (-not $script:__adbPath) {
+		$path = "$env:ANDROID_HOME/platform-tools/adb"
+		if ($IsWindows) {
+			$path = "$path.exe"
+		}
+		if (-not (Test-Path $path)) {
+			RaiseError "Failed to find adb executable in $path. Please ensure that the ANDROID_HOME environment variable is correctly set"
+		}
+		$script:__adbPath = (Resolve-Path $path).Path
+		# Also expose as $script:adb for any legacy consumers that expect the variable
+		$script:adb = $script:__adbPath
+	}
+	return $script:__adbPath
+}
+
+function Get-Jdb {
+	# Returns the resolved jdb path, resolving once and caching the result.
+	if (-not $script:__jdbPath) {
+		$path = "$env:JAVA_HOME/bin/jdb"
+		if ($IsWindows) {
+			$path = "$path.exe"
+		}
+		if (-not (Test-Path $path)) {
+			RaiseError "Failed to find jdb executable in $path. Please ensure that the JAVA_HOME environment variable is correctly set."
+		}
+		$script:__jdbPath = (Resolve-Path $path).Path
+		# Also expose as $script:jdb for any legacy consumers that expect the variable
+		$script:jdb = $script:__jdbPath
+	}
+	return $script:__jdbPath
+}
+
 function Adb-Shell {
 	param(
 		[string]$cmd,
@@ -86,10 +116,10 @@ function Adb-Shell {
 	}
 	try {
 		if ($deviceAdb) {
-			$($result = (& $adb -s $deviceAdb shell $cmd *>&1)) | Out-Null
+			$($result = (& (Get-Adb) -s $deviceAdb shell $cmd *>&1)) | Out-Null
 		}
 		else {
-			$($result = (& $adb shell $cmd *>&1)) | Out-Null
+			$($result = (& (Get-Adb) shell $cmd *>&1)) | Out-Null
 		}
 
 	}
@@ -123,7 +153,7 @@ function Adb-Cmd {
 	$errorAction = $ErrorActionPreference
 	try {
 		$ErrorActionPreference = "Continue"
-		$result = (& $adb $cmds *>&1)
+		$result = (& (Get-Adb) $cmds *>&1)
 	}
 	finally {
 		$ErrorActionPreference = $errorAction
@@ -159,35 +189,69 @@ function Adb-CopyDirectory {
 			# Files need to download
 			$outputFileChild = Join-Path -Path $outputFolder -ChildPath $line
 			$deviceFileChild = "$deviceFolder/$line"
-			Start-Process -PassThru -WindowStyle Hidden -FilePath "$adb" -ArgumentList "-s $deviceAdb exec-out run-as $packageName cat `"$deviceFileChild`"" -RedirectStandardOutput $outputFileChild | Out-Null
+			if ($IsWindows) {
+				Start-Process -PassThru -WindowStyle Hidden -FilePath (Get-Adb) -ArgumentList "-s $deviceAdb exec-out run-as $packageName cat `"$deviceFileChild`"" -RedirectStandardOutput $outputFileChild | Out-Null
+			}
+			else {
+				Start-Process -PassThru -FilePath (Get-Adb) -ArgumentList "-s $deviceAdb exec-out run-as $packageName cat `"$deviceFileChild`"" -RedirectStandardOutput $outputFileChild | Out-Null
+			}	
 		}
 	}
 }
 
 function Invoke-WithRetry {
-    param(
-        [Parameter(Mandatory=$true)]
-        [ScriptBlock]$ScriptBlock,
-        [int]$MaxRetryCount = 3
-    )
+	param(
+		[Parameter(Mandatory = $true)]
+		[ScriptBlock]$ScriptBlock,
+		[int]$MaxRetryCount = 3
+	)
 
-    $retryCount = 0
+	$retryCount = 0
 	$sleepInterval = 1
-    do {
-        try {
-            & $ScriptBlock
-            break
-        }
-        catch {
+	do {
+		try {
+			& $ScriptBlock
+			break
+		}
+		catch {
 			Start-Sleep -Seconds $sleepInterval
 			$sleepInterval = $sleepInterval * 2
-            if ($retryCount -ge $MaxRetryCount) {
-                RaiseError("Error: $_")
-            }
-            else {
+			if ($retryCount -ge $MaxRetryCount) {
+				RaiseError("Error: $_")
+			}
+			else {
 				$retryCount++
-                Write-Host "Error: $_`nRetrying ($retryCount/$MaxRetryCount)..."
-            }
-        }
-    } while ($true)
+				Write-Host "Error: $_`nRetrying ($retryCount/$MaxRetryCount)..."
+			}
+		}
+	} while ($true)
 }
+
+# Functions to install sdkmanager packages. Extracted from InstallAndroidDependencies.ps1
+function Install-SdkBuildDependencies {
+	param(
+		[Parameter(Mandatory = $true)][string]$SdkManager
+	)
+
+	& $SdkManager "cmdline-tools;latest"
+	# Check if sdkmanager created a duplicate (latest-2) and replace latest with it
+	$cmdlineLatest2 = Join-Path -Path $SdkManager -ChildPath "latest-2"
+	if (Test-Path $cmdlineLatest2) {
+		Write-Host "Detected latest-2 folder. Replacing latest with latest-2..."
+		Remove-Item -LiteralPath $cmdlineLatest -Recurse -Force -ErrorAction SilentlyContinue
+		Move-Item -Path $cmdlineLatest2 -Destination $cmdlineLatest -Force
+	}
+	& $SdkManager "build-tools;34.0.0" "ndk;26.1.10909125" "platform-tools" "platforms;android-29"
+}
+
+function Install-SdkEmulatorPackages {
+	param(
+		[Parameter(Mandatory = $true)][string]$SdkManager
+	)
+
+	& $SdkManager "emulator" "system-images;android-29;google_apis;x86_64"
+	if ($IsWindows) {
+		& $SdkManager "extras;google;Android_Emulator_Hypervisor_Driver"
+	}
+}
+

--- a/Utilities/Android/BuildApk.ps1
+++ b/Utilities/Android/BuildApk.ps1
@@ -1,6 +1,9 @@
 param(
 	[Parameter(Mandatory=$true)]
 	[string]$BuildToolsPath,
+
+	[Parameter(Mandatory=$true)]
+	[string]$JavaHome,
 	
 	[Parameter(Mandatory=$true)]
 	[string]$ContentDirectory,
@@ -72,8 +75,20 @@ if($lastexitcode -ne 0)
 
 Write-Host "Signing apk $finalApkPath with key $SignKey ..."
 Write-Host "apksigner:`"$apksigner`", SignKey:`"$SignKey`", SignPassword: `"$SignPassword`""
+Write-Host "JavaHome: `"$JavaHome`""
+$previousPath = $env:PATH
+if ($IsWindows) {
+    $env:PATH = "$JavaHome/bin;$env:PATH"
+} else {
+    $env:PATH = "$JavaHome/bin:$env:PATH"
+}
+try {
+	& $apksigner sign --ks $SignKey --ks-pass $SignPassword $finalApkPath
+}
+finally {
+	$env:PATH = $previousPath
+}
 
-& $apksigner sign --ks $SignKey --ks-pass $SignPassword $finalApkPath
 if($lastexitcode -ne 0)
 {
     Write-Host "FAILED with $lastexitcode"

--- a/Utilities/Android/CompileShaders.ps1
+++ b/Utilities/Android/CompileShaders.ps1
@@ -1,0 +1,34 @@
+param
+(
+    [string]$BinariesDir
+)
+
+# On Windows, if BinariesDir is not provided, default to the prebuilt binaries location
+if ($IsWindows -and [string]::IsNullOrEmpty($BinariesDir)) {
+    $BinariesDir = "$PSScriptRoot/../../Data/Tools/Precompiled"
+}
+
+if ([string]::IsNullOrEmpty($BinariesDir)) {
+    throw "BinariesDir parameter is required. Set it to the directory containing ezShaderCompiler"
+}
+
+$RootDir = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+
+Write-Host "Compiling Android Shaders..." -ForegroundColor Green
+$shaderCompilerPath = "$BinariesDir/ezShaderCompiler"
+if ($IsWindows) {
+    $shaderCompilerPath += ".exe"
+}
+
+if (-not (Test-Path $shaderCompilerPath)) {
+    throw "ezShaderCompiler not found at: $shaderCompilerPath"
+}
+
+& $shaderCompilerPath -renderer Vulkan -platform VULKAN -project "$RootDir/Data/Base" -shader Shaders/Pipeline
+if ($LASTEXITCODE -ne 0) { throw "ezShaderCompiler failed for Data/Base (exit code $LASTEXITCODE)." }
+
+& $shaderCompilerPath -renderer Vulkan -platform VULKAN -project "$RootDir/Data/UnitTests" -shader "RendererTest/Shaders"
+if ($LASTEXITCODE -ne 0) { throw "ezShaderCompiler failed for Data/UnitTests (exit code $LASTEXITCODE)." }
+
+& $shaderCompilerPath -renderer Vulkan -platform VULKAN -project "$RootDir/Data/Samples/ShaderExplorer" -shader Shaders
+if ($LASTEXITCODE -ne 0) { throw "ezShaderCompiler failed for Data/Samples/ShaderExplorer (exit code $LASTEXITCODE)." }

--- a/Utilities/Android/DbgAndroidLldb.ps1
+++ b/Utilities/Android/DbgAndroidLldb.ps1
@@ -43,12 +43,12 @@ if (-not $filesPresent) {
 	$lldbStartLocalPath = "$lldbLocalPath/start_lldb_server.sh"
 
 	if (-not (Test-Path $lldbServerLocalPath)) {
-		RaiseError "Could not find lldb-server in expected location: $lldbServerLocalPath. Please ensure that the ANDROID_NDK_HOME environment variable is correctly set."
+		RaiseError "Could not find lldb-server in expected location: $lldbServerLocalPath. Please ensure that the ANDROID_STUDIO environment variable is correctly set."
 	}
 	$lldbServerLocalPath = Resolve-Path $lldbServerLocalPath
 
 	if (-not (Test-Path $lldbStartLocalPath)) {
-		RaiseError "Could not find start_lldb_server.sh in expected location: $lldbStartLocalPath. Please ensure that the ANDROID_NDK_HOME environment variable is correctly set."
+		RaiseError "Could not find start_lldb_server.sh in expected location: $lldbStartLocalPath. Please ensure that the ANDROID_STUDIO environment variable is correctly set."
 	}
 	$lldbStartLocalPath = Resolve-Path $lldbStartLocalPath
 

--- a/Utilities/Android/InstallAndroidDependencies.ps1
+++ b/Utilities/Android/InstallAndroidDependencies.ps1
@@ -1,0 +1,223 @@
+param(
+    [switch]$installEmulator = $false,
+    [switch]$acceptLicence = $false
+)
+
+# Require PowerShell 7+
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Host "This script requires PowerShell 7 or newer. Please run it using 'pwsh'." -ForegroundColor Red
+    exit 1
+}
+
+# Import Android utils
+. "$PSScriptRoot/AndroidUtils.ps1"
+
+$sharedFolder = [System.IO.Path]::GetFullPath((Join-Path -Path $PSScriptRoot -ChildPath "../../Workspace/shared"))
+
+# Ensure shared android folder and cmdline-tools/latest exist by downloading Google's command-line tools
+$androidShared = Join-Path -Path $sharedFolder -ChildPath "android"
+$cmdlineParent = Join-Path -Path $androidShared -ChildPath "cmdline-tools"
+$cmdlineLatest = Join-Path -Path $cmdlineParent -ChildPath "latest"
+$jdkTarget = Join-Path -Path $androidShared -ChildPath "jdk17"
+
+# Ensure the shared android root exists and set ANDROID_HOME for this session so subsequent scripts find cmdline-tools
+if (-not (Test-Path $androidShared)) {
+    New-Item -ItemType Directory -Path $androidShared -Force | Out-Null
+}
+$env:ANDROID_HOME = [System.IO.Path]::GetFullPath($androidShared)
+Write-Host "Set ANDROID_HOME for this session to '$env:ANDROID_HOME'" -ForegroundColor Green
+function Get-PlatformInfo {
+
+    $platform = if ($IsWindows) { 'win' } elseif ($IsMacOS) { 'mac' } else { 'linux' }
+    $jdkPlatform = if ($IsWindows) { 'windows' } elseif ($IsMacOS) { 'mac' } else { 'linux' }
+    $jdkExt = if ($IsWindows) { 'zip' } else { 'tar.gz' }
+    return [PSCustomObject]@{ IsWindows = $IsWindows; IsMac = $IsMacOS; Platform = $platform; JdkPlatform = $jdkPlatform; JdkExt = $jdkExt }
+}
+
+function Invoke-DownloadAndExtract {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $fileName = [System.IO.Path]::GetFileName($Url)
+    if ([string]::IsNullOrEmpty($fileName)) { $fileName = "download" }
+    $archivePath = Join-Path -Path $Destination -ChildPath $fileName
+
+    $maxTries = 3
+    $try = 0
+    $downloaded = Test-Path $archivePath
+    while (-not $downloaded -and $try -lt $maxTries) {
+        $try++
+        try {
+            Write-Host "Downloading $Url (attempt $try/$maxTries) ..."
+            Invoke-WebRequest -Uri $Url -OutFile $archivePath -UseBasicParsing -ErrorAction Stop
+            $downloaded = $true
+        }
+        catch {
+            Write-Host "Download attempt $try failed: $_"
+            if ($try -ge $maxTries) {
+                Remove-Item -LiteralPath $archivePath -Recurse -Force -ErrorAction SilentlyContinue
+                throw "Failed to download $Url after $maxTries attempts."
+            }
+            Start-Sleep -Seconds (2 * $try)
+        }
+    }
+
+    if ($archivePath -match '\.zip$') {
+        try {
+            Expand-Archive -Path $archivePath -DestinationPath $Destination -Force
+        }
+        catch {
+            $err = $_ | Out-String
+            Remove-Item -LiteralPath $archivePath -Recurse -Force -ErrorAction SilentlyContinue
+            throw "Failed to extract zip $archivePath`n$err"
+        }
+    }
+    elseif ($archivePath -match '\.(tar\.gz|tgz)$') {
+        $tar = "tar"
+        try {
+            Start-Process -FilePath $tar -ArgumentList "-xzf", $archivePath, "-C", $Destination -NoNewWindow -Wait -PassThru -ErrorAction Stop
+        }
+        catch {
+            Remove-Item -LiteralPath $archivePath -Recurse -Force -ErrorAction SilentlyContinue
+            throw "Failed to extract tar.gz archive $archivePath : $_"
+        }
+    }
+    else {
+        Remove-Item -LiteralPath $archivePath -Recurse -Force -ErrorAction SilentlyContinue
+        throw "Unsupported archive format for $archivePath"
+    }
+}
+
+# Download and install cmdline-tools if missing
+if (-not (Test-Path $cmdlineLatest)) {
+    Write-Host "cmdline-tools not found at '$cmdlineLatest'. Downloading Android command-line tools..." -ForegroundColor Green
+
+    # determine platform name used by Google's downloads
+    $plat = Get-PlatformInfo
+    $cmdUrl = "https://dl.google.com/android/repository/commandlinetools-$($plat.Platform)-13114758_latest.zip"
+
+    # create parent
+    if (-not (Test-Path $cmdlineParent)) {
+        New-Item -ItemType Directory -Path $cmdlineParent -Force | Out-Null
+    }
+
+    Invoke-DownloadAndExtract -Url $cmdUrl -Destination $cmdlineParent
+    # move extracted 'cmdline-tools' folder to 'latest'
+    $extractedCmdline = Join-Path -Path $cmdlineParent -ChildPath "cmdline-tools"
+    if (-not (Test-Path $extractedCmdline)) {
+        throw "Expected extracted cmdline-tools folder not found at '$extractedCmdline'"
+    }
+    Move-Item -Path $extractedCmdline -Destination $cmdlineLatest
+
+    # ensure executables are runnable on non-windows
+    if (-not $plat.IsWindows) {
+        if (Test-Path (Join-Path -Path $cmdlineLatest -ChildPath "bin")) {
+            Get-ChildItem -Path (Join-Path -Path $cmdlineLatest -ChildPath "bin") -Recurse -File | ForEach-Object { try { & chmod +x $_.FullName } catch {} }
+        }
+    }
+    Write-Host "Android command-line tools installed to '$cmdlineLatest'." -ForegroundColor Green
+}
+else {
+    Write-Host "cmdline-tools already present at '$cmdlineLatest'. Skipping download."
+}
+
+# Download JDK (Eclipse Temurin 17 by default) and set JAVA_HOME for this session
+
+if (-not (Test-Path $jdkTarget)) {
+    Write-Host "JDK not found at '$jdkTarget'. Downloading JDK..." -ForegroundColor Green
+
+    $plat = Get-PlatformInfo
+    $jdkPlatform = $plat.JdkPlatform
+    $jdkExt = $plat.JdkExt
+
+    # Allow overriding via env var JDK_URL
+    if ($env:JDK_URL) {
+        $jdkUrl = $env:JDK_URL
+    }
+    else {
+        # default to Temurin 17 release asset name pattern
+        $jdkUrl = "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.6%2B10/OpenJDK17U-jdk_x64_${jdkPlatform}_hotspot_17.0.6_10.${jdkExt}"
+    }
+
+    $tmpJdkDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath "ez_jdk_install"
+    if (Test-Path $tmpJdkDir) { Remove-Item -LiteralPath $tmpJdkDir -Recurse -Force -ErrorAction SilentlyContinue }
+    New-Item -ItemType Directory -Path $tmpJdkDir | Out-Null
+
+    Invoke-DownloadAndExtract -Url $jdkUrl -Destination $tmpJdkDir
+
+    # Find the top-level folder that looks like a JDK (contains bin/java or bin/java.exe)
+    $jdkBinRel = "bin/java"
+    $jdkBinWinRel = "bin/java.exe"
+    $foundJdk = Get-ChildItem -Path $tmpJdkDir -Directory -ErrorAction SilentlyContinue | Where-Object {
+        (Test-Path (Join-Path -Path $_.FullName -ChildPath $jdkBinRel)) -or (Test-Path (Join-Path -Path $_.FullName -ChildPath $jdkBinWinRel))
+    } | Select-Object -First 1
+
+    if ($null -eq $foundJdk) {
+        # maybe the extract placed bin at top-level
+        if ((Test-Path (Join-Path -Path $tmpJdkDir -ChildPath $jdkBinRel)) -or (Test-Path (Join-Path -Path $tmpJdkDir -ChildPath $jdkBinWinRel))) {
+            $foundJdk = Get-Item -Path $tmpJdkDir
+        }
+    }
+
+    if ($null -eq $foundJdk) {
+        Remove-Item -LiteralPath $tmpJdkDir -Recurse -Force -ErrorAction SilentlyContinue
+        throw "Could not locate JDK installation in the extracted archive."
+    }
+
+    # Move/copy found JDK into $jdkTarget
+    if (Test-Path $jdkTarget) { Remove-Item -LiteralPath $jdkTarget -Recurse -Force -ErrorAction SilentlyContinue }
+    New-Item -ItemType Directory -Path $jdkTarget | Out-Null
+    Get-ChildItem -Path $foundJdk.FullName | ForEach-Object {
+        $src = $_.FullName
+        $dest = Join-Path -Path $jdkTarget -ChildPath $_.Name
+        Copy-Item -Path $src -Destination $dest -Recurse -Force
+    }
+
+    # make binaries executable on non-windows
+    if (-not $plat.IsWindows) {
+        if (Test-Path (Join-Path -Path $jdkTarget -ChildPath "bin")) {
+            Get-ChildItem -Path (Join-Path -Path $jdkTarget -ChildPath "bin") -Recurse -File | ForEach-Object { try { & chmod +x $_.FullName } catch {} }
+        }
+    }
+
+    Remove-Item -LiteralPath $tmpJdkDir -Recurse -Force -ErrorAction SilentlyContinue
+
+    Write-Host "JDK installed to '$jdkTarget'." -ForegroundColor Green
+}
+else {
+    Write-Host "JDK already present at '$jdkTarget'. Skipping download."
+}
+
+# Set JAVA_HOME for this session
+$env:JAVA_HOME = [System.IO.Path]::GetFullPath($jdkTarget)
+Write-Host "Set JAVA_HOME for this session to '$env:JAVA_HOME'" -ForegroundColor Green
+
+
+$sdkManager = Get-SdkManager
+if ($acceptLicence) {
+    
+    for ($i = 0; $i -lt 8; $i++) {
+        "y`ny`ny`n" | & $sdkManager --licenses | Out-Null
+    }
+}
+
+# build dependencies
+Install-SdkBuildDependencies -SdkManager $sdkManager
+
+if ($installEmulator) {
+    # Emulator packages
+    Install-SdkEmulatorPackages -SdkManager $sdkManager
+}
+
+Write-Host "Android Licenses..." -ForegroundColor Green
+if ($acceptLicence) {
+    
+    for ($i = 0; $i -lt 8; $i++) {
+        "y`ny`ny`n" | & $sdkManager --licenses | Out-Null
+    }
+}
+else {
+    & $sdkManager --licenses
+}

--- a/Utilities/Android/SetupAndroidEnvVars.ps1
+++ b/Utilities/Android/SetupAndroidEnvVars.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+  Export Android-related environment variables for the repository.
+
+.DESCRIPTION
+  Dot-source this script to export `ANDROID_HOME`, `ANDROID_NDK_HOME` and `JAVA_HOME`
+  into the current PowerShell session. The script computes the repository root by
+  walking two directories up from the script location.
+
+.USAGE
+  . .\SetupAndroidEnvVars.ps1
+#>
+
+param()
+
+if ($MyInvocation.InvocationName -ne '.') {
+    Write-Host "Please dot-source this script to export variables in the current session:" -ForegroundColor Yellow
+    Write-Host "  . $PSScriptRoot\SetupAndroidEnvVars.ps1" -ForegroundColor Cyan
+    return
+}
+
+# Compute repository root (two levels up from the script directory)
+$repoRoot = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+
+# Defaults matching the pipeline layout
+$androidHome = Join-Path $repoRoot "Workspace\shared\android"
+$androidNdkHome = Join-Path $androidHome "ndk\26.1.10909125"
+$javaHome = Join-Path $androidHome "jdk17"
+
+$env:ANDROID_HOME = $androidHome
+$env:ANDROID_NDK_HOME = $androidNdkHome
+$env:JAVA_HOME = $javaHome
+
+# Add platform-tools (adb) to PATH if not already present
+$platformTools = Join-Path $androidHome 'platform-tools'
+if ($env:Path -notlike "*$platformTools*") {
+  $env:Path = "$platformTools;$env:Path"
+}
+
+Write-Host "Exported environment variables:" -ForegroundColor Green
+Write-Host "  ANDROID_HOME=$env:ANDROID_HOME"
+Write-Host "  ANDROID_NDK_HOME=$env:ANDROID_NDK_HOME"
+Write-Host "  JAVA_HOME=$env:JAVA_HOME"
+Write-Host "  PATH=$env:Path"

--- a/Utilities/Android/SetupAndroidEnvVars.sh
+++ b/Utilities/Android/SetupAndroidEnvVars.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SetupAndroidEnvVars.sh
+# Source this script to export Android-related environment variables for the repo.
+# Usage: source Utilities/Android/SetupAndroidEnvVars.sh
+
+set -euo pipefail
+
+# Detect if script is sourced
+sourced=0
+if [ -n "${BASH_SOURCE-+x}" ]; then
+  if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    sourced=1
+  fi
+fi
+
+# Fallback check for shells that support return
+if [ $sourced -eq 0 ]; then
+  (return 0 2>/dev/null) && sourced=1 || true
+fi
+
+if [ $sourced -ne 1 ]; then
+  echo "Please source this file to export environment variables:"
+  echo "  source ${BASH_SOURCE[0]}"
+  exit 1
+fi
+
+# Determine repository root (always two levels up from this script)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Defaults matching the pipeline layout
+ANDROID_HOME="$REPO_ROOT/Workspace/shared/android"
+ANDROID_NDK_HOME="$ANDROID_HOME/ndk/26.1.10909125"
+JAVA_HOME="$ANDROID_HOME/jdk17"
+
+export ANDROID_HOME ANDROID_NDK_HOME JAVA_HOME
+
+# Add platform-tools (adb) to PATH if not already present
+platform_tools="$ANDROID_HOME/platform-tools"
+case ":$PATH:" in
+  *":$platform_tools:") ;;
+  *) export PATH="$platform_tools:$PATH" ;;
+esac
+
+cat <<EOF
+Exported environment variables:
+  ANDROID_HOME=$ANDROID_HOME
+  ANDROID_NDK_HOME=$ANDROID_NDK_HOME
+  JAVA_HOME=$JAVA_HOME
+  PATH=$PATH
+EOF


### PR DESCRIPTION
## Android Dependencies
* Android dependencies are now downloaded to **Workspace/shared** via the pwsh script `Utilities/Android/InstallAndroidDependencies.ps1`. This will download the Android tools, SDK and NDK. Parameteres exist to also install the emulator and for auto-accepting the Android licences to allow running it on CI.
* Shaders necessary to build Android tests and samples are compiled via the new script `Utilities/Android/CompileShaders.ps1`. On Linux, the `-BinariesDir` parameter has to be set to point to a binary dir that contains the ezShaderCompiler. On Windows, this defaults to the precompiled tools directory.
  * `Android-x64.yml` will now use the precompiled tools for shader compilation. If this becomes an issue during breaking changes, there is a parameter `compileShaderCompiler` at the top of the file to switch back to self-built shader compiler.
* To set the android env vars `ANDROID_HOME`, `ANDROID_NDK_HOME` and `JAVA_HOME` for the current session and put adb into the `PATH` env var, run `. ./Utilities/Android/SetupAndroidEnvVars.ps1` or the `.sh` equivalent for Linux.

## RunCMake
* `RunCMake.ps1` now uses cmake presets, meaning most of the settings are taken from the `CMakePresets.json` file. This changes the valid parameters for the `-Target` switch as this is now simply the preset name which always matches the folder name under `Workspace`. You will thus need to replace **Win64vs2022** with **vs2022x64**. Also added a `-VulkanSupport 1` bool paramter which can be used for Windows builds to enable Vulkan as well. Note that running `GenerateWin64vs2022.bat` on its own will keep the previously set value for Vulkan. The default is off for now.
* Added support for Android builds to `RunCMake.ps1`. Running e.g. `./RunCMake.ps1 -target android-arm64-debug` will run the dependency download, shader compilation and cmake project generation.

## Misc
* Fileserve now works under Linux as well.
* Added explicit generation of debug symbols to clang (`-g`) as some clang versions seem to have changed defaults, resulting in no debug info.
* Fixed ShaderExplorer sample to work on Android again.
* Disabled Fileserve for now on Android in ShaderExplorer as I can't get the port forwarding to work.

## TLDR Android build in Windows
```ps
./RunCMake.ps1 -target android-arm64-debug
ninja -C Workspace/android-arm64-debug
. ./Utilities/Android/SetupAndroidEnvVars.ps1
adb install ./Output/Bin/AndroidNinjaClangDebugArm64/ShaderExplorer.apk
```