### PR TITLE
PostMessage fixes and cleanups + Lighting fixes

### DIFF
--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -133,6 +133,9 @@ void ezWorld::Clear()
   DeleteDeadComponents();
 
   ezEventMessageHandlerComponent::ClearGlobalEventHandlersForWorld(this);
+
+  // reset the message time
+  m_Data.m_MessageTime = ezTime::MakeZero();
 }
 
 void ezWorld::SetCoordinateSystemProvider(const ezSharedPtr<ezCoordinateSystemProvider>& pProvider)
@@ -803,13 +806,15 @@ void ezWorld::SetObjectGlobalKey(ezGameObject* pObject, const ezHashedString& sG
   if (auto it = m_Data.m_GlobalKeyToIdTable.Find(sGlobalKey.GetHash()); it.IsValid())
   {
     if (it.Value() == pObject->m_InternalId) // same object, same global key ?
+    {
       return;
+    }
 
-                                             // we allow overwriting a global key to a different object here
-      // so that we can delete an object in a frame and spawn a new one in the same frame, that takes over
-      // due to the delayed deletion at the end of the frame, this would otherwise not work
-      // the only work-around would be to manually clear the global key before deleting an object
-      // but that would effectively do the same as this, it's just more complicated for the user
+    // we allow overwriting a global key to a different object here
+    // so that we can delete an object in a frame and spawn a new one in the same frame, that takes over
+    // due to the delayed deletion at the end of the frame, this would otherwise not work
+    // the only work-around would be to manually clear the global key before deleting an object
+    // but that would effectively do the same as this, it's just more complicated for the user
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
     ezLog::Warning("An object with the global key '{}' already exists. Overwriting with different object reference.", sGlobalKey);

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -394,65 +394,64 @@ void ezWorld::CancelComponentInitBatch(const ezComponentInitBatchHandle& hBatch)
   pInitBatch->m_ComponentsToInitialize.Clear();
   pInitBatch->m_ComponentsToStartSimulation.Clear();
 }
+
 void ezWorld::PostMessage(const ezGameObjectHandle& receiverObject, const ezMessage& msg, ezObjectMsgQueueType::Enum queueType, ezTime delay, bool bRecursive) const
 {
   // This method is allowed to be called from multiple threads.
+  auto& mutex = m_Data.m_MessageQueueMutex[queueType];
 
   EZ_ASSERT_DEBUG((receiverObject.m_InternalId.m_Data >> 62) == 0, "Upper 2 bits in object id must not be set");
 
-  QueuedMsgMetaData metaData;
-  metaData.m_uiReceiverObjectOrComponent = receiverObject.m_InternalId.m_Data;
-  metaData.m_uiReceiverIsComponent = false;
-  metaData.m_uiRecursive = bRecursive;
-
-  if (m_Data.m_ProcessingMessageQueue == queueType)
-  {
-    delay = ezMath::Max(delay, ezTime::MakeFromMilliseconds(1));
-  }
+  QueuedMsg queuedMsg;
+  queuedMsg.m_uiReceiverObjectOrComponent = receiverObject.m_InternalId.m_Data;
+  queuedMsg.m_uiReceiverIsComponent = false;
+  queuedMsg.m_uiRecursive = bRecursive;
 
   ezRTTIAllocator* pMsgRTTIAllocator = msg.GetDynamicRTTI()->GetAllocator();
   if (delay.IsPositive())
   {
-    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, &m_Data.m_Allocator);
+    queuedMsg.m_pMessage = pMsgRTTIAllocator->Clone<ezMessage>(&msg, &m_Data.m_Allocator);
+    queuedMsg.m_Due = m_Data.m_MessageTime + delay;
 
-    metaData.m_Due = m_Data.m_Clock.GetAccumulatedTime() + delay;
-    m_Data.m_TimedMessageQueues[queueType].Enqueue(pMsgCopy, metaData);
+    EZ_LOCK(mutex);
+    m_Data.m_TimedMessageQueues[queueType].PushBack(queuedMsg);
   }
   else
   {
-    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_LinearAllocator.GetCurrentAllocator());
-    m_Data.m_MessageQueues[queueType].Enqueue(pMsgCopy, metaData);
+    queuedMsg.m_pMessage = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_LinearAllocator.GetCurrentAllocator());
+
+    EZ_LOCK(mutex);
+    m_Data.m_MessageQueues[queueType].PushBack(queuedMsg);
   }
 }
 
 void ezWorld::PostMessage(const ezComponentHandle& hReceiverComponent, const ezMessage& msg, ezTime delay, ezObjectMsgQueueType::Enum queueType) const
 {
   // This method is allowed to be called from multiple threads.
+  auto& mutex = m_Data.m_MessageQueueMutex[queueType];
 
   EZ_ASSERT_DEBUG((hReceiverComponent.m_InternalId.m_Data >> 62) == 0, "Upper 2 bits in component id must not be set");
 
-  QueuedMsgMetaData metaData;
-  metaData.m_uiReceiverObjectOrComponent = hReceiverComponent.m_InternalId.m_Data;
-  metaData.m_uiReceiverIsComponent = true;
-  metaData.m_uiRecursive = false;
-
-  if (m_Data.m_ProcessingMessageQueue == queueType)
-  {
-    delay = ezMath::Max(delay, ezTime::MakeFromMilliseconds(1));
-  }
+  QueuedMsg queuedMsg;
+  queuedMsg.m_uiReceiverObjectOrComponent = hReceiverComponent.m_InternalId.m_Data;
+  queuedMsg.m_uiReceiverIsComponent = true;
+  queuedMsg.m_uiRecursive = false;
 
   ezRTTIAllocator* pMsgRTTIAllocator = msg.GetDynamicRTTI()->GetAllocator();
   if (delay.IsPositive())
   {
-    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, &m_Data.m_Allocator);
+    queuedMsg.m_pMessage = pMsgRTTIAllocator->Clone<ezMessage>(&msg, &m_Data.m_Allocator);
+    queuedMsg.m_Due = m_Data.m_MessageTime + delay;
 
-    metaData.m_Due = m_Data.m_Clock.GetAccumulatedTime() + delay;
-    m_Data.m_TimedMessageQueues[queueType].Enqueue(pMsgCopy, metaData);
+    EZ_LOCK(mutex);
+    m_Data.m_TimedMessageQueues[queueType].PushBack(queuedMsg);
   }
   else
   {
-    ezMessage* pMsgCopy = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_LinearAllocator.GetCurrentAllocator());
-    m_Data.m_MessageQueues[queueType].Enqueue(pMsgCopy, metaData);
+    queuedMsg.m_pMessage = pMsgRTTIAllocator->Clone<ezMessage>(&msg, m_Data.m_LinearAllocator.GetCurrentAllocator());
+
+    EZ_LOCK(mutex);
+    m_Data.m_MessageQueues[queueType].PushBack(queuedMsg);
   }
 }
 
@@ -496,6 +495,8 @@ void ezWorld::Update()
   {
     m_Data.m_Clock.Update();
   }
+
+  UpdateMessageTime();
 
   if (m_Data.m_pSpatialSystem != nullptr)
   {
@@ -805,10 +806,10 @@ void ezWorld::SetObjectGlobalKey(ezGameObject* pObject, const ezHashedString& sG
       return;
 
                                              // we allow overwriting a global key to a different object here
-      // so that we can delete an object in a frame and spawn a new one in the same frame, that takes over
-      // due to the delayed deletion at the end of the frame, this would otherwise not work
-      // the only work-around would be to manually clear the global key before deleting an object
-      // but that would effectively do the same as this, it's just more complicated for the user
+    // so that we can delete an object in a frame and spawn a new one in the same frame, that takes over
+    // due to the delayed deletion at the end of the frame, this would otherwise not work
+    // the only work-around would be to manually clear the global key before deleting an object
+    // but that would effectively do the same as this, it's just more complicated for the user
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
     ezLog::Warning("An object with the global key '{}' already exists. Overwriting with different object reference.", sGlobalKey);
@@ -854,11 +855,11 @@ ezStringView ezWorld::GetObjectGlobalKey(const ezGameObject* pObject) const
   return {};
 }
 
-void ezWorld::ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::Entry& entry)
+void ezWorld::ProcessQueuedMessage(const QueuedMsg& entry)
 {
-  if (entry.m_MetaData.m_uiReceiverIsComponent)
+  if (entry.m_uiReceiverIsComponent)
   {
-    ezComponentHandle hComponent(ezComponentId(entry.m_MetaData.m_uiReceiverObjectOrComponent));
+    ezComponentHandle hComponent(ezComponentId(entry.m_uiReceiverObjectOrComponent));
 
     ezComponent* pReceiverComponent = nullptr;
     if (TryGetComponent(hComponent, pReceiverComponent))
@@ -877,12 +878,12 @@ void ezWorld::ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::En
   }
   else
   {
-    ezGameObjectHandle hObject(ezGameObjectId(entry.m_MetaData.m_uiReceiverObjectOrComponent));
+    ezGameObjectHandle hObject(ezGameObjectId(entry.m_uiReceiverObjectOrComponent));
 
     ezGameObject* pReceiverObject = nullptr;
     if (TryGetObject(hObject, pReceiverObject))
     {
-      if (entry.m_MetaData.m_uiRecursive)
+      if (entry.m_uiRecursive)
       {
         pReceiverObject->SendMessageRecursiveInternal(*entry.m_pMessage, true);
       }
@@ -903,16 +904,31 @@ void ezWorld::ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::En
   }
 }
 
+void ezWorld::UpdateMessageTime()
+{
+  ezTime deltaTime;
+  if (GetWorldSimulationEnabled())
+  {
+    deltaTime = GetClock().GetTimeDiff();
+  }
+  else
+  {
+    deltaTime = ezClock::GetGlobalClock()->GetTimeDiff();
+  }
+
+  m_Data.m_MessageTime += deltaTime;
+}
+
 void ezWorld::ProcessQueuedMessages(ezObjectMsgQueueType::Enum queueType)
 {
   EZ_PROFILE_SCOPE("Process Queued Messages");
 
   struct MessageComparer
   {
-    EZ_FORCE_INLINE bool Less(const ezInternal::WorldData::MessageQueue::Entry& a, const ezInternal::WorldData::MessageQueue::Entry& b) const
+    EZ_FORCE_INLINE bool Less(const QueuedMsg& a, const QueuedMsg& b) const
     {
-      if (a.m_MetaData.m_Due != b.m_MetaData.m_Due)
-        return a.m_MetaData.m_Due < b.m_MetaData.m_Due;
+      if (a.m_Due != b.m_Due)
+        return a.m_Due < b.m_Due;
 
       const ezInt32 iKeyA = a.m_pMessage->GetSortingKey();
       const ezInt32 iKeyB = b.m_pMessage->GetSortingKey();
@@ -922,8 +938,8 @@ void ezWorld::ProcessQueuedMessages(ezObjectMsgQueueType::Enum queueType)
       if (a.m_pMessage->GetId() != b.m_pMessage->GetId())
         return a.m_pMessage->GetId() < b.m_pMessage->GetId();
 
-      if (a.m_MetaData.m_uiReceiverData != b.m_MetaData.m_uiReceiverData)
-        return a.m_MetaData.m_uiReceiverData < b.m_MetaData.m_uiReceiverData;
+      if (a.m_uiReceiverData != b.m_uiReceiverData)
+        return a.m_uiReceiverData < b.m_uiReceiverData;
 
       if (a.m_uiMessageHash == 0)
       {
@@ -939,44 +955,48 @@ void ezWorld::ProcessQueuedMessages(ezObjectMsgQueueType::Enum queueType)
     }
   };
 
+  auto& mutex = m_Data.m_MessageQueueMutex[queueType];
+
   // regular messages
   {
-    ezInternal::WorldData::MessageQueue& queue = m_Data.m_MessageQueues[queueType];
+    ezInternal::WorldData::MessageQueue& queue = m_Data.m_MessageProcessingQueues[queueType];
+
+    {
+      EZ_LOCK(mutex);
+      queue.Swap(m_Data.m_MessageQueues[queueType]);
+    }
+
     queue.Sort(MessageComparer());
 
-    m_Data.m_ProcessingMessageQueue = queueType;
     for (ezUInt32 i = 0; i < queue.GetCount(); ++i)
     {
       ProcessQueuedMessage(queue[i]);
 
       // no need to deallocate these messages, they are allocated through a frame allocator
     }
-    m_Data.m_ProcessingMessageQueue = ezObjectMsgQueueType::COUNT;
 
     queue.Clear();
   }
 
   // timed messages
   {
+    EZ_LOCK(mutex);
+
     ezInternal::WorldData::MessageQueue& queue = m_Data.m_TimedMessageQueues[queueType];
     queue.Sort(MessageComparer());
 
-    const ezTime now = m_Data.m_Clock.GetAccumulatedTime();
-
-    m_Data.m_ProcessingMessageQueue = queueType;
     while (!queue.IsEmpty())
     {
-      auto& entry = queue.Peek();
-      if (entry.m_MetaData.m_Due > now)
+      auto& entry = queue.PeekFront();
+      if (entry.m_Due > m_Data.m_MessageTime)
         break;
 
       ProcessQueuedMessage(entry);
 
       EZ_DELETE(&m_Data.m_Allocator, entry.m_pMessage);
 
-      queue.Dequeue();
+      queue.PopFront();
     }
-    m_Data.m_ProcessingMessageQueue = ezObjectMsgQueueType::COUNT;
   }
 }
 

--- a/Code/Engine/Core/World/Implementation/World.cpp
+++ b/Code/Engine/Core/World/Implementation/World.cpp
@@ -806,10 +806,10 @@ void ezWorld::SetObjectGlobalKey(ezGameObject* pObject, const ezHashedString& sG
       return;
 
                                              // we allow overwriting a global key to a different object here
-    // so that we can delete an object in a frame and spawn a new one in the same frame, that takes over
-    // due to the delayed deletion at the end of the frame, this would otherwise not work
-    // the only work-around would be to manually clear the global key before deleting an object
-    // but that would effectively do the same as this, it's just more complicated for the user
+      // so that we can delete an object in a frame and spawn a new one in the same frame, that takes over
+      // due to the delayed deletion at the end of the frame, this would otherwise not work
+      // the only work-around would be to manually clear the global key before deleting an object
+      // but that would effectively do the same as this, it's just more complicated for the user
 
 #if EZ_ENABLED(EZ_COMPILE_FOR_DEVELOPMENT)
     ezLog::Warning("An object with the global key '{}' already exists. Overwriting with different object reference.", sGlobalKey);

--- a/Code/Engine/Core/World/Implementation/WorldData.cpp
+++ b/Code/Engine/Core/World/Implementation/WorldData.cpp
@@ -76,7 +76,6 @@ namespace ezInternal
 #endif
 
     static_assert(sizeof(ezGameObject) == 128);
-    static_assert(sizeof(QueuedMsgMetaData) == 16);
     static_assert(EZ_COMPONENT_TYPE_INDEX_BITS <= sizeof(ezWorldModuleTypeId) * 8);
 
     auto pDefaultInitBatch = EZ_NEW(&m_Allocator, InitBatch, &m_Allocator, "Default", true);
@@ -185,10 +184,10 @@ namespace ezInternal
         MessageQueue& queue = m_TimedMessageQueues[i];
         while (!queue.IsEmpty())
         {
-          MessageQueue::Entry& entry = queue.Peek();
+          auto& entry = queue.PeekFront();
           EZ_DELETE(&m_Allocator, entry.m_pMessage);
 
-          queue.Dequeue();
+          queue.PopFront();
         }
       }
     }

--- a/Code/Engine/Core/World/Implementation/WorldData.h
+++ b/Code/Engine/Core/World/Implementation/WorldData.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <Foundation/Communication/MessageQueue.h>
+#include <Foundation/Communication/Message.h>
 #include <Foundation/Containers/HashTable.h>
 #include <Foundation/Math/Random.h>
 #include <Foundation/Memory/FrameAllocator.h>
@@ -208,14 +208,17 @@ namespace ezInternal
     ezClock m_Clock;
     ezRandom m_Random;
 
-    struct QueuedMsgMetaData
+    struct QueuedMsg
     {
       EZ_DECLARE_POD_TYPE();
 
-      EZ_ALWAYS_INLINE QueuedMsgMetaData()
+      EZ_ALWAYS_INLINE QueuedMsg()
         : m_uiReceiverData(0)
       {
       }
+
+      ezMessage* m_pMessage = nullptr;
+      mutable ezUInt64 m_uiMessageHash = 0;
 
       union
       {
@@ -232,10 +235,12 @@ namespace ezInternal
       ezTime m_Due;
     };
 
-    using MessageQueue = ezMessageQueue<QueuedMsgMetaData, ezLocalAllocatorWrapper>;
+    using MessageQueue = ezDeque<QueuedMsg, ezLocalAllocatorWrapper>;
+    mutable ezMutex m_MessageQueueMutex[ezObjectMsgQueueType::COUNT];
     mutable MessageQueue m_MessageQueues[ezObjectMsgQueueType::COUNT];
+    mutable MessageQueue m_MessageProcessingQueues[ezObjectMsgQueueType::COUNT];
     mutable MessageQueue m_TimedMessageQueues[ezObjectMsgQueueType::COUNT];
-    ezObjectMsgQueueType::Enum m_ProcessingMessageQueue = ezObjectMsgQueueType::COUNT;
+    ezTime m_MessageTime; // Used to determine when delayed messages are due. Advanced with the world clock when the simulation is running, otherwise the global clock is used.
 
     ezThreadID m_WriteThreadID;
     ezInt32 m_iWriteCounter = 0;

--- a/Code/Engine/Core/World/Implementation/World_inl.h
+++ b/Code/Engine/Core/World/Implementation/World_inl.h
@@ -344,15 +344,13 @@ EZ_FORCE_INLINE void ezWorld::SendMessageRecursive(const ezGameObjectHandle& hRe
   }
 }
 
-EZ_ALWAYS_INLINE void ezWorld::PostMessage(
-  const ezGameObjectHandle& hReceiverObject, const ezMessage& msg, ezTime delay, ezObjectMsgQueueType::Enum queueType) const
+EZ_ALWAYS_INLINE void ezWorld::PostMessage(const ezGameObjectHandle& hReceiverObject, const ezMessage& msg, ezTime delay, ezObjectMsgQueueType::Enum queueType) const
 {
   // This method is allowed to be called from multiple threads.
   PostMessage(hReceiverObject, msg, queueType, delay, false);
 }
 
-EZ_ALWAYS_INLINE void ezWorld::PostMessageRecursive(
-  const ezGameObjectHandle& hReceiverObject, const ezMessage& msg, ezTime delay, ezObjectMsgQueueType::Enum queueType) const
+EZ_ALWAYS_INLINE void ezWorld::PostMessageRecursive(const ezGameObjectHandle& hReceiverObject, const ezMessage& msg, ezTime delay, ezObjectMsgQueueType::Enum queueType) const
 {
   // This method is allowed to be called from multiple threads.
   PostMessage(hReceiverObject, msg, queueType, delay, true);

--- a/Code/Engine/Core/World/World.h
+++ b/Code/Engine/Core/World/World.h
@@ -418,8 +418,10 @@ private:
   void SetObjectGlobalKey(ezGameObject* pObject, const ezHashedString& sGlobalKey);
   ezStringView GetObjectGlobalKey(const ezGameObject* pObject) const;
 
+  using QueuedMsg = ezInternal::WorldData::QueuedMsg;
   void PostMessage(const ezGameObjectHandle& receiverObject, const ezMessage& msg, ezObjectMsgQueueType::Enum queueType, ezTime delay, bool bRecursive) const;
-  void ProcessQueuedMessage(const ezInternal::WorldData::MessageQueue::Entry& entry);
+  void UpdateMessageTime();
+  void ProcessQueuedMessage(const QueuedMsg& entry);
   void ProcessQueuedMessages(ezObjectMsgQueueType::Enum queueType);
 
   template <typename World, typename GameObject, typename Component>
@@ -464,8 +466,6 @@ private:
   ezSharedPtr<ezTask> m_pUpdateTask;
 
   ezInternal::WorldData m_Data;
-
-  using QueuedMsgMetaData = ezInternal::WorldData::QueuedMsgMetaData;
 
   ezUInt32 m_uiIndex;
   static ezStaticArray<ezWorld*, EZ_MAX_WORLDS> s_Worlds;

--- a/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
+++ b/Code/Engine/RendererCore/Lights/Implementation/ClusteredDataUtils.h
@@ -211,7 +211,7 @@ namespace
       const ezVec3 cookieRightDir = pSpotLightRenderData->m_qGlobalRotation * ezVec3(0, fScale, 0);
 
       // Set bit 15 as marker bit to indicate that we have a cookie.
-      // The shader checks for cookieParams0 != 0 which would not work in case the cookie id is 0 and rightDir.z is 0 as well.
+      // The shader checks for (cookieParams0 & 0xFFFF) != 0 which would not work in case the cookie id is 0.
       out_perLightData.cookieParams0 = (pSpotLightRenderData->m_CookieId.m_InstanceIndex & 0x7FFF) | (1 << 15) | (ezFloat16(cookieRightDir.z).GetRawData() << 16);
       out_perLightData.cookieParams1 = ezShaderUtils::Float2ToRG16F(cookieRightDir.GetAsVec2());
     }

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -703,7 +703,7 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
         attenuation *= lightData.intensity;
         float3 lightColor = GetLightColor(lightData);
 
-        if (lightData.cookieParams0 != 0)
+        if ((lightData.cookieParams0 & 0xFFFF) != 0)
         {
           lightColor *= SampleLightCookie(lightData, matData.worldPosition);
         }

--- a/Data/Base/Shaders/Common/Lighting.h
+++ b/Data/Base/Shaders/Common/Lighting.h
@@ -644,7 +644,7 @@ void EvaluateFillLight(float3 worldPosition, float3 worldNormal, float3 diffuseC
   }
 }
 
-AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clusterData, float3 screenPosition, bool applySSAO)
+AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clusterData, float3 screenPosition, bool useScreenSpaceTechniques)
 {
   float3 viewVector = normalize(GetCameraPosition() - matData.worldPosition);
 
@@ -694,7 +694,7 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
 
           shadowTerm = CalculateShadowTerm(matData.worldPosition, matData.vertexNormal, lightShadowVector, distanceToLight, type, lightData.shadowDataOffsetAndFadeOut, noise, randomRotation, extraPenumbraScale, subsurfaceShadow, debugColor);
 
-          if (type == LIGHT_TYPE_DIR && lightData.auxParams != 0)
+          if (useScreenSpaceTechniques && type == LIGHT_TYPE_DIR && lightData.auxParams != 0)
           {
             shadowTerm = min(shadowTerm, SampleShadowMask(screenPosition, lightData.auxParams - 1));
           }
@@ -731,7 +731,7 @@ AccumulatedLight CalculateLighting(ezMaterialData matData, ezPerClusterData clus
 
   float occlusion = matData.occlusion;
 
-  if (applySSAO)
+  if (useScreenSpaceTechniques)
   {
     float ssao = SampleSSAO(screenPosition);
     occlusion *= ssao;

--- a/Data/Base/Shaders/Materials/MaterialPixelShader.h
+++ b/Data/Base/Shaders/Materials/MaterialPixelShader.h
@@ -7,6 +7,10 @@
 #define USE_WORLDPOS
 #define USE_DATAOFFSETS
 
+#if !defined(NO_SCREEN_SPACE_TECHNIQUES)
+#  define USE_SCREEN_SPACE_TECHNIQUES
+#endif
+
 #if (BLEND_MODE == BLEND_MODE_MASKED || BLEND_MODE == BLEND_MODE_DITHERED) && RENDER_PASS != RENDER_PASS_WIREFRAME
 
 // No need to do alpha test again if we have a depth prepass
@@ -111,13 +115,13 @@ PS_OUT main(PS_IN Input)
 
 #if SHADING_MODE == SHADING_MODE_LIT
 #  if SHADING_QUALITY == SHADING_QUALITY_NORMAL
-#    if BLEND_MODE == BLEND_MODE_OPAQUE || BLEND_MODE == BLEND_MODE_MASKED || BLEND_MODE == BLEND_MODE_DITHERED
-  bool applySSAO = true;
+#    if defined(USE_SCREEN_SPACE_TECHNIQUES) && (BLEND_MODE == BLEND_MODE_OPAQUE || BLEND_MODE == BLEND_MODE_MASKED || BLEND_MODE == BLEND_MODE_DITHERED)
+  bool useScreenSpaceTechniques = true;
 #    else
-  bool applySSAO = false;
+  bool useScreenSpaceTechniques = false;
 #    endif
 
-  AccumulatedLight light = CalculateLighting(matData, clusterData, Input.Position.xyw, applySSAO);
+  AccumulatedLight light = CalculateLighting(matData, clusterData, Input.Position.xyw, useScreenSpaceTechniques);
 #  elif SHADING_QUALITY == SHADING_QUALITY_SIMPLIFIED
   AccumulatedLight light = CalculateLightingSimplified(matData);
 #  endif

--- a/Data/Base/Shaders/Particles/ParticleCommonVS.h
+++ b/Data/Base/Shaders/Particles/ParticleCommonVS.h
@@ -211,6 +211,11 @@ float3 CalculateParticleLighting(float4 screenPosition, float3 worldPosition, fl
         attenuation *= lightData.intensity;
         float3 lightColor = RGB8ToFloat3(lightData.colorAndType);
 
+        if ((lightData.cookieParams0 & 0xFFFF) != 0)
+        {
+          lightColor *= SampleLightCookie(lightData, worldPosition);
+        }
+
         totalLight += lightColor * (attenuation * shadowTerm);
       }
     }


### PR DESCRIPTION
* To prevent infinite post message loops we used a workaround that we added a small delay to all message of the same queue while we were processing this loop. To clean this up we now use the common "swap queue" before processing technique. This has the additional benefit that we now need less locks while processing.
* Timed messages are now also processed in the Editor even when the simulation is not running. The behavior before led to constant confusion why certain messages were not delivered in the Editor.

* Allow custom material shaders to skip all screen space techniques like e.g. SSAO and SSShadows.
* Fixed point lights which would wrongly sample light cookies since their cookieParams0 could be != 0 because we store the right dir for tube lights in there now. The shader now only checks the lower 16 bit which contain the cookie index.
* Particle lighting now also applies light cookies.