### PR TITLE
Several minor fixes

### DIFF
--- a/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
+++ b/Code/Editor/EditorFramework/PropertyGrid/Implementation/AssetBrowserPropertyWidget.cpp
@@ -164,7 +164,8 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
         m_pButton->setIcon(QIcon());
         m_pButton->setToolButtonStyle(Qt::ToolButtonStyle::ToolButtonTextOnly);
 
-        m_Pal.setColor(QPalette::Text, Qt::red);
+        m_Pal.setColor(QPalette::Active, QPalette::Text, Qt::red);
+        m_Pal.setColor(QPalette::Inactive, QPalette::Text, Qt::red);
         m_pWidget->setPalette(m_Pal);
 
         return;
@@ -211,7 +212,8 @@ void ezQtAssetPropertyWidget::InternalSetValue(const ezVariant& value)
       const QColor validColor = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Green));
       const QColor invalidColor = ezToQtColor(ezColorScheme::LightUI(ezColorScheme::Red));
 
-      m_Pal.setColor(QPalette::Text, m_AssetGuid.IsValid() ? validColor : invalidColor);
+      m_Pal.setColor(QPalette::Active, QPalette::Text, m_AssetGuid.IsValid() ? validColor : invalidColor);
+      m_Pal.setColor(QPalette::Inactive, QPalette::Text, m_AssetGuid.IsValid() ? validColor : invalidColor);
       m_pWidget->setPalette(m_Pal);
 
       if (m_AssetGuid.IsValid())

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -863,9 +863,14 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
 {
   SUPER::UpdateAssetDocumentInfo(pInfo);
 
-  if (!GetProperties()->m_sAssetFilterTags.IsEmpty())
+  const auto pProperties = GetProperties();
+
+  if (!pProperties->m_sAssetFilterTags.IsEmpty())
   {
-    const ezStringBuilder tags(";", GetProperties()->m_sAssetFilterTags, ";");
+    ezStringBuilder tags(";", pProperties->m_sAssetFilterTags, ";");
+    while (tags.ReplaceAll(";;", ";") > 0)
+    {
+    }
 
     pInfo->m_sAssetsDocumentTags = tags;
   }
@@ -874,26 +879,45 @@ void ezMaterialAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo
     pInfo->m_sAssetsDocumentTags.Clear();
   }
 
-  if (GetProperties()->m_ShaderMode != ezMaterialShaderMode::BaseMaterial)
+  if (pProperties->GetShaderMode() == ezMaterialShaderMode::BaseMaterial)
+  {
+    // if we have a base material, copy the document tags from there
+    // TODO: this is problematic, as changes to the tags in the base document would need to be saved in the derived document
+    // it would be better, if the asset curator could store a reference to the base document and pull the tags directly from there, on demand
+
+    if (auto pAsset = ezAssetCurator::GetSingleton()->FindSubAsset(pProperties->GetBaseMaterial()))
+    {
+      const ezStringView baseTags = pAsset->m_pAssetInfo->m_Info->GetAssetsDocumentTags();
+      if (!baseTags.IsEmpty())
+      {
+        ezStringBuilder tmp(pInfo->m_sAssetsDocumentTags, baseTags);
+        while (tmp.ReplaceAll(";;", ";") > 0)
+        {
+        }
+        pInfo->m_sAssetsDocumentTags = tmp;
+      }
+    }
+  }
+  else
   {
     // remove base material dependency, if it isn't used
-    pInfo->m_TransformDependencies.Remove(GetProperties()->GetBaseMaterial());
-    pInfo->m_ThumbnailDependencies.Remove(GetProperties()->GetBaseMaterial());
+    pInfo->m_TransformDependencies.Remove(pProperties->GetBaseMaterial());
+    pInfo->m_ThumbnailDependencies.Remove(pProperties->GetBaseMaterial());
   }
 
-  if (GetProperties()->m_ShaderMode != ezMaterialShaderMode::File)
+  if (pProperties->m_ShaderMode != ezMaterialShaderMode::File)
   {
-    const bool bInUseByBaseMaterial = GetProperties()->m_ShaderMode == ezMaterialShaderMode::BaseMaterial && ezStringUtils::IsEqual(GetProperties()->GetShader(), GetProperties()->GetBaseMaterial());
+    const bool bInUseByBaseMaterial = pProperties->m_ShaderMode == ezMaterialShaderMode::BaseMaterial && ezStringUtils::IsEqual(pProperties->GetShader(), pProperties->GetBaseMaterial());
 
     // remove shader file dependency, if it isn't used and differs from the base material
     if (!bInUseByBaseMaterial)
     {
-      pInfo->m_TransformDependencies.Remove(GetProperties()->GetShader());
-      pInfo->m_ThumbnailDependencies.Remove(GetProperties()->GetShader());
+      pInfo->m_TransformDependencies.Remove(pProperties->GetShader());
+      pInfo->m_ThumbnailDependencies.Remove(pProperties->GetShader());
     }
   }
 
-  if (GetProperties()->m_ShaderMode == ezMaterialShaderMode::Custom)
+  if (pProperties->m_ShaderMode == ezMaterialShaderMode::Custom)
   {
     // We write our own guid into the shader field so BaseMaterial materials can find the shader file.
     // This would cause us to have a dependency to ourselves so we need to remove it.

--- a/Code/Engine/Core/Interfaces/WindWorldModule.cpp
+++ b/Code/Engine/Core/Interfaces/WindWorldModule.cpp
@@ -8,7 +8,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezWindWorldModuleInterface, 1, ezRTTINoAllocator
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 EZ_BEGIN_STATIC_REFLECTED_ENUM(ezWindStrength, 1)
-  EZ_ENUM_CONSTANTS(ezWindStrength::Calm, ezWindStrength::LightBreeze, ezWindStrength::GentleBreeze, ezWindStrength::ModerateBreeze, ezWindStrength::StrongBreeze, ezWindStrength::Storm)
+  EZ_ENUM_CONSTANTS(ezWindStrength::None, ezWindStrength::Calm, ezWindStrength::LightBreeze, ezWindStrength::GentleBreeze, ezWindStrength::ModerateBreeze, ezWindStrength::StrongBreeze, ezWindStrength::Storm)
   EZ_ENUM_CONSTANTS(ezWindStrength::WeakShockwave, ezWindStrength::MediumShockwave, ezWindStrength::StrongShockwave, ezWindStrength::ExtremeShockwave)
 EZ_END_STATIC_REFLECTED_ENUM;
 // clang-format on
@@ -20,6 +20,9 @@ float ezWindStrength::GetInMetersPerSecond(Enum strength)
 
   switch (strength)
   {
+    case None:
+      return 0.0f;
+
     case Calm:
       return 0.5f;
 

--- a/Code/Engine/Core/Interfaces/WindWorldModule.h
+++ b/Code/Engine/Core/Interfaces/WindWorldModule.h
@@ -8,11 +8,11 @@
 /// See https://en.wikipedia.org/wiki/Beaufort_scale
 struct EZ_CORE_DLL ezWindStrength
 {
-  using StorageType = ezUInt8;
+  using StorageType = ezInt8;
 
   enum Enum
   {
-    None,
+    None = -1,
     Calm,
     LightBreeze,
     GentleBreeze,

--- a/Code/Engine/Core/Interfaces/WindWorldModule.h
+++ b/Code/Engine/Core/Interfaces/WindWorldModule.h
@@ -12,6 +12,7 @@ struct EZ_CORE_DLL ezWindStrength
 
   enum Enum
   {
+    None,
     Calm,
     LightBreeze,
     GentleBreeze,

--- a/Code/Engine/Foundation/Strings/Implementation/TranslationLookup.cpp
+++ b/Code/Engine/Foundation/Strings/Implementation/TranslationLookup.cpp
@@ -180,6 +180,8 @@ void ezTranslatorFromFiles::LoadTranslationFile(const char* szFullPath)
     sTooltip.Trim(" \t\r\n");
     sHelpUrl.Trim(" \t\r\n");
 
+    sTooltip.ReplaceAll("\\n", "\n");
+
     if (GetHighlightUntranslated())
     {
       sValue.Prepend("# ");

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TypeWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TypeWidget.cpp
@@ -119,7 +119,6 @@ void ezQtTypeWidget::BuildUI(const ezRTTI* pType, const ezMap<ezString, const ez
     else
     {
       pGroupBox->SetTitle(group->m_sGroup.GetData());
-      pGroupBox->SetBoldTitle(true);
 
       m_pGrid->SetCollapseState(pGroupBox);
       connect(pGroupBox, &ezQtGroupBoxBase::CollapseStateChanged, m_pGrid, &ezQtPropertyGridWidget::OnCollapseStateChanged);
@@ -135,7 +134,7 @@ void ezQtTypeWidget::BuildUI(const ezRTTI* pType, const ezMap<ezString, const ez
     pLayout->setColumnStretch(1, 0);
     pLayout->setColumnMinimumWidth(1, 5);
     pLayout->setColumnStretch(2, 2);
-    pLayout->setContentsMargins(0, 0, 0, 0);
+    pLayout->setContentsMargins(group->m_sGroup.IsEmpty() ? 0 : 10, 0, 0, 0);
     pLayout->setSpacing(0);
     pGroupBox->GetContent()->setLayout(pLayout);
 
@@ -158,7 +157,7 @@ void ezQtTypeWidget::BuildUI(const ezRTTI* pType, const ezMap<ezString, const ez
         ezQtManipulatorLabel* pLabel = new ezQtManipulatorLabel(this);
         pLabel->setText(QString::fromUtf8(pNewWidget->GetLabel(tmp)));
         pLabel->setAlignment(Qt::AlignLeft | Qt::AlignTop);
-        pLabel->setContentsMargins(0, 0, 0, 0); // 18 is a hacked value to align label with group boxes.
+        pLabel->setContentsMargins(0, 0, 0, 0);
         pLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 
         connect(pLabel, &QWidget::customContextMenuRequested, pNewWidget, &ezQtPropertyWidget::OnCustomContextMenu);


### PR DESCRIPTION
* Add 'None' to wind strength, since 'Calm' was not switching wind off entirely
* Grey out content of asset browser property widget when deactivated
* Inherit asset document tags in material asset (could use better solution in the future)
* Support newlines in tooltips
* Improved layout for property groups (small margin)