### PR TITLE
Android Arm64 Physical Device Testing

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Android-arm64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-arm64.yml
@@ -1,3 +1,9 @@
+parameters:
+- name: runTests
+  displayName: Run Tests
+  type: boolean
+  default: true
+
 trigger:
   branches:
     include:
@@ -8,6 +14,12 @@ resources:
   - repository: self
     type: git
     ref: dev
+
+variables:
+  androidHome: '$(System.DefaultWorkingDirectory)/Workspace/shared/android'
+  androidNdkHome: '$(System.DefaultWorkingDirectory)/Workspace/shared/android/ndk/26.1.10909125'
+  javaHome: '$(System.DefaultWorkingDirectory)/Workspace/shared/android/jdk17'
+  deviceAdb: '192.168.178.77:5555'
 
 jobs:
 - job: Android_arm64
@@ -79,4 +91,92 @@ jobs:
     inputs:
       targetType: inline
       script: ninja -C Workspace/android-arm64-dev
+
+  - ${{ if eq(parameters.runTests, true) }}:
+    - task: PowerShell@2
+      displayName: Connect to Device
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          & "$(androidHome)/platform-tools/adb" connect $(deviceAdb)
+          & "$(androidHome)/platform-tools/adb" -s $(deviceAdb) wait-for-device
+      env:
+        ANDROID_HOME: '$(androidHome)'
+
+    - task: PowerShell@2
+      displayName: Check Ready for Testing
+      inputs:
+        targetType: inline
+        script: Write-Host "##vso[task.setvariable variable=task.MSBuild.status]success"
+
+    - task: PowerShell@2
+      displayName: FoundationTest
+      condition: eq(variables['task.MSBuild.status'], 'success')
+      inputs:
+        targetType: filepath
+        pwsh: true
+        filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
+        arguments: "-deviceAdb $(deviceAdb) -packageName com.ezengine.FoundationTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/FoundationTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDevArm64/FoundationTest.apk"
+      env:
+        ANDROID_HOME: '$(androidHome)'
+        ANDROID_NDK_HOME: '$(androidNdkHome)'
+        JAVA_HOME: '$(javaHome)'
+
+    - task: PowerShell@2
+      displayName: CoreTest
+      condition: eq(variables['task.MSBuild.status'], 'success')
+      inputs:
+        targetType: filepath
+        pwsh: true
+        filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
+        arguments: "-deviceAdb $(deviceAdb) -packageName com.ezengine.CoreTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/CoreTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDevArm64/CoreTest.apk"
+      env:
+        ANDROID_HOME: '$(androidHome)'
+        ANDROID_NDK_HOME: '$(androidNdkHome)'
+        JAVA_HOME: '$(javaHome)'
+
+    - task: PowerShell@2
+      displayName: RendererTest
+      condition: eq(variables['task.MSBuild.status'], 'success')
+      inputs:
+        targetType: filepath
+        pwsh: true
+        filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
+        arguments: "-deviceAdb $(deviceAdb) -packageName com.ezengine.RendererTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/RendererTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDevArm64/RendererTest.apk"
+      env:
+        ANDROID_HOME: '$(androidHome)'
+        ANDROID_NDK_HOME: '$(androidNdkHome)'
+        JAVA_HOME: '$(javaHome)'
+
+    - task: PowerShell@2
+      displayName: ToolsFoundationTest
+      condition: eq(variables['task.MSBuild.status'], 'success')
+      inputs:
+        targetType: filepath
+        pwsh: true
+        filePath: $(System.DefaultWorkingDirectory)/Utilities/Android/AndroidTest.ps1
+        arguments: "-deviceAdb $(deviceAdb) -packageName com.ezengine.ToolsFoundationTest -activityName android.app.NativeActivity -outputFolder $(Build.ArtifactStagingDirectory)/Test/ToolsFoundationTest -apk $(System.DefaultWorkingDirectory)/Output/Bin/AndroidNinjaClangDevArm64/ToolsFoundationTest.apk"
+      env:
+        ANDROID_HOME: '$(androidHome)'
+        ANDROID_NDK_HOME: '$(androidNdkHome)'
+        JAVA_HOME: '$(javaHome)'
+
+    - task: PowerShell@2
+      displayName: Disconnect from Device
+      condition: always()
+      inputs:
+        pwsh: true
+        targetType: inline
+        script: |
+          & "$(androidHome)/platform-tools/adb" disconnect $(deviceAdb)
+      env:
+        ANDROID_HOME: '$(androidHome)'
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: TestResults'
+      condition: eq(variables['task.MSBuild.status'], 'success')
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)/Test
+        ArtifactName: TestResults
 ...

--- a/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
+++ b/Code/Engine/RendererDX11/Device/Implementation/DeviceDX11.cpp
@@ -1090,6 +1090,7 @@ void ezGALDeviceDX11::FillCapabilitiesPlatform()
       m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = true;
       m_Capabilities.m_bSupportsIndirectDraw = true;
       m_Capabilities.m_bSupportsSharedTextures = true;
+      m_Capabilities.m_bSupportsWireframe = true;
       break;
 
       // not supported any longer

--- a/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
+++ b/Code/Engine/RendererFoundation/Device/DeviceCapabilities.h
@@ -69,6 +69,7 @@ struct EZ_RENDERERFOUNDATION_DLL ezGALDeviceCapabilities
   bool m_bShaderStageSupported[ezGALShaderStage::ENUM_COUNT] = {};
   bool m_bSupportsIndirectDraw = false;
   bool m_bSupportsConservativeRasterization = false;
+  bool m_bSupportsWireframe = false;
   bool m_bSupportsVSRenderTargetArrayIndex = false;
   bool m_bSupportsTexelBuffer = false; ///< Whether ezGALBufferUsageFlags::TexelBuffer is supported. Hardcoded per platform as it must match SUPPORTS_TEXEL_BUFFER shader define.
   bool m_bSupportsMultipleSRVTypes = true; ///< Whether more than one of ezGALBufferUsageFlags::StructuredBuffer, ezGALBufferUsageFlags::TexelBuffer and ezGALBufferUsageFlags::ByteAddressBuffer is supported on a buffer.

--- a/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
+++ b/Code/Engine/RendererVulkan/Device/DeviceVulkan.h
@@ -161,6 +161,8 @@ public:
 
   vk::PhysicalDevice GetVulkanPhysicalDevice() const;
   EZ_ALWAYS_INLINE const vk::PhysicalDeviceProperties& GetPhysicalDeviceProperties() const { return m_properties.properties; }
+  vk::PhysicalDeviceFeatures2 GetPhysicalDeviceFeatures(void* pNext = nullptr) const;
+
   const Extensions& GetExtensions() const { return m_extensions; }
   const ezVulkanDispatchContext& GetDispatchContext() const { return m_dispatchContext; }
   vk::PipelineStageFlags GetSupportedStages() const;

--- a/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
+++ b/Code/Engine/RendererVulkan/Device/Implementation/DeviceVulkan.cpp
@@ -250,10 +250,7 @@ vk::Result ezGALDeviceVulkan::SelectDeviceExtensions(vk::DeviceCreateInfo& devic
   VK_SUCCEED_OR_RETURN_LOG(AddExtIfSupported(VK_KHR_SWAPCHAIN_EXTENSION_NAME, m_extensions.m_bDeviceSwapChain));
   AddExtIfSupported(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME, m_extensions.m_bShaderViewportIndexLayer);
 
-  vk::PhysicalDeviceFeatures2 features;
-  features.pNext = &m_extensions.m_borderColorEXT;
-  m_physicalDevice.getFeatures2(&features);
-
+  vk::PhysicalDeviceFeatures2 features = GetPhysicalDeviceFeatures(&m_extensions.m_borderColorEXT);
   m_supportedStages = vk::PipelineStageFlagBits::eVertexShader | vk::PipelineStageFlagBits::eFragmentShader | vk::PipelineStageFlagBits::eComputeShader;
   if (features.features.geometryShader)
   {
@@ -481,10 +478,7 @@ ezResult ezGALDeviceVulkan::InitPlatform()
 
     {
       vk::PhysicalDeviceTimelineSemaphoreFeatures timelineFeatures;
-      vk::PhysicalDeviceFeatures2 features2;
-      features2.pNext = &timelineFeatures;
-      m_physicalDevice.getFeatures2(&features2);
-
+      vk::PhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures(&timelineFeatures);
       m_extensions.m_bTimelineSemaphore = static_cast<bool>(timelineFeatures.timelineSemaphore);
       m_extensions.m_timelineSemaphoresEXT = timelineFeatures;
     }
@@ -573,8 +567,8 @@ ezResult ezGALDeviceVulkan::InitPlatform()
     deviceCreateInfo.enabledExtensionCount = deviceExtensionsPtr.GetCount();
     deviceCreateInfo.ppEnabledExtensionNames = deviceExtensionsPtr.GetData();
 
-    vk::PhysicalDeviceFeatures physicalDeviceFeatures = m_physicalDevice.getFeatures();
-    deviceCreateInfo.pEnabledFeatures = &physicalDeviceFeatures; // Enabling all available features for now
+    vk::PhysicalDeviceFeatures2 physicalDeviceFeatures = GetPhysicalDeviceFeatures();
+    deviceCreateInfo.pEnabledFeatures = &physicalDeviceFeatures.features; // Enabling all available features for now
     deviceCreateInfo.queueCreateInfoCount = queues.GetCount();
     deviceCreateInfo.pQueueCreateInfos = queues.GetData();
 
@@ -1660,7 +1654,7 @@ ezUInt64 ezGALDeviceVulkan::GetSafeFramePlatform() const
 void ezGALDeviceVulkan::FillCapabilitiesPlatform()
 {
   vk::PhysicalDeviceMemoryProperties memProperties = m_physicalDevice.getMemoryProperties();
-  vk::PhysicalDeviceFeatures features = m_physicalDevice.getFeatures();
+  vk::PhysicalDeviceFeatures2 features = GetPhysicalDeviceFeatures();
 
   ezUInt64 dedicatedMemory = 0;
   ezUInt64 systemMemory = 0;
@@ -1691,9 +1685,9 @@ void ezGALDeviceVulkan::FillCapabilitiesPlatform()
   m_Capabilities.m_materialBufferLayout = ezGALBufferLayout::Vulkan_Std430_relaxed;
 
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::VertexShader] = true;
-  m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = features.tessellationShader;
-  m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::DomainShader] = features.tessellationShader;
-  m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = features.geometryShader;
+  m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::HullShader] = features.features.tessellationShader;
+  m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::DomainShader] = features.features.tessellationShader;
+  m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::GeometryShader] = features.features.geometryShader;
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::PixelShader] = true;
   m_Capabilities.m_bShaderStageSupported[ezGALShaderStage::ComputeShader] = true; // we check this when creating the queue, always has to be supported
   m_Capabilities.m_bSupportsIndirectDraw = true;
@@ -1709,6 +1703,7 @@ void ezGALDeviceVulkan::FillCapabilitiesPlatform()
   m_Capabilities.m_bSupportsVSRenderTargetArrayIndex = m_extensions.m_bShaderViewportIndexLayer;
 
   m_Capabilities.m_bSupportsConservativeRasterization = false; // need to query for VK_EXT_CONSERVATIVE_RASTERIZATION
+  m_Capabilities.m_bSupportsWireframe = features.features.fillModeNonSolid;
 
   m_Capabilities.m_FormatSupport.SetCount(ezGALResourceFormat::ENUM_COUNT);
   for (ezUInt32 i = 0; i < ezGALResourceFormat::ENUM_COUNT; i++)
@@ -1797,6 +1792,19 @@ void ezGALDeviceVulkan::WaitIdleInternal(bool bAddUpdateForNextFrameCommands)
       ReclaimResources(m_PerFrameData[i].m_reclaimResources);
     }
   }
+}
+
+vk::PhysicalDeviceFeatures2 ezGALDeviceVulkan::GetPhysicalDeviceFeatures(void* pNext) const
+{
+  vk::PhysicalDeviceFeatures2 features;
+  features.pNext = pNext;
+  m_physicalDevice.getFeatures2(&features);
+
+  ezStringBuilder sDeviceName = ezStringUtf8(m_properties.properties.deviceName).GetView();
+  // Tessellation test crashes on Mali
+  if (sDeviceName == "Mali-G610")
+    features.features.tessellationShader = false;
+  return features;
 }
 
 vk::PipelineStageFlags ezGALDeviceVulkan::GetSupportedStages() const

--- a/Code/UnitTests/FoundationTest/Math/FrustumTest.cpp
+++ b/Code/UnitTests/FoundationTest/Math/FrustumTest.cpp
@@ -330,9 +330,18 @@ EZ_CREATE_SIMPLE_TEST(Math, Frustum)
     ezVec3 corners2[8];
     fNew.ComputeCornerPoints(corners2).AssertSuccess();
 
+    // On ARM64, MakeFromCorners uses cross products on nearly-parallel edge vectors (~171 units long, differing by ~0.2),
+    // causing catastrophic cancellation that amplifies small input differences into larger plane normal errors.
+    // The reconstructed far-plane corners end up with ~0.005 error vs ~0.001 on x86.
+#if EZ_ENABLED(EZ_PLATFORM_ARCH_ARM)
+    const float fCornerEpsilon = ezMath::VeryHugeEpsilon<float>();
+#else
+    const float fCornerEpsilon = ezMath::HugeEpsilon<float>();
+#endif
+
     for (ezUInt32 i = 0; i < 8; ++i)
     {
-      EZ_TEST_BOOL(corners[i].IsEqual(corners2[i], ezMath::HugeEpsilon<float>()));
+      EZ_TEST_BOOL(corners[i].IsEqual(corners2[i], fCornerEpsilon));
     }
   }
 

--- a/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
+++ b/Code/UnitTests/RendererTest/Basics/RasterizerStates.cpp
@@ -67,6 +67,7 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
     RasterStateDesc.m_bScissorTest = true;
   }
 
+
   if (m_iFrame == 7)
   {
     RasterStateDesc.m_bFrontCounterClockwise = false;
@@ -129,10 +130,14 @@ ezTestAppRun ezRendererTestBasics::SubtestRasterizerStates()
   EndRendering();
   if (RasterStateDesc.m_bWireFrame)
   {
-    ezStringView sRendererName = m_pDevice->GetRenderer();
-    const bool bRandomlyChangesLineThicknessOnDriverUpdate = sRendererName.IsEqual_NoCase("DX11") && m_pDevice->GetCapabilities().m_sAdapterName.FindSubString_NoCase("Nvidia");
+    const bool bSupportsWireframe = GetDeviceCapabilities().m_bSupportsWireframe;
+    if (bSupportsWireframe)
+    {
+      ezStringView sRendererName = m_pDevice->GetRenderer();
+      const bool bRandomlyChangesLineThicknessOnDriverUpdate = sRendererName.IsEqual_NoCase("DX11") && m_pDevice->GetCapabilities().m_sAdapterName.FindSubString_NoCase("Nvidia");
 
-    EZ_TEST_LINE_IMAGE(m_iFrame, bRandomlyChangesLineThicknessOnDriverUpdate ? 1000 : 300);
+      EZ_TEST_LINE_IMAGE(m_iFrame, bRandomlyChangesLineThicknessOnDriverUpdate ? 1000 : 300);
+    }
   }
   else
     EZ_TEST_IMAGE(m_iFrame, 200);

--- a/Code/UnitTests/RendererTest/Basics/Textures.cpp
+++ b/Code/UnitTests/RendererTest/Basics/Textures.cpp
@@ -171,76 +171,101 @@ ezTestAppRun ezRendererTestBasics::SubtestTexturesCube()
   const ezInt32 iNumFrames = 12;
 
   m_hShader = ezResourceManager::LoadResource<ezShaderResource>("RendererTest/Shaders/TexturedCube.ezShader");
+  ezEnum<ezGALResourceFormat> textureFormat;
+  ezStringView sTextureResourceId;
 
   if (m_iFrame == 0)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_XRGB_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_XRGB_NoMips_D.dds";
   }
 
   if (m_iFrame == 1)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_XRGB_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_XRGB_Mips_D.dds";
   }
 
   if (m_iFrame == 2)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_RGBA_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_RGBA_NoMips_D.dds";
   }
 
   if (m_iFrame == 3)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_RGBA_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::RGBAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_RGBA_Mips_D.dds";
   }
 
   if (m_iFrame == 4)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_DXT1_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BC1sRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_DXT1_NoMips_D.dds";
   }
 
   if (m_iFrame == 5)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_DXT1_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BC1sRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_DXT1_Mips_D.dds";
   }
 
   if (m_iFrame == 6)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_DXT3_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BC2sRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_DXT3_NoMips_D.dds";
   }
 
   if (m_iFrame == 7)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_DXT3_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BC2sRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_DXT3_Mips_D.dds";
   }
 
   if (m_iFrame == 8)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_DXT5_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BC3sRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_DXT5_NoMips_D.dds";
   }
 
   if (m_iFrame == 9)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_DXT5_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BC3sRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_DXT5_Mips_D.dds";
   }
 
   if (m_iFrame == 10)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_RGB_NoMips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_RGB_NoMips_D.dds";
   }
 
   if (m_iFrame == 11)
   {
-    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>("SharedData/Textures/Cubemap/ezLogo_Cube_RGB_Mips_D.dds");
+    textureFormat = ezGALResourceFormat::BGRAUByteNormalizedsRGB;
+    sTextureResourceId = "SharedData/Textures/Cubemap/ezLogo_Cube_RGB_Mips_D.dds";
   }
 
-  ezBindGroupBuilder& bindGroupTest = ezRenderContext::GetDefaultInstance()->GetBindGroup();
-  bindGroupTest.BindTexture("DiffuseTexture", m_hTextureCube);
-
+  const bool bSupported = m_pDevice->GetCapabilities().m_FormatSupport[textureFormat].AreAllSet(ezGALResourceFormatSupport::Texture);
+  if (bSupported)
+  {
+    ezBindGroupBuilder& bindGroupTest = ezRenderContext::GetDefaultInstance()->GetBindGroup();
+    m_hTextureCube = ezResourceManager::LoadResource<ezTextureCubeResource>(sTextureResourceId);
+    bindGroupTest.BindTexture("DiffuseTexture", m_hTextureCube);
+  }
   BeginRendering(ezColor::Black);
 
-  RenderObjects(ezShaderBindFlags::Default);
+  if (bSupported)
+  {
+    RenderObjects(ezShaderBindFlags::Default);
+  }
 
   EndRendering();
-  EZ_TEST_IMAGE(m_iFrame, 200);
+
+  if (bSupported)
+  {
+    EZ_TEST_IMAGE(m_iFrame, 200);
+  }
   EndCommands();
   EndFrame();
 

--- a/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
+++ b/Code/UnitTests/TestFramework/Framework/TestFramework.cpp
@@ -401,13 +401,16 @@ void ezTestFramework::ApplyTestOrderFromCommandLine(const ezCommandLineUtils& cm
     const ezUInt32 uiTestCount = GetTestCount();
     for (ezUInt32 uiTestIdx = 0; uiTestIdx < uiTestCount; ++uiTestIdx)
     {
-      const bool bEnable = std::regex_search(m_TestEntries[uiTestIdx].m_szTestName, filterRegex);
-      m_TestEntries[uiTestIdx].m_bEnableTest = bEnable;
+      const bool bEnableTest = std::regex_search(m_TestEntries[uiTestIdx].m_szTestName, filterRegex);
+      bool bAnySubTestEnabled = bEnableTest;
       const ezUInt32 uiSubTestCount = (ezUInt32)m_TestEntries[uiTestIdx].m_SubTests.size();
       for (ezUInt32 uiSubTest = 0; uiSubTest < uiSubTestCount; ++uiSubTest)
       {
-        m_TestEntries[uiTestIdx].m_SubTests[uiSubTest].m_bEnableTest = bEnable;
+        const bool bEnableSubTest = bEnableTest || std::regex_search(m_TestEntries[uiTestIdx].m_SubTests[uiSubTest].m_szSubTestName, filterRegex);
+        m_TestEntries[uiTestIdx].m_SubTests[uiSubTest].m_bEnableTest = bEnableSubTest;
+        bAnySubTestEnabled |= bEnableSubTest;
       }
+      m_TestEntries[uiTestIdx].m_bEnableTest = bAnySubTestEnabled;
     }
   }
 }

--- a/gitClean.txt
+++ b/gitClean.txt
@@ -1,2 +1,2 @@
 Change this file to force a clean build on CI.
-Change me: X7920CB7-B6E2-4555-B76C-FF53BDD6D330AAA
+Change me: XYZSX7920CB7-B6E2-4555-B76C-FF53BDD6D330ABAA


### PR DESCRIPTION
* Added a Radxa5b+ arm64 device to the Linux CI machine.
* Fix Textures test loading BCx textures without checking for capabilites.
* Extracted `GetPhysicalDeviceFeatures` function in Vulkan device to disable tesselation on my Mali test device as it crashes.
* Added `m_bSupportsWireframe` device capability and used it in `SubtestRasterizerStates`.
* Added support for enabling sub-tests via `-filter` on TestFramework.