### PR TITLE
ezSimdVec4d NEON Implementation

### DIFF
--- a/Code/Engine/Foundation/SimdMath/Implementation/FPU/FPUVec4d_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/FPU/FPUVec4d_inl.h
@@ -50,7 +50,7 @@ EZ_ALWAYS_INLINE void ezSimdVec4d::Set(float x, float y, float z, float w)
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::Set(double x, double y, double z, double w)
 {
-  m_v.Set(float(x), float(y), float(z), float(w));
+  m_v.Set(x, y, z, w);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::Set(int x, int y, int z, int w)
@@ -99,6 +99,25 @@ EZ_ALWAYS_INLINE void ezSimdVec4d::Store(double* pDoubles) const
   for (int i = 0; i < N; ++i)
   {
     pDoubles[i] = (&m_v.x)[i];
+  }
+}
+
+template <int N>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load(const float* pFloats)
+{
+  m_v.SetZero();
+  for (int i = 0; i < N; ++i)
+  {
+    (&m_v.x)[i] = static_cast<double>(pFloats[i]);
+  }
+}
+
+template <int N>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store(float* pFloats) const
+{
+  for (int i = 0; i < N; ++i)
+  {
+    pFloats[i] = static_cast<float>((&m_v.x)[i]);
   }
 }
 
@@ -552,10 +571,11 @@ EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::MulSub(const ezSimdVec4d& a, const ezS
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CopySign(const ezSimdVec4d& magnitude, const ezSimdVec4d& sign)
 {
   ezSimdVec4d result;
-  result.m_v.x = sign.m_v.x < 0.0 ? -magnitude.m_v.x : magnitude.m_v.x;
-  result.m_v.y = sign.m_v.y < 0.0 ? -magnitude.m_v.y : magnitude.m_v.y;
-  result.m_v.z = sign.m_v.z < 0.0 ? -magnitude.m_v.z : magnitude.m_v.z;
-  result.m_v.w = sign.m_v.w < 0.0 ? -magnitude.m_v.w : magnitude.m_v.w;
+  // Use std::copysign to properly handle -0.0
+  result.m_v.x = std::copysign(magnitude.m_v.x, sign.m_v.x);
+  result.m_v.y = std::copysign(magnitude.m_v.y, sign.m_v.y);
+  result.m_v.z = std::copysign(magnitude.m_v.z, sign.m_v.z);
+  result.m_v.w = std::copysign(magnitude.m_v.w, sign.m_v.w);
 
   return result;
 }

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONDouble_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONDouble_inl.h
@@ -1,37 +1,64 @@
 #pragma once
 
-EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble() {}
+EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble()
+{
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+#if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
+  // Initialize all data to NaN in debug mode to find problems with uninitialized data easier.
+  m_v.xy = vdupq_n_f64(ezMath::NaN<double>());
+  m_v.zw = m_v.xy;
+#endif
+}
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(float f)
 {
-  m_v.Set((double)f);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(static_cast<double>(f));
+  m_v.zw = m_v.xy;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(double f)
 {
-  m_v.Set(f);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(f);
+  m_v.zw = m_v.xy;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(ezInt32 i)
 {
-  m_v.Set((double)i);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(static_cast<double>(i));
+  m_v.zw = m_v.xy;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(ezUInt32 i)
 {
-  m_v.Set((double)i);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(static_cast<double>(i));
+  m_v.zw = m_v.xy;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(ezAngle a)
 {
-  m_v.Set(a.GetRadian());
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(a.GetRadian());
+  m_v.zw = m_v.xy;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(ezInternal::QuadFloat v)
 {
-  float x;
-  vst1q_lane_f32(&x, v, 0);
-  m_v.Set(x);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  // Convert first float to double and broadcast
+  float x = vgetq_lane_f32(v, 0);
+  m_v.xy = vdupq_n_f64(static_cast<double>(x));
+  m_v.zw = m_v.xy;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(ezInternal::QuadDouble v)
@@ -41,186 +68,229 @@ EZ_ALWAYS_INLINE ezSimdDouble::ezSimdDouble(ezInternal::QuadDouble v)
 
 EZ_ALWAYS_INLINE ezSimdDouble::operator double() const
 {
-  return m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0);
 }
 
 // static
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::MakeZero()
 {
-  return ezSimdDouble(0.0);
+  ezSimdDouble result;
+  result.m_v.xy = vdupq_n_f64(0.0);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 // static
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::MakeNaN()
 {
-  return ezSimdDouble(ezMath::NaN<double>());
+  ezSimdDouble result;
+  result.m_v.xy = vdupq_n_f64(ezMath::NaN<double>());
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::operator+(const ezSimdDouble& f) const
 {
-  return m_v + f.m_v;
+  ezSimdDouble result;
+  result.m_v.xy = vaddq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::operator-(const ezSimdDouble& f) const
 {
-  return m_v - f.m_v;
+  ezSimdDouble result;
+  result.m_v.xy = vsubq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::operator*(const ezSimdDouble& f) const
 {
-  return m_v.CompMul(f.m_v);
+  ezSimdDouble result;
+  result.m_v.xy = vmulq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::operator/(const ezSimdDouble& f) const
 {
-  return m_v.CompDiv(f.m_v);
+  ezSimdDouble result;
+  result.m_v.xy = vdivq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble& ezSimdDouble::operator+=(const ezSimdDouble& f)
 {
-  m_v += f.m_v;
+  m_v.xy = vaddq_f64(m_v.xy, f.m_v.xy);
+  m_v.zw = m_v.xy;
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble& ezSimdDouble::operator-=(const ezSimdDouble& f)
 {
-  m_v -= f.m_v;
+  m_v.xy = vsubq_f64(m_v.xy, f.m_v.xy);
+  m_v.zw = m_v.xy;
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble& ezSimdDouble::operator*=(const ezSimdDouble& f)
 {
-  m_v = m_v.CompMul(f.m_v);
+  m_v.xy = vmulq_f64(m_v.xy, f.m_v.xy);
+  m_v.zw = m_v.xy;
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble& ezSimdDouble::operator/=(const ezSimdDouble& f)
 {
-  m_v = m_v.CompDiv(f.m_v);
+  m_v.xy = vdivq_f64(m_v.xy, f.m_v.xy);
+  m_v.zw = m_v.xy;
   return *this;
 }
 
-EZ_ALWAYS_INLINE bool ezSimdDouble::IsEqual(const ezSimdDouble& rhs, const ezSimdDouble& dEpsilon) const
+EZ_ALWAYS_INLINE bool ezSimdDouble::IsEqual(const ezSimdDouble& rhs, const ezSimdDouble& fEpsilon) const
 {
-  return m_v.IsEqual(rhs.m_v, dEpsilon);
+  // Match SSE implementation: (this >= rhs - eps) && (this <= rhs + eps)
+  ezSimdDouble minusEps = rhs - fEpsilon;
+  ezSimdDouble plusEps = rhs + fEpsilon;
+  return ((*this >= minusEps) && (*this <= plusEps));
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator==(const ezSimdDouble& f) const
 {
-  return m_v.x == f.m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0) == vgetq_lane_f64(f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator!=(const ezSimdDouble& f) const
 {
-  return m_v.x != f.m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0) != vgetq_lane_f64(f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator>=(const ezSimdDouble& f) const
 {
-  return m_v.x >= f.m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0) >= vgetq_lane_f64(f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator>(const ezSimdDouble& f) const
 {
-  return m_v.x > f.m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0) > vgetq_lane_f64(f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator<=(const ezSimdDouble& f) const
 {
-  return m_v.x <= f.m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0) <= vgetq_lane_f64(f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator<(const ezSimdDouble& f) const
 {
-  return m_v.x < f.m_v.x;
+  return vgetq_lane_f64(m_v.xy, 0) < vgetq_lane_f64(f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator==(double f) const
 {
-  return m_v.x == f;
+  return vgetq_lane_f64(m_v.xy, 0) == f;
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator!=(double f) const
 {
-  return m_v.x != f;
+  return vgetq_lane_f64(m_v.xy, 0) != f;
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator>(double f) const
 {
-  return m_v.x > f;
+  return vgetq_lane_f64(m_v.xy, 0) > f;
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator>=(double f) const
 {
-  return m_v.x >= f;
+  return vgetq_lane_f64(m_v.xy, 0) >= f;
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator<(double f) const
 {
-  return m_v.x < f;
+  return vgetq_lane_f64(m_v.xy, 0) < f;
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator<=(double f) const
 {
-  return m_v.x <= f;
+  return vgetq_lane_f64(m_v.xy, 0) <= f;
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator==(float f) const
 {
-  return m_v.x == (double)f;
+  return vgetq_lane_f64(m_v.xy, 0) == static_cast<double>(f);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator!=(float f) const
 {
-  return m_v.x != (double)f;
+  return vgetq_lane_f64(m_v.xy, 0) != static_cast<double>(f);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator>(float f) const
 {
-  return m_v.x > (double)f;
+  return vgetq_lane_f64(m_v.xy, 0) > static_cast<double>(f);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator>=(float f) const
 {
-  return m_v.x >= (double)f;
+  return vgetq_lane_f64(m_v.xy, 0) >= static_cast<double>(f);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator<(float f) const
 {
-  return m_v.x < (double)f;
+  return vgetq_lane_f64(m_v.xy, 0) < static_cast<double>(f);
 }
 
 EZ_ALWAYS_INLINE bool ezSimdDouble::operator<=(float f) const
 {
-  return m_v.x <= (double)f;
+  return vgetq_lane_f64(m_v.xy, 0) <= static_cast<double>(f);
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::GetReciprocal() const
 {
-  return ezSimdDouble(1.0 / m_v.x);
+  ezSimdDouble result;
+  result.m_v.xy = vdivq_f64(vdupq_n_f64(1.0), m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::GetSqrt() const
 {
-  return ezSimdDouble(ezMath::Sqrt(m_v.x));
+  ezSimdDouble result;
+  result.m_v.xy = vsqrtq_f64(m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::GetInvSqrt() const
 {
-  return ezSimdDouble(1.0 / ezMath::Sqrt(m_v.x));
+  ezSimdDouble result;
+  result.m_v.xy = vdivq_f64(vdupq_n_f64(1.0), vsqrtq_f64(m_v.xy));
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::Max(const ezSimdDouble& f) const
 {
-  return m_v.CompMax(f.m_v);
+  ezSimdDouble result;
+  result.m_v.xy = vmaxq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::Min(const ezSimdDouble& f) const
 {
-  return m_v.CompMin(f.m_v);
+  ezSimdDouble result;
+  result.m_v.xy = vminq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdDouble::Abs() const
 {
-  return ezSimdDouble(ezMath::Abs(m_v.x));
+  ezSimdDouble result;
+  result.m_v.xy = vabsq_f64(m_v.xy);
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONMat4d_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONMat4d_inl.h
@@ -21,17 +21,17 @@ EZ_ALWAYS_INLINE void ezSimdMat4d::Transpose()
   // [z0 w0]   [z1 w1] --> [z0 z1]   [w0 w1]
   // [x2 y2]   [x3 y3]     [x2 x3]   [y2 y3]
   // [z2 w2]   [z3 w3]     [z2 z3]   [w2 w3]
-  
+
   // vtrn/vzip for 2-element pairs
-  float64x2_t x0x1 = vzip1q_f64(c0xy, c1xy);  // [x0, x1]
-  float64x2_t y0y1 = vzip2q_f64(c0xy, c1xy);  // [y0, y1]
-  float64x2_t z0z1 = vzip1q_f64(c0zw, c1zw);  // [z0, z1]
-  float64x2_t w0w1 = vzip2q_f64(c0zw, c1zw);  // [w0, w1]
-  
-  float64x2_t x2x3 = vzip1q_f64(c2xy, c3xy);  // [x2, x3]
-  float64x2_t y2y3 = vzip2q_f64(c2xy, c3xy);  // [y2, y3]
-  float64x2_t z2z3 = vzip1q_f64(c2zw, c3zw);  // [z2, z3]
-  float64x2_t w2w3 = vzip2q_f64(c2zw, c3zw);  // [w2, w3]
+  float64x2_t x0x1 = vzip1q_f64(c0xy, c1xy); // [x0, x1]
+  float64x2_t y0y1 = vzip2q_f64(c0xy, c1xy); // [y0, y1]
+  float64x2_t z0z1 = vzip1q_f64(c0zw, c1zw); // [z0, z1]
+  float64x2_t w0w1 = vzip2q_f64(c0zw, c1zw); // [w0, w1]
+
+  float64x2_t x2x3 = vzip1q_f64(c2xy, c3xy); // [x2, x3]
+  float64x2_t y2y3 = vzip2q_f64(c2xy, c3xy); // [y2, y3]
+  float64x2_t z2z3 = vzip1q_f64(c2zw, c3zw); // [z2, z3]
+  float64x2_t w2w3 = vzip2q_f64(c2zw, c3zw); // [w2, w3]
 
   // Assign result
   m_col0.m_v.xy = x0x1;

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONMat4d_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONMat4d_inl.h
@@ -2,10 +2,44 @@
 
 EZ_ALWAYS_INLINE void ezSimdMat4d::Transpose()
 {
-  ezMath::Swap(m_col0.m_v.y, m_col1.m_v.x);
-  ezMath::Swap(m_col0.m_v.z, m_col2.m_v.x);
-  ezMath::Swap(m_col0.m_v.w, m_col3.m_v.x);
-  ezMath::Swap(m_col1.m_v.z, m_col2.m_v.y);
-  ezMath::Swap(m_col1.m_v.w, m_col3.m_v.y);
-  ezMath::Swap(m_col2.m_v.w, m_col3.m_v.z);
+  // Transpose a 4x4 double matrix stored in four float64x2_t pairs
+  // Input: col0 = (x0, y0, z0, w0), col1 = (x1, y1, z1, w1), etc.
+  // Output: col0 = (x0, x1, x2, x3), col1 = (y0, y1, y2, y3), etc.
+
+  // Extract all xy and zw halves
+  float64x2_t c0xy = m_col0.m_v.xy;
+  float64x2_t c0zw = m_col0.m_v.zw;
+  float64x2_t c1xy = m_col1.m_v.xy;
+  float64x2_t c1zw = m_col1.m_v.zw;
+  float64x2_t c2xy = m_col2.m_v.xy;
+  float64x2_t c2zw = m_col2.m_v.zw;
+  float64x2_t c3xy = m_col3.m_v.xy;
+  float64x2_t c3zw = m_col3.m_v.zw;
+
+  // Transpose 2x2 blocks
+  // [x0 y0]   [x1 y1]     [x0 x1]   [y0 y1]
+  // [z0 w0]   [z1 w1] --> [z0 z1]   [w0 w1]
+  // [x2 y2]   [x3 y3]     [x2 x3]   [y2 y3]
+  // [z2 w2]   [z3 w3]     [z2 z3]   [w2 w3]
+  
+  // vtrn/vzip for 2-element pairs
+  float64x2_t x0x1 = vzip1q_f64(c0xy, c1xy);  // [x0, x1]
+  float64x2_t y0y1 = vzip2q_f64(c0xy, c1xy);  // [y0, y1]
+  float64x2_t z0z1 = vzip1q_f64(c0zw, c1zw);  // [z0, z1]
+  float64x2_t w0w1 = vzip2q_f64(c0zw, c1zw);  // [w0, w1]
+  
+  float64x2_t x2x3 = vzip1q_f64(c2xy, c3xy);  // [x2, x3]
+  float64x2_t y2y3 = vzip2q_f64(c2xy, c3xy);  // [y2, y3]
+  float64x2_t z2z3 = vzip1q_f64(c2zw, c3zw);  // [z2, z3]
+  float64x2_t w2w3 = vzip2q_f64(c2zw, c3zw);  // [w2, w3]
+
+  // Assign result
+  m_col0.m_v.xy = x0x1;
+  m_col0.m_v.zw = x2x3;
+  m_col1.m_v.xy = y0y1;
+  m_col1.m_v.zw = y2y3;
+  m_col2.m_v.xy = z0z1;
+  m_col2.m_v.zw = z2z3;
+  m_col3.m_v.xy = w0w1;
+  m_col3.m_v.zw = w2w3;
 }

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONTypes_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONTypes_inl.h
@@ -12,7 +12,12 @@
 
 namespace ezInternal
 {
-  using QuadDouble = ezVec4d;
+  struct QuadDouble
+  {
+    float64x2_t xy;
+    float64x2_t zw;
+  };
+
   using QuadFloat = float32x4_t;
   using QuadBool = uint32x4_t;
   

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONVec4d_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONVec4d_inl.h
@@ -1,134 +1,263 @@
 #pragma once
 
-EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d() = default;
-
-EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(double xyzw)
+EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d()
 {
-  m_v.Set(xyzw);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+#if EZ_ENABLED(EZ_MATH_CHECK_FOR_NAN)
+  // Initialize all data to NaN in debug mode to find problems with uninitialized data easier.
+  m_v.xy = vdupq_n_f64(ezMath::NaN<double>());
+  m_v.zw = m_v.xy;
+#endif
 }
 
-EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(float xyzw)
+EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(double fXyzw)
 {
-  m_v.Set(double(xyzw));
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(fXyzw);
+  m_v.zw = m_v.xy;
 }
 
-EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(const ezSimdDouble& xyzw)
+EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(float fXyzw)
 {
-  m_v = xyzw.m_v;
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v.xy = vdupq_n_f64(static_cast<double>(fXyzw));
+  m_v.zw = m_v.xy;
+}
+
+EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(const ezSimdDouble& fXyzw)
+{
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  m_v = fXyzw.m_v;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(float x, float y, float z, float w)
 {
-  m_v.Set(x, y, z, w);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  alignas(16) double vals[4] = {static_cast<double>(x), static_cast<double>(y), static_cast<double>(z), static_cast<double>(w)};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(double x, double y, double z, double w)
 {
-  m_v.Set(x, y, z, w);
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  alignas(16) double vals[4] = {x, y, z, w};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d::ezSimdVec4d(int x, int y, int z, int w)
 {
-  m_v.Set(double(x), double(y), double(z), double(w));
+  EZ_CHECK_SIMD_ALIGNMENT(this);
+
+  alignas(16) double vals[4] = {static_cast<double>(x), static_cast<double>(y), static_cast<double>(z), static_cast<double>(w)};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
 }
 
-EZ_ALWAYS_INLINE void ezSimdVec4d::Set(double xyzw)
+EZ_ALWAYS_INLINE void ezSimdVec4d::Set(double fXyzw)
 {
-  m_v.Set(xyzw);
+  m_v.xy = vdupq_n_f64(fXyzw);
+  m_v.zw = m_v.xy;
 }
 
-EZ_ALWAYS_INLINE void ezSimdVec4d::Set(float xyzw)
+EZ_ALWAYS_INLINE void ezSimdVec4d::Set(float fXyzw)
 {
-  m_v.Set(double(xyzw));
+  m_v.xy = vdupq_n_f64(static_cast<double>(fXyzw));
+  m_v.zw = m_v.xy;
 }
-
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::Set(float x, float y, float z, float w)
 {
-  m_v.Set(x, y, z, w);
+  alignas(16) double vals[4] = {static_cast<double>(x), static_cast<double>(y), static_cast<double>(z), static_cast<double>(w)};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::Set(double x, double y, double z, double w)
 {
-  m_v.Set(float(x), float(y), float(z), float(w));
+  alignas(16) double vals[4] = {x, y, z, w};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::Set(int x, int y, int z, int w)
 {
-  m_v.Set(double(x), double(y), double(z), double(w));
+  alignas(16) double vals[4] = {static_cast<double>(x), static_cast<double>(y), static_cast<double>(z), static_cast<double>(w)};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::SetX(const ezSimdDouble& f)
 {
-  m_v.x = f.m_v.x;
+  m_v.xy = vcopyq_laneq_f64(m_v.xy, 0, f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::SetY(const ezSimdDouble& f)
 {
-  m_v.y = f.m_v.x;
+  m_v.xy = vcopyq_laneq_f64(m_v.xy, 1, f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::SetZ(const ezSimdDouble& f)
 {
-  m_v.z = f.m_v.x;
+  m_v.zw = vcopyq_laneq_f64(m_v.zw, 0, f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::SetW(const ezSimdDouble& f)
 {
-  m_v.w = f.m_v.x;
+  m_v.zw = vcopyq_laneq_f64(m_v.zw, 1, f.m_v.xy, 0);
 }
 
 EZ_ALWAYS_INLINE void ezSimdVec4d::SetZero()
 {
-  m_v.SetZero();
+  m_v.xy = vdupq_n_f64(0.0);
+  m_v.zw = m_v.xy;
 }
 
-template <int N>
-EZ_ALWAYS_INLINE void ezSimdVec4d::Load(const double* pDoubles)
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<1>(const double* pDoubles)
 {
-  m_v.SetZero();
-  for (int i = 0; i < N; ++i)
-  {
-    (&m_v.x)[i] = pDoubles[i];
-  }
+  m_v.xy = vld1q_lane_f64(pDoubles, vdupq_n_f64(0.0), 0);
+  m_v.zw = vdupq_n_f64(0.0);
 }
 
-template <int N>
-EZ_ALWAYS_INLINE void ezSimdVec4d::Store(double* pDoubles) const
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<2>(const double* pDoubles)
 {
-  for (int i = 0; i < N; ++i)
-  {
-    pDoubles[i] = (&m_v.x)[i];
-  }
+  m_v.xy = vld1q_f64(pDoubles);
+  m_v.zw = vdupq_n_f64(0.0);
 }
 
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<3>(const double* pDoubles)
+{
+  m_v.xy = vld1q_f64(pDoubles);
+  m_v.zw = vld1q_lane_f64(pDoubles + 2, vdupq_n_f64(0.0), 0);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<4>(const double* pDoubles)
+{
+  m_v.xy = vld1q_f64(pDoubles);
+  m_v.zw = vld1q_f64(pDoubles + 2);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<1>(const float* pFloats)
+{
+  m_v.xy = vsetq_lane_f64(static_cast<double>(pFloats[0]), vdupq_n_f64(0.0), 0);
+  m_v.zw = vdupq_n_f64(0.0);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<2>(const float* pFloats)
+{
+  alignas(16) double vals[2] = {static_cast<double>(pFloats[0]), static_cast<double>(pFloats[1])};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vdupq_n_f64(0.0);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<3>(const float* pFloats)
+{
+  alignas(16) double vals[4] = {static_cast<double>(pFloats[0]), static_cast<double>(pFloats[1]), static_cast<double>(pFloats[2]), 0.0};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Load<4>(const float* pFloats)
+{
+  alignas(16) double vals[4] = {static_cast<double>(pFloats[0]), static_cast<double>(pFloats[1]), static_cast<double>(pFloats[2]), static_cast<double>(pFloats[3])};
+  m_v.xy = vld1q_f64(vals);
+  m_v.zw = vld1q_f64(vals + 2);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<1>(double* pDoubles) const
+{
+  vst1q_lane_f64(pDoubles, m_v.xy, 0);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<2>(double* pDoubles) const
+{
+  vst1q_f64(pDoubles, m_v.xy);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<3>(double* pDoubles) const
+{
+  vst1q_f64(pDoubles, m_v.xy);
+  vst1q_lane_f64(pDoubles + 2, m_v.zw, 0);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<4>(double* pDoubles) const
+{
+  vst1q_f64(pDoubles, m_v.xy);
+  vst1q_f64(pDoubles + 2, m_v.zw);
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<1>(float* pFloats) const
+{
+  pFloats[0] = static_cast<float>(vgetq_lane_f64(m_v.xy, 0));
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<2>(float* pFloats) const
+{
+  pFloats[0] = static_cast<float>(vgetq_lane_f64(m_v.xy, 0));
+  pFloats[1] = static_cast<float>(vgetq_lane_f64(m_v.xy, 1));
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<3>(float* pFloats) const
+{
+  pFloats[0] = static_cast<float>(vgetq_lane_f64(m_v.xy, 0));
+  pFloats[1] = static_cast<float>(vgetq_lane_f64(m_v.xy, 1));
+  pFloats[2] = static_cast<float>(vgetq_lane_f64(m_v.zw, 0));
+}
+
+template <>
+EZ_ALWAYS_INLINE void ezSimdVec4d::Store<4>(float* pFloats) const
+{
+  pFloats[0] = static_cast<float>(vgetq_lane_f64(m_v.xy, 0));
+  pFloats[1] = static_cast<float>(vgetq_lane_f64(m_v.xy, 1));
+  pFloats[2] = static_cast<float>(vgetq_lane_f64(m_v.zw, 0));
+  pFloats[3] = static_cast<float>(vgetq_lane_f64(m_v.zw, 1));
+}
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::GetReciprocal() const
 {
-  return ezVec4d(1.0).CompDiv(m_v);
+  ezSimdVec4d result;
+  float64x2_t one = vdupq_n_f64(1.0);
+  result.m_v.xy = vdivq_f64(one, m_v.xy);
+  result.m_v.zw = vdivq_f64(one, m_v.zw);
+  return result;
 }
-
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::GetSqrt() const
 {
   ezSimdVec4d result;
-  result.m_v.x = ezMath::Sqrt(m_v.x);
-  result.m_v.y = ezMath::Sqrt(m_v.y);
-  result.m_v.z = ezMath::Sqrt(m_v.z);
-  result.m_v.w = ezMath::Sqrt(m_v.w);
-
+  result.m_v.xy = vsqrtq_f64(m_v.xy);
+  result.m_v.zw = vsqrtq_f64(m_v.zw);
   return result;
 }
-
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::GetInvSqrt() const
 {
   ezSimdVec4d result;
-  result.m_v.x = 1.0 / ezMath::Sqrt(m_v.x);
-  result.m_v.y = 1.0 / ezMath::Sqrt(m_v.y);
-  result.m_v.z = 1.0 / ezMath::Sqrt(m_v.z);
-  result.m_v.w = 1.0 / ezMath::Sqrt(m_v.w);
-
+  float64x2_t one = vdupq_n_f64(1.0);
+  result.m_v.xy = vdivq_f64(one, vsqrtq_f64(m_v.xy));
+  result.m_v.zw = vdivq_f64(one, vsqrtq_f64(m_v.zw));
   return result;
 }
 
@@ -136,114 +265,137 @@ template <int N>
 void ezSimdVec4d::NormalizeIfNotZero(const ezSimdDouble& fEpsilon)
 {
   ezSimdDouble sqLength = GetLengthSquared<N>();
-  m_v *= sqLength.GetInvSqrt();
-  m_v = sqLength > fEpsilon.m_v ? m_v : ezVec4d::MakeZero();
+  ezSimdVec4bWide isNotZero;
+  isNotZero.m_v.xy = vcgtq_f64(sqLength.m_v.xy, fEpsilon.m_v.xy);
+  isNotZero.m_v.zw = isNotZero.m_v.xy;
+  ezSimdDouble invSqrt = sqLength.GetInvSqrt();
+  *this = Select(isNotZero, *this * invSqrt, MakeZero());
 }
 
 template <int N>
 EZ_ALWAYS_INLINE bool ezSimdVec4d::IsZero() const
 {
-  for (int i = 0; i < N; ++i)
-  {
-    if ((&m_v.x)[i] != 0.0)
-      return false;
-  }
-
-  return true;
+  const int mask = EZ_BIT(N) - 1;
+  float64x2_t zero = vdupq_n_f64(0.0);
+  uint64x2_t cmpXY = vceqq_f64(m_v.xy, zero);
+  uint64x2_t cmpZW = vceqq_f64(m_v.zw, zero);
+  int m1 = (vgetq_lane_u64(cmpXY, 0) ? 1 : 0) | (vgetq_lane_u64(cmpXY, 1) ? 2 : 0);
+  int m2 = (vgetq_lane_u64(cmpZW, 0) ? 1 : 0) | (vgetq_lane_u64(cmpZW, 1) ? 2 : 0);
+  return ((m1 | (m2 << 2)) & mask) == mask;
 }
 
 template <int N>
 EZ_ALWAYS_INLINE bool ezSimdVec4d::IsZero(const ezSimdDouble& fEpsilon) const
 {
-  for (int i = 0; i < N; ++i)
-  {
-    if (!ezMath::IsZero((&m_v.x)[i], (double)fEpsilon))
-      return false;
-  }
-
-  return true;
+  const int mask = EZ_BIT(N) - 1;
+  float64x2_t eps = vdupq_n_f64(static_cast<double>(fEpsilon));
+  float64x2_t absXY = vabsq_f64(m_v.xy);
+  float64x2_t absZW = vabsq_f64(m_v.zw);
+  uint64x2_t cmpXY = vcltq_f64(absXY, eps);
+  uint64x2_t cmpZW = vcltq_f64(absZW, eps);
+  int m1 = (vgetq_lane_u64(cmpXY, 0) ? 1 : 0) | (vgetq_lane_u64(cmpXY, 1) ? 2 : 0);
+  int m2 = (vgetq_lane_u64(cmpZW, 0) ? 1 : 0) | (vgetq_lane_u64(cmpZW, 1) ? 2 : 0);
+  return ((m1 | (m2 << 2)) & mask) == mask;
 }
 
 template <int N>
 EZ_ALWAYS_INLINE bool ezSimdVec4d::IsNaN() const
 {
-  for (int i = 0; i < N; ++i)
-  {
-    if (ezMath::IsNaN((&m_v.x)[i]))
-      return true;
-  }
-
-  return false;
+  // IEEE 754: NaN != NaN, so a == a is false if a is NaN
+  // vceqq_f64 returns 0 for NaN lanes, XOR inverts to detect them
+  const int mask = EZ_BIT(N) - 1;
+  uint64x2_t allOnes = vdupq_n_u64(~0ULL);
+  uint64x2_t nanXY = veorq_u64(vceqq_f64(m_v.xy, m_v.xy), allOnes);
+  uint64x2_t nanZW = veorq_u64(vceqq_f64(m_v.zw, m_v.zw), allOnes);
+  int m1 = (vgetq_lane_u64(nanXY, 0) ? 1 : 0) | (vgetq_lane_u64(nanXY, 1) ? 2 : 0);
+  int m2 = (vgetq_lane_u64(nanZW, 0) ? 1 : 0) | (vgetq_lane_u64(nanZW, 1) ? 2 : 0);
+  return ((m1 | (m2 << 2)) & mask) != 0;
 }
 
 template <int N>
 EZ_ALWAYS_INLINE bool ezSimdVec4d::IsValid() const
 {
-  for (int i = 0; i < N; ++i)
-  {
-    if (!ezMath::IsFinite((&m_v.x)[i]))
-      return false;
-  }
+  // Valid = not NaN and not Inf
+  // Inf/NaN: exponent bits all 1
+  uint64x2_t exponentMask = vdupq_n_u64(0x7FF0000000000000ULL);
+  uint64x2_t allOnes = vdupq_n_u64(~0ULL);
 
-  return true;
+  uint64x2_t bitsXY = vreinterpretq_u64_f64(m_v.xy);
+  uint64x2_t bitsZW = vreinterpretq_u64_f64(m_v.zw);
+  
+  // Check if exponent is NOT all 1s
+  uint64x2_t maskedXY = vandq_u64(bitsXY, exponentMask);
+  uint64x2_t maskedZW = vandq_u64(bitsZW, exponentMask);
+  uint64x2_t validXY = veorq_u64(vceqq_u64(maskedXY, exponentMask), allOnes);
+  uint64x2_t validZW = veorq_u64(vceqq_u64(maskedZW, exponentMask), allOnes);
+
+  const int mask = EZ_BIT(N) - 1;
+  int m1 = (vgetq_lane_u64(validXY, 0) ? 1 : 0) | (vgetq_lane_u64(validXY, 1) ? 2 : 0);
+  int m2 = (vgetq_lane_u64(validZW, 0) ? 1 : 0) | (vgetq_lane_u64(validZW, 1) ? 2 : 0);
+  return ((m1 | (m2 << 2)) & mask) == mask;
 }
 
 template <int N>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::GetComponent() const
 {
+  ezSimdDouble result;
   if constexpr (N == 0)
   {
-    return m_v.x;
+    result.m_v.xy = vdupq_laneq_f64(m_v.xy, 0);
   }
   else if constexpr (N == 1)
   {
-    return m_v.y;
+    result.m_v.xy = vdupq_laneq_f64(m_v.xy, 1);
   }
   else if constexpr (N == 2)
   {
-    return m_v.z;
-  }
-  else if constexpr (N == 3)
-  {
-    return m_v.w;
+    result.m_v.xy = vdupq_laneq_f64(m_v.zw, 0);
   }
   else
   {
-    return m_v.w;
+    result.m_v.xy = vdupq_laneq_f64(m_v.zw, 1);
   }
+  result.m_v.zw = result.m_v.xy;
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::x() const
 {
-  return m_v.x;
+  return GetComponent<0>();
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::y() const
 {
-  return m_v.y;
+  return GetComponent<1>();
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::z() const
 {
-  return m_v.z;
+  return GetComponent<2>();
 }
 
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::w() const
 {
-  return m_v.w;
+  return GetComponent<3>();
 }
 
 template <ezSwizzle::Enum s>
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Get() const
 {
   ezSimdVec4d result;
-
-  const double* v = &m_v.x;
-  result.m_v.x = v[(s & 0x3000) >> 12];
-  result.m_v.y = v[(s & 0x0300) >> 8];
-  result.m_v.z = v[(s & 0x0030) >> 4];
-  result.m_v.w = v[(s & 0x0003)];
-
+  
+  alignas(16) double vals[4];
+  vst1q_f64(vals, m_v.xy);
+  vst1q_f64(vals + 2, m_v.zw);
+  
+  alignas(16) double out[4];
+  out[0] = vals[(s & 0x3000) >> 12];
+  out[1] = vals[(s & 0x0300) >> 8];
+  out[2] = vals[(s & 0x0030) >> 4];
+  out[3] = vals[(s & 0x0003)];
+  
+  result.m_v.xy = vld1q_f64(out);
+  result.m_v.zw = vld1q_f64(out + 2);
   return result;
 }
 
@@ -251,163 +403,194 @@ template <ezSwizzle::Enum s>
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::GetCombined(const ezSimdVec4d& other) const
 {
   ezSimdVec4d result;
-
-  const double* v = &m_v.x;
-  const double* o = &other.m_v.x;
-  result.m_v.x = v[(s & 0x3000) >> 12];
-  result.m_v.y = v[(s & 0x0300) >> 8];
-  result.m_v.z = o[(s & 0x0030) >> 4];
-  result.m_v.w = o[(s & 0x0003)];
-
+  
+  alignas(16) double vals[4];
+  alignas(16) double otherVals[4];
+  vst1q_f64(vals, m_v.xy);
+  vst1q_f64(vals + 2, m_v.zw);
+  vst1q_f64(otherVals, other.m_v.xy);
+  vst1q_f64(otherVals + 2, other.m_v.zw);
+  
+  alignas(16) double out[4];
+  out[0] = vals[(s & 0x3000) >> 12];
+  out[1] = vals[(s & 0x0300) >> 8];
+  out[2] = otherVals[(s & 0x0030) >> 4];
+  out[3] = otherVals[(s & 0x0003)];
+  
+  result.m_v.xy = vld1q_f64(out);
+  result.m_v.zw = vld1q_f64(out + 2);
   return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::operator-() const
 {
-  return -m_v;
+  ezSimdVec4d result;
+  result.m_v.xy = vnegq_f64(m_v.xy);
+  result.m_v.zw = vnegq_f64(m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::operator+(const ezSimdVec4d& v) const
 {
-  return m_v + v.m_v;
+  ezSimdVec4d result;
+  result.m_v.xy = vaddq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vaddq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::operator-(const ezSimdVec4d& v) const
 {
-  return m_v - v.m_v;
+  ezSimdVec4d result;
+  result.m_v.xy = vsubq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vsubq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
-
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::operator*(const ezSimdDouble& f) const
 {
-  return m_v * f.m_v.x;
+  ezSimdVec4d result;
+  result.m_v.xy = vmulq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = vmulq_f64(m_v.zw, f.m_v.xy);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::operator/(const ezSimdDouble& f) const
 {
-  return m_v / f.m_v.x;
+  ezSimdVec4d result;
+  result.m_v.xy = vdivq_f64(m_v.xy, f.m_v.xy);
+  result.m_v.zw = vdivq_f64(m_v.zw, f.m_v.xy);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CompMul(const ezSimdVec4d& v) const
 {
-  return m_v.CompMul(v.m_v);
+  ezSimdVec4d result;
+  result.m_v.xy = vmulq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vmulq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CompDiv(const ezSimdVec4d& v) const
 {
-  return m_v.CompDiv(v.m_v);
+  ezSimdVec4d result;
+  result.m_v.xy = vdivq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vdivq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CompMin(const ezSimdVec4d& v) const
 {
-  return m_v.CompMin(v.m_v);
+  ezSimdVec4d result;
+  result.m_v.xy = vminq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vminq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CompMax(const ezSimdVec4d& v) const
 {
-  return m_v.CompMax(v.m_v);
+  ezSimdVec4d result;
+  result.m_v.xy = vmaxq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vmaxq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Abs() const
 {
-  return m_v.Abs();
+  ezSimdVec4d result;
+  result.m_v.xy = vabsq_f64(m_v.xy);
+  result.m_v.zw = vabsq_f64(m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Round() const
 {
   ezSimdVec4d result;
-  result.m_v.x = ezMath::Round(m_v.x);
-  result.m_v.y = ezMath::Round(m_v.y);
-  result.m_v.z = ezMath::Round(m_v.z);
-  result.m_v.w = ezMath::Round(m_v.w);
-
+  result.m_v.xy = vrndnq_f64(m_v.xy);
+  result.m_v.zw = vrndnq_f64(m_v.zw);
   return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Floor() const
 {
   ezSimdVec4d result;
-  result.m_v.x = ezMath::Floor(m_v.x);
-  result.m_v.y = ezMath::Floor(m_v.y);
-  result.m_v.z = ezMath::Floor(m_v.z);
-  result.m_v.w = ezMath::Floor(m_v.w);
-
+  result.m_v.xy = vrndmq_f64(m_v.xy);
+  result.m_v.zw = vrndmq_f64(m_v.zw);
   return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Ceil() const
 {
   ezSimdVec4d result;
-  result.m_v.x = ezMath::Ceil(m_v.x);
-  result.m_v.y = ezMath::Ceil(m_v.y);
-  result.m_v.z = ezMath::Ceil(m_v.z);
-  result.m_v.w = ezMath::Ceil(m_v.w);
-
+  result.m_v.xy = vrndpq_f64(m_v.xy);
+  result.m_v.zw = vrndpq_f64(m_v.zw);
   return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Trunc() const
 {
   ezSimdVec4d result;
-  result.m_v.x = ezMath::Trunc(m_v.x);
-  result.m_v.y = ezMath::Trunc(m_v.y);
-  result.m_v.z = ezMath::Trunc(m_v.z);
-  result.m_v.w = ezMath::Trunc(m_v.w);
-
+  result.m_v.xy = vrndq_f64(m_v.xy);
+  result.m_v.zw = vrndq_f64(m_v.zw);
   return result;
 }
 
-EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::FlipSign(const ezSimdVec4bWide& cmp) const
+EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::FlipSign(const ezSimdVec4bWide& vCmp) const
 {
-  ezSimdVec4d r;
-  r.m_v.x = vgetq_lane_u64(cmp.m_v.xy, 0) ? -m_v.x : m_v.x;
-  r.m_v.y = vgetq_lane_u64(cmp.m_v.xy, 1) ? -m_v.y : m_v.y;
-  r.m_v.z = vgetq_lane_u64(cmp.m_v.zw, 0) ? -m_v.z : m_v.z;
-  r.m_v.w = vgetq_lane_u64(cmp.m_v.zw, 1) ? -m_v.w : m_v.w;
-  return r;
+  ezSimdVec4d result;
+  // Create sign mask: -0.0 has bit pattern with only sign bit set
+  float64x2_t signMask = vreinterpretq_f64_u64(vdupq_n_u64(0x8000000000000000ULL));
+  // AND with comparison mask to get sign bit where comparison is true
+  float64x2_t flipXY = vreinterpretq_f64_u64(vandq_u64(vCmp.m_v.xy, vreinterpretq_u64_f64(signMask)));
+  float64x2_t flipZW = vreinterpretq_f64_u64(vandq_u64(vCmp.m_v.zw, vreinterpretq_u64_f64(signMask)));
+  // XOR to flip sign
+  result.m_v.xy = vreinterpretq_f64_u64(veorq_u64(vreinterpretq_u64_f64(m_v.xy), vreinterpretq_u64_f64(flipXY)));
+  result.m_v.zw = vreinterpretq_f64_u64(veorq_u64(vreinterpretq_u64_f64(m_v.zw), vreinterpretq_u64_f64(flipZW)));
+  return result;
 }
 
 // static
-EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Select(const ezSimdVec4bWide& cmp, const ezSimdVec4d& ifTrue, const ezSimdVec4d& ifFalse)
+EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Select(const ezSimdVec4bWide& vCmp, const ezSimdVec4d& vTrue, const ezSimdVec4d& vFalse)
 {
-  ezSimdVec4d r;
-  r.m_v.x = vgetq_lane_u64(cmp.m_v.xy, 0) ? ifTrue.m_v.x : ifFalse.m_v.x;
-  r.m_v.y = vgetq_lane_u64(cmp.m_v.xy, 1) ? ifTrue.m_v.y : ifFalse.m_v.y;
-  r.m_v.z = vgetq_lane_u64(cmp.m_v.zw, 0) ? ifTrue.m_v.z : ifFalse.m_v.z;
-  r.m_v.w = vgetq_lane_u64(cmp.m_v.zw, 1) ? ifTrue.m_v.w : ifFalse.m_v.w;
-  return r;
+  ezSimdVec4d result;
+  result.m_v.xy = vbslq_f64(vCmp.m_v.xy, vTrue.m_v.xy, vFalse.m_v.xy);
+  result.m_v.zw = vbslq_f64(vCmp.m_v.zw, vTrue.m_v.zw, vFalse.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d& ezSimdVec4d::operator+=(const ezSimdVec4d& v)
 {
-  m_v += v.m_v;
+  m_v.xy = vaddq_f64(m_v.xy, v.m_v.xy);
+  m_v.zw = vaddq_f64(m_v.zw, v.m_v.zw);
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d& ezSimdVec4d::operator-=(const ezSimdVec4d& v)
 {
-  m_v -= v.m_v;
+  m_v.xy = vsubq_f64(m_v.xy, v.m_v.xy);
+  m_v.zw = vsubq_f64(m_v.zw, v.m_v.zw);
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d& ezSimdVec4d::operator*=(const ezSimdDouble& f)
 {
-  m_v *= f.m_v.x;
+  m_v.xy = vmulq_f64(m_v.xy, f.m_v.xy);
+  m_v.zw = vmulq_f64(m_v.zw, f.m_v.xy);
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d& ezSimdVec4d::operator/=(const ezSimdDouble& f)
 {
-  m_v /= f.m_v.x;
+  m_v.xy = vdivq_f64(m_v.xy, f.m_v.xy);
+  m_v.zw = vdivq_f64(m_v.zw, f.m_v.xy);
   return *this;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator==(const ezSimdVec4d& v) const
 {
-  ezSimdVec4bWide r;
-  r.m_v.xy = vceqq_f64(vld1q_f64(&m_v.x), vld1q_f64(&v.m_v.x));
-  r.m_v.zw = vceqq_f64(vld1q_f64(&m_v.z), vld1q_f64(&v.m_v.z));
-  return r;
+  ezSimdVec4bWide result;
+  result.m_v.xy = vceqq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vceqq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator!=(const ezSimdVec4d& v) const
@@ -417,134 +600,224 @@ EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator!=(const ezSimdVec4d& v) c
 
 EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator<=(const ezSimdVec4d& v) const
 {
-  return !(*this > v);
+  ezSimdVec4bWide result;
+  result.m_v.xy = vcleq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vcleq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator<(const ezSimdVec4d& v) const
 {
-  ezSimdVec4bWide r;
-  r.m_v.xy = vcltq_f64(vld1q_f64(&m_v.x), vld1q_f64(&v.m_v.x));
-  r.m_v.zw = vcltq_f64(vld1q_f64(&m_v.z), vld1q_f64(&v.m_v.z));
-  return r;
+  ezSimdVec4bWide result;
+  result.m_v.xy = vcltq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vcltq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator>=(const ezSimdVec4d& v) const
 {
-  return !(*this < v);
+  ezSimdVec4bWide result;
+  result.m_v.xy = vcgeq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vcgeq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4bWide ezSimdVec4d::operator>(const ezSimdVec4d& v) const
 {
-  ezSimdVec4bWide r;
-  r.m_v.xy = vcgtq_f64(vld1q_f64(&m_v.x), vld1q_f64(&v.m_v.x));
-  r.m_v.zw = vcgtq_f64(vld1q_f64(&m_v.z), vld1q_f64(&v.m_v.z));
-  return r;
+  ezSimdVec4bWide result;
+  result.m_v.xy = vcgtq_f64(m_v.xy, v.m_v.xy);
+  result.m_v.zw = vcgtq_f64(m_v.zw, v.m_v.zw);
+  return result;
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalSum<2>() const
 {
-  return m_v.x + m_v.y;
+  // vpaddq_f64 does pairwise addition: [a0,a1], [b0,b1] -> [a0+a1, b0+b1]
+  // Passing same vector twice: [x,y], [x,y] -> [x+y, x+y]
+  float64x2_t sum = vpaddq_f64(m_v.xy, m_v.xy);
+  return ezSimdDouble(vgetq_lane_f64(sum, 0));
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalSum<3>() const
 {
-  return (double)HorizontalSum<2>() + m_v.z;
+  // First reduce xy pair, then add z
+  float64x2_t sumXY = vpaddq_f64(m_v.xy, m_v.xy);  // [x+y, x+y]
+  double z = vgetq_lane_f64(m_v.zw, 0);
+  return ezSimdDouble(vgetq_lane_f64(sumXY, 0) + z);
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalSum<4>() const
 {
-  return (double)HorizontalSum<3>() + m_v.w;
+  // vpaddq_f64: [x,y], [z,w] -> [x+y, z+w]
+  // Then pairwise add again to get final sum
+  float64x2_t pair = vpaddq_f64(m_v.xy, m_v.zw);   // [x+y, z+w]
+  float64x2_t total = vpaddq_f64(pair, pair);      // [x+y+z+w, x+y+z+w]
+  return ezSimdDouble(vgetq_lane_f64(total, 0));
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMin<2>() const
 {
-  return ezMath::Min(m_v.x, m_v.y);
+  // vpminq_f64 does pairwise min: [a0,a1], [b0,b1] -> [min(a0,a1), min(b0,b1)]
+  // Passing same vector twice: [x,y], [x,y] -> [min(x,y), min(x,y)]
+  float64x2_t minVal = vpminq_f64(m_v.xy, m_v.xy);
+  return ezSimdDouble(vgetq_lane_f64(minVal, 0));
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMin<3>() const
 {
-  return ezMath::Min((double)HorizontalMin<2>(), m_v.z);
+  // First reduce xy pair, then compare with z
+  float64x2_t minXY = vpminq_f64(m_v.xy, m_v.xy);  // [min(x,y), min(x,y)]
+  double z = vgetq_lane_f64(m_v.zw, 0);
+  double minXYVal = vgetq_lane_f64(minXY, 0);
+  return ezSimdDouble(minXYVal < z ? minXYVal : z);
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMin<4>() const
 {
-  return ezMath::Min((double)HorizontalMin<3>(), m_v.w);
+  // vpminq_f64: [x,y], [z,w] -> [min(x,y), min(z,w)]
+  // Then pairwise min again to get final minimum
+  float64x2_t pair = vpminq_f64(m_v.xy, m_v.zw);   // [min(x,y), min(z,w)]
+  float64x2_t minAll = vpminq_f64(pair, pair);     // [min(x,y,z,w), min(x,y,z,w)]
+  return ezSimdDouble(vgetq_lane_f64(minAll, 0));
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMax<2>() const
 {
-  return ezMath::Max(m_v.x, m_v.y);
+  // vpmaxq_f64 does pairwise max: [a0,a1], [b0,b1] -> [max(a0,a1), max(b0,b1)]
+  // Passing same vector twice: [x,y], [x,y] -> [max(x,y), max(x,y)]
+  float64x2_t maxVal = vpmaxq_f64(m_v.xy, m_v.xy);
+  return ezSimdDouble(vgetq_lane_f64(maxVal, 0));
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMax<3>() const
 {
-  return ezMath::Max((double)HorizontalMax<2>(), m_v.z);
+  // First reduce xy pair, then compare with z
+  float64x2_t maxXY = vpmaxq_f64(m_v.xy, m_v.xy);  // [max(x,y), max(x,y)]
+  double z = vgetq_lane_f64(m_v.zw, 0);
+  double maxXYVal = vgetq_lane_f64(maxXY, 0);
+  return ezSimdDouble(maxXYVal > z ? maxXYVal : z);
 }
 
 template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMax<4>() const
 {
-  return ezMath::Max((double)HorizontalMax<3>(), m_v.w);
+  // vpmaxq_f64: [x,y], [z,w] -> [max(x,y), max(z,w)]
+  // Then pairwise max again to get final maximum
+  float64x2_t pair = vpmaxq_f64(m_v.xy, m_v.zw);   // [max(x,y), max(z,w)]
+  float64x2_t maxAll = vpmaxq_f64(pair, pair);     // [max(x,y,z,w), max(x,y,z,w)]
+  return ezSimdDouble(vgetq_lane_f64(maxAll, 0));
 }
 
-template <int N>
-EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::Dot(const ezSimdVec4d& v) const
+template <>
+EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::Dot<1>(const ezSimdVec4d& v) const
 {
-  double result = 0.0;
+  return CompMul(v).GetComponent<0>();
+}
 
-  for (int i = 0; i < N; ++i)
-  {
-    result += (&m_v.x)[i] * (&v.m_v.x)[i];
-  }
+template <>
+EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::Dot<2>(const ezSimdVec4d& v) const
+{
+  return CompMul(v).HorizontalSum<2>();
+}
 
-  return result;
+template <>
+EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::Dot<3>(const ezSimdVec4d& v) const
+{
+  return CompMul(v).HorizontalSum<3>();
+}
+
+template <>
+EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::Dot<4>(const ezSimdVec4d& v) const
+{
+  return CompMul(v).HorizontalSum<4>();
 }
 
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CrossRH(const ezSimdVec4d& v) const
 {
-  return m_v.GetAsVec3().CrossRH(v.m_v.GetAsVec3()).GetAsVec4(0.0);
+  // Cross product: (y1*z2 - z1*y2, z1*x2 - x1*z2, x1*y2 - y1*x2, 0)
+  double x1 = vgetq_lane_f64(m_v.xy, 0);
+  double y1 = vgetq_lane_f64(m_v.xy, 1);
+  double z1 = vgetq_lane_f64(m_v.zw, 0);
+  double x2 = vgetq_lane_f64(v.m_v.xy, 0);
+  double y2 = vgetq_lane_f64(v.m_v.xy, 1);
+  double z2 = vgetq_lane_f64(v.m_v.zw, 0);
+  
+  alignas(16) double result[4] = {
+    y1 * z2 - z1 * y2,
+    z1 * x2 - x1 * z2,
+    x1 * y2 - y1 * x2,
+    0.0
+  };
+  
+  ezSimdVec4d r;
+  r.m_v.xy = vld1q_f64(result);
+  r.m_v.zw = vld1q_f64(result + 2);
+  return r;
 }
 
 // static
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::MulAdd(const ezSimdVec4d& a, const ezSimdVec4d& b, const ezSimdVec4d& c)
 {
-  return a.CompMul(b) + c;
+  ezSimdVec4d result;
+  result.m_v.xy = vfmaq_f64(c.m_v.xy, a.m_v.xy, b.m_v.xy);
+  result.m_v.zw = vfmaq_f64(c.m_v.zw, a.m_v.zw, b.m_v.zw);
+  return result;
 }
 
 // static
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::MulAdd(const ezSimdVec4d& a, const ezSimdDouble& b, const ezSimdVec4d& c)
 {
-  return a * b + c;
+  ezSimdVec4d result;
+  result.m_v.xy = vfmaq_f64(c.m_v.xy, a.m_v.xy, b.m_v.xy);
+  result.m_v.zw = vfmaq_f64(c.m_v.zw, a.m_v.zw, b.m_v.xy);
+  return result;
 }
 
 // static
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::MulSub(const ezSimdVec4d& a, const ezSimdVec4d& b, const ezSimdVec4d& c)
 {
+  // MulSub should compute a*b - c
   return a.CompMul(b) - c;
 }
 
 // static
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::MulSub(const ezSimdVec4d& a, const ezSimdDouble& b, const ezSimdVec4d& c)
 {
+  // MulSub should compute a*b - c
   return a * b - c;
 }
 
 // static
-EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CopySign(const ezSimdVec4d& magnitude, const ezSimdVec4d& sign)
+EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CopySign(const ezSimdVec4d& vMagnitude, const ezSimdVec4d& vSign)
 {
+  // Returns values with the magnitude of vMagnitude and the sign of vSign.
+  // IEEE 754 double: bit 63 = sign, bits 62-52 = exponent, bits 51-0 = mantissa
   ezSimdVec4d result;
-  result.m_v.x = sign.m_v.x < 0.0 ? -magnitude.m_v.x : magnitude.m_v.x;
-  result.m_v.y = sign.m_v.y < 0.0 ? -magnitude.m_v.y : magnitude.m_v.y;
-  result.m_v.z = sign.m_v.z < 0.0 ? -magnitude.m_v.z : magnitude.m_v.z;
-  result.m_v.w = sign.m_v.w < 0.0 ? -magnitude.m_v.w : magnitude.m_v.w;
 
+  // signMask: only bit 63 set (the sign bit)
+  uint64x2_t signMask = vdupq_n_u64(0x8000000000000000ULL);
+  // valueMask: all bits except bit 63 (magnitude bits)
+  uint64x2_t valueMask = vdupq_n_u64(0x7FFFFFFFFFFFFFFFULL);
+
+  // Extract magnitude bits (clear sign bit) from vMagnitude
+  uint64x2_t magBitsXY = vandq_u64(vreinterpretq_u64_f64(vMagnitude.m_v.xy), valueMask);
+  uint64x2_t magBitsZW = vandq_u64(vreinterpretq_u64_f64(vMagnitude.m_v.zw), valueMask);
+
+  // Extract only the sign bit from vSign
+  uint64x2_t signBitsXY = vandq_u64(vreinterpretq_u64_f64(vSign.m_v.xy), signMask);
+  uint64x2_t signBitsZW = vandq_u64(vreinterpretq_u64_f64(vSign.m_v.zw), signMask);
+
+  // Combine magnitude with new sign using OR
+  result.m_v.xy = vreinterpretq_f64_u64(vorrq_u64(magBitsXY, signBitsXY));
+  result.m_v.zw = vreinterpretq_f64_u64(vorrq_u64(magBitsZW, signBitsZW));
   return result;
 }
+

--- a/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONVec4d_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/NEON/NEONVec4d_inl.h
@@ -322,7 +322,7 @@ EZ_ALWAYS_INLINE bool ezSimdVec4d::IsValid() const
 
   uint64x2_t bitsXY = vreinterpretq_u64_f64(m_v.xy);
   uint64x2_t bitsZW = vreinterpretq_u64_f64(m_v.zw);
-  
+
   // Check if exponent is NOT all 1s
   uint64x2_t maskedXY = vandq_u64(bitsXY, exponentMask);
   uint64x2_t maskedZW = vandq_u64(bitsZW, exponentMask);
@@ -383,17 +383,17 @@ template <ezSwizzle::Enum s>
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::Get() const
 {
   ezSimdVec4d result;
-  
+
   alignas(16) double vals[4];
   vst1q_f64(vals, m_v.xy);
   vst1q_f64(vals + 2, m_v.zw);
-  
+
   alignas(16) double out[4];
   out[0] = vals[(s & 0x3000) >> 12];
   out[1] = vals[(s & 0x0300) >> 8];
   out[2] = vals[(s & 0x0030) >> 4];
   out[3] = vals[(s & 0x0003)];
-  
+
   result.m_v.xy = vld1q_f64(out);
   result.m_v.zw = vld1q_f64(out + 2);
   return result;
@@ -403,20 +403,20 @@ template <ezSwizzle::Enum s>
 EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::GetCombined(const ezSimdVec4d& other) const
 {
   ezSimdVec4d result;
-  
+
   alignas(16) double vals[4];
   alignas(16) double otherVals[4];
   vst1q_f64(vals, m_v.xy);
   vst1q_f64(vals + 2, m_v.zw);
   vst1q_f64(otherVals, other.m_v.xy);
   vst1q_f64(otherVals + 2, other.m_v.zw);
-  
+
   alignas(16) double out[4];
   out[0] = vals[(s & 0x3000) >> 12];
   out[1] = vals[(s & 0x0300) >> 8];
   out[2] = otherVals[(s & 0x0030) >> 4];
   out[3] = otherVals[(s & 0x0003)];
-  
+
   result.m_v.xy = vld1q_f64(out);
   result.m_v.zw = vld1q_f64(out + 2);
   return result;
@@ -643,7 +643,7 @@ template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalSum<3>() const
 {
   // First reduce xy pair, then add z
-  float64x2_t sumXY = vpaddq_f64(m_v.xy, m_v.xy);  // [x+y, x+y]
+  float64x2_t sumXY = vpaddq_f64(m_v.xy, m_v.xy); // [x+y, x+y]
   double z = vgetq_lane_f64(m_v.zw, 0);
   return ezSimdDouble(vgetq_lane_f64(sumXY, 0) + z);
 }
@@ -653,8 +653,8 @@ EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalSum<4>() const
 {
   // vpaddq_f64: [x,y], [z,w] -> [x+y, z+w]
   // Then pairwise add again to get final sum
-  float64x2_t pair = vpaddq_f64(m_v.xy, m_v.zw);   // [x+y, z+w]
-  float64x2_t total = vpaddq_f64(pair, pair);      // [x+y+z+w, x+y+z+w]
+  float64x2_t pair = vpaddq_f64(m_v.xy, m_v.zw); // [x+y, z+w]
+  float64x2_t total = vpaddq_f64(pair, pair);    // [x+y+z+w, x+y+z+w]
   return ezSimdDouble(vgetq_lane_f64(total, 0));
 }
 
@@ -671,7 +671,7 @@ template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMin<3>() const
 {
   // First reduce xy pair, then compare with z
-  float64x2_t minXY = vpminq_f64(m_v.xy, m_v.xy);  // [min(x,y), min(x,y)]
+  float64x2_t minXY = vpminq_f64(m_v.xy, m_v.xy); // [min(x,y), min(x,y)]
   double z = vgetq_lane_f64(m_v.zw, 0);
   double minXYVal = vgetq_lane_f64(minXY, 0);
   return ezSimdDouble(minXYVal < z ? minXYVal : z);
@@ -682,8 +682,8 @@ EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMin<4>() const
 {
   // vpminq_f64: [x,y], [z,w] -> [min(x,y), min(z,w)]
   // Then pairwise min again to get final minimum
-  float64x2_t pair = vpminq_f64(m_v.xy, m_v.zw);   // [min(x,y), min(z,w)]
-  float64x2_t minAll = vpminq_f64(pair, pair);     // [min(x,y,z,w), min(x,y,z,w)]
+  float64x2_t pair = vpminq_f64(m_v.xy, m_v.zw); // [min(x,y), min(z,w)]
+  float64x2_t minAll = vpminq_f64(pair, pair);   // [min(x,y,z,w), min(x,y,z,w)]
   return ezSimdDouble(vgetq_lane_f64(minAll, 0));
 }
 
@@ -700,7 +700,7 @@ template <>
 EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMax<3>() const
 {
   // First reduce xy pair, then compare with z
-  float64x2_t maxXY = vpmaxq_f64(m_v.xy, m_v.xy);  // [max(x,y), max(x,y)]
+  float64x2_t maxXY = vpmaxq_f64(m_v.xy, m_v.xy); // [max(x,y), max(x,y)]
   double z = vgetq_lane_f64(m_v.zw, 0);
   double maxXYVal = vgetq_lane_f64(maxXY, 0);
   return ezSimdDouble(maxXYVal > z ? maxXYVal : z);
@@ -711,8 +711,8 @@ EZ_ALWAYS_INLINE ezSimdDouble ezSimdVec4d::HorizontalMax<4>() const
 {
   // vpmaxq_f64: [x,y], [z,w] -> [max(x,y), max(z,w)]
   // Then pairwise max again to get final maximum
-  float64x2_t pair = vpmaxq_f64(m_v.xy, m_v.zw);   // [max(x,y), max(z,w)]
-  float64x2_t maxAll = vpmaxq_f64(pair, pair);     // [max(x,y,z,w), max(x,y,z,w)]
+  float64x2_t pair = vpmaxq_f64(m_v.xy, m_v.zw); // [max(x,y), max(z,w)]
+  float64x2_t maxAll = vpmaxq_f64(pair, pair);   // [max(x,y,z,w), max(x,y,z,w)]
   return ezSimdDouble(vgetq_lane_f64(maxAll, 0));
 }
 
@@ -749,14 +749,13 @@ EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CrossRH(const ezSimdVec4d& v) const
   double x2 = vgetq_lane_f64(v.m_v.xy, 0);
   double y2 = vgetq_lane_f64(v.m_v.xy, 1);
   double z2 = vgetq_lane_f64(v.m_v.zw, 0);
-  
+
   alignas(16) double result[4] = {
     y1 * z2 - z1 * y2,
     z1 * x2 - x1 * z2,
     x1 * y2 - y1 * x2,
-    0.0
-  };
-  
+    0.0};
+
   ezSimdVec4d r;
   r.m_v.xy = vld1q_f64(result);
   r.m_v.zw = vld1q_f64(result + 2);
@@ -820,4 +819,3 @@ EZ_ALWAYS_INLINE ezSimdVec4d ezSimdVec4d::CopySign(const ezSimdVec4d& vMagnitude
   result.m_v.zw = vreinterpretq_f64_u64(vorrq_u64(magBitsZW, signBitsZW));
   return result;
 }
-

--- a/Code/Engine/Foundation/SimdMath/Implementation/SSE/SSEVec4d_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/SSE/SSEVec4d_inl.h
@@ -183,7 +183,7 @@ EZ_ALWAYS_INLINE void ezSimdVec4d::Load<1>(const float* pFloat)
   m_v = _mm256_cvtps_pd(temp);
 #else
   m_v.xy = _mm_cvtps_pd(_mm_load_ss(pFloat));
-  m_v.zw = m_v.xy;
+  m_v.zw = _mm_setzero_pd();
 #endif
 }
 
@@ -196,7 +196,7 @@ EZ_ALWAYS_INLINE void ezSimdVec4d::Load<2>(const float* pFloat)
 #else
   __m128 temp = _mm_setr_ps(pFloat[0], pFloat[1], 0.0f, 0.0f);
   m_v.xy = _mm_cvtps_pd(temp);
-  m_v.zw = m_v.xy;
+  m_v.zw = _mm_setzero_pd();
 #endif
 }
 

--- a/Code/Engine/Foundation/SimdMath/Implementation/SimdQuatd_inl.h
+++ b/Code/Engine/Foundation/SimdMath/Implementation/SimdQuatd_inl.h
@@ -17,10 +17,10 @@ EZ_ALWAYS_INLINE ezSimdQuatd ezSimdQuatd::MakeFromElements(ezSimdDouble x, ezSim
   return ezSimdQuatd(ezSimdVec4d(x, y, z, w));
 }
 
-inline ezSimdQuatd ezSimdQuatd::MakeFromAxisAndAngle(const ezSimdVec4d& vRotationAxis, const ezSimdDouble& dAngle)
+inline ezSimdQuatd ezSimdQuatd::MakeFromAxisAndAngle(const ezSimdVec4d& vRotationAxis, const ezSimdDouble& fAngle)
 {
   ///\todo optimize
-  const ezAngled halfAngle = ezAngled::MakeFromRadian(dAngle) * 0.5;
+  const ezAngled halfAngle = ezAngled::MakeFromRadian(fAngle) * 0.5;
   double s = ezMath::Sin(halfAngle);
   double c = ezMath::Cos(halfAngle);
 

--- a/Code/Engine/Foundation/SimdMath/SimdVec4d.h
+++ b/Code/Engine/Foundation/SimdMath/SimdVec4d.h
@@ -42,15 +42,23 @@ public:
 
   void SetZero();
 
+  /// \brief Loads N floats from pFloats, converts them to double, and stores in the vector.
+  /// N must be between 1 and 4. Unused components are set to zero.
   template <int N>
   void Load(const float* pFloats);
 
+  /// \brief Loads N doubles from pDoubles into the vector.
+  /// N must be between 1 and 4. Unused components are set to zero.
   template <int N>
   void Load(const double* pDoubles);
 
+  /// \brief Converts the first N components to float and stores them to pFloats.
+  /// N must be between 1 and 4.
   template <int N>
   void Store(float* pFloats) const;
 
+  /// \brief Stores the first N components to pDoubles.
+  /// N must be between 1 and 4.
   template <int N>
   void Store(double* pDoubles) const;
 
@@ -79,9 +87,11 @@ public:
   template <int N>
   void Normalize();
 
+  /// \brief Normalizes the first N components if the squared length is greater than fEpsilon, otherwise sets the vector to zero.
   template <int N>
   void NormalizeIfNotZero(const ezSimdDouble& fEpsilon = ezMath::SmallEpsilon<double>());
 
+  /// \brief Normalizes the first N components if the squared length is greater than fEpsilon, otherwise sets the vector to vFallback.
   template <int N>
   void NormalizeIfNotZero(const ezSimdVec4d& vFallback, const ezSimdDouble& fEpsilon = ezMath::SmallEpsilon<double>());
 
@@ -161,15 +171,19 @@ public:
   [[nodiscard]] ezSimdVec4bWide operator>=(const ezSimdVec4d& v) const;
   [[nodiscard]] ezSimdVec4bWide operator>(const ezSimdVec4d& v) const;
 
+  /// \brief Returns the sum of the first N components.
   template <int N>
   [[nodiscard]] ezSimdDouble HorizontalSum() const;
 
+  /// \brief Returns the minimum of the first N components.
   template <int N>
   [[nodiscard]] ezSimdDouble HorizontalMin() const;
 
+  /// \brief Returns the maximum of the first N components.
   template <int N>
   [[nodiscard]] ezSimdDouble HorizontalMax() const;
 
+  /// \brief Returns the dot product of the first N components of this vector and v.
   template <int N>
   [[nodiscard]] ezSimdDouble Dot(const ezSimdVec4d& v) const;
 
@@ -179,12 +193,15 @@ public:
   ///\brief Generates an arbitrary vector such that Dot<3>(GetOrthogonalVector()) == 0
   [[nodiscard]] ezSimdVec4d GetOrthogonalVector() const;
 
+  /// \brief Returns a * b + c
   [[nodiscard]] static ezSimdVec4d MulAdd(const ezSimdVec4d& a, const ezSimdVec4d& b, const ezSimdVec4d& c);
   [[nodiscard]] static ezSimdVec4d MulAdd(const ezSimdVec4d& a, const ezSimdDouble& b, const ezSimdVec4d& c);
 
+  /// \brief Returns a * b - c
   [[nodiscard]] static ezSimdVec4d MulSub(const ezSimdVec4d& a, const ezSimdVec4d& b, const ezSimdVec4d& c);
   [[nodiscard]] static ezSimdVec4d MulSub(const ezSimdVec4d& a, const ezSimdDouble& b, const ezSimdVec4d& c);
 
+  /// \brief Returns a vector with the magnitude from vMagnitude and the sign from vSign.
   [[nodiscard]] static ezSimdVec4d CopySign(const ezSimdVec4d& vMagnitude, const ezSimdVec4d& vSign);
 
 public:

--- a/Code/Engine/Foundation/SimdMath/SimdVec4f.h
+++ b/Code/Engine/Foundation/SimdMath/SimdVec4f.h
@@ -36,9 +36,13 @@ public:
 
   void SetZero();                               // [tested]
 
+  /// \brief Loads N floats from pFloats into the vector.
+  /// N must be between 1 and 4. Unused components are set to zero.
   template <int N>
   void Load(const float* pFloats);              // [tested]
 
+  /// \brief Stores the first N components to pFloats.
+  /// N must be between 1 and 4.
   template <int N>
   void Store(float* pFloats) const;             // [tested]
 
@@ -70,9 +74,11 @@ public:
   template <int N, ezMathAcc::Enum acc = ezMathAcc::FULL>
   void Normalize();                                                                                                   // [tested]
 
+  /// \brief Normalizes the first N components if the squared length is greater than fEpsilon, otherwise sets the vector to zero.
   template <int N, ezMathAcc::Enum acc = ezMathAcc::FULL>
   void NormalizeIfNotZero(const ezSimdFloat& fEpsilon = ezMath::SmallEpsilon<float>());                               // [tested]
 
+  /// \brief Normalizes the first N components if the squared length is greater than fEpsilon, otherwise sets the vector to vFallback.
   template <int N, ezMathAcc::Enum acc = ezMathAcc::FULL>
   void NormalizeIfNotZero(const ezSimdVec4f& vFallback, const ezSimdFloat& fEpsilon = ezMath::SmallEpsilon<float>()); // [tested]
 
@@ -155,15 +161,19 @@ public:
   [[nodiscard]] ezSimdVec4b operator>=(const ezSimdVec4f& v) const;               // [tested]
   [[nodiscard]] ezSimdVec4b operator>(const ezSimdVec4f& v) const;                // [tested]
 
+  /// \brief Returns the sum of the first N components.
   template <int N>
   [[nodiscard]] ezSimdFloat HorizontalSum() const;                                // [tested]
 
+  /// \brief Returns the minimum of the first N components.
   template <int N>
   [[nodiscard]] ezSimdFloat HorizontalMin() const;                                // [tested]
 
+  /// \brief Returns the maximum of the first N components.
   template <int N>
   [[nodiscard]] ezSimdFloat HorizontalMax() const;                                // [tested]
 
+  /// \brief Returns the dot product of the first N components of this vector and v.
   template <int N>
   [[nodiscard]] ezSimdFloat Dot(const ezSimdVec4f& v) const;                      // [tested]
 
@@ -173,12 +183,15 @@ public:
   ///\brief Generates an arbitrary vector such that Dot<3>(GetOrthogonalVector()) == 0
   [[nodiscard]] ezSimdVec4f GetOrthogonalVector() const;                                                     // [tested]
 
+  /// \brief Returns a * b + c
   [[nodiscard]] static ezSimdVec4f MulAdd(const ezSimdVec4f& a, const ezSimdVec4f& b, const ezSimdVec4f& c); // [tested]
   [[nodiscard]] static ezSimdVec4f MulAdd(const ezSimdVec4f& a, const ezSimdFloat& b, const ezSimdVec4f& c); // [tested]
 
+  /// \brief Returns a * b - c
   [[nodiscard]] static ezSimdVec4f MulSub(const ezSimdVec4f& a, const ezSimdVec4f& b, const ezSimdVec4f& c); // [tested]
   [[nodiscard]] static ezSimdVec4f MulSub(const ezSimdVec4f& a, const ezSimdFloat& b, const ezSimdVec4f& c); // [tested]
 
+  /// \brief Returns a vector with the magnitude from vMagnitude and the sign from vSign.
   [[nodiscard]] static ezSimdVec4f CopySign(const ezSimdVec4f& vMagnitude, const ezSimdVec4f& vSign);        // [tested]
 
 public:

--- a/Code/UnitTests/FoundationTest/SimdMath/SimdDoubleTest.cpp
+++ b/Code/UnitTests/FoundationTest/SimdMath/SimdDoubleTest.cpp
@@ -147,6 +147,14 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdDouble)
     EZ_TEST_BOOL(c >= 2.0);
     EZ_TEST_BOOL(b < 5.0);
     EZ_TEST_BOOL(b <= 2.0);
+
+    // Test float overloads explicitly
+    EZ_TEST_BOOL(c == 2.0f);
+    EZ_TEST_BOOL(c != 5.0f);
+    EZ_TEST_BOOL(a > 2.0f);
+    EZ_TEST_BOOL(c >= 2.0f);
+    EZ_TEST_BOOL(b < 5.0f);
+    EZ_TEST_BOOL(b <= 2.0f);
   }
 
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "Misc")

--- a/Code/UnitTests/FoundationTest/SimdMath/SimdVec4dTest.cpp
+++ b/Code/UnitTests/FoundationTest/SimdMath/SimdVec4dTest.cpp
@@ -172,13 +172,13 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
     // Make sure the class didn't accidentally change in size.
 #if EZ_SIMD_IMPLEMENTATION == EZ_SIMD_IMPLEMENTATION_SSE
-#if EZ_SSE_LEVEL >= EZ_SSE_AVX
+#  if EZ_SSE_LEVEL >= EZ_SSE_AVX
     static_assert(sizeof(ezSimdVec4d) == 32);
     static_assert(alignof(ezSimdVec4d) == 32);
-#else
+#  else
     static_assert(sizeof(ezSimdVec4d) == 32);
     static_assert(alignof(ezSimdVec4d) == 16);
-#endif
+#  endif
 #endif
 
     ezSimdVec4d vInit1F(2.0);
@@ -193,15 +193,15 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
     // Make sure all components have the correct values
 #if EZ_SIMD_IMPLEMENTATION == EZ_SIMD_IMPLEMENTATION_SSE && EZ_ENABLED(EZ_COMPILER_MSVC)
-#if EZ_SSE_LEVEL >= EZ_SSE_AVX
+#  if EZ_SSE_LEVEL >= EZ_SSE_AVX
     EZ_TEST_BOOL(
       vInit4D.m_v.m256d_f64[0] == 1.0 && vInit4D.m_v.m256d_f64[1] == 2.0 && vInit4D.m_v.m256d_f64[2] == 3.0 && vInit4D.m_v.m256d_f64[3] == 4.0);
 
-#else
+#  else
     EZ_TEST_BOOL(
       vInit4D.m_v.xy.m128d_f64[0] == 1.0 && vInit4D.m_v.xy.m128d_f64[1] == 2.0 && vInit4D.m_v.zw.m128d_f64[0] == 3.0 && vInit4D.m_v.zw.m128d_f64[1] == 4.0);
 
-#endif
+#  endif
 #endif
 
     ezSimdVec4d vCopy(vInit4D);
@@ -276,12 +276,33 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
       // Make sure all components have the correct values
 #if EZ_SIMD_IMPLEMENTATION == EZ_SIMD_IMPLEMENTATION_SSE && EZ_ENABLED(EZ_COMPILER_MSVC)
-#if EZ_SSE_LEVEL >= EZ_SSE_AVX
+#  if EZ_SSE_LEVEL >= EZ_SSE_AVX
       EZ_TEST_BOOL(xyzw.m_v.m256d_f64[0] == 1.0 && xyzw.m_v.m256d_f64[1] == 2.0 && xyzw.m_v.m256d_f64[2] == 3.0 && xyzw.m_v.m256d_f64[3] == 4.0);
-#else
+#  else
       EZ_TEST_BOOL(xyzw.m_v.xy.m128d_f64[0] == 1.0 && xyzw.m_v.xy.m128d_f64[1] == 2.0 && xyzw.m_v.zw.m128d_f64[0] == 3.0 && xyzw.m_v.zw.m128d_f64[1] == 4.0);
+#  endif
 #endif
-#endif
+    }
+
+    // Test Load from float array - should zero unused components just like Load from double
+    {
+      float testBlockF[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+
+      ezSimdVec4d x;
+      x.Load<1>(testBlockF);
+      EZ_TEST_BOOL(x.x() == 1.0 && x.y() == 0.0 && x.z() == 0.0 && x.w() == 0.0);
+
+      ezSimdVec4d xy;
+      xy.Load<2>(testBlockF);
+      EZ_TEST_BOOL(xy.x() == 1.0 && xy.y() == 2.0 && xy.z() == 0.0 && xy.w() == 0.0);
+
+      ezSimdVec4d xyz;
+      xyz.Load<3>(testBlockF);
+      EZ_TEST_BOOL(xyz.x() == 1.0 && xyz.y() == 2.0 && xyz.z() == 3.0 && xyz.w() == 0.0);
+
+      ezSimdVec4d xyzw;
+      xyzw.Load<4>(testBlockF);
+      EZ_TEST_BOOL(xyzw.x() == 1.0 && xyzw.y() == 2.0 && xyzw.z() == 3.0 && xyzw.w() == 4.0);
     }
 
     {
@@ -305,6 +326,30 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
       memcpy(mem, testBlock, 32);
       b2.Store<4>(mem);
       EZ_TEST_BOOL(mem[0] == 1.0 && mem[1] == 2.0 && mem[2] == 3.0 && mem[3] == 4.0);
+    }
+
+    // Test Store to float array
+    {
+      float testBlockF[4] = {7.0f, 7.0f, 7.0f, 7.0f};
+      float memF[4] = {};
+
+      ezSimdVec4d b2(1.0, 2.0, 3.0, 4.0);
+
+      memcpy(memF, testBlockF, 16);
+      b2.Store<1>(memF);
+      EZ_TEST_BOOL(memF[0] == 1.0f && memF[1] == 7.0f && memF[2] == 7.0f && memF[3] == 7.0f);
+
+      memcpy(memF, testBlockF, 16);
+      b2.Store<2>(memF);
+      EZ_TEST_BOOL(memF[0] == 1.0f && memF[1] == 2.0f && memF[2] == 7.0f && memF[3] == 7.0f);
+
+      memcpy(memF, testBlockF, 16);
+      b2.Store<3>(memF);
+      EZ_TEST_BOOL(memF[0] == 1.0f && memF[1] == 2.0f && memF[2] == 3.0f && memF[3] == 7.0f);
+
+      memcpy(memF, testBlockF, 16);
+      b2.Store<4>(memF);
+      EZ_TEST_BOOL(memF[0] == 1.0f && memF[1] == 2.0f && memF[2] == 3.0f && memF[3] == 4.0f);
     }
   }
 
@@ -332,7 +377,14 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
       EZ_TEST_BOOL(a.GetInvSqrt().IsEqual(b, ezMath::SmallEpsilon<double>()).AllSet());
       EZ_TEST_BOOL(a.GetInvSqrt().IsEqual(b, ezMath::SmallEpsilon<double>()).AllSet());
+    }
 
+    // IsEqual with epsilon edge cases
+    {
+      ezSimdVec4d a(1.0, 2.0, 3.0, 4.0);
+      ezSimdVec4d b = a;
+      // Equal with zero epsilon should work for identical values
+      EZ_TEST_BOOL(a.IsEqual(b, 0.0).AllSet());
     }
 
     {
@@ -400,7 +452,6 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
       n[3] = a / r[3];
 
       TestNormalize(a, n, r, ezMath::SmallEpsilon<double>());
-
     }
 
     {
@@ -412,7 +463,6 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
       n[3] = a / ezVec4d(a.x(), a.y(), a.z(), a.w()).GetLength();
 
       TestNormalizeIfNotZero(a, n, ezMath::SmallEpsilon<double>());
-
     }
 
     {
@@ -560,7 +610,6 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
 
       EZ_TEST_BOOL(d1.IsEqual(divRes, ezMath::SmallEpsilon<double>()).AllSet());
-
     }
 
     {
@@ -608,6 +657,25 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
       c = ezSimdVec4d::Select(cmp, a, b);
       EZ_TEST_BOOL(c.x() == -3.0 && c.y() == 6.0 && c.z() == 4.0 && c.w() == 9.0);
+
+      ezSimdVec4d a2(1.0, 2.0, 3.0, 4.0);
+      ezSimdVec4d b2(10.0, 20.0, 30.0, 40.0);
+      ezSimdVec4bWide alternating(true, false, true, false);
+      ezSimdVec4d result = ezSimdVec4d::Select(alternating, a2, b2);
+      EZ_TEST_BOOL(result.x() == 1.0 && result.y() == 20.0 && result.z() == 3.0 && result.w() == 40.0);
+    }
+
+    // FlipSign all components
+    {
+      ezSimdVec4d a(-3.0, 5.0, -7.0, 9.0);
+      ezSimdVec4bWide allTrue(true, true, true, true);
+      ezSimdVec4bWide allFalse(false, false, false, false);
+
+      ezSimdVec4d flippedAll = a.FlipSign(allTrue);
+      EZ_TEST_BOOL(flippedAll.x() == 3.0 && flippedAll.y() == -5.0 && flippedAll.z() == 7.0 && flippedAll.w() == -9.0);
+
+      ezSimdVec4d flippedNone = a.FlipSign(allFalse);
+      EZ_TEST_BOOL((flippedNone == a).AllSet());
     }
 
     {
@@ -728,6 +796,25 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
       EZ_TEST_BOOL(c.z() == res.z);
     }
 
+    // Cross product edge cases
+    {
+      // Parallel vectors (should produce zero)
+      ezSimdVec4d a(1.0, 2.0, 3.0, 0.0);
+      ezSimdVec4d b(2.0, 4.0, 6.0, 0.0); // parallel to a
+      ezSimdVec4d c = a.CrossRH(b);
+      EZ_TEST_BOOL(c.IsZero<3>(ezMath::SmallEpsilon<double>()));
+
+      // Anti-parallel
+      ezSimdVec4d d(-1.0, -2.0, -3.0, 0.0);
+      ezSimdVec4d e = a.CrossRH(d);
+      EZ_TEST_BOOL(e.IsZero<3>(ezMath::SmallEpsilon<double>()));
+
+      // Cross with zero
+      ezSimdVec4d zero = ezSimdVec4d::MakeZero();
+      ezSimdVec4d f = a.CrossRH(zero);
+      EZ_TEST_BOOL(f.IsZero<3>());
+    }
+
     {
       ezSimdVec4d a(-3.0, 5.0, -7.0, 0.0);
       ezSimdVec4d b = a.GetOrthogonalVector();
@@ -746,6 +833,17 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
       EZ_TEST_BOOL(!b.IsZero<3>());
       EZ_TEST_DOUBLE(a.Dot<3>(b), 0.0, 0.0);
+    }
+
+    // GetOrthogonalVector edge cases
+    {
+      // Near-axis-aligned vectors
+      ezSimdVec4d a(1e-10, 0.9999999999, 1e-10, 0.0);
+      a.Normalize<3>();
+      ezSimdVec4d b = a.GetOrthogonalVector();
+
+      EZ_TEST_BOOL(!b.IsZero<3>());
+      EZ_TEST_DOUBLE(a.Dot<3>(b), 0.0, ezMath::SmallEpsilon<double>());
     }
 
     {
@@ -768,6 +866,34 @@ EZ_CREATE_SIMPLE_TEST(SimdMath, SimdVec4d)
 
       d = ezSimdVec4d::CopySign(b, a);
       EZ_TEST_BOOL(d.x() == -8.0 && d.y() == 6.0 && d.z() == -4.0 && d.w() == 2.0);
+
+      // Negative zero handling with CopySign
+      ezSimdVec4d mag(1.0, 2.0, 3.0, 4.0);
+      ezSimdVec4d negZero(-0.0, 0.0, -0.0, 0.0);
+      ezSimdVec4d result = ezSimdVec4d::CopySign(mag, negZero);
+      EZ_TEST_BOOL(result.x() == -1.0 && result.y() == 2.0 && result.z() == -3.0 && result.w() == 4.0);
+    }
+
+    // Lerp edge cases
+    {
+      ezSimdVec4d a(1.0, 2.0, 3.0, 4.0);
+      ezSimdVec4d b(5.0, 6.0, 7.0, 8.0);
+
+      // t = 0 should give a
+      ezSimdVec4d t0 = ezSimdVec4d::Lerp(a, b, ezSimdVec4d(0.0));
+      EZ_TEST_BOOL((t0 == a).AllSet());
+
+      // t = 1 should give b
+      ezSimdVec4d t1 = ezSimdVec4d::Lerp(a, b, ezSimdVec4d(1.0));
+      EZ_TEST_BOOL((t1 == b).AllSet());
+
+      // t = 0.5 should give midpoint
+      ezSimdVec4d tHalf = ezSimdVec4d::Lerp(a, b, ezSimdVec4d(0.5));
+      EZ_TEST_BOOL(tHalf.IsEqual(ezSimdVec4d(3.0, 4.0, 5.0, 6.0), ezMath::SmallEpsilon<double>()).AllSet());
+
+      // t outside [0,1] - extrapolation
+      ezSimdVec4d tNeg = ezSimdVec4d::Lerp(a, b, ezSimdVec4d(-1.0));
+      EZ_TEST_BOOL(tNeg.IsEqual(ezSimdVec4d(-3.0, -2.0, -1.0, 0.0), ezMath::SmallEpsilon<double>()).AllSet());
     }
   }
 }


### PR DESCRIPTION
## NEON SIMD refactoring
* Replaced `ezSimdVec4d` FPU fallback with native ARM64 NEON intrinsics using a QuadDouble struct (two float64x2_t registers).
* Replaced `ezSimdDouble` FPU fallback with the same QuadDouble struct used in `ezVec4d`.

## Bug fixes:
* `ezSimdVec4d::Load<1,2>(float*)` now zeros unused components instead of duplicating (SSE + NEON) to be in line with the double variant.
* FPU `ezSimdVec4d::Set(double,...)` no longer incorrectly casts to float, loosing precision.
* FPU `ezSimdVec4d::CopySign` now uses std::copysign for correct -0.0 handling
* Added missing FPU `ezSimdVec4d::Load/Store<N>(float*)` specializations.