### PR TITLE
Made it easier to launch ezInspector for different processes

### DIFF
--- a/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
+++ b/Code/Editor/EditorFramework/Actions/Implementation/ProjectActions.cpp
@@ -19,6 +19,7 @@
 #include <Foundation/IO/FileSystem/FileReader.h>
 #include <Foundation/IO/OSFile.h>
 #include <Foundation/Profiling/ProfilingUtils.h>
+#include <Foundation/Utilities/CommandLineUtils.h>
 #include <GuiFoundation/Dialogs/ShortcutEditorDlg.moc.h>
 
 ezActionDescriptorHandle ezProjectActions::s_hCatProjectGeneral;
@@ -62,7 +63,9 @@ ezActionDescriptorHandle ezProjectActions::s_hCatEditorSettings;
 ezActionDescriptorHandle ezProjectActions::s_hReloadResources;
 ezActionDescriptorHandle ezProjectActions::s_hReloadEngine;
 ezActionDescriptorHandle ezProjectActions::s_hLaunchFileserve;
-ezActionDescriptorHandle ezProjectActions::s_hLaunchInspector;
+ezActionDescriptorHandle ezProjectActions::s_hInspectorMenu;
+ezActionDescriptorHandle ezProjectActions::s_hLaunchInspectorPlayer;
+ezActionDescriptorHandle ezProjectActions::s_hLaunchInspectorEditorEngine;
 ezActionDescriptorHandle ezProjectActions::s_hLaunchTracy;
 ezActionDescriptorHandle ezProjectActions::s_hSaveProfiling;
 ezActionDescriptorHandle ezProjectActions::s_hOpenVsCode;
@@ -135,7 +138,9 @@ void ezProjectActions::RegisterActions()
   s_hReloadResources = EZ_REGISTER_ACTION_1("Engine.ReloadResources", ezActionScope::Global, "Engine", "F4", ezProjectAction, ezProjectAction::ButtonType::ReloadResources);
   s_hReloadEngine = EZ_REGISTER_ACTION_1("Engine.ReloadEngine", ezActionScope::Global, "Engine", "Ctrl+Shift+F4", ezProjectAction, ezProjectAction::ButtonType::ReloadEngine);
   s_hLaunchFileserve = EZ_REGISTER_ACTION_1("Editor.LaunchFileserve", ezActionScope::Global, "Engine", "", ezProjectAction, ezProjectAction::ButtonType::LaunchFileserve);
-  s_hLaunchInspector = EZ_REGISTER_ACTION_1("Editor.LaunchInspector", ezActionScope::Global, "Engine", "", ezProjectAction, ezProjectAction::ButtonType::LaunchInspector);
+  s_hInspectorMenu = EZ_REGISTER_MENU("G.Inspector");
+  s_hLaunchInspectorPlayer = EZ_REGISTER_ACTION_1("Editor.LaunchInspectorPlayer", ezActionScope::Global, "Engine", "", ezProjectAction, ezProjectAction::ButtonType::LaunchInspectorPlayer);
+  s_hLaunchInspectorEditorEngine = EZ_REGISTER_ACTION_1("Editor.LaunchInspectorEditorEngine", ezActionScope::Global, "Engine", "", ezProjectAction, ezProjectAction::ButtonType::LaunchInspectorEditorEngine);
   s_hLaunchTracy = EZ_REGISTER_ACTION_1("Editor.LaunchTracy", ezActionScope::Global, "Engine", "", ezProjectAction, ezProjectAction::ButtonType::LaunchTracy);
   s_hSaveProfiling = EZ_REGISTER_ACTION_1("Editor.SaveProfiling", ezActionScope::Global, "Engine", "Ctrl+Alt+P", ezProjectAction, ezProjectAction::ButtonType::SaveProfiling);
   s_hOpenVsCode = EZ_REGISTER_ACTION_1("Editor.OpenVsCode", ezActionScope::Global, "Project", "Ctrl+Alt+O", ezProjectAction, ezProjectAction::ButtonType::OpenVsCode);
@@ -174,7 +179,9 @@ void ezProjectActions::UnregisterActions()
   ezActionManager::UnregisterAction(s_hReloadResources);
   ezActionManager::UnregisterAction(s_hReloadEngine);
   ezActionManager::UnregisterAction(s_hLaunchFileserve);
-  ezActionManager::UnregisterAction(s_hLaunchInspector);
+  ezActionManager::UnregisterAction(s_hInspectorMenu);
+  ezActionManager::UnregisterAction(s_hLaunchInspectorPlayer);
+  ezActionManager::UnregisterAction(s_hLaunchInspectorEditorEngine);
   ezActionManager::UnregisterAction(s_hLaunchTracy);
   ezActionManager::UnregisterAction(s_hSaveProfiling);
   ezActionManager::UnregisterAction(s_hOpenVsCode);
@@ -248,7 +255,9 @@ void ezProjectActions::MapActions(ezStringView sMapping, const ezBitflags<ezStan
   pMap->MapAction(s_hExportProject, "G.Project.External", 10.0f);
 
   pMap->MapAction(s_hOpenVsCode, "G.Tools.External", 1.0f);
-  pMap->MapAction(s_hLaunchInspector, "G.Tools.External", 2.0f);
+  pMap->MapAction(s_hInspectorMenu, "G.Tools.External", 2.0f);
+  pMap->MapAction(s_hLaunchInspectorPlayer, "G.Inspector", 1.0f);
+  pMap->MapAction(s_hLaunchInspectorEditorEngine, "G.Inspector", 2.0f);
   pMap->MapAction(s_hLaunchTracy, "G.Tools.External", 3.0f);
   pMap->MapAction(s_hLaunchFileserve, "G.Tools.External", 4.0f);
 
@@ -409,7 +418,8 @@ ezProjectAction::ezProjectAction(const ezActionContext& context, const char* szN
     case ezProjectAction::ButtonType::LaunchFileserve:
       SetIconPath(":/EditorFramework/Icons/Fileserve.svg");
       break;
-    case ezProjectAction::ButtonType::LaunchInspector:
+    case ezProjectAction::ButtonType::LaunchInspectorEditorEngine:
+    case ezProjectAction::ButtonType::LaunchInspectorPlayer:
       SetIconPath(":/EditorFramework/Icons/Inspector.svg");
       break;
     case ezProjectAction::ButtonType::LaunchTracy:
@@ -483,7 +493,8 @@ ezProjectAction::ezProjectAction(const ezActionContext& context, const char* szN
       m_ButtonType == ButtonType::ReloadResources ||
       m_ButtonType == ButtonType::LaunchFileserve ||
       m_ButtonType == ButtonType::LaunchTracy ||
-      m_ButtonType == ButtonType::LaunchInspector ||
+      m_ButtonType == ButtonType::LaunchInspectorEditorEngine ||
+      m_ButtonType == ButtonType::LaunchInspectorPlayer ||
       m_ButtonType == ButtonType::OpenVsCode ||
       m_ButtonType == ButtonType::InputConfig ||
       m_ButtonType == ButtonType::AssetProfiles ||
@@ -518,7 +529,8 @@ ezProjectAction::~ezProjectAction()
       m_ButtonType == ButtonType::ReloadEngine ||
       m_ButtonType == ButtonType::ReloadResources ||
       m_ButtonType == ButtonType::LaunchFileserve ||
-      m_ButtonType == ButtonType::LaunchInspector ||
+      m_ButtonType == ButtonType::LaunchInspectorEditorEngine ||
+      m_ButtonType == ButtonType::LaunchInspectorPlayer ||
       m_ButtonType == ButtonType::LaunchTracy ||
       m_ButtonType == ButtonType::OpenVsCode ||
       m_ButtonType == ButtonType::InputConfig ||
@@ -732,11 +744,20 @@ void ezProjectAction::Execute(const ezVariant& value)
     }
     break;
 
-    case ezProjectAction::ButtonType::LaunchInspector:
+    case ezProjectAction::ButtonType::LaunchInspectorPlayer:
     {
       ezQtUiServices::GetSingleton()->ShowAllDocumentsTemporaryStatusBarMessage("Launching ezInspector...", ezTime::MakeFromSeconds(5));
 
-      ezQtEditorApp::GetSingleton()->RunInspector();
+      ezQtEditorApp::GetSingleton()->RunInspector(1040);
+    }
+    break;
+
+    case ezProjectAction::ButtonType::LaunchInspectorEditorEngine:
+    {
+      ezQtUiServices::GetSingleton()->ShowAllDocumentsTemporaryStatusBarMessage("Launching ezInspector...", ezTime::MakeFromSeconds(5));
+
+      const ezUInt16 uiPort = static_cast<ezUInt16>(ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-TelemetryPort", 1050));
+      ezQtEditorApp::GetSingleton()->RunInspector(uiPort);
     }
     break;
 

--- a/Code/Editor/EditorFramework/Actions/ProjectActions.h
+++ b/Code/Editor/EditorFramework/Actions/ProjectActions.h
@@ -56,7 +56,9 @@ public:
   static ezActionDescriptorHandle s_hReloadResources;
   static ezActionDescriptorHandle s_hReloadEngine;
   static ezActionDescriptorHandle s_hLaunchFileserve;
-  static ezActionDescriptorHandle s_hLaunchInspector;
+  static ezActionDescriptorHandle s_hInspectorMenu;
+  static ezActionDescriptorHandle s_hLaunchInspectorPlayer;
+  static ezActionDescriptorHandle s_hLaunchInspectorEditorEngine;
   static ezActionDescriptorHandle s_hLaunchTracy;
   static ezActionDescriptorHandle s_hSaveProfiling;
   static ezActionDescriptorHandle s_hOpenVsCode;
@@ -115,7 +117,8 @@ public:
     ReloadResources,
     ReloadEngine,
     LaunchFileserve,
-    LaunchInspector,
+    LaunchInspectorPlayer,
+    LaunchInspectorEditorEngine,
     LaunchTracy,
     SaveProfiling,
     OpenVsCode,

--- a/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
+++ b/Code/Editor/EditorFramework/EditorApp/EditorApp.moc.h
@@ -102,8 +102,8 @@ public:
   /// \brief Launches Fileserve with the settings for the current project.
   void RunFileserve();
 
-  /// \brief Launches ezInspector.
-  void RunInspector();
+  /// \brief Launches ezInspector, connecting to the given port. Pass 0 to use the Inspector's default/last-used connection.
+  void RunInspector(ezUInt16 uiPort = 0);
 
   /// \brief Launches Tracy.
   void RunTracy();

--- a/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
+++ b/Code/Editor/EditorFramework/EditorApp/ExternalTools.cpp
@@ -212,10 +212,15 @@ void ezQtEditorApp::RunFileserve()
   QProcess::startDetached(sToolPath.GetData(), args);
 }
 
-void ezQtEditorApp::RunInspector()
+void ezQtEditorApp::RunInspector(ezUInt16 uiPort)
 {
   const ezStringBuilder sToolPath = ezQtEditorApp::GetSingleton()->FindToolApplication("ezInspector");
   QStringList args;
+
+  if (uiPort != 0)
+  {
+    args << "-port" << QString::number(uiPort);
+  }
 
   QProcess::startDetached(sToolPath.GetData(), args);
 }

--- a/Code/Tools/Inspector/Inspector.cpp
+++ b/Code/Tools/Inspector/Inspector.cpp
@@ -2,6 +2,7 @@
 
 #include <Foundation/Application/Application.h>
 #include <Foundation/Communication/Telemetry.h>
+#include <Foundation/Utilities/CommandLineUtils.h>
 #include <Inspector/CVarsWidget.moc.h>
 #include <Inspector/DataTransferWidget.moc.h>
 #include <Inspector/FileWidget.moc.h>
@@ -109,7 +110,26 @@ public:
     QSettings Settings;
     const QString sServer = Settings.value("LastConnection", QLatin1String("localhost:1040")).toString();
 
-    ezTelemetry::ConnectToServer(sServer.toUtf8().data()).IgnoreResult();
+    // -url and -port can override the stored connection address
+    const ezStringView sUrlArg = ezCommandLineUtils::GetGlobalInstance()->GetStringOption("-url");
+    const ezInt32 iPortArg = ezCommandLineUtils::GetGlobalInstance()->GetIntOption("-port", -1);
+
+    ezStringBuilder sConnectTo(sServer.toUtf8().data());
+    if (!sUrlArg.IsEmpty() || iPortArg > 0)
+    {
+      const ezStringView sHost = sUrlArg.IsEmpty() ? ezStringView("localhost") : sUrlArg;
+      if (iPortArg > 0)
+        sConnectTo.SetFormat("{}:{}", sHost, iPortArg);
+      else
+        sConnectTo = sHost;
+
+      // Persist the command-line override so the Connect dialog reflects it
+      const QString sConnectToQt = QString::fromUtf8(sConnectTo.GetData());
+      Settings.setValue("LastConnection", sConnectToQt);
+      MainWindow.SetConnectionTarget(sConnectToQt);
+    }
+
+    ezTelemetry::ConnectToServer(sConnectTo).IgnoreResult();
 
     MainWindow.show();
     SetReturnCode(app.exec());

--- a/Code/Tools/Inspector/MainWidget.cpp
+++ b/Code/Tools/Inspector/MainWidget.cpp
@@ -125,10 +125,9 @@ void ezQtMainWidget::on_ButtonConnect_clicked()
     return;
 
   Settings.setValue("LastConnection", sRes);
+  ezQtMainWindow::s_pWidget->SetConnectionTarget(sRes);
 
-  if (ezTelemetry::ConnectToServer(sRes.toUtf8().data()) == EZ_SUCCESS)
-  {
-  }
+  ezTelemetry::ConnectToServer(sRes.toUtf8().data()).IgnoreResult();
 }
 
 void ezQtMainWidget::SaveFavorites()

--- a/Code/Tools/Inspector/MainWindow.cpp
+++ b/Code/Tools/Inspector/MainWindow.cpp
@@ -32,6 +32,7 @@ ezQtMainWindow::ezQtMainWindow()
                                                 ads::CDockManager::OpaqueSplitterResize | ads::CDockManager::AllTabsHaveCloseButton));
 
   QSettings Settings;
+  m_sConnectionTarget = Settings.value("LastConnection", QLatin1String("localhost:1040")).toString();
   SetAlwaysOnTop((OnTopMode)Settings.value("AlwaysOnTop", (int)WhenConnected).toInt());
 
   Settings.beginGroup("MainWindow");
@@ -150,6 +151,7 @@ ezQtMainWindow::ezQtMainWindow()
   for (ezInt32 i = 0; i < 10; ++i)
     m_pStatHistoryWidgets[i]->Load();
 
+  UpdateWindowTitle();
   SetupNetworkTimer();
 }
 
@@ -212,8 +214,6 @@ void ezQtMainWindow::UpdateNetwork()
 
   {
     static ezUInt32 uiServerID = 0;
-    static bool bConnected = false;
-    static ezString sLastServerName;
 
     if (ezTelemetry::IsConnectedToServer())
     {
@@ -227,29 +227,32 @@ void ezQtMainWindow::UpdateNetwork()
 
         ezQtLogDockWidget::s_pWidget->Log(s.GetData());
       }
-      else if (!bConnected)
+      else if (!m_bConnectedToServer)
       {
         ezQtLogDockWidget::s_pWidget->Log("Reconnected to Server.");
       }
 
-      if (sLastServerName != ezTelemetry::GetServerName())
+      if (m_sLastServerName != ezTelemetry::GetServerName())
       {
-        sLastServerName = ezTelemetry::GetServerName();
-        setWindowTitle(QString("ezInspector - %1").arg(sLastServerName.GetData()));
+        m_sLastServerName = ezTelemetry::GetServerName();
+        UpdateWindowTitle();
       }
 
-      bConnected = true;
+      if (!m_bConnectedToServer)
+      {
+        m_bConnectedToServer = true;
+        UpdateWindowTitle();
+      }
     }
     else
     {
-      if (bConnected)
+      if (m_bConnectedToServer)
       {
         ezQtLogDockWidget::s_pWidget->Log("Lost Connection to Server.");
-        setWindowTitle(QString("ezInspector - disconnected"));
-        sLastServerName.Clear();
+        m_sLastServerName.Clear();
+        m_bConnectedToServer = false;
+        UpdateWindowTitle();
       }
-
-      bConnected = false;
     }
   }
 
@@ -287,6 +290,22 @@ void ezQtMainWindow::UpdateNetwork()
     m_pStatHistoryWidgets[i]->UpdateStats();
 
   ezTelemetry::PerFrameUpdate();
+}
+
+void ezQtMainWindow::UpdateWindowTitle()
+{
+  if (m_bConnectedToServer && !m_sLastServerName.IsEmpty())
+    setWindowTitle(QString("ezInspector [%1] - %2").arg(m_sConnectionTarget, m_sLastServerName.GetData()));
+  else if (m_bConnectedToServer)
+    setWindowTitle(QString("ezInspector [%1] - connected").arg(m_sConnectionTarget));
+  else
+    setWindowTitle(QString("ezInspector [%1] - not connected").arg(m_sConnectionTarget));
+}
+
+void ezQtMainWindow::SetConnectionTarget(const QString& sTarget)
+{
+  m_sConnectionTarget = sTarget;
+  UpdateWindowTitle();
 }
 
 void ezQtMainWindow::DockWidgetVisibilityChanged(bool bVisible)

--- a/Code/Tools/Inspector/MainWindow.moc.h
+++ b/Code/Tools/Inspector/MainWindow.moc.h
@@ -28,6 +28,9 @@ public:
 
   virtual void closeEvent(QCloseEvent* pEvent);
 
+  /// Updates m_sConnectionTarget and refreshes the window title.
+  void SetConnectionTarget(const QString& sTarget);
+
 public Q_SLOTS:
   void DockWidgetVisibilityChanged(bool bVisible);
   void UpdateNetworkTimeOut();
@@ -55,10 +58,14 @@ private:
   void UpdateAlwaysOnTop();
   void SetupNetworkTimer();
   void UpdateNetwork();
+  void UpdateWindowTitle();
 
 private:
   OnTopMode m_OnTopMode;
   QTimer* m_pNetworkTimer;
+  QString m_sConnectionTarget;
+  ezString m_sLastServerName;
+  bool m_bConnectedToServer = false;
 
 public:
   ads::CDockManager* m_DockManager = nullptr;

--- a/Data/Tools/ezEditor/Localization/en/Editor.txt
+++ b/Data/Tools/ezEditor/Localization/en/Editor.txt
@@ -4,7 +4,9 @@ Editor.OpenDashboard;Show Dash&board...
 Project.Open;Open Project...
 Project.Create;Create Project...
 Editor.LaunchFileserve;Launch Fileserve...;Launches the ezFileServe application.
-Editor.LaunchInspector;Launch Inspector...;Launches the ezInspector application.
+G.Inspector;Launch Inspector
+Editor.LaunchInspectorPlayer;For &ezPlayer (Port 1040);Launches ezInspector and connects to the ezPlayer telemetry port (1040).
+Editor.LaunchInspectorEditorEngine;For &Editor Engine (Port 1050);Launches ezInspector and connects to the Editor Engine process telemetry port (1050).
 Editor.LaunchTracy;Launch Tracy...;Launches the Tracy profiler application.
 Editor.Plugins;Editor Pl&ugins...;Opens the editor plugins dialog
 Editor.Shortcuts;Shortcuts...;Opens the shortcut configuration dialog


### PR DESCRIPTION
You can now launch ezInspector for the editor or ezPlayer process:

<img width="1116" height="359" alt="image" src="https://github.com/user-attachments/assets/8722f772-f785-4d50-a25f-fe5e554da4c9" />
