### PR TITLE
Fixed DX11 texture update with render doc

### DIFF
--- a/Code/Engine/RendererCore/Meshes/Implementation/MeshRenderer.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/MeshRenderer.cpp
@@ -30,6 +30,7 @@ void ezMeshRenderer::GetSupportedRenderDataCategories(ezHybridArray<ezRenderData
   ref_categories.PushBack(ezDefaultRenderDataCategories::LitMasked);
   ref_categories.PushBack(ezDefaultRenderDataCategories::LitTransparent);
   ref_categories.PushBack(ezDefaultRenderDataCategories::LitForeground);
+  ref_categories.PushBack(ezDefaultRenderDataCategories::LitScreenFX);
   ref_categories.PushBack(ezDefaultRenderDataCategories::SimpleOpaque);
   ref_categories.PushBack(ezDefaultRenderDataCategories::SimpleTransparent);
   ref_categories.PushBack(ezDefaultRenderDataCategories::SimpleForeground);

--- a/Code/Engine/RendererDX11/Device/DeviceDX11.h
+++ b/Code/Engine/RendererDX11/Device/DeviceDX11.h
@@ -252,12 +252,14 @@ private:
   struct PendingCopy
   {
     TempResource m_SourceResource = {};
-    ezByteArrayPtr m_SourceData; // Used in case always mapped temp resources are not supported
+    ezGALSystemMemoryDescription m_SourceData; // Used in case always mapped temp resources are not supported
 
     ID3D11Resource* m_pDestResource = nullptr;
     ezUInt32 m_uiDestSubResource = 0;
     ezVec3U32 m_vDestPoint = ezVec3U32::MakeZero();
     ezVec3U32 m_vSourceSize = ezVec3U32::MakeZero();
+    bool m_bCopySubresource = false;
+    ezGALResourceFormat::Enum m_SourceFormat = ezGALResourceFormat::Invalid;
   };
 
   ezDynamicArray<PendingCopy, ezLocalAllocatorWrapper> m_PendingCopies;

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -1447,7 +1447,7 @@ void ezGALDeviceDX11::ProcessPendingCopies()
       else
       {
         tempResource = CopyToTempTexture(copy.m_SourceData, copy.m_vSourceSize.x, copy.m_vSourceSize.y, copy.m_vSourceSize.z, copy.m_SourceFormat, m_uiFrameCounter);
-      }      
+      }
     }
     UnmapTempResource(tempResource);
 

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -820,14 +820,14 @@ void ezGALDeviceDX11::UpdateBufferForNextFramePlatform(const ezGALBuffer* pBuffe
   }
   else
   {
-    copy.m_SourceData = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt8, sourceData.GetCount());
-    copy.m_SourceData.CopyFrom(sourceData);
+    auto sourceDataCopy = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt8, sourceData.GetCount());
+    ezMemoryUtils::Copy(sourceDataCopy.GetPtr(), sourceData.GetPtr(), sourceData.GetCount());
+    copy.m_SourceData.m_pData = sourceDataCopy;
   }
   copy.m_pDestResource = pBufferDX11->GetDXBuffer();
   copy.m_vDestPoint.Set(uiDestOffset, 0, 0);
-
-  const bool bWholeBuffer = uiDestOffset == 0 && copy.m_SourceResource.m_uiRowPitch == uiDestBufferSize;
-  copy.m_vSourceSize = ezVec3U32(bWholeBuffer ? ezInvalidIndex : sourceData.GetCount(), 1, 1);
+  copy.m_vSourceSize = ezVec3U32(sourceData.GetCount(), 1, 1);
+  copy.m_bCopySubresource = uiDestOffset != 0 || copy.m_SourceResource.m_uiRowPitch != uiDestBufferSize;
 }
 
 void ezGALDeviceDX11::UpdateTextureForNextFramePlatform(const ezGALTexture* pTexture, const ezGALSystemMemoryDescription& sourceData, const ezGALTextureSubresource& destinationSubResource, const ezBoundingBoxu32& destinationBox)
@@ -850,14 +850,26 @@ void ezGALDeviceDX11::UpdateTextureForNextFramePlatform(const ezGALTexture* pTex
   const ezUInt32 uiWidth = destinationBox.m_vMax.x - destinationBox.m_vMin.x;
   const ezUInt32 uiHeight = destinationBox.m_vMax.y - destinationBox.m_vMin.y;
   const ezUInt32 uiDepth = destinationBox.m_vMax.z - destinationBox.m_vMin.z;
-  bool bWholeTexture = destinationBox.m_vMin.IsZero() && destinationBox.m_vMax == ezVec3U32(desc.m_uiWidth, desc.m_uiHeight, desc.m_uiDepth);
 
   auto& copy = m_PendingCopies.ExpandAndGetRef();
-  copy.m_SourceResource = CopyToTempTexture(sourceData, uiWidth, uiHeight, uiDepth, desc.m_Format, m_uiFrameCounter + 1);
+  if (m_bSupportsAlwaysMappedTempResources)
+  {
+    copy.m_SourceResource = CopyToTempTexture(sourceData, uiWidth, uiHeight, uiDepth, desc.m_Format, m_uiFrameCounter + 1);
+  }
+  else
+  {
+    auto sourceDataCopy = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt8, sourceData.m_pData.GetCount());
+    ezMemoryUtils::Copy(sourceDataCopy.GetPtr(), sourceData.m_pData.GetPtr(), sourceData.m_pData.GetCount());
+    copy.m_SourceData.m_pData = sourceDataCopy;
+    copy.m_SourceData.m_uiRowPitch = sourceData.m_uiRowPitch;
+    copy.m_SourceData.m_uiSlicePitch = sourceData.m_uiSlicePitch;
+    copy.m_SourceFormat = desc.m_Format;
+  }
   copy.m_pDestResource = pTextureDX11->GetDXTexture();
   copy.m_uiDestSubResource = D3D11CalcSubresource(destinationSubResource.m_uiMipLevel, destinationSubResource.m_uiArraySlice, desc.m_uiMipLevelCount);
   copy.m_vDestPoint = destinationBox.m_vMin;
-  copy.m_vSourceSize = bWholeTexture ? ezVec3U32(ezInvalidIndex) : ezVec3U32(uiWidth, uiHeight, uiDepth);
+  copy.m_vSourceSize = ezVec3U32(uiWidth, uiHeight, uiDepth);
+  copy.m_bCopySubresource = !destinationBox.m_vMin.IsZero() || destinationBox.m_vMax != ezVec3U32(desc.m_uiWidth, desc.m_uiHeight, desc.m_uiDepth);
 }
 
 ezEnum<ezGALAsyncResult> ezGALDeviceDX11::GetTimestampResultPlatform(ezGALTimestampHandle hTimestamp, ezTime& out_result)
@@ -1428,18 +1440,25 @@ void ezGALDeviceDX11::ProcessPendingCopies()
 
     if (!m_bSupportsAlwaysMappedTempResources)
     {
-      tempResource = CopyToTempBuffer(copy.m_SourceData, m_uiFrameCounter);
+      if (copy.m_SourceData.m_uiRowPitch == 0)
+      {
+        tempResource = CopyToTempBuffer(ezMakeArrayPtr(copy.m_SourceData.m_pData.GetPtr(), copy.m_SourceData.m_pData.GetCount()), m_uiFrameCounter);
+      }
+      else
+      {
+        tempResource = CopyToTempTexture(copy.m_SourceData, copy.m_vSourceSize.x, copy.m_vSourceSize.y, copy.m_vSourceSize.z, copy.m_SourceFormat, m_uiFrameCounter);
+      }      
     }
     UnmapTempResource(tempResource);
 
-    if (copy.m_vSourceSize.x == ezInvalidIndex)
-    {
-      m_pImmediateContext->CopyResource(copy.m_pDestResource, tempResource.m_pResource);
-    }
-    else
+    if (copy.m_bCopySubresource)
     {
       D3D11_BOX srcBox = {0, 0, 0, copy.m_vSourceSize.x, copy.m_vSourceSize.y, copy.m_vSourceSize.z};
       m_pImmediateContext->CopySubresourceRegion(copy.m_pDestResource, copy.m_uiDestSubResource, copy.m_vDestPoint.x, copy.m_vDestPoint.y, copy.m_vDestPoint.z, tempResource.m_pResource, 0, &srcBox);
+    }
+    else
+    {
+      m_pImmediateContext->CopyResource(copy.m_pDestResource, tempResource.m_pResource);
     }
   }
   m_PendingCopies.Clear();

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -858,8 +858,10 @@ void ezGALDeviceDX11::UpdateTextureForNextFramePlatform(const ezGALTexture* pTex
   }
   else
   {
-    auto sourceDataCopy = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt8, sourceData.m_pData.GetCount());
-    ezMemoryUtils::Copy(sourceDataCopy.GetPtr(), sourceData.m_pData.GetPtr(), sourceData.m_pData.GetCount());
+    const ezUInt32 uiSourceDataCount = static_cast<ezUInt32>(sourceData.m_pData.GetCount());
+
+    auto sourceDataCopy = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ezUInt8, uiSourceDataCount);
+    ezMemoryUtils::Copy(sourceDataCopy.GetPtr(), sourceData.m_pData.GetPtr(), uiSourceDataCount);
     copy.m_SourceData.m_pData = sourceDataCopy;
     copy.m_SourceData.m_uiRowPitch = sourceData.m_uiRowPitch;
     copy.m_SourceData.m_uiSlicePitch = sourceData.m_uiSlicePitch;
@@ -1442,7 +1444,7 @@ void ezGALDeviceDX11::ProcessPendingCopies()
     {
       if (copy.m_SourceData.m_uiRowPitch == 0)
       {
-        tempResource = CopyToTempBuffer(ezMakeArrayPtr(copy.m_SourceData.m_pData.GetPtr(), copy.m_SourceData.m_pData.GetCount()), m_uiFrameCounter);
+        tempResource = CopyToTempBuffer(ezMakeArrayPtr(copy.m_SourceData.m_pData.GetPtr(), static_cast<ezUInt32>(copy.m_SourceData.m_pData.GetCount())), m_uiFrameCounter);
       }
       else
       {


### PR DESCRIPTION
Renderdoc does not like the way we handle staging resources in DX11 to keep the number of data copies at a minimum. Therefore we use an alternative path when render doc is active which involves more data copies. This path was only implemented for buffers but not for textures.