### PR TITLE
Command history now resets modified state when undoing to a saved state

### DIFF
--- a/Code/Engine/Foundation/Utilities/DGMLWriter.h
+++ b/Code/Engine/Foundation/Utilities/DGMLWriter.h
@@ -68,7 +68,7 @@ public:
   CategoryId AddConnectionCategory(ezStringView sName, const ezColor& color);
 
   /// \brief Adds a directed connection to the graph (an arrow pointing from source to target node).
-  ConnectionId AddConnection(NodeId source, NodeId target, ezStringView sLabel = {}, CategoryId uiCategory = ezInvalidIndex);
+  ConnectionId AddConnection(NodeId source, NodeId target, ezStringView sLabel = {}, CategoryId category = ezInvalidIndex);
 
   /// \brief Adds a property type. All properties currently use the data type 'string'
   PropertyId AddPropertyType(ezStringView sName);

--- a/Code/Engine/Foundation/Utilities/Implementation/DGMLWriter.cpp
+++ b/Code/Engine/Foundation/Utilities/Implementation/DGMLWriter.cpp
@@ -45,14 +45,14 @@ ezDGMLGraph::CategoryId ezDGMLGraph::AddConnectionCategory(ezStringView sName, c
   return m_ConnectionCategories.GetCount() - 1;
 }
 
-ezDGMLGraph::ConnectionId ezDGMLGraph::AddConnection(ezDGMLGraph::NodeId source, ezDGMLGraph::NodeId target, ezStringView sLabel, CategoryId uiCategory)
+ezDGMLGraph::ConnectionId ezDGMLGraph::AddConnection(ezDGMLGraph::NodeId source, ezDGMLGraph::NodeId target, ezStringView sLabel, CategoryId category)
 {
   ezDGMLGraph::Connection& connection = m_Connections.ExpandAndGetRef();
 
   connection.m_Source = source;
   connection.m_Target = target;
   connection.m_sLabel = sLabel;
-  connection.m_uiCategory = uiCategory;
+  connection.m_uiCategory = category;
 
   return m_Connections.GetCount() - 1;
 }

--- a/Code/Tools/Libs/ToolsFoundation/CommandHistory/CommandHistory.h
+++ b/Code/Tools/Libs/ToolsFoundation/CommandHistory/CommandHistory.h
@@ -3,6 +3,7 @@
 #include <Foundation/Types/RefCounted.h>
 #include <Foundation/Types/SharedPtr.h>
 #include <ToolsFoundation/Command/Command.h>
+#include <ToolsFoundation/Document/Implementation/Declarations.h>
 #include <ToolsFoundation/ToolsFoundationDLL.h>
 
 class ezCommandHistory;
@@ -63,6 +64,9 @@ public:
     ezDeque<ezCommandTransaction*> m_RedoHistory;
     ezDocument* m_pDocument = nullptr;
     ezEvent<const ezCommandHistoryEvent&, ezMutex> m_Events;
+
+    /// \brief The undo stack size at the point when the document was last saved. -1 if the saved state is no longer reachable via undo/redo.
+    ezInt32 m_iSavedHistoryIndex = 0;
   };
 
 public:
@@ -126,6 +130,7 @@ private:
   ezSharedPtr<ezCommandHistory::Storage> m_pHistoryStorage;
 
   ezEvent<const ezCommandHistoryEvent&, ezMutex>::Unsubscriber m_EventsUnsubscriber;
+  ezEvent<const ezDocumentEvent&>::Unsubscriber m_DocumentSavedUnsubscriber;
 
   bool m_bFireEventsWhenUndoingTempCommands = false;
   bool m_bTemporaryMode = false;

--- a/Code/Tools/Libs/ToolsFoundation/CommandHistory/Implementation/CommandHistory.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/CommandHistory/Implementation/CommandHistory.cpp
@@ -147,7 +147,9 @@ ezStatus ezCommandHistory::UndoInternal()
     m_pHistoryStorage->m_UndoHistory.PopBack();
     m_pHistoryStorage->m_RedoHistory.PushBack(pTransaction);
 
-    m_pHistoryStorage->m_pDocument->SetModified(true);
+    const bool bAtSavedState = m_pHistoryStorage->m_iSavedHistoryIndex >= 0 &&
+                               (ezInt32)m_pHistoryStorage->m_UndoHistory.GetCount() == m_pHistoryStorage->m_iSavedHistoryIndex;
+    m_pHistoryStorage->m_pDocument->SetModified(!bAtSavedState);
 
     status = ezStatus(EZ_SUCCESS);
   }
@@ -194,7 +196,9 @@ ezStatus ezCommandHistory::RedoInternal()
     m_pHistoryStorage->m_RedoHistory.PopBack();
     m_pHistoryStorage->m_UndoHistory.PushBack(pTransaction);
 
-    m_pHistoryStorage->m_pDocument->SetModified(true);
+    const bool bAtSavedState = m_pHistoryStorage->m_iSavedHistoryIndex >= 0 &&
+                               (ezInt32)m_pHistoryStorage->m_UndoHistory.GetCount() == m_pHistoryStorage->m_iSavedHistoryIndex;
+    m_pHistoryStorage->m_pDocument->SetModified(!bAtSavedState);
 
     status = ezStatus(EZ_SUCCESS);
   }
@@ -391,6 +395,12 @@ void ezCommandHistory::ClearUndoHistory()
 
     m_pHistoryStorage->m_UndoHistory.PopBack();
   }
+
+  // The saved state may no longer be reachable if it was in the undo history.
+  if (m_pHistoryStorage->m_iSavedHistoryIndex > 0)
+  {
+    m_pHistoryStorage->m_iSavedHistoryIndex = -1;
+  }
 }
 
 void ezCommandHistory::ClearRedoHistory()
@@ -404,6 +414,12 @@ void ezCommandHistory::ClearRedoHistory()
     pTransaction->GetDynamicRTTI()->GetAllocator()->Deallocate(pTransaction);
 
     m_pHistoryStorage->m_RedoHistory.PopBack();
+  }
+
+  // If the saved state is at or beyond the current undo position, it was in the redo stack and is now unreachable.
+  if (m_pHistoryStorage->m_iSavedHistoryIndex >= (ezInt32)m_pHistoryStorage->m_UndoHistory.GetCount())
+  {
+    m_pHistoryStorage->m_iSavedHistoryIndex = -1;
   }
 }
 
@@ -454,12 +470,23 @@ ezSharedPtr<ezCommandHistory::Storage> ezCommandHistory::SwapStorage(ezSharedPtr
   auto retVal = m_pHistoryStorage;
 
   m_EventsUnsubscriber.Unsubscribe();
+  m_DocumentSavedUnsubscriber.Unsubscribe();
 
   m_pHistoryStorage = pNewStorage;
 
   m_pHistoryStorage->m_Events.AddEventHandler([this](const ezCommandHistoryEvent& e)
     { m_Events.Broadcast(e); },
     m_EventsUnsubscriber);
+
+  m_pHistoryStorage->m_pDocument->m_EventsOne.AddEventHandler(
+    [this](const ezDocumentEvent& e)
+    {
+      if (e.m_Type == ezDocumentEvent::Type::DocumentSaved)
+      {
+        m_pHistoryStorage->m_iSavedHistoryIndex = (ezInt32)m_pHistoryStorage->m_UndoHistory.GetCount();
+      }
+    },
+    m_DocumentSavedUnsubscriber);
 
   return retVal;
 }


### PR DESCRIPTION
When you make a modification, the document gets marked 'modified'. Undoing the change would not reset this 'modified' flag. Now it does.