### PR TITLE
Linux crash dump support and EditorProcessor crash handling

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -86,7 +86,8 @@ public:
     WaitingForConnection,
     Ready,
     Processing,
-    ReportResult
+    ReportResult,
+    Crashed
   };
 
 public:
@@ -94,13 +95,17 @@ public:
   ~ezEditorProcessorProcess();
 
   ezUInt32 m_uiProcessorID;
-  ezTime m_ProcessingStartTime;
+  ezTime m_ProcessingStartTime; // When a work item was started.
   ezThreadSignal* m_pNewWorkSignal = nullptr;
 
   bool Tick(bool bStartNewWork); // returns false, if all processing is done, otherwise call Tick again.
 
+  /// \brief Called by the worker thread to restart a crashed process.
+  void RequestRestart();
+
   bool IsConnected() const;
   bool IsRunning() const;
+  bool IsCrashed() const;
   ezOsProcessID GetProcessId() const;
   bool HasProcessCrashed();
   void HandleHashMissmatch();
@@ -121,6 +126,7 @@ private:
   ezEditorProcessCommunicationChannel* m_pIPC;
   bool m_bProcessShouldBeRunning = false;
   bool m_bIsIdle = false;
+  ezOsProcessID m_CurrentProcessID = {};
 
   // New asset to process
   ezUuid m_AssetGuid;
@@ -179,6 +185,11 @@ public:
   /// \param uiProcessIndex The index of the process. Must be smaller than GetProcessCount.
   ezEditorProcessorState GetProcessState(ezUInt32 uiProcessIndex) const;
 
+  /// \brief Requests a restart of a crashed processor.
+  /// This is safe to call from any thread. The restart will be handled by the worker thread.
+  /// \param uiProcessIndex The index of the crashed process to restart. Must be smaller than GetProcessCount.
+  void RequestRestartProcess(ezUInt32 uiProcessIndex);
+
   void AddLogWriter(ezLoggingEvent::Handler handler);
   void RemoveLogWriter(ezLoggingEvent::Handler handler);
   void UpdateProcessStates();
@@ -207,6 +218,7 @@ private:
   mutable ezMutex m_ProcessorMutex;
   std::atomic<ProcessorState> m_ProcessorState = ProcessorState::Stopped;
   ezDynamicArray<ezEditorProcessorState> m_EditorProcessorStates;
+  ezDynamicArray<ezAtomicBool> m_RestartRequests; ///< Set by main thread, read by worker thread
 
   // Data owned by the process thread.
   ezDynamicArray<ezEditorProcessorProcess> m_Processes;

--- a/Code/Editor/EditorFramework/Assets/AssetProcessor.h
+++ b/Code/Editor/EditorFramework/Assets/AssetProcessor.h
@@ -95,7 +95,7 @@ public:
   ~ezEditorProcessorProcess();
 
   ezUInt32 m_uiProcessorID;
-  ezTime m_ProcessingStartTime; // When a work item was started.
+  ezTime m_ProcessingStartTime;  // When a work item was started.
   ezThreadSignal* m_pNewWorkSignal = nullptr;
 
   bool Tick(bool bStartNewWork); // returns false, if all processing is done, otherwise call Tick again.

--- a/Code/Editor/EditorFramework/Assets/Declarations.h
+++ b/Code/Editor/EditorFramework/Assets/Declarations.h
@@ -185,7 +185,7 @@ struct ezEditorProcessorState
 {
   bool operator==(const ezEditorProcessorState& rhs)
   {
-    return m_uiProcessID == rhs.m_uiProcessID && m_bConnected == rhs.m_bConnected && m_bRunning == rhs.m_bRunning;
+    return m_uiProcessID == rhs.m_uiProcessID && m_bConnected == rhs.m_bConnected && m_bRunning == rhs.m_bRunning && m_bCrashed == rhs.m_bCrashed;
   }
   bool operator!=(const ezEditorProcessorState& rhs)
   {
@@ -195,4 +195,5 @@ struct ezEditorProcessorState
   ezOsProcessID m_uiProcessID = 0;
   bool m_bConnected = false; ///< The IPC pipe to the process is established.
   bool m_bRunning = false;   ///< The process is currently running working on an asset.
+  bool m_bCrashed = false;   ///< The process has crashed.
 };

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -174,6 +174,16 @@ ezEditorProcessorState ezAssetProcessor::GetProcessState(ezUInt32 uiProcessIndex
   return {};
 }
 
+void ezAssetProcessor::RequestRestartProcess(ezUInt32 uiProcessIndex)
+{
+  EZ_LOCK(m_ProcessorMutex);
+  if (uiProcessIndex < m_RestartRequests.GetCount())
+  {
+    m_RestartRequests[uiProcessIndex].Set(true);
+    m_NewWorkSignal.RaiseSignal();
+  }
+}
+
 void ezAssetProcessor::AddLogWriter(ezLoggingEvent::Handler handler)
 {
   m_CuratorLog.AddLogWriter(handler);
@@ -194,6 +204,7 @@ void ezAssetProcessor::UpdateProcessStates()
       ezEditorProcessorState state;
       state.m_bConnected = m_Processes[i].IsConnected();
       state.m_bRunning = m_Processes[i].IsRunning();
+      state.m_bCrashed = m_Processes[i].IsCrashed();
       state.m_uiProcessID = m_Processes[i].GetProcessId();
 
       if (m_EditorProcessorStates[i] != state)
@@ -214,25 +225,36 @@ void ezAssetProcessor::UpdateProcessStates()
 
 void ezAssetProcessor::Run()
 {
+  QEventLoop loop;
   while (m_ProcessorState == ProcessorState::Running)
   {
+    loop.processEvents(QEventLoop::AllEvents);
     if (m_iPauseProcessing == 0)
     {
       EZ_PROFILE_SCOPE("ezAssetProcessor::Run");
+
+      // Check for restart requests
+      for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
+      {
+        if (m_RestartRequests[i].TestAndSet(true, false))
+        {
+          m_Processes[i].RequestRestart();
+        }
+      }
+
       for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
       {
         m_Processes[i].Tick(true);
       }
       UpdateProcessStates();
-
-      m_NewWorkSignal.WaitForSignal(ezTime::MakeFromSeconds(1));
     }
+    m_NewWorkSignal.WaitForSignal(ezTime::MakeFromSeconds(1));
   }
 
   while (true)
   {
     bool bAnyRunning = false;
-
+    loop.processEvents(QEventLoop::AllEvents);
     for (ezUInt32 i = 0; i < m_Processes.GetCount(); i++)
     {
       if (m_bForceStop)
@@ -331,6 +353,7 @@ ezResult ezEditorProcessorProcess::StartProcess()
   {
     return EZ_FAILURE;
   }
+  m_CurrentProcessID = m_pIPC->GetProcessId();
   return EZ_SUCCESS;
 }
 
@@ -480,6 +503,16 @@ void ezEditorProcessorProcess::OnProcessCrashed(ezStringView message)
     { m_LogEntries.PushBack(std::move(ref_entry)); });
   ezLog::Error(&logger, message);
   ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, message);
+  ezLog::Error("EditorProcessor with pid '{}' crashed. Right-click on the crashed instance in the curator panel to go to the crashdumps.", m_CurrentProcessID);
+}
+
+void ezEditorProcessorProcess::RequestRestart()
+{
+  if (m_State == State::Crashed)
+  {
+    ezLog::Info(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Restarting crashed processor {}", m_uiProcessorID);
+    m_State = State::LookingForWork;
+  }
 }
 
 bool ezEditorProcessorProcess::IsConnected() const
@@ -492,18 +525,19 @@ bool ezEditorProcessorProcess::IsRunning() const
   return m_State == State::Processing;
 }
 
+bool ezEditorProcessorProcess::IsCrashed() const
+{
+  return m_State == State::Crashed;
+}
+
 ezOsProcessID ezEditorProcessorProcess::GetProcessId() const
 {
-  if (m_pIPC)
-  {
-    return m_pIPC->GetProcessId();
-  }
-  return {};
+  return m_CurrentProcessID;
 }
 
 bool ezEditorProcessorProcess::HasProcessCrashed()
 {
-  return m_pIPC->IsClientAlive();
+  return !m_pIPC->IsClientAlive();
 }
 
 void ezEditorProcessorProcess::HandleHashMissmatch()
@@ -600,6 +634,7 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
         {
           return false; // don't call later
         }
+        m_ProcessingStartTime = ezTime::MakeZero();
         // Clear asset to process
         m_AssetGuid = {};
         m_AssetPath.Clear();
@@ -754,21 +789,28 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
       break;
       case State::ReportResult:
       {
+        const bool bProcessCrashed = !m_pIPC->IsClientAlive();
+
         if (!m_MissmatchTransformDependencies.IsEmpty())
         {
           HandleHashMissmatch();
         }
 
-        // Fire progress event for processing finished
+        // Fire progress event only if we actually started processing.
+        const bool bDidStartWork = !m_ProcessingStartTime.IsZero();
+        if (bDidStartWork)
         {
+          // The actual start times are only available if we receive a response message. If we crash, fall back to the range of [m_ProcessingStartTime, now()] as an estimate of the work time.
+          ezTime processingEndTime = ezTime::Now();
+
           ezAssetProcessorProgressEvent e;
           e.m_Type = ezAssetProcessorProgressEvent::Type::ProcessingFinished;
           e.m_uiProcessorID = m_uiProcessorID;
           e.m_AssetGuid = m_AssetGuid;
           e.m_sAssetPath = m_AssetPath.GetDataDirRelativePath();
-          e.m_StartTime = m_StartedProcessing;
-          e.m_TransformStartTime = m_StartedTransform;
-          e.m_EndTime = m_FinishedProcessing;
+          e.m_StartTime = bProcessCrashed ? m_ProcessingStartTime : m_StartedProcessing;
+          e.m_TransformStartTime = bProcessCrashed ? m_ProcessingStartTime : m_StartedTransform;
+          e.m_EndTime = bProcessCrashed ? processingEndTime : m_FinishedProcessing;
           e.m_Result = m_Status;
           ezAssetProcessor::GetSingleton()->m_ProgressEvents.Broadcast(e);
         }
@@ -790,7 +832,14 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
           {
             ezAssetCurator::GetSingleton()->UpdateAssetTransformLog(m_AssetGuid, m_LogEntries);
             ezAssetCurator::GetSingleton()->UpdateAssetTransformState(m_AssetGuid, ezAssetInfo::TransformState::TransformError);
-            ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Failed '{0}'", m_AssetPath.GetDataDirRelativePath());
+            if (bProcessCrashed)
+            {
+              ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Failed '{0}' (process crashed)", m_AssetPath.GetDataDirRelativePath());
+            }
+            else
+            {
+              ezLog::Error(&ezAssetProcessor::GetSingleton()->m_CuratorLog, "Failed '{0}'", m_AssetPath.GetDataDirRelativePath());
+            }
           }
         }
 
@@ -799,7 +848,19 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
           ezAssetCurator::GetSingleton()->m_Updating.Remove(m_AssetGuid);
         }
 
-        m_State = State::LookingForWork;
+        if (bProcessCrashed)
+        {
+          m_State = State::Crashed;
+        }
+        else
+        {
+          m_State = State::LookingForWork;
+        }
+      }
+      break;
+      case State::Crashed:
+      {
+          return false;
       }
       break;
     }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetProcessor.cpp
@@ -101,6 +101,7 @@ void ezAssetProcessor::StartProcessor()
   const ezUInt32 uiWorkerCount = ezMath::Min<ezUInt32>(ezTaskSystem::GetWorkerThreadCount(ezWorkerThreadType::LongTasks), pPreferences->m_uiMaxAssetProcessors);
   m_Processes.SetCount(uiWorkerCount);
   m_EditorProcessorStates.SetCount(uiWorkerCount);
+  m_RestartRequests.SetCount(uiWorkerCount);
 
   for (ezUInt32 idx = 0; idx < uiWorkerCount; ++idx)
   {
@@ -860,7 +861,7 @@ bool ezEditorProcessorProcess::Tick(bool bStartNewWork)
       break;
       case State::Crashed:
       {
-          return false;
+        return false;
       }
       break;
     }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/AssetProcessorProgressWidget.moc.h
@@ -94,8 +94,8 @@ private:
 
   static constexpr int s_iRowHeight = 30;
   static constexpr int s_iRowSpacing = 5;
-  static constexpr int s_iLeftMargin = 90;
-  static constexpr int s_iIndicatorSize = 10;
+  static constexpr int s_iLeftMargin = 100;
+  static constexpr int s_iIndicatorSize = 20;
   static constexpr int s_iTopMargin = 0;
 
 private Q_SLOTS:
@@ -131,9 +131,11 @@ private:
 
   // Display and interaction settings
   EditState m_EditState = EditState::None;
+
   ezTime m_TimelineLength = ezTime::MakeFromMinutes(1); // Multiple of 1min, resize when current time exceeds this.
   double m_fSceneTranslationX = 0;                      // Scene horizontal pan offset (in seconds)
   QPointF m_SceneToPixelScale = QPointF(20, 1);
+  QPoint m_StartMousePos = {0, 0};
   QPoint m_LastMousePos = {0, 0};
 
   // Cache for asset names so we don't have to store the name in ProcessorTask and also don't SPAM the ezAssetCurator.

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -390,9 +390,7 @@ void ezQtAssetProcessorProgressWidget::mouseReleaseEvent(QMouseEvent* e)
   {
     QMenu menu;
     menu.addAction("Open Document", this, [&]()
-    {
-      ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sAssetPath);
-    });
+      { ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sAssetPath); });
     menu.exec(e->globalPosition().toPoint());
   }
   else if (e->pos().x() < s_iLeftMargin && uiProcessorID != ezInvalidIndex)
@@ -402,15 +400,12 @@ void ezQtAssetProcessorProgressWidget::mouseReleaseEvent(QMouseEvent* e)
 
     QMenu menu;
     menu.addAction("Restart Process", this, [uiProcessorID]()
-    {
-      ezAssetProcessor::GetSingleton()->RequestRestartProcess(uiProcessorID);
-    });
+      { ezAssetProcessor::GetSingleton()->RequestRestartProcess(uiProcessorID); });
     menu.addAction("Open Crash Dump Location", this, []()
-    {
+      {
       ezStringBuilder sCrashDumpFolder = ezApplicationServices::GetSingleton()->GetApplicationUserDataFolder();
       sCrashDumpFolder.AppendPath("CrashDumps");
-      QDesktopServices::openUrl(QUrl::fromLocalFile(ezMakeQString(sCrashDumpFolder)));
-    });
+      QDesktopServices::openUrl(QUrl::fromLocalFile(ezMakeQString(sCrashDumpFolder))); });
     menu.exec(e->globalPosition().toPoint());
   }
 }

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetProcessorProgressWidget.cpp
@@ -7,11 +7,14 @@
 #include <Foundation/Time/Stopwatch.h>
 #include <GuiFoundation/Widgets/GridBarWidget.moc.h>
 #include <GuiFoundation/Widgets/WidgetUtils.h>
+#include <QDesktopServices>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QTimer>
 #include <QToolTip>
 #include <QWheelEvent>
+#include <ToolsFoundation/Application/ApplicationServices.h>
 
 ///////////////////////////////////////////
 // ezQtAssetProcessorProgressWidget::HistoryState
@@ -314,6 +317,7 @@ void ezQtAssetProcessorProgressWidget::paintEvent(QPaintEvent* event)
 void ezQtAssetProcessorProgressWidget::mousePressEvent(QMouseEvent* e)
 {
   QWidget::mousePressEvent(e);
+  m_StartMousePos = e->pos();
   m_LastMousePos = e->pos();
 
   if (m_EditState != EditState::None)
@@ -353,13 +357,61 @@ void ezQtAssetProcessorProgressWidget::mouseReleaseEvent(QMouseEvent* e)
 {
   QWidget::mouseReleaseEvent(e);
 
-  if (e->button() == Qt::RightButton)
+  if (e->button() != Qt::RightButton)
+    return;
+
+  if (m_EditState == EditState::Panning)
   {
-    if (m_EditState == EditState::Panning)
+    m_AssetNameCache.Clear();
+    m_EditState = EditState::None;
+  }
+
+  // Create Context menu
+  if (m_StartMousePos != m_LastMousePos)
+    return;
+
+  ezUInt32 uiProcessorID = 0;
+  ezStringBuilder sAssetPath;
+  ezEditorProcessorState state;
+  {
+    EZ_LOCK(m_pHistoryState->m_HistoryMutex);
+    const ProcessorTask* pTask = FindTaskAtPosition(e->pos(), uiProcessorID);
+    if (pTask)
     {
-      m_AssetNameCache.Clear();
-      m_EditState = EditState::None;
+      sAssetPath = GetAssetPath(pTask->m_AssetGuid);
     }
+    if (uiProcessorID != ezInvalidIndex)
+    {
+      state = m_pHistoryState->m_ProcessStates[uiProcessorID];
+    }
+  }
+
+  if (!sAssetPath.IsEmpty())
+  {
+    QMenu menu;
+    menu.addAction("Open Document", this, [&]()
+    {
+      ezQtEditorApp::GetSingleton()->OpenDocumentQueued(sAssetPath);
+    });
+    menu.exec(e->globalPosition().toPoint());
+  }
+  else if (e->pos().x() < s_iLeftMargin && uiProcessorID != ezInvalidIndex)
+  {
+    if (!state.m_bCrashed)
+      return;
+
+    QMenu menu;
+    menu.addAction("Restart Process", this, [uiProcessorID]()
+    {
+      ezAssetProcessor::GetSingleton()->RequestRestartProcess(uiProcessorID);
+    });
+    menu.addAction("Open Crash Dump Location", this, []()
+    {
+      ezStringBuilder sCrashDumpFolder = ezApplicationServices::GetSingleton()->GetApplicationUserDataFolder();
+      sCrashDumpFolder.AppendPath("CrashDumps");
+      QDesktopServices::openUrl(QUrl::fromLocalFile(ezMakeQString(sCrashDumpFolder)));
+    });
+    menu.exec(e->globalPosition().toPoint());
   }
 }
 
@@ -631,7 +683,11 @@ void ezQtAssetProcessorProgressWidget::ShowTooltip(QMouseEvent* e)
   {
     ezEditorProcessorState state = m_pHistoryState->m_ProcessStates[uiProcessorID];
     ezStringBuilder sTooltip;
-    sTooltip.SetFormat("ezEditorProcessor {}\nProcessID: {}\nConnected: {}\nRunning: {}", uiProcessorID, state.m_uiProcessID, state.m_bConnected, state.m_bRunning);
+    sTooltip.SetFormat("ezEditorProcessor {}\nProcessID: {}\nConnected: {}\nRunning: {}\n", uiProcessorID, state.m_uiProcessID, state.m_bConnected, state.m_bRunning);
+    if (state.m_bCrashed)
+    {
+      sTooltip.AppendFormat("Process has crashed!");
+    }
     QToolTip::showText(e->globalPosition().toPoint(), ezMakeQString(sTooltip), this);
     return;
   }
@@ -729,19 +785,24 @@ void ezQtAssetProcessorProgressWidget::DrawProcessorRow(QPainter& painter, ezUIn
   // Draw processor label background
   painter.fillRect(0, y, s_iLeftMargin - 5, s_iRowHeight, palette().color(QPalette::Window));
 
-  // Draw state indicator
+  // Draw state indicator icon
   {
     const int indicatorX = 5;
-    const int indicatorY = y + (s_iRowHeight - 10) / 2;
-    QColor indicatorColor = palette().color(QPalette::Mid);
-    if (state.m_bConnected)
+    const int indicatorY = y + (s_iRowHeight - s_iIndicatorSize) / 2;
+    const QRect iconRect(indicatorX, indicatorY, s_iIndicatorSize, s_iIndicatorSize);
+
+    const char* szIconPath = ":/EditorFramework/Icons/AssetProcessingForceStop.svg"; // Not connected
+    if (state.m_bCrashed)
     {
-      indicatorColor = state.m_bRunning ? ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Green)) : ezToQtColor(ezColorScheme::DarkUI(ezColorScheme::Yellow));
+      szIconPath = ":/EditorFramework/Icons/AssetFailedTransform.svg";               // Crashed
     }
-    painter.setBrush(indicatorColor);
-    painter.setPen(indicatorColor.darker(150));
-    painter.drawEllipse(indicatorX, indicatorY, s_iIndicatorSize, s_iIndicatorSize);
-    painter.setBrush(Qt::NoBrush);
+    else if (state.m_bConnected)
+    {
+      szIconPath = state.m_bRunning
+                     ? ":/EditorFramework/Icons/AssetProcessingStart.svg"  // Running
+                     : ":/EditorFramework/Icons/AssetProcessingPause.svg"; // Not running
+    }
+    ezQtUiServices::GetSingleton()->GetCachedIconResource(szIconPath).paint(&painter, iconRect, Qt::AlignCenter);
   }
 
   // Draw processor label

--- a/Code/Engine/Foundation/Math/Implementation/Constants_inl.h
+++ b/Code/Engine/Foundation/Math/Implementation/Constants_inl.h
@@ -331,7 +331,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.0000000000001;  
+      return (TYPE)0.000000000001;
     }
     else
     {
@@ -347,7 +347,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.000000000001;  
+      return (TYPE)0.00000000001;
     }
     else
     {
@@ -363,7 +363,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.00000000001;  
+      return (TYPE)0.0000000001;
     }
     else
     {
@@ -380,7 +380,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.0000000001;  
+      return (TYPE)0.000000001;
     }
     else
     {
@@ -397,7 +397,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.000000001;  
+      return (TYPE)0.00000001;
     }
     else
     {
@@ -414,7 +414,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.00000001; 
+      return (TYPE)0.0000001;
     }
     else
     {
@@ -430,7 +430,7 @@ namespace ezMath
     }
     else if constexpr (std::is_same_v<TYPE, double>)
     {
-      return (TYPE)0.0000001; 
+      return (TYPE)0.000001;
     }
     else
     {

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -146,7 +146,7 @@ public:
 
   /// \brief Returns, whether the squared length of this vector is very close to 1 within the given epsilon
   EZ_DECLARE_IF_FLOAT_TYPE
-  bool IsNormalized(Type fEpsilon = ezMath::HugeEpsilon<Type>()) const; // [tested]
+  bool IsNormalized(Type fEpsilon = ezMath::SqrtEpsilon<Type>()) const; // [tested]
 
   /// \brief Returns true, if any of x, y or z is NaN
   bool IsNaN() const; // [tested]

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -146,7 +146,7 @@ public:
 
   /// \brief Returns, whether the squared length of this vector is very close to 1 within the given epsilon
   EZ_DECLARE_IF_FLOAT_TYPE
-  bool IsNormalized(Type fEpsilon = ezMath::HugeEpsilon<float>()) const; // [tested]
+  bool IsNormalized(Type fEpsilon = ezMath::HugeEpsilon<Type>()) const; // [tested]
 
   /// \brief Returns true, if any of x, y or z is NaN
   bool IsNaN() const; // [tested]

--- a/Code/Engine/Foundation/Math/Vec3.h
+++ b/Code/Engine/Foundation/Math/Vec3.h
@@ -146,7 +146,7 @@ public:
 
   /// \brief Returns, whether the squared length of this vector is very close to 1 within the given epsilon
   EZ_DECLARE_IF_FLOAT_TYPE
-  bool IsNormalized(Type fEpsilon = ezMath::SqrtEpsilon<Type>()) const; // [tested]
+  bool IsNormalized(Type fEpsilon = ezMath::HugeEpsilon<float>()) const; // [tested]
 
   /// \brief Returns true, if any of x, y or z is NaN
   bool IsNaN() const; // [tested]

--- a/Code/Engine/Foundation/Platform/Linux/Features_Platform.h
+++ b/Code/Engine/Foundation/Platform/Linux/Features_Platform.h
@@ -95,3 +95,7 @@
 #else
 #  error "Unknown architecture."
 #endif
+
+/// Crash dumps are supported on Linux.
+#undef EZ_SUPPORTS_CRASH_DUMPS
+#define EZ_SUPPORTS_CRASH_DUMPS EZ_ON

--- a/Code/Engine/Foundation/Platform/Linux/MiniDumpUtils_Linux.cpp
+++ b/Code/Engine/Foundation/Platform/Linux/MiniDumpUtils_Linux.cpp
@@ -2,6 +2,156 @@
 
 #if EZ_ENABLED(EZ_PLATFORM_LINUX)
 
-#  include <Foundation/Platform/Posix/MiniDumpUtils_Posix.h>
+#  include <Foundation/IO/OSFile.h>
+#  include <Foundation/Strings/StringBuilder.h>
+#  include <Foundation/System/MiniDumpUtils.h>
+#  include <Foundation/System/Process.h>
+#  include <Foundation/System/ProcessGroup.h>
+#  include <Foundation/Utilities/CommandLineOptions.h>
+
+#  include <sys/wait.h>
+#  include <unistd.h>
+
+ezCommandLineOptionBool opt_FullCrashDumps("app", "-fullcrashdumps", "If enabled, crash dumps will contain the full memory image.", false);
+
+ezStatus ezMiniDumpUtils::WriteExternalProcessMiniDump(ezStringView sDumpFile, ezUInt32 uiProcessID, ezDumpType dumpTypeOverride)
+{
+  // Create the output directory if needed
+  {
+    ezStringBuilder folder = sDumpFile;
+    folder.PathParentDirectory();
+    if (ezOSFile::CreateDirectoryStructure(folder).Failed())
+      return ezStatus("Failed to create output directory structure.");
+  }
+
+  // gcore outputs to <dumpfile>.<pid> format, so we need to handle the filename
+  ezStringBuilder sCoreName = sDumpFile;
+  sCoreName.RemoveFileExtension();
+
+  // Run gcore to generate the core dump
+  // gcore -o <output_prefix> <pid>
+  ezProcessOptions procOpt;
+  procOpt.m_bHideConsoleWindow = true;
+  procOpt.m_sProcess = "gcore";
+  procOpt.m_Arguments.PushBack("-o");
+  procOpt.m_Arguments.PushBack(sCoreName);
+  procOpt.AddArgument("{}", uiProcessID);
+
+  ezInt32 iExitCode = -1;
+  if (ezProcess::Execute(procOpt, &iExitCode).Failed())
+  {
+    return ezStatus("gcore not found. Install gdb package to enable crash dump support.");
+  }
+
+  if (iExitCode != 0)
+  {
+    return ezStatus(ezFmt("gcore failed with exit code {}", iExitCode));
+  }
+
+  // gcore creates file as <prefix>.<pid>, rename to requested name
+  ezStringBuilder sGcoreOutput;
+  sGcoreOutput.SetFormat("{}.{}", sCoreName, uiProcessID);
+
+  if (ezOSFile::ExistsFile(sGcoreOutput))
+  {
+    if (sGcoreOutput != sDumpFile)
+    {
+      ezOSFile::MoveFileOrDirectory(sGcoreOutput, sDumpFile).IgnoreResult();
+    }
+  }
+
+  return EZ_SUCCESS;
+}
+
+ezStatus ezMiniDumpUtils::WriteOwnProcessMiniDump(ezStringView sDumpFile, void* pOsSpecificData, ezDumpType dumpTypeOverride)
+{
+  // Writing a dump of our own process is tricky because we're potentially in a crashed state.
+  // The preferred approach is LaunchMiniDumpTool. This function is a fallback.
+
+  // Create the output directory if needed
+  {
+    ezStringBuilder folder = sDumpFile;
+    folder.PathParentDirectory();
+    if (ezOSFile::CreateDirectoryStructure(folder).Failed())
+      return ezStatus("Failed to create output directory structure.");
+  }
+
+  pid_t myPid = getpid();
+
+  // Fork a child to run gcore on us
+  pid_t childPid = fork();
+  if (childPid == 0)
+  {
+    // Child process - run gcore on parent
+    ezStringBuilder sCoreName = sDumpFile;
+    sCoreName.RemoveFileExtension();
+
+    ezStringBuilder sPidArg;
+    sPidArg.SetFormat("{}", myPid);
+
+    execlp("gcore", "gcore", "-o", sCoreName.GetData(), sPidArg.GetData(), nullptr);
+    _exit(1); // execlp failed
+  }
+  else if (childPid > 0)
+  {
+    // Parent - wait for child
+    int status;
+    waitpid(childPid, &status, 0);
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+    {
+      // gcore succeeded, rename file from <prefix>.<pid> to requested name
+      ezStringBuilder sCoreName = sDumpFile;
+      sCoreName.RemoveFileExtension();
+
+      ezStringBuilder sGcoreOutput;
+      sGcoreOutput.SetFormat("{}.{}", sCoreName, myPid);
+
+      if (ezOSFile::ExistsFile(sGcoreOutput))
+      {
+        if (sGcoreOutput != sDumpFile)
+        {
+          ezOSFile::MoveFileOrDirectory(sGcoreOutput, sDumpFile).IgnoreResult();
+        }
+        return EZ_SUCCESS;
+      }
+    }
+  }
+
+  return ezStatus("Could not write mini dump - gcore not available or failed.");
+}
+
+ezStatus ezMiniDumpUtils::LaunchMiniDumpTool(ezStringView sDumpFile, ezDumpType dumpTypeOverride)
+{
+  ezStringBuilder sDumpToolPath = ezOSFile::GetApplicationDirectory();
+  sDumpToolPath.AppendPath("ezMiniDumpTool");
+  sDumpToolPath.MakeCleanPath();
+
+  if (!ezOSFile::ExistsFile(sDumpToolPath))
+    return ezStatus(ezFmt("ezMiniDumpTool not found in '{}'", sDumpToolPath));
+
+  ezProcessOptions procOpt;
+  procOpt.m_bHideConsoleWindow = true;
+  procOpt.m_sProcess = sDumpToolPath;
+  procOpt.m_Arguments.PushBack("-PID");
+  procOpt.AddArgument("{}", ezProcess::GetCurrentProcessID());
+  procOpt.m_Arguments.PushBack("-f");
+  procOpt.m_Arguments.PushBack(sDumpFile);
+
+  if ((opt_FullCrashDumps.GetOptionValue(ezCommandLineOption::LogMode::Always) && dumpTypeOverride == ezDumpType::Auto) || dumpTypeOverride == ezDumpType::MiniDumpWithFullMemory)
+  {
+    // Forward the '-fullcrashdumps' command line argument
+    procOpt.AddArgument("-fullcrashdumps");
+  }
+
+  ezProcessGroup proc;
+  if (proc.Launch(procOpt).Failed())
+    return ezStatus(ezFmt("Failed to launch '{}'", sDumpToolPath));
+
+  if (proc.WaitToFinish().Failed())
+    return ezStatus("Waiting for ezMiniDumpTool to finish failed.");
+
+  return EZ_SUCCESS;
+}
 
 #endif

--- a/Code/Engine/Foundation/Platform/Linux/MiniDumpUtils_Platform.h
+++ b/Code/Engine/Foundation/Platform/Linux/MiniDumpUtils_Platform.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace ezMiniDumpUtils
+{
+  /// \brief Linux-specific implementation for writing a core dump of the running process.
+  ///
+  /// This triggers gcore or uses the kernel's core dump mechanism.
+  EZ_FOUNDATION_DLL ezStatus WriteOwnProcessMiniDump(ezStringView sDumpFile, void* pOsSpecificData, ezDumpType dumpTypeOverride = ezDumpType::Auto);
+
+}; // namespace ezMiniDumpUtils

--- a/Code/Engine/Foundation/Platform/Posix/CrashHandler_Posix.h
+++ b/Code/Engine/Foundation/Platform/Posix/CrashHandler_Posix.h
@@ -93,7 +93,14 @@ void ezCrashHandler::SetCrashHandler(ezCrashHandler* pHandler)
 
 bool ezCrashHandler_WriteMiniDump::WriteOwnProcessMiniDump(void* pOsSpecificData)
 {
+#if EZ_ENABLED(EZ_SUPPORTS_CRASH_DUMPS)
+  ezStatus res = ezMiniDumpUtils::WriteOwnProcessMiniDump(m_sDumpFilePath, pOsSpecificData);
+  if (res.Failed())
+    ezLog::Printf("WriteOwnProcessMiniDump failed: %s\n", res.GetMessageString().GetData());
+  return res.Succeeded();
+#else
   return false;
+#endif
 }
 
 void ezCrashHandler_WriteMiniDump::PrintStackTrace(void* pOsSpecificData)

--- a/Code/Tools/MiniDumpTool/CMakeLists.txt
+++ b/Code/Tools/MiniDumpTool/CMakeLists.txt
@@ -1,7 +1,7 @@
 ez_cmake_init()
 
-# Writing external process dumps is only supported in windows right now.
-ez_requires(EZ_CMAKE_PLATFORM_WINDOWS)
+# Writing external process dumps is supported on Windows and Linux.
+ez_requires_one_of(EZ_CMAKE_PLATFORM_WINDOWS EZ_CMAKE_PLATFORM_LINUX)
 
 # Get the name of this folder as the project name
 get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)


### PR DESCRIPTION
## Linux crash dumps
* Enable `EZ_SUPPORTS_CRASH_DUMPS` on Linux.
* Implemented MiniDumpUtils for Linux using gcore (requires gdb package)
* `ezMiniDumpTool` now builds on Linux as well.

## EditorProcessor crash handling
* Added `Crashed` state to `ezEditorProcessorProcess`. Once crashed. A user has to manually call `ezAssetProcessor::RequestRestartProcess` to restart the instance via the curator panel context menu.
* While a processor is in the crashed state, the curator panel will change the state indicator icon and you can RMB on it to go to the dumps folder or restart the instance.
* Fix crash detection: `HasProcessCrashed()` now correctly returns `!IsClientAlive()`. Also pump the Qt message loop as otherwise the `QProcess` state never changes so crashes were never detected.
* If an instance crashes, we don't have correct timings for its work item so we fall back to the time we sent the request and the time we detected the crash as the runtime of the work item.
* Changed icons for processor states to be easier to understand.
  <img width="370" height="231" alt="image" src="https://github.com/user-attachments/assets/5e67e80a-1e5e-4045-8ff4-7f3b3e602d9b" />
