### PR TITLE
Fix Sampler Support in VSE

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -421,9 +421,14 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
     {
       if (pMsg1->m_sPayload == "ReloadAllResources")
       {
+        ezFileSystem::ReloadAllExternalDataDirectoryConfigs();
         ezResourceManager::ReloadAllResources(false);
       }
       ezRenderWorld::DeleteAllCachedRenderData();
+    }
+    else if (pMsg1->m_sWhatToDo == "ForceNoFallbackAcquisition")
+    {
+      ezResourceManager::ForceNoFallbackAcquisition(3);
     }
     else if (pMsg1->m_sWhatToDo == "SaveProfiling")
     {

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/VisualShader/VsCodeGenerator.cpp
@@ -4,6 +4,7 @@
 
 namespace
 {
+  static constexpr ezUInt8 s_uiSamplerDim = 255;
   // Returns the dimension of a type: 1 for float, 2 for ezVec2, 3 for ezVec3, 4 for ezVec4/ezColor, 0 for unknown
   ezUInt8 GetTypeDimension(const ezRTTI* pType)
   {
@@ -18,6 +19,9 @@ namespace
     // We treat 'auto' as float as all the default values for auto fields are float.
     if (pType == nullptr)
       return 1;
+
+    if (pType == ezVisualShaderTypeRegistry::GetSingleton()->GetPinSamplerType())
+      return s_uiSamplerDim;
 
     EZ_REPORT_FAILURE("Unknown RTTI type found in VSE type");
     return 0;
@@ -36,6 +40,8 @@ namespace
         return "float3";
       case 4:
         return "float4";
+      case s_uiSamplerDim:
+        return "SamplerState";
       default:
         EZ_REPORT_FAILURE("Unknown vector dimension found in HLSL type");
         return "float4";

--- a/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
+++ b/Code/UnitTests/EditorTest/MaterialDocument/MaterialDocumentTest.cpp
@@ -161,15 +161,15 @@ void ezMaterialDocumentTest::CaptureMaterialImage()
   ezActionManager::ExecuteAction(nullptr, "View.SkyBox", ctx2, false).AssertSuccess();
   ProcessEvents();
 
-  // Wait until the resource manager has finished loading, with a timeout as a safety net.
-  for (int i = 0; i < 200; ++i)
-  {
-    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(50));
-    ProcessEvents();
+  ezSimpleConfigMsgToEngine msg;
+  msg.m_sWhatToDo = "ForceNoFallbackAcquisition";
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
+  msg.m_sWhatToDo = "ReloadResources";
+  msg.m_sPayload = "ReloadAllResources";
+  ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 
-    if (i > 10 && !ezResourceManager::IsAnyLoadingInProgress())
-      break;
-  }
+  ProcessEvents();
+  WaitFrames(8);
 
   EZ_TEST_BOOL(CaptureImage(pWindow, "MatFromShader").Succeeded());
   EZ_TEST_IMAGE(1, 100);
@@ -309,18 +309,7 @@ void ezMaterialDocumentTest::CreateMaterialFromVSE()
   // Bug: Shader won't update until transformed and shader mode is switched back and forth.
   EZ_TEST_STATUS(m_pDoc->SaveDocument());
   ezAssetCurator::GetSingleton()->TransformAsset(m_MaterialGuid, ezTransformFlags::ForceTransform);
-  ezAssetCurator::GetSingleton()->WriteAssetTables(nullptr, true).AssertSuccess();
-  ezResourceManager::ReloadAllResources(false);
-
-  // Wait for the resource manager to finish loading the newly compiled shader before toggling ShaderMode.
-  for (int i = 0; i < 200; ++i)
-  {
-    ezThreadUtils::Sleep(ezTime::MakeFromMilliseconds(50));
-    ProcessEvents();
-
-    if (i > 10 && !ezResourceManager::IsAnyLoadingInProgress())
-      break;
-  }
+  ProcessEvents();
 
   pAccessor->StartTransaction("Change Property 'Shader Mode'");
   EZ_TEST_STATUS(pAccessor->SetValueByName(pProperties, "ShaderMode", 0));
@@ -341,7 +330,6 @@ void ezMaterialDocumentTest::CreateMaterialFromVSE()
   pAccessor->FinishTransaction();
 
   ProcessEvents();
-
   CaptureMaterialImage();
 
   CloseMaterial();

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.cpp
@@ -155,12 +155,14 @@ ezResult ezEditorTest::InitializeTest()
   }
 
   ezTestFramework::GetInstance()->SetImageReferenceTagsFromEnvironment(EZ_PLATFORM_NAME, ezGameApplication::GetActiveRenderer(), s_sAdapterName);
+  m_UIServicesTickEventHandlerID = ezQtUiServices::s_TickEvent.AddEventHandler(ezMakeDelegate(&ezEditorTest::UIServicesTickEventHandler, this));
 
   return EZ_SUCCESS;
 }
 
 ezResult ezEditorTest::DeInitializeTest()
 {
+  ezQtUiServices::s_TickEvent.RemoveEventHandler(m_UIServicesTickEventHandlerID);
   CloseCurrentProject();
 
   if (m_pApplication)
@@ -324,6 +326,29 @@ void ezEditorTest::ProcessEvents(ezUInt32 uiIterations)
     {
       qApp->processEvents();
     }
+  }
+}
+
+void ezEditorTest::WaitFrames(ezUInt32 uiFrames)
+{
+  EZ_PROFILE_SCOPE("WaitFrames");
+  // Add one because we could have started waiting between start and end frame.
+  uiFrames++;
+  ezUInt32 uiCurrentFrame = m_uiRenderedFrames;
+  if (qApp)
+  {
+    while ((m_uiRenderedFrames - uiCurrentFrame) < uiFrames)
+    {
+      qApp->processEvents();
+    }
+  }
+}
+
+void ezEditorTest::UIServicesTickEventHandler(const ezQtUiServices::TickEvent& e)
+{
+  if (e.m_Type == ezQtUiServices::TickEvent::Type::EndFrame)
+  {
+    m_uiRenderedFrames++;
   }
 }
 

--- a/Code/UnitTests/EditorTest/TestClass/TestClass.h
+++ b/Code/UnitTests/EditorTest/TestClass/TestClass.h
@@ -62,6 +62,8 @@ protected:
   void CloseCurrentProject();
   void SafeProfilingData();
   void ProcessEvents(ezUInt32 uiIterations = 1);
+  void WaitFrames(ezUInt32 uiFrames = 1);
+  void UIServicesTickEventHandler(const ezQtUiServices::TickEvent& e);
 
   std::unique_ptr<QMimeData> AssetsToDragMimeData(ezArrayPtr<ezUuid> assetGuids);
   std::unique_ptr<QMimeData> ObjectsDragMimeData(const ezDeque<const ezDocumentObject*>& objects);
@@ -75,4 +77,6 @@ protected:
   ezImage m_CapturedImage;
   ezDynamicArray<ezString> m_CommandLineArguments;
   ezDynamicArray<const char*> m_CommandLineArgumentPointers;
+  ezEventSubscriptionID m_UIServicesTickEventHandlerID = {};
+  ezUInt32 m_uiRenderedFrames = 0;
 };


### PR DESCRIPTION
* Fix sampler support by adding a dimension constant for samplers: `s_uiSamplerDim` which is then converted to `"SamplerState"` when creating the variable type.
* Made material editor tests more robust. Added a new function `WaitFrames` to the editor tests that allow waiting for N frames to be rendered in the engine process. The only cause for spurious failures now is that "Material Live Update" task is scheduled on a worker thread in the engine process and this can potentially stall and not finish in time before the screenshot is made. Not sure how to ensure this does not happen so far now we wait for 8 frames to be rendered.