### PR TITLE
Log which components don't have documentation links

### DIFF
--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentInfo.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetDocumentInfo.cpp
@@ -64,7 +64,10 @@ void ezAssetDocumentInfo::ClearMetaData()
 {
   for (auto* pObj : m_MetaInfo)
   {
-    pObj->GetDynamicRTTI()->GetAllocator()->Deallocate(pObj);
+    if (pObj)
+    {
+      pObj->GetDynamicRTTI()->GetAllocator()->Deallocate(pObj);
+    }
   }
   m_MetaInfo.Clear();
 }

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -260,6 +260,7 @@ private:
   void SetupNewProject();
   void LoadEditorPreferences();
   void LoadProjectPreferences();
+  void LogMissingComponentDocumentation();
   void StoreEnginePluginModificationTimes();
   bool CheckForEnginePluginModifications();
   void SaveAllOpenDocuments();

--- a/Code/Editor/EditorFramework/EditorApp/Projects.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Projects.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <Core/System/Window.h>
+#include <Core/World/Component.h>
 #include <EditorFramework/Actions/WindowLayoutActions.h>
 #include <EditorFramework/Assets/AssetCurator.h>
 #include <EditorFramework/Assets/AssetProcessor.h>
@@ -279,6 +280,8 @@ void ezQtEditorApp::ProjectEventHandler(const ezToolsProjectEvent& r)
         m_pTranslatorFromFiles->AddTranslationFilesFromFolder(":project/Editor/Localization/en");
       }
 
+      LogMissingComponentDocumentation();
+
       // tell the engine process which file system and plugin configuration to use
       ezEditorEngineProcessConnection::GetSingleton()->SetFileSystemConfig(m_FileSystemConfig);
       ezEditorEngineProcessConnection::GetSingleton()->SetPluginConfig(GetRuntimePluginConfig(true));
@@ -534,4 +537,25 @@ void ezQtEditorApp::SetupNewProject()
       file.Close().IgnoreResult();
     }
   }
+}
+
+void ezQtEditorApp::LogMissingComponentDocumentation()
+{
+  EZ_LOG_BLOCK("Missing Component Documentation");
+
+  ezRTTI::ForEachDerivedType<ezComponent>(
+    [](const ezRTTI* pRtti)
+    {
+      if (pRtti->GetAttributeByType<ezInDevelopmentAttribute>() != nullptr)
+        return;
+      if (pRtti->GetAttributeByType<ezHiddenAttribute>() != nullptr)
+        return;
+
+      ezStringView sTypeName = pRtti->GetTypeName();
+      if (ezTranslateHelpURL(sTypeName).IsEmpty())
+      {
+        ezLog::Warning("Component '{}' has no documentation link.", sTypeName);
+      }
+    },
+    ezRTTI::ForEachOptions::ExcludeAbstract);
 }

--- a/Data/Tools/ezEditor/Localization/en/JoltPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/JoltPlugin.txt
@@ -32,6 +32,8 @@ ezJoltDefaultCharacterComponent;Default Character Controller (Jolt);;https://eze
 ezJoltGrabObjectComponent;Grab Object (Jolt);;https://ezengine.net/pages/docs/physics/jolt/special/jolt-grab-object-component.html
 ezJoltClothSheetComponent;Cloth Sheet (Jolt);;https://ezengine.net/pages/docs/physics/jolt/special/jolt-cloth-sheet-component.html
 ezJoltBreakableSlabComponent;Breakable Slab (Jolt);;https://ezengine.net/pages/docs/physics/jolt/special/jolt-breakable-slab-component.html
+ezJoltGenerateCollisionComponent;Generate Collision Mesh (Jolt);;https://ezengine.net/pages/docs/physics/jolt/special/jolt-generate-collision-component.html
+
 
 # UI
 

--- a/Data/Tools/ezEditor/Localization/en/ProcGenPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/ProcGenPlugin.txt
@@ -9,6 +9,7 @@ ezProcVertexColorComponent;Procedural Vertex Color;;http://ezengine.net/pages/do
 ezProcVolumeSphereComponent;Procedural Volume Sphere;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-sphere-component.html
 ezProcVolumeBoxComponent;Procedural Volume Box;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-box-component.html
 ezProcVolumeImageComponent;Procedural Volume Image;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-image-component.html
+ezProcVolumeSplineComponent;Procedural Volume Spline;;http://ezengine.net/pages/docs/terrain/procedural/procgen-volume-spline-component.html
 
 # Enums
 

--- a/Data/Tools/ezEditor/Localization/en/RmlUiPlugin.txt
+++ b/Data/Tools/ezEditor/Localization/en/RmlUiPlugin.txt
@@ -4,8 +4,11 @@ RmlUi;Rml UI;;https://ezengine.net/pages/docs/ui/rmlui.html
 
 # Component Types
 
-ezRmlUiCanvas2DComponent;RmlUi Canvas 2D;;https://ezengine.net/pages/docs/ui/rmlui-canvas2d-component.html
+ezRmlUiCanvas2DComponent;RmlUi Canvas 2D;;https://ezengine.net/pages/docs/ui/rmlui.html
+
+# These still need dedicated documentation pages
 ezRmlUiCanvas3DComponent;RmlUi Canvas 3D
+ezRmlUiCanvas3DInteractionExampleComponent;RmlUi Canvas 3D Interaction Example
 
 # Properties
 

--- a/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
+++ b/Data/Tools/ezEditor/Localization/en/SceneAsset.txt
@@ -72,7 +72,6 @@ ezBakedProbesVolumeComponent;Baked Probes Volume
 ezScriptComponent;Script Component;;https://ezengine.net/pages/docs/custom-code/visual-script/script-component.html
 ezSplineComponent;Spline;;https://ezengine.net/pages/docs/animation/paths/spline-component.html
 ezSplineNodeComponent;Spline Node;;https://ezengine.net/pages/docs/animation/paths/spline-node-component.html
-ezFollowPathComponent;Follow Path;;https://ezengine.net/pages/docs/animation/paths/follow-path-component.html
 ezPowerConnectorComponent;Power Connector;;https://ezengine.net/pages/docs/gameplay/power-connector-component.html
 ezTriggerDelayModifierComponent;Trigger Delay Modifier;;https://ezengine.net/pages/docs/custom-code/game-logic/trigger-delay-modifier-component.html
 ezCommentComponent;Comment;;https://ezengine.net/pages/docs/misc/components/comment-component.html
@@ -86,6 +85,9 @@ ezAimIKComponent;Aim IK;;https://ezengine.net/pages/docs/animation/skeletal-anim
 ezCreatureCrawlComponent;Creature Crawl;;https://ezengine.net/pages/docs/gameplay/creature-crawl-component.html
 ezLodComponent;LOD Component;;https://ezengine.net/pages/docs/graphics/lod-component.html
 ezSceneTransitionComponent;Scene Transition;;https://ezengine.net/pages/docs/gameplay/scene-transition-component.html
+ezSplineMeshComponent;Spline Mesh;;https://ezengine.net/pages/docs/animation/paths/spline-mesh-component.html
+ezFollowSplineComponent;Follow Spline;;https://ezengine.net/pages/docs/animation/paths/follow-path-component.html
+ezVolumeSamplerComponent;Volume Sampler;;https://ezengine.net/pages/docs/gameplay/volume-sampler-component.html
 
 # Properties
 


### PR DESCRIPTION
This helps to find components that still need documentation pages, or for which the link isn't set up, yet.