### PR TITLE
Fixed #1950: Added AllowEnableReload option to ezPluginBundle

### DIFF
--- a/Code/Editor/EditorFramework/Assets/AssetDocument.h
+++ b/Code/Editor/EditorFramework/Assets/AssetDocument.h
@@ -136,7 +136,7 @@ public:
   };
 
   /// \brief Finds all usages of the given asset in this document and appends them to out_usages. The default implementation does nothing, override this if your document can reference other assets.
-  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const {}
+  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 uiMaxResults) const {}
 
   /// \brief Returns the ezEditorEngineConnection for this document.
   ezEditorEngineConnection* GetEditorEngineConnection() const { return m_pEngineConnection; }

--- a/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
+++ b/Code/Editor/EditorFramework/CodeGen/CppProject.cpp
@@ -1056,6 +1056,7 @@ void ezCppProject::UpdatePluginConfig(const ezCppSettings& cfg)
   bundles.m_Plugins.Remove(sPluginName);
   ezPluginBundle& plugin = bundles.m_Plugins[sPluginName];
   plugin.m_bLoadCopy = true;
+  plugin.m_bAllowEnableReload = true;
   plugin.m_bSelected = true;
   plugin.m_bMissing = true;
   plugin.m_LastModificationTime = ezTimestamp::MakeInvalid();

--- a/Code/Editor/EditorFramework/Dialogs/PluginSelectionWidget.cpp
+++ b/Code/Editor/EditorFramework/Dialogs/PluginSelectionWidget.cpp
@@ -99,11 +99,14 @@ void ezQtPluginSelectionWidget::on_PluginsList_currentItemChanged(QListWidgetIte
     auto& state = m_States[PluginsList->row(current)];
     DescriptionText->setPlainText(state.m_pInfo->m_sDescription.GetData());
     LoadCopy->setChecked(state.m_bLoadCopy);
-    LoadCopy->setEnabled(true);
+    const bool bAllowReload = state.m_pInfo->m_bAllowEnableReload;
+    LoadCopy->setEnabled(bAllowReload);
+    LoadCopy->setToolTip(bAllowReload ? "" : "This plugin does not support hot-reloading. Only plugins that are loaded purely dynamically at runtime and not linked against directly can use this feature.");
   }
   else
   {
     LoadCopy->setEnabled(false);
+    LoadCopy->setToolTip("");
   }
 }
 

--- a/Code/Editor/EditorFramework/Document/GameObjectDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectDocument.h
@@ -147,7 +147,7 @@ public:
   virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const override;
 
 private:
-  void FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const;
+  void FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 uiMaxResults) const;
   void DeallocateEditTools();
 
   ezDelegate<void(ezGameObjectEditTool*)> m_EditToolConfigDelegate;

--- a/Code/Editor/EditorFramework/Document/GameObjectDocument.h
+++ b/Code/Editor/EditorFramework/Document/GameObjectDocument.h
@@ -144,7 +144,7 @@ public:
   virtual void HandleEngineMessage(const ezEditorEngineDocumentMsg* pMsg) override;
 
   /// \brief Finds all usages of the given asset in this document and appends them to out_usages. The default implementation does nothing, override this if your document can reference other assets.
-  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const override;
+  virtual void FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 uiMaxResults) const override;
 
 private:
   void FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 uiMaxResults) const;

--- a/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
+++ b/Code/Editor/EditorFramework/Document/Implementation/GameObjectDocument.cpp
@@ -1051,13 +1051,13 @@ void ezGameObjectDocument::HandleEngineMessage(const ezEditorEngineDocumentMsg* 
 
 // the following method is similar to "ezAssetCurator::ReplaceAssetReferenceInObject"
 
-void ezGameObjectDocument::FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const
+void ezGameObjectDocument::FindAssetUsages(ezStringView sAssetToFind, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 uiMaxResults) const
 {
   out_usages.Clear();
-  FindAssetUsagesInternal(sAssetToFind, GetObjectManager()->GetRootObject(), out_usages, maxResults);
+  FindAssetUsagesInternal(sAssetToFind, GetObjectManager()->GetRootObject(), out_usages, uiMaxResults);
 }
 
-void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 maxResults) const
+void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, const ezDocumentObject* pObject, ezDynamicArray<AssetUsage>& out_usages, ezUInt32 uiMaxResults) const
 {
   auto pAccessor = GetObjectAccessor();
 
@@ -1100,7 +1100,7 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
               au.m_sObjectName = sFullPath;
               au.m_ObjectGuid = pObject->GetGuid();
 
-              if (out_usages.GetCount() >= maxResults)
+              if (out_usages.GetCount() >= uiMaxResults)
                 return;
             }
           }
@@ -1130,7 +1130,7 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
                 au.m_sObjectName = sFullPath;
                 au.m_ObjectGuid = pObject->GetGuid();
 
-                if (out_usages.GetCount() >= maxResults)
+                if (out_usages.GetCount() >= uiMaxResults)
                   return;
               }
             }
@@ -1161,7 +1161,7 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
                   au.m_sObjectName = sFullPath;
                   au.m_ObjectGuid = pObject->GetGuid();
 
-                  if (out_usages.GetCount() >= maxResults)
+                  if (out_usages.GetCount() >= uiMaxResults)
                     return;
                 }
               }
@@ -1184,9 +1184,9 @@ void ezGameObjectDocument::FindAssetUsagesInternal(ezStringView sAssetToFind, co
         pChild->GetParentPropertyType()->GetAttributeByType<ezTemporaryAttribute>() != nullptr)
       continue;
 
-    FindAssetUsagesInternal(sAssetToFind, pChild, out_usages, maxResults);
+    FindAssetUsagesInternal(sAssetToFind, pChild, out_usages, uiMaxResults);
 
-    if (out_usages.GetCount() >= maxResults)
+    if (out_usages.GetCount() >= uiMaxResults)
       return;
   }
 }

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/EditorPlugins.cpp
@@ -105,6 +105,9 @@ ezResult ezPluginBundle::ReadBundleFromDDL(ezOpenDdlReader& ref_ddl)
   if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::Bool, "Mandatory"))
     m_bMandatory = pElement->GetPrimitivesBool()[0];
 
+  if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::Bool, "AllowEnableReload"))
+    m_bAllowEnableReload = pElement->GetPrimitivesBool()[0];
+
   if (auto pElement = pInfo->FindChildOfType(ezOpenDdlPrimitiveType::String, "DisplayName"))
     m_sDisplayName = pElement->GetPrimitivesString()[0];
 

--- a/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
+++ b/Code/Editor/EditorFramework/EditorApp/Configuration/Plugins.h
@@ -25,6 +25,7 @@ struct EZ_EDITORFRAMEWORK_DLL ezPluginBundle
 
   // General Bundle Description
   bool m_bMandatory = false;                        ///< if set, the bundle is always used and not even displayed in the UI
+  bool m_bAllowEnableReload = false;                ///< If false, the "Enable Reload" option is not available for this bundle. Only set to true for plugins that are loaded purely dynamically at runtime and not linked against directly.
   ezString m_sDisplayName;                          ///< The string for displaying the bundle in UI
   ezString m_sDescription;                          ///< A proper description what this bundle is for, so that users know when to use it.
   ezHybridArray<ezString, 1> m_EditorPlugins;       ///< List of all the DLLs (without extension) to load into the editor process.

--- a/Code/EditorPlugins/Assets/EditorPluginAssets/Assets.ezPluginBundle
+++ b/Code/EditorPlugins/Assets/EditorPluginAssets/Assets.ezPluginBundle
@@ -34,4 +34,9 @@ PluginInfo
 	// if true, the plugin is not shown in the UI and always loaded
 	// only used for system functionality
 	bool %Mandatory{true}
+
+	// if true, the user can enable "hot reload" for this bundle in the editor UI.
+	// This makes the engine load a copy of the runtime DLL, so the original can be replaced and reloaded during development.
+	// Only enable this for plugins that are loaded purely dynamically at runtime and not linked against directly.
+	// bool %AllowEnableReload{false}
 }

--- a/Code/Samples/SampleGamePlugin/SampleGame.ezPluginBundle
+++ b/Code/Samples/SampleGamePlugin/SampleGame.ezPluginBundle
@@ -3,6 +3,7 @@
 
 PluginInfo
 {
+	bool %AllowEnableReload{true}
 	string %DisplayName{"Sample Game"}
 	string %Description{"Contains the C++ code of the sample game project."}
 	string %EditorPlugins{}

--- a/Code/Tools/Libs/GuiFoundation/Widgets/ItemView.moc.h
+++ b/Code/Tools/Libs/GuiFoundation/Widgets/ItemView.moc.h
@@ -194,8 +194,8 @@ class ezQtListView : public ezQtItemView<QListView>
   Q_OBJECT
 
 public:
-  ezQtListView(QWidget* parent)
-    : ezQtItemView<QListView>(parent)
+  ezQtListView(QWidget* pParent)
+    : ezQtItemView<QListView>(pParent)
   {
   }
 };

--- a/Data/Samples/PacMan/CppSource/PacManPlugin/PacManPlugin.ezPluginBundle
+++ b/Data/Samples/PacMan/CppSource/PacManPlugin/PacManPlugin.ezPluginBundle
@@ -1,6 +1,7 @@
 PluginInfo
 {
 	bool %Mandatory{false}
+	bool %AllowEnableReload{true}
 	string %DisplayName{"PacMan"}
 	string %Description{"C++ code for the PacMan project."}
 	string %EditorPlugins{}

--- a/Data/Samples/RTS/CppSource/RTSPlugin/RTSPlugin.ezPluginBundle
+++ b/Data/Samples/RTS/CppSource/RTSPlugin/RTSPlugin.ezPluginBundle
@@ -1,6 +1,7 @@
 PluginInfo
 {
 	bool %Mandatory{false}
+	bool %AllowEnableReload{true}
 	string %DisplayName{"RTS"}
 	string %Description{"C++ code for the RTS project."}
 	string %EditorPlugins{}

--- a/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CppProjectPlugin.ezPluginBundle
+++ b/Data/Tools/ezEditor/CppProject/CppSource/CppProjectPlugin/CppProjectPlugin.ezPluginBundle
@@ -1,6 +1,7 @@
 PluginInfo
 {
 	bool %Mandatory{false}
+	bool %AllowEnableReload{true}
 	string %DisplayName{"CppProject"}
 	string %Description{"C++ code for the CppProject project."}
 	string %EditorPlugins{}


### PR DESCRIPTION
The 'Enable Reload' checkbox in the plugin selection UI is now greyed out for plugins that do not explicitly opt in via `AllowEnableReload = true` in their .ezPluginBundle file. This prevents users from accidentally enabling hot-reload for plugins that don't support it (i.e. plugins that are linked against directly rather than loaded purely dynamically).

Users who have existing C++ game projects should modify their ezPluginBundle file to include the option (see examples in this commit).