### PR TITLE
Fixed enum copy/paste and prefab add undo

### DIFF
--- a/Code/BuildSystem/AzurePipelines/Android-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Android-x64.yml
@@ -49,13 +49,6 @@ jobs:
             Copy-Item -Path $pathA -Destination $pathB
         }
 
-  - task: AzureKeyVault@2
-    displayName: 'Azure Key Vault: ezKeys'
-    inputs:
-      ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
-      KeyVaultName: ezKeys
-      SecretsFilter: AzureBlobPW
-
   - ${{ if eq(parameters.compileShaderCompiler, true) }}:
     - task: CMake@1
       displayName: CMake vs2026x64

--- a/Code/BuildSystem/AzurePipelines/Linux-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Linux-x64.yml
@@ -1,9 +1,3 @@
-parameters:
-  - name: useVM
-    displayName: 'Start VM before build'
-    type: boolean
-    default: false
-
 trigger:
   branches:
     include:
@@ -22,26 +16,6 @@ variables:
     value: false
 
 jobs:
-- ${{ if eq(parameters.useVM, true) }}:
-  - job: StartVM
-    displayName: StartVM
-    pool:
-      vmImage: 'windows-latest'
-    steps:
-    - checkout: none
-    - task: AzureKeyVault@2
-      displayName: 'Azure Key Vault: ezKeys'
-      inputs:
-        ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
-        KeyVaultName: ezKeys
-        SecretsFilter: AzureFunctionKey
-    - task: PowerShell@2
-      displayName: StartVM
-      continueOnError: true
-      inputs:
-        targetType: inline
-        script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartVM?code=$(AzureFunctionKey)&vmname=Ubuntu-22.04"
-
 - job: Linux_x64
   timeoutInMinutes: 120
   displayName: Linux-x64

--- a/Code/BuildSystem/AzurePipelines/Windows-x64.yml
+++ b/Code/BuildSystem/AzurePipelines/Windows-x64.yml
@@ -3,10 +3,6 @@ parameters:
     displayName: 'Upload Caches'
     type: boolean
     default: false
-  - name: useVM
-    displayName: 'Start VM before build'
-    type: boolean
-    default: false
 
 trigger:
   branches:
@@ -18,25 +14,6 @@ resources:
     type: git
     ref: dev
 jobs:
-- ${{ if eq(parameters.useVM, true) }}:
-  - job: StartVM
-    displayName: StartVM
-    pool:
-      vmImage: 'windows-latest'
-    steps:
-    - checkout: none
-    - task: AzureKeyVault@2
-      displayName: 'Azure Key Vault: ezKeys'
-      inputs:
-        ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
-        KeyVaultName: ezKeys
-        SecretsFilter: AzureFunctionKey
-    - task: PowerShell@2
-      displayName: StartVM
-      continueOnError: true
-      inputs:
-        targetType: inline
-        script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartVM?code=$(AzureFunctionKey)&vmname=Windows10-1809"
 - job: Windows_x64
   displayName: Windows-x64
   timeoutInMinutes: 180
@@ -64,12 +41,6 @@ jobs:
             git clean -dfx
             Copy-Item -Path $pathA -Destination $pathB
         }
-  - task: AzureKeyVault@2
-    displayName: 'Azure Key Vault: ezKeys'
-    inputs:
-      ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
-      KeyVaultName: ezKeys
-      SecretsFilter: AzureBlobPW,ThirdPartyWinx64Qt6
   - task: PowerShell@2
     displayName: Delete old crash dumps
     inputs:

--- a/Code/BuildSystem/AzurePipelines/clang-tidy.yml
+++ b/Code/BuildSystem/AzurePipelines/clang-tidy.yml
@@ -14,25 +14,6 @@ trigger:
     - release
 
 jobs:
-- job: StartVM
-  displayName: StartVM
-  pool:
-    vmImage: 'windows-latest'
-  steps:
-  - checkout: none
-  - task: AzureKeyVault@2
-    displayName: 'Azure Key Vault: ezKeys'
-    inputs:
-      ConnectedServiceName: 3c1e6edd-3ce0-4297-9a12-163b037ea7bc
-      KeyVaultName: ezKeys
-      SecretsFilter: AzureFunctionKey
-  - task: PowerShell@2
-    displayName: StartVM
-    continueOnError: true
-    inputs:
-      targetType: inline
-      script: Invoke-RestMethod -Uri "https://ezengineci.azurewebsites.net/api/StartVM?code=$(AzureFunctionKey)&vmname=Windows10-1809"
-
 - job: ClangTidyVerification
   timeoutInMinutes: 120
   pool:

--- a/Code/Editor/EditorFramework/EditorApp/Qt.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Qt.cpp
@@ -154,10 +154,12 @@ static void QtDebugMessageHandler(QtMsgType type, const QMessageLogContext& cont
 #endif
     case QtWarningMsg:
     {
-      // I just hate this pointless message
+      // pointless Qt warnings that we shouldn't forward to our log
       if (sMsg.FindSubString("iCCP") != nullptr)
         return;
       if (sMsg.FindSubString("Unable to set geometry") != nullptr)
+        return;
+      if (sMsg.FindSubString("The cached device pixel ratio value was stale") != nullptr)
         return;
 
       ezLog::Warning("|Qt| {0} ({1}:{2}, {3})", sMsg, context.file, context.line, context.function);

--- a/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersDefaultStateProvider.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/ExposedParametersDefaultStateProvider.cpp
@@ -174,6 +174,12 @@ ezStatus ezExposedParametersAsTypeDefaultStateProvider::RevertProperty(ezDefault
 
 ezResult ezExposedParametersAsTypeDefaultStateProvider::GetDefaultValueInternal(ezDefaultStateProvider::SuperArray superPtr, ezObjectAccessorBase* pAccessor, const ezDocumentObject* pObject, const ezAbstractProperty* pProp, ezVariant index, ezVariant& out_DefaultValue)
 {
+  if (superPtr.GetCount() <= 1)
+  {
+    out_DefaultValue = {};
+    return EZ_FAILURE;
+  }
+
   // As we derive from ezExposedParametersDefaultStateProvider, we first need to convert the exposed parameter type, prop, accessor into the actual underlying data structure that the base class expects before calling it.
   // * The ezExposedParametersAsTypeCommandAccessor proxies the ezExposedParameterCommandAccessor so the proxy source is the correct accessor.
   // * The object stays the same.

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyBaseWidget.cpp
@@ -441,8 +441,21 @@ void ezQtPropertyWidget::ExtendContextMenu(QMenu& m)
                 if (!nodeProp.m_Value.IsValid() || nodeProp.m_Value.IsA<ezVariantArray>() || nodeProp.m_Value.IsA<ezVariantDictionary>())
                   continue;
                 ezVariant val = nodeProp.m_Value;
-                if (!val.CanConvertTo(pTargetProp->GetSpecificType()->GetVariantType()) && pTargetProp->GetSpecificType()->GetTypeName() != ezRTTI::FindTypeByName(content.m_Type)->GetTypeName())
-                  continue;
+                // Enum/bitflags values are serialized as strings in the object graph; convert back to integer before assignment.
+                if (pTargetProp->GetFlags().IsAnySet(ezPropertyFlags::IsEnum | ezPropertyFlags::Bitflags) && val.IsA<ezString>())
+                {
+                  ezInt64 iEnumValue = 0;
+                  if (!ezReflectionUtils::StringToEnumeration(pTargetProp->GetSpecificType(), val.Get<ezString>(), iEnumValue))
+                    continue;
+                  val = iEnumValue;
+                }
+                else
+                {
+                  const ezVariantType::Enum ttype = pTargetProp->GetSpecificType()->GetVariantType();
+                  if (!val.CanConvertTo(ttype) && pTargetProp->GetSpecificType()->GetTypeName() != ezRTTI::FindTypeByName(content.m_Type)->GetTypeName())
+                    continue;
+                }
+
                 ezReflectionUtils::ClampValue(val, pTargetProp->GetAttributeByType<ezClampValueAttribute>()).IgnoreResult();
                 m_pObjectAccessor->SetValue(pTarget, pTargetProp, val).LogFailure();
               }

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -32,7 +32,11 @@ ezQtPropertyEditorCheckboxWidget::ezQtPropertyEditorCheckboxWidget()
   m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   m_pLayout->addWidget(m_pWidget);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+  EZ_VERIFY(connect(m_pWidget, &QCheckBox::checkStateChanged, this, &ezQtPropertyEditorCheckboxWidget::on_StateChanged_triggered) != nullptr, "signal/slot connection failed");
+#else
   EZ_VERIFY(connect(m_pWidget, &QCheckBox::stateChanged, this, &ezQtPropertyEditorCheckboxWidget::on_StateChanged_triggered) != nullptr, "signal/slot connection failed");
+#endif
 }
 
 void ezQtPropertyEditorCheckboxWidget::InternalSetValue(const ezVariant& value)

--- a/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/PropertyGrid/Implementation/PropertyWidget.cpp
@@ -32,7 +32,7 @@ ezQtPropertyEditorCheckboxWidget::ezQtPropertyEditorCheckboxWidget()
   m_pWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
   m_pLayout->addWidget(m_pWidget);
 
-  EZ_VERIFY(connect(m_pWidget, SIGNAL(stateChanged(int)), this, SLOT(on_StateChanged_triggered(int))) != nullptr, "signal/slot connection failed");
+  EZ_VERIFY(connect(m_pWidget, &QCheckBox::stateChanged, this, &ezQtPropertyEditorCheckboxWidget::on_StateChanged_triggered) != nullptr, "signal/slot connection failed");
 }
 
 void ezQtPropertyEditorCheckboxWidget::InternalSetValue(const ezVariant& value)


### PR DESCRIPTION
Fixes #1939 - copy paste enum properties.
Fixes #1936 - undo add of prefabs with exposed parameters
