### PR TITLE
Fixed #1892: Better error handling for duplicate sub-asset GUIDs

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetCurator.h
+++ b/Code/Editor/EditorFramework/Assets/AssetCurator.h
@@ -440,7 +440,7 @@ private:
   void UpdateTrackedFiles(const ezUuid& assetGuid, const ezSet<ezString>& files, ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, ezSet<std::tuple<ezUuid, ezUuid>>& unresolved, bool bAdd);
   void UpdateUnresolvedTrackedFiles(ezMap<ezString, ezHybridArray<ezUuid, 1>>& inverseTracker, ezSet<std::tuple<ezUuid, ezUuid>>& unresolved);
   ezResult ReadAssetDocumentInfo(const ezDataDirPath& absFilePath, const ezFileStatus& stat, ezUniquePtr<ezAssetInfo>& assetInfo);
-  void UpdateSubAssets(ezAssetInfo& assetInfo);
+  ezResult UpdateSubAssets(ezAssetInfo& assetInfo);
 
   void RemoveAssetTransformState(const ezUuid& assetGuid);
   void InvalidateAssetTransformState(const ezUuid& assetGuid);

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetCurator.cpp
@@ -988,7 +988,11 @@ ezAssetInfo::TransformState ezAssetCurator::UpdateAssetTransformState(ezUuid ass
         pAssetInfo->m_MissingPackageDeps = std::move(missingPackageDeps);
         if (state == ezAssetInfo::TransformState::UpToDate)
         {
-          UpdateSubAssets(*pAssetInfo);
+          if (UpdateSubAssets(*pAssetInfo).Failed())
+          {
+            UpdateAssetTransformState(assetGuid, ezAssetInfo::TransformError);
+            state = ezAssetInfo::TransformState::TransformError;
+          }
         }
       }
     }

--- a/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
+++ b/Code/Editor/EditorFramework/Assets/Implementation/AssetUpdates.cpp
@@ -272,10 +272,19 @@ ezResult ezAssetCurator::EnsureAssetInfoUpdated(const ezDataDirPath& absFilePath
   UpdateAssetTransformState(newGuid, ezAssetInfo::TransformState::Unknown);
   // Don't call SetAssetExistanceState on newly created assets as their data structure is initialized in UpdateSubAssets for the first time.
   if (newExistanceState != ezAssetExistanceState::FileAdded)
+  {
     SetAssetExistanceState(*pCurrentAssetInfo, newExistanceState);
-  UpdateSubAssets(*pCurrentAssetInfo);
+  }
 
-  InvalidateAssetTransformState(newGuid);
+  if (UpdateSubAssets(*pCurrentAssetInfo).Succeeded())
+  {
+    InvalidateAssetTransformState(newGuid);
+  }
+  else
+  {
+    UpdateAssetTransformState(newGuid, ezAssetInfo::TransformState::TransformError);
+  }
+
   pFiles->LinkDocument(absFilePath, pCurrentAssetInfo->m_Info->m_DocumentID).AssertSuccess("Failed to link document in file system model");
   return EZ_SUCCESS;
 }
@@ -481,12 +490,12 @@ ezResult ezAssetCurator::ReadAssetDocumentInfo(const ezDataDirPath& absFilePath,
   return res;
 }
 
-void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
+ezResult ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
 {
   CURATOR_PROFILE("UpdateSubAssets");
   if (assetInfo.m_ExistanceState == ezAssetExistanceState::FileRemoved)
   {
-    return;
+    return EZ_SUCCESS;
   }
 
   if (assetInfo.m_ExistanceState == ezAssetExistanceState::FileAdded)
@@ -498,6 +507,9 @@ void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
     mainSub.m_Data.m_Guid = assetInfo.m_Info->m_DocumentID;
     mainSub.m_Data.m_sSubAssetsDocumentTypeName = assetInfo.m_Info->m_sAssetsDocumentTypeName;
   }
+
+  ezStringBuilder tmp;
+  ezTempHybridArray<ezLogEntry, 2> logEntries;
 
   {
     ezTempHybridArray<ezSubAssetData, 4> subAssets;
@@ -514,20 +526,30 @@ void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
 
     for (const ezSubAssetData& data : subAssets)
     {
-      const bool bExisted = m_KnownSubAssets.Find(data.m_Guid).IsValid();
-      EZ_ASSERT_DEV(bExisted == assetInfo.m_SubAssets.Contains(data.m_Guid), "Implementation error: m_KnownSubAssets and assetInfo.m_SubAssets are out of sync.");
-
-      ezSubAsset sub;
-      sub.m_bMainAsset = false;
-      sub.m_ExistanceState = bExisted ? ezAssetExistanceState::FileModified : ezAssetExistanceState::FileAdded;
-      sub.m_pAssetInfo = &assetInfo;
-      sub.m_Data = data;
-      m_KnownSubAssets.Insert(data.m_Guid, sub);
-
-      if (!bExisted)
+      const auto itSub = m_KnownSubAssets.Find(data.m_Guid);
+      const bool bExisted = itSub.IsValid();
+      if (bExisted == assetInfo.m_SubAssets.Contains(data.m_Guid))
       {
-        assetInfo.m_SubAssets.Insert(sub.m_Data.m_Guid);
-        m_SubAssetChanged.Insert(sub.m_Data.m_Guid);
+        ezSubAsset sub;
+        sub.m_bMainAsset = false;
+        sub.m_ExistanceState = bExisted ? ezAssetExistanceState::FileModified : ezAssetExistanceState::FileAdded;
+        sub.m_pAssetInfo = &assetInfo;
+        sub.m_Data = data;
+        m_KnownSubAssets.Insert(data.m_Guid, sub);
+
+        if (!bExisted)
+        {
+          assetInfo.m_SubAssets.Insert(sub.m_Data.m_Guid);
+          m_SubAssetChanged.Insert(sub.m_Data.m_Guid);
+        }
+      }
+      else
+      {
+        tmp.SetFormat("Sub-asset '{}' with GUID '{}' already exists in '{}'", data.m_sName, data.m_Guid, itSub.Value().m_pAssetInfo->m_Path.GetDataDirParentRelativePath());
+
+        auto& log = logEntries.ExpandAndGetRef();
+        log.m_Type = ezLogMsgType::ErrorMsg;
+        log.m_sMsg = tmp;
       }
     }
 
@@ -543,6 +565,13 @@ void ezAssetCurator::UpdateSubAssets(ezAssetInfo& assetInfo)
       }
     }
   }
+
+  if (logEntries.IsEmpty())
+    return EZ_SUCCESS;
+
+  assetInfo.m_LogEntries = logEntries;
+
+  return EZ_FAILURE;
 }
 
 void ezAssetCurator::RemoveAssetTransformState(const ezUuid& assetGuid)


### PR DESCRIPTION
When two assets generate the same sub-asset GUIDs, this is now detected and a useful asset error message is displayed in the asset curator.

<img width="2163" height="345" alt="image" src="https://github.com/user-attachments/assets/03229175-9c58-4d8a-a541-865ce83fcef9" />
