### PR TITLE
Background Asset Processing Performance Improvements

### DIFF
--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessCommunicationChannel.cpp
@@ -67,15 +67,11 @@ ezResult ezEngineProcessCommunicationChannel::ConnectToHostProcess()
 
     ezLog::Debug("Host Process ID: {0}", m_iHostPID);
 
-    m_pChannel = ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client);
+    CreateAndConnectChannel(ezIpcChannel::CreatePipeChannel(ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-IPC"), ezIpcChannel::Mode::Client));
   }
   else
   {
-    m_pChannel = ezIpcChannel::CreateNetworkChannel("localhost:1050", ezIpcChannel::Mode::Server);
+    CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel("localhost:1050", ezIpcChannel::Mode::Server));
   }
-  m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
-  m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::MessageFunc, this));
-  m_pChannel->Connect();
-
   return EZ_SUCCESS;
 }

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.cpp
@@ -53,7 +53,7 @@ void ezProcessCommunicationChannel::WaitForMessages()
   m_pProtocol->WaitForMessages().IgnoreResult();
 }
 
-void ezProcessCommunicationChannel::MessageFunc(const ezIpcProcessMessageProtocol::Event& msg)
+void ezProcessCommunicationChannel::OnIpcProtocolEvent(const ezIpcProcessMessageProtocol::Event& msg)
 {
   const ezProcessMessage* pMsg = msg.m_pMessage;
   const ezRTTI* pRtti = pMsg->GetDynamicRTTI();
@@ -83,6 +83,35 @@ void ezProcessCommunicationChannel::MessageFunc(const ezIpcProcessMessageProtoco
   e.m_bInterruptMessageProcessing = msg.m_bInterruptMessageProcessing;
   m_Events.Broadcast(e);
   msg.m_bInterruptMessageProcessing = e.m_bInterruptMessageProcessing;
+}
+
+void ezProcessCommunicationChannel::OnIpcChannelEvent(const ezIpcChannelEvent& msg)
+{
+  m_IpcChannelEvents.Broadcast(msg);
+}
+
+void ezProcessCommunicationChannel::CreateAndConnectChannel(ezInternal::NewInstance<ezIpcChannel>&& channel)
+{
+  EZ_ASSERT_DEBUG(m_pChannel == nullptr, "Channel already created");
+  m_pChannel = channel;
+  m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
+  m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::OnIpcProtocolEvent, this));
+  m_pChannel->m_Events.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::OnIpcChannelEvent, this));
+  m_pChannel->Connect();
+}
+
+void ezProcessCommunicationChannel::DestroyChannel()
+{
+  if (m_pProtocol)
+  {
+    m_pProtocol->m_MessageEvent.RemoveEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::OnIpcProtocolEvent, this));
+    m_pProtocol.Clear();
+  }
+  if (m_pChannel)
+  {
+    m_pChannel->m_Events.RemoveEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::OnIpcChannelEvent, this));
+    m_pChannel.Clear();
+  }
 }
 
 ezResult ezProcessCommunicationChannel::WaitForMessage(const ezRTTI* pMessageType, ezTime timeout, WaitForMessageCallback* pMessageCallack)

--- a/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
+++ b/Code/Editor/EditorEngineProcessFramework/IPC/ProcessCommunicationChannel.h
@@ -10,6 +10,7 @@
 class ezIpcChannel;
 class ezProcessMessage;
 class ezIpcProcessMessageProtocol;
+struct ezIpcChannelEvent;
 
 class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezProcessCommunicationChannel
 {
@@ -38,10 +39,13 @@ public:
   };
 
   ezEvent<const Event&> m_Events;
-
-  void MessageFunc(const ezIpcProcessMessageProtocol::Event& msg);
+  ezEvent<const ezIpcChannelEvent&, ezMutex> m_IpcChannelEvents;
 
 protected:
+  void OnIpcProtocolEvent(const ezIpcProcessMessageProtocol::Event& msg);
+  void OnIpcChannelEvent(const ezIpcChannelEvent& msg);
+  void CreateAndConnectChannel(ezInternal::NewInstance<ezIpcChannel>&& channel);
+  void DestroyChannel();
   ezUniquePtr<ezIpcProcessMessageProtocol> m_pProtocol;
   ezUniquePtr<ezIpcChannel> m_pChannel;
   const ezRTTI* m_pFirstAllowedMessageType = nullptr;

--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -362,7 +362,11 @@ public:
 
   /// Generates one transitive hull for all the dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
   void GenerateTransitiveHull(const ezStringView sAssetOrPath, ezSet<ezString>& inout_deps, ezBitflags<ezDependencyFlags> dependencyTypes) const;
-  /// Copies each value of deps into out_SettingsHashMap and fills the value of assets with the hash value of the dependencyType. For files, the file hash is used.
+
+  /// \brief Generates one transitive hull for all the asset dependencies that are enabled. The set will contain dependencies that are reachable via any combination of enabled reference types.
+  void GenerateTransitiveAssetHull(const ezUuid& assetGuid, ezSet<ezUuid>& inout_deps, ezBitflags<ezDependencyFlags> dependencyTypes);
+
+  /// \brief Copies each value of deps into out_SettingsHashMap and fills the value of assets with the hash value of the dependencyType. For files, the file hash is used.
   void GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_settingsHashMap) const;
 
   /// Generates one inverse transitive hull for all the types dependencies that are enabled. The set will contain inverse dependencies that can reach the given asset (pAssetInfo) via any combination of the enabled reference types. As only assets can have dependencies, the inverse hull is always just asset GUIDs.

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -8,8 +8,8 @@
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Logging/LogEntry.h>
 #include <Foundation/Threading/AtomicInteger.h>
-#include <Foundation/Threading/ThreadSignal.h>
 #include <Foundation/Threading/Thread.h>
+#include <Foundation/Threading/ThreadSignal.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <ToolsFoundation/FileSystem/DataDirPath.h>
 #include <atomic>

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -8,7 +8,7 @@
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Logging/LogEntry.h>
 #include <Foundation/Threading/AtomicInteger.h>
-#include <Foundation/Threading/TaskSystem.h>
+#include <Foundation/Threading/ThreadSignal.h>
 #include <Foundation/Threading/Thread.h>
 #include <Foundation/Types/UniquePtr.h>
 #include <ToolsFoundation/FileSystem/DataDirPath.h>
@@ -58,6 +58,7 @@ struct ezAssetProcessorProgressEvent
   ezUuid m_AssetGuid;
   ezString m_sAssetPath;
   ezTime m_StartTime;
+  ezTime m_TransformStartTime;
   ezTime m_EndTime;
   ezTransformStatus m_Result; ///< Only valid when m_Type == ProcessingFinished
 };
@@ -94,6 +95,7 @@ public:
 
   ezUInt32 m_uiProcessorID;
   ezTime m_ProcessingStartTime;
+  ezThreadSignal* m_pNewWorkSignal = nullptr;
 
   bool Tick(bool bStartNewWork); // returns false, if all processing is done, otherwise call Tick again.
 
@@ -108,6 +110,7 @@ public:
 
 private:
   void EventHandlerIPC(const ezProcessCommunicationChannel::Event& e);
+  void ChannelEventHandler(const ezIpcChannelEvent& e);
 
   bool GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState);
   bool GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState);
@@ -117,6 +120,7 @@ private:
   State m_State = State::LookingForWork;
   ezEditorProcessCommunicationChannel* m_pIPC;
   bool m_bProcessShouldBeRunning = false;
+  bool m_bIsIdle = false;
 
   // New asset to process
   ezUuid m_AssetGuid;
@@ -135,6 +139,9 @@ private:
   ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies;
   ezUInt64 m_uiMissmatchAssetHash = 0;
   ezUInt64 m_uiMissmatchThumbHash = 0;
+  ezTime m_StartedProcessing;
+  ezTime m_StartedTransform;
+  ezTime m_FinishedProcessing;
 };
 
 /// \brief Background asset processing is handled by this class.
@@ -192,6 +199,7 @@ private:
   ezAssetProcessorLog m_CuratorLog;
 
   // Process thread and its state
+  ezThreadSignal m_NewWorkSignal;
   ezUniquePtr<ezAssetProcessorThread> m_pThread;
   std::atomic<bool> m_bForceStop = false; ///< If set, background processes will be killed when stopping without waiting for their current task to finish.
 

--- a/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessorMessages.h
@@ -33,6 +33,9 @@ public:
   mutable ezMap<ezString, ezUInt64> m_MissmatchThumbnailDependencies; ///< Hashes of all thumbnail dependencies.
   ezUInt64 m_uiMissmatchAssetHash = 0;                                ///< Transform hash observed by the ezEditorProcessor.
   ezUInt64 m_uiMissmatchThumbHash = 0;                                ///< Thumbnail hash observed by the ezEditorProcessor.
+  ezTime m_StartedProcessing;
+  ezTime m_StartedTransform;
+  ezTime m_FinishedProcessing;
 };
 
 class EZ_EDITORFRAMEWORK_DLL ezFreeAllResourcesMsg : public ezProcessMessage

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -800,7 +800,21 @@ ezUInt64 ezAssetCurator::GetAssetThumbnailHash(ezUuid assetGuid)
 
 ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetGuid, const ezPlatformProfile*, const ezAssetDocumentTypeDescriptor* pTypeDescriptor, ezUInt64& out_uiAssetHash, ezUInt64& out_uiThumbHash, ezUInt64& out_uiPackageHash, bool bForce)
 {
-  return ezAssetCurator::UpdateAssetTransformState(assetGuid, out_uiAssetHash, out_uiThumbHash, out_uiPackageHash, bForce);
+  if (bForce)
+  {
+    ezSet<ezUuid> transitiveHull;
+    GenerateTransitiveAssetHull(assetGuid, transitiveHull, ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail | ezDependencyFlags::Package);
+    // Mark hull as not up to date
+    EZ_LOCK(m_CuratorMutex);
+    for (auto& asset : transitiveHull)
+    {
+      InvalidateAssetTransformState(asset);
+      //UpdateAssetTransformState(asset, ezAssetInfo::TransformState::Unknown);
+    }
+  }
+
+  // Running this will update the state of every asset marked as Unknown in the transitive hull.
+  return ezAssetCurator::UpdateAssetTransformState(assetGuid, out_uiAssetHash, out_uiThumbHash, out_uiPackageHash, false);
 }
 
 void ezAssetCurator::InvalidateAssetsWithTransformState(ezAssetInfo::TransformState state)
@@ -1328,6 +1342,59 @@ void ezAssetCurator::GenerateTransitiveHull(const ezStringView sAssetOrPath, ezS
   }
 }
 
+void ezAssetCurator::GenerateTransitiveAssetHull(const ezUuid& assetGuid, ezSet<ezUuid>& inout_deps, ezBitflags<ezDependencyFlags> dependencyTypes)
+{
+  ezHybridArray<ezUuid, 6> toDoList;
+
+  auto AddDependencies = [&](const ezSet<ezString>& dependencies)
+  {
+    for (const ezString& dep : dependencies)
+    {
+      if (!ezConversionUtils::IsStringUuid(dep))
+        continue;
+      ezUuid guid = ezConversionUtils::ConvertStringToUuid(dep);
+      if (!inout_deps.Contains(guid))
+      {
+        inout_deps.Insert(guid);
+        toDoList.PushBack(guid);
+      }
+    }
+  };
+
+  // Build the transitive hull of all assets under 'assetGuid'.
+  inout_deps.Insert(assetGuid);
+  toDoList.PushBack(assetGuid);
+  ezStringBuilder sAbsAssetPath;
+  while (!toDoList.IsEmpty())
+  {
+    ezUuid currentAsset = toDoList.PeekBack();
+    toDoList.PopBack();
+    {
+      EZ_LOCK(m_CuratorMutex);
+      auto it = m_KnownSubAssets.Find(currentAsset);
+      if (!it.IsValid())
+        continue;
+      sAbsAssetPath = it.Value().m_pAssetInfo->m_Path;
+    }
+    // To make sure the dependencies of the asset are up-to-date, we need to check for modifications.
+    // This must be done outside the lock to prevent deadlocks.
+    ezFileSystemModel::GetSingleton()->NotifyOfChange(sAbsAssetPath);
+
+    EZ_LOCK(m_CuratorMutex);
+    auto it = m_KnownSubAssets.Find(currentAsset);
+    if (!it.IsValid())
+      continue;
+
+    ezAssetInfo* pAssetInfo = it.Value().m_pAssetInfo;
+    if (dependencyTypes.IsSet(ezDependencyFlags::Transform))
+      AddDependencies(pAssetInfo->m_Info->m_TransformDependencies);
+    if (dependencyTypes.IsSet(ezDependencyFlags::Thumbnail))
+      AddDependencies(pAssetInfo->m_Info->m_ThumbnailDependencies);
+    if (dependencyTypes.IsSet(ezDependencyFlags::Package))
+      AddDependencies(pAssetInfo->m_Info->m_PackageDependencies);
+  }
+}
+
 void ezAssetCurator::GenerateSettingsHashMap(const ezSet<ezString>& deps, ezBitflags<ezDependencyFlags> dependencyType, ezMap<ezString, ezUInt64>& out_settingsHashMap) const
 {
   EZ_LOCK(m_CuratorMutex);
@@ -1666,13 +1733,13 @@ ezTransformStatus ezAssetCurator::ProcessAsset(ezAssetInfo* pAssetInfo, const ez
     ezAssetInfo::TransformState state2 = IsAssetUpToDate(pAssetInfo->m_Info->m_DocumentID, pAssetProfile, pTypeDesc, uiHash2, uiThumbHash2, uiPackageHash2);
 
     if (uiHash != uiHash2)
-      return ezTransformStatus(ezFmt("Asset hash changed while prosessing dependencies from {} to {}", uiHash, uiHash2));
+      return ezTransformStatus(ezFmt("Asset hash changed while processing dependencies from {} to {}", uiHash, uiHash2));
     if (uiThumbHash != uiThumbHash2)
-      return ezTransformStatus(ezFmt("Asset thumbnail hash changed while prosessing dependencies from {} to {}", uiThumbHash, uiThumbHash2));
+      return ezTransformStatus(ezFmt("Asset thumbnail hash changed while processing dependencies from {} to {}", uiThumbHash, uiThumbHash2));
     if (uiPackageHash != uiPackageHash2)
-      return ezTransformStatus(ezFmt("Asset package hash changed while prosessing dependencies from {} to {}", uiPackageHash, uiPackageHash2));
+      return ezTransformStatus(ezFmt("Asset package hash changed while processing dependencies from {} to {}", uiPackageHash, uiPackageHash2));
     if (state != state2)
-      return ezTransformStatus(ezFmt("Asset state changed while prosessing dependencies from {} to {}", state, state2));
+      return ezTransformStatus(ezFmt("Asset state changed while processing dependencies from {} to {}", state, state2));
   }
 #endif
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -809,7 +809,7 @@ ezAssetInfo::TransformState ezAssetCurator::IsAssetUpToDate(const ezUuid& assetG
     for (auto& asset : transitiveHull)
     {
       InvalidateAssetTransformState(asset);
-      //UpdateAssetTransformState(asset, ezAssetInfo::TransformState::Unknown);
+      // UpdateAssetTransformState(asset, ezAssetInfo::TransformState::Unknown);
     }
   }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -105,6 +105,7 @@ void ezAssetProcessor::StartProcessor()
   for (ezUInt32 idx = 0; idx < uiWorkerCount; ++idx)
   {
     m_Processes[idx].m_uiProcessorID = idx;
+    m_Processes[idx].m_pNewWorkSignal = &m_NewWorkSignal;
   }
 
   m_pThread = EZ_DEFAULT_NEW(ezAssetProcessorThread);
@@ -132,6 +133,9 @@ void ezAssetProcessor::StopProcessor(bool bForce)
           e.m_Type = ezAssetProcessorEvent::Type::AssetProcessorStateChanged;
           e.m_uiProcessCount = m_EditorProcessorStates.GetCount();
           m_Events.Broadcast(e);
+
+          // Make sure worker thread is woken up.
+          m_NewWorkSignal.RaiseSignal();
         }
       }
       break;
@@ -214,13 +218,15 @@ void ezAssetProcessor::Run()
   {
     if (m_iPauseProcessing == 0)
     {
+      EZ_PROFILE_SCOPE("ezAssetProcessor::Run");
       for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
       {
         m_Processes[i].Tick(true);
       }
       UpdateProcessStates();
+
+      m_NewWorkSignal.WaitForSignal(ezTime::MakeFromSeconds(1));
     }
-    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(100));
   }
 
   while (true)
@@ -277,11 +283,13 @@ ezEditorProcessorProcess::ezEditorProcessorProcess()
 {
   m_pIPC = EZ_DEFAULT_NEW(ezEditorProcessCommunicationChannel);
   m_pIPC->m_Events.AddEventHandler(ezMakeDelegate(&ezEditorProcessorProcess::EventHandlerIPC, this));
+  m_pIPC->m_IpcChannelEvents.AddEventHandler(ezMakeDelegate(&ezEditorProcessorProcess::ChannelEventHandler, this));
 }
 
 ezEditorProcessorProcess::~ezEditorProcessorProcess()
 {
   ShutdownProcess();
+  m_pIPC->m_IpcChannelEvents.RemoveEventHandler(ezMakeDelegate(&ezEditorProcessorProcess::ChannelEventHandler, this));
   m_pIPC->m_Events.RemoveEventHandler(ezMakeDelegate(&ezEditorProcessorProcess::EventHandlerIPC, this));
   EZ_DEFAULT_DELETE(m_pIPC);
 }
@@ -343,6 +351,17 @@ void ezEditorProcessorProcess::EventHandlerIPC(const ezProcessCommunicationChann
     m_MissmatchThumbnailDependencies.Swap(pMsg->m_MissmatchThumbnailDependencies);
     m_uiMissmatchAssetHash = pMsg->m_uiMissmatchAssetHash;
     m_uiMissmatchThumbHash = pMsg->m_uiMissmatchThumbHash;
+    m_StartedProcessing = pMsg->m_StartedProcessing;
+    m_StartedTransform = pMsg->m_StartedTransform;
+    m_FinishedProcessing = pMsg->m_FinishedProcessing;
+  }
+}
+
+void ezEditorProcessorProcess::ChannelEventHandler(const ezIpcChannelEvent& e)
+{
+  if (m_pNewWorkSignal)
+  {
+    m_pNewWorkSignal->RaiseSignal();
   }
 }
 
@@ -424,6 +443,7 @@ bool ezEditorProcessorProcess::GetNextAssetToProcess(ezAssetInfo* pInfo, ezUuid&
 
 bool ezEditorProcessorProcess::GetNextAssetToProcess(ezUuid& out_guid, ezDataDirPath& out_path, ezAssetInfo::TransformState& out_transformState)
 {
+  EZ_PROFILE_SCOPE("ezEditorProcessorProcess::GetNextAssetToProcess");
   EZ_LOCK(ezAssetCurator::GetSingleton()->m_CuratorMutex);
 
   for (auto it = ezAssetCurator::GetSingleton()->m_TransformState[ezAssetInfo::TransformState::NeedsTransform].GetIterator(); it.IsValid(); ++it)
@@ -569,6 +589,7 @@ void ezEditorProcessorProcess::HandleHashMissmatch()
 
 bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
 {
+  EZ_PROFILE_SCOPE("ezEditorProcessorProcess::Tick");
   while (true)
   {
     switch (m_State)
@@ -596,6 +617,9 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
         m_MissmatchThumbnailDependencies.Clear();
         m_uiMissmatchAssetHash = 0;
         m_uiMissmatchThumbHash = 0;
+        m_StartedProcessing = {};
+        m_StartedTransform = {};
+        m_FinishedProcessing = {};
         {
           auto pCurator = ezAssetCurator::GetSingleton();
 
@@ -605,8 +629,9 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
           {
             m_AssetGuid = ezUuid();
             m_AssetPath.Clear();
-            if (m_pIPC->IsClientAlive() && m_pIPC->IsConnected())
+            if (m_pIPC->IsClientAlive() && m_pIPC->IsConnected() && !m_bIsIdle)
             {
+              m_bIsIdle = true;
               // If we have nothing else to do, we might as well free some resource memory the process holds.
               ezFreeAllResourcesMsg msg;
               m_pIPC->SendMessage(&msg);
@@ -614,14 +639,15 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
 
             return bStartNewWork; // call again if we should be looking for new work
           }
+          m_bIsIdle = false;
 
-          ezAssetInfo::TransformState state = pCurator->IsAssetUpToDate(m_AssetGuid, nullptr, nullptr, m_uiAssetHash, m_uiThumbHash, m_uiPackageHash);
+
+          ezAssetInfo::TransformState state;
+          state = pCurator->IsAssetUpToDate(m_AssetGuid, nullptr, nullptr, m_uiAssetHash, m_uiThumbHash, m_uiPackageHash);
           EZ_ASSERT_DEV(state == ezAssetInfo::TransformState::NeedsTransform || state == ezAssetInfo::TransformState::NeedsThumbnail, "An asset was selected that is already up to date.");
-
           ezSet<ezString> dependencies;
           ezStringBuilder sTemp;
           pCurator->GenerateTransitiveHull(ezConversionUtils::ToString(m_AssetGuid, sTemp), dependencies, ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail);
-
           m_sPlatform = ezAssetCurator::GetSingleton()->GetActiveAssetProfile()->GetConfigName();
           m_TransitiveHull.Reserve(dependencies.GetCount());
           for (const ezString& str : dependencies)
@@ -715,12 +741,15 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
       break;
       case State::Processing:
       {
+        EZ_PROFILE_SCOPE("ezEditorProcessorProcess::Processing");
         m_pIPC->ProcessMessages();
         if (!m_pIPC->IsClientAlive())
         {
           OnProcessCrashed("Asset Processor crashed during processing");
           m_State = State::ReportResult;
         }
+        if (m_State == State::Processing)
+          return true; // call again later
       }
       break;
       case State::ReportResult:
@@ -737,8 +766,9 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
           e.m_uiProcessorID = m_uiProcessorID;
           e.m_AssetGuid = m_AssetGuid;
           e.m_sAssetPath = m_AssetPath.GetDataDirRelativePath();
-          e.m_StartTime = m_ProcessingStartTime;
-          e.m_EndTime = ezTime::Now();
+          e.m_StartTime = m_StartedProcessing;
+          e.m_TransformStartTime = m_StartedTransform;
+          e.m_EndTime = m_FinishedProcessing;
           e.m_Result = m_Status;
           ezAssetProcessor::GetSingleton()->m_ProgressEvents.Broadcast(e);
         }
@@ -747,17 +777,20 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
         {
           ezAssetCurator::GetSingleton()->NotifyOfAssetChange(m_AssetGuid);
           ezAssetCurator::GetSingleton()->NeedsReloadResources(m_AssetGuid);
+          ezLog::Info(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Finished '{0}'", m_AssetPath.GetDataDirRelativePath());
         }
         else
         {
           if (m_Status.m_Result == ezTransformResult::NeedsImport)
           {
             ezAssetCurator::GetSingleton()->UpdateAssetTransformState(m_AssetGuid, ezAssetInfo::TransformState::NeedsImport);
+            ezLog::Warning(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Needs Import '{0}'", m_AssetPath.GetDataDirRelativePath());
           }
           else
           {
             ezAssetCurator::GetSingleton()->UpdateAssetTransformLog(m_AssetGuid, m_LogEntries);
             ezAssetCurator::GetSingleton()->UpdateAssetTransformState(m_AssetGuid, ezAssetInfo::TransformState::TransformError);
+            ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Failed '{0}'", m_AssetPath.GetDataDirRelativePath());
           }
         }
 

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessorMessages.cpp
@@ -29,6 +29,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcessAssetResponseMsg, 1, ezRTTIDefaultAlloc
     EZ_MAP_MEMBER_PROPERTY("MissmatchThumbnailDependencies", m_MissmatchThumbnailDependencies),
     EZ_MEMBER_PROPERTY("MissmatchAssetHash", m_uiMissmatchAssetHash),
     EZ_MEMBER_PROPERTY("MissmatchThumbHash", m_uiMissmatchThumbHash),
+    EZ_MEMBER_PROPERTY("StartedProcessing", m_StartedProcessing),
+    EZ_MEMBER_PROPERTY("StartedTransform", m_StartedTransform),
+    EZ_MEMBER_PROPERTY("FinishedProcessing", m_FinishedProcessing),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
+++ b/Code/Editor/EditorFramework/IPC/EditorProcessCommunicationChannel.cpp
@@ -26,15 +26,12 @@ ezResult ezEditorProcessCommunicationChannel::StartClientProcess(const char* szP
 
   if (bRemote)
   {
-    m_pChannel = ezIpcChannel::CreateNetworkChannel("172.16.80.3:1050", ezIpcChannel::Mode::Client);
+    CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel("172.16.80.3:1050", ezIpcChannel::Mode::Client));
   }
   else
   {
-    m_pChannel = ezIpcChannel::CreatePipeChannel(sMemName, ezIpcChannel::Mode::Server);
+    CreateAndConnectChannel(ezIpcChannel::CreatePipeChannel(sMemName, ezIpcChannel::Mode::Server));
   }
-  m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
-  m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::MessageFunc, this));
-  m_pChannel->Connect();
   for (ezUInt32 i = 0; i < 100; i++)
   {
     if (m_pChannel->GetConnectionState() == ezIpcChannel::ConnectionState::Connecting)
@@ -77,12 +74,7 @@ ezResult ezEditorProcessCommunicationChannel::StartClientProcess(const char* szP
 
     if (!m_pClientProcess->waitForStarted())
     {
-      delete m_pClientProcess;
-      m_pClientProcess = nullptr;
-
-      m_pProtocol.Clear();
-      m_pChannel.Clear();
-
+      CloseConnection();
       ezLog::Error("Failed to start process '{0}'", sPath);
       return EZ_FAILURE;
     }
@@ -104,12 +96,7 @@ bool ezEditorProcessCommunicationChannel::IsClientAlive() const
 
 void ezEditorProcessCommunicationChannel::CloseConnection()
 {
-  if (m_pProtocol)
-  {
-    m_pProtocol->m_MessageEvent.RemoveEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::MessageFunc, this));
-    m_pProtocol.Clear();
-  }
-  m_pChannel.Clear();
+  DestroyChannel();
 
   if (m_pClientProcess)
   {
@@ -143,16 +130,9 @@ ezOsProcessID ezEditorProcessCommunicationChannel::GetProcessId() const
 ezResult ezEditorProcessRemoteCommunicationChannel::ConnectToServer(const char* szAddress)
 {
   EZ_LOG_BLOCK("ezEditorProcessRemoteCommunicationChannel::ConnectToServer");
-
   EZ_ASSERT_DEV(m_pChannel == nullptr, "ProcessCommunication object already in use");
-
   m_pFirstAllowedMessageType = nullptr;
-
-  m_pChannel = ezIpcChannel::CreateNetworkChannel(szAddress, ezIpcChannel::Mode::Client);
-  m_pProtocol = EZ_DEFAULT_NEW(ezIpcProcessMessageProtocol, m_pChannel.Borrow());
-  m_pProtocol->m_MessageEvent.AddEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::MessageFunc, this));
-  m_pChannel->Connect();
-
+  CreateAndConnectChannel(ezIpcChannel::CreateNetworkChannel(szAddress, ezIpcChannel::Mode::Client));
   return EZ_SUCCESS;
 }
 
@@ -163,12 +143,7 @@ bool ezEditorProcessRemoteCommunicationChannel::IsConnected() const
 
 void ezEditorProcessRemoteCommunicationChannel::CloseConnection()
 {
-  if (m_pProtocol)
-  {
-    m_pProtocol->m_MessageEvent.RemoveEventHandler(ezMakeDelegate(&ezProcessCommunicationChannel::MessageFunc, this));
-    m_pProtocol.Clear();
-  }
-  m_pChannel.Clear();
+  DestroyChannel();
 }
 
 void ezEditorProcessRemoteCommunicationChannel::TryConnect()

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -41,6 +41,7 @@ protected:
   virtual void mouseReleaseEvent(QMouseEvent* e) override;
   virtual void mouseDoubleClickEvent(QMouseEvent* e) override;
   virtual void wheelEvent(QWheelEvent* e) override;
+  virtual void changeEvent(QEvent* e) override;
   virtual QSize sizeHint() const override;
   virtual QSize minimumSizeHint() const override;
 
@@ -57,10 +58,11 @@ private:
     static constexpr ezUInt16 SuccessResult = 0xFFFF;
     EZ_ALWAYS_INLINE bool IsFinished() const { return m_fDurationInSeconds != -1; }
     EZ_ALWAYS_INLINE bool Failed() const { return m_uiResultIndex != SuccessResult; }
-    EZ_ALWAYS_INLINE ezTime EndTime() const { return IsFinished() ? m_StartTime + ezTime::MakeFromSeconds(m_fDurationInSeconds) : ezTime::MakeZero(); }
+    EZ_ALWAYS_INLINE float EndTime() const { return IsFinished() ? m_fStartTimeInSeconds + m_fDurationInSeconds : 0.0f; }
 
     ezUuid m_AssetGuid;
-    ezTime m_StartTime;
+    float m_fStartTimeInSeconds = 0.0f;
+    float m_fTransformStartTimeInSeconds = 0.0f;
     float m_fDurationInSeconds = -1;
     ezUInt16 m_uiResultIndex = -1; //< We only store failed results to safe space. Index points to m_FailedTransforms
     ezAssetInfo::TransformState m_TransformState = ezAssetInfo::Unknown;
@@ -115,7 +117,7 @@ private:
 
   void DrawTimeline(QPainter& painter) const;
   void DrawProcessorRow(QPainter& painter, ezUInt32 uiProcessorID, int y) const;
-  void DrawProcessorTask(QPainter& painter, const ProcessorTask& task, QRect rect) const;
+  void DrawProcessorTask(QPainter& painter, const ProcessorTask& task, const QRect& rect, const QRect& actualWork) const;
 
 private:
   ezEventSubscriptionID m_ProgressEventsID;
@@ -137,4 +139,20 @@ private:
   // Cache for asset names so we don't have to store the name in ProcessorTask and also don't SPAM the ezAssetCurator.
   mutable ezMap<ezUuid, ezString> m_AssetNameCache;
   ezString m_sUnknownAsset = "<DELETED>";
+  
+  // Paint performance tracking
+  mutable double m_fLastPaintTimeMs = 0.0;
+  
+  // Paint performance caches
+  mutable QPixmap m_SkipOffsetPattern;
+  mutable QFont m_ProcessorLabelFont;
+  mutable QFont m_TaskLabelFont;
+  mutable QColor m_NeedsTransformColor[2];
+  mutable QColor m_NeedsThumbnailColor[2];
+  mutable QColor m_ErrorColor[2];
+  mutable bool m_bCachesInitialized = false;
+  mutable ezDynamicArray<QString> m_ProcessorLabels; // Cached "Process N" strings
+  
+  void InitializePaintCaches() const;
+  void InvalidatePaintCaches();
 };

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -139,10 +139,10 @@ private:
   // Cache for asset names so we don't have to store the name in ProcessorTask and also don't SPAM the ezAssetCurator.
   mutable ezMap<ezUuid, ezString> m_AssetNameCache;
   ezString m_sUnknownAsset = "<DELETED>";
-  
+
   // Paint performance tracking
   mutable double m_fLastPaintTimeMs = 0.0;
-  
+
   // Paint performance caches
   mutable QPixmap m_SkipOffsetPattern;
   mutable QFont m_ProcessorLabelFont;
@@ -152,7 +152,7 @@ private:
   mutable QColor m_ErrorColor[2];
   mutable bool m_bCachesInitialized = false;
   mutable ezDynamicArray<QString> m_ProcessorLabels; // Cached "Process N" strings
-  
+
   void InitializePaintCaches() const;
   void InvalidatePaintCaches();
 };

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -223,16 +223,16 @@ void ezQtAssetProcessorProgressWidget::InitializePaintCaches() const
 {
   if (m_bCachesInitialized)
     return;
-  
+
   m_bCachesInitialized = true;
-  
+
   // Initialize fonts
   m_ProcessorLabelFont = font();
   m_ProcessorLabelFont.setPointSize(9);
-  
+
   m_TaskLabelFont = font();
   m_TaskLabelFont.setPointSize(8);
-  
+
   // Create skip offset pattern pixmap
   m_SkipOffsetPattern = QPixmap(16, 16);
   m_SkipOffsetPattern.fill(Qt::transparent);
@@ -281,9 +281,7 @@ void ezQtAssetProcessorProgressWidget::SetScrollBarWidget(QScrollBar* pScrollBar
       update(); //
     });
   connect(m_pScrollBar, &QScrollBar::sliderReleased, this, [this]()
-    {
-      m_AssetNameCache.Clear();
-    });
+    { m_AssetNameCache.Clear(); });
 
   ClampZoomPan();
   UpdateGridBarConfig();
@@ -304,10 +302,10 @@ void ezQtAssetProcessorProgressWidget::ClearHistory()
 void ezQtAssetProcessorProgressWidget::paintEvent(QPaintEvent* event)
 {
   EZ_PROFILE_SCOPE("ezQtAssetProcessorProgressWidget::paintEvent");
- 
+
   // Initialize caches on first paint
   InitializePaintCaches();
-  
+
   QPainter painter(this);
   painter.setRenderHint(QPainter::Antialiasing, false);
   DrawTimeline(painter);
@@ -426,7 +424,7 @@ void ezQtAssetProcessorProgressWidget::wheelEvent(QWheelEvent* e)
 void ezQtAssetProcessorProgressWidget::changeEvent(QEvent* e)
 {
   QWidget::changeEvent(e);
-  
+
   if (e->type() == QEvent::PaletteChange || e->type() == QEvent::StyleChange)
   {
     InvalidatePaintCaches();
@@ -650,7 +648,7 @@ void ezQtAssetProcessorProgressWidget::ShowTooltip(QMouseEvent* e)
   if (pTask->IsFinished())
   {
     sTooltip.AppendFormat("\n{} duration: {}s", pTask->m_TransformState == ezAssetInfo::TransformState::NeedsTransform ? "Transform" : "Thumbnail", ezArgF(pTask->m_fDurationInSeconds, 3));
-    sTooltip.AppendFormat("\nTime spent on curator updates: {}s",  ezArgF(pTask->m_fTransformStartTimeInSeconds - pTask->m_fStartTimeInSeconds, 3));
+    sTooltip.AppendFormat("\nTime spent on curator updates: {}s", ezArgF(pTask->m_fTransformStartTimeInSeconds - pTask->m_fStartTimeInSeconds, 3));
 
     if (pTask->Failed())
     {
@@ -685,10 +683,10 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
   ezDynamicArray<ProcessorTask> visibleTasks;
   ezHybridArray<ezTime, 8> skipOffsets;
   ezTime currentTime;
-  
+
   {
     EZ_LOCK(m_pHistoryState->m_HistoryMutex);
-    
+
     if (uiProcessorID < m_pHistoryState->m_ProcessStates.GetCount())
     {
       state = m_pHistoryState->m_ProcessStates[uiProcessorID];
@@ -696,7 +694,7 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
 
     skipOffsets = m_pHistoryState->m_SkipOffsets;
     currentTime = ezTime::Now() - m_pHistoryState->m_CurrentOffset;
-    
+
     // Copy only visible tasks
     if (uiProcessorID < m_pHistoryState->m_ProcessorHistory.GetCount())
     {
@@ -704,7 +702,7 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
       visibleTasks.Reserve(history.GetCount());
       const float fStartTimeView = static_cast<float>(MapToScene({s_iLeftMargin, 0}).x());
       const float fCurrentTimeSeconds = static_cast<float>(currentTime.GetSeconds());
-      
+
       auto it = std::upper_bound(begin(history), end(history), fStartTimeView,
         [&](float time, const ProcessorTask& task)
         {
@@ -712,17 +710,17 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
         });
       if (it != begin(history))
         it--;
-      
+
       for (; it != end(history); ++it)
       {
         const ProcessorTask& task = *it;
         float fTaskEndTime = task.IsFinished() ? task.EndTime() : fCurrentTimeSeconds;
-        
+
         if (fTaskEndTime < viewportRect.left())
           continue;
         if (task.m_fStartTimeInSeconds > viewportRect.right())
           break;
-        
+
         visibleTasks.PushBack(task);
       }
     }
@@ -750,13 +748,13 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
   {
     painter.setPen(palette().color(QPalette::Text));
     painter.setFont(m_ProcessorLabelFont);
-    
+
     // Ensure we have a cached label for this processor
     while (m_ProcessorLabels.GetCount() <= uiProcessorID)
     {
       m_ProcessorLabels.PushBack(QString("Process %1").arg(m_ProcessorLabels.GetCount()));
     }
-    
+
     painter.drawText(5 + s_iIndicatorSize + 8, y, s_iLeftMargin - 23 - s_iIndicatorSize, s_iRowHeight, Qt::AlignVCenter | Qt::AlignLeft,
       m_ProcessorLabels[uiProcessorID]);
   }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -4,6 +4,7 @@
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/EditorFrameworkPCH.h>
 #include <Foundation/Strings/PathUtils.h>
+#include <Foundation/Time/Stopwatch.h>
 #include <GuiFoundation/Widgets/GridBarWidget.moc.h>
 #include <GuiFoundation/Widgets/WidgetUtils.h>
 #include <QMouseEvent>
@@ -52,7 +53,7 @@ ezTime ezQtAssetProcessorProgressWidget::HistoryState::GetLatestTaskTime() const
     if (!history.IsEmpty())
     {
       auto& task = history.PeekBack();
-      ezTime taskTime = task.IsFinished() ? task.EndTime() : (ezTime::Now() - m_CurrentOffset);
+      ezTime taskTime = task.IsFinished() ? ezTime::MakeFromSeconds(task.EndTime()) : (ezTime::Now() - m_CurrentOffset);
       if (taskTime > latest)
       {
         latest = taskTime;
@@ -99,7 +100,8 @@ void ezQtAssetProcessorProgressWidget::HistoryState::OnProgressEvent(const ezAss
     // Add new task
     ProcessorTask task;
     task.m_AssetGuid = e.m_AssetGuid;
-    task.m_StartTime = e.m_StartTime - m_CurrentOffset;
+    task.m_fStartTimeInSeconds = static_cast<float>((e.m_StartTime - m_CurrentOffset).GetSeconds());
+    task.m_fTransformStartTimeInSeconds = task.m_fStartTimeInSeconds;
     task.m_TransformState = e.m_TransformState;
     history.PushBack(task);
   }
@@ -109,6 +111,7 @@ void ezQtAssetProcessorProgressWidget::HistoryState::OnProgressEvent(const ezAss
     EZ_ASSERT_DEBUG(task.m_AssetGuid == e.m_AssetGuid, "Processing finished should always map to the previously started asset");
     EZ_ASSERT_DEBUG(!task.IsFinished(), "Last task should not be finished if ProcessingFinished is emitted");
     task.m_fDurationInSeconds = static_cast<float>((e.m_EndTime - e.m_StartTime).GetSeconds());
+    task.m_fTransformStartTimeInSeconds = static_cast<float>((e.m_TransformStartTime - m_CurrentOffset).GetSeconds());
     if (e.m_Result.Failed())
     {
       m_FailedTransforms.PushBack(e.m_Result);
@@ -147,22 +150,22 @@ const ezQtAssetProcessorProgressWidget::ProcessorTask* ezQtAssetProcessorProgres
   EZ_LOCK(m_HistoryMutex);
 
   const ezDynamicArray<ProcessorTask>& history = m_ProcessorHistory[uiProcessorID];
-  const ezTime currentTime = ezTime::Now() - m_CurrentOffset;
+  const float fCurrentTime = static_cast<float>((ezTime::Now() - m_CurrentOffset).GetSeconds());
 
   // Use binary search to find the task at pointInTime
   auto it = std::upper_bound(begin(history), end(history), fPointInTimeSec,
     [&](double time, const ProcessorTask& task)
     {
-      return time < task.m_StartTime.GetSeconds();
+      return time < task.m_fStartTimeInSeconds;
     });
 
   if (it != begin(history))
   {
     --it;
-    double startTime = it->m_StartTime.GetSeconds();
-    double endTime = it->IsFinished() ? it->EndTime().GetSeconds() : currentTime.GetSeconds();
+    float fStartTime = it->m_fStartTimeInSeconds;
+    float fEndTime = it->IsFinished() ? it->EndTime() : fCurrentTime;
 
-    if (fPointInTimeSec >= startTime && fPointInTimeSec <= endTime)
+    if (fPointInTimeSec >= fStartTime && fPointInTimeSec <= fEndTime)
     {
       return &(*it);
     }
@@ -216,6 +219,45 @@ ezQtAssetProcessorProgressWidget::~ezQtAssetProcessorProgressWidget()
   m_pHistoryState->m_pParent = nullptr;
 }
 
+void ezQtAssetProcessorProgressWidget::InitializePaintCaches() const
+{
+  if (m_bCachesInitialized)
+    return;
+  
+  m_bCachesInitialized = true;
+  
+  // Initialize fonts
+  m_ProcessorLabelFont = font();
+  m_ProcessorLabelFont.setPointSize(9);
+  
+  m_TaskLabelFont = font();
+  m_TaskLabelFont.setPointSize(8);
+  
+  // Create skip offset pattern pixmap
+  m_SkipOffsetPattern = QPixmap(16, 16);
+  m_SkipOffsetPattern.fill(Qt::transparent);
+  QPainter pixPainter(&m_SkipOffsetPattern);
+  pixPainter.setPen(QPen(palette().color(QPalette::AlternateBase), 5));
+  pixPainter.drawLine(-16, -16, 32, 32);
+  pixPainter.drawLine(-32, -16, 16, 32);
+  pixPainter.drawLine(0, -16, 48, 32);
+  pixPainter.end();
+
+  // Cache task colors
+  m_NeedsTransformColor[0] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Blue));
+  m_NeedsTransformColor[1] = m_NeedsTransformColor[0].darker(150);
+  m_NeedsThumbnailColor[0] = ezToQtColor(ezColorScheme::DarkUI(float(ezColorScheme::Blue + ezColorScheme::Green) * 0.5f * ezColorScheme::s_fIndexNormalizer));
+  m_NeedsThumbnailColor[1] = m_NeedsThumbnailColor[0].darker(150);
+  m_ErrorColor[0] = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
+  m_ErrorColor[1] = m_ErrorColor[0].darker(150);
+}
+
+void ezQtAssetProcessorProgressWidget::InvalidatePaintCaches()
+{
+  m_bCachesInitialized = false;
+  m_ProcessorLabels.Clear();
+}
+
 void ezQtAssetProcessorProgressWidget::SetGridBarWidget(ezQGridBarWidget* pGridBar)
 {
   EZ_ASSERT_DEBUG(m_pGridBar == nullptr, "SetGridBarWidget should only be called once.");
@@ -235,9 +277,12 @@ void ezQtAssetProcessorProgressWidget::SetScrollBarWidget(QScrollBar* pScrollBar
     {
       m_fSceneTranslationX = static_cast<double>(v) / 1000.0;
       ClampZoomPan();
-      m_AssetNameCache.Clear();
       UpdateGridBarConfig();
       update(); //
+    });
+  connect(m_pScrollBar, &QScrollBar::sliderReleased, this, [this]()
+    {
+      m_AssetNameCache.Clear();
     });
 
   ClampZoomPan();
@@ -258,7 +303,13 @@ void ezQtAssetProcessorProgressWidget::ClearHistory()
 
 void ezQtAssetProcessorProgressWidget::paintEvent(QPaintEvent* event)
 {
+  EZ_PROFILE_SCOPE("ezQtAssetProcessorProgressWidget::paintEvent");
+ 
+  // Initialize caches on first paint
+  InitializePaintCaches();
+  
   QPainter painter(this);
+  painter.setRenderHint(QPainter::Antialiasing, false);
   DrawTimeline(painter);
 }
 
@@ -372,6 +423,16 @@ void ezQtAssetProcessorProgressWidget::wheelEvent(QWheelEvent* e)
   update();
 }
 
+void ezQtAssetProcessorProgressWidget::changeEvent(QEvent* e)
+{
+  QWidget::changeEvent(e);
+  
+  if (e->type() == QEvent::PaletteChange || e->type() == QEvent::StyleChange)
+  {
+    InvalidatePaintCaches();
+  }
+}
+
 QSize ezQtAssetProcessorProgressWidget::sizeHint() const
 {
   int height = s_iTopMargin + (s_iRowHeight + s_iRowSpacing) * m_uiMaxProcessors;
@@ -425,8 +486,6 @@ void ezQtAssetProcessorProgressWidget::OnHistoryChanged()
     ClampZoomPan();
     UpdateGridBarConfig();
   }
-
-  update();
 }
 
 void ezQtAssetProcessorProgressWidget::OnProcessorStateChanged()
@@ -591,6 +650,7 @@ void ezQtAssetProcessorProgressWidget::ShowTooltip(QMouseEvent* e)
   if (pTask->IsFinished())
   {
     sTooltip.AppendFormat("\n{} duration: {}s", pTask->m_TransformState == ezAssetInfo::TransformState::NeedsTransform ? "Transform" : "Thumbnail", ezArgF(pTask->m_fDurationInSeconds, 3));
+    sTooltip.AppendFormat("\nTime spent on curator updates: {}s",  ezArgF(pTask->m_fTransformStartTimeInSeconds - pTask->m_fStartTimeInSeconds, 3));
 
     if (pTask->Failed())
     {
@@ -620,8 +680,53 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
   const int timelineWidth = widgetWidth - s_iLeftMargin;
   const QRectF viewportRect = ComputeViewportSceneRect();
 
-  EZ_LOCK(m_pHistoryState->m_HistoryMutex);
-  const ezEditorProcessorState state = m_pHistoryState->m_ProcessStates[uiProcessorID];
+  // Copy state data and history under lock, then draw without lock
+  ezEditorProcessorState state;
+  ezDynamicArray<ProcessorTask> visibleTasks;
+  ezHybridArray<ezTime, 8> skipOffsets;
+  ezTime currentTime;
+  
+  {
+    EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+    
+    if (uiProcessorID < m_pHistoryState->m_ProcessStates.GetCount())
+    {
+      state = m_pHistoryState->m_ProcessStates[uiProcessorID];
+    }
+
+    skipOffsets = m_pHistoryState->m_SkipOffsets;
+    currentTime = ezTime::Now() - m_pHistoryState->m_CurrentOffset;
+    
+    // Copy only visible tasks
+    if (uiProcessorID < m_pHistoryState->m_ProcessorHistory.GetCount())
+    {
+      const auto& history = m_pHistoryState->m_ProcessorHistory[uiProcessorID];
+      visibleTasks.Reserve(history.GetCount());
+      const float fStartTimeView = static_cast<float>(MapToScene({s_iLeftMargin, 0}).x());
+      const float fCurrentTimeSeconds = static_cast<float>(currentTime.GetSeconds());
+      
+      auto it = std::upper_bound(begin(history), end(history), fStartTimeView,
+        [&](float time, const ProcessorTask& task)
+        {
+          return time < task.m_fStartTimeInSeconds;
+        });
+      if (it != begin(history))
+        it--;
+      
+      for (; it != end(history); ++it)
+      {
+        const ProcessorTask& task = *it;
+        float fTaskEndTime = task.IsFinished() ? task.EndTime() : fCurrentTimeSeconds;
+        
+        if (fTaskEndTime < viewportRect.left())
+          continue;
+        if (task.m_fStartTimeInSeconds > viewportRect.right())
+          break;
+        
+        visibleTasks.PushBack(task);
+      }
+    }
+  }
 
   // Draw processor label background
   painter.fillRect(0, y, s_iLeftMargin - 5, s_iRowHeight, palette().color(QPalette::Window));
@@ -635,22 +740,25 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
     {
       indicatorColor = state.m_bRunning ? ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Green)) : ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Yellow));
     }
-    painter.setRenderHint(QPainter::Antialiasing);
     painter.setBrush(indicatorColor);
     painter.setPen(indicatorColor.darker(150));
     painter.drawEllipse(indicatorX, indicatorY, s_iIndicatorSize, s_iIndicatorSize);
     painter.setBrush(Qt::NoBrush);
-    painter.setRenderHint(QPainter::Antialiasing, false);
   }
 
   // Draw processor label
   {
     painter.setPen(palette().color(QPalette::Text));
-    QFont labelFont = painter.font();
-    labelFont.setPointSize(9);
-    painter.setFont(labelFont);
+    painter.setFont(m_ProcessorLabelFont);
+    
+    // Ensure we have a cached label for this processor
+    while (m_ProcessorLabels.GetCount() <= uiProcessorID)
+    {
+      m_ProcessorLabels.PushBack(QString("Process %1").arg(m_ProcessorLabels.GetCount()));
+    }
+    
     painter.drawText(5 + s_iIndicatorSize + 8, y, s_iLeftMargin - 23 - s_iIndicatorSize, s_iRowHeight, Qt::AlignVCenter | Qt::AlignLeft,
-      QString("Process %1").arg(uiProcessorID));
+      m_ProcessorLabels[uiProcessorID]);
   }
 
   // Draw row background
@@ -658,16 +766,7 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
 
   // Draw skip offsets
   {
-    QPixmap pixmap(16, 16);
-    pixmap.fill(Qt::transparent);
-    QPainter pixPainter(&pixmap);
-    pixPainter.setPen(QPen(palette().color(QPalette::AlternateBase), 5));
-    pixPainter.drawLine(-16, -16, 32, 32);
-    pixPainter.drawLine(-32, -16, 16, 32);
-    pixPainter.drawLine(0, -16, 48, 32);
-    pixPainter.end();
-
-    for (const auto& skipOffset : m_pHistoryState->m_SkipOffsets)
+    for (const auto& skipOffset : skipOffsets)
     {
       QPoint startPt = MapFromScene(QPointF(skipOffset.GetSeconds(), y));
       if (startPt.x() < s_iLeftMargin)
@@ -676,47 +775,22 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
       }
       QPoint endPt = MapFromScene(QPointF(skipOffset.GetSeconds() + 1, y + s_iRowHeight));
       if (startPt.x() < endPt.x())
-        painter.fillRect(QRectF(startPt, endPt), QBrush(pixmap));
+        painter.fillRect(QRectF(startPt, endPt), QBrush(m_SkipOffsetPattern));
     }
   }
 
   // Draw tasks for this processor
-  if (uiProcessorID >= m_pHistoryState->m_ProcessorHistory.GetCount())
-    return;
-
-  const auto& history = m_pHistoryState->m_ProcessorHistory[uiProcessorID];
-  const ezTime currentTime = ezTime::Now() - m_pHistoryState->m_CurrentOffset;
-
-  // Find first visible task
-  const double startTime = MapToScene({s_iLeftMargin, 0}).x();
-  auto it = std::upper_bound(begin(history), end(history), startTime,
-    [&](double time, const ProcessorTask& task)
-    {
-      return time < task.m_StartTime.GetSeconds();
-    });
-  if (it != begin(history))
-    it--;
-
-  for (; it != end(history); ++it)
+  for (const ProcessorTask& task : visibleTasks)
   {
-    const ProcessorTask& task = *it;
-    ezTime taskStartTime = task.m_StartTime;
-    ezTime taskEndTime = task.IsFinished() ? task.EndTime() : currentTime;
-
-    double startSeconds = taskStartTime.GetSeconds();
-    double endSeconds = taskEndTime.GetSeconds();
-
-    // Skip if outside visible window
-    if (endSeconds < viewportRect.left())
-      continue;
-
-    if (startSeconds > viewportRect.right())
-      break;
+    float fTaskStartTime = task.m_fStartTimeInSeconds;
+    float fTaskEndTime = task.IsFinished() ? task.EndTime() : static_cast<float>(currentTime.GetSeconds());
 
     // Map to screen coordinates
-    QPoint startPt = MapFromScene(QPointF(startSeconds, y + 2));
-    QPoint endPt = MapFromScene(QPointF(endSeconds, y + s_iRowHeight - 4));
+    QPoint startPt = MapFromScene(QPointF(fTaskStartTime, y + 2));
+    QPoint transformPt = MapFromScene(QPointF(task.m_fTransformStartTimeInSeconds, y + 2));
+    QPoint endPt = MapFromScene(QPointF(fTaskEndTime, y + s_iRowHeight - 4));
     startPt.setX(ezMath::Max(startPt.x(), s_iLeftMargin));
+    transformPt.setX(ezMath::Max(transformPt.x(), s_iLeftMargin));
     endPt.setX(ezMath::Min(endPt.x(), widgetWidth));
     if (startPt.x() > endPt.x())
       continue;
@@ -725,55 +799,52 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
       endPt.setX(endPt.x() + 1);
 
     const QRect rect(startPt, endPt);
-    DrawProcessorTask(painter, task, rect);
+    const QRect actualWork(transformPt, endPt);
+    DrawProcessorTask(painter, task, rect, actualWork);
   }
 }
 
-void ezQtAssetProcessorProgressWidget::DrawProcessorTask(QPainter& painter, const ProcessorTask& task, QRect rect) const
+void ezQtAssetProcessorProgressWidget::DrawProcessorTask(QPainter& painter, const ProcessorTask& task, const QRect& rect, const QRect& actualWork) const
 {
   // Choose color based on status
   QColor barColor;
+  QColor barColorDarker;
   switch (task.m_TransformState)
   {
     case ezAssetInfo::NeedsTransform:
-      barColor = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Blue));
+      barColor = m_NeedsTransformColor[0];
+      barColorDarker = m_NeedsTransformColor[1];
       break;
     case ezAssetInfo::NeedsThumbnail:
-      barColor = ezToQtColor(ezColorScheme::DarkUI(float(ezColorScheme::Blue + ezColorScheme::Green) * 0.5f * ezColorScheme::s_fIndexNormalizer));
+      barColor = m_NeedsThumbnailColor[0];
+      barColorDarker = m_NeedsThumbnailColor[1];
       break;
     default:
       barColor = palette().color(QPalette::Highlight);
+      barColorDarker = barColor.darker(150);
       break;
   }
-
-  if (!task.IsFinished())
+  if (task.Failed())
   {
-    barColor = barColor.darker(150);
-  }
-  else if (task.Failed())
-  {
-    barColor = ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Red));
+    barColor = m_ErrorColor[0];
+    barColorDarker = m_ErrorColor[1];
   }
 
-  // Draw task bar
-  painter.fillRect(rect, barColor);
-
-  // Draw border
-  painter.setPen(barColor.darker(120));
-  painter.drawRect(rect);
+  // Draw task bar. The rect is over the entire task runtime
+  painter.fillRect(rect, barColorDarker);
+  // The actual work is when the task was actually processing instead of checking the asset curator for up-to-date info. We adjust the rect so we get a convenient border from the rect above.
+  painter.fillRect(actualWork.adjusted(1, 1, -1, -1), task.IsFinished() ? barColor : barColorDarker);
 
   // Draw asset name if there's enough space
   int barWidth = rect.width();
   if (barWidth > 30)
   {
     painter.setPen(palette().color(QPalette::BrightText));
-    QFont taskFont = painter.font();
-    taskFont.setPointSize(8);
-    painter.setFont(taskFont);
+    painter.setFont(m_TaskLabelFont);
 
     ezStringView fileName = ezPathUtils::GetFileNameAndExtension(GetAssetPath(task.m_AssetGuid));
     QString shortName = ezMakeQString(fileName);
-    QFontMetrics fm(taskFont);
+    QFontMetrics fm(m_TaskLabelFont);
     QString elidedName = fm.elidedText(shortName, Qt::ElideRight, barWidth - 6);
     QRect textRect = rect.adjusted(3, 0, -3, 0);
     painter.drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, elidedName);

--- a/Code/Editor/EditorProcessor/EditorProcessor.cpp
+++ b/Code/Editor/EditorProcessor/EditorProcessor.cpp
@@ -77,6 +77,7 @@ public:
       }
 
       ezProcessAssetResponseMsg msg;
+      msg.m_StartedProcessing = ezTime::Now();
       {
         ezLogEntryDelegate logger([&msg](ezLogEntry& ref_entry) -> void
           { msg.m_LogEntries.PushBack(std::move(ref_entry)); },
@@ -118,6 +119,7 @@ public:
 
           // Next, we force checking that the asset is up to date. This EditorProcessor instance might not have observed the generation of the output files of various dependencies yet and incorrectly assume that some dependencies still need to be transformed. To prevent this, we force checking the asset and all its dependencies via the filesystem, ignoring the caching.
           ezAssetInfo::TransformState state = ezAssetCurator::GetSingleton()->IsAssetUpToDate(pMsg->m_AssetGuid, ezAssetCurator::GetSingleton()->GetAssetProfile(uiPlatform), nullptr, uiAssetHash, uiThumbHash, uiPackageHash, true);
+          msg.m_StartedTransform = ezTime::Now();
 
           if ((uiAssetHash != pMsg->m_AssetHash) || (uiThumbHash != pMsg->m_ThumbHash))
           {
@@ -161,6 +163,7 @@ public:
           }
         }
       }
+      msg.m_FinishedProcessing = ezTime::Now();
       m_IPC.SendMessage(&msg);
     }
     else if (const ezFreeAllResourcesMsg* pMsg = ezDynamicCast<const ezFreeAllResourcesMsg*>(e.m_pMessage))

--- a/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
@@ -64,6 +64,7 @@ void ezQtLogModel::SetSearchText(const char* szText)
 
 void ezQtLogModel::AddLogMsg(const ezLogEntry& msg)
 {
+  bool bNeedInvoke = false;
   {
     EZ_LOCK(m_NewMessagesMutex);
 
@@ -75,13 +76,21 @@ void ezQtLogModel::AddLogMsg(const ezLogEntry& msg)
     }
 
     m_NewMessages.PushBack(msg);
+
+    // Only queue ProcessNewMessages if not already pending
+    if (!m_bProcessingPending)
+    {
+      m_bProcessingPending = true;
+      bNeedInvoke = true;
+    }
   }
 
   // always queue the message processing, otherwise it can happen that an error during this
   // triggers recursive logging, which is forbidden
-  QMetaObject::invokeMethod(this, "ProcessNewMessages", Qt::ConnectionType::QueuedConnection);
-
-  return;
+  if (bNeedInvoke)
+  {
+    QMetaObject::invokeMethod(this, "ProcessNewMessages", Qt::ConnectionType::QueuedConnection);
+  }
 }
 
 bool ezQtLogModel::IsFiltered(const ezLogEntry& lm) const
@@ -212,8 +221,18 @@ void ezQtLogModel::ProcessNewMessages()
   ezStringBuilder sLatestWarning;
   ezStringBuilder sLatestError;
 
+  // Collect messages to add to visible list
+  ezHybridArray<const ezLogEntry*, 64> messagesToAdd;
+
   {
     EZ_LOCK(m_NewMessagesMutex);
+    
+    // Reset processing flag so new messages can trigger another ProcessNewMessages
+    m_bProcessingPending = false;
+    
+    if (m_NewMessages.IsEmpty())
+      return;
+    
     ezStringBuilder s;
     for (const auto& msg : m_NewMessages)
     {
@@ -282,21 +301,32 @@ void ezQtLogModel::ProcessNewMessages()
         }
       }
 
+      // Add any queued block messages
       for (auto pMsg : m_BlockQueue)
       {
-        beginInsertRows(QModelIndex(), m_VisibleMessages.GetCount(), m_VisibleMessages.GetCount());
-        m_VisibleMessages.PushBack(pMsg);
-        endInsertRows();
+        messagesToAdd.PushBack(pMsg);
       }
-
       m_BlockQueue.Clear();
 
-      beginInsertRows(QModelIndex(), m_VisibleMessages.GetCount(), m_VisibleMessages.GetCount());
-      m_VisibleMessages.PushBack(&m_AllMessages.PeekBack());
-      endInsertRows();
+      // Add the current message
+      messagesToAdd.PushBack(&m_AllMessages.PeekBack());
     }
 
     m_NewMessages.Clear();
+  }
+
+  // Batch insert all visible messages at once
+  if (!messagesToAdd.IsEmpty())
+  {
+    const int iFirstRow = static_cast<int>(m_VisibleMessages.GetCount());
+    const int iLastRow = iFirstRow + static_cast<int>(messagesToAdd.GetCount()) - 1;
+    
+    beginInsertRows(QModelIndex(), iFirstRow, iLastRow);
+    for (auto pMsg : messagesToAdd)
+    {
+      m_VisibleMessages.PushBack(pMsg);
+    }
+    endInsertRows();
   }
 
   if (bNewErrors)

--- a/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
@@ -226,13 +226,13 @@ void ezQtLogModel::ProcessNewMessages()
 
   {
     EZ_LOCK(m_NewMessagesMutex);
-    
+
     // Reset processing flag so new messages can trigger another ProcessNewMessages
     m_bProcessingPending = false;
-    
+
     if (m_NewMessages.IsEmpty())
       return;
-    
+
     ezStringBuilder s;
     for (const auto& msg : m_NewMessages)
     {
@@ -320,7 +320,7 @@ void ezQtLogModel::ProcessNewMessages()
   {
     const int iFirstRow = static_cast<int>(m_VisibleMessages.GetCount());
     const int iLastRow = iFirstRow + static_cast<int>(messagesToAdd.GetCount()) - 1;
-    
+
     beginInsertRows(QModelIndex(), iFirstRow, iLastRow);
     for (auto pMsg : messagesToAdd)
     {

--- a/Code/Tools/Libs/GuiFoundation/Models/LogModel.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Models/LogModel.moc.h
@@ -55,6 +55,7 @@ private:
 
   mutable ezMutex m_NewMessagesMutex;
   ezDeque<ezLogEntry> m_NewMessages;
+  bool m_bProcessingPending = false; ///< Prevents duplicate queued ProcessNewMessages invocations
 
   ezUInt32 m_uiNumErrors = 0;
   ezUInt32 m_uiNumSeriousWarnings = 0;

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
@@ -117,18 +117,16 @@ bool ezQtLogWidget::RemoveLogItemContextActionCallback(const ezStringView& sName
   return s_LogCallbacks.Remove(sName);
 }
 
-void ezQtLogWidget::ScrollToBottomIfAtEnd(int iNumElements)
+void ezQtLogWidget::ScrollToBottomIfAtEnd(int iFirstNewRow)
 {
   if (ListViewLog->selectionModel()->hasSelection())
   {
-    if (ListViewLog->selectionModel()->selectedIndexes()[0].row() + 1 >= iNumElements)
-    {
-      ListViewLog->selectionModel()->clearSelection();
-      ListViewLog->scrollToBottom();
-    }
+    if (ListViewLog->selectionModel()->selectedIndexes()[0].row() + 1 < iFirstNewRow)
+      return;
+
+    ListViewLog->selectionModel()->clearSelection();
   }
-  else
-    ListViewLog->scrollToBottom();
+  ListViewLog->scrollToBottom();
 }
 
 void ezQtLogWidget::on_ButtonClearLog_clicked()

--- a/Code/Tools/Libs/GuiFoundation/Widgets/LogWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/LogWidget.moc.h
@@ -39,7 +39,7 @@ private Q_SLOTS:
 
 private:
   ezQtLogModel* m_pLog;
-  void ScrollToBottomIfAtEnd(int iNumElements);
+  void ScrollToBottomIfAtEnd(int iFirstNewRow);
 
   /// \brief List of callbacks invoked when the user double clicks a log message
   static ezMap<ezString, LogItemContextActionCallback> s_LogCallbacks;


### PR DESCRIPTION
## Asset Processor
Various accumulating factors slowed down asset processing. With these fixes, processing all of the testing chamber assets now takes 33sec instead of 185sec.
<img width="972" height="330" alt="image" src="https://github.com/user-attachments/assets/5ee47c66-1a64-4ce0-82de-e2d34bc6aeb7" />

* `ezAssetCurator::IsAssetUpToDate` with force flag set would recursively run through all dependencies and recheck that all input and output files are up to date. As you can reach the same asset transitively multiple times (e.g. a base material) the check was done again and again, making the function take 60 seconds on a large scene. The function now computes the transitive hull of assets via `ezAssetCurator::GenerateTransitiveAssetHull`, invalidates their transform state and then runs `ezAssetCurator::UpdateAssetTransformState` without the force flag, causing each asset to only be evaluated once.
* `ezAssetProcessor::Run` would sleep after every loop for 100ms, so all asset processing would always take at least 100ms, even if the asset took only 2ms to transform. The run function is now woken up whenever a new message comes in from any of the processes.
* If no work was available, the `ezAssetProcessor` sends a `ezFreeAllResourcesMsg` to the idle process. However, the code would do this on every tick until new work became available instead of only once, causing unnecessary CPU load.
* `ezEditorProcessorProcess::Tick` did not return from working on its state machine when in the `State::Processing`, effectively busy-waiting until an asset was finished before returning to the caller, starving the other processes from being given new work.
* `ezQtAssetProcessorProgressWidget` would hold only the mutex for new messages while painting, causing the `ezAssetProcessor` to stall as the event broadcast was stalled.
* Start / end time for each asset was computed in the `ezAssetProcessor` via sending the work request and receiving the response instead of computing it in the `ezEditorProcessor` when it received the message and when it finished its work. This caused it to look like work is being done, even though most of the time the `ezEditorProcessor` were idle, waiting for new work to arrive.

## IPC Classes
* Some refactoring to deduplicate IPC channel / protocol creation and destruction across all the classes derived from `ezProcessCommunicationChannel`.
* Added `ezProcessCommunicationChannel::m_IpcChannelEvents` which redirects from the internal `ezIpcChannel` event to inform users that new messages have arrived.

## Curator Panel
* `ezQtAssetProcessorProgressWidget` now caches various fonts, pixmaps, colors etc that are needed for painting to improve performance.
* `ezQtAssetProcessorProgressWidget` show how much time was spent during asset processing in asset curator updates (mainly the checks `ezAssetCurator::UpdateAssetTransformState`). You can see it as a darker bar before each task and on the tooltip.
* Improved performance of `ezQtLogModel` but only invoking `ProcessNewMessages` once for new message and by not calling `beginInsertRows` / `endInsertRows` for every message but instead only once for the entire batch of new messages.