### PR TITLE
Add radius parameter to the projectile component

### DIFF
--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -29,6 +29,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProjectileSurfaceInteraction, ezNoBase, 3, ezRT
     EZ_MEMBER_PROPERTY("ImpulseType", m_uiImpulseType)->AddAttributes(new ezDynamicEnumAttribute("PhysicsImpulseType")),
     EZ_MEMBER_PROPERTY("Impulse", m_fImpulse),
     EZ_MEMBER_PROPERTY("Damage", m_fDamage),
+    EZ_MEMBER_PROPERTY("InertiaRatio", m_fInertiaRatio)->AddAttributes(new ezDefaultValueAttribute(5.0f)),
   }
   EZ_END_PROPERTIES;
 }
@@ -45,6 +46,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 8, ezComponentMode::Dynamic)
     EZ_RESOURCE_MEMBER_PROPERTY("OnDeathPrefab", m_hDeathPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("Radius", m_fRadius)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_MEMBER_PROPERTY("StaticVelocityRatio", m_fStaticVelocityRatio)->AddAttributes(new ezDefaultValueAttribute(0.05f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_BITFLAGS_MEMBER_PROPERTY("ShapeTypesToHit", ezPhysicsShapeType, m_ShapeTypesToHit)->AddAttributes(new ezDefaultValueAttribute(ezVariant(ezPhysicsShapeType::Default & ~(ezPhysicsShapeType::Trigger)))),
     EZ_ACCESSOR_PROPERTY("FallbackSurface", GetFallbackSurfaceFile, SetFallbackSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ARRAY_MEMBER_PROPERTY("Interactions", m_SurfaceInteractions),
@@ -87,6 +89,7 @@ ezProjectileComponent::ezProjectileComponent()
   m_fMetersPerSecond = 10.0f;
   m_uiCollisionLayer = 0;
   m_fRadius = 0.0f;
+  m_fStaticVelocityRatio = 0.05f;
   m_fGravityMultiplier = 0.0f;
   m_vVelocity.SetZero();
   m_bSpawnPrefabOnStatic = false;
@@ -96,6 +99,8 @@ ezProjectileComponent::~ezProjectileComponent() = default;
 
 void ezProjectileComponent::Update()
 {
+  const float fPenetrationDepth = m_fRadius * 0.5f;
+
   if (m_fGravityMultiplier == 0.0f && m_fMetersPerSecond == 0.0f)
     return;
 
@@ -132,7 +137,7 @@ void ezProjectileComponent::Update()
     if (QueryCollision(*pPhysicsInterface, castResult, vCurPosition, vCurDirection, fDistance, queryParams))
     {
       const ezVec3 vNewCenterPosition = (m_fRadius > 0.0f)
-        ? CalculateSphereCenterPosition(vCurPosition, vCurDirection, castResult, m_fRadius * 0.5f)
+        ? CalculateSphereCenterPosition(vCurPosition, vCurDirection, castResult, fPenetrationDepth)
         : castResult.m_vPosition;
 
       const ezSurfaceResourceHandle hSurface = castResult.m_hSurface.IsValid() ? castResult.m_hSurface : m_hFallbackSurface;
@@ -216,41 +221,50 @@ void ezProjectileComponent::Update()
         }
         else if (interaction.m_Reaction == ezProjectileReaction::Reflect || interaction.m_Reaction == ezProjectileReaction::Bounce)
         {
-          /// \todo Should reflect around the actual hit position
-          /// \todo Should preserve travel distance while reflecting
-
-          // const float fLength = (vPos - vCurPosition).GetLength();
-
-          vNewPosition = vCurPosition; // vPos;
-
-          const ezVec3 vNewDirection = vCurDirection.GetReflectedVector(castResult.m_vNormal);
-
-          ezQuat qRot = ezQuat::MakeShortestRotation(vCurDirection, vNewDirection);
-
-          GetOwner()->SetGlobalRotation(qRot * GetOwner()->GetGlobalRotation());
-
-          m_vVelocity = qRot * m_vVelocity;
-
-          if (interaction.m_Reaction == ezProjectileReaction::Bounce)
+          vNewPosition = vCurPosition;
+          const float velocityToNormalProj = m_vVelocity.Dot(castResult.m_vNormal);
+          if (velocityToNormalProj < 0.0f)
           {
-            ezResourceLock<ezSurfaceResource> pSurface(hSurface, ezResourceAcquireMode::BlockTillLoaded);
+            // the same as m_vVelocity.GetReflectedVector but reuse precalculated velocityToNormalProj
+            ezVec3 vNewVelocity = m_vVelocity - 2.0f * velocityToNormalProj * castResult.m_vNormal;
 
-            if (pSurface)
+            // Position of the projectile at the moment of reflection
+
+            if (interaction.m_Reaction == ezProjectileReaction::Bounce)
             {
-              m_vVelocity *= pSurface->GetDescriptor().m_fPhysicsRestitution;
-            }
+              ezResourceLock<ezSurfaceResource> pSurface(hSurface, ezResourceAcquireMode::BlockTillLoaded);
 
-            if (m_vVelocity.GetLength() < 1.0f)
-            {
-              m_vVelocity = ezVec3::MakeZero();
-              m_fGravityMultiplier = 0.0f;
-
-              if (m_bSpawnPrefabOnStatic)
+              if (pSurface)
               {
-                SpawnDeathPrefab();
-                GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());
+                vNewVelocity *= pSurface->GetDescriptor().m_fPhysicsRestitution;
+              }
+
+              if (ShouldStopProjectile(*pPhysicsInterface, castResult, vNewVelocity))
+              {
+                vNewVelocity = ezVec3::MakeZero();
+                m_fGravityMultiplier = 0.0f;
+
+                if (m_bSpawnPrefabOnStatic)
+                {
+                  SpawnDeathPrefab();
+                  GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());
+                }
               }
             }
+
+            const ezVec3 vPositionOnReflection = vCurPosition + castResult.m_fDistance * vCurDirection;
+            ApplySpinRotation(interaction, castResult, vPositionOnReflection, vCurDirection, vNewVelocity);
+            const float fAbsVelocity = m_vVelocity.GetLength();
+            // condition velocityToNormalProj < 0.0f implies fAbsVelocity is non-zero
+            const float fTimeBeforeReflection = castResult.m_fDistance / fAbsVelocity;
+            const float fTimeLeft = ezMath::Max(0.0f, fTimeDiff - fTimeBeforeReflection);
+            // Path travelled back after the reflection
+            vNewPosition = vPositionOnReflection + vNewVelocity * fTimeLeft;
+            m_vVelocity = vNewVelocity;
+          }
+          else
+          {
+            vNewPosition += m_vVelocity * fTimeDiff;
           }
         }
         else if (interaction.m_Reaction == ezProjectileReaction::Attach)
@@ -289,6 +303,7 @@ void ezProjectileComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
   s << m_fGravityMultiplier;
   s << m_uiCollisionLayer;
   s << m_fRadius;
+  s << m_fStaticVelocityRatio;
   s << m_MaxLifetime;
   s << m_hDeathPrefab;
 
@@ -313,6 +328,9 @@ void ezProjectileComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 
     // Version 7
     s << ia.m_uiImpulseType;
+
+    // Version 8
+    s << ia.m_fInertiaRatio;
   }
 
   // Version 5
@@ -335,10 +353,12 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
   if (uiVersion >= 8)
   {
     s >> m_fRadius;
+    s >> m_fStaticVelocityRatio;
   }
   else
   {
     m_fRadius = 0.0f;
+    m_fStaticVelocityRatio = 0.05f;
   }
 
   s >> m_MaxLifetime;
@@ -377,6 +397,11 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
     {
       s >> ia.m_uiImpulseType;
     }
+
+    if (uiVersion >= 8)
+    {
+      s >> ia.m_fInertiaRatio;
+    }
   }
 
   if (uiVersion >= 5)
@@ -401,6 +426,61 @@ bool ezProjectileComponent::QueryCollision(const ezPhysicsWorldModuleInterface& 
   return physicsInterface.Raycast(out_result, vStart, vDirection, fDistance, queryParams);
 }
 
+void ezProjectileComponent::ApplySpinRotation(const ezProjectileSurfaceInteraction& interaction,
+                                              const ezPhysicsCastResult& castResult,
+                                              const ezVec3& vPositionOnReflection,
+                                              const ezVec3& vCurDirection,
+                                              const ezVec3& vNewVelocity)
+{
+  if (interaction.m_fInertiaRatio == 0.0f)
+    return;
+
+  const ezVec3 vRelativeHitPosOnReflection = castResult.m_vPosition - vPositionOnReflection;
+  const float vRelativeHitPosLength = vRelativeHitPosOnReflection.GetLength();
+  ezVec3 vForceRadialVector;
+  if (m_fRadius > 0.0f && vRelativeHitPosLength > 0.0f)
+  {
+    // if the projectile has a radius it is natural to assume that the torque is created
+    // by the force acting on the radial vector connecting the center to the contact point
+    vForceRadialVector = vRelativeHitPosOnReflection / vRelativeHitPosLength;
+  }
+  else
+  {
+    // Otherwise assume radial vector coincides with direction
+    vForceRadialVector = vCurDirection;
+  }
+
+  // Assuming the timeDiff is small we can say that the difference between velocities
+  // is proportional to the acting force
+  ezVec3 vEffectiveForce = m_vVelocity - vNewVelocity;
+  // We assume that this force is responsible for torque and angular momentum
+  ezVec3 vEffectiveTorque = -vForceRadialVector.CrossRH(vEffectiveForce) / interaction.m_fInertiaRatio;
+
+  const float fAngle = ezMath::Min(vEffectiveTorque.GetLength(), ezMath::Pi<float>());
+  if (fAngle > 0.0f)
+  {
+    ezAngle angle = ezAngle::MakeFromRadian(fAngle);
+    ezQuat qRot = ezQuat::MakeFromAxisAndAngle(vEffectiveTorque.GetNormalized(), angle);
+    GetOwner()->SetGlobalRotation(qRot * GetOwner()->GetGlobalRotation());
+  }
+}
+
+bool ezProjectileComponent::ShouldStopProjectile(const ezPhysicsWorldModuleInterface& physicsInterface, const ezPhysicsCastResult& castResult, const ezVec3& vVelocity)
+{
+  const ezVec3 vGravity = physicsInterface.GetGravity();
+  if (!vGravity.IsZero())
+  {
+    const ezVec3 vGravityDir = vGravity.GetNormalized();
+    // Check that projectile has hit the ground
+    // if not - return false to make sure it won't hang in the air after being stopped
+    if (vGravityDir.Dot(castResult.m_vNormal) > -0.6f)
+    {
+      return false;
+    }
+  }
+
+  return vVelocity.GetLength() < m_fStaticVelocityRatio * m_fMetersPerSecond;
+}
 
 ezInt32 ezProjectileComponent::FindSurfaceInteraction(const ezSurfaceResourceHandle& hSurface) const
 {

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -44,7 +44,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 8, ezComponentMode::Dynamic)
     EZ_MEMBER_PROPERTY("SpawnPrefabOnStatic", m_bSpawnPrefabOnStatic),
     EZ_RESOURCE_MEMBER_PROPERTY("OnDeathPrefab", m_hDeathPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
-    EZ_MEMBER_PROPERTY("Radius", m_fRadius)->AddAttributes(new ezDefaultValueAttribute(0.0f), new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_MEMBER_PROPERTY("Radius", m_fRadius)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_BITFLAGS_MEMBER_PROPERTY("ShapeTypesToHit", ezPhysicsShapeType, m_ShapeTypesToHit)->AddAttributes(new ezDefaultValueAttribute(ezVariant(ezPhysicsShapeType::Default & ~(ezPhysicsShapeType::Trigger)))),
     EZ_ACCESSOR_PROPERTY("FallbackSurface", GetFallbackSurfaceFile, SetFallbackSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ARRAY_MEMBER_PROPERTY("Interactions", m_SurfaceInteractions),

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -69,32 +69,16 @@ namespace
 {
   /// \brief Helper function to recalculate the sphere position from hit position
   /// \param vOrigin is expected to be the initial position of the particle before SweepTest
-  ezVec3 CalculateSphereCenterPosition(const ezVec3& vOrigin, const ezVec3& vDirection, float fRadius, const ezVec3& vHitPosition)
+  ezVec3 CalculateSphereCenterPosition(const ezVec3& vOrigin, const ezVec3& vDirection, const ezPhysicsCastResult& castResult, float fPenetrationDepth)
   {
-    const ezVec3 vHitRelative = vHitPosition - vOrigin;
-    const float fHitToDirProj = vHitRelative.Dot(vDirection);
-
-    if (fHitToDirProj < 0.0f)
+    if (castResult.m_fDistance == 0.0f)
     {
       // It says that the hit position is "behind" (if we move along vDirection) vOrigin
-      // Likely this can only happen when there is already a collision before the particle has started moving
-      // Thus, return the original line position
+      // Thus, return the original position
       return vOrigin;
     }
 
-    // Distance from hit pos to the line passing through the vOrigin along vDirection
-    // This distance is equal to r * sin(theta),
-    // where theta is the angle between vDirection and the vector connecting hit pos and supposed new sphere center (vNewCenter)
-    const float fDistSquared = vHitRelative.GetLengthSquared() - fHitToDirProj * fHitToDirProj;
-
-    // Here fOffset is r * cos(theta),
-    // it equals to the distance between vHitPosition and vNewCenter projected to vDirection
-    const float fOffset = ezMath::Sqrt(ezMath::Max(0.0f, fRadius * fRadius - fDistSquared));
-
-    const ezVec3 vNewCenter = vOrigin + (fHitToDirProj - fOffset) * vDirection;
-
-    // Lerp result to make projectile go a bit "inside" into the object it collided
-    return ezMath::Lerp(vNewCenter, vHitPosition, 0.1f);
+    return vOrigin + vDirection * (castResult.m_fDistance + fPenetrationDepth);
   }
 } // namespace
 
@@ -148,7 +132,7 @@ void ezProjectileComponent::Update()
     if (QueryCollision(*pPhysicsInterface, castResult, vCurPosition, vCurDirection, fDistance, queryParams))
     {
       const ezVec3 vNewCenterPosition = (m_fRadius > 0.0f)
-        ? CalculateSphereCenterPosition(vCurPosition, vCurDirection, m_fRadius, castResult.m_vPosition)
+        ? CalculateSphereCenterPosition(vCurPosition, vCurDirection, castResult, m_fRadius * 0.5f)
         : castResult.m_vPosition;
 
       const ezSurfaceResourceHandle hSurface = castResult.m_hSurface.IsValid() ? castResult.m_hSurface : m_hFallbackSurface;

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -19,6 +19,11 @@ EZ_BEGIN_STATIC_REFLECTED_ENUM(ezProjectileReaction, 2)
   EZ_ENUM_CONSTANT(ezProjectileReaction::PassThrough)
 EZ_END_STATIC_REFLECTED_ENUM;
 
+EZ_BEGIN_STATIC_REFLECTED_ENUM(ezProjectileBounceOrientation, 1)
+  EZ_ENUM_CONSTANT(ezProjectileBounceOrientation::Reflection),
+  EZ_ENUM_CONSTANT(ezProjectileBounceOrientation::Spinning)
+EZ_END_STATIC_REFLECTED_ENUM;
+
 EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProjectileSurfaceInteraction, ezNoBase, 3, ezRTTIDefaultAllocator<ezProjectileSurfaceInteraction>)
 {
   EZ_BEGIN_PROPERTIES
@@ -46,6 +51,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 8, ezComponentMode::Dynamic)
     EZ_RESOURCE_MEMBER_PROPERTY("OnDeathPrefab", m_hDeathPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
     EZ_MEMBER_PROPERTY("Radius", m_fRadius)->AddAttributes(new ezClampValueAttribute(0.0f, ezVariant())),
+    EZ_ENUM_MEMBER_PROPERTY("BounceOrientation", ezProjectileBounceOrientation, m_BounceOrientation)->AddAttributes(new ezDefaultValueAttribute((ezInt8)ezProjectileBounceOrientation::Reflection)),
     EZ_MEMBER_PROPERTY("StaticVelocityRatio", m_fStaticVelocityRatio)->AddAttributes(new ezDefaultValueAttribute(0.05f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_BITFLAGS_MEMBER_PROPERTY("ShapeTypesToHit", ezPhysicsShapeType, m_ShapeTypesToHit)->AddAttributes(new ezDefaultValueAttribute(ezVariant(ezPhysicsShapeType::Default & ~(ezPhysicsShapeType::Trigger)))),
     EZ_ACCESSOR_PROPERTY("FallbackSurface", GetFallbackSurfaceFile, SetFallbackSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
@@ -61,6 +67,8 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 8, ezComponentMode::Dynamic)
   {
     new ezCategoryAttribute("Gameplay"),
     new ezDirectionVisualizerAttribute(ezBasisAxis::PositiveX, 0.4f, ezColor::OrangeRed),
+    new ezSphereManipulatorAttribute("Radius"),
+    new ezSphereVisualizerAttribute("Radius"),
   }
   EZ_END_ATTRIBUTES;
 }
@@ -89,6 +97,7 @@ ezProjectileComponent::ezProjectileComponent()
   m_fMetersPerSecond = 10.0f;
   m_uiCollisionLayer = 0;
   m_fRadius = 0.0f;
+  m_BounceOrientation = ezProjectileBounceOrientation::Reflection;
   m_fStaticVelocityRatio = 0.05f;
   m_fGravityMultiplier = 0.0f;
   m_vVelocity.SetZero();
@@ -253,7 +262,14 @@ void ezProjectileComponent::Update()
             }
 
             const ezVec3 vPositionOnReflection = vCurPosition + castResult.m_fDistance * vCurDirection;
-            ApplySpinRotation(interaction, castResult, vPositionOnReflection, vCurDirection, vNewVelocity);
+            if (m_BounceOrientation == ezProjectileBounceOrientation::Reflection)
+            {
+              ApplyReflectionRotation(vCurDirection, castResult.m_vNormal);
+            }
+            else
+            {
+              ApplySpinningRotation(interaction, castResult, vPositionOnReflection, vCurDirection, vNewVelocity);
+            }
             const float fAbsVelocity = m_vVelocity.GetLength();
             // condition velocityToNormalProj < 0.0f implies fAbsVelocity is non-zero
             const float fTimeBeforeReflection = castResult.m_fDistance / fAbsVelocity;
@@ -302,8 +318,6 @@ void ezProjectileComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
   s << m_fMetersPerSecond;
   s << m_fGravityMultiplier;
   s << m_uiCollisionLayer;
-  s << m_fRadius;
-  s << m_fStaticVelocityRatio;
   s << m_MaxLifetime;
   s << m_hDeathPrefab;
 
@@ -328,9 +342,6 @@ void ezProjectileComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 
     // Version 7
     s << ia.m_uiImpulseType;
-
-    // Version 8
-    s << ia.m_fInertiaRatio;
   }
 
   // Version 5
@@ -338,6 +349,18 @@ void ezProjectileComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
 
   // Version 6
   s << m_bSpawnPrefabOnStatic;
+
+  // Version 8
+  s << m_fRadius;
+  ezProjectileBounceOrientation::StorageType bounceOrientation = m_BounceOrientation;
+  s << bounceOrientation;
+  s << m_fStaticVelocityRatio;
+
+  // Version 8
+  for (const auto& ia : m_SurfaceInteractions)
+  {
+    s << ia.m_fInertiaRatio;
+  }
 }
 
 void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
@@ -349,18 +372,6 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
   s >> m_fMetersPerSecond;
   s >> m_fGravityMultiplier;
   s >> m_uiCollisionLayer;
-
-  if (uiVersion >= 8)
-  {
-    s >> m_fRadius;
-    s >> m_fStaticVelocityRatio;
-  }
-  else
-  {
-    m_fRadius = 0.0f;
-    m_fStaticVelocityRatio = 0.05f;
-  }
-
   s >> m_MaxLifetime;
   s >> m_hDeathPrefab;
 
@@ -397,11 +408,6 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
     {
       s >> ia.m_uiImpulseType;
     }
-
-    if (uiVersion >= 8)
-    {
-      s >> ia.m_fInertiaRatio;
-    }
   }
 
   if (uiVersion >= 5)
@@ -412,6 +418,26 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
   if (uiVersion >= 6)
   {
     s >> m_bSpawnPrefabOnStatic;
+  }
+
+  if (uiVersion >= 8)
+  {
+    s >> m_fRadius;
+    ezProjectileBounceOrientation::StorageType bounceOrientation = ezProjectileBounceOrientation::Reflection;
+    s >> bounceOrientation;
+    m_BounceOrientation = (ezProjectileBounceOrientation::Enum)bounceOrientation;
+    s >> m_fStaticVelocityRatio;
+
+    for (auto& ia : m_SurfaceInteractions)
+    {
+      s >> ia.m_fInertiaRatio;
+    }
+  }
+  else
+  {
+    m_fRadius = 0.0f;
+    m_BounceOrientation = ezProjectileBounceOrientation::Reflection;
+    m_fStaticVelocityRatio = 0.05f;
   }
 }
 
@@ -426,11 +452,18 @@ bool ezProjectileComponent::QueryCollision(const ezPhysicsWorldModuleInterface& 
   return physicsInterface.Raycast(out_result, vStart, vDirection, fDistance, queryParams);
 }
 
-void ezProjectileComponent::ApplySpinRotation(const ezProjectileSurfaceInteraction& interaction,
-                                              const ezPhysicsCastResult& castResult,
-                                              const ezVec3& vPositionOnReflection,
-                                              const ezVec3& vCurDirection,
-                                              const ezVec3& vNewVelocity)
+void ezProjectileComponent::ApplyReflectionRotation(const ezVec3& vCurDirection, const ezVec3& vSurfaceNormal)
+{
+  const ezVec3 vNewDirection = vCurDirection.GetReflectedVector(vSurfaceNormal);
+  const ezQuat qRot = ezQuat::MakeShortestRotation(vCurDirection, vNewDirection);
+  GetOwner()->SetGlobalRotation(qRot * GetOwner()->GetGlobalRotation());
+}
+
+void ezProjectileComponent::ApplySpinningRotation(const ezProjectileSurfaceInteraction& interaction,
+                                                  const ezPhysicsCastResult& castResult,
+                                                  const ezVec3& vPositionOnReflection,
+                                                  const ezVec3& vCurDirection,
+                                                  const ezVec3& vNewVelocity)
 {
   if (interaction.m_fInertiaRatio == 0.0f)
     return;
@@ -473,7 +506,7 @@ bool ezProjectileComponent::ShouldStopProjectile(const ezPhysicsWorldModuleInter
     const ezVec3 vGravityDir = vGravity.GetNormalized();
     // Check that projectile has hit the ground
     // if not - return false to make sure it won't hang in the air after being stopped
-    if (vGravityDir.Dot(castResult.m_vNormal) > -0.6f)
+    if (-vGravityDir.Dot(castResult.m_vNormal) < ezMath::Cos(ezAngle::MakeFromDegree(40.f)))
     {
       return false;
     }

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/Implementation/ProjectileComponent.cpp
@@ -34,7 +34,7 @@ EZ_BEGIN_STATIC_REFLECTED_TYPE(ezProjectileSurfaceInteraction, ezNoBase, 3, ezRT
 }
 EZ_END_STATIC_REFLECTED_TYPE;
 
-EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 7, ezComponentMode::Dynamic)
+EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 8, ezComponentMode::Dynamic)
 {
   EZ_BEGIN_PROPERTIES
   {
@@ -44,6 +44,7 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 7, ezComponentMode::Dynamic)
     EZ_MEMBER_PROPERTY("SpawnPrefabOnStatic", m_bSpawnPrefabOnStatic),
     EZ_RESOURCE_MEMBER_PROPERTY("OnDeathPrefab", m_hDeathPrefab)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Prefab", ezDependencyFlags::Package)),
     EZ_MEMBER_PROPERTY("CollisionLayer", m_uiCollisionLayer)->AddAttributes(new ezDynamicEnumAttribute("PhysicsCollisionLayer")),
+    EZ_MEMBER_PROPERTY("Radius", m_fRadius)->AddAttributes(new ezDefaultValueAttribute(0.0f), new ezClampValueAttribute(0.0f, ezVariant())),
     EZ_BITFLAGS_MEMBER_PROPERTY("ShapeTypesToHit", ezPhysicsShapeType, m_ShapeTypesToHit)->AddAttributes(new ezDefaultValueAttribute(ezVariant(ezPhysicsShapeType::Default & ~(ezPhysicsShapeType::Trigger)))),
     EZ_ACCESSOR_PROPERTY("FallbackSurface", GetFallbackSurfaceFile, SetFallbackSurfaceFile)->AddAttributes(new ezAssetBrowserAttribute("CompatibleAsset_Surface", ezDependencyFlags::Package)),
     EZ_ARRAY_MEMBER_PROPERTY("Interactions", m_SurfaceInteractions),
@@ -64,10 +65,44 @@ EZ_BEGIN_COMPONENT_TYPE(ezProjectileComponent, 7, ezComponentMode::Dynamic)
 EZ_END_DYNAMIC_REFLECTED_TYPE;
 // clang-format on
 
+namespace
+{
+  /// \brief Helper function to recalculate the sphere position from hit position
+  /// \param vOrigin is expected to be the initial position of the particle before SweepTest
+  ezVec3 CalculateSphereCenterPosition(const ezVec3& vOrigin, const ezVec3& vDirection, float fRadius, const ezVec3& vHitPosition)
+  {
+    const ezVec3 vHitRelative = vHitPosition - vOrigin;
+    const float fHitToDirProj = vHitRelative.Dot(vDirection);
+
+    if (fHitToDirProj < 0.0f)
+    {
+      // It says that the hit position is "behind" (if we move along vDirection) vOrigin
+      // Likely this can only happen when there is already a collision before the particle has started moving
+      // Thus, return the original line position
+      return vOrigin;
+    }
+
+    // Distance from hit pos to the line passing through the vOrigin along vDirection
+    // This distance is equal to r * sin(theta),
+    // where theta is the angle between vDirection and the vector connecting hit pos and supposed new sphere center (vNewCenter)
+    const float fDistSquared = vHitRelative.GetLengthSquared() - fHitToDirProj * fHitToDirProj;
+
+    // Here fOffset is r * cos(theta),
+    // it equals to the distance between vHitPosition and vNewCenter projected to vDirection
+    const float fOffset = ezMath::Sqrt(ezMath::Max(0.0f, fRadius * fRadius - fDistSquared));
+
+    const ezVec3 vNewCenter = vOrigin + (fHitToDirProj - fOffset) * vDirection;
+
+    // Lerp result to make projectile go a bit "inside" into the object it collided
+    return ezMath::Lerp(vNewCenter, vHitPosition, 0.1f);
+  }
+} // namespace
+
 ezProjectileComponent::ezProjectileComponent()
 {
   m_fMetersPerSecond = 10.0f;
   m_uiCollisionLayer = 0;
+  m_fRadius = 0.0f;
   m_fGravityMultiplier = 0.0f;
   m_vVelocity.SetZero();
   m_bSpawnPrefabOnStatic = false;
@@ -85,6 +120,7 @@ void ezProjectileComponent::Update()
   if (pPhysicsInterface)
   {
     ezGameObject* pEntity = GetOwner();
+    const ezVec3 vCurPosition = pEntity->GetGlobalPosition();
 
     const float fTimeDiff = (float)GetWorld()->GetClock().GetTimeDiff().GetSeconds();
 
@@ -109,8 +145,12 @@ void ezProjectileComponent::Update()
     queryParams.m_ShapeTypes = m_ShapeTypesToHit;
 
     ezPhysicsCastResult castResult;
-    if (pPhysicsInterface->Raycast(castResult, pEntity->GetGlobalPosition(), vCurDirection, fDistance, queryParams))
+    if (QueryCollision(*pPhysicsInterface, castResult, vCurPosition, vCurDirection, fDistance, queryParams))
     {
+      const ezVec3 vNewCenterPosition = (m_fRadius > 0.0f)
+        ? CalculateSphereCenterPosition(vCurPosition, vCurDirection, m_fRadius, castResult.m_vPosition)
+        : castResult.m_vPosition;
+
       const ezSurfaceResourceHandle hSurface = castResult.m_hSurface.IsValid() ? castResult.m_hSurface : m_hFallbackSurface;
 
       const ezInt32 iInteraction = FindSurfaceInteraction(hSurface);
@@ -118,7 +158,7 @@ void ezProjectileComponent::Update()
       if (iInteraction == -1)
       {
         GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());
-        vNewPosition = castResult.m_vPosition;
+        vNewPosition = vNewCenterPosition;
       }
       else
       {
@@ -188,16 +228,16 @@ void ezProjectileComponent::Update()
 
 
           GetWorld()->DeleteObjectDelayed(GetOwner()->GetHandle());
-          vNewPosition = castResult.m_vPosition;
+          vNewPosition = vNewCenterPosition;
         }
         else if (interaction.m_Reaction == ezProjectileReaction::Reflect || interaction.m_Reaction == ezProjectileReaction::Bounce)
         {
           /// \todo Should reflect around the actual hit position
           /// \todo Should preserve travel distance while reflecting
 
-          // const float fLength = (vPos - pEntity->GetGlobalPosition()).GetLength();
+          // const float fLength = (vPos - vCurPosition).GetLength();
 
-          vNewPosition = pEntity->GetGlobalPosition(); // vPos;
+          vNewPosition = vCurPosition; // vPos;
 
           const ezVec3 vNewDirection = vCurDirection.GetReflectedVector(castResult.m_vNormal);
 
@@ -233,7 +273,7 @@ void ezProjectileComponent::Update()
         {
           m_fMetersPerSecond = 0.0f;
           m_fGravityMultiplier = 0.0f;
-          vNewPosition = castResult.m_vPosition;
+          vNewPosition = vNewCenterPosition;
 
           ezGameObject* pObject;
           if (GetWorld()->TryGetObject(castResult.m_hActorObject, pObject))
@@ -243,13 +283,13 @@ void ezProjectileComponent::Update()
         }
         else if (interaction.m_Reaction == ezProjectileReaction::PassThrough)
         {
-          vNewPosition = pEntity->GetGlobalPosition() + fDistance * vCurDirection;
+          vNewPosition = vCurPosition + fDistance * vCurDirection;
         }
       }
     }
     else
     {
-      vNewPosition = pEntity->GetGlobalPosition() + fDistance * vCurDirection;
+      vNewPosition = vCurPosition + fDistance * vCurDirection;
     }
 
     GetOwner()->SetGlobalPosition(vNewPosition);
@@ -264,6 +304,7 @@ void ezProjectileComponent::SerializeComponent(ezWorldWriter& inout_stream) cons
   s << m_fMetersPerSecond;
   s << m_fGravityMultiplier;
   s << m_uiCollisionLayer;
+  s << m_fRadius;
   s << m_MaxLifetime;
   s << m_hDeathPrefab;
 
@@ -306,6 +347,16 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
   s >> m_fMetersPerSecond;
   s >> m_fGravityMultiplier;
   s >> m_uiCollisionLayer;
+
+  if (uiVersion >= 8)
+  {
+    s >> m_fRadius;
+  }
+  else
+  {
+    m_fRadius = 0.0f;
+  }
+
   s >> m_MaxLifetime;
   s >> m_hDeathPrefab;
 
@@ -353,6 +404,17 @@ void ezProjectileComponent::DeserializeComponent(ezWorldReader& inout_stream)
   {
     s >> m_bSpawnPrefabOnStatic;
   }
+}
+
+
+bool ezProjectileComponent::QueryCollision(const ezPhysicsWorldModuleInterface& physicsInterface, ezPhysicsCastResult& out_result, const ezVec3& vStart, const ezVec3& vDirection, float fDistance, const ezPhysicsQueryParameters& queryParams) const
+{
+  if (m_fRadius > 0.0f)
+  {
+    return physicsInterface.SweepTestSphere(out_result, m_fRadius, vStart, vDirection, fDistance, queryParams);
+  }
+
+  return physicsInterface.Raycast(out_result, vStart, vDirection, fDistance, queryParams);
 }
 
 

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
@@ -91,7 +91,8 @@ public:
   /// Defines which other physics objects the projectile will collide with.
   ezUInt8 m_uiCollisionLayer; // [ property ]
 
-  /// If greater than zero, the projectile uses a sphere sweep with this radius instead of a raycast.
+  /// If greater than zero, a sphere shape query is used for collision detection
+  /// otherwise raycasting is used and projectile is treated like a "dot"
   float m_fRadius; // [ property ]
 
   /// A broad filter to ignore certain types of colliders.

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
@@ -49,6 +49,14 @@ struct EZ_GAMECOMPONENTS_DLL ezProjectileSurfaceInteraction
 
   /// \brief How much damage to do on this type of surface. Send via ezMsgDamage
   float m_fDamage = 0.0f;
+
+  /// \brief How much the rotation (spinning) of the owner object is affected by reflections/bounces about the surface
+  /// Positive values correspond to the rotation due to object "getting stuck in the surface"
+  /// Negative values correspond to the rotation due to object "sliding over the surface"
+  /// Larger by magnitude values correspond to smaller rotations.
+  /// If zero, than the rotation of the owner is not changed during reflection/bounces
+  /// Generally, it is an analogue of mass but for rotational movement
+  float m_fInertiaRatio = 5.0f;
 };
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMECOMPONENTS_DLL, ezProjectileSurfaceInteraction);
@@ -95,6 +103,9 @@ public:
   /// otherwise raycasting is used and projectile is treated like a "dot"
   float m_fRadius; // [ property ]
 
+  /// Velocity ratio below which a bounced projectile is considered static.
+  float m_fStaticVelocityRatio = 0.05f; // [ property ]
+
   /// A broad filter to ignore certain types of colliders.
   ezBitflags<ezPhysicsShapeType> m_ShapeTypesToHit; // [ property ]
 
@@ -118,7 +129,9 @@ private:
   void OnTriggered(ezMsgComponentInternalTrigger& msg); // [ msg handler ]
 
   void SpawnDeathPrefab();
+  void ApplySpinRotation(const ezProjectileSurfaceInteraction& interaction, const ezPhysicsCastResult& castResult, const ezVec3& vPositionOnReflection, const ezVec3& vCurDirection, const ezVec3& vNewVelocity);
   bool QueryCollision(const ezPhysicsWorldModuleInterface& physicsInterface, ezPhysicsCastResult& out_result, const ezVec3& vStart, const ezVec3& vDirection, float fDistance, const ezPhysicsQueryParameters& queryParams) const;
+  bool ShouldStopProjectile(const ezPhysicsWorldModuleInterface& physicsInterface, const ezPhysicsCastResult& castResult, const ezVec3& vVelocity);
 
 
   /// \brief If an unknown surface type is hit, the projectile will just delete itself without further interaction

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
@@ -91,6 +91,9 @@ public:
   /// Defines which other physics objects the projectile will collide with.
   ezUInt8 m_uiCollisionLayer; // [ property ]
 
+  /// If greater than zero, the projectile uses a sphere sweep with this radius instead of a raycast.
+  float m_fRadius; // [ property ]
+
   /// A broad filter to ignore certain types of colliders.
   ezBitflags<ezPhysicsShapeType> m_ShapeTypesToHit; // [ property ]
 
@@ -114,6 +117,7 @@ private:
   void OnTriggered(ezMsgComponentInternalTrigger& msg); // [ msg handler ]
 
   void SpawnDeathPrefab();
+  bool QueryCollision(const ezPhysicsWorldModuleInterface& physicsInterface, ezPhysicsCastResult& out_result, const ezVec3& vStart, const ezVec3& vDirection, float fDistance, const ezPhysicsQueryParameters& queryParams) const;
 
 
   /// \brief If an unknown surface type is hit, the projectile will just delete itself without further interaction

--- a/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
+++ b/Code/EnginePlugins/GameComponentsPlugin/Gameplay/ProjectileComponent.h
@@ -29,6 +29,22 @@ struct EZ_GAMECOMPONENTS_DLL ezProjectileReaction
 
 EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMECOMPONENTS_DLL, ezProjectileReaction);
 
+/// \brief Defines how the projectile owner orientation is updated on reflection / bounce.
+struct EZ_GAMECOMPONENTS_DLL ezProjectileBounceOrientation
+{
+  using StorageType = ezInt8;
+
+  enum Enum : StorageType
+  {
+    Spinning = 0,
+    Reflection = 1,
+
+    Default = Reflection
+  };
+};
+
+EZ_DECLARE_REFLECTABLE_TYPE(EZ_GAMECOMPONENTS_DLL, ezProjectileBounceOrientation);
+
 /// \brief Holds the information about how a projectile interacts with a specific surface type
 struct EZ_GAMECOMPONENTS_DLL ezProjectileSurfaceInteraction
 {
@@ -103,6 +119,9 @@ public:
   /// otherwise raycasting is used and projectile is treated like a "dot"
   float m_fRadius; // [ property ]
 
+  /// Defines how reflections / bounces rotate the owner object.
+  ezProjectileBounceOrientation::Enum m_BounceOrientation = ezProjectileBounceOrientation::Reflection; // [ property ]
+
   /// Velocity ratio below which a bounced projectile is considered static.
   float m_fStaticVelocityRatio = 0.05f; // [ property ]
 
@@ -129,7 +148,8 @@ private:
   void OnTriggered(ezMsgComponentInternalTrigger& msg); // [ msg handler ]
 
   void SpawnDeathPrefab();
-  void ApplySpinRotation(const ezProjectileSurfaceInteraction& interaction, const ezPhysicsCastResult& castResult, const ezVec3& vPositionOnReflection, const ezVec3& vCurDirection, const ezVec3& vNewVelocity);
+  void ApplyReflectionRotation(const ezVec3& vCurDirection, const ezVec3& vSurfaceNormal);
+  void ApplySpinningRotation(const ezProjectileSurfaceInteraction& interaction, const ezPhysicsCastResult& castResult, const ezVec3& vPositionOnReflection, const ezVec3& vCurDirection, const ezVec3& vNewVelocity);
   bool QueryCollision(const ezPhysicsWorldModuleInterface& physicsInterface, ezPhysicsCastResult& out_result, const ezVec3& vStart, const ezVec3& vDirection, float fDistance, const ezPhysicsQueryParameters& queryParams) const;
   bool ShouldStopProjectile(const ezPhysicsWorldModuleInterface& physicsInterface, const ezPhysicsCastResult& castResult, const ezVec3& vVelocity);
 


### PR DESCRIPTION
Main changes are the following:
1. Add radius parameter to the projectile component
2. If radius > 0 then use `physicsInterface.SweepTestSphere` instead of `physicsInterface.Raycast`
3. Also if radius > 0 then adjust object position based on the hit position information