### PR TITLE
Debug and gizmo rendering improvements

### DIFF
--- a/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
+++ b/Code/Editor/EditorEngineProcess/EngineProcGameApp.cpp
@@ -456,6 +456,7 @@ void ezEngineProcessGameApplication::EventHandlerIPC(const ezEngineProcessCommun
   else if (const auto* pMsg2b = ezDynamicCast<const ezGlobalSettingsMsgToEngine*>(e.m_pMessage))
   {
     ezGizmoRenderer::s_fGizmoScale = pMsg2b->m_fGizmoScale;
+    ezGizmoRenderer::s_fShapeIconScale = pMsg2b->m_fShapeIconScale;
   }
   else if (const auto* pMsg3 = ezDynamicCast<const ezChangeCVarMsgToEngine*>(e.m_pMessage))
   {

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/EngineProcessMessages.h
@@ -519,6 +519,7 @@ class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezGlobalSettingsMsgToEngine : public e
 
 public:
   float m_fGizmoScale = 0.0f;
+  float m_fShapeIconScale = 0.0f;
 };
 
 class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezWorldSettingsMsgToEngine : public ezEditorEngineDocumentMsg

--- a/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/EngineProcess/Implementation/EngineProcessMessages.cpp
@@ -524,6 +524,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezGlobalSettingsMsgToEngine, 1, ezRTTIDefaultAll
   EZ_BEGIN_PROPERTIES
   {
     EZ_MEMBER_PROPERTY("GizmoScale", m_fGizmoScale),
+    EZ_MEMBER_PROPERTY("ShapeIconScale", m_fShapeIconScale),
   }
   EZ_END_PROPERTIES;
 }

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoComponent.h
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoComponent.h
@@ -37,6 +37,7 @@ class EZ_EDITORENGINEPROCESSFRAMEWORK_DLL ezGizmoComponent : public ezMeshCompon
 protected:
   virtual ezMeshRenderData* CreateRenderData(const ezRenderDataManager* pRenderDataManager) const override;
   virtual ezResult GetLocalBounds(ezBoundingBoxSphere& bounds, bool& bAlwaysVisible, ezMsgUpdateLocalBounds& msg) override;
+  void OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const;
 
   //////////////////////////////////////////////////////////////////////////
   // ezGizmoComponent
@@ -47,4 +48,5 @@ public:
 
   ezColor m_GizmoColor = ezColor::White;
   bool m_bIsPickable = true;
+  ezDynamicArray<ezVec3> m_Lines;
 };

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoHandle.h
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoHandle.h
@@ -57,6 +57,7 @@ enum ezEngineGizmoHandleType
   Frustum,
   Cross,
   FromFile,
+  CustomLines,
 };
 
 struct ezGizmoFlags
@@ -102,6 +103,7 @@ public:
   virtual void UpdateForEngine(ezWorld* pWorld) override;
 
   void SetColor(const ezColor& col);
+  void SetLines(ezArrayPtr<const ezVec3> lines);
 
 protected:
   bool m_bConstantSize = true;
@@ -116,4 +118,5 @@ protected:
   ezGizmoComponent* m_pGizmoComponent = nullptr;
   ezColor m_Color = ezColor::CornflowerBlue; /* The Original! */
   ezWorld* m_pWorld = nullptr;
+  ezDynamicArray<ezVec3> m_Lines;
 };

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoRenderer.h
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/GizmoRenderer.h
@@ -16,4 +16,5 @@ public:
   virtual void RenderBatch(const ezRenderViewContext& renderContext, const ezRenderPipelinePass* pPass, const ezRenderDataBatch& batch) const override;
 
   static float s_fGizmoScale;
+  static float s_fShapeIconScale;
 };

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoComponent.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoComponent.cpp
@@ -1,7 +1,10 @@
 #include <EditorEngineProcessFramework/EditorEngineProcessFrameworkPCH.h>
 
 #include <EditorEngineProcessFramework/Gizmos/GizmoComponent.h>
+#include <RendererCore/Debug/DebugRenderer.h>
+#include <RendererCore/Pipeline/RenderData.h>
 #include <RendererCore/Pipeline/RenderDataManager.h>
+#include <RendererCore/Pipeline/View.h>
 
 ezGizmoComponentManager::ezGizmoComponentManager(ezWorld* pWorld)
   : ezComponentManager(pWorld)
@@ -14,6 +17,11 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 
 EZ_BEGIN_COMPONENT_TYPE(ezGizmoComponent, 1, ezComponentMode::Static)
 {
+  EZ_BEGIN_MESSAGEHANDLERS
+  {
+    EZ_MESSAGE_HANDLER(ezMsgExtractRenderData, OnMsgExtractRenderData),
+  }
+  EZ_END_MESSAGEHANDLERS;
   EZ_BEGIN_ATTRIBUTES
   {
     new ezHiddenAttribute(),
@@ -45,10 +53,46 @@ ezMeshRenderData* ezGizmoComponent::CreateRenderData(const ezRenderDataManager* 
   return pRenderData;
 }
 
+void ezGizmoComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) const
+{
+  if (!m_Lines.IsEmpty())
+  {
+    ezTempHybridArray<ezDebugRendererLine, 64> lines;
+    lines.Reserve(m_Lines.GetCount() / 2);
+    for (ezUInt32 v = 0; v < m_Lines.GetCount(); v += 2)
+    {
+      auto& l = lines.ExpandAndGetRef();
+      l.m_start = m_Lines[v];
+      l.m_end = m_Lines[v + 1];
+    }
+
+    ezDebugRenderer::DrawLinesOccluded(ezDebugRendererContext(msg.m_pView->GetHandle()), lines, m_GizmoColor.GetDarker(), GetOwner()->GetGlobalTransform());
+    ezDebugRenderer::DrawLines(ezDebugRendererContext(msg.m_pView->GetHandle()), lines, m_GizmoColor, GetOwner()->GetGlobalTransform());
+
+    if (!m_hMesh.IsValid())
+      return;
+  }
+
+  SUPER::OnMsgExtractRenderData(msg);
+}
+
 ezResult ezGizmoComponent::GetLocalBounds(ezBoundingBoxSphere& bounds, bool& bAlwaysVisible, ezMsgUpdateLocalBounds& msg)
 {
-  const ezResult r = SUPER::GetLocalBounds(bounds, bAlwaysVisible, msg);
-  // since there is always only a single gizmo on screen, there's no harm in making it always visible
+  ezResult r = EZ_SUCCESS;
+
+  if (!m_Lines.IsEmpty())
+  {
+    // The actual line data lives in the component and can be updated without touching bounds.
+    // A unit-sized placeholder is enough because the gizmo is flagged as always visible.
+    bounds = ezBoundingBoxSphere::MakeFromCenterExtents(ezVec3(0), ezVec3(1), 1);
+  }
+  else
+  {
+    r = SUPER::GetLocalBounds(bounds, bAlwaysVisible, msg);
+  }
+
+  // Since there is always only a single gizmo on screen, there's no harm in making it always visible.
+  // Must be set after SUPER, because the base implementation may reset it.
   bAlwaysVisible = true;
   return r;
 }

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoHandle.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoHandle.cpp
@@ -30,6 +30,7 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEngineGizmoHandle, 1, ezRTTIDefaultAllocator<e
     EZ_MEMBER_PROPERTY("Ortho", m_bShowInOrtho),
     EZ_MEMBER_PROPERTY("Pickable", m_bIsPickable),
     EZ_MEMBER_PROPERTY("FaceCam", m_bFaceCamera),
+    EZ_ARRAY_MEMBER_PROPERTY("Lines", m_Lines),
   }
   EZ_END_PROPERTIES;
 }
@@ -691,6 +692,11 @@ bool ezEngineGizmoHandle::SetupForEngine(ezWorld* pWorld, ezUInt32 uiNextCompone
       hMeshBuffer = CreateMeshBufferFromFile(m_sGizmoHandleMesh);
     }
     break;
+
+    case ezEngineGizmoHandleType::CustomLines:
+      // no mesh needed, OnMsgExtractRenderData in ezGizmoComponent handles this case
+      break;
+
     default:
       EZ_ASSERT_NOT_IMPLEMENTED;
   }
@@ -722,35 +728,36 @@ bool ezEngineGizmoHandle::SetupForEngine(ezWorld* pWorld, ezUInt32 uiNextCompone
   }
 
   ezGizmoComponent::CreateComponent(pObject, m_pGizmoComponent);
+  m_pGizmoComponent->m_GizmoColor = m_Color;
+  m_pGizmoComponent->m_bIsPickable = m_bIsPickable;
+  m_pGizmoComponent->SetUniqueID(uiNextComponentPickingID);
 
-
-  ezMeshResourceHandle hMesh;
-
-  if (m_bVisualizer)
+  if (hMeshBuffer.IsValid())
   {
-    hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/Visualizer.ezMaterial");
-  }
-  else if (m_bConstantSize)
-  {
-    if (m_bFaceCamera)
+    ezMeshResourceHandle hMesh;
+
+    if (m_bVisualizer)
     {
-      hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandleConstantSizeCamFacing.ezMaterial");
+      hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/Visualizer.ezMaterial");
+    }
+    else if (m_bConstantSize)
+    {
+      if (m_bFaceCamera)
+      {
+        hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandleConstantSizeCamFacing.ezMaterial");
+      }
+      else
+      {
+        hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandleConstantSize.ezMaterial");
+      }
     }
     else
     {
-      hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandleConstantSize.ezMaterial");
+      hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandle.ezMaterial");
     }
-  }
-  else
-  {
-    hMesh = CreateMeshResource(szMeshGuid, hMeshBuffer, "Editor/Materials/GizmoHandle.ezMaterial");
-  }
 
-  m_pGizmoComponent->m_GizmoColor = m_Color;
-  m_pGizmoComponent->m_bIsPickable = m_bIsPickable;
-  m_pGizmoComponent->SetMesh(hMesh);
-
-  m_pGizmoComponent->SetUniqueID(uiNextComponentPickingID);
+    m_pGizmoComponent->SetMesh(hMesh);
+  }
 
   return true;
 }
@@ -770,10 +777,17 @@ void ezEngineGizmoHandle::UpdateForEngine(ezWorld* pWorld)
 
   m_pGizmoComponent->m_GizmoColor = m_Color;
   m_pGizmoComponent->SetActiveFlag(m_bVisible);
+  m_pGizmoComponent->m_Lines = m_Lines;
 }
 
 void ezEngineGizmoHandle::SetColor(const ezColor& col)
 {
   m_Color = col;
+  SetModified();
+}
+
+void ezEngineGizmoHandle::SetLines(ezArrayPtr<const ezVec3> lines)
+{
+  m_Lines = lines;
   SetModified();
 }

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoRenderer.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoRenderer.cpp
@@ -17,6 +17,7 @@ EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
 float ezGizmoRenderer::s_fGizmoScale = 1.0f;
+float ezGizmoRenderer::s_fShapeIconScale = 1.0f;
 
 ezGizmoRenderer::ezGizmoRenderer() = default;
 ezGizmoRenderer::~ezGizmoRenderer() = default;

--- a/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoRenderer.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/Gizmos/Implementation/GizmoRenderer.cpp
@@ -53,6 +53,11 @@ void ezGizmoRenderer::RenderBatch(const ezRenderViewContext& renderViewContext, 
 
   const ezGizmoRenderData* pRenderData = batch.GetFirstData<ezGizmoRenderData>();
 
+  // Mesh-less gizmos (e.g. CustomLines) render their geometry via ezDebugRenderer inside the
+  // component's extraction callback, so there is nothing to do here.
+  if (!pRenderData->m_hMesh.IsValid())
+    return;
+
   const ezMeshResourceHandle& hMesh = pRenderData->m_hMesh;
   const ezMaterialResourceHandle& hMaterial = pRenderData->m_hMaterial;
   ezUInt32 uiSubMeshIndex = pRenderData->m_uiSubMeshIndex;

--- a/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
+++ b/Code/Editor/EditorEngineProcessFramework/PickingRenderPass/PickingRenderPass.cpp
@@ -137,12 +137,15 @@ void ezPickingRenderPass::Execute(const ezRenderViewContext& renderViewContext, 
 
   if (m_PendingReadback.m_bReadbackInProgress)
   {
-    // Wait for results
+    // Poll the readback non-blockingly (4ms budget). If the results aren't ready yet, bail out
+    // and try again next frame, rather than stalling the editor process on the GPU.
     {
-      ezEnum<ezGALAsyncResult> res = m_PendingReadback.m_PickingReadback.GetReadbackResult(ezTime::MakeFromHours(1));
-      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
-      res = m_PendingReadback.m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromHours(1));
-      EZ_ASSERT_ALWAYS(res == ezGALAsyncResult::Ready, "Readback of texture failed");
+      if (m_PendingReadback.m_PickingReadback.GetReadbackResult(ezTime::MakeFromMilliseconds(4)) != ezGALAsyncResult::Ready)
+        return;
+
+      if (m_PendingReadback.m_PickingDepthReadback.GetReadbackResult(ezTime::MakeFromMilliseconds(4)) != ezGALAsyncResult::Ready)
+        return;
+
       m_PendingReadback.m_bReadbackInProgress = false;
     }
 

--- a/Code/Editor/EditorFramework/EditorApp/Startup.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Startup.cpp
@@ -52,6 +52,7 @@
 #include <EditorFramework/Visualizers/CylinderVisualizerAdapter.h>
 #include <EditorFramework/Visualizers/DirectionVisualizerAdapter.h>
 #include <EditorFramework/Visualizers/PositionVisualizerAdapter.h>
+#include <EditorFramework/Visualizers/RoundedRectVisualizerAdapter.h>
 #include <EditorFramework/Visualizers/SphereVisualizerAdapter.h>
 #include <EditorFramework/Visualizers/VisualizerAdapterRegistry.h>
 #include <Foundation/Application/Application.h>
@@ -180,6 +181,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezCylinderVisualizerAttribute>(), [](const ezRTTI* pRtti)->ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezCylinderVisualizerAdapter); });
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezDirectionVisualizerAttribute>(), [](const ezRTTI* pRtti)->ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezDirectionVisualizerAdapter); });
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezConeVisualizerAttribute>(), [](const ezRTTI* pRtti)->ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezConeVisualizerAdapter); });
+    ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezRoundedRectVisualizerAttribute>(), [](const ezRTTI* pRtti)->ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezRoundedRectVisualizerAdapter); });
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezCameraVisualizerAttribute>(), [](const ezRTTI* pRtti)->ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezCameraVisualizerAdapter); });
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.RegisterCreator(ezGetStaticRTTI<ezPositionVisualizerAttribute>(), [](const ezRTTI* pRtti)->ezVisualizerAdapter* { return EZ_DEFAULT_NEW(ezPositionVisualizerAdapter); });
 
@@ -234,6 +236,7 @@ EZ_BEGIN_SUBSYSTEM_DECLARATION(EditorFramework, EditorFrameworkMain)
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezCylinderVisualizerAttribute>());
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezDirectionVisualizerAttribute>());
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezConeVisualizerAttribute>());
+    ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezRoundedRectVisualizerAttribute>());
     ezVisualizerAdapterRegistry::GetSingleton()->m_Factory.UnregisterCreator(ezGetStaticRTTI<ezCameraVisualizerAttribute>());
 
     ezPropertyMetaState::GetSingleton()->m_Events.RemoveEventHandler(ezCompilerPreferences_PropertyMetaStateEventHandler);

--- a/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
+++ b/Code/Editor/EditorFramework/IPC/EngineProcessConnection.cpp
@@ -5,6 +5,7 @@
 #include <EditorFramework/Dialogs/RemoteConnectionDlg.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/IPC/EngineProcessConnection.h>
+#include <EditorFramework/Preferences/EditorPreferences.h>
 #include <Foundation/Utilities/CommandLineUtils.h>
 #include <GuiFoundation/UIServices/QtWaitForOperationDlg.moc.h>
 #include <ToolsFoundation/Application/ApplicationServices.h>
@@ -416,6 +417,9 @@ ezResult ezEditorEngineProcessConnection::RestartProcess()
     ShutdownProcess();
     return EZ_FAILURE;
   }
+
+  ezEditorPreferencesUser* pPreferences = ezPreferences::QueryPreferences<ezEditorPreferencesUser>();
+  pPreferences->SyncGlobalSettingsToEngine();
 
   ezLog::Dev("Transmitting open documents to Engine Process");
 

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.cpp
@@ -21,7 +21,8 @@ EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezEditorPreferencesUser, 1, ezRTTIDefaultAllocat
     EZ_MEMBER_PROPERTY("FieldOfView", m_fPerspectiveFieldOfView)->AddAttributes(new ezDefaultValueAttribute(70.0f), new ezClampValueAttribute(10.0f, 150.0f)),
     EZ_MEMBER_PROPERTY("CameraRotationSpeed", m_fCameraRotationSpeed)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.01f, 100.0f)),
     EZ_MEMBER_PROPERTY("MaxFramerate", m_uiMaxFramerate)->AddAttributes(new ezDefaultValueAttribute(60)),
-    EZ_ACCESSOR_PROPERTY("GizmoSize", GetGizmoSize, SetGizmoSize)->AddAttributes(new ezDefaultValueAttribute(1.5f), new ezClampValueAttribute(0.2f, 5.0f)),
+    EZ_ACCESSOR_PROPERTY("GizmoSize", GetGizmoSize, SetGizmoSize)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.2f, 5.0f)),
+    EZ_ACCESSOR_PROPERTY("ShapeIconSize", GetShapeIconSize, SetShapeIconSize)->AddAttributes(new ezDefaultValueAttribute(1.0f), new ezClampValueAttribute(0.2f, 5.0f)),
     EZ_ACCESSOR_PROPERTY("ShowInDevelopmentFeatures", GetShowInDevelopmentFeatures, SetShowInDevelopmentFeatures),
     EZ_MEMBER_PROPERTY("RotationSnap", m_RotationSnapValue)->AddAttributes(new ezDefaultValueAttribute(ezAngle::MakeFromDegree(15.0f)), new ezHiddenAttribute()),
     EZ_MEMBER_PROPERTY("ScaleSnap", m_fScaleSnapValue)->AddAttributes(new ezDefaultValueAttribute(0.125f), new ezHiddenAttribute()),
@@ -107,9 +108,14 @@ void ezEditorPreferencesUser::SetHighlightUntranslatedUI(bool b)
 void ezEditorPreferencesUser::SetGizmoSize(float f)
 {
   m_fGizmoSize = f;
-  SyncGlobalSettings();
+  SyncGlobalSettingsToEngine();
 }
 
+void ezEditorPreferencesUser::SetShapeIconSize(float f)
+{
+  m_fShapeIconSize = f;
+  SyncGlobalSettingsToEngine();
+}
 
 void ezEditorPreferencesUser::SetMaxFramerate(ezUInt16 uiFPS)
 {
@@ -119,10 +125,11 @@ void ezEditorPreferencesUser::SetMaxFramerate(ezUInt16 uiFPS)
   m_uiMaxFramerate = uiFPS;
 }
 
-void ezEditorPreferencesUser::SyncGlobalSettings()
+void ezEditorPreferencesUser::SyncGlobalSettingsToEngine()
 {
   ezGlobalSettingsMsgToEngine msg;
   msg.m_fGizmoScale = m_fGizmoSize;
+  msg.m_fShapeIconScale = m_fShapeIconSize;
 
   ezEditorEngineProcessConnection::GetSingleton()->SendMessage(&msg);
 }

--- a/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
+++ b/Code/Editor/EditorFramework/Preferences/EditorPreferences.h
@@ -62,15 +62,19 @@ public:
   void SetGizmoSize(float f);
   float GetGizmoSize() const { return m_fGizmoSize; }
 
+  void SetShapeIconSize(float f);
+  float GetShapeIconSize() const { return m_fShapeIconSize; }
+
   void SetMaxFramerate(ezUInt16 uiFPS);
   ezUInt16 GetMaxFramerate() const { return m_uiMaxFramerate; }
 
   ezHybridArray<ezString, 8> m_RecentlyCreatedTypes;
 
-private:
-  void SyncGlobalSettings();
+  void SyncGlobalSettingsToEngine();
 
+private:
   float m_fGizmoSize = 1.5f;
+  float m_fShapeIconSize = 1.0f;
   bool m_bShowInDevelopmentFeatures = false;
   ezUInt16 m_uiMaxFramerate = 60;
 };

--- a/Code/Editor/EditorFramework/Visualizers/Implementation/RoundedRectVisualizerAdapter.cpp
+++ b/Code/Editor/EditorFramework/Visualizers/Implementation/RoundedRectVisualizerAdapter.cpp
@@ -1,0 +1,163 @@
+#include <EditorFramework/EditorFrameworkPCH.h>
+
+#include <EditorFramework/Assets/AssetDocument.h>
+#include <EditorFramework/Visualizers/RoundedRectVisualizerAdapter.h>
+#include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+ezRoundedRectVisualizerAdapter::ezRoundedRectVisualizerAdapter() = default;
+
+ezRoundedRectVisualizerAdapter::~ezRoundedRectVisualizerAdapter() = default;
+
+void ezRoundedRectVisualizerAdapter::Finalize()
+{
+  auto* pDoc = m_pObject->GetDocumentObjectManager()->GetDocument()->GetMainDocument();
+  const ezAssetDocument* pAssetDocument = ezDynamicCast<const ezAssetDocument*>(pDoc);
+  EZ_ASSERT_DEV(pAssetDocument != nullptr, "Visualizers are only supported in ezAssetDocument.");
+
+  const ezRoundedRectVisualizerAttribute* pAttr = static_cast<const ezRoundedRectVisualizerAttribute*>(m_pVisualizerAttr);
+
+  m_hLinesInner.ConfigureHandle(nullptr, ezEngineGizmoHandleType::CustomLines, pAttr->m_InnerColor, ezGizmoFlags::ShowInOrtho | ezGizmoFlags::Visualizer);
+  m_hLinesOuter.ConfigureHandle(nullptr, ezEngineGizmoHandleType::CustomLines, pAttr->m_OuterColor, ezGizmoFlags::ShowInOrtho | ezGizmoFlags::Visualizer);
+
+  pAssetDocument->AddSyncObject(&m_hLinesInner);
+  pAssetDocument->AddSyncObject(&m_hLinesOuter);
+}
+
+
+static void BuildRoundedRectLines(ezDynamicArray<ezVec3>& ref_lines, float fHalfX, float fHalfY, float fRadius)
+{
+  ref_lines.Clear();
+
+  // Straight edge along X (top and bottom), skipped when halfX == 0.
+  if (fHalfX > 0.0f)
+  {
+    ref_lines.PushBack(ezVec3(-fHalfX, -(fHalfY + fRadius), 0.0f));
+    ref_lines.PushBack(ezVec3(+fHalfX, -(fHalfY + fRadius), 0.0f));
+
+    ref_lines.PushBack(ezVec3(+fHalfX, +(fHalfY + fRadius), 0.0f));
+    ref_lines.PushBack(ezVec3(-fHalfX, +(fHalfY + fRadius), 0.0f));
+  }
+  // Straight edge along Y (left and right), skipped when halfY == 0.
+  if (fHalfY > 0.0f)
+  {
+    ref_lines.PushBack(ezVec3(+(fHalfX + fRadius), -fHalfY, 0.0f));
+    ref_lines.PushBack(ezVec3(+(fHalfX + fRadius), +fHalfY, 0.0f));
+
+    ref_lines.PushBack(ezVec3(-(fHalfX + fRadius), +fHalfY, 0.0f));
+    ref_lines.PushBack(ezVec3(-(fHalfX + fRadius), -fHalfY, 0.0f));
+  }
+
+  if (fRadius <= 0.0f)
+    return;
+
+  // 4 quarter-circle arcs at the corners.
+  constexpr ezUInt32 uiSegmentsPerQuarter = 8;
+  constexpr float fStep = ezMath::Pi<float>() * 0.5f / uiSegmentsPerQuarter;
+
+  const ezVec2 vCorners[4] = {
+    ezVec2(+fHalfX, -fHalfY),    // bottom-right
+    ezVec2(+fHalfX, +fHalfY),    // top-right
+    ezVec2(-fHalfX, +fHalfY),    // top-left
+    ezVec2(-fHalfX, -fHalfY),    // bottom-left
+  };
+  const float fStartAngles[4] = {
+    -ezMath::Pi<float>() * 0.5f, // bottom-right: -90° → 0°
+    0.0f,                        // top-right:    0° → 90°
+    ezMath::Pi<float>() * 0.5f,  // top-left:     90° → 180°
+    ezMath::Pi<float>(),         // bottom-left:  180° → 270°
+  };
+
+  for (ezUInt32 c = 0; c < 4; ++c)
+  {
+    for (ezUInt32 s = 0; s < uiSegmentsPerQuarter; ++s)
+    {
+      const ezAngle fA0 = ezAngle::MakeFromRadian(fStartAngles[c] + s * fStep);
+      const ezAngle fA1 = ezAngle::MakeFromRadian(fStartAngles[c] + (s + 1) * fStep);
+
+      ref_lines.PushBack(ezVec3(vCorners[c].x + fRadius * ezMath::Cos(fA0), vCorners[c].y + fRadius * ezMath::Sin(fA0), 0.0f));
+      ref_lines.PushBack(ezVec3(vCorners[c].x + fRadius * ezMath::Cos(fA1), vCorners[c].y + fRadius * ezMath::Sin(fA1), 0.0f));
+    }
+  }
+}
+
+void ezRoundedRectVisualizerAdapter::Update()
+{
+  const ezRoundedRectVisualizerAttribute* pAttr = static_cast<const ezRoundedRectVisualizerAttribute*>(m_pVisualizerAttr);
+  ezObjectAccessorBase* pObjectAccessor = GetObjectAccessor();
+
+  float fSizeX = 0;
+  float fSizeY = 0;
+  float fInnerRadius = 0;
+  float fOuterRadius = 0;
+
+  if (!pAttr->GetPropHalfSizeX().IsEmpty())
+  {
+    ezVariant value;
+    pObjectAccessor->GetValue(m_pObject, GetProperty(pAttr->GetPropHalfSizeX()), value).AssertSuccess();
+
+    EZ_ASSERT_DEBUG(value.IsValid() && value.CanConvertTo<float>(), "Invalid property bound to ezRoundedRectVisualizerAttribute 'size x'");
+    fSizeX = value.ConvertTo<float>();
+  }
+
+  if (!pAttr->GetPropHalfSizeY().IsEmpty())
+  {
+    ezVariant value;
+    pObjectAccessor->GetValue(m_pObject, GetProperty(pAttr->GetPropHalfSizeY()), value).AssertSuccess();
+
+    EZ_ASSERT_DEBUG(value.IsValid() && value.CanConvertTo<float>(), "Invalid property bound to ezRoundedRectVisualizerAttribute 'size y'");
+    fSizeY = value.ConvertTo<float>();
+  }
+
+  if (!pAttr->GetPropInnerRadius().IsEmpty())
+  {
+    ezVariant value;
+    pObjectAccessor->GetValue(m_pObject, GetProperty(pAttr->GetPropInnerRadius()), value).AssertSuccess();
+
+    EZ_ASSERT_DEBUG(value.IsValid() && value.CanConvertTo<float>(), "Invalid property bound to ezRoundedRectVisualizerAttribute 'inner'");
+    fInnerRadius = value.ConvertTo<float>();
+  }
+
+  if (!pAttr->GetPropOuterRadius().IsEmpty())
+  {
+    ezVariant value;
+    pObjectAccessor->GetValue(m_pObject, GetProperty(pAttr->GetPropOuterRadius()), value).AssertSuccess();
+
+    EZ_ASSERT_DEBUG(value.IsValid() && value.CanConvertTo<float>(), "Invalid property bound to ezRoundedRectVisualizerAttribute 'outer'");
+    fOuterRadius = value.ConvertTo<float>();
+  }
+
+  ezTempHybridArray<ezVec3, 64> ref_lines;
+
+  if (fSizeX > 0 || fSizeY > 0 || fInnerRadius > 0)
+  {
+    BuildRoundedRectLines(ref_lines, fSizeX, fSizeY, fInnerRadius);
+    m_hLinesInner.SetLines(ref_lines);
+    m_hLinesInner.SetVisible(m_bVisualizerIsVisible);
+  }
+  else
+  {
+    m_hLinesInner.SetVisible(false);
+  }
+
+  if (fOuterRadius > 0)
+  {
+    BuildRoundedRectLines(ref_lines, fSizeX, fSizeY, fInnerRadius + fOuterRadius);
+    m_hLinesOuter.SetLines(ref_lines);
+    m_hLinesOuter.SetVisible(m_bVisualizerIsVisible);
+  }
+  else
+  {
+    m_hLinesOuter.SetVisible(false);
+  }
+}
+
+void ezRoundedRectVisualizerAdapter::UpdateGizmoTransform()
+{
+  const ezRoundedRectVisualizerAttribute* pAttr = static_cast<const ezRoundedRectVisualizerAttribute*>(m_pVisualizerAttr);
+
+  ezTransform t = GetObjectTransform();
+  t.m_vPosition += t.m_qRotation * pAttr->m_vOffset;
+
+  m_hLinesInner.SetTransformation(t);
+  m_hLinesOuter.SetTransformation(t);
+}

--- a/Code/Editor/EditorFramework/Visualizers/RoundedRectVisualizerAdapter.h
+++ b/Code/Editor/EditorFramework/Visualizers/RoundedRectVisualizerAdapter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <EditorEngineProcessFramework/Gizmos/GizmoHandle.h>
+#include <EditorFramework/EditorFrameworkDLL.h>
+#include <EditorFramework/Visualizers/VisualizerAdapter.h>
+
+struct ezGizmoEvent;
+
+class ezRoundedRectVisualizerAdapter : public ezVisualizerAdapter
+{
+public:
+  ezRoundedRectVisualizerAdapter();
+  ~ezRoundedRectVisualizerAdapter();
+
+protected:
+  virtual void Finalize() override;
+  virtual void Update() override;
+
+  virtual void UpdateGizmoTransform() override;
+
+  ezEngineGizmoHandle m_hLinesInner;
+  ezEngineGizmoHandle m_hLinesOuter;
+};

--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
@@ -3,7 +3,9 @@
 #include <EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.h>
 #include <Foundation/IO/FileSystem/FileSystem.h>
 #include <Foundation/IO/TypeVersionContext.h>
+#include <Foundation/Reflection/Implementation/PropertyAttributes.h>
 #include <RendererCore/Components/SpriteComponent.h>
+#include <RendererCore/Debug/DebugRenderer.h>
 #include <RendererCore/Pipeline/RenderDataManager.h>
 #include <RendererCore/Pipeline/View.h>
 
@@ -131,7 +133,7 @@ void ezEditorShapeIconsExtractor::ExtractShapeIcon(const ezGameObject* pObject, 
     {
       pRenderData->m_hTexture = pShapeIconInfo->m_hTexture;
       pRenderData->m_fSize = m_fSize;
-      pRenderData->m_fMaxScreenSize = m_fMaxScreenSize;
+      pRenderData->m_fMaxScreenSize = m_fMaxScreenSize * ezDebugRenderer::GetTextScale();
       pRenderData->m_fAspectRatio = 1.0f;
       pRenderData->m_BlendMode = ezSpriteBlendMode::ShapeIcon;
       pRenderData->m_texCoordScale = ezVec2(1.0f);
@@ -157,7 +159,13 @@ void ezEditorShapeIconsExtractor::ExtractShapeIcon(const ezGameObject* pObject, 
       pRenderData->FillSortingKey();
     }
 
-    extractedRenderData.AddRenderData(pRenderData, category);
+    ezRenderData::Category effectiveCategory = category;
+    if (pShapeIconInfo->m_bAlwaysVisible && category == ezDefaultRenderDataCategories::SimpleOpaque)
+    {
+      effectiveCategory = ezDefaultRenderDataCategories::SimpleForeground;
+    }
+
+    extractedRenderData.AddRenderData(pRenderData, effectiveCategory);
   }
 }
 
@@ -214,6 +222,11 @@ void ezEditorShapeIconsExtractor::FillShapeIconInfo()
         if (auto pCatAttribute = pRtti->GetAttributeByType<ezCategoryAttribute>())
         {
           shapeIconInfo.m_FallbackColor = ezColorScheme::GetCategoryColor(pCatAttribute->GetCategory(), ezColorScheme::CategoryColorUsage::ViewportIcon);
+        }
+
+        if (pRtti->GetAttributeByType<ezShapeIconAlwaysVisibleAttribute>() != nullptr)
+        {
+          shapeIconInfo.m_bAlwaysVisible = true;
         }
       }
     });

--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.cpp
@@ -1,5 +1,6 @@
 #include <EnginePluginScene/EnginePluginScenePCH.h>
 
+#include <EditorEngineProcessFramework/Gizmos/GizmoRenderer.h>
 #include <EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.h>
 #include <Foundation/IO/FileSystem/FileSystem.h>
 #include <Foundation/IO/TypeVersionContext.h>
@@ -133,7 +134,7 @@ void ezEditorShapeIconsExtractor::ExtractShapeIcon(const ezGameObject* pObject, 
     {
       pRenderData->m_hTexture = pShapeIconInfo->m_hTexture;
       pRenderData->m_fSize = m_fSize;
-      pRenderData->m_fMaxScreenSize = m_fMaxScreenSize * ezDebugRenderer::GetTextScale();
+      pRenderData->m_fMaxScreenSize = m_fMaxScreenSize * ezDebugRenderer::GetTextScale() * ezGizmoRenderer::s_fShapeIconScale;
       pRenderData->m_fAspectRatio = 1.0f;
       pRenderData->m_BlendMode = ezSpriteBlendMode::ShapeIcon;
       pRenderData->m_texCoordScale = ezVec2(1.0f);

--- a/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.h
+++ b/Code/EditorPlugins/Scene/EnginePluginScene/RenderPipeline/EditorShapeIconsExtractor.h
@@ -38,6 +38,7 @@ private:
     const ezTypedMemberProperty<ezColor>* m_pColorProperty;
     const ezTypedMemberProperty<ezColorGammaUB>* m_pColorGammaProperty;
     ezColor m_FallbackColor = ezColor::White;
+    bool m_bAlwaysVisible = false;
   };
 
   ezHashTable<const ezRTTI*, ShapeIconInfo> m_ShapeIconInfos;

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.cpp
@@ -19,6 +19,9 @@ EZ_BEGIN_STATIC_REFLECTED_BITFLAGS(ezDependencyFlags, 1)
 EZ_BITFLAGS_CONSTANTS(ezDependencyFlags::Package, ezDependencyFlags::Thumbnail, ezDependencyFlags::Transform)
 EZ_END_STATIC_REFLECTED_BITFLAGS;
 
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezShapeIconAlwaysVisibleAttribute, 1, ezRTTIDefaultAllocator<ezShapeIconAlwaysVisibleAttribute>)
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+
 EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezCategoryAttribute, 1, ezRTTIDefaultAllocator<ezCategoryAttribute>)
 {
   EZ_BEGIN_PROPERTIES
@@ -974,6 +977,40 @@ ezConeVisualizerAttribute::ezConeVisualizerAttribute(ezEnum<ezBasisAxis> axis, c
   , m_Axis(axis)
   , m_Color(fixedColor)
   , m_fScale(fScale)
+{
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+// clang-format off
+EZ_BEGIN_DYNAMIC_REFLECTED_TYPE(ezRoundedRectVisualizerAttribute, 1, ezRTTIDefaultAllocator<ezRoundedRectVisualizerAttribute>)
+{
+  EZ_BEGIN_PROPERTIES
+  {
+    EZ_MEMBER_PROPERTY("InnerColor", m_InnerColor),
+    EZ_MEMBER_PROPERTY("OuterColor", m_OuterColor),
+    EZ_MEMBER_PROPERTY("Offset", m_vOffset),
+  }
+  EZ_END_PROPERTIES;
+  EZ_BEGIN_FUNCTIONS
+  {
+    EZ_CONSTRUCTOR_PROPERTY(const char*, const char*, const char*, const ezColor&, const char*, const ezColor&, ezVec3),
+  }
+  EZ_END_FUNCTIONS;
+}
+EZ_END_DYNAMIC_REFLECTED_TYPE;
+// clang-format on
+
+ezRoundedRectVisualizerAttribute::ezRoundedRectVisualizerAttribute()
+  : ezVisualizerAttribute(nullptr)
+{
+}
+
+ezRoundedRectVisualizerAttribute::ezRoundedRectVisualizerAttribute(const char* szHalfSizeXProp, const char* szHalfSizeYProp, const char* szInnerRadiusProp, const ezColor& innerColor, const char* szOuterRadiusProp, const ezColor& outerColor, ezVec3 vLocalOffset)
+  : ezVisualizerAttribute(szHalfSizeXProp, szHalfSizeYProp, szInnerRadiusProp, szOuterRadiusProp)
+  , m_InnerColor(innerColor)
+  , m_OuterColor(outerColor)
+  , m_vOffset(vLocalOffset)
 {
 }
 

--- a/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
+++ b/Code/Engine/Foundation/Reflection/Implementation/PropertyAttributes.h
@@ -31,6 +31,14 @@ class EZ_FOUNDATION_DLL ezTemporaryAttribute : public ezPropertyAttribute
   EZ_ADD_DYNAMIC_REFLECTION(ezTemporaryAttribute, ezPropertyAttribute);
 };
 
+/// \brief When placed on a component type, its editor shape icon will be rendered through geometry (always visible).
+///
+/// Useful for components whose icons tend to end up inside geometry, such as spline nodes.
+class EZ_FOUNDATION_DLL ezShapeIconAlwaysVisibleAttribute : public ezPropertyAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezShapeIconAlwaysVisibleAttribute, ezPropertyAttribute);
+};
+
 /// \brief Used to categorize types (e.g. add component menu)
 class EZ_FOUNDATION_DLL ezCategoryAttribute : public ezPropertyAttribute
 {
@@ -938,6 +946,34 @@ public:
   ezEnum<ezBasisAxis> m_Axis;
   ezColor m_Color;
   float m_fScale;
+};
+
+//////////////////////////////////////////////////////////////////////////
+
+/// \brief Visualizes an axis-aligned rectangle in the local XY-plane with rounded corners, optionally surrounded by a second larger outline.
+///
+/// The inner outline describes a rectangle of size 2*HalfSizeX by 2*HalfSizeY, with all four corners rounded by InnerRadius.
+/// When OuterRadius is greater than 0, a second outline is drawn at distance (InnerRadius + OuterRadius) from the rectangle edges.
+/// This can be used to depict an influence area or falloff around the inner shape.
+///
+/// All size and radius values are read from the properties named in the constructor; any property name may be empty to fix that value to 0.
+/// The shape is drawn in the object's local XY-plane, translated by the given local offset.
+class EZ_FOUNDATION_DLL ezRoundedRectVisualizerAttribute : public ezVisualizerAttribute
+{
+  EZ_ADD_DYNAMIC_REFLECTION(ezRoundedRectVisualizerAttribute, ezVisualizerAttribute);
+
+public:
+  ezRoundedRectVisualizerAttribute();
+  ezRoundedRectVisualizerAttribute(const char* szHalfSizeXProp, const char* szHalfSizeYProp, const char* szInnerRadiusProp, const ezColor& innerColor, const char* szOuterRadiusProp, const ezColor& outerColor, ezVec3 vLocalOffset);
+
+  const ezUntrackedString& GetPropHalfSizeX() const { return m_sProperty1; }
+  const ezUntrackedString& GetPropHalfSizeY() const { return m_sProperty2; }
+  const ezUntrackedString& GetPropInnerRadius() const { return m_sProperty3; }
+  const ezUntrackedString& GetPropOuterRadius() const { return m_sProperty4; }
+
+  ezColor m_InnerColor = ezColor::White;
+  ezColor m_OuterColor = ezColor::White;
+  ezVec3 m_vOffset = ezVec3::MakeZero();
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonComponent.cpp
+++ b/Code/Engine/RendererCore/AnimationSystem/Implementation/SkeletonComponent.cpp
@@ -74,6 +74,7 @@ void ezSkeletonComponent::Update()
     const ezVec3 vBoneDir = qBoneDir * ezVec3(1, 0, 0);
     const ezVec3 vBoneTangent = qBoneDir * ezVec3(0, 1, 0);
 
+    ezDebugRenderer::DrawLinesOccluded(GetWorld(), m_LinesSkeleton, ezColor::White, GetOwner()->GetGlobalTransform());
     ezDebugRenderer::DrawLines(GetWorld(), m_LinesSkeleton, ezColor::White, GetOwner()->GetGlobalTransform());
 
     for (const auto& shape : m_SpheresShapes)

--- a/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/RopeRenderComponent.cpp
@@ -158,6 +158,7 @@ void ezRopeRenderComponent::OnMsgExtractRenderData(ezMsgExtractRenderData& msg) 
       z.m_endColor = ezColor::Blue;
     }
 
+    ezDebugRenderer::DrawLinesOccluded(msg.m_pView->GetHandle(), lines, ezColor::White.GetDarker(), GetOwner()->GetGlobalTransform());
     ezDebugRenderer::DrawLines(msg.m_pView->GetHandle(), lines, ezColor::White, GetOwner()->GetGlobalTransform());
   }
 }

--- a/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
+++ b/Code/Engine/RendererCore/Components/Implementation/SplineComponent.cpp
@@ -553,7 +553,7 @@ void ezSplineComponent::DrawDebugVisualizations(ezBitflags<ezSplineComponentFlag
   const bool bVisUp = flags.IsSet(ezSplineComponentFlags::VisualizeUpDir);
 
   ezTempHybridArray<ezDebugRendererLine, 32> lines;
-  ezColor c = ezColorScheme::DarkUI(ezColorScheme::Red);
+  ezColor c = ezColorScheme::LightUI(ezColorScheme::Pink);
   ezColor cUp = ezColorScheme::LightUI(ezColorScheme::Blue);
 
   ezVec3 lastPos = GetPositionAtKey(0);
@@ -592,6 +592,7 @@ void ezSplineComponent::DrawDebugVisualizations(ezBitflags<ezSplineComponentFlag
     fLastKey = fKey;
   }
 
+  ezDebugRenderer::DrawLinesOccluded(GetWorld(), lines, ezColor::White.GetDarker(), GetOwner()->GetGlobalTransform());
   ezDebugRenderer::DrawLines(GetWorld(), lines, ezColor::White, GetOwner()->GetGlobalTransform());
 
   const bool bVisTangents = flags.IsSet(ezSplineComponentFlags::VisualizeTangents);
@@ -686,6 +687,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezSplineNodeComponent, 1, ezComponentMode::Static)
   EZ_BEGIN_ATTRIBUTES
   {
     new ezCategoryAttribute("Utilities/Splines"),
+    new ezShapeIconAlwaysVisibleAttribute(),
     new ezSplineTangentManipulatorAttribute("TangentModeIn", "CustomTangentIn"),
     new ezSplineTangentManipulatorAttribute("TangentModeOut", "CustomTangentOut"),
     new ezSplineManipulatorAttribute("EditNodes", "Closed"),

--- a/Code/Engine/RendererCore/Debug/DebugRenderer.h
+++ b/Code/Engine/RendererCore/Debug/DebugRenderer.h
@@ -141,6 +141,14 @@ public:
   /// \brief Renders the given set of lines for one frame.
   static void DrawLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
 
+  /// \brief Renders lines that are always visible on top of all geometry (no depth test), with distance-based fade-out.
+  ///
+  /// Useful for showing lines through walls. To get distinct colors for visible vs. occluded portions, additionally
+  /// call DrawLines() with the same lines but a different color: the depth-tested DrawLines() result overrides
+  /// the always-on-top DrawLinesOccluded() result wherever the lines are not occluded.
+  /// Rendering of the occluded layer can be disabled globally via the CVar 'Debug.RenderOccluded'.
+  static void DrawLinesOccluded(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform = ezMat4::MakeIdentity());
+
   /// \brief Renders the given set of lines in 2D (screen-space) for one frame.
   static void Draw2DLines(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color);
 

--- a/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
+++ b/Code/Engine/RendererCore/Debug/Implementation/DebugRenderer.cpp
@@ -17,6 +17,7 @@
 #include <RendererFoundation/Shader/Types.h>
 
 ezCVarFloat cvar_AppTextScale("App.TextScale", 1.0f, ezCVarFlags::Save, "Global scale for debug text");
+ezCVarBool cvar_DebugRenderOccluded("Debug.RenderOccluded", true, ezCVarFlags::Save, "Also render debug geometry behind opaque surfaces, dimmed.");
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -113,6 +114,7 @@ namespace
   struct PerContextData
   {
     ezDynamicArray<Vertex, ezAlignedAllocatorWrapper> m_lineVertices;
+    ezDynamicArray<Vertex, ezAlignedAllocatorWrapper> m_lineOccludedVertices;
     ezDynamicArray<Vertex, ezAlignedAllocatorWrapper> m_triangleVertices;
     ezDynamicArray<Vertex, ezAlignedAllocatorWrapper> m_triangle2DVertices;
     ezDynamicArray<Vertex, ezAlignedAllocatorWrapper> m_line2DVertices;
@@ -168,6 +170,7 @@ namespace
       if (pData)
       {
         pData->m_lineVertices.Clear();
+        pData->m_lineOccludedVertices.Clear();
         pData->m_line2DVertices.Clear();
         pData->m_lineBoxes.Clear();
         pData->m_solidBoxes.Clear();
@@ -503,6 +506,29 @@ void ezDebugRenderer::DrawLines(const ezDebugRendererContext& context, ezArrayPt
     for (ezUInt32 i = 0; i < 2; ++i)
     {
       auto& vertex = data.m_lineVertices.ExpandAndGetRef();
+      vertex.m_position = mTransform.m_Mat4.TransformPosition(pPositions[i]);
+      vertex.m_color = pColors[i] * color;
+    }
+  }
+}
+
+void ezDebugRenderer::DrawLinesOccluded(const ezDebugRendererContext& context, ezArrayPtr<const ezDebugRendererLine> lines, const ezColor& color, ezMatOrTransform mTransform /*= ezMat4::MakeIdentity()*/)
+{
+  if (lines.IsEmpty())
+    return;
+
+  EZ_LOCK(s_Mutex);
+
+  auto& data = GetDataForExtraction(context);
+
+  for (auto& line : lines)
+  {
+    const ezVec3* pPositions = &line.m_start;
+    const ezColor* pColors = &line.m_startColor;
+
+    for (ezUInt32 i = 0; i < 2; ++i)
+    {
+      auto& vertex = data.m_lineOccludedVertices.ExpandAndGetRef();
       vertex.m_position = mTransform.m_Mat4.TransformPosition(pPositions[i]);
       vertex.m_color = pColors[i] * color;
     }
@@ -1585,6 +1611,96 @@ void ezDebugRenderer::RenderInternalWorldSpace(const ezDebugRendererContext& con
   ezGALCommandEncoder* pGALCommandEncoder = renderViewContext.m_pRenderContext->GetCommandEncoder();
 
   ezBindGroupBuilder& bindGroupRenderPass = ezRenderContext::GetDefaultInstance()->GetBindGroup(EZ_GAL_BIND_GROUP_RENDER_PASS);
+
+  // 3D Lines that show through geometry (no depth test, distance fade).
+  // Rendered first so the depth-tested regular line buffer below can override the visible portions.
+  // Globally disabled via the CVar 'Debug.RenderOccluded'.
+  if (cvar_DebugRenderOccluded)
+  {
+    ezUInt32 uiNumLineVertices = pData->m_lineOccludedVertices.GetCount();
+    if (uiNumLineVertices != 0)
+    {
+      CreateVertexBuffer(BufferType::Lines, sizeof(Vertex));
+
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PRE_TRANSFORMED_VERTICES", "FALSE");
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("OCCLUDED_PASS", "TRUE");
+      renderViewContext.m_pRenderContext->BindShader(s_hDebugPrimitiveShader);
+
+      const Vertex* pLineData = pData->m_lineOccludedVertices.GetData();
+      while (uiNumLineVertices > 0)
+      {
+        ezGALBufferHandle hBuffer = s_DataBuffer[BufferType::Lines].GetNewBuffer();
+        const ezUInt32 uiNumLineVerticesInBatch = ezMath::Min<ezUInt32>(uiNumLineVertices, LINE_VERTICES_PER_BATCH);
+        EZ_ASSERT_DEV(uiNumLineVerticesInBatch % 2 == 0, "Vertex count must be a multiple of 2.");
+        pGALCommandEncoder->UpdateBuffer(hBuffer, 0, ezMakeArrayPtr(pLineData, uiNumLineVerticesInBatch).ToByteArray(), ezGALUpdateMode::AheadOfTime);
+
+        renderViewContext.m_pRenderContext->BindMeshBuffer(ezMakeArrayPtr(&hBuffer, 1), ezGALBufferHandle(), ezMakeArrayPtr(s_VertexAttributes), ezGALPrimitiveTopology::Lines, uiNumLineVerticesInBatch / 2);
+
+        renderViewContext.m_pRenderContext->DrawMeshBuffer().IgnoreResult();
+
+        uiNumLineVertices -= uiNumLineVerticesInBatch;
+        pLineData += LINE_VERTICES_PER_BATCH;
+      }
+    }
+  }
+
+  renderViewContext.m_pRenderContext->SetShaderPermutationVariable("OCCLUDED_PASS", "FALSE");
+
+  // 3D Lines without occlusion
+  {
+    ezUInt32 uiNumLineVertices = pData->m_lineVertices.GetCount();
+    if (uiNumLineVertices != 0)
+    {
+      CreateVertexBuffer(BufferType::Lines, sizeof(Vertex));
+
+      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PRE_TRANSFORMED_VERTICES", "FALSE");
+      renderViewContext.m_pRenderContext->BindShader(s_hDebugPrimitiveShader);
+
+      const Vertex* pLineData = pData->m_lineVertices.GetData();
+      while (uiNumLineVertices > 0)
+      {
+        ezGALBufferHandle hBuffer = s_DataBuffer[BufferType::Lines].GetNewBuffer();
+        const ezUInt32 uiNumLineVerticesInBatch = ezMath::Min<ezUInt32>(uiNumLineVertices, LINE_VERTICES_PER_BATCH);
+        EZ_ASSERT_DEV(uiNumLineVerticesInBatch % 2 == 0, "Vertex count must be a multiple of 2.");
+        pGALCommandEncoder->UpdateBuffer(hBuffer, 0, ezMakeArrayPtr(pLineData, uiNumLineVerticesInBatch).ToByteArray(), ezGALUpdateMode::AheadOfTime);
+
+        renderViewContext.m_pRenderContext->BindMeshBuffer(ezMakeArrayPtr(&hBuffer, 1), ezGALBufferHandle(), ezMakeArrayPtr(s_VertexAttributes), ezGALPrimitiveTopology::Lines, uiNumLineVerticesInBatch / 2);
+
+        renderViewContext.m_pRenderContext->DrawMeshBuffer().IgnoreResult();
+
+        uiNumLineVertices -= uiNumLineVerticesInBatch;
+        pLineData += LINE_VERTICES_PER_BATCH;
+      }
+    }
+  }
+
+  // LineBoxes
+  {
+    ezUInt32 uiNumLineBoxes = pData->m_lineBoxes.GetCount();
+    if (uiNumLineBoxes != 0)
+    {
+      CreateDataBuffer(BufferType::LineBoxes, sizeof(BoxData));
+
+      renderViewContext.m_pRenderContext->BindShader(s_hDebugGeometryShader);
+
+      renderViewContext.m_pRenderContext->BindMeshBuffer(s_hLineBoxMeshBuffer);
+
+      const BoxData* pLineBoxData = pData->m_lineBoxes.GetData();
+      while (uiNumLineBoxes > 0)
+      {
+        ezGALBufferHandle hBuffer = s_DataBuffer[BufferType::LineBoxes].GetNewBuffer();
+        const ezUInt32 uiNumLineBoxesInBatch = ezMath::Min<ezUInt32>(uiNumLineBoxes, BOXES_PER_BATCH);
+        bindGroupRenderPass.BindBuffer("boxData", hBuffer);
+        pGALCommandEncoder->UpdateBuffer(hBuffer, 0, ezMakeArrayPtr(pLineBoxData, uiNumLineBoxesInBatch).ToByteArray(), ezGALUpdateMode::AheadOfTime);
+
+        renderViewContext.m_pRenderContext->DrawMeshBuffer(0xFFFFFFFF, 0, uiNumLineBoxesInBatch).IgnoreResult();
+
+        uiNumLineBoxes -= uiNumLineBoxesInBatch;
+        pLineBoxData += BOXES_PER_BATCH;
+      }
+    }
+  }
+
   // SolidBoxes
   {
     ezUInt32 uiNumSolidBoxes = pData->m_solidBoxes.GetCount();
@@ -1680,61 +1796,6 @@ void ezDebugRenderer::RenderInternalWorldSpace(const ezDebugRendererContext& con
           uiNumVertices -= uiNumVerticesInBatch;
           pTriangleData += TEX_TRIANGLE_VERTICES_PER_BATCH;
         }
-      }
-    }
-  }
-
-  // 3D Lines
-  {
-    ezUInt32 uiNumLineVertices = pData->m_lineVertices.GetCount();
-    if (uiNumLineVertices != 0)
-    {
-      CreateVertexBuffer(BufferType::Lines, sizeof(Vertex));
-
-      renderViewContext.m_pRenderContext->SetShaderPermutationVariable("PRE_TRANSFORMED_VERTICES", "FALSE");
-      renderViewContext.m_pRenderContext->BindShader(s_hDebugPrimitiveShader);
-
-      const Vertex* pLineData = pData->m_lineVertices.GetData();
-      while (uiNumLineVertices > 0)
-      {
-        ezGALBufferHandle hBuffer = s_DataBuffer[BufferType::Lines].GetNewBuffer();
-        const ezUInt32 uiNumLineVerticesInBatch = ezMath::Min<ezUInt32>(uiNumLineVertices, LINE_VERTICES_PER_BATCH);
-        EZ_ASSERT_DEV(uiNumLineVerticesInBatch % 2 == 0, "Vertex count must be a multiple of 2.");
-        pGALCommandEncoder->UpdateBuffer(hBuffer, 0, ezMakeArrayPtr(pLineData, uiNumLineVerticesInBatch).ToByteArray(), ezGALUpdateMode::AheadOfTime);
-
-        renderViewContext.m_pRenderContext->BindMeshBuffer(ezMakeArrayPtr(&hBuffer, 1), ezGALBufferHandle(), ezMakeArrayPtr(s_VertexAttributes), ezGALPrimitiveTopology::Lines, uiNumLineVerticesInBatch / 2);
-
-        renderViewContext.m_pRenderContext->DrawMeshBuffer().IgnoreResult();
-
-        uiNumLineVertices -= uiNumLineVerticesInBatch;
-        pLineData += LINE_VERTICES_PER_BATCH;
-      }
-    }
-  }
-
-  // LineBoxes
-  {
-    ezUInt32 uiNumLineBoxes = pData->m_lineBoxes.GetCount();
-    if (uiNumLineBoxes != 0)
-    {
-      CreateDataBuffer(BufferType::LineBoxes, sizeof(BoxData));
-
-      renderViewContext.m_pRenderContext->BindShader(s_hDebugGeometryShader);
-
-      renderViewContext.m_pRenderContext->BindMeshBuffer(s_hLineBoxMeshBuffer);
-
-      const BoxData* pLineBoxData = pData->m_lineBoxes.GetData();
-      while (uiNumLineBoxes > 0)
-      {
-        ezGALBufferHandle hBuffer = s_DataBuffer[BufferType::LineBoxes].GetNewBuffer();
-        const ezUInt32 uiNumLineBoxesInBatch = ezMath::Min<ezUInt32>(uiNumLineBoxes, BOXES_PER_BATCH);
-        bindGroupRenderPass.BindBuffer("boxData", hBuffer);
-        pGALCommandEncoder->UpdateBuffer(hBuffer, 0, ezMakeArrayPtr(pLineBoxData, uiNumLineBoxesInBatch).ToByteArray(), ezGALUpdateMode::AheadOfTime);
-
-        renderViewContext.m_pRenderContext->DrawMeshBuffer(0xFFFFFFFF, 0, uiNumLineBoxesInBatch).IgnoreResult();
-
-        uiNumLineBoxes -= uiNumLineBoxesInBatch;
-        pLineBoxData += BOXES_PER_BATCH;
       }
     }
   }

--- a/Code/Engine/RendererCore/Pipeline/Implementation/View.cpp
+++ b/Code/Engine/RendererCore/Pipeline/Implementation/View.cpp
@@ -395,11 +395,15 @@ void ezView::SetReadBackProperty(ezMap<ezString, PropertyValue>& map, const char
 
 void ezView::ReadBackPassProperties()
 {
+  EZ_PROFILE_SCOPE("ViewReadBackPassProperties");
+
   ezTempHybridArray<ezRenderPipelinePass*, 32> passes;
   m_pRenderPipeline->GetPasses(passes);
 
   for (auto pPass : passes)
   {
+    EZ_PROFILE_SCOPE(pPass->GetName());
+
     pPass->ReadBackProperties(this);
   }
 }

--- a/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
+++ b/Code/Engine/RendererFoundation/Device/Implementation/Device.cpp
@@ -1570,6 +1570,8 @@ void ezGALDevice::EndFrame()
   EZ_PROFILE_SCOPE("ezGALDevice::EndFrame");
 
   {
+    EZ_PROFILE_SCOPE("ezGALDevice::BeforeEndFrame");
+
     ezGALDeviceEvent e;
     e.m_pDevice = this;
     e.m_Type = ezGALDeviceEvent::BeforeEndFrame;

--- a/Code/Engine/RendererFoundation/Profiling/Profiling.h
+++ b/Code/Engine/RendererFoundation/Profiling/Profiling.h
@@ -24,10 +24,12 @@ protected:
 #if EZ_ENABLED(EZ_USE_PROFILING) || defined(EZ_DOCS)
 
 /// \brief Profiles the current scope using the given name and also inserts a marker with the given command encoder.
-#  define EZ_PROFILE_AND_MARKER(GALCommandEncoder, szName) ezProfilingScopeAndMarker EZ_PP_CONCAT(_ezProfilingScope, EZ_SOURCE_LINE)(GALCommandEncoder, szName)
+#  define EZ_PROFILE_AND_MARKER(GALCommandEncoder, ScopeName)                                                \
+    ezProfilingScopeAndMarker EZ_PP_CONCAT(_ezProfilingScope, EZ_SOURCE_LINE)(GALCommandEncoder, ScopeName); \
+    EZ_TRACY_PROFILE_SCOPE(ScopeName)
 
 #else
 
-#  define EZ_PROFILE_AND_MARKER(GALCommandEncoder, szName) /*empty*/
+#  define EZ_PROFILE_AND_MARKER(GALCommandEncoder, ScopeName) /*empty*/
 
 #endif

--- a/Code/EnginePlugins/AiPlugin/Navigation/Implementation/Navigation.cpp
+++ b/Code/EnginePlugins/AiPlugin/Navigation/Implementation/Navigation.cpp
@@ -445,6 +445,7 @@ void ezAiNavigation::DebugDrawPathLine(const ezDebugRendererContext& context, ez
       vStart = vthis;
     }
 
+    ezDebugRenderer::DrawLinesOccluded(context, lines, straightLineColor.GetDarker());
     ezDebugRenderer::DrawLines(context, lines, straightLineColor);
   }
 }

--- a/Code/EnginePlugins/GameComponentsPlugin/Debugging/Implementation/LineToComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Debugging/Implementation/LineToComponent.cpp
@@ -46,6 +46,7 @@ void ezLineToComponent::Update()
   line.m_start = GetOwner()->GetGlobalPosition();
   line.m_end = pTarget->GetGlobalPosition();
 
+  ezDebugRenderer::DrawLinesOccluded(GetWorld(), lines, m_LineColor.GetDarker());
   ezDebugRenderer::DrawLines(GetWorld(), lines, m_LineColor);
 }
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/RaycastComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/RaycastComponent.cpp
@@ -295,6 +295,7 @@ void ezRaycastComponent::Update()
   if (false)
   {
     ezDebugRendererLine lines[] = {{rayStartPosition, vNewPos}};
+    ezDebugRenderer::DrawLinesOccluded(GetWorld(), lines, ezColor::GreenYellow.GetDarker());
     ezDebugRenderer::DrawLines(GetWorld(), lines, ezColor::GreenYellow);
   }
 }

--- a/Data/Base/Shaders/Common/ConstantBufferMacros.h
+++ b/Data/Base/Shaders/Common/ConstantBufferMacros.h
@@ -55,16 +55,29 @@ float3x3 TransformToRotation(Transform t)
 // #  define COLOR4UB(Name) uint Name // TODO: this doesn't actually work
 #  define BOOL1(Name) bool Name
 
-// The types below are not supported for material constants
-#  define PACKEDHALF2(Name1, Name2, CombinedName) uint CombinedName
-#  define PACKEDCOLOR4H(Name)    \
-    uint EZ_PP_CONCAT(Name, RG); \
-    uint EZ_PP_CONCAT(Name, GB)
+// ### The types below are not supported for material constants ###
 
+#  define PACKEDHALF2(Name1, Name2, CombinedName) uint CombinedName
 #  define UNPACKHALF2(Name1, Name2, CombinedName) \
     float Name1 = f16tof32(CombinedName);         \
     float Name2 = f16tof32(CombinedName >> 16)
+
+#  define PACKEDCOLOR4H(Name)    \
+    uint EZ_PP_CONCAT(Name, RG); \
+    uint EZ_PP_CONCAT(Name, GB)
 #  define UNPACKCOLOR4H(Name) RGBA16FToFloat4(EZ_PP_CONCAT(Name, RG), EZ_PP_CONCAT(Name, GB))
+
+#  define PACKEDUINT16(Name1, Name2, CombinedName) uint CombinedName
+#  define UNPACKUINT16(Name1, Name2, CombinedName) \
+    uint Name1 = CombinedName & 0xFFFF;            \
+    uint Name2 = CombinedName >> 16
+
+#  define PACKEDUINT8(Name1, Name2, Name3, Name4, CombinedName) uint CombinedName
+#  define UNPACKUINT8(Name1, Name2, Name3, Name4, CombinedName) \
+    uint Name1 = CombinedName & 0xFF;                           \
+    uint Name2 = (CombinedName >> 8) & 0xFF;                    \
+    uint Name3 = (CombinedName >> 16) & 0xFF;                   \
+    uint Name4 = (CombinedName >> 24) & 0xFF
 
 #else
 
@@ -95,11 +108,24 @@ float3x3 TransformToRotation(Transform t)
 #  define MAT4(Name) ezShaderMat4 Name
 #  define TRANSFORM(Name) ezShaderTransform Name
 #  define COLOR4F(Name) ezColor Name
+
 // #  define COLOR4UB(Name) ezColorGammaUB Name // TODO: this doesn't actually work (in the shader)
+
 #  define BOOL1(Name) ezShaderBool Name
+
 #  define PACKEDHALF2(Name1, Name2, CombinedName) \
     ezFloat16 Name1;                              \
     ezFloat16 Name2
 #  define PACKEDCOLOR4H(Name) ezColorLinear16f Name
+
+#  define PACKEDUINT16(Name1, Name2, CombinedName) \
+    ezUInt16 Name1;                                \
+    ezUInt16 Name2
+
+#  define PACKEDUINT8(Name1, Name2, Name3, Name4, CombinedName) \
+    ezUInt8 Name1;                                              \
+    ezUInt8 Name2;                                              \
+    ezUInt8 Name3;                                              \
+    ezUInt8 Name4
 
 #endif

--- a/Data/Base/Shaders/Debug/DebugPrimitive.ezShader
+++ b/Data/Base/Shaders/Debug/DebugPrimitive.ezShader
@@ -62,27 +62,20 @@ VS_OUT main(VS_IN Input)
 #include <Shaders/Materials/MaterialInterpolator.h>
 #include <Shaders/Common/GlobalConstants.h>
 
-float interleavedGradientNoise(float2 fragCoord)
-{
-  float3 magic = float3(0.06711056, 0.00583715, 52.9829189);
-  return frac(magic.z * frac(dot(fragCoord, magic.xy)));
-}
-
 float4 main(PS_IN Input) : SV_Target
 {
+  float4 col = Input.Color0;
+
 #if OCCLUDED_PASS
   {
     float viewDist = Input.Position.w;
     const float fadeStart = 30.0;
     const float fadeDist = 70.0;
     float fade = saturate(1.0 - (viewDist - fadeStart) / fadeDist);
-    if (interleavedGradientNoise(Input.Position.xy) > fade)
-    {
-      discard;
-    }
+    col.a *= fade;
   }
 #endif
 
-  return Input.Color0;
+  return col;
 }
 

--- a/Data/Base/Shaders/Debug/DebugPrimitive.ezShader
+++ b/Data/Base/Shaders/Debug/DebugPrimitive.ezShader
@@ -6,6 +6,7 @@ ALL
 PRE_TRANSFORMED_VERTICES
 CAMERA_MODE
 TOPOLOGY
+OCCLUDED_PASS
 
 [RENDERSTATE]
 
@@ -14,11 +15,16 @@ DestBlend0 = Blend_InvSrcAlpha
 SourceBlend0 = Blend_SrcAlpha
 DestBlendAlpha0 = Blend_InvSrcAlpha
 
-DepthTest = true
-#if PRE_TRANSFORMED_VERTICES
+#if OCCLUDED_PASS
+  DepthTest = false
   DepthWrite = false
 #else
-  DepthWrite = true
+  DepthTest = true
+  #if PRE_TRANSFORMED_VERTICES
+    DepthWrite = false
+  #else
+    DepthWrite = true
+  #endif
 #endif
 
 [VERTEXSHADER]
@@ -56,8 +62,27 @@ VS_OUT main(VS_IN Input)
 #include <Shaders/Materials/MaterialInterpolator.h>
 #include <Shaders/Common/GlobalConstants.h>
 
+float interleavedGradientNoise(float2 fragCoord)
+{
+  float3 magic = float3(0.06711056, 0.00583715, 52.9829189);
+  return frac(magic.z * frac(dot(fragCoord, magic.xy)));
+}
+
 float4 main(PS_IN Input) : SV_Target
 {
+#if OCCLUDED_PASS
+  {
+    float viewDist = Input.Position.w;
+    const float fadeStart = 30.0;
+    const float fadeDist = 70.0;
+    float fade = saturate(1.0 - (viewDist - fadeStart) / fadeDist);
+    if (interleavedGradientNoise(Input.Position.xy) > fade)
+    {
+      discard;
+    }
+  }
+#endif
+
   return Input.Color0;
 }
 

--- a/Data/Base/Shaders/Materials/SpriteMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/SpriteMaterial.ezShader
@@ -117,11 +117,6 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
 
 #include <Shaders/Materials/MaterialHelper.h>
 
-float interleavedGradientNoise(float2 fragCoord) {
-    float3 magic = float3(0.06711056, 0.00583715, 52.9829189);
-    return frac(magic.z * frac(dot(fragCoord, magic.xy)));
-}
-
 struct PS_OUT
 {
   #if RENDER_PASS != RENDER_PASS_DEPTH_ONLY
@@ -168,7 +163,7 @@ PS_OUT main(PS_IN Input)
     const float fadeStart = 75.0;
     const float fadeDist = 10.0;
     float fade = saturate(1.0 - (viewDist - fadeStart) / fadeDist);
-    if (interleavedGradientNoise(Input.Position.xy) > fade)
+    if (InterleavedGradientNoise(Input.Position.xy) > fade)
     {
       discard;
     }

--- a/Data/Base/Shaders/Materials/SpriteMaterial.ezShader
+++ b/Data/Base/Shaders/Materials/SpriteMaterial.ezShader
@@ -11,11 +11,17 @@ TWO_SIDED = FALSE
 FLIP_WINDING = FALSE
 CAMERA_MODE
 SHADING_MODE = SHADING_MODE_FULLBRIGHT
+PREPARE_DEPTH
 
 [RENDERSTATE]
 
 #include <Shaders/Materials/MaterialState.h>
 WireFrame = false
+
+#if SHAPE_ICON && PREPARE_DEPTH
+  DepthTest = false
+  DepthWrite = false
+#endif
 
 [SHADER]
 
@@ -92,6 +98,10 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
   Output.TexCoord0 = texCoords * texCoordScale + texCoordOffset;
   Output.Color0 = RGBA16FToFloat4(data.ColorRG, data.ColorBA);
 
+#if PREPARE_DEPTH && SHAPE_ICON
+  Output.Color0 = float4(0.12, 0.12, 0.15, 0);
+#endif
+
   #if defined(USE_GAME_OBJECT_ID)
     Output.GameObjectID = data.GameObjectID;
   #endif
@@ -106,6 +116,11 @@ VS_OUT main(uint VertexID : SV_VertexID, uint InstanceID : SV_InstanceID)
 #endif
 
 #include <Shaders/Materials/MaterialHelper.h>
+
+float interleavedGradientNoise(float2 fragCoord) {
+    float3 magic = float3(0.06711056, 0.00583715, 52.9829189);
+    return frac(magic.z * frac(dot(fragCoord, magic.xy)));
+}
 
 struct PS_OUT
 {
@@ -123,7 +138,7 @@ SamplerState SpriteTexture_AutoSampler BIND_GROUP(BG_DRAW_CALL);
 
 float GetOpacity()
 {
-  float opacity = SpriteTexture.Sample(SpriteTexture_AutoSampler, G.Input.TexCoord0.xy).a * G.Input.Color0.a;
+  float opacity = SpriteTexture.Sample(SpriteTexture_AutoSampler, G.Input.TexCoord0.xy).a;
 
   #if BLEND_MODE == BLEND_MODE_MASKED
     return opacity - 0.5;
@@ -146,14 +161,28 @@ PS_OUT main(PS_IN Input)
     discard;
   }
 
+#if SHAPE_ICON && PREPARE_DEPTH
+  {
+     // fade out after some distance
+    float viewDist = Input.Position.w;
+    const float fadeStart = 75.0;
+    const float fadeDist = 10.0;
+    float fade = saturate(1.0 - (viewDist - fadeStart) / fadeDist);
+    if (interleavedGradientNoise(Input.Position.xy) > fade)
+    {
+      discard;
+    }
+  }
+#endif
+
   float4 color = SpriteTexture.Sample(SpriteTexture_AutoSampler, Input.TexCoord0.xy);
 
 #if SHAPE_ICON
   float3 tintedColor = saturate(color.rgb * Input.Color0.rgb * 2.0);
-  float factor = saturate(GetLuminance(color.rgb) * 3.0 - 2.0);
+  float factor = saturate(GetLuminance(color.rgb * Input.Color0.a) * 3.0 - 2.0);
   color.rgb = lerp(tintedColor, 1.0, factor);
 #else
-  color *= Input.Color0;
+  color.rgb *= Input.Color0.rgb;
 #endif
 
   PS_OUT Output;

--- a/Data/Base/Shaders/PermutationVars/OCCLUDED_PASS.ezPermVar
+++ b/Data/Base/Shaders/PermutationVars/OCCLUDED_PASS.ezPermVar
@@ -1,0 +1,1 @@
+bool OCCLUDED_PASS;


### PR DESCRIPTION
ezDebugRenderer geometry is now rendered dimmed when occluded. Allows to see debug geometry through walls while keeping some perception of occlusion. Not sure yet, whether this should be enabled on everything by default, but difficult to implement differently.

Editor gizmos can now render themselves with arbitrary lines. Uses the debug renderer, so lines will show through walls (now). Allows for more dynamic gizmos.

Added an ezRoundedRectVisualizerAttribute, which visualizes a rounded rectangle around the object.

Added ezShapeIconAlwaysVisibleAttribute. If used, shape icons for that object shine through walls. Used on spline nodes, which makes it easier to use splines when they are inside objects (e.g. the spline meshes).

<img width="842" height="564" alt="grafik" src="https://github.com/user-attachments/assets/ce743400-ffb1-43c6-9210-90ebe616de12" />

<img width="1049" height="663" alt="image" src="https://github.com/user-attachments/assets/07e868a2-83f1-4cfb-9bf4-30a22da49bac" />
