### PR TITLE
Renamed some render states

### DIFF
--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
@@ -44,10 +44,11 @@ void ezShaderStateResourceDescriptor::Save(ezStreamWriter& inout_stream) const
   // Depth Stencil State
   {
     inout_stream << (ezUInt8)m_DepthStencilDesc.m_DepthTestFunc;
-    inout_stream << m_DepthStencilDesc.m_bDepthTest;
+    inout_stream << m_DepthStencilDesc.m_bDepthEnable;
     inout_stream << m_DepthStencilDesc.m_bDepthWrite;
-    inout_stream << m_DepthStencilDesc.m_bSeparateFrontAndBack;
-    inout_stream << m_DepthStencilDesc.m_bStencilTest;
+    bool m_bSeparateFrontAndBack = false;
+    inout_stream << m_bSeparateFrontAndBack;
+    inout_stream << m_DepthStencilDesc.m_bStencilEnable;
     inout_stream << m_DepthStencilDesc.m_uiStencilReadMask;
     inout_stream << m_DepthStencilDesc.m_uiStencilWriteMask;
     inout_stream << (ezUInt8)m_DepthStencilDesc.m_FrontFaceStencilOp.m_DepthFailOp;
@@ -113,10 +114,11 @@ void ezShaderStateResourceDescriptor::Load(ezStreamReader& inout_stream)
     ezUInt8 uiTemp = 0;
     inout_stream >> uiTemp;
     m_DepthStencilDesc.m_DepthTestFunc = (ezGALCompareFunc::Enum)uiTemp;
-    inout_stream >> m_DepthStencilDesc.m_bDepthTest;
+    inout_stream >> m_DepthStencilDesc.m_bDepthEnable;
     inout_stream >> m_DepthStencilDesc.m_bDepthWrite;
-    inout_stream >> m_DepthStencilDesc.m_bSeparateFrontAndBack;
-    inout_stream >> m_DepthStencilDesc.m_bStencilTest;
+    bool m_bSeparateFrontAndBack = false;
+    inout_stream >> m_bSeparateFrontAndBack;
+    inout_stream >> m_DepthStencilDesc.m_bStencilEnable;
     inout_stream >> m_DepthStencilDesc.m_uiStencilReadMask;
     inout_stream >> m_DepthStencilDesc.m_uiStencilWriteMask;
     inout_stream >> uiTemp;
@@ -176,10 +178,16 @@ ezUInt32 ezShaderStateResourceDescriptor::CalculateHash() const
   return m_BlendDesc.CalculateHash() + m_RasterizerDesc.CalculateHash() + m_DepthStencilDesc.CalculateHash();
 }
 
-static const char* InsertNumber(const char* szString, ezUInt32 uiNumber, ezStringBuilder& ref_sTemp)
+static const char* AppendNumber(const char* szString, ezInt32 iNumber, ezStringBuilder& ref_sTemp)
 {
-  ref_sTemp.SetFormat(szString, uiNumber);
-  return ref_sTemp.GetData();
+  if (iNumber >= 0)
+  {
+    ref_sTemp = szString;
+    ref_sTemp.AppendFormat("{}", iNumber);
+    return ref_sTemp;
+  }
+
+  return szString;
 }
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
@@ -386,23 +394,24 @@ ezResult ezShaderStateResourceDescriptor::Parse(const char* szSource)
 
     ezStringBuilder s;
 
-    for (ezUInt32 i = 0; i < 8; ++i)
+    // -1 for when no number is given
+    for (ezInt32 i = -1; i < 8; ++i)
     {
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_bBlendingEnabled = GetBoolStateVariable(
-        VariableValues, InsertNumber("BlendingEnabled{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_bBlendingEnabled);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_BlendOp = (ezGALBlendOp::Enum)GetEnumStateVariable(
-        VariableValues, StateValuesBlendOp, InsertNumber("BlendOp{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_BlendOp);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_BlendOpAlpha = (ezGALBlendOp::Enum)GetEnumStateVariable(
-        VariableValues, StateValuesBlendOp, InsertNumber("BlendOpAlpha{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_BlendOpAlpha);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_DestBlend = (ezGALBlend::Enum)GetEnumStateVariable(
-        VariableValues, StateValuesBlend, InsertNumber("DestBlend{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_DestBlend);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_DestBlendAlpha = (ezGALBlend::Enum)GetEnumStateVariable(
-        VariableValues, StateValuesBlend, InsertNumber("DestBlendAlpha{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_DestBlendAlpha);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_SourceBlend = (ezGALBlend::Enum)GetEnumStateVariable(
-        VariableValues, StateValuesBlend, InsertNumber("SourceBlend{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_SourceBlend);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_SourceBlendAlpha = (ezGALBlend::Enum)GetEnumStateVariable(VariableValues, StateValuesBlend,
-        InsertNumber("SourceBlendAlpha{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_SourceBlendAlpha);
-      m_BlendDesc.m_RenderTargetBlendDescriptions[i].m_uiWriteMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, InsertNumber("WriteMask{0}", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_uiWriteMask));
+      const ezInt32 idx = ezMath::Max(i, 0);
+
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_bBlendingEnabled = GetBoolStateVariable(VariableValues, AppendNumber("BlendingEnabled", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_bBlendingEnabled);
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_BlendOp = (ezGALBlendOp::Enum)GetEnumStateVariable(VariableValues, StateValuesBlendOp, AppendNumber("BlendOp", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_BlendOp);
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_BlendOpAlpha = (ezGALBlendOp::Enum)GetEnumStateVariable(VariableValues, StateValuesBlendOp, AppendNumber("BlendOpAlpha", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_BlendOpAlpha);
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_DestBlend = (ezGALBlend::Enum)GetEnumStateVariable(VariableValues, StateValuesBlend, AppendNumber("DestBlend", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_DestBlend);
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_DestBlendAlpha = (ezGALBlend::Enum)GetEnumStateVariable(VariableValues, StateValuesBlend, AppendNumber("DestBlendAlpha", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_DestBlendAlpha);
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_SourceBlend = (ezGALBlend::Enum)GetEnumStateVariable(VariableValues, StateValuesBlend, AppendNumber("SourceBlend", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_SourceBlend);
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_SourceBlendAlpha = (ezGALBlend::Enum)GetEnumStateVariable(VariableValues, StateValuesBlend, AppendNumber("SourceBlendAlpha", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_SourceBlendAlpha);
+
+      // if WriteMaskN is set, overwrite
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_uiWriteMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, AppendNumber("WriteMask", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[0].m_uiWriteMask)); // deprecated old name
+
+      // if ColorWriteMaskN is set, overwrite
+      m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_uiWriteMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, AppendNumber("ColorWriteMask", i, s), m_BlendDesc.m_RenderTargetBlendDescriptions[idx].m_uiWriteMask));
     }
   }
 
@@ -424,31 +433,22 @@ ezResult ezShaderStateResourceDescriptor::Parse(const char* szSource)
 
   // Retrieve Depth-Stencil State
   {
-    m_DepthStencilDesc.m_BackFaceStencilOp.m_DepthFailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesStencilOp, "BackFaceDepthFailOp", m_DepthStencilDesc.m_BackFaceStencilOp.m_DepthFailOp);
-    m_DepthStencilDesc.m_BackFaceStencilOp.m_FailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesStencilOp, "BackFaceFailOp", m_DepthStencilDesc.m_BackFaceStencilOp.m_FailOp);
-    m_DepthStencilDesc.m_BackFaceStencilOp.m_PassOp = (ezGALStencilOp::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesStencilOp, "BackFacePassOp", m_DepthStencilDesc.m_BackFaceStencilOp.m_PassOp);
-    m_DepthStencilDesc.m_BackFaceStencilOp.m_StencilFunc = (ezGALCompareFunc::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesCompareFunc, "BackFaceStencilFunc", m_DepthStencilDesc.m_BackFaceStencilOp.m_StencilFunc);
+    m_DepthStencilDesc.m_FrontFaceStencilOp.m_DepthFailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(VariableValues, StateValuesStencilOp, "StencilDepthFailOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_DepthFailOp);
+    m_DepthStencilDesc.m_FrontFaceStencilOp.m_FailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(VariableValues, StateValuesStencilOp, "StencilFailOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_FailOp);
+    m_DepthStencilDesc.m_FrontFaceStencilOp.m_PassOp = (ezGALStencilOp::Enum)GetEnumStateVariable(VariableValues, StateValuesStencilOp, "StencilPassOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_PassOp);
+    m_DepthStencilDesc.m_FrontFaceStencilOp.m_StencilFunc = (ezGALCompareFunc::Enum)GetEnumStateVariable(VariableValues, StateValuesCompareFunc, "StencilCompareFunc", m_DepthStencilDesc.m_FrontFaceStencilOp.m_StencilFunc);
 
-    m_DepthStencilDesc.m_FrontFaceStencilOp.m_DepthFailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesStencilOp, "FrontFaceDepthFailOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_DepthFailOp);
-    m_DepthStencilDesc.m_FrontFaceStencilOp.m_FailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesStencilOp, "FrontFaceFailOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_FailOp);
-    m_DepthStencilDesc.m_FrontFaceStencilOp.m_PassOp = (ezGALStencilOp::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesStencilOp, "FrontFacePassOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_PassOp);
-    m_DepthStencilDesc.m_FrontFaceStencilOp.m_StencilFunc = (ezGALCompareFunc::Enum)GetEnumStateVariable(
-      VariableValues, StateValuesCompareFunc, "FrontFaceStencilFunc", m_DepthStencilDesc.m_FrontFaceStencilOp.m_StencilFunc);
+    // uses front-face values as fallback, if not overwritten
+    m_DepthStencilDesc.m_BackFaceStencilOp.m_DepthFailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(VariableValues, StateValuesStencilOp, "StencilBackFaceDepthFailOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_DepthFailOp);
+    m_DepthStencilDesc.m_BackFaceStencilOp.m_FailOp = (ezGALStencilOp::Enum)GetEnumStateVariable(VariableValues, StateValuesStencilOp, "StencilBackFaceFailOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_FailOp);
+    m_DepthStencilDesc.m_BackFaceStencilOp.m_PassOp = (ezGALStencilOp::Enum)GetEnumStateVariable(VariableValues, StateValuesStencilOp, "StencilBackFacePassOp", m_DepthStencilDesc.m_FrontFaceStencilOp.m_PassOp);
+    m_DepthStencilDesc.m_BackFaceStencilOp.m_StencilFunc = (ezGALCompareFunc::Enum)GetEnumStateVariable(VariableValues, StateValuesCompareFunc, "StencilBackFaceCompareFunc", m_DepthStencilDesc.m_FrontFaceStencilOp.m_StencilFunc);
 
-    m_DepthStencilDesc.m_bDepthTest = GetBoolStateVariable(VariableValues, "DepthTest", m_DepthStencilDesc.m_bDepthTest);
+    m_DepthStencilDesc.m_bDepthEnable = GetBoolStateVariable(VariableValues, "DepthTest", m_DepthStencilDesc.m_bDepthEnable); // deprecated old name
+    m_DepthStencilDesc.m_bDepthEnable = GetBoolStateVariable(VariableValues, "DepthEnable", m_DepthStencilDesc.m_bDepthEnable);
     m_DepthStencilDesc.m_bDepthWrite = GetBoolStateVariable(VariableValues, "DepthWrite", m_DepthStencilDesc.m_bDepthWrite);
-    m_DepthStencilDesc.m_bSeparateFrontAndBack =
-      GetBoolStateVariable(VariableValues, "SeparateFrontAndBack", m_DepthStencilDesc.m_bSeparateFrontAndBack);
-    m_DepthStencilDesc.m_bStencilTest = GetBoolStateVariable(VariableValues, "StencilTest", m_DepthStencilDesc.m_bStencilTest);
-    m_DepthStencilDesc.m_DepthTestFunc =
-      (ezGALCompareFunc::Enum)GetEnumStateVariable(VariableValues, StateValuesCompareFunc, "DepthTestFunc", m_DepthStencilDesc.m_DepthTestFunc);
+    m_DepthStencilDesc.m_bStencilEnable = GetBoolStateVariable(VariableValues, "StencilEnable", m_DepthStencilDesc.m_bStencilEnable);
+    m_DepthStencilDesc.m_DepthTestFunc = (ezGALCompareFunc::Enum)GetEnumStateVariable(VariableValues, StateValuesCompareFunc, "DepthTestFunc", m_DepthStencilDesc.m_DepthTestFunc);
     m_DepthStencilDesc.m_uiStencilReadMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, "StencilReadMask", m_DepthStencilDesc.m_uiStencilReadMask));
     m_DepthStencilDesc.m_uiStencilWriteMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, "StencilWriteMask", m_DepthStencilDesc.m_uiStencilWriteMask));
   }

--- a/Code/Engine/RendererDX11/State/Implementation/StateDX11.cpp
+++ b/Code/Engine/RendererDX11/State/Implementation/StateDX11.cpp
@@ -132,10 +132,10 @@ ezGALDepthStencilStateDX11::~ezGALDepthStencilStateDX11() = default;
 ezResult ezGALDepthStencilStateDX11::InitPlatform(ezGALDevice* pDevice)
 {
   D3D11_DEPTH_STENCIL_DESC DXDesc;
-  DXDesc.DepthEnable = m_Description.m_bDepthTest;
+  DXDesc.DepthEnable = m_Description.m_bDepthEnable;
   DXDesc.DepthWriteMask = m_Description.m_bDepthWrite ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
   DXDesc.DepthFunc = GALCompareFuncToDX11[m_Description.m_DepthTestFunc];
-  DXDesc.StencilEnable = m_Description.m_bStencilTest;
+  DXDesc.StencilEnable = m_Description.m_bStencilEnable;
   DXDesc.StencilReadMask = m_Description.m_uiStencilReadMask;
   DXDesc.StencilWriteMask = m_Description.m_uiStencilWriteMask;
 
@@ -144,8 +144,7 @@ ezResult ezGALDepthStencilStateDX11::InitPlatform(ezGALDevice* pDevice)
   DXDesc.FrontFace.StencilPassOp = GALStencilOpTableIndexToDX11[m_Description.m_FrontFaceStencilOp.m_PassOp];
   DXDesc.FrontFace.StencilFunc = GALCompareFuncToDX11[m_Description.m_FrontFaceStencilOp.m_StencilFunc];
 
-  const ezGALStencilOpDescription& backFaceStencilOp =
-    m_Description.m_bSeparateFrontAndBack ? m_Description.m_BackFaceStencilOp : m_Description.m_FrontFaceStencilOp;
+  const ezGALStencilOpDescription& backFaceStencilOp = m_Description.m_BackFaceStencilOp;
   DXDesc.BackFace.StencilFailOp = GALStencilOpTableIndexToDX11[backFaceStencilOp.m_FailOp];
   DXDesc.BackFace.StencilDepthFailOp = GALStencilOpTableIndexToDX11[backFaceStencilOp.m_DepthFailOp];
   DXDesc.BackFace.StencilPassOp = GALStencilOpTableIndexToDX11[backFaceStencilOp.m_PassOp];

--- a/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
+++ b/Code/Engine/RendererFoundation/Descriptors/Descriptors.h
@@ -143,11 +143,9 @@ struct ezGALDepthStencilStateCreationDescription : public ezHashableStruct<ezGAL
 
   ezEnum<ezGALCompareFunc> m_DepthTestFunc = ezGALCompareFunc::Less;
 
-  bool m_bSeparateFrontAndBack = false; ///< If false, DX11 will use front face values for both front & back face values, GL will not call
-                                        ///< gl*Separate() funcs
-  bool m_bDepthTest = true;
+  bool m_bDepthEnable = true;
   bool m_bDepthWrite = true;
-  bool m_bStencilTest = false;
+  bool m_bStencilEnable = false;
   ezUInt8 m_uiStencilReadMask = 0xFF;
   ezUInt8 m_uiStencilWriteMask = 0xFF;
 };

--- a/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/GraphicsPipelineVulkan.cpp
@@ -80,7 +80,7 @@ ezResult ezGALGraphicsPipelineVulkan::InitPlatform(ezGALDevice* pDevice)
   ezHybridArray<vk::DynamicState, 3> dynamics;
   dynamics.PushBack(vk::DynamicState::eViewport);
   dynamics.PushBack(vk::DynamicState::eScissor);
-  if (pDepthStencilState->GetDescription().m_bStencilTest)
+  if (pDepthStencilState->GetDescription().m_bStencilEnable)
     dynamics.PushBack(vk::DynamicState::eStencilReference);
 
   vk::PipelineDynamicStateCreateInfo dynamic;

--- a/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
+++ b/Code/Engine/RendererVulkan/State/Implementation/StateVulkan.cpp
@@ -117,12 +117,12 @@ ezResult ezGALDepthStencilStateVulkan::InitPlatform(ezGALDevice* pDevice)
 {
   m_depthStencilState.depthBoundsTestEnable = VK_FALSE;
   m_depthStencilState.depthCompareOp = GALCompareFuncToVulkan[m_Description.m_DepthTestFunc];
-  m_depthStencilState.depthTestEnable = m_Description.m_bDepthTest ? VK_TRUE : VK_FALSE;
+  m_depthStencilState.depthTestEnable = m_Description.m_bDepthEnable ? VK_TRUE : VK_FALSE;
   m_depthStencilState.depthWriteEnable = m_Description.m_bDepthWrite ? VK_TRUE : VK_FALSE;
   m_depthStencilState.minDepthBounds = 0.f;
   m_depthStencilState.maxDepthBounds = 1.f;
 
-  m_depthStencilState.stencilTestEnable = m_Description.m_bStencilTest ? VK_TRUE : VK_FALSE;
+  m_depthStencilState.stencilTestEnable = m_Description.m_bStencilEnable ? VK_TRUE : VK_FALSE;
   m_depthStencilState.front.compareMask = m_Description.m_uiStencilReadMask;
   m_depthStencilState.front.writeMask = m_Description.m_uiStencilWriteMask;
   m_depthStencilState.front.compareOp = GALCompareFuncToVulkan[m_Description.m_FrontFaceStencilOp.m_StencilFunc];
@@ -130,8 +130,7 @@ ezResult ezGALDepthStencilStateVulkan::InitPlatform(ezGALDevice* pDevice)
   m_depthStencilState.front.failOp = GALStencilOpTableIndexToVulkan[m_Description.m_FrontFaceStencilOp.m_FailOp];
   m_depthStencilState.front.passOp = GALStencilOpTableIndexToVulkan[m_Description.m_FrontFaceStencilOp.m_PassOp];
 
-  const ezGALStencilOpDescription& backFaceStencilOp =
-    m_Description.m_bSeparateFrontAndBack ? m_Description.m_BackFaceStencilOp : m_Description.m_FrontFaceStencilOp;
+  const ezGALStencilOpDescription& backFaceStencilOp = m_Description.m_BackFaceStencilOp;
   m_depthStencilState.back.compareOp = GALCompareFuncToVulkan[backFaceStencilOp.m_StencilFunc];
   m_depthStencilState.back.depthFailOp = GALStencilOpTableIndexToVulkan[backFaceStencilOp.m_DepthFailOp];
   m_depthStencilState.back.failOp = GALStencilOpTableIndexToVulkan[backFaceStencilOp.m_FailOp];

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -16,10 +16,10 @@
 #endif
 
 #ifdef EZ_USE_QT
-int main(int argc, char** argv)
+int main(int iArgc, char** argv)
 {
 #else
-int main(int argc, const char** argv)
+int main(int iArgc, const char** argv)
 {
 #endif
   ezFileserverApp* pApp = new ezFileserverApp();

--- a/Data/Plugins/Shaders/RmlUi.ezShader
+++ b/Data/Plugins/Shaders/RmlUi.ezShader
@@ -13,7 +13,7 @@ SourceBlend0 = Blend_One
 DestBlendAlpha0 = Blend_InvSrcAlpha
 SourceBlendAlpha0 = Blend_One
 ScissorTest = true
-DepthTest = false
+DepthEnable = false
 DepthWrite = false
 CullMode = CullMode_None
 StencilReadMask = 1
@@ -21,15 +21,15 @@ StencilWriteMask = 1
 
 #if RMLUI_MODE == RMLUI_MODE_STENCIL_TEST
 
-StencilTest = true
-FrontFaceStencilFunc = CompareFunc_Equal
+StencilEnable = true
+StencilCompareFunc = CompareFunc_Equal
 
 #elif RMLUI_MODE == RMLUI_MODE_STENCIL_SET
 
-StencilTest = true
-FrontFaceStencilFunc = CompareFunc_Always
-FrontFacePassOp = StencilOp_Replace
-WriteMask0 = 0
+StencilEnable = true
+StencilCompareFunc = CompareFunc_Always
+StencilPassOp = StencilOp_Replace
+ColorWriteMask = 0
 
 #endif
 


### PR DESCRIPTION
Made names of some render states more less unintuitive:

* DepthTest -> DepthEnable (affects depth-writes, not just a test) "DepthTest" will still work, though, when used in shaders
* StencilTest -> StencilEnable old values don't work anymore
* SeparateFrontAndBack (stencil test) -> removed will just be detected automatically
* FrontFaceDepthFailOp -> StencilDepthFailOp
* FrontFaceFailOp -> StencilFailOp
* FrontFacePassOp -> StencilPassOp
* FrontFaceStencilFunc -> StencilCompareFunc
* BackFaceDepthFailOp -> StencilBackFaceDepthFailOp
* BackFaceFailOp -> StencilBackFaceFailOp
* BackFacePassOp -> StencilBackFacePassOp
* BackFaceStencilFunc -> StencilBackFaceCompareFunc

Also all blend states can now be defined without a number, e.g.
* BlendingEnabled0 -> BlendingEnabled

All subsequent render targets use the same values as target 0 anyway.

See updated documentation page here: https://ezengine.net/pages/docs/graphics/shaders/shader-render-state.html