### PR TITLE
Fix Editor Memory Leak

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <EditorFramework/EditorFrameworkDLL.h>
+#include <Foundation/Types/SharedPtr.h>
 #include <ToolsFoundation/FileSystem/FileSystemModel.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
-#include <Foundation/Types/SharedPtr.h>
 
 #include <QItemDelegate>
 #include <QTreeWidget>

--- a/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
+++ b/Code/Editor/EditorFramework/Assets/AssetBrowserFolderView.moc.h
@@ -3,6 +3,7 @@
 #include <EditorFramework/EditorFrameworkDLL.h>
 #include <ToolsFoundation/FileSystem/FileSystemModel.h>
 #include <ToolsFoundation/Project/ToolsProject.h>
+#include <Foundation/Types/SharedPtr.h>
 
 #include <QItemDelegate>
 #include <QTreeWidget>
@@ -90,16 +91,27 @@ private:
   void BuildDirectoryTree(const ezDataDirPath& path, ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem, bool bIsHidden);
   void RemoveDirectoryTreeItem(ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem);
   QTreeWidgetItem* FindDirectoryTreeItem(ezStringView sCurPath, QTreeWidgetItem* pParent, ezStringView sCurPathToItem);
-  void FileSystemModelFolderEventHandler(const ezFolderChangedEvent& e);
   void ProjectEventHandler(const ezToolsProjectEvent& e);
 
 private:
+  // Shared object as the event handler can be called after this object is destroyed due to the use of ezCopyOnBroadcastEvent in ezFileSystemModel.
+  // This is the only way to prevent race conditions and allow safe add/remove calls to multithreaded event broadcasters.
+  class QueuedFolderEvents : public ezRefCounted
+  {
+  public:
+    void FileSystemModelFolderEventHandler(const ezFolderChangedEvent& e);
+
+    ezMutex m_FolderStructureMutex;
+    eqQtAssetBrowserFolderView* m_pParent = nullptr;
+    ezHybridArray<ezFolderChangedEvent, 2> m_Events;
+  };
+
   bool m_bDialogMode = false;
   ezUInt32 m_uiKnownAssetFolderCount = 0;
   bool m_bTreeSelectionChangeInProgress = false;
 
   ezQtAssetBrowserFilter* m_pFilter = nullptr;
+  ezSharedPtr<QueuedFolderEvents> m_pFolderEvents;
 
-  ezMutex m_FolderStructureMutex;
-  ezHybridArray<ezFolderChangedEvent, 2> m_QueuedFolderEvents;
+  ezEventSubscriptionID m_FolderChangedSubscription = 0;
 };

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFolderView.cpp
@@ -81,7 +81,11 @@ eqQtAssetBrowserFolderView::eqQtAssetBrowserFolderView(QWidget* pParent)
   EZ_VERIFY(connect(pDelegate, &ezFolderNameDelegate::editingFinished, this, &eqQtAssetBrowserFolderView::OnFolderEditingFinished, Qt::QueuedConnection), "signal/slot connection failed");
   setItemDelegate(pDelegate);
 
-  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.AddEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::FileSystemModelFolderEventHandler, this));
+  m_pFolderEvents = EZ_DEFAULT_NEW(QueuedFolderEvents);
+  m_pFolderEvents->m_pParent = this;
+
+  m_FolderChangedSubscription = ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.AddEventHandler([pFolderEvents = m_pFolderEvents](const ezFolderChangedEvent& e)
+    { pFolderEvents->FileSystemModelFolderEventHandler(e); });
   ezToolsProject::s_Events.AddEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::ProjectEventHandler, this));
 
   EZ_VERIFY(connect(this, SIGNAL(itemSelectionChanged()), this, SLOT(OnItemSelectionChanged())) != nullptr, "signal/slot connection failed");
@@ -91,8 +95,11 @@ eqQtAssetBrowserFolderView::eqQtAssetBrowserFolderView(QWidget* pParent)
 
 eqQtAssetBrowserFolderView::~eqQtAssetBrowserFolderView()
 {
+  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.RemoveEventHandler(m_FolderChangedSubscription);
   ezToolsProject::s_Events.RemoveEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::ProjectEventHandler, this));
-  ezFileSystemModel::GetSingleton()->m_FolderChangedEvents.RemoveEventHandler(ezMakeDelegate(&eqQtAssetBrowserFolderView::FileSystemModelFolderEventHandler, this));
+
+  EZ_LOCK(m_pFolderEvents->m_FolderStructureMutex);
+  m_pFolderEvents->m_pParent = nullptr;
 }
 
 
@@ -194,12 +201,14 @@ void eqQtAssetBrowserFolderView::OnFolderEditingFinished(const QString& sAbsPath
   }
 }
 
-void eqQtAssetBrowserFolderView::FileSystemModelFolderEventHandler(const ezFolderChangedEvent& e)
+void eqQtAssetBrowserFolderView::QueuedFolderEvents::FileSystemModelFolderEventHandler(const ezFolderChangedEvent& e)
 {
   EZ_LOCK(m_FolderStructureMutex);
-  m_QueuedFolderEvents.PushBack(e);
+  if (m_pParent == nullptr)
+    return;
 
-  QTimer::singleShot(0, this, SLOT(OnFlushFileSystemEvents()));
+  m_Events.PushBack(e);
+  QMetaObject::invokeMethod(m_pParent, &eqQtAssetBrowserFolderView::OnFlushFileSystemEvents, Qt::QueuedConnection);
 }
 
 void eqQtAssetBrowserFolderView::ProjectEventHandler(const ezToolsProjectEvent& e)
@@ -407,9 +416,9 @@ void eqQtAssetBrowserFolderView::DeleteFolder()
 
 void eqQtAssetBrowserFolderView::OnFlushFileSystemEvents()
 {
-  EZ_LOCK(m_FolderStructureMutex);
+  EZ_LOCK(m_pFolderEvents->m_FolderStructureMutex);
 
-  for (const auto& e : m_QueuedFolderEvents)
+  for (const auto& e : m_pFolderEvents->m_Events)
   {
     switch (e.m_Type)
     {
@@ -434,7 +443,7 @@ void eqQtAssetBrowserFolderView::OnFlushFileSystemEvents()
     }
   }
 
-  m_QueuedFolderEvents.Clear();
+  m_pFolderEvents->m_Events.Clear();
 }
 
 void eqQtAssetBrowserFolderView::mouseDoubleClickEvent(QMouseEvent* e)


### PR DESCRIPTION
Fixes #1780.
This was a classical case of event broadcast after object destruction. The `ezFileSystemModel` events can still be in flight after the `eqQtAssetBrowserFolderView` dtor has run as the `ezFileSystemModel::m_FolderChangedEvents` is `ezCopyOnBroadcastEvent` to allow multi-threaded access. The easiest way to fix is to create a shared object between so that event callback owns the object as well as `eqQtAssetBrowserFolderView`.