### PR TITLE
Visual script and proc gen fixes, light shafts tint color

### DIFF
--- a/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptVariable.cpp
+++ b/Code/EditorPlugins/VisualScript/EditorPluginVisualScript/VisualScriptGraph/VisualScriptVariable.cpp
@@ -154,6 +154,12 @@ ezResult ezQtVisualScriptVariableWidget::GetVariantTypeDisplayName(ezVariantType
       type == ezVariantType::UInt16 ||
       type == ezVariantType::UInt32 ||
       type == ezVariantType::UInt64 ||
+      type == ezVariantType::Vector2I ||
+      type == ezVariantType::Vector3I ||
+      type == ezVariantType::Vector4I ||
+      type == ezVariantType::Vector2U ||
+      type == ezVariantType::Vector3U ||
+      type == ezVariantType::Vector4U ||
       type == ezVariantType::StringView ||
       type == ezVariantType::TempHashedString)
     return EZ_FAILURE;

--- a/Code/Engine/RendererCore/Components/Implementation/LightShaftsComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/LightShaftsComponent.cpp
@@ -15,7 +15,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 //////////////////////////////////////////////////////////////////////////
 
 // clang-format off
-EZ_BEGIN_COMPONENT_TYPE(ezLightShaftsComponent, 1, ezComponentMode::Static)
+EZ_BEGIN_COMPONENT_TYPE(ezLightShaftsComponent, 2, ezComponentMode::Static)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -23,11 +23,11 @@ EZ_BEGIN_COMPONENT_TYPE(ezLightShaftsComponent, 1, ezComponentMode::Static)
     EZ_ACCESSOR_PROPERTY("BrightnessThreshold", GetBrightnessThreshold, SetBrightnessThreshold)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(0.0f)),
     EZ_ACCESSOR_PROPERTY("MaxBrightness", GetMaxBrightness, SetMaxBrightness)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant()), new ezDefaultValueAttribute(10.0f)),
     EZ_ACCESSOR_PROPERTY("DiskMaskRadius", GetDiskMaskRadius, SetDiskMaskRadius)->AddAttributes(new ezClampValueAttribute(0.0f, 2.0f), new ezDefaultValueAttribute(0.1f)),
+    EZ_ACCESSOR_PROPERTY("TintColor", GetTintColor, SetTintColor),
   }
   EZ_END_PROPERTIES;
   EZ_BEGIN_MESSAGEHANDLERS
   {
-    EZ_MESSAGE_HANDLER(ezMsgUpdateLocalBounds, OnUpdateLocalBounds),
     EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
   }
   EZ_END_MESSAGEHANDLERS;
@@ -43,23 +43,6 @@ EZ_END_COMPONENT_TYPE;
 ezLightShaftsComponent::ezLightShaftsComponent() = default;
 ezLightShaftsComponent::~ezLightShaftsComponent() = default;
 
-void ezLightShaftsComponent::Deinitialize()
-{
-  ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
-
-  SUPER::Deinitialize();
-}
-
-void ezLightShaftsComponent::OnActivated()
-{
-  GetOwner()->UpdateLocalBounds();
-}
-
-void ezLightShaftsComponent::OnDeactivated()
-{
-  GetOwner()->UpdateLocalBounds();
-}
-
 void ezLightShaftsComponent::SerializeComponent(ezWorldWriter& inout_stream) const
 {
   SUPER::SerializeComponent(inout_stream);
@@ -69,6 +52,7 @@ void ezLightShaftsComponent::SerializeComponent(ezWorldWriter& inout_stream) con
   s << m_fMaxBrightness;
   s << m_fBrightnessThreshold;
   s << m_fDiskMaskRadius;
+  s << m_TintColor;
 }
 
 void ezLightShaftsComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -82,6 +66,17 @@ void ezLightShaftsComponent::DeserializeComponent(ezWorldReader& inout_stream)
   s >> m_fMaxBrightness;
   s >> m_fBrightnessThreshold;
   s >> m_fDiskMaskRadius;
+
+  if (uiVersion >= 2)
+  {
+    s >> m_TintColor;
+  }
+}
+
+ezResult ezLightShaftsComponent::GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg)
+{
+  ref_bAlwaysVisible = true;
+  return EZ_SUCCESS;
 }
 
 void ezLightShaftsComponent::SetIntensity(float fIntensity)
@@ -90,7 +85,7 @@ void ezLightShaftsComponent::SetIntensity(float fIntensity)
 
   if (IsActiveAndInitialized())
   {
-    ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
+    InvalidateCachedRenderData();
   }
 }
 
@@ -100,7 +95,7 @@ void ezLightShaftsComponent::SetBrightnessThreshold(float fBrightnessThreshold)
 
   if (IsActiveAndInitialized())
   {
-    ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
+    InvalidateCachedRenderData();
   }
 }
 
@@ -110,7 +105,7 @@ void ezLightShaftsComponent::SetMaxBrightness(float fMaxBrightness)
 
   if (IsActiveAndInitialized())
   {
-    ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
+    InvalidateCachedRenderData();
   }
 }
 
@@ -120,13 +115,18 @@ void ezLightShaftsComponent::SetDiskMaskRadius(float fDiskMaskRadius)
 
   if (IsActiveAndInitialized())
   {
-    ezRenderWorld::DeleteCachedRenderData(GetOwner()->GetHandle(), GetHandle());
+    InvalidateCachedRenderData();
   }
 }
 
-void ezLightShaftsComponent::OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg)
+void ezLightShaftsComponent::SetTintColor(const ezColorGammaUB& color)
 {
-  msg.SetAlwaysVisible(GetOwner()->IsDynamic() ? ezDefaultSpatialDataCategories::RenderDynamic : ezDefaultSpatialDataCategories::RenderStatic);
+  m_TintColor = color;
+
+  if (IsActiveAndInitialized())
+  {
+    InvalidateCachedRenderData();
+  }
 }
 
 void ezLightShaftsComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
@@ -146,6 +146,7 @@ void ezLightShaftsComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg)
   pRenderData->m_fMaxBrightness = m_fMaxBrightness;
   pRenderData->m_fBrightnessThreshold = m_fBrightnessThreshold;
   pRenderData->m_fDiskMaskRadius = m_fDiskMaskRadius;
+  pRenderData->m_TintColor = m_TintColor;
 
   msg.AddRenderData(pRenderData, ezDefaultRenderDataCategories::Light, ezRenderData::Caching::IfStatic);
 }

--- a/Code/Engine/RendererCore/Components/LightShaftsComponent.h
+++ b/Code/Engine/RendererCore/Components/LightShaftsComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/World/SettingsComponentManager.h>
+#include <RendererCore/Components/RenderComponent.h>
 #include <RendererCore/Pipeline/RenderData.h>
 
 struct ezMsgUpdateLocalBounds;
@@ -15,24 +16,28 @@ public:
   float m_fMaxBrightness;
   float m_fBrightnessThreshold;
   float m_fDiskMaskRadius;
+  ezColorGammaUB m_TintColor;
 };
 
 using ezLightShaftsComponentManager = ezSettingsComponentManager<class ezLightShaftsComponent>;
 
 /// \brief Adds a light shaft effect to the scene. Usually, this component is attached to the same game object as a directional light.
-class EZ_RENDERERCORE_DLL ezLightShaftsComponent : public ezComponent
+class EZ_RENDERERCORE_DLL ezLightShaftsComponent : public ezRenderComponent
 {
-  EZ_DECLARE_COMPONENT_TYPE(ezLightShaftsComponent, ezComponent, ezLightShaftsComponentManager);
+  EZ_DECLARE_COMPONENT_TYPE(ezLightShaftsComponent, ezRenderComponent, ezLightShaftsComponentManager);
 
   //////////////////////////////////////////////////////////////////////////
   // ezComponent
 
 public:
-  virtual void Deinitialize() override;
-  virtual void OnActivated() override;
-  virtual void OnDeactivated() override;
   virtual void SerializeComponent(ezWorldWriter& inout_stream) const override;
   virtual void DeserializeComponent(ezWorldReader& inout_stream) override;
+
+  //////////////////////////////////////////////////////////////////////////
+  // ezRenderComponent
+
+public:
+  virtual ezResult GetLocalBounds(ezBoundingBoxSphere& ref_bounds, bool& ref_bAlwaysVisible, ezMsgUpdateLocalBounds& ref_msg) override;
 
   //////////////////////////////////////////////////////////////////////////
   // ezLightShaftsComponent
@@ -60,12 +65,17 @@ public:
   void SetDiskMaskRadius(float fDiskMaskRadius);                // [ property ]
   float GetDiskMaskRadius() const { return m_fDiskMaskRadius; } // [ property ]
 
+  /// \brief The light shafts pick its color from the sky pixels at the center. The tint color can be used to add an additional color tint to the light shafts.
+  void SetTintColor(const ezColorGammaUB& color);                    // [ property ]
+  const ezColorGammaUB& GetTintColor() const { return m_TintColor; } // [ property ]
+
 private:
-  void OnUpdateLocalBounds(ezMsgUpdateLocalBounds& msg);
   void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
 
   float m_fIntensity = 1.0f;
   float m_fMaxBrightness = 10.0f;
   float m_fBrightnessThreshold = 0.0f;
   float m_fDiskMaskRadius = 0.1f;
+
+  ezColorGammaUB m_TintColor = ezColor::White;
 };

--- a/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
+++ b/Code/Engine/RendererCore/Lights/ClusteredDataExtractor.h
@@ -50,6 +50,7 @@ public:
   float m_fLightShaftsMaxBrightness = 0.0f;
   float m_fLightShaftsBrightnessThreshold = 0.0f;
   float m_fLightShaftsDiskMaskRadius = 0.0f;
+  ezColorGammaUB m_LightShaftsTintColor = ezColor::White;
 };
 
 /// Extracts lights, decals, and reflection probes into a clustered data structure.

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataExtractor.cpp
@@ -374,6 +374,7 @@ void ezClusteredDataExtractor::PostSortAndBatch(const ezView& view, const ezDyna
           pData->m_fLightShaftsMaxBrightness = pLightShaftsRenderData->m_fMaxBrightness;
           pData->m_fLightShaftsBrightnessThreshold = pLightShaftsRenderData->m_fBrightnessThreshold;
           pData->m_fLightShaftsDiskMaskRadius = pLightShaftsRenderData->m_fDiskMaskRadius;
+          pData->m_LightShaftsTintColor = pLightShaftsRenderData->m_TintColor;
         }
         else
         {

--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LightShaftsPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/LightShaftsPass.cpp
@@ -246,6 +246,8 @@ void ezLightShaftsPass::UpdateConstantBuffer(const ezClusteredDataCPU& clustered
 {
   ezLightShaftsConstants* pConstants = ezRenderContext::GetConstantBufferData<ezLightShaftsConstants>(m_hConstantBuffer);
 
+  pConstants->LightShaftsTintColor = clusteredData.m_LightShaftsTintColor;
+
   pConstants->LightShaftsIntensity = clusteredData.m_fLightShaftsIntensity;
   pConstants->LightShaftsMaxBrightness = clusteredData.m_fLightShaftsMaxBrightness;
   pConstants->LightShaftsBrightnessThreshold = clusteredData.m_fLightShaftsBrightnessThreshold;

--- a/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
+++ b/Code/EnginePlugins/ProcGenPlugin/Components/Implementation/ProcPlacementComponent.cpp
@@ -205,7 +205,13 @@ void ezProcPlacementComponentManager::PreparePlace(const ezWorldModule::UpdateCo
           }
         }
 
-        m_NewTiles.PushBackRange(outputContext.m_pUpdateTilesTask->GetNewTiles());
+        for (const auto& newTile : outputContext.m_pUpdateTilesTask->GetNewTiles())
+        {
+          if (!m_NewTiles.Contains(newTile))
+          {
+            m_NewTiles.PushBack(newTile);
+          }
+        }
       }
     }
 

--- a/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptData.cpp
+++ b/Code/EnginePlugins/VisualScriptPlugin/Runtime/VisualScriptData.cpp
@@ -370,14 +370,11 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
 {
   auto scriptDataType = dataOffset.GetType();
 
-#if EZ_ENABLED(EZ_COMPILE_FOR_DEBUG)
   // pExpectedType == nullptr means that the caller expects an ezVariant so we decide solely based on the scriptDataType.
-  // We set the pExpectedType to the equivalent of the scriptDataType here so we don't need to check for pExpectedType == nullptr in all the asserts below.
   if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezVariant>())
   {
     pExpectedType = ezVisualScriptDataType::GetRtti(scriptDataType);
   }
-#endif
 
   switch (scriptDataType)
   {
@@ -393,7 +390,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       return GetData<ezUInt8>(dataOffset);
 
     case ezVisualScriptDataType::Int:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezInt32>())
+      if (pExpectedType == ezGetStaticRTTI<ezInt32>())
       {
         return GetData<ezInt32>(dataOffset);
       }
@@ -429,7 +426,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       return GetData<ezColor>(dataOffset);
 
     case ezVisualScriptDataType::Vector2:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezVec2>())
+      if (pExpectedType == ezGetStaticRTTI<ezVec2>())
       {
         return GetData<ezVec2>(dataOffset);
       }
@@ -447,7 +444,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       break;
 
     case ezVisualScriptDataType::Vector3:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezVec3>())
+      if (pExpectedType == ezGetStaticRTTI<ezVec3>())
       {
         return GetData<ezVec3>(dataOffset);
       }
@@ -465,7 +462,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       break;
 
     case ezVisualScriptDataType::Vector4:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezVec4>())
+      if (pExpectedType == ezGetStaticRTTI<ezVec4>())
       {
         return GetData<ezVec4>(dataOffset);
       }
@@ -499,7 +496,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       return GetData<ezAngle>(dataOffset);
 
     case ezVisualScriptDataType::String:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezString>() || pExpectedType == ezGetStaticRTTI<const char*>())
+      if (pExpectedType == ezGetStaticRTTI<ezString>() || pExpectedType == ezGetStaticRTTI<const char*>())
       {
         return GetData<ezString>(dataOffset);
       }
@@ -511,7 +508,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       break;
 
     case ezVisualScriptDataType::HashedString:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezHashedString>())
+      if (pExpectedType == ezGetStaticRTTI<ezHashedString>())
       {
         return GetData<ezHashedString>(dataOffset);
       }
@@ -523,7 +520,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       break;
 
     case ezVisualScriptDataType::GameObject:
-      if (pExpectedType == nullptr || pExpectedType == ezGetStaticRTTI<ezGameObject>())
+      if (pExpectedType == ezGetStaticRTTI<ezGameObject>())
       {
         return GetPointerData(dataOffset, uiExecutionCounter);
       }
@@ -535,7 +532,7 @@ ezVariant ezVisualScriptDataStorage::GetDataAsVariant(DataOffset dataOffset, con
       break;
 
     case ezVisualScriptDataType::Component:
-      if (pExpectedType == nullptr || pExpectedType->IsDerivedFrom<ezComponent>())
+      if (pExpectedType->IsDerivedFrom<ezComponent>())
       {
         return GetPointerData(dataOffset, uiExecutionCounter);
       }

--- a/Data/Base/Shaders/Pipeline/LightShaftsConstants.h
+++ b/Data/Base/Shaders/Pipeline/LightShaftsConstants.h
@@ -5,6 +5,8 @@
 
 CONSTANT_BUFFER2(ezLightShaftsConstants, 3, BG_RENDER_PASS)
 {
+  COLOR4F(LightShaftsTintColor);
+
   FLOAT1(LightShaftsIntensity);
   FLOAT1(LightShaftsMaxBrightness);
   FLOAT1(LightShaftsBrightnessThreshold);

--- a/Data/Base/Shaders/Pipeline/LightShaftsMask.ezShader
+++ b/Data/Base/Shaders/Pipeline/LightShaftsMask.ezShader
@@ -45,5 +45,5 @@ float4 main(PS_IN input) : SV_Target
   float distToOrigin = length((input.TexCoord0 - LightShaftsOriginUVs) * float2(aspectRatio, 1));
   float diskMask = smoothstep(LightShaftsDiskMaskRadius, 0.0, distToOrigin);
 
-  return float4(sceneColor * (occlusion * edgeMask * diskMask * LightShaftsIntensity), 1);
+  return float4(sceneColor * LightShaftsTintColor.rgb * (occlusion * edgeMask * diskMask * LightShaftsIntensity), 1);
 }

--- a/Data/Samples/Testing Chambers/Prefabs/Sky.ezPrefab
+++ b/Data/Samples/Testing Chambers/Prefabs/Sky.ezPrefab
@@ -74,7 +74,7 @@ o
 		s %AssetType{"Prefab"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{13699384296078697487,10650164635913670525}}
-		u4 %Hash{1217016306571904369}
+		u4 %Hash{10110616545193450388}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{13850971636205318926,9059842567955752105}}
@@ -147,7 +147,7 @@ o
 {
 	Uuid %id{u4{14737824997050113921,4701838202341345428}}
 	s %t{"ezLightShaftsComponent"}
-	u3 %v{1}
+	u3 %v{2}
 	p
 	{
 		b %Active{1}
@@ -155,6 +155,7 @@ o
 		f %DiskMaskRadius{0xCDCCCC3D}
 		f %Intensity{0x9A99993E}
 		f %MaxBrightness{0x00002041}
+		ColorGamma %TintColor{u1{255,0,0,255}}
 	}
 }
 o
@@ -787,11 +788,11 @@ o
 		VarArray %Attributes{}
 		s %Flags{"ezTypeFlags::Class|ezTypeFlags::Minimal"}
 		VarArray %Functions{}
-		s %ParentTypeName{"ezComponent"}
+		s %ParentTypeName{"ezRenderComponent"}
 		s %PluginName{"Static"}
 		VarArray %Properties{}
 		s %TypeName{"ezLightShaftsComponent"}
-		u3 %TypeVersion{1}
+		u3 %TypeVersion{2}
 	}
 }
 o

--- a/Data/UnitTests/GameEngineTest/VisualScript/Data/BlackboardScript.ezVisualScriptClassAsset
+++ b/Data/UnitTests/GameEngineTest/VisualScript/Data/BlackboardScript.ezVisualScriptClassAsset
@@ -25,7 +25,7 @@ o
 		s %AssetType{"VisualScriptClass"}
 		VarArray %Dependencies{}
 		Uuid %DocumentID{u4{11410758142063444412,5252298219396556696}}
-		u4 %Hash{5765133772987612893}
+		u4 %Hash{17129424742192830212}
 		VarArray %MetaInfo
 		{
 			Uuid{u4{15977922773034048496,17053314215109263305}}
@@ -535,7 +535,7 @@ o
 	u3 %v{1}
 	p
 	{
-		Invalid %Fallback{}
+		i3 %Fallback{0}
 		HashedString %Name{s{"Counter"}}
 		Vec2 %Node::Pos{f{0x4D264C44,0x68D991C3}}
 	}


### PR DESCRIPTION
* Fixed visual script GetDataAsVariant. Fixes #1888
* Proc placement: don't add new tiles multiple times when visible from multiple views. Fixes #1894
* Light shafts tint color