### PR TITLE
Fixed Visual Shader usability issue when disconnecting parameters

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -347,6 +347,9 @@ void ezShaderTypeRegistry::UpdateShaderType(ShaderData& data)
     GetEnumType(enumDef);
   }
 
+  parameters.Sort([](const ezShaderParser::ParameterDefinition& lhs, const ezShaderParser::ParameterDefinition& rhs)
+    { return lhs.m_sName.Compare_NoCase(rhs.m_sName) < 0; });
+
   for (auto& parameter : parameters)
   {
     const ezRTTI* pType = GetType(parameter);

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
@@ -600,6 +600,8 @@ void ezVisualShaderTypeRegistry::ExtractNodeConfig(const ezOpenDdlReaderElement*
           nd.m_NodeType = ezVisualShaderNodeType::Texture;
         else if (pElement->GetPrimitivesString()[0] == "ShaderState")
           nd.m_NodeType = ezVisualShaderNodeType::ShaderState;
+        else if (pElement->GetPrimitivesString()[0] == "Parameter")
+          nd.m_NodeType = ezVisualShaderNodeType::Parameter;
         else
           nd.m_NodeType = ezVisualShaderNodeType::Generic;
       }

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
@@ -30,7 +30,8 @@ struct ezVisualShaderNodeType
     Generic,
     Main,
     Texture,
-    ShaderState,
+    ShaderState, ///< These have no connections, but must be part of the shader
+    Parameter,   ///< Will be added to the shader, even if there's no connection, to prevent that data is lost while editing
 
     Default = Generic
   };

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
@@ -121,10 +121,6 @@ ezStatus ezVisualShaderCodeGenerator::GatherAllNodes(const ezDocumentObject* pRo
 
       m_pMainNode = pRootObj;
     }
-    else if (pDesc->m_NodeType == ezVisualShaderNodeType::ShaderState)
-    {
-      m_StateNodes.PushBack(pRootObj);
-    }
   }
 
   const auto& children = pRootObj->GetChildren();
@@ -169,9 +165,22 @@ ezStatus ezVisualShaderCodeGenerator::GenerateVisualShader(const ezDocumentNodeM
 
   EZ_SUCCEED_OR_RETURN(GenerateNode(m_pMainNode));
 
-  for (auto pStateNode : m_StateNodes)
+  // now also generate code for certain nodes, even if they have no connections
+  // ShaderState nodes generally have no connections
+  // Parameter and Texture nodes are user inputs, if we don't output them, the UI won't show them
+  // and previously selected values get lost. That's very undesirable, so we always add them to the shader,
+  // even if they are currently not used.
+  for (auto itNode : m_Nodes)
   {
-    EZ_SUCCEED_OR_RETURN(GenerateNode(pStateNode));
+    if (itNode.Value().m_bCodeGenerated)
+      continue;
+
+    auto pDesc = m_pTypeRegistry->GetDescriptorForType(itNode.Key()->GetType());
+
+    if (pDesc->m_NodeType == ezVisualShaderNodeType::ShaderState || pDesc->m_NodeType == ezVisualShaderNodeType::Parameter || pDesc->m_NodeType == ezVisualShaderNodeType::Texture)
+    {
+      EZ_SUCCEED_OR_RETURN(GenerateNode(itNode.Key()));
+    }
   }
 
   ezStringBuilder sMaterialConstants = m_sShaderMaterialConstants;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
@@ -53,7 +53,6 @@ private:
   static void AppendStringIfUnique(ezStringBuilder& inout_String, const char* szAppend);
 
   const ezDocumentObject* m_pMainNode;
-  ezHybridArray<const ezDocumentObject*, 4> m_StateNodes;
   const ezVisualShaderTypeRegistry* m_pTypeRegistry;
   const ezDocumentNodeManager* m_pNodeManager;
   const ezRTTI* m_pNodeBaseRtti;

--- a/Data/Tools/ezEditor/VisualShader/Parameters.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Parameters.ddl
@@ -1,5 +1,6 @@
 Node %Parameter1f
 {
+  string %NodeType { "Parameter" }
   string %Category { "Parameters" }
   string %Color { "Red" }
   string %Docs { "Outputs a 1-component value that can be configured on the material." }
@@ -23,6 +24,7 @@ Node %Parameter1f
 
 Node %Parameter2f
 {
+  string %NodeType { "Parameter" }
   string %Category { "Parameters" }
   string %Color { "Red" }
   string %Docs { "Outputs a 2-component value that can be configured on the material." }
@@ -46,6 +48,7 @@ Node %Parameter2f
 
 Node %Parameter3f
 {
+  string %NodeType { "Parameter" }
   string %Category { "Parameters" }
   string %Color { "Red" }
   string %Docs { "Outputs a 3-component value that can be configured on the material." }
@@ -69,6 +72,7 @@ Node %Parameter3f
 
 Node %Parameter4f
 {
+  string %NodeType { "Parameter" }
   string %Category { "Parameters" }
   string %Color { "Red" }
   string %Docs { "Outputs a 4-component value that can be configured on the material." }
@@ -93,6 +97,7 @@ Node %Parameter4f
 
 Node %ParameterColor
 {
+  string %NodeType { "Parameter" }
   string %Category { "Parameters" }
   string %Color { "Red" }
   string %Docs { "Outputs a color value that can be configured on the material." }


### PR DESCRIPTION
The VSE does not include unreachable nodes in the generated shader. For the general code generation that's the right thing, but for user inputs (parameters, textures), that meant that the UI lost track of those variables and thus if a user had chosen a value before, that value then got lost. So now all parameters and textures are included in the shader, even if they are not used. This way the UI stays stable and values that were selected once, don't get lost. Also, parameters are now sorted alphabetically and don't depend on their order in the shader, anymore.