### PR TITLE
VSE: Linearized code generation and type system improvements

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -143,7 +143,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetProperties, 4, ezRTTIDefaultAlloc
 }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetDocument, 11, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetDocument, 12, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.cpp
@@ -354,6 +354,8 @@ void ezVisualShaderTypeRegistry::ExtractNodePins(const ezOpenDdlReaderElement* p
           pin.m_pDataType = ezGetStaticRTTI<ezString>();
         else if (sType == "sampler")
           pin.m_pDataType = m_pSamplerPinType;
+        else if (sType == "auto")
+          pin.m_pDataType = nullptr; // nullptr indicates "auto" type - computed from inputs at code generation time
         else
         {
           ezLog::Error("Invalid pin type '{0}'", sType);
@@ -411,9 +413,12 @@ void ezVisualShaderTypeRegistry::ExtractNodePins(const ezOpenDdlReaderElement* p
         pin.m_PropertyDesc.m_sName = pin.m_sName;
         pin.m_PropertyDesc.m_Category = ezPropertyCategory::Member;
         pin.m_PropertyDesc.m_Flags.SetValue((ezUInt16)ezPropertyFlags::Phantom | (ezUInt16)ezPropertyFlags::StandardType);
-        pin.m_PropertyDesc.m_sType = pin.m_pDataType->GetTypeName();
 
-        const ezVariant def = ExtractDefaultValue(pin.m_pDataType, pin.m_sDefaultValue);
+        // For "auto" type pins, use float as the fallback type for the property GUI
+        const ezRTTI* pPropertyType = pin.m_pDataType != nullptr ? pin.m_pDataType : ezGetStaticRTTI<float>();
+        pin.m_PropertyDesc.m_sType = pPropertyType->GetTypeName();
+
+        const ezVariant def = ExtractDefaultValue(pPropertyType, pin.m_sDefaultValue);
 
         if (def.IsValid())
         {
@@ -647,12 +652,26 @@ void ezVisualShaderTypeRegistry::ExtractNodeConfig(const ezOpenDdlReaderElement*
           temp.Append("\n");
         nd.m_sShaderCodeShaderShared = temp;
       }
-      else if (pElement->GetName() == "CodeVertexShader")
+      else if (pElement->GetName() == "CodeVertexDefines")
       {
         temp = pElement->GetPrimitivesString()[0];
         if (!temp.IsEmpty() && !temp.EndsWith("\n"))
           temp.Append("\n");
-        nd.m_sShaderCodeVertexShader = temp;
+        nd.m_sShaderCodeVertexDefines = temp;
+      }
+      else if (pElement->GetName() == "CodeVertexIncludes")
+      {
+        temp = pElement->GetPrimitivesString()[0];
+        if (!temp.IsEmpty() && !temp.EndsWith("\n"))
+          temp.Append("\n");
+        nd.m_sShaderCodeVertexIncludes = temp;
+      }
+      else if (pElement->GetName() == "CodeVertexBody")
+      {
+        temp = pElement->GetPrimitivesString()[0];
+        if (!temp.IsEmpty() && !temp.EndsWith("\n"))
+          temp.Append("\n");
+        nd.m_sShaderCodeVertexBody = temp;
       }
       else if (pElement->GetName() == "CodeMaterialParams")
       {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VisualShaderTypeRegistry.h
@@ -58,7 +58,9 @@ struct ezVisualShaderNodeDescriptor
   ezString m_sShaderCodeMaterialCB;
   ezString m_sShaderCodeRenderState;
   ezString m_sShaderCodeShaderShared;
-  ezString m_sShaderCodeVertexShader;
+  ezString m_sShaderCodeVertexDefines;
+  ezString m_sShaderCodeVertexIncludes;
+  ezString m_sShaderCodeVertexBody;
 
   ezHybridArray<ezVisualShaderPinDescriptor, 4> m_InputPins;
   ezHybridArray<ezVisualShaderPinDescriptor, 4> m_OutputPins;

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
@@ -15,13 +15,18 @@ namespace
       return 3;
     if (pType == ezGetStaticRTTI<ezVec4>() || pType == ezGetStaticRTTI<ezColor>())
       return 4;
+    // We treat 'auto' as float as all the default values for auto fields are float.
+    if (pType == nullptr)
+      return 1;
+
+    EZ_REPORT_FAILURE("Unknown RTTI type found in VSE type");
     return 0;
   }
 
   // Returns the HLSL type string for a given dimension
-  const char* DimensionToHlslType(ezUInt8 dimension)
+  const char* DimensionToHlslType(ezUInt8 uiDimension)
   {
-    switch (dimension)
+    switch (uiDimension)
     {
       case 1:
         return "float";
@@ -30,7 +35,9 @@ namespace
       case 3:
         return "float3";
       case 4:
+        return "float4";
       default:
+        EZ_REPORT_FAILURE("Unknown vector dimension found in HLSL type");
         return "float4";
     }
   }
@@ -188,6 +195,7 @@ ezString ezVisualShaderCodeGenerator::GetInputPinDefaultValue(const ezDocumentOb
 
 ezResult ezVisualShaderCodeGenerator::CollectNodesInTopologicalOrder(const ezDocumentObject* pRootNode, ezDynamicArray<const ezDocumentObject*>& out_Sorted) const
 {
+  // We need the reachable nodes to ignore connections that go out of this subtree as they are not relevant.
   ezHashSet<const ezDocumentObject*> reachableNodes;
   CollectReachableNodes(pRootNode, reachableNodes);
 
@@ -198,13 +206,13 @@ ezResult ezVisualShaderCodeGenerator::CollectNodesInTopologicalOrder(const ezDoc
 
   while (!nodeStack.IsEmpty())
   {
-    // Find next node with all execution dependencies visited
-    const ezDocumentObject* pAstNode = nullptr;
+    // Find the next node in which all outgoing connections are visited nodes or nodes outside the reachable nodes.
+    const ezDocumentObject* pNode = nullptr;
     for (ezUInt32 i = nodeStack.GetCount(); i-- > 0;)
     {
-      const ezDocumentObject* pCandidateAstNode = nodeStack[i];
+      const ezDocumentObject* pCandidateNode = nodeStack[i];
       bool bAllVisited = true;
-      ezArrayPtr<const ezUniquePtr<const ezPin>> outputPins = m_pNodeManager->GetOutputPins(pCandidateAstNode);
+      ezArrayPtr<const ezUniquePtr<const ezPin>> outputPins = m_pNodeManager->GetOutputPins(pCandidateNode);
       for (auto& pOutputPin : outputPins)
       {
         ezArrayPtr<const ezConnection* const> connections = m_pNodeManager->GetConnections(*pOutputPin);
@@ -223,22 +231,23 @@ ezResult ezVisualShaderCodeGenerator::CollectNodesInTopologicalOrder(const ezDoc
 
       if (bAllVisited)
       {
-        pAstNode = pCandidateAstNode;
+        pNode = pCandidateNode;
         nodeStack.RemoveAtAndCopy(i);
         break;
       }
     }
 
-    if (pAstNode == nullptr)
+    if (pNode == nullptr)
     {
       EZ_REPORT_FAILURE("Execution connection corrupted or loop detected");
       return EZ_FAILURE;
     }
 
-    EZ_VERIFY(visitedNodes.Insert(pAstNode) == false, "");
-    out_Sorted.PushBack(pAstNode);
+    EZ_VERIFY(visitedNodes.Insert(pNode) == false, "Every node should only be visited once");
+    out_Sorted.PushBack(pNode);
 
-    ezArrayPtr<const ezUniquePtr<const ezPin>> inputPins = m_pNodeManager->GetInputPins(pAstNode);
+    // Add all incoming connections of the node to the nodeStack.
+    ezArrayPtr<const ezUniquePtr<const ezPin>> inputPins = m_pNodeManager->GetInputPins(pNode);
     for (ezUInt32 i = 0; i < inputPins.GetCount(); ++i)
     {
       const ezUniquePtr<const ezPin>& pInputPin = inputPins[i];
@@ -246,13 +255,8 @@ ezResult ezVisualShaderCodeGenerator::CollectNodesInTopologicalOrder(const ezDoc
       for (const auto* pConnection : connections)
       {
         const ezDocumentObject* pParentNode = pConnection->GetSourcePin().GetParent();
-        if (visitedNodes.Contains(pParentNode))
-          continue;
-
         if (nodeStack.Contains(pParentNode) == false)
-        {
           nodeStack.PushBack(pParentNode);
-        }
       }
     }
   }
@@ -411,7 +415,7 @@ void ezVisualShaderCodeGenerator::GenerateInputHelperFunction(const ezPin* pInpu
 
       // Generate local variable with descriptive name including node type
       ezStringBuilder sVarName;
-      sVarName.SetFormat("_{0}_{1}_{2}", pDesc->m_sName, pOutPin->GetName(), nodeState.m_uiNodeId);
+      sVarName.SetFormat("_{0}_{1}_{2}", pDesc->m_sName, nodeState.m_uiNodeId, pOutPin->GetName());
       pinToVarName[pOutPin] = sVarName;
 
       // Add local variable declaration with the computed type
@@ -707,24 +711,27 @@ void ezVisualShaderCodeGenerator::ReplaceMainNodeInputPins(const ezDocumentObjec
     sPinPlaceholder.SetFormat("$in{0}", i);
 
     // Check if this shader section uses this placeholder
-    if (sInlineCode.FindSubString(sPinPlaceholder) == nullptr)
-      continue;
-
+    const bool bPresentInCode = sInlineCode.FindSubString(sPinPlaceholder) != nullptr;
+    // Even if this shader section is not using this placeholder, we need to insert the defines into sCodeForPlacingDefines as these must be equal between shader stages.
     auto connections = m_pNodeManager->GetConnections(*inputPins[i]);
     if (connections.IsEmpty())
     {
       ezString sValue = GetInputPinDefaultValue(pMainNode, pNodeDesc->m_InputPins[i], &sCodeForPlacingDefines);
-      sInlineCode.ReplaceAll(sPinPlaceholder, sValue);
+      if (bPresentInCode)
+        sInlineCode.ReplaceAll(sPinPlaceholder, sValue);
+      continue;
     }
-    else
-    {
-      // Generate the helper function for this input's subgraph
-      ezStringBuilder sHelperFunc, sFuncCall;
-      GenerateInputHelperFunction(inputPins[i].Borrow(), i, sHelperFunc, sFuncCall);
 
-      out_sHelperFunctions.Append(sHelperFunc);
-      sInlineCode.ReplaceAll(sPinPlaceholder, sFuncCall);
-    }
+    // Do generate and add the helper function to a shader stage that does not call the function.
+    if (!bPresentInCode)
+      continue;
+
+    // Generate the helper function for this input's subgraph
+    ezStringBuilder sHelperFunc, sFuncCall;
+    GenerateInputHelperFunction(inputPins[i].Borrow(), i, sHelperFunc, sFuncCall);
+
+    out_sHelperFunctions.Append(sHelperFunc);
+    sInlineCode.ReplaceAll(sPinPlaceholder, sFuncCall);
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
@@ -2,76 +2,110 @@
 
 #include <EditorPluginAssets/VisualShader/VsCodeGenerator.h>
 
-static ezString ToShaderString(const ezVariant& value)
+namespace
 {
-  ezStringBuilder temp;
-
-  switch (value.GetType())
+  // Returns the dimension of a type: 1 for float, 2 for ezVec2, 3 for ezVec3, 4 for ezVec4/ezColor, 0 for unknown
+  ezUInt8 GetTypeDimension(const ezRTTI* pType)
   {
-    case ezVariantType::String:
-    {
-      temp = value.Get<ezString>();
-    }
-    break;
-
-    case ezVariantType::Color:
-    case ezVariantType::ColorGamma:
-    {
-      ezColor v = value.ConvertTo<ezColor>();
-      temp.SetFormat("float4({0}, {1}, {2}, {3})", v.r, v.g, v.b, v.a);
-    }
-    break;
-
-    case ezVariantType::Vector4:
-    {
-      ezVec4 v = value.Get<ezVec4>();
-      temp.SetFormat("float4({0}, {1}, {2}, {3})", v.x, v.y, v.z, v.w);
-    }
-    break;
-
-    case ezVariantType::Vector3:
-    {
-      ezVec3 v = value.Get<ezVec3>();
-      temp.SetFormat("float3({0}, {1}, {2})", v.x, v.y, v.z);
-    }
-    break;
-
-    case ezVariantType::Vector2:
-    {
-      ezVec2 v = value.Get<ezVec2>();
-      temp.SetFormat("float2({0}, {1})", v.x, v.y);
-    }
-    break;
-
-    case ezVariantType::Float:
-    case ezVariantType::Int32:
-    case ezVariantType::Bool:
-    {
-      temp.SetFormat("{0}", value);
-    }
-    break;
-
-    case ezVariantType::Time:
-    {
-      float v = value.Get<ezTime>().GetSeconds();
-      temp.SetFormat("{0}", v);
-    }
-    break;
-
-    case ezVariantType::Angle:
-    {
-      float v = value.Get<ezAngle>().GetRadian();
-      temp.SetFormat("{0}", v);
-    }
-    break;
-
-    default:
-      temp = "<Invalid Type>";
-      break;
+    if (pType == ezGetStaticRTTI<float>())
+      return 1;
+    if (pType == ezGetStaticRTTI<ezVec2>())
+      return 2;
+    if (pType == ezGetStaticRTTI<ezVec3>())
+      return 3;
+    if (pType == ezGetStaticRTTI<ezVec4>() || pType == ezGetStaticRTTI<ezColor>())
+      return 4;
+    return 0;
   }
 
-  return temp;
-}
+  // Returns the HLSL type string for a given dimension
+  const char* DimensionToHlslType(ezUInt8 dimension)
+  {
+    switch (dimension)
+    {
+      case 1:
+        return "float";
+      case 2:
+        return "float2";
+      case 3:
+        return "float3";
+      case 4:
+      default:
+        return "float4";
+    }
+  }
+
+  ezString ToShaderString(const ezVariant& value)
+  {
+    ezStringBuilder temp;
+
+    switch (value.GetType())
+    {
+      case ezVariantType::String:
+      {
+        temp = value.Get<ezString>();
+      }
+      break;
+
+      case ezVariantType::Color:
+      case ezVariantType::ColorGamma:
+      {
+        ezColor v = value.ConvertTo<ezColor>();
+        temp.SetFormat("float4({0}, {1}, {2}, {3})", v.r, v.g, v.b, v.a);
+      }
+      break;
+
+      case ezVariantType::Vector4:
+      {
+        ezVec4 v = value.Get<ezVec4>();
+        temp.SetFormat("float4({0}, {1}, {2}, {3})", v.x, v.y, v.z, v.w);
+      }
+      break;
+
+      case ezVariantType::Vector3:
+      {
+        ezVec3 v = value.Get<ezVec3>();
+        temp.SetFormat("float3({0}, {1}, {2})", v.x, v.y, v.z);
+      }
+      break;
+
+      case ezVariantType::Vector2:
+      {
+        ezVec2 v = value.Get<ezVec2>();
+        temp.SetFormat("float2({0}, {1})", v.x, v.y);
+      }
+      break;
+
+      case ezVariantType::Float:
+      case ezVariantType::Int32:
+      case ezVariantType::Bool:
+      {
+        temp.SetFormat("{0}", value);
+      }
+      break;
+
+      case ezVariantType::Time:
+      {
+        float v = value.Get<ezTime>().GetSeconds();
+        temp.SetFormat("{0}", v);
+      }
+      break;
+
+      case ezVariantType::Angle:
+      {
+        float v = value.Get<ezAngle>().GetRadian();
+        temp.SetFormat("{0}", v);
+      }
+      break;
+
+      default:
+        temp = "<Invalid Type>";
+        break;
+    }
+
+    return temp;
+  }
+} // namespace
 
 ezVisualShaderCodeGenerator::ezVisualShaderCodeGenerator()
 {
@@ -98,6 +132,301 @@ void ezVisualShaderCodeGenerator::DetermineConfigFileDependencies(const ezDocume
 
     out_cfgFiles.Insert(pDesc->m_sCfgFile);
   }
+}
+
+void ezVisualShaderCodeGenerator::CollectReachableNodes(const ezDocumentObject* pRootNode, ezHashSet<const ezDocumentObject*>& out_Nodes) const
+{
+  out_Nodes.Clear();
+  ezHybridArray<const ezDocumentObject*, 64> nodeStack;
+  nodeStack.PushBack(pRootNode);
+
+  while (!nodeStack.IsEmpty())
+  {
+    const ezDocumentObject* pNode = nodeStack.PeekBack();
+    nodeStack.PopBack();
+    out_Nodes.Insert(pNode);
+
+    ezArrayPtr<const ezUniquePtr<const ezPin>> inputPins = m_pNodeManager->GetInputPins(pNode);
+    for (ezUInt32 i = 0; i < inputPins.GetCount(); ++i)
+    {
+      const ezUniquePtr<const ezPin>& pInputPin = inputPins[i];
+      ezArrayPtr<const ezConnection* const> connections = m_pNodeManager->GetConnections(*pInputPin);
+      for (const auto* pConnection : connections)
+      {
+        const ezDocumentObject* pParentNode = pConnection->GetSourcePin().GetParent();
+        if (out_Nodes.Contains(pParentNode))
+          continue;
+
+        if (!nodeStack.Contains(pParentNode))
+          nodeStack.PushBack(pParentNode);
+      }
+    }
+  }
+}
+
+ezString ezVisualShaderCodeGenerator::GetInputPinDefaultValue(const ezDocumentObject* pNode, const ezVisualShaderPinDescriptor& pinDesc, ezStringBuilder* pDefinesOut)
+{
+  if (pinDesc.m_bExposeAsProperty)
+  {
+    ezVariant val = pNode->GetTypeAccessor().GetValue(pinDesc.m_sName);
+    return ToShaderString(val);
+  }
+  else
+  {
+    if (pDefinesOut != nullptr)
+    {
+      for (const auto& sDefine : pinDesc.m_sDefinesWhenUsingDefaultValue)
+      {
+        pDefinesOut->Append("#if !defined(", sDefine, ")\n");
+        pDefinesOut->Append("  #define ", sDefine, "\n");
+        pDefinesOut->Append("#endif\n");
+      }
+    }
+    return pinDesc.m_sDefaultValue;
+  }
+}
+
+ezResult ezVisualShaderCodeGenerator::CollectNodesInTopologicalOrder(const ezDocumentObject* pRootNode, ezDynamicArray<const ezDocumentObject*>& out_Sorted) const
+{
+  ezHashSet<const ezDocumentObject*> reachableNodes;
+  CollectReachableNodes(pRootNode, reachableNodes);
+
+  ezHashSet<const ezDocumentObject*> visitedNodes;
+  visitedNodes.Reserve(reachableNodes.GetCount());
+  ezHybridArray<const ezDocumentObject*, 64> nodeStack;
+  nodeStack.PushBack(pRootNode);
+
+  while (!nodeStack.IsEmpty())
+  {
+    // Find next node with all execution dependencies visited
+    const ezDocumentObject* pAstNode = nullptr;
+    for (ezUInt32 i = nodeStack.GetCount(); i-- > 0;)
+    {
+      const ezDocumentObject* pCandidateAstNode = nodeStack[i];
+      bool bAllVisited = true;
+      ezArrayPtr<const ezUniquePtr<const ezPin>> outputPins = m_pNodeManager->GetOutputPins(pCandidateAstNode);
+      for (auto& pOutputPin : outputPins)
+      {
+        ezArrayPtr<const ezConnection* const> connections = m_pNodeManager->GetConnections(*pOutputPin);
+        for (const auto* pConnection : connections)
+        {
+          const ezDocumentObject* pParentNode = pConnection->GetTargetPin().GetParent();
+          if (reachableNodes.Contains(pParentNode) && !visitedNodes.Contains(pParentNode))
+          {
+            bAllVisited = false;
+            break;
+          }
+        }
+        if (!bAllVisited)
+          break;
+      }
+
+      if (bAllVisited)
+      {
+        pAstNode = pCandidateAstNode;
+        nodeStack.RemoveAtAndCopy(i);
+        break;
+      }
+    }
+
+    if (pAstNode == nullptr)
+    {
+      EZ_REPORT_FAILURE("Execution connection corrupted or loop detected");
+      return EZ_FAILURE;
+    }
+
+    EZ_VERIFY(visitedNodes.Insert(pAstNode) == false, "");
+    out_Sorted.PushBack(pAstNode);
+
+    ezArrayPtr<const ezUniquePtr<const ezPin>> inputPins = m_pNodeManager->GetInputPins(pAstNode);
+    for (ezUInt32 i = 0; i < inputPins.GetCount(); ++i)
+    {
+      const ezUniquePtr<const ezPin>& pInputPin = inputPins[i];
+      ezArrayPtr<const ezConnection* const> connections = m_pNodeManager->GetConnections(*pInputPin);
+      for (const auto* pConnection : connections)
+      {
+        const ezDocumentObject* pParentNode = pConnection->GetSourcePin().GetParent();
+        if (visitedNodes.Contains(pParentNode))
+          continue;
+
+        if (nodeStack.Contains(pParentNode) == false)
+        {
+          nodeStack.PushBack(pParentNode);
+        }
+      }
+    }
+  }
+
+  return EZ_SUCCESS;
+}
+
+void ezVisualShaderCodeGenerator::ComputeOutputPinDimensions()
+{
+  m_OutputPinDimensions.Clear();
+
+  // Find all root nodes (nodes with no outputs connected)
+  ezHybridArray<const ezDocumentObject*, 16> rootNodes;
+  for (auto& nodeIt : m_Nodes)
+  {
+    const ezDocumentObject* pNode = nodeIt.Key();
+    auto outputPins = m_pNodeManager->GetOutputPins(pNode);
+
+    bool bHasConnectedOutput = false;
+    for (auto& pOutPin : outputPins)
+    {
+      if (!m_pNodeManager->GetConnections(*pOutPin).IsEmpty())
+      {
+        bHasConnectedOutput = true;
+        break;
+      }
+    }
+
+    if (!bHasConnectedOutput)
+    {
+      rootNodes.PushBack(pNode);
+    }
+  }
+
+  // Process each root node's subgraph in topological order
+  for (const ezDocumentObject* pRootNode : rootNodes)
+  {
+    ezDynamicArray<const ezDocumentObject*> sortedNodes;
+    if (CollectNodesInTopologicalOrder(pRootNode, sortedNodes).Failed())
+      continue;
+
+    // Process nodes in reverse topological order (leaves first, root last) so that input dimensions are computed before nodes that depend on them
+    for (ezUInt32 i = sortedNodes.GetCount(); i-- > 0;)
+    {
+      const ezDocumentObject* pNode = sortedNodes[i];
+      const ezVisualShaderNodeDescriptor* pDesc = m_pTypeRegistry->GetDescriptorForType(pNode->GetType());
+
+      auto outputPins = m_pNodeManager->GetOutputPins(pNode);
+      for (ezUInt32 pinIdx = 0; pinIdx < outputPins.GetCount(); ++pinIdx)
+      {
+        const ezPin* pOutPin = outputPins[pinIdx].Borrow();
+
+        // Skip if already computed (node may be shared between subgraphs)
+        if (m_OutputPinDimensions.Contains(pOutPin))
+          continue;
+
+        // If output type is explicit, use it directly
+        if (pDesc->m_OutputPins[pinIdx].m_pDataType != nullptr)
+        {
+          ezUInt8 dim = GetTypeDimension(pDesc->m_OutputPins[pinIdx].m_pDataType);
+          if (dim == 0)
+            dim = 1;
+          m_OutputPinDimensions[pOutPin] = dim;
+          continue;
+        }
+
+        // "auto" type - compute from max of input dimensions. Since we're in topological order, all inputs should already be computed.
+        ezUInt8 effectiveDim = 0;
+        auto inputPins = m_pNodeManager->GetInputPins(pNode);
+        for (ezUInt32 inIdx = 0; inIdx < inputPins.GetCount(); ++inIdx)
+        {
+          auto inConnections = m_pNodeManager->GetConnections(*inputPins[inIdx]);
+          if (!inConnections.IsEmpty())
+          {
+            const ezPin* pConnectedPin = &inConnections[0]->GetSourcePin();
+            EZ_ASSERT_DEV(m_OutputPinDimensions.Contains(pConnectedPin), "Topological order should have processed all inputs first");
+            effectiveDim = ezMath::Max(effectiveDim, m_OutputPinDimensions[pConnectedPin]);
+          }
+          else
+          {
+            // No connection - use declared input type
+            effectiveDim = ezMath::Max(effectiveDim, GetTypeDimension(pDesc->m_InputPins[inIdx].m_pDataType));
+          }
+        }
+
+        if (effectiveDim == 0)
+          effectiveDim = 1;
+        m_OutputPinDimensions[pOutPin] = effectiveDim;
+      }
+    }
+  }
+}
+
+void ezVisualShaderCodeGenerator::GenerateInputHelperFunction(const ezPin* pInputPin, ezUInt32 uiInputIndex, ezStringBuilder& out_sFunctionCode, ezStringBuilder& out_sFunctionCall)
+{
+  out_sFunctionCode.Clear();
+  out_sFunctionCall.Clear();
+
+  // Generate linearized code for a main node input: local variables for each node in the subgraph
+  auto connections = m_pNodeManager->GetConnections(*pInputPin);
+  if (connections.IsEmpty())
+    return;
+
+  const ezPin* pSourcePin = &connections[0]->GetSourcePin();
+  ezDynamicArray<const ezDocumentObject*> sortedNodes;
+  CollectNodesInTopologicalOrder(pSourcePin->GetParent(), sortedNodes).AssertSuccess();
+
+  // Map from output pin to local variable name
+  ezMap<const ezPin*, ezString> pinToVarName;
+  ezStringBuilder sLocalVars;
+
+  // Generate local variable for each node's outputs in topological order (sortedNodes needs to be reversed as the array starts at pSourcePin's node)
+  for (ezUInt32 i = sortedNodes.GetCount(); i-- > 0;)
+  {
+    const ezDocumentObject* pNode = sortedNodes[i];
+    const ezVisualShaderNodeDescriptor* pDesc = m_pTypeRegistry->GetDescriptorForType(pNode->GetType());
+    const NodeState& nodeState = m_Nodes[pNode];
+
+    auto outputPins = m_pNodeManager->GetOutputPins(pNode);
+    for (ezUInt32 pinIdx = 0; pinIdx < outputPins.GetCount(); ++pinIdx)
+    {
+      const ezPin* pOutPin = outputPins[pinIdx].Borrow();
+
+      // Skip pins that aren't connected within the subgraph
+      if (!m_pNodeManager->HasConnections(*pOutPin))
+        continue;
+
+      ezUInt8 effectiveDim = m_OutputPinDimensions[pOutPin];
+      // Generate the expression for this output pin, using local variables for inputs
+      ezStringBuilder sExpr = pDesc->m_OutputPins[pinIdx].m_sShaderCodeInline;
+
+      // Replace input pin placeholders with local variable names or values
+      auto inputPins = m_pNodeManager->GetInputPins(pNode);
+      for (ezInt32 inIdx = (ezInt32)inputPins.GetCount() - 1; inIdx >= 0; --inIdx)
+      {
+        ezStringBuilder sPinPlaceholder;
+        sPinPlaceholder.SetFormat("$in{0}", inIdx);
+
+        auto inConnections = m_pNodeManager->GetConnections(*inputPins[inIdx]);
+        if (inConnections.IsEmpty())
+        {
+          ezString sValue = GetInputPinDefaultValue(pNode, pDesc->m_InputPins[inIdx]);
+          sExpr.ReplaceAll(sPinPlaceholder, sValue);
+        }
+        else
+        {
+          // Use local variable from connected output pin
+          const ezPin* pConnectedPin = &inConnections[0]->GetSourcePin();
+          EZ_ASSERT_DEV(pinToVarName.Contains(pConnectedPin), "Topological sort should have processed this pin already");
+          sExpr.ReplaceAll(sPinPlaceholder, pinToVarName[pConnectedPin].GetData());
+        }
+      }
+
+      // Replace property placeholders
+      InsertPropertyValues(pNode, pDesc, sExpr).IgnoreResult();
+
+      // Generate local variable with descriptive name including node type
+      ezStringBuilder sVarName;
+      sVarName.SetFormat("_{0}_{1}_{2}", pDesc->m_sName, pOutPin->GetName(), nodeState.m_uiNodeId);
+      pinToVarName[pOutPin] = sVarName;
+
+      // Add local variable declaration with the computed type
+      sLocalVars.AppendFormat("  {0} {1} = {2};\n", DimensionToHlslType(effectiveDim), sVarName, sExpr);
+    }
+  }
+
+  // Get the final variable name for the source pin
+  EZ_ASSERT_DEV(pinToVarName.Contains(pSourcePin), "Topological sort should have processed the source pin");
+  const ezString& sFinalVar = pinToVarName[pSourcePin];
+
+  // Generate the complete helper function
+  out_sFunctionCall.SetFormat("_{0}_{1}()", pInputPin->GetName(), uiInputIndex);
+  out_sFunctionCode.SetFormat("float4 {0} {\n{1}  return ToFloat4Direction({2});\n}\n\n",
+    out_sFunctionCall, sLocalVars, sFinalVar);
 }
 
 ezStatus ezVisualShaderCodeGenerator::GatherAllNodes(const ezDocumentObject* pRootObj)
@@ -163,6 +492,9 @@ ezStatus ezVisualShaderCodeGenerator::GenerateVisualShader(const ezDocumentNodeM
   if (m_pMainNode == nullptr)
     return ezStatus("Visual Shader does not contain an output node");
 
+  // Compute effective output type dimensions for all output pins (needed for "auto" types and GUI)
+  ComputeOutputPinDimensions();
+
   EZ_SUCCEED_OR_RETURN(GenerateNode(m_pMainNode));
 
   // now also generate code for certain nodes, even if they have no connections
@@ -191,9 +523,13 @@ ezStatus ezVisualShaderCodeGenerator::GenerateVisualShader(const ezDocumentNodeM
   m_sFinalShaderCode.Append("[MATERIALPARAMETER]\n\n", m_sShaderMaterialParam, "\n");
   m_sFinalShaderCode.Append("[RENDERSTATE]\n\n", m_sShaderRenderState, "\n");
   m_sFinalShaderCode.Append("[MATERIALCONSTANTS]\n\n", sMaterialConstants, "\n");
-  m_sFinalShaderCode.Append("[VERTEXSHADER]\n\n", m_sShaderVertexDefines, "\n", m_sShaderVertex, "\n");
+
+  m_sFinalShaderCode.Append("[VERTEXSHADER]\n\n", m_sShaderVertexDefines, "\n", m_sShaderVertexIncludes, "\n");
+  m_sFinalShaderCode.Append(m_sShaderVertexBody, "\n");
+
   m_sFinalShaderCode.Append("[PIXELSHADER]\n\n", m_sShaderPixelDefines, "\n", m_sShaderPixelIncludes, "\n");
-  m_sFinalShaderCode.Append(m_sShaderPixelConstants, "\n", m_sShaderPixelSamplers, "\n", m_sShaderPixelBody, "\n");
+  m_sFinalShaderCode.Append(m_sShaderPixelConstants, "\n", m_sShaderPixelSamplers, "\n");
+  m_sFinalShaderCode.Append(m_sShaderPixelBody, "\n");
 
   for (auto it = m_Nodes.GetIterator(); it.IsValid(); ++it)
   {
@@ -223,47 +559,68 @@ ezStatus ezVisualShaderCodeGenerator::GenerateNode(const ezDocumentObject* pNode
 
   EZ_SUCCEED_OR_RETURN(GenerateInputPinCode(m_pNodeManager->GetInputPins(pNode)));
 
-  ezStringBuilder sConstantsCode, sPsBodyCode, sMaterialParamCode, sMaterialConstantsCode, sPixelSamplersCode, sVsBodyCode, sMaterialCB, sPermutations,
-    sRenderStates, sPixelDefines, sPixelIncludes, sVertexDefines;
+  ezStringBuilder sPixelConstantsCode, sPixelBody, sMaterialParamCode, sMaterialConstantsCode, sPixelSamplersCode, sMaterialCB, sPermutations, sRenderStates, sPixelDefines, sPixelIncludes, sVertexDefines, sVertexIncludes, sVertexBody;
 
-  sVsBodyCode = pDesc->m_sShaderCodeShaderShared;
+  // Pixel shader sections
   sPixelDefines = pDesc->m_sShaderCodeShaderShared;
+  sPixelDefines.Append(pDesc->m_sShaderCodePixelDefines);
+  sPixelIncludes = pDesc->m_sShaderCodePixelIncludes;
+  sPixelConstantsCode = pDesc->m_sShaderCodePixelConstants;
+  sPixelBody = pDesc->m_sShaderCodePixelBody;
+  sPixelSamplersCode = pDesc->m_sShaderCodePixelSamplers;
 
-  sConstantsCode = pDesc->m_sShaderCodePixelConstants;
-  sPsBodyCode = pDesc->m_sShaderCodePixelBody;
+  // Vertex shader sections
+  sVertexDefines = pDesc->m_sShaderCodeShaderShared;
+  sVertexDefines.Append(pDesc->m_sShaderCodeVertexDefines);
+  sVertexIncludes = pDesc->m_sShaderCodeVertexIncludes;
+  sVertexBody = pDesc->m_sShaderCodeVertexBody;
+
+  // Material and other sections
   sMaterialParamCode = pDesc->m_sShaderCodeMaterialParams;
   sMaterialConstantsCode = pDesc->m_sShaderCodeMaterialConstants;
-  sPixelSamplersCode = pDesc->m_sShaderCodePixelSamplers;
-  sVsBodyCode.Append(pDesc->m_sShaderCodeVertexShader);
   sMaterialCB = pDesc->m_sShaderCodeMaterialCB;
   sPermutations = pDesc->m_sShaderCodePermutations;
   sRenderStates = pDesc->m_sShaderCodeRenderState;
-  sPixelDefines.Append(pDesc->m_sShaderCodePixelDefines);
-  sPixelIncludes = pDesc->m_sShaderCodePixelIncludes;
 
-  EZ_SUCCEED_OR_RETURN(ReplaceInputPinsByCode(pNode, pDesc, sPsBodyCode, sPixelDefines));
-  EZ_SUCCEED_OR_RETURN(ReplaceInputPinsByCode(pNode, pDesc, sVsBodyCode, sVertexDefines));
+  // For the main node, use linearized code generation for both pixel and vertex body
+  if (pNode == m_pMainNode)
+  {
+    ezStringBuilder sPsHelperFunctions;
+    ezStringBuilder sVsHelperFunctions;
+    ReplaceMainNodeInputPins(pNode, pDesc, sPixelBody, sPixelDefines, sPsHelperFunctions);
+    ReplaceMainNodeInputPins(pNode, pDesc, sVertexBody, sVertexDefines, sVsHelperFunctions);
+
+    AppendStringIfUnique(m_sShaderPixelBody, sPsHelperFunctions);
+    AppendStringIfUnique(m_sShaderVertexBody, sVsHelperFunctions);
+  }
+  else
+  {
+    EZ_SUCCEED_OR_RETURN(ReplaceInputPinsByCode(pNode, pDesc, sPixelBody, sPixelDefines));
+    EZ_SUCCEED_OR_RETURN(ReplaceInputPinsByCode(pNode, pDesc, sVertexBody, sVertexDefines));
+  }
 
   EZ_SUCCEED_OR_RETURN(CheckPropertyValues(pNode, pDesc));
-  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sConstantsCode));
-  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sVsBodyCode));
-  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPsBodyCode));
+  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPixelConstantsCode));
+  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sVertexBody));
+  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPixelBody));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sMaterialParamCode));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sMaterialConstantsCode));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPixelDefines));
+  EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sVertexDefines));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sMaterialCB));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sPixelSamplersCode));
   EZ_SUCCEED_OR_RETURN(InsertPropertyValues(pNode, pDesc, sRenderStates));
 
   SetPinDefines(pNode, sPermutations);
   SetPinDefines(pNode, sRenderStates);
-  SetPinDefines(pNode, sVsBodyCode);
+  SetPinDefines(pNode, sVertexBody);
+  SetPinDefines(pNode, sVertexDefines);
   SetPinDefines(pNode, sMaterialParamCode);
   SetPinDefines(pNode, sMaterialConstantsCode);
   SetPinDefines(pNode, sPixelDefines);
   SetPinDefines(pNode, sPixelIncludes);
-  SetPinDefines(pNode, sPsBodyCode);
-  SetPinDefines(pNode, sConstantsCode);
+  SetPinDefines(pNode, sPixelBody);
+  SetPinDefines(pNode, sPixelConstantsCode);
   SetPinDefines(pNode, sPixelSamplersCode);
   SetPinDefines(pNode, sMaterialCB);
 
@@ -271,13 +628,14 @@ ezStatus ezVisualShaderCodeGenerator::GenerateNode(const ezDocumentObject* pNode
     AppendStringIfUnique(m_sShaderPermutations, sPermutations);
     AppendStringIfUnique(m_sShaderRenderState, sRenderStates);
     AppendStringIfUnique(m_sShaderVertexDefines, sVertexDefines);
-    AppendStringIfUnique(m_sShaderVertex, sVsBodyCode);
+    AppendStringIfUnique(m_sShaderVertexIncludes, sVertexIncludes);
     AppendStringIfUnique(m_sShaderMaterialParam, sMaterialParamCode);
     AppendStringIfUnique(m_sShaderMaterialConstants, sMaterialConstantsCode);
     AppendStringIfUnique(m_sShaderPixelDefines, sPixelDefines);
     AppendStringIfUnique(m_sShaderPixelIncludes, sPixelIncludes);
-    AppendStringIfUnique(m_sShaderPixelBody, sPsBodyCode);
-    AppendStringIfUnique(m_sShaderPixelConstants, sConstantsCode);
+    AppendStringIfUnique(m_sShaderPixelBody, sPixelBody);
+    AppendStringIfUnique(m_sShaderVertexBody, sVertexBody);
+    AppendStringIfUnique(m_sShaderPixelConstants, sPixelConstantsCode);
     AppendStringIfUnique(m_sShaderPixelSamplers, sPixelSamplersCode);
     AppendStringIfUnique(m_sShaderMaterialCB, sMaterialCB);
   }
@@ -337,6 +695,39 @@ ezStatus ezVisualShaderCodeGenerator::GenerateOutputPinCode(const ezDocumentObje
 
 
 
+void ezVisualShaderCodeGenerator::ReplaceMainNodeInputPins(const ezDocumentObject* pMainNode, const ezVisualShaderNodeDescriptor* pNodeDesc, ezStringBuilder& sInlineCode, ezStringBuilder& sCodeForPlacingDefines, ezStringBuilder& out_sHelperFunctions)
+{
+  out_sHelperFunctions.Clear();
+
+  auto inputPins = m_pNodeManager->GetInputPins(pMainNode);
+
+  for (ezInt32 i = (ezInt32)inputPins.GetCount() - 1; i >= 0; --i)
+  {
+    ezStringBuilder sPinPlaceholder;
+    sPinPlaceholder.SetFormat("$in{0}", i);
+
+    // Check if this shader section uses this placeholder
+    if (sInlineCode.FindSubString(sPinPlaceholder) == nullptr)
+      continue;
+
+    auto connections = m_pNodeManager->GetConnections(*inputPins[i]);
+    if (connections.IsEmpty())
+    {
+      ezString sValue = GetInputPinDefaultValue(pMainNode, pNodeDesc->m_InputPins[i], &sCodeForPlacingDefines);
+      sInlineCode.ReplaceAll(sPinPlaceholder, sValue);
+    }
+    else
+    {
+      // Generate the helper function for this input's subgraph
+      ezStringBuilder sHelperFunc, sFuncCall;
+      GenerateInputHelperFunction(inputPins[i].Borrow(), i, sHelperFunc, sFuncCall);
+
+      out_sHelperFunctions.Append(sHelperFunc);
+      sInlineCode.ReplaceAll(sPinPlaceholder, sFuncCall);
+    }
+  }
+}
+
 ezStatus ezVisualShaderCodeGenerator::ReplaceInputPinsByCode(
   const ezDocumentObject* pOwnerNode, const ezVisualShaderNodeDescriptor* pNodeDesc, ezStringBuilder& sInlineCode, ezStringBuilder& sCodeForPlacingDefines)
 {
@@ -353,22 +744,7 @@ ezStatus ezVisualShaderCodeGenerator::ReplaceInputPinsByCode(
     auto connections = m_pNodeManager->GetConnections(*inputPins[i]);
     if (connections.IsEmpty())
     {
-      if (pNodeDesc->m_InputPins[i].m_bExposeAsProperty)
-      {
-        ezVariant val = pOwnerNode->GetTypeAccessor().GetValue(pNodeDesc->m_InputPins[i].m_sName);
-        sValue = ToShaderString(val);
-      }
-      else
-      {
-        sValue = pNodeDesc->m_InputPins[i].m_sDefaultValue;
-
-        for (const auto& sDefine : pNodeDesc->m_InputPins[i].m_sDefinesWhenUsingDefaultValue)
-        {
-          sCodeForPlacingDefines.Append("#if !defined(", sDefine, ")\n");
-          sCodeForPlacingDefines.Append("  #define ", sDefine, "\n");
-          sCodeForPlacingDefines.Append("#endif\n");
-        }
-      }
+      sValue = GetInputPinDefaultValue(pOwnerNode, pNodeDesc->m_InputPins[i], &sCodeForPlacingDefines);
 
       if (sValue.IsEmpty())
       {
@@ -435,12 +811,12 @@ void ezVisualShaderCodeGenerator::SetPinDefines(const ezDocumentObject* pOwnerNo
   }
 }
 
-void ezVisualShaderCodeGenerator::AppendStringIfUnique(ezStringBuilder& inout_String, const char* szAppend)
+void ezVisualShaderCodeGenerator::AppendStringIfUnique(ezStringBuilder& inout_String, ezStringView sAppend)
 {
-  if (inout_String.FindSubString(szAppend) != nullptr)
+  if (sAppend.IsEmpty() || inout_String.FindSubString(sAppend) != nullptr)
     return;
 
-  inout_String.Append(szAppend);
+  inout_String.Append(sAppend);
 }
 
 ezStatus ezVisualShaderCodeGenerator::CheckPropertyValues(const ezDocumentObject* pNode, const ezVisualShaderNodeDescriptor* pDesc)

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.h
@@ -49,8 +49,25 @@ private:
   ezStatus GenerateOutputPinCode(const ezDocumentObject* pOwnerNode, const ezPin& pinSource);
 
   ezStatus ReplaceInputPinsByCode(const ezDocumentObject* pOwnerNode, const ezVisualShaderNodeDescriptor* pNodeDesc, ezStringBuilder& sInlineCode, ezStringBuilder& sCodeForPlacingDefines);
+  void ReplaceMainNodeInputPins(const ezDocumentObject* pMainNode, const ezVisualShaderNodeDescriptor* pNodeDesc, ezStringBuilder& sInlineCode, ezStringBuilder& sCodeForPlacingDefines, ezStringBuilder& out_sHelperFunctions);
   void SetPinDefines(const ezDocumentObject* pOwnerNode, ezStringBuilder& sInlineCode);
-  static void AppendStringIfUnique(ezStringBuilder& inout_String, const char* szAppend);
+  static void AppendStringIfUnique(ezStringBuilder& inout_String, ezStringView sAppend);
+
+  // Generates the transitive hull of nodes connected via input pins to pNode.
+  void CollectReachableNodes(const ezDocumentObject* pNode, ezHashSet<const ezDocumentObject*>& out_Nodes) const;
+
+  // Gets the value to use for an unconnected input pin (either from property or default value)
+  // Optionally appends defines to pDefinesOut when using a default value
+  ezString GetInputPinDefaultValue(const ezDocumentObject* pNode, const ezVisualShaderPinDescriptor& pinDesc, ezStringBuilder* pDefinesOut = nullptr);
+
+  // Collects all nodes that are connected to the given connection. out_Sorted is sorted with the first element being the source pin of pStartConnection.
+  ezResult CollectNodesInTopologicalOrder(const ezDocumentObject* pRootNode, ezDynamicArray<const ezDocumentObject*>& out_Sorted) const;
+
+  // Computes the effective output type dimension for all output pins and stores in m_OutputPinDimensions
+  void ComputeOutputPinDimensions();
+
+  // Generates a helper function for a main node input pin, returns the function code and the function name
+  void GenerateInputHelperFunction(const ezPin* pInputPin, ezUInt32 uiInputIndex, ezStringBuilder& out_sFunctionCode, ezStringBuilder& out_sFunctionCall);
 
   const ezDocumentObject* m_pMainNode;
   const ezVisualShaderTypeRegistry* m_pTypeRegistry;
@@ -58,6 +75,7 @@ private:
   const ezRTTI* m_pNodeBaseRtti;
   ezMap<const ezDocumentObject*, NodeState> m_Nodes;
   ezMap<const ezPin*, OutputPinState> m_OutputPins;
+  ezMap<const ezPin*, ezUInt8> m_OutputPinDimensions; // Effective output type dimension for each output pin (1-4 for float-float4)
   ezMap<ezString, ezString> m_UsedIdentifiers; // Maps identifier name to node type name
 
   ezStringBuilder m_sShaderPixelDefines;
@@ -66,7 +84,8 @@ private:
   ezStringBuilder m_sShaderPixelSamplers;
   ezStringBuilder m_sShaderPixelBody;
   ezStringBuilder m_sShaderVertexDefines;
-  ezStringBuilder m_sShaderVertex;
+  ezStringBuilder m_sShaderVertexIncludes;
+  ezStringBuilder m_sShaderVertexBody;
   ezStringBuilder m_sShaderMaterialParam;
   ezStringBuilder m_sShaderMaterialConstants;
   ezStringBuilder m_sShaderMaterialCB;

--- a/Data/Tools/ezEditor/VisualShader/Conversions.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Conversions.ddl
@@ -6,7 +6,7 @@ Node %Split
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     unsigned_int8 %Color { 200, 200, 200 }
     string %Tooltip { "Value that should be split into components.\nCan be of any type, missing components output zero." }
   }
@@ -69,7 +69,7 @@ Node %MergeFloat2
 
   OutputPin %result
   {
-      string %Type { "float" }
+      string %Type { "float2" }
       unsigned_int8 %Color { 200, 200, 200 }
       string %Inline { "float2(ToFloat1($in0), ToFloat1($in1))" }
       string %Tooltip { "The first component of each input is put into the respective component of the output." }
@@ -111,7 +111,7 @@ Node %MergeFloat3
 
   OutputPin %result
   {
-      string %Type { "float" }
+      string %Type { "float3" }
       unsigned_int8 %Color { 200, 200, 200 }
       string %Inline { "float3(ToFloat1($in0), ToFloat1($in1), ToFloat1($in2))" }
       string %Tooltip { "The first component of each input is put into the respective component of the output." }
@@ -161,7 +161,7 @@ Node %MergeFloat4
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "float4" }
     unsigned_int8 %Color { 200, 200, 200 }
     string %Inline { "float4(ToFloat1($in0), ToFloat1($in1), ToFloat1($in2), ToFloat1($in3))" }
     string %Tooltip { "The first component of each input is put into the respective component of the output." }

--- a/Data/Tools/ezEditor/VisualShader/Math.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Math.ddl
@@ -8,14 +8,14 @@ Node %Lerp
 
   InputPin %x
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   InputPin %y
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "1" }
   }
@@ -30,7 +30,7 @@ Node %Lerp
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     unsigned_int8 %Color { 200, 200, 200 }
     string %Inline { "lerp(ToBiggerType($in0, $in1), ToBiggerType($in1, $in0), ToFloat1($in2))" }
     string %Tooltip { "Linear interpolation between x and y according to factor." }
@@ -46,7 +46,7 @@ Node %Step
 
   InputPin %edge
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0.5" }
     string %Tooltip { "The value to compare with 'x'." }
@@ -54,7 +54,7 @@ Node %Step
 
   InputPin %x
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
     string %Tooltip { "The value to compare with 'edge'." }
@@ -62,7 +62,7 @@ Node %Step
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     unsigned_int8 %Color { 200, 200, 200 }
     string %Inline { "step(ToBiggerType($in0, $in1), ToBiggerType($in1, $in0))" }
     string %Tooltip { "Returns 0 when x is smaller than edge, 1 otherwise." }
@@ -78,28 +78,28 @@ Node %SmoothStep
 
   InputPin %edge0
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0.3" }
   }
 
   InputPin %edge1
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0.6" }
   }
 
   InputPin %x
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0.5" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     unsigned_int8 %Color { 200, 200, 200 }
     string %Inline { "smoothstep(ToBiggerType($in0, $in1), ToBiggerType($in1, $in0), ToBiggerType(ToBiggerType($in2, $in0)), $in1))" }
     string %Tooltip { "Returns 0 when x is smaller than edge0, 1 when x is larger than edge1 and the hermite interpoliation in between." }

--- a/Data/Tools/ezEditor/VisualShader/Math_Basic.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Math_Basic.ddl
@@ -7,21 +7,21 @@ Node %Add
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "(ToBiggerType($in0, $in1) + ToBiggerType($in1, $in0))" }
     string %Tooltip { "a + b" }
   }
@@ -36,21 +36,21 @@ Node %Subtract
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "(ToBiggerType($in0, $in1) - ToBiggerType($in1, $in0))" }
     string %Tooltip { "a - b" }
   }
@@ -65,21 +65,21 @@ Node %Multiply
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "1" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "1" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "(ToBiggerType($in0, $in1) * ToBiggerType($in1, $in0))" }
     string %Tooltip { "a * b (component-wise)" }
   }
@@ -94,21 +94,21 @@ Node %Divide
 
   InputPin %a
     {
-      string %Type { "float" }
+      string %Type { "auto" }
       bool %Expose { true }
       string %DefaultValue { "1" }
     }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "1" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "(ToBiggerType($in0, $in1) / ToBiggerType($in1, $in0))" }
     string %Tooltip { "a / b (component-wise)" }
   }
@@ -123,21 +123,21 @@ Node %Modulo
 
   InputPin %a
     {
-      string %Type { "float" }
+      string %Type { "auto" }
       bool %Expose { true }
       string %DefaultValue { "1" }
     }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "1" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "(ToBiggerType($in0, $in1) % ToBiggerType($in1, $in0))" }
     string %Tooltip { "a modulo b (component-wise)" }
   }
@@ -151,12 +151,12 @@ Node %Fraction
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "frac($in0)" }
     string %Tooltip { "The fractional part of the input (component-wise)." }
   }
@@ -170,12 +170,12 @@ Node %Abs
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "abs($in0)" }
     string %Tooltip { "The absolute value of the input (component-wise)." }
   }
@@ -189,12 +189,12 @@ Node %Sign
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "sign($in0)" }
     string %Tooltip { "Outputs the sign of the input (component-wise)." }
   }
@@ -208,12 +208,12 @@ Node %Sqrt
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "sqrt($in0)" }
     string %Tooltip { "The square root of the input (component-wise)." }
   }
@@ -227,13 +227,13 @@ Node %Negate
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %DefaultValue { "0" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "-$in0" }
     string %Tooltip { "Negated input value." }
   }

--- a/Data/Tools/ezEditor/VisualShader/Math_Clamping.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Math_Clamping.ddl
@@ -7,21 +7,21 @@ Node %Max
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "max(ToBiggerType($in0, $in1), ToBiggerType($in1, $in0))" }
     string %Tooltip { "The larger of the two input values (component-wise)." }
   }
@@ -36,21 +36,21 @@ Node %Min
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "min(ToBiggerType($in0, $in1), ToBiggerType($in1, $in0))" }
     string %Tooltip { "The smaller of the two input values (component-wise)." }
   }
@@ -64,12 +64,12 @@ Node %Saturate
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "saturate($in0)" }
     string %Tooltip { "Clamps the input to the range [0, 1] (component-wise)." }
   }
@@ -84,13 +84,13 @@ Node %Clamp
 
   InputPin %x
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "The value to clamp." }
   }
 
   InputPin %min
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "0" }
     string %Tooltip { "The minimum value to clamp against." }
@@ -98,7 +98,7 @@ Node %Clamp
 
   InputPin %max
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     bool %Expose { true }
     string %DefaultValue { "1" }
     string %Tooltip { "The maximum value to clamp against." }
@@ -106,7 +106,7 @@ Node %Clamp
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "clamp($in0, ToSameType($in1, $in0), ToSameType($in2, $in0))" }
     string %Tooltip { "All output values will be clamped to be between Min and Max." }
   }

--- a/Data/Tools/ezEditor/VisualShader/Math_Rounding.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Math_Rounding.ddl
@@ -6,12 +6,12 @@ Node %Floor
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "floor($in0)" }
     string %Tooltip { "The largest integer which is less than or equal to the input (component-wise)." }
   }
@@ -25,12 +25,12 @@ Node %Ceil
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "ceil($in0)" }
     string %Tooltip { "The smallest integer which is greater than or equal to the input (component-wise)." }
   }
@@ -44,12 +44,12 @@ Node %Round
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "round($in0)" }
     string %Tooltip { "Rounds the input to the closest integer value (component-wise)." }
   }
@@ -63,12 +63,12 @@ Node %Truncate
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "trunc($in0)" }
     string %Tooltip { "Removes the fractional part of the input without rounding (component-wise)." }
   }

--- a/Data/Tools/ezEditor/VisualShader/Math_Trigonometry.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Math_Trigonometry.ddl
@@ -6,13 +6,13 @@ Node %Sine
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "The angle value in Radians." }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "sin($in0)" }
     string %Tooltip { "The sine of the input (component-wise)." }
   }
@@ -26,13 +26,13 @@ Node %Cosine
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "The angle value in Radians." }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "cos($in0)" }
     string %Tooltip { "The cosine of the input (component-wise)." }
   }
@@ -46,13 +46,13 @@ Node %Exp
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "exp($in0)" }
     string %Tooltip { "The base-e exponential (component-wise)." }
   }
@@ -66,13 +66,13 @@ Node %Exp2
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "exp2($in0)" }
     string %Tooltip { "The base-2 exponential (component-wise)." }
   }
@@ -86,13 +86,13 @@ Node %Log
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "log($in0)" }
     string %Tooltip { "The base-e logarithm of a. (component-wise)." }
   }
@@ -106,13 +106,13 @@ Node %Log2
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "log2($in0)" }
     string %Tooltip { "The base-2 logarithm of a. (component-wise)." }
   }
@@ -126,13 +126,13 @@ Node %Log10
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "log10($in0)" }
     string %Tooltip { "The base-10 logarithm of a. (component-wise)." }
   }
@@ -147,7 +147,7 @@ Node %Pow
 
   InputPin %Base
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
     bool %Expose { true }
     string %DefaultValue { "1" }
@@ -155,7 +155,7 @@ Node %Pow
 
   InputPin %Exponent
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "" }
     bool %Expose { true }
     string %DefaultValue { "1" }
@@ -163,7 +163,7 @@ Node %Pow
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "pow(ToBiggerType($in0, $in1), ToBiggerType($in1, $in0))" }
     string %Tooltip { "Base raised to the power of Exponent. (component-wise)." }
   }

--- a/Data/Tools/ezEditor/VisualShader/Math_Vector.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Math_Vector.ddl
@@ -6,12 +6,12 @@ Node %Distance
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
@@ -30,7 +30,7 @@ Node %Length
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
   }
 
   OutputPin %result
@@ -49,13 +49,13 @@ Node %Dot
 
   InputPin %a
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %DefaultValue { "0" }
   }
 
   InputPin %b
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %DefaultValue { "0" }
   }
 
@@ -101,13 +101,13 @@ Node %Normalize
 
   InputPin %vector
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Tooltip { "A vector. Avoid zero vectors to prevent NaN's." }
   }
 
   OutputPin %result
   {
-    string %Type { "float" }
+    string %Type { "auto" }
     string %Inline { "normalize($in0)" }
     string %Tooltip { "The normalized vector." }
   }

--- a/Data/Tools/ezEditor/VisualShader/Output_Decal.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Output_Decal.ddl
@@ -10,15 +10,18 @@ Node %DecalOutput
   string %CheckPermutations {""}
 
   string %CodeRenderStates { "#include <Shaders/Decals/DecalState.h>" }
-  string %CodeVertexShader { "
 
+  string %CodeVertexDefines { "" }
+
+  string %CodeVertexIncludes { "
 #include <Shaders/Decals/DecalVertexShader.h>
+" }
 
+  string %CodeVertexBody { "
 VS_OUT main(VS_IN Input)
 {
   return FillVertexData(Input);
 }
-
 " }
 
   string %CodeMaterialParams { "" }

--- a/Data/Tools/ezEditor/VisualShader/Output_Material.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Output_Material.ddl
@@ -32,8 +32,8 @@ VERTEX_SKINNING=FALSE
 "}
 
   string %CodeRenderStates { "#include <Shaders/Materials/MaterialState.h>" }
-  string %CodeVertexShader { "
 
+  string %CodeVertexDefines { "
 #if VERTEX_SKINNING
   #define USE_SKINNING
 #endif
@@ -49,7 +49,6 @@ VERTEX_SKINNING=FALSE
 #if !defined(USE_TANGENT)
   #define USE_TANGENT
 #endif
-
 #endif
 
 #if INPUT_PIN_10_CONNECTED
@@ -59,10 +58,14 @@ VERTEX_SKINNING=FALSE
 #if INPUT_PIN_11_CONNECTED
   #define USE_WORLD_POSITION_OFFSET
 #endif
+" }
 
+  string %CodeVertexIncludes { "
 #include <Shaders/Materials/MaterialVertexShader.h>
 #include <Shaders/Common/VisualShaderUtil.h>
+" }
 
+  string %CodeVertexBody { "
 VS_OUT main(VS_IN Input)
 {
   return FillVertexData(Input);
@@ -81,7 +84,6 @@ float3 GetWorldPositionOffset(ezPerInstanceData data, float3 worldPosition)
   return ToFloat3($in11);
 }
 #endif
-
 " }
 
   string %CodeMaterialParams { "
@@ -146,7 +148,6 @@ float MaskThreshold @Default($prop0);
 " }
 
   string %CodePixelBody { "
-  
 float3 GetBaseColor()
 {
   return ToColor3($in0);

--- a/Data/Tools/ezEditor/VisualShader/Output_QuadParticle.ddl
+++ b/Data/Tools/ezEditor/VisualShader/Output_QuadParticle.ddl
@@ -35,9 +35,13 @@ PARTICLE_LIGHTING_MODE=PARTICLE_LIGHTING_MODE_FULLBRIGHT
 #endif
 " }
 
-  string %CodeVertexShader { "
+  string %CodeVertexDefines { "" }
+
+  string %CodeVertexIncludes { "
 #include <Shaders/Particles/QuadParticleVertexShader.h>
 " }
+
+  string %CodeVertexBody { "" }
 
   string %CodeMaterialParams { "" }
 


### PR DESCRIPTION
## Code Generation
* Fix code explosion from recursive inlining - Replaced recursive inline expansion with linearized code generation using topological sorting. Main node inputs now generate helper functions with local variables instead of inlining expressions repeatedly. Output is now almost readable:
<img width="1414" height="950" alt="image" src="https://github.com/user-attachments/assets/7fcf3e79-193d-43e5-8d14-86d0822de0f4" />

## Type System
* Add "auto" type support - Pins can now use Type { "auto" } to dynamically compute their output type dimension from the maximum of their connected inputs. This prevents unnecessary type casts and allows HLSL code to be generated that has the minimum required number of components.
* Input pins also support "auto" type (Add, Subtract, Multiply, Min, Max, Lerp, etc.). This allows anything to be stuck in there. The gui always asumes this is a float for the default value logic because that's what the type was set to previously for all actually 'auto' types.
* Fix MergeFloat2/3/4 output types - Changed output types from float to the correct float2/float3/float4.

## DDL Structure
* Separate vertex/pixel shader sections in DDL - Split CodeVertexShader into CodeVertexDefines, CodeVertexIncludes, and CodeVertexBody for proper handling of vertex shader sections (consistent with pixel shader organization).


