### PR TITLE
Temp allocator

### DIFF
--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -420,7 +420,7 @@ void ezWorld::PostMessage(const ezGameObjectHandle& receiverObject, const ezMess
   }
   else
   {
-    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_StackAllocator.GetCurrentAllocator());
+    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_LinearAllocator.GetCurrentAllocator());
     m_Data.m_MessageQueues[queueType].Enqueue(pMsgCopy, metaData);
   }
 }
@@ -451,7 +451,7 @@ void ezWorld::PostMessage(const ezComponentHandle& hReceiverComponent, const ezM
   }
   else
   {
-    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_StackAllocator.GetCurrentAllocator());
+    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_LinearAllocator.GetCurrentAllocator());
     m_Data.m_MessageQueues[queueType].Enqueue(pMsgCopy, metaData);
   }
 }
@@ -577,7 +577,7 @@ void ezWorld::Update()
   }
 
   // Swap our double buffered stack allocator
-  m_Data.m_StackAllocator.Swap();
+  m_Data.m_LinearAllocator.Swap();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -45,7 +45,7 @@ namespace ezInternal
     , m_Allocator(desc.m_sName, ezFoundation::GetDefaultAllocator())
     , m_AllocatorWrapper(&m_Allocator)
     , m_BlockAllocator(desc.m_sName, &m_Allocator)
-    , m_StackAllocator(desc.m_sName, ezFoundation::GetAlignedAllocator())
+    , m_LinearAllocator(desc.m_sName, ezFoundation::GetAlignedAllocator())
     , m_ObjectStorage(&m_BlockAllocator, &m_Allocator)
     , m_MaxInitializationTimePerFrame(desc.m_MaxComponentInitializationTimePerFrame)
     , m_Clock(desc.m_sName)

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -29,7 +29,7 @@ namespace ezInternal
     mutable ezProxyAllocator m_Allocator;
     ezLocalAllocatorWrapper m_AllocatorWrapper;
     ezInternal::WorldLargeBlockAllocator m_BlockAllocator;
-    ezDoubleBufferedLinearAllocator m_StackAllocator;
+    ezDoubleBufferedLinearAllocator m_LinearAllocator;
 
     enum
     {

--- a/Code/Engine/Core/World/Implementation/WorldData_inl.h
+++ b/Code/Engine/Core/World/Implementation/WorldData_inl.h
@@ -37,7 +37,7 @@ namespace ezInternal
     ezParallelForParams parallelForParams;
     parallelForParams.m_uiBinSize = 100;
     parallelForParams.m_uiMaxTasksPerThread = 2;
-    parallelForParams.m_pTaskAllocator = m_StackAllocator.GetCurrentAllocator();
+    parallelForParams.m_pTaskAllocator = m_LinearAllocator.GetCurrentAllocator();
 
     ezTaskSystem::ParallelFor(
       blocks.GetArrayPtr(),

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -454,7 +454,7 @@ EZ_ALWAYS_INLINE ezInternal::WorldLargeBlockAllocator* ezWorld::GetBlockAllocato
 
 EZ_ALWAYS_INLINE ezDoubleBufferedLinearAllocator* ezWorld::GetStackAllocator()
 {
-  return &m_Data.m_StackAllocator;
+  return &m_Data.m_LinearAllocator;
 }
 
 EZ_ALWAYS_INLINE ezInternal::WorldData::ReadMarker& ezWorld::GetReadMarker() const

--- a/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
+++ b/Code/Engine/Core/WorldSerializer/Implementation/WorldReader.cpp
@@ -12,7 +12,7 @@ thread_local ezWorldReader::InstantiationContextBase* tl_pReaderContext = nullpt
 ezWorldReader::ezWorldReader() = default;
 ezWorldReader::~ezWorldReader() = default;
 
-ezResult ezWorldReader::ReadWorldDescription(ezStreamReader& inout_stream, bool bWarningOnUknownSkip)
+ezResult ezWorldReader::ReadWorldDescription(ezStreamReader& inout_stream, bool bWarningOnUnknownSkip)
 {
   m_pReadStream = &inout_stream;
 
@@ -71,7 +71,7 @@ ezResult ezWorldReader::ReadWorldDescription(ezStreamReader& inout_stream, bool 
   }
 
   // read all component data
-  ReadComponentDataToMemStream(bWarningOnUknownSkip);
+  ReadComponentDataToMemStream(bWarningOnUnknownSkip);
   m_pStringDedupReadContext->SetActive(false);
 
   return EZ_SUCCESS;
@@ -313,7 +313,7 @@ ezUniquePtr<ezWorldReader::InstantiationContextBase> ezWorldReader::Instantiate(
 {
   if (options.m_MaxStepTime <= ezTime::MakeZero())
   {
-    InstantiationContext context = InstantiationContext(*this, &world, bUseTransform, rootTransform, options, ezFrameAllocator::GetCurrentAllocator());
+    InstantiationContext context = InstantiationContext(*this, &world, bUseTransform, rootTransform, options, ezTempAllocator::Get());
 
     EZ_VERIFY(context.Step() == InstantiationContextBase::StepResult::Finished, "Instantiation should be completed after this call");
     return nullptr;
@@ -404,7 +404,7 @@ ezWorldReader::InstantiationContext::StepResult ezWorldReader::InstantiationCont
       if (m_WorldReader.m_RootObjectsToCreate.GetCount() == 1 && m_WorldReader.m_RootObjectsToCreate[0].m_Desc.m_sName == m_Options.m_ReplaceNamedRootWithParent)
       {
         m_uiCurrentIndex = 1;
-        EZ_ASSERT_DEBUG(m_IndexToGameObjectHandle.GetCapacity() > m_IndexToGameObjectHandle.GetCount(), "m_IndexToGameObjectHandle should have the enough capacity.");
+        EZ_ASSERT_DEBUG(m_IndexToGameObjectHandle.GetCapacity() > m_IndexToGameObjectHandle.GetCount(), "m_IndexToGameObjectHandle should have enough capacity.");
         m_IndexToGameObjectHandle.PushBack(m_Options.m_hParent);
 
         ezGameObject* pParent = nullptr;
@@ -588,7 +588,7 @@ bool ezWorldReader::InstantiationContext::CreateGameObjects(const ezDynamicArray
     }
 
     ezGameObject* pObject = nullptr;
-    EZ_ASSERT_DEBUG(m_IndexToGameObjectHandle.GetCapacity() > m_IndexToGameObjectHandle.GetCount(), "m_IndexToGameObjectHandle should have the enough capacity.");
+    EZ_ASSERT_DEBUG(m_IndexToGameObjectHandle.GetCapacity() > m_IndexToGameObjectHandle.GetCount(), "m_IndexToGameObjectHandle should have enough capacity.");
     m_IndexToGameObjectHandle.PushBack(m_pWorld->CreateObject(desc, pObject));
 
     if (!godesc.m_sGlobalKey.IsEmpty())
@@ -650,7 +650,7 @@ bool ezWorldReader::InstantiationContext::CreateComponents(ezTime endTime)
       ezGameObject* pOwnerObject = nullptr;
       if (!m_pWorld->TryGetObject(hOwner, pOwnerObject))
       {
-        EZ_REPORT_FAILURE("Owner object must be not null");
+        EZ_REPORT_FAILURE("Owner object must not be null");
       }
 
       ezComponent* pComponent = nullptr;
@@ -664,7 +664,7 @@ bool ezWorldReader::InstantiationContext::CreateComponents(ezTime endTime)
       }
 
       EZ_ASSERT_DEBUG(uiComponentIdx == compTypeState.m_ComponentIndexToHandle.GetCount(), "Component index doesn't match");
-      EZ_ASSERT_DEBUG(compTypeState.m_ComponentIndexToHandle.GetCapacity() > compTypeState.m_ComponentIndexToHandle.GetCount(), "m_ComponentIndexToHandle should have the enough capacity.");
+      EZ_ASSERT_DEBUG(compTypeState.m_ComponentIndexToHandle.GetCapacity() > compTypeState.m_ComponentIndexToHandle.GetCount(), "m_ComponentIndexToHandle should have enough capacity.");
       compTypeState.m_ComponentIndexToHandle.PushBack(hComponent);
 
       ++m_uiCurrentIndex;

--- a/Code/Engine/Foundation/Basics.h
+++ b/Code/Engine/Foundation/Basics.h
@@ -90,7 +90,6 @@ private:
   static bool s_bIsInitialized;
   static ezAllocator* s_pDefaultAllocator;
   static ezAllocator* s_pAlignedAllocator;
-  static ezAllocator* s_pTempAllocator;
 };
 
 #undef EZ_INCLUDING_BASICS_H

--- a/Code/Engine/Foundation/Basics.h
+++ b/Code/Engine/Foundation/Basics.h
@@ -60,9 +60,6 @@
 class EZ_FOUNDATION_DLL ezFoundation
 {
 public:
-  static ezAllocator* s_pDefaultAllocator;
-  static ezAllocator* s_pAlignedAllocator;
-
   /// \brief The default allocator can be used for any kind of allocation if no alignment is required
   EZ_ALWAYS_INLINE static ezAllocator* GetDefaultAllocator()
   {
@@ -91,6 +88,9 @@ private:
 
   static void Initialize();
   static bool s_bIsInitialized;
+  static ezAllocator* s_pDefaultAllocator;
+  static ezAllocator* s_pAlignedAllocator;
+  static ezAllocator* s_pTempAllocator;
 };
 
 #undef EZ_INCLUDING_BASICS_H

--- a/Code/Engine/Foundation/Basics/Basics.cpp
+++ b/Code/Engine/Foundation/Basics/Basics.cpp
@@ -15,7 +15,7 @@ using DefaultStaticsHeapType = ezAllocatorWithPolicy<ezAllocPolicyHeap, ezAlloca
 enum
 {
   HEAP_ALLOCATOR_BUFFER_SIZE = sizeof(DefaultHeapType),
-  ALIGNED_ALLOCATOR_BUFFER_SIZE = sizeof(DefaultAlignedHeapType)
+  ALIGNED_ALLOCATOR_BUFFER_SIZE = sizeof(DefaultAlignedHeapType),
 };
 
 alignas(EZ_ALIGNMENT_MINIMUM) static ezUInt8 s_DefaultAllocatorBuffer[HEAP_ALLOCATOR_BUFFER_SIZE];

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionAST.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionAST.cpp
@@ -445,7 +445,7 @@ ezExpressionAST::VectorComponent::Enum ezExpressionAST::VectorComponent::FromCha
 //////////////////////////////////////////////////////////////////////////
 
 ezExpressionAST::ezExpressionAST()
-  : m_Allocator("Expression AST", ezFoundation::GetAlignedAllocator())
+  : m_Allocator("Expression AST", ezFoundation::GetAlignedAllocator(), 4 * 1024)
 {
   static_assert(sizeof(Node) == 8);
 #if EZ_ENABLED(EZ_PLATFORM_64BIT)

--- a/Code/Engine/Foundation/Containers/DynamicArray.h
+++ b/Code/Engine/Foundation/Containers/DynamicArray.h
@@ -2,6 +2,7 @@
 
 #include <Foundation/Containers/ArrayBase.h>
 #include <Foundation/Memory/AllocatorWrapper.h>
+#include <Foundation/Memory/TempAllocator.h>
 #include <Foundation/Types/PointerWithFlags.h>
 
 /// \brief Implementation of a dynamically growing array.
@@ -105,6 +106,21 @@ protected:
     : ezDynamicArrayBase<T>(pInplaceStorage, uiCapacity, pAllocator)
   {
   }
+};
+
+/// A dynamic array that uses the temp allocator.
+/// This is ideal for temporary arrays that are only used within a short scope.
+/// The temp allocator is optimized for short-lived allocations and can be more efficient than the default allocator for this use case.
+template <typename T>
+class ezTempArray : public ezDynamicArray<T>
+{
+public:
+  ezTempArray();
+
+  void operator=(const ezDynamicArrayBase<T>& rhs);
+  void operator=(const ezArrayPtr<const T>& rhs);
+
+  void operator=(ezDynamicArrayBase<T>&& rhs) noexcept;
 };
 
 /// Overload of ezMakeArrayPtr for const dynamic arrays of pointer pointing to const type.

--- a/Code/Engine/Foundation/Containers/HybridArray.h
+++ b/Code/Engine/Foundation/Containers/HybridArray.h
@@ -47,4 +47,19 @@ protected:
   EZ_ALWAYS_INLINE const T* GetStaticArray() const { return reinterpret_cast<const T*>(m_StaticData); }
 };
 
+/// A hybrid array that uses the temp allocator if it exceeds the in-place storage.
+/// This is ideal for temporary arrays that are only used within a short scope and are not expected to grow beyond the in-place storage size in most cases.
+/// The temp allocator is optimized for short-lived allocations and can be more efficient than the default allocator for this use case.
+template <typename T, ezUInt32 Size>
+class ezTempHybridArray : public ezHybridArray<T, Size>
+{
+public:
+  ezTempHybridArray();
+
+  void operator=(const ezHybridArray<T, Size>& rhs);
+  void operator=(const ezArrayPtr<const T>& rhs);
+
+  void operator=(ezHybridArray<T, Size>&& rhs) noexcept;
+};
+
 #include <Foundation/Containers/Implementation/HybridArray_inl.h>

--- a/Code/Engine/Foundation/Containers/Implementation/DynamicArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/DynamicArray_inl.h
@@ -239,6 +239,8 @@ ezUInt64 ezDynamicArrayBase<T>::GetHeapMemoryUsage() const
   return (ezUInt64)this->m_uiCapacity * (ezUInt64)sizeof(T);
 }
 
+//////////////////////////////////////////////////////////////////////////
+
 template <typename T, typename A>
 ezDynamicArray<T, A>::ezDynamicArray()
   : ezDynamicArrayBase<T>(A::GetAllocator())
@@ -310,6 +312,34 @@ void ezDynamicArray<T, A>::operator=(ezDynamicArrayBase<T>&& rhs) noexcept
 {
   ezDynamicArrayBase<T>::operator=(std::move(rhs));
 }
+
+//////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+ezTempArray<T>::ezTempArray()
+  : ezDynamicArray<T>(ezTempAllocator::Get())
+{
+}
+
+template <typename T>
+void ezTempArray<T>::operator=(const ezDynamicArrayBase<T>& rhs)
+{
+  ezDynamicArrayBase<T>::operator=(rhs);
+}
+
+template <typename T>
+void ezTempArray<T>::operator=(const ezArrayPtr<const T>& rhs)
+{
+  ezArrayBase<T, ezDynamicArrayBase<T>>::operator=(rhs);
+}
+
+template <typename T>
+void ezTempArray<T>::operator=(ezDynamicArrayBase<T>&& rhs) noexcept
+{
+  ezDynamicArrayBase<T>::operator=(std::move(rhs));
+}
+
+//////////////////////////////////////////////////////////////////////////
 
 template <typename T, typename AllocatorWrapper>
 ezArrayPtr<const T* const> ezMakeArrayPtr(const ezDynamicArray<T*, AllocatorWrapper>& dynArray)

--- a/Code/Engine/Foundation/Containers/Implementation/HybridArray_inl.h
+++ b/Code/Engine/Foundation/Containers/Implementation/HybridArray_inl.h
@@ -1,4 +1,3 @@
-#include <Foundation/Containers/HybridArray.h>
 
 template <typename T, ezUInt32 Size, typename AllocatorWrapper /*= ezDefaultAllocatorWrapper*/>
 ezHybridArray<T, Size, AllocatorWrapper>::ezHybridArray()
@@ -49,4 +48,30 @@ template <typename T, ezUInt32 Size, typename AllocatorWrapper /*= ezDefaultAllo
 void ezHybridArray<T, Size, AllocatorWrapper>::operator=(ezHybridArray<T, Size, AllocatorWrapper>&& rhs) noexcept
 {
   ezDynamicArray<T, AllocatorWrapper>::operator=(std::move(rhs));
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+template <typename T, ezUInt32 Size>
+ezTempHybridArray<T, Size>::ezTempHybridArray()
+  : ezHybridArray<T, Size>(ezTempAllocator::Get())
+{
+}
+
+template <typename T, ezUInt32 Size>
+void ezTempHybridArray<T, Size>::operator=(const ezHybridArray<T, Size>& rhs)
+{
+  ezDynamicArray<T>::operator=(rhs);
+}
+
+template <typename T, ezUInt32 Size>
+void ezTempHybridArray<T, Size>::operator=(const ezArrayPtr<const T>& rhs)
+{
+  ezDynamicArray<T>::operator=(rhs);
+}
+
+template <typename T, ezUInt32 Size>
+void ezTempHybridArray<T, Size>::operator=(ezHybridArray<T, Size>&& rhs) noexcept
+{
+  ezDynamicArray<T>::operator=(std::move(rhs));
 }

--- a/Code/Engine/Foundation/FoundationPCH.cpp
+++ b/Code/Engine/Foundation/FoundationPCH.cpp
@@ -22,6 +22,7 @@ EZ_STATICLINK_LIBRARY(Foundation)
   EZ_STATICLINK_REFERENCE(Foundation_Math_Implementation_Math);
   EZ_STATICLINK_REFERENCE(Foundation_Math_Implementation_Random);
   EZ_STATICLINK_REFERENCE(Foundation_Memory_Implementation_FrameAllocator);
+  EZ_STATICLINK_REFERENCE(Foundation_Memory_Implementation_TempAllocator);
   EZ_STATICLINK_REFERENCE(Foundation_Platform_Win_DirectoryWatcher_Win);
   EZ_STATICLINK_REFERENCE(Foundation_Profiling_Implementation_Profiling);
   EZ_STATICLINK_REFERENCE(Foundation_Reflection_Implementation_AbstractProperty);
@@ -37,6 +38,8 @@ EZ_STATICLINK_LIBRARY(Foundation)
   EZ_STATICLINK_REFERENCE(Foundation_Time_Implementation_Clock);
   EZ_STATICLINK_REFERENCE(Foundation_Time_Implementation_Time);
   EZ_STATICLINK_REFERENCE(Foundation_Time_Implementation_Timestamp);
+  EZ_STATICLINK_REFERENCE(Foundation_Tracks_Implementation_ColorGradient);
+  EZ_STATICLINK_REFERENCE(Foundation_Tracks_Implementation_CurveEditData);
   EZ_STATICLINK_REFERENCE(Foundation_Types_Implementation_VarianceTypes);
   EZ_STATICLINK_REFERENCE(Foundation_Types_Implementation_VariantTypeRegistry);
 }

--- a/Code/Engine/Foundation/Memory/CommonAllocators.h
+++ b/Code/Engine/Foundation/Memory/CommonAllocators.h
@@ -10,7 +10,6 @@
 #include <Foundation/Memory/Policies/AllocPolicyHeap.h>
 #include <Foundation/Memory/Policies/AllocPolicyProxy.h>
 
-
 /// \brief Default heap allocator with alignment support.
 ///
 /// This allocator supports arbitrary alignment requirements.
@@ -22,7 +21,7 @@ using ezAlignedHeapAllocator = ezAllocatorWithPolicy<ezAllocPolicyAlignedHeap>;
 /// \brief Basic heap allocator without special alignment support.
 ///
 /// Faster than ezAlignedHeapAllocator but only supports natural alignment (alignof(T)).
-/// The is the recommended allocator for general purpose use.
+/// This is the recommended allocator for general purpose use.
 using ezHeapAllocator = ezAllocatorWithPolicy<ezAllocPolicyHeap>;
 
 /// \brief Debug allocator that adds guard pages around allocations.

--- a/Code/Engine/Foundation/Memory/Implementation/FrameAllocator.cpp
+++ b/Code/Engine/Foundation/Memory/Implementation/FrameAllocator.cpp
@@ -7,15 +7,17 @@
 
 ezDoubleBufferedLinearAllocator::ezDoubleBufferedLinearAllocator(ezStringView sName0, ezAllocator* pParent)
 {
+  constexpr ezUInt32 uiInitialSize = 1024 * 1024; // 1 MB
+
   ezStringBuilder sName = sName0;
   sName.Append("0");
 
-  m_pCurrentAllocator = EZ_DEFAULT_NEW(LinearAllocatorType, sName, pParent);
+  m_pCurrentAllocator = EZ_DEFAULT_NEW(LinearAllocatorType, sName, pParent, uiInitialSize);
 
   sName = sName0;
   sName.Append("1");
 
-  m_pOtherAllocator = EZ_DEFAULT_NEW(LinearAllocatorType, sName, pParent);
+  m_pOtherAllocator = EZ_DEFAULT_NEW(LinearAllocatorType, sName, pParent, uiInitialSize);
 }
 
 ezDoubleBufferedLinearAllocator::~ezDoubleBufferedLinearAllocator()

--- a/Code/Engine/Foundation/Memory/Implementation/LinearAllocator_inl.h
+++ b/Code/Engine/Foundation/Memory/Implementation/LinearAllocator_inl.h
@@ -1,9 +1,10 @@
 template <ezAllocatorTrackingMode TrackingMode, bool OverwriteMemoryOnReset>
-ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::ezLinearAllocator(ezStringView sName, ezAllocator* pParent)
-  : ezAllocatorWithPolicy<typename ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::PolicyStack, TrackingMode>(sName, pParent)
+ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::ezLinearAllocator(ezStringView sName, ezAllocator* pParent, ezUInt32 uiInitialSize)
+  : SUPER(sName, pParent)
   , m_DestructData(pParent)
   , m_PtrToDestructDataIndexTable(pParent)
 {
+  this->m_allocator.SetNextBucketSize(uiInitialSize);
 }
 
 template <ezAllocatorTrackingMode TrackingMode, bool OverwriteMemoryOnReset>
@@ -17,7 +18,7 @@ void* ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::Allocate(size_t u
 {
   EZ_LOCK(m_Mutex);
 
-  void* ptr = ezAllocatorWithPolicy<typename ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::PolicyStack, TrackingMode>::Allocate(uiSize, uiAlign, destructorFunc);
+  void* ptr = SUPER::Allocate(uiSize, uiAlign, destructorFunc);
 
   if (destructorFunc != nullptr)
   {
@@ -45,7 +46,7 @@ void ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::Deallocate(void* p
     data.m_Ptr = nullptr;
   }
 
-  ezAllocatorWithPolicy<typename ezLinearAllocator<TrackingMode, OverwriteMemoryOnReset>::PolicyStack, TrackingMode>::Deallocate(pPtr);
+  SUPER::Deallocate(pPtr);
 }
 
 EZ_MSVC_ANALYSIS_WARNING_PUSH

--- a/Code/Engine/Foundation/Memory/Implementation/TempAllocator.cpp
+++ b/Code/Engine/Foundation/Memory/Implementation/TempAllocator.cpp
@@ -1,0 +1,46 @@
+#include <Foundation/FoundationPCH.h>
+
+#include <Foundation/Configuration/Startup.h>
+#include <Foundation/Memory/AllocatorWithPolicy.h>
+#include <Foundation/Memory/Policies/AllocPolicyStack.h>
+#include <Foundation/Memory/TempAllocator.h>
+
+// clang-format off
+EZ_BEGIN_SUBSYSTEM_DECLARATION(Foundation, TempAllocator)
+
+  ON_CORESYSTEMS_STARTUP
+  {
+    ezTempAllocator::Startup();
+  }
+
+  ON_CORESYSTEMS_SHUTDOWN
+  {
+    ezTempAllocator::Shutdown();
+  }
+
+EZ_END_SUBSYSTEM_DECLARATION;
+// clang-format on
+
+ezAllocator* ezTempAllocator::s_pAllocator;
+
+// static
+void ezTempAllocator::Startup()
+{
+#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
+  static constexpr bool OverwriteMemoryOnFree = true;
+#else
+  static constexpr bool OverwriteMemoryOnFree = false;
+#endif
+  using StackAllocatorType = ezAllocatorWithPolicy<ezAllocPolicyStack<OverwriteMemoryOnFree>, ezAllocatorTrackingMode::Basics>;
+
+  s_pAllocator = EZ_DEFAULT_NEW(StackAllocatorType, "TempAllocator", ezFoundation::GetAlignedAllocator());
+}
+
+// static
+void ezTempAllocator::Shutdown()
+{
+  EZ_DEFAULT_DELETE(s_pAllocator);
+}
+
+
+EZ_STATICLINK_FILE(Foundation, Foundation_Memory_Implementation_TempAllocator);

--- a/Code/Engine/Foundation/Memory/LinearAllocator.h
+++ b/Code/Engine/Foundation/Memory/LinearAllocator.h
@@ -7,11 +7,11 @@
 #include <Foundation/Threading/Lock.h>
 #include <Foundation/Threading/Mutex.h>
 
-/// \brief Stack-based linear allocator that allocates memory sequentially.
+/// \brief Linear allocator that allocates memory sequentially.
 ///
-/// This allocator allocates memory by simply advancing a pointer within a pre-allocated buffer.
+/// This allocator allocates memory by simply advancing a pointer within pre-allocated chunks.
 /// Individual deallocations are not supported - the entire allocator must be reset at once.
-/// Very efficient for temporary allocations that follow a stack-like pattern.
+/// Very efficient for short lived allocations.
 ///
 /// Template parameters:
 /// - TrackingMode: Controls allocation tracking and debugging features
@@ -31,10 +31,11 @@
 template <ezAllocatorTrackingMode TrackingMode = ezAllocatorTrackingMode::Default, bool OverwriteMemoryOnReset = false>
 class ezLinearAllocator : public ezAllocatorWithPolicy<ezAllocPolicyLinear<OverwriteMemoryOnReset>, TrackingMode>
 {
-  using PolicyStack = ezAllocPolicyLinear<OverwriteMemoryOnReset>;
+  using SUPER = ezAllocatorWithPolicy<ezAllocPolicyLinear<OverwriteMemoryOnReset>, TrackingMode>;
+  using PolicyLinear = ezAllocPolicyLinear<OverwriteMemoryOnReset>;
 
 public:
-  ezLinearAllocator(ezStringView sName, ezAllocator* pParent);
+  ezLinearAllocator(ezStringView sName, ezAllocator* pParent, ezUInt32 uiInitialSize);
   ~ezLinearAllocator();
 
   virtual void* Allocate(size_t uiSize, size_t uiAlign, ezMemoryUtils::DestructorFunction destructorFunc) override;

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyLinear.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyLinear.h
@@ -32,6 +32,7 @@ public:
     }
   }
 
+  /// \brief Sets the size of the next bucket to allocate. This can be used to prevent an excessive number of buckets if the required total allocation size is known in advance.
   EZ_FORCE_INLINE void SetNextBucketSize(ezUInt32 uiSize)
   {
     m_uiNextBucketSize = uiSize;

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyLinear.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyLinear.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Foundation/Containers/HybridArray.h>
+#include <Foundation/Containers/SmallArray.h>
 
 /// \brief This policy implements a linear allocator that can only grow and at some point all allocations gets reset at once.
 ///
@@ -30,6 +30,11 @@ public:
     {
       m_pParent->Deallocate(bucket.GetPtr());
     }
+  }
+
+  EZ_FORCE_INLINE void SetNextBucketSize(ezUInt32 uiSize)
+  {
+    m_uiNextBucketSize = uiSize;
   }
 
   EZ_FORCE_INLINE void* Allocate(size_t uiSize, size_t uiAlign)
@@ -121,5 +126,5 @@ private:
 
   ezUInt8* m_pNextAllocation = nullptr;
 
-  ezHybridArray<ezArrayPtr<ezUInt8>, 4> m_Buckets;
+  ezSmallArray<ezArrayPtr<ezUInt8>, 4> m_Buckets;
 };

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
@@ -131,7 +131,7 @@ public:
   EZ_ALWAYS_INLINE ezAllocator* GetParent() const { return m_pParent; }
 
 private:
-  ezUInt32 GetMaxAllocationSize() const { return EZ_BIT(m_uiMaxAllocSizeLog2); }
+  ezUInt32 GetMaxAllocationSize() const { return 1u << m_uiMaxAllocSizeLog2; }
 
   ezArrayPtr<ezUInt8> GetOrCreateBucket(ezUInt32 uiRequestedSize)
   {

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <Foundation/Containers/HashTable.h>
+#include <Foundation/Containers/SmallArray.h>
+#include <Foundation/Threading/Mutex.h>
+#include <Foundation/Threading/Lock.h>
+
+/// \brief This policy implements a stack allocator. It is designed for scenarios where you have a lot of short-lived allocations that are freed in a LIFO order,
+/// but it also supports freeing in arbitrary order (at the cost of some fragmentation).
+///
+/// For debugging purposes, the policy can also overwrite all freed memory with 0xCDCDCDCD to make it easier to find use-after-free situations.
+///
+/// \see ezAllocatorWithPolicy
+template <bool OverwriteMemoryOnFree = false>
+class ezAllocPolicyStack
+{
+public:
+  enum
+  {
+    Alignment = 16
+  };
+
+  EZ_FORCE_INLINE ezAllocPolicyStack(ezAllocator* pParent)
+    : m_pParent(pParent)
+    , m_uiMaxAllocSizeLog2(20) // 1024 * 1024 = 2^20
+  {
+  }
+
+  EZ_FORCE_INLINE ~ezAllocPolicyStack()
+  {
+    EZ_ASSERT_DEV(m_uiCurrentBucketIndex == 0 && m_uiCurrentBucketOffset == 0 && m_Allocations.IsEmpty(), "There is still something allocated!");
+    for (auto& bucket : m_Buckets)
+    {
+      m_pParent->Deallocate(bucket.GetPtr());
+    }
+  }
+
+  EZ_FORCE_INLINE void SetMaxAllocationSize(ezUInt32 uiSize)
+  {
+    m_uiMaxAllocSizeLog2 = ezMath::Log2i(uiSize);
+  }
+
+  EZ_FORCE_INLINE void* Allocate(size_t uiSize, size_t uiAlign)
+  {
+    // For allocations larger than the max allocation size, we directly allocate from the parent allocator.
+    if (uiSize > GetMaxAllocationSize())
+    {
+      return m_pParent->Allocate(uiSize, uiAlign);
+    }
+
+    EZ_LOCK(m_Mutex);
+
+    EZ_IGNORE_UNUSED(uiAlign);
+    EZ_ASSERT_DEV(uiAlign <= Alignment && Alignment % uiAlign == 0, "Unsupported alignment {0}", ((ezUInt32)uiAlign));
+    const ezUInt32 uiSize32 = static_cast<ezUInt32>(ezMemoryUtils::AlignSize(uiSize, (size_t)Alignment));
+
+    auto bucket = GetOrCreateBucket(uiSize32);
+    EZ_ASSERT_DEBUG(m_uiCurrentBucketOffset + uiSize <= bucket.GetCount(), "");
+
+    ezUInt8* ptr = bucket.GetPtr() + m_uiCurrentBucketOffset;
+
+    const ezUInt32 uiGlobalOffset = (m_uiCurrentBucketIndex << m_uiMaxAllocSizeLog2) + m_uiCurrentBucketOffset;
+    m_Allocations.PushBack({ptr, uiGlobalOffset, uiSize32});
+
+    m_uiCurrentBucketOffset += uiSize32;
+
+    return ptr;
+  }
+
+  EZ_FORCE_INLINE void Deallocate(void* pPtr)
+  {
+    EZ_LOCK(m_Mutex);
+
+    if (m_Allocations.IsEmpty())
+    {
+      m_pParent->Deallocate(pPtr);
+      return;
+    }
+
+    auto& lastAlloc = m_Allocations.PeekBack();
+    if (lastAlloc.m_Ptr == pPtr)
+    {
+      const ezUInt32 uiOffsetMask = ezMath::Bitmask_LowN<ezUInt32>(m_uiMaxAllocSizeLog2);
+
+      m_uiCurrentBucketIndex = lastAlloc.m_uiGlobalOffset >> m_uiMaxAllocSizeLog2;
+      m_uiCurrentBucketOffset = lastAlloc.m_uiGlobalOffset & uiOffsetMask;
+
+      if constexpr (OverwriteMemoryOnFree)
+      {
+        ezMemoryUtils::PatternFill(static_cast<ezUInt8*>(pPtr), 0xCD, lastAlloc.m_uiSize);
+      }
+
+      m_Allocations.PopBack();
+
+      while (m_Allocations.IsEmpty() == false)
+      {
+        auto& alloc = m_Allocations.PeekBack();
+        if (alloc.m_Ptr != nullptr)
+          return;
+
+        m_uiCurrentBucketIndex = alloc.m_uiGlobalOffset >> m_uiMaxAllocSizeLog2;
+        m_uiCurrentBucketOffset = alloc.m_uiGlobalOffset & uiOffsetMask;
+
+        m_Allocations.PopBack();
+      }
+
+      return;
+    }
+    else
+    {
+      for (ezUInt32 i = m_Allocations.GetCount() - 1; i > 0; --i)
+      {
+        auto& alloc = m_Allocations[i - 1];
+        if (alloc.m_Ptr == pPtr)
+        {
+          if constexpr (OverwriteMemoryOnFree)
+          {
+            ezMemoryUtils::PatternFill(static_cast<ezUInt8*>(pPtr), 0xCD, alloc.m_uiSize);
+          }
+
+          alloc.m_Ptr = nullptr;
+          return;
+        }
+      }
+    }
+
+    // Allocation not found, this means it was a large allocation that was directly allocated from the parent allocator.
+    m_pParent->Deallocate(pPtr);
+  }
+
+  EZ_ALWAYS_INLINE ezAllocator* GetParent() const { return m_pParent; }
+
+private:
+  ezUInt32 GetMaxAllocationSize() const { return EZ_BIT(m_uiMaxAllocSizeLog2); }
+
+  ezArrayPtr<ezUInt8> GetOrCreateBucket(ezUInt32 uiRequestedSize)
+  {
+    const ezUInt32 uiMaxAllocSize = GetMaxAllocationSize();
+    const bool bFitsIntoCurrentBucket = !m_Buckets.IsEmpty() && m_uiCurrentBucketOffset + uiRequestedSize <= uiMaxAllocSize;
+    if (!bFitsIntoCurrentBucket)
+    {
+      m_uiCurrentBucketIndex = m_Buckets.GetCount();
+
+      auto newBucket = ezMakeArrayPtr(static_cast<ezUInt8*>(m_pParent->Allocate(uiMaxAllocSize, Alignment)), uiMaxAllocSize);
+      m_Buckets.PushBack(newBucket);
+
+      m_uiCurrentBucketOffset = 0;
+    }
+
+    return m_Buckets[m_uiCurrentBucketIndex];
+  }
+
+  ezAllocator* m_pParent = nullptr;
+
+  ezMutex m_Mutex;
+
+  ezUInt16 m_uiMaxAllocSizeLog2 = 0;
+  ezUInt16 m_uiCurrentBucketIndex = 0;
+  ezUInt32 m_uiCurrentBucketOffset = 0;
+
+  ezSmallArray<ezArrayPtr<ezUInt8>, 4> m_Buckets;
+
+  struct AllocationInfo
+  {
+    EZ_DECLARE_POD_TYPE();
+
+    void* m_Ptr;
+    ezUInt32 m_uiGlobalOffset;
+    ezUInt32 m_uiSize;
+  };
+
+  ezSmallArray<AllocationInfo, 16> m_Allocations;
+};

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
@@ -35,8 +35,11 @@ public:
     }
   }
 
+  /// \brief Sets the maximum allocation size that can be handled by this stack allocator. Allocations larger than this size will be directly allocated from the parent allocator.
   EZ_FORCE_INLINE void SetMaxAllocationSize(ezUInt32 uiSize)
   {
+    EZ_ASSERT_DEV(m_Allocations.IsEmpty(), "Cannot change max allocation size while there are active allocations!");
+
     m_uiMaxAllocSizeLog2 = ezMath::Log2i(uiSize);
   }
 

--- a/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
+++ b/Code/Engine/Foundation/Memory/Policies/AllocPolicyStack.h
@@ -2,8 +2,8 @@
 
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Containers/SmallArray.h>
-#include <Foundation/Threading/Mutex.h>
 #include <Foundation/Threading/Lock.h>
+#include <Foundation/Threading/Mutex.h>
 
 /// \brief This policy implements a stack allocator. It is designed for scenarios where you have a lot of short-lived allocations that are freed in a LIFO order,
 /// but it also supports freeing in arbitrary order (at the cost of some fragmentation).

--- a/Code/Engine/Foundation/Memory/TempAllocator.h
+++ b/Code/Engine/Foundation/Memory/TempAllocator.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Foundation/Memory/Allocator.h>
+
+/// \brief Stack-based allocator for temporary allocations.
+///
+/// This allocator is designed for short-lived allocations that ideally follow a LIFO pattern but can also handle out-of-order deallocations.
+class EZ_FOUNDATION_DLL ezTempAllocator
+{
+public:
+  EZ_ALWAYS_INLINE static ezAllocator* Get() { return s_pAllocator; }
+
+private:
+  EZ_MAKE_SUBSYSTEM_STARTUP_FRIEND(Foundation, TempAllocator);
+
+  static void Startup();
+  static void Shutdown();
+
+  static ezAllocator* s_pAllocator;
+};
+
+/// \brief Wrapper for the allocator that is used for temporary allocations.
+struct ezTempAllocatorWrapper
+{
+  EZ_ALWAYS_INLINE static ezAllocator* GetAllocator() { return ezTempAllocator::Get(); }
+};

--- a/Code/Engine/Foundation/Tracks/Implementation/ColorGradient.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/ColorGradient.cpp
@@ -667,3 +667,7 @@ double ezColorGradient::SnapTimeTo(double fTimeInSeconds, ezUInt32 uiFramesPerSe
 {
   return TickToTime(SnapTimeToTick(fTimeInSeconds, uiFramesPerSecond));
 }
+
+
+EZ_STATICLINK_FILE(Foundation, Foundation_Tracks_Implementation_ColorGradient);
+

--- a/Code/Engine/Foundation/Tracks/Implementation/ColorGradient.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/ColorGradient.cpp
@@ -670,4 +670,3 @@ double ezColorGradient::SnapTimeTo(double fTimeInSeconds, ezUInt32 uiFramesPerSe
 
 
 EZ_STATICLINK_FILE(Foundation, Foundation_Tracks_Implementation_ColorGradient);
-

--- a/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
@@ -281,4 +281,3 @@ ezCurve1DAssetData_1_2 g_ezCurve1DAssetData_1_2;
 
 
 EZ_STATICLINK_FILE(Foundation, Foundation_Tracks_Implementation_CurveEditData);
-

--- a/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/CurveEditData.cpp
@@ -278,3 +278,7 @@ public:
 };
 
 ezCurve1DAssetData_1_2 g_ezCurve1DAssetData_1_2;
+
+
+EZ_STATICLINK_FILE(Foundation, Foundation_Tracks_Implementation_CurveEditData);
+

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimatedMeshComponent.cpp
@@ -105,18 +105,19 @@ void ezAnimatedMeshComponent::InitializeAnimationPose()
     const ozz::animation::Skeleton* pOzzSkeleton = &pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
     const ezUInt32 uiNumSkeletonJoints = pOzzSkeleton->num_joints();
 
-    ezArrayPtr<ozz::math::Float4x4> pPoseMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, uiNumSkeletonJoints);
-    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pPoseMatrices.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
+    ezTempArray<ozz::math::Float4x4> poseMatrices;
+    poseMatrices.SetCountUninitialized(uiNumSkeletonJoints);
+    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(poseMatrices.GetData(), alignof(ozz::math::Float4x4)), "Unaligned cast");
     {
       ozz::animation::LocalToModelJob job;
       job.input = pOzzSkeleton->joint_rest_poses();
-      job.output = ozz::span<ozz::math::Float4x4>(pPoseMatrices.GetPtr(), pPoseMatrices.GetEndPtr());
+      job.output = ozz::span<ozz::math::Float4x4>(poseMatrices.GetData(), poseMatrices.GetCount());
       job.skeleton = pOzzSkeleton;
       job.Run();
     }
 
     ezMsgAnimationPoseUpdated msg;
-    msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pPoseMatrices.GetPtr()), pPoseMatrices.GetCount());
+    msg.m_ModelTransforms = poseMatrices.GetArrayPtr().Cast<const ezMat4>();
     msg.m_pRootTransform = &pSkeleton->GetDescriptor().m_RootTransform;
     msg.m_pSkeleton = &pSkeleton->GetDescriptor().m_Skeleton;
 

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/LodAnimatedMeshComponent.cpp
@@ -474,19 +474,19 @@ void ezLodAnimatedMeshComponent::InitializeAnimationPose()
     const ozz::animation::Skeleton* pOzzSkeleton = &pSkeleton->GetDescriptor().m_Skeleton.GetOzzSkeleton();
     const ezUInt32 uiNumSkeletonJoints = pOzzSkeleton->num_joints();
 
-    ezArrayPtr<ozz::math::Float4x4> pPoseMatrices = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, uiNumSkeletonJoints);
-
-    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pPoseMatrices.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
+    ezTempArray<ozz::math::Float4x4> poseMatrices;
+    poseMatrices.SetCountUninitialized(uiNumSkeletonJoints);
+    EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(poseMatrices.GetData(), alignof(ozz::math::Float4x4)), "Unaligned cast");
     {
       ozz::animation::LocalToModelJob job;
       job.input = pOzzSkeleton->joint_rest_poses();
-      job.output = ozz::span<ozz::math::Float4x4>(pPoseMatrices.GetPtr(), pPoseMatrices.GetEndPtr());
+      job.output = ozz::span<ozz::math::Float4x4>(poseMatrices.GetData(), poseMatrices.GetCount());
       job.skeleton = pOzzSkeleton;
       job.Run();
     }
 
     ezMsgAnimationPoseUpdated msg;
-    msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pPoseMatrices.GetPtr()), pPoseMatrices.GetCount());
+    msg.m_ModelTransforms = poseMatrices.GetArrayPtr().Cast<const ezMat4>();
     msg.m_pRootTransform = &pSkeleton->GetDescriptor().m_RootTransform;
     msg.m_pSkeleton = &pSkeleton->GetDescriptor().m_Skeleton;
 

--- a/Code/Engine/RendererCore/AnimationSystem/Declarations.h
+++ b/Code/Engine/RendererCore/AnimationSystem/Declarations.h
@@ -17,6 +17,8 @@ using ezSkeletonResourceHandle = ezTypedResourceHandle<class ezSkeletonResource>
 
 #define ezInvalidJointIndex static_cast<ezUInt16>(0xFFFFu)
 
+EZ_DEFINE_AS_POD_TYPE(ozz::math::Float4x4);
+
 namespace ozz::animation
 {
   class Skeleton;

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonPoseComponent.cpp
@@ -223,13 +223,13 @@ void ezSkeletonPoseComponent::SendRestPose()
   if (skel.GetJointCount() == 0)
     return;
 
-  ezArrayPtr<ozz::math::Float4x4> pFinalTransforms = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, skel.GetJointCount());
-  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pFinalTransforms.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
-
+  ezTempArray<ozz::math::Float4x4> poseMatrices;
+  poseMatrices.SetCountUninitialized(skel.GetJointCount());
+  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(poseMatrices.GetData(), alignof(ozz::math::Float4x4)), "Unaligned cast");
   {
     ozz::animation::LocalToModelJob job;
     job.input = skel.GetOzzSkeleton().joint_rest_poses();
-    job.output = ozz::span<ozz::math::Float4x4>(pFinalTransforms.GetPtr(), pFinalTransforms.GetEndPtr());
+    job.output = ozz::span<ozz::math::Float4x4>(poseMatrices.GetData(), poseMatrices.GetCount());
     job.skeleton = &skel.GetOzzSkeleton();
     job.Run();
   }
@@ -237,7 +237,7 @@ void ezSkeletonPoseComponent::SendRestPose()
   ezMsgAnimationPoseUpdated msg;
   msg.m_pRootTransform = &desc.m_RootTransform;
   msg.m_pSkeleton = &skel;
-  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());
+  msg.m_ModelTransforms = poseMatrices.GetArrayPtr().Cast<const ezMat4>();
 
   GetOwner()->SendMessageRecursive(msg);
 
@@ -254,12 +254,13 @@ void ezSkeletonPoseComponent::SendCustomPose()
   const auto& desc = pSkeleton->GetDescriptor();
   const auto& skel = desc.m_Skeleton;
 
-  ezArrayPtr<ozz::math::Float4x4> pFinalTransforms = EZ_NEW_ARRAY(ezFrameAllocator::GetCurrentAllocator(), ozz::math::Float4x4, skel.GetJointCount());
-  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pFinalTransforms.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
+  ezTempArray<ozz::math::Float4x4> finalTransforms;
+  finalTransforms.SetCountUninitialized(skel.GetJointCount());
+  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(finalTransforms.GetData(), alignof(ozz::math::Float4x4)), "Unaligned cast");
 
-  for (ezUInt32 i = 0; i < pFinalTransforms.GetCount(); ++i)
+  for (ezUInt32 i = 0; i < finalTransforms.GetCount(); ++i)
   {
-    pFinalTransforms[i] = ozz::math::Float4x4::identity();
+    finalTransforms[i] = ozz::math::Float4x4::identity();
   }
 
   ozz::vector<ozz::math::SoaTransform> ozzLocalTransforms;
@@ -299,10 +300,9 @@ void ezSkeletonPoseComponent::SendCustomPose()
     reinterpret_cast<float*>(&q.w)[idx1] = boneRot.w;
   }
 
-  EZ_ASSERT_DEBUG(ezMemoryUtils::IsAligned(pFinalTransforms.GetPtr(), alignof(ozz::math::Float4x4)), "Unaligned cast");
   ozz::animation::LocalToModelJob job;
   job.input = ozz::span<const ozz::math::SoaTransform>(ozzLocalTransforms.data(), ozzLocalTransforms.size());
-  job.output = ozz::span<ozz::math::Float4x4>(pFinalTransforms.GetPtr(), pFinalTransforms.GetEndPtr());
+  job.output = ozz::span<ozz::math::Float4x4>(finalTransforms.GetData(), finalTransforms.GetCount());
   job.skeleton = &skel.GetOzzSkeleton();
   EZ_ASSERT_DEBUG(job.Validate(), "");
   job.Run();
@@ -311,7 +311,7 @@ void ezSkeletonPoseComponent::SendCustomPose()
   ezMsgAnimationPoseUpdated msg;
   msg.m_pRootTransform = &desc.m_RootTransform;
   msg.m_pSkeleton = &skel;
-  msg.m_ModelTransforms = ezMakeArrayPtr(reinterpret_cast<const ezMat4*>(pFinalTransforms.GetPtr()), pFinalTransforms.GetCount());
+  msg.m_ModelTransforms = finalTransforms.GetArrayPtr().Cast<const ezMat4>();
 
   GetOwner()->SendMessageRecursive(msg);
 

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -126,7 +126,7 @@ void ezRopeRenderComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
   {
     auto boneTransforms = m_SkinningState.GetBoneTransformsForReading();
 
-    ezHybridArray<ezDebugRendererLine, 128> lines(ezFrameAllocator::GetCurrentAllocator());
+    ezTempHybridArray<ezDebugRendererLine, 128> lines;
     lines.Reserve(boneTransforms.GetCount() * 3);
 
     ezMat4 offsetMat;

--- a/Code/Engine/RendererCore/Meshes/Implementation/SplineMeshComponent.cpp
+++ b/Code/Engine/RendererCore/Meshes/Implementation/SplineMeshComponent.cpp
@@ -349,7 +349,7 @@ ezResult ezSplineMeshComponent::GenerateSplineMeshDesc(const ezSpline& spline, c
   constexpr auto topology = ezGALPrimitiveTopology::Triangles;
   ezUInt32 uiNumVertices = 0;
   ezUInt32 uiNumPrimitives = 0;
-  ezHybridArray<SubMeshInfo, 32> subMeshInfos(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<SubMeshInfo, 32> subMeshInfos;
   for (ezUInt32 uiMeshIndex = 0; uiMeshIndex < uiNumMeshes; ++uiMeshIndex)
   {
     auto pMesh = meshes[uiMeshIndex];
@@ -380,7 +380,7 @@ ezResult ezSplineMeshComponent::GenerateSplineMeshDesc(const ezSpline& spline, c
 
   ezUInt32 uiFirstVertex = 0;
   ezUInt32 uiIndexByteOffset = 0;
-  ezHybridArray<ezUInt32, 16> firstVertexPerMesh(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<ezUInt32, 16> firstVertexPerMesh;
   firstVertexPerMesh.SetCount(uiNumMeshes);
 
   const bool bHasNTT = splineMeshBufferDesc.GetVertexStreamConfig().HasNormalTangentAndTexCoord0();
@@ -584,7 +584,7 @@ ezResult ezSplineMeshComponent::GenerateDistribution(const ezSplineComponent& sp
 
   // Gather part offset and length information
   ezVec2 paddedStartLengthAndOffset = ezVec2::MakeZero();
-  ezHybridArray<ezVec2, 16> middleLengthAndOffset(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<ezVec2, 16> middleLengthAndOffset;
   ezVec2 paddedEndLengthAndOffset = ezVec2::MakeZero();
   {
     if (m_StartPart.IsValid())
@@ -617,7 +617,7 @@ ezResult ezSplineMeshComponent::GenerateDistribution(const ezSplineComponent& sp
 
     // First determine the total scale and gather middle part indices
     float fScale = 1.0f;
-    ezHybridArray<ezUInt32, 16> middlePartsIndices(ezFrameAllocator::GetCurrentAllocator());
+    ezTempHybridArray<ezUInt32, 16> middlePartsIndices;
     {
       float fCurrentLength = 0.0f;
 
@@ -800,8 +800,8 @@ ezUInt32 ezSplineMeshComponent::FindBestMiddlePart(float fRequestedLength, ezArr
 
 ezResult ezSplineMeshComponent::GenerateSplineMesh(const ezSplineComponent& splineComponent, ezMeshResourceDescriptor& out_splineMeshDesc, ezMsgGenerateSplineMeshCollision* out_pMsg /*= nullptr*/) const
 {
-  ezHybridArray<ezMeshResourceHandle, 16> meshes(ezFrameAllocator::GetCurrentAllocator());
-  ezHybridArray<ezVec2, 16> scaleOffsets(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<ezMeshResourceHandle, 16> meshes;
+  ezTempHybridArray<ezVec2, 16> scaleOffsets;
   EZ_SUCCEED_OR_RETURN(GenerateDistribution(splineComponent, meshes, scaleOffsets));
 
   if (out_pMsg != nullptr)
@@ -813,7 +813,7 @@ ezResult ezSplineMeshComponent::GenerateSplineMesh(const ezSplineComponent& spli
     out_pMsg->m_fLocalOffsetZ = m_fOffsetZ;
   }
 
-  ezHybridArray<ezCpuMeshResource*, 16> cpuMeshes(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<ezCpuMeshResource*, 16> cpuMeshes;
 
   for (auto& hMesh : meshes)
   {

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Extractor.cpp
@@ -220,7 +220,7 @@ void ezExtractor::ExtractRenderData(const ezView& view, const ezGameObject* pObj
         // Only cache render data if all parts should be cached otherwise the cache is incomplete and we won't call SendMessage again
         if (msg.m_uiNumCacheIfStatic > 0 && msg.m_ExtractedRenderData.GetCount() == msg.m_uiNumCacheIfStatic)
         {
-          ezHybridArray<ezInternal::RenderDataCacheEntry, 16> newCacheEntries(ezFrameAllocator::GetCurrentAllocator());
+          ezTempHybridArray<ezInternal::RenderDataCacheEntry, 16> newCacheEntries;
 
           for (ezUInt32 uiPartIndex = 0; uiPartIndex < msg.m_ExtractedRenderData.GetCount(); ++uiPartIndex)
           {

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderManager.cpp
@@ -288,7 +288,7 @@ ezShaderPermutationResourceHandle ezShaderManager::PreloadSinglePermutation(ezSh
   if (!pShader->IsShaderValid())
     return ezShaderPermutationResourceHandle();
 
-  ezHybridArray<ezPermutationVar, 64> filteredPermutationVariables(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<ezPermutationVar, 64> filteredPermutationVariables;
   ezUInt32 uiPermutationHash = FilterPermutationVars(pShader->GetUsedPermutationVars(), permVars, filteredPermutationVariables);
 
   return PreloadSinglePermutationInternal(pShader->GetResourceID(), pShader->GetResourceIDHash(), uiPermutationHash, filteredPermutationVariables);

--- a/Code/Engine/Utilities/GridAlgorithms/Implementation/Rasterization.cpp
+++ b/Code/Engine/Utilities/GridAlgorithms/Implementation/Rasterization.cpp
@@ -486,7 +486,7 @@ struct PointPair
   ezVec2I32 ptOuter;
 };
 
-static void SortTraceLines(ezDynamicArray<ez2DGridUtils::TraceLinePoint>& out_Result, ezVec2I32 vStart, const ezDynamicArray<PointPair>& pairs)
+static void SortTraceLines(ezDynamicArray<ez2DGridUtils::TraceLinePoint>& out_result, ezVec2I32 vStart, const ezDynamicArray<PointPair>& pairs)
 {
   bool bFound = false;
   for (const auto& pt : pairs)
@@ -495,13 +495,13 @@ static void SortTraceLines(ezDynamicArray<ez2DGridUtils::TraceLinePoint>& out_Re
     {
       bFound = true;
 
-      const ezUInt32 uiStartIdx = out_Result.GetCount();
-      auto& newPt = out_Result.ExpandAndGetRef();
+      const ezUInt32 uiStartIdx = out_result.GetCount();
+      auto& newPt = out_result.ExpandAndGetRef();
       newPt.m_vCellCoordOffset = pt.ptOuter;
 
-      SortTraceLines(out_Result, pt.ptOuter, pairs);
+      SortTraceLines(out_result, pt.ptOuter, pairs);
 
-      newPt.m_uiSkipCount = static_cast<ezUInt16>(out_Result.GetCount() - uiStartIdx - 1);
+      newPt.m_uiSkipCount = static_cast<ezUInt16>(out_result.GetCount() - uiStartIdx - 1);
     }
     else if (bFound)
     {

--- a/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Effects/Implementation/MeshDecalComponent.cpp
@@ -150,7 +150,7 @@ void ezMeshDecalComponent::UpdateDecals()
 
   DeleteDecals();
 
-  ezArrayMap<ezUInt32, ezTexture2DResourceHandle> indexToTexture(ezFrameAllocator::GetCurrentAllocator());
+  ezArrayMap<ezUInt32, ezTexture2DResourceHandle, ezTempAllocatorWrapper> indexToTexture;
   indexToTexture.Reserve(m_DecalDescs.GetCount());
 
   for (auto& desc : m_DecalDescs)

--- a/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Physics/Implementation/FakeRopeComponent.cpp
@@ -333,7 +333,7 @@ void ezFakeRopeComponent::SendCurrentPose()
 {
   ezMsgRopePoseUpdated poseMsg;
 
-  ezDynamicArray<ezTransform> pieces(ezFrameAllocator::GetCurrentAllocator());
+  ezTempArray<ezTransform> pieces;
 
   if (m_RopeSim.m_Nodes.GetCount() >= 2)
   {

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltBreakableSlabComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltBreakableSlabComponent.cpp
@@ -1014,7 +1014,7 @@ void ezJoltBreakableSlabComponent::CreateShardColliders(ezUInt32 uiFirstShard, e
   const ezJoltMaterial* pMaterial = GetPhysicsMaterial();
 
   // GetOrCreateBoneTransformsForWriting will resize as necessary but will lose existing data so we need to make a copy here
-  ezDynamicArray<ezShaderTransform> oldTransforms(ezFrameAllocator::GetCurrentAllocator());
+  ezTempArray<ezShaderTransform> oldTransforms;
   oldTransforms = m_SkinningState.GetBoneTransformsForReading();
 
   auto transforms = m_SkinningState.GetOrCreateBoneTransformsForWriting(*this, m_Breakable.m_Shards.GetCount());

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltGenerateCollisionComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltGenerateCollisionComponent.cpp
@@ -31,7 +31,7 @@ public:
 
   virtual void Execute() override
   {
-    ezHybridArray<ezCpuMeshResource*, 16> cpuMeshes(ezFrameAllocator::GetCurrentAllocator());
+    ezTempHybridArray<ezCpuMeshResource*, 16> cpuMeshes;
 
     for (auto& hMeshCpu : m_Meshes)
     {

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRagdollComponent.cpp
@@ -1041,7 +1041,7 @@ void ezJoltRagdollComponent::ComputeLimbGlobalTransform(ezTransform& transform, 
 
 void ezJoltRagdollComponent::CreateAllLimbs(const ezSkeletonResource& skeletonResource, const ezMsgAnimationPoseUpdated& pose, ezJoltWorldModule& worldModule, float fObjectScale, JPH::RagdollSettings* pRagdollSettings)
 {
-  ezMap<ezUInt16, LimbConstructionInfo> limbConstructionInfos(ezFrameAllocator::GetCurrentAllocator());
+  ezMap<ezUInt16, LimbConstructionInfo> limbConstructionInfos(ezTempAllocator::Get());
   limbConstructionInfos.FindOrAdd(ezInvalidJointIndex); // dummy root link
 
   ezUInt16 uiLastLimbIdx = ezInvalidJointIndex;

--- a/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Components/Implementation/JoltRopeComponent.cpp
@@ -751,7 +751,7 @@ void ezJoltRopeComponent::Update()
   //  }
   //}
 
-  ezHybridArray<ezTransform, 32> poses(ezFrameAllocator::GetCurrentAllocator());
+  ezTempHybridArray<ezTransform, 32> poses;
   poses.SetCountUninitialized(static_cast<ezUInt32>(m_pRagdoll->GetBodyCount()) + 1);
 
   ezMsgRopePoseUpdated poseMsg;
@@ -814,7 +814,7 @@ void ezJoltRopeComponent::SendPreviewPose()
   if (hAnchor1 == hAnchor2)
     return;
 
-  ezDynamicArray<ezTransform> pieces(ezFrameAllocator::GetCurrentAllocator());
+  ezTempArray<ezTransform> pieces;
 
   ezMsgRopePoseUpdated poseMsg;
   float fPieceLength;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -258,7 +258,7 @@ void ezProcPlacementComponentManager::PreparePlace(const ezWorldModule::UpdateCo
   }
 
   // Debug draw tiles
-  ezHashSet<ezUInt32> debugDrawnTiles(ezFrameAllocator::GetCurrentAllocator());
+  ezHashSet<ezUInt32> debugDrawnTiles(ezTempAllocator::Get());
   if (cvar_ProcGenVisTiles)
   {
     ezStringBuilder sb;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcVertexColorComponent.cpp
@@ -21,7 +21,7 @@ namespace
 {
   static ezCpuMeshResourceHandle ExtractCpuMeshResource(const ezMeshComponentBase& meshComponent)
   {
-    ezWorldGeoExtractionUtil::MeshObjectList meshObjects(ezFrameAllocator::GetCurrentAllocator());
+    ezWorldGeoExtractionUtil::MeshObjectList meshObjects(ezTempAllocator::Get());
 
     ezMsgExtractGeometry msg;
     msg.m_pMeshObjects = &meshObjects;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/VolumeCollection.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/VolumeCollection.cpp
@@ -59,7 +59,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezVolumeCollection, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezVolumeCollection::ezVolumeCollection()
-  : m_Allocator("VolumeCollection", ezFoundation::GetAlignedAllocator())
+  : m_Allocator("VolumeCollection", ezFoundation::GetAlignedAllocator(), 4 * 1024)
+  , m_SortedShapes(&m_Allocator)
 {
 }
 

--- a/Code/EnginePlugins/RmlUiPlugin/Implementation/RenderInterface.cpp
+++ b/Code/EnginePlugins/RmlUiPlugin/Implementation/RenderInterface.cpp
@@ -173,7 +173,7 @@ namespace ezRmlUiInternal
 
     // vertices
     {
-      ezDynamicArray<Vertex> vertexStorage(ezFrameAllocator::GetCurrentAllocator());
+      ezTempArray<Vertex> vertexStorage;
       vertexStorage.SetCountUninitialized(uiNumVertices);
 
       for (ezUInt32 i = 0; i < vertexStorage.GetCount(); ++i)

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptFunctionProperty.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptFunctionProperty.cpp
@@ -19,7 +19,7 @@ void ezVisualScriptFunctionProperty::Execute(void* pInstance, ezArrayPtr<ezVaria
   EZ_ASSERT_DEBUG(pInstance != nullptr, "Invalid instance");
   auto pVisualScriptInstance = static_cast<ezVisualScriptInstance*>(pInstance);
 
-  ezVisualScriptExecutionContext context(m_pDesc, ezFrameAllocator::GetCurrentAllocator());
+  ezVisualScriptExecutionContext context(m_pDesc, ezTempAllocator::Get());
   context.Initialize(*pVisualScriptInstance, arguments);
 
   auto result = context.Execute(ezTime::MakeZero());
@@ -51,7 +51,7 @@ void ezVisualScriptMessageHandler::Dispatch(ezAbstractMessageHandler* pSelf, voi
   ezHybridArray<ezVariant, 8> arguments;
   pHandler->FillMessagePropertyValues(ref_msg, arguments);
 
-  ezVisualScriptExecutionContext context(pHandler->m_pDesc, ezFrameAllocator::GetCurrentAllocator());
+  ezVisualScriptExecutionContext context(pHandler->m_pDesc, ezTempAllocator::Get());
   context.Initialize(*pVisualScriptInstance, arguments);
 
   auto result = context.Execute(ezTime::MakeZero());

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptNodeFunctions.cpp
@@ -341,7 +341,7 @@ namespace
 
     const ezUInt32 uiStartSlot = 4;
 
-    ezUniquePtr<ezMessage> pMessage = userData.m_pType->GetAllocator()->Allocate<ezMessage>(ezFrameAllocator::GetCurrentAllocator());
+    ezUniquePtr<ezMessage> pMessage = userData.m_pType->GetAllocator()->Allocate<ezMessage>(ezTempAllocator::Get());
     for (ezUInt32 i = 0; i < userData.m_uiNumProperties; ++i)
     {
       auto pProp = userData.m_Properties[i];

--- a/Code/Tools/HeaderCheck/HeaderCheck.cpp
+++ b/Code/Tools/HeaderCheck/HeaderCheck.cpp
@@ -45,7 +45,7 @@ private:
   bool m_bHadErrors;
   bool m_bHadSeriousWarnings;
   bool m_bHadWarnings;
-  ezUniquePtr<ezLinearAllocator<ezAllocatorTrackingMode::Nothing>> m_pStackAllocator;
+  ezUniquePtr<ezLinearAllocator<ezAllocatorTrackingMode::Nothing>> m_pLinearAllocator;
   ezDynamicArray<ezString> m_IncludeDirectories;
 
   struct IgnoreInfo
@@ -177,7 +177,8 @@ public:
     ezGlobalLog::AddLogWriter(ezLogWriter::VisualStudio::LogMessageHandler);
     ezGlobalLog::AddLogWriter(LogInspector);
 
-    m_pStackAllocator = EZ_DEFAULT_NEW(ezLinearAllocator<ezAllocatorTrackingMode::Nothing>, "Temp Allocator", ezFoundation::GetAlignedAllocator());
+    constexpr ezUInt32 uiInitalAllocatorSize = 1024 * 1024; 
+    m_pLinearAllocator = EZ_DEFAULT_NEW(ezLinearAllocator<ezAllocatorTrackingMode::Nothing>, "Temp Allocator", ezFoundation::GetAlignedAllocator(), uiInitalAllocatorSize);
 
     if (GetArgumentCount() < 2)
       ezLog::Error("This tool requires at leas one command-line argument: An absolute path to the top-level folder of a library.");
@@ -278,7 +279,7 @@ public:
     else
       SetReturnCode(0);
 
-    m_pStackAllocator = nullptr;
+    m_pLinearAllocator = nullptr;
 
     ezGlobalLog::RemoveLogWriter(LogInspector);
     ezGlobalLog::RemoveLogWriter(ezLogWriter::Console::LogMessageHandler);
@@ -354,7 +355,7 @@ public:
 
           EZ_LOG_BLOCK("Header", &currentFile.GetData()[uiSearchDirLength]);
           CheckHeaderFile(currentFile);
-          m_pStackAllocator->Reset();
+          m_pLinearAllocator->Reset();
         }
       }
     }
@@ -364,7 +365,7 @@ public:
 
   void CheckInclude(const ezStringBuilder& sCurrentFile, const ezStringBuilder& sIncludePath, ezUInt32 uiLine)
   {
-    ezStringBuilder absIncludePath(m_pStackAllocator.Borrow());
+    ezStringBuilder absIncludePath(m_pLinearAllocator.Borrow());
     bool includeOutside = true;
     if (sIncludePath.IsAbsolutePath())
     {
@@ -421,16 +422,16 @@ public:
 
   void CheckHeaderFile(const ezStringBuilder& sCurrentFile)
   {
-    ezStringBuilder fileContents(m_pStackAllocator.Borrow());
+    ezStringBuilder fileContents(m_pLinearAllocator.Borrow());
     ReadEntireFile(sCurrentFile.GetData(), fileContents).IgnoreResult();
 
     auto fileDir = sCurrentFile.GetFileDirectory();
 
-    ezStringBuilder internalMacroToken(m_pStackAllocator.Borrow());
+    ezStringBuilder internalMacroToken(m_pLinearAllocator.Borrow());
     internalMacroToken.Append("EZ_", m_sProjectName, "_INTERNAL_HEADER");
     auto internalMacroTokenView = internalMacroToken.GetView();
 
-    ezTokenizer tokenizer(m_pStackAllocator.Borrow());
+    ezTokenizer tokenizer(m_pLinearAllocator.Borrow());
     auto dataView = fileContents.GetView();
     tokenizer.Tokenize(ezArrayPtr<const ezUInt8>(reinterpret_cast<const ezUInt8*>(dataView.GetStartPointer()), dataView.GetElementCount()), ezLog::GetThreadLocalLogSystem());
 
@@ -467,8 +468,8 @@ public:
           if (curToken.m_iType == ezTokenType::String1)
           {
             // #include "bla"
-            ezStringBuilder absIncludePath(m_pStackAllocator.Borrow());
-            ezStringBuilder relativePath(m_pStackAllocator.Borrow());
+            ezStringBuilder absIncludePath(m_pLinearAllocator.Borrow());
+            ezStringBuilder relativePath(m_pLinearAllocator.Borrow());
             relativePath = curToken.m_DataView;
             relativePath.Trim("\"");
             relativePath.MakeCleanPath();
@@ -512,7 +513,7 @@ public:
             }
             else if (!isInternalHeader)
             {
-              ezStringBuilder includePath(m_pStackAllocator.Borrow());
+              ezStringBuilder includePath(m_pLinearAllocator.Borrow());
               includePath = ezStringView(startToken.m_DataView.GetEndPointer(), curToken.m_DataView.GetStartPointer());
               includePath.MakeCleanPath();
               CheckInclude(sCurrentFile, includePath, startToken.m_uiLine);

--- a/Code/Tools/HeaderCheck/HeaderCheck.cpp
+++ b/Code/Tools/HeaderCheck/HeaderCheck.cpp
@@ -177,7 +177,7 @@ public:
     ezGlobalLog::AddLogWriter(ezLogWriter::VisualStudio::LogMessageHandler);
     ezGlobalLog::AddLogWriter(LogInspector);
 
-    constexpr ezUInt32 uiInitalAllocatorSize = 1024 * 1024; 
+    constexpr ezUInt32 uiInitalAllocatorSize = 1024 * 1024;
     m_pLinearAllocator = EZ_DEFAULT_NEW(ezLinearAllocator<ezAllocatorTrackingMode::Nothing>, "Temp Allocator", ezFoundation::GetAlignedAllocator(), uiInitalAllocatorSize);
 
     if (GetArgumentCount() < 2)

--- a/Code/UnitTests/FoundationTest/Memory/AllocatorTest.cpp
+++ b/Code/UnitTests/FoundationTest/Memory/AllocatorTest.cpp
@@ -3,6 +3,7 @@
 #include <Foundation/Memory/CommonAllocators.h>
 #include <Foundation/Memory/LargeBlockAllocator.h>
 #include <Foundation/Memory/LinearAllocator.h>
+#include <Foundation/Memory/Policies/AllocPolicyStack.h>
 
 struct alignas(EZ_ALIGNMENT_MINIMUM) NonAlignedVector
 {
@@ -167,9 +168,9 @@ EZ_CREATE_SIMPLE_TEST(Memory, Allocator)
     EZ_TEST_BOOL(stats.m_uiAllocationSize == 0);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "StackAllocator")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "LinearAllocator")
   {
-    ezLinearAllocator<> allocator("TestStackAllocator", ezFoundation::GetAlignedAllocator());
+    ezLinearAllocator<> allocator("TestLinearAllocator", ezFoundation::GetAlignedAllocator(), 4096);
 
     void* blocks[8];
     for (size_t i = 0; i < EZ_ARRAY_SIZE(blocks); i++)
@@ -212,9 +213,9 @@ EZ_CREATE_SIMPLE_TEST(Memory, Allocator)
     allocator.Deallocate(allocs[0]);
   }
 
-  EZ_TEST_BLOCK(ezTestBlock::Enabled, "StackAllocator with non-PODs")
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "LinearAllocator with non-PODs")
   {
-    ezLinearAllocator<> allocator("TestStackAllocator", ezFoundation::GetAlignedAllocator());
+    ezLinearAllocator<> allocator("TestLinearAllocator", ezFoundation::GetAlignedAllocator(), 4096);
 
     ezDynamicArray<ezConstructionCounter*> counters;
     counters.Reserve(100);
@@ -241,5 +242,108 @@ EZ_CREATE_SIMPLE_TEST(Memory, Allocator)
     allocator.Reset();
 
     EZ_TEST_BOOL(ezConstructionCounter::HasDestructed(50));
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "TempAllocator")
+  {
+    using TempAllocatorType = ezAllocatorWithPolicy<ezAllocPolicyStack<true>>;
+
+    // Basic LIFO allocate/deallocate
+    {
+      TempAllocatorType allocator("TestTempAllocator", ezFoundation::GetAlignedAllocator());
+
+      ezUInt32* pA = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 64);
+      ezUInt32* pB = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 128);
+      ezUInt32* pC = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 256);
+
+      EZ_TEST_BOOL(pA != nullptr);
+      EZ_TEST_BOOL(pB != nullptr);
+      EZ_TEST_BOOL(pC != nullptr);
+
+      // All within the same bucket, so addresses should be ascending
+      EZ_TEST_BOOL(pA < pB);
+      EZ_TEST_BOOL(pB < pC);
+
+      // make copy of pA to check if it gets reused after deallocation
+      ezUInt32* pExpectedAlloc = pA;
+
+      // Deallocate in LIFO order
+      EZ_DELETE_RAW_BUFFER(&allocator, pC);
+      EZ_DELETE_RAW_BUFFER(&allocator, pB);
+      EZ_DELETE_RAW_BUFFER(&allocator, pA);
+
+      ezUInt32* pD = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 64);
+      EZ_TEST_BOOL(pD != nullptr);
+      EZ_TEST_BOOL(pD == pExpectedAlloc); // should reuse the same memory
+
+      EZ_DELETE_RAW_BUFFER(&allocator, pD);
+    }
+
+    // Out-of-order deallocation
+    {
+      TempAllocatorType allocator("TestTempAllocator", ezFoundation::GetAlignedAllocator());
+
+      ezUInt32* ptrs[5];
+      for (int i = 0; i < 5; ++i)
+      {
+        ptrs[i] = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 32);
+        EZ_TEST_BOOL(ptrs[i] != nullptr);
+      }
+
+      ezUInt32* pExpectedAlloc = ptrs[1]; // should be reused after free
+
+      // Free indices 1, 2, 3 out of order (all become nullptr entries)
+      EZ_DELETE_RAW_BUFFER(&allocator, ptrs[1]);
+      EZ_DELETE_RAW_BUFFER(&allocator, ptrs[2]);
+      EZ_DELETE_RAW_BUFFER(&allocator, ptrs[3]);
+
+      // Free index 4 (last) - should cascade and also pop the nullptr entries for 3, 2, 1
+      EZ_DELETE_RAW_BUFFER(&allocator, ptrs[4]);
+
+      ezUInt32* pD = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 64);
+      EZ_TEST_BOOL(pD != nullptr);
+      EZ_TEST_BOOL(pD == pExpectedAlloc); // should reuse the same memory
+
+      EZ_DELETE_RAW_BUFFER(&allocator, ptrs[0]);
+      EZ_DELETE_RAW_BUFFER(&allocator, pD);
+    }
+
+    // Multiple buckets (allocations that span across bucket boundaries)
+    {
+      TempAllocatorType allocator("TestTempAllocator", ezFoundation::GetAlignedAllocator());
+
+      // Fill first bucket (1024*1024 bytes max)
+      ezUInt32* pA = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 128 * 1024);
+      ezUInt32* pB = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 128 * 1024);
+      EZ_TEST_BOOL(pA != nullptr);
+      EZ_TEST_BOOL(pB != nullptr);
+
+      // This should trigger a new bucket
+      ezUInt32* pC = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 64);
+      EZ_TEST_BOOL(pC != nullptr);
+
+      // Deallocate in LIFO order - should roll back across bucket boundary
+      EZ_DELETE_RAW_BUFFER(&allocator, pC);
+      EZ_DELETE_RAW_BUFFER(&allocator, pB);
+      EZ_DELETE_RAW_BUFFER(&allocator, pA);
+    }
+
+    // Large allocations that exceed max allocation size (parent allocator fallback)
+    {
+      TempAllocatorType allocator("TestTempAllocator", ezFoundation::GetAlignedAllocator());
+
+      // This allocation exceeds the max allocation size, so it goes to the parent allocator
+      ezUInt32* pLarge = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 1024 * 1024);
+      EZ_TEST_BOOL(pLarge != nullptr);
+
+      // Mix a normal allocation in between
+      ezUInt32* pSmall = EZ_NEW_RAW_BUFFER(&allocator, ezUInt32, 64);
+      EZ_TEST_BOOL(pSmall != nullptr);
+
+      // Deallocating the large one should go to parent (not found in m_Allocations search, falls through)
+      EZ_DELETE_RAW_BUFFER(&allocator, pLarge);
+
+      EZ_DELETE_RAW_BUFFER(&allocator, pSmall);
+    }
   }
 }


### PR DESCRIPTION
* Added a new stack allocation policy that follows a real stack pattern (out of order deallocation is supported as well). In contrast to the linear allocation policy it can re-use the memory right after it has been deallocated which is ideal for short lived, temporary allocations.
* Added ezTempAllocator which makes use of that new stack allocation policy.
* Added an ezTempArray and an ezTempHybridArray class that use the ezTempAllocator for convience:
    * ezTempArray<T> = ezDynamicArray<T>(ezTempAllocator::Get())
    * ezTempHybridArray<T, Size> = ezHybridArray<T, Size>(ezTempAllocator::Get())
    * Note that the temp array classes are not typed by the allocator but constructed with the temp allocator. This makes them compatible with the default array types. E.g. if a function takes an ezDynamicArray<int> as input you can pass an ezTempArray<int> or an ezTempHybridArray.
* Made use of the temp allocator in other places as well.
