### PR TITLE
Fix spurious crash in DecalManager

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -188,7 +188,7 @@ void ezAssetCurator::WaitForInitialize()
   m_InitializeCuratorTaskID.Invalidate();
 
   EZ_LOCK(m_CuratorMutex);
-  ProcessAllCoreAssets();
+
   // Broadcast reset.
   {
     ezAssetCuratorEvent e;
@@ -196,6 +196,10 @@ void ezAssetCurator::WaitForInitialize()
     e.m_Type = ezAssetCuratorEvent::Type::AssetListReset;
     m_Events.Broadcast(e);
   }
+  // Write Asset tables must happen after the reset as that causes the writer to rebuilt its tables.
+  WriteAssetTables(nullptr, true).IgnoreResult();
+  // This needs to happen after tables are written so that some assets can load their dependencies.
+  ProcessAllCoreAssets();
 }
 
 void ezAssetCurator::Deinitialize()
@@ -1956,7 +1960,7 @@ void ezAssetCurator::ProcessAllCoreAssets()
         // prefer certain asset types over others, to ensure that thumbnail generation works
         ezHybridArray<ezTempHashedString, 4> transformOrder;
         transformOrder.PushBack(ezTempHashedString("RenderPipeline"));
-        transformOrder.PushBack(ezTempHashedString(""));
+        transformOrder.PushBack(ezTempHashedString());
 
         ezTransformStatus resReferences(EZ_SUCCESS);
 
@@ -1966,11 +1970,13 @@ void ezAssetCurator::ProcessAllCoreAssets()
           {
             if (ezAssetInfo* pInfo = GetAssetInfo(ref))
             {
-              if (name.GetHash() == 0ull || pInfo->m_Info->m_sAssetsDocumentTypeName == name)
+              if (name == ezTempHashedString() || pInfo->m_Info->m_sAssetsDocumentTypeName == name)
               {
                 resReferences = ProcessAsset(pInfo, pAssetProfile, ezTransformFlags::TriggeredManually);
                 if (resReferences.Failed())
-                  break;
+                {
+                  ezLog::Error("Core asset '{}' of type '{}' failed transformation.", ref, pInfo->m_Info->m_sAssetsDocumentTypeName);
+                }
               }
             }
           }

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
@@ -275,6 +275,9 @@ struct ezDecalManager::Data
 
     {
       m_hSimpleCopyMaterial = ezResourceManager::LoadResource<ezMaterialResource>("{ c542b3fa-0c24-4bac-97b7-e481f66f18f1 }"); // DecalCopy.ezMaterialAsset
+      ezResourceLock<ezMaterialResource> pMaterial(m_hSimpleCopyMaterial, ezResourceAcquireMode::BlockTillLoaded);
+      ezShaderResourceHandle hShader = pMaterial->GetCurrentDesc().m_hShader;
+      ezResourceLock<ezShaderResource> pShader(hShader, ezResourceAcquireMode::BlockTillLoaded);
     }
 
     const char* szBufferResourceName = "DecalPlaneMeshBuffer";

--- a/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
+++ b/Code/Engine/RendererCore/RenderContext/Implementation/RenderContext.cpp
@@ -1002,7 +1002,7 @@ ezResult ezRenderContext::BuildVertexDeclaration(ezGALShaderHandle hShader, ezAr
       Otherwise, this is harmless, the renderer will ignore invalid drawcalls and once all the correct stuff is
       available, it will work.
       */
-
+      s_GALVertexDeclarations.Remove(it);
       ezLog::Warning("Failed to create vertex declaration");
       return EZ_FAILURE;
     }


### PR DESCRIPTION
The main reason for the crash was that the core assets were not transformed at startup. The reason was complicated:
1. In `ezAssertCurator`, it was assumed that `ezTempHashedString("")` would result in a 0 hash, which is not the case. The code was fixed to not look at the has value at all and compare `ezTempHashedString` instances via operator.
2. No asset table was written before running `ProcessAllCoreAssets` so some of them might fail.
3. Failing a core asset would cancel transforming the rest of the core assets.
4. The `ezDecalManager` relies on a material called `DecalCopy` to work which is part of the core assets.
5. There is no dependency between decals and `DecalCopy` so random ordering could result in decals being processed before `DecalCopy` was processed.

Addtionally, the `ezDecalManager` now enforces loading the `DecalCopy` material and its shader at startup. 
Also fixed a small bug in the `ezRenderContext::BuildVertexDeclaration` which resulted in invalid handles being added to the cache.