### PR TITLE
Added editor tests to compile standard samples

### DIFF
--- a/Code/UnitTests/EditorTest/CMakeLists.txt
+++ b/Code/UnitTests/EditorTest/CMakeLists.txt
@@ -26,6 +26,9 @@ add_dependencies(${PROJECT_NAME}
   EditorPluginAssets
   EditorPluginParticle
   EditorPluginProcGen
+  EditorPluginJolt
+  EditorPluginRmlUi
+  EditorPluginMiniAudio
   ParticlePlugin
   TexConv
   Player

--- a/Code/UnitTests/EditorTest/Samples/Samples.cpp
+++ b/Code/UnitTests/EditorTest/Samples/Samples.cpp
@@ -1,0 +1,99 @@
+#include <EditorTest/EditorTestPCH.h>
+
+#include "Samples.h"
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/CodeGen/CppProject.h>
+#include <EditorFramework/CodeGen/CppSettings.h>
+#include <Foundation/IO/OSFile.h>
+#include <Foundation/Strings/StringConversion.h>
+#include <RendererCore/Components/SkyBoxComponent.h>
+#include <RendererCore/Textures/TextureCubeResource.h>
+#include <TestFramework/Framework/TestFramework.h>
+
+static ezEditorTestSamples s_EditorTestSamples;
+
+const char* ezEditorTestSamples::GetTestName() const
+{
+  return "Samples";
+}
+
+void ezEditorTestSamples::SetupSubTests()
+{
+  AddSubTest("Asteroids", SubTests::ST_Asteroids);
+  AddSubTest("PacMan", SubTests::ST_PacMan);
+  AddSubTest("RTS", SubTests::ST_RTS);
+}
+
+ezResult ezEditorTestSamples::InitializeTest()
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezEditorTestSamples::DeInitializeTest()
+{
+  return EZ_SUCCESS;
+}
+
+ezResult ezEditorTestSamples::InitializeSubTest(ezInt32 iIdentifier)
+{
+  if (SUPER::InitializeTest().Failed())
+    return EZ_FAILURE;
+
+  switch (iIdentifier)
+  {
+    case SubTests::ST_PacMan:
+      m_sProjectName = "PacMan";
+      break;
+    case SubTests::ST_Asteroids:
+      m_sProjectName = "Asteroids";
+      break;
+    case SubTests::ST_RTS:
+      m_sProjectName = "RTS";
+      break;
+
+      EZ_DEFAULT_CASE_NOT_IMPLEMENTED;
+  }
+
+  ezStringBuilder sPath("Data/Samples/", m_sProjectName);
+
+  if (SUPER::OpenProject(sPath).Failed())
+    return EZ_FAILURE;
+
+  if (ezCppProject::ForceSdkCompatibleCompiler().Failed())
+  {
+    ezLog::Error("Failed to autodetect SDK compatible compiler for testing");
+    return EZ_FAILURE;
+  }
+
+  ezPreferences::SaveApplicationPreferences();
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezEditorTestSamples::DeInitializeSubTest(ezInt32 iIdentifier)
+{
+  if (!m_sProjectPath.IsEmpty())
+  {
+    // The build results take up vast amounts of memory and prolong test result upload.
+    ezStringBuilder buildOutput = m_sProjectPath;
+    buildOutput.AppendPath("CppSource", "Build");
+    ezOSFile::DeleteFolder(buildOutput).IgnoreResult();
+    m_sProjectPath.Clear();
+  }
+
+  if (SUPER::DeInitializeTest().Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+
+ezTestAppRun ezEditorTestSamples::RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount)
+{
+  ProcessEvents();
+
+  EZ_TEST_STATUS(GenerateAndCompile());
+
+  ProcessEvents();
+  return ezTestAppRun::Quit;
+}

--- a/Code/UnitTests/EditorTest/Samples/Samples.cpp
+++ b/Code/UnitTests/EditorTest/Samples/Samples.cpp
@@ -10,7 +10,10 @@
 #include <RendererCore/Textures/TextureCubeResource.h>
 #include <TestFramework/Framework/TestFramework.h>
 
+#if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
+// only show/enable this test on Windows, since we can only compile game plugins there
 static ezEditorTestSamples s_EditorTestSamples;
+#endif
 
 const char* ezEditorTestSamples::GetTestName() const
 {

--- a/Code/UnitTests/EditorTest/Samples/Samples.h
+++ b/Code/UnitTests/EditorTest/Samples/Samples.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <EditorTest/EditorTestPCH.h>
+
+#include "../GenerateCompile/GenerateCompile.h"
+
+class ezEditorTestSamples : public ezEditorTestGenerateCompile
+{
+public:
+  using SUPER = ezEditorTest;
+
+  virtual const char* GetTestName() const override;
+
+private:
+  enum SubTests
+  {
+    ST_Asteroids,
+    ST_PacMan,
+    ST_RTS,
+  };
+
+  virtual void SetupSubTests() override;
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
+  virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;
+  virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
+  virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
+};

--- a/Data/Samples/RTS/CppSource/.clang-format
+++ b/Data/Samples/RTS/CppSource/.clang-format
@@ -1,3 +1,5 @@
+#ez-version 1
+
 BasedOnStyle: LLVM
 UseTab: Never
 IndentWidth: 2

--- a/Data/Samples/RTS/CppSource/.editorconfig
+++ b/Data/Samples/RTS/CppSource/.editorconfig
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # EditorConfig is awesome: http://EditorConfig.org
 # To make use of this, simply install a plugin for Visual Studio 20XX, Visual Studio Code, Notepad++ or XCode
 # Will work out of the box with Visual Studio 15

--- a/Data/Samples/RTS/CppSource/.gitattributes
+++ b/Data/Samples/RTS/CppSource/.gitattributes
@@ -1,3 +1,5 @@
+#ez-version 1
+
 # By default convert text files to what the user prefers
 * text=auto
 

--- a/Data/Samples/RTS/CppSource/.gitignore
+++ b/Data/Samples/RTS/CppSource/.gitignore
@@ -1,9 +1,12 @@
-﻿Build/*
+#ez-version 1
+
+Build/*
 AssetCache/
 
 # FMOD specific
 .cache/
 .user/
+.unsaved/
 
 # VSCode specific
 CMakeUserPresets.json

--- a/Data/Samples/RTS/CppSource/CMakeLists.txt
+++ b/Data/Samples/RTS/CppSource/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 cmake_minimum_required(VERSION 3.21)
 
 project (RTS VERSION 1.0 LANGUAGES C CXX)

--- a/Data/Samples/RTS/CppSource/RTSGame/CMakeLists.txt
+++ b/Data/Samples/RTS/CppSource/RTSGame/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name

--- a/Data/Samples/RTS/CppSource/RTSPlugin/CMakeLists.txt
+++ b/Data/Samples/RTS/CppSource/RTSPlugin/CMakeLists.txt
@@ -1,3 +1,4 @@
+#ez-version 1
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -15,4 +16,3 @@ target_link_libraries(${PROJECT_NAME}
 # include the EZ natvis file for a better debugging experience
 get_property(EZ_ROOT_DIR GLOBAL PROPERTY EZ_ROOT)
 target_sources(${PROJECT_NAME} PUBLIC "${EZ_ROOT_DIR}/Code/Engine/Foundation/ezEngine.natvis")
-


### PR DESCRIPTION
Opens and compiles the C++ code of these samples:
* Asteroids
* PacMan
* RTS

The SampleGamePlugin is already compiled by the solution, so no need to test separately.