### PR TITLE
Do not fail tests due to `adb logcat --clear`

### DIFF
--- a/Utilities/Android/AndroidTest.ps1
+++ b/Utilities/Android/AndroidTest.ps1
@@ -84,7 +84,10 @@ if ($apk) {
 }
 
 Write-Host "Clearing LogCat..."
-Adb-Cmd -s $deviceAdb logcat --clear
+$clearFunction = {
+    Adb-Cmd -ErrorAction Continue -s $deviceAdb logcat --clear
+}
+Invoke-WithRetry -ScriptBlock $clearFunction -MaxRetryCount 5
 
 Write-Host "Starting $packageName/$activityName..."
 if ($arguments) {
@@ -184,10 +187,11 @@ $outputLines -join "`n" | Out-File -Encoding "UTF8" $outputFilePath
 # Download artifacts from device
 Adb-CopyDirectory -deviceAdb $deviceAdb -packageName $packageName -outputFolder $outputFolder -deviceFolder "/data/data/$packageName/files"
 
-# Sleep a bit before clearing the log
-Start-Sleep -Seconds 1
-Adb-Cmd -s $deviceAdb logcat --clear
-Start-Sleep -Seconds 1
+try {
+    Invoke-WithRetry -ScriptBlock $clearFunction -MaxRetryCount 5
+} catch {
+    Write-Host "Warning: Failed to clear logcat: $_"
+}
 
 if ($testSuccess) {
     exit 0


### PR DESCRIPTION
Just added retries and try catch block around the `adb logcat --clear`. Note that as long as somebody has logcat streaming you can't clear it so probably there is a race between us stopping to read logcat and the clear command afterwards.