### PR TITLE
Added support for 2D array textures

### DIFF
--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/MaterialAsset.cpp
@@ -133,9 +133,9 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezMaterialAssetProperties, 4, ezRTTIDefaultAlloc
   {
     EZ_ENUM_ACCESSOR_PROPERTY("ShaderMode", ezMaterialShaderMode, GetShaderMode, SetShaderMode),
     EZ_ACCESSOR_PROPERTY("BaseMaterial", GetBaseMaterial, SetBaseMaterial)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Material", ezDependencyFlags::Transform | ezDependencyFlags::Thumbnail | ezDependencyFlags::Package)),
-    EZ_ACCESSOR_PROPERTY("Surface", GetSurface, SetSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
-    EZ_MEMBER_PROPERTY("AssetFilterTags", m_sAssetFilterTags),
     EZ_ACCESSOR_PROPERTY("Shader", GetShader, SetShader)->AddAttributes(new ezFileBrowserAttribute("Select Shader", "*.ezShader", "CustomAction_CreateShaderFromTemplate")),
+    EZ_MEMBER_PROPERTY("AssetFilterTags", m_sAssetFilterTags),
+    EZ_ACCESSOR_PROPERTY("Surface", GetSurface, SetSurface)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     // This property holds the phantom shader properties type so it is only used in the object graph but not actually in the instance of this object.
     EZ_ACCESSOR_PROPERTY("ShaderProperties", GetShaderProperties, SetShaderProperties)->AddFlags(ezPropertyFlags::PointerOwner)->AddAttributes(new ezContainerAttribute(false, false, false)),
   }
@@ -1000,7 +1000,7 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
         if (pCategory == nullptr)
           continue;
 
-        if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture 2D"))
+        if (ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture 2D") || ezStringUtils::IsEqual(pCategory->GetCategory(), "Texture 2D Array"))
         {
           Textures2D.PushBack(pProp);
         }
@@ -1119,10 +1119,14 @@ ezStatus ezMaterialAssetDocument::WriteMaterialAsset(ezStreamWriter& inout_strea
         ezStringBuilder sFilename, sResourceName;
         ezDynamicArray<ezUInt32> content;
 
-        // embed 2D texture data
+        // embed 2D texture data (not array textures - their lowres data has a different DDS structure)
         for (auto prop : Textures2D)
         {
           EZ_ASSERT_DEBUG(pObject != nullptr, "Need object to write out texture2d");
+          const ezCategoryAttribute* pCat = prop->GetAttributeByType<ezCategoryAttribute>();
+          if (pCat != nullptr && ezStringUtils::IsEqual(pCat->GetCategory(), "Texture 2D Array"))
+            continue;
+
           const char* szName = prop->GetPropertyName();
           sValue = pObject->GetTypeAccessor().GetValue(szName).ConvertTo<ezString>();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/MaterialAsset/ShaderTypeRegistry.cpp
@@ -179,6 +179,11 @@ namespace
         ref_attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 2D"));
         ref_attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "CompatibleAsset_Texture_2D"));
       }
+      else if (ref_def.m_sType.IsEqual("Texture2DArray"))
+      {
+        ref_attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 2D Array"));
+        ref_attributes.PushBack(EZ_DEFAULT_NEW(ezAssetBrowserAttribute, "CompatibleAsset_Texture_2D"));
+      }
       else if (ref_def.m_sType.IsEqual("Texture3D"))
       {
         ref_attributes.PushBack(EZ_DEFAULT_NEW(ezCategoryAttribute, "Texture 3D"));

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAsset.cpp
@@ -245,98 +245,125 @@ ezStatus ezTextureAssetDocument::RunTexConv(const char* szTargetFile, const ezAs
   arguments << "-addressW" << ToWrapMode(pProp->m_AddressModeW);
   arguments << "-filter" << ToFilterMode(pProp->m_TextureFilter);
 
-  const ezInt32 iNumInputFiles = pProp->GetNumInputFiles();
-  for (ezInt32 i = 0; i < iNumInputFiles; ++i)
+  if (pProp->m_bIsArrayTexture)
   {
-    temp.SetFormat("-in{0}", i);
+    arguments << "-type" << "Texture2DArray";
 
-    if (ezStringUtils::IsNullOrEmpty(pProp->GetInputFile(i)))
+    for (ezUInt32 i = 0; i < pProp->m_ArraySlices.GetCount(); ++i)
+    {
+      if (pProp->m_ArraySlices[i].IsEmpty())
+        continue;
+
+      ezStringBuilder sAbsPath = pProp->m_ArraySlices[i];
+      sAbsPath.MakeCleanPath();
+      if (!sAbsPath.IsAbsolutePath())
+        ezQtEditorApp::GetSingleton()->MakeDataDirectoryRelativePathAbsolute(sAbsPath);
+
+      temp.SetFormat("-in{0}", i);
+      arguments << temp.GetData();
+      arguments << QString::fromUtf8(sAbsPath.GetData());
+
+      temp.SetFormat("-rgba{0}", i);
+      arguments << temp.GetData();
+      temp.SetFormat("in{0}.rgba", i);
+      arguments << temp.GetData();
+    }
+  }
+  else
+  {
+    const ezInt32 iNumInputFiles = pProp->GetNumInputFiles();
+    for (ezInt32 i = 0; i < iNumInputFiles; ++i)
+    {
+      temp.SetFormat("-in{0}", i);
+
+      if (ezStringUtils::IsNullOrEmpty(pProp->GetInputFile(i)))
+        break;
+
+      arguments << temp.GetData();
+      arguments << QString(pProp->GetAbsoluteInputFilePath(i).GetData());
+    }
+
+    switch (pProp->GetChannelMapping())
+    {
+      case ezTexture2DChannelMappingEnum::R1:
+      {
+        arguments << "-r";
+        arguments << "in0.r"; // always linear
+      }
       break;
 
-    arguments << temp.GetData();
-    arguments << QString(pProp->GetAbsoluteInputFilePath(i).GetData());
-  }
+      case ezTexture2DChannelMappingEnum::RG1:
+      {
+        arguments << "-rg";
+        arguments << "in0.rg"; // always linear
+      }
+      break;
 
-  switch (pProp->GetChannelMapping())
-  {
-    case ezTexture2DChannelMappingEnum::R1:
-    {
-      arguments << "-r";
-      arguments << "in0.r"; // always linear
-    }
-    break;
+      case ezTexture2DChannelMappingEnum::R1_G2:
+      {
+        arguments << "-r";
+        arguments << "in0.r";
+        arguments << "-g";
+        arguments << "in1.g"; // always linear
+      }
+      break;
 
-    case ezTexture2DChannelMappingEnum::RG1:
-    {
-      arguments << "-rg";
-      arguments << "in0.rg"; // always linear
-    }
-    break;
+      case ezTexture2DChannelMappingEnum::RGB1:
+      {
+        arguments << "-rgb";
+        arguments << "in0.rgb";
+      }
+      break;
 
-    case ezTexture2DChannelMappingEnum::R1_G2:
-    {
-      arguments << "-r";
-      arguments << "in0.r";
-      arguments << "-g";
-      arguments << "in1.g"; // always linear
-    }
-    break;
+      case ezTexture2DChannelMappingEnum::RGB1_ABLACK:
+      {
+        arguments << "-rgb";
+        arguments << "in0.rgb";
+        arguments << "-a";
+        arguments << "black";
+      }
+      break;
 
-    case ezTexture2DChannelMappingEnum::RGB1:
-    {
-      arguments << "-rgb";
-      arguments << "in0.rgb";
-    }
-    break;
+      case ezTexture2DChannelMappingEnum::R1_G2_B3:
+      {
+        arguments << "-r";
+        arguments << "in0.r";
+        arguments << "-g";
+        arguments << "in1.r";
+        arguments << "-b";
+        arguments << "in2.r";
+      }
+      break;
 
-    case ezTexture2DChannelMappingEnum::RGB1_ABLACK:
-    {
-      arguments << "-rgb";
-      arguments << "in0.rgb";
-      arguments << "-a";
-      arguments << "black";
-    }
-    break;
+      case ezTexture2DChannelMappingEnum::RGBA1:
+      {
+        arguments << "-rgba";
+        arguments << "in0.rgba";
+      }
+      break;
 
-    case ezTexture2DChannelMappingEnum::R1_G2_B3:
-    {
-      arguments << "-r";
-      arguments << "in0.r";
-      arguments << "-g";
-      arguments << "in1.r";
-      arguments << "-b";
-      arguments << "in2.r";
-    }
-    break;
+      case ezTexture2DChannelMappingEnum::RGB1_A2:
+      {
+        arguments << "-rgb";
+        arguments << "in0.rgb";
+        arguments << "-a";
+        arguments << "in1.r";
+      }
+      break;
 
-    case ezTexture2DChannelMappingEnum::RGBA1:
-    {
-      arguments << "-rgba";
-      arguments << "in0.rgba";
+      case ezTexture2DChannelMappingEnum::R1_G2_B3_A4:
+      {
+        arguments << "-r";
+        arguments << "in0.r";
+        arguments << "-g";
+        arguments << "in1.r";
+        arguments << "-b";
+        arguments << "in2.r";
+        arguments << "-a";
+        arguments << "in3.r";
+      }
+      break;
     }
-    break;
-
-    case ezTexture2DChannelMappingEnum::RGB1_A2:
-    {
-      arguments << "-rgb";
-      arguments << "in0.rgb";
-      arguments << "-a";
-      arguments << "in1.r";
-    }
-    break;
-
-    case ezTexture2DChannelMappingEnum::R1_G2_B3_A4:
-    {
-      arguments << "-r";
-      arguments << "in0.r";
-      arguments << "-g";
-      arguments << "in1.r";
-      arguments << "-b";
-      arguments << "in2.r";
-      arguments << "-a";
-      arguments << "in3.r";
-    }
-    break;
   }
 
   EZ_SUCCEED_OR_RETURN(ezQtEditorApp::GetSingleton()->ExecuteTool("ezTexConv", arguments, 180, ezLog::GetThreadLocalLogSystem()));
@@ -366,10 +393,22 @@ void ezTextureAssetDocument::UpdateAssetDocumentInfo(ezAssetDocumentInfo* pInfo)
     pInfo->m_Outputs.Insert("LOWRES");
   }
 
+  // Always clean up any stale Input1-4 dependencies (may be present if the asset was previously non-array mode).
   for (ezUInt32 i = GetProperties()->GetNumInputFiles(); i < 4; ++i)
   {
-    // remove unused dependencies
     pInfo->m_TransformDependencies.Remove(GetProperties()->GetInputFile(i));
+  }
+
+  if (GetProperties()->m_bIsArrayTexture)
+  {
+    // Register all array slices as transform dependencies (dynamic array, not auto-registered by the base class).
+    for (const ezString& sSlice : GetProperties()->m_ArraySlices)
+    {
+      if (!sSlice.IsEmpty())
+      {
+        pInfo->m_TransformDependencies.Insert(sSlice);
+      }
+    }
   }
 }
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.cpp
@@ -28,24 +28,27 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureAssetProperties, 5, ezRTTIDefaultAlloca
   {
     EZ_MEMBER_PROPERTY("IsRenderTarget", m_bIsRenderTarget)->AddAttributes(new ezHiddenAttribute),
     EZ_ENUM_MEMBER_PROPERTY("Usage", ezTexConvUsage, m_TextureUsage),
+    EZ_ENUM_MEMBER_PROPERTY("CompressionMode", ezTexConvCompressionMode, m_CompressionMode),
 
     EZ_ENUM_MEMBER_PROPERTY("Format", ezRenderTargetFormat, m_RtFormat),
     EZ_ENUM_MEMBER_PROPERTY("Resolution", ezTexture2DResolution, m_Resolution),
     EZ_MEMBER_PROPERTY("CVarResScale", m_fCVarResolutionScale)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.1f, 10.0f)),
 
-    EZ_ENUM_MEMBER_PROPERTY("MipmapMode", ezTexConvMipmapMode, m_MipmapMode),
-    EZ_MEMBER_PROPERTY("PreserveAlphaCoverage", m_bPreserveAlphaCoverage),
-    EZ_MEMBER_PROPERTY("AlphaThreshold", m_fAlphaThreshold)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
-    EZ_ENUM_MEMBER_PROPERTY("CompressionMode", ezTexConvCompressionMode, m_CompressionMode),
-    EZ_MEMBER_PROPERTY("PremultipliedAlpha", m_bPremultipliedAlpha),
-    EZ_MEMBER_PROPERTY("DilateColor", m_bDilateColor)->AddAttributes(new ezDefaultValueAttribute(false)),
-    EZ_MEMBER_PROPERTY("FlipHorizontal", m_bFlipHorizontal),
-    EZ_MEMBER_PROPERTY("HdrExposureBias", m_fHdrExposureBias)->AddAttributes(new ezClampValueAttribute(-20.0f, 20.0f)),
-
     EZ_ENUM_MEMBER_PROPERTY("TextureFilter", ezTextureFilterSetting, m_TextureFilter),
     EZ_ENUM_MEMBER_PROPERTY("AddressModeU", ezImageAddressMode, m_AddressModeU),
     EZ_ENUM_MEMBER_PROPERTY("AddressModeV", ezImageAddressMode, m_AddressModeV),
     EZ_ENUM_MEMBER_PROPERTY("AddressModeW", ezImageAddressMode, m_AddressModeW),
+
+    EZ_MEMBER_PROPERTY("IsArrayTexture", m_bIsArrayTexture),
+
+    EZ_ENUM_MEMBER_PROPERTY("MipmapMode", ezTexConvMipmapMode, m_MipmapMode),
+    EZ_MEMBER_PROPERTY("PreserveAlphaCoverage", m_bPreserveAlphaCoverage),
+    EZ_MEMBER_PROPERTY("AlphaThreshold", m_fAlphaThreshold)->AddAttributes(new ezDefaultValueAttribute(0.5f), new ezClampValueAttribute(0.0f, 1.0f)),
+    EZ_MEMBER_PROPERTY("PremultipliedAlpha", m_bPremultipliedAlpha),
+
+    EZ_MEMBER_PROPERTY("DilateColor", m_bDilateColor)->AddAttributes(new ezDefaultValueAttribute(false)),
+    EZ_MEMBER_PROPERTY("FlipHorizontal", m_bFlipHorizontal),
+    EZ_MEMBER_PROPERTY("HdrExposureBias", m_fHdrExposureBias)->AddAttributes(new ezClampValueAttribute(-20.0f, 20.0f)),
 
     EZ_ENUM_MEMBER_PROPERTY("ChannelMapping", ezTexture2DChannelMappingEnum, m_ChannelMapping),
 
@@ -53,6 +56,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureAssetProperties, 5, ezRTTIDefaultAlloca
     EZ_ACCESSOR_PROPERTY("Input2", GetInputFile1, SetInputFile1)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
     EZ_ACCESSOR_PROPERTY("Input3", GetInputFile2, SetInputFile2)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
     EZ_ACCESSOR_PROPERTY("Input4", GetInputFile3, SetInputFile3)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
+
+    EZ_ARRAY_MEMBER_PROPERTY("ArraySlices", m_ArraySlices)->AddAttributes(new ezFileBrowserAttribute("Select Texture", ezFileBrowserAttribute::ImagesLdrAndHdr)),
 
   }
   EZ_END_PROPERTIES;
@@ -67,6 +72,7 @@ void ezTextureAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaState
     auto& props = *e.m_pPropertyStates;
 
     const bool isRenderTarget = e.m_pObject->GetTypeAccessor().GetValue("IsRenderTarget").ConvertTo<bool>();
+    const bool isTextureArray = e.m_pObject->GetTypeAccessor().GetValue("IsArrayTexture").ConvertTo<bool>();
 
     props["AddressModeW"].m_Visibility = ezPropertyUiState::Invisible;
 
@@ -92,9 +98,38 @@ void ezTextureAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaState
       props["Input2"].m_Visibility = ezPropertyUiState::Invisible;
       props["Input3"].m_Visibility = ezPropertyUiState::Invisible;
       props["Input4"].m_Visibility = ezPropertyUiState::Invisible;
+      props["ArraySlices"].m_Visibility = ezPropertyUiState::Invisible;
+      props["IsArrayTexture"].m_Visibility = ezPropertyUiState::Invisible;
 
       props["Format"].m_Visibility = ezPropertyUiState::Default;
       props["Resolution"].m_Visibility = ezPropertyUiState::Default;
+    }
+    else if (isTextureArray)
+    {
+      props["CVarResScale"].m_Visibility = ezPropertyUiState::Invisible;
+      props["Format"].m_Visibility = ezPropertyUiState::Invisible;
+      props["Resolution"].m_Visibility = ezPropertyUiState::Invisible;
+
+      props["ChannelMapping"].m_Visibility = ezPropertyUiState::Invisible;
+      props["Input1"].m_Visibility = ezPropertyUiState::Invisible;
+      props["Input2"].m_Visibility = ezPropertyUiState::Invisible;
+      props["Input3"].m_Visibility = ezPropertyUiState::Invisible;
+      props["Input4"].m_Visibility = ezPropertyUiState::Invisible;
+      props["FlipHorizontal"].m_Visibility = ezPropertyUiState::Invisible;
+      props["DilateColor"].m_Visibility = ezPropertyUiState::Invisible;
+      props["PremultipliedAlpha"].m_Visibility = ezPropertyUiState::Invisible;
+      props["PreserveAlphaCoverage"].m_Visibility = ezPropertyUiState::Invisible;
+      props["AlphaThreshold"].m_Visibility = ezPropertyUiState::Invisible;
+      props["HdrExposureBias"].m_Visibility = ezPropertyUiState::Invisible;
+
+      props["Usage"].m_Visibility = ezPropertyUiState::Default;
+      props["MipmapMode"].m_Visibility = ezPropertyUiState::Default;
+      props["CompressionMode"].m_Visibility = ezPropertyUiState::Default;
+      props["TextureFilter"].m_Visibility = ezPropertyUiState::Default;
+      props["AddressModeU"].m_Visibility = ezPropertyUiState::Default;
+      props["AddressModeV"].m_Visibility = ezPropertyUiState::Default;
+      props["ArraySlices"].m_Visibility = ezPropertyUiState::Default;
+      props["IsArrayTexture"].m_Visibility = ezPropertyUiState::Default;
     }
     else
     {
@@ -114,6 +149,8 @@ void ezTextureAssetProperties::PropertyMetaStateEventHandler(ezPropertyMetaState
       props["AlphaThreshold"].m_Visibility = ezPropertyUiState::Disabled;
       props["HdrExposureBias"].m_Visibility = ezPropertyUiState::Disabled;
       props["DilateColor"].m_Visibility = ezPropertyUiState::Disabled;
+      props["ArraySlices"].m_Visibility = ezPropertyUiState::Invisible;
+      props["IsArrayTexture"].m_Visibility = ezPropertyUiState::Default;
 
       const ezInt64 mapping = e.m_pObject->GetTypeAccessor().GetValue("ChannelMapping").ConvertTo<ezInt64>();
 

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.h
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/TextureAsset/TextureAssetObjects.h
@@ -101,6 +101,7 @@ public:
   ezInt32 GetNumInputFiles() const;
 
   bool m_bIsRenderTarget = false;
+  bool m_bIsArrayTexture = false;
   bool m_bPremultipliedAlpha = false;
   bool m_bFlipHorizontal = false;
   bool m_bDilateColor = false;
@@ -119,6 +120,8 @@ public:
 
   ezEnum<ezTexConvCompressionMode> m_CompressionMode;
   ezEnum<ezTexConvMipmapMode> m_MipmapMode;
+
+  ezDynamicArray<ezString> m_ArraySlices;
 
 private:
   ezEnum<ezTexture2DChannelMappingEnum> m_ChannelMapping;

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.cpp
@@ -4,6 +4,8 @@
 #include <EnginePluginAssets/TextureAsset/TextureView.h>
 
 #include <RendererCore/Meshes/MeshComponent.h>
+#include <RendererFoundation/Device/Device.h>
+#include <RendererFoundation/Resources/Texture.h>
 
 // clang-format off
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezTextureContext, 1, ezRTTIDefaultAllocator<ezTextureContext>)
@@ -42,22 +44,29 @@ ezTextureContext::ezTextureContext()
 
 void ezTextureContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
 {
-  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezDocumentConfigMsgToEngine>() && m_hMaterial.IsValid())
+  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezDocumentConfigMsgToEngine>() && !m_SlicePreviews.IsEmpty())
   {
     const ezDocumentConfigMsgToEngine* pMsg2 = static_cast<const ezDocumentConfigMsgToEngine*>(pMsg);
 
-    ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
     if (pMsg2->m_sWhatToDo == "SetChannelMode")
     {
-      pMaterial->SetParameter("ShowChannelMode", pMsg2->m_iValue);
-      pMaterial->SetParameter("AlphaThreshold", pMsg2->m_fValue);
+      for (auto& slice : m_SlicePreviews)
+      {
+        ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+        pMaterial->SetParameter("ShowChannelMode", pMsg2->m_iValue);
+        pMaterial->SetParameter("AlphaThreshold", pMsg2->m_fValue);
+      }
     }
     else if (pMsg2->m_sWhatToDo == "SetLodLevel")
     {
       if (pMsg2->m_iValue != m_iLodLevel)
       {
-        pMaterial->SetParameter("LodLevel", pMsg2->m_iValue);
         m_iLodLevel = pMsg2->m_iValue;
+        for (auto& slice : m_SlicePreviews)
+        {
+          ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+          pMaterial->SetParameter("LodLevel", pMsg2->m_iValue);
+        }
       }
     }
     else if (pMsg2->m_sWhatToDo == "SetTexture" && pMsg2->m_sValue.IsEmpty() == false)
@@ -66,17 +75,29 @@ void ezTextureContext::HandleMessage(const ezEditorEngineDocumentMsg* pMsg)
     }
   }
 
+  if (pMsg->GetDynamicRTTI()->IsDerivedFrom<ezViewRedrawMsgToEngine>())
+  {
+    // Non-blocking: check current array size and rebuild objects if it changed.
+    // Defaults to 1 if the texture is not yet loaded.
+    ezUInt32 uiArraySlices = 1;
+    if (m_hTexture.IsValid())
+    {
+      ezResourceLock<ezTexture2DResource> pTex(m_hTexture, ezResourceAcquireMode::PointerOnly);
+      if (pTex->GetFormat() != ezGALResourceFormat::Invalid && pTex->GetType() == ezGALTextureType::Texture2DArray)
+      {
+        const ezGALTexture* pGALTex = ezGALDevice::GetDefaultDevice()->GetTexture(pTex->GetGALTexture());
+        if (pGALTex != nullptr)
+          uiArraySlices = pGALTex->GetDescription().m_uiArraySize;
+      }
+    }
+    RebuildPreviewObjects(uiArraySlices);
+  }
+
   ezEngineProcessDocumentContext::HandleMessage(pMsg);
 }
 
 void ezTextureContext::OnInitialize()
 {
-  ezStringBuilder sTextureGuid;
-  ezConversionUtils::ToString(GetDocumentGuid(), sTextureGuid);
-  const ezStringBuilder sMaterialResource(sTextureGuid.GetData(), " - Texture Preview");
-
-  m_hMaterial = ezResourceManager::GetExistingResource<ezMaterialResource>(sMaterialResource);
-
   // Preview Mesh
   const char* szMeshName = "DefaultTexturePreviewMesh";
   m_hPreviewMeshResource = ezResourceManager::GetExistingResource<ezMeshResource>(szMeshName);
@@ -89,7 +110,6 @@ void ezTextureContext::OnInitialize()
 
     if (!hMeshBuffer.IsValid())
     {
-      // Build geometry
       ezGeometry geom;
       CreatePreviewRect(geom);
       geom.ComputeTangents();
@@ -100,45 +120,20 @@ void ezTextureContext::OnInitialize()
 
       hMeshBuffer = ezResourceManager::GetOrCreateResource<ezMeshBufferResource>(szMeshBufferName, std::move(desc), szMeshBufferName);
     }
-    {
-      ezResourceLock<ezMeshBufferResource> pMeshBuffer(hMeshBuffer, ezResourceAcquireMode::AllowLoadingFallback);
 
-      ezMeshResourceDescriptor md;
-      md.UseExistingMeshBuffer(hMeshBuffer);
-      md.AddSubMesh(pMeshBuffer->GetPrimitiveCount(), 0, 0);
-      md.SetMaterial(0, "");
-      md.ComputeBounds();
+    ezResourceLock<ezMeshBufferResource> pMeshBuffer(hMeshBuffer, ezResourceAcquireMode::AllowLoadingFallback);
 
-      m_hPreviewMeshResource = ezResourceManager::GetOrCreateResource<ezMeshResource>(szMeshName, std::move(md), pMeshBuffer->GetResourceDescription());
-    }
+    ezMeshResourceDescriptor md;
+    md.UseExistingMeshBuffer(hMeshBuffer);
+    md.AddSubMesh(pMeshBuffer->GetPrimitiveCount(), 0, 0);
+    md.SetMaterial(0, "");
+    md.ComputeBounds();
+
+    m_hPreviewMeshResource = ezResourceManager::GetOrCreateResource<ezMeshResource>(szMeshName, std::move(md), pMeshBuffer->GetResourceDescription());
   }
 
-  // Preview Material
-  if (!m_hMaterial.IsValid())
-  {
-    ezMaterialResourceDescriptor md;
-    md.m_hBaseMaterial = ezResourceManager::LoadResource<ezMaterialResource>("Editor/Materials/TexturePreview.ezMaterial");
-
-    m_hMaterial = ezResourceManager::GetOrCreateResource<ezMaterialResource>(sMaterialResource, std::move(md));
-  }
-
-  // Preview Object
-  {
-    EZ_LOCK(m_pWorld->GetWriteMarker());
-
-    ezGameObjectDesc obj;
-    ezGameObject* pObj;
-
-    obj.m_sName.Assign("TexturePreview");
-    obj.m_LocalRotation = ezQuat::MakeFromAxisAndAngle(ezVec3(0, 0, 1), ezAngle::MakeFromDegree(90));
-    m_hPreviewObject = m_pWorld->CreateObject(obj, pObj);
-
-    ezMeshComponent* pMesh;
-    m_hPreviewMesh2D = ezMeshComponent::CreateComponent(pObj, pMesh);
-    pMesh->SetMesh(m_hPreviewMeshResource);
-    pMesh->SetMaterial(0, m_hMaterial);
-  }
-
+  ezStringBuilder sTextureGuid;
+  ezConversionUtils::ToString(GetDocumentGuid(), sTextureGuid);
   SetTexture(sTextureGuid);
 }
 
@@ -152,18 +147,88 @@ void ezTextureContext::DestroyViewContext(ezEngineProcessViewContext* pContext)
   EZ_DEFAULT_DELETE(pContext);
 }
 
+void ezTextureContext::RebuildPreviewObjects(ezUInt32 uiNumArraySlices)
+{
+  if (uiNumArraySlices == 0)
+    uiNumArraySlices = 1;
+
+  if (uiNumArraySlices == m_uiNumArraySlices)
+    return;
+
+  m_uiNumArraySlices = uiNumArraySlices;
+
+  ezStringBuilder sTextureGuid;
+  ezConversionUtils::ToString(GetDocumentGuid(), sTextureGuid);
+
+  EZ_LOCK(m_pWorld->GetWriteMarker());
+
+  for (auto& slice : m_SlicePreviews)
+    m_pWorld->DeleteObjectDelayed(slice.m_hObject);
+  m_SlicePreviews.Clear();
+
+  // Each subsequent slice is placed slightly behind (positive X) and shifted in YZ
+  // so its edges peek out from behind the previous slice (deck-of-cards effect).
+  // The preview quad lies in the YZ plane after the 90 degree Z rotation on the game object.
+  const float fOffsetYZ = 0.25f;
+  const float fOffsetX = 0.2f;
+
+  for (ezUInt32 i = 0; i < uiNumArraySlices; ++i)
+  {
+    // Per-slice material
+    ezStringBuilder sMaterialName;
+    sMaterialName.SetFormat("{} - Texture Preview Slice {}", sTextureGuid, i);
+
+    ezMaterialResourceHandle hMaterial = ezResourceManager::GetExistingResource<ezMaterialResource>(sMaterialName);
+    if (!hMaterial.IsValid())
+    {
+      ezMaterialResourceDescriptor md;
+      md.m_hBaseMaterial = ezResourceManager::LoadResource<ezMaterialResource>("Editor/Materials/TexturePreview.ezMaterial");
+      hMaterial = ezResourceManager::GetOrCreateResource<ezMaterialResource>(sMaterialName, std::move(md));
+    }
+
+    {
+      ezResourceLock<ezMaterialResource> pMaterial(hMaterial, ezResourceAcquireMode::AllowLoadingFallback);
+      pMaterial->SetParameter("ArrayIndex", (int)i);
+      pMaterial->SetParameter("LodLevel", m_iLodLevel);
+
+      if (m_hTexture.IsValid())
+        pMaterial->SetTexture2DBinding("BaseTexture", m_hTexture);
+    }
+
+    // Game object at stacked position
+    ezGameObjectDesc obj;
+    ezGameObject* pObj = nullptr;
+    obj.m_sName.Assign("TexturePreview");
+    obj.m_LocalRotation = ezQuat::MakeFromAxisAndAngle(ezVec3(0, 0, 1), ezAngle::MakeFromDegree(90));
+    obj.m_LocalPosition = (float)i * ezVec3(fOffsetX, fOffsetYZ, -fOffsetYZ);
+    ezGameObjectHandle hObject = m_pWorld->CreateObject(obj, pObj);
+
+    ezMeshComponent* pMesh = nullptr;
+    ezComponentHandle hMeshComp = ezMeshComponent::CreateComponent(pObj, pMesh);
+    pMesh->SetMesh(m_hPreviewMeshResource);
+    pMesh->SetMaterial(0, hMaterial);
+
+    auto& slice = m_SlicePreviews.ExpandAndGetRef();
+    slice.m_hObject = hObject;
+    slice.m_hMeshComponent = hMeshComp;
+    slice.m_hMaterial = hMaterial;
+  }
+}
+
 void ezTextureContext::SetTexture(ezStringView sTextureFile)
 {
   if (m_hTexture.IsValid() && m_hTexture.GetResourceID() == sTextureFile)
     return;
 
   m_hTexture = ezResourceManager::LoadResource<ezTexture2DResource>(sTextureFile);
-  ezResourceLock<ezTexture2DResource> pTexture(m_hTexture, ezResourceAcquireMode::PointerOnly);
-  pTexture->m_ResourceEvents.AddEventHandler(ezMakeDelegate(&ezTextureContext::OnResourceEvent, this), m_TextureResourceEventSubscriber);
 
-  ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::BlockTillLoaded);
-  pMaterial->SetTexture2DBinding("BaseTexture", m_hTexture);
-  pMaterial->SetParameter("IsLinear", !ezGALResourceFormat::IsSrgb(pTexture->GetFormat()));
+  {
+    ezResourceLock<ezTexture2DResource> pTexture(m_hTexture, ezResourceAcquireMode::PointerOnly);
+    pTexture->m_ResourceEvents.AddEventHandler(ezMakeDelegate(&ezTextureContext::OnResourceEvent, this), m_TextureResourceEventSubscriber);
+  }
+
+  // Reset slice count so the next redraw triggers a rebuild with the new texture.
+  m_uiNumArraySlices = 0;
 }
 
 void ezTextureContext::OnResourceEvent(const ezResourceEvent& e)
@@ -173,8 +238,15 @@ void ezTextureContext::OnResourceEvent(const ezResourceEvent& e)
     const ezTexture2DResource* pTexture = static_cast<const ezTexture2DResource*>(e.m_pResource);
     if (pTexture->GetFormat() != ezGALResourceFormat::Invalid)
     {
-      ezResourceLock<ezMaterialResource> pMaterial(m_hMaterial, ezResourceAcquireMode::BlockTillLoaded);
-      pMaterial->SetParameter("IsLinear", !ezGALResourceFormat::IsSrgb(pTexture->GetFormat()));
+      const bool bIsLinear = !ezGALResourceFormat::IsSrgb(pTexture->GetFormat());
+      for (auto& slice : m_SlicePreviews)
+      {
+        ezResourceLock<ezMaterialResource> pMaterial(slice.m_hMaterial, ezResourceAcquireMode::BlockTillLoaded);
+        pMaterial->SetParameter("IsLinear", bIsLinear);
+      }
+
+      // Force a rebuild on the next redraw in case the array size changed.
+      m_uiNumArraySlices = 0;
     }
   }
 }

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.h
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureContext.h
@@ -22,6 +22,7 @@ public:
 
   const ezTexture2DResourceHandle& GetTexture() const { return m_hTexture; }
   int GetLodLevel() const { return m_iLodLevel; }
+  ezUInt32 GetNumArraySlices() const { return m_uiNumArraySlices; }
 
 protected:
   virtual void OnInitialize() override;
@@ -32,14 +33,21 @@ protected:
 private:
   void SetTexture(ezStringView sTextureFile);
   void OnResourceEvent(const ezResourceEvent& e);
+  void RebuildPreviewObjects(ezUInt32 uiNumArraySlices);
 
-  ezGameObjectHandle m_hPreviewObject;
-  ezComponentHandle m_hPreviewMesh2D;
+  struct PreviewSlice
+  {
+    ezGameObjectHandle m_hObject;
+    ezComponentHandle m_hMeshComponent;
+    ezMaterialResourceHandle m_hMaterial;
+  };
+
   ezMeshResourceHandle m_hPreviewMeshResource;
-  ezMaterialResourceHandle m_hMaterial;
-  ezTexture2DResourceHandle m_hTexture;
+  ezDynamicArray<PreviewSlice> m_SlicePreviews;
 
+  ezTexture2DResourceHandle m_hTexture;
   ezEvent<const ezResourceEvent&, ezMutex>::Unsubscriber m_TextureResourceEventSubscriber;
 
+  ezUInt32 m_uiNumArraySlices = 0;
   int m_iLodLevel = -1;
 };

--- a/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureView.cpp
+++ b/Code/EditorPlugins/Assets/EnginePluginAssets/TextureAsset/TextureView.cpp
@@ -56,7 +56,15 @@ void ezTextureViewContext::SetCamera(const ezViewRedrawMsgToEngine* pMsg)
       sText = "Unknown format";
     }
 
-    sText.PrependFormat("{}x{} - ", uiWidth, uiHeight);
+    const ezUInt32 uiArraySlices = m_pTextureContext->GetNumArraySlices();
+    if (uiArraySlices > 1)
+    {
+      sText.PrependFormat("{}x{} [{} slices] - ", uiWidth, uiHeight, uiArraySlices);
+    }
+    else
+    {
+      sText.PrependFormat("{}x{} - ", uiWidth, uiHeight);
+    }
     sText.Append("\nPreview Mip Level: ");
 
     if (iMipLevel < 0)

--- a/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
+++ b/Code/Engine/RendererCore/ShaderCompiler/Implementation/ShaderParser.cpp
@@ -43,6 +43,7 @@ namespace
     s_NameToTypeTable.Insert("Color", ezGetStaticRTTI<ezColor>());
     /// \todo Are we going to support linear UB colors ?
     s_NameToTypeTable.Insert("Texture2D", ezGetStaticRTTI<ezString>());
+    s_NameToTypeTable.Insert("Texture2DArray", ezGetStaticRTTI<ezString>());
     s_NameToTypeTable.Insert("Texture3D", ezGetStaticRTTI<ezString>());
     s_NameToTypeTable.Insert("TextureCube", ezGetStaticRTTI<ezString>());
 

--- a/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
+++ b/Code/Engine/Texture/Image/Formats/DdsFileFormat.cpp
@@ -165,7 +165,7 @@ static ezResult ReadImageData(ezStreamReader& inout_stream, ezImageHeader& ref_i
     return EZ_FAILURE;
   }
 
-  ezDdsHeaderDxt10 headerDxt10;
+  ezDdsHeaderDxt10 headerDxt10{};
 
   ezImageFormat::Enum format = ezImageFormat::UNKNOWN;
 
@@ -233,7 +233,9 @@ static ezResult ReadImageData(ezStreamReader& inout_stream, ezImageHeader& ref_i
   ref_imageHeader.SetImageFormat(format);
 
   const bool bHasMipMaps = (ref_ddsHeader.m_uiCaps & ezDdsCaps::MIPMAP) != 0;
-  const bool bCubeMap = (ref_ddsHeader.m_uiCaps2 & ezDdsCaps2::CUBEMAP) != 0;
+  const bool bDxt10 = (ref_ddsHeader.m_ddspf.m_uiFourCC == ezDdsDxt10FourCc);
+  const bool bCubeMap = (ref_ddsHeader.m_uiCaps2 & ezDdsCaps2::CUBEMAP) != 0 ||
+                        (bDxt10 && (headerDxt10.m_uiMiscFlag & ezDdsResourceMiscFlags::TEXTURECUBE) != 0);
   const bool bVolume = (ref_ddsHeader.m_uiCaps2 & ezDdsCaps2::VOLUME) != 0;
 
 
@@ -256,6 +258,11 @@ static ezResult ReadImageData(ezStreamReader& inout_stream, ezImageHeader& ref_i
   else if (bVolume)
   {
     ref_imageHeader.SetDepth(ref_ddsHeader.m_uiDepth);
+  }
+
+  if (bDxt10 && headerDxt10.m_uiArraySize > 1)
+  {
+    ref_imageHeader.SetNumArrayIndices(headerDxt10.m_uiArraySize);
   }
 
   return EZ_SUCCESS;

--- a/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
+++ b/Code/Engine/Texture/Image/Implementation/ImageUtils.cpp
@@ -581,12 +581,6 @@ ezResult ezImageUtils::ExtractLowerMipChain(const ezImageView& srcImg, ezImage& 
 {
   const ezImageHeader& srcImgHeader = srcImg.GetHeader();
 
-  if (srcImgHeader.GetNumFaces() != 1 || srcImgHeader.GetNumArrayIndices() != 1)
-  {
-    // Lower mips aren't stored contiguously for array/cube textures and would require copying. This isn't implemented yet.
-    return EZ_FAILURE;
-  }
-
   EZ_PROFILE_SCOPE("ezImageUtils::ExtractLowerMipChain");
 
   uiNumMips = ezMath::Min(uiNumMips, srcImgHeader.GetNumMipLevels());
@@ -620,16 +614,43 @@ ezResult ezImageUtils::ExtractLowerMipChain(const ezImageView& srcImg, ezImage& 
   dstImgHeader.SetNumArrayIndices(srcImgHeader.GetNumArrayIndices());
   dstImgHeader.SetNumMipLevels(uiNumMips);
 
-  const ezUInt8* pDataBegin = srcImg.GetPixelPointer<ezUInt8>(startMipLevel);
-  const ezUInt8* pDataEnd = srcImg.GetByteBlobPtr().GetEndPtr();
-  const ptrdiff_t dataSize = reinterpret_cast<ptrdiff_t>(pDataEnd) - reinterpret_cast<ptrdiff_t>(pDataBegin);
+  const ezUInt32 uiNumFaces = srcImgHeader.GetNumFaces();
+  const ezUInt32 uiNumArrayIndices = srcImgHeader.GetNumArrayIndices();
 
-  const ezConstByteBlobPtr lowResData(pDataBegin, static_cast<ezUInt64>(dataSize));
+  if (uiNumFaces == 1 && uiNumArrayIndices == 1)
+  {
+    // Fast path: mip levels are contiguous in memory for simple 2D textures.
+    const ezUInt8* pDataBegin = srcImg.GetPixelPointer<ezUInt8>(startMipLevel);
+    const ezUInt8* pDataEnd = srcImg.GetByteBlobPtr().GetEndPtr();
+    const ptrdiff_t dataSize = reinterpret_cast<ptrdiff_t>(pDataEnd) - reinterpret_cast<ptrdiff_t>(pDataBegin);
 
-  ezImageView dataview;
-  dataview.ResetAndViewExternalStorage(dstImgHeader, lowResData);
+    const ezConstByteBlobPtr lowResData(pDataBegin, static_cast<ezUInt64>(dataSize));
 
-  ref_dstImg.ResetAndCopy(dataview);
+    ezImageView dataview;
+    dataview.ResetAndViewExternalStorage(dstImgHeader, lowResData);
+
+    ref_dstImg.ResetAndCopy(dataview);
+  }
+  else
+  {
+    // For array/cube textures, mip levels of different slices are not contiguous,
+    // so each sub-image must be copied individually.
+    ref_dstImg.ResetAndAlloc(dstImgHeader);
+
+    for (ezUInt32 uiArrayIndex = 0; uiArrayIndex < uiNumArrayIndices; ++uiArrayIndex)
+    {
+      for (ezUInt32 uiFace = 0; uiFace < uiNumFaces; ++uiFace)
+      {
+        for (ezUInt32 uiMip = 0; uiMip < uiNumMips; ++uiMip)
+        {
+          const ezUInt32 uiSrcMip = startMipLevel + uiMip;
+          const ezImageView srcSubImage = srcImg.GetSubImageView(uiSrcMip, uiFace, uiArrayIndex);
+          ezUInt8* pDst = ref_dstImg.GetPixelPointer<ezUInt8>(uiMip, uiFace, uiArrayIndex);
+          ezMemoryUtils::Copy(pDst, srcSubImage.GetByteBlobPtr().GetPtr(), srcSubImage.GetByteBlobPtr().GetCount());
+        }
+      }
+    }
+  }
 
   return EZ_SUCCESS;
 }

--- a/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/Processor.cpp
@@ -84,6 +84,10 @@ ezResult ezTexConvProcessor::Process()
     {
       EZ_SUCCEED_OR_RETURN(Assemble3DTexture(assembledImg));
     }
+    else if (m_Descriptor.m_OutputType == ezTexConvOutputType::Texture2DArray)
+    {
+      EZ_SUCCEED_OR_RETURN(Assemble2DArrayTexture(assembledImg));
+    }
 
     EZ_SUCCEED_OR_RETURN(AdjustHdrExposure(assembledImg));
 

--- a/Code/Engine/Texture/TexConv/Implementation/Texture2DArray.cpp
+++ b/Code/Engine/Texture/TexConv/Implementation/Texture2DArray.cpp
@@ -1,0 +1,40 @@
+#include <Texture/TexturePCH.h>
+
+#include <Foundation/Profiling/Profiling.h>
+#include <Texture/TexConv/TexConvProcessor.h>
+
+ezResult ezTexConvProcessor::Assemble2DArrayTexture(ezImage& dst) const
+{
+  EZ_PROFILE_SCOPE("Assemble2DArrayTexture");
+
+  const auto& mappings = m_Descriptor.m_ChannelMappings;
+  const ezUInt32 uiNumSlices = mappings.GetCount();
+
+  if (uiNumSlices == 0)
+  {
+    ezLog::Error("No channel mappings provided for 2D array texture assembly. Need at least one slice.");
+    return EZ_FAILURE;
+  }
+
+  const ezUInt32 uiWidth = m_Descriptor.m_InputImages[0].GetWidth();
+  const ezUInt32 uiHeight = m_Descriptor.m_InputImages[0].GetHeight();
+
+  ezImageHeader header;
+  header.SetWidth(uiWidth);
+  header.SetHeight(uiHeight);
+  header.SetDepth(1);
+  header.SetNumFaces(1);
+  header.SetNumMipLevels(1);
+  header.SetNumArrayIndices(uiNumSlices);
+  header.SetImageFormat(ezImageFormat::R32G32B32A32_FLOAT);
+
+  dst.ResetAndAlloc(header);
+
+  for (ezUInt32 uiSlice = 0; uiSlice < uiNumSlices; ++uiSlice)
+  {
+    ezColor* pPixelOut = dst.GetPixelPointer<ezColor>(0, 0, uiSlice);
+    EZ_SUCCEED_OR_RETURN(Assemble2DSlice(mappings[uiSlice], uiWidth, uiHeight, pPixelOut));
+  }
+
+  return EZ_SUCCESS;
+}

--- a/Code/Engine/Texture/TexConv/TexConvEnums.h
+++ b/Code/Engine/Texture/TexConv/TexConvEnums.h
@@ -13,6 +13,7 @@ struct ezTexConvOutputType
     Volume,
     Cubemap,
     Atlas,
+    Texture2DArray,
 
     Default = Texture2D
   };

--- a/Code/Engine/Texture/TexConv/TexConvProcessor.h
+++ b/Code/Engine/Texture/TexConv/TexConvProcessor.h
@@ -49,6 +49,7 @@ private:
   ezResult DetermineTargetResolution(
     const ezImage& image, ezEnum<ezImageFormat> OutputImageFormat, ezUInt32& out_uiTargetResolutionX, ezUInt32& out_uiTargetResolutionY) const;
   ezResult Assemble2DTexture(const ezImageHeader& refImg, ezImage& dst) const;
+  ezResult Assemble2DArrayTexture(ezImage& dst) const;
   ezResult AssembleCubemap(ezImage& dst) const;
   ezResult Assemble3DTexture(ezImage& dst) const;
   ezResult AdjustHdrExposure(ezImage& img) const;

--- a/Code/Tools/TexConv/ParseOptions.cpp
+++ b/Code/Tools/TexConv/ParseOptions.cpp
@@ -93,7 +93,7 @@ Required to be non-zero when using ez specific output formats.\n\
 Example: -assetHashHigh 0xABCDABCD",
   "");
 
-ezCommandLineOptionEnum opt_Type("_TexConv", "-type", "The type of output to generate.", "2D = 1 | Volume = 2 | Cubemap = 3 | Atlas = 4", 1);
+ezCommandLineOptionEnum opt_Type("_TexConv", "-type", "The type of output to generate.", "2D = 1 | Volume = 2 | Cubemap = 3 | Atlas = 4 | Texture2DArray = 5", 1);
 
 ezCommandLineOptionEnum opt_Compression("_TexConv", "-compression", "Compression strength for output format.", "Medium = 1 | High = 2 | None = 0", 1);
 
@@ -277,6 +277,14 @@ ezResult ezTexConv::ParseOutputType()
     if (!m_bOutputSupports3D)
     {
       ezLog::Error("Volume textures are not supported by the chosen output file format.");
+      return EZ_FAILURE;
+    }
+  }
+  else if (m_Processor.m_Descriptor.m_OutputType == ezTexConvOutputType::Texture2DArray)
+  {
+    if (!m_bOutputSupports2D)
+    {
+      ezLog::Error("2D array textures are not supported by the chosen output file format.");
       return EZ_FAILURE;
     }
   }

--- a/Data/Base/Shaders/Editor/TexturePreview.ezShader
+++ b/Data/Base/Shaders/Editor/TexturePreview.ezShader
@@ -11,6 +11,7 @@ int ShowChannelMode;
 float AlphaThreshold;
 float LodLevel;
 bool IsLinear;
+int ArrayIndex;
 
 [RENDERSTATE]
 
@@ -27,6 +28,7 @@ CullMode = CullMode_None
   FLOAT1(AlphaThreshold);
   FLOAT1(LodLevel);
   BOOL1(IsLinear);
+  INT1(ArrayIndex);
 
 [VERTEXSHADER]
 
@@ -41,15 +43,16 @@ VS_OUT main(VS_IN Input)
 
 #include <Shaders/Materials/MaterialInterpolator.h>
 
-Texture2D BaseTexture BIND_GROUP(BG_MATERIAL);
+Texture2DArray BaseTexture BIND_GROUP(BG_MATERIAL);
 SamplerState BaseTexture_AutoSampler BIND_GROUP(BG_MATERIAL);
 
 float4 SampleTexture(PS_IN Input)
 {
+  float3 uvw = float3(Input.TexCoord0.xy, (float)GetMaterialData(ArrayIndex));
   if (GetMaterialData(LodLevel) < 0)
-    return BaseTexture.Sample(BaseTexture_AutoSampler, Input.TexCoord0.xy);
+    return BaseTexture.Sample(BaseTexture_AutoSampler, uvw);
 
-  return BaseTexture.SampleLevel(BaseTexture_AutoSampler, Input.TexCoord0.xy, GetMaterialData(LodLevel));
+  return BaseTexture.SampleLevel(BaseTexture_AutoSampler, uvw, GetMaterialData(LodLevel));
 }
 
 float4 main(PS_IN Input) : SV_Target


### PR DESCRIPTION
You can enable "Is Array Texture" in the 2D texture asset and then add a number of images to it, to have them all get packed into a single texture. Resolution of all images will be scaled to that of the first image. The texture preview shows all slices behind each other.

<img width="2008" height="1411" alt="image" src="https://github.com/user-attachments/assets/2fe621ad-08f0-41bf-b300-dcbea9707405" />
