### PR TITLE
Rewrote the window layout save/restore code

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/Actions/ProjectActions.h>
+#include <EditorFramework/Actions/WindowLayoutActions.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetDocumentGenerator.h>
 #include <EditorFramework/CodeGen/CppProject.h>
@@ -257,6 +258,8 @@ void ezProjectActions::MapActions(ezStringView sMapping, const ezBitflags<ezStan
 
   pMap->MapAction(s_hShortcutEditor, "G.Editor.Settings", 1.0f);
   pMap->MapAction(s_hPreferencesDlg, "G.Editor.Settings", 2.0f);
+
+  ezWindowLayoutActions::MapActions(sMapping);
 
   if (menus.IsSet(ezStandardMenuTypes::Help))
   {

--- a/Code/Editor/EditorFramework/Actions/Implementation/WindowLayoutActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/WindowLayoutActions.cpp
@@ -1,0 +1,258 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Actions/WindowLayoutActions.h>
+#include <GuiFoundation/Action/ActionManager.h>
+#include <GuiFoundation/Action/ActionMapManager.h>
+#include <GuiFoundation/ContainerWindow/ContainerWindow.moc.h>
+#include <GuiFoundation/DockPanels/ApplicationPanel.moc.h>
+#include <GuiFoundation/DocumentWindow/DocumentWindow.moc.h>
+
+#include <EditorFramework/Panels/AssetBrowserPanel/AssetBrowserPanel.moc.h>
+#include <EditorFramework/Panels/AssetCuratorPanel/AssetCuratorPanel.moc.h>
+#include <EditorFramework/Panels/CVarPanel/CVarPanel.moc.h>
+#include <EditorFramework/Panels/LogPanel/LogPanel.moc.h>
+#include <EditorFramework/Panels/LongOpsPanel/LongOpsPanel.moc.h>
+#include <QInputDialog>
+#include <QSettings>
+#include <ads/DockManager.h>
+
+ezActionDescriptorHandle ezWindowLayoutActions::s_hCatWindowLayout;
+ezActionDescriptorHandle ezWindowLayoutActions::s_hSetToDefaultPinned;
+ezActionDescriptorHandle ezWindowLayoutActions::s_hSetToDefaultUnpinned;
+ezActionDescriptorHandle ezWindowLayoutActions::s_hSetToAbBottom;
+
+static const char* s_szDefaultLayoutName = "Default";
+static const char* s_szSettingsGroup = "EditorWindowLayouts";
+
+static QByteArray s_DefaultLayoutState;
+
+void ezWindowLayoutActions::RegisterActions()
+{
+  s_hCatWindowLayout = EZ_REGISTER_MENU("WindowLayout");
+  s_hSetToDefaultPinned = EZ_REGISTER_ACTION_1("Layout.DefaultPinned", ezActionScope::Global, "Layout", "", ezWindowLayoutAction, ezWindowLayoutAction::ButtonType::SetToDefaultPinned);
+  s_hSetToDefaultUnpinned = EZ_REGISTER_ACTION_1("Layout.DefaultUnpinned", ezActionScope::Global, "Layout", "", ezWindowLayoutAction, ezWindowLayoutAction::ButtonType::SetToDefaultUnpinned);
+  s_hSetToAbBottom = EZ_REGISTER_ACTION_1("Layout.AbBottom", ezActionScope::Global, "Layout", "", ezWindowLayoutAction, ezWindowLayoutAction::ButtonType::SetToAbBottom);
+}
+
+void ezWindowLayoutActions::UnregisterActions()
+{
+  ezActionManager::UnregisterAction(s_hCatWindowLayout);
+  ezActionManager::UnregisterAction(s_hSetToDefaultPinned);
+  ezActionManager::UnregisterAction(s_hSetToDefaultUnpinned);
+  ezActionManager::UnregisterAction(s_hSetToAbBottom);
+}
+
+void ezWindowLayoutActions::MapActions(ezStringView sMapping)
+{
+  ezActionMap* pMap = ezActionMapManager::GetActionMap(sMapping);
+  EZ_ASSERT_DEV(pMap != nullptr, "The given mapping ('{0}') does not exist, mapping the actions failed!", sMapping);
+
+  pMap->MapAction(s_hCatWindowLayout, "G.Panels", 2.0f);
+  pMap->MapAction(s_hSetToDefaultPinned, "WindowLayout", 1.0f);
+  pMap->MapAction(s_hSetToDefaultUnpinned, "WindowLayout", 2.0f);
+  pMap->MapAction(s_hSetToAbBottom, "WindowLayout", 3.0f);
+}
+
+void ezWindowLayoutActions::RestoreUserLayout()
+{
+  ezQtContainerWindow* pContainer = ezQtContainerWindow::GetContainerWindow();
+  if (pContainer == nullptr)
+    return;
+
+  ads::CDockManager* pDockManager = pContainer->GetDockManager();
+  if (pDockManager == nullptr)
+    return;
+
+  QSettings settings;
+  settings.beginGroup(s_szSettingsGroup);
+  pDockManager->loadPerspectives(settings);
+  settings.endGroup();
+
+  pDockManager->openPerspective(s_szDefaultLayoutName);
+}
+
+void ezWindowLayoutActions::SaveUserLayout()
+{
+  ezQtContainerWindow* pContainer = ezQtContainerWindow::GetContainerWindow();
+  if (pContainer == nullptr)
+    return;
+
+  ads::CDockManager* pDockManager = pContainer->GetDockManager();
+  if (pDockManager == nullptr)
+    return;
+
+  pDockManager->addPerspective(s_szDefaultLayoutName);
+
+  QSettings settings;
+  settings.beginGroup(s_szSettingsGroup);
+  pDockManager->savePerspectives(settings);
+  settings.endGroup();
+}
+
+//////////////////////////////////////////////////////////////////////////
+// ezWindowLayoutAction
+//////////////////////////////////////////////////////////////////////////
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezWindowLayoutAction, 1, ezRTTINoAllocator)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+ezWindowLayoutAction::ezWindowLayoutAction(const ezActionContext& context, const char* szName, ButtonType button)
+  : ezButtonAction(context, szName, false, "")
+{
+  m_ButtonType = button;
+
+  switch (m_ButtonType)
+  {
+    case ButtonType::SetToDefaultPinned:
+    case ButtonType::SetToDefaultUnpinned:
+    case ButtonType::SetToAbBottom:
+      break;
+  }
+}
+
+void ezWindowLayoutAction::Execute(const ezVariant& value)
+{
+  ezQtContainerWindow* pContainer = ezQtContainerWindow::GetContainerWindow();
+  if (pContainer == nullptr)
+    return;
+
+  ads::CDockManager* pDockManager = pContainer->GetDockManager();
+  if (pDockManager == nullptr)
+    return;
+
+  // Get all application panels
+  const ezDynamicArray<ezQtApplicationPanel*>& allPanels = ezQtApplicationPanel::GetAllApplicationPanels();
+
+  // Find the specific panels we need
+  ezQtApplicationPanel* pAssetBrowserPanel = ezQtAssetBrowserPanel::GetSingleton();
+  ezQtApplicationPanel* pAssetCuratorPanel = ezQtAssetCuratorPanel::GetSingleton();
+  ezQtApplicationPanel* pLogPanel = ezQtLogPanel::GetSingleton();
+  ezQtApplicationPanel* pCVarPanel = ezQtCVarPanel::GetSingleton();
+  ezQtApplicationPanel* pLongOpsPanel = ezQtLongOpsPanel::GetSingleton();
+
+  switch (m_ButtonType)
+  {
+    case ButtonType::SetToDefaultPinned:
+    {
+      // Arrange panels the same way as in ezQtEditorApp::CreatePanels()
+      if (pAssetBrowserPanel)
+      {
+        pDockManager->removeDockWidget(pAssetBrowserPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetBrowserPanel);
+      }
+      if (pAssetCuratorPanel)
+      {
+        pDockManager->removeDockWidget(pAssetCuratorPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetCuratorPanel);
+      }
+      if (pLogPanel)
+      {
+        pDockManager->removeDockWidget(pLogPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLogPanel);
+      }
+      if (pCVarPanel)
+      {
+        pDockManager->removeDockWidget(pCVarPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pCVarPanel);
+      }
+      if (pLongOpsPanel)
+      {
+        pDockManager->removeDockWidget(pLongOpsPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLongOpsPanel);
+      }
+
+      break;
+    }
+
+    case ButtonType::SetToDefaultUnpinned:
+    {
+      // Arrange panels the same way as in ezQtEditorApp::CreatePanels()
+      // but set them all to unpinned (auto hide)
+      if (pAssetBrowserPanel)
+      {
+        pDockManager->removeDockWidget(pAssetBrowserPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetBrowserPanel);
+        pAssetBrowserPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pAssetCuratorPanel)
+      {
+        pDockManager->removeDockWidget(pAssetCuratorPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetCuratorPanel);
+        pAssetCuratorPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pLogPanel)
+      {
+        pDockManager->removeDockWidget(pLogPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLogPanel);
+        pLogPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pCVarPanel)
+      {
+        pDockManager->removeDockWidget(pCVarPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pCVarPanel);
+        pCVarPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pLongOpsPanel)
+      {
+        pDockManager->removeDockWidget(pLongOpsPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLongOpsPanel);
+        pLongOpsPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      break;
+    }
+
+    case ButtonType::SetToAbBottom:
+    {
+      // Arrange most panels as in ezQtEditorApp::CreatePanels()
+      // but dock the asset browser at the bottom of the screen (pinned / not auto-hide)
+      if (pAssetBrowserPanel)
+      {
+        pDockManager->removeDockWidget(pAssetBrowserPanel);
+        pDockManager->addDockWidget(ads::BottomDockWidgetArea, pAssetBrowserPanel);
+      }
+      if (pAssetCuratorPanel)
+      {
+        pDockManager->removeDockWidget(pAssetCuratorPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pAssetCuratorPanel);
+        pAssetCuratorPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pLogPanel)
+      {
+        pDockManager->removeDockWidget(pLogPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLogPanel);
+        pLogPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pCVarPanel)
+      {
+        pDockManager->removeDockWidget(pCVarPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pCVarPanel);
+        pCVarPanel->setAutoHide(true, ads::SideBarRight);
+      }
+      if (pLongOpsPanel)
+      {
+        pDockManager->removeDockWidget(pLongOpsPanel);
+        pDockManager->addDockWidgetTab(ads::RightDockWidgetArea, pLongOpsPanel);
+        pLongOpsPanel->setAutoHide(true, ads::SideBarRight);
+      }
+
+      break;
+    }
+  }
+
+  // Hide panels that are hidden by default
+  if (pCVarPanel)
+  {
+    pCVarPanel->toggleView(false);
+  }
+
+  if (pLongOpsPanel)
+  {
+    pLongOpsPanel->toggleView(false);
+  }
+
+  // Raise the asset browser to front
+  if (pAssetBrowserPanel)
+  {
+    pAssetBrowserPanel->EnsureVisible();
+  }
+}

--- a/Code/Editor/EditorFramework/Actions/WindowLayoutActions.h
+++ b/Code/Editor/EditorFramework/Actions/WindowLayoutActions.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <GuiFoundation/Action/BaseActions.h>
+
+/// Manages window layout save/restore using ADS perspective management.
+class EZ_EDITORFRAMEWORK_DLL ezWindowLayoutActions
+{
+public:
+  static void RegisterActions();
+  static void UnregisterActions();
+  static void MapActions(ezStringView sMapping);
+
+  /// Automatically restores the default layout at startup.
+  static void RestoreUserLayout();
+
+  /// Automatically saves the current layout as default at shutdown.
+  static void SaveUserLayout();
+
+  static ezActionDescriptorHandle s_hCatWindowLayout;
+  static ezActionDescriptorHandle s_hSetToDefaultPinned;
+  static ezActionDescriptorHandle s_hSetToDefaultUnpinned;
+  static ezActionDescriptorHandle s_hSetToAbBottom;
+};
+
+class EZ_EDITORFRAMEWORK_DLL ezWindowLayoutAction : public ezButtonAction
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezWindowLayoutAction, ezButtonAction);
+
+public:
+  enum class ButtonType
+  {
+    SetToDefaultPinned,
+    SetToDefaultUnpinned,
+    SetToAbBottom,
+  };
+
+  ezWindowLayoutAction(const ezActionContext& context, const char* szName, ButtonType button);
+  virtual void Execute(const ezVariant& value) override;
+
+private:
+  ButtonType m_ButtonType;
+};

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <Core/System/Window.h>
+#include <EditorFramework/Actions/WindowLayoutActions.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetProcessor.h>
 #include <EditorFramework/CodeGen/CppProject.h>
@@ -369,6 +370,12 @@ Explanation: For assets to work properly, they must be <a href='https://ezengine
     {
       m_RecentProjects.Insert(ezToolsProject::GetSingleton()->GetProjectFile(), 0);
       SaveSettings();
+
+      // Auto-save the global editor layout before documents are closed
+      if (!IsInHeadlessMode() && !IsInSafeMode() && !ezToolsProject::GetSingleton()->IsProjectClosing())
+      {
+        ezWindowLayoutActions::SaveUserLayout();
+      }
       break;
     }
 

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -247,10 +247,8 @@ ezResult ezQtEditorApp::CreateOrOpenProject(bool bCreate, ezStringView sFile0)
       }
     }
 
-    if (!ezQtEditorApp::GetSingleton()->IsInSafeMode())
-    {
-      ezQtContainerWindow::GetContainerWindow()->ScheduleRestoreWindowLayout();
-    }
+    // Show the window maximized when opening a project
+    ezQtContainerWindow::GetContainerWindow()->showMaximized();
   }
   return EZ_SUCCESS;
 }

--- a/Code/Editor/EditorFramework/EditorApp/Qt.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Qt.cpp
@@ -157,6 +157,8 @@ static void QtDebugMessageHandler(QtMsgType type, const QMessageLogContext& cont
       // I just hate this pointless message
       if (sMsg.FindSubString("iCCP") != nullptr)
         return;
+      if (sMsg.FindSubString("Unable to set geometry") != nullptr)
+        return;
 
       ezLog::Warning("|Qt| {0} ({1}:{2}, {3})", sMsg, context.file, context.line, context.function);
       break;

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -324,9 +324,6 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
 
   ezStartup::StartupCoreSystems();
 
-  // prevent restoration of window layouts when in safe mode
-  ezQtDocumentWindow::s_bAllowRestoreWindowLayout = !IsInSafeMode();
-
   {
     // Make sure that we have at least 4 worker threads for short running and 4 worker threads for long running tasks.
     // Otherwise the Editor might deadlock during asset transform.
@@ -441,11 +438,12 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
       CreateOrOpenProject(false, m_RecentProjects.GetFileList()[0].m_File).IgnoreResult();
     }
   }
-  else if (!IsInHeadlessMode() && !IsInSafeMode())
+  else if (!IsInHeadlessMode())
   {
+    // Show the window maximized when no project is being loaded
     if (ezQtContainerWindow::GetContainerWindow())
     {
-      ezQtContainerWindow::GetContainerWindow()->ScheduleRestoreWindowLayout();
+      ezQtContainerWindow::GetContainerWindow()->showMaximized();
     }
   }
 

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -10,6 +10,7 @@
 #include <EditorFramework/Actions/TransformGizmoActions.h>
 #include <EditorFramework/Actions/ViewActions.h>
 #include <EditorFramework/Actions/ViewLightActions.h>
+#include <EditorFramework/Actions/WindowLayoutActions.h>
 #include <EditorFramework/CodeGen/CodeEditorPreferencesWidget.moc.h>
 #include <EditorFramework/CodeGen/CompilerPreferencesWidget.moc.h>
 #include <EditorFramework/CodeGen/CppProject.h>
@@ -103,6 +104,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezTransformGizmoActions::RegisterActions();
     ezTranslateGizmoAction::RegisterActions();
     ezCommonAssetActions::RegisterActions();
+    ezWindowLayoutActions::RegisterActions();
 
     // Default Asset Menu Bar
     // All asset menu bar mappings should derive from this to allow for actions to be defined that show up in every asset document editor's menu bar.
@@ -197,6 +199,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezTransformGizmoActions::UnregisterActions();
     ezTranslateGizmoAction::UnregisterActions();
     ezCommonAssetActions::UnregisterActions();
+    ezWindowLayoutActions::UnregisterActions();
 
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezFileBrowserAttribute>());
     ezQtPropertyGridWidget::GetFactory().UnregisterCreator(ezGetStaticRTTI<ezExternalFileBrowserAttribute>());
@@ -406,6 +409,12 @@ void ezQtEditorApp::StartupEditor(ezBitflags<StartupFlags> startupFlags, const c
   }
 
   LoadEditorPlugins();
+
+  if (!IsInHeadlessMode() && !IsInSafeMode())
+  {
+    ezWindowLayoutActions::RestoreUserLayout();
+  }
+
   CloseSplashScreen();
 
   m_bIsRunning = true;
@@ -479,7 +488,7 @@ void ezQtEditorApp::ShutdownEditor()
   m_bIsRunning = false;
   ezStackTraceLogParser::Unregister();
 
-  ezToolsProject::SaveProjectState();
+  // ezToolsProject::SaveProjectState();
 
   m_pTimer->stop();
 

--- a/Code/Editor/EditorFramework/Settings/EditorSettings.cpp
+++ b/Code/Editor/EditorFramework/Settings/EditorSettings.cpp
@@ -31,7 +31,6 @@ void ezQtEditorApp::LoadRecentFiles()
 
 void ezQtEditorApp::SaveOpenDocumentsList()
 {
-  ezQtContainerWindow::GetContainerWindow()->SaveWindowLayout();
   const ezDynamicArray<ezQtDocumentWindow*>& windows = ezQtDocumentWindow::GetAllDocumentWindows();
 
   if (windows.IsEmpty())

--- a/Code/Editor/EditorFramework/Settings/SettingsTab.cpp
+++ b/Code/Editor/EditorFramework/Settings/SettingsTab.cpp
@@ -16,7 +16,7 @@ ezString ezQtSettingsTab::GetWindowIcon() const
 
 ezString ezQtSettingsTab::GetDisplayNameShort() const
 {
-  return "";
+  return "Settings";
 }
 
 void ezQtEditorApp::ShowSettingsDocument()

--- a/Code/Editor/EditorFramework/Settings/SettingsTab.moc.h
+++ b/Code/Editor/EditorFramework/Settings/SettingsTab.moc.h
@@ -18,8 +18,6 @@ public:
   virtual ezString GetWindowIcon() const override;
   virtual ezString GetDisplayNameShort() const override;
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "Settings"; }
-
 private:
   virtual bool InternalCanCloseWindow() override;
   virtual void InternalCloseDocumentWindow() override;

--- a/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptWindow/AngelScriptWindow.moc.h
+++ b/Code/EditorPlugins/AngelScript/EditorPluginAngelScript/AngelScriptWindow/AngelScriptWindow.moc.h
@@ -19,8 +19,6 @@ public:
   ezQtAngelScriptAssetDocumentWindow(ezAngelScriptAssetDocument* pDocument);
   ~ezQtAngelScriptAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "AngelScript"; }
-
 private Q_SLOTS:
   void onTextEditTextChanged();
   void onEditTimer();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimatedMeshAsset/AnimatedMeshAssetWindow.moc.h
@@ -21,7 +21,6 @@ public:
   ~ezQtAnimatedMeshAssetDocumentWindow();
 
   ezAnimatedMeshAssetDocument* GetMeshDocument();
-  virtual const char* GetWindowLayoutGroupName() const override { return "AnimatedMeshAsset"; }
 
 protected:
   virtual void InternalRedraw() override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationClipAsset/AnimationClipAssetWindow.moc.h
@@ -21,7 +21,6 @@ public:
   ~ezQtAnimationClipAssetDocumentWindow();
 
   ezAnimationClipAssetDocument* GetAnimationClipDocument();
-  virtual const char* GetWindowLayoutGroupName() const override { return "AnimationClipAsset"; }
 
   void ExtractRootMotionFromFeet();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/AnimationGraphAsset/AnimationGraphAssetWindow.moc.h
@@ -15,8 +15,6 @@ public:
   ezQtAnimationGraphAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtAnimationGraphAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "AnimationGraphAsset"; }
-
 private Q_SLOTS:
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/BlackboardTemplateAsset/BlackboardTemplateAssetWindow.moc.h
@@ -12,8 +12,6 @@ public:
   ezQtBlackboardTemplateAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtBlackboardTemplateAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "BlackboardTemplateAsset"; }
-
 private:
   void UpdatePreview();
   void RestoreResource();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CollectionAsset/CollectionAssetWindow.moc.h
@@ -11,6 +11,4 @@ class ezQtCollectionAssetDocumentWindow : public ezQtDocumentWindow
 public:
   ezQtCollectionAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtCollectionAssetDocumentWindow();
-
-  virtual const char* GetWindowLayoutGroupName() const override { return "CollectionAsset"; }
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ColorGradientAsset/ColorGradientAssetWindow.moc.h
@@ -14,8 +14,6 @@ public:
   ezQtColorGradientAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtColorGradientAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "ColorGradientAsset"; }
-
 private Q_SLOTS:
   void onGradientColorCpAdded(double posX, const ezColorGammaUB& color);
   void onGradientAlphaCpAdded(double posX, ezUInt8 alpha);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Curve1DAsset/Curve1DAssetWindow.moc.h
@@ -14,8 +14,6 @@ public:
   ezQtCurve1DAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtCurve1DAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "Curve1DAsset"; }
-
 private Q_SLOTS:
   void onInsertCpAt(ezUInt32 uiCurveIdx, ezInt64 tickX, double newPosY);
   void onCurveCpMoved(ezUInt32 curveIdx, ezUInt32 cpIdx, ezInt64 iTickX, double newPosY);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/CustomDataAsset/CustomDataAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/CustomDataAsset/CustomDataAssetWindow.moc.h
@@ -10,6 +10,4 @@ class ezQtCustomDataAssetDocumentWindow : public ezQtDocumentWindow
 
 public:
   ezQtCustomDataAssetDocumentWindow(ezDocument* pDocument);
-
-  virtual const char* GetWindowLayoutGroupName() const override { return "CustomDataAsset"; }
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/DecalAsset/DecalAssetWindow.moc.h
@@ -16,8 +16,6 @@ class ezQtDecalAssetDocumentWindow : public ezQtEngineDocumentWindow
 public:
   ezQtDecalAssetDocumentWindow(ezDecalAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "DecalAsset"; }
-
 private:
   virtual void InternalRedraw() override;
   void SendRedrawMsg();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/ImageDataAsset/ImageDataAssetWindow.moc.h
@@ -20,8 +20,6 @@ class ezQtImageDataAssetDocumentWindow : public ezQtDocumentWindow
 public:
   ezQtImageDataAssetDocumentWindow(ezImageDataAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "ImageDataAsset"; }
-
 private:
   void ImageDataAssetEventHandler(const ezImageDataAssetEvent& e);
   ezEvent<const ezImageDataAssetEvent&>::Unsubscriber m_EventUnsubscriper;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/LUTAsset/LUTAssetWindow.moc.h
@@ -15,8 +15,6 @@ class ezQtLUTAssetDocumentWindow : public ezQtDocumentWindow
 
 public:
   ezQtLUTAssetDocumentWindow(ezLUTAssetDocument* pDocument);
-
-  virtual const char* GetWindowLayoutGroupName() const override { return "LUTAsset"; }
 };
 
 class ezLUTAssetActions

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAssetWindow.moc.h
@@ -27,7 +27,6 @@ public:
   ~ezQtMaterialAssetDocumentWindow();
 
   ezMaterialAssetDocument* GetMaterialDocument();
-  virtual const char* GetWindowLayoutGroupName() const override { return "MaterialAsset"; }
 
 protected:
   virtual void InternalRedraw() override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MeshAsset/MeshAssetWindow.moc.h
@@ -20,7 +20,6 @@ public:
   ~ezQtMeshAssetDocumentWindow();
 
   ezMeshAssetDocument* GetMeshDocument();
-  virtual const char* GetWindowLayoutGroupName() const override { return "MeshAsset"; }
 
 protected:
   virtual void InternalRedraw() override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/PropertyAnimAsset/PropertyAnimAssetWindow.moc.h
@@ -58,8 +58,6 @@ public:
   ezQtPropertyAnimAssetDocumentWindow(ezPropertyAnimAssetDocument* pDocument);
   ~ezQtPropertyAnimAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "PropertyAnimAsset"; }
-
 public Q_SLOTS:
   void ToggleViews(QWidget* pView);
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/RenderPipelineAsset/RenderPipelineAssetWindow.moc.h
@@ -15,8 +15,6 @@ public:
   ezQtRenderPipelineAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtRenderPipelineAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "RenderPipelineAsset"; }
-
 private Q_SLOTS:
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SkeletonAsset/SkeletonAssetWindow.moc.h
@@ -18,7 +18,6 @@ public:
   ~ezQtSkeletonAssetDocumentWindow();
 
   ezSkeletonAssetDocument* GetSkeletonDocument();
-  virtual const char* GetWindowLayoutGroupName() const override { return "SkeletonAsset"; }
 
 protected:
   virtual void InternalRedraw() override;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/StateMachineAsset/StateMachineAssetWindow.moc.h
@@ -15,8 +15,6 @@ public:
   ezQtStateMachineAssetDocumentWindow(ezDocument* pDocument);
   ~ezQtStateMachineAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "StateMachineAsset"; }
-
 private Q_SLOTS:
 
 private:

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/SurfaceAsset/SurfaceAssetWindow.moc.h
@@ -10,6 +10,4 @@ class ezQtSurfaceAssetDocumentWindow : public ezQtDocumentWindow
 
 public:
   ezQtSurfaceAssetDocumentWindow(ezDocument* pDocument);
-
-  virtual const char* GetWindowLayoutGroupName() const override { return "SurfaceAsset"; }
 };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetWindow.moc.h
@@ -18,8 +18,6 @@ class ezQtTextureAssetDocumentWindow : public ezQtEngineDocumentWindow
 public:
   ezQtTextureAssetDocumentWindow(ezTextureAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "TextureAsset"; }
-
 private:
   virtual void InternalRedraw() override;
   void SendRedrawMsg();

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetWindow.moc.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureCubeAsset/TextureCubeAssetWindow.moc.h
@@ -18,8 +18,6 @@ class ezQtTextureCubeAssetDocumentWindow : public ezQtEngineDocumentWindow
 public:
   ezQtTextureCubeAssetDocumentWindow(ezTextureCubeAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "TextureCubeAsset"; }
-
 private:
   virtual void InternalRedraw() override;
   void SendRedrawMsg();

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundBankAsset/SoundBankAssetWindow.moc.h
@@ -17,7 +17,6 @@ public:
   ezSoundBankAssetDocumentWindow(ezDocument* pDocument);
 
   virtual const char* GetGroupName() const { return "SoundBankAsset"; }
-  virtual const char* GetWindowLayoutGroupName() const override { return "SoundBankAsset"; }
 
 private:
   ezSoundBankAssetDocument* m_pAssetDoc;

--- a/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetWindow.moc.h
+++ b/Code/EditorPlugins/Fmod/EditorPluginFmod/SoundEventAsset/SoundEventAssetWindow.moc.h
@@ -17,7 +17,6 @@ public:
   ~ezSoundEventAssetDocumentWindow();
 
   virtual const char* GetGroupName() const { return "SoundEventAsset"; }
-  virtual const char* GetWindowLayoutGroupName() const { return "SoundEventAsset"; }
 
 private Q_SLOTS:
 

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetWindow.moc.h
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/CollisionMeshAsset/JoltCollisionMeshAssetWindow.moc.h
@@ -14,8 +14,6 @@ class ezQtJoltCollisionMeshAssetDocumentWindow : public ezQtEngineDocumentWindow
 public:
   ezQtJoltCollisionMeshAssetDocumentWindow(ezAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "JoltCollisionMeshAsset"; }
-
 protected:
   virtual void InternalRedraw() override;
   virtual void ProcessMessageEventHandler(const ezEditorEngineDocumentMsg* pMsg) override;

--- a/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetWindow.moc.h
+++ b/Code/EditorPlugins/Kraut/EditorPluginKraut/KrautTreeAsset/KrautTreeAssetWindow.moc.h
@@ -15,8 +15,6 @@ public:
   ezQtKrautTreeAssetDocumentWindow(ezAssetDocument* pDocument);
   ~ezQtKrautTreeAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "KrautTreeAsset"; }
-
 protected:
   virtual void InternalRedraw() override;
   virtual void ProcessMessageEventHandler(const ezEditorEngineDocumentMsg* pMsg) override;

--- a/Code/EditorPlugins/MiniAudio/EditorPluginMiniAudio/SoundAsset/MiniAudioSoundAssetWindow.moc.h
+++ b/Code/EditorPlugins/MiniAudio/EditorPluginMiniAudio/SoundAsset/MiniAudioSoundAssetWindow.moc.h
@@ -17,7 +17,6 @@ public:
   ezMiniAudioSoundAssetDocumentWindow(ezDocument* pDocument);
 
   virtual const char* GetGroupName() const { return "MiniAudioSoundAsset"; }
-  virtual const char* GetWindowLayoutGroupName() const override { return "MiniAudioSoundAsset"; }
 
 private:
   ezMiniAudioSoundAssetDocument* m_pAssetDoc;

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.cpp
@@ -270,11 +270,6 @@ ezQtParticleEffectAssetDocumentWindow::~ezQtParticleEffectAssetDocumentWindow()
   GetDocument()->GetObjectManager()->m_PropertyEvents.RemoveEventHandler(ezMakeDelegate(&ezQtParticleEffectAssetDocumentWindow::PropertyEventHandler, this));
 }
 
-const char* ezQtParticleEffectAssetDocumentWindow::GetWindowLayoutGroupName() const
-{
-  return "ParticleEffectAsset2";
-}
-
 ezParticleEffectAssetDocument* ezQtParticleEffectAssetDocumentWindow::GetParticleDocument()
 {
   return static_cast<ezParticleEffectAssetDocument*>(GetDocument());

--- a/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.moc.h
+++ b/Code/EditorPlugins/Particle/EditorPluginParticle/ParticleEffectAsset/ParticleEffectAssetWindow.moc.h
@@ -22,7 +22,6 @@ public:
   ezQtParticleEffectAssetDocumentWindow(ezAssetDocument* pDocument);
   ~ezQtParticleEffectAssetDocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override;
   ezParticleEffectAssetDocument* GetParticleDocument();
 
 private Q_SLOTS:

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.moc.h
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAssetWindow.moc.h
@@ -19,8 +19,6 @@ public:
 
   ezProcGenGraphAssetDocument* GetProcGenGraphDocument();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "ProcGenAsset"; }
-
 private Q_SLOTS:
 
 

--- a/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetWindow.moc.h
+++ b/Code/EditorPlugins/RmlUi/EditorPluginRmlUi/RmlUiAsset/RmlUiAssetWindow.moc.h
@@ -14,8 +14,6 @@ class ezQtRmlUiAssetDocumentWindow : public ezQtEngineDocumentWindow
 public:
   ezQtRmlUiAssetDocumentWindow(ezAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "RmlUiAsset"; }
-
 protected:
   virtual void InternalRedraw() override;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2DocumentWindow.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2DocumentWindow.moc.h
@@ -12,7 +12,6 @@ public:
   ezQtScene2DocumentWindow(ezScene2Document* pDocument);
   ~ezQtScene2DocumentWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "Scene2"; }
   virtual bool InternalCanCloseWindow() override;
 
   ezStatus SaveAllLayers();

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentWindow.moc.h
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/SceneDocumentWindow.moc.h
@@ -72,6 +72,4 @@ class ezQtSceneDocumentWindow : public ezQtSceneDocumentWindowBase
 public:
   ezQtSceneDocumentWindow(ezSceneDocument* pDocument);
   ~ezQtSceneDocumentWindow();
-
-  virtual const char* GetWindowLayoutGroupName() const override { return "Scene"; }
 };

--- a/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAssetWindow.moc.h
+++ b/Code/EditorPlugins/Substance/EditorPluginSubstance/Assets/SubstancePackageAssetWindow.moc.h
@@ -15,8 +15,6 @@ class ezQtSubstancePackageAssetWindow : public ezQtEngineDocumentWindow
 public:
   ezQtSubstancePackageAssetWindow(ezSubstancePackageAssetDocument* pDocument);
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "SubstancePackageAsset"; }
-
 private:
   virtual void InternalRedraw() override;
   void SendRedrawMsg();

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptWindow.moc.h
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptWindow.moc.h
@@ -15,8 +15,6 @@ public:
   ezQtVisualScriptWindow(ezDocument* pDocument);
   ~ezQtVisualScriptWindow();
 
-  virtual const char* GetWindowLayoutGroupName() const override { return "VisualScriptGraph"; }
-
 private Q_SLOTS:
 
 private:

--- a/Code/Tools/Libs/GuiFoundation/Action/Implementation/StandardMenus.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Action/Implementation/StandardMenus.cpp
@@ -10,6 +10,7 @@ ezActionDescriptorHandle ezStandardMenus::s_hMenuProject;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuFile;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuEdit;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuPanels;
+ezActionDescriptorHandle ezStandardMenus::s_hMenuPanelsAll;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuScene;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuAsset;
 ezActionDescriptorHandle ezStandardMenus::s_hMenuView;
@@ -24,7 +25,8 @@ void ezStandardMenus::RegisterActions()
   s_hMenuProject = EZ_REGISTER_MENU("G.Project");
   s_hMenuFile = EZ_REGISTER_MENU("G.File");
   s_hMenuEdit = EZ_REGISTER_MENU("G.Edit");
-  s_hMenuPanels = EZ_REGISTER_DYNAMIC_MENU("G.Panels", ezApplicationPanelsMenuAction, "");
+  s_hMenuPanels = EZ_REGISTER_MENU("G.Panels");
+  s_hMenuPanelsAll = EZ_REGISTER_DYNAMIC_MENU("Panels.All", ezApplicationPanelsMenuAction, "Show Panels");
   s_hMenuScene = EZ_REGISTER_MENU("G.Scene");
   s_hMenuAsset = EZ_REGISTER_MENU("G.Asset");
   s_hMenuView = EZ_REGISTER_MENU("G.View");
@@ -41,6 +43,7 @@ void ezStandardMenus::UnregisterActions()
   ezActionManager::UnregisterAction(s_hMenuFile);
   ezActionManager::UnregisterAction(s_hMenuEdit);
   ezActionManager::UnregisterAction(s_hMenuPanels);
+  ezActionManager::UnregisterAction(s_hMenuPanelsAll);
   ezActionManager::UnregisterAction(s_hMenuScene);
   ezActionManager::UnregisterAction(s_hMenuAsset);
   ezActionManager::UnregisterAction(s_hMenuView);
@@ -80,7 +83,10 @@ void ezStandardMenus::MapActions(ezStringView sMapping, const ezBitflags<ezStand
     pMap->MapAction(s_hMenuTools, "", 6.0f);
 
   if (menus.IsAnySet(ezStandardMenuTypes::Panels))
+  {
     pMap->MapAction(s_hMenuPanels, "", 7.0f);
+    pMap->MapAction(s_hMenuPanelsAll, "G.Panels", 1.0f);
+  }
 
   if (menus.IsAnySet(ezStandardMenuTypes::Help))
   {

--- a/Code/Tools/Libs/GuiFoundation/Action/StandardMenus.h
+++ b/Code/Tools/Libs/GuiFoundation/Action/StandardMenus.h
@@ -51,6 +51,7 @@ public:
   static ezActionDescriptorHandle s_hMenuFile;
   static ezActionDescriptorHandle s_hMenuEdit;
   static ezActionDescriptorHandle s_hMenuPanels;
+  static ezActionDescriptorHandle s_hMenuPanelsAll;
   static ezActionDescriptorHandle s_hMenuScene;
   static ezActionDescriptorHandle s_hMenuAsset;
   static ezActionDescriptorHandle s_hMenuView;

--- a/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ActionViews/Implementation/QtProxy.cpp
@@ -378,11 +378,14 @@ void SetupQAction(ezAction* pAction, QPointer<QAction>& ref_pQtAction, QObject* 
       break;
       case ezActionScope::Document:
       {
-        // Parent is set to the window belonging to the document.
-        ezQtDocumentWindow* pWindow = ezQtDocumentWindow::FindWindowByDocument(pAction->GetContext().m_pDocument);
-        EZ_ASSERT_DEBUG(pWindow != nullptr, "You can't map a ezActionScope::Document action without that document existing!");
-        ref_pQtAction->setParent(pWindow);
-        ref_pQtAction->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+        if (pAction->GetContext().m_pDocument)
+        {
+          // Parent is set to the window belonging to the document.
+          ezQtDocumentWindow* pWindow = ezQtDocumentWindow::FindWindowByDocument(pAction->GetContext().m_pDocument);
+          EZ_ASSERT_DEBUG(pWindow != nullptr, "You can't map a ezActionScope::Document action without that document existing!");
+          ref_pQtAction->setParent(pWindow);
+          ref_pQtAction->setShortcutContext(Qt::ShortcutContext::WidgetWithChildrenShortcut);
+        }
       }
       break;
       case ezActionScope::Window:

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -153,15 +153,6 @@ void ezQtContainerWindow::UpdateWindowDecoration(ezQtDocumentWindow* pDocWindow)
   dock->setIcon(ezQtUiServices::GetCachedIconResource(pDocWindow->GetWindowIcon().GetData()));
   dock->setWindowTitle(QString::fromUtf8(pDocWindow->GetDisplayNameShort().GetData()));
 
-  // this is a hacky way to detect the ezQtSettingsTab
-  if (pDocWindow->GetDisplayNameShort().IsEmpty())
-  {
-    dock->setFeature(ads::CDockWidget::DockWidgetClosable, false);
-    dock->setFeature(ads::CDockWidget::DockWidgetMovable, false);
-    dock->setFeature(ads::CDockWidget::DockWidgetFloatable, false);
-    dock->setFeature(ads::CDockWidget::NoTab, true);
-  }
-
   if (dock->isFloating())
   {
     dock->dockContainer()->floatingWidget()->setWindowTitle(dock->windowTitle());
@@ -205,7 +196,7 @@ void ezQtContainerWindow::RemoveDocumentWindow(ezQtDocumentWindow* pDocWindow)
   {
     for (auto pDocWindow2 : m_DocumentWindows)
     {
-      UpdateWindowDecoration(pDocWindow);
+      UpdateWindowDecoration(pDocWindow2);
     }
   }
 }
@@ -247,6 +238,15 @@ void ezQtContainerWindow::AddDocumentWindow(ezQtDocumentWindow* pDocWindow)
 
   dock->setFeature(ads::CDockWidget::CustomCloseHandling, true);
   dock->setFeature(ads::CDockWidget::DockWidgetPinnable, false);
+
+  // this is a hacky way to detect the ezQtSettingsTab
+  if (displayName == "Settings")
+  {
+    dock->setFeature(ads::CDockWidget::DockWidgetClosable, false);
+    dock->setFeature(ads::CDockWidget::DockWidgetMovable, false);
+    dock->setFeature(ads::CDockWidget::DockWidgetFloatable, false);
+    dock->setFeature(ads::CDockWidget::NoTab, true);
+  }
 
   dock->setObjectName(pDocWindow->GetUniqueName());
   EZ_ASSERT_DEV(!dock->objectName().isEmpty(), "Dock name must not be empty.");
@@ -343,6 +343,69 @@ ezResult ezQtContainerWindow::EnsureVisible(ezQtApplicationPanel* pPanel)
   }
   pPanel->raise();
   return EZ_SUCCESS;
+}
+
+void ezQtContainerWindow::SaveDocumentWindowStates(ezMap<ads::CDockWidget*, DocumentWindowState>& out_states)
+{
+  out_states.Clear();
+  for (ads::CDockWidget* pDock : m_DocumentDocks)
+  {
+    DocumentWindowState state;
+    state.m_bFloating = pDock->isFloating();
+    out_states[pDock] = state;
+  }
+}
+
+void ezQtContainerWindow::RestoreDocumentWindowStates(const ezMap<ads::CDockWidget*, DocumentWindowState>& states)
+{
+  if (m_DocumentDocks.IsEmpty())
+    return;
+
+  // Find a dock area where documents are docked (not floating, not closed)
+  ads::CDockAreaWidget* pDocumentArea = nullptr;
+  for (ads::CDockWidget* pDock : m_DocumentDocks)
+  {
+    if (!pDock->isClosed() && !pDock->isFloating())
+    {
+      pDocumentArea = pDock->dockAreaWidget();
+      break;
+    }
+  }
+
+  // Restore each document window to its previous state
+  for (ads::CDockWidget* pDock : m_DocumentDocks)
+  {
+    auto it = states.Find(pDock);
+    const bool bWasFloating = it.IsValid() ? it.Value().m_bFloating : false;
+
+    if (pDock->isClosed())
+    {
+      if (bWasFloating)
+      {
+        // Was floating, make it floating again
+        m_pDockManager->addDockWidgetFloating(pDock);
+      }
+      else
+      {
+        // Was docked, re-dock it
+        if (pDocumentArea != nullptr)
+        {
+          m_pDockManager->addDockWidgetTabToArea(pDock, pDocumentArea);
+        }
+        else
+        {
+          // No area yet, add to center and use that as the document area
+          pDocumentArea = m_pDockManager->addDockWidgetTab(ads::CenterDockWidgetArea, pDock);
+        }
+      }
+    }
+    // If not closed, leave it as-is (it's already visible, either floating or docked)
+  }
+
+  for (auto pDocWindow : m_DocumentWindows)
+  {
+    UpdateWindowDecoration(pDocWindow);
+  }
 }
 
 ezResult ezQtContainerWindow::EnsureVisibleAnyContainer(ezDocument* pDocument)

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -6,11 +6,8 @@
 #include <GuiFoundation/DockPanels/ApplicationPanel.moc.h>
 #include <QCloseEvent>
 #include <QLabel>
-#include <QSettings>
 #include <QStatusBar>
 #include <QTabBar>
-#include <QTimer>
-#include <ToolsFoundation/Application/ApplicationServices.h>
 #include <ads/DockAreaWidget.h>
 #include <ads/DockManager.h>
 #include <ads/DockWidgetTab.h>
@@ -19,44 +16,10 @@
 ezQtContainerWindow* ezQtContainerWindow::s_pContainerWindow = nullptr;
 bool ezQtContainerWindow::s_bForceClose = false;
 
-namespace
-{
-  bool GetProjectLayoutPath(ezStringBuilder& out_sFile, bool bWrite)
-  {
-    if (!ezToolsProject::IsProjectOpen())
-    {
-      out_sFile.Clear();
-      return false;
-    }
-    out_sFile = ezApplicationServices::GetSingleton()->GetProjectPreferencesFolder();
-    out_sFile.AppendPath("layout.settings");
-    if (!bWrite && !QFile::exists(out_sFile.GetData()))
-    {
-      out_sFile.Clear();
-      return false;
-    }
-    return true;
-  }
-
-  bool GetApplicationLayoutPath(ezStringBuilder& out_sFile, bool bWrite)
-  {
-    out_sFile = ezApplicationServices::GetSingleton()->GetApplicationPreferencesFolder();
-    out_sFile.AppendPath("layout.settings");
-    if (!bWrite && !QFile::exists(out_sFile.GetData()))
-    {
-      out_sFile.Clear();
-      return false;
-    }
-    return true;
-  }
-} // namespace
-
 ezQtContainerWindow::ezQtContainerWindow()
 {
   setMinimumSize(QSize(800, 600));
-  m_bWindowLayoutRestored = false;
   m_pStatusBarLabel = nullptr;
-  m_iWindowLayoutRestoreScheduled = 0;
 
   s_pContainerWindow = this;
 
@@ -125,22 +88,8 @@ void ezQtContainerWindow::UpdateWindowTitle()
   setWindowTitle(QString::fromUtf8(sTitle.GetData()));
 }
 
-void ezQtContainerWindow::ScheduleRestoreWindowLayout()
-{
-  m_iWindowLayoutRestoreScheduled++;
-  QTimer::singleShot(0, this, SLOT(SlotRestoreLayout()));
-}
-
-void ezQtContainerWindow::SlotRestoreLayout()
-{
-  RestoreWindowLayout();
-}
-
 void ezQtContainerWindow::closeEvent(QCloseEvent* e)
 {
-  SaveWindowLayout();
-  SaveDocumentLayouts();
-
   if (s_bForceClose)
     return;
 
@@ -162,7 +111,6 @@ void ezQtContainerWindow::closeEvent(QCloseEvent* e)
   ezDynamicArray<ezQtDocumentWindow*> windows = m_DocumentWindows;
   for (ezQtDocumentWindow* pWindow : windows)
   {
-    pWindow->DisableWindowLayoutSaving();
     pWindow->ShutdownDocumentWindow();
   }
 
@@ -170,123 +118,6 @@ void ezQtContainerWindow::closeEvent(QCloseEvent* e)
   m_pDockManager->deleteLater();
   m_pDockManager = nullptr;
   QMainWindow::closeEvent(e);
-}
-
-void ezQtContainerWindow::SaveWindowLayout()
-{
-  if (!m_pDockManager)
-    return;
-
-  ezStringBuilder sFile;
-  GetApplicationLayoutPath(sFile, true);
-
-  ezStringBuilder sProjectFile;
-  GetProjectLayoutPath(sProjectFile, true);
-
-  QSettings Settings(ezToolsProject::IsProjectOpen() ? sProjectFile.GetData() : sFile.GetData(), QSettings::IniFormat);
-  Settings.beginGroup(QString::fromUtf8("ContainerWnd_ezEditor"));
-  {
-    Settings.setValue("DockManagerState", m_pDockManager->saveState(1));
-    Settings.setValue("WindowGeometry", saveGeometry());
-    Settings.setValue("WindowState", saveState());
-  }
-  Settings.endGroup();
-
-  if (ezToolsProject::IsProjectOpen())
-  {
-    // The last open project always serves as the default layout in case
-    // a new project is created or a project without layout data is opened.
-    QFile::remove(sFile.GetData());
-    QFile::copy(sProjectFile.GetData(), sFile.GetData());
-  }
-}
-
-void ezQtContainerWindow::SaveDocumentLayouts()
-{
-  for (ezUInt32 i = 0; i < m_DocumentWindows.GetCount(); ++i)
-    m_DocumentWindows[i]->SaveWindowLayout();
-}
-
-void ezQtContainerWindow::RestoreWindowLayout()
-{
-  --m_iWindowLayoutRestoreScheduled;
-  if (m_iWindowLayoutRestoreScheduled > 0)
-    return;
-
-  bool bCreteDefaultLayout = true;
-  EZ_SCOPE_EXIT(bCreteDefaultLayout ? showMaximized() : show(););
-
-  ezStringBuilder sFile;
-  if (!GetProjectLayoutPath(sFile, false))
-  {
-    if (!GetApplicationLayoutPath(sFile, false))
-    {
-      // No project or app settings file found, exiting.
-      return;
-    }
-  }
-
-  {
-    QSettings Settings(sFile.GetData(), QSettings::IniFormat);
-    Settings.beginGroup(QString::fromUtf8("ContainerWnd_ezEditor"));
-    {
-      QByteArray geom = Settings.value("WindowGeometry", QByteArray()).toByteArray();
-      if (!geom.isEmpty())
-      {
-        bCreteDefaultLayout = false;
-        restoreGeometry(geom);
-        restoreState(Settings.value("WindowState", saveState()).toByteArray());
-        auto dockState = Settings.value("DockManagerState");
-        if (dockState.isValid() && dockState.typeId() == QMetaType::QByteArray)
-        {
-          m_pDockManager->restoreState(dockState.toByteArray(), 1);
-          // As document windows can't be in a closed state (as pressing x destroys them),
-          // we need to fix any document window that was accidentally saved in its closed state.
-          for (ads::CDockWidget* dock : m_DocumentDocks)
-          {
-            if (dock->isClosed())
-            {
-              if (dock->dockContainer() == nullptr)
-              {
-                if (m_DocumentDocks.GetCount() >= 2)
-                {
-                  // If we can (we are not the only dock window), we are going to attach to a window that isn't us, ideally the settings window.
-                  ezUInt32 uiBestIndex = 0;
-                  for (ezUInt32 i = 0; i < m_DocumentDocks.GetCount(); i++)
-                  {
-                    if (ezStringUtils::IsEqual(m_DocumentWindows[i]->GetUniqueName(), "Settings"))
-                    {
-                      uiBestIndex = i;
-                      break;
-                    }
-                    else if (m_DocumentDocks[i] != dock)
-                    {
-                      uiBestIndex = i;
-                    }
-                  }
-
-                  ads::CDockAreaWidget* dockArea = m_DocumentDocks[uiBestIndex]->dockAreaWidget();
-                  m_pDockManager->addDockWidgetTabToArea(dock, dockArea);
-                }
-                else
-                {
-                  m_pDockManager->addDockWidgetTab(ads::CenterDockWidgetArea, dock);
-                }
-              }
-              dock->toggleView();
-            }
-          }
-        }
-      }
-    }
-    Settings.endGroup();
-  }
-
-  // do NOT restore the layouts of the document windows here
-  // the window may be too small at this time, and the layout restoration may thus resize the document widgets to the bare minimum
-  // and destroy the layout
-
-  m_bWindowLayoutRestored = true;
 }
 
 void ezQtContainerWindow::SlotUpdateWindowDecoration(void* pDocWindow)

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.moc.h
@@ -45,6 +45,19 @@ public:
 
   void GetDocumentWindows(ezHybridArray<ezQtDocumentWindow*, 16>& ref_windows);
 
+  struct DocumentWindowState
+  {
+    bool m_bFloating = false;
+  };
+
+  /// Saves the current state (floating/docked) of all document windows.
+  /// Call before restoring a layout.
+  void SaveDocumentWindowStates(ezMap<ads::CDockWidget*, DocumentWindowState>& out_states);
+
+  /// Restores document windows to their previous states after a layout change.
+  /// Call after restoring a layout.
+  void RestoreDocumentWindowStates(const ezMap<ads::CDockWidget*, DocumentWindowState>& states);
+
 protected:
   virtual bool eventFilter(QObject* obj, QEvent* e) override;
 

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.moc.h
@@ -45,12 +45,6 @@ public:
 
   void GetDocumentWindows(ezHybridArray<ezQtDocumentWindow*, 16>& ref_windows);
 
-  void SaveWindowLayout();
-  void SaveDocumentLayouts();
-  void RestoreWindowLayout();
-
-  void ScheduleRestoreWindowLayout();
-
 protected:
   virtual bool eventFilter(QObject* obj, QEvent* e) override;
 
@@ -62,12 +56,8 @@ private:
   ezResult EnsureVisible(ezDocument* pDocument);
   ezResult EnsureVisible(ezQtApplicationPanel* pPanel);
 
-  bool m_bWindowLayoutRestored;
-  ezInt32 m_iWindowLayoutRestoreScheduled;
-
 private Q_SLOTS:
   void SlotDocumentTabCloseRequested();
-  void SlotRestoreLayout();
   void SlotTabsContextMenuRequested(const QPoint& pos);
   void SlotUpdateWindowDecoration(void* pDocWindow);
   void SlotFloatingWidgetOpened(ads::CFloatingDockContainer* FloatingWidget);

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -10,19 +10,15 @@
 #include <GuiFoundation/ContainerWindow/ContainerWindow.moc.h>
 #include <GuiFoundation/DocumentWindow/DocumentWindow.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
-#include <QDockWidget>
 #include <QLabel>
 #include <QMessageBox>
-#include <QSettings>
 #include <QStatusBar>
-#include <QTimer>
 #include <ToolsFoundation/Document/Document.h>
 #include <ads/DockManager.h>
 #include <ads/DockWidget.h>
 
 ezEvent<const ezQtDocumentWindowEvent&> ezQtDocumentWindow::s_Events;
 ezDynamicArray<ezQtDocumentWindow*> ezQtDocumentWindow::s_AllDocumentWindows;
-bool ezQtDocumentWindow::s_bAllowRestoreWindowLayout = true;
 
 void ezQtDocumentWindow::Constructor()
 {
@@ -336,94 +332,6 @@ void ezQtDocumentWindow::FinishWindowCreation()
 {
   if (centralWidget())
     centralWidget()->installEventFilter(this);
-
-  ScheduleRestoreWindowLayout();
-}
-
-void ezQtDocumentWindow::ScheduleRestoreWindowLayout()
-{
-  QTimer::singleShot(0, this, SLOT(SlotRestoreLayout()));
-}
-
-void ezQtDocumentWindow::SlotRestoreLayout()
-{
-  EZ_LOG_BLOCK("DocSlotRestoreLayout");
-
-  RestoreWindowLayout(false);
-}
-
-void ezQtDocumentWindow::SaveWindowLayout()
-{
-  if (GetDocument() == nullptr)
-    return;
-
-  // This is a workaround for newer Qt versions (5.13 or so) that seem to change the state of QDockWidgets to "closed" once the parent
-  // QMainWindow gets the closeEvent, even though they still exist and the QMainWindow is not yet deleted. Previously this function was
-  // called multiple times, including once after the QMainWindow got its closeEvent, which would then save a corrupted state. Therefore,
-  // once the parent ezQtContainerWindow gets the closeEvent, we now prevent further saving of the window layout.
-  if (!m_bAllowSaveWindowLayout)
-    return;
-
-  ezLog::Debug("Save Layout - {}", GetDocument()->GetDocumentTypeName());
-
-  const bool bMaximized = isMaximized();
-
-  if (bMaximized)
-    showNormal();
-
-  QSettings Settings;
-  Settings.beginGroup("DocWndLayout");
-  Settings.beginGroup(GetWindowLayoutGroupName());
-  {
-    // All other properties are defined by the outer container window.
-    Settings.setValue("DocWndState", m_pDockManager->saveState());
-  }
-}
-
-void ezQtDocumentWindow::RestoreWindowLayout(bool bForce)
-{
-  if (GetDocument() == nullptr)
-    return;
-
-  if (!s_bAllowRestoreWindowLayout)
-    return;
-
-  if (!bForce && m_bWindowRestored)
-    return;
-
-  if (GetDocument() != nullptr)
-  {
-    ezLog::Debug("Restore Layout - {} ({})", GetDocument()->GetDocumentTypeName(), GetDocument()->GetDocumentPath());
-  }
-
-  m_bWindowRestored = true;
-
-  ezQtScopedUpdatesDisabled _(this);
-
-  {
-    ezHybridArray<QWidget*, 8> docks;
-
-    for (QDockWidget* dockWidget : findChildren<QDockWidget*>())
-    {
-      dockWidget->show();
-      QWidget* ptr = dockWidget->widget();
-      docks.PushBack(ptr);
-    }
-
-    QSettings Settings;
-    Settings.beginGroup("DocWndLayout");
-    Settings.beginGroup(GetWindowLayoutGroupName());
-    {
-      m_pDockManager->restoreState(Settings.value("DocWndState", m_pDockManager->saveState()).toByteArray());
-    }
-  }
-
-  statusBar()->clearMessage();
-}
-
-void ezQtDocumentWindow::DisableWindowLayoutSaving()
-{
-  m_bAllowSaveWindowLayout = false;
 }
 
 ezStatus ezQtDocumentWindow::SaveDocument()
@@ -569,8 +477,6 @@ void ezQtDocumentWindow::OnStatusBarMessageChanged(const QString& sNewText)
 
 void ezQtDocumentWindow::ShutdownDocumentWindow()
 {
-  SaveWindowLayout();
-
   InternalCloseDocumentWindow();
 
   ezQtDocumentWindowEvent e;

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -12,6 +12,7 @@
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <QLabel>
 #include <QMessageBox>
+#include <QSettings>
 #include <QStatusBar>
 #include <ToolsFoundation/Document/Document.h>
 #include <ads/DockManager.h>
@@ -50,6 +51,9 @@ void ezQtDocumentWindow::Constructor()
 
   ezQtUiServices::s_Events.AddEventHandler(ezMakeDelegate(&ezQtDocumentWindow::UIServicesEventHandler, this));
   ezQtUiServices::s_TickEvent.AddEventHandler(ezMakeDelegate(&ezQtDocumentWindow::UIServicesTickEventHandler, this));
+
+  // Automatically restore the saved nested layout for this document window type
+  QMetaObject::invokeMethod(this, "SlotRestoreDocumentLayout", Qt::ConnectionType::QueuedConnection);
 }
 
 ezQtDocumentWindow::ezQtDocumentWindow(ezDocument* pDocument)
@@ -475,8 +479,64 @@ void ezQtDocumentWindow::OnStatusBarMessageChanged(const QString& sNewText)
   statusBar()->setPalette(pal);
 }
 
+void ezQtDocumentWindow::SlotRestoreDocumentLayout()
+{
+  if (m_pDockManager == nullptr)
+    return;
+
+  const char* szTypeName = metaObject()->className();
+
+  QSettings settings;
+  settings.beginGroup("DocumentWindowLayouts");
+  QByteArray state = settings.value(szTypeName).toByteArray();
+  settings.endGroup();
+
+  if (!state.isEmpty())
+  {
+    m_pDockManager->restoreState(state);
+  }
+
+  // Schedule capturing the initial state after the layout has stabilized
+  // This needs to happen after the window becomes visible and Qt does its layout adjustments
+  QMetaObject::invokeMethod(this, "SlotCaptureInitialLayoutState", Qt::ConnectionType::QueuedConnection);
+}
+
+void ezQtDocumentWindow::SlotCaptureInitialLayoutState()
+{
+  if (m_pDockManager == nullptr || !m_InitialDocumentLayoutState.isEmpty())
+    return;
+
+  // Only capture once the window is actually visible and layouts have stabilized
+  if (!isVisible())
+  {
+    // If not visible yet, try again later
+    QMetaObject::invokeMethod(this, "SlotCaptureInitialLayoutState", Qt::ConnectionType::QueuedConnection);
+    return;
+  }
+
+  // Capture the baseline state after Qt has done its layout adjustments
+  m_InitialDocumentLayoutState = m_pDockManager->saveState();
+}
+
 void ezQtDocumentWindow::ShutdownDocumentWindow()
 {
+  // Auto-save the document layout if it changed
+  if (m_pDockManager != nullptr && !m_InitialDocumentLayoutState.isEmpty())
+  {
+    QByteArray currentState = m_pDockManager->saveState();
+
+    // Only save if the layout actually changed
+    if (currentState != m_InitialDocumentLayoutState)
+    {
+      const char* szTypeName = metaObject()->className();
+
+      QSettings settings;
+      settings.beginGroup("DocumentWindowLayouts");
+      settings.setValue(szTypeName, currentState);
+      settings.endGroup();
+    }
+  }
+
   InternalCloseDocumentWindow();
 
   ezQtDocumentWindowEvent e;

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
@@ -53,17 +53,12 @@ public:
 
   const char* GetUniqueName() const { return m_sUniqueName; }
 
-  /// \brief The 'GroupName' is used for serializing window layouts. It should be unique among different window types.
-  virtual const char* GetWindowLayoutGroupName() const = 0;
-
   ezDocument* GetDocument() const { return m_pDocument; }
 
   ezStatus SaveDocument();
 
   bool CanCloseWindow();
   void CloseDocumentWindow();
-
-  void ScheduleRestoreWindowLayout();
 
   bool IsVisibleInContainer() const { return m_bIsVisibleInContainer; }
   void SetTargetFramerate(ezInt16 iTargetFPS);
@@ -87,9 +82,6 @@ public:
   /// \brief For unit tests to take a screenshot of the window (may include multiple views) to do image comparisons.
   virtual void CreateImageCapture(const char* szOutputPath);
 
-  /// \brief In 'safe' mode we want to prevent the documents from using the stored window layout state
-  static bool s_bAllowRestoreWindowLayout;
-
 protected:
   virtual void showEvent(QShowEvent* event) override;
   virtual void hideEvent(QHideEvent* event) override;
@@ -99,17 +91,12 @@ protected:
   void FinishWindowCreation();
 
 private Q_SLOTS:
-  void SlotRestoreLayout();
   void SlotRedraw();
   void SlotQueuedDelete();
   void OnPermanentGlobalStatusClicked(bool);
   void OnStatusBarMessageChanged(const QString& sNewText);
 
 private:
-  void SaveWindowLayout();
-  void RestoreWindowLayout(bool bForce);
-  void DisableWindowLayoutSaving();
-
   void ShutdownDocumentWindow();
 
 private:
@@ -117,12 +104,10 @@ private:
 
   void SetVisibleInContainer(bool bVisible);
 
-  bool m_bWindowRestored = false;
   bool m_bIsVisibleInContainer = false;
   bool m_bRedrawIsTriggered = false;
   bool m_bIsDrawingATM = false;
   bool m_bTriggerRedrawQueued = false;
-  bool m_bAllowSaveWindowLayout = true;
   ezInt16 m_iTargetFramerate = 0;
   ezDocument* m_pDocument = nullptr;
   ezQtContainerWindow* m_pContainerWindow = nullptr;

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
@@ -27,7 +27,7 @@ struct ezQtDocumentWindowEvent
   };
 
   Type m_Type;
-  ezQtDocumentWindow* m_pWindow;
+  ezQtDocumentWindow* m_pWindow = nullptr;
 };
 
 /// \brief Base class for all document windows. Handles the most basic document window management.
@@ -95,6 +95,8 @@ private Q_SLOTS:
   void SlotQueuedDelete();
   void OnPermanentGlobalStatusClicked(bool);
   void OnStatusBarMessageChanged(const QString& sNewText);
+  void SlotRestoreDocumentLayout();
+  void SlotCaptureInitialLayoutState();
 
 private:
   void ShutdownDocumentWindow();
@@ -113,6 +115,7 @@ private:
   ezQtContainerWindow* m_pContainerWindow = nullptr;
   QLabel* m_pPermanentDocumentStatusText = nullptr;
   QToolButton* m_pPermanentGlobalStatusButton = nullptr;
+  QByteArray m_InitialDocumentLayoutState;
 
 private:
   void Constructor();

--- a/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
+++ b/Code/Tools/Libs/ModelImporter2/ImporterAssimp/ImporterAssimp.cpp
@@ -19,19 +19,31 @@ namespace ezModelImporter2
   class aiLogStreamError : public Assimp::LogStream
   {
   public:
-    void write(const char* szMessage) { ezLog::Warning("AssImp: {0}", szMessage); }
+    void write(const char* szMessage)
+    {
+      if (ezStringUtils::FindSubString(szMessage, "unexpected illumination model") != nullptr)
+        return;
+
+      ezLog::Warning("AssImp: {0}", szMessage);
+    }
   };
 
   class aiLogStreamWarning : public Assimp::LogStream
   {
   public:
-    void write(const char* szMessage) { ezLog::Warning("AssImp: {0}", szMessage); }
+    void write(const char* szMessage)
+    {
+      ezLog::Warning("AssImp: {0}", szMessage);
+    }
   };
 
   class aiLogStreamInfo : public Assimp::LogStream
   {
   public:
-    void write(const char* szMessage) { ezLog::Debug("AssImp: {0}", szMessage); }
+    void write(const char* szMessage)
+    {
+      ezLog::Debug("AssImp: {0}", szMessage);
+    }
   };
 
   ezResult ImporterAssimp::DoImport()

--- a/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Project/ToolsProject.cpp
@@ -120,8 +120,6 @@ void ezToolsProject::SaveProjectState()
 {
   if (GetSingleton())
   {
-    GetSingleton()->m_bIsClosing = true;
-
     ezToolsProjectEvent e;
     e.m_pProject = GetSingleton();
     e.m_Type = ezToolsProjectEvent::Type::ProjectSaveState;

--- a/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
@@ -160,9 +160,10 @@ void ezMaterialDocumentTest::CaptureMaterialImage()
   ezActionManager::ExecuteAction(nullptr, "View.SkyBox", ctx2, false).AssertSuccess();
   ProcessEvents();
 
-  for (int i = 0; i < 10; ++i)
+  // give the engine a bit of time to load the data
+  for (int i = 0; i < 40; ++i)
   {
-    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
+    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(50));
     ProcessEvents();
   }
 

--- a/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
@@ -161,7 +161,7 @@ void ezMaterialDocumentTest::CaptureMaterialImage()
   ProcessEvents();
 
   // give the engine a bit of time to load the data
-  for (int i = 0; i < 40; ++i)
+  for (int i = 0; i < 100; ++i)
   {
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(50));
     ProcessEvents();

--- a/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
@@ -161,7 +161,7 @@ void ezMaterialDocumentTest::CaptureMaterialImage()
   ProcessEvents();
 
   // give the engine a bit of time to load the data
-  for (int i = 0; i < 100; ++i)
+  for (int i = 0; i < 60; ++i)
   {
     ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(50));
     ProcessEvents();

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/AllDeclarations.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/AllDeclarations.txt
@@ -658,6 +658,7 @@ ezColor ezRandomPrefabComponent::get_Color1() const
 ezColor ezRandomPrefabComponent::get_Color2() const
 ezColor ezRopeRenderComponent::get_Color() const
 ezColor ezScriptComponent::GetScriptVariable_asColor(ezHashedString Name) const
+ezColor ezSplineMeshComponent::get_Color() const
 ezColor ezSpriteComponent::get_Color() const
 ezColor ezVolumeComponent::GetValue_asColor(ezTempHashedString Name) const
 ezColorAnimationComponent@ ezComponent::opCast()
@@ -727,6 +728,7 @@ ezComponent@ ezJoltDefaultCharacterComponent::opImplCast()
 ezComponent@ ezJoltDistanceConstraintComponent::opImplCast()
 ezComponent@ ezJoltDynamicActorComponent::opImplCast()
 ezComponent@ ezJoltFixedConstraintComponent::opImplCast()
+ezComponent@ ezJoltGenerateCollisionComponent::opImplCast()
 ezComponent@ ezJoltGrabObjectComponent::opImplCast()
 ezComponent@ ezJoltHingeConstraintComponent::opImplCast()
 ezComponent@ ezJoltHitboxComponent::opImplCast()
@@ -808,6 +810,7 @@ ezComponent@ ezSpawnBoxComponent::opImplCast()
 ezComponent@ ezSpawnComponent::opImplCast()
 ezComponent@ ezSphereReflectionProbeComponent::opImplCast()
 ezComponent@ ezSplineComponent::opImplCast()
+ezComponent@ ezSplineMeshComponent::opImplCast()
 ezComponent@ ezSplineNodeComponent::opImplCast()
 ezComponent@ ezSpotLightComponent::opImplCast()
 ezComponent@ ezSpriteComponent::opImplCast()
@@ -1026,6 +1029,7 @@ ezJoltDynamicActorComponent@ ezComponent::opCast()
 ezJoltDynamicActorComponent@ ezJoltActorComponent::opCast()
 ezJoltFixedConstraintComponent@ ezComponent::opCast()
 ezJoltFixedConstraintComponent@ ezJoltConstraintComponent::opCast()
+ezJoltGenerateCollisionComponent@ ezComponent::opCast()
 ezJoltGrabObjectComponent@ ezComponent::opCast()
 ezJoltHingeConstraintComponent@ ezComponent::opCast()
 ezJoltHingeConstraintComponent@ ezJoltConstraintComponent::opCast()
@@ -1114,6 +1118,7 @@ ezMeshComponentBase@ ezComponent::opCast()
 ezMeshComponentBase@ ezInstancedMeshComponent::opImplCast()
 ezMeshComponentBase@ ezMeshComponent::opImplCast()
 ezMeshComponentBase@ ezRenderComponent::opCast()
+ezMeshComponentBase@ ezSplineMeshComponent::opImplCast()
 ezMeshDecalComponent@ ezComponent::opCast()
 ezMessage@ ezEventMessage::opImplCast()
 ezMessage@ ezEventMsgSetPowerInput::opImplCast()
@@ -1335,6 +1340,7 @@ ezRenderComponent@ ezRmlUiCanvasComponentBase::opImplCast()
 ezRenderComponent@ ezRopeRenderComponent::opImplCast()
 ezRenderComponent@ ezSkeletonComponent::opImplCast()
 ezRenderComponent@ ezSkyBoxComponent::opImplCast()
+ezRenderComponent@ ezSplineMeshComponent::opImplCast()
 ezRenderComponent@ ezSpotLightComponent::opImplCast()
 ezRenderComponent@ ezSpriteComponent::opImplCast()
 ezRenderTargetActivatorComponent@ ezComponent::opCast()
@@ -1424,6 +1430,13 @@ ezSplineComponentFlags::VisualizeTangents
 ezSplineComponentFlags::VisualizeUpDir
 ezSplineComponentSpace::Global
 ezSplineComponentSpace::Local
+ezSplineMeshComponent@ ezComponent::opCast()
+ezSplineMeshComponent@ ezMeshComponentBase::opCast()
+ezSplineMeshComponent@ ezRenderComponent::opCast()
+ezSplineMeshDistributionMode ezSplineMeshComponent::get_DistributionMode() const
+ezSplineMeshDistributionMode::FitToSegment
+ezSplineMeshDistributionMode::ScaleEvenly
+ezSplineMeshDistributionMode::ScaleEvenlyPerSegment
 ezSplineNodeComponent@ ezComponent::opCast()
 ezSplineTangentMode ezSplineNodeComponent::get_TangentModeIn() const
 ezSplineTangentMode ezSplineNodeComponent::get_TangentModeOut() const
@@ -1484,7 +1497,6 @@ ezString ezPostProcessingComponent::get_VolumeType() const
 ezString ezPowerConnectorComponent::get_Buddy() const
 ezString ezPowerConnectorComponent::get_ConnectedTo() const
 ezString ezRaycastComponent::get_RaycastEndObject() const
-ezString ezRmlUiCanvas3DComponent::get_TextureSlotName() const
 ezString ezScriptComponent::GetScriptVariable_asString(ezHashedString Name) const
 ezString ezSensorComponent::get_SpatialCategory() const
 ezString ezSkeletonComponent::get_BonesToHighlight() const
@@ -1537,6 +1549,7 @@ ezStringView ezPropertyAnimComponent::get_Animation() const
 ezStringView ezRenderTargetActivatorComponent::get_RenderTarget() const
 ezStringView ezRmlUiCanvas3DComponent::get_BaseMaterial() const
 ezStringView ezRmlUiCanvas3DComponent::get_ProxyMesh() const
+ezStringView ezRmlUiCanvas3DComponent::get_TextureSlotName() const
 ezStringView ezRmlUiCanvasComponentBase::get_RmlFile() const
 ezStringView ezRopeRenderComponent::get_Material() const
 ezStringView ezScriptComponent::get_ScriptClass() const
@@ -1813,6 +1826,7 @@ ezVec4 ezLodMeshComponent::get_CustomData() const
 ezVec4 ezMath::Lerp(ezVec4 from, ezVec4 to, float factor)
 ezVec4 ezMeshComponent::get_CustomData() const
 ezVec4 ezScriptComponent::GetScriptVariable_asVec4(ezHashedString Name) const
+ezVec4 ezSplineMeshComponent::get_CustomData() const
 ezVec4 ezVec2::GetAsVec4(float z, float w) const
 ezVec4 ezVec3::GetAsDirectionVec4() const
 ezVec4 ezVec3::GetAsPositionVec4() const
@@ -2156,6 +2170,9 @@ float ezSphereReflectionProbeComponent::get_Radius() const
 float ezSplineComponent::FindKeyClosestToPoint(ezVec3 Point, float&out DistanceToPoint, ezSplineComponentSpace Space, float MaxError = 0.1) const
 float ezSplineComponent::GetKeyAtDistance(float Distance) const
 float ezSplineComponent::GetTotalLength() const
+float ezSplineMeshComponent::get_OffsetY() const
+float ezSplineMeshComponent::get_OffsetZ() const
+float ezSplineMeshComponent::get_SortingDepthOffset() const
 float ezSpotLightComponent::get_Range() const
 float ezSpotLightComponent::get_ShadowFadeOutRange() const
 float ezSpriteComponent::get_AspectRatio() const
@@ -2223,6 +2240,7 @@ int ezMsgComponentInternalTrigger::get_Payload() const
 int ezRandom::IntMinMax(int iMinValue, int iMaxValue)
 int ezRotorComponent::get_DegreesToRotate() const
 int ezScriptComponent::GetScriptVariable_asInt32(ezHashedString Name) const
+int ezSplineMeshComponent::get_Seed() const
 int ezString::Compare(ezStringView) const
 int ezString::CompareN(ezStringView, uint) const
 int ezString::CompareN_NoCase(ezStringView, uint) const
@@ -3036,6 +3054,7 @@ void ezRmlUiCanvas3DComponent::set_DpiScale(float)
 void ezRmlUiCanvas3DComponent::set_IsInteractive(bool)
 void ezRmlUiCanvas3DComponent::set_MaterialIndex(uint)
 void ezRmlUiCanvas3DComponent::set_ProxyMesh(ezStringView)
+void ezRmlUiCanvas3DComponent::set_TextureSlotName(ezStringView)
 void ezRmlUiCanvas3DInteractionExampleComponent::set_CollisionLayer(uint)
 void ezRmlUiCanvas3DInteractionExampleComponent::set_MaxDistance(float)
 void ezRmlUiCanvasComponentBase::set_AutobindBlackboards(bool)
@@ -3140,6 +3159,13 @@ void ezSphereReflectionProbeComponent::set_SphereProjection(bool)
 void ezSplineComponent::set_Closed(bool)
 void ezSplineComponent::set_EditNodes(uint8)
 void ezSplineComponent::set_Flags(ezSplineComponentFlags)
+void ezSplineMeshComponent::set_Color(ezColor)
+void ezSplineMeshComponent::set_CustomData(ezVec4)
+void ezSplineMeshComponent::set_DistributionMode(ezSplineMeshDistributionMode)
+void ezSplineMeshComponent::set_OffsetY(float)
+void ezSplineMeshComponent::set_OffsetZ(float)
+void ezSplineMeshComponent::set_Seed(int)
+void ezSplineMeshComponent::set_SortingDepthOffset(float)
 void ezSplineNodeComponent::set_CustomTangentIn(ezVec3)
 void ezSplineNodeComponent::set_CustomTangentOut(ezVec3)
 void ezSplineNodeComponent::set_LinkCustomTangents(bool)

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/Enums.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/Enums.txt
@@ -61,6 +61,7 @@ ExtremeShockwave
 Failed
 Fallen
 Falling
+FitToSegment
 Fixed
 FixedCornerBottomLeft
 FixedCornerBottomRight
@@ -158,6 +159,8 @@ RollXReactions
 RollYReactions
 RollZReactions
 Rope
+ScaleEvenly
+ScaleEvenlyPerSegment
 Seated
 SemiFixed
 SendMoveCharacterMsg

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/Properties.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/Properties.txt
@@ -156,6 +156,7 @@ Dimensions
 Directionality
 DisableTargetObjectOnNoHit
 Distance
+DistributionMode
 DocumentGuid
 DocumentType
 DodgerBlue
@@ -381,6 +382,8 @@ OcclusionDepthOffset
 OcclusionSampleRadius
 OcclusionSampleSpread
 OcclusionThreshold
+OffsetY
+OffsetZ
 OldLace
 OldStateName
 Olive
@@ -492,6 +495,7 @@ Scale
 ScriptClass
 SeaGreen
 SeaShell
+Seed
 SelfCollision
 SendEntryChangedMessage
 SetColorMode

--- a/Data/Samples/Testing Chambers/Editor/AngelScript/Types.txt
+++ b/Data/Samples/Testing Chambers/Editor/AngelScript/Types.txt
@@ -89,6 +89,7 @@ ezJoltDefaultCharacterComponent
 ezJoltDistanceConstraintComponent
 ezJoltDynamicActorComponent
 ezJoltFixedConstraintComponent
+ezJoltGenerateCollisionComponent
 ezJoltGrabObjectComponent
 ezJoltHingeConstraintComponent
 ezJoltHitboxComponent
@@ -228,6 +229,8 @@ ezSphereReflectionProbeComponent
 ezSplineComponent
 ezSplineComponentFlags
 ezSplineComponentSpace
+ezSplineMeshComponent
+ezSplineMeshDistributionMode
 ezSplineNodeComponent
 ezSplineTangentMode
 ezSpotLightComponent

--- a/Data/Samples/Testing Chambers/as.predefined
+++ b/Data/Samples/Testing Chambers/as.predefined
@@ -114,6 +114,13 @@ enum ezFillLightMode
   ModulateIndirect = 2,
 }
 
+enum ezSplineMeshDistributionMode
+{
+  FitToSegment = 0,
+  ScaleEvenly = 1,
+  ScaleEvenlyPerSegment = 2,
+}
+
 enum ezUpdateRate
 {
   EveryFrame = 0,
@@ -1210,6 +1217,7 @@ class ezComponent
   ezLodMeshComponent@ opCast();
   ezMeshComponent@ opCast();
   ezMeshComponentBase@ opCast();
+  ezSplineMeshComponent@ opCast();
   ezSensorComponent@ opCast();
   ezSensorSphereComponent@ opCast();
   ezSensorCylinderComponent@ opCast();
@@ -1288,6 +1296,7 @@ class ezComponent
   ezJoltDefaultCharacterComponent@ opCast();
   ezJoltBreakableSlabComponent@ opCast();
   ezJoltClothSheetComponent@ opCast();
+  ezJoltGenerateCollisionComponent@ opCast();
   ezJoltHitboxComponent@ opCast();
   ezJoltRagdollComponent@ opCast();
   ezJoltRopeComponent@ opCast();
@@ -1520,6 +1529,7 @@ class ezRenderComponent : ezComponent
   ezLodMeshComponent@ opCast();
   ezMeshComponent@ opCast();
   ezMeshComponentBase@ opCast();
+  ezSplineMeshComponent@ opCast();
   ezAnimatedMeshComponent@ opCast();
   ezLodAnimatedMeshComponent@ opCast();
   ezGreyBoxComponent@ opCast();
@@ -1846,6 +1856,7 @@ class ezMeshComponentBase : ezRenderComponent
 {
   ezInstancedMeshComponent@ opCast();
   ezMeshComponent@ opCast();
+  ezSplineMeshComponent@ opCast();
   ezAnimatedMeshComponent@ opCast();
 }
 
@@ -1870,6 +1881,17 @@ class ezLodMeshComponent : ezRenderComponent
 class ezMeshComponent : ezMeshComponentBase
 {
   ezStringView Mesh;
+  ezColor Color;
+  ezVec4 CustomData;
+  float SortingDepthOffset;
+}
+
+class ezSplineMeshComponent : ezMeshComponentBase
+{
+  ezSplineMeshDistributionMode DistributionMode;
+  int32 Seed;
+  float OffsetY;
+  float OffsetZ;
   ezColor Color;
   ezVec4 CustomData;
   float SortingDepthOffset;
@@ -2679,6 +2701,10 @@ class ezJoltClothSheetComponent : ezRenderComponent
   ezColor Color;
 }
 
+class ezJoltGenerateCollisionComponent : ezComponent
+{
+}
+
 class ezJoltHitboxComponent : ezComponent
 {
   uint GetObjectFilterID() const;
@@ -2960,7 +2986,7 @@ class ezRmlUiCanvas3DComponent : ezRmlUiCanvasComponentBase
   ezStringView ProxyMesh;
   ezStringView BaseMaterial;
   uint32 MaterialIndex;
-  ezString TextureSlotName;
+  ezStringView TextureSlotName;
   float DpiScale;
   bool ClearStaleInput;
   bool IsInteractive;

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -40,6 +40,9 @@ G.Help;&Help
 G.Project.Settings;Project Settings
 G.Plugins.Settings;Plugin Settings
 
+
+Panels.All;Show Panels
+
 # Engine
 
 Engine.ReloadResources;Reload Resources;Reloads resources, such as textures, if they have changed on disk.
@@ -286,3 +289,10 @@ ezVariantType::ColorGamma;ColorGamma
 
 ezCppProject::CppIDE;C++ IDE
 ezCompilerPreferences::CppCompiler;C++ Compiler
+
+
+# Window Layouts
+WindowLayout;Editor Layout
+Layout.DefaultPinned;Default (Pinned)
+Layout.DefaultUnpinned;Default (Unpinned)
+Layout.AbBottom;Asset Browser at Bottom


### PR DESCRIPTION
The windowing system and the way we utilize ADS has evolved over time. The save/restore code was adapted, but recently it was more and more unreliable.

I've ripped it out and made a clean implementation from scratch. Hopefully this works better now.
Additionally, I've added options to the "Panels" menu to switch between a few layout presets.