### PR TITLE
Apply root motion in post-async phase

### DIFF
--- a/Code/Engine/GameEngine/Animation/Skeletal/AnimationControllerComponent.h
+++ b/Code/Engine/GameEngine/Animation/Skeletal/AnimationControllerComponent.h
@@ -22,6 +22,7 @@ public:
 
 private:
   void Update(const ezWorldModule::UpdateContext& context);
+  void ApplyRootMotion(const ezWorldModule::UpdateContext& context);
   void ResourceEvent(const ezResourceEvent& e);
 
   ezDeque<ezComponentHandle> m_ComponentsToReset;
@@ -72,6 +73,7 @@ public:
 
 protected:
   void Update();
+  void ApplyRootMotion();
 
   ezEnum<ezRootMotionMode> m_RootMotionMode;
 
@@ -80,4 +82,7 @@ protected:
   ezAnimPoseGenerator m_PoseGenerator;
 
   ezTime m_ElapsedTimeSinceUpdate = ezTime::MakeZero();
+
+  ezVec3 m_vPendingTranslation = ezVec3::MakeZero();
+  ezAngle m_PendingRotationX, m_PendingRotationY, m_PendingRotationZ;
 };

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimationControllerComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/AnimationControllerComponent.cpp
@@ -158,13 +158,14 @@ void ezAnimationControllerComponent::Update()
 
   m_ElapsedTimeSinceUpdate = ezTime::MakeZero();
 
-  ezVec3 translation;
-  ezAngle rotationX;
-  ezAngle rotationY;
-  ezAngle rotationZ;
-  m_AnimController.GetRootMotion(translation, rotationX, rotationY, rotationZ);
+  m_AnimController.GetRootMotion(m_vPendingTranslation, m_PendingRotationX, m_PendingRotationY, m_PendingRotationZ);
+}
 
-  ezRootMotionMode::Apply(m_RootMotionMode, GetOwner(), translation, rotationX, rotationY, rotationZ);
+void ezAnimationControllerComponent::ApplyRootMotion()
+{
+  ezRootMotionMode::Apply(m_RootMotionMode, GetOwner(), m_vPendingTranslation, m_PendingRotationX, m_PendingRotationY, m_PendingRotationZ);
+  m_vPendingTranslation = ezVec3::MakeZero();
+  m_PendingRotationX = m_PendingRotationY = m_PendingRotationZ = ezAngle();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -177,12 +178,22 @@ ezAnimationControllerComponentManager::ezAnimationControllerComponentManager(ezW
 
 void ezAnimationControllerComponentManager::Initialize()
 {
-  auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezAnimationControllerComponentManager::Update, this);
-  desc.m_bOnlyUpdateWhenSimulating = true;
-  desc.m_Phase = ezWorldUpdatePhase::Async;
-  desc.m_uiAsyncPhaseBatchSize = 2;
+  {
+    auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezAnimationControllerComponentManager::Update, this);
+    desc.m_bOnlyUpdateWhenSimulating = true;
+    desc.m_Phase = ezWorldUpdatePhase::Async;
+    desc.m_uiAsyncPhaseBatchSize = 2;
 
-  this->RegisterUpdateFunction(desc);
+    this->RegisterUpdateFunction(desc);
+  }
+
+  {
+    auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezAnimationControllerComponentManager::ApplyRootMotion, this);
+    desc.m_bOnlyUpdateWhenSimulating = true;
+    desc.m_Phase = ezWorldUpdatePhase::PostAsync;
+
+    this->RegisterUpdateFunction(desc);
+  }
 
   ezResourceManager::GetResourceEvents().AddEventHandler(ezMakeDelegate(&ezAnimationControllerComponentManager::ResourceEvent, this));
 }
@@ -238,6 +249,18 @@ void ezAnimationControllerComponentManager::ResourceEvent(const ezResourceEvent&
           }
         }
       }
+    }
+  }
+}
+
+void ezAnimationControllerComponentManager::ApplyRootMotion(const ezWorldModule::UpdateContext& context)
+{
+  for (auto it = this->m_ComponentStorage.GetIterator(context.m_uiFirstComponentIndex, context.m_uiComponentCount); it.IsValid(); ++it)
+  {
+    ComponentType* pComponent = it;
+    if (pComponent->m_RootMotionMode != ezRootMotionMode::Ignore && pComponent->IsActiveAndInitialized())
+    {
+      pComponent->ApplyRootMotion();
     }
   }
 }

--- a/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
+++ b/Code/Engine/GameEngine/Animation/Skeletal/Implementation/SimpleAnimationComponent.cpp
@@ -191,16 +191,13 @@ void ezSimpleAnimationComponent::Update()
 
   if (m_RootMotionMode != ezRootMotionMode::Ignore)
   {
-    ezVec3 vRootMotion = tDiff.AsFloatInSeconds() * m_fSpeed * animDesc.m_vConstantRootMotion;
+    m_vPendingRootMotion = tDiff.AsFloatInSeconds() * m_fSpeed * animDesc.m_vConstantRootMotion;
 
     const bool bReverse = GetUserFlag(0);
     if (bReverse)
     {
-      vRootMotion = -vRootMotion;
+      m_vPendingRootMotion = -m_vPendingRootMotion;
     }
-
-    // only applies positional root motion
-    ezRootMotionMode::Apply(m_RootMotionMode, GetOwner(), vRootMotion, ezAngle(), ezAngle(), ezAngle());
   }
 
   if (poseGen.GetCurrentPose().IsEmpty())
@@ -223,6 +220,14 @@ void ezSimpleAnimationComponent::Update()
       SetActiveFlag(false);
     }
   }
+}
+
+void ezSimpleAnimationComponent::ApplyRootMotion()
+{
+  // only applies positional root motion; called from the PostAsync phase to allow safe game object modification
+  ezRootMotionMode::Apply(m_RootMotionMode, GetOwner(), m_vPendingRootMotion, ezAngle(), ezAngle(), ezAngle());
+
+  m_vPendingRootMotion = ezVec3::MakeZero();
 }
 
 bool ezSimpleAnimationComponent::UpdatePlaybackTime(ezTime tDiff, const ezEventTrack& eventTrack, ezAnimPoseEventTrackSampleMode& out_trackSampling)
@@ -327,6 +332,14 @@ void ezSimpleAnimationComponentManager::Initialize()
 
     this->RegisterUpdateFunction(desc);
   }
+
+  {
+    auto desc = EZ_CREATE_MODULE_UPDATE_FUNCTION_DESC(ezSimpleAnimationComponentManager::ApplyRootMotion, this);
+    desc.m_Phase = ezWorldUpdatePhase::PostAsync;
+    desc.m_bOnlyUpdateWhenSimulating = true;
+
+    this->RegisterUpdateFunction(desc);
+  }
 }
 
 void ezSimpleAnimationComponentManager::Update(const ezWorldModule::UpdateContext& context)
@@ -336,6 +349,17 @@ void ezSimpleAnimationComponentManager::Update(const ezWorldModule::UpdateContex
     if (it->IsActiveAndInitialized())
     {
       it->Update();
+    }
+  }
+}
+
+void ezSimpleAnimationComponentManager::ApplyRootMotion(const ezWorldModule::UpdateContext& context)
+{
+  for (auto it = this->m_ComponentStorage.GetIterator(context.m_uiFirstComponentIndex, context.m_uiComponentCount); it.IsValid(); ++it)
+  {
+    if (it->m_RootMotionMode != ezRootMotionMode::Ignore && it->IsActiveAndInitialized())
+    {
+      it->ApplyRootMotion();
     }
   }
 }

--- a/Code/Engine/GameEngine/Animation/Skeletal/SimpleAnimationComponent.h
+++ b/Code/Engine/GameEngine/Animation/Skeletal/SimpleAnimationComponent.h
@@ -30,6 +30,7 @@ public:
 
 private:
   void Update(const ezWorldModule::UpdateContext& context);
+  void ApplyRootMotion(const ezWorldModule::UpdateContext& context);
 };
 
 
@@ -79,6 +80,7 @@ public:
 
 protected:
   void Update();
+  void ApplyRootMotion();
   bool UpdatePlaybackTime(ezTime tDiff, const ezEventTrack& eventTrack, ezAnimPoseEventTrackSampleMode& out_trackSampling);
 
   ezEnum<ezRootMotionMode> m_RootMotionMode;
@@ -87,6 +89,7 @@ protected:
   ezSkeletonResourceHandle m_hSkeleton;
   ezTime m_ElapsedTimeSinceUpdate = ezTime::MakeZero();
   bool m_bEnableIK = false;
+  ezVec3 m_vPendingRootMotion = ezVec3::MakeZero();
 
   ozz::vector<ozz::math::SoaTransform> m_OzzLocalTransforms; // TODO: could be frame allocated
 };


### PR DESCRIPTION
Fixes an issue where root motion might get applied on a thread that has no write access to the world.