### PR TITLE
Performance improvements

### DIFF
--- a/Code/Engine/Core/World/Declarations.h
+++ b/Code/Engine/Core/World/Declarations.h
@@ -84,7 +84,11 @@ struct ezGameObjectHandle
 template <>
 struct ezHashHelper<ezGameObjectHandle>
 {
-  EZ_ALWAYS_INLINE static ezUInt32 Hash(ezGameObjectHandle value) { return ezHashHelper<ezUInt64>::Hash(value.GetInternalID().m_Data); }
+  EZ_ALWAYS_INLINE static ezUInt32 Hash(ezGameObjectHandle value)
+  {
+    const ezUInt64 data = value.GetInternalID().m_Data;
+    return ezHashingUtils::xxHash32(&data, sizeof(data));
+  }
 
   EZ_ALWAYS_INLINE static bool Equal(ezGameObjectHandle a, ezGameObjectHandle b) { return a == b; }
 };
@@ -177,9 +181,8 @@ struct ezHashHelper<ezComponentHandle>
 {
   EZ_ALWAYS_INLINE static ezUInt32 Hash(ezComponentHandle value)
   {
-    ezComponentId id = value.GetInternalID();
-    ezUInt64 data = *reinterpret_cast<ezUInt64*>(&id);
-    return ezHashHelper<ezUInt64>::Hash(data);
+    const ezUInt64 data = value.GetInternalID().m_Data;
+    return ezHashingUtils::xxHash32(&data, sizeof(data));
   }
 
   EZ_ALWAYS_INLINE static bool Equal(ezComponentHandle a, ezComponentHandle b) { return a == b; }

--- a/Code/Engine/Core/World/Implementation/GameObject.cpp
+++ b/Code/Engine/Core/World/Implementation/GameObject.cpp
@@ -818,10 +818,10 @@ void ezGameObject::UpdateLocalBounds()
   ezSpatialSystem* pSpatialSystem = GetWorld()->GetSpatialSystem();
   if (pSpatialSystem != nullptr && (bRecreateSpatialData || m_pTransformationData->m_hSpatialData.IsInvalidated()))
   {
+    // UpdateGlobalBounds is called internally by RecreateSpatialData
     m_pTransformationData->RecreateSpatialData(*pSpatialSystem);
   }
-
-  if (IsStatic())
+  else if (IsStatic())
   {
     m_pTransformationData->UpdateGlobalBounds(pSpatialSystem);
   }

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -147,9 +147,6 @@ bool ezWorldReader::HasComponentOfType(const ezRTTI* pRtti) const
 
 void ezWorldReader::ClearAndCompact()
 {
-  // m_IndexToGameObjectHandle.Clear();
-  // m_IndexToGameObjectHandle.Compact();
-
   m_RootObjectsToCreate.Clear();
   m_RootObjectsToCreate.Compact();
 
@@ -171,8 +168,9 @@ void ezWorldReader::ClearAndCompact()
 
 ezUInt64 ezWorldReader::GetHeapMemoryUsage() const
 {
-  return /*m_IndexToGameObjectHandle.GetHeapMemoryUsage() +*/ m_RootObjectsToCreate.GetHeapMemoryUsage() + m_ChildObjectsToCreate.GetHeapMemoryUsage() + m_ComponentTypes.GetHeapMemoryUsage() + m_ComponentTypeVersions.GetHeapMemoryUsage() + m_ComponentCreationStream.GetHeapMemoryUsage() +
-         m_ComponentDataStream.GetHeapMemoryUsage();
+  return m_RootObjectsToCreate.GetHeapMemoryUsage() + m_ChildObjectsToCreate.GetHeapMemoryUsage() +
+    m_ComponentTypes.GetHeapMemoryUsage() + m_ComponentTypeVersions.GetHeapMemoryUsage() +
+    m_ComponentCreationStream.GetHeapMemoryUsage() + m_ComponentDataStream.GetHeapMemoryUsage();
 }
 
 ezUInt32 ezWorldReader::GetRootObjectCount() const
@@ -315,32 +313,42 @@ ezUniquePtr<ezWorldReader::InstantiationContextBase> ezWorldReader::Instantiate(
 {
   if (options.m_MaxStepTime <= ezTime::MakeZero())
   {
-    InstantiationContext context = InstantiationContext(*this, &world, bUseTransform, rootTransform, options);
+    InstantiationContext context = InstantiationContext(*this, &world, bUseTransform, rootTransform, options, ezFrameAllocator::GetCurrentAllocator());
 
     EZ_VERIFY(context.Step() == InstantiationContextBase::StepResult::Finished, "Instantiation should be completed after this call");
     return nullptr;
   }
 
-  ezUniquePtr<InstantiationContext> pContext = EZ_DEFAULT_NEW(InstantiationContext, *this, &world, bUseTransform, rootTransform, options);
+  ezUniquePtr<InstantiationContext> pContext = EZ_DEFAULT_NEW(InstantiationContext, *this, &world, bUseTransform, rootTransform, options, ezFoundation::GetDefaultAllocator());
 
   return std::move(pContext);
 }
 
-ezWorldReader::InstantiationContext::InstantiationContext(ezWorldReader& ref_worldReader, ezWorld* pWorld, bool bUseTransform, const ezTransform& rootTransform, const ezPrefabInstantiationOptions& options)
+ezWorldReader::InstantiationContext::InstantiationContext(ezWorldReader& ref_worldReader, ezWorld* pWorld, bool bUseTransform, const ezTransform& rootTransform, const ezPrefabInstantiationOptions& options, ezAllocator* pAllocator)
   : m_WorldReader(ref_worldReader)
   , m_bUseTransform(bUseTransform)
   , m_RootTransform(rootTransform)
   , m_Options(options)
+  , m_IndexToGameObjectHandle(pAllocator)
+  , m_ComponentTypeStates(pAllocator)
 {
   m_Phase = Phase::CreateRootObjects;
 
   m_pWorld = pWorld;
 
-  m_IndexToGameObjectHandle.PushBack(ezGameObjectHandle());
+  const ezUInt32 uiRootObjectsToCreate = m_WorldReader.m_RootObjectsToCreate.GetCount();
+  const ezUInt32 uiChildObjectsToCreate = m_WorldReader.m_ChildObjectsToCreate.GetCount();
 
-  m_ComponentTypeStates.SetCount(ref_worldReader.m_ComponentTypes.GetCount());
-  for (auto& ct : m_ComponentTypeStates)
+  m_IndexToGameObjectHandle.Reserve(uiRootObjectsToCreate + uiChildObjectsToCreate + 1);
+  m_IndexToGameObjectHandle.PushBack(ezGameObjectHandle());  
+
+  m_ComponentTypeStates.Reserve(m_WorldReader.m_ComponentTypes.GetCount());
+  for (ezUInt32 i = 0; i < m_WorldReader.m_ComponentTypes.GetCount(); ++i)
   {
+    m_ComponentTypeStates.PushBack(ComponentTypeState(pAllocator));
+
+    auto& ct = m_ComponentTypeStates.PeekBack();
+    ct.m_ComponentIndexToHandle.Reserve(m_WorldReader.m_ComponentTypes[i].m_uiNumComponents);
     ct.m_ComponentIndexToHandle.PushBack(ezComponentHandle());
   }
 
@@ -357,8 +365,8 @@ ezWorldReader::InstantiationContext::InstantiationContext(ezWorldReader& ref_wor
   if (options.m_pProgress != nullptr)
   {
     m_pOverallProgressRange = EZ_DEFAULT_NEW(ezProgressRange, "Instantiate", Phase::Count, false, options.m_pProgress);
-    m_pOverallProgressRange->SetStepWeighting(Phase::CreateRootObjects, m_WorldReader.m_RootObjectsToCreate.GetCount() / 100.0f);
-    m_pOverallProgressRange->SetStepWeighting(Phase::CreateChildObjects, m_WorldReader.m_ChildObjectsToCreate.GetCount() / 100.0f);
+    m_pOverallProgressRange->SetStepWeighting(Phase::CreateRootObjects, uiRootObjectsToCreate / 100.0f);
+    m_pOverallProgressRange->SetStepWeighting(Phase::CreateChildObjects, uiChildObjectsToCreate / 100.0f);
     m_pOverallProgressRange->SetStepWeighting(Phase::CreateComponents, m_WorldReader.m_uiTotalNumComponents / 100.0f);
     m_pOverallProgressRange->SetStepWeighting(Phase::DeserializeComponents, m_WorldReader.m_uiTotalNumComponents / 100.0f);
     // Ten times more weight since init components takes way longer than the rest
@@ -396,6 +404,7 @@ ezWorldReader::InstantiationContext::StepResult ezWorldReader::InstantiationCont
       if (m_WorldReader.m_RootObjectsToCreate.GetCount() == 1 && m_WorldReader.m_RootObjectsToCreate[0].m_Desc.m_sName == m_Options.m_ReplaceNamedRootWithParent)
       {
         m_uiCurrentIndex = 1;
+        EZ_ASSERT_DEBUG(m_IndexToGameObjectHandle.GetCapacity() > m_IndexToGameObjectHandle.GetCount(), "m_IndexToGameObjectHandle should have the enough capacity.");
         m_IndexToGameObjectHandle.PushBack(m_Options.m_hParent);
 
         ezGameObject* pParent = nullptr;
@@ -579,6 +588,7 @@ bool ezWorldReader::InstantiationContext::CreateGameObjects(const ezDynamicArray
     }
 
     ezGameObject* pObject = nullptr;
+    EZ_ASSERT_DEBUG(m_IndexToGameObjectHandle.GetCapacity() > m_IndexToGameObjectHandle.GetCount(), "m_IndexToGameObjectHandle should have the enough capacity.");
     m_IndexToGameObjectHandle.PushBack(m_pWorld->CreateObject(desc, pObject));
 
     if (!godesc.m_sGlobalKey.IsEmpty())
@@ -654,6 +664,7 @@ bool ezWorldReader::InstantiationContext::CreateComponents(ezTime endTime)
       }
 
       EZ_ASSERT_DEBUG(uiComponentIdx == compTypeState.m_ComponentIndexToHandle.GetCount(), "Component index doesn't match");
+      EZ_ASSERT_DEBUG(compTypeState.m_ComponentIndexToHandle.GetCapacity() > compTypeState.m_ComponentIndexToHandle.GetCount(), "m_ComponentIndexToHandle should have the enough capacity.");
       compTypeState.m_ComponentIndexToHandle.PushBack(hComponent);
 
       ++m_uiCurrentIndex;

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -169,8 +169,8 @@ void ezWorldReader::ClearAndCompact()
 ezUInt64 ezWorldReader::GetHeapMemoryUsage() const
 {
   return m_RootObjectsToCreate.GetHeapMemoryUsage() + m_ChildObjectsToCreate.GetHeapMemoryUsage() +
-    m_ComponentTypes.GetHeapMemoryUsage() + m_ComponentTypeVersions.GetHeapMemoryUsage() +
-    m_ComponentCreationStream.GetHeapMemoryUsage() + m_ComponentDataStream.GetHeapMemoryUsage();
+         m_ComponentTypes.GetHeapMemoryUsage() + m_ComponentTypeVersions.GetHeapMemoryUsage() +
+         m_ComponentCreationStream.GetHeapMemoryUsage() + m_ComponentDataStream.GetHeapMemoryUsage();
 }
 
 ezUInt32 ezWorldReader::GetRootObjectCount() const
@@ -340,7 +340,7 @@ ezWorldReader::InstantiationContext::InstantiationContext(ezWorldReader& ref_wor
   const ezUInt32 uiChildObjectsToCreate = m_WorldReader.m_ChildObjectsToCreate.GetCount();
 
   m_IndexToGameObjectHandle.Reserve(uiRootObjectsToCreate + uiChildObjectsToCreate + 1);
-  m_IndexToGameObjectHandle.PushBack(ezGameObjectHandle());  
+  m_IndexToGameObjectHandle.PushBack(ezGameObjectHandle());
 
   m_ComponentTypeStates.Reserve(m_WorldReader.m_ComponentTypes.GetCount());
   for (ezUInt32 i = 0; i < m_WorldReader.m_ComponentTypes.GetCount(); ++i)

--- a/Code/Engine/Core/WorldSerializer/WorldReader.h
+++ b/Code/Engine/Core/WorldSerializer/WorldReader.h
@@ -196,7 +196,7 @@ private:
   class InstantiationContext : public InstantiationContextBase
   {
   public:
-    InstantiationContext(ezWorldReader& ref_worldReader, ezWorld* pWorld, bool bUseTransform, const ezTransform& rootTransform, const ezPrefabInstantiationOptions& options);
+    InstantiationContext(ezWorldReader& ref_worldReader, ezWorld* pWorld, bool bUseTransform, const ezTransform& rootTransform, const ezPrefabInstantiationOptions& options, ezAllocator* pAllocator);
     ~InstantiationContext();
 
     virtual StepResult Step() override;
@@ -228,6 +228,11 @@ private:
 
     struct ComponentTypeState
     {
+      ComponentTypeState(ezAllocator* pAllocator)
+        : m_ComponentIndexToHandle(pAllocator)
+      {
+      }
+
       ezUInt64 m_uiDataReadOffset = 0;
       ezDynamicArray<ezComponentHandle> m_ComponentIndexToHandle;
     };

--- a/Code/Engine/RendererCore/Components/Implementation/RenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RenderComponent.cpp
@@ -37,8 +37,13 @@ void ezRenderComponent::OnDeactivated()
   // Can't call InvalidateCachedRenderData because it checks whether we are active, which is not the case anymore.
   ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
 
-  // Can't call TriggerLocalBoundsUpdate because it checks whether we are active, which is not the case anymore.
-  GetOwner()->UpdateLocalBounds();
+  // Only update the local bounds if the owner is still active, if not no other components are active anymore and the bounds update would be pointless.
+  // The bounds will be updated when the owner is re-activated anyway.
+  if (GetOwner()->IsActive())
+  {
+    // Can't call TriggerLocalBoundsUpdate because it checks whether we are active, which is not the case anymore.
+    GetOwner()->UpdateLocalBounds();
+  }
 }
 
 void ezRenderComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
@@ -363,7 +363,7 @@ void PlacementTask::ExecuteVM()
       objectColor.r *= intensity;
       objectColor.g *= intensity;
       objectColor.b *= intensity;
-      objectColor.a = alpha;
+      objectColor.a = ezMath::ColorByteToFloat(alpha);
 
       placementTransform.m_ObjectColor = objectColor;
       placementTransform.m_bHasValidColor = true;

--- a/Data/Samples/Testing Chambers/Scenes/Splines.ezScene
+++ b/Data/Samples/Testing Chambers/Scenes/Splines.ezScene
@@ -11,7 +11,7 @@ o
 		s %AssetType{"Scene"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{12640593572254555674,10304997345485202463}}
-		u4 %Hash{9839971877231749725}
+		u4 %Hash{13691878469985653913}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -616,10 +616,11 @@ o
 {
 	Uuid %id{u4{7398741980933746105,5087335259099240879}}
 	s %t{"ezJoltGenerateCollisionComponent"}
-	u3 %v{1}
+	u3 %v{2}
 	p
 	{
 		b %Active{1}
+		u1 %CollisionLayer{0}
 		VarArray %MeshMappings
 		{
 			Uuid{u4{4898210761515694217,4785387480103292592}}
@@ -2608,7 +2609,7 @@ o
 		s %PluginName{"ezEditorPluginJolt"}
 		VarArray %Properties{}
 		s %TypeName{"ezJoltGenerateCollisionComponent"}
-		u3 %TypeVersion{1}
+		u3 %TypeVersion{2}
 	}
 }
 o


### PR DESCRIPTION
These changes improve performance when creating and destroying lots of mesh objects/prefabs. This e.g. happens with the procedural placement system.

* Reduced allocations in ezWorldReader::InstantiationContext and use frame allocator if possible
* Better hashing of game object and component handles. The previous hashing function led to lots of collision in the internal hash table of the render data caching.
* Got rid of a few unnecessary calculations with bounds updates
* Also fixed a bug with object color alpha for procedurally placed objects