### PR TITLE
#1942 Correct horizontal stepping calculation

### DIFF
--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -185,6 +185,7 @@ void ezJoltCharacterControllerComponent::RawMoveWithVelocity(const ezVec3& vVelo
   JPH::CharacterVirtual::ExtendedUpdateSettings updateSettings;
   updateSettings.mStickToFloorStepDown = JPH::Vec3(0, 0, -fMaxStepDown);
   updateSettings.mWalkStairsStepUp = fMaxStairStepUp > 0 ? JPH::Vec3(0, 0, fMaxStairStepUp) : JPH::Vec3::sZero();
+  updateSettings.mWalkStairsMinStepForward = GetShapeRadius() * 0.2f;
 
   // Update the character position
   m_pCharacter->ExtendedUpdate(GetUpdateTimeDelta(), ezJoltConversionUtils::ToVec3(pModule->GetCharacterGravity()), updateSettings, broadphaseFilter, objectFilter, m_BodyFilter, {}, *pModule->GetTempAllocator());
@@ -397,6 +398,7 @@ void ezJoltCharacterControllerComponent::VisualizeContacts(const ezDynamicArray<
 
 void ezJoltCharacterControllerComponent::Update(ezTime deltaTime)
 {
+  const float vel = GetOwner()->GetLinearVelocity().GetLength();
   m_fUpdateTimeDelta = deltaTime.AsFloatInSeconds();
   m_fInverseUpdateTimeDelta = static_cast<float>(1.0 / deltaTime.GetSeconds());
 
@@ -481,7 +483,6 @@ void ezJoltCharacterControllerComponent::MovePresenceBody(ezTime deltaTime)
     return;
 
   const ezSimdTransform trans = GetOwner()->GetGlobalTransformSimd();
-
   const float tDiff = deltaTime.AsFloatInSeconds();
 
   pBodies->MoveKinematic(bodyId, ezJoltConversionUtils::ToVec3(trans.m_Position), ezJoltConversionUtils::ToQuat(trans.m_Rotation).Normalized(), tDiff);

--- a/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
+++ b/Code/EnginePlugins/JoltPlugin/Character/Implementation/JoltCharacterControllerComponent.cpp
@@ -185,7 +185,6 @@ void ezJoltCharacterControllerComponent::RawMoveWithVelocity(const ezVec3& vVelo
   JPH::CharacterVirtual::ExtendedUpdateSettings updateSettings;
   updateSettings.mStickToFloorStepDown = JPH::Vec3(0, 0, -fMaxStepDown);
   updateSettings.mWalkStairsStepUp = fMaxStairStepUp > 0 ? JPH::Vec3(0, 0, fMaxStairStepUp) : JPH::Vec3::sZero();
-  updateSettings.mWalkStairsMinStepForward = GetShapeRadius() * 0.2f;
 
   // Update the character position
   m_pCharacter->ExtendedUpdate(GetUpdateTimeDelta(), ezJoltConversionUtils::ToVec3(pModule->GetCharacterGravity()), updateSettings, broadphaseFilter, objectFilter, m_BodyFilter, {}, *pModule->GetTempAllocator());

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterBase.h
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterBase.h
@@ -149,6 +149,7 @@ protected:
 	SubShapeID							mGroundBodySubShapeID;
 	RVec3								mGroundPosition = RVec3::sZero();
 	Vec3								mGroundNormal = Vec3::sZero();
+  Vec3                mGroundSurfaceNormal = Vec3::sZero();
 	Vec3								mGroundVelocity = Vec3::sZero();
 	RefConst<PhysicsMaterial>			mGroundMaterial = PhysicsMaterial::sDefault;
 	uint64								mGroundUserData = 0;

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.cpp
@@ -1144,6 +1144,7 @@ void CharacterVirtual::UpdateSupportingContact(bool inSkipContactVelocityCheck, 
 		mGroundBodyID = best_contact->mBodyB;
 		mGroundBodySubShapeID = best_contact->mSubShapeIDB;
 		mGroundPosition = best_contact->mPosition;
+    mGroundSurfaceNormal = best_contact->mSurfaceNormal;
 		mGroundMaterial = best_contact->mMaterial;
 		mGroundUserData = best_contact->mUserData;
 	}
@@ -1152,6 +1153,7 @@ void CharacterVirtual::UpdateSupportingContact(bool inSkipContactVelocityCheck, 
 		mGroundBodyID = BodyID();
 		mGroundBodySubShapeID = SubShapeID();
 		mGroundPosition = RVec3::sZero();
+    mGroundSurfaceNormal = RVec3::sZero();
 		mGroundMaterial = PhysicsMaterial::sDefault;
 		mGroundUserData = 0;
 	}
@@ -1532,12 +1534,8 @@ void CharacterVirtual::SetInnerBodyShape(const Shape *inShape)
 	mSystem->GetBodyInterface().SetShape(mInnerBodyID, inShape, false, EActivation::DontActivate);
 }
 
-bool CharacterVirtual::CanWalkStairs(Vec3Arg inLinearVelocity) const
+bool CharacterVirtual::CanWalkStairs(Vec3Arg inLinearVelocity, bool inAcceptNotCollided) const
 {
-	// We can only walk stairs if we're supported
-	if (!IsSupported())
-		return false;
-
 	// Check if there's enough horizontal velocity to trigger a stair walk
 	Vec3 horizontal_velocity = inLinearVelocity - inLinearVelocity.Dot(mUp) * mUp;
 	if (horizontal_velocity.IsNearZero(1.0e-6f))
@@ -1545,7 +1543,7 @@ bool CharacterVirtual::CanWalkStairs(Vec3Arg inLinearVelocity) const
 
 	// Check contacts for steep slopes
 	for (const Contact &c : mActiveContacts)
-		if (c.mHadCollision
+		if ((c.mHadCollision || inAcceptNotCollided)
 			&& !c.mWasDiscarded
 			&& c.mSurfaceNormal.Dot(horizontal_velocity - c.mLinearVelocity) < 0.0f // Pushing into the contact
 			&& IsSlopeTooSteep(c.mSurfaceNormal)) // Slope too steep
@@ -1554,7 +1552,7 @@ bool CharacterVirtual::CanWalkStairs(Vec3Arg inLinearVelocity) const
 	return false;
 }
 
-bool CharacterVirtual::WalkStairs(float inDeltaTime, Vec3Arg inStepUp, Vec3Arg inStepForward, Vec3Arg inStepForwardTest, Vec3Arg inStepDownExtra, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, const ShapeFilter &inShapeFilter, TempAllocator &inAllocator)
+bool CharacterVirtual::WalkStairs(float inDeltaTime, float inMinStepSize, Vec3Arg inStepUp, Vec3Arg inStepForward, Vec3Arg inStepForwardTest, Vec3Arg inStepDownExtra, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, const ShapeFilter &inShapeFilter, TempAllocator &inAllocator)
 {
 	StartTrackingContactChanges();
 	JPH_SCOPE_EXIT([this]() { FinishTrackingContactChanges(); });
@@ -1606,14 +1604,16 @@ bool CharacterVirtual::WalkStairs(float inDeltaTime, Vec3Arg inStepUp, Vec3Arg i
 	// so we need to cancel the stair walk or else we will move faster than we should as we've done
 	// normal movement first and then stair walk.
 	bool made_progress = false;
-	float max_dot = -0.05f * inStepForward.Length();
-	for (const Vec3 &normal : steep_slope_normals)
+	for (const Vec3& normal : steep_slope_normals)
+  {
+    float max_dot = 0.05f * inStepForward.Dot(normal);
 		if (normal.Dot(horizontal_movement) < max_dot)
 		{
 			// We moved more than 5% of the forward step against a steep slope, accept this as progress
 			made_progress = true;
 			break;
 		}
+  }
 	if (!made_progress)
 		return false;
 
@@ -1625,7 +1625,11 @@ bool CharacterVirtual::WalkStairs(float inDeltaTime, Vec3Arg inStepUp, Vec3Arg i
 
 	// Move down towards the floor.
 	// Note that we travel the same amount down as we traveled up with the specified extra
-	Vec3 down = -up + inStepDownExtra;
+  Vec3 virt_step_forward_horizontal = inMinStepSize * inStepForward.NormalizedOr(Vec3::sZero());
+  virt_step_forward_horizontal -= virt_step_forward_horizontal.Dot(mUp) * mUp;
+  Vec3 virt_sterp_forward_vertical = inStepForward.Dot(mUp) * mUp * 1.05f;
+  // Add test step forward for better sweep test behaviour
+	Vec3 down = -up + inStepDownExtra + virt_step_forward_horizontal;
 	if (!GetFirstContactForSweep(new_position, down, contact, dummy_ignored_contacts, inBroadPhaseLayerFilter, inObjectLayerFilter, inBodyFilter, inShapeFilter))
 		return false; // No floor found, we're in mid air, cancel stair walk
 
@@ -1682,9 +1686,20 @@ bool CharacterVirtual::WalkStairs(float inDeltaTime, Vec3Arg inStepUp, Vec3Arg i
 			return false;
 	}
 
+  // Test if the character have gained any height above the current ground plane
+  if (!mIsWalkingStairs)
+  {
+    Vec3 total_displacement = Vec3(contact.mPosition - mPosition);
+    if (total_displacement.Dot(mGroundSurfaceNormal) < 1e-4f)
+      return false;
+  }
+
 	// Calculate new down position
+  // Remove virtual forward step. It is not the exact cast result, yet in case inMinStepSize is much smaller than inStepUp, it should be accurate
+  down -= virt_step_forward_horizontal;
 	down *= contact.mFraction;
 	new_position += down;
+
 
 	// Move the character to the new location
 	MoveToContact(new_position, contact, inBroadPhaseLayerFilter, inObjectLayerFilter, inBodyFilter, inShapeFilter, inAllocator);
@@ -1732,6 +1747,10 @@ void CharacterVirtual::ExtendedUpdate(float inDeltaTime, Vec3Arg inGravity, cons
 	Vec3 desired_velocity = mLinearVelocity;
 	mLinearVelocity = CancelVelocityTowardsSteepSlopes(desired_velocity);
 
+  // Cancel vertical componen in case of walking stairs
+  if (mIsWalkingStairs)
+    mLinearVelocity -= mLinearVelocity.Dot(mUp) * mUp;
+
 	// Remember old position
 	RVec3 old_position = mPosition;
 
@@ -1746,7 +1765,7 @@ void CharacterVirtual::ExtendedUpdate(float inDeltaTime, Vec3Arg inGravity, cons
 		ground_to_air = false;
 
 	// If stick to floor enabled and we're going from supported to not supported
-	if (ground_to_air && !inSettings.mStickToFloorStepDown.IsNearZero())
+	if (ground_to_air && !inSettings.mStickToFloorStepDown.IsNearZero() && !mIsWalkingStairs)
 	{
 		// If we're not moving up, stick to the floor
 		float velocity = Vec3(mPosition - old_position).Dot(mUp) / inDeltaTime;
@@ -1755,17 +1774,20 @@ void CharacterVirtual::ExtendedUpdate(float inDeltaTime, Vec3Arg inGravity, cons
 	}
 
 	// If walk stairs enabled
-	if (!inSettings.mWalkStairsStepUp.IsNearZero() && IsSupported())
+  bool is_walking_stairs = mIsWalkingStairs;
+  mIsWalkingStairs = false;
+	if (!inSettings.mWalkStairsStepUp.IsNearZero() && (IsSupported() || is_walking_stairs))
 	{
 		// Calculate how much we wanted to move horizontally
+    Vec3 ground_normal = is_walking_stairs ? mPreviousNormal : mGroundNormal;
 		Vec3 desired_horizontal_step = desired_velocity * inDeltaTime;
-		desired_horizontal_step -= desired_horizontal_step.Dot(mGroundNormal) * mGroundNormal;
+		desired_horizontal_step -= desired_horizontal_step.Dot(ground_normal) * ground_normal;
 		float desired_horizontal_step_len = desired_horizontal_step.Length();
 		if (desired_horizontal_step_len > 0.0f)
 		{
 			// Calculate how much we moved horizontally
 			Vec3 achieved_horizontal_step = Vec3(mPosition - old_position);
-			achieved_horizontal_step -= achieved_horizontal_step.Dot(mGroundNormal) * mGroundNormal;
+			achieved_horizontal_step -= achieved_horizontal_step.Dot(ground_normal) * ground_normal;
 
 			// Only count movement in the direction of the desired movement
 			// (otherwise we find it ok if we're sliding downhill while we're trying to climb uphill)
@@ -1773,15 +1795,20 @@ void CharacterVirtual::ExtendedUpdate(float inDeltaTime, Vec3Arg inGravity, cons
 			achieved_horizontal_step = max(0.0f, achieved_horizontal_step.Dot(step_forward_normalized)) * step_forward_normalized;
 			float achieved_horizontal_step_len = achieved_horizontal_step.Length();
 
+      bool can_walk_stairs = CanWalkStairs(desired_velocity, is_walking_stairs);
+
+      if (can_walk_stairs && is_walking_stairs)
+        mIsWalkingStairs = true;
+
 			// If we didn't move as far as we wanted and we're against a slope that's too steep
 			if (achieved_horizontal_step_len + 1.0e-4f < desired_horizontal_step_len
-				&& CanWalkStairs(desired_velocity))
+				&& can_walk_stairs)
 			{
 				// Calculate how much we should step forward
 				// Note that we clamp the step forward to a minimum distance. This is done because at very high frame rates the delta time
 				// may be very small, causing a very small step forward. If the step becomes small enough, we may not move far enough
 				// horizontally to actually end up at the top of the step.
-				Vec3 step_forward = step_forward_normalized * max(inSettings.mWalkStairsMinStepForward, desired_horizontal_step_len - achieved_horizontal_step_len);
+				Vec3 step_forward = step_forward_normalized * max(0.0f, desired_horizontal_step_len - achieved_horizontal_step_len);
 
 				// Calculate how far to scan ahead for a floor. This is only used in case the floor normal at step_forward is too steep.
 				// In that case an additional check will be performed at this distance to check if that normal is not too steep.
@@ -1798,7 +1825,13 @@ void CharacterVirtual::ExtendedUpdate(float inDeltaTime, Vec3Arg inGravity, cons
 				// Calculate the correct magnitude for the test vector
 				step_forward_test *= inSettings.mWalkStairsStepForwardTest;
 
-				WalkStairs(inDeltaTime, inSettings.mWalkStairsStepUp, step_forward, step_forward_test, inSettings.mWalkStairsStepDownExtra, inBroadPhaseLayerFilter, inObjectLayerFilter, inBodyFilter, inShapeFilter, inAllocator);
+        if (WalkStairs(inDeltaTime, inSettings.mWalkStairsMinStepForward, inSettings.mWalkStairsStepUp, step_forward, step_forward_test, inSettings.mWalkStairsStepDownExtra, inBroadPhaseLayerFilter, inObjectLayerFilter, inBodyFilter, inShapeFilter, inAllocator))
+        {
+          mIsWalkingStairs = true;
+          mPreviousNormal = ground_normal;
+        }
+        else
+          mIsWalkingStairs = false;
 			}
 		}
 	}

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.cpp
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.cpp
@@ -1755,17 +1755,17 @@ void CharacterVirtual::ExtendedUpdate(float inDeltaTime, Vec3Arg inGravity, cons
 	}
 
 	// If walk stairs enabled
-	if (!inSettings.mWalkStairsStepUp.IsNearZero())
+	if (!inSettings.mWalkStairsStepUp.IsNearZero() && IsSupported())
 	{
 		// Calculate how much we wanted to move horizontally
 		Vec3 desired_horizontal_step = desired_velocity * inDeltaTime;
-		desired_horizontal_step -= desired_horizontal_step.Dot(mUp) * mUp;
+		desired_horizontal_step -= desired_horizontal_step.Dot(mGroundNormal) * mGroundNormal;
 		float desired_horizontal_step_len = desired_horizontal_step.Length();
 		if (desired_horizontal_step_len > 0.0f)
 		{
 			// Calculate how much we moved horizontally
 			Vec3 achieved_horizontal_step = Vec3(mPosition - old_position);
-			achieved_horizontal_step -= achieved_horizontal_step.Dot(mUp) * mUp;
+			achieved_horizontal_step -= achieved_horizontal_step.Dot(mGroundNormal) * mGroundNormal;
 
 			// Only count movement in the direction of the desired movement
 			// (otherwise we find it ok if we're sliding downhill while we're trying to climb uphill)

--- a/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.h
+++ b/Code/ThirdParty/Jolt/Physics/Character/CharacterVirtual.h
@@ -334,10 +334,12 @@ public:
 	/// This function will return true if the character has moved into a slope that is too steep (e.g. a vertical wall).
 	/// You would call WalkStairs to attempt to step up stairs.
 	/// @param inLinearVelocity The linear velocity that the player desired. This is used to determine if we're pushing into a step.
-	bool								CanWalkStairs(Vec3Arg inLinearVelocity) const;
+  /// @param inAcceptNotCollided Whether we should accept the contact as a slope if the character hasn't collided with it. Used when WalkStairs have to be called multiple times in the row.
+	bool								CanWalkStairs(Vec3Arg inLinearVelocity, bool inAcceptNotCollided) const;
 
 	/// When stair walking is needed, you can call the WalkStairs function to cast up, forward and down again to try to find a valid position
 	/// @param inDeltaTime Time step to simulate.
+  /// @param inMinStepSize When the framerate is high, the forward casting might not be enough to reach the new floor. That is the distance in the forward direction at which the object is casted down to test for a potential floor.
 	/// @param inStepUp The direction and distance to step up (this corresponds to the max step height)
 	/// @param inStepForward The direction and distance to step forward after the step up
 	/// @param inStepForwardTest When running at a high frequency, inStepForward can be very small and it's likely that you hit the side of the stairs on the way down. This could produce a normal that violates the max slope angle. If this happens, we test again using this distance from the up position to see if we find a valid slope.
@@ -348,7 +350,7 @@ public:
 	/// @param inShapeFilter Filter that is used to check if a character collides with a subshape.
 	/// @param inAllocator An allocator for temporary allocations. All memory will be freed by the time this function returns.
 	/// @return true if the stair walk was successful
-	bool								WalkStairs(float inDeltaTime, Vec3Arg inStepUp, Vec3Arg inStepForward, Vec3Arg inStepForwardTest, Vec3Arg inStepDownExtra, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, const ShapeFilter &inShapeFilter, TempAllocator &inAllocator);
+	bool								WalkStairs(float inDeltaTime, float inMinStepSize, Vec3Arg inStepUp, Vec3Arg inStepForward, Vec3Arg inStepForwardTest, Vec3Arg inStepDownExtra, const BroadPhaseLayerFilter &inBroadPhaseLayerFilter, const ObjectLayerFilter &inObjectLayerFilter, const BodyFilter &inBodyFilter, const ShapeFilter &inShapeFilter, TempAllocator &inAllocator);
 
 	/// This function can be used to artificially keep the character to the floor. Normally when a character is on a small step and starts moving horizontally, the character will
 	/// lose contact with the floor because the initial vertical velocity is zero while the horizontal velocity is quite high. To prevent the character from losing contact with the floor,
@@ -748,6 +750,13 @@ private:
 
 	// The inner rigid body that proxies the character in the world
 	BodyID								mInnerBodyID;
+
+  // Stair walking additional data
+  // Ground normal saved from the moment the character started walking stairs
+  // mGroundNormal can't be used for more than one step because for any further steps it is likely to be equal not to the ground but to the slope normal
+  Vec3                  mPreviousNormal = Vec3::sZero();
+  // Flag that indicates the character started walking stairs in previous updates
+  bool                  mIsWalkingStairs = false;
 };
 
 JPH_NAMESPACE_END


### PR DESCRIPTION
This PR is mainly for testing purposes, it (at least partially) resolves issue #1942. 

In the original version, the step forward calculation was very large, when the character appeared to be on the tilted ground. It has led to the artificial acceleration when stair stepping mode got enabled.  To make calculations correct, the `up`  vector is replaced (which in most cases is  the zAxis) with the ground normal vector