### PR TITLE
Added StencilRef value and Visual Shader State Nodes

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -1285,7 +1285,7 @@ void ezMaterialAssetDocument::RemoveDisconnectedNodes()
 
     auto pDesc = ezVisualShaderTypeRegistry::GetSingleton()->GetDescriptorForType(it.Key()->GetType());
 
-    if (pDesc->m_NodeType == ezVisualShaderNodeType::Main)
+    if (pDesc->m_NodeType == ezVisualShaderNodeType::Main || pDesc->m_NodeType == ezVisualShaderNodeType::ShaderState)
     {
       MarkReachableNodes(AllNodes, it.Key(), pNodeManager);
     }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderActions.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderActions.cpp
@@ -4,15 +4,18 @@
 #include <EditorPluginAssets/VisualShader/VisualShaderActions.h>
 #include <GuiFoundation/Action/ActionMapManager.h>
 
+ezActionDescriptorHandle ezVisualShaderActions::s_hVisualShaderCategory;
 ezActionDescriptorHandle ezVisualShaderActions::s_hCleanGraph;
 
 void ezVisualShaderActions::RegisterActions()
 {
+  s_hVisualShaderCategory = EZ_REGISTER_CATEGORY("VisualShaderCategory");
   s_hCleanGraph = EZ_REGISTER_ACTION_0("VisualShader.CleanGraph", ezActionScope::Document, "Visual Shader", "", ezVisualShaderAction);
 }
 
 void ezVisualShaderActions::UnregisterActions()
 {
+  ezActionManager::UnregisterAction(s_hVisualShaderCategory);
   ezActionManager::UnregisterAction(s_hCleanGraph);
 }
 
@@ -21,7 +24,9 @@ void ezVisualShaderActions::MapActions(ezStringView sMapping)
   ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
   EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);
 
-  pMap->MapAction(s_hCleanGraph, "", 30.0f);
+  // Use a high sort key to place Visual Shader actions on the far right of the toolbar
+  pMap->MapAction(s_hVisualShaderCategory, "", 1000.0f);
+  pMap->MapAction(s_hCleanGraph, "VisualShaderCategory", 1.0f);
 }
 
 
@@ -32,13 +37,35 @@ ezVisualShaderAction::ezVisualShaderAction(const ezActionContext& context, const
   : ezButtonAction(context, szName, false, "")
 {
   SetIconPath(":/EditorPluginAssets/Cleanup.svg");
+
+  // Register to listen for property changes on the document
+  m_Context.m_pDocument->GetObjectManager()->m_PropertyEvents.AddEventHandler(ezMakeDelegate(&ezVisualShaderAction::PropertyEventHandler, this));
+
+  // Initialize visibility based on current shader mode
+  ezMaterialAssetDocument* pMaterial = static_cast<ezMaterialAssetDocument*>(m_Context.m_pDocument);
+  const bool bCustom = pMaterial->GetPropertyObject()->GetTypeAccessor().GetValue("ShaderMode").ConvertTo<ezInt64>() == ezMaterialShaderMode::Custom;
+  SetVisible(bCustom, false);
 }
 
-ezVisualShaderAction::~ezVisualShaderAction() = default;
+ezVisualShaderAction::~ezVisualShaderAction()
+{
+  m_Context.m_pDocument->GetObjectManager()->m_PropertyEvents.RemoveEventHandler(ezMakeDelegate(&ezVisualShaderAction::PropertyEventHandler, this));
+}
 
 void ezVisualShaderAction::Execute(const ezVariant& value)
 {
-  ezMaterialAssetDocument* pMaterial = (ezMaterialAssetDocument*)(m_Context.m_pDocument);
-
+  ezMaterialAssetDocument* pMaterial = static_cast<ezMaterialAssetDocument*>(m_Context.m_pDocument);
   pMaterial->RemoveDisconnectedNodes();
+}
+
+void ezVisualShaderAction::PropertyEventHandler(const ezDocumentObjectPropertyEvent& e)
+{
+  ezMaterialAssetDocument* pMaterial = static_cast<ezMaterialAssetDocument*>(m_Context.m_pDocument);
+
+  // Only react to ShaderMode changes on the material property object
+  if (e.m_pObject == pMaterial->GetPropertyObject() && e.m_sProperty == "ShaderMode")
+  {
+    const bool bCustom = e.m_pObject->GetTypeAccessor().GetValue("ShaderMode").ConvertTo<ezInt64>() == ezMaterialShaderMode::Custom;
+    SetVisible(bCustom);
+  }
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderActions.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderActions.h
@@ -11,6 +11,7 @@ public:
 
   static void MapActions(ezStringView sMapping);
 
+  static ezActionDescriptorHandle s_hVisualShaderCategory;
   static ezActionDescriptorHandle s_hCleanGraph;
 };
 
@@ -23,4 +24,7 @@ public:
   ~ezVisualShaderAction();
 
   virtual void Execute(const ezVariant& value) override;
+
+private:
+  void PropertyEventHandler(const ezDocumentObjectPropertyEvent& e);
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
@@ -5,6 +5,7 @@
 #include <EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h>
 #include <Foundation/IO/OpenDdlReader.h>
 #include <Foundation/IO/OpenDdlUtils.h>
+#include <GuiFoundation/UIServices/DynamicStringEnum.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
 
 EZ_IMPLEMENT_SINGLETON(ezVisualShaderTypeRegistry);
@@ -499,6 +500,48 @@ void ezVisualShaderTypeRegistry::ExtractNodeProperties(const ezOpenDdlReaderElem
 
           iValueGroup = 1; // currently no way to specify the group
         }
+        else if (sType == "enum")
+        {
+          pRtti = ezGetStaticRTTI<ezString>();
+
+          // Read enum values from EnumValues property
+          const ezOpenDdlReaderElement* pEnumValues = pElement->FindChildOfType(ezOpenDdlPrimitiveType::String, "EnumValues");
+          if (pEnumValues)
+          {
+            // Create a unique enum name based on the node and property name
+            ezStringBuilder sEnumName;
+            sEnumName.SetFormat("{}_{}", nd.m_sName, prop.m_sName);
+
+            ezDynamicStringEnumAttribute* pAttr = EZ_DEFAULT_NEW(ezDynamicStringEnumAttribute, sEnumName);
+            prop.m_Attributes.PushBack(pAttr);
+
+            // Parse and register the enum values with the dynamic enum registry
+            ezStringBuilder enumValuesStr = pEnumValues->GetPrimitivesString()[0];
+
+            // Create or get the dynamic enum
+            auto& dynEnum = ezDynamicStringEnum::CreateDynamicEnum(sEnumName);
+            dynEnum.Clear();
+
+            // Parse comma-separated values
+            ezHybridArray<ezStringView, 32> values;
+            enumValuesStr.Split(false, values, ",");
+
+            for (const ezStringView& value : values)
+            {
+              ezStringBuilder trimmedValue = value;
+              trimmedValue.Trim(" \t\r\n");
+              if (!trimmedValue.IsEmpty())
+              {
+                dynEnum.AddValidValue(trimmedValue, false);
+              }
+            }
+          }
+          else
+          {
+            ezLog::Error("Property '{}' of type 'enum' is missing 'EnumValues'", prop.m_sName);
+            continue;
+          }
+        }
         else if (sType == "Texture2D")
         {
           pRtti = ezGetStaticRTTI<ezString>();
@@ -555,6 +598,8 @@ void ezVisualShaderTypeRegistry::ExtractNodeConfig(const ezOpenDdlReaderElement*
           nd.m_NodeType = ezVisualShaderNodeType::Main;
         else if (pElement->GetPrimitivesString()[0] == "Texture")
           nd.m_NodeType = ezVisualShaderNodeType::Texture;
+        else if (pElement->GetPrimitivesString()[0] == "ShaderState")
+          nd.m_NodeType = ezVisualShaderNodeType::ShaderState;
         else
           nd.m_NodeType = ezVisualShaderNodeType::Generic;
       }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
@@ -30,6 +30,7 @@ struct ezVisualShaderNodeType
     Generic,
     Main,
     Texture,
+    ShaderState,
 
     Default = Generic
   };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
@@ -121,6 +121,10 @@ ezStatus ezVisualShaderCodeGenerator::GatherAllNodes(const ezDocumentObject* pRo
 
       m_pMainNode = pRootObj;
     }
+    else if (pDesc->m_NodeType == ezVisualShaderNodeType::ShaderState)
+    {
+      m_StateNodes.PushBack(pRootObj);
+    }
   }
 
   const auto& children = pRootObj->GetChildren();
@@ -164,6 +168,11 @@ ezStatus ezVisualShaderCodeGenerator::GenerateVisualShader(const ezDocumentNodeM
     return ezStatus("Visual Shader does not contain an output node");
 
   EZ_SUCCEED_OR_RETURN(GenerateNode(m_pMainNode));
+
+  for (auto pStateNode : m_StateNodes)
+  {
+    EZ_SUCCEED_OR_RETURN(GenerateNode(pStateNode));
+  }
 
   ezStringBuilder sMaterialConstants = m_sShaderMaterialConstants;
   sMaterialConstants.ReplaceAll("VSE_CONSTANTS", m_sShaderMaterialCB);
@@ -235,6 +244,7 @@ ezStatus ezVisualShaderCodeGenerator::GenerateNode(const ezDocumentObject* pNode
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPixelDefines));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sMaterialCB));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPixelSamplersCode));
+  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sRenderStates));
 
   SetPinDefines(pNode, sPermutations);
   SetPinDefines(pNode, sRenderStates);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
@@ -53,6 +53,7 @@ private:
   static void AppendStringIfUnique(ezStringBuilder& inout_String, const char* szAppend);
 
   const ezDocumentObject* m_pMainNode;
+  ezHybridArray<const ezDocumentObject*, 4> m_StateNodes;
   const ezVisualShaderTypeRegistry* m_pTypeRegistry;
   const ezDocumentNodeManager* m_pNodeManager;
   const ezRTTI* m_pNodeBaseRtti;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -302,6 +302,12 @@ void ezRenderContext::SetRasterizerState(ezGALRasterizerStateHandle hRasterizerS
   m_StateFlags.Add(ezRenderContextFlags::PipelineChanged);
 }
 
+void ezRenderContext::SetStencilRefValue(ezUInt8 uiStencilRefValue)
+{
+  m_uiUserStencilRefValue = uiStencilRefValue;
+  m_StateFlags.Add(ezRenderContextFlags::NonPipelineStateChanged);
+}
+
 void ezRenderContext::BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuffer, ezGALBufferHandle hDataOffsetsBuffer /*= {}*/, ezUInt32 uiFirstDataOffset /*= 0*/)
 {
   ezResourceLock<ezMeshBufferResource> pMeshBuffer(hMeshBuffer, ezResourceAcquireMode::AllowLoadingFallback);
@@ -573,14 +579,29 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
     m_StateFlags.Remove(ezRenderContextFlags::MeshBufferBindingChanged);
   }
 
+  if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::NonPipelineStateChanged))
+  {
+    if (m_bUseUserStencilRefValue)
+    {
+      // Set the user provided stencil reference value
+      m_pGALCommandEncoder->SetStencilReference(m_uiUserStencilRefValue);
+    }
+    else
+    {
+      // Set stencil reference value from shader
+      m_pGALCommandEncoder->SetStencilReference(m_uiShaderStencilRefValue);
+    }
+
+    m_StateFlags.Remove(ezRenderContextFlags::NonPipelineStateChanged);
+  }
+
   if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::PipelineChanged))
   {
+    m_StateFlags.Remove(ezRenderContextFlags::PipelineChanged);
+
     if (m_bRendering)
     {
       m_pGALCommandEncoder->SetGraphicsPipeline(ezGALPipelineCache::GetPipeline(m_GraphicsPipeline));
-
-      // Set stencil reference value from shader
-      m_pGALCommandEncoder->SetStencilReference(m_uiStencilRefValue);
     }
     else if (m_bCompute)
     {
@@ -1081,12 +1102,15 @@ ezResult ezRenderContext::ApplyShaderState()
     if (!m_ShaderBindFlags.IsSet(ezShaderBindFlags::NoDepthStencilState))
     {
       m_GraphicsPipeline.m_hDepthStencilState = pShaderPermutation->GetDepthStencilState();
-      m_uiStencilRefValue = pShaderPermutation->GetStencilRefValue();
+      m_uiShaderStencilRefValue = pShaderPermutation->GetShaderStencilRefValue();
+      m_bUseUserStencilRefValue = pShaderPermutation->GetUseUserStencilRefValue();
     }
     else
     {
-      m_uiStencilRefValue = 0;
+      m_bUseUserStencilRefValue = true;
     }
+
+    m_StateFlags.Add(ezRenderContextFlags::NonPipelineStateChanged);
   }
 
   return EZ_SUCCESS;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -576,9 +576,16 @@ ezResult ezRenderContext::ApplyContextStates(bool bForce)
   if (bForce || m_StateFlags.IsSet(ezRenderContextFlags::PipelineChanged))
   {
     if (m_bRendering)
+    {
       m_pGALCommandEncoder->SetGraphicsPipeline(ezGALPipelineCache::GetPipeline(m_GraphicsPipeline));
+
+      // Set stencil reference value from shader
+      m_pGALCommandEncoder->SetStencilReference(m_uiStencilRefValue);
+    }
     else if (m_bCompute)
+    {
       m_pGALCommandEncoder->SetComputePipeline(ezGALPipelineCache::GetPipeline(m_ComputePipeline));
+    }
   }
 
   if (m_pActiveGALShader)
@@ -1072,7 +1079,14 @@ ezResult ezRenderContext::ApplyShaderState()
       m_GraphicsPipeline.m_hRasterizerState = pShaderPermutation->GetRasterizerState();
 
     if (!m_ShaderBindFlags.IsSet(ezShaderBindFlags::NoDepthStencilState))
+    {
       m_GraphicsPipeline.m_hDepthStencilState = pShaderPermutation->GetDepthStencilState();
+      m_uiStencilRefValue = pShaderPermutation->GetStencilRefValue();
+    }
+    else
+    {
+      m_uiStencilRefValue = 0;
+    }
   }
 
   return EZ_SUCCESS;

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContextStructs.h
@@ -55,8 +55,9 @@ struct EZ_RENDERERCORE_DLL ezRenderContextFlags
     MeshBufferBindingChanged = EZ_BIT(3),
     MaterialBindingChanged = EZ_BIT(4),
     PipelineChanged = EZ_BIT(5),
+    NonPipelineStateChanged = EZ_BIT(6),
 
-    AllStatesInvalid = ShaderStateChanged | BindGroupChanged | BindGroupLayoutChanged | MeshBufferBindingChanged | PipelineChanged,
+    AllStatesInvalid = ShaderStateChanged | BindGroupChanged | BindGroupLayoutChanged | MeshBufferBindingChanged | PipelineChanged | NonPipelineStateChanged,
     Default = None
   };
 
@@ -68,6 +69,7 @@ struct EZ_RENDERERCORE_DLL ezRenderContextFlags
     StorageType MeshBufferBindingChanged : 1;
     StorageType MaterialBindingChanged : 1;
     StorageType PipelineChanged : 1;
+    StorageType NonPipelineStateChanged : 1;
   };
 };
 

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -305,6 +305,8 @@ private:
   bool m_bAllowAsyncShaderLoading;
   bool m_bStereoRendering = false;
 
+  ezUInt8 m_uiStencilRefValue = 0;
+
   ezGALGraphicsPipelineCreationDescription m_GraphicsPipeline;
   ezGALComputePipelineCreationDescription m_ComputePipeline;
   ezBindGroupBuilder m_BindGroupBuilders[EZ_GAL_MAX_BIND_GROUPS];

--- a/Code/Engine/RendererCore/RenderContext/RenderContext.h
+++ b/Code/Engine/RendererCore/RenderContext/RenderContext.h
@@ -161,6 +161,7 @@ public:
   void SetBlendState(ezGALBlendStateHandle hBlendState);
   void SetDepthStencilState(ezGALDepthStencilStateHandle hDepthStencilState);
   void SetRasterizerState(ezGALRasterizerStateHandle hRasterizerState);
+  void SetStencilRefValue(ezUInt8 uiStencilRefValue);
 
   void BindMeshBuffer(const ezMeshBufferResourceHandle& hMeshBuffer, ezGALBufferHandle hDataOffsetsBuffer = {}, ezUInt32 uiFirstDataOffset = 0);
   void BindMeshBuffer(const ezDynamicMeshBufferResourceHandle& hDynamicMeshBuffer, ezGALBufferHandle hDataOffsetsBuffer = {}, ezUInt32 uiFirstDataOffset = 0);
@@ -305,7 +306,9 @@ private:
   bool m_bAllowAsyncShaderLoading;
   bool m_bStereoRendering = false;
 
-  ezUInt8 m_uiStencilRefValue = 0;
+  ezUInt8 m_uiUserStencilRefValue = 0;
+  ezUInt8 m_uiShaderStencilRefValue = 0;
+  bool m_bUseUserStencilRefValue = false;
 
   ezGALGraphicsPipelineCreationDescription m_GraphicsPipeline;
   ezGALComputePipelineCreationDescription m_ComputePipeline;

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationBinary.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationBinary.cpp
@@ -12,6 +12,7 @@ struct ezShaderPermutationBinaryVersion
     Version4 = 4,
     Version5 = 5,
     Version6 = 6, // Fixed DX11 particles vanishing
+    Version7 = 7,
 
     // Increase this version number to trigger shader recompilation
 

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
@@ -81,6 +81,7 @@ ezResourceLoadDesc ezShaderPermutationResource::UpdateContent(ezStreamReader* St
     m_hBlendState = pDevice->CreateBlendState(PermutationBinary.m_StateDescriptor.m_BlendDesc);
     m_hDepthStencilState = pDevice->CreateDepthStencilState(PermutationBinary.m_StateDescriptor.m_DepthStencilDesc);
     m_hRasterizerState = pDevice->CreateRasterizerState(PermutationBinary.m_StateDescriptor.m_RasterizerDesc);
+    m_uiStencilRef = PermutationBinary.m_StateDescriptor.m_uiStencilRef;
   }
 
   ezGALShaderCreationDescription ShaderDesc;

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderPermutationResource.cpp
@@ -81,7 +81,8 @@ ezResourceLoadDesc ezShaderPermutationResource::UpdateContent(ezStreamReader* St
     m_hBlendState = pDevice->CreateBlendState(PermutationBinary.m_StateDescriptor.m_BlendDesc);
     m_hDepthStencilState = pDevice->CreateDepthStencilState(PermutationBinary.m_StateDescriptor.m_DepthStencilDesc);
     m_hRasterizerState = pDevice->CreateRasterizerState(PermutationBinary.m_StateDescriptor.m_RasterizerDesc);
-    m_uiStencilRef = PermutationBinary.m_StateDescriptor.m_uiStencilRef;
+    m_uiShaderStencilRef = PermutationBinary.m_StateDescriptor.m_uiShaderStencilRef;
+    m_bUseUserStencilRef = PermutationBinary.m_StateDescriptor.m_bUseUserStencilRefValue;
   }
 
   ezGALShaderCreationDescription ShaderDesc;

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
@@ -10,6 +10,7 @@ struct ezShaderStateVersion
     Version1,
     Version2,
     Version3,
+    Version4, // Added stencil reference value
 
     ENUM_COUNT,
     Current = ENUM_COUNT - 1
@@ -71,6 +72,11 @@ void ezShaderStateResourceDescriptor::Save(ezStreamWriter& inout_stream) const
     inout_stream << m_RasterizerDesc.m_fSlopeScaledDepthBias;
     inout_stream << m_RasterizerDesc.m_iDepthBias;
     inout_stream << m_RasterizerDesc.m_bConservativeRasterization;
+  }
+
+  // Dynamic States
+  {
+    inout_stream << m_uiStencilRef;
   }
 }
 
@@ -171,11 +177,19 @@ void ezShaderStateResourceDescriptor::Load(ezStreamReader& inout_stream)
       inout_stream >> m_RasterizerDesc.m_bConservativeRasterization;
     }
   }
+
+  // Dynamic States
+  {
+    if (uiVersion >= ezShaderStateVersion::Version4)
+    {
+      inout_stream >> m_uiStencilRef;
+    }
+  }
 }
 
 ezUInt32 ezShaderStateResourceDescriptor::CalculateHash() const
 {
-  return m_BlendDesc.CalculateHash() + m_RasterizerDesc.CalculateHash() + m_DepthStencilDesc.CalculateHash();
+  return m_BlendDesc.CalculateHash() + m_RasterizerDesc.CalculateHash() + m_DepthStencilDesc.CalculateHash() + m_uiStencilRef;
 }
 
 static const char* AppendNumber(const char* szString, ezInt32 iNumber, ezStringBuilder& ref_sTemp)
@@ -451,6 +465,11 @@ ezResult ezShaderStateResourceDescriptor::Parse(const char* szSource)
     m_DepthStencilDesc.m_DepthTestFunc = (ezGALCompareFunc::Enum)GetEnumStateVariable(VariableValues, StateValuesCompareFunc, "DepthTestFunc", m_DepthStencilDesc.m_DepthTestFunc);
     m_DepthStencilDesc.m_uiStencilReadMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, "StencilReadMask", m_DepthStencilDesc.m_uiStencilReadMask));
     m_DepthStencilDesc.m_uiStencilWriteMask = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, "StencilWriteMask", m_DepthStencilDesc.m_uiStencilWriteMask));
+  }
+
+  // Dynamic States
+  {
+    m_uiStencilRef = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, "StencilRef", m_uiStencilRef));
   }
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)

--- a/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
+++ b/Code/Engine/RendererCore/Shader/Implementation/ShaderStateDescriptor.cpp
@@ -76,7 +76,8 @@ void ezShaderStateResourceDescriptor::Save(ezStreamWriter& inout_stream) const
 
   // Dynamic States
   {
-    inout_stream << m_uiStencilRef;
+    inout_stream << m_uiShaderStencilRef;
+    inout_stream << m_bUseUserStencilRefValue;
   }
 }
 
@@ -182,14 +183,15 @@ void ezShaderStateResourceDescriptor::Load(ezStreamReader& inout_stream)
   {
     if (uiVersion >= ezShaderStateVersion::Version4)
     {
-      inout_stream >> m_uiStencilRef;
+      inout_stream >> m_uiShaderStencilRef;
+      inout_stream >> m_bUseUserStencilRefValue;
     }
   }
 }
 
 ezUInt32 ezShaderStateResourceDescriptor::CalculateHash() const
 {
-  return m_BlendDesc.CalculateHash() + m_RasterizerDesc.CalculateHash() + m_DepthStencilDesc.CalculateHash() + m_uiStencilRef;
+  return m_BlendDesc.CalculateHash() + m_RasterizerDesc.CalculateHash() + m_DepthStencilDesc.CalculateHash() + m_uiShaderStencilRef + (m_bUseUserStencilRefValue ? 1 : 0);
 }
 
 static const char* AppendNumber(const char* szString, ezInt32 iNumber, ezStringBuilder& ref_sTemp)
@@ -469,7 +471,15 @@ ezResult ezShaderStateResourceDescriptor::Parse(const char* szSource)
 
   // Dynamic States
   {
-    m_uiStencilRef = static_cast<ezUInt8>(GetIntStateVariable(VariableValues, "StencilRef", m_uiStencilRef));
+    m_bUseUserStencilRefValue = GetBoolStateVariable(VariableValues, "UseUserStencilRef", m_bUseUserStencilRefValue);
+    const ezInt32 iStencilRef = GetIntStateVariable(VariableValues, "StencilRef", m_uiShaderStencilRef);
+    m_uiShaderStencilRef = static_cast<ezUInt8>(iStencilRef);
+
+    if (iStencilRef < 0)
+    {
+      // can either use UseUserStencilRef, or can set StencilRef to -1
+      m_bUseUserStencilRefValue = true;
+    }
   }
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)

--- a/Code/Engine/RendererCore/Shader/ShaderPermutationBinary.h
+++ b/Code/Engine/RendererCore/Shader/ShaderPermutationBinary.h
@@ -15,6 +15,8 @@ struct EZ_RENDERERCORE_DLL ezShaderStateResourceDescriptor
   ezGALDepthStencilStateCreationDescription m_DepthStencilDesc;
   ezGALRasterizerStateCreationDescription m_RasterizerDesc;
 
+  ezUInt8 m_uiStencilRef = 0; ///< Stencil reference value for stencil test comparison
+
   /// Parses state descriptions from shader source text.
   ezResult Parse(const char* szSource);
 

--- a/Code/Engine/RendererCore/Shader/ShaderPermutationBinary.h
+++ b/Code/Engine/RendererCore/Shader/ShaderPermutationBinary.h
@@ -15,7 +15,8 @@ struct EZ_RENDERERCORE_DLL ezShaderStateResourceDescriptor
   ezGALDepthStencilStateCreationDescription m_DepthStencilDesc;
   ezGALRasterizerStateCreationDescription m_RasterizerDesc;
 
-  ezUInt8 m_uiStencilRef = 0; ///< Stencil reference value for stencil test comparison
+  ezUInt8 m_uiShaderStencilRef = 0;       ///< Stencil reference value for stencil test comparison
+  bool m_bUseUserStencilRefValue = false; ///< Whether to use the stencil ref value, that is provided externally
 
   /// Parses state descriptions from shader source text.
   ezResult Parse(const char* szSource);

--- a/Code/Engine/RendererCore/Shader/ShaderPermutationResource.h
+++ b/Code/Engine/RendererCore/Shader/ShaderPermutationResource.h
@@ -38,7 +38,10 @@ public:
   ezGALRasterizerStateHandle GetRasterizerState() const { return m_hRasterizerState; }
 
   /// Returns the stencil reference value for stencil testing.
-  ezUInt8 GetStencilRefValue() const { return m_uiStencilRef; }
+  ezUInt8 GetShaderStencilRefValue() const { return m_uiShaderStencilRef; }
+
+  /// Returns whether the shader wants to use the user provided stencil reference value.
+  bool GetUseUserStencilRefValue() const { return m_bUseUserStencilRef; }
 
   /// Returns true if the shader compiled successfully.
   bool IsShaderValid() const { return m_bShaderPermutationValid; }
@@ -64,7 +67,8 @@ private:
   ezGALDepthStencilStateHandle m_hDepthStencilState;
   ezGALRasterizerStateHandle m_hRasterizerState;
 
-  ezUInt8 m_uiStencilRef = 0;
+  ezUInt8 m_uiShaderStencilRef = 0;
+  bool m_bUseUserStencilRef = false;
 
   ezHybridArray<ezPermutationVar, 16> m_PermutationVars;
 };

--- a/Code/Engine/RendererCore/Shader/ShaderPermutationResource.h
+++ b/Code/Engine/RendererCore/Shader/ShaderPermutationResource.h
@@ -37,6 +37,9 @@ public:
   ezGALDepthStencilStateHandle GetDepthStencilState() const { return m_hDepthStencilState; }
   ezGALRasterizerStateHandle GetRasterizerState() const { return m_hRasterizerState; }
 
+  /// Returns the stencil reference value for stencil testing.
+  ezUInt8 GetStencilRefValue() const { return m_uiStencilRef; }
+
   /// Returns true if the shader compiled successfully.
   bool IsShaderValid() const { return m_bShaderPermutationValid; }
 
@@ -60,6 +63,8 @@ private:
   ezGALBlendStateHandle m_hBlendState;
   ezGALDepthStencilStateHandle m_hDepthStencilState;
   ezGALRasterizerStateHandle m_hRasterizerState;
+
+  ezUInt8 m_uiStencilRef = 0;
 
   ezHybridArray<ezPermutationVar, 16> m_PermutationVars;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
@@ -40,9 +40,9 @@ ezUniquePtr<JPH::JobSystem> ezJoltCore::s_pJobSystemEZ;
 std::unique_ptr<JPH::JobSystem> ezJoltCore::s_pJobSystemJolt;
 ezUniquePtr<ezProxyAllocator> ezJoltCore::s_pAllocator;
 ezUniquePtr<ezProxyAllocator> ezJoltCore::s_pAllocatorAligned;
-ezUniquePtr<ezCollisionFilterConfig> ezJoltCore::s_CollisionFilterConfig;
-ezUniquePtr<ezWeightCategoryConfig> ezJoltCore::s_WeightCategoryConfig;
-ezUniquePtr<ezImpulseTypeConfig> ezJoltCore::s_ImpulseTypeConfig;
+ezUniquePtr<ezCollisionFilterConfig> ezJoltCore::s_pCollisionFilterConfig;
+ezUniquePtr<ezWeightCategoryConfig> ezJoltCore::s_pWeightCategoryConfig;
+ezUniquePtr<ezImpulseTypeConfig> ezJoltCore::s_pImpulseTypeConfig;
 
 ezJoltMaterial::ezJoltMaterial() = default;
 ezJoltMaterial::~ezJoltMaterial() = default;
@@ -140,17 +140,17 @@ void ezJoltCore::JoltAlignedFree(void* inBlock)
 
 const ezCollisionFilterConfig& ezJoltCore::GetCollisionFilterConfig()
 {
-  return *s_CollisionFilterConfig;
+  return *s_pCollisionFilterConfig;
 }
 
 const ezWeightCategoryConfig& ezJoltCore::GetWeightCategoryConfig()
 {
-  return *s_WeightCategoryConfig;
+  return *s_pWeightCategoryConfig;
 }
 
 const ezImpulseTypeConfig& ezJoltCore::GetImpulseTypeConfig()
 {
-  return *s_ImpulseTypeConfig;
+  return *s_pImpulseTypeConfig;
 }
 
 void ezJoltCore::ReloadConfigs()
@@ -164,14 +164,14 @@ void ezJoltCore::LoadCollisionFilters()
 {
   EZ_LOG_BLOCK("ezJoltCore::LoadCollisionFilters");
 
-  if (s_CollisionFilterConfig->Load().Failed())
+  if (s_pCollisionFilterConfig->Load().Failed())
   {
     ezLog::Info("Collision filter config file could not be found ('{}'). Using default values.", ezCollisionFilterConfig::s_sConfigFile);
 
     // setup some default config
 
-    s_CollisionFilterConfig->SetGroupName(0, "Default");
-    s_CollisionFilterConfig->EnableCollision(0, 0);
+    s_pCollisionFilterConfig->SetGroupName(0, "Default");
+    s_pCollisionFilterConfig->EnableCollision(0, 0);
   }
 }
 
@@ -179,7 +179,7 @@ void ezJoltCore::LoadWeightCategories()
 {
   EZ_LOG_BLOCK("ezJoltCore::LoadWeightCategories");
 
-  if (s_WeightCategoryConfig->Load().Failed())
+  if (s_pWeightCategoryConfig->Load().Failed())
   {
     ezLog::Info("Weight category config file could not be found ('{}').", ezWeightCategoryConfig::s_sConfigFile);
   }
@@ -189,7 +189,7 @@ void ezJoltCore::LoadImpulseTypes()
 {
   EZ_LOG_BLOCK("ezJoltCore::LoadImpulseTypes");
 
-  if (s_ImpulseTypeConfig->Load().Failed())
+  if (s_pImpulseTypeConfig->Load().Failed())
   {
     ezLog::Info("Impulse Types config file could not be found ('{}').", ezImpulseTypeConfig::s_sConfigFile);
   }
@@ -200,9 +200,9 @@ void ezJoltCore::Startup()
   s_pAllocator = EZ_DEFAULT_NEW(ezProxyAllocator, "Jolt-Core", ezFoundation::GetDefaultAllocator());
   s_pAllocatorAligned = EZ_DEFAULT_NEW(ezProxyAllocator, "Jolt-Core-Aligned", ezFoundation::GetAlignedAllocator());
 
-  s_CollisionFilterConfig = EZ_DEFAULT_NEW(ezCollisionFilterConfig);
-  s_WeightCategoryConfig = EZ_DEFAULT_NEW(ezWeightCategoryConfig);
-  s_ImpulseTypeConfig = EZ_DEFAULT_NEW(ezImpulseTypeConfig);
+  s_pCollisionFilterConfig = EZ_DEFAULT_NEW(ezCollisionFilterConfig);
+  s_pWeightCategoryConfig = EZ_DEFAULT_NEW(ezWeightCategoryConfig);
+  s_pImpulseTypeConfig = EZ_DEFAULT_NEW(ezImpulseTypeConfig);
 
   JPH::Trace = JoltTraceFunc;
   JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = JoltAssertFailed);
@@ -251,9 +251,9 @@ void ezJoltCore::Shutdown()
 
   JPH::Trace = nullptr;
 
-  s_CollisionFilterConfig.Clear();
-  s_WeightCategoryConfig.Clear();
-  s_ImpulseTypeConfig.Clear();
+  s_pCollisionFilterConfig.Clear();
+  s_pWeightCategoryConfig.Clear();
+  s_pImpulseTypeConfig.Clear();
 
   s_pAllocator.Clear();
   s_pAllocatorAligned.Clear();

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.cpp
@@ -40,9 +40,9 @@ ezUniquePtr<JPH::JobSystem> ezJoltCore::s_pJobSystemEZ;
 std::unique_ptr<JPH::JobSystem> ezJoltCore::s_pJobSystemJolt;
 ezUniquePtr<ezProxyAllocator> ezJoltCore::s_pAllocator;
 ezUniquePtr<ezProxyAllocator> ezJoltCore::s_pAllocatorAligned;
-ezCollisionFilterConfig ezJoltCore::s_CollisionFilterConfig;
-ezWeightCategoryConfig ezJoltCore::s_WeightCategoryConfig;
-ezImpulseTypeConfig ezJoltCore::s_ImpulseTypeConfig;
+ezUniquePtr<ezCollisionFilterConfig> ezJoltCore::s_CollisionFilterConfig;
+ezUniquePtr<ezWeightCategoryConfig> ezJoltCore::s_WeightCategoryConfig;
+ezUniquePtr<ezImpulseTypeConfig> ezJoltCore::s_ImpulseTypeConfig;
 
 ezJoltMaterial::ezJoltMaterial() = default;
 ezJoltMaterial::~ezJoltMaterial() = default;
@@ -140,17 +140,17 @@ void ezJoltCore::JoltAlignedFree(void* inBlock)
 
 const ezCollisionFilterConfig& ezJoltCore::GetCollisionFilterConfig()
 {
-  return s_CollisionFilterConfig;
+  return *s_CollisionFilterConfig;
 }
 
 const ezWeightCategoryConfig& ezJoltCore::GetWeightCategoryConfig()
 {
-  return s_WeightCategoryConfig;
+  return *s_WeightCategoryConfig;
 }
 
 const ezImpulseTypeConfig& ezJoltCore::GetImpulseTypeConfig()
 {
-  return s_ImpulseTypeConfig;
+  return *s_ImpulseTypeConfig;
 }
 
 void ezJoltCore::ReloadConfigs()
@@ -164,14 +164,14 @@ void ezJoltCore::LoadCollisionFilters()
 {
   EZ_LOG_BLOCK("ezJoltCore::LoadCollisionFilters");
 
-  if (s_CollisionFilterConfig.Load().Failed())
+  if (s_CollisionFilterConfig->Load().Failed())
   {
     ezLog::Info("Collision filter config file could not be found ('{}'). Using default values.", ezCollisionFilterConfig::s_sConfigFile);
 
     // setup some default config
 
-    s_CollisionFilterConfig.SetGroupName(0, "Default");
-    s_CollisionFilterConfig.EnableCollision(0, 0);
+    s_CollisionFilterConfig->SetGroupName(0, "Default");
+    s_CollisionFilterConfig->EnableCollision(0, 0);
   }
 }
 
@@ -179,7 +179,7 @@ void ezJoltCore::LoadWeightCategories()
 {
   EZ_LOG_BLOCK("ezJoltCore::LoadWeightCategories");
 
-  if (s_WeightCategoryConfig.Load().Failed())
+  if (s_WeightCategoryConfig->Load().Failed())
   {
     ezLog::Info("Weight category config file could not be found ('{}').", ezWeightCategoryConfig::s_sConfigFile);
   }
@@ -189,7 +189,7 @@ void ezJoltCore::LoadImpulseTypes()
 {
   EZ_LOG_BLOCK("ezJoltCore::LoadImpulseTypes");
 
-  if (s_ImpulseTypeConfig.Load().Failed())
+  if (s_ImpulseTypeConfig->Load().Failed())
   {
     ezLog::Info("Impulse Types config file could not be found ('{}').", ezImpulseTypeConfig::s_sConfigFile);
   }
@@ -199,6 +199,10 @@ void ezJoltCore::Startup()
 {
   s_pAllocator = EZ_DEFAULT_NEW(ezProxyAllocator, "Jolt-Core", ezFoundation::GetDefaultAllocator());
   s_pAllocatorAligned = EZ_DEFAULT_NEW(ezProxyAllocator, "Jolt-Core-Aligned", ezFoundation::GetAlignedAllocator());
+
+  s_CollisionFilterConfig = EZ_DEFAULT_NEW(ezCollisionFilterConfig);
+  s_WeightCategoryConfig = EZ_DEFAULT_NEW(ezWeightCategoryConfig);
+  s_ImpulseTypeConfig = EZ_DEFAULT_NEW(ezImpulseTypeConfig);
 
   JPH::Trace = JoltTraceFunc;
   JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = JoltAssertFailed);
@@ -246,6 +250,10 @@ void ezJoltCore::Shutdown()
   JPH::Factory::sInstance = nullptr;
 
   JPH::Trace = nullptr;
+
+  s_CollisionFilterConfig.Clear();
+  s_WeightCategoryConfig.Clear();
+  s_ImpulseTypeConfig.Clear();
 
   s_pAllocator.Clear();
   s_pAllocatorAligned.Clear();

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
@@ -63,7 +63,7 @@ private:
   static ezUniquePtr<ezProxyAllocator> s_pAllocator;
   static ezUniquePtr<ezProxyAllocator> s_pAllocatorAligned;
 
-  static ezUniquePtr<ezCollisionFilterConfig> s_CollisionFilterConfig;
-  static ezUniquePtr<ezWeightCategoryConfig> s_WeightCategoryConfig;
-  static ezUniquePtr<ezImpulseTypeConfig> s_ImpulseTypeConfig;
+  static ezUniquePtr<ezCollisionFilterConfig> s_pCollisionFilterConfig;
+  static ezUniquePtr<ezWeightCategoryConfig> s_pWeightCategoryConfig;
+  static ezUniquePtr<ezImpulseTypeConfig> s_pImpulseTypeConfig;
 };

--- a/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
+++ b/Code/EnginePlugins/JoltPlugin/System/JoltCore.h
@@ -63,7 +63,7 @@ private:
   static ezUniquePtr<ezProxyAllocator> s_pAllocator;
   static ezUniquePtr<ezProxyAllocator> s_pAllocatorAligned;
 
-  static ezCollisionFilterConfig s_CollisionFilterConfig;
-  static ezWeightCategoryConfig s_WeightCategoryConfig;
-  static ezImpulseTypeConfig s_ImpulseTypeConfig;
+  static ezUniquePtr<ezCollisionFilterConfig> s_CollisionFilterConfig;
+  static ezUniquePtr<ezWeightCategoryConfig> s_WeightCategoryConfig;
+  static ezUniquePtr<ezImpulseTypeConfig> s_ImpulseTypeConfig;
 };

--- a/Code/Tools/Fileserve/Fileserve.cpp
+++ b/Code/Tools/Fileserve/Fileserve.cpp
@@ -16,10 +16,10 @@
 #endif
 
 #ifdef EZ_USE_QT
-int main(int iArgc, char** argv)
+int main(int iArgc, char** pArgv)
 {
 #else
-int main(int iArgc, const char** argv)
+int main(int iArgc, const char** pArgv)
 {
 #endif
   ezFileserverApp* pApp = new ezFileserverApp();
@@ -28,7 +28,7 @@ int main(int iArgc, const char** argv)
 #  if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
   ezCommandLineUtils::GetGlobalInstance()->SetCommandLine();
 #  else
-  ezCommandLineUtils::GetGlobalInstance()->SetCommandLine(iArgc, argv);
+  ezCommandLineUtils::GetGlobalInstance()->SetCommandLine(iArgc, pArgv);
 #  endif
   int dummyArgc = 0;
   char** dummyArgv = nullptr;
@@ -44,7 +44,7 @@ int main(int iArgc, const char** argv)
   pQtApplication->exec();
   ezRun_Shutdown(pApp);
 #else
-  pApp->SetCommandLineArguments((ezUInt32)iArgc, argv);
+  pApp->SetCommandLineArguments((ezUInt32)iArgc, pArgv);
   ezRun(pApp);
 #endif
 

--- a/Code/Tools/Inspector/MainWidget.cpp
+++ b/Code/Tools/Inspector/MainWidget.cpp
@@ -66,11 +66,8 @@ void ezQtMainWidget::ProcessTelemetry(void* pUnuseed)
         if (!it.IsValid())
           break;
 
-        if (it.Value().m_pItem)
-          delete it.Value().m_pItem;
-
-        if (it.Value().m_pItemFavorite)
-          delete it.Value().m_pItemFavorite;
+        delete it.Value().m_pItem;
+        delete it.Value().m_pItemFavorite;
 
         s_pWidget->m_Stats.Remove(it);
       }

--- a/Data/Tools/ezEditor/VisualShader/RenderStates.ddl
+++ b/Data/Tools/ezEditor/VisualShader/RenderStates.ddl
@@ -1,0 +1,187 @@
+Node %StencilState
+{
+  string %NodeType { "ShaderState" }
+  string %Category { "RenderStates" }
+  string %Color { "Blue" }
+  string %Docs { "Configures the stencil buffer state for stencil testing operations" }
+
+  Property %StencilEnable
+  {
+    string %Type { "bool" }
+    string %DefaultValue { "true" }
+  }
+
+  Property %StencilCompareFunc
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "CompareFunc_Equal" }
+    string %EnumValues { "CompareFunc_Never, CompareFunc_Less, CompareFunc_Equal, CompareFunc_LessEqual, CompareFunc_Greater, CompareFunc_NotEqual, CompareFunc_GreaterEqual, CompareFunc_Always" }
+  }
+
+  Property %StencilPassOp
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "StencilOp_Keep" }
+    string %EnumValues { "StencilOp_Keep, StencilOp_Zero, StencilOp_Replace, StencilOp_IncrementSaturated, StencilOp_DecrementSaturated, StencilOp_Invert, StencilOp_Increment, StencilOp_Decrement" }
+  }
+
+  Property %StencilFailOp
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "StencilOp_Keep" }
+    string %EnumValues { "StencilOp_Keep, StencilOp_Zero, StencilOp_Replace, StencilOp_IncrementSaturated, StencilOp_DecrementSaturated, StencilOp_Invert, StencilOp_Increment, StencilOp_Decrement" }
+  }
+
+  Property %StencilDepthFailOp
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "StencilOp_Keep" }
+    string %EnumValues { "StencilOp_Keep, StencilOp_Zero, StencilOp_Replace, StencilOp_IncrementSaturated, StencilOp_DecrementSaturated, StencilOp_Invert, StencilOp_Increment, StencilOp_Decrement" }
+  }
+
+  Property %StencilReadMask
+  {
+    string %Type { "int" }
+    string %DefaultValue { "255" }
+  }
+
+  Property %StencilWriteMask
+  {
+    string %Type { "int" }
+    string %DefaultValue { "255" }
+  }
+
+  Property %StencilRef
+  {
+    string %Type { "int" }
+    string %DefaultValue { "0" }
+  }
+
+  string %CodeRenderStates { "StencilEnable = $prop0
+StencilCompareFunc = $prop1
+StencilPassOp = $prop2
+StencilFailOp = $prop3
+StencilDepthFailOp = $prop4
+StencilReadMask = $prop5
+StencilWriteMask = $prop6
+StencilRef = $prop7" }
+}
+
+Node %DepthState
+{
+  string %NodeType { "ShaderState" }
+  string %Category { "RenderStates" }
+  string %Color { "Blue" }
+  string %Docs { "Configures depth buffer testing and writing" }
+
+  Property %DepthEnable
+  {
+    string %Type { "bool" }
+    string %DefaultValue { "true" }
+  }
+
+  Property %DepthWrite
+  {
+    string %Type { "bool" }
+    string %DefaultValue { "true" }
+  }
+
+  Property %DepthTestFunc
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "CompareFunc_LessEqual" }
+    string %EnumValues { "CompareFunc_Never, CompareFunc_Less, CompareFunc_Equal, CompareFunc_LessEqual, CompareFunc_Greater, CompareFunc_NotEqual, CompareFunc_GreaterEqual, CompareFunc_Always" }
+  }
+
+  string %CodeRenderStates { "DepthEnable = $prop0
+DepthWrite = $prop1
+DepthTestFunc = $prop2" }
+}
+
+Node %BlendState
+{
+  string %NodeType { "ShaderState" }
+  string %Category { "RenderStates" }
+  string %Color { "Blue" }
+  string %Docs { "Configures color blending for render target 0" }
+
+  Property %BlendingEnabled
+  {
+    string %Type { "bool" }
+    string %DefaultValue { "false" }
+  }
+
+  Property %SourceBlend
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "Blend_SrcAlpha" }
+    string %EnumValues { "Blend_Zero, Blend_One, Blend_SrcColor, Blend_InvSrcColor, Blend_SrcAlpha, Blend_InvSrcAlpha, Blend_DestAlpha, Blend_InvDestAlpha, Blend_DestColor, Blend_InvDestColor, Blend_SrcAlphaSaturated, Blend_BlendFactor, Blend_InvBlendFactor" }
+  }
+
+  Property %DestBlend
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "Blend_InvSrcAlpha" }
+    string %EnumValues { "Blend_Zero, Blend_One, Blend_SrcColor, Blend_InvSrcColor, Blend_SrcAlpha, Blend_InvSrcAlpha, Blend_DestAlpha, Blend_InvDestAlpha, Blend_DestColor, Blend_InvDestColor, Blend_SrcAlphaSaturated, Blend_BlendFactor, Blend_InvBlendFactor" }
+  }
+
+  Property %BlendOp
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "BlendOp_Add" }
+    string %EnumValues { "BlendOp_Add, BlendOp_Subtract, BlendOp_RevSubtract, BlendOp_Min, BlendOp_Max" }
+  }
+
+  Property %SourceBlendAlpha
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "Blend_One" }
+    string %EnumValues { "Blend_Zero, Blend_One, Blend_SrcColor, Blend_InvSrcColor, Blend_SrcAlpha, Blend_InvSrcAlpha, Blend_DestAlpha, Blend_InvDestAlpha, Blend_DestColor, Blend_InvDestColor, Blend_SrcAlphaSaturated, Blend_BlendFactor, Blend_InvBlendFactor" }
+  }
+
+  Property %DestBlendAlpha
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "Blend_InvSrcAlpha" }
+    string %EnumValues { "Blend_Zero, Blend_One, Blend_SrcColor, Blend_InvSrcColor, Blend_SrcAlpha, Blend_InvSrcAlpha, Blend_DestAlpha, Blend_InvDestAlpha, Blend_DestColor, Blend_InvDestColor, Blend_SrcAlphaSaturated, Blend_BlendFactor, Blend_InvBlendFactor" }
+  }
+
+  Property %BlendOpAlpha
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "BlendOp_Add" }
+    string %EnumValues { "BlendOp_Add, BlendOp_Subtract, BlendOp_RevSubtract, BlendOp_Min, BlendOp_Max" }
+  }
+
+  string %CodeRenderStates { "BlendingEnabled = $prop0
+SourceBlend = $prop1
+DestBlend = $prop2
+BlendOp = $prop3
+SourceBlendAlpha = $prop4
+DestBlendAlpha = $prop5
+BlendOpAlpha = $prop6" }
+}
+
+Node %RasterizerState
+{
+  string %NodeType { "ShaderState" }
+  string %Category { "RenderStates" }
+  string %Color { "Blue" }
+  string %Docs { "Configures common rasterizer settings" }
+
+  Property %CullMode
+  {
+    string %Type { "enum" }
+    string %DefaultValue { "CullMode_Back" }
+    string %EnumValues { "CullMode_None, CullMode_Front, CullMode_Back" }
+  }
+
+  Property %WireFrame
+  {
+    string %Type { "bool" }
+    string %DefaultValue { "false" }
+  }
+
+  string %CodeRenderStates { "CullMode = $prop0
+WireFrame = $prop1" }
+}

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: A7920CB7-B6E0-4555-B76C-FF53BDD6D330
+Change me: A7920CB7-B6E2-4555-B76C-FF53BDD6D330


### PR DESCRIPTION
Visual Shaders can now set the render state through state nodes. Supports depth state, stencil state, blend state and rasterizer states. Added that one can set the StencilRef value from a shader (fixes #1749).