### PR TITLE
Use EnumAdapterByGpuPreference for DX11 adapter selection

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -100,7 +100,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: "$(System.DefaultWorkingDirectory)/RunCMake.ps1"
-      arguments: "-Target vs2022x64 -NoUnityBuild -NoSubmoduleUpdate -VulkanSupport 0 -SolutionName solution"
+      arguments: "-Target vs2022x64 -NoUnityBuild -NoSubmoduleUpdate -VulkanSupport 1 -SolutionName solution"
   - task: MSBuild@1
     displayName: Build Solution
     inputs:
@@ -127,28 +127,35 @@ jobs:
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2022Dev64\FoundationTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\FoundationTest
+      script: Output\Bin\WinVs2022Dev64\FoundationTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\FoundationTest
   - task: CmdLine@2
     displayName: CoreTest
     condition: eq(variables['task.MSBuild.status'], 'success')
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2022Dev64\CoreTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\CoreTest
+      script: Output\Bin\WinVs2022Dev64\CoreTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\CoreTest
   - task: CmdLine@2
     displayName: ToolsFoundationTest
     condition: eq(variables['task.MSBuild.status'], 'success')
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2022Dev64\ToolsFoundationTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\ToolsFoundationTest
+      script: Output\Bin\WinVs2022Dev64\ToolsFoundationTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\ToolsFoundationTest
   - task: CmdLine@2
     displayName: RendererTest
     condition: eq(variables['task.MSBuild.status'], 'success')
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2022Dev64\RendererTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTest
+      script: Output\Bin\WinVs2022Dev64\RendererTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTest
+  - task: CmdLine@2
+    displayName: RendererTest Vulkan
+    condition: eq(variables['task.MSBuild.status'], 'success')
+    env:
+      TRACY_NO_INVARIANT_CHECK: 1
+    inputs:
+      script: Output\Bin\WinVs2022Dev64\RendererTest.exe -renderer Vulkan -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\RendererTestVulkan
   - task: CmdLine@2
     displayName: EditorTest
     condition: eq(variables['task.MSBuild.status'], 'success')
@@ -157,14 +164,14 @@ jobs:
     inputs:
       script: |
         set QT_PLUGIN_PATH=Output\Bin\WinVs2022Dev64
-        Output\Bin\WinVs2022Dev64\EditorTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\EditorTest
+        Output\Bin\WinVs2022Dev64\EditorTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\EditorTest
   - task: CmdLine@2
     displayName: GameEngineTest
     condition: eq(variables['task.MSBuild.status'], 'success')
     env:
       TRACY_NO_INVARIANT_CHECK: 1
     inputs:
-      script: Output\Bin\WinVs2022Dev64\GameEngineTest.exe -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\GameEngineTest
+      script: Output\Bin\WinVs2022Dev64\GameEngineTest.exe -renderer DX11 -nosave -nogui -all -outputDir $(Build.ArtifactStagingDirectory)\Test\GameEngineTest
   - task: PowerShell@2
     displayName: Copy Dumps
     condition: eq(variables['task.MSBuild.status'], 'success')

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -30,7 +30,31 @@
 
 #include <d3d11.h>
 #include <d3d11_3.h>
+#include <dxgi1_6.h>
 #include <dxgidebug.h>
+
+namespace
+{
+  IDXGIAdapter1* CreateHighPerformanceAdapter()
+  {
+    IDXGIFactory1* pFactory1 = nullptr;
+    IDXGIFactory6* pFactory6 = nullptr;
+    IDXGIAdapter1* pAdapter = nullptr;
+    EZ_SCOPE_EXIT(EZ_GAL_DX11_RELEASE(pFactory1));
+    EZ_SCOPE_EXIT(EZ_GAL_DX11_RELEASE(pFactory6));
+
+    if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&pFactory1))))
+      return nullptr;
+
+    if (FAILED(pFactory1->QueryInterface(IID_PPV_ARGS(&pFactory6))))
+      return nullptr;
+
+    if (pFactory6->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(&pAdapter)) == DXGI_ERROR_NOT_FOUND)
+      return nullptr;
+
+    return pAdapter;
+  }
+}
 
 ezInternal::NewInstance<ezGALDevice> CreateDX11Device(ezAllocator* pAllocator, const ezGALDeviceCreationDescription& description)
 {
@@ -247,7 +271,9 @@ ezStringView ezGALDeviceDX11::GetRendererPlatform()
 
 ezResult ezGALDeviceDX11::InitPlatform()
 {
-  return InitPlatform(0, nullptr);
+  IDXGIAdapter1* pAdapter = CreateHighPerformanceAdapter();
+  EZ_SCOPE_EXIT(EZ_GAL_DX11_RELEASE(pAdapter));
+  return InitPlatform(0, pAdapter);
 }
 
 void ezGALDeviceDX11::ReportLiveGpuObjects()

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -54,7 +54,7 @@ namespace
 
     return pAdapter;
   }
-}
+} // namespace
 
 ezInternal::NewInstance<ezGALDevice> CreateDX11Device(ezAllocator* pAllocator, const ezGALDeviceCreationDescription& description)
 {

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -445,7 +445,16 @@ ezResult ezGALDeviceVulkan::InitPlatform()
     {
       m_extensions.m_bDebugUtilsMarkers = false;
     }
-    // TODO call vkGetPhysicalDeviceFeatures2 with VkPhysicalDeviceTimelineSemaphoreFeatures and figure out if timeline semaphores are supported
+
+    {
+      vk::PhysicalDeviceTimelineSemaphoreFeatures timelineFeatures;
+      vk::PhysicalDeviceFeatures2 features2;
+      features2.pNext = &timelineFeatures;
+      m_physicalDevice.getFeatures2(&features2);
+
+      m_extensions.m_bTimelineSemaphore = static_cast<bool>(timelineFeatures.timelineSemaphore);
+      m_extensions.m_timelineSemaphoresEXT = timelineFeatures;
+    }
   }
 
   ezHybridArray<vk::QueueFamilyProperties, 4> queueFamilyProperties;

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -411,7 +411,7 @@ void ezGALSwapChainVulkan::DestroySwapChainInternal(ezGALDeviceVulkan* pVulkanDe
 
   for (vk::Semaphore& sem : m_imageRenderFinishedSemaphores)
   {
-      pVulkanDevice->DeleteLater(sem);
+    pVulkanDevice->DeleteLater(sem);
   }
   m_imageRenderFinishedSemaphores.Clear();
 

--- a/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/SwapChainVulkan.cpp
@@ -136,8 +136,7 @@ void ezGALSwapChainVulkan::PresentRenderTarget(ezGALDevice* pDevice)
   }
 
   // Submit command buffer
-  vk::Semaphore currentPipelineRenderFinishedSemaphore = ezSemaphorePoolVulkan::RequestSemaphore();
-
+  vk::Semaphore currentPipelineRenderFinishedSemaphore = m_imageRenderFinishedSemaphores[m_uiCurrentSwapChainImage];
 
   pVulkanDevice->AddSignalSemaphore(ezGALDeviceVulkan::SemaphoreInfo::MakeSignalSemaphore(currentPipelineRenderFinishedSemaphore));
   pVulkanDevice->Submit();
@@ -157,8 +156,6 @@ void ezGALSwapChainVulkan::PresentRenderTarget(ezGALDevice* pDevice)
     ezLog::Warning("PresentInfoKHR {}", ezArgP(m_swapChainImages[m_uiCurrentSwapChainImage]));
 #endif
   }
-
-  pVulkanDevice->ReclaimLater(currentPipelineRenderFinishedSemaphore);
 }
 
 ezResult ezGALSwapChainVulkan::UpdateSwapChain(ezGALDevice* pDevice, ezEnum<ezGALPresentMode> newPresentMode)
@@ -373,6 +370,14 @@ ezResult ezGALSwapChainVulkan::CreateSwapChainInternal()
   m_swapChainImages.SetCount(uiSwapChainImages);
   VK_SUCCEED_OR_RETURN_EZ_FAILURE(m_pVulkanDevice->GetVulkanDevice().getSwapchainImagesKHR(m_vulkanSwapChain, &uiSwapChainImages, m_swapChainImages.GetData()));
 
+  // We can't use our pool here as the frame fence is not sufficient to reclaim swapchain semaphores. Thus, we create unique ones for every image.
+  m_imageRenderFinishedSemaphores.SetCount(uiSwapChainImages);
+  for (ezUInt32 i = 0; i < uiSwapChainImages; ++i)
+  {
+    vk::SemaphoreCreateInfo semaphoreCreateInfo;
+    VK_ASSERT_DEV(m_pVulkanDevice->GetVulkanDevice().createSemaphore(&semaphoreCreateInfo, nullptr, &m_imageRenderFinishedSemaphores[i]));
+  }
+
   for (ezUInt32 i = 0; i < uiSwapChainImages; i++)
   {
     m_pVulkanDevice->SetDebugName("SwapChainImage", m_swapChainImages[i]);
@@ -403,6 +408,12 @@ void ezGALSwapChainVulkan::DestroySwapChainInternal(ezGALDeviceVulkan* pVulkanDe
     pVulkanDevice->DestroyTexture(m_swapChainTextures[i]);
   }
   m_swapChainTextures.Clear();
+
+  for (vk::Semaphore& sem : m_imageRenderFinishedSemaphores)
+  {
+      pVulkanDevice->DeleteLater(sem);
+  }
+  m_imageRenderFinishedSemaphores.Clear();
 
   if (m_vulkanSwapChain)
   {

--- a/Code/Engine/RendererVulkan/Device/SwapChainVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/SwapChainVulkan.h
@@ -36,11 +36,12 @@ protected:
 
   vk::SurfaceKHR m_vulkanSurface;
   vk::SwapchainKHR m_vulkanSwapChain;
-  ezHybridArray<vk::Image, 3> m_swapChainImages;
-  ezHybridArray<ezGALTextureHandle, 3> m_swapChainTextures;
+  ezHybridArray<vk::Image, 4> m_swapChainImages;
+  ezHybridArray<ezGALTextureHandle, 4> m_swapChainTextures;
   ezUInt32 m_uiCurrentSwapChainImage = 0;
 
   vk::Semaphore m_currentPipelineImageAvailableSemaphore;
+  ezHybridArray<vk::Semaphore, 4> m_imageRenderFinishedSemaphores;
 };
 
 #include <RendererVulkan/Device/Implementation/SwapChainVulkan_inl.h>

--- a/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Pools/Implementation/QueryPoolVulkan.cpp
@@ -65,30 +65,64 @@ void ezQueryPoolVulkan::Calibrate()
 {
   EZ_PROFILE_SCOPE("Calibrate");
   // #TODO_VULKAN Replace with VK_KHR_calibrated_timestamps
-  // To correlate CPU to GPU time, we create an event, wait a bit for the GPU to get stuck on it and then signal it.
-  // We then observe the time right after on the CPU and on the GPU via a timestamp query.
-  vk::EventCreateInfo eventCreateInfo;
-  vk::Event event;
-  VK_ASSERT_DEV(m_TimestampPool.m_device.createEvent(&eventCreateInfo, nullptr, &event));
+  // Prefer a host-signaled timeline semaphore so the GPU can wait on the host.
+  if (m_pDevice->GetExtensions().m_bTimelineSemaphore)
+  {
+    vk::SemaphoreTypeCreateInfo timelineTypeInfo;
+    timelineTypeInfo.semaphoreType = vk::SemaphoreType::eTimeline;
+    timelineTypeInfo.initialValue = 0;
 
-  m_TimestampPool.m_device.waitIdle();
-  vk::CommandBuffer cb = m_pDevice->GetCurrentCommandBuffer();
-  cb.waitEvents(1, &event, vk::PipelineStageFlagBits::eHost, vk::PipelineStageFlagBits::eHost | vk::PipelineStageFlagBits::eTopOfPipe, 0, nullptr, 0, nullptr, 0, nullptr);
-  auto hTimestamp = InsertTimestamp(cb, vk::PipelineStageFlagBits::eTopOfPipe);
-  vk::Fence fence = m_pDevice->Submit();
+    vk::SemaphoreCreateInfo semCreateInfo;
+    semCreateInfo.pNext = &timelineTypeInfo;
 
-  ezTime systemTS;
-  ezThreadUtils::Sleep(ezTime::Milliseconds(100)); // Waiting for 100ms should be enough for the GPU to have gotten stuck on the event right?
-  m_TimestampPool.m_device.setEvent(event);
-  systemTS = ezTime::Now();
+    vk::Semaphore timelineSemaphore;
+    VK_ASSERT_DEV(m_TimestampPool.m_device.createSemaphore(&semCreateInfo, nullptr, &timelineSemaphore));
 
-  VK_ASSERT_DEV(m_TimestampPool.m_device.waitForFences(1, &fence, true, ezMath::MaxValue<ezUInt64>()));
+    m_TimestampPool.m_device.waitIdle();
+    vk::CommandBuffer cb = m_pDevice->GetCurrentCommandBuffer();
 
-  ezTime gpuTS;
-  EZ_VERIFY(GetTimestampResult(hTimestamp, gpuTS, true) == ezGALAsyncResult::Ready, "");
-  m_gpuToCpuDelta = systemTS - gpuTS;
+    // Insert the timestamp into the command buffer which will wait for the
+    // timeline semaphore to be signaled by the host before executing.
+    auto hTimestamp = InsertTimestamp(cb, vk::PipelineStageFlagBits::eTopOfPipe);
 
-  m_TimestampPool.m_device.destroyEvent(event);
+    m_pDevice->AddWaitSemaphore(ezGALDeviceVulkan::SemaphoreInfo::MakeWaitSemaphore(timelineSemaphore, vk::PipelineStageFlagBits::eTopOfPipe, vk::SemaphoreType::eTimeline, 1));
+
+    vk::Fence fence = m_pDevice->Submit();
+
+    // Signal the timeline semaphore from the host to let the GPU continue.
+    ezThreadUtils::Sleep(ezTime::Milliseconds(10));
+
+    vk::SemaphoreSignalInfo signalInfo;
+    signalInfo.semaphore = timelineSemaphore;
+    signalInfo.value = 1;
+    VK_ASSERT_DEV(m_TimestampPool.m_device.signalSemaphore(&signalInfo));
+    const ezTime systemTS = ezTime::Now();
+
+    VK_ASSERT_DEV(m_TimestampPool.m_device.waitForFences(1, &fence, true, ezMath::MaxValue<ezUInt64>()));
+
+    ezTime gpuTS;
+    EZ_VERIFY(GetTimestampResult(hTimestamp, gpuTS, true) == ezGALAsyncResult::Ready, "");
+    m_gpuToCpuDelta = systemTS - gpuTS;
+
+    m_TimestampPool.m_device.destroySemaphore(timelineSemaphore);
+  }
+  else
+  {
+    // Fallback for hardware without timeline semaphore support:
+    // Insert a timestamp, submit and wait for the fence, then sample host time.
+    // This provides a usable (though possibly less precise) GPU->CPU delta.
+    m_TimestampPool.m_device.waitIdle();
+    vk::CommandBuffer cb = m_pDevice->GetCurrentCommandBuffer();
+    auto hTimestamp = InsertTimestamp(cb, vk::PipelineStageFlagBits::eTopOfPipe);
+    vk::Fence fence = m_pDevice->Submit();
+
+    VK_ASSERT_DEV(m_TimestampPool.m_device.waitForFences(1, &fence, true, ezMath::MaxValue<ezUInt64>()));
+
+    const ezTime systemTS = ezTime::Now();
+    ezTime gpuTS;
+    EZ_VERIFY(GetTimestampResult(hTimestamp, gpuTS, true) == ezGALAsyncResult::Ready, "");
+    m_gpuToCpuDelta = systemTS - gpuTS;
+  }
 }
 
 void ezQueryPoolVulkan::AfterBeginFrame(vk::CommandBuffer commandBuffer)

--- a/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Utils/Implementation/PipelineBarrierVulkan.cpp
@@ -430,6 +430,9 @@ void ezPipelineBarrierVulkan::FullBarrier()
   vk::MemoryBarrier memoryBarrier;
   memoryBarrier.srcAccessMask = s_writeAccess | s_readAccess;
   memoryBarrier.dstAccessMask = s_writeAccess | s_readAccess;
+  memoryBarrier.srcAccessMask &= ~(vk::AccessFlagBits::eHostRead | vk::AccessFlagBits::eHostWrite);
+  memoryBarrier.dstAccessMask &= ~(vk::AccessFlagBits::eHostRead | vk::AccessFlagBits::eHostWrite);
+
 
   m_pCommandBuffer->pipelineBarrier(vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands, vk::DependencyFlags(), 1, &memoryBarrier, 0, nullptr, 0, nullptr);
 }

--- a/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
+++ b/Code/Engine/Texture/Image/Conversions/DXTexConversions.cpp
@@ -26,6 +26,7 @@ ezCVarBool cvar_TexturePenalizeDXConversions("Texture.PenalizeDXConversions", fa
 #  include <Texture/DirectXTex/DirectXTex.h>
 #  include <d3d11.h>
 #  include <dxgi.h>
+#  include <dxgi1_6.h>
 #  include <dxgiformat.h>
 #  include <wrl\client.h>
 
@@ -60,6 +61,51 @@ namespace
     return SUCCEEDED(s_CreateDXGIFactory1(IID_PPV_ARGS(pFactory)));
   }
 
+  ComPtr<IDXGIAdapter1> CreateHighPerformanceAdapter()
+  {
+    ComPtr<IDXGIAdapter1> pAdapter;
+    ComPtr<IDXGIFactory1> pFactory1;
+    ComPtr<IDXGIFactory6> pFactory6;
+    if (!GetDXGIFactory(pFactory1.GetAddressOf()))
+      return {};
+
+    if (FAILED(pFactory1->QueryInterface(IID_PPV_ARGS(pFactory6.GetAddressOf()))))
+      return {};
+
+    if (pFactory6->EnumAdapterByGpuPreference(0, DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE, IID_PPV_ARGS(pAdapter.ReleaseAndGetAddressOf())) == DXGI_ERROR_NOT_FOUND)
+      return {};
+
+    return pAdapter;
+  }
+
+  bool TryCreateD3D11Device(IDXGIAdapter* pAdapter, D3D_DRIVER_TYPE driverType, ComPtr<ID3D11Device>& ref_device)
+  {
+    static PFN_D3D11_CREATE_DEVICE s_DynamicD3D11CreateDevice = nullptr;
+
+    if (!s_DynamicD3D11CreateDevice)
+    {
+      HMODULE hModD3D11 = LoadLibraryA("d3d11.dll");
+      if (!hModD3D11)
+        return false;
+
+      s_DynamicD3D11CreateDevice = reinterpret_cast<PFN_D3D11_CREATE_DEVICE>(reinterpret_cast<void*>(GetProcAddress(hModD3D11, "D3D11CreateDevice")));
+      if (!s_DynamicD3D11CreateDevice)
+        return false;
+    }
+
+    static const D3D_FEATURE_LEVEL FeatureLevels[] = {D3D_FEATURE_LEVEL_11_1, D3D_FEATURE_LEVEL_11_0};
+    D3D_FEATURE_LEVEL SelectedFeatureLevel;
+
+    for (int featureLevelIdx = 0; featureLevelIdx < EZ_ARRAY_SIZE(FeatureLevels); ++featureLevelIdx)
+    {
+      if (SUCCEEDED(s_DynamicD3D11CreateDevice(pAdapter, driverType, nullptr, 0, &FeatureLevels[featureLevelIdx], 1, D3D11_SDK_VERSION, ref_device.ReleaseAndGetAddressOf(), &SelectedFeatureLevel, nullptr)))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
   enum class TypeOfDeviceCreated
   {
     None,
@@ -71,146 +117,45 @@ namespace
   TypeOfDeviceCreated CreateDevice(ComPtr<ID3D11Device>& ref_device)
   {
     ref_device = nullptr;
-
-    // Find a hardware adapter if possible, otherwise find any adapter.
-    ComPtr<IDXGIAdapter1> pHardwareAdapter1;
-    ComPtr<IDXGIAdapter1> pFallbackAdapter1;
-    {
-      int adapter = 0;
-      ComPtr<IDXGIFactory1> dxgiFactory;
-      if (GetDXGIFactory(dxgiFactory.GetAddressOf()))
-      {
-        ComPtr<IDXGIAdapter1> pAdapter1;
-        while (dxgiFactory->EnumAdapters1(adapter, pAdapter1.ReleaseAndGetAddressOf()) != DXGI_ERROR_NOT_FOUND)
-        {
-          DXGI_ADAPTER_DESC1 desc1;
-#  if !NDEBUG
-          const HRESULT descResult =
-#  endif
-            pAdapter1->GetDesc1(&desc1);
-          assert(SUCCEEDED(descResult));
-          constexpr auto basicDriverString = L"Microsoft Basic Render Driver";
-          if ((desc1.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) == 0 && _wcsicmp(basicDriverString, desc1.Description) != 0)
-          {
-            if (pHardwareAdapter1 == nullptr)
-            {
-              pHardwareAdapter1 = pAdapter1;
-            }
-          }
-          else if (pFallbackAdapter1 == nullptr)
-          {
-            pFallbackAdapter1 = pAdapter1;
-          }
-
-          ++adapter;
-        }
-      }
-    }
-
-    ComPtr<IDXGIAdapter1> pAdapter1;
     TypeOfDeviceCreated deviceType = TypeOfDeviceCreated::None;
-    if (pHardwareAdapter1 != nullptr)
+
+    ComPtr<IDXGIAdapter1> pAdapter = CreateHighPerformanceAdapter();
+    if (pAdapter != nullptr && TryCreateD3D11Device(pAdapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, ref_device))
     {
-      pAdapter1 = std::move(pHardwareAdapter1);
       deviceType = TypeOfDeviceCreated::Hardware;
     }
-    else if (pFallbackAdapter1 != nullptr)
+
+    // Fallback: try to create a hardware device without specifying an adapter
+    if (ref_device == nullptr && TryCreateD3D11Device(nullptr, D3D_DRIVER_TYPE_HARDWARE, ref_device))
     {
-      pAdapter1 = std::move(pFallbackAdapter1);
+      deviceType = TypeOfDeviceCreated::Hardware;
+    }
+
+    // Fallback: try to create a WARP software device
+    if (ref_device == nullptr && TryCreateD3D11Device(nullptr, D3D_DRIVER_TYPE_WARP, ref_device))
+    {
       deviceType = TypeOfDeviceCreated::Software;
     }
 
-    if (pAdapter1 == nullptr)
-    {
+    if (ref_device == nullptr)
       return TypeOfDeviceCreated::None;
-    }
 
-    // Get the IDXGIAdapter interface from the IDXGIAdapter1.
-    ComPtr<IDXGIAdapter> pAdapter;
+    auto GetDeviceName = [&]() -> ezString
     {
-#  if !NDEBUG
-      const HRESULT castResult =
-#  endif
-        pAdapter1->QueryInterface(pAdapter.GetAddressOf());
-      assert(SUCCEEDED(castResult));
-    }
-
-    {
-      DXGI_ADAPTER_DESC1 desc1;
-      pAdapter1->GetDesc1(&desc1);
-
-      ezLog::Info("D3D11 Device used for texture compression: '{}'", desc1.Description);
-    }
-
-    static PFN_D3D11_CREATE_DEVICE s_DynamicD3D11CreateDevice = nullptr;
-
-    if (!s_DynamicD3D11CreateDevice)
-    {
-      HMODULE hModD3D11 = LoadLibraryA("d3d11.dll");
-      if (!hModD3D11)
-        return TypeOfDeviceCreated::None;
-
-      s_DynamicD3D11CreateDevice = reinterpret_cast<PFN_D3D11_CREATE_DEVICE>(reinterpret_cast<void*>(GetProcAddress(hModD3D11, "D3D11CreateDevice")));
-      if (!s_DynamicD3D11CreateDevice)
-        return TypeOfDeviceCreated::None;
-    }
-
-    D3D_FEATURE_LEVEL featureLevels[] = {
-      D3D_FEATURE_LEVEL_11_0,
-      D3D_FEATURE_LEVEL_10_1,
-      D3D_FEATURE_LEVEL_10_0,
-    };
-
-    UINT createDeviceFlags = 0;
-    // #  ifdef _DEBUG
-    //     don't do this (especially not without a fallback for failure), not needed for texture conversion
-    //     createDeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
-    // #  endif
-
-    D3D_FEATURE_LEVEL fl;
-    HRESULT hr = s_DynamicD3D11CreateDevice(pAdapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, createDeviceFlags, featureLevels,
-      _countof(featureLevels), D3D11_SDK_VERSION, &ref_device, &fl, nullptr);
-
-    if (FAILED(hr) && (createDeviceFlags & D3D11_CREATE_DEVICE_DEBUG))
-    {
-      createDeviceFlags = createDeviceFlags & ~D3D11_CREATE_DEVICE_DEBUG;
-      hr = s_DynamicD3D11CreateDevice(pAdapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, createDeviceFlags, featureLevels,
-        _countof(featureLevels), D3D11_SDK_VERSION, &ref_device, &fl, nullptr);
-    }
-
-    if (SUCCEEDED(hr))
-    {
-      if (fl < D3D_FEATURE_LEVEL_11_0)
-      {
-        D3D11_FEATURE_DATA_D3D10_X_HARDWARE_OPTIONS hwopts;
-        hr = ref_device->CheckFeatureSupport(D3D11_FEATURE_D3D10_X_HARDWARE_OPTIONS, &hwopts, sizeof(hwopts));
-        if (FAILED(hr))
-          memset(&hwopts, 0, sizeof(hwopts));
-
-        if (!hwopts.ComputeShaders_Plus_RawAndStructuredBuffers_Via_Shader_4_x)
-        {
-          ref_device = nullptr;
-          hr = HRESULT_FROM_WIN32(ERROR_NOT_SUPPORTED);
-        }
-      }
-    }
-
-    if (SUCCEEDED(hr))
-    {
+      ComPtr<IDXGIDevice> pDXGIDevice;
+      if (FAILED(ref_device.As(&pDXGIDevice)))
+        return "<No IDXGIDevice interface>"_ezsv;
+      ComPtr<IDXGIAdapter> pAdapter;
+      if (FAILED(pDXGIDevice->GetAdapter(pAdapter.GetAddressOf())))
+        return "<GetAdapter Failed>"_ezsv;
       DXGI_ADAPTER_DESC desc;
-      hr = pAdapter->GetDesc(&desc);
-      if (SUCCEEDED(hr))
-      {
-        ezStringUtf8 sDesc(desc.Description);
-        ezLog::Dev("Using DirectCompute on \"{0}\"", sDesc.GetData());
-      }
-
-      return deviceType;
-    }
-    else
-    {
-      return TypeOfDeviceCreated::None;
-    }
+      if (FAILED(pAdapter->GetDesc(&desc)))
+        return "<GetDesc Failed>"_ezsv;
+      ezStringUtf8 sDesc(desc.Description);
+      return ezString(sDesc.GetData());
+    };
+    ezLog::Dev("Using DirectCompute on \"{0}\"", GetDeviceName());
+    return deviceType;
   }
 
   /// Ensures a device and its corresponding conversion table are constructed together.

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -2,7 +2,8 @@
 
 #include <Core/Graphics/Camera.h>
 #include <Foundation/Math/ColorScheme.h>
-#include <Foundation/Threading/ThreadUtils.h>
+#include <Foundation/Configuration/Startup.h>
+
 #include <RendererTest/Basics/PipelineStates.h>
 #include <RendererTest/Basics/RendererTestUtils.h>
 
@@ -35,31 +36,25 @@ void ezRendererTestPipelineStates::SetupSubTests()
   AddSubTest("14 - CustomVertexStreams", SubTests::ST_CustomVertexStreams);
 }
 
-ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
+ezResult ezRendererTestPipelineStates::InitializeTest()
 {
-  {
-    m_iDelay = 0;
-    m_CPUTime[0] = {};
-    m_CPUTime[1] = {};
-    m_GPUTime[0] = {};
-    m_GPUTime[1] = {};
-    m_timestamps[0] = {};
-    m_timestamps[1] = {};
-    m_queries[0] = {};
-    m_queries[1] = {};
-    m_queries[2] = {};
-    m_queries[3] = {};
-    m_hFence = {};
-  }
+  // Initialize core systems and renderer once for all sub-tests
+  ezStartup::StartupCoreSystems();
 
-  EZ_SUCCEED_OR_RETURN(ezGraphicsTest::InitializeSubTest(iIdentifier));
+  if (SetupRenderer().Failed())
+    return EZ_FAILURE;
+
+  // Create window once for all sub-tests
   EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
+
+  // Load shaders that are used across multiple sub-tests
   m_hMostBasicTriangleShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/MostBasicTriangle.ezShader");
   m_hNDCPositionOnlyShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/NDCPositionOnly.ezShader");
   m_hConstantBufferShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ConstantBuffer.ezShader");
   m_hPushConstantsShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/PushConstants.ezShader");
   m_hCustomVertexStreamShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/CustomVertexStreams.ezShader");
 
+  // Create meshes that are used across multiple sub-tests
   {
     ezMeshBufferResourceDescriptor desc;
     desc.AddStream(ezMeshVertexStreamType::Position);
@@ -90,9 +85,63 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 
     m_hSphereMesh = ezResourceManager::CreateResource<ezMeshBufferResource>("UnitTest-SphereMesh", std::move(desc), "SphereMesh");
   }
+
+  // Create constant buffers that are used across multiple sub-tests
   m_hTestPerFrameConstantBuffer = ezRenderContext::CreateConstantBufferStorage<ezTestPerFrame>();
   m_hTestColorsConstantBuffer = ezRenderContext::CreateConstantBufferStorage<ezTestColors>();
   m_hTestPositionsConstantBuffer = ezRenderContext::CreateConstantBufferStorage<ezTestPositions>();
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestPipelineStates::DeInitializeTest()
+{
+  // Clean up resources created in InitializeTest
+  m_hTriangleMesh.Invalidate();
+  m_hSphereMesh.Invalidate();
+
+  m_hMostBasicTriangleShader.Invalidate();
+  m_hNDCPositionOnlyShader.Invalidate();
+  m_hConstantBufferShader.Invalidate();
+  m_hPushConstantsShader.Invalidate();
+  m_hCustomVertexStreamShader.Invalidate();
+
+  m_hTestPerFrameConstantBuffer.Invalidate();
+  m_hTestColorsConstantBuffer.Invalidate();
+  m_hTestPositionsConstantBuffer.Invalidate();
+
+  // Destroy window once after all sub-tests
+  DestroyWindow();
+
+  // Shut down renderer and core systems once after all sub-tests
+  ShutdownRenderer();
+  ezStartup::ShutdownCoreSystems();
+  ezMemoryTracker::DumpMemoryLeaks();
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
+{
+  // Reset per-sub-test state
+  m_iFrame = -1;
+  m_bCaptureImage = false;
+  m_ImgCompFrames.Clear();
+
+  {
+    m_iDelay = 0;
+    m_CPUTime[0] = {};
+    m_CPUTime[1] = {};
+    m_GPUTime[0] = {};
+    m_GPUTime[1] = {};
+    m_timestamps[0] = {};
+    m_timestamps[1] = {};
+    m_queries[0] = {};
+    m_queries[1] = {};
+    m_queries[2] = {};
+    m_queries[3] = {};
+    m_hFence = {};
+  }
 
   if (iIdentifier == SubTests::ST_StructuredBuffer || iIdentifier == SubTests::ST_TexelBuffer || iIdentifier == SubTests::ST_ByteAddressBuffer)
   {
@@ -337,20 +386,9 @@ ezResult ezRendererTestPipelineStates::InitializeSubTest(ezInt32 iIdentifier)
 
 ezResult ezRendererTestPipelineStates::DeInitializeSubTest(ezInt32 iIdentifier)
 {
-  m_hTriangleMesh.Invalidate();
-  m_hSphereMesh.Invalidate();
-
-  m_hMostBasicTriangleShader.Invalidate();
-  m_hNDCPositionOnlyShader.Invalidate();
-  m_hConstantBufferShader.Invalidate();
-  m_hPushConstantsShader.Invalidate();
+  // Clean up per-sub-test resources (shaders and meshes shared across sub-tests are cleaned up in DeInitializeTest)
   m_hInstancingShader.Invalidate();
   m_hCopyBufferShader.Invalidate();
-  m_hCustomVertexStreamShader.Invalidate();
-
-  m_hTestPerFrameConstantBuffer.Invalidate();
-  m_hTestColorsConstantBuffer.Invalidate();
-  m_hTestPositionsConstantBuffer.Invalidate();
 
   if (!m_hInstancingData.IsInvalidated())
   {
@@ -393,8 +431,8 @@ ezResult ezRendererTestPipelineStates::DeInitializeSubTest(ezInt32 iIdentifier)
   }
   m_hFence = {};
 
-  DestroyWindow();
-  EZ_SUCCEED_OR_RETURN(ezGraphicsTest::DeInitializeSubTest(iIdentifier));
+  // Don't call parent's DeInitializeSubTest - renderer shutdown happens in DeInitializeTest
+
   return EZ_SUCCESS;
 }
 

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.cpp
@@ -1,8 +1,8 @@
 #include <RendererTest/RendererTestPCH.h>
 
 #include <Core/Graphics/Camera.h>
-#include <Foundation/Math/ColorScheme.h>
 #include <Foundation/Configuration/Startup.h>
+#include <Foundation/Math/ColorScheme.h>
 
 #include <RendererTest/Basics/PipelineStates.h>
 #include <RendererTest/Basics/RendererTestUtils.h>

--- a/Code/UnitTests/RendererTest/Basics/PipelineStates.h
+++ b/Code/UnitTests/RendererTest/Basics/PipelineStates.h
@@ -44,6 +44,8 @@ private:
   };
 
   virtual void SetupSubTests() override;
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -7,6 +7,49 @@
 #include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Resources/Texture.h>
 #include <RendererTest/Basics/Readback.h>
+#include <Foundation/Configuration/Startup.h>
+
+ezResult ezRendererTestReadback::InitializeTest()
+{
+  ezStartup::StartupCoreSystems();
+
+  if (SetupRenderer().Failed())
+    return EZ_FAILURE;
+
+  EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
+
+  m_hUVColorShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackFloat.ezShader");
+  m_hUVColorIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackInt.ezShader");
+  m_hUVColorUIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackUInt.ezShader");
+  m_hUVColorDepthShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackDepth.ezShader");
+
+  m_hTexture2DShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2D.ezShader");
+  m_hTexture2DDepthShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2DReadbackDepth.ezShader");
+  m_hTexture2DIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2DReadbackInt.ezShader");
+  m_hTexture2DUIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2DReadbackUInt.ezShader");
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestReadback::DeInitializeTest()
+{
+  m_hShader.Invalidate();
+  m_hUVColorShader.Invalidate();
+  m_hUVColorIntShader.Invalidate();
+  m_hUVColorUIntShader.Invalidate();
+  m_hUVColorDepthShader.Invalidate();
+  m_hTexture2DShader.Invalidate();
+  m_hTexture2DDepthShader.Invalidate();
+  m_hTexture2DIntShader.Invalidate();
+  m_hTexture2DUIntShader.Invalidate();
+
+  DestroyWindow();
+  ShutdownRenderer();
+  ezStartup::ShutdownCoreSystems();
+  ezMemoryTracker::DumpMemoryLeaks();
+
+  return EZ_SUCCESS;
+}
 
 void ezRendererTestReadback::SetupSubTests()
 {
@@ -46,20 +89,9 @@ void ezRendererTestReadback::SetupSubTests()
 ezResult ezRendererTestReadback::InitializeSubTest(ezInt32 iIdentifier)
 {
   m_iFrame = -1;
+  m_bCaptureImage = false;
+  m_ImgCompFrames.Clear();
   m_bReadbackInProgress = true;
-
-  EZ_SUCCEED_OR_RETURN(ezGraphicsTest::InitializeSubTest(iIdentifier));
-  EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
-
-  m_hUVColorShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackFloat.ezShader");
-  m_hUVColorIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackInt.ezShader");
-  m_hUVColorUIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackUInt.ezShader");
-  m_hUVColorDepthShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackDepth.ezShader");
-
-  m_hTexture2DShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2D.ezShader");
-  m_hTexture2DDepthShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2DReadbackDepth.ezShader");
-  m_hTexture2DIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2DReadbackInt.ezShader");
-  m_hTexture2DUIntShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/Texture2DReadbackUInt.ezShader");
 
   // Texture2D
   {
@@ -88,20 +120,8 @@ ezResult ezRendererTestReadback::DeInitializeSubTest(ezInt32 iIdentifier)
     m_pDevice->DestroyTexture(m_hTexture2DUpload);
     m_hTexture2DUpload.Invalidate();
   }
-  m_hShader.Invalidate();
-  m_hUVColorShader.Invalidate();
-  m_hUVColorIntShader.Invalidate();
-  m_hUVColorUIntShader.Invalidate();
-  m_hTexture2DShader.Invalidate();
-  m_hTexture2DDepthShader.Invalidate();
-  m_hTexture2DIntShader.Invalidate();
-  m_hTexture2DUIntShader.Invalidate();
-  m_hUVColorDepthShader.Invalidate();
 
-  DestroyWindow();
-
-  if (ezGraphicsTest::DeInitializeSubTest(iIdentifier).Failed())
-    return EZ_FAILURE;
+  // Don't call parent's DeInitializeSubTest - renderer shutdown happens in DeInitializeTest
 
   return EZ_SUCCESS;
 }

--- a/Code/UnitTests/RendererTest/Basics/Readback.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Readback.cpp
@@ -7,7 +7,6 @@
 #include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Resources/Texture.h>
 #include <RendererTest/Basics/Readback.h>
-#include <Foundation/Configuration/Startup.h>
 
 ezResult ezRendererTestReadback::InitializeTest()
 {

--- a/Code/UnitTests/RendererTest/Basics/Readback.h
+++ b/Code/UnitTests/RendererTest/Basics/Readback.h
@@ -22,6 +22,8 @@ public:
 private:
   virtual void SetupSubTests() override;
 
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult GetImage(ezImage& ref_img, const ezSubTestEntry& subTest, ezUInt32 uiImageNumber) override;

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
@@ -7,6 +7,29 @@
 #include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Resources/Texture.h>
 #include <RendererTest/Basics/ReadbackBuffer.h>
+#include <Foundation/Configuration/Startup.h>
+
+ezResult ezRendererTestReadbackBuffer::InitializeTest()
+{
+  ezStartup::StartupCoreSystems();
+
+  if (SetupRenderer().Failed())
+    return EZ_FAILURE;
+
+  EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestReadbackBuffer::DeInitializeTest()
+{
+  DestroyWindow();
+  ShutdownRenderer();
+  ezStartup::ShutdownCoreSystems();
+  ezMemoryTracker::DumpMemoryLeaks();
+
+  return EZ_SUCCESS;
+}
 
 void ezRendererTestReadbackBuffer::SetupSubTests()
 {
@@ -25,10 +48,9 @@ void ezRendererTestReadbackBuffer::SetupSubTests()
 ezResult ezRendererTestReadbackBuffer::InitializeSubTest(ezInt32 iIdentifier)
 {
   m_iFrame = -1;
+  m_bCaptureImage = false;
+  m_ImgCompFrames.Clear();
   m_bReadbackInProgress = true;
-
-  EZ_SUCCEED_OR_RETURN(ezGraphicsTest::InitializeSubTest(iIdentifier));
-  EZ_SUCCEED_OR_RETURN(CreateWindow(320, 240));
 
   // m_hUVColorShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/ReadbackFloat.ezShader");
 
@@ -138,10 +160,7 @@ ezResult ezRendererTestReadbackBuffer::DeInitializeSubTest(ezInt32 iIdentifier)
 
   m_hComputeShader.Invalidate();
 
-  DestroyWindow();
-
-  if (ezGraphicsTest::DeInitializeSubTest(iIdentifier).Failed())
-    return EZ_FAILURE;
+  // Don't call parent's DeInitializeSubTest - renderer shutdown happens in DeInitializeTest
 
   return EZ_SUCCESS;
 }

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.cpp
@@ -7,7 +7,6 @@
 #include <RendererFoundation/RendererReflection.h>
 #include <RendererFoundation/Resources/Texture.h>
 #include <RendererTest/Basics/ReadbackBuffer.h>
-#include <Foundation/Configuration/Startup.h>
 
 ezResult ezRendererTestReadbackBuffer::InitializeTest()
 {

--- a/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.h
+++ b/Code/UnitTests/RendererTest/Basics/ReadbackBuffer.h
@@ -31,6 +31,8 @@ private:
 
   virtual void SetupSubTests() override;
 
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezTestAppRun RunSubTest(ezInt32 iIdentifier, ezUInt32 uiInvocationCount) override;

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
@@ -2,6 +2,7 @@
 
 #include <Core/Graphics/Camera.h>
 #include <RendererTest/Basics/SwapChain.h>
+#include <Foundation/Configuration/Startup.h>
 
 ezResult ezRendererTestSwapChain::InitializeTest()
 {

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
@@ -3,12 +3,30 @@
 #include <Core/Graphics/Camera.h>
 #include <RendererTest/Basics/SwapChain.h>
 
+ezResult ezRendererTestSwapChain::InitializeTest()
+{
+  ezStartup::StartupCoreSystems();
+
+  if (SetupRenderer().Failed())
+    return EZ_FAILURE;
+
+  return EZ_SUCCESS;
+}
+
+ezResult ezRendererTestSwapChain::DeInitializeTest()
+{
+  ShutdownRenderer();
+  ezStartup::ShutdownCoreSystems();
+  ezMemoryTracker::DumpMemoryLeaks();
+
+  return EZ_SUCCESS;
+}
+
 ezResult ezRendererTestSwapChain::InitializeSubTest(ezInt32 iIdentifier)
 {
   m_iFrame = -1;
-
-  if (ezGraphicsTest::InitializeSubTest(iIdentifier).Failed())
-    return EZ_FAILURE;
+  m_bCaptureImage = false;
+  m_ImgCompFrames.Clear();
 
   m_CurrentWindowSize = ezSizeU32(320, 240);
 
@@ -25,12 +43,11 @@ ezResult ezRendererTestSwapChain::InitializeSubTest(ezInt32 iIdentifier)
     m_pWindow->Initialize(WindowCreationDesc).AssertSuccess("Window creation failed");
   }
 
-  // SwapChain
   {
     ezGALWindowSwapChainCreationDescription swapChainDesc;
     swapChainDesc.m_pWindow = m_pWindow;
     swapChainDesc.m_SampleCount = ezGALMSAASampleCount::None;
-    swapChainDesc.m_InitialPresentMode = (iIdentifier == SubTests::ST_NoVSync) ? ezGALPresentMode::Immediate : ezGALPresentMode::VSync;
+    swapChainDesc.m_InitialPresentMode = (iIdentifier == SubTests::ST_VSync) ? ezGALPresentMode::VSync : ezGALPresentMode::Immediate;
     m_hSwapChain = ezGALWindowSwapChain::Create(swapChainDesc);
   }
 
@@ -65,8 +82,7 @@ ezResult ezRendererTestSwapChain::DeInitializeSubTest(ezInt32 iIdentifier)
 {
   DestroyWindow();
 
-  if (ezGraphicsTest::DeInitializeSubTest(iIdentifier).Failed())
-    return EZ_FAILURE;
+  // Don't call parent's DeInitializeSubTest - renderer shutdown happens in DeInitializeTest
 
   return EZ_SUCCESS;
 }

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.cpp
@@ -1,8 +1,8 @@
 #include <RendererTest/RendererTestPCH.h>
 
 #include <Core/Graphics/Camera.h>
-#include <RendererTest/Basics/SwapChain.h>
 #include <Foundation/Configuration/Startup.h>
+#include <RendererTest/Basics/SwapChain.h>
 
 ezResult ezRendererTestSwapChain::InitializeTest()
 {

--- a/Code/UnitTests/RendererTest/Basics/SwapChain.h
+++ b/Code/UnitTests/RendererTest/Basics/SwapChain.h
@@ -15,7 +15,7 @@ private:
     ST_D16,
     ST_D24S8,
     ST_D32,
-    ST_NoVSync,
+    ST_VSync,
     ST_ResizeWindow,
   };
 
@@ -25,10 +25,12 @@ private:
     AddSubTest("Depth D16", SubTests::ST_D16);
     AddSubTest("Depth D24S8", SubTests::ST_D24S8);
     AddSubTest("Depth D32", SubTests::ST_D32);
-    AddSubTest("No VSync", SubTests::ST_NoVSync);
+    AddSubTest("VSync", SubTests::ST_VSync);
     AddSubTest("Resize Window", SubTests::ST_ResizeWindow);
   }
 
+  virtual ezResult InitializeTest() override;
+  virtual ezResult DeInitializeTest() override;
   virtual ezResult InitializeSubTest(ezInt32 iIdentifier) override;
   virtual ezResult DeInitializeSubTest(ezInt32 iIdentifier) override;
 
@@ -48,7 +50,7 @@ private:
       case SubTests::ST_D16:
       case SubTests::ST_D24S8:
       case SubTests::ST_D32:
-      case SubTests::ST_NoVSync:
+      case SubTests::ST_VSync:
         return BasicRenderLoop(iIdentifier, uiInvocationCount);
       default:
         EZ_ASSERT_NOT_IMPLEMENTED;


### PR DESCRIPTION
* In some cases texture conversion was running on i-gpu instead of d-gpu. Both the DX11 renderer and the texture tool now try to use `EnumAdapterByGpuPreference ` if supported for device selection.
* Fixed some Vulkan validation issues.
* New CPU/GPU time calibration in Vulkan based on timeline semaphores if supported. The old code was not valid according to validation. Will fallback to less acurate version if timeline semaphores are not supported.
* Made various renderer tests faster by initializing the renderer and creating window at test level instead of sub-test.
* Windows now compiles and runs the Vulkan renderer tests as well.