### PR TITLE
Add option to disable OS keys

### DIFF
--- a/Code/Engine/Core/Input/DeviceTypes/MouseKeyboard.h
+++ b/Code/Engine/Core/Input/DeviceTypes/MouseKeyboard.h
@@ -47,6 +47,15 @@ public:
   /// \brief Returns whether the mouse is confined to the application window or not.
   virtual ezMouseCursorClipMode::Enum GetClipMouseCursor() const = 0;
 
+  /// \brief If enabled, the OS will not handle system hotkeys (e.g. the Windows key) while this device is active.
+  ///
+  /// Can be called before or after device initialization. On platforms that support it, calling this after
+  /// initialization will re-register the input device with the updated setting.
+  virtual void SetDisableOSHotkeys(bool bDisable) { m_bDisableOSHotkeys = bDisable; }
+
+  /// \brief Returns whether OS hotkey suppression is currently requested.
+  bool GetDisableOSHotkeys() const { return m_bDisableOSHotkeys; }
+
   /// \brief Sets the scaling factor that is applied on all (relative) mouse input.
   virtual void SetMouseSpeed(const ezVec2& vScale) { m_vMouseScale = vScale; }
 
@@ -67,13 +76,14 @@ public:
 protected:
   virtual void UpdateInputSlotValues() override;
 
-  ezTime m_DoubleClickTime = ezTime::MakeFromMilliseconds(500);
   static ezInputDevice* s_pMouseOver;
+
+  ezTime m_DoubleClickTime = ezTime::MakeFromMilliseconds(500);
   ezVec2 m_vLocalMouseCoordinates = ezVec2(0.0f);
+  bool m_bDisableOSHotkeys = false;
 
 private:
   ezVec2 m_vMouseScale = ezVec2(1.0f);
-
   bool m_bIsFocused = true;
 
   ezTime m_LastMouseClick[3];

--- a/Code/Engine/Core/Platform/Win/InputDevice_Platform.h
+++ b/Code/Engine/Core/Platform/Win/InputDevice_Platform.h
@@ -28,6 +28,8 @@ public:
   virtual void SetShowMouseCursor(bool bShow) override;
   virtual bool GetShowMouseCursor() const override;
 
+  virtual void SetDisableOSHotkeys(bool bDisable) override;
+
 protected:
   virtual void InitializeDevice() override;
   virtual void RegisterInputSlots() override;
@@ -37,9 +39,11 @@ protected:
 private:
   void ApplyClipRect(ezMouseCursorClipMode::Enum mode);
   void OnFocusLost();
+  void RegisterRawInput();
+
+  static ezInputDeviceMouseKeyboard_Win* s_pGlobalInputHandler;
 
   ezMinWindows::HWND m_hWnd;
-  static ezInputDeviceMouseKeyboard_Win* s_pGlobalInputHandler;
   bool m_bShowCursor = true;
   ezMouseCursorClipMode::Enum m_ClipCursorMode = ezMouseCursorClipMode::NoClip;
   bool m_bApplyClipRect = false;

--- a/Code/Engine/Core/Platform/Win/InputDevice_Win.cpp
+++ b/Code/Engine/Core/Platform/Win/InputDevice_Win.cpp
@@ -46,34 +46,54 @@ ezInputDeviceMouseKeyboard_Win::~ezInputDeviceMouseKeyboard_Win()
   }
 }
 
+void ezInputDeviceMouseKeyboard_Win::RegisterRawInput()
+{
+  RAWINPUTDEVICE Rid[2];
+
+  // keyboard
+  Rid[0].usUsagePage = 0x01;
+  Rid[0].usUsage = 0x06;
+  Rid[0].dwFlags = m_bDisableOSHotkeys ? RIDEV_NOHOTKEYS : 0;
+  Rid[0].hwndTarget = nullptr;
+
+  // mouse
+  Rid[1].usUsagePage = 0x01;
+  Rid[1].usUsage = 0x02;
+  Rid[1].dwFlags = 0;
+  Rid[1].hwndTarget = nullptr;
+
+  if (RegisterRawInputDevices(&Rid[0], (UINT)2, sizeof(RAWINPUTDEVICE)) == FALSE)
+  {
+    ezLog::Error("Could not initialize RawInput for Mouse and Keyboard input.");
+  }
+  else
+  {
+    ezLog::Success("Initialized RawInput for Mouse and Keyboard input.");
+  }
+}
+
 void ezInputDeviceMouseKeyboard_Win::InitializeDevice()
 {
   if (s_pGlobalInputHandler == this)
   {
-    RAWINPUTDEVICE Rid[2];
-
-    // keyboard
-    Rid[0].usUsagePage = 0x01;
-    Rid[0].usUsage = 0x06;
-    Rid[0].dwFlags = 0; // RIDEV_NOHOTKEYS; // Disables Windows-Key and Application-Key (unclear whether to make this configurable)
-    Rid[0].hwndTarget = nullptr;
-
-    // mouse
-    Rid[1].usUsagePage = 0x01;
-    Rid[1].usUsage = 0x02;
-    Rid[1].dwFlags = 0;
-    Rid[1].hwndTarget = nullptr;
-
-    if (RegisterRawInputDevices(&Rid[0], (UINT)2, sizeof(RAWINPUTDEVICE)) == FALSE)
-    {
-      ezLog::Error("Could not initialize RawInput for Mouse and Keyboard input.");
-    }
-    else
-      ezLog::Success("Initialized RawInput for Mouse and Keyboard input.");
+    RegisterRawInput();
   }
   else
   {
     ezLog::Dev("Window doesn't handle global mouse/keyboard input.");
+  }
+}
+
+void ezInputDeviceMouseKeyboard_Win::SetDisableOSHotkeys(bool bDisable)
+{
+  if (m_bDisableOSHotkeys != bDisable)
+  {
+    m_bDisableOSHotkeys = bDisable;
+
+    if (s_pGlobalInputHandler == this)
+    {
+      RegisterRawInput();
+    }
   }
 }
 

--- a/Code/Tools/Player/Player.cpp
+++ b/Code/Tools/Player/Player.cpp
@@ -1,5 +1,7 @@
 #include <Player/Player.h>
 
+#include <Core/Input/DeviceTypes/MouseKeyboard.h>
+#include <Core/Input/InputManager.h>
 #include <Foundation/Configuration/Startup.h>
 #include <Foundation/Logging/Log.h>
 #include <Foundation/Utilities/CommandLineOptions.h>
@@ -53,6 +55,12 @@ void ezPlayerApplication::AfterCoreSystemsStartup()
   // the game state is also responsible for either creating a world, or loading it
   // the ezFallbackGameState inspects the command line to figure out which scene to load
   ActivateGameState(nullptr, {}, ezTransform::MakeIdentity());
+
+  // in ezPlayer we want OS keys (Windows key) to be disabled
+  if (auto* pDevice = ezInputManager::GetInputDeviceOfType<ezInputDeviceMouseKeyboard>())
+  {
+    pDevice->SetDisableOSHotkeys(true);
+  }
 }
 
 void ezPlayerApplication::DetermineProjectPath()


### PR DESCRIPTION
ezPlayer now disables the Windows key, since it uses that for its internal menu. Applications can now toggle themselves whether the Windows key is handled or not.