### PR TITLE
Extra render data category for mesh decals

### DIFF
--- a/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/Passes/TransparentForwardRenderPass.cpp
@@ -51,21 +51,32 @@ void ezTransparentForwardRenderPass::Execute(const ezRenderViewContext& renderVi
   ezGALDevice* pDevice = ezGALDevice::GetDefaultDevice();
 
   {
-    UpdateSceneColorTexture(renderViewContext, hSceneColor, pColorInput->m_TextureHandle);
-
-    SetupResources(renderViewContext.m_pRenderContext->GetCommandEncoder(), renderViewContext, inputs, outputs);
     SetupPermutationVars(renderViewContext);
     SetupLighting(renderViewContext);
 
-    ezBindGroupBuilder& bindGroupRenderPass = renderViewContext.m_pRenderContext->GetBindGroup(EZ_GAL_BIND_GROUP_RENDER_PASS);
-    bindGroupRenderPass.BindTexture("SceneColor", hSceneColor);
-    bindGroupRenderPass.BindSampler("SceneColorSampler", m_hSceneColorSamplerState);
-    bindGroupRenderPass.BindTexture("SSAOTexture", m_hWhiteTexture, ezResourceAcquireMode::BlockTillLoaded);
-    bindGroupRenderPass.BindTexture("ShadowMasksTexture", m_hWhiteTexture, ezResourceAcquireMode::BlockTillLoaded);
+    {
+      SetupResources(renderViewContext.m_pRenderContext->GetCommandEncoder(), renderViewContext, inputs, outputs);
 
-    RenderObjects(renderViewContext);
+      RenderDataWithCategory(renderViewContext, ezDefaultRenderDataCategories::LitMeshDecal);
 
-    renderViewContext.m_pRenderContext->EndRendering();
+      renderViewContext.m_pRenderContext->EndRendering();
+    }
+
+    UpdateSceneColorTexture(renderViewContext, hSceneColor, pColorInput->m_TextureHandle);
+
+    {
+      SetupResources(renderViewContext.m_pRenderContext->GetCommandEncoder(), renderViewContext, inputs, outputs);
+
+      ezBindGroupBuilder& bindGroupRenderPass = renderViewContext.m_pRenderContext->GetBindGroup(EZ_GAL_BIND_GROUP_RENDER_PASS);
+      bindGroupRenderPass.BindTexture("SceneColor", hSceneColor);
+      bindGroupRenderPass.BindSampler("SceneColorSampler", m_hSceneColorSamplerState);
+      bindGroupRenderPass.BindTexture("SSAOTexture", m_hWhiteTexture, ezResourceAcquireMode::BlockTillLoaded);
+      bindGroupRenderPass.BindTexture("ShadowMasksTexture", m_hWhiteTexture, ezResourceAcquireMode::BlockTillLoaded);
+
+      RenderObjects(renderViewContext);
+
+      renderViewContext.m_pRenderContext->EndRendering();
+    }
   }
   ezGPUResourcePool::GetDefaultInstance()->ReturnRenderTarget(hSceneColor);
 }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/RenderData.cpp
@@ -144,6 +144,7 @@ ezRenderData::Category ezDefaultRenderDataCategories::LitMaskedStatic = ezRender
 ezRenderData::Category ezDefaultRenderDataCategories::LitMaskedDynamic = ezRenderData::RegisterCategory("LitMaskedDynamic", &ezRenderSortingFunctions::ByRenderDataThenFrontToBackFunc);
 ezRenderData::Category ezDefaultRenderDataCategories::LitMasked = ezRenderData::RegisterRedirectedCategory("LitMasked", ezDefaultRenderDataCategories::LitMaskedStatic, ezDefaultRenderDataCategories::LitMaskedDynamic);
 
+ezRenderData::Category ezDefaultRenderDataCategories::LitMeshDecal = ezRenderData::RegisterCategory("LitMeshDecal", &ezRenderSortingFunctions::ByRenderDataThenFrontToBackFunc);
 ezRenderData::Category ezDefaultRenderDataCategories::LitTransparent = ezRenderData::RegisterCategory("LitTransparent", &ezRenderSortingFunctions::BackToFrontThenByRenderDataFunc);
 ezRenderData::Category ezDefaultRenderDataCategories::LitForeground = ezRenderData::RegisterCategory("LitForeground", &ezRenderSortingFunctions::ByRenderDataThenFrontToBackFunc);
 

--- a/Code/Engine/RendererCore/Pipeline/RenderData.h
+++ b/Code/Engine/RendererCore/Pipeline/RenderData.h
@@ -140,6 +140,7 @@ struct EZ_RENDERERCORE_DLL ezDefaultRenderDataCategories
   static ezRenderData::Category LitMasked;
   static ezRenderData::Category LitMaskedStatic;
   static ezRenderData::Category LitMaskedDynamic;
+  static ezRenderData::Category LitMeshDecal;
   static ezRenderData::Category LitTransparent;
   static ezRenderData::Category LitForeground;
   static ezRenderData::Category LensEffects;

--- a/Data/Base/Shaders/Pipeline/ScreenSpaceShadow.ezShader
+++ b/Data/Base/Shaders/Pipeline/ScreenSpaceShadow.ezShader
@@ -18,6 +18,7 @@ void main(uint3 groupID : SV_GroupID, uint groupThreadID : SV_GroupThreadID)
   dispatchParams.SetDefaults();
   dispatchParams.SurfaceThickness = SurfaceThickness;
   dispatchParams.ShadowContrast = ShadowContrast;
+  dispatchParams.IgnoreEdgePixels = true;
 
   dispatchParams.LightCoordinate = LightCoordinate;
   dispatchParams.WaveOffset = WaveOffset;

--- a/Data/Samples/Testing Chambers/Materials/MeshDecal.ezMaterialAsset
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecal.ezMaterialAsset
@@ -14,7 +14,7 @@ o
 			s{"Materials/MeshDecalMaterial.ezShader"}
 		}
 		Uuid %DocumentID{u4{13372529112349640576,5516946423271476972}}
-		u4 %Hash{898857983437426815}
+		u4 %Hash{7011489966184224663}
 		VarArray %MetaInfo{}
 		VarArray %Outputs{}
 		VarArray %PackageDeps
@@ -41,7 +41,7 @@ o
 	{
 		f %AlphaContrast{0x00000040}
 		s %AlphaTexture{"{ bac42aa1-3f34-43ff-a2ef-0347758a705a }"}
-		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_DITHERED"}
+		s %BLEND_MODE{"BLEND_MODE::BLEND_MODE_TRANSPARENT"}
 		Color %BaseColor{f{0xBD5EE53E,0x424BCA3E,0x349AB53E,0x9796163F}}
 		f %DepthBias{0x0000803F}
 		f %MaskThreshold{0x0000803E}

--- a/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
+++ b/Data/Samples/Testing Chambers/Materials/MeshDecalMaterial.ezShader
@@ -33,7 +33,7 @@ FLOAT1(AlphaContrast);
 
 [MATERIALCONFIG]
 
-#include <Shaders/Materials/MaterialConfig.h>
+RenderDataCategory = LitMeshDecal
 
 [RENDERSTATE]
 


### PR DESCRIPTION
* Added an extra render data category for mesh decals so they can be rendered as transparent on top of regular meshes but still end up in the resolved scene color texture for refraction effects
* Fixed "line" artifacts with screen space shadows on large flat surfaces