### PR TITLE
Manipulator improvements

### DIFF
--- a/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
+++ b/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
@@ -372,6 +372,11 @@ void ezGameObjectDocument::DetermineNodeName(const ezDocumentObject* pObject, co
     }
   }
 
+  if (!bHasIcon && out_pIcon)
+  {
+    *out_pIcon = ezQtUiServices::GetCachedIconResource(":/GuiFoundation/Icons/Object.svg");
+  }
+
   if (!out_sResult.IsEmpty())
     return;
 
@@ -382,8 +387,7 @@ void ezGameObjectDocument::DetermineNodeName(const ezDocumentObject* pObject, co
 }
 
 
-void ezGameObjectDocument::QueryCachedNodeName(
-  const ezDocumentObject* pObject, ezStringBuilder& out_sResult, ezUuid* out_pPrefabGuid, QIcon* out_pIcon /*= nullptr*/) const
+void ezGameObjectDocument::QueryCachedNodeName(const ezDocumentObject* pObject, ezStringBuilder& out_sResult, ezUuid* out_pPrefabGuid, QIcon* out_pIcon /*= nullptr*/) const
 {
   auto pMetaScene = m_GameObjectMetaData->BeginReadMetaData(pObject->GetGuid());
   auto pMetaDoc = m_DocumentObjectMetaData->BeginReadMetaData(pObject->GetGuid());

--- a/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
+++ b/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
@@ -150,9 +150,8 @@ void ezGameObjectDocument::SetActiveEditTool(const ezRTTI* pEditToolType)
   {
     if (m_pActiveEditTool == nullptr)
     {
-      // if there is currently no active edit tool, we may still have a manipulator active
-      // if so, when repeatedly selecting this action, toggle the visibility of manipulators
-      ezManipulatorManager::GetSingleton()->ToggleHideActiveManipulator(this);
+      // if there is currently no active edit tool, cycle through the manipulators available on the selected object
+      ezManipulatorManager::GetSingleton()->CycleActiveManipulator(this);
     }
 
     return;

--- a/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
+++ b/Code/Editor/EditorFramework/Manipulators/Implementation/SplineManipulatorAdapter.cpp
@@ -116,7 +116,49 @@ ezResult ezSplineManipulatorAdapter::FillControlPointFromNodeComponent(const ezD
 
 void ezSplineManipulatorAdapter::Finalize()
 {
-  // Update will be called directly after this, so nothing to do here
+  const ezSplineManipulatorAttribute* pAttr = static_cast<const ezSplineManipulatorAttribute*>(m_pManipulatorAttr);
+
+  auto HasSplineProperties = [&](const ezDocumentObject* pObj) -> bool
+  {
+    const ezRTTI* pType = pObj->GetTypeAccessor().GetType();
+    return pType->FindPropertyByName(pAttr->GetNodesProperty()) != nullptr &&
+           pType->FindPropertyByName(pAttr->GetClosedProperty()) != nullptr;
+  };
+
+  // m_pObject may not directly expose the spline properties. Walk up the parent chain.
+  // At each level, also check components (objects stored in the "Components" array property),
+  // since the relevant object may be a component of a game object rather than the game object itself.
+  while (m_pObject != nullptr)
+  {
+    if (HasSplineProperties(m_pObject))
+      break;
+
+    ezVariantArray componentUuids;
+    if (m_pObject->GetTypeAccessor().GetValues("Components", componentUuids))
+    {
+      const ezDocumentObject* pFoundComponent = nullptr;
+      for (const auto& v : componentUuids)
+      {
+        if (v.IsA<ezUuid>())
+        {
+          const ezDocumentObject* pComponent = m_pObject->GetDocumentObjectManager()->GetObject(v.Get<ezUuid>());
+          if (pComponent != nullptr && HasSplineProperties(pComponent))
+          {
+            pFoundComponent = pComponent;
+            break;
+          }
+        }
+      }
+
+      if (pFoundComponent != nullptr)
+      {
+        m_pObject = pFoundComponent;
+        break;
+      }
+    }
+
+    m_pObject = m_pObject->GetParent();
+  }
 }
 
 void ezSplineManipulatorAdapter::Update()

--- a/Code/Engine/RendererCore/Components/Implementation/FogComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/FogComponent.cpp
@@ -16,7 +16,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezFogComponent, 3, ezComponentMode::Static)
   {
     EZ_ACCESSOR_PROPERTY("Color", GetColor, SetColor)->AddAttributes(new ezDefaultValueAttribute(ezColorGammaUB(ezColor(0.2f, 0.2f, 0.3f)))),
     EZ_ACCESSOR_PROPERTY("Density", GetDensity, SetDensity)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1.0f)),
-    EZ_ACCESSOR_PROPERTY("StartDistance", GetStartDistance, SetStartDistance)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_ACCESSOR_PROPERTY("StartDistance", GetStartDistance, SetStartDistance),
     EZ_ACCESSOR_PROPERTY("HeightFalloff", GetHeightFalloff, SetHeightFalloff)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
     EZ_ACCESSOR_PROPERTY("ModulateWithSkyColor", GetModulateWithSkyColor, SetModulateWithSkyColor),
     EZ_ACCESSOR_PROPERTY("SkyDistance", GetSkyDistance, SetSkyDistance)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(1000.0f)),

--- a/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
@@ -694,6 +694,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSplineNodeComponent, 1, ezComponentMode::Static)
     EZ_ENUM_ACCESSOR_PROPERTY("TangentModeOut", ezSplineTangentMode, GetTangentModeOut, SetTangentModeOut),
     EZ_ACCESSOR_PROPERTY("CustomTangentOut", GetCustomTangentOut, SetCustomTangentOut),
     EZ_ACCESSOR_PROPERTY("LinkCustomTangents", GetLinkCustomTangents, SetLinkCustomTangents),
+    EZ_MEMBER_PROPERTY("EditNodes", m_uiDummy),
   }
   EZ_END_PROPERTIES;
 
@@ -709,6 +710,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSplineNodeComponent, 1, ezComponentMode::Static)
     new ezCategoryAttribute("Utilities/Splines"),
     new ezSplineTangentManipulatorAttribute("TangentModeIn", "CustomTangentIn"),
     new ezSplineTangentManipulatorAttribute("TangentModeOut", "CustomTangentOut"),
+    new ezSplineManipulatorAttribute("Nodes", "Closed", "EditNodes"),
   }
   EZ_END_ATTRIBUTES;
 }

--- a/Code/Engine/RendererCore/Components/SplineComponent.h
+++ b/Code/Engine/RendererCore/Components/SplineComponent.h
@@ -267,4 +267,6 @@ protected:
 
   ezVec3 m_vCustomTangentIn = ezVec3::MakeZero();
   ezVec3 m_vCustomTangentOut = ezVec3::MakeZero();
+
+  ezUInt8 m_uiDummy = 0;
 };

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ManipulatorLabel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ManipulatorLabel.cpp
@@ -4,18 +4,46 @@
 #include <GuiFoundation/PropertyGrid/ManipulatorManager.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QToolButton>
 #include <qevent.h>
 
 ezQtManipulatorLabel::ezQtManipulatorLabel(QWidget* pParent, Qt::WindowFlags f)
-  : QLabel(pParent, f)
+  : QWidget(pParent, f)
 {
-  setCursor(Qt::WhatsThisCursor);
+  QHBoxLayout* pLayout = new QHBoxLayout(this);
+  pLayout->setContentsMargins(0, 0, 0, 0);
+  pLayout->setSpacing(2);
+
+  m_pLabel = new QLabel(this);
+  m_pLabel->setCursor(Qt::WhatsThisCursor);
+  m_pLabel->installEventFilter(this);
+  pLayout->addWidget(m_pLabel, 1);
+
+  QIcon manipIcon;
+  manipIcon.addFile(":/GuiFoundation/Icons/Manipulator-off.svg", QSize(), QIcon::Normal, QIcon::Off);
+  manipIcon.addFile(":/GuiFoundation/Icons/Manipulator-on.svg", QSize(), QIcon::Normal, QIcon::On);
+
+  m_pButton = new QToolButton(this);
+  m_pButton->setCheckable(true);
+  m_pButton->setAutoRaise(true);
+  m_pButton->setIcon(manipIcon);
+  m_pButton->setFixedSize(24, 24);
+  m_pButton->setToolTip("Toggles the manipulator gizmo for this property.");
+  m_pButton->setVisible(false);
+  connect(m_pButton, &QAbstractButton::clicked, this, &ezQtManipulatorLabel::ToggleManipulator);
+  pLayout->addWidget(m_pButton, 0);
 }
 
-ezQtManipulatorLabel::ezQtManipulatorLabel(const QString& sText, QWidget* pParent, Qt::WindowFlags f)
-  : QLabel(sText, pParent, f)
-  , m_bIsDefault(true)
+void ezQtManipulatorLabel::setText(const QString& sText)
 {
+  m_pLabel->setText(sText);
+}
+
+void ezQtManipulatorLabel::setAlignment(Qt::Alignment alignment)
+{
+  m_pLabel->setAlignment(alignment);
 }
 
 const ezManipulatorAttribute* ezQtManipulatorLabel::GetManipulator() const
@@ -29,8 +57,9 @@ void ezQtManipulatorLabel::SetManipulator(const ezManipulatorAttribute* pManipul
 
   if (m_pManipulator)
   {
-    setCursor(Qt::PointingHandCursor);
-    setForegroundRole(QPalette::ColorRole::Link);
+    m_pLabel->setCursor(Qt::PointingHandCursor);
+    m_pLabel->setForegroundRole(QPalette::ColorRole::Link);
+    m_pButton->setVisible(true);
   }
 }
 
@@ -45,7 +74,8 @@ void ezQtManipulatorLabel::SetManipulatorActive(bool bActive)
 
   if (m_pManipulator)
   {
-    setForegroundRole(m_bActive ? QPalette::ColorRole::LinkVisited : QPalette::ColorRole::Link);
+    m_pLabel->setForegroundRole(m_bActive ? QPalette::ColorRole::LinkVisited : QPalette::ColorRole::Link);
+    m_pButton->setChecked(m_bActive);
   }
 }
 
@@ -54,35 +84,18 @@ void ezQtManipulatorLabel::SetSelection(const ezArrayPtr<ezPropertySelection>& i
   m_Items = items;
 }
 
-
 void ezQtManipulatorLabel::SetIsDefault(bool bIsDefault)
 {
   if (m_bIsDefault != bIsDefault)
   {
     m_bIsDefault = bIsDefault;
     m_Font.setBold(!m_bIsDefault);
-    setFont(m_Font);
+    m_pLabel->setFont(m_Font);
   }
 }
 
-
-void ezQtManipulatorLabel::contextMenuEvent(QContextMenuEvent* ev)
+void ezQtManipulatorLabel::ToggleManipulator()
 {
-  Q_EMIT customContextMenuRequested(ev->globalPos());
-}
-
-void ezQtManipulatorLabel::showEvent(QShowEvent* event)
-{
-  // Use of style sheets (ADS) breaks previously set font.
-  setFont(m_Font);
-  QLabel::showEvent(event);
-}
-
-void ezQtManipulatorLabel::mousePressEvent(QMouseEvent* ev)
-{
-  if (ev->button() != Qt::LeftButton)
-    return;
-
   if (m_pManipulator == nullptr)
     return;
 
@@ -94,28 +107,48 @@ void ezQtManipulatorLabel::mousePressEvent(QMouseEvent* ev)
     ezManipulatorManager::GetSingleton()->SetActiveManipulator(pDoc, m_pManipulator, m_Items);
 }
 
-#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
-void ezQtManipulatorLabel::enterEvent(QEnterEvent* ev)
-#else
-void ezQtManipulatorLabel::enterEvent(QEvent* ev)
-#endif
+void ezQtManipulatorLabel::showEvent(QShowEvent* event)
 {
-  if (m_pManipulator)
-  {
-    m_Font.setUnderline(true);
-    setFont(m_Font);
-  }
-
-  QLabel::enterEvent(ev);
+  // Use of style sheets (ADS) breaks previously set font.
+  m_pLabel->setFont(m_Font);
+  QWidget::showEvent(event);
 }
 
-void ezQtManipulatorLabel::leaveEvent(QEvent* ev)
+bool ezQtManipulatorLabel::eventFilter(QObject* pWatched, QEvent* pEvent)
 {
-  if (m_pManipulator)
+  if (pWatched == m_pLabel)
   {
-    m_Font.setUnderline(false);
-    setFont(m_Font);
+    switch (pEvent->type())
+    {
+      case QEvent::Enter:
+        if (m_pManipulator)
+        {
+          m_Font.setUnderline(true);
+          m_pLabel->setFont(m_Font);
+        }
+        break;
+
+      case QEvent::Leave:
+        if (m_pManipulator)
+        {
+          m_Font.setUnderline(false);
+          m_pLabel->setFont(m_Font);
+        }
+        break;
+
+      case QEvent::MouseButtonPress:
+        if (static_cast<QMouseEvent*>(pEvent)->button() == Qt::LeftButton)
+          ToggleManipulator();
+        break;
+
+      case QEvent::ContextMenu:
+        Q_EMIT customContextMenuRequested(static_cast<QContextMenuEvent*>(pEvent)->globalPos());
+        return true;
+
+      default:
+        break;
+    }
   }
 
-  QLabel::leaveEvent(ev);
+  return QWidget::eventFilter(pWatched, pEvent);
 }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ManipulatorLabel.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ManipulatorLabel.moc.h
@@ -2,16 +2,20 @@
 
 #include <GuiFoundation/GuiFoundationDLL.h>
 #include <GuiFoundation/PropertyGrid/PropertyBaseWidget.moc.h>
-#include <QLabel>
+#include <QWidget>
 
 class ezManipulatorAttribute;
+class QLabel;
+class QToolButton;
 
-class ezQtManipulatorLabel : public QLabel
+class ezQtManipulatorLabel : public QWidget
 {
   Q_OBJECT
 public:
   explicit ezQtManipulatorLabel(QWidget* pParent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
-  explicit ezQtManipulatorLabel(const QString& sText, QWidget* pParent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+
+  void setText(const QString& sText);
+  void setAlignment(Qt::Alignment alignment);
 
   const ezManipulatorAttribute* GetManipulator() const;
   void SetManipulator(const ezManipulatorAttribute* pManipulator);
@@ -21,27 +25,20 @@ public:
 
   void SetSelection(const ezArrayPtr<ezPropertySelection>& items);
 
+  void ToggleManipulator();
+
   void SetIsDefault(bool bIsDefault);
 
 protected:
-  virtual void contextMenuEvent(QContextMenuEvent* ev) override;
+  virtual bool eventFilter(QObject* pWatched, QEvent* pEvent) override;
   virtual void showEvent(QShowEvent* event) override;
 
 private:
-  virtual void mousePressEvent(QMouseEvent* ev) override;
-
-#if QT_VERSION > QT_VERSION_CHECK(6, 0, 0)
-  virtual void enterEvent(QEnterEvent* ev) override;
-#else
-  virtual void enterEvent(QEvent* ev) override;
-#endif
-
-  virtual void leaveEvent(QEvent* ev) override;
-
-private:
+  QLabel* m_pLabel = nullptr;
+  QToolButton* m_pButton = nullptr;
   ezArrayPtr<ezPropertySelection> m_Items;
   const ezManipulatorAttribute* m_pManipulator = nullptr;
   QFont m_Font;
   bool m_bActive = false;
-  bool m_bIsDefault = false;
+  bool m_bIsDefault = true;
 };

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ManipulatorManager.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/ManipulatorManager.cpp
@@ -42,8 +42,7 @@ ezManipulatorManager::~ezManipulatorManager()
   ezDocumentManager::s_Events.RemoveEventHandler(ezMakeDelegate(&ezManipulatorManager::DocumentManagerEventHandler, this));
 }
 
-const ezManipulatorAttribute* ezManipulatorManager::GetActiveManipulator(
-  const ezDocument* pDoc, const ezHybridArray<ezPropertySelection, 8>*& out_pSelection) const
+const ezManipulatorAttribute* ezManipulatorManager::GetActiveManipulator(const ezDocument* pDoc, const ezHybridArray<ezPropertySelection, 8>*& out_pSelection) const
 {
   out_pSelection = nullptr;
   auto it = m_ActiveManipulator.Find(pDoc);
@@ -139,6 +138,149 @@ void ezManipulatorManager::ToggleHideActiveManipulator(const ezDocument* pDoc)
       TransferToCurrentSelection(pDoc);
     }
   }
+}
+
+void ezManipulatorManager::CycleActiveManipulator(const ezDocument* pDoc)
+{
+  const ezDocumentObject* pCurrentObject = pDoc->GetSelectionManager()->GetCurrentObject();
+  if (pCurrentObject == nullptr)
+    return;
+
+  EZ_ASSERT_DEV(pDoc->GetManipulatorSearchStrategy() != ezManipulatorSearchStrategy::None,
+    "The document type '{}' has to override the function 'GetManipulatorSearchStrategy()'", pDoc->GetDynamicRTTI()->GetTypeName());
+
+  // Collect available manipulator attributes from the last selected object (or its children).
+  // Deduplicates by type + primary property so that e.g. multiple ezSplineNodeComponent children
+  // that share the same ezSplineManipulatorAttribute only contribute one entry.
+  ezTempHybridArray<const ezManipulatorAttribute*, 8> available;
+
+  auto collectManipulators = [&](const ezDocumentObject* pObj)
+  {
+    // Walk the full type hierarchy so attributes on base classes are included.
+    for (const ezRTTI* pRtti = pObj->GetTypeAccessor().GetType(); pRtti != nullptr; pRtti = pRtti->GetParentType())
+    {
+      for (const auto* pAttr : pRtti->GetAttributes())
+      {
+        if (!pAttr->GetDynamicRTTI()->IsDerivedFrom<ezManipulatorAttribute>())
+          continue;
+
+        const ezManipulatorAttribute* pManipAttr = static_cast<const ezManipulatorAttribute*>(pAttr);
+
+        // Skip duplicates (same type and primary property)
+        bool bAlreadyAdded = false;
+        for (const auto* pExisting : available)
+        {
+          if (pExisting->GetDynamicRTTI() == pManipAttr->GetDynamicRTTI() &&
+              pExisting->m_sProperty1 == pManipAttr->m_sProperty1)
+          {
+            bAlreadyAdded = true;
+            break;
+          }
+        }
+        if (!bAlreadyAdded)
+          available.PushBack(pManipAttr);
+      }
+    }
+  };
+
+  if (pDoc->GetManipulatorSearchStrategy() == ezManipulatorSearchStrategy::SelectedObject)
+  {
+    collectManipulators(pCurrentObject);
+  }
+  else if (pDoc->GetManipulatorSearchStrategy() == ezManipulatorSearchStrategy::ChildrenOfSelectedObject)
+  {
+    for (const auto* pChild : pCurrentObject->GetChildren())
+      collectManipulators(pChild);
+  }
+  else
+  {
+    EZ_ASSERT_NOT_IMPLEMENTED;
+  }
+
+  if (available.IsEmpty())
+    return;
+
+  // Find the index of the currently active manipulator
+  const ezHybridArray<ezPropertySelection, 8>* pSel = nullptr;
+  const ezManipulatorAttribute* pActive = GetActiveManipulator(pDoc, pSel);
+
+  ezInt32 iCurrentIndex = -1;
+  if (pActive != nullptr)
+  {
+    for (ezUInt32 i = 0; i < available.GetCount(); ++i)
+    {
+      if (available[i]->GetDynamicRTTI() == pActive->GetDynamicRTTI() &&
+          available[i]->m_sProperty1 == pActive->m_sProperty1)
+      {
+        iCurrentIndex = static_cast<ezInt32>(i);
+        break;
+      }
+    }
+  }
+
+  // If the last (or only) manipulator is currently active, clear and stop
+  if (iCurrentIndex >= static_cast<ezInt32>(available.GetCount()) - 1)
+  {
+    ClearActiveManipulator(pDoc);
+    return;
+  }
+
+  const ezManipulatorAttribute* pNext = available[iCurrentIndex + 1];
+
+  // Build a selection for pNext by searching through the current editor selection
+  ezTempHybridArray<ezPropertySelection, 8> newSelection;
+  const auto& selection = pDoc->GetSelectionManager()->GetSelection();
+
+  auto matchesNext = [&](const ezManipulatorAttribute* pManip) -> bool
+  {
+    return pManip->GetDynamicRTTI() == pNext->GetDynamicRTTI() &&
+           pManip->m_sProperty1 == pNext->m_sProperty1 && pManip->m_sProperty2 == pNext->m_sProperty2 &&
+           pManip->m_sProperty3 == pNext->m_sProperty3 && pManip->m_sProperty4 == pNext->m_sProperty4 &&
+           pManip->m_sProperty5 == pNext->m_sProperty5 && pManip->m_sProperty6 == pNext->m_sProperty6;
+  };
+
+  // Returns true if pObj (or any of its base types) has a manipulator attribute matching pNext.
+  auto hasMatchingManipulator = [&](const ezDocumentObject* pObj) -> bool
+  {
+    for (const ezRTTI* pRtti = pObj->GetTypeAccessor().GetType(); pRtti != nullptr; pRtti = pRtti->GetParentType())
+    {
+      for (const auto* pAttr : pRtti->GetAttributes())
+      {
+        if (pAttr->IsInstanceOf(pNext->GetDynamicRTTI()) && matchesNext(static_cast<const ezManipulatorAttribute*>(pAttr)))
+          return true;
+      }
+    }
+    return false;
+  };
+
+  if (pDoc->GetManipulatorSearchStrategy() == ezManipulatorSearchStrategy::SelectedObject)
+  {
+    for (const auto* pObj : selection)
+    {
+      if (hasMatchingManipulator(pObj))
+        newSelection.ExpandAndGetRef().m_pObject = pObj;
+    }
+  }
+  else if (pDoc->GetManipulatorSearchStrategy() == ezManipulatorSearchStrategy::ChildrenOfSelectedObject)
+  {
+    for (const auto* pObj : selection)
+    {
+      for (const auto* pChild : pObj->GetChildren())
+      {
+        if (hasMatchingManipulator(pChild))
+        {
+          newSelection.ExpandAndGetRef().m_pObject = pChild;
+          break;
+        }
+      }
+    }
+  }
+  else
+  {
+    EZ_ASSERT_NOT_IMPLEMENTED;
+  }
+
+  InternalSetActiveManipulator(pDoc, pNext, newSelection, true);
 }
 
 void ezManipulatorManager::StructureEventHandler(const ezDocumentObjectStructureEvent& e)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/ManipulatorManager.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/ManipulatorManager.h
@@ -63,6 +63,13 @@ public:
   /// Toggles the hidden flag for the active manipulator of the given document.
   void ToggleHideActiveManipulator(const ezDocument* pDoc);
 
+  /// Cycles through the manipulators available on the last selected object.
+  ///
+  /// If no manipulator is active, activates the first available one. If the currently active
+  /// manipulator is not the last in the list, activates the next one. If it is the last,
+  /// clears the active manipulator.
+  void CycleActiveManipulator(const ezDocument* pDoc);
+
 private:
   struct Data
   {

--- a/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Manipulator-off.svg
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Manipulator-off.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="#ffffff"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="Manipulator-off.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="1.15625"
+     inkscape:cx="400"
+     inkscape:cy="400"
+     inkscape:window-width="2194"
+     inkscape:window-height="1163"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="SVGRepo_iconCarrier" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round" />
+  <g
+     id="SVGRepo_iconCarrier">
+    <path
+       d="M17,7H7A5,5,0,0,0,7,17H17A5,5,0,0,0,17,7ZM7,15a3,3,0,1,1,3-3A3,3,0,0,1,7,15Z"
+       id="path1"
+       style="fill:#2fbdfe;fill-opacity:1" />
+    <path
+       d="M0,0H24V24H0Z"
+       fill="none"
+       id="path2" />
+  </g>
+</svg>

--- a/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Manipulator-on.svg
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Manipulator-on.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 24 24"
+   fill="#ffffff"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="Manipulator-on.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="1.15625"
+     inkscape:cx="400"
+     inkscape:cy="400"
+     inkscape:window-width="2194"
+     inkscape:window-height="1163"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="SVGRepo_iconCarrier" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round" />
+  <g
+     id="SVGRepo_iconCarrier">
+    <path
+       d="M17,7H7A5,5,0,0,0,7,17H17A5,5,0,0,0,17,7Zm0,8a3,3,0,1,1,3-3A3,3,0,0,1,17,15Z"
+       id="path1"
+       style="fill:#d4aa00" />
+    <path
+       d="M0,0H24V24H0Z"
+       fill="none"
+       id="path2" />
+  </g>
+</svg>

--- a/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Object.svg
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/Icons/Object.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+
+<svg
+   fill="#ffffff"
+   version="1.1"
+   id="Layer_1"
+   width="800px"
+   height="800px"
+   viewBox="0 0 92 92"
+   enable-background="new 0 0 92 92"
+   xml:space="preserve"
+   stroke="#ffffff"
+   sodipodi:docname="Object.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1" /><sodipodi:namedview
+   id="namedview1"
+   pagecolor="#505050"
+   bordercolor="#ffffff"
+   borderopacity="1"
+   inkscape:showpageshadow="0"
+   inkscape:pageopacity="0"
+   inkscape:pagecheckerboard="1"
+   inkscape:deskcolor="#505050"
+   inkscape:zoom="1.15625"
+   inkscape:cx="400"
+   inkscape:cy="400"
+   inkscape:window-width="2194"
+   inkscape:window-height="1163"
+   inkscape:window-x="1912"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />&#10;&#10;<g
+   id="SVGRepo_bgCarrier"
+   stroke-width="0" />&#10;&#10;<g
+   id="SVGRepo_tracerCarrier"
+   stroke-linecap="round"
+   stroke-linejoin="round" />&#10;&#10;<g
+   id="SVGRepo_iconCarrier"
+   transform="matrix(1.9316474,0,0,1.832188,-42.855781,-38.280646)"
+   style="fill:#666666;stroke:none;stroke-opacity:1"> <path
+   id="XMLID_32_"
+   d="m 46,53 c -1.8,0 -3.7,-0.8 -5,-2.1 -1.3,-1.3 -2,-3.1 -2,-4.9 0,-1.8 0.8,-3.6 2,-5 1.3,-1.3 3.1,-2 5,-2 1.8,0 3.6,0.8 4.9,2 1.3,1.3 2.1,3.1 2.1,5 0,1.8 -0.8,3.6 -2.1,4.9 C 49.6,52.2 47.8,53 46,53 Z"
+   style="fill:#666666;stroke:none;stroke-opacity:1" /> </g>&#10;&#10;</svg>

--- a/Code/Tools/Libs/GuiFoundation/QtResources/resources.qrc
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/resources.qrc
@@ -63,6 +63,8 @@
     <file>Icons/Clear.svg</file>
     <file>Icons/Help.svg</file>
     <file>Icons/Help-BW.svg</file>
+    <file>Icons/Manipulator-on.svg</file>
+    <file>Icons/Manipulator-off.svg</file>
     <file>Icons/Object.svg</file>
 	<file>Icons/Edit.svg</file>
   </qresource>

--- a/Code/Tools/Libs/GuiFoundation/QtResources/resources.qrc
+++ b/Code/Tools/Libs/GuiFoundation/QtResources/resources.qrc
@@ -63,6 +63,7 @@
     <file>Icons/Clear.svg</file>
     <file>Icons/Help.svg</file>
     <file>Icons/Help-BW.svg</file>
+    <file>Icons/Object.svg</file>
 	<file>Icons/Edit.svg</file>
   </qresource>
 </RCC>


### PR DESCRIPTION
* Spline manipulator is now available even when a node is selected. Makes spline editing much more comfortable.
* You can now cycle through available manipulators on the selected objects with Q, rather than just toggle it on and off.
* Properties with manipulators now also display a toggle button that makes it easier to notice.
* Game objects now always have an icon in the tree view
* Allow to set negative fog distances