### PR TITLE
Fixed crash when recreating decal atlas after profile change

### DIFF
--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenGraphAsset.cpp
@@ -98,7 +98,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenGraphAssetProperties, 1, ezRTTIDefaultA
   }
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenGraphAssetDocument, 9, ezRTTINoAllocator)
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezProcGenGraphAssetDocument, 10, ezRTTINoAllocator)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 

--- a/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
+++ b/Code/EditorPlugins/ProcGen/EditorPluginProcGen/ProcGenGraphAsset/ProcGenNodes.cpp
@@ -594,24 +594,11 @@ ezExpressionAST::Node* ezProcGen_Curve::GenerateExpressionASTNode(ezTempHashedSt
   {
     ezCurve1D curve;
     m_CurveData.ConvertToRuntimeData(curve);
-    curve.SortControlPoints();
-    curve.CreateLinearApproximation();
 
-    double fMinX, fMaxX;
-    curve.QueryExtents(fMinX, fMaxX);
-    fMinX = ezMath::Min(fMinX, 0.0);
-    fMaxX = ezMath::Max(fMaxX, 1.0);
-    const float fStep = static_cast<float>(fMaxX - fMinX) / static_cast<float>(m_uiNumSamples - 1);
+    ezSampledCurve1D sampledCurve;
+    curve.GenerateSampledCurve(m_uiNumSamples, sampledCurve).AssertSuccess();
 
-    ezDynamicArray<float> samples;
-    samples.SetCount(m_uiNumSamples);
-    for (ezUInt32 i = 0; i < m_uiNumSamples; ++i)
-    {
-      float x = static_cast<float>(fMinX + fStep * i);
-      samples[i] = curve.Evaluate(x);
-    }
-
-    uiCurveIndex = ref_context.m_SharedData.AddCurve(std::move(samples), fMinX, fMaxX);
+    uiCurveIndex = ref_context.m_SharedData.AddCurve(std::move(sampledCurve));
     EZ_ASSERT_DEV(uiCurveIndex <= 255, "Too many curves");
     if (!ref_context.m_CurveIndices.Contains(uiCurveIndex))
     {
@@ -620,11 +607,11 @@ ezExpressionAST::Node* ezProcGen_Curve::GenerateExpressionASTNode(ezTempHashedSt
   }
 
   ezExpressionAST::Node* arguments[] = {
-    pInput,
     out_ast.CreateConstant(uiCurveIndex, ezExpressionAST::DataType::Int),
+    pInput,
   };
 
-  return out_ast.CreateFunctionCall(ezProcGenExpressionFunctions::s_SampleCurveFunc.m_Desc, arguments);
+  return out_ast.CreateFunctionCall(ezExtendedExpressionFunctions::s_SampleCurveFunc.m_Desc, arguments);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/Foundation/CodeUtils/Expression/ExpressionDeclarations.h
+++ b/Code/Engine/Foundation/CodeUtils/Expression/ExpressionDeclarations.h
@@ -120,10 +120,17 @@ struct ezExpressionFunction
   ezExpression::ValidateGlobalDataFunction m_ValidateGlobalDataFunc;
 };
 
+/// \brief Contains the default expression functions that are always available in the expression system.
 struct EZ_FOUNDATION_DLL ezDefaultExpressionFunctions
 {
   static ezExpressionFunction s_RandomFunc;
   static ezExpressionFunction s_PerlinNoiseFunc;
+};
+
+/// \brief Contains extended expression functions that need to be registered explicitly with the expression VM.
+struct EZ_FOUNDATION_DLL ezExtendedExpressionFunctions
+{
+  static ezExpressionFunction s_SampleCurveFunc;
 };
 
 /// \brief Add this attribute a string property that should be interpreted as expression source.

--- a/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionDeclarations.cpp
+++ b/Code/Engine/Foundation/CodeUtils/Expression/Implementation/ExpressionDeclarations.cpp
@@ -3,6 +3,7 @@
 #include <Foundation/CodeUtils/Expression/ExpressionDeclarations.h>
 #include <Foundation/SimdMath/SimdNoise.h>
 #include <Foundation/SimdMath/SimdRandom.h>
+#include <Foundation/Tracks/Curve1D.h>
 
 using namespace ezExpression;
 
@@ -147,6 +148,8 @@ namespace
     }
   }
 
+  //////////////////////////////////////////////////////////////////////////
+
   static ezSimdPerlinNoise s_PerlinNoise(12345);
   static const ezEnum<RegisterType> s_PerlinNoiseInputTypes[] = {
     RegisterType::Float,
@@ -178,16 +181,92 @@ namespace
       ++pOutput;
     }
   }
+
+  //////////////////////////////////////////////////////////////////////////
+
+  static ezHashedString s_sCurves = ezMakeHashedString("Curves");
+
+  static const ezEnum<ezExpression::RegisterType> s_SampleCurvesInputTypes[] = {
+    ezExpression::RegisterType::Int,   // CurveIndex
+    ezExpression::RegisterType::Float, // X
+  };
+
+  static void SampleCurve(ezExpression::Inputs inputs, ezExpression::Output output, const ezExpression::GlobalData& globalData)
+  {
+    const ezVariantArray& curves = globalData.GetValue(s_sCurves)->Get<ezVariantArray>();
+    if (curves.IsEmpty())
+      return;
+
+    ezUInt32 uiCurveIndex = inputs[0].GetPtr()->i.x();
+    if (uiCurveIndex >= curves.GetCount())
+      return;
+
+    auto pSampledCurve = ezDynamicCast<const ezSampledCurve1D*>(curves[uiCurveIndex].Get<ezReflectedClass*>());
+    if (pSampledCurve == nullptr || pSampledCurve->m_Samples.IsEmpty())
+      return;
+
+    const ezUInt32 uiMaxIdx = pSampledCurve->m_Samples.GetCount() - 1;
+    const ezSimdVec4f vOffsetX = ezSimdVec4f(-pSampledCurve->m_fMinX);
+    const float fRange = pSampledCurve->m_fMaxX - pSampledCurve->m_fMinX;
+    const ezSimdVec4f vScale = ezSimdVec4f(fRange > 0.0f ? static_cast<float>(uiMaxIdx) / fRange : 0.0f);
+    const ezSimdVec4i vMaxIdx = ezSimdVec4i(uiMaxIdx);
+    const float* samples = pSampledCurve->m_Samples.GetData();
+
+    const ezExpression::Register* pX = inputs[1].GetPtr();
+    const ezExpression::Register* pXEnd = inputs[1].GetEndPtr();
+    ezExpression::Register* pOutput = output.GetPtr();
+
+    while (pX < pXEnd)
+    {
+      const ezSimdVec4f vT = (pX->f + vOffsetX).CompMul(vScale);
+      const ezSimdVec4i vIdx0 = ezSimdVec4i::Truncate(vT).CompMax(ezSimdVec4i::MakeZero()).CompMin(vMaxIdx);
+      const ezSimdVec4i vIdx1 = (vIdx0 + ezSimdVec4i(1)).CompMin(vMaxIdx);
+      const ezSimdVec4f vFrac = vT - vIdx0.ToFloat();
+
+      const float sample0[] = {samples[vIdx0.x()], samples[vIdx0.y()], samples[vIdx0.z()], samples[vIdx0.w()]};
+      const float sample1[] = {samples[vIdx1.x()], samples[vIdx1.y()], samples[vIdx1.z()], samples[vIdx1.w()]};
+      ezSimdVec4f vSample0, vSample1;
+      vSample0.Load<4>(sample0);
+      vSample1.Load<4>(sample1);
+
+      pOutput->f = ezSimdVec4f::Lerp(vSample0, vSample1, vFrac);
+
+      ++pX;
+      ++pOutput;
+    }
+  }
+
+  static ezResult SampleCurveValidate(const ezExpression::GlobalData& globalData)
+  {
+    if (!globalData.IsEmpty())
+    {
+      if (const ezVariant* pValue = globalData.GetValue(s_sCurves))
+      {
+        if (pValue->GetType() == ezVariantType::VariantArray)
+        {
+          return EZ_SUCCESS;
+        }
+      }
+    }
+
+    return EZ_FAILURE;
+  }
 } // namespace
 
 ezExpressionFunction ezDefaultExpressionFunctions::s_RandomFunc = {
-  {ezMakeHashedString("Random"), ezExpression::FunctionDesc::TypeList(s_RandomInputTypes), 1, RegisterType::Float},
+  {ezMakeHashedString("random"), ezExpression::FunctionDesc::TypeList(s_RandomInputTypes), 1, RegisterType::Float},
   &Random,
 };
 
 ezExpressionFunction ezDefaultExpressionFunctions::s_PerlinNoiseFunc = {
-  {ezMakeHashedString("PerlinNoise"), ezExpression::FunctionDesc::TypeList(s_PerlinNoiseInputTypes), 3, RegisterType::Float},
+  {ezMakeHashedString("perlinNoise"), ezExpression::FunctionDesc::TypeList(s_PerlinNoiseInputTypes), 3, RegisterType::Float},
   &PerlinNoise,
+};
+
+ezExpressionFunction ezExtendedExpressionFunctions::s_SampleCurveFunc = {
+  {ezMakeHashedString("sampleCurve"), ezExpression::FunctionDesc::TypeList(s_SampleCurvesInputTypes), 2, ezExpression::RegisterType::Float},
+  &SampleCurve,
+  &SampleCurveValidate,
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/Foundation/Tracks/Curve1D.h
+++ b/Code/Engine/Foundation/Tracks/Curve1D.h
@@ -4,10 +4,12 @@
 #include <Foundation/Containers/HybridArray.h>
 #include <Foundation/Math/Color.h>
 #include <Foundation/Math/Vec2.h>
+#include <Foundation/Reflection/Reflection.h>
 #include <Foundation/Types/Enum.h>
 
 class ezStreamWriter;
 class ezStreamReader;
+class ezSampledCurve1D;
 
 struct EZ_FOUNDATION_DLL ezCurveTangentMode
 {
@@ -150,6 +152,8 @@ public:
   void MakeAutoTangentLeft(ezUInt32 uiCpIdx);
   void MakeAutoTangentRight(ezUInt32 uiCpIdx);
 
+  ezResult GenerateSampledCurve(ezUInt32 uiNumSamples, ezSampledCurve1D& out_sampledCurve);
+
 private:
   void RecomputeLinearApproxExtremes();
   void ApproximateMinMaxValues(const ControlPoint& lhs, const ControlPoint& rhs, double& fMinY, double& fMaxY);
@@ -163,4 +167,23 @@ private:
   double m_fMinY, m_fMaxY;
   ezHybridArray<ControlPoint, 8> m_ControlPoints;
   ezHybridArray<ezVec2d, 24> m_LinearApproximation;
+};
+
+/// \brief A simple curve representation that only stores the precomputed sample points for linear interpolation.
+/// This allows fast evaluation at runtime at the cost of accuracy.
+///
+/// The curve is defined by a set of sample points, where the x values are evenly distributed between a specified minimum and maximum x value.
+/// The y values of the sample points can be used to approximate the curve through linear interpolation.
+class EZ_FOUNDATION_DLL ezSampledCurve1D : public ezReflectedClass
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezSampledCurve1D, ezReflectedClass);
+
+  ezDynamicArray<float> m_Samples;
+  float m_fMinX = 0.0f;
+  float m_fMaxX = 1.0f;
+
+  bool operator==(const ezSampledCurve1D& rhs) const;
+
+  void Save(ezStreamWriter& inout_stream) const;
+  ezResult Load(ezStreamReader& inout_stream);
 };

--- a/Code/Engine/Foundation/Tracks/Implementation/Curve1D.cpp
+++ b/Code/Engine/Foundation/Tracks/Implementation/Curve1D.cpp
@@ -563,3 +563,57 @@ void ezCurve1D::MakeAutoTangentRight(ezUInt32 uiCpIdx)
 
   tCP.m_RightTangent.Set((float)tangent.x, (float)tangent.y);
 }
+
+ezResult ezCurve1D::GenerateSampledCurve(ezUInt32 uiNumSamples, ezSampledCurve1D& out_sampledCurve)
+{
+  if (uiNumSamples < 2)
+    return EZ_FAILURE;
+
+  SortControlPoints();
+  CreateLinearApproximation();
+
+  double fMinX, fMaxX;
+  QueryExtents(fMinX, fMaxX);
+  fMinX = ezMath::Min(fMinX, 0.0);
+  fMaxX = ezMath::Max(fMaxX, 1.0);
+  const float fStep = static_cast<float>(fMaxX - fMinX) / static_cast<float>(uiNumSamples - 1);
+
+  ezDynamicArray<float> samples;
+  samples.SetCount(uiNumSamples);
+  for (ezUInt32 i = 0; i < uiNumSamples; ++i)
+  {
+    float x = static_cast<float>(fMinX + fStep * i);
+    samples[i] = static_cast<float>(Evaluate(x));
+  }
+
+  out_sampledCurve.m_Samples = std::move(samples);
+  out_sampledCurve.m_fMinX = static_cast<float>(fMinX);
+  out_sampledCurve.m_fMaxX = static_cast<float>(fMaxX);
+  return EZ_SUCCESS;
+}
+
+////////////////////////////////////////////////////////////////////////////
+
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezSampledCurve1D, 1, ezRTTIDefaultAllocator<ezSampledCurve1D>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
+bool ezSampledCurve1D::operator==(const ezSampledCurve1D& rhs) const
+{
+  return m_fMinX == rhs.m_fMinX && m_fMaxX == rhs.m_fMaxX && m_Samples == rhs.m_Samples;
+}
+
+void ezSampledCurve1D::Save(ezStreamWriter& inout_stream) const
+{
+  inout_stream.WriteArray(m_Samples).IgnoreResult();
+  inout_stream << m_fMinX;
+  inout_stream << m_fMaxX;
+}
+
+ezResult ezSampledCurve1D::Load(ezStreamReader& inout_stream)
+{
+  EZ_SUCCEED_OR_RETURN(inout_stream.ReadArray(m_Samples));
+  inout_stream >> m_fMinX;
+  inout_stream >> m_fMaxX;
+
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
+++ b/Code/Engine/RendererCore/Decals/Implementation/DecalManager.cpp
@@ -491,6 +491,26 @@ void ezDecalManager::OnEngineShutdown()
 // static
 void ezDecalManager::OnExtractionEvent(const ezRenderWorldExtractionEvent& e)
 {
+  if (e.m_Type == ezRenderWorldExtractionEvent::Type::BeginExtraction)
+  {
+    if (s_pData->m_RuntimeAtlas.IsInitialized() &&
+        (cvar_RenderingDecalsDynamicAtlasSize.HasDelayedSyncValueChanged() ||
+          s_uiLastConfigModification != ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter()))
+    {
+      EZ_LOCK(s_pData->m_Mutex);
+
+      s_pData->m_RuntimeAtlas.Deinitialize();
+
+      for (auto& decalInfo : s_pData->m_DecalInfos)
+      {
+        decalInfo.m_atlasAllocationId.Invalidate();
+        decalInfo.m_NextUpdateTime = ezTime::MakeFromHours(-1);
+      }
+
+      s_pData->EnsureResourceCreated();
+    }
+  }
+
   if (e.m_Type != ezRenderWorldExtractionEvent::Type::EndExtraction)
     return;
 
@@ -584,14 +604,6 @@ void ezDecalManager::OnRenderEvent(const ezRenderWorldRenderEvent& e)
 {
   if (e.m_Type != ezRenderWorldRenderEvent::Type::BeginRender)
     return;
-
-  if (s_pData->m_RuntimeAtlas.IsInitialized() &&
-      (cvar_RenderingDecalsDynamicAtlasSize.HasDelayedSyncValueChanged() ||
-        s_uiLastConfigModification != ezGameApplicationBase::GetGameApplicationBaseInstance()->GetPlatformProfile().GetLastModificationCounter()))
-  {
-    OnEngineShutdown();
-    OnEngineStartup();
-  }
 
   if (s_pData->m_RuntimeAtlas.IsInitialized() == false || s_pData->m_hPlaneMeshBuffer.IsValid() == false)
     return;

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Expression.cpp
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Expression.cpp
@@ -13,9 +13,6 @@
 #include <ParticlePlugin/System/ParticleSystemInstance.h>
 
 // clang-format off
-EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleExpressionCurveSamples, 1, ezRTTINoAllocator)
-EZ_END_DYNAMIC_REFLECTED_TYPE;
-
 EZ_BEGIN_STATIC_REFLECTED_TYPE(ezParticleExpressionInput, ezNoBase, 1, ezRTTIDefaultAllocator<ezParticleExpressionInput>)
 {
   EZ_BEGIN_PROPERTIES
@@ -46,79 +43,6 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezParticleBehavior_Expression, 1, ezRTTIDefaultAllocator<ezParticleBehavior_Expression>)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
-
-//////////////////////////////////////////////////////////////////////////
-// sampleCurve(index, at) expression function
-
-static ezHashedString s_sParticleCurves = ezMakeHashedString("ParticleCurves");
-
-static const ezEnum<ezExpression::RegisterType> s_SampleCurveTypes[] = {
-  ezExpression::RegisterType::Int,   // index
-  ezExpression::RegisterType::Float, // at
-};
-
-static void SampleCurveFunc(ezExpression::Inputs inputs, ezExpression::Output output, const ezExpression::GlobalData& globalData)
-{
-  const ezVariant* pCurvesVar = globalData.GetValue(s_sParticleCurves);
-  if (pCurvesVar == nullptr)
-    return;
-
-  const ezVariantArray& curves = pCurvesVar->Get<ezVariantArray>();
-
-  const ezUInt32 uiCurveIndex = static_cast<ezUInt32>(inputs[0].GetPtr()->i.x());
-  if (uiCurveIndex >= curves.GetCount())
-    return;
-
-  const auto* pSamples = static_cast<const ezParticleExpressionCurveSamples*>(curves[uiCurveIndex].Get<ezReflectedClass*>());
-  if (pSamples == nullptr || pSamples->m_Samples.IsEmpty())
-    return;
-
-  const ezUInt32 uiMaxIdx = pSamples->m_Samples.GetCount() - 1;
-  const ezSimdVec4f vOffsetX = ezSimdVec4f(-pSamples->m_fMinX);
-  const float fRange = pSamples->m_fMaxX - pSamples->m_fMinX;
-  const ezSimdVec4f vScale = ezSimdVec4f(fRange > 0.0f ? static_cast<float>(uiMaxIdx) / fRange : 0.0f);
-  const ezSimdVec4i vMaxIdx = ezSimdVec4i(uiMaxIdx);
-  const float* samples = pSamples->m_Samples.GetData();
-
-  const ezExpression::Register* pAt = inputs[1].GetPtr();
-  const ezExpression::Register* pAtEnd = inputs[1].GetEndPtr();
-  ezExpression::Register* pOutput = output.GetPtr();
-
-  while (pAt < pAtEnd)
-  {
-    const ezSimdVec4f vT = (pAt->f + vOffsetX).CompMul(vScale);
-    const ezSimdVec4i vIdx0 = ezSimdVec4i::Truncate(vT).CompMax(ezSimdVec4i::MakeZero()).CompMin(vMaxIdx);
-    const ezSimdVec4i vIdx1 = (vIdx0 + ezSimdVec4i(1)).CompMin(vMaxIdx);
-    const ezSimdVec4f vFrac = vT - vIdx0.ToFloat();
-
-    const float sample0[] = {samples[vIdx0.x()], samples[vIdx0.y()], samples[vIdx0.z()], samples[vIdx0.w()]};
-    const float sample1[] = {samples[vIdx1.x()], samples[vIdx1.y()], samples[vIdx1.z()], samples[vIdx1.w()]};
-    ezSimdVec4f vSample0, vSample1;
-    vSample0.Load<4>(sample0);
-    vSample1.Load<4>(sample1);
-
-    pOutput->f = ezSimdVec4f::Lerp(vSample0, vSample1, vFrac);
-
-    ++pAt;
-    ++pOutput;
-  }
-}
-
-static ezResult SampleCurveValidate(const ezExpression::GlobalData& globalData)
-{
-  if (const ezVariant* pValue = globalData.GetValue(s_sParticleCurves))
-  {
-    if (pValue->GetType() == ezVariantType::VariantArray)
-      return EZ_SUCCESS;
-  }
-  return EZ_FAILURE;
-}
-
-static ezExpressionFunction s_SampleCurveExprFunc = {
-  {ezMakeHashedString("sampleCurve"), ezExpression::FunctionDesc::TypeList(s_SampleCurveTypes), 2, ezExpression::RegisterType::Float},
-  &SampleCurveFunc,
-  &SampleCurveValidate,
-};
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -324,7 +248,7 @@ void ezParticleBehaviorFactory_Expression::CompileExpression(const ezParticleEff
   }
 
   ezExpressionParser parser;
-  parser.RegisterFunction(s_SampleCurveExprFunc.m_Desc);
+  parser.RegisterFunction(ezExtendedExpressionFunctions::s_SampleCurveFunc.m_Desc);
 
   ezExpressionParser::Options options;
   ezExpressionAST ast;
@@ -390,23 +314,8 @@ void ezParticleBehaviorFactory_Expression::BuildCurveSamples()
       continue;
     }
 
-    runtimeCurve.CreateLinearApproximation();
-
-    double fMinX, fMaxX;
-    runtimeCurve.QueryExtents(fMinX, fMaxX);
-
-    samples.m_fMinX = static_cast<float>(fMinX);
-    samples.m_fMaxX = static_cast<float>(fMaxX);
-
     constexpr ezUInt32 k_uiSampleCount = 256;
-    samples.m_Samples.SetCount(k_uiSampleCount);
-
-    const double fRange = fMaxX - fMinX;
-    for (ezUInt32 j = 0; j < k_uiSampleCount; ++j)
-    {
-      const double x = (fRange > 0.0) ? (fMinX + fRange * (j / static_cast<double>(k_uiSampleCount - 1))) : fMinX;
-      samples.m_Samples[j] = static_cast<float>(runtimeCurve.Evaluate(x));
-    }
+    runtimeCurve.GenerateSampledCurve(k_uiSampleCount, samples).AssertSuccess();
   }
 }
 
@@ -417,7 +326,7 @@ ezParticleBehavior_Expression::ezParticleBehavior_Expression()
   // execute last
   m_fPriority = 1000.0f;
 
-  m_VM.RegisterFunction(s_SampleCurveExprFunc);
+  m_VM.RegisterFunction(ezExtendedExpressionFunctions::s_SampleCurveFunc);
 }
 
 void ezParticleBehavior_Expression::CreateRequiredStreams()
@@ -601,9 +510,9 @@ void ezParticleBehavior_Expression::UpdateElements(ezUInt64 uiStartIndex, ezUInt
     curves.SetCount(m_pCurveSamples->GetCount());
     for (ezUInt32 i = 0; i < m_pCurveSamples->GetCount(); ++i)
     {
-      curves[i] = ezVariant(const_cast<ezParticleExpressionCurveSamples*>(&(*m_pCurveSamples)[i]));
+      curves[i] = ezVariant(const_cast<ezSampledCurve1D*>(&(*m_pCurveSamples)[i]));
     }
-    globalData.Insert(s_sParticleCurves, curves);
+    globalData.Insert(ezMakeHashedString("Curves"), curves);
   }
 
   if (m_VM.Execute(*m_pByteCode, vmInputs, vmOutputs, uiCount, globalData).Failed())

--- a/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Expression.h
+++ b/Code/EnginePlugins/ParticlePlugin/Behavior/ParticleBehavior_Expression.h
@@ -12,16 +12,6 @@
 
 EZ_DECLARE_FLAGS(ezUInt16, ezParticleStreamMask, Position, Velocity, Color, Size, LifeTime, Rotation);
 
-/// Pre-sampled curve data for fast lookups via sampleCurve() in expressions.
-struct EZ_PARTICLEPLUGIN_DLL ezParticleExpressionCurveSamples : public ezReflectedClass
-{
-  EZ_ADD_DYNAMIC_REFLECTION(ezParticleExpressionCurveSamples, ezReflectedClass);
-
-  ezDynamicArray<float> m_Samples; ///< Uniformly spaced samples covering [m_fMinX, m_fMaxX].
-  float m_fMinX = 0.0f;            ///< X position of the first sample.
-  float m_fMaxX = 1.0f;            ///< X position of the last sample.
-};
-
 /// One input slot for the expression behavior, holding either an inline or shared curve.
 struct EZ_PARTICLEPLUGIN_DLL ezParticleExpressionInput
 {
@@ -76,7 +66,7 @@ private:
   bool m_bUsesDiscard = false;
   ezBitflags<ezParticleStreamMask> m_InputStreams;
   ezBitflags<ezParticleStreamMask> m_OutputStreams;
-  ezDynamicArray<ezParticleExpressionCurveSamples> m_CurveSamples;
+  ezDynamicArray<ezSampledCurve1D> m_CurveSamples;
   ezDynamicArray<ezHashedString> m_FloatParamNames;
   ezDynamicArray<ezHashedString> m_ColorParamNames;
 };
@@ -96,7 +86,7 @@ public:
   const ezExpressionByteCode* m_pByteCode = nullptr;
 
   /// Points to the pre-sampled curve data owned by the factory. Null if there are no curve inputs.
-  const ezDynamicArray<ezParticleExpressionCurveSamples>* m_pCurveSamples = nullptr;
+  const ezDynamicArray<ezSampledCurve1D>* m_pCurveSamples = nullptr;
 
   /// Points to the effect parameter name lists owned by the factory. Null if no parameters are used.
   const ezDynamicArray<ezHashedString>* m_pFloatParamNames = nullptr;

--- a/Code/EnginePlugins/ProcGenPlugin/Declarations.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Declarations.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ProcGenPlugin/ProcGenPluginDLL.h>
+
 #include <Core/ResourceManager/ResourceHandle.h>
 #include <Core/World/Declarations.h>
 #include <Foundation/CodeUtils/Expression/ExpressionByteCode.h>
@@ -7,7 +9,6 @@
 #include <Foundation/SimdMath/SimdTransform.h>
 #include <Foundation/Strings/HashedString.h>
 #include <Foundation/Types/SharedPtr.h>
-#include <ProcGenPlugin/ProcGenPluginDLL.h>
 
 using ezColorGradientResourceHandle = ezTypedResourceHandle<class ezColorGradientResource>;
 using ezPrefabResourceHandle = ezTypedResourceHandle<class ezPrefabResource>;

--- a/Code/EnginePlugins/ProcGenPlugin/Resources/Implementation/ProcGenGraphSharedData.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Resources/Implementation/ProcGenGraphSharedData.cpp
@@ -4,27 +4,6 @@
 
 namespace ezProcGenInternal
 {
-  EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(CurveData, 1, ezRTTIDefaultAllocator<CurveData>)
-  EZ_END_DYNAMIC_REFLECTED_TYPE;
-
-  void CurveData::Save(ezStreamWriter& inout_stream) const
-  {
-    inout_stream.WriteArray(m_Samples).IgnoreResult();
-    inout_stream << m_fMinX;
-    inout_stream << m_fMaxX;
-  }
-
-  ezResult CurveData::Load(ezStreamReader& inout_stream)
-  {
-    EZ_SUCCEED_OR_RETURN(inout_stream.ReadArray(m_Samples));
-    inout_stream >> m_fMinX;
-    inout_stream >> m_fMaxX;
-
-    return EZ_SUCCESS;
-  }
-
-  ////////////////////////////////////////////////////////////////////////////
-
   ezUInt32 GraphSharedData::AddTagSet(const ezTagSet& tagSet)
   {
     ezUInt32 uiIndex = m_TagSets.IndexOf(tagSet);
@@ -36,24 +15,16 @@ namespace ezProcGenInternal
     return uiIndex;
   }
 
-  ezUInt32 GraphSharedData::AddCurve(ezDynamicArray<float>&& samples, float fMinX, float fMaxX)
+  ezUInt32 GraphSharedData::AddCurve(ezSampledCurve1D&& curve)
   {
-    for (ezUInt32 uiIndex = 0; uiIndex < m_Curves.GetCount(); ++uiIndex)
+    ezUInt32 uiIndex = m_Curves.IndexOf(curve);
+    if (uiIndex == ezInvalidIndex)
     {
-      const CurveData& existingCurve = m_Curves[uiIndex];
-      if (existingCurve.m_Samples == samples && existingCurve.m_fMinX == fMinX && existingCurve.m_fMaxX == fMaxX)
-      {
-        return uiIndex;
-      }
+      uiIndex = m_Curves.GetCount();
+      m_Curves.PushBack(std::move(curve));
     }
 
-    const ezUInt32 uiNewIndex = m_Curves.GetCount();
-    CurveData& curve = m_Curves.ExpandAndGetRef();
-    curve.m_Samples = std::move(samples);
-    curve.m_fMinX = fMinX;
-    curve.m_fMaxX = fMaxX;
-
-    return uiNewIndex;
+    return uiIndex;
   }
 
   const ezTagSet& GraphSharedData::GetTagSet(ezUInt32 uiIndex) const
@@ -61,7 +32,7 @@ namespace ezProcGenInternal
     return m_TagSets[uiIndex];
   }
 
-  const CurveData& GraphSharedData::GetCurve(ezUInt32 uiIndex) const
+  const ezSampledCurve1D& GraphSharedData::GetCurve(ezUInt32 uiIndex) const
   {
     return m_Curves[uiIndex];
   }
@@ -114,7 +85,7 @@ namespace ezProcGenInternal
 
       for (ezUInt32 i = 0; i < uiCount; ++i)
       {
-        CurveData curveData;
+        ezSampledCurve1D curveData;
         EZ_SUCCEED_OR_RETURN(curveData.Load(inout_stream));
         m_Curves.PushBack(std::move(curveData));
       }

--- a/Code/EnginePlugins/ProcGenPlugin/Resources/ProcGenGraphSharedData.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Resources/ProcGenGraphSharedData.h
@@ -1,37 +1,26 @@
 #pragma once
 
+#include <Foundation/Tracks/Curve1D.h>
 #include <Foundation/Types/TagSet.h>
 #include <ProcGenPlugin/Declarations.h>
 
 namespace ezProcGenInternal
 {
-  class EZ_PROCGENPLUGIN_DLL CurveData : public ezReflectedClass
-  {
-    EZ_ADD_DYNAMIC_REFLECTION(CurveData, ezReflectedClass);
-
-    ezDynamicArray<float> m_Samples;
-    float m_fMinX = 0.0f;
-    float m_fMaxX = 1.0f;
-
-    void Save(ezStreamWriter& inout_stream) const;
-    ezResult Load(ezStreamReader& inout_stream);
-  };
-
   class EZ_PROCGENPLUGIN_DLL GraphSharedData : public GraphSharedDataBase
   {
   public:
     ezUInt32 AddTagSet(const ezTagSet& tagSet);
-    ezUInt32 AddCurve(ezDynamicArray<float>&& samples, float fMinX, float fMaxX);
+    ezUInt32 AddCurve(ezSampledCurve1D&& curve);
 
     const ezTagSet& GetTagSet(ezUInt32 uiIndex) const;
-    const CurveData& GetCurve(ezUInt32 uiIndex) const;
+    const ezSampledCurve1D& GetCurve(ezUInt32 uiIndex) const;
 
     void Save(ezStreamWriter& inout_stream) const;
     ezResult Load(ezStreamReader& inout_stream);
 
   private:
     ezDynamicArray<ezTagSet> m_TagSets;
-    ezDynamicArray<CurveData> m_Curves;
+    ezDynamicArray<ezSampledCurve1D> m_Curves;
   };
 
 } // namespace ezProcGenInternal

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/PlacementTask.cpp
@@ -24,9 +24,9 @@ PlacementTask::PlacementTask(PlacementData* pData, const char* szName)
 {
   ConfigureTask(szName, ezTaskNesting::Maybe);
 
+  m_VM.RegisterFunction(ezExtendedExpressionFunctions::s_SampleCurveFunc);
   m_VM.RegisterFunction(ezProcGenExpressionFunctions::s_ApplyVolumesFunc);
   m_VM.RegisterFunction(ezProcGenExpressionFunctions::s_GetInstanceSeedFunc);
-  m_VM.RegisterFunction(ezProcGenExpressionFunctions::s_SampleCurveFunc);
 }
 
 PlacementTask::~PlacementTask() = default;

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/Utils.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/Utils.cpp
@@ -126,92 +126,18 @@ namespace
 
     return EZ_FAILURE;
   }
-
-  //////////////////////////////////////////////////////////////////////////
-
-  static ezHashedString s_sCurves = ezMakeHashedString("Curves");
-
-  static const ezEnum<ezExpression::RegisterType> s_SampleCurvesTypes[] = {
-    ezExpression::RegisterType::Float, // X
-    ezExpression::RegisterType::Int,   // CurveIndex
-  };
-
-  static void SampleCurve(ezExpression::Inputs inputs, ezExpression::Output output, const ezExpression::GlobalData& globalData)
-  {
-    const ezVariantArray& curves = globalData.GetValue(s_sCurves)->Get<ezVariantArray>();
-    if (curves.IsEmpty())
-      return;
-
-    ezUInt32 uiCurveIndex = inputs[1].GetPtr()->i.x();
-    auto pCurveData = ezDynamicCast<const ezProcGenInternal::CurveData*>(curves[uiCurveIndex].Get<ezReflectedClass*>());
-    if (pCurveData == nullptr)
-      return;
-
-    const ezUInt32 uiMaxIdx = pCurveData->m_Samples.GetCount() - 1;
-    const ezSimdVec4f vOffsetX = ezSimdVec4f(-pCurveData->m_fMinX);
-    const ezSimdVec4f vScale = ezSimdVec4f(static_cast<float>(uiMaxIdx) / (pCurveData->m_fMaxX - pCurveData->m_fMinX));
-    const ezSimdVec4i vMaxIdx = ezSimdVec4i(uiMaxIdx);
-    const float* samples = pCurveData->m_Samples.GetData();
-
-    const ezExpression::Register* pX = inputs[0].GetPtr();
-    const ezExpression::Register* pXEnd = inputs[0].GetEndPtr();
-    ezExpression::Register* pOutput = output.GetPtr();
-
-    while (pX < pXEnd)
-    {
-      const ezSimdVec4f vT = (pX->f + vOffsetX).CompMul(vScale);
-      const ezSimdVec4i vIdx0 = ezSimdVec4i::Truncate(vT).CompMax(ezSimdVec4i::MakeZero()).CompMin(vMaxIdx);
-      const ezSimdVec4i vIdx1 = (vIdx0 + ezSimdVec4i(1)).CompMin(vMaxIdx);
-      const ezSimdVec4f vFrac = vT - vIdx0.ToFloat();
-
-      const float sample0[] = {samples[vIdx0.x()], samples[vIdx0.y()], samples[vIdx0.z()], samples[vIdx0.w()]};
-      const float sample1[] = {samples[vIdx1.x()], samples[vIdx1.y()], samples[vIdx1.z()], samples[vIdx1.w()]};
-      ezSimdVec4f vSample0, vSample1;
-      vSample0.Load<4>(sample0);
-      vSample1.Load<4>(sample1);
-
-      const ezSimdVec4f vResult = ezSimdVec4f::Lerp(vSample0, vSample1, vFrac);
-      pOutput->f = vResult;
-
-      ++pX;
-      ++pOutput;
-    }
-  }
-
-  static ezResult SampleCurveValidate(const ezExpression::GlobalData& globalData)
-  {
-    if (!globalData.IsEmpty())
-    {
-      if (const ezVariant* pValue = globalData.GetValue(s_sCurves))
-      {
-        if (pValue->GetType() == ezVariantType::VariantArray)
-        {
-          return EZ_SUCCESS;
-        }
-      }
-    }
-
-    return EZ_FAILURE;
-  }
-
 } // namespace
 
 ezExpressionFunction ezProcGenExpressionFunctions::s_ApplyVolumesFunc = {
-  {ezMakeHashedString("ApplyVolumes"), ezExpression::FunctionDesc::TypeList(s_ApplyVolumesTypes), 5, ezExpression::RegisterType::Float},
+  {ezMakeHashedString("applyVolumes"), ezExpression::FunctionDesc::TypeList(s_ApplyVolumesTypes), 5, ezExpression::RegisterType::Float},
   &ApplyVolumes,
   &ApplyVolumesValidate,
 };
 
 ezExpressionFunction ezProcGenExpressionFunctions::s_GetInstanceSeedFunc = {
-  {ezMakeHashedString("GetInstanceSeed"), ezExpression::FunctionDesc::TypeList(), 0, ezExpression::RegisterType::Int},
+  {ezMakeHashedString("getInstanceSeed"), ezExpression::FunctionDesc::TypeList(), 0, ezExpression::RegisterType::Int},
   &GetInstanceSeed,
   &GetInstanceSeedValidate,
-};
-
-ezExpressionFunction ezProcGenExpressionFunctions::s_SampleCurveFunc = {
-  {ezMakeHashedString("SampleCurve"), ezExpression::FunctionDesc::TypeList(s_SampleCurvesTypes), 2, ezExpression::RegisterType::Float},
-  &SampleCurve,
-  &SampleCurveValidate,
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -262,8 +188,10 @@ void ezProcGenGlobalData::SetCurves(const ezProcGenInternal::Output& output, ezE
   if (curveIndices.IsEmpty())
     return;
 
+  const ezHashedString sCurves = ezMakeHashedString("Curves");
+
   ezVariantArray curves;
-  if (ezVariant* curvesVar = ref_globalData.GetValue(s_sCurves))
+  if (ezVariant* curvesVar = ref_globalData.GetValue(sCurves))
   {
     curves = curvesVar->Get<ezVariantArray>();
   }
@@ -282,5 +210,5 @@ void ezProcGenGlobalData::SetCurves(const ezProcGenInternal::Output& output, ezE
     curves[curveIndex] = ezVariant(&curveData);
   }
 
-  ref_globalData.Insert(s_sCurves, curves);
+  ref_globalData.Insert(sCurves, curves);
 }

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/VertexColorTask.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Implementation/VertexColorTask.cpp
@@ -32,9 +32,9 @@ using namespace ezProcGenInternal;
 
 VertexColorTask::VertexColorTask()
 {
+  m_VM.RegisterFunction(ezExtendedExpressionFunctions::s_SampleCurveFunc);
   m_VM.RegisterFunction(ezProcGenExpressionFunctions::s_ApplyVolumesFunc);
   m_VM.RegisterFunction(ezProcGenExpressionFunctions::s_GetInstanceSeedFunc);
-  m_VM.RegisterFunction(ezProcGenExpressionFunctions::s_SampleCurveFunc);
 }
 
 VertexColorTask::~VertexColorTask() = default;

--- a/Code/EnginePlugins/ProcGenPlugin/Tasks/Utils.h
+++ b/Code/EnginePlugins/ProcGenPlugin/Tasks/Utils.h
@@ -16,7 +16,6 @@ struct EZ_PROCGENPLUGIN_DLL ezProcGenExpressionFunctions
 {
   static ezExpressionFunction s_ApplyVolumesFunc;
   static ezExpressionFunction s_GetInstanceSeedFunc;
-  static ezExpressionFunction s_SampleCurveFunc;
 };
 
 class EZ_PROCGENPLUGIN_DLL ezProcGenGlobalData

--- a/Code/UnitTests/GameEngineTest/ProcGenTest/ProcGenTest.cpp
+++ b/Code/UnitTests/GameEngineTest/ProcGenTest/ProcGenTest.cpp
@@ -146,7 +146,7 @@ ezResult ezGameEngineTestProcGen::TestOutput(const ezHashedString& sOutputName, 
   if (m_pVM == nullptr)
   {
     m_pVM = EZ_DEFAULT_NEW(ezExpressionVM);
-    m_pVM->RegisterFunction(ezProcGenExpressionFunctions::s_SampleCurveFunc);
+    m_pVM->RegisterFunction(ezExtendedExpressionFunctions::s_SampleCurveFunc);
   }
 
   ezTempHybridArray<ezProcessingStream, 8> inputs;


### PR DESCRIPTION
* When the platform profile changed the runtime decal manager was completely destroyed which resulted in a crash when trying to access internal data the next frame. Now only the atlas is destroyed and recreated which should fix this issue. Fixes #1868 
* Also cleaned up curve sampling in expressions