### PR TITLE
Improvements for Cpp Project generation

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -900,6 +900,14 @@ void ezProjectAction::Execute(const ezVariant& value)
       }
       else
       {
+        // most likely the user executes this because there is a problem
+        // so use this opportunity to update the CMake files, if they are outdated
+        if (ezCppProject::PopulateWithDefaultSources(cpp).Failed())
+        {
+          ezQtUiServices::GetSingleton()->MessageBoxWarning("Failed to populate the CppSource directory with the default files.\n\nCheck the log for details.");
+          break;
+        }
+
         if (ezCppProject::RunCMake(cpp).Succeeded())
         {
           ezQtUiServices::GetSingleton()->MessageBoxInformation("Successfully regenerated the C++ solution.");

--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -874,7 +874,7 @@ void ezProjectAction::Execute(const ezVariant& value)
       {
         if (ezCppProject::BuildCodeIfNecessary(cpp).Succeeded())
         {
-          ezQtUiServices::GetSingleton()->MessageBoxInformation("Successfully compiled the C++ code.");
+          ezQtUiServices::GetSingleton()->MessageBoxInformation("Successfully compiled the C++ code.", "cpp-compile-success");
         }
         else
         {
@@ -910,7 +910,7 @@ void ezProjectAction::Execute(const ezVariant& value)
 
         if (ezCppProject::RunCMake(cpp).Succeeded())
         {
-          ezQtUiServices::GetSingleton()->MessageBoxInformation("Successfully regenerated the C++ solution.");
+          ezQtUiServices::GetSingleton()->MessageBoxInformation("Successfully regenerated the C++ solution.", "cpp-regen-success");
         }
         else
         {

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -642,6 +642,71 @@ bool ezCppProject::ExistsProjectCMakeListsTxt()
   return ezOSFile::ExistsFile(sPath);
 }
 
+bool ezCppProject::ShouldOverwriteExisting(ezStringView sSrc, ezStringView sDst)
+{
+  const ezStringView sFilename = sDst.GetFileNameAndExtension();
+
+  // only check certain files
+  // they use a "#ez-version" tag to identify when a file got modified in such a way
+  // that existing files should be overwritten
+  if (sFilename != "CMakeLists.txt" && sFilename != ".clang-format" && sFilename != ".editorconfig" && sFilename != ".gitattributes" && sFilename != ".gitignore")
+  {
+    return false;
+  }
+
+  ezOSFile srcFile;
+  if (srcFile.Open(sSrc, ezFileOpenMode::Read).Failed())
+    return false;
+
+  ezOSFile dstFile;
+  if (dstFile.Open(sDst, ezFileOpenMode::Read).Failed())
+    return true;
+
+  ezDataBuffer sc, dc;
+  srcFile.ReadAll(sc);
+  dstFile.ReadAll(dc);
+
+  if (sc == dc)
+    return false;
+
+  ezStringView srcContent = ezStringView((const char*)sc.GetData(), sc.GetCount());
+  ezStringView dstContent = ezStringView((const char*)dc.GetData(), dc.GetCount());
+
+  ezStringView sVersionSrc, sVersionDst;
+
+  if (const char* vSrc = srcContent.FindSubString("#ez-version"))
+  {
+    const char* srcEnd = srcContent.FindSubString("\n", vSrc);
+
+    if (srcEnd == nullptr)
+    {
+      srcEnd = srcContent.GetEndPointer();
+    }
+
+    sVersionSrc = ezStringView(vSrc + 8, srcEnd);
+    sVersionSrc.Trim();
+  }
+
+  if (const char* vDst = dstContent.FindSubString("#ez-version"))
+  {
+    const char* dstEnd = dstContent.FindSubString("\n", vDst);
+
+    if (dstEnd == nullptr)
+    {
+      dstEnd = dstContent.GetEndPointer();
+    }
+
+    sVersionDst = ezStringView(vDst + 8, dstEnd);
+    sVersionDst.Trim();
+  }
+
+  // don't overwrite the destination file, if it is different, but at the same version
+  if (sVersionSrc == sVersionDst)
+    return false;
+
+  return true;
+}
+
 ezResult ezCppProject::PopulateWithDefaultSources(const ezCppSettings& cfg)
 {
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -670,6 +735,8 @@ ezResult ezCppProject::PopulateWithDefaultSources(const ezCppSettings& cfg)
 
   // gather files
   {
+    bool bCheckOverwrite = false;
+
     for (const auto& item : items)
     {
       ezStringBuilder srcPath, dstPath;
@@ -686,8 +753,23 @@ ezResult ezCppProject::PopulateWithDefaultSources(const ezCppSettings& cfg)
       if (ezOSFile::ExistsFile(dstPath))
       {
         // if any file already exists, don't copy non-existing (user might have deleted unwanted sample files)
-        filesCopied.Clear();
-        break;
+        if (!bCheckOverwrite)
+        {
+          // first time we see an existing file, clear the list of files to copy and enter different mode
+          // from now on, we only add files to the copy list, that should get overwritten
+          filesCopied.Clear();
+          bCheckOverwrite = true;
+        }
+      }
+
+      if (bCheckOverwrite)
+      {
+        if (!ShouldOverwriteExisting(srcPath, dstPath))
+        {
+          // in this mode, don't copy files unless they should be overwritten
+          // mostly to update existing CMakeLists.txt files with newer versions
+          continue;
+        }
       }
 
       auto& ftc = filesCopied.ExpandAndGetRef();

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.h
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.h
@@ -130,6 +130,9 @@ struct EZ_EDITORFRAMEWORK_DLL ezCppProject : public ezPreferences
 
   static bool ExistsProjectCMakeListsTxt();
 
+  /// Returns true if sDst doesn't exist yet, or for some file types (e.g. CMakeLists.txt), when they got an update.
+  static bool ShouldOverwriteExisting(ezStringView sSrc, ezStringView sDst);
+
   static ezResult PopulateWithDefaultSources(const ezCppSettings& cfg);
 
   static ezResult CleanBuildDir(const ezCppSettings& cfg);

--- a/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/ExportProjectDlg.cpp
@@ -113,7 +113,7 @@ void ezQtExportProjectDlg::on_ExportProjectButton_clicked()
   }
   else
   {
-    ezQtUiServices::GetSingleton()->MessageBoxInformation("Project export successful.");
+    ezQtUiServices::GetSingleton()->MessageBoxInformation("Project export successful.", "project-export-success");
     ezQtUiServices::GetSingleton()->OpenInExplorer(szDstFolder, false);
   }
 }

--- a/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/CheckVersion.cpp
@@ -8,6 +8,7 @@
 #include <Foundation/IO/OpenDdlReader.h>
 #include <Foundation/IO/OpenDdlUtils.h>
 #include <Foundation/IO/OpenDdlWriter.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <QNetworkReply>
 #include <QProcess>
 
@@ -154,7 +155,7 @@ bool ezQtVersionChecker::Check(bool bForce)
 
 const char* ezQtVersionChecker::GetOwnVersion() const
 {
-  return EZ_PP_STRINGIFY(BUILDSYSTEM_SDKVERSION_MAJOR) "." EZ_PP_STRINGIFY(BUILDSYSTEM_SDKVERSION_MINOR) "." EZ_PP_STRINGIFY(BUILDSYSTEM_SDKVERSION_PATCH);
+  return ezQtUiServices::GetOwnVersionString();
 }
 
 const char* ezQtVersionChecker::GetKnownLatestVersion() const

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -371,16 +371,13 @@ void ezQtDocumentWindow::SaveWindowLayout()
   if (bMaximized)
     showNormal();
 
-  ezStringBuilder sGroup;
-  sGroup.SetFormat("DocWndLayout2_{0}", GetWindowLayoutGroupName());
-
   QSettings Settings;
-  Settings.beginGroup(QString::fromUtf8(sGroup, sGroup.GetElementCount()));
+  Settings.beginGroup("DocWndLayout");
+  Settings.beginGroup(GetWindowLayoutGroupName());
   {
     // All other properties are defined by the outer container window.
-    Settings.setValue("DocWndState2", m_pDockManager->saveState());
+    Settings.setValue("DocWndState", m_pDockManager->saveState());
   }
-  Settings.endGroup();
 }
 
 void ezQtDocumentWindow::RestoreWindowLayout(bool bForce)
@@ -403,9 +400,6 @@ void ezQtDocumentWindow::RestoreWindowLayout(bool bForce)
 
   ezQtScopedUpdatesDisabled _(this);
 
-  ezStringBuilder sGroup;
-  sGroup.SetFormat("DocWndLayout2_{0}", GetWindowLayoutGroupName());
-
   {
     ezHybridArray<QWidget*, 8> docks;
 
@@ -417,11 +411,11 @@ void ezQtDocumentWindow::RestoreWindowLayout(bool bForce)
     }
 
     QSettings Settings;
-    Settings.beginGroup(QString::fromUtf8(sGroup, sGroup.GetElementCount()));
+    Settings.beginGroup("DocWndLayout");
+    Settings.beginGroup(GetWindowLayoutGroupName());
     {
-      m_pDockManager->restoreState(Settings.value("DocWndState2", m_pDockManager->saveState()).toByteArray());
+      m_pDockManager->restoreState(Settings.value("DocWndState", m_pDockManager->saveState()).toByteArray());
     }
-    Settings.endGroup();
   }
 
   statusBar()->clearMessage();

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/MessageBoxes.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/MessageBoxes.cpp
@@ -5,6 +5,11 @@
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
+const char* ezQtUiServices::GetOwnVersionString()
+{
+  return EZ_PP_STRINGIFY(BUILDSYSTEM_SDKVERSION_MAJOR) "." EZ_PP_STRINGIFY(BUILDSYSTEM_SDKVERSION_MINOR) "." EZ_PP_STRINGIFY(BUILDSYSTEM_SDKVERSION_PATCH);
+}
+
 void ezQtUiServices::MessageBoxStatus(const ezStatus& s, const char* szFailureMsg, const char* szSuccessMsg, bool bOnlySuccessMsgIfDetails)
 {
   ezStringBuilder sResult;
@@ -35,7 +40,7 @@ void ezQtUiServices::MessageBoxStatus(const ezStatus& s, const char* szFailureMs
   }
 }
 
-void ezQtUiServices::MessageBoxInformation(const ezFormatString& msg)
+void ezQtUiServices::MessageBoxInformation(const ezFormatString& msg, ezStringView sDontShowAgainID)
 {
   ezStringBuilder tmp;
 
@@ -43,7 +48,34 @@ void ezQtUiServices::MessageBoxInformation(const ezFormatString& msg)
     ezLog::Info(msg.GetText(tmp));
   else
   {
-    QMessageBox::information(QApplication::activeWindow(), ezApplication::GetApplicationInstance()->GetApplicationName().GetData(), QString::fromUtf8(msg.GetTextCStr(tmp)), QMessageBox::StandardButton::Ok);
+    QMessageBox box(QApplication::activeWindow());
+    box.setWindowTitle(ezApplication::GetApplicationInstance()->GetApplicationName().GetData());
+    box.setText(QString::fromUtf8(msg.GetTextCStr(tmp)));
+    box.setIcon(QMessageBox::Icon::Information);
+
+    QSettings Settings;
+    Settings.beginGroup(GetOwnVersionString());
+    Settings.beginGroup("msgbox-dontshow");
+
+    if (!sDontShowAgainID.IsEmpty())
+    {
+      ShowAllDocumentsTemporaryStatusBarMessage(msg, ezTime::Seconds(3));
+
+      if (Settings.value(sDontShowAgainID.GetData(tmp), 0) != 0)
+      {
+        // don't show the messagebox again was selected at some point
+        return;
+      }
+
+      box.setCheckBox(new QCheckBox("Don't show again"));
+    }
+
+    box.exec();
+
+    if (box.checkBox() && box.checkBox()->isChecked())
+    {
+      Settings.setValue(sDontShowAgainID.GetData(tmp), 1);
+    }
   }
 }
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -64,6 +64,8 @@ public:
 public:
   ezQtUiServices();
 
+  static const char* GetOwnVersionString();
+
   /// \brief True if the application doesn't show any window and only works in the background
   static bool IsHeadless();
 
@@ -80,7 +82,7 @@ public:
   static void MessageBoxStatus(const ezStatus& s, const char* szFailureMsg, const char* szSuccessMsg = "", bool bOnlySuccessMsgIfDetails = true);
 
   /// \brief Shows an information message box
-  static void MessageBoxInformation(const ezFormatString& msg);
+  static void MessageBoxInformation(const ezFormatString& msg, ezStringView sDontShowAgainID = {});
 
   /// \brief Shows an warning message box
   static void MessageBoxWarning(const ezFormatString& msg);

--- a/Code/UnitTests/EditorTest/GenerateCompile/GenerateCompile.cpp
+++ b/Code/UnitTests/EditorTest/GenerateCompile/GenerateCompile.cpp
@@ -5,21 +5,21 @@
 #include <EditorFramework/CodeGen/CppSettings.h>
 #include <GuiFoundation/Action/ActionManager.h>
 
-static ezEditorTestGenerateCompile s_EditorTestGenerateAndCompile;
+static ezEditorTestGenerateCompilePacMan s_ezEditorTestGenerateCompilePacMan;
 
-const char* ezEditorTestGenerateCompile::GetTestName() const
+const char* ezEditorTestGenerateCompilePacMan::GetTestName() const
 {
   return "Generate and Compile";
 }
 
-void ezEditorTestGenerateCompile::SetupSubTests()
+void ezEditorTestGenerateCompilePacMan::SetupSubTests()
 {
   AddSubTest("01 - Generate and Compile", SubTests::ST_GenerateAndCompile);
   AddSubTest("02 - EditorProcessor: Compile Only", SubTests::ST_EditorProcessorCompileOnly);
   AddSubTest("03 - EditorProcessor: Compile and Transform", SubTests::ST_EditorProcessorCompileAndTransform);
 }
 
-ezResult ezEditorTestGenerateCompile::InitializeTest()
+ezResult ezEditorTestGenerateCompilePacMan::InitializeTest()
 {
   if (SUPER::InitializeTest().Failed())
     return EZ_FAILURE;
@@ -37,7 +37,7 @@ ezResult ezEditorTestGenerateCompile::InitializeTest()
   return EZ_SUCCESS;
 }
 
-ezResult ezEditorTestGenerateCompile::DeInitializeTest()
+ezResult ezEditorTestGenerateCompilePacMan::DeInitializeTest()
 {
   if (!m_sProjectPath.IsEmpty())
   {
@@ -53,24 +53,20 @@ ezResult ezEditorTestGenerateCompile::DeInitializeTest()
   return EZ_SUCCESS;
 }
 
-ezStatus ezEditorTestGenerateCompile::PrepareCompile(ezStringBuilder& dllPath, ezStringBuilder& bundlePath)
+ezStatus ezEditorTestGenerateCompile::PrepareCompile(ezStringBuilder& dllPath)
 {
   // Delete any existing build artifacts
   dllPath = ezOSFile::GetApplicationDirectory();
+  dllPath.AppendPath(m_sProjectName);
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-  dllPath.AppendPath("PacManPlugin.dll");
+  dllPath.Append("Plugin.dll");
 #else
-  dllPath.AppendPath("PacManPlugin.so");
+  dllPath.Append("Plugin.so");
 #endif
 
-  bundlePath = ezOSFile::GetApplicationDirectory();
-  bundlePath.AppendPath("PacManPlugin.ezPluginBundle");
-
   ezOSFile::DeleteFile(dllPath).IgnoreResult();
-  ezOSFile::DeleteFile(bundlePath).IgnoreResult();
 
-  if (!EZ_TEST_BOOL(!ezOSFile::ExistsFile(dllPath)) ||
-      !EZ_TEST_BOOL(!ezOSFile::ExistsFile(bundlePath)))
+  if (!EZ_TEST_BOOL(!ezOSFile::ExistsFile(dllPath)))
   {
     return ezStatus("Failed to delete existing build artifacts - DLL or bundle file still exists");
   }
@@ -111,8 +107,8 @@ ezStatus ezEditorTestGenerateCompile::RunEditorProcessor(const ezDynamicArray<ez
 
 ezStatus ezEditorTestGenerateCompile::EditorProcessorCompileOnly()
 {
-  ezStringBuilder dllPath, bundlePath;
-  EZ_SUCCEED_OR_RETURN(PrepareCompile(dllPath, bundlePath));
+  ezStringBuilder dllPath;
+  EZ_SUCCEED_OR_RETURN(PrepareCompile(dllPath));
 
   // Run EditorProcessor with -compile flag
   ezDynamicArray<ezString> arguments;
@@ -129,7 +125,6 @@ ezStatus ezEditorTestGenerateCompile::EditorProcessorCompileOnly()
 
   // Verify that the DLL and bundle files have been created
   EZ_TEST_BOOL(ezOSFile::ExistsFile(dllPath));
-  EZ_TEST_BOOL(ezOSFile::ExistsFile(bundlePath));
 
   return ezStatus(EZ_SUCCESS);
 }
@@ -145,8 +140,8 @@ ezStatus ezEditorTestGenerateCompile::EditorProcessorCompileAndTransform()
     return ezStatus(ezFmt("Failed to delete asset cache folder: {}", assetCachePath));
   }
 
-  ezStringBuilder dllPath, bundlePath;
-  EZ_SUCCEED_OR_RETURN(PrepareCompile(dllPath, bundlePath));
+  ezStringBuilder dllPath;
+  EZ_SUCCEED_OR_RETURN(PrepareCompile(dllPath));
 
   // Run EditorProcessor with -compile and -transform flags
   ezDynamicArray<ezString> arguments;
@@ -173,15 +168,14 @@ ezStatus ezEditorTestGenerateCompile::EditorProcessorCompileAndTransform()
 
   // Verify that the DLL and bundle files have been created
   EZ_TEST_BOOL(ezOSFile::ExistsFile(dllPath));
-  EZ_TEST_BOOL(ezOSFile::ExistsFile(bundlePath));
 
   return ezStatus(EZ_SUCCESS);
 }
 
 ezStatus ezEditorTestGenerateCompile::GenerateAndCompile()
 {
-  ezStringBuilder dllPath, bundlePath;
-  EZ_SUCCEED_OR_RETURN(PrepareCompile(dllPath, bundlePath));
+  ezStringBuilder dllPath;
+  EZ_SUCCEED_OR_RETURN(PrepareCompile(dllPath));
 
   ezCppSettings cpp;
   if (!EZ_TEST_RESULT(cpp.Load()))
@@ -205,7 +199,7 @@ ezStatus ezEditorTestGenerateCompile::GenerateAndCompile()
   return ezStatus(EZ_SUCCESS);
 }
 
-ezTestAppRun ezEditorTestGenerateCompile::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+ezTestAppRun ezEditorTestGenerateCompilePacMan::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
 {
   ProcessEvents();
   switch (iIdentifier)
@@ -230,12 +224,12 @@ ezTestAppRun ezEditorTestGenerateCompile::RunSubTest(ezInt32 iIdentifier, ezUInt
   return ezTestAppRun::Quit;
 }
 
-ezResult ezEditorTestGenerateCompile::InitializeSubTest(ezInt32 iIdentifier)
+ezResult ezEditorTestGenerateCompilePacMan::InitializeSubTest(ezInt32 iIdentifier)
 {
   return EZ_SUCCESS;
 }
 
-ezResult ezEditorTestGenerateCompile::DeInitializeSubTest(ezInt32 iIdentifier)
+ezResult ezEditorTestGenerateCompilePacMan::DeInitializeSubTest(ezInt32 iIdentifier)
 {
   ezDocumentManager::CloseAllDocuments();
   return EZ_SUCCESS;

--- a/Code/UnitTests/EditorTest/GenerateCompile/GenerateCompile.h
+++ b/Code/UnitTests/EditorTest/GenerateCompile/GenerateCompile.h
@@ -11,16 +11,32 @@ class ezEditorTestGenerateCompile : public ezEditorTest
 public:
   using SUPER = ezEditorTest;
 
+protected:
+  ezStatus PrepareCompile(ezStringBuilder& dllPath);
+  ezString GetEditorProcessorPath() const;
+  ezStatus RunEditorProcessor(const ezDynamicArray<ezString>& arguments);
+
+  ezStatus GenerateAndCompile();
+  ezStatus EditorProcessorCompileOnly();
+  ezStatus EditorProcessorCompileAndTransform();
+
+  ezString m_sProjectName;
+  ezDocument* m_pDocument = nullptr;
+};
+
+class ezEditorTestGenerateCompilePacMan : public ezEditorTestGenerateCompile
+{
+public:
+  using SUPER = ezEditorTestGenerateCompile;
+
+  ezEditorTestGenerateCompilePacMan()
+  {
+    m_sProjectName = "PacMan";
+  }
+
   virtual const char* GetTestName() const override;
 
 private:
-  enum SubTests
-  {
-    ST_GenerateAndCompile,
-    ST_EditorProcessorCompileOnly,
-    ST_EditorProcessorCompileAndTransform
-  };
-
   virtual void SetupSubTests() override;
   virtual ezResult InitializeTest() override;
   virtual ezResult DeInitializeTest() override;
@@ -29,13 +45,10 @@ private:
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
 
-  ezStatus PrepareCompile(ezStringBuilder& dllPath, ezStringBuilder& bundlePath);
-  ezString GetEditorProcessorPath() const;
-  ezStatus RunEditorProcessor(const ezDynamicArray<ezString>& arguments);
-
-  ezStatus GenerateAndCompile();
-  ezStatus EditorProcessorCompileOnly();
-  ezStatus EditorProcessorCompileAndTransform();
-
-  ezDocument* m_pDocument = nullptr;
+  enum SubTests
+  {
+    ST_GenerateAndCompile,
+    ST_EditorProcessorCompileOnly,
+    ST_EditorProcessorCompileAndTransform
+  };
 };

--- a/Data/Samples/Asteroids/CppSource/.clang-format
+++ b/Data/Samples/Asteroids/CppSource/.clang-format
@@ -1,3 +1,5 @@
+#ez-version 1
+
 BasedOnStyle: LLVM
 UseTab: Never
 IndentWidth: 2

--- a/Data/Samples/Asteroids/CppSource/.editorconfig
+++ b/Data/Samples/Asteroids/CppSource/.editorconfig
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # EditorConfig is awesome: http://EditorConfig.org
 # To make use of this, simply install a plugin for Visual Studio 20XX, Visual Studio Code, Notepad++ or XCode
 # Will work out of the box with Visual Studio 15

--- a/Data/Samples/Asteroids/CppSource/.gitattributes
+++ b/Data/Samples/Asteroids/CppSource/.gitattributes
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # By default convert text files to what the user prefers
 * text=auto
 

--- a/Data/Samples/Asteroids/CppSource/.gitignore
+++ b/Data/Samples/Asteroids/CppSource/.gitignore
@@ -1,9 +1,12 @@
-﻿Build/*
+#ez-version 1
+
+Build/*
 AssetCache/
 
 # FMOD specific
 .cache/
 .user/
+.unsaved/
 
 # VSCode specific
 CMakeUserPresets.json

--- a/Data/Samples/Asteroids/CppSource/AsteroidsGame/AsteroidsGame.cpp
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsGame/AsteroidsGame.cpp
@@ -95,16 +95,3 @@ void AsteroidsGame::AfterCoreSystemsStartup()
   ActivateGameState(nullptr, {}, ezTransform::MakeIdentity());
 }
 
-void AsteroidsGame::Run_InputUpdate()
-{
-  SUPER::Run_InputUpdate();
-
-  if (auto pGameState = GetActiveGameState())
-  {
-    // pass through the closing of the application
-    if (pGameState->WasQuitRequested())
-    {
-      RequestApplicationQuit();
-    }
-  }
-}

--- a/Data/Samples/Asteroids/CppSource/AsteroidsGame/AsteroidsGame.h
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsGame/AsteroidsGame.h
@@ -10,7 +10,6 @@ public:
   AsteroidsGame();
 
 protected:
-  virtual void Run_InputUpdate() override;
   virtual ezResult BeforeCoreSystemsStartup() override;
   virtual void AfterCoreSystemsStartup() override;
   virtual ezUniquePtr<ezGameStateBase> CreateGameState() override;

--- a/Data/Samples/Asteroids/CppSource/AsteroidsGame/CMakeLists.txt
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsGame/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name

--- a/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/CMakeLists.txt
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -8,9 +9,9 @@ ez_create_target(SHARED_LIBRARY ${PROJECT_NAME} NO_EZ_PREFIX NO_UNITY)
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
   GameEngine
+  Utilities
 )
 
 # include the EZ natvis file for a better debugging experience
 get_property(EZ_ROOT_DIR GLOBAL PROPERTY EZ_ROOT)
 target_sources(${PROJECT_NAME} PUBLIC "${EZ_ROOT_DIR}/Code/Engine/Foundation/ezEngine.natvis")
-

--- a/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/Components/ProjectileComponent.cpp
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/Components/ProjectileComponent.cpp
@@ -7,7 +7,6 @@
 #include <RendererCore/Meshes/MeshComponent.h>
 
 #include <Core/Input/DeviceTypes/Controller.h>
-#include <Core/System/ControllerInput.h>
 
 // clang-format off
 EZ_BEGIN_COMPONENT_TYPE(ProjectileComponent, 1, ezComponentMode::Dynamic);
@@ -77,9 +76,9 @@ void ProjectileComponent::Update()
           float HitTrack[20] = {
             1.0f, 0.1f, 0.0f, 0.1f, 0.0f, 0.1f, 0.0f, 0.1f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-          if (ezControllerInput::HasDevice())
+          if (auto pController = ezInputManager::GetInputDeviceOfType<ezInputDeviceController>())
           {
-            ezControllerInput::GetDevice()->AddVibrationTrack(static_cast<ezUInt8>(pShipComponent->m_iPlayerIndex), ezInputDeviceController::Motor::LeftMotor, HitTrack, 20);
+            pController->AddVibrationTrack(static_cast<ezUInt8>(pShipComponent->m_iPlayerIndex), ezInputDeviceController::Motor::LeftMotor, HitTrack, 20);
           }
         }
 

--- a/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/Components/ShipComponent.cpp
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/Components/ShipComponent.cpp
@@ -4,7 +4,6 @@
 #include <AsteroidsPlugin/GameState/Level.h>
 #include <Core/Input/DeviceTypes/Controller.h>
 #include <Core/Messages/SetColorMessage.h>
-#include <Core/System/ControllerInput.h>
 #include <Foundation/Configuration/CVar.h>
 #include <Foundation/Utilities/Stats.h>
 #include <RendererCore/Meshes/MeshComponent.h>
@@ -182,9 +181,9 @@ void ShipComponent::Update()
 
     float ShootTrack[20] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
 
-    if (ezControllerInput::HasDevice())
+    if (auto pController = ezInputManager::GetInputDeviceOfType<ezInputDeviceController>())
     {
-      ezControllerInput::GetDevice()->AddVibrationTrack(static_cast<ezUInt8>(m_iPlayerIndex), ezInputDeviceController::Motor::RightMotor, ShootTrack, 20);
+      pController->AddVibrationTrack(static_cast<ezUInt8>(m_iPlayerIndex), ezInputDeviceController::Motor::RightMotor, ShootTrack, 20);
     }
   }
 

--- a/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/GameState/AsteroidsGameState.cpp
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/GameState/AsteroidsGameState.cpp
@@ -3,7 +3,6 @@
 #include <AsteroidsPlugin/GameState/AsteroidsGameState.h>
 #include <Core/Input/DeviceTypes/Controller.h>
 #include <Core/Input/InputManager.h>
-#include <Core/System/ControllerInput.h>
 #include <Core/System/Window.h>
 #include <Core/World/World.h>
 #include <Foundation/Configuration/CVar.h>
@@ -38,7 +37,7 @@ namespace
 AsteroidsGameState::AsteroidsGameState() = default;
 AsteroidsGameState::~AsteroidsGameState() = default;
 
-ezString AsteroidsGameState::GetStartupSceneFile()
+void AsteroidsGameState::GetStartupOptions(ezString& out_sScene, ezString& out_sPreloadCollection)
 {
   // replace this to load a certain scene at startup
   // the default implementation looks at the command line "-scene" argument
@@ -46,13 +45,15 @@ ezString AsteroidsGameState::GetStartupSceneFile()
   // if we have a "-scene" command line argument, it was launched from the editor and we should load that
   if (ezCommandLineUtils::GetGlobalInstance()->HasOption("-scene"))
   {
-    return ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-scene");
+    out_sScene = ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-scene");
   }
-
-  // otherwise, we use the hardcoded 'Main.ezScene'
-  // if that doesn't exist, this function has to be adjusted
-  // note that you can return an asset GUID here, instead of a path
-  return "AssetCache/Common/Scenes/Main.ezBinScene";
+  else
+  {
+    // otherwise, we use the hardcoded 'Main.ezScene'
+    // if that doesn't exist, this function has to be adjusted
+    // note that you can return an asset GUID here, instead of a path
+    out_sScene = "AssetCache/Common/Scenes/Main.ezBinScene";
+  }
 }
 
 void AsteroidsGameState::OnActivation(ezWorld* pWorld, ezStringView sStartPosition, const ezTransform& startPositionOffset)
@@ -89,12 +90,18 @@ void AsteroidsGameState::OnChangedMainWorld(ezWorld* pPrevWorld, ezWorld* pNewWo
 
 void AsteroidsGameState::ConfigureInputActions()
 {
-  if (ezControllerInput::HasDevice())
+  // calling the base class is necessary to register the default key bindings
+  // e.g. ESC to quit, F1 to open the console
+  // if you want more control, take a look at what ezGameState::ConfigureInputActions() does
+  // and register only specific actions (see ezGameApplication::RegisterGameApplicationInputActions())
+  AsteroidsGameStateBase::ConfigureInputActions();
+
+  if (auto pController = ezInputManager::GetInputDeviceOfType<ezInputDeviceController>())
   {
-    ezControllerInput::GetDevice()->EnableVibration(0, true);
-    ezControllerInput::GetDevice()->EnableVibration(1, true);
-    ezControllerInput::GetDevice()->EnableVibration(2, true);
-    ezControllerInput::GetDevice()->EnableVibration(3, true);
+    pController->EnableVibration(0, true);
+    pController->EnableVibration(1, true);
+    pController->EnableVibration(2, true);
+    pController->EnableVibration(3, true);
   }
 
   // setup all controllers

--- a/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/GameState/AsteroidsGameState.h
+++ b/Data/Samples/Asteroids/CppSource/AsteroidsPlugin/GameState/AsteroidsGameState.h
@@ -26,7 +26,7 @@ public:
 protected:
   virtual void ConfigureInputActions() override;
   virtual void OnChangedMainWorld(ezWorld* pPrevWorld, ezWorld* pNewWorld, ezStringView sStartPosition, const ezTransform& startPositionOffset) override;
-  virtual ezString GetStartupSceneFile() override;
+  virtual void GetStartupOptions(ezString& out_sScene, ezString& out_sPreloadCollection) override;
 
 private:
   virtual void OnActivation(ezWorld* pWorld, ezStringView sStartPosition, const ezTransform& startPositionOffset) override;

--- a/Data/Samples/Asteroids/CppSource/CMakeLists.txt
+++ b/Data/Samples/Asteroids/CppSource/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 cmake_minimum_required(VERSION 3.21)
 
 project (Asteroids VERSION 1.0 LANGUAGES C CXX)

--- a/Data/Samples/PacMan/CppSource/.clang-format
+++ b/Data/Samples/PacMan/CppSource/.clang-format
@@ -1,3 +1,5 @@
+#ez-version 1
+
 BasedOnStyle: LLVM
 UseTab: Never
 IndentWidth: 2

--- a/Data/Samples/PacMan/CppSource/.editorconfig
+++ b/Data/Samples/PacMan/CppSource/.editorconfig
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # EditorConfig is awesome: http://EditorConfig.org
 # To make use of this, simply install a plugin for Visual Studio 20XX, Visual Studio Code, Notepad++ or XCode
 # Will work out of the box with Visual Studio 15

--- a/Data/Samples/PacMan/CppSource/.gitattributes
+++ b/Data/Samples/PacMan/CppSource/.gitattributes
@@ -1,0 +1,23 @@
+#ez-version 1
+
+# By default convert text files to what the user prefers
+* text=auto
+
+# Enforce LF for code, where the .editorconfig file also ensures LF is used
+*.h text eol=lf
+*.c text eol=lf
+*.cpp text eol=lf
+*.inl text eol=lf
+*.ps1 text eol=lf
+*.sh text eol=lf
+*.cmake text eol=lf
+*.ddl text eol=lf
+CMakeLists.txt text eol=lf
+
+# Windows specific files should use CR/LF
+*.bat     text eol=crlf
+*.cmd     text eol=crlf
+*.csproj  text eol=crlf
+*.sln     text eol=crlf
+*.vcproj  text eol=crlf
+*.vcxproj text eol=crlf

--- a/Data/Samples/PacMan/CppSource/.gitignore
+++ b/Data/Samples/PacMan/CppSource/.gitignore
@@ -1,1 +1,12 @@
+#ez-version 1
+
 Build/*
+AssetCache/
+
+# FMOD specific
+.cache/
+.user/
+.unsaved/
+
+# VSCode specific
+CMakeUserPresets.json

--- a/Data/Samples/PacMan/CppSource/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 cmake_minimum_required(VERSION 3.21)
 
 project (PacMan VERSION 1.0 LANGUAGES C CXX)

--- a/Data/Samples/PacMan/CppSource/PacManGame/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/PacManGame/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name

--- a/Data/Samples/PacMan/CppSource/PacManPlugin/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/PacManPlugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -10,11 +11,6 @@ target_link_libraries(${PROJECT_NAME}
   GameEngine
   Utilities
 )
-
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-		COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/PacManPlugin.ezPluginBundle" $<TARGET_FILE_DIR:${PROJECT_NAME}>
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-	  )
 
 # include the EZ natvis file for a better debugging experience
 get_property(EZ_ROOT_DIR GLOBAL PROPERTY EZ_ROOT)

--- a/Data/Tools/ezEditor/CppProject/CppSource/.clang-format
+++ b/Data/Tools/ezEditor/CppProject/CppSource/.clang-format
@@ -1,3 +1,5 @@
+#ez-version 1
+
 BasedOnStyle: LLVM
 UseTab: Never
 IndentWidth: 2

--- a/Data/Tools/ezEditor/CppProject/CppSource/.editorconfig
+++ b/Data/Tools/ezEditor/CppProject/CppSource/.editorconfig
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # EditorConfig is awesome: http://EditorConfig.org
 # To make use of this, simply install a plugin for Visual Studio 20XX, Visual Studio Code, Notepad++ or XCode
 # Will work out of the box with Visual Studio 15

--- a/Data/Tools/ezEditor/CppProject/CppSource/.gitattributes
+++ b/Data/Tools/ezEditor/CppProject/CppSource/.gitattributes
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # By default convert text files to what the user prefers
 * text=auto
 

--- a/Data/Tools/ezEditor/CppProject/CppSource/.gitignore
+++ b/Data/Tools/ezEditor/CppProject/CppSource/.gitignore
@@ -1,4 +1,6 @@
-﻿Build/*
+#ez-version 1
+
+Build/*
 AssetCache/
 
 # FMOD specific

--- a/Data/Tools/ezEditor/CppProject/CppSource/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 cmake_minimum_required(VERSION 3.21)
 
 project (CppProject VERSION 1.0 LANGUAGES C CXX)

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectGame/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectGame/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name


### PR DESCRIPTION
* Update CppProject CMake files when their template changed (added versioning)
* Fixed Asteroids sample code
* Updated PacMan CMake source
* Fixed EditorTest, which was using an outdated PacMan sample setup
* Added "Don't show again" checkbox option for some message boxes
* Don't show solution generate/compile/export message boxes if not desired