### PR TITLE
Don't block editor when engine is stuck

### DIFF
--- a/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
+++ b/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
@@ -129,6 +129,7 @@ protected:
 protected:
   void EngineViewProcessEventHandler(const ezEditorEngineProcessConnection::Event& e);
   void ShowRestartButton(bool bShow);
+  void ShowProcessStuckIndicator(bool bShow);
   void RecreateEngineViewport();
   virtual void OnOpenContextMenu(QPoint globalPos) {}
   virtual void HandleMarqueePickingResult(const ezViewMarqueePickingResultMsgToEditor* pMsg) {}
@@ -159,6 +160,7 @@ protected:
   QHBoxLayout* m_pMainLayout = nullptr;
   QPushButton* m_pRestartButton = nullptr;
   QWidget* m_pViewportWidget = nullptr;
+  QWidget* m_pStuckIndicator = nullptr;
 
   mutable ezObjectPickingResult m_LastPickingResult;
 

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -7,6 +7,7 @@
 #include <EditorFramework/Preferences/EditorPreferences.h>
 #include <Foundation/Utilities/GraphicsUtils.h>
 #include <GuiFoundation/ActionViews/ToolBarActionMapView.moc.h>
+#include <QLabel>
 
 ezUInt32 ezQtEngineViewWidget::s_uiNextViewID = 0;
 
@@ -639,6 +640,7 @@ void ezQtEngineViewWidget::EngineViewProcessEventHandler(const ezEditorEnginePro
   {
     case ezEditorEngineProcessConnection::Event::Type::ProcessCrashed:
     {
+      ShowProcessStuckIndicator(false);
       ShowRestartButton(true);
     }
     break;
@@ -650,9 +652,6 @@ void ezQtEngineViewWidget::EngineViewProcessEventHandler(const ezEditorEnginePro
     }
     break;
 
-    case ezEditorEngineProcessConnection::Event::Type::ProcessShutdown:
-      break;
-
     case ezEditorEngineProcessConnection::Event::Type::ProcessMessage:
       break;
 
@@ -660,7 +659,14 @@ void ezQtEngineViewWidget::EngineViewProcessEventHandler(const ezEditorEnginePro
       EZ_ASSERT_DEV(false, "Invalid message should never happen");
       break;
 
+    case ezEditorEngineProcessConnection::Event::Type::ProcessShutdown:
     case ezEditorEngineProcessConnection::Event::Type::ProcessRestarted:
+    case ezEditorEngineProcessConnection::Event::Type::ProcessUnstuck:
+      ShowProcessStuckIndicator(false);
+      break;
+
+    case ezEditorEngineProcessConnection::Event::Type::ProcessStuck:
+      ShowProcessStuckIndicator(true);
       break;
   }
 }
@@ -689,6 +695,47 @@ void ezQtEngineViewWidget::ShowRestartButton(bool bShow)
   }
 
   m_pViewportWidget->setVisible(!bShow);
+}
+
+void ezQtEngineViewWidget::ShowProcessStuckIndicator(bool bShow)
+{
+  if (m_pStuckIndicator == nullptr && bShow)
+  {
+    m_pStuckIndicator = new QWidget(m_pViewportWidget);
+    m_pStuckIndicator->setAttribute(Qt::WA_TransparentForMouseEvents);
+
+    QHBoxLayout* pLayout = new QHBoxLayout(m_pStuckIndicator);
+    pLayout->setContentsMargins(8, 8, 8, 8);
+
+    QLabel* pIcon = new QLabel(m_pStuckIndicator);
+    pIcon->setPixmap(QIcon(":/GuiFoundation/Icons/Warning.svg").pixmap(32, 32));
+    pIcon->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    pLayout->addWidget(pIcon);
+
+    ezOsProcessID engineProcess = ezEditorEngineProcessConnection::GetSingleton()->GetEngineProcessID();
+    ezStringBuilder sText;
+    sText.SetFormat("Viewport Stalled, ProcessId: {}\nThe engine process might be busy or ran into a problem.", engineProcess);
+
+    QLabel* pText = new QLabel(ezMakeQString(sText), m_pStuckIndicator);
+    pText->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    pText->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+    pLayout->addWidget(pText);
+
+    m_pStuckIndicator->adjustSize();
+    m_pStuckIndicator->setFixedWidth(5000);
+  }
+
+  if (m_pStuckIndicator)
+  {
+    m_pStuckIndicator->setVisible(bShow);
+
+    if (bShow)
+    {
+      m_pStuckIndicator->move(0, 0);
+      m_pStuckIndicator->raise();
+    }
+  }
 }
 
 void ezQtEngineViewWidget::RecreateEngineViewport()

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -35,6 +35,13 @@ void ezEditorEngineProcessConnection::HandleIPCEvent(const ezProcessCommunicatio
   {
     const ezSyncWithProcessMsgToEditor* msg = static_cast<const ezSyncWithProcessMsgToEditor*>(e.m_pMessage);
     m_uiRedrawCountReceived = msg->m_uiRedrawCount;
+    if (m_uiFailedRedrawCount >= s_uiMaxFailedRedrawCount)
+    {
+      Event e;
+      e.m_Type = Event::Type::ProcessUnstuck;
+      s_Events.Broadcast(e);
+    }
+    m_uiFailedRedrawCount = 0;
   }
   if (e.m_pMessage->GetDynamicRTTI()->IsDerivedFrom<ezEditorEngineDocumentMsg>())
   {
@@ -58,22 +65,36 @@ void ezEditorEngineProcessConnection::HandleIPCEvent(const ezProcessCommunicatio
 
 void ezEditorEngineProcessConnection::UIServicesTickEventHandler(const ezQtUiServices::TickEvent& e)
 {
-  if (e.m_Type == ezQtUiServices::TickEvent::Type::EndFrame)
+  if (e.m_Type == ezQtUiServices::TickEvent::Type::BeforeFrame)
+  {
+    if (IsProcessCrashed())
+    {
+      e.m_uiForceCancelFrame++;
+      return;
+    }
+
+    m_IPC.ProcessMessages();
+    // We still didn't get confirmation from the engine that the frame was drawn, so don't render another frame yet.
+    if (m_uiRedrawCountSent > m_uiRedrawCountReceived)
+    {
+      m_uiFailedRedrawCount++;
+      e.m_uiForceCancelFrame++;
+      if (m_uiFailedRedrawCount == s_uiMaxFailedRedrawCount)
+      {
+        Event e;
+        e.m_Type = Event::Type::ProcessStuck;
+        s_Events.Broadcast(e);
+      }
+      return;
+    }
+  }
+  else if (e.m_Type == ezQtUiServices::TickEvent::Type::EndFrame)
   {
     if (!IsProcessCrashed())
     {
       ezSyncWithProcessMsgToEngine sm;
       sm.m_uiRedrawCount = m_uiRedrawCountSent + 1;
       SendMessage(&sm);
-
-      if (m_uiRedrawCountSent > m_uiRedrawCountReceived)
-      {
-        ezStringBuilder sRedrawScope;
-        sRedrawScope.SetFormat("Wait For Redraw {}", m_uiRedrawCountReceived + 1);
-        EZ_PROFILE_SCOPE(sRedrawScope.GetData());
-        WaitForMessage(ezGetStaticRTTI<ezSyncWithProcessMsgToEditor>(), ezTime::MakeFromSeconds(2.0)).IgnoreResult();
-      }
-
       ++m_uiRedrawCountSent;
     }
   }
@@ -289,6 +310,7 @@ void ezEditorEngineProcessConnection::ShutdownProcess()
 
   m_bClientIsConfigured = false;
   m_bProcessShouldBeRunning = false;
+  m_uiRedrawCountReceived = m_uiRedrawCountSent;
   m_IPC.CloseConnection();
 
   Event e;
@@ -421,6 +443,8 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
   ezLog::Success("Engine Process is running");
 
   m_bClientIsConfigured = true;
+  // We could have crashed while a render was in flight which will now never complete so reset the received counter.
+  m_uiRedrawCountReceived = m_uiRedrawCountSent;
 
   Event e;
   e.m_Type = Event::Type::ProcessRestarted;

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.h
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.h
@@ -71,7 +71,7 @@ public:
       ProcessShutdown,
       ProcessMessage,
       ProcessRestarted,
-      ProcessStuck, ///< Engine process is not responding
+      ProcessStuck,   ///< Engine process is not responding
       ProcessUnstuck, ///< Engine process started responding again after ProcessStuck was triggered
     };
 

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.h
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.h
@@ -55,6 +55,8 @@ public:
 
   bool IsEngineSetup() const { return m_bClientIsConfigured; }
 
+  ezOsProcessID GetEngineProcessID() const { return m_IPC.GetProcessId(); }
+
   void ActivateRemoteProcess(const ezAssetDocument* pDocument, ezUInt32 uiViewID);
 
   ezProcessCommunicationChannel& GetCommunicationChannel() { return m_IPC; }
@@ -69,6 +71,8 @@ public:
       ProcessShutdown,
       ProcessMessage,
       ProcessRestarted,
+      ProcessStuck, ///< Engine process is not responding
+      ProcessUnstuck, ///< Engine process started responding again after ProcessStuck was triggered
     };
 
     Event()
@@ -90,12 +94,14 @@ private:
   bool ConnectToRemoteProcess();
   void ShutdownRemoteProcess();
 
-  bool m_bProcessShouldBeRunning;
-  bool m_bProcessCrashed;
-  bool m_bClientIsConfigured;
+  static constexpr ezUInt32 s_uiMaxFailedRedrawCount = 5 * 60;
+  bool m_bProcessShouldBeRunning = false;
+  bool m_bProcessCrashed = false;
+  bool m_bClientIsConfigured = false;
   ezEventSubscriptionID m_TickEventSubscriptionID = 0;
   ezUInt32 m_uiRedrawCountSent = 0;
   ezUInt32 m_uiRedrawCountReceived = 0;
+  ezUInt32 m_uiFailedRedrawCount = 0;
 
   ezEditorProcessCommunicationChannel m_IPC;
   ezUniquePtr<ezEditorProcessRemoteCommunicationChannel> m_pRemoteProcess;

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -127,7 +127,7 @@ void ezQtDocumentWindow::TriggerRedraw()
 
 void ezQtDocumentWindow::UIServicesTickEventHandler(const ezQtUiServices::TickEvent& e)
 {
-  auto ShouldRender = [&]()-> bool
+  auto ShouldRender = [&]() -> bool
   {
     if (!m_bIsVisibleInContainer)
       return false;

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.cpp
@@ -103,7 +103,7 @@ void ezQtDocumentWindow::SetVisibleInContainer(bool bVisible)
   if (m_bIsVisibleInContainer)
   {
     // if the window is now visible, immediately do a redraw and trigger the timers
-    SlotRedraw();
+    TriggerRedraw();
     // Make sure the window gains focus as well when it becomes visible so that shortcuts will immediately work.
     setFocus();
   }
@@ -117,18 +117,23 @@ void ezQtDocumentWindow::SetTargetFramerate(ezInt16 iTargetFPS)
   m_iTargetFramerate = iTargetFPS;
 
   if (m_iTargetFramerate != 0)
-    SlotRedraw();
+    TriggerRedraw();
 }
 
 void ezQtDocumentWindow::TriggerRedraw()
 {
-  SlotRedraw();
+  m_bRedrawIsTriggered = true;
 }
 
 void ezQtDocumentWindow::UIServicesTickEventHandler(const ezQtUiServices::TickEvent& e)
 {
-  if (e.m_Type == ezQtUiServices::TickEvent::Type::StartFrame && m_bIsVisibleInContainer)
+  auto ShouldRender = [&]()-> bool
   {
+    if (!m_bIsVisibleInContainer)
+      return false;
+    if (m_bRedrawIsTriggered)
+      return true;
+
     const ezInt32 iSystemFramerate = static_cast<ezInt32>(ezMath::Round(e.m_fRefreshRate));
 
     ezInt32 iTargetFramerate = m_iTargetFramerate;
@@ -144,13 +149,26 @@ void ezQtDocumentWindow::UIServicesTickEventHandler(const ezQtUiServices::TickEv
     {
       ezUInt32 mod = ezMath::Max(1u, (ezUInt32)ezMath::Floor(iSystemFramerate / (double)iTargetFramerate));
       if ((e.m_uiFrame % mod) != 0)
-        return;
+        return false;
     }
+    return true;
+  };
 
-    SlotRedraw();
+  if (e.m_Type == ezQtUiServices::TickEvent::Type::BeforeFrame)
+  {
+    if (ShouldRender())
+    {
+      e.m_uiFrameRequest++;
+    }
+  }
+  else if (e.m_Type == ezQtUiServices::TickEvent::Type::StartFrame)
+  {
+    if (ShouldRender())
+    {
+      SlotRedraw();
+    }
   }
 }
-
 
 void ezQtDocumentWindow::SlotRedraw()
 {
@@ -170,6 +188,7 @@ void ezQtDocumentWindow::SlotRedraw()
   m_bIsDrawingATM = true;
   InternalRedraw();
   m_bIsDrawingATM = false;
+  m_bRedrawIsTriggered = false;
 }
 
 void ezQtDocumentWindow::DocumentEventHandler(const ezDocumentEvent& e)

--- a/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/DocumentWindow/DocumentWindow.moc.h
@@ -105,7 +105,6 @@ private:
   friend class ezQtContainerWindow;
 
   void SetVisibleInContainer(bool bVisible);
-
   bool m_bIsVisibleInContainer = false;
   bool m_bRedrawIsTriggered = false;
   bool m_bIsDrawingATM = false;

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -288,17 +288,27 @@ void ezQtUiServices::TickEventHandler()
 
   EZ_ASSERT_DEV(!m_bIsDrawingATM, "Implementation error");
   ezTime startTime = ezTime::Now();
-
-  m_bIsDrawingATM = true;
   s_LastTickEvent.m_uiFrame++;
   s_LastTickEvent.m_Time = startTime;
-  s_LastTickEvent.m_Type = TickEvent::Type::StartFrame;
-  s_TickEvent.Broadcast(s_LastTickEvent);
 
-  s_LastTickEvent.m_Type = TickEvent::Type::EndFrame;
-  s_TickEvent.Broadcast(s_LastTickEvent);
-  m_bIsDrawingATM = false;
+  bool bFrameRequested = false;
+  {
+    s_LastTickEvent.m_Type = TickEvent::Type::BeforeFrame;
+    s_LastTickEvent.m_uiFrameRequest = 0;
+    s_LastTickEvent.m_uiForceCancelFrame = 0;
+    s_TickEvent.Broadcast(s_LastTickEvent);
+    bFrameRequested = s_LastTickEvent.m_uiFrameRequest != 0 && s_LastTickEvent.m_uiForceCancelFrame == 0;
+  }
 
+  if (bFrameRequested)
+  {
+    m_bIsDrawingATM = true;
+    s_LastTickEvent.m_Type = TickEvent::Type::StartFrame;
+    s_TickEvent.Broadcast(s_LastTickEvent);
+    s_LastTickEvent.m_Type = TickEvent::Type::EndFrame;
+    s_TickEvent.Broadcast(s_LastTickEvent);
+    m_bIsDrawingATM = false;
+  }
   const ezTime endTime = ezTime::Now();
   ezTime lastFrameTime = endTime - startTime;
 
@@ -311,6 +321,7 @@ void ezQtUiServices::TickEventHandler()
 
 void ezQtUiServices::LoadState()
 {
+  EZ_PROFILE_SCOPE("LoadState");
   QSettings Settings;
   Settings.beginGroup("EditorGUI");
   {
@@ -454,63 +465,71 @@ namespace ezQtUtils
 {
   bool IsEquivalentQtKey(const QKeyEvent* e, Qt::Key reference)
   {
+    // X11 (xcb) keycodes are hardware scan codes + 8 offset, Wayland uses raw evdev codes
+#if EZ_ENABLED(EZ_PLATFORM_LINUX)
+    const quint32 SC_OFFSET = (QGuiApplication::platformName() == "xcb") ? 8 : 0;
+#else
+    constexpr quint32 SC_OFFSET = 0;
+#endif
+
+    const quint32 nativeScanCode = e->nativeScanCode();
     switch (reference)
     {
       case Qt::Key_A:
-        return e->nativeScanCode() == 30;
+        return nativeScanCode == 30 + SC_OFFSET;
       case Qt::Key_B:
-        return e->nativeScanCode() == 48;
+        return nativeScanCode == 48 + SC_OFFSET;
       case Qt::Key_C:
-        return e->nativeScanCode() == 46;
+        return nativeScanCode == 46 + SC_OFFSET;
       case Qt::Key_D:
-        return e->nativeScanCode() == 32;
+        return nativeScanCode == 32 + SC_OFFSET;
       case Qt::Key_E:
-        return e->nativeScanCode() == 18;
+        return nativeScanCode == 18 + SC_OFFSET;
       case Qt::Key_F:
-        return e->nativeScanCode() == 33;
+        return nativeScanCode == 33 + SC_OFFSET;
       case Qt::Key_G:
-        return e->nativeScanCode() == 34;
+        return nativeScanCode == 34 + SC_OFFSET;
       case Qt::Key_H:
-        return e->nativeScanCode() == 35;
+        return nativeScanCode == 35 + SC_OFFSET;
       case Qt::Key_I:
-        return e->nativeScanCode() == 23;
+        return nativeScanCode == 23 + SC_OFFSET;
       case Qt::Key_J:
-        return e->nativeScanCode() == 36;
+        return nativeScanCode == 36 + SC_OFFSET;
       case Qt::Key_K:
-        return e->nativeScanCode() == 37;
+        return nativeScanCode == 37 + SC_OFFSET;
       case Qt::Key_L:
-        return e->nativeScanCode() == 38;
+        return nativeScanCode == 38 + SC_OFFSET;
       case Qt::Key_M:
-        return e->nativeScanCode() == 50;
+        return nativeScanCode == 50 + SC_OFFSET;
       case Qt::Key_N:
-        return e->nativeScanCode() == 49;
+        return nativeScanCode == 49 + SC_OFFSET;
       case Qt::Key_O:
-        return e->nativeScanCode() == 24;
+        return nativeScanCode == 24 + SC_OFFSET;
       case Qt::Key_P:
-        return e->nativeScanCode() == 25;
+        return nativeScanCode == 25 + SC_OFFSET;
       case Qt::Key_Q:
-        return e->nativeScanCode() == 16;
+        return nativeScanCode == 16 + SC_OFFSET;
       case Qt::Key_R:
-        return e->nativeScanCode() == 19;
+        return nativeScanCode == 19 + SC_OFFSET;
       case Qt::Key_S:
-        return e->nativeScanCode() == 31;
+        return nativeScanCode == 31 + SC_OFFSET;
       case Qt::Key_T:
-        return e->nativeScanCode() == 20;
+        return nativeScanCode == 20 + SC_OFFSET;
       case Qt::Key_U:
-        return e->nativeScanCode() == 22;
+        return nativeScanCode == 22 + SC_OFFSET;
       case Qt::Key_V:
-        return e->nativeScanCode() == 47;
+        return nativeScanCode == 47 + SC_OFFSET;
       case Qt::Key_W:
-        return e->nativeScanCode() == 17;
+        return nativeScanCode == 17 + SC_OFFSET;
       case Qt::Key_X:
-        return e->nativeScanCode() == 45;
+        return nativeScanCode == 45 + SC_OFFSET;
       case Qt::Key_Y:
-        return e->nativeScanCode() == 21;
+        return nativeScanCode == 21 + SC_OFFSET;
       case Qt::Key_Z:
-        return e->nativeScanCode() == 44;
+        return nativeScanCode == 44 + SC_OFFSET;
 
       default:
-        ezLog::Dev("IsEquivalentQtKey: Undefined scancode mapping for key: {} (pressed: {})", (int)reference, e->nativeScanCode());
+        ezLog::Dev("IsEquivalentQtKey: Undefined scancode mapping for key: {} (pressed: {})", (int)reference, nativeScanCode);
         break;
     }
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -58,7 +58,7 @@ public:
     ezUInt32 m_uiFrame = 0;
     ezTime m_Time;
     double m_fRefreshRate = 60.0;
-    mutable ezUInt32 m_uiFrameRequest = 0; ///< Only valid for Type::BeforeFrame. Increased by an event handler to request a frame. If zero after the broadcast, no frame is started.
+    mutable ezUInt32 m_uiFrameRequest = 0;     ///< Only valid for Type::BeforeFrame. Increased by an event handler to request a frame. If zero after the broadcast, no frame is started.
     mutable ezUInt32 m_uiForceCancelFrame = 0; ///< Only valid for Type::BeforeFrame. Increased by an event handler to cancel the frame. Regardless of m_uiFrameRequest, no frame is started if != zero.
   };
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -49,6 +49,7 @@ public:
   {
     enum class Type
     {
+      BeforeFrame, ///< Check for any request for a frame.
       StartFrame,
       EndFrame,
     };
@@ -57,6 +58,8 @@ public:
     ezUInt32 m_uiFrame = 0;
     ezTime m_Time;
     double m_fRefreshRate = 60.0;
+    mutable ezUInt32 m_uiFrameRequest = 0; ///< Only valid for Type::BeforeFrame. Increased by an event handler to request a frame. If zero after the broadcast, no frame is started.
+    mutable ezUInt32 m_uiForceCancelFrame = 0; ///< Only valid for Type::BeforeFrame. Increased by an event handler to cancel the frame. Regardless of m_uiFrameRequest, no frame is started if != zero.
   };
 
   static ezEvent<const ezQtUiServices::TickEvent&> s_TickEvent;


### PR DESCRIPTION
## Editor Engine Process Communication

* Added `ProcessStuck` and `ProcessUnstuck` events to detect unresponsive engine process.
* Changed frame synchronization to non-blocking: editor no longer waits for engine redraw confirmation.
* Added failed redraw counter with 5-sec threshold before triggering stuck state.

## Engine View Widget

* Added visual "Viewport Stalled" indicator when engine process stops responding.
* Indicator displays warning icon and engine process ID for debugging.
  <img width="404" height="108" alt="image" src="https://github.com/user-attachments/assets/24cb158a-63e9-445a-9214-787116048d16" />

## UI Services / Tick Event System:

* Added `BeforeFrame` tick event type with frame request/cancel mechanism.
* Document windows now always request frames via tick event instead of direct requests.
* Fixed `IsEquivalentQtKey` scan codes for Linux: added +8 offset for X11 (xcb).

## Document Window

* Refactored redraw logic to use new tick event frame request system.
* `TriggerRedraw()` now sets a flag instead of immediately rendering.