### PR TITLE
Added asset export option to asset browser

### DIFF
--- a/Code/Editor/EditorFramework/Actions/AssetActions.h
+++ b/Code/Editor/EditorFramework/Actions/AssetActions.h
@@ -20,6 +20,7 @@ public:
   static ezActionDescriptorHandle s_hCheckFileSystem;
   static ezActionDescriptorHandle s_hWriteDependencyDGML;
   static ezActionDescriptorHandle s_hCopyAssetGuid;
+  static ezActionDescriptorHandle s_hSelectInAssetBrowser;
 };
 
 ///
@@ -36,6 +37,7 @@ public:
     CheckFileSystem,
     WriteDependencyDGML,
     CopyAssetGuid,
+    SelectInAssetBrowser,
   };
 
   ezAssetAction(const ezActionContext& context, const char* szName, ButtonType button);

--- a/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/AssetActions.cpp
@@ -2,6 +2,7 @@
 
 #include <EditorFramework/Actions/AssetActions.h>
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 
 ezActionDescriptorHandle ezAssetActions::s_hAssetCategory;
@@ -11,6 +12,7 @@ ezActionDescriptorHandle ezAssetActions::s_hTransformAllAssets;
 ezActionDescriptorHandle ezAssetActions::s_hCheckFileSystem;
 ezActionDescriptorHandle ezAssetActions::s_hWriteDependencyDGML;
 ezActionDescriptorHandle ezAssetActions::s_hCopyAssetGuid;
+ezActionDescriptorHandle ezAssetActions::s_hSelectInAssetBrowser;
 
 void ezAssetActions::RegisterActions()
 {
@@ -21,9 +23,11 @@ void ezAssetActions::RegisterActions()
   s_hCheckFileSystem = EZ_REGISTER_ACTION_1("Asset.CheckFilesystem", ezActionScope::Global, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::CheckFileSystem);
   s_hWriteDependencyDGML = EZ_REGISTER_ACTION_1("Asset.WriteDependencyDGML", ezActionScope::Document, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::WriteDependencyDGML);
   s_hCopyAssetGuid = EZ_REGISTER_ACTION_1("Asset.CopyAssetGuid", ezActionScope::Document, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::CopyAssetGuid);
+  s_hSelectInAssetBrowser = EZ_REGISTER_ACTION_1("Asset.SelectInAssetBrowser", ezActionScope::Document, "Assets", "", ezAssetAction, ezAssetAction::ButtonType::SelectInAssetBrowser);
 
   {
     ezActionMap* pMap = ezActionMapManager::GetActionMap("DocumentWindowTabMenu");
+    pMap->MapAction(s_hSelectInAssetBrowser, "", 11.0f);
     pMap->MapAction(s_hCopyAssetGuid, "", 12.0f);
   }
 }
@@ -37,6 +41,7 @@ void ezAssetActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hCheckFileSystem);
   ezActionManager::UnregisterAction(s_hWriteDependencyDGML);
   ezActionManager::UnregisterAction(s_hCopyAssetGuid);
+  ezActionManager::UnregisterAction(s_hSelectInAssetBrowser);
 }
 
 void ezAssetActions::MapMenuActions(ezStringView sMapping)
@@ -102,6 +107,8 @@ ezAssetAction::ezAssetAction(const ezActionContext& context, const char* szName,
       break;
     case ezAssetAction::ButtonType::CopyAssetGuid:
       SetIconPath(":/GuiFoundation/Icons/Guid.svg");
+      break;
+    case ezAssetAction::ButtonType::SelectInAssetBrowser:
       break;
   }
 }
@@ -185,6 +192,13 @@ void ezAssetAction::Execute(const ezVariant& value)
       clipboard->setMimeData(mimeData);
 
       ezQtUiServices::GetSingleton()->ShowAllDocumentsTemporaryStatusBarMessage(ezFmt("Copied asset GUID: {}", sGuid), ezTime::MakeFromSeconds(5));
+    }
+    break;
+
+    case ezAssetAction::ButtonType::SelectInAssetBrowser:
+    {
+      ezQtAssetBrowserPanel::GetSingleton()->AssetBrowserWidget->SetSelectedAsset(m_Context.m_pDocument->GetGuid());
+      ezQtAssetBrowserPanel::GetSingleton()->raise();
     }
     break;
   }

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserWidget.moc.h
@@ -94,6 +94,7 @@ private Q_SLOTS:
   void DeleteSelection();
   void OnImportAsAboutToShow();
   void OnImportAsClicked();
+  void OnExportAssetWithDependencies();
 
 
 private:

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -274,6 +274,13 @@ public:
   /// \brief Iterates over all known data directories and returns the absolute path to the directory in which this asset is located
   ezString FindDataDirectoryForAsset(ezStringView sAbsoluteAssetPath) const;
 
+  /// \brief Collects all main asset GUIDs located within the specified folder path.
+  ///
+  /// Searches through all known assets and adds the string representation of their GUID
+  /// to the output array if their absolute path starts with the given folder path.
+  /// Only main assets are included (not sub-assets).
+  void GetAllAssetsInFolder(ezStringView sFolderPath, ezDynamicArray<ezString>& out_assetGuids) const;
+
   /// \brief Uses knowledge about all existing files on disk to find the best match for a file. Very slow.
   ///
   /// \param sFile
@@ -334,6 +341,20 @@ public:
 
   /// \brief Generates a DGML graph of all transform and thumbnail dependencies.
   void WriteDependencyDGML(const ezUuid& guid, ezStringView sOutputFile) const;
+
+  struct ExportResult
+  {
+    ezUInt32 m_uiCopiedFiles = 0;
+    ezUInt32 m_uiFailedFiles = 0;
+  };
+
+  /// \brief Exports assets and their dependencies to a destination folder.
+  ///
+  /// Takes an array of source paths (asset GUIDs as strings or file paths) and exports them
+  /// along with all their dependencies to the destination folder. Files are copied preserving
+  /// their relative paths from the data directories. Each file is copied only once, even if
+  /// it appears in multiple dependency trees.
+  ExportResult ExportAssets(ezArrayPtr<ezString> sources, ezStringView sDestinationFolder, bool bIncludeTransformDeps = true, bool bIncludeThumbnailDeps = true, bool bIncludePackageDeps = true) const;
 
   ///@}
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserWidget.cpp
@@ -1031,6 +1031,8 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
     QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
     bool bImportable = false;
     bool bAllFiles = true;
+    bool bHasExportableItems = false;
+
     for (const QModelIndex& id : selection)
     {
       bImportable |= id.data(ezQtAssetBrowserModel::UserRoles::Importable).toBool();
@@ -1039,6 +1041,11 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
       if (itemType.IsAnySet(ezAssetBrowserItemFlags::SubAsset | ezAssetBrowserItemFlags::DataDirectory))
       {
         bAllFiles = false;
+      }
+
+      if (itemType.IsAnySet(ezAssetBrowserItemFlags::Asset | ezAssetBrowserItemFlags::SubAsset | ezAssetBrowserItemFlags::Folder | ezAssetBrowserItemFlags::DataDirectory))
+      {
+        bHasExportableItems = true;
       }
     }
 
@@ -1072,6 +1079,13 @@ void ezQtAssetBrowserWidget::on_ListAssets_customContextMenuRequested(const QPoi
         pDelete->setEnabled(false);
         pDelete->setToolTip("Sub-assets and data directories can't be deleted.");
       }
+    }
+
+    // Export
+    if (bHasExportableItems)
+    {
+      m.addSeparator();
+      m.addAction(QIcon(QLatin1String(":/GuiFoundation/Icons/Export.svg")), QLatin1String("Export with Dependencies..."), this, SLOT(OnExportAssetWithDependencies()));
     }
 
     // Import assets
@@ -1254,6 +1268,72 @@ void ezQtAssetBrowserWidget::OnAssetSelectionCurrentChanged(const QModelIndex& c
 void ezQtAssetBrowserWidget::OnModelReset()
 {
   Q_EMIT ItemCleared();
+}
+
+void ezQtAssetBrowserWidget::OnExportAssetWithDependencies()
+{
+  if (!ListAssets->selectionModel()->hasSelection())
+    return;
+
+  ezAssetCurator* pCurator = ezAssetCurator::GetSingleton();
+  QModelIndexList selection = ListAssets->selectionModel()->selectedIndexes();
+
+  ezDynamicArray<ezString> sources;
+  ezStringBuilder sTemp;
+
+  for (const QModelIndex& index : selection)
+  {
+    const ezBitflags<ezAssetBrowserItemFlags> itemType = (ezAssetBrowserItemFlags::Enum)index.data(ezQtAssetBrowserModel::UserRoles::ItemFlags).toInt();
+
+    if (itemType.IsAnySet(ezAssetBrowserItemFlags::Folder | ezAssetBrowserItemFlags::DataDirectory))
+    {
+      QString sAbsPath = m_Model->data(index, ezQtAssetBrowserModel::UserRoles::AbsolutePath).toString();
+      ezString sFolderPath = sAbsPath.toUtf8().data();
+
+      pCurator->GetAllAssetsInFolder(sFolderPath, sources);
+    }
+    else if (itemType.IsAnySet(ezAssetBrowserItemFlags::Asset | ezAssetBrowserItemFlags::SubAsset))
+    {
+      ezUuid guid = m_Model->data(index, ezQtAssetBrowserModel::UserRoles::SubAssetGuid).value<ezUuid>();
+
+      if (guid.IsValid())
+      {
+        ezConversionUtils::ToString(guid, sTemp);
+        sources.PushBack(sTemp);
+      }
+    }
+  }
+
+  if (sources.IsEmpty())
+  {
+    ezQtUiServices::MessageBoxWarning("No valid assets or folders selected for export.");
+    return;
+  }
+
+  QString sDestination = QFileDialog::getExistingDirectory(
+    this,
+    QLatin1String("Select Export Destination"),
+    QString(),
+    QFileDialog::Option::ShowDirsOnly | QFileDialog::Option::DontResolveSymlinks);
+
+  if (sDestination.isEmpty())
+    return;
+
+  ezStringBuilder sDestPath = sDestination.toUtf8().data();
+  ezAssetCurator::ExportResult result = pCurator->ExportAssets(sources, sDestPath, true, true, true);
+
+  ezStringBuilder sMessage;
+  sMessage.SetFormat("Export completed.\n\nCopied {} file(s).", result.m_uiCopiedFiles);
+
+  if (result.m_uiFailedFiles > 0)
+  {
+    sMessage.AppendFormat("\n\nFailed to copy {} file(s).", result.m_uiFailedFiles);
+    ezQtUiServices::MessageBoxWarning(sMessage);
+  }
+  else
+  {
+    ezQtUiServices::MessageBoxInformation(sMessage);
+  }
 }
 
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -1012,6 +1012,34 @@ ezString ezAssetCurator::FindDataDirectoryForAsset(ezStringView sAbsoluteAssetPa
   return ezFileSystem::GetSdkRootDirectory();
 }
 
+void ezAssetCurator::GetAllAssetsInFolder(ezStringView sFolderPath, ezDynamicArray<ezString>& out_assetGuids) const
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  ezStringBuilder sFolderPathClean = sFolderPath;
+  sFolderPathClean.MakeCleanPath();
+
+  if (!sFolderPathClean.EndsWith("/"))
+    sFolderPathClean.Append("/");
+
+  ezStringBuilder sTemp;
+
+  for (auto it = m_KnownAssets.GetIterator(); it.IsValid(); ++it)
+  {
+    const ezAssetInfo* pAssetInfo = it.Value();
+    const ezString& sAssetPath = pAssetInfo->m_Path.GetAbsolutePath();
+
+    sTemp = sAssetPath;
+    sTemp.MakeCleanPath();
+
+    if (sTemp.StartsWith_NoCase(sFolderPathClean))
+    {
+      ezConversionUtils::ToString(pAssetInfo->m_Info->m_DocumentID, sTemp);
+      out_assetGuids.PushBack(sTemp);
+    }
+  }
+}
+
 ezResult ezAssetCurator::FindBestMatchForFile(ezStringBuilder& ref_sFile, ezArrayPtr<ezString> allowedFileExtensions) const
 {
   // TODO: Merge with exhaustive search in FindSubAsset
@@ -1418,6 +1446,75 @@ void ezAssetCurator::WriteDependencyDGML(const ezUuid& guid, ezStringView sOutpu
   }
 
   ezDGMLGraphWriter::WriteGraphToFile(sOutputFile, graph).IgnoreResult();
+}
+
+ezAssetCurator::ExportResult ezAssetCurator::ExportAssets(ezArrayPtr<ezString> sources, ezStringView sDestinationFolder, bool bIncludeTransformDeps, bool bIncludeThumbnailDeps, bool bIncludePackageDeps) const
+{
+  EZ_LOCK(m_CuratorMutex);
+
+  ExportResult result;
+
+  ezSet<ezString> allDependencies;
+
+  for (const ezString& source : sources)
+  {
+    GenerateTransitiveHull(source, allDependencies, bIncludeTransformDeps, bIncludeThumbnailDeps, bIncludePackageDeps);
+  }
+
+  ezStringBuilder sDestPath = sDestinationFolder;
+  ezStringBuilder sAbsPath;
+  ezStringBuilder sRelPath;
+  ezStringBuilder sTargetPath;
+  ezStringBuilder sTargetDir;
+
+  for (const ezString& dep : allDependencies)
+  {
+    sAbsPath.Clear();
+    const ezDataDirectoryInfo* ddi = nullptr;
+
+    if (ezConversionUtils::IsStringUuid(dep))
+    {
+      ezUuid depGuid = ezConversionUtils::ConvertStringToUuid(dep);
+      const auto pDepAsset = GetSubAsset(depGuid);
+
+      if (!pDepAsset.isValid())
+        continue;
+
+      sAbsPath = pDepAsset->m_pAssetInfo->m_Path.GetAbsolutePath();
+      sRelPath = pDepAsset->m_pAssetInfo->m_Path.GetDataDirRelativePath();
+
+      // the index in GetDataDirIndex() doesn't seem to match the index of ezFileSystem
+      // ddi = &ezFileSystem::GetDataDirectoryInfo(pDepAsset->m_pAssetInfo->m_Path.GetDataDirIndex());
+
+      if (ezFileSystem::ResolvePath(sAbsPath, &sAbsPath, &sRelPath, &ddi).Failed())
+        continue;
+    }
+    else
+    {
+      if (ezFileSystem::ResolvePath(dep, &sAbsPath, &sRelPath, &ddi).Failed())
+        continue;
+    }
+
+    if (ddi->m_sRootName == "BASE")
+      continue;
+
+    if (!ezOSFile::ExistsFile(sAbsPath))
+      continue;
+
+
+    ezStringBuilder sTargetPath = sDestPath;
+    sTargetPath.AppendPath(sRelPath);
+
+    if (ezOSFile::CopyFile(sAbsPath, sTargetPath).Failed())
+    {
+      result.m_uiFailedFiles++;
+      continue;
+    }
+
+    ++result.m_uiCopiedFiles;
+  }
+
+  return result;
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.cpp
@@ -150,3 +150,11 @@ ezTransformStatus ezAnimatedMeshAssetDocument::InternalCreateThumbnail(const Thu
   ezStatus status = ezAssetDocument::RemoteCreateThumbnail(ThumbnailInfo);
   return status;
 }
+
+void ezAnimatedMeshAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const
+{
+  SUPER::UpdateAssetDocumentInfo(pInfo);
+
+  // For glTF files, add any referenced external buffer files as dependencies
+  ezMeshImportUtils::AddGltfBufferDependencies(GetProperties()->m_sMeshFile, pInfo->m_TransformDependencies);
+}

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAsset.h
@@ -20,6 +20,7 @@ protected:
 
   ezStatus CreateMeshFromFile(ezAnimatedMeshAssetProperties* pProp, ezMeshResourceDescriptor& desc);
 
-
   virtual ezTransformStatus InternalCreateThumbnail(const ThumbnailInfo& ThumbnailInfo) override;
+
+  virtual void UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) const override;
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAsset.cpp
@@ -320,4 +320,9 @@ void ezMeshAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo) co
     const auto& sMeshFile = GetProperties()->m_sMeshFile;
     pInfo->m_TransformDependencies.Remove(sMeshFile);
   }
+  else
+  {
+    // For glTF files, add any referenced external buffer files as dependencies
+    ezMeshImportUtils::AddGltfBufferDependencies(GetProperties()->m_sMeshFile, pInfo->m_TransformDependencies);
+  }
 }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.cpp
@@ -5,6 +5,8 @@
 #include <EditorPluginAssets/TextureAsset/TextureAsset.h>
 #include <EditorPluginAssets/Util/MeshImportUtils.h>
 #include <Foundation/IO/FileSystem/DeferredFileWriter.h>
+#include <Foundation/IO/FileSystem/FileReader.h>
+#include <Foundation/IO/JSONReader.h>
 #include <Foundation/Utilities/Progress.h>
 #include <ModelImporter2/Importer/Importer.h>
 #include <RendererCore/Meshes/MeshResourceDescriptor.h>
@@ -504,6 +506,65 @@ namespace ezMeshImportUtils
     }
 
     WaitForPendingTasks();
+  }
+
+  void AddGltfBufferDependencies(ezStringView sMeshFile, ezSet<ezString>& inout_dependencies)
+  {
+    if (!sMeshFile.HasExtension("gltf"))
+      return;
+
+    ezStringBuilder sAbsFilePath = sMeshFile;
+
+    if (!ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sAbsFilePath))
+      return;
+
+    ezFileReader file;
+    if (file.Open(sAbsFilePath).Failed())
+      return;
+
+    ezJSONReader json;
+    if (json.Parse(file).Failed())
+      return;
+
+    const ezVariantDictionary& root = json.GetTopLevelObject();
+    const ezVariant* pBuffers = root.GetValue("buffers");
+    if (pBuffers == nullptr || !pBuffers->IsA<ezVariantArray>())
+      return;
+
+    const ezVariantArray& buffers = pBuffers->Get<ezVariantArray>();
+    ezStringBuilder sBufferPath;
+    ezStringBuilder sBufferDir = sAbsFilePath.GetFileDirectory();
+
+    for (const ezVariant& buffer : buffers)
+    {
+      if (!buffer.IsA<ezVariantDictionary>())
+        continue;
+
+      const ezVariantDictionary& bufferDict = buffer.Get<ezVariantDictionary>();
+      const ezVariant* pUri = bufferDict.GetValue("uri");
+      if (pUri == nullptr || !pUri->IsA<ezString>())
+        continue;
+
+      const ezString& sUri = pUri->Get<ezString>();
+
+      // Skip data URIs (embedded binary data)
+      if (sUri.StartsWith("data:"))
+        continue;
+
+      // Construct absolute path to the buffer file
+      sBufferPath = sBufferDir;
+      sBufferPath.AppendPath(sUri);
+      sBufferPath.MakeCleanPath();
+
+      if (!ezOSFile::ExistsFile(sBufferPath))
+        continue;
+
+      // Convert to data directory relative path
+      if (ezQtEditorApp::GetSingleton()->MakePathDataDirectoryRelative(sBufferPath))
+      {
+        inout_dependencies.Insert(sBufferPath);
+      }
+    }
   }
 
 } // namespace ezMeshImportUtils

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Util/MeshImportUtils.h
@@ -19,4 +19,14 @@ namespace ezMeshImportUtils
   EZ_EDITORPLUGINASSETS_DLL void SetMeshAssetMaterialSlots(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, const ezModelImporter2::Importer* pImporter);
   EZ_EDITORPLUGINASSETS_DLL void CopyMeshAssetMaterialSlotToResource(ezMeshResourceDescriptor& ref_desc, const ezHybridArray<ezMaterialResourceSlot, 8>& materialSlots);
   EZ_EDITORPLUGINASSETS_DLL void ImportMeshAssetMaterials(ezHybridArray<ezMaterialResourceSlot, 8>& inout_materialSlots, ezStringView sDocumentDirectory, const ezModelImporter2::Importer* pImporter);
+
+  /// \brief Extracts external buffer file dependencies from a glTF file and adds them to the transform dependencies set.
+  ///
+  /// Parses the glTF JSON to find all external buffer files referenced in the "buffers" array.
+  /// Skips embedded data URIs and only processes external file references.
+  /// All referenced buffer files are converted to data directory relative paths before being added.
+  ///
+  /// \param sMeshFile Data directory relative path to the glTF file
+  /// \param inout_dependencies Set to add the buffer file dependencies to
+  EZ_EDITORPLUGINASSETS_DLL void AddGltfBufferDependencies(ezStringView sMeshFile, ezSet<ezString>& inout_dependencies);
 } // namespace ezMeshImportUtils

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CMakeLists.txt
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CMakeLists.txt
@@ -14,6 +14,7 @@ ez_link_target_qt(TARGET ${PROJECT_NAME} COMPONENTS Core Gui Widgets)
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
   EditorFramework
+  EditorPluginAssets
   GameEngine
   ModelImporter2
   JoltPlugin

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.cpp
@@ -1,5 +1,6 @@
 #include <EditorPluginJolt/EditorPluginJoltPCH.h>
 
+#include <EditorPluginAssets/Util/MeshImportUtils.h>
 #include <EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAsset.h>
 #include <Foundation/IO/ChunkStream.h>
 #include <Foundation/Utilities/AssetFileHeader.h>
@@ -347,6 +348,11 @@ void ezJoltCollisionMeshAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentIn
     // remove the mesh file dependency, if it is not actually used
     const auto& sMeshFile = GetProperties()->m_sMeshFile;
     pInfo->m_TransformDependencies.Remove(sMeshFile);
+  }
+  else
+  {
+    // For glTF files, add any referenced external buffer files as dependencies
+    ezMeshImportUtils::AddGltfBufferDependencies(GetProperties()->m_sMeshFile, pInfo->m_TransformDependencies);
   }
 }
 

--- a/Code/UnitTests/GameEngineTest/EffectsTest/EffectsTest.cpp
+++ b/Code/UnitTests/GameEngineTest/EffectsTest/EffectsTest.cpp
@@ -60,7 +60,7 @@ ezResult ezGameEngineTestEffects::InitializeSubTest(ezInt32 iIdentifier)
     case SubTests::WindClothRopes:
     {
       m_ImgCompFrames.PushBack({20, 550});
-      m_ImgCompFrames.PushBack({100, 600});
+      m_ImgCompFrames.PushBack({100, 850});
 
       return m_pOwnApplication->LoadScene("Effects/AssetCache/Common/Scenes/Wind.ezBinScene");
     }

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -96,6 +96,7 @@ Asset.CheckFilesystem;Check Filesystem;Checks for new or deleted assets on disk
 Asset.WriteLookupTable;Write Lookup Table
 Asset.Help;Open Asset Documentation;Open online documentation for this asset type
 Asset.CopyAssetGuid;Copy Asset Guid;Stores the assets GUID in the clipboard.
+Asset.SelectInAssetBrowser;Select in Asset Browser
 
 # Prefabs
 


### PR DESCRIPTION
Right click assets (or folders) in the asset browser and choose "Export with Dependnecies". Then select a folder. This will copy all selected assets and their dependencies (other assets, input files) to that folder. Excludes all files from the "Base" directory, as those should exist in all projects anyway.

Can be used to easily copy an asset and everything that's needed to make it work, to another project.

<img width="920" height="663" alt="image" src="https://github.com/user-attachments/assets/0ab46992-d7ea-4a79-adf7-73095d37dda5" />
