### PR TITLE
Open Tags and Collision Layer Edit Dialogs from properties widget

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -656,7 +656,7 @@ void ezProjectAction::Execute(const ezVariant& value)
 
     case ezProjectAction::ButtonType::TagsDialog:
     {
-      ezQtTagsDlg dlg(nullptr);
+      ezQtTagsDlg dlg(value, nullptr);
       if (dlg.exec() == QDialog::Accepted)
       {
         ezToolsProject::BroadcastConfigChanged();

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFilter.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetBrowserFilter.cpp
@@ -351,7 +351,7 @@ bool ezQtAssetBrowserFilter::IsAssetFiltered(ezStringView sDataDirParentRelative
     else
     {
       // otherwise search for ";required;" in the tags string (note the semicolons at the start and end as delimiters
-      if (tags.FindSubString(m_sRequiredTag) == nullptr)
+      if (tags.FindSubString_NoCase(m_sRequiredTag) == nullptr)
         return true;
     }
   }

--- a/Code/Editor/EditorFramework/Dialogs/TagsDlg.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/TagsDlg.cpp
@@ -3,12 +3,18 @@
 #include <EditorFramework/Dialogs/TagsDlg.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 
-ezQtTagsDlg::ezQtTagsDlg(QWidget* pParent)
+ezQtTagsDlg::ezQtTagsDlg(const ezVariant& startup, QWidget* pParent)
   : QDialog(pParent)
 {
   setupUi(this);
 
   LoadTags();
+
+  if (startup.IsString())
+  {
+    m_sStartupCategory = startup.Get<ezString>();
+  }
+
   FillList();
 
   on_TreeTags_itemSelectionChanged();
@@ -168,6 +174,11 @@ void ezQtTagsDlg::FillList()
 
   ezSet<ezString> TagCategories;
 
+  if (!m_sStartupCategory.IsEmpty())
+  {
+    TagCategories.Insert(m_sStartupCategory);
+  }
+
   for (const auto& tag : m_Tags)
   {
     TagCategories.Insert(tag.m_sCategory);
@@ -181,6 +192,8 @@ void ezQtTagsDlg::FillList()
     pItem->setIcon(0, ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/Tag.svg"));
 
     m_CategoryToItem[it.Key()] = pItem;
+
+    pItem->setSelected(it.Key() == m_sStartupCategory);
   }
 
   for (const auto& tag : m_Tags)

--- a/Code/Editor/EditorFramework/Dialogs/TagsDlg.moc.h
+++ b/Code/Editor/EditorFramework/Dialogs/TagsDlg.moc.h
@@ -13,7 +13,7 @@ public:
   Q_OBJECT
 
 public:
-  ezQtTagsDlg(QWidget* pParent);
+  ezQtTagsDlg(const ezVariant& startup, QWidget* pParent);
 
 private Q_SLOTS:
   void on_ButtonNewCategory_clicked();
@@ -32,6 +32,7 @@ private:
 
   QTreeWidgetItem* CreateTagItem(QTreeWidgetItem* pParentItem, const QString& tag, bool bBuiltIn);
 
+  ezString m_sStartupCategory;
   ezHybridArray<ezToolsTag, 32> m_Tags;
   ezMap<ezString, QTreeWidgetItem*> m_CategoryToItem;
 };

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/Dialogs/JoltProjectSettingsDlg.cpp
@@ -35,6 +35,10 @@ ezQtJoltProjectSettingsDlg::ezQtJoltProjectSettingsDlg(const ezVariant& startup,
   if (startup.IsValid())
   {
     const ezString sStartup = startup.ConvertTo<ezString>();
+    if (sStartup == "CollisionLayers")
+    {
+      Tabs->setCurrentIndex(0);
+    }
     if (sStartup == "WeightCategories")
     {
       Tabs->setCurrentIndex(1);

--- a/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
+++ b/Code/EditorPlugins/Jolt/EditorPluginJolt/EditorPluginJolt.cpp
@@ -102,6 +102,7 @@ void UpdateCollisionLayerDynamicEnumValues()
 {
   auto& cfe = ezDynamicEnum::GetDynamicEnum("PhysicsCollisionLayer");
   cfe.Clear();
+  cfe.SetEditCommand("Jolt.Settings.Project", "CollisionLayers");
 
   ezCollisionFilterConfig cfg;
   if (cfg.Load().Failed())

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.cpp
@@ -1,5 +1,6 @@
 #include <GuiFoundation/GuiFoundationPCH.h>
 
+#include <GuiFoundation/Action/ActionManager.h>
 #include <GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.moc.h>
 #include <GuiFoundation/PropertyGrid/PropertyGridWidget.moc.h>
 #include <GuiFoundation/UIServices/UIServices.moc.h>
@@ -52,6 +53,7 @@ void ezQtPropertyEditorTagSetWidget::OnInit()
   const ezTagSetWidgetAttribute* pAssetAttribute = m_pProp->GetAttributeByType<ezTagSetWidgetAttribute>();
   EZ_ASSERT_DEV(pAssetAttribute != nullptr, "ezQtPropertyEditorTagSetWidget needs ezTagSetWidgetAttribute to be set.");
   ezStringBuilder sTagFilter = pAssetAttribute->GetTagFilter();
+  m_sTagFilter = sTagFilter;
   ezTempHybridArray<ezStringView, 4> categories;
   sTagFilter.Split(false, categories, ";");
 
@@ -107,6 +109,15 @@ void ezQtPropertyEditorTagSetWidget::OnInit()
     /*QAction* pCategory = */ m_pMenu->addSection(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/EditorFramework/Icons/Tag.svg"),
       QLatin1String("[") + QString(catname.GetData(tmp)) + QLatin1String("]"));
   }
+
+  m_pMenu->addSeparator();
+
+  QAction* pEditAction = new QAction(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/GuiFoundation/Icons/Edit.svg"), "Edit Tags...", m_pMenu);
+  connect(pEditAction, &QAction::triggered, this, [this]()
+    {
+      ezActionManager::ExecuteAction({}, "Engine.Tags", ezActionContext(const_cast<ezDocument*>(m_pGrid->GetDocument())), ezVariant(m_sTagFilter)).AssertSuccess();
+    });
+  m_pMenu->addAction(pEditAction);
 }
 
 void ezQtPropertyEditorTagSetWidget::InternalUpdateValue()

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.cpp
@@ -114,9 +114,7 @@ void ezQtPropertyEditorTagSetWidget::OnInit()
 
   QAction* pEditAction = new QAction(ezQtUiServices::GetSingleton()->GetCachedIconResource(":/GuiFoundation/Icons/Edit.svg"), "Edit Tags...", m_pMenu);
   connect(pEditAction, &QAction::triggered, this, [this]()
-    {
-      ezActionManager::ExecuteAction({}, "Engine.Tags", ezActionContext(const_cast<ezDocument*>(m_pGrid->GetDocument())), ezVariant(m_sTagFilter)).AssertSuccess();
-    });
+    { ezActionManager::ExecuteAction({}, "Engine.Tags", ezActionContext(const_cast<ezDocument*>(m_pGrid->GetDocument())), ezVariant(m_sTagFilter)).AssertSuccess(); });
   m_pMenu->addAction(pEditAction);
 }
 

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/TagSetPropertyWidget.moc.h
@@ -36,4 +36,5 @@ private:
   QHBoxLayout* m_pLayout;
   QPushButton* m_pWidget;
   QMenu* m_pMenu;
+  ezString m_sTagFilter;
 };


### PR DESCRIPTION
Makes it easier to edit collision layers and tags by providing a quick way to open their edit dialogs. The property widget for both now show an "Edit" entry inline.