### PR TITLE
AssetProcessor timeline widget

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -189,5 +189,8 @@ ezResult ezProcessCommunicationChannel::WaitForConnection(ezTime timeout)
 
 bool ezProcessCommunicationChannel::IsConnected() const
 {
+  if (!m_pChannel)
+    return false;
+
   return m_pChannel->IsConnected();
 }

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -353,7 +353,7 @@ public:
   /// along with all their dependencies to the destination folder. Files are copied preserving
   /// their relative paths from the data directories. Each file is copied only once, even if
   /// it appears in multiple dependency trees.
-  ExportResult ExportAssets(ezArrayPtr<ezString> sources, ezStringView sDestinationFolder, bool bIncludeTransformDeps = true, bool bIncludeThumbnailDeps = true, bool bIncludePackageDeps = true) const;
+  ExportResult ExportAssets(ezArrayPtr<ezString> sources, ezStringView sDestinationFolder, ezBitflags<ezDependencyFlags> includeDependencyTypes = ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail | ezDependencyFlags::Package) const;
 
   ///@}
 

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -333,7 +333,7 @@ public:
   /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
   void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, ezBitflags<ezDependencyFlags> dependencyTypes) const;
   /// \brief Copies each value of deps into out_SettingsHashMap and fills the value of assets with the hash value of the dependencyType. For files, the file hash is used.
-  void GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_SettingsHashMap) const;
+  void GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_settingsHashMap) const;
 
   /// \brief Generates one inverse transitive hull for all the types dependencies that are enabled. The set will contain inverse dependencies that can reach the given asset (pAssetInfo) via any combination of the enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.
   void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inout_inverseDeps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false) const;

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -28,7 +28,6 @@ class ezUpdateTask;
 class ezTask;
 class ezAssetDocumentManager;
 class ezDirectoryWatcher;
-class ezProcessTask;
 struct ezFileStats;
 class ezAssetProcessorLog;
 class ezFileSystemWatcher;
@@ -261,11 +260,11 @@ public:
   /// \brief Returns the table of all known assets in a locked structure
   const ezLockedAssetTable GetKnownAssets() const;
 
-  /// \brief Computes the combined hash for the asset and its dependencies. Returns 0 if anything went wrong.
-  ezUInt64 GetAssetDependencyHash(ezUuid assetGuid);
+  /// \brief Computes the transform hash for the asset and its transform dependencies. Returns 0 if anything went wrong.
+  ezUInt64 GetAssetTransformHash(ezUuid assetGuid);
 
-  /// \brief Computes the combined hash for the asset and its references. Returns 0 if anything went wrong.
-  ezUInt64 GetAssetReferenceHash(ezUuid assetGuid);
+  /// \brief Computes the thumbnail hash for the asset and its thumbnail dependencies. Returns 0 if anything went wrong.
+  ezUInt64 GetAssetThumbnailHash(ezUuid assetGuid);
 
   ezAssetInfo::TransformState IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile* pAssetProfile, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, ezUInt64& out_uiPackageHash, bool bForce = false);
   /// \brief Returns the number of assets in the system and how many are in what transform state
@@ -287,9 +286,9 @@ public:
   ///   File name (may include a path) to search for. Will be modified both on success and failure to give a 'reasonable' result.
   ezResult FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArrayPtr<ezString> allowedFileExtensions) const;
 
-  /// \brief Finds all uses, either as references or dependencies to a given asset.
+  /// \brief Finds all uses, either as transform or thumbnail dependencies to a given asset.
   ///
-  /// Technically this finds all references and dependencies to this asset but in practice there are no uses of transform dependencies between assets right now so the result is a list of references and can be referred to as such.
+  /// Technically this finds all dependencies to this asset but in practice there are no uses of transform dependencies between assets right now so the result is a list of thumbnail dependencies and can be referred to as simply a list of asset references.
   ///
   /// \param assetGuid
   ///   The asset to find use cases for.
@@ -323,18 +322,18 @@ public:
   /// \brief Checks file system for any changes. Call in case the file system watcher does not pick up certain changes.
   void CheckFileSystem();
 
-  void NeedsReloadResources(const ezUuid& assetGuid);
+  void NeedsReloadResources(const ezUuid& assetGuid) const;
 
   void InvalidateAssetsWithTransformState(ezAssetInfo::TransformState state);
 
-
   ///@}
-
   /// \name Utilities
   ///@{
 
   /// \brief Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
-  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false, bool bIncludePackageDeps = false) const;
+  void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, ezBitflags<ezDependencyFlags> dependencyTypes) const;
+  /// \brief Copies each value of deps into out_SettingsHashMap and fills the value of assets with the hash value of the dependencyType. For files, the file hash is used.
+  void GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_SettingsHashMap) const;
 
   /// \brief Generates one inverse transitive hull for all the types dependencies that are enabled. The set will contain inverse dependencies that can reach the given asset (pAssetInfo) via any combination of the enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.
   void GenerateInverseTransitiveHull(const ezAssetInfo* pAssetInfo, ezSet<ezUuid>& inout_inverseDeps, bool bIncludeTransformDeps = false, bool bIncludeThumbnailDeps = false) const;
@@ -397,7 +396,7 @@ private:
   /// \name Asset Hashing and Status Updates (AssetUpdates.cpp)
   ///@{
 
-  bool AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce);
+  bool AddAssetHash(ezString& sPath, ezBitflags<ezDependencyFlags> dependencyType, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce);
   ezAssetInfo::TransformState HashAsset(ezUInt64 uiSettingsHash, const ezHybridArray<ezString, 16>& assetTransformDeps, const ezHybridArray<ezString, 16>& assetThumbnailDeps, const ezHybridArray<ezString, 16>& assetPackageDeps, ezSet<ezString>& missingTransformDeps, ezSet<ezString>& missingThumbnailDeps, ezSet<ezString>& missingPackageDeps, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce);
 
   ezResult EnsureAssetInfoUpdated(const ezDataDirPath& absFilePath, const ezFileStatus& stat, bool bForce = false);
@@ -442,7 +441,7 @@ public:
 private:
   friend class ezUpdateTask;
   friend class ezAssetProcessor;
-  friend class ezProcessTask;
+  friend class ezEditorProcessorProcess;
 
   mutable ezCuratorMutex m_CuratorMutex; // Global lock
   ezTaskGroupID m_InitializeCuratorTaskID;

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -34,12 +34,12 @@ struct ezAssetProcessorEvent
   enum class Type
   {
     AssetProcessorStateChanged, ///< ezAssetProcessor::GetProcessorState changed
-    ProcessStateChanged, ///< ezAssetProcessor::GetProcessState changed
+    ProcessStateChanged,        ///< ezAssetProcessor::GetProcessState changed
   };
 
   Type m_Type;
   ezUInt8 m_uiProcessCount = 0; ///< Total number of processes. Only valid if ProcessorStateChanged.
-  ezUInt8 m_uiProcessorID = 0; ///< The changed process index. Only valid if ProcessStateChanged.
+  ezUInt8 m_uiProcessorID = 0;  ///< The changed process index. Only valid if ProcessStateChanged.
 };
 
 /// \brief Event type used by ezAssetProcessor::m_ProgressEvents

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -28,21 +28,44 @@ public:
   ezLoggingEvent m_LoggingEvent;
 };
 
+/// \brief Event type used by ezAssetProcessor::m_Events
 struct ezAssetProcessorEvent
 {
   enum class Type
   {
-    ProcessTaskStateChanged
+    AssetProcessorStateChanged, ///< ezAssetProcessor::GetProcessorState changed
+    ProcessStateChanged, ///< ezAssetProcessor::GetProcessState changed
   };
 
   Type m_Type;
+  ezUInt8 m_uiProcessCount = 0; ///< Total number of processes. Only valid if ProcessorStateChanged.
+  ezUInt8 m_uiProcessorID = 0; ///< The changed process index. Only valid if ProcessStateChanged.
 };
 
+/// \brief Event type used by ezAssetProcessor::m_ProgressEvents
+struct ezAssetProcessorProgressEvent
+{
+  enum class Type : ezUInt8
+  {
+    ProcessingStarted, ///< A process started working on an asset
+    ProcessingFinished ///< A process finished working on an asset
+  };
 
-class ezProcessThread : public ezThread
+  Type m_Type;
+  ezAssetInfo::TransformState m_TransformState = ezAssetInfo::Unknown;
+  ezUInt8 m_uiProcessorID;
+  ezUuid m_AssetGuid;
+  ezString m_sAssetPath;
+  ezTime m_StartTime;
+  ezTime m_EndTime;
+  ezTransformStatus m_Result; ///< Only valid when m_Type == ProcessingFinished
+};
+
+/// \brief Thread used by ezAssetProcessor to schedule work items on the ezEditorProcessorProcess instances.
+class ezAssetProcessorThread : public ezThread
 {
 public:
-  ezProcessThread()
+  ezAssetProcessorThread()
     : ezThread("ezProcessThread")
   {
   }
@@ -51,7 +74,8 @@ public:
   virtual ezUInt32 Run() override;
 };
 
-class ezProcessTask
+/// \brief Encapsulates one ezEditorProcessor process managed by ezAssetProcessor.
+class ezEditorProcessorProcess
 {
 public:
   enum class State
@@ -64,50 +88,62 @@ public:
   };
 
 public:
-  ezProcessTask();
-  ~ezProcessTask();
+  ezEditorProcessorProcess();
+  ~ezEditorProcessorProcess();
 
   ezUInt32 m_uiProcessorID;
+  ezTime m_ProcessingStartTime;
 
   bool Tick(bool bStartNewWork); // returns false, if all processing is done, otherwise call Tick again.
 
-  bool IsConnected();
-
+  bool IsConnected() const;
+  bool IsRunning() const;
+  ezOsProcessID GetProcessId() const;
   bool HasProcessCrashed();
+  void HandleHashMissmatch();
 
   ezResult StartProcess();
-
   void ShutdownProcess();
 
 private:
   void EventHandlerIPC(const ezProcessCommunicationChannel::Event& e);
 
-  bool GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, ezDataDirPath& out_path);
-  bool GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_path);
+  bool GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState);
+  bool GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState);
   void OnProcessCrashed(ezStringView message);
 
-
+private:
   State m_State = State::LookingForWork;
+  ezEditorProcessCommunicationChannel* m_pIPC;
+  bool m_bProcessShouldBeRunning = false;
+
+  // New asset to process
   ezUuid m_AssetGuid;
+  ezDataDirPath m_AssetPath;
+  ezAssetInfo::TransformState m_TransformState = ezAssetInfo::TransformState::Unknown;
+  ezString m_sPlatform;
   ezUInt64 m_uiAssetHash = 0;
   ezUInt64 m_uiThumbHash = 0;
   ezUInt64 m_uiPackageHash = 0;
-  ezDataDirPath m_AssetPath;
-  ezEditorProcessCommunicationChannel* m_pIPC;
-  bool m_bProcessShouldBeRunning = false;
+  ezDynamicArray<ezString> m_TransitiveHull;
+
+  // Transform result
   ezTransformStatus m_Status;
   ezDynamicArray<ezLogEntry> m_LogEntries;
-  ezDynamicArray<ezString> m_TransitiveHull;
+  ezMap<ezString, ezUInt64> m_MissmatchTransformDependencies;
+  ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies;
+  ezUInt64 m_MissmatchAssetHash = 0;
+  ezUInt64 m_MissmatchThumbHash = 0;
 };
 
 /// \brief Background asset processing is handled by this class.
-/// Creates EditorProcessor processes.
+/// Creates ezEditorProcessor processes which are managed by the ezEditorProcessorProcess class.
 class EZ_EDITORFRAMEWORK_DLL ezAssetProcessor
 {
   EZ_DECLARE_SINGLETON(ezAssetProcessor);
 
 public:
-  enum class ProcessTaskState : ezUInt8
+  enum class ProcessorState : ezUInt8
   {
     Stopped,  ///< No EditorProcessor or the process thread is running.
     Running,  ///< Everything is active.
@@ -120,23 +156,33 @@ public:
   // used to temporarily not process assets, usually because currently assets get imported
   ezAtomicInteger32 m_iPauseProcessing;
 
-  void StartProcessTask();
-  void StopProcessTask(bool bForce);
-  ProcessTaskState GetProcessTaskState() const
+  void StartProcessor();
+  void StopProcessor(bool bForce);
+
+  /// \brief Returns whether the asset processor is running, stopped or stopping.
+  ProcessorState GetProcessorState() const
   {
-    return m_ProcessTaskState;
+    return m_ProcessorState;
   }
+
+  /// \brief Returns how many ezEditorProcessor processes are managed by the ezAssetProcessor.
+  ezUInt32 GetProcessCount() const;
+  /// \brief Returns the state of one of the ezEditorProcessor processes.
+  /// \param uiProcessIndex The index of the process. Must be smaller than GetProcessCount.
+  ezEditorProcessorState GetProcessState(ezUInt32 uiProcessIndex) const;
 
   void AddLogWriter(ezLoggingEvent::Handler handler);
   void RemoveLogWriter(ezLoggingEvent::Handler handler);
+  void UpdateProcessStates();
 
 public:
   // Can be called from worker threads!
-  ezEvent<const ezAssetProcessorEvent&> m_Events;
+  ezCopyOnBroadcastEvent<const ezAssetProcessorEvent&, ezMutex> m_Events;
+  ezCopyOnBroadcastEvent<const ezAssetProcessorProgressEvent&, ezMutex> m_ProgressEvents;
 
 private:
-  friend class ezProcessTask;
-  friend class ezProcessThread;
+  friend class ezEditorProcessorProcess;
+  friend class ezAssetProcessorThread;
   friend class ezAssetCurator;
 
   void Run();
@@ -145,13 +191,14 @@ private:
   ezAssetProcessorLog m_CuratorLog;
 
   // Process thread and its state
-  ezUniquePtr<ezProcessThread> m_pThread;
+  ezUniquePtr<ezAssetProcessorThread> m_pThread;
   std::atomic<bool> m_bForceStop = false; ///< If set, background processes will be killed when stopping without waiting for their current task to finish.
 
   // Locks writes to m_ProcessTaskState to make sure the state machine does not go from running to stopped before having fired stopping.
   mutable ezMutex m_ProcessorMutex;
-  std::atomic<ProcessTaskState> m_ProcessTaskState = ProcessTaskState::Stopped;
+  std::atomic<ProcessorState> m_ProcessorState = ProcessorState::Stopped;
+  ezDynamicArray<ezEditorProcessorState> m_EditorProcessorStates;
 
   // Data owned by the process thread.
-  ezDynamicArray<ezProcessTask> m_ProcessTasks;
+  ezDynamicArray<ezEditorProcessorProcess> m_Processes;
 };

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -133,8 +133,8 @@ private:
   ezDynamicArray<ezLogEntry> m_LogEntries;
   ezMap<ezString, ezUInt64> m_MissmatchTransformDependencies;
   ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies;
-  ezUInt64 m_MissmatchAssetHash = 0;
-  ezUInt64 m_MissmatchThumbHash = 0;
+  ezUInt64 m_uiMissmatchAssetHash = 0;
+  ezUInt64 m_uiMissmatchThumbHash = 0;
 };
 
 /// \brief Background asset processing is handled by this class.

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/Declarations.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <EditorFramework/IPC/EditorProcessCommunicationChannel.h>

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -31,8 +31,8 @@ public:
   // If the fields below are used, the ezEditorProcessor detected a hash missmatch between the editor and its own state. It will send over its own state so the editor can detect differences. See ezEditorProcessorProcess::HandleHashMissmatch.
   mutable ezMap<ezString, ezUInt64> m_MissmatchTransformDependencies; ///< Hashes of all transform dependencies.
   mutable ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies; ///< Hashes of all thumbnail dependencies.
-  ezUInt64 m_MissmatchAssetHash = 0; ///< Transform hash observed by the ezEditorProcessor.
-  ezUInt64 m_MissmatchThumbHash = 0; ///< Thumbnail hash observed by the ezEditorProcessor.
+  ezUInt64 m_MissmatchAssetHash = 0;                                  ///< Transform hash observed by the ezEditorProcessor.
+  ezUInt64 m_MissmatchThumbHash = 0;                                  ///< Thumbnail hash observed by the ezEditorProcessor.
 };
 
 class EZ_EDITORFRAMEWORK_DLL ezFreeAllResourcesMsg : public ezProcessMessage

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -27,6 +27,12 @@ class EZ_EDITORFRAMEWORK_DLL ezProcessAssetResponseMsg : public ezProcessMessage
 public:
   ezTransformStatus m_Status;
   mutable ezDynamicArray<ezLogEntry> m_LogEntries;
+
+  // If the fields below are used, the ezEditorProcessor detected a hash missmatch between the editor and its own state. It will send over its own state so the editor can detect differences. See ezEditorProcessorProcess::HandleHashMissmatch.
+  mutable ezMap<ezString, ezUInt64> m_MissmatchTransformDependencies; ///< Hashes of all transform dependencies.
+  mutable ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies; ///< Hashes of all thumbnail dependencies.
+  ezUInt64 m_MissmatchAssetHash = 0; ///< Transform hash observed by the ezEditorProcessor.
+  ezUInt64 m_MissmatchThumbHash = 0; ///< Thumbnail hash observed by the ezEditorProcessor.
 };
 
 class EZ_EDITORFRAMEWORK_DLL ezFreeAllResourcesMsg : public ezProcessMessage

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -31,8 +31,8 @@ public:
   // If the fields below are used, the ezEditorProcessor detected a hash missmatch between the editor and its own state. It will send over its own state so the editor can detect differences. See ezEditorProcessorProcess::HandleHashMissmatch.
   mutable ezMap<ezString, ezUInt64> m_MissmatchTransformDependencies; ///< Hashes of all transform dependencies.
   mutable ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies; ///< Hashes of all thumbnail dependencies.
-  ezUInt64 m_MissmatchAssetHash = 0;                                  ///< Transform hash observed by the ezEditorProcessor.
-  ezUInt64 m_MissmatchThumbHash = 0;                                  ///< Thumbnail hash observed by the ezEditorProcessor.
+  ezUInt64 m_uiMissmatchAssetHash = 0;                                  ///< Transform hash observed by the ezEditorProcessor.
+  ezUInt64 m_uiMissmatchThumbHash = 0;                                  ///< Thumbnail hash observed by the ezEditorProcessor.
 };
 
 class EZ_EDITORFRAMEWORK_DLL ezFreeAllResourcesMsg : public ezProcessMessage

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -31,8 +31,8 @@ public:
   // If the fields below are used, the ezEditorProcessor detected a hash missmatch between the editor and its own state. It will send over its own state so the editor can detect differences. See ezEditorProcessorProcess::HandleHashMissmatch.
   mutable ezMap<ezString, ezUInt64> m_MissmatchTransformDependencies; ///< Hashes of all transform dependencies.
   mutable ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies; ///< Hashes of all thumbnail dependencies.
-  ezUInt64 m_uiMissmatchAssetHash = 0;                                  ///< Transform hash observed by the ezEditorProcessor.
-  ezUInt64 m_uiMissmatchThumbHash = 0;                                  ///< Thumbnail hash observed by the ezEditorProcessor.
+  ezUInt64 m_uiMissmatchAssetHash = 0;                                ///< Transform hash observed by the ezEditorProcessor.
+  ezUInt64 m_uiMissmatchThumbHash = 0;                                ///< Thumbnail hash observed by the ezEditorProcessor.
 };
 
 class EZ_EDITORFRAMEWORK_DLL ezFreeAllResourcesMsg : public ezProcessMessage

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -194,5 +194,5 @@ struct ezEditorProcessorState
 
   ezOsProcessID m_uiProcessID = 0;
   bool m_bConnected = false; ///< The IPC pipe to the process is established.
-  bool m_bRunning = false; ///< The process is currently running working on an asset.
+  bool m_bRunning = false;   ///< The process is currently running working on an asset.
 };

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -11,6 +11,7 @@
 
 class ezImage;
 class ezAssetFileHeader;
+using ezOsProcessID = ezUInt32;
 
 struct ezAssetExistanceState
 {
@@ -177,3 +178,21 @@ EZ_ALWAYS_INLINE ezResult ezToResult(const ezTransformStatus& result)
 {
   return result.m_Result == ezTransformResult::Success ? EZ_SUCCESS : EZ_FAILURE;
 }
+
+/// \brief Used by ezEditorProcessorProcess to define the current state of one of the running ezEditorProcessor processes managed by the ezAssetProcessor.
+/// \sa ezAssetProcessor
+struct ezEditorProcessorState
+{
+  bool operator==(const ezEditorProcessorState& rhs)
+  {
+    return m_uiProcessID == rhs.m_uiProcessID && m_bConnected == rhs.m_bConnected && m_bRunning == rhs.m_bRunning;
+  }
+  bool operator!=(const ezEditorProcessorState& rhs)
+  {
+    return !(*this == rhs);
+  }
+
+  ezOsProcessID m_uiProcessID = 0;
+  bool m_bConnected = false; ///< The IPC pipe to the process is established.
+  bool m_bRunning = false; ///< The process is currently running working on an asset.
+};

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -1320,7 +1320,7 @@ void ezQtAssetBrowserWidget::OnExportAssetWithDependencies()
     return;
 
   ezStringBuilder sDestPath = sDestination.toUtf8().data();
-  ezAssetCurator::ExportResult result = pCurator->ExportAssets(sources, sDestPath, true, true, true);
+  ezAssetCurator::ExportResult result = pCurator->ExportAssets(sources, sDestPath, ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail | ezDependencyFlags::Package);
 
   ezStringBuilder sMessage;
   sMessage.SetFormat("Export completed.\n\nCopied {} file(s).", result.m_uiCopiedFiles);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1516,7 +1516,7 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
   ezDGMLGraphWriter::WriteGraphToFile(sOutputFile, graph).IgnoreResult();
 }
 
-ezAssetCurator::ExportResult ezAssetCurator::ExportAssets(ezArrayPtr<ezString> sources, ezStringView sDestinationFolder, bool bIncludeTransformDeps, bool bIncludeThumbnailDeps, bool bIncludePackageDeps) const
+ezAssetCurator::ExportResult ezAssetCurator::ExportAssets(ezArrayPtr<ezString> sources, ezStringView sDestinationFolder, ezBitflags<ezDependencyFlags> includeDependencyTypes) const
 {
   EZ_LOCK(m_CuratorMutex);
 
@@ -1526,7 +1526,7 @@ ezAssetCurator::ExportResult ezAssetCurator::ExportAssets(ezArrayPtr<ezString> s
 
   for (const ezString& source : sources)
   {
-    GenerateTransitiveHull(source, allDependencies, bIncludeTransformDeps, bIncludeThumbnailDeps, bIncludePackageDeps);
+    GenerateTransitiveHull(source, allDependencies, includeDependencyTypes);
   }
 
   ezStringBuilder sDestPath = sDestinationFolder;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1323,7 +1323,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
   }
 }
 
-void ezAssetCurator::GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_SettingsHashMap) const
+void ezAssetCurator::GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_settingsHashMap) const
 {
   EZ_LOCK(m_CuratorMutex);
 
@@ -1368,7 +1368,7 @@ void ezAssetCurator::GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitf
         uiAssetHash = 2;
       }
     }
-    out_SettingsHashMap.Insert(sDepOrRef, uiAssetHash);
+    out_settingsHashMap.Insert(sDepOrRef, uiAssetHash);
   }
 }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -205,7 +205,7 @@ void ezAssetCurator::Deinitialize()
   SaveAssetProfiles().IgnoreResult();
 
   ShutdownUpdateTask();
-  ezAssetProcessor::GetSingleton()->StopProcessTask(true);
+  ezAssetProcessor::GetSingleton()->StopProcessor(true);
   ezFileSystemModel* pFiles = ezFileSystemModel::GetSingleton();
   ezFileSystemModel::FilesMap referencedFiles;
   ezFileSystemModel::FoldersMap referencedFolders;
@@ -775,7 +775,7 @@ const ezAssetCurator::ezLockedAssetTable ezAssetCurator::GetKnownAssets() const
   return ezLockedAssetTable(m_CuratorMutex, &m_KnownAssets);
 }
 
-ezUInt64 ezAssetCurator::GetAssetDependencyHash(ezUuid assetGuid)
+ezUInt64 ezAssetCurator::GetAssetTransformHash(ezUuid assetGuid)
 {
   ezUInt64 assetHash = 0;
   ezUInt64 thumbHash = 0;
@@ -784,7 +784,7 @@ ezUInt64 ezAssetCurator::GetAssetDependencyHash(ezUuid assetGuid)
   return assetHash;
 }
 
-ezUInt64 ezAssetCurator::GetAssetReferenceHash(ezUuid assetGuid)
+ezUInt64 ezAssetCurator::GetAssetThumbnailHash(ezUuid assetGuid)
 {
   ezUInt64 assetHash = 0;
   ezUInt64 packageHash = 0;
@@ -1232,7 +1232,7 @@ void ezAssetCurator::CheckFileSystem()
   ezLog::Debug("Asset Curator Refresh Time: {0} ms", ezArgF(sw.GetRunningTotal().GetMilliseconds(), 3));
 }
 
-void ezAssetCurator::NeedsReloadResources(const ezUuid& assetGuid)
+void ezAssetCurator::NeedsReloadResources(const ezUuid& assetGuid) const
 {
   if (m_pAssetTableWriter)
   {
@@ -1249,13 +1249,32 @@ void ezAssetCurator::NeedsReloadResources(const ezUuid& assetGuid)
   }
 }
 
-void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, bool bIncludeTransformDeps, bool bIncludeThumbnailDeps, bool bIncludePackageDeps) const
+void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, ezBitflags<ezDependencyFlags> dependencyTypes) const
 {
   EZ_LOCK(m_CuratorMutex);
 
   ezHybridArray<ezString, 6> toDoList;
-  inout_deps.Insert(sAssetOrPath);
-  toDoList.PushBack(sAssetOrPath);
+  if (ezConversionUtils::IsStringUuid(sAssetOrPath))
+  {
+    inout_deps.Insert(sAssetOrPath);
+    toDoList.PushBack(sAssetOrPath);
+  }
+  else
+  {
+    auto subAsset = FindSubAsset(sAssetOrPath);
+    if (subAsset.isValid())
+    {
+      ezStringBuilder sTmp;
+      ezConversionUtils::ToString(subAsset->m_pAssetInfo->m_Info->m_DocumentID, sTmp);
+      inout_deps.Insert(sTmp);
+      toDoList.PushBack(sTmp);
+    }
+    else
+    {
+      inout_deps.Insert(sAssetOrPath);
+      toDoList.PushBack(sAssetOrPath);
+    }
+  }
 
   while (!toDoList.IsEmpty())
   {
@@ -1267,7 +1286,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
       auto it = m_KnownSubAssets.Find(ezConversionUtils::ConvertStringToUuid(currentAsset));
       ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
 
-      if (bIncludeTransformDeps)
+      if (dependencyTypes.IsSet(ezDependencyFlags::Transform))
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_TransformDependencies)
         {
@@ -1278,7 +1297,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
           }
         }
       }
-      if (bIncludeThumbnailDeps)
+      if (dependencyTypes.IsSet(ezDependencyFlags::Thumbnail))
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_ThumbnailDependencies)
         {
@@ -1289,7 +1308,7 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
           }
         }
       }
-      if (bIncludePackageDeps)
+      if (dependencyTypes.IsSet(ezDependencyFlags::Package))
       {
         for (const ezString& dep : pAssetInfo->m_Info->m_PackageDependencies)
         {
@@ -1301,6 +1320,55 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
         }
       }
     }
+  }
+}
+
+void ezAssetCurator::GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_SettingsHashMap) const
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  for (const ezString& sDepOrRef : deps)
+  {
+    ezUInt64 uiAssetHash = 0;
+    if (ezConversionUtils::IsStringUuid(sDepOrRef))
+    {
+      auto it = m_KnownAssets.Find(ezConversionUtils::ConvertStringToUuid(sDepOrRef));
+      if (it.IsValid())
+      {
+        for (ezDependencyFlags::Enum dep : dependencyType)
+        {
+          switch (dep)
+          {
+            case ezDependencyFlags::Thumbnail:
+              uiAssetHash = it.Value()->m_ThumbHash;
+              break;
+            case ezDependencyFlags::Transform:
+              uiAssetHash = it.Value()->m_AssetHash;
+              break;
+            case ezDependencyFlags::Package:
+              uiAssetHash = it.Value()->m_PackageHash;
+              break;
+            default:
+              break;
+          }
+        }
+      }
+    }
+    else
+    {
+      ezStringBuilder sTmp = sDepOrRef;
+      if (ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sTmp))
+      {
+        ezFileStatus fileStatus;
+        ezResult res = ezFileSystemModel::GetSingleton()->HashFile(sTmp, fileStatus);
+        uiAssetHash = res.Failed() ? 1 : fileStatus.m_uiHash;
+      }
+      else
+      {
+        uiAssetHash = 2;
+      }
+    }
+    out_SettingsHashMap.Insert(sDepOrRef, uiAssetHash);
   }
 }
 
@@ -1365,7 +1433,7 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
 
   ezSet<ezString> deps;
   ezStringBuilder sTemp;
-  GenerateTransitiveHull(ezConversionUtils::ToString(guid, sTemp), deps, true, true);
+  GenerateTransitiveHull(ezConversionUtils::ToString(guid, sTemp), deps, ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail);
 
   ezHashTable<ezString, ezUInt32> nodeMap;
   nodeMap.Reserve(deps.GetCount());
@@ -2223,12 +2291,12 @@ void ezAssetCurator::SaveCaches(const ezFileSystemModel::FilesMap& referencedFil
 
 void ezAssetCurator::ClearAssetCaches(ezAssetDocumentManager::OutputReliability threshold)
 {
-  const bool bWasRunning = ezAssetProcessor::GetSingleton()->GetProcessTaskState() == ezAssetProcessor::ProcessTaskState::Running;
+  const bool bWasRunning = ezAssetProcessor::GetSingleton()->GetProcessorState() == ezAssetProcessor::ProcessorState::Running;
 
   if (bWasRunning)
   {
     // pause background asset processing while we delete files
-    ezAssetProcessor::GetSingleton()->StopProcessTask(true);
+    ezAssetProcessor::GetSingleton()->StopProcessor(true);
   }
 
   {
@@ -2295,6 +2363,6 @@ void ezAssetCurator::ClearAssetCaches(ezAssetDocumentManager::OutputReliability 
   if (bWasRunning)
   {
     // restart background asset processing
-    ezAssetProcessor::GetSingleton()->StartProcessTask();
+    ezAssetProcessor::GetSingleton()->StartProcessor();
   }
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -252,7 +252,7 @@ void ezAssetProcessor::Run()
     m_bForceStop = false;
   }
 
-  for (ezUInt8 uiProcessId = 0 ; uiProcessId < uiProcesses; uiProcessId++)
+  for (ezUInt8 uiProcessId = 0; uiProcessId < uiProcesses; uiProcessId++)
   {
     ezAssetProcessorEvent e;
     e.m_Type = ezAssetProcessorEvent::Type::ProcessStateChanged;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -77,13 +77,13 @@ ezAssetProcessor::~ezAssetProcessor()
     m_pThread->Join();
     m_pThread.Clear();
   }
-  EZ_ASSERT_DEV(m_ProcessTaskState == ProcessTaskState::Stopped, "Call StopProcessTask first before destroying the ezAssetProcessor.");
+  EZ_ASSERT_DEV(m_ProcessorState == ProcessorState::Stopped, "Call StopProcessor first before destroying the ezAssetProcessor.");
 }
 
-void ezAssetProcessor::StartProcessTask()
+void ezAssetProcessor::StartProcessor()
 {
   EZ_LOCK(m_ProcessorMutex);
-  if (m_ProcessTaskState != ProcessTaskState::Stopped)
+  if (m_ProcessorState != ProcessorState::Stopped)
   {
     return;
   }
@@ -95,50 +95,53 @@ void ezAssetProcessor::StartProcessTask()
     m_pThread.Clear();
   }
 
-  m_ProcessTaskState = ProcessTaskState::Running;
+  m_ProcessorState = ProcessorState::Running;
 
   ezEditorPreferencesUser* pPreferences = ezPreferences::QueryPreferences<ezEditorPreferencesUser>();
 
   const ezUInt32 uiWorkerCount = ezMath::Min<ezUInt32>(ezTaskSystem::GetWorkerThreadCount(ezWorkerThreadType::LongTasks), pPreferences->m_uiMaxAssetProcessors);
-  m_ProcessTasks.SetCount(uiWorkerCount);
+  m_Processes.SetCount(uiWorkerCount);
+  m_EditorProcessorStates.SetCount(uiWorkerCount);
 
   for (ezUInt32 idx = 0; idx < uiWorkerCount; ++idx)
   {
-    m_ProcessTasks[idx].m_uiProcessorID = idx;
+    m_Processes[idx].m_uiProcessorID = idx;
   }
 
-  m_pThread = EZ_DEFAULT_NEW(ezProcessThread);
+  m_pThread = EZ_DEFAULT_NEW(ezAssetProcessorThread);
   m_pThread->Start();
 
   {
     ezAssetProcessorEvent e;
-    e.m_Type = ezAssetProcessorEvent::Type::ProcessTaskStateChanged;
+    e.m_Type = ezAssetProcessorEvent::Type::AssetProcessorStateChanged;
+    e.m_uiProcessCount = m_EditorProcessorStates.GetCount();
     m_Events.Broadcast(e);
   }
 }
 
-void ezAssetProcessor::StopProcessTask(bool bForce)
+void ezAssetProcessor::StopProcessor(bool bForce)
 {
   {
     EZ_LOCK(m_ProcessorMutex);
-    switch (m_ProcessTaskState)
+    switch (m_ProcessorState)
     {
-      case ProcessTaskState::Running:
+      case ProcessorState::Running:
       {
-        m_ProcessTaskState = ProcessTaskState::Stopping;
+        m_ProcessorState = ProcessorState::Stopping;
         {
           ezAssetProcessorEvent e;
-          e.m_Type = ezAssetProcessorEvent::Type::ProcessTaskStateChanged;
+          e.m_Type = ezAssetProcessorEvent::Type::AssetProcessorStateChanged;
+          e.m_uiProcessCount = m_EditorProcessorStates.GetCount();
           m_Events.Broadcast(e);
         }
       }
       break;
-      case ProcessTaskState::Stopping:
+      case ProcessorState::Stopping:
         if (!bForce)
           return;
         break;
       default:
-      case ProcessTaskState::Stopped:
+      case ProcessorState::Stopped:
         return;
     }
   }
@@ -148,8 +151,24 @@ void ezAssetProcessor::StopProcessTask(bool bForce)
     m_bForceStop = true;
     m_pThread->Join();
     m_pThread.Clear();
-    EZ_ASSERT_DEV(m_ProcessTaskState == ProcessTaskState::Stopped, "Process task shoul have set the state to stopped.");
+    EZ_ASSERT_DEV(m_ProcessorState == ProcessorState::Stopped, "Process task shoul have set the state to stopped.");
   }
+}
+
+ezUInt32 ezAssetProcessor::GetProcessCount() const
+{
+  EZ_LOCK(m_ProcessorMutex);
+  return m_EditorProcessorStates.GetCount();
+}
+
+ezEditorProcessorState ezAssetProcessor::GetProcessState(ezUInt32 uiProcessIndex) const
+{
+  EZ_LOCK(m_ProcessorMutex);
+  if (uiProcessIndex < m_EditorProcessorStates.GetCount())
+  {
+    return m_EditorProcessorStates[uiProcessIndex];
+  }
+  return {};
 }
 
 void ezAssetProcessor::AddLogWriter(ezLoggingEvent::Handler handler)
@@ -162,18 +181,46 @@ void ezAssetProcessor::RemoveLogWriter(ezLoggingEvent::Handler handler)
   m_CuratorLog.RemoveLogWriter(handler);
 }
 
+void ezAssetProcessor::UpdateProcessStates()
+{
+  ezHybridArray<ezUInt8, 8> changedProcesses;
+  {
+    EZ_LOCK(m_ProcessorMutex);
+    for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
+    {
+      ezEditorProcessorState state;
+      state.m_bConnected = m_Processes[i].IsConnected();
+      state.m_bRunning = m_Processes[i].IsRunning();
+      state.m_uiProcessID = m_Processes[i].GetProcessId();
+
+      if (m_EditorProcessorStates[i] != state)
+      {
+        m_EditorProcessorStates[i] = state;
+        changedProcesses.PushBack(i);
+      }
+    }
+  }
+  for (ezUInt8 uiProcessId : changedProcesses)
+  {
+    ezAssetProcessorEvent e;
+    e.m_Type = ezAssetProcessorEvent::Type::ProcessStateChanged;
+    e.m_uiProcessorID = uiProcessId;
+    m_Events.Broadcast(e);
+  }
+}
+
 void ezAssetProcessor::Run()
 {
-  while (m_ProcessTaskState == ProcessTaskState::Running)
+  while (m_ProcessorState == ProcessorState::Running)
   {
     if (m_iPauseProcessing == 0)
     {
-      for (ezUInt32 i = 0; i < m_ProcessTasks.GetCount(); i++)
+      for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
       {
-        m_ProcessTasks[i].Tick(true);
+        m_Processes[i].Tick(true);
       }
+      UpdateProcessStates();
     }
-
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
   }
 
@@ -181,12 +228,12 @@ void ezAssetProcessor::Run()
   {
     bool bAnyRunning = false;
 
-    for (ezUInt32 i = 0; i < m_ProcessTasks.GetCount(); i++)
+    for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
     {
       if (m_bForceStop)
-        m_ProcessTasks[i].ShutdownProcess();
+        m_Processes[i].ShutdownProcess();
 
-      bAnyRunning |= m_ProcessTasks[i].Tick(false);
+      bAnyRunning |= m_Processes[i].Tick(false);
     }
 
     if (bAnyRunning)
@@ -195,13 +242,28 @@ void ezAssetProcessor::Run()
       break;
   }
 
-  EZ_LOCK(m_ProcessorMutex);
-  m_ProcessTasks.Clear();
-  m_ProcessTaskState = ProcessTaskState::Stopped;
-  m_bForceStop = false;
+  ezUInt32 uiProcesses = 0;
+  {
+    EZ_LOCK(m_ProcessorMutex);
+    uiProcesses = m_Processes.GetCount();
+    m_Processes.Clear();
+    m_EditorProcessorStates.Clear();
+    m_ProcessorState = ProcessorState::Stopped;
+    m_bForceStop = false;
+  }
+
+  for (ezUInt8 uiProcessId = 0 ; uiProcessId < uiProcesses; uiProcessId++)
   {
     ezAssetProcessorEvent e;
-    e.m_Type = ezAssetProcessorEvent::Type::ProcessTaskStateChanged;
+    e.m_Type = ezAssetProcessorEvent::Type::ProcessStateChanged;
+    e.m_uiProcessorID = uiProcessId;
+    m_Events.Broadcast(e);
+  }
+
+  {
+    ezAssetProcessorEvent e;
+    e.m_Type = ezAssetProcessorEvent::Type::AssetProcessorStateChanged;
+    e.m_uiProcessCount = m_EditorProcessorStates.GetCount();
     m_Events.Broadcast(e);
   }
 }
@@ -211,22 +273,22 @@ void ezAssetProcessor::Run()
 // ezProcessTask
 ////////////////////////////////////////////////////////////////////////
 
-ezProcessTask::ezProcessTask()
+ezEditorProcessorProcess::ezEditorProcessorProcess()
   : m_Status(EZ_SUCCESS)
 {
   m_pIPC = EZ_DEFAULT_NEW(ezEditorProcessCommunicationChannel);
-  m_pIPC->m_Events.AddEventHandler(ezMakeDelegate(&ezProcessTask::EventHandlerIPC, this));
+  m_pIPC->m_Events.AddEventHandler(ezMakeDelegate(&ezEditorProcessorProcess::EventHandlerIPC, this));
 }
 
-ezProcessTask::~ezProcessTask()
+ezEditorProcessorProcess::~ezEditorProcessorProcess()
 {
   ShutdownProcess();
-  m_pIPC->m_Events.RemoveEventHandler(ezMakeDelegate(&ezProcessTask::EventHandlerIPC, this));
+  m_pIPC->m_Events.RemoveEventHandler(ezMakeDelegate(&ezEditorProcessorProcess::EventHandlerIPC, this));
   EZ_DEFAULT_DELETE(m_pIPC);
 }
 
 
-ezResult ezProcessTask::StartProcess()
+ezResult ezEditorProcessorProcess::StartProcess()
 {
   const ezRTTI* pFirstAllowedMessageType = nullptr;
 
@@ -265,23 +327,27 @@ ezResult ezProcessTask::StartProcess()
   return EZ_SUCCESS;
 }
 
-void ezProcessTask::ShutdownProcess()
+void ezEditorProcessorProcess::ShutdownProcess()
 {
   m_pIPC->CloseConnection();
 }
 
-void ezProcessTask::EventHandlerIPC(const ezProcessCommunicationChannel::Event& e)
+void ezEditorProcessorProcess::EventHandlerIPC(const ezProcessCommunicationChannel::Event& e)
 {
   if (const ezProcessAssetResponseMsg* pMsg = ezDynamicCast<const ezProcessAssetResponseMsg*>(e.m_pMessage))
   {
     EZ_ASSERT_DEV(m_State == State::Processing, "Message handling should only happen when currently processing");
-    m_Status = pMsg->m_Status;
     m_State = State::ReportResult;
+    m_Status = pMsg->m_Status;
     m_LogEntries.Swap(pMsg->m_LogEntries);
+    m_MissmatchTransformDependencies.Swap(pMsg->m_MissmatchTransformDependencies);
+    m_MissmatchThumbnailDependencies.Swap(pMsg->m_MissmatchThumbnailDependencies);
+    m_MissmatchAssetHash = pMsg->m_MissmatchAssetHash;
+    m_MissmatchThumbHash = pMsg->m_MissmatchThumbHash;
   }
 }
 
-bool ezProcessTask::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, ezDataDirPath& out_path)
+bool ezEditorProcessorProcess::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState)
 {
   bool bComplete = true;
 
@@ -334,12 +400,12 @@ bool ezProcessTask::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, 
 
   if (ezAssetInfo* pDepInfo = TestFunc(pInfo->m_Info->m_TransformDependencies))
   {
-    return GetNextAssetToProcess(pDepInfo, out_guid, out_path);
+    return GetNextAssetToProcess(pDepInfo, out_guid, out_path, out_transformState);
   }
 
   if (ezAssetInfo* pDepInfo = TestFunc(pInfo->m_Info->m_ThumbnailDependencies))
   {
-    return GetNextAssetToProcess(pDepInfo, out_guid, out_path);
+    return GetNextAssetToProcess(pDepInfo, out_guid, out_path, out_transformState);
   }
 
   // not needed to go through package dependencies here
@@ -350,13 +416,14 @@ bool ezProcessTask::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, 
     ezAssetCurator::GetSingleton()->m_Updating.Insert(pInfo->m_Info->m_DocumentID);
     out_guid = pInfo->m_Info->m_DocumentID;
     out_path = pInfo->m_Path;
+    out_transformState = pInfo->m_TransformState;
     return true;
   }
 
   return false;
 }
 
-bool ezProcessTask::GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_path)
+bool ezEditorProcessorProcess::GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState)
 {
   EZ_LOCK(ezAssetCurator::GetSingleton()->m_CuratorMutex);
 
@@ -365,7 +432,7 @@ bool ezProcessTask::GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_p
     ezAssetInfo* pInfo = ezAssetCurator::GetSingleton()->GetAssetInfo(it.Key());
     if (pInfo)
     {
-      bool bRes = GetNextAssetToProcess(pInfo, out_guid, out_path);
+      bool bRes = GetNextAssetToProcess(pInfo, out_guid, out_path, out_transformState);
       if (bRes)
         return true;
     }
@@ -376,7 +443,7 @@ bool ezProcessTask::GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_p
     ezAssetInfo* pInfo = ezAssetCurator::GetSingleton()->GetAssetInfo(it.Key());
     if (pInfo)
     {
-      bool bRes = GetNextAssetToProcess(pInfo, out_guid, out_path);
+      bool bRes = GetNextAssetToProcess(pInfo, out_guid, out_path, out_transformState);
       if (bRes)
         return true;
     }
@@ -386,7 +453,7 @@ bool ezProcessTask::GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_p
 }
 
 
-void ezProcessTask::OnProcessCrashed(ezStringView message)
+void ezEditorProcessorProcess::OnProcessCrashed(ezStringView message)
 {
   ShutdownProcess();
   m_Status = ezStatus(message);
@@ -396,17 +463,112 @@ void ezProcessTask::OnProcessCrashed(ezStringView message)
   ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, message);
 }
 
-bool ezProcessTask::IsConnected()
+bool ezEditorProcessorProcess::IsConnected() const
 {
   return m_pIPC->IsConnected();
 }
 
-bool ezProcessTask::HasProcessCrashed()
+bool ezEditorProcessorProcess::IsRunning() const
+{
+  return m_State == State::Processing;
+}
+
+ezOsProcessID ezEditorProcessorProcess::GetProcessId() const
+{
+  if (m_pIPC)
+  {
+    return m_pIPC->GetProcessId();
+  }
+  return {};
+}
+
+bool ezEditorProcessorProcess::HasProcessCrashed()
 {
   return m_pIPC->IsClientAlive();
 }
 
-bool ezProcessTask::Tick(bool bStartNewWork)
+void ezEditorProcessorProcess::HandleHashMissmatch()
+{
+  EZ_SCOPE_EXIT(
+    {
+      m_MissmatchTransformDependencies.Clear();
+      m_MissmatchThumbnailDependencies.Clear();
+      m_MissmatchAssetHash = 0;
+      m_MissmatchThumbHash = 0;
+    });
+
+  ezUInt64 uiAssetHash = 0;
+  ezUInt64 uiThumbHash = 0;
+  ezUInt64 uiPackageHash = 0;
+  ezMap<ezString, ezUInt64> TransformDependencies;
+  ezMap<ezString, ezUInt64> ThumbnailDependencies;
+  {
+    // Check the asset hash again but force evaluation to detect cases where the file system watcher did not trigger.
+    const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(m_sPlatform);
+    ezAssetCurator::GetSingleton()->IsAssetUpToDate(m_AssetGuid, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, uiPackageHash, true);
+    if ((uiAssetHash == m_MissmatchAssetHash) || (uiThumbHash == m_MissmatchThumbHash))
+    {
+      // The newly computed hash now matches the one computed by the ezEditorProcessor.
+      return;
+    }
+
+    ezSet<ezString> dependencies;
+    ezAssetCurator::GetSingleton()->GenerateTransitiveHull(m_AssetPath.GetAbsolutePath(), dependencies, ezDependencyFlags::Transform);
+    ezAssetCurator::GetSingleton()->GenerateSettingsHashMap(dependencies, ezDependencyFlags::Transform, TransformDependencies);
+
+    dependencies.Clear();
+    ezAssetCurator::GetSingleton()->GenerateTransitiveHull(m_AssetPath.GetAbsolutePath(), dependencies, ezDependencyFlags::Thumbnail);
+    ezAssetCurator::GetSingleton()->GenerateSettingsHashMap(dependencies, ezDependencyFlags::Thumbnail, ThumbnailDependencies);
+  }
+
+  auto AddLogMessage = [&](ezStringView sMsg)
+  {
+    ezLogEntry le;
+    le.m_sMsg = sMsg;
+    le.m_Type = ezLogMsgType::WarningMsg;
+    m_LogEntries.PushBack(le);
+  };
+
+  auto CompareDependencies = [&](const ezMap<ezString, ezUInt64>& dependencies, const ezMap<ezString, ezUInt64>& missmatchDependencies, ezStringView sDependencyType)
+  {
+    ezStringBuilder sMsg;
+    for (auto it = TransformDependencies.GetIterator(); it.IsValid(); ++it)
+    {
+      const ezString& sKey = it.Key();
+      const ezUInt64 uiExpected = it.Value();
+
+      auto itOld = m_MissmatchTransformDependencies.Find(sKey);
+      if (itOld.IsValid())
+      {
+        const ezUInt64 uiOld = itOld.Value();
+        if (uiOld != uiExpected)
+        {
+          sMsg.SetFormat("{} dependency hash mismatch for '{}': expected {} != recorded {}", sDependencyType, sKey, uiExpected, uiOld);
+          AddLogMessage(sMsg);
+        }
+      }
+      else
+      {
+        sMsg.SetFormat("{} dependency missing in records: '{0}' (hash {1})", sDependencyType, sKey, uiExpected);
+        AddLogMessage(sMsg);
+      }
+    }
+
+    // Check for dependencies that used to be recorded but are no longer expected
+    for (auto it = m_MissmatchTransformDependencies.GetIterator(); it.IsValid(); ++it)
+    {
+      if (!TransformDependencies.Contains(it.Key()))
+      {
+        sMsg.SetFormat("{} dependency no longer present: '{0}' (old hash {1})", sDependencyType, it.Key(), it.Value());
+        AddLogMessage(sMsg);
+      }
+    }
+  };
+  CompareDependencies(TransformDependencies, m_MissmatchTransformDependencies, "Transform");
+  CompareDependencies(ThumbnailDependencies, m_MissmatchThumbnailDependencies, "Thumbnail");
+}
+
+bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
 {
   while (true)
   {
@@ -418,15 +580,29 @@ bool ezProcessTask::Tick(bool bStartNewWork)
         {
           return false; // don't call later
         }
-        m_LogEntries.Clear();
+        // Clear asset to process
+        m_AssetGuid = {};
+        m_AssetPath.Clear();
+        m_TransformState = ezAssetInfo::TransformState::Unknown;
+        m_sPlatform.Clear();
+        m_uiAssetHash = 0;
+        m_uiThumbHash = 0;
+        m_uiPackageHash = 0;
         m_TransitiveHull.Clear();
+
+        // Clear transform result
         m_Status = ezStatus(EZ_SUCCESS);
+        m_LogEntries.Clear();
+        m_MissmatchTransformDependencies.Clear();
+        m_MissmatchThumbnailDependencies.Clear();
+        m_MissmatchAssetHash = 0;
+        m_MissmatchThumbHash = 0;
         {
           auto pCurator = ezAssetCurator::GetSingleton();
 
           EZ_LOCK(pCurator->m_CuratorMutex);
 
-          if (!GetNextAssetToProcess(m_AssetGuid, m_AssetPath))
+          if (!GetNextAssetToProcess(m_AssetGuid, m_AssetPath, m_TransformState))
           {
             m_AssetGuid = ezUuid();
             m_AssetPath.Clear();
@@ -445,8 +621,9 @@ bool ezProcessTask::Tick(bool bStartNewWork)
 
           ezSet<ezString> dependencies;
           ezStringBuilder sTemp;
-          pCurator->GenerateTransitiveHull(ezConversionUtils::ToString(m_AssetGuid, sTemp), dependencies, true, true);
+          pCurator->GenerateTransitiveHull(ezConversionUtils::ToString(m_AssetGuid, sTemp), dependencies, ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail);
 
+          m_sPlatform = ezAssetCurator::GetSingleton()->GetActiveAssetProfile()->GetConfigName();
           m_TransitiveHull.Reserve(dependencies.GetCount());
           for (const ezString& str : dependencies)
           {
@@ -501,6 +678,20 @@ bool ezProcessTask::Tick(bool bStartNewWork)
       case State::Ready:
       {
         ezLog::Info(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Processing '{0}'", m_AssetPath.GetDataDirRelativePath());
+
+        // Fire progress event for processing started
+        m_ProcessingStartTime = ezTime::Now();
+        {
+          ezAssetProcessorProgressEvent e;
+          e.m_Type = ezAssetProcessorProgressEvent::Type::ProcessingStarted;
+          e.m_TransformState = m_TransformState;
+          e.m_uiProcessorID = (ezUInt8)m_uiProcessorID;
+          e.m_AssetGuid = m_AssetGuid;
+          e.m_sAssetPath = m_AssetPath.GetDataDirRelativePath();
+          e.m_StartTime = m_ProcessingStartTime;
+          ezAssetProcessor::GetSingleton()->m_ProgressEvents.Broadcast(e);
+        }
+
         // Send and wait
         ezProcessAssetMsg msg;
         msg.m_AssetGuid = m_AssetGuid;
@@ -509,7 +700,7 @@ bool ezProcessTask::Tick(bool bStartNewWork)
         msg.m_PackageHash = m_uiPackageHash;
         msg.m_sAssetPath = m_AssetPath;
         msg.m_DepRefHull.Swap(m_TransitiveHull);
-        msg.m_sPlatform = ezAssetCurator::GetSingleton()->GetActiveAssetProfile()->GetConfigName();
+        msg.m_sPlatform = m_sPlatform;
 
         if (m_pIPC->SendMessage(&msg))
         {
@@ -535,6 +726,24 @@ bool ezProcessTask::Tick(bool bStartNewWork)
       break;
       case State::ReportResult:
       {
+        if (!m_MissmatchTransformDependencies.IsEmpty())
+        {
+          HandleHashMissmatch();
+        }
+
+        // Fire progress event for processing finished
+        {
+          ezAssetProcessorProgressEvent e;
+          e.m_Type = ezAssetProcessorProgressEvent::Type::ProcessingFinished;
+          e.m_uiProcessorID = m_uiProcessorID;
+          e.m_AssetGuid = m_AssetGuid;
+          e.m_sAssetPath = m_AssetPath.GetDataDirRelativePath();
+          e.m_StartTime = m_ProcessingStartTime;
+          e.m_EndTime = ezTime::Now();
+          e.m_Result = m_Status;
+          ezAssetProcessor::GetSingleton()->m_ProgressEvents.Broadcast(e);
+        }
+
         if (m_Status.Succeeded())
         {
           ezAssetCurator::GetSingleton()->NotifyOfAssetChange(m_AssetGuid);
@@ -565,7 +774,7 @@ bool ezProcessTask::Tick(bool bStartNewWork)
   }
 }
 
-ezUInt32 ezProcessThread::Run()
+ezUInt32 ezAssetProcessorThread::Run()
 {
   ezAssetProcessor::GetSingleton()->Run();
   return 0;

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -341,8 +341,8 @@ void ezEditorProcessorProcess::EventHandlerIPC(const ezProcessCommunicationChann
     m_LogEntries.Swap(pMsg->m_LogEntries);
     m_MissmatchTransformDependencies.Swap(pMsg->m_MissmatchTransformDependencies);
     m_MissmatchThumbnailDependencies.Swap(pMsg->m_MissmatchThumbnailDependencies);
-    m_MissmatchAssetHash = pMsg->m_MissmatchAssetHash;
-    m_MissmatchThumbHash = pMsg->m_MissmatchThumbHash;
+    m_uiMissmatchAssetHash = pMsg->m_uiMissmatchAssetHash;
+    m_uiMissmatchThumbHash = pMsg->m_uiMissmatchThumbHash;
   }
 }
 
@@ -492,8 +492,8 @@ void ezEditorProcessorProcess::HandleHashMissmatch()
     {
       m_MissmatchTransformDependencies.Clear();
       m_MissmatchThumbnailDependencies.Clear();
-      m_MissmatchAssetHash = 0;
-      m_MissmatchThumbHash = 0;
+      m_uiMissmatchAssetHash = 0;
+      m_uiMissmatchThumbHash = 0;
     });
 
   ezUInt64 uiAssetHash = 0;
@@ -505,7 +505,7 @@ void ezEditorProcessorProcess::HandleHashMissmatch()
     // Check the asset hash again but force evaluation to detect cases where the file system watcher did not trigger.
     const ezUInt32 uiPlatform = ezAssetCurator::GetSingleton()->FindAssetProfileByName(m_sPlatform);
     ezAssetCurator::GetSingleton()->IsAssetUpToDate(m_AssetGuid, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, uiPackageHash, true);
-    if ((uiAssetHash == m_MissmatchAssetHash) || (uiThumbHash == m_MissmatchThumbHash))
+    if ((uiAssetHash == m_uiMissmatchAssetHash) || (uiThumbHash == m_uiMissmatchThumbHash))
     {
       // The newly computed hash now matches the one computed by the ezEditorProcessor.
       return;
@@ -594,8 +594,8 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
         m_LogEntries.Clear();
         m_MissmatchTransformDependencies.Clear();
         m_MissmatchThumbnailDependencies.Clear();
-        m_MissmatchAssetHash = 0;
-        m_MissmatchThumbHash = 0;
+        m_uiMissmatchAssetHash = 0;
+        m_uiMissmatchThumbHash = 0;
         {
           auto pCurator = ezAssetCurator::GetSingleton();
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -1,6 +1,5 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
-#include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetProcessor.h>
 #include <EditorFramework/Assets/AssetProcessorMessages.h>
 #include <EditorFramework/Preferences/EditorPreferences.h>

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
@@ -25,6 +25,10 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcessAssetResponseMsg, 1, ezRTTIDefaultAlloc
   {
     EZ_MEMBER_PROPERTY("Status", m_Status),
     EZ_ARRAY_MEMBER_PROPERTY("LogEntries", m_LogEntries),
+    EZ_MAP_MEMBER_PROPERTY("MissmatchTransformDependencies", m_MissmatchTransformDependencies),
+    EZ_MAP_MEMBER_PROPERTY("MissmatchThumbnailDependencies", m_MissmatchThumbnailDependencies),
+    EZ_MEMBER_PROPERTY("MissmatchAssetHash", m_MissmatchAssetHash),
+    EZ_MEMBER_PROPERTY("MissmatchThumbHash", m_MissmatchThumbHash),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
@@ -27,8 +27,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcessAssetResponseMsg, 1, ezRTTIDefaultAlloc
     EZ_ARRAY_MEMBER_PROPERTY("LogEntries", m_LogEntries),
     EZ_MAP_MEMBER_PROPERTY("MissmatchTransformDependencies", m_MissmatchTransformDependencies),
     EZ_MAP_MEMBER_PROPERTY("MissmatchThumbnailDependencies", m_MissmatchThumbnailDependencies),
-    EZ_MEMBER_PROPERTY("MissmatchAssetHash", m_MissmatchAssetHash),
-    EZ_MEMBER_PROPERTY("MissmatchThumbHash", m_MissmatchThumbHash),
+    EZ_MEMBER_PROPERTY("MissmatchAssetHash", m_uiMissmatchAssetHash),
+    EZ_MEMBER_PROPERTY("MissmatchThumbHash", m_uiMissmatchThumbHash),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetStatusIndicator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetStatusIndicator.cpp
@@ -74,7 +74,7 @@ void ezQtAssetStatusIndicator::UpdateDisplay()
   {
     auto flags = m_pAsset->GetAssetFlags();
     const bool bTransformOnSave = flags.IsSet(ezAssetDocumentFlags::AutoTransformOnSave);
-    const bool bBgRunning = ezAssetProcessor::GetSingleton()->GetProcessTaskState() == ezAssetProcessor::ProcessTaskState::Running;
+    const bool bBgRunning = ezAssetProcessor::GetSingleton()->GetProcessorState() == ezAssetProcessor::ProcessorState::Running;
 
     // no flag for live preview available (ignore)
 
@@ -108,7 +108,7 @@ void ezQtAssetStatusIndicator::UpdateDisplay()
       case ezAssetInfo::TransformState::NeedsImport:
       case ezAssetInfo::TransformState::NeedsTransform:
       {
-        const bool bBgRunning = ezAssetProcessor::GetSingleton()->GetProcessTaskState() == ezAssetProcessor::ProcessTaskState::Running;
+        const bool bBgRunning = ezAssetProcessor::GetSingleton()->GetProcessorState() == ezAssetProcessor::ProcessorState::Running;
 
         if (bBgRunning)
         {

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -27,7 +27,7 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
     for (const auto& dep : assetTransformDeps)
     {
       ezString sPath = dep;
-      if (!AddAssetHash(sPath, false, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
+      if (!AddAssetHash(sPath, ezDependencyFlags::Transform, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
       {
         missingTransformDeps.Insert(sPath);
       }
@@ -36,7 +36,7 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
     for (const auto& dep : assetThumbnailDeps)
     {
       ezString sPath = dep;
-      if (!AddAssetHash(sPath, true, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
+      if (!AddAssetHash(sPath, ezDependencyFlags::Thumbnail, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
       {
         missingThumbnailDeps.Insert(sPath);
       }
@@ -45,7 +45,7 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
     for (const auto& dep : assetPackageDeps)
     {
       ezString sPath = dep;
-      if (!AddAssetHash(sPath, true, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
+      if (!AddAssetHash(sPath, ezDependencyFlags::Package, out_AssetHash, out_ThumbHash, out_PackageHash, bForce))
       {
         missingPackageDeps.Insert(sPath);
       }
@@ -73,7 +73,7 @@ ezAssetInfo::TransformState ezAssetCurator::HashAsset(ezUInt64 uiSettingsHash, c
   return state;
 }
 
-bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce)
+bool ezAssetCurator::AddAssetHash(ezString& sPath, ezBitflags<ezDependencyFlags> dependencyType, ezUInt64& out_AssetHash, ezUInt64& out_ThumbHash, ezUInt64& out_PackageHash, bool bForce)
 {
   if (sPath.IsEmpty())
     return true;
@@ -91,13 +91,22 @@ bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& 
       return false;
     }
 
-    // Thumbs hash is affected by both transform dependencies and references.
-    out_ThumbHash += thumbHash;
-    out_PackageHash += packageHash;
-    if (!bIsReference)
+    for (ezDependencyFlags::Enum dep : dependencyType)
     {
-      // References do not affect the asset hash.
-      out_AssetHash += assetHash;
+      switch (dep)
+      {
+        case ezDependencyFlags::Thumbnail:
+          out_ThumbHash += thumbHash;
+          break;
+        case ezDependencyFlags::Transform:
+          out_AssetHash += assetHash;
+          break;
+        case ezDependencyFlags::Package:
+          out_PackageHash += packageHash;
+          break;
+        default:
+          break;
+      }
     }
     return true;
   }
@@ -120,12 +129,22 @@ bool ezAssetCurator::AddAssetHash(ezString& sPath, bool bIsReference, ezUInt64& 
     return false;
   }
 
-  // Thumbs hash is affected by both transform dependencies and references.
-  out_ThumbHash += fileStatus.m_uiHash;
-  if (!bIsReference)
+  for (ezDependencyFlags::Enum dep : dependencyType)
   {
-    // References do not affect the asset hash.
-    out_AssetHash += fileStatus.m_uiHash;
+    switch (dep)
+    {
+      case ezDependencyFlags::Thumbnail:
+        out_ThumbHash += fileStatus.m_uiHash;
+        break;
+      case ezDependencyFlags::Transform:
+        out_AssetHash += fileStatus.m_uiHash;
+        break;
+      case ezDependencyFlags::Package:
+        out_PackageHash += fileStatus.m_uiHash;
+        break;
+      default:
+        break;
+    }
   }
   return true;
 }

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -344,7 +344,7 @@ It is advised to compile the plugin now, but you can also do so later.</html>",
         if (pPreferences->m_bBackgroundAssetProcessing)
         {
           QTimer::singleShot(2000, this, [this]()
-            { ezAssetProcessor::GetSingleton()->StartProcessTask(); });
+            { ezAssetProcessor::GetSingleton()->StartProcessor(); });
         }
         else if (!lastTransform.IsValid() || (ezTimestamp::CurrentTimestamp() - lastTransform).GetHours() > 5 * 24)
         {

--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
@@ -129,6 +129,15 @@ ezString ezEditorProcessCommunicationChannel::GetStdoutContents()
   return ezString();
 }
 
+ezOsProcessID ezEditorProcessCommunicationChannel::GetProcessId() const
+{
+  if (m_pClientProcess && m_pClientProcess->state() != QProcess::NotRunning)
+  {
+    return static_cast<ezOsProcessID>(m_pClientProcess->processId());
+  }
+  return {};
+}
+
 //////////////////////////////////////////////////////////////////////////
 
 ezResult ezEditorProcessRemoteCommunicationChannel::ConnectToServer(const char* szAddress)

--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.h
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.h
@@ -2,8 +2,8 @@
 
 #include <EditorFramework/EditorFrameworkDLL.h>
 
-#include <Foundation/System/Process.h>
 #include <EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h>
+#include <Foundation/System/Process.h>
 
 template <typename T>
 class QList;

--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.h
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h>
 #include <EditorFramework/EditorFrameworkDLL.h>
+
+#include <Foundation/System/Process.h>
+#include <EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h>
 
 template <typename T>
 class QList;
@@ -14,12 +16,10 @@ class EZ_EDITORFRAMEWORK_DLL ezEditorProcessCommunicationChannel : public ezProc
 public:
   ezResult StartClientProcess(const char* szProcess, const QStringList& args, bool bRemote, const ezRTTI* pFirstAllowedMessageType = nullptr,
     ezUInt32 uiMemSize = 1024 * 1024 * 10);
-
   bool IsClientAlive() const;
-
   void CloseConnection();
-
   ezString GetStdoutContents();
+  ezOsProcessID GetProcessId() const;
 
 private:
   QProcess* m_pClientProcess = nullptr;

--- a/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetBrowserPanel/CuratorControl.cpp
@@ -110,18 +110,18 @@ void ezQtCuratorControl::mouseReleaseEvent(QMouseEvent* e)
 
 void ezQtCuratorControl::UpdateBackgroundProcessState()
 {
-  ezAssetProcessor::ProcessTaskState state = ezAssetProcessor::GetSingleton()->GetProcessTaskState();
+  ezAssetProcessor::ProcessorState state = ezAssetProcessor::GetSingleton()->GetProcessorState();
   switch (state)
   {
-    case ezAssetProcessor::ProcessTaskState::Stopped:
+    case ezAssetProcessor::ProcessorState::Stopped:
       m_pBackgroundProcess->setToolTip("Start background asset processing");
       m_pBackgroundProcess->setIcon(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetProcessingStart.svg"));
       break;
-    case ezAssetProcessor::ProcessTaskState::Running:
+    case ezAssetProcessor::ProcessorState::Running:
       m_pBackgroundProcess->setToolTip("Stop background asset processing");
       m_pBackgroundProcess->setIcon(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetProcessingPause.svg"));
       break;
-    case ezAssetProcessor::ProcessTaskState::Stopping:
+    case ezAssetProcessor::ProcessorState::Stopping:
       m_pBackgroundProcess->setToolTip("Force stop background asset processing");
       m_pBackgroundProcess->setIcon(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/AssetProcessingForceStop.svg"));
       break;
@@ -130,22 +130,22 @@ void ezQtCuratorControl::UpdateBackgroundProcessState()
   }
 
   m_pBackgroundProcess->setCheckable(true);
-  m_pBackgroundProcess->setChecked(state == ezAssetProcessor::ProcessTaskState::Running);
+  m_pBackgroundProcess->setChecked(state == ezAssetProcessor::ProcessorState::Running);
 }
 
 void ezQtCuratorControl::BackgroundProcessClicked(bool checked)
 {
-  ezAssetProcessor::ProcessTaskState state = ezAssetProcessor::GetSingleton()->GetProcessTaskState();
+  ezAssetProcessor::ProcessorState state = ezAssetProcessor::GetSingleton()->GetProcessorState();
 
-  if (state == ezAssetProcessor::ProcessTaskState::Stopped)
+  if (state == ezAssetProcessor::ProcessorState::Stopped)
   {
     ezAssetCurator::GetSingleton()->CheckFileSystem();
-    ezAssetProcessor::GetSingleton()->StartProcessTask();
+    ezAssetProcessor::GetSingleton()->StartProcessor();
   }
   else
   {
-    bool bForce = state == ezAssetProcessor::ProcessTaskState::Stopping;
-    ezAssetProcessor::GetSingleton()->StopProcessTask(bForce);
+    bool bForce = state == ezAssetProcessor::ProcessorState::Stopping;
+    ezAssetProcessor::GetSingleton()->StopProcessor(bForce);
   }
 }
 
@@ -204,7 +204,7 @@ void ezQtCuratorControl::AssetProcessorEvents(const ezAssetProcessorEvent& e)
 {
   switch (e.m_Type)
   {
-    case ezAssetProcessorEvent::Type::ProcessTaskStateChanged:
+    case ezAssetProcessorEvent::Type::AssetProcessorStateChanged:
     {
       QMetaObject::invokeMethod(this, "UpdateBackgroundProcessState", Qt::QueuedConnection);
     }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.ui
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.ui
@@ -21,6 +21,9 @@
     <normaloff>:/GuiFoundation/Icons/Log.svg</normaloff>:/GuiFoundation/Icons/Log.svg</iconset>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <item>
     <widget class="QFrame" name="dockWidgetContents">
      <property name="frameShape">
@@ -36,6 +39,9 @@
       <number>0</number>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -99,36 +105,79 @@
        </layout>
       </item>
       <item>
-       <widget class="ezQGridBarWidget" name="ProcessorProgressGridBar" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>20</height>
-         </size>
+       <layout class="QVBoxLayout" name="ProcessorLayout">
+        <property name="spacing">
+         <number>0</number>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>20</height>
-         </size>
+        <property name="topMargin">
+         <number>0</number>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="ezQtAssetProcessorProgressWidget" name="ProcessorProgress" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>200</height>
-         </size>
-        </property>
-       </widget>
+        <item>
+         <widget class="ezQGridBarWidget" name="ProcessorProgressGridBar" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>20</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ezQtAssetProcessorProgressWidget" name="ProcessorProgress" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>200</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Fixed</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>90</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QScrollBar" name="ProcessorScrollBar">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="ezQtLogWidget" name="CuratorLog" native="true">

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.ui
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>866</width>
-    <height>651</height>
+    <width>848</width>
+    <height>575</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,19 +20,7 @@
    <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
     <normaloff>:/GuiFoundation/Icons/Log.svg</normaloff>:/GuiFoundation/Icons/Log.svg</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_4">
    <item>
     <widget class="QFrame" name="dockWidgetContents">
      <property name="frameShape">
@@ -47,98 +35,158 @@
      <property name="midLineWidth">
       <number>0</number>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
-       <widget class="QSplitter" name="splitter_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="ActivityLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Activity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="ClearHistory">
+          <property name="toolTip">
+           <string>Clear History</string>
+          </property>
+          <property name="text">
+           <string>...</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../../Tools/Libs/GuiFoundation/QtResources/resources.qrc">
+            <normaloff>:/GuiFoundation/Icons/Delete.svg</normaloff>:/GuiFoundation/Icons/Delete.svg</iconset>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ezQtCuratorControl" name="CuratorControl" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="ezQGridBarWidget" name="ProcessorProgressGridBar" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>20</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ezQtAssetProcessorProgressWidget" name="ProcessorProgress" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>200</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ezQtLogWidget" name="CuratorLog" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
+          <verstretch>1</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="IssuesLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Transform Issues:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="CheckIndirect">
+          <property name="text">
+           <string>Show Indirect Issues</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QSplitter" name="splitter">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Horizontal</enum>
         </property>
         <property name="childrenCollapsible">
          <bool>false</bool>
         </property>
-        <widget class="QWidget" name="layoutWidget">
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <widget class="QLabel" name="ActivityLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Activity:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="ezQtLogWidget" name="CuratorLog" native="true"/>
-          </item>
-         </layout>
+        <widget class="QTreeView" name="ListAssets">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
         </widget>
-        <widget class="QWidget" name="layoutWidget1">
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QLabel" name="IssuesLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Transform Issues:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSplitter" name="splitter">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="childrenCollapsible">
-             <bool>false</bool>
-            </property>
-            <widget class="QTreeView" name="ListAssets">
-             <property name="editTriggers">
-              <set>QAbstractItemView::NoEditTriggers</set>
-             </property>
-             <property name="uniformRowHeights">
-              <bool>true</bool>
-             </property>
-            </widget>
-            <widget class="ezQtLogWidget" name="TransformLog" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-               <horstretch>1</horstretch>
-               <verstretch>1</verstretch>
-              </sizepolicy>
-             </property>
-            </widget>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QCheckBox" name="CheckIndirect">
-              <property name="text">
-               <string>Show Indirect Issues</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="ezQtCuratorControl" name="widget" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
+        <widget class="ezQtLogWidget" name="TransformLog" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>1</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
         </widget>
        </widget>
       </item>
@@ -158,6 +206,18 @@
    <class>ezQtCuratorControl</class>
    <extends>QWidget</extends>
    <header location="global">EditorFramework/Panels/AssetBrowserPanel/CuratorControl.moc.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ezQtAssetProcessorProgressWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ezQGridBarWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">GuiFoundation/Widgets/GridBarWidget.moc.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -12,6 +12,7 @@ class ezQGridBarWidget;
 struct ezAssetProcessorProgressEvent;
 struct ezAssetProcessorEvent;
 class QPushButton;
+class QScrollBar;
 
 /// \brief Visual progress widget that displays an asset processing timeline.
 ///
@@ -28,6 +29,7 @@ public:
 
   /// \brief An ezQGridBarWidget must be placed over this widget in a vertical layout and then set here.
   void SetGridBarWidget(ezQGridBarWidget* pGridBar);
+  void SetScrollBarWidget(QScrollBar* pScrollBar);
 
 public Q_SLOTS:
   void ClearHistory();
@@ -72,7 +74,7 @@ private:
     ezTime GetLatestTaskTime() const;
     void OnProgressEvent(const ezAssetProcessorProgressEvent& e);
     void OnProcessorEvent(const ezAssetProcessorEvent& e);
-    const ProcessorTask* FindTaskAtTime(ezUInt32 uiProcessorID, double pointInTime) const;
+    const ProcessorTask* FindTaskAtTime(ezUInt32 uiProcessorID, double fPointInTimeSec) const;
 
   public:
     mutable ezMutex m_HistoryMutex;
@@ -123,11 +125,12 @@ private:
 
   QTimer* m_pUpdateTimer = nullptr;
   ezQGridBarWidget* m_pGridBar = nullptr;
+  QScrollBar* m_pScrollBar = nullptr;
 
   // Display and interaction settings
   EditState m_EditState = EditState::None;
   ezTime m_TimelineLength = ezTime::MakeFromMinutes(1); // Multiple of 1min, resize when current time exceeds this.
-  double m_fSceneTranslationX = -100.0;                 // Scene horizontal pan offset (in seconds)
+  double m_fSceneTranslationX = 0;                 // Scene horizontal pan offset (in seconds)
   QPointF m_SceneToPixelScale = QPointF(20, 1);
   QPoint m_LastMousePos = {0, 0};
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -130,7 +130,7 @@ private:
   // Display and interaction settings
   EditState m_EditState = EditState::None;
   ezTime m_TimelineLength = ezTime::MakeFromMinutes(1); // Multiple of 1min, resize when current time exceeds this.
-  double m_fSceneTranslationX = 0;                 // Scene horizontal pan offset (in seconds)
+  double m_fSceneTranslationX = 0;                      // Scene horizontal pan offset (in seconds)
   QPointF m_SceneToPixelScale = QPointF(20, 1);
   QPoint m_LastMousePos = {0, 0};
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -127,7 +127,7 @@ private:
   // Display and interaction settings
   EditState m_EditState = EditState::None;
   ezTime m_TimelineLength = ezTime::MakeFromMinutes(1); // Multiple of 1min, resize when current time exceeds this.
-  double m_fSceneTranslationX = -100.0;         // Scene horizontal pan offset (in seconds)
+  double m_fSceneTranslationX = -100.0;                 // Scene horizontal pan offset (in seconds)
   QPointF m_SceneToPixelScale = QPointF(20, 1);
   QPoint m_LastMousePos = {0, 0};
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+
+#include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Assets/Declarations.h>
+#include <Foundation/Time/Time.h>
+#include <Foundation/Types/Uuid.h>
+#include <QWidget>
+
+class ezQGridBarWidget;
+struct ezAssetProcessorProgressEvent;
+struct ezAssetProcessorEvent;
+class QPushButton;
+
+/// \brief Visual progress widget that displays an asset processing timeline.
+///
+/// Shows a timeline view with Y-axis representing each ezEditorProcessor and X-axis representing time.
+/// Each asset being processed is displayed as a bar on the timeline.
+/// The timeline is compacted in that every length of time in which no asset processing happens is reduced to one second in the timeline and a diagonal pattern is drawn to indicate that the timeline cuts off there.
+class EZ_EDITORFRAMEWORK_DLL ezQtAssetProcessorProgressWidget : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit ezQtAssetProcessorProgressWidget(QWidget* pParent = nullptr);
+  ~ezQtAssetProcessorProgressWidget();
+
+  /// \brief An ezQGridBarWidget must be placed over this widget in a vertical layout and then set here.
+  void SetGridBarWidget(ezQGridBarWidget* pGridBar);
+
+public Q_SLOTS:
+  void ClearHistory();
+
+protected:
+  virtual void paintEvent(QPaintEvent* event) override;
+  virtual void mousePressEvent(QMouseEvent* e) override;
+  virtual void mouseMoveEvent(QMouseEvent* e) override;
+  virtual void mouseReleaseEvent(QMouseEvent* e) override;
+  virtual void mouseDoubleClickEvent(QMouseEvent* e) override;
+  virtual void wheelEvent(QWheelEvent* e) override;
+  virtual QSize sizeHint() const override;
+  virtual QSize minimumSizeHint() const override;
+
+private:
+  enum class EditState
+  {
+    None,
+    Panning
+  };
+
+  /// \brief Compact representation of an item in the timeline of the asset processor.
+  struct ProcessorTask
+  {
+    static constexpr ezUInt16 SuccessResult = 0xFFFF;
+    EZ_ALWAYS_INLINE bool IsFinished() const { return m_fDurationInSeconds != -1; }
+    EZ_ALWAYS_INLINE bool Failed() const { return m_uiResultIndex != SuccessResult; }
+    EZ_ALWAYS_INLINE ezTime EndTime() const { return IsFinished() ? m_StartTime + ezTime::MakeFromSeconds(m_fDurationInSeconds) : ezTime::MakeZero(); }
+
+    ezUuid m_AssetGuid;
+    ezTime m_StartTime;
+    float m_fDurationInSeconds = -1;
+    ezUInt16 m_uiResultIndex = -1; //< We only store failed results to safe space. Index points to m_FailedTransforms
+    ezAssetInfo::TransformState m_TransformState = ezAssetInfo::Unknown;
+  };
+
+  class HistoryState : public ezRefCounted
+  {
+  public:
+    void SetMaxProcessors(ezUInt32 uiCount);
+    void ClearHistory();
+    ezTime GetLatestTaskTime() const;
+    void OnProgressEvent(const ezAssetProcessorProgressEvent& e);
+    void OnProcessorEvent(const ezAssetProcessorEvent& e);
+    const ProcessorTask* FindTaskAtTime(ezUInt32 uiProcessorID, double pointInTime) const;
+
+  public:
+    mutable ezMutex m_HistoryMutex;
+    ezQtAssetProcessorProgressWidget* m_pParent = nullptr;
+    // Rendering the current time is a bit cumbersome so we instead subtract an offset to make the graph start at zero seconds. If this value is false, the next incoming asset transform will set m_CurrentOffset.
+    bool m_bCurrentOffsetValid = false;
+    // To compact various runs of asset processing in the timeline, this value is subtracted from the actual start / end time of each asset transform.
+    ezTime m_CurrentOffset;
+    // At which points in time the timeline got compacted. Just used for rendering a pattern to indicate that the timeline was cut off at these points.
+    ezDynamicArray<ezTime> m_SkipOffsets;
+    ezDynamicArray<ezDynamicArray<ProcessorTask>> m_ProcessorHistory; // [processorId][taskIndex]
+    ezDeque<ezTransformStatus> m_FailedTransforms;
+    ezDynamicArray<ezEditorProcessorState> m_ProcessStates;
+  };
+
+  static constexpr int s_iRowHeight = 30;
+  static constexpr int s_iRowSpacing = 5;
+  static constexpr int s_iLeftMargin = 90;
+  static constexpr int s_iIndicatorSize = 10;
+  static constexpr int s_iTopMargin = 0;
+
+private Q_SLOTS:
+  void OnUpdateTimer();
+  void OnHistoryChanged();
+  void OnProcessorStateChanged();
+  void OnProcessStateChanged(ezUInt8 uiProcessID);
+
+private:
+  QPoint MapFromScene(const QPointF& pos) const;
+  QPointF MapToScene(const QPoint& pos) const;
+  QRectF ComputeViewportSceneRect() const;
+  void ClampZoomPan();
+  void UpdateGridBarConfig() const;
+
+  const ezString& GetAssetPath(const ezUuid& assetGuid) const;
+  const ProcessorTask* FindTaskAtPosition(const QPoint& pos, ezUInt32& out_uiProcessorID) const;
+  void ShowTooltip(QMouseEvent* e);
+
+  void DrawTimeline(QPainter& painter) const;
+  void DrawProcessorRow(QPainter& painter, ezUInt32 uiProcessorID, int y) const;
+  void DrawProcessorTask(QPainter& painter, const ProcessorTask& task, QRect rect) const;
+
+private:
+  ezEventSubscriptionID m_ProgressEventsID;
+  ezEventSubscriptionID m_ProcessorEventsID;
+  ezSharedPtr<HistoryState> m_pHistoryState;
+  ezUInt32 m_uiMaxProcessors = 0;
+
+  QTimer* m_pUpdateTimer = nullptr;
+  ezQGridBarWidget* m_pGridBar = nullptr;
+
+  // Display and interaction settings
+  EditState m_EditState = EditState::None;
+  ezTime m_TimelineLength = ezTime::MakeFromMinutes(1); // Multiple of 1min, resize when current time exceeds this.
+  double m_fSceneTranslationX = -100.0;         // Scene horizontal pan offset (in seconds)
+  QPointF m_SceneToPixelScale = QPointF(20, 1);
+  QPoint m_LastMousePos = {0, 0};
+
+  // Cache for asset names so we don't have to store the name in ProcessorTask and also don't SPAM the ezAssetCurator.
+  mutable ezMap<ezUuid, ezString> m_AssetNameCache;
+  ezString m_sUnknownAsset = "<DELETED>";
+};

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -82,6 +82,8 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
 
   ezAssetProcessor::GetSingleton()->AddLogWriter(ezMakeDelegate(&ezQtAssetCuratorPanel::LogWriter, this));
 
+  ProcessorProgress->SetGridBarWidget(ProcessorProgressGridBar);
+
   m_pFilter = new ezQtAssetCuratorFilter(this);
   m_Model = QSharedPointer<ezQtAssetBrowserModel>(new ezQtAssetBrowserModel(this, m_pFilter));
   m_Model->Initialize();
@@ -111,6 +113,8 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
                 UpdateIssueInfo();
               }),
     "signal/slot connection failed");
+
+  EZ_VERIFY(connect(ClearHistory, &QToolButton::clicked, ProcessorProgress, &ezQtAssetProcessorProgressWidget::ClearHistory), "");
 }
 
 ezQtAssetCuratorPanel::~ezQtAssetCuratorPanel()

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -83,6 +83,7 @@ ezQtAssetCuratorPanel::ezQtAssetCuratorPanel(ads::CDockManager* pDockManager)
   ezAssetProcessor::GetSingleton()->AddLogWriter(ezMakeDelegate(&ezQtAssetCuratorPanel::LogWriter, this));
 
   ProcessorProgress->SetGridBarWidget(ProcessorProgressGridBar);
+  ProcessorProgress->SetScrollBarWidget(ProcessorScrollBar);
 
   m_pFilter = new ezQtAssetCuratorFilter(this);
   m_Model = QSharedPointer<ezQtAssetBrowserModel>(new ezQtAssetBrowserModel(this, m_pFilter));

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -136,7 +136,9 @@ void ezQtAssetProcessorProgressWidget::HistoryState::OnProcessorEvent(const ezAs
   }
   else if (e.m_Type == ezAssetProcessorEvent::Type::ProcessStateChanged)
   {
-    QMetaObject::invokeMethod(m_pParent, &ezQtAssetProcessorProgressWidget::OnProcessStateChanged, Qt::QueuedConnection, e.m_uiProcessorID);
+    const ezUInt8 uiProcId = e.m_uiProcessorID;
+    QMetaObject::invokeMethod(m_pParent, [p = m_pParent, uiProcId]()
+      { p->OnProcessStateChanged(uiProcId); }, Qt::QueuedConnection);
   }
 }
 

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -1,0 +1,748 @@
+#include <EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h>
+
+#include <EditorFramework/Assets/AssetProcessor.h>
+#include <EditorFramework/EditorApp/EditorApp.moc.h>
+#include <EditorFramework/EditorFrameworkPCH.h>
+#include <Foundation/Strings/PathUtils.h>
+#include <GuiFoundation/Widgets/GridBarWidget.moc.h>
+#include <GuiFoundation/Widgets/WidgetUtils.h>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QTimer>
+#include <QToolTip>
+#include <QWheelEvent>
+
+///////////////////////////////////////////
+// ezQtAssetProcessorProgressWidget::HistoryState
+
+void ezQtAssetProcessorProgressWidget::HistoryState::SetMaxProcessors(ezUInt32 uiCount)
+{
+  EZ_LOCK(m_HistoryMutex);
+  if (m_ProcessorHistory.GetCount() == uiCount)
+    return;
+
+  m_ProcessorHistory.SetCount(uiCount);
+  m_ProcessStates.SetCount(uiCount);
+}
+
+
+void ezQtAssetProcessorProgressWidget::HistoryState::ClearHistory()
+{
+  EZ_LOCK(m_HistoryMutex);
+
+  for (auto& history : m_ProcessorHistory)
+  {
+    history.Clear();
+  }
+
+  m_FailedTransforms.Clear();
+  m_bCurrentOffsetValid = false;
+  m_CurrentOffset = ezTime::MakeZero();
+  m_SkipOffsets.Clear();
+}
+
+ezTime ezQtAssetProcessorProgressWidget::HistoryState::GetLatestTaskTime() const
+{
+  EZ_LOCK(m_HistoryMutex);
+
+  ezTime latest = ezTime::MakeZero();
+
+  for (const auto& history : m_ProcessorHistory)
+  {
+    if (!history.IsEmpty())
+    {
+      auto& task = history.PeekBack();
+      ezTime taskTime = task.IsFinished() ? task.EndTime() : (ezTime::Now() - m_CurrentOffset);
+      if (taskTime > latest)
+      {
+        latest = taskTime;
+      }
+    }
+  }
+
+  return latest;
+}
+
+void ezQtAssetProcessorProgressWidget::HistoryState::OnProgressEvent(const ezAssetProcessorProgressEvent& e)
+{
+  EZ_LOCK(m_HistoryMutex);
+
+  if (m_pParent == nullptr)
+    return;
+
+  // Make sure we have space for this processor
+  if (e.m_uiProcessorID >= m_ProcessorHistory.GetCount())
+  {
+    SetMaxProcessors(e.m_uiProcessorID + 1);
+  }
+
+  auto& history = m_ProcessorHistory[e.m_uiProcessorID];
+
+  if (e.m_Type == ezAssetProcessorProgressEvent::Type::ProcessingStarted)
+  {
+    if (!m_bCurrentOffsetValid)
+    {
+      // Compute a new offset since we just started processing assets agan after a longer period of downtime.
+      if (m_CurrentOffset.IsZero())
+      {
+        // Special case for the very first asset im the timeline.
+        m_CurrentOffset = e.m_StartTime - (GetLatestTaskTime());
+      }
+      else
+      {
+        // We draw a 1-second area whenever we squish downtime. So the new offset must start one second later.
+        m_CurrentOffset = e.m_StartTime - (GetLatestTaskTime() + ezTime::MakeFromSeconds(1));
+      }
+      m_bCurrentOffsetValid = true;
+    }
+
+    // Add new task
+    ProcessorTask task;
+    task.m_AssetGuid = e.m_AssetGuid;
+    task.m_StartTime = e.m_StartTime - m_CurrentOffset;
+    task.m_TransformState = e.m_TransformState;
+    history.PushBack(task);
+  }
+  else if (e.m_Type == ezAssetProcessorProgressEvent::Type::ProcessingFinished)
+  {
+    ProcessorTask& task = history.PeekBack();
+    EZ_ASSERT_DEBUG(task.m_AssetGuid == e.m_AssetGuid, "Processing finished should always map to the previously started asset");
+    EZ_ASSERT_DEBUG(!task.IsFinished(), "Last task should not be finished if ProcessingFinished is emitted");
+    task.m_fDurationInSeconds = static_cast<float>((e.m_EndTime - e.m_StartTime).GetSeconds());
+    if (e.m_Result.Failed())
+    {
+      m_FailedTransforms.PushBack(e.m_Result);
+      task.m_uiResultIndex = m_FailedTransforms.GetCount() - 1;
+    }
+  }
+  QMetaObject::invokeMethod(m_pParent, &ezQtAssetProcessorProgressWidget::OnHistoryChanged, Qt::QueuedConnection);
+}
+
+void ezQtAssetProcessorProgressWidget::HistoryState::OnProcessorEvent(const ezAssetProcessorEvent& e)
+{
+  EZ_LOCK(m_HistoryMutex);
+  if (m_pParent == nullptr)
+    return;
+
+  if (e.m_Type == ezAssetProcessorEvent::Type::AssetProcessorStateChanged)
+  {
+    // Clear history when processing stops
+    auto state = ezAssetProcessor::GetSingleton()->GetProcessorState();
+    if (state == ezAssetProcessor::ProcessorState::Running)
+    {
+      SetMaxProcessors(e.m_uiProcessCount);
+    }
+    QMetaObject::invokeMethod(m_pParent, &ezQtAssetProcessorProgressWidget::OnProcessorStateChanged, Qt::QueuedConnection);
+  }
+  else if (e.m_Type == ezAssetProcessorEvent::Type::ProcessStateChanged)
+  {
+    QMetaObject::invokeMethod(m_pParent, &ezQtAssetProcessorProgressWidget::OnProcessStateChanged, Qt::QueuedConnection, e.m_uiProcessorID);
+  }
+}
+
+const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgressWidget::HistoryState::FindTaskAtTime(ezUInt32 uiProcessorID, double pointInTime) const
+{
+  EZ_LOCK(m_HistoryMutex);
+
+  const ezDynamicArray<ProcessorTask>& history = m_ProcessorHistory[uiProcessorID];
+  const ezTime currentTime = ezTime::Now() - m_CurrentOffset;
+
+  // Use binary search to find the task at pointInTime
+  auto it = std::upper_bound(begin(history), end(history), pointInTime,
+    [&](double time, const ProcessorTask& task)
+    {
+      return time < task.m_StartTime.GetSeconds();
+    });
+
+  if (it != begin(history))
+  {
+    --it;
+    double startTime = it->m_StartTime.GetSeconds();
+    double endTime = it->IsFinished() ? it->EndTime().GetSeconds() : currentTime.GetSeconds();
+
+    if (pointInTime >= startTime && pointInTime <= endTime)
+    {
+      return &(*it);
+    }
+  }
+
+  return nullptr;
+}
+
+///////////////////////////////////////////
+// ezQtAssetProcessorProgressWidget
+
+ezQtAssetProcessorProgressWidget::ezQtAssetProcessorProgressWidget(QWidget* pParent)
+  : QWidget(pParent)
+{
+  m_pHistoryState = EZ_DEFAULT_NEW(HistoryState);
+  m_pHistoryState->m_pParent = this;
+  m_pHistoryState->SetMaxProcessors(ezAssetProcessor::GetSingleton()->GetProcessCount());
+
+  setMinimumHeight(200);
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+  setMouseTracking(true);
+  setFocusPolicy(Qt::FocusPolicy::ClickFocus);
+  setBackgroundRole(QPalette::Window);
+
+  // Connect to asset processor events
+  m_ProgressEventsID = ezAssetProcessor::GetSingleton()->m_ProgressEvents.AddEventHandler([pHistoryState = m_pHistoryState](const ezAssetProcessorProgressEvent& e)
+    { pHistoryState->OnProgressEvent(e); });
+  m_ProcessorEventsID = ezAssetProcessor::GetSingleton()->m_Events.AddEventHandler([pHistoryState = m_pHistoryState](const ezAssetProcessorEvent& e)
+    { pHistoryState->OnProcessorEvent(e); });
+
+  // Setup update timer
+  m_pUpdateTimer = new QTimer(this);
+  connect(m_pUpdateTimer, &QTimer::timeout, this, &ezQtAssetProcessorProgressWidget::OnUpdateTimer);
+  m_pUpdateTimer->start(100);
+}
+
+ezQtAssetProcessorProgressWidget::~ezQtAssetProcessorProgressWidget()
+{
+  if (ezAssetProcessor::GetSingleton())
+  {
+    ezAssetProcessor::GetSingleton()->m_ProgressEvents.RemoveEventHandler(m_ProgressEventsID);
+    ezAssetProcessor::GetSingleton()->m_Events.RemoveEventHandler(m_ProcessorEventsID);
+  }
+
+  if (m_pUpdateTimer)
+  {
+    m_pUpdateTimer->stop();
+  }
+
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+  m_pHistoryState->m_pParent = nullptr;
+}
+
+void ezQtAssetProcessorProgressWidget::SetGridBarWidget(ezQGridBarWidget* pGridBar)
+{
+  m_pGridBar = pGridBar;
+  ClampZoomPan();
+  UpdateGridBarConfig();
+  OnHistoryChanged();
+}
+
+void ezQtAssetProcessorProgressWidget::ClearHistory()
+{
+  EZ_ASSERT_DEBUG(ezThreadUtils::IsMainThread(), "ClearHistory must be called on the main thread via queued connection");
+  m_pHistoryState->ClearHistory();
+  m_TimelineLength = ezTime::MakeFromMinutes(1);
+  m_fSceneTranslationX = -100.0;
+  ClampZoomPan();
+  UpdateGridBarConfig();
+  update();
+}
+
+void ezQtAssetProcessorProgressWidget::paintEvent(QPaintEvent* event)
+{
+  QPainter painter(this);
+  DrawTimeline(painter);
+}
+
+void ezQtAssetProcessorProgressWidget::mousePressEvent(QMouseEvent* e)
+{
+  QWidget::mousePressEvent(e);
+  m_LastMousePos = e->pos();
+
+  if (m_EditState != EditState::None)
+    return;
+
+  if (e->button() == Qt::RightButton)
+  {
+    m_EditState = EditState::Panning;
+  }
+}
+
+void ezQtAssetProcessorProgressWidget::mouseMoveEvent(QMouseEvent* e)
+{
+  QWidget::mouseMoveEvent(e);
+
+  const QPoint diff = e->pos() - m_LastMousePos;
+  double moveX = static_cast<double>(diff.x()) / m_SceneToPixelScale.x();
+
+  if (m_EditState == EditState::Panning)
+  {
+    setCursor(Qt::ClosedHandCursor);
+    m_fSceneTranslationX = m_fSceneTranslationX - moveX;
+    ClampZoomPan();
+    UpdateGridBarConfig();
+    update();
+  }
+  else
+  {
+    setCursor(Qt::ArrowCursor);
+    ShowTooltip(e);
+  }
+
+  m_LastMousePos = e->pos();
+}
+
+void ezQtAssetProcessorProgressWidget::mouseReleaseEvent(QMouseEvent* e)
+{
+  QWidget::mouseReleaseEvent(e);
+
+  if (e->button() == Qt::RightButton)
+  {
+    if (m_EditState == EditState::Panning)
+    {
+      m_AssetNameCache.Clear();
+      m_EditState = EditState::None;
+    }
+  }
+}
+
+void ezQtAssetProcessorProgressWidget::mouseDoubleClickEvent(QMouseEvent* e)
+{
+  QWidget::mouseDoubleClickEvent(e);
+
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+
+  ezUInt32 uiProcessorID = 0;
+  const ProcessorTask* pTask = FindTaskAtPosition(e->pos(), uiProcessorID);
+
+  if (pTask == nullptr)
+    return;
+
+  // If clicked on the processor label area, do nothing
+  if (e->pos().x() < s_iLeftMargin)
+    return;
+
+  const ezString& sAssetPath = GetAssetPath(pTask->m_AssetGuid);
+  ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sAssetPath);
+}
+
+void ezQtAssetProcessorProgressWidget::wheelEvent(QWheelEvent* e)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  const double ptAtX = MapToScene(mapFromGlobal(e->globalPosition().toPoint())).x();
+#else
+  const double ptAtX = MapToScene(mapFromGlobal(e->globalPos())).x();
+#endif
+
+  double posDiff = m_fSceneTranslationX - ptAtX;
+  double changeX = 1.2;
+
+  const double oldScaleX = m_SceneToPixelScale.x();
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+  if (e->angleDelta().y() > 0)
+#else
+  if (e->delta() > 0)
+#endif
+  {
+    m_SceneToPixelScale.setX(m_SceneToPixelScale.x() * changeX);
+  }
+  else
+  {
+    m_SceneToPixelScale.setX(m_SceneToPixelScale.x() * (1.0 / changeX));
+  }
+
+  // Clamp zoom first before computing offset or zooming at max-zoom will cause drift.
+  ClampZoomPan();
+  changeX = m_SceneToPixelScale.x() / oldScaleX;
+  posDiff = posDiff * (1.0 / changeX);
+  m_fSceneTranslationX = ptAtX + posDiff;
+  m_AssetNameCache.Clear();
+
+  ClampZoomPan();
+  UpdateGridBarConfig();
+  update();
+}
+
+QSize ezQtAssetProcessorProgressWidget::sizeHint() const
+{
+  int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors + s_iRowSpacing;
+  return QSize(800, height);
+}
+
+QSize ezQtAssetProcessorProgressWidget::minimumSizeHint() const
+{
+  int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors + s_iRowSpacing;
+  return QSize(400, ezMath::Max(200, height));
+}
+
+void ezQtAssetProcessorProgressWidget::OnUpdateTimer()
+{
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+  if (m_pHistoryState->m_bCurrentOffsetValid)
+  {
+    // If 1 second has passed and no asset is processing anymore, we cut the timeline here and add a Skip offset. This means that when the next event comes in, we recompute m_CurrentOffset so new transforms are appended right after the previous transforms. Basically we are cutting out downtime out of the graph in which nothing happens so it's nice to scroll through. We indicate that we cut the timeline by drawing a pattern in the background for one second that shows the timeline was cut.
+    ezTime currentPos = ezTime::Now() - m_pHistoryState->m_CurrentOffset;
+    ezTime latestTaskTime = m_pHistoryState->GetLatestTaskTime();
+    if ((currentPos - latestTaskTime) >= ezTime::MakeFromSeconds(1))
+    {
+      m_pHistoryState->m_bCurrentOffsetValid = false;
+      m_pHistoryState->m_SkipOffsets.PushBack(latestTaskTime);
+    }
+    // Trigger repaint for smooth timeline scrolling
+    update();
+  }
+}
+
+void ezQtAssetProcessorProgressWidget::OnHistoryChanged()
+{
+  EZ_ASSERT_DEBUG(ezThreadUtils::IsMainThread(), "OnHistoryChanged must be called on the main thread via queued connection");
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+
+  if (m_pHistoryState->m_ProcessorHistory.GetCount() > m_uiMaxProcessors)
+  {
+    // Update widget size based on processor count. We only expand as we don't want to shrink the widget on clear history.
+    m_uiMaxProcessors = m_pHistoryState->m_ProcessorHistory.GetCount();
+    int minHeight = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors + s_iRowSpacing;
+    setMinimumHeight(minHeight);
+  }
+
+  // Extend timeline length
+  ezTime latestTime = m_pHistoryState->GetLatestTaskTime();
+  ezUInt32 minutes = ezMath::Max(1, ezMath::CeilToInt(latestTime.GetMinutes()));
+  ezTime newTimelineLength = ezTime::MakeFromMinutes(minutes);
+  if (newTimelineLength != m_TimelineLength)
+  {
+    m_TimelineLength = newTimelineLength;
+    ClampZoomPan();
+    UpdateGridBarConfig();
+  }
+
+  update();
+}
+
+void ezQtAssetProcessorProgressWidget::OnProcessorStateChanged()
+{
+  OnHistoryChanged();
+  for (ezUInt32 i = 0; i < m_uiMaxProcessors; ++i)
+  {
+    OnProcessStateChanged(i);
+  }
+}
+
+void ezQtAssetProcessorProgressWidget::OnProcessStateChanged(ezUInt8 uiProcessID)
+{
+  ezEditorProcessorState state = ezAssetProcessor::GetSingleton()->GetProcessState(uiProcessID);
+  {
+    EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+    if (uiProcessID < m_pHistoryState->m_ProcessStates.GetCount())
+    {
+      m_pHistoryState->m_ProcessStates[uiProcessID] = state;
+    }
+  }
+  update();
+}
+
+QPoint ezQtAssetProcessorProgressWidget::MapFromScene(const QPointF& pos) const
+{
+  double x = pos.x() - m_fSceneTranslationX;
+  double y = pos.y();
+  x *= m_SceneToPixelScale.x();
+  y *= m_SceneToPixelScale.y();
+
+  return QPoint(static_cast<int>(x), static_cast<int>(y));
+}
+
+QPointF ezQtAssetProcessorProgressWidget::MapToScene(const QPoint& pos) const
+{
+  double x = pos.x();
+  double y = pos.y();
+  x /= m_SceneToPixelScale.x();
+  y /= m_SceneToPixelScale.y();
+
+  return QPointF(x + m_fSceneTranslationX, y);
+}
+
+QRectF ezQtAssetProcessorProgressWidget::ComputeViewportSceneRect() const
+{
+  int timelineWidth = width();
+  double viewWidthSeconds = timelineWidth / m_SceneToPixelScale.x();
+  return QRectF(m_fSceneTranslationX, 0, viewWidthSeconds, 1);
+}
+
+void ezQtAssetProcessorProgressWidget::ClampZoomPan()
+{
+  double minPixelPerSecond = width() / m_TimelineLength.GetSeconds();
+  m_SceneToPixelScale.setX(ezMath::Clamp(m_SceneToPixelScale.x(), minPixelPerSecond, 500.0));
+
+  double leftLimit = -s_iLeftMargin / m_SceneToPixelScale.x();
+  m_fSceneTranslationX = ezMath::Clamp(m_fSceneTranslationX, leftLimit, m_TimelineLength.GetSeconds());
+}
+
+void ezQtAssetProcessorProgressWidget::UpdateGridBarConfig() const
+{
+  EZ_ASSERT_DEBUG(ezThreadUtils::IsMainThread(), "UpdateGridBarConfig must be called from the main thread.");
+  if (m_pGridBar == nullptr)
+    return;
+
+  QRectF viewportSceneRect = ComputeViewportSceneRect();
+
+  double fFineGridDensity = 0.01;
+  double fRoughGridDensity = 0.01;
+  ezWidgetUtils::AdjustGridDensity(fFineGridDensity, fRoughGridDensity, rect().width(), viewportSceneRect.width(), 20);
+
+  m_pGridBar->SetConfig(viewportSceneRect, fRoughGridDensity, fFineGridDensity,
+    [this](const QPointF& pt) -> QPointF
+    {
+      return MapFromScene(pt);
+    });
+}
+
+const ezString& ezQtAssetProcessorProgressWidget::GetAssetPath(const ezUuid& assetGuid) const
+{
+  if (auto it = m_AssetNameCache.Find(assetGuid); it.IsValid())
+  {
+    return it.Value();
+  }
+
+  if (auto asset = ezAssetCurator::GetSingleton()->GetSubAsset(assetGuid); asset.isValid())
+  {
+    auto it = m_AssetNameCache.Insert(assetGuid, asset->m_pAssetInfo->m_Path.GetAbsolutePath());
+    return it.Value();
+  }
+
+  return m_sUnknownAsset;
+}
+
+const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgressWidget::FindTaskAtPosition(const QPoint& pos, ezUInt32& out_uiProcessorID) const
+{
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+  out_uiProcessorID = ezInvalidIndex;
+
+  // Determine which processor row we're in
+  int relativeY = pos.y() - s_iTopMargin;
+  if (relativeY < 0)
+    return nullptr;
+
+  ezUInt32 uiProcessorID = relativeY / (s_iRowHeight + s_iRowSpacing);
+  if (uiProcessorID >= m_pHistoryState->m_ProcessorHistory.GetCount())
+    return nullptr;
+
+  // Check if we're within the row bounds (not in the spacing)
+  int rowStartY = s_iTopMargin + uiProcessorID * (s_iRowHeight + s_iRowSpacing);
+  if (pos.y() < rowStartY || pos.y() > rowStartY + s_iRowHeight)
+    return nullptr;
+
+  out_uiProcessorID = uiProcessorID;
+  // Check if we're in the timeline area
+  if (pos.x() < s_iLeftMargin)
+    return nullptr;
+
+  // Convert mouse position to scene time
+  QPointF scenePos = MapToScene(pos);
+  double mouseTime = scenePos.x();
+
+  return m_pHistoryState->FindTaskAtTime(uiProcessorID, mouseTime);
+}
+
+void ezQtAssetProcessorProgressWidget::ShowTooltip(QMouseEvent* e)
+{
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+
+  ezUInt32 uiProcessorID = 0;
+  const ProcessorTask* pTask = FindTaskAtPosition(e->pos(), uiProcessorID);
+
+  if (e->pos().x() < s_iLeftMargin && uiProcessorID != ezInvalidIndex)
+  {
+    ezEditorProcessorState state = m_pHistoryState->m_ProcessStates[uiProcessorID];
+    ezStringBuilder sTooltip;
+    sTooltip.SetFormat("ezEditorProcessor {}\nProcessID: {}\nConnected: {}\nRunning: {}", uiProcessorID, state.m_uiProcessID, state.m_bConnected, state.m_bRunning);
+    QToolTip::showText(e->globalPosition().toPoint(), ezMakeQString(sTooltip), this);
+    return;
+  }
+
+  if (pTask == nullptr)
+  {
+    QToolTip::hideText();
+    return;
+  }
+
+  ezStringView sFileName = ezPathUtils::GetFileNameAndExtension(GetAssetPath(pTask->m_AssetGuid));
+  ezStringBuilder sTooltip;
+  sTooltip.SetFormat("{}\n\nPath: {}", sFileName, GetAssetPath(pTask->m_AssetGuid));
+  if (pTask->IsFinished())
+  {
+    sTooltip.AppendFormat("\n{} duration: {}s", pTask->m_TransformState == ezAssetInfo::TransformState::NeedsTransform ? "Transform" : "Thumbnail", ezArgF(pTask->m_fDurationInSeconds, 3));
+
+    if (pTask->Failed())
+    {
+      sTooltip.AppendFormat("\n\nError: {}", m_pHistoryState->m_FailedTransforms[pTask->m_uiResultIndex].m_sMessage);
+    }
+  }
+  else
+  {
+    sTooltip.Append("\n\nStatus: Processing...");
+  }
+
+  QToolTip::showText(e->globalPosition().toPoint(), ezMakeQString(sTooltip), this);
+}
+
+void ezQtAssetProcessorProgressWidget::DrawTimeline(QPainter& painter) const
+{
+  for (ezUInt32 i = 0; i < m_uiMaxProcessors; ++i)
+  {
+    int rowY = s_iTopMargin + i * (s_iRowHeight + s_iRowSpacing);
+    DrawProcessorRow(painter, i, rowY);
+  }
+}
+
+void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUInt32 uiProcessorID, int y) const
+{
+  const int widgetWidth = width();
+  const int timelineWidth = widgetWidth - s_iLeftMargin;
+  const QRectF viewportRect = ComputeViewportSceneRect();
+
+  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+  const ezEditorProcessorState state = m_pHistoryState->m_ProcessStates[uiProcessorID];
+
+  // Draw processor label background
+  painter.fillRect(0, y, s_iLeftMargin - 5, s_iRowHeight, palette().color(QPalette::Window));
+
+  // Draw state indicator
+  {
+    const int indicatorX = 5;
+    const int indicatorY = y + (s_iRowHeight - 10) / 2;
+    QColor indicatorColor = palette().color(QPalette::Mid);
+    if (state.m_bConnected)
+    {
+      indicatorColor = state.m_bRunning ? ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Green)) : ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Yellow));
+    }
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setBrush(indicatorColor);
+    painter.setPen(indicatorColor.darker(150));
+    painter.drawEllipse(indicatorX, indicatorY, s_iIndicatorSize, s_iIndicatorSize);
+    painter.setBrush(Qt::NoBrush);
+    painter.setRenderHint(QPainter::Antialiasing, false);
+  }
+
+  // Draw processor label
+  {
+    painter.setPen(palette().color(QPalette::Text));
+    QFont labelFont = painter.font();
+    labelFont.setPointSize(9);
+    painter.setFont(labelFont);
+    painter.drawText(5 + s_iIndicatorSize + 8, y, s_iLeftMargin - 23 - s_iIndicatorSize, s_iRowHeight, Qt::AlignVCenter | Qt::AlignLeft,
+      QString("Process %1").arg(uiProcessorID));
+  }
+
+  // Draw row background
+  painter.fillRect(s_iLeftMargin, y, timelineWidth, s_iRowHeight, palette().color(QPalette::Base));
+
+  // Draw skip offsets
+  {
+    QPixmap pixmap(16, 16);
+    pixmap.fill(Qt::transparent);
+    QPainter pixPainter(&pixmap);
+    pixPainter.setPen(QPen(palette().color(QPalette::AlternateBase), 5));
+    pixPainter.drawLine(-16, -16, 32, 32);
+    pixPainter.drawLine(-32, -16, 16, 32);
+    pixPainter.drawLine(0, -16, 48, 32);
+    pixPainter.end();
+
+    for (const auto& skipOffset : m_pHistoryState->m_SkipOffsets)
+    {
+      QPoint startPt = MapFromScene(QPointF(skipOffset.GetSeconds(), y));
+      if (startPt.x() < s_iLeftMargin)
+      {
+        startPt.setX(s_iLeftMargin);
+      }
+      QPoint endPt = MapFromScene(QPointF(skipOffset.GetSeconds() + 1, y + s_iRowHeight));
+      if (startPt.x() < endPt.x())
+        painter.fillRect(QRectF(startPt, endPt), QBrush(pixmap));
+    }
+  }
+
+  // Draw tasks for this processor
+  if (uiProcessorID >= m_pHistoryState->m_ProcessorHistory.GetCount())
+    return;
+
+  const auto& history = m_pHistoryState->m_ProcessorHistory[uiProcessorID];
+  const ezTime currentTime = ezTime::Now() - m_pHistoryState->m_CurrentOffset;
+
+  // Find first visible task
+  const double startTime = MapToScene({s_iLeftMargin, 0}).x();
+  auto it = std::upper_bound(begin(history), end(history), startTime,
+    [&](double time, const ProcessorTask& task)
+    {
+      return time < task.m_StartTime.GetSeconds();
+    });
+  if (it != begin(history))
+    it--;
+
+  for (; it != end(history); ++it)
+  {
+    const ProcessorTask& task = *it;
+    ezTime taskStartTime = task.m_StartTime;
+    ezTime taskEndTime = task.IsFinished() ? task.EndTime() : currentTime;
+
+    double startSeconds = taskStartTime.GetSeconds();
+    double endSeconds = taskEndTime.GetSeconds();
+
+    // Skip if outside visible window
+    if (endSeconds < viewportRect.left())
+      continue;
+
+    if (startSeconds > viewportRect.right())
+      break;
+
+    // Map to screen coordinates
+    QPoint startPt = MapFromScene(QPointF(startSeconds, y + 2));
+    QPoint endPt = MapFromScene(QPointF(endSeconds, y + s_iRowHeight - 4));
+    startPt.setX(ezMath::Max(startPt.x(), s_iLeftMargin));
+    endPt.setX(ezMath::Min(endPt.x(), widgetWidth));
+    if (startPt.x() > endPt.x())
+      continue;
+
+    if (endPt.x() == startPt.x())
+      endPt.setX(endPt.x() + 1);
+
+    const QRect rect(startPt, endPt);
+    DrawProcessorTask(painter, task, rect);
+  }
+}
+
+void ezQtAssetProcessorProgressWidget::DrawProcessorTask(QPainter& painter, const ProcessorTask& task, QRect rect) const
+{
+  // Choose color based on status
+  QColor barColor;
+  switch (task.m_TransformState)
+  {
+    case ezAssetInfo::NeedsTransform:
+      barColor = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Blue));
+      break;
+    case ezAssetInfo::NeedsThumbnail:
+      barColor = ezToQtColor(ezColorScheme::DarkUI(float(ezColorScheme::Blue + ezColorScheme::Green) * 0.5f * ezColorScheme::s_fIndexNormalizer));
+      break;
+    default:
+      barColor = palette().color(QPalette::Highlight);
+      break;
+  }
+
+  if (!task.IsFinished())
+  {
+    barColor = barColor.darker(150);
+  }
+  else if (task.Failed())
+  {
+    barColor = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
+  }
+
+  // Draw task bar
+  painter.fillRect(rect, barColor);
+
+  // Draw border
+  painter.setPen(barColor.darker(120));
+  painter.drawRect(rect);
+
+  // Draw asset name if there's enough space
+  int barWidth = rect.width();
+  if (barWidth > 30)
+  {
+    painter.setPen(palette().color(QPalette::BrightText));
+    QFont taskFont = painter.font();
+    taskFont.setPointSize(8);
+    painter.setFont(taskFont);
+
+    ezStringView fileName = ezPathUtils::GetFileNameAndExtension(GetAssetPath(task.m_AssetGuid));
+    QString shortName = ezMakeQString(fileName);
+    QFontMetrics fm(taskFont);
+    QString elidedName = fm.elidedText(shortName, Qt::ElideRight, barWidth - 6);
+    QRect textRect = rect.adjusted(3, 0, -3, 0);
+    painter.drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, elidedName);
+  }
+}

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -142,7 +142,7 @@ void ezQtAssetProcessorProgressWidget::HistoryState::OnProcessorEvent(const ezAs
   }
 }
 
-const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgressWidget::HistoryState::FindTaskAtTime(ezUInt32 uiProcessorID, double pointInTime) const
+const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgressWidget::HistoryState::FindTaskAtTime(ezUInt32 uiProcessorID, double fPointInTimeSec) const
 {
   EZ_LOCK(m_HistoryMutex);
 
@@ -150,7 +150,7 @@ const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgres
   const ezTime currentTime = ezTime::Now() - m_CurrentOffset;
 
   // Use binary search to find the task at pointInTime
-  auto it = std::upper_bound(begin(history), end(history), pointInTime,
+  auto it = std::upper_bound(begin(history), end(history), fPointInTimeSec,
     [&](double time, const ProcessorTask& task)
     {
       return time < task.m_StartTime.GetSeconds();
@@ -162,7 +162,7 @@ const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgres
     double startTime = it->m_StartTime.GetSeconds();
     double endTime = it->IsFinished() ? it->EndTime().GetSeconds() : currentTime.GetSeconds();
 
-    if (pointInTime >= startTime && pointInTime <= endTime)
+    if (fPointInTimeSec >= startTime && fPointInTimeSec <= endTime)
     {
       return &(*it);
     }
@@ -218,7 +218,28 @@ ezQtAssetProcessorProgressWidget::~ezQtAssetProcessorProgressWidget()
 
 void ezQtAssetProcessorProgressWidget::SetGridBarWidget(ezQGridBarWidget* pGridBar)
 {
+  EZ_ASSERT_DEBUG(m_pGridBar == nullptr, "SetGridBarWidget should only be called once.");
   m_pGridBar = pGridBar;
+  ClampZoomPan();
+  UpdateGridBarConfig();
+  OnHistoryChanged();
+}
+
+void ezQtAssetProcessorProgressWidget::SetScrollBarWidget(QScrollBar* pScrollBar)
+{
+  EZ_ASSERT_DEBUG(m_pScrollBar == nullptr, "SetScrollBarWidget should only be called once.");
+  m_pScrollBar = pScrollBar;
+
+  // When the scrollbar value changes, it provides milliseconds. Convert to seconds.
+  connect(m_pScrollBar, &QScrollBar::valueChanged, this, [this](int v)
+    {
+      m_fSceneTranslationX = static_cast<double>(v) / 1000.0;
+      ClampZoomPan();
+      m_AssetNameCache.Clear();
+      UpdateGridBarConfig();
+      update(); //
+    });
+  
   ClampZoomPan();
   UpdateGridBarConfig();
   OnHistoryChanged();
@@ -229,7 +250,7 @@ void ezQtAssetProcessorProgressWidget::ClearHistory()
   EZ_ASSERT_DEBUG(ezThreadUtils::IsMainThread(), "ClearHistory must be called on the main thread via queued connection");
   m_pHistoryState->ClearHistory();
   m_TimelineLength = ezTime::MakeFromMinutes(1);
-  m_fSceneTranslationX = -100.0;
+  m_fSceneTranslationX = 0;
   ClampZoomPan();
   UpdateGridBarConfig();
   update();
@@ -353,13 +374,13 @@ void ezQtAssetProcessorProgressWidget::wheelEvent(QWheelEvent* e)
 
 QSize ezQtAssetProcessorProgressWidget::sizeHint() const
 {
-  int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors + s_iRowSpacing;
+  int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors;
   return QSize(800, height);
 }
 
 QSize ezQtAssetProcessorProgressWidget::minimumSizeHint() const
 {
-  int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors + s_iRowSpacing;
+  int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors;
   return QSize(400, ezMath::Max(200, height));
 }
 
@@ -437,12 +458,12 @@ QPoint ezQtAssetProcessorProgressWidget::MapFromScene(const QPointF& pos) const
   x *= m_SceneToPixelScale.x();
   y *= m_SceneToPixelScale.y();
 
-  return QPoint(static_cast<int>(x), static_cast<int>(y));
+  return QPoint(static_cast<int>(x) + s_iLeftMargin, static_cast<int>(y));
 }
 
 QPointF ezQtAssetProcessorProgressWidget::MapToScene(const QPoint& pos) const
 {
-  double x = pos.x();
+  double x = pos.x() - s_iLeftMargin;
   double y = pos.y();
   x /= m_SceneToPixelScale.x();
   y /= m_SceneToPixelScale.y();
@@ -454,16 +475,16 @@ QRectF ezQtAssetProcessorProgressWidget::ComputeViewportSceneRect() const
 {
   int timelineWidth = width();
   double viewWidthSeconds = timelineWidth / m_SceneToPixelScale.x();
-  return QRectF(m_fSceneTranslationX, 0, viewWidthSeconds, 1);
+
+  double leftLimit = s_iLeftMargin / m_SceneToPixelScale.x();
+  return QRectF(m_fSceneTranslationX - leftLimit, 0, viewWidthSeconds, 1);
 }
 
 void ezQtAssetProcessorProgressWidget::ClampZoomPan()
 {
   double minPixelPerSecond = width() / m_TimelineLength.GetSeconds();
   m_SceneToPixelScale.setX(ezMath::Clamp(m_SceneToPixelScale.x(), minPixelPerSecond, 500.0));
-
-  double leftLimit = -s_iLeftMargin / m_SceneToPixelScale.x();
-  m_fSceneTranslationX = ezMath::Clamp(m_fSceneTranslationX, leftLimit, m_TimelineLength.GetSeconds());
+  m_fSceneTranslationX = ezMath::Clamp(m_fSceneTranslationX, 0.0, m_TimelineLength.GetSeconds());
 }
 
 void ezQtAssetProcessorProgressWidget::UpdateGridBarConfig() const
@@ -483,6 +504,16 @@ void ezQtAssetProcessorProgressWidget::UpdateGridBarConfig() const
     {
       return MapFromScene(pt);
     });
+
+  if (m_pScrollBar == nullptr)
+    return;
+
+  ezQtScopedBlockSignals bs(m_pScrollBar);
+  m_pScrollBar->setMinimum(0);
+  m_pScrollBar->setMaximum((int)m_TimelineLength.GetMilliseconds());
+  m_pScrollBar->setSliderPosition((int)(m_fSceneTranslationX * 1000.0));
+  m_pScrollBar->setSingleStep(100);
+  m_pScrollBar->setPageStep(10000);
 }
 
 const ezString& ezQtAssetProcessorProgressWidget::GetAssetPath(const ezUuid& assetGuid) const
@@ -578,7 +609,7 @@ void ezQtAssetProcessorProgressWidget::DrawTimeline(QPainter& painter) const
 {
   for (ezUInt32 i = 0; i < m_uiMaxProcessors; ++i)
   {
-    int rowY = s_iTopMargin + i * (s_iRowHeight + s_iRowSpacing);
+    int rowY = s_iTopMargin + s_iRowSpacing + i * (s_iRowHeight + s_iRowSpacing);
     DrawProcessorRow(painter, i, rowY);
   }
 }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -239,7 +239,7 @@ void ezQtAssetProcessorProgressWidget::SetScrollBarWidget(QScrollBar* pScrollBar
       UpdateGridBarConfig();
       update(); //
     });
-  
+
   ClampZoomPan();
   UpdateGridBarConfig();
   OnHistoryChanged();

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -119,9 +119,19 @@ public:
           // Next, we force checking that the asset is up to date. This EditorProcessor instance might not have observed the generation of the output files of various dependencies yet and incorrectly assume that some dependencies still need to be transformed. To prevent this, we force checking the asset and all its dependencies via the filesystem, ignoring the caching.
           ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(pMsg->m_AssetGuid, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, uiPackageHash, true);
 
-          if ((uiAssetHash != pMsg->m_AssetHash) || (uiThumbHash != pMsg->m_ThumbHash) || (uiPackageHash != pMsg->m_PackageHash))
+          if ((uiAssetHash != pMsg->m_AssetHash) || (uiThumbHash != pMsg->m_ThumbHash))
           {
-            ezLog::Warning("Asset '{}' of state '{}' in processor with hashes '{}|{}|{}' differs from the state in the editor with hashes '{}|{}|{}'", pMsg->m_sAssetPath, (int)state, uiAssetHash, uiThumbHash, uiPackageHash, pMsg->m_AssetHash, pMsg->m_ThumbHash, pMsg->m_PackageHash);
+            ezLog::Warning("Asset '{}' of state '{}' in processor with hashes '{}|{}' differs from the state in the editor with hashes '{}|{}'", pMsg->m_sAssetPath, (int)state, uiAssetHash, uiThumbHash, pMsg->m_AssetHash, pMsg->m_ThumbHash);
+            msg.m_MissmatchAssetHash = uiAssetHash;
+            msg.m_MissmatchThumbHash = uiThumbHash;
+
+            ezSet<ezString> dependencies;
+            ezAssetCurator::GetSingleton()->GenerateTransitiveHull(pMsg->m_sAssetPath, dependencies, ezDependencyFlags::Transform);
+            ezAssetCurator::GetSingleton()->GenerateSettingsHashMap(dependencies, ezDependencyFlags::Transform, msg.m_MissmatchTransformDependencies);
+
+            dependencies.Clear();
+            ezAssetCurator::GetSingleton()->GenerateTransitiveHull(pMsg->m_sAssetPath, dependencies, ezDependencyFlags::Thumbnail);
+            ezAssetCurator::GetSingleton()->GenerateSettingsHashMap(dependencies, ezDependencyFlags::Thumbnail, msg.m_MissmatchThumbnailDependencies);
           }
 
           if (state == ezAssetInfo::NeedsThumbnail || state == ezAssetInfo::NeedsTransform)

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -122,8 +122,8 @@ public:
           if ((uiAssetHash != pMsg->m_AssetHash) || (uiThumbHash != pMsg->m_ThumbHash))
           {
             ezLog::Warning("Asset '{}' of state '{}' in processor with hashes '{}|{}' differs from the state in the editor with hashes '{}|{}'", pMsg->m_sAssetPath, (int)state, uiAssetHash, uiThumbHash, pMsg->m_AssetHash, pMsg->m_ThumbHash);
-            msg.m_MissmatchAssetHash = uiAssetHash;
-            msg.m_MissmatchThumbHash = uiThumbHash;
+            msg.m_uiMissmatchAssetHash = uiAssetHash;
+            msg.m_uiMissmatchThumbHash = uiThumbHash;
 
             ezSet<ezString> dependencies;
             ezAssetCurator::GetSingleton()->GenerateTransitiveHull(pMsg->m_sAssetPath, dependencies, ezDependencyFlags::Transform);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetWindow.cpp
@@ -94,7 +94,7 @@ void ezQtBlackboardTemplateAssetDocumentWindow::UpdatePreview()
   sAbsFilePath.ChangeFileExtension("ezBlackboardTemplate");
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(GetDocument()->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(GetDocument()->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, pDocument->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetWindow.cpp
@@ -515,7 +515,7 @@ void ezQtColorGradientAssetDocumentWindow::SendLiveResourcePreview()
 
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(pDoc->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(pDoc->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, pDoc->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetWindow.cpp
@@ -356,7 +356,7 @@ void ezQtCurve1DAssetDocumentWindow::SendLiveResourcePreview()
 
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(pDoc->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(pDoc->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, pDoc->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAsset.cpp
@@ -145,7 +145,7 @@ ezTransformStatus ezDecalAssetDocument::InternalCreateThumbnail(const ThumbnailI
   EZ_SUCCEED_OR_RETURN(ezQtEditorApp::GetSingleton()->ExecuteTool("ezTexConv", arguments, 180, ezLog::GetThreadLocalLogSystem()));
 
   {
-    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetReferenceHash(GetGuid());
+    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetThumbnailHash(GetGuid());
     EZ_ASSERT_DEV(uiThumbnailHash != 0, "Thumbnail hash should never be zero when reaching this point!");
 
     ThumbnailInfo thumbnailInfo;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetManager.cpp
@@ -108,7 +108,7 @@ ezStatus ezDecalAssetDocumentManager::GenerateDecalTexture(const ezPlatformProfi
     if (asset.m_pAssetInfo->GetManager() != this)
       continue;
 
-    uiAssetHash += pCurator->GetAssetDependencyHash(it.Key());
+    uiAssetHash += pCurator->GetAssetTransformHash(it.Key());
   }
 
   ezStringBuilder decalFile = ezToolsProject::GetSingleton()->GetProjectDirectory();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAsset.cpp
@@ -121,7 +121,7 @@ ezStatus ezImageDataAssetDocument::RunTexConv(const char* szTargetFile, const ez
 
   if (bUpdateThumbnail)
   {
-    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetReferenceHash(GetGuid());
+    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetThumbnailHash(GetGuid());
     EZ_ASSERT_DEV(uiThumbnailHash != 0, "Thumbnail hash should never be zero when reaching this point!");
 
     ThumbnailInfo thumbnailInfo;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -909,6 +909,7 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
     for (const auto& sCfgFile : cfgFiles)
     {
       pInfo->m_TransformDependencies.Insert(sCfgFile);
+      pInfo->m_ThumbnailDependencies.Insert(sCfgFile);
     }
 
     pInfo->m_Outputs.Insert(ezMaterialAssetDocumentManager::s_szShaderOutputTag);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.cpp
@@ -308,7 +308,7 @@ void ezQtMaterialAssetDocumentWindow::UpdatePreview()
   sAbsFilePath.ChangeFileExtension("ezBinMaterial");
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(GetMaterialDocument()->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(GetMaterialDocument()->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, GetMaterialDocument()->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.cpp
@@ -276,7 +276,7 @@ void ezQtSkeletonAssetDocumentWindow::SendLiveResourcePreview()
 
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(pDoc->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(pDoc->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, pDoc->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -343,7 +343,7 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
 
   if (bUpdateThumbnail)
   {
-    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetReferenceHash(GetGuid());
+    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetThumbnailHash(GetGuid());
     EZ_ASSERT_DEV(uiThumbnailHash != 0, "Thumbnail hash should never be zero when reaching this point!");
 
     ThumbnailInfo thumbnailInfo;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAsset.cpp
@@ -157,7 +157,7 @@ ezStatus ezTextureCubeAssetDocument::RunTexConv(const char* szTargetFile, const 
 
   if (bUpdateThumbnail)
   {
-    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetReferenceHash(GetGuid());
+    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetThumbnailHash(GetGuid());
     EZ_ASSERT_DEV(uiThumbnailHash != 0, "Thumbnail hash should never be zero when reaching this point!");
 
     ThumbnailInfo thumbnailInfo;

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
@@ -544,7 +544,7 @@ void ezQtParticleEffectAssetDocumentWindow::SendLiveResourcePreview()
 
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(GetParticleDocument()->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(GetParticleDocument()->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, GetParticleDocument()->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.cpp
@@ -123,7 +123,7 @@ void ezProcGenGraphAssetDocumentWindow::UpdatePreview()
   sAbsFilePath.ChangeFileExtension("ezProcGenGraph");
   // Write Header
   memoryWriter << sAbsFilePath;
-  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetDependencyHash(GetDocument()->GetGuid());
+  const ezUInt64 uiHash = ezAssetCurator::GetSingleton()->GetAssetTransformHash(GetDocument()->GetGuid());
   ezAssetFileHeader AssetHeader;
   AssetHeader.SetFileHashAndVersion(uiHash, GetProcGenGraphDocument()->GetAssetTypeVersion());
   AssetHeader.Write(memoryWriter).IgnoreResult();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -273,7 +273,11 @@ void ezScene2Document::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
   for (auto it = m_Layers.GetIterator(); it.IsValid(); ++it)
   {
     if (it.Key() != this->GetDocumentInfo()->m_DocumentID)
-      pInfo->m_TransformDependencies.Insert(ezConversionUtils::ToString(it.Key(), sTemp));
+    {
+      ezConversionUtils::ToString(it.Key(), sTemp);
+      pInfo->m_TransformDependencies.Insert(sTemp);
+      pInfo->m_ThumbnailDependencies.Insert(sTemp);
+    }
   }
 }
 

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -1076,7 +1076,7 @@ ezStatus ezSubstancePackageAssetDocument::RunTexConv(const char* szInputFile, co
 
   if (sThumbnailFile.IsEmpty() == false)
   {
-    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetReferenceHash(GetGuid());
+    ezUInt64 uiThumbnailHash = ezAssetCurator::GetSingleton()->GetAssetThumbnailHash(GetGuid());
     EZ_ASSERT_DEV(uiThumbnailHash != 0, "Thumbnail hash should never be zero when reaching this point!");
 
     ThumbnailInfo thumbnailInfo;

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAsset.cpp
@@ -681,8 +681,12 @@ void ezSubstancePackageAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInf
   // Dependencies
   {
     pInfo->m_TransformDependencies.Insert(pProp->m_sSubstancePackage);
+    pInfo->m_ThumbnailDependencies.Insert(pProp->m_sSubstancePackage);
 
-    ReadDependencies(pProp->m_sSubstancePackage, pInfo->m_TransformDependencies).IgnoreResult();
+    ezSet<ezString> dependencies;
+    ReadDependencies(pProp->m_sSubstancePackage, dependencies).IgnoreResult();
+    pInfo->m_TransformDependencies.Union(dependencies);
+    pInfo->m_ThumbnailDependencies.Union(dependencies);
   }
 
   // Outputs


### PR DESCRIPTION
 # Curator Panel Upgrade

 * The Asset Curator panel now has a new widget on top that shows the timeline of processed assets in the `ezAssetProcessor`. The widget shows a timeline view with Y-axis representing each `ezEditorProcessor` process and X-axis representing time. Each asset being processed is displayed as a bar on the timeline. The timeline is compacted in that every length of time in which no asset processing happens is reduced to one second in the timeline and a diagonal pattern is drawn to indicate that the timeline cuts off there.
 * To support this, the `ezAssetProcessor` now has an event that is fired when processing of an asset starts of stops.

<img width="827" height="435" alt="image" src="https://github.com/user-attachments/assets/4d2b01b2-6c97-43c2-87f4-663ac79e10db" />

 # Bug Fixes

 * Fixed a bug in which the `ezAssetProcessor` would repeatedly try to update the same asset. This was caused by some old code in the `ezAssetCurator::AddAssetHash` function that was not properly migrated in the past. The code falsely incorporated package hashes into the thumbnail hash. This meant that package hash changes would affect the thumbnail hash. As there is no inverse dependency tracking of package hashes, changes to the package hash would not propagate upwords to dependent assets and invalidat those. However, as the `ezEditorProcessor` forces reevaluation of the transitive hull of dependencies it would update the thumbnail hash du to changes to the packaging and result in generating an asset for a different hash than the editor requested. The fix is simply to not add package hashes to Thumbnail hashes. Each hash type should be independent of the others. I.e. only assets that are in e.g. the transitive hull of thumbnail depndencies should affect the thumbnail hash. Transform or package dependencies should not affect the thumbnail hash. If we made this assumption implicitly in the past, we can change the hash function again but it should not incorporate the packaging dependencies into any other category.

 # Misc

 * Renamed various classes around the `ezAssetProcessor` to be more appropriately named.
 * Some code was written to detect hash missmatches between the `ezEditorProcessor` and the editor. As this can be useful if another bug in the code pops up, the code was left in but does not have any affect on the transform outcome. See `ezEditorProcessorProcess::HandleHashMissmatch`. We could make the transform fail in case a hash missmatch is registered but I assume that this can happen in the real world if the user is changing assets while processing is in flight. This is fine as long as the state of both editor and `ezEditorProcessor` is eventually consistent and does not run in circles like the bug above.