### PR TITLE
Added support for asset or object references in log messages

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -129,8 +129,14 @@ public:
   /// \brief Handles all messages received from the corresponding ezEngineProcessDocumentContext on the engine process.
   virtual void HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg);
 
+  struct AssetUsage
+  {
+    ezString m_sObjectName;
+    ezUuid m_ObjectGuid;
+  };
+
   /// \brief Finds all usages of the given asset in this document and appends them to out_usages. The default implementation does nothing, override this if your document can reference other assets.
-  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<ezString>& out_usages, ezUInt32 maxResults) const {}
+  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const {}
 
   /// \brief Returns the ezEditorEngineConnection for this document.
   ezEditorEngineConnection* GetEditorEngineConnection() const { return m_pEngineConnection; }

--- a/Code/Editor/EditorFramework/Document/GameObjectDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectDocument.h
@@ -47,9 +47,12 @@ struct EZ_EDITORFRAMEWORK_DLL ezGameObjectEvent
     GameModeChanged,
 
     GizmoTransformMayBeInvalid, ///< Sent when a change was made that may affect the current gizmo / manipulator state (ie. objects have been moved)
+
+    TriggerSetScenegraphFilter, ///< Sets the scenegraph search filter text. The filter string is stored in m_sPayload.
   };
 
   Type m_Type;
+  ezString m_sPayload;
 };
 
 struct ezGameObjectDocumentEvent
@@ -141,10 +144,10 @@ public:
   virtual void HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg) override;
 
   /// \brief Finds all usages of the given asset in this document and appends them to out_usages. The default implementation does nothing, override this if your document can reference other assets.
-  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<ezString>& out_usages, ezUInt32 maxResults) const override;
+  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const override;
 
 private:
-  void FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<ezString>& out_usages, ezUInt32 maxResults) const;
+  void FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const;
   void DeallocateEditTools();
 
   ezDelegate<void(ezGameObjectEditTool*)> m_EditToolConfigDelegate;

--- a/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
+++ b/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
@@ -1051,13 +1051,13 @@ void ezGameObjectDocument::HandleEngineMessage(const ezEditorEngineDocumentMsg* 
 
 // the following method is similar to "ezAssetCurator::ReplaceAssetReferenceInObject"
 
-void ezGameObjectDocument::FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<ezString>& out_usages, ezUInt32 maxResults) const
+void ezGameObjectDocument::FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const
 {
   out_usages.Clear();
   FindAssetUsagesInternal(sAssetToFind, GetObjectManager()->GetRootObject(), out_usages, maxResults);
 }
 
-void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<ezString>& out_usages, ezUInt32 maxResults) const
+void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const
 {
   auto pAccessor = GetObjectAccessor();
 
@@ -1095,7 +1095,10 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
             {
               ezStringBuilder sFullPath;
               GenerateFullDisplayName(pObject, sFullPath);
-              out_usages.PushBack(sFullPath);
+
+              auto& au = out_usages.ExpandAndGetRef();
+              au.m_sObjectName = sFullPath;
+              au.m_ObjectGuid = pObject->GetGuid();
 
               if (out_usages.GetCount() >= maxResults)
                 return;
@@ -1122,7 +1125,10 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
               {
                 ezStringBuilder sFullPath;
                 GenerateFullDisplayName(pObject, sFullPath);
-                out_usages.PushBack(sFullPath);
+
+                auto& au = out_usages.ExpandAndGetRef();
+                au.m_sObjectName = sFullPath;
+                au.m_ObjectGuid = pObject->GetGuid();
 
                 if (out_usages.GetCount() >= maxResults)
                   return;
@@ -1150,7 +1156,10 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
                 {
                   ezStringBuilder sFullPath;
                   GenerateFullDisplayName(pObject, sFullPath);
-                  out_usages.PushBack(sFullPath);
+
+                  auto& au = out_usages.ExpandAndGetRef();
+                  au.m_sObjectName = sFullPath;
+                  au.m_ObjectGuid = pObject->GetGuid();
 
                   if (out_usages.GetCount() >= maxResults)
                     return;

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.cpp
@@ -1,6 +1,7 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/Assets/AssetCurator.h>
+#include <EditorFramework/Document/GameObjectDocument.h>
 #include <EditorFramework/EditorApp/CheckVersion.moc.h>
 #include <EditorFramework/EditorApp/EditorApp.moc.h>
 #include <EditorFramework/Preferences/EditorPreferences.h>
@@ -189,6 +190,65 @@ void ezQtEditorApp::UiServicesEvents(const ezQtUiServices::Event& e)
   if (e.m_Type == ezQtUiServices::Event::Type::CheckForUpdates)
   {
     m_pVersionChecker->Check(true);
+  }
+
+  if (e.m_Type == ezQtUiServices::Event::Type::GotoLinkTarget)
+  {
+    ezStringView sTarget = e.m_sText;
+
+    if (sTarget.TrimWordStart("asset:"))
+    {
+      ezStringView sObjRef;
+
+      if (const char* szRef = sTarget.FindSubString("#"))
+      {
+        sObjRef = ezStringView(szRef + 1, sTarget.GetEndPointer());
+        sTarget = ezStringView(sTarget.GetStartPointer(), szRef);
+      }
+
+      if (ezConversionUtils::IsStringUuid(sTarget))
+      {
+        const ezUuid guid = ezConversionUtils::ConvertStringToUuid(sTarget);
+
+        ezStringBuilder path;
+
+        if (auto pAsset = ezAssetCurator::GetSingleton()->GetSubAsset(guid))
+        {
+          path = pAsset->m_pAssetInfo->m_Path;
+        }
+
+        if (!path.IsEmpty())
+        {
+          if (ezDocument* pDoc = OpenDocument(path, ezDocumentFlags::RequestWindow | ezDocumentFlags::AddToRecentFilesList))
+          {
+            ezStringView sFilter = sObjRef;
+            if (sFilter.TrimWordStart("filter:"))
+            {
+              // Strip surrounding quotes, if present.
+              sFilter.TrimWordStart("\"");
+              sFilter.TrimWordEnd("\"");
+
+              if (ezGameObjectDocument* pGameObjDoc = ezDynamicCast<ezGameObjectDocument*>(pDoc))
+              {
+                ezGameObjectEvent filterEvent;
+                filterEvent.m_Type = ezGameObjectEvent::Type::TriggerSetScenegraphFilter;
+                filterEvent.m_sPayload = sFilter;
+                pGameObjDoc->m_GameObjectEvents.Broadcast(filterEvent);
+              }
+            }
+            else if (ezConversionUtils::IsStringUuid(sObjRef))
+            {
+              const ezUuid objGuid = ezConversionUtils::ConvertStringToUuid(sObjRef);
+
+              if (auto pObj = pDoc->GetObjectManager()->GetObject(objGuid))
+              {
+                pDoc->GetSelectionManager()->SetSelection(pObj);
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }
 

--- a/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
+++ b/Code/Editor/EditorFramework/GUI/Implementation/RawDocumentTreeWidget.cpp
@@ -1,9 +1,146 @@
 #include <EditorFramework/EditorFrameworkPCH.h>
 
 #include <EditorFramework/GUI/RawDocumentTreeWidget.moc.h>
+#include <Foundation/Reflection/Implementation/PropertyAttributes.h>
+#include <Foundation/Utilities/ConversionUtils.h>
 #include <GuiFoundation/ActionViews/QtProxy.moc.h>
 #include <GuiFoundation/Models/TreeSearchFilterModel.moc.h>
 #include <ToolsFoundation/Object/ObjectAccessorBase.h>
+
+/// Delegate object for the scene graph filter model.
+///
+/// Handles matching game objects against the search text by checking component type names
+/// and, when the "ref:" keyword is used, whether any component property references a specific asset GUID.
+class ezGameObjectFilter
+{
+public:
+  bool Filter(QModelIndex index, const ezSearchPatternFilter& filter)
+  {
+    if (filter.GetSearchText() != m_sLastFilterText)
+    {
+      ParseFilter(filter.GetSearchText());
+    }
+
+    const ezQtDocumentTreeModel* pModel = qobject_cast<const ezQtDocumentTreeModel*>(index.model());
+    if (pModel == nullptr)
+      return false;
+
+    const ezDocumentObject* pObj = pModel->GetObject(index);
+    ezObjectAccessorBase* pAcc = pModel->GetDocumentTree()->GetDocument()->GetObjectAccessor();
+    ezVariant comp;
+
+    const ezInt32 iNum = pAcc->GetCountByName(pObj, "Components");
+    for (ezInt32 i = 0; i < iNum; ++i)
+    {
+      if (pAcc->GetValueByName(pObj, "Components", comp, i).Failed())
+        continue;
+
+      const ezDocumentObject* pCompObj = pAcc->GetObject(comp.Get<ezUuid>());
+
+      if (m_bGuidSearch)
+      {
+        if (ComponentReferencesGuid(pCompObj, m_SearchGuid))
+          return true;
+      }
+      else
+      {
+        if (filter.PassesFilters(pCompObj->GetType()->GetTypeName()))
+          return true;
+      }
+    }
+
+    return false;
+  }
+
+private:
+  void ParseFilter(const ezString& sText)
+  {
+    m_sLastFilterText = sText;
+    m_bGuidSearch = false;
+
+    const char* szRef = ezStringUtils::FindSubString_NoCase(sText.GetData(), "ref:");
+    if (szRef != nullptr)
+    {
+      const char* szGuid = szRef + strlen("ref:");
+      if (ezConversionUtils::IsStringUuid(szGuid))
+      {
+        m_SearchGuid = ezConversionUtils::ConvertStringToUuid(szGuid);
+        m_bGuidSearch = true;
+      }
+    }
+  }
+
+  static bool ComponentReferencesGuid(const ezDocumentObject* pCompObj, const ezUuid& searchGuid)
+  {
+    const ezIReflectedTypeAccessor& acc = pCompObj->GetTypeAccessor();
+
+    ezDynamicArray<const ezAbstractProperty*> properties;
+    acc.GetType()->GetAllProperties(properties);
+
+    for (const ezAbstractProperty* pProp : properties)
+    {
+      if (pProp->GetAttributeByType<ezAssetBrowserAttribute>() == nullptr)
+        continue;
+
+      const auto propVarType = pProp->GetSpecificType()->GetVariantType();
+      if (propVarType != ezVariantType::String && propVarType != ezVariantType::StringView)
+        continue;
+
+      switch (pProp->GetCategory())
+      {
+        case ezPropertyCategory::Member:
+        {
+          const ezVariant val = acc.GetValue(pProp->GetPropertyName());
+          if (val.CanConvertTo<ezString>())
+          {
+            const ezString sVal = val.ConvertTo<ezString>();
+            if (ezConversionUtils::IsStringUuid(sVal) && ezConversionUtils::ConvertStringToUuid(sVal) == searchGuid)
+              return true;
+          }
+          break;
+        }
+        case ezPropertyCategory::Array:
+        {
+          const ezInt32 iCount = acc.GetCount(pProp->GetPropertyName());
+          for (ezInt32 i = 0; i < iCount; ++i)
+          {
+            const ezVariant val = acc.GetValue(pProp->GetPropertyName(), i);
+            if (val.CanConvertTo<ezString>())
+            {
+              const ezString sVal = val.ConvertTo<ezString>();
+              if (ezConversionUtils::IsStringUuid(sVal) && ezConversionUtils::ConvertStringToUuid(sVal) == searchGuid)
+                return true;
+            }
+          }
+          break;
+        }
+        case ezPropertyCategory::Map:
+        {
+          ezDynamicArray<ezVariant> keys;
+          acc.GetKeys(pProp->GetPropertyName(), keys);
+          for (const ezVariant& key : keys)
+          {
+            const ezVariant val = acc.GetValue(pProp->GetPropertyName(), key);
+            if (val.CanConvertTo<ezString>())
+            {
+              const ezString sVal = val.ConvertTo<ezString>();
+              if (ezConversionUtils::IsStringUuid(sVal) && ezConversionUtils::ConvertStringToUuid(sVal) == searchGuid)
+                return true;
+            }
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    return false;
+  }
+
+  ezString m_sLastFilterText;
+  bool m_bGuidSearch = false;
+  ezUuid m_SearchGuid;
+};
 
 ezQtDocumentTreeView::ezQtDocumentTreeView(QWidget* pParent)
   : ezQtItemView<QTreeView>(pParent)
@@ -19,29 +156,6 @@ ezQtDocumentTreeView::ezQtDocumentTreeView(QWidget* pParent, ezDocument* pDocume
   Initialize(pDocument, std::move(pModel), pSelection);
 }
 
-static bool GameObjectFilterFunc(QModelIndex index, const ezSearchPatternFilter& filter)
-{
-  if (const ezQtDocumentTreeModel* pModel = qobject_cast<const ezQtDocumentTreeModel*>(index.model()))
-  {
-    auto pObj = pModel->GetObject(index);
-    auto pAcc = pModel->GetDocumentTree()->GetDocument()->GetObjectAccessor();
-
-    ezVariant comp;
-
-    const ezInt32 iNum = pAcc->GetCountByName(pObj, "Components");
-    for (ezInt32 i = 0; i < iNum; ++i)
-    {
-      if (pAcc->GetValueByName(pObj, "Components", comp, i).Succeeded())
-      {
-        if (filter.PassesFilters(pAcc->GetObject(comp.Get<ezUuid>())->GetType()->GetTypeName()))
-          return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 void ezQtDocumentTreeView::Initialize(ezDocument* pDocument, std::unique_ptr<ezQtDocumentTreeModel> pModel, ezSelectionManager* pSelection)
 {
   m_pDocument = pDocument;
@@ -53,9 +167,10 @@ void ezQtDocumentTreeView::Initialize(ezDocument* pDocument, std::unique_ptr<ezQ
     m_pSelectionManager = m_pDocument->GetSelectionManager();
   }
 
+  m_pGameObjectFilter = std::make_unique<ezGameObjectFilter>();
   m_pFilterModel.reset(new ezQtTreeSearchFilterModel(this));
   m_pFilterModel->setSourceModel(m_pModel.get());
-  m_pFilterModel->SetCustomFilterFunc(GameObjectFilterFunc);
+  m_pFilterModel->SetCustomFilterFunc(ezMakeDelegate(&ezGameObjectFilter::Filter, m_pGameObjectFilter.get()));
 
   setSelectionBehavior(QAbstractItemView::SelectionBehavior::SelectRows);
   setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);

--- a/Code/Editor/EditorFramework/GUI/RawDocumentTreeWidget.moc.h
+++ b/Code/Editor/EditorFramework/GUI/RawDocumentTreeWidget.moc.h
@@ -11,6 +11,7 @@
 
 class ezQtTreeSearchFilterModel;
 class ezSelectionManager;
+class ezGameObjectFilter;
 
 class EZ_EDITORFRAMEWORK_DLL ezQtDocumentTreeView : public ezQtItemView<QTreeView>
 {
@@ -42,6 +43,7 @@ private:
 private:
   std::unique_ptr<ezQtDocumentTreeModel> m_pModel;
   std::unique_ptr<ezQtTreeSearchFilterModel> m_pFilterModel;
+  std::unique_ptr<ezGameObjectFilter> m_pGameObjectFilter;
   ezSelectionManager* m_pSelectionManager = nullptr;
   ezDocument* m_pDocument = nullptr;
   bool m_bBlockSelectionSignal = false;

--- a/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/AssetCuratorPanel/Implementation/AssetCuratorPanel.cpp
@@ -198,7 +198,7 @@ void ezQtAssetCuratorPanel::UpdateIssueInfo()
       ezDocument* pDocument = ezQtEditorApp::GetSingleton()->OpenDocument(sDocumentPath, ezDocumentFlags::None);
 
       constexpr ezUInt32 maxResults = 3;
-      ezTempHybridArray<ezString, maxResults> uses;
+      ezTempHybridArray<ezAssetDocument::AssetUsage, maxResults> uses;
       if (pDocument != nullptr)
       {
         // cast a document to ezAssetDocument to access the FindAssetUsages function.
@@ -223,10 +223,10 @@ void ezQtAssetCuratorPanel::UpdateIssueInfo()
           {
             usesString.Append(", ");
           }
-          usesString.Append(use);
+          usesString.Append("'", use.m_sObjectName, "'");
         }
 
-        sTmp.SetFormat("{}. Used by objects: {}", sDep, usesString);
+        sTmp.SetFormat("{}. Used by objects: [[{}|asset:{}#filter:\"ref:{}\"]]", sDep, usesString, pSubAsset->m_pAssetInfo->m_Info->m_DocumentID, sDep);
       }
 
       return sTmp;

--- a/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectPanel.cpp
+++ b/Code/Editor/EditorFramework/Panels/GameObjectPanel/Implementation/GameObjectPanel.cpp
@@ -23,6 +23,7 @@ ezQtGameObjectWidget::ezQtGameObjectWidget(QWidget* pParent, ezGameObjectDocumen
   m_pFilterWidget = new ezQtSearchWidget(this);
   m_pFilterWidget->setObjectName("ezQtSearchWidget");
   m_pFilterWidget->setPlaceholderText("Search by name or component type");
+  m_pFilterWidget->setToolTip("Search by object name or component type name.\nUse 'ref:{GUID}' to show only objects that reference a specific asset.");
   connect(m_pFilterWidget, &ezQtSearchWidget::textChanged, this, &ezQtGameObjectWidget::OnFilterTextChanged);
 
   layout()->addWidget(m_pFilterWidget);
@@ -60,6 +61,11 @@ void ezQtGameObjectWidget::DocumentSceneEventHandler(const ezGameObjectEvent& e)
     case ezGameObjectEvent::Type::TriggerExpandScenegraph:
     {
       m_pTreeWidget->expandAll();
+    }
+    break;
+    case ezGameObjectEvent::Type::TriggerSetScenegraphFilter:
+    {
+      m_pFilterWidget->setText(QString::fromUtf8(e.m_sPayload.GetData()));
     }
     break;
 

--- a/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Models/Implementation/LogModel.cpp
@@ -125,7 +125,8 @@ QVariant ezQtLogModel::data(const QModelIndex& index, int iRole) const
   if (iRow < 0 || iRow >= (ezInt32)m_VisibleMessages.GetCount())
     return QVariant();
 
-  const ezLogEntry& msg = *m_VisibleMessages[iRow];
+  const ModelEntry& entry = *m_VisibleMessages[iRow];
+  const ezLogEntry& msg = entry.m_Log;
 
   switch (iRole)
   {
@@ -168,9 +169,29 @@ QVariant ezQtLogModel::data(const QModelIndex& index, int iRole) const
       }
     }
 
+    case UserRoles::Link:
+      if (entry.m_sLink.IsEmpty())
+        return QVariant();
+
+      return ezMakeQString(entry.m_sLink);
+
+    case UserRoles::LinkText:
+      if (entry.m_sLinkText.IsEmpty())
+        return QVariant();
+
+      return ezMakeQString(entry.m_sLinkText);
+
+    case UserRoles::LinkTarget:
+      if (entry.m_sLinkTarget.IsEmpty())
+        return QVariant();
+
+      return ezMakeQString(entry.m_sLinkTarget);
+
     default:
       return QVariant();
   }
+
+  return QVariant();
 }
 
 Qt::ItemFlags ezQtLogModel::flags(const QModelIndex& index) const
@@ -222,7 +243,7 @@ void ezQtLogModel::ProcessNewMessages()
   ezStringBuilder sLatestError;
 
   // Collect messages to add to visible list
-  ezTempHybridArray<const ezLogEntry*, 64> messagesToAdd;
+  ezTempHybridArray<const ModelEntry*, 64> messagesToAdd;
 
   {
     EZ_LOCK(m_NewMessagesMutex);
@@ -236,7 +257,8 @@ void ezQtLogModel::ProcessNewMessages()
     ezStringBuilder s;
     for (const auto& msg : m_NewMessages)
     {
-      m_AllMessages.PushBack(msg);
+      auto& entry = m_AllMessages.ExpandAndGetRef();
+      entry.m_Log = msg;
 
       if (msg.m_Type == ezLogMsgType::BeginGroup || msg.m_Type == ezLogMsgType::EndGroup)
       {
@@ -255,12 +277,12 @@ void ezQtLogModel::ProcessNewMessages()
           s.Append(" >>>");
         }
 
-        m_AllMessages.PeekBack().m_sMsg = s;
+        entry.m_Log.m_sMsg = s;
       }
       else
       {
         s.SetPrintf("%*s%s", 4 * msg.m_uiIndentation, "", msg.m_sMsg.GetData());
-        m_AllMessages.PeekBack().m_sMsg = s;
+        entry.m_Log.m_sMsg = s;
 
         if (msg.m_Type == ezLogMsgType::ErrorMsg)
         {
@@ -282,6 +304,7 @@ void ezQtLogModel::ProcessNewMessages()
         }
       }
 
+      FindLink(entry);
 
       // if the message would not be shown anyway, don't trigger an update
       if (IsFiltered(msg))
@@ -352,14 +375,14 @@ void ezQtLogModel::UpdateVisibleEntries() const
   m_VisibleMessages.Clear();
   for (const auto& msg : m_AllMessages)
   {
-    if (IsFiltered(msg))
+    if (IsFiltered(msg.m_Log))
       continue;
 
-    if (msg.m_Type == ezLogMsgType::EndGroup)
+    if (msg.m_Log.m_Type == ezLogMsgType::EndGroup)
     {
       if (!m_VisibleMessages.IsEmpty())
       {
-        if (m_VisibleMessages.PeekBack()->m_Type == ezLogMsgType::BeginGroup)
+        if (m_VisibleMessages.PeekBack()->m_Log.m_Type == ezLogMsgType::BeginGroup)
           m_VisibleMessages.PopBack();
         else
           m_VisibleMessages.PushBack(&msg);
@@ -369,5 +392,38 @@ void ezQtLogModel::UpdateVisibleEntries() const
     {
       m_VisibleMessages.PushBack(&msg);
     }
+  }
+}
+
+void ezQtLogModel::FindLink(ModelEntry& ref_entry) const
+{
+  // Link format:
+  //   [[Display Text|scheme:target]]
+  //
+  // For instance:
+  //   Object [[Bernd|asset:{ Doc-UUID }#{ Obj-UUID }]] not found.
+  //
+  // Link handler can parse the link target further, e.g. detect the scheme to support different actions.
+
+  const char* szStart = ref_entry.m_Log.m_sMsg.FindSubString("[[");
+  while (szStart != nullptr)
+  {
+    const char* szSeparator = ref_entry.m_Log.m_sMsg.FindSubString("|", szStart);
+    const char* szEnd = ref_entry.m_Log.m_sMsg.FindSubString("]]", szStart);
+
+    if (szSeparator && szEnd && szSeparator < szEnd)
+    {
+      ref_entry.m_sLink = ezStringView(szStart, szEnd + 2);
+
+      ref_entry.m_sLinkText = ezStringView(szStart + 2, szSeparator);
+      ref_entry.m_sLinkTarget = ezStringView(szSeparator + 1, szEnd);
+
+      ref_entry.m_sLinkText.Trim();
+      ref_entry.m_sLinkTarget.Trim();
+      return;
+    }
+
+    // Find next candidate
+    szStart = ref_entry.m_Log.m_sMsg.FindSubString("[[", szStart + 1);
   }
 }

--- a/Code/Tools/Libs/GuiFoundation/Models/LogModel.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Models/LogModel.moc.h
@@ -12,6 +12,13 @@ class EZ_GUIFOUNDATION_DLL ezQtLogModel : public QAbstractItemModel
   Q_OBJECT
 
 public:
+  enum UserRoles
+  {
+    Link = Qt::UserRole + 1,
+    LinkText = Qt::UserRole + 2,
+    LinkTarget = Qt::UserRole + 3,
+  };
+
   ezQtLogModel(QObject* pParent);
   void Clear();
   void SetLogLevel(ezLogMsgType::Enum logLevel);
@@ -41,17 +48,27 @@ private Q_SLOTS:
   void ProcessNewMessages();
 
 private:
+  /// Wraps a log entry with optional embedded link data parsed from [[text|target]] syntax.
+  struct ModelEntry
+  {
+    ezLogEntry m_Log;
+    ezStringView m_sLink;       ///< Full [[text|target]] substring, empty if no link present.
+    ezStringView m_sLinkText;   ///< Display text of the link.
+    ezStringView m_sLinkTarget; ///< Link target (e.g. "asset:{guid}").
+  };
+
   void Invalidate();
   bool IsFiltered(const ezLogEntry& lm) const;
   void UpdateVisibleEntries() const;
+  void FindLink(ModelEntry& ref_entry) const;
 
   ezLogMsgType::Enum m_LogLevel;
   ezString m_sSearchText;
-  ezDeque<ezLogEntry> m_AllMessages;
+  ezDeque<ModelEntry> m_AllMessages;
 
   mutable bool m_bIsValid;
-  mutable ezDeque<const ezLogEntry*> m_VisibleMessages;
-  mutable ezHybridArray<const ezLogEntry*, 16> m_BlockQueue;
+  mutable ezDeque<const ModelEntry*> m_VisibleMessages;
+  mutable ezHybridArray<const ModelEntry*, 16> m_BlockQueue;
 
   mutable ezMutex m_NewMessagesMutex;
   ezDeque<ezLogEntry> m_NewMessages;

--- a/Code/Tools/Libs/GuiFoundation/Platform/Linux/UIServices_Linux.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Platform/Linux/UIServices_Linux.cpp
@@ -4,25 +4,25 @@
 
 #  include <GuiFoundation/UIServices/UIServices.moc.h>
 
-void ezQtUiServices::OpenInExplorer(const char* szPath, bool bIsFile)
+void ezQtUiServices::OpenInExplorer(ezStringView sPath, bool bIsFile)
 {
   QStringList args;
   ezStringBuilder parentDir;
 
   if (bIsFile)
   {
-    parentDir = szPath;
+    parentDir = sPath;
     parentDir = parentDir.GetFileDirectory();
-    szPath = parentDir.GetData();
+    sPath = parentDir.GetData();
   }
-  args << QDir::toNativeSeparators(szPath);
+  args << QDir::toNativeSeparators(ezMakeQString(sPath));
 
   QProcess::startDetached("xdg-open", args);
 }
 
-void ezQtUiServices::OpenWith(const char* szPath)
+void ezQtUiServices::OpenWith(ezStringView sPath0)
 {
-  ezStringBuilder sPath = szPath;
+  ezStringBuilder sPath = sPath0;
   sPath.MakeCleanPath();
   sPath.MakePathSeparatorsNative();
 

--- a/Code/Tools/Libs/GuiFoundation/Platform/Win/UIServices_Win.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Platform/Win/UIServices_Win.cpp
@@ -9,21 +9,21 @@
 #  include <Foundation/IO/OSFile.h>
 #  include <ShlObj_core.h>
 
-void ezQtUiServices::OpenInExplorer(const char* szPath, bool bIsFile)
+void ezQtUiServices::OpenInExplorer(ezStringView sPath, bool bIsFile)
 {
   QStringList args;
 
   if (bIsFile)
     args << "/select,";
 
-  args << QDir::toNativeSeparators(szPath);
+  args << QDir::toNativeSeparators(ezMakeQString(sPath));
 
   QProcess::startDetached("explorer", args);
 }
 
-void ezQtUiServices::OpenWith(const char* szPath)
+void ezQtUiServices::OpenWith(ezStringView sPath0)
 {
-  ezStringBuilder sPath = szPath;
+  ezStringBuilder sPath = sPath0;
   sPath.MakeCleanPath();
   sPath.MakePathSeparatorsNative();
 

--- a/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/Implementation/UIServices.cpp
@@ -273,6 +273,14 @@ void ezQtUiServices::CheckForUpdates()
   s_Events.Broadcast(e);
 }
 
+void ezQtUiServices::GotoLinkTarget(ezStringView sLinkTarget)
+{
+  Event e;
+  e.m_Type = Event::Type::GotoLinkTarget;
+  e.m_sText = sLinkTarget;
+  s_Events.Broadcast(e);
+}
+
 void ezQtUiServices::Init()
 {
   s_LastTickEvent.m_fRefreshRate = 60.0;
@@ -369,12 +377,12 @@ void ezQtUiServices::ShowGlobalStatusBarMessage(const ezFormatString& msg)
 }
 
 
-ezResult ezQtUiServices::OpenFileInDefaultProgram(const char* szPath)
+ezResult ezQtUiServices::OpenFileInDefaultProgram(ezStringView sPath)
 {
-  return QDesktopServices::openUrl(QUrl::fromLocalFile(szPath)) ? EZ_SUCCESS : EZ_FAILURE;
+  return QDesktopServices::openUrl(QUrl::fromLocalFile(ezMakeQString(sPath))) ? EZ_SUCCESS : EZ_FAILURE;
 }
 
-ezResult ezQtUiServices::OpenInVisualStudio(const char* szPath)
+ezResult ezQtUiServices::OpenInVisualStudio(ezStringView sPath)
 {
   QString sVSExe;
   QSettings settings("\\HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\Applications\\VSLauncher.exe\\Shell\\Open\\Command", QSettings::NativeFormat);
@@ -387,7 +395,7 @@ ezResult ezQtUiServices::OpenInVisualStudio(const char* szPath)
   }
 
   QStringList arguments;
-  arguments.push_back(szPath);
+  arguments.push_back(ezMakeQString(sPath));
 
   QProcess proc;
   if (proc.startDetached(sVSExe, arguments) == false)
@@ -398,7 +406,7 @@ ezResult ezQtUiServices::OpenInVisualStudio(const char* szPath)
   return EZ_SUCCESS;
 }
 
-ezResult ezQtUiServices::OpenInRider(const char* szPath)
+ezResult ezQtUiServices::OpenInRider(ezStringView sPath)
 {
   QString sRiderPath;
 
@@ -453,7 +461,7 @@ ezResult ezQtUiServices::OpenInRider(const char* szPath)
 #endif
 
   QStringList arguments;
-  arguments.push_back(szPath);
+  arguments.push_back(ezMakeQString(sPath));
 
   if (!QProcess::startDetached(sRiderPath, arguments))
   {

--- a/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/UIServices/UIServices.moc.h
@@ -28,6 +28,7 @@ public:
       ShowGlobalStatusBarText,
       ClickedDocumentPermanentStatusBarText,
       CheckForUpdates,
+      GotoLinkTarget,
     };
 
     enum TextType
@@ -69,64 +70,64 @@ public:
 
   static const char* GetOwnVersionString();
 
-  /// \brief True if the application doesn't show any window and only works in the background
+  /// True if the application doesn't show any window and only works in the background
   static bool IsHeadless();
 
-  /// \brief Set to true if the application doesn't show any window and only works in the background
+  /// Set to true if the application doesn't show any window and only works in the background
   static void SetHeadless(bool bHeadless);
 
-  /// \brief Shows a non-modal color dialog. The Qt slots are called when the selected color is changed or when the dialog is closed and the result
+  /// Shows a non-modal color dialog. The Qt slots are called when the selected color is changed or when the dialog is closed and the result
   /// accepted or rejected.
   void ShowColorDialog(const ezColor& color, bool bAlpha, bool bHDR, QWidget* pParent, const char* szSlotCurColChanged, const char* szSlotAccept, const char* szSlotReject);
 
-  /// \brief Might show a message box depending on the given status. If the status is 'failure' the szFailureMsg is shown, including the message in
+  /// Might show a message box depending on the given status. If the status is 'failure' the szFailureMsg is shown, including the message in
   /// ezStatus. If the status is success a message box with text szSuccessMsg is shown, but only if the status message is not empty or if
   /// bOnlySuccessMsgIfDetails is false.
   static void MessageBoxStatus(const ezStatus& s, const char* szFailureMsg, const char* szSuccessMsg = "", bool bOnlySuccessMsgIfDetails = true);
 
-  /// \brief Shows an information message box
+  /// Shows an information message box
   static void MessageBoxInformation(const ezFormatString& msg, ezStringView sDontShowAgainID = {});
 
-  /// \brief Shows an warning message box
+  /// Shows an warning message box
   static void MessageBoxWarning(const ezFormatString& msg);
 
-  /// \brief Shows a question message box and returns which button the user pressed
+  /// Shows a question message box and returns which button the user pressed
   static QMessageBox::StandardButton MessageBoxQuestion(const ezFormatString& msg, QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
 
-  /// \brief Use this if you need to display a status bar message in any/all documents. Go directly through the document, if you only want to show a
+  /// Use this if you need to display a status bar message in any/all documents. Go directly through the document, if you only want to show a
   /// message in a single document window.
   static void ShowAllDocumentsTemporaryStatusBarMessage(const ezFormatString& msg, ezTime timeOut);
 
   static void ShowAllDocumentsPermanentStatusBarMessage(const ezFormatString& msg, Event::TextType type);
 
-  /// \brief Shows a 'critical' message in all container windows (in red), which does not disappear, until it is replaced with another (empty) string.
+  /// Shows a 'critical' message in all container windows (in red), which does not disappear, until it is replaced with another (empty) string.
   static void ShowGlobalStatusBarMessage(const ezFormatString& msg);
 
-  /// \brief Opens the given file in the program that is registered in the OS to handle that file type.
-  static ezResult OpenFileInDefaultProgram(const char* szPath);
+  /// Opens the given file in the program that is registered in the OS to handle that file type.
+  static ezResult OpenFileInDefaultProgram(ezStringView sPath);
 
-  /// \brief Open the given file in Visual Studio
-  static ezResult OpenInVisualStudio(const char* szPath);
+  /// Open the given file in Visual Studio
+  static ezResult OpenInVisualStudio(ezStringView sPath);
 
-  /// \brief Open the given file in Jetbrains Rider
-  static ezResult OpenInRider(const char* szPath);
+  /// Open the given file in Jetbrains Rider
+  static ezResult OpenInRider(ezStringView sPath);
 
-  /// \brief Opens the given file or folder in the Explorer
-  static void OpenInExplorer(const char* szPath, bool bIsFile);
+  /// Opens the given file or folder in the Explorer
+  static void OpenInExplorer(ezStringView sPath, bool bIsFile);
 
-  /// \brief Shows the "Open With" dialog
-  static void OpenWith(const char* szPath);
+  /// Shows the "Open With" dialog
+  static void OpenWith(ezStringView sPath);
 
-  /// \brief Attempts to launch Visual Studio Code with the given command line
+  /// Attempts to launch Visual Studio Code with the given command line
   static ezStatus OpenInVsCode(const QStringList& arguments);
 
-  /// \brief Loads some global state used by ezQtUiServices from the registry. E.g. the last position of the color dialog.
+  /// Loads some global state used by ezQtUiServices from the registry. E.g. the last position of the color dialog.
   void LoadState();
 
-  /// \brief Saves some global state used by ezQtUiServices to the registry.
+  /// Saves some global state used by ezQtUiServices to the registry.
   void SaveState();
 
-  /// \brief Returns a cached QIcon that was created from an internal Qt resource (e.g. 'QIcon(":QtNamespace/MyIcon.png")' ). Prevents creating the
+  /// Returns a cached QIcon that was created from an internal Qt resource (e.g. 'QIcon(":QtNamespace/MyIcon.png")' ). Prevents creating the
   /// object over and over.
   ///
   /// If svgTintColor is a non-zero color, and sIdentifier points to an .SVG file, then the first time the icon is requested with that color,
@@ -135,22 +136,32 @@ public:
   /// Usually this is used to get different shades of the same icon, such that it looks good on the target background.
   static const QIcon& GetCachedIconResource(ezStringView sIdentifier, ezColor svgTintColor = ezColor::MakeZero());
 
-  /// \brief Returns a cached QImage that was created from an internal Qt resource (e.g. 'QImage(":QtNamespace/MyIcon.png")' ). Prevents creating the
+  /// Returns a cached QImage that was created from an internal Qt resource (e.g. 'QImage(":QtNamespace/MyIcon.png")' ). Prevents creating the
   /// object over and over.
   static const QImage& GetCachedImageResource(const char* szIdentifier);
 
-  /// \brief Returns a cached QPixmap that was created from an internal Qt resource (e.g. 'QPixmap(":QtNamespace/MyIcon.png")' ). Prevents creating
+  /// Returns a cached QPixmap that was created from an internal Qt resource (e.g. 'QPixmap(":QtNamespace/MyIcon.png")' ). Prevents creating
   /// the object over and over.
   static const QPixmap& GetCachedPixmapResource(const char* szIdentifier);
 
-  /// \brief Adds the pattern to the gitignore file.
+  /// Adds the pattern to the gitignore file.
   ///
   /// If the gitignore file does not exist, it is created.
   /// If the pattern is already present in the file, it is not added again.
   static ezResult AddToGitIgnore(const char* szGitIgnoreFile, const char* szPattern);
 
-  /// \brief Raises the 'CheckForUpdates' event
+  /// Raises the 'CheckForUpdates' event
   static void CheckForUpdates();
+
+  /// For opening internal links to documents, object references, etc.
+  ///
+  /// Used for instance by log windows to support embedded links.
+  /// Can be links to assets, document or even objects inside scenes.
+  /// Could also be external URLs.
+  /// What's supported is determined by whoever handles the request.
+  /// The link target should look like this: "scheme:string".
+  /// The "scheme:" allows handlers to distinguish the format of the rest of the string and whether it supports it.
+  static void GotoLinkTarget(ezStringView sLinkTarget);
 
   void Init();
 

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
@@ -4,6 +4,103 @@
 #include <GuiFoundation/Widgets/LogWidget.moc.h>
 #include <QClipboard>
 #include <QKeyEvent>
+#include <QRegularExpression>
+
+//////////////////////////////////////////////////////////////////////////
+
+
+ezQtLogWidgetItemDelegate::ezQtLogWidgetItemDelegate(QObject* pParent)
+  : ezQtItemDelegate(pParent)
+{
+}
+
+void ezQtLogWidgetItemDelegate::paint(QPainter* pPainter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+  const QVariant link = index.data(ezQtLogModel::UserRoles::Link);
+
+  if (!link.isValid())
+  {
+    ezQtItemDelegate::paint(pPainter, option, index);
+    return;
+  }
+
+  const QVariant linkText = index.data(ezQtLogModel::UserRoles::LinkText);
+
+  const QString sLink = link.toString();
+  const QString sLinkText = linkText.isValid() ? linkText.toString() : QString();
+  const QString sLogText = index.data(Qt::DisplayRole).toString();
+
+  drawBackground(pPainter, option, index);
+
+  const bool bSelected = option.state & QStyle::State_Selected;
+  const QColor textColor = bSelected ? option.palette.highlightedText().color() : option.palette.text().color();
+  const QString sLinkColor = bSelected ? option.palette.link().color().name() : option.palette.linkVisited().color().name();
+
+  QString sHtml = sLogText.toHtmlEscaped();
+  const bool bHovered = (index == m_HoveredIndex);
+  const QString sDecoration = bHovered ? QStringLiteral("; text-decoration:underline;") : QString();
+  sHtml.replace(sLink.toHtmlEscaped(), QStringLiteral("<span style=\"color:") + sLinkColor + sDecoration + QStringLiteral(";\">") + sLinkText.toHtmlEscaped() + QString("</span>"));
+
+  m_Doc.setDefaultFont(option.font);
+  m_Doc.setDefaultStyleSheet(QStringLiteral("body { color: ") + textColor.name() + QStringLiteral("; }"));
+  m_Doc.setHtml(QStringLiteral("<body>") + sHtml + QStringLiteral("</body>"));
+  m_Doc.setDocumentMargin(0);
+
+  pPainter->save();
+  pPainter->translate(option.rect.left(), option.rect.top());
+  m_Doc.drawContents(pPainter, QRectF(0, 0, option.rect.width(), option.rect.height()));
+  pPainter->restore();
+}
+
+bool ezQtLogWidgetItemDelegate::mouseHoverEvent(QHoverEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+  if (pEvent->type() == QEvent::HoverEnter)
+  {
+    m_HoveredIndex = index;
+  }
+  else if (pEvent->type() == QEvent::HoverLeave)
+  {
+    m_HoveredIndex = QModelIndex();
+  }
+
+  return false;
+}
+
+bool ezQtLogWidgetItemDelegate::mouseDoubleClickEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+  QVariant linkTarget = index.data(ezQtLogModel::UserRoles::LinkTarget);
+  if (!linkTarget.isValid())
+  {
+    return false;
+  }
+
+  ezQtUiServices::GotoLinkTarget(qtToEzString(linkTarget.toString()));
+  return true;
+}
+
+
+bool ezQtLogWidgetItemDelegate::mousePressEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+  if (pEvent->button() == Qt::MouseButton::MiddleButton)
+  {
+    // necessary, so that we get mouseReleaseEvent
+    return true;
+  }
+
+  return false;
+}
+
+bool ezQtLogWidgetItemDelegate::mouseReleaseEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+  if (pEvent->button() == Qt::MouseButton::MiddleButton)
+  {
+    return mouseDoubleClickEvent(pEvent, option, index);
+  }
+
+  return false;
+}
+
+//////////////////////////////////////////////////////////////////////////
 
 ezMap<ezString, ezQtLogWidget::LogItemContextActionCallback> ezQtLogWidget::s_LogCallbacks;
 
@@ -12,10 +109,13 @@ ezQtLogWidget::ezQtLogWidget(QWidget* pParent)
 {
   setupUi(this);
 
+  m_pDelegate = new ezQtLogWidgetItemDelegate(this);
+
   m_pLog = new ezQtLogModel(this);
   ListViewLog->setModel(m_pLog);
   ListViewLog->setUniformItemSizes(true);
   ListViewLog->installEventFilter(this);
+  ListViewLog->setItemDelegate(m_pDelegate);
   connect(m_pLog, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex& parent, int iFirst, int iLast)
     { ScrollToBottomIfAtEnd(iFirst); });
   connect(ListViewLog, &QAbstractItemView::doubleClicked, this, &ezQtLogWidget::OnItemDoubleClicked);

--- a/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/Implementation/LogWidget.cpp
@@ -1,6 +1,7 @@
 #include <GuiFoundation/GuiFoundationPCH.h>
 
 #include <GuiFoundation/Models/LogModel.moc.h>
+#include <GuiFoundation/UIServices/UIServices.moc.h>
 #include <GuiFoundation/Widgets/LogWidget.moc.h>
 #include <QClipboard>
 #include <QKeyEvent>

--- a/Code/Tools/Libs/GuiFoundation/Widgets/ItemView.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/ItemView.moc.h
@@ -5,6 +5,7 @@
 #include <QAbstractItemView>
 #include <QHoverEvent>
 #include <QItemDelegate>
+#include <QListView>
 #include <QStyledItemDelegate>
 
 /// \brief In combination with ezQtItemView this delegate allows for receiving the full range of mouse input.
@@ -183,4 +184,18 @@ private:
   ezQtItemDelegate* m_pFocusedDelegate = nullptr;
   QPersistentModelIndex m_Hovered;
   QPersistentModelIndex m_Focused;
+};
+
+
+//////////////////////////////////////////////////////////////////////////
+
+class ezQtListView : public ezQtItemView<QListView>
+{
+  Q_OBJECT
+
+public:
+  ezQtListView(QWidget* parent)
+    : ezQtItemView<QListView>(parent)
+  {
+  }
 };

--- a/Code/Tools/Libs/GuiFoundation/Widgets/LogWidget.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/LogWidget.moc.h
@@ -3,11 +3,30 @@
 #include <Foundation/Basics.h>
 #include <Foundation/Logging/Log.h>
 #include <GuiFoundation/GuiFoundationDLL.h>
+#include <GuiFoundation/Widgets/ItemView.moc.h>
 #include <GuiFoundation/ui_LogWidget.h>
+#include <QTextDocument>
 #include <QWidget>
 
 class ezQtLogModel;
 class ezQtSearchWidget;
+
+/// Renders log entries that contain embedded [[text|target]] links and handles navigation on double-click or middle-click.
+class ezQtLogWidgetItemDelegate : public ezQtItemDelegate
+{
+  Q_OBJECT
+public:
+  ezQtLogWidgetItemDelegate(QObject* pParent);
+  virtual void paint(QPainter* pPainter, const QStyleOptionViewItem& opt, const QModelIndex& index) const override;
+  virtual bool mouseHoverEvent(QHoverEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index) override;
+  virtual bool mouseDoubleClickEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index) override;
+  virtual bool mousePressEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index) override;
+  virtual bool mouseReleaseEvent(QMouseEvent* pEvent, const QStyleOptionViewItem& option, const QModelIndex& index) override;
+
+private:
+  QPersistentModelIndex m_HoveredIndex;
+  mutable QTextDocument m_Doc;
+};
 
 /// \brief The application wide panel that shows the engine log output and the editor log output
 class EZ_GUIFOUNDATION_DLL ezQtLogWidget : public QWidget, public Ui_LogWidget
@@ -40,6 +59,8 @@ private Q_SLOTS:
 private:
   ezQtLogModel* m_pLog;
   void ScrollToBottomIfAtEnd(int iFirstNewRow);
+
+  ezQtLogWidgetItemDelegate* m_pDelegate = nullptr;
 
   /// \brief List of callbacks invoked when the user double clicks a log message
   static ezMap<ezString, LogItemContextActionCallback> s_LogCallbacks;

--- a/Code/Tools/Libs/GuiFoundation/Widgets/LogWidget.ui
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/LogWidget.ui
@@ -142,9 +142,9 @@
     </layout>
    </item>
    <item>
-    <widget class="QListView" name="ListViewLog">
+    <widget class="ezQtListView" name="ListViewLog">
      <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
+      <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
      </property>
      <property name="showDropIndicator" stdset="0">
       <bool>true</bool>
@@ -153,10 +153,10 @@
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
+      <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
      </property>
      <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
+      <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
      </property>
      <property name="uniformItemSizes">
       <bool>true</bool>
@@ -171,6 +171,11 @@
    <extends>QWidget</extends>
    <header location="global">GuiFoundation/Widgets/SearchWidget.moc.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ezQtListView</class>
+   <extends>QListView</extends>
+   <header location="global">GuiFoundation/Widgets/ItemView.moc.h</header>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
If a log message contains a string formatted like this "[[Text|scheme:target]]" the log widget will only display "Text". It can be double-clicked or middle-clicked and that will attempt to open "scheme:target".

Currently this supports to open assets via "asset:GUID". You can also select an object in a document through "asset:GUID#GUID". Or you can set the scene tree search text via "asset:GUID#filter:\"stuff\"".

The scene tree search now also supports the search type "ref:GUID", where it will only display objects that reference an asset with the given GUID. This makes it possible to find all references to an asset in a scene.

The asset curator now uses this feature to show all objects that reference missing assets.

Improvement of #1935.