### PR TITLE
Some Linux Polishing

### DIFF
--- a/.github/skills/debug-pretty-printers/SKILL.md
+++ b/.github/skills/debug-pretty-printers/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: debug-pretty-printers
+description: Debug and develop GDB and LLDB pretty printers for ezEngine C++ types. Use this skill when working with ezEngine debugger visualizers in ezEngine-gdb.py, ezEngine.py, or ezEngine.natvis. Covers testing with VisualizerZoo.cpp, common errors, and debugging techniques.
+---
+
+# Debugging ezEngine Pretty Printers
+
+This skill provides guidance for developing and debugging pretty printers (debugger visualizers) for ezEngine.
+
+## File Locations
+
+All pretty printer files are in `Code/Engine/Foundation/`:
+
+- **GDB**: `Code/Engine/Foundation/ezEngine-gdb.py` - Python pretty printers for GDB
+- **LLDB**: `Code/Engine/Foundation/ezEngine.py` - Python pretty printers for LLDB  
+- **Natvis**: `Code/Engine/Foundation/ezEngine.natvis` - Visual Studio/MSVC visualizers (XML)
+- **Auto-load**: `.gdbinit` in repository root - Automatically loads GDB printers
+
+## Testing with VisualizerZoo.cpp
+
+The primary test file for pretty printers is `Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp`. This file contains test variables for all visualized types organized in `EZ_TEST_BLOCK` sections.
+
+### Finding test sections
+
+Search for `EZ_TEST_BLOCK` macros to find each section:
+
+```bash
+grep -n "EZ_TEST_BLOCK" Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+```
+Eac hsection is named descriptively, e.g. `EZ_TEST_BLOCK(ezTestBlock::Enabled, "Strings")` contains tests for the string types.
+
+### Setting breakpoints
+
+Each `EZ_TEST_BLOCK` section ends with `EZ_TEST_BOOL(true);` - this is where you should set your breakpoint. At this point, all variables in the block are initialized and in scope.
+
+To find the breakpoint line for a section:
+
+```bash
+# Find the section start, then look for the EZ_TEST_BOOL(true) before the closing brace
+grep -n "EZ_TEST_BLOCK.*Strings" Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+# Then search forward from that line for EZ_TEST_BOOL(true)
+```
+
+Or in an editor, search for `EZ_TEST_BLOCK.*SectionName`, then find the `EZ_TEST_BOOL(true);` at the end of that block.
+
+### Running the test
+
+First, ensure FoundationTest is built:
+
+```bash
+cmake --build Workspace/copilot --target FoundationTest
+```
+
+### Testing GDB printers in batch mode
+
+Use this exact command pattern to test printers (run from the repository root):
+
+```bash
+gdb -batch \
+  -ex "set pagination off" \
+  -ex "source Code/Engine/Foundation/ezEngine-gdb.py" \
+  -ex "break VisualizerZoo.cpp:LINE_NUMBER" \
+  -ex "run -run -noGui -all" \
+  -ex "print variableName" \
+  ./Workspace/copilot-output/Bin/LinuxNinjaGccDebug64/FoundationTest
+```
+
+Replace `LINE_NUMBER` with the line of `EZ_TEST_BOOL(true);` in the relevant section.
+
+Key points:
+- Use `timeout 30` prefix if the test might hang
+- The breakpoint must be on the `EZ_TEST_BOOL(true);` line at the END of the block (all variables initialized)
+- Add `2>&1 | tail -15` to limit output
+
+### Example: Testing string printers
+
+1. Find the Strings section:
+   ```bash
+   grep -n "EZ_TEST_BLOCK.*Strings" Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+   ```
+
+2. Find the `EZ_TEST_BOOL(true);` at the end of that block and note the line number
+
+3. Run GDB with that breakpoint (from repository root):
+   ```bash
+   gdb -batch \
+     -ex "set pagination off" \
+     -ex "source Code/Engine/Foundation/ezEngine-gdb.py" \
+     -ex "break VisualizerZoo.cpp:101" \
+     -ex "run -run -noGui -all" \
+     -ex "print string" \
+     -ex "print stringView" \
+     ./Workspace/copilot-output/Bin/LinuxNinjaGccDebug64/FoundationTest
+   ```
+
+### Viewing expanded children
+
+Use `set print array on` to see children on separate lines:
+
+```bash
+gdb -batch \
+  -ex "set pagination off" \
+  -ex "set print array on" \
+  -ex "source Code/Engine/Foundation/ezEngine-gdb.py" \
+  -ex "break VisualizerZoo.cpp:LINE_NUMBER" \
+  -ex "run -run -noGui -all" \
+  -ex "print variableName" \
+  ./Workspace/copilot-output/Bin/LinuxNinjaGccDebug64/FoundationTest
+```
+
+## ezEngine GDB Printer Structure
+
+### Registration pattern (from ezEngine-gdb.py)
+
+```python
+def build_pretty_printers():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("ezEngine")
+    
+    # Strings
+    pp.add_printer('ezHybridStringBase', r'^ezHybridStringBase<.*>$', ezHybridStringPrinter)
+    pp.add_printer('ezStringBuilder', r'^ezStringBuilder$', ezHybridStringPrinter)
+    
+    # Containers  
+    pp.add_printer('ezDynamicArray', r'^ezDynamicArray<.*>$', ezDynamicArrayPrinter)
+    
+    return pp
+
+gdb.printing.register_pretty_printer(gdb.current_objfile(), build_pretty_printers())
+```
+
+### Printer class pattern
+
+```python
+class ezMyTypePrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        """Return the display string for the value."""
+        try:
+            return f"{{ count={count} }}"
+        except Exception as e:
+            return f"<error: {e}>"
+
+    def children(self):
+        """Yield (name, value) tuples for expandable children."""
+        try:
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_pAllocator', self.val['m_pAllocator']
+            for i in range(count):
+                yield f'[{i}]', (m_pElements + i).dereference()
+        except Exception as e:
+            yield 'error', str(e)
+
+    def display_hint(self):
+        return 'array'  # or 'string' or 'map'
+```
+
+## Common Errors and Solutions
+
+### "Type is not a template"
+
+**Problem**: Calling `val.type.template_argument(0)` on `ezStringBuilder` (not a template).
+
+**Solution**: Get size from the actual member instead:
+```python
+# Instead of: local_storage_size = val.type.template_argument(0)
+local_storage_size = m_Data['m_StaticData'].type.sizeof
+```
+
+### "Trying to read string with inappropriate type"
+
+**Problem**: Calling `.string()` on array address instead of `char*`.
+
+**Solution**: Cast to `char*` first:
+```python
+char_ptr_type = gdb.lookup_type('char').pointer()
+ptr = m_Data['m_StaticData'].address.cast(char_ptr_type)
+result = ptr.string(length=count)
+```
+
+### "There is no member named X"
+
+**Problem**: Wrong member name. Check the LLDB or Natvis implementation for correct names.
+
+**Solution**: Use GDB to inspect the actual type:
+```bash
+gdb -batch -ex "ptype ezHashedString" ./Output/Bin/LinuxNinjaGccDebug64/FoundationTest
+```
+
+### Children showing as strings instead of expandable values
+
+**Problem**: Yielding formatted strings in `children()` instead of GDB values.
+
+**Solution**: Yield actual GDB values that have their own printers:
+```python
+# Wrong - yields a string, not expandable
+yield 'c0', f"{{ x={x}, y={y}, z={z} }}"
+
+# Correct - yields the actual value, GDB will use ezVec3Printer on it
+yield 'c0', elements[0].address.cast(vec3_type.pointer()).dereference()
+```
+
+### ezHybridString inline vs heap storage
+
+The `ezHybridStringBase` uses inline storage (`m_StaticData`) when capacity fits, otherwise heap (`m_pElements`):
+
+```python
+def _get_string_data(self):
+    m_Data = self.val['m_Data']
+    m_uiCount = int(m_Data['m_uiCount'])
+    m_uiCapacity = int(m_Data['m_uiCapacity'])
+    local_storage_size = m_Data['m_StaticData'].type.sizeof
+
+    if m_uiCapacity <= local_storage_size:
+        # Using inline storage
+        char_ptr_type = gdb.lookup_type('char').pointer()
+        ptr = m_Data['m_StaticData'].address.cast(char_ptr_type)
+    else:
+        # Using heap storage
+        ptr = m_Data['m_pElements']
+
+    return ptr, m_uiCount
+```
+
+### Template type lookup for math types
+
+To cast array elements to vector types (e.g., for ezMat3 columns):
+
+```python
+elements = self.val['m_fElementsCM']
+elem_type = elements[0].type
+vec3_type = gdb.lookup_type(f'ezVec3Template<{elem_type}>')
+col0 = elements[0].address.cast(vec3_type.pointer()).dereference()
+```
+
+## LLDB Comparison
+
+When implementing GDB printers, reference the LLDB implementation in `ezEngine.py`:
+
+- LLDB uses `set_fields(['m_uiCount', 'm_uiCapacity', 'm_pAllocator'])` to add member children
+- GDB equivalent: yield each field in `children()` before array elements
+- LLDB `GetChildMemberWithName('m_Data')` → GDB `self.val['m_Data']`
+- LLDB `GetValueAsUnsigned(0)` → GDB `int(self.val['m_Member'])`
+
+## Debugging Workflow
+
+1. **Identify the type**: Check which printer handles it in `build_pretty_printers()`
+2. **Find test variable**: Look in VisualizerZoo.cpp for a variable of that type
+3. **Set breakpoint after initialization**: Use the table above for correct line numbers
+4. **Test to_string() first**: Get the display string working before children()
+5. **Add children() incrementally**: Test each child field separately
+6. **Compare with LLDB/Natvis**: Use existing implementations as reference for member names
+
+## Auto-loading
+
+The `.gdbinit` file in the repository root automatically loads the printers when debugging in the ezEngine directory. It uses path detection relative to the current working directory.

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -538,6 +538,7 @@ void ezQtEditorApp::CreatePluginSelectionDDL(const char* szProjectFile, const ch
 
 void ezQtEditorApp::LoadPluginBundleDlls(const char* szProjectFile)
 {
+  EZ_PROFILE_SCOPE("LoadPluginBundleDlls");
   ezStringBuilder sPath = szProjectFile;
   sPath.PathParentDirectory();
   sPath.AppendPath("Editor/PluginSelection.ddl");
@@ -612,6 +613,7 @@ void ezQtEditorApp::LoadPluginBundleDlls(const char* szProjectFile)
   ezSet<ezString> NotLoaded;
   for (const ezApplicationPluginConfig::PluginConfig& it : order)
   {
+    EZ_PROFILE_SCOPE(it.m_sAppDirRelativePath.GetData());
     if (ezPlugin::LoadPlugin(it.m_sAppDirRelativePath, it.m_bLoadCopy ? ezPluginLoadFlags::LoadCopy : ezPluginLoadFlags::Default).Failed())
     {
       NotLoaded.Insert(it.m_sAppDirRelativePath);

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -55,6 +55,7 @@ void ezQtEditorApp::SlotQueuedOpenProject(QString sProject)
 
 ezResult ezQtEditorApp::CreateOrOpenProject(bool bCreate, ezStringView sFile0)
 {
+  EZ_PROFILE_SCOPE("CreateOrOpenProject");
   ezStringBuilder sFile = sFile0;
   if (!bCreate)
   {
@@ -93,7 +94,7 @@ ezResult ezQtEditorApp::CreateOrOpenProject(bool bCreate, ezStringView sFile0)
     }
   }
 
-  EZ_PROFILE_SCOPE("CreateOrOpenProject");
+
   m_bLoadingProjectInProgress = true;
   EZ_SCOPE_EXIT(m_bLoadingProjectInProgress = false;);
 

--- a/Code/Editor/EditorFramework/Settings/EditorSettings.cpp
+++ b/Code/Editor/EditorFramework/Settings/EditorSettings.cpp
@@ -3,8 +3,8 @@
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <EditorFramework/Preferences/Preferences.h>
-#include <ToolsFoundation/Application/ApplicationServices.h>
 #include <Foundation/Profiling/Profiling.h>
+#include <ToolsFoundation/Application/ApplicationServices.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 #  include <EditorFramework/EditorApp/WindowsJumpList.h>

--- a/Code/Editor/EditorFramework/Settings/EditorSettings.cpp
+++ b/Code/Editor/EditorFramework/Settings/EditorSettings.cpp
@@ -4,6 +4,7 @@
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <EditorFramework/Preferences/Preferences.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
+#include <Foundation/Profiling/Profiling.h>
 
 #if EZ_ENABLED(EZ_PLATFORM_WINDOWS_DESKTOP)
 #  include <EditorFramework/EditorApp/WindowsJumpList.h>
@@ -11,6 +12,7 @@
 
 void ezQtEditorApp::SaveRecentFiles()
 {
+  EZ_PROFILE_SCOPE("SaveRecentFiles");
   if (m_StartupFlags.IsAnySet(StartupFlags::Headless | StartupFlags::UnitTest | StartupFlags::Background))
     return;
 
@@ -25,6 +27,7 @@ void ezQtEditorApp::SaveRecentFiles()
 
 void ezQtEditorApp::LoadRecentFiles()
 {
+  EZ_PROFILE_SCOPE("LoadRecentFiles");
   m_RecentProjects.Load(":appdata/Settings/RecentProjects.txt");
   m_RecentDocuments.Load(":appdata/Settings/RecentDocuments.txt");
 }

--- a/Code/Editor/EditorFramework/Settings/SettingsTab.cpp
+++ b/Code/Editor/EditorFramework/Settings/SettingsTab.cpp
@@ -21,6 +21,7 @@ ezString ezQtSettingsTab::GetDisplayNameShort() const
 
 void ezQtEditorApp::ShowSettingsDocument()
 {
+  EZ_PROFILE_SCOPE("ShowSettingsDocument");
   ezQtSettingsTab* pSettingsTab = ezQtSettingsTab::GetSingleton();
 
   if (pSettingsTab == nullptr)

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
@@ -468,7 +468,11 @@ void ezQtJoltProjectSettingsDlg::on_ImpulsesTable_itemSelectionChanged()
     pCheck->setChecked(bOverride);
     pCheck->setProperty("ImpulseKey", uiImpulseKey);
     pCheck->setProperty("WeightKey", uiWeightKey);
+    EZ_WARNING_PUSH()
+    EZ_WARNING_DISABLE_GCC("-Wdeprecated-declarations")
+    EZ_WARNING_DISABLE_CLANG("-Wdeprecated-declarations")
     connect(pCheck, &QCheckBox::stateChanged, this, &ezQtJoltProjectSettingsDlg::onImpulseOverrideChecked);
+    EZ_WARNING_POP()
 
     ezQtDoubleSpinBox* pNumber = new ezQtDoubleSpinBox(nullptr);
     pNumber->setProperty("ImpulseKey", uiImpulseKey);

--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptVariable.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptVariable.cpp
@@ -33,8 +33,8 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezVisualScriptVariableType, 1)
 EZ_END_STATIC_REFLECTED_ENUM;
 // clang-format on
 
-static_assert(ezVisualScriptVariableType::Variant == ezVisualScriptDataType::Variant);
-static_assert(ezVisualScriptVariableType::Resource == ezVisualScriptDataType::Resource);
+static_assert(static_cast<int>(ezVisualScriptVariableType::Variant) == static_cast<int>(ezVisualScriptDataType::Variant));
+static_assert(static_cast<int>(ezVisualScriptVariableType::Resource) == static_cast<int>(ezVisualScriptDataType::Resource));
 
 ///////////////////////////////////////////////////////////////////////////
 

--- a/Code/Engine/Foundation/Basics/Compiler/GCC.h
+++ b/Code/Engine/Foundation/Basics/Compiler/GCC.h
@@ -15,9 +15,14 @@
         __builtin_debugtrap(); \
       }
 #  elif defined(__i386__) || defined(__x86_64__)
-#    define EZ_DEBUG_BREAK            \
-      {                               \
-        __asm__ __volatile__("int3"); \
+// Use a non-inline function to avoid C++20 extension warnings when EZ_ASSERT is used in constexpr contexts
+[[gnu::noinline]] inline void ezGccDebugBreak()
+{
+  __asm__ __volatile__("int3");
+}
+#    define EZ_DEBUG_BREAK \
+      {                    \
+        ezGccDebugBreak(); \
       }
 #  else
 #    include <signal.h>

--- a/Code/Engine/Foundation/ezEngine-gdb.py
+++ b/Code/Engine/Foundation/ezEngine-gdb.py
@@ -43,6 +43,9 @@ def build_pretty_printers():
     pp.add_printer('ezMap', r'^ezMap<.*>$', ezMapPrinter)
     pp.add_printer('ezSetBase', r'^ezSetBase<.*>$', ezMapPrinter)
     pp.add_printer('ezSet', r'^ezSet<.*>$', ezMapPrinter)
+    pp.add_printer('ezHashTableBase::Entry', r'^ezHashTableBase<.*>::Entry$', ezHashTableEntryPrinter)
+    pp.add_printer('ezMapBase::Node', r'^ezMapBase<.*>::Node$', ezMapNodePrinter)
+    pp.add_printer('ezSetBase::Node', r'^ezSetBase<.*>::Node$', ezSetNodePrinter)
     pp.add_printer('ezStaticRingBuffer', r'^ezStaticRingBuffer<.*>$', ezStaticRingBufferPrinter)
 
     # Basic Types
@@ -84,11 +87,26 @@ class ezHybridStringPrinter:
     def __init__(self, val):
         self.val = val
 
+    def _get_string_data(self):
+        """Extract string data, returning (pointer, count) or raises exception."""
+        m_Data = self.val['m_Data']
+        m_uiCount = int(m_Data['m_uiCount'])
+        m_uiCapacity = int(m_Data['m_uiCapacity'])
+        local_storage_size = m_Data['m_StaticData'].type.sizeof
+
+        if m_uiCapacity <= local_storage_size:
+            # Using inline storage - cast to char* for string() method
+            char_ptr_type = gdb.lookup_type('char').pointer()
+            ptr = m_Data['m_StaticData'].address.cast(char_ptr_type)
+        else:
+            # Using heap storage
+            ptr = m_Data['m_pElements']
+
+        return ptr, m_uiCount
+
     def to_string(self):
         try:
-            m_Data = self.val['m_Data']
-            m_pElements = m_Data['m_pElements']
-            m_uiCount = int(m_Data['m_uiCount'])
+            ptr, m_uiCount = self._get_string_data()
 
             if m_uiCount == 0:
                 return '""'
@@ -97,9 +115,26 @@ class ezHybridStringPrinter:
 
             # String length excludes null terminator for display
             str_len = m_uiCount - 1 if m_uiCount > 0 else 0
-            return m_pElements.string(length=str_len)
+            return ptr.string(length=str_len)
         except Exception as e:
             return f"<error: {e}>"
+
+    def children(self):
+        try:
+            m_Data = self.val['m_Data']
+            ptr, m_uiCount = self._get_string_data()
+
+            # Create contents as char array
+            if m_uiCount > 0 and m_uiCount <= 0x10000000:
+                char_type = gdb.lookup_type('char')
+                char_array_type = char_type.array(m_uiCount - 1)
+                contents = ptr.cast(char_array_type.pointer()).dereference()
+                yield 'contents', contents
+
+            yield 'm_uiCount', m_Data['m_uiCount']
+            yield 'm_pAllocator', m_Data['m_pAllocator']
+        except Exception as e:
+            yield 'error', str(e)
 
     def display_hint(self):
         return 'string'
@@ -124,6 +159,21 @@ class ezStringViewPrinter:
         except Exception as e:
             return f"<error: {e}>"
 
+    def children(self):
+        try:
+            m_pStart = self.val['m_pStart']
+            m_uiElementCount = int(self.val['m_uiElementCount'])
+
+            if m_pStart != 0 and m_uiElementCount > 0:
+                char_type = gdb.lookup_type('char')
+                char_array_type = char_type.array(m_uiElementCount - 1)
+                contents = m_pStart.cast(char_array_type.pointer()).dereference()
+                yield 'contents', contents
+
+            yield 'm_uiElementCount', self.val['m_uiElementCount']
+        except Exception as e:
+            yield 'error', str(e)
+
     def display_hint(self):
         return 'string'
 
@@ -144,6 +194,15 @@ class ezHashedStringPrinter:
             return ezHybridStringPrinter(m_sString).to_string()
         except Exception as e:
             return f"<error: {e}>"
+
+    def children(self):
+        try:
+            m_Data = self.val['m_Data']
+            m_pElement = m_Data['m_pElement']
+            yield 'm_sString', m_pElement['m_Value']['m_sString']
+            yield 'm_uiHash', m_pElement['m_Key']
+        except Exception as e:
+            yield 'error', str(e)
 
     def display_hint(self):
         return 'string'
@@ -207,6 +266,10 @@ class ezDynamicArrayPrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_uiCapacity', self.val['m_uiCapacity']
+            yield 'm_pAllocator', self.val['m_pAllocator']
+
             count = int(self.val['m_uiCount'])
             m_pElements = self.val['m_pElements']
 
@@ -231,6 +294,10 @@ class ezSmallArrayPrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_uiCapacity', self.val['m_uiCapacity']
+            yield 'm_uiUserData', self.val['m_uiUserData']
+
             count = int(self.val['m_uiCount'])
             capacity = int(self.val['m_uiCapacity'])
 
@@ -277,6 +344,9 @@ class ezStaticArrayPrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_uiCapacity', self.val['m_uiCapacity']
+
             count = int(self.val['m_uiCount'])
             m_Data = self.val['m_Data']
 
@@ -306,6 +376,8 @@ class ezArrayPtrPrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+
             count = int(self.val['m_uiCount'])
             m_pPtr = self.val['m_pPtr']
 
@@ -330,6 +402,10 @@ class ezHashTablePrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_uiCapacity', self.val['m_uiCapacity']
+            yield 'm_pAllocator', self.val['m_pAllocator']
+
             count = int(self.val['m_uiCount'])
             capacity = int(self.val['m_uiCapacity'])
             m_pEntries = self.val['m_pEntries']
@@ -360,6 +436,31 @@ class ezHashTablePrinter:
         return 'array'
 
 
+class ezHashTableEntryPrinter:
+    """Pretty printer for ezHashTableBase<K, V>::Entry."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            key = self.val['key']
+            value = self.val['value']
+            # Use summary=True to get only the to_string() output, not full expansion
+            key_str = key.format_string(summary=True)
+            value_str = value.format_string(summary=True)
+            return f"key = {key_str}, value = {value_str}"
+        except Exception as e:
+            return f"<error: {e}>"
+
+    def children(self):
+        try:
+            yield 'key', self.val['key']
+            yield 'value', self.val['value']
+        except Exception as e:
+            yield 'error', str(e)
+
+
 class ezListPrinter:
     """Pretty printer for ezListBase<T> and ezList<T>."""
 
@@ -372,6 +473,8 @@ class ezListPrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+
             count = int(self.val['m_uiCount'])
             m_First = self.val['m_First']
             current = m_First['m_pNext']
@@ -399,6 +502,9 @@ class ezDequePrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_pAllocator', self.val['m_pAllocator']
+
             count = int(self.val['m_uiCount'])
             m_pChunks = self.val['m_pChunks']
             first_element = int(self.val['m_uiFirstElement'])
@@ -501,6 +607,8 @@ class ezMapPrinter:
 
     def children(self):
         try:
+            yield 'm_uiCount', self.val['m_uiCount']
+
             if self.m_uiCount == 0:
                 return
 
@@ -532,6 +640,51 @@ class ezMapPrinter:
         return 'array'
 
 
+class ezMapNodePrinter:
+    """Pretty printer for ezMapBase<K, V>::Node."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            key = self.val['m_Key']
+            value = self.val['m_Value']
+            # Use summary=True to get only the to_string() output, not full expansion
+            key_str = key.format_string(summary=True)
+            value_str = value.format_string(summary=True)
+            return f"key = {key_str}, value = {value_str}"
+        except Exception as e:
+            return f"<error: {e}>"
+
+    def children(self):
+        try:
+            yield 'm_Key', self.val['m_Key']
+            yield 'm_Value', self.val['m_Value']
+        except Exception as e:
+            yield 'error', str(e)
+
+
+class ezSetNodePrinter:
+    """Pretty printer for ezSetBase<K>::Node."""
+
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            key = self.val['m_Key']
+            return key.format_string(summary=True)
+        except Exception as e:
+            return f"<error: {e}>"
+
+    def children(self):
+        try:
+            yield 'm_Key', self.val['m_Key']
+        except Exception as e:
+            yield 'error', str(e)
+
+
 class ezStaticRingBufferPrinter:
     """Pretty printer for ezStaticRingBuffer<T, N>."""
 
@@ -548,8 +701,8 @@ class ezStaticRingBufferPrinter:
             first = int(self.val['m_uiFirstElement'])
             m_pElements = self.val['m_pElements']
             capacity = self.val.type.template_argument(1)
-            yield 'count', count
-            yield 'first', first
+            yield 'm_uiCount', self.val['m_uiCount']
+            yield 'm_uiFirstElement', self.val['m_uiFirstElement']
 
             for i in range(count):
                 actual_index = (first + i) % capacity

--- a/Code/Engine/RendererCore/Pipeline/Implementation/SortingFunctions.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/SortingFunctions.cpp
@@ -22,7 +22,7 @@ namespace
   EZ_ALWAYS_INLINE ezUInt64 NormalizeDistance(float fDistance, float fMaxDistance)
   {
     const float fNormalizedDistance = ezMath::Saturate(fDistance / fMaxDistance);
-    return static_cast<ezUInt64>(fNormalizedDistance * (EZ_BIT(Bits) - 1));
+    return static_cast<ezUInt64>(fNormalizedDistance * static_cast<float>(EZ_BIT(Bits) - 1));
   }
 
   template <ezUInt32 Bits>

--- a/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
+++ b/Code/Engine/RendererVulkan/MemoryAllocator/Implementation/MemoryAllocatorVulkan.cpp
@@ -52,7 +52,7 @@ static_assert(sizeof(ezVulkanAllocationInfo) == sizeof(VmaAllocationInfo));
 
 EZ_DEFINE_AS_POD_TYPE(VkExportMemoryAllocateInfo);
 
-namespace
+namespace ezMemoryAllocatorVulkanInternal
 {
   struct ExportedSharedPool
   {
@@ -68,8 +68,10 @@ struct ezMemoryAllocatorVulkan::Impl
 {
   VmaAllocator m_allocator;
   ezMutex m_exportedSharedPoolsMutex;
-  ezHashTable<uint32_t, ExportedSharedPool> m_exportedSharedPools;
+  ezHashTable<uint32_t, ezMemoryAllocatorVulkanInternal::ExportedSharedPool> m_exportedSharedPools;
 };
+
+using ExportedSharedPool = ezMemoryAllocatorVulkanInternal::ExportedSharedPool;
 
 ezMemoryAllocatorVulkan::Impl* ezMemoryAllocatorVulkan::m_pImpl = nullptr;
 

--- a/Code/EnginePlugins/OpenXRPlugin/init.cmake
+++ b/Code/EnginePlugins/OpenXRPlugin/init.cmake
@@ -41,6 +41,11 @@ macro(ez_fetch_openxr)
 	set_target_properties(openxr_loader PROPERTIES FOLDER "ThirdParty")
 	set_target_properties(XrApiLayer_core_validation PROPERTIES FOLDER "ThirdParty")
 
+	# Suppress warnings in third-party generated code
+	if(EZ_CMAKE_COMPILER_GCC OR EZ_CMAKE_COMPILER_CLANG)
+		target_compile_options(XrApiLayer_core_validation PRIVATE -Wno-address)
+	endif()
+
 endmacro()
 
 ######################################

--- a/Code/ThirdParty/ozz/CMakeLists.txt
+++ b/Code/ThirdParty/ozz/CMakeLists.txt
@@ -21,9 +21,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE OZZ_BUILD_ANIMATIONTOOLS_LIB)
 target_compile_definitions(${PROJECT_NAME} PRIVATE OZZ_BUILD_ANIMATIONFBX_LIB)
 target_compile_definitions(${PROJECT_NAME} PRIVATE OZZ_BUILD_OPTIONS_LIB)
 
-if(EZ_CMAKE_PLATFORM_LINUX OR EZ_CMAKE_PLATFORM_ANDROID)
-  # Right now, running SIMD version on Linux crashes. Fallback to float implementation.
-  target_compile_definitions(${PROJECT_NAME} PRIVATE OZZ_BUILD_SIMD_REF)
+if(EZ_CMAKE_PLATFORM_ANDROID)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE OZZ_SIMD_ARM_NEON)
 endif()
 
 if(EZ_CMAKE_COMPILER_MSVC)

--- a/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/ContainerWindow/ContainerWindow.cpp
@@ -216,6 +216,7 @@ void ezQtContainerWindow::RemoveApplicationPanel(ezQtApplicationPanel* pPanel)
 
 void ezQtContainerWindow::AddDocumentWindow(ezQtDocumentWindow* pDocWindow)
 {
+  EZ_PROFILE_SCOPE("AddDocumentWindow");
   EZ_ASSERT_DEV(!pDocWindow->objectName().isEmpty(), "Panel name must be unique and not empty.");
 
   if (m_DocumentWindows.IndexOf(pDocWindow) != ezInvalidIndex)
@@ -261,6 +262,7 @@ void ezQtContainerWindow::AddDocumentWindow(ezQtDocumentWindow* pDocWindow)
   }
   else
   {
+    EZ_PROFILE_SCOPE("AddDocumentWindow - addDockWidgetTab");
     m_pDockManager->addDockWidgetTab(ads::CenterDockWidgetArea, dock);
   }
   m_DocumentDocks.PushBack(dock);

--- a/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
+++ b/Code/UnitTests/FoundationTest/CodeUtils/VisualizerZoo.cpp
@@ -80,7 +80,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     ezString c;
   };
   EZ_TEST_BOOL(true);
-  // Strings
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Strings")
   {
     ezString stringEmpty;
     ezString string = u8"こんにちは 世界";
@@ -101,7 +101,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // Containers
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Containers")
   {
     ezDynamicArray<ezString> dynamicArray;
     dynamicArray.PushBack("Item1");
@@ -169,7 +169,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // ezVariant
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "ezVariant")
   {
     ezVariant variantInvalid; // Default constructor creates Invalid type
     ezVariant variantBool = ezVariant(true);
@@ -234,7 +234,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // Enum
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Enum")
   {
     ezEnum<ezVariantType> enumTest = ezVariantType::Angle;
     ezEnum<ezVariantType> enumArray[3] = {ezVariantType::Int32, ezVariantType::String, ezVariantType::Color};
@@ -244,7 +244,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // Bitflags
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Bitflags")
   {
     TestFlags::Enum rawBitflags = TestFlags::Bit1;
     TestFlags::Enum rawBitflags2 = (TestFlags::Enum)(TestFlags::Bit1 | TestFlags::Bit2).GetValue();
@@ -264,7 +264,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // Math
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Math")
   {
     ezVec2 vec2(1.0f, 2.0f);
     ezVec3 vec3(1.0f, 2.0f, 3.0f);
@@ -293,7 +293,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // UniquePtr
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "UniquePtr")
   {
     ezUniquePtr<ReflectedTest> uniquePtr = EZ_DEFAULT_NEW(ReflectedTest);
     uniquePtr->u = 1.0f;
@@ -307,7 +307,7 @@ EZ_CREATE_SIMPLE_TEST(CodeUtils, VisualizerZoo)
     EZ_TEST_BOOL(true);
   }
 
-  // Mutex
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Mutex")
   {
     ezMutex mutex;
     EZ_LOCK(mutex);


### PR DESCRIPTION
* Some profiling scopes to debug editor startup times (mostly limited by DLL loading and Qt init code like icon loading).
* Fix various compiler warnings. Most notably moved `EZ_DEBUG_BREAK`'s call to `int3` into a function as it was encountered in constexpr context which spammed some C++20 warning in GCC.
* Re-enabled OZZ SIMD use on Linux.
* I can't be bothered to maintain 3 pretty printer implementations for ezEngine so I added a github skill so an LLM can implement and self-check gdb pretty printer implementations.