### PR TITLE
Automatically link against used engine plugins

### DIFF
--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -823,6 +823,8 @@ ezResult ezCppProject::PopulateWithDefaultSources(const ezCppSettings& cfg)
     }
   }
 
+  EZ_SUCCEED_OR_RETURN(UpdateEnginePluginDependencies());
+
   s_ChangeEvents.Broadcast(cfg);
   return EZ_SUCCESS;
 }
@@ -850,6 +852,8 @@ ezResult ezCppProject::RunCMake(const ezCppSettings& cfg)
     ezLog::Error("No CMakeLists.txt exists in target source directory '{}'", GetTargetSourceDir());
     return EZ_FAILURE;
   }
+
+  EZ_SUCCEED_OR_RETURN(UpdateEnginePluginDependencies());
 
   if (auto compilerWorking = TestCompiler(); compilerWorking.Failed())
   {
@@ -1058,6 +1062,85 @@ void ezCppProject::UpdatePluginConfig(const ezCppSettings& cfg)
   plugin.m_RuntimePlugins.PushBack(sPluginName);
 
   ezQtEditorApp::GetSingleton()->WritePluginSelectionStateDDL();
+}
+
+ezResult ezCppProject::UpdateEnginePluginDependencies()
+{
+  // Only update if project has custom C++ code
+  if (!ExistsProjectCMakeListsTxt())
+    return EZ_SUCCESS;
+
+  const ezPluginBundleSet& bundles = ezQtEditorApp::GetSingleton()->GetPluginBundles();
+
+  // Collect selected engine plugin target names
+  ezDynamicArray<ezString> selectedPlugins;
+  for (auto it = bundles.m_Plugins.GetIterator(); it.IsValid(); ++it)
+  {
+    const ezPluginBundle& bundle = it.Value();
+
+    // Filter: selected, not mandatory, not a project plugin, has CMake target name
+    if (bundle.m_bSelected &&
+        !bundle.m_bMandatory &&
+        !bundle.m_ExclusiveFeatures.Contains("ProjectPlugin") &&
+        !bundle.m_sCMakeTargetName.IsEmpty())
+    {
+      selectedPlugins.PushBack(bundle.m_sCMakeTargetName);
+    }
+  }
+
+  // Sort plugins for consistent output
+  selectedPlugins.Sort();
+
+  // Build the CMake file content
+  ezStringBuilder content;
+  content.AppendWithSeparator("# This file is auto-generated, do not modify.\n", "");
+  content.Append("# The ezEditor may modify this file to add build configuration options.\n");
+  content.Append("\n");
+
+  // Only add target_link_libraries if there are selected plugins
+  if (!selectedPlugins.IsEmpty())
+  {
+    content.Append("\n");
+    content.Append("# Link against selected engine plugins\n");
+    content.Append("target_link_libraries(${PROJECT_NAME} PRIVATE\n");
+
+    for (const ezString& plugin : selectedPlugins)
+    {
+      content.Append("  ", plugin, "\n");
+    }
+
+    content.Append(")\n");
+  }
+
+  // Write to file
+  ezStringBuilder sFilePath = GetTargetSourceDir();
+  sFilePath.AppendPath("Configs/CMakeEngineExtensions.txt");
+
+  // Ensure directory exists
+  ezStringBuilder sDir = sFilePath.GetFileDirectory();
+  if (ezOSFile::CreateDirectoryStructure(sDir).Failed())
+  {
+    ezLog::Error("Failed to create directory for CMakeEngineExtensions.txt: '{}'", sDir);
+    return EZ_FAILURE;
+  }
+
+  // Write file
+  ezDeferredFileWriter fileWriter;
+  fileWriter.SetOutput(sFilePath);
+
+  if (fileWriter.WriteBytes(content.GetData(), content.GetElementCount()).Failed())
+  {
+    ezLog::Error("Failed to write CMakeEngineExtensions.txt: '{}'", sFilePath);
+    return EZ_FAILURE;
+  }
+
+  if (fileWriter.Close().Failed())
+  {
+    ezLog::Error("Failed to close CMakeEngineExtensions.txt: '{}'", sFilePath);
+    return EZ_FAILURE;
+  }
+
+  return EZ_SUCCESS;
 }
 
 ezResult ezCppProject::EnsureCppPluginReady()

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.h
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.h
@@ -7,26 +7,28 @@
 #include <Foundation/Types/Status.h>
 #include <Foundation/Types/VariantType.h>
 
-// Only saved in editor preferences, does not have to work cross-platform
+/// Specifies which IDE to use for opening C++ project solution files.
+/// Only saved in editor preferences, does not have to work cross-platform.
 struct EZ_EDITORFRAMEWORK_DLL ezIDE
 {
   using StorageType = ezUInt8;
 
   enum Enum
   {
-    DefaultProgram, // Uses the system default way of opening an sln file
+    DefaultProgram,   ///< Uses the system default way of opening an sln file
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS)
-    VisualStudio,
+    VisualStudio,     ///< Opens with Visual Studio
 #endif
-    VisualStudioCode,
-    Rider,
+    VisualStudioCode, ///< Opens with VS Code
+    Rider,            ///< Opens with JetBrains Rider
     Default = DefaultProgram
   };
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_EDITORFRAMEWORK_DLL, ezIDE);
 
-// Only saved in editor preferences, does not have to work cross-platform
+/// Specifies which compiler to use for building C++ plugin code.
+/// Only saved in editor preferences, does not have to work cross-platform.
 struct EZ_EDITORFRAMEWORK_DLL ezCompiler
 {
   using StorageType = ezUInt8;
@@ -51,79 +53,105 @@ struct EZ_EDITORFRAMEWORK_DLL ezCompiler
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_EDITORFRAMEWORK_DLL, ezCompiler);
 
+/// Stores compiler configuration including custom compiler paths.
 struct EZ_EDITORFRAMEWORK_DLL ezCompilerPreferences
 {
   ezEnum<ezCompiler> m_Compiler;
-  bool m_bCustomCompiler;
-  ezString m_sCppCompiler;
-  ezString m_sCCompiler;
-  ezString m_sRcCompiler;
+  bool m_bCustomCompiler = false; ///< If true, use custom compiler paths instead of predefined compiler
+  ezString m_sCppCompiler;        ///< Path to C++ compiler executable
+  ezString m_sCCompiler;          ///< Path to C compiler executable
+  ezString m_sRcCompiler;         ///< Path to resource compiler executable
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_EDITORFRAMEWORK_DLL, ezCompilerPreferences);
 
+/// Configuration for launching an external code editor.
 struct EZ_EDITORFRAMEWORK_DLL ezCodeEditorPreferences
 {
-  bool m_bIsVisualStudio;
-  ezString m_sEditorPath;
-  ezString m_sEditorArgs;
+  bool m_bIsVisualStudio = false; ///< If true, uses Visual Studio specific command line format
+  ezString m_sEditorPath;         ///< Full path to the code editor executable
+  ezString m_sEditorArgs;         ///< Command line arguments passed to the editor
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_EDITORFRAMEWORK_DLL, ezCodeEditorPreferences);
 
+/// Manages C++ plugin project generation, compilation, and IDE integration.
+///
+/// Provides functionality to generate CMake projects for C++ game plugins,
+/// configure compilers, build solutions, and open code in external editors.
 struct EZ_EDITORFRAMEWORK_DLL ezCppProject : public ezPreferences
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezCppProject, ezPreferences);
 
+  /// Describes a compiler configuration detected or configured on this machine.
   struct MachineSpecificCompilerPaths
   {
-    ezString m_sNiceName;
+    ezString m_sNiceName;    ///< Display name for this compiler configuration
     ezEnum<ezCompiler> m_Compiler;
-    ezString m_sCCompiler;
-    ezString m_sCppCompiler;
-    bool m_bIsCustom;
+    ezString m_sCCompiler;   ///< Path to C compiler
+    ezString m_sCppCompiler; ///< Path to C++ compiler
+    bool m_bIsCustom;        ///< If true, this is a user-configured compiler, not auto-detected
   };
 
+  /// Result type for operations that may modify files.
   enum class ModifyResult
   {
-    FAILURE,
-    NOT_MODIFIED,
-    MODIFIED
+    FAILURE,      ///< Operation failed
+    NOT_MODIFIED, ///< Files already up-to-date, no changes made
+    MODIFIED      ///< Files were successfully modified
   };
 
 
   ezCppProject();
   ~ezCppProject();
 
+  /// Returns the directory where C++ plugin template files are copied to.
+  /// If sProjectDirectory is empty, uses the current project directory.
   static ezString GetTargetSourceDir(ezStringView sProjectDirectory = {});
 
+  /// Returns the CMake generator-specific folder name (e.g., "vs2022x64").
   static ezString GetGeneratorFolderName(const ezCppSettings& cfg);
 
+  /// Returns the CMake generator name string for the -G parameter.
   static ezString GetCMakeGeneratorName(const ezCppSettings& cfg);
 
+  /// Returns the source directory for the C++ plugin project.
+  /// If sProjectDirectory is empty, uses the current project directory.
   static ezString GetPluginSourceDir(const ezCppSettings& cfg, ezStringView sProjectDirectory = {});
 
+  /// Returns the CMake build directory path.
   static ezString GetBuildDir(const ezCppSettings& cfg);
 
+  /// Returns the full path to the generated solution file.
   static ezString GetSolutionPath(const ezCppSettings& cfg);
 
+  /// Opens the solution file in the configured IDE.
   static ezStatus OpenSolution(const ezCppSettings& cfg);
 
-  /// \brief Attempts to launch the configured code editor with the specified file and line number
+  /// Attempts to launch the configured code editor with the specified file and line number
   static ezStatus OpenInCodeEditor(const ezStringView& sFileName, ezInt32 iLineNumber);
 
   static ezStringView CompilerToString(ezCompiler::Enum compiler);
 
+  /// Returns the compiler used to build the editor SDK itself.
+  /// Plugins should typically use a compatible compiler to avoid ABI issues.
   static ezCompiler::Enum GetSdkCompiler();
 
+  /// Returns the major version number of the compiler used to build the SDK.
   static ezString GetSdkCompilerMajorVersion();
 
+  /// Tests if the currently configured compiler can be invoked successfully.
   static ezStatus TestCompiler();
 
+  /// Returns the path to the CMake executable bundled with the engine.
   static const char* GetCMakePath();
 
+  /// Verifies that the CMake cache matches the current configuration.
+  /// Returns failure if the cache is outdated or incompatible.
   static ezResult CheckCMakeCache(const ezCppSettings& cfg);
 
+  /// Checks if CMakeUserPresets.json needs updating for the given configuration.
+  /// If bWriteResult is true, writes the updated file when changes are needed.
   static ModifyResult CheckCMakeUserPresets(const ezCppSettings& cfg, bool bWriteResult);
 
   static bool ExistsSolution(const ezCppSettings& cfg);
@@ -133,36 +161,55 @@ struct EZ_EDITORFRAMEWORK_DLL ezCppProject : public ezPreferences
   /// Returns true if sDst doesn't exist yet, or for some file types (e.g. CMakeLists.txt), when they got an update.
   static bool ShouldOverwriteExisting(ezStringView sSrc, ezStringView sDst);
 
+  /// Copies default C++ plugin template files to the project's source directory.
   static ezResult PopulateWithDefaultSources(const ezCppSettings& cfg);
 
   static ezResult CleanBuildDir(const ezCppSettings& cfg);
 
+  /// Runs CMake to generate the build system files.
   static ezResult RunCMake(const ezCppSettings& cfg);
 
+  /// Checks if CMake needs to run and executes it if required.
+  /// Skips CMake if the build files are already up-to-date.
   static ezResult RunCMakeIfNecessary(const ezCppSettings& cfg);
 
+  /// Compiles the C++ plugin solution using the configured compiler.
   static ezResult CompileSolution(const ezCppSettings& cfg);
 
+  /// Checks if compilation is needed and builds the code if required.
+  /// Skips the build if the plugin binary is already up-to-date.
   static ezResult BuildCodeIfNecessary(const ezCppSettings& cfg);
 
+  /// Creates a minimal CMakeUserPresets.json structure for the given configuration.
   static ezVariantDictionary CreateEmptyCMakeUserPresetsJson(const ezCppSettings& cfg);
 
+  /// Updates an existing CMakeUserPresets.json with current configuration settings.
+  /// The inout_json parameter is both read and modified.
   static ModifyResult ModifyCMakeUserPresetsJson(const ezCppSettings& cfg, ezVariantDictionary& inout_json);
 
+  /// Writes the plugin configuration header files based on current settings.
   static void UpdatePluginConfig(const ezCppSettings& cfg);
 
+  /// Writes CMakeEngineExtensions.txt with the selected engine plugins for linking.
+  static ezResult UpdateEnginePluginDependencies();
+
+  /// Ensures the C++ plugin project is generated and compiled.
+  /// Runs all necessary steps to make the plugin ready for use.
   static ezResult EnsureCppPluginReady();
 
+  /// Checks whether the C++ plugin needs to be rebuilt.
+  /// Returns true if source files have changed since the last build.
   static bool IsBuildRequired();
 
-  /// \brief Fired when a notable change has been made.
+  /// Fired when a notable change has been made.
   static ezEvent<const ezCppSettings&> s_ChangeEvents;
 
   static void LoadPreferences();
 
   static ezArrayPtr<const MachineSpecificCompilerPaths> GetMachineSpecificCompilers() { return s_MachineSpecificCompilers.GetArrayPtr(); }
 
-  // Change the current preferences to point to a SDK compatible compiler
+  /// Changes the current preferences to use an SDK-compatible compiler.
+  /// This is necessary to avoid ABI compatibility issues between the plugin and engine.
   static ezResult ForceSdkCompatibleCompiler();
 
 private:

--- a/Code/Editor/EditorFramework/Dialogs/PluginSelectionDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/PluginSelectionDlg.cpp
@@ -1,5 +1,6 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
+#include <EditorFramework/CodeGen/CppProject.h>
 #include <EditorFramework/Dialogs/PluginSelectionDlg.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <Foundation/IO/OpenDdlWriter.h>
@@ -28,6 +29,7 @@ void ezQtPluginSelectionDlg::on_Buttons_clicked(QAbstractButton* pButton)
       *m_pPluginSet = m_LocalPluginSet;
 
       ezQtEditorApp::GetSingleton()->WritePluginSelectionStateDDL();
+      ezCppProject::UpdateEnginePluginDependencies().IgnoreResult();
       ezQtEditorApp::GetSingleton()->AddRestartRequiredReason("The set of active plugins has changed.");
     }
 

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
@@ -160,6 +160,9 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
       m_EnabledInTemplates[i] = pElement->GetPrimitivesString()[i];
   }
 
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "CMakeTargetName"))
+    m_sCMakeTargetName = pElement->GetPrimitivesString()[0];
+
   m_bMissing = false;
 
   return EZ_SUCCESS;

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
@@ -34,6 +34,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezPluginBundle
   ezHybridArray<ezString, 1> m_RequiredBundles;     ///< The file names (without path or extension) of other bundles that are required for this bundle to work.
   ezHybridArray<ezString, 1> m_ExclusiveFeatures;   ///< If two bundles have the same string in this list, they can't be activated at the same time. So for example only one bundle with the feature 'Sound' or 'Physics' may be activated simultaneously. Only enforced by the UI.
   ezHybridArray<ezString, 1> m_EnabledInTemplates;  ///< In which project templates this plugin should be active by default.
+  ezString m_sCMakeTargetName;                      ///< The CMake target name for linking user plugins against this plugin.
 
   /// \brief Reads the bundle description, but not the state.
   ezResult ReadBundleFromDDL(ezOpenDdlReader& ref_ddl);

--- a/Code/EnginePlugins/AiPlugin/AI.ezPluginBundle
+++ b/Code/EnginePlugins/AiPlugin/AI.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General3D"}
+	string %CMakeTargetName{"AiPlugin"}
 }

--- a/Code/EnginePlugins/AngelScriptPlugin/AngelScript.ezPluginBundle
+++ b/Code/EnginePlugins/AngelScriptPlugin/AngelScript.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{}
+	string %CMakeTargetName{"AngelScriptPlugin"}
 }

--- a/Code/EnginePlugins/FmodPlugin/Fmod.ezPluginBundle
+++ b/Code/EnginePlugins/FmodPlugin/Fmod.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{"Sound"}
 	string %EnabledInTemplates{"General2D", "General3D"}
+	string %CMakeTargetName{"FmodPlugin"}
 }

--- a/Code/EnginePlugins/GameComponentsPlugin/GameComponents.ezPluginBundle
+++ b/Code/EnginePlugins/GameComponentsPlugin/GameComponents.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General3D"}
+	string %CMakeTargetName{"GameComponentsPlugin"}
 }

--- a/Code/EnginePlugins/JoltPlugin/Jolt.ezPluginBundle
+++ b/Code/EnginePlugins/JoltPlugin/Jolt.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{"physics"}
 	string %EnabledInTemplates{"General3D"}
+	string %CMakeTargetName{"JoltPlugin"}
 }

--- a/Code/EnginePlugins/KrautPlugin/Kraut.ezPluginBundle
+++ b/Code/EnginePlugins/KrautPlugin/Kraut.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General3D"}
+	string %CMakeTargetName{"KrautPlugin"}
 }

--- a/Code/EnginePlugins/MiniAudioPlugin/MiniAudio.ezPluginBundle
+++ b/Code/EnginePlugins/MiniAudioPlugin/MiniAudio.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{"Sound"}
 	string %EnabledInTemplates{}
+	string %CMakeTargetName{"MiniAudioPlugin"}
 }

--- a/Code/EnginePlugins/OpenXRPlugin/OpenXR.ezPluginBundle
+++ b/Code/EnginePlugins/OpenXRPlugin/OpenXR.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{}
+	string %CMakeTargetName{"OpenXRPlugin"}
 }

--- a/Code/EnginePlugins/ParticlePlugin/Particles.ezPluginBundle
+++ b/Code/EnginePlugins/ParticlePlugin/Particles.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General2D", "General3D"}
+	string %CMakeTargetName{"ParticlePlugin"}
 }

--- a/Code/EnginePlugins/ProcGenPlugin/ProcGen.ezPluginBundle
+++ b/Code/EnginePlugins/ProcGenPlugin/ProcGen.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General3D"}
+	string %CMakeTargetName{"ProcGenPlugin"}
 }

--- a/Code/EnginePlugins/RenderDocPlugin/RenderDoc.ezPluginBundle
+++ b/Code/EnginePlugins/RenderDocPlugin/RenderDoc.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{}
+	string %CMakeTargetName{"RenderDocPlugin"}
 }

--- a/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
+++ b/Code/EnginePlugins/RmlUiPlugin/RmlUi.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General2D", "General3D"}
+	string %CMakeTargetName{"RmlUiPlugin"}
 }

--- a/Code/EnginePlugins/VisualScriptPlugin/VisualScript.ezPluginBundle
+++ b/Code/EnginePlugins/VisualScriptPlugin/VisualScript.ezPluginBundle
@@ -12,4 +12,5 @@ PluginInfo
 	string %RequiredPlugins{}
 	string %ExclusiveFeatures{}
 	string %EnabledInTemplates{"General2D", "General3D"}
+	string %CMakeTargetName{"VisualScriptPlugin"}
 }

--- a/Data/Samples/PacMan/CppSource/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 1
+#ez-version 2
 cmake_minimum_required(VERSION 3.21)
 
 project (PacMan VERSION 1.0 LANGUAGES C CXX)
@@ -29,6 +29,12 @@ if(PROJECT_IS_TOP_LEVEL)
 
 	ez_configure_external_project()
 
+endif()
+
+# Include optional user extensions for custom build configuration
+# This file can be used to add custom CMake logic without modifying this template
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
 endif()
 
 add_subdirectory("PacManPlugin")

--- a/Data/Samples/PacMan/CppSource/Configs/CMakeEngineExtensions.txt
+++ b/Data/Samples/PacMan/CppSource/Configs/CMakeEngineExtensions.txt
@@ -1,0 +1,10 @@
+# The ezEditor may modify this file to add build configuration options.
+
+
+# Link against selected engine plugins
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  GameComponentsPlugin
+  JoltPlugin
+  MiniAudioPlugin
+  ParticlePlugin
+)

--- a/Data/Samples/PacMan/CppSource/PacManGame/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/PacManGame/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 1
+#ez-version 2
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -19,3 +19,14 @@ target_sources(${PROJECT_NAME} PUBLIC "${EZ_ROOT_DIR}/Code/Engine/Foundation/ezE
 target_compile_definitions(${PROJECT_NAME} PRIVATE "GAME_PROJECT_FOLDER=${CMAKE_CURRENT_LIST_DIR}/../../")
 
 add_dependencies(${PROJECT_NAME} PacManPlugin)
+
+# Include optional extensions set up by the ezEditor
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+endif()
+
+# Include optional user extensions for custom target configuration
+# This file can be used to add additional link libraries, includes, etc. without modifying this template
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+endif()

--- a/Data/Samples/PacMan/CppSource/PacManPlugin/CMakeLists.txt
+++ b/Data/Samples/PacMan/CppSource/PacManPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 1
+#ez-version 2
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -15,3 +15,14 @@ target_link_libraries(${PROJECT_NAME}
 # include the EZ natvis file for a better debugging experience
 get_property(EZ_ROOT_DIR GLOBAL PROPERTY EZ_ROOT)
 target_sources(${PROJECT_NAME} PUBLIC "${EZ_ROOT_DIR}/Code/Engine/Foundation/ezEngine.natvis")
+
+# Include optional extensions set up by the ezEditor
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+endif()
+
+# Include optional user extensions for custom target configuration
+# This file can be used to add additional link libraries, includes, etc. without modifying this template
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+endif()

--- a/Data/Tools/ezEditor/CppProject/CppSource/CMakeExtensions.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CMakeExtensions.txt
@@ -1,0 +1,17 @@
+# CMake Extensions File
+#
+# This file is included by CMakeLists.txt and allows you to extend the global build
+# configuration without modifying the template CMakeLists.txt file directly.
+#
+# This file will NOT be overwritten when templates are updated.
+#
+# For project specific modifications, there are dedicated extension files in their respective folders.
+
+# Examples of what you can add here:
+
+# Add custom compile definitions:
+#  add_compile_definitions(MY_CUSTOM_DEFINE=1)
+
+# Add custom include directories:
+#  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/MyLib/include")
+

--- a/Data/Tools/ezEditor/CppProject/CppSource/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 1
+#ez-version 2
 cmake_minimum_required(VERSION 3.21)
 
 project (CppProject VERSION 1.0 LANGUAGES C CXX)
@@ -29,6 +29,12 @@ if(PROJECT_IS_TOP_LEVEL)
 
 	ez_configure_external_project()
 
+endif()
+
+# Include optional user extensions for custom build configuration
+# This file can be used to add custom CMake logic without modifying this template
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
 endif()
 
 add_subdirectory("CppProjectPlugin")

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectGame/CMakeExtensions.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectGame/CMakeExtensions.txt
@@ -1,0 +1,40 @@
+# CMake Extensions File
+#
+# This file is included by CMakeLists.txt and allows you to extend the build
+# configuration without modifying the template CMakeLists.txt file directly.
+#
+# This file will NOT be overwritten when templates are updated.
+
+# The variable ${PROJECT_NAME} contains the name of the application target.
+
+# Examples of what you can add here:
+
+# Add additional link libraries:
+#    target_link_libraries(${PROJECT_NAME}
+#      PRIVATE
+#      MyCustomLibrary
+#      SomeThirdPartyLib
+#    )
+
+# Add include directories:
+#    target_include_directories(${PROJECT_NAME}
+#      PRIVATE
+#      "${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/include"
+#    )
+
+# Add compile definitions:
+#    target_compile_definitions(${PROJECT_NAME}
+#      PRIVATE
+#      MY_PLUGIN_FEATURE=1
+#    )
+
+# Set target-specific properties:
+#    set_target_properties(${PROJECT_NAME} PROPERTIES
+#      CXX_STANDARD 17
+#    )
+
+# Add custom build steps:
+#    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+#      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+#      "source_file" "destination_file"
+#    )

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectGame/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectGame/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 1
+#ez-version 2
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -19,3 +19,14 @@ target_sources(${PROJECT_NAME} PUBLIC "${EZ_ROOT_DIR}/Code/Engine/Foundation/ezE
 target_compile_definitions(${PROJECT_NAME} PRIVATE "GAME_PROJECT_FOLDER=${CMAKE_CURRENT_LIST_DIR}/../../")
 
 add_dependencies(${PROJECT_NAME} CppProjectPlugin)
+
+# Include optional extensions set up by the ezEditor
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+endif()
+
+# Include optional user extensions for custom target configuration
+# This file can be used to add additional link libraries, includes, etc. without modifying this template
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+endif()

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeExtensions.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeExtensions.txt
@@ -1,0 +1,40 @@
+# CMake Extensions File
+#
+# This file is included by CMakeLists.txt and allows you to extend the build
+# configuration without modifying the template CMakeLists.txt file directly.
+#
+# This file will NOT be overwritten when templates are updated.
+
+# The variable ${PROJECT_NAME} contains the name of the plugin target.
+
+# Examples of what you can add here:
+
+# Add additional link libraries:
+#    target_link_libraries(${PROJECT_NAME}
+#      PRIVATE
+#      MyCustomLibrary
+#      SomeThirdPartyLib
+#    )
+
+# Add include directories:
+#    target_include_directories(${PROJECT_NAME}
+#      PRIVATE
+#      "${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/include"
+#    )
+
+# Add compile definitions:
+#    target_compile_definitions(${PROJECT_NAME}
+#      PRIVATE
+#      MY_PLUGIN_FEATURE=1
+#    )
+
+# Set target-specific properties:
+#    set_target_properties(${PROJECT_NAME} PROPERTIES
+#      CXX_STANDARD 17
+#    )
+
+# Add custom build steps:
+#    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+#      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+#      "source_file" "destination_file"
+#    )

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeLists.txt
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-#ez-version 1
+#ez-version 2
 ez_cmake_init()
 
 # Get the name of this folder as the project name
@@ -15,3 +15,14 @@ target_link_libraries(${PROJECT_NAME}
 # include the EZ natvis file for a better debugging experience
 get_property(EZ_ROOT_DIR GLOBAL PROPERTY EZ_ROOT)
 target_sources(${PROJECT_NAME} PUBLIC "${EZ_ROOT_DIR}/Code/Engine/Foundation/ezEngine.natvis")
+
+# Include optional extensions set up by the ezEditor
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/../Configs/CMakeEngineExtensions.txt")
+endif()
+
+# Include optional user extensions for custom target configuration
+# This file can be used to add additional link libraries, includes, etc. without modifying this template
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+	include("${CMAKE_CURRENT_SOURCE_DIR}/CMakeExtensions.txt")
+endif()


### PR DESCRIPTION
Custom game plugins now automatically link against all plugin DLLs that are referenced in the editor.