### PR TITLE
Spline editing improvements

### DIFF
--- a/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
+++ b/Code/Editor/EditorFramework/DocumentWindow/EngineViewWidget.moc.h
@@ -90,6 +90,9 @@ public:
   /// \brief Starts a picking operation for the given pixel position in this view. Returns the most recent picking information in the meantime.
   const ezObjectPickingResult& PickObject(ezUInt16 uiScreenPosX, ezUInt16 uiScreenPosY) const;
 
+  /// \brief Clears the last stored picking position. Only needed when it is vital that no stale picking data can be used next time.
+  void ClearLastPickedObject();
+
   /// \brief Similar to PickObject, but computes the intersection with the given plane instead.
   ezResult PickPlane(ezUInt16 uiScreenPosX, ezUInt16 uiScreenPosY, const ezPlane& plane, ezVec3& out_vPosition) const;
 

--- a/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
+++ b/Code/Editor/EditorFramework/DocumentWindow/Implementation/EngineViewWidget.cpp
@@ -273,6 +273,10 @@ const ezObjectPickingResult& ezQtEngineViewWidget::PickObject(ezUInt16 uiScreenP
   return m_LastPickingResult;
 }
 
+void ezQtEngineViewWidget::ClearLastPickedObject()
+{
+  m_LastPickingResult.Reset();
+}
 
 ezResult ezQtEngineViewWidget::PickPlane(ezUInt16 uiScreenPosX, ezUInt16 uiScreenPosY, const ezPlane& plane, ezVec3& out_vPosition) const
 {

--- a/Code/Editor/EditorFramework/Gizmos/GizmoBase.h
+++ b/Code/Editor/EditorFramework/Gizmos/GizmoBase.h
@@ -52,12 +52,12 @@ protected:
   ezResult GetPointOnPlane(const ezPlane& plane, const ezVec2I32& vScreenPos, const ezMat4& mInvViewProj, ezVec3& out_Result) const;
   ezResult GetPointOnAxis(const ezVec3& vStartPos, const ezVec3& vAxis, const ezVec2I32& vScreenPos, const ezMat4& mInvViewProj, ezVec3& out_Result, float* out_pProjectedLength = nullptr) const;
 
-  const ezCamera* m_pCamera;
-  ezGizmoHandle* m_pInteractionGizmoHandle;
+  const ezCamera* m_pCamera = nullptr;
+  ezGizmoHandle* m_pInteractionGizmoHandle = nullptr;
   ezVec3 m_vInteractionPivot;
   ezVec2I32 m_vViewport;
 
 private:
-  bool m_bVisible;
+  bool m_bVisible = false;
   ezTransform m_Transformation;
 };

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/ClickGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/ClickGizmo.cpp
@@ -1,11 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
-#include <Core/Graphics/Camera.h>
-#include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorFramework/DocumentWindow/EngineDocumentWindow.moc.h>
 #include <EditorFramework/Gizmos/ClickGizmo.h>
-#include <EditorFramework/Preferences/EditorPreferences.h>
-#include <Foundation/Utilities/GraphicsUtils.h>
 
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezClickGizmo, 1, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
@@ -80,5 +76,6 @@ ezEditorInput ezClickGizmo::DoMouseReleaseEvent(QMouseEvent* e)
   FocusLost(false);
 
   SetActiveInputContext(nullptr);
+
   return ezEditorInput::WasExclusivelyHandled;
 }

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/ClickGizmo.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/ClickGizmo.cpp
@@ -1,5 +1,6 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
+#include <EditorFramework/Assets/AssetDocument.h>
 #include <EditorFramework/DocumentWindow/EngineDocumentWindow.moc.h>
 #include <EditorFramework/Gizmos/ClickGizmo.h>
 

--- a/Code/Editor/EditorFramework/Gizmos/Implementation/GizmoBase.cpp
+++ b/Code/Editor/EditorFramework/Gizmos/Implementation/GizmoBase.cpp
@@ -9,7 +9,6 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 ezGizmo::ezGizmo()
 {
-  m_bVisible = false;
   m_Transformation.SetIdentity();
   m_Transformation.m_vScale.SetZero();
 }

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/ManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/ManipulatorAdapter.cpp
@@ -2,15 +2,10 @@
 
 #include <EditorFramework/Manipulators/ManipulatorAdapter.h>
 #include <GuiFoundation/DocumentWindow/DocumentWindow.moc.h>
-#include <ToolsFoundation/Command/TreeCommands.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 
 ezManipulatorAdapter::ezManipulatorAdapter()
 {
-  m_pManipulatorAttr = nullptr;
-  m_pObject = nullptr;
-  m_bManipulatorIsVisible = true;
-
   ezQtDocumentWindow::s_Events.AddEventHandler(ezMakeDelegate(&ezManipulatorAdapter::DocumentWindowEventHandler, this));
 }
 

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
@@ -3,6 +3,7 @@
 #include <EditorFramework/DocumentWindow/EngineDocumentWindow.moc.h>
 #include <EditorFramework/Manipulators/SplineManipulatorAdapter.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
+#include <ToolsFoundation/Utilities/StringAlgorithms.h>
 
 ezSplineManipulatorAdapter::ezSplineManipulatorAdapter() = default;
 ezSplineManipulatorAdapter::~ezSplineManipulatorAdapter() = default;
@@ -125,7 +126,10 @@ void ezSplineManipulatorAdapter::Update()
 
 void ezSplineManipulatorAdapter::ClickGizmoEventHandler(const ezGizmoEvent& e)
 {
-  int index = -1;
+  if (e.m_Type != ezGizmoEvent::Type::Interaction)
+    return;
+
+  ezInt32 index = -1;
 
   for (ezUInt32 i = 0; i < m_Gizmos.GetCount(); ++i)
   {
@@ -147,10 +151,9 @@ void ezSplineManipulatorAdapter::ClickGizmoEventHandler(const ezGizmoEvent& e)
   }
 
   ezStringBuilder sNewNodeName;
-  sNewNodeName.SetFormat("{}", index);
-  sNewNodeName = MakeUniqueName(sNewNodeName);
+  MakeUniqueName(index, sNewNodeName);
 
-  index = ezMath::Min<int>(index, m_Spline.m_ControlPoints.GetCount());
+  index = ezMath::Min<ezInt32>(index, m_Spline.m_ControlPoints.GetCount());
 
   auto pObjectAcessor = GetObjectAccessor();
 
@@ -298,35 +301,43 @@ void ezSplineManipulatorAdapter::ConfigureGizmos()
   UpdateGizmoTransform();
 }
 
-ezString ezSplineManipulatorAdapter::MakeUniqueName(ezStringView sSuggestedName)
+void ezSplineManipulatorAdapter::MakeUniqueName(ezInt32 iIndex, ezStringBuilder& ref_sName)
 {
-  auto IsUniqueName = [&](ezStringView sName)
+  const ezSplineManipulatorAttribute* pAttr = static_cast<const ezSplineManipulatorAttribute*>(m_pManipulatorAttr);
+  ezVariantArray nodeNames;
+  m_pObject->GetTypeAccessor().GetValues(pAttr->GetNodesProperty(), nodeNames);
+
+  if (nodeNames.IsEmpty())
   {
-    const ezSplineManipulatorAttribute* pAttr = static_cast<const ezSplineManipulatorAttribute*>(m_pManipulatorAttr);
+    ref_sName = "1";
+    return;
+  }
 
-    ezVariantArray nodeNames;
-    m_pObject->GetTypeAccessor().GetValues(pAttr->GetNodesProperty(), nodeNames);
-
-    for (auto& v : nodeNames)
+  auto IsUniqueName = [&](ezStringView sName) -> bool
+  {
+    for (const auto& v : nodeNames)
     {
       if (v.Get<ezHashedString>() == sName)
         return false;
     }
-
     return true;
   };
 
-  if (IsUniqueName(sSuggestedName))
-    return sSuggestedName;
+  const ezStringView sLeft = (iIndex > 0) ? nodeNames[iIndex - 1].Get<ezHashedString>().GetView() : ezStringView();
+  const ezStringView sRight = (iIndex < (ezInt32)nodeNames.GetCount()) ? nodeNames[iIndex].Get<ezHashedString>().GetView() : ezStringView();
 
-  ezUInt32 uiSuffixIndex = 0;
-  ezStringBuilder sCombinedName;
+  ezStringAlgorithms::ComputeNameBetween(sLeft, sRight, ref_sName);
 
+  if (IsUniqueName(ref_sName))
+    return;
+
+  // Fallback: append an incrementing sub-index until the name is unique
+  ezStringBuilder sBase = ref_sName;
+  ezUInt32 uiSuffix = 1;
   do
   {
-    ++uiSuffixIndex;
-    sCombinedName.SetFormat("{}.{}", sSuggestedName, uiSuffixIndex);
-  } while (!IsUniqueName(sCombinedName));
-
-  return sCombinedName;
+    ref_sName = sBase;
+    ref_sName.AppendFormat(".{}", uiSuffix);
+    ++uiSuffix;
+  } while (!IsUniqueName(ref_sName));
 }

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
@@ -231,8 +231,7 @@ void ezSplineManipulatorAdapter::ClickGizmoEventHandler(const ezGizmoEvent& e)
         {
           pSelMan->SetSelection(pObj);
         }
-      }
-    });
+      } });
 }
 
 /// Returns the position on the given spline segment at 50% arc-length.

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/DocumentWindow/EngineDocumentWindow.moc.h>
+#include <EditorFramework/DocumentWindow/EngineViewWidget.moc.h>
 #include <EditorFramework/Manipulators/SplineManipulatorAdapter.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
 #include <ToolsFoundation/Utilities/StringAlgorithms.h>
@@ -128,6 +129,8 @@ void ezSplineManipulatorAdapter::ClickGizmoEventHandler(const ezGizmoEvent& e)
 {
   if (e.m_Type != ezGizmoEvent::Type::Interaction)
     return;
+
+  e.m_pGizmo->GetOwnerView()->ClearLastPickedObject();
 
   ezInt32 index = -1;
 

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
@@ -218,6 +218,21 @@ void ezSplineManipulatorAdapter::ClickGizmoEventHandler(const ezGizmoEvent& e)
   pObjectAcessor->FinishTransaction();
 
   Update();
+
+  // Defer the selection change to avoid destroying this adapter (and its gizmos) while
+  // their event dispatch is still on the call stack. SetSelection triggers ClearAdapters
+  // via the manipulator manager, which deletes 'this'. The document outlives the adapter.
+  const ezDocument* pDoc = m_pObject->GetDocumentObjectManager()->GetDocument();
+  QTimer::singleShot(0, [pDoc, gameObjectUuid]()
+    {
+      if (auto pSelMan = pDoc->GetSelectionManager())
+      {
+        if (const ezDocumentObject* pObj = pDoc->GetObjectManager()->GetObject(gameObjectUuid))
+        {
+          pSelMan->SetSelection(pObj);
+        }
+      }
+    });
 }
 
 /// Returns the position on the given spline segment at 50% arc-length.

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
@@ -217,6 +217,44 @@ void ezSplineManipulatorAdapter::ClickGizmoEventHandler(const ezGizmoEvent& e)
   Update();
 }
 
+/// Returns the position on the given spline segment at 50% arc-length.
+/// Uses uniform sampling with a local parameter t in [0, 1] to avoid the
+/// Bezier overshoot that occurs with EvaluatePosition(segmentIndex + 0.5f)
+/// when adjacent segments have very different lengths.
+static ezVec3 EvaluateSegmentArcLengthMidpoint(const ezSpline& spline, ezUInt32 uiSegment)
+{
+  constexpr ezUInt32 uiNumSamples = 16;
+
+  float fCumulative[uiNumSamples + 1];
+  fCumulative[0] = 0.0f;
+
+  ezSimdVec4f vPrev = spline.EvaluatePosition(uiSegment, 0.0f);
+  for (ezUInt32 k = 1; k <= uiNumSamples; ++k)
+  {
+    const float fLocalT = static_cast<float>(k) / uiNumSamples;
+    const ezSimdVec4f vCur = spline.EvaluatePosition(uiSegment, fLocalT);
+    fCumulative[k] = fCumulative[k - 1] + (vCur - vPrev).GetLength<3>();
+    vPrev = vCur;
+  }
+
+  const float fHalfLength = fCumulative[uiNumSamples] * 0.5f;
+
+  if (fHalfLength < ezMath::SmallEpsilon<float>())
+    return ezSimdConversion::ToVec3(spline.EvaluatePosition(uiSegment, 0.5f));
+
+  for (ezUInt32 k = 1; k <= uiNumSamples; ++k)
+  {
+    if (fCumulative[k] >= fHalfLength)
+    {
+      const float fFrac = ezMath::Unlerp(fCumulative[k - 1], fCumulative[k], fHalfLength);
+      const float fLocalT = (static_cast<float>(k - 1) + fFrac) / uiNumSamples;
+      return ezSimdConversion::ToVec3(spline.EvaluatePosition(uiSegment, fLocalT));
+    }
+  }
+
+  return ezSimdConversion::ToVec3(spline.EvaluatePosition(uiSegment, 0.5f));
+}
+
 void ezSplineManipulatorAdapter::UpdateGizmoTransform()
 {
   const ezTransform ownerTransform = GetObjectTransform();
@@ -227,12 +265,14 @@ void ezSplineManipulatorAdapter::UpdateGizmoTransform()
     return t;
   };
 
+  const ezUInt32 uiNumCPs = m_Spline.m_ControlPoints.GetCount();
+
   ezUInt32 uiFirstGizmo = 0;
   ezUInt32 uiNumGizmos = m_Gizmos.GetCount();
 
   if (!m_Spline.m_bClosed)
   {
-    if (m_Spline.m_ControlPoints.IsEmpty())
+    if (uiNumCPs == 0)
     {
       m_Gizmos.PeekFront().SetTransformation(MakeGizmoTransform(ezVec3(-0.5, 0, 0)));
       m_Gizmos.PeekBack().SetTransformation(MakeGizmoTransform(ezVec3(0.5, 0, 0)));
@@ -259,7 +299,7 @@ void ezSplineManipulatorAdapter::UpdateGizmoTransform()
   {
     auto& gizmo = m_Gizmos[uiFirstGizmo + i];
 
-    const ezVec3 offset = ezSimdConversion::ToVec3(m_Spline.EvaluatePosition(i + 0.5f));
+    const ezVec3 offset = EvaluateSegmentArcLengthMidpoint(m_Spline, i);
     gizmo.SetTransformation(MakeGizmoTransform(offset));
   }
 }

--- a/Code/Editor/EditorFramework/Manipulators/ManipulatorAdapter.h
+++ b/Code/Editor/EditorFramework/Manipulators/ManipulatorAdapter.h
@@ -12,12 +12,25 @@ struct ezQtDocumentWindowEvent;
 class ezObjectAccessorBase;
 class ezGridSettingsMsgToEngine;
 
+/// Abstract base class for in-viewport gizmo adapters driven by an ezManipulatorAttribute.
+///
+/// An adapter bridges one document object and one ezManipulatorAttribute to a set of gizmos
+/// rendered in the viewport. It is instantiated by ezManipulatorAdapterRegistry and initialized
+/// via SetManipulator(). Subclasses implement Finalize(), Update(), and UpdateGizmoTransform()
+/// to set up and maintain their gizmos. UpdateGizmoTransform() is called every frame before
+/// the viewport is redrawn, while Update() is called on property changes and after transactions.
+///
+/// Adapters are deleted synchronously by ezManipulatorAdapterRegistry::ClearAdapters when the
+/// active manipulator changes (e.g. due to a selection change). Any code path inside an adapter
+/// that changes the selection must therefore defer the change to avoid deleting itself while
+/// still on the call stack.
 class EZ_EDITORFRAMEWORK_DLL ezManipulatorAdapter
 {
 public:
   ezManipulatorAdapter();
   virtual ~ezManipulatorAdapter();
 
+  /// Connects this adapter to the given attribute and document object, then calls Finalize() and Update().
   void SetManipulator(const ezManipulatorAttribute* pAttribute, const ezDocumentObject* pObject);
 
   virtual void QueryGridSettings(ezGridSettingsMsgToEngine& out_gridSettings) {}
@@ -33,20 +46,28 @@ protected:
   ezObjectAccessorBase* GetObjectAccessor() const;
   const ezAbstractProperty* GetProperty(const char* szProperty) const;
 
+  /// Called once after SetManipulator(). Use this for one-time gizmo setup that depends on m_pObject being valid.
   virtual void Finalize() = 0;
+
+  /// Called when a relevant property on m_pObject changes, after a transaction finishes, or on visibility changes.
   virtual void Update() = 0;
+
+  /// Called every frame before the viewport redraws. Update gizmo world-space transforms here.
   virtual void UpdateGizmoTransform() = 0;
 
+  /// Starts a temporary command sequence for live drag interaction. Must be paired with EndTemporaryInteraction() or CancelTemporayInteraction().
   void BeginTemporaryInteraction();
   void EndTemporaryInteraction();
   void CancelTemporayInteraction();
+
+  /// Convenience wrapper that starts a transaction, sets up to six properties on m_pObject, and finishes the transaction.
   void ChangeProperties(const char* szProperty1, ezVariant value1, const char* szProperty2 = nullptr, ezVariant value2 = ezVariant(),
     const char* szProperty3 = nullptr, ezVariant value3 = ezVariant(), const char* szProperty4 = nullptr, ezVariant value4 = ezVariant(),
     const char* szProperty5 = nullptr, ezVariant value5 = ezVariant(), const char* szProperty6 = nullptr, ezVariant value6 = ezVariant());
 
-  bool m_bManipulatorIsVisible;
-  const ezManipulatorAttribute* m_pManipulatorAttr;
-  const ezDocumentObject* m_pObject;
+  bool m_bManipulatorIsVisible = false;
+  const ezManipulatorAttribute* m_pManipulatorAttr = nullptr;
+  const ezDocumentObject* m_pObject = nullptr; ///< The document object this adapter operates on. Valid for the lifetime of the adapter.
 
   void ClampProperty(const char* szProperty, ezVariant& value) const;
 };

--- a/Code/Editor/EditorFramework/Manipulators/ManipulatorAdapterRegistry.h
+++ b/Code/Editor/EditorFramework/Manipulators/ManipulatorAdapterRegistry.h
@@ -8,6 +8,17 @@
 struct ezManipulatorManagerEvent;
 class ezDocument;
 
+/// Singleton that owns and manages ezManipulatorAdapter instances for all open documents.
+///
+/// Listens to ezManipulatorManager::m_Events. When the active manipulator changes, it tears
+/// down all existing adapters for that document and creates new ones via m_Factory, one per
+/// object in the selection. m_Factory maps the RTTI of an ezManipulatorAttribute subclass to
+/// the corresponding ezManipulatorAdapter subclass. Adapters must be registered there by the
+/// code that introduces them.
+///
+/// Adapters are heap-allocated and owned by this registry. They are deleted synchronously
+/// in ClearAdapters, which means an adapter must not call into code that reaches ClearAdapters
+/// on the same call stack (e.g. changing the document selection from within a gizmo event).
 class EZ_EDITORFRAMEWORK_DLL ezManipulatorAdapterRegistry
 {
   EZ_DECLARE_SINGLETON(ezManipulatorAdapterRegistry);
@@ -16,8 +27,11 @@ public:
   ezManipulatorAdapterRegistry();
   ~ezManipulatorAdapterRegistry();
 
+  /// Maps ezManipulatorAttribute RTTI types to their corresponding ezManipulatorAdapter factory functions.
+  /// Register new adapter types here to make them available to the system.
   ezRttiMappedObjectFactory<ezManipulatorAdapter> m_Factory;
 
+  /// Collects grid settings from all active adapters for the given document.
   void QueryGridSettings(const ezDocument* pDocument, ezGridSettingsMsgToEngine& out_gridSettings);
 
 private:

--- a/Code/Editor/EditorFramework/Manipulators/SplineManipulatorAdapter.h
+++ b/Code/Editor/EditorFramework/Manipulators/SplineManipulatorAdapter.h
@@ -31,7 +31,7 @@ protected:
 
   void BuildSpline();
   void ConfigureGizmos();
-  ezString MakeUniqueName(ezStringView sSuggestedName);
+  void MakeUniqueName(ezInt32 iIndex, ezStringBuilder& ref_sName);
 
   ezSpline m_Spline;
 

--- a/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
+++ b/Code/EditorPlugins/Scene/EditorPluginScene/Scene/Scene2Document.cpp
@@ -288,36 +288,56 @@ void ezScene2Document::PreventDoubleSelectionChange(bool b)
 
 void ezScene2Document::UndoSelection()
 {
-  if (m_SelectionStack.IsEmpty())
-    return;
+  bool bAllowRetry = true;
 
-  if (m_SelectionStack.GetCount() > 1)
-    m_SelectionStack.PopBack();
-
-  auto& back = m_SelectionStack.PeekBack();
-
-  m_bStoreSelectionChange = false;
-  EZ_SCOPE_EXIT(m_bStoreSelectionChange = true);
-
-  if (SetActiveLayer(back.m_documentGuid).Failed())
-    return;
-
-  auto* pDoc = ezDocumentManager::GetDocumentByGuid(back.m_documentGuid);
-  if (pDoc == nullptr)
-    return;
-
-  auto pObjMan = pDoc->GetObjectManager();
-
-  ezDeque<const ezDocumentObject*> newSel;
-  for (const ezUuid& guid : back.m_Objects)
+  // if a previous selection can't be restored, try the next one
+  while (bAllowRetry)
   {
-    if (auto pDoc = pObjMan->GetObject(guid))
+    if (m_SelectionStack.IsEmpty())
+      return;
+
+    if (m_SelectionStack.GetCount() > 1)
+      m_SelectionStack.PopBack();
+    else
+      bAllowRetry = false;
+
+    auto& back = m_SelectionStack.PeekBack();
+
+    m_bStoreSelectionChange = false;
+    EZ_SCOPE_EXIT(m_bStoreSelectionChange = true);
+
+    if (SetActiveLayer(back.m_documentGuid).Failed())
+      continue;
+
+    auto* pDoc = ezDocumentManager::GetDocumentByGuid(back.m_documentGuid);
+    if (pDoc == nullptr)
+      continue;
+
+    auto pObjMan = pDoc->GetObjectManager();
+
+    if (back.m_Objects.IsEmpty())
     {
-      newSel.PushBack(pDoc);
+      GetSelectionManager()->Clear();
+      return;
+    }
+    else
+    {
+      ezDeque<const ezDocumentObject*> newSel;
+      for (const ezUuid& guid : back.m_Objects)
+      {
+        if (auto pDoc = pObjMan->GetObject(guid))
+        {
+          newSel.PushBack(pDoc);
+        }
+      }
+
+      if (newSel.IsEmpty())
+        continue;
+
+      GetSelectionManager()->SetSelection(newSel);
+      return;
     }
   }
-
-  GetSelectionManager()->SetSelection(newSel);
 }
 
 void ezScene2Document::LayerSelectionEventHandler(const ezSelectionManagerEvent& e)

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -579,6 +579,16 @@ private:
 
 //////////////////////////////////////////////////////////////////////////
 
+/// Base class for property attributes that activate an in-viewport manipulator gizmo.
+///
+/// Attach a subclass of this attribute to a reflected property or type to signal that an
+/// interactive gizmo should appear in the viewport when the object is selected. The attribute
+/// names up to six properties that the manipulator reads and writes. Which properties are used
+/// depends on the concrete subclass.
+///
+/// The editor discovers this attribute through the reflection system. The ManipulatorManager
+/// tracks which manipulator is active per document and drives the ManipulatorAdapterRegistry,
+/// which instantiates the corresponding ezManipulatorAdapter to handle the actual gizmo logic.
 class EZ_FOUNDATION_DLL ezManipulatorAttribute : public ezPropertyAttribute
 {
   EZ_ADD_DYNAMIC_REFLECTION(ezManipulatorAttribute, ezPropertyAttribute);

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/ManipulatorManager.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/ManipulatorManager.h
@@ -10,14 +10,31 @@ class ezManipulatorAttribute;
 struct ezPhantomRttiManagerEvent;
 struct ezSelectionManagerEvent;
 
+/// Broadcast by ezManipulatorManager whenever the active manipulator or its selection changes.
+///
+/// If m_pManipulator is nullptr or m_bHideManipulators is true, any active gizmos should be
+/// torn down. Listeners are responsible for updating or recreating their gizmos accordingly.
 struct EZ_GUIFOUNDATION_DLL ezManipulatorManagerEvent
 {
-  const ezDocument* m_pDocument;
-  const ezManipulatorAttribute* m_pManipulator;
-  const ezHybridArray<ezPropertySelection, 8>* m_pSelection;
-  bool m_bHideManipulators;
+  const ezDocument* m_pDocument = nullptr;
+  const ezManipulatorAttribute* m_pManipulator = nullptr;
+  const ezHybridArray<ezPropertySelection, 8>* m_pSelection = nullptr;
+  bool m_bHideManipulators = false;
 };
 
+/// Singleton that tracks which manipulator is active per document.
+///
+/// A manipulator becomes active when the property grid detects a focused property that carries
+/// an ezManipulatorAttribute. The manager stores one active attribute and a corresponding
+/// object selection per document and broadcasts m_Events whenever the state changes.
+///
+/// On selection changes the manager automatically re-evaluates which objects in the current
+/// selection carry the same attribute and updates the stored selection accordingly. The
+/// document type controls whether the manager looks at selected objects directly or at their
+/// children via GetManipulatorSearchStrategy().
+///
+/// Hiding a manipulator (HideActiveManipulator / ToggleHideActiveManipulator) suppresses the
+/// gizmo without clearing the active attribute, so it can be restored when un-hidden.
 class EZ_GUIFOUNDATION_DLL ezManipulatorManager
 {
   EZ_DECLARE_SINGLETON(ezManipulatorManager);
@@ -26,34 +43,35 @@ public:
   ezManipulatorManager();
   ~ezManipulatorManager();
 
+  /// Returns the currently active manipulator attribute and the associated selection for the given document.
+  /// Returns nullptr and sets out_pSelection to nullptr when no manipulator is active.
   const ezManipulatorAttribute* GetActiveManipulator(const ezDocument* pDoc, const ezHybridArray<ezPropertySelection, 8>*& out_pSelection) const;
 
-  void SetActiveManipulator(
-    const ezDocument* pDoc, const ezManipulatorAttribute* pManipulator, const ezHybridArray<ezPropertySelection, 8>& selection);
+  /// Sets the active manipulator for a document and broadcasts the change.
+  /// Also resets the hidden flag so the gizmo becomes visible.
+  void SetActiveManipulator(const ezDocument* pDoc, const ezManipulatorAttribute* pManipulator, const ezHybridArray<ezPropertySelection, 8>& selection);
 
+  /// Deactivates the manipulator for the given document and broadcasts the change.
   void ClearActiveManipulator(const ezDocument* pDoc);
 
+  /// Fired whenever the active manipulator, its selection, or the hidden state changes for any document.
   ezCopyOnBroadcastEvent<const ezManipulatorManagerEvent&> m_Events;
 
+  /// Sets the hidden flag without deactivating the manipulator. Gizmos are hidden when bHide is true.
   void HideActiveManipulator(const ezDocument* pDoc, bool bHide);
+
+  /// Toggles the hidden flag for the active manipulator of the given document.
   void ToggleHideActiveManipulator(const ezDocument* pDoc);
 
 private:
   struct Data
   {
-    Data()
-    {
-      m_pAttribute = nullptr;
-      m_bHideManipulators = false;
-    }
-
-    const ezManipulatorAttribute* m_pAttribute;
+    const ezManipulatorAttribute* m_pAttribute = nullptr;
     ezHybridArray<ezPropertySelection, 8> m_Selection;
-    bool m_bHideManipulators;
+    bool m_bHideManipulators = false;
   };
 
-  void InternalSetActiveManipulator(
-    const ezDocument* pDoc, const ezManipulatorAttribute* pManipulator, const ezHybridArray<ezPropertySelection, 8>& selection, bool bUnhide);
+  void InternalSetActiveManipulator(const ezDocument* pDoc, const ezManipulatorAttribute* pManipulator, const ezHybridArray<ezPropertySelection, 8>& selection, bool bUnhide);
 
   void StructureEventHandler(const ezDocumentObjectStructureEvent& e);
   void SelectionEventHandler(const ezSelectionManagerEvent& e);

--- a/Code/Tools/Libs/ToolsFoundation/Document/Document.h
+++ b/Code/Tools/Libs/ToolsFoundation/Document/Document.h
@@ -51,8 +51,8 @@ public:
 enum class ezManipulatorSearchStrategy
 {
   None,                    ///< No manipulator search.
-  SelectedObject,          ///< Search for manipulators on the selected object.
-  ChildrenOfSelectedObject ///< Search for manipulators on the children of the selected object.
+  SelectedObject,          ///< Search for manipulators on the selected document object.
+  ChildrenOfSelectedObject ///< Search for manipulators on the children of the selected document object (e.g. on components of game objects).
 };
 
 /// \brief Base class for all editable documents in the editor. Handles state, object management, undo/redo, and more.

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/StringAlgorithms.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/StringAlgorithms.cpp
@@ -1,0 +1,158 @@
+#include <ToolsFoundation/ToolsFoundationPCH.h>
+
+#include <Foundation/Strings/StringBuilder.h>
+#include <Foundation/Utilities/ConversionUtils.h>
+#include <ToolsFoundation/Utilities/StringAlgorithms.h>
+
+static void ParseSegments(ezStringView sName, ezHybridArray<ezInt32, 8>& out_segs)
+{
+  out_segs.Clear();
+  while (!sName.IsEmpty())
+  {
+    const char* pDot = sName.FindSubString(".");
+    ezStringView sSeg;
+    if (pDot == nullptr)
+    {
+      sSeg = sName;
+      sName = ezStringView();
+    }
+    else
+    {
+      sSeg = ezStringView(sName.GetStartPointer(), pDot);
+      sName = ezStringView(pDot + 1, sName.GetEndPointer());
+    }
+    ezInt32 val = 0;
+    ezConversionUtils::StringToInt(sSeg, val).IgnoreResult();
+    out_segs.PushBack(val);
+  }
+}
+
+static void AppendSegments(ezArrayPtr<const ezInt32> segs, ezStringBuilder& ref_sb)
+{
+  for (ezUInt32 i = 0; i < segs.GetCount(); ++i)
+  {
+    if (i > 0)
+      ref_sb.Append(".");
+    ref_sb.AppendFormat("{}", segs[i]);
+  }
+}
+
+static void FindMidpointWithVirtual(ezArrayPtr<const ezInt32> lSegs, ezInt32 virtualRight, ezHybridArray<ezInt32, 8>& ref_result)
+{
+  while (true)
+  {
+    const ezInt32 lRoot = lSegs.IsEmpty() ? 0 : lSegs[0];
+    const ezInt32 diff = virtualRight - lRoot;
+
+    if (diff > 1)
+    {
+      ref_result.PushBack((lRoot + virtualRight) / 2);
+      return;
+    }
+
+    // diff == 1: adjacent values, go one level deeper
+    ref_result.PushBack(lRoot);
+    lSegs = lSegs.IsEmpty() ? lSegs : lSegs.GetSubArray(1);
+    virtualRight = 10;
+  }
+}
+
+static void FindMidpoint(ezArrayPtr<const ezInt32> lSegs, ezArrayPtr<const ezInt32> rSegs, ezHybridArray<ezInt32, 8>& ref_result)
+{
+  // Strip matching prefix
+  while (!lSegs.IsEmpty() && !rSegs.IsEmpty() && lSegs[0] == rSegs[0])
+  {
+    ref_result.PushBack(lSegs[0]);
+    lSegs = lSegs.GetSubArray(1);
+    rSegs = rSegs.GetSubArray(1);
+  }
+
+  const ezInt32 lRoot = lSegs.IsEmpty() ? 0 : lSegs[0];
+  const ezInt32 rRoot = rSegs.IsEmpty() ? lRoot + 1 : rSegs[0];
+  const ezInt32 diff = rRoot - lRoot;
+
+  EZ_ASSERT_DEBUG(diff > 0, "Left segment value must be less than right segment value");
+
+  if (diff > 1)
+  {
+    ref_result.PushBack((lRoot + rRoot) / 2);
+    return;
+  }
+
+  // diff == 1: fall back to sub-level notation
+  ref_result.PushBack(lRoot);
+  const ezArrayPtr<const ezInt32> lTail = lSegs.IsEmpty() ? lSegs : lSegs.GetSubArray(1);
+  FindMidpointWithVirtual(lTail, 10, ref_result);
+}
+
+/// Splits sName into a leading text prefix and a trailing numeric part.
+/// The numeric part begins at the first digit, or at a '-' immediately followed by a digit.
+/// ref_sName is updated to point at the numeric part; the prefix is returned.
+static ezStringView ExtractTextPrefix(ezStringView& ref_sName)
+{
+  const char* pStart = ref_sName.GetStartPointer();
+  const char* pEnd = ref_sName.GetEndPointer();
+  const char* p = pStart;
+
+  while (p < pEnd)
+  {
+    const char c = *p;
+    if (c >= '0' && c <= '9')
+      break;
+    if (c == '-' && p + 1 < pEnd && p[1] >= '0' && p[1] <= '9')
+      break;
+    ++p;
+  }
+
+  ezStringView prefix(pStart, p);
+  ref_sName = ezStringView(p, pEnd);
+  return prefix;
+}
+
+void ezStringAlgorithms::ComputeNameBetween(ezStringView sLeft, ezStringView sRight, ezStringBuilder& ref_sName)
+{
+  if (sLeft.IsEmpty() && sRight.IsEmpty())
+  {
+    ref_sName = "1";
+    return;
+  }
+
+  // Strip any leading text prefix (non-numeric characters) from both names.
+  // The result inherits the left prefix, or the right prefix when prepending.
+  ezStringView sLeftNumeric = sLeft;
+  ezStringView sRightNumeric = sRight;
+  ezStringView sLeftPrefix, sRightPrefix;
+  if (!sLeft.IsEmpty())
+    sLeftPrefix = ExtractTextPrefix(sLeftNumeric);
+  if (!sRight.IsEmpty())
+    sRightPrefix = ExtractTextPrefix(sRightNumeric);
+
+  const ezStringView sResultPrefix = sLeft.IsEmpty() ? sRightPrefix : sLeftPrefix;
+
+  ezHybridArray<ezInt32, 8> lSegs, rSegs, midSegs;
+
+  if (sLeft.IsEmpty())
+  {
+    // Prepend: go one below the right neighbor's root integer (may produce negative numbers)
+    ParseSegments(sRightNumeric, rSegs);
+    midSegs.PushBack((rSegs.IsEmpty() ? 0 : rSegs[0]) - 1);
+  }
+  else if (sRight.IsEmpty())
+  {
+    // Append: go one above the left neighbor's root integer
+    ParseSegments(sLeftNumeric, lSegs);
+    midSegs.PushBack((lSegs.IsEmpty() ? 0 : lSegs[0]) + 1);
+  }
+  else
+  {
+    ParseSegments(sLeftNumeric, lSegs);
+    ParseSegments(sRightNumeric, rSegs);
+    FindMidpoint(lSegs, rSegs, midSegs);
+  }
+
+  ref_sName.Clear();
+  ref_sName.Append(sResultPrefix);
+  if (!sResultPrefix.IsEmpty() && *(sResultPrefix.GetEndPointer() - 1) != ' ')
+    ref_sName.Append(" ");
+  AppendSegments(midSegs, ref_sName);
+}

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/StringAlgorithms.cpp
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/Implementation/StringAlgorithms.cpp
@@ -27,48 +27,48 @@ static void ParseSegments(ezStringView sName, ezHybridArray<ezInt32, 8>& out_seg
   }
 }
 
-static void AppendSegments(ezArrayPtr<const ezInt32> segs, ezStringBuilder& ref_sb)
+static void AppendSegments(ezArrayPtr<const ezInt32> segs, ezStringBuilder& ref_sText)
 {
   for (ezUInt32 i = 0; i < segs.GetCount(); ++i)
   {
     if (i > 0)
-      ref_sb.Append(".");
-    ref_sb.AppendFormat("{}", segs[i]);
+      ref_sText.Append(".");
+    ref_sText.AppendFormat("{}", segs[i]);
   }
 }
 
-static void FindMidpointWithVirtual(ezArrayPtr<const ezInt32> lSegs, ezInt32 virtualRight, ezHybridArray<ezInt32, 8>& ref_result)
+static void FindMidpointWithVirtual(ezArrayPtr<const ezInt32> leftSegs, ezInt32 iVirtualRight, ezHybridArray<ezInt32, 8>& ref_result)
 {
   while (true)
   {
-    const ezInt32 lRoot = lSegs.IsEmpty() ? 0 : lSegs[0];
-    const ezInt32 diff = virtualRight - lRoot;
+    const ezInt32 lRoot = leftSegs.IsEmpty() ? 0 : leftSegs[0];
+    const ezInt32 diff = iVirtualRight - lRoot;
 
     if (diff > 1)
     {
-      ref_result.PushBack((lRoot + virtualRight) / 2);
+      ref_result.PushBack((lRoot + iVirtualRight) / 2);
       return;
     }
 
     // diff == 1: adjacent values, go one level deeper
     ref_result.PushBack(lRoot);
-    lSegs = lSegs.IsEmpty() ? lSegs : lSegs.GetSubArray(1);
-    virtualRight = 10;
+    leftSegs = leftSegs.IsEmpty() ? leftSegs : leftSegs.GetSubArray(1);
+    iVirtualRight = 10;
   }
 }
 
-static void FindMidpoint(ezArrayPtr<const ezInt32> lSegs, ezArrayPtr<const ezInt32> rSegs, ezHybridArray<ezInt32, 8>& ref_result)
+static void FindMidpoint(ezArrayPtr<const ezInt32> leftSegs, ezArrayPtr<const ezInt32> rightSegs, ezHybridArray<ezInt32, 8>& ref_result)
 {
   // Strip matching prefix
-  while (!lSegs.IsEmpty() && !rSegs.IsEmpty() && lSegs[0] == rSegs[0])
+  while (!leftSegs.IsEmpty() && !rightSegs.IsEmpty() && leftSegs[0] == rightSegs[0])
   {
-    ref_result.PushBack(lSegs[0]);
-    lSegs = lSegs.GetSubArray(1);
-    rSegs = rSegs.GetSubArray(1);
+    ref_result.PushBack(leftSegs[0]);
+    leftSegs = leftSegs.GetSubArray(1);
+    rightSegs = rightSegs.GetSubArray(1);
   }
 
-  const ezInt32 lRoot = lSegs.IsEmpty() ? 0 : lSegs[0];
-  const ezInt32 rRoot = rSegs.IsEmpty() ? lRoot + 1 : rSegs[0];
+  const ezInt32 lRoot = leftSegs.IsEmpty() ? 0 : leftSegs[0];
+  const ezInt32 rRoot = rightSegs.IsEmpty() ? lRoot + 1 : rightSegs[0];
   const ezInt32 diff = rRoot - lRoot;
 
   EZ_ASSERT_DEBUG(diff > 0, "Left segment value must be less than right segment value");
@@ -81,7 +81,7 @@ static void FindMidpoint(ezArrayPtr<const ezInt32> lSegs, ezArrayPtr<const ezInt
 
   // diff == 1: fall back to sub-level notation
   ref_result.PushBack(lRoot);
-  const ezArrayPtr<const ezInt32> lTail = lSegs.IsEmpty() ? lSegs : lSegs.GetSubArray(1);
+  const ezArrayPtr<const ezInt32> lTail = leftSegs.IsEmpty() ? leftSegs : leftSegs.GetSubArray(1);
   FindMidpointWithVirtual(lTail, 10, ref_result);
 }
 

--- a/Code/Tools/Libs/ToolsFoundation/Utilities/StringAlgorithms.h
+++ b/Code/Tools/Libs/ToolsFoundation/Utilities/StringAlgorithms.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Foundation/Strings/StringView.h>
+#include <ToolsFoundation/ToolsFoundationDLL.h>
+
+class ezStringBuilder;
+
+namespace ezStringAlgorithms
+{
+  /// Computes an ordered name for an item inserted between sLeft and sRight.
+  ///
+  /// Uses the Dewey decimal scheme to produce a human-readable name that conveys the
+  /// item's position relative to its neighbors without renaming any existing items.
+  /// Integer midpoints are preferred when the gap allows (e.g. "3" between "2" and "4",
+  /// "15" between "10" and "20"), falling back to dot-separated sub-levels for adjacent
+  /// values (e.g. "3.5" between "3" and "4", "3.7" between "3.5" and "4").
+  ///
+  /// Either neighbor may be empty: an empty sLeft means prepend (goes one below sRight's
+  /// root integer, potentially negative), an empty sRight means append (goes one above
+  /// sLeft's root integer).
+  EZ_TOOLSFOUNDATION_DLL void ComputeNameBetween(ezStringView sLeft, ezStringView sRight, ezStringBuilder& ref_sName);
+} // namespace ezStringAlgorithms

--- a/Code/UnitTests/ToolsFoundationTest/Utilities/StringAlgorithmsTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Utilities/StringAlgorithmsTest.cpp
@@ -1,0 +1,119 @@
+#include <ToolsFoundationTest/ToolsFoundationTestPCH.h>
+
+#include <Foundation/Strings/StringBuilder.h>
+#include <ToolsFoundation/Utilities/StringAlgorithms.h>
+
+EZ_CREATE_SIMPLE_TEST_GROUP(Utilities);
+
+EZ_CREATE_SIMPLE_TEST(Utilities, StringAlgorithms)
+{
+  auto Check = [](ezStringView sLeft, ezStringView sRight, ezStringView sExpected)
+  {
+    ezStringBuilder sResult;
+    ezStringAlgorithms::ComputeNameBetween(sLeft, sRight, sResult);
+    EZ_TEST_STRING(sResult, sExpected);
+  };
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Append")
+  {
+    Check("1", "", "2");
+    Check("3", "", "4");
+    Check("-1", "", "0");
+    // Root integer is used regardless of sub-levels
+    Check("3.5", "", "4");
+    Check("3.5.2", "", "4");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "Prepend")
+  {
+    Check("", "1", "0");
+    Check("", "3", "2");
+    Check("", "0", "-1");
+    Check("", "-1", "-2");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "IntegerMidpoint")
+  {
+    // Gap > 1: use integer midpoint
+    Check("2", "4", "3");
+    Check("1", "9", "5");
+    Check("10", "20", "15");
+    Check("0", "10", "5");
+    Check("-4", "0", "-2");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "AdjacentIntegers")
+  {
+    // Gap == 1: fall back to first sub-level
+    Check("3", "4", "3.5");
+    Check("1", "2", "1.5");
+    Check("0", "1", "0.5");
+    Check("-2", "-1", "-2.5");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SubLevelInsertions")
+  {
+    // Inserting between a fractional name and the next integer
+    Check("3.5", "4", "3.7"); // midpoint of 5 and 10 = 7
+    Check("3.7", "4", "3.8"); // midpoint of 7 and 10 = 8
+    Check("3.8", "4", "3.9"); // midpoint of 8 and 10 = 9
+    Check("3.9", "4", "3.9.5"); // 9 adjacent to 10, go deeper
+    Check("3.9.5", "4", "3.9.7");
+    Check("3.9.9", "4", "3.9.9.5");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "SamePrefix")
+  {
+    // Both names share a common root prefix
+    Check("3.2", "3.4", "3.3");
+    Check("3.5", "3.7", "3.6");
+    Check("3.5", "3.6", "3.5.5");
+    Check("3.2", "3.3", "3.2.5");
+    Check("1.1", "1.9", "1.5");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "BothEmpty")
+  {
+    // No neighbors at all: return the initial name
+    Check("", "", "1");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "NonNumericStrings")
+  {
+    // Fully non-numeric names have an all-text prefix and an empty numeric part (treated as 0).
+    // The prefix is copied to the result; the numeric portion follows the usual scheme.
+    Check("", "foo", "foo -1");   // prefix "foo" inherited from right; numeric: 0-1 = -1
+    Check("foo", "", "foo 1");    // prefix "foo" from left; numeric: 0+1 = 1
+    Check("foo", "bar", "foo 0.5"); // both numeric parts empty (→ 0); prefix "foo" from left
+
+    // Mixed: one numeric, one non-numeric
+    Check("", "hello", "hello -1"); // prefix "hello" from right; numeric: 0-1 = -1
+    Check("hello", "", "hello 1");  // prefix "hello" from left; numeric: 0+1 = 1
+    Check("foo", "2", "foo 1");     // left numeric empty (→0), right numeric 2; midpoint=1
+
+    // Dot-notation with non-numeric segments: the entire string becomes the text prefix
+    // since there are no digits at all.
+    Check("", "a.b.c", "a.b.c -1");
+    Check("a.b.c", "", "a.b.c 1");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "WithSameTextPrefix")
+  {
+    // Both names share a common root prefix
+    Check("Node 3.2", "Node 3.4", "Node 3.3");
+    Check("Node 3.5", "Node 3.7", "Node 3.6");
+    Check("Node 3.5", "Node 3.6", "Node 3.5.5");
+    Check("Node 3.2", "Node 3.3", "Node 3.2.5");
+    Check("Node 1.1", "Node 1.9", "Node 1.5");
+  }
+
+  EZ_TEST_BLOCK(ezTestBlock::Enabled, "WithDifferentTextPrefix")
+  {
+    // Both names share a common root prefix
+    Check("Bla 3.2", "Blub 3.4", "Bla 3.3");
+    Check("Bla 3.5", "Blub 3.7", "Bla 3.6");
+    Check("Bla 3.5", "Blub 3.6", "Bla 3.5.5");
+    Check("Bla 3.2", "Blub 3.3", "Bla 3.2.5");
+    Check("Bla 1.1", "Blub 1.9", "Bla 1.5");
+  }
+}

--- a/Code/UnitTests/ToolsFoundationTest/Utilities/StringAlgorithmsTest.cpp
+++ b/Code/UnitTests/ToolsFoundationTest/Utilities/StringAlgorithmsTest.cpp
@@ -54,9 +54,9 @@ EZ_CREATE_SIMPLE_TEST(Utilities, StringAlgorithms)
   EZ_TEST_BLOCK(ezTestBlock::Enabled, "SubLevelInsertions")
   {
     // Inserting between a fractional name and the next integer
-    Check("3.5", "4", "3.7"); // midpoint of 5 and 10 = 7
-    Check("3.7", "4", "3.8"); // midpoint of 7 and 10 = 8
-    Check("3.8", "4", "3.9"); // midpoint of 8 and 10 = 9
+    Check("3.5", "4", "3.7");   // midpoint of 5 and 10 = 7
+    Check("3.7", "4", "3.8");   // midpoint of 7 and 10 = 8
+    Check("3.8", "4", "3.9");   // midpoint of 8 and 10 = 9
     Check("3.9", "4", "3.9.5"); // 9 adjacent to 10, go deeper
     Check("3.9.5", "4", "3.9.7");
     Check("3.9.9", "4", "3.9.9.5");
@@ -82,8 +82,8 @@ EZ_CREATE_SIMPLE_TEST(Utilities, StringAlgorithms)
   {
     // Fully non-numeric names have an all-text prefix and an empty numeric part (treated as 0).
     // The prefix is copied to the result; the numeric portion follows the usual scheme.
-    Check("", "foo", "foo -1");   // prefix "foo" inherited from right; numeric: 0-1 = -1
-    Check("foo", "", "foo 1");    // prefix "foo" from left; numeric: 0+1 = 1
+    Check("", "foo", "foo -1");     // prefix "foo" inherited from right; numeric: 0-1 = -1
+    Check("foo", "", "foo 1");      // prefix "foo" from left; numeric: 0+1 = 1
     Check("foo", "bar", "foo 0.5"); // both numeric parts empty (→ 0); prefix "foo" from left
 
     // Mixed: one numeric, one non-numeric


### PR DESCRIPTION
* Added `ezStringAlgorithms` to ToolsFoundation. Currently only contains `ezStringAlgorithms::ComputeNameBetween()`. This implements the *Dewey decimal scheme* for building a unique numbered name even when inserting in the middle. TL;DR: Makes spline node names better.

* Spline node insert points are now actually in the middle of a spline segment.

* Clicking a spline insertion point twice without moving the mouse, doesn't insert another node anymore.

* When a spline point gets inserted, it is now immediately selected.

* Pressing `Ctrl+B` for *undo selection* now skips undo steps that failed to do something (due to deleted objects).

* Added some documentation comments to manipulator code.