### PR TITLE
Documents can now show errors that happened while loading

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocument.cpp
@@ -449,6 +449,16 @@ ezTransformStatus ezAssetDocument::DoTransformAsset(const ezPlatformProfile* pAs
   if (flags.IsAnySet(ezAssetDocumentFlags::DisableTransform))
     return ezStatus("Asset transform has been disabled on this asset");
 
+  if (GetUnknownObjectTypeInstances() > 0)
+  {
+    return ezStatus("Asset contains unknown object types. Please open the document and fix the errors.");
+  }
+
+  if (!GetLoadingErrors().IsEmpty())
+  {
+    return ezStatus("Asset had loading errors. Please open the document and fix the errors.");
+  }
+
   const ezPlatformProfile* pAssetProfile = ezAssetDocumentManager::DetermineFinalTargetProfile(pAssetProfile0);
 
   ezUInt64 uiHash = 0;

--- a/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.cpp
@@ -106,10 +106,10 @@ void ezQtRemoteConnectionDlg::showEvent(QShowEvent* event)
     {
       QAction* pAction = new QAction(this);
       pAction->setText(QString("%1.%2.%3.%4")
-                         .arg(m_RecentAddresses[i].part[0])
-                         .arg(m_RecentAddresses[i].part[1])
-                         .arg(m_RecentAddresses[i].part[2])
-                         .arg(m_RecentAddresses[i].part[3]));
+          .arg(m_RecentAddresses[i].part[0])
+          .arg(m_RecentAddresses[i].part[1])
+          .arg(m_RecentAddresses[i].part[2])
+          .arg(m_RecentAddresses[i].part[3]));
       pAction->setData(i);
 
       connect(pAction, &QAction::triggered, this, &ezQtRemoteConnectionDlg::onRecentIPselected);
@@ -124,10 +124,10 @@ void ezQtRemoteConnectionDlg::showEvent(QShowEvent* event)
     {
       QAction* pAction = new QAction(this);
       pAction->setText(QString("%1.%2.%3.%4")
-                         .arg(m_RecentFsAddresses[i].part[0])
-                         .arg(m_RecentFsAddresses[i].part[1])
-                         .arg(m_RecentFsAddresses[i].part[2])
-                         .arg(m_RecentFsAddresses[i].part[3]));
+          .arg(m_RecentFsAddresses[i].part[0])
+          .arg(m_RecentFsAddresses[i].part[1])
+          .arg(m_RecentFsAddresses[i].part[2])
+          .arg(m_RecentFsAddresses[i].part[3]));
       pAction->setData(i);
 
       connect(pAction, &QAction::triggered, this, &ezQtRemoteConnectionDlg::onRecentFsIPselected);

--- a/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/RemoteConnectionDlg.cpp
@@ -106,10 +106,10 @@ void ezQtRemoteConnectionDlg::showEvent(QShowEvent* event)
     {
       QAction* pAction = new QAction(this);
       pAction->setText(QString("%1.%2.%3.%4")
-          .arg(m_RecentAddresses[i].part[0])
-          .arg(m_RecentAddresses[i].part[1])
-          .arg(m_RecentAddresses[i].part[2])
-          .arg(m_RecentAddresses[i].part[3]));
+                         .arg(m_RecentAddresses[i].part[0])
+                         .arg(m_RecentAddresses[i].part[1])
+                         .arg(m_RecentAddresses[i].part[2])
+                         .arg(m_RecentAddresses[i].part[3]));
       pAction->setData(i);
 
       connect(pAction, &QAction::triggered, this, &ezQtRemoteConnectionDlg::onRecentIPselected);
@@ -124,10 +124,10 @@ void ezQtRemoteConnectionDlg::showEvent(QShowEvent* event)
     {
       QAction* pAction = new QAction(this);
       pAction->setText(QString("%1.%2.%3.%4")
-          .arg(m_RecentFsAddresses[i].part[0])
-          .arg(m_RecentFsAddresses[i].part[1])
-          .arg(m_RecentFsAddresses[i].part[2])
-          .arg(m_RecentFsAddresses[i].part[3]));
+                         .arg(m_RecentFsAddresses[i].part[0])
+                         .arg(m_RecentFsAddresses[i].part[1])
+                         .arg(m_RecentFsAddresses[i].part[2])
+                         .arg(m_RecentFsAddresses[i].part[3]));
       pAction->setData(i);
 
       connect(pAction, &QAction::triggered, this, &ezQtRemoteConnectionDlg::onRecentFsIPselected);

--- a/Code/Editor/EditorFramework/EditorApp/Documents.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Documents.cpp
@@ -61,6 +61,17 @@ The following types are missing:\n",
       }
       ezQtUiServices::MessageBoxWarning(s);
     }
+
+    if (!pDocument->GetLoadingErrors().IsEmpty())
+    {
+      ezStringBuilder s;
+      s.SetFormat("The document '{}' had errors during loading:\n\n", sDocument);
+      for (const ezString& err : pDocument->GetLoadingErrors())
+      {
+        s.Append(err, "\n");
+      }
+      ezQtUiServices::MessageBoxWarning(s);
+    }
   }
 
   if (flags.IsSet(ezDocumentFlags::RequestWindow))

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -50,8 +50,8 @@ public:
 /// \brief Strategies for searching for manipulators in the document.
 enum class ezManipulatorSearchStrategy
 {
-  None,                  ///< No manipulator search.
-  SelectedObject,        ///< Search for manipulators on the selected object.
+  None,                    ///< No manipulator search.
+  SelectedObject,          ///< Search for manipulators on the selected object.
   ChildrenOfSelectedObject ///< Search for manipulators on the children of the selected object.
 };
 
@@ -97,7 +97,7 @@ public:
   ezDocument* GetActiveSubDocument() { return m_pActiveSubDocument; }
 
 protected:
-  ezDocument* m_pHostDocument = nullptr; ///< Pointer to the main document if this is a sub-document, otherwise self.
+  ezDocument* m_pHostDocument = nullptr;      ///< Pointer to the main document if this is a sub-document, otherwise self.
   ezDocument* m_pActiveSubDocument = nullptr; ///< Pointer to the currently active sub-document.
 
   ///@}
@@ -215,6 +215,12 @@ public:
   /// \brief Returns the number of unknown object type instances encountered during loading.
   ezUInt32 GetUnknownObjectTypeInstances() const { return m_uiUnknownObjectTypeInstances; }
 
+  /// \brief Returns errors accumulated during loading (e.g. unresolvable connections).
+  ///
+  /// Non-empty after loading means the document is in a broken state. Transforms should fail,
+  /// and the user should be informed when opening the document.
+  const ezDynamicArray<ezString>& GetLoadingErrors() const { return m_LoadingErrors; }
+
   /// \brief If disabled, this document will not be put into the recent files list.
   void SetAddToResetFilesList(bool b) { m_bAddToRecentFilesList = b; }
 
@@ -272,6 +278,11 @@ public:
 
   /// \brief Event for object accessor change notifications.
   mutable ezEvent<const ezObjectAccessorChangeEvent&> m_ObjectAccessorChangeEvents;
+
+  /// \brief Adds an error message to the list of loading errors.
+  ///
+  /// This can be used during loading to accumulate errors, e.g. unresolvable connections, missing prefabs, etc.
+  void AddLoadingError(ezStringView sError);
 
 protected:
   void SetModified(bool b);
@@ -336,6 +347,8 @@ private:
   ezSet<ezString> m_UnknownObjectTypes;
   /// \brief Number of unknown object type instances encountered during loading.
   ezUInt32 m_uiUnknownObjectTypeInstances = 0;
+  /// \brief Errors accumulated during loading, e.g. unresolvable connections.
+  ezDynamicArray<ezString> m_LoadingErrors;
 
   ezTaskGroupID m_ActiveSaveTask;
   ezStatus m_LastSaveResult = EZ_SUCCESS;

--- a/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Implementation/Document.cpp
@@ -381,6 +381,11 @@ void ezDocument::SetUnknownObjectTypes(const ezSet<ezString>& Types, ezUInt32 ui
   m_uiUnknownObjectTypeInstances = uiInstances;
 }
 
+void ezDocument::AddLoadingError(ezStringView sError)
+{
+  m_LoadingErrors.PushBack(sError);
+}
+
 
 void ezDocument::BroadcastInterDocumentMessage(ezReflectedClass* pMessage, ezDocument* pSender)
 {

--- a/Code/Tools/Libs/ToolsFoundation/VisualGraph/Implementation/VisualGraphObjectManager.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/VisualGraph/Implementation/VisualGraphObjectManager.cpp
@@ -491,6 +491,10 @@ void ezVisualGraphObjectManager::RestoreMetaDataAfterLoading(const ezAbstractObj
       }
       else
       {
+        ezStringBuilder sError;
+        sError.SetFormat("Connection from pin '{}' to pin '{}' could not be restored because a pin no longer exists. The connection has been removed.",
+          sourcePinVar.Get<ezString>(), targetPinVar.Get<ezString>());
+        GetDocument()->AddLoadingError(sError);
         RemoveObject(pObject);
         DestroyObject(pObject);
       }


### PR DESCRIPTION
Documents that became broken due to external dependencies, can now display errors when opening. These errors also automatically make the asset transform fail.